### PR TITLE
feat(kanban): card labels + priority/due/avatars share one row

### DIFF
--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -93,30 +93,35 @@ export function SessionCard({ session, status, meta, labels = [], onOpen, onDrag
         {badge === 'needs' && <span className="kanban-badge kanban-badge--needs">NEEDS YOU</span>}
         {status?.unread && <span className="kanban-card__unread" />}
       </div>
-      <LabelChips labels={labels} size="sm" className="kanban-card__labels" />
-      {(assignees.length > 0 || due !== undefined || priority !== undefined) && (
+      {(labels.length > 0 || assignees.length > 0 || due !== undefined || priority !== undefined) && (
         <div className="kanban-card__metarow">
-          {priority !== undefined && PRIO_COLOR[priority] && (
-            <span
-              className="kanban-due kanban-prio-chip"
-              style={{ background: `${PRIO_COLOR[priority]}26`, color: PRIO_COLOR[priority] }}
-            >
-              {priority.toUpperCase()}
-            </span>
-          )}
-          {due !== undefined && (
-            <span className={`kanban-due${overdue ? ' kanban-due--overdue' : ''}`}>
-              {new Date(due).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}
-            </span>
-          )}
-          <span className="kanban-card__avatars">
-            {assignees.slice(0, 3).map((a) => (
-              <span key={a.name} className="kanban-avatar kanban-avatar--sm" style={{ background: a.color }} title={a.name}>
-                {(a.name.trim()[0] ?? '?').toUpperCase()}
+          {/* Labels share the priority/due/avatars row (left); the meta chips hug the right. */}
+          <LabelChips labels={labels} size="sm" className="kanban-card__metalabels" />
+          <div className="kanban-card__metaright">
+            {priority !== undefined && PRIO_COLOR[priority] && (
+              <span
+                className="kanban-due kanban-prio-chip"
+                style={{ background: `${PRIO_COLOR[priority]}26`, color: PRIO_COLOR[priority] }}
+              >
+                {priority.toUpperCase()}
               </span>
-            ))}
-            {assignees.length > 3 && <span className="kanban-avatar kanban-avatar--sm kanban-avatar--more">+{assignees.length - 3}</span>}
-          </span>
+            )}
+            {due !== undefined && (
+              <span className={`kanban-due${overdue ? ' kanban-due--overdue' : ''}`}>
+                {new Date(due).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}
+              </span>
+            )}
+            {assignees.length > 0 && (
+              <span className="kanban-card__avatars">
+                {assignees.slice(0, 3).map((a) => (
+                  <span key={a.name} className="kanban-avatar kanban-avatar--sm" style={{ background: a.color }} title={a.name}>
+                    {(a.name.trim()[0] ?? '?').toUpperCase()}
+                  </span>
+                ))}
+                {assignees.length > 3 && <span className="kanban-avatar kanban-avatar--sm kanban-avatar--more">+{assignees.length - 3}</span>}
+              </span>
+            )}
+          </div>
         </div>
       )}
       {/* Detail line is ALWAYS visible when the card has something to say (no expand step):

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7853,11 +7853,23 @@ body,
 .kanban-card__metarow {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 6px 8px;
+  flex-wrap: wrap;
   margin-top: 7px;
 }
-.kanban-card__avatars {
+/* Labels take the left of the shared row and wrap; the priority/due/avatars hug the right. */
+.kanban-card__metalabels {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.kanban-card__metaright {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+.kanban-card__avatars {
   display: inline-flex;
   gap: 4px;
 }


### PR DESCRIPTION
Requested: on a board card the **label (tag) row** and the **priority row** were separate — put them on the same row.

The label chips and the priority/due/assignee chips lived on two stacked rows of a card. Now they share one **meta row**: labels flow on the left (wrapping), the priority / due / avatars hug the right (`margin-left:auto`). The row renders whenever the card has labels **or** any meta.

Server-Edition verified: a card with two labels (bug, backend) + a **HIGH** priority renders them on the same row (measured same top). Typecheck + build green; layout-only, no logic change.