### PR TITLE
fix(pty): frame injected prompts as bracketed paste so a multiplexer can't swallow the Enter

### DIFF
--- a/src/core/paste-injection.test.ts
+++ b/src/core/paste-injection.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { bracketedInjection, PASTE_START, PASTE_END } from './paste-injection'
+
+describe('bracketedInjection', () => {
+  it('frames the text in paste markers with the Enter in the same body', () => {
+    expect(bracketedInjection('hello', true)).toBe(`${PASTE_START}hello${PASTE_END}\r`)
+  })
+  it('omits the Enter when not requested (dictation insert)', () => {
+    expect(bracketedInjection('hello', false)).toBe(`${PASTE_START}hello${PASTE_END}`)
+  })
+  it('keeps multiline text inside one paste frame — newlines are content, not submits', () => {
+    const body = bracketedInjection('line one\nline two', true)
+    expect(body).toBe(`${PASTE_START}line one\nline two${PASTE_END}\r`)
+    expect(body.indexOf('\r')).toBe(body.length - 1)
+  })
+})

--- a/src/core/paste-injection.ts
+++ b/src/core/paste-injection.ts
@@ -1,0 +1,18 @@
+// Injected prompts (context-link notes, note pushes, slash commands, dictation insert) are
+// delivered through `tmux send-keys`. Sending the text and the Enter as two separate keystroke
+// writes races the receiving TUI's paste heuristics: a composer that treats a rapid unmarked
+// burst as a paste can absorb an Enter arriving milliseconds behind it as pasted content
+// instead of a submit — observed with Claude Code hosted inside the herdr multiplexer (#47),
+// whose input pipeline re-chunks the byte stream. When the target application has REQUESTED
+// bracketed-paste mode (tmux tracks this per pane as `bracket_paste_flag`), deliver the
+// injection the way paste-aware apps expect: the text framed in paste markers and the Enter
+// appended in the SAME write, so the composer sees a definitive paste boundary and the Enter
+// can never be re-chunked into the paste. Apps that never requested bracketed paste keep the
+// legacy two-step delivery bit-for-bit.
+export const PASTE_START = '\x1b[200~'
+export const PASTE_END = '\x1b[201~'
+
+/** The single-write injection body for a bracketed-paste-aware target. */
+export function bracketedInjection(text: string, enter: boolean): string {
+  return PASTE_START + text + PASTE_END + (enter ? '\r' : '')
+}

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -27,6 +27,7 @@ import {
   remoteCapturePaneArgs
 } from './remote-ssh/control-master'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
+import { bracketedInjection } from './paste-injection'
 import { releasePty, type ReleasablePty } from './pty-release'
 import { effectiveSize, type PtySize } from './pty-size'
 import { machOArch, archMismatch } from './macho-arch'
