### PR TITLE
feat: board log — per-person comments & activity history in the card modal

### DIFF
--- a/src/core/board-log-handlers.test.ts
+++ b/src/core/board-log-handlers.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { registerBoardLogHandlers, type BoardLogRoute, type BoardLogRouter } from './board-log-handlers'
+import { boardLogRemotePath, type RemoteLogExec } from './board-log'
+import { IPC } from '../shared/ipc'
+import type { BoardLogEntry, BoardLogReadResult } from '../shared/types'
+
+const entry = (over: Partial<BoardLogEntry> = {}): BoardLogEntry => ({
+  id: 'e1',
+  ts: 1000,
+  author: { name: 'enes', color: '#f00' },
+  kind: 'comment',
+  text: 'hello',
+  ...over
+})
+
+// A router that always returns a fixed route — most tests need only one project.
+const routerFor = (route: BoardLogRoute): BoardLogRouter => ({ route: () => route })
+
+const append = (f: FakePlatform, projectId: string, e: BoardLogEntry) =>
+  f.handlers[IPC.boardLogAppend](projectId, e) as Promise<boolean>
+const read = (f: FakePlatform, projectId: string, opts?: unknown) =>
+  f.handlers[IPC.boardLogRead](projectId, opts) as Promise<BoardLogReadResult>
+
+describe('registerBoardLogHandlers — routing', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-boardlog-h-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('local: append writes and read returns the entry newest-first', async () => {
+    const f = fakePlatform()
+    registerBoardLogHandlers(f, routerFor({ kind: 'local', cwd: dir }))
+    expect(await append(f, 'p1', entry({ id: 'a' }))).toBe(true)
+    expect(await append(f, 'p1', entry({ id: 'b' }))).toBe(true)
+    const res = await read(f, 'p1')
+    expect(res.unsupported).toBeUndefined()
+    expect(res.entries.map((e) => e.id)).toEqual(['b', 'a'])
+    // file is on disk under .nodeterm
+    expect(fs.existsSync(path.join(dir, '.nodeterm', 'board-log.jsonl'))).toBe(true)
+  })
+
+  it('unsupported: append resolves false, read returns { entries: [], unsupported: true }', async () => {
+    const f = fakePlatform()
+    registerBoardLogHandlers(f, routerFor({ kind: 'unsupported' }))
+    expect(await append(f, 'p1', entry())).toBe(false)
+    expect(await read(f, 'p1')).toEqual({ entries: [], unsupported: true })
+  })
+
+  it('remote: routes through the injected exec (append + tail)', async () => {
+    const store: string[] = []
+    const exec: RemoteLogExec = {
+      append: async (_p, line) => void store.push(line),
+      tail: async () => store.join('\n')
+    }
+    const f = fakePlatform()
+    registerBoardLogHandlers(f, routerFor({ kind: 'remote', remoteCwd: '/remote/cwd', exec, fingerprint: async () => '0' }))
+    expect(await append(f, 'p1', entry({ id: 'x' }))).toBe(true)
+    const res = await read(f, 'p1')
+    expect(res.entries.map((e) => e.id)).toEqual(['x'])
+  })
+
+  it('append never throws when the remote exec rejects → resolves false', async () => {
+    const exec: RemoteLogExec = {
+      append: async () => {
+        throw new Error('ssh down')
+      },
+      tail: async () => ''
+    }
+    const f = fakePlatform()
+    registerBoardLogHandlers(f, routerFor({ kind: 'remote', remoteCwd: '/r', exec, fingerprint: async () => '0' }))
+    await expect(append(f, 'p1', entry())).resolves.toBe(false)
+  })
+})
+
+describe('registerBoardLogHandlers — change subscription', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-boardlog-h-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('local watch: broadcasts boardLogChanged on the project channel after an append', async () => {
+    const f = fakePlatform()
+    registerBoardLogHandlers(f, routerFor({ kind: 'local', cwd: dir }))
+    // A real project's .nodeterm dir exists (project.json lives there); the store watches that dir,
+    // so create it before subscribing (an initial append does that).
+    await append(f, 'p1', entry({ id: 'a' }))
+    f.listeners[IPC.boardLogSubscribe]('p1')
+    await append(f, 'p1', entry({ id: 'b' }))
+    // fs.watch is debounced 250ms in the store; give it margin
+    await new Promise((r) => setTimeout(r, 500))
+    const pushed = f.sent.filter((s) => s.channel === IPC.boardLogChanged('p1'))
+    expect(pushed.length).toBeGreaterThanOrEqual(1)
+    f.listeners[IPC.boardLogUnsubscribe]('p1')
+  })
+
+  it('remote poll: broadcasts only when the fingerprint changes; stops on last unsubscribe', async () => {
+    vi.useFakeTimers()
+    try {
+      let fp = 'a'
+      const calls = { fingerprint: 0 }
+      const exec: RemoteLogExec = { append: async () => {}, tail: async () => '' }
+      const f = fakePlatform()
+      registerBoardLogHandlers(
+        f,
+        routerFor({
+          kind: 'remote',
+          remoteCwd: '/r',
+          exec,
+          fingerprint: async () => {
+            calls.fingerprint++
+            return fp
+          }
+        })
+      )
+      // two subscribers, ref-counted
+      f.listeners[IPC.boardLogSubscribe]('p1')
+      f.listeners[IPC.boardLogSubscribe]('p1')
+      await vi.advanceTimersByTimeAsync(0) // initial tick sets last = 'a' (no push)
+      expect(f.sent.filter((s) => s.channel === IPC.boardLogChanged('p1'))).toHaveLength(0)
+
+      fp = 'b'
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(f.sent.filter((s) => s.channel === IPC.boardLogChanged('p1'))).toHaveLength(1)
+
+      // one unsubscribe keeps the poll alive (count still 1)
+      f.listeners[IPC.boardLogUnsubscribe]('p1')
+      const before = calls.fingerprint
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(calls.fingerprint).toBeGreaterThan(before)
+
+      // last unsubscribe stops the poll: no further fingerprint calls
+      f.listeners[IPC.boardLogUnsubscribe]('p1')
+      const settled = calls.fingerprint
+      await vi.advanceTimersByTimeAsync(15000)
+      expect(calls.fingerprint).toBe(settled)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('boardLogRemotePath', () => {
+  it('joins cwd/.nodeterm/board-log.jsonl posix-style', () => {
+    expect(boardLogRemotePath('/home/u/proj')).toBe('/home/u/proj/.nodeterm/board-log.jsonl')
+    expect(boardLogRemotePath('~/proj/')).toBe('~/proj/.nodeterm/board-log.jsonl')
+  })
+})

--- a/src/core/board-log-handlers.ts
+++ b/src/core/board-log-handlers.ts
@@ -1,0 +1,106 @@
+import type { CorePlatform } from './platform'
+import { BoardLogStore, type RemoteLogExec } from './board-log'
+import { IPC } from '../shared/ipc'
+import type { BoardLogEntry, BoardLogReadOpts, BoardLogReadResult } from '../shared/types'
+
+// Board-log RPC surface, registered ONCE for every shell (Electron main + Server Edition) through
+// CorePlatform — the same seam fs-handlers.ts uses, so the two can never drift. The pure log I/O is
+// already in core/board-log.ts; this only wires request/response + the per-project change push, and
+// delegates the "where does this project's log live?" question to an injected BoardLogRouter (the one
+// piece that differs per shell: desktop resolves SSH connections, the server never does).
+
+/** Where a project's board log lives, resolved per call by the shell.
+ *  - `local`  → node:fs under `cwd/.nodeterm/board-log.jsonl`.
+ *  - `remote` → desktop SSH: `exec` does the append/tail over the ControlMaster; `fingerprint`
+ *               returns a cheap size/hash (`wc -c`) the change-poll compares every 5s.
+ *  - `unsupported` → inline/no-cwd canvas, a disconnected SSH project, or an SSH project on the
+ *               Server Edition (v1). Reads answer `{ entries: [], unsupported: true }`; appends `false`. */
+export type BoardLogRoute =
+  | { kind: 'local'; cwd: string }
+  | { kind: 'remote'; remoteCwd: string; exec: RemoteLogExec; fingerprint: () => Promise<string> }
+  | { kind: 'unsupported' }
+
+export interface BoardLogRouter {
+  route(projectId: string): BoardLogRoute
+}
+
+const POLL_MS = 5000
+
+/** Registers boardLogAppend / boardLogRead / boardLogSubscribe / boardLogUnsubscribe and drives the
+ *  per-project `boardLogChanged` push. Ref-counted per project: the first subscriber starts a watch
+ *  (local fs.watch) or a poll (desktop SSH), the last one stops it. */
+export function registerBoardLogHandlers(platform: CorePlatform, router: BoardLogRouter): void {
+  const localStore = new BoardLogStore({})
+
+  platform.handle(IPC.boardLogAppend, async (projectId: string, entry: BoardLogEntry): Promise<boolean> => {
+    const r = router.route(projectId)
+    if (r.kind === 'local') return localStore.append(r.cwd, entry)
+    if (r.kind === 'remote') return new BoardLogStore({ remote: r.exec }).append(r.remoteCwd, entry)
+    return false
+  })
+
+  platform.handle(
+    IPC.boardLogRead,
+    async (projectId: string, opts?: BoardLogReadOpts): Promise<BoardLogReadResult> => {
+      const r = router.route(projectId)
+      if (r.kind === 'local') return { entries: await localStore.read(r.cwd, opts) }
+      if (r.kind === 'remote')
+        return { entries: await new BoardLogStore({ remote: r.exec }).read(r.remoteCwd, opts) }
+      return { entries: [], unsupported: true }
+    }
+  )
+
+  // Change subscription, ref-counted per project id (the renderer subscribes/unsubscribes as its
+  // board panel mounts/unmounts; a leaked subscription is at worst one idle fs.watch/poll).
+  interface Sub {
+    count: number
+    stop: () => void
+  }
+  const subs = new Map<string, Sub>()
+
+  const startWatch = (projectId: string): (() => void) => {
+    const emit = (): void => platform.broadcast(IPC.boardLogChanged(projectId), projectId)
+    const r = router.route(projectId)
+    if (r.kind === 'local') return localStore.watch(r.cwd, emit)
+    if (r.kind === 'remote') {
+      let last: string | undefined
+      let alive = true
+      const tick = async (): Promise<void> => {
+        if (!alive) return
+        try {
+          const fp = await r.fingerprint()
+          if (last !== undefined && fp !== last) emit()
+          last = fp
+        } catch {
+          /* transient ssh failure: keep the last fingerprint, retry next tick */
+        }
+      }
+      void tick()
+      const timer = setInterval(() => void tick(), POLL_MS)
+      return () => {
+        alive = false
+        clearInterval(timer)
+      }
+    }
+    return () => {}
+  }
+
+  platform.on(IPC.boardLogSubscribe, (projectId: string) => {
+    const existing = subs.get(projectId)
+    if (existing) {
+      existing.count++
+      return
+    }
+    subs.set(projectId, { count: 1, stop: startWatch(projectId) })
+  })
+
+  platform.on(IPC.boardLogUnsubscribe, (projectId: string) => {
+    const existing = subs.get(projectId)
+    if (!existing) return
+    existing.count--
+    if (existing.count <= 0) {
+      existing.stop()
+      subs.delete(projectId)
+    }
+  })
+}

--- a/src/core/board-log.test.ts
+++ b/src/core/board-log.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import type { BoardLogEntry } from '@shared/types'
+import { buildLine, parseLines, validEntry, BoardLogStore, type RemoteLogExec } from './board-log'
+
+const entry = (over: Partial<BoardLogEntry> = {}): BoardLogEntry => ({
+  id: 'e1',
+  ts: 1000,
+  author: { name: 'enes', color: '#f00' },
+  kind: 'comment',
+  text: 'hello',
+  ...over
+})
+
+describe('buildLine / parseLines / validEntry', () => {
+  it('buildLine is single-line JSON + newline, round-trips through parseLines', () => {
+    const e = entry({ text: 'line one\nline two' }) // newline in text is JSON-escaped, stays one line
+    const line = buildLine(e)
+    expect(line.endsWith('\n')).toBe(true)
+    expect(line.slice(0, -1).includes('\n')).toBe(false)
+    expect(parseLines(line)).toEqual([e])
+  })
+
+  it('parseLines is tolerant: skips a garbage line, keeps the valid one', () => {
+    const good = buildLine(entry({ id: 'ok' }))
+    const raw = 'not json\n' + '{"missing":"fields"}\n' + good
+    expect(parseLines(raw)).toEqual([entry({ id: 'ok' })])
+  })
+
+  it('parseLines is newest-first and capped at 500 by default; all:true returns everything', () => {
+    const raw = Array.from({ length: 600 }, (_, i) => buildLine(entry({ id: `e${i}`, ts: i }))).join('')
+    const capped = parseLines(raw)
+    expect(capped).toHaveLength(500)
+    expect(capped[0].id).toBe('e599') // newest first
+    expect(capped[499].id).toBe('e100')
+    expect(parseLines(raw, { all: true })).toHaveLength(600)
+    expect(parseLines(raw, { cap: 3 }).map((e) => e.id)).toEqual(['e599', 'e598', 'e597'])
+  })
+
+  it('validEntry accepts a comment and an event entry, rejects malformed shapes', () => {
+    expect(validEntry(entry())).toBe(true)
+    expect(validEntry(entry({ kind: 'event', text: undefined, event: { type: 'card-moved', from: 'a', to: 'b' } }))).toBe(true)
+    expect(validEntry(null)).toBe(false)
+    expect(validEntry({ id: 1, ts: 0, author: { name: 'x', color: 'y' }, kind: 'comment' })).toBe(false)
+    expect(validEntry({ id: 'x', ts: 'no', author: { name: 'x', color: 'y' }, kind: 'comment' })).toBe(false)
+    expect(validEntry({ id: 'x', ts: 0, author: { name: 'x' }, kind: 'comment' })).toBe(false)
+    expect(validEntry({ id: 'x', ts: 0, author: { name: 'x', color: 'y' }, kind: 'nope' })).toBe(false)
+  })
+})
+
+describe('BoardLogStore (local fs)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'board-log-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('append writes to <cwd>/.nodeterm/board-log.jsonl and read returns newest-first', async () => {
+    const store = new BoardLogStore({})
+    expect(await store.append(dir, entry({ id: 'a', ts: 1 }))).toBe(true)
+    expect(await store.append(dir, entry({ id: 'b', ts: 2 }))).toBe(true)
+    expect(fs.existsSync(path.join(dir, '.nodeterm', 'board-log.jsonl'))).toBe(true)
+    const got = await store.read(dir)
+    expect(got.map((e) => e.id)).toEqual(['b', 'a'])
+  })
+
+  it('read returns [] when the log file does not exist', async () => {
+    expect(await new BoardLogStore({}).read(dir)).toEqual([])
+  })
+
+  it('append never throws and returns false when the path is unwritable', async () => {
+    // A regular file where the cwd should be → mkdir(<file>/.nodeterm) fails with ENOTDIR.
+    const file = path.join(dir, 'not-a-dir')
+    fs.writeFileSync(file, 'x')
+    await expect(new BoardLogStore({}).append(file, entry())).resolves.toBe(false)
+  })
+
+  it('watch fires (debounced) when the log changes, and the returned unsub stops it', async () => {
+    const store = new BoardLogStore({})
+    await store.append(dir, entry({ id: 'seed' }))
+    let hits = 0
+    const unsub = store.watch(dir, () => {
+      hits++
+    })
+    await store.append(dir, entry({ id: 'later' }))
+    await new Promise((r) => setTimeout(r, 500))
+    unsub()
+    expect(hits).toBeGreaterThanOrEqual(1)
+    const after = hits
+    await store.append(dir, entry({ id: 'after-unsub' }))
+    await new Promise((r) => setTimeout(r, 400))
+    expect(hits).toBe(after)
+  })
+})
+
+describe('BoardLogStore (remote exec injected)', () => {
+  it('append passes the newline-free JSON line to remote.append; read tails and parses', async () => {
+    const appended: Array<{ path: string; line: string }> = []
+    let tailReq: { path: string; lines: number } | undefined
+    const raw = buildLine(entry({ id: 'r1', ts: 1 })) + buildLine(entry({ id: 'r2', ts: 2 }))
+    const remote: RemoteLogExec = {
+      append: async (p, line) => {
+        appended.push({ path: p, line })
+      },
+      tail: async (p, lines) => {
+        tailReq = { path: p, lines }
+        return raw
+      }
+    }
+    const store = new BoardLogStore({ remote })
+    expect(await store.append('/srv/proj', entry({ id: 'r2', ts: 2 }))).toBe(true)
+    expect(appended[0].path).toBe('/srv/proj/.nodeterm/board-log.jsonl')
+    expect(appended[0].line.includes('\n')).toBe(false) // printf adds the newline remote-side
+    const got = await store.read('/srv/proj', { cap: 10 })
+    expect(tailReq).toEqual({ path: '/srv/proj/.nodeterm/board-log.jsonl', lines: 10 })
+    expect(got.map((e) => e.id)).toEqual(['r2', 'r1'])
+  })
+
+  it('remote append returns false when the exec rejects; watch is a no-op unsub', async () => {
+    const remote: RemoteLogExec = {
+      append: async () => {
+        throw new Error('ssh down')
+      },
+      tail: async () => ''
+    }
+    const store = new BoardLogStore({ remote })
+    expect(await store.append('/srv/proj', entry())).toBe(false)
+    expect(typeof store.watch('/srv/proj', () => {})).toBe('function')
+  })
+})

--- a/src/core/board-log.test.ts
+++ b/src/core/board-log.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import type { BoardLogEntry } from '@shared/types'
-import { buildLine, parseLines, validEntry, BoardLogStore, type RemoteLogExec } from './board-log'
+import { buildLine, parseLines, validEntry, BoardLogStore, BOARD_LOG_TEXT_MAX, type RemoteLogExec } from './board-log'
 
 const entry = (over: Partial<BoardLogEntry> = {}): BoardLogEntry => ({
   id: 'e1',
@@ -21,6 +21,19 @@ describe('buildLine / parseLines / validEntry', () => {
     expect(line.endsWith('\n')).toBe(true)
     expect(line.slice(0, -1).includes('\n')).toBe(false)
     expect(parseLines(line)).toEqual([e])
+  })
+
+  it('buildLine clamps over-long text to BOARD_LOG_TEXT_MAX chars + ellipsis, line stays valid JSON', () => {
+    const long = 'x'.repeat(BOARD_LOG_TEXT_MAX + 5000)
+    const line = buildLine(entry({ id: 'big', text: long }))
+    expect(line.endsWith('\n')).toBe(true)
+    const parsed = JSON.parse(line.slice(0, -1)) as BoardLogEntry // valid single-line JSON
+    expect(parsed.text).toHaveLength(BOARD_LOG_TEXT_MAX + 1) // cap chars + the '…'
+    expect(parsed.text!.endsWith('…')).toBe(true)
+    expect(parsed.text!.slice(0, -1)).toBe('x'.repeat(BOARD_LOG_TEXT_MAX))
+    // Text exactly at the cap is left untouched (no ellipsis).
+    const exact = 'y'.repeat(BOARD_LOG_TEXT_MAX)
+    expect((JSON.parse(buildLine(entry({ text: exact })).slice(0, -1)) as BoardLogEntry).text).toBe(exact)
   })
 
   it('parseLines is tolerant: skips a garbage line, keeps the valid one', () => {

--- a/src/core/board-log.ts
+++ b/src/core/board-log.ts
@@ -1,0 +1,149 @@
+import fs from 'fs'
+import path from 'path'
+import { watch, type FSWatcher } from 'fs'
+import type { BoardLogEntry } from '@shared/types'
+
+// Append-only board history. Each project's board log lives beside its nodes at
+// `<cwd>/.nodeterm/board-log.jsonl`, one JSON entry per line, oldest-first on disk. Local
+// projects use node:fs directly; SSH projects go through an injected RemoteLogExec (the seam
+// that keeps this file electron-free — the ssh command builders live in main/ssh-fs.ts). The
+// pure line build/parse helpers are exported so the diff/renderer can reason about entries.
+
+const LOG_DIR = '.nodeterm'
+const LOG_FILE = 'board-log.jsonl'
+const DEFAULT_CAP = 500
+// `all` still needs a finite tail count for the remote path; larger than any realistic log.
+const ALL_LINES = 1_000_000_000
+
+export interface ParseOpts {
+  cap?: number
+  all?: boolean
+}
+
+/** Remote (SSH) log I/O, injected so core stays electron-free. `line` has no trailing newline
+ *  (the remote `printf '%s\n'` adds it); `tail` returns the last `lines` lines, oldest-first. */
+export interface RemoteLogExec {
+  append(path: string, line: string): Promise<void>
+  tail(path: string, lines: number): Promise<string>
+}
+
+/** True when `x` is a structurally-valid BoardLogEntry. Tolerant callers use it to skip
+ *  corrupt/foreign lines rather than throwing the whole log away. */
+export function validEntry(x: unknown): x is BoardLogEntry {
+  if (!x || typeof x !== 'object') return false
+  const e = x as Record<string, unknown>
+  if (typeof e.id !== 'string' || typeof e.ts !== 'number') return false
+  const a = e.author as Record<string, unknown> | undefined
+  if (!a || typeof a !== 'object' || typeof a.name !== 'string' || typeof a.color !== 'string') return false
+  if (e.kind !== 'comment' && e.kind !== 'event') return false
+  if (e.nodeId !== undefined && typeof e.nodeId !== 'string') return false
+  if (e.text !== undefined && typeof e.text !== 'string') return false
+  if (e.event !== undefined && (typeof e.event !== 'object' || e.event === null)) return false
+  return true
+}
+
+/** One log line: single-line JSON + '\n'. Any newline in `text` is JSON-escaped, so the line
+ *  never breaks the one-entry-per-line invariant. */
+export function buildLine(entry: BoardLogEntry): string {
+  return JSON.stringify(entry) + '\n'
+}
+
+/** Parse a raw log blob → entries, NEWEST-FIRST. Tolerant: lines that fail JSON.parse or the
+ *  shape check are skipped. Capped at `cap` (default 500) unless `all` is set. */
+export function parseLines(raw: string, opts: ParseOpts = {}): BoardLogEntry[] {
+  const out: BoardLogEntry[] = []
+  for (const line of raw.split('\n')) {
+    const t = line.trim()
+    if (!t) continue
+    let obj: unknown
+    try {
+      obj = JSON.parse(t)
+    } catch {
+      continue
+    }
+    if (validEntry(obj)) out.push(obj)
+  }
+  out.reverse() // disk is oldest-first; callers want newest-first
+  if (opts.all) return out
+  return out.slice(0, opts.cap ?? DEFAULT_CAP)
+}
+
+function posixJoin(cwd: string, ...parts: string[]): string {
+  return [cwd.replace(/\/+$/, ''), ...parts].join('/')
+}
+
+export class BoardLogStore {
+  private remote?: RemoteLogExec
+  constructor(opts: { remote?: RemoteLogExec }) {
+    this.remote = opts.remote
+  }
+
+  private localPath(cwd: string): string {
+    return path.join(cwd, LOG_DIR, LOG_FILE)
+  }
+  private remotePath(cwd: string): string {
+    return posixJoin(cwd, LOG_DIR, LOG_FILE)
+  }
+
+  /** Append one entry. Fire-and-forget-safe: never throws — returns false on any fs/exec error. */
+  async append(cwd: string, entry: BoardLogEntry): Promise<boolean> {
+    const line = buildLine(entry)
+    if (this.remote) {
+      try {
+        await this.remote.append(this.remotePath(cwd), line.replace(/\n$/, ''))
+        return true
+      } catch {
+        return false
+      }
+    }
+    try {
+      fs.mkdirSync(path.join(cwd, LOG_DIR), { recursive: true })
+      fs.appendFileSync(this.localPath(cwd), line)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /** Read the log, newest-first (see parseLines). Missing file / failed read → []. */
+  async read(cwd: string, opts: ParseOpts = {}): Promise<BoardLogEntry[]> {
+    if (this.remote) {
+      try {
+        const raw = await this.remote.tail(this.remotePath(cwd), opts.all ? ALL_LINES : opts.cap ?? DEFAULT_CAP)
+        return parseLines(raw, opts)
+      } catch {
+        return []
+      }
+    }
+    let raw: string
+    try {
+      raw = await fs.promises.readFile(this.localPath(cwd), 'utf-8')
+    } catch {
+      return []
+    }
+    return parseLines(raw, opts)
+  }
+
+  /** Watch the log for changes; `cb` fires (debounced 250ms) on each change. Returns an unsub.
+   *  Watches the `.nodeterm` dir (tolerant of the log file not existing yet); remote → no-op. */
+  watch(cwd: string, cb: () => void): () => void {
+    if (this.remote) return () => {}
+    const dir = path.join(cwd, LOG_DIR)
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let watcher: FSWatcher
+    try {
+      watcher = watch(dir, (_event, filename) => {
+        if (filename && filename !== LOG_FILE) return
+        clearTimeout(timer)
+        timer = setTimeout(cb, 250)
+      })
+      watcher.on('error', () => {})
+    } catch {
+      return () => {}
+    }
+    return () => {
+      clearTimeout(timer)
+      watcher.close()
+    }
+  }
+}

--- a/src/core/board-log.ts
+++ b/src/core/board-log.ts
@@ -72,6 +72,12 @@ function posixJoin(cwd: string, ...parts: string[]): string {
   return [cwd.replace(/\/+$/, ''), ...parts].join('/')
 }
 
+/** The remote (POSIX) path of a project's board log under `cwd`. Exported so the desktop SSH
+ *  change-poll can fingerprint the same file the store's RemoteLogExec reads/writes. */
+export function boardLogRemotePath(cwd: string): string {
+  return posixJoin(cwd, LOG_DIR, LOG_FILE)
+}
+
 export class BoardLogStore {
   private remote?: RemoteLogExec
   constructor(opts: { remote?: RemoteLogExec }) {
@@ -82,7 +88,7 @@ export class BoardLogStore {
     return path.join(cwd, LOG_DIR, LOG_FILE)
   }
   private remotePath(cwd: string): string {
-    return posixJoin(cwd, LOG_DIR, LOG_FILE)
+    return boardLogRemotePath(cwd)
   }
 
   /** Append one entry. Fire-and-forget-safe: never throws — returns false on any fs/exec error. */

--- a/src/core/board-log.ts
+++ b/src/core/board-log.ts
@@ -1,7 +1,10 @@
 import fs from 'fs'
 import path from 'path'
 import { watch, type FSWatcher } from 'fs'
-import type { BoardLogEntry } from '@shared/types'
+import { BOARD_LOG_TEXT_MAX, type BoardLogEntry } from '@shared/types'
+
+// Re-exported so callers of this module (and its tests) can reach the cap alongside buildLine.
+export { BOARD_LOG_TEXT_MAX }
 
 // Append-only board history. Each project's board log lives beside its nodes at
 // `<cwd>/.nodeterm/board-log.jsonl`, one JSON entry per line, oldest-first on disk. Local
@@ -12,6 +15,14 @@ import type { BoardLogEntry } from '@shared/types'
 const LOG_DIR = '.nodeterm'
 const LOG_FILE = 'board-log.jsonl'
 const DEFAULT_CAP = 500
+
+/** Clamp an entry's `text` to `BOARD_LOG_TEXT_MAX` chars (+ '…' when truncated). Returns the
+ *  same entry when nothing changes, else a shallow copy with the shortened text. */
+export function clampEntryText(entry: BoardLogEntry): BoardLogEntry {
+  const { text } = entry
+  if (typeof text !== 'string' || text.length <= BOARD_LOG_TEXT_MAX) return entry
+  return { ...entry, text: text.slice(0, BOARD_LOG_TEXT_MAX) + '…' }
+}
 // `all` still needs a finite tail count for the remote path; larger than any realistic log.
 const ALL_LINES = 1_000_000_000
 
@@ -45,7 +56,7 @@ export function validEntry(x: unknown): x is BoardLogEntry {
 /** One log line: single-line JSON + '\n'. Any newline in `text` is JSON-escaped, so the line
  *  never breaks the one-entry-per-line invariant. */
 export function buildLine(entry: BoardLogEntry): string {
-  return JSON.stringify(entry) + '\n'
+  return JSON.stringify(clampEntryText(entry)) + '\n'
 }
 
 /** Parse a raw log blob → entries, NEWEST-FIRST. Tolerant: lines that fail JSON.parse or the

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -363,6 +363,12 @@ export class WorkspaceStore {
     return (this.index?.entries ?? []).filter((e) => e.ssh).map((e) => e.id)
   }
 
+  /** The local folder cwd of a project by id (index lookup), or undefined for ssh/inline/unknown
+   *  projects. Sync (reads the in-memory index): the board-log router's local-vs-unsupported call. */
+  localCwdForProject(projectId: string): string | undefined {
+    return this.index?.entries.find((e) => e.id === projectId && e.cwd)?.cwd
+  }
+
   /** The local ref cwds of the current index — the workspace half of the phone bridge's fs/git
    *  jail. The phone browses EVERY project over `projects.list`, so jailing to only the active
    *  canvas's node cwds denied any project the desktop didn't happen to have focused. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,9 @@ import { randomUUID } from 'crypto'
 import { app, BrowserWindow, dialog, ipcMain, Notification, powerMonitor, shell, systemPreferences } from 'electron'
 import { IPC } from '../shared/ipc'
 import { registerFsHandlers } from '../core/fs-handlers'
+import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
+import type { RemoteLogExec } from '../core/board-log'
+import { boardLogRemotePath } from '../core/board-log'
 import { PtyManager } from '../core/pty-manager'
 import { WorkspaceStore } from '../core/workspace-store'
 import { WorkspaceWatcher } from '../core/workspace-watcher'
@@ -92,7 +95,7 @@ import { decodeOffer } from './remote/pairing'
 import { loadOrCreatePeerKeyPair } from './remote/peer-identity'
 import { initSshProject } from './remote-ssh/ssh-project'
 import { setGitRemoteResolver, type GitRemoteRef } from '../core/remote-ssh/remote-git'
-import { SshFs } from './ssh-fs'
+import { SshFs, sshAppendArgs, sshTailArgs, sshSizeArgs } from './ssh-fs'
 import { makeRemoteWorkspaceIO } from './remote-workspace-io'
 import {
   registerMediaScheme,
@@ -645,6 +648,40 @@ app.whenReady().then(async () => {
   ipcMain.handle(IPC.sshFsExists, (_e, projectId: string, p: string) => {
     const ref = sshFsRefFor(projectId)
     return ref ? sshFs.exists(ref, p) : Promise.resolve(false)
+  })
+
+  // Board-log: same CorePlatform registrar as the Server Edition (core/board-log-handlers.ts), with
+  // a desktop router that adds SSH routing on top of the local-cwd/unsupported the server also does.
+  // A connected SSH project (refForProject → a ref with a remoteCwd) reads/writes/fingerprints over
+  // its ControlMaster; anything else falls to the local folder cwd, then unsupported.
+  registerBoardLogHandlers(corePlatform, {
+    route: (projectId: string): BoardLogRoute => {
+      const ref = sshProjectManager?.refForProject(projectId)
+      if (ref?.remoteCwd) {
+        const run = (args: string[], stdin?: string) =>
+          sshProjectManager!.sshRun(args, stdin)
+        const exec: RemoteLogExec = {
+          append: async (p, line) => {
+            const { code } = await run(sshAppendArgs(ref.conn, ref.controlPath, p, line))
+            if (code !== 0) throw new Error('board-log ssh append failed')
+          },
+          tail: async (p, lines) => {
+            const { code, stdout } = await run(sshTailArgs(ref.conn, ref.controlPath, p, lines))
+            return code === 0 ? stdout : ''
+          }
+        }
+        const remotePath = boardLogRemotePath(ref.remoteCwd)
+        const fingerprint = async (): Promise<string> => {
+          const { code, stdout } = await run(sshSizeArgs(ref.conn, ref.controlPath, remotePath))
+          if (code !== 0) throw new Error('board-log ssh fingerprint failed')
+          return stdout.trim()
+        }
+        return { kind: 'remote', remoteCwd: ref.remoteCwd, exec, fingerprint }
+      }
+      const cwd = workspaceStore.localCwdForProject(projectId)
+      if (cwd) return { kind: 'local', cwd }
+      return { kind: 'unsupported' }
+    }
   })
 
   ipcMain.handle(IPC.dialogSelectFolder, async () => {

--- a/src/main/ssh-fs.test.ts
+++ b/src/main/ssh-fs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { sshListArgs, sshReadArgs, sshReadBinaryArgs, sshWriteArgs, sshMkdirArgs, sshExistsArgs, sshCheckIgnoreArgs, sshAppendArgs, sshTailArgs, parseLsEntries, SshFs } from './ssh-fs'
+import { sshListArgs, sshReadArgs, sshReadBinaryArgs, sshWriteArgs, sshMkdirArgs, sshExistsArgs, sshCheckIgnoreArgs, sshAppendArgs, sshTailArgs, sshSizeArgs, parseLsEntries, SshFs } from './ssh-fs'
 
 const conn = { host: 'h', user: 'u' }
 const ref = { conn, controlPath: '/s.sock' }
@@ -59,6 +59,13 @@ describe('ssh-fs arg builders', () => {
   })
   it('tail leaves a leading ~/ unquoted and coerces the line count to a safe integer', () => {
     expect(sshTailArgs(conn, '/s', '~/p/log', 12.9).join(' ')).toContain(`tail -n 12 ~/'p/log'`)
+  })
+  it('size runs `cat | wc -c` on the quoted path (quiet + 0 on a missing file)', () => {
+    const j = sshSizeArgs(conn, '/s.sock', '/a b/log.jsonl').join(' ')
+    expect(j).toContain(`cat '/a b/log.jsonl' 2>/dev/null | wc -c`)
+  })
+  it('size leaves a leading ~/ unquoted so the remote shell tilde-expands the path', () => {
+    expect(sshSizeArgs(conn, '/s', '~/p/log.jsonl').join(' ')).toContain(`cat ~/'p/log.jsonl' 2>/dev/null | wc -c`)
   })
   it('exists runs test -e on the quoted path', () => {
     expect(sshExistsArgs(conn, '/s.sock', '/a b/c').join(' ')).toContain(`test -e '/a b/c'`)

--- a/src/main/ssh-fs.test.ts
+++ b/src/main/ssh-fs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { sshListArgs, sshReadArgs, sshReadBinaryArgs, sshWriteArgs, sshMkdirArgs, sshExistsArgs, sshCheckIgnoreArgs, parseLsEntries, SshFs } from './ssh-fs'
+import { sshListArgs, sshReadArgs, sshReadBinaryArgs, sshWriteArgs, sshMkdirArgs, sshExistsArgs, sshCheckIgnoreArgs, sshAppendArgs, sshTailArgs, parseLsEntries, SshFs } from './ssh-fs'
 
 const conn = { host: 'h', user: 'u' }
 const ref = { conn, controlPath: '/s.sock' }
@@ -39,6 +39,26 @@ describe('ssh-fs arg builders', () => {
   })
   it('mkdir leaves a leading ~/ unquoted so the remote shell tilde-expands the path', () => {
     expect(sshMkdirArgs(conn, '/s', '~/projects/new').join(' ')).toContain(`mkdir -p ~/'projects/new'`)
+  })
+  it('append mkdir -p the dirname, printf %s\\n the single-quoted line, >> the quoted path', () => {
+    const j = sshAppendArgs(conn, '/s.sock', '/d/e/log.jsonl', '{"id":"a"}').join(' ')
+    expect(j).toContain(`mkdir -p '/d/e'`)
+    expect(j).toContain("printf '%s\\n' '{\"id\":\"a\"}'")
+    expect(j).toContain(`>> '/d/e/log.jsonl'`)
+  })
+  it('append single-quote-escapes a quote in the line content', () => {
+    expect(sshAppendArgs(conn, '/s', '/d/log', `{"t":"a'b"}`).join(' ')).toContain(`printf '%s\\n' '{"t":"a'\\''b"}'`)
+  })
+  it('append leaves a leading ~/ unquoted for the mkdir dirname and the >> target', () => {
+    const j = sshAppendArgs(conn, '/s', '~/p/log.jsonl', 'L').join(' ')
+    expect(j).toContain(`mkdir -p ~/'p'`)
+    expect(j).toContain(`>> ~/'p/log.jsonl'`)
+  })
+  it('tail runs tail -n <lines> on the quoted path', () => {
+    expect(sshTailArgs(conn, '/s.sock', '/a b/log', 500).join(' ')).toContain(`tail -n 500 '/a b/log'`)
+  })
+  it('tail leaves a leading ~/ unquoted and coerces the line count to a safe integer', () => {
+    expect(sshTailArgs(conn, '/s', '~/p/log', 12.9).join(' ')).toContain(`tail -n 12 ~/'p/log'`)
   })
   it('exists runs test -e on the quoted path', () => {
     expect(sshExistsArgs(conn, '/s.sock', '/a b/c').join(' ')).toContain(`test -e '/a b/c'`)

--- a/src/main/ssh-fs.ts
+++ b/src/main/ssh-fs.ts
@@ -51,6 +51,12 @@ export function sshAppendArgs(conn: SshConnection, cp: string, path: string, lin
 export function sshTailArgs(conn: SshConnection, cp: string, path: string, lines: number): string[] {
   return childArgs(conn, cp, `tail -n ${Math.max(0, Math.trunc(lines))} ${quoteRemotePath(path)}`)
 }
+export function sshSizeArgs(conn: SshConnection, cp: string, path: string): string[] {
+  // A cheap change fingerprint for the board-log poll: the byte size of the file, or `0` when it
+  // does not exist yet. `cat | wc -c` (not `wc -c < file`) stays quiet + prints 0 on a missing file
+  // instead of erroring, so the poll never mistakes "not there yet" for a failure.
+  return childArgs(conn, cp, `cat ${quoteRemotePath(path)} 2>/dev/null | wc -c`)
+}
 export function sshExistsArgs(conn: SshConnection, cp: string, path: string): string[] {
   return childArgs(conn, cp, `test -e ${quoteRemotePath(path)}`)
 }

--- a/src/main/ssh-fs.ts
+++ b/src/main/ssh-fs.ts
@@ -38,6 +38,19 @@ export function sshWriteArgs(conn: SshConnection, cp: string, path: string): str
 export function sshMkdirArgs(conn: SshConnection, cp: string, path: string): string[] {
   return childArgs(conn, cp, `mkdir -p ${quoteRemotePath(path)}`)
 }
+export function sshAppendArgs(conn: SshConnection, cp: string, path: string, line: string): string[] {
+  // Append one board-log line. `printf '%s\n'` (never `echo`) supplies the trailing newline and
+  // treats the line literally — the JSON content is posixQuote'd, so a `%`/backslash/quote in it
+  // is inert. mkdir -p keeps the first append on a fresh clone from failing.
+  return childArgs(
+    conn,
+    cp,
+    `mkdir -p ${quoteRemotePath(dirname(path))} && printf '%s\\n' ${posixQuote(line)} >> ${quoteRemotePath(path)}`
+  )
+}
+export function sshTailArgs(conn: SshConnection, cp: string, path: string, lines: number): string[] {
+  return childArgs(conn, cp, `tail -n ${Math.max(0, Math.trunc(lines))} ${quoteRemotePath(path)}`)
+}
 export function sshExistsArgs(conn: SshConnection, cp: string, path: string): string[] {
   return childArgs(conn, cp, `test -e ${quoteRemotePath(path)}`)
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -480,6 +480,20 @@ const api: NodeTerminalApi = {
     setLinks: (map) => ipcRenderer.invoke(IPC.contextLinkSetLinks, map),
     info: () => ipcRenderer.invoke(IPC.contextLinkInfo)
   },
+  boardLog: {
+    append: (projectId, entry) => ipcRenderer.invoke(IPC.boardLogAppend, projectId, entry),
+    read: (projectId, opts) => ipcRenderer.invoke(IPC.boardLogRead, projectId, opts),
+    onChanged: (projectId, cb) => {
+      const ch = IPC.boardLogChanged(projectId)
+      const handler = (): void => cb()
+      ipcRenderer.on(ch, handler)
+      ipcRenderer.send(IPC.boardLogSubscribe, projectId)
+      return () => {
+        ipcRenderer.removeListener(ch, handler)
+        ipcRenderer.send(IPC.boardLogUnsubscribe, projectId)
+      }
+    }
+  },
   // Per-node subscriptions (each terminal/editor listens) — multiplexed so they don't pile up
   // ipcRenderer listeners and trip the MaxListeners warning.
   onMarkdownToggle: subscribe(IPC.appToggleMarkdown),

--- a/src/renderer/bridge/relay-api.ts
+++ b/src/renderer/bridge/relay-api.ts
@@ -124,8 +124,8 @@ export function buildRelayApi(connectionId: string, transport?: FrameTransport):
     //    silent no-op): ──
     // The SDK chat node has no relay chat builder yet (the Server Edition defers it too). Routing to
     // the local chat driver would run it on the WRONG machine (a host cwd that does not exist
-    // locally), so refuse with E_UNSUPPORTED instead. contextLink / transcripts / handoff stay LOCAL
-    // by way of `...local` (a v1 degrade: they read/write on this machine, not the host).
+    // locally), so refuse with E_UNSUPPORTED instead. contextLink / transcripts / handoff / boardLog
+    // stay LOCAL by way of `...local` (a v1 degrade: they read/write on this machine, not the host).
     chat: stub.chat,
     // Agent canvas-control (`agent:control`) is not wired over the relay (matches the Server
     // Edition); inert no-ops rather than a local subscription that never carries the host's events.

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -11,7 +11,7 @@
 // benign value, and everything else rejects with a coded error.
 //
 // The object is `satisfies Omit<NodeTerminalApi, 'pty' | 'workspace' | 'settings' | 'fs' | 'git'
-// | 'files' | 'context' | 'dialog'>`, so the TypeScript compiler is the completeness test: if
+// | 'files' | 'context' | 'boardLog' | 'dialog'>`, so the TypeScript compiler is the completeness test: if
 // `NodeTerminalApi` gains a member, this file fails to typecheck until the stub is declared.
 
 import {
@@ -110,6 +110,7 @@ export function buildStubApi(): Omit<
   | 'git'
   | 'files'
   | 'context'
+  | 'boardLog'
   | 'canvas'
   | 'dialog'
   | 'onAgentStatus'
@@ -329,6 +330,7 @@ export function buildStubApi(): Omit<
     | 'git'
     | 'files'
     | 'context'
+    | 'boardLog'
     | 'canvas'
     | 'dialog'
     | 'onAgentStatus'

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -16,6 +16,8 @@ import {
 import { IPC } from '../../shared/ipc'
 import {
   UNKNOWN_CLAUDE_CLI_CAPS,
+  type BoardLogApi,
+  type BoardLogReadResult,
   type ClaudeApi,
   type ClaudeCliCaps,
   type ContextApi,
@@ -279,7 +281,7 @@ export function buildRealApi(
  */
 export function buildFilesApi(
   client: RpcClient
-): Pick<NodeTerminalApi, 'fs' | 'git' | 'files' | 'context'> {
+): Pick<NodeTerminalApi, 'fs' | 'git' | 'files' | 'context' | 'boardLog'> {
   const fs: FsApi = {
     list: (dirPath) => client.request(IPC.fsList, dirPath) as ReturnType<FsApi['list']>,
     read: (filePath) => client.request(IPC.fsRead, filePath) as Promise<string>,
@@ -384,7 +386,25 @@ export function buildFilesApi(
       client.cast(IPC.contextEnsure, sessionId, cwd, accountId)
   }
 
-  return { fs, git, files, context }
+  // Board-log: REAL over the bridge for local projects (the server routes local; SSH projects on the
+  // server answer `unsupported`). `onChanged` is `.on` → subscribe, plus the ref-counted cast pair the
+  // preload sends so the server starts/stops watching this project's log.
+  const boardLog: BoardLogApi = {
+    append: (projectId, entry) =>
+      client.request(IPC.boardLogAppend, projectId, entry) as Promise<boolean>,
+    read: (projectId, opts) =>
+      client.request(IPC.boardLogRead, projectId, opts) as Promise<BoardLogReadResult>,
+    onChanged: (projectId, cb) => {
+      const unsub = client.subscribe(IPC.boardLogChanged(projectId), cb as Listener)
+      client.cast(IPC.boardLogSubscribe, projectId)
+      return () => {
+        unsub()
+        client.cast(IPC.boardLogUnsubscribe, projectId)
+      }
+    }
+  }
+
+  return { fs, git, files, context, boardLog }
 }
 
 /**

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -181,8 +181,10 @@ import { useEntitlement } from '../state/entitlement'
 import type { SshServer, SshConnection } from '@shared/ssh'
 import { sshHostKey } from '@shared/ssh'
 import type { CanvasNodeState, Project, ProjectKanban, SshProjectStatus, TranscriptHit } from '@shared/types'
-import { KanbanView, type KanbanCreateChoice } from '../components/kanban/KanbanView'
+import { KanbanView, type KanbanCreateChoice, type KanbanSession } from '../components/kanban/KanbanView'
 import { assignNode, defaultKanban } from '../lib/kanban'
+import { boardLogEvents } from '../lib/boardLogDiff'
+import { useBoardLog } from '../state/boardLog'
 import { isKanbanOpen, useViewMode } from '../state/viewMode'
 import {
   createCanvasPublisher,
@@ -648,6 +650,10 @@ export function Canvas() {
   const settings = useSettings((s) => s.settings)
   const viewportRef = useRef<Viewport>({ x: 0, y: 0, zoom: 1 })
   const nodesRef = useRef<CanvasNode[]>(nodes)
+  // Live mirror of the derived board cards (defined far below), so the board-log emission funnel
+  // in onKanbanChange — declared above kanbanSessions — can resolve a node's card title without a
+  // dep cycle. Assigned right after that useMemo, same render-mirror idiom as nodesRef.
+  const kanbanSessionsRef = useRef<KanbanSession[]>([])
   // focusNodeById, for callbacks declared ABOVE its definition (openFile's dedupe focuses the
   // already-open node). Assigned right after the definition, same render-mirror idiom as nodesRef.
   const focusNodeRef = useRef<(nodeId: string) => void>(() => {})
@@ -1237,10 +1243,24 @@ export function Canvas() {
     (next: ProjectKanban) => {
       const id = useProjects.getState().activeProjectId
       if (!id) return
+      // The board BEFORE this change — read fresh at callback entry (a stale closed-over value
+      // would misattribute the diff). Same lazy-default as the KanbanView render.
+      const prev = useProjects.getState().getProject(id)?.kanban ?? seedBoard
       useProjects.getState().setProjectKanban(id, next)
       markDirty() // rides the existing debounced persist (commitActiveToStore + workspace.save)
+      // cardTitle must return '' for — and ONLY for — nodes that no longer exist (the diff reads
+      // '' as "pruned removal, not a move"). A LIVE node with an empty title maps to 'Untitled',
+      // never '' (see boardLogEvents' JSDoc).
+      const sessions = kanbanSessionsRef.current
+      const cardTitle = (nodeId: string): string => {
+        const s = sessions.find((x) => x.id === nodeId)
+        return s ? s.title || 'Untitled' : ''
+      }
+      for (const { nodeId, event } of boardLogEvents(prev, next, cardTitle)) {
+        useBoardLog.getState().append(api, id, { kind: 'event', nodeId, event })
+      }
     },
-    [markDirty]
+    [markDirty, api, seedBoard]
   )
 
   // The node states that go on the wire: React Flow's managed nodes minus the ephemeral cards
@@ -4086,6 +4106,7 @@ export function Canvas() {
         }),
     [nodes]
   )
+  kanbanSessionsRef.current = kanbanSessions
 
   // Create a node from the board's per-column "+ New" menu: it lands on the canvas (view
   // center) and, for a real column, is assigned there. The assignment is written directly —
@@ -4116,13 +4137,33 @@ export function Canvas() {
                 activePermissionMode()
               )
       setNodes((ns) => [...ns, node])
+      const board = project?.kanban ?? seedBoard
       if (columnId) {
-        const board = project?.kanban ?? seedBoard
         useProjects.getState().setProjectKanban(activeProjectId, assignNode(board, node.id, columnId, null))
       }
       markDirty()
+      // Log card-created directly here — the assignment above is written straight to the store
+      // (not via onKanbanChange), so its diff never runs and never double-logs a card-moved.
+      const toName = columnId
+        ? board.columns.find((c) => c.id === columnId)?.title ?? 'Ungrouped'
+        : 'Ungrouped'
+      const kindLabel =
+        choice.kind === 'terminal'
+          ? 'Terminal'
+          : choice.kind === 'sticky'
+            ? 'Sticky note'
+            : agentConfig(choice.agentId)?.label ??
+              useSettings.getState().settings.customAgents.find((a) => a.id === choice.agentId)
+                ?.label ??
+              choice.agentId
+      const title = (node.data.title as string) || kindLabel
+      useBoardLog.getState().append(api, activeProjectId, {
+        kind: 'event',
+        nodeId: node.id,
+        event: { type: 'card-created', to: toName, title }
+      })
     },
-    [activeProjectId, viewCenter, setNodes, markDirty, seedBoard]
+    [activeProjectId, viewCenter, setNodes, markDirty, seedBoard, api]
   )
 
   const openNodeFromKanban = useCallback(

--- a/src/renderer/components/kanban/BoardLogPanel.tsx
+++ b/src/renderer/components/kanban/BoardLogPanel.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import type { BoardLogEntry, BoardLogEvent } from '@shared/types'
+import { formatTimeAgo } from '../../lib/usageFormat'
+import { useSession } from '../../session/session'
+import { useProjects } from '../../state/projects'
+import { useBoardLog } from '../../state/boardLog'
+import type { KanbanSession } from './KanbanView'
+
+interface BoardLogPanelProps {
+  /** The card whose activity this panel shows — feed + composer are scoped to `card.id`. */
+  card: KanbanSession
+}
+
+/** Human one-liner for an activity event. column-* events carry no nodeId and so never reach a
+ *  card-scoped feed; they are handled defensively for completeness. */
+function eventLine(name: string, e: BoardLogEvent): string {
+  switch (e.type) {
+    case 'card-created':
+      return `${name} created this card in ${e.to ?? 'Ungrouped'}`
+    case 'card-moved':
+      return `${name} moved this card ${e.from ?? 'Ungrouped'} → ${e.to ?? 'Ungrouped'}`
+    case 'column-added':
+      return `${name} added column ${e.title ?? ''}`.trimEnd()
+    case 'column-renamed':
+      return `${name} renamed column ${e.from ?? ''} → ${e.to ?? ''}`
+    case 'column-deleted':
+      return `${name} deleted column ${e.title ?? ''}`.trimEnd()
+  }
+}
+
+/** Right panel of the card modal (all card kinds): a composer on top and the card's own
+ *  comments + activity feed newest-first. Reads/writes the board log for the ACTIVE project via
+ *  its session api — resolved here (not threaded from Canvas). Subscribes on mount, so a teammate's
+ *  comment or a board change lands live; unsubscribes on unmount / card swap. */
+export function BoardLogPanel({ card }: BoardLogPanelProps) {
+  const { api } = useSession()
+  const projectId = useProjects((s) => s.activeProjectId)
+  const entries = useBoardLog((s) => s.entriesByProject[projectId])
+  const unsupported = useBoardLog((s) => !!s.unsupportedByProject[projectId])
+  const error = useBoardLog((s) => !!s.errorByProject[projectId])
+  const [draft, setDraft] = useState('')
+
+  useEffect(() => {
+    if (!projectId) return
+    void useBoardLog.getState().load(api, projectId)
+    const unsub = useBoardLog.getState().subscribeChanged(api, projectId)
+    return unsub
+  }, [api, projectId])
+
+  const send = () => {
+    const text = draft.trim()
+    if (!text) return
+    useBoardLog.getState().append(api, projectId, { kind: 'comment', nodeId: card.id, text })
+    setDraft('')
+  }
+
+  // Card-scoped: this card's comments + its own events. Column events (no nodeId) never match.
+  const feed = (entries ?? []).filter((e) => e.nodeId === card.id)
+
+  return (
+    <div className="board-log">
+      <div className="board-log__title">Comments & activity</div>
+      {unsupported ? (
+        <div className="board-log__hint">Board history needs a project folder</div>
+      ) : (
+        <textarea
+          className="board-log__composer"
+          value={draft}
+          placeholder="Write a comment…"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            // Enter sends; Shift+Enter inserts a newline (default textarea behavior).
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              send()
+            }
+          }}
+        />
+      )}
+      {error && <div className="board-log__error">Couldn’t save your last comment.</div>}
+      <div className="board-log__feed">
+        {feed.map((entry) => (
+          <FeedRow key={entry.id} entry={entry} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function FeedRow({ entry }: { entry: BoardLogEntry }) {
+  const when = formatTimeAgo(entry.ts)
+  if (entry.kind === 'event' && entry.event) {
+    return <div className="board-log__event">{eventLine(entry.author.name, entry.event)}</div>
+  }
+  return (
+    <div className="board-log__comment">
+      <div className="board-log__meta">
+        <span className="board-log__dot" style={{ background: entry.author.color }} />
+        <span className="board-log__author">{entry.author.name}</span>
+        <span className="board-log__time">{when}</span>
+      </div>
+      <div className="board-log__text">{entry.text}</div>
+    </div>
+  )
+}

--- a/src/renderer/components/kanban/BoardLogPanel.tsx
+++ b/src/renderer/components/kanban/BoardLogPanel.tsx
@@ -35,7 +35,7 @@ function eventLine(name: string, e: BoardLogEvent): string {
 export function BoardLogPanel({ card }: BoardLogPanelProps) {
   const { api } = useSession()
   const projectId = useProjects((s) => s.activeProjectId)
-  const entries = useBoardLog((s) => s.entriesByProject[projectId])
+  const entries = useBoardLog((s) => s.entriesFor(projectId))
   const unsupported = useBoardLog((s) => !!s.unsupportedByProject[projectId])
   const error = useBoardLog((s) => !!s.errorByProject[projectId])
   const [draft, setDraft] = useState('')
@@ -70,14 +70,17 @@ export function BoardLogPanel({ card }: BoardLogPanelProps) {
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
             // Enter sends; Shift+Enter inserts a newline (default textarea behavior).
-            if (e.key === 'Enter' && !e.shiftKey) {
+            // Never submit mid-IME-composition (e.g. selecting a kanji candidate with Enter).
+            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
               e.preventDefault()
               send()
             }
           }}
         />
       )}
-      {error && <div className="board-log__error">Couldn’t save your last comment.</div>}
+      {!unsupported && error && (
+        <div className="board-log__error">Some board history couldn’t be saved.</div>
+      )}
       <div className="board-log__feed">
         {feed.map((entry) => (
           <FeedRow key={entry.id} entry={entry} />

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
 import type { KanbanSession } from './KanbanView'
+import { BoardLogPanel } from './BoardLogPanel'
 import { ModalTerminal } from './ModalTerminal'
 
 interface CardModalProps {
@@ -99,24 +100,28 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
           </button>
         </div>
         <div className="kanban-modal__body">
-          {session.kind === 'sticky' ? (
-            <textarea
-              className="kanban-modal__sticky"
-              value={session.text ?? ''}
-              placeholder="Write a note…"
-              onChange={(e) => onEditSticky(e.target.value)}
-            />
-          ) : (
-            <div className="kanban-modal__pane" data-kind={session.kind}>
-              {session.kind === 'terminal' ? (
-                // A live SECOND client on the node's session — keyed by node id so switching cards
-                // remounts a fresh viewer. Chat has no PTY; it opens on the canvas.
-                <ModalTerminal key={session.id} nodeId={session.id} spawn={session.spawn} />
-              ) : (
-                <div className="kanban-modal__placeholder">Chat sessions open on the canvas.</div>
-              )}
-            </div>
-          )}
+          {/* Body is a flex row: the card's own pane (2/3) + the board-log panel (1/3, all kinds). */}
+          <div className="kanban-modal__main">
+            {session.kind === 'sticky' ? (
+              <textarea
+                className="kanban-modal__sticky"
+                value={session.text ?? ''}
+                placeholder="Write a note…"
+                onChange={(e) => onEditSticky(e.target.value)}
+              />
+            ) : (
+              <div className="kanban-modal__pane" data-kind={session.kind}>
+                {session.kind === 'terminal' ? (
+                  // A live SECOND client on the node's session — keyed by node id so switching cards
+                  // remounts a fresh viewer. Chat has no PTY; it opens on the canvas.
+                  <ModalTerminal key={session.id} nodeId={session.id} spawn={session.spawn} />
+                ) : (
+                  <div className="kanban-modal__placeholder">Chat sessions open on the canvas.</div>
+                )}
+              </div>
+            )}
+          </div>
+          <BoardLogPanel card={session} />
         </div>
       </div>
     </div>,

--- a/src/renderer/lib/boardLogDiff.test.ts
+++ b/src/renderer/lib/boardLogDiff.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectKanban } from '@shared/types'
+import { boardLogEvents } from './boardLogDiff'
+
+const col = (id: string, title: string) => ({ id, title, color: '#111' })
+const board = (columns: ProjectKanban['columns'], assignments: ProjectKanban['assignments']): ProjectKanban => ({
+  columns,
+  assignments
+})
+// Every real node is relevant by default; a pruned node returns '' (see prune test).
+const title = (id: string) => `card-${id}`
+
+describe('boardLogEvents', () => {
+  it('assignment added → card-moved from Ungrouped to the new column', () => {
+    const cols = [col('c1', 'To Do')]
+    const prev = board(cols, [])
+    const next = board(cols, [{ nodeId: 'n1', columnId: 'c1' }])
+    expect(boardLogEvents(prev, next, title)).toEqual([
+      { nodeId: 'n1', event: { type: 'card-moved', from: 'Ungrouped', to: 'To Do' } }
+    ])
+  })
+
+  it('assignment columnId changed → card-moved from old to new column name', () => {
+    const cols = [col('c1', 'To Do'), col('c2', 'Done')]
+    const prev = board(cols, [{ nodeId: 'n1', columnId: 'c1' }])
+    const next = board(cols, [{ nodeId: 'n1', columnId: 'c2' }])
+    expect(boardLogEvents(prev, next, title)).toEqual([
+      { nodeId: 'n1', event: { type: 'card-moved', from: 'To Do', to: 'Done' } }
+    ])
+  })
+
+  it('assignment removed while node still relevant → card-moved to Ungrouped', () => {
+    const cols = [col('c1', 'To Do')]
+    const prev = board(cols, [{ nodeId: 'n1', columnId: 'c1' }])
+    const next = board(cols, [])
+    expect(boardLogEvents(prev, next, title)).toEqual([
+      { nodeId: 'n1', event: { type: 'card-moved', from: 'To Do', to: 'Ungrouped' } }
+    ])
+  })
+
+  it('assignment removed by prune (node gone) → no move', () => {
+    const cols = [col('c1', 'To Do')]
+    const prev = board(cols, [{ nodeId: 'gone', columnId: 'c1' }])
+    const next = board(cols, [])
+    // cardTitle('gone') === '' → the node no longer exists (pruneAssignments), so no move noise.
+    expect(boardLogEvents(prev, next, (id) => (id === 'gone' ? '' : `card-${id}`))).toEqual([])
+  })
+
+  it('column added → column-added {title}', () => {
+    const prev = board([col('c1', 'To Do')], [])
+    const next = board([col('c1', 'To Do'), col('c2', 'Done')], [])
+    expect(boardLogEvents(prev, next, title)).toEqual([{ event: { type: 'column-added', title: 'Done' } }])
+  })
+
+  it('column title changed → column-renamed {from,to}', () => {
+    const prev = board([col('c1', 'To Do')], [])
+    const next = board([col('c1', 'Doing')], [])
+    expect(boardLogEvents(prev, next, title)).toEqual([{ event: { type: 'column-renamed', from: 'To Do', to: 'Doing' } }])
+  })
+
+  it('column deleted → only column-deleted {title}; per-card moves to Ungrouped are suppressed', () => {
+    const prev = board([col('c1', 'To Do'), col('c2', 'Done')], [
+      { nodeId: 'n1', columnId: 'c2' },
+      { nodeId: 'n2', columnId: 'c2' }
+    ])
+    // deleteColumn('c2') removes the column AND both assignments.
+    const next = board([col('c1', 'To Do')], [])
+    expect(boardLogEvents(prev, next, title)).toEqual([{ event: { type: 'column-deleted', title: 'Done' } }])
+  })
+
+  it('pure column reorder → []', () => {
+    const prev = board([col('c1', 'To Do'), col('c2', 'Done')], [])
+    const next = board([col('c2', 'Done'), col('c1', 'To Do')], [])
+    expect(boardLogEvents(prev, next, title)).toEqual([])
+  })
+
+  it('intra-column card order change → []', () => {
+    const cols = [col('c1', 'To Do')]
+    const prev = board(cols, [
+      { nodeId: 'a', columnId: 'c1' },
+      { nodeId: 'b', columnId: 'c1' }
+    ])
+    const next = board(cols, [
+      { nodeId: 'b', columnId: 'c1' },
+      { nodeId: 'a', columnId: 'c1' }
+    ])
+    expect(boardLogEvents(prev, next, title)).toEqual([])
+  })
+
+  it('no change at all → []', () => {
+    const cols = [col('c1', 'To Do')]
+    const b = board(cols, [{ nodeId: 'a', columnId: 'c1' }])
+    expect(boardLogEvents(b, b, title)).toEqual([])
+  })
+
+  it('dangling prev assignment (column already missing) resolves from-name to Ungrouped', () => {
+    // Assignment points at a column that exists in neither board (a leftover from elsewhere);
+    // moving it into a real column reads as coming from Ungrouped.
+    const prev = board([col('c1', 'To Do')], [{ nodeId: 'n1', columnId: 'dead' }])
+    const next = board([col('c1', 'To Do')], [{ nodeId: 'n1', columnId: 'c1' }])
+    expect(boardLogEvents(prev, next, title)).toEqual([
+      { nodeId: 'n1', event: { type: 'card-moved', from: 'Ungrouped', to: 'To Do' } }
+    ])
+  })
+})

--- a/src/renderer/lib/boardLogDiff.ts
+++ b/src/renderer/lib/boardLogDiff.ts
@@ -1,0 +1,60 @@
+import type { BoardLogEvent, ProjectKanban } from '@shared/types'
+
+// Pure prev→next board diff → the events worth recording in the board log. No fs, no IPC:
+// the caller computes the next board (renderer/lib/kanban.ts) and asks here what changed.
+// Column names are resolved at event time; the virtual (unassigned) column is 'Ungrouped'.
+
+const UNGROUPED = 'Ungrouped'
+
+/** Board events implied by a prev→next board change. Column names resolved at event time;
+ *  the virtual column is named 'Ungrouped'. Pure; returns [] when nothing loggable changed. */
+export function boardLogEvents(
+  prev: ProjectKanban,
+  next: ProjectKanban,
+  cardTitle: (nodeId: string) => string
+): Array<{ nodeId?: string; event: BoardLogEvent }> {
+  const out: Array<{ nodeId?: string; event: BoardLogEvent }> = []
+  const prevCols = new Map(prev.columns.map((c) => [c.id, c.title]))
+  const nextCols = new Map(next.columns.map((c) => [c.id, c.title]))
+
+  // Column added / renamed, in next order.
+  for (const c of next.columns) {
+    const old = prevCols.get(c.id)
+    if (old === undefined) out.push({ event: { type: 'column-added', title: c.title } })
+    else if (old !== c.title) out.push({ event: { type: 'column-renamed', from: old, to: c.title } })
+  }
+  // Column deleted — records ONLY column-deleted; the per-card "moved to Ungrouped" noise that
+  // deleteColumn produces (it drops the column's assignments too) is suppressed below.
+  const deleted = new Set<string>()
+  for (const c of prev.columns) {
+    if (!nextCols.has(c.id)) {
+      deleted.add(c.id)
+      out.push({ event: { type: 'column-deleted', title: c.title } })
+    }
+  }
+
+  const prevA = new Map(prev.assignments.map((a) => [a.nodeId, a.columnId]))
+  const nextA = new Map(next.assignments.map((a) => [a.nodeId, a.columnId]))
+  const nodeIds: string[] = []
+  const seen = new Set<string>()
+  for (const a of [...prev.assignments, ...next.assignments]) {
+    if (!seen.has(a.nodeId)) {
+      seen.add(a.nodeId)
+      nodeIds.push(a.nodeId)
+    }
+  }
+
+  for (const nodeId of nodeIds) {
+    const pc = prevA.get(nodeId)
+    const nc = nextA.get(nodeId)
+    if (pc === nc) continue // unchanged, or same column with only an intra-column reorder
+    const fromName = pc === undefined ? UNGROUPED : prevCols.get(pc) ?? UNGROUPED
+    const toName = nc === undefined ? UNGROUPED : nextCols.get(nc) ?? UNGROUPED
+    if (nc === undefined) {
+      if (pc !== undefined && deleted.has(pc)) continue // column deleted → not a move
+      if (!cardTitle(nodeId)) continue // node no longer exists (pruneAssignments) → not a move
+    }
+    out.push({ nodeId, event: { type: 'card-moved', from: fromName, to: toName } })
+  }
+  return out
+}

--- a/src/renderer/lib/boardLogDiff.ts
+++ b/src/renderer/lib/boardLogDiff.ts
@@ -7,7 +7,12 @@ import type { BoardLogEvent, ProjectKanban } from '@shared/types'
 const UNGROUPED = 'Ungrouped'
 
 /** Board events implied by a prev→next board change. Column names resolved at event time;
- *  the virtual column is named 'Ungrouped'. Pure; returns [] when nothing loggable changed. */
+ *  the virtual column is named 'Ungrouped'. Pure; returns [] when nothing loggable changed.
+ *
+ *  BINDING INVARIANT — `cardTitle` MUST return '' for, and ONLY for, a nodeId whose node no
+ *  longer exists: a removed assignment with an empty title is read as a prune (not a move) and
+ *  suppressed. A LIVE node with an empty title must map to a non-empty placeholder ('Untitled'),
+ *  never '' — otherwise moving/removing an untitled card would be silently dropped. */
 export function boardLogEvents(
   prev: ProjectKanban,
   next: ProjectKanban,

--- a/src/renderer/state/boardLog.ts
+++ b/src/renderer/state/boardLog.ts
@@ -1,0 +1,102 @@
+import { create } from 'zustand'
+import type { BoardLogEntry, NodeTerminalApi } from '@shared/types'
+import { loadIdentity } from './presence'
+
+/**
+ * Board-log store — the renderer view of a project's append-only board history
+ * (`.nodeterm/board-log.jsonl`, project-routed by the `boardLog` api). One entry list per
+ * project id; the modal's "Comments & activity" panel reads it and appends to it.
+ *
+ * The api is passed IN (never captured off `window.nodeTerminal`): a remote project's board log
+ * lives on its host and is reached through that session's api, so every call takes the api the
+ * caller resolved for the project (Canvas uses its session api; the panel uses `useSession()`).
+ *
+ * `append` is OPTIMISTIC + fire-and-forget: it stamps the entry, prepends it locally (the log is
+ * newest-first, matching `read`), and calls `api.boardLog.append` without awaiting — on a `false`
+ * result or a rejection it raises a quiet per-project `error` flag (the local entry stays; the
+ * next change-push reload reconciles). `read` is authoritative: it REPLACES the list, so our own
+ * appended entry (same client-generated id, persisted verbatim) never duplicates on reload.
+ */
+
+/** The default author when the user has never picked a presence identity. */
+const ANON_AUTHOR = { name: 'you', color: '#8e8e93' }
+
+/** Shared stable empty list — a project with no loaded entries returns this exact array, so a
+ *  reactive selector does not see a fresh `[]` (and re-render) on every unrelated store write. */
+const EMPTY: BoardLogEntry[] = []
+
+/** The caller-supplied part of an entry; the store stamps `id`/`ts`/`author`. */
+export type BoardLogAppendInput = Pick<BoardLogEntry, 'kind' | 'nodeId' | 'text' | 'event'>
+
+interface BoardLogState {
+  /** Loaded entries per project id, NEWEST-FIRST. */
+  entriesByProject: Record<string, BoardLogEntry[]>
+  /** Projects whose log is unreachable (inline/no-cwd, disconnected SSH, server-side SSH). */
+  unsupportedByProject: Record<string, boolean>
+  /** Quiet flag: an append failed for this project (the local entry is still shown). */
+  errorByProject: Record<string, boolean>
+  /** The entries for a project (stable empty array when none are loaded). */
+  entriesFor(projectId: string): BoardLogEntry[]
+  /** Read the log for a project and replace its list; records the unsupported/clears error flags. */
+  load(api: NodeTerminalApi, projectId: string): Promise<void>
+  /** Stamp + optimistically prepend an entry, then fire-and-forget the api append. */
+  append(api: NodeTerminalApi, projectId: string, input: BoardLogAppendInput): void
+  /** Wire `onChanged` → reload for a project; returns the unsubscribe. */
+  subscribeChanged(api: NodeTerminalApi, projectId: string): () => void
+}
+
+export const useBoardLog = create<BoardLogState>((set, get) => ({
+  entriesByProject: {},
+  unsupportedByProject: {},
+  errorByProject: {},
+
+  entriesFor: (projectId) => get().entriesByProject[projectId] ?? EMPTY,
+
+  load: async (api, projectId) => {
+    try {
+      const res = await api.boardLog.read(projectId)
+      set((s) => ({
+        entriesByProject: { ...s.entriesByProject, [projectId]: res.entries },
+        unsupportedByProject: { ...s.unsupportedByProject, [projectId]: !!res.unsupported },
+        // A successful read supersedes any stale append error for this project.
+        errorByProject: { ...s.errorByProject, [projectId]: false }
+      }))
+    } catch {
+      // A failed read leaves the last-known list untouched — never blank the panel on a hiccup.
+    }
+  },
+
+  append: (api, projectId, input) => {
+    const id = loadIdentity()
+    const author = id ? { name: id.name, color: id.color } : ANON_AUTHOR
+    const entry: BoardLogEntry = {
+      id: crypto.randomUUID(),
+      ts: Date.now(),
+      author,
+      kind: input.kind,
+      ...(input.nodeId !== undefined ? { nodeId: input.nodeId } : {}),
+      ...(input.text !== undefined ? { text: input.text } : {}),
+      ...(input.event !== undefined ? { event: input.event } : {})
+    }
+    // Optimistic newest-first insert.
+    set((s) => ({
+      entriesByProject: {
+        ...s.entriesByProject,
+        [projectId]: [entry, ...(s.entriesByProject[projectId] ?? EMPTY)]
+      }
+    }))
+    const flagError = () =>
+      set((s) => ({ errorByProject: { ...s.errorByProject, [projectId]: true } }))
+    api.boardLog
+      .append(projectId, entry)
+      .then((ok) => {
+        if (!ok) flagError()
+      })
+      .catch(flagError)
+  },
+
+  subscribeChanged: (api, projectId) =>
+    api.boardLog.onChanged(projectId, () => {
+      void get().load(api, projectId)
+    })
+}))

--- a/src/renderer/state/boardLog.ts
+++ b/src/renderer/state/boardLog.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { BoardLogEntry, NodeTerminalApi } from '@shared/types'
+import { BOARD_LOG_TEXT_MAX, type BoardLogEntry, type NodeTerminalApi } from '@shared/types'
 import { loadIdentity } from './presence'
 
 /**
@@ -69,13 +69,20 @@ export const useBoardLog = create<BoardLogState>((set, get) => ({
   append: (api, projectId, input) => {
     const id = loadIdentity()
     const author = id ? { name: id.name, color: id.color } : ANON_AUTHOR
+    // Clamp identically to buildLine (src/core/board-log.ts) so the optimistic entry the user sees
+    // matches what lands on disk — an over-long paste would otherwise silently truncate on reload
+    // (and, over SSH, fail the append entirely and vanish).
+    const text =
+      input.text !== undefined && input.text.length > BOARD_LOG_TEXT_MAX
+        ? input.text.slice(0, BOARD_LOG_TEXT_MAX) + '…'
+        : input.text
     const entry: BoardLogEntry = {
       id: crypto.randomUUID(),
       ts: Date.now(),
       author,
       kind: input.kind,
       ...(input.nodeId !== undefined ? { nodeId: input.nodeId } : {}),
-      ...(input.text !== undefined ? { text: input.text } : {}),
+      ...(text !== undefined ? { text } : {}),
       ...(input.event !== undefined ? { event: input.event } : {})
     }
     // Optimistic newest-first insert.

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6710,6 +6710,12 @@ body,
   min-height: 0;
   display: flex;
 }
+/* The card's own pane (terminal / sticky / chat) takes 2/3; the board-log panel takes 1/3. */
+.kanban-modal__main {
+  flex: 2;
+  min-width: 0;
+  display: flex;
+}
 .kanban-modal__sticky {
   flex: 1;
   background: none;
@@ -6737,4 +6743,101 @@ body,
   flex: 1;
   min-width: 0;
   padding: 8px;
+}
+
+/* ── Board log: the modal's "Comments & activity" panel (right 1/3) ── */
+.board-log {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.015);
+}
+.board-log__title {
+  flex: 0 0 auto;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.4);
+  padding: 12px 14px 8px;
+}
+.board-log__composer {
+  flex: 0 0 auto;
+  margin: 0 12px 10px;
+  min-height: 52px;
+  max-height: 140px;
+  resize: none;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 7px;
+  color: rgba(255, 255, 255, 0.9);
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 8px 10px;
+  outline: none;
+}
+.board-log__composer:focus {
+  border-color: var(--accent);
+}
+.board-log__hint {
+  flex: 0 0 auto;
+  margin: 0 14px 10px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.35);
+}
+.board-log__error {
+  flex: 0 0 auto;
+  margin: 0 14px 8px;
+  font-size: 10px;
+  color: rgba(255, 120, 120, 0.75);
+}
+.board-log__feed {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.board-log__comment {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.board-log__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.board-log__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.board-log__author {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+.board-log__time {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+}
+.board-log__text {
+  font-size: 12px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.82);
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding-left: 14px;
+}
+.board-log__event {
+  font-size: 11px;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.42);
+  padding-left: 14px;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,6 +13,7 @@ import { SettingsStore } from '../core/settings-store'
 import { WorkspaceStore } from '../core/workspace-store'
 import { PtyManager } from '../core/pty-manager'
 import { registerCoreHandlers } from './handlers'
+import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
 import { hookServer } from '../core/agents/hook-server'
 import { installManagedAgentHooks } from '../core/agents/hooks'
 import {
@@ -148,6 +149,16 @@ export async function startServer(
 
   // fs + git + commit handlers (shared with desktop core services).
   registerCoreHandlers(platform, { getSettings: () => settingsStore.get() })
+
+  // Board-log: same CorePlatform registrar as desktop, but the Server Edition has no SSH projects
+  // (terminals are local), so the router only ever resolves a local folder cwd or unsupported —
+  // an SSH-ref project answers `{ entries: [], unsupported: true }` (v1: no remote board log here).
+  registerBoardLogHandlers(platform, {
+    route: (projectId: string): BoardLogRoute => {
+      const cwd = workspaceStore.localCwdForProject(projectId)
+      return cwd ? { kind: 'local', cwd } : { kind: 'unsupported' }
+    }
+  })
 
   // Agent status pipeline — mirrors the desktop boot order in src/main/index.ts:
   // mirror-init → wire the hook-server listeners onto the platform → install the managed hook

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -52,6 +52,16 @@ export const IPC = {
   canvasMut: 'canvas:mut',
   contextLinkSetLinks: 'context-link:set-links',
   contextLinkInfo: 'context-link:info',
+  /** Board-log (`.nodeterm/board-log.jsonl`): request/response append + read, routed per project
+   *  (local cwd / desktop-ssh / unsupported) in core/board-log-handlers.ts. */
+  boardLogAppend: 'board-log:append',
+  boardLogRead: 'board-log:read',
+  /** Fire-and-forget ref-counted subscribe/unsubscribe: the first subscriber for a project starts
+   *  the local fs.watch (or the desktop-ssh 5s poll); the last one stops it. */
+  boardLogSubscribe: 'board-log:subscribe',
+  boardLogUnsubscribe: 'board-log:unsubscribe',
+  /** Per-project push fired when a project's board log changes (mirrors ptyData/chatEvent naming). */
+  boardLogChanged: (projectId: string) => `board-log:changed:${projectId}`,
   appUpdateAvailable: 'app:update-available',
   appUpdateDownloaded: 'app:update-downloaded',
   appUpdateProgress: 'app:update-progress',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -218,6 +218,34 @@ export interface ProjectKanban {
   assignments: KanbanAssignment[]
 }
 
+/** Who produced a board-log entry (a teammate on a shared board, or this user). */
+export interface BoardLogAuthor {
+  name: string
+  color: string
+}
+
+/** A structural board change worth recording. `type` is closed; the optional fields carry
+ *  the human-readable names resolved at event time (the virtual column is named 'Ungrouped'). */
+export interface BoardLogEvent {
+  type: 'card-created' | 'card-moved' | 'column-added' | 'column-renamed' | 'column-deleted'
+  from?: string
+  to?: string
+  /** Column title for column-added/deleted; card title for card-created. */
+  title?: string
+}
+
+/** One line of the append-only board history (`.nodeterm/board-log.jsonl`). A `comment`
+ *  carries `text`; an `event` carries `event`. Serialized one-per-line as JSON. */
+export interface BoardLogEntry {
+  id: string
+  ts: number
+  author: BoardLogAuthor
+  nodeId?: string
+  kind: 'comment' | 'event'
+  text?: string
+  event?: BoardLogEvent
+}
+
 /** A project is one canvas/page: its own nodes, viewport, and default working dir. */
 export interface Project {
   id: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -246,6 +246,32 @@ export interface BoardLogEntry {
   event?: BoardLogEvent
 }
 
+/** Read options for the board log: cap the newest N entries (default 500 in the store) or `all`. */
+export interface BoardLogReadOpts {
+  cap?: number
+  all?: boolean
+}
+
+/** Result of a board-log read. `unsupported` is set (with `entries: []`) when the project has no
+ *  reachable log — an inline/no-cwd canvas, a disconnected SSH project, or an SSH project on the
+ *  Server Edition (v1 has no remote board log there). */
+export interface BoardLogReadResult {
+  entries: BoardLogEntry[]
+  unsupported?: boolean
+}
+
+/** The board-log surface on `window.nodeTerminal`. Project-routed: the main/server side resolves
+ *  the project to a local cwd, a desktop SSH connection, or unsupported. `append` is
+ *  fire-and-forget-safe (resolves `false` on any failure, never throws). */
+export interface BoardLogApi {
+  /** Append one entry. Resolves `false` on any failure (unsupported project, fs/exec error). */
+  append(projectId: string, entry: BoardLogEntry): Promise<boolean>
+  /** Read the log newest-first (see BoardLogReadResult). */
+  read(projectId: string, opts?: BoardLogReadOpts): Promise<BoardLogReadResult>
+  /** Subscribe to change pushes for one project; returns an unsubscribe. */
+  onChanged(projectId: string, cb: () => void): () => void
+}
+
 /** A project is one canvas/page: its own nodes, viewport, and default working dir. */
 export interface Project {
   id: string
@@ -1505,6 +1531,7 @@ export interface NodeTerminalApi {
   license: LicenseApi
   relayQuota: RelayQuotaApi
   contextLink: ContextLinkApi
+  boardLog: BoardLogApi
   usage: UsageApi
   context: ContextApi
   canvas: CanvasApi

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -246,6 +246,13 @@ export interface BoardLogEntry {
   event?: BoardLogEvent
 }
 
+/** Max chars kept for a comment's `text`. On an SSH project the whole JSON line becomes one
+ *  shell arg (`printf '%s\n' '<line>'` over the ControlMaster); an unbounded paste blows past
+ *  ARG_MAX → the append fails → the optimistic entry silently vanishes on reload. Locally it
+ *  just bloats the append-only file. Shared so core (disk) and the renderer (optimistic UI)
+ *  clamp identically. */
+export const BOARD_LOG_TEXT_MAX = 16_384
+
 /** Read options for the board log: cap the newest N entries (default 500 in the store) or `all`. */
 export interface BoardLogReadOpts {
   cap?: number


### PR DESCRIPTION
## Summary

Sub-project B of the "Trello for Claude Code" spec: every card now carries a **Comments & activity** panel (right third of the card modal), backed by an append-only, git-shareable history file.

- **`<cwd>/.nodeterm/board-log.jsonl`** — one JSON line per entry `{id, ts, author{name,color}, nodeId?, kind: comment|event, …}`; tolerant newest-first reader (cap 500), corrupt/foreign lines skipped; comment text clamped at 16KB (SSH arg-max silent-loss + unbounded-growth guard).
- **Events from ONE pure funnel** (`lib/boardLogDiff.ts`, fully unit-tested): card-moved (column names at event time, Ungrouped included), column added/renamed/deleted — with the subtle cases right (a column deletion suppresses the per-card "moved to Ungrouped" noise; prunes of deleted nodes don't log; pure reorders log nothing). `+ New session` logs card-created.
- **Author = presence identity** (`nodeterm.presence.me`), so relay/team sessions attribute per person; solo fallback "you".
- **Cross-surface wiring** through a core registrar BOTH shells boot (Server Edition works; jailing verified: the client supplies only a projectId — the path derives from the server's own registry). Desktop SSH projects append/read over the project ControlMaster (`printf >>` / `tail -n`) with a 5s change poll; local projects get an fs.watch push. Inline (cwd-less) projects show a hint.
- **Panel**: composer (Enter sends, Shift+Enter newline, IME-safe), feed filtered to the card, comments as speech rows + events as muted one-liners, live updates, quiet error note.

Review trail: 3 task-scoped reviews (one carried a binding invariant — `cardTitle` existence semantics — into the next task, verified honored) + final whole-branch review ("ready with one trivial fix", applied).

## Test plan

- [x] Full suite 2312/2312; typecheck clean; no-electron boundaries green
- [x] Live e2e (Server Edition browser): comment lands in board-log.jsonl with author; drag → `card-moved {from: To Do, to: Done}` on disk and in the feed; corrupt line injected on disk → watcher pushed a reload, feed intact, garbage skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h