### PR TITLE
fix(kanban): show the New-project (welcome) screen above the board

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7508,6 +7508,7 @@ export function Canvas() {
             onReopen={reopenProject}
             onDeleteClosed={deleteProject}
             onClose={hasProjects ? () => setWelcomeOpen(false) : undefined}
+            overBoard={kanbanOpen}
           />
         )}
 

--- a/src/renderer/components/WelcomeScreen.tsx
+++ b/src/renderer/components/WelcomeScreen.tsx
@@ -17,6 +17,12 @@ interface WelcomeScreenProps {
    * — adds a close button, Escape, and click-outside. Omitted for the permanent no-projects screen.
    */
   onClose?: () => void
+  /**
+   * Raise the screen above the kanban board overlay (z 25). Without this, opening "+" while a
+   * project is in kanban view left the (z 5) welcome screen painted BEHIND the opaque board, so
+   * nothing appeared. No effect on the canvas, where the welcome screen already sits on top.
+   */
+  overBoard?: boolean
 }
 
 /** Start screen with quick actions — shown when there are no projects, or on demand via "+". */
@@ -28,7 +34,8 @@ export function WelcomeScreen({
   closedProjects = [],
   onReopen,
   onDeleteClosed,
-  onClose
+  onClose,
+  overBoard
 }: WelcomeScreenProps) {
   useEffect(() => {
     if (!onClose) return
@@ -41,7 +48,7 @@ export function WelcomeScreen({
 
   return (
     <div
-      className="welcome"
+      className={overBoard ? 'welcome welcome--over-board' : 'welcome'}
       onClick={onClose ? (e) => e.target === e.currentTarget && onClose() : undefined}
     >
       {onClose && (

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2259,6 +2259,13 @@ body,
   background: var(--canvas-bg);
 }
 
+/* Opened via "+" while a project is in kanban view: the board overlay (z 25) is opaque and would
+   hide the default z-5 welcome screen. Lift it above the board + controls (26) + banners (27), but
+   keep it below the tab bar (30) so tabs stay reachable — same relative stacking as on the canvas. */
+.welcome--over-board {
+  z-index: 28;
+}
+
 .welcome__brand {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Problem

The tab bar's **+** button opens the welcome / start screen (New project, Open folder…, Clone repo…, Connect over SSH…). But while a project is in **kanban view**, clicking **+** did nothing visible — the new-project page never appeared, unlike on the canvas.

**Cause:** `.welcome` has `z-index: 5`, which sits below the canvas (fine there). The kanban board, however, is an **opaque overlay at z 25**. So the welcome screen did open — it was just painted *behind* the board.

## Fix

- Add an `overBoard` prop to `WelcomeScreen` (mirrors `UsageIndicator`'s), which applies a `welcome--over-board` modifier.
- `.welcome--over-board { z-index: 28 }` — above the board (25), controls cluster (26) and banners (27), still **below the tab bar (30)** so tabs stay reachable — the same relative stacking the welcome screen has on the canvas.
- Canvas behavior is **untouched**: the modifier is only applied when `kanbanOpen`.

## Testing

- `npm run typecheck` + `npm run build` clean.
- Server Edition drive: opened a project in kanban view → clicked the tab bar **+** → the welcome screen now renders full-screen at **z 28**, is the topmost element (hit-test), and all four action cards are visible. Real-clicking **New project** created a second project and dismissed the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
