### PR TITLE
feat(grok): the RUNNING indicator is the brand mark breathing, not a critter

### DIFF
--- a/docs/grok-agent.md
+++ b/docs/grok-agent.md
@@ -316,7 +316,7 @@ ai-name / comments).
 | Context meter | **not implemented for grok** (§1) | idem | idem |
 | Managed accounts | **deliberately N/A** — accounts are a claude config-dir mechanism. `createAgentNode` never stamps an `accountId` onto a non-claude node, and `CLAUDE_CONFIG_DIR` is irrelevant to `~/.grok/hooks`. A grok node in a managed-account project must still report status (checklist 7) | idem | idem |
 | Brand logo | the **official** xAI mark, INLINED in `agentIcons.tsx` as `GrokMark` rather than shipped as an asset — it is a single monochrome path, so `fill="currentColor"` inherits the label colour and is correct in both themes. The other four marks are multi-colour and stay `<img src>` assets, where `currentColor` cannot inherit | same component, for free | the phone draws its own icons — **follow-up owed** |
-| Notch mascot | yes — its own mid-slate (`#8494a8`) critter through the shared `buildQuadrantSprite`; the CSS rule block is *shared* with claude's, so the geometry cannot drift | **N/A** — there is no notch there; the canvas badge mascot works | the phone has its own SwiftUI renderer |
+| Working indicator | the **brand mark, breathing** — no critter. `AgentMascot` renders the same `GrokMark` the menus use, pulsing with a `currentColor` drop-shadow bloom, and the notch strip builds the identical glyph from `lib/grokMark.ts` (`createGrokMarkSvg`), so one agent is never two things on two surfaces | **N/A** — no notch there; the canvas badge indicator works | the phone has its own SwiftUI renderer |
 | Fullscreen TUI setting | **N/A** — grok runs full-screen by default, so `claude-tui.ts` has no grok analogue | idem | idem |
 | Deterministic hook-reply approvals (phone Approve/Deny) | **claude-only** — `pty-manager` arms `NODETERM_PERM_WAIT_SECS` only for claude, and grok does not subscribe `PermissionRequest` at all | idem | a grok node's approvals are not answerable from the phone |
 | Kanban card + card modal | badges and the 💬 comments panel work (derived from the same nodes and the same status store); the meter row has nothing to show for grok | same | the iOS board is a separate read/move mirror |
@@ -516,7 +516,8 @@ Surfaces
     confirm the node title does NOT adopt grok's session name there (readSessionName is stubbed).
 28. Phone: does a grok node appear in the inbox with the right state? Its "what it's doing now"
     activity line will be absent (§8.3).
-29. macOS notch: does the grok mascot walk while it works?
+29. macOS notch: does the grok mark pulse and bloom while it works, on the black capsule, next to
+    claude's walking critter without looking out of place?
 30. Kanban board + card modal: badges and the 💬 comments panel on a grok card (the meter row has
     nothing to show).
 
@@ -547,7 +548,10 @@ Two traps with no code fix — appended so the numbering above stays stable
     `fill="currentColor"` (§8.8), so readability is guaranteed by construction — it takes the label
     colour, black-on-light and white-on-dark, the way xAI uses it. What is *not* guaranteed is
     legibility at that size: it is a fine diagonal glyph, and thin strokes can turn to mush where the
