### PR TITLE
feat: per-column + New session menu; sticky notes join the board as cards

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -181,8 +181,8 @@ import { useEntitlement } from '../state/entitlement'
 import type { SshServer } from '@shared/ssh'
 import { sshHostKey } from '@shared/ssh'
 import type { CanvasNodeState, Project, ProjectKanban, SshProjectStatus, TranscriptHit } from '@shared/types'
-import { KanbanView } from '../components/kanban/KanbanView'
-import { defaultKanban } from '../lib/kanban'
+import { KanbanView, type KanbanCreateChoice } from '../components/kanban/KanbanView'
+import { assignNode, defaultKanban } from '../lib/kanban'
 import { isKanbanOpen, useViewMode } from '../state/viewMode'
 import {
   createCanvasPublisher,
@@ -4051,15 +4051,66 @@ export function Canvas() {
   const kanbanSessions = useMemo(
     () =>
       nodes
-        .filter((n) => n.type === 'terminal' || n.type === 'chat')
-        .map((n) => ({
-          id: n.id,
-          title: (n.data.title as string) ?? '',
-          color: (n.data.color as string) ?? NODE_COLORS[0],
-          kind: n.type as 'terminal' | 'chat',
-          agentId: n.data.agentId as string | undefined
-        })),
+        .filter((n) => n.type === 'terminal' || n.type === 'chat' || n.type === 'sticky')
+        .map((n) => {
+          if (n.type === 'sticky') {
+            const text = ((n.data.text as string) ?? '').trim()
+            return {
+              id: n.id,
+              // A note has no title of its own — its first line is the card label.
+              title: text.split('\n')[0].slice(0, 80) || 'Note',
+              color: (n.data.color as string) ?? NODE_COLORS[2],
+              kind: 'sticky' as const,
+              text
+            }
+          }
+          return {
+            id: n.id,
+            title: (n.data.title as string) ?? '',
+            color: (n.data.color as string) ?? NODE_COLORS[0],
+            kind: n.type as 'terminal' | 'chat',
+            agentId: n.data.agentId as string | undefined
+          }
+        }),
     [nodes]
+  )
+
+  // Create a node from the board's per-column "+ New" menu: it lands on the canvas (view
+  // center) and, for a real column, is assigned there. The assignment is written directly —
+  // NOT through the board's pruned commit path: the fresh node isn't in the derived session
+  // list until the next render, and a pruned commit would strip the assignment right back off.
+  const createNodeInColumn = useCallback(
+    (choice: KanbanCreateChoice, columnId: string | null) => {
+      const project = useProjects.getState().getProject(activeProjectId)
+      const index = nodesRef.current.length
+      const at = viewCenter()
+      const node =
+        choice.kind === 'terminal'
+          ? createTerminalNode(index, project?.cwd, at, undefined, project?.ssh)
+          : choice.kind === 'sticky'
+            ? createStickyNode(index, at)
+            : createAgentNode(
+                choice.agentId,
+                index,
+                project?.cwd,
+                at,
+                undefined,
+                project?.ssh,
+                resolveNewNodeAccount(
+                  undefined,
+                  project,
+                  useSettings.getState().settings.claudeAccounts
+                ),
+                activePermissionMode()
+              )
+      setNodes((ns) => [...ns, node])
+      if (columnId) {
+        const board = project?.kanban ?? seedBoard
+        useProjects.getState().setProjectKanban(activeProjectId, assignNode(board, node.id, columnId, null))
+      }
+      markDirty()
+    },
+    [activeProjectId, viewCenter, setNodes, markDirty, seedBoard]
   )
 
   const openNodeFromKanban = useCallback(
@@ -5782,6 +5833,7 @@ export function Canvas() {
           sessions={kanbanSessions}
           onChange={onKanbanChange}
           onOpenNode={openNodeFromKanban}
+          onCreateNode={createNodeInColumn}
         />
       )}
       <UpdateCard />

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -3,7 +3,7 @@ import type { KanbanColumn as KanbanColumnT } from '@shared/types'
 import type { AgentNodeStatus } from '../../state/agentStatus'
 import { NODE_COLORS } from '../../state/workspace'
 import { SessionCard } from './SessionCard'
-import type { KanbanSession } from './KanbanView'
+import type { KanbanCreateChoice, KanbanCreateOption, KanbanSession } from './KanbanView'
 
 interface KanbanColumnProps {
   /** null = the virtual Ungrouped column: fixed label, no rename/recolor/delete, header not draggable. */
@@ -17,6 +17,9 @@ interface KanbanColumnProps {
   onRecolor?: (color: string) => void
   onDelete?: () => void
   onOpenNode: (nodeId: string) => void
+  /** "+ New" menu entries (agents, terminal, sticky) and what to do when one is picked. */
+  createOptions: KanbanCreateOption[]
+  onCreate: (choice: KanbanCreateChoice) => void
   // Drag plumbing — the single drag source of truth lives in KanbanView.
   onCardDragStart: (nodeId: string) => void
   onColumnDragStart?: () => void
@@ -28,11 +31,13 @@ interface KanbanColumnProps {
 
 export function KanbanColumn({
   column, cards, statusById, expandedIds, onToggleCard, onRename, onRecolor, onDelete, onOpenNode,
-  onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn, onDropBeforeCard
+  createOptions, onCreate, onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn,
+  onDropBeforeCard
 }: KanbanColumnProps) {
   const [editingTitle, setEditingTitle] = useState(false)
   const [title, setTitle] = useState(column?.title ?? '')
   const [swatchesOpen, setSwatchesOpen] = useState(false)
+  const [newMenuOpen, setNewMenuOpen] = useState(false)
 
   const commitTitle = () => {
     const t = title.trim()
@@ -129,6 +134,26 @@ export function KanbanColumn({
             onDropBefore={() => onDropBeforeCard(s.id)}
           />
         ))}
+      </div>
+      <div className="kanban-col__footer">
+        {newMenuOpen && (
+          <div className="kanban-col__newmenu">
+            {createOptions.map((o) => (
+              <button
+                key={o.key}
+                onClick={() => {
+                  setNewMenuOpen(false)
+                  onCreate(o.choice)
+                }}
+              >
+                {o.label}
+              </button>
+            ))}
+          </div>
+        )}
+        <button className="kanban-col__new" onClick={() => setNewMenuOpen((v) => !v)}>
+          + New session
+        </button>
       </div>
     </div>
   )

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -1,7 +1,9 @@
 import { useRef, useState } from 'react'
 import type { ProjectKanban } from '@shared/types'
+import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type AgentId } from '@shared/agents/config'
 import { useAgentStatus } from '../../state/agentStatus'
 import { useProjects } from '../../state/projects'
+import { useSettings } from '../../state/settings'
 import {
   addColumn, assignNode, assignedTo, deleteColumn, moveColumn, nextColumnColor,
   pruneAssignments, recolorColumn, renameColumn, unassigned
@@ -14,8 +16,23 @@ export interface KanbanSession {
   id: string
   title: string
   color: string
-  kind: 'terminal' | 'chat'
+  kind: 'terminal' | 'chat' | 'sticky'
   agentId?: string
+  /** Sticky note body — shown in the expanded detail row. */
+  text?: string
+}
+
+/** What the per-column "+ New" menu can create. */
+export type KanbanCreateChoice =
+  | { kind: 'terminal' }
+  | { kind: 'sticky' }
+  | { kind: 'agent'; agentId: AgentId }
+
+/** One "+ New" menu entry (label + the choice it fires). */
+export interface KanbanCreateOption {
+  key: string
+  label: string
+  choice: KanbanCreateChoice
 }
 
 interface KanbanViewProps {
@@ -24,6 +41,8 @@ interface KanbanViewProps {
   onChange: (next: ProjectKanban) => void
   /** Open a session from its card: switch back to canvas view and focus the node. */
   onOpenNode: (nodeId: string) => void
+  /** Create a node from a column's "+ New" menu (columnId null = Ungrouped: no assignment). */
+  onCreateNode: (choice: KanbanCreateChoice, columnId: string | null) => void
 }
 
 type Drag = { kind: 'card' | 'column'; id: string } | null
@@ -31,7 +50,7 @@ type Drag = { kind: 'card' | 'column'; id: string } | null
 /** Full-page session board OVER the canvas. The canvas stays mounted underneath (its
  *  agent-status listeners must keep running, and display:none would 0×0-resize every
  *  terminal into a tmux SIGWINCH) — this is an opaque overlay, nothing more. */
-export function KanbanView({ board, sessions, onChange, onOpenNode }: KanbanViewProps) {
+export function KanbanView({ board, sessions, onChange, onOpenNode, onCreateNode }: KanbanViewProps) {
   const dragRef = useRef<Drag>(null)
   const statusById = useAgentStatus((s) => s.byId)
   // Primitive selectors (not one object) — an object selector would re-render on every store set.
@@ -39,6 +58,23 @@ export function KanbanView({ board, sessions, onChange, onOpenNode }: KanbanView
   const projectColor = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.color)
   // Card detail rows open per session id; transient by design (resets when the board closes).
   const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(new Set())
+  const customAgents = useSettings((s) => s.settings.customAgents)
+  // "+ New" menu entries: the builtin agents, the user's custom agents, then terminal + sticky
+  // (same universe as the dock's add menu, minus canvas-only kinds).
+  const createOptions: KanbanCreateOption[] = [
+    ...BUILTIN_AGENT_IDS.map((id) => ({
+      key: id,
+      label: AGENT_CONFIG[id].label,
+      choice: { kind: 'agent', agentId: id } as KanbanCreateChoice
+    })),
+    ...customAgents.map((a) => ({
+      key: a.id,
+      label: a.label,
+      choice: { kind: 'agent', agentId: a.id } as KanbanCreateChoice
+    })),
+    { key: 'terminal', label: 'Terminal', choice: { kind: 'terminal' } },
+    { key: 'sticky', label: 'Sticky note', choice: { kind: 'sticky' } }
+  ]
   const byId = new Map(sessions.map((s) => [s.id, s]))
 
   const toggleExpanded = (id: string) =>
@@ -95,6 +131,8 @@ export function KanbanView({ board, sessions, onChange, onOpenNode }: KanbanView
           expandedIds={expandedIds}
           onToggleCard={toggleExpanded}
           onOpenNode={onOpenNode}
+          createOptions={createOptions}
+          onCreate={(choice) => onCreateNode(choice, null)}
           onCardDragStart={(id) => (dragRef.current = { kind: 'card', id })}
           onDragEnd={() => (dragRef.current = null)}
           onDropOnColumn={() => dropOnColumn(null)}
@@ -112,6 +150,8 @@ export function KanbanView({ board, sessions, onChange, onOpenNode }: KanbanView
             onRecolor={(c) => commit(recolorColumn(board, col.id, c))}
             onDelete={() => commit(deleteColumn(board, col.id))}
             onOpenNode={onOpenNode}
+            createOptions={createOptions}
+            onCreate={(choice) => onCreateNode(choice, col.id)}
             onCardDragStart={(id) => (dragRef.current = { kind: 'card', id })}
             onColumnDragStart={() => (dragRef.current = { kind: 'column', id: col.id })}
             onDragEnd={() => (dragRef.current = null)}

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -19,10 +19,11 @@ interface SessionCardProps {
 export function SessionCard({
   session, status, expanded, onToggle, onOpen, onDragStart, onDragEnd, onDropBefore
 }: SessionCardProps) {
+  const sticky = session.kind === 'sticky'
   const badge =
-    status?.state === 'working'
+    !sticky && status?.state === 'working'
       ? 'running'
-      : status?.state === 'waiting' || status?.state === 'blocked'
+      : !sticky && (status?.state === 'waiting' || status?.state === 'blocked')
         ? 'needs'
         : null
   return (
@@ -51,6 +52,7 @@ export function SessionCard({
         <span className="kanban-card__nodedot" style={{ background: session.color }} />
         <span className="kanban-card__title">{session.title}</span>
         {session.kind === 'chat' && <span className="kanban-card__kind">chat</span>}
+        {sticky && <span className="kanban-card__kind">note</span>}
         {badge === 'running' && <span className="kanban-badge kanban-badge--running">RUNNING</span>}
         {badge === 'needs' && <span className="kanban-badge kanban-badge--needs">NEEDS YOU</span>}
         {status?.unread && <span className="kanban-card__unread" />}
@@ -58,14 +60,22 @@ export function SessionCard({
       {expanded && (
         /* Clicks inside the detail row (meter popover, session chip) must not collapse the card. */
         <div className="kanban-card__detail" onClick={(e) => e.stopPropagation()}>
-          <ContextMeter sessionId={status?.sessionId ?? null} />
-          {status?.session && (
-            <span className="kanban-card__session" title={status.session}>
-              {status.session}
-            </span>
-          )}
-          {!status?.sessionId && (
-            <span className="kanban-card__kindlabel">{session.kind === 'chat' ? 'chat' : 'terminal'}</span>
+          {sticky ? (
+            <span className="kanban-card__stickytext">{session.text || 'Empty note'}</span>
+          ) : (
+            <>
+              <ContextMeter sessionId={status?.sessionId ?? null} />
+              {status?.session && (
+                <span className="kanban-card__session" title={status.session}>
+                  {status.session}
+                </span>
+              )}
+              {!status?.sessionId && (
+                <span className="kanban-card__kindlabel">
+                  {session.kind === 'chat' ? 'chat' : 'terminal'}
+                </span>
+              )}
+            </>
           )}
           <button className="kanban-card__open" title="Open on canvas" onClick={onOpen}>
             ↗

--- a/src/renderer/nodes/StickyNode.tsx
+++ b/src/renderer/nodes/StickyNode.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from '../state/workspace'
+import { ColumnPill } from '../components/kanban/ColumnPill'
 
 /**
  * A sticky note node: a colored, resizable card with free-text content.
@@ -29,6 +30,9 @@ export function StickyNode({ id, data, selected }: NodeProps<CanvasNode>) {
     )
 
   return (
+    <>
+    {/* Sibling of the root: .sticky-node is overflow:hidden and would clip the half-pill. */}
+    <ColumnPill nodeId={id} />
     <div
       className={`sticky-node${selected ? ' selected' : ''}${collapsed ? ' collapsed' : ''}`}
       style={{ background: `${data.color}22`, borderColor: data.color }}
@@ -98,5 +102,6 @@ export function StickyNode({ id, data, selected }: NodeProps<CanvasNode>) {
         onChange={(e) => updateNodeData(id, { text: e.target.value })}
       />
     </div>
+    </>
   )
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6570,3 +6570,65 @@ body,
 .kanban-node-pill:hover {
   filter: brightness(1.3);
 }
+
+/* ---- Kanban column footer: per-column "+ New session" with a create menu ---- */
+.kanban-col__footer {
+  position: relative;
+  padding: 6px 10px 10px;
+}
+.kanban-col__new {
+  width: 100%;
+  background: none;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 11px;
+  padding: 6px 8px;
+  cursor: pointer;
+  text-align: left;
+}
+.kanban-col__new:hover {
+  color: rgba(255, 255, 255, 0.8);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+.kanban-col__newmenu {
+  position: absolute;
+  bottom: 100%;
+  left: 10px;
+  right: 10px;
+  margin-bottom: 4px;
+  background: #1c1c1e;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  padding: 4px;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+}
+.kanban-col__newmenu button {
+  background: none;
+  border: none;
+  border-radius: 5px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 12px;
+  text-align: left;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+.kanban-col__newmenu button:hover {
+  background: var(--accent);
+  color: #fff;
+}
+.kanban-card__stickytext {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.6);
+  white-space: pre-line;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}


### PR DESCRIPTION
## Summary

- **"+ New session" at the bottom of every board column** (Ungrouped included): a small menu offering the builtin agents (Claude Code / Codex / Gemini / opencode), the user's custom agents, Terminal, and Sticky note. The node is created on the canvas through the same machinery as the dock (view-center position, project cwd/ssh, managed-account default, permission-mode funnel) and — for a real column — assigned there immediately. The assignment is written un-pruned: the fresh node isn't in the derived session list until the next render, and the pruned commit path would strip it right back off.
- **Sticky notes are now board cards**: first line of the note is the card label (with a `note` tag), the expanded detail row shows the note text (clamped) + ↗; assignable/draggable like any card. StickyNode also gets the column half-pill on canvas.

## Test plan

- [x] Full suite 2163/2163 (one flaky failure on first run passed clean on re-run), typecheck clean
- [x] Live browser drive: + New menu lists agents/terminal/sticky; Terminal created from "To Do" lands assigned in To Do; Sticky created from "Done" appears as a note card there; both nodes + assignments persisted to `.nodeterm/project.json`; sticky visible on canvas after toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h