@@ -1912,12 +1913,51 @@ export class PtyManager {
     }
     if (!this.tmuxPath) return false
     try {
+      if (await this.bracketPasteRequested(target)) {
+        // Paste-aware target (agent TUIs, multiplexers like herdr): one atomic write — the
+        // text framed in paste markers plus the Enter — so the composer sees a definitive
+        // paste boundary and the Enter can never be re-chunked into the paste (issue #47).
+        await runAsync(this.tmuxPath, [
+          '-L',
+          TMUX_SOCKET,
+          'send-keys',
+          '-t',
+          target,
+          '-l',
+          bracketedInjection(text, enter)
+        ])
+        return true
+      }
       // The literal text and the Enter (when sent) must go in order, so await sequentially.
       await runAsync(this.tmuxPath, ['-L', TMUX_SOCKET, 'send-keys', '-t', target, '-l', text])
       if (enter) {
         await runAsync(this.tmuxPath, ['-L', TMUX_SOCKET, 'send-keys', '-t', target, 'Enter'])
       }
       return true
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Did the application in this pane request bracketed-paste mode? tmux tracks the DECSET
+   * 2004 state per pane and exposes it as `bracket_paste_flag`. Unknown — query fails, old
+   * tmux without the format — reads as false, so delivery degrades to the legacy two-step
+   * path rather than sending paste markers an unaware app would render as garbage input.
+   */
+  private async bracketPasteRequested(target: string): Promise<boolean> {
+    if (!this.tmuxPath) return false
+    try {
+      const { stdout } = await runAsync(this.tmuxPath, [
+        '-L',
+        TMUX_SOCKET,
+        'display-message',
+        '-p',
+        '-t',
+        target,
+        '#{bracket_paste_flag}'
+      ])
+      return stdout.trim() === '1'
     } catch {
       return false
     }

--- a/src/core/remote-ssh/control-master.test.ts
+++ b/src/core/remote-ssh/control-master.test.ts
@@ -100,31 +100,46 @@ describe('remoteTmuxHasSessionArgs', () => {
 })
 
 describe('remoteTmuxSendKeysArgs', () => {
+  const TMUX = `tmux -L ${RMT_TMUX_SOCKET}`
+  /** The remote command is a paste-aware conditional: framed atomic send when the pane's app
+   *  requested bracketed paste, the legacy two-step send otherwise (issue #47). */
+  const conditional = (session: string, framed: string, legacy: string): string =>
+    `if [ "$(${TMUX} display-message -p -t ${session} '#{bracket_paste_flag}' 2>/dev/null)" = 1 ]; then ${framed}; else ${legacy}; fi`
+
   it('sends literal text with -l -- (no Enter) when enter is false', () => {
     const args = remoteTmuxSendKeysArgs(conn, '/s.sock', 'nt-x', 'hello', false)
     expect(args).toEqual([
       ...childPrefix,
       'deploy@h.example.com',
-      `tmux -L ${RMT_TMUX_SOCKET} send-keys -t nt-x -l -- 'hello'`
+      conditional(
+        'nt-x',
+        `${TMUX} send-keys -t nt-x -l -- '\x1b[200~hello\x1b[201~'`,
+        `${TMUX} send-keys -t nt-x -l -- 'hello'`
+      )
     ])
   })
-  it('appends a second send-keys Enter, joined by &&, when enter is true', () => {
+  it('appends Enter inside the framed write; legacy branch keeps the && two-step', () => {
     const args = remoteTmuxSendKeysArgs(conn, '/s.sock', 'nt-x', 'hello', true)
     expect(args[args.length - 1]).toBe(
-      `tmux -L ${RMT_TMUX_SOCKET} send-keys -t nt-x -l -- 'hello' && tmux -L ${RMT_TMUX_SOCKET} send-keys -t nt-x Enter`
+      conditional(
+        'nt-x',
+        `${TMUX} send-keys -t nt-x -l -- '\x1b[200~hello\x1b[201~\r'`,
+        `${TMUX} send-keys -t nt-x -l -- 'hello' && ${TMUX} send-keys -t nt-x Enter`
+      )
     )
   })
   it('single-quote-escapes a single quote in the text (the \'\\\'\' idiom)', () => {
     const args = remoteTmuxSendKeysArgs(conn, '/s.sock', 'nt-x', `it's`, false)
-    expect(args[args.length - 1]).toBe(`tmux -L ${RMT_TMUX_SOCKET} send-keys -t nt-x -l -- 'it'\\''s'`)
+    expect(args[args.length - 1]).toContain(`${TMUX} send-keys -t nt-x -l -- 'it'\\''s'`)
+    expect(args[args.length - 1]).toContain(`'\x1b[200~it'\\''s\x1b[201~'`)
   })
   it('keeps a multiline text as one literal token (single-quoted, newlines preserved)', () => {
     const args = remoteTmuxSendKeysArgs(conn, '/s.sock', 'nt-x', 'line one\nline two', false)
-    expect(args[args.length - 1]).toBe(`tmux -L ${RMT_TMUX_SOCKET} send-keys -t nt-x -l -- 'line one\nline two'`)
+    expect(args[args.length - 1]).toContain(`${TMUX} send-keys -t nt-x -l -- 'line one\nline two'`)
   })
   it('guards leading-dash text from being read as a send-keys option (-l --)', () => {
     const args = remoteTmuxSendKeysArgs(conn, '/s.sock', 'nt-x', '-not-an-option', false)
-    expect(args[args.length - 1]).toBe(`tmux -L ${RMT_TMUX_SOCKET} send-keys -t nt-x -l -- '-not-an-option'`)
+    expect(args[args.length - 1]).toContain(`${TMUX} send-keys -t nt-x -l -- '-not-an-option'`)
   })
 })
 

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { createHash } from 'crypto'
 import { posixQuote, quoteRemotePath, remoteTmuxCommand, type SshConnection } from '../../shared/ssh'
 import { canControlCanvas } from '../../shared/agents/config'
+import { bracketedInjection } from '../paste-injection'
 // Dependency-free (no node-pty): safe to import from these pure builders.
 
 /** Dedicated remote tmux socket so an SSH project never collides with the user's own tmux. */
@@ -111,14 +112,20 @@ export function remoteTmuxHasSessionArgs(conn: SshConnection, controlPath: strin
 /**
  * Send literal text (and optionally Enter) into a node's REMOTE tmux session — the remote
  * counterpart of `PtyManager.sendText`'s local `tmux send-keys` path (dictation insert, /rename,
- * /branch, note pushes). Built as ONE remote command so text and Enter run strictly in order on
+ * /branch, note pushes). Built as ONE remote command so everything runs strictly in order on
  * the remote host without a second network round trip: `-l --` sends the text literally (`-l`)
  * and stops option parsing first (`--`, so text starting with `-` is never read as another
  * send-keys flag); `text` is single-quoted (`posixQuote`) so it survives the remote shell as one
- * token verbatim, multiline included. Joined with `&&`, not `;` — this mirrors the local path's
- * ordering guarantee (`PtyManager.sendText`): Enter only fires if the text send actually
- * succeeded, so a failed text send can never leave a lone Enter to submit whatever was already
- * composed in a live agent prompt.
+ * token verbatim, multiline included.
+ *
+ * Mirrors the local path's paste-aware delivery (`PtyManager.sendText`, issue #47): when the
+ * remote pane's application requested bracketed-paste mode (`bracket_paste_flag`), the text is
+ * framed in paste markers with the Enter appended in the SAME send-keys, so a re-chunking
+ * middle layer (e.g. the herdr multiplexer) can never absorb the Enter into the paste. The
+ * quoted body carries raw ESC/CR bytes — inside single quotes they reach tmux verbatim.
+ * Otherwise the legacy two-step send runs, joined with `&&`, not `;`: Enter only fires if the
+ * text send actually succeeded, so a failed text send can never leave a lone Enter to submit
+ * whatever was already composed in a live agent prompt.
  */
 export function remoteTmuxSendKeysArgs(
   conn: SshConnection,
@@ -127,8 +134,11 @@ export function remoteTmuxSendKeysArgs(
   text: string,
   enter: boolean
 ): string[] {
-  let cmd = `tmux -L ${RMT_TMUX_SOCKET} send-keys -t ${sessionId} -l -- ${posixQuote(text)}`
-  if (enter) cmd += ` && tmux -L ${RMT_TMUX_SOCKET} send-keys -t ${sessionId} Enter`
+  const tmux = `tmux -L ${RMT_TMUX_SOCKET}`
+  const framed = `${tmux} send-keys -t ${sessionId} -l -- ${posixQuote(bracketedInjection(text, enter))}`
+  let legacy = `${tmux} send-keys -t ${sessionId} -l -- ${posixQuote(text)}`
+  if (enter) legacy += ` && ${tmux} send-keys -t ${sessionId} Enter`
+  const cmd = `if [ "$(${tmux} display-message -p -t ${sessionId} '#{bracket_paste_flag}' 2>/dev/null)" = 1 ]; then ${framed}; else ${legacy}; fi`
   return childArgs(conn, controlPath, cmd)
 }
 /**


### PR DESCRIPTION
Fixes #47

## Problem

`PtyManager.sendText` — the path behind context-link discovery notes, sticky-note pushes, slash commands (/rename, /branch), dictation insert, and the canvas-control `write` verb — delivered injected prompts as **two separate** `tmux send-keys`: the literal text, then a standalone `Enter`. When something re-chunks terminal input between nodeterm and the agent (e.g. Claude Code hosted inside the [herdr](https://github.com/ogulcancelik/herdr) multiplexer), the Enter arrives so close behind the text burst that the agent's paste detection absorbs it as pasted content — so the message lands in the composer **unsent**. A bare agent tolerates the same two-step send because nothing re-chunks it.

## Fix

Deliver the way paste-aware apps expect. When the target application has requested bracketed-paste mode — tmux tracks this per pane as `#{bracket_paste_flag}` — frame the text in `\e[200~…\e[201~` and append the Enter in the **same** `send-keys`, so the receiver sees a definitive paste boundary and the Enter can never be re-chunked into the paste. Applications that never enabled bracketed paste (flag `0`, e.g. a raw program like `cat`) keep the **legacy two-step send bit-for-bit** — sending paste markers to something that doesn't understand them would insert literal `[200~` garbage.

The signal is deliberately "does the receiver understand paste framing," not "is this an agent." That's the honest, checkable property, and framing is safe exactly when it holds (a modern interactive zsh sets the flag too, and handles the paste correctly).

- **`src/core/paste-injection.ts`** (new): `bracketedInjection(text, enter)` builds the framed body. Small, pure, unit-tested.
- **`pty-manager.sendText`** (local path): probe `bracket_paste_flag`; on `1`, do the single framed write; otherwise the existing two-step send. `enter: false` (dictation insert) frames without the trailing `\r`, so multi-line inserts no longer risk a stray line submitting.
- **`remoteTmuxSendKeysArgs`** (SSH-project path): the same paste-aware branch built as one remote command over the ControlMaster, so remote nodes behave identically.

## Testing

- `npm run typecheck` clean. New `paste-injection` unit tests + updated `control-master` arg tests pass; full `vitest` run has no new failures (the two failing files — `pty-single-user` temp-dir race, `viewMode` Node-localStorage quirk — fail identically on unmodified `main`).
- Verified live at the tmux boundary that `sendText` drives (isolated herdr + claude sessions on a scratch socket):

  | Target | `bracket_paste_flag` | Path | Result |
  |---|---|---|---|
  | plain zsh | 1 | framed | `echo FRAMED_SHELL_OK` executed |
  | `cat` (no bracketed paste) | 0 | **legacy** | — (markers correctly not sent) |
  | bare Claude Code | 1 | framed | submitted, replied "BARE-OK" |
  | Claude Code inside herdr | 1 | framed | submitted, replied "FRAMED-OK" |

## Honest caveat

In an isolated herdr rig I could **not** deterministically reproduce the original *failure* — the legacy two-step send happened to submit there too, so the real-app failure depends on timing I couldn't reliably recreate in isolation. The fix stands on its own regardless: framing text as bracketed paste with an atomic Enter is the correct, race-free way to inject into any paste-aware TUI (it's exactly what herdr's own automation API does), and it's positively verified to submit across all three target types with the legacy path preserved for non-paste receivers.
