### PR TITLE
feat: opt-in agent hibernation (Eco) — exit idle offscreen CLIs, resume on view

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7042,7 +7042,18 @@ export function Canvas() {
           break
         case 'session':
           if (e.sessionTitle) cs.setSession(e.nodeId, e.sessionTitle)
-          if (e.sessionPhase === 'start') cs.setState(e.nodeId, undefined, e.agentId)
+          if (e.sessionPhase === 'start') {
+            cs.setState(e.nodeId, undefined, e.agentId)
+            // A SessionStart is proof a CLI just LAUNCHED in that pane, so a hibernated flag on
+            // this node is now false — our own `/exit` produces a SessionEnd, never a
+            // SessionStart. This is the residual `setState`'s live-state self-heal cannot reach:
+            // a user who relaunches the agent by hand and then takes no turn would keep a SLEEPING
+            // chip on a running CLI (and the sweep, which skips hibernated nodes, would leave that
+            // session exempt from Eco for good). Deliberately NOT the same as clearing on `done`,
+            // which would let a late Stop POST undo a hibernation we just performed. The setter
+            // bails when the flag is already unset, so this is free for every other session start.
+            cs.setHibernated(e.nodeId, false)
+          }
           if (e.sessionPhase === 'end') {
             cs.setState(e.nodeId, undefined, e.agentId)
             // In-session /loop dies with its session; cron (and scheduled cloud routines)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -28,7 +28,9 @@ import {
   disposeTerminalOnUnmount,
   disposeParkedTerminal,
   disposeAllParkedTerminals,
-  isNodeOffscreen,
+  isNodeRemote,
+  isNodeWatched,
+  setWatchedNode,
   wakeHibernatedNode
 } from '../nodes/TerminalNode'
 import { solveFitPadding } from './fit-view'
@@ -5441,6 +5443,10 @@ export function Canvas() {
   // whole board on every Canvas render.
   const setKanbanModalNode = useCallback((id: string | null) => {
     kanbanModalNodeRef.current = id
+    // The one place the "is anyone looking at this session" predicate learns about the modal —
+    // every asker (the sweep's plan, the node's fire-time re-ask, the nudge) reads it through
+    // `isNodeWatched`, so the modal clause cannot go missing from one of them.
+    setWatchedNode(id)
     // Opening a card IS opening the session — the second way in, and the one the canvas
     // visibility observer says nothing about. A hibernated node reached this way resumes its
     // conversation just as it would on a pan-back, instead of showing the bare shell it was
@@ -7115,16 +7121,14 @@ export function Canvas() {
             parentNodeId: v.parentNodeId,
             status: v.state
           })),
-          // The nodes' own visibility observers (Phase 2's) are the authority — never a second
-          // observer here, and "we have not heard" is never read as "nobody is looking".
-          //
-          // …with ONE override the observers structurally cannot know about: a kanban card modal
-          // co-attaches the same tmux session over a canvas nobody can see, so its node is
-          // off-screen by every measurement and yet is the one session the user is looking at.
-          // Quitting the CLI under an open modal is the same intrusion as quitting it under the
-          // node itself.
-          isOffscreen: (nodeId) =>
-            nodeId !== kanbanModalNodeRef.current && isNodeOffscreen(nodeId),
+          // `isNodeWatched` is the ONE predicate for "the user is looking at this session" — the
+          // nodes' own visibility observers (Phase 2's) plus the open card modal, which no
+          // observer can see (it co-attaches the same tmux session over a canvas nobody is
+          // looking at). The node's exit closure re-asks the SAME function at fire time.
+          isOffscreen: (nodeId) => !isNodeWatched(nodeId),
+          // Remote (SSH / relay) sessions are excluded in v1 — here rather than only at the exit,
+          // or two of them could occupy both batch slots on every pass (see the policy).
+          isRemote: isNodeRemote,
           // Wired = mounted with a live terminal that registered its hibernate pair. An
           // offscreen-DISPOSED node (Phase 2) has already given its buffer back and has no pane
           // to quit, so it drops out here.
@@ -7149,9 +7153,7 @@ export function Canvas() {
               // EDGE has passed, so no wake trigger is left and the node would sit SLEEPING in
               // front of the user. Nudge it: the node re-reads the flag itself, so this is a
               // no-op wherever the user did not arrive.
-              if (!isNodeOffscreen(nodeId) || nodeId === kanbanModalNodeRef.current) {
-                wakeHibernatedNode(nodeId)
-              }
+              if (isNodeWatched(nodeId)) wakeHibernatedNode(nodeId)
             }
             // 'exit-timeout' / 'not-eligible': the CLI is still running and NOTHING is recorded —
             // marking it hibernated would put a SLEEPING chip on a live session and suppress the

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -27,7 +27,8 @@ import {
   setSshRetryHandler,
   disposeTerminalOnUnmount,
   disposeParkedTerminal,
-  disposeAllParkedTerminals
+  disposeAllParkedTerminals,
+  isNodeOffscreen
 } from '../nodes/TerminalNode'
 import { solveFitPadding } from './fit-view'
 import {
@@ -157,6 +158,7 @@ import { SshPassphrasePrompt } from '../components/SshPassphrasePrompt'
 import { transport } from '../terminal/local-transport'
 import { sshFs } from '../terminal/ssh-fs'
 import {
+  agentHibernateFns,
   agentRestartFn,
   planBulkRestart,
   restartEligibility,
@@ -165,6 +167,8 @@ import {
   type BulkRestartPlan,
   type RestartOutcome
 } from '../terminal/agent-restart'
+import { planHibernation, HIBERNATE_SWEEP_MS } from '../terminal/hibernation-policy'
+import { buildHibernationCandidates } from '../lib/hibernationCandidates'
 import { prepareQuickOpenFiles, type QuickOpenIndexedFile } from '../lib/quickOpenSearch'
 import { opensInEditor } from '../lib/openTarget'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
@@ -1137,7 +1141,9 @@ export function Canvas() {
     let sig = ''
     for (const [id, st] of Object.entries(s.byId)) {
       if (!st.loop) continue
-      sig += `${id}|${st.loop.kind ?? ''}|${st.loop.count}|${st.loop.items?.length ?? 0}|${st.loop.task ?? ''}|${st.loop.schedule ?? ''}|${st.state === 'working' ? 1 : 0}|`
+      // `dismissed` rides the signature (it is what the card derivation filters on), so the ×
+      // removes the card on the next render rather than waiting for some other loop change.
+      sig += `${id}|${st.loop.kind ?? ''}|${st.loop.count}|${st.loop.items?.length ?? 0}|${st.loop.task ?? ''}|${st.loop.schedule ?? ''}|${st.state === 'working' ? 1 : 0}|${st.loop.dismissed ? 1 : 0}|`
     }
     return sig
   })
@@ -1222,7 +1228,10 @@ export function Canvas() {
     const eEdges: Edge[] = []
     // Loop nodes: one per terminal node currently running a /loop, placed below-left.
     for (const [pid, st] of Object.entries(claudeById)) {
-      if (!st.loop) continue
+      // A DISMISSED cron/schedule entry is kept on purpose (it is the hibernation guard's only
+      // evidence that a wakeup is pending — see agentStatus's `loop.dismissed`), so the filter
+      // lives here, in the render layer, and nowhere else.
+      if (!st.loop || st.loop.dismissed) continue
       const parent = nodes.find((n) => n.id === pid)
       if (!parent) continue
       const ph = parent.measured?.height ?? (parent.height as number) ?? 400
@@ -7048,6 +7057,86 @@ export function Canvas() {
     const t = setInterval(() => useAgentStatus.getState().sweepStaleWorking(), 60_000)
     return () => clearInterval(t)
   }, [])
+
+  /**
+   * ECO — hibernate idle, offscreen agent CLIs (`settings.agentHibernationEnabled`, off by
+   * default). The CLI is asked to `/exit` and its conversation is resumed (`--resume`) the next
+   * time the node is looked at; the tmux session, its pane and its scrollback are untouched. What
+   * is reclaimed is the agent process's RAM, which on a canvas of a dozen sessions is most of it.
+   *
+   * Every DECISION is in the pure `planHibernation`, and every FACT it reads is assembled by the
+   * pure `buildHibernationCandidates` — deliberately not inline here, because two of those facts
+   * (a dismissed cron card is still recurring; an unfinished subagent pins its parent) are the
+   * difference between Eco mode and a silently cancelled job, and an inline `.map()` is where a
+   * rule like that rots untested.
+   *
+   * Nothing is retried and nothing is remembered: an outcome other than `'exited'` simply leaves
+   * the node alone, and the next sweep re-asks with fresh facts. The batch cap lives in the policy.
+   */
+  const hibernationEnabled = useSettings((s) => s.settings.agentHibernationEnabled)
+  useEffect(() => {
+    if (!hibernationEnabled) return
+    let stopped = false
+    let sweeping = false
+    const sweep = async (): Promise<void> => {
+      // One sweep at a time. Each exit waits on a real pane (up to RESTART_EXIT_TIMEOUT_MS), so a
+      // slow pass can outlive its interval; overlapping passes would only be refused by the
+      // per-node guard, but re-planning against half-applied state is noise nobody needs.
+      if (sweeping) return
+      sweeping = true
+      try {
+        const s = useSettings.getState().settings
+        const candidates = buildHibernationCandidates({
+          nodes: nodesRef.current
+            .filter((n) => n.type === 'terminal')
+            .map((n) => ({ id: n.id, agentId: createdAgentId(n.data) })),
+          statusById: useAgentStatus.getState().byId,
+          // Any card that has not finished pins its parent — see the adapter's header.
+          subagents: Object.values(useAgentNodes.getState().byId).map((v) => ({
+            parentNodeId: v.parentNodeId,
+            status: v.state
+          })),
+          // The nodes' own visibility observers (Phase 2's) are the authority — never a second
+          // observer here, and "we have not heard" is never read as "nobody is looking".
+          isOffscreen: isNodeOffscreen,
+          // Wired = mounted with a live terminal that registered its hibernate pair. An
+          // offscreen-DISPOSED node (Phase 2) has already given its buffer back and has no pane
+          // to quit, so it drops out here.
+          isWired: (nodeId) => !!agentHibernateFns(nodeId)
+        })
+        const ids = planHibernation(candidates, Date.now(), {
+          enabled: s.agentHibernationEnabled,
+          idleMinutes: s.agentHibernationIdleMinutes
+        })
+        // Sequential, like the bulk restart: each exit is a real conversation being asked to quit
+        // in a real pane, and the cap keeps the pass short.
+        for (const nodeId of ids) {
+          if (stopped) return
+          const fns = agentHibernateFns(nodeId)
+          if (!fns) continue // unmounted between the plan and its turn
+          try {
+            if ((await fns.exit()) === 'exited') {
+              useAgentStatus.getState().setHibernated(nodeId, true)
+            }
+            // 'exit-timeout' / 'not-eligible': the CLI is still running and NOTHING is recorded —
+            // marking it hibernated would put a SLEEPING chip on a live session and suppress the
+            // wake's only trigger. The next sweep re-evaluates.
+          } catch (err) {
+            // The writes go unguarded down to the socket; one node's throw must not abandon the
+            // rest of the pass (nor the interval).
+            console.warn('[hibernate] exit failed for', nodeId, err)
+          }
+        }
+      } finally {
+        sweeping = false
+      }
+    }
+    const t = setInterval(() => void sweep(), HIBERNATE_SWEEP_MS)
+    return () => {
+      stopped = true
+      clearInterval(t)
+    }
+  }, [hibernationEnabled])
 
   // When the palette opens, capture each terminal's visible buffer (cached ~3s) so the
   // search can match text shown in terminals/Claude sessions.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -28,7 +28,8 @@ import {
   disposeTerminalOnUnmount,
   disposeParkedTerminal,
   disposeAllParkedTerminals,
-  isNodeOffscreen
+  isNodeOffscreen,
+  wakeHibernatedNode
 } from '../nodes/TerminalNode'
 import { solveFitPadding } from './fit-view'
 import {
@@ -169,6 +170,7 @@ import {
 } from '../terminal/agent-restart'
 import { planHibernation, HIBERNATE_SWEEP_MS } from '../terminal/hibernation-policy'
 import { buildHibernationCandidates } from '../lib/hibernationCandidates'
+import { applyLoopDismiss } from '../lib/loopCard'
 import { prepareQuickOpenFiles, type QuickOpenIndexedFile } from '../lib/quickOpenSearch'
 import { opensInEditor } from '../lib/openTarget'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
@@ -5016,15 +5018,15 @@ export function Canvas() {
       ...(isLoop
         ? ([
             {
-              // Same as the card's own ×: drops the CARD, never the cron/schedule job itself.
+              // Same as the card's own ×: drops the CARD, never the cron/schedule job itself —
+              // and literally the same code path (`applyLoopDismiss`), because these two surfaces
+              // are one user action and had already drifted apart once: this one cleared the
+              // durable `loop` entry, which is the only thing keeping Eco mode from quitting the
+              // CLI a live cron was going to fire in.
               label: 'Dismiss card',
               icon: <IconTrash />,
               danger: true,
-              onClick: () => {
-                const pid = id.slice('loop-'.length)
-                useAgentStatus.getState().setLoop(pid, false)
-                useAgentNodes.getState().clearLoop(pid)
-              }
+              onClick: () => applyLoopDismiss(id.slice('loop-'.length))
             }
           ] as MenuItem[])
         : [])
@@ -5439,6 +5441,12 @@ export function Canvas() {
   // whole board on every Canvas render.
   const setKanbanModalNode = useCallback((id: string | null) => {
     kanbanModalNodeRef.current = id
+    // Opening a card IS opening the session — the second way in, and the one the canvas
+    // visibility observer says nothing about. A hibernated node reached this way resumes its
+    // conversation just as it would on a pan-back, instead of showing the bare shell it was
+    // exited to with nothing on screen to explain it. No-op for every node that is not
+    // hibernated (the node re-reads the flag itself).
+    if (id) wakeHibernatedNode(id)
   }, [])
 
   const onPaletteQuery = useCallback((q: string) => {
@@ -7098,7 +7106,14 @@ export function Canvas() {
           })),
           // The nodes' own visibility observers (Phase 2's) are the authority — never a second
           // observer here, and "we have not heard" is never read as "nobody is looking".
-          isOffscreen: isNodeOffscreen,
+          //
+          // …with ONE override the observers structurally cannot know about: a kanban card modal
+          // co-attaches the same tmux session over a canvas nobody can see, so its node is
+          // off-screen by every measurement and yet is the one session the user is looking at.
+          // Quitting the CLI under an open modal is the same intrusion as quitting it under the
+          // node itself.
+          isOffscreen: (nodeId) =>
+            nodeId !== kanbanModalNodeRef.current && isNodeOffscreen(nodeId),
           // Wired = mounted with a live terminal that registered its hibernate pair. An
           // offscreen-DISPOSED node (Phase 2) has already given its buffer back and has no pane
           // to quit, so it drops out here.
@@ -7117,6 +7132,15 @@ export function Canvas() {
           try {
             if ((await fns.exit()) === 'exited') {
               useAgentStatus.getState().setHibernated(nodeId, true)
+              // A batch can take ~12 s, and the user may have arrived during it. The node's own
+              // exit closure re-checks visibility before writing anything, but the pan can also
+              // land in the window between that check and this line — and by then the visible
+              // EDGE has passed, so no wake trigger is left and the node would sit SLEEPING in
+              // front of the user. Nudge it: the node re-reads the flag itself, so this is a
+              // no-op wherever the user did not arrive.
+              if (!isNodeOffscreen(nodeId) || nodeId === kanbanModalNodeRef.current) {
+                wakeHibernatedNode(nodeId)
+              }
             }
             // 'exit-timeout' / 'not-eligible': the CLI is still running and NOTHING is recorded —
             // marking it hibernated would put a SLEEPING chip on a live session and suppress the

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -47,12 +47,18 @@ export const SessionCard = memo(function SessionCard({
     const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
     return e.clientY < r.top + r.height / 2 ? 'before' : 'after'
   }
+  // The board is the canvas's other view of the same sessions, and it reads the same store — so
+  // SLEEPING (Eco: the agent CLI was exited to reclaim its RAM) is one more branch here, not a
+  // follow-up. Ranked last: a hibernated node is idle by definition, so `working`/`waiting` can
+  // only mean the wake already landed and the hooks are ahead of the flag.
   const badge =
     session.kind !== 'sticky' && status?.state === 'working'
       ? 'running'
       : session.kind !== 'sticky' && (status?.state === 'waiting' || status?.state === 'blocked')
         ? 'needs'
-        : null
+        : session.kind !== 'sticky' && status?.hibernated
+          ? 'sleeping'
+          : null
   const stickyPreview = session.kind === 'sticky' ? (session.text ?? '').trim() : ''
   const assignees = meta?.assignees ?? []
   const due = meta?.dueAt
@@ -102,6 +108,14 @@ export const SessionCard = memo(function SessionCard({
         {session.kind === 'browser' && <span className="kanban-card__kind">web</span>}
         {badge === 'running' && <span className="kanban-badge kanban-badge--running">RUNNING</span>}
         {badge === 'needs' && <span className="kanban-badge kanban-badge--needs">NEEDS YOU</span>}
+        {badge === 'sleeping' && (
+          <span
+            className="kanban-badge kanban-badge--sleeping"
+            title="Agent hibernated to save memory — resumes when you open the session"
+          >
+            SLEEPING
+          </span>
+        )}
         {status?.unread && <span className="kanban-card__unread" />}
       </div>
       {(labels.length > 0 || assignees.length > 0 || due !== undefined || priority !== undefined) && (

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -221,7 +221,7 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
       <SearchableRow {...ROWS.hibernation}>
         <FieldRow
           label="Hibernate idle agents"
-          description="Exit an agent CLI that has been idle and offscreen this long, freeing its memory; the conversation resumes automatically when you view the node. Scheduled, /loop and /cron agents — and sessions with subagents still running — are never touched."
+          description="Exit an agent CLI that has been idle and offscreen this long, freeing its memory; the conversation resumes automatically when you view the node. While this is on, the terminal view of an offscreen agent is kept until the agent hibernates, so the bigger saving happens first. Scheduled, /loop and /cron agents — and sessions with subagents still running — are never touched."
           control={
             <div className="flex items-center gap-2">
               <Switch

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -236,14 +236,11 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
                 min={5}
                 max={600}
                 step={5}
-                // A cleared/invalid field falls back to the default rather than 0: zero minutes
-                // would exit every session the instant a turn ends. Never NaN — it does not
-                // survive the JSON round-trip to settings.json (it lands as `null`).
-                onChange={(v) =>
-                  update({
-                    agentHibernationIdleMinutes: Number.isFinite(v) && v > 0 ? Math.max(5, v) : 30
-                  })
-                }
+                // A cleared/invalid field falls back to the default rather than 0 (zero minutes
+                // would mean "the instant a turn ends"). Deliberately no floor mid-typing: a
+                // per-keystroke `Math.max(5, v)` makes 45 untypable (4 snaps to 5, then 55). The
+                // real guard is `planHibernation`, which refuses any non-positive window outright.
+                onChange={(v) => update({ agentHibernationIdleMinutes: v || 30 })}
               />
               <span className="text-[13px] text-muted">min</span>
             </div>

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -27,6 +27,7 @@ import { SegmentedPill } from '@renderer/ui/SegmentedPill'
 import { Button } from '@renderer/ui/Button'
 import { Select } from '@renderer/ui/Select'
 import { Switch } from '@renderer/ui/Switch'
+import { NumberField } from '@renderer/ui/NumberField'
 import { SettingsSection } from '../SettingsSection'
 import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
@@ -60,6 +61,21 @@ const ROWS = {
     title: 'One-click approvals',
     keywords: ['approve', 'deny', 'approval', 'permission', 'hook', 'phone', 'canvas', 'one click', 'claude']
   },
+  hibernation: {
+    title: 'Hibernate idle agents',
+    keywords: [
+      'hibernate',
+      'eco',
+      'idle',
+      'memory',
+      'ram',
+      'exit',
+      'resume',
+      'offscreen',
+      'minutes',
+      'sleep'
+    ]
+  }
 }
 const ENTRIES = Object.values(ROWS)
 
@@ -199,6 +215,38 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
               ariaLabel="One-click hook-reply approvals"
               onChange={(on) => update({ hookReplyApprovals: on })}
             />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.hibernation}>
+        <FieldRow
+          label="Hibernate idle agents"
+          description="Exit an agent CLI that has been idle and offscreen this long, freeing its memory; the conversation resumes automatically when you view the node. Scheduled, /loop and /cron agents — and sessions with subagents still running — are never touched."
+          control={
+            <div className="flex items-center gap-2">
+              <Switch
+                checked={settings.agentHibernationEnabled}
+                ariaLabel="Hibernate idle agents"
+                onChange={(on) => update({ agentHibernationEnabled: on })}
+              />
+              <NumberField
+                value={settings.agentHibernationIdleMinutes}
+                ariaLabel="Hibernate after minutes"
+                disabled={!settings.agentHibernationEnabled}
+                min={5}
+                max={600}
+                step={5}
+                // A cleared/invalid field falls back to the default rather than 0: zero minutes
+                // would exit every session the instant a turn ends. Never NaN — it does not
+                // survive the JSON round-trip to settings.json (it lands as `null`).
+                onChange={(v) =>
+                  update({
+                    agentHibernationIdleMinutes: Number.isFinite(v) && v > 0 ? Math.max(5, v) : 30
+                  })
+                }
+              />
+              <span className="text-[13px] text-muted">min</span>
+            </div>
           }
         />
       </SearchableRow>

--- a/src/renderer/lib/hibernationCandidates.test.ts
+++ b/src/renderer/lib/hibernationCandidates.test.ts
@@ -12,6 +12,7 @@ function inputs(over: Partial<HibernationCandidateInputs> = {}): HibernationCand
     subagents: [],
     isOffscreen: () => true,
     isWired: () => true,
+    isRemote: () => false,
     ...over
   }
 }
@@ -27,6 +28,7 @@ describe('buildHibernationCandidates', () => {
         wired: true,
         offscreen: true,
         hibernated: false,
+        remote: false,
         recurring: false,
         liveSubagents: false,
         lastEventAt: IDLE
@@ -80,6 +82,24 @@ describe('buildHibernationCandidates', () => {
         { parentNodeId: 'a', status: 'working' }
       ])
     ).toBe(true)
+  })
+
+  it('carries the REMOTE fact per node, so the plan can exclude it before the batch slice', () => {
+    const rows = buildHibernationCandidates(
+      inputs({
+        nodes: [
+          { id: 'a', agentId: 'claude' },
+          { id: 'b', agentId: 'claude' }
+        ],
+        isRemote: (id) => id === 'a'
+      })
+    )
+    expect(rows.map((r) => [r.id, r.remote])).toEqual([
+      ['a', true],
+      ['b', false]
+    ])
+    // A remote node is refused however idle it looks — the whole point of asking at plan time.
+    expect(planHibernation([rows[0]], NOW, { enabled: true, idleMinutes: 30 })).toEqual([])
   })
 
   it('carries wiring and visibility from the callbacks, per node', () => {

--- a/src/renderer/lib/hibernationCandidates.test.ts
+++ b/src/renderer/lib/hibernationCandidates.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { buildHibernationCandidates, type HibernationCandidateInputs } from './hibernationCandidates'
+import { planHibernation } from '../terminal/hibernation-policy'
+
+const NOW = 1_800_000_000_000
+const IDLE = NOW - 60 * 60_000 // an hour of silence: past any window used below
+
+function inputs(over: Partial<HibernationCandidateInputs> = {}): HibernationCandidateInputs {
+  return {
+    nodes: [{ id: 'a', agentId: 'claude' }],
+    statusById: { a: { state: 'done', sessionId: 'sid-a', lastEventAt: IDLE } },
+    subagents: [],
+    isOffscreen: () => true,
+    isWired: () => true,
+    ...over
+  }
+}
+
+describe('buildHibernationCandidates', () => {
+  it('lifts the live facts onto the policy row', () => {
+    expect(buildHibernationCandidates(inputs())).toEqual([
+      {
+        id: 'a',
+        agentId: 'claude',
+        state: 'done',
+        sessionId: 'sid-a',
+        wired: true,
+        offscreen: true,
+        hibernated: false,
+        recurring: false,
+        liveSubagents: false,
+        lastEventAt: IDLE
+      }
+    ])
+  })
+
+  it('reads a DISMISSED cron entry as recurring — the card is hidden, the job is not gone', () => {
+    // The exact hole this adapter exists to close: dismissing a cron card used to CLEAR the entry,
+    // which dropped the only guard between Eco mode and a silently cancelled job. The entry is now
+    // retained with `dismissed: true`, and this row must not read that flag.
+    const rows = buildHibernationCandidates(
+      inputs({
+        statusById: {
+          a: {
+            state: 'done',
+            sessionId: 'sid-a',
+            lastEventAt: IDLE,
+            loop: { kind: 'cron', count: 0, items: [], dismissed: true }
+          }
+        }
+      })
+    )
+    expect(rows[0].recurring).toBe(true)
+    // …and end to end: the policy refuses it, however idle and offscreen it looks.
+    expect(planHibernation(rows, NOW, { enabled: true, idleMinutes: 30 })).toEqual([])
+  })
+
+  it('reads a visible loop entry as recurring too', () => {
+    const rows = buildHibernationCandidates(
+      inputs({
+        statusById: { a: { state: 'done', sessionId: 'sid-a', lastEventAt: IDLE, loop: { kind: 'loop' } } }
+      })
+    )
+    expect(rows[0].recurring).toBe(true)
+  })
+
+  it('counts any non-done subagent card of THIS parent as live', () => {
+    const withCards = (subagents: HibernationCandidateInputs['subagents']) =>
+      buildHibernationCandidates(inputs({ subagents }))[0].liveSubagents
+    expect(withCards([{ parentNodeId: 'a', status: 'working' }])).toBe(true)
+    // Unknown state is not evidence that it finished — conservative, like pendingLaunch's deps.
+    expect(withCards([{ parentNodeId: 'a', status: undefined }])).toBe(true)
+    expect(withCards([{ parentNodeId: 'a', status: 'done' }])).toBe(false)
+    // …and a sibling node's running subagent must never pin THIS node.
+    expect(withCards([{ parentNodeId: 'b', status: 'working' }])).toBe(false)
+    // A done card beside a live one still leaves the parent pinned.
+    expect(
+      withCards([
+        { parentNodeId: 'a', status: 'done' },
+        { parentNodeId: 'a', status: 'working' }
+      ])
+    ).toBe(true)
+  })
+
+  it('carries wiring and visibility from the callbacks, per node', () => {
+    const rows = buildHibernationCandidates(
+      inputs({
+        nodes: [
+          { id: 'a', agentId: 'claude' },
+          { id: 'b', agentId: 'claude' }
+        ],
+        statusById: { a: { state: 'done' }, b: { state: 'done' } },
+        isOffscreen: (id) => id === 'a',
+        isWired: (id) => id === 'b'
+      })
+    )
+    expect(rows.map((r) => [r.id, r.offscreen, r.wired])).toEqual([
+      ['a', true, false],
+      ['b', false, true]
+    ])
+  })
+
+  it('emits a row for a node with no status at all — the policy refuses it, this does not filter', () => {
+    const rows = buildHibernationCandidates(inputs({ statusById: {} }))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ state: undefined, lastEventAt: undefined, hibernated: false })
+    expect(planHibernation(rows, NOW, { enabled: true, idleMinutes: 30 })).toEqual([])
+  })
+
+  it('marks an already-hibernated node so the sweep cannot pick it twice', () => {
+    const rows = buildHibernationCandidates(
+      inputs({ statusById: { a: { state: 'done', sessionId: 'sid-a', lastEventAt: IDLE, hibernated: true } } })
+    )
+    expect(rows[0].hibernated).toBe(true)
+    expect(planHibernation(rows, NOW, { enabled: true, idleMinutes: 30 })).toEqual([])
+  })
+
+  it('an idle, offscreen, wired agent node with none of the guards IS planned', () => {
+    // The positive control: without it, every refusal above could be passing for the wrong reason.
+    expect(planHibernation(buildHibernationCandidates(inputs()), NOW, { enabled: true, idleMinutes: 30 })).toEqual(['a'])
+  })
+})

--- a/src/renderer/lib/hibernationCandidates.ts
+++ b/src/renderer/lib/hibernationCandidates.ts
@@ -55,6 +55,9 @@ export interface HibernationCandidateInputs {
   isOffscreen: (nodeId: string) => boolean
   /** Does this node have a live terminal with a registered hibernate pair? */
   isWired: (nodeId: string) => boolean
+  /** Does this node's session run on another machine (SSH project / relay tab)? Excluded in v1 —
+   *  and excluded HERE, at plan time, for the batch-slot reason in the policy's `remote` field. */
+  isRemote: (nodeId: string) => boolean
 }
 
 export function buildHibernationCandidates(
@@ -75,6 +78,7 @@ export function buildHibernationCandidates(
       wired: inputs.isWired(n.id),
       offscreen: inputs.isOffscreen(n.id),
       hibernated: !!st?.hibernated,
+      remote: inputs.isRemote(n.id),
       recurring: !!st?.loop,
       liveSubagents: liveParents.has(n.id),
       lastEventAt: st?.lastEventAt

--- a/src/renderer/lib/hibernationCandidates.ts
+++ b/src/renderer/lib/hibernationCandidates.ts
@@ -1,0 +1,83 @@
+/**
+ * Assemble the rows `planHibernation` decides on — the ADAPTER between four live sources (the
+ * canvas nodes, the agent-status table, the subagent cards, and the node's own wiring/visibility)
+ * and the pure policy in `terminal/hibernation-policy.ts`.
+ *
+ * It exists as its own tested function rather than as a `.map()` inside the sweep because two of
+ * the four facts are SAFETY facts, and an untested inline expression is exactly where they rot:
+ *
+ *  - **`recurring` is `!!loop`, dismissed or not.** A dismissed cron/schedule card keeps its entry
+ *    precisely so this row stays true (see `agentStatus`'s `loop.dismissed`): the card is hidden,
+ *    the job is not gone, and `/exit` would kill the CLI its wakeup lives in. Reading the render
+ *    filter here — "no card, so nothing recurring" — silently cancels the job Eco mode was never
+ *    allowed to touch. That hole is the reason this file has a test.
+ *  - **`liveSubagents` is "any card for this parent that is NOT done".** Claude launches subagents
+ *    async and their completion is queued into the PARENT's transcript, which a dead parent CLI
+ *    never reads. An unknown/absent state counts as LIVE — the conservative direction, and the
+ *    same rule as pendingLaunch's "an unknown dependency state is not satisfied".
+ *
+ * Everything else is a straight lift, and the policy owns every actual decision: this function
+ * never filters, so a node that is ineligible arrives as a row that `planHibernation` refuses.
+ */
+import type { HibernationCandidate } from '../terminal/hibernation-policy'
+
+/** One canvas node as the sweep sees it: its id and the agent it was CREATED as (`data.agentId`,
+ *  legacy `tags` fallback — resolved by the caller through the same `createdAgentId` helper the
+ *  node's own registration uses, so the filter and the closure agree on what is an agent). */
+export interface HibernationNodeInput {
+  id: string
+  agentId?: string
+}
+
+/** One agent-status entry, narrowed to what the plan reads. */
+export interface HibernationStatusInput {
+  state?: string
+  sessionId?: string
+  hibernated?: boolean
+  lastEventAt?: number
+  /** Present = this node has a `/loop`, `/schedule` or `/cron` on it. Its `dismissed` flag is
+   *  deliberately NOT consulted — see the header. */
+  loop?: unknown
+}
+
+/** One subagent card, narrowed: whose it is, and whether it has finished. */
+export interface HibernationSubagentInput {
+  parentNodeId: string
+  status?: string
+}
+
+export interface HibernationCandidateInputs {
+  nodes: HibernationNodeInput[]
+  statusById: Record<string, HibernationStatusInput | undefined>
+  subagents: HibernationSubagentInput[]
+  /** Is this node out of the viewport right now? (The Phase 2 visibility observer's own verdict —
+   *  never a second observer.) */
+  isOffscreen: (nodeId: string) => boolean
+  /** Does this node have a live terminal with a registered hibernate pair? */
+  isWired: (nodeId: string) => boolean
+}
+
+export function buildHibernationCandidates(
+  inputs: HibernationCandidateInputs
+): HibernationCandidate[] {
+  // One pass over the cards, so a canvas with a large fan-out doesn't cost nodes × cards.
+  const liveParents = new Set<string>()
+  for (const s of inputs.subagents) {
+    if (s.status !== 'done') liveParents.add(s.parentNodeId)
+  }
+  return inputs.nodes.map((n) => {
+    const st = inputs.statusById[n.id]
+    return {
+      id: n.id,
+      agentId: n.agentId,
+      state: st?.state,
+      sessionId: st?.sessionId,
+      wired: inputs.isWired(n.id),
+      offscreen: inputs.isOffscreen(n.id),
+      hibernated: !!st?.hibernated,
+      recurring: !!st?.loop,
+      liveSubagents: liveParents.has(n.id),
+      lastEventAt: st?.lastEventAt
+    }
+  })
+}

--- a/src/renderer/lib/loopCard.test.ts
+++ b/src/renderer/lib/loopCard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { applyLoopDismiss, loopDismissAction } from './loopCard'
+import { useAgentStatus } from '../state/agentStatus'
+
+describe('loopDismissAction', () => {
+  it('keeps the fact for jobs that outlive the session, clears the in-session loop', () => {
+    expect(loopDismissAction('cron')).toBe('mark-dismissed')
+    expect(loopDismissAction('schedule')).toBe('mark-dismissed')
+    expect(loopDismissAction('loop')).toBe('clear')
+    expect(loopDismissAction(undefined)).toBe('clear')
+  })
+})
+
+describe('applyLoopDismiss — one path for BOTH dismiss surfaces', () => {
+  beforeEach(() => {
+    useAgentStatus.setState({ byId: {} })
+  })
+
+  it('marks a cron card dismissed and KEEPS the entry (the job is still out there)', () => {
+    useAgentStatus.getState().setLoop('n1', true, 'cron', { schedule: '0 9 * * *' })
+    applyLoopDismiss('n1')
+    // The card is gone from every render site; the guard Eco mode reads is not.
+    expect(useAgentStatus.getState().byId['n1'].loop).toMatchObject({
+      kind: 'cron',
+      dismissed: true
+    })
+  })
+
+  it('marks a schedule card the same way', () => {
+    useAgentStatus.getState().setLoop('n2', true, 'schedule')
+    applyLoopDismiss('n2')
+    expect(useAgentStatus.getState().byId['n2'].loop?.dismissed).toBe(true)
+  })
+
+  it('clears an in-session /loop outright — it dies with its session anyway', () => {
+    useAgentStatus.getState().setLoop('n3', true, 'loop')
+    applyLoopDismiss('n3')
+    expect(useAgentStatus.getState().byId['n3'].loop).toBeUndefined()
+  })
+
+  it('is a no-op for a node with no card', () => {
+    applyLoopDismiss('n4')
+    expect(useAgentStatus.getState().byId['n4']).toBeUndefined()
+  })
+})

--- a/src/renderer/lib/loopCard.ts
+++ b/src/renderer/lib/loopCard.ts
@@ -1,0 +1,40 @@
+/**
+ * Dismissing a /loop · /schedule · /cron CARD — the ONE place that knows what a dismiss owes.
+ *
+ * There are two dismiss surfaces for the same user action (the card's own × and the card's
+ * right-click menu), and they drifted: one kept the durable recurring fact and the other destroyed
+ * it. What is at stake is not the card. `agentStatus.loop` is the only record that this node has a
+ * wakeup pending, and it is what stops Eco mode from asking the CLI to `/exit` — a `cron` whose
+ * entry has been cleared looks EXACTLY like an idle session (done, offscreen, long silent), so the
+ * next sweep quits the process the job was going to fire in. The card's own tooltip has always
+ * promised the opposite: "does not remove the job".
+ *
+ * So: a `cron`/`schedule` dismiss MARKS the entry (`loop.dismissed` — every render site filters on
+ * it, nothing else reads it), while an in-session `/loop` still clears outright, because that one
+ * dies with its session and there is no fact left to keep. A real end (CronDelete) is a real clear,
+ * and goes through `setLoop(id, false)` as it always has.
+ */
+import { useAgentStatus } from '../state/agentStatus'
+import { useAgentNodes } from '../state/agentNodes'
+
+/** What dismissing a card of this kind must do to the durable entry. Pure — the whole decision. */
+export function loopDismissAction(
+  kind: string | undefined
+): 'mark-dismissed' | 'clear' {
+  // Unknown kinds clear, matching the historical behavior of every non-cron card.
+  return kind === 'cron' || kind === 'schedule' ? 'mark-dismissed' : 'clear'
+}
+
+/**
+ * Apply a dismiss to the parent terminal's card. The KIND is read from the store, not passed in:
+ * that entry is where the card's own data came from, and a second source is how the two surfaces
+ * disagreed in the first place.
+ */
+export function applyLoopDismiss(parentNodeId: string): void {
+  const status = useAgentStatus.getState()
+  const kind = status.byId[parentNodeId]?.loop?.kind
+  if (loopDismissAction(kind) === 'mark-dismissed') status.dismissLoopCard(parentNodeId)
+  else status.setLoop(parentNodeId, false)
+  // The card's dragged position/size go either way — the card is gone from the screen.
+  useAgentNodes.getState().clearLoop(parentNodeId)
+}

--- a/src/renderer/lib/sessionList.ts
+++ b/src/renderer/lib/sessionList.ts
@@ -129,7 +129,12 @@ function toRow(n: SessionNodeInput, status: AgentNodeStatus | undefined): Sessio
     stateLabel: STATE_LABEL[statusKind],
     unread: !!status?.unread,
     session: status?.session,
-    loop: status?.loop ? { kind: status.loop.kind, count: status.loop.count } : undefined,
+    // A dismissed cron/schedule entry is retained as a fact (the hibernation guard reads it) but
+    // shows nowhere it did not show before — this chip included.
+    loop:
+      status?.loop && !status.loop.dismissed
+        ? { kind: status.loop.kind, count: status.loop.count }
+        : undefined,
     cwd: n.cwd,
     sshHost: n.ssh?.host,
     sessionId: status?.sessionId,

--- a/src/renderer/nodes/LoopNode.tsx
+++ b/src/renderer/nodes/LoopNode.tsx
@@ -36,10 +36,19 @@ export function LoopNode({ id, data, selected }: NodeProps<CanvasNode>) {
   // Manual dismiss: cron/schedule cards persist across turns/sessions/restarts, so a job
   // removed while the app wasn't watching (or one the user just wants gone) needs an ×.
   // Dismissing only drops the CARD — it does not touch the cron job itself.
+  //
+  // …which is why a cron/schedule card is dismissed by MARKING it, not by clearing the entry.
+  // That entry is the only record that this node has a wakeup pending, and it is what keeps Eco
+  // mode from hibernating the node (`/exit` kills the CLI, and the scheduled wakeup dies with it).
+  // Clearing it dropped that guard while the job kept running — the card's own tooltip promises
+  // the opposite. An in-session `/loop` still clears outright: it dies with its session anyway,
+  // so there is no fact left to keep.
   const dismiss = (e: React.MouseEvent) => {
     e.stopPropagation()
     const parentId = id.replace(/^loop-/, '')
-    useAgentStatus.getState().setLoop(parentId, false)
+    const cs = useAgentStatus.getState()
+    if (kind === 'cron' || kind === 'schedule') cs.dismissLoopCard(parentId)
+    else cs.setLoop(parentId, false)
     useAgentNodes.getState().clearLoop(parentId)
   }
 

--- a/src/renderer/nodes/LoopNode.tsx
+++ b/src/renderer/nodes/LoopNode.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react'
 import type { CanvasNode } from '../state/workspace'
 import { useAgentNodes } from '../state/agentNodes'
-import { useAgentStatus } from '../state/agentStatus'
+import { applyLoopDismiss } from '../lib/loopCard'
 import { useSession } from '../session/session'
 
 /**
@@ -37,19 +37,13 @@ export function LoopNode({ id, data, selected }: NodeProps<CanvasNode>) {
   // removed while the app wasn't watching (or one the user just wants gone) needs an ×.
   // Dismissing only drops the CARD — it does not touch the cron job itself.
   //
-  // …which is why a cron/schedule card is dismissed by MARKING it, not by clearing the entry.
-  // That entry is the only record that this node has a wakeup pending, and it is what keeps Eco
-  // mode from hibernating the node (`/exit` kills the CLI, and the scheduled wakeup dies with it).
-  // Clearing it dropped that guard while the job kept running — the card's own tooltip promises
-  // the opposite. An in-session `/loop` still clears outright: it dies with its session anyway,
-  // so there is no fact left to keep.
+  // …which is why the whole decision lives in `lib/loopCard.ts`, shared with the card's
+  // right-click "Dismiss card": a cron/schedule dismiss MARKS the entry rather than clearing it,
+  // because that entry is the only record that a wakeup is pending — and the guard that keeps Eco
+  // mode from `/exit`ing the CLI it lives in.
   const dismiss = (e: React.MouseEvent) => {
     e.stopPropagation()
-    const parentId = id.replace(/^loop-/, '')
-    const cs = useAgentStatus.getState()
-    if (kind === 'cron' || kind === 'schedule') cs.dismissLoopCard(parentId)
-    else cs.setLoop(parentId, false)
-    useAgentNodes.getState().clearLoop(parentId)
+    applyLoopDismiss(id.replace(/^loop-/, ''))
   }
 
   // The cards are `selectable: false` in React Flow (a rubber band must not sweep a fan-out

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -65,6 +65,7 @@ import {
   offscreenCoreIsRemote,
   offscreenDisposeMs,
   planOffscreenVisibility,
+  releaseStillEnabled,
   shouldDeferReleaseForEco,
   OFFSCREEN_DEFER_RETRY_MS,
   OFFSCREEN_DISPOSE_MS_DEFAULT
@@ -3162,7 +3163,7 @@ export function TerminalNode({
             // The setting can also have been switched OFF while this timer counted down; a fire
             // that disposed anyway would take a buffer the user has just asked us to keep.
             const liveSettings = useSettings.getState().settings
-            if (offscreenDisposeMs(liveSettings.offscreenTerminalMinutes) === null) return
+            if (!releaseStillEnabled(liveSettings.offscreenTerminalMinutes)) return
             // Nothing to give back (no session yet, or one that was closed/ended under us) ⇒ no
             // dispose. A null ref means no lifecycle run is live at all, which answers the same way.
             if (!offscreenLiveRef.current?.()) return
@@ -3174,11 +3175,17 @@ export function TerminalNode({
             // ~15 MB; the CLI is hundreds. So wait for the big prize, on the sweep's own cadence,
             // and only up to the capped total — a node that can never hibernate must not hold its
             // viewer forever.
+            const ecoStatus = useAgentStatus.getState().byId[id]
             if (
               shouldDeferReleaseForEco({
                 ecoEnabled: liveSettings.agentHibernationEnabled,
                 resumableAgent: hibernationTargetRef.current,
-                hibernated: !!useAgentStatus.getState().byId[id]?.hibernated,
+                hibernated: !!ecoStatus?.hibernated,
+                // Same "unknown idle is not idle" rule the policy applies: with no hook event seen
+                // in this run there is no idle clock, `planHibernation` refuses this node outright,
+                // and waiting for a hibernation that cannot come would hold every warm node's
+                // viewer for the full cap after each app restart.
+                idleKnown: ecoStatus?.lastEventAt !== undefined,
                 offscreenElapsedMs: Date.now() - (offscreenSinceRef.current ?? Date.now()),
                 idleMinutes: liveSettings.agentHibernationIdleMinutes,
                 offscreenMinutes:

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -87,10 +87,19 @@ import {
 } from '../lib/glyphGridNode'
 import { deliverCommand, type DeliveryIo } from '../terminal/command-delivery'
 import {
+  agentHibernateFns,
   guardConcurrentRestart,
+  isShellCommand,
+  performExitPhase,
   performRestartResume,
+  performResumePhase,
+  queryPaneWithin,
+  registerAgentHibernate,
   registerAgentRestart,
-  restartEligibility
+  restartEligibility,
+  RESTART_EXIT_TIMEOUT_MS,
+  type ExitPhaseOutcome,
+  type ResumePhaseOutcome
 } from '../terminal/agent-restart'
 import { FindBar } from '../components/FindBar'
 import { IconSearch, IconChat, IconMic, IconReload } from '../components/icons'
@@ -628,6 +637,38 @@ const coSubs = new Map<string, (s: CoState) => void>()
 const restartSubs = new Map<string, () => void>()
 
 /**
+ * Which mounted terminals are currently OUT of the viewport, published by the one visibility
+ * observer each node already runs (Phase 2's) — never a second observer, and never a second
+ * verdict: this map only mirrors what that callback decided.
+ *
+ * Read by Canvas's hibernation sweep, which asks about nodes it does not render itself. Keyed by
+ * NODE id (like `restartFns`, not like the session-scoped `termKey` maps) because that is the id
+ * the sweep, the plan and the registry all speak.
+ *
+ * ABSENT = not offscreen. A node that has not reported yet (its observer's first delivery is
+ * queued, or the environment has no IntersectionObserver at all) must never be read as "nobody is
+ * looking at it" — that is the direction that hibernates a session the user is staring at.
+ */
+const offscreenNodes = new Set<string>()
+
+/** How long a freshly mounted node waits before asking to be woken: the spawn its resume line is
+ *  written into is still in flight at mount (no session id, no pane). */
+const WAKE_MOUNT_DELAY_MS = 2000
+/** Bounded retries for a wake that came back `'not-eligible'` — timing, not a standing refusal. */
+const WAKE_ATTEMPTS = 3
+const WAKE_RETRY_MS = 4000
+
+function setNodeOffscreen(nodeId: string, offscreen: boolean): void {
+  if (offscreen) offscreenNodes.add(nodeId)
+  else offscreenNodes.delete(nodeId)
+}
+
+/** Is this node out of the viewport? Unknown answers `false` — see `offscreenNodes`. */
+export function isNodeOffscreen(nodeId: string): boolean {
+  return offscreenNodes.has(nodeId)
+}
+
+/**
  * The mounted instance publishes its copy-feedback sink here, for the same reason as
  * `restartSubs`: the OSC 52 handler is registered ONCE per xterm instance and that instance
  * SURVIVES A PARK (project switch → remount within TERM_PARK_MS), so a handler holding this
@@ -994,6 +1035,76 @@ export function TerminalNode({
     !remoteSession &&
     (data.cwd as string | undefined) !== parentWtPath
   const status = useAgentStatus((s) => s.byId[id])
+  // --- Eco / hibernation wake (see terminal/hibernation-policy.ts) ---
+  // A hibernated node's CLI was asked to `/exit` while nobody was looking; its tmux session, pane
+  // and scrollback are untouched, and the conversation comes back with the provider's own
+  // `--resume`. THREE things ask for that here, all through one function:
+  //   1. the visibility observer, on the offscreen→visible edge (the everyday path);
+  //   2. mount-while-already-visible — a node the canvas opens ON SCREEN never transitions, so
+  //      after a relaunch (the flag is persisted) nothing would ever ask;
+  //   3. the SLEEPING chip's own click, which is also the escape hatch when the two above have
+  //      given up.
+  // Never fired more than once at a time (`wakeInFlightRef`, plus `guardConcurrentRestart` inside
+  // the registered closure), and always re-reads the flag: a wake that raced another one, or a
+  // sweep that landed in between, must not deliver a second launch line into the same pane.
+  const wakeInFlightRef = useRef(false)
+  const wakeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wakeRef = useRef<(attempt?: number) => void>(() => {})
+  wakeRef.current = (attempt = 0): void => {
+    // A wake that could not run YET is retried a couple of times: at mount the spawn is still in
+    // flight, and a node coming back from an offscreen DISPOSE re-registers its pair one render
+    // later than the visibility edge that asked. Past the attempts it is a standing refusal (the
+    // pane belongs to something else now) and the chip's click is the way forward — nothing keeps
+    // typing into a pane on a timer.
+    const retryLater = (): void => {
+      if (attempt + 1 >= WAKE_ATTEMPTS) return
+      if (wakeTimerRef.current) clearTimeout(wakeTimerRef.current)
+      wakeTimerRef.current = setTimeout(() => wakeRef.current(attempt + 1), WAKE_RETRY_MS)
+    }
+    if (wakeInFlightRef.current) return
+    if (!useAgentStatus.getState().byId[id]?.hibernated) return
+    const fns = agentHibernateFns(id)
+    if (!fns) return retryLater() // no terminal here yet (mid-spawn, or an offscreen revive)
+    wakeInFlightRef.current = true
+    void fns
+      .resume()
+      .then((outcome) => {
+        if (outcome === 'resumed') {
+          useAgentStatus.getState().setHibernated(id, false)
+          return
+        }
+        // 'not-eligible' — usually timing, not a refusal that will stand: at mount the spawn is
+        // still in flight (no session id yet), and right after a reveal tmux may not have answered
+        // `paneCommand` yet. See `retryLater`.
+        retryLater()
+      })
+      .catch(() => {
+        // A transport that threw leaves the node hibernated (and the chip clickable). Reporting a
+        // wake here would clear the badge over a pane nothing was typed into.
+      })
+      .finally(() => {
+        wakeInFlightRef.current = false
+      })
+  }
+  // Ask once shortly after mount, for the node that is ALREADY visible: its observer reports
+  // `visible` with no preceding hidden verdict, and an environment without IntersectionObserver
+  // reports nothing at all. Delayed because the spawn this wake writes into is still in flight at
+  // mount. Skipped while the node is known-offscreen — the reveal edge owns that case.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (!isNodeOffscreen(id)) wakeRef.current()
+    }, WAKE_MOUNT_DELAY_MS)
+    return () => {
+      clearTimeout(t)
+      if (wakeTimerRef.current) {
+        clearTimeout(wakeTimerRef.current)
+        wakeTimerRef.current = null
+      }
+      // This node is leaving the canvas: it is nobody's hibernation candidate until it reports
+      // again. (Absent = not offscreen; see `offscreenNodes`.)
+      setNodeOffscreen(id, false)
+    }
+  }, [id])
   // Held launch (canvas-control `--after`). Canvas owns firing it; the node only surfaces that
   // it is armed, and by WHAT it is blocked — dep titles read straight off the live canvas, since
   // "waits for term-17" tells the user nothing.
@@ -2330,6 +2441,20 @@ export function TerminalNode({
             unsub()
           })
         }
+        // Hibernation × cold restore. `hibernated` is PERSISTED, so it can outlive the very thing
+        // it describes:
+        //  - `fresh` (the tmux session is GONE — a reboot, a reaped server, a first open): the CLI
+        //    it refers to died with the session. The node is not hibernated, it is simply gone, so
+        //    the flag is dropped and the ORDINARY cold-restore auto-resume below brings the
+        //    conversation back exactly as it does for any other node. Leaving the flag set would
+        //    park a SLEEPING chip over a dead pane and hand the resume to the wake path, which
+        //    (rightly) refuses a pane it cannot see a shell in.
+        //  - warm attach (`!fresh`): the shell we exited to is still sitting in the pane, by
+        //    design. Nothing auto-resumes here — the branch below is `fresh`-only — and the wake
+        //    path owns the relaunch. That is the whole feature.
+        if (fresh && useAgentStatus.getState().byId[id]?.hibernated) {
+          useAgentStatus.getState().setHibernated(id, false)
+        }
         // Run a one-shot command on first open (e.g. "gh auth login" or the agent CLI), then
         // forget it.
         if (data.initialCommand) {
@@ -2450,6 +2575,68 @@ export function TerminalNode({
         })
       })
     )
+
+    // Eco / hibernation (`settings.agentHibernationEnabled`): the same two halves as the restart
+    // above, registered as a PAIR because they are driven far apart in time — Canvas's sweep quits
+    // an idle, offscreen CLI to reclaim its RAM, and the node's own wake resumes the conversation
+    // when the user comes back to it. Same `io`, same `paneCommand`, same `isLive`, same
+    // `guardConcurrentRestart` node id, so a sweep and a menu restart can never write into one pane
+    // at once. Registered in the effect BODY for the same reason as the restart closure: an adopted
+    // (parked → remounted) terminal never reaches the spawn continuation.
+    const unregisterHibernate = registerAgentHibernate(id, {
+      exit: guardConcurrentRestart(id, async (): Promise<ExitPhaseOutcome> => {
+        // SSH / relay sessions are excluded in v1, exactly as the offscreen dispose excludes them
+        // (offscreen-policy.ts): the exit and its much later resume would race the ControlMaster /
+        // relay lifecycle, and a wake that cannot reach the host leaves a dead conversation behind.
+        // Read at CALL time — a local project can BECOME an SSH project long after this mount.
+        if (offscreenRemoteRef.current) return 'not-eligible'
+        const st = useAgentStatus.getState().byId[id]
+        const agentSessionId = st?.sessionId
+        // Re-asked here, not trusted from the plan: a node that started working between the sweep's
+        // decision and its turn must keep its turn (BUSY_STATES — an exit line typed into a
+        // permission prompt ANSWERS it).
+        const gate = restartEligibility(agentId, st?.state, agentSessionId)
+        if (!gate.ok || !agentId || !agentSessionId || !restartTarget()) return 'not-eligible'
+        return performExitPhase({
+          agentId,
+          sessionId: agentSessionId,
+          io: restartIo,
+          paneCommand: () => api.pty.paneCommand(id),
+          isLive: restartTarget
+        })
+      }),
+      resume: guardConcurrentRestart(id, async (): Promise<ResumePhaseOutcome> => {
+        const st = useAgentStatus.getState().byId[id]
+        const agentSessionId = st?.sessionId
+        if (!agentId || !agentSessionId || !restartTarget()) return 'not-eligible'
+        // THE load-bearing gate of the wake half. Hours can pass between the exit and this
+        // resume, and the pane is a REPL the user can type into: by now it may belong to vim, to
+        // `top`, or to a claude the user launched by hand. `deliverCommand`'s first write is NOT
+        // preceded by a Ctrl-U (the exit half is where that lives), so a launch line typed into a
+        // live program is sent to that program — a message to somebody's session, or a mangled
+        // command. A pane we cannot READ answers null and is refused for the same reason.
+        const pane = await queryPaneWithin(() => api.pty.paneCommand(id), RESTART_EXIT_TIMEOUT_MS)
+        if (!isShellCommand(pane)) return 'not-eligible'
+        // Same funnel, same await, same reasoning as the restart closure above: the permission
+        // mode is a property of how a session is LAUNCHED, so it is re-resolved now (a wake can be
+        // hours after the exit, and days after the node was created).
+        const base = resumeCommand(agentId, agentSessionId)
+        const command = base
+          ? withPermissionMode(base, agentId, await ensureActivePermissionMode(agentId))
+          : undefined
+        return performResumePhase({
+          agentId,
+          sessionId: agentSessionId,
+          io: restartIo,
+          command,
+          isLive: restartTarget,
+          onDelivery: (cancel) => {
+            if (life.dead) cancel()
+            else cleanups.push(cancel)
+          }
+        })
+      })
+    })
 
     // Coalesce observer bursts: dragging the NodeResizer fires per animation frame, and every
     // call is a full cell-geometry measure + a resize IPC → node-pty → tmux (which redraws the
@@ -2629,6 +2816,9 @@ export function TerminalNode({
       // Nothing may restart a node that is no longer mounted — park, respawn and real teardown all
       // pass through here. A remount re-registers (superseding, so a stale unregister is inert).
       unregisterRestart()
+      // …and nothing may hibernate or wake one either: with no registration the sweep reads this
+      // node as unwired (`planHibernation` refuses it) and the wake finds nothing to resume into.
+      unregisterHibernate()
       observer.disconnect()
       rootObserver.disconnect()
       // The visibility observer is NOT disconnected here — it is mount-stable and must outlive an
@@ -2784,7 +2974,16 @@ export function TerminalNode({
         // The renderer half first: it reads `wasVisibleRef` as the PREVIOUS verdict for its
         // hidden→visible edge test, so the write below must come after it.
         visibilityReportRef.current?.(visible)
+        const wasVisible = wasVisibleRef.current
         wasVisibleRef.current = visible
+        // Publish the same verdict for the hibernation sweep, which runs in Canvas and cannot see
+        // this node's box. One observer, two consumers — a second observer would be a second
+        // opinion about the same rectangle.
+        setNodeOffscreen(id, !visible)
+        // …and the wake edge: a hibernated node the user has just panned back to gets its
+        // conversation resumed before they can reach for the chip. No-op (one map lookup) for a
+        // node that is not hibernated, which is every node in the default case.
+        if (visible && !wasVisible) wakeRef.current()
         // …and the offscreen-dispose state machine. Every decision is the pure
         // `planOffscreenVisibility`; this block only executes the plan.
         const disposeMs = offscreenDisposeMs(
@@ -3458,7 +3657,28 @@ export function TerminalNode({
             RUNNING
           </span>
         )}
-        {showLoop && status?.loop && (
+        {/* Eco: this node's CLI was exited to reclaim its RAM while nobody was looking. The tmux
+            session, the pane and the scrollback are untouched — only the process is gone — and
+            revealing the node resumes the conversation. Clickable because the automatic wake can
+            refuse (a pane that now belongs to something else, a spawn that is still coming up),
+            and a badge with no way forward is a dead end. Muted on purpose: nothing is wrong. */}
+        {status?.hibernated && (
+          <button
+            className="term-node__status term-node__status--sleeping nodrag"
+            title="Agent hibernated to save memory — click to resume"
+            onClick={(e) => {
+              e.stopPropagation()
+              wakeRef.current()
+            }}
+          >
+            <span className="term-node__status-dot" />
+            SLEEPING
+          </button>
+        )}
+        {/* Dismissed (cron/schedule) entries are retained as a fact but hidden everywhere they
+            were shown before — chip included, so the × still does exactly what it always did to
+            the screen. See agentStatus's `loop.dismissed`. */}
+        {showLoop && status?.loop && !status.loop.dismissed && (
           <span
             className="term-node__status term-node__status--loop"
             title={`Running /${status.loop.kind}`}

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -85,7 +85,7 @@ import {
   validCellSize,
   type Vec2
 } from '../lib/glyphGridNode'
-import { deliverCommand, type DeliveryIo } from '../terminal/command-delivery'
+import { deliverCommand, KILL_LINE, type DeliveryIo } from '../terminal/command-delivery'
 import {
   agentHibernateFns,
   guardConcurrentRestart,
@@ -669,6 +669,23 @@ export function isNodeOffscreen(nodeId: string): boolean {
 }
 
 /**
+ * Each mounted node publishes its wake trigger here, so anything that means "the user is looking
+ * at this session now" can ask for the conversation back without owning the machinery: the sweep
+ * itself (a node hibernated in the same tick the user panned back to it), and the kanban card
+ * modal (a second, equally real way of opening a session — the canvas visibility observer says
+ * nothing about it).
+ *
+ * Same park-surviving reason as `restartSubs`: no entry = nobody is mounted = nothing to wake.
+ */
+const wakeSubs = new Map<string, () => void>()
+
+/** Ask a node to resume its hibernated CLI. No-op if it is not mounted, or not hibernated (the
+ *  node re-reads the flag itself — this is a nudge, never an assertion). */
+export function wakeHibernatedNode(nodeId: string): void {
+  wakeSubs.get(nodeId)?.()
+}
+
+/**
  * The mounted instance publishes its copy-feedback sink here, for the same reason as
  * `restartSubs`: the OSC 52 handler is registered ONCE per xterm instance and that instance
  * SURVIVES A PARK (project switch → remount within TERM_PARK_MS), so a handler holding this
@@ -1091,11 +1108,16 @@ export function TerminalNode({
   // reports nothing at all. Delayed because the spawn this wake writes into is still in flight at
   // mount. Skipped while the node is known-offscreen — the reveal edge owns that case.
   useEffect(() => {
+    // Published for the two askers that are not this node: the sweep (a node hibernated in the
+    // very tick the user panned back to it) and the kanban card modal.
+    const trigger = (): void => wakeRef.current()
+    wakeSubs.set(id, trigger)
     const t = setTimeout(() => {
       if (!isNodeOffscreen(id)) wakeRef.current()
     }, WAKE_MOUNT_DELAY_MS)
     return () => {
       clearTimeout(t)
+      if (wakeSubs.get(id) === trigger) wakeSubs.delete(id)
       if (wakeTimerRef.current) {
         clearTimeout(wakeTimerRef.current)
         wakeTimerRef.current = null
@@ -2585,6 +2607,15 @@ export function TerminalNode({
     // (parked → remounted) terminal never reaches the spawn continuation.
     const unregisterHibernate = registerAgentHibernate(id, {
       exit: guardConcurrentRestart(id, async (): Promise<ExitPhaseOutcome> => {
+        // "Is this node STILL out of view?" — re-asked at FIRE time, never trusted from the plan,
+        // the same discipline as `mayDisposeOffscreen`. A sweep can spend ~12 s working through
+        // its batch, and the node whose turn comes last may be one the user panned back to and is
+        // now typing in: KILL_LINE + `/exit` would land in a pane they are watching, taking their
+        // half-written prompt with it. Worse, the visible EDGE has already passed by then, so no
+        // wake trigger is left and the node would sit SLEEPING on screen until clicked.
+        // (`isNodeOffscreen` and this node's own `wasVisibleRef` are the same observer's verdict;
+        // the map is used here so the sweep and the node cannot disagree.)
+        if (!isNodeOffscreen(id)) return 'not-eligible'
         // SSH / relay sessions are excluded in v1, exactly as the offscreen dispose excludes them
         // (offscreen-policy.ts): the exit and its much later resume would race the ControlMaster /
         // relay lifecycle, and a wake that cannot reach the host leaves a dead conversation behind.
@@ -2609,14 +2640,10 @@ export function TerminalNode({
         const st = useAgentStatus.getState().byId[id]
         const agentSessionId = st?.sessionId
         if (!agentId || !agentSessionId || !restartTarget()) return 'not-eligible'
-        // THE load-bearing gate of the wake half. Hours can pass between the exit and this
-        // resume, and the pane is a REPL the user can type into: by now it may belong to vim, to
-        // `top`, or to a claude the user launched by hand. `deliverCommand`'s first write is NOT
-        // preceded by a Ctrl-U (the exit half is where that lives), so a launch line typed into a
-        // live program is sent to that program — a message to somebody's session, or a mangled
-        // command. A pane we cannot READ answers null and is refused for the same reason.
-        const pane = await queryPaneWithin(() => api.pty.paneCommand(id), RESTART_EXIT_TIMEOUT_MS)
-        if (!isShellCommand(pane)) return 'not-eligible'
+        // Command FIRST, pane check LAST. Both of these awaits can take a moment (the claude
+        // version probe behind `ensureActivePermissionMode` most of all), and whatever is asked
+        // first is stale by the time the delivery runs — so the fact that must be freshest is the
+        // one asked last: what owns the pane we are about to type into.
         // Same funnel, same await, same reasoning as the restart closure above: the permission
         // mode is a property of how a session is LAUNCHED, so it is re-resolved now (a wake can be
         // hours after the exit, and days after the node was created).
@@ -2624,6 +2651,21 @@ export function TerminalNode({
         const command = base
           ? withPermissionMode(base, agentId, await ensureActivePermissionMode(agentId))
           : undefined
+        // THE load-bearing gate of the wake half. Hours can pass between the exit and this
+        // resume, and the pane is a REPL the user can type into: by now it may belong to vim, to
+        // `top`, or to a claude the user launched by hand — and a launch line typed into a live
+        // program is sent to that program, as a message or a mangled command. A pane we cannot
+        // READ answers null and is refused for the same reason.
+        const pane = await queryPaneWithin(() => api.pty.paneCommand(id), RESTART_EXIT_TIMEOUT_MS)
+        if (!isShellCommand(pane)) return 'not-eligible'
+        // Clear the line before the launch line goes in. The shell above is the one WE exited to,
+        // hours ago — nothing stops a passer-by (or a stray paste, or the user's own aborted
+        // command) from having left a half-typed line at its prompt, and `deliverCommand`'s first
+        // write is not preceded by a Ctrl-U. The exit half clears the line for exactly this
+        // reason; the wake half owes the same. Deliberately HERE and not inside
+        // `performResumePhase`: that function's output is pinned byte-for-byte by Task 8's tests,
+        // and the restart path (which just cleared the line itself) must not clear it twice.
+        restartIo.write(KILL_LINE)
         return performResumePhase({
           agentId,
           sessionId: agentSessionId,

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -64,7 +64,10 @@ import {
   mayDisposeOffscreen,
   offscreenCoreIsRemote,
   offscreenDisposeMs,
-  planOffscreenVisibility
+  planOffscreenVisibility,
+  shouldDeferReleaseForEco,
+  OFFSCREEN_DEFER_RETRY_MS,
+  OFFSCREEN_DISPOSE_MS_DEFAULT
 } from '../terminal/offscreen-policy'
 import { attachGlyphGrid, type GlyphGridAttachment } from '../terminal/glyphgrid-attach'
 import type { GridHandle } from '../glyphgrid/engine'
@@ -88,6 +91,7 @@ import {
 import { deliverCommand, KILL_LINE, type DeliveryIo } from '../terminal/command-delivery'
 import {
   agentHibernateFns,
+  exitSequence,
   guardConcurrentRestart,
   isShellCommand,
   performExitPhase,
@@ -651,6 +655,38 @@ const restartSubs = new Map<string, () => void>()
  */
 const offscreenNodes = new Set<string>()
 
+/**
+ * Nodes whose session runs on ANOTHER machine (SSH project terminal, relay/remote-server tab).
+ * Published by the node itself, because the answer is a union of two independent facts only it can
+ * see (`offscreenRemoteRef`). Read by the hibernation sweep at PLAN time — see the policy's
+ * `remote` field for why excluding these only at the exit was not enough.
+ */
+const remoteNodes = new Set<string>()
+
+function setNodeRemote(nodeId: string, remote: boolean): void {
+  if (remote) remoteNodes.add(nodeId)
+  else remoteNodes.delete(nodeId)
+}
+
+/** Does this node's session live on another machine? Unknown answers `false` (a node that has not
+ *  reported is local until it says otherwise; the exit closure re-asks at fire time regardless). */
+export function isNodeRemote(nodeId: string): boolean {
+  return remoteNodes.has(nodeId)
+}
+
+/**
+ * The open kanban card modal's node, if any — the ONE thing that makes a node "being looked at"
+ * without the canvas observer knowing: the modal co-attaches the same tmux session over a canvas
+ * nobody can see, so its node is off-screen by every measurement and is nevertheless the session
+ * the user has open. Published by Canvas (which owns the modal), kept HERE so that the watched
+ * question has exactly one answer for all of its askers.
+ */
+let watchedNodeId: string | null = null
+
+export function setWatchedNode(nodeId: string | null): void {
+  watchedNodeId = nodeId
+}
+
 /** How long a freshly mounted node waits before asking to be woken: the spawn its resume line is
  *  written into is still in flight at mount (no session id, no pane). */
 const WAKE_MOUNT_DELAY_MS = 2000
@@ -663,9 +699,20 @@ function setNodeOffscreen(nodeId: string, offscreen: boolean): void {
   else offscreenNodes.delete(nodeId)
 }
 
-/** Is this node out of the viewport? Unknown answers `false` — see `offscreenNodes`. */
-export function isNodeOffscreen(nodeId: string): boolean {
-  return offscreenNodes.has(nodeId)
+/**
+ * "Is the user looking at this session RIGHT NOW?" — the one predicate behind every hibernation
+ * decision that turns on attention: the sweep's plan, the exit closure's fire-time re-ask, and the
+ * post-mark nudge. It has to be ONE function: the first version of this feature asked the question
+ * three times, and the fire-time copy was missing the modal clause — so a card modal opened
+ * mid-batch could still have `/exit` typed into it.
+ *
+ * Two ways to be watched, and the second is not visible to any observer: the node is on screen, or
+ * its kanban card modal is open (see `watchedNodeId`). Unknown answers WATCHED — a node whose
+ * observer has not delivered yet must never be read as "nobody is looking", which is the direction
+ * that quits a session out from under someone.
+ */
+export function isNodeWatched(nodeId: string): boolean {
+  return !offscreenNodes.has(nodeId) || watchedNodeId === nodeId
 }
 
 /**
@@ -910,6 +957,9 @@ export function TerminalNode({
   const [offscreenDown, setOffscreenDown] = useState(false)
   const offscreenDownRef = useRef(false)
   const offscreenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  /** When the current offscreen stretch began (null = on screen). The Eco deferral's cap is
+   *  measured against it, so it is stamped once per stretch, not per observer callback. */
+  const offscreenSinceRef = useRef<number | null>(null)
   const [offscreenEpoch, setOffscreenEpoch] = useState(0)
   /** The visibility observer's last verdict. Component-level (not per-lifecycle-run) because it
    *  must survive an offscreen dispose and because a budget client registered by a later run needs
@@ -999,6 +1049,12 @@ export function TerminalNode({
   // gemini names its own sessions but has no rename command, so it polls and never pushes.
   const canReadTitleNode = !!agentId && canReadTitle(agentId)
   const agentLabel = (agentId ? agentConfig(agentId) : undefined)?.label ?? 'Agent'
+  // Could this node's CLI ever be hibernated — quit AND brought back? A durable property of the
+  // agent, not of its current state: the offscreen release consults it to decide whether waiting
+  // for Eco is even meaningful here (see `shouldDeferReleaseForEco`).
+  const hibernationTarget = !!agentId && canResume(agentId) && !!exitSequence(agentId)
+  const hibernationTargetRef = useRef(hibernationTarget)
+  hibernationTargetRef.current = hibernationTarget
 
   // Keep the listener's mirrors current every render.
   titleAutoRef.current = data.titleAuto !== false
@@ -1046,6 +1102,14 @@ export function TerminalNode({
   // project long after the lifecycle run that would otherwise have captured the answer.
   const offscreenRemoteRef = useRef(false)
   offscreenRemoteRef.current = remoteSession || offscreenCoreIsRemote(session.source)
+  // …and published for the hibernation sweep, which needs the same answer at PLAN time (see the
+  // policy's `remote` field: excluding these only at the exit let two remote nodes occupy both
+  // batch slots forever). Re-published whenever it changes — a local project can become an SSH one.
+  const nodeIsRemote = offscreenRemoteRef.current
+  useEffect(() => {
+    setNodeRemote(id, nodeIsRemote)
+    return () => setNodeRemote(id, false)
+  }, [id, nodeIsRemote])
   const canMoveIntoWorktree =
     !!parentWtPath &&
     !parentWtStale &&
@@ -1113,7 +1177,7 @@ export function TerminalNode({
     const trigger = (): void => wakeRef.current()
     wakeSubs.set(id, trigger)
     const t = setTimeout(() => {
-      if (!isNodeOffscreen(id)) wakeRef.current()
+      if (isNodeWatched(id)) wakeRef.current()
     }, WAKE_MOUNT_DELAY_MS)
     return () => {
       clearTimeout(t)
@@ -2607,15 +2671,15 @@ export function TerminalNode({
     // (parked → remounted) terminal never reaches the spawn continuation.
     const unregisterHibernate = registerAgentHibernate(id, {
       exit: guardConcurrentRestart(id, async (): Promise<ExitPhaseOutcome> => {
-        // "Is this node STILL out of view?" — re-asked at FIRE time, never trusted from the plan,
-        // the same discipline as `mayDisposeOffscreen`. A sweep can spend ~12 s working through
-        // its batch, and the node whose turn comes last may be one the user panned back to and is
-        // now typing in: KILL_LINE + `/exit` would land in a pane they are watching, taking their
-        // half-written prompt with it. Worse, the visible EDGE has already passed by then, so no
-        // wake trigger is left and the node would sit SLEEPING on screen until clicked.
-        // (`isNodeOffscreen` and this node's own `wasVisibleRef` are the same observer's verdict;
-        // the map is used here so the sweep and the node cannot disagree.)
-        if (!isNodeOffscreen(id)) return 'not-eligible'
+        // "Is the user looking at this session STILL?" — re-asked at FIRE time, never trusted from
+        // the plan, the same discipline as `mayDisposeOffscreen`. A sweep can spend ~12 s working
+        // through its batch, and the node whose turn comes last may be one the user panned back to
+        // (or opened as a card modal) and is now typing in: KILL_LINE + `/exit` would land in a
+        // pane they are watching, taking their half-written prompt with it. Worse, the visible
+        // EDGE has already passed by then, so no wake trigger is left and the node would sit
+        // SLEEPING on screen until clicked. Deliberately the SAME `isNodeWatched` the plan and the
+        // nudge ask — a second copy of this question is how the modal clause went missing once.
+        if (isNodeWatched(id)) return 'not-eligible'
         // SSH / relay sessions are excluded in v1, exactly as the offscreen dispose excludes them
         // (offscreen-policy.ts): the exit and its much later resume would race the ControlMaster /
         // relay lifecycle, and a wake that cannot reach the host leaves a dead conversation behind.
@@ -2628,13 +2692,29 @@ export function TerminalNode({
         // permission prompt ANSWERS it).
         const gate = restartEligibility(agentId, st?.state, agentSessionId)
         if (!gate.ok || !agentId || !agentSessionId || !restartTarget()) return 'not-eligible'
-        return performExitPhase({
+        const outcome = await performExitPhase({
           agentId,
           sessionId: agentSessionId,
           io: restartIo,
           paneCommand: () => api.pty.paneCommand(id),
           isLive: restartTarget
         })
+        if (outcome === 'exited') {
+          // Remember WHAT the pane settled to. The wake will only type into a pane it recognizes,
+          // and its `isShellCommand` allowlist does not know `nu`, `xonsh` or `pwsh` — while the
+          // exit half accepts those through its allowlist-free "the command stopped being the CLI"
+          // signal. Without this record the wake is STRICTER than the exit that produced it, and
+          // such a user is hibernated and then never woken: the chip refuses forever.
+          // One extra poll rather than a value out of `performExitPhase`, whose behavior is pinned
+          // byte-for-byte by Task 8's tests. `null` (a pane we could not read) FORGETS the old
+          // value: a stale string must never stand in as permission to type into today's pane.
+          const settled = await queryPaneWithin(
+            () => api.pty.paneCommand(id),
+            RESTART_EXIT_TIMEOUT_MS
+          )
+          useAgentStatus.getState().setHibernatedPane(id, settled)
+        }
+        return outcome
       }),
       resume: guardConcurrentRestart(id, async (): Promise<ResumePhaseOutcome> => {
         const st = useAgentStatus.getState().byId[id]
@@ -2648,16 +2728,29 @@ export function TerminalNode({
         // mode is a property of how a session is LAUNCHED, so it is re-resolved now (a wake can be
         // hours after the exit, and days after the node was created).
         const base = resumeCommand(agentId, agentSessionId)
-        const command = base
-          ? withPermissionMode(base, agentId, await ensureActivePermissionMode(agentId))
-          : undefined
+        // Refused BEFORE anything is written. `performResumePhase` gates on this same bare command
+        // and would refuse too — but the KILL_LINE below is ours, so leaving this check to it
+        // meant an unusable session id erased the pane's line (three times, once per wake trigger)
+        // and then declined to resume.
+        if (!base) return 'not-eligible'
+        const command = withPermissionMode(
+          base,
+          agentId,
+          await ensureActivePermissionMode(agentId)
+        )
         // THE load-bearing gate of the wake half. Hours can pass between the exit and this
         // resume, and the pane is a REPL the user can type into: by now it may belong to vim, to
         // `top`, or to a claude the user launched by hand — and a launch line typed into a live
         // program is sent to that program, as a message or a mangled command. A pane we cannot
         // READ answers null and is refused for the same reason.
+        //
+        // Two ways to recognize it, mirroring the exit half's two: a KNOWN shell, or the exact
+        // command this node's own exit measured the pane settling to (`hibernatedPane`). The
+        // second is what keeps a `nu` / `xonsh` / `pwsh` user — whom the exit accepts through its
+        // allowlist-free signal — from being hibernated and never woken.
         const pane = await queryPaneWithin(() => api.pty.paneCommand(id), RESTART_EXIT_TIMEOUT_MS)
-        if (!isShellCommand(pane)) return 'not-eligible'
+        const settled = useAgentStatus.getState().byId[id]?.hibernatedPane
+        if (!isShellCommand(pane) && !(pane !== null && pane === settled)) return 'not-eligible'
         // Clear the line before the launch line goes in. The shell above is the one WE exited to,
         // hours ago — nothing stops a passer-by (or a stray paste, or the user's own aborted
         // command) from having left a half-typed line at its prompt, and `deliverCommand`'s first
@@ -3026,6 +3119,9 @@ export function TerminalNode({
         // conversation resumed before they can reach for the chip. No-op (one map lookup) for a
         // node that is not hibernated, which is every node in the default case.
         if (visible && !wasVisible) wakeRef.current()
+        // A visible node is not in an offscreen stretch at all — the next hidden edge starts a
+        // fresh clock for the Eco deferral's cap.
+        if (visible) offscreenSinceRef.current = null
         // …and the offscreen-dispose state machine. Every decision is the pure
         // `planOffscreenVisibility`; this block only executes the plan.
         const disposeMs = offscreenDisposeMs(
@@ -3047,7 +3143,11 @@ export function TerminalNode({
           setOffscreenEpoch((n) => n + 1) // re-run the lifecycle effect → fresh warm tmux attach
         }
         if (plan.armTimer && disposeMs !== null) {
-          offscreenTimerRef.current = setTimeout(() => {
+          // When this offscreen stretch began — the clock the Eco deferral's cap is measured
+          // against. Stamped only here, where a NEW timer is armed (the plan refuses to re-arm
+          // while one is pending), so a pan that keeps reporting hidden cannot keep pushing it out.
+          offscreenSinceRef.current = Date.now()
+          const fireRelease = (): void => {
             offscreenTimerRef.current = null
             // Every input re-asked at FIRE time, never at arm time: ten minutes is long enough for
             // all of them to have changed. `wasVisibleRef` is the observer's own latest verdict.
@@ -3059,16 +3159,43 @@ export function TerminalNode({
               })
             )
               return
+            // The setting can also have been switched OFF while this timer counted down; a fire
+            // that disposed anyway would take a buffer the user has just asked us to keep.
+            const liveSettings = useSettings.getState().settings
+            if (offscreenDisposeMs(liveSettings.offscreenTerminalMinutes) === null) return
             // Nothing to give back (no session yet, or one that was closed/ended under us) ⇒ no
             // dispose. A null ref means no lifecycle run is live at all, which answers the same way.
             if (!offscreenLiveRef.current?.()) return
+            // ECO ORDERING (see `shouldDeferReleaseForEco`): hibernate first, release second. This
+            // release would UNWIRE the node — the lifecycle effect tears down, the hibernate pair
+            // unregisters, and `planHibernation` then reads the node as unwired — and at the
+            // shipped defaults it fires at 10 minutes against a 30-minute idle window, so the
+            // canonical "finish a turn, pan away" session never hibernated at all. The viewer is
+            // ~15 MB; the CLI is hundreds. So wait for the big prize, on the sweep's own cadence,
+            // and only up to the capped total — a node that can never hibernate must not hold its
+            // viewer forever.
+            if (
+              shouldDeferReleaseForEco({
+                ecoEnabled: liveSettings.agentHibernationEnabled,
+                resumableAgent: hibernationTargetRef.current,
+                hibernated: !!useAgentStatus.getState().byId[id]?.hibernated,
+                offscreenElapsedMs: Date.now() - (offscreenSinceRef.current ?? Date.now()),
+                idleMinutes: liveSettings.agentHibernationIdleMinutes,
+                offscreenMinutes:
+                  liveSettings.offscreenTerminalMinutes ?? OFFSCREEN_DISPOSE_MS_DEFAULT / 60_000
+              })
+            ) {
+              offscreenTimerRef.current = setTimeout(fireRelease, OFFSCREEN_DEFER_RETRY_MS)
+              return
+            }
             offscreenDownRef.current = true
             // The cleanup must DISPOSE, not park: parking keeps the very buffer this feature exists
             // to give back. Set before the state flip, since that flip is what runs the cleanup.
             noParkIds.add(termKey)
             setOffscreenDown(true)
             setOffscreenEpoch((n) => n + 1)
-          }, disposeMs)
+          }
+          offscreenTimerRef.current = setTimeout(fireRelease, disposeMs)
         }
       },
       { rootMargin: '256px' }

--- a/src/renderer/state/agentStatus.persist.test.ts
+++ b/src/renderer/state/agentStatus.persist.test.ts
@@ -96,6 +96,56 @@ describe('loop persistence (cron/schedule survive an app restart)', () => {
     expect(Date.now() - st.lastEventAt!).toBeLessThan(5000) // hours-old clock replaced
   })
 
+  it('persists `hibernatedPane` with the flag and drops it on wake', async () => {
+    // What the pane settled to when the CLI let go: the wake's second way of recognizing a pane it
+    // may type into, for shells the `isShellCommand` allowlist does not know (nu/xonsh/pwsh).
+    // Kept past a wake it would be a standing permission to type into whatever that string names.
+    const store = memStorage()
+    vi.stubGlobal('localStorage', store)
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().setHibernatedPane('n15', 'nu')
+    useAgentStatus.getState().setHibernated('n15', true)
+    expect(JSON.parse(store.getItem('nodeterm.agentStatus')!).n15).toMatchObject({
+      hibernated: true,
+      hibernatedPane: 'nu'
+    })
+    useAgentStatus.getState().setHibernated('n15', false)
+    expect(useAgentStatus.getState().byId['n15'].hibernatedPane).toBeUndefined()
+    expect(JSON.parse(store.getItem('nodeterm.agentStatus')!).n15?.hibernatedPane).toBeUndefined()
+  })
+
+  it('forgets the recorded pane when the exit could not read one (null)', async () => {
+    vi.stubGlobal('localStorage', memStorage())
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().setHibernatedPane('n16', 'nu')
+    useAgentStatus.getState().setHibernatedPane('n16', null)
+    // A stale string must never stand in as permission to type into TODAY's pane.
+    expect(useAgentStatus.getState().byId['n16'].hibernatedPane).toBeUndefined()
+  })
+
+  it('drops `hibernatedPane` with the flag on the live-state self-heal', async () => {
+    vi.stubGlobal('localStorage', memStorage())
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().setHibernatedPane('n17', 'nu')
+    useAgentStatus.getState().setHibernated('n17', true)
+    useAgentStatus.getState().setState('n17', 'working', 'claude')
+    expect(useAgentStatus.getState().byId['n17'].hibernated).toBeUndefined()
+    expect(useAgentStatus.getState().byId['n17'].hibernatedPane).toBeUndefined()
+  })
+
+  it('never restores a recorded pane without the flag it belongs to', async () => {
+    vi.stubGlobal(
+      'localStorage',
+      memStorage({
+        'nodeterm.agentStatus': JSON.stringify({
+          n18: { unread: false, sessionId: 's', hibernatedPane: 'nu' }
+        })
+      })
+    )
+    const { useAgentStatus } = await import('./agentStatus')
+    expect(useAgentStatus.getState().byId['n18'].hibernatedPane).toBeUndefined()
+  })
+
   it('setHibernated(false) on a node that is not hibernated changes NOTHING', async () => {
     // Load-bearing since Canvas calls it on every SessionStart (a fresh launch disproves the
     // flag): the bail must not create an entry, must not touch the idle clock — which would hide

--- a/src/renderer/state/agentStatus.persist.test.ts
+++ b/src/renderer/state/agentStatus.persist.test.ts
@@ -48,6 +48,56 @@ describe('loop persistence (cron/schedule survive an app restart)', () => {
     })
   })
 
+  it('persists `hibernated` and drops the key when the node wakes', async () => {
+    const store = memStorage()
+    vi.stubGlobal('localStorage', store)
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().setHibernated('n1', true)
+    expect(JSON.parse(store.getItem('nodeterm.agentStatus')!).n1.hibernated).toBe(true)
+    useAgentStatus.getState().setHibernated('n1', false)
+    expect(JSON.parse(store.getItem('nodeterm.agentStatus') ?? '{}').n1?.hibernated).toBeUndefined()
+  })
+
+  it('restores `hibernated` on load (the CLI stays exited across an app restart)', async () => {
+    vi.stubGlobal(
+      'localStorage',
+      memStorage({
+        'nodeterm.agentStatus': JSON.stringify({ n4: { unread: false, sessionId: 's', hibernated: true } })
+      })
+    )
+    const { useAgentStatus } = await import('./agentStatus')
+    expect(useAgentStatus.getState().byId['n4']?.hibernated).toBe(true)
+  })
+
+  it('never persists `lastEventAt` — a stale idle clock would hibernate on relaunch', async () => {
+    const store = memStorage()
+    vi.stubGlobal('localStorage', store)
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().setState('n5', 'done', 'claude')
+    // The live entry carries the idle clock…
+    expect(useAgentStatus.getState().byId['n5'].lastEventAt).toBeTypeOf('number')
+    // …but nothing durable happened yet, so nothing was written at all.
+    useAgentStatus.getState().setSessionId('n5', 'sess-1')
+    const saved = JSON.parse(store.getItem('nodeterm.agentStatus')!)
+    expect(saved.n5.sessionId).toBe('sess-1')
+    expect(saved.n5.lastEventAt).toBeUndefined()
+    expect(saved.n5.stateAt).toBeUndefined()
+    expect(saved.n5.state).toBeUndefined()
+  })
+
+  it('stamps `lastEventAt` on a state transition only (same-state refresh keeps the idle clock)', async () => {
+    vi.stubGlobal('localStorage', memStorage())
+    const { useAgentStatus } = await import('./agentStatus')
+    const st = useAgentStatus.getState()
+    st.setState('n6', 'working', 'claude')
+    st.setState('n6', 'done', 'claude')
+    const first = useAgentStatus.getState().byId['n6'].lastEventAt!
+    expect(first).toBeTypeOf('number')
+    // A same-state event refreshes freshness, not the idle clock.
+    st.setState('n6', 'done', 'claude')
+    expect(useAgentStatus.getState().byId['n6'].lastEventAt).toBe(first)
+  })
+
   it('tolerates a persisted entry without loop (older format)', async () => {
     vi.stubGlobal(
       'localStorage',

--- a/src/renderer/state/agentStatus.persist.test.ts
+++ b/src/renderer/state/agentStatus.persist.test.ts
@@ -98,6 +98,46 @@ describe('loop persistence (cron/schedule survive an app restart)', () => {
     expect(useAgentStatus.getState().byId['n6'].lastEventAt).toBe(first)
   })
 
+  it('dismissLoopCard hides the card but KEEPS the entry — the job is still out there', async () => {
+    // The card's × has always promised "does not remove the job", but clearing the entry dropped
+    // the only record that a wakeup is pending — which is what stops Eco mode from `/exit`ing the
+    // CLI the wakeup lives in. So a dismiss now MARKS, and only the render filters on the mark.
+    const store = memStorage()
+    vi.stubGlobal('localStorage', store)
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().setLoop('n7', true, 'cron', { schedule: '0 9 * * *' })
+    useAgentStatus.getState().dismissLoopCard('n7')
+    expect(useAgentStatus.getState().byId['n7'].loop).toMatchObject({ kind: 'cron', dismissed: true })
+    const saved = JSON.parse(store.getItem('nodeterm.agentStatus')!)
+    expect(saved.n7.loop).toMatchObject({ kind: 'cron', dismissed: true })
+    // A real end (CronDelete) is still a real clear.
+    useAgentStatus.getState().setLoop('n7', false)
+    expect(useAgentStatus.getState().byId['n7'].loop).toBeUndefined()
+  })
+
+  it('restores `loop.dismissed` on load, and a new recurring event un-dismisses', async () => {
+    vi.stubGlobal(
+      'localStorage',
+      memStorage({
+        'nodeterm.agentStatus': JSON.stringify({
+          n8: { unread: false, loop: { count: 1, kind: 'schedule', items: [], dismissed: true } }
+        })
+      })
+    )
+    const { useAgentStatus } = await import('./agentStatus')
+    expect(useAgentStatus.getState().byId['n8'].loop).toMatchObject({ kind: 'schedule', dismissed: true })
+    // setLoop(active) rebuilds the entry from scratch — a freshly created job shows its card again.
+    useAgentStatus.getState().setLoop('n8', true, 'cron')
+    expect(useAgentStatus.getState().byId['n8'].loop?.dismissed).toBeUndefined()
+  })
+
+  it('is a no-op for a node with no loop entry', async () => {
+    vi.stubGlobal('localStorage', memStorage())
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().dismissLoopCard('n9')
+    expect(useAgentStatus.getState().byId['n9']).toBeUndefined()
+  })
+
   it('tolerates a persisted entry without loop (older format)', async () => {
     vi.stubGlobal(
       'localStorage',

--- a/src/renderer/state/agentStatus.persist.test.ts
+++ b/src/renderer/state/agentStatus.persist.test.ts
@@ -58,6 +58,44 @@ describe('loop persistence (cron/schedule survive an app restart)', () => {
     expect(JSON.parse(store.getItem('nodeterm.agentStatus') ?? '{}').n1?.hibernated).toBeUndefined()
   })
 
+  it('clears `hibernated` on a LIVE state — a hook event is proof the CLI is running', async () => {
+    // Left standing, the flag renders RUNNING and SLEEPING at once AND exempts the session from
+    // Eco for good (the sweep skips hibernated nodes). The three ways it goes stale are all real:
+    // the user relaunched the agent by hand, a wake landed, or a resume we could not confirm
+    // actually worked.
+    const store = memStorage()
+    vi.stubGlobal('localStorage', store)
+    const { useAgentStatus } = await import('./agentStatus')
+    for (const state of ['working', 'blocked', 'waiting'] as const) {
+      useAgentStatus.getState().setHibernated('n10', true)
+      useAgentStatus.getState().setState('n10', state, 'claude')
+      expect(useAgentStatus.getState().byId['n10'].hibernated, state).toBeUndefined()
+      // …and it reaches disk, or a relaunch would restore a flag we have disproved.
+      expect(JSON.parse(store.getItem('nodeterm.agentStatus')!).n10?.hibernated, state).toBeUndefined()
+      useAgentStatus.getState().setState('n10', undefined)
+    }
+  })
+
+  it('keeps `hibernated` through a `done` event — a late Stop must not undo the exit', async () => {
+    vi.stubGlobal('localStorage', memStorage())
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().setHibernated('n11', true)
+    useAgentStatus.getState().setState('n11', 'done', 'claude')
+    expect(useAgentStatus.getState().byId['n11'].hibernated).toBe(true)
+  })
+
+  it('waking restarts the idle clock, so a quiet resumed session is not re-hibernated', async () => {
+    vi.stubGlobal('localStorage', memStorage())
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.setState({
+      byId: { n12: { unread: false, state: 'done', lastEventAt: Date.now() - 6 * 3600_000, hibernated: true } }
+    })
+    useAgentStatus.getState().setHibernated('n12', false)
+    const st = useAgentStatus.getState().byId['n12']
+    expect(st.hibernated).toBeUndefined()
+    expect(Date.now() - st.lastEventAt!).toBeLessThan(5000) // hours-old clock replaced
+  })
+
   it('restores `hibernated` on load (the CLI stays exited across an app restart)', async () => {
     vi.stubGlobal(
       'localStorage',

--- a/src/renderer/state/agentStatus.persist.test.ts
+++ b/src/renderer/state/agentStatus.persist.test.ts
@@ -96,6 +96,22 @@ describe('loop persistence (cron/schedule survive an app restart)', () => {
     expect(Date.now() - st.lastEventAt!).toBeLessThan(5000) // hours-old clock replaced
   })
 
+  it('setHibernated(false) on a node that is not hibernated changes NOTHING', async () => {
+    // Load-bearing since Canvas calls it on every SessionStart (a fresh launch disproves the
+    // flag): the bail must not create an entry, must not touch the idle clock — which would hide
+    // a genuinely idle session from the sweep — and must not write.
+    const store = memStorage()
+    vi.stubGlobal('localStorage', store)
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().setHibernated('n13', false)
+    expect(useAgentStatus.getState().byId['n13']).toBeUndefined()
+    const idle = Date.now() - 45 * 60_000
+    useAgentStatus.setState({ byId: { n14: { unread: false, state: 'done', lastEventAt: idle } } })
+    useAgentStatus.getState().setHibernated('n14', false)
+    expect(useAgentStatus.getState().byId['n14'].lastEventAt).toBe(idle)
+    expect(store.getItem('nodeterm.agentStatus')).toBeNull()
+  })
+
   it('restores `hibernated` on load (the CLI stays exited across an app restart)', async () => {
     vi.stubGlobal(
       'localStorage',

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -78,6 +78,20 @@ export interface AgentNodeStatus {
   loop?: {
     count: number
     kind: 'loop' | 'schedule' | 'cron'
+    /**
+     * The user dismissed the CARD, but the job itself is still out there. Only `cron`/`schedule`
+     * ever carry this: those outlive turns, sessions and app restarts, so "I don't want to look at
+     * this card" and "this job is gone" are different statements — and the card's × has always
+     * said so ("does not remove the job"). An in-session `/loop` still clears outright; it dies
+     * with its session anyway.
+     *
+     * It matters beyond the card: `loop` is the ONLY record that this node has a wakeup pending,
+     * and it is what stops Eco mode from hibernating it (`/exit` kills the CLI process, and the
+     * scheduled wakeup dies with it — a silently cancelled job). Clearing the entry on dismiss
+     * dropped that guard while the job lived on, so the fact is now retained and only the RENDER
+     * filters on it. A real end (CronDelete) still clears the entry.
+     */
+    dismissed?: boolean
     /** Schedule expression (cron) shown as a sub-label. */
     schedule?: string
     /** The task/prompt — shown in full and re-issued by the node's Play button. */
@@ -123,6 +137,9 @@ export interface AgentStatusStore {
     kind?: 'loop' | 'schedule' | 'cron',
     opts?: { schedule?: string; task?: string }
   ): void
+  /** Hide a cron/schedule CARD while keeping the fact that the job exists (see `loop.dismissed`).
+   *  No-op if the node has no loop entry. */
+  dismissLoopCard(id: string): void
   /** Record a /loop iteration (count++ and append its summary). No-op if not looping. */
   bumpLoop(id: string, message?: string): void
   remove(id: string): void
@@ -210,6 +227,9 @@ export function createAgentStatusSession(
             task: v.loop.task,
             items: Array.isArray(v.loop.items) ? v.loop.items : []
           }
+          // A dismissed card must STAY dismissed across a restart — and the fact it hides
+          // (a live cron/schedule job) must stay readable to the hibernation guard.
+          if (v.loop.dismissed) out[id].loop.dismissed = true
         }
       }
       return out
@@ -388,6 +408,15 @@ export function createAgentStatusSession(
         if (!prev.loop) return s
         const { loop: _drop, ...rest } = prev
         const byId = { ...s.byId, [id]: rest }
+        save(byId)
+        return { byId }
+      }),
+
+    dismissLoopCard: (id) =>
+      set((s) => {
+        const prev = s.byId[id]
+        if (!prev?.loop || prev.loop.dismissed) return s
+        const byId = { ...s.byId, [id]: { ...prev, loop: { ...prev.loop, dismissed: true } } }
         save(byId)
         return { byId }
       }),

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -42,6 +42,22 @@ export interface AgentNodeStatus {
    * interrupt-inference baseline. Same-state events refresh it in place (no re-render).
    */
   stateAt?: number
+  /**
+   * When this node last CHANGED state — the idle clock the hibernation policy reads
+   * (`terminal/hibernation-policy.ts`). Deliberately not `stateAt`: that one is refreshed by
+   * every same-state event (freshness), while "how long has this session been idle" means "how
+   * long since the turn ended". TRANSIENT — never persisted: a relaunch has seen no events yet,
+   * and a stale stamp read as "idle since before the restart" would hibernate a session the
+   * moment the app came back. Absent ⇒ unknown idle ⇒ never a hibernation candidate.
+   */
+  lastEventAt?: number
+  /**
+   * The agent CLI was exited to reclaim its RAM ("Eco" mode) and its conversation is waiting to be
+   * resumed when the node is next viewed. PERSISTED beside unread/session/sessionId: the tmux
+   * session outlives the app, so after a relaunch this flag is the only thing that knows the pane
+   * holds a shell rather than a live CLI.
+   */
+  hibernated?: boolean
   /** Which agent this node is running (claude/codex/gemini/…), when known. */
   agentId?: AgentId
   /** A turn finished / needs attention while the user wasn't looking. */
@@ -89,6 +105,8 @@ export interface AgentStatusStore {
   sweepStaleWorking(staleMs?: number): void
   setSession(id: string, session: string): void
   setSessionId(id: string, sessionId: string): void
+  /** Mark the node's agent CLI as exited-for-RAM (true) or live again (false). Persisted. */
+  setHibernated(id: string, on: boolean): void
   markUnread(id: string): void
   /**
    * Drop a node's unread flag. By default a clear of a FINISHED (done) node also ACKs the read
@@ -178,6 +196,9 @@ export function createAgentStatusSession(
       const out: Record<string, AgentNodeStatus> = {}
       for (const [id, v] of Object.entries(data)) {
         out[id] = { unread: !!v.unread, session: v.session, sessionId: v.sessionId, agentId: v.agentId }
+        // Only when set: an absent flag stays absent, so an entry saved before this field
+        // existed hydrates byte-identically (and `hibernated: false` never grows in the file).
+        if (v.hibernated) out[id].hibernated = true
         // A recurring job (cron/schedule — and tmux keeps in-session loops alive too) outlives
         // the app: restore its card. Minimal shape check so a corrupt entry can't break load.
         if (v.loop && typeof v.loop === 'object' && v.loop.kind) {
@@ -202,13 +223,14 @@ export function createAgentStatusSession(
     try {
       const out: Record<string, Partial<AgentNodeStatus>> = {}
       for (const [id, v] of Object.entries(byId)) {
-        if (v.unread || v.session || v.sessionId || v.loop || v.agentId) {
+        if (v.unread || v.session || v.sessionId || v.loop || v.agentId || v.hibernated) {
           out[id] = {
             unread: v.unread,
             session: v.session,
             sessionId: v.sessionId,
             agentId: v.agentId,
-            loop: v.loop
+            loop: v.loop,
+            hibernated: v.hibernated
           }
         }
       }
@@ -258,7 +280,10 @@ export function createAgentStatusSession(
           if (s.byId[id]) s.byId[id].stateAt = now
           return s
         }
-        const next = { ...prev, state, stateAt: now }
+        // The ONE place a state transition is recorded, so it is also the one place the idle
+        // clock is stamped (the same-state fast path above deliberately does not touch it —
+        // see `lastEventAt`).
+        const next = { ...prev, state, stateAt: now, lastEventAt: now }
         if (agentId !== undefined) next.agentId = agentId
         // Retain the approval ticket only while blocked; any other state clears it (transient).
         next.pendingId = state === 'blocked' ? (pendingId ?? prev.pendingId) : undefined
@@ -293,6 +318,18 @@ export function createAgentStatusSession(
         const prev = s.byId[id] ?? EMPTY
         if (prev.sessionId === sessionId) return s
         const byId = { ...s.byId, [id]: { ...prev, sessionId } }
+        save(byId)
+        return { byId }
+      }),
+
+    setHibernated: (id, on) =>
+      set((s) => {
+        const prev = s.byId[id] ?? EMPTY
+        if (!!prev.hibernated === on) return s
+        // Cleared by dropping the key, not by storing `false`: `save` skips entries that carry
+        // nothing durable, so a woken node leaves no residue behind in localStorage.
+        const next = { ...prev, hibernated: on ? true : undefined }
+        const byId = { ...s.byId, [id]: next }
         save(byId)
         return { byId }
       }),

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -6,8 +6,9 @@ import type { NodeTerminalApi } from '@shared/types'
 
 /**
  * Transient per-node status for agent (e.g. Claude Code) sessions, driven by the agent's hooks.
- * `unread`, `session`, `sessionId` and `agentId` are persisted to localStorage so they survive
- * a reload/restart; the live `state` (working/waiting/…) is not (it'd be stale on relaunch).
+ * `unread`, `session`, `sessionId`, `agentId`, `loop` and `hibernated` are persisted to
+ * localStorage so they survive a reload/restart; the live `state` (working/waiting/…) is not
+ * (it'd be stale on relaunch), and neither are its two clocks (`stateAt`, `lastEventAt`).
  * `agentId` is durable because a PLAIN terminal's agent identity exists nowhere else: an
  * explicit agent node re-derives it from `data.agentId`, but a hand-launched `claude` in a
  * plain terminal is only known here, and its context links must keep classifying across

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -120,7 +120,9 @@ export interface AgentStatusStore {
   sweepStaleWorking(staleMs?: number): void
   setSession(id: string, session: string): void
   setSessionId(id: string, sessionId: string): void
-  /** Mark the node's agent CLI as exited-for-RAM (true) or live again (false). Persisted. */
+  /** Mark the node's agent CLI as exited-for-RAM (true) or live again (false). Persisted.
+   *  Waking also restarts the idle clock (`lastEventAt`), so a quiet resumed session is not
+   *  re-hibernated on the next sweep. */
   setHibernated(id: string, on: boolean): void
   markUnread(id: string): void
   /**
@@ -308,7 +310,23 @@ export function createAgentStatusSession(
         if (agentId !== undefined) next.agentId = agentId
         // Retain the approval ticket only while blocked; any other state clears it (transient).
         next.pendingId = state === 'blocked' ? (pendingId ?? prev.pendingId) : undefined
-        return { byId: { ...s.byId, [id]: next } }
+        // A LIVE state is proof the CLI is running, so the hibernated flag is simply wrong and is
+        // dropped here — the one self-heal this flag has. It is set by a controller that watched
+        // the CLI let go of the pane, but the world moves on without us: the user relaunches the
+        // agent by hand, a wake lands and its `--resume` starts reporting, or a resume we could
+        // not confirm turns out to have worked. Left standing, the flag is not cosmetic: it
+        // renders RUNNING and SLEEPING side by side, and (because a hibernated node is skipped by
+        // the sweep) exempts that session from Eco for good.
+        // `done` deliberately does NOT clear it — a hibernated node's last known state IS done,
+        // and a late Stop POST arriving after the exit would undo the hibernation we just did.
+        const alive = state === 'working' || state === 'blocked' || state === 'waiting'
+        if (alive && prev.hibernated) next.hibernated = undefined
+        const byId = { ...s.byId, [id]: next }
+        // `state` itself is transient, so a plain transition writes nothing — but dropping a
+        // PERSISTED flag has to reach disk, or a relaunch would restore a hibernated node that
+        // has been demonstrably running since.
+        if (alive && prev.hibernated) save(byId)
+        return { byId }
       }),
 
     sweepStaleWorking: (staleMs = STALE_WORKING_MS) =>
@@ -350,6 +368,13 @@ export function createAgentStatusSession(
         // Cleared by dropping the key, not by storing `false`: `save` skips entries that carry
         // nothing durable, so a woken node leaves no residue behind in localStorage.
         const next = { ...prev, hibernated: on ? true : undefined }
+        // Waking RESTARTS the idle clock. Without this, a node whose conversation was resumed but
+        // whose CLI then sits quiet (an agent that fires no hook until you talk to it) still
+        // carries the `lastEventAt` from before it was hibernated — hours old — so the very next
+        // sweep, 60 s later, would quit the session the user just came back to. Hibernating does
+        // not touch the clock: nothing happened in that session, and the flag itself is what keeps
+        // the sweep off it.
+        if (!on) next.lastEventAt = Date.now()
         const byId = { ...s.byId, [id]: next }
         save(byId)
         return { byId }

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -59,6 +59,19 @@ export interface AgentNodeStatus {
    * holds a shell rather than a live CLI.
    */
   hibernated?: boolean
+  /**
+   * What the pane's foreground command settled to once the CLI let go of it — recorded at the
+   * moment of hibernation, persisted beside the flag, and dropped with it.
+   *
+   * The wake refuses to type a launch line into a pane it does not recognize as a shell, and its
+   * allowlist (`isShellCommand`) knows zsh/bash/fish/… but not `nu`, `xonsh` or `pwsh`. The EXIT
+   * half has a second, allowlist-free signal for exactly those users (the foreground command
+   * stopped being the CLI, twice in a row) — so without this the wake is STRICTER than the exit,
+   * and a `nu` user could be hibernated and then never woken: the chip would refuse forever.
+   * Remembering what we exited TO closes that gap, and it is narrow by construction: it permits
+   * one specific string, on one specific node, recorded by us.
+   */
+  hibernatedPane?: string
   /** Which agent this node is running (claude/codex/gemini/…), when known. */
   agentId?: AgentId
   /** A turn finished / needs attention while the user wasn't looking. */
@@ -124,6 +137,9 @@ export interface AgentStatusStore {
    *  Waking also restarts the idle clock (`lastEventAt`), so a quiet resumed session is not
    *  re-hibernated on the next sweep. */
   setHibernated(id: string, on: boolean): void
+  /** Record what the pane settled to when this node's CLI let go of it (`null` = forget: a stale
+   *  value must never permit a wake into a pane we did not measure). See `hibernatedPane`. */
+  setHibernatedPane(id: string, pane: string | null): void
   markUnread(id: string): void
   /**
    * Drop a node's unread flag. By default a clear of a FINISHED (done) node also ACKs the read
@@ -219,6 +235,10 @@ export function createAgentStatusSession(
         // Only when set: an absent flag stays absent, so an entry saved before this field
         // existed hydrates byte-identically (and `hibernated: false` never grows in the file).
         if (v.hibernated) out[id].hibernated = true
+        // Only alongside the flag: the pane we exited TO is meaningless (and, as a wake
+        // permission, unwanted) once the node is not hibernated any more.
+        if (v.hibernated && typeof v.hibernatedPane === 'string')
+          out[id].hibernatedPane = v.hibernatedPane
         // A recurring job (cron/schedule — and tmux keeps in-session loops alive too) outlives
         // the app: restore its card. Minimal shape check so a corrupt entry can't break load.
         if (v.loop && typeof v.loop === 'object' && v.loop.kind) {
@@ -253,7 +273,9 @@ export function createAgentStatusSession(
             sessionId: v.sessionId,
             agentId: v.agentId,
             loop: v.loop,
-            hibernated: v.hibernated
+            hibernated: v.hibernated,
+            // Never written without the flag it belongs to (see `hibernatedPane`).
+            hibernatedPane: v.hibernated ? v.hibernatedPane : undefined
           }
         }
       }
@@ -320,7 +342,10 @@ export function createAgentStatusSession(
         // `done` deliberately does NOT clear it — a hibernated node's last known state IS done,
         // and a late Stop POST arriving after the exit would undo the hibernation we just did.
         const alive = state === 'working' || state === 'blocked' || state === 'waiting'
-        if (alive && prev.hibernated) next.hibernated = undefined
+        if (alive && prev.hibernated) {
+          next.hibernated = undefined
+          next.hibernatedPane = undefined // goes with the flag, always
+        }
         const byId = { ...s.byId, [id]: next }
         // `state` itself is transient, so a plain transition writes nothing — but dropping a
         // PERSISTED flag has to reach disk, or a relaunch would restore a hibernated node that
@@ -367,7 +392,15 @@ export function createAgentStatusSession(
         if (!!prev.hibernated === on) return s
         // Cleared by dropping the key, not by storing `false`: `save` skips entries that carry
         // nothing durable, so a woken node leaves no residue behind in localStorage.
-        const next = { ...prev, hibernated: on ? true : undefined }
+        // The recorded pane belongs to THIS hibernation: it goes with the flag, in both
+        // directions. Kept past a wake it would be a standing permission to type into whatever
+        // that string names, long after we measured it.
+        const next: AgentNodeStatus = {
+          ...prev,
+          hibernated: on ? true : undefined,
+          // Hibernating KEEPS what the exit closure just recorded; waking drops it.
+          hibernatedPane: on ? prev.hibernatedPane : undefined
+        }
         // Waking RESTARTS the idle clock. Without this, a node whose conversation was resumed but
         // whose CLI then sits quiet (an agent that fires no hook until you talk to it) still
         // carries the `lastEventAt` from before it was hibernated — hours old — so the very next
@@ -376,6 +409,16 @@ export function createAgentStatusSession(
         // the sweep off it.
         if (!on) next.lastEventAt = Date.now()
         const byId = { ...s.byId, [id]: next }
+        save(byId)
+        return { byId }
+      }),
+
+    setHibernatedPane: (id, pane) =>
+      set((s) => {
+        const prev = s.byId[id] ?? EMPTY
+        const next = pane ?? undefined
+        if (prev.hibernatedPane === next) return s
+        const byId = { ...s.byId, [id]: { ...prev, hibernatedPane: next } }
         save(byId)
         return { byId }
       }),

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1396,6 +1396,25 @@ body,
   color: #bf7af0;
 }
 
+/* SLEEPING: the agent CLI was exited to reclaim its RAM (Eco); the session itself is fine, so
+   this is the quietest chip on the header — grey, no pulse. It is a <button> (click = resume),
+   which the base chip's styling does not cover. */
+.term-node__status--sleeping {
+  color: var(--muted);
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+.term-node__status--sleeping:hover {
+  color: var(--text);
+}
+
 .term-node__status--attention .term-node__status-dot {
   animation: nt-pulse 1.1s ease-in-out infinite;
 }
@@ -7606,6 +7625,11 @@ body,
 .kanban-badge--needs {
   color: var(--warn);
   background: rgba(255, 159, 10, 0.12);
+}
+/* Eco: the agent CLI was exited to reclaim RAM. Quiet — the session is fine. */
+.kanban-badge--sleeping {
+  color: var(--muted);
+  background: rgba(var(--tint-rgb), 0.08);
 }
 .kanban-card__unread {
   width: 7px;

--- a/src/renderer/terminal/agent-restart.test.ts
+++ b/src/renderer/terminal/agent-restart.test.ts
@@ -3,6 +3,7 @@ import { resumeCommand } from '../../shared/agents/config'
 import { withPermissionMode } from '../../shared/agents/approval-mode'
 import {
   __resetAgentRestartForTests,
+  agentHibernateFns,
   agentRestartFn,
   exitSequence,
   guardConcurrentRestart,
@@ -11,12 +12,15 @@ import {
   performRestartResume,
   performResumePhase,
   planBulkRestart,
+  registerAgentHibernate,
   registerAgentRestart,
   restartEligibility,
   settleRestart,
   summarizeBulkRestart,
   summarizeOutcomes,
+  type AgentHibernateFns,
   type BulkRestartCandidate,
+  type ExitPhaseOutcome,
   type RestartOutcome
 } from './agent-restart'
 
@@ -539,6 +543,29 @@ describe('performExitPhase', () => {
     expect(written).toEqual([])
   })
 
+  it('needs the changed reading TWICE before it calls an unlisted shell an exit', async () => {
+    // The allowlist cannot know `nu` / `xonsh` / a hand-set defaultShell, so "the foreground
+    // command is no longer what it was" is the other exit signal — and it is required on two
+    // CONSECUTIVE polls, because a single changed reading can be a momentary foreground CHILD of a
+    // still-running CLI. Typing the resume line into a live CLI would send it as a message.
+    const { io } = fakeIo()
+    const panes = ['claude', 'git', 'claude', 'nu', 'nu']
+    let i = 0
+    const p = performExitPhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      // The pre-flight consumes the first reading, so `before` is 'claude'.
+      paneCommand: async () => panes[Math.min(i++, panes.length - 1)] ?? null,
+      timeoutMs: 5000,
+      pollMs: 100
+    })
+    await vi.advanceTimersByTimeAsync(150) // poll 1 → 'git': changed, but not yet twice
+    await vi.advanceTimersByTimeAsync(100) // poll 2 → 'claude': the CLI is still there
+    await vi.advanceTimersByTimeAsync(250) // polls 3+4 → 'nu' twice in a row
+    expect(await p).toBe('exited')
+  })
+
   it('stops polling a pane that dies under the wait', async () => {
     const { io } = fakeIo()
     let live = true
@@ -628,6 +655,24 @@ describe('performResumePhase', () => {
     expect(settled).toBe(false) // written, but still un-submitted through the verify retries
     await vi.advanceTimersByTimeAsync(10_000)
     expect(await p).toBe('resumed')
+  })
+
+  it('rejects when the transport throws after the delivery announced itself', async () => {
+    // The delivery can announce its end from INSIDE deliverCommand's synchronous body and THEN
+    // throw (a transport that rejects the very first write ends the delivery, then reports). A
+    // promise resolved on that announcement could no longer be rejected, and the caller would
+    // record a resume — a woken node, with a dead pane and nothing typed into it.
+    const io = {
+      write() {
+        throw new Error('socket CONNECTING')
+      },
+      onData() {
+        return () => {}
+      }
+    }
+    await expect(
+      performResumePhase({ agentId: 'claude', sessionId: 'sid-1', io })
+    ).rejects.toThrow('socket CONNECTING')
   })
 
   it('respects isLive: a session that died under the delivery is not a resume', async () => {
@@ -931,6 +976,53 @@ describe('agent restart registry', () => {
     const fn = async (): Promise<RestartOutcome> => 'restarted'
     registerAgentRestart('n2', fn)()
     expect(agentRestartFn('n2')).toBeUndefined()
+  })
+})
+
+describe('agent hibernate registry', () => {
+  beforeEach(() => __resetAgentRestartForTests())
+
+  const pair = (tag: 'a' | 'b'): AgentHibernateFns => ({
+    exit: async () => (tag === 'a' ? 'exited' : 'exit-timeout'),
+    resume: async () => 'resumed'
+  })
+
+  it('registers, resolves and unregisters; re-register supersedes', () => {
+    const a = pair('a')
+    const un = registerAgentHibernate('n1', a)
+    expect(agentHibernateFns('n1')).toBe(a)
+    const b = pair('b')
+    registerAgentHibernate('n1', b)
+    un() // stale unregister from the superseded registration must be inert
+    expect(agentHibernateFns('n1')).toBe(b)
+  })
+
+  it('drops a live registration on unregister (node unmount)', () => {
+    registerAgentHibernate('n2', pair('a'))()
+    expect(agentHibernateFns('n2')).toBeUndefined()
+  })
+
+  it('is cleared by the test reset, like the restart registry', () => {
+    registerAgentHibernate('n3', pair('a'))
+    __resetAgentRestartForTests()
+    expect(agentHibernateFns('n3')).toBeUndefined()
+  })
+
+  it('shares one in-flight guard with restarts: a sweep cannot quit a pane mid-restart', async () => {
+    // Both halves go through `guardConcurrentRestart` with the NODE id, so the hibernation sweep,
+    // the wake and a user restart serialize against each other — two `/exit` lines into one pane
+    // is the exact accident the guard exists for.
+    let release: (o: RestartOutcome) => void = () => {}
+    const restart = guardConcurrentRestart(
+      'n-shared',
+      () => new Promise<RestartOutcome>((r) => (release = r))
+    )
+    const hibernateExit = guardConcurrentRestart('n-shared', async (): Promise<ExitPhaseOutcome> => 'exited')
+    const running = restart()
+    expect(await hibernateExit()).toBe('not-eligible')
+    release('restarted')
+    expect(await running).toBe('restarted')
+    expect(await hibernateExit()).toBe('exited') // pane free again
   })
 })
 

--- a/src/renderer/terminal/agent-restart.test.ts
+++ b/src/renderer/terminal/agent-restart.test.ts
@@ -7,7 +7,9 @@ import {
   exitSequence,
   guardConcurrentRestart,
   isShellCommand,
+  performExitPhase,
   performRestartResume,
+  performResumePhase,
   planBulkRestart,
   registerAgentRestart,
   restartEligibility,
@@ -444,6 +446,202 @@ describe('performRestartResume', () => {
     await vi.advanceTimersByTimeAsync(2000)
     expect(await p).toBe('exit-timeout')
     expect(handles).toEqual([])
+  })
+})
+
+describe('performExitPhase', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('quits the CLI and reports exited once the pane reports a shell — writing nothing after', async () => {
+    const { written, io } = fakeIo()
+    let pane = 'claude'
+    const p = performExitPhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      paneCommand: async () => pane,
+      timeoutMs: 6000,
+      pollMs: 100
+    })
+    await vi.advanceTimersByTimeAsync(250) // a few polls while the CLI is still up
+    pane = 'zsh'
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(await p).toBe('exited')
+    // The exit phase's ENTIRE output: clear the line, then the CLI's own exit command. The resume
+    // line belongs to the other phase, so nothing here may reach the pane after `/exit`.
+    expect(written).toEqual(['\x15', '/exit\r'])
+  })
+
+  it('writes NOTHING and refuses when the pre-flight probe answers null', async () => {
+    const { written, io } = fakeIo()
+    const p = performExitPhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      paneCommand: async () => null, // tmux off / no binary — the poll could never end
+      timeoutMs: 1000,
+      pollMs: 100
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+    // A pane we cannot WATCH must never be quit: the CLI would die with the resume never sent.
+    expect(await p).toBe('not-eligible')
+    expect(written).toEqual([])
+  })
+
+  it('reports exit-timeout, without a resume, when the CLI never lets go of the pane', async () => {
+    const { written, io } = fakeIo()
+    const p = performExitPhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      paneCommand: async () => 'claude',
+      timeoutMs: 1000,
+      pollMs: 100
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(await p).toBe('exit-timeout')
+    expect(written).toEqual(['\x15', '/exit\r']) // never force-killed, never resumed
+  })
+
+  it('refuses a session we could never resume into — the exit alone would lose it', async () => {
+    const { written, io } = fakeIo()
+    expect(
+      await performExitPhase({
+        agentId: 'claude',
+        sessionId: '-bad', // rejected by resumeCommand's SAFE_SESSION_ID
+        io,
+        paneCommand: async () => 'zsh'
+      })
+    ).toBe('not-eligible')
+    expect(
+      await performExitPhase({
+        agentId: 'opencode', // resumable, but no exit sequence
+        sessionId: 's',
+        io,
+        paneCommand: async () => 'zsh'
+      })
+    ).toBe('not-eligible')
+    expect(written).toEqual([])
+  })
+
+  it('respects isLive: a session already gone is never written to', async () => {
+    const { written, io } = fakeIo()
+    expect(
+      await performExitPhase({
+        agentId: 'claude',
+        sessionId: 'sid-1',
+        io,
+        paneCommand: async () => 'zsh',
+        isLive: () => false
+      })
+    ).toBe('not-eligible')
+    expect(written).toEqual([])
+  })
+
+  it('stops polling a pane that dies under the wait', async () => {
+    const { io } = fakeIo()
+    let live = true
+    const p = performExitPhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      paneCommand: async () => 'claude',
+      timeoutMs: 5000,
+      pollMs: 100,
+      isLive: () => live
+    })
+    await vi.advanceTimersByTimeAsync(150)
+    live = false
+    await vi.advanceTimersByTimeAsync(200)
+    expect(await p).toBe('not-eligible') // not a timeout: there is no pane left to time out in
+  })
+})
+
+describe('performResumePhase', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('delivers the bare resume command and reports resumed once the delivery settles', async () => {
+    const { written, io } = fakeIo()
+    const p = performResumePhase({ agentId: 'claude', sessionId: 'sid-1', io })
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(await p).toBe('resumed')
+    expect(written.join('')).toContain('claude --resume sid-1')
+    expect(written.join('')).not.toContain('/exit') // the exit belongs to the other phase
+  })
+
+  it("prefers the caller's command (permission mode) over the bare one", async () => {
+    const { written, io } = fakeIo()
+    const p = performResumePhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      command: 'claude --resume sid-1 --permission-mode plan'
+    })
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(await p).toBe('resumed')
+    expect(written.join('')).toContain('claude --resume sid-1 --permission-mode plan')
+  })
+
+  it('keeps the bare command as the gate even when the caller overrides it', async () => {
+    const { written, io } = fakeIo()
+    expect(
+      await performResumePhase({
+        agentId: 'claude',
+        sessionId: '-bad',
+        io,
+        command: 'claude --resume -bad --permission-mode plan'
+      })
+    ).toBe('not-eligible')
+    expect(written).toEqual([])
+  })
+
+  it('hands the delivery cancel out as the delivery starts', async () => {
+    const { written, io } = silentIo()
+    let cancel: (() => void) | undefined
+    const p = performResumePhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      onDelivery: (c) => {
+        cancel = c
+      }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(typeof cancel).toBe('function')
+    const delivered = written.length
+    cancel?.()
+    expect(await p).toBe('resumed')
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(written.length).toBe(delivered) // no retries into a torn-down transport
+  })
+
+  it('resolves only once the resume line has left the pane', async () => {
+    const { io } = silentIo()
+    let settled = false
+    const p = performResumePhase({ agentId: 'claude', sessionId: 'sid-1', io }).then((o) => {
+      settled = true
+      return o
+    })
+    await vi.advanceTimersByTimeAsync(200)
+    expect(settled).toBe(false) // written, but still un-submitted through the verify retries
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(await p).toBe('resumed')
+  })
+
+  it('respects isLive: a session that died under the delivery is not a resume', async () => {
+    const { io } = fakeIo()
+    let live = true
+    const p = performResumePhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      isLive: () => live
+    })
+    live = false
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(await p).toBe('not-eligible')
   })
 })
 

--- a/src/renderer/terminal/agent-restart.ts
+++ b/src/renderer/terminal/agent-restart.ts
@@ -197,6 +197,12 @@ export async function performExitPhase(d: {
 /**
  * PHASE 2 — echo-deliver the resume command into a pane the CLI has already let go of.
  *
+ * Deliberately NOT gated on `exitSequence`: this half only types a launch line into a pane that is
+ * already free, so a CLI we have no way to ASK to quit is still perfectly resumable here (the exit
+ * half owns that question). What gates this half is the bare `resumeCommand` below — the session id
+ * has to be one this app would put on a command line. Hibernation's wake path relies on the split:
+ * it drives this half alone, hours after the exit.
+ *
  * Resolves only once the resume line has actually LEFT the pane (deliverCommand's echo-verify
  * retries run for up to DELIVERY_ATTEMPTS × VERIFY_TIMEOUT_MS after the first write). The
  * un-submitted line is the pane's most fragile moment — anything typed into it during that window
@@ -287,9 +293,10 @@ export async function performResumePhase(d: {
  * function's four outcomes are unchanged: `'exited'` continues, anything else from the exit half
  * is passed through as-is, and a `'resumed'` is what the caller reads as `'restarted'`.
  *
- * The eligibility gate is repeated here so a refusal costs no phase call at all; both halves
- * re-check it themselves, since either can be driven directly (hibernation quits a pane in one
- * phase and resumes it much later in the other).
+ * No gate of its own: `performExitPhase` refuses (writing nothing) on exactly the same two facts —
+ * no exit sequence, or a session id `resumeCommand` would not put on a command line — and it runs
+ * first, so a copy here could only drift. Both halves re-check for themselves because either can be
+ * driven directly: hibernation quits a pane in one phase and resumes it much later in the other.
  */
 export async function performRestartResume(d: {
   agentId: string
@@ -312,9 +319,6 @@ export async function performRestartResume(d: {
    */
   isLive?: () => boolean
 }): Promise<RestartOutcome> {
-  // The BARE command is the gate even when the caller overrides it: `resumeCommand` is what
-  // validates the session id before it reaches a command line.
-  if (!exitSequence(d.agentId) || !resumeCommand(d.agentId, d.sessionId)) return 'not-eligible'
   const exited = await performExitPhase({
     agentId: d.agentId,
     sessionId: d.sessionId,
@@ -347,7 +351,13 @@ const inFlight = new Set<string>()
  * reach the same node, and two runs against one pane would write two `/exit` lines (the second
  * typed INTO the CLI the first is resuming) and two resume commands.
  *
- * The node is held for the WHOLE run, delivery included (see performRestartResume's header): a
+ * ONE set for every kind of run: a hibernation exit, a wake resume and a user restart all pass
+ * through here, so a sweep cannot quit the pane a menu restart is already resuming, and vice versa.
+ * Generic in the outcome so the two halves can be guarded on their own (`ExitPhaseOutcome` /
+ * `ResumePhaseOutcome`), which is what hibernation drives — the refusal is `'not-eligible'`, a
+ * member of every one of those unions.
+ *
+ * The node is held for the WHOLE run, delivery included (see performResumePhase's header): a
  * second `/exit` arriving while the resume line sits un-submitted in the pane would be spliced
  * into it and submit `claude --resume <sid>/exit` — the exact mangled line command-delivery.ts
  * exists to prevent, and likeliest precisely when echo verification is being slow.
@@ -357,10 +367,10 @@ const inFlight = new Set<string>()
  * does not count — so a doubled request is neither counted twice as restarted nor reported as a
  * failure the user could act on. (The alternative, a fifth outcome, would break that frozen line.)
  */
-export function guardConcurrentRestart(
+export function guardConcurrentRestart<T extends string>(
   nodeId: string,
-  fn: () => Promise<RestartOutcome>
-): () => Promise<RestartOutcome> {
+  fn: () => Promise<T>
+): () => Promise<T | 'not-eligible'> {
   return async () => {
     if (inFlight.has(nodeId)) return 'not-eligible'
     inFlight.add(nodeId)
@@ -389,12 +399,44 @@ export function agentRestartFn(nodeId: string): (() => Promise<RestartOutcome>) 
   return restartFns.get(nodeId)
 }
 
-/** TEST ONLY (house pattern: webgl-budget's `__resetWebglBudgetForTests`): both maps above are
+/**
+ * A node's two HIBERNATION halves, registered together because they are useless apart: the sweep
+ * quits the CLI now, and the wake resumes the same conversation minutes or hours later.
+ *
+ * Separate from `restartFns` on purpose — a restart is one indivisible action, hibernation is two
+ * that are deliberately far apart in time — but both are built by the SAME node from the same
+ * `io` / `paneCommand` / `isLive`, and both go through `guardConcurrentRestart`, so the sweep, the
+ * wake and a user restart can never write into one pane at once.
+ */
+export interface AgentHibernateFns {
+  /** Ask the CLI to quit and wait for the pane. `'exited'` is the only outcome that may be
+   *  recorded as hibernated — anything else leaves the node exactly as it was. */
+  exit: () => Promise<ExitPhaseOutcome>
+  /** Re-launch the conversation with the provider's own `--resume`. */
+  resume: () => Promise<ResumePhaseOutcome>
+}
+
+const hibernateFns = new Map<string, AgentHibernateFns>()
+
+/** Register a node's hibernate/wake pair; returns an unregister that is inert if superseded. */
+export function registerAgentHibernate(nodeId: string, fns: AgentHibernateFns): () => void {
+  hibernateFns.set(nodeId, fns)
+  return () => {
+    if (hibernateFns.get(nodeId) === fns) hibernateFns.delete(nodeId)
+  }
+}
+
+export function agentHibernateFns(nodeId: string): AgentHibernateFns | undefined {
+  return hibernateFns.get(nodeId)
+}
+
+/** TEST ONLY (house pattern: webgl-budget's `__resetWebglBudgetForTests`): the maps above are
  *  module-global, so a test that leaves a restart in flight would otherwise refuse the next
  *  test's restart of the same node id. */
 export function __resetAgentRestartForTests(): void {
   inFlight.clear()
   restartFns.clear()
+  hibernateFns.clear()
 }
 
 // ── Bulk run: who gets restarted, and how the run is summed up ──────────────────────────

--- a/src/renderer/terminal/agent-restart.ts
+++ b/src/renderer/terminal/agent-restart.ts
@@ -88,8 +88,17 @@ export const RESTART_DELIVERY_TIMEOUT_MS = DELIVERY_ATTEMPTS * VERIFY_TIMEOUT_MS
  * One bounded pane query. Unbounded, a wedged tmux server (or a relay whose IPC never answers)
  * would hang the restart — and with it the bulk run's summary — forever. A lapsed, failed or
  * empty query reads as `null`: "we cannot see this pane right now".
+ *
+ * Exported for hibernation's WAKE, which asks the same question for a sharper reason: hours pass
+ * between the exit and the resume, so the pane may since have been given to vim, to `top`, or to a
+ * CLI the user launched by hand — and the resume's first write is un-KILL_LINE'd, so it would be
+ * spliced into whatever is there. One definition, not a second copy in the node (a duplicated rule
+ * drifts; see CLAUDE.md's "Adding a new agent" rule 10).
  */
-async function queryPane(fn: () => Promise<string | null>, ms: number): Promise<string | null> {
+export async function queryPaneWithin(
+  fn: () => Promise<string | null>,
+  ms: number
+): Promise<string | null> {
   let lapse: ReturnType<typeof setTimeout> | undefined
   try {
     return await Promise.race([
@@ -159,7 +168,7 @@ export async function performExitPhase(d: {
   // ── Pre-flight: prove we can SEE this pane before quitting anything in it (see the header).
   // Reported as `'not-eligible'`, the outcome that means "not a target right now" and is the one
   // the menu and the notice already have wording for. Nothing has been written at this point.
-  const before = await queryPane(d.paneCommand, timeoutMs)
+  const before = await queryPaneWithin(d.paneCommand, timeoutMs)
   if (before === null || gone()) return 'not-eligible'
   // Clear the prompt before typing the exit command. The pane is a REPL the user types into: a
   // half-written prompt left in it would otherwise be submitted as `…refactor the/exit` — the
@@ -178,7 +187,7 @@ export async function performExitPhase(d: {
   let last: string | null = null
   for (;;) {
     await new Promise((r) => setTimeout(r, pollMs))
-    const pane = await queryPane(d.paneCommand, Math.max(0, deadline - Date.now()))
+    const pane = await queryPaneWithin(d.paneCommand, Math.max(0, deadline - Date.now()))
     if (gone()) return 'not-eligible' // stop polling a pane that no longer exists
     // Two ways to know the CLI let go of the pane. The allowlist is the confident one and is
     // taken immediately. The other — "the foreground command is no longer what it was before the

--- a/src/renderer/terminal/agent-restart.ts
+++ b/src/renderer/terminal/agent-restart.ts
@@ -105,11 +105,18 @@ async function queryPane(fn: () => Promise<string | null>, ms: number): Promise<
   }
 }
 
+/** The exit half's own outcomes. `'exited'` means only that the CLI let go of the pane — the
+ *  conversation is not back until the resume half has delivered. */
+export type ExitPhaseOutcome = 'exited' | 'exit-timeout' | 'not-eligible'
+
+/** The resume half's own outcomes. `'not-eligible'` covers both refusals: a session id that could
+ *  never reach a command line, and a pane that stopped existing under the delivery. */
+export type ResumePhaseOutcome = 'resumed' | 'not-eligible'
+
 /**
- * In-place CLI restart: ask the agent to quit, wait until the CLI has let go of the pane, then
- * echo-deliver the resume command into it. Never force-kills — on timeout the CLI is left
- * running and the caller reports the node. Once the exit has been sent, `paneCommand` errors count
- * as "not a shell yet"; the timeout is the backstop.
+ * PHASE 1 — ask the agent to quit and wait until the CLI has let go of the pane. Never
+ * force-kills: on timeout the CLI is left running and the caller reports the node. Once the exit
+ * has been sent, `paneCommand` errors count as "not a shell yet"; the timeout is the backstop.
  *
  * NOTHING is written until one `paneCommand` has come back non-null. The exit command is
  * irreversible — the conversation is only recoverable through the `--resume` that follows it — so
@@ -118,53 +125,30 @@ async function queryPane(fn: () => Promise<string | null>, ms: number): Promise<
  * relaunch never sent, and the user told (after 6s of polling) that "the session was left
  * running". The pre-flight makes that state a plain `'not-eligible'`, with an untouched pane.
  *
- * Resolves only once the resume line has actually LEFT the pane (deliverCommand's echo-verify
- * retries run for up to DELIVERY_ATTEMPTS × VERIFY_TIMEOUT_MS after the first write). The
- * un-submitted line is the pane's most fragile moment — anything typed into it during that window
- * is spliced into the command — so "this restart is over" must mean the delivery settled, not that
- * it was started. `guardConcurrentRestart` frees the node on exactly that boundary.
+ * The bare `resumeCommand` is a gate HERE too, not only in the resume half: a session this app
+ * would refuse to resume must not be exited either, or the exit alone would lose it. Hibernation
+ * (which quits a pane it means to bring back later) depends on that refusal being decided before
+ * the first byte is written.
  */
-export async function performRestartResume(d: {
+export async function performExitPhase(d: {
   agentId: string
   sessionId: string
   io: DeliveryIo
   paneCommand: () => Promise<string | null>
-  /**
-   * The exact launch line to relaunch with, when the caller has one. `withPermissionMode` is the
-   * app's single funnel for every CLI launch, and it needs the ACTIVE mode — an async read that
-   * belongs to the node, not to this module. Without it a canvas running in `acceptEdits` / `plan`
-   * would come back from a bulk restart in the default mode and start prompting.
-   *
-   * Eligibility is still decided by the bare `resumeCommand` below: a session id this app would
-   * not put on a command line (SAFE_SESSION_ID) refuses the restart before anything is written,
-   * whatever the caller passes.
-   */
-  command?: string
   timeoutMs?: number
   pollMs?: number
-  /** Backstop for the resume delivery; see RESTART_DELIVERY_TIMEOUT_MS. */
-  deliveryTimeoutMs?: number
   /**
-   * Handed `deliverCommand`'s cancel the moment a delivery starts — and only then. The delivery
-   * outlives this promise (it runs on its own echo-verify timers), so its lifetime belongs to
-   * whoever owns the transport: a node torn down mid-restart cancels it here instead of letting
-   * a retry rewrite, or the fail-open submit, land in a dead session.
-   */
-  onDelivery?: (cancel: () => void) => void
-  /**
-   * "Is the pane we are restarting still there?" — asked before the exit is written, on every
-   * poll, and once more after the delivery, before a restart is reported. A session can die under
-   * a restart (the node is deleted or respawned, or another client destroys the tmux session): its
-   * io then silently no-ops and reporting `'restarted'` would put a phantom in the bulk summary.
+   * "Is the pane we are quitting still there?" — asked before the exit is written and on every
+   * poll. A session can die under a restart (the node is deleted or respawned, or another client
+   * destroys the tmux session), and there is then no pane left to fail in.
    */
   isLive?: () => boolean
-}): Promise<RestartOutcome> {
+}): Promise<ExitPhaseOutcome> {
   const exit = exitSequence(d.agentId)
   const base = resumeCommand(d.agentId, d.sessionId)
-  // The BARE command is the gate even when the caller overrides it: `resumeCommand` is what
-  // validates the session id before it reaches a command line.
+  // The BARE command is the gate: `resumeCommand` is what validates the session id before it
+  // reaches a command line, and a session we could not resume must not be quit.
   if (!exit || !base) return 'not-eligible'
-  const cmd = d.command ?? base
   const timeoutMs = d.timeoutMs ?? RESTART_EXIT_TIMEOUT_MS
   const pollMs = d.pollMs ?? RESTART_POLL_MS
   // A dead session is not a restart that failed — there is no pane left to fail in. `'not-eligible'`
@@ -203,11 +187,59 @@ export async function performRestartResume(d: {
     // already quit and never resumed. It is required on two CONSECUTIVE polls: a single changed
     // reading can be a momentary foreground child of a still-running CLI, and typing the resume
     // line into a live CLI would send it as a message.
-    if (isShellCommand(pane)) break
-    if (pane !== null && pane !== before && pane === last) break
+    if (isShellCommand(pane)) return 'exited'
+    if (pane !== null && pane !== before && pane === last) return 'exited'
     last = pane
     if (Date.now() > deadline) return 'exit-timeout'
   }
+}
+
+/**
+ * PHASE 2 — echo-deliver the resume command into a pane the CLI has already let go of.
+ *
+ * Resolves only once the resume line has actually LEFT the pane (deliverCommand's echo-verify
+ * retries run for up to DELIVERY_ATTEMPTS × VERIFY_TIMEOUT_MS after the first write). The
+ * un-submitted line is the pane's most fragile moment — anything typed into it during that window
+ * is spliced into the command — so "this delivery is over" must mean it settled, not that it was
+ * started. `guardConcurrentRestart` frees the node on exactly that boundary.
+ */
+export async function performResumePhase(d: {
+  agentId: string
+  sessionId: string
+  io: DeliveryIo
+  /**
+   * The exact launch line to relaunch with, when the caller has one. `withPermissionMode` is the
+   * app's single funnel for every CLI launch, and it needs the ACTIVE mode — an async read that
+   * belongs to the node, not to this module. Without it a canvas running in `acceptEdits` / `plan`
+   * would come back from a bulk restart in the default mode and start prompting.
+   *
+   * Eligibility is still decided by the bare `resumeCommand` below: a session id this app would
+   * not put on a command line (SAFE_SESSION_ID) refuses the delivery before anything is written,
+   * whatever the caller passes.
+   */
+  command?: string
+  /** Backstop for the resume delivery; see RESTART_DELIVERY_TIMEOUT_MS. */
+  deliveryTimeoutMs?: number
+  /**
+   * Handed `deliverCommand`'s cancel the moment a delivery starts — and only then. The delivery
+   * outlives this promise (it runs on its own echo-verify timers), so its lifetime belongs to
+   * whoever owns the transport: a node torn down mid-restart cancels it here instead of letting
+   * a retry rewrite, or the fail-open submit, land in a dead session.
+   */
+  onDelivery?: (cancel: () => void) => void
+  /**
+   * Asked once more after the delivery, before a resume is reported: a session that died under it
+   * had the delivery cancelled by the teardown, so nothing reached the pane and reporting success
+   * would put a phantom in the bulk summary.
+   */
+  isLive?: () => boolean
+}): Promise<ResumePhaseOutcome> {
+  const base = resumeCommand(d.agentId, d.sessionId)
+  // The BARE command is the gate even when the caller overrides it: `resumeCommand` is what
+  // validates the session id before it reaches a command line.
+  if (!base) return 'not-eligible'
+  const cmd = d.command ?? base
+  const gone = (): boolean => !!d.isLive && !d.isLive()
   // Awaited, not fire-and-forget: see the header. `deliverCommand` is started inside the executor
   // (synchronously, so `onDelivery` still hands the cancel out before any await) and announces the
   // end of the delivery — submitted, fail-open or cancelled — through `settle`.
@@ -244,8 +276,67 @@ export async function performRestartResume(d: {
     lapse = setTimeout(resolve, d.deliveryTimeoutMs ?? RESTART_DELIVERY_TIMEOUT_MS)
   })
   // The session can have died while the line was being verified — the delivery is then cancelled by
-  // the teardown and nothing reached the pane, so don't claim a restart.
-  return gone() ? 'not-eligible' : 'restarted'
+  // the teardown and nothing reached the pane, so don't claim a resume.
+  return gone() ? 'not-eligible' : 'resumed'
+}
+
+/**
+ * In-place CLI restart: the two phases above, in order. Ask the agent to quit, wait until the CLI
+ * has let go of the pane (`performExitPhase`), then echo-deliver the resume command into it
+ * (`performResumePhase`). Composition only — every rule lives in one of the two halves, and this
+ * function's four outcomes are unchanged: `'exited'` continues, anything else from the exit half
+ * is passed through as-is, and a `'resumed'` is what the caller reads as `'restarted'`.
+ *
+ * The eligibility gate is repeated here so a refusal costs no phase call at all; both halves
+ * re-check it themselves, since either can be driven directly (hibernation quits a pane in one
+ * phase and resumes it much later in the other).
+ */
+export async function performRestartResume(d: {
+  agentId: string
+  sessionId: string
+  io: DeliveryIo
+  paneCommand: () => Promise<string | null>
+  /** See `performResumePhase`: the caller's launch line (permission mode), gated by the bare one. */
+  command?: string
+  timeoutMs?: number
+  pollMs?: number
+  /** Backstop for the resume delivery; see RESTART_DELIVERY_TIMEOUT_MS. */
+  deliveryTimeoutMs?: number
+  /** Handed `deliverCommand`'s cancel as the delivery starts; see `performResumePhase`. */
+  onDelivery?: (cancel: () => void) => void
+  /**
+   * "Is the pane we are restarting still there?" — asked before the exit is written, on every
+   * poll, and once more after the delivery, before a restart is reported. A session can die under
+   * a restart (the node is deleted or respawned, or another client destroys the tmux session): its
+   * io then silently no-ops and reporting `'restarted'` would put a phantom in the bulk summary.
+   */
+  isLive?: () => boolean
+}): Promise<RestartOutcome> {
+  // The BARE command is the gate even when the caller overrides it: `resumeCommand` is what
+  // validates the session id before it reaches a command line.
+  if (!exitSequence(d.agentId) || !resumeCommand(d.agentId, d.sessionId)) return 'not-eligible'
+  const exited = await performExitPhase({
+    agentId: d.agentId,
+    sessionId: d.sessionId,
+    io: d.io,
+    paneCommand: d.paneCommand,
+    timeoutMs: d.timeoutMs,
+    pollMs: d.pollMs,
+    isLive: d.isLive
+  })
+  // `'exit-timeout'` / `'not-eligible'` mean the same things they always did, so they are the
+  // restart's outcome verbatim — nothing has been resumed and nothing more may be written.
+  if (exited !== 'exited') return exited
+  const resumed = await performResumePhase({
+    agentId: d.agentId,
+    sessionId: d.sessionId,
+    io: d.io,
+    command: d.command,
+    deliveryTimeoutMs: d.deliveryTimeoutMs,
+    onDelivery: d.onDelivery,
+    isLive: d.isLive
+  })
+  return resumed === 'resumed' ? 'restarted' : resumed
 }
 
 // ── One restart at a time, per node ──────────────────────────────────────────────────────

--- a/src/renderer/terminal/hibernation-policy.test.ts
+++ b/src/renderer/terminal/hibernation-policy.test.ts
@@ -9,6 +9,7 @@ const base = (id: string, over: object = {}) => ({
   wired: true,
   offscreen: true,
   hibernated: false,
+  remote: false,
   recurring: false,
   liveSubagents: false,
   lastEventAt: 0,
@@ -91,6 +92,24 @@ describe('planHibernation', () => {
     expect(planHibernation([base('a', { wired: false })], NOW, cfg)).toEqual([])
     expect(planHibernation([base('a', { offscreen: false })], NOW, cfg)).toEqual([])
     expect(planHibernation([base('a', { hibernated: true })], NOW, cfg)).toEqual([])
+  })
+
+  it('excludes REMOTE sessions here, not only at the exit — the batch is a slice', () => {
+    expect(planHibernation([base('a', { remote: true })], NOW, cfg)).toEqual([])
+    // The reason it must be excluded at PLAN time: two remote nodes at the head of the oldest-idle
+    // order would fill both slots on every pass, and the local node behind them would never be
+    // reached — Eco silently doing nothing on the machine it was enabled for.
+    expect(
+      planHibernation(
+        [
+          base('r1', { remote: true, lastEventAt: 0 }),
+          base('r2', { remote: true, lastEventAt: 1 }),
+          base('local', { lastEventAt: 2 })
+        ],
+        NOW,
+        cfg
+      )
+    ).toEqual(['local'])
   })
 
   it('empty candidate list → empty', () => {

--- a/src/renderer/terminal/hibernation-policy.test.ts
+++ b/src/renderer/terminal/hibernation-policy.test.ts
@@ -70,6 +70,17 @@ describe('planHibernation', () => {
     expect(planHibernation([base('a', { lastEventAt: NOW - 30 * 60_000 })], NOW, cfg)).toEqual(['a'])
   })
 
+  it('refuses a non-positive / unreadable idle window — settings.json is hand-editable', () => {
+    // settings.json is hand-edited and merged without clamping, so any of these can reach here.
+    // Each must read as "off": a 0 or negative window makes EVERY done+offscreen node eligible on
+    // the first sweep — Eco would exit live CLIs the instant a turn ends.
+    for (const idleMinutes of [0, -1, -30, NaN, null as unknown as number, undefined as unknown as number]) {
+      expect(planHibernation([base('a')], NOW, { ...cfg, idleMinutes }), String(idleMinutes)).toEqual([])
+    }
+    // …but a small positive window is honored, not floored away.
+    expect(planHibernation([base('a', { lastEventAt: NOW - 60_000 })], NOW, { ...cfg, idleMinutes: 1 })).toEqual(['a'])
+  })
+
   it('refuses a node the restart gate itself refuses (no session id / not resumable)', () => {
     expect(planHibernation([base('a', { sessionId: undefined })], NOW, cfg)).toEqual([])
     expect(planHibernation([base('a', { agentId: 'opencode' })], NOW, cfg)).toEqual([])

--- a/src/renderer/terminal/hibernation-policy.test.ts
+++ b/src/renderer/terminal/hibernation-policy.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { planHibernation, HIBERNATE_BATCH_MAX } from './hibernation-policy'
+
+const base = (id: string, over: object = {}) => ({
+  id,
+  agentId: 'claude',
+  state: 'done',
+  sessionId: 's-' + id,
+  wired: true,
+  offscreen: true,
+  hibernated: false,
+  recurring: false,
+  liveSubagents: false,
+  lastEventAt: 0,
+  ...over
+})
+const cfg = { enabled: true, idleMinutes: 30 }
+const NOW = 100 * 60_000
+
+describe('planHibernation', () => {
+  it('takes only done, offscreen, wired, long-idle nodes; oldest first; max 2', () => {
+    const out = planHibernation(
+      [
+        base('a', { lastEventAt: 10 * 60_000 }),
+        base('b', { lastEventAt: 5 * 60_000 }),
+        base('c', { lastEventAt: 1 * 60_000 }),
+        base('d', { state: 'working' }),
+        base('e', { offscreen: false }),
+        base('f', { lastEventAt: undefined }),
+        base('g', { hibernated: true }),
+        base('h', { wired: false }),
+        base('i', { state: 'waiting' }),
+        base('j', { recurring: true }),
+        base('k', { liveSubagents: true })
+      ],
+      NOW,
+      cfg
+    )
+    expect(out).toEqual(['c', 'b'])
+    expect(HIBERNATE_BATCH_MAX).toBe(2)
+  })
+
+  it('never hibernates a recurring (loop/cron/schedule) node, however idle', () => {
+    expect(planHibernation([base('a', { recurring: true, lastEventAt: 0 })], NOW, cfg)).toEqual([])
+  })
+
+  it('never hibernates a node with a live subagent, however idle', () => {
+    expect(planHibernation([base('a', { liveSubagents: true, lastEventAt: 0 })], NOW, cfg)).toEqual(
+      []
+    )
+  })
+
+  it('never hibernates a waiting node — the question would be swallowed', () => {
+    expect(planHibernation([base('a', { state: 'waiting' })], NOW, cfg)).toEqual([])
+    expect(planHibernation([base('a', { state: 'blocked' })], NOW, cfg)).toEqual([])
+    expect(planHibernation([base('a', { state: undefined })], NOW, cfg)).toEqual([])
+  })
+
+  it('never hibernates a node with no lastEventAt — unknown idle is not idle', () => {
+    expect(planHibernation([base('a', { lastEventAt: undefined })], NOW, cfg)).toEqual([])
+  })
+
+  it('disabled → empty', () => {
+    expect(planHibernation([base('a')], NOW, { ...cfg, enabled: false })).toEqual([])
+  })
+
+  it('idle window respected', () => {
+    expect(planHibernation([base('a', { lastEventAt: NOW - 29 * 60_000 })], NOW, cfg)).toEqual([])
+    // Exactly at the window is eligible (>=, not >).
+    expect(planHibernation([base('a', { lastEventAt: NOW - 30 * 60_000 })], NOW, cfg)).toEqual(['a'])
+  })
+
+  it('refuses a node the restart gate itself refuses (no session id / not resumable)', () => {
+    expect(planHibernation([base('a', { sessionId: undefined })], NOW, cfg)).toEqual([])
+    expect(planHibernation([base('a', { agentId: 'opencode' })], NOW, cfg)).toEqual([])
+    expect(planHibernation([base('a', { agentId: undefined })], NOW, cfg)).toEqual([])
+  })
+
+  it('excludes unwired, onscreen and already-hibernated nodes', () => {
+    expect(planHibernation([base('a', { wired: false })], NOW, cfg)).toEqual([])
+    expect(planHibernation([base('a', { offscreen: false })], NOW, cfg)).toEqual([])
+    expect(planHibernation([base('a', { hibernated: true })], NOW, cfg)).toEqual([])
+  })
+
+  it('empty candidate list → empty', () => {
+    expect(planHibernation([], NOW, cfg)).toEqual([])
+  })
+})

--- a/src/renderer/terminal/hibernation-policy.ts
+++ b/src/renderer/terminal/hibernation-policy.ts
@@ -1,0 +1,88 @@
+/**
+ * Which idle agent sessions may be HIBERNATED — the pure decision half of "Eco" mode
+ * (`settings.agentHibernationEnabled`). Hibernating means the agent CLI is asked to `/exit` and
+ * the conversation is resumed (`--resume`) the next time the user looks at the node: the tmux
+ * session, its pane and its scrollback are untouched; what is reclaimed is the CLI process's RAM.
+ * The wiring that acts on this plan lives elsewhere — this module only decides.
+ *
+ * WHY EACH EXCLUSION EXISTS (each one is a way to lose the user's work or their attention):
+ *
+ *  - **Only `done`, never `waiting`** (nor `blocked`, nor an unknown state). `waiting`/`blocked`
+ *    mean the CLI is holding a question or a permission request open for the user. Exiting there
+ *    would SILENTLY SWALLOW A NEEDS-YOU QUESTION — the badge is exactly the thing the user is
+ *    being asked to come back for, and the exit line typed into a permission prompt would ANSWER
+ *    it rather than quit. `working` is refused for the obvious reason (a turn in flight), and an
+ *    unknown state is not evidence of idleness.
+ *  - **Never a `recurring` node** (`/loop`, `/schedule`, `/cron`, any kind). `/exit` kills the CLI
+ *    PROCESS, and a loop's `ScheduleWakeup` / an in-session cron wakeup dies with it — the job
+ *    would simply never fire again. Between iterations such a node looks EXACTLY like the target
+ *    profile (`done`, offscreen, long idle), so this guard is the only thing standing between Eco
+ *    mode and a silently cancelled recurring job.
+ *  - **Never a node with live subagents.** Claude launches subagents async: the completion of an
+ *    async-launched subagent is queued into the PARENT's transcript, and a dead parent CLI never
+ *    reads it. Hibernating the parent orphans every subagent still running under it.
+ *  - **Unknown idle is NOT idle.** A candidate with no `lastEventAt` (no hook event has ever been
+ *    seen for it in this run) is never eligible — the same rule as pendingLaunch's "an unknown
+ *    dependency state is not satisfied". Guessing here costs the user a live session.
+ *  - **`restartEligibility` is the shared gate.** Hibernation is exit + resume, so a node this
+ *    module picks must be one the restart machinery could actually bring back: a CLI we cannot
+ *    quit or resume, or a session with no provider session id, has nothing to resume INTO.
+ *
+ * The batch cap keeps a sweep from stopping a canvas full of agents at once (each exit + resume
+ * is real work in a real pane): the oldest-idle nodes go first, at most `HIBERNATE_BATCH_MAX` per
+ * pass, so a long-idle backlog drains over several sweeps instead of in one storm.
+ */
+import { restartEligibility } from './agent-restart'
+
+/** How many sessions one hibernation pass may take. */
+export const HIBERNATE_BATCH_MAX = 2
+
+export interface HibernationCandidate {
+  id: string
+  agentId?: string
+  state?: string
+  sessionId?: string
+  /** The node has a live terminal/PTY wired up (an unwired node has nothing to exit). */
+  wired: boolean
+  /** The node is out of view. */
+  offscreen: boolean
+  /** Already hibernated — nothing left to reclaim. */
+  hibernated: boolean
+  /** Any `/loop`, `/schedule` or `/cron` indicator on this node (from `agentStatus.loop`). */
+  recurring: boolean
+  /** Any non-done subagent card whose parent is this node (from `state/agentNodes.ts`). */
+  liveSubagents: boolean
+  /** When this node's last hook event landed. Absent = never seen ⇒ never eligible. */
+  lastEventAt?: number
+}
+
+export interface HibernationConfig {
+  enabled: boolean
+  idleMinutes: number
+}
+
+/** The node ids to hibernate now: oldest-idle first, at most `HIBERNATE_BATCH_MAX`. */
+export function planHibernation(
+  candidates: HibernationCandidate[],
+  nowMs: number,
+  cfg: HibernationConfig
+): string[] {
+  if (!cfg.enabled) return []
+  const idleMs = cfg.idleMinutes * 60_000
+  return candidates
+    .filter(
+      (c) =>
+        !c.hibernated &&
+        c.wired &&
+        c.offscreen &&
+        c.state === 'done' &&
+        !c.recurring &&
+        !c.liveSubagents &&
+        restartEligibility(c.agentId, c.state, c.sessionId).ok &&
+        // `?? Infinity`: no event ever seen ⇒ the difference is -Infinity ⇒ never eligible.
+        nowMs - (c.lastEventAt ?? Infinity) >= idleMs
+    )
+    .sort((a, b) => (a.lastEventAt ?? 0) - (b.lastEventAt ?? 0))
+    .slice(0, HIBERNATE_BATCH_MAX)
+    .map((c) => c.id)
+}

--- a/src/renderer/terminal/hibernation-policy.ts
+++ b/src/renderer/terminal/hibernation-policy.ts
@@ -68,6 +68,12 @@ export function planHibernation(
   cfg: HibernationConfig
 ): string[] {
   if (!cfg.enabled) return []
+  // The window is re-validated HERE, not trusted from the type: settings.json is hand-editable and
+  // merged without clamping, so `idleMinutes` can arrive as null, NaN, 0 or negative — and the UI
+  // clamp only guards keystrokes. Each of those would make the window zero or negative, i.e. EVERY
+  // done+offscreen node eligible on the first sweep: Eco exiting live CLIs the instant a turn ends.
+  // So an unreadable window reads as "off" — the same call `offscreenDisposeMs` makes one file over.
+  if (!(cfg.idleMinutes > 0)) return []
   const idleMs = cfg.idleMinutes * 60_000
   return candidates
     .filter(

--- a/src/renderer/terminal/hibernation-policy.ts
+++ b/src/renderer/terminal/hibernation-policy.ts
@@ -24,6 +24,10 @@
  *  - **Unknown idle is NOT idle.** A candidate with no `lastEventAt` (no hook event has ever been
  *    seen for it in this run) is never eligible — the same rule as pendingLaunch's "an unknown
  *    dependency state is not satisfied". Guessing here costs the user a live session.
+ *  - **Never a REMOTE session** (SSH project / relay tab) in v1 — and excluded at PLAN time, not
+ *    only when the exit is attempted: the plan is a deterministic sort-and-slice, so two remote
+ *    nodes at the head of the oldest-idle order would occupy both batch slots on every pass and no
+ *    local node would ever hibernate.
  *  - **`restartEligibility` is the shared gate.** Hibernation is exit + resume, so a node this
  *    module picks must be one the restart machinery could actually bring back: a CLI we cannot
  *    quit or resume, or a session with no provider session id, has nothing to resume INTO.
@@ -52,6 +56,19 @@ export interface HibernationCandidate {
   offscreen: boolean
   /** Already hibernated — nothing left to reclaim. */
   hibernated: boolean
+  /**
+   * The session runs on ANOTHER MACHINE (an SSH project's terminal, or a relay/remote-server tab).
+   * Excluded in v1, the same call the offscreen dispose makes: the exit and its much later resume
+   * would race the ControlMaster / relay lifecycle, and a wake that cannot reach the host leaves a
+   * dead conversation behind.
+   *
+   * Excluded HERE and not only at the moment of the exit, because this plan is a deterministic
+   * sort-and-slice: two remote nodes sitting at the head of the oldest-idle order would fill both
+   * batch slots on every pass, refuse at fire time, and no local node would ever be hibernated —
+   * a feature that silently does nothing, which is the hardest kind of failure to notice. The
+   * fire-time check stays as the freshness re-ask (a project can BECOME an SSH project).
+   */
+  remote: boolean
   /** Any `/loop`, `/schedule` or `/cron` indicator on this node (from `agentStatus.loop`). */
   recurring: boolean
   /** Any non-done subagent card whose parent is this node (from `state/agentNodes.ts`). */
@@ -83,6 +100,7 @@ export function planHibernation(
     .filter(
       (c) =>
         !c.hibernated &&
+        !c.remote &&
         c.wired &&
         c.offscreen &&
         c.state === 'done' &&

--- a/src/renderer/terminal/hibernation-policy.ts
+++ b/src/renderer/terminal/hibernation-policy.ts
@@ -37,6 +37,10 @@ import { restartEligibility } from './agent-restart'
 /** How many sessions one hibernation pass may take. */
 export const HIBERNATE_BATCH_MAX = 2
 
+/** How often the canvas re-asks. Coarse on purpose: the shortest window the setting offers is
+ *  measured in minutes, so a faster sweep would only pay for a plan that cannot have changed. */
+export const HIBERNATE_SWEEP_MS = 60_000
+
 export interface HibernationCandidate {
   id: string
   agentId?: string

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -4,7 +4,8 @@ import {
   offscreenDisposeMs,
   mayDisposeOffscreen,
   offscreenCoreIsRemote,
-  planOffscreenVisibility
+  planOffscreenVisibility,
+  shouldDeferReleaseForEco
 } from './offscreen-policy'
 
 describe('offscreen dispose policy', () => {
@@ -96,5 +97,44 @@ describe('planOffscreenVisibility', () => {
     expect(
       planOffscreenVisibility({ visible: true, down: false, timerArmed: false, disposeMs: ms })
     ).toEqual({ cancelTimer: false, armTimer: false, revive: false })
+  })
+})
+
+describe('shouldDeferReleaseForEco — hibernate first, then release the viewer', () => {
+  // Defaults: the release fires at 10 minutes, the idle window closes at 30. Without the deferral
+  // the release wins, unwires the node, and "finish a turn and pan away" never hibernates at all.
+  const base = {
+    ecoEnabled: true,
+    resumableAgent: true,
+    hibernated: false,
+    offscreenElapsedMs: 10 * 60_000,
+    idleMinutes: 30,
+    offscreenMinutes: 10
+  }
+
+  it('defers at the release deadline, so the bigger prize (the CLI) is still reachable', () => {
+    expect(shouldDeferReleaseForEco(base)).toBe(true)
+  })
+
+  it('stops deferring once the node HAS hibernated — the pane is a plain shell now', () => {
+    expect(shouldDeferReleaseForEco({ ...base, hibernated: true })).toBe(false)
+  })
+
+  it('never defers with Eco off, or for a CLI that can never be quit + resumed', () => {
+    expect(shouldDeferReleaseForEco({ ...base, ecoEnabled: false })).toBe(false)
+    expect(shouldDeferReleaseForEco({ ...base, resumableAgent: false })).toBe(false)
+  })
+
+  it('never defers on an unusable idle window (planHibernation refuses those outright)', () => {
+    for (const idleMinutes of [0, -5, NaN])
+      expect(shouldDeferReleaseForEco({ ...base, idleMinutes }), String(idleMinutes)).toBe(false)
+  })
+
+  it('caps the wait at idle + offscreen, so a node that can NEVER hibernate is not stranded', () => {
+    // A /cron node, one with a live subagent, one whose session id never arrived: nothing here
+    // knows that, and the cap is what makes not knowing safe.
+    expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 40 * 60_000 - 1 })).toBe(true)
+    expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 40 * 60_000 })).toBe(false)
+    expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 90 * 60_000 })).toBe(false)
   })
 })

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   OFFSCREEN_DISPOSE_MS_DEFAULT,
   offscreenDisposeMs,
+  releaseStillEnabled,
   mayDisposeOffscreen,
   offscreenCoreIsRemote,
   planOffscreenVisibility,
@@ -107,6 +108,7 @@ describe('shouldDeferReleaseForEco — hibernate first, then release the viewer'
     ecoEnabled: true,
     resumableAgent: true,
     hibernated: false,
+    idleKnown: true,
     offscreenElapsedMs: 10 * 60_000,
     idleMinutes: 30,
     offscreenMinutes: 10
@@ -125,6 +127,15 @@ describe('shouldDeferReleaseForEco — hibernate first, then release the viewer'
     expect(shouldDeferReleaseForEco({ ...base, resumableAgent: false })).toBe(false)
   })
 
+  it('never defers while the idle clock is UNKNOWN — the policy refuses those nodes anyway', () => {
+    // `lastEventAt` is transient by design, so after every app restart a warm agent node has no
+    // clock until it takes a turn — and `planHibernation`'s "unknown idle is not idle" rule
+    // refuses it. Deferring for it would hold every warm node's viewer for the whole cap, i.e.
+    // switching Eco ON would mean a memory REGRESSION for the first stretch of each session.
+    expect(shouldDeferReleaseForEco({ ...base, idleKnown: false })).toBe(false)
+    expect(shouldDeferReleaseForEco({ ...base, idleKnown: true })).toBe(true)
+  })
+
   it('never defers on an unusable idle window (planHibernation refuses those outright)', () => {
     for (const idleMinutes of [0, -5, NaN])
       expect(shouldDeferReleaseForEco({ ...base, idleMinutes }), String(idleMinutes)).toBe(false)
@@ -136,5 +147,17 @@ describe('shouldDeferReleaseForEco — hibernate first, then release the viewer'
     expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 40 * 60_000 - 1 })).toBe(true)
     expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 40 * 60_000 })).toBe(false)
     expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 90 * 60_000 })).toBe(false)
+  })
+})
+
+describe('releaseStillEnabled — the fire-time re-ask of the setting itself', () => {
+  it('refuses a release whose feature was switched off while the timer counted down', () => {
+    // A timer armed ten minutes ago outlives the setting that armed it, and the Eco deferral makes
+    // that window longer still. Disposing anyway would take the buffer the user just asked us to
+    // keep — indistinguishable, from the outside, from the feature being broken.
+    expect(releaseStillEnabled(10)).toBe(true)
+    expect(releaseStillEnabled(undefined)).toBe(true) // unset = the default window, still on
+    expect(releaseStillEnabled(0)).toBe(false)
+    expect(releaseStillEnabled(-5)).toBe(false)
   })
 })

--- a/src/renderer/terminal/offscreen-policy.ts
+++ b/src/renderer/terminal/offscreen-policy.ts
@@ -43,6 +43,17 @@ export function mayDisposeOffscreen(i: {
   return !i.visible && !i.remote && !i.selected
 }
 
+/**
+ * Is the offscreen release still switched ON — asked at FIRE time, not only when the timer was
+ * armed. A timer armed ten minutes ago outlives the setting that armed it: the user can turn the
+ * feature off (or to 0) while it counts down, and a fire that disposed anyway would take the very
+ * buffer they just asked us to keep, with no way to tell the difference from a bug. The deferral
+ * below makes this window longer still, which is what turned a latent case into a real one.
+ */
+export function releaseStillEnabled(settingMinutes: number | undefined): boolean {
+  return offscreenDisposeMs(settingMinutes) !== null
+}
+
 /** How often a DEFERRED release re-asks. The hibernation sweep's own cadence, because that is
  *  exactly what the deferral is waiting for: one sweep after the node hibernates, the viewer goes. */
 export const OFFSCREEN_DEFER_RETRY_MS = 60_000
@@ -71,6 +82,14 @@ export const OFFSCREEN_DEFER_RETRY_MS = 60_000
  * (a working node goes done, a session id arrives late), and asking for it here would re-implement
  * `planHibernation` in a second place. The question asked is the durable one — could this node's
  * CLI ever be quit and resumed at all — and the cap covers the rest.
+ *
+ * ONE exception to that, and it is not a moving target at all: `idleKnown`. The policy's "unknown
+ * idle is NOT idle" rule refuses any candidate with no `lastEventAt`, and that clock is TRANSIENT
+ * by design — a relaunch has seen no hook events yet. So after every app restart, every warm
+ * agent node is one hibernation can provably deliver nothing for until it takes a turn, and
+ * deferring for them would hold every viewer for the whole 40-minute cap: Eco switched on would
+ * MEAN a memory regression for the first stretch of each session. Waiting is only justified when
+ * the thing waited for can actually happen.
  */
 export function shouldDeferReleaseForEco(i: {
   ecoEnabled: boolean
@@ -78,12 +97,18 @@ export function shouldDeferReleaseForEco(i: {
   resumableAgent: boolean
   /** Already hibernated — the CLI is gone, so the release is now a pure win and must proceed. */
   hibernated: boolean
+  /**
+   * Has ANY hook event been seen for this node in this app run (`lastEventAt` is set)? Without
+   * one, `planHibernation` refuses the node outright — unknown idle is not idle — so there is
+   * nothing to wait for. See the header.
+   */
+  idleKnown: boolean
   /** How long this node has been continuously out of view. */
   offscreenElapsedMs: number
   idleMinutes: number
   offscreenMinutes: number
 }): boolean {
-  if (!i.ecoEnabled || !i.resumableAgent || i.hibernated) return false
+  if (!i.ecoEnabled || !i.resumableAgent || i.hibernated || !i.idleKnown) return false
   // An unusable window means Eco is off in practice (`planHibernation` refuses a non-positive one),
   // so there is nothing to wait for — release on the ordinary schedule.
   if (!(i.idleMinutes > 0)) return false

--- a/src/renderer/terminal/offscreen-policy.ts
+++ b/src/renderer/terminal/offscreen-policy.ts
@@ -43,6 +43,54 @@ export function mayDisposeOffscreen(i: {
   return !i.visible && !i.remote && !i.selected
 }
 
+/** How often a DEFERRED release re-asks. The hibernation sweep's own cadence, because that is
+ *  exactly what the deferral is waiting for: one sweep after the node hibernates, the viewer goes. */
+export const OFFSCREEN_DEFER_RETRY_MS = 60_000
+
+/**
+ * PHASE 5 ORDERING: with Eco on, releasing an offscreen terminal's viewer WAITS for its agent to
+ * hibernate first.
+ *
+ * The two features want the same node and they are not equal prizes. This release reclaims the
+ * xterm buffer and the PTY client — roughly 15 MB at the top end. Hibernation reclaims the agent
+ * CLI PROCESS, which is hundreds of MB. But the release UNWIRES the node (the lifecycle effect
+ * tears down, so the hibernate pair is unregistered and `planHibernation` reads the node as
+ * unwired), and at the shipped defaults it fires FIRST — 10 minutes offscreen against a 30-minute
+ * idle window. The canonical case the whole feature exists for, "finish a turn and pan away",
+ * therefore never hibernated at all: the small prize was taken in a way that forfeited the large
+ * one. So the release defers, and the ordering becomes hibernate-then-release; once the CLI is
+ * gone, the pane holds a plain shell and the viewer release is a pure win on top.
+ *
+ * The deferral is CAPPED, and the cap is why this cannot strand anything: a node that will never
+ * hibernate — a `/cron` node, one with a live subagent, an agent with no session id yet — must not
+ * hold its viewer forever waiting for something that is not coming. Past
+ * `idleMinutes + offscreenMinutes` the release proceeds regardless, so the worst case is that a
+ * non-hibernating node keeps its buffer for the sum of the two windows instead of one of them.
+ *
+ * Deliberately NOT gated on "this node is currently eligible": eligibility is a moving target
+ * (a working node goes done, a session id arrives late), and asking for it here would re-implement
+ * `planHibernation` in a second place. The question asked is the durable one — could this node's
+ * CLI ever be quit and resumed at all — and the cap covers the rest.
+ */
+export function shouldDeferReleaseForEco(i: {
+  ecoEnabled: boolean
+  /** Is this an agent whose CLI this app can quit AND resume? (Anything else can never hibernate.) */
+  resumableAgent: boolean
+  /** Already hibernated — the CLI is gone, so the release is now a pure win and must proceed. */
+  hibernated: boolean
+  /** How long this node has been continuously out of view. */
+  offscreenElapsedMs: number
+  idleMinutes: number
+  offscreenMinutes: number
+}): boolean {
+  if (!i.ecoEnabled || !i.resumableAgent || i.hibernated) return false
+  // An unusable window means Eco is off in practice (`planHibernation` refuses a non-positive one),
+  // so there is nothing to wait for — release on the ordinary schedule.
+  if (!(i.idleMinutes > 0)) return false
+  const cap = (i.idleMinutes + Math.max(0, i.offscreenMinutes)) * 60_000
+  return i.offscreenElapsedMs < cap
+}
+
 /** What a visibility report owes the offscreen state machine. Pure so the node only has to run it. */
 export interface OffscreenPlan {
   /** Drop the pending dispose timer (it is armed and no longer wanted). */

--- a/src/renderer/ui/NumberField.tsx
+++ b/src/renderer/ui/NumberField.tsx
@@ -6,7 +6,9 @@ export function NumberField({
   min,
   max,
   step,
-  className
+  className,
+  disabled,
+  ariaLabel
 }: {
   value: number
   onChange: (v: number) => void
@@ -14,6 +16,8 @@ export function NumberField({
   max?: number
   step?: number
   className?: string
+  disabled?: boolean
+  ariaLabel?: string
 }): React.JSX.Element {
   return (
     <input
@@ -22,9 +26,12 @@ export function NumberField({
       min={min}
       max={max}
       step={step}
+      disabled={disabled}
+      aria-label={ariaLabel}
       onChange={(e) => onChange(Number(e.target.value))}
       className={cn(
         'h-8 w-24 rounded-md border border-border bg-bg px-2.5 text-[13px] text-text outline-none focus:border-accent',
+        disabled && 'opacity-40',
         className
       )}
     />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -907,6 +907,14 @@ export interface Settings {
    *  driver runs in `default`). Overridable per project via Project.defaultPermissionMode.
    *  `auto` is version-gated: CLIs below 2.1.71 reject the value, so it degrades to no flag. */
   claudePermissionMode: AgentPermissionMode
+  /** "Eco": exit the agent CLI of a session that has been idle AND offscreen for
+   *  `agentHibernationIdleMinutes`, reclaiming its RAM; the conversation is resumed automatically
+   *  when the node is viewed again. Default OFF — opt-in, because it stops a real process.
+   *  Scheduled/loop agents and sessions with live subagents are never touched
+   *  (renderer/terminal/hibernation-policy.ts explains why). */
+  agentHibernationEnabled: boolean
+  /** How long a session must be idle + offscreen before "Eco" hibernates it (minutes). */
+  agentHibernationIdleMinutes: number
   /** Send anonymous usage data (version/OS) to the telemetry backend. Opt-OUT (default on):
    *  version/OS only, nothing personal, client IP never stored. Turn it off in Settings → Privacy
    *  (or hard-disable with DO_NOT_TRACK / NODETERM_TELEMETRY_DISABLED). Note: a lighter anonymous
@@ -1017,6 +1025,10 @@ export const DEFAULT_SETTINGS: Settings = {
   // Sessions start in auto mode out of the box. Existing users pick this up on hydrate
   // (settings hydrate merges over DEFAULT_SETTINGS) — a deliberate behavior change.
   claudePermissionMode: 'auto',
+  // Opt-in: hibernation exits a live CLI, so nobody gets it without asking. The 30-minute floor
+  // is deliberately long — shorter windows exit sessions the user is between turns on.
+  agentHibernationEnabled: false,
+  agentHibernationIdleMinutes: 30,
   // Opt-out (default on). Existing users pick this up on hydrate ONLY if their settings.json has
   // no telemetryEnabled key yet; anyone who already saved settings keeps their stored value.
   telemetryEnabled: true,


### PR DESCRIPTION
Final phase of the RAM-optimization series (plan in-repo; #110, #114, #118, #127 merged). The research finding that started the series: the #1 RAM consumer is not the app but idle agent CLI processes (field case: 95 sessions ≈ 34 GB). This is cmux's Agent Hibernation pattern built on nodeterm's own restart machinery: an idle, offscreen agent CLI is asked to quit with its own exit command; the tmux session and shell stay; the conversation resumes with `--resume` when you look at the node again.

## Behavior (all opt-in: Settings → Agents → "Hibernate idle agents", default OFF)

- Every 60 s, up to **2** nodes per pass: agent is hook-idle in state `done`, fully offscreen (kanban card modal counts as watched), idle ≥ `agentHibernationIdleMinutes` (default 30), local (SSH/relay excluded at plan AND fire time), no recurring job, no live subagents, `restartEligibility` passes. The exit re-asks "still offscreen?" at fire time and runs the full restart pre-flight (never quits a pane it cannot watch; never `working`/`blocked`/`waiting`).
- The node shows a clickable **SLEEPING** chip (canvas + kanban card). Wake — on view, on chip click, on modal open — verifies a **shell owns the pane** (allowlist OR the exact command the exit settled on, so nu/xonsh/pwsh users wake too), then delivers `withPermissionMode(resumeCommand(...))` KILL_LINE'd and echo-verified. Sweep, wake, and the menu restart share one per-node concurrency guard.
- **Recurring jobs are structurally protected:** `/loop`/`/cron`/`/schedule` nodes are never candidates, and dismissing a cron card (either dismiss surface — both now go through one pure funnel) hides the card but retains the fact; `/exit` would kill the wakeup with the process.
- **Self-healing flag:** a live hook event or a SessionStart clears `hibernated` (a manual relaunch can't leave a stale chip); a cold restore (reboot/reap) clears it and lets the normal auto-resume own the node.
- **Ordering with Phase 2:** with Eco on, an offscreen agent node's terminal view is held (60 s re-arm, hard cap `idle+offscreen` ≈ 40 min at defaults) until the agent hibernates — the CLI (hundreds of MB) is the bigger prize than the viewer (~15 MB). Nodes whose idle clock is unknown (e.g. right after an app restart) skip the deferral entirely and release at the normal 10 min.

## Review history (2 task rounds + 2 final-review waves; every catch was real)

Caught and fixed along the way: the second dismiss path re-opening the recurring-fact hole; the exit not re-asking visibility at fire time (stale plan → `/exit` into a watched pane); the kanban modal neither protecting nor waking its node; the flag never self-healing (RUNNING+SLEEPING double badge); remote candidates starving the deterministic batch; the wake gate being stricter than the exit's (hibernatable-but-never-wakeable shells); and the Eco deferral holding every viewer for 40 min after each app restart while hibernation could deliver nothing.

## Disclosures

1. Default off; at defaults the only behavioral delta is the loop-dismiss semantics change above (every render site filters dismissed entries; a new recurring event un-dismisses).
2. Phase 2 behavior fix that rode along: an armed dispose timer now refuses to fire if `offscreenTerminalMinutes` was switched off while it counted down (`releaseStillEnabled`, tested).
3. Eco is structurally inert for sessions with no turn in *this* app run (`lastEventAt` is transient) — the "stale CLIs from yesterday" case is a documented follow-up (needs a `pane_current_command` signal).
4. `hibernated` + `hibernatedPane` persist per machine (default keyed store) — consistent with the SSH exclusion. `hibernatedPane` widens *when* the wake types, never *what* (payload is always the validated resume command).
5. Known edge: a hook POST arriving after the exit can clear the flag on an exited CLI (NEEDS YOU over a shell; menu restart recovers `waiting`, `blocked` needs a manual resume).
6. A node hibernated *and* offscreen-disposed shows a bare shell in a freshly opened card modal while the bounded wake attempts expire; the modal header carries no state badges today.
7. Mobile: N/A (no sweep on the phone; an attached hibernated session shows a shell).

## Testing

- 4692 tests / 369 files green at HEAD (re-run by the final reviewer); typecheck clean. agent-restart's pre-existing suite: **zero deletions** across the whole branch (Task 8's behavior pin).
- New coverage: exit/resume phase splits (12), hibernation policy incl. every exclusion + non-positive-window refusal (mutation-checked), candidate adapter incl. the dismissed-cron row, loop-dismiss funnel, deferral policy both directions, store persistence (flag + pane, never the clocks).
- **Nothing device-verified** — the 8-item checklist (in the plan + task report) is owed before suggesting Eco to anyone: /exit on the shipping CLI, wake under plan/acceptEdits, managed accounts, cold restore, modal behavior, recurring protection end-to-end, hibernate-before-release ordering, real RAM measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)