### PR TITLE
fix(kanban): card-modal terminal clamped to the hidden canvas node's grid

### DIFF
--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -72,6 +72,7 @@ import type { ClientId } from '@shared/presence'
 import { PresenceChips } from '../components/PresenceChips'
 import { useAgentNodes } from '../state/agentNodes'
 import { useProjects } from '../state/projects'
+import { useViewMode } from '../state/viewMode'
 import { useSshConn } from '../state/sshConn'
 import { useWorktrees } from '../state/worktrees'
 import { isRemoteSessionNode } from '@shared/worktree'
@@ -377,6 +378,16 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
   // The live session's "measure my grid, render it, report it" routine (set by the lifecycle
   // effect), so effects outside that closure (font/cursor changes) resize through the same path.
   const applyFitRef = useRef<(() => void) | null>(null)
+  // This project shows the KANBAN board (an opaque overlay over the canvas). While it does, this
+  // canvas terminal is not visible — but it is still a co-attach subscriber, and its (often
+  // zoomed-small) grid would clamp a CARD-MODAL viewer of the same session to a tiny size, pushing
+  // an agent's input box off the bottom. So while the board is up we report "not viewing" (null),
+  // exactly like a park, and the visible modal drives the shared grid. A node only ever lives in the
+  // ACTIVE project's React Flow, so the active project's view is the one that matters.
+  const boardOpen = useViewMode(
+    (s) => s.viewByProject[useProjects.getState().activeProjectId ?? ''] === 'kanban'
+  )
+  const boardOpenRef = useRef(boardOpen)
   const dwellRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [showColors, setShowColors] = useState(false)
   const [armed, setArmed] = useState(true)
@@ -681,6 +692,9 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
     // the other viewer's (larger) grid. Zeroed here, so an adopting client always re-reports.
     let sentCols = 0
     let sentRows = 0
+    // Whether we've already reported "not viewing" because the kanban board is up (see boardOpen).
+    // Guards against re-sending the null on every ResizeObserver tick while the board stays open.
+    let boardParked = false
     // What we last REPORTED — the reference the letterbox is measured against — is published to a
     // module-level registry (`setFittedSize`), NOT held here: the `onSize` listener that reads it is
     // wired once and SURVIVES a park, so a closure variable would leave it comparing the pty's size
@@ -701,6 +715,22 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
      */
     const applyFit = () => {
       try {
+        // Board up → this canvas terminal is hidden behind the overlay. Report "not viewing" (null)
+        // so a card-modal viewer of the same session drives the grid instead of being clamped to our
+        // (possibly zoomed-tiny) canvas size. No modal viewer → no size vote at all → the pty simply
+        // keeps its last size (the "parked SOLO subscriber leaves the pty alone" case). When the board
+        // closes, the boardOpen effect re-runs applyFit and the `sentCols/sentRows` reset below forces
+        // a fresh report of the real fit.
+        if (boardOpenRef.current) {
+          if (sessionId && !boardParked) {
+            boardParked = true
+            sentCols = 0
+            sentRows = 0
+            transport.resize(sessionId, null, null)
+          }
+          return
+        }
+        boardParked = false
         const size = reportedSize(fit.proposeDimensions())
         if (!size) return
         if (size.cols === sentCols && size.rows === sentRows) return
@@ -1395,6 +1425,15 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
     term.options.scrollback = xtermScrollback(tmuxScrollback)
     applyFitRef.current?.()
   }, [fontSize, fontFamily, cursorBlink, tmuxScrollback])
+
+  // Kanban board opened/closed: re-evaluate our size vote. Open → applyFit reports null (yield the
+  // grid to a card-modal viewer); close → it re-reports the real fit. On the first run boardOpen
+  // matches the ref's init value, and applyFit is guarded (no-op when nothing changed), so this
+  // never fires a redundant resize at mount on the common canvas-view path.
+  useEffect(() => {
+    boardOpenRef.current = boardOpen
+    applyFitRef.current?.()
+  }, [boardOpen])
 
   const toggleCollapse = () =>
     setNodes((ns) =>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7167,6 +7167,13 @@ body,
 .kanban-modal__term {
   flex: 1;
   min-width: 0;
+  /* min-height:0 is load-bearing: without it this flex item's automatic minimum is its CONTENT
+   * height, so once the terminal is free to use its own grid (the canvas node parks its size vote
+   * while the board is up) FitAddon and the host feed each other taller and taller — the pane ran
+   * away to ~200 rows. Pinned to 0, the host stays its flex allocation and fit measures the real
+   * visible height. */
+  min-height: 0;
+  overflow: hidden;
   padding: 8px;
 }
 


### PR DESCRIPTION
## Problem

Opening a terminal **card modal** in the kanban board shows the agent's session, but the input box ("yazma yeri") gets pushed off the bottom — a running tool's output/todo fills the few visible rows and there's nowhere to type. Reported with a Claude session whose tool checklist filled the terminal and hid the prompt.

## Root cause

Co-attach sizing: the pty runs at the **smallest subscriber's grid**. While the board is up, the canvas node behind the opaque overlay is *still a subscriber*. Zoomed out, that node fits a tiny grid (measured: **15 rows**), so it clamps the modal to 15 rows even inside a 680px modal — the rest is dead letterbox and the agent renders cramped with its input crushed at the bottom.

## Fix (two parts)

1. **`TerminalNode`** — while this project shows the kanban board, the canvas terminal isn't visible, so it reports "not viewing" (`null` size), *exactly like a park*, and the visible modal drives the shared grid. No modal viewer ⇒ no size vote ⇒ the pty keeps its last size (the parked-solo case, already unit-tested). A `boardOpen` effect re-runs `applyFit` on toggle; a mount-with-board-open parks via the existing post-session `applyFit()`. Guarded so the common canvas-view path fires no redundant resize.

2. **`styles.css`** — `.kanban-modal__term` needed `min-height: 0` (+ `overflow:hidden`). Once the terminal was free to use its own grid, this flex item's automatic minimum was its **content** height, so FitAddon and the host fed each other and the pane ran away to ~200 rows / 3000px. The old clamp had been *masking* this latent flex bug; unclamping exposed it.

## Verification (Server Edition drive)

With a small/zoomed canvas node behind a large board:
- **Before:** modal rendered **15 rows** in a 559px pane (326px letterbox) — cramped.
- **After part 1 only:** ran away to **197 rows / 2971px** (exposed the flex bug).
- **After both:** **37 rows** filling the 559px pane (4px letterbox) — input has full room.
- Closing the board re-fits the canvas terminal to its normal size (no runaway).

Full suite green (2989), typecheck clean.

## Three surfaces

- **Desktop + Server Edition:** fixed (pure renderer/CSS; verified in the browser).
- **Mobile:** N/A (no kanban card modal / co-attach-with-canvas concept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)