### PR TITLE
feat: reorder cards within a kanban column by drag

### DIFF
--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -27,7 +27,7 @@ interface KanbanColumnProps {
   onDragEnd: () => void
   /** Drop on the column body: a card lands at the END of this column; a column lands BEFORE it. */
   onDropOnColumn: () => void
-  onDropBeforeCard: (nodeId: string) => void
+  onDropAtCard: (nodeId: string, side: 'before' | 'after') => void
   /** Right-click on a card — bubbles the cursor position + node id up to the board menu. */
   onCardContext: (nodeId: string, x: number, y: number) => void
 }
@@ -35,7 +35,7 @@ interface KanbanColumnProps {
 export function KanbanColumn({
   column, cards, statusById, metaOf, onRename, onRecolor, onDelete, onOpenCard, onCardContext,
   createOptions, onCreate, onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn,
-  onDropBeforeCard
+  onDropAtCard
 }: KanbanColumnProps) {
   const [editingTitle, setEditingTitle] = useState(false)
   const [title, setTitle] = useState(column?.title ?? '')
@@ -139,7 +139,7 @@ export function KanbanColumn({
             onContext={(x, y) => onCardContext(s.id, x, y)}
             onDragStart={() => onCardDragStart(s.id)}
             onDragEnd={onDragEnd}
-            onDropBefore={() => onDropBeforeCard(s.id)}
+            onDropAt={(side) => onDropAtCard(s.id, side)}
           />
         ))}
       </div>

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -134,11 +134,21 @@ export function KanbanView({
     // a column dropped on Ungrouped is a no-op — Ungrouped is always first
   }
 
-  const dropBeforeCard = (columnId: string | null, nodeId: string) => {
+  const dropAtCard = (columnId: string | null, targetNodeId: string, side: 'before' | 'after') => {
     const drag = takeDrag()
     if (!drag) return
-    if (drag.kind === 'card') commit(assignNode(board, drag.id, columnId, nodeId))
-    else if (columnId !== null) commit(moveColumn(board, drag.id, columnId))
+    if (drag.kind === 'column') {
+      if (columnId !== null) commit(moveColumn(board, drag.id, columnId))
+      return
+    }
+    // "after this card" = "before the NEXT card in the column" (null = end of column).
+    const ids = columnId === null ? unassigned(board, sessions.map((s) => s.id)) : assignedTo(board, columnId)
+    let beforeId: string | null = targetNodeId
+    if (side === 'after') {
+      const i = ids.indexOf(targetNodeId)
+      beforeId = i >= 0 && i + 1 < ids.length ? ids[i + 1] : null
+    }
+    commit(assignNode(board, drag.id, columnId, beforeId))
   }
 
   const sessionsFor = (ids: string[]) =>
@@ -189,7 +199,7 @@ export function KanbanView({
           onCardDragStart={(id) => (dragRef.current = { kind: 'card', id })}
           onDragEnd={() => (dragRef.current = null)}
           onDropOnColumn={() => dropOnColumn(null)}
-          onDropBeforeCard={(id) => dropBeforeCard(null, id)}
+          onDropAtCard={(id, side) => dropAtCard(null, id, side)}
           onCardContext={(id, x, y) => setCardMenu({ nodeId: id, x, y })}
         />
         {board.columns.map((col) => (
@@ -209,7 +219,7 @@ export function KanbanView({
             onColumnDragStart={() => (dragRef.current = { kind: 'column', id: col.id })}
             onDragEnd={() => (dragRef.current = null)}
             onDropOnColumn={() => dropOnColumn(col.id)}
-            onDropBeforeCard={(id) => dropBeforeCard(col.id, id)}
+            onDropAtCard={(id, side) => dropAtCard(col.id, id, side)}
             onCardContext={(id, x, y) => setCardMenu({ nodeId: id, x, y })}
           />
         ))}

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -12,15 +12,21 @@ interface SessionCardProps {
   onOpen: () => void
   onDragStart: () => void
   onDragEnd: () => void
-  /** A dragged card was dropped on this card — insert it before this one. */
-  onDropBefore: () => void
+  /** A dragged card was dropped on this card — before it (top half) or after it (bottom half). */
+  onDropAt: (side: 'before' | 'after') => void
   /** Right-click on the card — opens the actions menu at the cursor. */
   onContext: (x: number, y: number) => void
 }
 
-export function SessionCard({ session, status, meta, onOpen, onDragStart, onDragEnd, onDropBefore, onContext }: SessionCardProps) {
+export function SessionCard({ session, status, meta, onOpen, onDragStart, onDragEnd, onDropAt, onContext }: SessionCardProps) {
   // Local drag state only styles THIS card (ghost look) — the drag payload lives in KanbanView.
   const [dragging, setDragging] = useState(false)
+  // Which edge a drag is hovering over → shows the drop line (top = before, bottom = after).
+  const [dropSide, setDropSide] = useState<'before' | 'after' | null>(null)
+  const sideFor = (e: React.DragEvent): 'before' | 'after' => {
+    const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
+    return e.clientY < r.top + r.height / 2 ? 'before' : 'after'
+  }
   const badge =
     session.kind !== 'sticky' && status?.state === 'working'
       ? 'running'
@@ -41,7 +47,9 @@ export function SessionCard({ session, status, meta, onOpen, onDragStart, onDrag
   const hasDetail = !!status?.sessionId || !!status?.session || stickyPreview.includes('\n')
   return (
     <div
-      className={`kanban-card kanban-card--session${dragging ? ' kanban-card--dragging' : ''}`}
+      className={`kanban-card kanban-card--session${dragging ? ' kanban-card--dragging' : ''}${
+        dropSide ? ` kanban-card--drop-${dropSide}` : ''
+      }`}
       draggable
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = 'move'
@@ -50,13 +58,21 @@ export function SessionCard({ session, status, meta, onOpen, onDragStart, onDrag
       }}
       onDragEnd={() => {
         setDragging(false)
+        setDropSide(null)
         onDragEnd()
       }}
-      onDragOver={(e) => e.preventDefault()}
+      onDragOver={(e) => {
+        e.preventDefault()
+        const side = sideFor(e)
+        if (side !== dropSide) setDropSide(side)
+      }}
+      onDragLeave={() => setDropSide(null)}
       onDrop={(e) => {
         e.preventDefault()
         e.stopPropagation() // don't let the column's end-drop swallow a drop aimed at this card
-        onDropBefore()
+        const side = sideFor(e)
+        setDropSide(null)
+        onDropAt(side)
       }}
       onClick={onOpen}
       onContextMenu={(e) => {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8388,3 +8388,27 @@ body,
 .kanban-modal__pane[data-kind='browser'] .browser-surface {
   width: 100%;
 }
+
+/* Reorder drop indicator: an accent line at the card edge the drop will land on. */
+.kanban-card--drop-before,
+.kanban-card--drop-after {
+  position: relative;
+}
+.kanban-card--drop-before::before,
+.kanban-card--drop-after::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 2px;
+  box-shadow: 0 0 6px var(--accent);
+  z-index: 2;
+}
+.kanban-card--drop-before::before {
+  top: -5px;
+}
+.kanban-card--drop-after::after {
+  bottom: -5px;
+}


### PR DESCRIPTION
Dragging a card onto another now reorders it within the column, with a visible accent drop-line: the target card's **top half** inserts the dragged card **before** it, the **bottom half** inserts it **after** (i.e. before the next card / at the column end). The new order persists to `kanban.assignments`. Cross-column moves and column reordering are unchanged; Ungrouped keeps canvas order (it has no assignments to reorder).

## Test plan
- [x] Full suite 2776/2776, typecheck clean
- [x] Live drive: aaa,bbb,ccc → drag ccc onto aaa's top half → ccc,aaa,bbb → drop onto aaa's bottom half → aaa,ccc,bbb; the new order is written to project.json's kanban.assignments (ra,rc,rb)