### PR TITLE
feat(projects): add idle project state to skip PTY/SSH auto-resume

### DIFF
--- a/src/core/workspace-files.test.ts
+++ b/src/core/workspace-files.test.ts
@@ -51,6 +51,16 @@ describe('projectToFile / fileToProject round-trip', () => {
     expect(back.nodes[0]).toMatchObject({ cwd: '/new/root/x', agentId: 'claude', accountId: 'acct1' })
     expect(back.unavailable).toBeUndefined()
   })
+
+  it('drops idle from the shared file, restores it from base like closed', () => {
+    const p = project({ idle: true, defaultAccountId: 'acct1' })
+    const f = projectToFile(p, 1, '2026-08-11T00:00:00.000Z')
+    expect((f as any).idle).toBeUndefined()
+    const back = fileToProject(f, { cwd: '/x', idle: true })
+    expect(back.idle).toBe(true)
+    const notIdle = fileToProject(f, { cwd: '/x' })
+    expect(notIdle.idle).toBeUndefined()
+  })
 })
 
 describe('sameProjectContent', () => {
@@ -135,6 +145,18 @@ describe('splitWorkspace', () => {
       () => 1, '2026-07-11T00:00:00.000Z')
     expect(remote.index.entries[0]).toMatchObject({ id: 'p1', ssh: { remoteCwd: '~/app' } })
     expect(remote.index.entries[0].cache).toBeUndefined() // no cache fabricated from the placeholder
+  })
+})
+
+describe('splitWorkspace', () => {
+  it('carries idle into the index header, like closed', () => {
+    const ws: Workspace = {
+      version: 2,
+      activeProjectId: 'p1',
+      projects: [project({ idle: true, cwd: '/a/b' })]
+    }
+    const { index } = splitWorkspace(ws, () => 1, '2026-08-11T00:00:00.000Z')
+    expect(index.entries[0].idle).toBe(true)
   })
 })
 

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -44,6 +44,7 @@ export interface IndexEntryV3 {
   name: string
   color: string
   closed?: boolean
+  idle?: boolean
   cwd?: string
   ssh?: Project['ssh']
   cache?: ProjectFileV1
@@ -137,6 +138,7 @@ export function fileToProject(
     cwd?: string
     ssh?: Project['ssh']
     closed?: boolean
+    idle?: boolean
     /** This machine's own exec values for these nodes (from the local index entry). A file read
      *  WITHOUT them — an adopted/cloned folder, a probe — gets the safe defaults, never the file's
      *  own `shell`/`ssh.extraArgs`. */
@@ -159,7 +161,8 @@ export function fileToProject(
     ...(validKanban(f.kanban) ? { kanban: f.kanban } : {}),
     ...(base.cwd ? { cwd: base.cwd } : {}),
     ...(base.ssh ? { ssh: base.ssh } : {}),
-    ...(base.closed ? { closed: true } : {})
+    ...(base.closed ? { closed: true } : {}),
+    ...(base.idle ? { idle: true } : {})
   }
 }
 
@@ -182,7 +185,11 @@ export function splitWorkspace(
     // disk — it has no disk representation at all. Drop it entirely (no ref, no inline, no
     // cache) BEFORE the unavailable handling, so it leaks in none of the branches below.
     if (p.remote) continue
-    const header = { id: p.id, name: p.name, color: p.color, ...(p.closed ? { closed: true } : {}) }
+    const header = {
+      id: p.id, name: p.name, color: p.color,
+      ...(p.closed ? { closed: true } : {}),
+      ...(p.idle ? { idle: true } : {})
+    }
     if (p.unavailable) {
       // Placeholder (folder missing / server unreachable at load): its nodes:[] is not real
       // data. Emit a header-only ref preserving the ref shape — NEVER a file and NEVER an ssh

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -214,7 +214,7 @@ export class WorkspaceStore {
           this.revs.set(p.id, p.rev)
           this.lastWritten.set(projectFilePath(e.cwd), read.raw)
           projects.push(
-            fileToProject(p, { cwd: e.cwd, closed: e.closed, localExec: this.execOverlay(e, p) })
+            fileToProject(p, { cwd: e.cwd, closed: e.closed, idle: e.idle, localExec: this.execOverlay(e, p) })
           )
         } else {
           this.deferExecMigration(e)
@@ -227,6 +227,7 @@ export class WorkspaceStore {
             fileToProject(e.cache, {
               ssh: e.ssh,
               closed: e.closed,
+              idle: e.idle,
               localExec: this.execOverlay(e, e.cache)
             })
           )
@@ -481,7 +482,7 @@ export class WorkspaceStore {
     if (!read) return null
     this.revs.set(read.file.id, read.file.rev)
     this.lastWritten.set(projectFilePath(e.cwd), read.raw)
-    return fileToProject(read.file, { cwd: e.cwd, closed: e.closed, localExec: e.localExec })
+    return fileToProject(read.file, { cwd: e.cwd, closed: e.closed, idle: e.idle, localExec: e.localExec })
   }
 
   /** Maps a watched file path back to its project and re-reads it. */
@@ -706,7 +707,7 @@ export class WorkspaceStore {
       this.revs.set(parsed.id, parsed.rev)
       platform().broadcast(
         IPC.workspaceExternalChange,
-        fileToProject(parsed, { cwd: e.cwd, closed: e.closed, localExec: e.localExec })
+        fileToProject(parsed, { cwd: e.cwd, closed: e.closed, idle: e.idle, localExec: e.localExec })
       )
     } catch { /* the file is written and cached; the next load/poll surfaces the node */ }
     return true
@@ -775,7 +776,7 @@ export class WorkspaceStore {
       this.revs.set(e.id, adopted.rev)
       if (owed) this.unmirrored.add(e.id)
       else this.unmirrored.delete(e.id) // pure adopt: the server copy IS the truth now — nothing owed
-      return fileToProject(adopted, { ssh: e.ssh, closed: e.closed, localExec: e.localExec })
+      return fileToProject(adopted, { ssh: e.ssh, closed: e.closed, idle: e.idle, localExec: e.localExec })
     }
     // Our cache stood. Before it clobbers the server, merge in any remote-only session nodes (the
     // phone's drifted append) so the push carries them instead of erasing them.
@@ -786,7 +787,7 @@ export class WorkspaceStore {
         e.cache = { ...e.cache, nodes: [...e.cache.nodes, ...rescued], rev: Math.max(cacheRev, remote.rev) + 1 }
         this.revs.set(e.id, e.cache.rev)
         this.unmirrored.add(e.id) // the merged set must land on the server
-        merged = fileToProject(e.cache, { ssh: e.ssh, closed: e.closed, localExec: e.localExec })
+        merged = fileToProject(e.cache, { ssh: e.ssh, closed: e.closed, idle: e.idle, localExec: e.localExec })
       }
     }
     if (e.cache && (pushIfStanding || this.unmirrored.has(e.id))) {
@@ -817,12 +818,13 @@ function nodesMissingFrom(base: CanvasNodeState[], from: CanvasNodeState[]): Can
 }
 
 /** A labeled grey placeholder for a ref whose file can't be read right now. */
-function unavailableProject(e: { id: string; name: string; color: string; closed?: boolean; cwd?: string; ssh?: Project['ssh'] }): Project {
+function unavailableProject(e: { id: string; name: string; color: string; closed?: boolean; idle?: boolean; cwd?: string; ssh?: Project['ssh'] }): Project {
   return {
     id: e.id, name: e.name, color: e.color,
     viewport: { x: 0, y: 0, zoom: 1 }, nodes: [],
     ...(e.cwd ? { cwd: e.cwd } : {}), ...(e.ssh ? { ssh: e.ssh } : {}),
     ...(e.closed ? { closed: true } : {}),
+    ...(e.idle ? { idle: true } : {}),
     unavailable: true
   }
 }

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -311,6 +311,7 @@ import {
   flowToNodeStates,
   groupSelectedNodes,
   markNodesIdle,
+  resumeIdleNodes,
   NODE_COLORS,
   nodeStatesToFlow,
   reorderNodeBefore,
@@ -858,6 +859,11 @@ export function Canvas() {
   // One-shot: the next active-project load keeps the CURRENT camera instead of applying the
   // project's saved viewport. Set by reloadActiveProject (in-place external-change reload).
   const preserveViewportRef = useRef(false)
+  // One-shot: the next active-project load bumps every node's respawnNonce (via
+  // resumeIdleNodes) instead of loading the flow as-is. Set by resumeProject when resuming
+  // the ACTIVE project — its TerminalNode components stay mounted across the reload (same node
+  // ids), so clearing `idle` alone never reaches their spawn effect; the nonce bump does.
+  const resumePendingRef = useRef(false)
   const [consentOpen, setConsentOpen] = useState(false)
   // Drives WorktreeDialog. `groupId` null = create the group frame around the new worktree;
   // set = bind an existing group (the group context menu). `at` is the pane cursor, if any.
@@ -1674,13 +1680,20 @@ export function Canvas() {
         .catch(() => {
           /* status surfaced via onStatus → the connection banner */
         })
-    } else if (!project.idle) {
+    } else {
       // Local active project: ensure all git ops run local (no stale remote from a prior SSH tab).
+      // Unconditional (not gated on `!project.idle`): this branch only clears routing and spawns no
+      // connection, so it must run even for an idle local project — otherwise switching from an SSH
+      // project into an idle local one leaves remote git routing armed for the wrong project.
       void api.git.setActiveRemote(null)
     }
     loadingRef.current = true
     let flow = nodeStatesToFlow(project.nodes)
     if (project.idle) flow = markNodesIdle(flow)
+    if (resumePendingRef.current) {
+      resumePendingRef.current = false
+      flow = resumeIdleNodes(flow)
+    }
     setNodes(flow)
     // React Flow now holds THIS project's canvas: the commit guard may pair it with the active id
     // again. Both refs are assigned HERE, synchronously, because `setNodes` only lands on the next
@@ -7550,13 +7563,33 @@ export function Canvas() {
   // Resume an idle project: clear the flag and re-run the active-project effect (which now
   // takes the SSH-connect / node-spawn branches it skipped while idle) via reloadNonce — the
   // same mechanism an external-change reload already uses, so a resumed project materializes
-  // exactly like a fresh tab switch into it.
+  // exactly like a fresh tab switch into it. For the ACTIVE project, its TerminalNode components
+  // stay mounted across that reload (nodeStatesToFlow rebuilds the flow with the same node ids),
+  // so clearing `idle` alone never reaches the already-mounted spawn effect — resumePendingRef
+  // tells the reload to also bump every node's respawnNonce (via resumeIdleNodes), which does.
+  // A background (non-active) project needs no such bump: it materializes via a fresh mount the
+  // next time it becomes active, and a fresh mount always runs the spawn effect regardless of
+  // respawnNonce.
+  // The persist() is load-bearing: the store action alone never reaches project.json on disk.
   const resumeProject = useCallback(
     (id: string) => {
       useProjects.getState().setProjectIdle(id, false)
-      if (id === activeProjectId) useProjects.getState().requestReload()
+      if (id === activeProjectId) {
+        resumePendingRef.current = true
+        useProjects.getState().requestReload()
+      }
+      void persist()
     },
-    [activeProjectId]
+    [activeProjectId, persist]
+  )
+
+  // The persist() is load-bearing: the store action alone never reaches project.json on disk.
+  const markProjectIdle = useCallback(
+    (id: string) => {
+      useProjects.getState().setProjectIdle(id, true)
+      void persist()
+    },
+    [persist]
   )
 
   // Right-click on a sidebar project header: mostly the same project actions as the tab caret
@@ -7590,8 +7623,7 @@ export function Canvas() {
           {
             label: project.idle ? 'Resume' : 'Mark idle',
             icon: <IconPause />,
-            onClick: () =>
-              project.idle ? resumeProject(projectId) : useProjects.getState().setProjectIdle(projectId, true)
+            onClick: () => (project.idle ? resumeProject(projectId) : markProjectIdle(projectId))
           },
           { type: 'separator' },
           { type: 'colors', onPick: (color) => setProjectColor(projectId, color) },
@@ -7605,7 +7637,16 @@ export function Canvas() {
         ]
       })
     },
-    [activeProjectId, switchProject, renameProject, setProjectFolder, setProjectColor, closeProject, resumeProject]
+    [
+      activeProjectId,
+      switchProject,
+      renameProject,
+      setProjectFolder,
+      setProjectColor,
+      closeProject,
+      resumeProject,
+      markProjectIdle
+    ]
   )
 
   // Reopen a previously closed project and make it active — the active-project effect reloads its

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -309,6 +309,7 @@ import {
   duplicateNode,
   flowToNodeStates,
   groupSelectedNodes,
+  markNodesIdle,
   NODE_COLORS,
   nodeStatesToFlow,
   reorderNodeBefore,
@@ -1654,7 +1655,7 @@ export function Canvas() {
     // SSH project: (re)open its ControlMaster and record the controlPath so this project's
     // terminal nodes can run over it. Idempotent in main (a live master is reused), so a tab
     // switch back to a connected project is a no-op. Remote tmux is unaffected by the master.
-    if (project.ssh) {
+    if (project.ssh && !project.idle) {
       const ssh = project.ssh
       // SSH remote projects are free (Core). Only phone/relay remote access is Pro-gated.
       window.nodeTerminal.sshProject
@@ -1668,12 +1669,13 @@ export function Canvas() {
         .catch(() => {
           /* status surfaced via onStatus → the connection banner */
         })
-    } else {
+    } else if (!project.idle) {
       // Local active project: ensure all git ops run local (no stale remote from a prior SSH tab).
       void api.git.setActiveRemote(null)
     }
     loadingRef.current = true
-    const flow = nodeStatesToFlow(project.nodes)
+    let flow = nodeStatesToFlow(project.nodes)
+    if (project.idle) flow = markNodesIdle(flow)
     setNodes(flow)
     // React Flow now holds THIS project's canvas: the commit guard may pair it with the active id
     // again. Both refs are assigned HERE, synchronously, because `setNodes` only lands on the next
@@ -7538,6 +7540,18 @@ export function Canvas() {
       void writeDisk()
     },
     [commitActiveToStore, writeDisk, disposeRelayTabForProject]
+  )
+
+  // Resume an idle project: clear the flag and re-run the active-project effect (which now
+  // takes the SSH-connect / node-spawn branches it skipped while idle) via reloadNonce — the
+  // same mechanism an external-change reload already uses, so a resumed project materializes
+  // exactly like a fresh tab switch into it.
+  const resumeProject = useCallback(
+    (id: string) => {
+      useProjects.getState().setProjectIdle(id, false)
+      if (id === activeProjectId) useProjects.getState().requestReload()
+    },
+    [activeProjectId]
   )
 
   // Right-click on a sidebar project header: mostly the same project actions as the tab caret

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -87,6 +87,7 @@ import {
   IconReload,
   IconPower,
   IconNote,
+  IconPause,
   IconPhone,
   IconProject,
   IconRemote,
@@ -1036,6 +1037,10 @@ export function Canvas() {
   }, [getViewport, setViewport])
 
   const activeProjectId = useProjects((s) => s.activeProjectId)
+  // Subscribed (not a `.getState()` snapshot) so marking the ACTIVE project idle from the sidebar
+  // context menu re-renders the idle banner immediately instead of waiting on an unrelated
+  // re-render to pick up the flag.
+  const activeProjectIdle = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId)?.idle)
   // Bumped by `requestReload()`; a dependency of the project-load effect so an in-place reload of
   // the ALREADY-active project actually re-runs it (see reloadActiveProject).
   const reloadNonce = useProjects((s) => s.reloadNonce)
@@ -7582,6 +7587,12 @@ export function Canvas() {
             }
           },
           { label: 'Set folder…', icon: <IconProject />, onClick: () => setProjectFolder(projectId) },
+          {
+            label: project.idle ? 'Resume' : 'Mark idle',
+            icon: <IconPause />,
+            onClick: () =>
+              project.idle ? resumeProject(projectId) : useProjects.getState().setProjectIdle(projectId, true)
+          },
           { type: 'separator' },
           { type: 'colors', onPick: (color) => setProjectColor(projectId, color) },
           { type: 'separator' },
@@ -7594,7 +7605,7 @@ export function Canvas() {
         ]
       })
     },
-    [activeProjectId, switchProject, renameProject, setProjectFolder, setProjectColor, closeProject]
+    [activeProjectId, switchProject, renameProject, setProjectFolder, setProjectColor, closeProject, resumeProject]
   )
 
   // Reopen a previously closed project and make it active — the active-project effect reloads its
