### PR TITLE
feat(renderer): release offscreen terminals in place; reattach on approach

### DIFF
--- a/src/renderer/components/settings/sections/TmuxSection.tsx
+++ b/src/renderer/components/settings/sections/TmuxSection.tsx
@@ -10,7 +10,11 @@ const ROWS = {
     title: 'Persistent sessions (tmux)',
     keywords: ['tmux', 'persistent', 'session', 'continuity']
   },
-  scrollback: { title: 'Scrollback lines', keywords: ['tmux', 'scrollback', 'history', 'lines'] }
+  scrollback: { title: 'Scrollback lines', keywords: ['tmux', 'scrollback', 'history', 'lines'] },
+  offscreen: {
+    title: 'Release offscreen terminals',
+    keywords: ['offscreen', 'memory', 'ram', 'release', 'reattach', 'idle', 'minutes']
+  }
 }
 const ENTRIES = Object.values(ROWS)
 
@@ -47,6 +51,26 @@ export function TmuxSection({ isActive }: { isActive: boolean }): React.JSX.Elem
               max={200000}
               step={1000}
               onChange={(v) => update({ tmuxScrollback: v || 50000 })}
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.offscreen}>
+        <FieldRow
+          label="Release offscreen terminals"
+          description="Minutes a terminal may sit offscreen before its view is released (tmux keeps it running; it reattaches on view). 0 = never."
+          control={
+            <NumberField
+              value={settings.offscreenTerminalMinutes}
+              min={0}
+              max={240}
+              step={1}
+              // A cleared/invalid field reads back as 0 = "never", the safe end of this setting.
+              // Never NaN: `offscreenDisposeMs` would read it as "off" anyway, but NaN does not
+              // survive a JSON round-trip to settings.json (it lands as `null`).
+              onChange={(v) =>
+                update({ offscreenTerminalMinutes: Number.isFinite(v) ? Math.max(0, v) : 0 })
+              }
             />
           }
         />

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -2848,6 +2848,12 @@ export function TerminalNode({
    * cleanup at all, so an unmount that follows a dispose would clear nothing, ever — a leaked store
    * entry per node, in a branch about memory.
    *
+   * The RESPAWN case (worktree move, Refresh) changes with it, and is correct for the same reason:
+   * that node did not depart either, and its session comes back within seconds — reattached or
+   * cold-restored — at which point the agent's own hooks re-fire and Canvas's `agent:status`
+   * listener overwrites the state (a SessionStart is what clears it). Clearing it here would only
+   * blank the badge for the gap in between, on a node the user is looking at.
+   *
    * What is NOT cleared here is as deliberate as it was before: the node's PERSISTED status
    * (unread / session / sessionId) stays, because a project switch is a detach and the context
    * meter looks that sessionId up on remount. Real deletion drops the whole entry in
@@ -3669,7 +3675,15 @@ export function TerminalNode({
             Deliberately above the overlays below it in the DOM but the least insistent of them —
             it states a resting state, not a failure. Nobody is ever looking at it as it appears
             (that is the precondition for appearing); it exists for the frame between coming into
-            view and the reattach redraw, and for a node parked at the edge of the viewport. */}
+            view and the reattach redraw, and for a node parked at the edge of the viewport.
+
+            …with ONE case where it is seen head-on, and it is deliberate: a COLLAPSED node. The
+            body is `display: none` while collapsed, so the observed element reports
+            not-intersecting and a collapsed terminal is disposed after the window even though its
+            header sits in plain view. Expanding revives it — the display flip changes the
+            intersection, the observer fires, and the node reattaches. Collapsed is exactly the
+            state in which nobody is reading this terminal's output, which is why the WebGL budget
+            has always treated it as hidden too; this feature only agrees with it. Not a bug. */}
         {offscreenDown && (
           <div className="term-node__offscreen nodrag">
             <span>Session running — reattaches on view</span>

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -844,6 +844,17 @@ export function TerminalNode({
   const offscreenDownRef = useRef(false)
   const offscreenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [offscreenEpoch, setOffscreenEpoch] = useState(0)
+  /** The visibility observer's last verdict. Component-level (not per-lifecycle-run) because it
+   *  must survive an offscreen dispose and because a budget client registered by a later run needs
+   *  the CURRENT answer — see `ensureWebglClient`. */
+  const wasVisibleRef = useRef(false)
+  /** What the CURRENT lifecycle run wants done with a visibility verdict (budget report + the
+   *  hidden→visible repaint heal). Null exactly while this node has no terminal: between runs, and
+   *  for the whole time it is offscreen-disposed. The observer that calls it is mount-stable. */
+  const visibilityReportRef = useRef<((visible: boolean) => void) | null>(null)
+  /** Is there a live session here that could be given back? Published by the lifecycle run
+   *  (`restartTarget`), null between runs — the dispose timer refuses when it cannot ask. */
+  const offscreenLiveRef = useRef<(() => boolean) | null>(null)
   // Selection is a live veto (`mayDisposeOffscreen`): a selected node is one the user is working
   // with — it can be off-screen mid-drag or right after a ⌘K jump — so it is never taken down.
   const selectedRef = useRef(selected)
@@ -948,13 +959,20 @@ export function TerminalNode({
   // The affordance is absent, not merely refused on click.
   const sshProject = useProjects((s) => !!s.projects.find((p) => p.id === s.activeProjectId)?.ssh)
   const remoteSession = sshProject || isRemoteSessionNode(data)
-  // The SAME question the ↪ affordance asks, mirrored for the offscreen-dispose gate: a remote
-  // session's respawn runs the requireRemote/offline machinery, and a revive while the
-  // ControlMaster happens to be down would surface the offline overlay on a node the user never
-  // touched. Excluded in v1 (offscreen-policy.ts), read through a ref because a project can BECOME
-  // an SSH project long after the lifecycle effect captured its render.
-  const remoteSessionRef = useRef(remoteSession)
-  remoteSessionRef.current = remoteSession
+  // "Does this node's session live on another machine?" for the offscreen-dispose gate. It starts
+  // from the SAME question the ↪ affordance asks and then adds `data.remote` — a RELAY tab's
+  // terminals, whose session lives on the host at the other end of the relay tunnel. Both are
+  // excluded in v1 (offscreen-policy.ts): a revive re-runs the spawn path, and doing that while
+  // the ControlMaster or the relay link happens to be down surfaces the offline overlay / a spawn
+  // error on a node the user never touched.
+  //
+  // `isRemoteSessionNode` is deliberately NOT widened for this: it is the worktree gate, and
+  // worktrees exclude relay nodes on purpose (a relay node's repo is the host's, and that gate
+  // asks a different question). The union belongs here, at the one call site that means it.
+  // A ref because a project can BECOME an SSH project (or a tab a relay tab) long after the
+  // lifecycle run that would otherwise have captured the answer.
+  const offscreenRemoteRef = useRef(false)
+  offscreenRemoteRef.current = remoteSession || !!data.remote
   const canMoveIntoWorktree =
     !!parentWtPath &&
     !parentWtStale &&
@@ -1154,13 +1172,9 @@ export function TerminalNode({
     // "lost context" placeholder). The callbacks stay dumb and idempotent.
     let webgl: WebglAddon | null = null
     let webglHandle: WebglClientHandle | null = null
-    /** The IntersectionObserver's last verdict, re-stated to any budget client registered after
-     *  it (the observer will not fire again until visibility actually CHANGES, and a fresh client
-     *  starts out believing it is hidden). Declared up here with the handle it belongs to, not
-     *  next to the observer: `ensureWebglClient` can run from the glyph setup at mount, which is
-     *  BEFORE the observer is built — a `let` declared down there would be in its temporal dead
-     *  zone and throw. */
-    let wasVisible = false
+    // (The observer's last verdict lives in the component-level `wasVisibleRef`: it must survive an
+    // offscreen dispose, and a budget client registered by a LATER run — this one included — needs
+    // the current answer, not `false`. See `visibilityReportRef`.)
     // --- glyphgrid (experimental shared renderer) -----------------------------------------
     // Live only while this terminal paints into the shared canvas instead of its own renderer.
     // All four stay null for the default modes: `setupGlyph()` returns on its first gate without
@@ -1452,7 +1466,12 @@ export function TerminalNode({
       // and a fresh registration would be a leak into a coordinator nothing will unregister from.
       if (disposed || webglHandle) return
       webglHandle = registerWebglClient(id, { acquire: acquireWebgl, release: releaseWebgl })
-      webglHandle.setVisible(wasVisible)
+      // Re-state the observer's last verdict: it will not fire again until visibility actually
+      // CHANGES, and a fresh client starts out believing it is hidden. The ref (not a per-run
+      // `let`) is what makes this true for a client registered by a REVIVE as well — no new
+      // intersection change follows one, so `false` there would leave a visible terminal on the
+      // DOM renderer until it was panned out and back.
+      webglHandle.setVisible(wasVisibleRef.current)
     }
 
     // --- glyphgrid (experimental shared renderer) -------------------------------------------
@@ -2474,6 +2493,10 @@ export function TerminalNode({
     // view. The observer's initial callback (queued shortly after `observe()`) is what reports
     // visibility on mount/adopt — this replaces the old unconditional `loadWebgl()` calls in both
     // the parked and fresh paths above; the DOM renderer covers the gap until a grant lands.
+    // (That observer is MOUNT-STABLE and lives in its own effect below — it has to outlive an
+    // offscreen dispose. This run reaches it by publishing `visibilityReportRef` at the bottom of
+    // this effect, and a client registered without a fresh verdict seeds itself from
+    // `wasVisibleRef` in `ensureWebglClient`.)
     //
     // …unless this terminal paints into the SHARED canvas. Then xterm never draws its pixels, so
     // there is no per-terminal context to budget, nothing to acquire on approach and no DOM-strand
@@ -2548,80 +2571,43 @@ export function TerminalNode({
         console.warn(`[glyphgrid] generation handler failed for ${id} (continuing)`, err)
       }
     })
-    const visibilityObserver = new IntersectionObserver(
-      (entries) => {
-        // disconnect() does not flush already-QUEUED notifications (Blink delivers them after),
-        // so a mount that unmounts within the initial-delivery window could otherwise acquire a
-        // context onto a parked/disposed terminal — the very leak this feature exists to prevent.
-        if (disposed) return
-        const visible = entries[entries.length - 1]?.isIntersecting ?? false
-        webglHandle?.setVisible(visible)
-        // Hidden → visible: issue the one full repaint that cannot be swallowed (the element is
-        // attached and intersecting RIGHT NOW). This is the master heal for every "stuck blank /
-        // partial until manual refresh" strand accumulated while off-screen — whichever renderer
-        // is active, and whatever xterm's own deferred-refresh bookkeeping lost in the meantime.
-        // One-shot per transition (not per frame), so a zoom-out burst costs one repaint per node.
-        // The invariant check first: a stray black canvas left by a broken swap while hidden
-        // would otherwise cover everything the repaint draws (no-op when a webgl grant is live).
-        // Gated on everSwapped: a node that never swapped renderers has nothing to heal, and
-        // paying a full repaint per node entering the viewport is what made panning janky.
-        if (visible && !wasVisible && everSwapped) {
-          verifyCleanDomState('visible')
-          fullRepaint()
-        }
-        wasVisible = visible
-        // …and the offscreen-dispose state machine, riding the same verdict. Everything it decides
-        // is the pure `planOffscreenVisibility`; this block only executes the plan.
-        const disposeMs = offscreenDisposeMs(
-          useSettings.getState().settings.offscreenTerminalMinutes
-        )
-        const plan = planOffscreenVisibility({
-          visible,
-          down: offscreenDownRef.current,
-          timerArmed: !!offscreenTimerRef.current,
-          disposeMs
-        })
-        if (plan.cancelTimer && offscreenTimerRef.current) {
-          clearTimeout(offscreenTimerRef.current)
-          offscreenTimerRef.current = null
-        }
-        if (plan.revive) {
-          offscreenDownRef.current = false
-          setOffscreenDown(false)
-          setOffscreenEpoch((n) => n + 1) // re-run the lifecycle effect → fresh warm tmux attach
-        }
-        if (plan.armTimer && disposeMs !== null) {
-          offscreenTimerRef.current = setTimeout(() => {
-            offscreenTimerRef.current = null
-            // Re-asked at FIRE time, never at arm time: ten minutes is long enough for every input
-            // to have changed. `wasVisible` is the observer's own latest verdict.
-            if (
-              !mayDisposeOffscreen({
-                visible: wasVisible,
-                remote: remoteSessionRef.current,
-                selected: selectedRef.current
-              })
-            )
-              return
-            // Nothing to reclaim, and nothing safe to respawn: a spawn still in flight has no
-            // session yet, and a session another client closed (or one that ended with no
-            // replacement) must never be re-created — the overlays own those states, and a revive
-            // would land on `noSpawn` with an empty screen. Both are exactly the states the park
-            // branch below refuses to park.
-            const coNow = getCo(termKey)
-            if (!sessionId || coNow.closed || coNow.ended) return
-            offscreenDownRef.current = true
-            // The cleanup must DISPOSE, not park: parking keeps the very buffer this feature exists
-            // to give back. Set before the state flip, since that flip is what runs the cleanup.
-            noParkIds.add(termKey)
-            setOffscreenDown(true)
-            setOffscreenEpoch((n) => n + 1)
-          }, disposeMs)
-        }
-      },
-      { rootMargin: '256px' }
-    )
-    visibilityObserver.observe(container)
+    // What THIS session owes a visibility verdict. The IntersectionObserver itself is NOT ours: it
+    // lives in a mount-stable effect below, because an observer owned by this effect dies with the
+    // offscreen dispose it is supposed to reverse (the down transition runs this cleanup, and the
+    // re-run early-returns before ever constructing one — the node would then be blind, and the
+    // plate permanent). So this effect publishes a REPORT function instead, and the observer always
+    // calls the live one; `visibilityReportRef` is null exactly while there is no terminal here.
+    //
+    // `wasVisibleRef` is the observer's last verdict and is read as the PREVIOUS value here — the
+    // observer writes it after calling us, so the edge test below is intact.
+    const reportVisible = (visible: boolean): void => {
+      // A queued notification can still be delivered after this run's teardown (the observer is not
+      // disconnected by it, and Blink delivers already-queued entries anyway), and acquiring a
+      // context onto a parked/disposed terminal is the very leak the budget exists to prevent.
+      // Belt to the ref-clearing brace in the cleanup below.
+      if (disposed) return
+      webglHandle?.setVisible(visible)
+      // Hidden → visible: issue the one full repaint that cannot be swallowed (the element is
+      // attached and intersecting RIGHT NOW). This is the master heal for every "stuck blank /
+      // partial until manual refresh" strand accumulated while off-screen — whichever renderer
+      // is active, and whatever xterm's own deferred-refresh bookkeeping lost in the meantime.
+      // One-shot per transition (not per frame), so a zoom-out burst costs one repaint per node.
+      // The invariant check first: a stray black canvas left by a broken swap while hidden
+      // would otherwise cover everything the repaint draws (no-op when a webgl grant is live).
+      // Gated on everSwapped: a node that never swapped renderers has nothing to heal, and
+      // paying a full repaint per node entering the viewport is what made panning janky.
+      if (visible && !wasVisibleRef.current && everSwapped) {
+        verifyCleanDomState('visible')
+        fullRepaint()
+      }
+    }
+    visibilityReportRef.current = reportVisible
+    // Is there a live session here worth giving back? `restartTarget` asks exactly that question
+    // (spawn still in flight ⇒ no session id; a session another client closed, or one that ended
+    // with no replacement, must never be re-created — the overlays own those states and a revive
+    // would land on `noSpawn` with an empty screen), and they are the same states the park branch
+    // below refuses to park. Null while down / between runs ⇒ the timer refuses.
+    offscreenLiveRef.current = restartTarget
 
     return () => {
       disposed = true
@@ -2630,7 +2616,12 @@ export function TerminalNode({
       unregisterRestart()
       observer.disconnect()
       rootObserver.disconnect()
-      visibilityObserver.disconnect()
+      // The visibility observer is NOT disconnected here — it is mount-stable and must outlive an
+      // offscreen dispose (see the effect below). What dies with this run is what it feeds: clear
+      // both published functions, but only if they are still OURS (a respawn's new run has already
+      // published its own by the time this cleanup executes).
+      if (visibilityReportRef.current === reportVisible) visibilityReportRef.current = null
+      if (offscreenLiveRef.current === restartTarget) offscreenLiveRef.current = null
       // Torn down HERE, not through `cleanups`: that array is carried over by a park and only run
       // at a real teardown, so pushing onto it would stack one more focus listener (closing over a
       // dead effect's grid) on every park/adopt cycle. These belong to this effect run, exactly
@@ -2639,35 +2630,18 @@ export function TerminalNode({
       document.removeEventListener('visibilitychange', onVisibilityChange)
       if (resizeTimer) clearTimeout(resizeTimer)
       if (dwellRef.current) clearTimeout(dwellRef.current)
-      // The offscreen timer belongs to THIS effect's observer closure (it reads its `wasVisible`
-      // and `sessionId`), so it dies with it. A respawn's fresh observer re-arms from its own
-      // initial delivery; a down transition already fired and cleared it.
-      if (offscreenTimerRef.current) {
-        clearTimeout(offscreenTimerRef.current)
-        offscreenTimerRef.current = null
-      }
+      // The offscreen timer is deliberately NOT cleared here: it belongs to the mount-stable
+      // observer effect below, reads every input through a ref, and refuses on its own when
+      // `offscreenLiveRef` is null. Clearing it on a respawn would drop a window that has been
+      // counting down for minutes.
       useAgentStatus.getState().setActive(id, false)
       // Teammates stop seeing us in this node's header. releaseFocus, not reportFocus(null): on a
       // project switch every node unmounts, and an unconditional clear could undo the focus the
       // node we just moved into already published.
       presence.releaseFocus(id)
-      // Unmount happens on a project switch (a detach — the tmux session keeps running) as
-      // well as on real deletion, and we can't tell them apart here. Don't wipe the node's
-      // persisted status (that would drop the sessionId the context meter looks up on remount,
-      // making the meter vanish when you switch projects); only clear the live state. Real
-      // deletion drops the entry in Canvas.deleteNodes.
-      //
-      // …EXCEPT for an offscreen dispose, which is not an unmount at all: the node is still on this
-      // canvas, still in this project, still bound to the same running session — it merely gave its
-      // view back. Clearing the live state there would drop the RUNNING/NEEDS-YOU badge and the
-      // subagent fan-out off a node the user can still SEE (its kanban card most of all, which
-      // reads the same store), until the next hook event happened to re-fill them. The badge is
-      // node-id keyed and fed by Canvas's `agent:status` listener, which is entirely independent of
-      // this component's mount — so leaving it alone is both correct and free.
-      if (!offscreenDownRef.current) {
-        useAgentStatus.getState().setState(id, undefined)
-        useAgentNodes.getState().clearForParent(id)
-      }
+      // (The live agent state + subagent fan-out are cleared by the UNMOUNT-only effect below, not
+      // here: this cleanup also runs for a respawn and for an offscreen dispose, neither of which
+      // is a departure. See that effect for the whole argument.)
       termRef.current = null
       fitRef.current = null
       searchAddonRef.current = null
@@ -2761,6 +2735,124 @@ export function TerminalNode({
     setOffscreenDown(false)
     setOffscreenEpoch((n) => n + 1)
   }, [data.respawnNonce])
+
+  /**
+   * Viewport visibility — ONE observer for this node's whole life, deliberately not owned by the
+   * lifecycle effect above.
+   *
+   * It feeds two consumers: the WebGL budget coordinator (which grants/reclaims contexts by
+   * viewport visibility, plus the hidden→visible repaint heal) and the offscreen-dispose state
+   * machine. The second is why the ownership had to move. An observer built by the lifecycle effect
+   * is disconnected by that effect's cleanup — and the down transition IS that cleanup, after which
+   * the re-run early-returns before constructing a new one. The node would be blind from that
+   * moment on: the revive branch unreachable, the plate permanent (only a header Refresh or a
+   * project switch could recover it), and the policy's "switching the setting to 0 can never strand
+   * a disposed terminal" promise false. Same reasoning, same shape as `useDiscardWhenHidden`.
+   *
+   * Everything mutable therefore arrives through a ref, read at CALL time: what the current
+   * lifecycle run wants done with a verdict (`visibilityReportRef` — always the LIVE webgl handle,
+   * never a disposed one, and null while there is no terminal), whether a session exists to give
+   * back (`offscreenLiveRef`), whether this node is remote or selected, and the setting itself
+   * (re-read on every callback, so switching the feature off disarms a timer armed minutes ago).
+   *
+   * IntersectionObserver measures the rendered box, so React Flow's pan/zoom transform is accounted
+   * for natively — no coupling to its store, and identical behavior in the browser Server Edition.
+   * `rootMargin` pre-announces a node panning into view. The `observe()` call's initial delivery is
+   * what reports visibility at mount.
+   */
+  useEffect(() => {
+    const container = bodyRef.current
+    if (!container || typeof IntersectionObserver === 'undefined') return
+    const io = new IntersectionObserver(
+      (entries) => {
+        const visible = entries[entries.length - 1]?.isIntersecting ?? false
+        // The renderer half first: it reads `wasVisibleRef` as the PREVIOUS verdict for its
+        // hidden→visible edge test, so the write below must come after it.
+        visibilityReportRef.current?.(visible)
+        wasVisibleRef.current = visible
+        // …and the offscreen-dispose state machine. Every decision is the pure
+        // `planOffscreenVisibility`; this block only executes the plan.
+        const disposeMs = offscreenDisposeMs(
+          useSettings.getState().settings.offscreenTerminalMinutes
+        )
+        const plan = planOffscreenVisibility({
+          visible,
+          down: offscreenDownRef.current,
+          timerArmed: !!offscreenTimerRef.current,
+          disposeMs
+        })
+        if (plan.cancelTimer && offscreenTimerRef.current) {
+          clearTimeout(offscreenTimerRef.current)
+          offscreenTimerRef.current = null
+        }
+        if (plan.revive) {
+          offscreenDownRef.current = false
+          setOffscreenDown(false)
+          setOffscreenEpoch((n) => n + 1) // re-run the lifecycle effect → fresh warm tmux attach
+        }
+        if (plan.armTimer && disposeMs !== null) {
+          offscreenTimerRef.current = setTimeout(() => {
+            offscreenTimerRef.current = null
+            // Every input re-asked at FIRE time, never at arm time: ten minutes is long enough for
+            // all of them to have changed. `wasVisibleRef` is the observer's own latest verdict.
+            if (
+              !mayDisposeOffscreen({
+                visible: wasVisibleRef.current,
+                remote: offscreenRemoteRef.current,
+                selected: selectedRef.current
+              })
+            )
+              return
+            // Nothing to give back (no session yet, or one that was closed/ended under us) ⇒ no
+            // dispose. A null ref means no lifecycle run is live at all, which answers the same way.
+            if (!offscreenLiveRef.current?.()) return
+            offscreenDownRef.current = true
+            // The cleanup must DISPOSE, not park: parking keeps the very buffer this feature exists
+            // to give back. Set before the state flip, since that flip is what runs the cleanup.
+            noParkIds.add(termKey)
+            setOffscreenDown(true)
+            setOffscreenEpoch((n) => n + 1)
+          }, disposeMs)
+        }
+      },
+      { rootMargin: '256px' }
+    )
+    io.observe(container)
+    return () => {
+      io.disconnect()
+      if (offscreenTimerRef.current) {
+        clearTimeout(offscreenTimerRef.current)
+        offscreenTimerRef.current = null
+      }
+    }
+    // `termKey` is stable for this node's lifetime (see its declaration); listed so the effect is
+    // honestly keyed on what its closure captures.
+  }, [termKey])
+
+  /**
+   * DEPARTURE-only bookkeeping: the node is leaving the canvas (project switch, or deletion).
+   *
+   * This lives in its own unmount-scoped effect rather than in the lifecycle cleanup because that
+   * cleanup runs for three different events — a park, a respawn, and now an offscreen dispose — and
+   * only the first of those is a departure. Clearing the live state on an offscreen dispose drops
+   * the RUNNING / NEEDS-YOU badge and the subagent fan-out off a node the user can still SEE (its
+   * kanban card most of all, which reads the same store) for a node that never went anywhere. And
+   * guarding the clear inside that cleanup instead is worse still: a node that is DOWN registers no
+   * cleanup at all, so an unmount that follows a dispose would clear nothing, ever — a leaked store
+   * entry per node, in a branch about memory.
+   *
+   * What is NOT cleared here is as deliberate as it was before: the node's PERSISTED status
+   * (unread / session / sessionId) stays, because a project switch is a detach and the context
+   * meter looks that sessionId up on remount. Real deletion drops the whole entry in
+   * `Canvas.deleteNodes`.
+   */
+  useEffect(
+    () => () => {
+      useAgentStatus.getState().setState(id, undefined)
+      useAgentNodes.getState().clearForParent(id)
+    },
+    [id]
+  )
 
   // glyphgrid origin sync. React Flow rewrites these two props per frame while the node is
   // dragged; `setOrigin` is change-gated inside the engine, and a drag is exactly the gesture the

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -60,6 +60,11 @@ import {
 import { useXtermVisualSettings } from '../terminal/useXtermVisualSettings'
 import { loseWebglContexts, registerWebglClient, type WebglClientHandle } from '../terminal/webgl-budget'
 import { PARK_MAX, planParkEviction } from '../terminal/park-budget'
+import {
+  mayDisposeOffscreen,
+  offscreenDisposeMs,
+  planOffscreenVisibility
+} from '../terminal/offscreen-policy'
 import { attachGlyphGrid, type GlyphGridAttachment } from '../terminal/glyphgrid-attach'
 import type { GridHandle } from '../glyphgrid/engine'
 import {
@@ -826,6 +831,23 @@ export function TerminalNode({
   // spawn fresh) from a plain unmount (nonce unchanged → park for quick re-adoption).
   const respawnNonceRef = useRef(data.respawnNonce)
   respawnNonceRef.current = data.respawnNonce
+  // --- offscreen dispose (see terminal/offscreen-policy.ts) ---
+  // A terminal nobody has looked at for `settings.offscreenTerminalMinutes` gives its xterm buffer
+  // and its PTY client back: the node STAYS MOUNTED on the canvas and its tmux session keeps
+  // running, so coming back into view is a warm reattach (tmux redraws — the same contract as the
+  // Refresh action and the post-park remount). `offscreenDown` renders the plate and makes the
+  // lifecycle effect spawn nothing; `offscreenEpoch` is what re-runs that effect on BOTH edges
+  // (down → its cleanup disposes, up → it spawns fresh). The ref mirror exists because the
+  // decision is taken inside the lifecycle effect's IntersectionObserver closure, which cannot
+  // see fresh state.
+  const [offscreenDown, setOffscreenDown] = useState(false)
+  const offscreenDownRef = useRef(false)
+  const offscreenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [offscreenEpoch, setOffscreenEpoch] = useState(0)
+  // Selection is a live veto (`mayDisposeOffscreen`): a selected node is one the user is working
+  // with — it can be off-screen mid-drag or right after a ⌘K jump — so it is never taken down.
+  const selectedRef = useRef(selected)
+  selectedRef.current = selected
   // --- glyphgrid (experimental shared renderer) ---
   // This node's registered grid, published by the lifecycle effect so the position effect can push
   // an origin without re-running (and therefore respawning) the terminal. Null for every terminal
@@ -926,6 +948,13 @@ export function TerminalNode({
   // The affordance is absent, not merely refused on click.
   const sshProject = useProjects((s) => !!s.projects.find((p) => p.id === s.activeProjectId)?.ssh)
   const remoteSession = sshProject || isRemoteSessionNode(data)
+  // The SAME question the ↪ affordance asks, mirrored for the offscreen-dispose gate: a remote
+  // session's respawn runs the requireRemote/offline machinery, and a revive while the
+  // ControlMaster happens to be down would surface the offline overlay on a node the user never
+  // touched. Excluded in v1 (offscreen-policy.ts), read through a ref because a project can BECOME
+  // an SSH project long after the lifecycle effect captured its render.
+  const remoteSessionRef = useRef(remoteSession)
+  remoteSessionRef.current = remoteSession
   const canMoveIntoWorktree =
     !!parentWtPath &&
     !parentWtStale &&
@@ -1083,6 +1112,11 @@ export function TerminalNode({
   // (kill the old session + dispose xterm), then recreates the session with the latest
   // `data.cwd`. The node `id` (= tmux persistKey) is unchanged, so it's the same target.
   useEffect(() => {
+    // Offscreen-disposed: this node gave its xterm + PTY client back and is showing the plate.
+    // Spawn NOTHING until it is approached again (the observer below clears the flag and bumps the
+    // epoch, which re-runs this effect). Returning no cleanup is deliberate: there is nothing of
+    // this effect's to tear down, and the down transition's own cleanup already ran.
+    if (offscreenDownRef.current) return
     const container = bodyRef.current
     if (!container) return
 
@@ -2536,6 +2570,54 @@ export function TerminalNode({
           fullRepaint()
         }
         wasVisible = visible
+        // …and the offscreen-dispose state machine, riding the same verdict. Everything it decides
+        // is the pure `planOffscreenVisibility`; this block only executes the plan.
+        const disposeMs = offscreenDisposeMs(
+          useSettings.getState().settings.offscreenTerminalMinutes
+        )
+        const plan = planOffscreenVisibility({
+          visible,
+          down: offscreenDownRef.current,
+          timerArmed: !!offscreenTimerRef.current,
+          disposeMs
+        })
+        if (plan.cancelTimer && offscreenTimerRef.current) {
+          clearTimeout(offscreenTimerRef.current)
+          offscreenTimerRef.current = null
+        }
+        if (plan.revive) {
+          offscreenDownRef.current = false
+          setOffscreenDown(false)
+          setOffscreenEpoch((n) => n + 1) // re-run the lifecycle effect → fresh warm tmux attach
+        }
+        if (plan.armTimer && disposeMs !== null) {
+          offscreenTimerRef.current = setTimeout(() => {
+            offscreenTimerRef.current = null
+            // Re-asked at FIRE time, never at arm time: ten minutes is long enough for every input
+            // to have changed. `wasVisible` is the observer's own latest verdict.
+            if (
+              !mayDisposeOffscreen({
+                visible: wasVisible,
+                remote: remoteSessionRef.current,
+                selected: selectedRef.current
+              })
+            )
+              return
+            // Nothing to reclaim, and nothing safe to respawn: a spawn still in flight has no
+            // session yet, and a session another client closed (or one that ended with no
+            // replacement) must never be re-created — the overlays own those states, and a revive
+            // would land on `noSpawn` with an empty screen. Both are exactly the states the park
+            // branch below refuses to park.
+            const coNow = getCo(termKey)
+            if (!sessionId || coNow.closed || coNow.ended) return
+            offscreenDownRef.current = true
+            // The cleanup must DISPOSE, not park: parking keeps the very buffer this feature exists
+            // to give back. Set before the state flip, since that flip is what runs the cleanup.
+            noParkIds.add(termKey)
+            setOffscreenDown(true)
+            setOffscreenEpoch((n) => n + 1)
+          }, disposeMs)
+        }
       },
       { rootMargin: '256px' }
     )
@@ -2557,6 +2639,13 @@ export function TerminalNode({
       document.removeEventListener('visibilitychange', onVisibilityChange)
       if (resizeTimer) clearTimeout(resizeTimer)
       if (dwellRef.current) clearTimeout(dwellRef.current)
+      // The offscreen timer belongs to THIS effect's observer closure (it reads its `wasVisible`
+      // and `sessionId`), so it dies with it. A respawn's fresh observer re-arms from its own
+      // initial delivery; a down transition already fired and cleared it.
+      if (offscreenTimerRef.current) {
+        clearTimeout(offscreenTimerRef.current)
+        offscreenTimerRef.current = null
+      }
       useAgentStatus.getState().setActive(id, false)
       // Teammates stop seeing us in this node's header. releaseFocus, not reportFocus(null): on a
       // project switch every node unmounts, and an unconditional clear could undo the focus the
@@ -2567,8 +2656,18 @@ export function TerminalNode({
       // persisted status (that would drop the sessionId the context meter looks up on remount,
       // making the meter vanish when you switch projects); only clear the live state. Real
       // deletion drops the entry in Canvas.deleteNodes.
-      useAgentStatus.getState().setState(id, undefined)
-      useAgentNodes.getState().clearForParent(id)
+      //
+      // …EXCEPT for an offscreen dispose, which is not an unmount at all: the node is still on this
+      // canvas, still in this project, still bound to the same running session — it merely gave its
+      // view back. Clearing the live state there would drop the RUNNING/NEEDS-YOU badge and the
+      // subagent fan-out off a node the user can still SEE (its kanban card most of all, which
+      // reads the same store), until the next hook event happened to re-fill them. The badge is
+      // node-id keyed and fed by Canvas's `agent:status` listener, which is entirely independent of
+      // this component's mount — so leaving it alone is both correct and free.
+      if (!offscreenDownRef.current) {
+        useAgentStatus.getState().setState(id, undefined)
+        useAgentNodes.getState().clearForParent(id)
+      }
       termRef.current = null
       fitRef.current = null
       searchAddonRef.current = null
@@ -2645,7 +2744,22 @@ export function TerminalNode({
       if (sessionId) killSession(sessionId)
       term.dispose()
     }
+    // `offscreenEpoch` is bumped on BOTH offscreen edges: going down runs this effect's cleanup
+    // (which disposes rather than parks — see `noParkIds` above), coming back up runs the body
+    // again for a fresh warm attach. It carries no information itself; it is the trigger.
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.respawnNonce, offscreenEpoch])
+
+  // A respawn asked for while this node is offscreen-disposed must not be swallowed. The effect
+  // above early-returns while down, so the bump alone would do nothing and the request (Refresh, a
+  // worktree move, a reconnect flush) would be lost until the user happened to pan back. Coming up
+  // here IS the respawn: the effect re-runs and creates the session with the node's current data.
+  // No-op on mount and on every bump of a node that is up, which is every node in the default case.
+  useEffect(() => {
+    if (!offscreenDownRef.current) return
+    offscreenDownRef.current = false
+    setOffscreenDown(false)
+    setOffscreenEpoch((n) => n + 1)
   }, [data.respawnNonce])
 
   // glyphgrid origin sync. React Flow rewrites these two props per frame while the node is
@@ -3450,6 +3564,16 @@ export function TerminalNode({
         {copy.feedback && (
           <div className={`term-copy-pill term-copy-pill--${copy.feedback.kind}`}>
             {copy.feedback.label}
+          </div>
+        )}
+        {/* Offscreen-disposed: the xterm and the PTY client are gone, the tmux session is not.
+            Deliberately above the overlays below it in the DOM but the least insistent of them —
+            it states a resting state, not a failure. Nobody is ever looking at it as it appears
+            (that is the precondition for appearing); it exists for the frame between coming into
+            view and the reattach redraw, and for a node parked at the edge of the viewport. */}
+        {offscreenDown && (
+          <div className="term-node__offscreen nodrag">
+            <span>Session running — reattaches on view</span>
           </div>
         )}
         {co.closed && (

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -62,6 +62,7 @@ import { loseWebglContexts, registerWebglClient, type WebglClientHandle } from '
 import { PARK_MAX, planParkEviction } from '../terminal/park-budget'
 import {
   mayDisposeOffscreen,
+  offscreenCoreIsRemote,
   offscreenDisposeMs,
   planOffscreenVisibility
 } from '../terminal/offscreen-policy'
@@ -959,20 +960,26 @@ export function TerminalNode({
   // The affordance is absent, not merely refused on click.
   const sshProject = useProjects((s) => !!s.projects.find((p) => p.id === s.activeProjectId)?.ssh)
   const remoteSession = sshProject || isRemoteSessionNode(data)
-  // "Does this node's session live on another machine?" for the offscreen-dispose gate. It starts
-  // from the SAME question the ↪ affordance asks and then adds `data.remote` — a RELAY tab's
-  // terminals, whose session lives on the host at the other end of the relay tunnel. Both are
-  // excluded in v1 (offscreen-policy.ts): a revive re-runs the spawn path, and doing that while
-  // the ControlMaster or the relay link happens to be down surfaces the offline overlay / a spawn
-  // error on a node the user never touched.
+  // "Does this node's session live on another machine?" for the offscreen-dispose gate — asked in
+  // TWO halves, because the two ways of being remote are independent facts:
+  //  1. the PROJECT is an SSH project / this node is an SSH-project terminal (`remoteSession`, the
+  //     same question the ↪ affordance asks), and
+  //  2. the SESSION's core is elsewhere (`offscreenCoreIsRemote`): a RELAY tab's terminals run on
+  //     the paired desktop, a remote-server tab's on that server. Nothing on the node's `data` says
+  //     so — that is a property of the tab it renders under — which is why this half must be asked
+  //     of `session.source` and not of a node field. (The Server Edition's own browser session is
+  //     `'local'`: its core is the server it is served from, up whenever the UI is, so those nodes
+  //     stay eligible — the whole point of the feature on that surface.)
+  // Both are excluded in v1 (offscreen-policy.ts): a revive re-runs the spawn path, and doing that
+  // while the ControlMaster or the relay link happens to be down surfaces the offline overlay / a
+  // spawn error on a node the user never touched.
   //
   // `isRemoteSessionNode` is deliberately NOT widened for this: it is the worktree gate, and
-  // worktrees exclude relay nodes on purpose (a relay node's repo is the host's, and that gate
-  // asks a different question). The union belongs here, at the one call site that means it.
-  // A ref because a project can BECOME an SSH project (or a tab a relay tab) long after the
-  // lifecycle run that would otherwise have captured the answer.
+  // worktrees exclude relay nodes on purpose (that gate asks a different question). The union
+  // belongs here, at the one call site that means it. A ref because a project can BECOME an SSH
+  // project long after the lifecycle run that would otherwise have captured the answer.
   const offscreenRemoteRef = useRef(false)
-  offscreenRemoteRef.current = remoteSession || !!data.remote
+  offscreenRemoteRef.current = remoteSession || offscreenCoreIsRemote(session.source)
   const canMoveIntoWorktree =
     !!parentWtPath &&
     !parentWtStale &&

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1952,6 +1952,24 @@ body,
   height: auto;
 }
 
+/* Offscreen dispose (terminal/offscreen-policy.ts): this node's view was released after sitting
+   out of the viewport; the tmux session keeps running and re-entering the viewport reattaches.
+   Same geometry as `.term-node__closed` — it covers the (now empty) terminal body — but a quieter
+   fill and no action, because there is nothing for the user to do and nothing has gone wrong. */
+.term-node__offscreen {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+  background: rgba(var(--card-rgb), 0.94);
+}
+
 /* Another client permanently destroyed this node's session (tmux kill-session): the terminal is
    dead and must never respawn — say so over the last screen. */
 .term-node__closed {

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -56,6 +56,30 @@ describe('planOffscreenVisibility', () => {
       planOffscreenVisibility({ visible: true, down: true, timerArmed: false, disposeMs: null })
     ).toEqual({ cancelTimer: false, armTimer: false, revive: true })
   })
+  // The sequence a real node walks, driven the way the (mount-stable) observer drives it. Its
+  // point is the LAST step: the revive is decided from `down` + `visible` alone — no armed timer,
+  // no live setting, nothing that the down transition consumed. Which is also why the observer
+  // that delivers that last verdict may not be owned by the effect the dispose tears down.
+  it('walks hidden → armed → down → visible → revived', () => {
+    let down = false
+    let timerArmed = false
+    const step = (visible: boolean): void => {
+      const p = planOffscreenVisibility({ visible, down, timerArmed, disposeMs: ms })
+      if (p.cancelTimer) timerArmed = false
+      if (p.armTimer) timerArmed = true
+      if (p.revive) down = false
+    }
+    step(false)
+    expect(timerArmed).toBe(true)
+    step(false) // a pan keeps reporting hidden; the deadline must not move
+    expect(timerArmed).toBe(true)
+    // …the timer fires: the node goes down and the timer is spent.
+    timerArmed = false
+    down = true
+    step(true)
+    expect(down).toBe(false)
+    expect(timerArmed).toBe(false)
+  })
   it('a visible node with nothing pending owes nothing', () => {
     expect(
       planOffscreenVisibility({ visible: true, down: false, timerArmed: false, disposeMs: ms })

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -3,6 +3,7 @@ import {
   OFFSCREEN_DISPOSE_MS_DEFAULT,
   offscreenDisposeMs,
   mayDisposeOffscreen,
+  offscreenCoreIsRemote,
   planOffscreenVisibility
 } from './offscreen-policy'
 
@@ -20,6 +21,17 @@ describe('offscreen dispose policy', () => {
     expect(mayDisposeOffscreen({ visible: true, remote: false, selected: false })).toBe(false)
     expect(mayDisposeOffscreen({ visible: false, remote: true, selected: false })).toBe(false)
     expect(mayDisposeOffscreen({ visible: false, remote: false, selected: true })).toBe(false)
+  })
+  // The second link in "a relay-sourced node never disposes": this predicate answers `true`, and
+  // the row above proves `remote: true` refuses. Pinned as a test rather than as a comment because
+  // the first attempt at this gate read a node field (`data.remote`) that is only ever set on a
+  // PROJECT — a constant `false` that no type could catch and no test then covered.
+  it('a session whose core is on another machine is remote; both local surfaces are not', () => {
+    expect(offscreenCoreIsRemote('relay')).toBe(true)
+    expect(offscreenCoreIsRemote('server')).toBe(true)
+    // Electron's own session AND the Server Edition's browser session: the core is at the other end
+    // of a preload / a same-machine socket, up whenever the UI is.
+    expect(offscreenCoreIsRemote('local')).toBe(false)
   })
 })
 

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { OFFSCREEN_DISPOSE_MS_DEFAULT, offscreenDisposeMs, mayDisposeOffscreen } from './offscreen-policy'
+import {
+  OFFSCREEN_DISPOSE_MS_DEFAULT,
+  offscreenDisposeMs,
+  mayDisposeOffscreen,
+  planOffscreenVisibility
+} from './offscreen-policy'
 
 describe('offscreen dispose policy', () => {
   it('default is 10 minutes; 0 disables; undefined falls back to default', () => {
@@ -15,5 +20,45 @@ describe('offscreen dispose policy', () => {
     expect(mayDisposeOffscreen({ visible: true, remote: false, selected: false })).toBe(false)
     expect(mayDisposeOffscreen({ visible: false, remote: true, selected: false })).toBe(false)
     expect(mayDisposeOffscreen({ visible: false, remote: false, selected: true })).toBe(false)
+  })
+})
+
+describe('planOffscreenVisibility', () => {
+  const ms = 600_000
+  it('arms the timer once when a live terminal goes offscreen', () => {
+    expect(
+      planOffscreenVisibility({ visible: false, down: false, timerArmed: false, disposeMs: ms })
+    ).toEqual({ cancelTimer: false, armTimer: true, revive: false })
+  })
+  it('never re-arms while a timer is already armed (a pan fires the observer repeatedly)', () => {
+    expect(
+      planOffscreenVisibility({ visible: false, down: false, timerArmed: true, disposeMs: ms })
+    ).toEqual({ cancelTimer: false, armTimer: false, revive: false })
+  })
+  it('arms nothing while already down, and nothing when the feature is off', () => {
+    expect(
+      planOffscreenVisibility({ visible: false, down: true, timerArmed: false, disposeMs: ms })
+    ).toEqual({ cancelTimer: false, armTimer: false, revive: false })
+    expect(
+      planOffscreenVisibility({ visible: false, down: false, timerArmed: false, disposeMs: null })
+    ).toEqual({ cancelTimer: false, armTimer: false, revive: false })
+  })
+  it('cancels an armed timer the moment the node is visible again', () => {
+    expect(
+      planOffscreenVisibility({ visible: true, down: false, timerArmed: true, disposeMs: ms })
+    ).toEqual({ cancelTimer: true, armTimer: false, revive: false })
+  })
+  it('revives a downed node on visibility — even with the feature switched off meanwhile', () => {
+    expect(
+      planOffscreenVisibility({ visible: true, down: true, timerArmed: false, disposeMs: ms })
+    ).toEqual({ cancelTimer: false, armTimer: false, revive: true })
+    expect(
+      planOffscreenVisibility({ visible: true, down: true, timerArmed: false, disposeMs: null })
+    ).toEqual({ cancelTimer: false, armTimer: false, revive: true })
+  })
+  it('a visible node with nothing pending owes nothing', () => {
+    expect(
+      planOffscreenVisibility({ visible: true, down: false, timerArmed: false, disposeMs: ms })
+    ).toEqual({ cancelTimer: false, armTimer: false, revive: false })
   })
 })

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { OFFSCREEN_DISPOSE_MS_DEFAULT, offscreenDisposeMs, mayDisposeOffscreen } from './offscreen-policy'
+
+describe('offscreen dispose policy', () => {
+  it('default is 10 minutes; 0 disables; undefined falls back to default', () => {
+    expect(OFFSCREEN_DISPOSE_MS_DEFAULT).toBe(600_000)
+    expect(offscreenDisposeMs(undefined)).toBe(600_000)
+    expect(offscreenDisposeMs(10)).toBe(600_000)
+    expect(offscreenDisposeMs(0)).toBeNull()
+    expect(offscreenDisposeMs(-3)).toBeNull()
+    expect(offscreenDisposeMs(2)).toBe(120_000)
+  })
+  it('never disposes a visible, selected, or remote terminal', () => {
+    expect(mayDisposeOffscreen({ visible: false, remote: false, selected: false })).toBe(true)
+    expect(mayDisposeOffscreen({ visible: true, remote: false, selected: false })).toBe(false)
+    expect(mayDisposeOffscreen({ visible: false, remote: true, selected: false })).toBe(false)
+    expect(mayDisposeOffscreen({ visible: false, remote: false, selected: true })).toBe(false)
+  })
+})

--- a/src/renderer/terminal/offscreen-policy.ts
+++ b/src/renderer/terminal/offscreen-policy.ts
@@ -1,0 +1,27 @@
+/**
+ * When to tear down an OFFSCREEN terminal's xterm+PTY client in place (node stays mounted; the
+ * tmux session keeps running and re-attach redraws — same contract as the Refresh action and the
+ * post-park remount). cmux's renderer-realization idea taken one level deeper: past this window
+ * nobody has looked at the node for so long that reattach-redraw fidelity is indistinguishable
+ * from park fidelity, and the buffer (up to ~16 MB full) is pure cost.
+ *
+ * REMOTE (SSH) nodes are excluded in v1: their spawn path runs the requireRemote/offline
+ * machinery and a re-spawn while the ControlMaster is down would surface the offline overlay for
+ * a node the user never touched. Follow-up once demand exists.
+ */
+export const OFFSCREEN_DISPOSE_MS_DEFAULT = 10 * 60_000
+
+/** Setting is in minutes; 0 or negative = feature off; undefined = default. */
+export function offscreenDisposeMs(settingMinutes: number | undefined): number | null {
+  if (settingMinutes === undefined) return OFFSCREEN_DISPOSE_MS_DEFAULT
+  if (!(settingMinutes > 0)) return null
+  return Math.round(settingMinutes * 60_000)
+}
+
+export function mayDisposeOffscreen(i: {
+  visible: boolean
+  remote: boolean
+  selected: boolean
+}): boolean {
+  return !i.visible && !i.remote && !i.selected
+}

--- a/src/renderer/terminal/offscreen-policy.ts
+++ b/src/renderer/terminal/offscreen-policy.ts
@@ -25,3 +25,37 @@ export function mayDisposeOffscreen(i: {
 }): boolean {
   return !i.visible && !i.remote && !i.selected
 }
+
+/** What a visibility report owes the offscreen state machine. Pure so the node only has to run it. */
+export interface OffscreenPlan {
+  /** Drop the pending dispose timer (it is armed and no longer wanted). */
+  cancelTimer: boolean
+  /** Arm the dispose timer for `offscreenDisposeMs`. */
+  armTimer: boolean
+  /** Come back up: clear the down flag and re-run the lifecycle effect (fresh warm attach). */
+  revive: boolean
+}
+
+/**
+ * The whole down/up decision, given the observer's latest verdict.
+ *
+ * Visible always wins immediately — a node the user is looking at must never sit behind the plate
+ * waiting for a timer — and re-arming is refused while `down` (there is nothing left to dispose)
+ * or while a timer is already armed (the observer fires on every intersection change, and a
+ * re-arm per fire would push the deadline out forever on a canvas that is being panned).
+ * `disposeMs === null` is the feature switched off: nothing is ever armed, but a node that is
+ * ALREADY down still revives, so flipping the setting to 0 can never strand a disposed terminal.
+ */
+export function planOffscreenVisibility(i: {
+  visible: boolean
+  down: boolean
+  timerArmed: boolean
+  disposeMs: number | null
+}): OffscreenPlan {
+  if (i.visible) return { cancelTimer: i.timerArmed, armTimer: false, revive: i.down }
+  return {
+    cancelTimer: false,
+    armTimer: i.disposeMs !== null && !i.down && !i.timerArmed,
+    revive: false
+  }
+}

--- a/src/renderer/terminal/offscreen-policy.ts
+++ b/src/renderer/terminal/offscreen-policy.ts
@@ -9,7 +9,24 @@
  * machinery and a re-spawn while the ControlMaster is down would surface the offline overlay for
  * a node the user never touched. Follow-up once demand exists.
  */
+import type { SessionSource } from '../session/session'
+
 export const OFFSCREEN_DISPOSE_MS_DEFAULT = 10 * 60_000
+
+/**
+ * Does this node's CORE live on another machine? That — not the node's own fields — is what decides
+ * whether a revive would run a spawn across a link that can be down.
+ *
+ * Asked of the session the node renders under, because that is where the answer actually is: a
+ * relay tab's terminals run on the paired desktop, a remote-server tab's on that server, and
+ * neither node carries a field saying so (`data.ssh`/`data.sshRemoteTmux` describe an SSH PROJECT,
+ * which is a different thing and is asked separately). `'local'` covers the Electron app AND the
+ * Server Edition's own browser session — the core is at the other end of a preload or a
+ * same-machine websocket, always up when the UI is, so those stay eligible.
+ */
+export function offscreenCoreIsRemote(source: SessionSource): boolean {
+  return source !== 'local'
+}
 
 /** Setting is in minutes; 0 or negative = feature off; undefined = default. */
 export function offscreenDisposeMs(settingMinutes: number | undefined): number | null {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -850,6 +850,9 @@ export interface Settings {
    *  renderer. See `resolveTerminalRenderer` (shared/webgl.ts) for the full history. */
   terminalGpuRendering: 'auto' | 'on' | 'off' | 'shared'
   tmuxScrollback: number
+  /** Minutes a terminal may sit fully offscreen before its xterm+PTY client is torn down in
+   *  place (tmux keeps the session; re-approach reattaches and redraws). 0 = never. */
+  offscreenTerminalMinutes: number
   /** AI commit message agent: a local coding-agent CLI run read-only. */
   commitAgent: 'claude' | 'codex' | 'custom'
   /** For commitAgent='custom': command template; {prompt} placeholder optional (else stdin). */
@@ -988,6 +991,7 @@ export const DEFAULT_SETTINGS: Settings = {
   tmuxEnabled: true,
   terminalGpuRendering: 'auto',
   tmuxScrollback: 50000,
+  offscreenTerminalMinutes: 10,
   commitAgent: 'claude',
   commitAgentCommand: '',
   commitExtraPrompt: '',


### PR DESCRIPTION
Phase 2 of the RAM-optimization series (plan in-repo; Phases 1 #110 and 4 #114 merged). The single biggest renderer cost was terminals offscreen paying full price — each mounted xterm holds up to ~15-17 MB of buffer plus DOM while nobody looks at it, and React Flow mounts every node of the active project.

## Behavior

- A terminal **fully offscreen in the canvas viewport** for `offscreenTerminalMinutes` (default **10**, `0` = never; Settings → tmux section) has its xterm + PTY client torn down **in place**: the node stays mounted with a plate ("Session running — reattaches on view"), and the tmux session keeps running untouched — herdr's "invisible things render nothing" on top of our existing "state lives in tmux" contract.
- When the node re-approaches the viewport (256 px pre-announce), it revives with a **warm tmux reattach** — the same path every post-park remount already takes. Live E2E on the Server Edition measured revive at **<500 ms** after a ⌘K jump.
- Excluded, never disposed: **SSH-project nodes, relay tabs, remote server tabs** (`offscreenCoreIsRemote(session.source)` — a revive over a down link would surface spawn errors on a node the user never touched), selected nodes, and visible nodes (re-checked at fire time). A **collapsed** node counts as hidden (its body is `display:none`) — same convention as the WebGL budget; expanding revives it.
- A `respawnNonce` refresh issued while released is honored (revive + fresh spawn), never swallowed.

## Review history (3 rounds, the machinery earned its keep)

- Task review caught a **feature-defeating CRITICAL**: the visibility observer originally lived inside the lifecycle effect, so going down destroyed the only thing that could bring the node back (permanent plate). Fixed by splitting the observer into a mount-stable `[termKey]` effect that publishes to the live run through refs — the same pattern #114's `useDiscardWhenHidden` documents.
- Round 2 caught the relay gate guarding on `data.remote` — **a field nothing sets** (constant false, type-invisible). Re-gated on `session.source !== 'local'`, typed against the real `SessionSource` union and pinned by tests.
- Agent status / subagent fan-out clears moved to a dedicated unmount-only effect, so a release (or respawn) no longer blanks a live RUNNING badge; real departure still clears.

## Verified live (headless Server Edition + scripted Chromium, window = 1 min, two full runs)

1. Offscreen node released: no `.xterm`, plate shown; onscreen sibling untouched — PASS ×2
2. Both tmux sessions alive after release (client detached, session running) — PASS ×2
3. ⌘K jump revives: xterm back, plate gone, <500 ms — PASS ×2
4. Typing into the revived terminal reaches the pty (`echo E2E_REVIVE_OK` round-trip) — PASS
5. Full suite 4555 tests / typecheck clean. (Three **pre-existing** unhandled stub rejections — `license.getStatus`, `ssh.list`, `transcripts.search` from the browser-bridge stubs — fire at app mount on main too; separate follow-up.)

## Known trade-offs (deferred, ledgered)

- A released node is a *detached* tmux session, i.e. it joins the session reaper's candidate pool (6 h grace still applies) — canvas-visible nodes can now be in that pool.
- Bulk "restart idle agents" counts a released node under "skipped (no session)" — safe but mislabeled; follow-up: revive-then-restart.
- A dispose timer that fires but refuses (spawn in flight) re-arms only on the next intersection change — fail-safe (memory just isn't reclaimed yet).
- Desktop Electron + kanban modal not exercised live (modal co-attach verified in code: separate PTY viewer, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)