### PR TITLE
feat(settings): Usage section with per-provider toggles; regroup the sidebar

### DIFF
--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ClaudeUsage, ProviderUsage, UsageLimit } from '@shared/types'
 import { AGENT_CONFIG } from '@shared/agents/config'
 import { useSettings } from '../state/settings'
-import { formatResetCountdown, formatTimeAgo, severityColor } from '../lib/usageFormat'
+import { formatResetCountdown, formatTimeAgo, percentNumber, percentText, severityColor } from '../lib/usageFormat'
 import {
   enabledProviders,
   hasAnyUsage,
@@ -18,7 +18,7 @@ import { systemAccountDisplay } from '../state/workspace'
  * A single limit row in the popover: bar, "% left", reset countdown. Bars render REMAINING
  * quota (the limit carries percent USED), which is the convention this pill has always used.
  */
-function LimitRow({ limit }: { limit: UsageLimit }) {
+function LimitRow({ limit, mode }: { limit: UsageLimit; mode: 'used' | 'remaining' }) {
   const left = 100 - limit.usedPercent
   return (
     <div className="usage-row">
@@ -34,7 +34,7 @@ function LimitRow({ limit }: { limit: UsageLimit }) {
         />
       </div>
       <div className="usage-row__meta">
-        <span>{Math.round(left)}% left</span>
+        <span>{percentText(limit.usedPercent, mode)}</span>
         <span>{formatResetCountdown(limit.resetsAt)}</span>
       </div>
     </div>
@@ -45,13 +45,23 @@ function LimitRow({ limit }: { limit: UsageLimit }) {
  * One account's limit bars under a label, for the multi-account popover. Reuses LimitRow's
  * markup — `u` is null while its on-demand fetch is in flight.
  */
-function AccountUsageBlock({ label, email, u }: { label: string; email?: string; u: ClaudeUsage | null }) {
+function AccountUsageBlock({
+  label,
+  email,
+  u,
+  mode
+}: {
+  label: string
+  email?: string
+  u: ClaudeUsage | null
+  mode: 'used' | 'remaining'
+}) {
   return (
     <div className="usage-account">
       <div className="usage-account__label">{label}</div>
       {(email ?? u?.email) && <div className="usage-account__email">{email ?? u?.email}</div>}
       {u?.limits.map((l) => (
-        <LimitRow key={limitKey(l)} limit={l} />
+        <LimitRow key={limitKey(l)} limit={l} mode={mode} />
       ))}
       {u && u.limits.length === 0 && <div className="usage-popover__empty">No usage data.</div>}
       {!u && <div className="usage-popover__empty usage-pill__pulse">···</div>}
@@ -71,7 +81,7 @@ function labelFor(provider: string): string {
   return providerLabel(provider, agentLabel)
 }
 
-function ProviderBlock({ u }: { u: ProviderUsage }) {
+function ProviderBlock({ u, mode }: { u: ProviderUsage; mode: 'used' | 'remaining' }) {
   if (u.status === 'unavailable') return null
   const label = labelFor(u.provider)
   return (
@@ -79,7 +89,7 @@ function ProviderBlock({ u }: { u: ProviderUsage }) {
       <div className="usage-account__label">{label}</div>
       {u.account && <div className="usage-account__email">{u.account}</div>}
       {u.limits.map((l) => (
-        <LimitRow key={limitKey(l)} limit={l} />
+        <LimitRow key={limitKey(l)} limit={l} mode={mode} />
       ))}
       {u.limits.length === 0 && (
         <div className="usage-popover__empty">
@@ -106,6 +116,8 @@ export function UsageIndicator(): JSX.Element | null {
 
   const claudeAccounts = useSettings((s) => s.settings.claudeAccounts)
   const systemLabelSetting = useSettings((s) => s.settings.systemAccountLabel)
+  const hiddenProviders = useSettings((s) => s.settings.hiddenUsageProviders)
+  const percentMode = useSettings((s) => s.settings.usagePercentMode)
   // Local logged-in accounts get their own popover row; skip pending logins + remote (host) ones.
   const accounts = useMemo(
     () => claudeAccounts.filter((a) => !a.pending && !a.host),
@@ -156,14 +168,20 @@ export function UsageIndicator(): JSX.Element | null {
     return () => window.removeEventListener('mousedown', onDown)
   }, [open])
 
+  // Settings → Usage toggles are a display choice, applied before any other rule — a hidden
+  // provider is invisible here even when signed in and mid-limit.
+  const hidden = new Set(hiddenProviders)
+  const visibleProviders = providers.filter((p) => !hidden.has(p.provider))
+  const claudeUsage = hidden.has('claude') ? null : usage
+
   // Only providers the user has actually enabled reach the pill; render whenever ANY of them
   // (Claude included) has something to say. Both rules are pure and pinned by tests — gating on
   // Claude alone, which is what this did, left a Codex-only user with no pill at all.
-  const enabled = enabledProviders(providers)
-  if (!hasAnyUsage(usage, providers)) return null
+  const enabled = enabledProviders(visibleProviders)
+  if (!hasAnyUsage(claudeUsage, visibleProviders)) return null
 
-  const limits = usage?.limits ?? []
-  const status = usage?.status ?? 'unavailable'
+  const limits = claudeUsage?.limits ?? []
+  const status = claudeUsage?.status ?? 'unavailable'
   const hasData = limits.length > 0 || enabled.length > 0
   const fetching = refreshing
   const isError = status === 'error'
@@ -206,7 +224,7 @@ export function UsageIndicator(): JSX.Element | null {
           <span key={limitKey(l)}>
             {i > 0 && <span className="usage-pill__sep">·</span>}
             <span className="usage-pill__num">
-              {Math.round(100 - l.usedPercent)}% {limitShortLabel(l.kind, l.scopeLabel)}
+              {percentNumber(l.usedPercent, percentMode)}% {limitShortLabel(l.kind, l.scopeLabel)}
             </span>
           </span>
         ))}
@@ -216,10 +234,10 @@ export function UsageIndicator(): JSX.Element | null {
           const worst = primaryLimit(p.limits)
           if (!worst) return null
           return (
-            <span key={p.provider}>
+            <span key={p.provider} className="usage-pill__provider">
               {(limits.length > 0 || i > 0) && <span className="usage-pill__sep">·</span>}
               <span className="usage-pill__num">
-                {Math.round(100 - worst.usedPercent)}% {labelFor(p.provider)}
+                {percentNumber(worst.usedPercent, percentMode)}% {labelFor(p.provider)}
               </span>
             </span>
           )
@@ -244,13 +262,14 @@ export function UsageIndicator(): JSX.Element | null {
           {accounts.length > 0 && usage ? (
             <>
               <AccountUsageBlock
+                mode={percentMode}
                 label={systemAccountDisplay(systemLabelSetting, usage.email)}
                 // Avoid printing the email twice when it's already the display label.
                 email={systemLabelSetting.trim() ? (usage.email ?? undefined) : undefined}
                 u={usage}
               />
               {accounts.map((a) => (
-                <AccountUsageBlock key={a.id} label={a.label} email={a.email} u={acctUsage[a.id] ?? null} />
+                <AccountUsageBlock key={a.id} mode={percentMode} label={a.label} email={a.email} u={acctUsage[a.id] ?? null} />
               ))}
             </>
           ) : (
@@ -261,7 +280,7 @@ export function UsageIndicator(): JSX.Element | null {
                 <div className="usage-account__label">Claude</div>
               )}
               {limits.map((l) => (
-                <LimitRow key={limitKey(l)} limit={l} />
+                <LimitRow key={limitKey(l)} limit={l} mode={percentMode} />
               ))}
               {!hasData && <div className="usage-popover__empty">No usage data.</div>}
               {usage?.email && (
@@ -272,8 +291,8 @@ export function UsageIndicator(): JSX.Element | null {
               )}
             </>
           )}
-          {providers.map((p) => (
-            <ProviderBlock key={p.provider} u={p} />
+          {visibleProviders.map((p) => (
+            <ProviderBlock key={p.provider} u={p} mode={percentMode} />
           ))}
         </div>
       )}

--- a/src/renderer/components/settings/SettingsIcons.tsx
+++ b/src/renderer/components/settings/SettingsIcons.tsx
@@ -38,6 +38,12 @@ const PATHS: Record<SettingsSectionId, React.JSX.Element> = {
   agents: (
     <path d="M8 2.3 9.4 5.9 13 7.3 9.4 8.7 8 12.3 6.6 8.7 3 7.3 6.6 5.9z" />
   ),
+  usage: (
+    <>
+      <path d="M2.5 12.5a5.5 5.5 0 1 1 11 0" />
+      <path d="M8 12.5 10.8 8" />
+    </>
+  ),
   accounts: (
     <>
       <circle cx="8" cy="5.5" r="2.6" />

--- a/src/renderer/components/settings/SettingsPage.tsx
+++ b/src/renderer/components/settings/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { AppearanceSection } from './sections/AppearanceSection'
 import { PhoneSection } from './sections/PhoneSection'
 import { SpeechSection } from './sections/SpeechSection'
 import { AgentsSection } from './sections/AgentsSection'
+import { UsageSection } from './sections/UsageSection'
 import { AccountsSection } from './sections/AccountsSection'
 import { CustomAgentsSection } from './sections/CustomAgentsSection'
 import { NotificationsSection } from './sections/NotificationsSection'
@@ -71,6 +72,7 @@ export function SettingsPage({
             <PhoneSection isActive={active === 'phone'} />
             <SpeechSection isActive={active === 'speech'} onNavigate={setActive} />
             <AgentsSection isActive={active === 'agents'} />
+            <UsageSection isActive={active === 'usage'} />
             <AccountsSection isActive={active === 'accounts'} />
             <CustomAgentsSection isActive={active === 'custom-agents'} />
             <NotificationsSection isActive={active === 'notifications'} />

--- a/src/renderer/components/settings/nav.test.ts
+++ b/src/renderer/components/settings/nav.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { SETTINGS_GROUPS, allSectionIds, FIRST_SECTION_ID } from './nav'
 
 describe('SETTINGS_GROUPS', () => {
-  it('lists exactly 18 sections with no duplicates', () => {
+  it('lists exactly 19 sections with no duplicates', () => {
     const ids = allSectionIds()
-    expect(ids).toHaveLength(18)
-    expect(new Set(ids).size).toBe(18)
+    expect(ids).toHaveLength(19)
+    expect(new Set(ids).size).toBe(19)
   })
   it('starts at a section that exists in the groups', () => {
     expect(allSectionIds()).toContain(FIRST_SECTION_ID)

--- a/src/renderer/components/settings/nav.ts
+++ b/src/renderer/components/settings/nav.ts
@@ -6,6 +6,7 @@ export type SettingsSectionId =
   | 'phone'
   | 'speech'
   | 'agents'
+  | 'usage'
   | 'accounts'
   | 'custom-agents'
   | 'notifications'
@@ -24,40 +25,44 @@ export interface SettingsGroup {
   sections: { id: SettingsSectionId; title: string }[]
 }
 
+// Grouped by what the user is DOING, not by where the code lives: AI work first (it is what
+// the app is for), then the workspace around it, then connectivity, then app housekeeping.
 export const SETTINGS_GROUPS: SettingsGroup[] = [
   {
-    id: 'general',
-    title: 'General',
-    sections: [
-      { id: 'terminal', title: 'Terminal' },
-      { id: 'shell', title: 'Shell' },
-      { id: 'behavior', title: 'Behavior' },
-      { id: 'appearance', title: 'Appearance' },
-      { id: 'phone', title: 'Phone' },
-      { id: 'speech', title: 'Speech' }
-    ]
-  },
-  {
-    id: 'agents',
-    title: 'Agents',
+    id: 'ai',
+    title: 'AI capabilities',
     sections: [
       { id: 'agents', title: 'Agents' },
       { id: 'accounts', title: 'Accounts' },
       { id: 'custom-agents', title: 'Custom agents' },
-      { id: 'notifications', title: 'Notifications' },
+      { id: 'usage', title: 'Usage' },
       { id: 'commit', title: 'Commit messages' }
     ]
   },
   {
-    id: 'sessions',
-    title: 'Sessions',
-    sections: [{ id: 'tmux', title: 'tmux' }]
+    id: 'workspace',
+    title: 'Workspace',
+    sections: [
+      { id: 'terminal', title: 'Terminal' },
+      { id: 'shell', title: 'Shell' },
+      { id: 'tmux', title: 'tmux' },
+      { id: 'behavior', title: 'Behavior' }
+    ]
   },
   {
-    id: 'account',
-    title: 'Account',
+    id: 'interface',
+    title: 'Interface',
     sections: [
-      { id: 'license', title: 'License' },
+      { id: 'appearance', title: 'Appearance' },
+      { id: 'notifications', title: 'Notifications' },
+      { id: 'speech', title: 'Speech' }
+    ]
+  },
+  {
+    id: 'connectivity',
+    title: 'Remote & team',
+    sections: [
+      { id: 'phone', title: 'Phone' },
       { id: 'remote', title: 'Remote access' },
       { id: 'team-access', title: 'Team Access' },
       { id: 'ssh', title: 'Remote (SSH)' }
@@ -67,13 +72,14 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
     id: 'application',
     title: 'Application',
     sections: [
+      { id: 'license', title: 'License' },
       { id: 'updates', title: 'Updates' },
       { id: 'privacy', title: 'Privacy' }
     ]
   }
 ]
 
-export const FIRST_SECTION_ID: SettingsSectionId = 'terminal'
+export const FIRST_SECTION_ID: SettingsSectionId = 'agents'
 
 export function allSectionIds(): SettingsSectionId[] {
   return SETTINGS_GROUPS.flatMap((g) => g.sections.map((s) => s.id))

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -46,113 +46,12 @@ const ROWS = {
       'shift tab'
     ]
   },
-  cookieProviders: {
-    title: 'Usage from web consoles',
-    keywords: [
-      'minimax',
-      'opencode',
-      'usage',
-      'quota',
-      'cookie',
-      'limits',
-      'provider',
-      'session'
-    ]
-  }
 }
 const ENTRIES = Object.values(ROWS)
-
-/**
- * Providers that publish no CLI credential — their quota lives behind a web console session, so
- * the user pastes a cookie. Each row is write-only: it can store or clear a value and can see
- * WHETHER one is stored, but the secret is never read back into the UI.
- */
-const COOKIE_PROVIDER_ROWS = [
-  {
-    id: 'minimax',
-    label: 'MiniMax',
-    description:
-      "MiniMax exposes no CLI credential, so its quota is read with your console session. Open platform.minimax.io/console/usage, copy the request's Cookie header from DevTools, and paste it here.",
-    placeholder: 'Cookie: _token=…'
-  },
-  {
-    id: 'opencode',
-    label: 'opencode',
-    description:
-      'opencode publishes no usage API, so the numbers are read from your dashboard page. Open opencode.ai, copy the Cookie header from DevTools, and paste it here. Because this reads a page rather than an API, it can stop working when opencode changes their site — it will report an error rather than silently showing nothing.',
-    placeholder: 'auth=…'
-  }
-] as const
-
-function CookieProviderRow({
-  id,
-  label,
-  description,
-  placeholder,
-  stored,
-  onChange
-}: {
-  id: string
-  label: string
-  description: string
-  placeholder: string
-  stored: boolean
-  onChange: (stored: boolean) => void
-}): React.JSX.Element {
-  const [value, setValue] = useState('')
-  const save = async (next: string): Promise<void> => {
-    onChange(await window.nodeTerminal.usage.setProviderCookie(id, next))
-    // Never keep the secret in component state once it has been handed over.
-    setValue('')
-  }
-  return (
-    <FieldRow
-      label={label}
-      description={description}
-      note={
-        stored
-          ? 'Stored in a file only your user can read, never in settings.json. It is not shown again — paste a fresh one when your session expires.'
-          : 'This is a live session credential. It is stored in a 0600 file, not in settings.json, and is never read back into the UI.'
-      }
-      control={
-        <div className="flex items-center gap-2">
-          <input
-            type="password"
-            className="input w-64"
-            placeholder={stored ? '•••••••• stored' : placeholder}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            autoComplete="off"
-            spellCheck={false}
-          />
-          <Button onClick={() => void save(value)} disabled={!value.trim()}>
-            Save
-          </Button>
-          {stored && <Button onClick={() => void save('')}>Clear</Button>}
-        </div>
-      }
-    />
-  )
-}
 
 export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.Element {
   const settings = useSettings((s) => s.settings)
   const update = useSettings((s) => s.update)
-  // Cookie-based providers are write-only across the IPC boundary: we can ask WHICH have one
-  // stored and set/clear them, but never read a value back — so an input starts empty even when
-  // one is configured, and is cleared the moment it is handed over.
-  const [cookieStored, setCookieStored] = useState<Record<string, boolean>>({})
-  useEffect(() => {
-    if (!isActive) return
-    let cancelled = false
-    void window.nodeTerminal.usage.cookieProviders().then((v) => {
-      if (!cancelled) setCookieStored(v)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [isActive])
-
   const rows: { id: AgentId; label: string; isBuiltin: boolean }[] = [
     ...BUILTIN_AGENT_IDS.map((id) => ({ id, label: AGENT_CONFIG[id].label, isBuiltin: true })),
     ...settings.customAgents.map((c) => ({ id: c.id, label: c.label || c.id, isBuiltin: false }))
@@ -218,16 +117,6 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
             )
           })}
         </div>
-      </SearchableRow>
-      <SearchableRow {...ROWS.cookieProviders}>
-        {COOKIE_PROVIDER_ROWS.map((p) => (
-          <CookieProviderRow
-            key={p.id}
-            {...p}
-            stored={!!cookieStored[p.id]}
-            onChange={(stored) => setCookieStored((m) => ({ ...m, [p.id]: stored }))}
-          />
-        ))}
       </SearchableRow>
       <SearchableRow {...ROWS.permissionMode}>
         <FieldRow

--- a/src/renderer/components/settings/sections/UsageSection.tsx
+++ b/src/renderer/components/settings/sections/UsageSection.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react'
+import { useSettings } from '../../../state/settings'
+import { SettingsSection } from '../SettingsSection'
+import { SearchableRow } from '../SearchableRow'
+import { FieldRow } from '../FieldRow'
+import { Switch } from '@renderer/ui/Switch'
+import { Button } from '@renderer/ui/Button'
+import { SegmentedPill } from '@renderer/ui/SegmentedPill'
+import { USAGE_PROVIDER_IDS, providerLabel } from '@shared/usage-limits'
+import { AGENT_CONFIG } from '@shared/agents/config'
+
+const ROWS = {
+  percentMode: {
+    title: 'Usage percentages',
+    keywords: ['usage', 'percent', 'used', 'remaining', 'left', 'display']
+  },
+  visibility: {
+    title: 'Providers',
+    keywords: [
+      'usage',
+      'provider',
+      'show',
+      'hide',
+      'toggle',
+      'claude',
+      'codex',
+      'gemini',
+      'grok',
+      'kimi',
+      'minimax',
+      'opencode',
+      'pill',
+      'indicator'
+    ]
+  },
+  cookies: {
+    title: 'Web-console sign-in',
+    keywords: ['minimax', 'opencode', 'cookie', 'session', 'sign in', 'credential', 'paste']
+  }
+}
+const ENTRIES = Object.values(ROWS)
+
+/** AGENT_CONFIG is keyed by builtin ids; billing-only providers fall through to the label table. */
+function labelFor(provider: string): string {
+  const agentLabel = (AGENT_CONFIG as Record<string, { label?: string } | undefined>)[provider]?.label
+  return providerLabel(provider, agentLabel)
+}
+
+const PROVIDER_BLURBS: Record<string, string> = {
+  claude: 'Session, weekly and per-model limits from your Claude subscription.',
+  codex: 'Session and weekly limits from your ChatGPT (Codex) subscription.',
+  gemini: 'Per-model hourly quota from the Gemini CLI sign-in.',
+  grok: 'Weekly credits and monthly budget from the Grok CLI sign-in.',
+  kimi: 'Session and weekly quota from the Kimi Code sign-in.',
+  minimax: 'Per-model session quota — needs the cookie below.',
+  opencode: 'Session, weekly and monthly usage — needs the cookie below.'
+}
+
+/**
+ * Providers that publish no CLI credential — their quota lives behind a web console session, so
+ * the user pastes a cookie. Each row is write-only: it can store or clear a value and can see
+ * WHETHER one is stored, but the secret is never read back into the UI.
+ */
+const COOKIE_PROVIDER_ROWS = [
+  {
+    id: 'minimax',
+    label: 'MiniMax',
+    description:
+      "MiniMax exposes no CLI credential, so its quota is read with your console session. Open platform.minimax.io/console/usage, copy the request's Cookie header from DevTools, and paste it here.",
+    placeholder: 'Cookie: _token=…'
+  },
+  {
+    id: 'opencode',
+    label: 'opencode',
+    description:
+      'opencode publishes no usage API, so the numbers are read from your dashboard page. Open opencode.ai, copy the Cookie header from DevTools, and paste it here. Because this reads a page rather than an API, it can stop working when opencode changes their site — it will report an error rather than silently showing nothing.',
+    placeholder: 'auth=…'
+  }
+] as const
+
+function CookieProviderRow({
+  id,
+  label,
+  description,
+  placeholder,
+  stored,
+  onChange
+}: {
+  id: string
+  label: string
+  description: string
+  placeholder: string
+  stored: boolean
+  onChange: (stored: boolean) => void
+}): React.JSX.Element {
+  const [value, setValue] = useState('')
+  const save = async (next: string): Promise<void> => {
+    onChange(await window.nodeTerminal.usage.setProviderCookie(id, next))
+    // Never keep the secret in component state once it has been handed over.
+    setValue('')
+  }
+  return (
+    <FieldRow
+      label={label}
+      description={description}
+      note={
+        stored
+          ? 'Stored in a file only your user can read, never in settings.json. It is not shown again — paste a fresh one when your session expires.'
+          : 'This is a live session credential. It is stored in a 0600 file, not in settings.json, and is never read back into the UI.'
+      }
+      control={
+        <div className="flex items-center gap-2">
+          <input
+            type="password"
+            className="input w-64"
+            placeholder={stored ? '•••••••• stored' : placeholder}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <Button onClick={() => void save(value)} disabled={!value.trim()}>
+            Save
+          </Button>
+          {stored && <Button onClick={() => void save('')}>Clear</Button>}
+        </div>
+      }
+    />
+  )
+}
+
+export function UsageSection({ isActive }: { isActive: boolean }): React.JSX.Element | null {
+  const settings = useSettings((s) => s.settings)
+  const update = useSettings((s) => s.update)
+
+  const hidden = new Set(settings.hiddenUsageProviders)
+  const setShown = (provider: string, shown: boolean): void => {
+    const next = settings.hiddenUsageProviders.filter((p) => p !== provider)
+    if (!shown) next.push(provider)
+    update({ hiddenUsageProviders: next })
+  }
+
+  // Which cookie providers have one stored — state only; the values never reach the renderer.
+  const [cookieStored, setCookieStored] = useState<Record<string, boolean>>({})
+  useEffect(() => {
+    if (!isActive) return
+    let cancelled = false
+    void window.nodeTerminal.usage.cookieProviders().then((v) => {
+      if (!cancelled) setCookieStored(v)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isActive])
+
+  return (
+    <SettingsSection
+      id="usage"
+      title="Usage"
+      description="Subscription limits shown in the pill at the bottom-left of the canvas. Hiding a provider is a display choice — credentials are untouched, so re-enabling is instant."
+      isActive={isActive}
+      searchEntries={ENTRIES}
+    >
+      <SearchableRow {...ROWS.percentMode}>
+        <FieldRow
+          label="Usage percentages"
+          description="Whether provider limits show the percentage used or remaining."
+          control={
+            <SegmentedPill
+              value={settings.usagePercentMode}
+              options={[
+                { value: 'used', label: 'Used' },
+                { value: 'remaining', label: 'Remaining' }
+              ]}
+              onChange={(v) => update({ usagePercentMode: v })}
+              ariaLabel="Usage percentage display"
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.visibility}>
+        <div className="space-y-5">
+          {USAGE_PROVIDER_IDS.map((id) => (
+            <FieldRow
+              key={id}
+              label={`${labelFor(id)} usage`}
+              description={PROVIDER_BLURBS[id] ?? ''}
+              control={
+                <Switch
+                  checked={!hidden.has(id)}
+                  onChange={(v) => setShown(id, v)}
+                  ariaLabel={`Show ${labelFor(id)} usage`}
+                />
+              }
+            />
+          ))}
+        </div>
+      </SearchableRow>
+      <SearchableRow {...ROWS.cookies}>
+        <div className="space-y-5">
+          {COOKIE_PROVIDER_ROWS.map((p) => (
+            <CookieProviderRow
+              key={p.id}
+              {...p}
+              stored={!!cookieStored[p.id]}
+              onChange={(stored) => setCookieStored((m) => ({ ...m, [p.id]: stored }))}
+            />
+          ))}
+        </div>
+      </SearchableRow>
+    </SettingsSection>
+  )
+}

--- a/src/renderer/lib/usageFormat.ts
+++ b/src/renderer/lib/usageFormat.ts
@@ -70,3 +70,19 @@ export function severityColor(severity: string | null, leftPercent: number): str
       return barColor(leftPercent)
   }
 }
+
+/**
+ * The percentage a limit renders as, honouring the used/remaining display setting. Only the
+ * NUMBER flips — the bar always fills with what is left (a fuel gauge), because inverting the
+ * fill per mode would also invert what the severity colours appear to mean.
+ */
+export function percentText(usedPercent: number, mode: 'used' | 'remaining'): string {
+  return mode === 'used'
+    ? `${Math.round(usedPercent)}% used`
+    : `${Math.round(100 - usedPercent)}% left`
+}
+
+/** Compact form for the pill: the bare number, no suffix (the segment label follows it). */
+export function percentNumber(usedPercent: number, mode: 'used' | 'remaining'): number {
+  return Math.round(mode === 'used' ? usedPercent : 100 - usedPercent)
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -4727,6 +4727,9 @@ body,
 .usage-pill__minibar-fill { display: block; height: 100%; border-radius: 3px; }
 .usage-pill__num { color: var(--label, #fff); }
 .usage-pill__sep { color: rgba(255, 255, 255, 0.4); }
+/* Non-Claude provider segments read one step quieter than the Claude numbers, so a long pill
+   still scans as "Claude first, others after" without needing separate icons per provider. */
+.usage-pill__provider .usage-pill__num { color: rgba(255, 255, 255, 0.75); font-size: 11px; }
 .usage-pill__dim { color: rgba(255, 255, 255, 0.5); }
 .usage-pill__pulse { animation: usage-pulse 1.2s ease-in-out infinite; }
 @keyframes usage-pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -608,6 +608,12 @@ export interface Settings {
   systemAccountLabel: string
   /** Agent ids hidden from the Add menus. */
   disabledAgents: AgentId[]
+  /** Usage providers hidden from the pill + popover (Settings → Usage toggles). Hiding is a
+   *  DISPLAY choice — credentials and fetchers are untouched, so re-enabling is instant. */
+  hiddenUsageProviders: string[]
+  /** Whether usage percentages render as consumed ("32% used") or remaining ("68% left").
+   *  'remaining' is the historical default; orca users tend to expect 'used'. */
+  usagePercentMode: 'used' | 'remaining'
   /** Which agent the ⌘⇧C shortcut / quick-add launches. Always a launchable builtin. */
   defaultAgent: AgentId
   /** The permission mode Claude TERMINAL (CLI) sessions START in — passed as `--permission-mode`
@@ -664,6 +670,8 @@ export const DEFAULT_SETTINGS: Settings = {
   // All three builtin agents (Claude/Codex/Gemini) show in the Add menus out of the box.
   // Existing users keep whatever they've saved (their persisted disabledAgents overrides this).
   disabledAgents: [],
+  hiddenUsageProviders: [],
+  usagePercentMode: 'remaining',
   defaultAgent: 'claude',
   // Sessions start in auto mode out of the box. Existing users pick this up on hydrate
   // (settings hydrate merges over DEFAULT_SETTINGS) — a deliberate behavior change.

--- a/src/shared/usage-limits.ts
+++ b/src/shared/usage-limits.ts
@@ -79,6 +79,21 @@ export function hasAnyUsage(
 }
 
 /**
+ * Every usage provider the app can read, in display order — Claude first (the primary agent),
+ * then the rest alphabetically. The Settings toggles iterate this, so a new provider gets its
+ * on/off switch by being added here.
+ */
+export const USAGE_PROVIDER_IDS = [
+  'claude',
+  'codex',
+  'gemini',
+  'grok',
+  'kimi',
+  'minimax',
+  'opencode'
+] as const
+
+/**
  * Display names for usage providers that are NOT builtin agents — Grok, Kimi and the rest are
  * billing relationships we can read, not CLIs nodeterm spawns, so they have no AGENT_CONFIG
  * entry to borrow a label from.


### PR DESCRIPTION
Implements the orca-style settings ask: grouped sidebar, visual polish, and — the concrete feature — **per-provider usage visibility toggles** with a used/remaining display choice.

## New: Settings → AI capabilities → Usage

Modelled on orca's status-bar panel (second screenshot):

- **Usage percentages: Used / Remaining** segmented control. `remaining` is the default — the pill's historical behavior. Only the *number* flips: the bar always fills with what's left (a fuel gauge), because inverting the fill per mode would also invert what the severity colours appear to mean.
- **One switch per provider** (Claude, Codex, Gemini, Grok, Kimi, MiniMax, opencode), each with a one-line blurb of what it shows and where it comes from.
- **The web-console cookie rows (MiniMax / opencode) move here** from the Agents section — they're usage configuration and were only in Agents because it predated this section.

Hiding is a **display choice**: credentials and fetchers are untouched, so re-enabling is instant. It's applied before every other pill rule — a hidden provider is invisible even when signed in and mid-limit, Claude included.

## Sidebar regrouping

Grouped by what the user is *doing*, not where the code lives:

| Before | After |
|---|---|
| General / Agents / Sessions / Account / Application | **AI capabilities** / Workspace / Interface / Remote & team / Application |

AI first — it's what the app is for. Section **ids are unchanged**, so deep links (`initialSection`) and settings search keep working; the entry section moves from Terminal to Agents to match.

## Polish

Non-Claude pill segments render one step quieter (smaller, dimmer) than the Claude numbers, so a long pill still scans as "Claude first, others after" without per-provider icons.

## Compat

Both settings ride the existing shallow-merge hydration (`{ ...DEFAULT_SETTINGS, ...saved }`) — existing users pick up defaults with no migration. 232 files / 2400 tests pass; both tsconfig projects clean.

⚠️ UI not visually verified on this box (Linux server, no display) — needs the Mac rebuild that's already owed for the rest of the usage work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)