### PR TITLE
fix(codex-hooks): append managed handler so pre-existing user hooks keep their trust

### DIFF
--- a/src/core/agents/hooks/codex.test.ts
+++ b/src/core/agents/hooks/codex.test.ts
@@ -18,15 +18,15 @@ describe('buildCodexHooksAndTrust', () => {
     expect(buildCodexHooksAndTrust(null, 'cmd', '/h/hooks.json')).toBeNull()
   })
 
-  it('prepends the managed handler to all six events + emits one trust entry per event', () => {
+  it('appends the managed handler to all six events + emits one trust entry per event', () => {
     const command = buildManagedCommand('/home/u/.nodeterm/agent-hooks/codex.sh')
     const built = buildCodexHooksAndTrust({}, command, '/home/u/.codex/hooks.json')
     expect(built).not.toBeNull()
     const { config, trustEntries } = built!
-    // one definition per subscribed event, our managed handler first
+    // one definition per subscribed event, our managed handler last
     for (const ev of CODEX_EVENTS) {
       const defs = config.hooks?.[ev]
-      expect(defs?.[0]?.hooks?.[0]?.command).toBe(command)
+      expect(defs?.at(-1)?.hooks?.[0]?.command).toBe(command)
     }
     expect(trustEntries).toHaveLength(CODEX_EVENTS.length)
     expect(trustEntries.every((e) => e.command === command)).toBe(true)
@@ -38,20 +38,40 @@ describe('buildCodexHooksAndTrust', () => {
     const first = buildCodexHooksAndTrust({}, command, '/x/hooks.json')!
     const second = buildCodexHooksAndTrust(first.config, command, '/x/hooks.json')!
     for (const ev of CODEX_EVENTS) {
-      // exactly one managed handler at the head, none trailing
+      // exactly one managed handler, still at the tail
       const defs = second.config.hooks?.[ev] ?? []
       const managed = defs.filter((d) => d.hooks?.some((h) => h.command === command))
       expect(managed).toHaveLength(1)
+      expect(defs.at(-1)?.hooks?.[0]?.command).toBe(command)
     }
   })
 
-  it('preserves a user-authored hook in a subscribed event (kept AFTER the managed handler)', () => {
+  it('preserves a user-authored hook at its original index before the managed handler', () => {
     const command = buildManagedCommand('/x/agent-hooks/codex.sh')
     const userDef = { hooks: [{ type: 'command' as const, command: 'echo mine' }] }
     const built = buildCodexHooksAndTrust({ hooks: { Stop: [userDef] } }, command, '/x/hooks.json')!
     const stop = built.config.hooks?.Stop ?? []
-    expect(stop[0]?.hooks?.[0]?.command).toBe(command)
-    expect(stop.some((d) => d.hooks?.some((h) => h.command === 'echo mine'))).toBe(true)
+    expect(stop[0]).toEqual(userDef)
+    expect(stop.at(-1)?.hooks?.[0]?.command).toBe(command)
+  })
+
+  it('keeps two user definitions at their trust-key indices and trusts the managed tail', () => {
+    const command = buildManagedCommand('/x/agent-hooks/codex.sh')
+    const firstUserDef = { hooks: [{ type: 'command' as const, command: 'echo first' }] }
+    const secondUserDef = { hooks: [{ type: 'command' as const, command: 'echo second' }] }
+    const built = buildCodexHooksAndTrust(
+      { hooks: { SessionStart: [firstUserDef, secondUserDef] } },
+      command,
+      '/x/hooks.json'
+    )!
+    const sessionStart = built.config.hooks?.SessionStart ?? []
+    expect(sessionStart[0]).toEqual(firstUserDef)
+    expect(sessionStart[1]).toEqual(secondUserDef)
+    expect(sessionStart[2]?.hooks?.[0]?.command).toBe(command)
+    expect(built.trustEntries.find((entry) => entry.eventLabel === 'session_start')).toMatchObject({
+      groupIndex: 2,
+      handlerIndex: 0
+    })
   })
 
   it('sweeps a stale managed handler out of an event we no longer subscribe to', () => {

--- a/src/core/agents/hooks/codex.ts
+++ b/src/core/agents/hooks/codex.ts
@@ -160,19 +160,20 @@ export function buildCodexHooksAndTrust(
     }
   }
 
-  // Prepend our managed handler to each subscribed event (idempotent — strip any
-  // prior managed copy first) and record the matching trust entry at
-  // groupIndex 0 / handlerIndex 0.
+  // Why: Codex keys hook trust by index, so prepending shifts user hooks out
+  // from under their stored hashes and silently disables them. Append our
+  // managed handler to keep existing indices stable (idempotent — strip any
+  // prior managed copy first) and trust its actual index.
   const trustEntries: CodexTrustEntry[] = []
   for (const eventName of CODEX_EVENTS) {
     const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
     const cleaned = removeManagedFromDefinitions(current)
     const definition: HookDefinition = { hooks: [{ type: 'command', command }] }
-    nextHooks[eventName] = [definition, ...cleaned]
+    nextHooks[eventName] = [...cleaned, definition]
     trustEntries.push({
       sourcePath,
       eventLabel: CODEX_EVENT_LABEL[eventName],
-      groupIndex: 0,
+      groupIndex: cleaned.length,
       handlerIndex: 0,
       command
     })
@@ -263,9 +264,12 @@ export function installCodexHooks(): void {
   }
 
   try {
-    // Prepending keeps the status hook ahead of any user hooks so a slow user
-    // hook can't leave the badge stale. The trust entry is keyed by the local
-    // hooks.json path (computeTrustKey realpath's it to match how codex keys it).
+    // Why: appending keeps user-hook indices stable so their existing Codex
+    // trust entries remain valid. The cost is the one prepending used to buy —
+    // a slow user hook ahead of ours can delay the badge — which is the lesser
+    // failure next to silently disabling the user's whole hook chain. The
+    // managed trust entry is keyed by the local hooks.json path (computeTrustKey
+    // realpath's it to match how codex keys it).
     const built = buildCodexHooksAndTrust(config, command, hooksFile)
     if (!built) return
     writeHooksJson(hooksFile, built.config)


### PR DESCRIPTION
Fixes #51.

## What

`buildCodexHooksAndTrust` appends the managed handler after the user's definitions instead
of prepending it, and records its trust entry at the tail index rather than always `0`.

```diff
-    nextHooks[eventName] = [definition, ...cleaned]
+    nextHooks[eventName] = [...cleaned, definition]
       trustEntries.push({
         sourcePath,
         eventLabel: CODEX_EVENT_LABEL[eventName],
-      groupIndex: 0,
+      groupIndex: cleaned.length,
```

## Why

Codex keys hook trust by index (`<hooks.json>:<event>:<groupIndex>:<handlerIndex>`) while
`trusted_hash` covers hook **content** only. Prepending shifts every pre-existing user hook
one slot, so the hash stored at a given key no longer matches the command now at that index
and Codex silently refuses to run it — no warning, badge unaffected. Issue #51 has the
A/B reproduction (a user `SessionStart` hook that injects context stops injecting after a
single nodeterm launch, and comes back when the pre-launch config is restored).

Appending keeps existing indices stable, so every user trust entry stays valid. It also
brings the Codex service in line with `install-helper.ts`, which already appends
(`existing.push(...)`) for the Claude / Gemini / opencode services.

## The trade-off this gives up

The comment in `installCodexHooks` said prepending "keeps the status hook ahead of any user
hooks so a slow user hook can't leave the badge stale". That cost is real and I kept it
documented in the code: a slow user hook ahead of the managed one can delay the badge.
Silently disabling the user's whole hook chain seemed clearly the worse of the two, but if
badge latency matters more to you, the alternative is to keep prepending and *re-key* the
user's existing trust entries (`:N:M` → `:N+1:M`, carrying the stored hash over). Because
the hash is content-only that relocates grants the user already made rather than creating
new ones. Say the word and I'll switch this PR to that shape instead.

## Upgrade path — not covered here

This does not repair an installation the previous prepend logic already clobbered: that
install overwrote the trust hash at `:0:0`, so the user hook now at index 0 still mismatches
after appending. Issue #51 sketches a safe cleanup (drop stale entries whose stored hash
equals the managed command's hash but whose content at that key is not the managed command
— removal only, no new trust granted). I left it out because the alternative repair,
recomputing the user's hash from whatever hooks.json currently says, is trust-on-first-sight
and that is your call, not mine. Happy to add either follow-up here.

## Tests

- Renamed/updated the three tests that encoded head-position ordering; they now assert the
  managed handler is last and that user definitions keep their original indices.
- Added a regression test: two pre-existing user definitions stay at indices 0 and 1, the
  managed handler lands at 2, and the emitted trust entry carries `groupIndex: 2`.
- The golden field-verified hash test is **unchanged and still passes** — it builds from an
  empty `hooks.json`, where the managed handler still lands at index 0.

```
npx vitest run src/core/agents/hooks/codex.test.ts      →  8 passed
npx vitest run src/core/agents/hooks src/main/remote-ssh
        src/core/agent-status-mirror.test.ts             →  235 passed (10 files)
npm run typecheck                                       →  clean
```

Verified against nodeterm 0.2.24 and codex-cli 0.145.0 on macOS 26.5.2 (arm64).
