### PR TITLE
feat: memory-pressure responder chain — release WebGL + parks, early reaper sweep

### DIFF
--- a/src/core/memory-pressure.test.ts
+++ b/src/core/memory-pressure.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createMemoryPressureMonitor } from './memory-pressure'
+
+const mem = (availableMb: number, totalMb = 16000) => () => ({ availableMb, totalMb })
+
+describe('memory pressure monitor', () => {
+  it('classifies warning below 10% available and critical below 5%', () => {
+    const on = vi.fn()
+    const m = createMemoryPressureMonitor({ readMem: mem(1500), selfRssMb: () => 500, onPressure: on })
+    expect(m.check()).toBe('warning')
+    const c = createMemoryPressureMonitor({ readMem: mem(700), selfRssMb: () => 500, onPressure: on })
+    expect(c.check()).toBe('critical')
+  })
+  it('a failed mem read is never pressure', () => {
+    const m = createMemoryPressureMonitor({ readMem: () => null, selfRssMb: () => 500, onPressure: vi.fn() })
+    expect(m.check()).toBeNull()
+  })
+  it('self-RSS thresholds fire independently of host memory', () => {
+    const m = createMemoryPressureMonitor({ readMem: mem(8000), selfRssMb: () => 5000, onPressure: vi.fn() })
+    expect(m.check()).toBe('warning')
+    const c = createMemoryPressureMonitor({ readMem: mem(8000), selfRssMb: () => 9000, onPressure: vi.fn() })
+    expect(c.check()).toBe('critical')
+  })
+  it('re-fires a severity at most once per 60s (edge-trigger + floor)', () => {
+    vi.useFakeTimers()
+    const on = vi.fn()
+    const m = createMemoryPressureMonitor({ readMem: mem(1500), selfRssMb: () => 0, intervalMs: 1000, onPressure: on })
+    m.start()
+    vi.advanceTimersByTime(3500)
+    expect(on).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(60_000)
+    expect(on).toHaveBeenCalledTimes(2)
+    m.stop()
+    vi.useRealTimers()
+  })
+})

--- a/src/core/memory-pressure.test.ts
+++ b/src/core/memory-pressure.test.ts
@@ -15,13 +15,17 @@ describe('memory pressure monitor', () => {
     const m = createMemoryPressureMonitor({ readMem: () => null, selfRssMb: () => 500, onPressure: vi.fn() })
     expect(m.check()).toBeNull()
   })
+  it('self-RSS still counts when the host read fails', () => {
+    const m = createMemoryPressureMonitor({ readMem: () => null, selfRssMb: () => 9000, onPressure: vi.fn() })
+    expect(m.check()).toBe('critical')
+  })
   it('self-RSS thresholds fire independently of host memory', () => {
     const m = createMemoryPressureMonitor({ readMem: mem(8000), selfRssMb: () => 5000, onPressure: vi.fn() })
     expect(m.check()).toBe('warning')
     const c = createMemoryPressureMonitor({ readMem: mem(8000), selfRssMb: () => 9000, onPressure: vi.fn() })
     expect(c.check()).toBe('critical')
   })
