### PR TITLE
fix(core): the reaper must not cull on a byte watermark on macOS either

### DIFF
--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -69,6 +69,28 @@ Retargeting the reaper is a separate change with separate risk (it would start k
 user is looking at). This feature adds **sight**, not policy: it shows the 31 GB and lets a human
 decide. The one thing it shares with the reaper is `readMemInfo` (§3).
 
+
+### The reaper does not cull on a byte watermark on macOS either
+
+Fixing `readMemInfo` made the bytes HONEST; it did not make them the right instrument. The same
+capture that verified the formula showed the machine at **82% used with macOS's own Memory Pressure
+graph GREEN** (8.38 GB compressed, 1.77 GB swap in use). A 10%-available watermark therefore fires
+in states the OS itself calls healthy — and the reaper's pressure trigger culls sessions.
+
+So `hostMemReader` (darwin ⇒ `null`) is the reaper's **default** reader, not something the shells
+inject. That is deliberate: a wiring line can be deleted with the whole suite green — measured twice
+on this branch — whereas a default cannot. `planReap` treats `null` as *no pressure signal*, so on
+macOS only the detached-COUNT cap can trigger a cull, and that is not memory-based at all.
+
+The reaper keeps its purpose on macOS: the count cap bounds accumulation, the pty-pressure monitor
+covers the resource that actually ran out, and this panel gives the user the visibility to cull
+deliberately. What it loses is the ability to cull on a signal that was telling it the wrong thing.
+
+**Guarded at the source, and honestly:** `hostMemReader` differs from `readMemInfo` ONLY on darwin,
+and CI runs on Linux where they are the same function — so reverting the default leaves every
+BEHAVIOURAL test green (measured). `session-budget.test.ts` therefore asserts the default in the
+source text, with that limitation written next to it.
+
 ## 3. `readMemInfo` has exactly one home
 
 It lives in `session-memory.ts`; `session-budget.ts` imports **and re-exports** it. Two features now

--- a/src/core/memory-pressure.ts
+++ b/src/core/memory-pressure.ts
@@ -4,7 +4,9 @@
 // own RSS, because the host signal alone can't tell you YOU are the problem.
 // Consumers hang reclaim levers off onPressure; all levers must be idempotent — the monitor
 // re-fires a held severity at most once per RE_FIRE_FLOOR_MS.
-import { readMemInfo, type MemInfo } from './session-budget'
+import { hostMemReader, type MemInfo } from './session-budget'
+
+export { hostMemReader }
 
 export type PressureSeverity = 'warning' | 'critical'
 
@@ -13,35 +15,6 @@ export const RE_FIRE_FLOOR_MS = 60_000
 export const SELF_RSS_WARN_MB = 4096
 export const SELF_RSS_CRIT_MB = 8192
 
