### PR TITLE
feat: context-window pill + popover in the card modal header

### DIFF
--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
 import { IconChat, IconMic, IconSearch } from '../icons'
+import { ContextMeter } from '../ContextMeter'
+import { useAgentStatus } from '../../state/agentStatus'
 import { useSession } from '../../session/session'
 import type { KanbanSession } from './KanbanView'
 import { BoardLogPanel } from './BoardLogPanel'
@@ -31,6 +33,7 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
   const [editingTitle, setEditingTitle] = useState(false)
   const [title, setTitle] = useState(session.title)
   const [searchOpen, setSearchOpen] = useState(false)
+  const agentSessionId = useAgentStatus((st) => st.byId[session.id]?.sessionId)
   const [naming, setNaming] = useState(false)
   // Comments & activity panel: OPEN by default in the modal; the header 💬 collapses it.
   const [panelOpen, setPanelOpen] = useState(true)
@@ -109,6 +112,8 @@ export function CardModal({ session, columnTitle, onClose, onOpenCanvas, onRenam
           <span className="kanban-modal__column">{columnTitle ?? 'Ungrouped'}</span>
           {isTerminal && (
             <>
+              {/* Same context-window pill + popover as the node header (null until usage data). */}
+              <ContextMeter sessionId={agentSessionId ?? null} />
               <button
                 className="kanban-modal__action"
                 title="Search this terminal"


### PR DESCRIPTION
## Summary

The card modal's header now carries the node header's **ContextMeter** for terminal cards: the model + fullness pill (e.g. "Fable 5 ▓ 41%"), clicking it opens the same context popover (token figures, model, last update). Reuses the existing component wholesale — `sessionId` resolved from the agent-status store; renders nothing until the session has usage data (plain shells unaffected, verified live).

## Test plan

- [x] kanban suites + typecheck clean; live smoke: modal header + terminal intact, pill correctly absent without usage data (the component's populated path is the battle-tested node-header meter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h