@@ -8296,18 +8307,14 @@ export function Canvas() {
         </ReactFlow>
         </SessionProvider>
 
-        {(() => {
-          const activeProject = activeProjectId ? useProjects.getState().getProject(activeProjectId) : undefined
-          if (!activeProject?.idle) return null
-          return (
-            <div className="idle-project-banner">
-              <span>Project idle</span>
-              <button type="button" onClick={() => resumeProject(activeProject.id)}>
-                Resume
-              </button>
-            </div>
-          )
-        })()}
+        {activeProjectIdle && activeProjectId && (
+          <div className="idle-project-banner">
+            <span>Project idle</span>
+            <button type="button" onClick={() => resumeProject(activeProjectId)}>
+              Resume
+            </button>
+          </div>
+        )}
 
         {/* MUST stay OUTSIDE <ReactFlow>. The library's wrapper carries inline
             `position: relative; z-index: 0`, which makes the whole flow one stacking context

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -8296,6 +8296,19 @@ export function Canvas() {
         </ReactFlow>
         </SessionProvider>
 
+        {(() => {
+          const activeProject = activeProjectId ? useProjects.getState().getProject(activeProjectId) : undefined
+          if (!activeProject?.idle) return null
+          return (
+            <div className="idle-project-banner">
+              <span>Project idle</span>
+              <button type="button" onClick={() => resumeProject(activeProject.id)}>
+                Resume
+              </button>
+            </div>
+          )
+        })()}
+
         {/* MUST stay OUTSIDE <ReactFlow>. The library's wrapper carries inline
             `position: relative; z-index: 0`, which makes the whole flow one stacking context
             painted at 0 among flow-wrap's siblings — so no z-index INSIDE it, however large,

--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -7,7 +7,7 @@ import {
   type SessionNodeInput
 } from '../lib/sessionList'
 import { SessionRow } from './SessionRow'
-import { IconBellFilled, IconCircleCheck, IconPin } from './icons'
+import { IconBellFilled, IconCircleCheck, IconPause, IconPin } from './icons'
 import { useProjects } from '../state/projects'
 import { useSettings } from '../state/settings'
 import { useAgentStatus } from '../state/agentStatus'
@@ -51,6 +51,10 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
   const allProjects = useProjects((s) => s.projects)
   // Closed projects are hidden from the tab bar; hide them from the sidebar too.
   const projects = useMemo(() => allProjects.filter((p) => !p.closed), [allProjects])
+  const idleProjectIds = useMemo(
+    () => new Set(projects.filter((p) => p.idle).map((p) => p.id)),
+    [projects]
+  )
   const activeProjectId = useProjects((s) => s.activeProjectId)
   const statusById = useAgentStatus((s) => s.byId)
   const namingById = useSessionNaming((s) => s.byId)
@@ -280,7 +284,7 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
               {...(dragProj ? projDropProps(g.projectId) : {})}
             >
               <div
-                className={`ss-group__head${dropClass(g.projectId, null)}`}
+                className={`ss-group__head${dropClass(g.projectId, null)}${idleProjectIds.has(g.projectId) ? ' is-idle' : ''}`}
                 // One click, one action (projectHeadClickAction documents why it is never both):
                 // an inactive project switches — through Canvas, so the outgoing project's live
                 // nodes are committed and the new active id is persisted — and the active one
@@ -322,6 +326,11 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
                   {(g.projectName.trim() || '?').charAt(0).toUpperCase()}
                 </span>
                 <span className="ss-group__name">{g.projectName}</span>
+                {idleProjectIds.has(g.projectId) && (
+                  <span className="ss-group__idle-badge" title="Idle — click to switch, right-click to Resume">
+                    <IconPause />
+                  </span>
+                )}
                 {branches[g.projectId] && (
                   <span className="ss-group__branch">⎇ {branches[g.projectId]}</span>
                 )}

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -137,6 +137,12 @@ export const IconSwitch = () => (
   </svg>
 )
 
+export const IconPause = () => (
+  <svg {...S}>
+    <path d="M9 6v12M15 6v12" />
+  </svg>
+)
+
 export const IconJump = () => (
   <svg {...S}>
     <circle cx="11" cy="11" r="7" />

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -46,6 +46,7 @@ import {
   seedPaint,
   setFittedSize,
   shouldApplyResync,
+  shouldSkipSpawn,
   stripTrailingNewline,
   takeRecycled,
   terminalKey,
@@ -2265,7 +2266,11 @@ export function TerminalNode({
     // Prefetch the persisted scrollback in parallel with the spawn so it's ready to replay the
     // instant the session resolves (a cold restart after a reboot recreates the tmux session
     // empty — see the `fresh` handling below). Cheap no-op ('') when there's no snapshot.
-    const noSpawn = !!getCo(termKey).closed || getCo(termKey).ended
+    const noSpawn = shouldSkipSpawn({
+      closed: !!getCo(termKey).closed,
+      ended: !!getCo(termKey).ended,
+      projectIdle: !!data.projectIdle
+    })
     const scrollbackPromise =
       parked || noSpawn
         ? Promise.resolve('')

--- a/src/renderer/state/projects.test.ts
+++ b/src/renderer/state/projects.test.ts
@@ -193,3 +193,16 @@ describe('setProjectColor', () => {
     expect(useProjects.getState().projects).toHaveLength(0)
   })
 })
+
+describe('setProjectIdle', () => {
+  it('toggles idle on the target project only, leaves others untouched', () => {
+    const a = useProjects.getState().openFolderProject('/a')
+    const b = useProjects.getState().openFolderProject('/b')
+    useProjects.getState().setProjectIdle(a.id, true)
+    const s = useProjects.getState()
+    expect(s.projects.find((p) => p.id === a.id)?.idle).toBe(true)
+    expect(s.projects.find((p) => p.id === b.id)?.idle).toBeUndefined()
+    useProjects.getState().setProjectIdle(a.id, false)
+    expect(useProjects.getState().projects.find((p) => p.id === a.id)?.idle).toBe(false)
+  })
+})

--- a/src/renderer/state/projects.ts
+++ b/src/renderer/state/projects.ts
@@ -59,6 +59,10 @@ interface ProjectsState {
    *  persisted (see the toWorkspace tripwire). Set true when a relay tab's socket drops (Stage 4
    *  Task 7) so it stays reconnectable; cleared when it reconnects. */
   setProjectUnavailable(id: string, unavailable: boolean): void
+  /** Marks (or clears) a project idle — visible/selectable but exempt from PTY spawn / SSH
+   *  connect until resumed. Persisted (unlike `unavailable`). Passive: does not touch any
+   *  already-live session for this project. */
+  setProjectIdle(id: string, idle: boolean): void
   /** Sets (or clears, with undefined) the project's default Claude account for new nodes. */
   setProjectDefaultAccount(id: string, accountId: string | undefined): void
   /** Sets (or clears, with undefined = fall back to the global setting) the project's default
@@ -243,6 +247,12 @@ export const useProjects = create<ProjectsState>((set, get) => ({
   setProjectUnavailable(id, unavailable) {
     set((s) => ({
       projects: s.projects.map((p) => (p.id === id ? { ...p, unavailable } : p))
+    }))
+  },
+
+  setProjectIdle(id, idle) {
+    set((s) => ({
+      projects: s.projects.map((p) => (p.id === id ? { ...p, idle } : p))
     }))
   },
 

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -15,6 +15,7 @@ import {
   reorderNodeBefore,
   reparentNode,
   resolveNewNodeAccount,
+  resumeIdleNodes,
   ungroupNodes
 } from './workspace'
 import type { CanvasNode } from './workspace'
@@ -543,5 +544,38 @@ describe('markNodesIdle', () => {
     for (const n of marked) expect(n.data.projectIdle).toBe(true)
     expect(marked[0].id).toBe(flow[0].id)
     expect(marked[0].position).toEqual(flow[0].position)
+  })
+})
+
+describe('resumeIdleNodes', () => {
+  const node = (over: Partial<CanvasNodeState> = {}): CanvasNodeState => ({
+    id: 'term-1', kind: 'terminal', position: { x: 0, y: 0 },
+    size: { width: 400, height: 300 }, title: 't', color: '#fff', group: null, ...over
+  })
+
+  it('clears projectIdle and bumps respawnNonce on every node that had it set', () => {
+    const flow = markNodesIdle(nodeStatesToFlow([node(), node({ id: 'term-2' })]))
+    for (const n of flow) expect(n.data.projectIdle).toBe(true)
+
+    const resumed = resumeIdleNodes(flow)
+    expect(resumed).toHaveLength(2)
+    for (const n of resumed) {
+      expect(n.data.projectIdle).toBe(false)
+      expect(n.data.respawnNonce).toBe(1)
+    }
+  })
+
+  it('increments an existing respawnNonce rather than resetting it', () => {
+    const flow = nodeStatesToFlow([node()])
+    const withNonce = flow.map((n) => ({ ...n, data: { ...n.data, respawnNonce: 3 } }))
+    const resumed = resumeIdleNodes(withNonce)
+    expect(resumed[0].data.respawnNonce).toBe(4)
+  })
+
+  it('changes nothing else about the node (id, position untouched)', () => {
+    const flow = nodeStatesToFlow([node()])
+    const resumed = resumeIdleNodes(flow)
+    expect(resumed[0].id).toBe(flow[0].id)
+    expect(resumed[0].position).toEqual(flow[0].position)
   })
 })

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -9,6 +9,7 @@ import {
   fitGroupToChildren,
   flowToNodeStates,
   groupSelectedNodes,
+  markNodesIdle,
   nodeStatesToFlow,
   nodeSshFor,
   reorderNodeBefore,
@@ -17,6 +18,7 @@ import {
   ungroupNodes
 } from './workspace'
 import type { CanvasNode } from './workspace'
+import type { CanvasNodeState } from '@shared/types'
 
 const term = (id: string, pos: { x: number; y: number }, parentId?: string): CanvasNode =>
   ({
@@ -525,5 +527,21 @@ describe('createAgentNode prompt injection', () => {
   it('keeps argv injection byte-identical for codex and gemini', () => {
     expect(createAgentNode('codex', 0, undefined, undefined, 'do X').data.initialCommand).toBe("codex 'do X'")
     expect(createAgentNode('gemini', 0, undefined, undefined, 'do X').data.initialCommand).toBe("gemini 'do X'")
+  })
+})
+
+describe('markNodesIdle', () => {
+  const node = (over: Partial<CanvasNodeState> = {}): CanvasNodeState => ({
+    id: 'term-1', kind: 'terminal', position: { x: 0, y: 0 },
+    size: { width: 400, height: 300 }, title: 't', color: '#fff', group: null, ...over
+  })
+
+  it('stamps data.projectIdle on every node, changes nothing else', () => {
+    const flow = nodeStatesToFlow([node(), node({ id: 'term-2' })])
+    const marked = markNodesIdle(flow)
+    expect(marked).toHaveLength(2)
+    for (const n of marked) expect(n.data.projectIdle).toBe(true)
+    expect(marked[0].id).toBe(flow[0].id)
+    expect(marked[0].position).toEqual(flow[0].position)
   })
 })

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -71,6 +71,13 @@ export interface NodeData {
    * deliberately absent from flowToNodeStates, like initialCommand/expandedHeight.
    */
   respawnNonce?: number
+  /**
+   * Runtime-only, never persisted (like `respawnNonce` — deliberately absent from
+   * flowToNodeStates): set by Canvas's active-project effect when the owning project is
+   * `idle`. `TerminalNode`'s spawn guard treats this the same as an ended/killed session —
+   * see the `noSpawn` extension in terminal-config.ts.
+   */
+  projectIdle?: boolean
   shell?: string
   cwd?: string
   text?: string
@@ -1082,6 +1089,13 @@ export function nodeStatesToFlow(states: CanvasNodeState[]): CanvasNode[] {
       }
     }
   })
