### PR TITLE
fix(webgl): bound terminal backing-surface memory

### DIFF
--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -50,7 +50,15 @@ import {
   xtermScrollback,
   type SessionLife
 } from '../terminal/terminal-config'
-import { loseWebglContexts, registerWebglClient, type WebglClientHandle } from '../terminal/webgl-budget'
+import {
+  createWebglSurfaceResizeController,
+  estimateWebglSurfaceBytes,
+  loseWebglContexts,
+  registerWebglClient,
+  subscribeDevicePixelRatio,
+  type WebglClientHandle,
+  type WebglSurfaceResizeController
+} from '../terminal/webgl-budget'
 import { deliverCommand, type DeliveryIo } from '../terminal/command-delivery'
 import {
   guardConcurrentRestart,
@@ -377,6 +385,7 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
   // The live session's "measure my grid, render it, report it" routine (set by the lifecycle
   // effect), so effects outside that closure (font/cursor changes) resize through the same path.
   const applyFitRef = useRef<(() => void) | null>(null)
+  const surfaceResizeControllerRef = useRef<WebglSurfaceResizeController | null>(null)
   const dwellRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [showColors, setShowColors] = useState(false)
   const [armed, setArmed] = useState(true)
@@ -619,11 +628,19 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
     // holds far more terminals than that, so a context is NOT acquired per mounted node. The
     // module-level BUDGET COORDINATOR (`webgl-budget.ts`) owns the grant decision and all timing:
     // this node reports viewport visibility (via the IntersectionObserver below), and the
-    // coordinator calls back into `acquireWebgl`/`releaseWebgl`, keeping the total contexts WE hold
-    // under `WEBGL_BUDGET` so the browser never has to force-evict (which is what flashed the dead
-    // "lost context" placeholder). The callbacks stay dumb and idempotent.
+    // coordinator calls back into `acquireWebgl`/`releaseWebgl`, keeping both context count and
+    // estimated raw backing-surface bytes under budget. Count prevents browser force-eviction (the
+    // dead "lost context" placeholder); bytes bound intrinsically large high-DPI nodes even when
+    // React Flow zoom makes them look small. The callbacks stay dumb and idempotent.
     let webgl: WebglAddon | null = null
     let webglHandle: WebglClientHandle | null = null
+    const surfaceBytes = () =>
+      estimateWebglSurfaceBytes(
+        container.clientWidth,
+        container.clientHeight,
+        window.devicePixelRatio
+      )
+    const initialSurfaceBytes = surfaceBytes()
     const acquireWebgl = (): boolean => {
       if (webgl) return true
       try {
@@ -716,6 +733,32 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
       }
     }
     applyFitRef.current = applyFit
+
+    webglHandle = registerWebglClient(
+      id,
+      { acquire: acquireWebgl, release: releaseWebgl },
+      initialSurfaceBytes
+    )
+    const surfaceResizeController = createWebglSurfaceResizeController({
+      initialSurfaceBytes,
+      readSurfaceBytes: surfaceBytes,
+      applyFit,
+      reportSurfaceBytes: (bytes) => webglHandle?.setSurfaceBytes(bytes)
+    })
+    surfaceResizeControllerRef.current = surfaceResizeController
+    // This shared watcher must register before term.open installs xterm's own DPR listener.
+    // It stays installed across parked nodes and suspends GPU grants before xterm can resize them.
+    const stopWatchingDpr = subscribeDevicePixelRatio(window, () =>
+      surfaceResizeController.suspendAndScheduleFit()
+    )
+    // Node dragging fires per frame; each fit measures cells and redraws tmux. The controller
+    // preserves the existing trailing 80 ms fit while charging any surface growth immediately.
+    const observer = new ResizeObserver(() => surfaceResizeController.measureAndScheduleFit())
+    try {
+      observer.observe(container, { box: 'device-pixel-content-box' })
+    } catch {
+      observer.observe(container)
+    }
 
     if (parked) {
       // Reattach the parked xterm's DOM element: the PTY never detached, so the screen is
@@ -1267,27 +1310,16 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
       })
     )
 
-    // Coalesce observer bursts: dragging the NodeResizer fires per animation frame, and every
-    // call is a full cell-geometry measure + a resize IPC → node-pty → tmux (which redraws the
-    // whole pane). One trailing fit per settle is enough — the canvas node frame itself still
-    // tracks the drag live; only the terminal reflow waits for the pause.
-    let resizeTimer: ReturnType<typeof setTimeout> | null = null
-    const observer = new ResizeObserver(() => {
-      if (resizeTimer) clearTimeout(resizeTimer)
-      resizeTimer = setTimeout(applyFit, 80)
-    })
-    observer.observe(container)
-
     // Viewport-scoped WebGL, coordinated by the module-level budget (`webgl-budget.ts`): the
     // IntersectionObserver only REPORTS visibility to the coordinator, which owns the grant decision
-    // and all timing (acquire debounce, release delay, and LRU-hidden reclaim so we never exceed the
-    // budget). IntersectionObserver measures against the rendered box, so React Flow's pan/zoom CSS
+    // and all timing (acquire debounce, release delay, surface-byte accounting, and LRU-hidden
+    // reclaim so neither budget is exceeded). IntersectionObserver measures against the rendered
+    // box, so React Flow's pan/zoom CSS
     // transform is accounted for natively — no coupling to the React Flow store, and it works
     // identically in the browser Server Edition. `rootMargin` pre-announces a node panning into
     // view. The observer's initial callback (queued shortly after `observe()`) is what reports
     // visibility on mount/adopt — this replaces the old unconditional `loadWebgl()` calls in both
     // the parked and fresh paths above; the DOM renderer covers the gap until a grant lands.
