### PR TITLE
feat(kanban): Notion-style board labels (create/assign, colors, filter)

### DIFF
--- a/src/renderer/components/kanban/CardMetaBar.tsx
+++ b/src/renderer/components/kanban/CardMetaBar.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import type { BoardLogAuthor, KanbanPriority, ProjectKanban } from '@shared/types'
-import { cardMeta, setCardDue, setCardPriority, toggleAssignee } from '../../lib/kanban'
+import { cardMeta, labelsForCard, setCardDue, setCardPriority, toggleAssignee } from '../../lib/kanban'
+import { LabelChips } from './LabelChips'
+import { LabelPicker } from './LabelPicker'
 import { loadIdentity, selectOthers, usePresence } from '../../state/presence'
 import { useBoardLog } from '../../state/boardLog'
 import { useProjects } from '../../state/projects'
@@ -32,7 +34,9 @@ interface CardMetaBarProps {
  *  author already seen in the board log — no separate membership system. */
 export function CardMetaBar({ nodeId, board, onChange }: CardMetaBarProps) {
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [labelsOpen, setLabelsOpen] = useState(false)
   const meta = cardMeta(board, nodeId)
+  const labels = labelsForCard(board, nodeId)
   const projectId = useProjects((s) => s.activeProjectId)
   const logEntries = useBoardLog((s) => s.entriesFor(projectId))
   const peers = usePresence(selectOthers)
@@ -91,6 +95,27 @@ export function CardMetaBar({ nodeId, board, onChange }: CardMetaBarProps) {
                 )
               })}
             </div>
