### PR TITLE
feat(usage): add the MiniMax provider, with its cookie stored outside settings.json

### DIFF
--- a/src/core/usage/minimax-cookie.ts
+++ b/src/core/usage/minimax-cookie.ts
@@ -1,0 +1,53 @@
+// Storage for the MiniMax browser cookie.
+//
+// This deliberately does NOT live in settings.json. That file is written with default
+// permissions and is treated throughout the app as CONFIG — the `claudeAccounts` list sits
+// there precisely because an account list is config, not a credential. A MiniMax session cookie
+// is the opposite: it is a live bearer credential that grants access to the user's MiniMax
+// account, so it gets its own file with 0600 and never appears in a config blob that is
+// world-readable, copied between machines, or pasted into a bug report.
+import { promises as fs } from 'fs'
+import path from 'path'
+import { platform } from '../platform'
+
+const FILE = 'minimax-cookie.json'
+/** Owner read/write only. The whole reason this is a separate file. */
+const MODE = 0o600
+
+function file(): string {
+  return path.join(platform().userDataDir, FILE)
+}
+
+/** The stored cookie header, or null when MiniMax has not been configured. */
+export async function readMinimaxCookie(): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(file(), 'utf-8')
+    const j = JSON.parse(raw) as Record<string, unknown>
+    return typeof j.cookie === 'string' && j.cookie.trim() ? j.cookie : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Store (or, with an empty value, clear) the cookie. Written to a temp file first and renamed,
+ * so a crash mid-write cannot leave a half-written credential behind — and the temp file is
+ * created with the restricted mode too, since a rename preserves whatever the source had.
+ */
+export async function writeMinimaxCookie(cookie: string): Promise<void> {
+  const target = file()
+  if (!cookie.trim()) {
+    await fs.rm(target, { force: true })
+    return
+  }
+  const tmp = `${target}.tmp`
+  await fs.writeFile(tmp, JSON.stringify({ cookie }), { encoding: 'utf-8', mode: MODE })
+  await fs.rename(tmp, target)
+  // Belt and braces: an existing temp file from a previous run would keep its own mode.
+  await fs.chmod(target, MODE).catch(() => undefined)
+}
+
+/** Whether a cookie is stored — for the settings UI, which must never read the value back. */
+export async function hasMinimaxCookie(): Promise<boolean> {
+  return (await readMinimaxCookie()) !== null
+}

