### PR TITLE
feat: Trello-style kanban toggle on the tab, board title strip, collapsible session cards

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -5811,16 +5811,6 @@ export function Canvas() {
           <span className="cluster-search__icon">⌕</span>
           <span className="kbd">{hintLabel('⌘K')}</span>
         </button>
-        {/* Lives here, not in the tab bar: many open projects pushed a tab-strip toggle out of
-            sight, and this cluster is the stable home of view/panel controls. */}
-        {activeProjectId && (
-          <button
-            title={hintLabel(kanbanOpen ? 'Canvas view (⌘⇧B)' : 'Kanban view (⌘⇧B)')}
-            onClick={() => useViewMode.getState().toggle(activeProjectId)}
-          >
-            {kanbanOpen ? <IconCanvasView /> : <IconKanban />}
-          </button>
-        )}
         <button title={hintLabel('Explorer (⌘⇧E)')} onClick={() => setExplorerOpen(true)}>
           <IconExplorer />
         </button>

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useProjects } from '../state/projects'
+import { useViewMode } from '../state/viewMode'
 import { useAgentStatus } from '../state/agentStatus'
 import { useSettings } from '../state/settings'
 import { accountsForProject, sshAccountsHint, systemAccountDisplay } from '../state/workspace'
@@ -9,6 +10,7 @@ import { sshAutoModeHint } from '../state/permissionMode'
 import { useSystemAccount } from '../state/systemAccount'
 import { sessionCount, sessionForProject, useProjectSession } from '../session/session'
 import { tabClickAction } from '../session/relay-tab'
