### PR TITLE
feat: browser nodes on the kanban board (cards + live webview modal)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4238,8 +4238,18 @@ export function Canvas() {
   const kanbanSessions = useMemo(
     () =>
       nodes
-        .filter((n) => n.type === 'terminal' || n.type === 'sticky')
+        .filter((n) => n.type === 'terminal' || n.type === 'sticky' || n.type === 'browser')
         .map((n) => {
+          if (n.type === 'browser') {
+            return {
+              id: n.id,
+              title: (n.data.title as string) || 'Browser',
+              color: (n.data.color as string) ?? NODE_COLORS[0],
+              kind: 'browser' as const,
+              url: n.data.url as string | undefined,
+              spawn: {}
+            }
+          }
           if (n.type === 'sticky') {
             const text = ((n.data.text as string) ?? '').trim()
             return {
@@ -4289,7 +4299,9 @@ export function Canvas() {
           ? createTerminalNode(index, project?.cwd, at, undefined, project?.ssh)
           : choice.kind === 'sticky'
             ? createStickyNode(index, at)
-            : createAgentNode(
+            : choice.kind === 'browser'
+              ? createBrowserNode(index, '', at)
+              : createAgentNode(
                 choice.agentId,
                 index,
                 project?.cwd,
@@ -4319,7 +4331,9 @@ export function Canvas() {
           ? 'Terminal'
           : choice.kind === 'sticky'
             ? 'Sticky note'
-            : agentConfig(choice.agentId)?.label ??
+            : choice.kind === 'browser'
+              ? 'Browser'
+              : agentConfig(choice.agentId)?.label ??
               useSettings.getState().settings.customAgents.find((a) => a.id === choice.agentId)
                 ?.label ??
               choice.agentId
@@ -4347,6 +4361,15 @@ export function Canvas() {
       })
     },
     [deleteNodes]
+  )
+
+  // Persist a browser card's navigation (url/title) from the modal webview back to the node.
+  const browserNavFromKanban = useCallback(
+    (nodeId: string, patch: { url?: string; title?: string }) => {
+      setNodes((ns) => ns.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n)))
+      markDirty()
+    },
+    [setNodes, markDirty]
   )
 
   const openNodeFromKanban = useCallback(
@@ -6120,6 +6143,7 @@ export function Canvas() {
           onEditSticky={editStickyText}
           onDeleteNode={deleteNodeFromKanban}
           onModalNodeChange={(id) => (kanbanModalNodeRef.current = id)}
+          onBrowserNav={browserNavFromKanban}
         />
       )}
       <UpdateCard />

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -10,6 +10,7 @@ import type { KanbanSession } from './KanbanView'
 import { BoardLogPanel } from './BoardLogPanel'
 import { CardMetaBar } from './CardMetaBar'
 import { ModalTerminal } from './ModalTerminal'
+import { BrowserSurface } from '../../nodes/BrowserSurface'
 
 interface CardModalProps {
   session: KanbanSession
@@ -25,12 +26,14 @@ interface CardModalProps {
   onRename: (title: string) => void
   /** Sticky text write-through (only called for kind 'sticky'). */
   onEditSticky: (text: string) => void
+  /** Browser navigation write-through (only called for kind 'browser'). */
+  onBrowserNav: (patch: { url?: string; title?: string }) => void
 }
 
 /** Trello-style card popup over the board. Scrim click / Esc close it; the board (and the
  *  canvas under it) stay mounted. Terminal cards carry the node header's actions too:
  *  search / dictate / AI-name / markdown view (the node itself is hidden under the board). */
-export function CardModal({ session, columnTitle, board, onChangeBoard, onClose, onOpenCanvas, onRename, onEditSticky }: CardModalProps) {
+export function CardModal({ session, columnTitle, board, onChangeBoard, onClose, onOpenCanvas, onRename, onEditSticky, onBrowserNav }: CardModalProps) {
   const { api } = useSession()
   const idRef = useRef<string>()
   if (!idRef.current) idRef.current = nextDialogId()
@@ -43,6 +46,7 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
   // Comments & activity panel: OPEN by default in the modal; the header 💬 collapses it.
   const [panelOpen, setPanelOpen] = useState(true)
   const isTerminal = session.kind === 'terminal'
+  const isBrowser = session.kind === 'browser'
 
   const nameWithAi = async () => {
     setNaming(true)
@@ -176,8 +180,7 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
               <div className="kanban-modal__pane" data-kind={session.kind}>
                 {session.kind === 'terminal' ? (
                   // A live SECOND client on the node's session — keyed by node id so switching cards
-                  // remounts a fresh viewer. Chat has no PTY; it opens on the canvas. The markdown
-                  // view OVERLAYS the terminal (kept mounted — its viewer must not detach/re-seed).
+                  // remounts a fresh viewer.
                   <ModalTerminal
                     key={session.id}
                     nodeId={session.id}
@@ -185,8 +188,18 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
                     searchOpen={searchOpen}
                     onCloseSearch={() => setSearchOpen(false)}
                   />
+                ) : isBrowser ? (
+                  // A live browser webview seeded with the node's URL; navigation persists back to
+                  // the node (the canvas node picks it up on its next mount).
+                  <BrowserSurface
+                    key={session.id}
+                    nodeId={session.id}
+                    url={session.url ?? ''}
+                    onUrlChange={(u) => onBrowserNav({ url: u })}
+                    onTitleChange={(t) => onBrowserNav({ title: t })}
+                  />
                 ) : (
-                  <div className="kanban-modal__placeholder">Chat sessions open on the canvas.</div>
+                  <div className="kanban-modal__placeholder">Open on the canvas.</div>
                 )}
               </div>
             )}

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -19,10 +19,12 @@ export interface KanbanSession {
   id: string
   title: string
   color: string
-  kind: 'terminal' | 'sticky'
+  kind: 'terminal' | 'sticky' | 'browser'
   agentId?: string
   /** Sticky note body — shown in the expanded detail row. */
   text?: string
+  /** Browser node URL (kind 'browser' only) — shown on the card, opened in the modal webview. */
+  url?: string
   /** The subset of the node's `data` the card modal's co-attach terminal needs to spawn/join the
    *  same session (kind 'terminal' only; sticky passes `{}`). */
   spawn: ModalSpawn
@@ -32,6 +34,7 @@ export interface KanbanSession {
 export type KanbanCreateChoice =
   | { kind: 'terminal' }
   | { kind: 'sticky' }
+  | { kind: 'browser' }
   | { kind: 'agent'; agentId: AgentId }
 
 /** One "+ New" menu entry (label + the choice it fires). */
@@ -58,6 +61,8 @@ interface KanbanViewProps {
   /** Reports which node's card modal is open (null = none) so the canvas can target it — e.g.
    *  the dictation shortcut dictates into the open card's session, not a canvas selection. */
   onModalNodeChange: (nodeId: string | null) => void
+  /** Persist a browser card's navigation (url/title) from the modal webview to the node. */
+  onBrowserNav: (nodeId: string, patch: { url?: string; title?: string }) => void
 }
 
 type Drag = { kind: 'card' | 'column'; id: string } | null
@@ -67,7 +72,7 @@ type Drag = { kind: 'card' | 'column'; id: string } | null
  *  terminal into a tmux SIGWINCH) — this is an opaque overlay, nothing more. */
 export function KanbanView({
   board, sessions, onChange, onOpenNode, onCreateNode, onRenameNode, onEditSticky, onDeleteNode,
-  onModalNodeChange
+  onModalNodeChange, onBrowserNav
 }: KanbanViewProps) {
   const dragRef = useRef<Drag>(null)
   // One card modal at a time; a deleted node closes it via the byId.has render guard.
@@ -100,6 +105,7 @@ export function KanbanView({
       choice: { kind: 'agent', agentId: a.id } as KanbanCreateChoice
     })),
     { key: 'terminal', label: 'Terminal', choice: { kind: 'terminal' } },
+    { key: 'browser', label: 'Browser', choice: { kind: 'browser' } },
     { key: 'sticky', label: 'Sticky note', choice: { kind: 'sticky' } }
   ]
   const byId = new Map(sessions.map((s) => [s.id, s]))
@@ -232,6 +238,7 @@ export function KanbanView({
           }}
           onRename={(t) => onRenameNode(modalNodeId, t)}
           onEditSticky={(t) => onEditSticky(modalNodeId, t)}
+          onBrowserNav={(patch) => onBrowserNav(modalNodeId, patch)}
         />
       )}
     </div>

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -69,6 +69,7 @@ export function SessionCard({ session, status, meta, onOpen, onDragStart, onDrag
         <span className="kanban-card__nodedot" style={{ background: session.color }} />
         <span className="kanban-card__title">{session.title}</span>
         {session.kind === 'sticky' && <span className="kanban-card__kind">note</span>}
+        {session.kind === 'browser' && <span className="kanban-card__kind">web</span>}
         {badge === 'running' && <span className="kanban-badge kanban-badge--running">RUNNING</span>}
         {badge === 'needs' && <span className="kanban-badge kanban-badge--needs">NEEDS YOU</span>}
         {status?.unread && <span className="kanban-card__unread" />}

--- a/src/renderer/nodes/BrowserNode.tsx
+++ b/src/renderer/nodes/BrowserNode.tsx
@@ -1,127 +1,17 @@
-import { useEffect, useRef, useState } from 'react'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import type { CanvasNode } from '../state/workspace'
-import { searchOrUrl } from './browserUrl'
-import { BrowserStartPage } from './BrowserStartPage'
-import { useBrowserHistory } from '../state/browserHistory'
-
-// Minimal typing for the Electron <webview> element methods/events we use.
-type WebviewEl = HTMLElement & {
-  goBack(): void
-  goForward(): void
-  reload(): void
-  stop(): void
-  loadURL(url: string): void
-  canGoBack(): boolean
-  canGoForward(): boolean
-  getWebContentsId(): number
-}
+import { BrowserSurface } from './BrowserSurface'
 
 /**
- * A navigable Chromium browser node (Electron <webview>) with a back/forward/reload + address
- * toolbar. Locked down (no nodeintegration); `allowpopups` is set only so main can capture
- * new-window requests and turn them into another browser node. The last top-level URL is
- * persisted to `data.url` so the node reopens where it was. The frame/header mirror
- * {@link WebNode}/VideoNode for consistent drag/resize/close behavior.
+ * A navigable Chromium browser node: node chrome (frame/header/resize/close) wrapping the shared
+ * {@link BrowserSurface} (webview + toolbar). The last top-level URL persists to `data.url` so the
+ * node reopens where it was; the same surface backs the kanban card modal's browser popup.
  */
 export default function BrowserNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const { deleteElements, updateNodeData } = useReactFlow()
-  const ref = useRef<WebviewEl | null>(null)
-  const lastUrlRef = useRef('')
-  // Seed the initial webview src ONCE at mount; navigations persist via updateNodeData but must
-  // not re-push `src` into a webview that already navigated there (would cause a reload loop).
-  const [startUrl] = useState(() => (data.url as string) ?? '')
-  // Navigation is driven by the `src` attribute, NOT webview.loadURL(): a src-less <webview>
-  // (a blank "New browser" node) doesn't emit dom-ready, so imperative loadURL() before then is a
-  // no-op — typing a URL "didn't go". Setting `src` is how you give a webview its first (and next)
-  // page. did-navigate only updates `address`, never `src`, so in-page navigation can't loop.
-  const [src, setSrc] = useState(startUrl)
-  const [address, setAddress] = useState(startUrl)
-  const [loading, setLoading] = useState(false)
-  const [canBack, setCanBack] = useState(false)
-  const [canFwd, setCanFwd] = useState(false)
-  const [failed, setFailed] = useState('')
-
-  useEffect(() => {
-    const wv = ref.current
-    if (!wv) return
-    const onStart = (): void => setLoading(true)
-    const onStop = (): void => {
-      setLoading(false)
-      setCanBack(wv.canGoBack())
-      setCanFwd(wv.canGoForward())
-    }
-    const onNav = (e: Event): void => {
-      const u = (e as unknown as { url: string }).url
-      setAddress(u)
-      setFailed('')
-      updateNodeData(id, { url: u }) // persist last top-level URL
-      lastUrlRef.current = u
-      useBrowserHistory.getState().record(u, u)
-    }
-    const onNavInPage = (e: Event): void => setAddress((e as unknown as { url: string }).url)
-    const onTitle = (e: Event): void => {
-      const title = (e as unknown as { title: string }).title
-      updateNodeData(id, { title })
-      if (lastUrlRef.current) useBrowserHistory.getState().record(lastUrlRef.current, title)
-    }
-    const onFail = (e: Event): void => {
-      const ev = e as unknown as { isMainFrame: boolean; errorCode: number; errorDescription: string }
-      // -3 (ABORTED) fires on user-initiated stop / redirect races — ignore it.
-      if (ev.isMainFrame && ev.errorCode !== -3) setFailed(ev.errorDescription || 'Failed to load')
-    }
-    wv.addEventListener('did-start-loading', onStart)
-    wv.addEventListener('did-stop-loading', onStop)
-    wv.addEventListener('did-navigate', onNav)
-    wv.addEventListener('did-navigate-in-page', onNavInPage)
-    wv.addEventListener('page-title-updated', onTitle)
-    wv.addEventListener('did-fail-load', onFail)
-    return () => {
-      wv.removeEventListener('did-start-loading', onStart)
-      wv.removeEventListener('did-stop-loading', onStop)
-      wv.removeEventListener('did-navigate', onNav)
-      wv.removeEventListener('did-navigate-in-page', onNavInPage)
-      wv.removeEventListener('page-title-updated', onTitle)
-      wv.removeEventListener('did-fail-load', onFail)
-    }
-  }, [id, updateNodeData])
-
-  // Register the guest's webContents id → node id so main can turn its new-window (target=_blank
-  // / window.open) requests into another connected browser node. Paired unregister on unmount.
-  useEffect(() => {
-    const wv = ref.current
-    if (!wv) return
-    let wcId = 0
-    const onReady = (): void => {
-      wcId = wv.getWebContentsId()
-      window.nodeTerminal.browser.register(wcId, id)
-    }
-    wv.addEventListener('dom-ready', onReady)
-    return () => {
-      wv.removeEventListener('dom-ready', onReady)
-      if (wcId) window.nodeTerminal.browser.unregister(wcId)
-    }
-  }, [id])
-
-  const go = (): void => {
-    const safe = searchOrUrl(address)
-    if (!safe) {
-      setFailed('Enter a URL or search term')
-      return
-    }
-    setAddress(safe)
-    setFailed('')
-    // Navigate by (re)setting the src attribute. If the same URL is entered twice the attribute
-    // doesn't change, so force a reload through the element in that case.
-    if (safe === src) ref.current?.reload()
-    else setSrc(safe)
-  }
 
   return (
-    <div
-      className={`term-node browser-node${selected ? ' selected' : ''}`}
-      style={{ borderTopColor: data.color }}
-    >
+    <div className={`term-node browser-node${selected ? ' selected' : ''}`} style={{ borderTopColor: data.color }}>
       <NodeResizer minWidth={360} minHeight={240} isVisible={selected} color={data.color} />
       {/* Invisible target handle so a rope from the agent node that opened this can attach. */}
       <Handle
@@ -141,77 +31,22 @@ export default function BrowserNode({ id, data, selected }: NodeProps<CanvasNode
       />
 
       <div className="term-node__header">
-        <span className="term-node__title-text" title={address}>
+        <span className="term-node__title-text" title={(data.url as string) || ''}>
           {(data.title as string) || 'Browser'}
         </span>
         <span className="term-node__spacer" />
-        <button
-          className="term-node__close"
-          title="Close"
-          onClick={() => deleteElements({ nodes: [{ id }] })}
-        >
+        <button className="term-node__close" title="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
           ×
         </button>
       </div>
 
-      <div className="browser-node__toolbar nodrag">
-        <button
-          className="browser-node__btn"
-          disabled={!canBack}
-          onClick={() => ref.current?.goBack()}
-          title="Back"
-        >
-          ◀
-        </button>
-        <button
-          className="browser-node__btn"
-          disabled={!canFwd}
-          onClick={() => ref.current?.goForward()}
-          title="Forward"
-        >
-          ▶
-        </button>
-        <button
-          className="browser-node__btn"
-          onClick={() => (loading ? ref.current?.stop() : ref.current?.reload())}
-          title={loading ? 'Stop' : 'Reload'}
-        >
-          {loading ? '✕' : '⟳'}
-        </button>
-        <input
-          className="browser-node__address"
-          value={address}
-          spellCheck={false}
-          placeholder="Enter a URL and press Enter"
-          onChange={(e) => setAddress(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') go()
-          }}
-        />
-      </div>
-
       <div className="editor-node__body">
-        <div className="browser-node__view nodrag nowheel">
-          {/* eslint-disable-next-line react/no-unknown-property */}
-          <webview
-            ref={ref as unknown as React.Ref<HTMLElement>}
-            src={src || undefined}
-            // React types `allowpopups` as a boolean (@types/react WebViewHTMLAttributes);
-            // rendered as the `allowpopups` attribute Electron reads. No `nodeintegration`.
-            allowpopups={true}
-            style={{ width: '100%', height: '100%' }}
-          />
-          {!src && (
-            <BrowserStartPage
-              onNavigate={(u) => {
-                setSrc(u)
-                setAddress(u)
-                setFailed('')
-              }}
-            />
-          )}
-          {failed && <div className="browser-node__error">{failed}</div>}
-        </div>
+        <BrowserSurface
+          nodeId={id}
+          url={(data.url as string) ?? ''}
+          onUrlChange={(u) => updateNodeData(id, { url: u })}
+          onTitleChange={(t) => updateNodeData(id, { title: t })}
+        />
       </div>
     </div>
   )

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef, useState } from 'react'
+import { searchOrUrl } from './browserUrl'
+import { BrowserStartPage } from './BrowserStartPage'
+import { useBrowserHistory } from '../state/browserHistory'
+
+// Minimal typing for the Electron <webview> element methods/events we use.
+type WebviewEl = HTMLElement & {
+  goBack(): void
+  goForward(): void
+  reload(): void
+  stop(): void
+  loadURL(url: string): void
+  canGoBack(): boolean
+  canGoForward(): boolean
+  getWebContentsId(): number
+}
+
+interface BrowserSurfaceProps {
+  /** The node id — registers the guest webContents so main can route its new-window requests. */
+  nodeId: string
+  /** Initial URL (seeded once at mount). */
+  url: string
+  /** Persist the top-level URL after a navigation. */
+  onUrlChange: (url: string) => void
+  /** Persist the page title. */
+  onTitleChange: (title: string) => void
+}
+
+/**
+ * The navigable Chromium surface (Electron <webview> + back/forward/reload + address bar), with
+ * no node chrome. Shared by the canvas {@link BrowserNode} and the kanban card modal, so a browser
+ * opens and navigates the same way on both. Navigation is driven by the `src` attribute (a src-less
+ * webview never emits dom-ready, so imperative loadURL before then is a no-op); `did-navigate` only
+ * updates the address, so in-page navigation can't loop.
+ */
+export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: BrowserSurfaceProps) {
+  const ref = useRef<WebviewEl | null>(null)
+  const lastUrlRef = useRef('')
+  const [startUrl] = useState(() => url ?? '')
+  const [src, setSrc] = useState(startUrl)
+  const [address, setAddress] = useState(startUrl)
+  const [loading, setLoading] = useState(false)
+  const [canBack, setCanBack] = useState(false)
+  const [canFwd, setCanFwd] = useState(false)
+  const [failed, setFailed] = useState('')
+
+  useEffect(() => {
+    const wv = ref.current
+    if (!wv) return
+    const onStart = (): void => setLoading(true)
+    const onStop = (): void => {
+      setLoading(false)
+      setCanBack(wv.canGoBack())
+      setCanFwd(wv.canGoForward())
+    }
+    const onNav = (e: Event): void => {
+      const u = (e as unknown as { url: string }).url
+      setAddress(u)
+      setFailed('')
+      onUrlChange(u)
+      lastUrlRef.current = u
+      useBrowserHistory.getState().record(u, u)
+    }
+    const onNavInPage = (e: Event): void => setAddress((e as unknown as { url: string }).url)
+    const onTitle = (e: Event): void => {
+      const title = (e as unknown as { title: string }).title
+      onTitleChange(title)
+      if (lastUrlRef.current) useBrowserHistory.getState().record(lastUrlRef.current, title)
+    }
+    const onFail = (e: Event): void => {
+      const ev = e as unknown as { isMainFrame: boolean; errorCode: number; errorDescription: string }
+      if (ev.isMainFrame && ev.errorCode !== -3) setFailed(ev.errorDescription || 'Failed to load')
+    }
+    wv.addEventListener('did-start-loading', onStart)
+    wv.addEventListener('did-stop-loading', onStop)
+    wv.addEventListener('did-navigate', onNav)
+    wv.addEventListener('did-navigate-in-page', onNavInPage)
+    wv.addEventListener('page-title-updated', onTitle)
+    wv.addEventListener('did-fail-load', onFail)
+    return () => {
+      wv.removeEventListener('did-start-loading', onStart)
+      wv.removeEventListener('did-stop-loading', onStop)
+      wv.removeEventListener('did-navigate', onNav)
+      wv.removeEventListener('did-navigate-in-page', onNavInPage)
+      wv.removeEventListener('page-title-updated', onTitle)
+      wv.removeEventListener('did-fail-load', onFail)
+    }
+  }, [onUrlChange, onTitleChange])
+
+  useEffect(() => {
+    const wv = ref.current
+    if (!wv) return
+    let wcId = 0
+    const onReady = (): void => {
+      wcId = wv.getWebContentsId()
+      window.nodeTerminal.browser.register(wcId, nodeId)
+    }
+    wv.addEventListener('dom-ready', onReady)
+    return () => {
+      wv.removeEventListener('dom-ready', onReady)
+      if (wcId) window.nodeTerminal.browser.unregister(wcId)
+    }
+  }, [nodeId])
+
+  // Keep the two webviews for one node (canvas + modal) in sync: when `url` changes from the
+  // OUTSIDE (the other webview navigated → node.data.url updated) and differs from where we are,
+  // follow it. Guarded on `!== address` so our own did-navigate (which sets address = url) is a
+  // no-op — no reload loop.
+  useEffect(() => {
+    if (url && url !== address) {
+      setSrc(url)
+      setAddress(url)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url])
+
+  const go = (): void => {
+    const safe = searchOrUrl(address)
+    if (!safe) {
+      setFailed('Enter a URL or search term')
+      return
+    }
+    setAddress(safe)
+    setFailed('')
+    if (safe === src) ref.current?.reload()
+    else setSrc(safe)
+  }
+
+  return (
+    <div className="browser-surface">
+      <div className="browser-node__toolbar nodrag">
+        <button className="browser-node__btn" disabled={!canBack} onClick={() => ref.current?.goBack()} title="Back">
+          ◀
+        </button>
+        <button className="browser-node__btn" disabled={!canFwd} onClick={() => ref.current?.goForward()} title="Forward">
+          ▶
+        </button>
+        <button
+          className="browser-node__btn"
+          onClick={() => (loading ? ref.current?.stop() : ref.current?.reload())}
+          title={loading ? 'Stop' : 'Reload'}
+        >
+          {loading ? '✕' : '⟳'}
+        </button>
+        <input
+          className="browser-node__address"
+          value={address}
+          spellCheck={false}
+          placeholder="Enter a URL and press Enter"
+          onChange={(e) => setAddress(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') go()
+          }}
+        />
+      </div>
+      <div className="browser-node__view nodrag nowheel">
+        {/* eslint-disable-next-line react/no-unknown-property */}
+        <webview
+          ref={ref as unknown as React.Ref<HTMLElement>}
+          src={src || undefined}
+          allowpopups={true}
+          style={{ width: '100%', height: '100%' }}
+        />
+        {!src && (
+          <BrowserStartPage
+            onNavigate={(u) => {
+              setSrc(u)
+              setAddress(u)
+              setFailed('')
+            }}
+          />
+        )}
+        {failed && <div className="browser-node__error">{failed}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8335,3 +8335,19 @@ body,
   border-radius: 8px;
   padding: 6px 12px;
 }
+
+/* Shared browser surface (canvas node + kanban card modal): toolbar on top, webview fills. */
+.browser-surface {
+  flex: 1;
+  min-height: 0;
+  height: 100%; /* the canvas node's .editor-node__body is display:block, so flex:1 alone is inert */
+  display: flex;
+  flex-direction: column;
+}
+/* In the card modal the browser pane fills the main area (no node header/toolbar chrome). */
+.kanban-modal__pane[data-kind='browser'] {
+  flex-direction: column;
+}
+.kanban-modal__pane[data-kind='browser'] .browser-surface {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary

Browser nodes now live on the board like terminals/stickies:

- **Cards**: a browser node shows as a card with a `web` chip.
- **Live popup**: clicking it opens a real Chromium webview in the card modal (address bar + back/forward/reload), navigable — not just a link.
- **+ New → Browser** creates one in a column.
- **Shared surface**: extracted BrowserNode's webview + toolbar into `BrowserSurface` (webview, navigation events, `browser.register`, start page), used by both the canvas node and the modal. Modal navigation persists to `data.url`/`data.title`; the two webviews for one node re-seed to stay in sync.

Review-driven fixes: the extracted surface fills correctly inside the canvas node's `display:block` body (`height:100%`); the canvas ↔ modal webviews follow each other on external URL changes (guarded, no reload loop). Dual `browser.register` is benign (keyed by distinct webContents ids). Server Edition degrades as before (webview inert, register is a no-op stub).

## Test plan

- [x] Full suite 2756/2756, typecheck clean; BrowserNode refactor behavior-preserving (adversarial review)
- [x] Live drive: + New has Browser; browser card shows the web chip; modal renders the browser surface (address bar + webview element); no terminal-only actions on a browser card. Real webview navigation is Electron-only (verified on Mac).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSBNcMe1gnHTziQT6pDo4h