### PR TITLE
feat: session memory — a system-resource pill and a per-session breakdown

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -190,6 +190,35 @@ to its node: on next open it **cold-restores** (scrollback snapshot + `claude --
 kill switch via env: `NODETERM_SESSION_MIN_AVAILABLE_MB`, `NODETERM_SESSION_MAX_DETACHED`,
 `NODETERM_SESSION_GRACE_HOURS`, `NODETERM_SESSION_REAP_BATCH`, `NODETERM_SESSION_REAP_DISABLED=1`.
 
+### Session memory (the RAM pill + per-session panel)
+
+The reaper's counterpart for a human: `startSessionMemoryService` (`src/core/session-memory-service.ts`)
+is booted here too, beside the reaper in `src/server/index.ts`, and `window.nodeTerminal.sessionMemory`
+has a **real** ws-bridge implementation (not a stub). So the browser gets the bottom-left RAM pill and
+the per-session breakdown, and both describe **the machine the server is served from**: its
+`/proc/meminfo`, its `node-terminal` / `nodeterm-rmt` tmux sockets, its process table. Full write-up:
+`docs/session-memory.md`.
+
+**An SSH project's scope answers `ok:false` — "could not measure" — and that is deliberate.** The
+server has no ControlMaster, so it cannot read the other host; answering with its own sessions would
+publish this machine's memory under that host's name. Same degrade as remote usage, one step
+stricter:
+
+- The service is given **`isRemoteProject` but no `run`**. Knowing which projects are somebody
+  else's machine and being able to read them are different capabilities, and the option pair is
+  asymmetric to say so (`run` optional, `isRemoteProject` required).
+- The refusal is decided **by identity**, not by trusting the renderer's `remote` flag:
+  `sshScopePredicate({ sshProjectIds: () => workspaceStore.sshProjectIds() })`. A query arriving
+  without that flag — a client that has not learned the project is an SSH one yet — would otherwise
+  fall through to the LOCAL sweep, which is exactly the misattribution the refusal exists to prevent.
+- **That predicate depends on the boot-time `await workspaceStore.load(...)`** earlier in
+  `startServer` (a line documented there as being for Context Link). Move it below the service boot,
+  or drop it, and every SSH project silently reads as local again.
+  `test/server/session-memory-e2e.test.ts` fails if that happens.
+
+A **headless** host boots the service like every other core service, but with no UI attached nothing
+queries it.
+
 ## Security model
 
 Single-user auth. There is one password; sessions are per-browser.

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -211,10 +211,13 @@ stricter:
   `sshScopePredicate({ sshProjectIds: () => workspaceStore.sshProjectIds() })`. A query arriving
   without that flag — a client that has not learned the project is an SSH one yet — would otherwise
   fall through to the LOCAL sweep, which is exactly the misattribution the refusal exists to prevent.
-- **That predicate depends on the boot-time `await workspaceStore.load(...)`** earlier in
-  `startServer` (a line documented there as being for Context Link). Move it below the service boot,
-  or drop it, and every SSH project silently reads as local again.
-  `test/server/session-memory-e2e.test.ts` fails if that happens.
+- **That predicate depends on the boot-time `await workspaceStore.load(...)`** in `startServer` (a
+  line documented there as being for Context Link). Drop it — or stop awaiting it before
+  `server.listen()` — and every SSH project silently reads as local again;
+  `test/server/session-memory-e2e.test.ts` fails if that happens. What is **not** load-bearing is
+  where that load sits relative to the service boot: `isRemoteProject` is a closure evaluated per
+  QUERY, and no query can arrive before `startServer` reaches `listen()`. The requirement is that
+  the load completes before the server *serves*, not that it precedes any particular boot line.
 
 A **headless** host boots the service like every other core service, but with no UI attached nothing
 queries it.

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -1,0 +1,314 @@
+# Session memory: the RAM pill and the per-session panel
+
+A bottom-left **RAM pill** beside the usage pill, and the **session-memory panel** it opens: how
+much memory the machine the *active project* runs on is using, and which `nt-*` tmux session is
+holding it.
+
+> Design spec: `docs/superpowers/specs/2026-08-10-session-memory-panel-design.md`.
+> The condensed rules live in `CLAUDE.md` ("Session memory"); this document carries the
+> measurements, the reasoning that is too long for that file, and **§10, the device checklist** for
+> everything that could not be verified on the headless Linux box this was built on.
+
+Files:
+
+| Layer | File |
+|---|---|
+| Local read + pure assembly | `src/core/session-memory.ts` |
+| The SSH host's leg (generated `sh`) | `src/core/session-memory-remote.ts` |
+| RPC + routing (booted by BOTH shells) | `src/core/session-memory-service.ts` |
+| Renderer store (two cadences) | `src/renderer/state/sessionMemory.ts` |
+| Rows → titles / projects / orphans | `src/renderer/lib/sessionMemoryRows.ts` |
+| Where a kill has to land | `src/renderer/lib/sessionKill.ts` |
+| Pill + panel | `src/renderer/components/SystemResourcePill.tsx`, `SessionMemoryPanel.tsx` |
+
+---
+
+## 1. What was measured, and what it means
+
+The feature exists because a user reported *"Claude terminals are killing my memory, each one takes
+2 GB"*. Measured on the production host (64 GB, 95 live `claude` processes):
+
+| What | Measurement |
+|---|---|
+| `claude` process alone | avg **335 MB**, peak **1159 MB** |
+| 95 `claude` processes | **31.1 GB** |
+| MCP children per session | +30–200 MB (playwright-mcp + Chrome ≈ 200 MB alone) |
+| One "Claude terminal" tree | **440 MB – 1.2 GB** |
+| nodeterm-server (per user) | 49–82 MB |
+| tmux client (per attached session) | 5.1 MB × 59 = 303 MB |
+
+Two facts settle the attribution:
+
+1. **nodeterm does not allocate it.** It is the agent CLI's own V8 heap. `RssAnon` is essentially
+   all of the RSS (1165 MB of 1187 MB on the largest process), and this repo sets no `NODE_OPTIONS`
+   / `--max-old-space-size`, so V8 sizes its heap from system RAM (`heap_size_limit = 4144 MB` on
+   that host).
+2. **It is not a leak.** RSS is flat with process age — 0–24 h avg **340 MB**, 1–7 day avg 339 MB,
+   7 day+ avg **326 MB**. Each process takes a flat baseline and never returns it.
+
+So the user's *number* was right and their *attribution* was wrong — but nodeterm is not innocent
+either: it keeps those processes alive (only `×` kills a session; project close and app quit merely
+detach) and the canvas invites many at once. One measured client held **51 attached sessions ≈
+17 GB**.
+
+**The gap this closes is the blindness, not the allocation.** Nothing in the product told the user
+that 18 sessions were live, that one of them was 1.2 GB, or that six belonged to a project they
+closed three weeks ago. Capping agent memory (`--max-old-space-size`) was considered and rejected
+for v1: a low ceiling OOM-kills a long-context session, which is worse than the 2 GB.
+
+**Do not re-derive these numbers.** They are here so the next person does not spend an afternoon on
+`/proc` arithmetic to reach the same conclusion.
+
+## 2. Why the reaper is deliberately untouched
+
+`src/core/session-budget.ts` reaps only **detached** sessions idle past a grace window. On the
+measured host that made its kill list **empty** — 60 `nt-` sessions, 50 attached, **0 eligible** —
+while 31 GB sat there. An open canvas is attached, and attached is untouchable.
+
+Retargeting the reaper is a separate change with separate risk (it would start killing sessions a
+user is looking at). This feature adds **sight**, not policy: it shows the 31 GB and lets a human
+decide. The one thing it shares with the reaper is `readMemInfo` (§3).
+
+## 3. `readMemInfo` has exactly one home
+
+It lives in `session-memory.ts`; `session-budget.ts` imports **and re-exports** it. Two features now
+read host RAM — the reaper's watermark and the pill — and a second copy would drift. The reaper and
+the pill must never disagree about how much RAM is free.
+
+Linux `/proc/meminfo` `MemAvailable` is the honest number; `os.freemem()` is the fallback elsewhere
+(on Linux that fallback would report `MemFree`, materially smaller under a warm page cache, which
+is why the file read comes first). `null` when nothing is readable — **never zero**.
+
+## 4. `ok:false` is not `ok:true` with no rows
+
+This is the rule the whole feature exists to honour, and every layer preserves it:
+
+- `collectSessionMemory` returns `ok:false` when there is no tmux binary, when the process table is
+  unreadable, or when **no socket answered**. A socket with no tmux server is an *answer* (the
+  normal state of a socket nobody has used), classified by `isNoServerError` — deliberately narrow
+  and **anchored** to tmux's own connect message, because `promisify(execFile)` folds stderr into
+  `err.message` and a bare `no such file or directory` also matches a tmux client missing a shared
+  library (exit 127 on *every* socket) and a dead ssh ControlMaster. Laundering either into "no
+  sessions here" prints an empty panel over 20 live ones.
+- `parseRemoteSessionMemory` returns `ok:false` on a missing **or out-of-order** section marker, and
+  on an empty process table (a host always has processes).
+- The store carries `ok:false` through untouched, and treats a *rejected* call as the same fact.
+- The panel renders four distinct sentences: "Could not measure sessions on this machine.",
+  "Measuring…", "No sessions are running here.", and the list. The grand total and the
+  "*n* sessions" count are gated on a `measured` flag (`ok && loadedScope === scopeKey`), so a
+  failure can never show "0 B / 0 sessions" beside it.
+
+## 5. Reading this machine
+
+`/proc/<pid>/status` is read for the whole table, **never `statm`**. `status` carries `PPid` and
+`VmRSS` in one file and already in kB; `statm` reports RSS in **pages**, which forces a page-size
+assumption — a hard-coded 4096 under-reports **4×** on a 16 KiB-page arm64 kernel and **16×** on the
+64 KiB-page enterprise arm64 builds (it would print 40 MB for a 640 MB session). Do not "optimise"
+this back to `statm`.
+
+Non-Linux (and an unreadable `/proc`) falls through to one `ps -eo pid,ppid,rss` call, through the
+same injectable seam as tmux — nothing in `session-memory.ts` reaches a subprocess around it.
+
+`rollupTree` walks each pane pid's descendants with a `seen` guard (a table captured while pids are
+recycling can present a cyclic ppid chain, and a sweep that hangs is worse than one that
+under-reports). **`childCount` counts EVERY descendant**, the agent CLI included: `pane_pid` is the
+pane's *shell*, so a claude session with two MCP servers reports **3**. The panel therefore says
+"child processes", never "MCP" — a plain `npm run dev` has children too.
+
+`list-panes -a` emits one line per **pane**, so the first pane of a session wins in both legs (same
+key, same order) — one session is one row.
+
+## 6. The SSH leg
+
+An SSH project's sessions live on the host, so the sweep runs there: core generates ONE POSIX `sh`
+script, the shell runs it over the project's ControlMaster, and only the printed sections come back
+— the same division of labour as `remote-claude-usage.ts` (core owns the command *and* the parsing;
+the shell owns the master). One round trip carries all three facts, because each extra `ssh` exec is
+a login on someone else's machine.
+
+It is generated shell that no compiler checks, so `session-memory-remote.test.ts` runs it **for real
+under `/bin/sh`** against a fake host tree — the same discipline as `remote-claude-usage.test.ts` and
+`canvas-control-shim.test.ts`. Keep it that way. It is not ceremony: the plan's own script said
+`echo ##MEM`, which prints an **empty line** under POSIX sh (an unquoted `#` starts a word-initial
+comment), and would have made **every healthy host report `ok:false`**. The markers are quoted for
+that reason.
+
+Two more properties of that script are load-bearing: every section header is printed
+**unconditionally** (a missing one means the stream was cut short, not that the host had nothing),
+and the socket names + `-F` format come from the shared constants, so the remote sweep can never
+look at a different socket or ask for different fields than the local one. A non-Linux host has no
+`/proc/meminfo`, so its `mem` is legitimately `null` — the pill must pulse there, never show 0.
+
+## 7. Which machine answers
+
+`session-memory-service.ts` makes exactly one decision: local sweep or remote leg. Two independent
+sources say "remote" and **either is enough** (OR, never AND) — the renderer's own `remote` flag
+(it already knows from `usageScope`) and the shell's `isRemoteProject`. A source that answers "no"
+because it is momentarily uninformed (an index not loaded, a master that just dropped) would
+otherwise turn a remote query into a local sweep and publish **this** machine's sessions under the
+host's name.
+
+`sshScopePredicate` builds that shell-side answer from **identity, not liveness**:
+`workspaceStore.sshProjectIds()` (a disconnected SSH project is still someone else's machine),
+OR-ed with the live masters for a project the index has not yet listed.
+
+The `remote` option pair is deliberately asymmetric: `run` is optional (a shell may be unable to
+read another host), `isRemoteProject` is **required** — reading-without-knowing is not coherent and
+stays a compile error.
+
+One in-flight remote read per project is coalesced (the panel wants both the RAM number and the
+rows; that is two identical `ps` execs on someone else's machine otherwise). The key is the
+`projectId` and nothing else, because that is the only thing deciding which host the command lands
+on. It is cleared on settle — a concurrency guard, never a cache.
+
+## 8. The renderer: scope, cadence, ownership
+
+**Scope** is `usageScopeKey(activeProject)` — the same helper the usage indicator uses, so the two
+pills cannot disagree about which machine they describe. The store stamps every request with the
+scope itself (not a counter: `refreshFull` and `startHostPoll` can be called for different scopes
+with no intervening bump), discards a response stamped with a scope it has left, and clears the
+previous machine's facts on a real change.
+
+**The cadence split follows the cost:**
+
+- **Local scope** — the pill polls `HOST_POLL_MS` (30 s). One file read, free.
+- **SSH scope** — **never polled.** One read on scope entry, one when the project's ControlMaster
+  comes up (an SSH project is opened before its master is ready, and with no timer behind it a first
+  read against a dead master would leave the pill blank), and one per panel open / `⟳`. This is the
+  rule `CLAUDE.md` already sets for remote usage, for the same reason.
+
+**The full sweep never runs on a timer and never from the pill.** The panel is *unmounted* while
+closed and its mount is what triggers the sweep.
+
+**Ownership contract:** the store's poll timer and its active-scope stamp are **module singletons**,
+and the **pill is their single owner**. The panel must never call `startHostPoll` / `stopHostPoll` —
+a `stopHostPoll` on unmount would clear the pill's interval with nothing left to restart it, and the
+number would silently freeze until the next scope change.
+
+The store resolves its api through `sessionForProject(projectId).api`, not `window.nodeTerminal`: a
+relay tab's renderer runs on the guest while its sessions live on the host, and its api is the
+stub — `ok:false`, which the panel surfaces as *not available here*, not as a failure to retry.
+
+## 9. Rows, orphans, and where a kill lands
+
+`resolveSessionRows` resolves each `nt-<nodeId>` against **every** project the store holds:
+
+- **A closed project is not an orphan.** `closeProject` only sets `closed = true` and keeps the
+  project and its nodes on disk, so its sessions resolve to a real title and are labelled with their
+  project. Calling them orphans would invite the user to kill sessions they deliberately parked. The
+  panel therefore passes the full `projects` array — filtering to open tabs defeats this rule
+  silently, from outside the file that states it.
+- **`orphan` is the distinguishing field, not `state === null`.** A plain terminal never enters the
+  agent-status map, so deriving orphan-ness from a missing agent state would flag every one of them.
+  An orphan's state is dropped rather than passed on (the panel could not explain a "working" dot on
+  a row it cannot travel to) and its dot renders hollow.
+- Orphans are the point: they are exactly what the reaper cannot see and no canvas can show.
+
+**The kill is routed by the SCOPE, not by the row** (`planSessionKill`). `transport.destroy(nodeId)`
+reaches a *remote* tmux session only through a LIVE local client carrying `sshRemote` — which an
+orphan has not, and neither has a node owned by a non-active project. Before this, every orphan
+row's `×` on an SSH project promised a kill it could not perform: the local socket was touched, the
+host's `nt-<id>` kept running, and the row came back on the next refresh with no explanation. So on
+an SSH scope the kill *additionally* runs `sshProject.killSessions(activeProjectId, [nodeId])` over
+that project's own ControlMaster, which needs no live session and is idempotent (the mounted case,
+where `destroy` already ended it, is a harmless best-effort miss).
+
+That is safe because it is a **round trip, not a lookup**: the panel's `nodeId` is literally
+`session.slice('nt-')` from the sweep, and `killSessions` maps it back through the same idempotent
+`sessionName()`, so the remote leg kills **the exact session name the sweep observed, on the host it
+observed it on**. It does not rest on node ids being globally unique (they are only per-launch
+unique).
+
+Ownership is re-resolved at click time rather than taken from the row's `orphan` flag — the rows are
+a snapshot of the last sweep, and a node created since would otherwise be killed as an orphan. With
+an owner, the kill goes through `closeSession`, the same path the sessions sidebar and the node's
+own `×` use.
+
+### Surfaces
+
+- **Desktop** — full, including the SSH leg.
+- **Server Edition** — the service runs and reports the machine it is served from. An SSH scope
+  answers `ok:false` (no ControlMaster is injected) — and it says so **by identity**, via
+  `sshScopePredicate` over `workspaceStore.sshProjectIds()`, rather than trusting the renderer's
+  flag. See `docs/SERVER.md`.
+- **Relay tabs** — the ws-bridge stub answers `ok:false`; the panel says session memory is not
+  available on a relay tab rather than reporting a failure.
+- **Kanban board** — Canvas passes `overBoard={kanbanOpen}`, which raises the pill to z 26 over the
+  board's opaque 25 (the same prop `UsageIndicator` takes beside it); an open panel rises to 60, over
+  the board and the banners but below ConfirmDialog / the palette.
+- **Mobile companion** — **N/A for v1.** *nodeterm mobile* attaches to tmux sessions over the
+  transport protocol and has no concept of per-session host memory; adding one means extending that
+  protocol. A follow-up in `~/projects/nodeterm-ios`, not built here.
+
+### Known gaps (v1, deliberate)
+
+- The session list is **uncapped**. A host with hundreds of sessions makes a long list; truncating
+  silently would hide exactly the rows that matter. If it becomes a problem the fix is a visible
+  "showing top N" line, never a silent cap.
+- A pane pid that exits between the tmux call and the process sweep emits a legitimate-looking
+  **0 MB row** rather than being dropped — the same "measurement failure rendered as zero" shape as
+  §4, at row granularity.
+- Switching between two SSH projects with the **same `user@host`** (the scope key carries no port)
+  leaves the previous rows on screen until the re-sweep, because `enterScope` only clears when the
+  scope *string* changes.
+- The **sessions sidebar** has the same class of bug this feature fixed in the panel: a destructive
+  confirm that lies for a row owned by a non-active project. Not fixed here — its rows span
+  arbitrary projects on arbitrary hosts, so its correct fix is owner-routed per row, a different
+  rule on a surface this change does not own.
+
+## 10. Device checklist
+
+Everything below was argued from code, CSS or a Linux measurement and could **not** be exercised on
+the headless Linux box this was built on. Format follows `docs/grok-agent.md` §9 /
+`docs/gemini-agent.md` §9. Highest value first: items 1–5.
+
+```
+The kill actually reaching the host (the bug most recently fixed, and the one no test can prove)
+ 1. SSH project, a row with "no node": press ×, confirm, then on the HOST run
+    `tmux -L nodeterm-rmt ls` — the nt-<id> session must be GONE, not merely absent from the panel.
+ 2. Same, for a row owned by a CLOSED ssh project (it resolves to a title, so it takes the
+    closeSession path plus the remote kill — both legs must land).
+ 3. Kill a node created less than a sweep ago (<1 s): the confirm wording may say "no node" from the
+    stale snapshot, but the CANVAS node must be removed too — ownership is re-resolved at click time.
+ 4. Local project: kill a row and confirm `tmux -L node-terminal ls` loses it, and that no remote
+    kill is attempted (a local nt-<id> whose node belongs to an SSH project must NOT be killed on
+    the host).
+
+macOS (the ps path never runs on Linux)
+ 5. Open the panel on a Mac: `defaultProcessTableReader` returns null there, so the whole table
+    comes from `ps -eo pid,ppid,rss`. Rows must populate, and the totals must be plausible — BSD ps
+    reports rss in kB, but confirm one known process against Activity Monitor before trusting it.
+ 6. macOS pill numbers: `os.freemem()` reports FREE, not AVAILABLE, memory. Confirm used/total reads
+    plausibly rather than alarmingly (a Mac with a big page cache will look fuller than it is).
+
+The SSH leg
+ 7. Open an SSH project: the panel must list THAT host's sessions and no local ones, and its header
+    scope + the pill's title must read `user@host`.
+ 8. Open an SSH project BEFORE its ControlMaster is up. The pill must end on a NUMBER, not a
+    permanent pulse — this is the only place the connection-up re-read can be observed.
+ 9. A non-Linux SSH host (no /proc/meminfo): the pill must PULSE, never show "0 GB".
+10. Kill the master mid-sweep (`ssh -O exit`) and press ⟳: "Could not measure", never an empty list.
+11. Watch ⟳ during a slow remote sweep: the button must be disabled and spinning (loading is
+    asserted nowhere).
+
+Layout and theming (argued from CSS only)
+12. Default window and ~900 px wide: the cluster at left:60px clears the React Flow controls and the
+    canvas-lock button.
+13. A machine with NO agent usage — UsageIndicator renders null, so the RAM pill must sit alone at
+    left:60px, un-clipped.
+14. Kanban board open: the pill is visible AND clickable over the board.
+15. Sessions sidebar open: the collapsed pill passes UNDER the sidebar exactly as the usage pill
+    does.
+16. Usage popover open beside the RAM pill: no overlap, pill still clickable.
+17. Both themes: hover (light is why the ink overlay exists) and the bar's colour steps at ~75% and
+    ~90% used.
+18. fitView / goToNode must no longer tuck nodes under the pill.
+
+Cadence and the other surfaces
+19. Local project, panel closed: the pill's number moves after 30 s.
+20. Local project: opening the panel triggers a sweep; closing and reopening triggers another; the
+    pill alone never does (watch for `ps`/`/proc` activity, or an ssh exec on an SSH scope).
+21. Server Edition in a browser: a local project's panel is full; an SSH project's panel says
+    "Could not measure", with no local rows attributed to the host.
+22. Relay tab: the panel says session memory is not available there, and offers no ⟳.
+```

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -148,6 +148,16 @@ pill.** `sessionBudgetConfig`'s watermark defaults to 10% of RAM (2457 MB on a 2
 reaped idle detached sessions every 10 minutes regardless of how much memory was actually free. One
 reader, two consumers: that is the reason they share a definition.
 
+**A failed `vm_stat` yields NO SIGNAL, not a fallback.** `darwinMemInfo` returns `null` rather than
+dropping through to `os.freemem()` — that value is exactly what caused the bug, so falling back to it
+would restore it on any Mac where `vm_stat` is missing, slow or unparseable. Both consumers degrade
+correctly on `null`: `planReap` treats it as no pressure (absence of evidence never triggers a kill)
+and the pill pulses instead of printing a number it has not earned.
+
+**Confirmed in the field.** The reaper symptom was reported independently as "my sessions keep
+disappearing" on macOS, before the cause was known. Until this ships, the workaround on an affected
+machine is the reaper's own kill switch: `NODETERM_SESSION_REAP_DISABLED=1`.
+
 **Unverified:** the fixture in `session-memory.test.ts` is composed from Apple's documented format,
 not captured from a real machine. Device checklist item 6 is what closes it.
 

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -90,8 +90,16 @@ This is the rule the whole feature exists to honour, and every layer preserves i
   `err.message` and a bare `no such file or directory` also matches a tmux client missing a shared
   library (exit 127 on *every* socket) and a dead ssh ControlMaster. Laundering either into "no
   sessions here" prints an empty panel over 20 live ones.
-- `parseRemoteSessionMemory` returns `ok:false` on a missing **or out-of-order** section marker, and
-  on an empty process table (a host always has processes).
+- `parseRemoteSessionMemory` returns `ok:false` on a missing **or out-of-order** section marker, on
+  an empty process table (a host always has processes), and — the remote counterpart of the rule
+  above — when **no socket answered**. Each socket is fenced in the reply (`##SOCK <name>` … its
+  tmux exit status as `##SOCKRC <n>`) with tmux's stderr folded in (`2>&1`), and the SAME
+  `isNoServerError` classifies it: exit 0 answers with panes, "no server running" / "error
+  connecting to … (no such file or directory)" answers "nothing here", **anything else did not
+  answer** (nor did a fence the stream cut off mid-socket). Before this the sweep was
+  `{ tmux …; tmux …; } || true` with stderr discarded, so a host whose tmux client could not start
+  — exit 127 on *every* socket, live sessions untouched — produced a stream byte-identical to an
+  idle host's and the panel said "No sessions are running here." over thirty of them.
 - The store carries `ok:false` through untouched, and treats a *rejected* call as the same fact.
 - The panel renders four distinct sentences: "Could not measure sessions on this machine.",
   "Measuring…", "No sessions are running here.", and the list. The grand total and the
@@ -133,10 +141,13 @@ under `/bin/sh`** against a fake host tree — the same discipline as `remote-cl
 comment), and would have made **every healthy host report `ok:false`**. The markers are quoted for
 that reason.
 
-Two more properties of that script are load-bearing: every section header is printed
-**unconditionally** (a missing one means the stream was cut short, not that the host had nothing),
-and the socket names + `-F` format come from the shared constants, so the remote sweep can never
-look at a different socket or ask for different fields than the local one. A non-Linux host has no
+Three more properties of that script are load-bearing: every section header is printed
+**unconditionally** (a missing one means the stream was cut short, not that the host had nothing);
+the socket names + `-F` format come from the shared constants, so the remote sweep can never
+look at a different socket or ask for different fields than the local one; and **each socket is
+fenced with its own tmux exit status and its stderr** (§4) — an exit status alone cannot tell an
+unused socket from a broken tmux, and dropping both is what let a failed sweep render as an empty
+host. A non-Linux host has no
 `/proc/meminfo`, so its `mem` is legitimately `null` — the pill must pulse there, never show 0.
 
 ## 7. Which machine answers

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -219,6 +219,33 @@ That is safe because it is a **round trip, not a lookup**: the panel's `nodeId` 
 observed it on**. It does not rest on node ids being globally unique (they are only per-launch
 unique).
 
+**The name and the host were never the hard part — the SOCKET was.** Two nodeterm tmux sockets exist
+on one machine at the same time: `node-terminal` for a nodeterm running ON it (desktop or Server
+Edition) and `nodeterm-rmt` for one SSH-ing INTO it. The sweep lists **both**
+(`session-memory.ts`, `session-memory-remote.ts`) while the kill targeted **one** — so every row that
+came off the other socket got the confirm "this stops its tmux session" and a kill that landed
+nowhere. That is not an exotic host: one running its own `nodeterm-server` *and* being SSH'd into is
+exactly it, and the local mirror is the same shape (this machine's panel listing the `nodeterm-rmt`
+sessions that another machine's nodeterm spawned here — all of them orphans locally, since their
+nodes are on that machine's canvas). So a kill that knows only a NAME now goes to **every socket that
+name could be on**: `KILL_TMUX_SOCKETS`, via `remoteTmuxKillEverySocketArgs` (remote) and
+`localKillSockets` (local). Three things make that safe rather than reckless:
+
+- It is **best-effort by contract**: tmux exits non-zero with "can't find session" on whichever
+  socket does not hold it, which is the already-ignored case both legs were written around.
+- The target is **exact** — `-t =nt-<id>`. Without `=`, tmux falls back to fnmatch and then to
+  PREFIX matching whenever the name is not found, and "not found" is the normal outcome of a
+  speculative kill. Node ids end in a counter, so `nt-…-1` is a prefix of `nt-…-12`: a miss could
+  have killed a *different* session. The reaper already killed this way, for this reason.
+- The fan-out happens only when we do **not** know the socket. A destroy for a session we hold aims
+  at that session's socket alone, so the ordinary node-`×` path still fires exactly one kill
+  (pinned in `pty-single-user.test.ts`).
+
+Note the deliberate duplication: the sweep and the reaper keep their own `[TMUX_SOCKET,
+RMT_TMUX_SOCKET]` arrays. For them the ORDER is load-bearing — the sweep's `bySession` is first-wins,
+so it decides which socket a duplicate name is attributed to — and for a kill it means nothing.
+Sharing one constant would couple a de-duplication preference to a kill list.
+
 Ownership is re-resolved at click time rather than taken from the row's `orphan` flag — the rows are
 a snapshot of the last sweep, and a node created since would otherwise be killed as an orphan. With
 an owner, the kill goes through `closeSession`, the same path the sessions sidebar and the node's
@@ -236,6 +263,12 @@ own `×` use.
 - **Kanban board** — Canvas passes `overBoard={kanbanOpen}`, which raises the pill to z 26 over the
   board's opaque 25 (the same prop `UsageIndicator` takes beside it); an open panel rises to 60, over
   the board and the banners but below ConfirmDialog / the palette.
+- **Sessions sidebar** — an open panel also has to clear the sidebar (z 12) when the board is
+  *closed*, which is a separate rule: `.sysres-indicator:has(.sessmem-panel) { z-index: 13 }`,
+  mirroring `.usage-indicator:has(.usage-popover)`. Both `:has()` rules only work because the pill
+  cluster is mounted OUTSIDE `<ReactFlow>` — the library's wrapper carries an inline `z-index: 0`
+  that would trap any value inside it, however large. The collapsed pill deliberately keeps its low
+  layer (5) and passes *under* the sidebar.
 - **Mobile companion** — **N/A for v1.** *nodeterm mobile* attaches to tmux sessions over the
   transport protocol and has no concept of per-session host memory; adding one means extending that
   protocol. A follow-up in `~/projects/nodeterm-ios`, not built here.
@@ -264,15 +297,28 @@ the headless Linux box this was built on. Format follows `docs/grok-agent.md` §
 
 ```
 The kill actually reaching the host (the bug most recently fixed, and the one no test can prove)
- 1. SSH project, a row with "no node": press ×, confirm, then on the HOST run
-    `tmux -L nodeterm-rmt ls` — the nt-<id> session must be GONE, not merely absent from the panel.
+ 1. SSH project, a row with "no node": press ×, confirm, then on the HOST run BOTH
+    `tmux -L nodeterm-rmt ls` and `tmux -L node-terminal ls` — the nt-<id> session must be GONE from
+    wherever it was, not merely absent from the panel.
  2. Same, for a row owned by a CLOSED ssh project (it resolves to a title, so it takes the
     closeSession path plus the remote kill — both legs must land).
+ 2b. THE CROSS-SOCKET CASE, and the reason both sockets are now killed. On a host that also runs its
+    own `nodeterm-server`, open an SSH project pointed at it: the panel lists that server's own
+    sessions (they live on `node-terminal`, not `nodeterm-rmt`). Kill one and confirm with
+    `tmux -L node-terminal ls` on the host. Before the fix this row's confirm was a no-op.
+ 2c. The LOCAL mirror of 2b: from another machine, SSH into this one with nodeterm and open a
+    terminal (it lands on this machine's `nodeterm-rmt`). On THIS machine the panel shows it as an
+    orphan; kill it and confirm with `tmux -L nodeterm-rmt ls` locally.
  3. Kill a node created less than a sweep ago (<1 s): the confirm wording may say "no node" from the
-    stale snapshot, but the CANVAS node must be removed too — ownership is re-resolved at click time.
- 4. Local project: kill a row and confirm `tmux -L node-terminal ls` loses it, and that no remote
-    kill is attempted (a local nt-<id> whose node belongs to an SSH project must NOT be killed on
-    the host).
+    stale snapshot, and the CANVAS node is currently left behind (§4's known hole) — confirm which
+    of the two actually happens on a real machine.
+ 4. Local project, ordinary node ×: confirm `tmux -L node-terminal ls` loses it, that the node's own
+    kill still fires exactly ONE kill-session (no fan-out on the path we hold a session for), and
+    that no remote kill is attempted — a local nt-<id> whose node belongs to an SSH project must NOT
+    be killed on the host.
+ 4b. tmux target exactness: create nodes until two session names share a prefix (`nt-…-1` and
+    `nt-…-12` — same millisecond, counters 1 and 12), delete the SHORTER one, and confirm the longer
+    one survives. This is what `-t =<name>` buys and it has only been reasoned about.
 
 macOS (the ps path never runs on Linux)
  5. Open the panel on a Mac: `defaultProcessTableReader` returns null there, so the whole table
@@ -303,6 +349,19 @@ Layout and theming (argued from CSS only)
 17. Both themes: hover (light is why the ink overlay exists) and the bar's colour steps at ~75% and
     ~90% used.
 18. fitView / goToNode must no longer tuck nodes under the pill.
+
+Rows, travel and the panel itself (restored — these were in the task reports and lost on the way in)
+23. A `claude` node with 2 MCP servers must read `+3 child processes`, not +2: `pane_pid` is the
+    pane's SHELL, so the count includes the agent CLI itself. This is the ONLY item that can
+    falsify the "reports 3" claim made twice above; everything else about the sub-line is arithmetic.
+24. Travel to a row whose node lives in a CLOSED project: the tab must REOPEN and the camera land on
+    the node. This is the likeliest thing on the list to be wrong — the load and the focus happen in
+    the same tick, and `travelToNode` (not `focusNodeById`) is what handles it.
+25. A LOCAL orphan row (`tmux -L node-terminal new-session -d -s nt-fake-1`) renders with a hollow
+    dot and a "no node" chip, and its title is inert — clicking it must do nothing at all.
+26. The panel STAYS OPEN through a kill: the ConfirmDialog is a portal outside the pill's container,
+    and answering it must not dismiss the list the user is working through. Clicking anywhere else
+    on the canvas must still close the panel.
 
 Cadence and the other surfaces
 19. Local project, panel closed: the pill's number moves after 30 s.

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -248,9 +248,19 @@ name could be on**: `KILL_TMUX_SOCKETS`, via `remoteTmuxKillEverySocketArgs` (re
   PREFIX matching whenever the name is not found, and "not found" is the normal outcome of a
   speculative kill. Node ids end in a counter, so `nt-…-1` is a prefix of `nt-…-12`: a miss could
   have killed a *different* session. The reaper already killed this way, for this reason.
-- The fan-out happens only when we do **not** know the socket. A destroy for a session we hold aims
-  at that session's socket alone, so the ordinary node-`×` path still fires exactly one kill
-  (pinned in `pty-single-user.test.ts`).
+- **The fan-out is opt-in, and only the panel opts in.** Two conditions have to hold: we do not know
+  the socket, *and* the caller asked for it (`localKillSockets(liveSocket, everySocket)`,
+  `sshProject.killSessions(…, { everySocket: true })`, `transport.destroy(id, { everySocket: true })`).
+  A destroy for a session we hold aims at that session's socket alone whatever the caller asked, so
+  the ordinary node-`×` on a mounted node still fires exactly one kill. But the **unheld** branch is
+  not rare — an ordinary node-`×` on a node that was never mounted in this process takes it every
+  time, which is the common case right after an app restart and for every non-active project's node
+  — and project deletion is the same shape remotely. Those callers know their own nodes, so they
+  stay narrow: speculating at `nodeterm-rmt` aims at sessions ANOTHER machine's nodeterm SSHed in to
+  spawn here, and speculating at a host's `node-terminal` aims at sessions a nodeterm running ON it
+  owns. Both defaults and both opt-ins are pinned (`pty-single-user.test.ts`,
+  `control-master.test.ts`, `ssh-project.killSessions.test.ts`), including that the wire flag must
+  be a literal `true`.
 
 Note the deliberate duplication: the sweep and the reaper keep their own `[TMUX_SOCKET,
 RMT_TMUX_SOCKET]` arrays. For them the ORDER is load-bearing — the sweep's `bySession` is first-wins,

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -305,10 +305,20 @@ own `×` use.
 - Switching between two SSH projects with the **same `user@host`** (the scope key carries no port)
   leaves the previous rows on screen until the re-sweep, because `enterScope` only clears when the
   scope *string* changes.
-- The **sessions sidebar** has the same class of bug this feature fixed in the panel: a destructive
-  confirm that lies for a row owned by a non-active project. Not fixed here — its rows span
-  arbitrary projects on arbitrary hosts, so its correct fix is owner-routed per row, a different
-  rule on a surface this change does not own.
+- **FOLLOW-UP OWED — the sessions sidebar still has the bug this feature fixed in the panel, and the
+  two surfaces now disagree about the same session.** `SessionsSidebar.tsx`'s close button calls
+  `closeSession(projectId, id)` (via `Canvas.tsx`'s `onCloseSession`) with **no remote leg**: for an
+  SSH project's node that is not mounted, `transport.destroy` has no live client carrying
+  `sshRemote`, so it touches only the local socket while the host's `nt-<id>` keeps running — after
+  a confirm that says it stopped. The session-memory panel routes the identical case through
+  `planSessionKill` → `sshProject.killSessions`, so ending a session from the panel works and
+  ending the same session from the sidebar does not.
+  Deliberately out of scope here: the sidebar's rows span arbitrary projects on arbitrary hosts, so
+  its correct fix is **owner-routed per row** (the owner project's own master, not the active
+  project's — the panel's rule is only sound because the panel shows one machine at a time), which
+  is a different rule on a surface this change does not own. Whoever takes it should reuse
+  `planSessionKill`'s shape rather than inventing a third kill path, and should widen its
+  `remoteProjectId` leg from "the active project" to "the row's owner" as the same change.
 
 ## 10. Device checklist
 
@@ -355,6 +365,9 @@ The SSH leg
     permanent pulse — this is the only place the connection-up re-read can be observed.
  9. A non-Linux SSH host (no /proc/meminfo): the pill must PULSE, never show "0 GB".
 10. Kill the master mid-sweep (`ssh -O exit`) and press ⟳: "Could not measure", never an empty list.
+10b. BREAK TMUX ON THE HOST while sessions are running (rename the binary, or `chmod 000` the socket
+    dir) and press ⟳: the panel must say "Could not measure", NOT "No sessions are running here.".
+    This is what the per-socket `##SOCKRC` fence buys, and the only place it can be seen for real.
 11. Watch ⟳ during a slow remote sweep: the button must be disabled and spinning (loading is
     asserted nowhere).
 
@@ -371,24 +384,26 @@ Layout and theming (argued from CSS only)
     ~90% used.
 18. fitView / goToNode must no longer tuck nodes under the pill.
 
-Rows, travel and the panel itself (restored — these were in the task reports and lost on the way in)
-23. A `claude` node with 2 MCP servers must read `+3 child processes`, not +2: `pane_pid` is the
+Rows, travel and the panel itself
+19. A `claude` node with 2 MCP servers must read `+3 child processes`, not +2: `pane_pid` is the
     pane's SHELL, so the count includes the agent CLI itself. This is the ONLY item that can
     falsify the "reports 3" claim made twice above; everything else about the sub-line is arithmetic.
-24. Travel to a row whose node lives in a CLOSED project: the tab must REOPEN and the camera land on
+20. Travel to a row whose node lives in a CLOSED project: the tab must REOPEN and the camera land on
     the node. This is the likeliest thing on the list to be wrong — the load and the focus happen in
     the same tick, and `travelToNode` (not `focusNodeById`) is what handles it.
-25. A LOCAL orphan row (`tmux -L node-terminal new-session -d -s nt-fake-1`) renders with a hollow
+21. A LOCAL orphan row (`tmux -L node-terminal new-session -d -s nt-fake-1`) renders with a hollow
     dot and a "no node" chip, and its title is inert — clicking it must do nothing at all.
-26. The panel STAYS OPEN through a kill: the ConfirmDialog is a portal outside the pill's container,
+22. The panel STAYS OPEN through a kill: the ConfirmDialog is a portal outside the pill's container,
     and answering it must not dismiss the list the user is working through. Clicking anywhere else
     on the canvas must still close the panel.
+23. The confirm on a row that HAS a node must say the node is removed too, and it must actually be
+    gone from the canvas afterwards — the panel's purpose invites a user who only wanted the RAM.
 
 Cadence and the other surfaces
-19. Local project, panel closed: the pill's number moves after 30 s.
-20. Local project: opening the panel triggers a sweep; closing and reopening triggers another; the
+24. Local project, panel closed: the pill's number moves after 30 s.
+25. Local project: opening the panel triggers a sweep; closing and reopening triggers another; the
     pill alone never does (watch for `ps`/`/proc` activity, or an ssh exec on an SSH scope).
-21. Server Edition in a browser: a local project's panel is full; an SSH project's panel says
+26. Server Edition in a browser: a local project's panel is full; an SSH project's panel says
     "Could not measure", with no local rows attributed to the host.
-22. Relay tab: the panel says session memory is not available there, and offers no ⟳.
+27. Relay tab: the panel says session memory is not available there, and offers no ⟳.
 ```

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -126,6 +126,31 @@ pane's *shell*, so a claude session with two MCP servers reports **3**. The pane
 `list-panes -a` emits one line per **pane**, so the first pane of a session wins in both legs (same
 key, same order) — one session is one row.
 
+### macOS reads `vm_stat`, not `os.freemem()`
+
+libuv's `os.freemem()` counts only genuinely FREE pages, and a healthy Mac keeps that near zero on
+purpose — file-backed and purgeable pages are held until something needs them. So `total - free`
+renders every Mac at ~100% used. Observed in the field: a 24 GB Mac reporting **23.9 / 24.0 GB**
+while the panel's sessions summed to 2.8 GB.
+
+`parseVmStat` computes what Activity Monitor calls Memory Used —
+`anonymous - purgeable + wired + compressor` — and treats the rest as available. It is an
+**approximation of Activity Monitor, not a reproduction**: Apple documents no exact figure, and on
+Apple Silicon the parts are known not to sum to its total.
+
+**The page size is read from `vm_stat`'s own header, never assumed.** Apple Silicon uses 16 KiB
+pages; hard-coding 4096 would report a quarter of real usage — the identical mistake this file
+already fixed on the Linux side, where `statm` tempted the same constant.
+
+**This also fixed the reaper, which is why the change lives in `readMemInfo` rather than in the
+pill.** `sessionBudgetConfig`'s watermark defaults to 10% of RAM (2457 MB on a 24 GB machine), and
+`os.freemem()` sat permanently below it — so `planReap` saw memory pressure on EVERY sweep and a Mac
+reaped idle detached sessions every 10 minutes regardless of how much memory was actually free. One
+reader, two consumers: that is the reason they share a definition.
+
+**Unverified:** the fixture in `session-memory.test.ts` is composed from Apple's documented format,
+not captured from a real machine. Device checklist item 6 is what closes it.
+
 ## 6. The SSH leg
 
 An SSH project's sessions live on the host, so the sweep runs there: core generates ONE POSIX `sh`
@@ -364,7 +389,8 @@ macOS (the ps path never runs on Linux)
  5. Open the panel on a Mac: `defaultProcessTableReader` returns null there, so the whole table
     comes from `ps -eo pid,ppid,rss`. Rows must populate, and the totals must be plausible — BSD ps
     reports rss in kB, but confirm one known process against Activity Monitor before trusting it.
- 6. macOS pill numbers: `os.freemem()` reports FREE, not AVAILABLE, memory. Confirm used/total reads
+ 6. macOS: capture real `vm_stat` output and check `parseVmStat` against Activity Monitor's Memory
+    Used (the fixture is COMPOSED, not captured). Confirm the pill's used/total reads
     plausibly rather than alarmingly (a Mac with a big page cache will look fuller than it is).
 
 The SSH leg

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -191,6 +191,15 @@ previous machine's facts on a real change.
 **The full sweep never runs on a timer and never from the pill.** The panel is *unmounted* while
 closed and its mount is what triggers the sweep.
 
+**The pill is icon-only at rest.** It sits on every canvas, always, so a permanent
+`RAM 15.6 GB / 62.5 GB` is a row of numbers nobody asked for — the pill's job is to be findable, not
+to report continuously. Hover (or keyboard focus, or an open panel) reveals used/total; the icon
+itself carries the pressure reading through the same thresholds the old mini-bar used, tinting as
+memory is CONSUMED. The reveal is **CSS, not a conditional mount**: the numbers stay in the DOM at
+rest so they remain the button's accessible name, and a hover-mounted figure would be unreachable to
+anything that reads the control without pointing at it. The pill sits to the LEFT of the usage pill
+— this machine's resources before this account's quota.
+
 **Ownership contract:** the store's poll timer and its active-scope stamp are **module singletons**,
 and the **pill is their single owner**. The panel must never call `startHostPoll` / `stopHostPoll` —
 a `stopHostPoll` on unmount would clear the pill's interval with nothing left to restart it, and the
@@ -380,7 +389,7 @@ Layout and theming (argued from CSS only)
 15. Sessions sidebar open: the collapsed pill passes UNDER the sidebar exactly as the usage pill
     does.
 16. Usage popover open beside the RAM pill: no overlap, pill still clickable.
-17. Both themes: hover (light is why the ink overlay exists) and the bar's colour steps at ~75% and
+17. Both themes: hover (light is why the ink overlay exists) and the icon's colour steps at ~75% and
     ~90% used.
 18. fitView / goToNode must no longer tuck nodes under the pill.
 

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -655,8 +655,13 @@ export class PtyManager {
     // event they get has to name WHO did it ("closed by <name>" — see `destroySession`).
     // Registered ONLY here: `on` and `onWithSender` compose on the same channel, so a leftover
     // plain listener would run the destroy — and its `tmux kill-session` — twice.
-    platform().onWithSender(IPC.ptyDestroy, (senderId: number, persistKey: string) =>
-      this.endFromClient(senderId, IPC.ptyDestroy, persistKey, 'delete')
+    // Optional TRAILING `everySocket`: only the session-memory panel's SPECULATIVE kill sets it,
+    // and only for a row it holds no session for (see `localKillSockets`). `=== true` because the
+    // value arrives verbatim off the wire; absent ⇒ the narrow, historical single-socket kill.
+    platform().onWithSender(
+      IPC.ptyDestroy,
+      (senderId: number, persistKey: string, everySocket?: unknown) =>
+        this.endFromClient(senderId, IPC.ptyDestroy, persistKey, 'delete', everySocket === true)
     )
     // Sender-aware for the opposite reason: the client that RECYCLED the node drives its own
     // respawn, so it is the one client that must NOT be sent the restart notice.
@@ -746,12 +751,13 @@ export class PtyManager {
     clientId: ClientId,
     channel: string,
     persistKey: string,
-    intent: EndIntent
+    intent: EndIntent,
+    everySocket = false
   ): Promise<void> {
     if (typeof persistKey !== 'string' || !persistKey || persistKey.length > REF_MAX_LEN)
       return Promise.resolve()
     if (!this.allowEnd(clientId, channel)) return Promise.resolve()
-    return this.endSession(clientId, persistKey, intent)
+    return this.endSession(clientId, persistKey, intent, everySocket)
   }
 
   /** Take one token from this client's bucket for a session-ending channel (see PTY_END_BUDGET).
@@ -2123,8 +2129,12 @@ export class PtyManager {
    *
    * `clientId` is null when nothing/no-one attributable did it (an internal caller).
    */
-  destroySession(clientId: ClientId | null, persistKey: string): Promise<void> {
-    return this.endSession(clientId, persistKey, 'delete')
+  destroySession(
+    clientId: ClientId | null,
+    persistKey: string,
+    opts?: { everySocket?: boolean }
+  ): Promise<void> {
+    return this.endSession(clientId, persistKey, 'delete', opts?.everySocket === true)
   }
 
   /**
@@ -2161,7 +2171,8 @@ export class PtyManager {
   private async endSession(
     clientId: ClientId | null,
     persistKey: string,
-    intent: EndIntent
+    intent: EndIntent,
+    everySocket = false
   ): Promise<void> {
     // Both callers run while the session is still live, so its sshRemote is known. Capture it
     // synchronously before any await. The index is the co-attach one (UI sessions); the scan is
@@ -2239,15 +2250,16 @@ export class PtyManager {
       // such session", which is already the ignored case below.
     }
     if (!this.tmuxPath) return
-    // Which socket(s) to aim at. Holding the session ourselves means we know: it is the local one.
-    // Holding NOTHING means the name is all we have, and on this machine a `nt-<id>` can also be
-    // living on the `nodeterm-rmt` socket — that is where ANOTHER machine's nodeterm puts the
-    // sessions it SSHes in to spawn. The session-memory panel lists those (it sweeps both sockets)
-    // and offers to end them, so a kill that only ever tried `node-terminal` showed a confirm
-    // saying "this stops its tmux session" and then did nothing. The common path — deleting a node
-    // whose session we hold — is unchanged, and every extra call is the already-ignored
-    // "no such session".
-    for (const socket of localKillSockets(dying ? TMUX_SOCKET : null)) {
+    // Which socket(s) to aim at. Holding the session ourselves means we KNOW: it is the local one,
+    // one kill, unchanged. Holding nothing means the name is all we have — and then the fan-out is
+    // the CALLER's to ask for, because on this machine a `nt-<id>` we hold nothing for can also be
+    // living on the `nodeterm-rmt` socket, where ANOTHER machine's nodeterm puts the sessions it
+    // SSHes in to spawn. Only the session-memory panel's speculative kill sets `everySocket`: it
+    // sweeps both sockets and offers to end what it found, so a kill that only tried
+    // `node-terminal` showed a confirm saying "this stops its tmux session" and did nothing. An
+    // ordinary node-× on a node never mounted in this process takes the same unheld branch and
+    // must NOT inherit that blast radius.
+    for (const socket of localKillSockets(dying ? TMUX_SOCKET : null, everySocket)) {
       try {
         await runAsync(this.tmuxPath, localTmuxKillArgs(socket, sessionName(persistKey)))
       } catch {

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -23,6 +23,8 @@ import {
   remoteHookEnvArgs,
   remoteTmuxHasSessionArgs,
   remoteTmuxKillArgs,
+  localKillSockets,
+  localTmuxKillArgs,
   remoteTmuxPtyArgs,
   remoteTmuxSendKeysArgs,
   remoteCapturePaneArgs,
@@ -2237,10 +2239,20 @@ export class PtyManager {
       // such session", which is already the ignored case below.
     }
     if (!this.tmuxPath) return
-    try {
-      await runAsync(this.tmuxPath, ['-L', TMUX_SOCKET, 'kill-session', '-t', sessionName(persistKey)])
-    } catch {
-      // session may not exist; ignore
+    // Which socket(s) to aim at. Holding the session ourselves means we know: it is the local one.
+    // Holding NOTHING means the name is all we have, and on this machine a `nt-<id>` can also be
+    // living on the `nodeterm-rmt` socket — that is where ANOTHER machine's nodeterm puts the
+    // sessions it SSHes in to spawn. The session-memory panel lists those (it sweeps both sockets)
+    // and offers to end them, so a kill that only ever tried `node-terminal` showed a confirm
+    // saying "this stops its tmux session" and then did nothing. The common path — deleting a node
+    // whose session we hold — is unchanged, and every extra call is the already-ignored
+    // "no such session".
+    for (const socket of localKillSockets(dying ? TMUX_SOCKET : null)) {
+      try {
+        await runAsync(this.tmuxPath, localTmuxKillArgs(socket, sessionName(persistKey)))
+      } catch {
+        // session may not exist on this socket; ignore
+      }
     }
   }
 

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -375,14 +375,14 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
   })
 
   // Destroying a name we hold NOTHING for is how the session-memory panel ends an ORPHAN row — a
-  // tmux session with no node on any canvas. It is also every session that outlived the process
-  // that spawned it. We cannot know which socket carries it, and on this machine a `nt-<id>` may be
-  // on `nodeterm-rmt`: that is where ANOTHER machine's nodeterm puts the sessions it SSHes in to
-  // spawn, and the panel sweeps (and offers to end) both sockets. Aiming only at `node-terminal`
-  // meant a confirm reading "this stops its tmux session" that killed nothing at all.
-  it('destroying a session we do not hold tries EVERY socket it could be on', async () => {
+  // tmux session with no node on any canvas. We cannot know which socket carries it, and on this
+  // machine a `nt-<id>` may be on `nodeterm-rmt`: that is where ANOTHER machine's nodeterm puts the
+  // sessions it SSHes in to spawn, and the panel sweeps (and offers to end) both sockets. Aiming
+  // only at `node-terminal` meant a confirm reading "this stops its tmux session" that killed
+  // nothing at all.
+  it('destroying a session we do not hold tries EVERY socket when the caller asks', async () => {
     const m = await tmuxManager()
-    await m.destroySession(SOLO, 'never-opened-here')
+    await m.destroySession(SOLO, 'never-opened-here', { everySocket: true })
     const kills = tmuxCalls('kill-session')
     expect(kills.map((c) => c.args[c.args.indexOf('-L') + 1]).sort()).toEqual([
       'node-terminal',
@@ -391,6 +391,41 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     for (const k of kills) {
       expect(k.args[k.args.indexOf('-t') + 1]).toBe(`=${sessionName('never-opened-here')}`)
     }
+  })
+
+  // ...but the fan-out is OPT-IN, and the unheld branch is not rare: an ordinary node-× on a node
+  // that was never mounted in this process takes it every time (the common case after an app
+  // restart, and every non-active project's node). Those callers know their own node and have no
+  // business speculating at `nodeterm-rmt`, which holds another machine's sessions.
+  it('destroying a session we do not hold stays on ONE socket by default', async () => {
+    const m = await tmuxManager()
+    await m.destroySession(SOLO, 'never-opened-here')
+    const kills = tmuxCalls('kill-session')
+    expect(kills.map((c) => c.args[c.args.indexOf('-L') + 1])).toEqual(['node-terminal'])
+  })
+
+  // The flag arrives verbatim from a renderer, so the wire path must demand a real `true` — and it
+  // must reach `endSession`, which is the half a `destroySession`-only test cannot see.
+  it('honours everySocket off the wire, and only for a literal true', async () => {
+    await tmuxManager()
+    await (fake.senderListeners[IPC.ptyDestroy](
+      SOLO,
+      'never-opened-here',
+      true
+    ) as unknown as Promise<void>)
+    expect(tmuxCalls('kill-session').map((c) => c.args[c.args.indexOf('-L') + 1]).sort()).toEqual([
+      'node-terminal',
+      'nodeterm-rmt'
+    ])
+    execCalls.length = 0
+    await (fake.senderListeners[IPC.ptyDestroy](
+      SOLO,
+      'never-opened-2',
+      'yes' as unknown as boolean
+    ) as unknown as Promise<void>)
+    expect(tmuxCalls('kill-session').map((c) => c.args[c.args.indexOf('-L') + 1])).toEqual([
+      'node-terminal'
+    ])
   })
 
   // ── recycle (move into worktree) = destroy, minus the "someone closed it" fan-out ─────────

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -364,8 +364,33 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     await create(80, 24)
     await m.destroySession(SOLO, 'solo-1')
     const kills = tmuxCalls('kill-session')
+    // ONE kill: we hold this session, so we know which socket it is on and the destroy aims only
+    // there. A destroy with NO live session cannot know, and fans out over both sockets
+    // (`localKillSockets`) — this length is what keeps that off the solo path.
     expect(kills).toHaveLength(1)
-    expect(kills[0].args[kills[0].args.indexOf('-t') + 1]).toBe(sessionName('solo-1'))
+    expect(kills[0].args[kills[0].args.indexOf('-L') + 1]).toBe('node-terminal')
+    // `=` forces an EXACT tmux target. Node ids end in a counter, so `nt-a-1` is a prefix of
+    // `nt-a-12`, and tmux falls back to prefix matching whenever the exact name is not found.
+    expect(kills[0].args[kills[0].args.indexOf('-t') + 1]).toBe(`=${sessionName('solo-1')}`)
+  })
+
+  // Destroying a name we hold NOTHING for is how the session-memory panel ends an ORPHAN row — a
+  // tmux session with no node on any canvas. It is also every session that outlived the process
+  // that spawned it. We cannot know which socket carries it, and on this machine a `nt-<id>` may be
+  // on `nodeterm-rmt`: that is where ANOTHER machine's nodeterm puts the sessions it SSHes in to
+  // spawn, and the panel sweeps (and offers to end) both sockets. Aiming only at `node-terminal`
+  // meant a confirm reading "this stops its tmux session" that killed nothing at all.
+  it('destroying a session we do not hold tries EVERY socket it could be on', async () => {
+    const m = await tmuxManager()
+    await m.destroySession(SOLO, 'never-opened-here')
+    const kills = tmuxCalls('kill-session')
+    expect(kills.map((c) => c.args[c.args.indexOf('-L') + 1]).sort()).toEqual([
+      'node-terminal',
+      'nodeterm-rmt'
+    ])
+    for (const k of kills) {
+      expect(k.args[k.args.indexOf('-t') + 1]).toBe(`=${sessionName('never-opened-here')}`)
+    }
   })
 
   // ── recycle (move into worktree) = destroy, minus the "someone closed it" fan-out ─────────
@@ -379,8 +404,8 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     await (fake.senderListeners[IPC.ptyRecycle](SOLO, 'solo-1') as unknown as Promise<void>)
 
     const kills = tmuxCalls('kill-session')
-    expect(kills).toHaveLength(1)
-    expect(kills[0].args[kills[0].args.indexOf('-t') + 1]).toBe(sessionName('solo-1'))
+    expect(kills).toHaveLength(1) // we hold the session; one socket, one kill
+    expect(kills[0].args[kills[0].args.indexOf('-t') + 1]).toBe(`=${sessionName('solo-1')}`)
     expect(spawned[0].killed).toBe(true) // the old pty client is released
     expect(fake.sent).toEqual([]) // solo: nobody to tell, so nothing is sent
 

--- a/src/core/remote-ssh/control-master.test.ts
+++ b/src/core/remote-ssh/control-master.test.ts
@@ -15,6 +15,11 @@ import {
   listDirArgs,
   mkDirArgs,
   RMT_TMUX_SOCKET,
+  KILL_TMUX_SOCKETS,
+  localKillSockets,
+  localTmuxKillArgs,
+  remoteTmuxKillArgs,
+  remoteTmuxKillEverySocketArgs,
   hookForwardArgs,
   hookForwardCancelArgs,
   remoteHookEnvArgs,
@@ -379,5 +384,53 @@ describe('probeSaysAbsent (has-session probe discrimination)', () => {
     expect(probeSaysAbsent(new Error('plain'))).toBe(false)
     expect(probeSaysAbsent(undefined)).toBe(false)
     expect(probeSaysAbsent(null)).toBe(false)
+  })
+})
+
+describe('killing a session by name (both sockets, exact target)', () => {
+  // Two nodeterm tmux sockets live on every host at once: `node-terminal` for a nodeterm running ON
+  // the machine, `nodeterm-rmt` for one SSH-ing INTO it. The session-memory sweep lists BOTH, so a
+  // kill routed to one of them promised something it could not do for every row off the other — a
+  // host running its own nodeterm-server is exactly that shape.
+  it('covers both sockets a nodeterm session can live on', () => {
+    expect([...KILL_TMUX_SOCKETS].sort()).toEqual(['node-terminal', 'nodeterm-rmt'])
+  })
+
+  it('targets the session EXACTLY — never tmux prefix matching', () => {
+    // A speculative kill misses by design, and a miss is when tmux falls back to fnmatch and then
+    // to prefix matching. Node ids end in a counter, so `nt-a-1` is a prefix of `nt-a-12`: without
+    // `=` a miss could kill a different session.
+    expect(localTmuxKillArgs('node-terminal', 'nt-a-1')).toEqual([
+      '-L', 'node-terminal', 'kill-session', '-t', '=nt-a-1'
+    ])
+    expect(remoteTmuxKillArgs(conn, '/s.sock', 'nt-a-1').at(-1)).toContain('-t =nt-a-1')
+  })
+
+  it('aims a local destroy at the socket we hold, and at every socket when we hold nothing', () => {
+    // Holding the session means we know which socket it is on. Holding nothing (an orphan row in
+    // the session-memory panel, or any session that outlived the process that spawned it) means the
+    // name is all we have.
+    expect(localKillSockets('node-terminal')).toEqual(['node-terminal'])
+    expect([...localKillSockets(null)].sort()).toEqual(['node-terminal', 'nodeterm-rmt'])
+  })
+
+  it('keeps the remote default on the ssh socket, and overrides it explicitly', () => {
+    expect(remoteTmuxKillArgs(conn, '/s.sock', 'nt-x').at(-1)).toBe(
+      `tmux -L ${RMT_TMUX_SOCKET} kill-session -t =nt-x`
+    )
+    expect(remoteTmuxKillArgs(conn, '/s.sock', 'nt-x', 'node-terminal').at(-1)).toBe(
+      'tmux -L node-terminal kill-session -t =nt-x'
+    )
+  })
+
+  it('kills a name on EVERY remote socket, one ssh invocation each', () => {
+    const runs = remoteTmuxKillEverySocketArgs(conn, '/s.sock', 'nt-x')
+    expect(runs).toHaveLength(2)
+    expect(runs.map((r) => r.at(-1)).sort()).toEqual([
+      'tmux -L node-terminal kill-session -t =nt-x',
+      `tmux -L ${RMT_TMUX_SOCKET} kill-session -t =nt-x`
+    ])
+    // Each is a complete child-ssh argv, not a bare command.
+    for (const r of runs) expect(r.slice(0, childPrefix.length)).toEqual(childPrefix)
   })
 })

--- a/src/core/remote-ssh/control-master.test.ts
+++ b/src/core/remote-ssh/control-master.test.ts
@@ -406,12 +406,19 @@ describe('killing a session by name (both sockets, exact target)', () => {
     expect(remoteTmuxKillArgs(conn, '/s.sock', 'nt-a-1').at(-1)).toContain('-t =nt-a-1')
   })
 
-  it('aims a local destroy at the socket we hold, and at every socket when we hold nothing', () => {
-    // Holding the session means we know which socket it is on. Holding nothing (an orphan row in
-    // the session-memory panel, or any session that outlived the process that spawned it) means the
-    // name is all we have.
+  it('aims a local destroy at the socket we hold, whatever the caller asked for', () => {
+    // Holding the session means we KNOW which socket it is on, so the fan-out flag is irrelevant:
+    // one kill either way. This is what keeps the ordinary node-x path at exactly one kill.
     expect(localKillSockets('node-terminal')).toEqual(['node-terminal'])
-    expect([...localKillSockets(null)].sort()).toEqual(['node-terminal', 'nodeterm-rmt'])
+    expect(localKillSockets('node-terminal', true)).toEqual(['node-terminal'])
+  })
+
+  it('fans a socket-less kill out only when the caller opts in', () => {
+    // Holding nothing means the name is all we have — but the unheld branch is NOT rare (an
+    // ordinary node-x on a node never mounted in this process takes it), so the blast radius is
+    // the caller's to ask for. Only the session-memory panel, which swept BOTH sockets, does.
+    expect(localKillSockets(null)).toEqual(['node-terminal'])
+    expect([...localKillSockets(null, true)].sort()).toEqual(['node-terminal', 'nodeterm-rmt'])
   })
 
   it('keeps the remote default on the ssh socket, and overrides it explicitly', () => {

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -4,6 +4,7 @@ import os from 'os'
 import path from 'path'
 import { createHash } from 'crypto'
 import { posixQuote, quoteRemotePath, remoteTmuxCommand, type SshConnection } from '../../shared/ssh'
+import { TMUX_SOCKET } from '../tmux-naming'
 import { canControlCanvas } from '../../shared/agents/config'
 import { bracketedInjection } from '../paste-injection'
 // Dependency-free (no node-pty): safe to import from these pure builders.
@@ -252,8 +253,71 @@ export function remoteTmuxSendKeysArgs(
 export function probeSaysAbsent(err: unknown): boolean {
   return (err as { code?: unknown } | null)?.code === 1
 }
-export function remoteTmuxKillArgs(conn: SshConnection, controlPath: string, sessionId: string): string[] {
-  return childArgs(conn, controlPath, `tmux -L ${RMT_TMUX_SOCKET} kill-session -t ${sessionId}`)
+/**
+ * Every tmux socket a nodeterm session can be living on, on ONE machine — used when we are asked to
+ * end a session by NAME and do not know which socket holds it.
+ *
+ * Both exist on the same host all the time: `node-terminal` is what a nodeterm running ON that
+ * machine uses (desktop or Server Edition), `nodeterm-rmt` is what a nodeterm SSH-ing INTO it uses.
+ * The session-memory sweep lists both (`session-memory.ts`, `session-memory-remote.ts`) — so a kill
+ * that only ever targeted one of them promised something it could not do for every row that came
+ * off the other. That is not exotic: a host that runs its own `nodeterm-server` and is also SSH'd
+ * into is exactly this shape.
+ *
+ * Deliberately NOT the same constant the sweep and the reaper use, even though it holds the same two
+ * names: for THEM the order is load-bearing (the sweep's `bySession` is first-wins, so the order
+ * decides which socket a duplicate name is attributed to), and for a kill it means nothing. Sharing
+ * one array would silently couple a de-duplication preference to a kill list.
+ */
+export const KILL_TMUX_SOCKETS: readonly string[] = [TMUX_SOCKET, RMT_TMUX_SOCKET]
+
+/**
+ * Which local sockets a destroy must attempt. `liveSocket` is the socket of the session we actually
+ * hold (which we know is the right one); `null` = we hold nothing, so the name is all we have and
+ * every socket that could carry it has to be tried. An orphan row in the session-memory panel — and
+ * any node whose session outlived the process that spawned it — takes the `null` branch.
+ */
+export function localKillSockets(liveSocket: string | null): readonly string[] {
+  return liveSocket ? [liveSocket] : KILL_TMUX_SOCKETS
+}
+
+/**
+ * `=` forces tmux to match the target EXACTLY. Without it tmux falls back to fnmatch and then to
+ * PREFIX matching when the name is not found — and "not found" is the normal case for every kill we
+ * fire speculatively at a socket. Node ids end in a counter (`term-<base36 ms>-1`), so `nt-…-1` is a
+ * prefix of `nt-…-12`: a miss could kill a DIFFERENT session. The reaper already kills this way
+ * (`session-budget.ts`) for the same reason.
+ */
+function exactTarget(sessionId: string): string {
+  return `=${sessionId}`
+}
+
+/** Local `tmux kill-session` argv (the binary is resolved by the caller). */
+export function localTmuxKillArgs(socket: string, sessionId: string): string[] {
+  return ['-L', socket, 'kill-session', '-t', exactTarget(sessionId)]
+}
+
+export function remoteTmuxKillArgs(
+  conn: SshConnection,
+  controlPath: string,
+  sessionId: string,
+  socket: string = RMT_TMUX_SOCKET
+): string[] {
+  return childArgs(conn, controlPath, `tmux -L ${socket} kill-session -t ${exactTarget(sessionId)}`)
+}
+
+/**
+ * One kill per socket, for a caller that knows only the session NAME (`SshProjectManager.
+ * killSessions`, which the session-memory panel and project deletion both use). Best-effort by
+ * contract: tmux exits non-zero with "can't find session" on every socket that does not hold it,
+ * and that is an expected, ignored outcome rather than a failure.
+ */
+export function remoteTmuxKillEverySocketArgs(
+  conn: SshConnection,
+  controlPath: string,
+  sessionId: string
+): string[][] {
+  return KILL_TMUX_SOCKETS.map((socket) => remoteTmuxKillArgs(conn, controlPath, sessionId, socket))
 }
 export function remoteCapturePaneArgs(conn: SshConnection, controlPath: string, sessionId: string, full: boolean): string[] {
   return childArgs(

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -272,13 +272,27 @@ export function probeSaysAbsent(err: unknown): boolean {
 export const KILL_TMUX_SOCKETS: readonly string[] = [TMUX_SOCKET, RMT_TMUX_SOCKET]
 
 /**
- * Which local sockets a destroy must attempt. `liveSocket` is the socket of the session we actually
- * hold (which we know is the right one); `null` = we hold nothing, so the name is all we have and
- * every socket that could carry it has to be tried. An orphan row in the session-memory panel — and
- * any node whose session outlived the process that spawned it — takes the `null` branch.
+ * Which local sockets a destroy must attempt.
+ *
+ * `liveSocket` is the socket of the session we actually HOLD, which we know is the right one: one
+ * kill, and the fan-out below can never reach the ordinary path.
+ *
+ * With no live session the name is all we have, and then it depends on who is asking:
+ *  - `everySocket: false` (the default, and every ordinary caller) → the local socket only. An
+ *    ordinary node-× on a node that was never mounted in THIS process — the common case after an
+ *    app restart — has no business speculating at `nodeterm-rmt`, which carries the sessions
+ *    ANOTHER machine's nodeterm SSHed in to spawn here.
+ *  - `everySocket: true` → every socket the name could be on. Only the session-memory panel's
+ *    speculative kill asks for this, and it is the one caller that has earned it: the panel sweeps
+ *    BOTH sockets, so an orphan row genuinely can be on either, and a kill aimed at one of them
+ *    showed a confirm reading "this stops its tmux session" and then killed nothing at all.
  */
-export function localKillSockets(liveSocket: string | null): readonly string[] {
-  return liveSocket ? [liveSocket] : KILL_TMUX_SOCKETS
+export function localKillSockets(
+  liveSocket: string | null,
+  everySocket = false
+): readonly string[] {
+  if (liveSocket) return [liveSocket]
+  return everySocket ? KILL_TMUX_SOCKETS : [TMUX_SOCKET]
 }
 
 /**
@@ -307,10 +321,14 @@ export function remoteTmuxKillArgs(
 }
 
 /**
- * One kill per socket, for a caller that knows only the session NAME (`SshProjectManager.
- * killSessions`, which the session-memory panel and project deletion both use). Best-effort by
- * contract: tmux exits non-zero with "can't find session" on every socket that does not hold it,
- * and that is an expected, ignored outcome rather than a failure.
+ * One kill per socket, for a caller that knows only the session NAME and does not know which socket
+ * carries it — i.e. `SshProjectManager.killSessions({ everySocket: true })`, which is the
+ * session-memory panel's route. Project deletion does NOT use this: it knows its own nodes, they
+ * are all on the SSH project's own socket, and speculating at the host's `node-terminal` would aim
+ * at sessions a nodeterm running ON that host owns.
+ *
+ * Best-effort by contract: tmux exits non-zero with "can't find session" on every socket that does
+ * not hold it, and that is an expected, ignored outcome rather than a failure.
  */
 export function remoteTmuxKillEverySocketArgs(
   conn: SshConnection,

--- a/src/core/session-budget.ts
+++ b/src/core/session-budget.ts
@@ -21,26 +21,24 @@
 // Electron-free (src/core): all exec/mem/clock access is behind injectable seams (template:
 // ack-sweep.ts), so both shells boot it and tests drive it without touching tmux.
 
-import fs from 'fs'
 import os from 'os'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { TMUX_SOCKET } from './tmux-naming'
 import { RMT_TMUX_SOCKET } from './remote-ssh/control-master'
+import { readMemInfo, type MemInfo } from './session-memory'
 
 const runAsync = promisify(execFile)
+
+// One definition, two consumers (the reaper's watermark and the system-resource pill): a copied
+// second reader would let them disagree about how much RAM is free.
+export { readMemInfo, type MemInfo } from './session-memory'
 
 /** One tmux session as reported by `list-sessions`. `activitySec` is epoch seconds. */
 export interface SessionInfo {
   name: string
   attached: boolean
   activitySec: number
-}
-
-/** Host memory snapshot in MB. `null` from a reader means "could not read" — see planReap. */
-export interface MemInfo {
-  availableMb: number
-  totalMb: number
 }
 
 export interface SessionBudgetConfig {
@@ -120,26 +118,6 @@ export function parseSessionList(stdout: string): SessionInfo[] {
     out.push({ name: parts[0], attached: attached > 0, activitySec: activity })
   }
   return out
-}
-
-/** Linux `/proc/meminfo` (MemAvailable is the honest number); `os.freemem()` fallback elsewhere.
- *  Returns null when nothing readable — the policy treats that as "no pressure signal". */
-export function readMemInfo(): MemInfo | null {
-  try {
-    const text = fs.readFileSync('/proc/meminfo', 'utf8')
-    const avail = /MemAvailable:\s+(\d+)\s*kB/.exec(text)
-    const total = /MemTotal:\s+(\d+)\s*kB/.exec(text)
-    if (avail && total) {
-      return { availableMb: Math.round(Number(avail[1]) / 1024), totalMb: Math.round(Number(total[1]) / 1024) }
-    }
-  } catch {
-    // fall through to the os fallback
-  }
-  try {
-    return { availableMb: Math.round(os.freemem() / 1048576), totalMb: Math.round(os.totalmem() / 1048576) }
-  } catch {
-    return null
-  }
 }
 
 export interface SessionReaperOpts {

--- a/src/core/session-memory-remote.test.ts
+++ b/src/core/session-memory-remote.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  remoteSessionMemoryCommand,
+  parseRemoteSessionMemory,
+  fetchRemoteSessionMemory
+} from './session-memory-remote'
+
+const run = promisify(execFile)
+
+describe('parseRemoteSessionMemory', () => {
+  it('parses all three sections into a report', () => {
+    const r = parseRemoteSessionMemory(
+      '##MEM\nMemAvailable: 13500000 kB\nMemTotal: 65700000 kB\n' +
+        '##PANES\nnt-term-a|100|claude\n' +
+        '##PROCS\n100 1 1024\n200 100 358400\n'
+    )
+    expect(r.ok).toBe(true)
+    expect(r.mem).toEqual({ availableMb: 13184, totalMb: 64160 })
+    expect(r.rows).toHaveLength(1)
+    expect(r.rows[0]).toMatchObject({ nodeId: 'term-a', selfMb: 1, childrenMb: 350 })
+  })
+
+  it('reports ok:false when the PROCS section is missing (the read was cut short)', () => {
+    const r = parseRemoteSessionMemory('##MEM\n##PANES\nnt-term-a|100|claude\n')
+    expect(r.ok).toBe(false)
+    expect(r.rows).toEqual([])
+  })
+
+  it('reports ok:true with no rows when the host has no nt- sessions', () => {
+    const r = parseRemoteSessionMemory('##MEM\n##PANES\n##PROCS\n100 1 1024\n')
+    expect(r.ok).toBe(true)
+    expect(r.rows).toEqual([])
+  })
+
+  // Both sockets are swept in ONE stream, and `list-panes -a` prints a line per PANE, so the same
+  // session can appear several times. It is still one session, hence one row (the local leg's
+  // `bySession` map makes the same promise).
+  it('collapses a session reported by several panes into one row', () => {
+    const r = parseRemoteSessionMemory(
+      '##MEM\n##PANES\nnt-term-a|100|claude\nnt-term-a|300|bash\n##PROCS\n100 1 1024\n300 1 2048\n'
+    )
+    expect(r.ok).toBe(true)
+    expect(r.rows.map((x) => x.panePid)).toEqual([100])
+  })
+})
+
+describe('fetchRemoteSessionMemory', () => {
+  it('reports ok:false when the command could not run (a dead master says nothing)', async () => {
+    const r = await fetchRemoteSessionMemory('p1', async () => null)
+    expect(r.ok).toBe(false)
+  })
+
+  it('reports ok:false when the runner throws', async () => {
+    const r = await fetchRemoteSessionMemory('p1', async () => {
+      throw new Error('master down')
+    })
+    expect(r.ok).toBe(false)
+  })
+})
+
+// The command is generated shell that no compiler checks. Run it for real.
+describe('remoteSessionMemoryCommand under /bin/sh', () => {
+  let dir: string
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sessmem-'))
+    // A fake tmux on PATH that answers list-panes and nothing else.
+    fs.writeFileSync(
+      path.join(dir, 'tmux'),
+      '#!/bin/sh\nfor a in "$@"; do [ "$a" = "list-panes" ] && { echo "nt-term-a|$$|claude"; exit 0; }; done\nexit 1\n'
+    )
+    fs.chmodSync(path.join(dir, 'tmux'), 0o755)
+  })
+
+  afterAll(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  it('produces a parseable report on a host with a tmux server', async () => {
+    const { stdout } = await run('/bin/sh', ['-c', remoteSessionMemoryCommand()], {
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ''}` }
+    })
+    const r = parseRemoteSessionMemory(stdout)
+    expect(r.ok).toBe(true)
+    expect(r.rows.map((x) => x.nodeId)).toEqual(['term-a'])
+    // The row resolved against the REAL process table, so it has a real size.
+    expect(r.rows[0].totalMb).toBeGreaterThanOrEqual(0)
+  })
+
+  it('exits 0 and reports no rows when no tmux server is running', async () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'sessmem-notmux-'))
+    fs.writeFileSync(path.join(empty, 'tmux'), '#!/bin/sh\nexit 1\n')
+    fs.chmodSync(path.join(empty, 'tmux'), 0o755)
+    const { stdout } = await run('/bin/sh', ['-c', remoteSessionMemoryCommand()], {
+      env: { ...process.env, PATH: `${empty}:${process.env.PATH ?? ''}` }
+    })
+    const r = parseRemoteSessionMemory(stdout)
+    // A clean miss is an ANSWER: the sweep ran, the host simply has nothing.
+    expect(r.ok).toBe(true)
+    expect(r.rows).toEqual([])
+    fs.rmSync(empty, { recursive: true, force: true })
+  })
+})

--- a/src/core/session-memory-remote.test.ts
+++ b/src/core/session-memory-remote.test.ts
@@ -12,11 +12,23 @@ import {
 
 const run = promisify(execFile)
 
+/** One socket's fence inside the `##PANES` section: what the generated command prints per socket.
+ *  Every fixture below goes through this, so a change to the fence breaks the tests loudly rather
+ *  than leaving them asserting a shape the command no longer emits. */
+const sock = (name: string, rc: number, body = ''): string =>
+  `##SOCK ${name}\n${body}##SOCKRC ${rc}\n`
+
+/** The two sockets answering "no server running" — the normal state of an idle host, and the
+ *  baseline every "the panes are what matters" fixture wants. */
+const bothIdle = (panes = ''): string =>
+  sock('node-terminal', 0, panes) + sock('nodeterm-rmt', 1, 'no server running on /tmp/x\n')
+
 describe('parseRemoteSessionMemory', () => {
   it('parses all three sections into a report', () => {
     const r = parseRemoteSessionMemory(
       '##MEM\nMemAvailable: 13500000 kB\nMemTotal: 65700000 kB\n' +
-        '##PANES\nnt-term-a|100|claude\n' +
+        '##PANES\n' +
+        bothIdle('nt-term-a|100|claude\n') +
         '##PROCS\n100 1 1024\n200 100 358400\n'
     )
     expect(r.ok).toBe(true)
@@ -26,15 +38,87 @@ describe('parseRemoteSessionMemory', () => {
   })
 
   it('reports ok:false when the PROCS section is missing (the read was cut short)', () => {
-    const r = parseRemoteSessionMemory('##MEM\n##PANES\nnt-term-a|100|claude\n')
+    const r = parseRemoteSessionMemory('##MEM\n##PANES\n' + bothIdle('nt-term-a|100|claude\n'))
     expect(r.ok).toBe(false)
     expect(r.rows).toEqual([])
   })
 
   it('reports ok:true with no rows when the host has no nt- sessions', () => {
-    const r = parseRemoteSessionMemory('##MEM\n##PANES\n##PROCS\n100 1 1024\n')
+    const r = parseRemoteSessionMemory('##MEM\n##PANES\n' + bothIdle() + '##PROCS\n100 1 1024\n')
     expect(r.ok).toBe(true)
     expect(r.rows).toEqual([])
+  })
+
+  // The whole point of the per-socket fence. `{ tmux …; tmux …; } || true` with stderr discarded
+  // produced a byte-identical stream for "this host has no tmux server" and "every tmux call on
+  // this host failed", and the panel rendered the second as "No sessions are running here.".
+  describe('a socket that FAILED is not a socket that answered "nothing"', () => {
+    const procs = '##PROCS\n100 1 1024\n'
+
+    it('accepts tmux saying there is no server (an ANSWER: the socket is simply unused)', () => {
+      const r = parseRemoteSessionMemory(
+        '##MEM\n##PANES\n' +
+          sock('node-terminal', 1, 'no server running on /tmp/tmux-0/node-terminal\n') +
+          sock('nodeterm-rmt', 1, 'error connecting to /tmp/tmux-0/nodeterm-rmt (No such file or directory)\n') +
+          procs
+      )
+      expect(r.ok).toBe(true)
+      expect(r.rows).toEqual([])
+    })
+
+    it('reports ok:false when EVERY socket failed for some other reason', () => {
+      // A tmux client missing a shared library exits 127 on every socket — the same binary, so the
+      // host's live sessions are untouched and very much still there.
+      const linker =
+        'tmux: error while loading shared libraries: libevent-2.1.so.7: cannot open shared object file: No such file or directory\n'
+      const r = parseRemoteSessionMemory(
+        '##MEM\n##PANES\n' +
+          sock('node-terminal', 127, linker) +
+          sock('nodeterm-rmt', 127, linker) +
+          procs
+      )
+      expect(r.ok).toBe(false)
+      expect(r.rows).toEqual([])
+    })
+
+    it('reports ok:true when only SOME sockets failed — one answer is enough', () => {
+      const r = parseRemoteSessionMemory(
+        '##MEM\n##PANES\n' +
+          sock('node-terminal', 0, 'nt-term-a|100|claude\n') +
+          sock('nodeterm-rmt', 13, 'error connecting to /tmp/tmux-1/nodeterm-rmt (Permission denied)\n') +
+          '##PROCS\n100 1 1024\n'
+      )
+      expect(r.ok).toBe(true)
+      expect(r.rows.map((x) => x.nodeId)).toEqual(['term-a'])
+    })
+
+    it('reports ok:false when a socket fence was never closed (the stream was cut mid-socket)', () => {
+      const r = parseRemoteSessionMemory(
+        '##MEM\n##PANES\n##SOCK node-terminal\nnt-term-a|100|claude\n' + procs
+      )
+      expect(r.ok).toBe(false)
+      expect(r.rows).toEqual([])
+    })
+
+    // The fence is matched against the sockets we asked for and a numeric status, so a session
+    // whose NAME or foreground command looks like a marker cannot open or close a block.
+    it('cannot be fenced by pane data that looks like a marker', () => {
+      // The fake opener sits AFTER a real pane and the fake closer INSIDE a real pane line, so a
+      // loosened match (`startsWith('##SOCK ')`, or an unanchored `##SOCKRC`) drops one of the two
+      // rows instead of merely renaming a command.
+      const r = parseRemoteSessionMemory(
+        '##MEM\n##PANES\n' +
+          sock(
+            'node-terminal',
+            0,
+            'nt-term-a|100|claude\n##SOCK not-a-socket\nnt-term-b|200|##SOCKRC 0\n'
+          ) +
+          sock('nodeterm-rmt', 1, 'no server running\n') +
+          '##PROCS\n100 1 1024\n200 1 2048\n'
+      )
+      expect(r.ok).toBe(true)
+      expect(r.rows.map((x) => x.nodeId).sort()).toEqual(['term-a', 'term-b'])
+    })
   })
 
   // An ssh exec channel is not a clean pipe — a login shell's rc file can write to stdout ahead of
@@ -47,7 +131,8 @@ describe('parseRemoteSessionMemory', () => {
     const r = parseRemoteSessionMemory(
       '##PROCS\n' +
         '##MEM\nMemAvailable: 1024 kB\nMemTotal: 2048 kB\n' +
-        '##PANES\nnt-term-a|100|claude\n' +
+        '##PANES\n' +
+        bothIdle('nt-term-a|100|claude\n') +
         '##PROCS\n100 1 1024\n200 100 358400\n'
     )
     expect(r.ok).toBe(false)
@@ -58,7 +143,8 @@ describe('parseRemoteSessionMemory', () => {
   it('is not confused by a marker appearing inside pane or process data', () => {
     const r = parseRemoteSessionMemory(
       '##MEM\nMemAvailable: 1024 kB\nMemTotal: 2048 kB\n' +
-        '##PANES\nnt-term-b|300|##PROCS\n' +
+        '##PANES\n' +
+        bothIdle('nt-term-b|300|##PROCS\n') +
         '##PROCS\n300 1 1024\n##PANES\n400 1 2048\n'
     )
     expect(r.ok).toBe(true)
@@ -72,9 +158,13 @@ describe('parseRemoteSessionMemory', () => {
   // `bySession` map makes the same promise).
   it('collapses a session reported by several panes into one row', () => {
     const r = parseRemoteSessionMemory(
-      '##MEM\n##PANES\nnt-term-a|100|claude\nnt-term-a|300|bash\n##PROCS\n100 1 1024\n300 1 2048\n'
+      '##MEM\n##PANES\n' +
+        sock('node-terminal', 0, 'nt-term-a|100|claude\n') +
+        sock('nodeterm-rmt', 0, 'nt-term-a|300|bash\n') +
+        '##PROCS\n100 1 1024\n300 1 2048\n'
     )
     expect(r.ok).toBe(true)
+    // First socket in sweep order wins, exactly as the local leg's first-wins `bySession` does.
     expect(r.rows.map((x) => x.panePid)).toEqual([100])
   })
 })
@@ -170,14 +260,42 @@ describe('remoteSessionMemoryCommand under /bin/sh', () => {
     expect(r.rows.map((x) => x.nodeId)).toEqual(['term-a'])
   })
 
-  it('exits 0 and reports no rows when no tmux server is running', async () => {
-    const empty = fakeHost('sessmem-notmux-', { tmux: '#!/bin/sh\nexit 1\n' })
+  // tmux's OWN words for "there is no server on this socket", on stderr with a non-zero status.
+  // A blanket `exit 1` would pass this test while proving nothing: it cannot tell "no server" from
+  // "tmux is broken", which are the two cases the fence exists to separate.
+  it('exits 0 and reports no rows when tmux says no server is running', async () => {
+    const empty = fakeHost('sessmem-notmux-', {
+      tmux: '#!/bin/sh\necho "no server running on /tmp/tmux-0/default" >&2\nexit 1\n'
+    })
     const { stdout } = await run('/bin/sh', ['-c', remoteSessionMemoryCommand()], {
       env: { ...process.env, PATH: `${empty}:${process.env.PATH ?? ''}` }
     })
     const r = parseRemoteSessionMemory(stdout)
     // A clean miss is an ANSWER: the sweep ran, the host simply has nothing.
     expect(r.ok).toBe(true)
+    expect(r.rows).toEqual([])
+  })
+
+  // The failure this whole fence was added for, end to end through the real shell: a tmux client
+  // that cannot start exits 127 on EVERY socket while the host's sessions keep running. Under the
+  // old command (stderr to /dev/null, status dropped) this stream was byte-identical to the one
+  // above and the panel said "No sessions are running here." over thirty live sessions.
+  it('reports ok:false when the tmux client itself is broken on every socket', async () => {
+    const broken = fakeHost('sessmem-brokentmux-', {
+      tmux:
+        '#!/bin/sh\necho "tmux: error while loading shared libraries: libevent-2.1.so.7: ' +
+        'cannot open shared object file: No such file or directory" >&2\nexit 127\n'
+    })
+    const { stdout } = await run('/bin/sh', ['-c', remoteSessionMemoryCommand()], {
+      env: { ...process.env, PATH: `${broken}:${process.env.PATH ?? ''}` }
+    })
+    // The shell still exits 0 and still prints all three markers plus a real process table — which
+    // is exactly why the panes section had to carry a per-socket STATUS to tell the two apart.
+    expect(stdout).toContain('##MEM')
+    expect(stdout).toContain('##PANES')
+    expect(stdout).toContain('##PROCS')
+    const r = parseRemoteSessionMemory(stdout)
+    expect(r.ok).toBe(false)
     expect(r.rows).toEqual([])
   })
 })

--- a/src/core/session-memory-remote.test.ts
+++ b/src/core/session-memory-remote.test.ts
@@ -37,6 +37,36 @@ describe('parseRemoteSessionMemory', () => {
     expect(r.rows).toEqual([])
   })
 
+  // An ssh exec channel is not a clean pipe — a login shell's rc file can write to stdout ahead of
+  // our first marker. Out-of-order markers must fail closed, not produce a confident empty report.
+  // The stream below is a COMPLETE, healthy sweep with one stray `##PROCS` echoed ahead of it by a
+  // login shell's rc file. Every part must stay realistic: the real PROCS tail still parses, so the
+  // empty-table check does NOT catch this, and without the ordering guard the panes slice comes out
+  // empty and the report is a confident `{ok:true, rows:[]}` over a host with live sessions.
+  it('reports ok:false when the markers arrive out of order', () => {
+    const r = parseRemoteSessionMemory(
+      '##PROCS\n' +
+        '##MEM\nMemAvailable: 1024 kB\nMemTotal: 2048 kB\n' +
+        '##PANES\nnt-term-a|100|claude\n' +
+        '##PROCS\n100 1 1024\n200 100 358400\n'
+    )
+    expect(r.ok).toBe(false)
+    expect(r.rows).toEqual([])
+  })
+
+  // A marker string inside DATA is not a marker: only a whole line counts, and only the first one.
+  it('is not confused by a marker appearing inside pane or process data', () => {
+    const r = parseRemoteSessionMemory(
+      '##MEM\nMemAvailable: 1024 kB\nMemTotal: 2048 kB\n' +
+        '##PANES\nnt-term-b|300|##PROCS\n' +
+        '##PROCS\n300 1 1024\n##PANES\n400 1 2048\n'
+    )
+    expect(r.ok).toBe(true)
+    expect(r.mem).toEqual({ availableMb: 1, totalMb: 2 })
+    expect(r.rows).toHaveLength(1)
+    expect(r.rows[0]).toMatchObject({ nodeId: 'term-b', command: '##PROCS', selfMb: 1, totalMb: 1 })
+  })
+
   // Both sockets are swept in ONE stream, and `list-panes -a` prints a line per PANE, so the same
   // session can appear several times. It is still one session, hence one row (the local leg's
   // `bySession` map makes the same promise).
@@ -67,13 +97,17 @@ describe('fetchRemoteSessionMemory', () => {
 describe('remoteSessionMemoryCommand under /bin/sh', () => {
   let dir: string
 
+  // A fake tmux that answers list-panes and nothing else. It reports `$PPID` — the sh running our
+  // generated command — NOT its own `$$`: the fake exits immediately, so a `$$` pid is already dead
+  // by the time `ps` runs and every row would roll up to 0, making a size assertion vacuous.
+  // `$PPID` is alive for the whole sweep, so the row proves the rollup really joined the pane pid
+  // to the host's process table.
+  const FAKE_TMUX =
+    '#!/bin/sh\nfor a in "$@"; do [ "$a" = "list-panes" ] && { echo "nt-term-a|$PPID|claude"; exit 0; }; done\nexit 1\n'
+
   beforeAll(() => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sessmem-'))
-    // A fake tmux on PATH that answers list-panes and nothing else.
-    fs.writeFileSync(
-      path.join(dir, 'tmux'),
-      '#!/bin/sh\nfor a in "$@"; do [ "$a" = "list-panes" ] && { echo "nt-term-a|$$|claude"; exit 0; }; done\nexit 1\n'
-    )
+    fs.writeFileSync(path.join(dir, 'tmux'), FAKE_TMUX)
     fs.chmodSync(path.join(dir, 'tmux'), 0o755)
   })
 
@@ -86,8 +120,29 @@ describe('remoteSessionMemoryCommand under /bin/sh', () => {
     const r = parseRemoteSessionMemory(stdout)
     expect(r.ok).toBe(true)
     expect(r.rows.map((x) => x.nodeId)).toEqual(['term-a'])
-    // The row resolved against the REAL process table, so it has a real size.
-    expect(r.rows[0].totalMb).toBeGreaterThanOrEqual(0)
+    // The pane pid was resolved against the REAL process table: a live shell plus its children.
+    // A 0 here would mean the rollup never found the pid, which is the failure worth catching.
+    expect(r.rows[0].totalMb).toBeGreaterThan(0)
+    expect(r.mem).not.toBeNull()
+  })
+
+  // A host with no /proc/meminfo (the macOS/BSD shape). Deliberately NO free/vm_stat/sysctl
+  // fallback: the sweep still answers with rows, and `mem` is null = "no signal", never a zero.
+  it('still reports rows with mem:null when /proc/meminfo is unreadable', async () => {
+    const noproc = fs.mkdtempSync(path.join(os.tmpdir(), 'sessmem-nomem-'))
+    fs.writeFileSync(path.join(noproc, 'tmux'), FAKE_TMUX)
+    fs.chmodSync(path.join(noproc, 'tmux'), 0o755)
+    // Stub `cat` so reading /proc/meminfo fails the way it does off Linux.
+    fs.writeFileSync(path.join(noproc, 'cat'), '#!/bin/sh\nexit 1\n')
+    fs.chmodSync(path.join(noproc, 'cat'), 0o755)
+    const { stdout } = await run('/bin/sh', ['-c', remoteSessionMemoryCommand()], {
+      env: { ...process.env, PATH: `${noproc}:${process.env.PATH ?? ''}` }
+    })
+    const r = parseRemoteSessionMemory(stdout)
+    expect(r.ok).toBe(true)
+    expect(r.mem).toBeNull()
+    expect(r.rows.map((x) => x.nodeId)).toEqual(['term-a'])
+    fs.rmSync(noproc, { recursive: true, force: true })
   })
 
   it('exits 0 and reports no rows when no tmux server is running', async () => {

--- a/src/core/session-memory-remote.test.ts
+++ b/src/core/session-memory-remote.test.ts
@@ -96,6 +96,19 @@ describe('fetchRemoteSessionMemory', () => {
 // The command is generated shell that no compiler checks. Run it for real.
 describe('remoteSessionMemoryCommand under /bin/sh', () => {
   let dir: string
+  // Every temp dir is registered here and removed in afterAll, so a FAILING assertion cannot leak
+  // one into tmpdir (an inline rmSync after the expects never runs when an expect throws).
+  const temps: string[] = []
+
+  const fakeHost = (prefix: string, files: Record<string, string>): string => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+    temps.push(d)
+    for (const [name, body] of Object.entries(files)) {
+      fs.writeFileSync(path.join(d, name), body)
+      fs.chmodSync(path.join(d, name), 0o755)
+    }
+    return d
+  }
 
   // A fake tmux that answers list-panes and nothing else. It reports `$PPID` — the sh running our
   // generated command — NOT its own `$$`: the fake exits immediately, so a `$$` pid is already dead
@@ -106,12 +119,12 @@ describe('remoteSessionMemoryCommand under /bin/sh', () => {
     '#!/bin/sh\nfor a in "$@"; do [ "$a" = "list-panes" ] && { echo "nt-term-a|$PPID|claude"; exit 0; }; done\nexit 1\n'
 
   beforeAll(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sessmem-'))
-    fs.writeFileSync(path.join(dir, 'tmux'), FAKE_TMUX)
-    fs.chmodSync(path.join(dir, 'tmux'), 0o755)
+    dir = fakeHost('sessmem-', { tmux: FAKE_TMUX })
   })
 
-  afterAll(() => fs.rmSync(dir, { recursive: true, force: true }))
+  afterAll(() => {
+    for (const d of temps) fs.rmSync(d, { recursive: true, force: true })
+  })
 
   it('produces a parseable report on a host with a tmux server', async () => {
     const { stdout } = await run('/bin/sh', ['-c', remoteSessionMemoryCommand()], {
@@ -123,18 +136,31 @@ describe('remoteSessionMemoryCommand under /bin/sh', () => {
     // The pane pid was resolved against the REAL process table: a live shell plus its children.
     // A 0 here would mean the rollup never found the pid, which is the failure worth catching.
     expect(r.rows[0].totalMb).toBeGreaterThan(0)
-    expect(r.mem).not.toBeNull()
+    // Never assert `mem` unconditionally: this repo is maintained from macOS, which has no
+    // /proc/meminfo, so a bare `not.toBeNull()` turns `npm test` red there — and contradicts the
+    // sibling test below, which asserts that exact absence is fine.
+    //
+    // The condition is what the SWEEP produced, not `fs.existsSync('/proc/meminfo')`: the test
+    // process's view of the kernel is not the shell's (a stubbed `cat` breaks the read while
+    // existsSync still says yes). So: IF the host emitted any MemAvailable/MemTotal lines, THEN we
+    // must have understood them. Not tautological — it is the only check that the generated
+    // `grep -E '^(MemAvailable|MemTotal):'` matches the kernel's own text, which the unit tests
+    // cannot catch because they feed that section by hand.
+    const memSection = stdout.slice(stdout.indexOf('##MEM'), stdout.indexOf('##PANES'))
+    if (/Mem(Available|Total):/.test(memSection)) expect(r.mem).not.toBeNull()
   })
 
   // A host with no /proc/meminfo (the macOS/BSD shape). Deliberately NO free/vm_stat/sysctl
   // fallback: the sweep still answers with rows, and `mem` is null = "no signal", never a zero.
+  //
+  // COVERAGE LIMIT: the `cat` stub is what creates that condition on Linux. On a host that has no
+  // /proc/meminfo to begin with (macOS) the stub changes nothing, so there the test observes the
+  // NATIVE shape rather than a simulated one — the end state asserted is identical on both, but
+  // only the Linux run proves the stub-induced failure path. Making it strictly meaningful on
+  // macOS would need a `mem`-producing fallback, which is deliberately not implemented.
   it('still reports rows with mem:null when /proc/meminfo is unreadable', async () => {
-    const noproc = fs.mkdtempSync(path.join(os.tmpdir(), 'sessmem-nomem-'))
-    fs.writeFileSync(path.join(noproc, 'tmux'), FAKE_TMUX)
-    fs.chmodSync(path.join(noproc, 'tmux'), 0o755)
     // Stub `cat` so reading /proc/meminfo fails the way it does off Linux.
-    fs.writeFileSync(path.join(noproc, 'cat'), '#!/bin/sh\nexit 1\n')
-    fs.chmodSync(path.join(noproc, 'cat'), 0o755)
+    const noproc = fakeHost('sessmem-nomem-', { tmux: FAKE_TMUX, cat: '#!/bin/sh\nexit 1\n' })
     const { stdout } = await run('/bin/sh', ['-c', remoteSessionMemoryCommand()], {
       env: { ...process.env, PATH: `${noproc}:${process.env.PATH ?? ''}` }
     })
@@ -142,13 +168,10 @@ describe('remoteSessionMemoryCommand under /bin/sh', () => {
     expect(r.ok).toBe(true)
     expect(r.mem).toBeNull()
     expect(r.rows.map((x) => x.nodeId)).toEqual(['term-a'])
-    fs.rmSync(noproc, { recursive: true, force: true })
   })
 
   it('exits 0 and reports no rows when no tmux server is running', async () => {
-    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'sessmem-notmux-'))
-    fs.writeFileSync(path.join(empty, 'tmux'), '#!/bin/sh\nexit 1\n')
-    fs.chmodSync(path.join(empty, 'tmux'), 0o755)
+    const empty = fakeHost('sessmem-notmux-', { tmux: '#!/bin/sh\nexit 1\n' })
     const { stdout } = await run('/bin/sh', ['-c', remoteSessionMemoryCommand()], {
       env: { ...process.env, PATH: `${empty}:${process.env.PATH ?? ''}` }
     })
@@ -156,6 +179,5 @@ describe('remoteSessionMemoryCommand under /bin/sh', () => {
     // A clean miss is an ANSWER: the sweep ran, the host simply has nothing.
     expect(r.ok).toBe(true)
     expect(r.rows).toEqual([])
-    fs.rmSync(empty, { recursive: true, force: true })
   })
 })

--- a/src/core/session-memory-remote.ts
+++ b/src/core/session-memory-remote.ts
@@ -8,6 +8,7 @@
 
 import {
   buildReport,
+  isNoServerError,
   parsePaneList,
   parseProcessTable,
   PANE_FMT,
@@ -21,6 +22,14 @@ import { RMT_TMUX_SOCKET } from './remote-ssh/control-master'
 const MEM = '##MEM'
 const PANES = '##PANES'
 const PROCS = '##PROCS'
+/** Per-socket fence inside the `##PANES` section: `##SOCK <name>` opens it, `##SOCKRC <n>` closes
+ *  it with that socket's tmux exit status. See `parsePanesSection` for why it exists. */
+const SOCK = '##SOCK'
+const SOCKRC = '##SOCKRC'
+
+/** The sockets the remote sweep lists, in the order it lists them (the local leg's default order —
+ *  `bySession` is first-wins, so the order decides which socket a duplicate name is attributed to). */
+const SWEEP_SOCKETS: readonly string[] = [TMUX_SOCKET, RMT_TMUX_SOCKET]
 
 /**
  * The generated command. Notes that are load-bearing:
@@ -28,8 +37,18 @@ const PROCS = '##PROCS'
  *    short (dead master, killed mid-stream) rather than "the host had nothing".
  *  - The headers are QUOTED. `echo ##MEM` prints an EMPTY LINE: an unquoted `#` at the start of a
  *    word begins a comment in POSIX sh, so the marker is eaten by the shell and every report comes
- *    back `ok:false`. Measured under dash. Do not drop the quotes.
- *  - `tmux ... || true` — a host with no tmux server must exit 0. "No sessions" is an answer.
+ *    back `ok:false`. Measured under dash. Do not drop the quotes. (`"${SOCKRC} $?"` is
+ *    double-quoted for the same reason AND so `$?` still expands.)
+ *  - Each socket gets its OWN fence, and its tmux stderr is folded into the fence (`2>&1`) rather
+ *    than thrown away. This is the remote counterpart of the local leg's `isNoServerError`: the
+ *    exit status alone cannot tell "there is no tmux server on this socket" (an ANSWER, and the
+ *    normal state of a socket nobody has used) from "the tmux client is broken / the socket dir
+ *    belongs to another uid / the server hung" (NOT an answer). The previous form —
+ *    `{ tmux …; tmux …; } || true` with stderr discarded — collapsed both into an empty section,
+ *    so a host running thirty sessions with a broken tmux reported `{ok:true, rows:[]}` and the
+ *    panel said "No sessions are running here."
+ *  - Nothing after a socket's own line can fail the script: `$?` is consumed by the very next
+ *    `echo`, so the command still exits 0 for the shell's exit-code gate.
  *  - The socket names and the `-F` format come from the shared constants, so the remote sweep can
  *    never look at a different socket, or ask for different fields, than the local one.
  *  - `ps -eo pid,ppid,rss` is used even on Linux hosts: it is one process instead of thousands of
@@ -37,12 +56,16 @@ const PROCS = '##PROCS'
  */
 export function remoteSessionMemoryCommand(): string {
   const listPanes = (socket: string): string =>
-    `tmux -L ${socket} list-panes -a -F '${PANE_FMT}' 2>/dev/null`
+    [
+      `echo '${SOCK} ${socket}'`,
+      `tmux -L ${socket} list-panes -a -F '${PANE_FMT}' 2>&1`,
+      `echo "${SOCKRC} $?"`
+    ].join('\n')
   return [
     `echo '${MEM}'`,
     `cat /proc/meminfo 2>/dev/null | grep -E '^(MemAvailable|MemTotal):' 2>/dev/null || true`,
     `echo '${PANES}'`,
-    `{ ${listPanes(TMUX_SOCKET)}; ${listPanes(RMT_TMUX_SOCKET)}; } || true`,
+    ...SWEEP_SOCKETS.map(listPanes),
     `echo '${PROCS}'`,
     `ps -eo pid,ppid,rss 2>/dev/null || true`
   ].join('\n')
@@ -58,6 +81,52 @@ function parseMem(lines: string[]): MemInfo | null {
     if (t) totalMb = Math.round(Number(t[1]) / 1024)
   }
   return availableMb !== null && totalMb !== null ? { availableMb, totalMb } : null
+}
+
+/**
+ * The `##PANES` section, one fenced block per socket. Returns how many sockets ANSWERED and the
+ * panes they reported.
+ *
+ * "Answered" is the same distinction the local leg draws with `isNoServerError`, applied to the
+ * SAME classifier (a second copy would drift — this branch's ledger records three such drifts):
+ *  - exit 0 → the socket answered, and its lines are panes;
+ *  - non-zero with tmux's own "no server running" / "error connecting to … (no such file or
+ *    directory)" → the socket answered "there is nothing here", which is the normal state of a
+ *    socket nobody has used;
+ *  - any other failure (a tmux client missing a shared library exits 127 on EVERY socket, a
+ *    socket dir owned by another uid, a hung server timing out) → NOT an answer.
+ *  - a block with no `##SOCKRC` line at all → the stream was cut mid-socket; NOT an answer.
+ *
+ * The block header is matched against the sockets we actually asked for, and the closer against
+ * `##SOCKRC <digits>`, so neither can be forged by a pane whose session name or foreground command
+ * happens to start with the marker text.
+ */
+function parsePanesSection(lines: readonly string[]): { answered: number; panes: PaneRef[] } {
+  const headers = new Map(SWEEP_SOCKETS.map((s) => [`${SOCK} ${s}`, s]))
+  let answered = 0
+  const panes: PaneRef[] = []
+  let buf: string[] | null = null
+  for (const line of lines) {
+    if (headers.has(line)) {
+      // A new fence with the previous one still open means the previous socket's status never
+      // arrived. It did not answer, and its buffered lines are not trustworthy panes.
+      buf = []
+      continue
+    }
+    const rc = /^##SOCKRC (\d+)$/.exec(line)
+    if (rc && buf !== null) {
+      if (rc[1] === '0') {
+        answered++
+        panes.push(...parsePaneList(buf.join('\n')))
+      } else if (isNoServerError(buf.join('\n'))) {
+        answered++
+      }
+      buf = null
+      continue
+    }
+    if (buf !== null) buf.push(line)
+  }
+  return { answered, panes }
 }
 
 /** Split the fenced sections and reuse the LOCAL assembly, so both legs cannot drift. */
@@ -82,14 +151,20 @@ export function parseRemoteSessionMemory(stdout: string): SessionMemoryReport {
   if (!(iMem < iPanes && iPanes < iProcs)) return { ok: false, rows: [], mem: null }
 
   const mem = parseMem(lines.slice(iMem + 1, iPanes))
-  const panes = parsePaneList(lines.slice(iPanes + 1, iProcs).join('\n'))
+  const { answered, panes } = parsePanesSection(lines.slice(iPanes + 1, iProcs))
   const table = parseProcessTable(lines.slice(iProcs + 1).join('\n'))
   // A host always has processes, so an empty table means `ps` never ran (or its output was lost).
   if (table.length === 0) return { ok: false, rows: [], mem }
+  // Nobody answered: a broken tmux client, a socket dir owned by another uid, a hung server. We did
+  // not look, so we cannot claim the host has nothing — that would print "No sessions are running
+  // here." over thirty live ones. Exactly the local leg's rule (`collectSessionMemory`), and the
+  // reason a blunt "any error ⇒ ok:false" is wrong: on a host with no tmux server at all EVERY
+  // socket fails, and there the honest answer is "there are no sessions".
+  if (answered === 0) return { ok: false, rows: [], mem }
 
-  // Both sockets print into ONE section and `list-panes -a` emits a line per PANE, so a session
-  // can appear several times. First pane of a session wins — one session is one row, exactly as
-  // the local leg's `bySession` map guarantees.
+  // Both sockets print into the SAME section (each behind its own fence) and `list-panes -a` emits
+  // a line per PANE, so a session can appear several times. First pane of a session wins — one
+  // session is one row, exactly as the local leg's `bySession` map guarantees.
   const bySession = new Map<string, PaneRef>()
   for (const p of panes) if (!bySession.has(p.session)) bySession.set(p.session, p)
   return buildReport([...bySession.values()], table, mem)

--- a/src/core/session-memory-remote.ts
+++ b/src/core/session-memory-remote.ts
@@ -1,0 +1,107 @@
+// The SSH leg of session memory: an SSH project's sessions live on the HOST, so the sweep must
+// happen there. Core generates one POSIX sh line, the shell runs it over the project's
+// ControlMaster, and only the printed sections come back — the same division of labour as
+// remote-claude-usage.ts (core owns the command AND the parsing; the shell owns the master).
+//
+// One round trip carries all three facts, because each extra `ssh` exec is a login on someone
+// else's machine.
+
+import {
+  buildReport,
+  parsePaneList,
+  parseProcessTable,
+  PANE_FMT,
+  type MemInfo,
+  type PaneRef,
+  type SessionMemoryReport
+} from './session-memory'
+import { TMUX_SOCKET } from './tmux-naming'
+import { RMT_TMUX_SOCKET } from './remote-ssh/control-master'
+
+const MEM = '##MEM'
+const PANES = '##PANES'
+const PROCS = '##PROCS'
+
+/**
+ * The generated command. Notes that are load-bearing:
+ *  - Every section header is printed unconditionally, so a MISSING one means the read was cut
+ *    short (dead master, killed mid-stream) rather than "the host had nothing".
+ *  - The headers are QUOTED. `echo ##MEM` prints an EMPTY LINE: an unquoted `#` at the start of a
+ *    word begins a comment in POSIX sh, so the marker is eaten by the shell and every report comes
+ *    back `ok:false`. Measured under dash. Do not drop the quotes.
+ *  - `tmux ... || true` — a host with no tmux server must exit 0. "No sessions" is an answer.
+ *  - The socket names and the `-F` format come from the shared constants, so the remote sweep can
+ *    never look at a different socket, or ask for different fields, than the local one.
+ *  - `ps -eo pid,ppid,rss` is used even on Linux hosts: it is one process instead of thousands of
+ *    /proc reads over a link we do not control, and its output is what we already parse.
+ */
+export function remoteSessionMemoryCommand(): string {
+  const listPanes = (socket: string): string =>
+    `tmux -L ${socket} list-panes -a -F '${PANE_FMT}' 2>/dev/null`
+  return [
+    `echo '${MEM}'`,
+    `cat /proc/meminfo 2>/dev/null | grep -E '^(MemAvailable|MemTotal):' || true`,
+    `echo '${PANES}'`,
+    `{ ${listPanes(TMUX_SOCKET)}; ${listPanes(RMT_TMUX_SOCKET)}; } || true`,
+    `echo '${PROCS}'`,
+    `ps -eo pid,ppid,rss 2>/dev/null || true`
+  ].join('\n')
+}
+
+function parseMem(lines: string[]): MemInfo | null {
+  let availableMb: number | null = null
+  let totalMb: number | null = null
+  for (const l of lines) {
+    const a = /MemAvailable:\s+(\d+)\s*kB/.exec(l)
+    if (a) availableMb = Math.round(Number(a[1]) / 1024)
+    const t = /MemTotal:\s+(\d+)\s*kB/.exec(l)
+    if (t) totalMb = Math.round(Number(t[1]) / 1024)
+  }
+  return availableMb !== null && totalMb !== null ? { availableMb, totalMb } : null
+}
+
+/** Split the fenced sections and reuse the LOCAL assembly, so both legs cannot drift. */
+export function parseRemoteSessionMemory(stdout: string): SessionMemoryReport {
+  // Tolerant of a CR-terminated stream (an ssh channel that ended up on a pty): the section
+  // markers are matched whole-line, so a stray \r would hide every one of them.
+  const lines = stdout.split('\n').map((l) => l.replace(/\r$/, ''))
+  const iMem = lines.indexOf(MEM)
+  const iPanes = lines.indexOf(PANES)
+  const iProcs = lines.indexOf(PROCS)
+  // A missing header means the stream was cut short — not evidence that the host has nothing.
+  if (iMem < 0 || iPanes < 0 || iProcs < 0) return { ok: false, rows: [], mem: null }
+
+  const mem = parseMem(lines.slice(iMem + 1, iPanes))
+  const panes = parsePaneList(lines.slice(iPanes + 1, iProcs).join('\n'))
+  const table = parseProcessTable(lines.slice(iProcs + 1).join('\n'))
+  // A host always has processes, so an empty table means `ps` never ran (or its output was lost).
+  if (table.length === 0) return { ok: false, rows: [], mem }
+
+  // Both sockets print into ONE section and `list-panes -a` emits a line per PANE, so a session
+  // can appear several times. First pane of a session wins — one session is one row, exactly as
+  // the local leg's `bySession` map guarantees.
+  const bySession = new Map<string, PaneRef>()
+  for (const p of panes) if (!bySession.has(p.session)) bySession.set(p.session, p)
+  return buildReport([...bySession.values()], table, mem)
+}
+
+/** Runs a POSIX sh command on the project's host; resolves stdout, or null if it could not run. */
+export type RemoteSessionMemoryRunner = (
+  projectId: string,
+  command: string
+) => Promise<string | null>
+
+export async function fetchRemoteSessionMemory(
+  projectId: string,
+  run: RemoteSessionMemoryRunner
+): Promise<SessionMemoryReport> {
+  let stdout: string | null = null
+  try {
+    stdout = await run(projectId, remoteSessionMemoryCommand())
+  } catch {
+    return { ok: false, rows: [], mem: null }
+  }
+  // A dead master says nothing about what the host is running.
+  if (stdout === null) return { ok: false, rows: [], mem: null }
+  return parseRemoteSessionMemory(stdout)
+}

--- a/src/core/session-memory-remote.ts
+++ b/src/core/session-memory-remote.ts
@@ -40,7 +40,7 @@ export function remoteSessionMemoryCommand(): string {
     `tmux -L ${socket} list-panes -a -F '${PANE_FMT}' 2>/dev/null`
   return [
     `echo '${MEM}'`,
-    `cat /proc/meminfo 2>/dev/null | grep -E '^(MemAvailable|MemTotal):' || true`,
+    `cat /proc/meminfo 2>/dev/null | grep -E '^(MemAvailable|MemTotal):' 2>/dev/null || true`,
     `echo '${PANES}'`,
     `{ ${listPanes(TMUX_SOCKET)}; ${listPanes(RMT_TMUX_SOCKET)}; } || true`,
     `echo '${PROCS}'`,
@@ -68,8 +68,18 @@ export function parseRemoteSessionMemory(stdout: string): SessionMemoryReport {
   const iMem = lines.indexOf(MEM)
   const iPanes = lines.indexOf(PANES)
   const iProcs = lines.indexOf(PROCS)
-  // A missing header means the stream was cut short — not evidence that the host has nothing.
+  // Two distinct failures, both of which must read as "we could not look", never as "nothing here":
+  //  - a MISSING header (a `-1`) means the stream was cut short — a master that died mid-read;
+  //  - headers OUT OF ORDER mean the stream is not ours to trust. An ssh exec channel is not a
+  //    clean pipe: a login shell's rc file writing to stdout is a documented hazard in this repo
+  //    (it is why the remote `claude --version` probe goes through a login shell deliberately), so
+  //    a `.profile` that echoes `##PROCS` is enough to put a marker ahead of `##MEM`. Unchecked,
+  //    the panes slice would come out empty while `ps` still parsed from the tail, and the report
+  //    would be a confident `{ok:true, rows:[]}` — "this host has nothing" over live sessions.
+  // The ordering test subsumes the `-1` check (a -1 can never sit below a found index), but both
+  // are spelled out because they are different diagnoses of a broken read.
   if (iMem < 0 || iPanes < 0 || iProcs < 0) return { ok: false, rows: [], mem: null }
+  if (!(iMem < iPanes && iPanes < iProcs)) return { ok: false, rows: [], mem: null }
 
   const mem = parseMem(lines.slice(iMem + 1, iPanes))
   const panes = parsePaneList(lines.slice(iPanes + 1, iProcs).join('\n'))

--- a/src/core/session-memory-service.test.ts
+++ b/src/core/session-memory-service.test.ts
@@ -20,6 +20,19 @@ const host = (q: SessionMemoryQuery): Promise<MemInfo | null> =>
 /** A remote reply the parser accepts: all three markers, in order, with one process row. */
 const OK_REPLY = '##MEM\n##PANES\n##PROCS\n100 1 1024\n'
 
+/** The same, carrying the HOST's RAM — so an answer says positively which machine produced it.
+ *  `totalMb` comes back as `totalKb / 1024`, i.e. 4096 MB for the default. */
+const hostReply = (totalMb = 4096): string =>
+  [
+    '##MEM',
+    `MemAvailable: ${(totalMb / 2) * 1024} kB`,
+    `MemTotal: ${totalMb * 1024} kB`,
+    '##PANES',
+    '##PROCS',
+    '100 1 1024'
+  ].join('\n')
+const HOST_REPLY = hostReply()
+
 beforeEach(() => {
   resetPlatformForTests()
   platform = fakePlatform()
@@ -69,16 +82,17 @@ describe('startSessionMemoryService', () => {
     expect(readMem).not.toHaveBeenCalled()
   })
 
-  it('refuses a remote:true query the shell does not recognise as remote', async () => {
+  it('honours a remote:true query the shell does not recognise as remote', async () => {
     // The two sources disagree — the renderer says SSH, the manager has no such project (not yet
     // connected, or already gone). Trusting the manager here would sweep THIS machine and label
     // the rows as the host's. The claim of remoteness is what decides; only its ANSWER is doubted.
-    // `run` returns a VALID reply, so `ok:false` can no longer be true by accident: it would be
-    // `true` if the read were routed remotely and `true` (locally swept) if it were not — the only
-    // way to get a refusal here is the disagreement being resolved towards the remote host and the
-    // runner reporting it could not look. `readMem` catches a local sweep whatever tmux does.
+    //
+    // `run` returns a VALID reply carrying the HOST's RAM, so the result says positively which
+    // machine answered: 4096 MB total can only have come from the remote reply, and the injected
+    // local reader (22 MB) is never consulted. An `ok:false` assertion would have been decorative
+    // here — with a stub that reports "could not look", a refusal proves nothing about routing.
     const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
-    const run = vi.fn(async () => null)
+    const run = vi.fn(async () => HOST_REPLY)
     startSessionMemoryService({
       tmuxBin: () => '/usr/bin/tmux',
       readMem,
@@ -86,8 +100,29 @@ describe('startSessionMemoryService', () => {
     })
     const r = await read({ projectId: 'ssh1', remote: true })
     expect(run).toHaveBeenCalledOnce()
-    expect(r).toEqual({ ok: false, rows: [], mem: null })
+    expect(r.ok).toBe(true)
+    expect(r.mem).toEqual({ availableMb: 2048, totalMb: 4096 })
     expect(readMem).not.toHaveBeenCalled()
+  })
+
+  it('refuses an SSH scope when the shell knows it is remote but cannot read it', async () => {
+    // The SERVER EDITION's shape: `isRemoteProject` (it has the workspace index) and NO `run` (no
+    // ControlMaster). Booting with neither — as the server did before this round — let an SSH query
+    // WITHOUT the renderer's flag fall through to the local sweep and publish this machine's
+    // sessions under the remote host's name.
+    const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
+    startSessionMemoryService({
+      tmuxBin: () => '/usr/bin/tmux',
+      readMem,
+      remote: { isRemoteProject: (id) => id === 'ssh1' }
+    })
+    // No `remote: true` flag: the shell's knowledge is the only thing routing this.
+    expect(await read({ projectId: 'ssh1' })).toEqual({ ok: false, rows: [], mem: null })
+    expect(await host({ projectId: 'ssh1' })).toBeNull()
+    expect(readMem).not.toHaveBeenCalled()
+    // …while a local project on the same shell is still swept normally.
+    await read({ projectId: 'local1' })
+    expect(readMem).toHaveBeenCalled()
   })
 
   it('treats a DISCONNECTED ssh project as remote (identity, not liveness)', async () => {
@@ -123,6 +158,14 @@ describe('startSessionMemoryService', () => {
     expect(isRemoteProject('ssh2')).toBe(true)
   })
 
+  it('works with the index alone — the no-manager shape the Server Edition uses', async () => {
+    // `connectedProjectIds` is optional, and the shell that omits it is a production path (the
+    // Server Edition has a workspace index and no SSH-project manager), not a hypothetical.
+    const isRemoteProject = sshScopePredicate({ sshProjectIds: () => ['ssh1'] })
+    expect(isRemoteProject('ssh1')).toBe(true)
+    expect(isRemoteProject('local1')).toBe(false)
+  })
+
   it('coalesces the two channels onto ONE remote round trip', async () => {
     // A remote read is a whole-process-table `ps` on somebody else's machine, and the panel wants
     // both the rows and the RAM number. Firing them concurrently must not cost two ssh execs.
@@ -147,6 +190,32 @@ describe('startSessionMemoryService', () => {
     // Not a cache: once settled, the next read runs again.
     await read({ projectId: 'ssh1' })
     expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces PER PROJECT — two hosts in flight never share a report', async () => {
+    // The coalescer is the one place in this service that can hand one scope's report to another
+    // host's caller, and the only thing preventing it is the key. A single-project test cannot see
+    // that: two concurrent reads for DIFFERENT hosts must stay two round trips with two answers.
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((res) => {
+      release = res
+    })
+    // Each host reports its own RAM, so the two answers are distinguishable by content, not just
+    // by call count — a shared key would give one caller the other machine's numbers.
+    const run = vi.fn(async (projectId: string) => {
+      await gate
+      return hostReply(projectId === 'ssh1' ? 4096 : 8192)
+    })
+    startSessionMemoryService({
+      tmuxBin: () => '/usr/bin/tmux',
+      remote: { run, isRemoteProject: () => true }
+    })
+    const both = Promise.all([read({ projectId: 'ssh1' }), read({ projectId: 'ssh2' })])
+    release?.()
+    const [a, b] = await both
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(a.mem?.totalMb).toBe(4096)
+    expect(b.mem?.totalMb).toBe(8192)
   })
 
   it('never runs the local sweep for a remote scope with no projectId', async () => {

--- a/src/core/session-memory-service.test.ts
+++ b/src/core/session-memory-service.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { IPC } from '../shared/ipc'
 import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform, type FakePlatform } from './platform-fake'
-import { startSessionMemoryService } from './session-memory-service'
+import { startSessionMemoryService, sshScopePredicate } from './session-memory-service'
 import type { MemInfo, SessionMemoryReport, SessionMemoryQuery } from '../shared/types'
 
 // The repo's own platform fake (src/core/platform-fake.ts) — a plain recording object whose
@@ -73,15 +73,80 @@ describe('startSessionMemoryService', () => {
     // The two sources disagree — the renderer says SSH, the manager has no such project (not yet
     // connected, or already gone). Trusting the manager here would sweep THIS machine and label
     // the rows as the host's. The claim of remoteness is what decides; only its ANSWER is doubted.
+    // `run` returns a VALID reply, so `ok:false` can no longer be true by accident: it would be
+    // `true` if the read were routed remotely and `true` (locally swept) if it were not — the only
+    // way to get a refusal here is the disagreement being resolved towards the remote host and the
+    // runner reporting it could not look. `readMem` catches a local sweep whatever tmux does.
+    const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
     const run = vi.fn(async () => null)
     startSessionMemoryService({
       tmuxBin: () => '/usr/bin/tmux',
+      readMem,
       remote: { run, isRemoteProject: () => false }
     })
     const r = await read({ projectId: 'ssh1', remote: true })
     expect(run).toHaveBeenCalledOnce()
-    expect(r.ok).toBe(false)
-    expect(r.rows).toEqual([])
+    expect(r).toEqual({ ok: false, rows: [], mem: null })
+    expect(readMem).not.toHaveBeenCalled()
+  })
+
+  it('treats a DISCONNECTED ssh project as remote (identity, not liveness)', async () => {
+    // The desktop's `isRemoteProject`. `connectedHosts()` answers "is the master up right now",
+    // which is false for a project that is reconnecting, just dropped, or not opened yet — and a
+    // "no" there used to mean the LOCAL sweep answered under the remote host's name. The workspace
+    // index is the connection-independent source, so an SSH project counts while offline.
+    const isRemoteProject = sshScopePredicate({
+      sshProjectIds: () => ['ssh1'],
+      connectedProjectIds: () => [] // nothing connected: every master is down
+    })
+    expect(isRemoteProject('ssh1')).toBe(true)
+    expect(isRemoteProject('local1')).toBe(false)
+
+    // And end-to-end through the service, with the renderer's flag ABSENT — the shell's answer is
+    // the only thing standing between this query and a local sweep (the renderer flag is Task 5/7).
+    const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
+    const run = vi.fn(async () => null)
+    startSessionMemoryService({ tmuxBin: () => '/usr/bin/tmux', readMem, remote: { run, isRemoteProject } })
+    const r = await read({ projectId: 'ssh1' })
+    expect(run).toHaveBeenCalledOnce()
+    expect(r).toEqual({ ok: false, rows: [], mem: null })
+    expect(readMem).not.toHaveBeenCalled()
+  })
+
+  it('counts a connected project the index has not listed', async () => {
+    // The other direction: an index that has not loaded (or an entry added by another machine)
+    // must not make a project with a LIVE master read as local. Neither source can veto the other.
+    const isRemoteProject = sshScopePredicate({
+      sshProjectIds: () => [],
+      connectedProjectIds: () => ['ssh2']
+    })
+    expect(isRemoteProject('ssh2')).toBe(true)
+  })
+
+  it('coalesces the two channels onto ONE remote round trip', async () => {
+    // A remote read is a whole-process-table `ps` on somebody else's machine, and the panel wants
+    // both the rows and the RAM number. Firing them concurrently must not cost two ssh execs.
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((res) => {
+      release = res
+    })
+    const run = vi.fn(async () => {
+      await gate
+      return OK_REPLY
+    })
+    startSessionMemoryService({
+      tmuxBin: () => '/usr/bin/tmux',
+      remote: { run, isRemoteProject: () => true }
+    })
+    const both = Promise.all([read({ projectId: 'ssh1' }), host({ projectId: 'ssh1' })])
+    release?.()
+    const [report] = await both
+    expect(run).toHaveBeenCalledOnce()
+    expect(report.ok).toBe(true)
+
+    // Not a cache: once settled, the next read runs again.
+    await read({ projectId: 'ssh1' })
+    expect(run).toHaveBeenCalledTimes(2)
   })
 
   it('never runs the local sweep for a remote scope with no projectId', async () => {

--- a/src/core/session-memory-service.test.ts
+++ b/src/core/session-memory-service.test.ts
@@ -110,9 +110,12 @@ describe('startSessionMemoryService', () => {
     // ControlMaster). Booting with neither — as the server did before this round — let an SSH query
     // WITHOUT the renderer's flag fall through to the local sweep and publish this machine's
     // sessions under the remote host's name.
+    // `tmuxBin: () => null`, like the other local-routing test: a unit test must not shell out, and
+    // the local leg below only needs to be DISTINGUISHABLE from the refusal, not successful.
+    // (`collectSessionMemory` reads memory before it looks at tmux, so `readMem` still fires.)
     const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
     startSessionMemoryService({
-      tmuxBin: () => '/usr/bin/tmux',
+      tmuxBin: () => null,
       readMem,
       remote: { isRemoteProject: (id) => id === 'ssh1' }
     })

--- a/src/core/session-memory-service.test.ts
+++ b/src/core/session-memory-service.test.ts
@@ -1,0 +1,127 @@
+// What the RPC surface DECIDES: which machine a query is answered from. The sweeps themselves are
+// covered by session-memory.test.ts / session-memory-remote.test.ts — here the only question is
+// routing, and the only dangerous answer is attributing one host's memory to another.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { IPC } from '../shared/ipc'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { startSessionMemoryService } from './session-memory-service'
+import type { MemInfo, SessionMemoryReport, SessionMemoryQuery } from '../shared/types'
+
+// The repo's own platform fake (src/core/platform-fake.ts) — a plain recording object whose
+// `handlers` map holds whatever the service registered. Same setup as usage-service.remote.test.ts.
+let platform: FakePlatform
+
+const read = (q: SessionMemoryQuery): Promise<SessionMemoryReport> =>
+  platform.handlers[IPC.sessionMemory](q) as Promise<SessionMemoryReport>
+const host = (q: SessionMemoryQuery): Promise<MemInfo | null> =>
+  platform.handlers[IPC.sessionMemoryHost](q) as Promise<MemInfo | null>
+
+/** A remote reply the parser accepts: all three markers, in order, with one process row. */
+const OK_REPLY = '##MEM\n##PANES\n##PROCS\n100 1 1024\n'
+
+beforeEach(() => {
+  resetPlatformForTests()
+  platform = fakePlatform()
+  initPlatform(platform)
+})
+
+afterEach(() => resetPlatformForTests())
+
+describe('startSessionMemoryService', () => {
+  it('routes a LOCAL project to the local sweep', async () => {
+    const run = vi.fn()
+    startSessionMemoryService({
+      // The local sweep short-circuits to ok:false with no tmux binary, which is enough to prove
+      // routing without touching the host's real tmux.
+      tmuxBin: () => null,
+      remote: { run, isRemoteProject: () => false }
+    })
+    const r = await read({ projectId: 'p1' })
+    expect(run).not.toHaveBeenCalled()
+    expect(r.ok).toBe(false)
+  })
+
+  it('routes an SSH project to the remote runner', async () => {
+    const run = vi.fn(async () => OK_REPLY)
+    startSessionMemoryService({
+      tmuxBin: () => '/usr/bin/tmux',
+      remote: { run, isRemoteProject: (id) => id === 'ssh1' }
+    })
+    const r = await read({ projectId: 'ssh1' })
+    expect(run).toHaveBeenCalledOnce()
+    expect(r.ok).toBe(true)
+  })
+
+  it('answers ok:false for an SSH project when no remote deps were injected', async () => {
+    // The Server Edition case: no ControlMaster to run on. It must not silently answer with the
+    // LOCAL machine's sessions, which belong to a different host entirely.
+    //
+    // `readMem` is the mutation detector: a local sweep always reads it, a refusal never does. The
+    // ok/rows assertions alone would survive the guard's deletion on a host whose tmux happens to
+    // be missing (every socket errors ⇒ ok:false either way) — a green test proving nothing.
+    const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
+    startSessionMemoryService({ tmuxBin: () => '/usr/bin/tmux', readMem })
+    const r = await read({ projectId: 'ssh1', remote: true })
+    expect(r.ok).toBe(false)
+    expect(r.rows).toEqual([])
+    expect(r.mem).toBeNull()
+    expect(readMem).not.toHaveBeenCalled()
+  })
+
+  it('refuses a remote:true query the shell does not recognise as remote', async () => {
+    // The two sources disagree — the renderer says SSH, the manager has no such project (not yet
+    // connected, or already gone). Trusting the manager here would sweep THIS machine and label
+    // the rows as the host's. The claim of remoteness is what decides; only its ANSWER is doubted.
+    const run = vi.fn(async () => null)
+    startSessionMemoryService({
+      tmuxBin: () => '/usr/bin/tmux',
+      remote: { run, isRemoteProject: () => false }
+    })
+    const r = await read({ projectId: 'ssh1', remote: true })
+    expect(run).toHaveBeenCalledOnce()
+    expect(r.ok).toBe(false)
+    expect(r.rows).toEqual([])
+  })
+
+  it('never runs the local sweep for a remote scope with no projectId', async () => {
+    // `remote: true` with nothing to run against is still not an invitation to read this machine.
+    const readMem = vi.fn(() => ({ availableMb: 1, totalMb: 2 }))
+    const run = vi.fn()
+    startSessionMemoryService({
+      tmuxBin: () => '/usr/bin/tmux',
+      readMem,
+      remote: { run, isRemoteProject: () => true }
+    })
+    const r = await read({ remote: true })
+    expect(run).not.toHaveBeenCalled()
+    expect(r).toEqual({ ok: false, rows: [], mem: null })
+    // Not even the local RAM number: it describes the wrong machine.
+    expect(readMem).not.toHaveBeenCalled()
+  })
+
+  it('reads the local RAM for a local scope and the host RAM for a remote one', async () => {
+    const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
+    const run = vi.fn(async () => ['##MEM', 'MemAvailable: 2097152 kB', 'MemTotal: 4194304 kB', '##PANES', '##PROCS', '100 1 1024'].join('\n'))
+    startSessionMemoryService({
+      tmuxBin: () => '/usr/bin/tmux',
+      readMem,
+      remote: { run, isRemoteProject: (id) => id === 'ssh1' }
+    })
+    expect(await host({ projectId: 'p1' })).toEqual({ availableMb: 11, totalMb: 22 })
+    expect(await host({ projectId: 'ssh1' })).toEqual({ availableMb: 2048, totalMb: 4096 })
+  })
+
+  it('answers a null host RAM for an SSH scope with no remote deps', async () => {
+    const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
+    startSessionMemoryService({ tmuxBin: () => '/usr/bin/tmux', readMem })
+    expect(await host({ projectId: 'ssh1', remote: true })).toBeNull()
+    expect(readMem).not.toHaveBeenCalled()
+  })
+
+  it('tolerates a query-less call (a bare read is this machine)', async () => {
+    startSessionMemoryService({ tmuxBin: () => null })
+    const r = await (platform.handlers[IPC.sessionMemory]() as Promise<SessionMemoryReport>)
+    expect(r.ok).toBe(false)
+  })
+})

--- a/src/core/session-memory-service.test.ts
+++ b/src/core/session-memory-service.test.ts
@@ -17,8 +17,14 @@ const read = (q: SessionMemoryQuery): Promise<SessionMemoryReport> =>
 const host = (q: SessionMemoryQuery): Promise<MemInfo | null> =>
   platform.handlers[IPC.sessionMemoryHost](q) as Promise<MemInfo | null>
 
-/** A remote reply the parser accepts: all three markers, in order, with one process row. */
-const OK_REPLY = '##MEM\n##PANES\n##PROCS\n100 1 1024\n'
+/** One socket answering "no server running" — the per-socket fence the sweep now emits. A `##PANES`
+ *  section with NO fence in it means no socket answered, which is `ok:false` by design (see
+ *  session-memory-remote.ts): "every tmux call failed" must not render as "this host has nothing". */
+const IDLE_SOCKET = '##SOCK node-terminal\nno server running on /tmp/x\n##SOCKRC 1\n'
+
+/** A remote reply the parser accepts: all three markers, in order, one answered socket, one
+ *  process row. */
+const OK_REPLY = `##MEM\n##PANES\n${IDLE_SOCKET}##PROCS\n100 1 1024\n`
 
 /** The same, carrying the HOST's RAM — so an answer says positively which machine produced it.
  *  `totalMb` comes back as `totalKb / 1024`, i.e. 4096 MB for the default. */
@@ -28,6 +34,7 @@ const hostReply = (totalMb = 4096): string =>
     `MemAvailable: ${(totalMb / 2) * 1024} kB`,
     `MemTotal: ${totalMb * 1024} kB`,
     '##PANES',
+    IDLE_SOCKET.trimEnd(),
     '##PROCS',
     '100 1 1024'
   ].join('\n')
@@ -239,7 +246,9 @@ describe('startSessionMemoryService', () => {
 
   it('reads the local RAM for a local scope and the host RAM for a remote one', async () => {
     const readMem = vi.fn(() => ({ availableMb: 11, totalMb: 22 }))
-    const run = vi.fn(async () => ['##MEM', 'MemAvailable: 2097152 kB', 'MemTotal: 4194304 kB', '##PANES', '##PROCS', '100 1 1024'].join('\n'))
+    const run = vi.fn(async () =>
+      ['##MEM', 'MemAvailable: 2097152 kB', 'MemTotal: 4194304 kB', '##PANES', IDLE_SOCKET.trimEnd(), '##PROCS', '100 1 1024'].join('\n')
+    )
     startSessionMemoryService({
       tmuxBin: () => '/usr/bin/tmux',
       readMem,

--- a/src/core/session-memory-service.ts
+++ b/src/core/session-memory-service.ts
@@ -22,21 +22,66 @@ export interface SessionMemoryServiceOptions {
   }
 }
 
-const EMPTY = (mem: MemInfo | null): SessionMemoryReport => ({ ok: false, rows: [], mem })
+/** The facts a shell can offer about which projects are somebody else's machine. */
+export interface SshScopeSources {
+  /** Every project the workspace index calls an SSH project — the IDENTITY question. */
+  sshProjectIds: () => string[]
+  /** Projects whose ControlMaster is up right now — a LIVENESS question, and only a supplement. */
+  connectedProjectIds?: () => string[]
+}
+
+/**
+ * Build the shell's `isRemoteProject`. This must answer "is this project someone else's machine?",
+ * which is a property of the PROJECT, not of its connection: a disconnected SSH project is still a
+ * remote scope. Asking `connectedHosts()` alone votes "local" for a project that is reconnecting,
+ * just dropped, or not connected yet — precisely the window the refusal below exists for, and the
+ * one where a local sweep would be published under the remote host's name.
+ *
+ * Connectedness is still OR-ed in as a second source: a project the index has not (yet) listed —
+ * a stale/unloaded index, an entry added by another machine — but which has a live master is
+ * unambiguously remote too. Neither source can veto the other; either one alone is enough.
+ *
+ * Both getters are called per query (projects connect and disconnect under us) and must not throw.
+ */
+export function sshScopePredicate(sources: SshScopeSources): (projectId: string) => boolean {
+  return (projectId: string): boolean =>
+    sources.sshProjectIds().includes(projectId) ||
+    (sources.connectedProjectIds?.() ?? []).includes(projectId)
+}
+
+const EMPTY = (): SessionMemoryReport => ({ ok: false, rows: [], mem: null })
 
 export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { dispose(): void } {
   /**
    * Two independent sources say "this scope is remote", and EITHER is enough:
    *  - the renderer's own `remote` flag (it already knows from `usageScope` which project is an
    *    SSH one), and
-   *  - the shell's project manager.
-   * They are OR-ed, not AND-ed, on purpose. A manager that has not (yet) registered a project as
-   * connected — reconnecting, just dropped — would otherwise turn a remote query into a LOCAL
-   * sweep, and the panel would label this machine's sessions as the host's. A claim of remoteness
-   * is trusted; only its answer can fail.
+   *  - the shell's `isRemoteProject` (see `sshScopePredicate`).
+   * They are OR-ed, not AND-ed, on purpose. A source that answers "no" because it is momentarily
+   * uninformed — an index not loaded, a master that just dropped — would otherwise turn a remote
+   * query into a LOCAL sweep, and the panel would label this machine's sessions as the host's. A
+   * claim of remoteness is trusted; only its ANSWER can fail.
    */
   const isRemote = (q: SessionMemoryQuery): boolean =>
     q.remote === true || (!!q.projectId && !!opts.remote?.isRemoteProject(q.projectId))
+
+  /**
+   * One in-flight remote read per project, shared by both channels. A remote read is a `ps` of the
+   * whole process table on somebody else's machine, and the panel legitimately wants both the RAM
+   * number and the rows — which is two identical execs back to back unless they are coalesced.
+   * Keyed by projectId (the only thing the command depends on) and cleared on settle, so this is a
+   * concurrency guard, never a cache: a later read always re-runs.
+   */
+  const inFlight = new Map<string, Promise<SessionMemoryReport>>()
+  const readRemote = (projectId: string, run: RemoteSessionMemoryRunner): Promise<SessionMemoryReport> => {
+    const pending = inFlight.get(projectId)
+    if (pending) return pending
+    const p = fetchRemoteSessionMemory(projectId, run).finally(() => {
+      inFlight.delete(projectId)
+    })
+    inFlight.set(projectId, p)
+    return p
+  }
 
   platform().handle(
     IPC.sessionMemory,
@@ -45,8 +90,8 @@ export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { 
         // No ControlMaster injected (Server Edition), or nothing to run against: answering with
         // the LOCAL machine's sessions would attribute one host's memory to another. Refuse — and
         // with a null `mem` too, since even the RAM number would describe the wrong machine.
-        if (!opts.remote || !q.projectId) return EMPTY(null)
-        return fetchRemoteSessionMemory(q.projectId, opts.remote.run)
+        if (!opts.remote || !q.projectId) return EMPTY()
+        return readRemote(q.projectId, opts.remote.run)
       }
       return collectSessionMemory({ tmuxBin: opts.tmuxBin, readMem: opts.readMem })
     }
@@ -58,11 +103,12 @@ export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { 
       if (!isRemote(q)) return (opts.readMem ?? readMemInfo)()
       if (!opts.remote || !q.projectId) return null
       // One round trip serves both numbers; the pill uses only `mem`.
-      return (await fetchRemoteSessionMemory(q.projectId, opts.remote.run)).mem
+      return (await readRemote(q.projectId, opts.remote.run)).mem
     }
   )
 
-  // Nothing to tear down: both handlers are pull-only, with no timer and no cache. `dispose` exists
-  // so a shell can treat this like the other services it starts.
+  // Nothing to tear down: both handlers are pull-only, with no timer and no cache (`inFlight` holds
+  // only unsettled promises). `dispose` exists so a shell can treat this like the other services it
+  // starts.
   return { dispose: (): void => {} }
 }

--- a/src/core/session-memory-service.ts
+++ b/src/core/session-memory-service.ts
@@ -1,0 +1,68 @@
+// RPC surface for session memory. Registered by BOTH shells (src/main and src/server) exactly as
+// the usage service is: core owns the reading and the parsing, the shell injects the ControlMaster.
+//
+// The one decision made here is WHICH MACHINE answers. Everything else is delegated:
+// `collectSessionMemory` for this host, `fetchRemoteSessionMemory` for an SSH project's host.
+
+import { IPC } from '../shared/ipc'
+import { platform } from './platform'
+import type { MemInfo, SessionMemoryQuery, SessionMemoryReport } from '../shared/types'
+import { collectSessionMemory, readMemInfo } from './session-memory'
+import { fetchRemoteSessionMemory, type RemoteSessionMemoryRunner } from './session-memory-remote'
+
+export interface SessionMemoryServiceOptions {
+  /** Lazy tmux resolver (PtyManager resolves after init; null = tmux unavailable). */
+  tmuxBin: () => string | null
+  /** Host RAM reader, injectable for tests. Defaults to the real `/proc/meminfo` read. */
+  readMem?: () => MemInfo | null
+  /** Absent ⇒ SSH scopes answer `ok:false` — see the handler. */
+  remote?: {
+    run: RemoteSessionMemoryRunner
+    isRemoteProject: (projectId: string) => boolean
+  }
+}
+
+const EMPTY = (mem: MemInfo | null): SessionMemoryReport => ({ ok: false, rows: [], mem })
+
+export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { dispose(): void } {
+  /**
+   * Two independent sources say "this scope is remote", and EITHER is enough:
+   *  - the renderer's own `remote` flag (it already knows from `usageScope` which project is an
+   *    SSH one), and
+   *  - the shell's project manager.
+   * They are OR-ed, not AND-ed, on purpose. A manager that has not (yet) registered a project as
+   * connected — reconnecting, just dropped — would otherwise turn a remote query into a LOCAL
+   * sweep, and the panel would label this machine's sessions as the host's. A claim of remoteness
+   * is trusted; only its answer can fail.
+   */
+  const isRemote = (q: SessionMemoryQuery): boolean =>
+    q.remote === true || (!!q.projectId && !!opts.remote?.isRemoteProject(q.projectId))
+
+  platform().handle(
+    IPC.sessionMemory,
+    async (q: SessionMemoryQuery = {}): Promise<SessionMemoryReport> => {
+      if (isRemote(q)) {
+        // No ControlMaster injected (Server Edition), or nothing to run against: answering with
+        // the LOCAL machine's sessions would attribute one host's memory to another. Refuse — and
+        // with a null `mem` too, since even the RAM number would describe the wrong machine.
+        if (!opts.remote || !q.projectId) return EMPTY(null)
+        return fetchRemoteSessionMemory(q.projectId, opts.remote.run)
+      }
+      return collectSessionMemory({ tmuxBin: opts.tmuxBin, readMem: opts.readMem })
+    }
+  )
+
+  platform().handle(
+    IPC.sessionMemoryHost,
+    async (q: SessionMemoryQuery = {}): Promise<MemInfo | null> => {
+      if (!isRemote(q)) return (opts.readMem ?? readMemInfo)()
+      if (!opts.remote || !q.projectId) return null
+      // One round trip serves both numbers; the pill uses only `mem`.
+      return (await fetchRemoteSessionMemory(q.projectId, opts.remote.run)).mem
+    }
+  )
+
+  // Nothing to tear down: both handlers are pull-only, with no timer and no cache. `dispose` exists
+  // so a shell can treat this like the other services it starts.
+  return { dispose: (): void => {} }
+}

--- a/src/core/session-memory-service.ts
+++ b/src/core/session-memory-service.ts
@@ -16,16 +16,21 @@ export interface SessionMemoryServiceOptions {
   /** Host RAM reader, injectable for tests. Defaults to the real `/proc/meminfo` read. */
   readMem?: () => MemInfo | null
   /**
-   * The two remote facts, INDEPENDENTLY optional — a shell can know which projects are somebody
-   * else's machine without being able to read them:
-   *  - `isRemoteProject` absent ⇒ only the renderer's `remote` flag marks a scope as remote;
-   *  - `run` absent ⇒ a remote scope is REFUSED (`ok:false`), never swept locally.
-   * The Server Edition supplies the first and not the second: it has the workspace index, so it
-   * KNOWS a project is an SSH one, and it has no ControlMaster, so it cannot answer for that host.
+   * The two remote facts, in a deliberately ASYMMETRIC pair: knowing which projects are somebody
+   * else's machine is required, being able to read them is not.
+   *  - `run` absent ⇒ a remote scope is REFUSED (`ok:false`), never swept locally. This is the
+   *    Server Edition: it has the workspace index, so it KNOWS a project is an SSH one, and it has
+   *    no ControlMaster, so it cannot answer for that host. Knowing-without-reading is coherent.
+   *  - `isRemoteProject` is NOT optional, because reading-without-knowing is not coherent: a shell
+   *    that can run the command but cannot say which projects need it would route every UNFLAGGED
+   *    SSH query to the LOCAL sweep — the misattribution this whole surface exists to prevent. It
+   *    stays type-illegal rather than merely discouraged.
+   * Omit `remote` entirely and only the renderer's `remote` flag marks a scope as remote — which
+   * is why no shell should do that (both ship an `isRemoteProject`).
    */
   remote?: {
     run?: RemoteSessionMemoryRunner
-    isRemoteProject?: (projectId: string) => boolean
+    isRemoteProject: (projectId: string) => boolean
   }
 }
 
@@ -70,20 +75,19 @@ export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { 
    * claim of remoteness is trusted; only its ANSWER can fail.
    */
   const isRemote = (q: SessionMemoryQuery): boolean =>
-    q.remote === true || (!!q.projectId && !!opts.remote?.isRemoteProject?.(q.projectId))
+    q.remote === true || (!!q.projectId && !!opts.remote?.isRemoteProject(q.projectId))
 
   /**
    * One in-flight remote read per project, shared by both channels. A remote read is a `ps` of the
    * whole process table on somebody else's machine, and the panel legitimately wants both the RAM
    * number and the rows — which is two identical execs back to back unless they are coalesced.
-   * Keyed by projectId (the only thing the command depends on) and cleared on settle, so this is a
-   * concurrency guard, never a cache: a later read always re-runs.
+   * Cleared on settle, so this is a concurrency guard, never a cache: a later read always re-runs.
+   *
+   * The key is the projectId and NOTHING else, because that is the only thing deciding which host
+   * the command lands on. A key shared across projects would hand one host's report to another
+   * host's caller — the same misattribution the refusal below exists to prevent, arriving by a
+   * different door, and invisible to any test that uses a single project.
    */
-  //
-  // The key is the projectId and nothing else: it is the ONLY thing that decides which host the
-  // command lands on, so a shared key across projects would hand one host's report to another
-  // host's caller — the same misattribution the refusal above exists to prevent, arriving by a
-  // different door.
   const inFlight = new Map<string, Promise<SessionMemoryReport>>()
   const readRemote = (projectId: string, run: RemoteSessionMemoryRunner): Promise<SessionMemoryReport> => {
     const pending = inFlight.get(projectId)

--- a/src/core/session-memory-service.ts
+++ b/src/core/session-memory-service.ts
@@ -15,10 +15,17 @@ export interface SessionMemoryServiceOptions {
   tmuxBin: () => string | null
   /** Host RAM reader, injectable for tests. Defaults to the real `/proc/meminfo` read. */
   readMem?: () => MemInfo | null
-  /** Absent ⇒ SSH scopes answer `ok:false` — see the handler. */
+  /**
+   * The two remote facts, INDEPENDENTLY optional — a shell can know which projects are somebody
+   * else's machine without being able to read them:
+   *  - `isRemoteProject` absent ⇒ only the renderer's `remote` flag marks a scope as remote;
+   *  - `run` absent ⇒ a remote scope is REFUSED (`ok:false`), never swept locally.
+   * The Server Edition supplies the first and not the second: it has the workspace index, so it
+   * KNOWS a project is an SSH one, and it has no ControlMaster, so it cannot answer for that host.
+   */
   remote?: {
-    run: RemoteSessionMemoryRunner
-    isRemoteProject: (projectId: string) => boolean
+    run?: RemoteSessionMemoryRunner
+    isRemoteProject?: (projectId: string) => boolean
   }
 }
 
@@ -63,7 +70,7 @@ export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { 
    * claim of remoteness is trusted; only its ANSWER can fail.
    */
   const isRemote = (q: SessionMemoryQuery): boolean =>
-    q.remote === true || (!!q.projectId && !!opts.remote?.isRemoteProject(q.projectId))
+    q.remote === true || (!!q.projectId && !!opts.remote?.isRemoteProject?.(q.projectId))
 
   /**
    * One in-flight remote read per project, shared by both channels. A remote read is a `ps` of the
@@ -72,6 +79,11 @@ export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { 
    * Keyed by projectId (the only thing the command depends on) and cleared on settle, so this is a
    * concurrency guard, never a cache: a later read always re-runs.
    */
+  //
+  // The key is the projectId and nothing else: it is the ONLY thing that decides which host the
+  // command lands on, so a shared key across projects would hand one host's report to another
+  // host's caller — the same misattribution the refusal above exists to prevent, arriving by a
+  // different door.
   const inFlight = new Map<string, Promise<SessionMemoryReport>>()
   const readRemote = (projectId: string, run: RemoteSessionMemoryRunner): Promise<SessionMemoryReport> => {
     const pending = inFlight.get(projectId)
@@ -90,8 +102,9 @@ export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { 
         // No ControlMaster injected (Server Edition), or nothing to run against: answering with
         // the LOCAL machine's sessions would attribute one host's memory to another. Refuse — and
         // with a null `mem` too, since even the RAM number would describe the wrong machine.
-        if (!opts.remote || !q.projectId) return EMPTY()
-        return readRemote(q.projectId, opts.remote.run)
+        const run = opts.remote?.run
+        if (!run || !q.projectId) return EMPTY()
+        return readRemote(q.projectId, run)
       }
       return collectSessionMemory({ tmuxBin: opts.tmuxBin, readMem: opts.readMem })
     }
@@ -101,9 +114,10 @@ export function startSessionMemoryService(opts: SessionMemoryServiceOptions): { 
     IPC.sessionMemoryHost,
     async (q: SessionMemoryQuery = {}): Promise<MemInfo | null> => {
       if (!isRemote(q)) return (opts.readMem ?? readMemInfo)()
-      if (!opts.remote || !q.projectId) return null
+      const run = opts.remote?.run
+      if (!run || !q.projectId) return null
       // One round trip serves both numbers; the pill uses only `mem`.
-      return (await readRemote(q.projectId, opts.remote.run)).mem
+      return (await readRemote(q.projectId, run)).mem
     }
   )
 

--- a/src/core/session-memory.test.ts
+++ b/src/core/session-memory.test.ts
@@ -236,3 +236,59 @@ describe('collectSessionMemory', () => {
     }
   })
 })
+
+import { parseVmStat } from './session-memory'
+
+/** Shaped from Apple's documented `vm_stat` format, at a 16 KiB page (Apple Silicon). COMPOSED, not
+ *  captured — nobody in this loop has a Mac. Numbers chosen so the arithmetic is checkable by hand:
+ *  anonymous 800k - purgeable 50k + wired 150k + compressor 100k = 1,000,000 pages.
+ *  1,000,000 x 16384 B = 15625 MiB used of a 24576 MiB machine, i.e. 8951 MiB available. */
+const VM_STAT = [
+  'Mach Virtual Memory Statistics: (page size of 16384 bytes)',
+  'Pages free:                                50000.',
+  'Pages active:                             600000.',
+  'Pages inactive:                           400000.',
+  'Pages speculative:                         30000.',
+  'Pages throttled:                               0.',
+  'Pages wired down:                         150000.',
+  'Pages purgeable:                           50000.',
+  '"Translation faults":                  987654321.',
+  'Pages occupied by compressor:             100000.',
+  'File-backed pages:                        700000.',
+  'Anonymous pages:                          800000.'
+].join('\n')
+
+const TOTAL_BYTES = 24576 * 1048576
+
+describe('parseVmStat', () => {
+  it('reports app+wired+compressed as used, not the near-zero free page count', () => {
+    // The bug this exists for: `Pages free` is 50000 (≈781 MiB) on a machine with 8.4 GiB genuinely
+    // available, because macOS holds the rest as reclaimable cache.
+    expect(parseVmStat(VM_STAT, TOTAL_BYTES)).toEqual({ availableMb: 8951, totalMb: 24576 })
+  })
+
+  it('reads the page size from the header rather than assuming 4096', () => {
+    // Same class as the Linux statm bug: a hard-coded 4096 would report a QUARTER of the real usage
+    // on Apple Silicon, i.e. an alarmingly empty machine.
+    const fourK = parseVmStat(VM_STAT.replace('16384 bytes', '4096 bytes'), TOTAL_BYTES)
+    // 1,000,000 x 4096 B = 3906 MiB, so the machine would read 5044 MiB emptier than it is.
+    expect(fourK).toEqual({ availableMb: 20670, totalMb: 24576 })
+  })
+
+  it('subtracts purgeable pages from anonymous — they are droppable cache, not app memory', () => {
+    const noPurge = parseVmStat(VM_STAT.replace(/Pages purgeable:.*\n/, ''), TOTAL_BYTES)
+    // Without the subtraction the machine reads 50000 pages (781 MiB) fuller than it is.
+    expect(noPurge?.availableMb).toBe(8951 - 781)
+  })
+
+  it('returns null when a field it needs is missing, rather than a partial number', () => {
+    expect(parseVmStat(VM_STAT.replace(/Pages wired down:.*\n/, ''), TOTAL_BYTES)).toBeNull()
+    expect(parseVmStat('not vm_stat output', TOTAL_BYTES)).toBeNull()
+    expect(parseVmStat(VM_STAT, 0)).toBeNull()
+  })
+
+  it('never reports negative availability on a heavily compressed machine', () => {
+    const tiny = parseVmStat(VM_STAT, 1024 * 1048576)
+    expect(tiny?.availableMb).toBe(0)
+  })
+})

--- a/src/core/session-memory.test.ts
+++ b/src/core/session-memory.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { indexProcesses, rollupTree, parseProcessTable, type ProcEntry } from './session-memory'
+import {
+  indexProcesses,
+  rollupTree,
+  parseProcessTable,
+  parsePaneList,
+  buildReport,
+  collectSessionMemory,
+  type ProcEntry
+} from './session-memory'
 
 const P = (pid: number, ppid: number, rssKb: number): ProcEntry => ({ pid, ppid, rssKb })
 
@@ -54,5 +62,100 @@ describe('parseProcessTable', () => {
 
   it('returns an empty array for empty input rather than throwing', () => {
     expect(parseProcessTable('')).toEqual([])
+  })
+})
+
+describe('parsePaneList', () => {
+  it('parses the pipe-delimited pane list and skips malformed lines', () => {
+    expect(
+      parsePaneList('nt-term-a|100|claude\nbroken\nnt-term-b|200|zsh\n|300|x\n')
+    ).toEqual([
+      { session: 'nt-term-a', panePid: 100, command: 'claude' },
+      { session: 'nt-term-b', panePid: 200, command: 'zsh' }
+    ])
+  })
+})
+
+describe('buildReport', () => {
+  it('rolls up each nt- session and sorts by total descending', () => {
+    const r = buildReport(
+      [
+        { session: 'nt-small', panePid: 100, command: 'zsh' },
+        { session: 'nt-big', panePid: 200, command: 'claude' }
+      ],
+      [
+        P(100, 1, 40 * 1024),
+        P(200, 1, 350 * 1024),
+        P(201, 200, 50 * 1024)
+      ],
+      { availableMb: 1000, totalMb: 64000 }
+    )
+    expect(r.ok).toBe(true)
+    expect(r.rows.map((x) => x.session)).toEqual(['nt-big', 'nt-small'])
+    expect(r.rows[0]).toMatchObject({
+      nodeId: 'big',
+      totalMb: 400,
+      selfMb: 350,
+      childrenMb: 50,
+      childCount: 1,
+      command: 'claude'
+    })
+  })
+
+  it('ignores sessions that are not nt- prefixed', () => {
+    const r = buildReport(
+      [{ session: 'my-own-tmux', panePid: 100, command: 'zsh' }],
+      [P(100, 1, 40 * 1024)],
+      null
+    )
+    expect(r.rows).toEqual([])
+  })
+})
+
+describe('collectSessionMemory', () => {
+  const table = [P(100, 1, 40 * 1024), P(200, 1, 350 * 1024)]
+
+  it('reports ok:false with no rows when the process table cannot be read', async () => {
+    const r = await collectSessionMemory({
+      tmuxBin: () => '/usr/bin/tmux',
+      sockets: ['s1'],
+      exec: async () => 'nt-a|100|claude\n',
+      readTable: () => null,
+      readMem: () => ({ availableMb: 1, totalMb: 2 })
+    })
+    // "could not look" must never render as "uses nothing".
+    expect(r.ok).toBe(false)
+    expect(r.rows).toEqual([])
+  })
+
+  it('reports ok:true with no rows when tmux has no server (a real answer)', async () => {
+    const r = await collectSessionMemory({
+      tmuxBin: () => '/usr/bin/tmux',
+      sockets: ['s1'],
+      exec: async () => {
+        throw new Error('no server running')
+      },
+      readTable: () => table,
+      readMem: () => null
+    })
+    expect(r.ok).toBe(true)
+    expect(r.rows).toEqual([])
+  })
+
+  it('reports ok:false when tmux is unavailable entirely', async () => {
+    const r = await collectSessionMemory({ tmuxBin: () => null, readTable: () => table })
+    expect(r.ok).toBe(false)
+  })
+
+  it('merges panes from every socket and dedupes by session name', async () => {
+    const r = await collectSessionMemory({
+      tmuxBin: () => '/usr/bin/tmux',
+      sockets: ['s1', 's2'],
+      exec: async (_bin, args) =>
+        args[1] === 's1' ? 'nt-a|100|zsh\n' : 'nt-b|200|claude\nnt-a|100|zsh\n',
+      readTable: () => table,
+      readMem: () => null
+    })
+    expect(r.rows.map((x) => x.session).sort()).toEqual(['nt-a', 'nt-b'])
   })
 })

--- a/src/core/session-memory.test.ts
+++ b/src/core/session-memory.test.ts
@@ -237,7 +237,7 @@ describe('collectSessionMemory', () => {
   })
 })
 
-import { parseVmStat } from './session-memory'
+import { parseVmStat, darwinMemInfo } from './session-memory'
 
 /** Shaped from Apple's documented `vm_stat` format, at a 16 KiB page (Apple Silicon). COMPOSED, not
  *  captured — nobody in this loop has a Mac. Numbers chosen so the arithmetic is checkable by hand:
@@ -290,5 +290,27 @@ describe('parseVmStat', () => {
   it('never reports negative availability on a heavily compressed machine', () => {
     const tiny = parseVmStat(VM_STAT, 1024 * 1048576)
     expect(tiny?.availableMb).toBe(0)
+  })
+})
+
+describe('darwinMemInfo', () => {
+  it('reports null when vm_stat cannot run — never the os.freemem() value', () => {
+    // The whole point. Falling back to os.freemem() here would restore the bug: on macOS it reads
+    // near zero, the reaper's 10%-of-RAM watermark reads as permanent pressure, and idle detached
+    // sessions get reaped every sweep. A confirmed field symptom ("my sessions keep disappearing").
+    // planReap treats null as NO pressure, so no signal is the safe answer.
+    expect(
+      darwinMemInfo(() => {
+        throw new Error('spawn vm_stat ENOENT')
+      }, TOTAL_BYTES)
+    ).toBeNull()
+  })
+
+  it('reports null on output it cannot parse', () => {
+    expect(darwinMemInfo(() => 'garbage', TOTAL_BYTES)).toBeNull()
+  })
+
+  it('passes a good reading through', () => {
+    expect(darwinMemInfo(() => VM_STAT, TOTAL_BYTES)).toEqual({ availableMb: 8951, totalMb: 24576 })
   })
 })

--- a/src/core/session-memory.test.ts
+++ b/src/core/session-memory.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import fs from 'fs'
 import {
   indexProcesses,
   rollupTree,
@@ -6,6 +7,7 @@ import {
   parsePaneList,
   buildReport,
   collectSessionMemory,
+  isNoServerError,
   type ProcEntry
 } from './session-memory'
 
@@ -67,8 +69,10 @@ describe('parseProcessTable', () => {
 
 describe('parsePaneList', () => {
   it('parses the pipe-delimited pane list and skips malformed lines', () => {
+    // `nt-zero||sh` is the phantom case: an empty pid field parses as 0, which IS finite, so a
+    // finite-only guard would emit a 0 MB row for a pid that cannot exist.
     expect(
-      parsePaneList('nt-term-a|100|claude\nbroken\nnt-term-b|200|zsh\n|300|x\n')
+      parsePaneList('nt-term-a|100|claude\nbroken\nnt-term-b|200|zsh\n|300|x\nnt-zero||sh\n')
     ).toEqual([
       { session: 'nt-term-a', panePid: 100, command: 'claude' },
       { session: 'nt-term-b', panePid: 200, command: 'zsh' }
@@ -126,6 +130,8 @@ describe('collectSessionMemory', () => {
     // "could not look" must never render as "uses nothing".
     expect(r.ok).toBe(false)
     expect(r.rows).toEqual([])
+    // The host total is still a real reading — the failure path must not throw it away.
+    expect(r.mem).toEqual({ availableMb: 1, totalMb: 2 })
   })
 
   it('reports ok:true with no rows when tmux has no server (a real answer)', async () => {
@@ -145,17 +151,75 @@ describe('collectSessionMemory', () => {
   it('reports ok:false when tmux is unavailable entirely', async () => {
     const r = await collectSessionMemory({ tmuxBin: () => null, readTable: () => table })
     expect(r.ok).toBe(false)
+    expect(r.rows).toEqual([])
   })
 
-  it('merges panes from every socket and dedupes by session name', async () => {
+  it('counts "no server" as an answer but a permission failure as a failure', () => {
+    expect(isNoServerError('no server running on /tmp/tmux-0/node-terminal')).toBe(true)
+    expect(isNoServerError('error connecting to /tmp/x (No such file or directory)')).toBe(true)
+    // A socket dir we may not read says nothing about whether sessions exist there.
+    expect(isNoServerError('error connecting to /tmp/x (Permission denied)')).toBe(false)
+    expect(isNoServerError('killed: timeout')).toBe(false)
+  })
+
+  it('reports ok:false when NO socket answered', async () => {
+    // One socket erroring is normal (nobody used it). Every socket erroring means we never looked,
+    // and "we never looked" must not render as "there are no sessions".
+    const r = await collectSessionMemory({
+      tmuxBin: () => '/usr/bin/tmux',
+      sockets: ['s1', 's2'],
+      exec: async () => {
+        throw new Error('connect failed')
+      },
+      readTable: () => table,
+      readMem: () => null
+    })
+    expect(r.ok).toBe(false)
+    expect(r.rows).toEqual([])
+  })
+
+  it('merges panes from every socket and the first socket wins a duplicate session', async () => {
     const r = await collectSessionMemory({
       tmuxBin: () => '/usr/bin/tmux',
       sockets: ['s1', 's2'],
       exec: async (_bin, args) =>
-        args[1] === 's1' ? 'nt-a|100|zsh\n' : 'nt-b|200|claude\nnt-a|100|zsh\n',
+        args[1] === 's1' ? 'nt-a|100|zsh\n' : 'nt-b|200|claude\nnt-a|999|claude\n',
       readTable: () => table,
       readMem: () => null
     })
     expect(r.rows.map((x) => x.session).sort()).toEqual(['nt-a', 'nt-b'])
+    // s2 also reported nt-a, with a different pid and command: s1's entry must be the one kept.
+    expect(r.rows.find((x) => x.session === 'nt-a')).toMatchObject({
+      panePid: 100,
+      command: 'zsh'
+    })
+  })
+
+  it('routes the ps fallback through the injected exec seam', async () => {
+    // With no readTable injected the default /proc reader runs first; make it fail so the `ps`
+    // fallback is reached on every platform, including the Linux box this suite runs on.
+    const spy = vi.spyOn(fs, 'readdirSync').mockImplementation(() => {
+      throw new Error('/proc unreadable')
+    })
+    try {
+      const calls: string[] = []
+      const r = await collectSessionMemory({
+        tmuxBin: () => '/usr/bin/tmux',
+        sockets: ['s1'],
+        exec: async (bin) => {
+          calls.push(bin)
+          if (bin === 'ps') return '  PID  PPID    RSS\n  100     1   1024\n'
+          return 'nt-a|100|zsh\n'
+        },
+        readMem: () => null
+      })
+      // The `ps` call must come THROUGH the seam, not around it — otherwise this path can never
+      // be driven by a test and the file's "every exec is injectable" promise is false.
+      expect(calls).toContain('ps')
+      expect(r.ok).toBe(true)
+      expect(r.rows[0]).toMatchObject({ session: 'nt-a', selfMb: 1 })
+    } finally {
+      spy.mockRestore()
+    }
   })
 })

--- a/src/core/session-memory.test.ts
+++ b/src/core/session-memory.test.ts
@@ -160,6 +160,19 @@ describe('collectSessionMemory', () => {
     // A socket dir we may not read says nothing about whether sessions exist there.
     expect(isNoServerError('error connecting to /tmp/x (Permission denied)')).toBe(false)
     expect(isNoServerError('killed: timeout')).toBe(false)
+    // The regression the anchor exists for: stderr that merely CONTAINS the errno phrase. A tmux
+    // client that cannot load a library fails this way on EVERY socket — same binary — so counting
+    // it as an answer would print "no sessions" while the already-running server holds live ones.
+    expect(
+      isNoServerError(
+        'Command failed: tmux -L node-terminal list-panes\ntmux: error while loading shared ' +
+          'libraries: libtinfo.so.6: cannot open shared object file: No such file or directory'
+      )
+    ).toBe(false)
+    // Same shape one layer out: a dead ssh ControlMaster, which this sweep may later run over.
+    expect(isNoServerError('Control socket connect(/tmp/cm.sock): No such file or directory')).toBe(
+      false
+    )
   })
 
   it('reports ok:false when NO socket answered', async () => {

--- a/src/core/session-memory.test.ts
+++ b/src/core/session-memory.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { indexProcesses, rollupTree, parseProcessTable, type ProcEntry } from './session-memory'
+
+const P = (pid: number, ppid: number, rssKb: number): ProcEntry => ({ pid, ppid, rssKb })
+
+describe('indexProcesses + rollupTree', () => {
+  it('sums a pane pid and every descendant, splitting self from children', () => {
+    // pane(100) -> claude(200) -> mcp(300), and claude also has mcp2(301)
+    const { table, kids } = indexProcesses([
+      P(100, 1, 1024),
+      P(200, 100, 350 * 1024),
+      P(300, 200, 30 * 1024),
+      P(301, 200, 20 * 1024)
+    ])
+    const r = rollupTree(table, kids, 100)
+    expect(r.selfMb).toBe(1)
+    expect(r.childrenMb).toBe(400)
+    expect(r.childCount).toBe(3)
+    expect(r.totalMb).toBe(401)
+  })
+
+  it('returns zeros for a pid that is not in the table', () => {
+    const { table, kids } = indexProcesses([P(100, 1, 1024)])
+    expect(rollupTree(table, kids, 999)).toEqual({
+      selfMb: 0,
+      childrenMb: 0,
+      childCount: 0,
+      totalMb: 0
+    })
+  })
+
+  it('does not loop forever on a cyclic ppid chain', () => {
+    // A pid whose parent chain points back at it must not hang the sweep.
+    const { table, kids } = indexProcesses([P(100, 200, 1024), P(200, 100, 1024)])
+    const r = rollupTree(table, kids, 100)
+    expect(r.totalMb).toBe(2)
+    expect(r.childCount).toBe(1)
+  })
+})
+
+describe('parseProcessTable', () => {
+  it('parses ps output and skips the header and malformed lines', () => {
+    const out = parseProcessTable(
+      '  PID  PPID    RSS COMMAND\n' +
+        '  100     1   1024 tmux\n' +
+        'garbage line\n' +
+        '  200   100 358400 claude\n'
+    )
+    expect(out).toEqual([
+      { pid: 100, ppid: 1, rssKb: 1024 },
+      { pid: 200, ppid: 100, rssKb: 358400 }
+    ])
+  })
+
+  it('returns an empty array for empty input rather than throwing', () => {
+    expect(parseProcessTable('')).toEqual([])
+  })
+})

--- a/src/core/session-memory.ts
+++ b/src/core/session-memory.ts
@@ -230,9 +230,18 @@ export function defaultProcessTableReader(): ProcEntry[] | null {
  * denied)") or a timeout against a hung server is a real failure, and laundering it into "no
  * sessions here" is exactly the mistake `ok:false` exists to prevent: it would print an empty
  * panel over 20 live sessions. Only the two phrasings that positively assert absence count.
+ *
+ * The second alternative is ANCHORED to tmux's own connect message rather than matching a bare
+ * `no such file or directory`. `promisify(execFile)` folds stderr into `err.message`, so an
+ * unanchored errno string matches any failure that merely contains it — a tmux client missing a
+ * shared library exits 127 with "cannot open shared object file: No such file or directory" on
+ * EVERY socket (same binary), which would report "no sessions" while the server started before the
+ * breakage still runs live ones. The same string is how a dead ssh ControlMaster fails
+ * ("Control socket connect(…): No such file or directory"), which matters the moment this sweep is
+ * routed over one. tmux ships no gettext (its messages are C literals), so anchoring is safe.
  */
 export function isNoServerError(message: string): boolean {
-  return /no server running|no such file or directory/i.test(message)
+  return /no server running|error connecting to [^\n]*\(no such file or directory\)/i.test(message)
 }
 
 /**

--- a/src/core/session-memory.ts
+++ b/src/core/session-memory.ts
@@ -10,7 +10,7 @@
 
 import fs from 'fs'
 import os from 'os'
-import { execFile } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import { promisify } from 'util'
 import type { MemInfo, SessionMemoryRow, SessionMemoryReport } from '../shared/types'
 import { TMUX_SOCKET } from './tmux-naming'
@@ -105,6 +105,48 @@ export function parseProcessTable(stdout: string): ProcEntry[] {
  *
  *  Lives here rather than in session-budget.ts because two features now read it (the reaper's
  *  watermark and the system-resource pill) and a second copy would drift. */
+/**
+ * Parse `vm_stat` into the same MemInfo shape, given the machine's total bytes.
+ *
+ * macOS deliberately keeps almost nothing "free": file-backed and purgeable pages are held until
+ * something needs them, so libuv's `os.freemem()` — which counts only genuinely free pages —
+ * reports near zero on a healthy Mac. `total - free` therefore renders every Mac as ~100% full,
+ * which is both useless and alarming. (It also pinned the session reaper's watermark permanently
+ * below its threshold, so a Mac reaped idle detached sessions on every sweep regardless of memory.)
+ *
+ * The number Activity Monitor calls "Memory Used" is app + wired + compressed, i.e.
+ * `anonymous - purgeable + wired + compressor`; everything else is reclaimable and counts as
+ * available. This is an approximation of Activity Monitor, not a reproduction of it — Apple does not
+ * document the exact figure, and on Apple Silicon the parts are known not to sum to its total.
+ *
+ * The page size is READ FROM THE HEADER, never assumed: Apple Silicon uses 16 KiB pages, and
+ * hard-coding 4096 is the identical bug this file already fixed on the Linux side.
+ */
+export function parseVmStat(text: string, totalBytes: number): MemInfo | null {
+  const pageSize = Number(/page size of (\d+) bytes/.exec(text)?.[1])
+  if (!Number.isFinite(pageSize) || pageSize <= 0 || !Number.isFinite(totalBytes) || totalBytes <= 0) {
+    return null
+  }
+  const pages = (label: string): number | null => {
+    const m = new RegExp(`^${label}:\\s+(\\d+)\\.`, 'm').exec(text)
+    return m ? Number(m[1]) : null
+  }
+  const anonymous = pages('Anonymous pages')
+  const wired = pages('Pages wired down')
+  const compressor = pages('Pages occupied by compressor')
+  // `Pages purgeable` is a SUBSET of anonymous — caches an app has volunteered as droppable.
+  const purgeable = pages('Pages purgeable') ?? 0
+  // A missing field means we are not looking at vm_stat output we understand. Report nothing rather
+  // than a number built from a partial read — the pill pulses, which is the honest answer.
+  if (anonymous === null || wired === null || compressor === null) return null
+
+  const usedBytes = (Math.max(0, anonymous - purgeable) + wired + compressor) * pageSize
+  const totalMb = Math.round(totalBytes / 1048576)
+  // Clamp: the parts are an approximation and can exceed the total on a heavily compressed system.
+  const availableMb = Math.max(0, totalMb - Math.round(usedBytes / 1048576))
+  return { availableMb, totalMb }
+}
+
 export function readMemInfo(): MemInfo | null {
   try {
     const text = fs.readFileSync('/proc/meminfo', 'utf8')
@@ -118,6 +160,20 @@ export function readMemInfo(): MemInfo | null {
     }
   } catch {
     // fall through to the os fallback
+  }
+  // macOS: `os.freemem()` counts only genuinely free pages, which a healthy Mac keeps near zero —
+  // see parseVmStat. Ask the kernel for the real breakdown instead. Sync on purpose: both callers
+  // (the 30 s pill poll and the reaper's 10 min sweep) are far apart, and keeping ONE signature
+  // means the reaper's watermark is fixed by the same change.
+  if (process.platform === 'darwin') {
+    try {
+      const out = execFileSync('vm_stat', { encoding: 'utf8', timeout: 5_000 })
+      const parsed = parseVmStat(out, os.totalmem())
+      if (parsed) return parsed
+    } catch {
+      // vm_stat missing or unreadable — fall through to the generic reader below, which is wrong on
+      // macOS but is still better than reporting nothing at all.
+    }
   }
   try {
     return {

--- a/src/core/session-memory.ts
+++ b/src/core/session-memory.ts
@@ -106,6 +106,26 @@ export function parseProcessTable(stdout: string): ProcEntry[] {
  *  Lives here rather than in session-budget.ts because two features now read it (the reaper's
  *  watermark and the system-resource pill) and a second copy would drift. */
 /**
+ * macOS reading, or `null`. **There is deliberately no fallback to `os.freemem()` here.**
+ *
+ * That fallback is the very number this function exists to replace: on macOS it sits near zero, and
+ * the session reaper's watermark (10% of RAM) then reads as permanent memory pressure — which had a
+ * Mac reaping idle detached sessions every 10 minutes regardless of how much memory was free. A
+ * confirmed field symptom, reported as "my sessions keep disappearing".
+ *
+ * So a `vm_stat` we cannot run or cannot parse yields NO SIGNAL, not a wrong one. Both consumers
+ * degrade correctly on null: `planReap` treats it as "no pressure" (absence of evidence never
+ * triggers a kill) and the pill pulses instead of printing a number it has not earned.
+ */
+export function darwinMemInfo(runVmStat: () => string, totalBytes: number): MemInfo | null {
+  try {
+    return parseVmStat(runVmStat(), totalBytes)
+  } catch {
+    return null
+  }
+}
+
+/**
  * Parse `vm_stat` into the same MemInfo shape, given the machine's total bytes.
  *
  * macOS deliberately keeps almost nothing "free": file-backed and purgeable pages are held until
@@ -166,14 +186,10 @@ export function readMemInfo(): MemInfo | null {
   // (the 30 s pill poll and the reaper's 10 min sweep) are far apart, and keeping ONE signature
   // means the reaper's watermark is fixed by the same change.
   if (process.platform === 'darwin') {
-    try {
-      const out = execFileSync('vm_stat', { encoding: 'utf8', timeout: 5_000 })
-      const parsed = parseVmStat(out, os.totalmem())
-      if (parsed) return parsed
-    } catch {
-      // vm_stat missing or unreadable — fall through to the generic reader below, which is wrong on
-      // macOS but is still better than reporting nothing at all.
-    }
+    return darwinMemInfo(
+      () => execFileSync('vm_stat', { encoding: 'utf8', timeout: 5_000 }),
+      os.totalmem()
+    )
   }
   try {
     return {

--- a/src/core/session-memory.ts
+++ b/src/core/session-memory.ts
@@ -1,0 +1,121 @@
+// Per-session memory accounting: which nt- tmux session is holding how much RSS, including the
+// agent CLI's own children (MCP servers, headless browsers).
+//
+// The measurement a user actually asks about is the PROCESS TREE under a pane, not the pane's own
+// process: a `claude` session is ~335 MB itself but routinely carries 30-200 MB of MCP children,
+// and a report that named only the pane would understate it by a third.
+//
+// Electron-free (src/core): every fs/exec access is behind an injectable seam (template:
+// session-budget.ts), so both shells boot it and tests drive it without touching /proc or tmux.
+
+import fs from 'fs'
+import os from 'os'
+import type { MemInfo } from '../shared/types'
+
+export type { MemInfo }
+
+/** One process from the host's table. `rssKb` is resident set size in kB. Core-internal: it never
+ *  crosses the wire, so it does not belong in shared/types. */
+export interface ProcEntry {
+  pid: number
+  ppid: number
+  rssKb: number
+}
+
+/** Reads the whole process table at once; null when it could not run. */
+export type ProcessTableReader = () => ProcEntry[] | null
+
+const kbToMb = (kb: number): number => Math.round(kb / 1024)
+
+/** Index a flat table into pid→entry plus ppid→children, so a tree walk is O(nodes). */
+export function indexProcesses(entries: readonly ProcEntry[]): {
+  table: Map<number, ProcEntry>
+  kids: Map<number, number[]>
+} {
+  const table = new Map<number, ProcEntry>()
+  const kids = new Map<number, number[]>()
+  for (const e of entries) {
+    table.set(e.pid, e)
+    const list = kids.get(e.ppid)
+    if (list) list.push(e.pid)
+    else kids.set(e.ppid, [e.pid])
+  }
+  return { table, kids }
+}
+
+/**
+ * Total RSS of `root` and every descendant, split into the pane's own process and everything
+ * below it (which is what the panel's `└ +N MCP` sub-line reports).
+ *
+ * A `seen` set guards the walk: a process table captured while pids are being recycled can
+ * present a cyclic ppid chain, and a sweep that hangs is worse than one that under-reports.
+ */
+export function rollupTree(
+  table: ReadonlyMap<number, ProcEntry>,
+  kids: ReadonlyMap<number, number[]>,
+  root: number
+): { selfMb: number; childrenMb: number; childCount: number; totalMb: number } {
+  const self = table.get(root)
+  if (!self) return { selfMb: 0, childrenMb: 0, childCount: 0, totalMb: 0 }
+  let childrenKb = 0
+  let childCount = 0
+  const seen = new Set<number>([root])
+  const stack = [...(kids.get(root) ?? [])]
+  while (stack.length > 0) {
+    const pid = stack.pop() as number
+    if (seen.has(pid)) continue
+    seen.add(pid)
+    const e = table.get(pid)
+    if (!e) continue
+    childrenKb += e.rssKb
+    childCount++
+    for (const k of kids.get(pid) ?? []) stack.push(k)
+  }
+  const selfMb = kbToMb(self.rssKb)
+  const childrenMb = kbToMb(childrenKb)
+  return { selfMb, childrenMb, childCount, totalMb: selfMb + childrenMb }
+}
+
+/** Parse `ps -eo pid,ppid,rss` output. Tolerant: header and malformed lines are skipped. */
+export function parseProcessTable(stdout: string): ProcEntry[] {
+  const out: ProcEntry[] = []
+  for (const line of stdout.split('\n')) {
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 3) continue
+    const pid = Number(parts[0])
+    const ppid = Number(parts[1])
+    const rssKb = Number(parts[2])
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid) || !Number.isFinite(rssKb)) continue
+    out.push({ pid, ppid, rssKb })
+  }
+  return out
+}
+
+/** Linux `/proc/meminfo` (MemAvailable is the honest number); `os.freemem()` fallback elsewhere.
+ *  Returns null when nothing is readable — callers treat that as "no signal", never as zero.
+ *
+ *  Lives here rather than in session-budget.ts because two features now read it (the reaper's
+ *  watermark and the system-resource pill) and a second copy would drift. */
+export function readMemInfo(): MemInfo | null {
+  try {
+    const text = fs.readFileSync('/proc/meminfo', 'utf8')
+    const avail = /MemAvailable:\s+(\d+)\s*kB/.exec(text)
+    const total = /MemTotal:\s+(\d+)\s*kB/.exec(text)
+    if (avail && total) {
+      return {
+        availableMb: Math.round(Number(avail[1]) / 1024),
+        totalMb: Math.round(Number(total[1]) / 1024)
+      }
+    }
+  } catch {
+    // fall through to the os fallback
+  }
+  try {
+    return {
+      availableMb: Math.round(os.freemem() / 1048576),
+      totalMb: Math.round(os.totalmem() / 1048576)
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/core/session-memory.ts
+++ b/src/core/session-memory.ts
@@ -10,9 +10,15 @@
 
 import fs from 'fs'
 import os from 'os'
-import type { MemInfo } from '../shared/types'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import type { MemInfo, SessionMemoryRow, SessionMemoryReport } from '../shared/types'
+import { TMUX_SOCKET } from './tmux-naming'
+import { RMT_TMUX_SOCKET } from './remote-ssh/control-master'
 
-export type { MemInfo }
+export type { MemInfo, SessionMemoryRow, SessionMemoryReport }
+
+const runAsync = promisify(execFile)
 
 /** One process from the host's table. `rssKb` is resident set size in kB. Core-internal: it never
  *  crosses the wire, so it does not belong in shared/types. */
@@ -45,7 +51,10 @@ export function indexProcesses(entries: readonly ProcEntry[]): {
 
 /**
  * Total RSS of `root` and every descendant, split into the pane's own process and everything
- * below it (which is what the panel's `└ +N MCP` sub-line reports).
+ * below it (which is what the panel's `└ +N child processes` sub-line reports).
+ *
+ * `childCount` counts EVERY descendant, the agent CLI included: `root` is the pane's SHELL, so a
+ * claude session with two MCP servers reports 3, not 2. Labelling it `+N MCP` would be a lie.
  *
  * A `seen` set guards the walk: a process table captured while pids are being recycled can
  * present a cyclic ppid chain, and a sweep that hangs is worse than one that under-reports.
@@ -118,4 +127,144 @@ export function readMemInfo(): MemInfo | null {
   } catch {
     return null
   }
+}
+
+/** One tmux pane as reported by `list-panes -a`. Core-internal. */
+export interface PaneRef {
+  session: string
+  panePid: number
+  command: string
+}
+
+const PANE_FMT = '#{session_name}|#{pane_pid}|#{pane_current_command}'
+
+/** Parse `list-panes -a -F '<PANE_FMT>'`. Tolerant: malformed lines are skipped. */
+export function parsePaneList(stdout: string): PaneRef[] {
+  const out: PaneRef[] = []
+  for (const line of stdout.split('\n')) {
+    const parts = line.trim().split('|')
+    if (parts.length < 3) continue
+    const panePid = Number(parts[1])
+    if (!parts[0] || !Number.isFinite(panePid)) continue
+    out.push({ session: parts[0], panePid, command: parts[2] })
+  }
+  return out
+}
+
+/** Pure assembly: panes + a process table → sorted rows. Only `nt-` sessions are ours. */
+export function buildReport(
+  panes: readonly PaneRef[],
+  table: readonly ProcEntry[],
+  mem: MemInfo | null
+): SessionMemoryReport {
+  const { table: byPid, kids } = indexProcesses(table)
+  const rows: SessionMemoryRow[] = []
+  for (const p of panes) {
+    if (!p.session.startsWith('nt-')) continue
+    const t = rollupTree(byPid, kids, p.panePid)
+    rows.push({
+      session: p.session,
+      nodeId: p.session.slice('nt-'.length),
+      panePid: p.panePid,
+      command: p.command,
+      ...t
+    })
+  }
+  rows.sort((a, b) => b.totalMb - a.totalMb)
+  return { ok: true, rows, mem }
+}
+
+export interface SessionMemoryDeps {
+  /** Lazy tmux resolver (PtyManager resolves after init; null = tmux unavailable). */
+  tmuxBin: () => string | null
+  /** Sockets to sweep. Default: the local socket + the SSH-remote socket. */
+  sockets?: string[]
+  exec?: (bin: string, args: string[]) => Promise<string>
+  readTable?: ProcessTableReader
+  readMem?: () => MemInfo | null
+}
+
+/** Default reader: /proc on Linux (no subprocess), one `ps` call everywhere else. */
+export function defaultProcessTableReader(): ProcEntry[] | null {
+  if (process.platform === 'linux') {
+    try {
+      const out: ProcEntry[] = []
+      for (const name of fs.readdirSync('/proc')) {
+        if (!/^\d+$/.test(name)) continue
+        try {
+          const stat = fs.readFileSync(`/proc/${name}/stat`, 'utf8')
+          // The comm field is parenthesized and may contain spaces: split AFTER the last ')'.
+          const after = stat.slice(stat.lastIndexOf(')') + 2).split(' ')
+          const ppid = Number(after[1])
+          const statm = fs.readFileSync(`/proc/${name}/statm`, 'utf8').split(' ')
+          const rssPages = Number(statm[1])
+          if (!Number.isFinite(ppid) || !Number.isFinite(rssPages)) continue
+          out.push({ pid: Number(name), ppid, rssKb: (rssPages * 4096) / 1024 })
+        } catch {
+          // The process exited between readdir and read — skip it, never fail the sweep.
+        }
+      }
+      return out
+    } catch {
+      return null
+    }
+  }
+  return null // non-Linux falls through to the ps path in collectSessionMemory
+}
+
+/**
+ * One sweep. Failure rules (CLAUDE.md: a failed read is never evidence of absence):
+ *  - no tmux binary, or an unreadable process table → `ok: false`, no rows;
+ *  - a socket whose `list-panes` fails contributes NO panes but is NOT a failure — "no server
+ *    running" is the normal answer for a socket nobody has used yet.
+ */
+export async function collectSessionMemory(
+  deps: SessionMemoryDeps
+): Promise<SessionMemoryReport> {
+  const readMem = deps.readMem ?? readMemInfo
+  const mem = readMem()
+  const bin = deps.tmuxBin()
+  if (!bin) return { ok: false, rows: [], mem }
+
+  const exec =
+    deps.exec ??
+    (async (b: string, args: string[]): Promise<string> => {
+      const { stdout } = await runAsync(b, args, { timeout: 15_000 })
+      return stdout
+    })
+
+  const readTable =
+    deps.readTable ??
+    ((): ProcEntry[] | null => {
+      const viaProc = defaultProcessTableReader()
+      if (viaProc) return viaProc
+      return null
+    })
+
+  let table = readTable()
+  if (table === null && !deps.readTable) {
+    // Non-Linux (or an unreadable /proc): one `ps` call for the whole table.
+    try {
+      const { stdout } = await runAsync('ps', ['-eo', 'pid,ppid,rss'], { timeout: 15_000 })
+      table = parseProcessTable(stdout)
+    } catch {
+      table = null
+    }
+  }
+  if (table === null) return { ok: false, rows: [], mem }
+
+  const sockets = deps.sockets ?? [TMUX_SOCKET, RMT_TMUX_SOCKET]
+  const bySession = new Map<string, PaneRef>()
+  for (const s of sockets) {
+    try {
+      const stdout = await exec(bin, ['-L', s, 'list-panes', '-a', '-F', PANE_FMT])
+      // First pane of a session wins: a session with several panes is still one row.
+      for (const p of parsePaneList(stdout))
+        if (!bySession.has(p.session)) bySession.set(p.session, p)
+    } catch {
+      // "no server running" and a real failure both land here; neither yields panes, and neither
+      // makes the whole sweep a failure — the other socket may well have answered.
+    }
+  }
+  return buildReport([...bySession.values()], table, mem)
 }

--- a/src/core/session-memory.ts
+++ b/src/core/session-memory.ts
@@ -136,7 +136,9 @@ export interface PaneRef {
   command: string
 }
 
-const PANE_FMT = '#{session_name}|#{pane_pid}|#{pane_current_command}'
+/** The `-F` format `parsePaneList` reads. Exported so the SSH leg's generated shell asks for the
+ *  exact same fields — a second copy of this string would drift from its own parser. */
+export const PANE_FMT = '#{session_name}|#{pane_pid}|#{pane_current_command}'
 
 /** Parse `list-panes -a -F '<PANE_FMT>'`. Tolerant: malformed lines are skipped. */
 export function parsePaneList(stdout: string): PaneRef[] {

--- a/src/core/session-memory.ts
+++ b/src/core/session-memory.ts
@@ -145,7 +145,9 @@ export function parsePaneList(stdout: string): PaneRef[] {
     const parts = line.trim().split('|')
     if (parts.length < 3) continue
     const panePid = Number(parts[1])
-    if (!parts[0] || !Number.isFinite(panePid)) continue
+    // `> 0`, not just finite: an empty pid field parses as 0, which would produce a phantom row
+    // rolled up from a pid that cannot exist.
+    if (!parts[0] || !Number.isFinite(panePid) || panePid <= 0) continue
     out.push({ session: parts[0], panePid, command: parts[2] })
   }
   return out
@@ -184,7 +186,16 @@ export interface SessionMemoryDeps {
   readMem?: () => MemInfo | null
 }
 
-/** Default reader: /proc on Linux (no subprocess), one `ps` call everywhere else. */
+/**
+ * Reads the whole table from `/proc` on Linux, with no subprocess. Returns null on every other
+ * platform (and when `/proc` itself is unreadable) — the caller falls back to one `ps` call.
+ *
+ * `/proc/<pid>/status` is deliberately read INSTEAD of `stat` + `statm`: it carries both facts we
+ * need in ONE file, and its `VmRSS` is already in kB. `statm` reports RSS in PAGES, which would
+ * force a page-size assumption — hard-coding 4096 under-reports 4× on a 16 KiB-page arm64 kernel
+ * and 16× on the 64 KiB-page enterprise arm64 builds, i.e. it would print 40 MB for a 640 MB
+ * session. Do not "optimise" this back to `statm`.
+ */
 export function defaultProcessTableReader(): ProcEntry[] | null {
   if (process.platform === 'linux') {
     try {
@@ -192,14 +203,12 @@ export function defaultProcessTableReader(): ProcEntry[] | null {
       for (const name of fs.readdirSync('/proc')) {
         if (!/^\d+$/.test(name)) continue
         try {
-          const stat = fs.readFileSync(`/proc/${name}/stat`, 'utf8')
-          // The comm field is parenthesized and may contain spaces: split AFTER the last ')'.
-          const after = stat.slice(stat.lastIndexOf(')') + 2).split(' ')
-          const ppid = Number(after[1])
-          const statm = fs.readFileSync(`/proc/${name}/statm`, 'utf8').split(' ')
-          const rssPages = Number(statm[1])
-          if (!Number.isFinite(ppid) || !Number.isFinite(rssPages)) continue
-          out.push({ pid: Number(name), ppid, rssKb: (rssPages * 4096) / 1024 })
+          const status = fs.readFileSync(`/proc/${name}/status`, 'utf8')
+          const ppid = Number(/^PPid:\s+(\d+)/m.exec(status)?.[1])
+          const rssKb = Number(/^VmRSS:\s+(\d+)/m.exec(status)?.[1])
+          // Kernel threads have no VmRSS and are dropped here — they are never pane descendants.
+          if (!Number.isFinite(ppid) || !Number.isFinite(rssKb)) continue
+          out.push({ pid: Number(name), ppid, rssKb })
         } catch {
           // The process exited between readdir and read — skip it, never fail the sweep.
         }
@@ -213,10 +222,27 @@ export function defaultProcessTableReader(): ProcEntry[] | null {
 }
 
 /**
+ * Does a failed `list-panes` mean "there is no tmux server on that socket" — which is an ANSWER,
+ * and the normal state of a socket nobody has used — rather than "the sweep could not run"?
+ * tmux exits non-zero for both, so its message is the only signal we get.
+ *
+ * Deliberately narrow. A permission-denied socket directory ("error connecting to … (Permission
+ * denied)") or a timeout against a hung server is a real failure, and laundering it into "no
+ * sessions here" is exactly the mistake `ok:false` exists to prevent: it would print an empty
+ * panel over 20 live sessions. Only the two phrasings that positively assert absence count.
+ */
+export function isNoServerError(message: string): boolean {
+  return /no server running|no such file or directory/i.test(message)
+}
+
+/**
  * One sweep. Failure rules (CLAUDE.md: a failed read is never evidence of absence):
  *  - no tmux binary, or an unreadable process table → `ok: false`, no rows;
- *  - a socket whose `list-panes` fails contributes NO panes but is NOT a failure — "no server
- *    running" is the normal answer for a socket nobody has used yet.
+ *  - a socket with no tmux server contributes NO panes but is NOT a failure — "no server running"
+ *    is the normal answer for a socket nobody has used yet (`isNoServerError`);
+ *  - but if NO socket answered — every one of them failed for some OTHER reason — the sweep never
+ *    ran → `ok: false`. "Every socket errored" and "we looked and found nothing" are different
+ *    facts and must not render the same.
  */
 export async function collectSessionMemory(
   deps: SessionMemoryDeps
@@ -233,20 +259,14 @@ export async function collectSessionMemory(
       return stdout
     })
 
-  const readTable =
-    deps.readTable ??
-    ((): ProcEntry[] | null => {
-      const viaProc = defaultProcessTableReader()
-      if (viaProc) return viaProc
-      return null
-    })
+  const readTable = deps.readTable ?? defaultProcessTableReader
 
   let table = readTable()
   if (table === null && !deps.readTable) {
-    // Non-Linux (or an unreadable /proc): one `ps` call for the whole table.
+    // Non-Linux (or an unreadable /proc): one `ps` call for the whole table, through the same
+    // injectable seam as tmux — nothing in this file may reach a subprocess around it.
     try {
-      const { stdout } = await runAsync('ps', ['-eo', 'pid,ppid,rss'], { timeout: 15_000 })
-      table = parseProcessTable(stdout)
+      table = parseProcessTable(await exec('ps', ['-eo', 'pid,ppid,rss']))
     } catch {
       table = null
     }
@@ -255,16 +275,22 @@ export async function collectSessionMemory(
 
   const sockets = deps.sockets ?? [TMUX_SOCKET, RMT_TMUX_SOCKET]
   const bySession = new Map<string, PaneRef>()
+  let answered = 0
   for (const s of sockets) {
     try {
       const stdout = await exec(bin, ['-L', s, 'list-panes', '-a', '-F', PANE_FMT])
+      answered++
       // First pane of a session wins: a session with several panes is still one row.
       for (const p of parsePaneList(stdout))
         if (!bySession.has(p.session)) bySession.set(p.session, p)
-    } catch {
-      // "no server running" and a real failure both land here; neither yields panes, and neither
-      // makes the whole sweep a failure — the other socket may well have answered.
+    } catch (err) {
+      // "No server on this socket" is an empty ANSWER, so it still counts as having looked. Any
+      // other failure yields neither panes nor an answer.
+      if (isNoServerError(err instanceof Error ? err.message : String(err))) answered++
     }
   }
+  // Nobody answered: broken tmux, an unreadable socket dir, a timeout against a hung server. We did
+  // not look, so we cannot claim there is nothing — that would print "no sessions" over 20 live ones.
+  if (answered === 0) return { ok: false, rows: [], mem }
   return buildReport([...bySession.values()], table, mem)
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,7 +69,7 @@ import { createGrantsAccessor, type PushGrant } from '../core/push-grants'
 import { createRemoteGrantsCache } from '../core/remote-push-grants'
 import { createAckSweeper } from '../core/ack-sweep'
 import { createSessionReaper } from '../core/session-budget'
-import { startSessionMemoryService } from '../core/session-memory-service'
+import { startSessionMemoryService, sshScopePredicate } from '../core/session-memory-service'
 import { getDeviceId } from '../core/device-id'
 import { initRemoteStatusPush } from './remote-ssh/remote-status-push'
 import { initCanvasSync } from '../core/canvas-sync'
@@ -1511,8 +1511,15 @@ app.whenReady().then(async () => {
   startSessionMemoryService({
     tmuxBin: () => ptyManager.getTmuxBin(),
     remote: {
-      isRemoteProject: (projectId) =>
-        (sshProjectManager?.connectedHosts() ?? []).some((h) => h.projectId === projectId),
+      // Identity, not liveness: a DISCONNECTED SSH project is still someone else's machine, and
+      // `connectedHosts()` alone would answer "local" for it — exactly the window the service's
+      // refusal exists for. The workspace index is the connection-independent source; the live
+      // masters are OR-ed in for a project the index has not (yet) listed. See sshScopePredicate.
+      isRemoteProject: sshScopePredicate({
+        sshProjectIds: () => workspaceStore.sshProjectIds(),
+        connectedProjectIds: () =>
+          (sshProjectManager?.connectedHosts() ?? []).map((h) => h.projectId)
+      }),
       run: async (projectId, command) => {
         const mgr = sshProjectManager
         const ref = mgr?.refForProject(projectId)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,6 +69,7 @@ import { createGrantsAccessor, type PushGrant } from '../core/push-grants'
 import { createRemoteGrantsCache } from '../core/remote-push-grants'
 import { createAckSweeper } from '../core/ack-sweep'
 import { createSessionReaper } from '../core/session-budget'
+import { startSessionMemoryService } from '../core/session-memory-service'
 import { getDeviceId } from '../core/device-id'
 import { initRemoteStatusPush } from './remote-ssh/remote-status-push'
 import { initCanvasSync } from '../core/canvas-sync'
@@ -1501,6 +1502,37 @@ app.whenReady().then(async () => {
   // Local sockets only — a remote SSH host's sessions are reaped by that host's own
   // nodeterm-server, never across the wire. Timer is unref'd; no explicit stop needed.
   createSessionReaper({ tmuxBin: () => ptyManager.getTmuxBin() }).start()
+  // Session memory (docs/superpowers/specs/2026-08-10-session-memory-panel-design.md): the pill's
+  // cheap RAM read plus the on-demand per-session breakdown. An SSH project's sessions live on ITS
+  // host, so they are read THERE over the project's ControlMaster — the same injection Context Link
+  // and remote usage use (core owns the command + the parsing, main owns the master).
+  // `sshProjectManager` is assigned far below, so both closures resolve it lazily; they only ever
+  // run after a project has connected.
+  startSessionMemoryService({
+    tmuxBin: () => ptyManager.getTmuxBin(),
+    remote: {
+      isRemoteProject: (projectId) =>
+        (sshProjectManager?.connectedHosts() ?? []).some((h) => h.projectId === projectId),
+      run: async (projectId, command) => {
+        const mgr = sshProjectManager
+        const ref = mgr?.refForProject(projectId)
+        if (!mgr || !ref) return null
+        try {
+          const { code, stdout } = await mgr.sshRun(childArgs(ref.conn, ref.controlPath, command))
+          // Gated on the exit code, unlike the usage runner: every command in the generated script
+          // ends `|| true`, so a completed read exits 0 unconditionally. A non-zero code therefore
+          // means ssh itself could not run it — a dead ControlMaster reports exactly that, with an
+          // EMPTY stdout ("Control socket connect(…): No such file or directory" goes to stderr).
+          // Passing that empty string on would leave "the host answered nothing" to be inferred
+          // from a missing marker; `null` says "we could not look" outright.
+          if (code !== 0) return null
+          return stdout
+        } catch {
+          return null
+        }
+      }
+    }
+  })
   const ackSweeper = createAckSweeper({
     handlers: { ackDone, onUnreadClear: (id) => sendToMain(IPC.agentUnreadClear, id) }
   })

--- a/src/main/remote-ssh/ssh-project.killSessions.test.ts
+++ b/src/main/remote-ssh/ssh-project.killSessions.test.ts
@@ -1,0 +1,78 @@
+// `killSessions` is what the session-memory panel and project deletion use to end a session on a
+// HOST by name. It is the only leg of that kill nothing else covers: the argv builders are pinned in
+// core/remote-ssh/control-master.test.ts, but "the manager actually runs every argv the builder
+// returned" lives here — and a mutation that fired only the first socket survived the whole suite
+// until this file existed.
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/nodeterm-test' },
+  ipcMain: { handle: () => undefined, on: () => undefined }
+}))
+
+import { SshProjectManager } from './ssh-project'
+
+const conn = { host: 'h.example.com', user: 'deploy', port: 22 }
+
+/** A manager with one connected project and a recording runner. `conns` is private; a test is the
+ *  one caller allowed to seed it, since `connect()` would need a real ssh. */
+function managerWithConn(): { mgr: SshProjectManager; runs: string[][] } {
+  const runs: string[][] = []
+  const run = async (args: string[]): Promise<{ code: number; stdout: string }> => {
+    runs.push(args)
+    // tmux exits non-zero with "can't find session" on whichever socket does not hold it. The
+    // contract is best-effort, so a rejection must not stop the sibling kill.
+    if (args.at(-1)?.includes('node-terminal')) throw new Error("can't find session")
+    return { code: 0, stdout: '' }
+  }
+  const mgr = new SshProjectManager({ run } as never)
+  ;(mgr as unknown as { conns: Map<string, unknown> }).conns.set('p1', {
+    conn,
+    controlPath: '/s.sock',
+    master: { kill: () => undefined }
+  })
+  return { mgr, runs }
+}
+
+const commands = (runs: string[][]): string[] => runs.map((r) => r.at(-1)!).sort()
+
+describe('SshProjectManager.killSessions', () => {
+  it('kills the name on EVERY tmux socket the host can carry it on', async () => {
+    // The session-memory sweep lists both sockets, so its rows can come off either. A kill aimed
+    // only at `nodeterm-rmt` left every row from a host's own nodeterm-server running, after a
+    // confirm that said otherwise.
+    const { mgr, runs } = managerWithConn()
+    await mgr.killSessions('p1', ['abc'])
+    expect(commands(runs)).toEqual([
+      'tmux -L node-terminal kill-session -t =nt-abc',
+      'tmux -L nodeterm-rmt kill-session -t =nt-abc'
+    ])
+  })
+
+  it('is best-effort: a socket that refuses does not spare the others', async () => {
+    // The `node-terminal` run above throws. `killSessions` must still resolve, and the sibling
+    // kill must still have gone out.
+    const { mgr, runs } = managerWithConn()
+    await expect(mgr.killSessions('p1', ['abc'])).resolves.toBeUndefined()
+    expect(runs).toHaveLength(2)
+  })
+
+  it('covers every id it was given', async () => {
+    const { mgr, runs } = managerWithConn()
+    await mgr.killSessions('p1', ['a', 'b'])
+    expect(commands(runs)).toEqual([
+      'tmux -L node-terminal kill-session -t =nt-a',
+      'tmux -L node-terminal kill-session -t =nt-b',
+      'tmux -L nodeterm-rmt kill-session -t =nt-a',
+      'tmux -L nodeterm-rmt kill-session -t =nt-b'
+    ])
+  })
+
+  it('does nothing at all for a project with no live master', async () => {
+    // No connection ⇒ no ssh to run over. Silence is right; inventing a run would open a fresh
+    // direct connection per id.
+    const { mgr, runs } = managerWithConn()
+    await mgr.killSessions('not-connected', ['abc'])
+    expect(runs).toEqual([])
+  })
+})

--- a/src/main/remote-ssh/ssh-project.killSessions.test.ts
+++ b/src/main/remote-ssh/ssh-project.killSessions.test.ts
@@ -37,29 +37,43 @@ function managerWithConn(): { mgr: SshProjectManager; runs: string[][] } {
 const commands = (runs: string[][]): string[] => runs.map((r) => r.at(-1)!).sort()
 
 describe('SshProjectManager.killSessions', () => {
-  it('kills the name on EVERY tmux socket the host can carry it on', async () => {
+  it('kills the name on EVERY tmux socket when the caller opts in', async () => {
     // The session-memory sweep lists both sockets, so its rows can come off either. A kill aimed
     // only at `nodeterm-rmt` left every row from a host's own nodeterm-server running, after a
     // confirm that said otherwise.
     const { mgr, runs } = managerWithConn()
-    await mgr.killSessions('p1', ['abc'])
+    await mgr.killSessions('p1', ['abc'], { everySocket: true })
     expect(commands(runs)).toEqual([
       'tmux -L node-terminal kill-session -t =nt-abc',
       'tmux -L nodeterm-rmt kill-session -t =nt-abc'
     ])
   })
 
+  it('stays on the project s own socket by default', async () => {
+    // Project deletion knows its own nodes and they are all on `nodeterm-rmt`. `node-terminal` on
+    // that host belongs to a nodeterm running ON it, so a delete must not speculate there.
+    const { mgr, runs } = managerWithConn()
+    await mgr.killSessions('p1', ['abc'])
+    expect(commands(runs)).toEqual(['tmux -L nodeterm-rmt kill-session -t =nt-abc'])
+  })
+
+  it('demands a literal true — the flag comes off the wire', async () => {
+    const { mgr, runs } = managerWithConn()
+    await mgr.killSessions('p1', ['abc'], { everySocket: 'yes' as unknown as boolean })
+    expect(commands(runs)).toEqual(['tmux -L nodeterm-rmt kill-session -t =nt-abc'])
+  })
+
   it('is best-effort: a socket that refuses does not spare the others', async () => {
     // The `node-terminal` run above throws. `killSessions` must still resolve, and the sibling
     // kill must still have gone out.
     const { mgr, runs } = managerWithConn()
-    await expect(mgr.killSessions('p1', ['abc'])).resolves.toBeUndefined()
+    await expect(mgr.killSessions('p1', ['abc'], { everySocket: true })).resolves.toBeUndefined()
     expect(runs).toHaveLength(2)
   })
 
   it('covers every id it was given', async () => {
     const { mgr, runs } = managerWithConn()
-    await mgr.killSessions('p1', ['a', 'b'])
+    await mgr.killSessions('p1', ['a', 'b'], { everySocket: true })
     expect(commands(runs)).toEqual([
       'tmux -L node-terminal kill-session -t =nt-a',
       'tmux -L node-terminal kill-session -t =nt-b',

--- a/src/main/remote-ssh/ssh-project.ts
+++ b/src/main/remote-ssh/ssh-project.ts
@@ -21,7 +21,7 @@ import {
   mkDirArgs,
   exitMasterArgs,
   checkMasterArgs,
-  remoteTmuxKillArgs,
+  remoteTmuxKillEverySocketArgs,
   childArgs,
   scpArgs,
   scpDownArgs,
@@ -869,17 +869,26 @@ export class SshProjectManager {
    * regardless of whether the nodes were mounted (only the active project's nodes are). `nodeIds`
    * are raw node ids; we map each to its `nt-<id>` session name (the same name `spawnSession` /
    * `remoteTmuxHasSessionArgs` use). Best-effort per id, a missing session is ignored.
+   *
+   * The kill goes to EVERY tmux socket on the host, not just the `nodeterm-rmt` one an SSH project
+   * spawns on. Callers here know only a session NAME: project deletion knows its own nodes (always
+   * remote), but the session-memory panel passes rows swept off BOTH of the host's sockets — and a
+   * host that runs its own `nodeterm-server` keeps those sessions on `node-terminal`. Those rows
+   * used to get a confirm reading "this stops its tmux session" followed by a kill aimed at the
+   * other socket, so nothing died. See `KILL_TMUX_SOCKETS`.
    */
   async killSessions(projectId: string, nodeIds: string[]): Promise<void> {
     const c = this.conns.get(projectId)
     if (!c) return
     await Promise.all(
-      nodeIds.map((id) =>
-        this.r.run(remoteTmuxKillArgs(c.conn, c.controlPath, sessionName(id))).then(
-          () => undefined,
-          () => undefined
+      nodeIds
+        .flatMap((id) => remoteTmuxKillEverySocketArgs(c.conn, c.controlPath, sessionName(id)))
+        .map((args) =>
+          this.r.run(args).then(
+            () => undefined,
+            () => undefined
+          )
         )
-      )
     )
   }
 

--- a/src/main/remote-ssh/ssh-project.ts
+++ b/src/main/remote-ssh/ssh-project.ts
@@ -21,6 +21,7 @@ import {
   mkDirArgs,
   exitMasterArgs,
   checkMasterArgs,
+  remoteTmuxKillArgs,
   remoteTmuxKillEverySocketArgs,
   childArgs,
   scpArgs,
@@ -870,19 +871,31 @@ export class SshProjectManager {
    * are raw node ids; we map each to its `nt-<id>` session name (the same name `spawnSession` /
    * `remoteTmuxHasSessionArgs` use). Best-effort per id, a missing session is ignored.
    *
-   * The kill goes to EVERY tmux socket on the host, not just the `nodeterm-rmt` one an SSH project
-   * spawns on. Callers here know only a session NAME: project deletion knows its own nodes (always
-   * remote), but the session-memory panel passes rows swept off BOTH of the host's sockets — and a
-   * host that runs its own `nodeterm-server` keeps those sessions on `node-terminal`. Those rows
-   * used to get a confirm reading "this stops its tmux session" followed by a kill aimed at the
-   * other socket, so nothing died. See `KILL_TMUX_SOCKETS`.
+   * `everySocket` widens the kill to EVERY tmux socket on the host instead of just the
+   * `nodeterm-rmt` one an SSH project spawns on, and it is **opt-in for one caller**. The
+   * session-memory panel passes rows swept off BOTH of the host's sockets — a host that runs its
+   * own `nodeterm-server` keeps those on `node-terminal` — and such a row used to get a confirm
+   * reading "this stops its tmux session" followed by a kill aimed at the other socket, so nothing
+   * died. Project deletion deliberately stays narrow: it knows its own nodes, they are all on the
+   * project's own socket, and speculating at `node-terminal` would aim at sessions belonging to a
+   * nodeterm running ON that host. See `KILL_TMUX_SOCKETS`.
    */
-  async killSessions(projectId: string, nodeIds: string[]): Promise<void> {
+  async killSessions(
+    projectId: string,
+    nodeIds: string[],
+    opts?: { everySocket?: boolean }
+  ): Promise<void> {
     const c = this.conns.get(projectId)
     if (!c) return
+    // `=== true`, not truthy: this value arrives from a renderer over IPC / the ws bridge.
+    const everySocket = opts?.everySocket === true
     await Promise.all(
       nodeIds
-        .flatMap((id) => remoteTmuxKillEverySocketArgs(c.conn, c.controlPath, sessionName(id)))
+        .flatMap((id) =>
+          everySocket
+            ? remoteTmuxKillEverySocketArgs(c.conn, c.controlPath, sessionName(id))
+            : [remoteTmuxKillArgs(c.conn, c.controlPath, sessionName(id))]
+        )
         .map((args) =>
           this.r.run(args).then(
             () => undefined,
@@ -1594,8 +1607,10 @@ export function initSshProject(
   ipcMain.handle(IPC.sshDisconnectProject, (_e, projectId: string) =>
     mgr.disconnect(projectId, { final: true })
   )
-  ipcMain.handle(IPC.sshKillSessions, (_e, projectId: string, nodeIds: string[]) =>
-    mgr.killSessions(projectId, nodeIds)
+  ipcMain.handle(
+    IPC.sshKillSessions,
+    (_e, projectId: string, nodeIds: string[], opts?: { everySocket?: boolean }) =>
+      mgr.killSessions(projectId, nodeIds, opts)
   )
   ipcMain.handle(IPC.sshListDir, (_e, projectId: string, dir: string) => mgr.listDir(projectId, dir))
   ipcMain.handle(IPC.sshMkdir, (_e, projectId: string, dir: string) => mgr.makeDir(projectId, dir))

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -66,6 +66,23 @@ describe('preload sshProject passphrase wiring', () => {
     expect(h.removeListener).toHaveBeenCalledWith(IPC.sshPassphraseRequest, handler)
   })
 
+  // The desktop half of the session-memory surface. `remote` is the renderer's own "this scope is
+  // an SSH host" claim and one of the TWO independent sources the core service ORs to decide which
+  // machine answers; `projectId` is the only thing naming that machine. A preload that normalized
+  // either (dropped a `false`, defaulted the object, reordered the args) would route a remote query
+  // into a LOCAL sweep and publish this machine's sessions under the host's name — invisible to
+  // every other test, since core is handed a perfectly well-formed query.
+  it('sessionMemory forwards the query verbatim on both channels', async () => {
+    const q = { projectId: 'p1', remote: true }
+    await api.sessionMemory.read(q)
+    await api.sessionMemory.host(q)
+    expect(h.invoke).toHaveBeenCalledWith(IPC.sessionMemory, { projectId: 'p1', remote: true })
+    expect(h.invoke).toHaveBeenCalledWith(IPC.sessionMemoryHost, { projectId: 'p1', remote: true })
+    // An explicit `remote: false` is a claim too, and must not be normalized away.
+    await api.sessionMemory.read({ projectId: 'p2', remote: false })
+    expect(h.invoke).toHaveBeenCalledWith(IPC.sessionMemory, { projectId: 'p2', remote: false })
+  })
+
   it('onPassphraseDismiss subscribes the dismiss channel and forwards the requestId', () => {
     const got: { requestId: string }[] = []
     const off = api.sshProject.onPassphraseDismiss((e) => got.push(e))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,7 @@ import type {
   RecycledInfo,
   RelayPeerPending,
   RemoteUsageQuery,
+  SessionMemoryQuery,
   UpdateInfo,
   UpdateProgress,
   Workspace,
@@ -377,6 +378,14 @@ const api: NodeTerminalApi = {
       ipcRenderer.on(IPC.usageUpdate, handler)
       return () => ipcRenderer.removeListener(IPC.usageUpdate, handler)
     }
+  },
+  // The query is forwarded VERBATIM: `remote` is the renderer's own "this scope is an SSH host"
+  // claim, which the core service ORs with its own `isRemoteProject`. Normalizing it here (say,
+  // dropping a `false`, or defaulting the object) would silently re-open the misattribution this
+  // surface exists to prevent — one machine's sessions published under another's name.
+  sessionMemory: {
+    read: (q?: SessionMemoryQuery) => ipcRenderer.invoke(IPC.sessionMemory, q),
+    host: (q?: SessionMemoryQuery) => ipcRenderer.invoke(IPC.sessionMemoryHost, q)
   },
   context: {
     onUpdate: (listener) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -61,7 +61,8 @@ const api: NodeTerminalApi = {
     setFlow: (sessionId, resume, viewerId) =>
       ipcRenderer.send(IPC.ptyFlow, sessionId, resume, viewerId),
     kill: (sessionId, viewerId) => ipcRenderer.send(IPC.ptyKill, sessionId, viewerId),
-    destroy: (persistKey) => ipcRenderer.send(IPC.ptyDestroy, persistKey),
+    destroy: (persistKey, opts) =>
+      ipcRenderer.send(IPC.ptyDestroy, persistKey, opts?.everySocket === true),
     recycle: (persistKey) => ipcRenderer.send(IPC.ptyRecycle, persistKey),
     generateName: (persistKey, cwd) => ipcRenderer.invoke(IPC.ptyGenerateName, persistKey, cwd),
     generateGroupName: (memberKeys, cwd) =>
@@ -191,8 +192,8 @@ const api: NodeTerminalApi = {
     connect: (projectId, conn, remoteCwd) =>
       ipcRenderer.invoke(IPC.sshConnectProject, projectId, conn, remoteCwd),
     disconnect: (projectId) => ipcRenderer.invoke(IPC.sshDisconnectProject, projectId),
-    killSessions: (projectId, nodeIds) =>
-      ipcRenderer.invoke(IPC.sshKillSessions, projectId, nodeIds),
+    killSessions: (projectId, nodeIds, opts) =>
+      ipcRenderer.invoke(IPC.sshKillSessions, projectId, nodeIds, opts),
     listDir: (projectId, dir) => ipcRenderer.invoke(IPC.sshListDir, projectId, dir),
     mkdir: (projectId, dir) => ipcRenderer.invoke(IPC.sshMkdir, projectId, dir),
     uploadFile: (projectId, localPath, fileName) =>

--- a/src/renderer/bridge/stubs.test.ts
+++ b/src/renderer/bridge/stubs.test.ts
@@ -66,6 +66,11 @@ describe('bridge stubs', () => {
     // UpdatePolicy — a `null` here was a TypeError on every Server Edition page load.
     await expect(s.updates.getPolicy()).resolves.toEqual({ minSupported: null, mandatory: false })
     await expect(s.usage.fetch()).resolves.toBeNull()
+    // `ok:false` is load-bearing: the stub means "we could not measure", and an `ok:true` with no
+    // rows would render as "nothing on this machine is using memory" — a confident wrong answer on
+    // exactly the surface (the relay tab) where the sessions live on somebody else's machine.
+    await expect(s.sessionMemory.read()).resolves.toEqual({ ok: false, rows: [], mem: null })
+    await expect(s.sessionMemory.host()).resolves.toBeNull()
     await expect(s.license.getStatus()).rejects.toMatchObject({ code: E_UNSUPPORTED })
   })
 

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -243,6 +243,18 @@ export function buildStubApi(): Omit<
       cookieProviders: () => Promise.resolve({}),
       onUpdate: noopUnsub
     },
+    sessionMemory: {
+      // Superseded by the real WS-backed namespace in ws-bridge (the core session-memory service
+      // runs in the server shell too), so nothing reaches these in a live browser session. Kept
+      // only to satisfy `satisfies NodeTerminalApi`.
+      //
+      // Where it DOES stay in force is the relay tab, which shares this stub surface: there the
+      // renderer runs on the guest while the sessions live on the host, so answering at all would
+      // describe the wrong machine. `ok:false` / `null` are the service's own words for "could not
+      // measure" — the one honest answer, and never mistakable for "nothing is using memory".
+      read: () => Promise.resolve({ ok: false, rows: [], mem: null }),
+      host: () => Promise.resolve(null)
+    },
     claude: {
       // Overridden by the real WS-backed namespace in ws-bridge; the stub still answers with the
       // fail-open caps (never rejects) because the permission-mode gate reads it on the boot path.

--- a/src/renderer/bridge/ws-bridge.namespaces.test.ts
+++ b/src/renderer/bridge/ws-bridge.namespaces.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { buildFilesApi, buildRealApi } from './ws-bridge'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { buildFilesApi, buildRealApi, buildSessionMemoryApi } from './ws-bridge'
 import { IPC } from '../../shared/ipc'
 
 function fakeClient() {
@@ -67,5 +69,58 @@ describe('buildRealApi: workspace', () => {
     const un = api.workspace.onMigrated(() => {})
     expect(c.calls[0]).toEqual({ kind: 'subscribe', method: IPC.workspaceMigrated, args: [] })
     expect(typeof un).toBe('function')
+  })
+})
+
+describe('buildRealApi: sessionMemory', () => {
+  // A real WS namespace, not a stub: the same core service (`startSessionMemoryService`) registers
+  // both channels in the server shell, so the browser gets a genuine per-session breakdown of the
+  // machine it is served from.
+  it('read/host hit the real channels', async () => {
+    const c = fakeClient()
+    const api = buildSessionMemoryApi(c as never)
+    await api.sessionMemory.read()
+    await api.sessionMemory.host()
+    expect(c.calls.map((x) => ({ kind: x.kind, method: x.method }))).toEqual([
+      { kind: 'request', method: IPC.sessionMemory },
+      { kind: 'request', method: IPC.sessionMemoryHost }
+    ])
+  })
+
+  // The query is the ONLY thing that decides which machine answers: `projectId` names the scope and
+  // `remote` is the renderer's own "this scope is an SSH host" claim, which the service ORs with its
+  // own `isRemoteProject`. A layer that drops or rewrites either one turns a remote query into a
+  // LOCAL sweep, and the panel publishes this machine's sessions under the host's name. So the
+  // query must arrive at the RPC call byte-identical, on BOTH channels.
+  it('passes projectId and the remote flag through unmodified', async () => {
+    const c = fakeClient()
+    const api = buildSessionMemoryApi(c as never)
+    const q = { projectId: 'p1', remote: true }
+    await api.sessionMemory.read(q)
+    await api.sessionMemory.host(q)
+    expect(c.calls).toEqual([
+      { kind: 'request', method: IPC.sessionMemory, args: [{ projectId: 'p1', remote: true }] },
+      { kind: 'request', method: IPC.sessionMemoryHost, args: [{ projectId: 'p1', remote: true }] }
+    ])
+  })
+
+  // `remote: false` is a claim too ("the renderer says this is NOT an SSH scope"), and it must not
+  // be normalized away into `undefined` — the shell's own predicate still gets to say otherwise,
+  // but the renderer's answer has to reach it as written.
+  it('keeps an explicit remote:false', async () => {
+    const c = fakeClient()
+    const api = buildSessionMemoryApi(c as never)
+    await api.sessionMemory.read({ projectId: 'p2', remote: false })
+    expect(c.calls[0].args).toEqual([{ projectId: 'p2', remote: false }])
+  })
+
+  // The builder above is dead code unless it is actually spread into the assembled api. It cannot
+  // be caught by the compiler: `buildStubApi()` already supplies a `sessionMemory`, so dropping the
+  // spread leaves `NodeTerminalApi` satisfied and the STUB silently wins in every live browser
+  // session. installWsBridge needs a socket + DOM to run, so the wiring is pinned by source text.
+  it('is spread into the assembled window.nodeTerminal', () => {
+    const src = readFileSync(join(__dirname, 'ws-bridge.ts'), 'utf8')
+    const install = src.slice(src.indexOf('export async function installWsBridge'))
+    expect(install).toContain('...buildSessionMemoryApi(client)')
   })
 })

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -212,7 +212,9 @@ export function buildRealApi(
       client.cast(IPC.ptyResize, sessionId, cols, rows, viewerId),
     setFlow: (sessionId, resume, viewerId) => client.cast(IPC.ptyFlow, sessionId, resume, viewerId),
     kill: (sessionId, viewerId) => client.cast(IPC.ptyKill, sessionId, viewerId),
-    destroy: (persistKey) => client.cast(IPC.ptyDestroy, persistKey),
+    // The trailing flag rides as a plain boolean; the core handler re-checks `=== true`.
+    destroy: (persistKey, opts) =>
+      client.cast(IPC.ptyDestroy, persistKey, opts?.everySocket === true),
     recycle: (persistKey) => client.cast(IPC.ptyRecycle, persistKey),
     // No server handler — degrade gracefully (never reject the boot path).
     generateName: () => Promise.resolve(AI_NAMING_UNAVAILABLE),

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -27,6 +27,7 @@ import {
   type FilesApi,
   type FsApi,
   type GitApi,
+  type MemInfo,
   type NodeTerminalApi,
   type PresenceApi,
   type PtyApi,
@@ -36,6 +37,8 @@ import {
   type ProviderUsage,
   type RemoteAccountUsage,
   type RemoteUsageQuery,
+  type SessionMemoryQuery,
+  type SessionMemoryReport,
   type Settings,
   type SpeechApi,
   type SpeechModelInfo,
@@ -609,6 +612,31 @@ function buildUsageApi(client: RpcClient): Pick<NodeTerminalApi, 'usage'> {
 }
 
 /**
+ * Real, not a stub: the same core service (`startSessionMemoryService`) registers these channels in
+ * the server shell, so the browser gets a genuine per-session breakdown of the machine it is served
+ * from — the one it is actually looking at.
+ *
+ * The query is forwarded VERBATIM. `remote` is the renderer's own "this scope is an SSH host"
+ * claim and is one of TWO independent sources the service ORs to decide which machine answers;
+ * `projectId` is the only thing naming that machine. A layer that drops or rewrites either turns a
+ * remote query into a local sweep, and this machine's sessions get published under the host's name.
+ *
+ * Neither member catches: a transport failure must not be laundered into `{ok:false}` / `null`,
+ * which are the service's own words for "the sweep could not run" and "RAM unreadable". The panel
+ * shows a failed request as a failed request.
+ */
+export function buildSessionMemoryApi(client: RpcClient): Pick<NodeTerminalApi, 'sessionMemory'> {
+  return {
+    sessionMemory: {
+      read: (q?: SessionMemoryQuery) =>
+        client.request(IPC.sessionMemory, q) as Promise<SessionMemoryReport>,
+      host: (q?: SessionMemoryQuery) =>
+        client.request(IPC.sessionMemoryHost, q) as Promise<MemInfo | null>
+    }
+  }
+}
+
+/**
  * Build the `claude` namespace over an RpcClient. `cliCaps` is a REAL handler on the server
  * (`registerClaudeCliIpc` runs in the server shell too), so the browser resolves the very same
  * `--permission-mode auto` version gate as desktop instead of silently no-opping into "auto
@@ -779,6 +807,7 @@ export async function installWsBridge(): Promise<boolean> {
     ...buildPresenceApi(client),
     ...buildSpeechApi(client),
     ...buildUsageApi(client),
+    ...buildSessionMemoryApi(client),
     ...buildGitHubApi(client),
     // `claude` is assembled from two builders: `cliCaps` from the relay-shared one, and the
     // transcript reader from the Server-Edition-only one (which also supplies `chat`).

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -6541,7 +6541,13 @@ export function Canvas() {
   const closeSession = useCallback(
     (projectId: string, id: string, alsoOnConfirm?: () => void) => {
       setConfirm({
-        message: 'End this session? This stops its tmux session.',
+        // Both halves, because this does both: the tmux session ends AND the node is removed from
+        // its canvas (either branch below). The wording came from the sessions sidebar, where the
+        // node going too is the obvious intent — but the session-memory panel reuses this path, and
+        // there the user's intent is reclaiming RAM, for which killing the node is a side effect
+        // they have to be told about. (Keeping the node would need a second destroy path, which is
+        // deliberately NOT what this is.)
+        message: 'End this session? This stops its tmux session and removes the node from its canvas.',
         confirmLabel: 'End session',
         danger: true,
         onConfirm: () => {
@@ -6602,9 +6608,12 @@ export function Canvas() {
         return
       }
       setConfirm({
+        // The orphan wording stays as it is: there is no node to remove, which is the whole point
+        // of the row. The other branch is a node the sweep saw but this click could not resolve an
+        // owner for, so it says what the owner path says.
         message: orphan
           ? 'End this session? It has no node on any canvas — this stops its tmux session.'
-          : 'End this session? This stops its tmux session.',
+          : 'End this session? This stops its tmux session and removes the node from its canvas.',
         confirmLabel: 'End session',
         danger: true,
         onConfirm: () => {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -6588,10 +6588,13 @@ export function Canvas() {
     (nodeId: string, orphan: boolean) => {
       const store = useProjects.getState()
       const plan = planSessionKill(nodeId, store.projects, store.activeProjectId)
+      // `everySocket` on BOTH legs, and only here: the panel's rows are swept off both of the
+      // machine's tmux sockets, so a row it offers to end genuinely can be on either. Every other
+      // caller (project deletion, an ordinary node-×) knows its own nodes and stays narrow.
       const remoteKill = plan.remoteProjectId
         ? () =>
             void window.nodeTerminal.sshProject
-              .killSessions(plan.remoteProjectId!, [nodeId])
+              .killSessions(plan.remoteProjectId!, [nodeId], { everySocket: true })
               .catch(() => {})
         : undefined
       if (plan.ownerProjectId) {
@@ -6605,7 +6608,7 @@ export function Canvas() {
         confirmLabel: 'End session',
         danger: true,
         onConfirm: () => {
-          transport.destroy(nodeId)
+          transport.destroy(nodeId, { everySocket: true })
           remoteKill?.()
           // Nothing else to clean up: with no node anywhere, there is no canvas entry to remove and
           // no parked terminal to dispose. Persisted agent status is dropped anyway, since a

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -6560,6 +6560,44 @@ export function Canvas() {
     [activeProjectId, deleteNodes, writeDisk]
   )
 
+  /**
+   * End a session picked from the session-memory panel, which lists tmux sessions rather than
+   * canvas nodes — so a row may have no node behind it at all.
+   *
+   * The owner is resolved HERE, at click time, instead of being taken from the row's `orphan` flag:
+   * the panel's rows are a snapshot of the last sweep, and a node created since would otherwise be
+   * killed as an orphan — tmux dies, the canvas node stays, pointing at nothing. When there IS an
+   * owner this goes through `closeSession`, i.e. the exact path the sessions sidebar and the node's
+   * own × use (confirm → destroy → drop the node), so the panel can never invent a third one.
+   */
+  const killSessionById = useCallback(
+    (nodeId: string, orphan: boolean) => {
+      const owner = useProjects
+        .getState()
+        .projects.find((p) => p.nodes.some((n) => n.id === nodeId))
+      if (owner) {
+        closeSession(owner.id, nodeId)
+        return
+      }
+      setConfirm({
+        message: orphan
+          ? 'End this session? It has no node on any canvas — this stops its tmux session.'
+          : 'End this session? This stops its tmux session.',
+        confirmLabel: 'End session',
+        danger: true,
+        onConfirm: () => {
+          transport.destroy(nodeId)
+          // Nothing else to clean up: with no node anywhere, there is no canvas entry to remove and
+          // no parked terminal to dispose. Persisted agent status is dropped anyway, since a
+          // session id can outlive the node it belonged to.
+          useAgentStatus.getState().remove(nodeId)
+          setConfirm(null)
+        }
+      })
+    },
+    [closeSession, setConfirm]
+  )
+
   const renameSession = useCallback(
     (projectId: string, id: string, title: string) => {
       if (projectId === activeProjectId) {
@@ -7897,7 +7935,14 @@ export function Canvas() {
             parks a node underneath either pill. */}
         <div className="canvas-pills" data-canvas-chrome>
           <UsageIndicator overBoard={kanbanOpen} />
-          <SystemResourcePill overBoard={kanbanOpen} />
+          {/* `travelToNode`, not `focusNodeById`: the panel resolves sessions in CLOSED projects
+              too (their tmux sessions keep running), and reaching one means reopening its tab
+              first — the same path a notification click and a peer jump take. */}
+          <SystemResourcePill
+            overBoard={kanbanOpen}
+            onGoToNode={travelToNode}
+            onKillSession={killSessionById}
+          />
         </div>
 
         <PresenceNamePrompt />

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -140,6 +140,7 @@ import {
   viewportForRect,
   type FocusableNode
 } from '../lib/nodeFocus'
+import { planSessionKill } from '../lib/sessionKill'
 import { RemoteAccessDialog } from '../components/RemoteAccessDialog'
 import { SshProjectDialog } from '../components/SshProjectDialog'
 import { SshPassphrasePrompt } from '../components/SshPassphrasePrompt'
@@ -6538,7 +6539,7 @@ export function Canvas() {
   // Close (end) a session. tmux sessions are keyed by node id, so destroy works for an
   // inactive project's node even though it isn't mounted; then drop it from the store.
   const closeSession = useCallback(
-    (projectId: string, id: string) => {
+    (projectId: string, id: string, alsoOnConfirm?: () => void) => {
       setConfirm({
         message: 'End this session? This stops its tmux session.',
         confirmLabel: 'End session',
@@ -6553,6 +6554,10 @@ export function Canvas() {
             useProjects.getState().removeNode(projectId, id)
             void writeDisk()
           }
+          // The session-memory panel's remote leg (see `killSessionById`): the local destroy above
+          // cannot reach a HOST's tmux session unless a live client carries `sshRemote`. Runs only
+          // after the user confirmed, which is why it is a callback and not done at the call site.
+          alsoOnConfirm?.()
           setConfirm(null)
         }
       })
@@ -6561,22 +6566,36 @@ export function Canvas() {
   )
 
   /**
-   * End a session picked from the session-memory panel, which lists tmux sessions rather than
-   * canvas nodes — so a row may have no node behind it at all.
+   * End a session picked from the session-memory panel, which lists tmux SESSIONS rather than
+   * canvas nodes — so a row may have no node behind it at all, and (on an SSH project) may not even
+   * be on this machine.
    *
-   * The owner is resolved HERE, at click time, instead of being taken from the row's `orphan` flag:
-   * the panel's rows are a snapshot of the last sweep, and a node created since would otherwise be
-   * killed as an orphan — tmux dies, the canvas node stays, pointing at nothing. When there IS an
-   * owner this goes through `closeSession`, i.e. the exact path the sessions sidebar and the node's
-   * own × use (confirm → destroy → drop the node), so the panel can never invent a third one.
+   * Both halves of the plan are the pure `planSessionKill`:
+   *
+   * - **Who owns it** is resolved HERE, at click time, rather than taken from the row's `orphan`
+   *   flag: the rows are a snapshot of the last sweep, and a node created since would otherwise be
+   *   killed as an orphan. With an owner this goes through `closeSession` — the exact path the
+   *   sessions sidebar and the node's own × use — so the panel never invents a third one.
+   * - **Which machine** is the ACTIVE project's, because that is the machine the panel is showing.
+   *   `transport.destroy` reaches a REMOTE session only through a live client carrying `sshRemote`,
+   *   which an orphan and an unmounted node both lack — so on an SSH scope the kill would have
+   *   touched only the local socket while the host's `nt-<id>` kept running, after a confirm that
+   *   said otherwise. `sshProject.killSessions` runs `tmux kill-session` over that project's own
+   *   ControlMaster and needs no live session; it is best-effort per id, so running it for the
+   *   mounted case too (where `destroy` already ended it) is a harmless miss.
    */
   const killSessionById = useCallback(
     (nodeId: string, orphan: boolean) => {
-      const owner = useProjects
-        .getState()
-        .projects.find((p) => p.nodes.some((n) => n.id === nodeId))
-      if (owner) {
-        closeSession(owner.id, nodeId)
+      const store = useProjects.getState()
+      const plan = planSessionKill(nodeId, store.projects, store.activeProjectId)
+      const remoteKill = plan.remoteProjectId
+        ? () =>
+            void window.nodeTerminal.sshProject
+              .killSessions(plan.remoteProjectId!, [nodeId])
+              .catch(() => {})
+        : undefined
+      if (plan.ownerProjectId) {
+        closeSession(plan.ownerProjectId, nodeId, remoteKill)
         return
       }
       setConfirm({
@@ -6587,6 +6606,7 @@ export function Canvas() {
         danger: true,
         onConfirm: () => {
           transport.destroy(nodeId)
+          remoteKill?.()
           // Nothing else to clean up: with no node anywhere, there is no canvas entry to remove and
           // no parked terminal to dispose. Persisted agent status is dropped anyway, since a
           // session id can outlive the node it belonged to.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7966,7 +7966,6 @@ export function Canvas() {
             obstacle rect (instead of one per pill, overlapping after inflation), so fitView never
             parks a node underneath either pill. */}
         <div className="canvas-pills" data-canvas-chrome>
-          <UsageIndicator overBoard={kanbanOpen} />
           {/* `travelToNode`, not `focusNodeById`: the panel resolves sessions in CLOSED projects
               too (their tmux sessions keep running), and reaching one means reopening its tab
               first — the same path a notification click and a peer jump take. */}
@@ -7975,7 +7974,9 @@ export function Canvas() {
             onGoToNode={travelToNode}
             onKillSession={killSessionById}
           />
-        </div>
+        
+          <UsageIndicator overBoard={kanbanOpen} />
+</div>
 
         <PresenceNamePrompt />
 

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -127,6 +127,7 @@ import { NotifyConsentDialog } from '../components/NotifyConsentDialog'
 import { SessionsSidebar } from '../components/SessionsSidebar'
 import type { SessionNodeInput } from '../lib/sessionList'
 import { UsageIndicator } from '../components/UsageIndicator'
+import { SystemResourcePill } from '../components/SystemResourcePill'
 import { PresenceLayer } from '../components/PresenceLayer'
 import { Facepile } from '../components/Facepile'
 import { PresenceNamePrompt } from '../components/PresenceNamePrompt'
@@ -7886,11 +7887,15 @@ export function Canvas() {
         {/* MUST stay OUTSIDE <ReactFlow>. The library's wrapper carries inline
             `position: relative; z-index: 0`, which makes the whole flow one stacking context
             painted at 0 among flow-wrap's siblings — so no z-index INSIDE it, however large,
-            can ever rise above the sessions sidebar (z 12). Mounted here, the indicator's own
+            can ever rise above the sessions sidebar (z 12). Mounted here, each pill's own
             z-index (5 collapsed, 13 with the popover open) competes in the same context as the
-            sidebar and the open popover wins. It uses no React Flow hooks, and .flow-wrap is
-            position:relative, so its absolute left/bottom anchors are unchanged. */}
-        <UsageIndicator overBoard={kanbanOpen} />
+            sidebar and the open popover wins. Neither uses React Flow hooks, and .flow-wrap is
+            position:relative, so the cluster's absolute left/bottom anchor is unchanged.
+            The cluster itself deliberately has NO z-index — see .canvas-pills in styles.css. */}
+        <div className="canvas-pills">
+          <UsageIndicator overBoard={kanbanOpen} />
+          <SystemResourcePill overBoard={kanbanOpen} />
+        </div>
 
         <PresenceNamePrompt />
 

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7891,8 +7891,11 @@ export function Canvas() {
             z-index (5 collapsed, 13 with the popover open) competes in the same context as the
             sidebar and the open popover wins. Neither uses React Flow hooks, and .flow-wrap is
             position:relative, so the cluster's absolute left/bottom anchor is unchanged.
-            The cluster itself deliberately has NO z-index — see .canvas-pills in styles.css. */}
-        <div className="canvas-pills">
+            The cluster itself deliberately has NO z-index — see .canvas-pills in styles.css.
+            `data-canvas-chrome` is fit-view's own documented opt-in: it makes the whole cluster ONE
+            obstacle rect (instead of one per pill, overlapping after inflation), so fitView never
+            parks a node underneath either pill. */}
+        <div className="canvas-pills" data-canvas-chrome>
           <UsageIndicator overBoard={kanbanOpen} />
           <SystemResourcePill overBoard={kanbanOpen} />
         </div>

--- a/src/renderer/canvas/canvas-chrome.test.tsx
+++ b/src/renderer/canvas/canvas-chrome.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+//
+// Two things Canvas.tsx wires that nothing else could see it stop wiring.
+//
+// Canvas is a monolith with no render harness, so the pieces below are pinned where they live: the
+// chrome opt-in by RENDERING the cluster that carries it and asking `chromeObstacles` for it, and
+// the wiring by reading the call site. A source read is a weak test in general, but it is the only
+// thing standing between a one-character deletion and a silently reintroduced bug — which is
+// exactly the shape that survived the whole suite once on this branch already.
+import fs from 'fs'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { chromeObstacles, FIT_VIEW_GAP } from './fit-view'
+
+const CANVAS_SRC = fs.readFileSync(path.join(__dirname, 'Canvas.tsx'), 'utf8')
+
+/** jsdom lays nothing out, so every rect is 0×0 and `chromeObstacles`'s size filter would drop the
+ *  element. Give it the measurement a real bottom-left pill cluster has. */
+function measured(el: Element, r: { left: number; top: number; right: number; bottom: number }): void {
+  el.getBoundingClientRect = () =>
+    ({ ...r, width: r.right - r.left, height: r.bottom - r.top, x: r.left, y: r.top }) as DOMRect
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('the canvas pill cluster is fit-view chrome', () => {
+  const VIEWPORT = { left: 0, top: 0, right: 1200, bottom: 800 }
+  const PILLS = { left: 60, top: 740, right: 300, bottom: 766 }
+
+  it('is picked up as an obstacle through data-canvas-chrome', () => {
+    // Exactly the markup Canvas renders: the ATTRIBUTE is the whole opt-in — `.canvas-pills` is not
+    // in CANVAS_CHROME_SELECTOR, so nothing else can reach this element.
+    document.body.innerHTML = '<div class="canvas-pills" data-canvas-chrome></div>'
+    const el = document.querySelector('.canvas-pills')!
+    measured(el, PILLS)
+    const obstacles = chromeObstacles(VIEWPORT)
+    expect(obstacles).toHaveLength(1)
+    // Inflated by the gap, so fitView keeps content clear of the pills rather than flush against.
+    expect(obstacles[0]).toEqual({
+      left: PILLS.left - FIT_VIEW_GAP,
+      top: PILLS.top - FIT_VIEW_GAP,
+      right: PILLS.right + FIT_VIEW_GAP,
+      bottom: PILLS.bottom + FIT_VIEW_GAP
+    })
+  })
+
+  it('is invisible to fit-view without the attribute', () => {
+    // The failure this pins: dropping `data-canvas-chrome` leaves a rendering, clickable cluster and
+    // a fitView that parks nodes underneath it — no error, no test, nothing to notice.
+    document.body.innerHTML = '<div class="canvas-pills"></div>'
+    measured(document.querySelector('.canvas-pills')!, PILLS)
+    expect(chromeObstacles(VIEWPORT)).toEqual([])
+  })
+
+  it('is what Canvas actually renders', () => {
+    expect(CANVAS_SRC).toContain('<div className="canvas-pills" data-canvas-chrome>')
+  })
+})
+
+describe('the session-memory panel is the one caller that fans a kill across sockets', () => {
+  // Both legs of the panel's speculative kill (see `localKillSockets`): its rows are swept off BOTH
+  // of the machine's tmux sockets, so a row it offers to end can be on either. Every other caller
+  // knows its own nodes and must stay narrow, which is why the flag is opt-in — and why dropping it
+  // here restores the exact bug the confirm used to lie about, with the whole suite green.
+  it('asks for every socket on the local destroy and the remote kill', () => {
+    expect(CANVAS_SRC).toContain("transport.destroy(nodeId, { everySocket: true })")
+    expect(CANVAS_SRC).toContain(
+      ".killSessions(plan.remoteProjectId!, [nodeId], { everySocket: true })"
+    )
+  })
+
+  it('leaves project deletion narrow', () => {
+    // The other `killSessions` call site (deleteProject) passes ids and nothing else. `node-terminal`
+    // on that host belongs to a nodeterm running ON it, not to the project being deleted.
+    expect(CANVAS_SRC).toContain('.killSessions(id, nodeIds)')
+  })
+})

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -77,3 +77,20 @@ describe('the session-memory panel is the one caller that fans a kill across soc
     expect(CANVAS_SRC).toContain('.killSessions(id, nodeIds)')
   })
 })
+
+describe('the end-session confirm describes both things it does', () => {
+  // `closeSession` stops the tmux session AND deletes the canvas node. The wording is inherited
+  // from the sessions sidebar, where deleting the node is the obvious intent — but the
+  // session-memory panel reuses the same path, and there the user came to reclaim RAM. Saying only
+  // "this stops its tmux session" makes the node's removal a surprise on the one surface whose
+  // purpose invites it. (Keeping the node would need a SECOND destroy path; deliberately not built.)
+  it('says the node goes too, on every owned-session confirm', () => {
+    const owned = CANVAS_SRC.match(/End this session\?[^']*/g) ?? []
+    expect(owned.length).toBeGreaterThanOrEqual(3)
+    for (const m of owned) {
+      // The orphan row is the one exception, and it is honest: there is no node to remove.
+      if (m.includes('no node on any canvas')) continue
+      expect(m).toContain('removes the node from its canvas')
+    }
+  })
+})

--- a/src/renderer/canvas/fit-view.ts
+++ b/src/renderer/canvas/fit-view.ts
@@ -20,6 +20,7 @@ export const CANVAS_CHROME_SELECTOR = [
   '.minimap',
   '.react-flow__controls',
   '.usage-indicator',
+  '.sysres-indicator',
   '.controls-cluster',
   '.sessions-sidebar',
   '.sessions-icon-cluster',

--- a/src/renderer/canvas/fit-view.ts
+++ b/src/renderer/canvas/fit-view.ts
@@ -19,8 +19,10 @@ export const CANVAS_CHROME_SELECTOR = [
   '.dock',
   '.minimap',
   '.react-flow__controls',
-  '.usage-indicator',
-  '.sysres-indicator',
+  // The bottom-left pill cluster (usage + system resources) opts in via `data-canvas-chrome` on its
+  // wrapper, so the two pills are ONE obstacle rect instead of two overlapping inflated ones. The
+  // wrapper's border box is exactly their union (they are its only, in-flow, children), and an
+  // empty cluster measures 0 and is dropped by the size filter below.
   '.controls-cluster',
   '.sessions-sidebar',
   '.sessions-icon-cluster',

--- a/src/renderer/components/SessionMemoryPanel.test.tsx
+++ b/src/renderer/components/SessionMemoryPanel.test.tsx
@@ -325,6 +325,24 @@ describe('SessionMemoryPanel', () => {
     expect(host.querySelector('.sessmem-panel__count')?.textContent).toBe('4 sessions')
   })
 
+  // The feature's own premise: the user who prompted it blamed nodeterm for memory that is the
+  // agent CLI's own V8 heap. Numbers rendered inside nodeterm's chrome with nothing said about
+  // whose they are let this panel repeat the mistake it exists to correct, and that fact lived only
+  // in the docs.
+  it('says whose memory it is showing', () => {
+    mount()
+    const attrib = host.querySelector('.sessmem-panel__attrib')?.textContent ?? ''
+    expect(attrib).toMatch(/not nodeterm/i)
+  })
+
+  it('says it in EVERY state, including a failed sweep', () => {
+    // A failed measurement is exactly when a user is most likely to be blaming the wrong process,
+    // so the line must not hang off the rows.
+    mount({ ok: false, rows: [] })
+    expect(host.querySelector('.sessmem-panel__note')?.textContent).toContain('Could not measure')
+    expect(host.querySelector('.sessmem-panel__attrib')?.textContent ?? '').toMatch(/not nodeterm/i)
+  })
+
   it('never touches the host poll — the pill owns that timer', () => {
     // `timer` and `activeScope` in the store are MODULE singletons. A `stopHostPoll` here would
     // clear the pill's interval on close with nothing left to restart it, and the pill's number

--- a/src/renderer/components/SessionMemoryPanel.test.tsx
+++ b/src/renderer/components/SessionMemoryPanel.test.tsx
@@ -1,0 +1,301 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import type { Project, SessionMemoryRow } from '@shared/types'
+import { useAgentStatus } from '../state/agentStatus'
+import { useProjects } from '../state/projects'
+import { useSessionMemory } from '../state/sessionMemory'
+import { SessionMemoryPanel } from './SessionMemoryPanel'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const project = (over: Partial<Project> = {}): Project => ({
+  id: 'p1',
+  name: 'Web',
+  color: '#fff',
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: [],
+  ...over
+})
+
+const node = (id: string, title: string): Project['nodes'][number] =>
+  ({ id, kind: 'terminal', title, position: { x: 0, y: 0 } }) as unknown as Project['nodes'][number]
+
+const row = (over: Partial<SessionMemoryRow> & { nodeId: string }): SessionMemoryRow => ({
+  session: `nt-${over.nodeId}`,
+  panePid: 100,
+  selfMb: over.totalMb ?? 0,
+  childrenMb: 0,
+  childCount: 0,
+  totalMb: 0,
+  command: 'bash',
+  ...over
+})
+
+/**
+ * The FIXTURE is the whole test, so it has to discriminate every branch on its own:
+ *   - `t1` has children, so `selfMb` and `totalMb` differ (a header that summed the pane process
+ *     alone would print 1.2 GB where the truth is 1.5 GB).
+ *   - `t3` lives in a CLOSED project — the one row that proves the panel feeds `resolveSessionRows`
+ *     every project rather than the open tabs.
+ *   - `t2` is a real node with NO agent state: the row that separates "orphan" from "no state". A
+ *     fixture where every non-orphan happened to be `working` would let `state === null` pass as a
+ *     stand-in for `orphan`.
+ *   - `ghost` has no node anywhere — the actual orphan.
+ */
+const ROWS: SessionMemoryRow[] = [
+  row({ nodeId: 't1', selfMb: 600, childrenMb: 300, childCount: 2, totalMb: 900, command: 'claude' }),
+  row({ nodeId: 't3', selfMb: 500, totalMb: 500, command: 'codex' }),
+  row({ nodeId: 't2', selfMb: 120, totalMb: 120, command: 'bash' }),
+  row({ nodeId: 'ghost', selfMb: 40, totalMb: 40, command: 'zsh' })
+]
+
+const PROJECTS: Project[] = [
+  project({ id: 'p1', name: 'Web', nodes: [node('t1', 'Big agent'), node('t2', 'Plain shell')] }),
+  project({ id: 'p2', name: 'Old', closed: true, nodes: [node('t3', 'Parked session')] })
+]
+
+let host: HTMLDivElement
+let root: Root
+let onGoToNode: Mock<(nodeId: string) => void>
+let onKillSession: Mock<(nodeId: string, orphan: boolean) => void>
+let onClose: Mock<() => void>
+let refreshFull: Mock<(scopeKey: string, projectId?: string) => Promise<void>>
+let startHostPoll: Mock<(scopeKey: string, projectId?: string) => void>
+let stopHostPoll: Mock<() => void>
+
+function mount(over: Partial<ReturnType<typeof useSessionMemory.getState>> = {}): void {
+  useSessionMemory.setState({
+    ok: true,
+    rows: ROWS,
+    loadedScope: '',
+    loading: false,
+    refreshFull,
+    startHostPoll,
+    stopHostPoll,
+    ...over
+  })
+  host = document.createElement('div')
+  root = createRoot(host)
+  act(() =>
+    root.render(
+      <SessionMemoryPanel onGoToNode={onGoToNode} onKillSession={onKillSession} onClose={onClose} />
+    )
+  )
+}
+
+const rowsOf = (): HTMLElement[] => [...host.querySelectorAll<HTMLElement>('.sessmem-row')]
+const mainOf = (i: number): HTMLButtonElement =>
+  rowsOf()[i].querySelector<HTMLButtonElement>('.sessmem-row__main')!
+const killOf = (i: number): HTMLButtonElement =>
+  rowsOf()[i].querySelector<HTMLButtonElement>('.sessmem-row__kill')!
+const text = (): string => host.textContent ?? ''
+
+beforeEach(() => {
+  onGoToNode = vi.fn<(nodeId: string) => void>()
+  onKillSession = vi.fn<(nodeId: string, orphan: boolean) => void>()
+  onClose = vi.fn<() => void>()
+  refreshFull = vi.fn<(scopeKey: string, projectId?: string) => Promise<void>>(async () => {})
+  startHostPoll = vi.fn<(scopeKey: string, projectId?: string) => void>()
+  stopHostPoll = vi.fn<() => void>()
+  useProjects.setState({ projects: PROJECTS, activeProjectId: 'p1' })
+  useAgentStatus.setState({ byId: { t1: { state: 'working', unread: false } } })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+})
+
+describe('SessionMemoryPanel', () => {
+  it('renders every row in the order core sorted them', () => {
+    mount()
+    // No re-sort here: core already sorted by total descending, and a second sort would let the
+    // panel and the report disagree about which session is the biggest.
+    expect(rowsOf().map((r) => r.querySelector('.sessmem-row__title')?.textContent)).toEqual([
+      'Big agent',
+      'Parked session',
+      'Plain shell',
+      'nt-ghost'
+    ])
+    expect(rowsOf().map((r) => r.querySelector('.sessmem-row__cmd')?.textContent)).toEqual([
+      'claude',
+      'codex',
+      'bash',
+      'zsh'
+    ])
+  })
+
+  it('never truncates the list', () => {
+    // A cap would have to be a visible "showing top N" line; a silent slice would hide exactly the
+    // sessions a user opened this panel to find.
+    const many = Array.from({ length: 12 }, (_, i) =>
+      row({ nodeId: `n${i}`, selfMb: 100 - i, totalMb: 100 - i })
+    )
+    mount({ rows: many })
+    expect(rowsOf()).toHaveLength(12)
+  })
+
+  it('totals the row TOTAL, children included', () => {
+    mount()
+    // 900 + 500 + 120 + 40 = 1560 MB. Summing `selfMb` instead would print 1.2 GB.
+    expect(host.querySelector('.sessmem-panel__total')?.textContent).toBe('1.5 GB')
+  })
+
+  it("resolves a CLOSED project's session to its real title", () => {
+    // closeProject keeps the project and its nodes on disk. Passing only the open tabs would turn
+    // every parked session into an orphan — silently, in this file, with the suite green.
+    mount()
+    const parked = rowsOf()[1]
+    expect(parked.querySelector('.sessmem-row__title')?.textContent).toBe('Parked session')
+    expect(parked.querySelector('.sessmem-row__project')?.textContent).toBe('Old')
+    expect(mainOf(1).disabled).toBe(false)
+    expect(parked.querySelector('.sessmem-row__orphan')).toBeNull()
+  })
+
+  it('reads orphan-ness from the row, never from a missing agent state', () => {
+    mount()
+    // `t2` is a plain terminal: a real node with a real title that never enters the agent-status
+    // map. Deriving orphan-ness from `state === null` would flag it — and every other plain
+    // terminal on the canvas — as a session with nowhere to travel.
+    expect(mainOf(2).disabled).toBe(false)
+    expect(rowsOf()[2].querySelector('.sessmem-row__orphan')).toBeNull()
+    expect(rowsOf()[2].querySelector('.sessmem-row__dot--hollow')).toBeNull()
+    // The real orphan, by contrast.
+    expect(mainOf(3).disabled).toBe(true)
+    expect(rowsOf()[3].querySelector('.sessmem-row__orphan')).not.toBeNull()
+    expect(rowsOf()[3].querySelector('.sessmem-row__dot--hollow')).not.toBeNull()
+  })
+
+  it('travels to a resolvable row and closes', () => {
+    mount()
+    act(() => mainOf(0).click())
+    expect(onGoToNode).toHaveBeenCalledWith('t1')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('travels to a CLOSED project session too', () => {
+    mount()
+    act(() => mainOf(1).click())
+    expect(onGoToNode).toHaveBeenCalledWith('t3')
+  })
+
+  it('leaves an orphan row inert but still killable', () => {
+    mount()
+    act(() => mainOf(3).click())
+    expect(onGoToNode).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+    act(() => killOf(3).click())
+    expect(onKillSession).toHaveBeenCalledWith('ghost', true)
+  })
+
+  it('kills a resolvable row as a non-orphan', () => {
+    mount()
+    act(() => killOf(0).click())
+    expect(onKillSession).toHaveBeenCalledWith('t1', false)
+    // Killing is not travelling: the panel stays put behind its confirm dialog.
+    expect(onGoToNode).not.toHaveBeenCalled()
+  })
+
+  it('names the extra processes as CHILD processes, not as MCP servers', () => {
+    mount()
+    // `childCount` counts every descendant of the pane — the agent CLI itself plus whatever it
+    // spawned — because `pane_pid` is the pane's SHELL. Calling them MCP servers would miscount
+    // (claude + 2 MCP servers reads as 3) and mislabel a plain `npm run dev`.
+    const kids = rowsOf()[0].querySelector('.sessmem-row__kids')?.textContent ?? ''
+    expect(kids).toContain('2 child processes')
+    expect(kids).toContain('300.0 MB')
+    expect(text()).not.toContain('MCP')
+    // Only the row that has children gets the sub-line.
+    expect(host.querySelectorAll('.sessmem-row__kids')).toHaveLength(1)
+  })
+
+  it('says it could not measure — never an empty list, never a zero', () => {
+    mount({ ok: false, rows: [], loadedScope: null })
+    expect(text()).toContain('Could not measure')
+    expect(rowsOf()).toHaveLength(0)
+    expect(host.querySelector('.sessmem-panel__total')).toBeNull()
+    expect(text()).not.toContain('0 MB')
+    expect(text()).not.toContain('0 sessions')
+    // "We could not look" is the one state where the retry matters most.
+    expect(host.querySelector<HTMLButtonElement>('.sessmem-panel__refresh')?.disabled).toBe(false)
+  })
+
+  it('distinguishes a measured-empty machine from a failed sweep', () => {
+    mount({ ok: true, rows: [], loadedScope: '' })
+    expect(text()).not.toContain('Could not measure')
+    expect(text()).toContain('No sessions')
+  })
+
+  it('says nothing at all before the first sweep lands', () => {
+    // `rows: []` with nothing loaded yet is not "there are no sessions" either.
+    mount({ ok: true, rows: [], loadedScope: null, loading: true })
+    expect(text()).not.toContain('No sessions')
+    expect(text()).not.toContain('Could not measure')
+    expect(text()).toContain('Measuring')
+  })
+
+  it('tells a relay tab it is unsupported here, not that the measurement failed', () => {
+    // A relay tab's renderer runs on the guest while its sessions live on the host, so its
+    // sessionMemory api is the ws-bridge stub: a permanent `ok:false`. That is the honest STUB
+    // value and the wrong user-facing story — there is nothing to retry.
+    useProjects.setState({
+      projects: [project({ id: 'r1', name: 'Mac', remote: true })],
+      activeProjectId: 'r1'
+    })
+    mount({ ok: false, rows: [], loadedScope: null })
+    expect(text()).not.toContain('Could not measure')
+    expect(text()).toContain('relay')
+    expect(host.querySelector('.sessmem-panel__refresh')).toBeNull()
+    // No point sweeping a machine whose answer is a stub.
+    expect(refreshFull).not.toHaveBeenCalled()
+  })
+
+  it('sweeps on open and on refresh, always naming the project', () => {
+    mount()
+    expect(refreshFull).toHaveBeenCalledTimes(1)
+    // The project id is explicit: the store's `activeSessionApi()` fallback is the one path that
+    // can address the wrong machine.
+    expect(refreshFull).toHaveBeenCalledWith('', 'p1')
+    act(() => host.querySelector<HTMLButtonElement>('.sessmem-panel__refresh')!.click())
+    expect(refreshFull).toHaveBeenCalledTimes(2)
+    expect(refreshFull).toHaveBeenLastCalledWith('', 'p1')
+  })
+
+  it('scopes the sweep and the header to an SSH project´s host', () => {
+    useProjects.setState({
+      projects: [
+        project({
+          id: 'ssh1',
+          name: 'Box',
+          ssh: { server: { host: 'box', user: 'enes', port: 22 } as never, remoteCwd: '/srv' }
+        })
+      ],
+      activeProjectId: 'ssh1'
+    })
+    mount({ loadedScope: 'enes@box' })
+    expect(refreshFull).toHaveBeenCalledWith('enes@box', 'ssh1')
+    expect(host.querySelector('.sessmem-panel__scope')?.textContent).toBe('enes@box')
+  })
+
+  it('labels the local scope as this machine', () => {
+    mount()
+    expect(host.querySelector('.sessmem-panel__scope')?.textContent).toBe('This machine')
+  })
+
+  it('counts the sessions it is showing', () => {
+    mount()
+    expect(host.querySelector('.sessmem-panel__count')?.textContent).toBe('4 sessions')
+  })
+
+  it('never touches the host poll — the pill owns that timer', () => {
+    // `timer` and `activeScope` in the store are MODULE singletons. A `stopHostPoll` here would
+    // clear the pill's interval on close with nothing left to restart it, and the pill's number
+    // would freeze until the next scope change.
+    mount()
+    act(() => root.unmount())
+    expect(startHostPoll).not.toHaveBeenCalled()
+    expect(stopHostPoll).not.toHaveBeenCalled()
+    root = createRoot(document.createElement('div'))
+  })
+})

--- a/src/renderer/components/SessionMemoryPanel.test.tsx
+++ b/src/renderer/components/SessionMemoryPanel.test.tsx
@@ -211,12 +211,20 @@ describe('SessionMemoryPanel', () => {
   })
 
   it('says it could not measure — never an empty list, never a zero', () => {
-    mount({ ok: false, rows: [], loadedScope: null })
+    // `loadedScope: ''` on purpose, and it is the realistic shape: the store's failure path sets
+    // `ok:false, rows:[]` and leaves `loadedScope` where the last SUCCESSFUL sweep put it. So a
+    // panel that decided "have we measured?" from the scope stamp alone would find a match here and
+    // render a confident `0 MB` / `0 sessions` over a sweep that failed — with a `loadedScope: null`
+    // fixture it would have fallen into "Measuring…" and passed.
+    mount({ ok: false, rows: [], loadedScope: '' })
     expect(text()).toContain('Could not measure')
     expect(rowsOf()).toHaveLength(0)
     expect(host.querySelector('.sessmem-panel__total')).toBeNull()
-    expect(text()).not.toContain('0 MB')
     expect(text()).not.toContain('0 sessions')
+    // Not `not.toContain('0 MB')`: `formatBytes(0)` is "0 B", so spelling one unit would have let
+    // the zero through. Without a reading there is no number we are entitled to print at all —
+    // the same rule the pill holds itself to.
+    expect(text()).not.toMatch(/\d/)
     // "We could not look" is the one state where the retry matters most.
     expect(host.querySelector<HTMLButtonElement>('.sessmem-panel__refresh')?.disabled).toBe(false)
   })
@@ -245,6 +253,7 @@ describe('SessionMemoryPanel', () => {
     })
     mount({ ok: false, rows: [], loadedScope: null })
     expect(text()).not.toContain('Could not measure')
+    expect(text()).not.toContain('Measuring')
     expect(text()).toContain('relay')
     expect(host.querySelector('.sessmem-panel__refresh')).toBeNull()
     // No point sweeping a machine whose answer is a stub.

--- a/src/renderer/components/SessionMemoryPanel.test.tsx
+++ b/src/renderer/components/SessionMemoryPanel.test.tsx
@@ -241,6 +241,34 @@ describe('SessionMemoryPanel', () => {
     expect(text()).not.toContain('No sessions')
     expect(text()).not.toContain('Could not measure')
     expect(text()).toContain('Measuring')
+    // …and the header and footer have to stay silent too. `ok` is still TRUE in this state, so a
+    // total or a count gated on `ok` instead of on "did we measure THIS machine" prints `0 B` /
+    // `0 sessions` beside "Measuring…" — the same conflation, one state along.
+    expect(host.querySelector('.sessmem-panel__total')).toBeNull()
+    expect(text()).not.toContain('0 sessions')
+    expect(text()).not.toMatch(/\d/)
+  })
+
+  it('disables the refresh and spins it while a sweep is in flight', () => {
+    // A remote sweep is an ssh exec plus a `ps` on someone else's machine. Without this the user
+    // can queue several by clicking, and nothing on screen says one is already running.
+    mount({ loading: true })
+    const refresh = host.querySelector<HTMLButtonElement>('.sessmem-panel__refresh')!
+    expect(refresh.disabled).toBe(true)
+    expect(refresh.classList.contains('spin')).toBe(true)
+    act(() => refresh.click())
+    expect(refreshFull).toHaveBeenCalledTimes(1) // the mount sweep, and nothing the click added
+  })
+
+  it('refuses to sweep with no active project — never through the api fallback', () => {
+    // Unreachable from the pill today (it renders nothing without an active project), but this is
+    // the one call that could fall through to the store's `activeSessionApi()`, which is the single
+    // path able to address the wrong machine. The mount effect always guarded it; the ⟳ did not.
+    useProjects.setState({ projects: [], activeProjectId: '' })
+    mount()
+    expect(refreshFull).not.toHaveBeenCalled()
+    act(() => host.querySelector<HTMLButtonElement>('.sessmem-panel__refresh')!.click())
+    expect(refreshFull).not.toHaveBeenCalled()
   })
 
   it('tells a relay tab it is unsupported here, not that the measurement failed', () => {

--- a/src/renderer/components/SessionMemoryPanel.tsx
+++ b/src/renderer/components/SessionMemoryPanel.tsx
@@ -9,7 +9,7 @@
 //      never enters the agent-status map at all.
 //   3. Every row is rendered. A cap would have to announce itself.
 
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import type { AgentState } from '@shared/agents/normalize'
 import { formatBytes } from '@shared/fsLimits'
 import { useAgentStatus } from '../state/agentStatus'
@@ -92,15 +92,17 @@ export function SessionMemoryPanel({
   // The sweep runs on OPEN (the panel is unmounted while closed) and on ⟳ — never on a timer, and
   // never from the pill: it walks the whole process table, and on an SSH scope that is an ssh exec
   // plus a `ps` of somebody else's machine. The project id is explicit, because the store's
-  // `activeSessionApi()` fallback is the one path that can address the wrong machine.
+  // `activeSessionApi()` fallback is the one path that can address the wrong machine — so BOTH
+  // callers go through this one guarded function instead of each repeating the condition.
   //
   // This component must NEVER call `startHostPoll` / `stopHostPoll`: the store's timer and its
   // active-scope stamp are module singletons owned by the pill, and a `stopHostPoll` on unmount
   // would clear the pill's interval with nothing left to restart it.
-  useEffect(() => {
+  const sweep = useCallback(() => {
     if (relay || !activeProjectId) return
     void refreshFull(scopeKey, activeProjectId)
   }, [relay, scopeKey, activeProjectId, refreshFull])
+  useEffect(() => sweep(), [sweep])
 
   // Have we got an answer for THIS machine yet? A `loadedScope` from the machine we just left says
   // nothing about this one, so it is compared, not merely checked for existence.
@@ -199,7 +201,7 @@ export function SessionMemoryPanel({
             title="Re-measure"
             aria-label="Re-measure"
             disabled={loading}
-            onClick={() => void refreshFull(scopeKey, activeProjectId)}
+            onClick={sweep}
           >
             ⟳
           </button>

--- a/src/renderer/components/SessionMemoryPanel.tsx
+++ b/src/renderer/components/SessionMemoryPanel.tsx
@@ -190,6 +190,17 @@ export function SessionMemoryPanel({
 
       {body}
 
+      {/* Whose memory this is. The feature exists because a user reported "Claude terminals are
+          killing my memory" — their NUMBER was right and their attribution was wrong: it is the
+          agent CLI's own V8 heap, and nodeterm allocates none of it. Showing those numbers inside
+          nodeterm's chrome with nothing said about it lets the panel repeat the mistake it was
+          built to correct. One line, no figures: the measurements vary per machine and per model,
+          and quoting one here would age into a lie (docs/session-memory.md §1 has them). */}
+      <div className="sessmem-panel__attrib">
+        Memory held by each session's own processes — the agent CLI and what it spawned, not
+        nodeterm itself.
+      </div>
+
       <div className="sessmem-panel__foot">
         <span className="sessmem-panel__count">
           {measured ? `${views.length} session${views.length === 1 ? '' : 's'}` : ''}

--- a/src/renderer/components/SessionMemoryPanel.tsx
+++ b/src/renderer/components/SessionMemoryPanel.tsx
@@ -1,0 +1,210 @@
+// The panel behind the system-resource pill: which sessions are holding the machine's memory,
+// biggest first, each one travelable and killable.
+//
+// Three rules run through the whole file, and each of them is a fact this feature exists to stop
+// the app from getting wrong:
+//   1. "We could not look" and "there is nothing" are DIFFERENT ANSWERS. A failed sweep says so —
+//      it never degrades into an empty list, a `0 MB` total or a "0 sessions" count.
+//   2. Orphan-ness comes from the resolved row, never from a missing agent state: a plain terminal
+//      never enters the agent-status map at all.
+//   3. Every row is rendered. A cap would have to announce itself.
+
+import { useEffect, useMemo } from 'react'
+import type { AgentState } from '@shared/agents/normalize'
+import { formatBytes } from '@shared/fsLimits'
+import { useAgentStatus } from '../state/agentStatus'
+import { useProjects } from '../state/projects'
+import { useSessionMemory } from '../state/sessionMemory'
+import { resolveSessionRows, totalMb } from '../lib/sessionMemoryRows'
+import { usageScopeKey } from '../lib/usageScope'
+
+export interface SessionMemoryPanelProps {
+  /** Travel to the node behind a row. Canvas passes `travelToNode`, so a CLOSED project's tab is
+   *  reopened first — the panel lists those sessions, so it has to be able to reach them. */
+  onGoToNode: (nodeId: string) => void
+  /** Confirm + end the session. `orphan` says whether the panel believes there is a node behind it;
+   *  Canvas re-resolves the owner at click time and only uses this for the wording. */
+  onKillSession: (nodeId: string, orphan: boolean) => void
+  onClose: () => void
+}
+
+/** Every number in this feature is MB; `formatBytes` speaks bytes. One formatter, so the panel's
+ *  units read like the rest of the app. */
+function formatMb(mb: number): string {
+  return formatBytes(mb * 1024 * 1024)
+}
+
+/**
+ * The node header's status vocabulary, as a dot: working is `--success`, waiting/blocked is
+ * `--warn` (the two states the header spells RUNNING and NEEDS YOU), everything else is quiet.
+ * Hollow = orphan: there is no node to have a state, and a filled neutral dot would read as "idle".
+ */
+function StatusDot({ state, hollow }: { state: AgentState | null; hollow: boolean }): JSX.Element {
+  const kind =
+    state === 'working' ? 'working' : state === 'waiting' || state === 'blocked' ? 'attention' : 'idle'
+  return (
+    <span
+      className={`sessmem-row__dot sessmem-row__dot--${kind}${hollow ? ' sessmem-row__dot--hollow' : ''}`}
+      aria-hidden
+    />
+  )
+}
+
+export function SessionMemoryPanel({
+  onGoToNode,
+  onKillSession,
+  onClose
+}: SessionMemoryPanelProps): JSX.Element {
+  const ok = useSessionMemory((s) => s.ok)
+  const rows = useSessionMemory((s) => s.rows)
+  const loading = useSessionMemory((s) => s.loading)
+  const loadedScope = useSessionMemory((s) => s.loadedScope)
+  const refreshFull = useSessionMemory((s) => s.refreshFull)
+
+  // EVERY project, closed ones included: `closeProject` keeps the project and its nodes on disk
+  // (only the tab goes away), so its sessions resolve to a real title. Filtering to the open tabs
+  // here would turn every deliberately parked session into an orphan.
+  const projects = useProjects((s) => s.projects)
+  const activeProjectId = useProjects((s) => s.activeProjectId)
+  const active = useMemo(
+    () => projects.find((p) => p.id === activeProjectId),
+    [projects, activeProjectId]
+  )
+  const scopeKey = usageScopeKey(active)
+  // A relay tab's renderer runs on the GUEST while its sessions live on the host, so its
+  // sessionMemory api is the ws-bridge stub — a permanent `ok:false`. That is the honest stub value
+  // and the wrong story to tell a human: nothing failed and there is nothing to retry. The runtime
+  // `remote` flag is how the rest of the renderer spots a relay tab (see TerminalNode's file links).
+  const relay = !!active?.remote
+
+  const byId = useAgentStatus((s) => s.byId)
+  // `resolveSessionRows` wants the bare states; an entry's `state` is optional, and an unknown one
+  // is null rather than a default.
+  const states = useMemo(
+    () => Object.fromEntries(Object.entries(byId).map(([id, v]) => [id, v.state])),
+    [byId]
+  )
+  const views = useMemo(
+    () => resolveSessionRows(rows, projects, states),
+    [rows, projects, states]
+  )
+
+  // The sweep runs on OPEN (the panel is unmounted while closed) and on ⟳ — never on a timer, and
+  // never from the pill: it walks the whole process table, and on an SSH scope that is an ssh exec
+  // plus a `ps` of somebody else's machine. The project id is explicit, because the store's
+  // `activeSessionApi()` fallback is the one path that can address the wrong machine.
+  //
+  // This component must NEVER call `startHostPoll` / `stopHostPoll`: the store's timer and its
+  // active-scope stamp are module singletons owned by the pill, and a `stopHostPoll` on unmount
+  // would clear the pill's interval with nothing left to restart it.
+  useEffect(() => {
+    if (relay || !activeProjectId) return
+    void refreshFull(scopeKey, activeProjectId)
+  }, [relay, scopeKey, activeProjectId, refreshFull])
+
+  // Have we got an answer for THIS machine yet? A `loadedScope` from the machine we just left says
+  // nothing about this one, so it is compared, not merely checked for existence.
+  const measured = ok && loadedScope === scopeKey
+
+  let body: JSX.Element
+  if (relay) {
+    body = (
+      <div className="sessmem-panel__note">
+        Session memory is not available on a relay tab — these sessions run on the other machine.
+      </div>
+    )
+  } else if (!ok) {
+    // Rendering an empty list here would report "nothing is using memory" at exactly the moment we
+    // failed to measure it.
+    body = <div className="sessmem-panel__note">Could not measure sessions on this machine.</div>
+  } else if (!measured) {
+    body = <div className="sessmem-panel__note">Measuring…</div>
+  } else if (views.length === 0) {
+    // We looked, and there really is nothing — a different sentence from the two above.
+    body = <div className="sessmem-panel__note">No sessions are running here.</div>
+  } else {
+    body = (
+      <ul className="sessmem-panel__rows">
+        {/* Every row, in core's order (already sorted by total, descending). */}
+        {views.map((v) => (
+          <li key={v.row.session} className="sessmem-row">
+            <button
+              className="sessmem-row__main"
+              // Nothing to travel to. The guard inside is not redundant: `disabled` is the DOM's
+              // answer and this is the code's.
+              disabled={v.orphan}
+              onClick={() => {
+                if (v.orphan) return
+                onGoToNode(v.row.nodeId)
+                onClose()
+              }}
+              title={v.orphan ? 'No node on any canvas' : `Go to ${v.title}`}
+            >
+              <StatusDot state={v.state} hollow={v.orphan} />
+              <span className="sessmem-row__title">{v.title}</span>
+              {v.orphan ? (
+                <span className="sessmem-row__orphan">no node</span>
+              ) : (
+                v.projectId !== activeProjectId && (
+                  <span className="sessmem-row__project">{v.projectName}</span>
+                )
+              )}
+              <span className="sessmem-row__cmd">{v.row.command}</span>
+              <span className="sessmem-row__mb">{formatMb(v.row.totalMb)}</span>
+            </button>
+            <button
+              className="sessmem-row__kill"
+              title="End this session"
+              aria-label={`End ${v.title}`}
+              onClick={() => onKillSession(v.row.nodeId, v.orphan)}
+            >
+              ×
+            </button>
+            {v.row.childCount > 0 && (
+              // "child processes", NOT "MCP servers": `pane_pid` is the pane's SHELL, so the count
+              // is the agent CLI itself plus everything it spawned. A claude session with two MCP
+              // servers reads as 3, and a plain `npm run dev` has children too.
+              <div className="sessmem-row__kids">
+                └ +{v.row.childCount} child processes <span>{formatMb(v.row.childrenMb)}</span>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  return (
+    <div className="sessmem-panel" id="sessmem-panel" role="region" aria-label="Session memory">
+      <div className="sessmem-panel__head">
+        <span className="sessmem-panel__title">Session memory</span>
+        {/* Which machine these numbers describe. The SSH panel is visually identical to the local
+            one, so the scope has to be written down. */}
+        <span className="sessmem-panel__scope">{scopeKey || 'This machine'}</span>
+        {/* No total unless we measured one: a grand total of `0 MB` beside a failure is the exact
+            conflation this panel exists to end. */}
+        {measured && <span className="sessmem-panel__total">{formatMb(totalMb(views))}</span>}
+      </div>
+
+      {body}
+
+      <div className="sessmem-panel__foot">
+        <span className="sessmem-panel__count">
+          {measured ? `${views.length} session${views.length === 1 ? '' : 's'}` : ''}
+        </span>
+        {/* A relay tab has nothing to retry — the answer is a stub, not a failure. */}
+        {!relay && (
+          <button
+            className={`sessmem-panel__refresh${loading ? ' spin' : ''}`}
+            title="Re-measure"
+            aria-label="Re-measure"
+            disabled={loading}
+            onClick={() => void refreshFull(scopeKey, activeProjectId)}
+          >
+            ⟳
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/SystemResourcePill.test.tsx
+++ b/src/renderer/components/SystemResourcePill.test.tsx
@@ -47,7 +47,11 @@ function mount(mem: MemInfo | null, overBoard = false): void {
   useSessionMemory.setState({ mem, startHostPoll, stopHostPoll, refreshFull })
   host = document.createElement('div')
   root = createRoot(host)
-  act(() => root.render(<SystemResourcePill overBoard={overBoard} />))
+  act(() =>
+    root.render(
+      <SystemResourcePill overBoard={overBoard} onGoToNode={vi.fn()} onKillSession={vi.fn()} />
+    )
+  )
 }
 
 beforeEach(() => {
@@ -128,16 +132,22 @@ describe('SystemResourcePill', () => {
     expect(refreshFull).not.toHaveBeenCalled()
   })
 
-  it('never runs the full sweep — the cheap read is the pill´s, the expensive one the panel´s', () => {
+  it('never runs the full sweep itself — the cheap read is the pill´s, the expensive one the panel´s', () => {
     // `refreshFull` walks the whole process table, and on an SSH scope that is an ssh exec plus a
     // remote `ps`. On this component's 30 s timer that would be a background cost nobody asked for,
     // and the real action swallows its failures, so it would show no symptom at all.
     mount(MEM)
     expect(refreshFull).not.toHaveBeenCalled()
-    // Not even when the pill is clicked: opening the panel is what triggers the sweep, and the
-    // panel does it itself (Task 9).
+    // Clicking sweeps exactly once, and the call comes from the MOUNTED PANEL — never from a
+    // second caller here that a later timer could be attached to. (The sweep-on-open contract
+    // itself is pinned in SessionMemoryPanel.test.tsx.)
     act(() => host.querySelector<HTMLButtonElement>('.sysres-pill')!.click())
-    expect(refreshFull).not.toHaveBeenCalled()
+    expect(host.querySelector('.sessmem-panel')).not.toBeNull()
+    expect(refreshFull).toHaveBeenCalledTimes(1)
+    // Closing unmounts the panel, so nothing keeps sweeping behind it.
+    act(() => host.querySelector<HTMLButtonElement>('.sysres-pill')!.click())
+    expect(host.querySelector('.sessmem-panel')).toBeNull()
+    expect(refreshFull).toHaveBeenCalledTimes(1)
   })
 
   it('renders nothing and polls nothing without an active project', () => {
@@ -163,5 +173,19 @@ describe('SystemResourcePill', () => {
     expect(host.querySelector('.sysres-pill')?.getAttribute('aria-expanded')).toBe('true')
     act(() => host.querySelector<HTMLButtonElement>('.sysres-pill')!.click())
     expect(host.querySelector('.sysres-pill')?.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('announces a region that actually exists', () => {
+    // `aria-expanded` on its own told assistive tech about an expandable region and expanded
+    // nothing. It may only ship pointing at the real panel.
+    mount(MEM)
+    const pill = host.querySelector<HTMLButtonElement>('.sysres-pill')!
+    const controls = pill.getAttribute('aria-controls')
+    expect(controls).toBeTruthy()
+    expect(host.querySelector(`#${controls}`)).toBeNull()
+    act(() => pill.click())
+    const panel = host.querySelector(`#${controls}`)
+    expect(panel).not.toBeNull()
+    expect(panel?.classList.contains('sessmem-panel')).toBe(true)
   })
 })

--- a/src/renderer/components/SystemResourcePill.test.tsx
+++ b/src/renderer/components/SystemResourcePill.test.tsx
@@ -75,10 +75,26 @@ describe('SystemResourcePill', () => {
     expect(pill?.textContent).not.toContain('46.9 GB')
   })
 
-  it('fills the bar by memory USED, not by what is free', () => {
+  it('keeps the numbers in the DOM at rest — the reveal is CSS, not a mount', () => {
+    // The collapsed pill is icon-only, but the detail must still exist: it carries the button's
+    // accessible name, and a hover-mounted number would be unreachable to a screen reader and to
+    // anything that reads the control without pointing at it.
     mount(MEM)
-    const fill = host.querySelector<HTMLElement>('.sysres-pill__minibar-fill')
-    expect(fill?.style.width).toBe('25%')
+    const detail = host.querySelector('.sysres-pill__detail')
+    expect(detail).not.toBeNull()
+    expect(detail?.textContent).toContain('15.6 GB')
+  })
+
+  it('tints the icon by memory USED, not by what is free', () => {
+    // The icon carries the pressure reading now that the bar is gone. 25% used is calm; the same
+    // machine read as 75% FREE would be the danger tint, which is the mistake this pins.
+    mount(MEM)
+    expect(host.querySelector<HTMLElement>('.sysres-pill__icon')?.style.color).toBe('')
+    act(() => root.unmount())
+    // 63 of 64 GB used — the same machine read as "98% free" would stay calm, which is the
+    // direction this pins.
+    mount({ totalMb: 64000, availableMb: 1000 })
+    expect(host.querySelector<HTMLElement>('.sysres-pill__icon')?.style.color).toBe('var(--danger)')
   })
 
   it('pulses instead of claiming a number when the reading is null', () => {
@@ -90,7 +106,6 @@ describe('SystemResourcePill', () => {
     // is any digit at all — there is no number we are entitled to print without a reading.
     expect(pill?.textContent).not.toMatch(/\d/)
     expect(pill?.textContent).not.toContain('GB')
-    expect(host.querySelector('.sysres-pill__minibar')).toBeNull()
   })
 
   it('treats a zero total as unreadable rather than dividing by it', () => {

--- a/src/renderer/components/SystemResourcePill.test.tsx
+++ b/src/renderer/components/SystemResourcePill.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import type { MemInfo, Project } from '@shared/types'
+import { useProjects } from '../state/projects'
+import { useSshConn } from '../state/sshConn'
+import { useSessionMemory } from '../state/sessionMemory'
+import { SystemResourcePill } from './SystemResourcePill'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const project = (over: Partial<Project> = {}): Project => ({
+  id: 'p1',
+  name: 'p',
+  color: '#fff',
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: [],
+  ...over
+})
+
+const sshProject = (): Project =>
+  project({ id: 'ssh1', ssh: { server: { host: 'box', user: 'enes', port: 22 } as never, remoteCwd: '/srv' } })
+
+/**
+ * The FIXTURE is the whole test. `used = totalMb - availableMb` must be distinguishable from every
+ * other number in the object, or a component that printed `availableMb` (or `totalMb`) would pass:
+ * total 64000, available 48000 ⇒ used 16000, and 15.6 / 46.9 / 62.5 GB are three different strings.
+ */
+const MEM: MemInfo = { totalMb: 64000, availableMb: 48000 }
+
+let host: HTMLDivElement
+let root: Root
+let startHostPoll: Mock<(scopeKey: string, projectId?: string) => void>
+let stopHostPoll: Mock<() => void>
+
+/** Mount with the store's poll actions stubbed — the real ones would talk to a session registry
+ *  that does not exist in a jsdom test, and `refreshHost` would clear the `mem` fixture on the way
+ *  through `enterScope`. */
+function mount(mem: MemInfo | null, overBoard = false): void {
+  useSessionMemory.setState({ mem, startHostPoll, stopHostPoll })
+  host = document.createElement('div')
+  root = createRoot(host)
+  act(() => root.render(<SystemResourcePill overBoard={overBoard} />))
+}
+
+beforeEach(() => {
+  startHostPoll = vi.fn<(scopeKey: string, projectId?: string) => void>()
+  stopHostPoll = vi.fn<() => void>()
+  useProjects.setState({ projects: [project()], activeProjectId: 'p1' })
+  useSshConn.setState({ byProject: {} })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+})
+
+describe('SystemResourcePill', () => {
+  it('renders used / total, never the available or total figure alone', () => {
+    mount(MEM)
+    const pill = host.querySelector('.sysres-pill')
+    expect(pill?.textContent).toContain('15.6 GB')
+    expect(pill?.textContent).toContain('62.5 GB')
+    expect(pill?.textContent).not.toContain('46.9 GB')
+  })
+
+  it('fills the bar by memory USED, not by what is free', () => {
+    mount(MEM)
+    const fill = host.querySelector<HTMLElement>('.sysres-pill__minibar-fill')
+    expect(fill?.style.width).toBe('25%')
+  })
+
+  it('pulses instead of claiming a number when the reading is null', () => {
+    mount(null)
+    const pill = host.querySelector('.sysres-pill')
+    expect(pill).not.toBeNull()
+    expect(host.querySelector('.sysres-pill__pulse')).not.toBeNull()
+    // The one thing this pill must never say. `0 GB` is the shape a confident zero takes, but so
+    // is any digit at all — there is no number we are entitled to print without a reading.
+    expect(pill?.textContent).not.toMatch(/\d/)
+    expect(pill?.textContent).not.toContain('GB')
+    expect(host.querySelector('.sysres-pill__minibar')).toBeNull()
+  })
+
+  it('treats a zero total as unreadable rather than dividing by it', () => {
+    mount({ totalMb: 0, availableMb: 0 })
+    expect(host.querySelector('.sysres-pill__pulse')).not.toBeNull()
+    expect(host.querySelector('.sysres-pill')?.textContent).not.toMatch(/\d/)
+  })
+
+  it('starts the host poll for the active project and stops it on unmount', () => {
+    mount(MEM)
+    expect(startHostPoll).toHaveBeenCalledTimes(1)
+    // Explicit project id — the store's `activeSessionApi()` fallback is the only path that can
+    // address the wrong machine.
+    expect(startHostPoll).toHaveBeenCalledWith('', 'p1')
+    act(() => root.unmount())
+    expect(stopHostPoll).toHaveBeenCalledTimes(1)
+    // The afterEach unmount must not throw on an already-unmounted root.
+    root = createRoot(document.createElement('div'))
+  })
+
+  it('polls an SSH project under its HOST key, never the local scope', () => {
+    useProjects.setState({ projects: [sshProject()], activeProjectId: 'ssh1' })
+    mount(MEM)
+    expect(startHostPoll).toHaveBeenCalledWith('enes@box', 'ssh1')
+  })
+
+  it('re-reads when the SSH project connection comes up', () => {
+    useProjects.setState({ projects: [sshProject()], activeProjectId: 'ssh1' })
+    mount(MEM)
+    expect(startHostPoll).toHaveBeenCalledTimes(1)
+    // An SSH scope is read ONCE with no timer behind it, so a first read that landed before the
+    // ControlMaster was up would leave the pill blank until the panel was opened.
+    act(() => {
+      useSshConn.setState({ byProject: { ssh1: { controlPath: '/tmp/cm' } } })
+    })
+    expect(startHostPoll).toHaveBeenCalledTimes(2)
+    expect(startHostPoll).toHaveBeenLastCalledWith('enes@box', 'ssh1')
+  })
+
+  it('renders nothing and polls nothing without an active project', () => {
+    useProjects.setState({ projects: [], activeProjectId: '' })
+    mount(MEM)
+    expect(host.querySelector('.sysres-pill')).toBeNull()
+    expect(startHostPoll).not.toHaveBeenCalled()
+  })
+
+  it('rises above the kanban overlay only when the board is open', () => {
+    mount(MEM, true)
+    expect(host.querySelector('.sysres-indicator--board')).not.toBeNull()
+    act(() => root.unmount())
+    mount(MEM, false)
+    expect(host.querySelector('.sysres-indicator--board')).toBeNull()
+  })
+
+  it('toggles its open state — the pill is the panel´s only entry point', () => {
+    mount(MEM)
+    const pill = host.querySelector<HTMLButtonElement>('.sysres-pill')!
+    expect(pill.getAttribute('aria-expanded')).toBe('false')
+    act(() => pill.click())
+    expect(host.querySelector('.sysres-pill')?.getAttribute('aria-expanded')).toBe('true')
+    act(() => host.querySelector<HTMLButtonElement>('.sysres-pill')!.click())
+    expect(host.querySelector('.sysres-pill')?.getAttribute('aria-expanded')).toBe('false')
+  })
+})

--- a/src/renderer/components/SystemResourcePill.test.tsx
+++ b/src/renderer/components/SystemResourcePill.test.tsx
@@ -33,12 +33,18 @@ let host: HTMLDivElement
 let root: Root
 let startHostPoll: Mock<(scopeKey: string, projectId?: string) => void>
 let stopHostPoll: Mock<() => void>
+let refreshFull: Mock<(scopeKey: string, projectId?: string) => Promise<void>>
 
-/** Mount with the store's poll actions stubbed — the real ones would talk to a session registry
- *  that does not exist in a jsdom test, and `refreshHost` would clear the `mem` fixture on the way
- *  through `enterScope`. */
+/** Mount with the store's actions stubbed — the real ones would talk to a session registry that
+ *  does not exist in a jsdom test, and `refreshHost` would clear the `mem` fixture on the way
+ *  through `enterScope`.
+ *
+ *  `refreshFull` is stubbed for a different reason: it must be OBSERVABLE. The real one swallows
+ *  every failure, so a future edit that put the full process-table sweep on this pill's 30 s timer
+ *  would leave the suite green and show no symptom — while costing an ssh exec plus a remote `ps`
+ *  every 30 seconds on an SSH scope. */
 function mount(mem: MemInfo | null, overBoard = false): void {
-  useSessionMemory.setState({ mem, startHostPoll, stopHostPoll })
+  useSessionMemory.setState({ mem, startHostPoll, stopHostPoll, refreshFull })
   host = document.createElement('div')
   root = createRoot(host)
   act(() => root.render(<SystemResourcePill overBoard={overBoard} />))
@@ -47,6 +53,7 @@ function mount(mem: MemInfo | null, overBoard = false): void {
 beforeEach(() => {
   startHostPoll = vi.fn<(scopeKey: string, projectId?: string) => void>()
   stopHostPoll = vi.fn<() => void>()
+  refreshFull = vi.fn<(scopeKey: string, projectId?: string) => Promise<void>>(async () => {})
   useProjects.setState({ projects: [project()], activeProjectId: 'p1' })
   useSshConn.setState({ byProject: {} })
 })
@@ -117,6 +124,20 @@ describe('SystemResourcePill', () => {
     })
     expect(startHostPoll).toHaveBeenCalledTimes(2)
     expect(startHostPoll).toHaveBeenLastCalledWith('enes@box', 'ssh1')
+    // The connect-up path is the likeliest place for someone to "just also refresh the rows".
+    expect(refreshFull).not.toHaveBeenCalled()
+  })
+
+  it('never runs the full sweep — the cheap read is the pill´s, the expensive one the panel´s', () => {
+    // `refreshFull` walks the whole process table, and on an SSH scope that is an ssh exec plus a
+    // remote `ps`. On this component's 30 s timer that would be a background cost nobody asked for,
+    // and the real action swallows its failures, so it would show no symptom at all.
+    mount(MEM)
+    expect(refreshFull).not.toHaveBeenCalled()
+    // Not even when the pill is clicked: opening the panel is what triggers the sweep, and the
+    // panel does it itself (Task 9).
+    act(() => host.querySelector<HTMLButtonElement>('.sysres-pill')!.click())
+    expect(refreshFull).not.toHaveBeenCalled()
   })
 
   it('renders nothing and polls nothing without an active project', () => {

--- a/src/renderer/components/SystemResourcePill.test.tsx
+++ b/src/renderer/components/SystemResourcePill.test.tsx
@@ -175,6 +175,26 @@ describe('SystemResourcePill', () => {
     expect(host.querySelector('.sysres-pill')?.getAttribute('aria-expanded')).toBe('false')
   })
 
+  it('closes on an outside click, but not on the kill confirm', () => {
+    mount(MEM)
+    document.body.appendChild(host)
+    act(() => host.querySelector<HTMLButtonElement>('.sysres-pill')!.click())
+    expect(host.querySelector('.sessmem-panel')).not.toBeNull()
+
+    // The `×` raises a ConfirmDialog through a portal OUTSIDE this container. Answering it must not
+    // dismiss the list the user is working through.
+    const confirm = document.createElement('div')
+    confirm.className = 'confirm-overlay'
+    document.body.appendChild(confirm)
+    act(() => confirm.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })))
+    expect(host.querySelector('.sessmem-panel')).not.toBeNull()
+
+    act(() => document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })))
+    expect(host.querySelector('.sessmem-panel')).toBeNull()
+    confirm.remove()
+    host.remove()
+  })
+
   it('announces a region that actually exists', () => {
     // `aria-expanded` on its own told assistive tech about an expandable region and expanded
     // nothing. It may only ship pointing at the real panel.

--- a/src/renderer/components/SystemResourcePill.tsx
+++ b/src/renderer/components/SystemResourcePill.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { formatBytes } from '@shared/fsLimits'
 import { useProjects } from '../state/projects'
 import { useSshConn } from '../state/sshConn'
@@ -37,6 +37,7 @@ export function SystemResourcePill({
   onKillSession
 }: SystemResourcePillProps): JSX.Element | null {
   const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
 
   const mem = useSessionMemory((s) => s.mem)
   const startHostPoll = useSessionMemory((s) => s.startHostPoll)
@@ -71,6 +72,22 @@ export function SystemResourcePill({
     startHostPoll(scopeKey, activeProjectId)
     return () => stopHostPoll()
   }, [scopeKey, activeProjectId, sshUp, startHostPoll, stopHostPoll])
+
+  // Close on an outside click, like the usage popover beside it — otherwise the panel sits over the
+  // canvas until the pill is clicked again. The ConfirmDialog the `×` raises is a PORTAL outside
+  // this container, so it is excluded explicitly: answering "yes, end it" must not also dismiss the
+  // list the user is working through.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent): void => {
+      const target = e.target as HTMLElement | null
+      if (wrapRef.current?.contains(target)) return
+      if (target?.closest('.confirm-overlay')) return
+      setOpen(false)
+    }
+    window.addEventListener('mousedown', onDown)
+    return () => window.removeEventListener('mousedown', onDown)
+  }, [open])
 
   if (!activeProjectId) return null
 
@@ -111,7 +128,7 @@ export function SystemResourcePill({
   }
 
   return (
-    <div className={`sysres-indicator${overBoard ? ' sysres-indicator--board' : ''}`}>
+    <div ref={wrapRef} className={`sysres-indicator${overBoard ? ' sysres-indicator--board' : ''}`}>
       {open && (
         <SessionMemoryPanel
           onGoToNode={onGoToNode}

--- a/src/renderer/components/SystemResourcePill.tsx
+++ b/src/renderer/components/SystemResourcePill.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react'
+import { formatBytes } from '@shared/fsLimits'
+import { useProjects } from '../state/projects'
+import { useSshConn } from '../state/sshConn'
+import { useSessionMemory } from '../state/sessionMemory'
+import { usageScopeKey } from '../lib/usageScope'
+
+/** `formatBytes` speaks bytes; every number in this feature is MB. */
+const MB = 1024 * 1024
+
+/** Used-RAM thresholds the bar changes colour at. Pressure, not quota — see the bar's comment. */
+const WARN_PERCENT = 75
+const DANGER_PERCENT = 90
+
+/**
+ * Bottom-left system-resource pill: how much RAM the machine the ACTIVE project runs on is using.
+ * Sits beside the usage pill in the same cluster and takes its scope from the same helper
+ * (`usageScopeKey`), so the two can never disagree about which machine they describe.
+ *
+ * Clicking toggles the session-memory panel (Task 9 renders it into the slot below); this pill is
+ * the panel's only entry point.
+ */
+export function SystemResourcePill({ overBoard = false }: { overBoard?: boolean }): JSX.Element | null {
+  const [open, setOpen] = useState(false)
+
+  const mem = useSessionMemory((s) => s.mem)
+  const startHostPoll = useSessionMemory((s) => s.startHostPoll)
+  const stopHostPoll = useSessionMemory((s) => s.stopHostPoll)
+
+  // The pill follows the ACTIVE project, exactly like UsageIndicator: on a local project this is
+  // this machine, on an SSH project it is that host. Selecting the scope KEY (one primitive) rather
+  // than the project object keeps this out of the re-render path of every canvas edit.
+  const activeProjectId = useProjects((s) => s.activeProjectId)
+  const scopeKey = useProjects((s) =>
+    usageScopeKey(s.projects.find((p) => p.id === s.activeProjectId))
+  )
+  const sshUp = useSshConn((s) => !!s.byProject[activeProjectId])
+
+  // OWNERSHIP CONTRACT — do not add a second caller.
+  // `useSessionMemory`'s poll timer and its active-scope stamp are MODULE SINGLETONS, and this
+  // component is their single owner: only this effect may call `startHostPoll` / `stopHostPoll`.
+  // The panel must NOT call `stopHostPoll` on unmount — it would clear this pill's interval with
+  // nothing left to restart it, and the number would silently freeze until the next scope change.
+  //
+  // `sshUp` is in the deps for the same reason remote usage re-reads on connect (CLAUDE.md, Remote
+  // usage): an SSH project is opened before its ControlMaster is ready, and an SSH scope is read
+  // ONCE with no timer behind it — so a first read that landed on a dead master would leave the pill
+  // blank until the user opened the panel. A local project never appears in `byProject`, so this
+  // never disturbs the 30 s local cadence. A connection DROP re-reads too, which is right: the read
+  // fails and the pill returns to "unknown" instead of holding a stale number under a dead master.
+  useEffect(() => {
+    // No active project (welcome screen) = no machine to describe. Passing an empty project id
+    // would fall through the store's `activeSessionApi()` fallback, which is the one path that can
+    // address the wrong machine.
+    if (!activeProjectId) return
+    startHostPoll(scopeKey, activeProjectId)
+    return () => stopHostPoll()
+  }, [scopeKey, activeProjectId, sshUp, startHostPoll, stopHostPoll])
+
+  if (!activeProjectId) return null
+
+  let body: JSX.Element
+  // `null` = could not read — the normal answer on a non-Linux SSH host, and on any host whose
+  // first read has not landed yet. Pulse, NEVER "0 GB": a confident zero is the one thing this pill
+  // must never say, since the number is the whole reason anyone looks at it. A `totalMb` of zero is
+  // the same fact wearing a plausible shape (and would render the bar as NaN%).
+  if (mem === null || mem.totalMb <= 0) {
+    body = <span className="sysres-pill__dim sysres-pill__pulse">···</span>
+  } else {
+    const usedMb = Math.max(0, mem.totalMb - mem.availableMb)
+    const usedPercent = Math.min(100, (usedMb / mem.totalMb) * 100)
+    // The bar fills as memory is CONSUMED — the opposite direction to the usage pill's bar beside
+    // it, which drains as quota is spent. Deliberate: every system monitor draws RAM this way, and
+    // "the bar is nearly full" is the reading a user already has for memory pressure.
+    const color =
+      usedPercent >= DANGER_PERCENT
+        ? 'var(--danger)'
+        : usedPercent >= WARN_PERCENT
+          ? 'var(--warn)'
+          : 'var(--success)'
+    body = (
+      <>
+        <span className="sysres-pill__minibar" aria-hidden>
+          <span
+            className="sysres-pill__minibar-fill"
+            style={{ width: `${usedPercent}%`, background: color }}
+          />
+        </span>
+        <span className="sysres-pill__num">
+          {formatBytes(usedMb * MB)}
+          <span className="sysres-pill__sep"> / </span>
+          {formatBytes(mem.totalMb * MB)}
+        </span>
+      </>
+    )
+  }
+
+  return (
+    <div className={`sysres-indicator${overBoard ? ' sysres-indicator--board' : ''}`}>
+      {/* Task 9 renders <SessionMemoryPanel /> here while `open`. The pill owns the open state so
+          the panel can be unmounted entirely when closed — its sweep is expensive and must never
+          run behind a closed panel. */}
+      <button
+        className="sysres-pill"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        // The SSH pill is visually identical to the local one, so the title is what answers
+        // "whose memory is this?" without opening the panel.
+        title={scopeKey ? `Memory on ${scopeKey}` : 'Memory on this machine'}
+      >
+        <span className="sysres-pill__icon">RAM</span>
+        {body}
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/SystemResourcePill.tsx
+++ b/src/renderer/components/SystemResourcePill.tsx
@@ -5,6 +5,7 @@ import { useSshConn } from '../state/sshConn'
 import { useSessionMemory } from '../state/sessionMemory'
 import { usageScopeKey } from '../lib/usageScope'
 import { SessionMemoryPanel } from './SessionMemoryPanel'
+import { IconResource } from './icons'
 
 /** `formatBytes` speaks bytes; every number in this feature is MB. */
 const MB = 1024 * 1024
@@ -92,39 +93,33 @@ export function SystemResourcePill({
   if (!activeProjectId) return null
 
   let body: JSX.Element
+  let iconColor: string | undefined
   // `null` = could not read — the normal answer on a non-Linux SSH host, and on any host whose
   // first read has not landed yet. Pulse, NEVER "0 GB": a confident zero is the one thing this pill
   // must never say, since the number is the whole reason anyone looks at it. A `totalMb` of zero is
   // the same fact wearing a plausible shape (and would render the bar as NaN%).
   if (mem === null || mem.totalMb <= 0) {
-    body = <span className="sysres-pill__dim sysres-pill__pulse">···</span>
+    body = <span className="sysres-pill__detail sysres-pill__dim sysres-pill__pulse">···</span>
   } else {
     const usedMb = Math.max(0, mem.totalMb - mem.availableMb)
     const usedPercent = Math.min(100, (usedMb / mem.totalMb) * 100)
-    // The bar fills as memory is CONSUMED — the opposite direction to the usage pill's bar beside
-    // it, which drains as quota is spent. Deliberate: every system monitor draws RAM this way, and
-    // "the bar is nearly full" is the reading a user already has for memory pressure.
+    // The ICON carries the pressure reading now that the bar is gone: it tints as memory is
+    // consumed, so a glance still says "this machine is tight" without the pill claiming a row of
+    // the canvas. Same thresholds the bar used.
     const color =
       usedPercent >= DANGER_PERCENT
         ? 'var(--danger)'
         : usedPercent >= WARN_PERCENT
           ? 'var(--warn)'
-          : 'var(--success)'
+          : undefined
     body = (
-      <>
-        <span className="sysres-pill__minibar" aria-hidden>
-          <span
-            className="sysres-pill__minibar-fill"
-            style={{ width: `${usedPercent}%`, background: color }}
-          />
-        </span>
-        <span className="sysres-pill__num">
-          {formatBytes(usedMb * MB)}
-          <span className="sysres-pill__sep"> / </span>
-          {formatBytes(mem.totalMb * MB)}
-        </span>
-      </>
+      <span className="sysres-pill__detail sysres-pill__num" style={color ? { color } : undefined}>
+        {formatBytes(usedMb * MB)}
+        <span className="sysres-pill__sep"> / </span>
+        {formatBytes(mem.totalMb * MB)}
+      </span>
     )
+    iconColor = color
   }
 
   return (
@@ -147,7 +142,9 @@ export function SystemResourcePill({
         // "whose memory is this?" without opening the panel.
         title={scopeKey ? `Memory on ${scopeKey}` : 'Memory on this machine'}
       >
-        <span className="sysres-pill__icon">RAM</span>
+        <span className="sysres-pill__icon" style={iconColor ? { color: iconColor } : undefined}>
+          <IconResource />
+        </span>
         {body}
       </button>
     </div>

--- a/src/renderer/components/SystemResourcePill.tsx
+++ b/src/renderer/components/SystemResourcePill.tsx
@@ -4,6 +4,7 @@ import { useProjects } from '../state/projects'
 import { useSshConn } from '../state/sshConn'
 import { useSessionMemory } from '../state/sessionMemory'
 import { usageScopeKey } from '../lib/usageScope'
+import { SessionMemoryPanel } from './SessionMemoryPanel'
 
 /** `formatBytes` speaks bytes; every number in this feature is MB. */
 const MB = 1024 * 1024
@@ -12,15 +13,29 @@ const MB = 1024 * 1024
 const WARN_PERCENT = 75
 const DANGER_PERCENT = 90
 
+export interface SystemResourcePillProps {
+  overBoard?: boolean
+  /** Handed straight to the panel. Required, not optional: an omitted callback would compile into
+   *  a panel whose rows silently do nothing. */
+  onGoToNode: (nodeId: string) => void
+  onKillSession: (nodeId: string, orphan: boolean) => void
+}
+
 /**
  * Bottom-left system-resource pill: how much RAM the machine the ACTIVE project runs on is using.
  * Sits beside the usage pill in the same cluster and takes its scope from the same helper
  * (`usageScopeKey`), so the two can never disagree about which machine they describe.
  *
- * Clicking toggles the session-memory panel (Task 9 renders it into the slot below); this pill is
- * the panel's only entry point.
+ * Clicking toggles the session-memory panel; this pill is the panel's only entry point. The panel
+ * is UNMOUNTED while closed — its sweep is expensive (the whole process table, and over SSH an
+ * exec on someone else's machine) and must never run behind a closed panel. Mounting is what
+ * triggers the sweep, which is also why the pill itself never calls `refreshFull`.
  */
-export function SystemResourcePill({ overBoard = false }: { overBoard?: boolean }): JSX.Element | null {
+export function SystemResourcePill({
+  overBoard = false,
+  onGoToNode,
+  onKillSession
+}: SystemResourcePillProps): JSX.Element | null {
   const [open, setOpen] = useState(false)
 
   const mem = useSessionMemory((s) => s.mem)
@@ -97,13 +112,20 @@ export function SystemResourcePill({ overBoard = false }: { overBoard?: boolean 
 
   return (
     <div className={`sysres-indicator${overBoard ? ' sysres-indicator--board' : ''}`}>
-      {/* Task 9 renders <SessionMemoryPanel /> here while `open`. The pill owns the open state so
-          the panel can be unmounted entirely when closed — its sweep is expensive and must never
-          run behind a closed panel. */}
+      {open && (
+        <SessionMemoryPanel
+          onGoToNode={onGoToNode}
+          onKillSession={onKillSession}
+          onClose={() => setOpen(false)}
+        />
+      )}
       <button
         className="sysres-pill"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
+        // Points at the region `aria-expanded` announces. The panel is mounted only while open, so
+        // this resolves exactly when it claims to.
+        aria-controls="sessmem-panel"
         // The SSH pill is visually identical to the local one, so the title is what answers
         // "whose memory is this?" without opening the panel.
         title={scopeKey ? `Memory on ${scopeKey}` : 'Memory on this machine'}

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -210,6 +210,15 @@ export const IconSearch = () => (
   </svg>
 )
 
+/** Memory/resource glyph: a chip with pins. Used by the system-resource pill, whose collapsed
+ *  state is icon-only — the numbers appear on hover. */
+export const IconResource = () => (
+  <svg {...S}>
+    <rect x="7" y="7" width="10" height="10" rx="1.5" />
+    <path d="M10 3v4M14 3v4M10 17v4M14 17v4M3 10h4M3 14h4M17 10h4M17 14h4" />
+  </svg>
+)
+
 export const IconWeb = () => (
   <svg {...S}>
     <circle cx="12" cy="12" r="9" />

--- a/src/renderer/lib/sessionKill.test.ts
+++ b/src/renderer/lib/sessionKill.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import type { Project } from '@shared/types'
+import { planSessionKill } from './sessionKill'
+
+const project = (id: string, nodeIds: string[], over: Partial<Project> = {}): Project =>
+  ({
+    id,
+    name: id,
+    color: '#fff',
+    viewport: { x: 0, y: 0, zoom: 1 },
+    nodes: nodeIds.map((n) => ({ id: n, kind: 'terminal', title: n, position: { x: 0, y: 0 } })),
+    ...over
+  }) as unknown as Project
+
+const ssh = (id: string, nodeIds: string[], over: Partial<Project> = {}): Project =>
+  project(id, nodeIds, {
+    ssh: { server: { host: 'box', user: 'enes', port: 22 } as never, remoteCwd: '/srv' },
+    ...over
+  })
+
+describe('planSessionKill', () => {
+  it('finds the owner across every project, closed ones included', () => {
+    const plan = planSessionKill('c', [project('p1', ['a']), project('p2', ['c'], { closed: true })], 'p1')
+    expect(plan.ownerProjectId).toBe('p2')
+  })
+
+  it('reports no owner for an orphan', () => {
+    expect(planSessionKill('ghost', [project('p1', ['a'])], 'p1').ownerProjectId).toBeNull()
+  })
+
+  it('kills an ORPHAN on the host when the scope is an SSH project', () => {
+    // The whole point. `transport.destroy` reaches a remote session only through a LIVE client
+    // carrying `sshRemote`; an orphan has no node and therefore no client, so destroy alone would
+    // touch the local socket and leave the host's `nt-ghost` running — after a confirm that said
+    // otherwise.
+    const plan = planSessionKill('ghost', [ssh('s1', ['a'])], 's1')
+    expect(plan).toEqual({ ownerProjectId: null, remoteProjectId: 's1' })
+  })
+
+  it('kills a NON-ACTIVE project´s session on the host too', () => {
+    // Same trap one step along: an unmounted node has no live client either. This is the case the
+    // sessions sidebar has always got wrong; it never listed another machine's sessions, and this
+    // panel's whole purpose is to.
+    const plan = planSessionKill('b', [ssh('s1', ['a']), ssh('s2', ['b'], { closed: true })], 's1')
+    expect(plan).toEqual({ ownerProjectId: 's2', remoteProjectId: 's1' })
+  })
+
+  it('routes the remote kill through the ACTIVE project, never the owner', () => {
+    // The panel shows ONE machine — the active project's — and the sweep that produced these rows
+    // ran over that project's master. The owner's own connection may be down, or on another host.
+    expect(planSessionKill('b', [ssh('s1', ['a']), ssh('s2', ['b'])], 's1').remoteProjectId).toBe('s1')
+  })
+
+  it('never reaches for a host when the scope is this machine', () => {
+    // A local sweep lists LOCAL sessions. A local `nt-b` whose node belongs to an SSH project is
+    // the stranded local fallback `requireRemote` exists to prevent — killing it on the host would
+    // leave it running here.
+    const plan = planSessionKill('b', [project('p1', ['a']), ssh('s2', ['b'])], 'p1')
+    expect(plan).toEqual({ ownerProjectId: 's2', remoteProjectId: null })
+  })
+
+  it('survives an unknown active project', () => {
+    expect(planSessionKill('a', [project('p1', ['a'])], '').remoteProjectId).toBeNull()
+  })
+})

--- a/src/renderer/lib/sessionKill.ts
+++ b/src/renderer/lib/sessionKill.ts
@@ -17,6 +17,13 @@
 // needs no live session. It is idempotent — a session already ended by `destroy` (the mounted case)
 // is a best-effort miss on the host — so no case analysis is needed at the call site.
 
+// KNOWN GAP, recorded in docs/session-memory.md's "Known gaps": the SESSIONS SIDEBAR still calls
+// `closeSession` with no remote leg, so ending an unmounted SSH node's session there leaves the
+// host's `nt-<id>` running after a confirm that said otherwise — the two surfaces now disagree
+// about the same session. Its correct fix is owner-routed per row (the row's OWNER project's
+// master, not the active project's, which is only sound here because the panel shows one machine
+// at a time); reuse this file rather than adding a third kill path.
+
 import type { Project } from '@shared/types'
 
 export interface SessionKillPlan {

--- a/src/renderer/lib/sessionKill.ts
+++ b/src/renderer/lib/sessionKill.ts
@@ -1,0 +1,50 @@
+// Where a session picked from the SESSION-MEMORY PANEL has to be killed.
+//
+// The panel is the first surface in the app that lists sessions on a machine other than the one
+// the renderer runs on: an SSH project's rows come from `ps` on the HOST. That makes the ordinary
+// kill path a lie in exactly the cases the panel adds.
+//
+// `transport.destroy(nodeId)` reaches a REMOTE tmux session only through a LIVE local client that
+// carries `sshRemote` (see `PtyManager.endSession`) — i.e. only for a node that is currently
+// mounted. An ORPHAN row has no node at all, and a row owned by a non-active project has no live
+// client either, so for both of those `destroy` touches only the local socket while the remote
+// `nt-<id>` keeps running. The confirm would promise a kill it cannot perform, and the row would
+// come back on the next refresh with no explanation.
+//
+// So the plan is decided by the SCOPE, not by the row: **the panel kills on the machine it is
+// showing you.** On an SSH scope every row is a session on that host, so the kill additionally runs
+// `tmux kill-session` over that project's own ControlMaster (`sshProject.killSessions`), which
+// needs no live session. It is idempotent — a session already ended by `destroy` (the mounted case)
+// is a best-effort miss on the host — so no case analysis is needed at the call site.
+
+import type { Project } from '@shared/types'
+
+export interface SessionKillPlan {
+  /**
+   * The project whose canvas node must go too, or `null` when no project owns this session (an
+   * orphan). Resolved against EVERY project, closed ones included — `closeProject` keeps its nodes.
+   */
+  ownerProjectId: string | null
+  /**
+   * The project whose ControlMaster must run the remote `tmux kill-session`, or `null` when the
+   * scope is this machine. This is the ACTIVE project, never the owner: the panel shows one
+   * machine at a time, and that machine is the active project's.
+   */
+  remoteProjectId: string | null
+}
+
+export function planSessionKill(
+  nodeId: string,
+  projects: readonly Project[],
+  activeProjectId: string
+): SessionKillPlan {
+  const owner = projects.find((p) => (p.nodes ?? []).some((n) => n.id === nodeId))
+  const active = projects.find((p) => p.id === activeProjectId)
+  return {
+    ownerProjectId: owner?.id ?? null,
+    // `active.ssh`, not `owner.ssh`: a local scope lists LOCAL sessions, and a local `nt-<id>`
+    // whose node belongs to an SSH project is precisely the stranded local fallback that
+    // `requireRemote` exists to prevent — killing it on the host would leave it running here.
+    remoteProjectId: active?.ssh ? active.id : null
+  }
+}

--- a/src/renderer/lib/sessionMemoryRows.test.ts
+++ b/src/renderer/lib/sessionMemoryRows.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { resolveSessionRows, totalMb } from './sessionMemoryRows'
+import type { SessionMemoryRow } from '@shared/types'
+
+const row = (nodeId: string, mb: number): SessionMemoryRow => ({
+  session: `nt-${nodeId}`,
+  nodeId,
+  panePid: 1,
+  selfMb: mb,
+  childrenMb: 0,
+  childCount: 0,
+  totalMb: mb,
+  command: 'claude'
+})
+
+const project = (id: string, name: string, nodeIds: string[], closed = false): any => ({
+  id,
+  name,
+  color: '#fff',
+  viewport: { x: 0, y: 0, zoom: 1 },
+  closed,
+  nodes: nodeIds.map((n) => ({ id: n, kind: 'terminal', title: `T ${n}`, position: { x: 0, y: 0 } }))
+})
+
+describe('resolveSessionRows', () => {
+  it('resolves a node title and project name from the OPEN project', () => {
+    const [v] = resolveSessionRows([row('a', 100)], [project('p1', 'Web', ['a'])], { a: 'working' })
+    expect(v).toMatchObject({ title: 'T a', projectId: 'p1', projectName: 'Web', orphan: false, state: 'working' })
+  })
+
+  it('resolves across ALL projects, not just the active one', () => {
+    const [v] = resolveSessionRows(
+      [row('b', 100)],
+      [project('p1', 'Web', ['a']), project('p2', 'API', ['b'])],
+      {}
+    )
+    expect(v).toMatchObject({ projectId: 'p2', projectName: 'API', orphan: false })
+  })
+
+  it('a CLOSED project is not an orphan — its nodes are still on disk', () => {
+    // closeProject keeps the project and its nodes; calling these orphans would invite the user to
+    // kill sessions they deliberately parked.
+    const [v] = resolveSessionRows([row('c', 100)], [project('p3', 'Old', ['c'], true)], {})
+    expect(v.orphan).toBe(false)
+    expect(v.projectName).toBe('Old')
+  })
+
+  it('marks a session with no node on any canvas as an orphan with no state', () => {
+    const [v] = resolveSessionRows([row('ghost', 100)], [project('p1', 'Web', ['a'])], {
+      ghost: 'working'
+    })
+    expect(v).toMatchObject({ orphan: true, projectId: null, projectName: null, state: null })
+    expect(v.title).toContain('ghost')
+  })
+
+  it('preserves core ordering (already sorted by size)', () => {
+    const vs = resolveSessionRows([row('big', 900), row('small', 10)], [], {})
+    expect(vs.map((v) => v.row.nodeId)).toEqual(['big', 'small'])
+  })
+})
+
+describe('totalMb', () => {
+  it('sums every row', () => {
+    expect(totalMb(resolveSessionRows([row('a', 100), row('b', 250)], [], {}))).toBe(350)
+  })
+
+  it('sums the row TOTAL, not just the pane process', () => {
+    // childCount counts every descendant of the pane — the agent CLI plus anything it spawned —
+    // and their memory lives in childrenMb, so a header that summed selfMb would under-report by
+    // most of the session. The other fixtures have no children, so only this one pins the field.
+    const withChildren: SessionMemoryRow = {
+      ...row('a', 100),
+      childrenMb: 400,
+      childCount: 3,
+      totalMb: 500
+    }
+    expect(totalMb(resolveSessionRows([withChildren], [], {}))).toBe(500)
+  })
+})

--- a/src/renderer/lib/sessionMemoryRows.ts
+++ b/src/renderer/lib/sessionMemoryRows.ts
@@ -1,0 +1,76 @@
+// Turn core's session-memory rows into rows the panel can render: whose node is this, which
+// project does it belong to, and is there a node at all?
+//
+// Pure and store-free (the caller passes the projects and the agent states), so the whole
+// orphan/closed-project policy is unit-testable without mounting anything.
+
+import type { AgentState } from '@shared/agents/normalize'
+import type { Project, SessionMemoryRow } from '@shared/types'
+
+export interface SessionMemoryView {
+  row: SessionMemoryRow
+  /** The node's title, or the session name when there is no node to name it. */
+  title: string
+  projectId: string | null
+  projectName: string | null
+  orphan: boolean
+  /** Agent state for the dot. Always null for an orphan — see below. */
+  state: AgentState | null
+}
+
+/**
+ * Resolve each row against EVERY project, not just the active one.
+ *
+ * A CLOSED project is deliberately included: `closeProject` only sets `closed = true` and keeps
+ * the project and its nodes on disk, so its sessions resolve to a real title. Treating them as
+ * orphans would invite the user to kill sessions they deliberately parked.
+ *
+ * Order is preserved — core already sorted by `totalMb` descending, and re-sorting here would let
+ * the panel and the report disagree.
+ */
+export function resolveSessionRows(
+  rows: readonly SessionMemoryRow[],
+  projects: readonly Project[],
+  states: Readonly<Record<string, AgentState | undefined>>
+): SessionMemoryView[] {
+  const index = new Map<string, { projectId: string; projectName: string; title: string }>()
+  for (const p of projects) {
+    for (const n of p.nodes ?? []) {
+      if (index.has(n.id)) continue
+      index.set(n.id, {
+        projectId: p.id,
+        projectName: p.name,
+        title: n.title?.trim() || n.id
+      })
+    }
+  }
+
+  return rows.map((row) => {
+    const hit = index.get(row.nodeId)
+    if (!hit) {
+      // No node on any canvas. A state without a node is meaningless — the panel could not
+      // explain a "working" dot on a row it cannot travel to — so it is dropped, not passed on.
+      return {
+        row,
+        title: row.session,
+        projectId: null,
+        projectName: null,
+        orphan: true,
+        state: null
+      }
+    }
+    return {
+      row,
+      title: hit.title,
+      projectId: hit.projectId,
+      projectName: hit.projectName,
+      orphan: false,
+      state: states[row.nodeId] ?? null
+    }
+  })
+}
+
+/** Grand total across the resolved rows — the panel header's number. */
+export function totalMb(views: readonly SessionMemoryView[]): number {
+  return views.reduce((sum, v) => sum + v.row.totalMb, 0)
+}

--- a/src/renderer/state/sessionMemory.test.ts
+++ b/src/renderer/state/sessionMemory.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useSessionMemory, HOST_POLL_MS } from './sessionMemory'
+import { createSession, resetSessionsForTest, setActiveSession } from '../session/session'
+import type { NodeTerminalApi } from '@shared/types'
+
+const host = vi.fn()
+const read = vi.fn()
+
+/** Let the pending microtasks (an awaited api call) settle without advancing the clock. */
+const flush = async (): Promise<void> => {
+  await vi.advanceTimersByTimeAsync(0)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  host.mockReset().mockResolvedValue({ availableMb: 1000, totalMb: 64000 })
+  read.mockReset().mockResolvedValue({ ok: true, rows: [], mem: null })
+  // The store reads through the ACTIVE SESSION's api (the same route state/worktrees.ts takes), so
+  // register a session whose api carries the mocks. Store construction touches no wire.
+  resetSessionsForTest()
+  setActiveSession(
+    createSession('local', { sessionMemory: { host, read } } as unknown as NodeTerminalApi, 'test')
+      .id
+  )
+  useSessionMemory.setState({ ok: true, rows: [], mem: null, loading: false, loadedScope: null })
+})
+
+afterEach(() => {
+  useSessionMemory.getState().stopHostPoll()
+  vi.useRealTimers()
+})
+
+describe('host poll cadence', () => {
+  it('polls repeatedly for a LOCAL scope', async () => {
+    useSessionMemory.getState().startHostPoll('', 'p1')
+    await vi.advanceTimersByTimeAsync(HOST_POLL_MS * 2 + 10)
+    // one immediate read + two ticks
+    expect(host.mock.calls.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('reads ONCE and schedules nothing for an SSH scope', async () => {
+    useSessionMemory.getState().startHostPoll('user@host', 'p1')
+    await vi.advanceTimersByTimeAsync(HOST_POLL_MS * 3)
+    // Each read is an ssh exec on someone else's machine — never on a timer.
+    expect(host).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops the local timer when the scope becomes an SSH host', async () => {
+    useSessionMemory.getState().startHostPoll('', 'p1')
+    await vi.advanceTimersByTimeAsync(HOST_POLL_MS + 10)
+    host.mockClear()
+    useSessionMemory.getState().startHostPoll('user@host', 'ssh1')
+    await vi.advanceTimersByTimeAsync(HOST_POLL_MS * 3)
+    // Only the one immediate read the switch itself performed — the local interval must be gone.
+    expect(host).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the query the shell is handed', () => {
+  it('tells the shell an SSH scope is remote, with the project that names the host', async () => {
+    useSessionMemory.getState().startHostPoll('user@host', 'ssh1')
+    await flush()
+    await useSessionMemory.getState().refreshFull('user@host', 'ssh1')
+    // `remote` is one of the two independent sources the service routes on — dropping it would let
+    // an SSH scope be answered with the local machine's sessions.
+    expect(host).toHaveBeenCalledWith({ projectId: 'ssh1', remote: true })
+    expect(read).toHaveBeenCalledWith({ projectId: 'ssh1', remote: true })
+  })
+
+  it('marks a local scope not-remote', async () => {
+    await useSessionMemory.getState().refreshFull('', 'p1')
+    expect(read).toHaveBeenCalledWith({ projectId: 'p1', remote: false })
+  })
+})
+
+describe('scope guarding', () => {
+  it('discards a response whose scope we have since left', async () => {
+    let release: (v: unknown) => void = () => {}
+    read.mockReturnValueOnce(new Promise((r) => (release = r)))
+    const p = useSessionMemory.getState().refreshFull('user@host', 'ssh1')
+    // Switch to the local machine while the SSH read is still in flight.
+    useSessionMemory.getState().startHostPoll('', 'p1')
+    release({ ok: true, rows: [{ nodeId: 'ghost' }], mem: null })
+    await p
+    expect(useSessionMemory.getState().rows).toEqual([])
+    expect(useSessionMemory.getState().loadedScope).not.toBe('user@host')
+  })
+
+  it('discards a HOST reading from a scope we have since left', async () => {
+    let release: (v: unknown) => void = () => {}
+    host.mockReturnValueOnce(new Promise((r) => (release = r)))
+    useSessionMemory.getState().startHostPoll('user@host', 'ssh1')
+    // Back to this machine; its own read answers with the default 64 GB fixture.
+    useSessionMemory.getState().startHostPoll('', 'p1')
+    await flush()
+    release({ availableMb: 7, totalMb: 7 })
+    await flush()
+    // The host's 7 MB must never be shown under the local machine's label.
+    expect(useSessionMemory.getState().mem).toEqual({ availableMb: 1000, totalMb: 64000 })
+  })
+
+  it('drops the previous scope´s rows the moment the scope changes', async () => {
+    read.mockResolvedValueOnce({
+      ok: true,
+      rows: [{ nodeId: 'remote-node' }],
+      mem: { availableMb: 5, totalMb: 10 }
+    })
+    await useSessionMemory.getState().refreshFull('user@host', 'ssh1')
+    expect(useSessionMemory.getState().rows).toHaveLength(1)
+    useSessionMemory.getState().startHostPoll('', 'p1')
+    // Not "stale rows under a new label" — no rows at all until the local machine answers.
+    expect(useSessionMemory.getState().rows).toEqual([])
+    expect(useSessionMemory.getState().loadedScope).toBeNull()
+  })
+})
+
+describe('failure semantics', () => {
+  it('keeps ok:false and no rows — never an empty success', async () => {
+    read.mockResolvedValueOnce({ ok: false, rows: [], mem: null })
+    await useSessionMemory.getState().refreshFull('', 'p1')
+    expect(useSessionMemory.getState().ok).toBe(false)
+    expect(useSessionMemory.getState().rows).toEqual([])
+  })
+
+  it('reports a rejected read as ok:false, not as an empty session list', async () => {
+    read.mockRejectedValueOnce(new Error('bridge down'))
+    await useSessionMemory.getState().refreshFull('', 'p1')
+    expect(useSessionMemory.getState().ok).toBe(false)
+  })
+
+  it('leaves mem null when the host read throws, rather than reporting zero', async () => {
+    // Start from a KNOWN reading, so "still null" cannot pass just because null is the initial
+    // state — the assertion has to prove the failure actually cleared it.
+    await useSessionMemory.getState().refreshHost('', 'p1')
+    expect(useSessionMemory.getState().mem).toEqual({ availableMb: 1000, totalMb: 64000 })
+    host.mockRejectedValueOnce(new Error('nope'))
+    await useSessionMemory.getState().refreshHost('', 'p1')
+    expect(useSessionMemory.getState().mem).toBeNull()
+  })
+
+  it('clears loading after refreshFull', async () => {
+    await useSessionMemory.getState().refreshFull('', 'p1')
+    expect(useSessionMemory.getState().loading).toBe(false)
+  })
+
+  it('leaves no spinner behind when the scope changes mid-read', async () => {
+    let release: (v: unknown) => void = () => {}
+    read.mockReturnValueOnce(new Promise((r) => (release = r)))
+    const p = useSessionMemory.getState().refreshFull('user@host', 'ssh1')
+    useSessionMemory.getState().startHostPoll('', 'p1')
+    release({ ok: true, rows: [], mem: null })
+    await p
+    expect(useSessionMemory.getState().loading).toBe(false)
+  })
+})

--- a/src/renderer/state/sessionMemory.ts
+++ b/src/renderer/state/sessionMemory.ts
@@ -1,0 +1,134 @@
+// Session-memory store. Two cadences, because the two reads cost wildly different things:
+//   - `refreshHost` is one file read locally → safe to poll (the pill's number).
+//   - `refreshFull` walks the whole process table, and over SSH it is an exec on someone else's
+//     machine → on demand only (panel open, refresh button). Never on a timer.
+//
+// Scope changes are guarded the way state/worktrees.ts guards project switches, except the stamp
+// here is the SCOPE ITSELF rather than a counter: a response stamped with a scope we have since
+// left is DISCARDED, so an SSH host's rows (or its RAM number) can never land under the local
+// machine's label. A counter alone is not enough — `refreshFull` and `startHostPoll` can be called
+// for different scopes without any intervening bump, which is exactly the switch this must catch.
+
+import { create } from 'zustand'
+import type { MemInfo, SessionMemoryApi, SessionMemoryQuery, SessionMemoryRow } from '@shared/types'
+import { activeSessionApi, sessionForProject } from '../session/session'
+
+/** How often the pill re-reads the LOCAL machine's RAM. Local only — see `startHostPoll`. */
+export const HOST_POLL_MS = 30_000
+
+interface SessionMemoryState {
+  ok: boolean
+  rows: SessionMemoryRow[]
+  mem: MemInfo | null
+  loading: boolean
+  /** Scope key the current rows belong to; null before the first successful load. */
+  loadedScope: string | null
+  refreshHost(scopeKey: string, projectId?: string): Promise<void>
+  refreshFull(scopeKey: string, projectId?: string): Promise<void>
+  startHostPoll(scopeKey: string, projectId?: string): void
+  stopHostPoll(): void
+}
+
+let timer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * The scope every in-flight request is measured against. `null` before the first request. Module
+ * level, not store state, because a stale response must be judged against the scope that is CURRENT
+ * when it resolves — reading it out of a store snapshot captured before the await would defeat the
+ * whole guard.
+ */
+let activeScope: string | null = null
+
+const query = (scopeKey: string, projectId?: string): SessionMemoryQuery => ({
+  projectId,
+  // The renderer's half of the routing decision: it already knows from `usageScope` whether the
+  // active project runs on an SSH host. The shell confirms it independently; dropping it here would
+  // leave a not-yet-registered SSH project to be answered with the local machine's sessions.
+  remote: scopeKey !== ''
+})
+
+/**
+ * The api of the session that owns this project — NOT `window.nodeTerminal`. A relay tab's renderer
+ * runs on the guest while its sessions live on the host, and its api deliberately answers
+ * `ok:false` / `null` ("could not measure") rather than describing the wrong machine; reading the
+ * global would silently hand it this machine's sessions instead.
+ */
+const api = (projectId?: string): SessionMemoryApi =>
+  projectId ? sessionForProject(projectId).api.sessionMemory : activeSessionApi().sessionMemory
+
+export const useSessionMemory = create<SessionMemoryState>((set, get) => ({
+  ok: true,
+  rows: [],
+  mem: null,
+  loading: false,
+  loadedScope: null,
+
+  async refreshHost(scopeKey, projectId) {
+    enterScope(scopeKey, set)
+    let mem: MemInfo | null = null
+    try {
+      mem = await api(projectId).host(query(scopeKey, projectId))
+    } catch {
+      mem = null // could not read — the pill says "unknown"; it must not claim 0.
+    }
+    if (scopeKey !== activeScope) return
+    set({ mem })
+  },
+
+  async refreshFull(scopeKey, projectId) {
+    enterScope(scopeKey, set)
+    set({ loading: true })
+    try {
+      const r = await api(projectId).read(query(scopeKey, projectId))
+      if (scopeKey !== activeScope) return
+      // `ok:false` is carried through untouched: the panel renders "could not measure", never an
+      // empty session list.
+      set({ ok: r.ok, rows: r.rows, mem: r.mem, loadedScope: scopeKey })
+    } catch {
+      // A rejected call (dead WS bridge, no session yet) is the same fact as `ok:false` — the sweep
+      // could not run. It is emphatically not "there are no sessions".
+      if (scopeKey !== activeScope) return
+      set({ ok: false, rows: [] })
+    } finally {
+      // A response for a scope we have left owns nothing here — `enterScope` already cleared the
+      // spinner when it switched.
+      if (scopeKey === activeScope) set({ loading: false })
+    }
+  },
+
+  startHostPoll(scopeKey, projectId) {
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+    void get().refreshHost(scopeKey, projectId)
+    // SSH scope: one read, no timer. Every tick would be an ssh exec plus a `ps` of somebody else's
+    // whole process table — the same rule CLAUDE.md sets for remote usage ("on demand, never
+    // polled").
+    if (scopeKey !== '') return
+    timer = setInterval(() => void get().refreshHost(scopeKey, projectId), HOST_POLL_MS)
+  },
+
+  stopHostPoll() {
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+}))
+
+type SetState = (partial: Partial<SessionMemoryState>) => void
+
+/**
+ * Adopt `scopeKey` as the scope every in-flight response is judged against, and — when it actually
+ * changed — drop the previous machine's facts. Keeping them would leave one host's rows on screen
+ * under another's label for as long as the new machine takes to answer, which is the same
+ * misattribution the stamp check exists to prevent, just visible for a shorter while.
+ */
+function enterScope(scopeKey: string, set: SetState): void {
+  if (activeScope === scopeKey) return
+  activeScope = scopeKey
+  // `loading:false` too: whatever was in flight now belongs to a scope we have left, so its
+  // `finally` will (correctly) not clear the spinner it set.
+  set({ ok: true, rows: [], mem: null, loading: false, loadedScope: null })
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5808,6 +5808,14 @@ body,
   color: rgba(var(--tint-rgb), 0.45);
   font-variant-numeric: tabular-nums;
 }
+/* The attribution line: quieter than a row, above the foot rule, and rendered in EVERY state — a
+   failed sweep is exactly when a user is most likely to be blaming the wrong process. */
+.sessmem-panel__attrib {
+  margin-top: 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: rgba(var(--tint-rgb), 0.45);
+}
 .sessmem-panel__foot {
   display: flex;
   align-items: center;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5453,11 +5453,28 @@ body,
   background: rgba(10, 132, 255, 0.14);
 }
 
-/* ---- Claude usage indicator (bottom-left, right of React Flow Controls) ---- */
-.usage-indicator {
+/* ---- Bottom-left pill cluster (usage + system resources) ----
+   ONE flex row, because neither pill can hard-code an offset for the other: the usage pill's width
+   changes with every number it prints, and it is absent altogether for a user with no agent
+   subscription at all.
+   Deliberately carries NO z-index: an absolutely positioned box with `z-index: auto` establishes no
+   stacking context, so each pill's own z-index (5 / 13 / 26 / 60) keeps competing with the sessions
+   sidebar and the kanban overlay exactly as it did when each was anchored on its own. Do not add
+   z-index, transform, filter or opacity here — any of them would trap both pills below the sidebar. */
+.canvas-pills {
   position: absolute;
   left: 60px; /* clear the React Flow Controls column */
   bottom: 18px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ---- Claude usage indicator (in the bottom-left cluster) ---- */
+.usage-indicator {
+  /* Positioned — so the z-index rules below still apply and the popover anchors here — but PLACED
+     by the cluster above rather than by its own left/bottom. */
+  position: relative;
   z-index: 5;
   display: flex;
   align-items: center;
@@ -5480,7 +5497,10 @@ body,
 .usage-indicator--board:has(.usage-popover) {
   z-index: 60; /* over the board + banners, below ConfirmDialog/palette (70) */
 }
-.usage-pill {
+/* The two pills share one shell so they read as a single control rather than as two widgets that
+   happen to be adjacent. Grouped rather than duplicated, so tuning one can never drift the other. */
+.usage-pill,
+.sysres-pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -5496,7 +5516,8 @@ body,
 }
 .usage-pill:hover { background: rgba(44, 44, 46, 0.95); }
 .usage-pill__icon { color: #d97757; font-size: 13px; }
-.usage-pill__minibar {
+.usage-pill__minibar,
+.sysres-pill__minibar {
   display: inline-block;
   width: 42px;
   height: 6px;
@@ -5504,15 +5525,52 @@ body,
   background: rgba(var(--tint-rgb), 0.14);
   overflow: hidden;
 }
-.usage-pill__minibar-fill { display: block; height: 100%; border-radius: 3px; }
-.usage-pill__num { color: var(--text-strong); }
-.usage-pill__sep { color: rgba(var(--tint-rgb), 0.4); }
+.usage-pill__minibar-fill,
+.sysres-pill__minibar-fill { display: block; height: 100%; border-radius: 3px; }
+.usage-pill__num,
+.sysres-pill__num { color: var(--text-strong); }
+.usage-pill__sep,
+.sysres-pill__sep { color: rgba(var(--tint-rgb), 0.4); }
 /* Non-Claude provider segments read one step quieter than the Claude numbers, so a long pill
    still scans as "Claude first, others after" without needing separate icons per provider. */
 .usage-pill__provider .usage-pill__num { color: rgba(var(--tint-rgb), 0.75); font-size: 11px; }
-.usage-pill__dim { color: rgba(var(--tint-rgb), 0.5); }
-.usage-pill__pulse { animation: usage-pulse 1.2s ease-in-out infinite; }
+.usage-pill__dim,
+.sysres-pill__dim { color: rgba(var(--tint-rgb), 0.5); }
+.usage-pill__pulse,
+.sysres-pill__pulse { animation: usage-pulse 1.2s ease-in-out infinite; }
 @keyframes usage-pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* ---- System-resource pill (RAM of the machine the active project runs on) ----
+   Shares the usage pill's shell above; only the bits that differ live here. */
+.sysres-indicator {
+  position: relative;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+}
+/* Kanban board is an opaque overlay at z 25; while it's open this pill must sit ABOVE it (same
+   layer as the controls cluster), or the board's bottom-left corner swallows it. Mirrors
+   `.usage-indicator--board`. */
+.sysres-indicator--board {
+  z-index: 26;
+}
+/* Not a copy of `.usage-pill:hover`: that rule's literal is a dark-theme colour, which would read
+   as a black smear on the light theme. An ink overlay over the same card surface lifts it in BOTH
+   themes (the tint token flips with the theme). */
+.sysres-pill:hover {
+  background:
+    linear-gradient(rgba(var(--tint-rgb), 0.08), rgba(var(--tint-rgb), 0.08)),
+    rgba(var(--card-rgb), 0.92);
+}
+/* A word, not a glyph: "12.4 GB / 62.5 GB" beside a quota pill is ambiguous about what is being
+   measured, and every symbol for memory is either an emoji or a guess. Set quiet — it is a unit
+   label, not a value. */
+.sysres-pill__icon {
+  color: rgba(var(--tint-rgb), 0.5);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
 
 .usage-refresh {
   display: inline-flex;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5554,6 +5554,16 @@ body,
 .sysres-indicator--board {
   z-index: 26;
 }
+/* While the session-memory panel is open, rise above the sessions sidebar (z 12) — a tall sidebar
+   reaches the bottom-left corner and would cover the panel. Exactly the pairing
+   `.usage-indicator:has(.usage-popover)` uses, and it only works because the cluster is mounted
+   OUTSIDE <ReactFlow> (whose wrapper's inline `z-index: 0` would trap any inner value). */
+.sysres-indicator:has(.sessmem-panel) {
+  z-index: 13;
+}
+.sysres-indicator--board:has(.sessmem-panel) {
+  z-index: 60; /* over the board + banners, below ConfirmDialog/palette (70) */
+}
 /* Not a copy of `.usage-pill:hover`: that rule's literal is a dark-theme colour, which would read
    as a black smear on the light theme. An ink overlay over the same card surface lifts it in BOTH
    themes (the tint token flips with the theme). */
@@ -5647,6 +5657,184 @@ body,
   background: rgba(var(--tint-rgb), 0.08);
   vertical-align: middle;
 }
+
+/* ---- Session-memory panel (opened by the system-resource pill) ----
+   Same surface, border and shadow as `.usage-popover` above — the two panels open from adjacent
+   pills in the same corner, so anything that made them read as different kinds of thing would be
+   an accident. Wider, because a row carries a title, a project, a command and a number. */
+.sessmem-panel {
+  position: absolute;
+  bottom: 34px;
+  left: 0;
+  width: 380px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(var(--popover-rgb), 0.98);
+  border: 1px solid rgba(var(--tint-rgb), 0.1);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, calc(0.5 * var(--shadow-k)));
+  color: var(--text-strong);
+}
+.sessmem-panel__head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.sessmem-panel__title { font-size: 14px; font-weight: 600; }
+.sessmem-panel__scope {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: rgba(var(--tint-rgb), 0.5);
+}
+.sessmem-panel__total {
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-strong);
+}
+/* One voice for all four non-list states (relay / could-not-measure / measuring / nothing here).
+   They are different SENTENCES, deliberately, but they are the same kind of answer. */
+.sessmem-panel__note {
+  padding: 10px 2px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: rgba(var(--tint-rgb), 0.6);
+}
+.sessmem-panel__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  /* Every row is rendered — the list SCROLLS rather than truncating. A cap would have to say so. */
+  max-height: 320px;
+  overflow-y: auto;
+}
+.sessmem-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.sessmem-row__main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 6px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.sessmem-row__main:hover:not(:disabled) { background: rgba(var(--tint-rgb), 0.08); }
+/* An orphan has nowhere to travel to, so the row is inert rather than misleadingly clickable —
+   but it keeps full contrast: it is still a session the user may want to end. */
+.sessmem-row__main:disabled { cursor: default; }
+.sessmem-row__dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.sessmem-row__dot--working {
+  background: var(--success);
+  /* Reuse the terminal-header badge pulse rather than a bespoke keyframe. */
+  animation: nt-pulse 1.1s ease-in-out infinite;
+}
+.sessmem-row__dot--attention { background: var(--warn); }
+.sessmem-row__dot--idle { background: rgba(var(--tint-rgb), 0.3); }
+/* Hollow = orphan: there is no node to have a state, and a filled neutral dot would read "idle". */
+.sessmem-row__dot--hollow {
+  background: transparent;
+  border: 1px solid rgba(var(--tint-rgb), 0.35);
+  animation: none;
+}
+.sessmem-row__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Where this session lives, shown only when it is NOT the project you are looking at — most often
+   a closed project, whose sessions keep running. */
+.sessmem-row__project,
+.sessmem-row__orphan {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 10px;
+  color: rgba(var(--tint-rgb), 0.55);
+  background: rgba(var(--tint-rgb), 0.08);
+}
+.sessmem-row__cmd {
+  flex: 0 0 auto;
+  max-width: 90px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: rgba(var(--tint-rgb), 0.45);
+}
+.sessmem-row__mb {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-strong);
+}
+.sessmem-row__kill {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(var(--tint-rgb), 0.45);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+.sessmem-row__kill:hover { color: var(--danger); background: rgba(var(--tint-rgb), 0.08); }
+/* The pane's descendants — the agent CLI itself included, since pane_pid is the pane's shell. */
+.sessmem-row__kids {
+  flex: 1 0 100%;
+  padding: 0 6px 4px 20px;
+  font-size: 11px;
+  color: rgba(var(--tint-rgb), 0.45);
+  font-variant-numeric: tabular-nums;
+}
+.sessmem-panel__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(var(--tint-rgb), 0.1);
+  font-size: 11px;
+  color: rgba(var(--tint-rgb), 0.5);
+}
+.sessmem-panel__refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 11px;
+  background: transparent;
+  color: rgba(var(--tint-rgb), 0.7);
+  font-size: 13px;
+  cursor: pointer;
+}
+.sessmem-panel__refresh:hover { color: var(--text-strong); background: rgba(var(--tint-rgb), 0.08); }
+.sessmem-panel__refresh:disabled { opacity: 0.4; cursor: default; }
+/* Same spin as the usage panel's refresh. */
+.sessmem-panel__refresh.spin { animation: usage-spin 0.9s linear infinite; }
 
 /* ---- Claude context-window meter (per-node header pill + popover) ---- */
 .ctx-meter {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5499,29 +5499,37 @@ body,
 }
 /* The two pills share one shell so they read as a single control rather than as two widgets that
    happen to be adjacent. Grouped rather than duplicated, so tuning one can never drift the other. */
+/* SHARED SHELL — both pills. Do not fold pill-specific sizing in here: the system-resource pill's
+   icon-only collapse lives in its OWN rule below, because putting it here silently shrank the usage
+   pill to a 26px circle too. */
 .usage-pill,
-/* Icon-only at rest: the pill is ambient chrome, and a permanent "RAM 15.6 / 62.5 GB" is a row of
-   numbers nobody asked for on every canvas. The detail is revealed on hover (and while the panel is
-   open, so the control does not shrink out from under the cursor that opened it). */
 .sysres-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0;
+  gap: 6px;
   height: 26px;
-  width: 26px;
-  padding: 0;
-  justify-content: center;
+  padding: 0 9px;
   border-radius: 13px;
-  transition:
-    width 140ms ease,
-    padding 140ms ease,
-    gap 140ms ease;
   background: rgba(var(--card-rgb), 0.92);
   border: 1px solid rgba(var(--tint-rgb), 0.08);
   color: var(--text-strong);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
   cursor: pointer;
+}
+/* Icon-only at rest — this pill ONLY. It is ambient chrome on every canvas, so a permanent
+   "RAM 15.6 GB / 62.5 GB" is a row of numbers nobody asked for. Overrides the shared shell's
+   padding/gap; the detail is revealed on hover (and while the panel is open, so the control does
+   not shrink out from under the cursor that opened it). */
+.sysres-pill {
+  width: 26px;
+  padding: 0;
+  gap: 0;
+  justify-content: center;
+  transition:
+    width 140ms ease,
+    padding 140ms ease,
+    gap 140ms ease;
 }
 .usage-pill:hover { background: rgba(44, 44, 46, 0.95); }
 .usage-pill__icon { color: #d97757; font-size: 13px; }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5500,13 +5500,22 @@ body,
 /* The two pills share one shell so they read as a single control rather than as two widgets that
    happen to be adjacent. Grouped rather than duplicated, so tuning one can never drift the other. */
 .usage-pill,
+/* Icon-only at rest: the pill is ambient chrome, and a permanent "RAM 15.6 / 62.5 GB" is a row of
+   numbers nobody asked for on every canvas. The detail is revealed on hover (and while the panel is
+   open, so the control does not shrink out from under the cursor that opened it). */
 .sysres-pill {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 0;
   height: 26px;
-  padding: 0 9px;
+  width: 26px;
+  padding: 0;
+  justify-content: center;
   border-radius: 13px;
+  transition:
+    width 140ms ease,
+    padding 140ms ease,
+    gap 140ms ease;
   background: rgba(var(--card-rgb), 0.92);
   border: 1px solid rgba(var(--tint-rgb), 0.08);
   color: var(--text-strong);
@@ -5516,8 +5525,7 @@ body,
 }
 .usage-pill:hover { background: rgba(44, 44, 46, 0.95); }
 .usage-pill__icon { color: #d97757; font-size: 13px; }
-.usage-pill__minibar,
-.sysres-pill__minibar {
+.usage-pill__minibar {
   display: inline-block;
   width: 42px;
   height: 6px;
@@ -5525,8 +5533,7 @@ body,
   background: rgba(var(--tint-rgb), 0.14);
   overflow: hidden;
 }
-.usage-pill__minibar-fill,
-.sysres-pill__minibar-fill { display: block; height: 100%; border-radius: 3px; }
+.usage-pill__minibar-fill { display: block; height: 100%; border-radius: 3px; }
 .usage-pill__num,
 .sysres-pill__num { color: var(--text-strong); }
 .usage-pill__sep,
@@ -5539,6 +5546,40 @@ body,
 .usage-pill__pulse,
 .sysres-pill__pulse { animation: usage-pulse 1.2s ease-in-out infinite; }
 @keyframes usage-pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* Expanded: hover, keyboard focus, or an open panel. `width: auto` cannot be transitioned, so the
+   pill animates padding/gap only and the detail carries the width — enough to read as a reveal
+   rather than a jump, without a magic max-width that clips a wider number (a 1 TB host prints
+   more characters than a 16 GB one). */
+.sysres-pill:hover,
+.sysres-pill:focus-visible,
+.sysres-indicator:has(.sessmem-panel) .sysres-pill {
+  width: auto;
+  gap: 6px;
+  padding: 0 9px;
+}
+/* Present in the DOM at rest (so the accessible name and any assertion still see the number) but
+   taking no space until the pill expands. */
+.sysres-pill__detail {
+  display: inline-block;
+  max-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  opacity: 0;
+  transition:
+    max-width 140ms ease,
+    opacity 140ms ease;
+}
+.sysres-pill:hover .sysres-pill__detail,
+.sysres-pill:focus-visible .sysres-pill__detail,
+.sysres-indicator:has(.sessmem-panel) .sysres-pill__detail {
+  max-width: 200px;
+  opacity: 1;
+}
+.sysres-pill__icon {
+  display: inline-flex;
+  color: rgba(var(--tint-rgb), 0.75);
+}
 
 /* ---- System-resource pill (RAM of the machine the active project runs on) ----
    Shares the usage pill's shell above; only the bits that differ live here. */
@@ -5572,16 +5613,6 @@ body,
     linear-gradient(rgba(var(--tint-rgb), 0.08), rgba(var(--tint-rgb), 0.08)),
     rgba(var(--card-rgb), 0.92);
 }
-/* A word, not a glyph: "12.4 GB / 62.5 GB" beside a quota pill is ambiguous about what is being
-   measured, and every symbol for memory is either an emoji or a guess. Set quiet — it is a unit
-   label, not a value. */
-.sysres-pill__icon {
-  color: rgba(var(--tint-rgb), 0.5);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-
 .usage-refresh {
   display: inline-flex;
   align-items: center;

--- a/src/renderer/styles.pills.test.ts
+++ b/src/renderer/styles.pills.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Guard on the bottom-left pill cluster's SHARED shell.
+ *
+ * Written after a real regression: the system-resource pill was collapsed to an icon by editing
+ * what looked like a `.sysres-pill` rule — but the selector was `.usage-pill, .sysres-pill`, so the
+ * `width: 26px; padding: 0` landed on the Claude usage pill too and squashed it into a circle. The
+ * two pills sit side by side and share a shell deliberately; the failure mode is that a change
+ * aimed at one silently reshapes the other, and nothing rendered in CI would have caught it.
+ *
+ * The rule this pins: the shared block carries only what BOTH pills want. Per-pill sizing lives in
+ * a rule whose selector names exactly one pill.
+ */
+
+const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
+
+/**
+ * The declaration body of the rule whose selector list is EXACTLY `selectors`.
+ *
+ * Parses rules rather than regexing the selector, because a regex anchored on `\n.sysres-pill {`
+ * also matches the CONTINUATION line of `.usage-pill,\n.sysres-pill {` — which is the very
+ * confusion this file exists to catch, and it caught the first draft of this helper.
+ */
+function ruleBody(selectors: string[]): string {
+  const want = selectors.join(',')
+  for (const chunk of CSS.split('}')) {
+    const brace = chunk.indexOf('{')
+    if (brace < 0) continue
+    const head = chunk
+      .slice(0, brace)
+      .replace(/\/\*[\s\S]*?\*\//g, '') // comments may sit between selectors
+      .split(',')
+      .map((sel) => sel.trim())
+      .filter(Boolean)
+      .join(',')
+    if (head === want) return chunk.slice(brace + 1)
+  }
+  throw new Error(`no rule whose selector list is exactly: ${want}`)
+}
+
+describe('bottom-left pill cluster', () => {
+  it('shares one shell between the usage pill and the resource pill', () => {
+    const shared = ruleBody(['.usage-pill', '.sysres-pill'])
+    expect(shared).toContain('height: 26px')
+    expect(shared).toContain('border-radius: 13px')
+  })
+
+  it('keeps per-pill SIZING out of the shared shell', () => {
+    // `width` and `justify-content` are the two that squashed the usage pill. A shared `padding` is
+    // fine (both want the same one) — what is not fine is a width, because only one pill collapses.
+    const shared = ruleBody(['.usage-pill', '.sysres-pill'])
+    expect(shared).not.toMatch(/(^|\s)width:/)
+    expect(shared).not.toMatch(/justify-content:/)
+  })
+
+  it('collapses ONLY the resource pill to an icon', () => {
+    const own = ruleBody(['.sysres-pill'])
+    expect(own).toContain('width: 26px')
+    // The proof it is the resource pill's alone: the shared block above must not have grown it.
+    const shared = ruleBody(['.usage-pill', '.sysres-pill'])
+    expect(shared).not.toContain('width: 26px')
+  })
+})

--- a/src/renderer/terminal/local-transport.ts
+++ b/src/renderer/terminal/local-transport.ts
@@ -57,8 +57,8 @@ export class LocalTransport implements TerminalTransport {
     this.pty.kill(sessionId, this.viewerId)
   }
 
-  destroy(persistKey: string): void {
-    this.pty.destroy(persistKey)
+  destroy(persistKey: string, opts?: { everySocket?: boolean }): void {
+    this.pty.destroy(persistKey, opts)
   }
 
   recycle(persistKey: string): void {

--- a/src/renderer/terminal/transport.ts
+++ b/src/renderer/terminal/transport.ts
@@ -26,8 +26,12 @@ export interface TerminalTransport {
   /**
    * Permanently ends a node's persistent session because the node is being DELETED (× / delete).
    * Co-viewers are told "closed by <name>" and must never respawn it.
+   *
+   * `opts.everySocket` widens a kill for a session this process holds NOTHING for to every local
+   * tmux socket the name could be on. Opt-in for the session-memory panel's speculative kill only
+   * (see `localKillSockets`); an ordinary × leaves it unset.
    */
-  destroy(persistKey: string): void
+  destroy(persistKey: string, opts?: { everySocket?: boolean }): void
   /**
    * Ends a node's persistent session so the SAME node id can respawn in a new cwd ("move into
    * worktree"). The tmux kill is identical to `destroy` — without it the respawn would just

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -50,6 +50,7 @@ import { createPushNotify, createLiveUpdatePush } from '../core/push-notify'
 import { createGrantsAccessor } from '../core/push-grants'
 import { createAckSweeper } from '../core/ack-sweep'
 import { createSessionReaper } from '../core/session-budget'
+import { startSessionMemoryService } from '../core/session-memory-service'
 import { claudeCliCaps, type ClaudeCliCaps } from '../core/claude-cli'
 import { claudeConfigDirFor } from '../core/claude-config-dir'
 import { presenceHub } from '../core/presence/hub'
@@ -442,6 +443,13 @@ export async function startServer(
   // open. Kill switch + tuning via NODETERM_SESSION_* env (core/session-budget.ts).
   const sessionReaper = createSessionReaper({ tmuxBin: () => ptyManager.getTmuxBin() })
   sessionReaper.start()
+
+  // Session memory: the pill's RAM read plus the on-demand per-session breakdown. No remote deps —
+  // the Server Edition runs ON the host whose sessions it reports and has no SSH-project manager.
+  // An SSH scope therefore answers ok:false rather than mis-attributing this machine's sessions to
+  // another host. Registered here (not in handlers/index.ts) because this is where `ptyManager`
+  // lives — the same call site as the reaper above, mirroring src/main/index.ts.
+  startSessionMemoryService({ tmuxBin: () => ptyManager.getTmuxBin() })
 
   // Headless notification host: every core service above (incl. the loopback hook server, which
   // is its own listener and MUST run) is booted, but we bind NO public HTTP/WS listener — no

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -50,7 +50,7 @@ import { createPushNotify, createLiveUpdatePush } from '../core/push-notify'
 import { createGrantsAccessor } from '../core/push-grants'
 import { createAckSweeper } from '../core/ack-sweep'
 import { createSessionReaper } from '../core/session-budget'
-import { startSessionMemoryService } from '../core/session-memory-service'
+import { startSessionMemoryService, sshScopePredicate } from '../core/session-memory-service'
 import { claudeCliCaps, type ClaudeCliCaps } from '../core/claude-cli'
 import { claudeConfigDirFor } from '../core/claude-config-dir'
 import { presenceHub } from '../core/presence/hub'
@@ -444,12 +444,24 @@ export async function startServer(
   const sessionReaper = createSessionReaper({ tmuxBin: () => ptyManager.getTmuxBin() })
   sessionReaper.start()
 
-  // Session memory: the pill's RAM read plus the on-demand per-session breakdown. No remote deps —
-  // the Server Edition runs ON the host whose sessions it reports and has no SSH-project manager.
-  // An SSH scope therefore answers ok:false rather than mis-attributing this machine's sessions to
-  // another host. Registered here (not in handlers/index.ts) because this is where `ptyManager`
-  // lives — the same call site as the reaper above, mirroring src/main/index.ts.
-  startSessionMemoryService({ tmuxBin: () => ptyManager.getTmuxBin() })
+  // Session memory: the pill's RAM read plus the on-demand per-session breakdown. The Server
+  // Edition runs ON the host whose sessions it reports and has no SSH-project manager, so it passes
+  // no `run` — an SSH scope is REFUSED (ok:false), never swept locally.
+  //
+  // It does supply `isRemoteProject`, because knowing which projects are somebody else's machine
+  // and being able to READ them are different capabilities: the workspace index answers the first
+  // right here (the same source as the SSH check in the agentAnswerPermission handler above).
+  // Without it, an SSH query arriving WITHOUT the renderer's `remote` flag would fall through to
+  // the local sweep and publish this server's own sessions under the remote host's name — the exact
+  // misattribution the refusal exists to prevent. Registered here (not in handlers/index.ts)
+  // because this is where `ptyManager` lives — the same call site as the reaper above, mirroring
+  // src/main/index.ts.
+  startSessionMemoryService({
+    tmuxBin: () => ptyManager.getTmuxBin(),
+    remote: {
+      isRemoteProject: sshScopePredicate({ sshProjectIds: () => workspaceStore.sshProjectIds() })
+    }
+  })
 
   // Headless notification host: every core service above (incl. the loopback hook server, which
   // is its own listener and MUST run) is booted, but we bind NO public HTTP/WS listener — no

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -456,6 +456,12 @@ export async function startServer(
   // misattribution the refusal exists to prevent. Registered here (not in handlers/index.ts)
   // because this is where `ptyManager` lives — the same call site as the reaper above, mirroring
   // src/main/index.ts.
+  //
+  // DEPENDENCY, and one that breaks silently: `sshProjectIds()` reads the IN-MEMORY index, which is
+  // populated only by the `await workspaceStore.load(...)` above — a line documented there as being
+  // for context-link. Move it below this point, or drop it, and every SSH project reads as local
+  // here: the refusal quietly degrades to renderer-flag-only routing, which is the misattribution
+  // bug itself. `test/server/session-memory-e2e.test.ts` exists to fail if that happens.
   startSessionMemoryService({
     tmuxBin: () => ptyManager.getTmuxBin(),
     remote: {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -459,9 +459,15 @@ export async function startServer(
   //
   // DEPENDENCY, and one that breaks silently: `sshProjectIds()` reads the IN-MEMORY index, which is
   // populated only by the `await workspaceStore.load(...)` above — a line documented there as being
-  // for context-link. Move it below this point, or drop it, and every SSH project reads as local
-  // here: the refusal quietly degrades to renderer-flag-only routing, which is the misattribution
-  // bug itself. `test/server/session-memory-e2e.test.ts` exists to fail if that happens.
+  // for context-link. Drop it, or stop awaiting it before `server.listen()` below, and every SSH
+  // project reads as local here: the refusal quietly degrades to renderer-flag-only routing, which
+  // is the misattribution bug itself. `test/server/session-memory-e2e.test.ts` exists to fail if
+  // that happens.
+  //
+  // What is NOT load-bearing is this boot's position relative to that load. `isRemoteProject` is a
+  // closure evaluated per QUERY, and no query can arrive before `startServer` reaches `listen()`,
+  // so reordering the two would change nothing. The requirement is that the load happens and is
+  // complete before the server serves — not that it precedes this line.
   startSessionMemoryService({
     tmuxBin: () => ptyManager.getTmuxBin(),
     remote: {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -115,6 +115,13 @@ export const IPC = {
   usageSetProviderCookie: 'usage:set-provider-cookie',
   /** Which cookie providers have one stored — lets the UI show state without handling secrets. */
   usageCookieProviders: 'usage:cookie-providers',
+  /** Per-session memory breakdown for the scoped machine. On demand only — never polled: the
+   *  local sweep walks the whole process table, and the SSH one is an exec on someone else's
+   *  host. */
+  sessionMemory: 'session-memory:read',
+  /** The scoped machine's RAM (available/total) — the cheap read behind the system-resource
+   *  pill. Safe to poll locally; NOT polled for an SSH scope. */
+  sessionMemoryHost: 'session-memory:host',
   contextUpdate: 'context:update',
   contextEnsure: 'context:ensure',
   // Team presence (docs/team-presence.md). `presence:hello` is a REQUEST: its response tells the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1459,6 +1459,35 @@ export interface MemInfo {
   totalMb: number
 }
 
+/** One nt- session's memory, as the panel renders it. */
+export interface SessionMemoryRow {
+  /** tmux session name, `nt-<nodeId>`. */
+  session: string
+  /** The canvas node id — the session name minus the `nt-` prefix. */
+  nodeId: string
+  panePid: number
+  /** The pane's own process. */
+  selfMb: number
+  /** Everything below it (MCP servers, headless browsers, …). */
+  childrenMb: number
+  childCount: number
+  totalMb: number
+  /** `#{pane_current_command}` — the agent/shell label. */
+  command: string
+}
+
+/**
+ * `ok: false` means the sweep could not run (no tmux binary, unreadable process table). It is NOT
+ * the same as an empty `rows` with `ok: true`, which means "we looked and there are no sessions".
+ * Collapsing the two would make the panel report "nothing is using memory" at exactly the moment
+ * it failed to measure.
+ */
+export interface SessionMemoryReport {
+  ok: boolean
+  rows: SessionMemoryRow[]
+  mem: MemInfo | null
+}
+
 /** Claude Code subscription usage snapshot for the bottom-left indicator. */
 export interface ClaudeUsage {
   /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1500,6 +1500,23 @@ export interface SessionMemoryQuery {
   remote?: boolean
 }
 
+/**
+ * Per-session memory for the machine the ACTIVE PROJECT runs on — the same scoping rule the usage
+ * indicator follows (`usageScope`), for the same reason: a number is meaningless without the
+ * machine it describes.
+ *
+ * Both members are on-demand only, never polled: a remote answer costs an ssh exec plus a `ps` of
+ * somebody else's whole process table. Pass the query through verbatim — `remote` is one of the two
+ * independent sources the service uses to decide which host answers.
+ */
+export interface SessionMemoryApi {
+  /** Per-session breakdown for the scoped machine. `ok:false` = the sweep could not run, which is
+   *  NOT an empty `rows` with `ok:true` ("we looked, there are none"). */
+  read(q?: SessionMemoryQuery): Promise<SessionMemoryReport>
+  /** The scoped machine's RAM. `null` = could not read (never "zero"). */
+  host(q?: SessionMemoryQuery): Promise<MemInfo | null>
+}
+
 /** Claude Code subscription usage snapshot for the bottom-left indicator. */
 export interface ClaudeUsage {
   /**
@@ -1989,6 +2006,7 @@ export interface NodeTerminalApi {
   githubIssues: import('./github-issues').GitHubIssuesApi
   githubControl: import('./github-issues').GitHubControlApi
   usage: UsageApi
+  sessionMemory: SessionMemoryApi
   context: ContextApi
   canvas: CanvasApi
   claude: ClaudeApi

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1488,6 +1488,18 @@ export interface SessionMemoryReport {
   mem: MemInfo | null
 }
 
+/**
+ * What the renderer asks for: the machine a project runs ON, never "this machine" implicitly.
+ * `remote: true` is the renderer saying it already knows (from `usageScope`) that the active
+ * project is an SSH one; the shell's own `isRemoteProject` is a second, independent confirmation,
+ * so a project the shell has not (yet) registered as connected still cannot be answered with the
+ * local machine's sessions.
+ */
+export interface SessionMemoryQuery {
+  projectId?: string
+  remote?: boolean
+}
+
 /** Claude Code subscription usage snapshot for the bottom-left indicator. */
 export interface ClaudeUsage {
   /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -532,8 +532,14 @@ export interface PtyApi {
    *  node attached; absent ⇒ the PRIMARY view. */
   kill(sessionId: string, viewerId?: string): void
   /** Permanently ends the persistent session for a node (kills its tmux session) because the node
-   *  is being DELETED. Co-viewers get `onClosed` and must not respawn it. */
-  destroy(persistKey: string): void
+   *  is being DELETED. Co-viewers get `onClosed` and must not respawn it.
+   *
+   *  `everySocket` (optional, trailing) widens a kill for a session we hold NOTHING for to every
+   *  local tmux socket the name could be on. Opt-in for one caller — the session-memory panel's
+   *  speculative kill of a row it swept off either socket. An ordinary node-× must not set it: it
+   *  takes the same unheld branch after an app restart, and `nodeterm-rmt` holds sessions another
+   *  machine's nodeterm SSHed in to spawn. */
+  destroy(persistKey: string, opts?: { everySocket?: boolean }): void
   /** Ends a node's persistent session so the SAME node id respawns in a new cwd ("move into
    *  worktree"). Same tmux kill as `destroy`, opposite intent: the node stays on the canvas, so
    *  co-viewers get `onRecycled` (restart + re-attach), never the permanent closed state. */
@@ -1103,8 +1109,17 @@ export interface SshProjectApi {
    * Authoritative teardown on project delete: works regardless of whether the nodes are
    * mounted, and must be awaited BEFORE disconnect (which kills the master). `nodeIds` are
    * raw node ids; main maps them to `nt-<id>` session names.
+   *
+   * `everySocket` widens the kill to every tmux socket on the host rather than the `nodeterm-rmt`
+   * one an SSH project spawns on. Opt-in for ONE caller — the session-memory panel, whose rows are
+   * swept off both sockets. Project deletion stays narrow: `node-terminal` on that host belongs to
+   * a nodeterm running ON it, not to us.
    */
-  killSessions(projectId: string, nodeIds: string[]): Promise<void>
+  killSessions(
+    projectId: string,
+    nodeIds: string[],
+    opts?: { everySocket?: boolean }
+  ): Promise<void>
   /** List remote sub-directories of `path` (default ~). */
   listDir(projectId: string, path: string): Promise<{ path: string; dirs: string[] }>
   /** Create a remote directory (mkdir -p). Resolves false when not connected or the mkdir fails. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1451,6 +1451,14 @@ export interface ProviderUsage {
   status: 'unavailable' | 'fetching' | 'ok' | 'error'
 }
 
+/** Host memory snapshot in MB. `null` from any reader means "could not read" — never "zero".
+ *  Shared because it crosses the wire for the system-resource pill; core reads it, the renderer
+ *  renders it. */
+export interface MemInfo {
+  availableMb: number
+  totalMb: number
+}
+
 /** Claude Code subscription usage snapshot for the bottom-left indicator. */
 export interface ClaudeUsage {
   /**

--- a/test/server/session-memory-e2e.test.ts
+++ b/test/server/session-memory-e2e.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import WebSocket from 'ws'
+import { startServer } from '../../src/server/index'
+import { IPC } from '../../src/shared/ipc'
+import type { MemInfo, SessionMemoryReport } from '../../src/shared/types'
+
+/**
+ * The Server Edition's session-memory refusal, end to end.
+ *
+ * The property under test is a SAFETY one: this server has no ControlMaster, so it can never read
+ * an SSH project's host — and answering such a query with its OWN sessions would publish one
+ * machine's memory under another machine's name. It must refuse instead, and it must do so from
+ * its own knowledge (the workspace index), NOT from a `remote: true` flag the renderer sends —
+ * which is why every request below deliberately omits that flag.
+ *
+ * Two couplings this pins that no unit test can:
+ *  1. the shell actually passes `isRemoteProject` (booting with no `remote` deps at all was the
+ *     original bug), and
+ *  2. `sshProjectIds()` has real data by the time a query arrives — i.e. the boot-time
+ *     `workspaceStore.load(...)`, whose comment attributes it to context-link, is load-bearing for
+ *     this refusal too.
+ *
+ * No network and no sshd: the ssh entry is only ever READ from the index here. `loadV3`'s ssh
+ * branch is offline (a cached project, else an `unavailable` placeholder) and `sshProjectIds()`
+ * returns the entry's id in either case.
+ */
+describe('server e2e: session memory refuses an SSH scope', () => {
+  let dataDir: string, close: () => Promise<void>, port: number, cookie: string
+
+  const SSH_ID = 'ssh-e2e'
+  const LOCAL_ID = 'local-e2e'
+
+  beforeAll(async () => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-sessmem-e2e-'))
+    // Written BEFORE boot: the index is read once at startup, and the refusal depends on it.
+    fs.writeFileSync(
+      path.join(dataDir, 'workspace.json'),
+      JSON.stringify({
+        version: 3,
+        activeProjectId: SSH_ID,
+        entries: [
+          {
+            id: SSH_ID,
+            name: 'ssh project',
+            color: '#888888',
+            ssh: { server: { host: 'example.invalid', user: 'nobody' }, remoteCwd: '/srv/x' }
+          },
+          { id: LOCAL_ID, name: 'local project', color: '#888888', project: { id: LOCAL_ID, name: 'local project', color: '#888888', nodes: [] } }
+        ]
+      })
+    )
+    const srv = await startServer({
+      port: 0,
+      host: '127.0.0.1',
+      dataDir,
+      rendererDir: path.join(dataDir, 'no-renderer'),
+      insecureHttp: false,
+      passwordSeed: 'e2e-password-123',
+      // Never touch the developer's real ~/.claude — see server-e2e.test.ts.
+      installHooks: false
+    })
+    port = srv.port
+    close = srv.close
+    const res = await fetch(`http://127.0.0.1:${port}/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'password=e2e-password-123',
+      redirect: 'manual'
+    })
+    expect(res.status).toBe(303)
+    cookie = res.headers.get('set-cookie')!.split(';')[0]
+  }, 30_000)
+
+  afterAll(async () => {
+    await close?.()
+    fs.rmSync(dataDir, { recursive: true, force: true })
+  })
+
+  /** One WS connection, several RPC calls, results keyed by request id. */
+  async function rpc(calls: { method: string; args: unknown[] }[]): Promise<unknown[]> {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, { headers: { cookie } })
+    await new Promise<void>((res, rej) => {
+      ws.on('open', () => res())
+      ws.on('error', rej)
+    })
+    try {
+      const results = new Map<number, unknown>()
+      await new Promise<void>((resolve, reject) => {
+        ws.on('message', (d, isBinary) => {
+          if (isBinary) return
+          const m = JSON.parse(d.toString())
+          if (m.t !== 'res') return
+          if (!m.ok) return reject(new Error(`${calls[m.id - 1]?.method} rejected: ${m.error}`))
+          results.set(m.id, m.result)
+          if (results.size === calls.length) resolve()
+        })
+        calls.forEach((c, i) => ws.send(JSON.stringify({ t: 'req', id: i + 1, method: c.method, args: c.args })))
+        setTimeout(() => reject(new Error('session-memory rpc timed out')), 20_000)
+      })
+      return calls.map((_, i) => results.get(i + 1))
+    } finally {
+      ws.close()
+    }
+  }
+
+  it('answers ok:false for an ssh project — with no renderer flag to help it', async () => {
+    const [report, mem] = (await rpc([
+      { method: IPC.sessionMemory, args: [{ projectId: SSH_ID }] },
+      { method: IPC.sessionMemoryHost, args: [{ projectId: SSH_ID }] }
+    ])) as [SessionMemoryReport, MemInfo | null]
+
+    // Not merely "no rows": `ok:false` is what tells the panel it could not look, and a null `mem`
+    // is what stops the pill printing THIS machine's RAM under the remote host's name.
+    expect(report.ok).toBe(false)
+    expect(report.rows).toEqual([])
+    expect(report.mem).toBeNull()
+    expect(mem).toBeNull()
+  }, 30_000)
+
+  it('still serves a LOCAL project from this machine', async () => {
+    // The refusal must be scoped to the ssh entry, not a blanket "the server answers nothing".
+    const [report, mem] = (await rpc([
+      { method: IPC.sessionMemory, args: [{ projectId: LOCAL_ID }] },
+      { method: IPC.sessionMemoryHost, args: [{ projectId: LOCAL_ID }] }
+    ])) as [SessionMemoryReport, MemInfo | null]
+
+    // `ok` depends on whether this machine has a usable tmux, so both values are correct here; what
+    // must differ from the ssh case is that a local scope is answered from the local reader at all.
+    expect(typeof report.ok).toBe('boolean')
+    expect(Array.isArray(report.rows)).toBe(true)
+    // /proc/meminfo (or the os fallback) always answers on a machine that can run this suite.
+    expect(mem).not.toBeNull()
+    expect(Number.isFinite(mem?.totalMb)).toBe(true)
+  }, 30_000)
+})


### PR DESCRIPTION
## Why

A user reported: *"How do you manage memory? Claude terminals are killing my memory each one takes 2gb… regretted updating."*

Measured on the production host (64 GB, 95 live `claude` processes):

| What | Measurement |
|---|---|
| `claude` process alone | avg **335 MB**, peak **1159 MB** |
| 95 `claude` processes | **31.1 GB** |
| MCP children per session | +30–200 MB (playwright-mcp + Chrome ≈ 200 MB alone) |
| One "Claude terminal" tree | **440 MB – 1.2 GB** |
| nodeterm-server (per user) | 49–82 MB |
| tmux client (per attached session) | 5.1 MB × 59 = 303 MB |

Two facts settle it: **nodeterm does not allocate that memory** (it is the Claude Code CLI's own V8 heap — `RssAnon` is essentially all of RSS, and this repo sets no `--max-old-space-size`), and **it is not a leak** (RSS is flat with process age: 0-24 h avg 340 MB vs 7 day+ avg 326 MB).

So the user's number is right and their attribution is wrong — but nodeterm keeps those processes alive and shows the user nothing. The reaper cannot help: it only reaps DETACHED sessions, and on that host its kill list was **empty** (60 `nt-` sessions, 50 attached, 0 eligible) while 31 GB sat there. An open canvas is attached, and attached is untouchable.

**This PR closes the blindness, not the allocation.** Capping agent memory and retargeting the reaper were both considered and deliberately left out (see Non-goals).

## What

- **A system-resource pill** in the canvas's bottom-left, beside the usage pill, showing the scoped machine's used/total RAM. Reuses the existing `readMemInfo()`, so it is one file read locally.
- **An on-demand panel** it opens: one row per `nt-` session, sorted by process-tree total, with child processes rolled up. Rows travel (`goToNode`) or die (`×` behind a ConfirmDialog).
- **Orphan rows** — sessions with no node on any canvas. They are the point: exactly what the reaper cannot see and no canvas can show.

Scope follows `usageScope`, so the pill and the panel describe the same machine the usage indicator does: a local project shows this machine, an SSH project shows that host (read over its ControlMaster in one `sh` round trip).

## Load-bearing decisions

- **`ok:false` is not `ok:true` with no rows.** "Could not measure" and "there is nothing" are different facts, preserved at every layer and rendered differently. This is the rule the feature exists to honour.
- **The local reader reads `/proc/<pid>/status`, never `statm`** — a hard-coded 4096-byte page under-reports 4× on 16 KiB-page arm64 and **16× on 64 KiB-page arm64** (RHEL/SUSE). Do not optimise it back.
- **`readMemInfo` has one home**, imported by `session-budget.ts`: the reaper's watermark and the pill must never disagree about free RAM.
- **Local scope polls (30 s); an SSH scope never does** — every remote read is an ssh exec on someone else's machine, the same rule CLAUDE.md already sets for remote usage.
- **A closed project is not an orphan.** `closeProject` keeps its nodes on disk, so its sessions resolve to a real title; calling them orphans would invite killing sessions the user deliberately parked.
- **Kills fan out across both tmux sockets with exact targets (`-t =`).** The fan-out was required because the sweep observes two sockets while the kill targeted one — an SSH orphan's `×` was a silent no-op on the host. The exactness was required *by* the fan-out: verified against real tmux 3.4, a speculative miss falls back to prefix matching, and `nt-<id>-1` prefixes `nt-<id>-12`.
- **Generated SSH shell is tested under a real `/bin/sh`** — `echo ##MEM` prints an *empty line* under POSIX sh (an unquoted `#` starts a comment), which would have made every healthy host report `ok:false`.

## Non-goals

- **Capping agent memory** (`NODE_OPTIONS=--max-old-space-size`): a low ceiling OOM-kills a long-context session, which is worse than the 2 GB.
- **Lazy PTY attach / not cold-starting agents**: changes the user experience — agents would stop resuming when a project opens.
- **Retargeting the reaper**: separate change, separate risk.

## Surfaces

Desktop ✅ · Server Edition ✅ (core service + a real ws-bridge namespace; an SSH scope answers `ok:false` **by identity**, not by relying on a renderer flag) · SSH ✅ · Relay tabs read as *unsupported*, not as a failure · Mobile: N/A (separate repo, no per-session host memory concept).

## Tests

4564 passed / 8 skipped (362 files); typecheck clean. Every guard was mutation-tested — deleted, and the covering test confirmed to fail. That discipline caught **nine** vacuous tests, including one mutation that survived the entire 4541-test suite because `SshProjectManager` had no test file at all.

## Not verified — needs a real machine

This was built on a headless box: nothing was ever rendered, and nothing ran against a real sshd. `docs/session-memory.md` §10 carries a 27-item checklist. Highest value:

1. SSH orphan kill actually removes the host's `nt-*` session (both sockets).
2. The macOS local leg — `defaultProcessTableReader` returns null off Linux, so the entire non-Linux path is the `ps` fallback, never exercised on a Mac.
3. The pill's layout cases, especially on a machine with no agent usage (`UsageIndicator` returns `null` there, so the RAM pill sits alone).

## Known gaps

- The **sessions sidebar**'s confirm has the same defect this PR fixed in the panel (no remote leg, so an unmounted SSH node's host session survives). Pre-existing and deliberately out of scope — its correct fix is owner-routed per row. Filed in `docs/session-memory.md`.
- `CLAUDE.md` is gitignored in this repo, so its section is **not in this PR**. The 149-line block is on the branch author's box and must be applied by hand.
