### PR TITLE
feat: usage pill over the kanban board + right-click card actions (open/move/delete)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4324,6 +4324,22 @@ export function Canvas() {
     [activeProjectId, viewCenter, setNodes, markDirty, seedBoard, api]
   )
 
+  // Delete a session from the board — same confirm + teardown as the canvas Delete key.
+  const deleteNodeFromKanban = useCallback(
+    (nodeId: string) => {
+      const node = nodesRef.current.find((n) => n.id === nodeId)
+      const label = (node?.data.title as string) || 'this session'
+      setConfirm({
+        message: `Delete ${label}? Its terminal session will end.`,
+        onConfirm: () => {
+          deleteNodes([nodeId])
+          setConfirm(null)
+        }
+      })
+    },
+    [deleteNodes]
+  )
+
   const openNodeFromKanban = useCallback(
     (nodeId: string) => {
       const id = useProjects.getState().activeProjectId
@@ -6066,6 +6082,7 @@ export function Canvas() {
           onCreateNode={createNodeInColumn}
           onRenameNode={(nodeId, title) => renameSession(activeProjectId, nodeId, title)}
           onEditSticky={editStickyText}
+          onDeleteNode={deleteNodeFromKanban}
         />
       )}
       <UpdateCard />
@@ -6247,7 +6264,7 @@ export function Canvas() {
             z-index (5 collapsed, 13 with the popover open) competes in the same context as the
             sidebar and the open popover wins. It uses no React Flow hooks, and .flow-wrap is
             position:relative, so its absolute left/bottom anchors are unchanged. */}
-        <UsageIndicator />
+        <UsageIndicator overBoard={kanbanOpen} />
 
         <PresenceNamePrompt />
 

--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -106,7 +106,7 @@ function ProviderBlock({ u, mode }: { u: ProviderUsage; mode: 'used' | 'remainin
  * last-known data shown on stale/error. Compact pill = mini-bar + one "N% label" per limit,
  * e.g. "93% 5h · 39% wk · 13% Fable" — the bar tracks whichever limit is closest to biting.
  */
-export function UsageIndicator(): JSX.Element | null {
+export function UsageIndicator({ overBoard = false }: { overBoard?: boolean }): JSX.Element | null {
   const [usage, setUsage] = useState<ClaudeUsage | null>(null)
   const [open, setOpen] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
@@ -248,7 +248,7 @@ export function UsageIndicator(): JSX.Element | null {
   }
 
   return (
-    <div className="usage-indicator" ref={popRef}>
+    <div className={`usage-indicator${overBoard ? ' usage-indicator--board' : ''}`} ref={popRef}>
       {open && (
         <div className="usage-popover">
           <div className="usage-popover__head">

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -28,10 +28,12 @@ interface KanbanColumnProps {
   /** Drop on the column body: a card lands at the END of this column; a column lands BEFORE it. */
   onDropOnColumn: () => void
   onDropBeforeCard: (nodeId: string) => void
+  /** Right-click on a card — bubbles the cursor position + node id up to the board menu. */
+  onCardContext: (nodeId: string, x: number, y: number) => void
 }
 
 export function KanbanColumn({
-  column, cards, statusById, metaOf, onRename, onRecolor, onDelete, onOpenCard,
+  column, cards, statusById, metaOf, onRename, onRecolor, onDelete, onOpenCard, onCardContext,
   createOptions, onCreate, onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn,
   onDropBeforeCard
 }: KanbanColumnProps) {
@@ -134,6 +136,7 @@ export function KanbanColumn({
             status={statusById[s.id]}
             meta={metaOf(s.id)}
             onOpen={() => onOpenCard(s.id)}
+            onContext={(x, y) => onCardContext(s.id, x, y)}
             onDragStart={() => onCardDragStart(s.id)}
             onDragEnd={onDragEnd}
             onDropBefore={() => onDropBeforeCard(s.id)}

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -11,6 +11,7 @@ import {
 import { CardModal } from './CardModal'
 import { KanbanColumn } from './KanbanColumn'
 import type { ModalSpawn } from './ModalTerminal'
+import { ContextMenu, type MenuItem } from '../ContextMenu'
 
 /** One session node shown as a board card — derived LIVE from the canvas nodes; the board
  *  itself stores only column assignments. */
@@ -52,6 +53,8 @@ interface KanbanViewProps {
   onRenameNode: (nodeId: string, title: string) => void
   /** Write-through a sticky node's body text (only fired for kind 'sticky'). */
   onEditSticky: (nodeId: string, text: string) => void
+  /** Permanently delete a node (ends its session) — routed through the canvas confirm. */
+  onDeleteNode: (nodeId: string) => void
 }
 
 type Drag = { kind: 'card' | 'column'; id: string } | null
@@ -60,11 +63,13 @@ type Drag = { kind: 'card' | 'column'; id: string } | null
  *  agent-status listeners must keep running, and display:none would 0×0-resize every
  *  terminal into a tmux SIGWINCH) — this is an opaque overlay, nothing more. */
 export function KanbanView({
-  board, sessions, onChange, onOpenNode, onCreateNode, onRenameNode, onEditSticky
+  board, sessions, onChange, onOpenNode, onCreateNode, onRenameNode, onEditSticky, onDeleteNode
 }: KanbanViewProps) {
   const dragRef = useRef<Drag>(null)
   // One card modal at a time; a deleted node closes it via the byId.has render guard.
   const [modalNodeId, setModalNodeId] = useState<string | null>(null)
+  // Right-click card menu (open on canvas / move / delete).
+  const [cardMenu, setCardMenu] = useState<{ x: number; y: number; nodeId: string } | null>(null)
   const statusById = useAgentStatus((s) => s.byId)
   // Primitive selectors (not one object) — an object selector would re-render on every store set.
   const projectName = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.name)
@@ -118,6 +123,31 @@ export function KanbanView({
   const sessionsFor = (ids: string[]) =>
     ids.flatMap((id) => (byId.has(id) ? [byId.get(id)!] : []))
 
+  // Right-click menu for a card: open on canvas, move to another column, delete.
+  const cardMenuItems = (nodeId: string): MenuItem[] => {
+    const curColId = columnForNode(board, nodeId)?.id ?? null
+    const moveTargets: MenuItem[] = [
+      ...(curColId !== null
+        ? [{ label: 'Ungrouped', onClick: () => commit(assignNode(board, nodeId, null, null)) }]
+        : []),
+      ...board.columns
+        .filter((c) => c.id !== curColId)
+        .map((c) => ({
+          label: c.title,
+          onClick: () => commit(assignNode(board, nodeId, c.id, null))
+        }))
+    ]
+    return [
+      { label: 'Open card', onClick: () => setModalNodeId(nodeId) },
+      { label: 'Open on canvas', onClick: () => onOpenNode(nodeId) },
+      ...(moveTargets.length
+        ? ([{ type: 'submenu', label: 'Move to', children: moveTargets }] as MenuItem[])
+        : []),
+      { type: 'separator' },
+      { label: 'Delete', danger: true, onClick: () => onDeleteNode(nodeId) }
+    ]
+  }
+
   return (
     <div className="kanban-overlay">
       {/* Title strip: names the board's project AND pushes the columns below the top-right
@@ -139,6 +169,7 @@ export function KanbanView({
           onDragEnd={() => (dragRef.current = null)}
           onDropOnColumn={() => dropOnColumn(null)}
           onDropBeforeCard={(id) => dropBeforeCard(null, id)}
+          onCardContext={(id, x, y) => setCardMenu({ nodeId: id, x, y })}
         />
         {board.columns.map((col) => (
           <KanbanColumn
@@ -158,6 +189,7 @@ export function KanbanView({
             onDragEnd={() => (dragRef.current = null)}
             onDropOnColumn={() => dropOnColumn(col.id)}
             onDropBeforeCard={(id) => dropBeforeCard(col.id, id)}
+            onCardContext={(id, x, y) => setCardMenu({ nodeId: id, x, y })}
           />
         ))}
         <button
@@ -167,6 +199,15 @@ export function KanbanView({
           + Add column
         </button>
       </div>
+      {cardMenu && byId.has(cardMenu.nodeId) && (
+        <ContextMenu
+          x={cardMenu.x}
+          y={cardMenu.y}
+          zIndex={60}
+          items={cardMenuItems(cardMenu.nodeId)}
+          onClose={() => setCardMenu(null)}
+        />
+      )}
       {modalNodeId && byId.has(modalNodeId) && (
         <CardModal
           session={byId.get(modalNodeId)!}

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -14,9 +14,11 @@ interface SessionCardProps {
   onDragEnd: () => void
   /** A dragged card was dropped on this card — insert it before this one. */
   onDropBefore: () => void
+  /** Right-click on the card — opens the actions menu at the cursor. */
+  onContext: (x: number, y: number) => void
 }
 
-export function SessionCard({ session, status, meta, onOpen, onDragStart, onDragEnd, onDropBefore }: SessionCardProps) {
+export function SessionCard({ session, status, meta, onOpen, onDragStart, onDragEnd, onDropBefore, onContext }: SessionCardProps) {
   // Local drag state only styles THIS card (ghost look) — the drag payload lives in KanbanView.
   const [dragging, setDragging] = useState(false)
   const badge =
@@ -57,6 +59,10 @@ export function SessionCard({ session, status, meta, onOpen, onDragStart, onDrag
         onDropBefore()
       }}
       onClick={onOpen}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        onContext(e.clientX, e.clientY)
+      }}
       title="Open card"
     >
       <div className="kanban-card__row">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -4839,6 +4839,14 @@ body,
 .usage-indicator:has(.usage-popover) {
   z-index: 13;
 }
+/* Kanban board is an opaque overlay at z 25; while it's open the usage pill must sit ABOVE it
+   (same layer as the controls cluster) so it stays visible in the board's bottom-left corner. */
+.usage-indicator--board {
+  z-index: 26;
+}
+.usage-indicator--board:has(.usage-popover) {
+  z-index: 60; /* over the board + banners, below ConfirmDialog/palette (70) */
+}
 .usage-pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Two board affordances that were missing vs the canvas:

- **Usage indicator on the board**: the bottom-left usage pill was hidden under the opaque board overlay (z 25). It now rises above it while kanban is open (`.usage-indicator--board`, z 26; popover z 60, below dialogs) so it stays visible and clickable — same corner as on canvas.
- **Right-click card actions**: a card context menu (reusing the canvas `ContextMenu`): **Open card**, **Open on canvas**, **Move to ▸ <column>/Ungrouped**, and **Delete** (red; routed through the canvas confirm → "Delete <title>? Its terminal session will end." → ends the tmux session, same teardown as the Delete key).

## Test plan

- [x] Full suite 2752/2752, typecheck clean
- [x] Live drive: usage pill present with the over-board variant (computed z 26) while the board is open; right-click a card opens the actions menu (Open card / Open on canvas / Move to / Delete); Delete opens the confirm dialog naming the session; screenshots verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h