### PR TITLE
fix(agents): hold NEEDS YOU through codex request_user_input turn end

### DIFF
--- a/src/core/agent-status-mirror.test.ts
+++ b/src/core/agent-status-mirror.test.ts
@@ -1604,3 +1604,77 @@ describe('consecutive asks (answered on the desktop)', () => {
     un()
   })
 })
+
+describe('reduceEntry — codex request_user_input hold (awaitingInput)', () => {
+  const ask = (): NormalizedAgentEvent =>
+    ev({ agentId: 'codex', kind: 'state', state: 'waiting', awaitingInput: true })
+
+  it('holds waiting through the turn-end done that follows an unanswered ask', () => {
+    const a = reduceEntry(undefined, ask(), 1000)
+    expect(a.state).toBe('waiting')
+    expect(a.awaitingInput).toBe(true)
+    const b = reduceEntry(a, ev({ agentId: 'codex', kind: 'state', state: 'done' }), 2000)
+    expect(b.state).toBe('waiting')
+    expect(b.awaitingInput).toBe(true)
+  })
+
+  it('the answer (a genuine new turn) releases the hold; the NEXT done lands normally', () => {
+    let e = reduceEntry(undefined, ask(), 1000)
+    e = reduceEntry(e, ev({ agentId: 'codex', kind: 'state', state: 'done' }), 2000)
+    e = reduceEntry(e, ev({ agentId: 'codex', kind: 'state', state: 'working', newTurn: true }), 3000)
+    expect(e.state).toBe('working')
+    expect(e.awaitingInput).toBeFalsy()
+    e = reduceEntry(e, ev({ agentId: 'codex', kind: 'state', state: 'done' }), 4000)
+    expect(e.state).toBe('done')
+  })
+
+  it('an interrupt clears the ask (the user was right there)', () => {
+    const a = reduceEntry(undefined, ask(), 1000)
+    const b = reduceEntry(
+      a,
+      ev({ agentId: 'codex', kind: 'state', state: 'done', interrupted: true }),
+      2000
+    )
+    expect(b.state).toBe('done')
+    expect(b.awaitingInput).toBeFalsy()
+  })
+
+  it('other tool activity supersedes the ask', () => {
+    const a = reduceEntry(undefined, ask(), 1000)
+    const b = reduceEntry(a, ev({ agentId: 'codex', kind: 'state', state: 'working' }), 2000)
+    expect(b.awaitingInput).toBeFalsy()
+    const c = reduceEntry(b, ev({ agentId: 'codex', kind: 'state', state: 'done' }), 3000)
+    expect(c.state).toBe('done')
+  })
+
+  it('a session boundary resets the hold', () => {
+    const a = reduceEntry(undefined, ask(), 1000)
+    const b = reduceEntry(a, ev({ agentId: 'codex', kind: 'session', sessionPhase: 'end' }), 2000)
+    expect(b.state).toBeUndefined()
+    expect(b.awaitingInput).toBeFalsy()
+  })
+})
+
+describe('recordAgentEvent — codex request_user_input broadcast conversion', () => {
+  let dir: string
+  let file: string
+
+  beforeEach(() => {
+    _resetForTest()
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-status-'))
+    file = path.join(dir, 'agent-status.json')
+    initAgentStatusMirror(file)
+  })
+
+  afterEach(() => {
+    _resetForTest()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('rewrites the held turn-end done to waiting, so every consumer agrees', () => {
+    recordAgentEvent(ev({ agentId: 'codex', state: 'waiting', awaitingInput: true }))
+    const out = recordAgentEvent(ev({ agentId: 'codex', state: 'done' }))
+    expect(out.state).toBe('waiting')
+    expect(_snapshot().n1.state).toBe('waiting')
+  })
+})

--- a/src/core/agent-status-mirror.ts
+++ b/src/core/agent-status-mirror.ts
@@ -50,6 +50,10 @@ export interface MirrorEntry {
    * events), left alone by identity-only (subagent/recurring) events and holdoff-ignored ones.
    */
   updatedAt: number
+  /** An unanswered Codex `request_user_input` is pending on this node: its turn-end `done`
+   *  must be held as `waiting` (see reduceEntry). Cleared by anything that supersedes the
+   *  ask — a new turn, other tool activity, an interrupt, or a session boundary. */
+  awaitingInput?: boolean
 }
 
 /** This host's Server-Edition install metadata (spec: server-update). Written by the installer
@@ -306,6 +310,21 @@ export function reduceEntry(
     // move a node that is still `working`. A node that is blocked/waiting is ALSO idle at the
     // prompt — clearing it there would drop a live approval — and one already done needs nothing.
     if (ev.idle && prev?.state !== 'working') return next
+    // An unanswered Codex `request_user_input`: the ask arrives as waiting+awaitingInput and the
+    // turn's OWN Stop follows as `done` before the user answers (the ask ends the turn; the answer
+    // opens a new one). That done must not flip the node green over a live question — hold
+    // `waiting`. Anything else supersedes the ask: a new turn (the answer), other tool activity,
+    // an interrupt (the user was right there), a session boundary — all drop the flag, keeping the
+    // stuck-NEEDS-YOU failure mode this file already defends against (see the `idle` rules) out.
+    if (ev.awaitingInput) {
+      next.awaitingInput = true
+    } else if (prev?.awaitingInput && ev.state === 'done' && !ev.interrupted) {
+      next.state = 'waiting'
+      next.updatedAt = now
+      return next
+    } else {
+      next.awaitingInput = undefined
+    }
     // Done-holdoff: a late, non-newTurn `working` (out-of-order parallel hook, or an in-flight
     // tool POST at interrupt) must not resurrect a turn that just finished. Only a genuine new
     // turn (UserPromptSubmit) may. Leave state + updatedAt untouched so the window keeps
@@ -322,6 +341,7 @@ export function reduceEntry(
   } else if (ev.kind === 'session') {
     // SessionStart / SessionEnd both reset the node to idle (renderer: setState(id, undefined)).
     next.state = undefined
+    next.awaitingInput = undefined
     next.updatedAt = now
   }
   // subagent-start / subagent-end / recurring: identity captured above, main state untouched.
@@ -1059,13 +1079,20 @@ export function recordAgentEvent(ev: NormalizedAgentEvent): NormalizedAgentEvent
   const prevState = prev?.state
   const next = reduceEntry(prev, ev, now)
   state.set(nodeId, next)
-  const classification = produceInboxFromState(nodeId, ev, prevState, next.state, now)
+  // reduceEntry held an unanswered `request_user_input` through its turn-end `done` — rewrite
+  // the broadcast to what the reducer decided, so every consumer (canvas store, notch, phone)
+  // agrees the node is still waiting rather than each re-deriving it from the raw done.
+  let out = ev
+  if (ev.kind === 'state' && ev.state === 'done' && next.awaitingInput && next.state === 'waiting') {
+    out = { ...ev, state: 'waiting' }
+  }
+  const classification = produceInboxFromState(nodeId, out, prevState, next.state, now)
   scheduleWrite()
-  if (!classification) return ev
+  if (!classification) return out
   // Enrich the broadcast event from the SAME classification the inbox used. A question drops
   // pendingId (approve/deny is wrong UX for a picker); an approval keeps ev.pendingId as-is.
-  if (classification.kind === 'question') return { ...ev, askKind: 'question', pendingId: undefined }
-  return { ...ev, askKind: 'approval' }
+  if (classification.kind === 'question') return { ...out, askKind: 'question', pendingId: undefined }
+  return { ...out, askKind: 'approval' }
 }
 
 /**

--- a/src/shared/agents/normalize.test.ts
+++ b/src/shared/agents/normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeClaude, normalizeFor, type RawHookEnvelope } from './normalize'
+import { normalizeClaude, normalizeCodex, normalizeFor, type RawHookEnvelope } from './normalize'
 
 function env(payload: Record<string, unknown>): RawHookEnvelope {
   return { nodeId: 'n1', agentId: 'claude', payload }
@@ -239,5 +239,42 @@ describe('normalizeOpencode', () => {
 
   it('ignores unknown events', () => {
     expect(normalizeFor('opencode', ocEnv({ event: 'tui.toast.show' }))).toBeNull()
+  })
+})
+
+describe('normalizeCodex — request_user_input (ask-the-user)', () => {
+  function cenv(payload: Record<string, unknown>): RawHookEnvelope {
+    return { nodeId: 'n1', agentId: 'codex', payload }
+  }
+
+  it('PreToolUse(request_user_input) → waiting + awaitingInput, carrying the question', () => {
+    const e = normalizeCodex(
+      cenv({
+        hook_event_name: 'PreToolUse',
+        session_id: 's1',
+        tool_name: 'request_user_input',
+        tool_input: { questions: [{ question: 'Choose A or B?' }] }
+      })
+    )
+    expect(e).toMatchObject({
+      kind: 'state',
+      state: 'waiting',
+      awaitingInput: true,
+      lastMessage: 'Choose A or B?',
+      sessionId: 's1'
+    })
+  })
+
+  // The ask ends the turn; a PostToolUse for the ask itself is an immediate ack, not the
+  // user's answer (that arrives as a fresh UserPromptSubmit) — it must not clear the ask.
+  it('PostToolUse(request_user_input) → null (must not clear the ask)', () => {
+    const e = normalizeCodex(cenv({ hook_event_name: 'PostToolUse', tool_name: 'request_user_input' }))
+    expect(e).toBeNull()
+  })
+
+  it('other tool events still map to working, without the flag', () => {
+    const e = normalizeCodex(cenv({ hook_event_name: 'PreToolUse', tool_name: 'shell' }))
+    expect(e).toMatchObject({ kind: 'state', state: 'working' })
+    expect(e?.awaitingInput).toBeFalsy()
   })
 })

--- a/src/shared/agents/normalize.ts
+++ b/src/shared/agents/normalize.ts
@@ -17,6 +17,12 @@ export interface NormalizedAgentEvent {
   // move a node that is still `working` (see reduceEntry / the Canvas listener), because a
   // pending approval/question is also "idle at the prompt" and must not be cleared by it.
   idle?: boolean
+  // waiting only (Codex `request_user_input`): the turn ENDS (Stop fires) with this question
+  // still unanswered — the answer arrives as a fresh UserPromptSubmit, not a tool result — so
+  // reduceEntry must hold `waiting` through that turn-end `done` instead of letting it flip
+  // the node to a green "done" over a blocked session. Cleared by the next genuine turn, any
+  // other tool activity, an interrupt, or a session boundary (see reduceEntry).
+  awaitingInput?: boolean
   // true only for a genuine new turn (Claude UserPromptSubmit), so the renderer can
   // clear per-turn fan-out without clearing on every mid-turn tool event.
   newTurn?: boolean
@@ -250,12 +256,15 @@ export function normalizeClaude(env: RawHookEnvelope): NormalizedAgentEvent | nu
 }
 
 // Codex hook payload. Event name is read defensively; codex emits a session id under
-// `session_id`.
+// `session_id`. Tool events carry `tool_name`/`tool_input` (same shape as Claude's —
+// codex-rs/hooks serializes them on pre_tool_use/post_tool_use).
 interface CodexPayload {
   hook_event_name?: string
   hookEventName?: string
   session_id?: string
   prompt?: string
+  tool_name?: string
+  tool_input?: { prompt?: string; question?: string; questions?: { question?: string }[] }
 }
 
 export function normalizeCodex(env: RawHookEnvelope): NormalizedAgentEvent | null {
@@ -267,6 +276,24 @@ export function normalizeCodex(env: RawHookEnvelope): NormalizedAgentEvent | nul
   // per-turn fan-out once per turn, not on every tool event.
   if (ev === 'UserPromptSubmit') {
     return { ...base, kind: 'state', state: 'working', newTurn: true }
+  }
+  // `request_user_input` is Codex's ask-the-user tool, and it is NOT a blocking tool: the
+  // turn ENDS (Stop fires) with the question still unanswered, and the answer arrives as a
+  // fresh UserPromptSubmit. Mapping its tool-start to `working` left the node lit green as
+  // "done" while the agent sat on a question (observed live, codex-cli 0.145.0). Emit
+  // `waiting` + `awaitingInput` so reduceEntry can hold the ask through the turn-end Stop.
+  if (p.tool_name === 'request_user_input' && (ev === 'PreToolUse' || ev === 'PostToolUse')) {
+    // A PostToolUse for the ask itself (an immediate ack) must not clear the ask.
+    if (ev === 'PostToolUse') return null
+    const q = p.tool_input
+    const question = q?.questions?.[0]?.question ?? q?.question ?? q?.prompt
+    return {
+      ...base,
+      kind: 'state',
+      state: 'waiting',
+      awaitingInput: true,
+      ...(question ? { lastMessage: question } : {})
+    }
   }
   // SessionStart + tool events keep the node "working".
   if (ev === 'SessionStart' || ev === 'PreToolUse' || ev === 'PostToolUse') {


### PR DESCRIPTION
## The lie

Codex's `request_user_input` is its ask-the-user tool, and it does not behave like a blocking tool: the **turn ends** — `Stop` fires — with the question still unanswered, and the answer arrives later as a fresh `UserPromptSubmit`. Because `normalizeCodex` maps every tool-start to `working`, the sequence lands as `working` → `done`: the node (and the notch) light **green/"done" while the agent is sitting on a question**.

Observed live on macOS with codex-cli 0.145.0: prompt Codex with *"Call request_user_input to ask me to choose A or B; do not continue until I answer"* → the notch shows a persistent green light while the terminal sits on "Choose A or B?". For anyone triaging red-before-green, a blocked agent hides behind a completed-looking dot. (For what it's worth, this tool's needs-you design is the reason I adopted nodeterm this week — this was the one badge I caught lying.)

## The fix

Follows the grammar this codebase already uses for tricky signals (the `idle_prompt` rescue): the normalizer stays pure and emits a richer event; the reducer owns the transition rule; the funnel broadcasts what the reducer decided.

- **`normalizeCodex`**: `PreToolUse` with `tool_name === 'request_user_input'` → `waiting` + a new `awaitingInput` flag, carrying the question text as `lastMessage` (codex-rs serializes `tool_name`/`tool_input` on tool events). Its own `PostToolUse` (an immediate ack) maps to `null` so it cannot clear the ask.
- **`reduceEntry`**: a non-interrupted `done` arriving while `awaitingInput` is up holds `waiting` instead of flipping green. The flag drops on anything that genuinely supersedes the ask — a real new turn (the answer), any other tool activity, an interrupt, a session boundary — biased exactly like the existing idle rules: never risk a stuck NEEDS YOU.
- **`recordAgentEvent`**: rewrites that held `done` to `waiting` in the returned/broadcast event, so the canvas store, notch, and phone mirror all agree without re-deriving it.

## Testing

- 9 new tests: the `normalizeCodex` mapping (3, first coverage for the codex normalizer) and the reducer hold/release lifecycle + broadcast conversion (6).
- Full suite: 3,941 passed / 8 skipped, `npm run typecheck` clean.
- Live repro above validated manually before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5mnWs5R1SSDtsKXG8gZnC