### PR TITLE
Fix 2s slowloris kill of confirmation-gated control requests; add global seamless agent messaging toggle

### DIFF
--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -149,6 +149,13 @@ class HookServer {
             await readBody(req),
             String(req.headers['content-type'] ?? '')
           )
+          // Body fully received: disarm the slowloris guard. A destructive
+          // control verb legitimately parks here while the renderer waits for
+          // the user's confirmation (up to the 120s control timeout), and the
+          // receive-phase guard used to destroy the socket after 2s of that
+          // wait -- the caller saw "endpoint unreachable" while the dialog
+          // was still up.
+          req.setTimeout(0)
           const result = this.controlHandler
             ? await this.controlHandler({ verb, nodeId, args })
             : { ok: false, error: 'control unavailable' }
@@ -174,6 +181,9 @@ class HookServer {
           )
           // Always text: the caller is the sh shim, and the payload IS prose (a rendered
           // transcript). The handler owns the authorization — see context-link.ts.
+          // Disarm the receive-phase guard here too: a linked-transcript
+          // read over SSH can take longer than 2s to render its response.
+          req.setTimeout(0)
           const text = this.contextLinkHandler
             ? await this.contextLinkHandler({ verb, nodeId, args })
             : 'Context link is unavailable in this session.'

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -6356,6 +6356,28 @@ export function Canvas() {
               reply({ ok: false, error: 'write requires --node' })
               return
             }
+            const deliver = async () => {
+              try {
+                const ok = await api.pty.sendText(args.node, args.text ?? '')
+                reply({
+                  ok,
+                  message: ok ? 'sent' : 'failed',
+                  error: ok ? undefined : 'sendText failed'
+                })
+              } catch (e) {
+                reply({ ok: false, error: String(e) })
+              }
+            }
+            // Seamless agent messaging (Settings -> Agents, default off): the user has
+            // pre-approved every agent-to-node send, so deliver directly — no dialog, and no
+            // interaction with the one-confirm-at-a-time guard. This is a BLANKET grant that
+            // does not depend on WHICH node is calling, so it is safe against the hook token
+            // not being node-scoped; finer per-pair trust is intentionally deferred until the
+            // token identifies the calling node.
+            if (useSettings.getState().settings.agentSeamlessWrites) {
+              void deliver()
+              return
+            }
             // One confirm dialog at a time: setConfirm would replace a pending one, orphaning its
             // reply and hanging that earlier request to its 120s timeout — and a second dialog
             // mounted on top of a destructive one (the worktree-removal confirm) turned an Enter
@@ -6372,16 +6394,7 @@ export function Canvas() {
               requestedBy: srcTitle,
               onConfirm: async () => {
                 setConfirm(null)
-                try {
-                  const ok = await api.pty.sendText(args.node, args.text ?? '')
-                  reply({
-                    ok,
-                    message: ok ? 'sent' : 'failed',
-                    error: ok ? undefined : 'sendText failed'
-                  })
-                } catch (e) {
-                  reply({ ok: false, error: String(e) })
-                }
+                await deliver()
               },
               onCancel: () => reply({ ok: false, error: 'denied by user' })
             })

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -60,6 +60,10 @@ const ROWS = {
     title: 'One-click approvals',
     keywords: ['approve', 'deny', 'approval', 'permission', 'hook', 'phone', 'canvas', 'one click', 'claude']
   },
+  agentSeamlessWrites: {
+    title: 'Seamless agent messaging',
+    keywords: ['seamless', 'write', 'send', 'message', 'confirm', 'dialog', 'agent', 'pair', 'control']
+  },
 }
 const ENTRIES = Object.values(ROWS)
 