+}
+
+/** Stamps every node's data with `projectIdle: true` — used when materializing an idle
+ *  project's canvas, so TerminalNode's spawn guard skips PTY/SSH connect. Pure; does not
+ *  mutate its input. */
+export function markNodesIdle(nodes: CanvasNode[]): CanvasNode[] {
+  return nodes.map((n) => ({ ...n, data: { ...n.data, projectIdle: true } }))
 }
 
 /** Serializes live React Flow nodes back into persisted node states. */

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -1098,6 +1098,24 @@ export function markNodesIdle(nodes: CanvasNode[]): CanvasNode[] {
   return nodes.map((n) => ({ ...n, data: { ...n.data, projectIdle: true } }))
 }
 
+/** Resumes a previously-idle project's flow: clears the `projectIdle` stamp and bumps
+ *  `respawnNonce` on every node. Clearing `project.idle` alone does not reach an
+ *  already-mounted TerminalNode's lifecycle effect (it is keyed on `respawnNonce`, not
+ *  `projectIdle` — see the Resume-button bug this fixes); bumping the nonce is what makes
+ *  the effect re-run and actually spawn. A node that never spawned while idle has nothing to
+ *  tear down, so bumping it is harmless — the effect proceeds straight to a fresh spawn. Pure;
+ *  does not mutate its input. */
+export function resumeIdleNodes(nodes: CanvasNode[]): CanvasNode[] {
+  return nodes.map((n) => ({
+    ...n,
+    data: {
+      ...n.data,
+      projectIdle: false,
+      respawnNonce: ((n.data.respawnNonce as number | undefined) ?? 0) + 1
+    }
+  }))
+}
+
 /** Serializes live React Flow nodes back into persisted node states. */
 export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
   const sizeFor = (kind: NodeKind) =>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6443,6 +6443,8 @@ body,
 .ss-group__head:hover .ss-group__add { opacity: 0.7; }
 .ss-group__add:hover { opacity: 1 !important; color: var(--accent); }
 .ss-group__empty { padding: 4px 8px 6px 22px; font-size: 11px; color: var(--muted); }
