### PR TITLE
docs: parseVmStat verified on a real Mac; sharpen why darwin stays silent

### DIFF
--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -158,8 +158,14 @@ and the pill pulses instead of printing a number it has not earned.
 disappearing" on macOS, before the cause was known. Until this ships, the workaround on an affected
 machine is the reaper's own kill switch: `NODETERM_SESSION_REAP_DISABLED=1`.
 
-**Unverified:** the fixture in `session-memory.test.ts` is composed from Apple's documented format,
-not captured from a real machine. Device checklist item 6 is what closes it.
+**VERIFIED on a real Mac (2026-08-12, 24 GB machine) — device checklist item 6 is closed.**
+Activity Monitor reported App 7.67 GB + Wired 2.95 GB + Compressed 8.38 GB = **19.00 GB**; the pill
+read **19.1 GB**. AM's own headline "Memory Used" said 19.73 GB — it exceeds the sum of its own
+parts on Apple Silicon, a documented discrepancy rather than an error here. Before the fix the same
+machine read **23.9 / 24.0 GB**.
+
+The test fixture remains composed from Apple's documented format; what is verified is the FORMULA
+against a real machine, not that fixture's specific numbers.
 
 ## 6. The SSH leg
 
@@ -399,11 +405,10 @@ macOS (the ps path never runs on Linux)
  5. Open the panel on a Mac: `defaultProcessTableReader` returns null there, so the whole table
     comes from `ps -eo pid,ppid,rss`. Rows must populate, and the totals must be plausible — BSD ps
     reports rss in kB, but confirm one known process against Activity Monitor before trusting it.
- 6. macOS: capture real `vm_stat` output and check `parseVmStat` against Activity Monitor's Memory
-    Used (the fixture is COMPOSED, not captured). Confirm the pill's used/total reads
-    plausibly rather than alarmingly (a Mac with a big page cache will look fuller than it is).
-
-The SSH leg
+ 6. ~~macOS: check `parseVmStat` against Activity Monitor.~~ **DONE 2026-08-12** — 19.1 GB vs
+    AM's 19.00 GB of parts on a 24 GB machine (was 23.9/24.0 before the fix). Still open on
+    macOS: give the memory-PRESSURE monitor a real signal (`kern.memorystatus_vm_pressure_level`)
+    rather than a byte watermark — the same capture showed 82% used with AM's pressure graph GREEN.
  7. Open an SSH project: the panel must list THAT host's sessions and no local ones, and its header
     scope + the pill's title must read `user@host`.
  8. Open an SSH project BEFORE its ControlMaster is up. The pill must end on a NUMBER, not a

--- a/src/core/memory-pressure.ts
+++ b/src/core/memory-pressure.ts
@@ -14,18 +14,30 @@ export const SELF_RSS_WARN_MB = 4096
 export const SELF_RSS_CRIT_MB = 8192
 
 /**
- * The DEFAULT host-memory reader — platform-aware, because `readMemInfo`'s non-Linux fallback is
- * `os.freemem()`, and on **darwin** that is vm_stat's `free_count` alone: it excludes inactive,
- * purgeable and compressor pages, all of which macOS hands back on demand. A perfectly healthy
- * 16 GB Mac idles at a few hundred MB "free", i.e. under BOTH watermarks — the monitor would sit
- * permanently CRITICAL on the primary desktop platform, disposing every parked terminal and
- * sweeping the reaper once a minute forever. Per the repo rule, a guess must degrade to NOTHING
- * rather than to something wrong: on darwin the host leg is silent (`null` is explicitly "no
- * pressure signal", not "no pressure") and the self-RSS leg carries the monitor alone.
+ * The DEFAULT host-memory reader — still silent on **darwin**, but no longer for the reason this
+ * comment used to give.
  *
- * Follow-up: give macOS a REAL signal (the memory-pressure/compressor state, swap-in rate, or
- * Electron's `app.getAppMetrics`) and drop the special case — the platform is not un-measurable,
- * `os.freemem()` is simply the wrong instrument for it.
+ * The original reason was that `readMemInfo` fell back to `os.freemem()` off Linux, which on darwin
+ * counts only genuinely free pages — excluding inactive, purgeable and compressor pages, all of
+ * which macOS hands back on demand. A healthy Mac idles at a few hundred MB "free", under BOTH
+ * watermarks, so this monitor would have sat permanently CRITICAL on the primary desktop platform.
+ * (The same reading had the session reaper culling idle detached sessions on every sweep — a
+ * confirmed field symptom, reported as "my sessions keep disappearing".)
+ *
+ * That instrument is fixed: `readMemInfo` now reads `vm_stat` on darwin, VERIFIED on a real 24 GB
+ * Mac (2026-08-12) — Activity Monitor's App 7.67 + Wired 2.95 + Compressed 8.38 = 19.00 GB against
+ * our 19.1 GB, where the same machine read 23.9/24.0 before. So the REAPER's watermark is honest
+ * there now, which is what closed the bug.
+ *
+ * **This leg stays silent anyway, and the verification is what sharpened the reason.** Available
+ * BYTES is not macOS's pressure signal. That same capture had the machine at 82% used with 8.38 GB
+ * compressed and 1.77 GB of swap in use — and macOS's own Memory Pressure graph was GREEN. A
+ * watermark at 10%/5% available therefore fires in states the OS itself calls healthy, and the
+ * critical one sweeps the reaper: we would cull sessions on a machine macOS says is fine. That is
+ * the same class of mistake as the bug this started with, reached from the other direction.
+ *
+ * Follow-up (unchanged in shape, sharper in target): give this leg macOS's REAL pressure signal —
+ * `kern.memorystatus_vm_pressure_level`, or the `memory_pressure` tool — rather than a byte count.
  */
 export function hostMemReader(platform: NodeJS.Platform = process.platform): () => MemInfo | null {
   return platform === 'darwin' ? (): null => null : readMemInfo


### PR DESCRIPTION
Follow-up to #134, from the device verification it asked for.

**Device checklist item 6 is closed.** On a 24 GB Mac:

| | |
|---|---|
| Activity Monitor, App + Wired + Compressed | 7.67 + 2.95 + 8.38 = **19.00 GB** |
| The pill | **19.1 GB** |
| Same machine before the fix | **23.9 / 24.0 GB** |

AM's headline "Memory Used" said 19.73 GB — it exceeds the sum of its own parts on Apple Silicon, which is the documented discrepancy, not an error here. What is verified is the FORMULA against a real machine; the unit-test fixture is still composed from Apple's documented format.

**The verification also sharpened the other decision.** `hostMemReader` stays silent on darwin, but not because macOS is unmeasurable — available *bytes* is simply not its pressure signal. The same capture had the machine at 82% used, with 8.38 GB compressed and 1.77 GB of swap in use, while macOS's own Memory Pressure graph was **green**. A 10%/5%-available watermark fires in states the OS itself calls healthy, and the critical one sweeps the reaper: we would cull sessions on a machine macOS says is fine — the same class of mistake as the bug this started with, reached from the other direction.

The follow-up is now a specific target: `kern.memorystatus_vm_pressure_level` (or the `memory_pressure` tool), not a byte count.

**Also corrects the record:** 4738cd68's merge message claimed this comment had already been fixed. It had not — that edit was made in the working tree during the merge and never staged, so it was lost with the worktree.