### PR TITLE
fix(core): the session reaper is idleness, not attachment

### DIFF
--- a/src/core/session-budget.test.ts
+++ b/src/core/session-budget.test.ts
@@ -13,13 +13,13 @@ const NOW = 1_753_000_000 // fixed epoch seconds for every test
 const cfg = (over: Partial<SessionBudgetConfig> = {}): SessionBudgetConfig => ({
   disabled: false,
   minAvailableMb: 2048,
-  maxDetached: 48,
+  maxIdle: 48,
   graceSec: 6 * 3600,
   batchMax: 8,
   ...over
 })
 
-/** A detached nt- session idle for `idleH` hours. */
+/** An nt- session whose last activity was `idleH` hours ago. */
 const idle = (name: string, idleH: number, attached = false): SessionInfo => ({
   name,
   attached,
@@ -30,14 +30,22 @@ const lowMem = { availableMb: 500, totalMb: 64_000 }
 const okMem = { availableMb: 30_000, totalMb: 64_000 }
 
 describe('planReap (pure policy)', () => {
-  it('under memory pressure, reaps the least-recently-active detached sessions first', () => {
+  it('under memory pressure, reaps the least-recently-active sessions first', () => {
     const plan = planReap([idle('nt-old', 240), idle('nt-mid', 48), idle('nt-new', 7)], lowMem, NOW, cfg({ batchMax: 2 }))
     expect(plan).toEqual(['nt-old', 'nt-mid'])
   })
 
-  it('never reaps an attached session, no matter how idle', () => {
-    const plan = planReap([idle('nt-watched', 500, true), idle('nt-idle', 500)], lowMem, NOW, cfg())
-    expect(plan).toEqual(['nt-idle'])
+  // Attachment used to veto eviction, which made the reaper a no-op wherever every session is
+  // shown on a canvas: a multi-tenant host measured 54 of 54 sessions attached and planned []
+  // on every sweep. Idleness decides now; attachment is not consulted at all.
+  it('reaps an idle session even while attached (attachment is not a signal)', () => {
+    const plan = planReap([idle('nt-shown', 500, true), idle('nt-hidden', 400)], lowMem, NOW, cfg())
+    expect(plan).toEqual(['nt-shown', 'nt-hidden'])
+  })
+
+  it('a canvas where every session is attached is still reapable', () => {
+    const sessions = Array.from({ length: 4 }, (_, i) => idle(`nt-s${i}`, 100 + i, true))
+    expect(planReap(sessions, lowMem, NOW, cfg({ batchMax: 2 }))).toEqual(['nt-s3', 'nt-s2'])
   })
 
   it('never reaps within the grace window, even under pressure', () => {
@@ -60,22 +68,24 @@ describe('planReap (pure policy)', () => {
     expect(plan).toEqual([])
   })
 
-  it('count cap is a backstop: excess detached sessions are reaped even with healthy memory', () => {
+  it('count cap is a backstop: excess idle sessions are reaped even with healthy memory', () => {
     const sessions = Array.from({ length: 10 }, (_, i) => idle(`nt-s${i}`, 100 + i))
-    const plan = planReap(sessions, okMem, NOW, cfg({ maxDetached: 7 }))
-    // 10 detached, cap 7 → 3 oldest go (highest idle hours = oldest activity)
+    const plan = planReap(sessions, okMem, NOW, cfg({ maxIdle: 7 }))
+    // 10 idle, cap 7 → 3 oldest go (highest idle hours = oldest activity)
     expect(plan).toEqual(['nt-s9', 'nt-s8', 'nt-s7'])
   })
 
-  it('attached sessions do not count toward freeing the cap, but are never the ones killed', () => {
-    const sessions = [idle('nt-live', 500, true), ...Array.from({ length: 5 }, (_, i) => idle(`nt-d${i}`, 100 + i))]
-    const plan = planReap(sessions, okMem, NOW, cfg({ maxDetached: 4 }))
+  // The cap bounds the idle pile, not the session count: a host where people are actively working
+  // in fifty sessions is not accumulating anything, and firing there would take work away.
+  it('sessions inside the grace window do not count toward the cap', () => {
+    const sessions = [idle('nt-busy', 1), ...Array.from({ length: 5 }, (_, i) => idle(`nt-d${i}`, 100 + i))]
+    const plan = planReap(sessions, okMem, NOW, cfg({ maxIdle: 4 }))
     expect(plan).toEqual(['nt-d4'])
   })
 
   it('combined triggers stay bounded by batchMax per sweep (gradual convergence)', () => {
     const sessions = Array.from({ length: 30 }, (_, i) => idle(`nt-s${i}`, 100 + i))
-    const plan = planReap(sessions, lowMem, NOW, cfg({ maxDetached: 5, batchMax: 4 }))
+    const plan = planReap(sessions, lowMem, NOW, cfg({ maxIdle: 5, batchMax: 4 }))
     expect(plan).toHaveLength(4)
   })
 
@@ -102,9 +112,9 @@ describe('parseSessionList', () => {
 })
 
 describe('sessionBudgetConfig', () => {
-  it('defaults: 10% of RAM watermark (floor 1GB), cap 48, grace 6h, batch 8', () => {
+  it('defaults: 10% of RAM watermark (floor 1GB), cap 48, grace 24h, batch 8', () => {
     const c = sessionBudgetConfig({}, 64_000)
-    expect(c).toEqual({ disabled: false, minAvailableMb: 6400, maxDetached: 48, graceSec: 21_600, batchMax: 8 })
+    expect(c).toEqual({ disabled: false, minAvailableMb: 6400, maxIdle: 48, graceSec: 86_400, batchMax: 8 })
     expect(sessionBudgetConfig({}, 4000).minAvailableMb).toBe(1024)
   })
 
@@ -112,16 +122,28 @@ describe('sessionBudgetConfig', () => {
     const c = sessionBudgetConfig(
       {
         NODETERM_SESSION_MIN_AVAILABLE_MB: '3000',
-        NODETERM_SESSION_MAX_DETACHED: 'garbage',
+        NODETERM_SESSION_MAX_IDLE: 'garbage',
         NODETERM_SESSION_GRACE_HOURS: '12',
         NODETERM_SESSION_REAP_DISABLED: '1'
       },
       64_000
     )
     expect(c.minAvailableMb).toBe(3000)
-    expect(c.maxDetached).toBe(48)
+    expect(c.maxIdle).toBe(48)
     expect(c.graceSec).toBe(43_200)
     expect(c.disabled).toBe(true)
+  })
+
+  // The cap was renamed when attachment stopped gating eligibility. An operator who tuned the old
+  // variable meant "do not let more than N of these pile up", and that intent outlives the rename —
+  // silently reverting such a host to the default would be the rename quietly changing behaviour.
+  it('the legacy MAX_DETACHED variable still sets the cap', () => {
+    expect(sessionBudgetConfig({ NODETERM_SESSION_MAX_DETACHED: '12' }, 64_000).maxIdle).toBe(12)
+  })
+
+  it('the new MAX_IDLE variable wins when both are set', () => {
+    const env = { NODETERM_SESSION_MAX_IDLE: '5', NODETERM_SESSION_MAX_DETACHED: '99' }
+    expect(sessionBudgetConfig(env, 64_000).maxIdle).toBe(5)
   })
 })
 
@@ -173,7 +195,11 @@ describe('createSessionReaper (service)', () => {
     ])
   })
 
-  it('re-verifies at kill time: a session attached between plan and kill is spared', async () => {
+  // A sweep spans several tmux calls across sockets, so the world can move between planning and
+  // killing. The re-verify checks the same rule that made the session eligible — it used to check
+  // attachment, which no longer means anything; waking up shows as activity, so that is what is
+  // re-read.
+  it('re-verifies at kill time: a session that became active between plan and kill is spared', async () => {
     let first = true
     const w = fakeWorld({})
     const exec = async (bin: string, args: string[]): Promise<string> => {
@@ -182,13 +208,20 @@ describe('createSessionReaper (service)', () => {
           first = false
           return `nt-x|0|${OLD}`
         }
-        return `nt-x|1|${OLD}` // now attached
+        return `nt-x|0|${NOW}` // typed into just now — no longer idle
       }
       return w.exec(bin, args)
     }
     const reaper = createSessionReaper({ ...base, tmuxBin: () => 'tmux', sockets: ['node-terminal'], exec })
     expect(await reaper.sweep()).toBe(0)
     expect(w.calls.filter((c) => c.args[2] === 'kill-session')).toHaveLength(0)
+  })
+
+  it('still attached but still idle at kill time → reaped', async () => {
+    const w = fakeWorld({ 'node-terminal': [`nt-x|1|${OLD}`] })
+    const reaper = createSessionReaper({ ...base, tmuxBin: () => 'tmux', sockets: ['node-terminal'], exec: w.exec })
+    expect(await reaper.sweep()).toBe(1)
+    expect(w.calls.filter((c) => c.args[2] === 'kill-session')).toHaveLength(1)
   })
 
   it('a socket whose listing fails contributes no candidates; the other socket still sweeps', async () => {

--- a/src/core/session-budget.ts
+++ b/src/core/session-budget.ts
@@ -1,17 +1,32 @@
-// Session budget: reap long-idle DETACHED nt- tmux sessions under memory pressure (or past a
-// count cap), so abandoned agent sessions can't accumulate until the host swaps itself to death
-// (field report: 95 sessions / 34 GB of idle claude processes on one host).
+// Session budget: reap long-idle nt- tmux sessions under memory pressure (or past a count cap),
+// so abandoned agent sessions can't accumulate until the host swaps itself to death (field report:
+// 95 sessions / 34 GB of idle claude processes on one host).
 //
 // This is the tmux counterpart of the renderer's WebGL budget (`terminal/webgl-budget.ts`), and it
 // deliberately reuses that design's rules rather than inventing an expiry policy:
 //   - a bounded budget, enforced only when exceeded — never a calendar-based expiry;
 //   - eviction picks the LEAST-RECENTLY-ACTIVE holder;
-//   - an ATTACHED session (someone is looking at it) is never evicted, exactly like a visible
-//     WebGL holder; a recently-active one is protected by a grace window (the release delay);
+//   - a recently-active session is protected by a grace window (the WebGL release delay);
 //   - reaping is gradual (per-sweep batch), so one sweep can never mass-kill its way past the
 //     target — the next sweep re-evaluates.
 //
-// Killing a detached session is safe BECAUSE of the cold-restore contract: to the node, a reap is
+// ATTACHMENT IS NOT PART OF THAT ANALOGY, and used to be — the rule was "an attached session is
+// never evicted, exactly like a visible WebGL holder". It made the reaper a structural no-op:
+// measured on the multi-tenant host, 54 of 54 nt- sessions reported attached=1 and `planReap`
+// returned [] on every sweep it had ever run. The analogy breaks because the two words mean
+// different things. WebGL "visible" is a live attention signal — the terminal is inside the
+// viewport at this instant. tmux "attached" only means a mounted node exists somewhere, which is
+// true for every node on every project's canvas whether or not the user is looking at that
+// project, and whether or not it has been touched in a week. The honest analogue of "visible"
+// (node is in the ACTIVE project's viewport) is renderer state the host-side reaper cannot see.
+//
+// So activity staleness is the only signal left, and it carries the protection alone: the grace
+// window is now the whole guard, which is why it defaults to a day rather than the 6 h that was
+// safe back when attachment was also required. Measured on the same host: over a 3-minute sample,
+// 5 of 53 attached sessions advanced their activity and 48 did not — attachment separates nothing,
+// activity separates cleanly.
+//
+// Killing an idle session is safe BECAUSE of the cold-restore contract: to the node, a reap is
 // indistinguishable from a machine reboot. On next open `tmux has-session` fails → fresh=true →
 // the renderer replays the scrollback snapshot and re-launches a resumable agent
 // (`claude --resume …`). For that to hold, the reaper must kill ONLY the tmux session: it must
@@ -48,9 +63,9 @@ export interface SessionBudgetConfig {
   disabled: boolean
   /** Watermark: reap only while host available memory is BELOW this (primary trigger). */
   minAvailableMb: number
-  /** Backstop: max detached nt- sessions across sockets; excess is reaped even without pressure. */
-  maxDetached: number
-  /** A session with activity newer than this is never reaped (protects same-day project switches). */
+  /** Backstop: max idle-past-grace nt- sessions across sockets; excess is reaped without pressure. */
+  maxIdle: number
+  /** A session with activity newer than this is never reaped. Sole guard — see the header. */
   graceSec: number
   /** Max kills per sweep — convergence is gradual and re-evaluated each sweep. */
   batchMax: number
@@ -64,17 +79,26 @@ function envInt(env: NodeJS.ProcessEnv, key: string, fallback: number): number {
 /**
  * Defaults, overridable per host via env (systemd `Environment=` lines):
  *   NODETERM_SESSION_MIN_AVAILABLE_MB  (default: 10% of total RAM, floor 1 GB)
- *   NODETERM_SESSION_MAX_DETACHED     (default: 48)
- *   NODETERM_SESSION_GRACE_HOURS      (default: 6)
- *   NODETERM_SESSION_REAP_BATCH       (default: 8)
- *   NODETERM_SESSION_REAP_DISABLED=1  (kill switch)
+ *   NODETERM_SESSION_MAX_IDLE          (default: 48)
+ *   NODETERM_SESSION_GRACE_HOURS       (default: 24)
+ *   NODETERM_SESSION_REAP_BATCH        (default: 8)
+ *   NODETERM_SESSION_REAP_DISABLED=1   (kill switch)
+ *
+ * `NODETERM_SESSION_MAX_DETACHED` is still read as a fallback: the cap it names counts a different
+ * population now (idle rather than detached), but an operator who set it meant "do not let more
+ * than N of these pile up", and that intent survives the rename. Dropping it would silently
+ * restore the default on hosts that had deliberately tuned it.
+ *
+ * The grace default is 24 h, not the original 6 h, because attachment no longer gates eligibility
+ * (see the header): grace is the only thing standing between a session someone left open over
+ * lunch and a sweep that happens to run while memory is tight.
  */
 export function sessionBudgetConfig(env: NodeJS.ProcessEnv, totalMb: number): SessionBudgetConfig {
   return {
     disabled: env.NODETERM_SESSION_REAP_DISABLED === '1' || env.NODETERM_SESSION_REAP_DISABLED === 'true',
     minAvailableMb: envInt(env, 'NODETERM_SESSION_MIN_AVAILABLE_MB', Math.max(1024, Math.round(totalMb * 0.1))),
-    maxDetached: envInt(env, 'NODETERM_SESSION_MAX_DETACHED', 48),
-    graceSec: envInt(env, 'NODETERM_SESSION_GRACE_HOURS', 6) * 3600,
+    maxIdle: envInt(env, 'NODETERM_SESSION_MAX_IDLE', envInt(env, 'NODETERM_SESSION_MAX_DETACHED', 48)),
+    graceSec: envInt(env, 'NODETERM_SESSION_GRACE_HOURS', 24) * 3600,
     batchMax: envInt(env, 'NODETERM_SESSION_REAP_BATCH', 8)
   }
 }
@@ -82,11 +106,16 @@ export function sessionBudgetConfig(env: NodeJS.ProcessEnv, totalMb: number): Se
 /**
  * Pure policy: which sessions to kill this sweep, least-recently-active first.
  *
- * Eligible = named `nt-*` AND detached AND idle past the grace window. Then:
+ * Eligible = named `nt-*` AND idle past the grace window. Attachment is deliberately NOT consulted
+ * — see the header for why it separated nothing on a canvas app. Then:
  *   - memory below the watermark → up to `batchMax` (a failed memory read — `mem === null` — is
  *     NOT pressure: absence of evidence never triggers the primary path);
- *   - detached count over `maxDetached` → the excess, even with healthy memory;
+ *   - idle count over `maxIdle` → the excess, even with healthy memory;
  * combined take is bounded by `batchMax`.
+ *
+ * The cap counts the ELIGIBLE population, not every nt- session: a host where fifty sessions are
+ * all in active use is not accumulating anything, and a cap that fired on it would reap sessions
+ * out from under people who are working. What the backstop is meant to bound is the idle pile.
  */
 export function planReap(
   sessions: SessionInfo[],
@@ -95,14 +124,13 @@ export function planReap(
   cfg: SessionBudgetConfig
 ): string[] {
   if (cfg.disabled) return []
-  const nt = sessions.filter((s) => s.name.startsWith('nt-'))
-  const detached = nt.filter((s) => !s.attached)
-  const eligible = detached
+  const eligible = sessions
+    .filter((s) => s.name.startsWith('nt-'))
     .filter((s) => nowSec - s.activitySec >= cfg.graceSec)
     .sort((a, b) => a.activitySec - b.activitySec)
 
   const pressure = mem !== null && mem.availableMb < cfg.minAvailableMb ? cfg.batchMax : 0
-  const overCap = Math.max(0, detached.length - cfg.maxDetached)
+  const overCap = Math.max(0, eligible.length - cfg.maxIdle)
   const take = Math.min(cfg.batchMax, Math.max(pressure, overCap))
   return eligible.slice(0, take).map((s) => s.name)
 }
@@ -217,17 +245,24 @@ export function createSessionReaper(opts: SessionReaperOpts): SessionReaper {
     for (const [socket, listed] of bySocket) {
       const names = listed.filter((s) => plan.has(s.name)).map((s) => s.name)
       if (names.length === 0) continue
-      // Kill-time re-verify on a FRESH list: only sessions still present and still detached die.
+      // Kill-time re-verify on a FRESH list: only sessions still present and STILL IDLE die. This
+      // used to re-check attachment; it now re-checks the same rule that made the session eligible,
+      // so a session that woke up between planning and killing is spared on the signal that
+      // actually means it woke up. A sweep can take seconds across sockets, and the whole point of
+      // re-verifying is that the world may have moved in between.
       const fresh = await listSocket(bin, socket)
       if (!fresh) continue
-      const stillDetached = new Set(fresh.filter((s) => !s.attached).map((s) => s.name))
+      const now = nowSec()
+      const stillIdle = new Set(
+        fresh.filter((s) => now - s.activitySec >= cfg.graceSec).map((s) => s.name)
+      )
       for (const name of names) {
-        if (!stillDetached.has(name)) continue
+        if (!stillIdle.has(name)) continue
         try {
           // `=` forces an exact target match — never tmux's prefix matching.
           await exec(bin, ['-L', socket, 'kill-session', '-t', `=${name}`])
           killed++
-          log(`[session-budget] reaped idle detached session ${name} (socket ${socket})`)
+          log(`[session-budget] reaped idle session ${name} (socket ${socket})`)
         } catch {
           // A vanished-in-between session or a kill failure changes nothing; next sweep re-plans.
         }


### PR DESCRIPTION
> **Depends on #108.** The reaper's safety story is "a reaped session resumes on next open". That is only true when the node knows its session id, and #108 is what guarantees it has one. Merging this first would turn "idle session reaped" into "conversation lost" for nodes whose id was never learned — measured at 18 of 40 on one host.

## The bug

The reaper never fired on a canvas. Its eligibility rule required a session to be **detached**, borrowed from the WebGL budget's "never evict a visible holder".

The two words do not mean the same thing:

| | WebGL `visible` | tmux `attached` |
|---|---|---|
| means | in the viewport, this instant | a mounted node exists somewhere |
| true when the user is looking elsewhere | no | **yes** |
| true for a node untouched for a week | no | **yes** |

Measured on a multi-tenant host: **54 of 54** `nt-` sessions reported `attached=1`, so `planReap()` returned `[]` on every sweep it had ever run. That host then died of a global OOM with ~32 GB held by 90 claude sessions, three quarters idle for over a day — precisely the accumulation this code exists to prevent.

Over a 3-minute sample on the same host, 5 of 53 sessions advanced their activity and 48 did not. **Attachment separates nothing; activity separates cleanly.**

## The change

- `planReap` no longer consults attachment — eligible is `nt-*` **and** idle past grace
- the kill-time re-verify re-reads the same rule that made a session eligible, so a session that wakes mid-sweep is spared on the signal that actually means it woke up (it used to re-check attachment)
- `maxDetached` → `maxIdle`, counting the **eligible** population: fifty sessions in active use are not accumulation, and a cap firing there would take work away from people
- grace default **6 h → 24 h**, because grace is now the only guard left — all that stands between a session left open over lunch and a sweep during tight memory

`NODETERM_SESSION_MAX_DETACHED` is still read as a fallback: an operator who tuned it meant "do not let more than N of these pile up", and that intent outlives the rename.

Reaping stays safe for the same reason as before — to the node a reap is a reboot, and cold restore replays the scrollback and resumes the agent.

## Verification

- `npm run typecheck` clean
- 98 test files / 1329 tests in `src/core` pass
- `session-budget.test.ts`: 21 → 25 tests; the two that asserted the old contract were replaced with ones asserting the new

🤖 Generated with [Claude Code](https://claude.com/claude-code)
