### PR TITLE
fix(canvas): context links work for agents launched by hand in plain terminals

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -1713,13 +1713,18 @@ export function Canvas() {
     [onNodesChange, markDirty]
   )
 
-  // Resolve a node's agent id, with a tags fallback for not-yet-migrated legacy nodes.
+  // Resolve a node's agent id, with a tags fallback for not-yet-migrated legacy nodes and a
+  // hook-status fallback for plain terminals where the user launched an agent CLI by hand:
+  // every local session carries the hook env (pty-manager defaults agentId to 'claude'), so
+  // the managed hooks report who's actually running inside even when data.agentId was never
+  // set at node creation.
   const agentIdOf = useCallback((id: string): AgentId | undefined => {
     const n = nodesRef.current.find((x) => x.id === id)
     if (!n || n.type !== 'terminal') return undefined
     return (
       (n.data.agentId as AgentId | undefined) ??
-      (((n.data.tags as string[]) ?? []).includes('claude') ? 'claude' : undefined)
+      (((n.data.tags as string[]) ?? []).includes('claude') ? 'claude' : undefined) ??
+      useAgentStatus.getState().byId[id]?.agentId
     )
   }, [])
 
@@ -1835,11 +1840,16 @@ export function Canvas() {
 
   // Rewrite link files when a linked node's session starts/changes: main resolves
   // codex/gemini transcripts by sessionId, so a session that appears after the edge was
-  // drawn must trigger a rewrite. Primitive signature, not the byId map (see loopSig).
+  // drawn must trigger a rewrite. agentId is part of the signature for the same reason: a
+  // plain terminal's identity arrives from hooks after the fact, and the map entry gains
+  // its agentId/sessionId only once it's known. Primitive signature, not the byId map (see
+  // loopSig).
   const linkSessionSig = useAgentStatus((s) => {
     let sig = ''
     for (const e of linkEdges) {
-      sig += (s.byId[e.source]?.sessionId ?? '') + '|' + (s.byId[e.target]?.sessionId ?? '') + '|'
+      const a = s.byId[e.source]
+      const b = s.byId[e.target]
+      sig += `${a?.agentId ?? ''}:${a?.sessionId ?? ''}|${b?.agentId ?? ''}:${b?.sessionId ?? ''}|`
     }
     return sig
   })
@@ -1873,7 +1883,12 @@ export function Canvas() {
     // project's map would sever the links of background projects whose agents keep running.
     const { projects, activeProjectId } = useProjects.getState()
     const map = {
-      ...buildBackgroundLinkMaps(projects, activeProjectId, (id) => useAgentStatus.getState().byId[id]?.sessionId),
+      ...buildBackgroundLinkMaps(
+        projects,
+        activeProjectId,
+        (id) => useAgentStatus.getState().byId[id]?.sessionId,
+        (id) => useAgentStatus.getState().byId[id]?.agentId
+      ),
       ...buildLinkMap(valid, infoOf)
     }
     const t = setTimeout(() => void window.nodeTerminal.contextLink.setLinks(map), 150)

--- a/src/renderer/lib/noteLink.test.ts
+++ b/src/renderer/lib/noteLink.test.ts
@@ -186,6 +186,32 @@ describe('buildBackgroundLinkMaps', () => {
       sessionId: 'sess-b2'
     })
   })
