### PR TITLE
test(core): darwin-gated behavioural guard for the reaper's default memory reader

### DIFF
--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -427,10 +427,23 @@ macOS (the ps path never runs on Linux)
  5. Open the panel on a Mac: `defaultProcessTableReader` returns null there, so the whole table
     comes from `ps -eo pid,ppid,rss`. Rows must populate, and the totals must be plausible — BSD ps
     reports rss in kB, but confirm one known process against Activity Monitor before trusting it.
+    PARTIAL 2026-08-12: the units ARE kB, but `ps rss` and AM's "Memory" column measure different
+    things — WindowServer read 92,768 kB (90.6 MB) of RSS while AM showed 763.5 MB of footprint on
+    the same tick, an 8× gap for a compressed/IOKit-heavy process. The panel will understate such
+    processes; "plausible" must mean plausible-as-RSS, not AM-equal. Panel populate still unchecked.
  6. ~~macOS: check `parseVmStat` against Activity Monitor.~~ **DONE 2026-08-12** — 19.1 GB vs
     AM's 19.00 GB of parts on a 24 GB machine (was 23.9/24.0 before the fix). Still open on
     macOS: give the memory-PRESSURE monitor a real signal (`kern.memorystatus_vm_pressure_level`)
     rather than a byte watermark — the same capture showed 82% used with AM's pressure graph GREEN.
+    RE-VERIFIED independently 2026-08-12 (second session, shipping function imported via esbuild
+    bundle, vm_stat captured on the same tick as an AM screenshot): ours 18.87 GB used vs AM's
+    parts 7.23 + 2.99 + 8.66 = 18.88 GB — 0.05% off; AM's HEADLINE "Memory Used" was 19.70 GB,
+    0.83 GB (4.2%) above its own parts, confirming the header comment that the parts do not sum to
+    the headline on Apple Silicon. Same capture: `os.freemem()` said 0.10 GB. Page-size trap
+    mutation-verified: hard-coding 4096 against the machine's 16,384-byte pages under-reported used
+    memory exactly 4.00× (18.87 → 4.72 GB). The darwin reaper default is now also guarded by a
+    BEHAVIOURAL test (darwin-gated, mutation-verified on this machine: reverting the default to
+    `readMemInfo` reaps 8) — see session-budget.test.ts, which CI's source-text check stands in for.
  7. Open an SSH project: the panel must list THAT host's sessions and no local ones, and its header
     scope + the pill's title must read `user@host`.
  8. Open an SSH project BEFORE its ControlMaster is up. The pill must end on a NUMBER, not a

--- a/src/core/session-budget.test.ts
+++ b/src/core/session-budget.test.ts
@@ -6,6 +6,7 @@ import {
   parseSessionList,
   sessionBudgetConfig,
   createSessionReaper,
+  readMemInfo,
   type SessionInfo,
   type SessionBudgetConfig
 } from './session-budget'
