### PR TITLE
fix: Esc interrupts the agent in the kanban card modal (was closing the popup)

### DIFF
--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -68,13 +68,20 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape' || !isTopDialog(id)) return
-      e.preventDefault()
-      e.stopPropagation()
+      // A rename in progress owns Esc first (cancel the edit, not the modal).
       if (editingTitleRef.current) {
-        // Esc during a rename cancels the EDIT, not the modal.
+        e.preventDefault()
+        e.stopPropagation()
         setEditingTitle(false)
         return
       }
+      // Terminal focused → Esc belongs to the SESSION (agent "esc to interrupt"), not the modal.
+      // Don't consume it: leave it to xterm's own handler. Close the modal via ×, the scrim, or
+      // Esc while focus is elsewhere (the board-log composer, the header, etc.).
+      const ae = document.activeElement
+      if (ae && ae.closest('.kanban-modal__term')) return
+      e.preventDefault()
+      e.stopPropagation()
       onClose()
     }
     // Capture phase: beat the canvas/global keydown listeners to the Escape.


### PR DESCRIPTION
In the card modal's co-attach terminal, Esc (Claude's "esc to interrupt") was closing the popup instead of reaching the session — the modal's capture-phase Esc handler consumed it before xterm. Now, when focus is inside the terminal pane, Esc is left for the session; the modal still closes via Esc from anywhere else (comments composer, header), the scrim, or ×, and a rename-in-progress still cancels on Esc first.

## Test plan
- [x] Full suite 2776/2776, typecheck clean
- [x] Live drive: Esc with the modal terminal focused keeps the modal open (goes to the session); Esc from the comments composer closes it