### PR TITLE
feat(renderer): browser Memory Saver — discard hidden webviews, restore from URL

### DIFF
--- a/docs/superpowers/plans/2026-08-10-ram-optimization.md
+++ b/docs/superpowers/plans/2026-08-10-ram-optimization.md
@@ -648,7 +648,7 @@ Run: `npm run typecheck && npx vitest run src/core src/renderer/terminal`. Commi
 
 ## Phase 4 — Browser/web node Memory Saver (one PR)
 
-Chrome's own "Memory Saver" semantics on canvas webviews: a `BrowserSurface`/`WebNode` webview hidden (offscreen or kanban-covered) for 5 minutes is **discarded** — the `<webview>` loses its `src` (guest renderer process dies), the descriptor `{url, address}` is kept, a plate renders — and restored on visibility. Back/forward stack is lost on restore (Electron webview cannot serialize it); PR body states this openly.
+Chrome's own "Memory Saver" semantics on canvas webviews: a `BrowserSurface`/`WebNode` webview hidden (**offscreen in the canvas viewport**) for 5 minutes is **discarded** — the `<webview>` element is unmounted, so the guest renderer process dies; the descriptor `{url, address}` is kept, a plate renders — and restored on visibility. Back/forward stack is lost on restore (Electron webview cannot serialize it); PR body states this openly.
 
 **Files:**
 - Create: `src/renderer/nodes/browser-discard-policy.ts`, `src/renderer/nodes/browser-discard-policy.test.ts`
