### PR TITLE
feat: Trello-style card modal with a live viewer terminal (core viewer identity)

### DIFF
--- a/src/core/pty-coattach.test.ts
+++ b/src/core/pty-coattach.test.ts
@@ -1299,4 +1299,52 @@ describe('viewer identity: multiple views per connection', () => {
     killV(ALICE, sessionId, 'modal') // the last view closes
     expect(spawned[0].killed).toBe(true) // …only now is the pty released
   })
+
+  // ── The Server Edition's per-CONNECTION socket pause outlives a single view's departure ──────
+  // A browser's WS send-buffer backpressure (`setFlow(uiId, …, 'socket')`) is owned by the whole
+  // CONNECTION, not by one xterm — it rides the PRIMARY view by convention (the socket forwards no
+  // viewerId). So when the canvas node (PRIMARY) unmounts while the kanban modal is still open on the
+  // SAME connection, that one shared socket may still be jammed: a `kill` that returned EVERY owner's
+  // ticket for the departing view — as a full departure does — would hand back the socket's pause too
+  // and permanently un-pause a drowning connection, because the renderer's flow control is
+  // edge-latched and will never re-pause (invariant (b) on `pausedBy`). The socket ticket must
+  // survive until the client's LAST view leaves; only THIS view's own renderer pause is unreturnable.
+  it("a PRIMARY-view kill keeps the client's per-connection SOCKET pause while a modal view stays", async () => {
+    const m = await manager()
+    vi.spyOn(m, 'captureForResync').mockResolvedValue('x')
+    const { sessionId } = await createV(ALICE, undefined) // the canvas node (PRIMARY)
+    await createV(ALICE, 'modal') // the kanban card modal, SAME connection
+
+    m.setFlow(ALICE, sessionId, false, 'socket') // ALICE's WS socket is backed up (per-connection)
+    expect(spawned[0].paused).toBe(true)
+
+    killV(ALICE, sessionId) // the canvas node unmounts (PRIMARY) — the modal stays open
+    expect(spawned[0].paused).toBe(true) // the connection is still jammed; the pty must STAY paused
+    expect(spawned[0].killed).toBe(false) // …and the modal keeps it alive
+
+    m.setFlow(ALICE, sessionId, true, 'socket') // the socket finally drains into the browser
+    expect(spawned[0].paused).toBe(false) // only now does the pty resume
+
+    killV(ALICE, sessionId, 'modal') // the last view closes → the pty is released
+    expect(spawned[0].killed).toBe(true)
+  })
+
+  // Belt-and-braces: if the socket is STILL jammed when the client's last view leaves, the departure
+  // sweep must return the socket ticket (which rides the PRIMARY view, not the departing modal's
+  // key), or a released pty would be left holding an un-returnable pause on a session that is gone.
+  it("the client's last view leaving sweeps a still-held socket pause (no leaked ticket)", async () => {
+    const m = await manager()
+    vi.spyOn(m, 'captureForResync').mockResolvedValue('x')
+    const { sessionId } = await createV(ALICE, undefined)
+    await createV(ALICE, 'modal')
+    await createV(BOB, undefined) // a second CONNECTION keeps the pty alive after ALICE fully leaves
+
+    m.setFlow(ALICE, sessionId, false, 'socket')
+    killV(ALICE, sessionId) // PRIMARY view goes; ALICE's socket pause stays (modal still open)
+    expect(spawned[0].paused).toBe(true)
+
+    killV(ALICE, sessionId, 'modal') // ALICE's LAST view leaves without ever resuming the socket
+    expect(spawned[0].paused).toBe(false) // the departure sweep returns the leftover socket ticket
+    expect(spawned[0].killed).toBe(false) // BOB still watches, so the pty is not released
+  })
 })

--- a/src/core/pty-coattach.test.ts
+++ b/src/core/pty-coattach.test.ts
@@ -1178,3 +1178,125 @@ describe('tmuxAttachFlags', () => {
     expect(tmuxAttachFlags(true)).toEqual(['-A'])
   })
 })