--- a/src/core/usage/minimax-usage.test.ts
+++ b/src/core/usage/minimax-usage.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  mapMinimaxLimits,
+  mapMinimaxItem,
+  cookieValue,
+  isUsableMinimaxCookie,
+  minimaxRejected,
+  fetchMinimaxUsage
+} from './minimax-usage'
+import { readMinimaxCookie, writeMinimaxCookie, hasMinimaxCookie } from './minimax-cookie'
+import { initPlatform, resetPlatformForTests, type CorePlatform } from '../platform'
+import { primaryLimit, limitLabel } from '../../shared/usage-limits'
+
+/**
+ * NOTE: not captured from a live account — no MiniMax session was available on the machine this
+ * was written on. Follows the field contract orca's fetcher documents.
+ */
+const BODY = {
+  base_resp: { status_code: 0, status_msg: 'success' },
+  model_remains: [
+    {
+      model_name: 'MiniMax-M2',
+      current_interval_remaining_percent: 35,
+      start_time: 1_784_400_000_000,
+      end_time: 1_784_418_000_000
+    },
+    {
+      model_name: 'MiniMax-Text-01',
+      current_interval_remaining_percent: 80,
+      start_time: 1_784_400_000_000,
+      end_time: 1_784_418_000_000
+    }
+  ]
+}
+
+describe('cookieValue', () => {
+  it('extracts a named cookie from a pasted header', () => {
+    expect(cookieValue('a=1; _token=abc123; b=2', '_token')).toBe('abc123')
+  })
+
+  it('does not match a name that merely ends with the target', () => {
+    expect(cookieValue('x_token=nope', '_token')).toBeNull()
+  })
+
+  it('returns null for an absent or valueless cookie', () => {
+    expect(cookieValue('a=1', '_token')).toBeNull()
+    expect(cookieValue('_token=', '_token')).toBeNull()
+  })
+})
+
+describe('isUsableMinimaxCookie', () => {
+  it('requires _token, which is what actually authenticates', () => {
+    // Catching this here turns a mystifying 401 into an obvious "you copied the wrong header".
+    expect(isUsableMinimaxCookie('sessionid=x; other=y')).toBe(false)
+    expect(isUsableMinimaxCookie('sessionid=x; _token=abc')).toBe(true)
+    expect(isUsableMinimaxCookie(null)).toBe(false)
+    expect(isUsableMinimaxCookie('')).toBe(false)
+  })
+})
+
+describe('mapMinimaxItem', () => {
+  it('inverts remaining into used and labels by model', () => {
+    const l = mapMinimaxItem(BODY.model_remains[0])
+    expect(l).toMatchObject({
+      kind: 'session_scoped',
+      usedPercent: 65,
+      scopeLabel: 'MiniMax-M2',
+      windowMinutes: 300
+    })
+  })
+
+  it('pins the window to the contracted 5h rather than deriving it', () => {
+    // The API's end-start drifts below the bucket it sells (4h, 295 min, …).
+    const l = mapMinimaxItem({
+      model_name: 'M',
+      current_interval_remaining_percent: 50,
+      start_time: 0,
+      end_time: 60_000
+    })
+    expect(l?.windowMinutes).toBe(300)
+  })
+
+  it('accepts numeric fields as strings', () => {
+    expect(mapMinimaxItem({ model_name: 'M', current_interval_remaining_percent: '25' })?.usedPercent).toBe(75)
+  })
+
+  it('drops an entry with no model or no percentage', () => {
+    expect(mapMinimaxItem({ current_interval_remaining_percent: 10 })).toBeNull()
+    expect(mapMinimaxItem({ model_name: 'M' })).toBeNull()
+    expect(mapMinimaxItem(null)).toBeNull()
+  })
+
+  it('reports no severity', () => {
+    expect(mapMinimaxItem(BODY.model_remains[0])?.severity).toBeNull()
+  })
+})
+
+describe('mapMinimaxLimits', () => {
+  it('emits EVERY model, not one preferred pick', () => {
+    // Orca selects a single model because its shape has one session slot; ours carries a list.
+    const limits = mapMinimaxLimits(BODY)
+    expect(limits.map((l) => l.scopeLabel)).toEqual(['MiniMax-M2', 'MiniMax-Text-01'])
+  })
+
+  it('labels rows by model without the UI knowing anything about MiniMax', () => {
+    expect(limitLabel('session_scoped', 'MiniMax-M2')).toBe('MiniMax-M2')
+  })
+
+  it('leads with the most constrained model', () => {
+    expect(primaryLimit(mapMinimaxLimits(BODY))?.scopeLabel).toBe('MiniMax-M2')
+  })
+
+  it('returns nothing for a junk body', () => {
+    expect(mapMinimaxLimits(null)).toEqual([])
+    expect(mapMinimaxLimits({})).toEqual([])
+    expect(mapMinimaxLimits({ model_remains: 'nope' })).toEqual([])
+  })
+})
+
+describe('minimaxRejected', () => {
+  it('detects a failure reported inside an HTTP 200', () => {
+    // An expired session shows up this way, not as a 401 — the usual stale-cookie path.
+    expect(minimaxRejected({ base_resp: { status_code: 1004 } })).toBe(true)
+    expect(minimaxRejected(BODY)).toBe(false)
+    expect(minimaxRejected({})).toBe(false)
+  })
+})
+
+describe('fetchMinimaxUsage', () => {
+  it('reports unavailable without touching the network when no cookie is configured', async () => {
+    await expect(fetchMinimaxUsage(null)).resolves.toMatchObject({
+      provider: 'minimax',
+      status: 'unavailable',
+      limits: []
+    })
+  })
+
+  it('reports unavailable for a cookie missing _token', async () => {
+    await expect(fetchMinimaxUsage('a=1; b=2')).resolves.toMatchObject({ status: 'unavailable' })
+  })
+})
+
+describe('minimax cookie storage', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-minimax-'))
+    initPlatform({ userDataDir: dir } as unknown as CorePlatform)
+  })
+
+  afterEach(() => {
+    resetPlatformForTests()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('round-trips a cookie', async () => {
+    await writeMinimaxCookie('_token=abc')
+    await expect(readMinimaxCookie()).resolves.toBe('_token=abc')
+    await expect(hasMinimaxCookie()).resolves.toBe(true)
+  })
+
+  it('stores it OUTSIDE settings.json, readable only by the owner', async () => {
+    // The whole reason this is a separate file: settings.json is written with default
+    // permissions, and this value is a live bearer credential, not config.
+    await writeMinimaxCookie('_token=abc')
+    const mode = fs.statSync(path.join(dir, 'minimax-cookie.json')).mode & 0o777
+    expect(mode).toBe(0o600)
+    expect(fs.existsSync(path.join(dir, 'settings.json'))).toBe(false)
+  })
+
+  it('clears the stored cookie, leaving no file behind', async () => {
+    await writeMinimaxCookie('_token=abc')
+    await writeMinimaxCookie('')
+    await expect(readMinimaxCookie()).resolves.toBeNull()
+    await expect(hasMinimaxCookie()).resolves.toBe(false)
+    expect(fs.existsSync(path.join(dir, 'minimax-cookie.json'))).toBe(false)
+  })
+
+  it('treats a whitespace-only paste as clearing, not as a cookie', async () => {
+    await writeMinimaxCookie('   ')
+    await expect(hasMinimaxCookie()).resolves.toBe(false)
+  })
+
+  it('reports no cookie rather than throwing on a corrupt file', async () => {
+    fs.writeFileSync(path.join(dir, 'minimax-cookie.json'), '{{{')
+    await expect(readMinimaxCookie()).resolves.toBeNull()
+  })
+
+  it('leaves no temp file behind after a write', async () => {
+    await writeMinimaxCookie('_token=abc')
+    expect(fs.readdirSync(dir)).toEqual(['minimax-cookie.json'])
+  })
+})

