### PR TITLE
fix(settings): fix custom agents on a plain-http server

### DIFF
--- a/src/renderer/components/settings/sections/CustomAgentsSection.test.tsx
+++ b/src/renderer/components/settings/sections/CustomAgentsSection.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { CustomAgentsSection } from './CustomAgentsSection'
+
+// Standalone harness — react-dom + the real zustand settings store, no
+// testing-library dependency. Each agent card is identified by a "Remove" button.
+function renderSection(): { host: HTMLElement; root: Root } {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  act(() => {
+    root.render(<CustomAgentsSection isActive />)
+  })
+  return { host, root }
+}
+
+function addButton(host: HTMLElement): HTMLButtonElement {
+  const btn = Array.from(host.querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === 'Add agent'
+  )
+  expect(btn).toBeTruthy()
+  return btn as HTMLButtonElement
+}
+
+function agentCards(host: HTMLElement): number {
+  return (host.textContent!.split('Remove').length - 1)
+}
+
+describe('CustomAgentsSection add agent', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('adds a new agent card when Add agent is clicked', () => {
+    const { host, root } = renderSection()
+    const before = agentCards(host)
+    act(() => {
+      addButton(host).click()
+    })
+    expect(agentCards(host)).toBe(before + 1)
+    root.unmount()
+  })
+
+  it('adds a card even when crypto.randomUUID is unavailable (plain-HTTP server)', () => {
+    // Regression for CustomAgentsSection's original crypto.randomUUID() call: that is
+    // secure-context-only, so the Server Edition on a LAN (plain http) threw on click,
+    // and "Add agent" appeared to do nothing. getRandomValues is available everywhere.
+    const desc = Object.getOwnPropertyDescriptor(window.crypto, 'randomUUID')
+    Object.defineProperty(window.crypto, 'randomUUID', {
+      value: undefined,
+      configurable: true
+    })
+    const { host, root } = renderSection()
+    const before = agentCards(host)
+    try {
+      act(() => {
+        addButton(host).click()
+      })
+      expect(agentCards(host)).toBe(before + 1)
+    } finally {
+      if (desc) Object.defineProperty(window.crypto, 'randomUUID', desc)
+    }
+    root.unmount()
+  })
+})

--- a/src/renderer/components/settings/sections/CustomAgentsSection.tsx
+++ b/src/renderer/components/settings/sections/CustomAgentsSection.tsx
@@ -7,6 +7,7 @@ import { FieldRow } from '../FieldRow'
 import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
 import { Select } from '@renderer/ui/Select'
