### PR TITLE
polish: kanban motion & typography — click-to-open cards, Trello-style drop highlight

### DIFF
--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -10,9 +10,6 @@ interface KanbanColumnProps {
   column: KanbanColumnT | null
   cards: KanbanSession[]
   statusById: Record<string, AgentNodeStatus>
-  /** Which cards show their detail row (card click toggles membership). */
-  expandedIds: ReadonlySet<string>
-  onToggleCard: (nodeId: string) => void
   onRename?: (title: string) => void
   onRecolor?: (color: string) => void
   onDelete?: () => void
@@ -31,7 +28,7 @@ interface KanbanColumnProps {
 }
 
 export function KanbanColumn({
-  column, cards, statusById, expandedIds, onToggleCard, onRename, onRecolor, onDelete, onOpenCard,
+  column, cards, statusById, onRename, onRecolor, onDelete, onOpenCard,
   createOptions, onCreate, onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn,
   onDropBeforeCard
 }: KanbanColumnProps) {
@@ -39,6 +36,8 @@ export function KanbanColumn({
   const [title, setTitle] = useState(column?.title ?? '')
   const [swatchesOpen, setSwatchesOpen] = useState(false)
   const [newMenuOpen, setNewMenuOpen] = useState(false)
+  // Trello-style drop highlight: counted enter/leave (dragleave fires when crossing children).
+  const [dragOverCount, setDragOverCount] = useState(0)
 
   const commitTitle = () => {
     const t = title.trim()
@@ -48,10 +47,13 @@ export function KanbanColumn({
 
   return (
     <div
-      className={`kanban-col${column ? '' : ' kanban-col--ungrouped'}`}
+      className={`kanban-col${column ? '' : ' kanban-col--ungrouped'}${dragOverCount > 0 ? ' kanban-col--drop' : ''}`}
       onDragOver={(e) => e.preventDefault()}
+      onDragEnter={() => setDragOverCount((c) => c + 1)}
+      onDragLeave={() => setDragOverCount((c) => Math.max(0, c - 1))}
       onDrop={(e) => {
         e.preventDefault()
+        setDragOverCount(0)
         onDropOnColumn()
       }}
     >
@@ -127,9 +129,7 @@ export function KanbanColumn({
             key={s.id}
             session={s}
             status={statusById[s.id]}
-            expanded={expandedIds.has(s.id)}
-            onToggle={() => onToggleCard(s.id)}
-            onOpenModal={() => onOpenCard(s.id)}
+            onOpen={() => onOpenCard(s.id)}
             onDragStart={() => onCardDragStart(s.id)}
             onDragEnd={onDragEnd}
             onDropBefore={() => onDropBeforeCard(s.id)}

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -69,8 +69,6 @@ export function KanbanView({
   // Primitive selectors (not one object) — an object selector would re-render on every store set.
   const projectName = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.name)
   const projectColor = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.color)
-  // Card detail rows open per session id; transient by design (resets when the board closes).
-  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(new Set())
   const customAgents = useSettings((s) => s.settings.customAgents)
   // "+ New" menu entries: the builtin agents, the user's custom agents, then terminal + sticky
   // (same universe as the dock's add menu, minus canvas-only kinds).
@@ -89,14 +87,6 @@ export function KanbanView({
     { key: 'sticky', label: 'Sticky note', choice: { kind: 'sticky' } }
   ]
   const byId = new Map(sessions.map((s) => [s.id, s]))
-
-  const toggleExpanded = (id: string) =>
-    setExpandedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
 
   // Prune dead nodes' assignments on every persisted change, so they never accumulate
   // in the shared file.
@@ -141,8 +131,6 @@ export function KanbanView({
           column={null}
           cards={sessionsFor(unassigned(board, sessions.map((s) => s.id)))}
           statusById={statusById}
-          expandedIds={expandedIds}
-          onToggleCard={toggleExpanded}
           onOpenCard={setModalNodeId}
           createOptions={createOptions}
           onCreate={(choice) => onCreateNode(choice, null)}
@@ -157,8 +145,6 @@ export function KanbanView({
             column={col}
             cards={sessionsFor(assignedTo(board, col.id))}
             statusById={statusById}
-            expandedIds={expandedIds}
-            onToggleCard={toggleExpanded}
             onRename={(t) => commit(renameColumn(board, col.id, t))}
             onRecolor={(c) => commit(recolorColumn(board, col.id, c))}
             onDelete={() => commit(deleteColumn(board, col.id))}

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { AgentNodeStatus } from '../../state/agentStatus'
 import { ContextMeter } from '../ContextMeter'
 import type { KanbanSession } from './KanbanView'
@@ -5,62 +6,61 @@ import type { KanbanSession } from './KanbanView'
 interface SessionCardProps {
   session: KanbanSession
   status?: AgentNodeStatus
-  expanded: boolean
-  /** Single click toggles the detail row — opening the card moved to ↗ / double-click. */
-  onToggle: () => void
-  /** Open the card modal: both the ↗ button and double-click fire this. */
-  onOpenModal: () => void
+  /** Single click opens the card modal directly (the expand/collapse step was dropped). */
+  onOpen: () => void
   onDragStart: () => void
   onDragEnd: () => void
   /** A dragged card was dropped on this card — insert it before this one. */
   onDropBefore: () => void
 }
 
-export function SessionCard({
-  session, status, expanded, onToggle, onOpenModal, onDragStart, onDragEnd, onDropBefore
-}: SessionCardProps) {
-  const sticky = session.kind === 'sticky'
+export function SessionCard({ session, status, onOpen, onDragStart, onDragEnd, onDropBefore }: SessionCardProps) {
+  // Local drag state only styles THIS card (ghost look) — the drag payload lives in KanbanView.
+  const [dragging, setDragging] = useState(false)
   const badge =
-    !sticky && status?.state === 'working'
+    session.kind !== 'sticky' && status?.state === 'working'
       ? 'running'
-      : !sticky && (status?.state === 'waiting' || status?.state === 'blocked')
+      : session.kind !== 'sticky' && (status?.state === 'waiting' || status?.state === 'blocked')
         ? 'needs'
         : null
+  const stickyPreview = session.kind === 'sticky' ? (session.text ?? '').trim() : ''
+  const hasDetail = !!status?.sessionId || !!status?.session || stickyPreview.includes('\n')
   return (
     <div
-      className={`kanban-card kanban-card--session${expanded ? ' kanban-card--expanded' : ''}`}
+      className={`kanban-card kanban-card--session${dragging ? ' kanban-card--dragging' : ''}`}
       draggable
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = 'move'
+        setDragging(true)
         onDragStart()
       }}
-      onDragEnd={onDragEnd}
+      onDragEnd={() => {
+        setDragging(false)
+        onDragEnd()
+      }}
       onDragOver={(e) => e.preventDefault()}
       onDrop={(e) => {
         e.preventDefault()
         e.stopPropagation() // don't let the column's end-drop swallow a drop aimed at this card
         onDropBefore()
       }}
-      onClick={onToggle}
-      onDoubleClick={(e) => {
-        e.stopPropagation()
-        onOpenModal()
-      }}
-      title={expanded ? 'Collapse' : 'Expand'}
+      onClick={onOpen}
+      title="Open card"
     >
       <div className="kanban-card__row">
         <span className="kanban-card__nodedot" style={{ background: session.color }} />
         <span className="kanban-card__title">{session.title}</span>
-        {sticky && <span className="kanban-card__kind">note</span>}
+        {session.kind === 'sticky' && <span className="kanban-card__kind">note</span>}
         {badge === 'running' && <span className="kanban-badge kanban-badge--running">RUNNING</span>}
         {badge === 'needs' && <span className="kanban-badge kanban-badge--needs">NEEDS YOU</span>}
         {status?.unread && <span className="kanban-card__unread" />}
       </div>
-      {expanded && (
-        /* Clicks inside the detail row (meter popover, session chip) must not collapse the card. */
+      {/* Detail line is ALWAYS visible when the card has something to say (no expand step):
+          agents show the context meter + session chip; multi-line notes show a preview. */}
+      {hasDetail && (
         <div className="kanban-card__detail" onClick={(e) => e.stopPropagation()}>
-          {sticky ? (
-            <span className="kanban-card__stickytext">{session.text || 'Empty note'}</span>
+          {session.kind === 'sticky' ? (
+            <span className="kanban-card__stickytext">{stickyPreview}</span>
           ) : (
             <>
               <ContextMeter sessionId={status?.sessionId ?? null} />
@@ -69,14 +69,8 @@ export function SessionCard({
                   {status.session}
                 </span>
               )}
-              {!status?.sessionId && (
-                <span className="kanban-card__kindlabel">terminal</span>
-              )}
             </>
           )}
-          <button className="kanban-card__open" title="Open card" onClick={onOpenModal}>
-            ↗
-          </button>
         </div>
       )}
     </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6327,7 +6327,7 @@ body,
   flex: 0 0 auto;
 }
 .kanban-header__name {
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 700;
   color: rgba(255, 255, 255, 0.9);
   white-space: nowrap;
@@ -6348,11 +6348,18 @@ body,
 .kanban-col {
   display: flex;
   flex-direction: column;
-  flex: 0 0 272px;
+  flex: 0 0 288px;
   max-height: 100%;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
+  border-radius: 12px;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+}
+/* Trello-style "this column will take the drop" state. */
+.kanban-col--drop {
+  border-color: var(--accent);
+  background: rgba(10, 132, 255, 0.07);
+  box-shadow: 0 0 0 1px var(--accent), 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 .kanban-col__header {
   display: flex;
@@ -6372,8 +6379,8 @@ body,
 }
 .kanban-col__title {
   flex: 1;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 13.5px;
+  font-weight: 700;
   color: rgba(255, 255, 255, 0.85);
   cursor: text;
   white-space: nowrap;
@@ -6392,7 +6399,7 @@ body,
   outline: none;
 }
 .kanban-col__count {
-  font-size: 11px;
+  font-size: 12px;
   color: rgba(255, 255, 255, 0.4);
 }
 .kanban-col__close {
@@ -6446,10 +6453,10 @@ body,
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 8px;
-  padding-top: 8px;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
-  min-height: 22px;
+  margin-top: 7px;
+  padding-top: 7px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  min-height: 20px;
   cursor: default;
 }
 .kanban-card__session {
@@ -6495,8 +6502,9 @@ body,
 .kanban-card__title {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.9);
+  font-size: 13.5px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.94);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -6550,9 +6558,13 @@ body,
   cursor: pointer;
   white-space: nowrap;
 }
+.kanban-add-col {
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
 .kanban-add-col:hover {
-  color: rgba(255, 255, 255, 0.8);
-  border-color: rgba(255, 255, 255, 0.3);
+  color: #fff;
+  border-color: var(--accent);
+  background: rgba(10, 132, 255, 0.06);
 }
 
 
@@ -6599,9 +6611,13 @@ body,
   cursor: pointer;
   text-align: left;
 }
+.kanban-col__new {
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
 .kanban-col__new:hover {
-  color: rgba(255, 255, 255, 0.8);
-  border-color: rgba(255, 255, 255, 0.3);
+  color: #fff;
+  border-color: var(--accent);
+  background: rgba(10, 132, 255, 0.08);
 }
 .kanban-col__newmenu {
   position: absolute;
@@ -6635,27 +6651,43 @@ body,
 .kanban-card__stickytext {
   flex: 1;
   min-width: 0;
-  font-size: 11px;
+  font-size: 12px;
   color: rgba(255, 255, 255, 0.6);
   white-space: pre-line;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 6;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   word-break: break-word;
 }
 
 /* ---- Kanban card modal (Trello-style popup over the board) ---- */
+@keyframes kanban-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
 .kanban-modal-scrim {
   position: fixed;
   inset: 0;
   z-index: 55; /* above the board (25) + drawers (~40), below ConfirmDialog (70+) */
   background: rgba(0, 0, 0, 0.55);
+  animation: kanban-fade 0.14s ease-out;
   display: flex;
   align-items: center;
   justify-content: center;
 }
+@keyframes kanban-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.965) translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
 .kanban-modal {
+  animation: kanban-pop 0.16s ease-out;
   width: min(1040px, calc(100vw - 96px));
   height: min(680px, calc(100vh - 120px));
   display: flex;
@@ -6868,7 +6900,18 @@ body,
 }
 
 /* ---- Node comments flyout: the header 💬 expands the board-log feed to the node's right ---- */
+@keyframes kanban-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
 .term-node__comments {
+  animation: kanban-slide-in 0.14s ease-out;
   position: absolute;
   left: 100%;
   top: 0;


### PR DESCRIPTION
## Summary

Final polish pass on the board, per live-use feedback:

- **Single click on a card opens it** — the expand/collapse step is gone. The detail line (context-meter pill + session chip; a note's 3-line preview) is now ALWAYS visible when the card has something to show.
- **Trello-style drag feedback**: the dragged card ghosts (opacity + slight tilt), and the column under the pointer lights up with an accent outline + tinted background (counted dragenter/dragleave so child-crossings don't flicker); clears on drop/dragend.
- **Typography up**: card titles 12→13.5px medium, column titles 12→13.5px bold, board header 14→16px, counts 11→12px; columns widen 272→288px.
- **Motion**: card hover lift + accent border, modal pop-in (scale+fade) with scrim fade, node comments flyout slide-in, accent hover states on "+ New session" / "+ Add column".

## Test plan

- [x] Suite 2383/2384 — the single failure (`worktree.test.ts`) is the pre-existing chat-removal fallout on main, fails identically there; typecheck clean (also adapted SessionCard to main's narrowed `KanbanSession.kind` after the chat-node removal)
- [x] Live drive 7/7: click opens the modal directly (no expand state left), drop-target column highlights and clears, dragged card ghosts, computed font sizes verified, screenshots reviewed against the Trello reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h