-    other four marks (heavier, multi-colour) do not. Look at the pane submenu, the Dock `+`, the
+    other four marks (heavier, multi-colour) do not. **The same glyph is also the RUNNING indicator**
+    (§7, pulsing with a bloom), so check it there too, in both themes — the badge sits on
+    `--panel-header`, which is the light surface where a `currentColor` bloom has the least to work
+    with. Look at the pane submenu, the Dock `+`, the
     command palette and Settings → Agents, and flip the theme. If it reads as a smudge, the fix is a
     size-specific viewBox nudge, not a colour change.
 ```

--- a/docs/mascot-sprites.md
+++ b/docs/mascot-sprites.md
@@ -28,26 +28,24 @@ Quadrant char → (UL, UR, LL, LR) sub-pixel bits:
 - **Walk**: frame index = `floor(t × 2.5) % 2` (≈ 2.5 steps/s).
 - **Bob**: vertical offset alternates with the frame (±0.5–1.5 px scaled to render size).
 
-## Grok mascot (same machinery, original critter)
+## Grok — the brand mark, breathing (no critter)
 
-An ORIGINAL pixel critter — not a brand mark, and deliberately a different silhouette from the
-Claude one (narrow head with two antenna pixels that swap sides, wider body), on the same 9×3
-quadrant grid so the geometry and the walk are shared verbatim. The FEET row is byte-identical to
-Claude's in both frames — the shared walk is the point, and it is what keeps the two critters
-stepping in the same rhythm:
+Grok has **no sprite**. It had an original quadrant critter first; standing next to two real
+mascots it read as neither, so the working indicator became the glyph grok actually has — its
+official mark, pulsing with a bloom instead of walking.
 
-```
-frame 0:  "▘ ▐███▌ ▝" / " ▙█████▟ " / "  ▘▘ ▝▝  "
-frame 1:  "▝ ▐███▌ ▘" / " ▙█████▟ " / "  ▝▝ ▘▘  "
-```
-
-- Color: `#8494a8`, a mid-tone. The badge lives in the node HEADER (`--panel-header`), which is
-  `#323232` dark but `#eae5db` LIGHT, so the sprite must survive both themes plus the notch
-  capsule's black. Measured contrast (dark / light / notch): this `4.14 / 2.47 / 6.78` vs Claude
-  coral's `4.11 / 2.49 / 6.73` — same balance. A light slate-300 reads 8.64 dark but **1.18
-  light**, i.e. invisible in a shipped theme; the node color `#64748b` reads only 2.69 dark.
-- Both sprites go through `buildQuadrantSprite(frames, color)` in `src/renderer/lib/mascot.ts`
-  and reuse `CLAUDE_FRAME_WIDTH/HEIGHT`, so they cannot drift on aspect ratio or smoothing.
+- Geometry + path: `src/renderer/lib/grokMark.ts`, shared by the React badge (`AgentMascot` via
+  `GrokMark`) and the notch HUD, which builds DOM imperatively (`createGrokMarkSvg`). One source, so
+  the two surfaces cannot show different marks.
+- The mark is a single monochrome path painted in `currentColor`, and the **bloom is a drop-shadow of
+  that same colour**. That is what makes it theme-correct with no ink of its own: light-on-dark in
+  the dark theme and on the notch's black capsule, dark-on-light in the light theme. A fixed glow
+  colour would have vanished into one of the two backgrounds — the trap the retired sprite had to
+  solve with a measured mid-tone.
+- Two shadows, tight + wide (`0 0 1px` + `0 0 4px`): the tight one keeps the thin diagonal strokes
+  from washing out at 13–16 px, the wide one is the glow.
+- `prefers-reduced-motion` freezes it at the LIT end of the cycle, so a working node reads as awake
+  rather than dimmed.
 
 ## Codex pet (spritesheet asset)
 

--- a/src/renderer/hud/hud.css
+++ b/src/renderer/hud/hud.css
@@ -140,13 +140,35 @@ body {
   image-rendering: pixelated;
   will-change: background-position, transform;
 }
