### PR TITLE
feat(terminal): GPU-rendering toggle — escape hatch for macOS window flicker

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,7 @@ import { canRename, type AgentId } from '@shared/agents/config'
 import { readFile } from 'fs/promises'
 import { homedir, hostname } from 'os'
 import { randomUUID } from 'crypto'
-import { app, BrowserWindow, dialog, ipcMain, Notification, powerMonitor, shell, systemPreferences } from 'electron'
+import { app, BrowserWindow, clipboard, dialog, ipcMain, Notification, powerMonitor, shell, systemPreferences } from 'electron'
 import { IPC } from '../shared/ipc'
 import { registerFsHandlers } from '../core/fs-handlers'
 import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
@@ -552,6 +552,12 @@ app.whenReady().then(async () => {
     // app-level focus with `steal` is what actually activates us across apps.
     if (process.platform === 'darwin') app.focus({ steal: true })
     w.focus()
+  })
+
+  // System-clipboard write from the MAIN process. Renderer/preload `clipboard` access is deprecated
+  // in Electron (logs a warning per call); the renderer sends this instead. Text only, fire-and-forget.
+  ipcMain.on(IPC.clipboardWrite, (_e, text: string) => {
+    if (typeof text === 'string') clipboard.writeText(text)
   })
 
   // Dock badge: number of Claude nodes with unread output (macOS only). '' clears it.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { clipboard, contextBridge, ipcRenderer, webUtils } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC } from '../shared/ipc'
 import type {
   CanvasMutation,
@@ -241,7 +241,8 @@ const api: NodeTerminalApi = {
     setActiveRemote: (projectId) => ipcRenderer.invoke(IPC.gitSetActiveRemote, projectId)
   },
   clipboard: {
-    writeText: (text: string) => clipboard.writeText(text)
+    // Route to the MAIN process: renderer-side `clipboard` access is deprecated in Electron.
+    writeText: (text: string) => ipcRenderer.send(IPC.clipboardWrite, text)
   },
   shell: {
     reveal: (path: string) => ipcRenderer.send(IPC.shellReveal, path),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,10 +1,21 @@
+import { useEffect } from 'react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { Canvas } from './canvas/Canvas'
 import { PromptDialogHost } from './components/promptDialog'
 import { SessionProvider } from './session/session'
 import { localSession } from './session/localSession'
+import { useSettings } from './state/settings'
+import { setWebglEnabled } from './terminal/webgl-budget'
 
 export default function App() {
+  // Apply the GPU-terminal-rendering toggle to the WebGL budget coordinator, live. Off reclaims
+  // every context (terminals fall back to the DOM renderer) — the escape hatch for the macOS
+  // compositor-flicker case. Subscribed at the root so it holds whatever view is showing.
+  const gpu = useSettings((s) => s.settings.terminalGpuRendering)
+  useEffect(() => {
+    setWebglEnabled(gpu !== false)
+  }, [gpu])
+
   return (
     <SessionProvider session={localSession}>
       <ReactFlowProvider>

--- a/src/renderer/components/settings/sections/TerminalSection.tsx
+++ b/src/renderer/components/settings/sections/TerminalSection.tsx
@@ -9,7 +9,11 @@ import { NumberField } from '@renderer/ui/NumberField'
 const ROWS = {
   fontSize: { title: 'Font size', keywords: ['font', 'size', 'text'] },
   fontFamily: { title: 'Font family', keywords: ['font', 'family', 'typeface', 'monospace'] },
-  cursorBlink: { title: 'Cursor blink', keywords: ['cursor', 'blink'] }
+  cursorBlink: { title: 'Cursor blink', keywords: ['cursor', 'blink'] },
+  gpu: {
+    title: 'GPU terminal rendering',
+    keywords: ['gpu', 'webgl', 'renderer', 'flicker', 'performance', 'graphics', 'acceleration']
+  }
 }
 const ENTRIES = Object.values(ROWS)
 
@@ -51,6 +55,19 @@ export function TerminalSection({ isActive }: { isActive: boolean }): React.JSX.
               checked={settings.cursorBlink}
               onChange={(v) => update({ cursorBlink: v })}
               ariaLabel="Cursor blink"
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.gpu}>
+        <FieldRow
+          label="GPU terminal rendering"
+          description="Turn off if the window flickers. Terminals then use the DOM renderer (no WebGL)."
+          control={
+            <Switch
+              checked={settings.terminalGpuRendering !== false}
+              onChange={(v) => update({ terminalGpuRendering: v })}
+              ariaLabel="GPU terminal rendering"
             />
           }
         />

--- a/src/renderer/terminal/webgl-budget.test.ts
+++ b/src/renderer/terminal/webgl-budget.test.ts
@@ -5,6 +5,7 @@ import {
   getWebglBudget,
   loseWebglContexts,
   setWebglBudget,
+  setWebglEnabled,
   WEBGL_ACQUIRE_DEBOUNCE_MS,
   WEBGL_BUDGET,
   WEBGL_LOSS_STREAK_MAX,
@@ -97,6 +98,48 @@ describe('webgl-budget coordinator', () => {
     expect(extra.rec.acquires).toBe(0)
     expect(extra.rec.held).toBe(false)
     expect(clients.every((c) => c.rec.held)).toBe(true)
+  })
+
+  // ── The GPU-rendering master switch (Settings toggle → macOS flicker escape hatch) ──────────
+  it('setWebglEnabled(false) reclaims every live context and blocks new grants', () => {
+    const a = fakeClient('a')
+    const b = fakeClient('b')
+    grant(a)
+    grant(b)
+    expect(a.rec.held && b.rec.held).toBe(true)
+
+    setWebglEnabled(false)
+    // Every held context is reclaimed immediately (no release-delay wait) → all on DOM renderer.
+    expect(a.rec.held).toBe(false)
+    expect(b.rec.held).toBe(false)
+    expect(a.rec.releases).toBe(1)
+
+    // A newly-visible client is NOT granted while disabled, even under budget.
+    const c = fakeClient('c')
+    grant(c)
+    expect(c.rec.acquires).toBe(0)
+    expect(c.rec.held).toBe(false)
+  })
+
+  it('setWebglEnabled(true) re-grants the visible clients', () => {
+    const a = fakeClient('a')
+    grant(a)
+    setWebglEnabled(false)
+    expect(a.rec.held).toBe(false)
+
+    setWebglEnabled(true)
+    // `a` is still visible → it re-acquires immediately (no debounce; it never went hidden).
+    expect(a.rec.held).toBe(true)
+    expect(a.rec.acquires).toBe(2)
+  })
+
+  it('setWebglEnabled is idempotent (no reclaim on a redundant off→off)', () => {
+    const a = fakeClient('a')
+    grant(a)
+    setWebglEnabled(false)
+    expect(a.rec.releases).toBe(1)
+    setWebglEnabled(false) // no-op
+    expect(a.rec.releases).toBe(1)
   })
 
   it('releases a hidden holder after the release delay', () => {

--- a/src/renderer/terminal/webgl-budget.ts
+++ b/src/renderer/terminal/webgl-budget.ts
@@ -54,6 +54,12 @@ export const WEBGL_BUDGET = 12
 /** Live ceiling — `WEBGL_BUDGET` unless the shell raised it (see `setWebglBudget`). */
 let budget = WEBGL_BUDGET
 
+/** Master switch (Settings → the GPU-terminal-rendering toggle). When false, the coordinator
+ *  grants NOTHING and every terminal stays on xterm's DOM renderer — an escape hatch for machines
+ *  where many live WebGL contexts destabilize the OS compositor (observed as whole-window flicker
+ *  on some macOS GPUs). Default on; `setWebglEnabled` reclaims/re-grants live when it flips. */
+let enabled = true
+
 /**
  * Raise (or lower) the live budget. Called once at boot by the shell that knows its platform cap
  * (desktop raises the Chromium cap to `WEBGL_CONTEXT_CAP_DESKTOP`, so it can afford a higher
@@ -62,6 +68,29 @@ let budget = WEBGL_BUDGET
 export function setWebglBudget(n: number): void {
   if (!Number.isFinite(n) || n < 1) return
   budget = Math.floor(n)
+}
+
+/**
+ * Turn GPU (WebGL) terminal rendering on or off globally. OFF reclaims every currently-held
+ * context immediately (each client falls back to xterm's DOM renderer) and blocks all future
+ * grants; ON re-attempts a grant for every visible client, budget-gated as usual. Idempotent, and
+ * safe to call before any client registers (boot). This is the user-facing escape hatch for the
+ * macOS compositor-flicker case — see `enabled`.
+ */
+export function setWebglEnabled(on: boolean): void {
+  if (enabled === on) return
+  enabled = on
+  if (!on) {
+    // Drop every live context now (bypassing release delays) so the flicker stops on this frame.
+    for (const c of clients.values()) {
+      cancelAcquire(c)
+      reclaim(c)
+    }
+    return
+  }
+  // Back on: give every visible client a chance to re-acquire, oldest-visible first is irrelevant
+  // (tryGrant is budget-gated and never evicts a visible holder), so a simple sweep suffices.
+  for (const c of clients.values()) if (c.visible) tryGrant(c)
 }
 
 /** The live budget (test/introspection seam). */
@@ -223,6 +252,8 @@ function tryGrant(c: Client): void {
   cancelAcquire(c)
   // Guard: the client may have gone hidden or been disposed between debounce start and fire.
   if (!clients.has(c.id) || !c.visible || c.granted) return
+  // Master switch off → never grant; every terminal stays on the DOM renderer.
+  if (!enabled) return
   if (grantCount() < budget) {
     doGrant(c)
     return
@@ -361,4 +392,5 @@ export function __resetWebglBudgetForTests(): void {
   clients.clear()
   visibilityClock = 0
   budget = WEBGL_BUDGET
+  enabled = true
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -34,6 +34,9 @@ export const IPC = {
   appCloseNode: 'app:close-node',
   appCloseWindow: 'app:close-window',
   appFocusWindow: 'app:focus-window',
+  /** Write text to the system clipboard from the MAIN process. Renderer-side `clipboard` access is
+   *  deprecated in Electron; the renderer sends this instead (fire-and-forget). */
+  clipboardWrite: 'clipboard:write',
   appNotify: 'app:notify',
   appOpenNotificationSettings: 'app:open-notification-settings',
   appFocusNode: 'app:focus-node',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -669,6 +669,10 @@ export interface Settings {
   canvasDragMode: 'select' | 'pan'
   accent: string
   tmuxEnabled: boolean
+  /** GPU (WebGL) terminal rendering. Off routes every terminal to xterm's DOM renderer — an escape
+   *  hatch for machines where many live WebGL contexts destabilize the OS compositor (whole-window
+   *  flicker on some macOS GPUs). Default on. */
+  terminalGpuRendering: boolean
   tmuxScrollback: number
   /** AI commit message agent: a local coding-agent CLI run read-only. */
   commitAgent: 'claude' | 'codex' | 'custom'
@@ -787,6 +791,7 @@ export const DEFAULT_SETTINGS: Settings = {
   canvasDragMode: 'select',
   accent: '#0a84ff',
   tmuxEnabled: true,
+  terminalGpuRendering: true,
   tmuxScrollback: 50000,
   commitAgent: 'claude',
   commitAgentCommand: '',


### PR DESCRIPTION
## Problem

A macOS user reported **whole-window flicker** (project tabs included) that comes and goes on **mouse movement** — with **no WebGL/JS errors in the console**, only a benign Electron clipboard deprecation. No console spam is the signature of a pure **GPU compositing** problem (not a context-loss storm).

The recent desktop change that raises Chromium's WebGL context cap to **32** and the renderer budget to **24** (`src/shared/webgl.ts`, merged 2026-07-23, **never Mac-verified**) lets the app hold many live WebGL contexts. On some macOS GPUs that destabilizes the OS compositor and flickers the whole window on any canvas repaint. The user's projects are agent-heavy (many terminals = many contexts), fitting exactly.

## Fix — a user-facing escape hatch

**Settings → Terminal → "GPU terminal rendering"** (default on). Off routes every terminal to xterm's DOM renderer (no WebGL contexts). One clean switch in the budget coordinator:

- `setWebglEnabled(false)` reclaims every live context immediately (each client falls back to the DOM renderer) and blocks future grants; `true` re-grants the visible clients. `tryGrant` early-returns while disabled.
- Shared setting `terminalGpuRendering` (default `true`; read as `!== false` so an old `settings.json` counts as on). `App` subscribes at the root and applies it live.
- Terminal settings section gets the toggle with a "turn off if the window flickers" hint.

This gives the user an **instant A/B test + fix**: toggle off → if the flicker stops, the WebGL hypothesis is confirmed and they have a working app immediately (the confirmation I can't do on the Linux/headless box).

## Verification

- **Unit tests** (`webgl-budget.test.ts`, +3): off reclaims all + blocks grants; on re-grants; idempotent. Full suite green (3040).
- **Server-Edition drive:** toggling off switches a live terminal from the WebGL canvas (**2 canvases → 0 canvases, DOM rows**) and back **on** (→ 2 canvases) — live, no reload, terminal stays functional.

## Also: clipboard deprecation

The console warning the user saw (`Accessing 'clipboard.writeText' from the renderer process is deprecated`) came from the preload calling `clipboard.writeText` directly. Routed through a new `clipboard:write` IPC to the **main** process instead (no more renderer-side clipboard access). Unrelated to the flicker, but removes the console noise.

## Three surfaces

- **Desktop + Server Edition:** renderer-only, works on both (verified in browser).
- **Clipboard IPC:** desktop-only; the browser bridge keeps its own `execCommand`/`navigator.clipboard` path.
- **Mobile:** N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)