### PR TITLE
fix(canvas): fit view into the largest chrome-free rectangle

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -25,6 +25,7 @@ import {
   disposeTerminalOnUnmount,
   disposeParkedTerminal
 } from '../nodes/TerminalNode'
+import { solveFitPadding } from './fit-view'
 import { SshReconnector } from '../lib/sshReconnect'
 import { terminalKey } from '../terminal/terminal-config'
 import { StickyNode } from '../nodes/StickyNode'
@@ -329,6 +330,7 @@ const ropeEdge = (id: string, source: string, target: string, color: string): Ed
   style: { stroke: color, strokeWidth: 1.5 },
   markerEnd: { type: MarkerType.ArrowClosed, color, width: 14, height: 14 }
 })
+
 
 const minimapNodeColor = (n: Node): string =>
   (n.data as { color?: string })?.color ?? '#0a84ff'
@@ -679,8 +681,31 @@ export function Canvas() {
    */
   const hasPeersRef = useRef(false)
   const [, bumpHist] = useState(0)
-  const { setViewport, getViewport, fitView, zoomIn, zoomOut, screenToFlowPosition, setCenter, getZoom } =
-    useReactFlow()
+  const {
+    setViewport,
+    getViewport,
+    fitView,
+    zoomIn,
+    zoomOut,
+    screenToFlowPosition,
+    setCenter,
+    getZoom,
+    getNodes,
+    getNodesBounds
+  } = useReactFlow()
+
+  // Single "fit everything" path for every fit-view entry point (dock button, the built-in
+  // Controls button, the ⌘K palette and the context menu) so they behave identically and there's
+  // one place to tune. Solved per click against the CURRENT chrome layout and the CURRENT content
+  // shape, so hiding the minimap or fitting a narrow column reclaims that space instead of paying
+  // a fixed toll for panels the content never reaches.
+  const fitAll = useCallback(() => {
+    const wrap = flowWrapRef.current
+    const bounds = getNodesBounds(getNodes())
+    const padding = wrap ? solveFitPadding(wrap, bounds.width, bounds.height) : null
+    // Nothing to fit, or chrome swallowing the viewport: let fitView use its own framing.
+    void fitView({ duration: 300, padding: padding ?? 0.1 })
+  }, [fitView, getNodes, getNodesBounds])
 
   const activeProjectId = useProjects((s) => s.activeProjectId)
   // The ACTIVE session + its presence — what the canvas-sync publisher and onMutation subscriber
@@ -3997,7 +4022,7 @@ export function Canvas() {
           { type: 'separator' },
           // Canvas actions.
           { label: 'Select all', icon: <IconSelectAll />, onClick: selectAll },
-          { label: 'Fit view', icon: <IconFit />, onClick: () => fitView({ padding: 0.2, duration: 300 }) }
+          { label: 'Fit view', icon: <IconFit />, onClick: fitAll }
         ]
       })
     },
@@ -5712,7 +5737,7 @@ export function Canvas() {
         icon: <IconRemote />,
         run: () => void connectRemote()
       },
-      { id: 'fit', label: 'Fit view', icon: <IconFit />, run: () => fitView({ padding: 0.2, duration: 300 }) },
+      { id: 'fit', label: 'Fit view', icon: <IconFit />, run: fitAll },
       { id: 'save', label: 'Save', icon: <IconSave />, run: () => void persist() }
     ]
     const store = useProjects.getState()