-/* Claude + Grok share the quadrant-sprite geometry (see lib/mascot.ts) — one rule block. */
-.mascot--claude,
-.mascot--grok {
+.mascot--claude {
   width: var(--mascot-w);
   height: var(--mascot-h);
   background-size: calc(var(--mascot-w) * 2) var(--mascot-h);
   animation: mascot-walk-claude 0.8s steps(1) infinite;
+}
+/* Grok is the brand mark breathing, not a sprite — same treatment as the canvas badge. The bloom is
+   a drop-shadow of `currentColor`, so it needs no ink of its own; on this strip that resolves
+   against --capsule-bg (#000), which is why it reads as a glow here. */
+.mascot--grok {
+  animation: mascot-pulse-grok 1.6s ease-in-out infinite;
+}
+@keyframes mascot-pulse-grok {
+  0%,
+  100% {
+    opacity: 0.55;
+    filter: none;
+  }
+  50% {
+    opacity: 1;
+    filter: drop-shadow(0 0 1px currentColor) drop-shadow(0 0 4px currentColor);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mascot--grok {
+    animation: none;
+    opacity: 1;
+    filter: drop-shadow(0 0 1px currentColor);
+  }
 }
 @keyframes mascot-walk-claude {
   0% {

--- a/src/renderer/hud/main.ts
+++ b/src/renderer/hud/main.ts
@@ -4,7 +4,8 @@
 // and row clicks to focus the node in nodeterm.
 
 import './hud.css'
-import { CLAUDE_MASCOT, CODEX_MASCOT, DONE_BLOB, GROK_MASCOT } from '../lib/mascot'
+import { CLAUDE_MASCOT, CODEX_MASCOT, DONE_BLOB } from '../lib/mascot'
+import { createGrokMarkSvg } from '../lib/grokMark'
 import { orderIndicatorAgents } from './indicator'
 import codexPet from '../assets/pet-codex.webp'
 
@@ -127,15 +128,16 @@ function reltime(ts: number): string {
 // and the Codex pet at 26px; these are the sensible defaults — NAIL EXACTLY ON A MAC (the notch
 // bar height varies by model, and 26px overflows a short bar). Aspect ratios are preserved from
 // the sprite geometry, so only the height matters.
-/** Height of every quadrant-block sprite (claude, grok) — they share the frame aspect. */
+/** Height of the quadrant-block sprite (claude), and of grok's inline brand mark — one number so
+ *  the two working indicators sit on the same baseline in the strip. */
 const HUD_QUADRANT_H = 13
 const HUD_CODEX_H = 17
 
-/** A quadrant-block sprite mascot (claude, grok) — the sizing math is shared so the notch strip
+/** A quadrant-block sprite mascot (claude today) — the sizing math is shared so the notch strip
  *  and the canvas badge can never disagree about the geometry in lib/mascot.ts. */
 function quadrantMascot(
   mascot: { src: string; frameWidth: number; frameHeight: number },
-  variant: 'claude' | 'grok'
+  variant: 'claude'
 ): HTMLElement {
   const el = document.createElement('span')
   el.className = `mascot mascot--${variant}`
@@ -158,9 +160,13 @@ function codexMascot(): HTMLElement {
   el.style.backgroundImage = `url(${codexPet})`
   return el
 }
-function workingMascot(agentId?: string): HTMLElement {
+// Returns an SVGSVGElement for grok (an inline brand mark) and HTMLElement for the sprite
+// mascots; every caller only appends it, so `Element` is the honest shared type.
+function workingMascot(agentId?: string): Element {
   if (agentId === 'claude' && CLAUDE_MASCOT.src) return quadrantMascot(CLAUDE_MASCOT, 'claude')
-  if (agentId === 'grok' && GROK_MASCOT.src) return quadrantMascot(GROK_MASCOT, 'grok')
+  // grok breathes its own brand mark instead of walking a critter — the SAME treatment the canvas
+  // badge uses (AgentMascot), so one agent is never two different things on two surfaces.
+  if (agentId === 'grok') return createGrokMarkSvg(HUD_QUADRANT_H, 'mascot mascot--grok')
   if (agentId === 'codex') return codexMascot()
   const dot = document.createElement('span')
   dot.className = 'mascot mascot--dot'
@@ -175,7 +181,7 @@ function doneBlob(): HTMLElement {
   else blob.classList.add('done-blob--fallback')
   return blob
 }
-function rowIcon(row: HudRow): HTMLElement {
+function rowIcon(row: HudRow): Element {
   if (row.state === 'working') return workingMascot(row.agentId)
   if (row.state === 'done') {
     const c = document.createElement('span')

--- a/src/renderer/lib/agentIcons.tsx
+++ b/src/renderer/lib/agentIcons.tsx
@@ -4,6 +4,7 @@ import codexIcon from '../assets/codex-color.svg'
 import geminiIcon from '../assets/gemini-color.svg'
 import opencodeIcon from '../assets/opencode.svg'
 import { IconTerminal } from '../components/icons'
+import { GROK_MARK_PATH, GROK_MARK_VIEWBOX } from './grokMark'
 
 // Brand logo per builtin agent; custom/unknown agents fall back to the terminal glyph.
 //
@@ -19,35 +20,31 @@ const AGENT_LOGO: Partial<Record<string, string>> = {
 }
 
 /**
- * The official Grok mark (xAI), inlined rather than shipped as an asset.
+ * The official Grok mark (xAI), inlined rather than shipped as an asset — geometry from
+ * `lib/grokMark.ts`, which the notch HUD's imperative renderer shares.
  *
- * It is a SINGLE monochrome path, and the vendor's own usage is one ink that flips with the
- * background — black on light, white on dark. Inlining is what buys us that: `fill="currentColor"`
- * inherits the surrounding label colour, so the mark is correct in both themes with one copy and no
- * arbitrary recolour. As an `<img src>` it could not (an SVG in an `<img>` is an isolated document,
- * so `currentColor` resolves against nothing and paints black — invisible on the dark theme, which
- * is the default).
- *
- * `viewBox` is the mark's own 512×492, NOT square: with the default `preserveAspectRatio` the glyph
- * scales to fit a `size`×`size` box and stays centred, so it is never stretched. Do not "tidy" the
- * viewBox to 512×512.
+ * `className` is how the RUNNING badge reuses this exact glyph as its "working" indicator (it
+ * pulses and blooms instead of walking — grok has no critter; see AgentMascot).
  */
-function GrokMark({ size }: { size: number }): React.JSX.Element {
+export function GrokMark({
+  size,
+  className
+}: {
+  size: number
+  className?: string
+}): React.JSX.Element {
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 512 492"
+      viewBox={GROK_MARK_VIEWBOX}
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden
+      className={className}
       style={{ display: 'block' }}
     >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M197.76 315.52l170.197-125.803c8.342-6.186 20.267-3.776 24.256 5.803 20.907 50.539 11.563 111.253-30.08 152.939-41.621 41.685-99.562 50.816-152.512 29.994l-57.834 26.816c82.965 56.768 183.701 42.731 246.656-20.33 49.941-50.006 65.408-118.166 50.944-179.627l.128.149c-20.971-90.282 5.162-126.378 58.666-200.17 1.28-1.75 2.56-3.499 3.819-5.291l-70.421 70.507v-.214l-243.883 245.27m-35.072 30.528c-59.563-56.96-49.28-145.088 1.515-195.926 37.568-37.61 99.136-52.97 152.874-30.4l57.707-26.666a166.554 166.554 0 00-39.019-21.334 191.467 191.467 0 00-208.042 41.942c-54.038 54.101-71.04 137.301-41.856 208.298 21.802 53.056-13.931 90.582-49.92 128.47C23.104 463.915 10.304 477.333 0 491.541l162.56-145.386"
-      />
+      <path fillRule="evenodd" clipRule="evenodd" d={GROK_MARK_PATH} />
     </svg>
   )
 }

--- a/src/renderer/lib/grokMark.ts
+++ b/src/renderer/lib/grokMark.ts
@@ -1,0 +1,41 @@
+// The official Grok mark (xAI), as raw geometry so BOTH renderers can draw it: the React
+// `AgentIcon` / `AgentMascot` in the canvas, and the plain-DOM notch HUD, which builds its nodes
+// imperatively and cannot use JSX.
+//
+// A single monochrome path is the whole reason grok is drawn rather than shipped as an asset: with
+// `fill="currentColor"` the mark takes the surrounding label colour, black-on-light and
+// white-on-dark, which is the vendor's own usage — and an SVG loaded through `<img src>` is an
+// isolated document where `currentColor` resolves against nothing and paints black, invisible on the
+// default dark theme.
+
+/** The mark's own aspect box. NOT square — squaring it would stretch the glyph. */
+export const GROK_MARK_VIEWBOX = '0 0 512 492'
+
+export const GROK_MARK_PATH =
+  'M197.76 315.52l170.197-125.803c8.342-6.186 20.267-3.776 24.256 5.803 20.907 50.539 11.563 111.253-30.08 152.939-41.621 41.685-99.562 50.816-152.512 29.994l-57.834 26.816c82.965 56.768 183.701 42.731 246.656-20.33 49.941-50.006 65.408-118.166 50.944-179.627l.128.149c-20.971-90.282 5.162-126.378 58.666-200.17 1.28-1.75 2.56-3.499 3.819-5.291l-70.421 70.507v-.214l-243.883 245.27m-35.072 30.528c-59.563-56.96-49.28-145.088 1.515-195.926 37.568-37.61 99.136-52.97 152.874-30.4l57.707-26.666a166.554 166.554 0 00-39.019-21.334 191.467 191.467 0 00-208.042 41.942c-54.038 54.101-71.04 137.301-41.856 208.298 21.802 53.056-13.931 90.582-49.92 128.47C23.104 463.915 10.304 477.333 0 491.541l162.56-145.386'
+
+/**
+ * Build the mark as a real SVG element, for the imperative renderer (the notch HUD).
+ *
+ * `createElementNS` rather than `innerHTML`: the path is a static constant so there is nothing to
+ * inject, but building nodes is the same cost and keeps the HUD free of any HTML-string parsing
+ * habit that a later, less-static caller could inherit.
+ */
+export function createGrokMarkSvg(size: number, className: string): SVGSVGElement {
+  const NS = 'http://www.w3.org/2000/svg'
+  const svg = document.createElementNS(NS, 'svg')
+  svg.setAttribute('width', String(size))
+  svg.setAttribute('height', String(size))
+  svg.setAttribute('viewBox', GROK_MARK_VIEWBOX)
+  // No explicit fill: `fill="currentColor"` is the point, and it is the SVG default for a path
+  // whose ancestors set `color`. Set it anyway so the element is self-describing out of context.
+  svg.setAttribute('fill', 'currentColor')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.setAttribute('class', className)
+  const path = document.createElementNS(NS, 'path')
+  path.setAttribute('fill-rule', 'evenodd')
+  path.setAttribute('clip-rule', 'evenodd')
+  path.setAttribute('d', GROK_MARK_PATH)
+  svg.appendChild(path)
+  return svg
+}

--- a/src/renderer/lib/mascot.test.ts
+++ b/src/renderer/lib/mascot.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect } from 'vitest'
 import {
   CLAUDE_FRAMES,
   CLAUDE_FRAME_ART,
-  GROK_FRAME_ART,
-  GROK_MASCOT,
   SUB_COLS,
   SUB_ROWS,
   decodeQuadrant,
@@ -86,64 +84,5 @@ describe('walk frames', () => {
     const body0 = CLAUDE_FRAMES[0].pixels.slice(0, 4 * SUB_COLS)
     const body1 = CLAUDE_FRAMES[1].pixels.slice(0, 4 * SUB_COLS)
     expect(body0).toEqual(body1)
-  })
-})
-
-describe('grok mascot', () => {
-  it('has two walk frames on the same sub-pixel grid as the others', () => {
-    expect(GROK_FRAME_ART).toHaveLength(2)
-    for (const frame of GROK_FRAME_ART) {
-      const bmp = decodeFrame(frame)
-      expect(bmp.width).toBe(SUB_COLS)
-      expect(bmp.height).toBe(SUB_ROWS)
-    }
-  })
-
-  it('draws an actual critter in both frames (not a blank sheet)', () => {
-    // Without this, blanking the art to a single stray pixel passes every other assertion here.
-    for (const frame of GROK_FRAME_ART) {
-      expect(decodeFrame(frame).pixels.some(Boolean)).toBe(true)
-      expect(countOn(decodeFrame(frame))).toBeGreaterThan(20)
-    }
-  })
-
-  it('is written only from glyphs the decoder knows', () => {
-    // Hand-authored art's realistic regression: a typo'd or look-alike block (e.g. the half-block
-    // ▀, absent from QUADRANT_BITS) decodes SILENTLY to nothing, leaving holes no other test sees.
-    for (const frame of GROK_FRAME_ART) {
-      for (const ch of frame.join('')) {
-        expect(QUADRANT_BITS[ch]).toBeDefined()
-      }
-    }
-  })
-
-  it('alternates the feet, so it walks instead of sliding', () => {
-    // "Walks" = the FEET move while the body stays put. Whole-bitmap inequality is not enough:
-    // grok's antennae already differ between frames, so it would pass with identical feet.
-    const [a, b] = GROK_FRAME_ART.map(decodeFrame)
-    const fa = footRegion(a)
-    const fb = footRegion(b)
-    expect(fa).not.toEqual(fb)
-    // The walk moves the feet, it does not remove them.
-    expect(fa.some(Boolean)).toBe(true)
-    expect(fb.some(Boolean)).toBe(true)
-    // The body (art row 1 → sub-pixel rows 2–3) is identical, so the critter does not slide.
-    expect(a.pixels.slice(2 * SUB_COLS, 4 * SUB_COLS)).toEqual(
-      b.pixels.slice(2 * SUB_COLS, 4 * SUB_COLS)
-    )
-    // The head row DOES differ, by design: the two antennae swap sides so it bobs as it walks.
-    // (This is why the body slice above stops at row 2 instead of covering rows 0–3 like
-    // claude's equivalent test.)
-    expect(a.pixels.slice(0, 2 * SUB_COLS)).not.toEqual(b.pixels.slice(0, 2 * SUB_COLS))
-  })
-
-  it("is a DIFFERENT critter from claude's, not a recolor", () => {
-    expect(GROK_FRAME_ART[0]).not.toEqual(CLAUDE_FRAME_ART[0])
-  })
-
-  it('exposes the geometry the CSS animation needs', () => {
-    expect(GROK_MASCOT.frameCount).toBe(2)
-    expect(GROK_MASCOT.frameWidth).toBeGreaterThan(0)
-    expect(GROK_MASCOT.frameHeight).toBeGreaterThan(0)
   })
 })

--- a/src/renderer/lib/mascot.ts
+++ b/src/renderer/lib/mascot.ts
@@ -131,46 +131,6 @@ export const CLAUDE_MASCOT = {
   frameCount: CLAUDE_FRAMES.length
 }
 
-// --- Grok critter ---------------------------------------------------------------------------
-
-/**
- * The sprite color — a MID-tone, deliberately not the node color and not a light slate.
- *
- * The badge is NOT on the canvas: `AgentMascot` renders inside `.term-node__status` in the node
- * HEADER, whose background is `--panel-header` — `#323232` in the dark theme but `#eae5db` in the
- * LIGHT one. So the sprite has to survive both, plus the notch capsule (`--capsule-bg: #000`).
- * One color, chosen to match Claude coral's balance across the two themes rather than to win on
- * either (measured contrast vs `--panel-header` dark / light / vs the notch black):
- *   coral #d97757 → 4.11 / 2.49 / 6.73      this #8494a8 → 4.14 / 2.47 / 6.78
- * A light slate-300 measures 8.64 dark but 1.18 LIGHT — a ghost in a shipped theme, which is why
- * it is not used here. Single color on purpose: the component sets `background-image` inline, so a
- * CSS `[data-theme]` override could not win, and two sprites is more machinery than this needs.
- */
-export const GROK_COLOR = '#8494a8'
-
-/**
- * Grok's two walk frames. A different silhouette from Claude's rounded blob — narrower body with
- * two raised antennae that swap sides between frames, so it bobs as it walks. Composed only from
- * the quadrant characters in QUADRANT_BITS (there is no half-block ▀/▄ in that table).
- */
-export const GROK_FRAME_ART: readonly string[][] = [
-  ['▘ ▐███▌ ▝', ' ▙█████▟ ', '  ▘▘ ▝▝  '],
-  ['▝ ▐███▌ ▘', ' ▙█████▟ ', '  ▝▝ ▘▘  ']
-]
-
-/** The two decoded grok walk frames. */
-export const GROK_FRAMES: MascotBitmap[] = GROK_FRAME_ART.map(decodeFrame)
-
-/** Grok walk spritesheet — same grid and display geometry as Claude's, so the CSS walk animation
- *  (`steps(1)` over three keyframes) and the HUD sizing math are shared verbatim. */
-export const GROK_MASCOT = {
-  /** data: URI PNG, or '' outside a DOM (tests). */
-  src: buildQuadrantSprite(GROK_FRAMES, GROK_COLOR),
-  frameWidth: CLAUDE_FRAME_WIDTH,
-  frameHeight: CLAUDE_FRAME_HEIGHT,
-  frameCount: GROK_FRAMES.length
-}
-
 // --- "Done, unseen" pixel blob (Notch HUD) -------------------------------------------------
 //
 // agent-notch draws a shimmering green blob on a 7×7 grid of crisp pixels for a finished-but-

--- a/src/renderer/nodes/AgentMascot.tsx
+++ b/src/renderer/nodes/AgentMascot.tsx
@@ -1,13 +1,20 @@
 import type { CSSProperties } from 'react'
 import type { AgentId } from '@shared/agents/config'
-import { CLAUDE_MASCOT, CODEX_MASCOT, GROK_MASCOT } from '../lib/mascot'
+import { CLAUDE_MASCOT, CODEX_MASCOT } from '../lib/mascot'
+import { GrokMark } from '../lib/agentIcons'
 import codexPet from '../assets/pet-codex.webp'
+
+/** Grok's badge glyph height, matched to CLAUDE_FRAME_HEIGHT so the two sit on one baseline. */
+const GROK_BADGE_SIZE = 16
 
 /**
  * The walking mascot shown inside the RUNNING badge (docs/mascot-sprites.md):
  * - claude → the runtime-drawn coral pixel critter (data-URI spritesheet; the walk is CSS
  *   `steps(1)` over three keyframes, NOT `steps(2)` — see .term-node__mascot--claude).
- * - grok   → its own slate critter, same quadrant machinery and walk geometry.
+ * - grok   → its own BRAND MARK, pulsing and blooming rather than walking. It had a quadrant
+ *   critter first; a hand-drawn creature next to two real mascots read as neither, so the glyph
+ *   grok actually has is what animates. `currentColor` + a `drop-shadow` bloom keeps that legible
+ *   in both themes without picking an ink (see .term-node__mascot--grok).
  * - codex  → pet-codex.webp, first-row walk cycle (CSS `steps(8)`).
  * - anything else (gemini/opencode/custom/plain) → the plain pulsing dot, unchanged.
  *
@@ -25,13 +32,10 @@ export function AgentMascot({ agentId }: { agentId?: AgentId }): React.JSX.Eleme
     return <span className="term-node__mascot term-node__mascot--claude" style={style} aria-hidden />
   }
 
-  if (agentId === 'grok' && GROK_MASCOT.src) {
-    const style = {
-      '--mascot-w': `${GROK_MASCOT.frameWidth}px`,
-      '--mascot-h': `${GROK_MASCOT.frameHeight}px`,
-      backgroundImage: `url(${GROK_MASCOT.src})`
-    } as CSSProperties
-    return <span className="term-node__mascot term-node__mascot--grok" style={style} aria-hidden />
+  if (agentId === 'grok') {
+    // The badge's own glyph, not a sprite — so there is no spritesheet, no frame geometry and
+    // nothing that can desync from lib/mascot.ts. Sized to sit level with claude's 16px-tall critter.
+    return <GrokMark size={GROK_BADGE_SIZE} className="term-node__mascot--grok" />
   }
 
   if (agentId === 'codex') {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1313,14 +1313,44 @@ body,
 
 /* Claude: coral pixel critter, 2-frame walk (~2.5 steps/s ⇒ 0.8s/cycle) + an alternating bob.
    steps(1) holds each keyframe's value across its segment, giving two discrete frame+bob states. */
-/* Claude and Grok are both quadrant-block sprites from lib/mascot.ts: same 2-frame sheet, same
-   display geometry, so they share one rule block — the numbers must never be forked. */
-.term-node__mascot--claude,
-.term-node__mascot--grok {
+.term-node__mascot--claude {
   width: var(--mascot-w);
   height: var(--mascot-h);
   background-size: calc(var(--mascot-w) * 2) var(--mascot-h);
   animation: mascot-walk-claude 0.8s steps(1) infinite;
+}
+
+/* Grok has no critter: its RUNNING indicator is the brand mark itself, breathing. Deliberately NOT
+   a sprite — the glyph is an inline SVG painted in `currentColor`, so the bloom is a drop-shadow of
+   that same colour and needs no ink of its own. That is what makes it correct in both themes: the
+   halo is light-on-dark and dark-on-light, exactly like the mark. A fixed glow colour would have
+   vanished into one of the two backgrounds. */
+.term-node__mascot--grok {
+  animation: mascot-pulse-grok 1.6s ease-in-out infinite;
+}
+
+@keyframes mascot-pulse-grok {
+  0%,
+  100% {
+    opacity: 0.55;
+    filter: none;
+  }
+  50% {
+    opacity: 1;
+    /* Two shadows, tight + wide: the tight one keeps the thin diagonal strokes from washing out at
+       16px, the wide one is the actual bloom. */
+    filter: drop-shadow(0 0 1px currentColor) drop-shadow(0 0 4px currentColor);
+  }
+}
+
+/* Same contract the presence chip follows: motion is decoration, the state must still read without
+   it. Frozen at the lit end of the cycle, so a working grok node looks awake rather than dimmed. */
+@media (prefers-reduced-motion: reduce) {
+  .term-node__mascot--grok {
+    animation: none;
+    opacity: 1;
+    filter: drop-shadow(0 0 1px currentColor);
+  }
 }
 
 @keyframes mascot-walk-claude {


### PR DESCRIPTION
The hand-drawn quadrant critter didn't work. Next to two real mascots — claude's runtime-painted blob and codex's actual pet — an invented creature read as neither, so grok's working indicator becomes the glyph it actually has: the official mark, pulsing with a bloom instead of walking.

## Why the bloom is a `currentColor` drop-shadow

That is the whole trick. The mark is already painted in the label colour, so its halo is light-on-dark in the dark theme and on the notch's black capsule, and dark-on-light in the light one — no ink of its own, nothing to measure. It sidesteps the exact problem the retired sprite had to solve with a hand-picked mid-tone (`#8494a8`, measured 4.14 dark / 2.47 light against `--panel-header`).

Two shadows, tight + wide (`0 0 1px` + `0 0 4px`): the tight one keeps the thin diagonal strokes from washing out at 13–16 px, the wide one is the glow.

`prefers-reduced-motion` freezes it at the **lit** end of the cycle, so a working node reads as awake rather than dimmed — the same contract `.presence-chip--typing` already follows.

## Both surfaces, from one source

The path and viewBox move to `lib/grokMark.ts`, shared by the React badge (`AgentMascot` → `GrokMark`) and the notch HUD, which builds DOM imperatively and has no JSX (`createGrokMarkSvg`, via `createElementNS` rather than an `innerHTML` habit a later caller could inherit). Leaving the sprite in the notch would have made one agent two different things on two surfaces.

## The sprite is deleted, not left dead

`GROK_FRAME_ART`, `GROK_FRAMES`, `GROK_MASCOT`, `GROK_COLOR` and their four tests are gone, and `docs/mascot-sprites.md` now explains why grok has no critter instead of documenting one. `buildQuadrantSprite` stays — claude uses it.

Docs: `docs/grok-agent.md`'s surfaces table row is now "Working indicator", checklist 29 asks about the pulse rather than a walk, and 34 adds the badge surface (`--panel-header` light is where a `currentColor` bloom has the least to work with).

## Verification

`npm run typecheck` clean; full suite **4219 passed | 8 skipped** (−6 = the four deleted grok sprite tests plus their two removed cases). No `GROK_MASCOT` / `GROK_FRAME` / `GROK_COLOR` reference survives anywhere in `src/`.

Appearance still needs a human — this is CSS, and I have no display. Checklist 29 and 34 cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)