### PR TITLE
feat(usage): surface enabled providers in the pill, not just the popover

### DIFF
--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -4,6 +4,8 @@ import { AGENT_CONFIG } from '@shared/agents/config'
 import { useSettings } from '../state/settings'
 import { formatResetCountdown, formatTimeAgo, severityColor } from '../lib/usageFormat'
 import {
+  enabledProviders,
+  hasAnyUsage,
   limitKey,
   limitLabel,
   limitShortLabel,
@@ -63,12 +65,15 @@ function AccountUsageBlock({ label, email, u }: { label: string; email?: string;
  * run Codex is noise, not information. An 'error' provider IS shown, because that is a
  * configured provider failing and hiding it would make the popover flap between refreshes.
  */
+/** AGENT_CONFIG is keyed by builtin ids; billing-only providers fall through to the shared table. */
+function labelFor(provider: string): string {
+  const agentLabel = (AGENT_CONFIG as Record<string, { label?: string } | undefined>)[provider]?.label
+  return providerLabel(provider, agentLabel)
+}
+
 function ProviderBlock({ u }: { u: ProviderUsage }) {
   if (u.status === 'unavailable') return null
-  // AGENT_CONFIG is keyed by the builtin ids; `provider` is an open string, so a billing-only
-  // provider (Grok, Kimi, …) has no entry and falls through to the shared label table.
-  const agentLabel = (AGENT_CONFIG as Record<string, { label?: string } | undefined>)[u.provider]?.label
-  const label = providerLabel(u.provider, agentLabel)
+  const label = labelFor(u.provider)
   return (
     <div className="usage-account">
       <div className="usage-account__label">{label}</div>
@@ -112,10 +117,12 @@ export function UsageIndicator(): JSX.Element | null {
     return window.nodeTerminal.usage.onUpdate(setUsage)
   }, [])
 
-  // Other providers are fetched only while the popover is open — each costs a network call (and
-  // possibly a subprocess), so polling them for a collapsed pill would spend that for nothing.
+  // Fetched once on mount and again whenever the popover opens (the service caches, so the
+  // second call is usually free). On mount rather than popover-only because the pill itself
+  // surfaces enabled providers now — and a provider the user has never signed into costs no
+  // network call at all: every fetcher short-circuits to 'unavailable' on a missing credentials
+  // file. So the price of asking is one failed read per unused provider, not five round-trips.
   useEffect(() => {
-    if (!open) return
     let cancelled = false
     void window.nodeTerminal.usage.providers().then((ps) => {
       if (!cancelled) setProviders(ps)
@@ -149,15 +156,21 @@ export function UsageIndicator(): JSX.Element | null {
     return () => window.removeEventListener('mousedown', onDown)
   }, [open])
 
-  if (!usage || usage.status === 'unavailable') return null
+  // Only providers the user has actually enabled reach the pill; render whenever ANY of them
+  // (Claude included) has something to say. Both rules are pure and pinned by tests — gating on
+  // Claude alone, which is what this did, left a Codex-only user with no pill at all.
+  const enabled = enabledProviders(providers)
+  if (!hasAnyUsage(usage, providers)) return null
 
-  const { limits, status } = usage
-  const hasData = limits.length > 0
+  const limits = usage?.limits ?? []
+  const status = usage?.status ?? 'unavailable'
+  const hasData = limits.length > 0 || enabled.length > 0
   const fetching = refreshing
   const isError = status === 'error'
   // The pill leads with whatever is closest to biting, so a scoped model cap that is nearly
-  // exhausted can't hide behind a comfortable 5h window.
-  const primary = primaryLimit(limits)
+  // exhausted can't hide behind a comfortable 5h window. Considers every enabled provider, not
+  // just Claude, so an exhausted Codex window drives the bar too.
+  const primary = primaryLimit([...limits, ...enabled.flatMap((p) => p.limits)])
 
   const refresh = async (e: React.MouseEvent): Promise<void> => {
     e.stopPropagation()
@@ -197,6 +210,20 @@ export function UsageIndicator(): JSX.Element | null {
             </span>
           </span>
         ))}
+        {/* One segment per enabled provider, carrying only its worst limit — a provider's full
+            breakdown belongs in the popover, not in a pill that has to fit beside the canvas. */}
+        {enabled.map((p, i) => {
+          const worst = primaryLimit(p.limits)
+          if (!worst) return null
+          return (
+            <span key={p.provider}>
+              {(limits.length > 0 || i > 0) && <span className="usage-pill__sep">·</span>}
+              <span className="usage-pill__num">
+                {Math.round(100 - worst.usedPercent)}% {labelFor(p.provider)}
+              </span>
+            </span>
+          )
+        })}
         {isError && hasData && <span className="usage-pill__dim">⚠</span>}
       </>
     )
@@ -207,10 +234,14 @@ export function UsageIndicator(): JSX.Element | null {
       {open && (
         <div className="usage-popover">
           <div className="usage-popover__head">
-            <span className="usage-popover__title">✦ Claude</span>
-            <span className="usage-popover__ago">Updated {formatTimeAgo(usage.updatedAt)}</span>
+            <span className="usage-popover__title">✦ Usage</span>
+            {/* Timestamp tracks the Claude snapshot, the only one that is polled. Absent when
+                Claude is not signed in and the panel is showing other providers only. */}
+            {usage && (
+              <span className="usage-popover__ago">Updated {formatTimeAgo(usage.updatedAt)}</span>
+            )}
           </div>
-          {accounts.length > 0 ? (
+          {accounts.length > 0 && usage ? (
             <>
               <AccountUsageBlock
                 label={systemAccountDisplay(systemLabelSetting, usage.email)}
@@ -224,11 +255,16 @@ export function UsageIndicator(): JSX.Element | null {
             </>
           ) : (
             <>
+              {/* Claude's rows are bare when it is the only provider; once others share the
+                  panel they need a heading of their own to stay attributable. */}
+              {enabled.length > 0 && limits.length > 0 && (
+                <div className="usage-account__label">Claude</div>
+              )}
               {limits.map((l) => (
                 <LimitRow key={limitKey(l)} limit={l} />
               ))}
               {!hasData && <div className="usage-popover__empty">No usage data.</div>}
-              {usage.email && (
+              {usage?.email && (
                 <div className="usage-account">
                   <div className="usage-account__label">Claude Account</div>
                   <div className="usage-account__email">{usage.email}</div>
@@ -241,7 +277,7 @@ export function UsageIndicator(): JSX.Element | null {
           ))}
         </div>
       )}
-      <button className="usage-pill" onClick={() => setOpen((v) => !v)} title="Claude usage">
+      <button className="usage-pill" onClick={() => setOpen((v) => !v)} title="Agent usage">
         <span className="usage-pill__icon">✦</span>
         {pillBody}
       </button>

--- a/src/shared/usage-limits.test.ts
+++ b/src/shared/usage-limits.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { limitLabel, limitShortLabel, primaryLimit, findLimit, limitKey } from './usage-limits'
-import type { UsageLimit } from './types'
+import {
+  limitLabel,
+  limitShortLabel,
+  primaryLimit,
+  findLimit,
+  limitKey,
+  enabledProviders,
+  hasAnyUsage,
+  providerLabel
+} from './usage-limits'
+import type { ProviderUsage, UsageLimit } from './types'
 
 function limit(over: Partial<UsageLimit>): UsageLimit {
   return {
@@ -88,5 +97,58 @@ describe('limitKey', () => {
     const a = limit({ kind: 'weekly_scoped', scopeLabel: 'Fable' })
     const b = limit({ kind: 'weekly_scoped', scopeLabel: 'Opus' })
     expect(limitKey(a)).not.toBe(limitKey(b))
+  })
+})
+
+function provider(over: Partial<ProviderUsage>): ProviderUsage {
+  return { provider: 'codex', limits: [], account: null, updatedAt: 0, status: 'ok', ...over }
+}
+
+describe('enabledProviders', () => {
+  it('keeps only signed-in providers that have something to report', () => {
+    const kept = enabledProviders([
+      provider({ provider: 'codex', limits: [limit({ usedPercent: 10 })] }),
+      provider({ provider: 'gemini', status: 'unavailable' }),
+      // 'ok' but empty: signed in with nothing to show is still nothing to show.
+      provider({ provider: 'grok', limits: [] })
+    ])
+    expect(kept.map((p) => p.provider)).toEqual(['codex'])
+  })
+})
+
+describe('hasAnyUsage', () => {
+  it('renders for a Codex-only user with no Claude at all', () => {
+    // The regression this exists for: gating on Claude left such a user with no indicator.
+    expect(
+      hasAnyUsage(null, [provider({ provider: 'codex', limits: [limit({ usedPercent: 5 })] })])
+    ).toBe(true)
+  })
+
+  it('renders when Claude alone is available', () => {
+    expect(hasAnyUsage({ status: 'ok' }, [])).toBe(true)
+  })
+
+  it('keeps rendering a failing Claude, so the pill does not flap between refreshes', () => {
+    expect(hasAnyUsage({ status: 'error' }, [])).toBe(true)
+  })
+
+  it('renders nothing when no provider is configured', () => {
+    expect(hasAnyUsage({ status: 'unavailable' }, [])).toBe(false)
+    expect(hasAnyUsage(null, [provider({ status: 'unavailable' })])).toBe(false)
+  })
+})
+
+describe('providerLabel', () => {
+  it('prefers a builtin agent label', () => {
+    expect(providerLabel('codex', 'Codex')).toBe('Codex')
+  })
+
+  it('names billing-only providers that have no agent entry', () => {
+    expect(providerLabel('grok')).toBe('Grok')
+    expect(providerLabel('minimax')).toBe('MiniMax')
+  })
+
+  it('falls back to the raw id so a new provider never renders blank', () => {
+    expect(providerLabel('whatever-next')).toBe('whatever-next')
   })
 })

--- a/src/shared/usage-limits.ts
+++ b/src/shared/usage-limits.ts
@@ -3,7 +3,7 @@
 //
 // The parsing that produces `UsageLimit[]` from a raw provider payload is service-side and
 // lives in core/usage — only the vocabulary lives here.
-import type { UsageLimit } from './types'
+import type { ProviderUsage, UsageLimit } from './types'
 
 /**
  * Human label for a limit. A scoped limit is named by its model ("Fable"); everything else
@@ -53,6 +53,29 @@ export function findLimit(limits: UsageLimit[], kind: string): UsageLimit | null
 /** Stable React key / dedupe key for a limit (kind alone repeats across scoped models). */
 export function limitKey(limit: UsageLimit): string {
   return `${limit.kind}:${limit.scopeLabel ?? ''}`
+}
+
+/**
+ * The providers the user has actually enabled: signed in AND with something to report. Anything
+ * else is noise in the pill for someone who has never used that service.
+ */
+export function enabledProviders(providers: ProviderUsage[]): ProviderUsage[] {
+  return providers.filter((p) => p.status === 'ok' && p.limits.length > 0)
+}
+
+/**
+ * Whether the usage indicator has anything to show at all.
+ *
+ * Deliberately NOT "is Claude available": gating on Claude alone leaves a Codex-only or
+ * Gemini-only user with no indicator whatsoever. An 'error' Claude still renders, because that
+ * is a configured provider failing and hiding it would make the pill flap between refreshes.
+ */
+export function hasAnyUsage(
+  claude: { status: string } | null | undefined,
+  providers: ProviderUsage[]
+): boolean {
+  if (claude && (claude.status === 'ok' || claude.status === 'error')) return true
+  return enabledProviders(providers).length > 0
 }
 
 /**


### PR DESCRIPTION
Implements the "sadece enable olanı göster" decision, and fixes a real blindness in what shipped earlier.

## The bug

Providers reached only the popover. Two consequences:

1. An exhausted Codex or Gemini window was **invisible** unless you happened to open the popover.
2. Worse — the component returned `null` whenever *Claude* was unavailable. A **Codex-only or Gemini-only user had no usage indicator at all.**

## The change

- The pill renders whenever **any** provider has something to say, not just Claude.
- One segment per enabled provider, carrying that provider's **worst** limit. The full breakdown stays in the popover — a pill has to fit beside the canvas.
- **Only enabled providers appear**: signed in *and* with something to report. A provider the user has never touched is noise, not information.
- The mini-bar now considers every enabled provider, so an exhausted Codex window drives the colour instead of hiding behind a comfortable Claude session.

```
Claude only:      ✦ [bar] 82% 5h · 35% wk · 8% Fable
Claude + Codex:   ✦ [bar] 82% 5h · 35% wk · 8% Fable · 29% Codex
Codex only:       ✦ [bar] 29% Codex          ← previously: nothing at all
```

## Testable, not just visible

`enabledProviders` and `hasAnyUsage` are pure functions in `shared/usage-limits.ts`, so the Codex-only regression is pinned by a test rather than by reading JSX. That matters here because the UI can't be exercised on this box.

## Cost

Providers are now fetched on mount as well as on popover-open, since the pill depends on them. Cheaper than it sounds: **every fetcher short-circuits to `unavailable` on a missing credentials file without touching the network**, so the price of asking is one failed read per unused provider, not five round-trips.

## Also

Popover title becomes "Usage" rather than "Claude", and Claude's rows gain a heading once other providers share the panel — otherwise they sat unattributed above labelled sections.

226 files / 2270 tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)