### PR TITLE
fix(kanban): co-attach terminal can't scroll until a keystroke

### DIFF
--- a/src/core/pty-coattach.test.ts
+++ b/src/core/pty-coattach.test.ts
@@ -1169,6 +1169,89 @@ describe('a joiner is painted from the current screen', () => {
   })
 })
 
+// ── A joiner must be told tmux's mouse tracking is ON ─────────────────────────────────────────
+// tmux emits the mouse-enable DECSET sequences (?1000h/?1002h/?1006h) to a client ONLY at its own
+// attach. A co-attach subscriber (kanban card modal, second window) joins mid-stream and never
+// sees them; neither the `screen` capture (capture-pane carries no private modes) nor a SIGWINCH
+// redraw re-emits them. So the joiner's xterm reports no mouse events and the wheel can't scroll
+// tmux history until a keystroke wakes it. `coAttachMouse` tells the renderer to enable it — set on
+// EVERY tmux-backed join (both the screen-painted and the resized branch), never on a plain-shell
+// join (no tmux ⇒ no tmux mouse) nor on the solo spawn.
+describe('a tmux-backed joiner is told to enable mouse tracking', () => {
+  let fake: FakePlatform
+
+  beforeEach(() => {
+    spawned.length = 0
+    failNextSpawn = false
+    fake = fakePlatform()
+    initPlatform(fake)
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    resetPlatformForTests()
+  })
+
+  // A manager whose sessions are tmux-BACKED: force the tmux path (init()/tmuxStatus() aren't run
+  // in unit tests) and stub the has-session probe so no real tmux socket is touched.
+  async function tmuxManager() {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager()
+    m.registerIpc()
+    ;(m as unknown as { tmuxPath: string }).tmuxPath = '/usr/bin/tmux'
+    vi.spyOn(m as unknown as { tmuxSessionExists: (k: string) => Promise<boolean> }, 'tmuxSessionExists').mockResolvedValue(false)
+    return m
+  }
+  const create = (clientId: number, cols = 80, rows = 24, persistKey = 'node-1') =>
+    fake.handlers[IPC.ptyCreate](clientId, { cols, rows, persistKey }) as Promise<{
+      sessionId: string
+      fresh: boolean
+      screen?: string
+      coAttachMouse?: boolean
+    }>
+
+  it('sets coAttachMouse on a joiner whose grid EQUALS the pty (the screen-painted branch)', async () => {
+    const m = await tmuxManager()
+    vi.spyOn(m, 'captureForResync').mockResolvedValue('current screen')
+    await create(ALICE, 80, 24)
+
+    const b = await create(BOB, 80, 24)
+    expect(b.screen).toBe('current screen') // equal grid → painted from the capture…
+    expect(b.coAttachMouse).toBe(true) // …which carries no mouse modes, so enable them explicitly
+  })
+
+  it('sets coAttachMouse on a joiner that SHRINKS the pty too (a SIGWINCH redraw re-emits no mouse modes)', async () => {
+    const m = await tmuxManager()
+    const capture = vi.spyOn(m, 'captureForResync').mockResolvedValue('current screen')
+    await create(ALICE, 120, 40)
+
+    const b = await create(BOB, 80, 24) // strictly smaller → the pty resizes, tmux redraws
+    expect(spawned[0].resizes.at(-1)).toEqual({ cols: 80, rows: 24 })
+    expect(capture).not.toHaveBeenCalled() // tmux paints it; no screen rides the result…
+    expect(b.screen).toBeUndefined()
+    expect(b.coAttachMouse).toBe(true) // …but the redraw does NOT re-send mouse modes, so still enable
+  })
+
+  it('never sets coAttachMouse on the SOLO spawn (that client got its modes from its own tmux attach)', async () => {
+    await tmuxManager()
+    const a = await create(ALICE, 80, 24)
+    expect(a.coAttachMouse).toBeUndefined()
+  })
+
+  it('never sets coAttachMouse on a PLAIN-SHELL join (no tmux ⇒ no tmux mouse to enable)', async () => {
+    // The default manager has no tmux path, so the session is not persisted (persistKey unset).
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager()
+    m.registerIpc()
+    vi.spyOn(m, 'captureForResync').mockResolvedValue('current screen')
+    await create(ALICE, 80, 24)
+
+    const b = await create(BOB, 80, 24)
+    expect(b.fresh).toBe(false) // it did join the live session…
+    expect(b.coAttachMouse).toBeUndefined() // …but a plain shell has no tmux mouse to turn on
+  })
+})
+
 describe('tmuxAttachFlags', () => {
   it("keeps -D for the app's own client: exactly ONE tmux client per session", async () => {
     const { tmuxAttachFlags } = await import('./pty-manager')

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -918,9 +918,16 @@ export class PtyManager {
     // server returns that one itself when the socket drains. Scoped to THIS view: the other view's
     // (e.g. the still-open modal's) renderer pause is untouched.
     this.releaseFlow(existing, sub, 'renderer')
+    // A tmux-backed join needs the mouse-tracking mode-enable sequences tmux only emits at its own
+    // attach — a mid-stream subscriber missed them, and neither the `screen` capture nor a SIGWINCH
+    // redraw re-sends them, so without this the joiner can't wheel-scroll tmux history until a
+    // keystroke. `persistKey` is set iff tmux-backed (local or remote), which is exactly the gate:
+    // our tmux always runs `mouse on`, so enabling these unconditionally matches its client state.
+    // Rides `base` so it reaches the renderer on BOTH the resized and screen-painted branches.
+    const coAttachMouse = existing.persistKey ? true : undefined
     const base: PtyCreateResult = existing.accountFallback
-      ? { sessionId: existingId, fresh: false, accountFallback: true }
-      : { sessionId: existingId, fresh: false }
+      ? { sessionId: existingId, fresh: false, accountFallback: true, coAttachMouse }
+      : { sessionId: existingId, fresh: false, coAttachMouse }
     if (resized) return Promise.resolve(base) // tmux is redrawing this client — do not paint twice
     // An empty capture (plain shell — no tmux to capture; a tmux/ssh blip) is OMITTED, never sent
     // as '': the renderer must not reset a terminal for nothing. A plain-shell joiner therefore

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -19,7 +19,8 @@ import {
   terminalKeyAction,
   toXtermText,
   xtermScrollback,
-  SHIFT_ENTER_SEQ
+  SHIFT_ENTER_SEQ,
+  CO_ATTACH_MOUSE_SEQ
 } from '../../terminal/terminal-config'
 import { resolveSshRemote } from '../../nodes/TerminalNode'
 import { buildSshArgs, type SshConnection } from '@shared/ssh'
@@ -227,6 +228,11 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
         // Start from a known-clean SGR state, then convert the capture's LFs to CRLFs.
         term.write('\x1b[0m' + toXtermText(stripTrailingNewline(res.screen)))
       }
+
+      // Co-attach joiners miss the mouse-tracking mode tmux only sends at its own attach, so the
+      // wheel can't scroll tmux history until a keystroke wakes it. Enable it here (see
+      // CO_ATTACH_MOUSE_SEQ). Painting content first, then the modes, keeps the seed untouched.
+      if (res.coAttachMouse) term.write(CO_ATTACH_MOUSE_SEQ)
 
       const ro = new ResizeObserver(() => {
         fit.fit()

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -46,6 +46,7 @@ import {
   terminalKeyAction,
   toXtermText,
   SHIFT_ENTER_SEQ,
+  CO_ATTACH_MOUSE_SEQ,
   xtermScrollback,
   type SessionLife
 } from '../terminal/terminal-config'
@@ -898,7 +899,7 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
           accountId: data.accountId,
           sshRemote
         })
-        .then(async ({ sessionId: sid, fresh, accountFallback: fellBack, closed, screen }) => {
+        .then(async ({ sessionId: sid, fresh, accountFallback: fellBack, closed, screen, coAttachMouse }) => {
         // REFUSED: core's tombstone says another client deleted this node while we weren't
         // subscribed (our project was closed/inactive, so no `pty:closed` could reach us). Nothing
         // was spawned — land in the same "closed by <name>" state a subscribed co-viewer gets.
@@ -1106,6 +1107,11 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
               term.write('\x1b[0m' + toXtermText(stripTrailingNewline(screen as string)))
             }
           }
+          // A CO-ATTACH JOINER (a second window on this node — rare on the canvas, but possible)
+          // missed the mouse-tracking mode tmux only emits at its own attach, so it can't
+          // wheel-scroll tmux history. Enable it (see CO_ATTACH_MOUSE_SEQ). Only ever set on a join,
+          // so this never fires on the solo spawn / warm-reattach-with-own-tmux-client path.
+          if (coAttachMouse) term.write(CO_ATTACH_MOUSE_SEQ)
         } catch (err) {
           // Never let a seed failure freeze the terminal: the live stream matters more than the
           // history. `finally` still opens the gate below.

--- a/src/renderer/terminal/terminal-config.ts
+++ b/src/renderer/terminal/terminal-config.ts
@@ -230,6 +230,17 @@ export interface ResyncTarget {
 export const RESYNC_NOTICE = '\r\n\x1b[90m── reconnected — earlier output skipped ──\x1b[0m\r\n'
 
 /**
+ * The mouse-tracking mode-enable sequences tmux sends a client at attach (`mouse on`): X11 mouse
+ * (`?1000h`), button-event/drag tracking (`?1002h`) and SGR extended coordinates (`?1006h`). A
+ * co-attach JOINER (kanban card modal, second window) subscribes mid-stream and never receives
+ * them, so its xterm reports no mouse events and the wheel can't scroll tmux history. Write this
+ * into the joiner's xterm when `PtyCreateResult.coAttachMouse` is set (measured net client state
+ * for a `mouse on` server; the enable is idempotent, and any later app mode change flows over the
+ * live stream to the now-subscribed view).
+ */
+export const CO_ATTACH_MOUSE_SEQ = '\x1b[?1000h\x1b[?1002h\x1b[?1006h'
+
+/**
  * The capture generation of the LAST repaint issued for a terminal, so a deferred repaint can tell
  * that a newer capture has superseded it (see `repaintResync`). Weak, and keyed by the xterm itself:
  * a disposed terminal takes its counter with it, and no node id has to be threaded through.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -71,6 +71,20 @@ export interface PtyCreateResult {
    */
   screen?: string
   /**
+   * This create JOINED a live TMUX-backed session (co-attach), so the fresh xterm must be told
+   * tmux's mouse-tracking is on. tmux emits the mouse-enable DECSET sequences (`?1000h ?1002h
+   * ?1006h`) to a client ONLY at its own attach — a mid-stream subscriber (the kanban card modal,
+   * a second window) never sees them, and neither `screen` (`capture-pane` carries no private
+   * modes) nor a SIGWINCH redraw re-emits them. Without them xterm treats the wheel as local
+   * scrollback (empty on the alternate screen), so the joiner cannot scroll tmux's history until a
+   * keystroke makes the app re-request mouse. The renderer writes `CO_ATTACH_MOUSE_SEQ` when this
+   * is set. Since our tmux is always `mouse on` (local and remote), enabling these unconditionally
+   * on a tmux-backed join matches tmux's own invariant client state; the enable is idempotent.
+   * Set on BOTH join branches (screen-painted and resized) — the resize does not deliver them.
+   * Absent for a plain-shell join (no tmux ⇒ no tmux mouse) and for the solo spawn path.
+   */
+  coAttachMouse?: boolean
+  /**
    * REFUSED: this node's session was permanently destroyed by ANOTHER client, so nothing was
    * spawned (`sessionId` is empty) — the terminal shows the "closed by <name>" state instead.
    *


### PR DESCRIPTION
## Problem

In the kanban card modal, the co-attach popup terminal sometimes can't be scrolled: the cursor blinks at the end and the user has to press a key or click first, after which scrolling works. The canvas terminal doesn't have this bug.

## Root cause

The card modal opens a **second** xterm client on the node's tmux session — a mid-stream co-attach subscriber (one tmux client, N subscribers). tmux emits its mouse-tracking mode-enable sequences (`?1000h ?1002h ?1006h`) to a client **only at its own attach**. A joiner subscribes after that, so it never receives them — and neither the `screen` paint (`capture-pane -p -e` carries no private modes) nor a SIGWINCH redraw re-emits them (both measured against tmux 3.x). So the joiner's xterm reports no mouse events and the wheel falls through to empty local scrollback on the alternate screen — no scroll until a keystroke makes the agent CLI re-request mouse, which tmux then forwards.

The canvas terminal is normally the session *spawner* (its own tmux attach delivers the modes), which is why it doesn't show the bug.

## Fix

`join()` now sets `PtyCreateResult.coAttachMouse` for **tmux-backed** joins (gated on `persistKey`; set on both the screen-painted and the resized branch, since a resize doesn't deliver the modes either). The renderer writes `CO_ATTACH_MOUSE_SEQ` (`\e[?1000h\e[?1002h\e[?1006h`) into the fresh xterm when it's set. Our tmux always runs `mouse on` (local and remote), so enabling these unconditionally matches tmux's own invariant client state; the enable is idempotent and later app mode changes flow over the live stream to the now-subscribed view.

Wired in both `ModalTerminal` (kanban card) and `TerminalNode` (a second desktop window on the same node). It rides the create result as a plain field, so it works over the **Server-Edition WS bridge** automatically.

## Three surfaces

- **Desktop / Server Edition:** fixed (same renderer path; the flag crosses the bridge as JSON).
- **Mobile companion:** not applicable here — it uses SwiftTerm over the transport protocol and attaches independently; any equivalent is a follow-up in the iOS repo.

## Tests

- 4 new unit tests in `pty-coattach.test.ts`: `coAttachMouse` is set on a tmux-backed joiner (equal-grid screen branch **and** shrinking-resize branch), and **not** set on the solo spawn or a plain-shell join.
- Full suite green (2979 passed).
- **Verified end-to-end in the Server Edition:** a wheel over a freshly-opened card-modal terminal — with no prior keystroke — now emits SGR mouse reports (`\e[<64;…M` / `\e[<65;…M`) to the pty, so tmux scrolls its history immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)