@@ -198,6 +202,19 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
               checked={settings.hookReplyApprovals}
               ariaLabel="One-click hook-reply approvals"
               onChange={(on) => update({ hookReplyApprovals: on })}
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.agentSeamlessWrites}>
+        <FieldRow
+          label="Seamless agent messaging"
+          description="Deliver agent-to-node write requests without the per-message confirmation dialog. Any control-capable agent can then type into any node's terminal unseen — enable only for trusted pair-programming flows. Closing nodes always confirms."
+          control={
+            <Switch
+              checked={settings.agentSeamlessWrites}
+              ariaLabel="Seamless agent messaging"
+              onChange={(on) => update({ agentSeamlessWrites: on })}
             />
           }
         />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -926,6 +926,12 @@ export interface Settings {
    *  hook holds briefly for a phone/canvas Approve/Deny before falling through to the normal
    *  interactive prompt. Off ⇒ the env var is absent ⇒ exact legacy behavior. Claude-only. */
   hookReplyApprovals: boolean
+  /** Seamless agent messaging (opt-in, default off): agent-to-node `write` control requests
+   *  deliver without the per-message confirmation dialog. With this on, any control-capable
+   *  agent node can type into any other node's terminal without the user seeing it first --
+   *  the same plumbing a cross-agent prompt injection would use. Intended for supervised
+   *  pair-programming flows. `close` keeps its confirmation regardless. */
+  agentSeamlessWrites: boolean
   /** macOS Notch HUD (docs/notch-hud.md): a transparent always-on-top strip by the notch showing
    *  walking agent mascots while agents work, expanding into a mini session panel. Default on;
    *  macOS + desktop only (ignored on other platforms / Server Edition). */
@@ -1012,6 +1018,9 @@ export const DEFAULT_SETTINGS: Settings = {
   // Deterministic hook-reply approvals default ON (existing users pick it up on hydrate). Only
   // affects Claude terminal sessions; off reproduces the pre-feature launch bit-for-bit.
   hookReplyApprovals: true,
+  // Seamless agent writes default OFF: skipping the per-message confirmation is an explicit
+  // trust decision the user makes in Settings -> Agents, never a default posture.
+  agentSeamlessWrites: false,
   // macOS Notch HUD default ON (guarded to darwin at runtime; a no-op elsewhere).
   notchHud: true,
   notchWidth: 168,


### PR DESCRIPTION
Two commits: a bug fix that makes agent `write`/`close` confirmations work at all, and a trust model on top of the working dialog.

## Bug: the slowloris guard kills confirmation-gated control requests (commit 1)

`hook-server.ts` arms `req.setTimeout(SLOWLORIS_MS /* 2s */, () => req.destroy())` before routing. For `/control/write` and `/control/close`, the main-process handler forwards to the renderer and legitimately waits up to 120s for the user's confirmation dialog — so the socket is destroyed 2 seconds into that wait. The calling shim sees curl code 000 and prints "Could not reach nodeterm (control endpoint unreachable)" while the dialog is still on screen; with the one-confirm-at-a-time guard, one stuck dialog then bounces every later write. In practice, agent-to-agent messaging only worked if the user clicked within 2 seconds.

Fix: disarm the guard (`req.setTimeout(0)`) once the request body is fully read, on the `/control/` and `/context-link/` routes (a linked-transcript read over SSH can also legitimately exceed 2s). The receive phase — what the guard exists for — is still covered.

## Feature: seamless agent messaging, global + per-pair (commits 1+2)

With the dialog now functional, pair-programming flows (agent A drives agent B, reviews, sends the next piece) still pay one click per message. This adds pre-approval at two scopes:

- **Global** (`Settings → Agents → "Seamless agent messaging"`, default **off**): every agent write delivers without the dialog. Documented in the setting's comment as the blunt instrument it is.
- **Per node pair** (the interesting one): with the global off, the write dialog gains an *"Always allow between these two nodes (both directions)"* checkbox. Confirming with it checked stores a canonical sorted `idA|idB` key on the project (persisted like the kanban board), and writes between that pair — either direction — deliver directly from then on.

Design decisions, so review can disagree with them specifically:

- **Grants die with their endpoints**: `deleteNodes` prunes every grant referencing a deleted node, so trust can never outlive — or transfer to a later reuse of — a node id.
- **`close` always confirms**, at both scopes. Only messaging is pre-approvable.
- **The one-confirm-at-a-time invariant holds**: seamless sends never mount a dialog, and the checkbox rebuilds the dialog state through the guarded `setConfirm` (never the raw setter), sharing the reply closures so a rebuild can't orphan a pending request.
- **Management/visibility**: `Settings → Agents → "Trusted node pairs"` shows a live grant count for the active project with Clear-all. The ConfirmDialog `option` prop already existed (worktree deletion opt-in) and is reused, not duplicated.

## Validation

- `npm run typecheck` clean; `npm run test` green (4468 passed; one pre-existing flaky filesystem-watch test in `board-log-handlers.test.ts` fails occasionally under full-suite load and passes in isolation, unchanged tree included).
- Exercised live: pre-fix, writes died at exactly 2s; post-fix with everything off, the dialog flow works (~seconds, human click); with a pair grant, delivery is ~100ms silent, both directions; deleting a granted node prunes the grant.

Happy to split the bug fix into its own PR if you'd rather take it separately, or to adjust the trust model (e.g. per-direction grants, TTLs) to taste.
