### PR TITLE
fix(terminal): refocus the app window after a file is dropped in

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -533,6 +533,21 @@ app.whenReady().then(async () => {
 
   ipcMain.on(IPC.appCloseWindow, () => BrowserWindow.getFocusedWindow()?.close())
 
+  // Bring the window forward after a file is dropped into a terminal. On macOS a drag-drop from
+  // another app does NOT activate the destination app, so without this the drag-source keeps OS
+  // keyboard focus and the user types into the wrong application. `getMainWindow()` (not the
+  // focused window — there may be none) restores + shows + focuses.
+  ipcMain.on(IPC.appFocusWindow, () => {
+    const w = getMainWindow()
+    if (!w) return
+    if (w.isMinimized()) w.restore()
+    w.show()
+    // On macOS `win.focus()` alone won't pull us in front of the still-active drag-source app —
+    // app-level focus with `steal` is what actually activates us across apps.
+    if (process.platform === 'darwin') app.focus({ steal: true })
+    w.focus()
+  })
+
   // Dock badge: number of Claude nodes with unread output (macOS only). '' clears it.
   ipcMain.on(IPC.appSetBadge, (_e, count: number) => {
     if (process.platform !== 'darwin' || !app.dock) return

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -498,6 +498,7 @@ const api: NodeTerminalApi = {
   onMarkdownToggle: subscribe(IPC.appToggleMarkdown),
   onCloseNode: subscribe(IPC.appCloseNode),
   closeWindow: () => ipcRenderer.send(IPC.appCloseWindow),
+  focusWindow: () => ipcRenderer.send(IPC.appFocusWindow),
   setBadgeCount: (count) => ipcRenderer.send(IPC.appSetBadge, count),
   // Absolute path of a dropped/picked File (File.path was removed in Electron 30+).
   getPathForFile: (file: File) => webUtils.getPathForFile(file),

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -306,6 +306,15 @@ export function buildStubApi(): Omit<
     onMarkdownToggle: noopUnsub,
     onCloseNode: noopUnsub,
     closeWindow: noop,
+    // Best-effort: a browser tab can't force itself frontmost the way the desktop BrowserWindow
+    // can, but `window.focus()` still helps when the page is merely blurred (not another OS app).
+    focusWindow: () => {
+      try {
+        window.focus()
+      } catch {
+        /* focus is a no-op in some embeddings — never throw into a drop handler */
+      }
+    },
     setBadgeCount: noop,
     getPathForFile: (): string => '',
     notify: async (payload: NotifyPayload): Promise<'shown' | 'failed' | 'skipped'> => {

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -288,6 +288,10 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
       paths = await droppedPaths(files, { sshRemoteTmux: false, projectId: '' })
     }
     if (!paths.length) return
+    // A drag-drop from another OS app doesn't bring our window forward (esp. macOS), so the
+    // drag-source keeps keyboard focus — the user's next keystrokes would land in the wrong app.
+    // Raise our window FIRST, then focus the terminal, so typing after the drop reaches it.
+    window.nodeTerminal.focusWindow()
     term.focus()
     term.paste(paths.join(' ') + ' ')
   }

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -1493,6 +1493,9 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
     // Enter the terminal and paste the path(s) like a real drop (trailing space to continue).
     if (dwellRef.current) clearTimeout(dwellRef.current)
     setArmed(false)
+    // A drag-drop from another OS app doesn't bring our window forward (esp. macOS), so raise it
+    // FIRST — otherwise the drag-source keeps keyboard focus and the user types into the wrong app.
+    window.nodeTerminal.focusWindow()
     term.focus()
     term.paste(paths.join(' ') + ' ')
     useAgentStatus.getState().setActive(id, true)

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -33,6 +33,7 @@ export const IPC = {
   appToggleMarkdown: 'app:toggle-markdown',
   appCloseNode: 'app:close-node',
   appCloseWindow: 'app:close-window',
+  appFocusWindow: 'app:focus-window',
   appNotify: 'app:notify',
   appOpenNotificationSettings: 'app:open-notification-settings',
   appFocusNode: 'app:focus-node',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1745,6 +1745,12 @@ export interface NodeTerminalApi {
   onCloseNode(listener: () => void): () => void
   /** Close the application window (Cmd/Ctrl+W fallback when no node is selected). */
   closeWindow(): void
+  /** Bring the app window to the foreground (show + OS focus). Called after a file is DROPPED
+   *  into a terminal: on macOS a drag-drop from another app (Finder/browser) does not activate
+   *  the destination app, so the drag-source keeps keyboard focus and the user's next keystrokes
+   *  land in the WRONG application — `term.focus()` (DOM-only) can't fix that. Desktop raises the
+   *  BrowserWindow; the browser bridge does a best-effort `window.focus()`. */
+  focusWindow(): void
   /** Set the macOS Dock badge to the unread-message count (0 clears it). */
   setBadgeCount(count: number): void
   /** Absolute filesystem path for a dropped/picked File (for drag-into-terminal). */


### PR DESCRIPTION
## Problem

In the kanban card modal (and on the canvas), after dropping a file/image into a terminal to then type more, the keystrokes went to **another application** — the user had to left-click the terminal again first.

## Root cause

On macOS a drag-drop from another app (Finder, a browser) does **not** activate the destination app: the drag-source keeps OS keyboard focus. `term.focus()` only sets DOM focus *inside* our window, so it can't fix a window that isn't frontmost — the next keystrokes land in the app the file was dragged from.

## Fix

New `focusWindow()` API member, called by both terminal drop handlers (`ModalTerminal` + `TerminalNode`) right before `term.focus()`:

- **Desktop:** raises the `BrowserWindow` (restore + show + focus), and on macOS also `app.focus({ steal: true })` — `win.focus()` alone won't pull us in front of a still-active drag-source app.
- **Server Edition:** best-effort `window.focus()` in the browser bridge.

## Three surfaces

- **Desktop:** real window raise (the actual fix for the reported macOS case).
- **Server Edition:** `window.focus()` best-effort.
- **Relay tabs:** inherit `focusWindow` via `...local` — focusing the local UI window is correct regardless of which session owns the terminal.
- **Mobile:** N/A (no drag-drop-from-another-app model).

## Tests

- `satisfies NodeTerminalApi` gate + typecheck confirm every bridge assembler implements `focusWindow`; bridge/stubs tests green.
- Full suite green (2989).
- Server-Edition smoke: `window.nodeTerminal.focusWindow` is present and callable without throwing.
- The desktop window-raise (`app.focus`/`BrowserWindow.focus`) is inherently platform-native — **Mac verification owed** (can't be exercised on the Linux CI/dev box), like other desktop-native items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)