+import { uuid } from '@renderer/lib/uuid'
 
 const ROWS = {
   custom: { title: 'Custom agents', keywords: ['custom', 'agent', 'cli', 'byo', 'aider'] }
@@ -25,7 +26,7 @@ export function CustomAgentsSection({ isActive }: { isActive: boolean }): React.
       customAgents: [
         ...customAgents,
         {
-          id: 'custom:' + crypto.randomUUID(),
+          id: 'custom:' + uuid(),
           label: 'Custom agent',
           launchCmd: '',
           promptInjectionMode: 'argv'

--- a/src/renderer/components/settings/sections/SshSection.tsx
+++ b/src/renderer/components/settings/sections/SshSection.tsx
@@ -6,6 +6,7 @@ import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
 import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
+import { uuid } from '@renderer/lib/uuid'
 
 const ROWS = {
   servers: {
@@ -44,7 +45,7 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
       const fresh = withUser.filter((c) => !seen.has(key(c)))
       for (const c of fresh) {
         await useSshServers.getState().save({
-          id: crypto.randomUUID(),
+          id: uuid(),
           label: c.label,
           host: c.host,
           user: c.user as string,
@@ -206,7 +207,7 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
               <Button
                 onClick={() =>
                   setSshDraft({
-                    id: crypto.randomUUID(),
+                    id: uuid(),
                     label: '',
                     host: '',
                     user: '',

--- a/src/renderer/lib/uuid.test.ts
+++ b/src/renderer/lib/uuid.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { uuid } from './uuid'
+
+describe('uuid', () => {
+  it('returns an RFC 4122 v4-shaped uuid', () => {
+    const id = uuid()
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    )
+  })
+
+  it('returns unique ids', () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => uuid()))
+    expect(ids.size).toBe(1000)
+  })
+
+  it('works without crypto.randomUUID (plain-http / insecure contexts)', () => {
+    // The Server Edition on a LAN is not a secure context: randomUUID is
+    // secure-context-only, getRandomValues is not. Simulate that environment.
+    const desc = Object.getOwnPropertyDescriptor(globalThis.crypto, 'randomUUID')
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      value: undefined,
+      configurable: true
+    })
+    try {
+      expect(() => uuid()).not.toThrow()
+      expect(uuid()).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      )
+    } finally {
+      if (desc) Object.defineProperty(globalThis.crypto, 'randomUUID', desc)
+    }
+  })
+})

--- a/src/renderer/lib/uuid.ts
+++ b/src/renderer/lib/uuid.ts
@@ -1,0 +1,17 @@
+/**
+ * RFC 4122 v4 UUID from crypto.getRandomValues.
+ *
+ * `crypto.randomUUID()` exists only in secure contexts (HTTPS / localhost), so it is
+ * undefined in the Server Edition served over plain HTTP on a LAN — a click that calls
+ * it throws silently and nothing happens. `crypto.getRandomValues` is available in
+ * every context, so this helper works identically in Electron, the browser server, and
+ * tests. Keep using it for ids that must not depend on the page's context.
+ */
+export function uuid(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  bytes[6] = (bytes[6] & 0x0f) | 0x40 // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80 // variant 10
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}

--- a/src/renderer/state/boardLog.ts
+++ b/src/renderer/state/boardLog.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { BOARD_LOG_TEXT_MAX, type BoardLogEntry, type NodeTerminalApi } from '@shared/types'
 import { loadIdentity } from './presence'
+import { uuid } from '../lib/uuid'
 
 /**
  * Board-log store — the renderer view of a project's append-only board history
@@ -77,7 +78,7 @@ export const useBoardLog = create<BoardLogState>((set, get) => ({
         ? input.text.slice(0, BOARD_LOG_TEXT_MAX) + '…'
         : input.text
     const entry: BoardLogEntry = {
-      id: crypto.randomUUID(),
+      id: uuid(),
       ts: Date.now(),
       author,
       kind: input.kind,


### PR DESCRIPTION
## What broke

On the Server Edition served over plain HTTP on a LAN, a click in three settings surfaces silently did nothing:

- **Custom agents → Add agent** — no new agent card appeared
- **Remote (SSH) → import from SSH / new server draft** — no row appeared
- **Board log** (`src/renderer/state/boardLog.ts`) — an entry wasn't created

**Root cause:** the renderer called `crypto.randomUUID()`, which is defined only in *secure contexts* (HTTPS or `localhost`). A LAN host reached over plain `http://<ip>:8443` is not a secure context, so `crypto.randomUUID` is `undefined` there and the call throws silently. The whole point of the Server Edition is to serve over plain HTTP (the app's own `--insecure-http` flag), so any code that needs an id must not assume a secure context.

## The fix

1. Add `src/renderer/lib/uuid.ts` — an RFC 4122 v4 generator built on `crypto.getRandomValues()`, which is available in every context, including insecure ones.
2. Swap the four `crypto.randomUUID()` call sites in `CustomAgentsSection`, `SshSection` (×2), and `boardLog` to the new `uuid()` helper.
3. Add tests:
   - `src/renderer/lib/uuid.test.ts` — v4 shape, uniqueness (1000 ids), and the insecure-context regression (`randomUUID` deleted, `uuid()` still works).
   - `src/renderer/components/settings/sections/CustomAgentsSection.test.tsx` — clicking Add agent commits a card, including under the insecure-context regression.

**Tradeoff:** no entropy/quality loss — the helper produces the same 16 random bytes with version/variant bits set as `randomUUID()`; it simply doesn't depend on the page being a secure context.

## Measured

- Live on the real LAN address over plain HTTP (browser reported `isSecureContext: false`, `typeof crypto.randomUUID === 'undefined'`): clicking **Add agent** now appends a card. Repeated clicks with an error-capture hook installed produced **zero** exceptions.
- Note: `127.0.0.1` is *not* a valid repro — browsers treat loopback as a secure context where `randomUUID` exists; the bug only reproduces on the actual LAN IP, which is how it slipped through.

## Also covered en route

Same root cause, so I moved the SSH import + board-log ids to the same helper rather than leave two more broken surfaces behind. Happy to split any of these into a separate PR if the maintainer prefers.

## Not in scope

- Local-HTTP hardening or TLS — this makes the plain-HTTP LAN workflow *work*, not secure it.
- `SshSection`'s import parser or any other SSH behavior — only the id-generation bug is touched.

## Testing

- `npm run typecheck` — pass
- New/affected tests — **5/5** pass, including the insecure-context regression (RED→GREEN).
- `npm run build` — pass
- Full suite: green when run with a free port. One environmental note: `test/server/headless-e2e.test.ts` asserts port `8443` is free, so it's red whenever a local Server Edition is running — this reproduces identically on a clean `main` checkout and is unrelated to this change (confirmed in the prior session).

## References

- MDN, [`Crypto.randomUUID()` secure-context requirement]
- MDN, [`Crypto.getRandomValues()` — available in all contexts]
- Project precedent for documenting contextual behavior: `docs/SERVER.md` (`--insecure-http`).