--- a/src/core/usage/minimax-usage.ts
+++ b/src/core/usage/minimax-usage.ts
@@ -1,0 +1,154 @@
+// MiniMax coding-plan usage.
+//
+// Unlike every other provider here, MiniMax exposes no CLI credential on disk — the quota lives
+// behind the web console's session. So the user pastes their browser Cookie header into
+// Settings and we replay it. That cookie is a live bearer credential, which is why it is stored
+// in its own 0600 file rather than in settings.json (see minimax-cookie.ts).
+import type { ProviderUsage, UsageLimit } from '../../shared/types'
+import { parseResetTimestamp } from './claude-usage-map'
+
+const USAGE_URL = 'https://platform.minimax.io/v1/api/openplatform/coding_plan/remains'
+const ORIGIN = 'https://platform.minimax.io'
+const REFERER = 'https://platform.minimax.io/console/usage'
+const FETCH_TIMEOUT_MS = 15_000
+
+/**
+ * The API reports `end_time - start_time`, and that span drifts below the contracted bucket
+ * (4h, 295 min, …). The plan sells a 5-hour session, so the label is pinned rather than derived
+ * — the same choice Codex's fallback durations make.
+ */
+const SESSION_WINDOW_MINUTES = 300
+
+/**
+ * MiniMax's endpoint rejects clients that don't look like a browser, so a real per-platform
+ * Firefox UA is sent instead of an app-specific agent string. Do not "clean this up" into a
+ * nodeterm UA — the request will start failing.
+ */
+function browserUserAgent(): string {
+  if (process.platform === 'win32') {
+    return 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:152.0) Gecko/20100101 Firefox/152.0'
+  }
+  if (process.platform === 'darwin') {
+    return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:152.0) Gecko/20100101 Firefox/152.0'
+  }
+  return 'Mozilla/5.0 (X11; Linux x86_64; rv:152.0) Gecko/20100101 Firefox/152.0'
+}
+
+/** Pull one cookie's value out of a pasted `Cookie:` header. */
+export function cookieValue(cookie: string, name: string): string | null {
+  for (const part of cookie.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    if (part.slice(0, eq).trim() === name) {
+      const v = part.slice(eq + 1).trim()
+      return v || null
+    }
+  }
+  return null
+}
+
+/**
+ * `_token` is what actually authenticates the request, so a paste that lacks it is not a usable
+ * cookie no matter how long it is — catching that here turns a mystifying 401 into an obvious
+ * "you copied the wrong header".
+ */
+export function isUsableMinimaxCookie(cookie: string | null | undefined): boolean {
+  return !!cookie && cookieValue(cookie, '_token') !== null
+}
+
+function asNumber(v: unknown): number | null {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null
+  if (typeof v === 'string') {
+    const n = Number(v)
+    return Number.isFinite(n) ? n : null
+  }
+  return null
+}
+
+/**
+ * One per-model entry. MiniMax reports what is REMAINING, like Gemini, so this inverts. The
+ * model name rides in `scopeLabel`, the same treatment Claude's scoped caps and Gemini's buckets
+ * get — the UI needs to know nothing about MiniMax to label it.
+ */
+export function mapMinimaxItem(item: unknown): UsageLimit | null {
+  if (!item || typeof item !== 'object') return null
+  const it = item as Record<string, unknown>
+  const modelName = typeof it.model_name === 'string' ? it.model_name : null
+  const remaining = asNumber(it.current_interval_remaining_percent)
+  if (!modelName || remaining === null) return null
+
+  return {
+    kind: 'session_scoped',
+    group: 'session',
+    usedPercent: Math.min(100, Math.max(0, 100 - remaining)),
+    severity: null,
+    resetsAt: parseResetTimestamp(it.end_time),
+    windowMinutes: SESSION_WINDOW_MINUTES,
+    scopeLabel: modelName,
+    isActive: false
+  }
+}
+
+/**
+ * Every model's window, not just one. Orca selects a single preferred model because its shape
+ * has one session slot to fill; ours carries a list, so a plan covering several models shows
+ * each of them.
+ */
+export function mapMinimaxLimits(body: unknown): UsageLimit[] {
+  if (!body || typeof body !== 'object') return []
+  const items = (body as Record<string, any>).model_remains
+  if (!Array.isArray(items)) return []
+  return items.map(mapMinimaxItem).filter((l): l is UsageLimit => l !== null)
+}
+
+/** A non-zero `base_resp.status_code` is MiniMax reporting failure inside an HTTP 200. */
+export function minimaxRejected(body: unknown): boolean {
+  const code = (body as any)?.base_resp?.status_code
+  return typeof code === 'number' && code !== 0
+}
+
+function snapshot(limits: UsageLimit[], status: ProviderUsage['status']): ProviderUsage {
+  return { provider: 'minimax', limits, account: null, updatedAt: Date.now(), status }
+}
+
+/**
+ * MiniMax usage. Never rejects.
+ *
+ * A stale cookie is reported as 'unavailable' rather than 'error': the user's session simply
+ * expired and they need to paste a fresh one, which is the same "not signed in" story every
+ * other provider tells — not a fault worth an alarm icon.
+ */
+export async function fetchMinimaxUsage(cookie: string | null): Promise<ProviderUsage> {
+  if (!isUsableMinimaxCookie(cookie)) return snapshot([], 'unavailable')
+  try {
+    const headers: Record<string, string> = {
+      cookie: cookie!,
+      accept: 'application/json',
+      origin: ORIGIN,
+      referer: REFERER,
+      'user-agent': browserUserAgent()
+    }
+    // The console scopes the query to the active group; without this the endpoint answers for
+    // the wrong one (or refuses) on accounts that belong to more than one.
+    const groupId = cookieValue(cookie!, 'minimax_group_id_v2')
+    if (groupId) headers['x-group-id'] = groupId
+
+    const ctrl = new AbortController()
+    const t = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS)
+    const res = await fetch(USAGE_URL, { headers, signal: ctrl.signal }).finally(() =>
+      clearTimeout(t)
+    )
+    if (res.status === 401 || res.status === 403) return snapshot([], 'unavailable')
+    if (!res.ok) return snapshot([], 'error')
+
+    const body = await res.json()
+    // An expired session is answered inside a 200 with a non-zero status_code, so this is the
+    // usual way a stale cookie shows up — not the 401 above.
+    if (minimaxRejected(body)) return snapshot([], 'unavailable')
+
+    const limits = mapMinimaxLimits(body)
+    return snapshot(limits, limits.length > 0 ? 'ok' : 'unavailable')
+  } catch {
+    return snapshot([], 'error')
+  }
+}

