### PR TITLE
feat(windows): add psmux support and NSIS packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "server:dev": "npm run build && npm run server:build && node out/server/main.cjs",
     "make-icon": "node scripts/make-icon.mjs",
     "make-social": "node scripts/make-social.mjs",
-    "dist": "npm run make-icon && electron-vite build && electron-builder --mac --arm64 -c.mac.identity=null -c.mac.notarize=false",
-    "dist:linux": "npm run make-icon && electron-vite build && electron-builder --linux",
+    "dist": "npm run make-icon && electron-vite build && electron-builder --mac --arm64 --publish never -c.mac.identity=null -c.mac.notarize=false -c.extraMetadata.nodeTermUpdates=disabled",
+    "dist:linux": "npm run make-icon && electron-vite build && electron-builder --linux --publish never -c.extraMetadata.nodeTermUpdates=disabled",
     "dist:win": "npm run make-icon && electron-vite build && electron-builder --win --x64 --publish never -c.extraMetadata.nodeTermUpdates=disabled",
     "release": "npm run make-icon && electron-vite build && sh -c 'electron-builder --mac --arm64 --x64 --publish never; s=$?; npm run rebuild; exit $s'",
     "postinstall": "electron-rebuild -f -w node-pty,smart-whisper"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "make-social": "node scripts/make-social.mjs",
     "dist": "npm run make-icon && electron-vite build && electron-builder --mac --arm64 -c.mac.identity=null -c.mac.notarize=false",
     "dist:linux": "npm run make-icon && electron-vite build && electron-builder --linux",
+    "dist:win": "npm run make-icon && electron-vite build && electron-builder --win --x64 --publish never -c.extraMetadata.nodeTermUpdates=disabled",
     "release": "npm run make-icon && electron-vite build && sh -c 'electron-builder --mac --arm64 --x64 --publish never; s=$?; npm run rebuild; exit $s'",
     "postinstall": "electron-rebuild -f -w node-pty,smart-whisper"
   },
