### PR TITLE
feat: drop files into the kanban card modal's terminal

### DIFF
--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -1,14 +1,16 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { SearchAddon } from '@xterm/addon-search'
 import { hasUsage } from '@shared/agents/config'
 import { FindBar } from '../FindBar'
 import { useAgentStatus } from '../../state/agentStatus'
+import { useProjects } from '../../state/projects'
 import { useSession } from '../../session/session'
 import { useSettings } from '../../state/settings'
 import { useTerminalSearch } from '../../terminal/useTerminalSearch'
 import { LocalTransport } from '../../terminal/local-transport'
+import { droppedPaths } from '../../terminal/file-drop'
 import { parseOsc52 } from '../../terminal/osc52'
 import {
   attachReplay,
@@ -59,6 +61,8 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
   const termRef = useRef<Terminal | null>(null)
   const searchAddonRef = useRef<SearchAddon | null>(null)
   const agentSessionId = useAgentStatus((s) => s.byId[nodeId]?.sessionId)
+  const [dropping, setDropping] = useState(false)
+  const [uploading, setUploading] = useState(false)
 
   // Same search machinery as the canvas node: capture-indexed matches + xterm highlight.
   const readBuffer = useCallback((): string => {
@@ -246,8 +250,50 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodeId])
 
+  // File drop → paste the path(s) into the co-attached session, just like the canvas node.
+  const onDragOver = (e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer.types).includes('Files')) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'copy'
+    if (!dropping) setDropping(true)
+  }
+  const onDragLeave = (e: React.DragEvent) => {
+    const rt = e.relatedTarget as Node | null
+    if (!rt || !(e.currentTarget as HTMLElement).contains(rt)) setDropping(false)
+  }
+  const onDrop = async (e: React.DragEvent) => {
+    const files = Array.from(e.dataTransfer.files)
+    setDropping(false)
+    if (!files.length) return
+    e.preventDefault()
+    e.stopPropagation()
+    const term = termRef.current
+    if (!term) return
+    let paths: string[]
+    if (spawn.sshRemoteTmux) {
+      const projectId = useProjects.getState().activeProjectId
+      setUploading(true)
+      try {
+        paths = await droppedPaths(files, { sshRemoteTmux: true, projectId })
+      } finally {
+        setUploading(false)
+      }
+    } else {
+      paths = await droppedPaths(files, { sshRemoteTmux: false, projectId: '' })
+    }
+    if (!paths.length) return
+    term.focus()
+    term.paste(paths.join(' ') + ' ')
+  }
+
   return (
-    <div className="kanban-modal__termwrap">
+    <div
+      className={`kanban-modal__termwrap${dropping ? ' kanban-modal__termwrap--drop' : ''}`}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      {uploading && <div className="kanban-modal__upload">Uploading…</div>}
       {searchOpen && (
         <FindBar
           query={search.query}

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -14,6 +14,7 @@ import { WebglAddon } from '@xterm/addon-webgl'
 import { renderMarkdown } from '../lib/markdown'
 import { ChatPanel } from './ChatPanel'
 import { LocalTransport } from '../terminal/local-transport'
+import { droppedPaths } from '../terminal/file-drop'
 import type { TerminalTransport } from '../terminal/transport'
 import { patchTerminalScale } from '../terminal/scale-fix'
 import { parseOsc52 } from '../terminal/osc52'
@@ -75,11 +76,6 @@ import { hintLabel } from '@shared/platform-utils'
 import { ColumnPill } from '../components/kanban/ColumnPill'
 import { BoardLogPanel } from '../components/kanban/BoardLogPanel'
 import { AgentMascot } from './AgentMascot'
-
-/** Backslash-escape shell-special characters, like a native terminal does on file drop. */
-function escapeDroppedPath(p: string): string {
-  return p.replace(/([ \t"'`\\()&;|<>$!*?[\]{}#~])/g, '\\$1')
-}
 
 /**
  * Resolve the `sshRemote` create option for an SSH-project terminal: the owning project's live
@@ -1374,38 +1370,25 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
 
     let paths: string[]
     if (data.sshRemoteTmux) {
-      // Remote terminal: a local path is useless on the remote host. Upload each file over the
-      // project's ControlMaster and paste the REMOTE absolute path instead. Fail-open: skip nulls.
-      // scp takes seconds and pastes nothing until it's done, so show an overlay while it runs —
-      // without it a drop looks like it silently did nothing.
+      // Remote terminal: uploading over the ControlMaster takes seconds and pastes nothing until
+      // it's done, so show an overlay while it runs — without it a drop looks like it silently did
+      // nothing. (The upload + REMOTE-path resolution itself lives in the shared droppedPaths.)
       const projectId = useProjects.getState().activeProjectId
       if (uploadNoteTimer.current) clearTimeout(uploadNoteTimer.current)
       setUploadNote({
         text: `Uploading ${files.length === 1 ? files[0].name : `${files.length} files`}…`,
       })
-      let uploaded: (string | null)[] = []
       try {
-        uploaded = await Promise.all(
-          files.map((f) => {
-            const lp = window.nodeTerminal.getPathForFile(f)
-            return lp
-              ? window.nodeTerminal.sshProject.uploadFile(projectId, lp, f.name).catch(() => null)
-              : Promise.resolve(null)
-          })
-        )
+        paths = await droppedPaths(files, { sshRemoteTmux: true, projectId })
       } finally {
         setUploadNote(null)
       }
-      paths = uploaded.filter((p): p is string => !!p).map(escapeDroppedPath)
       if (!paths.length) {
         setUploadNote({ text: 'Upload failed', failed: true })
         uploadNoteTimer.current = setTimeout(() => setUploadNote(null), 2500)
       }
     } else {
-      paths = files
-        .map((f) => window.nodeTerminal.getPathForFile(f))
-        .filter(Boolean)
-        .map(escapeDroppedPath)
+      paths = await droppedPaths(files, { sshRemoteTmux: false, projectId: '' })
     }
     if (!paths.length) return
     // Enter the terminal and paste the path(s) like a real drop (trailing space to continue).

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8310,3 +8310,28 @@ body,
 .ctx-menu--scroll::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* Modal terminal file-drop affordance (mirrors the canvas node's dropping state). */
+.kanban-modal__termwrap--drop::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border: 2px dashed var(--accent);
+  border-radius: 8px;
+  background: rgba(10, 132, 255, 0.06);
+  pointer-events: none;
+  z-index: 3;
+}
+.kanban-modal__upload {
+  position: absolute;
+  left: 50%;
+  bottom: 14px;
+  transform: translateX(-50%);
+  z-index: 4;
+  font-size: 12px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 6px 12px;
+}

--- a/src/renderer/terminal/file-drop.ts
+++ b/src/renderer/terminal/file-drop.ts
@@ -1,0 +1,34 @@
+// Shared terminal file-drop logic — used by both the canvas TerminalNode and the kanban card
+// modal's co-attach terminal (ModalTerminal), so a file dropped onto either pastes the same way.
+
+/** Backslash-escape shell-special characters, like a native terminal does on file drop. */
+export function escapeDroppedPath(p: string): string {
+  return p.replace(/([ \t"'`\\()&;|<>$!*?[\]{}#~])/g, '\\$1')
+}
+
+/**
+ * Resolve dropped files to terminal-pasteable paths. For an SSH-project terminal a local path is
+ * useless on the host, so each file is uploaded over the project's ControlMaster and its REMOTE
+ * absolute path is returned; for a local terminal the local path is used. Fail-open: files that
+ * can't be resolved/uploaded are dropped from the result (never throws).
+ */
+export async function droppedPaths(
+  files: File[],
+  opts: { sshRemoteTmux: boolean; projectId: string }
+): Promise<string[]> {
+  if (opts.sshRemoteTmux) {
+    const uploaded = await Promise.all(
+      files.map((f) => {
+        const lp = window.nodeTerminal.getPathForFile(f)
+        return lp
+          ? window.nodeTerminal.sshProject.uploadFile(opts.projectId, lp, f.name).catch(() => null)
+          : Promise.resolve(null)
+      })
+    )
+    return uploaded.filter((p): p is string => !!p).map(escapeDroppedPath)
+  }
+  return files
+    .map((f) => window.nodeTerminal.getPathForFile(f))
+    .filter((p): p is string => !!p)
+    .map(escapeDroppedPath)
+}


### PR DESCRIPTION
## Summary

A session popup (card modal) open on the board couldn't accept file drops. The co-attach terminal in the modal now accepts them exactly like the canvas node: dropped files' local paths — or, for an SSH project, files uploaded over the project ControlMaster and resolved to their REMOTE path — are pasted into the shared session (trailing space), with a dashed drop-highlight and an "Uploading…" note during an SSH upload.

Refactor: extracted the canvas node's drop logic (`escapeDroppedPath` + the local/SSH path resolution) into `terminal/file-drop.ts` (`droppedPaths`), and pointed both `TerminalNode` and `ModalTerminal` at it — one implementation, no drift. TerminalNode's existing upload-note UX is preserved (it wraps `droppedPaths`).

## Test plan

- [x] Full suite 2756/2756, typecheck clean (TerminalNode's drop behavior unchanged — now via the shared helper)
- [x] Live drive: modal terminal wrapper present; a Files dragover shows the drop-highlight, dragleave clears it, and the drop handler is bound. Real local-path paste depends on Electron's `File.path` (verified on Mac); the logic is the same shared code the canvas node uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h