-/**
- * The DEFAULT host-memory reader — still silent on **darwin**, but no longer for the reason this
- * comment used to give.
- *
- * The original reason was that `readMemInfo` fell back to `os.freemem()` off Linux, which on darwin
- * counts only genuinely free pages — excluding inactive, purgeable and compressor pages, all of
- * which macOS hands back on demand. A healthy Mac idles at a few hundred MB "free", under BOTH
- * watermarks, so this monitor would have sat permanently CRITICAL on the primary desktop platform.
- * (The same reading had the session reaper culling idle detached sessions on every sweep — a
- * confirmed field symptom, reported as "my sessions keep disappearing".)
- *
- * That instrument is fixed: `readMemInfo` now reads `vm_stat` on darwin, VERIFIED on a real 24 GB
- * Mac (2026-08-12) — Activity Monitor's App 7.67 + Wired 2.95 + Compressed 8.38 = 19.00 GB against
- * our 19.1 GB, where the same machine read 23.9/24.0 before. So the REAPER's watermark is honest
- * there now, which is what closed the bug.
- *
- * **This leg stays silent anyway, and the verification is what sharpened the reason.** Available
- * BYTES is not macOS's pressure signal. That same capture had the machine at 82% used with 8.38 GB
- * compressed and 1.77 GB of swap in use — and macOS's own Memory Pressure graph was GREEN. A
- * watermark at 10%/5% available therefore fires in states the OS itself calls healthy, and the
- * critical one sweeps the reaper: we would cull sessions on a machine macOS says is fine. That is
- * the same class of mistake as the bug this started with, reached from the other direction.
- *
- * Follow-up (unchanged in shape, sharper in target): give this leg macOS's REAL pressure signal —
- * `kern.memorystatus_vm_pressure_level`, or the `memory_pressure` tool — rather than a byte count.
- */
-export function hostMemReader(platform: NodeJS.Platform = process.platform): () => MemInfo | null {
-  return platform === 'darwin' ? (): null => null : readMemInfo
-}
 
 export interface MemoryPressureMonitor {
   start(): void

--- a/src/core/session-budget.test.ts
+++ b/src/core/session-budget.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   planReap,
   parseSessionList,
@@ -285,5 +287,47 @@ describe('createSessionReaper (service)', () => {
     })
     expect(await reaper.sweep({ pressure: 'pty' })).toBe(0)
     expect(w.calls.filter((c) => c.args[2] === 'kill-session')).toHaveLength(0)
+  })
+})
+
+describe('planReap with no memory signal (the darwin shape)', () => {
+  const idle = (name: string, hoursAgo: number): SessionInfo => ({
+    name,
+    clients: 0,
+    activitySec: 1_000_000 - hoursAgo * 3600
+  })
+
+  it('culls NOTHING on memory grounds when the reader reports null', () => {
+    // macOS: available BYTES is not the OS's pressure signal (measured: 82% used, 8.38 GB
+    // compressed, macOS's own graph GREEN). hostMemReader returns null there, and null must mean
+    // "no pressure signal", never "no memory". Absence of evidence may not cull a session.
+    const sessions = Array.from({ length: 20 }, (_, i) => idle(`nt-old-${i}`, 48))
+    const cfg = sessionBudgetConfig({}, 24576)
+    expect(planReap(sessions, null, 1_000_000, cfg)).toEqual([])
+  })
+
+  it('still culls past the detached-count cap without any memory signal', () => {
+    // The cap is not memory-based, so it survives — that is what keeps the reaper useful on macOS.
+    const sessions = Array.from({ length: 60 }, (_, i) => idle(`nt-old-${i}`, 48))
+    const cfg = sessionBudgetConfig({}, 24576)
+    expect(planReap(sessions, null, 1_000_000, cfg).length).toBeGreaterThan(0)
+  })
+})
+
+describe("the reaper's default memory reader", () => {
+  /**
+   * A SOURCE-level guard, deliberately, and here is why a behavioural one is not possible:
+   * `hostMemReader` differs from `readMemInfo` ONLY on darwin, and these tests run on Linux, where
+   * the two are the same function. Reverting the default to `readMemInfo` therefore leaves every
+   * behavioural test green — measured, not assumed.
+   *
+   * What it guards is the thing that actually broke: on macOS `readMemInfo` reports honest bytes,
+   * but available BYTES are not the OS's pressure signal (82% used with macOS's own graph GREEN,
+   * measured 2026-08-12), so a byte watermark culls sessions on a machine macOS says is fine.
+   */
+  it('defaults to hostMemReader, not readMemInfo', () => {
+    const src = readFileSync(join(__dirname, 'session-budget.ts'), 'utf8')
+    expect(src).toContain('opts.readMem ?? hostMemReader()')
+    expect(src).not.toContain('opts.readMem ?? readMemInfo')
   })
 })

--- a/src/core/session-budget.ts
+++ b/src/core/session-budget.ts
@@ -144,6 +144,36 @@ export function parseSessionList(stdout: string): SessionInfo[] {
   return out
 }
 
+/**
+ * The DEFAULT host-memory reader — still silent on **darwin**, but no longer for the reason this
+ * comment used to give.
+ *
+ * The original reason was that `readMemInfo` fell back to `os.freemem()` off Linux, which on darwin
+ * counts only genuinely free pages — excluding inactive, purgeable and compressor pages, all of
+ * which macOS hands back on demand. A healthy Mac idles at a few hundred MB "free", under BOTH
+ * watermarks, so this monitor would have sat permanently CRITICAL on the primary desktop platform.
+ * (The same reading had the session reaper culling idle detached sessions on every sweep — a
+ * confirmed field symptom, reported as "my sessions keep disappearing".)
+ *
+ * That instrument is fixed: `readMemInfo` now reads `vm_stat` on darwin, VERIFIED on a real 24 GB
+ * Mac (2026-08-12) — Activity Monitor's App 7.67 + Wired 2.95 + Compressed 8.38 = 19.00 GB against
+ * our 19.1 GB, where the same machine read 23.9/24.0 before. So the REAPER's watermark is honest
+ * there now, which is what closed the bug.
+ *
+ * **This leg stays silent anyway, and the verification is what sharpened the reason.** Available
+ * BYTES is not macOS's pressure signal. That same capture had the machine at 82% used with 8.38 GB
+ * compressed and 1.77 GB of swap in use — and macOS's own Memory Pressure graph was GREEN. A
+ * watermark at 10%/5% available therefore fires in states the OS itself calls healthy, and the
+ * critical one sweeps the reaper: we would cull sessions on a machine macOS says is fine. That is
+ * the same class of mistake as the bug this started with, reached from the other direction.
+ *
+ * Follow-up (unchanged in shape, sharper in target): give this leg macOS's REAL pressure signal —
+ * `kern.memorystatus_vm_pressure_level`, or the `memory_pressure` tool — rather than a byte count.
+ */
+export function hostMemReader(platform: NodeJS.Platform = process.platform): () => MemInfo | null {
+  return platform === 'darwin' ? (): null => null : readMemInfo
+}
+
 export interface SessionReaperOpts {
   /** Lazy tmux binary resolver (PtyManager resolves after init; null = tmux unavailable → no-op). */
   tmuxBin: () => string | null
@@ -218,7 +248,9 @@ export function createSessionReaper(opts: SessionReaperOpts): SessionReaper {
       const { stdout } = await runAsync(bin, args, { timeout: 15_000 })
       return stdout
     })