-    webglHandle = registerWebglClient(id, { acquire: acquireWebgl, release: releaseWebgl })
     const visibilityObserver = new IntersectionObserver(
       (entries) => {
         // disconnect() does not flush already-QUEUED notifications (Blink delivers them after),
@@ -1307,8 +1339,9 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
       // pass through here. A remount re-registers (superseding, so a stale unregister is inert).
       unregisterRestart()
       observer.disconnect()
+      stopWatchingDpr()
+      surfaceResizeController.dispose()
       visibilityObserver.disconnect()
-      if (resizeTimer) clearTimeout(resizeTimer)
       if (dwellRef.current) clearTimeout(dwellRef.current)
       useAgentStatus.getState().setActive(id, false)
       // Teammates stop seeing us in this node's header. releaseFocus, not reportFocus(null): on a
@@ -1326,6 +1359,9 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
       fitRef.current = null
       searchAddonRef.current = null
       if (applyFitRef.current === applyFit) applyFitRef.current = null
+      if (surfaceResizeControllerRef.current === surfaceResizeController) {
+        surfaceResizeControllerRef.current = null
+      }
       // Free the GPU context on unmount (park or teardown) either way, and unregister from the
       // budget coordinator (which releases any held grant + cancels its timers). The park path must
       // keep releasing it as it always has (contexts are capped ~16, and a parked terminal is
@@ -1389,11 +1425,23 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
   useEffect(() => {
     const term = termRef.current
     if (!term) return
-    term.options.fontSize = fontSize
-    term.options.fontFamily = fontFamily
-    term.options.cursorBlink = cursorBlink
-    term.options.scrollback = xtermScrollback(tmuxScrollback)
-    applyFitRef.current?.()
+    const geometryChanged =
+      term.options.fontSize !== fontSize || term.options.fontFamily !== fontFamily
+    const applyOptions = () => {
+      term.options.fontSize = fontSize
+      term.options.fontFamily = fontFamily
+      term.options.cursorBlink = cursorBlink
+      term.options.scrollback = xtermScrollback(tmuxScrollback)
+    }
+    const surfaceController = surfaceResizeControllerRef.current
+    if (geometryChanged && surfaceController) {
+      // Drop WebGL before xterm applies the new font to its old grid, then fit on DOM and re-cost
+      // before the coordinator may grant a correctly sized GPU canvas again.
+      surfaceController.runGeometryChange(applyOptions)
+    } else {
+      applyOptions()
+      applyFitRef.current?.()
+    }
   }, [fontSize, fontFamily, cursorBlink, tmuxScrollback])
 
   const toggleCollapse = () =>

--- a/src/renderer/terminal/webgl-budget.test.ts
+++ b/src/renderer/terminal/webgl-budget.test.ts
@@ -1,33 +1,43 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  createWebglSurfaceResizeController,
   registerWebglClient,
   __resetWebglBudgetForTests,
+  estimateWebglSurfaceBytes,
   getWebglBudget,
   loseWebglContexts,
   setWebglBudget,
+  subscribeDevicePixelRatio,
   WEBGL_ACQUIRE_DEBOUNCE_MS,
   WEBGL_BUDGET,
   WEBGL_LOSS_STREAK_MAX,
   WEBGL_REACQUIRE_AFTER_LOSS_MS,
   WEBGL_RELEASE_DELAY_MS,
+  WEBGL_SURFACE_BUDGET_BYTES,
+  WEBGL_SURFACE_RESIZE_SETTLE_MS,
+  watchDevicePixelRatio,
   type WebglClientHandle
 } from './webgl-budget'
 
 /** A fake client that records acquire/release calls and reports a configurable acquire result. */
-function fakeClient(id: string, opts: { acquireOk?: boolean } = {}) {
+function fakeClient(id: string, opts: { acquireOk?: boolean; surfaceBytes?: number } = {}) {
   const rec = { acquires: 0, releases: 0, held: false }
   const acquireOk = opts.acquireOk ?? true
-  const handle: WebglClientHandle = registerWebglClient(id, {
-    acquire() {
-      rec.acquires++
-      if (acquireOk) rec.held = true
-      return acquireOk
+  const handle: WebglClientHandle = registerWebglClient(
+    id,
+    {
+      acquire() {
+        rec.acquires++
+        if (acquireOk) rec.held = true
+        return acquireOk
+      },
+      release() {
+        rec.releases++
+        rec.held = false
+      }
     },
-    release() {
-      rec.releases++
-      rec.held = false
-    }
-  })
+    opts.surfaceBytes ?? 1
+  )
   return { id, rec, handle }
 }
 
@@ -97,6 +107,128 @@ describe('webgl-budget coordinator', () => {
     expect(extra.rec.acquires).toBe(0)
     expect(extra.rec.held).toBe(false)
     expect(clients.every((c) => c.rec.held)).toBe(true)
+  })
+
+  it('refuses a grant below the context ceiling when raw surface bytes would exceed budget', () => {
+    const overHalf = Math.floor(WEBGL_SURFACE_BUDGET_BYTES / 2) + 1
+    const first = fakeClient('first', { surfaceBytes: overHalf })
+    const second = fakeClient('second', { surfaceBytes: overHalf })
+
+    grant(first)
+    grant(second)
+
+    expect(first.rec.held).toBe(true)
+    expect(second.rec.acquires).toBe(0)
+    expect(second.rec.held).toBe(false)
+  })
+
+  it('reclaims as many LRU hidden holders as needed to fit surface bytes', () => {
+    const quarter = WEBGL_SURFACE_BUDGET_BYTES / 4
+    const first = fakeClient('first', { surfaceBytes: quarter })
+    const second = fakeClient('second', { surfaceBytes: quarter })
+    const visible = fakeClient('visible', { surfaceBytes: quarter })
+    ;[first, second, visible].forEach(grant)
+    first.handle.setVisible(false)
+    second.handle.setVisible(false)
+
+    const newcomer = fakeClient('newcomer', { surfaceBytes: quarter * 3 })
+    grant(newcomer)
+
+    expect(first.rec.releases).toBe(1)
+    expect(second.rec.releases).toBe(1)
+    expect(visible.rec.held).toBe(true)
+    expect(newcomer.rec.held).toBe(true)
+  })
+
+  it('refuses one surface that exceeds the raw byte budget', () => {
+    const hidden = fakeClient('hidden')
+    grant(hidden)
+    hidden.handle.setVisible(false)
+    const oversized = fakeClient('oversized', {
+      surfaceBytes: WEBGL_SURFACE_BUDGET_BYTES * 2
+    })
+
+    grant(oversized)
+
+    expect(oversized.rec.acquires).toBe(0)
+    expect(oversized.rec.held).toBe(false)
+    expect(hidden.rec.releases).toBe(0)
+    expect(hidden.rec.held).toBe(true)
+  })
+
+  it('releases an oversized resized client without discarding hidden warm holders', () => {
+    const resized = fakeClient('resized')
+    const hidden = fakeClient('hidden')
+    grant(resized)
+    grant(hidden)
+    hidden.handle.setVisible(false)
+
+    resized.handle.setSurfaceBytes(WEBGL_SURFACE_BUDGET_BYTES * 2)
+
+    expect(resized.rec.releases).toBe(1)
+    expect(resized.rec.held).toBe(false)
+    expect(hidden.rec.releases).toBe(0)
+    expect(hidden.rec.held).toBe(true)
+  })
+
+  it('releases the resized client when visible grants no longer fit the surface budget', () => {
+    const oneThird = Math.floor(WEBGL_SURFACE_BUDGET_BYTES / 3)
+    const resized = fakeClient('resized', { surfaceBytes: oneThird })
+    const incumbent = fakeClient('incumbent', { surfaceBytes: oneThird })
+    grant(resized)
+    grant(incumbent)
+
+    resized.handle.setSurfaceBytes(Math.floor(WEBGL_SURFACE_BUDGET_BYTES * 0.75))
+
+    expect(resized.rec.releases).toBe(1)
+    expect(resized.rec.held).toBe(false)
+    expect(incumbent.rec.held).toBe(true)
+  })
+
+  it('reclaims hidden holders before releasing a resized visible client', () => {
+    const oneThird = Math.floor(WEBGL_SURFACE_BUDGET_BYTES / 3)
+    const resized = fakeClient('resized', { surfaceBytes: oneThird })
+    const hidden = fakeClient('hidden', { surfaceBytes: oneThird })
+    grant(resized)
+    grant(hidden)
+    hidden.handle.setVisible(false)
+
+    resized.handle.setSurfaceBytes(Math.floor(WEBGL_SURFACE_BUDGET_BYTES * 0.75))
+
+    expect(hidden.rec.releases).toBe(1)
+    expect(resized.rec.releases).toBe(0)
+    expect(resized.rec.held).toBe(true)
+  })
+
+  it('retries a still-visible refused client when a smaller surface estimate now fits', () => {
+    const incumbent = fakeClient('incumbent', {
+      surfaceBytes: Math.floor(WEBGL_SURFACE_BUDGET_BYTES * 0.75)
+    })
+    const resized = fakeClient('resized', {
+      surfaceBytes: Math.floor(WEBGL_SURFACE_BUDGET_BYTES / 2)
+    })
+    grant(incumbent)
+    grant(resized)
+    expect(resized.rec.acquires).toBe(0)
+
+    resized.handle.setSurfaceBytes(Math.floor(WEBGL_SURFACE_BUDGET_BYTES / 4))
+
+    expect(resized.rec.acquires).toBe(1)
+    expect(resized.rec.held).toBe(true)
+  })
+
+  it('keeps an invalid surface estimate on DOM until a valid measurement arrives', () => {
+    const unknown = fakeClient('unknown', { surfaceBytes: 0 })
+    const second = fakeClient('second')
+    grant(unknown)
+    grant(second)
+
+    expect(unknown.rec.acquires).toBe(0)
+    expect(unknown.rec.held).toBe(false)
+    expect(second.rec.held).toBe(true)
+
+    unknown.handle.setSurfaceBytes(1)
+    expect(unknown.rec.held).toBe(true)
   })
 
   it('releases a hidden holder after the release delay', () => {
@@ -257,6 +389,20 @@ describe('webgl-budget coordinator', () => {
     expect(extra.rec.held).toBe(false)
   })
 
+  it('keeps all 24 default-size Retina terminals eligible on desktop', () => {
+    const desktopBudget = 24
+    const defaultSurfaceBytes = estimateWebglSurfaceBytes(640, 440, 2)
+    expect(defaultSurfaceBytes * desktopBudget).toBeLessThan(WEBGL_SURFACE_BUDGET_BYTES)
+    setWebglBudget(desktopBudget)
+
+    const clients = Array.from({ length: desktopBudget }, (_, i) =>
+      fakeClient(`c${i}`, { surfaceBytes: defaultSurfaceBytes })
+    )
+    clients.forEach(grant)
+
+    expect(clients.every((c) => c.rec.held)).toBe(true)
+  })
+
   it('setWebglBudget ignores nonsense values and reset restores the default', () => {
     setWebglBudget(0)
     expect(getWebglBudget()).toBe(WEBGL_BUDGET)
@@ -266,6 +412,249 @@ describe('webgl-budget coordinator', () => {
     expect(getWebglBudget()).toBe(20)
     __resetWebglBudgetForTests()
     expect(getWebglBudget()).toBe(WEBGL_BUDGET)
+  })
+})
+
+describe('estimateWebglSurfaceBytes', () => {
+  it('uses unscaled CSS dimensions, DPR, BGRA bytes, and outward rounding', () => {
+    expect(estimateWebglSurfaceBytes(640, 440, 2)).toBe(1280 * 880 * 4)
+    expect(estimateWebglSurfaceBytes(640.1, 440.1, 1.25)).toBe(
+      Math.ceil(640.1 * 1.25) * Math.ceil(440.1 * 1.25) * 4
+    )
+  })
+
+  it.each([
+    [0, 440, 2],
+    [-1, 440, 2],
+    [640, 0, 2],
+    [640, 440, 0],
+    [Number.NaN, 440, 2],
+    [640, Number.POSITIVE_INFINITY, 2]
+  ])('fails closed for invalid dimensions/DPR (%s, %s, %s)', (width, height, dpr) => {
+    expect(estimateWebglSurfaceBytes(width, height, dpr)).toBe(Number.MAX_SAFE_INTEGER)
+  })
+})
+
+describe('WebGL surface resize adapter', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('reports growth before the delayed terminal fit', () => {
+    let measuredBytes = 10
+    const events: string[] = []
+    const controller = createWebglSurfaceResizeController({
+      initialSurfaceBytes: measuredBytes,
+      readSurfaceBytes: () => measuredBytes,
+      applyFit: () => events.push('fit'),
+      reportSurfaceBytes: (bytes) => events.push(`report:${bytes}`)
+    })
+
+    measuredBytes = 20
+    controller.measureAndScheduleFit()
+
+    expect(events).toEqual(['report:20'])
+    vi.advanceTimersByTime(WEBGL_SURFACE_RESIZE_SETTLE_MS)
+    expect(events).toEqual(['report:20', 'fit'])
+  })
+
+  it('reports shrink only after xterm has fitted the smaller grid', () => {
+    let measuredBytes = 20
+    const events: string[] = []
+    const controller = createWebglSurfaceResizeController({
+      initialSurfaceBytes: measuredBytes,
+      readSurfaceBytes: () => measuredBytes,
+      applyFit: () => {
+        events.push('fit')
+        measuredBytes = 8
+      },
+      reportSurfaceBytes: (bytes) => events.push(`report:${bytes}`)
+    })
+
+    measuredBytes = 10
+    controller.measureAndScheduleFit()
+
+    expect(events).toEqual([])
+    vi.advanceTimersByTime(WEBGL_SURFACE_RESIZE_SETTLE_MS)
+    expect(events).toEqual(['fit', 'report:8'])
+  })
+
+  it('fails closed when DPR grows during a pending shrink', () => {
+    let measuredBytes = 4
+    const events: string[] = []
+    const controller = createWebglSurfaceResizeController({
+      initialSurfaceBytes: measuredBytes,
+      readSurfaceBytes: () => measuredBytes,
+      applyFit: () => events.push('fit'),
+      reportSurfaceBytes: (bytes) => events.push(`report:${bytes}`)
+    })
+
+    measuredBytes = 2.56
+    controller.measureAndScheduleFit()
+    measuredBytes = 10.24
+    controller.suspendAndScheduleFit()
+    events.push('xterm-dpr-resize')
+
+    expect(events).toEqual([`report:${Number.MAX_SAFE_INTEGER}`, 'xterm-dpr-resize'])
+    vi.advanceTimersByTime(WEBGL_SURFACE_RESIZE_SETTLE_MS)
+    expect(events).toEqual([
+      `report:${Number.MAX_SAFE_INTEGER}`,
+      'xterm-dpr-resize',
+      'fit',
+      'report:10.24'
+    ])
+  })
+
+  it('coalesces observer bursts and cancels a pending fit on dispose', () => {
+    const applyFit = vi.fn()
+    const controller = createWebglSurfaceResizeController({
+      initialSurfaceBytes: 10,
+      readSurfaceBytes: () => 10,
+      applyFit,
+      reportSurfaceBytes: vi.fn()
+    })
+
+    controller.measureAndScheduleFit()
+    controller.measureAndScheduleFit()
+    vi.advanceTimersByTime(WEBGL_SURFACE_RESIZE_SETTLE_MS - 1)
+    expect(applyFit).not.toHaveBeenCalled()
+    controller.dispose()
+    controller.measureAndScheduleFit()
+    vi.advanceTimersByTime(WEBGL_SURFACE_RESIZE_SETTLE_MS)
+    expect(applyFit).not.toHaveBeenCalled()
+  })
+
+  it('suspends WebGL before a geometry option changes and reports after fit', () => {
+    const events: string[] = []
+    const controller = createWebglSurfaceResizeController({
+      initialSurfaceBytes: 10,
+      readSurfaceBytes: () => 10,
+      applyFit: () => events.push('fit'),
+      reportSurfaceBytes: (bytes) => events.push(`report:${bytes}`)
+    })
+
+    controller.runGeometryChange(() => events.push('change'))
+
+    expect(events).toEqual([
+      `report:${Number.MAX_SAFE_INTEGER}`,
+      'change',
+      'fit',
+      'report:10'
+    ])
+  })
+})
+
+describe('watchDevicePixelRatio', () => {
+  it('re-arms a resolution query and also detects DPR through window resize', () => {
+    type QueryRecord = {
+      query: string
+      changeListener: (() => void) | null
+    }
+    const queries: QueryRecord[] = []
+    const resize = { listener: null as (() => void) | null }
+    const targetWindow = {
+      devicePixelRatio: 1,
+      matchMedia: vi.fn((query: string) => {
+        const record: QueryRecord = { query, changeListener: null }
+        queries.push(record)
+        return {
+          addEventListener: (_type: string, listener: () => void) => {
+            record.changeListener = listener
+          },
+          removeEventListener: (_type: string, listener: () => void) => {
+            if (record.changeListener === listener) record.changeListener = null
+          },
+          addListener: vi.fn(),
+          removeListener: vi.fn()
+        }
+      }),
+      addEventListener: (_type: string, listener: () => void) => {
+        resize.listener = listener
+      },
+      removeEventListener: (_type: string, listener: () => void) => {
+        if (resize.listener === listener) resize.listener = null
+      }
+    }
+    const onChange = vi.fn()
+    const stop = watchDevicePixelRatio(targetWindow as never, onChange)
+
+    expect(queries[0].query).toContain('1dppx')
+    targetWindow.devicePixelRatio = 2
+    queries[0].changeListener?.()
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(queries[0].changeListener).toBeNull()
+    expect(queries[1].query).toContain('2dppx')
+
+    targetWindow.devicePixelRatio = 1.5
+    resize.listener?.()
+    expect(onChange).toHaveBeenCalledTimes(2)
+    expect(queries[2].query).toContain('1.5dppx')
+
+    stop()
+    expect(resize.listener).toBeNull()
+    expect(queries[2].changeListener).toBeNull()
+  })
+
+  it('supports legacy MediaQueryList listeners used by older browsers', () => {
+    const media = { listener: null as (() => void) | null }
+    const removeListener = vi.fn((listener: () => void) => {
+      if (media.listener === listener) media.listener = null
+    })
+    const targetWindow = {
+      devicePixelRatio: 1,
+      matchMedia: () => ({
+        addEventListener: undefined,
+        removeEventListener: undefined,
+        addListener: (listener: () => void) => {
+          media.listener = listener
+        },
+        removeListener
+      }),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+    const onChange = vi.fn()
+    const stop = watchDevicePixelRatio(targetWindow as never, onChange)
+
+    targetWindow.devicePixelRatio = 2
+    media.listener?.()
+    expect(onChange).toHaveBeenCalledOnce()
+
+    stop()
+    expect(removeListener).toHaveBeenCalled()
+    expect(media.listener).toBeNull()
+  })
+
+  it('keeps one early shared watcher across park-style unsubscribe and resubscribe', () => {
+    const resizeListeners: Array<() => void> = []
+    const targetWindow = {
+      devicePixelRatio: 1,
+      matchMedia: () => ({
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn()
+      }),
+      addEventListener: (_type: string, listener: () => void) => {
+        resizeListeners.push(listener)
+      },
+      removeEventListener: vi.fn()
+    }
+    const events: string[] = []
+    const stopFirst = subscribeDevicePixelRatio(targetWindow as never, () =>
+      events.push('budget:first')
+    )
+    stopFirst()
+
+    resizeListeners.push(() => events.push('xterm'))
+    const stopRestored = subscribeDevicePixelRatio(targetWindow as never, () =>
+      events.push('budget:restored')
+    )
+    targetWindow.devicePixelRatio = 2
+    resizeListeners.forEach((listener) => listener())
+
+    expect(events).toEqual(['budget:restored', 'xterm'])
+    expect(resizeListeners).toHaveLength(2)
+    stopRestored()
   })
 })
 

--- a/src/renderer/terminal/webgl-budget.ts
+++ b/src/renderer/terminal/webgl-budget.ts
@@ -14,18 +14,23 @@
  * acquire immediately — so the browser force-evicts, and the dead placeholder flashes.
  *
  * This coordinator keeps the number of contexts WE hold at or under `WEBGL_BUDGET`, which sits
- * comfortably below the browser cap. If we never exceed it ourselves, the browser never has to
- * force-evict anyone, so the dead placeholder cannot appear. The coordinator owns ALL timing and
- * the grant decision; the per-node `acquire`/`release` callbacks stay dumb and idempotent.
+ * comfortably below the browser cap. It ALSO bounds their estimated raw backing-surface bytes:
+ * context count alone is not a memory budget, because one large high-DPI terminal canvas can cost
+ * tens of MiB and Metal/the compositor may keep several copies. React Flow zoom only transforms
+ * the canvas visually; it does not shrink xterm's intrinsic backing canvas. If we obey both limits,
+ * the browser never has to force-evict a context and a zoomed-out canvas cannot legally grant
+ * gigabytes of terminal-sized surfaces. The coordinator owns ALL timing and the grant decision;
+ * the per-node `acquire`/`release` callbacks stay dumb and idempotent.
  *
  * Grant rules:
  *  - A client that becomes visible is granted only after a short ACQUIRE DEBOUNCE
  *    (`WEBGL_ACQUIRE_DEBOUNCE_MS`), so a fast pan sweeping a node across the viewport for a couple
  *    of frames never acquires. (`rootMargin` on the observer already pre-announces approach.)
- *  - If granting would exceed the budget, the coordinator immediately RECLAIMS from the
- *    least-recently-visible HIDDEN holder (bypassing that holder's release delay). If every holder
- *    is currently visible (zoomed way out), the newcomer is NOT granted and stays on the DOM
- *    renderer. Either way we never push past the budget, so the browser never force-evicts.
+ *  - If granting would exceed either budget, the coordinator immediately RECLAIMS as many
+ *    least-recently-visible HIDDEN holders as needed (bypassing their release delay). If every
+ *    holder is currently visible (zoomed way out), the newcomer is NOT granted and stays on the
+ *    DOM renderer. Either way we never push past a budget, so the browser never force-evicts and
+ *    terminal backing surfaces cannot grow without an area bound.
  *  - A client that becomes hidden keeps its context for `WEBGL_RELEASE_DELAY_MS` (warm for a
  *    pan-back) but is the first reclaim candidate during that window.
  *  - `acquire()` returning false (WebGL2 unavailable / threw) does not count against the budget.
@@ -50,6 +55,235 @@
  * everywhere: our budget stays comfortably under whatever the platform cap actually is.
  */
 export const WEBGL_BUDGET = 12
+
+/**
+ * Aggregate estimate for ONE raw BGRA backing surface per granted terminal.
+ *
+ * This is deliberately not described as exact GPU memory: Chromium, Metal and the compositor may
+ * retain several copies. 128 MiB still fits all 24 ordinary 640x440 terminals at DPR 2 (about
+ * 103 MiB before subtracting node chrome), while large zoomed-out nodes consume their honest
+ * intrinsic high-DPI cost instead of each counting as the same single slot.
+ */
+export const WEBGL_SURFACE_BUDGET_BYTES = 128 * 1024 * 1024
+
+const BGRA_BYTES_PER_PIXEL = 4
+
+/**
+ * Estimate one terminal's raw backing-surface bytes from its UNTRANSFORMED CSS box. Callers must
+ * use clientWidth/clientHeight, not getBoundingClientRect(): React Flow zoom scales the latter but
+ * xterm's backing canvas remains intrinsic-size × DPR.
+ *
+ * Invalid/zero dimensions fail closed above the budget, so an unmeasured client stays on the DOM
+ * renderer until a real size arrives and cannot make area accounting disappear.
+ */
+export function estimateWebglSurfaceBytes(
+  cssWidth: number,
+  cssHeight: number,
+  devicePixelRatio: number
+): number {
+  if (
+    !Number.isFinite(cssWidth) ||
+    cssWidth <= 0 ||
+    !Number.isFinite(cssHeight) ||
+    cssHeight <= 0 ||
+    !Number.isFinite(devicePixelRatio) ||
+    devicePixelRatio <= 0
+  ) {
+    return Number.MAX_SAFE_INTEGER
+  }
+  const pixelWidth = Math.ceil(cssWidth * devicePixelRatio)
+  const pixelHeight = Math.ceil(cssHeight * devicePixelRatio)
+  const bytes = pixelWidth * pixelHeight * BGRA_BYTES_PER_PIXEL
+  return Number.isSafeInteger(bytes) ? bytes : Number.MAX_SAFE_INTEGER
+}
+
+export const WEBGL_SURFACE_RESIZE_SETTLE_MS = 80
+
+interface WebglSurfaceResizeControllerOptions {
+  initialSurfaceBytes: number
+  readSurfaceBytes(): number
+  applyFit(): void
+  reportSurfaceBytes(surfaceBytes: number): void
+  settleMs?: number
+}
+
+export interface WebglSurfaceResizeController {
+  measureAndScheduleFit(): void
+  suspendAndScheduleFit(): void
+  runGeometryChange(change: () => void): void
+  dispose(): void
+}
+
+/**
+ * Keep surface accounting conservative while terminal fitting is debounced.
+ *
+ * Growth is reported before xterm can enlarge its backing canvas. Shrink is reported only after
+ * the delayed fit has synchronously adopted the smaller grid, because reporting it earlier can
+ * immediately grant WebGL against an old, larger canvas.
+ */
+export function createWebglSurfaceResizeController(
+  options: WebglSurfaceResizeControllerOptions
+): WebglSurfaceResizeController {
+  let reportedSurfaceBytes = options.initialSurfaceBytes
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const settleMs = options.settleMs ?? WEBGL_SURFACE_RESIZE_SETTLE_MS
+  let disposed = false
+
+  const scheduleFitAndReport = () => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      options.applyFit()
+      const fittedSurfaceBytes = options.readSurfaceBytes()
+      if (fittedSurfaceBytes !== reportedSurfaceBytes) {
+        reportedSurfaceBytes = fittedSurfaceBytes
+        options.reportSurfaceBytes(reportedSurfaceBytes)
+      }
+    }, settleMs)
+  }
+
+  return {
+    measureAndScheduleFit() {
+      if (disposed) return
+      const nextSurfaceBytes = options.readSurfaceBytes()
+      if (nextSurfaceBytes > reportedSurfaceBytes) {
+        reportedSurfaceBytes = nextSurfaceBytes
+        options.reportSurfaceBytes(reportedSurfaceBytes)
+      }
+      scheduleFitAndReport()
+    },
+    suspendAndScheduleFit() {
+      if (disposed) return
+      reportedSurfaceBytes = Number.MAX_SAFE_INTEGER
+      options.reportSurfaceBytes(reportedSurfaceBytes)
+      scheduleFitAndReport()
+    },
+    runGeometryChange(change: () => void) {
+      if (disposed) {
+        change()
+        return
+      }
+      if (timer) clearTimeout(timer)
+      timer = null
+      reportedSurfaceBytes = Number.MAX_SAFE_INTEGER
+      options.reportSurfaceBytes(reportedSurfaceBytes)
+      try {
+        change()
+      } finally {
+        options.applyFit()
+        reportedSurfaceBytes = options.readSurfaceBytes()
+        options.reportSurfaceBytes(reportedSurfaceBytes)
+      }
+    },
+    dispose() {
+      disposed = true
+      if (timer) clearTimeout(timer)
+      timer = null
+    }
+  }
+}
+
+type DevicePixelRatioWindow = Pick<
+  Window,
+  'devicePixelRatio' | 'matchMedia' | 'addEventListener' | 'removeEventListener'
+>
+
+/**
+ * Watch DPR independently of element resizing. Ordinary ResizeObserver fallback does not fire
+ * when a fixed-size window moves between displays, while xterm still resizes its backing canvas.
+ * Re-arm the resolution query after every change so later transitions are also observed.
+ */
+export function watchDevicePixelRatio(
+  targetWindow: DevicePixelRatioWindow,
+  onChange: () => void
+): () => void {
+  let currentDpr = targetWindow.devicePixelRatio
+  let mediaQuery: MediaQueryList | null = null
+  let usingModernListener = false
+  let disposed = false
+
+  const removeMediaListener = () => {
+    if (!mediaQuery) return
+    if (usingModernListener) mediaQuery.removeEventListener('change', checkForChange)
+    else mediaQuery.removeListener(checkForChange)
+    mediaQuery = null
+  }
+
+  const armMediaQuery = () => {
+    removeMediaListener()
+    if (disposed || typeof targetWindow.matchMedia !== 'function') return
+    try {
+      mediaQuery = targetWindow.matchMedia(
+        `screen and (resolution: ${targetWindow.devicePixelRatio}dppx)`
+      )
+      usingModernListener = typeof mediaQuery.addEventListener === 'function'
+      if (usingModernListener) mediaQuery.addEventListener('change', checkForChange)
+      else mediaQuery.addListener(checkForChange)
+    } catch {
+      mediaQuery = null
+    }
+  }
+
+  function checkForChange(): void {
+    if (disposed || targetWindow.devicePixelRatio === currentDpr) return
+    currentDpr = targetWindow.devicePixelRatio
+    onChange()
+    armMediaQuery()
+  }
+
+  targetWindow.addEventListener('resize', checkForChange)
+  armMediaQuery()
+
+  return () => {
+    disposed = true
+    targetWindow.removeEventListener('resize', checkForChange)
+    removeMediaListener()
+  }
+}
+
+interface SharedDevicePixelRatioWatch {
+  subscribers: Set<() => void>
+  stop: () => void
+}
+
+const sharedDevicePixelRatioWatches = new WeakMap<
+  DevicePixelRatioWindow,
+  SharedDevicePixelRatioWatch
+>()
+
+/**
+ * Subscribe through one renderer-lifetime DPR watcher installed before xterm opens.
+ *
+ * The root watcher intentionally remains installed when the last node unsubscribes. Parked xterm
+ * instances keep their own older listeners, so tearing down and recreating our root watcher would
+ * let xterm enlarge a restored WebGL canvas before the budget can reclaim it.
+ */
+export function subscribeDevicePixelRatio(
+  targetWindow: DevicePixelRatioWindow,
+  onChange: () => void
+): () => void {
+  let shared = sharedDevicePixelRatioWatches.get(targetWindow)
+  if (!shared) {
+    const subscribers = new Set<() => void>()
+    shared = {
+      subscribers,
+      stop: watchDevicePixelRatio(targetWindow, () => {
+        for (const subscriber of Array.from(subscribers)) {
+          try {
+            subscriber()
+          } catch {
+            // One terminal must not prevent the remaining clients from charging the new DPR.
+          }
+        }
+      })
+    }
+    sharedDevicePixelRatioWatches.set(targetWindow, shared)
+  }
+  shared.subscribers.add(onChange)
+  return () => {
+    shared?.subscribers.delete(onChange)
+  }
+}
 
 /** Live ceiling — `WEBGL_BUDGET` unless the shell raised it (see `setWebglBudget`). */
 let budget = WEBGL_BUDGET
@@ -135,6 +369,8 @@ export interface WebglClientCallbacks {
 export interface WebglClientHandle {
   /** Report this node's viewport visibility (driven by its IntersectionObserver). */
   setVisible(visible: boolean): void
+  /** Report a changed intrinsic high-DPI backing-surface estimate. */
+  setSurfaceBytes(surfaceBytes: number): void
   /** Report that the addon's own `onContextLoss` fired: drop this grant from the accounting. */
   contextLost(): void
   /** Node unmount: release any held context, cancel timers, and forget this client. */
@@ -148,6 +384,8 @@ interface Client {
   visible: boolean
   /** Whether we believe this client currently holds a live context (counts against the budget). */
   granted: boolean
+  /** Estimated bytes for one raw BGRA backing surface at the intrinsic size and current DPR. */
+  surfaceBytes: number
   acquireTimer: ReturnType<typeof setTimeout> | null
   releaseTimer: ReturnType<typeof setTimeout> | null
   /**
@@ -168,6 +406,30 @@ function grantCount(): number {
   let n = 0
   for (const c of clients.values()) if (c.granted) n++
   return n
+}
+
+function normalizeSurfaceBytes(surfaceBytes: number): number {
+  if (!Number.isFinite(surfaceBytes) || surfaceBytes <= 0) return Number.MAX_SAFE_INTEGER
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.ceil(surfaceBytes))
+}
+
+function grantedSurfaceBytes(): number {
+  let bytes = 0
+  for (const c of clients.values()) if (c.granted) bytes += c.surfaceBytes
+  return bytes
+}
+
+function canGrant(c: Client): boolean {
+  const count = grantCount()
+  return (
+    count < budget &&
+    grantedSurfaceBytes() + c.surfaceBytes <= WEBGL_SURFACE_BUDGET_BYTES
+  )
+}
+
+function grantsFitBudgets(): boolean {
+  const count = grantCount()
+  return count <= budget && grantedSurfaceBytes() <= WEBGL_SURFACE_BUDGET_BYTES
 }
 
 function cancelAcquire(c: Client): void {
@@ -218,24 +480,44 @@ function doGrant(c: Client): void {
   if (ok) c.granted = true
 }
 
-/** Attempt to grant `c` a context, reclaiming a hidden holder's slot if the budget is full. */
+/** Attempt to grant `c`, reclaiming hidden holders until both count and surface budgets fit. */
 function tryGrant(c: Client): void {
   cancelAcquire(c)
   // Guard: the client may have gone hidden or been disposed between debounce start and fire.
   if (!clients.has(c.id) || !c.visible || c.granted) return
-  if (grantCount() < budget) {
-    doGrant(c)
-    return
+  // This client can never fit. Do not discard useful hidden warm contexts trying to make room.
+  if (c.surfaceBytes > WEBGL_SURFACE_BUDGET_BYTES) return
+  while (!canGrant(c)) {
+    // Full by context count or surface bytes: reclaim the LRU hidden holder and re-check. An area
+    // deficit can require more than one victim. If every holder is visible, preserve incumbents;
+    // the newcomer stays on the DOM renderer until a later transition or smaller size retries.
+    const victim = lruHiddenHolder()
+    if (!victim) return
+    reclaim(victim)
   }
-  // Full: reclaim the least-recently-visible hidden holder to free exactly one slot.
-  const victim = lruHiddenHolder()
-  if (!victim) {
-    // Every holder is currently visible (zoomed way out): do not push past the budget. The
-    // newcomer stays on the DOM renderer until a later visibility transition frees a slot.
-    return
-  }
-  reclaim(victim)
   doGrant(c)
+}
+
+/**
+ * Enforce both limits after a granted client's intrinsic size changes. Hidden warm holders remain
+ * the first victims. If all remaining holders are visible, the client that grew bears the
+ * downgrade instead of unexpectedly blanking another visible terminal.
+ */
+function enforceBudgetsAfterResize(c: Client): void {
+  if (c.surfaceBytes > WEBGL_SURFACE_BUDGET_BYTES) {
+    reclaim(c)
+    return
+  }
+  while (!grantsFitBudgets()) {
+    const victim = lruHiddenHolder()
+    if (victim) {
+      reclaim(victim)
+      if (victim === c) return
+      continue
+    }
+    reclaim(c)
+    return
+  }
 }
 
 function setVisible(c: Client, visible: boolean): void {
@@ -280,7 +562,11 @@ function setVisible(c: Client, visible: boolean): void {
  * or reclaim the GPU context; the node drives `handle.setVisible` from its IntersectionObserver,
  * reports external context loss via `handle.contextLost`, and calls `handle.dispose` on unmount.
  */
-export function registerWebglClient(id: string, callbacks: WebglClientCallbacks): WebglClientHandle {
+export function registerWebglClient(
+  id: string,
+  callbacks: WebglClientCallbacks,
+  surfaceBytes: number
+): WebglClientHandle {
   // A re-register under the same id (e.g. a remount that raced teardown) supersedes the old entry.
   // Release a still-granted predecessor: its handle's dispose() will short-circuit (stale-handle
   // guard), so without this the old WebglAddon would leak a real browser context while the
@@ -304,6 +590,7 @@ export function registerWebglClient(id: string, callbacks: WebglClientCallbacks)
     release: callbacks.release,
     visible: false,
     granted: false,
+    surfaceBytes: normalizeSurfaceBytes(surfaceBytes),
     acquireTimer: null,
     releaseTimer: null,
     hiddenAt: 0,
@@ -315,6 +602,20 @@ export function registerWebglClient(id: string, callbacks: WebglClientCallbacks)
     setVisible(visible: boolean) {
       const c = clients.get(id)
       if (c === client) setVisible(c, visible)
+    },
+    setSurfaceBytes(surfaceBytes: number) {
+      const c = clients.get(id)
+      if (c !== client) return
+      const next = normalizeSurfaceBytes(surfaceBytes)
+      if (next === c.surfaceBytes) return
+      c.surfaceBytes = next
+      if (c.granted) {
+        enforceBudgetsAfterResize(c)
+      } else if (c.visible && !c.acquireTimer) {
+        // A continuously visible client may have been refused only because its old size did not
+        // fit. It has already served the visibility debounce; a smaller measured size may retry.
+        tryGrant(c)
+      }
     },
     contextLost() {
       const c = clients.get(id)


### PR DESCRIPTION
### Problem

The WebGL coordinator limits context count, but treats every terminal as equal cost. Large terminal
nodes keep their intrinsic DPR-scaled backing canvases when React Flow zoom makes them look small.
Many large terminals can therefore remain under the 24-context desktop limit while allocating
hundreds of MiB of raw terminal surfaces and multiple GiB after browser/GPU copies.

### Root cause

Context count protects Chromium's active-context ceiling; it is not a memory budget. The existing
visibility prefetch and context lifecycle are correct, but grants have no area component.

### Fix

- Keep the existing context ceiling.
- Add a 128 MiB aggregate estimate for intrinsic BGRA terminal surfaces.
- Reclaim hidden holders in LRU order until both limits fit.
- Keep oversized, invalid, or all-visible overflow clients live on xterm's DOM renderer.
- Charge CSS growth before fit and shrink only after fit.
- Suspend WebGL across DPR and live font-geometry transitions, then fit and retry.
- Preserve explicit context loss and recovery behavior.

At the default 640x440 size and DPR 2, all 24 desktop grants still fit at about 103 MiB aggregate.

### Preserved behavior

This does not limit sessions, tmux panes, persisted nodes, or canvas layout. It changes no PTY,
tmux, persistence, main-process, preload, dependency, or setting code.

### Tests

- Focused WebGL coordinator and transition tests: 43 passed
- Full Vitest suite: 3,013 passed
- TypeScript typecheck: passed
- Production build: passed
- Independent diff review: no remaining findings

Native packaged-build GPU measurement is still pending; the source and production build were not
launched as Electron during this verification.