--- a/src/core/usage/usage-service.ts
+++ b/src/core/usage/usage-service.ts
@@ -23,6 +23,8 @@ import { fetchCodexUsage } from './codex-usage'
 import { fetchGeminiUsage } from './gemini-usage'
 import { fetchGrokUsage } from './grok-usage'
 import { fetchKimiUsage } from './kimi-usage'
+import { fetchMinimaxUsage } from './minimax-usage'
+import { readMinimaxCookie, writeMinimaxCookie, hasMinimaxCookie } from './minimax-cookie'
 import { usageCredsPaths } from '../claude-accounts-core'
 import { claudeConfigDirFor } from '../claude-config-dir'
 import { platform } from '../platform'
@@ -50,7 +52,9 @@ const OTHER_PROVIDERS: { id: string; fetch: () => Promise<ProviderUsage> }[] = [
   { id: 'codex', fetch: fetchCodexUsage },
   { id: 'gemini', fetch: fetchGeminiUsage },
   { id: 'grok', fetch: fetchGrokUsage },
-  { id: 'kimi', fetch: fetchKimiUsage }
+  { id: 'kimi', fetch: fetchKimiUsage },
+  // MiniMax has no on-disk CLI credential; its cookie is read from our own 0600 store.
+  { id: 'minimax', fetch: async () => fetchMinimaxUsage(await readMinimaxCookie()) }
 ]
 
 /** Parse a credentials JSON blob; tokens may sit at top level or under `claudeAiOauth`. */