+import { IconCanvasView, IconKanban } from './icons'
 import {
   ALL_PERMISSION_MODES,
   PERMISSION_MODE_LABELS,
@@ -77,6 +79,7 @@ export function TabBar({
   // Closed projects are hidden here (reopen them from the start screen's "Recently closed").
   const projects = useMemo(() => allProjects.filter((p) => !p.closed), [allProjects])
   const activeId = useProjects((s) => s.activeProjectId)
+  const kanbanActive = useViewMode((s) => !!activeId && !!s.viewByProject[activeId])
   // Unread dots need only the unread id set — subscribing to the whole status map re-rendered
   // the TabBar on every working/waiting flip of any agent. Primitive signature → rare updates.
   const unreadIds = useAgentStatus((s) => {
@@ -309,6 +312,18 @@ export function TabBar({
                   </span>
                 )}
 
+                {active && editingId !== p.id && (
+                  <button
+                    className="tab__board-toggle"
+                    title={kanbanActive ? 'Canvas view (⌘⇧B)' : 'Kanban view (⌘⇧B)'}
+                    onClick={(e) => {
+                      e.stopPropagation() // a tab click switches projects — this only flips the view
+                      useViewMode.getState().toggle(p.id)
+                    }}
+                  >
+                    {kanbanActive ? <IconCanvasView /> : <IconKanban />}
+                  </button>
+                )}
                 {active && editingId !== p.id && (
                   <button
                     className="tab__caret"

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -10,6 +10,9 @@ interface KanbanColumnProps {
   column: KanbanColumnT | null
   cards: KanbanSession[]
   statusById: Record<string, AgentNodeStatus>
+  /** Which cards show their detail row (card click toggles membership). */
+  expandedIds: ReadonlySet<string>
+  onToggleCard: (nodeId: string) => void
   onRename?: (title: string) => void
   onRecolor?: (color: string) => void
   onDelete?: () => void
@@ -24,7 +27,7 @@ interface KanbanColumnProps {
 }
 
 export function KanbanColumn({
-  column, cards, statusById, onRename, onRecolor, onDelete, onOpenNode,
+  column, cards, statusById, expandedIds, onToggleCard, onRename, onRecolor, onDelete, onOpenNode,
   onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn, onDropBeforeCard
 }: KanbanColumnProps) {
   const [editingTitle, setEditingTitle] = useState(false)
@@ -118,6 +121,8 @@ export function KanbanColumn({
             key={s.id}
             session={s}
             status={statusById[s.id]}
+            expanded={expandedIds.has(s.id)}
+            onToggle={() => onToggleCard(s.id)}
             onOpen={() => onOpenNode(s.id)}
             onDragStart={() => onCardDragStart(s.id)}
             onDragEnd={onDragEnd}

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -1,6 +1,7 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import type { ProjectKanban } from '@shared/types'
 import { useAgentStatus } from '../../state/agentStatus'
+import { useProjects } from '../../state/projects'
 import {
   addColumn, assignNode, assignedTo, deleteColumn, moveColumn, nextColumnColor,
   pruneAssignments, recolorColumn, renameColumn, unassigned
@@ -33,7 +34,20 @@ type Drag = { kind: 'card' | 'column'; id: string } | null
 export function KanbanView({ board, sessions, onChange, onOpenNode }: KanbanViewProps) {
   const dragRef = useRef<Drag>(null)
   const statusById = useAgentStatus((s) => s.byId)
+  // Primitive selectors (not one object) — an object selector would re-render on every store set.
+  const projectName = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.name)
+  const projectColor = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.color)
+  // Card detail rows open per session id; transient by design (resets when the board closes).
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(new Set())
   const byId = new Map(sessions.map((s) => [s.id, s]))
+
+  const toggleExpanded = (id: string) =>
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
 
   // Prune dead nodes' assignments on every persisted change, so they never accumulate
   // in the shared file.
@@ -67,11 +81,19 @@ export function KanbanView({ board, sessions, onChange, onOpenNode }: KanbanView
 
   return (
     <div className="kanban-overlay">
+      {/* Title strip: names the board's project AND pushes the columns below the top-right
+          controls cluster, so column headers never sit under its icons. */}
+      <div className="kanban-header">
+        <span className="kanban-header__dot" style={{ background: projectColor }} />
+        <span className="kanban-header__name">{projectName}</span>
+      </div>
       <div className="kanban-board">
         <KanbanColumn
           column={null}
           cards={sessionsFor(unassigned(board, sessions.map((s) => s.id)))}
           statusById={statusById}
+          expandedIds={expandedIds}
+          onToggleCard={toggleExpanded}
           onOpenNode={onOpenNode}
           onCardDragStart={(id) => (dragRef.current = { kind: 'card', id })}
           onDragEnd={() => (dragRef.current = null)}
@@ -84,6 +106,8 @@ export function KanbanView({ board, sessions, onChange, onOpenNode }: KanbanView
             column={col}
             cards={sessionsFor(assignedTo(board, col.id))}
             statusById={statusById}
+            expandedIds={expandedIds}
+            onToggleCard={toggleExpanded}
             onRename={(t) => commit(renameColumn(board, col.id, t))}
             onRecolor={(c) => commit(recolorColumn(board, col.id, c))}
             onDelete={() => commit(deleteColumn(board, col.id))}

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -1,9 +1,13 @@
 import type { AgentNodeStatus } from '../../state/agentStatus'
+import { ContextMeter } from '../ContextMeter'
 import type { KanbanSession } from './KanbanView'
 
 interface SessionCardProps {
   session: KanbanSession
   status?: AgentNodeStatus
+  expanded: boolean
+  /** Single click toggles the detail row — opening the node moved to ↗ / double-click. */
+  onToggle: () => void
   /** Open on canvas: switch back to canvas view and focus this node. */
   onOpen: () => void
   onDragStart: () => void
@@ -12,7 +16,9 @@ interface SessionCardProps {
   onDropBefore: () => void
 }
 
-export function SessionCard({ session, status, onOpen, onDragStart, onDragEnd, onDropBefore }: SessionCardProps) {
+export function SessionCard({
+  session, status, expanded, onToggle, onOpen, onDragStart, onDragEnd, onDropBefore
+}: SessionCardProps) {
   const badge =
     status?.state === 'working'
       ? 'running'
@@ -21,7 +27,7 @@ export function SessionCard({ session, status, onOpen, onDragStart, onDragEnd, o
         : null
   return (
     <div
-      className="kanban-card kanban-card--session"
+      className={`kanban-card kanban-card--session${expanded ? ' kanban-card--expanded' : ''}`}
       draggable
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = 'move'
@@ -34,15 +40,38 @@ export function SessionCard({ session, status, onOpen, onDragStart, onDragEnd, o
         e.stopPropagation() // don't let the column's end-drop swallow a drop aimed at this card
         onDropBefore()
       }}
-      onClick={onOpen}
-      title="Open on canvas"
+      onClick={onToggle}
+      onDoubleClick={(e) => {
+        e.stopPropagation()
+        onOpen()
+      }}
+      title={expanded ? 'Collapse' : 'Expand'}
     >
-      <span className="kanban-card__nodedot" style={{ background: session.color }} />
-      <span className="kanban-card__title">{session.title}</span>
-      {session.kind === 'chat' && <span className="kanban-card__kind">chat</span>}
-      {badge === 'running' && <span className="kanban-badge kanban-badge--running">RUNNING</span>}
-      {badge === 'needs' && <span className="kanban-badge kanban-badge--needs">NEEDS YOU</span>}
-      {status?.unread && <span className="kanban-card__unread" />}
+      <div className="kanban-card__row">
+        <span className="kanban-card__nodedot" style={{ background: session.color }} />
+        <span className="kanban-card__title">{session.title}</span>
+        {session.kind === 'chat' && <span className="kanban-card__kind">chat</span>}
+        {badge === 'running' && <span className="kanban-badge kanban-badge--running">RUNNING</span>}
+        {badge === 'needs' && <span className="kanban-badge kanban-badge--needs">NEEDS YOU</span>}
+        {status?.unread && <span className="kanban-card__unread" />}
+      </div>
+      {expanded && (
+        /* Clicks inside the detail row (meter popover, session chip) must not collapse the card. */
+        <div className="kanban-card__detail" onClick={(e) => e.stopPropagation()}>
+          <ContextMeter sessionId={status?.sessionId ?? null} />
+          {status?.session && (
+            <span className="kanban-card__session" title={status.session}>
+              {status.session}
+            </span>
+          )}
+          {!status?.sessionId && (
+            <span className="kanban-card__kindlabel">{session.kind === 'chat' ? 'chat' : 'terminal'}</span>
+          )}
+          <button className="kanban-card__open" title="Open on canvas" onClick={onOpen}>
+            ↗
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -194,6 +194,22 @@ body,
   outline: none;
 }
 
+.tab__board-toggle {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  border: none;
+  color: currentColor;
+  cursor: pointer;
+  line-height: 1;
+  padding: 2px 2px;
+  border-radius: 4px;
+  opacity: 0.55;
+}
+.tab__board-toggle:hover {
+  opacity: 1;
+}
+
 .tab__caret {
   background: transparent;
   border: none;
@@ -6274,10 +6290,40 @@ body,
   bottom: 0;
   z-index: 25; /* over the flow, under the tab bar (30) and the drawers/dialogs (40+) */
   background: #000;
-  overflow-x: auto;
-  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+/* Title strip: the project the board belongs to. Its height also clears the floating
+   controls cluster (top-right), so column headers never sit under those icons. */
+.kanban-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 46px;
+  padding: 0 18px;
+  padding-right: 300px; /* keep a long project name from running under the cluster icons */
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.kanban-header__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.kanban-header__name {
+  font-size: 14px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .kanban-board {
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
   display: flex;
   align-items: flex-start;
   gap: 12px;
@@ -6370,14 +6416,58 @@ body,
 }
 .kanban-card {
   position: relative;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  display: block;
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 8px;
   padding: 8px 10px;
-  cursor: grab;
+  cursor: pointer; /* click = expand/collapse; drag still works via the draggable attr */
+}
+.kanban-card__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.kanban-card__detail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  min-height: 22px;
+  cursor: default;
+}
+.kanban-card__session {
+  flex: 1;
+  min-width: 0;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.45);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.kanban-card__kindlabel {
+  flex: 1;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.35);
+}
+.kanban-card__open {
+  margin-left: auto;
+  flex: 0 0 auto;
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 5px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 12px;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+.kanban-card__open:hover {
+  background: var(--accent);
+  color: #fff;
 }
 .kanban-card:hover {
   border-color: rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
## Summary

Second UX round on the session board, from live use:

- **Toggle lives on the active project tab** (Trello-style: small board/canvas icon right after the project name, before the caret) — the view belongs to the project, and the active tab is always visible. The controls-cluster toggle from the previous round is removed; ⌘⇧B and ⌘K commands unchanged.
- **Board title strip**: the board opens with a full-width header (project color dot + name); columns start below it, so column headers no longer run under the top-right cluster icons.
- **Collapsible cards**: single click toggles a detail row (was: click opened the node). The detail row is styled like the terminal node's header strip: the **ContextMeter pill** (model + % — reused component, appears when the session has usage data), the session-name chip, and an **↗ Open on canvas** button. Double-click still opens the node directly. Plain terminals show a kind label instead of the meter. Collapse state is transient (per board open).

## Test plan

- [x] Full suite 2139/2139, typecheck clean
- [x] Live browser drive (Server Edition): 8/8 — tab toggle present, cluster toggle gone, header strip shows project name, click expands/collapses, ↗ returns to canvas with the node selected, double-click opens; screenshots verified (no icon/column collision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h