@@ -6122,7 +6147,7 @@ export function Canvas() {
             size={2.5}
             color="#4a4a4a"
           />
-          <Controls showInteractive={false} position="bottom-left">
+          <Controls showInteractive={false} position="bottom-left" onFitView={fitAll}>
             <ControlButton
               className={`canvas-lock-btn${canvasLocked ? ' locked' : ''}`}
               title={canvasLocked ? 'Unlock view (pan/zoom)' : 'Lock view (pan/zoom) — nodes stay movable'}
@@ -6510,7 +6535,7 @@ export function Canvas() {
         onAddRemote={() => openRemotePicker({ x: window.innerWidth / 2, y: window.innerHeight / 2 })}
         onConnectRemote={() => void connectRemote()}
         onSave={persist}
-        onFitView={() => fitView({ padding: 0.2, duration: 300 })}
+        onFitView={fitAll}
         onZoomIn={() => zoomIn({ duration: 150 })}
         onZoomOut={() => zoomOut({ duration: 150 })}
         onDictate={toggleDictation}

--- a/src/renderer/canvas/fit-view.test.ts
+++ b/src/renderer/canvas/fit-view.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { largestFreeRect, rectToPadding, rectsOverlap, type FitRect } from './fit-view'
+
+/**
+ * Geometry measured from a real 1264x722 canvas (see docs/superpowers/specs) — the chrome rects
+ * are the actual dock / minimap / controls positions, already inflated by the gap.
+ */
+const VIEWPORT: FitRect = { left: 12, top: 56, right: 1252, bottom: 754 }
+const DOCK: FitRect = { left: 407, top: 678, right: 858, bottom: 756 }
+const MINIMAP: FitRect = { left: 1035, top: 587, right: 1261, bottom: 763 }
+const CONTROLS: FitRect = { left: 3, top: 635, right: 53, bottom: 763 }
+const CHROME = [DOCK, MINIMAP, CONTROLS]
+
+const w = (r: FitRect): number => r.right - r.left
+const h = (r: FitRect): number => r.bottom - r.top
+const zoomOf = (r: FitRect, cw: number, ch: number): number => Math.min(w(r) / cw, h(r) / ch)
+
+describe('largestFreeRect', () => {
+  it('never returns a rect that overlaps any chrome', () => {
+    for (const [cw, ch] of [
+      [2000, 600],
+      [300, 2000],
+      [1000, 1000],
+      [50, 50],
+      [5000, 20]
+    ]) {
+      const r = largestFreeRect(VIEWPORT, CHROME, cw, ch)
+      expect(r, `content ${cw}x${ch}`).not.toBeNull()
+      for (const c of CHROME) expect(rectsOverlap(r!, c), `content ${cw}x${ch}`).toBe(false)
+    }
+  })
+
+  it('stays inside the viewport', () => {
+    const r = largestFreeRect(VIEWPORT, CHROME, 1000, 1000)!
+    expect(r.left).toBeGreaterThanOrEqual(VIEWPORT.left)
+    expect(r.top).toBeGreaterThanOrEqual(VIEWPORT.top)
+    expect(r.right).toBeLessThanOrEqual(VIEWPORT.right)
+    expect(r.bottom).toBeLessThanOrEqual(VIEWPORT.bottom)
+  })
+
+  it('does not charge narrow content for the bottom-right minimap', () => {
+    // The regression this whole module exists for: a tall narrow column sits well clear of the
+    // minimap's x-range, so it must be allowed to run past the minimap's top edge.
+    const r = largestFreeRect(VIEWPORT, CHROME, 300, 2000)!
+    expect(r.bottom).toBeGreaterThan(MINIMAP.top)
+    expect(r.right).toBeLessThanOrEqual(MINIMAP.left)
+  })
+
+  it('beats a naive "reserve the deepest bottom intrusion" strategy for narrow content', () => {
+    const naiveBottom = Math.min(DOCK.top, MINIMAP.top, CONTROLS.top)
+    const naive: FitRect = { ...VIEWPORT, bottom: naiveBottom }
+    const solved = largestFreeRect(VIEWPORT, CHROME, 300, 2000)!
+    expect(zoomOf(solved, 300, 2000)).toBeGreaterThan(zoomOf(naive, 300, 2000))
+  })
+
+  it('uses the full width for wide content, stopping above the bottom chrome', () => {
+    const r = largestFreeRect(VIEWPORT, CHROME, 4000, 500)!
+    // Wide content genuinely spans the minimap's and controls' x-range, so it must clear them.
+    expect(r.bottom).toBeLessThanOrEqual(Math.min(MINIMAP.top, CONTROLS.top))
+    expect(w(r)).toBeGreaterThan(1000)
+  })
+
+  it('returns the whole viewport when nothing is in the way', () => {
+    const r = largestFreeRect(VIEWPORT, [], 1000, 1000)!
+    expect(r).toEqual(VIEWPORT)
+  })
+
+  it('reclaims space when chrome is hidden (fewer obstacles ⇒ at least as much zoom)', () => {
+    const withAll = largestFreeRect(VIEWPORT, CHROME, 1200, 700)!
+    const withoutMinimap = largestFreeRect(VIEWPORT, [DOCK, CONTROLS], 1200, 700)!
+    expect(zoomOf(withoutMinimap, 1200, 700)).toBeGreaterThanOrEqual(zoomOf(withAll, 1200, 700))
+  })
+
+  it('is exhaustive: no sampled free rect beats the chosen one', () => {
+    const cw = 900
+    const ch = 800
+    const best = largestFreeRect(VIEWPORT, CHROME, cw, ch)!
+    const bestZoom = zoomOf(best, cw, ch)
+    // Brute-force a grid of candidate rects; none may afford more zoom than the solver's. Track
+    // the max and assert once — an expect() per candidate would be millions of calls.
+    const step = 25
+    let brute = 0
+    for (let l = VIEWPORT.left; l < VIEWPORT.right; l += step) {
+      for (let r2 = l + step; r2 <= VIEWPORT.right; r2 += step) {
+        for (let t = VIEWPORT.top; t < VIEWPORT.bottom; t += step) {
+          for (let b = t + step; b <= VIEWPORT.bottom; b += step) {
+            const cand: FitRect = { left: l, right: r2, top: t, bottom: b }
+            if (CHROME.some((c) => rectsOverlap(c, cand))) continue
+            const z = zoomOf(cand, cw, ch)
+            if (z > brute) brute = z
+          }
+        }
+      }
+    }
+    expect(brute).toBeLessThanOrEqual(bestZoom + 1e-6)
+  })
+
+  it('guards degenerate content', () => {
+    expect(largestFreeRect(VIEWPORT, CHROME, 0, 100)).toBeNull()
+    expect(largestFreeRect(VIEWPORT, CHROME, 100, 0)).toBeNull()
+  })
+})
+
+describe('rectToPadding', () => {
+  it('converts a chosen rect into per-side px insets', () => {
+    const outer: FitRect = { left: 0, top: 0, right: 1000, bottom: 800 }
+    expect(rectToPadding(outer, { left: 20, top: 30, right: 900, bottom: 700 })).toEqual({
+      left: '20px',
+      top: '30px',
+      right: '100px',
+      bottom: '100px'
+    })
+  })
+
+  it('never emits negative padding', () => {
+    const outer: FitRect = { left: 0, top: 0, right: 100, bottom: 100 }
+    expect(rectToPadding(outer, { left: -10, top: -10, right: 110, bottom: 110 })).toEqual({
+      left: '0px',
+      top: '0px',
+      right: '0px',
+      bottom: '0px'
+    })
+  })
+})

--- a/src/renderer/canvas/fit-view.ts
+++ b/src/renderer/canvas/fit-view.ts
@@ -1,0 +1,160 @@
+/**
+ * Fit-view geometry: place the canvas content in the largest chrome-free rectangle.
+ *
+ * The dock, minimap, controls, sidebars and banners all paint OVER the flow, so a plain `fitView`
+ * tucks nodes underneath them. Reserving a fixed margin per edge is too blunt — it taxes content
+ * that never reaches the offending panel (narrow content paying for a bottom-RIGHT minimap).
+ *
+ * Instead every visible overlay becomes an obstacle rect, and we pick the free rectangle that lets
+ * the content — at its own aspect ratio — reach the highest zoom. xyflow's directional padding is
+ * exactly "fit inside the viewport minus these insets", so the winning rect maps straight onto it.
+ *
+ * Kept DOM-light and free of React so the geometry can be unit-tested on its own.
+ */
+
+/** Chrome that floats over the canvas. New chrome can opt in via `data-canvas-chrome` instead of
+ *  being added here. */
+export const CANVAS_CHROME_SELECTOR = [
+  '[data-canvas-chrome]',
+  '.dock',
+  '.minimap',
+  '.react-flow__controls',
+  '.usage-indicator',
+  '.controls-cluster',
+  '.sessions-sidebar',
+  '.sessions-icon-cluster',
+  '.top-banners',
+  '.presence-prompt',
+  '.dictation',
+  '.update-card'
+].join(',')
+
+/** Breathing room kept between the content and both the chrome and the window edge. */
+export const FIT_VIEW_GAP = 12
+
+export type FitRect = { left: number; top: number; right: number; bottom: number }
+
+export const rectsOverlap = (a: FitRect, b: FitRect): boolean =>
+  a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom
+
+const width = (r: FitRect): number => r.right - r.left
+const height = (r: FitRect): number => r.bottom - r.top
+
+/**
+ * Largest chrome-free rectangle inside `viewport`, chosen to maximize the zoom a
+ * `contentW × contentH` box can reach inside it (ties → bigger area, then closer to centre).
+ *
+ * Every maximal empty rectangle has each edge either on the viewport border or flush against an
+ * obstacle edge, so enumerating obstacle/viewport edge pairs is exhaustive: this returns the true
+ * optimum, not an approximation. ~8 overlays → ~18 boundaries per axis, comfortably under a ms.
+ *
+ * Returns null only if no non-degenerate free rectangle exists.
+ */
+export function largestFreeRect(
+  viewport: FitRect,
+  obstacles: FitRect[],
+  contentW: number,
+  contentH: number
+): FitRect | null {
+  if (contentW <= 0 || contentH <= 0) return null
+  const axis = (lo: number, hi: number, edges: number[]): number[] =>
+    [...new Set([lo, hi, ...edges.filter((v) => v > lo && v < hi)])].sort((a, b) => a - b)
+  const xs = axis(viewport.left, viewport.right, obstacles.flatMap((o) => [o.left, o.right]))
+  const ys = axis(viewport.top, viewport.bottom, obstacles.flatMap((o) => [o.top, o.bottom]))
+
+  const vcx = (viewport.left + viewport.right) / 2
+  const vcy = (viewport.top + viewport.bottom) / 2
+  let best: FitRect | null = null
+  let bestZoom = -1
+  let bestArea = -1
+  let bestOffCentre = Infinity
+
+  for (let i = 0; i < xs.length - 1; i++) {
+    for (let j = i + 1; j < xs.length; j++) {
+      for (let k = 0; k < ys.length - 1; k++) {
+        for (let l = k + 1; l < ys.length; l++) {
+          const r: FitRect = { left: xs[i], right: xs[j], top: ys[k], bottom: ys[l] }
+          const w = width(r)
+          const h = height(r)
+          if (w < 1 || h < 1) continue
+          if (obstacles.some((o) => rectsOverlap(o, r))) continue
+          // Zoom this rect affords the content. Ties are common once the caller's maxZoom clamps,
+          // so fall back to area and then centredness to keep results stable and pleasant.
+          const zoom = Math.min(w / contentW, h / contentH)
+          const area = w * h
+          const offCentre =
+            Math.abs((r.left + r.right) / 2 - vcx) + Math.abs((r.top + r.bottom) / 2 - vcy)
+          const better =
+            zoom > bestZoom + 1e-6 ||
+            (zoom > bestZoom - 1e-6 &&
+              (area > bestArea + 1e-6 || (area > bestArea - 1e-6 && offCentre < bestOffCentre)))
+          if (!better) continue
+          best = r
+          bestZoom = zoom
+          bestArea = area
+          bestOffCentre = offCentre
+        }
+      }
+    }
+  }
+  return best
+}
+
+/** Inflate a measured chrome rect by the gap so content keeps its distance. */
+export const inflate = (r: FitRect, by: number): FitRect => ({
+  left: r.left - by,
+  top: r.top - by,
+  right: r.right + by,
+  bottom: r.bottom + by
+})
+
+/** Visible canvas chrome as obstacle rects, inflated by the gap and limited to the viewport. */
+export function chromeObstacles(viewport: FitRect, root: ParentNode = document): FitRect[] {
+  return [...root.querySelectorAll(CANVAS_CHROME_SELECTOR)]
+    .map((el) => el.getBoundingClientRect())
+    // Hidden/collapsed chrome measures 0 — it must not reserve any space.
+    .filter((r) => r.width > 0 && r.height > 0)
+    .map((r) => inflate({ left: r.left, top: r.top, right: r.right, bottom: r.bottom }, FIT_VIEW_GAP))
+    .filter((r) => rectsOverlap(r, viewport))
+}
+
+/** Padding accepted by xyflow's `fitView` (px strings per side). */
+export type FitPadding = {
+  top: `${number}px`
+  left: `${number}px`
+  right: `${number}px`
+  bottom: `${number}px`
+}
+
+/** Express a chosen free rect as the directional insets `fitView` expects, relative to `outer`. */
+export function rectToPadding(outer: FitRect, rect: FitRect): FitPadding {
+  return {
+    top: `${Math.max(0, Math.round(rect.top - outer.top))}px`,
+    left: `${Math.max(0, Math.round(rect.left - outer.left))}px`,
+    right: `${Math.max(0, Math.round(outer.right - rect.right))}px`,
+    bottom: `${Math.max(0, Math.round(outer.bottom - rect.bottom))}px`
+  }
+}
+
+/**
+ * Solve the fit-view padding for the current chrome layout and content shape.
+ * Returns null when there is nothing sensible to solve, so callers can fall back to plain fitView.
+ */
+export function solveFitPadding(
+  wrap: HTMLElement,
+  contentW: number,
+  contentH: number
+): FitPadding | null {
+  if (contentW <= 0 || contentH <= 0) return null
+  const v = wrap.getBoundingClientRect()
+  const outer: FitRect = { left: v.left, top: v.top, right: v.right, bottom: v.bottom }
+  const viewport: FitRect = {
+    left: outer.left + FIT_VIEW_GAP,
+    top: outer.top + FIT_VIEW_GAP,
+    right: outer.right - FIT_VIEW_GAP,
+    bottom: outer.bottom - FIT_VIEW_GAP
+  }
+  if (width(viewport) < 1 || height(viewport) < 1) return null
+  const rect = largestFreeRect(viewport, chromeObstacles(viewport), contentW, contentH)
+  return rect ? rectToPadding(outer, rect) : null
+}


### PR DESCRIPTION
## Problem

Both fit-view buttons framed nodes **underneath** the floating canvas chrome.

There are two of them, which surprised me at first:

1. **Bottom-left**, between zoom-out (−) and the lock — React Flow's built-in `<Controls>` fit button, using the library default padding (`0.1`).
2. **Bottom-center dock** — the app's own button, using `fitView({ padding: 0.2 })`.

Both used *uniform* padding, which ignores the dock, minimap, controls, sidebars and banners that paint over the flow. So after a fit, nodes near an edge tucked under them.

I kept both buttons (that's a UX call for the maintainer) and fixed only the overlap.

## Why not just reserve a margin per edge

That was my first attempt, and it's too blunt: the minimap only occupies the bottom **right**, yet every fit paid its ~167px toll even when the content came nowhere near it — a tall narrow column got squeezed for a panel it never touched.

## Approach

Treat each **visible** overlay as an obstacle rect, then pick the free rectangle that lets the content — at **its own aspect ratio** — reach the highest zoom, and express that rect as directional padding.

That mapping is exact. From `@xyflow/system`:

```js
const xZoom = (width - p.x) / bounds.width   // p.x = left + right
const zoom  = min(xZoom, yZoom)              // centred, then nudged to honour each side
```

so directional padding is precisely "fit inside the viewport minus these insets" — content is guaranteed to land inside the chosen rect.

**The search is exact, not heuristic.** Every maximal empty rectangle has each edge either on the viewport border or flush against an obstacle edge, so enumerating obstacle/viewport edge pairs is exhaustive. ~8 overlays → ~18 boundaries per axis, well under a millisecond on a user-initiated click.

## Result

Measured live on a 1024×620 canvas with 7 visible chrome elements, minimap top-left at (807, 497):

| Content | Chosen rect | Behaviour |
| --- | --- | --- |
| narrow 300×2000 | `[326,56 → 728,576]` | bottom **576 > 497** — runs *past* the minimap, since right `728 < 807` clears it horizontally |
| wide 4000×500 | `[12,258 → 1012,485]` | bottom **485 < 497** — stops *above* the minimap, which it genuinely spans |

Narrow-content zoom improves 0.2205 → 0.26 (~18% more).

Also gained: sidebars and top clusters are respected (the previous behaviour ignored them entirely), hidden chrome measures 0×0 and reserves nothing, and new chrome can opt in with a `data-canvas-chrome` attribute instead of editing a list.

## Notes

- All four fit entry points — the `<Controls>` button (via `onFitView`, which fires at click time), the dock, the ⌘K palette and the canvas context menu — now share one `fitAll`.
- `goToNode` (single-node focus) is deliberately untouched; it has its own zoom clamps.
- Geometry lives in `src/renderer/canvas/fit-view.ts` — pure, DOM-light and React-free — so it is unit-testable outside the ~6600-line `Canvas.tsx`. `fitAll` is now three lines.
- Worth knowing if you test by hand: `fitView` animates for 300ms, so measuring immediately after a click reads a stale transform.

## Testing

- 11 new unit tests in `fit-view.test.ts`, covering both regressions plus a brute-force exhaustiveness check that asserts no sampled free rect beats the solver's choice.
- `npm run typecheck`, `npm test` (2585 tests) and `npm run build` all pass locally.
- Verified in Server Edition in a browser: all four fit paths measured **zero** node/chrome intersections against 7 live overlays.