+          )}
+        </div>
+      </div>
+      <div className="kanban-meta__group">
+        <span className="kanban-meta__label">Labels</span>
+        <div className="kanban-meta__row kanban-meta__row--labels">
+          <LabelChips labels={labels} size="md" />
+          <button
+            className="kanban-avatar kanban-avatar--add"
+            title="Add label"
+            onClick={() => setLabelsOpen((v) => !v)}
+          >
+            +
+          </button>
+          {labelsOpen && (
+            <>
+              <div className="label-picker__scrim" onMouseDown={() => setLabelsOpen(false)} />
+              <div className="label-picker__pop">
+                <LabelPicker board={board} nodeId={nodeId} onChange={onChange} />
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -3,7 +3,7 @@ import type { KanbanColumn as KanbanColumnT } from '@shared/types'
 import type { AgentNodeStatus } from '../../state/agentStatus'
 import { NODE_COLORS } from '../../state/workspace'
 import { SessionCard } from './SessionCard'
-import type { KanbanCardMeta } from '@shared/types'
+import type { KanbanCardMeta, KanbanLabel } from '@shared/types'
 import type { KanbanCreateChoice, KanbanCreateOption, KanbanSession } from './KanbanView'
 
 interface KanbanColumnProps {
@@ -18,6 +18,8 @@ interface KanbanColumnProps {
   onOpenCard: (nodeId: string) => void
   /** Card metadata lookup (assignees/due) for the chips on each card. */
   metaOf: (nodeId: string) => KanbanCardMeta | undefined
+  /** Resolved board labels for a card (the colored label chips). */
+  labelsOf: (nodeId: string) => KanbanLabel[]
   /** "+ New" menu entries (agents, terminal, sticky) and what to do when one is picked. */
   createOptions: KanbanCreateOption[]
   onCreate: (choice: KanbanCreateChoice) => void
@@ -33,7 +35,7 @@ interface KanbanColumnProps {
 }
 
 export function KanbanColumn({
-  column, cards, statusById, metaOf, onRename, onRecolor, onDelete, onOpenCard, onCardContext,
+  column, cards, statusById, metaOf, labelsOf, onRename, onRecolor, onDelete, onOpenCard, onCardContext,
   createOptions, onCreate, onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn,
   onDropAtCard
 }: KanbanColumnProps) {
@@ -135,6 +137,7 @@ export function KanbanColumn({
             session={s}
             status={statusById[s.id]}
             meta={metaOf(s.id)}
+            labels={labelsOf(s.id)}
             onOpen={() => onOpenCard(s.id)}
             onContext={(x, y) => onCardContext(s.id, x, y)}
             onDragStart={() => onCardDragStart(s.id)}

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -6,9 +6,11 @@ import { useViewMode } from '../../state/viewMode'
 import { useProjects } from '../../state/projects'
 import { useSettings } from '../../state/settings'
 import {
-  addColumn, assignNode, assignedTo, cardMeta, columnForNode, deleteColumn, moveColumn,
+  addColumn, assignNode, assignedTo, boardLabels, cardMatchesLabelFilter, cardMeta, columnForNode,
+  deleteColumn, labelsForCard, moveColumn,
   nextColumnColor, pruneAssignments, recolorColumn, renameColumn, unassigned
 } from '../../lib/kanban'
+import { labelSwatch } from '../../lib/kanbanLabelColors'
 import { CardModal } from './CardModal'
 import { KanbanColumn } from './KanbanColumn'
 import type { ModalSpawn } from './ModalTerminal'
@@ -82,6 +84,17 @@ export function KanbanView({
   const [modalNodeId, setModalNodeId] = useState<string | null>(null)
   // Right-click card menu (open on canvas / move / delete).
   const [cardMenu, setCardMenu] = useState<{ x: number; y: number; nodeId: string } | null>(null)
+  // Board label filter — transient (per board session; resets when you leave the board). Empty =
+  // show everything; otherwise a card must carry at least one selected label (cardMatchesLabelFilter).
+  const [labelFilter, setLabelFilter] = useState<string[]>([])
+  const [filterOpen, setFilterOpen] = useState(false)
+  // Drop ids no longer in the palette so a deleted label can't keep the board filtered to nothing.
+  const paletteLabels = boardLabels(board)
+  const activeFilter = labelFilter.filter((id) => paletteLabels.some((l) => l.id === id))
+  const visible = (ids: string[]): string[] =>
+    activeFilter.length ? ids.filter((id) => cardMatchesLabelFilter(board, id, activeFilter)) : ids
+  const toggleFilter = (id: string): void =>
+    setLabelFilter((f) => (f.includes(id) ? f.filter((x) => x !== id) : [...f, id]))
   // Opening a card = you're looking at that session: clear its unread badge, and report the open
   // node to the canvas (dictation shortcut targeting).
   useEffect(() => {
@@ -195,13 +208,49 @@ export function KanbanView({
       <div className="kanban-header">
         <span className="kanban-header__dot" style={{ background: projectColor }} />
         <span className="kanban-header__name">{projectName}</span>
+        {paletteLabels.length > 0 && (
+          <div className="kanban-header__filter">
+            <button
+              className={`kanban-filter-btn${activeFilter.length ? ' kanban-filter-btn--on' : ''}`}
+              title="Filter by label"
+              onClick={() => setFilterOpen((v) => !v)}
+            >
+              Filter{activeFilter.length ? ` · ${activeFilter.length}` : ''}
+            </button>
+            {filterOpen && (
+              <>
+                <div className="label-picker__scrim" onMouseDown={() => setFilterOpen(false)} />
+                <div className="kanban-filter-menu">
+                  {paletteLabels.map((l) => {
+                    const s = labelSwatch(l.color)
+                    const on = activeFilter.includes(l.id)
+                    return (
+                      <button key={l.id} className="kanban-filter-row" onClick={() => toggleFilter(l.id)}>
+                        <span className="kanban-label-chip" style={{ background: s.bg, color: s.fg }}>
+                          {l.name || 'Label'}
+                        </span>
+                        {on && <span className="label-picker__rowcheck">✓</span>}
+                      </button>
+                    )
+                  })}
+                  {activeFilter.length > 0 && (
+                    <button className="kanban-filter-clear" onClick={() => setLabelFilter([])}>
+                      Clear filter
+                    </button>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
       </div>
       <div className="kanban-board">
         <KanbanColumn
           column={null}
-          cards={sessionsFor(unassigned(board, sessions.map((s) => s.id)))}
+          cards={sessionsFor(visible(unassigned(board, sessions.map((s) => s.id))))}
           statusById={statusById}
           metaOf={(id) => cardMeta(board, id)}
+          labelsOf={(id) => labelsForCard(board, id)}
           onOpenCard={setModalNodeId}
           createOptions={createOptions}
           onCreate={(choice) => onCreateNode(choice, null)}
@@ -215,9 +264,10 @@ export function KanbanView({
           <KanbanColumn
             key={col.id}
             column={col}
-            cards={sessionsFor(assignedTo(board, col.id))}
+            cards={sessionsFor(visible(assignedTo(board, col.id)))}
             statusById={statusById}
             metaOf={(id) => cardMeta(board, id)}
+            labelsOf={(id) => labelsForCard(board, id)}
             onRename={(t) => commit(renameColumn(board, col.id, t))}
             onRecolor={(c) => commit(recolorColumn(board, col.id, c))}
             onDelete={() => commit(deleteColumn(board, col.id))}

--- a/src/renderer/components/kanban/LabelChips.tsx
+++ b/src/renderer/components/kanban/LabelChips.tsx
@@ -1,0 +1,28 @@
+import type { KanbanLabel } from '@shared/types'
+import { labelSwatch } from '../../lib/kanbanLabelColors'
+
+/** Renders a set of resolved board labels as colored pills. `size` tunes the padding/font for the
+ *  card face (sm) vs the modal / node body (md). Display-only — editing lives in LabelPicker. */
+export function LabelChips({
+  labels,
+  size = 'sm',
+  className = ''
+}: {
+  labels: KanbanLabel[]
+  size?: 'sm' | 'md'
+  className?: string
+}): React.JSX.Element | null {
+  if (!labels.length) return null
+  return (
+    <div className={`kanban-labels kanban-labels--${size} ${className}`.trim()}>
+      {labels.map((l) => {
+        const s = labelSwatch(l.color)
+        return (
+          <span key={l.id} className="kanban-label-chip" style={{ background: s.bg, color: s.fg }}>
+            {l.name || 'Label'}
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/components/kanban/LabelPicker.tsx
+++ b/src/renderer/components/kanban/LabelPicker.tsx
@@ -1,0 +1,170 @@
+import { useMemo, useRef, useState } from 'react'
+import type { KanbanLabelColor, ProjectKanban } from '@shared/types'
+import {
+  KANBAN_LABEL_COLORS,
+  boardLabels,
+  createLabel,
+  deleteLabel,
+  labelsForCard,
+  recolorLabel,
+  renameLabel,
+  toggleCardLabel
+} from '../../lib/kanban'
+import { LABEL_COLOR_OPTIONS, labelSwatch } from '../../lib/kanbanLabelColors'
+
+/** Auto-color for a newly created label: rotate the palette (skipping 'default') so consecutive
+ *  new labels get distinct colors, Notion-style. */
+function nextLabelColor(board: ProjectKanban): KanbanLabelColor {
+  const colors = KANBAN_LABEL_COLORS.filter((c) => c !== 'default')
+  return colors[boardLabels(board).length % colors.length]
+}
+
+/**
+ * Notion-style label picker: type to filter existing labels or CREATE a new one inline, click a row
+ * to assign/unassign, and edit a label (rename / recolor / delete) from its ⋯ menu. All edits go
+ * through the pure `kanban.ts` transforms and out via `onChange` (which the modal persists).
+ */
+export function LabelPicker({
+  board,
+  nodeId,
+  onChange
+}: {
+  board: ProjectKanban
+  nodeId: string
+  onChange: (next: ProjectKanban) => void
+}): React.JSX.Element {
+  const [query, setQuery] = useState('')
+  const [editing, setEditing] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const all = boardLabels(board)
+  const assigned = labelsForCard(board, nodeId)
+  const assignedIds = useMemo(() => new Set(assigned.map((l) => l.id)), [assigned])
+  const q = query.trim().toLowerCase()
+  const filtered = q ? all.filter((l) => l.name.toLowerCase().includes(q)) : all
+  const exact = all.some((l) => l.name.trim().toLowerCase() === q)
+  const canCreate = q.length > 0 && !exact
+
+  const toggle = (id: string) => onChange(toggleCardLabel(board, nodeId, id))
+  const create = () => {
+    if (!canCreate) return
+    const { k, id } = createLabel(board, query.trim(), nextLabelColor(board))
+    onChange(toggleCardLabel(k, nodeId, id))
+    setQuery('')
+    inputRef.current?.focus()
+  }
+
+  const editLabel = editing ? all.find((l) => l.id === editing) : undefined
+
+  if (editLabel) {
+    // ── Edit panel for one label (rename / color / delete) — Notion's ⋯ popover. ──
+    const sw = labelSwatch(editLabel.color)
+    return (
+      <div className="label-picker" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="label-picker__edithead">
+          <button className="label-picker__back" title="Back" onClick={() => setEditing(null)}>
+            ‹
+          </button>
+          <input
+            className="label-picker__renameinput"
+            autoFocus
+            value={editLabel.name}
+            style={{ background: sw.bg, color: sw.fg }}
+            onChange={(e) => onChange(renameLabel(board, editLabel.id, e.target.value))}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === 'Escape') setEditing(null)
+            }}
+          />
+        </div>
+        <button
+          className="label-picker__delete"
+          onClick={() => {
+            onChange(deleteLabel(board, editLabel.id))
+            setEditing(null)
+          }}
+        >
+          🗑 Delete
+        </button>
+        <div className="label-picker__colhead">Colors</div>
+        <div className="label-picker__colors">
+          {LABEL_COLOR_OPTIONS.map((opt) => (
+            <button
+              key={opt.color}
+              className="label-picker__colorrow"
+              onClick={() => onChange(recolorLabel(board, editLabel.id, opt.color))}
+            >
+              <span className="label-picker__swatch" style={{ background: opt.bg }} />
+              <span className="label-picker__colorname">{opt.title}</span>
+              {editLabel.color === opt.color && <span className="label-picker__check">✓</span>}
+            </button>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="label-picker" onMouseDown={(e) => e.stopPropagation()}>
+      <div className="label-picker__input" onClick={() => inputRef.current?.focus()}>
+        {assigned.map((l) => {
+          const s = labelSwatch(l.color)
+          return (
+            <span key={l.id} className="kanban-label-chip" style={{ background: s.bg, color: s.fg }}>
+              {l.name || 'Label'}
+              <button className="kanban-label-chip__x" title="Remove" onClick={() => toggle(l.id)}>
+                ×
+              </button>
+            </span>
+          )
+        })}
+        <input
+          ref={inputRef}
+          className="label-picker__search"
+          autoFocus
+          value={query}
+          spellCheck={false}
+          placeholder={assigned.length ? '' : 'Select an option or create one'}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && canCreate) create()
+            if (e.key === 'Backspace' && !query && assigned.length) toggle(assigned[assigned.length - 1].id)
+          }}
+        />
+      </div>
+      <div className="label-picker__hint">Select an option or create one</div>
+      <div className="label-picker__list">
+        {filtered.map((l) => {
+          const s = labelSwatch(l.color)
+          return (
+            <div key={l.id} className="label-picker__row">
+              <button className="label-picker__pick" onClick={() => toggle(l.id)}>
+                <span className="kanban-label-chip" style={{ background: s.bg, color: s.fg }}>
+                  {l.name || 'Label'}
+                </span>
+                {assignedIds.has(l.id) && <span className="label-picker__rowcheck">✓</span>}
+              </button>
+              <button
+                className="label-picker__more"
+                title="Edit label"
+                onClick={() => setEditing(l.id)}
+              >
+                ⋯
+              </button>
+            </div>
+          )
+        })}
+        {canCreate && (
+          <button className="label-picker__create" onClick={create}>
+            Create{' '}
+            <span
+              className="kanban-label-chip"
+              style={{ background: labelSwatch(nextLabelColor(board)).bg, color: labelSwatch(nextLabelColor(board)).fg }}
+            >
+              {query.trim()}
+            </span>
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react'
-import type { KanbanCardMeta, KanbanPriority } from '@shared/types'
+import type { KanbanCardMeta, KanbanLabel, KanbanPriority } from '@shared/types'
 import type { AgentNodeStatus } from '../../state/agentStatus'
 import { ContextMeter } from '../ContextMeter'
+import { LabelChips } from './LabelChips'
 import type { KanbanSession } from './KanbanView'
 
 interface SessionCardProps {
   session: KanbanSession
   status?: AgentNodeStatus
   meta?: KanbanCardMeta
+  /** Resolved board labels on this card (LabelChips) — resolved by the board, passed in. */
+  labels?: KanbanLabel[]
   /** Single click opens the card modal directly (the expand/collapse step was dropped). */
   onOpen: () => void
   onDragStart: () => void
@@ -18,7 +21,7 @@ interface SessionCardProps {
   onContext: (x: number, y: number) => void
 }
 
-export function SessionCard({ session, status, meta, onOpen, onDragStart, onDragEnd, onDropAt, onContext }: SessionCardProps) {
+export function SessionCard({ session, status, meta, labels = [], onOpen, onDragStart, onDragEnd, onDropAt, onContext }: SessionCardProps) {
   // Local drag state only styles THIS card (ghost look) — the drag payload lives in KanbanView.
   const [dragging, setDragging] = useState(false)
   // Which edge a drag is hovering over → shows the drop line (top = before, bottom = after).
@@ -90,6 +93,7 @@ export function SessionCard({ session, status, meta, onOpen, onDragStart, onDrag
         {badge === 'needs' && <span className="kanban-badge kanban-badge--needs">NEEDS YOU</span>}
         {status?.unread && <span className="kanban-card__unread" />}
       </div>
+      <LabelChips labels={labels} size="sm" className="kanban-card__labels" />
       {(assignees.length > 0 || due !== undefined || priority !== undefined) && (
         <div className="kanban-card__metarow">
           {priority !== undefined && PRIO_COLOR[priority] && (

--- a/src/renderer/lib/kanban.test.ts
+++ b/src/renderer/lib/kanban.test.ts
@@ -3,7 +3,9 @@ import type { ProjectKanban } from '@shared/types'
 import {
   addColumn, assignNode, assignedTo, defaultKanban, deleteColumn, moveColumn,
   cardMeta, columnForNode, nextColumnColor, pruneAssignments, recolorColumn, renameColumn,
-  setCardDue, setCardPriority, toggleAssignee, unassigned
+  setCardDue, setCardPriority, toggleAssignee, unassigned,
+  boardLabels, cardMatchesLabelFilter, createLabel, deleteLabel, labelColor, labelsForCard,
+  recolorLabel, renameLabel, reorderLabels, toggleCardLabel
 } from './kanban'
 
 const board = (): ProjectKanban => ({
@@ -151,5 +153,101 @@ describe('card priority', () => {
     const cleared = setCardDue(k, 'n1', null)
     expect(cardMeta(cleared, 'n1')).toMatchObject({ priority: 'low', assignees: [enes] })
     expect(cardMeta(cleared, 'n1')?.dueAt).toBeUndefined()
+  })
+})
+
+describe('board labels', () => {
+  it('createLabel adds to the palette and returns the new id; labelColor normalizes garbage', () => {
+    const { k, id } = createLabel(board(), '  Bug ', 'red')
+    expect(boardLabels(k)).toHaveLength(1)
+    expect(boardLabels(k)[0]).toMatchObject({ id, name: 'Bug', color: 'red' })
+    expect(labelColor('nonsense')).toBe('default')
+    // a garbage color at create time is coerced to 'default'
+    const { k: k2 } = createLabel(board(), 'x', 'chartreuse' as never)
+    expect(boardLabels(k2)[0].color).toBe('default')
+  })
+
+  it('rename / recolor touch only the target label', () => {
+    let k = createLabel(board(), 'A', 'blue').k
+    const idA = boardLabels(k)[0].id
+    k = createLabel(k, 'B', 'green').k
+    const idB = boardLabels(k)[1].id
+    k = recolorLabel(renameLabel(k, idA, 'Acil'), idA, 'orange')
+    expect(boardLabels(k)[0]).toMatchObject({ id: idA, name: 'Acil', color: 'orange' })
+    expect(boardLabels(k)[1]).toMatchObject({ id: idB, name: 'B', color: 'green' })
+  })
+
+  it('toggleCardLabel adds then removes; labelsForCard resolves in palette order and drops dangling', () => {
+    let k = createLabel(board(), 'A', 'blue').k
+    const a = boardLabels(k)[0].id
+    k = createLabel(k, 'B', 'green').k
+    const b = boardLabels(k)[1].id
+    k = toggleCardLabel(toggleCardLabel(k, 'n1', b), 'n1', a) // apply b then a
+    // resolved in PALETTE order (a before b), not application order
+    expect(labelsForCard(k, 'n1').map((l) => l.name)).toEqual(['A', 'B'])
+    // a card carrying a since-deleted id resolves to nothing for it
+    k = { ...k, meta: [{ nodeId: 'n1', labels: [a, 'ghost'] }] }
+    expect(labelsForCard(k, 'n1').map((l) => l.name)).toEqual(['A'])
+    // toggling a on again removes it
+    k = toggleCardLabel({ ...k, meta: [{ nodeId: 'n1', labels: [a] }] }, 'n1', a)
+    expect(cardMeta(k, 'n1')).toBeUndefined() // emptied meta entry is dropped
+  })
+
+  it('deleteLabel removes the label AND strips its id from every card', () => {
+    let k = createLabel(board(), 'A', 'blue').k
+    const a = boardLabels(k)[0].id
+    k = createLabel(k, 'B', 'green').k
+    const b = boardLabels(k)[1].id
+    k = toggleCardLabel(toggleCardLabel(k, 'n1', a), 'n1', b)
+    k = toggleCardLabel(k, 'n2', a)
+    k = deleteLabel(k, a)
+    expect(boardLabels(k).map((l) => l.name)).toEqual(['B'])
+    expect(cardMeta(k, 'n1')?.labels).toEqual([b]) // a stripped, b kept
+    expect(cardMeta(k, 'n2')).toBeUndefined() // n2 had only a → meta entry dropped
+  })
+
+  it('deleteLabel preserves a card entry that still has OTHER meta', () => {
+    let k = createLabel(board(), 'A', 'blue').k
+    const a = boardLabels(k)[0].id
+    k = setCardPriority(toggleCardLabel(k, 'n1', a), 'n1', 'high')
+    k = deleteLabel(k, a)
+    expect(cardMeta(k, 'n1')).toMatchObject({ priority: 'high' })
+    expect(cardMeta(k, 'n1')?.labels ?? []).toEqual([])
+  })
+
+  it('reorderLabels moves a label before another (null = end)', () => {
+    let k = createLabel(createLabel(createLabel(board(), 'A', 'blue').k, 'B', 'green').k, 'C', 'red').k
+    const [a, b, c] = boardLabels(k).map((l) => l.id)
+    expect(boardLabels(reorderLabels(k, c, a)).map((l) => l.name)).toEqual(['C', 'A', 'B'])
+    expect(boardLabels(reorderLabels(k, a, null)).map((l) => l.name)).toEqual(['B', 'C', 'A'])
+  })
+
+  it('cardMatchesLabelFilter: empty filter matches all; otherwise OR over the card labels', () => {
+    let k = createLabel(board(), 'A', 'blue').k
+    const a = boardLabels(k)[0].id
+    k = createLabel(k, 'B', 'green').k
+    const b = boardLabels(k)[1].id
+    k = toggleCardLabel(k, 'n1', a) // n1 has A only
+    expect(cardMatchesLabelFilter(k, 'n1', [])).toBe(true)
+    expect(cardMatchesLabelFilter(k, 'n1', [a])).toBe(true)
+    expect(cardMatchesLabelFilter(k, 'n1', [b])).toBe(false)
+    expect(cardMatchesLabelFilter(k, 'n1', [a, b])).toBe(true) // OR
+    expect(cardMatchesLabelFilter(k, 'n2', [a])).toBe(false) // n2 unlabelled
+  })
+
+  it('boardLabels tolerates a missing/garbage labels array', () => {
+    expect(boardLabels({ columns: [], assignments: [] })).toEqual([])
+    expect(boardLabels({ columns: [], assignments: [], labels: 'x' as never })).toEqual([])
+    expect(boardLabels({ columns: [], assignments: [], labels: [null, { id: 'z', name: 'Z', color: 'blue' }] as never })).toHaveLength(1)
+  })
+
+  it('setCardDue / toggleAssignee preserve existing labels', () => {
+    let k = createLabel(board(), 'A', 'blue').k
+    const a = boardLabels(k)[0].id
+    k = toggleCardLabel(k, 'n1', a)
+    k = setCardDue(k, 'n1', 123)
+    expect(cardMeta(k, 'n1')).toMatchObject({ dueAt: 123, labels: [a] })
+    k = toggleAssignee(k, 'n1', { name: 'enes', color: '#fff' })
+    expect(cardMeta(k, 'n1')?.labels).toEqual([a])
   })
 })

--- a/src/renderer/lib/kanban.ts
+++ b/src/renderer/lib/kanban.ts
@@ -1,4 +1,4 @@
-import type { BoardLogAuthor, KanbanAssignment, KanbanCardMeta, KanbanColumn, KanbanPriority, ProjectKanban } from '@shared/types'
+import type { BoardLogAuthor, KanbanAssignment, KanbanCardMeta, KanbanColumn, KanbanLabel, KanbanLabelColor, KanbanPriority, ProjectKanban } from '@shared/types'
 import { NODE_COLORS } from '../state/workspace'
 
 // Pure kanban board transforms — the ONLY place board structure changes. The UI computes
@@ -150,7 +150,10 @@ function withCardMeta(
   const rest = metaList(k).filter((m) => m && m.nodeId !== nodeId)
   const keep =
     next &&
-    ((next.assignees?.length ?? 0) > 0 || next.dueAt !== undefined || next.priority !== undefined)
+    ((next.assignees?.length ?? 0) > 0 ||
+      next.dueAt !== undefined ||
+      next.priority !== undefined ||
+      (next.labels?.length ?? 0) > 0)
   const meta = keep ? [...rest, { nodeId, ...next }] : rest
   const { meta: _m, ...bare } = k
   return meta.length ? { ...bare, meta } : bare
@@ -168,7 +171,12 @@ export function toggleAssignee(
   const assignees = had
     ? (cur?.assignees ?? []).filter((a) => a.name !== person.name)
     : [...(cur?.assignees ?? []), person]
-  return withCardMeta(k, nodeId, { assignees, dueAt: cur?.dueAt, priority: cur?.priority })
+  return withCardMeta(k, nodeId, {
+    assignees,
+    dueAt: cur?.dueAt,
+    priority: cur?.priority,
+    labels: cur?.labels
+  })
 }
 
 /** Sets (or clears, with null) the card's due timestamp. */
@@ -177,6 +185,7 @@ export function setCardDue(k: ProjectKanban, nodeId: string, dueAt: number | nul
   return withCardMeta(k, nodeId, {
     assignees: cur?.assignees,
     priority: cur?.priority,
+    labels: cur?.labels,
     ...(dueAt === null ? {} : { dueAt })
   })
 }
@@ -191,6 +200,127 @@ export function setCardPriority(
   return withCardMeta(k, nodeId, {
     assignees: cur?.assignees,
     dueAt: cur?.dueAt,
+    labels: cur?.labels,
     ...(priority === null ? {} : { priority })
   })
+}
+
+// ── Board labels (Notion-style palette) ──────────────────────────────────────────────────────
+
+/** Ordered color palette for the picker (also the fallback order). Chip colors live in the UI
+ *  (`kanbanLabelColors.ts`); this is the closed set of names only. */
+export const KANBAN_LABEL_COLORS: KanbanLabelColor[] = [
+  'default',
+  'gray',
+  'brown',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+  'pink',
+  'red'
+]
+
+/** Normalize any read color to a known palette value ('default' for garbage from a hand-edited file). */
+export function labelColor(c: unknown): KanbanLabelColor {
+  return KANBAN_LABEL_COLORS.includes(c as KanbanLabelColor) ? (c as KanbanLabelColor) : 'default'
+}
+
+/** The board's label palette (defensive against a missing/garbage array), ids+names deduped-safe. */
+export function boardLabels(k: ProjectKanban): KanbanLabel[] {
+  if (!Array.isArray(k.labels)) return []
+  return k.labels.filter(
+    (l): l is KanbanLabel => !!l && typeof l.id === 'string' && typeof l.name === 'string'
+  )
+}
+
+/** The resolved labels applied to a card, in palette order, dropping ids with no matching label. */
+export function labelsForCard(k: ProjectKanban, nodeId: string): KanbanLabel[] {
+  const ids = cardMeta(k, nodeId)?.labels
+  if (!Array.isArray(ids) || !ids.length) return []
+  const set = new Set(ids)
+  return boardLabels(k).filter((l) => set.has(l.id))
+}
+
+/** Create a new board label; returns the next board AND the new id (so the caller can select it). */
+export function createLabel(
+  k: ProjectKanban,
+  name: string,
+  color: KanbanLabelColor
+): { k: ProjectKanban; id: string } {
+  const id = kid('klbl')
+  const label: KanbanLabel = { id, name: name.trim(), color: labelColor(color) }
+  return { k: { ...k, labels: [...boardLabels(k), label] }, id }
+}
+
+export function renameLabel(k: ProjectKanban, id: string, name: string): ProjectKanban {
+  return { ...k, labels: boardLabels(k).map((l) => (l.id === id ? { ...l, name: name.trim() } : l)) }
+}
+
+export function recolorLabel(k: ProjectKanban, id: string, color: KanbanLabelColor): ProjectKanban {
+  return {
+    ...k,
+    labels: boardLabels(k).map((l) => (l.id === id ? { ...l, color: labelColor(color) } : l))
+  }
+}
+
+/** Deletes a board label AND strips its id from every card's meta (no dangling references). */
+export function deleteLabel(k: ProjectKanban, id: string): ProjectKanban {
+  const labels = boardLabels(k).filter((l) => l.id !== id)
+  const meta = metaList(k)
+    .map((m) => (m?.labels?.includes(id) ? { ...m, labels: m.labels.filter((x) => x !== id) } : m))
+    // an entry emptied to nothing but the nodeId is dropped, matching withCardMeta's invariant
+    .filter(
+      (m) =>
+        (m.assignees?.length ?? 0) > 0 ||
+        m.dueAt !== undefined ||
+        m.priority !== undefined ||
+        (m.labels?.length ?? 0) > 0
+    )
+  const { labels: _l, meta: _m, ...bare } = k
+  return {
+    ...bare,
+    ...(labels.length ? { labels } : {}),
+    ...(meta.length ? { meta } : {})
+  }
+}
+
+/** Moves a label before `beforeId` (null = to the end) — the palette's display order. */
+export function reorderLabels(k: ProjectKanban, id: string, beforeId: string | null): ProjectKanban {
+  if (id === beforeId) return k
+  const labels = boardLabels(k)
+  const dragged = labels.find((l) => l.id === id)
+  if (!dragged) return k
+  const without = labels.filter((l) => l.id !== id)
+  const idx = beforeId ? without.findIndex((l) => l.id === beforeId) : -1
+  const at = idx === -1 ? without.length : idx
+  return { ...k, labels: [...without.slice(0, at), dragged, ...without.slice(at)] }
+}
+
+/** Toggle a label on a card (add if absent, remove if present). Preserves the card's other meta. */
+export function toggleCardLabel(k: ProjectKanban, nodeId: string, labelId: string): ProjectKanban {
+  const cur = cardMeta(k, nodeId)
+  const has = (cur?.labels ?? []).includes(labelId)
+  const labels = has
+    ? (cur?.labels ?? []).filter((x) => x !== labelId)
+    : [...(cur?.labels ?? []), labelId]
+  return withCardMeta(k, nodeId, {
+    assignees: cur?.assignees,
+    dueAt: cur?.dueAt,
+    priority: cur?.priority,
+    labels
+  })
+}
+
+/** Does a card pass the label filter? Empty filter = everything; otherwise the card must carry
+ *  AT LEAST ONE of the selected labels (OR semantics, like Trello's default). */
+export function cardMatchesLabelFilter(
+  k: ProjectKanban,
+  nodeId: string,
+  filterIds: readonly string[]
+): boolean {
+  if (!filterIds.length) return true
+  const on = new Set(cardMeta(k, nodeId)?.labels ?? [])
+  return filterIds.some((id) => on.has(id))
 }

--- a/src/renderer/lib/kanbanLabelColors.ts
+++ b/src/renderer/lib/kanbanLabelColors.ts
@@ -1,0 +1,37 @@
+import type { KanbanLabelColor } from '@shared/types'
+import { KANBAN_LABEL_COLORS, labelColor } from './kanban'
+
+// The Notion label palette, rendered for nodeterm's dark UI: a muted background + a lighter
+// same-hue text, so a chip reads clearly on the black canvas and the dark board. The NAME set is
+// the source of truth (`KANBAN_LABEL_COLORS` in kanban.ts); this only maps each to CSS + a label.
+
+interface LabelSwatch {
+  /** Human label for the color picker row ("Brown", "Orange", …). */
+  title: string
+  /** Chip background. */
+  bg: string
+  /** Chip text. */
+  fg: string
+}
+
+const SWATCHES: Record<KanbanLabelColor, LabelSwatch> = {
+  default: { title: 'Default', bg: 'rgba(255,255,255,0.10)', fg: 'rgba(255,255,255,0.88)' },
+  gray: { title: 'Gray', bg: '#5f6360', fg: '#e7e9e8' },
+  brown: { title: 'Brown', bg: '#61452b', fg: '#e8d0b8' },
+  orange: { title: 'Orange', bg: '#6b3f1d', fg: '#f0c19a' },
+  yellow: { title: 'Yellow', bg: '#63521f', fg: '#e7d089' },
+  green: { title: 'Green', bg: '#26503b', fg: '#9fd8b8' },
+  blue: { title: 'Blue', bg: '#22496b', fg: '#a6cdf0' },
+  purple: { title: 'Purple', bg: '#463063', fg: '#cbb0e8' },
+  pink: { title: 'Pink', bg: '#5e2f47', fg: '#eeb0cf' },
+  red: { title: 'Red', bg: '#642b28', fg: '#f0a9a2' }
+}
+
+/** Chip style for a label color (garbage → 'default'). */
+export function labelSwatch(color: unknown): LabelSwatch {
+  return SWATCHES[labelColor(color)]
+}
+
+/** The palette in picker order, each with its name + swatch. */
+export const LABEL_COLOR_OPTIONS: Array<{ color: KanbanLabelColor } & LabelSwatch> =
+  KANBAN_LABEL_COLORS.map((color) => ({ color, ...SWATCHES[color] }))

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Handle,
   NodeResizer,
@@ -61,6 +61,8 @@ import {
 import { FindBar } from '../components/FindBar'
 import { IconSearch, IconChat, IconMic, IconReload } from '../components/icons'
 import { NodeTags } from '../components/NodeTags'
+import { LabelChips } from '../components/kanban/LabelChips'
+import { labelsForCard } from '../lib/kanban'
 import { Tooltip } from '../components/Tooltip'
 import { useTerminalSearch } from '../terminal/useTerminalSearch'
 import { ContextMeter } from '../components/ContextMeter'
@@ -421,6 +423,16 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
   const mdMode = !!data.mdMode
   const collapsed = !!data.collapsed
   const tags = (data.tags as string[]) ?? []
+  // Kanban labels applied to this card, resolved from the ACTIVE project's board palette (a node
+  // only ever lives in the active project). Read the kanban ref reactively; resolve in a memo so a
+  // fresh array doesn't churn the selector.
+  const projectKanbanForLabels = useProjects(
+    (s) => s.projects.find((p) => p.id === s.activeProjectId)?.kanban
+  )
+  const kanbanLabels = useMemo(
+    () => (projectKanbanForLabels ? labelsForCard(projectKanbanForLabels, id) : []),
+    [projectKanbanForLabels, id]
+  )
   // Derive the node's agent once, through the shared helper — the canvas menu decides whether to
   // offer this node's in-place restart from the SAME derivation, and a second copy drifting from
   // this one yields a row whose closure refuses every click.
@@ -2041,6 +2053,10 @@ export function TerminalNode({ id, data, selected, parentId }: NodeProps<CanvasN
           onPrev={handlePrev}
           onClose={() => setSearchOpen(false)}
         />
+      )}
+
+      {kanbanLabels.length > 0 && (
+        <LabelChips labels={kanbanLabels} size="sm" className="term-node__labels nodrag" />
       )}
 
       {!collapsed && (

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7355,6 +7355,312 @@ body,
 }
 
 /* ---- Card metadata (Trello-style Members / Due date) ---- */
+/* ── Kanban labels (Notion-style) ── */
+.kanban-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.kanban-label-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border-radius: 4px;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.kanban-labels--sm .kanban-label-chip {
+  font-size: 10.5px;
+  padding: 1px 6px;
+}
+.kanban-labels--md .kanban-label-chip,
+.label-picker .kanban-label-chip {
+  font-size: 12px;
+  padding: 2px 8px;
+}
+.kanban-label-chip__x {
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: 0.65;
+  cursor: pointer;
+  padding: 0 0 0 1px;
+  font-size: 12px;
+  line-height: 1;
+}
+.kanban-label-chip__x:hover {
+  opacity: 1;
+}
+.kanban-card__labels {
+  margin: 4px 0 0 18px; /* align under the title, past the node dot */
+}
+.term-node__labels {
+  padding: 0 8px 4px;
+}
+.kanban-meta__row--labels {
+  position: relative;
+  align-items: center;
+  gap: 6px;
+}
+
+/* ── Label picker (create/assign/edit) ── */
+.label-picker__scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 58;
+}
+.label-picker__pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 59;
+}
+.label-picker {
+  width: 280px;
+  background: #202022;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.label-picker__input {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  min-height: 30px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  cursor: text;
+}
+.label-picker__search {
+  flex: 1;
+  min-width: 80px;
+  background: none;
+  border: none;
+  outline: none;
+  color: #fff;
+  font-size: 13px;
+}
+.label-picker__hint {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.4);
+  padding: 2px 2px 0;
+}
+.label-picker__list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+.label-picker__row {
+  display: flex;
+  align-items: center;
+  border-radius: 5px;
+}
+.label-picker__row:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+.label-picker__pick {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 5px 6px;
+  min-width: 0;
+}
+.label-picker__rowcheck {
+  margin-left: auto;
+  color: var(--accent);
+  font-size: 12px;
+}
+.label-picker__more {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 5px;
+  font-size: 15px;
+}
+.label-picker__more:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+.label-picker__create {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 5px;
+  font-size: 12.5px;
+  text-align: left;
+}
+.label-picker__create:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+/* edit panel */
+.label-picker__edithead {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.label-picker__back {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.label-picker__renameinput {
+  flex: 1;
+  border: none;
+  outline: none;
+  border-radius: 5px;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+.label-picker__delete {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 5px;
+  font-size: 12.5px;
+  text-align: left;
+}
+.label-picker__delete:hover {
+  background: rgba(255, 120, 120, 0.14);
+  color: #ff8f8f;
+}
+.label-picker__colhead {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.4);
+  padding: 4px 2px 0;
+}
+.label-picker__colors {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.label-picker__colorrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 5px 6px;
+  border-radius: 5px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 12.5px;
+}
+.label-picker__colorrow:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+.label-picker__swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+.label-picker__check {
+  margin-left: auto;
+  color: var(--accent);
+}
+
+/* ── Board label filter (header) ── */
+.kanban-header__filter {
+  position: relative;
+  margin-left: 12px;
+}
+.kanban-filter-btn {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+.kanban-filter-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+.kanban-filter-btn--on {
+  border-color: var(--accent);
+  color: #fff;
+}
+.kanban-filter-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 59;
+  width: 240px;
+  background: #202022;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.kanban-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 5px 6px;
+  border-radius: 5px;
+}
+.kanban-filter-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+.kanban-filter-clear {
+  margin-top: 4px;
+  background: none;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  padding: 6px;
+  font-size: 12px;
+  text-align: left;
+}
+.kanban-filter-clear:hover {
+  color: #fff;
+}
+
 .kanban-meta {
   flex: 0 0 auto;
   display: flex;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -261,6 +261,31 @@ export interface KanbanCardMeta {
   dueAt?: number
   /** Absent = no priority. */
   priority?: KanbanPriority
+  /** Ids of the board labels applied to this card (see ProjectKanban.labels). Absent/empty = none;
+   *  ids that no longer resolve to a label are dropped by readers (dangling-safe). */
+  labels?: string[]
+}
+
+/** The Notion label palette. A closed set so the chip colors and the picker can't desync; an
+ *  unknown value read from a hand-edited file falls back to 'default'. */
+export type KanbanLabelColor =
+  | 'default'
+  | 'gray'
+  | 'brown'
+  | 'orange'
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'purple'
+  | 'pink'
+  | 'red'
+
+/** A board-level label (Notion-style): defined once per board, applied to any number of cards by
+ *  id (KanbanCardMeta.labels). Order in ProjectKanban.labels is the palette's display order. */
+export interface KanbanLabel {
+  id: string
+  name: string
+  color: KanbanLabelColor
 }
 
 export interface ProjectKanban {
@@ -268,6 +293,9 @@ export interface ProjectKanban {
   assignments: KanbanAssignment[]
   /** Optional card metadata; tolerated as absent/malformed by every reader (lib normalizes). */
   meta?: KanbanCardMeta[]
+  /** Board-level label palette (Notion-style). Cards reference these by id in `meta[].labels`;
+   *  tolerated as absent/malformed by every reader. */
+  labels?: KanbanLabel[]
 }
 
 /** Who produced a board-log entry (a teammate on a shared board, or this user). */


### PR DESCRIPTION
Kanban cards can now carry **colored board labels**, Notion-style — as requested (renkli, anında oluştur-veya-ata, filtreli, `.nodeterm`'de kalıcı).

## What it does
- **Notion picker:** type to filter existing labels or **Create** one inline; click a row to assign/unassign; each label has a **⋯** menu → rename, recolor (10-color palette), delete.
- **Colored chips** show on the **card face**, the **card modal**, and the **canvas node**.
- **Filter** the board by label from a header control (OR semantics; transient per board session).
- **Persists** in `.nodeterm/project.json` (git-shared; rides the same rev/mirror/watcher as the rest of the board).

## Data model (`shared/types.ts`)
- `ProjectKanban.labels: {id, name, color}[]` — a board-level palette.
- `KanbanLabelColor` — the closed Notion palette (`default/gray/brown/orange/yellow/green/blue/purple/pink/red`); a garbage value from a hand-edited file falls back to `default`.
- `KanbanCardMeta.labels: string[]` — the label ids on a card (dangling-safe).

## Pure logic (`lib/kanban.ts`, **+9 unit tests**)
`createLabel` / `renameLabel` / `recolorLabel` / `deleteLabel` (also strips the id from every card) / `reorderLabels` / `toggleCardLabel` / `labelsForCard` (palette order, drops dangling) / `boardLabels` (tolerates a garbage array) / `cardMatchesLabelFilter` (empty = all, else OR). The existing meta writers now preserve `labels`. Colors→CSS in `lib/kanbanLabelColors.ts`. Like `meta`, `labels` is tolerated by readers, so `validKanban` is unchanged.

## Verification (Server-Edition drive)
- Create 2 labels (distinct auto-colors) → chips appear on the **card**, **modal picker**, and **canvas node**.
- Filter by a present label keeps the card; the hide case is covered by the unit test.
- `labels` palette + `meta.labels` **persisted to workspace.json**.
- ⋯ edit panel: rename input + all **10 colors** + delete; recolor applied live.
- Full suite green (**3048**), typecheck clean, both builds OK.

## Three surfaces
- **Desktop + Server Edition:** pure renderer + `workspace.save` (verified in browser).
- **v1 follow-ups (deliberate):** board-log integration for label add/remove, and the iOS board's label display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)