### PR TITLE
fix: kanban + New menu direction, card unread clear, dictation shortcut from the modal

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -1048,16 +1048,24 @@ export function Canvas() {
   // does NOT close the overlay itself; it bumps `dictationStopSignal` so DictationOverlay can
   // decide what "press again" means from its own current phase (stop-and-transcribe while
   // recording, dismiss otherwise) — see the `stopSignal` prop doc.
+  // The node whose kanban card modal is open (null = none). The dictation shortcut targets THIS
+  // when set, since no canvas node is selected while the board covers the canvas.
+  const kanbanModalNodeRef = useRef<string | null>(null)
   const toggleDictation = useCallback(() => {
     setDictationOpen((open) => {
       if (open) {
         setDictationStopSignal((n) => n + 1)
         return true
       }
-      const sel = nodesRef.current.find((n) => n.selected && n.type === 'terminal')
+      // A kanban card modal open over the board wins (nothing on the canvas is selected then);
+      // otherwise fall back to the selected canvas terminal.
+      const modalId = kanbanModalNodeRef.current
+      const target = modalId
+        ? nodesRef.current.find((n) => n.id === modalId && n.type === 'terminal')
+        : nodesRef.current.find((n) => n.selected && n.type === 'terminal')
       setDictationTarget(
-        sel
-          ? { kind: 'terminal', nodeId: sel.id, title: (sel.data.title as string) || 'Untitled' }
+        target
+          ? { kind: 'terminal', nodeId: target.id, title: (target.data.title as string) || 'Untitled' }
           : null
       )
       setDictationNonce((n) => n + 1)
@@ -6111,6 +6119,7 @@ export function Canvas() {
           onRenameNode={(nodeId, title) => renameSession(activeProjectId, nodeId, title)}
           onEditSticky={editStickyText}
           onDeleteNode={deleteNodeFromKanban}
+          onModalNodeChange={(id) => (kanbanModalNodeRef.current = id)}
         />
       )}
       <UpdateCard />

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { ProjectKanban } from '@shared/types'
 import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type AgentId } from '@shared/agents/config'
 import { useAgentStatus } from '../../state/agentStatus'
@@ -55,6 +55,9 @@ interface KanbanViewProps {
   onEditSticky: (nodeId: string, text: string) => void
   /** Permanently delete a node (ends its session) — routed through the canvas confirm. */
   onDeleteNode: (nodeId: string) => void
+  /** Reports which node's card modal is open (null = none) so the canvas can target it — e.g.
+   *  the dictation shortcut dictates into the open card's session, not a canvas selection. */
+  onModalNodeChange: (nodeId: string | null) => void
 }
 
 type Drag = { kind: 'card' | 'column'; id: string } | null
@@ -63,13 +66,21 @@ type Drag = { kind: 'card' | 'column'; id: string } | null
  *  agent-status listeners must keep running, and display:none would 0×0-resize every
  *  terminal into a tmux SIGWINCH) — this is an opaque overlay, nothing more. */
 export function KanbanView({
-  board, sessions, onChange, onOpenNode, onCreateNode, onRenameNode, onEditSticky, onDeleteNode
+  board, sessions, onChange, onOpenNode, onCreateNode, onRenameNode, onEditSticky, onDeleteNode,
+  onModalNodeChange
 }: KanbanViewProps) {
   const dragRef = useRef<Drag>(null)
   // One card modal at a time; a deleted node closes it via the byId.has render guard.
   const [modalNodeId, setModalNodeId] = useState<string | null>(null)
   // Right-click card menu (open on canvas / move / delete).
   const [cardMenu, setCardMenu] = useState<{ x: number; y: number; nodeId: string } | null>(null)
+  // Opening a card = you're looking at that session: clear its unread badge, and report the open
+  // node to the canvas (dictation shortcut targeting).
+  useEffect(() => {
+    onModalNodeChange(modalNodeId)
+    if (modalNodeId) useAgentStatus.getState().clearUnread(modalNodeId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modalNodeId])
   const statusById = useAgentStatus((s) => s.byId)
   // Primitive selectors (not one object) — an object selector would re-render on every store set.
   const projectName = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.name)

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6771,10 +6771,10 @@ body,
 }
 .kanban-col__newmenu {
   position: absolute;
-  bottom: 100%;
+  top: 100%;
   left: 10px;
   right: 10px;
-  margin-bottom: 4px;
+  margin-top: 4px;
   background: #1c1c1e;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 8px;


### PR DESCRIPTION
Three board fixes:
- **+ New menu opens downward** (was opening up, off the top of a low column).
- **Opening a card modal clears that session's unread badge** — same as selecting the node on the canvas (you're looking at it now).
- **The dictation shortcut targets the open card modal's session** when the board covers the canvas (no canvas node is selected then), so speech works from the popup.

## Test plan
- [x] Full suite 2756/2756, typecheck clean
- [x] Live drive: + New menu renders below the button (menuTop 228 > btnTop 188); card modal opens with the unread-clear + modal-node wiring; modal terminal present as the dictation target