### PR TITLE
feat(usage): add the Gemini provider

### DIFF
--- a/src/core/usage/gemini-usage.test.ts
+++ b/src/core/usage/gemini-usage.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  dedupeBuckets,
+  parseQuotaBuckets,
+  modelLabel,
+  readGeminiCreds,
+  fetchGeminiUsage
+} from './gemini-usage'
+import { primaryLimit, limitLabel } from '../../shared/usage-limits'
+
+/**
+ * Cloud Code's `retrieveUserQuota` buckets: `remainingFraction` is what is LEFT (0–1),
+ * `resetTime` an ISO string, `modelId` the raw model name.
+ *
+ * NOTE: not captured from a live account — no Gemini credentials were available on the machine
+ * this was written on. Follows the documented field contract; numbers are illustrative.
+ */
+const BUCKETS = [
+  { remainingFraction: 0.25, resetTime: '2026-07-19T17:00:00Z', modelId: 'gemini-2.5-pro' },
+  { remainingFraction: 0.9, resetTime: '2026-07-19T17:00:00Z', modelId: 'gemini-2.5-flash' }
+]
+
+function mktemp(contents?: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-'))
+  if (contents !== undefined) fs.writeFileSync(path.join(dir, 'oauth_creds.json'), contents)
+  return dir
+}
+
+describe('bucket mapping', () => {
+  it('inverts remainingFraction into percent USED', () => {
+    // Google is the only provider that reports what is LEFT. Getting this backwards would show
+    // a drained quota as untouched.
+    const limits = dedupeBuckets(BUCKETS)
+    expect(limits.find((l) => l.scopeLabel === 'Pro')?.usedPercent).toBe(75)
+    expect(limits.find((l) => l.scopeLabel === 'Flash')?.usedPercent).toBe(10)
+  })
+
+  it('labels each bucket by model, so the UI needs no Gemini knowledge', () => {
+    const limits = dedupeBuckets(BUCKETS)
+    expect(limitLabel(limits[0].kind, limits[0].scopeLabel)).toBe('Pro')
+  })
+
+  it('reports the hourly window and no severity', () => {
+    for (const l of dedupeBuckets(BUCKETS)) {
+      expect(l.windowMinutes).toBe(60)
+      expect(l.severity).toBeNull()
+    }
+  })
+
+  it('parses the ISO reset stamp', () => {
+    expect(dedupeBuckets(BUCKETS)[0].resetsAt).toBe(Date.parse('2026-07-19T17:00:00Z'))
+  })
+
+  it('survives an unparseable reset stamp', () => {
+    const l = dedupeBuckets([{ remainingFraction: 0.5, resetTime: 'soon', modelId: 'x' }])
+    expect(l[0].resetsAt).toBeNull()
+  })
+
+  it('clamps a fraction outside 0–1', () => {
+    expect(dedupeBuckets([{ remainingFraction: 1.4, resetTime: '', modelId: 'a' }])[0].usedPercent).toBe(0)
+    expect(dedupeBuckets([{ remainingFraction: -2, resetTime: '', modelId: 'b' }])[0].usedPercent).toBe(100)
+  })
+})
+
+describe('modelLabel', () => {
+  it('uses the friendly name for known ids', () => {
+    expect(modelLabel('gemini-2.5-pro')).toBe('Pro')
+    expect(modelLabel('gemini-3.1-flash-lite')).toBe('3.1 Flash Lite')
+  })
+
+  it('humanizes an unknown id rather than showing it raw', () => {
+    expect(modelLabel('gemini-4.0-ultra')).toBe('4.0 Ultra')
+  })
+})
+
+describe('dedupeBuckets', () => {
+  it('collapses aliases that share one underlying quota', () => {
+    // Google returns the same bucket under several ids; rendering all of them repeats one bar.
+    const limits = dedupeBuckets([
+      { remainingFraction: 0.25, resetTime: '2026-07-19T17:00:00Z', modelId: 'gemini-2.5-pro' },
+      { remainingFraction: 0.25, resetTime: '2026-07-19T17:00:00Z', modelId: 'gemini-pro-latest' },
+      { remainingFraction: 0.25, resetTime: '2026-07-19T17:00:00Z', modelId: 'gemini-2.5-pro-exp-0827' }
+    ])
+    expect(limits).toHaveLength(1)
+    // The known label wins over the humanized ones.
+    expect(limits[0].scopeLabel).toBe('Pro')
+  })
+
+  it('keeps buckets that differ in usage or reset time', () => {
+    expect(dedupeBuckets(BUCKETS)).toHaveLength(2)
+  })
+
+  it('prefers the shorter name among equally-unknown aliases', () => {
+    const limits = dedupeBuckets([
+      { remainingFraction: 0.5, resetTime: 'x', modelId: 'gemini-zeta-experimental-preview' },
+      { remainingFraction: 0.5, resetTime: 'x', modelId: 'gemini-zeta' }
+    ])
+    expect(limits).toHaveLength(1)
+    expect(limits[0].scopeLabel).toBe('Zeta')
+  })
+})
+
+describe('parseQuotaBuckets', () => {
+  it('accepts both the bare array and the { buckets } wrapper', () => {
+    expect(parseQuotaBuckets(BUCKETS)).toHaveLength(2)
+    expect(parseQuotaBuckets({ buckets: BUCKETS })).toHaveLength(2)
+  })
+
+  it('drops malformed entries instead of emitting NaN bars', () => {
+    const parsed = parseQuotaBuckets([
+      { remainingFraction: 'lots', resetTime: 'x', modelId: 'a' },
+      { remainingFraction: 0.5, modelId: 'b' },
+      BUCKETS[0]
+    ])
+    expect(parsed).toHaveLength(1)
+  })
+
+  it('returns nothing for a junk body', () => {
+    expect(parseQuotaBuckets(null)).toEqual([])
+    expect(parseQuotaBuckets({})).toEqual([])
+    expect(parseQuotaBuckets('nope')).toEqual([])
+  })
+})
+
+describe('readGeminiCreds', () => {
+  it('reads the access token', async () => {
+    const dir = mktemp(JSON.stringify({ access_token: 'tok', expiry_date: Date.now() + 60_000 }))
+    await expect(readGeminiCreds(dir)).resolves.toEqual({ accessToken: 'tok', expired: false })
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('flags an expired token', async () => {
+    const dir = mktemp(JSON.stringify({ access_token: 'tok', expiry_date: Date.now() - 1000 }))
+    await expect(readGeminiCreds(dir)).resolves.toMatchObject({ expired: true })
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('treats a missing expiry_date as not-expired and lets the API decide', async () => {
+    // Refusing to try on incomplete local metadata would be a self-inflicted outage.
+    const dir = mktemp(JSON.stringify({ access_token: 'tok' }))
+    await expect(readGeminiCreds(dir)).resolves.toEqual({ accessToken: 'tok', expired: false })
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns nulls for a missing or malformed file rather than throwing', async () => {
+    const dir = mktemp()
+    await expect(readGeminiCreds(dir)).resolves.toEqual({ accessToken: null, expired: false })
+    fs.writeFileSync(path.join(dir, 'oauth_creds.json'), 'not json')
+    await expect(readGeminiCreds(dir)).resolves.toEqual({ accessToken: null, expired: false })
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+describe('fetchGeminiUsage', () => {
+  it('reports unavailable when not signed in, without touching the network', async () => {
+    const dir = mktemp()
+    await expect(fetchGeminiUsage(dir)).resolves.toMatchObject({
+      provider: 'gemini',
+      status: 'unavailable',
+      limits: []
+    })
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reports unavailable on an expired token instead of calling the API', async () => {
+    // We deliberately do not refresh (see the module header), so a lapsed token is "nothing to
+    // show" rather than an error the user is asked to act on.
+    const dir = mktemp(JSON.stringify({ access_token: 'tok', expiry_date: 1 }))
+    await expect(fetchGeminiUsage(dir)).resolves.toMatchObject({ status: 'unavailable' })
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+describe('shared helpers over Gemini limits', () => {
+  it('leads with the most constrained model, no synthesized session window needed', () => {
+    expect(primaryLimit(dedupeBuckets(BUCKETS))?.scopeLabel).toBe('Pro')
+  })
+})

--- a/src/core/usage/gemini-usage.ts
+++ b/src/core/usage/gemini-usage.ts
@@ -1,0 +1,216 @@
+// Gemini CLI subscription usage, via Google's internal Cloud Code quota API — the same endpoint
+// the Gemini CLI itself reads.
+//
+// Two deliberate limits, both narrower than orca's equivalent:
+//
+//   * We read ONLY `~/.gemini/oauth_creds.json`. Orca additionally scans opencode's data
+//     directories (`~/.local/share/opencode/auth.json`, the macOS Application Support copy, …)
+//     for a Google token — and gates that behind an explicit opt-in precisely because it means
+//     reading another application's credentials off disk. The simplest correct answer is not to.
+//
+//   * We never refresh the token. Same policy as the Claude and Codex providers: display-only,
+//     no credential writes. Orca refreshes using an OAuth client id/secret extracted from the
+//     installed Gemini CLI's JS bundle, which is both fragile (a CLI update breaks it) and a
+//     step up in credential handling we have no need to take.
+//
+//     The tradeoff is real and worth knowing: Google access tokens are short-lived (~1h), so an
+//     expired token reports 'unavailable' until the user next runs `gemini`, which refreshes it.
+//     Usage is therefore reliable while you are actually using Gemini and goes quiet afterwards.
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import type { ProviderUsage, UsageLimit } from '../../shared/types'
+
+const LOAD_CODE_ASSIST_URL = 'https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist'
+const RETRIEVE_QUOTA_URL = 'https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota'
+const FETCH_TIMEOUT_MS = 8000
+/** Google's quota buckets are hourly. The API does not state the duration, so this is fixed. */
+const BUCKET_WINDOW_MINUTES = 60
+
+/** Friendly names for the model ids Google returns. Anything unlisted is humanized instead. */
+const MODEL_LABELS: Record<string, string> = {
+  'gemini-3.1-pro': '3.1 Pro',
+  'gemini-3.1-flash': '3.1 Flash',
+  'gemini-3.1-flash-lite': '3.1 Flash Lite',
+  'gemini-3.0-pro': '3.0 Pro',
+  'gemini-3.0-flash': '3.0 Flash',
+  'gemini-2.5-pro': 'Pro',
+  'gemini-2.5-flash': 'Flash',
+  'gemini-2.5-flash-lite': 'Flash Lite',
+  'gemini-2.0-pro': '2.0 Pro',
+  'gemini-2.0-flash': '2.0 Flash',
+  'gemini-2.0-flash-lite': '2.0 Flash Lite',
+  'gemini-1.5-pro': '1.5 Pro',
+  'gemini-1.5-flash': '1.5 Flash'
+}
+
+export function modelLabel(modelId: string): string {
+  const known = MODEL_LABELS[modelId]
+  if (known) return known
+  return modelId
+    .replace(/^gemini-/i, '')
+    .split('-')
+    .map((part) => (part ? part[0]!.toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+interface GeminiCreds {
+  accessToken: string | null
+  expired: boolean
+}
+
+/** Read the Gemini CLI's OAuth credentials. Never written back. */
+export async function readGeminiCreds(home = path.join(os.homedir(), '.gemini')): Promise<GeminiCreds> {
+  try {
+    const raw = await fs.readFile(path.join(home, 'oauth_creds.json'), 'utf-8')
+    const j = JSON.parse(raw) as Record<string, any>
+    const accessToken = typeof j.access_token === 'string' ? j.access_token : null
+    // `expiry_date` is Unix ms. Treat a missing one as "not expired" and let the API decide —
+    // refusing to try on incomplete local metadata would be a self-inflicted outage.
+    const expired = typeof j.expiry_date === 'number' ? j.expiry_date <= Date.now() : false
+    return { accessToken, expired }
+  } catch {
+    return { accessToken: null, expired: false }
+  }
+}
+
+interface QuotaBucket {
+  remainingFraction: number
+  resetTime: string
+  modelId: string
+}
+
+function isQuotaBucket(o: unknown): o is QuotaBucket {
+  if (!o || typeof o !== 'object') return false
+  const b = o as Record<string, any>
+  return (
+    typeof b.remainingFraction === 'number' &&
+    Number.isFinite(b.remainingFraction) &&
+    typeof b.resetTime === 'string' &&
+    typeof b.modelId === 'string'
+  )
+}
+
+/** The response has been seen both as a bare array and wrapped in `{ buckets }`. Accept both. */
+export function parseQuotaBuckets(data: unknown): QuotaBucket[] {
+  const raw = Array.isArray(data)
+    ? data
+    : data && typeof data === 'object' && Array.isArray((data as any).buckets)
+      ? (data as any).buckets
+      : []
+  return (raw as unknown[]).filter(isQuotaBucket)
+}
+
+/**
+ * Map one bucket. Google reports what is LEFT (`remainingFraction`, 0–1) where every other
+ * provider reports what is used, so this inverts — getting that backwards would show a drained
+ * quota as untouched.
+ */
+function mapBucket(b: QuotaBucket): UsageLimit {
+  const usedPercent = Math.min(100, Math.max(0, Math.round((1 - b.remainingFraction) * 100)))
+  const resetsAt = Date.parse(b.resetTime)
+  return {
+    // Each bucket is a per-model cap, which is the same idea as Claude's `weekly_scoped` — the
+    // model rides in scopeLabel, so the UI labels it without knowing anything about Gemini.
+    kind: 'model_hourly',
+    group: 'model',
+    usedPercent,
+    // Google reports no severity.
+    severity: null,
+    resetsAt: Number.isNaN(resetsAt) ? null : resetsAt,
+    windowMinutes: BUCKET_WINDOW_MINUTES,
+    scopeLabel: modelLabel(b.modelId),
+    isActive: false
+  }
+}
+
+/**
+ * Google returns the same underlying bucket under several model aliases (a `-latest` id and its
+ * concrete version share one quota), so rendering them all would repeat one bar three times.
+ * Identical (usedPercent, resetsAt) means one bucket; keep the entry with the best name —
+ * a known label beats an unknown one, and among equals the shorter one wins.
+ */
+export function dedupeBuckets(buckets: QuotaBucket[]): UsageLimit[] {
+  const out: { limit: UsageLimit; known: boolean }[] = []
+  const seen = new Map<string, number>()
+
+  for (const b of buckets) {
+    const limit = mapBucket(b)
+    const known = b.modelId in MODEL_LABELS
+    const key = `${limit.usedPercent}-${limit.resetsAt}`
+    const at = seen.get(key)
+    if (at === undefined) {
+      seen.set(key, out.length)
+      out.push({ limit, known })
+      continue
+    }
+    const prev = out[at]!
+    const better =
+      (known && !prev.known) ||
+      (known === prev.known && (limit.scopeLabel?.length ?? 0) < (prev.limit.scopeLabel?.length ?? 0))
+    if (better) out[at] = { limit, known }
+  }
+  return out.map((e) => e.limit)
+}
+
+function snapshot(limits: UsageLimit[], status: ProviderUsage['status']): ProviderUsage {
+  return { provider: 'gemini', limits, account: null, updatedAt: Date.now(), status }
+}
+
+async function postJson(url: string, token: string, body: unknown): Promise<Response> {
+  const ctrl = new AbortController()
+  const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS)
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+    signal: ctrl.signal
+  }).finally(() => clearTimeout(t))
+}
+
+/**
+ * The quota call is project-scoped. `GOOGLE_CLOUD_PROJECT` short-circuits the lookup (the Gemini
+ * CLI honours it too); otherwise ask Code Assist which project this account is onboarded to.
+ */
+export async function resolveProjectId(token: string): Promise<string | null> {
+  const fromEnv = process.env.GOOGLE_CLOUD_PROJECT?.trim()
+  if (fromEnv) return fromEnv
+  const res = await postJson(LOAD_CODE_ASSIST_URL, token, {
+    metadata: { ideType: 'GEMINI_CLI', pluginType: 'GEMINI' }
+  })
+  if (!res.ok) return null
+  const data = (await res.json()) as Record<string, any>
+  return typeof data.cloudaicompanionProject === 'string' ? data.cloudaicompanionProject : null
+}
+
+/**
+ * Gemini usage. Never rejects — a missing credentials file, an expired token and an unreachable
+ * API are all "we don't know", which the UI renders as no data rather than an error the user
+ * cannot act on.
+ *
+ * Note there is no synthesized "session" window here. Orca derives one from its most-constrained
+ * bucket because its shape has fixed session/weekly slots to fill; ours carries a list, so the
+ * buckets ARE the limits and `primaryLimit` already leads with the worst of them.
+ */
+export async function fetchGeminiUsage(
+  home = path.join(os.homedir(), '.gemini')
+): Promise<ProviderUsage> {
+  try {
+    const { accessToken, expired } = await readGeminiCreds(home)
+    // Not signed in, or the token lapsed and only the CLI can renew it — see the header note.
+    if (!accessToken || expired) return snapshot([], 'unavailable')
+
+    const projectId = await resolveProjectId(accessToken)
+    if (!projectId) return snapshot([], 'unavailable')
+
+    const res = await postJson(RETRIEVE_QUOTA_URL, accessToken, { project: projectId })
+    // 401/403 means the token is stale despite its local expiry_date — same "nothing to show"
+    // outcome as being logged out, not an error worth alarming about.
+    if (res.status === 401 || res.status === 403) return snapshot([], 'unavailable')
+    if (!res.ok) return snapshot([], 'error')
+
+    return snapshot(dedupeBuckets(parseQuotaBuckets(await res.json())), 'ok')
+  } catch {
+    return snapshot([], 'error')
+  }
+}

--- a/src/core/usage/usage-service.ts
+++ b/src/core/usage/usage-service.ts
@@ -20,6 +20,7 @@ import type {
 import { findLimit } from '../../shared/usage-limits'
 import { mapUsageLimits } from './claude-usage-map'
 import { fetchCodexUsage } from './codex-usage'
+import { fetchGeminiUsage } from './gemini-usage'
 import { usageCredsPaths } from '../claude-accounts-core'
 import { claudeConfigDirFor } from '../claude-config-dir'
 import { platform } from '../platform'
@@ -44,7 +45,8 @@ interface OAuthCreds {
  * Adding a provider is one entry here plus its fetcher — no changes to the service or the UI.
  */
 const OTHER_PROVIDERS: { id: string; fetch: () => Promise<ProviderUsage> }[] = [
-  { id: 'codex', fetch: fetchCodexUsage }
+  { id: 'codex', fetch: fetchCodexUsage },
+  { id: 'gemini', fetch: fetchGeminiUsage }
 ]
 
 /** Parse a credentials JSON blob; tokens may sit at top level or under `claudeAiOauth`. */


### PR DESCRIPTION
Third provider (after Claude #6/#7 and Codex #9), and the first real test of the claim from #9 that adding one is "a fetcher plus one line in `OTHER_PROVIDERS`". It was exactly that — the service and the UI are untouched.

## Fit

Gemini's per-model hourly buckets map onto the shape more naturally than anything so far. Each bucket is a per-model cap — the same idea as Claude's `weekly_scoped` — so the model name rides in `scopeLabel` and the UI labels it without knowing what Gemini is.

**No synthesized "session" window.** Orca derives one from its most-constrained bucket because its shape has fixed `session`/`weekly` slots to fill. Ours carries a list, so the buckets *are* the limits and `primaryLimit` already leads with the worst.

## Two inversions, both easy to get backwards

- **Google reports what is LEFT** (`remainingFraction`, 0–1) where every other provider reports what is used. Not inverting would render a drained quota as untouched.
- **The API returns one bucket under several model aliases** (a `-latest` id and its concrete version share a quota), so the same bar would be drawn three times. Deduped on `(usedPercent, resetsAt)`, keeping the best name: a known label beats a humanized one, and among equals the shorter wins.

## Two things this deliberately does NOT do

Both narrower than orca:

| | Orca | Here |
|---|---|---|
| Credential sources | `~/.gemini` **plus** opencode's data dirs (behind an opt-in) | `~/.gemini/oauth_creds.json` only |
| Expired token | Refreshes using an OAuth client id/secret **extracted from the installed CLI's JS bundle** | Reports `unavailable` |

Orca gates the opencode scan behind explicit opt-in precisely because it means reading another application's credentials off disk — the simplest correct answer is not to. And bundle-extracted client secrets break on a CLI update and are a step up in credential handling we have no need to take; it also matches the display-only, never-write-credentials policy the Claude and Codex providers already follow.

**The tradeoff is real and worth knowing:** Google access tokens last ~1h, so usage is reliable while you're actually using Gemini and goes quiet afterwards until the CLI refreshes. If that turns out to be too quiet in practice, in-memory refresh (no file write) is the follow-up — but it needs a decision about where the client credentials come from.

## Verified

224 files / 2203 tests pass; typecheck clean — **verified in an isolated git worktree**, because a concurrent session had unrelated half-finished edits to `usage-service.ts` and the server handlers in the shared working tree.

⚠️ **Unit-tested only.** No Gemini credentials were available on the machine this was written on, so the fixtures follow the documented field contract rather than a captured live response — same caveat as Codex in #9.

Next: the shared CLI PTY fallback (Claude + Codex both need it), then Grok / Kimi / MiniMax / opencode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)