-  it('re-fires a severity at most once per 60s (edge-trigger + floor)', () => {
+  it('re-fires a severity at most once per 60s (floor)', () => {
     vi.useFakeTimers()
     const on = vi.fn()
     const m = createMemoryPressureMonitor({ readMem: mem(1500), selfRssMb: () => 0, intervalMs: 1000, onPressure: on })
@@ -31,6 +35,39 @@ describe('memory pressure monitor', () => {
     vi.advanceTimersByTime(60_000)
     expect(on).toHaveBeenCalledTimes(2)
     m.stop()
+    vi.useRealTimers()
+  })
+  it('stop() ends the sweeps for good', () => {
+    vi.useFakeTimers()
+    const on = vi.fn()
+    const m = createMemoryPressureMonitor({ readMem: mem(700), selfRssMb: () => 0, intervalMs: 1000, onPressure: on })
+    m.start()
+    vi.advanceTimersByTime(1000)
+    expect(on).toHaveBeenCalledTimes(1)
+    m.stop()
+    vi.advanceTimersByTime(600_000)
+    expect(on).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+  it('a throwing consumer does not break the monitor', () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let calls = 0
+    const m = createMemoryPressureMonitor({
+      readMem: mem(700),
+      selfRssMb: () => 0,
+      intervalMs: 1000,
+      onPressure: () => {
+        calls++
+        throw new Error('destroyed window')
+      }
+    })
+    m.start()
+    expect(() => vi.advanceTimersByTime(1000)).not.toThrow()
+    vi.advanceTimersByTime(61_000)
+    expect(calls).toBe(2) // still firing after the throw
+    m.stop()
+    warn.mockRestore()
     vi.useRealTimers()
   })
 })

--- a/src/core/memory-pressure.test.ts
+++ b/src/core/memory-pressure.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { createMemoryPressureMonitor } from './memory-pressure'
+import { createMemoryPressureMonitor, hostMemReader } from './memory-pressure'
+import { readMemInfo } from './session-budget'
 
 const mem = (availableMb: number, totalMb = 16000) => () => ({ availableMb, totalMb })
 
@@ -48,6 +49,20 @@ describe('memory pressure monitor', () => {
     vi.advanceTimersByTime(600_000)
     expect(on).toHaveBeenCalledTimes(1)
     vi.useRealTimers()
+  })
+  it('the default host reader is SILENT on darwin (os.freemem there is vm_stat free_count)', () => {
+    const read = hostMemReader('darwin')
+    expect(read()).toBeNull()
+    // Host leg silent → a healthy Mac is never classified from "free" memory…
+    const quiet = createMemoryPressureMonitor({ readMem: read, selfRssMb: () => 500, onPressure: vi.fn() })
+    expect(quiet.check()).toBeNull()
+    // …but the self-RSS leg still carries the monitor on its own.
+    const loud = createMemoryPressureMonitor({ readMem: read, selfRssMb: () => 9000, onPressure: vi.fn() })
+    expect(loud.check()).toBe('critical')
+  })
+  it('the default host reader is the real one everywhere else', () => {
+    expect(hostMemReader('linux')).toBe(readMemInfo)
+    expect(hostMemReader('win32')).toBe(readMemInfo)
   })
   it('a throwing consumer does not break the monitor', () => {
     vi.useFakeTimers()

--- a/src/core/memory-pressure.ts
+++ b/src/core/memory-pressure.ts
@@ -1,0 +1,63 @@
+// Two-signal memory pressure (cmux's MemoryPressureMonitor pattern, Electron-free): host
+// available-memory watermarks (readMemInfo — the same source session-budget trusts) plus this
+// process's own RSS, because the host signal alone can't tell you YOU are the problem.
+// Consumers hang reclaim levers off onPressure; all levers must be idempotent — the monitor
+// re-fires a held severity at most once per RE_FIRE_FLOOR_MS.
+import { readMemInfo, type MemInfo } from './session-budget'
+
+export type PressureSeverity = 'warning' | 'critical'
+
+export const PRESSURE_INTERVAL_MS = 30_000
+export const RE_FIRE_FLOOR_MS = 60_000
+export const SELF_RSS_WARN_MB = 4096
+export const SELF_RSS_CRIT_MB = 8192
+
+export interface MemoryPressureMonitor {
+  start(): void
+  stop(): void
+  /** One classification pass; null = no pressure (including "could not read"). */
+  check(): PressureSeverity | null
+}
+
+export function createMemoryPressureMonitor(opts: {
+  readMem?: () => MemInfo | null
+  selfRssMb?: () => number
+  intervalMs?: number
+  onPressure: (s: PressureSeverity) => void
+}): MemoryPressureMonitor {
+  const readMem = opts.readMem ?? readMemInfo
+  const selfRss = opts.selfRssMb ?? ((): number => Math.round(process.memoryUsage().rss / 1048576))
+  let timer: ReturnType<typeof setInterval> | null = null
+  let lastFired = 0
+
+  const check = (): PressureSeverity | null => {
+    const rss = selfRss()
+    const m = readMem()
+    // A failed read is never evidence of pressure; self-RSS still counts.
+    const hostCrit = m !== null && m.availableMb < m.totalMb * 0.05
+    const hostWarn = m !== null && m.availableMb < m.totalMb * 0.1
+    if (hostCrit || rss > SELF_RSS_CRIT_MB) return 'critical'
+    if (hostWarn || rss > SELF_RSS_WARN_MB) return 'warning'
+    return null
+  }
+
+  return {
+    check,
+    start(): void {
+      if (timer) return
+      timer = setInterval(() => {
+        const s = check()
+        if (!s) return
+        const now = Date.now()
+        if (now - lastFired < RE_FIRE_FLOOR_MS) return
+        lastFired = now
+        opts.onPressure(s)
+      }, opts.intervalMs ?? PRESSURE_INTERVAL_MS)
+      timer.unref?.()
+    },
+    stop(): void {
+      if (timer) clearInterval(timer)
+      timer = null
+    }
+  }
+}

--- a/src/core/memory-pressure.ts
+++ b/src/core/memory-pressure.ts
@@ -51,7 +51,14 @@ export function createMemoryPressureMonitor(opts: {
         const now = Date.now()
         if (now - lastFired < RE_FIRE_FLOOR_MS) return
         lastFired = now
-        opts.onPressure(s)
+        // A consumer throw must never take the shell down with it — the responders run in a
+        // shell (`webContents.send` on a destroyed window, a reaper sweep) and this timer is the
+        // only thing on the stack. Log and keep the monitor alive, like session-budget's sweep.
+        try {
+          opts.onPressure(s)
+        } catch (e) {
+          console.warn('[memory-pressure] onPressure threw', e)
+        }
       }, opts.intervalMs ?? PRESSURE_INTERVAL_MS)
       timer.unref?.()
     },

--- a/src/core/memory-pressure.ts
+++ b/src/core/memory-pressure.ts
@@ -1,6 +1,7 @@
 // Two-signal memory pressure (cmux's MemoryPressureMonitor pattern, Electron-free): host
-// available-memory watermarks (readMemInfo — the same source session-budget trusts) plus this
-// process's own RSS, because the host signal alone can't tell you YOU are the problem.
+// available-memory watermarks (readMemInfo — the same source session-budget trusts, except on
+// darwin, where it is not measuring what its name says; see hostMemReader) plus this process's
+// own RSS, because the host signal alone can't tell you YOU are the problem.
 // Consumers hang reclaim levers off onPressure; all levers must be idempotent — the monitor
 // re-fires a held severity at most once per RE_FIRE_FLOOR_MS.
 import { readMemInfo, type MemInfo } from './session-budget'
@@ -11,6 +12,24 @@ export const PRESSURE_INTERVAL_MS = 30_000
 export const RE_FIRE_FLOOR_MS = 60_000
 export const SELF_RSS_WARN_MB = 4096
 export const SELF_RSS_CRIT_MB = 8192
+
+/**
+ * The DEFAULT host-memory reader — platform-aware, because `readMemInfo`'s non-Linux fallback is
+ * `os.freemem()`, and on **darwin** that is vm_stat's `free_count` alone: it excludes inactive,
+ * purgeable and compressor pages, all of which macOS hands back on demand. A perfectly healthy
+ * 16 GB Mac idles at a few hundred MB "free", i.e. under BOTH watermarks — the monitor would sit
+ * permanently CRITICAL on the primary desktop platform, disposing every parked terminal and
+ * sweeping the reaper once a minute forever. Per the repo rule, a guess must degrade to NOTHING
+ * rather than to something wrong: on darwin the host leg is silent (`null` is explicitly "no
+ * pressure signal", not "no pressure") and the self-RSS leg carries the monitor alone.
+ *
+ * Follow-up: give macOS a REAL signal (the memory-pressure/compressor state, swap-in rate, or
+ * Electron's `app.getAppMetrics`) and drop the special case — the platform is not un-measurable,
+ * `os.freemem()` is simply the wrong instrument for it.
+ */
+export function hostMemReader(platform: NodeJS.Platform = process.platform): () => MemInfo | null {
+  return platform === 'darwin' ? (): null => null : readMemInfo
+}
 
 export interface MemoryPressureMonitor {
   start(): void
@@ -25,8 +44,10 @@ export function createMemoryPressureMonitor(opts: {
   intervalMs?: number
   onPressure: (s: PressureSeverity) => void
 }): MemoryPressureMonitor {
-  const readMem = opts.readMem ?? readMemInfo
-  const selfRss = opts.selfRssMb ?? ((): number => Math.round(process.memoryUsage().rss / 1048576))
+  const readMem = opts.readMem ?? hostMemReader()
+  // `memoryUsage.rss()` reads just the one number; `memoryUsage()` builds the whole stats object
+  // (heap walk included) every 30 s for a field we throw away.
+  const selfRss = opts.selfRssMb ?? ((): number => Math.round(process.memoryUsage.rss() / 1048576))
   let timer: ReturnType<typeof setInterval> | null = null
   let lastFired = 0
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,6 +69,7 @@ import { createGrantsAccessor, type PushGrant } from '../core/push-grants'
 import { createRemoteGrantsCache } from '../core/remote-push-grants'
 import { createAckSweeper } from '../core/ack-sweep'
 import { createSessionReaper } from '../core/session-budget'
+import { createMemoryPressureMonitor } from '../core/memory-pressure'
 import { getDeviceId } from '../core/device-id'
 import { initRemoteStatusPush } from './remote-ssh/remote-status-push'
 import { initCanvasSync } from '../core/canvas-sync'
@@ -1525,7 +1526,21 @@ app.whenReady().then(async () => {
   // budget). Attached sessions are never touched; a reaped node cold-restores on next open.
   // Local sockets only — a remote SSH host's sessions are reaped by that host's own
   // nodeterm-server, never across the wire. Timer is unref'd; no explicit stop needed.
-  createSessionReaper({ tmuxBin: () => ptyManager.getTmuxBin() }).start()
+  const sessionReaper = createSessionReaper({ tmuxBin: () => ptyManager.getTmuxBin() })
+  sessionReaper.start()
+  // Memory pressure (core/memory-pressure.ts): the reaper's own 10-minute timer is the steady
+  // state; this is the fast path. On a watermark crossing the renderer runs its reclaim levers
+  // (hidden WebGL contexts, parked terminals) and a CRITICAL reading also sweeps the reaper NOW
+  // rather than waiting out its timer. Both levers are idempotent and the monitor re-fires at most
+  // once a minute. The send goes through `sendToMain`, which resolves the window AT SEND TIME and
+  // no-ops while it is closed (macOS keeps the app alive without one) — the monitor's own
+  // try/catch is the backstop, not the primary.
+  createMemoryPressureMonitor({
+    onPressure: (severity) => {
+      sendToMain(IPC.appMemoryPressure, severity)
+      if (severity === 'critical') void sessionReaper.sweep()
+    }
+  }).start()
   const ackSweeper = createAckSweeper({
     handlers: { ackDone, onUnreadClear: (id) => sendToMain(IPC.agentUnreadClear, id) }
   })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -550,6 +550,11 @@ const api: NodeTerminalApi = {
     ipcRenderer.on(IPC.appFocusNode, handler)
     return () => ipcRenderer.removeListener(IPC.appFocusNode, handler)
   },
+  onMemoryPressure: (listener) => {
+    const handler = (_e: unknown, severity: 'warning' | 'critical') => listener(severity)
+    ipcRenderer.on(IPC.appMemoryPressure, handler)
+    return () => ipcRenderer.removeListener(IPC.appMemoryPressure, handler)
+  },
   answerPermission: (payload) => ipcRenderer.invoke(IPC.agentAnswerPermission, payload),
   ackDone: (nodeId) => {
     void ipcRenderer.invoke(IPC.agentAckDone, nodeId)

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -335,6 +335,12 @@ export function buildStubApi(): Omit<
     },
     openNotificationSettings: pnoop,
     onFocusNode: noopUnsub,
+    // Server Edition v1: the memory-pressure levers run HOST-side only (the session reaper, driven
+    // by the same core monitor in src/server/index.ts). A browser tab's own memory — its WebGL
+    // contexts and parked terminals — belongs to the browser, which already discards and reclaims
+    // on its own terms; pushing our levers over the wire would fight it, not help it. Deliberate
+    // no-op, not an oversight.
+    onMemoryPressure: noopUnsub,
     onAgentControl: noopUnsub,
     sendAgentControlResult: noop
   } satisfies Omit<

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -26,7 +26,8 @@ import {
   setSshDropHandler,
   setSshRetryHandler,
   disposeTerminalOnUnmount,
-  disposeParkedTerminal
+  disposeParkedTerminal,
+  disposeAllParkedTerminals
 } from '../nodes/TerminalNode'
 import { solveFitPadding } from './fit-view'
 import {
@@ -44,7 +45,12 @@ import {
 } from './SharedGlyphLayer'
 import { SshReconnector } from '../lib/sshReconnect'
 import { terminalKey } from '../terminal/terminal-config'
-import { setWebglGesture, setWebglZoom, WEBGL_GESTURE_SETTLE_MS } from '../terminal/webgl-budget'
+import {
+  setWebglGesture,
+  setWebglZoom,
+  releaseAllHiddenGrants,
+  WEBGL_GESTURE_SETTLE_MS
+} from '../terminal/webgl-budget'
 import { StickyNode } from '../nodes/StickyNode'
 import { GroupNode, setWorktreeActionHandler } from '../nodes/GroupNode'
 import { LazyEditorNode, LazyDiffNode } from '../nodes/lazyMonacoNodes'
@@ -7393,6 +7399,21 @@ export function Canvas() {
   // OS-notification click → focus the originating node (see the note beside focusNodeById:
   // travelToNode, not focusNodeById, so a closed project's tab is reopened first).
   useEffect(() => window.nodeTerminal.onFocusNode(travelToNode), [travelToNode])
+
+  // Memory pressure (core/memory-pressure.ts, pushed by the shell): run the renderer's reclaim
+  // levers. Both are idempotent and cost only warmth — a reclaimed hidden context re-grants on its
+  // next visibility transition, a dropped park re-mounts as an ordinary warm reattach — and the
+  // shell re-fires at most once a minute, so this never runs hot. Severity is not branched on
+  // (yet): the levers are cheap enough to run on 'warning', and the extra CRITICAL step (an early
+  // session-reaper sweep) belongs to the shell, not here. Optional-called because the Server
+  // Edition's bridge declares this a documented no-op.
+  useEffect(() => {
+    const off = window.nodeTerminal.onMemoryPressure?.(() => {
+      releaseAllHiddenGrants()
+      disposeAllParkedTerminals()
+    })
+    return () => off?.()
+  }, [])
 
   // Permanently remove a project (from the "Recently closed" list): end every terminal's tmux
   // session, drop persisted agent status, tear down any SSH master, then delete it from disk.

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -296,6 +296,14 @@ export function disposeParkedTerminal(key: string): void {
   disposeParked(p)
 }
 
+/** Memory-pressure lever: drop EVERY parked terminal now, without waiting out `TERM_PARK_MS`. The
+ *  park is a cache, not state — each dropped entry costs only its warm re-adopt, and the node
+ *  re-mounts as an ordinary warm reattach (tmux redraws; the session and its scrollback are
+ *  untouched). Idempotent; iterates a copy because `disposeParkedTerminal` mutates the map. */
+export function disposeAllParkedTerminals(): void {
+  for (const key of [...parkedTerminals.keys()]) disposeParkedTerminal(key)
+}
+
 /** Session-scoped keys (`terminalKey`) whose next unmount must dispose (not park) — set on permanent
  *  deletion, where the unmount runs AFTER the session was already destroyed, so parking would keep a
  *  dead xterm. */

--- a/src/renderer/terminal/webgl-budget.test.ts
+++ b/src/renderer/terminal/webgl-budget.test.ts
@@ -4,6 +4,7 @@ import {
   __resetWebglBudgetForTests,
   getWebglBudget,
   loseWebglContexts,
+  releaseAllHiddenGrants,
   setWebglBudget,
   setWebglEnabled,
   setWebglGesture,
@@ -453,6 +454,85 @@ describe('webgl-budget coordinator', () => {
       setWebglGesture(false)
       vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
       expect(clients.every((c) => !c.rec.held)).toBe(true)
+    })
+  })
+
+  describe('releaseAllHiddenGrants (memory-pressure lever)', () => {
+    it('gives back a hidden holder without waiting out the release delay', () => {
+      const a = fakeClient('a')
+      grant(a)
+      a.handle.setVisible(false)
+      // Well inside the warm window — the lever is what ends it, not the timer.
+      expect(a.rec.held).toBe(true)
+      releaseAllHiddenGrants()
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 3)
+      expect(a.rec.held).toBe(false)
+      expect(a.rec.releases).toBe(1)
+    })
+
+    it('never touches a VISIBLE holder', () => {
+      const visible = fakeClient('visible')
+      const hidden = fakeClient('hidden')
+      grant(visible)
+      grant(hidden)
+      hidden.handle.setVisible(false)
+      releaseAllHiddenGrants()
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(hidden.rec.held).toBe(false)
+      expect(visible.rec.held).toBe(true)
+      expect(visible.rec.releases).toBe(0)
+    })
+
+    it('is idempotent — a second call releases nothing extra', () => {
+      const a = fakeClient('a')
+      grant(a)
+      a.handle.setVisible(false)
+      releaseAllHiddenGrants()
+      releaseAllHiddenGrants()
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(a.rec.releases).toBe(1)
+      releaseAllHiddenGrants() // nothing granted left to give back
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(a.rec.releases).toBe(1)
+    })
+
+    it('queues the releases through the drain instead of swapping in one frame', () => {
+      const clients = ['a', 'b', 'c', 'd', 'e'].map((id) => fakeClient(id))
+      clients.forEach(grant)
+      clients.forEach((c) => c.handle.setVisible(false))
+      releaseAllHiddenGrants()
+      // A synchronous reclaim loop would have released all five here — that is the swap storm.
+      expect(clients.filter((c) => c.rec.held).length).toBe(clients.length - WEBGL_SWAPS_PER_DRAIN)
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(clients.every((c) => !c.rec.held)).toBe(true)
+    })
+
+    it('releases NOTHING mid-gesture, then trickles once the canvas is at rest', () => {
+      const clients = ['a', 'b', 'c', 'd'].map((id) => fakeClient(id))
+      clients.forEach(grant)
+      setWebglGesture(true)
+      clients.forEach((c) => c.handle.setVisible(false))
+      releaseAllHiddenGrants()
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 10)
+      // The load-bearing rule: no renderer swap while the user pans/zooms, pressure or not.
+      expect(clients.every((c) => c.rec.held)).toBe(true)
+      setWebglGesture(false)
+      expect(clients.filter((c) => c.rec.held).length).toBe(clients.length - WEBGL_SWAPS_PER_DRAIN)
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(clients.every((c) => !c.rec.held)).toBe(true)
+    })
+
+    it('forgives a queued release for a client that became visible again', () => {
+      const a = fakeClient('a')
+      grant(a)
+      a.handle.setVisible(false)
+      setWebglGesture(true)
+      releaseAllHiddenGrants()
+      a.handle.setVisible(true) // pans back before the drain ran
+      setWebglGesture(false)
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(a.rec.held).toBe(true)
+      expect(a.rec.releases).toBe(0)
     })
   })
 })

--- a/src/renderer/terminal/webgl-budget.ts
+++ b/src/renderer/terminal/webgl-budget.ts
@@ -344,6 +344,20 @@ function reclaim(c: Client): void {
   c.granted = false
 }
 
+/**
+ * Memory-pressure lever: reclaim EVERY hidden holder's context now, bypassing the release delay.
+ * Visible holders are untouched — the same invariant `lruHiddenHolder` applies, and for the same
+ * reason: taking a context off a terminal the user is looking at trades memory for a visible
+ * downgrade. Idempotent (a client that holds nothing is skipped), and each reclaimed client
+ * re-grants through the normal budget-gated path on its next visibility transition.
+ */
+export function releaseAllHiddenGrants(): void {
+  for (const c of clients.values()) {
+    if (!c.granted || c.visible) continue
+    reclaim(c)
+  }
+}
+
 /** The least-recently-visible HIDDEN holder, or null if every holder is currently visible. */
 function lruHiddenHolder(): Client | null {
   let best: Client | null = null

--- a/src/renderer/terminal/webgl-budget.ts
+++ b/src/renderer/terminal/webgl-budget.ts
@@ -345,17 +345,30 @@ function reclaim(c: Client): void {
 }
 
 /**
- * Memory-pressure lever: reclaim EVERY hidden holder's context now, bypassing the release delay.
- * Visible holders are untouched — the same invariant `lruHiddenHolder` applies, and for the same
- * reason: taking a context off a terminal the user is looking at trades memory for a visible
- * downgrade. Idempotent (a client that holds nothing is skipped), and each reclaimed client
- * re-grants through the normal budget-gated path on its next visibility transition.
+ * Memory-pressure lever: give back EVERY hidden holder's context, skipping the release delay's
+ * warm-for-a-pan-back window. Visible holders are untouched — the same invariant `lruHiddenHolder`
+ * applies, and for the same reason: taking a context off a terminal the user is looking at trades
+ * memory for a visible downgrade.
+ *
+ * The releases are QUEUED (`owed` + `drain`), not executed here — pressure wants the memory back
+ * SOON, not this frame. Releasing ~24 contexts in one synchronous loop is a swap storm: exactly
+ * what the zoom threshold's one-frame mass release turned out to be, and mid-gesture it lands in
+ * the GPU-pressure window where a swap dies midway and strands a terminal black. The drain path
+ * is what keeps "soon" honest: it no-ops while a gesture runs, re-checks `!c.visible` before each
+ * release (a client that came back keeps its warm context), and trickles at
+ * `WEBGL_SWAPS_PER_DRAIN` per `WEBGL_DRAIN_MS`.
+ *
+ * Idempotent: a client already queued with `releaseOwed` is simply re-added to a Set — the flag is
+ * never cleared here, so a second call cannot cancel a pending release.
  */
 export function releaseAllHiddenGrants(): void {
   for (const c of clients.values()) {
     if (!c.granted || c.visible) continue
-    reclaim(c)
+    cancelRelease(c) // the delayed release is superseded by the queued one
+    c.releaseOwed = true
+    owed.add(c)
   }
+  drain()
 }
 
 /** The least-recently-visible HIDDEN holder, or null if every holder is currently visible. */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -50,6 +50,7 @@ import { createPushNotify, createLiveUpdatePush } from '../core/push-notify'
 import { createGrantsAccessor } from '../core/push-grants'
 import { createAckSweeper } from '../core/ack-sweep'
 import { createSessionReaper } from '../core/session-budget'
+import { createMemoryPressureMonitor } from '../core/memory-pressure'
 import { claudeCliCaps, type ClaudeCliCaps } from '../core/claude-cli'
 import { claudeConfigDirFor } from '../core/claude-config-dir'
 import { presenceHub } from '../core/presence/hub'
@@ -442,6 +443,19 @@ export async function startServer(
   // open. Kill switch + tuning via NODETERM_SESSION_* env (core/session-budget.ts).
   const sessionReaper = createSessionReaper({ tmuxBin: () => ptyManager.getTmuxBin() })
   sessionReaper.start()
+  // Memory pressure (core/memory-pressure.ts): only the reaper leg on this shell. A CRITICAL
+  // reading sweeps NOW instead of waiting out the reaper's 10-minute timer — that is the whole
+  // responder chain here. The renderer levers the desktop also runs (hidden WebGL contexts,
+  // parked terminals) are deliberately NOT pushed to attached browsers: a tab's own memory is the
+  // browser's to manage, and it already discards on its own terms (see the documented no-op in
+  // renderer/bridge/stubs.ts). Stopped on close beside the reaper — the timer is unref'd, but a
+  // test that starts and closes several servers must not leave sweepers behind.
+  const pressure = createMemoryPressureMonitor({
+    onPressure: (severity) => {
+      if (severity === 'critical') void sessionReaper.sweep()
+    }
+  })
+  pressure.start()
 
   // Headless notification host: every core service above (incl. the loopback hook server, which
   // is its own listener and MUST run) is booted, but we bind NO public HTTP/WS listener — no
@@ -454,6 +468,7 @@ export async function startServer(
       async close() {
         // Detach PTY clients — tmux sessions keep running (Phase 1 contract).
         sessionReaper.stop()
+        pressure.stop()
         await contextLink.stop()
         await ptyManager.killAll()
         // Same native hazard as the desktop app: a whisper transcribe still running when the
@@ -500,6 +515,7 @@ export async function startServer(
     async close() {
       // Detach PTY clients — tmux sessions keep running (Phase 1 contract; never kill the server).
       sessionReaper.stop()
+      pressure.stop()
       await contextLink.stop()
       await ptyManager.killAll()
       // Same native hazard as the desktop app: a whisper transcribe still running when the node

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -41,6 +41,10 @@ export const IPC = {
   appOpenNotificationSettings: 'app:open-notification-settings',
   appFocusNode: 'app:focus-node',
   appSetBadge: 'app:set-badge',
+  /** Main → renderer: the host (or this process's own RSS) crossed a memory-pressure watermark,
+   *  so the renderer should run its reclaim levers now (hidden WebGL contexts, parked terminals).
+   *  Payload: `'warning' | 'critical'`. Re-fired at most once a minute — see core/memory-pressure. */
+  appMemoryPressure: 'app:memory-pressure',
   agentStatus: 'agent:status',
   /** Renderer → main/server: answer a held Claude permission hook (deterministic approvals).
    *  Payload: `{ nodeId, pendingId, decision: 'allow'|'deny' }`; resolves boolean. See

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2011,6 +2011,12 @@ export interface NodeTerminalApi {
   openNotificationSettings(): Promise<void>
   /** Fires when a notification is clicked, asking the renderer to focus a node. Returns unsubscribe. */
   onFocusNode(listener: (nodeId: string) => void): () => void
+  /** Fires when the shell's memory-pressure monitor (core/memory-pressure.ts) sees the host — or
+   *  this process's own RSS — cross a watermark: the renderer answers by running its reclaim
+   *  levers (hidden WebGL contexts, parked terminals). At most one fire a minute, so the levers
+   *  need only be idempotent, not cheap. Returns unsubscribe. Server Edition: never fires (the
+   *  pressure levers run host-side there; a browser tab's memory belongs to the browser). */
+  onMemoryPressure(listener: (severity: 'warning' | 'critical') => void): () => void
   /** Answer a Claude permission request via the deterministic hook-reply channel (spec:
    *  docs/hook-reply-approvals.md). Writes the one-line answer file the held hook is polling
    *  (`~/.nodeterm/pending/<pendingId>.answer`) on the host the agent runs on — the LOCAL fs for a


### PR DESCRIPTION
Phase 3 of the RAM-optimization series (plan in-repo; #110, #114, #118 merged). Until now nothing reacted to memory pressure — the host swapped itself to death before any lever moved (the 2026-08-03 multi-tenant swap-thrash incident). This adds cmux's two-signal responder pattern on top of the levers earlier phases built.

## Behavior

- **Core monitor** (`src/core/memory-pressure.ts`, Electron-free, both shells boot it): every 30 s, classify pressure from two signals — host `MemAvailable` watermarks (warning <10% of total, critical <5%) OR the process's own RSS (>4 GB / >8 GB). A failed memory read is never pressure (house rule); re-fires are floored at 60 s; a consumer throw cannot kill the timer.
- **Desktop, on any pressure:** broadcast to the renderer, which (1) queues every hidden WebGL grant into the budget's own `owed`+`drain` machinery — released at the normal trickle rate, never mid-gesture (review caught the first version bypassing the gesture latch: a 30 s tick landing mid-pan would have done ~24 synchronous swaps, the module's documented black-terminal recipe) — and (2) disposes all parked terminals (each becomes a warm tmux reattach later).
- **Desktop, on critical:** additionally run the session reaper's sweep immediately instead of waiting for its 10-minute timer (same eligibility rules — only 6h-idle detached sessions; nothing new becomes killable, it just happens sooner).
- **Server Edition:** monitor + critical→sweep leg; stopped on both shutdown paths.

## Disclosures (each a deliberate decision)

1. **macOS host leg is deliberately silent.** `os.freemem()` on darwin is vm_stat `free_count` only (excludes inactive/purgeable/compressor), which would read a healthy Mac as permanently critical — disposing the park cache and sweeping the reaper every 60 s. Per "a guess must degrade to nothing, never to something wrong", `hostMemReader('darwin')` returns a null reader; the RSS leg remains. Follow-up: a real macOS signal (compressor/swap state or `app.getAppMetrics`) replaces the special case.
2. **The self-RSS leg observes the MAIN process only** (renderer memory is invisible to it, and main rarely nears 4 GB) — on desktop the host-availability leg does the real work; the RSS leg earns its keep on Server Edition where one process holds everything. Net: on macOS desktop the chain is effectively inert until #1's follow-up lands; on Linux desktop + Server Edition it is fully live.
3. **The re-fire floor is severity-blind:** a warning at t=0 defers a critical at t=10 s until t=60 s — bounded cost, since the critical leg only accelerates a 10-minute backstop.
4. **Server Edition renderer leg is a documented N/A** (a browser tab's WebGL/parks are the browser's to reclaim; `renderer/bridge/stubs.ts`). Mobile: N/A.
5. **The session reaper still reads raw `readMemInfo`**, so #1's darwin caveat pre-exists for its own 10-minute sweep — unchanged here, slated for the same follow-up.
6. On the default macOS renderer (shared glyphgrid) terminals are not WebGL-budget clients, so the WebGL lever is idle there regardless — the park lever is what fires.

## Testing

- Monitor: 9 tests (watermarks, null-read never pressure + RSS-still-counts, floor, stop() asserted, throwing consumer, darwin/linux reader identity — mutation-sensitive).
- WebGL lever: 6 tests on the budget's own harness; reverting the drain-routing to a direct reclaim loop fails exactly the three latch/trickle tests (mutation-checked).
- Full suite at HEAD: 366 files / 4622 tests green (re-run by the final reviewer); typecheck clean.
- Runtime observation of a real pressure fire is owed (needs a host actually under pressure); all trigger paths are unit-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)