### PR TITLE
feat(sidebar): show working/total badge on project rows with active sessions

### DIFF
--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -309,6 +309,12 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
                     {signals.unread}
                   </span>
                 )}
+                {signals.working > 0 && (
+                  <span className="ss-group__sig ss-group__sig--working" title="Sessions running right now">
+                    <span className="ss-group__sig-spin" />
+                    {signals.working}/{projectCount(g)}
+                  </span>
+                )}
                 <span className="ss-group__count">{projectCount(g)}</span>
                 <button
                   className="ss-group__add"

--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -312,7 +312,7 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
                 {signals.working > 0 && (
                   <span className="ss-group__sig ss-group__sig--working" title="Sessions running right now">
                     <span className="ss-group__sig-spin" />
-                    {signals.working}/{projectCount(g)}
+                    {signals.working}
                   </span>
                 )}
                 <span className="ss-group__count">{projectCount(g)}</span>

--- a/src/renderer/lib/sessionList.test.ts
+++ b/src/renderer/lib/sessionList.test.ts
@@ -161,6 +161,51 @@ describe('projectSignalCounts', () => {
     }))
   })
 
+  // Restored from before the working badge: the original a–f matrix. It pins the row-glyph
+  // PRECEDENCE (attention beats unread, a working session is not yet unread) across both
+  // ungrouped and grouped sessions, which the narrower fixtures below do not reach. The working
+  // count is asserted alongside it rather than replacing it.
+  it('counts attention and unread across ungrouped and grouped sessions', () => {
+    const proj: ProjectInput[] = [
+      {
+        id: 'p1',
+        name: 'P1',
+        color: '#123',
+        nodes: [
+          node('g1', { kind: 'group', title: 'G', color: '#abc' }),
+          node('a'), // waiting → attention
+          node('b', { parentId: 'g1' }), // blocked → attention
+          node('c'), // done + unread → unread
+          node('d'), // idle + unread → unread (state lost, unread persisted)
+          node('e'), // working + unread → NOT counted (mirrors the row glyph precedence)
+          node('f') // plain idle → neither
+        ]
+      }
+    ]
+    const status: Record<string, AgentNodeStatus> = {
+      a: { unread: false, state: 'waiting' },
+      b: { unread: true, state: 'blocked' }, // attention wins over unread
+      c: { unread: true, state: 'done' },
+      d: { unread: true },
+      e: { unread: true, state: 'working' }
+    }
+    const [g] = buildSessionList(proj, null, 'p1', status, '')
+    // `e` is the load-bearing one: it is the single working session AND carries an unread mark,
+    // so it must land in `working` and NOT in `unread`.
+    expect(projectSignalCounts(g)).toEqual({ attention: 2, unread: 2, working: 1 })
+  })
+
+  it('returns zeros for a quiet project', () => {
+    const [g] = buildSessionList(
+      [{ id: 'p1', name: 'P1', color: '#123', nodes: [node('x')] }],
+      null,
+      'p1',
+      {},
+      ''
+    )
+    expect(projectSignalCounts(g)).toEqual({ attention: 0, unread: 0, working: 0 })
+  })
+
   it('counts working sessions alongside attention/unread', () => {
     const g = group([
       { statusKind: 'working' },

--- a/src/renderer/lib/sessionList.test.ts
+++ b/src/renderer/lib/sessionList.test.ts
@@ -4,7 +4,9 @@ import {
   sessionStatusKind,
   isGroupCollapsed,
   projectSignalCounts,
-  type ProjectInput
+  type ProjectInput,
+  type SessionRowVM,
+  type SessionGroup
 } from './sessionList'
 import type { AgentNodeStatus } from '../state/agentStatus'
 
@@ -140,42 +142,37 @@ describe('buildSessionList', () => {
 })
 
 describe('projectSignalCounts', () => {
-  it('counts attention and unread across ungrouped and grouped sessions', () => {
-    const proj: ProjectInput[] = [
-      {
-        id: 'p1',
-        name: 'P1',
-        color: '#123',
-        nodes: [
-          node('g1', { kind: 'group', title: 'G', color: '#abc' }),
-          node('a'), // waiting → attention
-          node('b', { parentId: 'g1' }), // blocked → attention
-          node('c'), // done + unread → unread
-          node('d'), // idle + unread → unread (state lost, unread persisted)
-          node('e'), // working + unread → NOT counted (mirrors the row glyph precedence)
-          node('f') // plain idle → neither
-        ]
-      }
-    ]
-    const status: Record<string, AgentNodeStatus> = {
-      a: { unread: false, state: 'waiting' },
-      b: { unread: true, state: 'blocked' }, // attention wins over unread
-      c: { unread: true, state: 'done' },
-      d: { unread: true },
-      e: { unread: true, state: 'working' }
-    }
-    const [g] = buildSessionList(proj, null, 'p1', status, '')
-    expect(projectSignalCounts(g)).toEqual({ attention: 2, unread: 2 })
+  const group = (sessions: Partial<SessionRowVM>[]) => ({
+    projectId: 'p1',
+    projectName: 'P',
+    projectColor: '#111',
+    isActive: false,
+    groups: [],
+    ungrouped: sessions.map((s, i) => ({
+      id: `s${i}`,
+      title: `s${i}`,
+      color: '#888',
+      isAgent: false,
+      statusKind: 'idle' as const,
+      stateLabel: 'Idle',
+      unread: false,
+      usesContext: false,
+      ...s
+    }))
   })
 
-  it('returns zeros for a quiet project', () => {
-    const [g] = buildSessionList(
-      [{ id: 'p1', name: 'P1', color: '#123', nodes: [node('x')] }],
-      null,
-      'p1',
-      {},
-      ''
-    )
-    expect(projectSignalCounts(g)).toEqual({ attention: 0, unread: 0 })
+  it('counts working sessions alongside attention/unread', () => {
+    const g = group([
+      { statusKind: 'working' },
+      { statusKind: 'working' },
+      { statusKind: 'attention' },
+      { statusKind: 'idle' }
+    ])
+    expect(projectSignalCounts(g)).toEqual({ attention: 1, unread: 0, working: 2 })
+  })
+
+  it('working is 0 when nothing is running', () => {
+    const g = group([{ statusKind: 'idle' }, { statusKind: 'done', unread: true }])
+    expect(projectSignalCounts(g).working).toBe(0)
   })
 })

--- a/src/renderer/lib/sessionList.test.ts
+++ b/src/renderer/lib/sessionList.test.ts
@@ -142,7 +142,7 @@ describe('buildSessionList', () => {
 })
 
 describe('projectSignalCounts', () => {
-  const group = (sessions: Partial<SessionRowVM>[]) => ({
+  const group = (sessions: Partial<SessionRowVM>[]): SessionGroup => ({
     projectId: 'p1',
     projectName: 'P',
     projectColor: '#111',
@@ -171,8 +171,31 @@ describe('projectSignalCounts', () => {
     expect(projectSignalCounts(g)).toEqual({ attention: 1, unread: 0, working: 2 })
   })
 
-  it('working is 0 when nothing is running', () => {
+  it('working is 0 when nothing is running, and unread is counted when not working', () => {
     const g = group([{ statusKind: 'idle' }, { statusKind: 'done', unread: true }])
-    expect(projectSignalCounts(g).working).toBe(0)
+    expect(projectSignalCounts(g)).toEqual({ attention: 0, unread: 1, working: 0 })
+  })
+
+  it('drives through buildSessionList: counts grouped sessions, attention wins over unread, working is not double-counted as unread', () => {
+    const proj: ProjectInput[] = [
+      {
+        id: 'p1',
+        name: 'Alpha',
+        color: '#111',
+        nodes: [
+          node('g1', { kind: 'group', title: 'Frontend', color: '#abc' }),
+          node('a1', { agentId: 'claude', parentId: 'g1' }), // attention + unread -> attention only
+          node('a2', { agentId: 'claude', parentId: 'g1' }), // working + unread -> working only
+          node('t1') // ungrouped, idle
+        ]
+      }
+    ]
+    const status: Record<string, AgentNodeStatus> = {
+      a1: { unread: true, state: 'blocked', agentId: 'claude', session: 'blocked task', sessionId: 'sess-a1' },
+      a2: { unread: true, state: 'working', agentId: 'claude', session: 'working task', sessionId: 'sess-a2' }
+    }
+    const [p1] = buildSessionList(proj, null, 'p1', status, '')
+    expect(p1.groups[0].sessions.map((s) => s.id)).toEqual(['a1', 'a2']) // sanity: sessions really live under group.groups
+    expect(projectSignalCounts(p1)).toEqual({ attention: 1, unread: 0, working: 1 })
   })
 })

--- a/src/renderer/lib/sessionList.ts
+++ b/src/renderer/lib/sessionList.ts
@@ -56,14 +56,22 @@ export function isGroupCollapsed(
  * an attention session is never double-counted as unread, and a working one isn't
  * unread yet (a new turn is running; the old mark resurfaces when it ends).
  */
-export function projectSignalCounts(group: SessionGroup): { attention: number; unread: number } {
+/**
+ * Header badges for a project group: how many sessions need the user right now
+ * (waiting/blocked), how many finished unseen, and how many are actively working right now.
+ * Mirrors the row glyph's precedence — an attention session is never double-counted as unread,
+ * and a working one isn't unread yet (a new turn is running; the old mark resurfaces when it ends).
+ */
+export function projectSignalCounts(group: SessionGroup): { attention: number; unread: number; working: number } {
   let attention = 0
   let unread = 0
+  let working = 0
   for (const s of [...group.ungrouped, ...group.groups.flatMap((b) => b.sessions)]) {
     if (s.statusKind === 'attention') attention++
     else if (s.unread && s.statusKind !== 'working') unread++
+    if (s.statusKind === 'working') working++
   }
-  return { attention, unread }
+  return { attention, unread, working }
 }
 
 export function sessionStatusKind(state: AgentNodeStatus['state']): StatusKind {

--- a/src/renderer/lib/sessionList.ts
+++ b/src/renderer/lib/sessionList.ts
@@ -52,12 +52,6 @@ export function isGroupCollapsed(
 
 /**
  * Header badges for a project group: how many sessions need the user right now
- * (waiting/blocked) and how many finished unseen. Mirrors the row glyph's precedence —
- * an attention session is never double-counted as unread, and a working one isn't
- * unread yet (a new turn is running; the old mark resurfaces when it ends).
- */
-/**
- * Header badges for a project group: how many sessions need the user right now
  * (waiting/blocked), how many finished unseen, and how many are actively working right now.
  * Mirrors the row glyph's precedence — an attention session is never double-counted as unread,
  * and a working one isn't unread yet (a new turn is running; the old mark resurfaces when it ends).

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6381,6 +6381,14 @@ body,
   border-top-color: transparent;
   animation: nt-spin 1s steps(12, end) infinite;
 }
+/* Respect the OS setting: spinning ring/arc badges freeze in place rather than
+   keep animating forever. */
+@media (prefers-reduced-motion: reduce) {
+  .ss-dot--working,
+  .ss-group__sig-spin {
+    animation: none;
+  }
+}
 .ss-group__add { margin-left: auto; opacity: 0; border: none; background: transparent; color: var(--text); cursor: pointer; font-size: 15px; line-height: 1; padding: 0 4px; }
 .ss-group__head:hover .ss-group__add { opacity: 0.7; }
 .ss-group__add:hover { opacity: 1 !important; color: var(--accent); }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -17,6 +17,10 @@
      (A white that sits on a saturated ACCENT fill is a different thing and stays `#fff`.) */
   --text-strong: #fff;
 
+  /* Working (agent mid-turn) accent: the clay spinner/glow color, shared by every "working"
+     indicator (node glow, sidebar dot, project-header badge) so it only has to be edited once. */
+  --agent-working: #d97757;
+
   --bg: #1e1e1e; /* content / canvas / terminal (controlBackground) */
   --panel: #282828; /* bars, panels, node chrome (underPage) */
   --panel-header: #323232; /* elevated / hover (windowBackground) */
@@ -6282,17 +6286,7 @@ body,
 .ss-bell svg { width: 13px; height: 13px; }
 .ss-dot--working {
   background: transparent;
-  border: 2px solid #d97757;
-  border-top-color: transparent;
-  animation: nt-spin 1s steps(12, end) infinite;
-}
-.ss-group__sig--working { color: #d97757; }
-.ss-group__sig-spin {
-  display: inline-block;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  border: 1.5px solid #d97757;
+  border: 2px solid var(--agent-working);
   border-top-color: transparent;
   animation: nt-spin 1s steps(12, end) infinite;
 }
@@ -6377,6 +6371,16 @@ body,
 .ss-group__sig svg { width: 11px; height: 11px; }
 .ss-group__sig--attention { color: var(--danger); }
 .ss-group__sig--unread { color: var(--accent); }
+.ss-group__sig--working { color: var(--agent-working); }
+.ss-group__sig-spin {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1.5px solid var(--agent-working);
+  border-top-color: transparent;
+  animation: nt-spin 1s steps(12, end) infinite;
+}
 .ss-group__add { margin-left: auto; opacity: 0; border: none; background: transparent; color: var(--text); cursor: pointer; font-size: 15px; line-height: 1; padding: 0 4px; }
 .ss-group__head:hover .ss-group__add { opacity: 0.7; }
 .ss-group__add:hover { opacity: 1 !important; color: var(--accent); }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6286,6 +6286,16 @@ body,
   border-top-color: transparent;
   animation: nt-spin 1s steps(12, end) infinite;
 }
+.ss-group__sig--working { color: #d97757; }
+.ss-group__sig-spin {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1.5px solid #d97757;
+  border-top-color: transparent;
+  animation: nt-spin 1s steps(12, end) infinite;
+}
 
 .ss-row__body { min-width: 0; flex: 1; display: flex; flex-direction: column; gap: 2px; }
 .ss-row__titleline { display: flex; align-items: center; gap: 6px; min-width: 0; }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -155,6 +155,11 @@
   --warn: #a85c00;
   --caution: #806100;
   --success: #1f7a38;
+  /* Same story for the working clay: #d97757 is tuned for a dark field and measures 2.7:1 against
+     these surfaces — under this palette's 4.3 floor, and it is rendered as TEXT (the badge count),
+     not just a dot. Darkened at the same hue (15°) into the band the other status hues occupy,
+     so "working" still reads as the same colour in both themes. */
+  --agent-working: #b04a28;
 
   /* Dots must read as a grid, not as noise: the dark-mode grey is far too heavy on a pale field,
      and a neutral one would be the only cold thing on screen. */

--- a/src/renderer/styles.theme.test.ts
+++ b/src/renderer/styles.theme.test.ts
@@ -13,9 +13,24 @@ import { join } from 'node:path'
 
 const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
 
+/**
+ * Where the light block actually starts. This MUST be anchored to the selector at the start of a
+ * line: a plain `indexOf(":root[data-theme='light']")` matches the *doc comment* inside the `:root`
+ * block that points at it (styles.css line ~6), which is 90 lines too early. That is not a
+ * cosmetic slip — it silently hollowed out two suites below. `dark` collapsed to three lines, so
+ * "the light theme overrides every themeable token" passed with an EMPTY token list for every
+ * token added since; and `LIGHT` resolved to the tail of the DARK block, so the contrast floors
+ * were measuring the dark palette against itself. Keep the `^` anchor.
+ */
+const LIGHT_BLOCK_START = CSS.search(/^:root\[data-theme='light'\]\s*\{/m)
+
 /** Everything before the end of the `:root[data-theme='light']` block — where literals belong. */
-const TOKEN_BLOCK_END = CSS.indexOf('\n}\n', CSS.indexOf(":root[data-theme='light']")) + 3
+const TOKEN_BLOCK_END = CSS.indexOf('\n}\n', LIGHT_BLOCK_START) + 3
 const RULES = CSS.slice(TOKEN_BLOCK_END)
+
+/** The two token blocks, sliced once. */
+const DARK = CSS.slice(CSS.indexOf(':root {'), LIGHT_BLOCK_START)
+const LIGHT = CSS.slice(LIGHT_BLOCK_START, TOKEN_BLOCK_END)
 
 function luminance(r: number, g: number, b: number): number {
   return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
@@ -107,14 +122,14 @@ describe('the light theme overrides every themeable token', () => {
   // A token defined in `:root` but absent from the light block keeps its DARK value on a light
   // page. Colour-valued tokens must appear in both; geometry (radii, fonts) is theme-independent.
   it('covers every colour token', () => {
-    const dark = CSS.slice(CSS.indexOf(':root {'), CSS.indexOf(":root[data-theme='light']"))
-    const light = CSS.slice(CSS.indexOf(":root[data-theme='light']"), TOKEN_BLOCK_END)
+    const dark = DARK
+    const light = LIGHT
     const colourish = (decl: string): boolean =>
       /#[0-9a-f]{3,8}|rgba?\(|^\s*\d+,\s*\d+,\s*\d+\s*$/i.test(decl)
 
     const darkTokens = Array.from(dark.matchAll(/^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);/gm))
       .filter(([, , v]) => colourish(v))
-      .map(([, k]) => k)
+      .map(([, k, v]) => [k, v] as const)
     const lightTokens = new Set(
       Array.from(light.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm), (x) => x[1])
     )
@@ -122,7 +137,18 @@ describe('the light theme overrides every themeable token', () => {
     // The git-graph lane hues are branch IDENTITY, not chrome: they must stay the same colour in
     // both themes or a graph would change meaning when the theme flips.
     const themeIndependent = (k: string): boolean => k.startsWith('--git-graph-')
-    const missing = darkTokens.filter((k) => !lightTokens.has(k) && !themeIndependent(k))
+    // A token mixed ONLY from `--tint-rgb` already flips with the theme by construction — that
+    // triple is itself overridden in the light block, which is the whole point of routing ~280
+    // overlays through it. `--text: rgba(var(--tint-rgb), 0.85)` is the live example: it is
+    // deliberately NOT restated in the light block (only `--muted`/`--border`, whose alphas had to
+    // be raised to buy back the contrast warmth costs). Requiring a redundant restatement here
+    // would teach the next person to copy tokens that are already correct.
+    const followsTint = (v: string): boolean =>
+      /^\s*rgba?\(\s*var\(--tint-rgb\)[^)]*\)\s*$/.test(v)
+    const missing = darkTokens
+      .filter(([k]) => !lightTokens.has(k) && !themeIndependent(k))
+      .filter(([, v]) => !followsTint(v))
+      .map(([k]) => k)
     expect(missing).toEqual([])
   })
 })
@@ -137,11 +163,17 @@ describe('the light theme overrides every themeable token', () => {
  * quietly drops body text under the floor.
  */
 describe('light palette contrast', () => {
-  const LIGHT = CSS.slice(CSS.indexOf(":root[data-theme='light']"), TOKEN_BLOCK_END)
-
+  /**
+   * A light-palette token — falling back to the dark block when light does not restate it.
+   * That fall-back is not laxity: the only tokens light omits are the ones mixed purely from
+   * `--tint-rgb` (`--text` is the live example), which read as the LIGHT ink here because
+   * `--tint-rgb` itself is overridden. And a hue that genuinely went missing would resolve to its
+   * dark-field value and fail the contrast floor below — loudly, which is the point.
+   */
   function token(name: string): string {
-    const m = new RegExp(`^\\s*${name}\\s*:\\s*([^;]+);`, 'm').exec(LIGHT)
-    if (!m) throw new Error(`light block has no ${name}`)
+    const re = new RegExp(`^\\s*${name}\\s*:\\s*([^;]+);`, 'm')
+    const m = re.exec(LIGHT) ?? re.exec(DARK)
+    if (!m) throw new Error(`neither token block defines ${name}`)
     return m[1].trim()
   }
 
@@ -191,7 +223,10 @@ describe('light palette contrast', () => {
   })
 
   it.each(SURFACES)('the status hues and link accent stay legible on %s', (_name, bg) => {
-    for (const t of ['--accent-text', '--danger', '--warn', '--caution', '--success']) {
+    // `--agent-working` is on this list because the sidebar's project badge paints its COUNT with
+    // it (`.ss-group__sig--working`) — it is text, so it owes the text floor, not the 3:1 one.
+    const HUES = ['--accent-text', '--danger', '--warn', '--caution', '--success', '--agent-working']
+    for (const t of HUES) {
       expect(contrast(hex(token(t)), bg), `${t}`).toBeGreaterThanOrEqual(4.3)
     }
   })


### PR DESCRIPTION
## Summary
- Adds a working-count badge with a spinning glyph to project header rows in the sidebar whenever at least one session in that project is actively running an agent turn — hidden entirely when nothing is working. It reads like its `attention` / `unread` siblings: a glyph plus its own count, with the project's existing total still shown once by `.ss-group__count`.
- Reuses the existing `nt-spin` animation and introduces an `--agent-working` CSS custom property so the colour stops being duplicated between the per-session dot and the new badge. The token is defined in **both** the dark and the light palette (`#d97757` / `#b04a28`) — the badge paints a COUNT with it, so it owes the light palette's 4.3:1 text floor.
- Respects `prefers-reduced-motion`: the spinning ring/arc badges freeze in place.

## Also in this PR: the theme guard that should have caught the missing light token

`styles.theme.test.ts` sliced the light block with `indexOf(":root[data-theme='light']")`, which matches the **doc comment** inside the `:root` block ~90 lines earlier. Two suites had been passing vacuously as a result:

- *"the light theme overrides every themeable token"* compared against an **empty** dark-token list, so every token added since went unchecked.
- The light **contrast floors** resolved `LIGHT` to the tail of the *dark* block — they were measuring the dark palette against itself.

The slice is now anchored to the selector at the start of a line. With it fixed the suite flagged one further token, `--text`; that one is a genuine false positive (it is mixed purely from `--tint-rgb`, which the light block *does* override, so it flips by construction) and is now exempted by shape rather than silenced. `--agent-working` was added to the asserted hue list, and both fixes were mutation-checked: removing the light token, or reverting it to the dark clay, each fail the suite.

## Test plan
- [x] `projectSignalCounts` unit tests: working count, zero case, grouped-session traversal, attention-over-unread precedence, working-not-double-counted-as-unread — the original a–f matrix is kept, with the working assertions added alongside it
- [x] `npm run typecheck` clean
- [x] `npx vitest run src/renderer` — 153 files / 2085 tests passing
- [ ] Manual: badge shows/hides correctly as sessions start and finish
- [ ] Manual: spinner and count legible in **both** themes