### PR TITLE
feat: chat icon becomes comments — node flyout + default-open modal panel

### DIFF
--- a/src/renderer/components/kanban/BoardLogPanel.tsx
+++ b/src/renderer/components/kanban/BoardLogPanel.tsx
@@ -7,8 +7,10 @@ import { useBoardLog } from '../../state/boardLog'
 import type { KanbanSession } from './KanbanView'
 
 interface BoardLogPanelProps {
-  /** The card whose activity this panel shows — feed + composer are scoped to `card.id`. */
-  card: KanbanSession
+  /** The card/node whose activity this panel shows — feed + composer are scoped to `card.id`.
+   *  Only the id is needed, so the canvas node flyout can use this panel without building a
+   *  full KanbanSession. */
+  card: Pick<KanbanSession, 'id'>
 }
 
 /** Human one-liner for an activity event. column-* events carry no nodeId and so never reach a

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
 import { IconChat, IconMic, IconSearch } from '../icons'
-import { renderMarkdown } from '../../lib/markdown'
 import { useSession } from '../../session/session'
 import type { KanbanSession } from './KanbanView'
 import { BoardLogPanel } from './BoardLogPanel'
@@ -33,8 +32,8 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
   const [title, setTitle] = useState(session.title)
   const [searchOpen, setSearchOpen] = useState(false)
   const [naming, setNaming] = useState(false)
-  // Markdown view of the captured output (the node's ⌘M, modal edition): null = terminal.
-  const [mdHtml, setMdHtml] = useState<string | null>(null)
+  // Comments & activity panel: OPEN by default in the modal; the header 💬 collapses it.
+  const [panelOpen, setPanelOpen] = useState(true)
   const isTerminal = session.kind === 'terminal'
 
   const nameWithAi = async () => {
@@ -42,15 +41,6 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
     const r = await api.pty.generateName(session.id, session.spawn.cwd ?? '')
     setNaming(false)
     if (r.ok) onRename(r.message)
-  }
-
-  const toggleMd = async () => {
-    if (mdHtml !== null) {
-      setMdHtml(null)
-      return
-    }
-    const captured = await api.pty.capture(session.id, true)
-    setMdHtml(renderMarkdown(captured || ''))
   }
   // Ref mirror: the capture-phase listener below closes over stale state otherwise.
   const editingTitleRef = useRef(false)
@@ -144,16 +134,16 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
               >
                 {naming ? '…' : '✦'}
               </button>
-              <button
-                className="kanban-modal__action"
-                title="Markdown view of the output"
-                aria-pressed={mdHtml !== null}
-                onClick={toggleMd}
-              >
-                <IconChat />
-              </button>
             </>
           )}
+          <button
+            className="kanban-modal__action"
+            title={panelOpen ? 'Hide comments & activity' : 'Show comments & activity'}
+            aria-pressed={panelOpen}
+            onClick={() => setPanelOpen((v) => !v)}
+          >
+            <IconChat />
+          </button>
           <button className="kanban-modal__action" title="Open on canvas" onClick={onOpenCanvas}>
             ↗
           </button>
@@ -177,25 +167,20 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
                   // A live SECOND client on the node's session — keyed by node id so switching cards
                   // remounts a fresh viewer. Chat has no PTY; it opens on the canvas. The markdown
                   // view OVERLAYS the terminal (kept mounted — its viewer must not detach/re-seed).
-                  <>
-                    <ModalTerminal
-                      key={session.id}
-                      nodeId={session.id}
-                      spawn={session.spawn}
-                      searchOpen={searchOpen}
-                      onCloseSearch={() => setSearchOpen(false)}
-                    />
-                    {mdHtml !== null && (
-                      <div className="kanban-modal__md" dangerouslySetInnerHTML={{ __html: mdHtml }} />
-                    )}
-                  </>
+                  <ModalTerminal
+                    key={session.id}
+                    nodeId={session.id}
+                    spawn={session.spawn}
+                    searchOpen={searchOpen}
+                    onCloseSearch={() => setSearchOpen(false)}
+                  />
                 ) : (
                   <div className="kanban-modal__placeholder">Chat sessions open on the canvas.</div>
                 )}
               </div>
             )}
           </div>
-          <BoardLogPanel card={session} />
+          {panelOpen && <BoardLogPanel card={session} />}
         </div>
       </div>
     </div>,

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -73,6 +73,7 @@ import { ensureActivePermissionMode } from '../state/permissionMode'
 import { buildSshArgs, type SshConnection } from '@shared/ssh'
 import { hintLabel } from '@shared/platform-utils'
 import { ColumnPill } from '../components/kanban/ColumnPill'
+import { BoardLogPanel } from '../components/kanban/BoardLogPanel'
 
 /** Backslash-escape shell-special characters, like a native terminal does on file drop. */
 function escapeDroppedPath(p: string): string {
@@ -402,6 +403,8 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
   const contextLinkCapable = !!agentId && canContextLink(agentId) // context-link tip wording only; handles render on all terminals
   const showUsage = !!agentId && hasUsage(agentId) // per-node context-window meter
   const showChat = !!agentId && canChat(agentId) // Cmd+M opens a chat panel instead of markdown
+  // The header 💬 now opens the board-log comments flyout (right side); ⌘M keeps the markdown/chat view.
+  const [commentsOpen, setCommentsOpen] = useState(false)
   const canRenameNode = !!agentId && canRename(agentId) // title ⇄ session-name two-way sync
   const agentLabel = (agentId ? agentConfig(agentId) : undefined)?.label ?? 'Agent'
 
@@ -1723,17 +1726,15 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
             {naming ? '…' : '✦'}
           </button>
         </Tooltip>
-        {showChat && (
-          <Tooltip label={hintLabel('Chat / markdown view (⌘M)')}>
-            <button
-              className="term-node__chat nodrag"
-              aria-pressed={!!data.mdMode}
-              onClick={() => updateNodeData(id, (n) => ({ mdMode: !n.data.mdMode }))}
-            >
-              <IconChat />
-            </button>
-          </Tooltip>
-        )}
+        <Tooltip label="Comments & activity">
+          <button
+            className="term-node__chat nodrag"
+            aria-pressed={commentsOpen}
+            onClick={() => setCommentsOpen((v) => !v)}
+          >
+            <IconChat />
+          </button>
+        </Tooltip>
         <button
           className="term-node__close"
           title="Close (ends the session)"
@@ -1816,6 +1817,13 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
           ))}
       </div>
     </div>
