### PR TITLE
fix(kanban): label color picker didn't open (clipped by the list overflow)

### DIFF
--- a/src/renderer/components/kanban/LabelPicker.tsx
+++ b/src/renderer/components/kanban/LabelPicker.tsx
@@ -152,8 +152,9 @@ export function LabelPicker({
             </div>
           )
         })}
-        {canCreate && (
-          <div className="label-picker__createrow">
+      </div>
+      {canCreate && (
+        <div className="label-picker__createrow">
             <button
               className="label-picker__createcolor"
               title="Pick color"
@@ -190,9 +191,8 @@ export function LabelPicker({
                 ))}
               </div>
             )}
-          </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Reported: **"renk seçme yeri açılmıyor"** — clicking the color swatch on the **Create «name»** row in the label picker did nothing; the color dropdown never appeared.

## Root cause
The Create row lived **inside** `.label-picker__list` (`overflow-y: auto`). Its absolutely-positioned color menu extended past the list box and was **clipped away by the list's overflow**. It was in the DOM (a programmatic click could hit it — which is why my earlier drive test passed), but a real user couldn't see or click it.

## Fix
Move the Create row **out** of the scrollable list, as a sibling below it, so the color menu isn't inside the clip anymore.

## Verification (Server Edition, real click)
The 10-color menu now opens visibly (in-viewport, on top — `hitInside:true`), and picking **Red** turns the Create chip red. Typecheck + build green; markup-only.