### PR TITLE
feat: terminal actions in the card modal (search / dictate / AI-name / markdown view)

### DIFF
--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
+import { IconChat, IconMic, IconSearch } from '../icons'
+import { renderMarkdown } from '../../lib/markdown'
+import { useSession } from '../../session/session'
 import type { KanbanSession } from './KanbanView'
 import { BoardLogPanel } from './BoardLogPanel'
 import { ModalTerminal } from './ModalTerminal'
@@ -19,14 +22,36 @@ interface CardModalProps {
 }
 
 /** Trello-style card popup over the board. Scrim click / Esc close it; the board (and the
- *  canvas under it) stay mounted. Terminal pane arrives in Task 2 — until then terminal
- *  cards show the sticky/chat-style body with the open-on-canvas action. */
+ *  canvas under it) stay mounted. Terminal cards carry the node header's actions too:
+ *  search / dictate / AI-name / markdown view (the node itself is hidden under the board). */
 export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRename, onEditSticky }: CardModalProps) {
+  const { api } = useSession()
   const idRef = useRef<string>()
   if (!idRef.current) idRef.current = nextDialogId()
   const id = idRef.current
   const [editingTitle, setEditingTitle] = useState(false)
   const [title, setTitle] = useState(session.title)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [naming, setNaming] = useState(false)
+  // Markdown view of the captured output (the node's ⌘M, modal edition): null = terminal.
+  const [mdHtml, setMdHtml] = useState<string | null>(null)
+  const isTerminal = session.kind === 'terminal'
+
+  const nameWithAi = async () => {
+    setNaming(true)
+    const r = await api.pty.generateName(session.id, session.spawn.cwd ?? '')
+    setNaming(false)
+    if (r.ok) onRename(r.message)
+  }
+
+  const toggleMd = async () => {
+    if (mdHtml !== null) {
+      setMdHtml(null)
+      return
+    }
+    const captured = await api.pty.capture(session.id, true)
+    setMdHtml(renderMarkdown(captured || ''))
+  }
   // Ref mirror: the capture-phase listener below closes over stale state otherwise.
   const editingTitleRef = useRef(false)
   useEffect(() => {
@@ -92,6 +117,43 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
             </span>
           )}
           <span className="kanban-modal__column">{columnTitle ?? 'Ungrouped'}</span>
+          {isTerminal && (
+            <>
+              <button
+                className="kanban-modal__action"
+                title="Search this terminal"
+                aria-pressed={searchOpen}
+                onClick={() => setSearchOpen((v) => !v)}
+              >
+                <IconSearch />
+              </button>
+              <button
+                className="kanban-modal__action"
+                title="Dictate into this terminal"
+                onClick={() =>
+                  window.dispatchEvent(new CustomEvent('nodeterm:dictate', { detail: { nodeId: session.id } }))
+                }
+              >
+                <IconMic />
+              </button>
+              <button
+                className="kanban-modal__action"
+                title="Name with AI (from terminal output)"
+                disabled={naming}
+                onClick={nameWithAi}
+              >
+                {naming ? '…' : '✦'}
+              </button>
+              <button
+                className="kanban-modal__action"
+                title="Markdown view of the output"
+                aria-pressed={mdHtml !== null}
+                onClick={toggleMd}
+              >
+                <IconChat />
+              </button>
+            </>
+          )}
           <button className="kanban-modal__action" title="Open on canvas" onClick={onOpenCanvas}>
             ↗
           </button>
@@ -113,8 +175,20 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
               <div className="kanban-modal__pane" data-kind={session.kind}>
                 {session.kind === 'terminal' ? (
                   // A live SECOND client on the node's session — keyed by node id so switching cards
-                  // remounts a fresh viewer. Chat has no PTY; it opens on the canvas.
-                  <ModalTerminal key={session.id} nodeId={session.id} spawn={session.spawn} />
+                  // remounts a fresh viewer. Chat has no PTY; it opens on the canvas. The markdown
+                  // view OVERLAYS the terminal (kept mounted — its viewer must not detach/re-seed).
+                  <>
+                    <ModalTerminal
+                      key={session.id}
+                      nodeId={session.id}
+                      spawn={session.spawn}
+                      searchOpen={searchOpen}
+                      onCloseSearch={() => setSearchOpen(false)}
+                    />
+                    {mdHtml !== null && (
+                      <div className="kanban-modal__md" dangerouslySetInnerHTML={{ __html: mdHtml }} />
+                    )}
+                  </>
                 ) : (
                   <div className="kanban-modal__placeholder">Chat sessions open on the canvas.</div>
                 )}

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+import { SearchAddon } from '@xterm/addon-search'
+import { hasUsage } from '@shared/agents/config'
+import { FindBar } from '../FindBar'
+import { useAgentStatus } from '../../state/agentStatus'
 import { useSession } from '../../session/session'
 import { useSettings } from '../../state/settings'
+import { useTerminalSearch } from '../../terminal/useTerminalSearch'
 import { LocalTransport } from '../../terminal/local-transport'
 import { parseOsc52 } from '../../terminal/osc52'
 import {
@@ -40,9 +45,57 @@ export interface ModalSpawn {
  * is short-lived and always on top. Closing kills ONLY this viewer (the last-view release stays with
  * the canvas node). The MIRROR-tagged blocks below are copied byte-for-byte from TerminalNode.
  */
-export function ModalTerminal({ nodeId, spawn }: { nodeId: string; spawn: ModalSpawn }) {
+interface ModalTerminalProps {
+  nodeId: string
+  spawn: ModalSpawn
+  /** The modal header's 🔍 toggle — the FindBar renders inside this pane. */
+  searchOpen: boolean
+  onCloseSearch: () => void
+}
+
+export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: ModalTerminalProps) {
   const { api } = useSession()
   const hostRef = useRef<HTMLDivElement>(null)
+  const termRef = useRef<Terminal | null>(null)
+  const searchAddonRef = useRef<SearchAddon | null>(null)
+  const agentSessionId = useAgentStatus((s) => s.byId[nodeId]?.sessionId)
+
+  // Same search machinery as the canvas node: capture-indexed matches + xterm highlight.
+  const readBuffer = useCallback((): string => {
+    const b = termRef.current?.buffer.active
+    if (!b) return ''
+    const lines: string[] = []
+    for (let i = 0; i < b.length; i++) lines[i] = b.getLine(i)?.translateToString() ?? ''
+    return lines.join('\n')
+  }, [])
+  const search = useTerminalSearch({
+    nodeId,
+    sessionId: agentSessionId,
+    cwd: spawn.cwd,
+    accountId: spawn.accountId,
+    searchTranscript: !!spawn.agentId && hasUsage(spawn.agentId),
+    open: searchOpen,
+    readBuffer
+  })
+  // MIRROR TerminalNode's findOpts — one source for the highlight colors.
+  const findOpts = {
+    decorations: {
+      matchBackground: '#ffd54f55',
+      activeMatchBackground: '#ffb300',
+      matchOverviewRuler: '#ffd54f',
+      activeMatchColorOverviewRuler: '#ffb300'
+    }
+  }
+  const handleNext = useCallback(() => {
+    search.next()
+    if (search.query.trim()) searchAddonRef.current?.findNext(search.query, findOpts)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search])
+  const handlePrev = useCallback(() => {
+    search.prev()
+    if (search.query.trim()) searchAddonRef.current?.findPrevious(search.query, findOpts)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search])
 
   useEffect(() => {
     // A unique viewerId per mount: the core namespaces it per connection, so uniqueness only has to
@@ -61,6 +114,10 @@ export function ModalTerminal({ nodeId, spawn }: { nodeId: string; spawn: ModalS
     })
     const fit = new FitAddon()
     term.loadAddon(fit)
+    const searchAddon = new SearchAddon()
+    term.loadAddon(searchAddon)
+    termRef.current = term
+    searchAddonRef.current = searchAddon
     term.open(hostRef.current!)
     fit.fit()
 
@@ -189,5 +246,21 @@ export function ModalTerminal({ nodeId, spawn }: { nodeId: string; spawn: ModalS
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodeId])
 
-  return <div ref={hostRef} className="kanban-modal__term" />
+  return (
+    <div className="kanban-modal__termwrap">
+      {searchOpen && (
+        <FindBar
+          query={search.query}
+          onQueryChange={search.setQuery}
+          matchIndex={search.matchIndex}
+          matchCount={search.matchCount}
+          current={search.current}
+          onNext={handleNext}
+          onPrev={handlePrev}
+          onClose={onCloseSearch}
+        />
+      )}
+      <div ref={hostRef} className="kanban-modal__term" />
+    </div>
+  )
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -479,7 +479,7 @@ body,
   bottom: 88px;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 21;
+  z-index: 60; /* above the kanban board (25) and the card modal scrim (55) — the mic works there too */
   width: 420px;
   max-width: 92vw;
   display: flex;
@@ -6729,6 +6729,7 @@ body,
   font-family: inherit;
 }
 .kanban-modal__pane {
+  position: relative; /* anchors the markdown-view overlay */
   flex: 1;
   min-width: 0;
   display: flex;
@@ -6840,4 +6841,32 @@ body,
   line-height: 1.4;
   color: rgba(255, 255, 255, 0.42);
   padding-left: 14px;
+}
+
+.kanban-modal__termwrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.kanban-modal__action[aria-pressed='true'] {
+  background: var(--accent);
+  color: #fff;
+}
+.kanban-modal__md {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: 14px 18px;
+  background: #161618;
+  font-size: 13px;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.88);
+}
+.kanban-modal__md pre {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  padding: 8px 10px;
+  overflow-x: auto;
 }


### PR DESCRIPTION
## Summary

The card modal's header now carries the terminal node's four actions (the node itself is hidden under the board, so they must live here too):

- **🔍 Search** — the same `useTerminalSearch` + `FindBar` machinery as the canvas node, bound to the modal's own xterm (SearchAddon highlights, capture-indexed matches, transcript search for usage-capable agents).
- **🎤 Dictate** — dispatches the existing `nodeterm:dictate` event; text lands in the shared tmux session so it types live in the modal terminal. The dictation overlay's z-index rises 21 → 60 (it sat under the board overlay and the modal scrim).
- **✦ AI-name** — `pty.generateName` routed through the modal's rename funnel (title + `/rename` sync).
- **💬 Markdown view** — the node's ⌘M in modal form: captured output rendered through the shared DOMPurify-sanitized `renderMarkdown`, as an overlay ABOVE the still-mounted terminal (the viewer must not detach/re-seed on toggle). Security review's XSS flag on this path is mitigated at the seam: `renderMarkdown` = marked → `DOMPurify.sanitize` (the same canonical sanitizer as the node's ⌘M view and editor preview).

Sticky/chat cards don't show the four (no meaning there).

## Test plan

- [x] Full suite 2400/2400, typecheck clean
- [x] Live drive (Server Edition browser): all four buttons present; FindBar finds typed content (1/4 matches); markdown overlay toggles on/off; mic opens the dictation overlay ABOVE the modal; **team attribution verified** — comments from two presence identities (enes/blue, mehmet/purple) land in one feed with distinct name + color dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h