### PR TITLE
fix(kanban): modal terminal's last row (TUI status bar) was clipped

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7198,7 +7198,10 @@ body,
    * visible height. */
   min-height: 0;
   overflow: hidden;
-  padding: 8px;
+  /* NO padding here: FitAddon measures THIS element's height but only subtracts the xterm
+   * element's own padding (0), not the host's — so an 8px inset here made it over-compute one
+   * extra row and `overflow:hidden` clipped the terminal's last line (a full-screen TUI's status
+   * bar vanished). The visual inset lives on the wrapper instead. */
 }
 
 /* ── Board log: the modal's "Comments & activity" panel (right 1/3) ── */
@@ -7315,8 +7318,10 @@ body,
   position: relative;
   flex: 1;
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
+  padding: 8px; /* the terminal's inset — off the FitAddon-measured host (see .kanban-modal__term) */
 }
 .kanban-modal__action[aria-pressed='true'] {
   background: var(--accent);


### PR DESCRIPTION
Reported: in a kanban card modal the **bottom of the terminal isn't visible** — a full-screen agent's status bar ("auto mode on…", below the input) is cut off under the modal edge.

## Root cause
`.kanban-modal__term` (the element FitAddon measures) had `padding: 8px` with `box-sizing: border-box`. FitAddon reads the host's height but subtracts only the **xterm element's** own padding (0), not the host's — so it over-computed **one extra row** (37 rows / 555px into a **543px** content box), and `overflow:hidden` clipped the ~12px overshoot: the terminal's **last line**. The 8px inset came in with the earlier sizing fix (#65) and this overshoot was missed (my measurement then compared heights without the padding).

## Fix
Move the visual inset onto the wrapper `.kanban-modal__termwrap` (which FitAddon does **not** measure) and leave the measured host padding-free.

## Verification (Server Edition)
- **Before:** 37 rows, xterm 555px overflows the 543px host by **+12px** → last row clipped.
- **After:** **36 rows**, xterm 540px in a 543px host → **-3px** (fits with slack, no clip). The last line is fully visible.

CSS-only; build green.