### PR TITLE
feat: kanban board polish — usage margin, macOS no-drag, menu icons

### DIFF
--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -201,6 +201,26 @@ export const IconSearch = () => (
   </svg>
 )
 
+export const IconWeb = () => (
+  <svg {...S}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18" />
+  </svg>
+)
+
+export const IconExternal = () => (
+  <svg {...S}>
+    <path d="M9 5h10v10M19 5 8 16M5 9v10h10" />
+  </svg>
+)
+
+export const IconAgent = () => (
+  <svg {...S}>
+    <path d="M12 3l1.8 4.2L18 9l-4.2 1.8L12 15l-1.8-4.2L6 9l4.2-1.8z" />
+    <path d="M18 15l.9 2.1L21 18l-2.1.9L18 21l-.9-2.1L15 18l2.1-.9z" />
+  </svg>
+)
+
 export const IconMic = () => (
   <svg {...S}>
     <rect x="9" y="2" width="6" height="12" rx="3" />

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -154,6 +154,7 @@ export function KanbanColumn({
                   onCreate(o.choice)
                 }}
               >
+                <span className="kanban-col__newicon">{o.icon}</span>
                 {o.label}
               </button>
             ))}

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -12,6 +12,7 @@ import { CardModal } from './CardModal'
 import { KanbanColumn } from './KanbanColumn'
 import type { ModalSpawn } from './ModalTerminal'
 import { ContextMenu, type MenuItem } from '../ContextMenu'
+import { IconAgent, IconExternal, IconNote, IconSwitch, IconTerminal, IconTrash, IconWeb } from '../icons'
 
 /** One session node shown as a board card — derived LIVE from the canvas nodes; the board
  *  itself stores only column assignments. */
@@ -42,6 +43,7 @@ export interface KanbanCreateOption {
   key: string
   label: string
   choice: KanbanCreateChoice
+  icon: JSX.Element
 }
 
 interface KanbanViewProps {
@@ -97,16 +99,18 @@ export function KanbanView({
     ...BUILTIN_AGENT_IDS.map((id) => ({
       key: id,
       label: AGENT_CONFIG[id].label,
-      choice: { kind: 'agent', agentId: id } as KanbanCreateChoice
+      choice: { kind: 'agent', agentId: id } as KanbanCreateChoice,
+      icon: <IconAgent />
     })),
     ...customAgents.map((a) => ({
       key: a.id,
       label: a.label,
-      choice: { kind: 'agent', agentId: a.id } as KanbanCreateChoice
+      choice: { kind: 'agent', agentId: a.id } as KanbanCreateChoice,
+      icon: <IconAgent />
     })),
-    { key: 'terminal', label: 'Terminal', choice: { kind: 'terminal' } },
-    { key: 'browser', label: 'Browser', choice: { kind: 'browser' } },
-    { key: 'sticky', label: 'Sticky note', choice: { kind: 'sticky' } }
+    { key: 'terminal', label: 'Terminal', choice: { kind: 'terminal' }, icon: <IconTerminal /> },
+    { key: 'browser', label: 'Browser', choice: { kind: 'browser' }, icon: <IconWeb /> },
+    { key: 'sticky', label: 'Sticky note', choice: { kind: 'sticky' }, icon: <IconNote /> }
   ]
   const byId = new Map(sessions.map((s) => [s.id, s]))
 
@@ -155,13 +159,13 @@ export function KanbanView({
         }))
     ]
     return [
-      { label: 'Open card', onClick: () => setModalNodeId(nodeId) },
-      { label: 'Open on canvas', onClick: () => onOpenNode(nodeId) },
+      { label: 'Open card', icon: <IconExternal />, onClick: () => setModalNodeId(nodeId) },
+      { label: 'Open on canvas', icon: <IconExternal />, onClick: () => onOpenNode(nodeId) },
       ...(moveTargets.length
-        ? ([{ type: 'submenu', label: 'Move to', children: moveTargets }] as MenuItem[])
+        ? ([{ type: 'submenu', label: 'Move to', icon: <IconSwitch />, children: moveTargets }] as MenuItem[])
         : []),
       { type: 'separator' },
-      { label: 'Delete', danger: true, onClick: () => onDeleteNode(nodeId) }
+      { label: 'Delete', icon: <IconTrash />, danger: true, onClick: () => onDeleteNode(nodeId) }
     ]
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2874,7 +2874,8 @@ body,
 .tab-menu,
 .controls-cluster,
 .dock,
-.dictation {
+.dictation,
+.kanban-overlay {
   -webkit-app-region: no-drag;
 }
 
@@ -6479,7 +6480,9 @@ body,
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  padding: 16px;
+  /* Extra bottom room so the columns' cards clear the floating usage pill (bottom-left, z 26)
+     — the board's foot mirror of the top title strip. */
+  padding: 16px 16px 56px;
   height: 100%;
   box-sizing: border-box;
 }
@@ -6785,6 +6788,9 @@ body,
   flex-direction: column;
 }
 .kanban-col__newmenu button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   background: none;
   border: none;
   border-radius: 5px;
@@ -6793,6 +6799,20 @@ body,
   text-align: left;
   padding: 6px 8px;
   cursor: pointer;
+}
+.kanban-col__newicon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  color: rgba(255, 255, 255, 0.6);
+  flex: 0 0 auto;
+}
+.kanban-col__newicon svg {
+  width: 14px;
+  height: 14px;
+}
+.kanban-col__newmenu button:hover .kanban-col__newicon {
+  color: #fff;
 }
 .kanban-col__newmenu button:hover {
   background: var(--accent);


### PR DESCRIPTION
Four board fixes from live use:
- **Usage pill margin**: bottom padding on the board so the columns' cards clear the floating usage pill (the board's foot-margin, mirroring the top title strip). Verified no overlap even with a tall column.
- **macOS drag fix**: `.kanban-overlay` joins the `-webkit-app-region: no-drag` opt-out list, so clicks in the title-bar strip reach the controls (Source Control button not responding on the board — the panel z-index was already correct; the overlay was eating the click as a window-drag on a notched Mac).
- **Menu icons**: SVG icons on the `+ New session` menu (agents ✦ / terminal / browser 🌐 / sticky) and the card right-click menu (open / move / delete).

Also: a CLAUDE.md note making the kanban board a first-class surface — when you touch a node's UI, wire the card/modal in the SAME change (so we stop shipping a feature on one view and bolting it onto the other later). [CLAUDE.md is local/gitignored, applied to the working tree.]

## Test plan
- [x] Full suite 2756/2756, typecheck clean
- [x] Live drive: column bottom above the usage pill (704 < 716); every + New item has an SVG icon (7/7); card context menu has icons (4 svgs); overlay computes -webkit-app-region: no-drag. macOS drag behavior verified on Mac.