@@ -95,6 +96,17 @@
           ]
         }
       ]
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "icon": "build/icon.png"
     },
     "publish": {
       "provider": "generic",

--- a/src/core/exec-path.test.ts
+++ b/src/core/exec-path.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { execCandidates, findInPathString, isExecutable } from './exec-path'
+
+describe('isExecutable', () => {
+  it('accepts a real executable and rejects a path that is not there', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-exec-'))
+    try {
+      const p = path.join(d, os.platform() === 'win32' ? 'nt-fake.exe' : 'nt-fake')
+      fs.writeFileSync(p, '')
+      fs.chmodSync(p, 0o755)
+      expect(isExecutable(p)).toBe(true)
+      expect(isExecutable(path.join(d, 'nope'))).toBe(false)
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true })
+    }
+  })
+
+  // THE REASON THIS HELPER EXISTS, and it cannot be expressed on any other platform.
+  //
+  // Windows ships its most important commands — winget above all — as APP EXECUTION ALIASES:
+  // zero-length reparse points under `…\AppData\Local\Microsoft\WindowsApps`. `fs.existsSync`
+  // answers FALSE for one (it resolves the link and gets EACCES), while the file is on PATH and
+  // runs perfectly. Any lookup written with `existsSync` therefore reports the single package
+  // manager Windows actually has as "not installed" — which silently emptied the tmux banner's
+  // install button. `fs.accessSync(X_OK)` sees them.
+  //
+  // Self-skipping (the repo's ssh-docker convention): a machine without the alias still runs green.
+  const alias = path.join(
+    os.homedir(),
+    'AppData',
+    'Local',
+    'Microsoft',
+    'WindowsApps',
+    'winget.exe'
+  )
+  const hasAlias = os.platform() === 'win32' && (() => {
+    try {
+      return fs.lstatSync(alias).isSymbolicLink()
+    } catch {
+      return false
+    }
+  })()
+
+  it.runIf(hasAlias)('sees a Windows App Execution Alias, which fs.existsSync does not', () => {
+    expect(fs.existsSync(alias)).toBe(false) // the trap this helper exists to avoid
+    expect(isExecutable(alias)).toBe(true)
+  })
+})
+
+describe('execCandidates', () => {
+  it('posix: the bare name and nothing else', () => {
+    // The mode bits carry executability there, and PATHEXT is meaningless — appending
+    // extensions would only cost a stat per PATH entry per lookup.
+    expect(execCandidates('tmux', 'darwin', '.COM;.EXE')).toEqual(['tmux'])
+    expect(execCandidates('tmux', 'linux', undefined)).toEqual(['tmux'])
+  })
+
+  it('win32: every PATHEXT extension, in PATHEXT order', () => {
+    expect(execCandidates('tmux', 'win32', '.COM;.EXE;.CMD')).toEqual([
+      'tmux.COM',
+      'tmux.EXE',
+      'tmux.CMD'
+    ])
+  })
+
+  it('win32: never the bare name — Windows has no execute bit, so it would match a DIRECTORY', () => {
+    // fs.accessSync(dir, X_OK) succeeds for a directory on Windows, so a bare candidate would
+    // happily resolve `C:\...\tmux\` as "the tmux executable" and every spawn would then fail.
+    expect(execCandidates('tmux', 'win32', '.EXE')).not.toContain('tmux')
+  })
+
+  it('win32: an explicit extension is honored verbatim (CreateProcess does not append PATHEXT)', () => {
+    expect(execCandidates('tmux.exe', 'win32', '.COM;.EXE')).toEqual(['tmux.exe'])
+  })
+
+  it('win32: falls back to a built-in PATHEXT when the env has none', () => {
+    const c = execCandidates('tmux', 'win32', undefined)
+    expect(c).toContain('tmux.EXE')
+    expect(c).toContain('tmux.CMD')
+    expect(c).toContain('tmux.BAT')
+  })
+
+  it('win32: tolerates a ragged PATHEXT (empty entries, stray spaces, missing dots)', () => {
+    expect(execCandidates('tmux', 'win32', '.EXE; ;.CMD;')).toEqual(['tmux.EXE', 'tmux.CMD'])
+  })
+})
+
+describe('findInPathString', () => {
+  const dirs: string[] = []
+  afterEach(() => {
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  /** A real file on disk under a real PATH dir — the whole point is that this walks the fs. */
+  function bin(name: string): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-path-'))
+    dirs.push(d)
+    const p = path.join(d, name)
+    fs.writeFileSync(p, '')
+    fs.chmodSync(p, 0o755) // no-op on Windows, load-bearing on POSIX (X_OK)
+    return p
+  }
+
+  it('finds an executable installed under the host platform s own naming', () => {
+    // The file is named the way this platform really names executables: `nt-fake` on POSIX,
+    // `nt-fake.exe` on Windows. Both must resolve from the bare name — that is the contract
+    // every caller (findTmux, findSsh, findInLoginPath) relies on.
+    const real = bin(os.platform() === 'win32' ? 'nt-fake.exe' : 'nt-fake')
+    const hit = findInPathString('nt-fake', path.dirname(real))
+    expect(hit).not.toBeNull()
+    // Compared under the platform's OWN file-name rules: the suffix is taken from PATHEXT, which
+    // is conventionally upper-case (`.EXE`), while the file on disk is `.exe`. Windows resolves
+    // and spawns either spelling — normalizing the case would cost a readdir per lookup and buy
+    // nothing. On POSIX this is a plain string comparison, unchanged.
+    const same = (a: string, b: string): boolean =>
+      os.platform() === 'win32' ? a.toLowerCase() === b.toLowerCase() : a === b
+    expect(same(hit as string, real)).toBe(true)
+    // …and it really is the file we planted, not merely a plausible-looking string.
+    expect(fs.existsSync(hit as string)).toBe(true)
+  })
+
+  it('returns null when nothing on the PATH matches', () => {
+    const dir = path.dirname(bin('nt-other'))
+    expect(findInPathString('nt-fake', dir)).toBeNull()
+  })
+
+  it('tolerates an absent PATH', () => {
+    expect(findInPathString('nt-fake', null)).toBeNull()
+    expect(findInPathString('nt-fake', undefined)).toBeNull()
+  })
+})

--- a/src/core/exec-path.ts
+++ b/src/core/exec-path.ts
@@ -67,17 +67,71 @@ export function shellPathNow(): string | null | undefined {
   return cachedShellPath
 }
 
+/** Extensions to try when the environment declares no PATHEXT — the four that actually matter
+ *  for a CLI on PATH (a native exe, and the three shim flavours installers emit). */
+const DEFAULT_PATHEXT = '.COM;.EXE;.BAT;.CMD'
+
+/**
+ * The filenames to try for `bin` inside one PATH directory, in order.
+ *
+ * POSIX: just `bin`. The name on disk IS the command name and the mode bits say the rest.
+ *
+ * Windows: there is no such thing as an extensionless command. What sits on PATH is `tmux.exe`,
+ * `psmux.cmd`, a WinGet shim — and PATHEXT is the list of suffixes that make a file runnable. So
+ * `path.join(dir, 'tmux')` matches NOTHING there no matter what is installed, which is why every
+ * lookup built on this module (tmux, ssh, claude, git) answered null on Windows.
+ *
+ * The bare name is deliberately NOT a Windows candidate. Windows has no execute permission bit, so
+ * `fs.accessSync(p, X_OK)` degrades to a plain existence check — and it succeeds for DIRECTORIES.
+ * A bare candidate would therefore resolve a directory called `…\tmux\` as "the tmux executable",
+ * and every spawn after that would fail with an opaque EACCES/EISDIR instead of the honest
+ * "not installed". An extension the caller already supplied is honored verbatim, matching
+ * CreateProcess: a name containing a dot is never PATHEXT-expanded.
+ */
+export function execCandidates(
+  bin: string,
+  plat: NodeJS.Platform | string = os.platform(),
+  pathext: string | undefined = process.env.PATHEXT
+): string[] {
+  if (plat !== 'win32') return [bin]
+  if (path.extname(bin)) return [bin]
+  return (pathext || DEFAULT_PATHEXT)
+    .split(';')
+    .map((e) => e.trim())
+    .filter((e) => e.startsWith('.') && e.length > 1)
+    .map((e) => `${bin}${e}`)
+}
+
+/**
+ * Is this path a runnable command? The ONE place that question is answered, so no caller has to
+ * re-derive it — and two callers previously got it wrong in opposite directions.
+ *
+ * `fs.accessSync(X_OK)`, not `fs.existsSync`. On POSIX that is simply the stronger and more
+ * accurate check (a file without the exec bit is not a command). On Windows it is the only one
+ * that WORKS: the commands that matter most there — `winget` above all — ship as APP EXECUTION
+ * ALIASES, zero-length reparse points under `…\AppData\Local\Microsoft\WindowsApps`.
+ * `fs.existsSync` answers FALSE for one (it resolves the link and gets EACCES) even though the
+ * file is on PATH and runs perfectly, so an `existsSync`-based lookup reports the only package
+ * manager Windows has as "not installed".
+ */
+export function isExecutable(p: string): boolean {
+  try {
+    fs.accessSync(p, fs.constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
 /** Walk a PATH string for an executable — sync but SUBPROCESS-FREE (one accessSync per entry),
  *  so it is safe on the main thread. Returns the first accessible match, or null. */
 export function findInPathString(bin: string, pathStr: string | null | undefined): string | null {
+  const names = execCandidates(bin)
   for (const dir of (pathStr ?? '').split(path.delimiter)) {
     if (!dir) continue
-    const candidate = path.join(dir, bin)
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK)
-      return candidate
-    } catch {
-      // not here — keep looking
+    for (const name of names) {
+      const candidate = path.join(dir, name)
+      if (isExecutable(candidate)) return candidate
     }
   }
   return null
@@ -90,13 +144,6 @@ export function findInPathString(bin: string, pathStr: string | null | undefined
 export function findExecutableSync(bin: string, fallbacks: string[] = []): string | null {
   const hit = findInPathString(bin, cachedShellPath ?? process.env.PATH)
   if (hit) return hit
-  for (const c of fallbacks) {
-    try {
-      fs.accessSync(c, fs.constants.X_OK)
-      return c
-    } catch {
-      // keep trying
-    }
-  }
+  for (const c of fallbacks) if (isExecutable(c)) return c
   return null
 }

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -40,7 +40,13 @@ import { effectiveSize, type PtySize } from './pty-size'
 import { machOArch, archMismatch } from './macho-arch'
 import { writeScrollback, readScrollback, deleteScrollback } from './scrollback-store'
 import { claudeConfigDirFor } from './claude-config-dir'
-import { findExecutableSync, findInPathString, resolveShellPath, shellPathNow } from './exec-path'
+import {
+  findExecutableSync,
+  findInPathString,
+  isExecutable,
+  resolveShellPath,
+  shellPathNow
+} from './exec-path'
 import { AUTH_ENV_STRIP, accountTmuxEnvArgs, remoteAccountConfigDirAbs } from './claude-accounts-core'
 import { presenceHub } from './presence/hub'
 
@@ -146,21 +152,49 @@ bind -T copy-mode-vi TripleClick1Pane send-keys -X select-line \\; send-keys -X 
 `
 }
 
+/**
+ * Executable names that provide the tmux command surface, in preference order.
+ *
+ * `tmux` is the reference implementation and always wins. `psmux` is a tmux-compatible
+ * multiplexer for Windows — where tmux does not exist at all, and without which the app degrades
+ * SILENTLY to a plain shell: no continuity across an app restart or a reboot, no scrollback
+ * restore, no resumable agent, and nothing telling the user why. It answers every subcommand this
+ * file issues (verified against psmux 3.3.7 — see `tmux-discovery.test.ts` for the list), so it
+ * needs no adapter: just another name to look for.
+ *
+ * The extra lookup is a plain PATH walk and only ever runs when `tmux` was NOT found, so a macOS
+ * or Linux host — which hits the well-known absolute paths below first — pays nothing.
+ */
+const TMUX_BIN_NAMES = ['tmux', 'psmux'] as const
+
+/** Absolute locations a GUI app must check itself, since it inherits only a minimal PATH.
+ *  POSIX-only by construction; on Windows every entry simply fails to exist. */
+const TMUX_WELL_KNOWN = ['/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux', '/bin/tmux']
+
 /** Resolve an absolute tmux path (GUI apps don't inherit the shell PATH). Subprocess-free:
  *  the old fallback here was a SYNC login-shell `command -v tmux` — sourcing the profile
  *  (nvm/conda: 100-800ms) on the main thread, re-triggered every 3s by the tmux-missing
  *  banner's install poll, freezing all windows and IPC each time. Now it walks the cached
  *  login-shell PATH instead; before that async probe settles a nonstandard location can be
- *  missed, which init()'s post-probe ensureTmux() re-run and tmuxStatus()'s re-probe cover. */
-function findTmux(): string | null {
-  for (const c of ['/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux', '/bin/tmux']) {
+ *  missed, which init()'s post-probe ensureTmux() re-run and tmuxStatus()'s re-probe cover.
+ *
+ *  Both arguments are injection seams for the tests ONLY — production always calls it bare. */
+export function findTmux(
+  pathStr: string | null | undefined = shellPathNow() ?? process.env.PATH,
+  wellKnown: readonly string[] = TMUX_WELL_KNOWN
+): string | null {
+  for (const c of wellKnown) {
     try {
       if (fs.existsSync(c)) return c
     } catch {
       // ignore
     }
   }
-  return findInPathString('tmux', shellPathNow() ?? process.env.PATH)
+  for (const name of TMUX_BIN_NAMES) {
+    const hit = findInPathString(name, pathStr)
+    if (hit) return hit
+  }
+  return null
 }
 
 /** Resolve an absolute ssh path (GUI apps don't inherit the shell PATH). */
@@ -760,7 +794,10 @@ export class PtyManager {
     const available = !!this.tmuxPath
     const hint = available
       ? null
-      : tmuxInstall(process.platform, (cmd) => findCommand(cmd, process.env, fs.existsSync))
+      : // `isExecutable`, NOT `fs.existsSync`: on Windows the package manager we look for
+        // (`winget`) is an App Execution Alias, which existsSync reports as absent — see
+        // `isExecutable`. On POSIX it is also simply the more accurate question.
+        tmuxInstall(process.platform, (cmd) => findCommand(cmd, process.env, isExecutable))
     return {
       available,
       installCommand: hint?.command ?? null,

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -167,9 +167,26 @@ bind -T copy-mode-vi TripleClick1Pane send-keys -X select-line \\; send-keys -X 
  */
 const TMUX_BIN_NAMES = ['tmux', 'psmux'] as const
 
-/** Absolute locations a GUI app must check itself, since it inherits only a minimal PATH.
- *  POSIX-only by construction; on Windows every entry simply fails to exist. */
-const TMUX_WELL_KNOWN = ['/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux', '/bin/tmux']
+/** Absolute locations a GUI app must check itself, since it inherits only a minimal PATH. */
+const TMUX_WELL_KNOWN_POSIX = ['/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux', '/bin/tmux']
+
+/**
+ * The well-known list for a platform — empty on Windows, where these four paths cannot help and
+ * can only hurt. They are POSIX layout and rooted WITHOUT a drive letter, so Windows resolves them
+ * against whatever drive happens to be current (`/bin/tmux` is `E:\bin\tmux` from a checkout on
+ * E:). They also name an EXTENSIONLESS file, and the walk below is a bare `existsSync` with no
+ * PATHEXT expansion — so it can never match a real `tmux.exe`, however one got installed there
+ * (the same reason `execCandidates` in ./exec-path exists).
+ *
+ * What it CAN match is a directory: `existsSync` answers true for one. Since this list is
+ * consulted BEFORE the PATH, a stray `…\bin\tmux\` folder would be handed back as "the
+ * multiplexer", and every spawn after it would fail with an opaque EACCES/EISDIR instead of
+ * falling through to the psmux that actually works. Windows has no fixed install location for a
+ * multiplexer anyway, so asking only the PATH there loses nothing.
+ */
+export function wellKnownTmux(plat: NodeJS.Platform | string = process.platform): readonly string[] {
+  return plat === 'win32' ? [] : TMUX_WELL_KNOWN_POSIX
+}
 
 /** Resolve an absolute tmux path (GUI apps don't inherit the shell PATH). Subprocess-free:
  *  the old fallback here was a SYNC login-shell `command -v tmux` — sourcing the profile
@@ -181,7 +198,7 @@ const TMUX_WELL_KNOWN = ['/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/
  *  Both arguments are injection seams for the tests ONLY — production always calls it bare. */
 export function findTmux(
   pathStr: string | null | undefined = shellPathNow() ?? process.env.PATH,
-  wellKnown: readonly string[] = TMUX_WELL_KNOWN
+  wellKnown: readonly string[] = wellKnownTmux()
 ): string | null {
   for (const c of wellKnown) {
     try {

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -209,7 +209,12 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     expect(env.TERM).toBe('xterm-256color')
     expect(env.TMUX).toBeUndefined()
     expect(env.TMUX_PANE).toBeUndefined()
-    expect(env.PATH).toBe('/usr/bin:/bin')
+    // The login-shell PATH probe (stubbed above to answer `/usr/bin:/bin`) is a POSIX notion:
+    // `resolveShellPath` short-circuits to null on Windows, where there is no profile to source
+    // and a GUI process already inherits the user's full PATH. So the contract differs by
+    // platform and the assertion has to as well — asserting the POSIX string on Windows was
+    // testing the stub, not the manager.
+    expect(env.PATH).toBe(os.platform() === 'win32' ? process.env.PATH : '/usr/bin:/bin')
     fs.rmSync(cwd, { recursive: true, force: true })
   })
 

--- a/src/core/tmux-discovery.test.ts
+++ b/src/core/tmux-discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { findTmux } from './pty-manager'
+import { findTmux, wellKnownTmux } from './pty-manager'
 
 /**
  * WHICH BINARY PROVIDES THE MULTIPLEXER.
@@ -76,5 +76,20 @@ describe('findTmux', () => {
     expect(binName(findTmux(dir, [path.join(dir, 'nope', 'tmux')]))).toBe(
       os.platform() === 'win32' ? 'psmux.exe' : 'psmux'
     )
+  })
+})
+
+describe('wellKnownTmux', () => {
+  it('offers the POSIX install locations on macOS and Linux', () => {
+    expect(wellKnownTmux('darwin')).toContain('/opt/homebrew/bin/tmux')
+    expect(wellKnownTmux('linux')).toContain('/usr/bin/tmux')
+  })
+
+  it('offers none on Windows, where a rooted path means the CURRENT DRIVE', () => {
+    // `/usr/bin/tmux` resolves to `C:\usr\bin\tmux` there — a path an MSYS2 install rooted at the
+    // drive root really creates. That tmux is real but does not speak ConPTY, and this list is
+    // consulted before the PATH, so keeping it would let a stray MSYS binary outrank the working
+    // psmux the user installed.
+    expect(wellKnownTmux('win32')).toEqual([])
   })
 })

--- a/src/core/tmux-discovery.test.ts
+++ b/src/core/tmux-discovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { findTmux } from './pty-manager'
+
+/**
+ * WHICH BINARY PROVIDES THE MULTIPLEXER.
+ *
+ * Everything about persistence — a terminal surviving an app restart, a reboot, a power cut —
+ * hangs off resolving one executable. `tmux` is that executable on macOS and Linux. On Windows
+ * there is no tmux, and the app used to degrade SILENTLY to a plain shell: no continuity, no
+ * scrollback restore, no resumable agent, and no way for the user to find out why.
+ *
+ * psmux is a tmux-compatible multiplexer for Windows that ships `tmux`, `psmux` and `pmux` command
+ * aliases. It answers every subcommand this app issues (verified against psmux 3.3.7: source-file,
+ * has-session, new-session -A -D -e -c -s, capture-pane -p -e -S, send-keys -l/Enter,
+ * display-message with #{cursor_x}/#{cursor_y}/#{cursor_flag}/#{pane_current_command},
+ * list-sessions -F, kill-session). So the fix is not a Windows code path — it is one more NAME to
+ * look for, on every platform.
+ */
+describe('findTmux', () => {
+  const dirs: string[] = []
+  afterEach(() => {
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  /** A PATH directory holding real files named the way THIS platform names executables. */
+  function pathDir(...bins: string[]): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-mux-'))
+    dirs.push(d)
+    for (const b of bins) {
+      const p = path.join(d, os.platform() === 'win32' ? `${b}.exe` : b)
+      fs.writeFileSync(p, '')
+      fs.chmodSync(p, 0o755) // no-op on Windows, load-bearing on POSIX (X_OK)
+    }
+    return d
+  }
+
+  /** The resolved file's name, lower-cased: the suffix comes from PATHEXT (`.EXE`) while the file
+   *  on disk is `.exe`, and Windows treats those as the same name. */
+  const binName = (p: string | null): string | null =>
+    p === null ? null : path.basename(p).toLowerCase()
+
+  it('resolves tmux from the PATH', () => {
+    expect(binName(findTmux(pathDir('tmux'), []))).toBe(os.platform() === 'win32' ? 'tmux.exe' : 'tmux')
+  })
+
+  it('resolves psmux when it is the only multiplexer installed', () => {
+    // THE WINDOWS CASE. Before this, a psmux-only host resolved nothing and every terminal fell
+    // through to the plain-shell branch — the silent degrade this whole port exists to remove.
+    expect(binName(findTmux(pathDir('psmux'), []))).toBe(
+      os.platform() === 'win32' ? 'psmux.exe' : 'psmux'
+    )
+  })
+
+  it('prefers tmux over psmux when both are installed', () => {
+    // tmux is the reference implementation; psmux is the compatible stand-in. Wherever the real
+    // thing exists it wins, so no macOS/Linux host can ever be pulled onto the fallback.
+    expect(binName(findTmux(pathDir('tmux', 'psmux'), []))).toBe(
+      os.platform() === 'win32' ? 'tmux.exe' : 'tmux'
+    )
+  })
+
+  it('returns null when no multiplexer is installed', () => {
+    expect(findTmux(pathDir('git'), [])).toBeNull()
+  })
+
+  it('prefers a well-known absolute location over the PATH (GUI apps inherit a minimal PATH)', () => {
+    const wellKnown = path.join(pathDir('tmux'), os.platform() === 'win32' ? 'tmux.exe' : 'tmux')
+    expect(findTmux(pathDir('tmux'), [wellKnown])).toBe(wellKnown)
+  })
+
+  it('skips a well-known location that does not exist', () => {
+    const dir = pathDir('psmux')
+    expect(binName(findTmux(dir, [path.join(dir, 'nope', 'tmux')]))).toBe(
+      os.platform() === 'win32' ? 'psmux.exe' : 'psmux'
+    )
+  })
+})

--- a/src/core/tmux-hint.test.ts
+++ b/src/core/tmux-hint.test.ts
@@ -31,8 +31,21 @@ describe('tmuxInstall', () => {
     expect(tmuxInstall('linux', () => false)).toBeNull()
   })
 
-  it('win32 (no native tmux): never suggests a command', () => {
-    expect(tmuxInstall('win32', () => true)).toBeNull()
+  // Windows has no tmux, and used to get NO hint at all — the banner was hidden there entirely,
+  // so the app degraded to a plain shell (no continuity across a restart or a reboot) with
+  // nothing on screen saying so. psmux is a tmux-compatible multiplexer for Windows and winget
+  // is the OS's own package manager, which makes this exactly as actionable as the brew line.
+  it('win32 with winget: installs psmux, the tmux-compatible multiplexer', () => {
+    const hint = tmuxInstall('win32', (c) => c === 'winget')
+    expect(hint?.command).toContain('winget install')
+    expect(hint?.command).toContain('marlocarlo.psmux')
+    expect(hint?.label).toBe('Install psmux')
+  })
+
+  it('win32 without winget: no command to suggest', () => {
+    // Same rule as a linux with no known package manager: the banner still WARNS, it just has
+    // no button. Inventing an installer we cannot run would be worse than saying nothing.
+    expect(tmuxInstall('win32', () => false)).toBeNull()
   })
 })
 
@@ -40,13 +53,36 @@ describe('findCommand', () => {
   it('scans PATH entries and the common GUI-blind dirs (apps do not inherit the shell PATH)', () => {
     const seen: string[] = []
     const exists = (p: string) => (seen.push(p), p === '/opt/homebrew/bin/brew')
-    expect(findCommand('brew', { PATH: '/usr/bin:/bin' }, exists)).toBe(true)
+    expect(findCommand('brew', { PATH: '/usr/bin:/bin' }, exists, 'darwin')).toBe(true)
     expect(seen).toContain('/usr/bin/brew') // PATH first
     expect(seen).toContain('/opt/homebrew/bin/brew') // then the common dirs
-    expect(findCommand('brew', { PATH: '/usr/bin' }, () => false)).toBe(false)
+    expect(findCommand('brew', { PATH: '/usr/bin' }, () => false, 'darwin')).toBe(false)
   })
 
   it('tolerates a missing PATH', () => {
-    expect(findCommand('brew', {}, (p) => p === '/usr/local/bin/brew')).toBe(true)
+    expect(findCommand('brew', {}, (p) => p === '/usr/local/bin/brew', 'darwin')).toBe(true)
+  })
+
+  // Every part of the POSIX lookup is wrong on Windows: `:` is not the separator (it splits
+  // `C:\Users` in half), `/` is not the path separator, `/usr/local/bin` does not exist, and
+  // nothing on PATH is extensionless — the command is `winget.exe`. Unfixed, the win32 hint
+  // above could never find a package manager and would always answer null.
+  it('win32: splits PATH on ; and probes the PATHEXT spellings', () => {
+    const seen: string[] = []
+    const exists = (p: string) =>
+      (seen.push(p), p === 'C:\\Users\\Will\\AppData\\Local\\Microsoft\\WinGet\\Links\\winget.EXE')
+    const env = {
+      PATH: 'C:\\Windows\\system32;C:\\Users\\Will\\AppData\\Local\\Microsoft\\WinGet\\Links',
+      PATHEXT: '.COM;.EXE'
+    }
+    expect(findCommand('winget', env, exists, 'win32')).toBe(true)
+    expect(seen).toContain('C:\\Windows\\system32\\winget.COM')
+    expect(seen).toContain('C:\\Windows\\system32\\winget.EXE')
+  })
+
+  it('win32: never probes the POSIX bin dirs', () => {
+    const seen: string[] = []
+    findCommand('winget', { PATH: 'C:\\Windows' }, (p) => (seen.push(p), false), 'win32')
+    expect(seen.some((p) => p.startsWith('/'))).toBe(false)
   })
 })

--- a/src/core/tmux-hint.ts
+++ b/src/core/tmux-hint.ts
@@ -3,6 +3,8 @@
 // can't attach — which users never discover on their own; the banner makes it visible and offers
 // a one-click install (run in a terminal node, gh-sign-in style).
 
+import { execCandidates } from './exec-path'
+
 export interface TmuxInstallHint {
   command: string
   /** Button caption — tells the user up front when more than tmux is being installed. */
@@ -10,8 +12,8 @@ export interface TmuxInstallHint {
 }
 
 /** Suggested one-shot install for the host, or null when there is nothing sensible to run
- *  (win32; a linux with no known package manager). Order within linux is Debian-family first
- *  (the Server Edition's documented target), then the other majors.
+ *  (a linux with no known package manager; a win32 without winget). Order within linux is
+ *  Debian-family first (the Server Edition's documented target), then the other majors.
  *
  *  darwin WITHOUT brew is never text-only: macOS has no built-in package manager, so the button
  *  chains the OFFICIAL Homebrew installer (which itself prompts for confirmation + password —
@@ -47,21 +49,49 @@ export function tmuxInstall(
                 : null
     return command ? { command, label: 'Install tmux' } : null
   }
+  if (platform === 'win32') {
+    // Windows has no tmux. psmux is a tmux-compatible multiplexer for it — same socket namespaces
+    // (`-L`), same detached sessions, same subcommand surface — and winget is the OS's own package
+    // manager, so this is exactly as actionable as the brew line above. Without it a Windows user
+    // silently ran on the plain-shell fallback: no terminal surviving an app restart or a reboot,
+    // no scrollback restore, no resumable agent, and nothing on screen explaining why.
+    // `-e --id` pins the exact package (winget otherwise prompts on an ambiguous name, which
+    // would hang forever in a terminal node nobody is watching).
+    if (hasCommand('winget'))
+      return { command: 'winget install -e --id marlocarlo.psmux', label: 'Install psmux' }
+    return null
+  }
   return null
 }
 
 /** Dirs GUI apps routinely miss (they don't inherit the shell PATH) — same reasoning as
- *  findTmux in pty-manager. Checked after the process PATH. */
+ *  findTmux in pty-manager. Checked after the process PATH. POSIX-only by construction. */
 const COMMON_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin', '/opt/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']
 
-/** Is `name` on the process PATH or in the common bin dirs? `exists` is injected (fs.existsSync
- *  in production) so the lookup stays pure and testable. */
+/**
+ * Is `name` on the process PATH (or, on POSIX, in the common bin dirs)? `exists` is injected
+ * (`isExecutable` in production — NOT `fs.existsSync`, which cannot see the Windows App Execution
+ * Alias that `winget` is) so the lookup stays pure and testable.
+ *
+ * `platform` is explicit rather than read from `process` because every mechanical detail of the
+ * walk differs: Windows separates PATH with `;` (splitting on `:` cuts `C:\Users` in half),
+ * separates path components with `\`, has no `/usr/local/bin`, and has no extensionless commands
+ * at all — the file is `winget.exe`, named by PATHEXT (`execCandidates`, the same rule the real
+ * executable lookup uses).
+ */
 export function findCommand(
   name: string,
   env: Record<string, string | undefined>,
-  exists: (path: string) => boolean
+  exists: (path: string) => boolean,
+  platform: NodeJS.Platform | string = process.platform
 ): boolean {
-  const dirs = [...(env.PATH ? env.PATH.split(':') : []), ...COMMON_BIN_DIRS]
-  return dirs.some((d) => d && exists(`${d}/${name}`))
+  const win = platform === 'win32'
+  const dirs = [
+    ...(env.PATH ? env.PATH.split(win ? ';' : ':') : []),
+    ...(win ? [] : COMMON_BIN_DIRS)
+  ]
+  const names = execCandidates(name, platform, env.PATHEXT)
+  const sep = win ? '\\' : '/'
+  return dirs.some((d) => d && names.some((n) => exists(`${d}${sep}${n}`)))
 }
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -5,15 +5,36 @@
 // requires a signed + notarized build; unsigned builds still surface the card for a manual
 // download.
 import { app, ipcMain, Notification } from 'electron'
+import fs from 'fs'
+import path from 'path'
 // Named import — the default-import + destructure pattern returns undefined under
 // electron-vite v5's CJS interop.
 import { autoUpdater } from 'electron-updater'
 import { IPC } from '../shared/ipc'
-import { isManualUpdatePlatform, toUpdateAvailablePayload } from '../shared/update-platform'
+import {
+  isManualUpdatePlatform,
+  shouldEnableUpdater,
+  toUpdateAvailablePayload
+} from '../shared/update-platform'
 import { getMainWindow, sendToMain } from './main-window'
 import { retainUntilDismissed } from './notifications'
 
 const SIX_HOURS = 6 * 60 * 60 * 1000
+
+/** Local unsigned packages carry this marker in their packaged package.json via extraMetadata. */
+function packagedUpdateMode(): unknown {
+  if (!app.isPackaged) return undefined
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(app.getAppPath(), 'package.json'), 'utf8')) as {
+      nodeTermUpdates?: unknown
+    }
+    return pkg.nodeTermUpdates
+  } catch (err) {
+    // A normal release without the marker must preserve the established updater behavior.
+    console.warn('[updater] could not read packaged update mode:', err)
+    return undefined
+  }
+}
 
 /**
  * The window is resolved AT EVENT TIME (getMainWindow/sendToMain) — never captured in a closure.
@@ -37,9 +58,9 @@ export function initUpdater(onBeforeRestart?: () => void): void {
     autoUpdater.quitAndInstall()
   })
 
-  if (!app.isPackaged) {
-    // Dev: there is no update server. A manual check reports "up to date" so the Settings
-    // button still gives feedback; automatic checks are skipped entirely.
+  if (!shouldEnableUpdater(app.isPackaged, packagedUpdateMode())) {
+    // Dev and explicitly local/unsigned packages have no update channel. A manual check reports
+    // "up to date" for feedback; automatic networking and updater event wiring stay disabled.
     ipcMain.on(IPC.appCheckForUpdates, () => send(IPC.appUpdateNotAvailable))
     return
   }

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -21,7 +21,23 @@ import { retainUntilDismissed } from './notifications'
 
 const SIX_HOURS = 6 * 60 * 60 * 1000
 
-/** Local unsigned packages carry this marker in their packaged package.json via extraMetadata. */
+/**
+ * The `nodeTermUpdates` marker a LOCAL package carries in its packaged package.json, injected by
+ * the `dist*` scripts via electron-builder's `extraMetadata`. `release` does not set it, so a
+ * promoted build is untouched and keeps updating itself.
+ *
+ * It exists because a locally packaged app is indistinguishable from a release at runtime —
+ * `app.isPackaged` is true for both — so it polled the production feed for a version that was
+ * never published there and logged a 404 on `latest*.yml` every six hours. Found while smoke
+ * testing the Windows NSIS build, but nothing about it is Windows-specific: `npm run dist` on
+ * macOS and `dist:linux` produce the same unpublished build and hit the same 404, which is why
+ * all three scripts set the marker.
+ *
+ * The trade-off, stated plainly: a `dist*` package can no longer smoke-test the updater wiring
+ * itself — a manual check there now answers "up to date" without going near the network. The old
+ * behaviour at least proved the wiring was live, at the cost of a recurring 404 in every local
+ * build's log. Verifying the real feed is the job of a `release` package, which carries no marker.
+ */
 function packagedUpdateMode(): unknown {
   if (!app.isPackaged) return undefined
   try {

--- a/src/renderer/components/TmuxBanner.tsx
+++ b/src/renderer/components/TmuxBanner.tsx
@@ -30,6 +30,62 @@ export function pollOutcome(available: boolean, elapsedMs: number): InstallPhase
   return elapsedMs >= INSTALL_CAP_MS ? 'failed' : 'installing'
 }
 
+/** What the multiplexer is CALLED on this host. `tmux` is the reference implementation and its own
+ *  name wherever it ships; it ships no Windows build, and the thing this banner offers there is
+ *  psmux — so naming it tmux on win32 would send the user looking for a package they cannot get.
+ *  Only the NAME differs: every behaviour described below is the same on both. */
+export function multiplexerName(platform: string): string {
+  return platform === 'win32' ? 'psmux' : 'tmux'
+}
+
+/**
+ * Title + body for a phase. Pure, and split out of the component for exactly one reason: the
+ * strings are now platform-dependent and the no-installer fallback is the branch that used to be
+ * WRONG on Windows. It advised `brew install tmux` — a package manager macOS-only by construction,
+ * naming a package with no Windows build — and it became reachable there the moment the win32 gate
+ * above was removed. That branch means "no one-click install exists here", which on Windows is
+ * specifically "winget was not found", not "use your package manager".
+ */
+export function bannerCopy(
+  phase: InstallPhase,
+  platform: string,
+  hasInstallCommand: boolean
+): { title: string; body: string } {
+  const name = multiplexerName(platform)
+  const win = platform === 'win32'
+  if (phase === 'installing')
+    return {
+      title: `Installing ${name}`,
+      body: 'Running the install in a terminal node — watch it for progress (it may ask for your password).'
+    }
+  if (phase === 'ready')
+    return {
+      title: `${name} ready`,
+      body: 'New terminals will survive restarts from now on. Terminals opened before the install stay on the plain shell.'
+    }
+  const title = `${name} not found`
+  if (phase === 'failed')
+    return {
+      title,
+      body: win
+        ? 'The install hasn’t completed. Check the terminal node for errors, or install psmux manually and restart nodeterm.'
+        : 'The install hasn’t completed. Check the terminal node for errors, or install tmux with your package manager and restart nodeterm.'
+    }
+  if (hasInstallCommand)
+    return {
+      title,
+      body: `Terminals won’t survive restarts and the mobile app can’t attach until ${name} is installed.`
+    }
+  return {
+    title,
+    body: win
+      ? // No winget, so there is no command to offer — and no honest one-liner to print either.
+        // Say what is missing and stop, rather than inventing an install path we did not verify.
+        'Terminals won’t survive restarts and the mobile app can’t attach. winget wasn’t found, so there is no one-click install — install psmux (a tmux-compatible multiplexer for Windows) and restart nodeterm.'
+      : 'Terminals won’t survive restarts and the mobile app can’t attach. Install tmux with your package manager (e.g. brew install tmux), then restart nodeterm.'
+  }
+}
+
 export function TmuxBanner({ onInstall }: { onInstall: (command: string) => void }): JSX.Element | null {
   const [status, setStatus] = useState<TmuxStatus | null>(null)
   const [dismissed, setDismissed] = useState(false)
@@ -82,18 +138,7 @@ export function TmuxBanner({ onInstall }: { onInstall: (command: string) => void
   if (!status || dismissed) return null
   if (status.available && phase === 'missing') return null
 
-  const title =
-    phase === 'installing' ? 'Installing tmux' : phase === 'ready' ? 'tmux ready' : 'tmux not found'
-  const body =
-    phase === 'installing'
-      ? 'Running the install in a terminal node — watch it for progress (it may ask for your password).'
-      : phase === 'ready'
-        ? 'New terminals will survive restarts from now on. Terminals opened before the install stay on the plain shell.'
-        : phase === 'failed'
-          ? 'The install hasn’t completed. Check the terminal node for errors, or install tmux with your package manager and restart nodeterm.'
-          : status.installCommand
-            ? 'Terminals won’t survive restarts and the mobile app can’t attach until tmux is installed.'
-            : 'Terminals won’t survive restarts and the mobile app can’t attach. Install tmux with your package manager (e.g. brew install tmux), then restart nodeterm.'
+  const { title, body } = bannerCopy(phase, status.platform, !!status.installCommand)
 
   const showInstall = (phase === 'missing' || phase === 'failed') && !!status.installCommand
   return (

--- a/src/renderer/components/TmuxBanner.tsx
+++ b/src/renderer/components/TmuxBanner.tsx
@@ -10,7 +10,13 @@ import { localSession } from '../session/localSession'
 // version, which dismissed the banner optimistically and left the user guessing (second field
 // report) — keeps the banner up as a status strip: installing → ready | failed. tmuxStatus()
 // re-probes on every call (ensureTmux), so `available` flipping true is also what makes NEW
-// terminals tmux-backed without a restart. Hidden on win32 and on any fetch error (fail-open).
+// terminals tmux-backed without a restart. Hidden on any fetch error (fail-open).
+//
+// It used to be hidden on win32 outright, because there was nothing to say: Windows has no tmux
+// and `tmuxInstall` had no command for it. That made Windows the ONE platform where the silent
+// degrade this banner exists to expose was itself invisible. psmux (a tmux-compatible multiplexer,
+// installable via winget) gives win32 both an answer and a button, so the platform gate is gone —
+// `status.available` already hides the banner wherever a multiplexer is present.
 
 export const INSTALL_POLL_MS = 3000
 export const INSTALL_CAP_MS = 5 * 60_000
@@ -73,7 +79,7 @@ export function TmuxBanner({ onInstall }: { onInstall: (command: string) => void
     return () => clearTimeout(t)
   }, [phase])
 
-  if (!status || dismissed || status.platform === 'win32') return null
+  if (!status || dismissed) return null
   if (status.available && phase === 'missing') return null
 
   const title =

--- a/src/renderer/components/tmux-banner-phase.test.ts
+++ b/src/renderer/components/tmux-banner-phase.test.ts
@@ -8,7 +8,60 @@ vi.mock('../session/localSession', () => ({
   localSession: { api: { pty: { tmuxStatus: async () => ({ available: false }) } } }
 }))
 
-import { INSTALL_CAP_MS, pollOutcome } from './TmuxBanner'
+import { bannerCopy, INSTALL_CAP_MS, multiplexerName, pollOutcome } from './TmuxBanner'
+
+describe('multiplexerName', () => {
+  it('is tmux wherever tmux exists, and psmux on Windows where it does not', () => {
+    expect(multiplexerName('darwin')).toBe('tmux')
+    expect(multiplexerName('linux')).toBe('tmux')
+    expect(multiplexerName('win32')).toBe('psmux')
+  })
+})
+
+describe('bannerCopy', () => {
+  it('names the multiplexer the host actually has, in every phase', () => {
+    // All FOUR of InstallPhase: `failed` shares the `not found` title with `missing`, and leaving
+    // it out would let a hardcoded 'tmux not found' literal pass this file.
+    for (const [phase, mac, win] of [
+      ['missing', 'tmux not found', 'psmux not found'],
+      ['failed', 'tmux not found', 'psmux not found'],
+      ['installing', 'Installing tmux', 'Installing psmux'],
+      ['ready', 'tmux ready', 'psmux ready']
+    ] as const) {
+      expect(bannerCopy(phase, 'darwin', true).title).toBe(mac)
+      expect(bannerCopy(phase, 'win32', true).title).toBe(win)
+    }
+  })
+
+  it('never advises brew or tmux on Windows when there is no one-click install', () => {
+    // THE REGRESSION THIS GUARDS. Removing the win32 gate made the no-installer branch reachable
+    // on Windows, where it told the user to run a macOS-only package manager to install a package
+    // with no Windows build. That branch means "winget was not found" there.
+    const { body } = bannerCopy('missing', 'win32', false)
+    expect(body).not.toMatch(/brew/i)
+    expect(body).not.toMatch(/install tmux/i)
+    expect(body).not.toMatch(/package manager/i)
+    expect(body).toMatch(/winget/)
+    expect(body).toMatch(/install psmux/)
+  })
+
+  it('keeps the package-manager advice on POSIX', () => {
+    expect(bannerCopy('missing', 'darwin', false).body).toMatch(/brew install tmux/)
+    expect(bannerCopy('failed', 'linux', true).body).toMatch(/package manager/)
+  })
+
+  it('points a failed Windows install at a manual install, not a package manager', () => {
+    expect(bannerCopy('failed', 'win32', true).body).toMatch(/install psmux manually/)
+  })
+
+  // `failed` is only reachable via the Install button, which requires an installCommand — so the
+  // flag is dead input there, and these assertions pin that rather than implying coverage of a
+  // "failed without an installer" state the app never reaches.
+  it('ignores the installer flag once an install has failed', () => {
+    for (const platform of ['darwin', 'win32'])
+      expect(bannerCopy('failed', platform, false)).toEqual(bannerCopy('failed', platform, true))
+  })
+})
 
 describe('pollOutcome', () => {
   it('stays installing while unavailable and under the cap', () => {

--- a/src/renderer/terminal/command-delivery.test.ts
+++ b/src/renderer/terminal/command-delivery.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  ABORT_LINE,
   DELIVERY_ATTEMPTS,
   VERIFY_TIMEOUT_MS,
   cleanEcho,
@@ -80,23 +81,31 @@ describe('deliverCommand', () => {
     expect(f.writes).toEqual([CMD, '\r'])
   })
 
-  it('kills the line and rewrites when the echo never completes, then succeeds', () => {
+  // The abort MUST NOT be Ctrl-U. PSReadLine ships EditMode=Windows, where Ctrl-U is UNBOUND, so
+  // it self-inserts and renders as a literal `^U` — the rewrite then lands as `^Uclaude` and the
+  // shell reports an unknown command. Measured on a psmux/PowerShell pane; see the constant.
+  it('aborts the pending line with Ctrl-C, never with a Ctrl-U that PSReadLine self-inserts', () => {
+    expect(ABORT_LINE).toBe('\x03')
+    expect(ABORT_LINE).not.toBe('\x15')
+  })
+
+  it('aborts the line and rewrites when the echo never completes, then succeeds', () => {
     const f = fakeIo()
     deliverCommand(f.io, CMD)
     f.emit(CMD.slice(0, 30)) // the tty flush ate the rest
     vi.advanceTimersByTime(VERIFY_TIMEOUT_MS)
-    expect(f.writes).toEqual([CMD, '\x15', CMD])
+    expect(f.writes).toEqual([CMD, ABORT_LINE, CMD])
     f.emit(CMD) // clean echo on attempt 2
-    expect(f.writes).toEqual([CMD, '\x15', CMD, '\r'])
+    expect(f.writes).toEqual([CMD, ABORT_LINE, CMD, '\r'])
   })
 
   it('fails open: after the last attempt times out it submits unverified', () => {
     const f = fakeIo()
     deliverCommand(f.io, CMD)
     for (let i = 0; i < DELIVERY_ATTEMPTS; i++) vi.advanceTimersByTime(VERIFY_TIMEOUT_MS)
-    // attempt 1..N writes, N-1 kill-lines between them, final bare Enter.
+    // attempt 1..N writes, N-1 aborts between them, final bare Enter.
     expect(f.writes.filter((w) => w === CMD)).toHaveLength(DELIVERY_ATTEMPTS)
-    expect(f.writes.filter((w) => w === '\x15')).toHaveLength(DELIVERY_ATTEMPTS - 1)
+    expect(f.writes.filter((w) => w === ABORT_LINE)).toHaveLength(DELIVERY_ATTEMPTS - 1)
     expect(f.writes[f.writes.length - 1]).toBe('\r')
   })
 
@@ -177,10 +186,10 @@ describe('deliverCommand', () => {
   }
 
   it('settles the delivery when the retry write throws, instead of stranding it', () => {
-    const f = throwingIo((d) => d === '\x15')
+    const f = throwingIo((d) => d === ABORT_LINE)
     let ends = 0
     deliverCommand(f.io, CMD, () => (ends += 1))
-    vi.advanceTimersByTime(VERIFY_TIMEOUT_MS) // echo never came → kill-line → throw
+    vi.advanceTimersByTime(VERIFY_TIMEOUT_MS) // echo never came → abort → throw
     expect(ends).toBe(1)
     expect(vi.getTimerCount()).toBe(0) // no retry chain left behind
     vi.advanceTimersByTime(VERIFY_TIMEOUT_MS * DELIVERY_ATTEMPTS)

--- a/src/renderer/terminal/command-delivery.ts
+++ b/src/renderer/terminal/command-delivery.ts
@@ -4,7 +4,7 @@
 // mangled line submitted anyway strands the shell at `quote>` (field report: 3 spawned
 // team agents, none started, each needed a manual `'` + Enter). So: write WITHOUT Enter,
 // wait until the shell has echoed the tail of the line back, THEN submit. A verify timeout
-// kills the pending line (Ctrl-U) and rewrites; the LAST attempt submits unverified —
+// aborts the pending line (Ctrl-C) and rewrites; the LAST attempt submits unverified —
 // fail-open, a terminal whose echo we can't recognize must never block the launch (that
 // worst case is exactly the pre-fix behavior).
 
@@ -14,8 +14,32 @@ export const DELIVERY_ATTEMPTS = 3
  *  sequence interleaved mid-line rarely lands inside the matched window. */
 export const ECHO_TAIL_CHARS = 24
 /** Ctrl-U — clear the pending input line before a rewrite. Exported because the in-place restart
- *  choreography clears the line the same way before typing its exit command (agent-restart.ts). */
+ *  choreography clears the line the same way before typing its exit command (agent-restart.ts),
+ *  where the pane is owned by an agent TUI reading raw stdin — its own kill-line binding, not the
+ *  host shell's line editor. Do NOT use it against a SHELL prompt; see ABORT_LINE. */
 export const KILL_LINE = '\x15'
+/**
+ * Ctrl-C — abandon whatever the previous attempt left in the SHELL's line editor, so the rewrite
+ * below starts from a clean prompt.
+ *
+ * This is deliberately not Ctrl-U, which is what a POSIX-only reading of "clear the line" asks
+ * for. PSReadLine — the line editor every Windows PowerShell pane runs — ships `EditMode=Windows`,
+ * and in that mode Ctrl-U is simply UNBOUND: it self-inserts and renders as a literal `^U`. The
+ * retry meant to repair a half-eaten line was therefore CREATING one, and the fail-open submit at
+ * the end of the attempts ran `^Uclaude` — an unknown command, the agent never launched. Measured
+ * on a psmux/PowerShell pane: `PS …> claude^Uclaude`.
+ *
+ * Ctrl-C is the one abort every line editor in scope honors — PSReadLine binds it to
+ * CopyOrCancelLine (cancels, with nothing selected), and POSIX shells discard the line on SIGINT.
+ * Keying this off the platform instead would be wrong twice over: the behavior belongs to the
+ * SHELL, not the OS, so a `win32` branch would hand ESC to a Git Bash pane on Windows (where ESC
+ * is readline's Meta prefix and would mangle the command's first character), and nothing the
+ * renderer can see at delivery time names the shell anyway.
+ *
+ * Safe on an already-empty prompt, which is the common case here — the attempt that timed out
+ * usually never reached the line editor at all: it prints a bare `^C` and redraws the prompt.
+ */
+export const ABORT_LINE = '\x03'
 
 // CSI (\x1b[...X), OSC (\x1b]...BEL|ST) and single-char ESC sequences.
 // eslint-disable-next-line no-control-regex
@@ -103,7 +127,7 @@ export function deliverCommand(io: DeliveryIo, cmd: string, onSettled?: () => vo
         submit() // fail-open: unverified submit beats a never-launched agent
         return
       }
-      if (!write(KILL_LINE)) return // transport gone — the delivery is over, not stuck
+      if (!write(ABORT_LINE)) return // transport gone — the delivery is over, not stuck
       tryOnce()
     }, VERIFY_TIMEOUT_MS)
     write(cmd, attempt === 1)

--- a/src/shared/update-platform.test.ts
+++ b/src/shared/update-platform.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import fs from 'fs'
+import path from 'path'
 import { isManualUpdatePlatform, shouldEnableUpdater, toUpdateAvailablePayload } from './update-platform'
 
 describe('isManualUpdatePlatform', () => {
@@ -29,6 +31,31 @@ describe('shouldEnableUpdater', () => {
   it('keeps updater behavior unchanged for normal packaged releases', () => {
     expect(shouldEnableUpdater(true, undefined)).toBe(true)
     expect(shouldEnableUpdater(true, 'enabled')).toBe(true)
+  })
+})
+
+/**
+ * `shouldEnableUpdater` is only half the fix — it reads a marker the BUILD has to set. A `dist*`
+ * script that forgets it produces a package indistinguishable from a release (`app.isPackaged` is
+ * true for both), which then polls the production feed for a version nobody published and logs a
+ * 404 on `latest*.yml` every six hours. That is a build-config mistake no unit test of the pure
+ * function can catch, so assert it against the real package.json — the same guard-test shape as
+ * `src/core/no-electron.test.ts`.
+ */
+describe('local dist scripts opt out of the production update feed', () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf8')
+  ) as { scripts: Record<string, string> }
+  const MARKER = '-c.extraMetadata.nodeTermUpdates=disabled'
+
+  it('every dist script carries the marker — not just the one whose 404 was noticed', () => {
+    const dist = Object.keys(pkg.scripts).filter((s) => s === 'dist' || s.startsWith('dist:'))
+    expect(dist.length).toBeGreaterThanOrEqual(3) // dist, dist:linux, dist:win
+    expect(dist.filter((s) => !pkg.scripts[s].includes(MARKER))).toEqual([])
+  })
+
+  it('release does NOT carry it — a promoted build must keep updating itself', () => {
+    expect(pkg.scripts.release).not.toContain(MARKER)
   })
 })
 

--- a/src/shared/update-platform.test.ts
+++ b/src/shared/update-platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isManualUpdatePlatform, toUpdateAvailablePayload } from './update-platform'
+import { isManualUpdatePlatform, shouldEnableUpdater, toUpdateAvailablePayload } from './update-platform'
 
 describe('isManualUpdatePlatform', () => {
   it('linux with APPIMAGE set → auto (self-installs)', () => {
@@ -17,6 +17,18 @@ describe('isManualUpdatePlatform', () => {
 
   it('win32 → auto', () => {
     expect(isManualUpdatePlatform('win32', false)).toBe(false)
+  })
+})
+
+describe('shouldEnableUpdater', () => {
+  it('disables checks in development and in explicitly local packaged builds', () => {
+    expect(shouldEnableUpdater(false, undefined)).toBe(false)
+    expect(shouldEnableUpdater(true, 'disabled')).toBe(false)
+  })
+
+  it('keeps updater behavior unchanged for normal packaged releases', () => {
+    expect(shouldEnableUpdater(true, undefined)).toBe(true)
+    expect(shouldEnableUpdater(true, 'enabled')).toBe(true)
   })
 })
 

--- a/src/shared/update-platform.ts
+++ b/src/shared/update-platform.ts
@@ -15,6 +15,11 @@ export function isManualUpdatePlatform(platform: string, hasAppImage: boolean): 
   return platform === 'linux' && !hasAppImage
 }
 
+/** True when updater networking should be initialized for this runtime/build. */
+export function shouldEnableUpdater(isPackaged: boolean, updateMode: unknown): boolean {
+  return isPackaged && updateMode !== 'disabled'
+}
+
 /** Reduce an electron-updater update-available info to the renderer's UpdateInfo payload. */
 export function toUpdateAvailablePayload(
   info: { version: string; releaseNotes?: unknown },


### PR DESCRIPTION
## Problem

nodeterm already contains several Windows-aware paths (PowerShell, ConPTY via `node-pty`, path handling), but two missing pieces prevent the desktop app from preserving terminal sessions there:

1. executable discovery probes extensionless names, so commands such as `tmux.exe`, `ssh.exe`, `git.exe`, and `claude.exe` are not found through a normal Windows `PATH`;
2. Windows has no native tmux package, and the UI previously hid the missing-multiplexer banner on `win32`.

Without a detected multiplexer, terminals silently fall back to a plain shell and lose reattach/scrollback continuity when the UI restarts.

## Change

- make executable discovery `PATHEXT`-aware on Windows while leaving POSIX lookup unchanged;
- centralize the executable-access check so Windows App Execution Aliases such as `winget.exe` can be detected;
- resolve `tmux` first and then `psmux`, a Windows tmux-compatible multiplexer;
- expose the missing-multiplexer banner on Windows and offer:

  ```text
  winget install -e --id marlocarlo.psmux
  ```

- make the banner's copy name the multiplexer the host actually has. Un-hiding the banner on `win32` made its no-installer fallback reachable there for the first time, and that fallback advised `brew install tmux` — a macOS-only package manager naming a package with no Windows build. Title and body now come from a pure `bannerCopy(phase, platform, hasInstallCommand)`; on Windows without winget it names winget as what is missing instead of inventing an install path;
- skip the well-known absolute tmux locations on `win32`. They are POSIX paths rooted without a drive letter, and the walk is a bare `existsSync` with no `PATHEXT` expansion, so it can never match a real `tmux.exe` — but `existsSync` is true for directories, so a stray directory named `tmux` under one of those paths would be returned as "the multiplexer" ahead of the PATH, and every spawn after it would fail with an opaque `EACCES`/`EISDIR`. macOS and Linux keep the same list, in the same order, ahead of the PATH;
- add focused tests for executable discovery, tmux/psmux selection, and the banner copy;
- add an unsigned Windows x64 NSIS target (`npm run dist:win`);
- keep locally packaged builds off the production updater feed (see below).

The psmux integration is capability/name detection rather than a separate Windows terminal backend; macOS/Linux continue to prefer the reference tmux binary.

### On the updater change

This one is not Windows-specific, and it is included here because the Windows package is what surfaced it.

A locally packaged app is indistinguishable from a release at runtime — `app.isPackaged` is true for both — so any `dist`-produced build initialized electron-updater against the production feed, polled it for a version nobody published, and logged a 404 on `latest*.yml` at boot and every six hours after. `npm run dist` on macOS and `npm run dist:linux` produce the same unpublished build and hit the same 404, so the opt-out marker is set by all three `dist` scripts rather than only `dist:win`, and `--publish never` comes with it (electron-builder defaults to `onTagOrDraft`, which on a tagged checkout with a token in the environment would try to publish a local smoke build).

`release` does not set the marker, so a promoted build wires up and updates itself exactly as before. The CI release workflow packages Linux through `electron-builder` directly and never goes through `dist:linux`, so it is unaffected either way. A guard test asserts the scripts themselves, since a `dist` script that forgets the marker is a build-config mistake no unit test of the pure function can catch and the failure mode is silent.

Happy to split this into its own PR if you would rather keep this one strictly to the Windows port.

## Verification

Tested on native Windows with Node 22 and psmux 3.3.7. Re-run on the current branch after rebasing onto `main`:

- `npm run typecheck` passes;
- 66 focused Windows/updater/banner tests pass across 7 files;
- 48 remote unit tests pass;
- `npm run build` passes;
- `npm run dist:win` produces an unsigned x64 NSIS installer, and the packaged `package.json` carries the update-opt-out marker;
- the full suite shows no regression from this branch. It is not green on a Windows host — 115 pre-existing failures across 29 files, all POSIX-only assertions (`/bin/sh`, Unix domain sockets, `0600` permissions, rooted `/...` paths) — and the count is identical with and without these commits. CI runs on `ubuntu-latest`, where those files pass.

Verified earlier on the same branch content: `npm ci` completes including Electron rebuilds for `node-pty` and `smart-whisper`; a manual GUI smoke test; and an end-to-end ConPTY/psmux probe covering session creation, UI-client disconnect, reattach to the same shell, preserved scrollback, detached `send-keys`, and session cleanup.

## Known limitations / follow-ups

- SSH askpass still tries to create a Unix-style socket path on Windows and logs `EACCES`; that is separate from terminal persistence and should be handled in a focused follow-up.
- psmux does not currently expose tmux's `terminal-features` option or `#{bracket_paste_flag}`. Basic terminal persistence and command transport work; `bracketPasteRequested` already treats a failed query as false, so paste delivery degrades to the legacy two-step path rather than misbehaving, but those optional capabilities need separate compatibility handling.
- The Windows artifact is intentionally unsigned; this PR does not add release publishing, signing, or production auto-update configuration for it.

🤖 Generated with Claude Code and independently verified by Ignis.