@@ -756,9 +756,11 @@ Import `useSettings` (same store TerminalNode uses) and the policy module. Add `
 
 - [ ] **Step 6: WebNode.tsx** — same pattern, same policy module, on its root div; on restore re-run the existing `src` effect by re-setting state from `url`/`filePath` (the `media.allow` promise path already handles re-grant).
 
-- [ ] **Step 7: Verify + commit + PR** — `npm run typecheck && npx vitest run src/renderer/nodes`. Manual: open a browser node, cover it with kanban view for >5 min, verify in Activity Monitor / `ps` that the guest process exited; return to canvas, verify reload. Commit `feat(renderer): browser Memory Saver — discard hidden webviews, restore from URL`.
+- [ ] **Step 7: Verify + commit + PR** — `npm run typecheck && npx vitest run src/renderer/nodes`. Manual: open a browser node, **pan the node fully off-screen** for >5 min, verify in Activity Monitor / `ps` that the guest process exited; pan it back into view and verify the reload. Commit `feat(renderer): browser Memory Saver — discard hidden webviews, restore from URL`.
 
 **Surfaces:** Desktop only in practice (`<webview>` requires Electron; the Server Edition renders browser nodes via the same components but webview doesn't exist in a plain browser — verify how BrowserNode degrades there today and keep that behavior). Mobile: N/A.
+
+**Deferred by user decision (v1 = pan-only):** "hidden" means **geometrically offscreen**, as reported by an `IntersectionObserver`. Two other senses of hidden were considered and deliberately left out. (1) **Kanban-covered** — the board is an opaque overlay, but the canvas stays MOUNTED beneath it and every node still intersects the viewport, so occlusion is invisible to an IntersectionObserver; discarding on it would need an explicit signal from `KanbanView`. (2) **Window-hidden** (`document.visibilityState`) — a minimized or background window would discard every browser node at once, and every one of them would reload on return. Both are follow-ups, not gaps in v1. A page that is **making sound** is never discarded regardless (Chrome's own rule), and a load in flight blocks a discard until it finishes.
 
 ---
 

--- a/src/renderer/components/settings/sections/BehaviorSection.tsx
+++ b/src/renderer/components/settings/sections/BehaviorSection.tsx
@@ -28,6 +28,10 @@ const ROWS = {
   dragMode: {
     title: 'Canvas left-drag',
     keywords: ['pan', 'drag', 'select', 'canvas', 'mouse', 'grab', 'figma', 'miro']
+  },
+  browserSaver: {
+    title: 'Browser memory saver',
+    keywords: ['browser', 'memory', 'saver', 'ram', 'webview', 'discard', 'page', 'web']
   }
 }
 const ENTRIES = Object.values(ROWS)
@@ -168,6 +172,19 @@ export function BehaviorSection({ isActive }: { isActive: boolean }): React.JSX.
               <option value="select">Select (default)</option>
               <option value="pan">Pan the canvas</option>
             </Select>
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.browserSaver}>
+        <FieldRow
+          label="Browser memory saver"
+          description="Free a hidden browser page's memory after 5 minutes; it reloads when shown. Each page is a whole Chromium process."
+          control={
+            <Switch
+              checked={settings.browserMemorySaver}
+              onChange={(v) => update({ browserMemorySaver: v })}
+              ariaLabel="Browser memory saver"
+            />
           }
         />
       </SearchableRow>

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { searchOrUrl } from './browserUrl'
 import { BrowserStartPage } from './BrowserStartPage'
 import { useBrowserHistory } from '../state/browserHistory'
-import { useDiscardWhenHidden } from './useDiscardWhenHidden'
+import { useDiscardWhenHidden, webviewAudible } from './useDiscardWhenHidden'
 import { DiscardedPlate } from './DiscardedPlate'
 
 // Minimal typing for the Electron <webview> element methods/events we use.
@@ -15,6 +15,8 @@ type WebviewEl = HTMLElement & {
   canGoBack(): boolean
   canGoForward(): boolean
   getWebContentsId(): number
+  /** Throws before the guest attaches — always go through `webviewAudible`. */
+  isCurrentlyAudible?: () => boolean
 }
 
 interface BrowserSurfaceProps {
@@ -51,6 +53,10 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
   // a callback that must not force the observer to be re-created.
   const [discarded, setDiscarded] = useState(false)
   const loadingRef = useRef(false)
+  /** Set by a restore, cleared by the first did-navigate after it — that one is an echo. */
+  const restoringNavRef = useRef(false)
+  /** The last title we reported (null = the gate is open for the current page's first title). */
+  const lastTitleRef = useRef<string | null>(null)
   /** The page a discard would rebuild from — the last location we actually LOADED, never the
    *  address input (which holds whatever the user typed, submitted or not). */
   const locationRef = useRef(startUrl)
@@ -70,9 +76,20 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     }
     const onNav = (e: Event): void => {
       const u = (e as unknown as { url: string }).url
+      // A memory-saver restore replays the URL we were already on, and its did-navigate is
+      // indistinguishable from a real one. Reporting it would make MERELY LOOKING at a node dirty
+      // the project (updateNodeData → dirty + rev bump + SSH mirror write) and bump an unchanged
+      // page to the top of Recent. One-shot and value-checked, so a user who navigates for real
+      // immediately after a reveal is still recorded.
+      const echo = restoringNavRef.current && u === locationRef.current
+      restoringNavRef.current = false
       setAddress(u)
       locationRef.current = u
       setFailed('')
+      if (echo) return
+      // A genuine navigation re-opens the title gate below: the first title of the NEW page always
+      // records, however it compares to the old page's.
+      lastTitleRef.current = null
       onUrlChange(u)
       lastUrlRef.current = u
       useBrowserHistory.getState().record(u, u)
@@ -84,6 +101,11 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     }
     const onTitle = (e: Event): void => {
       const title = (e as unknown as { title: string }).title
+      // The restored page re-announces the title it already had, which would re-dirty the project
+      // and re-bump history through the other half of the same reveal. Suppressing it by VALUE
+      // rather than by a restore flag means a title that genuinely changed still lands.
+      if (title === lastTitleRef.current) return
+      lastTitleRef.current = title
       onTitleChange(title)
       if (lastUrlRef.current) useBrowserHistory.getState().record(lastUrlRef.current, title)
     }
@@ -135,6 +157,7 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
   // release and rebuild its page.
   useDiscardWhenHidden(rootRef, {
     isLoading: () => loadingRef.current,
+    isAudible: () => webviewAudible(ref.current),
     hasContent: () => !!locationRef.current,
     onDiscard: () => {
       setDiscarded(true)
@@ -145,6 +168,8 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     },
     onRestore: () => {
       setDiscarded(false)
+      // The restore's own did-navigate is an ECHO of where we already were — see `onNav`.
+      restoringNavRef.current = true
       // Restore from the descriptor. Setting `src` and `address` to the SAME value preserves the
       // `url !== address` guard of the sync effect below, so the restore can't start a reload loop.
       const back = locationRef.current

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { searchOrUrl } from './browserUrl'
 import { BrowserStartPage } from './BrowserStartPage'
 import { useBrowserHistory } from '../state/browserHistory'
-import { useSettings } from '../state/settings'
-import { BROWSER_DISCARD_MS, shouldDiscard } from './browser-discard-policy'
+import { useDiscardWhenHidden } from './useDiscardWhenHidden'
+import { DiscardedPlate } from './DiscardedPlate'
 
 // Minimal typing for the Electron <webview> element methods/events we use.
 type WebviewEl = HTMLElement & {
@@ -46,13 +46,11 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
   const [canBack, setCanBack] = useState(false)
   const [canFwd, setCanFwd] = useState(false)
   const [failed, setFailed] = useState('')
-  // Memory saver (see the discard effect): the page is released while hidden and rebuilt on
-  // reveal. These four are REFS, not state, because the observer below is created once and must
-  // read the CURRENT values without being torn down and re-armed on every state flip.
+  // Memory saver (see `useDiscardWhenHidden`): the page is released while hidden and rebuilt on
+  // reveal. `loadingRef` mirrors the `loading` state because the hook reads it at fire time, from
+  // a callback that must not force the observer to be re-created.
   const [discarded, setDiscarded] = useState(false)
-  const discardedRef = useRef(false)
   const loadingRef = useRef(false)
-  const hiddenSinceRef = useRef<number | null>(null)
   /** The page a discard would rebuild from — the last location we actually LOADED, never the
    *  address input (which holds whatever the user typed, submitted or not). */
   const locationRef = useRef(startUrl)
@@ -132,65 +130,28 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
 
   // ── Memory saver ────────────────────────────────────────────────────────────────────────────
   // A browser node parked off-screen is a whole Chromium renderer process doing nothing, and the
-  // canvas caps nothing. Hidden past the window (and not mid-load, and with the setting on) the
-  // page is released; entering the viewport rebuilds it from `locationRef`.
-  //
-  // The observer is created ONCE. Putting `discarded`/`loading` in the deps would re-create it —
-  // and IntersectionObserver re-reports on `observe()`, so the hidden timer would restart on every
-  // state flip and a page could sit hidden forever without reaching the window. Everything mutable
-  // is therefore read through a ref, and the SETTING is read at fire time (turning the saver off
-  // must disarm a timer armed minutes earlier).
-  useEffect(() => {
-    const el = rootRef.current
-    if (!el || typeof IntersectionObserver === 'undefined') return
-    let timer: ReturnType<typeof setTimeout> | null = null
-    const clear = (): void => {
-      if (timer) clearTimeout(timer)
-      timer = null
-    }
-    const fire = (): void => {
-      timer = null
-      const since = hiddenSinceRef.current
-      if (since == null || discardedRef.current) return
-      const enabled = useSettings.getState().settings.browserMemorySaver
-      if (!shouldDiscard({ hiddenMs: Date.now() - since, loading: loadingRef.current, enabled }))
-        return
-      // A start page has no guest process to release, and discarding it would replace the one
-      // useful thing on screen with a plate. (A page still loading after the whole window is not
-      // re-checked either: v1 waits for the next hide, rather than polling.)
-      if (!locationRef.current) return
-      discardedRef.current = true
+  // canvas caps nothing. The state machine (observer, timer, fire-time re-checks) lives in the
+  // shared hook; this surface contributes only what "loading"/"content" mean for it and how to
+  // release and rebuild its page.
+  useDiscardWhenHidden(rootRef, {
+    isLoading: () => loadingRef.current,
+    hasContent: () => !!locationRef.current,
+    onDiscard: () => {
       setDiscarded(true)
       setSrc('')
       // A failure banner belongs to the page we just released; the restore re-navigates and will
       // raise its own if the load fails again.
       setFailed('')
-    }
-    const obs = new IntersectionObserver((entries) => {
-      const visible = entries[entries.length - 1]?.isIntersecting ?? true
-      if (!visible) {
-        if (hiddenSinceRef.current == null) hiddenSinceRef.current = Date.now()
-        // +1s slack so the reading at fire time is strictly PAST the window (`shouldDiscard` is >).
-        if (!timer) timer = setTimeout(fire, BROWSER_DISCARD_MS + 1000)
-        return
-      }
-      hiddenSinceRef.current = null
-      clear()
-      if (!discardedRef.current) return
-      discardedRef.current = false
+    },
+    onRestore: () => {
       setDiscarded(false)
       // Restore from the descriptor. Setting `src` and `address` to the SAME value preserves the
       // `url !== address` guard of the sync effect below, so the restore can't start a reload loop.
       const back = locationRef.current
       setSrc(back)
       setAddress(back)
-    })
-    obs.observe(el)
-    return () => {
-      obs.disconnect()
-      clear()
     }
-  }, [])
+  })
 
   // Keep the two webviews for one node (canvas + modal) in sync: when `url` changes from the
   // OUTSIDE (the other webview navigated → node.data.url updated) and differs from where we are,
@@ -269,11 +230,7 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
             }}
           />
         )}
-        {discarded && (
-          <div className="browser-node__discarded">
-            <span>Page released to save memory — reopens on view</span>
-          </div>
-        )}
+        {discarded && <DiscardedPlate />}
         {failed && <div className="browser-node__error">{failed}</div>}
       </div>
     </div>

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -53,8 +53,10 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
   // a callback that must not force the observer to be re-created.
   const [discarded, setDiscarded] = useState(false)
   const loadingRef = useRef(false)
-  /** Set by a restore, cleared by the first did-navigate after it — that one is an echo. */
-  const restoringNavRef = useRef(false)
+  /** The URL a restore is replaying (null = no restore in flight); the first did-navigate carrying
+   *  exactly it is that echo. Cleared by that navigation, by any user-initiated one, and by a
+   *  failed load. */
+  const restoringNavRef = useRef<string | null>(null)
   /** The last title we reported (null = the gate is open for the current page's first title). */
   const lastTitleRef = useRef<string | null>(null)
   /** The page a discard would rebuild from — the last location we actually LOADED, never the
@@ -81,8 +83,13 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
       // the project (updateNodeData → dirty + rev bump + SSH mirror write) and bump an unchanged
       // page to the top of Recent. One-shot and value-checked, so a user who navigates for real
       // immediately after a reveal is still recorded.
-      const echo = restoringNavRef.current && u === locationRef.current
-      restoringNavRef.current = false
+      // The ref holds the restore's URL rather than a boolean because `locationRef` moves with
+      // every navigation INITIATOR: compared against it, a user's own same-URL navigation read as
+      // an echo, and after a FAILED restore (no did-navigate ever arrives) the stuck flag swallowed
+      // the next address-bar navigation to ANY url — leaving `data.url` stale and filing that
+      // page's title under the previous one.
+      const echo = restoringNavRef.current !== null && u === restoringNavRef.current
+      restoringNavRef.current = null
       setAddress(u)
       locationRef.current = u
       setFailed('')
@@ -111,7 +118,11 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     }
     const onFail = (e: Event): void => {
       const ev = e as unknown as { isMainFrame: boolean; errorCode: number; errorDescription: string }
-      if (ev.isMainFrame && ev.errorCode !== -3) setFailed(ev.errorDescription || 'Failed to load')
+      if (ev.isMainFrame && ev.errorCode !== -3) {
+        // A restore that never landed has no echo to swallow — disarm, or the next navigation pays.
+        restoringNavRef.current = null
+        setFailed(ev.errorDescription || 'Failed to load')
+      }
     }
     wv.addEventListener('did-start-loading', onStart)
     wv.addEventListener('did-stop-loading', onStop)
@@ -168,11 +179,11 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     },
     onRestore: () => {
       setDiscarded(false)
-      // The restore's own did-navigate is an ECHO of where we already were — see `onNav`.
-      restoringNavRef.current = true
       // Restore from the descriptor. Setting `src` and `address` to the SAME value preserves the
       // `url !== address` guard of the sync effect below, so the restore can't start a reload loop.
       const back = locationRef.current
+      // The restore's own did-navigate is an ECHO of this exact URL — see `onNav`.
+      restoringNavRef.current = back
       setSrc(back)
       setAddress(back)
     }
@@ -184,6 +195,8 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
   // no-op — no reload loop.
   useEffect(() => {
     if (url && url !== address) {
+      // A navigation with an initiator: whatever it navigates to is not a restore echo.
+      restoringNavRef.current = null
       setSrc(url)
       setAddress(url)
       // Keep the discard descriptor current even while discarded: a node released off-screen must
@@ -201,6 +214,8 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     }
     setAddress(safe)
     setFailed('')
+    // A navigation with an initiator: whatever it navigates to is not a restore echo.
+    restoringNavRef.current = null
     locationRef.current = safe
     if (safe === src) ref.current?.reload()
     else setSrc(safe)
@@ -248,6 +263,8 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
         {!src && !discarded && (
           <BrowserStartPage
             onNavigate={(u) => {
+              // A navigation with an initiator: whatever it navigates to is not a restore echo.
+              restoringNavRef.current = null
               setSrc(u)
               setAddress(u)
               locationRef.current = u

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { searchOrUrl } from './browserUrl'
 import { BrowserStartPage } from './BrowserStartPage'
 import { useBrowserHistory } from '../state/browserHistory'
+import { useSettings } from '../state/settings'
+import { BROWSER_DISCARD_MS, shouldDiscard } from './browser-discard-policy'
 
 // Minimal typing for the Electron <webview> element methods/events we use.
 type WebviewEl = HTMLElement & {
@@ -35,6 +37,7 @@ interface BrowserSurfaceProps {
  */
 export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: BrowserSurfaceProps) {
   const ref = useRef<WebviewEl | null>(null)
+  const rootRef = useRef<HTMLDivElement | null>(null)
   const lastUrlRef = useRef('')
   const [startUrl] = useState(() => url ?? '')
   const [src, setSrc] = useState(startUrl)
@@ -43,12 +46,26 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
   const [canBack, setCanBack] = useState(false)
   const [canFwd, setCanFwd] = useState(false)
   const [failed, setFailed] = useState('')
+  // Memory saver (see the discard effect): the page is released while hidden and rebuilt on
+  // reveal. These four are REFS, not state, because the observer below is created once and must
+  // read the CURRENT values without being torn down and re-armed on every state flip.
+  const [discarded, setDiscarded] = useState(false)
+  const discardedRef = useRef(false)
+  const loadingRef = useRef(false)
+  const hiddenSinceRef = useRef<number | null>(null)
+  /** The page a discard would rebuild from — the last location we actually LOADED, never the
+   *  address input (which holds whatever the user typed, submitted or not). */
+  const locationRef = useRef(startUrl)
 
   useEffect(() => {
     const wv = ref.current
     if (!wv) return
-    const onStart = (): void => setLoading(true)
+    const onStart = (): void => {
+      loadingRef.current = true
+      setLoading(true)
+    }
     const onStop = (): void => {
+      loadingRef.current = false
       setLoading(false)
       setCanBack(wv.canGoBack())
       setCanFwd(wv.canGoForward())
@@ -56,12 +73,17 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     const onNav = (e: Event): void => {
       const u = (e as unknown as { url: string }).url
       setAddress(u)
+      locationRef.current = u
       setFailed('')
       onUrlChange(u)
       lastUrlRef.current = u
       useBrowserHistory.getState().record(u, u)
     }
-    const onNavInPage = (e: Event): void => setAddress((e as unknown as { url: string }).url)
+    const onNavInPage = (e: Event): void => {
+      const u = (e as unknown as { url: string }).url
+      setAddress(u)
+      locationRef.current = u
+    }
     const onTitle = (e: Event): void => {
       const title = (e as unknown as { title: string }).title
       onTitleChange(title)
@@ -85,8 +107,14 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
       wv.removeEventListener('page-title-updated', onTitle)
       wv.removeEventListener('did-fail-load', onFail)
     }
-  }, [onUrlChange, onTitleChange])
+    // `discarded` is a dep because a discard UNMOUNTS the <webview> element (dropping `src` alone
+    // would leave the guest process alive): the restored element is a different node, so the
+    // listeners have to be re-attached to it.
+  }, [onUrlChange, onTitleChange, discarded])
 
+  // Registers the guest so main can route its new-window requests. `discarded` is a dep for the
+  // same reason as above — and it is what makes a discard UNREGISTER the dead wcId through this
+  // cleanup, rather than leaking it until the node unmounts.
   useEffect(() => {
     const wv = ref.current
     if (!wv) return
@@ -100,7 +128,69 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
       wv.removeEventListener('dom-ready', onReady)
       if (wcId) window.nodeTerminal.browser.unregister(wcId)
     }
-  }, [nodeId])
+  }, [nodeId, discarded])
+
+  // ── Memory saver ────────────────────────────────────────────────────────────────────────────
+  // A browser node parked off-screen is a whole Chromium renderer process doing nothing, and the
+  // canvas caps nothing. Hidden past the window (and not mid-load, and with the setting on) the
+  // page is released; entering the viewport rebuilds it from `locationRef`.
+  //
+  // The observer is created ONCE. Putting `discarded`/`loading` in the deps would re-create it —
+  // and IntersectionObserver re-reports on `observe()`, so the hidden timer would restart on every
+  // state flip and a page could sit hidden forever without reaching the window. Everything mutable
+  // is therefore read through a ref, and the SETTING is read at fire time (turning the saver off
+  // must disarm a timer armed minutes earlier).
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el || typeof IntersectionObserver === 'undefined') return
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const clear = (): void => {
+      if (timer) clearTimeout(timer)
+      timer = null
+    }
+    const fire = (): void => {
+      timer = null
+      const since = hiddenSinceRef.current
+      if (since == null || discardedRef.current) return
+      const enabled = useSettings.getState().settings.browserMemorySaver
+      if (!shouldDiscard({ hiddenMs: Date.now() - since, loading: loadingRef.current, enabled }))
+        return
+      // A start page has no guest process to release, and discarding it would replace the one
+      // useful thing on screen with a plate. (A page still loading after the whole window is not
+      // re-checked either: v1 waits for the next hide, rather than polling.)
+      if (!locationRef.current) return
+      discardedRef.current = true
+      setDiscarded(true)
+      setSrc('')
+      // A failure banner belongs to the page we just released; the restore re-navigates and will
+      // raise its own if the load fails again.
+      setFailed('')
+    }
+    const obs = new IntersectionObserver((entries) => {
+      const visible = entries[entries.length - 1]?.isIntersecting ?? true
+      if (!visible) {
+        if (hiddenSinceRef.current == null) hiddenSinceRef.current = Date.now()
+        // +1s slack so the reading at fire time is strictly PAST the window (`shouldDiscard` is >).
+        if (!timer) timer = setTimeout(fire, BROWSER_DISCARD_MS + 1000)
+        return
+      }
+      hiddenSinceRef.current = null
+      clear()
+      if (!discardedRef.current) return
+      discardedRef.current = false
+      setDiscarded(false)
+      // Restore from the descriptor. Setting `src` and `address` to the SAME value preserves the
+      // `url !== address` guard of the sync effect below, so the restore can't start a reload loop.
+      const back = locationRef.current
+      setSrc(back)
+      setAddress(back)
+    })
+    obs.observe(el)
+    return () => {
+      obs.disconnect()
+      clear()
+    }
+  }, [])
 
   // Keep the two webviews for one node (canvas + modal) in sync: when `url` changes from the
   // OUTSIDE (the other webview navigated → node.data.url updated) and differs from where we are,
@@ -110,6 +200,9 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     if (url && url !== address) {
       setSrc(url)
       setAddress(url)
+      // Keep the discard descriptor current even while discarded: a node released off-screen must
+      // come back at where the OTHER webview navigated to, not at where it was released.
+      locationRef.current = url
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [url])
@@ -122,12 +215,13 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
     }
     setAddress(safe)
     setFailed('')
+    locationRef.current = safe
     if (safe === src) ref.current?.reload()
     else setSrc(safe)
   }
 
   return (
-    <div className="browser-surface">
+    <div className="browser-surface" ref={rootRef}>
       <div className="browser-node__toolbar nodrag">
         <button className="browser-node__btn" disabled={!canBack} onClick={() => ref.current?.goBack()} title="Back">
           ◀
@@ -154,21 +248,31 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
         />
       </div>
       <div className="browser-node__view nodrag nowheel">
-        {/* eslint-disable-next-line react/no-unknown-property */}
-        <webview
-          ref={ref as unknown as React.Ref<HTMLElement>}
-          src={src || undefined}
-          allowpopups={true}
-          style={{ width: '100%', height: '100%' }}
-        />
-        {!src && (
+        {/* The element is UNMOUNTED while discarded — that is what ends the guest process; an
+            emptied `src` attribute does not (Electron ignores a src mutation to nothing). */}
+        {!discarded && (
+          // eslint-disable-next-line react/no-unknown-property
+          <webview
+            ref={ref as unknown as React.Ref<HTMLElement>}
+            src={src || undefined}
+            allowpopups={true}
+            style={{ width: '100%', height: '100%' }}
+          />
+        )}
+        {!src && !discarded && (
           <BrowserStartPage
             onNavigate={(u) => {
               setSrc(u)
               setAddress(u)
+              locationRef.current = u
               setFailed('')
             }}
           />
+        )}
+        {discarded && (
+          <div className="browser-node__discarded">
+            <span>Page released to save memory — reopens on view</span>
+          </div>
         )}
         {failed && <div className="browser-node__error">{failed}</div>}
       </div>

--- a/src/renderer/nodes/DiscardedPlate.tsx
+++ b/src/renderer/nodes/DiscardedPlate.tsx
@@ -1,0 +1,14 @@
+/**
+ * What stands in for a page whose Chromium process was released while the node sat off-screen
+ * ({@link useDiscardWhenHidden}). One component so the two surfaces that host a `<webview>` cannot
+ * drift into two different wordings for the same state.
+ *
+ * Deliberately quiet: this is an ambient state that heals itself on view, not an error.
+ */
+export function DiscardedPlate({ restoring = false }: { restoring?: boolean }): React.JSX.Element {
+  return (
+    <div className="browser-node__discarded">
+      <span>{restoring ? 'Reopening…' : 'Page released to save memory — reopens on view'}</span>
+    </div>
+  )
+}

--- a/src/renderer/nodes/WebNode.tsx
+++ b/src/renderer/nodes/WebNode.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import type { CanvasNode } from '../state/workspace'
 import { httpUrl } from './webUrl'
+import { useSettings } from '../state/settings'
+import { BROWSER_DISCARD_MS, shouldDiscard } from './browser-discard-policy'
 
 /**
  * A web view node. When `data.url` is set it loads that live URL; otherwise it serves the
@@ -16,6 +18,20 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const url = (data.url as string) ?? ''
   const filePath = (data.filePath as string) ?? ''
   const title = (data.title as string) || url || filePath.split('/').pop() || 'web'
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  // Memory saver — same policy as {@link BrowserSurface}: hidden long enough, the <webview> is
+  // unmounted (its Chromium process exits) and rebuilt on reveal. `revive` is what re-runs the
+  // source effect below, so the `nt-media://` grant is re-issued for a local file exactly as it
+  // was at mount. Mutable inputs are refs because the observer is created once (see BrowserSurface).
+  const [discarded, setDiscarded] = useState(false)
+  const [revive, setRevive] = useState(0)
+  const discardedRef = useRef(false)
+  const hiddenSinceRef = useRef<number | null>(null)
+  const srcRef = useRef('')
+  /** "Loading" here is the media grant being in flight — the only await between mount and a
+   *  usable src (a live URL is resolved synchronously). Discarding mid-grant would drop the
+   *  answer to a request already made. */
+  const grantingRef = useRef(false)
 
   useEffect(() => {
     let alive = true
@@ -23,26 +39,75 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
       const safe = httpUrl(url)
       if (safe) {
         setSrc(safe)
+        srcRef.current = safe
       } else {
         setError('Unsupported URL scheme — only http/https')
       }
     } else if (filePath) {
+      grantingRef.current = true
       window.nodeTerminal.media
         .allow(filePath)
         .then((mediaUrl) => {
-          if (alive) setSrc(mediaUrl)
+          grantingRef.current = false
+          if (alive) {
+            setSrc(mediaUrl)
+            srcRef.current = mediaUrl
+          }
         })
         .catch(() => {
+          grantingRef.current = false
           if (alive) setError('Couldn’t load this page.')
         })
     }
     return () => {
       alive = false
     }
-  }, [url, filePath])
+  }, [url, filePath, revive])
+
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el || typeof IntersectionObserver === 'undefined') return
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const clear = (): void => {
+      if (timer) clearTimeout(timer)
+      timer = null
+    }
+    const fire = (): void => {
+      timer = null
+      const since = hiddenSinceRef.current
+      if (since == null || discardedRef.current || !srcRef.current) return
+      const enabled = useSettings.getState().settings.browserMemorySaver
+      if (!shouldDiscard({ hiddenMs: Date.now() - since, loading: grantingRef.current, enabled }))
+        return
+      discardedRef.current = true
+      setDiscarded(true)
+      setSrc('')
+    }
+    const obs = new IntersectionObserver((entries) => {
+      const visible = entries[entries.length - 1]?.isIntersecting ?? true
+      if (!visible) {
+        if (hiddenSinceRef.current == null) hiddenSinceRef.current = Date.now()
+        if (!timer) timer = setTimeout(fire, BROWSER_DISCARD_MS + 1000)
+        return
+      }
+      hiddenSinceRef.current = null
+      clear()
+      if (!discardedRef.current) return
+      discardedRef.current = false
+      setDiscarded(false)
+      setError('')
+      setRevive((n) => n + 1)
+    })
+    obs.observe(el)
+    return () => {
+      obs.disconnect()
+      clear()
+    }
+  }, [])
 
   return (
     <div
+      ref={rootRef}
       className={`term-node web-node${selected ? ' selected' : ''}`}
       style={{ borderTopColor: data.color }}
     >
@@ -84,7 +149,11 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
 
       <div className="editor-node__body">
         <div className="editor-node__image nodrag nowheel">
-          {src ? (
+          {discarded ? (
+            <div className="browser-node__discarded">
+              <span>Page released to save memory — reopens on view</span>
+            </div>
+          ) : src ? (
             // eslint-disable-next-line react/no-unknown-property
             <webview src={src} style={{ width: '100%', height: '100%' }} />
           ) : (

--- a/src/renderer/nodes/WebNode.tsx
+++ b/src/renderer/nodes/WebNode.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import type { CanvasNode } from '../state/workspace'
 import { httpUrl } from './webUrl'
-import { useSettings } from '../state/settings'
-import { BROWSER_DISCARD_MS, shouldDiscard } from './browser-discard-policy'
+import { useDiscardWhenHidden } from './useDiscardWhenHidden'
+import { DiscardedPlate } from './DiscardedPlate'
 
 /**
  * A web view node. When `data.url` is set it loads that live URL; otherwise it serves the
@@ -19,14 +19,13 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const filePath = (data.filePath as string) ?? ''
   const title = (data.title as string) || url || filePath.split('/').pop() || 'web'
   const rootRef = useRef<HTMLDivElement | null>(null)
-  // Memory saver — same policy as {@link BrowserSurface}: hidden long enough, the <webview> is
-  // unmounted (its Chromium process exits) and rebuilt on reveal. `revive` is what re-runs the
-  // source effect below, so the `nt-media://` grant is re-issued for a local file exactly as it
-  // was at mount. Mutable inputs are refs because the observer is created once (see BrowserSurface).
+  // Memory saver — the same shared hook {@link BrowserSurface} uses: hidden long enough, the
+  // <webview> is unmounted (its Chromium process exits) and rebuilt on reveal. `revive` is what
+  // re-runs the source effect below, so the `nt-media://` grant is re-issued for a local file
+  // exactly as it was at mount. `srcRef` mirrors `src` for the hook's fire-time content check.
   const [discarded, setDiscarded] = useState(false)
+  const [restoring, setRestoring] = useState(false)
   const [revive, setRevive] = useState(0)
-  const discardedRef = useRef(false)
-  const hiddenSinceRef = useRef<number | null>(null)
   const srcRef = useRef('')
   /** "Loading" here is the media grant being in flight — the only await between mount and a
    *  usable src (a live URL is resolved synchronously). Discarding mid-grant would drop the
@@ -35,6 +34,12 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
 
   useEffect(() => {
     let alive = true
+    // `settled` ends the restore plate (see `restoring`): the source effect has produced an
+    // outcome — a src, an error, or nothing to load at all. Without the last case a node whose
+    // url/filePath vanished while it was hidden would sit under the plate forever.
+    const settled = (): void => {
+      if (alive) setRestoring(false)
+    }
     if (url) {
       const safe = httpUrl(url)
       if (safe) {
@@ -43,6 +48,7 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
       } else {
         setError('Unsupported URL scheme — only http/https')
       }
+      settled()
     } else if (filePath) {
       grantingRef.current = true
       window.nodeTerminal.media
@@ -53,57 +59,38 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
             setSrc(mediaUrl)
             srcRef.current = mediaUrl
           }
+          settled()
         })
         .catch(() => {
           grantingRef.current = false
           if (alive) setError('Couldn’t load this page.')
+          settled()
         })
+    } else {
+      settled()
     }
     return () => {
       alive = false
     }
   }, [url, filePath, revive])
 
-  useEffect(() => {
-    const el = rootRef.current
-    if (!el || typeof IntersectionObserver === 'undefined') return
-    let timer: ReturnType<typeof setTimeout> | null = null
-    const clear = (): void => {
-      if (timer) clearTimeout(timer)
-      timer = null
-    }
-    const fire = (): void => {
-      timer = null
-      const since = hiddenSinceRef.current
-      if (since == null || discardedRef.current || !srcRef.current) return
-      const enabled = useSettings.getState().settings.browserMemorySaver
-      if (!shouldDiscard({ hiddenMs: Date.now() - since, loading: grantingRef.current, enabled }))
-        return
-      discardedRef.current = true
+  useDiscardWhenHidden(rootRef, {
+    isLoading: () => grantingRef.current,
+    hasContent: () => !!srcRef.current,
+    onDiscard: () => {
       setDiscarded(true)
       setSrc('')
-    }
-    const obs = new IntersectionObserver((entries) => {
-      const visible = entries[entries.length - 1]?.isIntersecting ?? true
-      if (!visible) {
-        if (hiddenSinceRef.current == null) hiddenSinceRef.current = Date.now()
-        if (!timer) timer = setTimeout(fire, BROWSER_DISCARD_MS + 1000)
-        return
-      }
-      hiddenSinceRef.current = null
-      clear()
-      if (!discardedRef.current) return
-      discardedRef.current = false
+      srcRef.current = ''
+    },
+    onRestore: () => {
       setDiscarded(false)
+      // Hold the plate until the source effect has re-run to an outcome. A local file's grant is a
+      // round-trip to main, and without this the node flashes "No source" for the whole of it.
+      setRestoring(true)
       setError('')
       setRevive((n) => n + 1)
-    })
-    obs.observe(el)
-    return () => {
-      obs.disconnect()
-      clear()
     }
-  }, [])
+  })
 
   return (
     <div
@@ -149,10 +136,8 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
 
       <div className="editor-node__body">
         <div className="editor-node__image nodrag nowheel">
-          {discarded ? (
-            <div className="browser-node__discarded">
-              <span>Page released to save memory — reopens on view</span>
-            </div>
+          {discarded || restoring ? (
+            <DiscardedPlate restoring={restoring} />
           ) : src ? (
             // eslint-disable-next-line react/no-unknown-property
             <webview src={src} style={{ width: '100%', height: '100%' }} />

--- a/src/renderer/nodes/WebNode.tsx
+++ b/src/renderer/nodes/WebNode.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import type { CanvasNode } from '../state/workspace'
 import { httpUrl } from './webUrl'
-import { useDiscardWhenHidden } from './useDiscardWhenHidden'
+import { useDiscardWhenHidden, webviewAudible, type AudibleWebview } from './useDiscardWhenHidden'
 import { DiscardedPlate } from './DiscardedPlate'
 
 /**
@@ -19,6 +19,8 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const filePath = (data.filePath as string) ?? ''
   const title = (data.title as string) || url || filePath.split('/').pop() || 'web'
   const rootRef = useRef<HTMLDivElement | null>(null)
+  /** The guest, for the audible check only — a local html page can hold a playing <video>. */
+  const wvRef = useRef<AudibleWebview | null>(null)
   // Memory saver — the same shared hook {@link BrowserSurface} uses: hidden long enough, the
   // <webview> is unmounted (its Chromium process exits) and rebuilt on reveal. `revive` is what
   // re-runs the source effect below, so the `nt-media://` grant is re-issued for a local file
@@ -76,6 +78,7 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
 
   useDiscardWhenHidden(rootRef, {
     isLoading: () => grantingRef.current,
+    isAudible: () => webviewAudible(wvRef.current),
     hasContent: () => !!srcRef.current,
     onDiscard: () => {
       setDiscarded(true)
@@ -140,7 +143,13 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
             <DiscardedPlate restoring={restoring} />
           ) : src ? (
             // eslint-disable-next-line react/no-unknown-property
-            <webview src={src} style={{ width: '100%', height: '100%' }} />
+            <webview
+              ref={(el) => {
+                wvRef.current = el as unknown as AudibleWebview | null
+              }}
+              src={src}
+              style={{ width: '100%', height: '100%' }}
+            />
           ) : (
             <span className="editor-node__loading">{error || 'No source'}</span>
           )}

--- a/src/renderer/nodes/browser-discard-policy.test.ts
+++ b/src/renderer/nodes/browser-discard-policy.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { BROWSER_DISCARD_MS, shouldDiscard } from './browser-discard-policy'
+
+describe('browser discard policy', () => {
+  it('discards only when enabled, hidden past the window, and not loading', () => {
+    expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS + 1, loading: false, enabled: true })).toBe(true)
+    expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS - 1, loading: false, enabled: true })).toBe(false)
+    expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS + 1, loading: true, enabled: true })).toBe(false)
+    expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS + 1, loading: false, enabled: false })).toBe(false)
+  })
+
+  it('treats the window boundary as not-yet-elapsed', () => {
+    // The timer fires on a slack margin past the window, so an exactly-equal reading means the
+    // clock jumped (sleep/wake) rather than the page having genuinely sat hidden long enough.
+    expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS, loading: false, enabled: true })).toBe(false)
+  })
+
+  it('is five minutes', () => {
+    expect(BROWSER_DISCARD_MS).toBe(5 * 60_000)
+  })
+})