+  it('falls back to the hook-reported agentId for plain terminals', () => {
+    // A hand-launched `claude` in a plain terminal: the serialized node has no agentId, but
+    // the status store (fed by the managed hooks) knows who's running inside.
+    const plainProjects = [
+      {
+        id: 'p-bg',
+        nodes: [node({ id: 'm1', title: 'Manual', cwd: '/m' }), node({ id: 'm2', title: 'Also', cwd: '/m' })],
+        bridges: [{ id: 'e', source: 'm1', target: 'm2' }]
+      }
+    ]
+    const map = buildBackgroundLinkMaps(
+      plainProjects,
+      null,
+      (id) => (id === 'm2' ? 'sess-m2' : undefined),
+      (id) => (id === 'm2' ? 'claude' : undefined)
+    )
+    expect(map['m1']).toContainEqual({
+      id: 'm2',
+      title: 'Also',
+      cwd: '/m',
+      agentId: 'claude',
+      sessionId: 'sess-m2'
+    })
+    // m2's entry for m1 stays a bare terminal (no agentId reported for m1).
+    expect(map['m2']).toContainEqual({ id: 'm1', title: 'Manual', cwd: '/m' })
+  })
   it('drops edges whose endpoints are gone from the serialized nodes', () => {
     const map = buildBackgroundLinkMaps(
       [{ id: 'p', nodes: [node({ id: 'z1' })], bridges: [{ id: 'e', source: 'z1', target: 'gone' }] }],

--- a/src/renderer/lib/noteLink.ts
+++ b/src/renderer/lib/noteLink.ts
@@ -115,11 +115,17 @@ export function buildLinkMap(
  * pushed map — pushing only the active project's map deleted the link files of background
  * projects whose tmux sessions (and agents mid-task) were still running.
  * Node ids are globally unique across projects, so the maps merge without collisions.
+ *
+ * `agentIdOf` is the hook-status fallback for plain terminals where the user launched an
+ * agent CLI by hand: the serialized node carries no agentId, but the status store (fed by
+ * the managed hooks, node ids are per-core so background projects share it) knows who's
+ * running inside.
  */
 export function buildBackgroundLinkMaps(
   projects: Array<{ id: string; nodes: CanvasNodeState[]; bridges?: BridgeLink[] }>,
   activeProjectId: string | null,
-  sessionIdOf: (nodeId: string) => string | undefined
+  sessionIdOf: (nodeId: string) => string | undefined,
+  agentIdOf?: (nodeId: string) => string | undefined
 ): ContextLinkMap {
   const map: ContextLinkMap = {}
   for (const p of projects) {
@@ -129,14 +135,15 @@ export function buildBackgroundLinkMaps(
     const infoOf = (id: string): LinkNodeInfo => {
       const n = byId.get(id)!
       const sticky = n.kind === 'sticky'
+      const agentId = sticky ? undefined : (n.agentId ?? agentIdOf?.(id))
       return {
         id,
         title: n.title || id,
         cwd: n.cwd ?? '',
         note: sticky ? (n.text ?? '') : undefined,
         sticky,
-        agentId: sticky ? undefined : n.agentId,
-        sessionId: !sticky && n.agentId ? sessionIdOf(id) : undefined,
+        agentId,
+        sessionId: agentId ? sessionIdOf(id) : undefined,
         accountId: sticky ? undefined : n.accountId
       }
     }

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -5,8 +5,12 @@ import type { NodeTerminalApi } from '@shared/types'
 
 /**
  * Transient per-node status for agent (e.g. Claude Code) sessions, driven by the agent's hooks.
- * `unread`, `session` and `sessionId` are persisted to localStorage so they survive a
- * reload/restart; the live `state` (working/waiting/…) is not (it'd be stale on relaunch).
+ * `unread`, `session`, `sessionId` and `agentId` are persisted to localStorage so they survive
+ * a reload/restart; the live `state` (working/waiting/…) is not (it'd be stale on relaunch).
+ * `agentId` is durable because a PLAIN terminal's agent identity exists nowhere else: an
+ * explicit agent node re-derives it from `data.agentId`, but a hand-launched `claude` in a
+ * plain terminal is only known here, and its context links must keep classifying across
+ * restarts (tmux keeps the session — and the agent — alive through them).
  *
  * ONE STORE PER CORE (stage 4): `createAgentStatusSession(persistKey?)` builds an isolated
  * instance — node ids are per-core, so status tables from two cores must never mix. The module
@@ -160,7 +164,7 @@ export function createAgentStatusSession(persistKey?: string): AgentStatusSessio
       const data = JSON.parse(raw) as Record<string, Partial<AgentNodeStatus>>
       const out: Record<string, AgentNodeStatus> = {}
       for (const [id, v] of Object.entries(data)) {
-        out[id] = { unread: !!v.unread, session: v.session, sessionId: v.sessionId }
+        out[id] = { unread: !!v.unread, session: v.session, sessionId: v.sessionId, agentId: v.agentId }
         // A recurring job (cron/schedule — and tmux keeps in-session loops alive too) outlives
         // the app: restore its card. Minimal shape check so a corrupt entry can't break load.
         if (v.loop && typeof v.loop === 'object' && v.loop.kind) {
@@ -185,8 +189,14 @@ export function createAgentStatusSession(persistKey?: string): AgentStatusSessio
     try {
       const out: Record<string, Partial<AgentNodeStatus>> = {}
       for (const [id, v] of Object.entries(byId)) {
-        if (v.unread || v.session || v.sessionId || v.loop) {
-          out[id] = { unread: v.unread, session: v.session, sessionId: v.sessionId, loop: v.loop }
+        if (v.unread || v.session || v.sessionId || v.loop || v.agentId) {
+          out[id] = {
+            unread: v.unread,
+            session: v.session,
+            sessionId: v.sessionId,
+            agentId: v.agentId,
+            loop: v.loop
+          }
         }
       }
       localStorage.setItem(persistKey, JSON.stringify(out))


### PR DESCRIPTION
Fixes #45

## Problem

Connecting two plain terminal nodes where the user started Claude Code by hand (⌘T, then typing `claude`) does nothing — the link doesn't take and no context is shared. It only works when the nodes were created as agent nodes (⌘⇧C).

Cause: the link classifier resolves agent identity from the node's `data.agentId`, which is only stamped at creation time for explicit agent nodes. A plain terminal never gets it, so `classifyLink` sees both endpoints as context-incapable and refuses the edge before any link plumbing runs — even though the managed hooks (armed in every local session via the PTY env) have already reported exactly which agent is running inside.

## Fix

Consult the hook-reported identity as a fallback:

- **`Canvas.tsx` — `agentIdOf`** falls back to `useAgentStatus.byId[id].agentId` (the hook-reported identity) when the node has no `data.agentId`. This is the core change: classification, discovery notes, and the link map all key off `agentIdOf`, so everything downstream flows once it passes.
- **`Canvas.tsx` — `linkSessionSig`** now includes `agentId`, so the link map re-pushes when a node's identity arrives *after* the edge was drawn (e.g. right after an app restart).
- **`agentStatus.ts`** persists `agentId` alongside `sessionId`/`session`/`unread`. A plain terminal's agent identity exists nowhere else, and tmux keeps the session (and the agent) alive across app restarts — the link must keep classifying too.
- **`noteLink.ts` — `buildBackgroundLinkMaps`** accepts the same fallback (optional param, existing call sites unaffected), so background projects' plain-terminal links survive the full link-map rewrite. New unit test covers it.

Terminals that have never run an agent still refuse the connection — the gate is unchanged, it just consults an identity source that already existed.

## Testing

- `npm run typecheck` clean; noteLink suite 22/22 (incl. new fallback test); full `vitest` run has no new failures (the two failing files — `pty-single-user` temp-dir race, `viewMode` Node localStorage quirk — fail identically on unmodified `main`).
- Verified live in an isolated instance (`NT_MULTI`): two plain terminals with hand-launched `claude` → drag connect → ⇌ context edge forms, both sides receive the "[nodeterm] You are now linked…" note, link files carry `agent`/`sessionId`/`transcriptPath`, and the get-linked-context skill in one node correctly reads the other's transcript. Control: two fresh terminals that never ran an agent → same drag, edge refused.

## Not in scope

The other `data.agentId` gates on plain terminals (status badge, chat panel, context meter, resume) — promoting those for hand-launched agents would be a natural follow-up if wanted.