+
+// ── Viewer identity: one connection holds MANY independently-detachable views ──────────────────
+// The kanban card modal opens a SECOND terminal view of a node's tmux session INSIDE the same
+// desktop renderer. Both views present the SAME ClientId (one webContents), so the subscriber
+// ledger keys on the composite (ClientId, viewerId ?? PRIMARY): the modal is a real second
+// subscriber, its size votes independently, and closing it detaches ONLY it — the canvas node's
+// client (and everyone else's) is untouched. An absent viewerId is the PRIMARY view (the canvas
+// node), and every legacy call omits it, so it maps bit-for-bit to today's single-subscriber path.
+describe('viewer identity: multiple views per connection', () => {
+  let fake: FakePlatform
+
+  beforeEach(() => {
+    spawned.length = 0
+    failNextSpawn = false
+    fake = fakePlatform()
+    initPlatform(fake)
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    resetPlatformForTests()
+  })
+
+  async function manager() {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager()
+    m.registerIpc()
+    return m
+  }
+  // create carries an optional viewerId in its options; kill/resize carry it as a TRAILING arg.
+  const createV = (
+    clientId: number,
+    viewerId: string | undefined,
+    cols = 80,
+    rows = 24,
+    persistKey = 'node-1'
+  ) =>
+    fake.handlers[IPC.ptyCreate](clientId, { cols, rows, persistKey, viewerId }) as Promise<{
+      sessionId: string
+      fresh: boolean
+      screen?: string
+    }>
+  const killV = (clientId: number, sessionId: string, viewerId?: string) =>
+    fake.senderListeners[IPC.ptyKill](clientId, sessionId, viewerId)
+  const resizeV = (
+    clientId: number,
+    sessionId: string,
+    cols: number | null,
+    rows: number | null,
+    viewerId?: string
+  ) => fake.senderListeners[IPC.ptyResize](clientId, sessionId, cols, rows, viewerId)
+  const write = (clientId: number, sessionId: string, data: string) =>
+    fake.senderListeners[IPC.ptyWrite](clientId, sessionId, data)
+
+  it('a second VIEW in the same client joins the session (same id, painted, both subscribed)', async () => {
+    const m = await manager()
+    vi.spyOn(m, 'captureForResync').mockResolvedValue('current screen')
+    const a = await createV(ALICE, undefined) // the canvas node (PRIMARY)
+    const b = await createV(ALICE, 'modal') // the kanban card modal, SAME renderer
+
+    expect(spawned).toHaveLength(1) // ONE pty, ONE tmux client
+    expect(b.sessionId).toBe(a.sessionId) // the modal JOINED the live session
+    expect(b.fresh).toBe(false) // …so no cold-restore replay
+    expect(b.screen).toBe('current screen') // …and its empty xterm is painted from the screen
+
+    // Data fans out to the shared renderer ONCE — both views listen on the same per-client channel,
+    // so a second send would double every byte in both xterms.
+    spawned[0].onDataCb?.('hi')
+    vi.advanceTimersByTime(20)
+    const data = fake.sent.filter((s) => s.channel === IPC.ptyData(a.sessionId))
+    expect(data.map((s) => s.to)).toEqual([ALICE])
+
+    // Two independent subscribers now share the client: the pty is released only when BOTH leave.
+    killV(ALICE, a.sessionId, 'modal')
+    expect(spawned[0].killed).toBe(false)
+    killV(ALICE, a.sessionId) // the PRIMARY view (no viewerId)
+    expect(spawned[0].killed).toBe(true)
+  })
+
+  it('killing the modal view detaches ONLY it — the primary keeps the session and still steers it', async () => {
+    const m = await manager()
+    vi.spyOn(m, 'captureForResync').mockResolvedValue('x')
+    const { sessionId } = await createV(ALICE, undefined)
+    await createV(ALICE, 'modal')
+
+    killV(ALICE, sessionId, 'modal') // close the card modal
+    expect(spawned[0].killed).toBe(false) // pty untouched — the canvas node still watches
+
+    write(ALICE, sessionId, 'ls\n') // the client still has a view, so it may still write
+    expect(spawned[0].writes).toEqual(['ls\n'])
+  })
+
+  it('a modal view resizing smaller shrinks the shared pty; closing it restores the primary size', async () => {
+    const m = await manager()
+    vi.spyOn(m, 'captureForResync').mockResolvedValue('x')
+    const { sessionId } = await createV(ALICE, undefined, 120, 40) // primary 120x40
+    await createV(ALICE, 'modal', 120, 40) // modal joins at the same grid
+
+    resizeV(ALICE, sessionId, 80, 24, 'modal') // the card modal is a smaller pane
+    expect(spawned[0].resizes.at(-1)).toEqual({ cols: 80, rows: 24 }) // min shrinks the pty
+
+    killV(ALICE, sessionId, 'modal') // close the modal → its size vote is withdrawn
+    expect(spawned[0].resizes.at(-1)).toEqual({ cols: 120, rows: 40 }) // back to the primary's size
+    expect(spawned[0].killed).toBe(false) // …and the pty stays alive for the canvas node
+  })
+
+  it('killing the PRIMARY (no viewerId) leaves the modal view holding the session alive', async () => {
+    const m = await manager()
+    vi.spyOn(m, 'captureForResync').mockResolvedValue('x')
+    const { sessionId } = await createV(ALICE, undefined)
+    await createV(ALICE, 'modal')
+
+    killV(ALICE, sessionId) // the canvas node unmounts (PRIMARY) — but the modal is still open
+    expect(spawned[0].killed).toBe(false) // the modal keeps the session alive: NO releasePty
+
+    write(ALICE, sessionId, 'x') // the client is still a subscriber (via the modal), so it may steer
+    expect(spawned[0].writes).toEqual(['x'])
+
+    killV(ALICE, sessionId, 'modal') // the last view closes
+    expect(spawned[0].killed).toBe(true) // …only now is the pty released
+  })
+})

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -261,6 +261,39 @@ export async function findInLoginPath(bin: string): Promise<string | null> {
 /** A UI client: an Electron webContents id or a ServerPlatform uiId. */
 type ClientId = number
 
+/** A viewer id: which VIEW within one client. `PRIMARY_VIEWER` is the default view — the canvas
+ *  node, and every legacy call that omits a viewerId. A second view in the SAME renderer (the
+ *  kanban card modal) passes its own id, so one connection can hold several independently-
+ *  detachable views of the same session. */
+type ViewerId = string
+const PRIMARY_VIEWER: ViewerId = ''
+
+/**
+ * The composite subscriber key: one (client, view) pair. The subscriber ledger keys on this, so a
+ * ClientId can hold many subscribers — the canvas node (PRIMARY) and the modal — each subscribing,
+ * sizing, pausing and detaching on its own. A `null` client (the relay host's detached sink) is
+ * NOT a composite subscriber; it keys the `sizes`/flow ledgers by literal `null`, exactly as before.
+ *
+ * Encoding: `<clientId> <viewerId>`. clientId is always a number (no space), so
+ * `subClient` recovers the client from the FIRST space regardless of what the viewerId
+ * (which arrives off the wire) contains. Absent viewerId ⇒ PRIMARY ⇒ `<clientId> `, i.e. one
+ * entry per client — bit-for-bit the pre-viewer ledger for every existing caller.
+ */
+type SubKey = string
+function subKey(clientId: ClientId, viewerId: ViewerId): SubKey {
+  return `${clientId} ${viewerId}`
+}
+/** The ClientId behind a composite subscriber key — the collapse to "which person", for the
+ *  per-ClientId data/exit/size channels and the closed-by/recycled fan-out (viewers are invisible
+ *  to peers). */
+function subClient(sub: SubKey): ClientId {
+  return Number(sub.slice(0, sub.indexOf(' ')))
+}
+/** The viewer id within a composite subscriber key (PRIMARY for a default view). */
+function subViewer(sub: SubKey): ViewerId {
+  return sub.slice(sub.indexOf(' ') + 1)
+}
+
 /**
  * WHO, within one client, owes us a resume (see `Session.pausedBy`).
  *
@@ -281,10 +314,13 @@ export type FlowOwner = 'renderer' | 'socket'
 /** All the owners one client can owe a pause under — the sweep on any leave path. */
 const FLOW_OWNERS: readonly FlowOwner[] = ['renderer', 'socket']
 
-/** The ledger key for one (client, owner) pause. `null` is the relay host's detached sink, which
- *  has no ClientId; it pauses on relay backpressure, i.e. as a `renderer`-side owner. */
-function flowTicket(clientId: ClientId | null, owner: FlowOwner): string {
-  return `${owner}#${clientId ?? 'relay'}`
+/** The ledger key for one (view, owner) pause. The `sub` is a composite subscriber key, so a
+ *  client's two views (canvas node + modal) pause the shared pty on their OWN tickets — each xterm
+ *  is edge-latched independently, so collapsing them by ClientId would let one hand back the pause
+ *  the other still owes (the same bug the `owner` dimension prevents for the socket). `null` is the
+ *  relay host's detached sink, which has no ClientId; it pauses as a `renderer`-side owner. */
+function flowTicket(sub: SubKey | null, owner: FlowOwner): string {
+  return `${owner}#${sub ?? 'relay'}`
 }
 
 /** One client's reported fit, run through the same floor/clamp the pty itself gets, so a size we
@@ -295,21 +331,24 @@ function normalizeSize(cols: number, rows: number): PtySize {
 
 interface Session {
   proc: pty.IPty
-  /** Every UI watching this session. Co-attach: ONE pty and ONE tmux client, N subscribers —
-   *  a second client on the same persistKey joins this set instead of spawning a second tmux
-   *  client (whose `-D` would then kick the first one off). Empty for a purely detached
-   *  (relay-served) session. */
-  subscribers: Set<ClientId>
+  /** Every VIEW watching this session, keyed by the composite `(ClientId, viewerId)` (`SubKey`).
+   *  Co-attach: ONE pty and ONE tmux client, N subscribers — a second client on the same persistKey
+   *  (or the SAME client's second view, e.g. the kanban card modal) joins this set instead of
+   *  spawning a second tmux client (whose `-D` would then kick the first one off). Empty for a
+   *  purely detached (relay-served) session. */
+  subscribers: Set<SubKey>
   /** Each VIEWING subscriber's last reported cols/rows — the pty runs at the min of these
    *  (`effectiveSize`). A subscriber that is subscribed but NOT looking is ABSENT from this map:
-   *  it still gets output, it just doesn't constrain the size (see `resize`). `null` keys the
-   *  relay host's detached sink, which has no ClientId but does report a size. */
-  sizes: Map<ClientId | null, PtySize>
+   *  it still gets output, it just doesn't constrain the size (see `resize`). Keyed by the composite
+   *  `SubKey` so two views in one client vote independently; `null` keys the relay host's detached
+   *  sink, which has no ClientId but does report a size. */
+  sizes: Map<SubKey | null, PtySize>
   /** The size each subscriber's xterm is believed to be rendering: the last authoritative size we
    *  sent it, or — if it has reported a fit since — its own fit (the renderer applies its own fit
-   *  locally, exactly as it always has). We only send `pty:size` to a subscriber whose view differs
-   *  from the effective size, which is what keeps a SOLO user's resize free of any extra IPC. */
-  shown: Map<ClientId, PtySize>
+   *  locally, exactly as it always has). Keyed by the composite `SubKey`. We only send `pty:size` to
+   *  a subscriber whose view differs from the effective size, which is what keeps a SOLO user's
+   *  resize free of any extra IPC. */
+  shown: Map<SubKey, PtySize>
   /** The size currently pushed into the pty (seeded from the spawn's cols/rows). Guards against
    *  re-resizing the tmux client to the size it already has — that is a full-pane redraw. */
   appliedSize?: PtySize
@@ -593,9 +632,17 @@ export class PtyManager {
     // channel, so leaving the old plain listener in place would run the resize twice.
     platform().onWithSender(
       IPC.ptyResize,
-      (senderId: number, sessionId: string, cols: number | null, rows: number | null) => {
+      (
+        senderId: number,
+        sessionId: string,
+        cols: number | null,
+        rows: number | null,
+        // Optional TRAILING viewerId: a client's second view (the kanban card modal) sizes on its
+        // own vote. Absent (every legacy caller) ⇒ the PRIMARY view.
+        viewerId?: string
+      ) => {
         if (!this.subscribes(senderId, sessionId)) return
-        this.resize(senderId, sessionId, cols, rows)
+        this.resize(senderId, sessionId, cols, rows, viewerId)
       }
     )
     // Sender-aware: a pause belongs to the client whose xterm backlog overflowed, and only that
@@ -604,17 +651,25 @@ export class PtyManager {
     // run the flow change twice (and, with an unattributed sessionId, wrongly).
     platform().onWithSender(
       IPC.ptyFlow,
-      (senderId: number, sessionId: string, resume: boolean) => {
+      // Optional TRAILING viewerId: a client's second view (the modal) is an independently
+      // edge-latched xterm, so its pause is owed on its own ticket. The `owner` is always
+      // 'renderer' off the wire (the Server Edition's 'socket' owner uses the direct setFlow call).
+      (senderId: number, sessionId: string, resume: boolean, viewerId?: string) => {
         if (!this.subscribes(senderId, sessionId)) return
-        this.setFlow(senderId, sessionId, resume)
+        this.setFlow(senderId, sessionId, resume, 'renderer', viewerId)
       }
     )
     // Sender-aware: with co-attach a kill detaches just THAT client, and the pty (and the tmux
     // session behind it) survives while any other subscriber is still watching.
-    platform().onWithSender(IPC.ptyKill, (senderId: number, sessionId: string) => {
-      if (!this.subscribes(senderId, sessionId)) return
-      this.kill(senderId, sessionId)
-    })
+    platform().onWithSender(
+      IPC.ptyKill,
+      // Optional TRAILING viewerId: closing the kanban card modal detaches ONLY that view; the
+      // canvas node's client (PRIMARY, or any other view) keeps the session alive. Absent ⇒ PRIMARY.
+      (senderId: number, sessionId: string, viewerId?: string) => {
+        if (!this.subscribes(senderId, sessionId)) return
+        this.kill(senderId, sessionId, viewerId)
+      }
+    )
     // Sender-aware: the × permanently ends a session OTHER people may be watching, so the close
     // event they get has to name WHO did it ("closed by <name>" — see `destroySession`).
     // Registered ONLY here: `on` and `onWithSender` compose on the same channel, so a leftover
@@ -673,7 +728,22 @@ export class PtyManager {
    * subscribers by design, and that path is not off the wire.
    */
   private subscribes(clientId: ClientId, sessionId: string): boolean {
-    return this.sessions.get(sessionId)?.subscribers.has(clientId) ?? false
+    const subs = this.sessions.get(sessionId)?.subscribers
+    if (!subs) return false
+    // Client-scoped, not view-scoped: a client that opened this node in ANY view (canvas node or
+    // modal) may steer it. A kill/resize naming a viewer this client doesn't hold is then a
+    // harmless no-op delete, not a security hole — the gate's job is "is this the right person".
+    for (const sub of subs) if (subClient(sub) === clientId) return true
+    return false
+  }
+
+  /** The distinct ClientIds watching this session — the collapse of the composite ledger for the
+   *  per-ClientId data/exit channels: a client's two views share one `pty:data:<id>` channel, so a
+   *  chunk must be sent to each client ONCE (a second send would double every byte in both xterms). */
+  private clientsOf(session: Session): ClientId[] {
+    const clients = new Set<ClientId>()
+    for (const sub of session.subscribers) clients.add(subClient(sub))
+    return [...clients]
   }
 
   /**
@@ -822,13 +892,16 @@ export class PtyManager {
     const existingId = this.byPersistKey.get(persistKey)
     const existing = existingId ? this.sessions.get(existingId) : undefined
     if (!existingId || !existing) return undefined
-    existing.subscribers.add(clientId)
+    // The joining VIEW's composite key: a second client, OR the SAME client's second view (the
+    // kanban card modal). Either way it is a distinct subscriber of the one shared session/pty.
+    const sub = subKey(clientId, options.viewerId ?? PRIMARY_VIEWER)
+    existing.subscribers.add(sub)
     // The joiner's xterm has fitted itself to its own window; that is what it renders until we
     // tell it otherwise. applySize() then either shrinks the pty to it (it is the new smallest) or
     // sends it the authoritative size to render + letterbox.
     const size = normalizeSize(options.cols, options.rows)
-    existing.sizes.set(clientId, size)
-    existing.shown.set(clientId, size)
+    existing.sizes.set(sub, size)
+    existing.shown.set(sub, size)
     const before = existing.appliedSize
     this.applySize(existingId, existing)
     const resized =
@@ -839,8 +912,9 @@ export class PtyManager {
     // only THIS client's RENDERER pause: a pause owed by a DIFFERENT client that is still here and
     // still drowning stays in place, and so does this client's own SOCKET pause — a fresh page says
     // nothing about the state of the WS send buffer under it (invariant (b) on `pausedBy`), and the
-    // server returns that one itself when the socket drains.
-    this.releaseFlow(existing, clientId, 'renderer')
+    // server returns that one itself when the socket drains. Scoped to THIS view: the other view's
+    // (e.g. the still-open modal's) renderer pause is untouched.
+    this.releaseFlow(existing, sub, 'renderer')
     const base: PtyCreateResult = existing.accountFallback
       ? { sessionId: existingId, fresh: false, accountFallback: true }
       : { sessionId: existingId, fresh: false }
@@ -1223,17 +1297,20 @@ export class PtyManager {
     const tmuxBacked = !!(this.tmuxPath && settings.tmuxEnabled && options.persistKey)
     const persisted = !!options.persistKey && (remote ? true : tmuxBacked)
     const spawnSize = normalizeSize(options.cols, options.rows)
+    // The spawning view's composite key. Usually the canvas node (PRIMARY), but a modal that opens
+    // a node whose canvas terminal is closed spawns it too — under its own viewerId, correctly.
+    const spawnSub = clientId === null ? null : subKey(clientId, options.viewerId ?? PRIMARY_VIEWER)
     const session: Session = {
       proc,
-      subscribers: clientId === null ? new Set<ClientId>() : new Set<ClientId>([clientId]),
+      subscribers: spawnSub === null ? new Set<SubKey>() : new Set<SubKey>([spawnSub]),
       sizes:
-        clientId === null
-          ? new Map<ClientId | null, PtySize>()
-          : new Map<ClientId | null, PtySize>([[clientId, spawnSize]]),
+        spawnSub === null
+          ? new Map<SubKey | null, PtySize>()
+          : new Map<SubKey | null, PtySize>([[spawnSub, spawnSize]]),
       shown:
-        clientId === null
-          ? new Map<ClientId, PtySize>()
-          : new Map<ClientId, PtySize>([[clientId, spawnSize]]),
+        spawnSub === null
+          ? new Map<SubKey, PtySize>()
+          : new Map<SubKey, PtySize>([[spawnSub, spawnSize]]),
       // node-pty was just spawned with these cols/rows, so the pty ALREADY has this size — record
       // it so a co-attach (or a fit that reports the same numbers) doesn't ioctl it needlessly.
       // A detached (relay-served) pty is left unseeded: its first `resize` must reach the pty,
@@ -1275,7 +1352,8 @@ export class PtyManager {
     proc.onExit(({ exitCode }) => {
       this.flush(sessionId, session) // deliver any buffered output before the exit signal
       session.onExit?.(exitCode) // relay host sink (unchanged)
-      for (const sub of session.subscribers) this.send(sub, IPC.ptyExit(sessionId), exitCode)
+      for (const client of this.clientsOf(session))
+        this.send(client, IPC.ptyExit(sessionId), exitCode)
       this.forget(sessionId, session)
     })
 
@@ -1363,7 +1441,10 @@ export class PtyManager {
       const shown = session.shown.get(sub)
       if (shown && shown.cols === size.cols && shown.rows === size.rows) continue
       session.shown.set(sub, size)
-      this.send(sub, channel, size)
+      // Collapse to the ClientId: `pty:size:<id>` is a per-client channel. Two views in one client
+      // share it, so both xterms receive one send and each renders the authoritative size (and
+      // letterboxes) — exactly the co-attach contract. (A solo user, min(one), is never sent at all.)
+      this.send(subClient(sub), channel, size)
     }
   }
 
@@ -1391,7 +1472,8 @@ export class PtyManager {
     session.bufBytes = 0
     session.onData?.(data) // relay host sink (unchanged)
     const channel = IPC.ptyData(sessionId)
-    for (const sub of session.subscribers) this.send(sub, channel, data)
+    // One send per distinct client — a client's views share the per-client `pty:data:<id>` channel.
+    for (const client of this.clientsOf(session)) this.send(client, channel, data)
   }
 
   /**
@@ -1414,6 +1496,11 @@ export class PtyManager {
    * A socket drain then returns the SOCKET's ticket only, never the pause the browser's own xterm
    * still owes.
    *
+   * `viewerId` scopes the RENDERER pause to one VIEW: a client's canvas node and its kanban modal
+   * are two separate xterms, each edge-latched, so they pause on their own tickets — same reasoning
+   * as `owner`, one dimension over. Absent ⇒ PRIMARY. The `socket` owner is per-connection, so it
+   * rides the PRIMARY key by convention; the two owners never collide (different `owner`).
+   *
    * Single user: the set holds exactly his one renderer ticket while paused and is empty when he
    * resumes, so the actuator sees exactly the pause/resume pair it always saw.
    */
@@ -1421,16 +1508,18 @@ export class PtyManager {
     clientId: ClientId | null,
     sessionId: string,
     resume: boolean,
-    owner: FlowOwner = 'renderer'
+    owner: FlowOwner = 'renderer',
+    viewerId?: string
   ): void {
     const session = this.sessions.get(sessionId)
     if (!session) return
+    const sub = clientId === null ? null : subKey(clientId, viewerId ?? PRIMARY_VIEWER)
     if (resume) {
-      this.releaseFlow(session, clientId, owner)
+      this.releaseFlow(session, sub, owner)
       return
     }
     const wasPaused = session.pausedBy.size > 0
-    session.pausedBy.add(flowTicket(clientId, owner))
+    session.pausedBy.add(flowTicket(sub, owner))
     if (wasPaused) return // already paused by someone — pause() again would be a no-op
     try {
       session.proc.pause()
@@ -1440,24 +1529,24 @@ export class PtyManager {
   }
 
   /**
-   * Return a pause `clientId` owed us — because it resumed, or because it LEFT (kill /
+   * Return a pause a VIEW (`sub`) owed us — because it resumed, or because it LEFT (kill /
    * dropClient) or reloaded (join). The pty resumes only when the ledger empties: a pause still
-   * owed by a client that is here and behind must survive every other client's comings and goings,
-   * or that client's renderer queue grows without bound (its flow control is edge-latched and will
-   * never re-pause). No-op when this client owed nothing — the single-user resume path is then
+   * owed by a view that is here and behind must survive every other view's comings and goings,
+   * or that renderer's queue grows without bound (its flow control is edge-latched and will
+   * never re-pause). No-op when this view owed nothing — the single-user resume path is then
    * exactly the old `paused=false; proc.resume()`.
    *
-   * `owner` scopes WHICH of that client's tickets is returned:
+   * `owner` scopes WHICH of that view's tickets is returned:
    *  - a drain returns exactly the one that drained (invariant (b)): the socket emptying says
    *    nothing about the browser's xterm backlog, and vice versa;
-   *  - omitting it returns ALL of them, which is what a client's DEPARTURE means (invariant (a)):
+   *  - omitting it returns ALL of them, which is what a view's DEPARTURE means (invariant (a)):
    *    it receives nothing more on this session, so no owner of its can ever resume us again.
    */
-  private releaseFlow(session: Session, clientId: ClientId | null, owner?: FlowOwner): void {
+  private releaseFlow(session: Session, sub: SubKey | null, owner?: FlowOwner): void {
     const owners = owner ? [owner] : FLOW_OWNERS
     let released = false
     for (const o of owners) {
-      if (session.pausedBy.delete(flowTicket(clientId, o))) released = true
+      if (session.pausedBy.delete(flowTicket(sub, o))) released = true
     }
     if (!released) return
     if (session.pausedBy.size > 0) return
@@ -1468,9 +1557,30 @@ export class PtyManager {
     }
   }
 
-  /** Does this client owe a resume on this session under ANY owner? (dropClient's sweep gate.) */
-  private owesFlow(session: Session, clientId: ClientId | null): boolean {
-    return FLOW_OWNERS.some((o) => session.pausedBy.has(flowTicket(clientId, o)))
+  /**
+   * Return EVERY pause a whole CLIENT owed us, across all of its views and owners — the departure
+   * sweep for `dropClient`. A vanished webContents takes all its views (canvas node + modal) with
+   * it, so each of their tickets is unreturnable and must go, or the pty freezes for every co-viewer
+   * (invariant (a)). Scans `pausedBy` because a client's tickets are spread over an unknown set of
+   * viewer ids. Returns whether anything was released (the caller re-negotiates size iff so).
+   */
+  private releaseFlowForClient(session: Session, clientId: ClientId): boolean {
+    let released = false
+    for (const ticket of [...session.pausedBy]) {
+      // A ticket is `${owner}#${sub}`; the sub follows the first '#'. 'relay' (the null sink) never
+      // belongs to a client, so it is skipped.
+      const sub = ticket.slice(ticket.indexOf('#') + 1)
+      if (sub === 'relay') continue
+      if (subClient(sub) === clientId && session.pausedBy.delete(ticket)) released = true
+    }
+    if (released && session.pausedBy.size === 0) {
+      try {
+        session.proc.resume()
+      } catch {
+        // resume can throw if the proc already exited; ignore.
+      }
+    }
+    return released
   }
 
   /**
@@ -1530,24 +1640,28 @@ export class PtyManager {
     clientId: ClientId | null,
     sessionId: string,
     cols: number | null,
-    rows: number | null
+    rows: number | null,
+    viewerId?: string
   ): void {
     const session = this.sessions.get(sessionId)
     if (!session) return
+    // The reporting VIEW's key (null = the relay sink, keyed by literal null as before). A client's
+    // canvas node and modal vote separately, so the pty runs at the min over both.
+    const sub = clientId === null ? null : subKey(clientId, viewerId ?? PRIMARY_VIEWER)
     // Loose `== null` on purpose (belt and braces): the sizes arrive over IPC on the desktop and
     // over a JSON wire in the Server Edition, and JSON has no `undefined`. If any encoding path
-    // ever loses the distinction again, "no size" must degrade to PARK — dropping the client from
+    // ever loses the distinction again, "no size" must degrade to PARK — dropping the view from
     // the ledger — and never to `normalizeSize(undefined, undefined)`, which clamps to a 1×1 grid
     // and would shrink the shared pty to one cell for every co-attached viewer.
     if (cols == null || rows == null) {
-      session.sizes.delete(clientId)
+      session.sizes.delete(sub)
     } else {
       const size = normalizeSize(cols, rows)
-      session.sizes.set(clientId, size)
-      // The client's own xterm fits itself locally (as it always has), so its fit — not the last
+      session.sizes.set(sub, size)
+      // The view's own xterm fits itself locally (as it always has), so its fit — not the last
       // authoritative size we sent it — is what it is rendering right now. If that fit isn't the
       // effective size, applySize() below corrects it straight back.
-      if (clientId !== null) session.shown.set(clientId, size)
+      if (sub !== null) session.shown.set(sub, size)
     }
     this.applySize(sessionId, session)
   }
@@ -1561,25 +1675,28 @@ export class PtyManager {
    * `clientId` is null for the relay host releasing its own detached (sink-served) pty: it drops
    * the sinks, which are that session's only "subscriber".
    */
-  kill(clientId: ClientId | null, sessionId: string): void {
+  kill(clientId: ClientId | null, sessionId: string, viewerId?: string): void {
     const session = this.sessions.get(sessionId)
     if (!session) return
+    // The departing VIEW's key (null = the relay sink). Closing the kanban modal names its viewerId
+    // and detaches ONLY it; the canvas node's PRIMARY view stays subscribed and the pty lives on.
+    const sub = clientId === null ? null : subKey(clientId, viewerId ?? PRIMARY_VIEWER)
     if (clientId === null) {
       session.onData = undefined
       session.onExit = undefined
       session.sizes.delete(null)
     } else {
-      session.subscribers.delete(clientId)
-      session.sizes.delete(clientId)
-      session.shown.delete(clientId)
+      session.subscribers.delete(sub as SubKey)
+      session.sizes.delete(sub)
+      session.shown.delete(sub as SubKey)
     }
-    // The departing client (or sink) may have been one of the ones that paused us, and it will
+    // The departing view (or sink) may have been one of the ones that paused us, and it will
     // never send the matching resume now — leaving that pause in place would freeze the terminal
     // for everyone who stayed. EVERY owner it owed goes back (no `owner` argument): it stops
     // receiving this session's output entirely, so neither its renderer nor its socket can ever
-    // resume us again. A pause owed by a client that is STILL here is untouched: the pty stays
+    // resume us again. A pause owed by a view that is STILL here is untouched: the pty stays
     // paused until IT drains (its renderer cannot re-pause — see `Session.pausedBy`).
-    this.releaseFlow(session, clientId)
+    this.releaseFlow(session, sub)
     if (session.subscribers.size > 0 || session.onData) {
       // Somebody is still watching: the departing client's size no longer constrains the pty.
       this.applySize(sessionId, session)
@@ -1611,8 +1728,13 @@ export class PtyManager {
   dropClient(clientId: ClientId): void {
     // Snapshot the entries: kill() mutates `sessions` when a session falls to zero subscribers.
     for (const [sessionId, session] of [...this.sessions]) {
-      if (session.subscribers.has(clientId)) {
-        this.kill(clientId, sessionId)
+      // A vanished webContents takes ALL its views with it (canvas node + any modal), so kill each
+      // of this client's composite subscriptions. The last one released takes the pty down — exactly
+      // as the per-view `pty:kill`s would have, had the tab closed cleanly. (The outer snapshot holds
+      // the session ref even after the final kill `forget`s it.)
+      const views = [...session.subscribers].filter((s) => subClient(s) === clientId)
+      if (views.length > 0) {
+        for (const sub of views) this.kill(clientId, sessionId, subViewer(sub))
         continue
       }
       // NOT a subscriber — and yet it may still hold state here. Sweeping only the sessions a client
@@ -1621,14 +1743,16 @@ export class PtyManager {
       // for every real viewer, for the life of the core process. The wire casts are now gated on
       // membership (`subscribes`), so this should find nothing; sweep unconditionally anyway — the
       // invariant "nothing outlives its client" must not depend on every future caller remembering
-      // the gate.
-      const hadSize = session.sizes.delete(clientId)
-      const hadShown = session.shown.delete(clientId)
-      if (!hadSize && !hadShown && !this.owesFlow(session, clientId)) continue
+      // the gate. Sweep by CLIENT (every view/owner it might have planted), not by a single key.
+      let changed = false
+      for (const key of [...session.sizes.keys()])
+        if (key !== null && subClient(key) === clientId && session.sizes.delete(key)) changed = true
+      for (const key of [...session.shown.keys()])
+        if (subClient(key) === clientId) session.shown.delete(key)
       // Every owner's ticket, not just the renderer's: a vanished client's SOCKET pause is as
       // unreturnable as its renderer's (invariant (a) — the pty would freeze for every co-viewer).
-      this.releaseFlow(session, clientId)
-      this.applySize(sessionId, session)
+      if (this.releaseFlowForClient(session, clientId)) changed = true
+      if (changed) this.applySize(sessionId, session)
     }
   }
 
@@ -1877,10 +2001,16 @@ export class PtyManager {
     if (dyingId && dying) {
       this.byPersistKey.delete(persistKey)
       dying.indexKey = undefined
-      const others = [...dying.subscribers].filter((sub) => sub !== clientId)
+      // Collapse the composite subscribers to DISTINCT clients, minus the destroyer: closed/recycled
+      // are per-ClientId events (a client's two views share one channel and hear it once), and
+      // viewer granularity is invisible to peers. The destroyer is excluded whether it watched via
+      // the canvas node, the modal, or both.
+      const others = [...new Set([...dying.subscribers].map(subClient))].filter(
+        (c) => c !== clientId
+      )
       if (intent === 'delete') {
         const channel = IPC.ptyClosed(dyingId)
-        for (const sub of others) this.send(sub, channel, { by: clientId })
+        for (const client of others) this.send(client, channel, { by: clientId })
       } else if (others.length > 0) {
         this.armRecycle(persistKey, dyingId, others)
       }

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -1692,11 +1692,23 @@ export class PtyManager {
     }
     // The departing view (or sink) may have been one of the ones that paused us, and it will
     // never send the matching resume now — leaving that pause in place would freeze the terminal
-    // for everyone who stayed. EVERY owner it owed goes back (no `owner` argument): it stops
-    // receiving this session's output entirely, so neither its renderer nor its socket can ever
-    // resume us again. A pause owed by a view that is STILL here is untouched: the pty stays
-    // paused until IT drains (its renderer cannot re-pause — see `Session.pausedBy`).
-    this.releaseFlow(session, sub)
+    // for everyone who stayed. But WHICH tickets are unreturnable depends on whether the CLIENT is
+    // wholly gone or just this one VIEW:
+    //  - the relay sink (clientId null) departs entirely → return every owner it owed.
+    //  - the client still has ANOTHER view (e.g. the canvas node closed but the kanban modal is
+    //    still open on the SAME connection): only THIS view's RENDERER pause is unreturnable — its
+    //    own xterm is gone. The SOCKET pause is per-CONNECTION (it rides the PRIMARY view and is
+    //    shared by every view of this client), so it must survive; handing it back here would
+    //    permanently un-pause a still-jammed connection whose renderer flow control is edge-latched.
+    //  - this was the client's LAST view → the whole connection is gone. Sweep every ticket it owes
+    //    across all its views and owners (its socket ticket rides the PRIMARY view, so it is not
+    //    necessarily keyed on `sub`) — the same departure sweep `dropClient` uses.
+    // A pause owed by a DIFFERENT client that is still here is untouched either way (the pty stays
+    // paused until IT drains — its renderer cannot re-pause; see `Session.pausedBy`).
+    if (clientId === null) this.releaseFlow(session, sub)
+    else if ([...session.subscribers].some((s) => subClient(s) === clientId))
+      this.releaseFlow(session, sub, 'renderer')
+    else this.releaseFlowForClient(session, clientId)
     if (session.subscribers.size > 0 || session.onData) {
       // Somebody is still watching: the departing client's size no longer constrains the pty.
       this.applySize(sessionId, session)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -54,9 +54,11 @@ const api: NodeTerminalApi = {
   pty: {
     create: (options: PtyCreateOptions) => ipcRenderer.invoke(IPC.ptyCreate, options),
     write: (sessionId, data) => ipcRenderer.send(IPC.ptyWrite, sessionId, data),
-    resize: (sessionId, cols, rows) => ipcRenderer.send(IPC.ptyResize, sessionId, cols, rows),
-    setFlow: (sessionId, resume) => ipcRenderer.send(IPC.ptyFlow, sessionId, resume),
-    kill: (sessionId) => ipcRenderer.send(IPC.ptyKill, sessionId),
+    resize: (sessionId, cols, rows, viewerId) =>
+      ipcRenderer.send(IPC.ptyResize, sessionId, cols, rows, viewerId),
+    setFlow: (sessionId, resume, viewerId) =>
+      ipcRenderer.send(IPC.ptyFlow, sessionId, resume, viewerId),
+    kill: (sessionId, viewerId) => ipcRenderer.send(IPC.ptyKill, sessionId, viewerId),
     destroy: (persistKey) => ipcRenderer.send(IPC.ptyDestroy, persistKey),
     recycle: (persistKey) => ipcRenderer.send(IPC.ptyRecycle, persistKey),
     generateName: (persistKey, cwd) => ipcRenderer.invoke(IPC.ptyGenerateName, persistKey, cwd),

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -197,9 +197,10 @@ export function buildRealApi(
     create: (options: PtyCreateOptions) =>
       client.request(IPC.ptyCreate, options) as ReturnType<PtyApi['create']>,
     write: (sessionId, data) => client.cast(IPC.ptyWrite, sessionId, data),
-    resize: (sessionId, cols, rows) => client.cast(IPC.ptyResize, sessionId, cols, rows),
-    setFlow: (sessionId, resume) => client.cast(IPC.ptyFlow, sessionId, resume),
-    kill: (sessionId) => client.cast(IPC.ptyKill, sessionId),
+    resize: (sessionId, cols, rows, viewerId) =>
+      client.cast(IPC.ptyResize, sessionId, cols, rows, viewerId),
+    setFlow: (sessionId, resume, viewerId) => client.cast(IPC.ptyFlow, sessionId, resume, viewerId),
+    kill: (sessionId, viewerId) => client.cast(IPC.ptyKill, sessionId, viewerId),
     destroy: (persistKey) => client.cast(IPC.ptyDestroy, persistKey),
     recycle: (persistKey) => client.cast(IPC.ptyRecycle, persistKey),
     // No server handler — degrade gracefully (never reject the boot path).

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -178,7 +178,7 @@ import { useSshConn } from '../state/sshConn'
 import { useSystemAccount } from '../state/systemAccount'
 import { requireProOr } from '../state/upgradeGate'
 import { useEntitlement } from '../state/entitlement'
-import type { SshServer } from '@shared/ssh'
+import type { SshServer, SshConnection } from '@shared/ssh'
 import { sshHostKey } from '@shared/ssh'
 import type { CanvasNodeState, Project, ProjectKanban, SshProjectStatus, TranscriptHit } from '@shared/types'
 import { KanbanView, type KanbanCreateChoice } from '../components/kanban/KanbanView'
@@ -4061,7 +4061,9 @@ export function Canvas() {
               title: text.split('\n')[0].slice(0, 80) || 'Note',
               color: (n.data.color as string) ?? NODE_COLORS[2],
               kind: 'sticky' as const,
-              text
+              text,
+              // Sticky/chat cards never open a live terminal — the modal reads no spawn info.
+              spawn: {}
             }
           }
           return {
@@ -4069,7 +4071,17 @@ export function Canvas() {
             title: (n.data.title as string) ?? '',
             color: (n.data.color as string) ?? NODE_COLORS[0],
             kind: n.type as 'terminal' | 'chat',
-            agentId: n.data.agentId as string | undefined
+            agentId: n.data.agentId as string | undefined,
+            // What the card modal's co-attach terminal needs to join THIS node's session the same
+            // way the canvas TerminalNode does (used for kind 'terminal'; a chat card ignores it).
+            spawn: {
+              shell: n.data.shell as string | undefined,
+              cwd: n.data.cwd as string | undefined,
+              agentId: n.data.agentId as string | undefined,
+              accountId: n.data.accountId as string | undefined,
+              ssh: n.data.ssh as SshConnection | undefined,
+              sshRemoteTmux: !!n.data.sshRemoteTmux
+            }
           }
         }),
     [nodes]

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4880,6 +4880,16 @@ export function Canvas() {
     [activeProjectId, setNodes, markDirty, writeDisk]
   )
 
+  // Write-through a sticky node's body text from the kanban card modal (the canvas sticky
+  // reads the same data.text path).
+  const editStickyText = useCallback(
+    (nodeId: string, text: string) => {
+      setNodes((ns) => ns.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, text } } : n)))
+      markDirty()
+    },
+    [setNodes, markDirty]
+  )
+
   // Sidebar "Name with AI": generate a title from the session's captured terminal output
   // (same BYO-agent path as the terminal node's ✦), then apply it via renameSession.
   const aiNameSession = useCallback(
@@ -5834,6 +5844,8 @@ export function Canvas() {
           onChange={onKanbanChange}
           onOpenNode={openNodeFromKanban}
           onCreateNode={createNodeInColumn}
+          onRenameNode={(nodeId, title) => renameSession(activeProjectId, nodeId, title)}
+          onEditSticky={editStickyText}
         />
       )}
       <UpdateCard />

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
 import type { KanbanSession } from './KanbanView'
+import { ModalTerminal } from './ModalTerminal'
 
 interface CardModalProps {
   session: KanbanSession
@@ -107,10 +108,13 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
             />
           ) : (
             <div className="kanban-modal__pane" data-kind={session.kind}>
-              {/* Task 2 replaces this with the live co-attach terminal for kind 'terminal'. */}
-              <div className="kanban-modal__placeholder">
-                {session.kind === 'chat' ? 'Chat sessions open on the canvas.' : 'Terminal'}
-              </div>
+              {session.kind === 'terminal' ? (
+                // A live SECOND client on the node's session — keyed by node id so switching cards
+                // remounts a fresh viewer. Chat has no PTY; it opens on the canvas.
+                <ModalTerminal key={session.id} nodeId={session.id} spawn={session.spawn} />
+              ) : (
+                <div className="kanban-modal__placeholder">Chat sessions open on the canvas.</div>
+              )}
             </div>
           )}
         </div>

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
+import type { KanbanSession } from './KanbanView'
+
+interface CardModalProps {
+  session: KanbanSession
+  /** Column title shown as a chip; null = Ungrouped. */
+  columnTitle: string | null
+  onClose: () => void
+  /** Secondary action: close the modal, switch to canvas, focus the node. */
+  onOpenCanvas: () => void
+  /** Rename funnel (same as the sidebar's). */
+  onRename: (title: string) => void
+  /** Sticky text write-through (only called for kind 'sticky'). */
+  onEditSticky: (text: string) => void
+}
+
+/** Trello-style card popup over the board. Scrim click / Esc close it; the board (and the
+ *  canvas under it) stay mounted. Terminal pane arrives in Task 2 — until then terminal
+ *  cards show the sticky/chat-style body with the open-on-canvas action. */
+export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRename, onEditSticky }: CardModalProps) {
+  const idRef = useRef<string>()
+  if (!idRef.current) idRef.current = nextDialogId()
+  const id = idRef.current
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [title, setTitle] = useState(session.title)
+
+  useEffect(() => {
+    pushDialog(id)
+    return () => popDialog(id)
+  }, [id])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || !isTopDialog(id)) return
+      e.preventDefault()
+      e.stopPropagation()
+      onClose()
+    }
+    // Capture phase: beat the canvas/global keydown listeners to the Escape.
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [id, onClose])
+
+  const commitTitle = () => {
+    const t = title.trim()
+    if (t && t !== session.title) onRename(t)
+    setEditingTitle(false)
+  }
+
+  return createPortal(
+    <div className="kanban-modal-scrim" onMouseDown={onClose}>
+      {/* stopPropagation: clicks inside the sheet must not reach the scrim-close */}
+      <div className="kanban-modal" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="kanban-modal__header">
+          <span className="kanban-card__nodedot" style={{ background: session.color }} />
+          {editingTitle ? (
+            <input
+              className="kanban-modal__rename"
+              autoFocus
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onBlur={commitTitle}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commitTitle()
+                if (e.key === 'Escape') {
+                  e.stopPropagation()
+                  setEditingTitle(false)
+                }
+              }}
+            />
+          ) : (
+            <span
+              className="kanban-modal__title"
+              onClick={() => {
+                if (session.kind === 'sticky') return // a note's label IS its first line
+                setTitle(session.title)
+                setEditingTitle(true)
+              }}
+            >
+              {session.title}
+            </span>
+          )}
+          <span className="kanban-modal__column">{columnTitle ?? 'Ungrouped'}</span>
+          <button className="kanban-modal__action" title="Open on canvas" onClick={onOpenCanvas}>
+            ↗
+          </button>
+          <button className="kanban-modal__action" title="Close" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="kanban-modal__body">
+          {session.kind === 'sticky' ? (
+            <textarea
+              className="kanban-modal__sticky"
+              value={session.text ?? ''}
+              placeholder="Write a note…"
+              onChange={(e) => onEditSticky(e.target.value)}
+            />
+          ) : (
+            <div className="kanban-modal__pane" data-kind={session.kind}>
+              {/* Task 2 replaces this with the live co-attach terminal for kind 'terminal'. */}
+              <div className="kanban-modal__placeholder">
+                {session.kind === 'chat' ? 'Chat sessions open on the canvas.' : 'Terminal'}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -25,6 +25,11 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
   const id = idRef.current
   const [editingTitle, setEditingTitle] = useState(false)
   const [title, setTitle] = useState(session.title)
+  // Ref mirror: the capture-phase listener below closes over stale state otherwise.
+  const editingTitleRef = useRef(false)
+  useEffect(() => {
+    editingTitleRef.current = editingTitle
+  }, [editingTitle])
 
   useEffect(() => {
     pushDialog(id)
@@ -36,6 +41,11 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
       if (e.key !== 'Escape' || !isTopDialog(id)) return
       e.preventDefault()
       e.stopPropagation()
+      if (editingTitleRef.current) {
+        // Esc during a rename cancels the EDIT, not the modal.
+        setEditingTitle(false)
+        return
+      }
       onClose()
     }
     // Capture phase: beat the canvas/global keydown listeners to the Escape.
@@ -63,11 +73,8 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
               onChange={(e) => setTitle(e.target.value)}
               onBlur={commitTitle}
               onKeyDown={(e) => {
+                // Esc is owned by the capture-phase handler (cancels the edit).
                 if (e.key === 'Enter') commitTitle()
-                if (e.key === 'Escape') {
-                  e.stopPropagation()
-                  setEditingTitle(false)
-                }
               }}
             />
           ) : (

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -16,7 +16,8 @@ interface KanbanColumnProps {
   onRename?: (title: string) => void
   onRecolor?: (color: string) => void
   onDelete?: () => void
-  onOpenNode: (nodeId: string) => void
+  /** Open a card's modal (↗ / double-click on the card). */
+  onOpenCard: (nodeId: string) => void
   /** "+ New" menu entries (agents, terminal, sticky) and what to do when one is picked. */
   createOptions: KanbanCreateOption[]
   onCreate: (choice: KanbanCreateChoice) => void
@@ -30,7 +31,7 @@ interface KanbanColumnProps {
 }
 
 export function KanbanColumn({
-  column, cards, statusById, expandedIds, onToggleCard, onRename, onRecolor, onDelete, onOpenNode,
+  column, cards, statusById, expandedIds, onToggleCard, onRename, onRecolor, onDelete, onOpenCard,
   createOptions, onCreate, onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn,
   onDropBeforeCard
 }: KanbanColumnProps) {
@@ -128,7 +129,7 @@ export function KanbanColumn({
             status={statusById[s.id]}
             expanded={expandedIds.has(s.id)}
             onToggle={() => onToggleCard(s.id)}
-            onOpen={() => onOpenNode(s.id)}
+            onOpenModal={() => onOpenCard(s.id)}
             onDragStart={() => onCardDragStart(s.id)}
             onDragEnd={onDragEnd}
             onDropBefore={() => onDropBeforeCard(s.id)}

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../lib/kanban'
 import { CardModal } from './CardModal'
 import { KanbanColumn } from './KanbanColumn'
+import type { ModalSpawn } from './ModalTerminal'
 
 /** One session node shown as a board card — derived LIVE from the canvas nodes; the board
  *  itself stores only column assignments. */
@@ -21,6 +22,9 @@ export interface KanbanSession {
   agentId?: string
   /** Sticky note body — shown in the expanded detail row. */
   text?: string
+  /** The subset of the node's `data` the card modal's co-attach terminal needs to spawn/join the
+   *  same session (kind 'terminal' only; sticky/chat pass `{}`). */
+  spawn: ModalSpawn
 }
 
 /** What the per-column "+ New" menu can create. */

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -5,9 +5,10 @@ import { useAgentStatus } from '../../state/agentStatus'
 import { useProjects } from '../../state/projects'
 import { useSettings } from '../../state/settings'
 import {
-  addColumn, assignNode, assignedTo, deleteColumn, moveColumn, nextColumnColor,
+  addColumn, assignNode, assignedTo, columnForNode, deleteColumn, moveColumn, nextColumnColor,
   pruneAssignments, recolorColumn, renameColumn, unassigned
 } from '../../lib/kanban'
+import { CardModal } from './CardModal'
 import { KanbanColumn } from './KanbanColumn'
 
 /** One session node shown as a board card — derived LIVE from the canvas nodes; the board
@@ -43,6 +44,10 @@ interface KanbanViewProps {
   onOpenNode: (nodeId: string) => void
   /** Create a node from a column's "+ New" menu (columnId null = Ungrouped: no assignment). */
   onCreateNode: (choice: KanbanCreateChoice, columnId: string | null) => void
+  /** Rename a node (same funnel as the sessions sidebar). */
+  onRenameNode: (nodeId: string, title: string) => void
+  /** Write-through a sticky node's body text (only fired for kind 'sticky'). */
+  onEditSticky: (nodeId: string, text: string) => void
 }
 
 type Drag = { kind: 'card' | 'column'; id: string } | null
@@ -50,8 +55,12 @@ type Drag = { kind: 'card' | 'column'; id: string } | null
 /** Full-page session board OVER the canvas. The canvas stays mounted underneath (its
  *  agent-status listeners must keep running, and display:none would 0×0-resize every
  *  terminal into a tmux SIGWINCH) — this is an opaque overlay, nothing more. */
-export function KanbanView({ board, sessions, onChange, onOpenNode, onCreateNode }: KanbanViewProps) {
+export function KanbanView({
+  board, sessions, onChange, onOpenNode, onCreateNode, onRenameNode, onEditSticky
+}: KanbanViewProps) {
   const dragRef = useRef<Drag>(null)
+  // One card modal at a time; a deleted node closes it via the byId.has render guard.
+  const [modalNodeId, setModalNodeId] = useState<string | null>(null)
   const statusById = useAgentStatus((s) => s.byId)
   // Primitive selectors (not one object) — an object selector would re-render on every store set.
   const projectName = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.name)
@@ -130,7 +139,7 @@ export function KanbanView({ board, sessions, onChange, onOpenNode, onCreateNode
           statusById={statusById}
           expandedIds={expandedIds}
           onToggleCard={toggleExpanded}
-          onOpenNode={onOpenNode}
+          onOpenCard={setModalNodeId}
           createOptions={createOptions}
           onCreate={(choice) => onCreateNode(choice, null)}
           onCardDragStart={(id) => (dragRef.current = { kind: 'card', id })}
@@ -149,7 +158,7 @@ export function KanbanView({ board, sessions, onChange, onOpenNode, onCreateNode
             onRename={(t) => commit(renameColumn(board, col.id, t))}
             onRecolor={(c) => commit(recolorColumn(board, col.id, c))}
             onDelete={() => commit(deleteColumn(board, col.id))}
-            onOpenNode={onOpenNode}
+            onOpenCard={setModalNodeId}
             createOptions={createOptions}
             onCreate={(choice) => onCreateNode(choice, col.id)}
             onCardDragStart={(id) => (dragRef.current = { kind: 'card', id })}
@@ -166,6 +175,19 @@ export function KanbanView({ board, sessions, onChange, onOpenNode, onCreateNode
           + Add column
         </button>
       </div>
+      {modalNodeId && byId.has(modalNodeId) && (
+        <CardModal
+          session={byId.get(modalNodeId)!}
+          columnTitle={columnForNode(board, modalNodeId)?.title ?? null}
+          onClose={() => setModalNodeId(null)}
+          onOpenCanvas={() => {
+            setModalNodeId(null)
+            onOpenNode(modalNodeId)
+          }}
+          onRename={(t) => onRenameNode(modalNodeId, t)}
+          onEditSticky={(t) => onEditSticky(modalNodeId, t)}
+        />
+      )}
     </div>
   )
 }

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -8,7 +8,9 @@ import { parseOsc52 } from '../../terminal/osc52'
 import {
   attachReplay,
   seedPaint,
+  stripTrailingNewline,
   terminalKeyAction,
+  toXtermText,
   xtermScrollback,
   SHIFT_ENTER_SEQ
 } from '../../terminal/terminal-config'
@@ -137,11 +139,20 @@ export function ModalTerminal({ nodeId, spawn }: { nodeId: string; spawn: ModalS
           transport.onSize(res.sessionId, (size) => term.resize(size.cols, size.rows))
         )
       term.onData((d) => sessionId && transport.write(sessionId, d))
+      // DELIBERATELY omitted vs. TerminalNode: no flow-control pause (transport.setFlow) and no
+      // onResync handler. The pty's pacing/backpressure comes from the canvas node's client — the
+      // modal is a transient, always-on-top second view and never drives the shared session's flow.
 
       // A fresh (cold-restart / first-open) session's tmux pane is gone, so replay the persisted
       // scrollback. A warm join is painted from the server-captured screen inside create(). Agent
-      // auto-resume is deliberately canvas-only — the modal never re-launches a CLI.
+      // auto-resume is deliberately canvas-only — the modal never re-launches a CLI. Both the
+      // snapshot and `res.screen` come from `capture-pane -p` (LF-separated, no CR bytes) and this
+      // xterm runs with convertEol:false, so they MUST go through toXtermText or they staircase.
       const snapshot = res.fresh ? await api.pty.readScrollback(nodeId) : null
+      // The read above is a suspension point: bail if the modal closed while it was in flight, so we
+      // never write into a disposed xterm or observe a null host ref (mirrors TerminalNode's
+      // post-await onDisposed check).
+      if (dead) return
       const paint = seedPaint({
         replay: attachReplay({ parked: false, fresh: res.fresh, hasInitialCommand: false }),
         superseded: false,
@@ -149,10 +160,11 @@ export function ModalTerminal({ nodeId, spawn }: { nodeId: string; spawn: ModalS
         screen: res.screen
       })
       if (paint === 'snapshot') {
-        if (snapshot) term.write(snapshot)
+        if (snapshot) term.write(toXtermText(snapshot))
         term.write('\r\n\x1b[90m— cold start · agent auto-resume happens on canvas —\x1b[0m\r\n')
       } else if (paint === 'create-screen' && res.screen) {
-        term.write(res.screen)
+        // Start from a known-clean SGR state, then convert the capture's LFs to CRLFs.
+        term.write('\x1b[0m' + toXtermText(stripTrailingNewline(res.screen)))
       }
 
       const ro = new ResizeObserver(() => {

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useRef } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { useSession } from '../../session/session'
+import { useSettings } from '../../state/settings'
+import { LocalTransport } from '../../terminal/local-transport'
+import { parseOsc52 } from '../../terminal/osc52'
+import {
+  attachReplay,
+  seedPaint,
+  terminalKeyAction,
+  xtermScrollback,
+  SHIFT_ENTER_SEQ
+} from '../../terminal/terminal-config'
+import { resolveSshRemote } from '../../nodes/TerminalNode'
+import { buildSshArgs, type SshConnection } from '@shared/ssh'
+
+/** The subset of a node's `data` a SECOND client needs to attach to its session the same way the
+ *  canvas TerminalNode does. Canvas fills it from the node's data; sticky/chat cards pass `{}`. */
+export interface ModalSpawn {
+  shell?: string
+  cwd?: string
+  agentId?: string
+  accountId?: string
+  /** The node's `data.ssh` — a local `ssh <host>` node runs ssh as its pty program. */
+  ssh?: SshConnection
+  /** SSH-project node: tmux runs on the REMOTE host (over the project's ControlMaster). */
+  sshRemoteTmux?: boolean
+}
+
+/**
+ * A SECOND live client on the node's tmux session, living only while the card modal is open.
+ *
+ * It rides the viewer-identity seam (Task 2a): a per-mount `viewerId` makes this a distinct
+ * subscriber of the SAME session as the canvas node — its create/resize/kill co-attach and detach
+ * independently, so opening or closing the modal never disturbs the canvas node's client (live or
+ * parked). Deliberately minimal vs. TerminalNode: NO park, NO WebGL budget, NO hover-guard — a modal
+ * is short-lived and always on top. Closing kills ONLY this viewer (the last-view release stays with
+ * the canvas node). The MIRROR-tagged blocks below are copied byte-for-byte from TerminalNode.
+ */
+export function ModalTerminal({ nodeId, spawn }: { nodeId: string; spawn: ModalSpawn }) {
+  const { api } = useSession()
+  const hostRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    // A unique viewerId per mount: the core namespaces it per connection, so uniqueness only has to
+    // hold within THIS window. It makes the modal a second subscriber of the node's shared session.
+    const viewerId = `modal-${nodeId}-${Math.random().toString(36).slice(2, 8)}`
+    const transport = new LocalTransport(api, viewerId)
+    const s = useSettings.getState().settings
+    const term = new Terminal({
+      fontFamily: s.fontFamily,
+      fontSize: s.fontSize,
+      cursorBlink: s.cursorBlink,
+      theme: { background: '#161618', foreground: '#e6e6e6' },
+      allowProposedApi: true,
+      scrollback: xtermScrollback(s.tmuxScrollback),
+      macOptionClickForcesSelection: true
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(hostRef.current!)
+    fit.fit()
+
+    let sessionId: string | null = null
+    let dead = false
+    const cleanups: Array<() => void> = []
+
+    // MIRROR TerminalNode "WRITE-ONLY — `parseOsc52` returns null" — the OSC 52 clipboard-write path.
+    // tmux's mouse is ON, so a drag-select in copy-mode emits OSC 52 to this client; this handler
+    // writes the system clipboard. `parseOsc52` returns null for a `?` read query so a remote program
+    // can never read the local clipboard. Returning true swallows the sequence (also the read query).
+    term.parser.registerOscHandler(52, (data) => {
+      const text = parseOsc52(data)
+      if (text !== null) window.nodeTerminal.clipboard.writeText(text)
+      return true
+    })
+
+    // MIRROR TerminalNode "const action = terminalKeyAction" — Cmd+C / Ctrl+Shift+C / Ctrl+Insert copy
+    // the xterm selection (a canvas can't be DOM-copied), and Shift+Enter → ESC+CR (`SHIFT_ENTER_SEQ`)
+    // so agent CLIs insert a newline instead of submitting. A copy chord is always swallowed (else
+    // Ctrl+Shift+C would fall through to the pty as \x03/SIGINT); plain Ctrl+C is left alone.
+    term.attachCustomKeyEventHandler((e) => {
+      const action = terminalKeyAction(e, term.hasSelection())
+      if (action === 'pass') return true
+      e.preventDefault()
+      if (action === 'copy') window.nodeTerminal.clipboard.writeText(term.getSelection())
+      else if (action === 'shift-enter' && sessionId) transport.write(sessionId, SHIFT_ENTER_SEQ)
+      return false
+    })
+
+    void (async () => {
+      // SSH-project node: resolve the live ControlMaster (may not be up yet on a cold load).
+      const sshRemote =
+        spawn.sshRemoteTmux && spawn.ssh
+          ? await resolveSshRemote(spawn.ssh, spawn.cwd)
+          : undefined
+      if (dead) return
+      // A local `ssh <host>` node runs ssh as its own pty program (shell:'ssh' + buildSshArgs); an
+      // SSH-PROJECT node uses tmux on the remote host instead (sshRemote), so it is NOT localSsh.
+      const localSsh = !!spawn.ssh && !spawn.sshRemoteTmux
+      const res = await transport.create({
+        cols: term.cols,
+        rows: term.rows,
+        shell: localSsh ? 'ssh' : spawn.shell,
+        shellArgs: localSsh ? buildSshArgs(spawn.ssh!) : undefined,
+        // Don't spawn a LOCAL tmux in a non-existent remote cwd if the master never came up.
+        cwd: spawn.sshRemoteTmux && !sshRemote ? undefined : spawn.cwd,
+        persistKey: nodeId,
+        agentId: spawn.agentId,
+        accountId: spawn.accountId,
+        sshRemote
+      })
+      // Another client permanently deleted this node's session — never resurrect it (no live session
+      // to join, and the tombstone refused a fresh spawn). Show the state and stop.
+      if (res.closed) {
+        term.write('\r\n\x1b[90m[session closed by another user]\x1b[0m\r\n')
+        return
+      }
+      // Unmounted while the create was in flight: detach the viewer we just registered so it doesn't
+      // linger as a phantom subscriber constraining the shared pty's size.
+      if (dead) {
+        transport.kill(res.sessionId)
+        return
+      }
+      sessionId = res.sessionId
+      cleanups.push(transport.onData(res.sessionId, (d) => term.write(d)))
+      cleanups.push(
+        transport.onExit(res.sessionId, () =>
+          term.write('\r\n\x1b[90m[session ended]\x1b[0m\r\n')
+        )
+      )
+      // The pty runs at the SMALLEST subscriber's grid; render exactly what it tells us and letterbox
+      // the rest (the canvas node votes independently — the modal's smaller pane may shrink it).
+      if (transport.onSize)
+        cleanups.push(
+          transport.onSize(res.sessionId, (size) => term.resize(size.cols, size.rows))
+        )
+      term.onData((d) => sessionId && transport.write(sessionId, d))
+
+      // A fresh (cold-restart / first-open) session's tmux pane is gone, so replay the persisted
+      // scrollback. A warm join is painted from the server-captured screen inside create(). Agent
+      // auto-resume is deliberately canvas-only — the modal never re-launches a CLI.
+      const snapshot = res.fresh ? await api.pty.readScrollback(nodeId) : null
+      const paint = seedPaint({
+        replay: attachReplay({ parked: false, fresh: res.fresh, hasInitialCommand: false }),
+        superseded: false,
+        snapshot,
+        screen: res.screen
+      })
+      if (paint === 'snapshot') {
+        if (snapshot) term.write(snapshot)
+        term.write('\r\n\x1b[90m— cold start · agent auto-resume happens on canvas —\x1b[0m\r\n')
+      } else if (paint === 'create-screen' && res.screen) {
+        term.write(res.screen)
+      }
+
+      const ro = new ResizeObserver(() => {
+        fit.fit()
+        if (sessionId) transport.resize(sessionId, term.cols, term.rows)
+      })
+      ro.observe(hostRef.current!)
+      cleanups.push(() => ro.disconnect())
+      transport.resize(res.sessionId, term.cols, term.rows)
+      term.focus()
+    })()
+
+    return () => {
+      dead = true
+      cleanups.forEach((fn) => fn())
+      // Kill ONLY this modal's viewer — the instance appends its viewerId. The canvas node's PRIMARY
+      // (or parked) client is a different composite subscriber and is untouched; the shared pty lives
+      // on until its last view goes.
+      if (sessionId) transport.kill(sessionId)
+      term.dispose()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeId])
+
+  return <div ref={hostRef} className="kanban-modal__term" />
+}

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -6,10 +6,10 @@ interface SessionCardProps {
   session: KanbanSession
   status?: AgentNodeStatus
   expanded: boolean
-  /** Single click toggles the detail row — opening the node moved to ↗ / double-click. */
+  /** Single click toggles the detail row — opening the card moved to ↗ / double-click. */
   onToggle: () => void
-  /** Open on canvas: switch back to canvas view and focus this node. */
-  onOpen: () => void
+  /** Open the card modal: both the ↗ button and double-click fire this. */
+  onOpenModal: () => void
   onDragStart: () => void
   onDragEnd: () => void
   /** A dragged card was dropped on this card — insert it before this one. */
@@ -17,7 +17,7 @@ interface SessionCardProps {
 }
 
 export function SessionCard({
-  session, status, expanded, onToggle, onOpen, onDragStart, onDragEnd, onDropBefore
+  session, status, expanded, onToggle, onOpenModal, onDragStart, onDragEnd, onDropBefore
 }: SessionCardProps) {
   const sticky = session.kind === 'sticky'
   const badge =
@@ -44,7 +44,7 @@ export function SessionCard({
       onClick={onToggle}
       onDoubleClick={(e) => {
         e.stopPropagation()
-        onOpen()
+        onOpenModal()
       }}
       title={expanded ? 'Collapse' : 'Expand'}
     >
@@ -77,7 +77,7 @@ export function SessionCard({
               )}
             </>
           )}
-          <button className="kanban-card__open" title="Open on canvas" onClick={onOpen}>
+          <button className="kanban-card__open" title="Open card" onClick={onOpenModal}>
             ↗
           </button>
         </div>

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -87,7 +87,7 @@ function escapeDroppedPath(p: string): string {
  * Returns undefined if no master appears within the window (connection failed); the caller then
  * degrades gracefully instead of spawning a local tmux in a non-existent remote directory.
  */
-async function resolveSshRemote(
+export async function resolveSshRemote(
   conn: SshConnection,
   cwd: string | undefined
 ): Promise<

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6732,3 +6732,9 @@ body,
   color: rgba(255, 255, 255, 0.35);
   font-size: 12px;
 }
+/* The live co-attach terminal fills the pane; the ResizeObserver in ModalTerminal drives fit(). */
+.kanban-modal__term {
+  flex: 1;
+  min-width: 0;
+  padding: 8px;
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6632,3 +6632,103 @@ body,
   -webkit-box-orient: vertical;
   word-break: break-word;
 }
+
+/* ---- Kanban card modal (Trello-style popup over the board) ---- */
+.kanban-modal-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 55; /* above the board (25) + drawers (~40), below ConfirmDialog (70+) */
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.kanban-modal {
+  width: min(1040px, calc(100vw - 96px));
+  height: min(680px, calc(100vh - 120px));
+  display: flex;
+  flex-direction: column;
+  background: #161618;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+.kanban-modal__header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.kanban-modal__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.92);
+  cursor: text;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.kanban-modal__rename {
+  flex: 1;
+  min-width: 0;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--accent);
+  border-radius: 5px;
+  color: #fff;
+  font-size: 13px;
+  padding: 3px 8px;
+  outline: none;
+}
+.kanban-modal__column {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-right: auto;
+}
+.kanban-modal__action {
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 13px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+.kanban-modal__action:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+}
+.kanban-modal__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+.kanban-modal__sticky {
+  flex: 1;
+  background: none;
+  border: none;
+  resize: none;
+  outline: none;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 13px;
+  line-height: 1.5;
+  padding: 14px 16px;
+  font-family: inherit;
+}
+.kanban-modal__pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+}
+.kanban-modal__placeholder {
+  margin: auto;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 12px;
+}

--- a/src/renderer/terminal/local-transport.ts
+++ b/src/renderer/terminal/local-transport.ts
@@ -9,10 +9,22 @@ import type { TerminalTransport } from './transport'
  * identical to the pre-injection global reads.
  */
 export class LocalTransport implements TerminalTransport {
-  /** Lazy `window.nodeTerminal` fallback (not an eager default parameter): the module-scope
-   *  `transport` singleton below is constructed at import time, and under node (vitest, no
-   *  jsdom) `window` doesn't exist yet — it must only be touched on first use. */
-  constructor(private readonly injectedApi?: NodeTerminalApi) {}
+  /**
+   * `injectedApi` — lazy `window.nodeTerminal` fallback (not an eager default parameter): the
+   * module-scope `transport` singleton below is constructed at import time, and under node (vitest,
+   * no jsdom) `window` doesn't exist yet — it must only be touched on first use.
+   *
+   * `viewerId` — which VIEW of a session this transport instance drives. The canvas node's
+   * transport omits it (the PRIMARY view = today's exact behavior); the kanban card modal
+   * constructs its own `LocalTransport(api, 'modal-<nodeId>')`, so its create/resize/setFlow/kill
+   * co-attach and detach as an independent subscriber of the SAME session, without disturbing the
+   * canvas node's client. The `TerminalTransport` method signatures are unchanged — the viewer is
+   * baked into the instance, not threaded through every call site.
+   */
+  constructor(
+    private readonly injectedApi?: NodeTerminalApi,
+    private readonly viewerId?: string
+  ) {}
 
   private get api(): NodeTerminalApi {
     return this.injectedApi ?? window.nodeTerminal
@@ -23,7 +35,10 @@ export class LocalTransport implements TerminalTransport {
   }
 
   create(options: PtyCreateOptions): Promise<PtyCreateResult> {
-    return this.pty.create(options)
+    // Append the viewer only when this instance has one, so a PRIMARY transport's options object is
+    // untouched (an explicit `viewerId: undefined` would still be PRIMARY, but keeping it absent is
+    // bit-for-bit the pre-viewer create).
+    return this.pty.create(this.viewerId ? { ...options, viewerId: this.viewerId } : options)
   }
 
   write(sessionId: string, data: string): void {
@@ -31,15 +46,15 @@ export class LocalTransport implements TerminalTransport {
   }
 
   resize(sessionId: string, cols: number | null, rows: number | null): void {
-    this.pty.resize(sessionId, cols, rows)
+    this.pty.resize(sessionId, cols, rows, this.viewerId)
   }
 
   setFlow(sessionId: string, resume: boolean): void {
-    this.pty.setFlow(sessionId, resume)
+    this.pty.setFlow(sessionId, resume, this.viewerId)
   }
 
   kill(sessionId: string): void {
-    this.pty.kill(sessionId)
+    this.pty.kill(sessionId, this.viewerId)
   }
 
   destroy(persistKey: string): void {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,6 +27,14 @@ export interface PtyCreateOptions {
   agentId?: AgentId
   /** Managed Claude account: inject CLAUDE_CONFIG_DIR for this account into the session env. */
   accountId?: string
+  /**
+   * Which VIEW of the session this is, WITHIN one connection. A second view in the same renderer
+   * (the kanban card modal) passes its own id so it co-attaches as an independently-detachable
+   * subscriber rather than a no-op join; absent ⇒ the PRIMARY view (the canvas node) and bit-for-bit
+   * the pre-viewer behavior. Invisible to peers — viewers collapse to the ClientId everywhere a
+   * subscriber maps to a person.
+   */
+  viewerId?: string
   /** When set, this PTY runs on a remote host over the project's ssh ControlMaster, in remote tmux.
    * `remoteHome` is the connection's resolved `$HOME`, used to build an ABSOLUTE remote
    * `CLAUDE_CONFIG_DIR` for a managed remote account (tmux `-e` values are not shell-expanded). */
@@ -304,12 +312,18 @@ export interface PtyApi {
   /** Updates the PTY when the terminal is resized. The pty runs at the SMALLEST subscriber's grid,
    *  so this is a REPORT, not a command — the effective size comes back over `onSize`.
    *  `cols`/`rows` null means "subscribed, but not viewing" (a parked terminal): the client leaves
-   *  the size set entirely, so a parked small window can't shrink everyone else's terminal. */
-  resize(sessionId: string, cols: number | null, rows: number | null): void
-  /** Flow control: pause (false) or resume (true) reading the PTY when xterm is backed up. */
-  setFlow(sessionId: string, resume: boolean): void
-  /** Detaches/terminates the PTY client (the underlying tmux session survives). */
-  kill(sessionId: string): void
+   *  the size set entirely, so a parked small window can't shrink everyone else's terminal.
+   *  `viewerId` (optional, trailing) scopes the size vote to one VIEW within the connection (the
+   *  kanban card modal); absent ⇒ the PRIMARY view. */
+  resize(sessionId: string, cols: number | null, rows: number | null, viewerId?: string): void
+  /** Flow control: pause (false) or resume (true) reading the PTY when xterm is backed up.
+   *  `viewerId` (optional, trailing) scopes the pause to one VIEW (a client's second xterm is
+   *  edge-latched independently); absent ⇒ the PRIMARY view. */
+  setFlow(sessionId: string, resume: boolean, viewerId?: string): void
+  /** Detaches/terminates ONE view of the PTY (the underlying tmux session survives). `viewerId`
+   *  (optional, trailing) names the view to detach — closing the kanban modal leaves the canvas
+   *  node attached; absent ⇒ the PRIMARY view. */
+  kill(sessionId: string, viewerId?: string): void
   /** Permanently ends the persistent session for a node (kills its tmux session) because the node
    *  is being DELETED. Co-viewers get `onClosed` and must not respawn it. */
   destroy(persistKey: string): void


### PR DESCRIPTION
## Summary

Sub-project A of the "Trello for Claude Code" spec: a card's ↗ / double-click now opens a **centered modal over the board** (scrim/Esc closes; rename in the header; column chip; "Open on canvas" moved inside) — with a **fully interactive terminal**.

- **Core: viewer identity** (`feat(pty)`, the load-bearing commit). The pty subscriber ledger's key becomes the composite `(ClientId, viewerId ?? PRIMARY)`, carried as an optional TRAILING arg through preload/IPC/ws-bridge/LocalTransport. One connection can now hold multiple independently-detachable views of a session — absent viewerId is bit-for-bit the old behavior (the untouched single-user + co-attach suites are the proof; 4 new tests pin the multi-view contract). Found & fixed along the way: a client's per-connection socket pause was released when ONE view left (latent Server-Edition backpressure bug, RED→GREEN tested).
- **ModalTerminal**: a second live view of the node's tmux session (seed-painted from the joiner screen with the proper xterm text transforms; fresh-cold start replays the scrollback snapshot + a muted hint, agent auto-resume stays canvas-only). Closing the modal detaches only its own viewer — verified live: typing in the modal executed in the real tmux session and the canvas client survived the close.
- **Sticky cards** edit their note text in the modal (live both ways); chat cards show info + open-on-canvas.

Review trail: every commit passed task-scoped review; the core change got an adversarial review (which flagged the socket-pause bug fixed here) + re-review; final whole-branch review: ready, with three accepted cosmetic/edge minors (modal onClosed line, Esc-cancel blur nuance shared with pre-existing code, modal flow-control edges — documented in-code).

## Test plan

- [x] Full suite 2209/2209; typecheck clean; guard suites (pty-single-user, co-attach, release, typing, size, platform) pass UNCHANGED
- [x] Live e2e drive (Server Edition, headless browser): modal opens with title + column chip; terminal paints without staircase; typed command verified inside tmux via capture-pane; canvas client alive after modal close (list-clients); sticky modal edit reflected live; scrim + Esc close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h