@@ -293,6 +297,17 @@ export function startUsageService(opts: UsageServiceOptions = {}): UsageService 
       providersInFlight = null
     }
   }
+
+  // The cookie is write-only from the UI's perspective: it can be set and cleared, and the UI
+  // can ask WHETHER one is stored, but there is no channel that hands the value back. A
+  // credential that never crosses the boundary cannot be leaked by whatever reads it.
+  platform().handle(IPC.usageSetMinimaxCookie, async (cookie: string) => {
+    await writeMinimaxCookie(typeof cookie === 'string' ? cookie : '')
+    // Drop the cache so the next read reflects the new cookie instead of the old snapshot.
+    providersAt = 0
+    return hasMinimaxCookie()
+  })
+  platform().handle(IPC.usageHasMinimaxCookie, () => hasMinimaxCookie())
 
   platform().handle(IPC.usageProviders, (force?: boolean) => {
     if (!force && providersAt && Date.now() - providersAt < REFETCH_DEBOUNCE_MS) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -326,6 +326,8 @@ const api: NodeTerminalApi = {
     fetch: (accountId?: string) => ipcRenderer.invoke(IPC.usageFetch, accountId),
     refresh: (accountId?: string) => ipcRenderer.invoke(IPC.usageRefresh, accountId),
     providers: (force?: boolean) => ipcRenderer.invoke(IPC.usageProviders, force),
+    setMinimaxCookie: (cookie: string) => ipcRenderer.invoke(IPC.usageSetMinimaxCookie, cookie),
+    hasMinimaxCookie: () => ipcRenderer.invoke(IPC.usageHasMinimaxCookie),
     onUpdate: (listener) => {
       const handler = (_e: unknown, payload: Parameters<typeof listener>[0]) => listener(payload)
       ipcRenderer.on(IPC.usageUpdate, handler)

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -227,6 +227,8 @@ export function buildStubApi(): Omit<
       // Empty, not a reject: "no providers configured" is a real answer and the popover
       // renders it as nothing. This one needs no cast — the honest type already fits.
       providers: () => Promise.resolve([]),
+      setMinimaxCookie: U('usage.setMinimaxCookie'),
+      hasMinimaxCookie: () => Promise.resolve(false),
       onUpdate: noopUnsub
     },
     claude: {

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -486,6 +486,9 @@ function buildUsageApi(client: RpcClient): Pick<NodeTerminalApi, 'usage'> {
         client.request(IPC.usageRefresh, accountId) as Promise<ClaudeUsage>,
       providers: (force?: boolean) =>
         client.request(IPC.usageProviders, force) as Promise<ProviderUsage[]>,
+      setMinimaxCookie: (cookie: string) =>
+        client.request(IPC.usageSetMinimaxCookie, cookie) as Promise<boolean>,
+      hasMinimaxCookie: () => client.request(IPC.usageHasMinimaxCookie) as Promise<boolean>,
       onUpdate: (listener) => client.subscribe(IPC.usageUpdate, listener as Listener)
     }
   }

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -45,6 +45,10 @@ const ROWS = {
       'claude',
       'shift tab'
     ]
+  },
+  minimax: {
+    title: 'MiniMax usage',
+    keywords: ['minimax', 'usage', 'quota', 'cookie', 'limits', 'provider']
   }
 }
 const ENTRIES = Object.values(ROWS)
@@ -52,6 +56,22 @@ const ENTRIES = Object.values(ROWS)
 export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.Element {
   const settings = useSettings((s) => s.settings)
   const update = useSettings((s) => s.update)
+  // The MiniMax cookie is write-only across the IPC boundary: we can ask WHETHER one is stored
+  // and set/clear it, but never read the value back — so the input starts empty even when one
+  // is configured, and is cleared the moment it is handed over.
+  const [minimaxCookie, setMinimaxCookie] = useState('')
+  const [minimaxSaved, setMinimaxSaved] = useState(false)
+  useEffect(() => {
+    if (!isActive) return
+    let cancelled = false
+    void window.nodeTerminal.usage.hasMinimaxCookie().then((v) => {
+      if (!cancelled) setMinimaxSaved(v)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isActive])
+
   const rows: { id: AgentId; label: string; isBuiltin: boolean }[] = [
     ...BUILTIN_AGENT_IDS.map((id) => ({ id, label: AGENT_CONFIG[id].label, isBuiltin: true })),
     ...settings.customAgents.map((c) => ({ id: c.id, label: c.label || c.id, isBuiltin: false }))
@@ -117,6 +137,50 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
             )
           })}
         </div>
+      </SearchableRow>
+      <SearchableRow {...ROWS.minimax}>
+        <FieldRow
+          label="Browser cookie"
+          description="MiniMax exposes no CLI credential, so its quota is read with your console session. In the browser, open platform.minimax.io/console/usage, copy the request's Cookie header, and paste it here."
+          note={
+            minimaxSaved
+              ? 'Stored outside settings.json, in a file only your user can read. It is never shown again — paste a fresh one when your session expires.'
+              : 'This is a live session credential. It is stored in a 0600 file, not in settings.json, and is never read back into the UI.'
+          }
+          control={
+            <div className="flex items-center gap-2">
+              <input
+                type="password"
+                className="input w-64"
+                placeholder={minimaxSaved ? '•••••••• stored' : 'Cookie: _token=…'}
+                value={minimaxCookie}
+                onChange={(e) => setMinimaxCookie(e.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <Button
+                onClick={async () => {
+                  setMinimaxSaved(await window.nodeTerminal.usage.setMinimaxCookie(minimaxCookie))
+                  // Never keep the secret in component state once it has been handed over.
+                  setMinimaxCookie('')
+                }}
+                disabled={!minimaxCookie.trim()}
+              >
+                Save
+              </Button>
+              {minimaxSaved && (
+                <Button
+                  onClick={async () => {
+                    setMinimaxSaved(await window.nodeTerminal.usage.setMinimaxCookie(''))
+                    setMinimaxCookie('')
+                  }}
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+          }
+        />
       </SearchableRow>
       <SearchableRow {...ROWS.permissionMode}>
         <FieldRow

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -75,6 +75,10 @@ export const IPC = {
   usageUpdate: 'usage:update',
   /** Non-Claude providers (codex, …) as one list; Claude keeps its own account-aware channels. */
   usageProviders: 'usage:providers',
+  /** Store/clear the MiniMax browser cookie. Write-only: there is no channel that reads it back. */
+  usageSetMinimaxCookie: 'usage:set-minimax-cookie',
+  /** Whether a MiniMax cookie is stored — lets the UI show state without handling the value. */
+  usageHasMinimaxCookie: 'usage:has-minimax-cookie',
   contextUpdate: 'context:update',
   contextEnsure: 'context:ensure',
   // Team presence (docs/team-presence.md). `presence:hello` is a REQUEST: its response tells the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1026,6 +1026,11 @@ export interface UsageApi {
    *  `force` to bypass the cache debounce. Providers that aren't signed in come back
    *  'unavailable' rather than being omitted, so the caller can tell "off" from "broken". */
   providers(force?: boolean): Promise<ProviderUsage[]>
+  /** Store (or, with an empty string, clear) the MiniMax browser cookie. Resolves to whether one
+   *  is now stored. Write-only by design — nothing reads the value back across this boundary. */
+  setMinimaxCookie(cookie: string): Promise<boolean>
+  /** Whether a MiniMax cookie is stored, so the UI can show state without handling the secret. */
+  hasMinimaxCookie(): Promise<boolean>
   /** Fires whenever main pushes a new snapshot (poll/refresh). Returns unsubscribe. */
   onUpdate(listener: (usage: ClaudeUsage) => void): () => void
 }


### PR DESCRIPTION
Sixth provider. MiniMax exposes no CLI credential on disk — its quota lives behind the web console's session — so the user pastes their browser `Cookie` header into Settings and we replay it.

## The security decision

**orca stores this cookie in settings; this does not.**

It goes in its own file at `0600`. The distinction is one CLAUDE.md already draws for `claudeAccounts`: *an account list is config, a session cookie is a live bearer credential.* `settings.json` is written with default permissions and is the file users copy between machines and paste into bug reports. A credential that grants access to someone's MiniMax account does not belong in it.

The cookie is also **write-only across the IPC boundary**: the UI can set it, clear it, and ask *whether* one is stored — but no channel hands the value back. The settings input starts empty even when one is configured, and is cleared the moment it's handed over. A secret that never crosses the boundary can't be leaked by whatever reads it.

Both properties are tested (`0600` mode asserted; no `settings.json` written).

## Provider details worth keeping

- Reports what is **remaining**, like Gemini — so this inverts.
- The window is **pinned to the contracted 5h** rather than derived from `end_time - start_time`, which drifts below the bucket the plan sells (4h, 295 min). Same choice Codex's fallback durations make.
- A **browser User-Agent is required** — the endpoint rejects clients that don't look like one. Do not "clean up" the Firefox UA into a nodeterm agent string.
- An expired session arrives as a **non-zero `base_resp.status_code` inside an HTTP 200**, not a 401 — so that's the path a stale cookie actually takes. Reported as `unavailable`, not `error`: the user needs to paste a fresh cookie, which is the same "not signed in" story every other provider tells.
- `_token` is what authenticates, so a paste lacking it is rejected up front — turning a mystifying 401 into an obvious "you copied the wrong header".

Per-model entries ride in `scopeLabel` (same treatment as Claude's scoped caps and Gemini's buckets), and **every** model is emitted rather than one preferred pick — orca selects one because its shape has a single session slot to fill.

## Verified

227 files / 2298 tests pass; typecheck clean. With no cookie configured, the provider settles to `unavailable` without touching the network.

⚠️ **Unit-tested only** for the network path — no MiniMax session was available on the machine this was written on, so the response fixtures follow the documented field contract rather than a captured response. The storage half (0600, no read-back, clear-on-empty, corrupt-file tolerance) *is* fully exercised.

Remaining: opencode, which scrapes `opencode.ai` HTML — worth a conversation about whether that fragility is wanted, given it's the same failure mode that got the PTY tier cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)