+.ss-group__head.is-idle { opacity: 0.55; }
+.ss-group__idle-badge { display: inline-flex; margin-left: 4px; opacity: 0.8; }
 
 /* Canvas-group sub-section inside a project */
 .ss-subgroup {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -519,6 +519,32 @@ body,
   box-shadow: 0 10px 32px rgba(0, 0, 0, calc(0.5 * var(--shadow-k)));
 }
 
+.idle-project-banner {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  background: rgba(var(--menu-rgb), 0.92);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 13px;
+}
+
+.idle-project-banner button {
+  padding: 3px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+}
+
 .dock-btn {
   position: relative;
   display: inline-flex;

--- a/src/renderer/terminal/terminal-config.test.ts
+++ b/src/renderer/terminal/terminal-config.test.ts
@@ -17,6 +17,7 @@ import {
   seedPaint,
   setFittedSize,
   shouldApplyResync,
+  shouldSkipSpawn,
   stripTrailingNewline,
   takeRecycled,
   terminalKey,
@@ -235,6 +236,15 @@ describe('recycleAction', () => {
 
   it('treats a payload-less/legacy notice as "no replacement" (never spawn in a stale cwd)', () => {
     expect(recycleAction(undefined)).toBe('ended')
+  })
+})
+
+describe('shouldSkipSpawn', () => {
+  it('skips when closed, ended, or the owning project is idle; spawns otherwise', () => {
+    expect(shouldSkipSpawn({ closed: false, ended: false, projectIdle: false })).toBe(false)
+    expect(shouldSkipSpawn({ closed: true, ended: false, projectIdle: false })).toBe(true)
+    expect(shouldSkipSpawn({ closed: false, ended: true, projectIdle: false })).toBe(true)
+    expect(shouldSkipSpawn({ closed: false, ended: false, projectIdle: true })).toBe(true)
   })
 })
 

--- a/src/renderer/terminal/terminal-config.ts
+++ b/src/renderer/terminal/terminal-config.ts
@@ -134,6 +134,14 @@ export function recycleAction(info: { ready: boolean } | undefined): 'restart' |
   return info?.ready ? 'restart' : 'ended'
 }
 
+/** Whether TerminalNode's spawn effect must skip `transport.create(...)` entirely: an ended/
+ *  killed session (`closed`/`ended` — see `noSpawn`'s original callers) OR the owning project
+ *  is idle. Pure, so the three reasons stay independently testable instead of an inline `||`
+ *  chain at the call site. */
+export function shouldSkipSpawn(opts: { closed: boolean; ended: boolean; projectIdle: boolean }): boolean {
+  return opts.closed || opts.ended || opts.projectIdle
+}
+
 /**
  * Should a `pty:resync` payload be painted? The server promises never to send an empty capture,
  * but the renderer guards anyway: a resync RESETS the emulator, and a screen reset on an empty

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -483,6 +483,14 @@ export interface Project {
    */
   closed?: boolean
   /**
+   * Idle projects stay visible and selectable in the sidebar, but PTY spawn / SSH connect /
+   * tmux reattach are suppressed for them until the user explicitly resumes. Unlike `closed`,
+   * an idle project's tab still shows and can become `activeProjectId`. Passive: marking an
+   * already-live project idle does not kill its running sessions — it only blocks future
+   * auto-resume.
+   */
+  idle?: boolean
+  /**
    * Set at load time when the project's .nodeterm/project.json could not be read
    * (folder missing, server unreachable, corrupt file). Runtime-only — never persisted.
    * Unavailable projects show a greyed tab and cannot be activated.


### PR DESCRIPTION
## Summary
- Projects can now be marked **idle**: they stay visible/selectable in the sidebar and tab bar, but PTY spawn / SSH ControlMaster connect / tmux reattach are suppressed until the user explicitly resumes them — frees memory without hiding the project like `closed` does.
- Toggle via sidebar right-click → "Mark idle" / "Resume" (dimmed row + pause badge while idle), or via a "Project idle" banner + Resume button shown over the canvas when the active project is idle.
- Persisted (`Project.idle`), machine-local like `closed` — never leaks into the shared `.nodeterm/project.json`.
- Passive semantics: marking an already-live project idle never kills its running sessions, only blocks future auto-resume.

## Notable fixes during review
- Resume didn't actually respawn terminals (React Flow re-renders existing node components on reload rather than remounting them, so `TerminalNode`'s spawn effect never re-ran) — fixed by bumping each resumed node's `respawnNonce`.
- Idle toggles weren't persisted to disk (missing `persist()`, unlike sibling project-mutation actions).
- Git remote routing could leak into an idle local project after switching away from an SSH project.

## Test plan
- [x] `node_modules/.bin/vitest run` — 4586/4613 passing; the 20 failing tests are in 5 pre-existing native-PTY/sandbox-environment test files (`pty-coattach`, `pty-require-remote`, `pty-spawn-diagnosis`, `pty-typing`, `server-e2e`), confirmed unrelated to this branch (none of its files are touched by this diff; failure count/category matches pre-branch baseline)
- [x] `npm run typecheck` — clean
- [x] `npm run build` (`electron-vite build`) — clean
- [ ] Manual: mark a project idle, switch to it — canvas freezes (no terminal output), banner shows, no new PTY/SSH connect fires
- [ ] Manual: click Resume — terminals actually spawn/reattach
- [ ] Manual: mark the *active* project idle while its sessions are live — sessions keep running (not killed)
- [ ] Manual: restart the app — idle flag survives, idle project's sessions do not auto-resume