-  const readMem = opts.readMem ?? readMemInfo
+  // Platform-aware BY DEFAULT — not injected by the shells. A wiring line can be deleted with
+  // the suite green (measured); a default cannot. See hostMemReader for why darwin is silent.
+  const readMem = opts.readMem ?? hostMemReader()
   const env = opts.env ?? process.env
   const nowSec = opts.nowSec ?? ((): number => Math.floor(Date.now() / 1000))
   const log = opts.log ?? ((m: string): void => console.log(m))

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1532,6 +1532,19 @@ app.whenReady().then(async () => {
   // `shadowed` subtracts our own control-mode shadows from tmux's attached flag: a shadow is a real
   // tmux client but NOT a watcher, so a shadowed session must stay exactly as cullable as an idle
   // detached one (see PtyManager.shadowedTmuxSessions).
+  // `readMem: hostMemReader()` — the SAME platform-aware reader the memory-pressure monitor uses,
+  // and for the same reason. On darwin it returns null, so `planReap` sees no pressure signal and
+  // only the detached-count cap can trigger a cull.
+  //
+  // Available BYTES is not macOS's pressure signal. Measured on a 24 GB Mac (2026-08-12): 82% used,
+  // 8.38 GB compressed, 1.77 GB swap in use — and macOS's own Memory Pressure graph GREEN. A
+  // 10%-available watermark fires in states the OS itself calls healthy, so a byte trigger there
+  // culls sessions on a machine macOS says is fine. Fixing readMemInfo made the bytes HONEST; it
+  // did not make them the right instrument.
+  //
+  // This is not a regression of the reaper's purpose on macOS: the count cap still bounds
+  // accumulation, the pty-pressure monitor covers the resource that actually ran out, and the
+  // session-memory panel gives the user the visibility to cull deliberately.
   const sessionReaper = createSessionReaper({
     tmuxBin: () => ptyManager.getTmuxBin(),
     shadowed: (socket) => ptyManager.shadowedTmuxSessions(socket)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -446,6 +446,10 @@ export async function startServer(
   // `shadowed` subtracts our own control-mode shadows from tmux's attached flag: a shadow is a real
   // tmux client but NOT a watcher, so a shadowed session must stay exactly as cullable as an idle
   // detached one (see PtyManager.shadowedTmuxSessions).
+  // `readMem: hostMemReader()` — same platform-aware reader as the memory-pressure monitor below.
+  // A Server Edition host is normally Linux, where this IS `readMemInfo`; the darwin branch matters
+  // for a Mac serving the browser UI, where available bytes are not the OS's pressure signal (see
+  // hostMemReader). Kept identical to the desktop shell so the two cannot drift.
   const sessionReaper = createSessionReaper({
     tmuxBin: () => ptyManager.getTmuxBin(),
     shadowed: (socket) => ptyManager.shadowedTmuxSessions(socket)


### PR DESCRIPTION
Follow-up to #135 — it merged before this commit landed on the branch.

#134 made `readMemInfo` report **honest** bytes on macOS, which fixed the confirmed field bug (the reaper saw permanent pressure and culled idle detached sessions every sweep). This closes the other half: honest bytes are still the **wrong instrument** there.

The capture that verified the formula also showed the machine at **82% used with macOS's own Memory Pressure graph GREEN** — 8.38 GB compressed, 1.77 GB swap in use. A 10%-available watermark therefore fires in states the OS itself calls healthy, and the reaper's pressure trigger culls sessions. That is the original bug reached from the other direction.

**What changes:** `hostMemReader` (darwin ⇒ `null`) moves into `session-budget.ts` and becomes the reaper's **default** reader. The move also removes the import cycle that forced it to live in `memory-pressure.ts`, which now re-exports it. `planReap` already treats `null` as *no pressure signal*, so on macOS only the detached-COUNT cap can cull — and that is not memory-based.

**Default, not injection, on purpose:** a wiring line can be deleted with the whole suite green. That was measured twice on this branch (Task 4's M17, and this change's own first attempt). A default cannot be deleted the same way.

**The reaper keeps its purpose on macOS:** the count cap bounds accumulation, the pty-pressure monitor covers the resource that actually ran out (#132/#133), and the session-memory panel gives the user the visibility to cull deliberately. What it loses is the ability to cull on a signal that was telling it the wrong thing.

**Guarded at the source, with the limitation stated:** `hostMemReader` differs from `readMemInfo` ONLY on darwin, and CI runs on Linux where they are the same function — so reverting the default leaves every *behavioural* test green (measured). The assertion is on the source text and says exactly that next to itself.