@@ -316,10 +317,11 @@ describe('planReap with no memory signal (the darwin shape)', () => {
 
 describe("the reaper's default memory reader", () => {
   /**
-   * A SOURCE-level guard, deliberately, and here is why a behavioural one is not possible:
-   * `hostMemReader` differs from `readMemInfo` ONLY on darwin, and these tests run on Linux, where
-   * the two are the same function. Reverting the default to `readMemInfo` therefore leaves every
-   * behavioural test green — measured, not assumed.
+   * A SOURCE-level guard, deliberately, and here is why a behavioural one is not possible ON THIS
+   * PLATFORM: `hostMemReader` differs from `readMemInfo` ONLY on darwin, and CI runs on Linux,
+   * where the two are the same function. Reverting the default to `readMemInfo` therefore leaves
+   * every behavioural test green — measured, not assumed. The darwin-gated suite below IS the
+   * behavioural version of this guard; this string check is what stands in for it everywhere else.
    *
    * What it guards is the thing that actually broke: on macOS `readMemInfo` reports honest bytes,
    * but available BYTES are not the OS's pressure signal (82% used with macOS's own graph GREEN,
@@ -329,5 +331,46 @@ describe("the reaper's default memory reader", () => {
     const src = readFileSync(join(__dirname, 'session-budget.ts'), 'utf8')
     expect(src).toContain('opts.readMem ?? hostMemReader()')
     expect(src).not.toContain('opts.readMem ?? readMemInfo')
+  })
+})
+
+describe('darwin default reader: no byte reading may ever reap (behavioural)', () => {
+  /**
+   * Gated to darwin because only there do `hostMemReader` and `readMemInfo` diverge — on Linux
+   * they are the same function, so this test would FAIL there for the wrong reason (the real
+   * `/proc/meminfo` reading legitimately trips the impossible watermark below). On a Mac it is
+   * the real guard the source-text check above merely approximates.
+   */
+  const onDarwin = it.skipIf(process.platform !== 'darwin')
+
+  onDarwin('readMemInfo yields an honest reading here — the discriminator is real, not vacuous', () => {
+    // If vm_stat parsing ever regressed to null on darwin, the reaping test below would pass for
+    // an empty reason (both readers null). This companion assertion is what keeps it meaningful.
+    const mem = readMemInfo()
+    expect(mem).not.toBeNull()
+    expect(mem!.totalMb).toBeGreaterThan(1024)
+    expect(mem!.availableMb).toBeGreaterThan(0)
+    expect(mem!.availableMb).toBeLessThan(mem!.totalMb)
+  })
+
+  onDarwin('without an injected readMem, sessions survive NO MATTER how full memory is', async () => {
+    // The watermark is set above any physically possible host (1 TB available), so ANY byte
+    // reading — however healthy the machine — counts as pressure. Only a reader that refuses to
+    // produce bytes at all (hostMemReader's darwin null) keeps these sessions alive. This encodes
+    // "memory fullness must never reap on macOS" without depending on the host's current load.
+    const w = fakeWorld({
+      'node-terminal': Array.from({ length: 20 }, (_, i) => `nt-idle-${i}|0|${OLD}`)
+    })
+    const reaper = createSessionReaper({
+      tmuxBin: () => 'tmux',
+      sockets: ['node-terminal'],
+      exec: w.exec,
+      env: { NODETERM_SESSION_MIN_AVAILABLE_MB: '1000000000' },
+      nowSec: () => NOW,
+      log: () => {}
+      // deliberately NO readMem: the default reader is the thing under test
+    })
+    expect(await reaper.sweep()).toBe(0)
+    expect(w.calls.filter((c) => c.args[2] === 'kill-session')).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## What

Adds the behavioural test the source-text guard in `session-budget.test.ts` could not be: proof that `createSessionReaper()` **without an injected `readMem`** never reaps on memory grounds on macOS, no matter how full memory is.

- 20 detached `nt-` sessions idle far past grace, no `readMem` injected.
- The watermark is env-pinned above any physically possible host (1 TB available), so **any** byte reading counts as pressure; only `hostMemReader`'s darwin `null` refuses. This encodes *"memory fullness must never reap on macOS"* without depending on the host's current load.
- A companion assertion pins `readMemInfo()` non-null on darwin so the main test can never pass vacuously (both readers null).
- `it.skipIf(process.platform !== 'darwin')`: on Linux the two readers are the same function and the real `/proc/meminfo` reading legitimately trips the impossible watermark — the test would fail there for the wrong reason. The existing source-text check remains as CI's stand-in; its comment now points here.

## Mutation verification (on a real 24 GB M-series Mac, macOS 26.5.2)

Reverting the default to `readMemInfo` (the pre-#136 state):

```
× without an injected readMem, sessions survive NO MATTER how full memory is
  AssertionError: expected 8 to be +0
```

A full batch of 8 reaped — the exact field bug ("my sessions keep disappearing"). With `hostMemReader()` restored: 31/31 pass.

## Also

`docs/session-memory.md` §10: item 6 re-verified independently (shipping `parseVmStat` vs a same-tick Activity Monitor capture: 18.87 vs 18.88 GB parts, 0.05% off; 4096-page mutation under-reports exactly 4.00×), item 5 partial (BSD `ps rss` units are kB, but RSS vs AM footprint gaps up to 8× measured).

Gate: `npm run typecheck` clean, `npx vitest run` 5021 passed / 8 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TxMV9B96o8U7rHxob5zB1