+    {/* Board-log comments flyout — a SIBLING of the root (overflow:hidden would clip it),
+        expanding to the node's right. Same feed/composer as the card modal's panel. */}
+    {commentsOpen && !collapsed && (
+      <div className="term-node__comments nodrag nowheel" onMouseDown={(e) => e.stopPropagation()}>
+        <BoardLogPanel card={{ id }} />
+      </div>
+    )}
     </>
   )
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6854,19 +6854,23 @@ body,
   background: var(--accent);
   color: #fff;
 }
-.kanban-modal__md {
+
+/* ---- Node comments flyout: the header 💬 expands the board-log feed to the node's right ---- */
+.term-node__comments {
   position: absolute;
-  inset: 0;
-  overflow-y: auto;
-  padding: 14px 18px;
+  left: 100%;
+  top: 0;
+  bottom: 0;
+  margin-left: 10px;
+  width: 300px;
+  display: flex;
   background: #161618;
-  font-size: 13px;
-  line-height: 1.55;
-  color: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  z-index: 5;
 }
-.kanban-modal__md pre {
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 6px;
-  padding: 8px 10px;
-  overflow-x: auto;
+.term-node__comments .board-log {
+  border-left: none;
 }


### PR DESCRIPTION
## Summary

The 💬 icon is repurposed on both surfaces to the board-log comments:

- **Canvas node**: 💬 expands a **comments flyout to the node's right** (300px, sibling of the overflow:hidden node root, `nodrag nowheel`) hosting the same BoardLogPanel feed + composer as the modal. Shown on ALL terminal nodes now (the old icon was chat-capable-agents-only). The markdown/chat view stays reachable via ⌘M — only the icon's job changed.
- **Card modal**: the Comments & activity panel is now **open by default**; 💬 collapses/reopens it. The just-added markdown-view button is removed (superseded by this repurpose; ⌘M covers markdown on canvas).
- `BoardLogPanel`'s card prop loosened to `Pick<KanbanSession, 'id'>` so the node flyout reuses it without building a full card object.

## Test plan

- [x] Full suite 2400/2400, typecheck clean
- [x] Live drive: node 💬 opens the right flyout with composer; a comment posted there lands on THAT node's feed (verified on disk by nodeId) and appears in the same node's modal; card-scoped filtering confirmed (another card's modal correctly does NOT show it); modal panel open by default, 💬 collapses/reopens; markdown button gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h