### PR TITLE
feat: kanban toggle in the controls cluster; column half-pill on session nodes

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -5811,6 +5811,16 @@ export function Canvas() {
           <span className="cluster-search__icon">⌕</span>
           <span className="kbd">{hintLabel('⌘K')}</span>
         </button>
+        {/* Lives here, not in the tab bar: many open projects pushed a tab-strip toggle out of
+            sight, and this cluster is the stable home of view/panel controls. */}
+        {activeProjectId && (
+          <button
+            title={hintLabel(kanbanOpen ? 'Canvas view (⌘⇧B)' : 'Kanban view (⌘⇧B)')}
+            onClick={() => useViewMode.getState().toggle(activeProjectId)}
+          >
+            {kanbanOpen ? <IconCanvasView /> : <IconKanban />}
+          </button>
+        )}
         <button title={hintLabel('Explorer (⌘⇧E)')} onClick={() => setExplorerOpen(true)}>
           <IconExplorer />
         </button>

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -9,8 +9,6 @@ import { sshAutoModeHint } from '../state/permissionMode'
 import { useSystemAccount } from '../state/systemAccount'
 import { sessionCount, sessionForProject, useProjectSession } from '../session/session'
 import { tabClickAction } from '../session/relay-tab'
-import { useViewMode } from '../state/viewMode'
-import { IconCanvasView, IconKanban } from './icons'
 import {
   ALL_PERMISSION_MODES,
   PERMISSION_MODE_LABELS,
@@ -79,7 +77,6 @@ export function TabBar({
   // Closed projects are hidden here (reopen them from the start screen's "Recently closed").
   const projects = useMemo(() => allProjects.filter((p) => !p.closed), [allProjects])
   const activeId = useProjects((s) => s.activeProjectId)
-  const kanbanActive = useViewMode((s) => !!activeId && !!s.viewByProject[activeId])
   // Unread dots need only the unread id set — subscribing to the whole status map re-rendered
   // the TabBar on every working/waiting flip of any agent. Primitive signature → rare updates.
   const unreadIds = useAgentStatus((s) => {
@@ -332,15 +329,6 @@ export function TabBar({
           <button className="tab__add" title="New project" onClick={onOpenWelcome}>
             +
           </button>
-          {activeId && (
-            <button
-              className="tab__view-toggle"
-              title={kanbanActive ? 'Canvas view (⌘⇧B)' : 'Kanban view (⌘⇧B)'}
-              onClick={() => useViewMode.getState().toggle(activeId)}
-            >
-              {kanbanActive ? <IconCanvasView /> : <IconKanban />}
-            </button>
-          )}
         </div>
       </div>
 

--- a/src/renderer/components/kanban/ColumnPill.tsx
+++ b/src/renderer/components/kanban/ColumnPill.tsx
@@ -1,0 +1,27 @@
+import { columnForNode } from '../../lib/kanban'
+import { useProjects } from '../../state/projects'
+import { useViewMode } from '../../state/viewMode'
+
+/** Half-pill flush against a session node's TOP edge showing its kanban column — rendered as
+ *  a SIBLING of the node's root (the roots are overflow:hidden, which would clip a child
+ *  poking above the border). Hidden for Ungrouped/unassigned nodes; click opens the board. */
+export function ColumnPill({ nodeId }: { nodeId: string }) {
+  const column = useProjects((s) =>
+    columnForNode(s.projects.find((p) => p.id === s.activeProjectId)?.kanban, nodeId)
+  )
+  if (!column) return null
+  return (
+    <button
+      className="kanban-node-pill nodrag"
+      style={{ background: `${column.color}2e`, borderColor: column.color, color: column.color }}
+      title={`Kanban: ${column.title} — open the board`}
+      onClick={(e) => {
+        e.stopPropagation() // don't select/drag the node under the pill
+        const id = useProjects.getState().activeProjectId
+        if (id) useViewMode.getState().toggle(id)
+      }}
+    >
+      {column.title}
+    </button>
+  )
+}

--- a/src/renderer/lib/kanban.test.ts
+++ b/src/renderer/lib/kanban.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import type { ProjectKanban } from '@shared/types'
 import {
   addColumn, assignNode, assignedTo, defaultKanban, deleteColumn, moveColumn,
-  nextColumnColor, pruneAssignments, recolorColumn, renameColumn, unassigned
+  columnForNode, nextColumnColor, pruneAssignments, recolorColumn, renameColumn, unassigned
 } from './kanban'
 
 const board = (): ProjectKanban => ({
@@ -86,5 +86,15 @@ describe('assignments', () => {
     expect(k.assignments.map((a) => a.nodeId)).toEqual(['n1', 'n3'])
     const same = board()
     expect(pruneAssignments(same, ['n1', 'n2', 'n3'])).toBe(same)
+  })
+})
+
+describe('columnForNode', () => {
+  it('resolves the assigned column; undefined for unassigned, dangling, or no board', () => {
+    expect(columnForNode(board(), 'n1')).toMatchObject({ id: 'a', title: 'To Do' })
+    expect(columnForNode(board(), 'n9')).toBeUndefined()
+    const dangling: ProjectKanban = { ...board(), assignments: [{ nodeId: 'n1', columnId: 'gone' }] }
+    expect(columnForNode(dangling, 'n1')).toBeUndefined()
+    expect(columnForNode(undefined, 'n1')).toBeUndefined()
   })
 })

--- a/src/renderer/lib/kanban.ts
+++ b/src/renderer/lib/kanban.ts
@@ -1,4 +1,4 @@
-import type { KanbanAssignment, ProjectKanban } from '@shared/types'
+import type { KanbanAssignment, KanbanColumn, ProjectKanban } from '@shared/types'
 import { NODE_COLORS } from '../state/workspace'
 
 // Pure kanban board transforms — the ONLY place board structure changes. The UI computes
@@ -109,4 +109,16 @@ export function pruneAssignments(k: ProjectKanban, liveIds: string[]): ProjectKa
   const live = new Set(liveIds)
   const assignments = k.assignments.filter((a) => live.has(a.nodeId))
   return assignments.length === k.assignments.length ? k : { ...k, assignments }
+}
+
+/** The column a node is assigned to, resolved against a project's board — undefined when
+ *  unassigned, dangling (column deleted elsewhere), or the project has no board yet. All
+ *  three mean Ungrouped, and the canvas shows no column pill for Ungrouped. */
+export function columnForNode(
+  k: ProjectKanban | undefined,
+  nodeId: string
+): KanbanColumn | undefined {
+  if (!k) return undefined
+  const a = k.assignments.find((x) => x.nodeId === nodeId)
+  return a ? k.columns.find((c) => c.id === a.columnId) : undefined
 }

--- a/src/renderer/nodes/ChatNode.tsx
+++ b/src/renderer/nodes/ChatNode.tsx
@@ -19,6 +19,7 @@ import { useSession } from '../session/session'
 import { accountChipLabel, createDiffNode, type CanvasNode } from '../state/workspace'
 import { useSettings } from '../state/settings'
 import type { ChatImageAttachment, ChatToolSummary } from '@shared/types'
+import { ColumnPill } from '../components/kanban/ColumnPill'
 
 const MAX_IMAGES = 5
 const MAX_IMAGE_BYTES = 2 * 1024 * 1024 // 2 MB per image
@@ -249,6 +250,9 @@ export default function ChatNode({ id, data, selected }: NodeProps<CanvasNode>) 
   }
 
   return (
+    <>
+    {/* Sibling of the root: .chat-node is overflow:hidden and would clip the half-pill. */}
+    <ColumnPill nodeId={id} />
     <div className={`chat-node${selected ? ' selected' : ''}`} style={{ borderTopColor: data.color }}>
       <NodeResizer isVisible={selected} minWidth={360} minHeight={280} />
       <div className="chat-node__header">
@@ -387,5 +391,6 @@ export default function ChatNode({ id, data, selected }: NodeProps<CanvasNode>) 
       </div>
       )}
     </div>
+    </>
   )
 }

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -72,6 +72,7 @@ import { hasHooks, canRecur, canContextLink, hasUsage, canChat, canResume, canRe
 import { ensureActivePermissionMode } from '../state/permissionMode'
 import { buildSshArgs, type SshConnection } from '@shared/ssh'
 import { hintLabel } from '@shared/platform-utils'
+import { ColumnPill } from '../components/kanban/ColumnPill'
 
 /** Backslash-escape shell-special characters, like a native terminal does on file drop. */
 function escapeDroppedPath(p: string): string {
@@ -1504,6 +1505,9 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
     status?.state !== 'blocked'
 
   return (
+    <>
+    {/* Sibling of the root: .term-node is overflow:hidden and would clip the half-pill. */}
+    <ColumnPill nodeId={id} />
     <div
       className={`term-node${selected ? ' selected' : ''}${collapsed ? ' collapsed' : ''}${
         isUnread ? ' unread' : ''
@@ -1812,5 +1816,6 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
           ))}
       </div>
     </div>
+    </>
   )
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2328,7 +2328,7 @@ body,
   position: absolute;
   top: 54px;
   right: 14px;
-  z-index: 11;
+  z-index: 26; /* above the kanban overlay (25) — the view toggle must stay reachable on the board */
   display: flex;
   align-items: center; /* center the presence facepile (26px) against the 34px toolbar buttons */
   gap: 6px;
@@ -2360,7 +2360,7 @@ body,
   top: 46px;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 26; /* above the kanban overlay (25), below the tab bar (30) */
+  z-index: 27; /* above the kanban overlay (25) and the cluster (26), below the tab bar (30) */
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -6451,21 +6451,30 @@ body,
   border-color: rgba(255, 255, 255, 0.3);
 }
 
-.tab__view-toggle {
+
+/* ---- Kanban column pill: half-pill flush against a session node's top edge (rendered as a
+   sibling of the overflow:hidden node root, so it can poke above the border). ---- */
+.kanban-node-pill {
+  position: absolute;
+  top: -19px;
+  right: 10px;
+  height: 19px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  margin-left: 2px;
-  background: none;
-  border: none;
-  border-radius: 6px;
-  color: rgba(255, 255, 255, 0.55);
+  padding: 0 9px;
+  border: 1px solid;
+  border-bottom: none;
+  border-radius: 7px 7px 0 0; /* the flat bottom is what makes it read as attached */
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  max-width: 45%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   cursor: pointer;
-  -webkit-app-region: no-drag; /* the tab bar is the window drag region */
+  backdrop-filter: blur(4px);
 }
-.tab__view-toggle:hover {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.9);
+.kanban-node-pill:hover {
+  filter: brightness(1.3);
 }


### PR DESCRIPTION
## Summary

Two UX corrections from live use of the session board:

- **View toggle moves to the controls cluster** (next to Explorer / Source Control / Settings) — with many projects open, the tab-strip toggle scrolled out of sight; the cluster is the stable home of view/panel controls. The tab-bar button is removed (⌘⇧B and the ⌘K commands unchanged). The cluster's z-index rises above the board overlay (banners one step above it) so the toggle stays clickable while the board is open.
- **Column half-pill on session nodes**: a terminal/chat assigned to a non-Ungrouped column shows its column name in a half-pill flush against the node's TOP edge (column color, flat bottom = "attached" look). Rendered as a sibling of the node root (the roots are overflow:hidden), derived live from the board (`columnForNode` in lib/kanban), hidden for Ungrouped/dangling, click opens the board.

## Test plan

- [x] `columnForNode` unit test (assigned / unassigned / dangling / no board), TDD; full suite 2139/2139 (the 2 previously pre-existing pty failures are fixed on main now), typecheck clean
- [x] Live browser drive (Server Edition, seeded assigned+unassigned terminals): 10/10 — no tab-bar toggle, cluster toggle present, works over the open board, one pill per assigned node with correct name, pill click opens the board, drag-assign on the board grows a second pill live on canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h