--- a/src/renderer/nodes/browser-discard-policy.test.ts
+++ b/src/renderer/nodes/browser-discard-policy.test.ts
@@ -9,6 +9,15 @@ describe('browser discard policy', () => {
     expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS + 1, loading: false, enabled: false })).toBe(false)
   })
 
+  it('never discards a page that is making sound', () => {
+    // Audible = in use, even off-screen (a call, music, a video being listened to).
+    expect(
+      shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS + 1, loading: false, enabled: true, audible: true })
+    ).toBe(false)
+    // A surface that cannot tell (no `audible` at all) is not treated as audible.
+    expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS + 1, loading: false, enabled: true })).toBe(true)
+  })
+
   it('treats the window boundary as not-yet-elapsed', () => {
     // The timer fires on a slack margin past the window, so an exactly-equal reading means the
     // clock jumped (sleep/wake) rather than the page having genuinely sat hidden long enough.

--- a/src/renderer/nodes/browser-discard-policy.ts
+++ b/src/renderer/nodes/browser-discard-policy.ts
@@ -4,11 +4,18 @@
  * browser/web nodes it holds. A page that has sat hidden this long is cheaper to rebuild from its
  * URL on reveal than to keep resident.
  *
- * Two constraints are baked into the predicate:
+ * Three constraints are baked into the predicate:
  *  - **Never discard mid-load.** Restoring would replay a half-finished navigation (and a POST
  *    result or an interstitial would simply be lost).
- *  - **The setting is read at DECISION time, not at arm time.** A user who switches the saver off
- *    while a page is hidden must not have it discarded by a timer armed a minute earlier.
+ *  - **Never discard a page making noise.** Audible = in use, even off-screen (a call, music, a
+ *    video the user is listening to). Chrome exempts audible tabs for the same reason.
+ *  - **The setting is re-read when the timer FIRES, not when it was armed** — so a user who
+ *    switches the saver off during a hidden stretch is not discarded by an older timer. The
+ *    symmetry is deliberately incomplete: switching the saver ON mid-hide does NOT discard that
+ *    page at the end of the current stretch, because the disabled branch arms no retry (pinned by
+ *    `useDiscardWhenHidden.test.tsx`). Such a page is picked up on its next hide→show cycle. The
+ *    conservative direction is the right one — a user turning the feature off must be obeyed at
+ *    once, one turning it on can wait.
  *
  * The back/forward stack does NOT survive a discard — Electron's `<webview>` cannot serialize it.
  * What survives is the descriptor (the current URL) and the user's own history store, which is the
@@ -16,6 +23,12 @@
  */
 export const BROWSER_DISCARD_MS = 5 * 60_000
 
-export function shouldDiscard(i: { hiddenMs: number; loading: boolean; enabled: boolean }): boolean {
-  return i.enabled && !i.loading && i.hiddenMs > BROWSER_DISCARD_MS
+export function shouldDiscard(i: {
+  hiddenMs: number
+  loading: boolean
+  enabled: boolean
+  /** Is the page making sound right now? Optional so a surface that cannot tell says nothing. */
+  audible?: boolean
+}): boolean {
+  return i.enabled && !i.loading && !i.audible && i.hiddenMs > BROWSER_DISCARD_MS
 }

--- a/src/renderer/nodes/browser-discard-policy.ts
+++ b/src/renderer/nodes/browser-discard-policy.ts
@@ -1,0 +1,21 @@
+/**
+ * Hidden-webview discard ("Browser Memory Saver", the same idea as Chrome tab discarding): each
+ * Electron `<webview>` is a full Chromium renderer PROCESS, and a canvas has no cap on how many
+ * browser/web nodes it holds. A page that has sat hidden this long is cheaper to rebuild from its
+ * URL on reveal than to keep resident.
+ *
+ * Two constraints are baked into the predicate:
+ *  - **Never discard mid-load.** Restoring would replay a half-finished navigation (and a POST
+ *    result or an interstitial would simply be lost).
+ *  - **The setting is read at DECISION time, not at arm time.** A user who switches the saver off
+ *    while a page is hidden must not have it discarded by a timer armed a minute earlier.
+ *
+ * The back/forward stack does NOT survive a discard — Electron's `<webview>` cannot serialize it.
+ * What survives is the descriptor (the current URL) and the user's own history store, which is the
+ * same trade Chrome makes.
+ */
+export const BROWSER_DISCARD_MS = 5 * 60_000
+
+export function shouldDiscard(i: { hiddenMs: number; loading: boolean; enabled: boolean }): boolean {
+  return i.enabled && !i.loading && i.hiddenMs > BROWSER_DISCARD_MS
+}

--- a/src/renderer/nodes/useDiscardWhenHidden.test.tsx
+++ b/src/renderer/nodes/useDiscardWhenHidden.test.tsx
@@ -9,6 +9,7 @@ import {
   DISCARD_RETRY_MS,
   DISCARD_SLACK_MS,
   useDiscardWhenHidden,
+  webviewAudible,
   type DiscardWhenHiddenOptions
 } from './useDiscardWhenHidden'
 
@@ -40,6 +41,7 @@ function Harness(props: Partial<DiscardWhenHiddenOptions> & { onEl?: (el: HTMLEl
   const ref = useRef<HTMLDivElement | null>(null)
   useDiscardWhenHidden(ref, {
     isLoading: props.isLoading ?? (() => false),
+    isAudible: props.isAudible,
     hasContent: props.hasContent ?? (() => true),
     onDiscard: props.onDiscard ?? (() => {}),
     onRestore: props.onRestore ?? (() => {})
@@ -173,6 +175,38 @@ describe('useDiscardWhenHidden', () => {
     loading = false
     advance(DISCARD_RETRY_MS)
     expect(onDiscard).toHaveBeenCalledTimes(1)
+  })
+
+  it('never discards a page making sound, and reclaims it once it goes quiet', () => {
+    const onDiscard = vi.fn()
+    let audible = true
+    let el!: HTMLElement
+    root = mount({ onDiscard, isAudible: () => audible, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+    expect(onDiscard).not.toHaveBeenCalled()
+    // Still playing a minute later — still exempt, and still re-armed.
+    advance(DISCARD_RETRY_MS)
+    expect(onDiscard).not.toHaveBeenCalled()
+    audible = false
+    advance(DISCARD_RETRY_MS)
+    expect(onDiscard).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads audibility through a webview ref that can throw or be absent', () => {
+    // A guest that has not attached yet throws on the call, and a discarded surface has no element
+    // at all — neither is "audible", and neither may take the saver down with it.
+    expect(webviewAudible(null)).toBe(false)
+    expect(webviewAudible(undefined)).toBe(false)
+    expect(webviewAudible({})).toBe(false)
+    expect(
+      webviewAudible({
+        isCurrentlyAudible: () => {
+          throw new Error('The WebView must be attached to the DOM')
+        }
+      })
+    ).toBe(false)
+    expect(webviewAudible({ isCurrentlyAudible: () => true })).toBe(true)
   })
 
   it('honours the setting at FIRE time, not at arm time', () => {

--- a/src/renderer/nodes/useDiscardWhenHidden.test.tsx
+++ b/src/renderer/nodes/useDiscardWhenHidden.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act, useRef } from 'react'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import { useSettings } from '../state/settings'
+import { BROWSER_DISCARD_MS, shouldDiscard } from './browser-discard-policy'
+import {
+  DISCARD_RETRY_MS,
+  DISCARD_SLACK_MS,
+  useDiscardWhenHidden,
+  type DiscardWhenHiddenOptions
+} from './useDiscardWhenHidden'
+
+// Standalone harness — react-dom + the real zustand settings store, no testing-library
+// dependency (the same shape as CustomAgentsSection.test.tsx).
+
+/** The single observer the harness creates, so a test can drive visibility by hand. */
+let observed: ((visible: boolean) => void) | null = null
+
+class FakeIntersectionObserver {
+  constructor(private cb: (entries: { isIntersecting: boolean }[]) => void) {
+    observed = (visible: boolean) => this.cb([{ isIntersecting: visible }])
+  }
+  observe(): void {}
+  disconnect(): void {
+    observed = null
+  }
+}
+
+/** Geometry the hook re-measures at fire time. jsdom's own rect is all-zero = off-screen. */
+function stubRect(el: HTMLElement, onScreen: boolean): void {
+  el.getBoundingClientRect = () =>
+    (onScreen
+      ? { top: 10, left: 10, bottom: 110, right: 110, width: 100, height: 100 }
+      : { top: -500, left: -500, bottom: -400, right: -400, width: 100, height: 100 }) as DOMRect
+}
+
+function Harness(props: Partial<DiscardWhenHiddenOptions> & { onEl?: (el: HTMLElement) => void }) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  useDiscardWhenHidden(ref, {
+    isLoading: props.isLoading ?? (() => false),
+    hasContent: props.hasContent ?? (() => true),
+    onDiscard: props.onDiscard ?? (() => {}),
+    onRestore: props.onRestore ?? (() => {})
+  })
+  return (
+    <div
+      ref={(el) => {
+        ref.current = el
+        if (el) props.onEl?.(el)
+      }}
+    />
+  )
+}
+
+function mount(props: Parameters<typeof Harness>[0]): Root {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  act(() => {
+    root.render(<Harness {...props} />)
+  })
+  return root
+}
+
+/** Hide the element (geometry + the observer's verdict). */
+function hide(el: HTMLElement): void {
+  stubRect(el, false)
+  act(() => observed?.(false))
+}
+function show(el: HTMLElement): void {
+  stubRect(el, true)
+  act(() => observed?.(true))
+}
+function advance(ms: number): void {
+  act(() => {
+    vi.advanceTimersByTime(ms)
+  })
+}
+
+describe('useDiscardWhenHidden', () => {
+  let root: Root | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+    useSettings.setState({ settings: { ...DEFAULT_SETTINGS } })
+    observed = null
+  })
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('does not discard before the window has elapsed', () => {
+    const onDiscard = vi.fn()
+    let el!: HTMLElement
+    root = mount({ onDiscard, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS)
+    expect(onDiscard).not.toHaveBeenCalled()
+  })
+
+  it('discards once the element has been hidden past the window', () => {
+    const onDiscard = vi.fn()
+    let el!: HTMLElement
+    root = mount({ onDiscard, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+    expect(onDiscard).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels the pending discard when the element is revealed', () => {
+    const onDiscard = vi.fn()
+    const onRestore = vi.fn()
+    let el!: HTMLElement
+    root = mount({ onDiscard, onRestore, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS - 1000)
+    show(el)
+    advance(BROWSER_DISCARD_MS * 2)
+    expect(onDiscard).not.toHaveBeenCalled()
+    // Nothing was discarded, so there is nothing to restore either.
+    expect(onRestore).not.toHaveBeenCalled()
+  })
+
+  it('restores exactly once, and only after a discard', () => {
+    const onDiscard = vi.fn()
+    const onRestore = vi.fn()
+    let el!: HTMLElement
+    root = mount({ onDiscard, onRestore, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+    show(el)
+    show(el)
+    expect(onDiscard).toHaveBeenCalledTimes(1)
+    expect(onRestore).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not discard a surface that is still on screen when the timer fires', () => {
+    // The timer task and the observer callback are separate tasks: a reveal a frame before the
+    // timer would otherwise flash a plate + reload on a page the user is looking at.
+    const onDiscard = vi.fn()
+    let el!: HTMLElement
+    root = mount({ onDiscard, onEl: (e) => (el = e) })
+    hide(el)
+    stubRect(el, true) // revealed, but the observer entry has not been delivered yet
+    advance(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+    expect(onDiscard).not.toHaveBeenCalled()
+  })
+
+  it('never discards a surface with nothing loaded', () => {
+    const onDiscard = vi.fn()
+    let el!: HTMLElement
+    root = mount({ onDiscard, hasContent: () => false, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS * 3)
+    expect(onDiscard).not.toHaveBeenCalled()
+  })
+
+  it('blocks on a load in flight at fire time, then retries when it finishes', () => {
+    const onDiscard = vi.fn()
+    let loading = true
+    let el!: HTMLElement
+    root = mount({ onDiscard, isLoading: () => loading, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+    expect(onDiscard).not.toHaveBeenCalled()
+    // The re-arm is what keeps a load from disarming the saver for the whole hidden stretch.
+    loading = false
+    advance(DISCARD_RETRY_MS)
+    expect(onDiscard).toHaveBeenCalledTimes(1)
+  })
+
+  it('honours the setting at FIRE time, not at arm time', () => {
+    const onDiscard = vi.fn()
+    let el!: HTMLElement
+    root = mount({ onDiscard, onEl: (e) => (el = e) })
+    hide(el)
+    useSettings.setState({ settings: { ...DEFAULT_SETTINGS, browserMemorySaver: false } })
+    advance(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+    expect(onDiscard).not.toHaveBeenCalled()
+    // …and a disabled saver does not leave a retry armed either (that branch is loading-only).
+    advance(DISCARD_RETRY_MS * 2)
+    expect(onDiscard).not.toHaveBeenCalled()
+  })
+
+  it('shares one decision with the pure policy', () => {
+    // The hook must not grow its own copy of the threshold.
+    expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS + DISCARD_SLACK_MS, loading: false, enabled: true })).toBe(true)
+  })
+})

--- a/src/renderer/nodes/useDiscardWhenHidden.ts
+++ b/src/renderer/nodes/useDiscardWhenHidden.ts
@@ -5,17 +5,42 @@ import { BROWSER_DISCARD_MS, shouldDiscard } from './browser-discard-policy'
 /** Slack past the window so the reading at fire time is strictly PAST it (`shouldDiscard` is `>`). */
 export const DISCARD_SLACK_MS = 1000
 /**
- * Re-check interval when the ONLY thing blocking a discard was a load in flight. A load ends by
- * itself, so treating it as a decision for the whole hidden stretch would disarm the saver for a
- * page that finished a second later — the one blocker that deserves a retry rather than a wait for
- * the next hide→show cycle. Bounded (a fixed re-arm, never a poll loop): each retry only runs while
- * the element is still hidden, and any reveal clears the timer.
+ * Re-check interval when the only thing blocking a discard was TRANSIENT — a load in flight, or a
+ * page making sound. Both end by themselves, so treating either as a decision for the whole hidden
+ * stretch would disarm the saver for a page that finished (or went quiet) a second later. Bounded
+ * (a fixed re-arm, never a poll loop): each retry only runs while the element is still hidden, and
+ * any reveal clears the timer.
  */
 export const DISCARD_RETRY_MS = 60_000
+
+/** The slice of Electron's `WebviewTag` the audible check needs. */
+export type AudibleWebview = { isCurrentlyAudible?: () => boolean }
+
+/**
+ * Is this webview making sound right now?
+ *
+ * Asked by direct QUERY rather than by tracking `media-started-playing` / `media-paused` into a
+ * flag, and the choice is about which way each is wrong. The query cannot drift: it is the guest's
+ * own answer at the instant we ask. The event pair can — a missed or unpaired event leaves a flag
+ * stuck, and stuck-audible means that node's saver is silently dead forever (the worst failure
+ * here, because nothing surfaces it). The query's only weakness is that it throws before the guest
+ * attaches, and a guest that does not exist yet cannot be playing anything — so `false` there is
+ * the CORRECT answer, not merely a safe one.
+ */
+export function webviewAudible(el: AudibleWebview | null | undefined): boolean {
+  try {
+    return el?.isCurrentlyAudible?.() === true
+  } catch {
+    return false
+  }
+}
 
 export interface DiscardWhenHiddenOptions {
   /** Is a load in flight right now? A discard mid-load would replay a half-finished navigation. */
   isLoading: () => boolean
+  /** Is the page making sound right now? Omitted = this surface cannot tell (never treated as
+   *  audible — a surface with no webview has nothing playing). */
+  isAudible?: () => boolean
   /** Is there anything to release? (A start page / empty node has no guest process.) */
   hasContent: () => boolean
   /** Release the page: the caller unmounts its `<webview>` and shows its plate. */
@@ -87,8 +112,11 @@ export function useDiscardWhenHidden(
       if (!o.hasContent()) return
       const enabled = useSettings.getState().settings.browserMemorySaver
       const loading = o.isLoading()
-      if (!shouldDiscard({ hiddenMs: Date.now() - hiddenSince, loading, enabled })) {
-        if (enabled && loading) arm(DISCARD_RETRY_MS)
+      const audible = o.isAudible?.() ?? false
+      if (!shouldDiscard({ hiddenMs: Date.now() - hiddenSince, loading, enabled, audible })) {
+        // Both blockers END BY THEMSELVES, so they earn a retry rather than disarming the saver for
+        // the whole hidden stretch. A disabled setting does not: see the policy's doc comment.
+        if (enabled && (loading || audible)) arm(DISCARD_RETRY_MS)
         return
       }
       discarded = true

--- a/src/renderer/nodes/useDiscardWhenHidden.ts
+++ b/src/renderer/nodes/useDiscardWhenHidden.ts
@@ -1,0 +1,120 @@
+import { useEffect, useRef, type RefObject } from 'react'
+import { useSettings } from '../state/settings'
+import { BROWSER_DISCARD_MS, shouldDiscard } from './browser-discard-policy'
+
+/** Slack past the window so the reading at fire time is strictly PAST it (`shouldDiscard` is `>`). */
+export const DISCARD_SLACK_MS = 1000
+/**
+ * Re-check interval when the ONLY thing blocking a discard was a load in flight. A load ends by
+ * itself, so treating it as a decision for the whole hidden stretch would disarm the saver for a
+ * page that finished a second later — the one blocker that deserves a retry rather than a wait for
+ * the next hide→show cycle. Bounded (a fixed re-arm, never a poll loop): each retry only runs while
+ * the element is still hidden, and any reveal clears the timer.
+ */
+export const DISCARD_RETRY_MS = 60_000
+
+export interface DiscardWhenHiddenOptions {
+  /** Is a load in flight right now? A discard mid-load would replay a half-finished navigation. */
+  isLoading: () => boolean
+  /** Is there anything to release? (A start page / empty node has no guest process.) */
+  hasContent: () => boolean
+  /** Release the page: the caller unmounts its `<webview>` and shows its plate. */
+  onDiscard: () => void
+  /** Rebuild the page from the caller's own descriptor. Only ever called after `onDiscard`. */
+  onRestore: () => void
+}
+
+/**
+ * The hidden-webview memory saver, shared by every surface that hosts an Electron `<webview>`
+ * ({@link BrowserSurface}, WebNode). Each webview is a whole Chromium renderer process and the
+ * canvas caps nothing, so a page hidden past {@link BROWSER_DISCARD_MS} is released and rebuilt
+ * from its URL on reveal.
+ *
+ * This lives in ONE place on purpose: the state machine (observer lifecycle, hidden-since stamp,
+ * timer arm/clear, the fire-time re-checks) is the whole risk of the feature, and two copies of it
+ * drift — the first pair already disagreed about guard ORDER and lost half the reasoning comments.
+ * The component keeps only what is genuinely its own: what "loading"/"content" mean for it, and how
+ * to tear down and rebuild its page.
+ *
+ * The observer is created ONCE (mount-stable). Re-creating it on every state flip would re-arm the
+ * hidden timer each time — `observe()` re-reports immediately — so a page could sit hidden forever
+ * without ever reaching the window. Every mutable input is therefore read through a ref at fire
+ * time, including the SETTING: switching the saver off must disarm a timer armed minutes earlier.
+ */
+export function useDiscardWhenHidden(
+  rootRef: RefObject<HTMLElement | null>,
+  opts: DiscardWhenHiddenOptions
+): void {
+  // Re-read on every render so the mount-stable effect below always calls the CURRENT closures
+  // (they capture component state and are re-created each render).
+  const optsRef = useRef(opts)
+  optsRef.current = opts
+
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el || typeof IntersectionObserver === 'undefined') return
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let hiddenSince: number | null = null
+    let discarded = false
+
+    const clear = (): void => {
+      if (timer) clearTimeout(timer)
+      timer = null
+    }
+    const arm = (ms: number): void => {
+      if (!timer) timer = setTimeout(fire, ms)
+    }
+    /** Geometry, not the observer's verdict — see the M1 note in `fire`. */
+    const onScreen = (): boolean => {
+      const r = el.getBoundingClientRect()
+      if (r.width === 0 && r.height === 0) return false
+      return (
+        r.bottom > 0 && r.right > 0 && r.top < window.innerHeight && r.left < window.innerWidth
+      )
+    }
+    function fire(): void {
+      timer = null
+      const o = optsRef.current
+      if (hiddenSince == null || discarded) return
+      // The timer task and the IntersectionObserver callback are separate tasks: a node revealed a
+      // frame before this fires has not delivered its "visible" entry yet, and discarding here
+      // would flash a plate + reload on a page the user is looking at. Re-measure instead of
+      // trusting the last verdict.
+      if (onScreen()) return
+      // Nothing loaded = no guest process to release, and the plate would replace the one useful
+      // thing on screen (a start page). Checked BEFORE the policy so an empty node never even
+      // consults the clock.
+      if (!o.hasContent()) return
+      const enabled = useSettings.getState().settings.browserMemorySaver
+      const loading = o.isLoading()
+      if (!shouldDiscard({ hiddenMs: Date.now() - hiddenSince, loading, enabled })) {
+        if (enabled && loading) arm(DISCARD_RETRY_MS)
+        return
+      }
+      discarded = true
+      o.onDiscard()
+    }
+
+    const obs = new IntersectionObserver((entries) => {
+      const visible = entries[entries.length - 1]?.isIntersecting ?? true
+      if (!visible) {
+        if (hiddenSince == null) hiddenSince = Date.now()
+        arm(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+        return
+      }
+      hiddenSince = null
+      clear()
+      if (!discarded) return
+      discarded = false
+      optsRef.current.onRestore()
+    })
+    obs.observe(el)
+    return () => {
+      obs.disconnect()
+      clear()
+    }
+    // Mount-stable by design (see the doc comment). `rootRef` is a ref object; `opts` is read
+    // through `optsRef`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6149,6 +6149,21 @@ body,
   width: 100%;
   height: 100%;
 }
+/* Memory saver plate: what stands in for a page whose Chromium process was released while the
+   node sat off-screen. Deliberately quiet — this is an ambient state that heals itself on view,
+   not an error. */
+.browser-node__discarded {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 12px;
+  background: var(--bg);
+  color: var(--muted);
+  font-size: 12px;
+}
 .browser-node__error {
   position: absolute;
   left: 0;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -820,6 +820,14 @@ export interface Settings {
    *  directly (grab cursor), for mouse users who pan constantly; box-select then moves to
    *  Shift+drag (React Flow's selectionKeyCode). */
   canvasDragMode: 'select' | 'pan'
+  /**
+   * Browser memory saver: release a browser/web node's page after it has been hidden for
+   * `BROWSER_DISCARD_MS` (5 min), reloading it from its URL when it is shown again. Each
+   * `<webview>` is a whole Chromium renderer process and the canvas caps nothing, so an
+   * afternoon of opened pages is otherwise permanently resident. On by default — the cost is a
+   * reload (and the lost back/forward stack, which a webview cannot serialize), not lost work.
+   */
+  browserMemorySaver: boolean
   accent: string
   tmuxEnabled: boolean
   /** GPU (WebGL) terminal rendering. 'off' routes every terminal to xterm's DOM renderer.
@@ -971,6 +979,7 @@ export const DEFAULT_SETTINGS: Settings = {
   terminalMiddleClickPaste: false,
   wheelZoom: false,
   canvasDragMode: 'select',
+  browserMemorySaver: true,
   accent: '#0a84ff',
   tmuxEnabled: true,
   terminalGpuRendering: 'auto',


### PR DESCRIPTION
Phase 4 of the RAM-optimization series (plan: docs/superpowers/plans/2026-08-10-ram-optimization.md; Phase 1 was #110). Each browser/web canvas node owns a full Chromium guest process with no cap; this discards the hidden ones and rebuilds them from a descriptor on reveal — Chrome's own tab-discarding semantics applied to canvas nodes.

## Behavior

- A `<webview>` node fully **offscreen in the canvas viewport** for 5 minutes has its element unmounted (guest renderer process exits). The node keeps `{url, title}`; a plate says the page was released. Panning it back into view rebuilds the webview at the last **loaded** URL (never the typed-but-unsubmitted address).
- Never discarded: a page still **loading**, or one **playing audio/video** (`isCurrentlyAudible`, Chrome's audible-tab rule) — both re-check at fire time and re-arm a bounded 60 s retry, so a page that finishes/goes quiet is still reclaimed.
- Setting: **Settings → Behavior → "Browser memory saver"**, default ON.
- The restore's echo navigation is swallowed by identity (URL-valued one-shot ref, disarmed at every user-initiated navigation start and on `did-fail-load`), so a hide/reveal cycle does **not** dirty the workspace, bump `project.json` rev, write the SSH mirror, or reorder browser history.

## Disclosed costs (inherent to discarding)

- Back/forward stack does not survive a discard (Electron webview cannot serialize it; URL + the history store do).
- Unsaved in-page state (scroll, half-typed forms) is lost after 5 min offscreen — same trade Chrome's Memory Saver makes.
- v1 trigger is **pan-only** by explicit decision: a kanban-covered canvas and a minimized/background window do NOT discard (IntersectionObserver is geometric; `visibilityState`/`isKanbanOpen` legs considered and deferred).

## Architecture

- Pure policy `browser-discard-policy.ts` (`BROWSER_DISCARD_MS`, `shouldDiscard` — one predicate holds every rule, incl. the audible exemption).
- One shared `useDiscardWhenHidden` hook (mount-stable IntersectionObserver; options read through a ref so state flips never re-arm the timer; fire-time re-checks; geometry re-measure at fire time so a node revealed a frame before the timer never flashes a reload) + shared `DiscardedPlate`. Both components consume it — review caught the initial two-copy version already micro-drifting, and the hook now carries the state-machine's test coverage (11 cases, mutation-checked).
- `WebNode` re-issues its `nt-media://` grant on restore and holds the plate until the source settles.

## Testing

- 4483 tests / 354 files green, typecheck clean.
- Owed device checks (headless dev box): (1) helper-process count drops after 5 min offscreen and the page reloads on reveal, (2) a playing YouTube node offscreen is NOT discarded, (3) failed-restore → address-bar navigation persists (the echo-swallow correction).

## Deferred (ledgered)

- Toolbar buttons stay enabled while discarded (inert; offscreen by construction).
- Server Edition: observer runs but `<webview>` is inert there anyway; plate copy slightly over-claims. Gate on `isBrowserRuntime()` if it ever matters.
- `ERR_ABORTED` restore (URL resolving to a download) leaves the echo ref armed for one same-URL swallow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)