### PR TITLE
fix(confirm): keep the confirm dialog within the viewport for long messages

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3575,8 +3575,13 @@ body,
 }
 
 .confirm {
-  width: 320px;
+  width: 420px;
   max-width: 90vw;
+  /* Cap the height so a long message (e.g. an agent control-write preview) can
+     never grow the box past the viewport — the message area scrolls instead. */
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
   background: rgba(40, 40, 42, 0.99);
   border: 1px solid var(--border);
   border-radius: 14px;
@@ -3893,6 +3898,11 @@ body,
 
 .confirm__msg {
   margin: 0 0 16px;
+  /* The scrollable region once the box hits its max-height, so the action buttons
+     below stay on-screen instead of being pushed past the viewport. */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
   font-size: 13px;
   line-height: 1.5;
   color: var(--text);


### PR DESCRIPTION
## Problem

`ConfirmDialog` renders into `.confirm`, which has a fixed `width: 320px` and **no height cap**. When the `message` is long — e.g. an agent control-write preview, which echoes the full text being typed into another node — the narrow box wraps it into many lines and grows past the viewport. The `.confirm__actions` buttons get pushed below the bottom edge of the window, so the dialog can't be confirmed or cancelled without the box overflowing the screen.

## Fix (CSS-only, no behavior change)

- Widen `.confirm` to `420px`, matching the app's other dialogs (`.confirm.bind-dialog`, `.clone-dialog`, `.confirm.dir-picker` all already use `420px`).
- Cap the box at `max-height: 85vh` and lay it out as a `flex` column.
- Make `.confirm__msg` the scroll region (`flex: 1 1 auto; min-height: 0; overflow-y: auto`) so a long message scrolls **inside** the box while the action buttons stay pinned and on-screen.

## Before / After

**Before** — long message, fixed 320px, no height cap → box taller than the viewport, buttons pushed off-screen:

```
┌───────────────┐  ← top of box (above viewport)
│ line 1 …      │
│ line 2 …      │
│ …             │
╎ (many lines)  ╎
│ line N …      │
├───────────────┤
│ [Cancel][OK]  │  ← below the bottom edge, unreachable
└───────────────┘
```

**After** — 420px wide, capped at 85vh, message scrolls, buttons always visible:

```
┌─────────────────────┐  ← fits within 85vh
│ line 1 …          ▲ │
│ line 2 …          █ │  ← .confirm__msg scrolls
│ line 3 …          ▼ │
├─────────────────────┤
│        [Cancel][OK] │  ← always on-screen
└─────────────────────┘
```

Short messages are visually unchanged apart from the slightly wider box.

Verified by inspecting the diff and CSS layout; not run through a full app build.
