### PR TITLE
feat(pty): tmux control-mode shadow clients — pty-free background sessions

### DIFF
--- a/docs/superpowers/plans/2026-08-11-tmux-control-mode-shadow-clients.md
+++ b/docs/superpowers/plans/2026-08-11-tmux-control-mode-shadow-clients.md
@@ -1,0 +1,299 @@
+# Tmux Control-Mode Shadow Clients Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Background (zero-subscriber) tmux sessions keep observability and input without holding any pty device, dropping nodeterm's floor cost to 1 pty per session (the unavoidable pane pty) and ending `kern.tty.ptmx_max` exhaustion as a failure class.
+
+**Architecture:** Visible sessions keep today's design untouched: one node-pty client running `tmux new-session -A -D` (the "painter" — see the hard-won warning at `src/core/pty-manager.ts:101-107`; we never re-derive screen state from `capture-pane`). What changes is only the *unwatched* side: when the idle-reaper (branch `fix/pty-limit-detection-reap`) releases a session's client pty, a session that still has a background consumer (relay `onData` sink, background write) gets a **shadow client** instead of nothing — a `tmux -C attach-session` child over plain pipes (control mode allocates **no pty device**). The shadow streams the pane's raw bytes via `%output` events and executes `send-keys` for input. First human subscriber ⇒ shadow is killed and the existing cold-attach path spawns the real pty client, exactly as after an app restart.
+
+**Tech Stack:** tmux control mode (`-C`, protocol stable since tmux 1.8; we require the repo's existing floor, tmux ≥ 3.2 — same floor `terminal-features` already imposes, `src/core/pty-manager.ts:109-115`), Node `child_process.spawn` with pipes, vitest.
+
+## Global Constraints
+
+- NEVER kill tmux *sessions*: closed-project sessions run forever BY DESIGN (`src/core/pty-manager.ts:465-468` region; reclaim path is the user's "Recently closed" delete). Shadow lifecycle may only kill its own *client*.
+- Never suggest or use `tmux kill-server`.
+- Any real-pty detach goes through `releasePty()` (`src/core/pty-release.ts`) — never bare `proc.kill()`.
+- The visible-terminal path (node-pty client, `-A -D` attach flags, alternate screen, mouse copy via OSC 52) is untouchable in this plan. No control-mode rendering for visible terminals — `pty-manager.ts:101-107` documents why the painter stays.
+- `src/core/` stays Electron-free (it is shared with the server edition — see the `platform()` seam).
+- Worktree setup for implementers: fresh worktrees have no node_modules; run `ln -s /Users/enes/projects/nodebasedterminal/node_modules node_modules` and NEVER run npm install / rebuild / postinstall (arch-sensitive native builds).
+- Plan file itself: `docs/superpowers/plans/` is gitignored; commit this file with `git add -f`, as prior plans did.
+- All commits end with the repo's `Co-Authored-By:` convention.
+
+## Revision Points (named assumptions — re-check before executing)
+
+1. **Reap-branch seam — RESOLVED 2026-08-11, and it reshapes Task 3.** `fix/pty-limit-detection-reap` merged (through main `02d3ec17`). Actual seams: `releaseClient()` (extracted final-snapshot + `releasePty` + index cleanup, shared with `kill()`), `forget()` (drops `byPersistKey`; next `pty:create` warm-reattaches via `tmux new-session -A`, `fresh:false`), sweep in `src/core/pty-reap.ts` (`REAP_IDLE_MS` 10min / `REAP_SWEEP_MS` 60s, pure `shouldReap`), `Session.tmuxBacked`, attachment decided against `platform().clientIds()`.
+   **Timer-interaction check item (added 2026-08-11 after PR #118 merged):** three lifecycles now run side by side — renderer park (`TERM_PARK_MS` 5min), offscreen dispose (`offscreenTerminalMinutes` default 10min, `src/renderer/terminal/offscreen-policy.ts`), and the reap sweep (`REAP_IDLE_MS` 10min). Before executing Tasks 3-4, verify with the merged code: (a) an offscreen-disposed node drops its subscription, so its session releases IMMEDIATELY via the zero-subscriber path — the reap never sees it; confirm a shadow attached to such a session is disposed by the same `create()` swap-out when the node scrolls back into view; (b) the reap threshold must stay ≥ 2× park (documented in pty-reap.ts) and any shadow linger must stay well under all three so it never keeps a session looking "watched"; (c) none of the three may treat a live shadow as a subscriber (a shadow must be invisible to `platform().clientIds()`-based attachment checks).
+   **Finding that invalidates Task 3's original trigger:** a session at literal zero subscribers is released *immediately* by `kill()`/`dropClient` — the reaper's population is *stranded* subscribers (client ids that no longer exist). And a relay `onData` sink **counts as a watcher — relay-served ptys are never reaped**. So the planned trigger "reaper releases a session that still has an onData sink" cannot occur. Task 3's premise is rewritten below (see the task); net effect: the shadow's near-term value concentrates in Task 4 (background writes without spawning a pty client) and in *optionally* letting relay-lite viewers ride `%output` later; the pty-pressure emergency itself is already handled by the reap. Execute this plan as capacity/product need dictates, not as a fire.
+2. **Competitor research — RESOLVED 2026-08-11.** Findings that bind this plan:
+   - **`-C`, never `-CC`** — verified in tmux source (`client.c`: `-CC` calls `tcgetattr(STDIN)` and exits on failure) and empirically on this machine (tmux 3.6a: `-CC` over a fifo dies `tcgetattr failed`; `-C` over the same fifo streams cleanly, holds **0 ptys**, `send-keys` and `refresh-client -C` both work pty-free). This plan already specifies `-C` throughout — do not "upgrade" it.
+   - **Commands are server-wide; streams are per-attached-session.** A single shared `-C` client can `send-keys -t <any-session>` — so **Task 4 needs exactly ONE shared control client for the whole server**, not one per session. Only `%output` *streaming* is scoped to the attached session (nodeterm = one session per node), so Task 3's observability shadow stays per-session (or uses `link-window` into a monitor session — decide at execution).
+   - **Sizing correctness:** with only a control client attached, the pane's size follows `refresh-client -C <cols>x<rows>` — a shadow MUST push the session's last-known effective size on attach, or the pane may reflow to a default. Add this to Task 3's swap-in step (read the size the released painter last enforced).
+   - **Wire-cost gate:** control-mode output escapes control bytes to octal (~4× inflation on TUI-heavy output). Before executing Task 3, run a load probe (the research harness pattern: fifo + `-C attach` + a chatty TUI in ~60 panes) and record CPU; if unacceptable, restrict shadows to `Snapshots`-style polling (`capture-pane`) instead of live `%output`.
+   - **Prior art:** cmux ships `-CC`-based remote mirroring (their client owns a tty, hence `-CC`); no mature Node control-mode library exists — Task 1's codec is the parser, as planned. Adjacent ideas recorded in the backlog (not this plan): cmux Agent Hibernation (cap + SIGTERM idle background agents + native `--resume`), VibeTunnel per-session subscription flags (Stdout|Snapshots|Events over one socket), cmux child-exit policy + restore spawn pacing, herdr `pane.read` text API for zoomed-out cards.
+3. **Consumer inventory.** The only in-main background consumers of live output found today are the relay host sink (`session.onData`, `pty-manager.ts:1031`, `:1516`) and renderer forwarding (moot at zero subscribers). If at execution time `grep -n "onData" src/core/pty-manager.ts` shows new consumers, list them in Task 3's swap conditions.
+
+## File Structure
+
+- Create: `src/core/tmux-control.ts` — pure control-mode protocol codec (no I/O).
+- Create: `src/core/tmux-control.test.ts`
+- Create: `src/core/tmux-control-client.ts` — `ControlModeClient`: child-process lifecycle + command/reply correlation, injectable spawn.
+- Create: `src/core/tmux-control-client.test.ts`
+- Modify: `src/core/pty-manager.ts` — shadow registry + swap logic at the release/attach seams.
+- Modify (tests): `src/core/pty-coattach.test.ts` conventions reused in a new `src/core/pty-shadow.test.ts`.
+
+---
+
+### Task 1: Control-mode protocol codec (pure)
+
+Control mode is line-oriented: notifications start with `%`; command replies are bracketed by `%begin <ts> <num> <flags>` … `%end <ts> <num> <flags>` (or `%error`). `%output %<pane-id> <data>` carries the pane's raw bytes with `\ooo` octal escapes. This task builds the pure codec; no process, no fs.
+
+**Files:**
+- Create: `src/core/tmux-control.ts`
+- Test: `src/core/tmux-control.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type ControlEvent =
+    | { kind: 'output'; paneId: string; data: string }        // octal-decoded
+    | { kind: 'reply'; num: number; ok: boolean; body: string[] }
+    | { kind: 'exited' }                                       // %exit
+    | { kind: 'other'; line: string }                          // %session-changed etc.
+  export function createControlDecoder(): { push(chunk: string): ControlEvent[] }
+  export function decodeOctal(s: string): string
+  export function encodeSendKeysHex(target: string, data: string): string
+  ```
+  `encodeSendKeysHex('nt-term-1', 'ls\n')` → `send-keys -t nt-term-1 -H 6c 73 0a` — hex bytes, because control-mode commands are one text line and `-H` sidesteps every quoting/UTF-8 hazard (`-l` literal mode would need shell-grade escaping).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/core/tmux-control.test.ts
+import { describe, it, expect } from 'vitest'
+import { createControlDecoder, decodeOctal, encodeSendKeysHex } from './tmux-control'
+
+describe('decodeOctal', () => {
+  it('decodes tmux %output octal escapes back to bytes', () => {
+    expect(decodeOctal('hello\\012world\\033[31m')).toBe('hello\nworld\x1b[31m')
+  })
+  it('passes plain text through untouched', () => {
+    expect(decodeOctal('just text')).toBe('just text')
+  })
+  it('keeps a literal backslash that is not an octal escape', () => {
+    expect(decodeOctal('a\\\\b')).toBe('a\\b')
+  })
+})
+
+describe('createControlDecoder', () => {
+  it('emits an output event per %output line, pane id preserved', () => {
+    const d = createControlDecoder()
+    const ev = d.push('%output %3 abc\\012\n')
+    expect(ev).toEqual([{ kind: 'output', paneId: '%3', data: 'abc\n' }])
+  })
+  it('buffers partial lines across pushes', () => {
+    const d = createControlDecoder()
+    expect(d.push('%output %3 ab')).toEqual([])
+    expect(d.push('c\n')).toEqual([{ kind: 'output', paneId: '%3', data: 'abc' }])
+  })
+  it('collects a %begin/%end block into one ok reply with its body', () => {
+    const d = createControlDecoder()
+    const ev = d.push('%begin 100 7 0\nline1\nline2\n%end 100 7 0\n')
+    expect(ev).toEqual([{ kind: 'reply', num: 7, ok: true, body: ['line1', 'line2'] }])
+  })
+  it('collects a %begin/%error block into one failed reply', () => {
+    const d = createControlDecoder()
+    const ev = d.push('%begin 100 8 0\nno such session\n%error 100 8 0\n')
+    expect(ev).toEqual([{ kind: 'reply', num: 8, ok: false, body: ['no such session'] }])
+  })
+  it('reports %exit as exited', () => {
+    expect(createControlDecoder().push('%exit\n')).toEqual([{ kind: 'exited' }])
+  })
+  it('passes unknown notifications through as other', () => {
+    expect(createControlDecoder().push('%session-changed $1 nt-x\n'))
+      .toEqual([{ kind: 'other', line: '%session-changed $1 nt-x' }])
+  })
+})
+
+describe('encodeSendKeysHex', () => {
+  it('encodes bytes as hex send-keys arguments', () => {
+    expect(encodeSendKeysHex('nt-term-1', 'ls\n')).toBe('send-keys -t nt-term-1 -H 6c 73 0a')
+  })
+  it('encodes multi-byte UTF-8 per byte', () => {
+    expect(encodeSendKeysHex('s', 'ç')).toBe('send-keys -t s -H c3 a7')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/core/tmux-control.test.ts`
+Expected: FAIL — module `./tmux-control` not found.
+
+- [ ] **Step 3: Implement the codec**
+
+```ts
+// src/core/tmux-control.ts
+/** Pure tmux control-mode (-C) protocol codec. No I/O here — the client (tmux-control-client.ts)
+ *  owns the process; this file owns the line protocol, so every parsing rule is unit-testable.
+ *  Protocol: notifications are %-prefixed lines; command replies arrive as a
+ *  `%begin <ts> <num> <flags>` … body … `%end|%error <ts> <num> <flags>` block; `%output %<pane> <data>`
+ *  carries raw pane bytes with non-printables as \ooo octal escapes. */
+
+export type ControlEvent =
+  | { kind: 'output'; paneId: string; data: string }
+  | { kind: 'reply'; num: number; ok: boolean; body: string[] }
+  | { kind: 'exited' }
+  | { kind: 'other'; line: string }
+
+export function decodeOctal(s: string): string {
+  return s.replace(/\\(\d{3}|\\)/g, (_, esc: string) =>
+    esc === '\\' ? '\\' : String.fromCharCode(parseInt(esc, 8))
+  )
+}
+
+export function encodeSendKeysHex(target: string, data: string): string {
+  const bytes = [...Buffer.from(data, 'utf8')].map((b) => b.toString(16).padStart(2, '0'))
+  return `send-keys -t ${target} -H ${bytes.join(' ')}`
+}
+
+export function createControlDecoder(): { push(chunk: string): ControlEvent[] } {
+  let buf = ''
+  let block: { num: number; body: string[] } | null = null
+  return {
+    push(chunk: string): ControlEvent[] {
+      buf += chunk
+      const out: ControlEvent[] = []
+      let nl: number
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).replace(/\r$/, '')
+        buf = buf.slice(nl + 1)
+        if (block) {
+          const done = line.match(/^%(end|error) \d+ (\d+) \d+$/)
+          if (done) {
+            out.push({ kind: 'reply', num: block.num, ok: done[1] === 'end', body: block.body })
+            block = null
+          } else {
+            block.body.push(line)
+          }
+          continue
+        }
+        const begin = line.match(/^%begin \d+ (\d+) \d+$/)
+        if (begin) {
+          block = { num: Number(begin[1]), body: [] }
+        } else if (line.startsWith('%output ')) {
+          const m = line.match(/^%output (%\d+) (.*)$/s)
+          if (m) out.push({ kind: 'output', paneId: m[1], data: decodeOctal(m[2]) })
+        } else if (line === '%exit' || line.startsWith('%exit ')) {
+          out.push({ kind: 'exited' })
+        } else if (line.startsWith('%')) {
+          out.push({ kind: 'other', line })
+        }
+        // Non-% lines outside a block: tmux sends none in -C; drop silently.
+      }
+      return out
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run src/core/tmux-control.test.ts` — Expected: PASS (all 11).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/tmux-control.ts src/core/tmux-control.test.ts
+git commit -m "feat(pty): tmux control-mode protocol codec
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: ControlModeClient (process wrapper, injectable spawn)
+
+**Files:**
+- Create: `src/core/tmux-control-client.ts`
+- Test: `src/core/tmux-control-client.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's `createControlDecoder`, `encodeSendKeysHex`, `ControlEvent`.
+- Produces:
+  ```ts
+  export interface ControlSpawn {  // injectable child_process seam (tests pass a fake)
+    spawn(bin: string, args: string[]): {
+      stdin: { write(s: string): void }
+      stdout: { on(ev: 'data', cb: (b: Buffer) => void): void }
+      on(ev: 'exit', cb: (code: number | null) => void): void
+      kill(): void
+    }
+  }
+  export class ControlModeClient {
+    constructor(opts: {
+      tmuxBin: string; socket: string; sessionName: string
+      onOutput: (data: string) => void
+      onExit: () => void
+      spawner?: ControlSpawn                       // default: real child_process
+    })
+    start(): void                                   // spawn `tmux -L <socket> -C attach-session -t <name>`
+    sendKeys(data: string): Promise<boolean>        // hex send-keys, resolves on %end/%error
+    command(line: string): Promise<{ ok: boolean; body: string[] }>
+    dispose(): void                                 // detach command then kill; idempotent
+    readonly alive: boolean
+  }
+  ```
+  Command/reply correlation: control mode answers commands **in order** — a FIFO of pending resolvers matched to `reply` events by arrival order (the `num` field is asserted monotonic only in tests; ordering is the contract).
+
+- [ ] **Step 1: Write the failing tests** — with a `FakeControlSpawn` capturing stdin writes and letting tests feed stdout. Cover: spawn args are exactly `['-L', socket, '-C', 'attach-session', '-t', sessionName]`; `%output` events reach `onOutput` decoded; `sendKeys('ls\n')` writes the Task-1 hex line + newline to stdin and resolves `true` on an ok reply, `false` on `%error`; two overlapping `command()` calls resolve in FIFO order; process exit fires `onExit` once, rejects pending commands, `alive` flips false; `dispose()` writes `detach-client\n` then kills, and a second `dispose()` is a no-op.
+- [ ] **Step 2: Run to verify failure** — `npx vitest run src/core/tmux-control-client.test.ts` fails on missing module.
+- [ ] **Step 3: Implement** — thin: pipe stdout chunks into the decoder, dispatch events; `command()` pushes `{resolve}` onto a FIFO and writes the line; `reply` shifts the FIFO. No timers in v1 (the reaper swap in Task 3 owns timeouts).
+- [ ] **Step 4: Run to verify pass.**
+- [ ] **Step 5: Commit** (`feat(pty): control-mode client over pipes — zero pty devices`).
+
+---
+
+### Task 3: Shadow swap in PtyManager
+
+The behavior seam — premise REVISED per Revision Point 1: the reap never releases a session that still has an `onData` sink (a sink is a watcher), so the shadow is NOT a reap-time swap. Instead: a **released** session (reaped-stranded or plain-killed, `byPersistKey` forgotten) that a background feature later needs — Task 4's write path today; an opt-in lightweight observer API tomorrow — gets a `ControlModeClient` shadow attached ON DEMAND rather than a full painter respawn. First real subscriber still wins: the `create()` path disposes any live shadow BEFORE the normal warm-reattach (`tmux new-session -A`) spawns the painter client, order asserted in tests. Sessions nobody asks about keep costing zero.
+
+**Files:**
+- Modify: `src/core/pty-manager.ts` (fields on `Session`: `shadow?: ControlModeClient`; swap-in at the reaper's release site; swap-out at the top of the attach path; both guarded `this.tmuxPath !== null`)
+- Test: `src/core/pty-shadow.test.ts` (conventions from `src/core/pty-coattach.test.ts` — fake pty factory + fake platform; add a `FakeControlSpawn` injection point via a new optional `PtyManager` constructor dep, defaulting to real)
+
+**Interfaces:**
+- Consumes: Task 2's `ControlModeClient`; the reap branch's release seam (Revision Point 1); `sessionName(persistKey)` and `TMUX_SOCKET` (existing, `pty-manager.ts`).
+- Produces: `Session.shadow` invariant — **a session never has both a live `proc` client and a live shadow**; asserted in tests.
+
+- [ ] Steps follow the same red-green-commit cycle: (1) failing tests — reap with sink ⇒ shadow attached + onData still streams; reap without sink ⇒ no shadow; subscriber arrival ⇒ shadow disposed before pty spawn (order asserted via call log); shadow process death ⇒ session survives, flagged for lazy re-shadow on next sweep; app quit ⇒ all shadows disposed. (2) verify RED, (3) implement, (4) verify GREEN + full `npx vitest run` + `npm run -s typecheck`, (5) commit.
+
+---
+
+### Task 4: Background input (`send-keys`) for shadowed sessions
+
+Canvas-control's `write --node` verb (and the relay host's write path) currently require the client pty. Per Revision Point 2: `send-keys` is server-wide, so this task uses **one shared `ControlModeClient` for the whole tmux server** (attached to any session; lazily started on first background write, disposed after a 10s linger so bursts don't churn processes — constant documented in code). Route writes to any released session through `shared.sendKeys(target, data)` — extend Task 2's `sendKeys` with an explicit target parameter (`encodeSendKeysHex` already takes one).
+
+**Files:**
+- Modify: `src/core/pty-manager.ts` (`write()` fallthrough: real client → shadow → temporary shadow)
+- Test: extend `src/core/pty-shadow.test.ts`
+
+Steps: red-green-commit as above; tests assert the exact `send-keys -H` line hits the fake spawner's stdin and that the temporary shadow disposes after the linger (fake timers).
+
+---
+
+### Task 5: Flag, observability, smoke list
+
+- Settings flag `ptyShadowClients` (default ON; kill-switch honesty — one release of soak time), read at the two swap sites only.
+- One log line per swap direction (`[pty] shadow attach <session>` / `[pty] painter attach <session>`) — greppable in field reports.
+- Update the spawn-failure diagnostic from branch `fix/pty-limit-detection-reap` to mention shadows in its exhaustion hint copy only if that branch's copy names a session count.
+- GUI smoke list (manual, goes in the final report, not code): (1) open 2 projects, background one, confirm `ls /dev/ttys* | wc -l` drops by ~1 per backgrounded terminal after the reap threshold; (2) phone/relay viewer on a backgrounded session still streams; (3) `nodeterm.sh write` into a background node lands (visible after switching); (4) switching back to the project shows the painter attach with intact alternate-screen TUI (run `htop` before backgrounding); (5) `tmux -L node-terminal list-clients` during background shows the `-C` client, no pty path.
+
+Steps: red-green-commit for the flag gate (pure decision helper + test), then wire, then full suite + typecheck, commit.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: pty elimination for unwatched sessions (Tasks 2-3), input without pty (Task 4), painter path untouched (Global Constraints + Task 3 swap-out ordering), rollback (Task 5 flag). Gap accepted consciously: no control-mode rendering for visible terminals — out of scope by design, documented at the top.
+- Types: `ControlEvent`/`ControlModeClient` names match across Tasks 1-4; `Session.shadow` introduced once (Task 3) and reused (Task 4).
+- Placeholders: Tasks 3-5 compress the five TDD steps into cycle descriptions with named assertions instead of full listings — deliberate, because their exact diffs depend on Revision Point 1 (the reap branch's merged seams). Tasks 1-2 are fully concrete and safe to execute today.

--- a/src/core/pty-background-write.test.ts
+++ b/src/core/pty-background-write.test.ts
@@ -518,6 +518,43 @@ describe('background writes into released sessions', () => {
     expect(vi.getTimerCount()).toBe(before)
   })
 
+  it('logs the shared client’s attach with the same line a shadow logs', async () => {
+    const lines: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => void lines.push(a.join(' ')))
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+
+    await m.backgroundWrite('node-1', 'ls\n')
+    await m.backgroundWrite('node-1', 'ls\n') // served by the SAME client — so no second line
+
+    // From the outside the shared client and a per-session shadow are the same event: a control
+    // client of ours became that session's attached client. Somebody reading `list-clients` after a
+    // field report should not have to know which of the two kinds they are looking at.
+    expect(lines.filter((l) => l === `[pty] shadow attach ${sessionName('node-1')}`)).toHaveLength(1)
+  })
+
+  it('a relay-served session is never reaped, so a phone’s keystrokes reach its painter', async () => {
+    // The relay host holds `stream.sessionId` for the lifetime of a stream and calls
+    // `pty.write(clientId, stream.sessionId, …)` directly (host-service.ts), BYPASSING the
+    // `subscribes()` gate the renderer's `pty:write` goes through — so it genuinely can reach
+    // `write()`'s miss path. What it cannot reach is a RELEASED record: a relay sink counts as a
+    // watcher (`reapTick`), and `kill()` only releases once that sink is gone — by which time the
+    // host has dropped the stream and `onFrame` no longer routes input for it. This pins the
+    // reasoning that "the mechanism has no production caller" rests on; if a future change stops
+    // the sink counting as a watcher, this test is the one that says so.
+    const { REAP_IDLE_MS, REAP_SWEEP_MS } = await import('./pty-reap')
+    const m = await tmuxManager()
+    const sessionId = m.attachDetached('node-1', { onData: () => {}, onExit: () => {} })
+
+    vi.advanceTimersByTime(REAP_IDLE_MS + REAP_SWEEP_MS * 3)
+    m.write(null, sessionId, 'ls\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(spawned[0].killed).toBe(false) // the sweep left the phone's pty alone…
+    expect(spawned[0].writes).toEqual(['ls\n']) // …and tier 1 answered the write
+    expect(control.calls).toHaveLength(0) // no control client was needed, or started
+  })
+
   it('destroying a node disposes the shared client attached to its session', async () => {
     const m = await tmuxManager()
     await release(ALICE, 'node-1')

--- a/src/core/pty-background-write.test.ts
+++ b/src/core/pty-background-write.test.ts
@@ -183,6 +183,14 @@ describe('background writes into released sessions', () => {
     m.registerIpc()
     return m
   }
+  /** The same manager with one setting flipped — tmux is still installed and still enabled. */
+  async function managerWith(patch: Partial<typeof DEFAULT_SETTINGS>) {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager({ controlSpawn: control })
+    m.init(() => ({ ...DEFAULT_SETTINGS, ...patch }))
+    m.registerIpc()
+    return m
+  }
   const create = (clientId: number, persistKey = 'node-1', cols = 80, rows = 24) =>
     fake.handlers[IPC.ptyCreate](clientId, { cols, rows, persistKey }) as Promise<{
       sessionId: string
@@ -451,6 +459,77 @@ describe('background writes into released sessions', () => {
     // session, so the keys would go to a name that does not exist.
     expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(false)
     expect(control.calls).toHaveLength(0)
+  })
+
+  it('refuses the control-client tiers with ptyShadowClients switched off', async () => {
+    const m = await managerWith({ ptyShadowClients: false })
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+
+    // The kill switch means what it says: with it off, this process never spawns a `tmux -C` child,
+    // so a released node is simply unreachable again — the behavior of the release this mechanism
+    // shipped in.
+    expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(false)
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('still writes into the painter with ptyShadowClients switched off — tier 1 is not a shadow', async () => {
+    const m = await managerWith({ ptyShadowClients: false })
+    await create(ALICE, 'node-1')
+
+    // Tier 1 is the session's own pty, which exists with or without this feature. Gating it would
+    // turn the kill switch into "background writes stop working", which is a different setting.
+    expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(true)
+    expect(spawned[0].writes).toEqual(['ls\n'])
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('falls through to the shared client when the node’s shadow is dead but still indexed', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    const shadow = await m.shadowAttach('node-1')
+    // A holder retiring the client it was handed. `dispose()` is SILENT by design (it fires no
+    // `onExit`), so nothing evicted the map entry — the shadow is dead and still indexed.
+    shadow?.dispose()
+
+    expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(true)
+
+    // Tier 2 asks whether the shadow is ALIVE, not whether an entry exists. And falling through is
+    // safe for exactly the reason the never-retry rule needs: a client that is not running rejects
+    // `command()` BEFORE writing a byte (tmux-control-client.ts), so no send-keys can have reached
+    // tmux twice.
+    expect(control.calls).toHaveLength(2)
+    expect(control.children[1].writes).toContain(LS_KEYS('nt-node-1'))
+    expect(control.children[0].writes).not.toContain(LS_KEYS('nt-node-1'))
+  })
+
+  it('clears the linger when the shared client dies mid-command', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    const before = vi.getTimerCount()
+
+    const writing = m.backgroundWrite('node-1', 'ls\n') // arms the linger
+    control.only.exit(1) // …and the client dies under it: its own onExit clears `shared`
+
+    expect(await writing).toBe(false)
+    // With nothing attached, the linger is a timer armed for a client that no longer exists — and
+    // the dispose it will run is aimed at whatever IS attached when it fires. It goes with the
+    // client, whether or not there was still an entry to dispose.
+    expect(vi.getTimerCount()).toBe(before)
+  })
+
+  it('destroying a node disposes the shared client attached to its session', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await m.backgroundWrite('node-1', 'ls\n')
+
+    await m.destroySession(ALICE, 'node-1')
+
+    // The tmux session is about to be killed: a client of ours attached to it would linger until
+    // tmux dropped it, and would meanwhile be subtracted from the session budget for a name that no
+    // longer exists.
+    expect(control.only.killed).toBe(1)
+    expect(m.shadowedTmuxSessions(TMUX_SOCKET)).toEqual([])
   })
 })
 

--- a/src/core/pty-background-write.test.ts
+++ b/src/core/pty-background-write.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { IPC } from '../shared/ipc'
+import { DEFAULT_SETTINGS } from '../shared/types'
+import { TMUX_SOCKET, sessionName, isSessionName } from './tmux-naming'
+import type { ControlSpawn } from './tmux-control-client'
+
+/**
+ * BACKGROUND WRITES: typing into a node whose PAINTER pty client has been released, without
+ * respawning one. `send-keys` is server-wide in control mode, so the fallthrough is
+ * painter → the node's own shadow (if one is already up) → ONE shared control client for the whole
+ * tmux server, started lazily on the first background write and disposed after a short linger.
+ *
+ * The harness is `pty-shadow.test.ts`'s, with one addition: the fake pty records what was written
+ * into it, because "the painter got the bytes" is half of what this file asserts.
+ */
+
+/** One fake pty per spawn. `killed` is what a released client pty looks like from here. */
+interface FakePty {
+  onDataCb?: (d: string) => void
+  onExitCb?: (e: { exitCode: number }) => void
+  writes: string[]
+  killed: boolean
+  /** node-pty throws on a write to a process that has already gone (as `resize` does). */
+  throwOnWrite: boolean
+}
+const spawned: FakePty[] = []
+/** Spawn/dispose events across BOTH child kinds, so a test can assert their relative ORDER. */
+const log: string[] = []
+
+vi.mock('node-pty', () => ({
+  spawn: () => {
+    const p: FakePty = { writes: [], killed: false, throwOnWrite: false }
+    spawned.push(p)
+    log.push('pty-spawn')
+    return {
+      onData: (cb: (d: string) => void) => {
+        p.onDataCb = cb
+      },
+      onExit: (cb: (e: { exitCode: number }) => void) => {
+        p.onExitCb = cb
+      },
+      write: (d: string) => {
+        if (p.throwOnWrite) throw new Error('write EIO')
+        p.writes.push(d)
+      },
+      resize: () => {},
+      pause: () => {},
+      resume: () => {},
+      kill: () => {
+        p.killed = true
+      },
+      pid: 1
+    }
+  }
+}))
+
+/** Every tmux side-call goes through child_process; `liveTmuxSessions` answers `has-session`. */
+const liveTmuxSessions = new Set<string>()
+
+vi.mock('child_process', () => {
+  type Cb = (err: Error | null, res?: { stdout: string; stderr: string }) => void
+  const execFile = (file: string, args: string[], a?: unknown, b?: unknown): unknown => {
+    const cb = (typeof a === 'function' ? a : b) as Cb | undefined
+    const ok = (stdout: string): void => cb?.(null, { stdout, stderr: '' })
+    if (args.includes('has-session')) {
+      const target = args[args.indexOf('-t') + 1]
+      if (liveTmuxSessions.has(target)) ok('')
+      else cb?.(Object.assign(new Error('no such session'), { code: 1 }))
+    } else if (args[0] === '-ilc') {
+      ok('__NT_PATH_START__/usr/bin:/bin__NT_PATH_END__')
+    } else {
+      ok('')
+    }
+    return {}
+  }
+  return { execFile, execFileSync: (): string => '' }
+})
+
+/** One fake control-mode child per client: what was written to it, and whether it was killed. */
+interface FakeControlChild {
+  writes: string[]
+  killed: number
+  exit(code: number | null): void
+  feed(latin1: string): void
+}
+
+/**
+ * The injected `ControlSpawn`. It answers commands like a healthy tmux does — ASYNCHRONOUSLY (a
+ * reply delivered inside the `write` call would arrive before the client had queued its resolver,
+ * which is not a thing the real protocol can do) — and `autoReply = false` plays the wedged tmux
+ * that takes a command and never answers.
+ */
+class FakeControlSpawn implements ControlSpawn {
+  calls: Array<{ bin: string; args: string[] }> = []
+  children: FakeControlChild[] = []
+  autoReply = true
+  private num = 0
+  spawn(bin: string, args: string[]) {
+    this.calls.push({ bin, args })
+    log.push('control-spawn')
+    let onData: ((b: Buffer) => void) | undefined
+    let onExit: ((code: number | null) => void) | undefined
+    const child: FakeControlChild = {
+      writes: [],
+      killed: 0,
+      exit: (code) => onExit?.(code),
+      feed: (s) => onData?.(Buffer.from(s, 'latin1'))
+    }
+    this.children.push(child)
+    return {
+      stdin: {
+        write: (s: string) => {
+          child.writes.push(s)
+          // `detach-client` is the disposal handshake, not a command with a reply.
+          if (!this.autoReply || s.startsWith('detach-client')) return
+          const n = ++this.num
+          // A real microtask (not a timer): tests run under fake timers.
+          void Promise.resolve().then(() => child.feed(`%begin 1700 ${n} 0\n%end 1700 ${n} 0\n`))
+        }
+      },
+      stdout: {
+        on: (_ev: 'data', cb: (b: Buffer) => void) => {
+          onData = cb
+        }
+      },
+      on: (_ev: 'exit', cb: (code: number | null) => void) => {
+        onExit = cb
+      },
+      kill: () => {
+        child.killed++
+        log.push('control-kill')
+      }
+    }
+  }
+  get only(): FakeControlChild {
+    return this.children[0]
+  }
+}
+
+const ALICE = 1
+const BOB = 2
+
+/** `ls\n` as the wire sees it: hex bytes, because a control-mode command is one text line. */
+const LS_KEYS = (target: string): string => `send-keys -t ${target} -H 6c 73 0a\n`
+
+describe('background writes into released sessions', () => {
+  let fake: FakePlatform
+  let userDataDir: string
+  let control: FakeControlSpawn
+
+  beforeEach(() => {
+    spawned.length = 0
+    log.length = 0
+    liveTmuxSessions.clear()
+    control = new FakeControlSpawn()
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-bgwrite-'))
+    fake = fakePlatform({ userDataDir })
+    initPlatform(fake)
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    resetPlatformForTests()
+    // Best effort, as in pty-shadow.test.ts: a fired-and-forgotten scrollback snapshot can still be
+    // landing here, and a cleanup that fails the suite is worse than a leftover dir.
+    try {
+      fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 20 })
+    } catch {
+      /* a temp dir we could not remove is not a test result */
+    }
+  })
+
+  async function tmuxManager() {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager({ controlSpawn: control })
+    m.init(() => DEFAULT_SETTINGS)
+    m.registerIpc()
+    return m
+  }
+  const create = (clientId: number, persistKey = 'node-1', cols = 80, rows = 24) =>
+    fake.handlers[IPC.ptyCreate](clientId, { cols, rows, persistKey }) as Promise<{
+      sessionId: string
+      fresh: boolean
+    }>
+  /** pty:kill is sender-aware: it unsubscribes ONE view, and the last one out releases the pty. */
+  const kill = (clientId: number, sessionId: string) =>
+    fake.senderListeners[IPC.ptyKill](clientId, sessionId)
+  /** Open a node and let it go — the state every background write in this file starts from. */
+  const release = async (clientId: number, persistKey: string) => {
+    const { sessionId } = await create(clientId, persistKey)
+    kill(clientId, sessionId)
+    return sessionId
+  }
+  const attachArgs = (key: string) => [
+    '-L',
+    TMUX_SOCKET,
+    '-C',
+    'attach-session',
+    '-t',
+    sessionName(key)
+  ]
+
+  it('types into a released session over a control client — no pty, exact send-keys line', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+
+    expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(true)
+
+    expect(control.calls).toEqual([{ bin: m.getTmuxBin(), args: attachArgs('node-1') }])
+    expect(control.only.writes).toContain(LS_KEYS('nt-node-1'))
+    // The whole point: reaching the session cost no second pty device.
+    expect(spawned).toHaveLength(1)
+    expect(spawned[0].killed).toBe(true)
+  })
+
+  it('writes straight into the painter while the node is on screen — control clients untouched', async () => {
+    const m = await tmuxManager()
+    await create(ALICE, 'node-1')
+
+    expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(true)
+
+    expect(spawned[0].writes).toEqual(['ls\n'])
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('reports a failure rather than rejecting when the painter’s pty is already gone', async () => {
+    const m = await tmuxManager()
+    await create(ALICE, 'node-1')
+    spawned[0].throwOnWrite = true // node-pty throws on a write to a process that has exited
+
+    // `write()` fires this path and forgets it, so a rejection here would surface as an UNHANDLED
+    // rejection in the main process — a crash risk, from a pty that merely died first.
+    await expect(m.backgroundWrite('node-1', 'ls\n')).resolves.toBe(false)
+  })
+
+  it('prefers the node’s own shadow to the shared client', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await m.shadowAttach('node-1')
+
+    expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(true)
+
+    // One client, and it is the shadow that was already up: a second attach to the same session
+    // would put two clients of ours on one pane for nothing.
+    expect(control.calls).toHaveLength(1)
+    expect(control.only.writes).toContain(LS_KEYS('nt-node-1'))
+  })
+
+  it('starts ONE shared client for a burst of writes to different nodes', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await release(BOB, 'node-2')
+    await release(BOB, 'node-3')
+
+    await m.backgroundWrite('node-1', 'ls\n')
+    await m.backgroundWrite('node-2', 'ls\n')
+    await m.backgroundWrite('node-3', 'ls\n')
+
+    // `send-keys` is SERVER-wide: one attached client can target every session on the socket, so a
+    // burst costs one process, not one per node.
+    expect(control.calls).toHaveLength(1)
+    expect(control.only.writes).toEqual([
+      LS_KEYS('nt-node-1'),
+      LS_KEYS('nt-node-2'),
+      LS_KEYS('nt-node-3')
+    ])
+  })
+
+  it('disposes the shared client after the linger, and starts a fresh one for a later write', async () => {
+    const { BACKGROUND_WRITE_LINGER_MS } = await import('./pty-manager')
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await m.backgroundWrite('node-1', 'ls\n')
+
+    expect(control.only.killed).toBe(0)
+    vi.advanceTimersByTime(BACKGROUND_WRITE_LINGER_MS)
+
+    expect(control.only.writes).toContain('detach-client\n') // detached politely, then killed
+    expect(control.only.killed).toBe(1)
+
+    expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(true)
+    expect(control.calls).toHaveLength(2)
+  })
+
+  it('pushes the linger out on every background write', async () => {
+    const { BACKGROUND_WRITE_LINGER_MS } = await import('./pty-manager')
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    const almost = BACKGROUND_WRITE_LINGER_MS - 1
+
+    await m.backgroundWrite('node-1', 'ls\n')
+    vi.advanceTimersByTime(almost)
+    await m.backgroundWrite('node-1', 'ls\n')
+    vi.advanceTimersByTime(almost)
+
+    // A steady trickle of background writes keeps ONE client instead of churning a process per
+    // write — which is the entire reason the linger exists.
+    expect(control.only.killed).toBe(0)
+    expect(control.calls).toHaveLength(1)
+    vi.advanceTimersByTime(BACKGROUND_WRITE_LINGER_MS)
+    expect(control.only.killed).toBe(1)
+  })
+
+  it('refuses a released REMOTE node — its tmux lives on the far host, not on our socket', async () => {
+    const m = await tmuxManager()
+    const res = (await fake.handlers[IPC.ptyCreate](ALICE, {
+      cols: 80,
+      rows: 24,
+      persistKey: 'node-r',
+      sshRemote: { conn: { host: 'h1', user: 'u' }, controlPath: '/tmp/cm', remoteCwd: '/srv/app' }
+    })) as { sessionId: string }
+    expect(m.sshRemoteForNode('node-r')).toBeDefined() // the spawn really did take the remote branch
+    kill(ALICE, res.sessionId)
+
+    // `nt-node-r` on OUR socket is either nothing at all or — worse — the local orphan a create
+    // issued with the master down once left behind. Typing into that is typing into the wrong box.
+    expect(await m.backgroundWrite('node-r', 'ls\n')).toBe(false)
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('refuses a node it has no released record for — it cannot prove that session is ours', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+
+    // No record means this process never opened the node: `nt-<id>` on our socket could be a remote
+    // node's local orphan, or another machine's idea of it. Blind-writing it is the one thing a
+    // background feature must never do.
+    expect(await m.backgroundWrite('node-nobody-opened', 'ls\n')).toBe(false)
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('never retries a timed-out send-keys on another client — tmux may already have run it', async () => {
+    const { SHADOW_CMD_TIMEOUT_MS } = await import('./pty-manager')
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await m.shadowAttach('node-1')
+    control.autoReply = false // tmux takes the command and never answers
+
+    const writing = m.backgroundWrite('node-1', 'ls\n')
+    await vi.advanceTimersByTimeAsync(SHADOW_CMD_TIMEOUT_MS)
+
+    expect(await writing).toBe(false)
+    expect(control.only.killed).toBe(1) // the desynced client is gone…
+    expect(control.calls).toHaveLength(1) // …and nothing re-sent the keys anywhere else
+  })
+
+  it('falls through from a released session id — a stale write lands instead of vanishing', async () => {
+    const m = await tmuxManager()
+    const sessionId = await release(ALICE, 'node-1')
+
+    // The session id a caller was holding when the pty client went away (the relay host keeps one
+    // per stream). It resolves to no `Session` at all, and used to drop the bytes on the floor.
+    m.write(ALICE, sessionId, 'ls\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(control.only.writes).toContain(LS_KEYS('nt-node-1'))
+  })
+
+  it('retires the shared client BEFORE the painter spawns when the node comes back', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await m.backgroundWrite('node-1', 'ls\n')
+    liveTmuxSessions.add(sessionName('node-1')) // tmux kept it running, as it does across a detach
+    log.length = 0
+
+    await create(ALICE, 'node-1')
+
+    // Same rule as a per-session shadow: exactly one client of ours is ever negotiating the pane.
+    expect(log).toEqual(['control-kill', 'pty-spawn'])
+    expect(control.only.writes).toContain('detach-client\n')
+  })
+
+  it('yields to a shadow of the session it is attached to — one client of ours per session', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await m.backgroundWrite('node-1', 'ls\n')
+
+    await m.shadowAttach('node-1')
+
+    // Two of our clients on one session would break the session budget's "subtract one" arithmetic
+    // and put two grids on one pane. The shared client is the one that goes: it is re-startable
+    // anywhere, the shadow is not.
+    expect(control.only.killed).toBe(1)
+    expect(m.shadowedTmuxSessions(TMUX_SOCKET)).toEqual([sessionName('node-1')])
+  })
+
+  it('app quit disposes the shared client', async () => {
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await m.backgroundWrite('node-1', 'ls\n')
+
+    await m.killAll()
+
+    expect(control.only.killed).toBe(1)
+    expect(control.only.writes).toContain('detach-client\n')
+  })
+
+  it('is subtracted from the session budget, exactly like a shadow', async () => {
+    // A shared client is a real tmux client on whatever session it attached to, so it flips that
+    // session's `#{session_attached}` — and an attached session is never culled. Without the
+    // subtraction, one background write would exempt a session from the memory-pressure valve for
+    // as long as the client lingered.
+    const { createSessionReaper } = await import('./session-budget')
+    const m = await tmuxManager()
+    await release(ALICE, 'node-1')
+    await m.backgroundWrite('node-1', 'ls\n')
+
+    const NOW = 1_000_000
+    const OLD = NOW - 100_000 // well past the 6h grace window
+    const killed: Array<{ socket: string; target: string }> = []
+    const reaper = createSessionReaper({
+      tmuxBin: () => m.getTmuxBin(),
+      sockets: [TMUX_SOCKET],
+      shadowed: (socket) => m.shadowedTmuxSessions(socket),
+      exec: async (_bin: string, args: string[]) => {
+        if (args.includes('kill-session')) {
+          killed.push({
+            socket: args[args.indexOf('-L') + 1],
+            target: args[args.indexOf('-t') + 1]
+          })
+          return ''
+        }
+        // `nt-node-1` reads as attached because our shared client IS one; `nt-node-9` is genuinely
+        // attached (somebody is looking at it) and must survive.
+        return `nt-node-1|1|${OLD}\nnt-node-9|1|${OLD}`
+      },
+      readMem: () => ({ availableMb: 100, totalMb: 8000 }), // under the watermark: real pressure
+      env: {},
+      nowSec: () => NOW
+    })
+
+    expect(await reaper.sweep()).toBe(1)
+    expect(killed).toEqual([{ socket: TMUX_SOCKET, target: '=nt-node-1' }])
+  })
+
+  it('does nothing with tmux switched off in settings', async () => {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager({ controlSpawn: control })
+    m.init(() => ({ ...DEFAULT_SETTINGS, tmuxEnabled: false }))
+    m.registerIpc()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+
+    // The binary is right there, so `tmuxPath` alone would say yes — but nothing spawned a tmux
+    // session, so the keys would go to a name that does not exist.
+    expect(await m.backgroundWrite('node-1', 'ls\n')).toBe(false)
+    expect(control.calls).toHaveLength(0)
+  })
+})
+
+describe('isSessionName', () => {
+  // `encodeSendKeysHex` interpolates the target UNQUOTED into the command line, so anything that is
+  // not a name this app generated is refused before it is interpolated (Task 2 handoff note 12).
+  it('accepts the names sessionName generates', () => {
+    expect(isSessionName(sessionName('node-1'))).toBe(true)
+    expect(isSessionName(sessionName('Node_9-x'))).toBe(true)
+  })
+  it('rejects a name this app did not generate', () => {
+    expect(isSessionName('scratch')).toBe(false) // no nt- prefix: somebody else's session
+    expect(isSessionName('nt-')).toBe(false) // the empty node id
+    expect(isSessionName('nt-a b')).toBe(false) // a space splits the command line
+    expect(isSessionName('nt-a;kill-server')).toBe(false)
+    expect(isSessionName('nt-a\nkill-server')).toBe(false)
+  })
+})

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -786,8 +786,13 @@ export class PtyManager {
       socket: TMUX_SOCKET,
       sessionName: sessionName(persistKey),
       // Nothing consumes a shadowed session's output yet (the first consumer, Task 4's background
-      // write path, only WRITES). Dropping it keeps `%output`'s ~4x octal inflation off the main
-      // thread until something actually asks for the bytes.
+      // write path, only WRITES). This drops the bytes; it does NOT avoid their cost — an attached
+      // `-C` client is sent every `%output` line regardless, and the client octal-decodes then
+      // UTF-8-decodes each one on the main thread before this callback throws it away. All the drop
+      // buys is not forwarding it any further. STANDING OBLIGATION: before any first production
+      // caller, either run the wire-cost probe (measure that traffic on a busy session) or issue
+      // `refresh-client -fno-output` for write-only clients so tmux stops sending it at all
+      // (tmux >= 3.2 — the floor this feature would then require).
       onOutput: () => {},
       // An UNEXPECTED death only — `dispose()` is silent by design, so this can never fire for a
       // swap-out we asked for. Forget the entry and stop there: the tmux session, its processes and
@@ -1026,8 +1031,14 @@ export class PtyManager {
       tmuxBin: this.tmuxPath,
       socket: TMUX_SOCKET,
       sessionName: sessionName(persistKey),
-      // This client writes; it never reads. Dropping `%output` keeps its ~4x octal inflation off
-      // the main thread for every session on the server it happens to be attached to.
+      // This client writes; it never reads — but dropping `%output` here saves none of its cost.
+      // While attached, tmux sends this client the pane output of the session it landed on, and it
+      // octal-decodes then UTF-8-decodes all of it on the main thread before this callback discards
+      // it; the drop
+      // only stops it going further. The linger bounds how long that is paid for. STANDING
+      // OBLIGATION (same as the per-session shadow above): before any first production caller,
+      // either run the wire-cost probe or issue `refresh-client -fno-output` for these write-only
+      // clients (tmux >= 3.2) so the bytes are never sent.
       onOutput: () => {},
       onExit: () => {
         if (this.shared?.client === client) this.shared = null

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -33,6 +33,7 @@ import { parsePaneCursor } from './pane-cursor'
 import { readSpawnResources, spawnResourceNote } from './spawn-resources'
 import { primePtyCeiling, readPtyDevices, spawnFailureHint } from './pty-devices'
 import { REAP_SWEEP_MS, shouldReap } from './pty-reap'
+import { ControlModeClient, type ControlSpawn } from './tmux-control-client'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
 import { bracketedInjection } from './paste-injection'
 import { releasePty, type ReleasablePty } from './pty-release'
@@ -470,6 +471,20 @@ export const TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000
 export const PTY_END_BUDGET = { perSec: 20, burst: 200 }
 
 /**
+ * How long a command issued to a SHADOW may go unanswered before that shadow is torn down.
+ *
+ * `ControlModeClient` has no timers of its own, deliberately (tmux-control-client.ts): it pairs
+ * replies with commands POSITIONALLY, so a reply that never arrives does not merely stall one
+ * caller — every later reply pairs with the wrong command, permanently, and there is no recovery
+ * short of a new client. That is why the timeout disposes rather than retries.
+ *
+ * Five seconds is orders of magnitude past what it bounds: the only command a shadow issues today
+ * is a local `refresh-client -C` over a pipe to a tmux server on this machine (sub-millisecond).
+ * Hitting it means the server is wedged or the pipe is dead, not that it is busy.
+ */
+export const SHADOW_CMD_TIMEOUT_MS = 5_000
+
+/**
  * Manages all live PTY processes and bridges them to the renderer over IPC.
  *
  * On macOS/Linux with tmux available, each terminal node attaches to a persistent
@@ -537,6 +552,37 @@ export class PtyManager {
   /** ONE shared sweep for the idle reap (see `reapTick` / pty-reap.ts), armed by the first
    *  tmux-backed session and cleared once no session is left. */
   private reapTimer: ReturnType<typeof setInterval> | null = null
+  /**
+   * persistKey (node id) → the control-mode SHADOW attached to that node's tmux session.
+   *
+   * Keyed by persistKey rather than held on `Session`, because the nodes a shadow exists for are
+   * exactly the ones that HAVE no `Session`: `releaseClient` → `forget` drops the entry from
+   * `sessions` and `byPersistKey` the moment the pty client is released, and what survives is the
+   * tmux session — which is the thing a shadow attaches to.
+   *
+   * This map IS the invariant. An entry here means no painter pty client of ours is attached for
+   * that node: `shadowAttach` refuses while one is, and `spawnSession` disposes the entry before
+   * spawning one. Nothing else may put a client in here.
+   */
+  private shadows = new Map<string, ControlModeClient>()
+  /**
+   * persistKey (node id) → the last effective size this manager pushed into that node's pty before
+   * releasing it. With only a control client attached, the pane's size follows
+   * `refresh-client -C <cols>x<rows>`, so this is what a shadow re-asserts on attach.
+   *
+   * It deliberately outlives the `Session` (the tmux session outlives it too) and is dropped when
+   * the node is destroyed. Growth is one small record per tmux-backed node this process has ever
+   * released — the same order as the session map itself, and rewritten rather than appended on
+   * every subsequent release.
+   */
+  private lastSize = new Map<string, PtySize>()
+  /** The child-process seam for shadow clients. Undefined in production, where `ControlModeClient`
+   *  uses `child_process` (see tmux-control-client.ts); tests inject a fake spawner. */
+  private readonly controlSpawn: ControlSpawn | undefined
+
+  constructor(deps: { controlSpawn?: ControlSpawn } = {}) {
+    this.controlSpawn = deps.controlSpawn
+  }
 
   private ensureSnapshotTimer(): void {
     if (this.snapshotTimer) return
@@ -618,8 +664,129 @@ export class PtyManager {
     // Skipped when nothing arrived since the last periodic capture (pane content is unchanged).
     if (session.persistKey && session.outputSinceSnapshot)
       void this.snapshotScrollback(session.persistKey, session.sshRemote)
+    // Remember the grid the painter last enforced. It is the only record of it that survives this
+    // call (the Session goes with `forget` below), and a shadow attached later re-asserts it —
+    // otherwise the pane could reflow and the user would come back to a rewrapped screen.
+    if (session.persistKey && session.appliedSize)
+      this.lastSize.set(session.persistKey, session.appliedSize)
     releasePty(session.proc as ReleasablePty)
     this.forget(sessionId, session)
+  }
+
+  /**
+   * Attach a control-mode SHADOW to the tmux session of a node whose painter pty client has been
+   * released — `tmux -C attach-session` over plain pipes, holding ZERO pty devices — so a
+   * background feature can reach a session nobody is watching without respawning the terminal (a
+   * pty device, a tmux client, an ssh child, and a full redraw the user never asked for).
+   *
+   * Attach-or-reuse; returns the live client, or null when there is nothing to shadow or nothing to
+   * shadow it with:
+   *  - tmux is unavailable or switched off: there is no tmux session to attach to, and a non-tmux
+   *    session's work lives in the pty client that is already gone.
+   *  - a PAINTER pty client is still attached for this node. A session never has both: the painter
+   *    attaches with `-D` (it would kick the shadow off a moment later anyway), and two clients of
+   *    ours on one pane would hand tmux the size negotiation that pty-size.ts exists to keep.
+   *  - the shadow was torn down while its opening size push was outstanding (see `shadowCommand`).
+   *
+   * WHAT A SHADOW IS NOT: not a subscriber, not a `Session`, not a renderer client id. Nothing that
+   * decides "is somebody watching" can see it — the reap sweep asks `platform().clientIds()` and
+   * walks `this.sessions`, the renderer's park and the offscreen dispose are per-node renderer
+   * state — so a shadow can never keep a session looking watched. (It IS a real tmux client and
+   * does appear in `tmux list-clients`; nothing in this app asks tmux that question.)
+   */
+  async shadowAttach(persistKey: string): Promise<ControlModeClient | null> {
+    // Both halves of "is there a tmux session at all": the binary, and the setting that decides
+    // whether sessions are spawned under it. With tmux switched OFF, `tmuxPath` is still set (the
+    // binary is installed) but every session is a plain shell — so a shadow would attach to a name
+    // nothing ever created and die on arrival, and its caller would read that as "reached it".
+    if (!this.tmuxPath || !this.getSettings().tmuxEnabled) return null
+    const live = this.shadows.get(persistKey)
+    if (live?.alive) return live
+    // Died since it was attached (its `onExit` normally clears the entry; this covers a caller that
+    // gets here first). Re-attaching is LAZY on purpose: nothing re-shadows a session nobody asked
+    // about, so a node that is never wanted again costs nothing.
+    if (live) this.shadows.delete(persistKey)
+    if (this.sessionByPersistKey(persistKey)) return null
+    const client = new ControlModeClient({
+      tmuxBin: this.tmuxPath,
+      socket: TMUX_SOCKET,
+      sessionName: sessionName(persistKey),
+      // Nothing consumes a shadowed session's output yet (the first consumer, Task 4's background
+      // write path, only WRITES). Dropping it keeps `%output`'s ~4x octal inflation off the main
+      // thread until something actually asks for the bytes.
+      onOutput: () => {},
+      // An UNEXPECTED death only — `dispose()` is silent by design, so this can never fire for a
+      // swap-out we asked for. Forget the entry and stop there: the tmux session, its processes and
+      // its scrollback are untouched, and the next `shadowAttach` re-attaches.
+      onExit: () => {
+        if (this.shadows.get(persistKey) === client) this.shadows.delete(persistKey)
+      },
+      spawner: this.controlSpawn
+    })
+    this.shadows.set(persistKey, client)
+    client.start()
+    const size = this.lastSize.get(persistKey)
+    if (size) {
+      const line = `refresh-client -C ${size.cols}x${size.rows}`
+      const reply = await this.shadowCommand(persistKey, line)
+      // Only a torn-down shadow (timeout, or death under us) fails the attach. tmux REFUSING the
+      // size (`%error`) leaves a perfectly usable client and a pane at its standing size, which is
+      // the same outcome as having no size to push.
+      if (reply === null) return null
+    }
+    // NO recorded size pushes nothing, deliberately: the pane keeps the standing size it has had
+    // since its last painter, and inventing one here would reflow a pane that is perfectly fine.
+    // (A relay-served pty released without ever reporting a size is exactly that case.)
+    //
+    // Re-read the map rather than returning `client`: a `create()` may have swapped this shadow out
+    // for a painter across the await above, and handing back a disposed client would look live.
+    return this.shadows.get(persistKey) ?? null
+  }
+
+  /** Retire a node's shadow, if it has one. Idempotent. The entry is dropped HERE because
+   *  `dispose()` is silent (it does not fire `onExit`) — a deliberate swap-out is not a death. */
+  shadowDispose(persistKey: string): void {
+    const client = this.shadows.get(persistKey)
+    if (!client) return
+    this.shadows.delete(persistKey)
+    client.dispose()
+  }
+
+  /**
+   * Run ONE control-mode command on a node's shadow, bounded by `SHADOW_CMD_TIMEOUT_MS`. EVERY
+   * command issued to a shadow must go through here: the client owns no timers, and a reply that
+   * never comes desyncs its positional FIFO for good — so the timeout is a teardown, not a retry.
+   *
+   * Returns the reply (`ok` is tmux's own verdict), or null when there is no shadow, or when the
+   * command timed out / the client died — in which case the shadow is gone and a caller that still
+   * wants one asks `shadowAttach` for a fresh client.
+   */
+  private async shadowCommand(
+    persistKey: string,
+    line: string
+  ): Promise<{ ok: boolean; body: string[] } | null> {
+    const client = this.shadows.get(persistKey)
+    if (!client) return null
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        client.command(line),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`tmux control-mode command timed out: ${line}`)),
+            SHADOW_CMD_TIMEOUT_MS
+          )
+          timer.unref?.()
+        })
+      ])
+    } catch {
+      // Only if it is still OUR client: a shadow replaced across the await was already disposed by
+      // whoever replaced it, and disposing again would take down a healthy successor.
+      if (this.shadows.get(persistKey) === client) this.shadowDispose(persistKey)
+      return null
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
   }
 
   /** Must run after app is ready (needs userData path). */
@@ -1157,6 +1324,17 @@ export class PtyManager {
     clientId: ClientId | null,
     sinks: DetachedSinks | undefined
   ): string {
+    // SWAP-OUT, before anything at all is spawned: a painter pty client is arriving for this node,
+    // and a session never has both. The painter attaches with `-D` and would kick the shadow off by
+    // itself — but only once tmux has processed both attaches, leaving a window where two clients
+    // of ours negotiate one pane. Retiring it first (politely: `dispose()` sends `detach-client`)
+    // means exactly one client is ever attached, and because `dispose()` is silent this can never
+    // be mistaken for a shadow that died and wants re-attaching.
+    //
+    // Here rather than in `create()` so EVERY path to a painter is covered — the warm reattach, the
+    // relay host's `attachDetached`, and whatever spawns next — and so the ordering is provable:
+    // it is the first statement before `pty.spawn` in the same synchronous function.
+    if (options.persistKey) this.shadowDispose(options.persistKey)
     const sessionId = `pty-${++this.counter}`
     // For a remote (ssh-project) node the local PTY just holds the ssh client, so its local cwd
     // must be a real LOCAL directory (options.cwd is a REMOTE path that wouldn't exist locally and
@@ -2261,6 +2439,11 @@ export class PtyManager {
     // Also drop any in-flight create for this node: a create racing the kill-session below must
     // spawn a fresh session, not await (and then join) the one we are ending.
     this.inflight.delete(persistKey)
+    // The tmux session is about to be killed, so everything attached to it goes now: a shadow would
+    // otherwise linger until tmux dropped its client, and the size we remembered describes a pane
+    // that is about to stop existing.
+    this.shadowDispose(persistKey)
+    this.lastSize.delete(persistKey)
     // A DELETE is remembered (the respawn guard for clients `pty:closed` cannot reach — see
     // `tombstones`); a RECYCLE explicitly forgets, because the node is not going anywhere and its
     // replacement session must be spawnable. Recorded even when no live session exists in this
@@ -2357,6 +2540,10 @@ export class PtyManager {
         finals.push(this.snapshotScrollback(session.persistKey, session.sshRemote))
       releasePty(session.proc as ReleasablePty)
     }
+    // Shadows are child processes of OURS, so quitting takes them with us — the tmux sessions they
+    // were attached to keep running with no client at all, which is exactly what persistence means.
+    for (const persistKey of [...this.shadows.keys()]) this.shadowDispose(persistKey)
+    this.lastSize.clear()
     this.sessions.clear()
     this.byPersistKey.clear()
     // Pending recycle notices die with the sessions they were waiting on (their timers would

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -34,7 +34,8 @@ import { readSpawnResources, spawnResourceNote } from './spawn-resources'
 import { primePtyCeiling, readPtyDevices, spawnFailureHint } from './pty-devices'
 import { REAP_SWEEP_MS, shouldReap } from './pty-reap'
 import { ControlModeClient, type ControlSpawn } from './tmux-control-client'
-import { TMUX_SOCKET, sessionName } from './tmux-naming'
+import { TMUX_SOCKET, sessionName, isSessionName } from './tmux-naming'
+import { encodeSendKeysHex } from './tmux-control'
 import { bracketedInjection } from './paste-injection'
 import { releasePty, type ReleasablePty } from './pty-release'
 import { effectiveSize, type PtySize } from './pty-size'
@@ -485,6 +486,20 @@ export const PTY_END_BUDGET = { perSec: 20, burst: 200 }
 export const SHADOW_CMD_TIMEOUT_MS = 5_000
 
 /**
+ * How long the SHARED background-write control client stays attached after the last background
+ * write (see `backgroundWrite`).
+ *
+ * It exists so a BURST — an agent pushing a multi-line prompt, a run of slash commands — costs one
+ * `tmux -C` child instead of one per keystroke batch, and nothing more. Ten seconds is past any
+ * plausible gap inside one such burst and far short of every lifecycle it must not interfere with:
+ * the renderer's 5-minute park (`TERM_PARK_MS`), the 10-minute offscreen dispose
+ * (`offscreen-policy.ts`) and the 10-minute idle reap (`REAP_IDLE_MS`). That ordering is the point
+ * of picking a number this small: an idle client is a real tmux client on some session, and the
+ * shorter it lives the smaller the window in which anything has to reason about it at all.
+ */
+export const BACKGROUND_WRITE_LINGER_MS = 10_000
+
+/**
  * Manages all live PTY processes and bridges them to the renderer over IPC.
  *
  * On macOS/Linux with tmux available, each terminal node attaches to a persistent
@@ -568,7 +583,10 @@ export class PtyManager {
   /**
    * persistKey (node id) → what a shadow needs to know about a session whose pty client this
    * manager has RELEASED. Written by `releaseClient`, because `forget` then drops the `Session` and
-   * with it the only other record of either fact:
+   * with it the only other record of any of these facts:
+   *  - `sessionId`: the id that session answered to. A caller can still be holding it — the relay
+   *    host keeps one per stream — and `write()` resolves it back to this node instead of dropping
+   *    the bytes, which is the only route a released session has left to an existing write path.
    *  - `size`: the effective grid the painter last enforced. With only a control client attached
    *    the pane follows `refresh-client -C <cols>x<rows>`, so this is what a shadow re-asserts.
    *  - `remote`: this node's tmux ran on a REMOTE host (an SSH project) — over that project's
@@ -583,7 +601,23 @@ export class PtyManager {
    * persisted node this process has ever released: the same order as the session map itself, and
    * rewritten rather than appended on every subsequent release of the same node.
    */
-  private released = new Map<string, { size?: PtySize; remote: boolean }>()
+  private released = new Map<string, { sessionId: string; size?: PtySize; remote: boolean }>()
+  /**
+   * The ONE control-mode client this manager keeps for background WRITES, plus the node whose tmux
+   * session it is attached to (see `backgroundWrite` / `sharedClientFor`).
+   *
+   * Shared rather than per-session because control-mode COMMANDS are server-wide: `send-keys -t X`
+   * reaches every session on the socket from whatever session the client happens to be attached to.
+   * Only `%output` streaming is scoped to the attachment, and this client streams nothing.
+   *
+   * `persistKey` is kept because the attachment is the one thing about it that is NOT server-wide:
+   * it makes this a real tmux client of THAT session, so it has to be subtracted from the session
+   * budget (`shadowedTmuxSessions`) and retired whenever something else wants to be that session's
+   * only client of ours — a painter spawning, or a per-session shadow attaching.
+   */
+  private shared: { client: ControlModeClient; persistKey: string } | null = null
+  /** Disposes `shared` once no background write has needed it for `BACKGROUND_WRITE_LINGER_MS`. */
+  private sharedLinger: ReturnType<typeof setTimeout> | null = null
   /** The child-process seam for shadow clients. Undefined in production, where `ControlModeClient`
    *  uses `child_process` (see tmux-control-client.ts); tests inject a fake spawner. */
   private readonly controlSpawn: ControlSpawn | undefined
@@ -678,6 +712,7 @@ export class PtyManager {
     // below; this is the record that survives it.
     if (session.persistKey)
       this.released.set(session.persistKey, {
+        sessionId,
         size: session.appliedSize,
         remote: !!session.sshRemote
       })
@@ -732,6 +767,12 @@ export class PtyManager {
     // name, which is a different machine's idea of the node and must never be typed into. Routing
     // control mode over ssh is a separate job; refusing is the honest answer until it exists.
     if (known?.remote) return null
+    // At most ONE client of ours per tmux session. The shared background-write client may already
+    // be attached to this one (it attaches to whatever session first needed a background write);
+    // it is the one that yields, because it can be re-started against any session and a shadow
+    // cannot. Two of ours here would also break the session budget's "subtract one client per
+    // shadowed name" arithmetic, which has no way to know it should subtract two.
+    this.sharedDisposeOn(persistKey)
     const client = new ControlModeClient({
       tmuxBin: this.tmuxPath,
       socket: TMUX_SOCKET,
@@ -792,6 +833,11 @@ export class PtyManager {
     const names: string[] = []
     for (const [persistKey, client] of this.shadows)
       if (client.alive) names.push(sessionName(persistKey))
+    // The shared background-write client is a tmux client of the session it attached to, exactly
+    // like a shadow, and is subtracted the same way. It can never DOUBLE with a shadow of that same
+    // session — `shadowAttach` retires it first — which is what keeps the budget's "minus one
+    // client per name" arithmetic (session-budget.ts) honest.
+    if (this.shared?.client.alive) names.push(sessionName(this.shared.persistKey))
     return names
   }
 
@@ -823,6 +869,23 @@ export class PtyManager {
   ): Promise<{ ok: boolean; body: string[] } | null> {
     const client = this.shadows.get(persistKey)
     if (!client) return null
+    return this.controlCommand(client, line, () => {
+      // Only if it is still OUR client: a shadow replaced across the await was already disposed by
+      // whoever replaced it, and disposing again would take down a healthy successor.
+      if (this.shadows.get(persistKey) === client) this.shadowDispose(persistKey)
+    })
+  }
+
+  /**
+   * The timeout that every control-mode command in this manager is issued under — the shared body
+   * of `shadowCommand` and of the shared background-write client's commands. `onBroken` is how the
+   * caller retires ITS client; this method never decides which registry a client lives in.
+   */
+  private async controlCommand(
+    client: ControlModeClient,
+    line: string,
+    onBroken: () => void
+  ): Promise<{ ok: boolean; body: string[] } | null> {
     // Refuse a multi-line command HERE rather than letting the client refuse it below. Both answer
     // null, but the difference is what happens to the shadow: the catch treats a rejection as
     // evidence the channel is unusable and DISPOSES, which is right for a timeout or a death and
@@ -844,13 +907,145 @@ export class PtyManager {
         })
       ])
     } catch {
-      // Only if it is still OUR client: a shadow replaced across the await was already disposed by
-      // whoever replaced it, and disposing again would take down a healthy successor.
-      if (this.shadows.get(persistKey) === client) this.shadowDispose(persistKey)
+      onBroken()
       return null
     } finally {
       if (timer) clearTimeout(timer)
     }
+  }
+
+  /**
+   * Type `data` into a node whose PAINTER pty client is gone, without spawning one.
+   *
+   * The fallthrough, in order:
+   *  1. **the painter**, if the node is on screen after all — the session's own pty, exactly as a
+   *     keystroke from its terminal. (A caller holding a stale session id can land here; it is the
+   *     same NODE either way, which is what the caller asked for.)
+   *  2. **the node's own shadow**, if one is already up. Never attaches one: a shadow exists to be
+   *     re-used by whoever attached it, and a write does not need a session-scoped client.
+   *  3. **the shared control client** (`sharedClientFor`) — one `tmux -C` child for the whole
+   *     server, because `send-keys -t <session>` is a server-wide command.
+   *
+   * Returns whether the keys were delivered. **A false is never retried on another client**: a
+   * timed-out `send-keys` may well have run — control mode loses the REPLY, not necessarily the
+   * command — so re-sending it elsewhere risks typing the input twice, which is worse than not
+   * typing it at all.
+   *
+   * REFUSALS, both of them the same rule — never write into a session this process cannot prove is
+   * the node's own local one:
+   *  - a node with no `released` record: this process never released it, so `nt-<id>` on our socket
+   *    is a name we have no claim to (a remote node's local orphan, another machine's idea of it, a
+   *    session someone else made). An unknown key is not evidence of a session.
+   *  - a node whose record says `remote`: its tmux is on the far host. Reaching it means the
+   *    project's ControlMaster (`remoteTmuxSendKeysArgs`), not this channel; refusing is the honest
+   *    answer until that exists.
+   */
+  async backgroundWrite(persistKey: string, data: string): Promise<boolean> {
+    // Nothing to type — and `encodeSendKeysHex` would build a `send-keys -H ` with no bytes after
+    // it, which is a command line worth not sending.
+    if (!data) return false
+    const live = this.sessionByPersistKey(persistKey)
+    if (live) {
+      try {
+        live.proc.write(data)
+      } catch {
+        // node-pty throws on a write to a process that has already exited (the same hazard
+        // `applySize` guards on resize). This method is called fire-and-forget from `write()`, so a
+        // throw would surface as an UNHANDLED rejection in the main process — the crash risk Task
+        // 2's handoff note 2 names. A dead painter is a delivery failure, not an exception.
+        return false
+      }
+      return true
+    }
+    if (!this.tmuxPath || !this.getSettings().tmuxEnabled) return false
+    const known = this.released.get(persistKey)
+    if (!known || known.remote) return false
+    const target = sessionName(persistKey)
+    // Belt and braces: `encodeSendKeysHex` interpolates the target UNQUOTED (Task 2 handoff note
+    // 12), and this line reaches a tmux server holding every session on the socket. `sessionName`
+    // cannot produce anything else today — which is exactly why this stays cheap.
+    if (!isSessionName(target)) return false
+    const line = encodeSendKeysHex(target, data)
+    const shadow = this.shadows.get(persistKey)
+    if (shadow) return (await this.shadowCommand(persistKey, line))?.ok ?? false
+    const client = this.sharedClientFor(persistKey)
+    if (!client) return false
+    return (await this.controlCommand(client, line, () => this.sharedDispose(client)))?.ok ?? false
+  }
+
+  /**
+   * The shared background-write client, started on demand and attached to `persistKey`'s session.
+   *
+   * WHICH session it attaches to is deterministic and deliberately the least interesting choice
+   * available: the session of the background write that needed it. That session was just proved to
+   * be local, released and ours — so the attach cannot land on a foreign session, and cannot put a
+   * second client of ours on a pane a painter is already drawing. Every command it then issues
+   * carries its own explicit `-t`, so the attachment never decides where the keys go.
+   *
+   * It pushes NO size, unlike a per-session shadow: it displays nothing, and `refresh-client -C`
+   * would resize the pane for whoever IS watching that session (their own `tmux attach`). The pane
+   * keeps the standing size its last painter left it at.
+   *
+   * Null when tmux is unavailable or the child could not be spawned (`child_process.spawn` throws
+   * synchronously on EMFILE and friends — the machine a background feature reaches for a client on).
+   */
+  private sharedClientFor(persistKey: string): ControlModeClient | null {
+    if (!this.tmuxPath) return null
+    this.armSharedLinger()
+    const live = this.shared
+    if (live?.client.alive) return live.client
+    if (live) this.shared = null // died since it was started; its onExit normally clears this
+    const client = new ControlModeClient({
+      tmuxBin: this.tmuxPath,
+      socket: TMUX_SOCKET,
+      sessionName: sessionName(persistKey),
+      // This client writes; it never reads. Dropping `%output` keeps its ~4x octal inflation off
+      // the main thread for every session on the server it happens to be attached to.
+      onOutput: () => {},
+      onExit: () => {
+        if (this.shared?.client === client) this.shared = null
+      },
+      spawner: this.controlSpawn
+    })
+    this.shared = { client, persistKey }
+    try {
+      client.start()
+    } catch {
+      this.shared = null
+      return null
+    }
+    return client
+  }
+
+  /** (Re)arm the linger: the client goes `BACKGROUND_WRITE_LINGER_MS` after the LAST write wanted
+   *  it, so a burst keeps one child and a trickle does not churn one per write. */
+  private armSharedLinger(): void {
+    if (this.sharedLinger) clearTimeout(this.sharedLinger)
+    this.sharedLinger = setTimeout(() => this.sharedDispose(), BACKGROUND_WRITE_LINGER_MS)
+    // Node keeps the process alive for a pending timer, and this one must never be the reason a
+    // quitting app lingers (the other manager timers unref for the same reason).
+    this.sharedLinger.unref?.()
+  }
+
+  /** Retire the shared client. Idempotent. `only` makes it a no-op unless that exact client is
+   *  still the current one — a caller reacting to a failure must not take down its successor. */
+  private sharedDispose(only?: ControlModeClient): void {
+    const live = this.shared
+    if (!live || (only && live.client !== only)) return
+    this.shared = null
+    if (this.sharedLinger) {
+      clearTimeout(this.sharedLinger)
+      this.sharedLinger = null
+    }
+    live.client.dispose()
+  }
+
+  /** Retire the shared client if it is attached to THIS node's session — for the two events that
+   *  claim that session for another client of ours (a painter spawning, a shadow attaching) and for
+   *  the one that ends it (`endSession`). Elsewhere it keeps lingering; the attachment is
+   *  incidental, and it can be re-started against any session. */
+  private sharedDisposeOn(persistKey: string): void {
+    if (this.shared?.persistKey === persistKey) this.sharedDispose()
   }
 
   /** Must run after app is ready (needs userData path). */
@@ -1398,7 +1593,12 @@ export class PtyManager {
     // Here rather than in `create()` so EVERY path to a painter is covered — the warm reattach, the
     // relay host's `attachDetached`, and whatever spawns next — and so the ordering is provable:
     // it is the first statement before `pty.spawn` in the same synchronous function.
-    if (options.persistKey) this.shadowDispose(options.persistKey)
+    // The shared background-write client goes too, for the same reason, when it is this node's
+    // session it happens to be attached to.
+    if (options.persistKey) {
+      this.shadowDispose(options.persistKey)
+      this.sharedDisposeOn(options.persistKey)
+    }
     const sessionId = `pty-${++this.counter}`
     // For a remote (ssh-project) node the local PTY just holds the ssh client, so its local cwd
     // must be a real LOCAL directory (options.cwd is a REMOTE path that wouldn't exist locally and
@@ -1992,10 +2192,34 @@ export class PtyManager {
    */
   write(clientId: ClientId | null, sessionId: string, data: string): void {
     const session = this.sessions.get(sessionId)
-    if (!session) return
+    if (!session) return this.backgroundWriteBySessionId(sessionId, data)
     if (clientId !== null && session.nodeId && presenceHub.peerCount() > 1)
       presenceHub.noteTyping(clientId, session.nodeId)
     session.proc.write(data)
+  }
+
+  /**
+   * The `write()` miss: no live session answers to this id. It may still be a session THIS process
+   * released — the pty client detached, the tmux session (and everything running in it) untouched —
+   * whose id a caller is still holding, which is what the relay host does for the lifetime of a
+   * stream. Those bytes used to go on the floor; now they take the background path, which reaches
+   * the node without respawning a pty client for it.
+   *
+   * A linear scan rather than a second index: the `released` map is one small record per node this
+   * process has released, this is the cold path (a stray write, not a keystroke stream), and two
+   * maps that have to agree about the same fact is precisely the shape of bug the session-budget
+   * subtraction already had to be fixed for once.
+   *
+   * Fire-and-forget, because `write()` is: `backgroundWrite` never rejects, and there is nobody to
+   * report a delivery failure to on this path. No typing badge either — a released session is one
+   * nobody is watching, so the badge would light up on a terminal that is not on anybody's screen.
+   */
+  private backgroundWriteBySessionId(sessionId: string, data: string): void {
+    for (const [persistKey, rec] of this.released) {
+      if (rec.sessionId !== sessionId) continue
+      void this.backgroundWrite(persistKey, data)
+      return
+    }
   }
 
   /**
@@ -2507,6 +2731,7 @@ export class PtyManager {
     // otherwise linger until tmux dropped its client, and what we remembered about the released
     // session describes a pane that is about to stop existing.
     this.shadowDispose(persistKey)
+    this.sharedDisposeOn(persistKey)
     this.released.delete(persistKey)
     // A DELETE is remembered (the respawn guard for clients `pty:closed` cannot reach — see
     // `tombstones`); a RECYCLE explicitly forgets, because the node is not going anywhere and its
@@ -2607,6 +2832,8 @@ export class PtyManager {
     // Shadows are child processes of OURS, so quitting takes them with us — the tmux sessions they
     // were attached to keep running with no client at all, which is exactly what persistence means.
     for (const persistKey of [...this.shadows.keys()]) this.shadowDispose(persistKey)
+    // …and so does the shared background-write client, along with its linger timer.
+    this.sharedDispose()
     this.released.clear()
     this.sessions.clear()
     this.byPersistKey.clear()

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -730,6 +730,9 @@ export class PtyManager {
    * shadow it with:
    *  - tmux is unavailable or switched off: there is no tmux session to attach to, and a non-tmux
    *    session's work lives in the pty client that is already gone.
+   *  - `ptyShadowClients` is off: the kill switch (see the setting's doc). This is ONE of the two
+   *    places it is read — the other is `backgroundWrite` — because these are the only two entry
+   *    points that can start a control client of ours.
    *  - a PAINTER pty client is still attached for this node. A session never has both: the painter
    *    attaches with `-D` (it would kick the shadow off a moment later anyway), and two clients of
    *    ours on one pane would hand tmux the size negotiation that pty-size.ts exists to keep.
@@ -752,7 +755,12 @@ export class PtyManager {
     // whether sessions are spawned under it. With tmux switched OFF, `tmuxPath` is still set (the
     // binary is installed) but every session is a plain shell — so a shadow would attach to a name
     // nothing ever created and die on arrival, and its caller would read that as "reached it".
-    if (!this.tmuxPath || !this.getSettings().tmuxEnabled) return null
+    const settings = this.getSettings()
+    if (!this.tmuxPath || !settings.tmuxEnabled) return null
+    // The kill switch, read here rather than at each of the three places a shadow is USED: a caller
+    // that cannot get a client cannot use one, and a flag scattered over the tier guards would be a
+    // flag with three chances to be forgotten.
+    if (!settings.ptyShadowClients) return null
     const live = this.shadows.get(persistKey)
     if (live?.alive) return live
     // Died since it was attached (its `onExit` normally clears the entry; this covers a caller that
@@ -799,6 +807,10 @@ export class PtyManager {
       this.shadows.delete(persistKey)
       return null
     }
+    // One line per swap direction, in the field-report vocabulary of this feature ("shadow attach" /
+    // "painter attach", see `spawnSession`). Only when a client is actually STARTED: a re-used
+    // shadow swapped nothing, and a line per caller would say nothing about the session's state.
+    console.log(`[pty] shadow attach ${sessionName(persistKey)}`)
     const size = this.released.get(persistKey)?.size
     if (size) {
       const line = `refresh-client -C ${size.cols}x${size.rows}`
@@ -957,7 +969,13 @@ export class PtyManager {
       }
       return true
     }
-    if (!this.tmuxPath || !this.getSettings().tmuxEnabled) return false
+    const settings = this.getSettings()
+    if (!this.tmuxPath || !settings.tmuxEnabled) return false
+    // The kill switch, and the reason it sits BELOW tier 1: the painter is the session's own pty,
+    // which exists with or without this feature — gating it would turn "no control clients" into
+    // "background writes stop working", which is a different setting. Below here, every tier needs
+    // a `tmux -C` child, so this one check covers both of them (`shadowAttach` carries the other).
+    if (!settings.ptyShadowClients) return false
     const known = this.released.get(persistKey)
     if (!known || known.remote) return false
     const target = sessionName(persistKey)
@@ -967,7 +985,12 @@ export class PtyManager {
     if (!isSessionName(target)) return false
     const line = encodeSendKeysHex(target, data)
     const shadow = this.shadows.get(persistKey)
-    if (shadow) return (await this.shadowCommand(persistKey, line))?.ok ?? false
+    // ALIVE, not merely present: `dispose()` is silent (it fires no `onExit`), so a shadow retired
+    // by whoever was handed it leaves its entry behind, and a dead client can deliver nothing.
+    // Falling through to tier 3 does not violate the never-retry rule either — a client that is not
+    // running rejects `command()` BEFORE writing a byte (tmux-control-client.ts), so the keys it
+    // refused cannot also have reached tmux.
+    if (shadow?.alive) return (await this.shadowCommand(persistKey, line))?.ok ?? false
     const client = this.sharedClientFor(persistKey)
     if (!client) return false
     return (await this.controlCommand(client, line, () => this.sharedDispose(client)))?.ok ?? false
@@ -990,7 +1013,11 @@ export class PtyManager {
    * synchronously on EMFILE and friends — the machine a background feature reaches for a client on).
    */
   private sharedClientFor(persistKey: string): ControlModeClient | null {
-    if (!this.tmuxPath) return null
+    // BOTH halves of "is there a tmux session at all", as `shadowAttach` carries them: with tmux
+    // switched off `tmuxPath` is still set (the binary is installed) but nothing ever created a
+    // session, so this would attach to a name that does not exist. Its only caller checks the same
+    // thing three lines earlier — this is here so a second caller cannot arrive without it.
+    if (!this.tmuxPath || !this.getSettings().tmuxEnabled) return null
     this.armSharedLinger()
     const live = this.shared
     if (live?.client.alive) return live.client
@@ -1014,6 +1041,10 @@ export class PtyManager {
       this.shared = null
       return null
     }
+    // Same line as a per-session shadow, deliberately: from the outside these are the same event —
+    // a control client of ours became this session's attached client — and a field report should
+    // not have to know which of the two kinds it is looking at. The linger keeps it rare.
+    console.log(`[pty] shadow attach ${sessionName(persistKey)}`)
     return client
   }
 
@@ -1027,16 +1058,24 @@ export class PtyManager {
     this.sharedLinger.unref?.()
   }
 
-  /** Retire the shared client. Idempotent. `only` makes it a no-op unless that exact client is
-   *  still the current one — a caller reacting to a failure must not take down its successor. */
+  /** Retire the shared client AND its linger. Idempotent. `only` makes it a no-op while a DIFFERENT
+   *  client is the current one — a caller reacting to its own client's failure must take down
+   *  neither the successor nor the successor's timer. With nothing attached at all there is no
+   *  successor to protect, and the timer goes either way. */
   private sharedDispose(only?: ControlModeClient): void {
     const live = this.shared
-    if (!live || (only && live.client !== only)) return
-    this.shared = null
+    // A SUCCESSOR is left entirely alone, linger included: `only` is passed by a caller reacting to
+    // its own client's failure, and by then a later write may already have started a new one.
+    if (only && live && live.client !== only) return
+    // Cleared even when nothing is attached — `onExit` clears `shared` on its own (a client that
+    // died under us), and the linger armed for it would otherwise stay pending, aimed at whatever
+    // is attached when it fires.
     if (this.sharedLinger) {
       clearTimeout(this.sharedLinger)
       this.sharedLinger = null
     }
+    if (!live) return
+    this.shared = null
     live.client.dispose()
   }
 
@@ -1596,6 +1635,13 @@ export class PtyManager {
     // The shared background-write client goes too, for the same reason, when it is this node's
     // session it happens to be attached to.
     if (options.persistKey) {
+      // The other half of the swap log (see `shadowAttach`), and only when there is really
+      // something to retire: a painter arriving at a session no control client held swapped
+      // nothing, and a line per terminal anyone opens is noise in the report it exists for.
+      const held =
+        this.shadows.get(options.persistKey)?.alive ||
+        (this.shared?.persistKey === options.persistKey && this.shared.client.alive)
+      if (held) console.log(`[pty] painter attach ${sessionName(options.persistKey)}`)
       this.shadowDispose(options.persistKey)
       this.sharedDisposeOn(options.persistKey)
     }

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -577,9 +577,11 @@ export class PtyManager {
    *    under the same name. Never shadow it locally.
    *
    * It deliberately outlives the `Session` (the tmux session outlives it too) and is dropped when
-   * the node is destroyed. Growth is one small record per tmux-backed node this process has ever
-   * released — the same order as the session map itself, and rewritten rather than appended on
-   * every subsequent release.
+   * the node is destroyed. The write is unconditional for every PERSISTED session released — local
+   * tmux-backed and remote alike, with or without a recorded size — so the map also holds records
+   * whose only content is "remote, do not shadow". Growth is therefore one small record per
+   * persisted node this process has ever released: the same order as the session map itself, and
+   * rewritten rather than appended on every subsequent release of the same node.
    */
   private released = new Map<string, { size?: PtySize; remote: boolean }>()
   /** The child-process seam for shadow clients. Undefined in production, where `ControlModeClient`

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -566,16 +566,22 @@ export class PtyManager {
    */
   private shadows = new Map<string, ControlModeClient>()
   /**
-   * persistKey (node id) → the last effective size this manager pushed into that node's pty before
-   * releasing it. With only a control client attached, the pane's size follows
-   * `refresh-client -C <cols>x<rows>`, so this is what a shadow re-asserts on attach.
+   * persistKey (node id) → what a shadow needs to know about a session whose pty client this
+   * manager has RELEASED. Written by `releaseClient`, because `forget` then drops the `Session` and
+   * with it the only other record of either fact:
+   *  - `size`: the effective grid the painter last enforced. With only a control client attached
+   *    the pane follows `refresh-client -C <cols>x<rows>`, so this is what a shadow re-asserts.
+   *  - `remote`: this node's tmux ran on a REMOTE host (an SSH project) — over that project's
+   *    ControlMaster, on the `nodeterm-rmt` socket THERE. Our local socket holds no session for it;
+   *    at best nothing, at worst the local orphan a create issued with the master down once left
+   *    under the same name. Never shadow it locally.
    *
    * It deliberately outlives the `Session` (the tmux session outlives it too) and is dropped when
    * the node is destroyed. Growth is one small record per tmux-backed node this process has ever
    * released — the same order as the session map itself, and rewritten rather than appended on
    * every subsequent release.
    */
-  private lastSize = new Map<string, PtySize>()
+  private released = new Map<string, { size?: PtySize; remote: boolean }>()
   /** The child-process seam for shadow clients. Undefined in production, where `ControlModeClient`
    *  uses `child_process` (see tmux-control-client.ts); tests inject a fake spawner. */
   private readonly controlSpawn: ControlSpawn | undefined
@@ -664,11 +670,15 @@ export class PtyManager {
     // Skipped when nothing arrived since the last periodic capture (pane content is unchanged).
     if (session.persistKey && session.outputSinceSnapshot)
       void this.snapshotScrollback(session.persistKey, session.sshRemote)
-    // Remember the grid the painter last enforced. It is the only record of it that survives this
-    // call (the Session goes with `forget` below), and a shadow attached later re-asserts it —
-    // otherwise the pane could reflow and the user would come back to a rewrapped screen.
-    if (session.persistKey && session.appliedSize)
-      this.lastSize.set(session.persistKey, session.appliedSize)
+    // Remember what a later shadow would have no other way to learn — the grid the painter last
+    // enforced (so the pane is not left to reflow), and whether this node's tmux was REMOTE (so it
+    // is never shadowed against our local socket). The `Session` holding both goes with `forget`
+    // below; this is the record that survives it.
+    if (session.persistKey)
+      this.released.set(session.persistKey, {
+        size: session.appliedSize,
+        remote: !!session.sshRemote
+      })
     releasePty(session.proc as ReleasablePty)
     this.forget(sessionId, session)
   }
@@ -686,13 +696,19 @@ export class PtyManager {
    *  - a PAINTER pty client is still attached for this node. A session never has both: the painter
    *    attaches with `-D` (it would kick the shadow off a moment later anyway), and two clients of
    *    ours on one pane would hand tmux the size negotiation that pty-size.ts exists to keep.
-   *  - the shadow was torn down while its opening size push was outstanding (see `shadowCommand`).
+   *  - the node is REMOTE (an SSH project): its tmux runs on the far host, not on our socket.
+   *  - the control client could not be spawned, or was torn down while its opening size push was
+   *    outstanding (see `shadowCommand`). This method never rejects; failure is always null.
    *
-   * WHAT A SHADOW IS NOT: not a subscriber, not a `Session`, not a renderer client id. Nothing that
-   * decides "is somebody watching" can see it — the reap sweep asks `platform().clientIds()` and
-   * walks `this.sessions`, the renderer's park and the offscreen dispose are per-node renderer
-   * state — so a shadow can never keep a session looking watched. (It IS a real tmux client and
-   * does appear in `tmux list-clients`; nothing in this app asks tmux that question.)
+   * WHAT A SHADOW IS NOT: not a subscriber, not a `Session`, not a renderer client id. Nothing in
+   * this process that decides "is somebody watching" can see it — the reap sweep asks
+   * `platform().clientIds()` and walks `this.sessions`, and the renderer's park and offscreen
+   * dispose are per-node renderer state.
+   *
+   * It IS a real tmux client, so anything that asks TMUX "is this session attached" does see it,
+   * and must subtract it. There is one such consumer: the session budget (session-budget.ts) culls
+   * idle DETACHED sessions under memory pressure, and it takes `shadowedTmuxSessions` for exactly
+   * this reason. Any future `list-clients`/`session_attached` reader owes the same subtraction.
    */
   async shadowAttach(persistKey: string): Promise<ControlModeClient | null> {
     // Both halves of "is there a tmux session at all": the binary, and the setting that decides
@@ -707,6 +723,13 @@ export class PtyManager {
     // about, so a node that is never wanted again costs nothing.
     if (live) this.shadows.delete(persistKey)
     if (this.sessionByPersistKey(persistKey)) return null
+    const known = this.released.get(persistKey)
+    // A remote (SSH-project) node's tmux server is on the FAR host, reached over that project's
+    // ControlMaster on the `nodeterm-rmt` socket. A local `-C attach -t nt-<id>` here would find
+    // nothing — or, if a create once ran with the master down, the LOCAL orphan wearing this node's
+    // name, which is a different machine's idea of the node and must never be typed into. Routing
+    // control mode over ssh is a separate job; refusing is the honest answer until it exists.
+    if (known?.remote) return null
     const client = new ControlModeClient({
       tmuxBin: this.tmuxPath,
       socket: TMUX_SOCKET,
@@ -724,8 +747,16 @@ export class PtyManager {
       spawner: this.controlSpawn
     })
     this.shadows.set(persistKey, client)
-    client.start()
-    const size = this.lastSize.get(persistKey)
+    try {
+      client.start()
+    } catch {
+      // `child_process.spawn` throws SYNCHRONOUSLY on EMFILE and friends — and a machine short of
+      // file descriptors is exactly the machine a background feature reaches for a shadow on. The
+      // contract is "null, never a rejection", so swallow it and leave no half-attached entry.
+      this.shadows.delete(persistKey)
+      return null
+    }
+    const size = this.released.get(persistKey)?.size
     if (size) {
       const line = `refresh-client -C ${size.cols}x${size.rows}`
       const reply = await this.shadowCommand(persistKey, line)
@@ -743,6 +774,25 @@ export class PtyManager {
     return this.shadows.get(persistKey) ?? null
   }
 
+  /**
+   * The tmux sessions this manager currently shadows on `socket` — the subtraction the session
+   * budget needs (session-budget.ts): a held `-C attach` flips `#{session_attached}` to 1, and an
+   * attached session is never culled, so without this a shadowed session would be permanently
+   * exempt from the memory-pressure safety valve. A shadow is not a watcher; the budget may kill
+   * the session under it, and the shadow dies with it.
+   *
+   * Socket-scoped because `nt-<node>` is only unique within a socket: shadows are attached on the
+   * LOCAL socket only, and a genuinely attached session of the same name on `nodeterm-rmt` (an SSH
+   * host's own sessions) keeps its exemption.
+   */
+  shadowedTmuxSessions(socket: string): string[] {
+    if (socket !== TMUX_SOCKET) return []
+    const names: string[] = []
+    for (const [persistKey, client] of this.shadows)
+      if (client.alive) names.push(sessionName(persistKey))
+    return names
+  }
+
   /** Retire a node's shadow, if it has one. Idempotent. The entry is dropped HERE because
    *  `dispose()` is silent (it does not fire `onExit`) — a deliberate swap-out is not a death. */
   shadowDispose(persistKey: string): void {
@@ -757,16 +807,28 @@ export class PtyManager {
    * command issued to a shadow must go through here: the client owns no timers, and a reply that
    * never comes desyncs its positional FIFO for good — so the timeout is a teardown, not a retry.
    *
-   * Returns the reply (`ok` is tmux's own verdict), or null when there is no shadow, or when the
-   * command timed out / the client died — in which case the shadow is gone and a caller that still
-   * wants one asks `shadowAttach` for a fresh client.
+   * Returns the reply (`ok` is tmux's own verdict), or null when there is no shadow, when the line
+   * is not a single command, or when the command timed out / the client died — in the last case the
+   * shadow is gone and a caller that still wants one asks `shadowAttach` for a fresh client.
+   *
+   * Public because it is the sanctioned way to talk to a shadow: a caller reaching past it to
+   * `client.command()` would be issuing an unbounded command, which is the one thing this whole
+   * mechanism cannot survive.
    */
-  private async shadowCommand(
+  async shadowCommand(
     persistKey: string,
     line: string
   ): Promise<{ ok: boolean; body: string[] } | null> {
     const client = this.shadows.get(persistKey)
     if (!client) return null
+    // Refuse a multi-line command HERE rather than letting the client refuse it below. Both answer
+    // null, but the difference is what happens to the shadow: the catch treats a rejection as
+    // evidence the channel is unusable and DISPOSES, which is right for a timeout or a death and
+    // pure collateral damage for a line that was never written (the FIFO cannot have desynced —
+    // see the same guard in tmux-control-client.ts). Screening it out up front is what makes the
+    // catch's blanket teardown safe: everything that can reject past this point has either reached
+    // the wire or lost the client.
+    if (/[\r\n]/.test(line)) return null
     let timer: ReturnType<typeof setTimeout> | undefined
     try {
       return await Promise.race([
@@ -2440,10 +2502,10 @@ export class PtyManager {
     // spawn a fresh session, not await (and then join) the one we are ending.
     this.inflight.delete(persistKey)
     // The tmux session is about to be killed, so everything attached to it goes now: a shadow would
-    // otherwise linger until tmux dropped its client, and the size we remembered describes a pane
-    // that is about to stop existing.
+    // otherwise linger until tmux dropped its client, and what we remembered about the released
+    // session describes a pane that is about to stop existing.
     this.shadowDispose(persistKey)
-    this.lastSize.delete(persistKey)
+    this.released.delete(persistKey)
     // A DELETE is remembered (the respawn guard for clients `pty:closed` cannot reach — see
     // `tombstones`); a RECYCLE explicitly forgets, because the node is not going anywhere and its
     // replacement session must be spawnable. Recorded even when no live session exists in this
@@ -2543,7 +2605,7 @@ export class PtyManager {
     // Shadows are child processes of OURS, so quitting takes them with us — the tmux sessions they
     // were attached to keep running with no client at all, which is exactly what persistence means.
     for (const persistKey of [...this.shadows.keys()]) this.shadowDispose(persistKey)
-    this.lastSize.clear()
+    this.released.clear()
     this.sessions.clear()
     this.byPersistKey.clear()
     // Pending recycle notices die with the sessions they were waiting on (their timers would

--- a/src/core/pty-shadow.test.ts
+++ b/src/core/pty-shadow.test.ts
@@ -414,6 +414,49 @@ describe('control-mode shadow clients for released sessions', () => {
     expect(killed).toEqual([{ socket: 'node-terminal', target: '=nt-node-1' }])
   })
 
+  it('leaves a session somebody is really watching alone — the attached flag is a client COUNT', async () => {
+    // `#{session_attached}` counts clients. Subtracting our shadow by forcing the flag to false
+    // would report a session that has our shadow PLUS a real client — the user's own
+    // `tmux -L node-terminal attach`, or a second nodeterm process on the same socket — as
+    // detached, and the budget would then kill a session out from under a live user, inverting its
+    // one hard rule in the state-destroying direction. The shadow comes off the COUNT.
+    const { createSessionReaper } = await import('./session-budget')
+    const m = await tmuxManager()
+    const a = await create(ALICE, 'node-1')
+    const b = await create(BOB, 'node-2')
+    kill(ALICE, a.sessionId)
+    kill(BOB, b.sessionId)
+    await m.shadowAttach('node-1')
+    await m.shadowAttach('node-2')
+
+    const NOW = 1_000_000
+    const OLD = NOW - 100_000
+    const killed: string[] = []
+    let listings = 0
+    const reaper = createSessionReaper({
+      tmuxBin: () => m.getTmuxBin(),
+      sockets: ['node-terminal'],
+      shadowed: (socket) => m.shadowedTmuxSessions(socket),
+      exec: async (_bin: string, args: string[]) => {
+        if (args.includes('kill-session')) {
+          killed.push(args[args.indexOf('-t') + 1])
+          return ''
+        }
+        // nt-node-1 carries the user's own client the whole time (2 = theirs + ours), so the PLAN
+        // must never name it. nt-node-2 is shadow-only when the plan is made and gains a real
+        // client before the kill — precisely what the kill-time re-verify exists for.
+        const nodeTwo = listings++ === 0 ? 1 : 2
+        return `nt-node-1|2|${OLD}\nnt-node-2|${nodeTwo}|${OLD}`
+      },
+      readMem: () => ({ availableMb: 100, totalMb: 8000 }), // under the watermark: real pressure
+      env: {},
+      nowSec: () => NOW
+    })
+
+    expect(await reaper.sweep()).toBe(0)
+    expect(killed).toEqual([])
+  })
+
   it('refuses a released REMOTE node — its tmux lives on the far host, not on our socket', async () => {
     const m = await tmuxManager()
     const res = (await fake.handlers[IPC.ptyCreate](ALICE, {

--- a/src/core/pty-shadow.test.ts
+++ b/src/core/pty-shadow.test.ts
@@ -98,8 +98,11 @@ class FakeControlSpawn implements ControlSpawn {
   calls: Array<{ bin: string; args: string[] }> = []
   children: FakeControlChild[] = []
   autoReply = true
+  /** `child_process.spawn` throws SYNCHRONOUSLY (EMFILE, a bad cwd) — this plays that. */
+  throwOnSpawn = false
   private num = 0
   spawn(bin: string, args: string[]) {
+    if (this.throwOnSpawn) throw new Error('spawn EMFILE')
     this.calls.push({ bin, args })
     log.push('control-spawn')
     let onData: ((b: Buffer) => void) | undefined
@@ -367,6 +370,93 @@ describe('control-mode shadow clients for released sessions', () => {
 
     expect(control.children.map((c) => c.killed)).toEqual([1, 1])
     expect(control.children.every((c) => c.writes.includes('detach-client\n'))).toBe(true)
+  })
+
+  it('stays reapable by the SESSION BUDGET, which reads tmux’s own attached flag', async () => {
+    // The one attachment check a shadow really is visible to: `session-budget.ts` culls idle
+    // DETACHED `nt-*` sessions under memory pressure, and a held `-C attach` flips
+    // `#{session_attached}` to 1 — so a shadowed session would be permanently exempt from the
+    // memory-pressure safety valve. It runs in production from BOTH shells against this socket.
+    const { createSessionReaper } = await import('./session-budget')
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+    await m.shadowAttach('node-1')
+
+    const NOW = 1_000_000
+    const OLD = NOW - 100_000 // well past the 6h grace window
+    const listings: Record<string, string> = {
+      // `nt-node-1` reads as attached because our shadow IS a real tmux client; `nt-node-9` is a
+      // genuinely attached session (somebody is looking at it) and must survive.
+      'node-terminal': `nt-node-1|1|${OLD}\nnt-node-9|1|${OLD}`,
+      // The SAME NAME on the SSH-remote socket, attached for real. Shadows only ever live on the
+      // local socket, so the exclusion must not follow the name across sockets.
+      'nodeterm-rmt': `nt-node-1|1|${OLD}`
+    }
+    const killed: Array<{ socket: string; target: string }> = []
+    const reaper = createSessionReaper({
+      tmuxBin: () => m.getTmuxBin(),
+      shadowed: (socket) => m.shadowedTmuxSessions(socket),
+      exec: async (_bin: string, args: string[]) => {
+        const socket = args[args.indexOf('-L') + 1]
+        if (args.includes('kill-session')) {
+          killed.push({ socket, target: args[args.indexOf('-t') + 1] })
+          return ''
+        }
+        return listings[socket] ?? ''
+      },
+      readMem: () => ({ availableMb: 100, totalMb: 8000 }), // under the watermark: real pressure
+      env: {},
+      nowSec: () => NOW
+    })
+
+    expect(await reaper.sweep()).toBe(1)
+    expect(killed).toEqual([{ socket: 'node-terminal', target: '=nt-node-1' }])
+  })
+
+  it('refuses a released REMOTE node — its tmux lives on the far host, not on our socket', async () => {
+    const m = await tmuxManager()
+    const res = (await fake.handlers[IPC.ptyCreate](ALICE, {
+      cols: 80,
+      rows: 24,
+      persistKey: 'node-r',
+      sshRemote: { conn: { host: 'h1', user: 'u' }, controlPath: '/tmp/cm', remoteCwd: '/srv/app' }
+    })) as { sessionId: string }
+    expect(m.sshRemoteForNode('node-r')).toBeDefined() // the spawn really did take the remote branch
+    kill(ALICE, res.sessionId)
+
+    // `nt-node-r` on OUR socket is either nothing at all or — worse — the local orphan a create
+    // issued with the master down once left behind. Neither is this node's session.
+    expect(await m.shadowAttach('node-r')).toBeNull()
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('returns null (never rejects) when the control client cannot even be spawned', async () => {
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+    control.throwOnSpawn = true
+
+    expect(await m.shadowAttach('node-1')).toBeNull()
+
+    // …and no half-attached entry is left behind: the next ask spawns a real one.
+    control.throwOnSpawn = false
+    expect(await m.shadowAttach('node-1')).not.toBeNull()
+    expect(control.calls).toHaveLength(1)
+  })
+
+  it('keeps a shadow whose command was refused before anything was written', async () => {
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+    const shadow = await m.shadowAttach('node-1')
+
+    // A malformed line is refused CLIENT-side, before a byte is written, so the FIFO cannot have
+    // desynced — tearing the shadow (and its tmux client) down over it would be pure collateral.
+    expect(await m.shadowCommand('node-1', 'display-message -p x\nkill-server')).toBeNull()
+
+    expect(control.only.killed).toBe(0)
+    expect(await m.shadowAttach('node-1')).toBe(shadow)
   })
 
   it('does nothing with tmux switched off in settings — no session is tmux-backed', async () => {

--- a/src/core/pty-shadow.test.ts
+++ b/src/core/pty-shadow.test.ts
@@ -516,6 +516,55 @@ describe('control-mode shadow clients for released sessions', () => {
     expect(control.calls).toHaveLength(0)
   })
 
+  it('spawns nothing with ptyShadowClients switched off — the kill switch', async () => {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager({ controlSpawn: control })
+    m.init(() => ({ ...DEFAULT_SETTINGS, ptyShadowClients: false }))
+    m.registerIpc()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+
+    // Everything else about this session is exactly as it is with the flag on: tmux is there, the
+    // session is released, the record is ours. The flag is the ONE reason nothing attaches, which
+    // is what makes "switch it off" a truthful instruction in a field report.
+    expect(await m.shadowAttach('node-1')).toBeNull()
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('logs one greppable line per swap direction', async () => {
+    const lines: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => void lines.push(a.join(' ')))
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+
+    await m.shadowAttach('node-1')
+    await m.shadowAttach('node-1') // re-used, not re-attached — so no second line
+
+    expect(lines.filter((l) => l === `[pty] shadow attach ${sessionName('node-1')}`)).toHaveLength(1)
+
+    liveTmuxSessions.add(sessionName('node-1')) // tmux kept the session across the detach
+    await create(ALICE)
+
+    // The other direction. "My terminal came back blank" is answerable from these two lines alone:
+    // they name the session, the direction, and (by their order) which client held it when.
+    expect(lines.filter((l) => l === `[pty] painter attach ${sessionName('node-1')}`)).toHaveLength(
+      1
+    )
+  })
+
+  it('says nothing when a painter spawns with no control client to retire', async () => {
+    const lines: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => void lines.push(a.join(' ')))
+    const m = await tmuxManager()
+
+    await create(ALICE) // the ordinary case: opening a terminal retires nothing
+
+    // One line per SWAP, not per terminal anyone ever opens: a log nobody can read is a log that
+    // answers no field report.
+    expect(lines.some((l) => l.startsWith('[pty] painter attach'))).toBe(false)
+  })
+
   it('does nothing without tmux — there is no tmux session to shadow', async () => {
     const m = await plainManager()
     const { sessionId } = await create(ALICE)

--- a/src/core/pty-shadow.test.ts
+++ b/src/core/pty-shadow.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { IPC } from '../shared/ipc'
+import { DEFAULT_SETTINGS } from '../shared/types'
+import { TMUX_SOCKET, sessionName } from './tmux-naming'
+import { REAP_IDLE_MS, REAP_SWEEP_MS } from './pty-reap'
+import type { ControlSpawn } from './tmux-control-client'
+
+/**
+ * SHADOW CLIENTS: a tmux control-mode (`-C`) client over plain pipes, attached to the tmux session
+ * of a node whose PAINTER pty client has already been released — the idle reap's stranded ones, and
+ * the ones a plain `pty:kill` (last subscriber out, offscreen dispose) let go immediately. It holds
+ * ZERO pty devices, which is what lets a background feature reach a node nobody is watching without
+ * respawning a terminal (a pty device, a tmux client, an ssh child and a full redraw).
+ *
+ * Two invariants carry the whole design, and most of what follows asserts one of them:
+ *  - a node never has a live painter AND a live shadow at the same time;
+ *  - a shadow is INVISIBLE to everything that asks "is somebody watching" — the reap sweep (which
+ *    decides against `platform().clientIds()`), the renderer's 5-minute park and the 10-minute
+ *    offscreen dispose. It is not a subscriber, not a `Session`, and not a renderer client id.
+ */
+
+/** One fake pty per spawn. `killed` is what a released client pty looks like from here. */
+interface FakePty {
+  onDataCb?: (d: string) => void
+  onExitCb?: (e: { exitCode: number }) => void
+  killed: boolean
+}
+const spawned: FakePty[] = []
+/** Spawn/dispose events across BOTH child kinds, so a test can assert their relative ORDER. */
+const log: string[] = []
+
+vi.mock('node-pty', () => ({
+  spawn: () => {
+    const p: FakePty = { killed: false }
+    spawned.push(p)
+    log.push('pty-spawn')
+    return {
+      onData: (cb: (d: string) => void) => {
+        p.onDataCb = cb
+      },
+      onExit: (cb: (e: { exitCode: number }) => void) => {
+        p.onExitCb = cb
+      },
+      write: () => {},
+      resize: () => {},
+      pause: () => {},
+      resume: () => {},
+      kill: () => {
+        p.killed = true
+      },
+      pid: 1
+    }
+  }
+}))
+
+/** Every tmux side-call goes through child_process; `liveTmuxSessions` answers `has-session`. */
+const liveTmuxSessions = new Set<string>()
+
+vi.mock('child_process', () => {
+  type Cb = (err: Error | null, res?: { stdout: string; stderr: string }) => void
+  const execFile = (file: string, args: string[], a?: unknown, b?: unknown): unknown => {
+    const cb = (typeof a === 'function' ? a : b) as Cb | undefined
+    const ok = (stdout: string): void => cb?.(null, { stdout, stderr: '' })
+    if (args.includes('has-session')) {
+      const target = args[args.indexOf('-t') + 1]
+      if (liveTmuxSessions.has(target)) ok('')
+      else cb?.(Object.assign(new Error('no such session'), { code: 1 }))
+    } else if (args[0] === '-ilc') {
+      ok('__NT_PATH_START__/usr/bin:/bin__NT_PATH_END__')
+    } else {
+      ok('')
+    }
+    return {}
+  }
+  return { execFile, execFileSync: (): string => '' }
+})
+
+/** One fake control-mode child per shadow: what was written to it, and whether it was killed. */
+interface FakeControlChild {
+  writes: string[]
+  killed: number
+  exit(code: number | null): void
+  feed(latin1: string): void
+}
+
+/**
+ * The injected `ControlSpawn`. It answers commands like a healthy tmux does — ASYNCHRONOUSLY (a
+ * reply delivered inside the `write` call would arrive before the client had queued its resolver,
+ * which is not a thing the real protocol can do) — and `autoReply = false` plays the wedged tmux
+ * that takes a command and never answers.
+ */
+class FakeControlSpawn implements ControlSpawn {
+  calls: Array<{ bin: string; args: string[] }> = []
+  children: FakeControlChild[] = []
+  autoReply = true
+  private num = 0
+  spawn(bin: string, args: string[]) {
+    this.calls.push({ bin, args })
+    log.push('control-spawn')
+    let onData: ((b: Buffer) => void) | undefined
+    let onExit: ((code: number | null) => void) | undefined
+    const child: FakeControlChild = {
+      writes: [],
+      killed: 0,
+      exit: (code) => onExit?.(code),
+      feed: (s) => onData?.(Buffer.from(s, 'latin1'))
+    }
+    this.children.push(child)
+    return {
+      stdin: {
+        write: (s: string) => {
+          child.writes.push(s)
+          // `detach-client` is the disposal handshake, not a command with a reply.
+          if (!this.autoReply || s.startsWith('detach-client')) return
+          const n = ++this.num
+          // A real microtask (not a timer): tests run under fake timers.
+          void Promise.resolve().then(() =>
+            child.feed(`%begin 1700 ${n} 0\n%end 1700 ${n} 0\n`)
+          )
+        }
+      },
+      stdout: {
+        on: (_ev: 'data', cb: (b: Buffer) => void) => {
+          onData = cb
+        }
+      },
+      on: (_ev: 'exit', cb: (code: number | null) => void) => {
+        onExit = cb
+      },
+      kill: () => {
+        child.killed++
+        log.push('control-kill')
+      }
+    }
+  }
+  get only(): FakeControlChild {
+    return this.children[0]
+  }
+}
+
+const ALICE = 1
+const BOB = 2
+
+describe('control-mode shadow clients for released sessions', () => {
+  let fake: FakePlatform
+  let userDataDir: string
+  let control: FakeControlSpawn
+
+  beforeEach(() => {
+    spawned.length = 0
+    log.length = 0
+    liveTmuxSessions.clear()
+    control = new FakeControlSpawn()
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-shadow-'))
+    fake = fakePlatform({ userDataDir })
+    initPlatform(fake)
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    resetPlatformForTests()
+    // Best effort, as in pty-idle-reap.test.ts: a fired-and-forgotten scrollback snapshot can still
+    // be landing here, and a cleanup that fails the suite is worse than a leftover dir.
+    try {
+      fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 20 })
+    } catch {
+      /* a temp dir we could not remove is not a test result */
+    }
+  })
+
+  /** A manager WITH init(): tmux-backed, which is what a real user always gets. */
+  async function tmuxManager() {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager({ controlSpawn: control })
+    m.init(() => DEFAULT_SETTINGS)
+    m.registerIpc()
+    return m
+  }
+  /** A manager WITHOUT init(): no tmux, so there is no tmux session to shadow. */
+  async function plainManager() {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager({ controlSpawn: control })
+    m.registerIpc()
+    return m
+  }
+  const create = (clientId: number, persistKey = 'node-1', cols = 80, rows = 24) =>
+    fake.handlers[IPC.ptyCreate](clientId, { cols, rows, persistKey }) as Promise<{
+      sessionId: string
+      fresh: boolean
+    }>
+  /** pty:kill is sender-aware: it unsubscribes ONE view, and the last one out releases the pty. */
+  const kill = (clientId: number, sessionId: string) =>
+    fake.senderListeners[IPC.ptyKill](clientId, sessionId)
+  /** Run the sweep past the idle threshold (it only decides on its own ticks). */
+  const idle = (ms = REAP_IDLE_MS + REAP_SWEEP_MS) => vi.advanceTimersByTime(ms)
+  const attachArgs = (key: string) => ['-L', TMUX_SOCKET, '-C', 'attach-session', '-t', sessionName(key)]
+
+  it('shadows a session the reap stranded — over pipes, taking no pty device', async () => {
+    const m = await tmuxManager()
+    await create(ALICE) // …and Alice's window is then destroyed without a pty:kill ever arriving
+    idle()
+    expect(spawned[0].killed).toBe(true) // the sweep released her client pty
+
+    const shadow = await m.shadowAttach('node-1')
+
+    expect(shadow).not.toBeNull()
+    expect(control.calls).toEqual([{ bin: m.getTmuxBin(), args: attachArgs('node-1') }])
+    // The whole point: reaching the session cost no second pty.
+    expect(spawned).toHaveLength(1)
+  })
+
+  it('shadows a session released the instant its last subscriber left (the offscreen path)', async () => {
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId) // offscreen dispose / node unmount: zero subscribers, released at once
+
+    expect(spawned[0].killed).toBe(true)
+    expect(await m.shadowAttach('node-1')).not.toBeNull()
+    expect(control.calls).toHaveLength(1)
+  })
+
+  it('refuses while the painter pty client is attached — never both at once', async () => {
+    const m = await tmuxManager()
+    await create(ALICE)
+
+    expect(await m.shadowAttach('node-1')).toBeNull()
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('re-uses a live shadow instead of spawning a second control client', async () => {
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+
+    const first = await m.shadowAttach('node-1')
+    const second = await m.shadowAttach('node-1')
+
+    expect(second).toBe(first)
+    expect(control.calls).toHaveLength(1)
+  })
+
+  it('re-asserts the size the painter last enforced — a control client sizes the pane', async () => {
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE, 'node-1', 100, 30)
+    kill(ALICE, sessionId)
+
+    await m.shadowAttach('node-1')
+
+    // With only a control client attached the pane follows `refresh-client -C`; without this push
+    // the user would come back to a pane reflowed to somebody else's default.
+    expect(control.only.writes).toContain('refresh-client -C 100x30\n')
+  })
+
+  it('pushes no size when the released session never recorded one', async () => {
+    const m = await tmuxManager()
+    // A relay-served (detached) pty: its sink reports no size at create time, so this manager never
+    // enforced one. Pushing an invented size would reflow a pane that is perfectly fine.
+    const sessionId = m.attachDetached('node-1', { onData: () => {}, onExit: () => {} })
+    m.kill(null, sessionId)
+
+    await m.shadowAttach('node-1')
+
+    expect(control.only.writes.some((w) => w.startsWith('refresh-client'))).toBe(false)
+  })
+
+  it('is invisible to the reaper: not a watcher, and never swept up itself', async () => {
+    const m = await tmuxManager()
+    await create(ALICE, 'node-1')
+    idle()
+    await m.shadowAttach('node-1')
+
+    // A second node is opened and abandoned the same way. If the shadow had registered anywhere the
+    // sweep looks — a client id, a subscriber, a Session — it would show here: as a session that
+    // never becomes reapable, or as a shadow the sweep tore down.
+    await create(BOB, 'node-2')
+    idle()
+
+    expect(spawned[1].killed).toBe(true) // node-2 still reaps ⇒ clientIds() is unpolluted
+    expect(control.only.killed).toBe(0) // the sweep does not touch a shadow…
+    expect(control.calls).toHaveLength(1) // …and never attaches one either
+  })
+
+  it('disposes the shadow BEFORE spawning the painter when the node comes back', async () => {
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+    await m.shadowAttach('node-1')
+    liveTmuxSessions.add(sessionName('node-1')) // tmux kept it running, as it does across a detach
+    log.length = 0
+
+    await create(ALICE) // the node scrolls back into view / the user reopens the project
+
+    // Order is the assertion: the painter attaches with `-D` and would kick the shadow off anyway,
+    // but only after tmux has processed both attaches — so the shadow goes first, and exactly one
+    // client of ours is ever negotiating the pane.
+    expect(log).toEqual(['control-kill', 'pty-spawn'])
+    expect(control.only.writes).toContain('detach-client\n') // detached politely, then killed
+    expect(spawned[1].killed).toBe(false) // the painter is live and untouched
+  })
+
+  it('leaves the session alone when its shadow dies, and re-attaches lazily on the next ask', async () => {
+    const m = await tmuxManager()
+    await create(ALICE)
+    idle()
+    await m.shadowAttach('node-1')
+
+    control.children[0].exit(1) // the control client died on its own (tmux restart, OOM kill)
+
+    // Nothing is resurrected on its behalf — no pty, no session, no eager re-attach.
+    expect(spawned).toHaveLength(1)
+    expect(control.calls).toHaveLength(1)
+
+    const again = await m.shadowAttach('node-1')
+
+    expect(again).not.toBeNull()
+    expect(control.calls).toEqual([
+      { bin: m.getTmuxBin(), args: attachArgs('node-1') },
+      { bin: m.getTmuxBin(), args: attachArgs('node-1') }
+    ])
+  })
+
+  it('disposes a shadow whose reply never comes — a lost reply desyncs the FIFO forever', async () => {
+    const { SHADOW_CMD_TIMEOUT_MS } = await import('./pty-manager')
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE, 'node-1', 100, 30)
+    kill(ALICE, sessionId)
+    control.autoReply = false // tmux takes the command and never answers
+
+    const attaching = m.shadowAttach('node-1')
+    await vi.advanceTimersByTimeAsync(SHADOW_CMD_TIMEOUT_MS)
+
+    expect(await attaching).toBeNull()
+    expect(control.only.killed).toBe(1)
+    // …and the entry is gone, so the next ask gets a fresh client rather than a desynced one.
+    control.autoReply = true
+    expect(await m.shadowAttach('node-1')).not.toBeNull()
+    expect(control.calls).toHaveLength(2)
+  })
+
+  it('destroying a node takes its shadow with it — the tmux session is going away', async () => {
+    const m = await tmuxManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+    await m.shadowAttach('node-1')
+
+    await m.destroySession(ALICE, 'node-1')
+
+    expect(control.only.killed).toBe(1)
+  })
+
+  it('app quit disposes every shadow', async () => {
+    const m = await tmuxManager()
+    const a = await create(ALICE, 'node-1')
+    const b = await create(BOB, 'node-2')
+    kill(ALICE, a.sessionId)
+    kill(BOB, b.sessionId)
+    await m.shadowAttach('node-1')
+    await m.shadowAttach('node-2')
+
+    await m.killAll()
+
+    expect(control.children.map((c) => c.killed)).toEqual([1, 1])
+    expect(control.children.every((c) => c.writes.includes('detach-client\n'))).toBe(true)
+  })
+
+  it('does nothing with tmux switched off in settings — no session is tmux-backed', async () => {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager({ controlSpawn: control })
+    m.init(() => ({ ...DEFAULT_SETTINGS, tmuxEnabled: false }))
+    m.registerIpc()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+
+    // The binary is right there, so `tmuxPath` alone would say yes — but nothing spawned a tmux
+    // session, so a shadow would attach to a name that does not exist and die on arrival.
+    expect(await m.shadowAttach('node-1')).toBeNull()
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('does nothing without tmux — there is no tmux session to shadow', async () => {
+    const m = await plainManager()
+    const { sessionId } = await create(ALICE)
+    kill(ALICE, sessionId)
+
+    expect(await m.shadowAttach('node-1')).toBeNull()
+    expect(control.calls).toHaveLength(0)
+  })
+})

--- a/src/core/session-budget.test.ts
+++ b/src/core/session-budget.test.ts
@@ -19,10 +19,10 @@ const cfg = (over: Partial<SessionBudgetConfig> = {}): SessionBudgetConfig => ({
   ...over
 })
 
-/** A detached nt- session idle for `idleH` hours. */
-const idle = (name: string, idleH: number, attached = false): SessionInfo => ({
+/** An nt- session idle for `idleH` hours, with `clients` attached (0 = detached). */
+const idle = (name: string, idleH: number, clients = 0): SessionInfo => ({
   name,
-  attached,
+  clients,
   activitySec: NOW - idleH * 3600
 })
 
@@ -36,7 +36,7 @@ describe('planReap (pure policy)', () => {
   })
 
   it('never reaps an attached session, no matter how idle', () => {
-    const plan = planReap([idle('nt-watched', 500, true), idle('nt-idle', 500)], lowMem, NOW, cfg())
+    const plan = planReap([idle('nt-watched', 500, 1), idle('nt-idle', 500)], lowMem, NOW, cfg())
     expect(plan).toEqual(['nt-idle'])
   })
 
@@ -68,7 +68,7 @@ describe('planReap (pure policy)', () => {
   })
 
   it('attached sessions do not count toward freeing the cap, but are never the ones killed', () => {
-    const sessions = [idle('nt-live', 500, true), ...Array.from({ length: 5 }, (_, i) => idle(`nt-d${i}`, 100 + i))]
+    const sessions = [idle('nt-live', 500, 2), ...Array.from({ length: 5 }, (_, i) => idle(`nt-d${i}`, 100 + i))]
     const plan = planReap(sessions, okMem, NOW, cfg({ maxDetached: 4 }))
     expect(plan).toEqual(['nt-d4'])
   })
@@ -92,11 +92,11 @@ describe('planReap (pure policy)', () => {
 })
 
 describe('parseSessionList', () => {
-  it('parses names, attached counts and activity, skipping malformed lines', () => {
+  it('parses names, CLIENT COUNTS and activity, skipping malformed lines', () => {
     const out = parseSessionList('nt-a|0|1753000000\nnt-b|2|1753000100\n\njunk\nx|y|z\n')
     expect(out).toEqual([
-      { name: 'nt-a', attached: false, activitySec: 1_753_000_000 },
-      { name: 'nt-b', attached: true, activitySec: 1_753_000_100 }
+      { name: 'nt-a', clients: 0, activitySec: 1_753_000_000 },
+      { name: 'nt-b', clients: 2, activitySec: 1_753_000_100 }
     ])
   })
 })

--- a/src/core/session-budget.ts
+++ b/src/core/session-budget.ts
@@ -35,7 +35,18 @@ const runAsync = promisify(execFile)
 /** One tmux session as reported by `list-sessions`. `activitySec` is epoch seconds. */
 export interface SessionInfo {
   name: string
-  attached: boolean
+  /**
+   * How many clients tmux reports attached. A COUNT, not a flag: `#{session_attached}` is the
+   * number of clients, and one session can have several — the app's painter, the user's own `tmux
+   * -L node-terminal attach`, a second nodeterm process on the same socket, one of our
+   * control-mode shadows.
+   *
+   * Carried numerically rather than collapsed to a boolean at parse time because the `shadowed`
+   * seam SUBTRACTS: a session holding our shadow AND a real client must still read as attached,
+   * and a boolean can only be forced to false — which would reap the session out from under
+   * whoever the other client belongs to.
+   */
+  clients: number
   activitySec: number
 }
 
@@ -98,7 +109,7 @@ export function planReap(
 ): string[] {
   if (cfg.disabled) return []
   const nt = sessions.filter((s) => s.name.startsWith('nt-'))
-  const detached = nt.filter((s) => !s.attached)
+  const detached = nt.filter((s) => s.clients === 0)
   const eligible = detached
     .filter((s) => nowSec - s.activitySec >= cfg.graceSec)
     .sort((a, b) => a.activitySec - b.activitySec)
@@ -119,7 +130,7 @@ export function parseSessionList(stdout: string): SessionInfo[] {
     const attached = Number(parts[1])
     const activity = Number(parts[2])
     if (!parts[0] || !Number.isFinite(attached) || !Number.isFinite(activity)) continue
-    out.push({ name: parts[0], attached: attached > 0, activitySec: activity })
+    out.push({ name: parts[0], clients: Math.max(0, attached), activitySec: activity })
   }
   return out
 }
@@ -209,13 +220,20 @@ export function createSessionReaper(opts: SessionReaperOpts): SessionReaper {
   const listSocket = async (bin: string, socket: string): Promise<SessionInfo[] | null> => {
     try {
       const listed = parseSessionList(await exec(bin, ['-L', socket, 'list-sessions', '-F', LIST_FMT]))
-      // Our own shadows are subtracted from tmux's `attached` HERE, at the one place every listing
-      // comes through, so the plan and the kill-time re-verify can never disagree about it (a
-      // shadow attached between the two would otherwise resurrect the exemption). Re-read each
+      // Our own shadows are subtracted from tmux's client COUNT here, at the one place every
+      // listing comes through, so the plan and the kill-time re-verify can never disagree about it
+      // (a shadow attached between the two would otherwise resurrect the exemption). Re-read each
       // time: the set changes as sessions are shadowed and swapped back to painters.
+      //
+      // Minus ONE client, never "detached": this app holds at most one shadow per session, and
+      // anything left over is somebody else's client — the user's own `tmux attach`, another
+      // nodeterm process on this socket — whose session must keep the exemption. Forcing the flag
+      // false here would reap a session out from under a live user.
       const shadowed = new Set(opts.shadowed?.(socket) ?? [])
       if (shadowed.size === 0) return listed
-      return listed.map((s) => (s.attached && shadowed.has(s.name) ? { ...s, attached: false } : s))
+      return listed.map((s) =>
+        s.clients > 0 && shadowed.has(s.name) ? { ...s, clients: s.clients - 1 } : s
+      )
     } catch {
       // "no server running" and a real failure both land here; neither yields candidates.
       return null
@@ -245,7 +263,7 @@ export function createSessionReaper(opts: SessionReaperOpts): SessionReaper {
       // Kill-time re-verify on a FRESH list: only sessions still present and still detached die.
       const fresh = await listSocket(bin, socket)
       if (!fresh) continue
-      const stillDetached = new Set(fresh.filter((s) => !s.attached).map((s) => s.name))
+      const stillDetached = new Set(fresh.filter((s) => s.clients === 0).map((s) => s.name))
       for (const name of names) {
         if (!stillDetached.has(name)) continue
         try {

--- a/src/core/session-budget.ts
+++ b/src/core/session-budget.ts
@@ -163,16 +163,25 @@ export interface SessionReaperOpts {
    *  process) is the natural owner of reaping them; the desktops that spawned them may be gone. */
   sockets?: string[]
   /**
-   * The tmux sessions THIS process holds a control-mode SHADOW on, per socket (see
-   * `PtyManager.shadowedTmuxSessions`). They are reported as DETACHED regardless of what tmux says,
-   * in the plan AND in the kill-time re-verify.
+   * The tmux sessions THIS process holds a control-mode client on, per socket — a per-session
+   * shadow or the shared background-write client (see `PtyManager.shadowedTmuxSessions`). Each name
+   * listed has exactly ONE client SUBTRACTED FROM ITS COUNT, in the plan AND in the kill-time
+   * re-verify; anything left over is somebody else's client and keeps its exemption.
    *
-   * A shadow is a real tmux client, so a held `-C attach` flips `#{session_attached}` to 1 — and an
-   * attached session is never evicted here. Without this hook, attaching a shadow (something no
-   * user asked for and nobody is watching) would make a session permanently exempt from the
-   * memory-pressure safety valve this whole module exists to be. A shadow is not a watcher: the
-   * session may be reaped under it exactly as if nothing were attached, and the shadow's client
-   * dies with the session it was attached to.
+   * A control client is a real tmux client, so a held `-C attach` puts this process into
+   * `#{session_attached}` — and an attached session is never evicted here. Without this hook,
+   * attaching one (something no user asked for and nobody is watching) would make a session
+   * permanently exempt from the memory-pressure safety valve this whole module exists to be. It is
+   * not a watcher: the session may be reaped under it exactly as if nothing were attached, and the
+   * client dies with the session it was attached to.
+   *
+   * SUBTRACT, never force-detach — `#{session_attached}` is a client COUNT, not a flag. A session
+   * holding ours PLUS a real one (the user's own `tmux attach`, a second nodeterm process on this
+   * socket) must stay exempt, or the budget kills a session out from under a live user. That is
+   * this module's one hard rule, and forcing the state inverts it.
+   *
+   * At most one of ours per name: PtyManager retires the shared client before shadowing the session
+   * it is attached to, so nothing here ever owes a subtraction of two.
    *
    * Per SOCKET, not per name: `nt-<node>` is only unique within a socket, and a genuinely attached
    * session of the same name on `nodeterm-rmt` must keep its exemption.

--- a/src/core/session-budget.ts
+++ b/src/core/session-budget.ts
@@ -7,7 +7,9 @@
 //   - a bounded budget, enforced only when exceeded — never a calendar-based expiry;
 //   - eviction picks the LEAST-RECENTLY-ACTIVE holder;
 //   - an ATTACHED session (someone is looking at it) is never evicted, exactly like a visible
-//     WebGL holder; a recently-active one is protected by a grace window (the release delay);
+//     WebGL holder; a recently-active one is protected by a grace window (the release delay).
+//     "Attached" means a WATCHER: this app's own control-mode shadows are tmux clients too, and
+//     they are subtracted from tmux's flag via the `shadowed` seam — see SessionReaperOpts;
 //   - reaping is gradual (per-sweep batch), so one sweep can never mass-kill its way past the
 //     target — the next sweep re-evaluates.
 //
@@ -149,6 +151,22 @@ export interface SessionReaperOpts {
    *  SSH projects accumulates sessions on `nodeterm-rmt`, and its own nodeterm-server (this
    *  process) is the natural owner of reaping them; the desktops that spawned them may be gone. */
   sockets?: string[]
+  /**
+   * The tmux sessions THIS process holds a control-mode SHADOW on, per socket (see
+   * `PtyManager.shadowedTmuxSessions`). They are reported as DETACHED regardless of what tmux says,
+   * in the plan AND in the kill-time re-verify.
+   *
+   * A shadow is a real tmux client, so a held `-C attach` flips `#{session_attached}` to 1 — and an
+   * attached session is never evicted here. Without this hook, attaching a shadow (something no
+   * user asked for and nobody is watching) would make a session permanently exempt from the
+   * memory-pressure safety valve this whole module exists to be. A shadow is not a watcher: the
+   * session may be reaped under it exactly as if nothing were attached, and the shadow's client
+   * dies with the session it was attached to.
+   *
+   * Per SOCKET, not per name: `nt-<node>` is only unique within a socket, and a genuinely attached
+   * session of the same name on `nodeterm-rmt` must keep its exemption.
+   */
+  shadowed?: (socket: string) => Iterable<string>
   exec?: (bin: string, args: string[]) => Promise<string>
   readMem?: () => MemInfo | null
   env?: NodeJS.ProcessEnv
@@ -190,7 +208,14 @@ export function createSessionReaper(opts: SessionReaperOpts): SessionReaper {
 
   const listSocket = async (bin: string, socket: string): Promise<SessionInfo[] | null> => {
     try {
-      return parseSessionList(await exec(bin, ['-L', socket, 'list-sessions', '-F', LIST_FMT]))
+      const listed = parseSessionList(await exec(bin, ['-L', socket, 'list-sessions', '-F', LIST_FMT]))
+      // Our own shadows are subtracted from tmux's `attached` HERE, at the one place every listing
+      // comes through, so the plan and the kill-time re-verify can never disagree about it (a
+      // shadow attached between the two would otherwise resurrect the exemption). Re-read each
+      // time: the set changes as sessions are shadowed and swapped back to painters.
+      const shadowed = new Set(opts.shadowed?.(socket) ?? [])
+      if (shadowed.size === 0) return listed
+      return listed.map((s) => (s.attached && shadowed.has(s.name) ? { ...s, attached: false } : s))
     } catch {
       // "no server running" and a real failure both land here; neither yields candidates.
       return null

--- a/src/core/settings-store.test.ts
+++ b/src/core/settings-store.test.ts
@@ -38,6 +38,27 @@ describe('SettingsStore nested-default merge', () => {
     expect(s.fontSize).toBe(15)
   })
 
+  it('turns pty shadow clients ON for an existing settings.json that predates the flag', () => {
+    writeFileSync(path.join(dir, 'settings.json'), JSON.stringify({ tmuxEnabled: true }), 'utf-8')
+    const store = new SettingsStore()
+    store.init()
+    // Every install that upgrades into this release has a settings.json without the key. If the
+    // shallow merge did not carry the default through, the feature would be off for exactly the
+    // population it needs its soak release from.
+    expect(store.get().ptyShadowClients).toBe(true)
+  })
+
+  it('keeps an explicit ptyShadowClients:false — the kill switch survives a load', () => {
+    writeFileSync(
+      path.join(dir, 'settings.json'),
+      JSON.stringify({ ptyShadowClients: false }),
+      'utf-8'
+    )
+    const store = new SettingsStore()
+    store.init()
+    expect(store.get().ptyShadowClients).toBe(false)
+  })
+
   it('leaves an already-modern speech object alone', () => {
     writeFileSync(
       path.join(dir, 'settings.json'),

--- a/src/core/tmux-control-client.test.ts
+++ b/src/core/tmux-control-client.test.ts
@@ -168,6 +168,23 @@ describe('ControlModeClient.command', () => {
     expect(await first).toEqual({ ok: true, body: ['80'] })
     expect(await second).toEqual({ ok: true, body: ['24'] })
   })
+  it('refuses a line with an embedded newline instead of desyncing the FIFO', async () => {
+    // One `command()` call queues ONE resolver, so a line carrying its own newline would send TWO
+    // commands, draw TWO replies, and pair every later reply with the wrong caller — forever, since
+    // this layer has no timers to notice. Reject before anything is written or queued.
+    const { client, child } = makeClient()
+    const bad = client.command('display -p a\nkill-server')
+    await expect(bad).rejects.toThrow(/newline/)
+    expect(child.writes).toEqual([])
+    const good = client.command('list-panes')
+    child.feed(reply(1, ['still in phase']))
+    await expect(good).resolves.toEqual({ ok: true, body: ['still in phase'] })
+  })
+  it('refuses a line with an embedded carriage return', async () => {
+    const { client, child } = makeClient()
+    await expect(client.command('display -p a\rkill-server')).rejects.toThrow(/newline/)
+    expect(child.writes).toEqual([])
+  })
   it('rejects instead of hanging when the client is not running', async () => {
     const spawner = new FakeControlSpawn()
     const client = new ControlModeClient({
@@ -210,7 +227,12 @@ describe('ControlModeClient exit', () => {
     const { client, child } = makeClient({ onExit })
     const pending = client.command('list-panes')
     child.feed('%begin 1700 1 0\n')
-    child.feed('x'.repeat(MAX_PENDING_BYTES + 1))
+    // Fed in realistic ~64KiB pipe chunks, each one complete lines and each far under the cap: what
+    // must trip is the total accumulated SINCE THE LAST COMPLETED EVENT (no event can complete while
+    // the block stays open), not any single chunk's length.
+    const chunk = `${'x'.repeat(64 * 1024 - 1)}\n`
+    const enough = Math.ceil(MAX_PENDING_BYTES / chunk.length) + 1
+    for (let i = 0; i < enough && client.alive; i++) child.feed(chunk)
     expect(child.killed).toBe(1)
     expect(onExit).toHaveBeenCalledTimes(1)
     expect(client.alive).toBe(false)

--- a/src/core/tmux-control-client.test.ts
+++ b/src/core/tmux-control-client.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ControlModeClient, MAX_PENDING_BYTES, type ControlSpawn } from './tmux-control-client'
+
+/**
+ * The client is the only place that owns a tmux control-mode PROCESS, so everything worth asserting
+ * here is a lifecycle promise: what gets spawned, that bytes arrive undamaged, that replies pair with
+ * the right command, and that a dead or wedged peer never leaves a caller hanging forever.
+ */
+
+/** One fake child per spawn: tests drive stdout with `feed`, then read back what was written. */
+interface FakeChild {
+  writes: string[]
+  killed: number
+  exit(code: number | null): void
+  feed(latin1: string): void
+}
+
+class FakeControlSpawn implements ControlSpawn {
+  calls: Array<{ bin: string; args: string[] }> = []
+  children: FakeChild[] = []
+  spawn(bin: string, args: string[]) {
+    this.calls.push({ bin, args })
+    let onData: ((b: Buffer) => void) | undefined
+    let onExit: ((code: number | null) => void) | undefined
+    const child: FakeChild = {
+      writes: [],
+      killed: 0,
+      exit: (code) => onExit?.(code),
+      // Buffer.from(s, 'latin1') is the byte-exact transport the real spawner hands us.
+      feed: (s) => onData?.(Buffer.from(s, 'latin1'))
+    }
+    this.children.push(child)
+    return {
+      stdin: {
+        write: (s: string) => {
+          child.writes.push(s)
+        }
+      },
+      stdout: {
+        on: (_ev: 'data', cb: (b: Buffer) => void) => {
+          onData = cb
+        }
+      },
+      on: (_ev: 'exit', cb: (code: number | null) => void) => {
+        onExit = cb
+      },
+      kill: () => {
+        child.killed++
+      }
+    }
+  }
+  get only(): FakeChild {
+    return this.children[0]
+  }
+}
+
+/** A started client plus its fake, wired with recording callbacks — the shape every test needs. */
+function makeClient(over: Partial<{ onOutput: (d: string) => void; onExit: () => void }> = {}) {
+  const spawner = new FakeControlSpawn()
+  const out: string[] = []
+  const exits: number[] = []
+  const client = new ControlModeClient({
+    tmuxBin: '/opt/homebrew/bin/tmux',
+    socket: 'node-terminal',
+    sessionName: 'nt-term-1',
+    onOutput: over.onOutput ?? ((d) => out.push(d)),
+    onExit: over.onExit ?? (() => exits.push(1)),
+    spawner
+  })
+  client.start()
+  return { client, spawner, out, exits, child: spawner.only }
+}
+
+/** tmux answers `%begin/%end`; ts and num must repeat in the terminator or the codec keeps the block open. */
+function reply(num: number, body: string[] = [], ok = true): string {
+  const term = ok ? '%end' : '%error'
+  return [`%begin 1700 ${num} 0`, ...body, `${term} 1700 ${num} 0`, ''].join('\n')
+}
+
+describe('ControlModeClient.start', () => {
+  it('spawns tmux in control mode on the session socket', () => {
+    const { spawner } = makeClient()
+    expect(spawner.calls).toEqual([
+      {
+        bin: '/opt/homebrew/bin/tmux',
+        args: ['-L', 'node-terminal', '-C', 'attach-session', '-t', 'nt-term-1']
+      }
+    ])
+  })
+  it('is alive once started and not before', () => {
+    const spawner = new FakeControlSpawn()
+    const client = new ControlModeClient({
+      tmuxBin: 'tmux',
+      socket: 's',
+      sessionName: 'nt-term-1',
+      onOutput: () => {},
+      onExit: () => {},
+      spawner
+    })
+    expect(client.alive).toBe(false)
+    client.start()
+    expect(client.alive).toBe(true)
+  })
+})
+
+describe('ControlModeClient output', () => {
+  it('delivers %output payloads to onOutput with the octal escapes decoded', () => {
+    const { child, out } = makeClient()
+    child.feed('%output %1 hi\\015\\012')
+    child.feed('there\\012\n')
+    expect(out).toEqual(['hi\r\nthere\n'])
+  })
+  it('re-assembles a UTF-8 character split across two %output lines', () => {
+    // The transport is latin1 (bytes >= 0x80 ride RAW and unescaped), so `ç` arrives as the two
+    // chars \xc3 \xa7 — possibly in different lines. A per-byte utf8 decode would emit two U+FFFDs.
+    const { child, out } = makeClient()
+    child.feed('%output %1 \xc3\n')
+    child.feed('%output %1 \xa7\n')
+    expect(out.join('')).toBe('ç')
+  })
+  it('ignores notifications that are neither output nor replies', () => {
+    const { child, out } = makeClient()
+    child.feed('%session-changed $0 nt-term-1\n%window-add @2\n')
+    expect(out).toEqual([])
+  })
+})
+
+describe('ControlModeClient.sendKeys', () => {
+  it('writes the hex send-keys line and resolves true on an ok reply', async () => {
+    const { client, child } = makeClient()
+    const p = client.sendKeys('ls\n')
+    expect(child.writes).toEqual(['send-keys -t nt-term-1 -H 6c 73 0a\n'])
+    child.feed(reply(1))
+    await expect(p).resolves.toBe(true)
+  })
+  it('resolves false when tmux answers %error', async () => {
+    const { client, child } = makeClient()
+    const p = client.sendKeys('x')
+    child.feed(reply(1, ["can't find pane"], false))
+    await expect(p).resolves.toBe(false)
+  })
+  it('can target another session on the same server', async () => {
+    const { client, child } = makeClient()
+    const p = client.sendKeys('x', 'nt-term-9')
+    expect(child.writes).toEqual(['send-keys -t nt-term-9 -H 78\n'])
+    child.feed(reply(1))
+    await expect(p).resolves.toBe(true)
+  })
+})
+
+describe('ControlModeClient.command', () => {
+  it('resolves with the reply body', async () => {
+    const { client, child } = makeClient()
+    const p = client.command('list-panes')
+    expect(child.writes).toEqual(['list-panes\n'])
+    child.feed(reply(1, ['%1: [80x24]']))
+    await expect(p).resolves.toEqual({ ok: true, body: ['%1: [80x24]'] })
+  })
+  it('pairs overlapping commands with replies in FIFO arrival order', async () => {
+    // Control mode answers in order and the reply carries no correlation to the command text, so
+    // arrival order IS the correlation. Getting this wrong silently swaps two callers' answers.
+    const { client, child } = makeClient()
+    const first = client.command('display -p #{pane_width}')
+    const second = client.command('display -p #{pane_height}')
+    expect(child.writes).toEqual(['display -p #{pane_width}\n', 'display -p #{pane_height}\n'])
+    child.feed(reply(1, ['80']))
+    child.feed(reply(2, ['24']))
+    expect(await first).toEqual({ ok: true, body: ['80'] })
+    expect(await second).toEqual({ ok: true, body: ['24'] })
+  })
+  it('rejects instead of hanging when the client is not running', async () => {
+    const spawner = new FakeControlSpawn()
+    const client = new ControlModeClient({
+      tmuxBin: 'tmux',
+      socket: 's',
+      sessionName: 'nt-term-1',
+      onOutput: () => {},
+      onExit: () => {},
+      spawner
+    })
+    await expect(client.command('list-panes')).rejects.toThrow(/not running/)
+  })
+})
+
+describe('ControlModeClient exit', () => {
+  it('fires onExit once, rejects pending commands and stops being alive', async () => {
+    const onExit = vi.fn()
+    const { client, child } = makeClient({ onExit })
+    const pending = client.command('list-panes')
+    child.exit(0)
+    child.exit(0) // a second exit event must not double-notify the owner
+    expect(onExit).toHaveBeenCalledTimes(1)
+    expect(client.alive).toBe(false)
+    await expect(pending).rejects.toThrow(/exited/)
+  })
+  it('treats a %exit notification as the end of the client', async () => {
+    const onExit = vi.fn()
+    const { client, child } = makeClient({ onExit })
+    const pending = client.command('list-panes')
+    child.feed('%exit server exited\n')
+    expect(onExit).toHaveBeenCalledTimes(1)
+    expect(client.alive).toBe(false)
+    expect(child.killed).toBe(1)
+    await expect(pending).rejects.toThrow(/exited/)
+  })
+  it('kills a peer that floods the stream without ever completing an event', async () => {
+    // The codec buffers an unterminated line and an unterminated %begin block FOREVER; a peer that
+    // loses a terminator would grow the heap until the app dies. Past the cap we call it broken.
+    const onExit = vi.fn()
+    const { client, child } = makeClient({ onExit })
+    const pending = client.command('list-panes')
+    child.feed('%begin 1700 1 0\n')
+    child.feed('x'.repeat(MAX_PENDING_BYTES + 1))
+    expect(child.killed).toBe(1)
+    expect(onExit).toHaveBeenCalledTimes(1)
+    expect(client.alive).toBe(false)
+    await expect(pending).rejects.toThrow(/wedged|exited/)
+  })
+  it('does not count healthy traffic towards the flood cap', () => {
+    const { client, child } = makeClient()
+    const line = `%output %1 ${'x'.repeat(1000)}\n`
+    for (let i = 0; i < Math.ceil(MAX_PENDING_BYTES / line.length) + 10; i++) child.feed(line)
+    expect(client.alive).toBe(true)
+    expect(child.killed).toBe(0)
+  })
+})
+
+describe('ControlModeClient with the real child_process spawner', () => {
+  it('reports a tmux binary that cannot be spawned as an exit', async () => {
+    // The default spawner is otherwise untested, and ENOENT is its nastiest path: Node emits 'error'
+    // (which THROWS if unhandled) and may never emit 'exit', so a client without that wiring would
+    // both crash the app and stay "alive" with every command hanging forever.
+    let resolveExit: () => void
+    const exited = new Promise<void>((r) => (resolveExit = r))
+    const client = new ControlModeClient({
+      tmuxBin: '/nonexistent/tmux-does-not-exist',
+      socket: 'node-terminal',
+      sessionName: 'nt-term-1',
+      onOutput: () => {},
+      onExit: () => resolveExit()
+    })
+    client.start()
+    await exited
+    expect(client.alive).toBe(false)
+    await expect(client.command('list-panes')).rejects.toThrow(/not running/)
+  })
+})
+
+describe('ControlModeClient.dispose', () => {
+  it('detaches politely, then kills', () => {
+    const { client, child } = makeClient()
+    client.dispose()
+    expect(child.writes).toEqual(['detach-client\n'])
+    expect(child.killed).toBe(1)
+    expect(client.alive).toBe(false)
+  })
+  it('is idempotent', () => {
+    const { client, child } = makeClient()
+    client.dispose()
+    client.dispose()
+    expect(child.writes).toEqual(['detach-client\n'])
+    expect(child.killed).toBe(1)
+  })
+  it('rejects pending commands but does not report an unexpected exit', async () => {
+    // A swap-out (Task 3) disposes the shadow on purpose; onExit means "the client died on us" and
+    // firing it here would make the owner re-attach the very shadow it just retired.
+    const onExit = vi.fn()
+    const { client, child } = makeClient({ onExit })
+    const pending = client.command('list-panes')
+    client.dispose()
+    child.exit(0)
+    expect(onExit).not.toHaveBeenCalled()
+    await expect(pending).rejects.toThrow(/disposed/)
+  })
+  it('stops delivering output after disposal', () => {
+    const { client, child, out } = makeClient()
+    client.dispose()
+    child.feed('%output %1 late\n')
+    expect(out).toEqual([])
+  })
+})

--- a/src/core/tmux-control-client.ts
+++ b/src/core/tmux-control-client.ts
@@ -1,0 +1,202 @@
+// A tmux control-mode (`-C`) client over plain pipes: process lifecycle + command/reply correlation
+// on top of the pure codec in tmux-control.ts. The point of the whole exercise is the pty device it
+// does NOT hold — `tmux -C attach-session` streams a session's bytes and accepts `send-keys` while
+// allocating zero pty devices, which is what lets an unwatched session stay observable for free.
+//
+// Electron-free by design (src/core is shared with the server edition): the only host dependency is
+// `child_process.spawn`, and it sits behind the `ControlSpawn` seam so tests drive a fake instead.
+
+import { spawn as nodeSpawn } from 'child_process'
+import { StringDecoder } from 'string_decoder'
+import { createControlDecoder, encodeSendKeysHex, type ControlEvent } from './tmux-control'
+
+/**
+ * The child-process seam. Deliberately the smallest surface the client needs — stdout is handed over
+ * as raw Buffers (NEVER a utf8-decoded string; see the ENCODING note in tmux-control.ts) and stderr
+ * is not part of the contract at all.
+ */
+export interface ControlSpawn {
+  spawn(
+    bin: string,
+    args: string[]
+  ): {
+    stdin: { write(s: string): void }
+    stdout: { on(ev: 'data', cb: (b: Buffer) => void): void }
+    on(ev: 'exit', cb: (code: number | null) => void): void
+    kill(): void
+  }
+}
+
+/**
+ * How much stream we accept without the codec completing a single event before we declare the peer
+ * broken. The codec buffers a partial line, and an open `%begin` block's body, without bound — a
+ * tmux that never sends the matching `%end` (or a wedged pipe that never sends a newline) would grow
+ * the heap until the app dies. 8 MiB is orders of magnitude past any reply we issue, so hitting it
+ * means "wedged", not "busy": we tear the client down exactly as if the process had exited.
+ */
+export const MAX_PENDING_BYTES = 8 * 1024 * 1024
+
+/** Real `child_process` wiring. stderr is dropped: nothing reads it, and an unread pipe can block. */
+const realSpawner: ControlSpawn = {
+  spawn(bin, args) {
+    const cp = nodeSpawn(bin, args, { stdio: ['pipe', 'pipe', 'ignore'] })
+    // An unhandled 'error' on a child or its pipes THROWS. Both are reachable in normal operation —
+    // a missing/unrunnable tmux binary (ENOENT), and an EPIPE from writing to a client that just
+    // died — and neither may take the app down. The child's 'error' doubles as an exit report,
+    // because Node does not promise an 'exit' event for a process that never spawned.
+    cp.stdin?.on('error', () => {})
+    cp.stdout?.on('error', () => {})
+    return {
+      // Commands are ASCII, but latin1 keeps the write path byte-exact for anything that is not.
+      stdin: { write: (s: string) => void cp.stdin?.write(s, 'latin1') },
+      stdout: { on: (_ev, cb) => void cp.stdout?.on('data', cb) },
+      on: (_ev, cb) => {
+        cp.on('exit', cb)
+        cp.on('error', () => cb(null))
+      },
+      kill: () => void cp.kill()
+    }
+  }
+}
+
+interface Pending {
+  resolve(r: { ok: boolean; body: string[] }): void
+  reject(e: Error): void
+}
+
+export interface ControlModeClientOpts {
+  tmuxBin: string
+  socket: string
+  sessionName: string
+  /** Pane bytes, UTF-8 decoded and re-assembled across chunk/line boundaries. */
+  onOutput(data: string): void
+  /** The client died on its own (process exit, `%exit`, or wedged peer). Never fires after dispose. */
+  onExit(): void
+  spawner?: ControlSpawn
+}
+
+export class ControlModeClient {
+  private readonly opts: ControlModeClientOpts
+  private readonly spawner: ControlSpawn
+  private readonly decoder = createControlDecoder()
+  /** One UTF-8 decoder per pane: interleaving panes through a shared one would split characters. */
+  private readonly utf8 = new Map<string, StringDecoder>()
+  /** Control mode answers commands IN ORDER, so arrival order is the only correlation there is. */
+  private readonly pending: Pending[] = []
+  private proc: ReturnType<ControlSpawn['spawn']> | null = null
+  private pendingBytes = 0
+  private gone = false
+  private disposed = false
+
+  constructor(opts: ControlModeClientOpts) {
+    this.opts = opts
+    this.spawner = opts.spawner ?? realSpawner
+  }
+
+  /** True between `start()` and the client's death or disposal. */
+  get alive(): boolean {
+    return this.proc !== null && !this.gone && !this.disposed
+  }
+
+  /** Attach: `tmux -L <socket> -C attach-session -t <session>`. Calling twice is a no-op. */
+  start(): void {
+    if (this.proc || this.disposed) return
+    const args = ['-L', this.opts.socket, '-C', 'attach-session', '-t', this.opts.sessionName]
+    this.proc = this.spawner.spawn(this.opts.tmuxBin, args)
+    this.proc.stdout.on('data', (b) => this.onChunk(b))
+    this.proc.on('exit', () => this.die('control-mode client exited'))
+  }
+
+  /** Type `data` into `target` (default: our own session). Resolves false when tmux says `%error`. */
+  async sendKeys(data: string, target = this.opts.sessionName): Promise<boolean> {
+    const { ok } = await this.command(encodeSendKeysHex(target, data))
+    return ok
+  }
+
+  /** Run one control-mode command line. Rejects if the client is not running or dies while waiting. */
+  command(line: string): Promise<{ ok: boolean; body: string[] }> {
+    if (!this.alive || !this.proc) {
+      return Promise.reject(new Error('tmux control-mode client is not running'))
+    }
+    const proc = this.proc
+    return new Promise((resolve, reject) => {
+      // Write BEFORE queueing: a throwing write rejects this promise, and a resolver left in the
+      // FIFO for a command tmux never saw would pair every later reply with the wrong caller.
+      // (Safe ordering — the reply cannot arrive before this synchronous block ends.)
+      proc.stdin.write(`${line}\n`)
+      this.pending.push({ resolve, reject })
+    })
+  }
+
+  /** Detach politely, then kill. Idempotent, and never reports an exit the caller asked for. */
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    const proc = this.proc
+    if (proc && !this.gone) {
+      // `detach-client` lets tmux drop the client cleanly; the kill is the backstop, not the plan.
+      try {
+        proc.stdin.write('detach-client\n')
+      } catch {
+        /* pipe already gone — the kill below is what matters */
+      }
+      try {
+        proc.kill()
+      } catch {
+        /* already dead */
+      }
+    }
+    this.rejectPending(new Error('tmux control-mode client was disposed'))
+  }
+
+  private onChunk(chunk: Buffer): void {
+    if (!this.alive) return
+    // latin1 is byte-exact: tmux escapes only bytes < 0x20 and the backslash, so anything >= 0x80
+    // travels raw and a utf8 decode HERE would mangle it beyond recovery.
+    const text = chunk.toString('latin1')
+    this.pendingBytes += text.length
+    if (this.pendingBytes > MAX_PENDING_BYTES) {
+      this.die(`tmux control-mode client wedged (${MAX_PENDING_BYTES} bytes, no complete event)`)
+      return
+    }
+    const events = this.decoder.push(text)
+    if (events.length > 0) this.pendingBytes = 0
+    for (const ev of events) {
+      this.dispatch(ev)
+      if (!this.alive) return
+    }
+  }
+
+  private dispatch(ev: ControlEvent): void {
+    if (ev.kind === 'output') {
+      // The codec hands back one CHAR per byte; re-assemble to a Buffer and decode UTF-8 with a
+      // streaming decoder so a character split across %output lines survives.
+      let dec = this.utf8.get(ev.paneId)
+      if (!dec) this.utf8.set(ev.paneId, (dec = new StringDecoder('utf8')))
+      const text = dec.write(Buffer.from(ev.data, 'latin1'))
+      if (text) this.opts.onOutput(text)
+    } else if (ev.kind === 'reply') {
+      this.pending.shift()?.resolve({ ok: ev.ok, body: ev.body })
+    } else if (ev.kind === 'exited') {
+      this.die('tmux control-mode client exited')
+    }
+    // 'other' notifications (%session-changed, %window-add, …) carry nothing this client acts on.
+  }
+
+  /** The client died on us: notify once, fail everyone waiting, and make sure the process is gone. */
+  private die(why: string): void {
+    if (this.gone || this.disposed) return
+    this.gone = true
+    try {
+      this.proc?.kill()
+    } catch {
+      /* already dead */
+    }
+    this.rejectPending(new Error(why))
+    this.opts.onExit()
+  }
+
+  private rejectPending(err: Error): void {
+    while (this.pending.length > 0) this.pending.shift()?.reject(err)
+  }
+}

--- a/src/core/tmux-control-client.ts
+++ b/src/core/tmux-control-client.ts
@@ -113,8 +113,19 @@ export class ControlModeClient {
     return ok
   }
 
-  /** Run one control-mode command line. Rejects if the client is not running or dies while waiting. */
+  /**
+   * Run ONE control-mode command line. Every failure arrives as a rejected promise (this class never
+   * throws at the caller): a `line` that is not a single line, a client that is not running, or a
+   * client that dies while the reply is outstanding.
+   */
   command(line: string): Promise<{ ok: boolean; body: string[] }> {
+    if (/[\r\n]/.test(line)) {
+      // The protocol is one command per line and this call queues exactly ONE resolver, so a line
+      // carrying its own newline would run two commands, draw two replies, and pair every later
+      // reply with the wrong caller — permanently, because positional correlation has no timer to
+      // notice. Refusing the input is what keeps that state unreachable.
+      return Promise.reject(new Error('tmux control-mode command must not contain a newline'))
+    }
     if (!this.alive || !this.proc) {
       return Promise.reject(new Error('tmux control-mode client is not running'))
     }

--- a/src/core/tmux-control.test.ts
+++ b/src/core/tmux-control.test.ts
@@ -34,6 +34,23 @@ describe('createControlDecoder', () => {
     const ev = d.push('%begin 100 8 0\nno such session\n%error 100 8 0\n')
     expect(ev).toEqual([{ kind: 'reply', num: 8, ok: false, body: ['no such session'] }])
   })
+  it('keeps a body line that only looks like a terminator inside the reply body', () => {
+    // tmux does NOT escape command output inside a block, so a reply carrying pane text (e.g.
+    // capture-pane) can contain a line spelled exactly like `%end`. Only the OPEN block's ts+num
+    // may close it — otherwise the reply truncates and every later line is parsed one block off.
+    const d = createControlDecoder()
+    const ev = d.push('%begin 100 7 0\n%end 99 6 0\ntail\n%end 100 7 0\n')
+    expect(ev).toEqual([{ kind: 'reply', num: 7, ok: true, body: ['%end 99 6 0', 'tail'] }])
+  })
+  it('does not let a foreign %error close the open block', () => {
+    const d = createControlDecoder()
+    const ev = d.push('%begin 100 7 0\n%error 100 6 0\n%end 100 7 0\n')
+    expect(ev).toEqual([{ kind: 'reply', num: 7, ok: true, body: ['%error 100 6 0'] }])
+  })
+  it('parses CRLF-terminated lines like LF ones, keeping an escaped CR in the payload', () => {
+    const d = createControlDecoder()
+    expect(d.push('%output %3 ab\\015\r\n')).toEqual([{ kind: 'output', paneId: '%3', data: 'ab\r' }])
+  })
   it('reports %exit as exited', () => {
     expect(createControlDecoder().push('%exit\n')).toEqual([{ kind: 'exited' }])
   })

--- a/src/core/tmux-control.test.ts
+++ b/src/core/tmux-control.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { createControlDecoder, decodeOctal, encodeSendKeysHex } from './tmux-control'
+
+describe('decodeOctal', () => {
+  it('decodes tmux %output octal escapes back to bytes', () => {
+    expect(decodeOctal('hello\\012world\\033[31m')).toBe('hello\nworld\x1b[31m')
+  })
+  it('passes plain text through untouched', () => {
+    expect(decodeOctal('just text')).toBe('just text')
+  })
+  it('keeps a literal backslash that is not an octal escape', () => {
+    expect(decodeOctal('a\\\\b')).toBe('a\\b')
+  })
+})
+
+describe('createControlDecoder', () => {
+  it('emits an output event per %output line, pane id preserved', () => {
+    const d = createControlDecoder()
+    const ev = d.push('%output %3 abc\\012\n')
+    expect(ev).toEqual([{ kind: 'output', paneId: '%3', data: 'abc\n' }])
+  })
+  it('buffers partial lines across pushes', () => {
+    const d = createControlDecoder()
+    expect(d.push('%output %3 ab')).toEqual([])
+    expect(d.push('c\n')).toEqual([{ kind: 'output', paneId: '%3', data: 'abc' }])
+  })
+  it('collects a %begin/%end block into one ok reply with its body', () => {
+    const d = createControlDecoder()
+    const ev = d.push('%begin 100 7 0\nline1\nline2\n%end 100 7 0\n')
+    expect(ev).toEqual([{ kind: 'reply', num: 7, ok: true, body: ['line1', 'line2'] }])
+  })
+  it('collects a %begin/%error block into one failed reply', () => {
+    const d = createControlDecoder()
+    const ev = d.push('%begin 100 8 0\nno such session\n%error 100 8 0\n')
+    expect(ev).toEqual([{ kind: 'reply', num: 8, ok: false, body: ['no such session'] }])
+  })
+  it('reports %exit as exited', () => {
+    expect(createControlDecoder().push('%exit\n')).toEqual([{ kind: 'exited' }])
+  })
+  it('passes unknown notifications through as other', () => {
+    expect(createControlDecoder().push('%session-changed $1 nt-x\n'))
+      .toEqual([{ kind: 'other', line: '%session-changed $1 nt-x' }])
+  })
+})
+
+describe('encodeSendKeysHex', () => {
+  it('encodes bytes as hex send-keys arguments', () => {
+    expect(encodeSendKeysHex('nt-term-1', 'ls\n')).toBe('send-keys -t nt-term-1 -H 6c 73 0a')
+  })
+  it('encodes multi-byte UTF-8 per byte', () => {
+    expect(encodeSendKeysHex('s', 'ç')).toBe('send-keys -t s -H c3 a7')
+  })
+})

--- a/src/core/tmux-control.ts
+++ b/src/core/tmux-control.ts
@@ -4,6 +4,13 @@
 // Protocol: notifications are %-prefixed lines; command replies arrive as a
 // `%begin <ts> <num> <flags>` … body … `%end|%error <ts> <num> <flags>` block; `%output %<pane> <data>`
 // carries raw pane bytes with non-printables as \ooo octal escapes.
+//
+// ENCODING (hard requirement on the client): feed this decoder LATIN1-decoded chunks — read the
+// tmux process stream as 'latin1'/'binary' (or decode Buffers with latin1), never `setEncoding('utf8')`.
+// tmux escapes only bytes < 0x20 and the backslash; every byte >= 0x80 rides the channel RAW, so a
+// UTF-8 decode of the transport silently mangles them (a `ç` split across two chunks becomes U+FFFD
+// and is unrecoverable). Latin1 is lossless byte↔char, which is what makes `decodeOctal`'s
+// byte-per-char output re-assemblable into correct UTF-8 downstream.
 
 export type ControlEvent =
   | { kind: 'output'; paneId: string; data: string }
@@ -16,6 +23,9 @@ export type ControlEvent =
  * byte-per-char string (latin1-style), not decoded UTF-8: a `ç` arrives as `\303\247` and comes back
  * as two chars. The caller re-assembles bytes before handing them to a UTF-8 decoder, which is also
  * what makes split multi-byte sequences across chunks survive.
+ *
+ * That contract holds ONLY for latin1-decoded input (see the ENCODING note at the top of the file):
+ * unescaped high bytes must have survived the transport one-char-per-byte to be re-assembled here.
  */
 export function decodeOctal(s: string): string {
   return s.replace(/\\(\d{3}|\\)/g, (_, esc: string) =>
@@ -35,11 +45,13 @@ export function encodeSendKeysHex(target: string, data: string): string {
 
 /**
  * A stateful line splitter over the control-mode stream. `push` takes an arbitrary chunk (partial
- * lines are held until their newline arrives) and returns the events it completed.
+ * lines are held until their newline arrives) and returns the events it completed. Chunks MUST be
+ * latin1-decoded — see the ENCODING note at the top of the file.
  */
 export function createControlDecoder(): { push(chunk: string): ControlEvent[] } {
   let buf = ''
-  let block: { num: number; body: string[] } | null = null
+  // ts+num are kept as the RAW strings from `%begin` so the terminator can be matched literally.
+  let block: { ts: string; num: string; body: string[] } | null = null
   return {
     push(chunk: string): ControlEvent[] {
       buf += chunk
@@ -49,20 +61,27 @@ export function createControlDecoder(): { push(chunk: string): ControlEvent[] } 
         const line = buf.slice(0, nl).replace(/\r$/, '')
         buf = buf.slice(nl + 1)
         if (block) {
-          // The terminator repeats the command number; tmux cannot interleave blocks, so the open
-          // block's own num stays authoritative and only end-vs-error decides success.
-          const done = line.match(/^%(end|error) \d+ \d+ \d+$/)
-          if (done) {
-            out.push({ kind: 'reply', num: block.num, ok: done[1] === 'end', body: block.body })
+          // Command output inside a block is NOT escaped by tmux, so a body line can be spelled
+          // exactly like a terminator (capture-pane of a screen showing one, say). Only a terminator
+          // repeating this block's own ts AND num closes it; anything else is body. Without that
+          // guard the reply truncates and every following line is parsed one block out of phase.
+          const done = line.match(/^%(end|error) (\d+) (\d+) \d+$/)
+          if (done && done[2] === block.ts && done[3] === block.num) {
+            out.push({
+              kind: 'reply',
+              num: Number(block.num),
+              ok: done[1] === 'end',
+              body: block.body
+            })
             block = null
           } else {
             block.body.push(line)
           }
           continue
         }
-        const begin = line.match(/^%begin \d+ (\d+) \d+$/)
+        const begin = line.match(/^%begin (\d+) (\d+) \d+$/)
         if (begin) {
-          block = { num: Number(begin[1]), body: [] }
+          block = { ts: begin[1], num: begin[2], body: [] }
         } else if (line.startsWith('%output ')) {
           const m = line.match(/^%output (%\d+) (.*)$/s)
           if (m) out.push({ kind: 'output', paneId: m[1], data: decodeOctal(m[2]) })

--- a/src/core/tmux-control.ts
+++ b/src/core/tmux-control.ts
@@ -1,0 +1,79 @@
+// Pure tmux control-mode (-C) protocol codec. No I/O here — the client (tmux-control-client.ts)
+// owns the process; this file owns the line protocol, so every parsing rule is unit-testable.
+//
+// Protocol: notifications are %-prefixed lines; command replies arrive as a
+// `%begin <ts> <num> <flags>` … body … `%end|%error <ts> <num> <flags>` block; `%output %<pane> <data>`
+// carries raw pane bytes with non-printables as \ooo octal escapes.
+
+export type ControlEvent =
+  | { kind: 'output'; paneId: string; data: string }
+  | { kind: 'reply'; num: number; ok: boolean; body: string[] }
+  | { kind: 'exited' }
+  | { kind: 'other'; line: string }
+
+/**
+ * Undo tmux's `\ooo` escaping of an `%output` payload. One escape is one BYTE, so the result is a
+ * byte-per-char string (latin1-style), not decoded UTF-8: a `ç` arrives as `\303\247` and comes back
+ * as two chars. The caller re-assembles bytes before handing them to a UTF-8 decoder, which is also
+ * what makes split multi-byte sequences across chunks survive.
+ */
+export function decodeOctal(s: string): string {
+  return s.replace(/\\(\d{3}|\\)/g, (_, esc: string) =>
+    esc === '\\' ? '\\' : String.fromCharCode(parseInt(esc, 8))
+  )
+}
+
+/**
+ * A `send-keys` command line that types `data` into `target`. Hex (`-H`) because a control-mode
+ * command must fit on ONE text line: it sidesteps every quoting/UTF-8 hazard that `-l` literal mode
+ * would need shell-grade escaping for.
+ */
+export function encodeSendKeysHex(target: string, data: string): string {
+  const bytes = [...Buffer.from(data, 'utf8')].map((b) => b.toString(16).padStart(2, '0'))
+  return `send-keys -t ${target} -H ${bytes.join(' ')}`
+}
+
+/**
+ * A stateful line splitter over the control-mode stream. `push` takes an arbitrary chunk (partial
+ * lines are held until their newline arrives) and returns the events it completed.
+ */
+export function createControlDecoder(): { push(chunk: string): ControlEvent[] } {
+  let buf = ''
+  let block: { num: number; body: string[] } | null = null
+  return {
+    push(chunk: string): ControlEvent[] {
+      buf += chunk
+      const out: ControlEvent[] = []
+      let nl: number
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).replace(/\r$/, '')
+        buf = buf.slice(nl + 1)
+        if (block) {
+          // The terminator repeats the command number; tmux cannot interleave blocks, so the open
+          // block's own num stays authoritative and only end-vs-error decides success.
+          const done = line.match(/^%(end|error) \d+ \d+ \d+$/)
+          if (done) {
+            out.push({ kind: 'reply', num: block.num, ok: done[1] === 'end', body: block.body })
+            block = null
+          } else {
+            block.body.push(line)
+          }
+          continue
+        }
+        const begin = line.match(/^%begin \d+ (\d+) \d+$/)
+        if (begin) {
+          block = { num: Number(begin[1]), body: [] }
+        } else if (line.startsWith('%output ')) {
+          const m = line.match(/^%output (%\d+) (.*)$/s)
+          if (m) out.push({ kind: 'output', paneId: m[1], data: decodeOctal(m[2]) })
+        } else if (line === '%exit' || line.startsWith('%exit ')) {
+          out.push({ kind: 'exited' })
+        } else if (line.startsWith('%')) {
+          out.push({ kind: 'other', line })
+        }
+        // Non-% lines outside a block: tmux sends none in -C; drop silently.
+      }
+      return out
+    }
+  }
+}

--- a/src/core/tmux-naming.ts
+++ b/src/core/tmux-naming.ts
@@ -7,3 +7,18 @@ export const TMUX_SOCKET = 'node-terminal'
 export function sessionName(persistKey: string): string {
   return `nt-${persistKey.replace(/[^a-zA-Z0-9_-]/g, '_')}`
 }
+
+/**
+ * Is this a tmux target THIS app generated (i.e. the output of `sessionName` for some node id)?
+ *
+ * The check exists for the one caller that cannot quote: a tmux control-mode command is a single
+ * text line and `encodeSendKeysHex` interpolates its target into it UNQUOTED, so a target carrying
+ * a space would split into the wrong arguments and one carrying a newline would run a second
+ * command. `sessionName` already sanitizes everything outside `[A-Za-z0-9_-]` away, so this can only
+ * fail on a name that did not come from it — an empty node id, or a raw target somebody passed in.
+ * Refusing there is cheap; the alternative is a shell-grade escaping problem on a line that reaches
+ * a tmux server with every session on it.
+ */
+export function isSessionName(target: string): boolean {
+  return /^nt-[A-Za-z0-9_-]+$/.test(target)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1525,7 +1525,13 @@ app.whenReady().then(async () => {
   // budget). Attached sessions are never touched; a reaped node cold-restores on next open.
   // Local sockets only — a remote SSH host's sessions are reaped by that host's own
   // nodeterm-server, never across the wire. Timer is unref'd; no explicit stop needed.
-  createSessionReaper({ tmuxBin: () => ptyManager.getTmuxBin() }).start()
+  // `shadowed` subtracts our own control-mode shadows from tmux's attached flag: a shadow is a real
+  // tmux client but NOT a watcher, so a shadowed session must stay exactly as cullable as an idle
+  // detached one (see PtyManager.shadowedTmuxSessions).
+  createSessionReaper({
+    tmuxBin: () => ptyManager.getTmuxBin(),
+    shadowed: (socket) => ptyManager.shadowedTmuxSessions(socket)
+  }).start()
   const ackSweeper = createAckSweeper({
     handlers: { ackDone, onUnreadClear: (id) => sendToMain(IPC.agentUnreadClear, id) }
   })

--- a/src/main/remote/remote-security.test.ts
+++ b/src/main/remote/remote-security.test.ts
@@ -2,6 +2,8 @@
 //   R1 — host serves no `pty.create`; `fs.*` is confined to the shared roots.
 //   R2 — the channel SAS is deterministic + identical on both peers.
 //   R3 — replayed/reordered encrypted boxes are dropped (per-direction monotonic counter).
+//   R4 — killing a stream forgets it in the SAME synchronous turn, so a late Input frame for that
+//        streamId can never be written into a session that is already released.
 import { describe, expect, it, vi } from 'vitest'
 import { createHostHandlers, type HostFsOps, type HostPtyManager, type HostRelaySocket } from './host-service'
 import { genKeyPair, deriveSharedKey, sasFromSharedKey, publicKeyToB64 } from './e2ee'
@@ -248,5 +250,74 @@ describe('pty.scroll drives tmux through the session pty', () => {
     handlers.onRpc({ id: '3', method: 'pty.scroll', params: { streamId: 99, dir: 'up', lines: 2 } })
     expect(pty.write).not.toHaveBeenCalled()
     expect(responses.at(-1)).toMatchObject({ id: '3', ok: true })
+  })
+})
+
+// --- R4: kill → dropStream is ONE synchronous step ---------------------------
+
+// The invariant: a client's Input frame must never be written into a session the host has already
+// released. Nothing enforces that but the ADJACENCY of two statements — `pty.kill(null, sessionId)`
+// and the `dropStream` that forgets the streamId (handleKill; closeAll's `streams.clear()`). Put any
+// yield between them and every frame the relay delivers in that window is written into a session on
+// its way out (and, once a session is released, a background write can re-reach its tmux pane).
+//
+// So these tests pin the adjacency rather than the outcome: the late frame is queued as a microtask
+// BEFORE the kill turn runs, which is exactly the window an `await` between the two statements would
+// open. They pass only while the drop is synchronous with the kill.
+function inputFrame(streamId: number, data: string): Frame {
+  return { op: OP.Input, streamId, seq: 0, payload: new TextEncoder().encode(data) }
+}
+
+/** Attach a stream (id = n-th attach) and settle the async capture → attachDetached handoff. */
+async function attachStream(
+  handlers: ReturnType<typeof createHostHandlers>,
+  nodeId: string
+): Promise<void> {
+  handlers.onRpc({ id: `a-${nodeId}`, method: 'pty.attach', params: { nodeId, cols: 80, rows: 24 } })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('R4: a killed stream stops accepting input in the same turn', () => {
+  it('drops an Input frame that lands one microtask after pty.kill', async () => {
+    const { socket, fs, pty } = makeHostFakes()
+    const writeMock = pty.write as ReturnType<typeof vi.fn>
+    const handlers = createHostHandlers(pty, socket, fs, () => ['/work'])
+    await attachStream(handlers, 'node-a')
+
+    // Control: while the stream lives, this exact frame IS written — so a later "not written"
+    // cannot be an artifact of a wrong streamId or an attach that never completed.
+    handlers.onFrame(inputFrame(1, 'echo live\n'))
+    expect(writeMock).toHaveBeenCalledWith(null, 'sess', 'echo live\n')
+    writeMock.mockClear()
+
+    // Queue the frame FIRST: its microtask runs immediately after the kill's synchronous turn,
+    // i.e. inside the gap any `await` between kill() and dropStream() would create.
+    const late = Promise.resolve().then(() => handlers.onFrame(inputFrame(1, 'echo late\n')))
+    handlers.onRpc({ id: 'k', method: 'pty.kill', params: { streamId: 1 } })
+    expect(pty.kill).toHaveBeenCalledWith(null, 'sess')
+    await late
+
+    expect(writeMock).not.toHaveBeenCalled()
+  })
+
+  it('drops Input frames for every stream that closeAll killed', async () => {
+    const { socket, fs, pty } = makeHostFakes()
+    const writeMock = pty.write as ReturnType<typeof vi.fn>
+    const handlers = createHostHandlers(pty, socket, fs, () => ['/work'])
+    await attachStream(handlers, 'node-a')
+    await attachStream(handlers, 'node-b')
+    handlers.onFrame(inputFrame(2, 'echo live\n')) // control: stream 2 is real and routable
+    expect(writeMock).toHaveBeenCalledTimes(1)
+    writeMock.mockClear()
+
+    const late = Promise.resolve().then(() => {
+      handlers.onFrame(inputFrame(1, 'echo late\n'))
+      handlers.onFrame(inputFrame(2, 'echo late\n'))
+    })
+    handlers.closeAll()
+    expect(pty.kill).toHaveBeenCalledTimes(2)
+    await late
+
+    expect(writeMock).not.toHaveBeenCalled()
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -440,7 +440,13 @@ export async function startServer(
   // and this standing process is the natural owner of reaping them (field report: 95 sessions /
   // 34 GB idle claude). Attached sessions are never touched; a reaped node cold-restores on next
   // open. Kill switch + tuning via NODETERM_SESSION_* env (core/session-budget.ts).
-  const sessionReaper = createSessionReaper({ tmuxBin: () => ptyManager.getTmuxBin() })
+  // `shadowed` subtracts our own control-mode shadows from tmux's attached flag: a shadow is a real
+  // tmux client but NOT a watcher, so a shadowed session must stay exactly as cullable as an idle
+  // detached one (see PtyManager.shadowedTmuxSessions).
+  const sessionReaper = createSessionReaper({
+    tmuxBin: () => ptyManager.getTmuxBin(),
+    shadowed: (socket) => ptyManager.shadowedTmuxSessions(socket)
+  })
   sessionReaper.start()
 
   // Headless notification host: every core service above (incl. the loopback hook server, which

--- a/src/shared/default-settings.test.ts
+++ b/src/shared/default-settings.test.ts
@@ -6,6 +6,13 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.gitAutoFetch).toBe(true)
   })
 
+  it('ships pty shadow clients ON, so the kill switch is a real one', () => {
+    // Default OFF would mean the mechanism never runs in the field and the flag proves nothing;
+    // default ON means a field report can be answered with "turn it off", and that instruction
+    // reaches existing installs through the { ...DEFAULT_SETTINGS, ...saved } merge.
+    expect(DEFAULT_SETTINGS.ptyShadowClients).toBe(true)
+  })
+
   it('defaults to auto permission mode for new and existing users', () => {
     // Deliberate behavior change: auto mode ensures Claude sessions start with
     // permission auto-grants enabled. This reaches existing users via

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -834,6 +834,20 @@ export interface Settings {
   browserMemorySaver: boolean
   accent: string
   tmuxEnabled: boolean
+  /**
+   * Reach a released tmux session with a control-mode (`tmux -C`) client instead of respawning its
+   * terminal — the shadow clients in pty-manager.ts (`shadowAttach`) and the shared background-write
+   * client behind `backgroundWrite`. A control client holds ZERO pty devices, which is the whole
+   * point: the machine-wide `kern.tty.ptmx_max` ceiling is what a canvas of idle terminals runs into
+   * first (see pty-devices.ts).
+   *
+   * ON by default, and read at those two entry points only: switching it off means this process
+   * spawns no `tmux -C` child at all, and a released session is simply unreachable again — exactly
+   * the behavior of the release before it. It is a kill switch for one soak release, not a feature
+   * toggle: nothing user-visible depends on it (the mechanism has no production caller yet), so it
+   * has no settings row and is flipped in settings.json.
+   */
+  ptyShadowClients: boolean
   /** GPU (WebGL) terminal rendering. 'off' routes every terminal to xterm's DOM renderer.
    *  'auto' (default) = one WebGL context PER TERMINAL everywhere except macOS, where it is
    *  'shared'. Repeated macOS field reports (whole-window flicker; terminals compositing black
@@ -989,6 +1003,7 @@ export const DEFAULT_SETTINGS: Settings = {
   browserMemorySaver: true,
   accent: '#0a84ff',
   tmuxEnabled: true,
+  ptyShadowClients: true,
   terminalGpuRendering: 'auto',
   tmuxScrollback: 50000,
   offscreenTerminalMinutes: 10,


### PR DESCRIPTION
## Summary

Infrastructure for **pty-free background terminal access**: a released (unwatched) tmux session can now be observed and written to through a `tmux -C` control-mode client over plain pipes — **zero pty devices** — instead of respawning a painter client. Follow-up to the pty-exhaustion incident (kern.tty.ptmx_max, 2026-08-11) on top of the merged spawn-diagnosis + idle-reap work.

- `src/core/tmux-control.ts` — pure control-mode protocol codec (octal `%output` decode, `%begin/%end` reply blocks matched on ts+num, hex `send-keys` encoding); latin1 transport contract documented
- `src/core/tmux-control-client.ts` — `ControlModeClient` process wrapper: FIFO reply correlation, per-pane UTF-8 reassembly, 8MiB no-progress cap, newline-injection guard, injectable spawn seam
- `PtyManager`: per-session shadows (`shadowAttach`/`shadowCommand`, 5s command timeout), background writes (`backgroundWrite` tiering painter → shadow → one shared server-wide client with a 10s linger), session-budget integration (shadows subtracted from `session_attached` as a numeric count so a genuinely-attached session is never mis-culled)
- `ptyShadowClients` kill switch (default ON), greppable swap logs, host-side `kill→dropStream` adjacency pinned by tests
- Ships **dark**: no production caller yet (adjudicated: the relay path cannot reach it — pinned by test). First consumer is a separate product decision; standing obligation recorded in-code: wire-cost probe or `refresh-client -f no-output` before any first caller.

## Process

Plan-driven (plan committed in-branch at `docs/superpowers/plans/2026-08-11-tmux-control-mode-shadow-clients.md`), 5 tasks × independent review, 5 fix rounds, 2 adjudications; findings closed with mutation-verified tests (86 new tests). Review loop caught 3 real bugs pre-merge: budget-reaper exemption via `session_attached`, boolean-subtraction mis-cull, FIFO newline desync.

## Test plan

- Full suite: 4699 passed / 8 skipped; typecheck clean (known env-bound `server-e2e` real-pty failure reproduces on the base commit in the worktree environment; verified green expectation on main checkout post-merge)
- GUI smoke list written (task-5 report), deliberately unrun while the mechanism is dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01No8UHtXZ9eNwkQ2BZPh6Xf