### PR TITLE
fix(kanban): flip the "+ New session" menu up when it would fall off-screen

### DIFF
--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react'
+import { memo, useCallback, useLayoutEffect, useRef, useState } from 'react'
 import type { KanbanColumn as KanbanColumnT } from '@shared/types'
 import { NODE_COLORS } from '../../state/workspace'
 import { SessionCard } from './SessionCard'
@@ -61,8 +61,28 @@ export const KanbanColumn = memo(function KanbanColumn({
   const [title, setTitle] = useState(column?.title ?? '')
   const [swatchesOpen, setSwatchesOpen] = useState(false)
   const [newMenuOpen, setNewMenuOpen] = useState(false)
+  // The "+ New session" menu normally drops DOWN (top:100%); a column near the window's bottom edge
+  // would push it off-screen, so we flip it UP when it doesn't fit below. Measured on open.
+  const [menuUp, setMenuUp] = useState(false)
+  const newMenuRef = useRef<HTMLDivElement>(null)
   // Trello-style drop highlight: counted enter/leave (dragleave fires when crossing children).
   const [dragOverCount, setDragOverCount] = useState(0)
+
+  useLayoutEffect(() => {
+    if (!newMenuOpen) {
+      setMenuUp(false)
+      return
+    }
+    const el = newMenuRef.current
+    if (!el) return
+    // Measured while rendered DOWN. If its bottom clears the viewport AND there's more room above
+    // the trigger than below it, flip up. (getBoundingClientRect includes the current position.)
+    const rect = el.getBoundingClientRect()
+    const overflowsBelow = rect.bottom > window.innerHeight - 8
+    const spaceAbove = rect.top // menu top ≈ just under the button
+    const spaceBelow = window.innerHeight - rect.top
+    if (overflowsBelow && spaceAbove > spaceBelow) setMenuUp(true)
+  }, [newMenuOpen])
 
   const colId = column?.id ?? null
   // Binds this column's id onto the shared card-drop handler; stable while the parent's is.
@@ -195,7 +215,7 @@ export const KanbanColumn = memo(function KanbanColumn({
       </div>
       <div className="kanban-col__footer">
         {newMenuOpen && (
-          <div className="kanban-col__newmenu">
+          <div ref={newMenuRef} className={menuUp ? 'kanban-col__newmenu kanban-col__newmenu--up' : 'kanban-col__newmenu'}>
             {createOptions.map((o) => (
               <button
                 key={o.key}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7622,6 +7622,13 @@ body,
   display: flex;
   flex-direction: column;
 }
+/* Flipped up when the column sits near the window's bottom edge (see KanbanColumn's layout effect). */
+.kanban-col__newmenu--up {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 4px;
+}
 .kanban-col__newmenu button {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Problem

In kanban view, a column's **+ New session** dropdown was hard-positioned `top: 100%` — it always opened **downward**. For a column near the window's bottom edge, the menu fell below the viewport and got clipped, so the agent list (Claude Code, Codex, …) was unreachable.

## Fix

- On open, `KanbanColumn` measures the menu (rendered in its default down position) in a `useLayoutEffect`. If its bottom clears the viewport **and** there's more room above the trigger than below, it adds a `kanban-col__newmenu--up` modifier.
- `.kanban-col__newmenu--up` anchors the menu `bottom: 100%` (opens upward) instead of `top: 100%`.
- When there's room below, nothing changes — the menu still drops down as before.

## Testing

- `npm run typecheck` + `npm run build` clean.
- Server Edition drive, two cases:
  - **Room below** (viewport h=480): menu opens **down**, fits in the viewport, no `--up` class.
  - **No room below** (viewport h=300): menu **flips up** (`--up` applied), sits above the button (menu bottom 178 ≤ button top 188), chosen because there was more space above than below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
