### PR TITLE
fix(terminal): never kill a live agent on a plain-shell session — park/offscreen protection (#126)

### DIFF
--- a/docs/remote-sessions.md
+++ b/docs/remote-sessions.md
@@ -422,6 +422,16 @@ the dialect deletion orphaned, blanking the phone; that flag is gone).
   next live mutation. Re-running `api.workspace.load()` into the bound project on reconnect closes it.
 - **Change the shared project without dropping the session** — sharing is fixed per hosting session
   (change project = stop + restart hosting). A live "share a different project" control is a follow-up.
+- **Agent status is not routed into the per-session stores** — `SessionStores.agentStatus`
+  (`agentStatusForApi(api)`) is built for every session, but nothing writes the non-local
+  instances: Canvas's `agent:status` subscription sits above the per-project session provider and
+  writes the DEFAULT store, and `useSessionStores()` has no consumers. Cosmetic until #126's
+  plain-shell protection landed, which reads a node's own session store to decide whether killing
+  its terminal would end a running agent (`terminal/live-work.ts`) — so **relay parks/offscreen
+  releases are unprotected**: a relay node always reads `undefined` there, and `persistent:false`
+  can now legitimately arrive from a tmux-less relay HOST. The consumer side is already written
+  against the seam and needs no change; what is missing is a subscription per session feeding
+  `SessionStores.agentStatus`.
 - **SDK chat node over relay** — refuses (`E_UNSUPPORTED`) in a relay tab, matching Server Edition.
 - **The preload↔main relay IPC boundary is not covered by vitest** (it needs Electron). Two real
   send/handle + payload-shape bugs were found and fixed by inspection during 4c; the two-instance

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -16,7 +16,7 @@ import {
   type Settings,
   type TmuxStatus
 } from '../shared/types'
-import { findCommand, tmuxInstall } from './tmux-hint'
+import { findCommand, findFixedTmux, tmuxInstall } from './tmux-hint'
 import { hookServer, PERM_WAIT_SECS_DEFAULT } from './agents/hook-server'
 import {
   probeSaysAbsent,
@@ -156,20 +156,32 @@ bind -T copy-mode-vi TripleClick1Pane send-keys -X select-line \\; send-keys -X 
 `
 }
 
-/** Resolve an absolute tmux path (GUI apps don't inherit the shell PATH). Subprocess-free:
- *  the old fallback here was a SYNC login-shell `command -v tmux` — sourcing the profile
- *  (nvm/conda: 100-800ms) on the main thread, re-triggered every 3s by the tmux-missing
- *  banner's install poll, freezing all windows and IPC each time. Now it walks the cached
- *  login-shell PATH instead; before that async probe settles a nonstandard location can be
- *  missed, which init()'s post-probe ensureTmux() re-run and tmuxStatus()'s re-probe cover. */
+/**
+ * Resolve an absolute tmux path (GUI apps don't inherit the shell PATH). Subprocess-free: the old
+ * fallback here was a SYNC login-shell `command -v tmux` — sourcing the profile (nvm/conda:
+ * 100-800ms) on the main thread, re-triggered every 3s by the tmux-missing banner's install poll,
+ * freezing all windows and IPC each time. Now it walks a fixed candidate list
+ * (`tmuxCandidatePaths` — Homebrew, MacPorts, Nix, Linuxbrew, the distro paths) and then the
+ * cached login-shell PATH.
+ *
+ * BEFORE THAT ASYNC PATH PROBE SETTLES, a tmux living ONLY on the user's shell PATH is still
+ * invisible, and a session spawned in that window silently becomes a plain shell with no
+ * persistence — the window this candidate list narrows, and the reason issue #126 could bite a
+ * machine that has tmux installed. Two things close it after the fact: init()'s post-probe
+ * `ensureTmux()` re-run and `tmuxStatus()`'s re-probe, both of which upgrade NEW sessions without
+ * a restart. A session already spawned plain is NOT migrated (there is no way to move a running
+ * process into a tmux pane); its recovery is the node's own Refresh/respawn, which re-creates it
+ * through the now-resolved tmux.
+ */
 function findTmux(): string | null {
-  for (const c of ['/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux', '/bin/tmux']) {
-    try {
-      if (fs.existsSync(c)) return c
-    } catch {
-      // ignore
-    }
+  let user: string | null = null
+  try {
+    user = os.userInfo().username
+  } catch {
+    // no passwd entry (some containers) — findFixedTmux falls back to the home basename
   }
+  const fixed = findFixedTmux((p) => fs.existsSync(p), os.homedir(), user)
+  if (fixed) return fixed
   return findInPathString('tmux', shellPathNow() ?? process.env.PATH)
 }
 
@@ -1122,9 +1134,13 @@ export class PtyManager {
   }
 
   /** Probe tmux and write/push the generated config. Idempotent and safe to re-run: a later
-   *  successful probe (e.g. right after the banner's install command finishes) brings tmux
-   *  up for NEW sessions without an app restart — existing plain-shell sessions are left
-   *  alone. No-op while tmux is already resolved or before init() provided settings. */
+   *  successful probe (the banner's install command finishing, or init()'s post-PATH-probe re-run
+   *  finding a tmux only the login shell knew about) brings tmux up for NEW sessions without an
+   *  app restart — existing plain-shell sessions are left alone. There is deliberately no
+   *  migration: a process already running under a bare pty cannot be moved into a tmux pane, so
+   *  the recovery for one of those is the node's own refresh/respawn, which re-creates the session
+   *  through the now-resolved tmux (at the cost of that shell's state, as any respawn is).
+   *  No-op while tmux is already resolved or before init() provided settings. */
   ensureTmux(): void {
     if (this.tmuxPath || !this.getSettings) return
     const found = findTmux()
@@ -1470,9 +1486,12 @@ export class PtyManager {
     // our tmux always runs `mouse on`, so enabling these unconditionally matches its client state.
     // Rides `base` so it reaches the renderer on BOTH the resized and screen-painted branches.
     const coAttachMouse = existing.persistKey ? true : undefined
+    // Same source, different question (and different consumer): a joiner needs to know whether the
+    // session it landed on survives losing a client, because its own unmount may park it.
+    const persistent = !!existing.persistKey
     const base: PtyCreateResult = existing.accountFallback
-      ? { sessionId: existingId, fresh: false, accountFallback: true, coAttachMouse }
-      : { sessionId: existingId, fresh: false, coAttachMouse }
+      ? { sessionId: existingId, fresh: false, accountFallback: true, coAttachMouse, persistent }
+      : { sessionId: existingId, fresh: false, coAttachMouse, persistent }
     if (resized) return Promise.resolve(base) // tmux is redrawing this client — do not paint twice
     // An empty capture (plain shell — no tmux to capture; a tmux/ssh blip) is OMITTED, never sent
     // as '': the renderer must not reset a terminal for nothing. A plain-shell joiner therefore
@@ -1530,9 +1549,16 @@ export class PtyManager {
     // so the session env below picks it up — awaiting keeps the event loop free either way.
     await resolveShellPath()
     const sessionId = this.spawnSession(options, clientId, undefined)
+    const spawned = this.sessions.get(sessionId)
     // Surface a missing-account-dir fallback so the renderer can flag the node's account chip.
-    const accountFallback = this.sessions.get(sessionId)?.accountFallback
-    return accountFallback ? { sessionId, fresh, accountFallback } : { sessionId, fresh }
+    const accountFallback = spawned?.accountFallback
+    // The session's `persistKey` is set iff the spawn actually landed on a tmux, local or remote
+    // (`persisted` in spawnSession) — i.e. exactly "this session survives losing its client",
+    // which is what the renderer's cache-dispose levers must not assume. See PtyCreateResult.
+    const persistent = !!spawned?.persistKey
+    return accountFallback
+      ? { sessionId, fresh, accountFallback, persistent }
+      : { sessionId, fresh, persistent }
   }
 
   /** Does the node's remote tmux session exist (over the project's ControlMaster)? Async so the

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -174,13 +174,20 @@ bind -T copy-mode-vi TripleClick1Pane send-keys -X select-line \\; send-keys -X 
  * through the now-resolved tmux.
  */
 function findTmux(): string | null {
+  // BOTH lookups inside the guard: `os.homedir()` throws the same SystemError as `userInfo()` when
+  // there is no passwd entry and no $HOME (some containers), and a thrown probe here would take
+  // out tmux discovery entirely — degrading a machine that HAS tmux to the plain-shell fallback,
+  // which is the failure this whole function is being hardened against. Unknown home/user simply
+  // drops the candidates derived from them.
+  let home: string | null = null
   let user: string | null = null
   try {
+    home = os.homedir()
     user = os.userInfo().username
   } catch {
-    // no passwd entry (some containers) — findFixedTmux falls back to the home basename
+    // no home / no passwd entry — the fixed system paths below are still checked
   }
-  const fixed = findFixedTmux((p) => fs.existsSync(p), os.homedir(), user)
+  const fixed = findFixedTmux((p) => fs.existsSync(p), home, user)
   if (fixed) return fixed
   return findInPathString('tmux', shellPathNow() ?? process.env.PATH)
 }

--- a/src/core/pty-tmux-late-probe.test.ts
+++ b/src/core/pty-tmux-late-probe.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform } from './platform-fake'
+
+/**
+ * THE SILENT PLAIN-SHELL WINDOW.
+ *
+ * `findTmux` is subprocess-free by design (a sync login shell on the main thread froze every
+ * window for 100-800ms per lookup), so it knows two things: a FIXED list of install locations, and
+ * the login-shell PATH — which is resolved ASYNCHRONOUSLY and is simply not available for the
+ * first moments of a run. A tmux that lives in neither is invisible, and a session spawned in that
+ * window becomes a plain shell with NO PERSISTENCE and no banner: the app never says so, and the
+ * park/offscreen disposes that are merely "detach a tmux client" everywhere else become "kill the
+ * shell and the agent CLI in it" (issue #126).
+ *
+ * The fixed list closing as much of that window as it cheaply can is one half (tmux-hint.test.ts);
+ * this is the other half — the guarantee that the window CLOSES: `init()` re-runs `ensureTmux()`
+ * when the PATH probe lands, so a nonstandard tmux is picked up for NEW sessions with no restart.
+ * Sessions already spawned plain are not migrated (a running process cannot be moved into a tmux
+ * pane); their recovery is the node's own refresh/respawn.
+ */
+
+const probe = vi.hoisted(() => ({ shellPath: undefined as string | undefined }))
+vi.mock('./exec-path', () => ({
+  resolveShellPath: () => Promise.resolve(probe.shellPath ?? null),
+  shellPathNow: () => probe.shellPath,
+  findInPathString: (bin: string, pathStr: string | null | undefined) =>
+    pathStr === '/opt/weird/bin' ? `/opt/weird/bin/${bin}` : null,
+  findExecutableSync: () => null
+}))
+vi.mock('node-pty', () => ({ spawn: () => ({ onData: () => {}, onExit: () => {}, kill: () => {} }) }))
+
+describe('tmux discovery after the login-shell PATH probe settles', () => {
+  beforeEach(() => {
+    probe.shellPath = undefined
+    initPlatform(fakePlatform())
+    // No tmux in ANY fixed location — the whole point is a tmux only the shell PATH knows about.
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false)
+    // ensureTmux writes the generated tmux.conf into userDataDir; the fake's dir does not exist.
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    resetPlatformForTests()
+  })
+
+  it('upgrades new sessions once the probe lands, without a restart', async () => {
+    const { PtyManager } = await import('./pty-manager')
+    const mgr = new PtyManager()
+    mgr.init(() => ({ tmuxEnabled: true, tmuxScrollback: 10_000 }) as never)
+    // The probe has not settled: the nonstandard install is invisible and this run would spawn
+    // plain shells. This is the window the fixed candidate list narrows but cannot delete.
+    expect(mgr.getTmuxBin()).toBeNull()
+
+    probe.shellPath = '/opt/weird/bin'
+    await Promise.resolve() // let init()'s `resolveShellPath().then(() => ensureTmux())` run
+    await Promise.resolve()
+    expect(mgr.getTmuxBin()).toBe('/opt/weird/bin/tmux')
+  })
+
+  it('tmuxStatus() re-probes too, so the banner clears itself', async () => {
+    const { PtyManager } = await import('./pty-manager')
+    const mgr = new PtyManager()
+    mgr.init(() => ({ tmuxEnabled: true, tmuxScrollback: 10_000 }) as never)
+    expect(mgr.tmuxStatus().available).toBe(false)
+    probe.shellPath = '/opt/weird/bin'
+    expect(mgr.tmuxStatus().available).toBe(true)
+  })
+})

--- a/src/core/tmux-hint.test.ts
+++ b/src/core/tmux-hint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { findCommand, tmuxInstall } from './tmux-hint'
+import { findCommand, findFixedTmux, tmuxCandidatePaths, tmuxInstall } from './tmux-hint'
 
 describe('tmuxInstall', () => {
   it('darwin with brew: one-click brew install', () => {
@@ -48,5 +48,49 @@ describe('findCommand', () => {
 
   it('tolerates a missing PATH', () => {
     expect(findCommand('brew', {}, (p) => p === '/usr/local/bin/brew')).toBe(true)
+  })
+})
+
+describe('tmuxCandidatePaths / findFixedTmux', () => {
+  it('keeps the four historical paths first, in their historical order', () => {
+    expect(tmuxCandidatePaths('/Users/dev', 'dev').slice(0, 4)).toEqual([
+      '/opt/homebrew/bin/tmux',
+      '/usr/local/bin/tmux',
+      '/usr/bin/tmux',
+      '/bin/tmux'
+    ])
+  })
+
+  it('covers the package managers the four fixed paths missed (silent plain-shell fallback)', () => {
+    const paths = tmuxCandidatePaths('/Users/dev', 'dev')
+    expect(paths).toContain('/opt/local/bin/tmux') // MacPorts
+    expect(paths).toContain('/run/current-system/sw/bin/tmux') // NixOS system profile
+    expect(paths).toContain('/Users/dev/.nix-profile/bin/tmux') // nix single-user profile
+    expect(paths).toContain('/etc/profiles/per-user/dev/bin/tmux') // home-manager / nix-darwin
+    expect(paths).toContain('/home/linuxbrew/.linuxbrew/bin/tmux') // Linuxbrew
+  })
+
+  it('falls back to the home directory basename when no user name is known', () => {
+    expect(tmuxCandidatePaths('/home/ada')).toContain('/etc/profiles/per-user/ada/bin/tmux')
+    // No home at all (an odd/locked-down environment): the home-derived paths are simply absent,
+    // never emitted as `undefined/...`.
+    expect(tmuxCandidatePaths(null).some((p) => p.includes('undefined'))).toBe(false)
+    expect(tmuxCandidatePaths(null).some((p) => p.includes('.nix-profile'))).toBe(false)
+  })
+
+  it('returns the FIRST candidate that exists', () => {
+    const seen: string[] = []
+    const exists = (p: string): boolean => (seen.push(p), p === '/opt/local/bin/tmux')
+    expect(findFixedTmux(exists, '/Users/dev', 'dev')).toBe('/opt/local/bin/tmux')
+    expect(seen[0]).toBe('/opt/homebrew/bin/tmux') // ordered walk, homebrew still wins first
+    expect(findFixedTmux(() => false, '/Users/dev', 'dev')).toBeNull()
+  })
+
+  it('treats a throwing existsSync as "not here" rather than failing the whole probe', () => {
+    const exists = (p: string): boolean => {
+      if (p === '/opt/homebrew/bin/tmux') throw new Error('EPERM')
+      return p === '/usr/bin/tmux'
+    }
+    expect(findFixedTmux(exists, '/Users/dev', 'dev')).toBe('/usr/bin/tmux')
   })
 })

--- a/src/core/tmux-hint.ts
+++ b/src/core/tmux-hint.ts
@@ -54,6 +54,59 @@ export function tmuxInstall(
  *  findTmux in pty-manager. Checked after the process PATH. */
 const COMMON_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin', '/opt/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']
 
+/**
+ * Absolute places a tmux binary is routinely installed, walked in order by `findFixedTmux` — the
+ * subprocess-free half of pty-manager's `findTmux` (the other half walks the login-shell PATH,
+ * which is only accurate once the async probe has settled).
+ *
+ * The list is FIXED on purpose: this runs on the spawn path, and a shell-out to find tmux is the
+ * exact thing `exec-path.ts` exists to have removed (a sync login shell on the main thread cost
+ * 100-800ms per lookup). Missing an install location is not cosmetic — it silently drops the app
+ * into the plain-shell fallback, where a park/offscreen dispose kills the shell AND whatever agent
+ * CLI is running in it (issue #126) instead of merely detaching a tmux client.
+ *
+ * The first four are the historical list and keep their historical order (Homebrew arm64, then
+ * Homebrew Intel / manual `/usr/local`, then the distro paths); the rest are the package managers
+ * that were falling through: MacPorts, Nix (system profile, per-user profile, home-manager /
+ * nix-darwin) and Linuxbrew. `home`/`user` come from the caller (`os.homedir()` /
+ * `os.userInfo().username`); an unknown home simply omits the paths derived from it.
+ */
+export function tmuxCandidatePaths(home?: string | null, user?: string | null): string[] {
+  const paths = [
+    '/opt/homebrew/bin/tmux',
+    '/usr/local/bin/tmux',
+    '/usr/bin/tmux',
+    '/bin/tmux',
+    '/opt/local/bin/tmux',
+    '/run/current-system/sw/bin/tmux',
+    '/home/linuxbrew/.linuxbrew/bin/tmux'
+  ]
+  if (home) paths.push(`${home}/.nix-profile/bin/tmux`)
+  // The per-user nix profile is keyed by USER NAME, not by home path; the home basename is the
+  // fallback because that is what it is on every platform this list targets.
+  const name = user || (home ? home.slice(home.lastIndexOf('/') + 1) : '')
+  if (name) paths.push(`/etc/profiles/per-user/${name}/bin/tmux`)
+  return paths
+}
+
+/** First `tmuxCandidatePaths` entry that exists, or null. `exists` is injected (fs.existsSync in
+ *  production) so the walk stays pure and testable; a throwing `exists` reads as "not here", never
+ *  as a failed probe — one unreadable directory must not hide a tmux two entries later. */
+export function findFixedTmux(
+  exists: (path: string) => boolean,
+  home?: string | null,
+  user?: string | null
+): string | null {
+  for (const candidate of tmuxCandidatePaths(home, user)) {
+    try {
+      if (exists(candidate)) return candidate
+    } catch {
+      // unreadable — keep looking
+    }
+  }
+  return null
+}
+
 /** Is `name` on the process PATH or in the common bin dirs? `exists` is injected (fs.existsSync
  *  in production) so the lookup stays pure and testable. */
 export function findCommand(

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -295,6 +295,8 @@ interface ParkedTerminal {
    *  lever reads later than that, so without this snapshot every park looks agent-less. See
    *  `effectiveAgentState`. */
   parkedAgentState?: AgentState
+  /** When this entry was parked — what ages the snapshot above (`parkedStateFloor`). */
+  parkedAt: number
   /** The node's agent state RIGHT NOW, read from the store of the session this node belongs to
    *  (a relay tab's status lives in its own instance, not the default one). Closed over at park
    *  time because the module-level levers have no access to the component's session. */
@@ -324,6 +326,7 @@ function parkDisposable(key: string): boolean {
   return canDisposeParkedEntry({
     tmuxBacked: p.tmuxBacked,
     parkedAgentState: p.parkedAgentState,
+    parkedAt: p.parkedAt,
     liveAgentState: p.readAgentState()
   })
 }
@@ -846,17 +849,27 @@ export function TerminalNode({
   // unmounts the node), so capturing it in the once-mounted lifecycle effect below is safe, like `api`.
   const presence = useActiveSessionPresence()
   /**
-   * THIS node's agent-status store, for the memory levers that must not kill live work.
+   * THIS node's agent-status store, for the memory levers that must not kill live work — resolved
+   * the way the session registry resolves it (`buildStores` → `agentStatusForApi`, memoized by api
+   * identity), so this node is judged against the status table of the core it actually runs on.
    *
-   * Resolved the way the session registry resolves it — memoized by api identity — so a relay
-   * tab's node reads the RELAY core's status table rather than the local one. That matters now
-   * that `persistent:false` can arrive from a tmux-less relay HOST: such a node is exactly a
-   * plain-shell agent session, and against the default store its state would always read
-   * `undefined` (= disposable), i.e. unprotected. For the local session this IS `useAgentStatus`
-   * (the WeakMap is seeded with `window.nodeTerminal`), so nothing about local behavior changes.
+   * WHAT THAT MEANS TODAY, PLAINLY: for the local session this resolves to the default persisted
+   * instance — the exact object `useAgentStatus` exports — so local nodes are protected. For a
+   * RELAY tab it resolves to that core's keyless instance, and NOTHING WRITES THAT INSTANCE YET:
+   * Canvas's `agent:status` subscription sits above the per-project session provider and writes
+   * the default store, and `useSessionStores()` currently has no consumers at all. So a relay
+   * node's state always reads `undefined` here, and RELAY PARKS REMAIN UNPROTECTED — which now
+   * matters, because `persistent:false` can arrive from a tmux-less relay HOST, i.e. exactly a
+   * plain-shell agent session on someone else's machine.
+   *
+   * Resolving it this way regardless is deliberate and is the cheap half of the fix: routing relay
+   * agent-status into the per-session stores (`useSessionStores` / `SessionStores.agentStatus` is
+   * the intended seam) is a real feature and belongs in its own change. When it lands, this code
+   * lights up unchanged — no branch here to find and update.
    *
    * Scoped deliberately to the protection paths. The other status reads in this file predate
-   * per-session stores and are left exactly as they were; widening them is a separate change.
+   * per-session stores and are left exactly as they were; widening them is that same separate
+   * change.
    */
   const agentStatusStore = agentStatusForApi(api).store
   const readAgentState = useCallback(
@@ -3117,6 +3130,7 @@ export function TerminalNode({
           // Snapshot NOW, because the departure effect declared below this one clears this node's
           // agent status on this very unmount — every lever reads later and would see nothing.
           parkedAgentState: readAgentState(),
+          parkedAt: Date.now(),
           readAgentState,
           cleanups,
           life,

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -74,6 +74,7 @@ import {
   planOffscreenVisibility,
   releaseStillEnabled,
   shouldDeferReleaseForEco,
+  shouldDeferReleaseForLiveWork,
   OFFSCREEN_DEFER_RETRY_MS,
   OFFSCREEN_DISPOSE_MS_DEFAULT
 } from '../terminal/offscreen-policy'
@@ -1017,6 +1018,13 @@ export function TerminalNode({
   /** Is there a live session here that could be given back? Published by the lifecycle run
    *  (`restartTarget`), null between runs — the dispose timer refuses when it cannot ask. */
   const offscreenLiveRef = useRef<(() => boolean) | null>(null)
+  /** Does the CURRENT session survive losing its client (tmux, local or remote)? Published by the
+   *  lifecycle run from `PtyCreateResult.persistent` — the offscreen release reads it to decide
+   *  whether disposing this terminal would end a running agent (`wouldKillLiveWork`). Read only
+   *  AFTER `offscreenLiveRef` has confirmed a live session, so a value left over from a torn-down
+   *  run is never acted on. Seeded `true`: the historical assumption, never a protection on a
+   *  guess. */
+  const sessionPersistentRef = useRef(true)
   // Selection is a live veto (`mayDisposeOffscreen`): a selected node is one the user is working
   // with — it can be off-screen mid-drag or right after a ⌘K jump — so it is never taken down.
   const selectedRef = useRef(selected)
@@ -1635,6 +1643,7 @@ export function TerminalNode({
     // (`PtyCreateResult.persistent` absent), behaves exactly as it always did rather than being
     // protected on a guess. See `canDisposePark`.
     let sessionPersistent = parked ? parked.tmuxBacked : true
+    sessionPersistentRef.current = sessionPersistent
     let disposed = false
     // Last cols/rows REPORTED to the pty (seeded at create): a resize IPC makes tmux redraw the
     // whole pane, so a same-size fit (e.g. the ResizeObserver's initial tick right after mount)
@@ -2331,6 +2340,8 @@ export function TerminalNode({
         sessionId = sid
         // `?? true`: an absent flag is an older core over the relay, not a plain shell.
         sessionPersistent = persistent ?? true
+        // Published for the mount-stable observer effect, which cannot see this closure.
+        sessionPersistentRef.current = sessionPersistent
         if (fellBack) setAccountFallback(true)
         // Catch up a size change that landed while the spawn was in flight (applyFit skips the
         // IPC until sessionId is set, and the observer won't re-fire without another change).
@@ -3232,6 +3243,22 @@ export function TerminalNode({
             // Nothing to give back (no session yet, or one that was closed/ended under us) ⇒ no
             // dispose. A null ref means no lifecycle run is live at all, which answers the same way.
             if (!offscreenLiveRef.current?.()) return
+            // LIVE WORK ON A PLAIN SHELL (issue #126): this release is only "give the buffer back,
+            // re-attach later" while tmux is underneath. Without it the pty is the shell, so
+            // disposing an offscreen agent node kills the CLI mid-turn — panning away is not a
+            // request to stop it. Defer on the same retry the Eco ordering uses, but with no cap:
+            // what this waits for (the turn ending) always comes, and giving up would BE the bug.
+            // Asked after `offscreenLiveRef`, so the persistence ref is only read for a session
+            // this run actually has.
+            if (
+              shouldDeferReleaseForLiveWork({
+                tmuxBacked: sessionPersistentRef.current,
+                agentState: useAgentStatus.getState().byId[id]?.state
+              })
+            ) {
+              offscreenTimerRef.current = setTimeout(fireRelease, OFFSCREEN_DEFER_RETRY_MS)
+              return
+            }
             // ECO ORDERING (see `shouldDeferReleaseForEco`): hibernate first, release second. This
             // release would UNWIRE the node — the lifecycle effect tears down, the hibernate pair
             // unregisters, and `planHibernation` then reads the node as unwired — and at the

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -62,7 +62,7 @@ import { loseWebglContexts, registerWebglClient, type WebglClientHandle } from '
 import {
   PARK_MAX,
   armParkExpiry,
-  canDisposePark,
+  canDisposeParkedEntry,
   disposableParks,
   planParkEviction,
   type ParkTimer
@@ -125,7 +125,8 @@ import { isZoomModifierHeld } from '../lib/zoomModifier'
 import { isHidden } from '../lib/ui-visibility'
 import { readsClaudeTranscript } from '../lib/transcriptGates'
 import { useSettings } from '../state/settings'
-import { useAgentStatus, inferInterruptAfterSettle } from '../state/agentStatus'
+import { useAgentStatus, agentStatusForApi, inferInterruptAfterSettle } from '../state/agentStatus'
+import type { AgentState } from '@shared/agents/normalize'
 import type { ClientId } from '@shared/presence'
 import { PresenceChips } from '../components/PresenceChips'
 import { useAgentNodes } from '../state/agentNodes'
@@ -286,12 +287,18 @@ interface ParkedTerminal {
   search: SearchAddon
   transport: TerminalTransport
   sessionId: string
-  /** The node this park belongs to — the key into `agentStatus.byId` the protection reads. (The
-   *  map's own key is session-scoped, `terminalKey(sessionId, nodeId)`, so it is not the node id.) */
-  nodeId: string
   /** `PtyCreateResult.persistent`: the session survives a client kill (tmux, local or remote).
    *  False = plain shell, where disposing this park ends the session for real. */
   tmuxBacked: boolean
+  /** The node's agent state AT PARK TIME — the protection FLOOR. The unmount that parks is also
+   *  the one that CLEARS this node's agent status (TerminalNode's departure effect), and every
+   *  lever reads later than that, so without this snapshot every park looks agent-less. See
+   *  `effectiveAgentState`. */
+  parkedAgentState?: AgentState
+  /** The node's agent state RIGHT NOW, read from the store of the session this node belongs to
+   *  (a relay tab's status lives in its own instance, not the default one). Closed over at park
+   *  time because the module-level levers have no access to the component's session. */
+  readAgentState: () => AgentState | undefined
   /** Session-scoped teardown (transport/xterm listeners) — run only at final dispose. */
   cleanups: Array<() => void>
   /**
@@ -307,20 +314,17 @@ interface ParkedTerminal {
 const parkedTerminals = new Map<string, ParkedTerminal>()
 const TERM_PARK_MS = 5 * 60 * 1000
 
-/** May the BUDGET levers dispose this park? Reads the node's live agent state the way the
- *  hibernation sweep does (the same store, non-reactively) and pairs it with the session's
- *  tmux-backedness. An unknown key is disposable — there is nothing there to protect.
- *
- *  `useAgentStatus` is the DEFAULT (local-core) store, like every other status read in this file.
- *  A relay tab's status lives in its own session-scoped store, so a remote node reads as "no
- *  agent" here — which changes nothing: a remote session is tmux-backed on the remote host, so it
- *  is disposable either way. */
+/** May the BUDGET levers dispose this park? The entry carries both halves of the answer: the
+ *  session's tmux-backedness, and a live read of the node's OWN agent-status store with the
+ *  park-time snapshot as a floor under it (see `canDisposeParkedEntry`). An unknown key is
+ *  disposable — there is nothing there to protect. */
 function parkDisposable(key: string): boolean {
   const p = parkedTerminals.get(key)
   if (!p) return true
-  return canDisposePark({
+  return canDisposeParkedEntry({
     tmuxBacked: p.tmuxBacked,
-    agentState: useAgentStatus.getState().byId[p.nodeId]?.state
+    parkedAgentState: p.parkedAgentState,
+    liveAgentState: p.readAgentState()
   })
 }
 
@@ -841,6 +845,28 @@ export function TerminalNode({
   // `defaultPresence` (byte-identical to before). Stable for the node's lifetime (a tab switch
   // unmounts the node), so capturing it in the once-mounted lifecycle effect below is safe, like `api`.
   const presence = useActiveSessionPresence()
+  /**
+   * THIS node's agent-status store, for the memory levers that must not kill live work.
+   *
+   * Resolved the way the session registry resolves it — memoized by api identity — so a relay
+   * tab's node reads the RELAY core's status table rather than the local one. That matters now
+   * that `persistent:false` can arrive from a tmux-less relay HOST: such a node is exactly a
+   * plain-shell agent session, and against the default store its state would always read
+   * `undefined` (= disposable), i.e. unprotected. For the local session this IS `useAgentStatus`
+   * (the WeakMap is seeded with `window.nodeTerminal`), so nothing about local behavior changes.
+   *
+   * Scoped deliberately to the protection paths. The other status reads in this file predate
+   * per-session stores and are left exactly as they were; widening them is a separate change.
+   */
+  const agentStatusStore = agentStatusForApi(api).store
+  const readAgentState = useCallback(
+    (): AgentState | undefined => agentStatusStore.getState().byId[id]?.state,
+    [agentStatusStore, id]
+  )
+  /** Mirror for the mount-stable visibility observer, which is keyed on `termKey` alone and takes
+   *  everything mutable through a ref (see its docblock). */
+  const readAgentStateRef = useRef(readAgentState)
+  readAgentStateRef.current = readAgentState
   // Session-scope the module-global node-keyed maps (parkedTerminals / coStates / coSubs /
   // restartSubs / noParkIds): a relay tab adopts the host's project KEEPING node ids, so a local
   // node and a relay node can share a bare id. `session.id` is stable for this node's lifetime
@@ -3087,8 +3113,11 @@ export function TerminalNode({
           search: searchAddon,
           transport,
           sessionId,
-          nodeId: id,
           tmuxBacked: sessionPersistent,
+          // Snapshot NOW, because the departure effect declared below this one clears this node's
+          // agent status on this very unmount — every lever reads later and would see nothing.
+          parkedAgentState: readAgentState(),
+          readAgentState,
           cleanups,
           life,
           // The window RE-ARMS (PARK_RECHECK_MS) while this park is protected, instead of killing a
@@ -3253,9 +3282,16 @@ export function TerminalNode({
             if (
               shouldDeferReleaseForLiveWork({
                 tmuxBacked: sessionPersistentRef.current,
-                agentState: useAgentStatus.getState().byId[id]?.state
+                agentState: readAgentStateRef.current()
               })
             ) {
+              // Re-stamp the offscreen clock: this node is not RELEASABLE yet, and the Eco
+              // deferral's cap is measured from the start of the releasable stretch. Without this
+              // a long live-work wait would blow that cap outright, so the release that finally
+              // runs would skip the hibernate-first ordering and forfeit the CLI's hundreds of MB
+              // at the exact moment they became reclaimable. The stretch effectively begins when
+              // the work ends.
+              offscreenSinceRef.current = Date.now()
               offscreenTimerRef.current = setTimeout(fireRelease, OFFSCREEN_DEFER_RETRY_MS)
               return
             }

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -59,7 +59,14 @@ import {
 } from '../terminal/terminal-config'
 import { useXtermVisualSettings } from '../terminal/useXtermVisualSettings'
 import { loseWebglContexts, registerWebglClient, type WebglClientHandle } from '../terminal/webgl-budget'
-import { PARK_MAX, planParkEviction } from '../terminal/park-budget'
+import {
+  PARK_MAX,
+  armParkExpiry,
+  canDisposePark,
+  disposableParks,
+  planParkEviction,
+  type ParkTimer
+} from '../terminal/park-budget'
 import {
   mayDisposeOffscreen,
   offscreenCoreIsRemote,
@@ -265,6 +272,12 @@ export function setSshRetryHandler(
  * COUNT as well as time — beyond `PARK_MAX` the oldest entries are evicted early (see
  * `terminal/park-budget.ts`), so a remount past the cap is the same warm reattach as one past the
  * window.
+ *
+ * "The PTY client detaches; the session keeps running" is true ONLY with tmux underneath. On the
+ * plain-shell fallback the pty IS the shell, so the same dispose kills the shell and whatever runs
+ * in it — which is how a project switch could terminate a working agent mid-task (issue #126).
+ * Every dispose driven purely by the BUDGET (window expiry, LRU cap, memory-pressure lever) is
+ * therefore gated on `canDisposePark`; a deliberate dispose (delete, respawn, dead session) is not.
  */
 interface ParkedTerminal {
   term: Terminal
@@ -272,6 +285,12 @@ interface ParkedTerminal {
   search: SearchAddon
   transport: TerminalTransport
   sessionId: string
+  /** The node this park belongs to — the key into `agentStatus.byId` the protection reads. (The
+   *  map's own key is session-scoped, `terminalKey(sessionId, nodeId)`, so it is not the node id.) */
+  nodeId: string
+  /** `PtyCreateResult.persistent`: the session survives a client kill (tmux, local or remote).
+   *  False = plain shell, where disposing this park ends the session for real. */
+  tmuxBacked: boolean
   /** Session-scoped teardown (transport/xterm listeners) — run only at final dispose. */
   cleanups: Array<() => void>
   /**
@@ -281,13 +300,31 @@ interface ParkedTerminal {
    * cleanup and the park dispose all race for it.
    */
   life: SessionLife & { killed: boolean }
-  timer: ReturnType<typeof setTimeout>
+  /** The park window, which RE-ARMS while the entry is protected (see `armParkExpiry`). */
+  timer: ParkTimer
 }
 const parkedTerminals = new Map<string, ParkedTerminal>()
 const TERM_PARK_MS = 5 * 60 * 1000
 
+/** May the BUDGET levers dispose this park? Reads the node's live agent state the way the
+ *  hibernation sweep does (the same store, non-reactively) and pairs it with the session's
+ *  tmux-backedness. An unknown key is disposable — there is nothing there to protect.
+ *
+ *  `useAgentStatus` is the DEFAULT (local-core) store, like every other status read in this file.
+ *  A relay tab's status lives in its own session-scoped store, so a remote node reads as "no
+ *  agent" here — which changes nothing: a remote session is tmux-backed on the remote host, so it
+ *  is disposable either way. */
+function parkDisposable(key: string): boolean {
+  const p = parkedTerminals.get(key)
+  if (!p) return true
+  return canDisposePark({
+    tmuxBacked: p.tmuxBacked,
+    agentState: useAgentStatus.getState().byId[p.nodeId]?.state
+  })
+}
+
 function disposeParked(p: ParkedTerminal): void {
-  clearTimeout(p.timer)
+  p.timer.cancel()
   // Mark the session dead BEFORE tearing it down: a spawn continuation still awaiting its history
   // seed reads this to see that the session it handed off no longer exists (→ teardown, not
   // continue-parked), instead of wiring listeners onto a killed session.
@@ -313,9 +350,16 @@ export function disposeParkedTerminal(key: string): void {
 /** Memory-pressure lever: drop EVERY parked terminal now, without waiting out `TERM_PARK_MS`. The
  *  park is a cache, not state — each dropped entry costs only its warm re-adopt, and the node
  *  re-mounts as an ordinary warm reattach (tmux redraws; the session and its scrollback are
- *  untouched). Idempotent; iterates a copy because `disposeParkedTerminal` mutates the map. */
+ *  untouched). Idempotent; iterates a copy because `disposeParkedTerminal` mutates the map.
+ *
+ *  EXCEPT the protected ones (`canDisposePark`): for a plain-shell session the sentence above is
+ *  false — the dispose is not a re-adopt cost, it is the end of the session — so a park holding a
+ *  working agent on a non-tmux shell is left alone and released by its own expiry re-check.
+ *  Everything else still goes, which is the whole point of the lever. */
 export function disposeAllParkedTerminals(): void {
-  for (const key of [...parkedTerminals.keys()]) disposeParkedTerminal(key)
+  for (const key of disposableParks([...parkedTerminals.keys()], parkDisposable)) {
+    disposeParkedTerminal(key)
+  }
 }
 
 /** Session-scoped keys (`terminalKey`) whose next unmount must dispose (not park) — set on permanent
@@ -1359,7 +1403,7 @@ export function TerminalNode({
     const parked = parkedTerminals.get(termKey)
     if (parked) {
       parkedTerminals.delete(termKey)
-      clearTimeout(parked.timer)
+      parked.timer.cancel()
     }
 
     const s = useSettings.getState().settings
@@ -1585,6 +1629,12 @@ export function TerminalNode({
     }
 
     let sessionId: string | null = parked ? parked.sessionId : null
+    // Does this session survive losing its client (tmux, local or remote)? Read off the create
+    // result below, carried over when adopting a park. Seeded `true` — the historical assumption —
+    // so a session whose create has not answered yet, or a core too old to say
+    // (`PtyCreateResult.persistent` absent), behaves exactly as it always did rather than being
+    // protected on a guess. See `canDisposePark`.
+    let sessionPersistent = parked ? parked.tmuxBacked : true
     let disposed = false
     // Last cols/rows REPORTED to the pty (seeded at create): a resize IPC makes tmux redraw the
     // whole pane, so a same-size fit (e.g. the ResizeObserver's initial tick right after mount)
@@ -2240,6 +2290,7 @@ export function TerminalNode({
           screen,
           cursor,
           coAttachMouse,
+          persistent,
           unavailable
         }) => {
         // REFUSED: `requireRemote` and core could not spawn remotely (the master died inside our
@@ -2278,6 +2329,8 @@ export function TerminalNode({
         let offData: (() => void) | undefined
         if (onDisposed()) return
         sessionId = sid
+        // `?? true`: an absent flag is an older core over the relay, not a plain shell.
+        sessionPersistent = persistent ?? true
         if (fellBack) setAccountFallback(true)
         // Catch up a size change that landed while the spawn was in flight (applyFit skips the
         // IPC until sessionId is set, and the observer won't re-fire without another change).
@@ -3023,26 +3076,38 @@ export function TerminalNode({
           search: searchAddon,
           transport,
           sessionId,
+          nodeId: id,
+          tmuxBacked: sessionPersistent,
           cleanups,
           life,
-          timer: setTimeout(() => {
-            if (parkedTerminals.get(termKey) === entry) {
-              parkedTerminals.delete(termKey)
-              disposeParked(entry)
-            }
-          }, TERM_PARK_MS)
+          // The window RE-ARMS (PARK_RECHECK_MS) while this park is protected, instead of killing a
+          // plain shell that is still running the user's agent — and instead of leaking the park,
+          // which is what a plain "skip the dispose" would do.
+          timer: armParkExpiry(
+            () => parkDisposable(termKey),
+            () => {
+              if (parkedTerminals.get(termKey) === entry) {
+                parkedTerminals.delete(termKey)
+                disposeParked(entry)
+              }
+            },
+            TERM_PARK_MS
+          )
         }
         disposeParkedTerminal(termKey) // defensive: never stack two entries for one node
         parkedTerminals.set(termKey, entry)
         // Enforce the park count cap: evict the OLDEST parks (their next remount becomes a warm
-        // tmux reattach — the post-window behavior, just earlier). Never the entry just parked.
+        // tmux reattach — the post-window behavior, just earlier). Never the entry just parked,
+        // and never a PROTECTED one — the plan skips those and takes the next-oldest disposable
+        // park instead, and the cap is simply exceeded when every park is protected (see
+        // planParkEviction: a bounded cache overrun beats killing live work).
         // Eviction MUST observe the POST-ADOPTION map: a project switch flushes every outgoing
         // node's cleanup (parking each) BEFORE any incoming node's mount effect adopts its own
         // park, so evicting inline would dispose the parks the incoming project is about to
         // re-adopt. A microtask is what defers past the whole synchronous passive-effect flush
         // (cleanups AND mounts); adoption has removed its entries from the map by then.
         queueMicrotask(() => {
-          for (const k of planParkEviction([...parkedTerminals.keys()], PARK_MAX)) {
+          for (const k of planParkEviction([...parkedTerminals.keys()], PARK_MAX, parkDisposable)) {
             if (k !== termKey) disposeParkedTerminal(k)
           }
         })

--- a/src/renderer/terminal/live-work.test.ts
+++ b/src/renderer/terminal/live-work.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { wouldKillLiveWork } from './live-work'
+
+describe('wouldKillLiveWork', () => {
+  it('is true only for a NON-tmux session whose agent is working/waiting/blocked', () => {
+    for (const agentState of ['working', 'waiting', 'blocked'] as const) {
+      expect(wouldKillLiveWork({ tmuxBacked: false, agentState })).toBe(true)
+    }
+  })
+  it('is false for a tmux-backed session, whatever its agent is doing', () => {
+    // The kill only detaches our client there — tmux, the pane and the CLI all keep running.
+    for (const agentState of ['working', 'waiting', 'blocked', 'done', undefined] as const) {
+      expect(wouldKillLiveWork({ tmuxBacked: true, agentState })).toBe(false)
+    }
+  })
+  it('is false for a finished or unknown agent, and for a terminal with no agent at all', () => {
+    expect(wouldKillLiveWork({ tmuxBacked: false, agentState: 'done' })).toBe(false)
+    expect(wouldKillLiveWork({ tmuxBacked: false })).toBe(false)
+  })
+})

--- a/src/renderer/terminal/live-work.test.ts
+++ b/src/renderer/terminal/live-work.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { effectiveAgentState, wouldKillLiveWork } from './live-work'
+import { WORKING_STALE_MS } from '@shared/agents/stale'
+import { effectiveAgentState, parkedStateFloor, wouldKillLiveWork } from './live-work'
 
 describe('wouldKillLiveWork', () => {
   it('is true only for a NON-tmux session whose agent is working/waiting/blocked', () => {
@@ -36,5 +37,32 @@ describe('effectiveAgentState — the snapshot FLOOR under a live store read', (
   })
   it('is undefined only when neither knows anything', () => {
     expect(effectiveAgentState(undefined, undefined)).toBeUndefined()
+  })
+})
+
+describe('parkedStateFloor — a `working` snapshot ages out, the others do not', () => {
+  const t0 = 1_000_000
+  it('holds a working snapshot inside the stale-working window', () => {
+    expect(parkedStateFloor('working', t0, t0)).toBe('working')
+    expect(parkedStateFloor('working', t0, t0 + WORKING_STALE_MS)).toBe('working')
+  })
+  it('drops a working snapshot past it — no sweep can reach a parked entry to do it for us', () => {
+    // The renderer sweep matches `state === 'working'`, and the departure clear already set this
+    // node's entry to undefined; the core sweep's synthetic end edge feeds onNodeStateChange
+    // consumers, never the renderer's agent:status IPC. So a CLI that died silently would leave
+    // this park re-arming forever, holding a PARK_MAX slot for a session that no longer exists.
+    expect(parkedStateFloor('working', t0, t0 + WORKING_STALE_MS + 1)).toBeUndefined()
+    expect(parkedStateFloor('working', t0, t0 + 10 * WORKING_STALE_MS)).toBeUndefined()
+  })
+  it('never ages waiting/blocked — a question held open is not stale, it is waiting for the user', () => {
+    expect(parkedStateFloor('waiting', t0, t0 + 10 * WORKING_STALE_MS)).toBe('waiting')
+    expect(parkedStateFloor('blocked', t0, t0 + 10 * WORKING_STALE_MS)).toBe('blocked')
+  })
+  it('passes through done/absent, and cannot age a snapshot with no timestamp', () => {
+    expect(parkedStateFloor('done', t0, t0 + 10 * WORKING_STALE_MS)).toBe('done')
+    expect(parkedStateFloor(undefined, t0, t0)).toBeUndefined()
+    // No stamp ⇒ no age ⇒ treated as fresh. TerminalNode always stamps; this is the safe answer
+    // for a caller that forgot, since the alternative is dropping a live agent's protection.
+    expect(parkedStateFloor('working', undefined, t0 + 10 * WORKING_STALE_MS)).toBe('working')
   })
 })

--- a/src/renderer/terminal/live-work.test.ts
+++ b/src/renderer/terminal/live-work.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { wouldKillLiveWork } from './live-work'
+import { effectiveAgentState, wouldKillLiveWork } from './live-work'
 
 describe('wouldKillLiveWork', () => {
   it('is true only for a NON-tmux session whose agent is working/waiting/blocked', () => {
@@ -16,5 +16,25 @@ describe('wouldKillLiveWork', () => {
   it('is false for a finished or unknown agent, and for a terminal with no agent at all', () => {
     expect(wouldKillLiveWork({ tmuxBacked: false, agentState: 'done' })).toBe(false)
     expect(wouldKillLiveWork({ tmuxBacked: false })).toBe(false)
+  })
+})
+
+describe('effectiveAgentState — the snapshot FLOOR under a live store read', () => {
+  it('falls back to the snapshot when the store has forgotten the node', () => {
+    // THE #126 REPRO. TerminalNode's departure effect clears agent status on the very unmount that
+    // parks the terminal, so every later reader — the LRU in a microtask, the expiry minutes on —
+    // sees `undefined` and calls a working agent disposable. The snapshot is what survives it.
+    expect(effectiveAgentState(undefined, 'working')).toBe('working')
+    expect(effectiveAgentState(undefined, 'waiting')).toBe('waiting')
+  })
+  it('lets a LIVE state override the snapshot in both directions', () => {
+    // Hook events keep landing for a parked node (Canvas's listener is keyed by node id, not by
+    // mount), so a turn that ends while parked must be able to RELEASE the protection…
+    expect(effectiveAgentState('done', 'working')).toBe('done')
+    // …and one that starts must be able to add it.
+    expect(effectiveAgentState('working', 'done')).toBe('working')
+  })
+  it('is undefined only when neither knows anything', () => {
+    expect(effectiveAgentState(undefined, undefined)).toBeUndefined()
   })
 })

--- a/src/renderer/terminal/live-work.ts
+++ b/src/renderer/terminal/live-work.ts
@@ -1,0 +1,52 @@
+/**
+ * THE ONE QUESTION EVERY MEMORY LEVER MUST ASK BEFORE IT KILLS A PTY CLIENT: would that kill end
+ * work the user has running?
+ *
+ * The renderer reclaims terminal memory in four places, and all four are written as if dropping a
+ * PTY client were free — "the tmux session keeps running and re-attach redraws". That sentence is
+ * true only where tmux is actually underneath. On the plain-shell fallback (no tmux installed,
+ * tmux switched off in settings, or an install path `findTmux` missed) the pty IS the shell, so
+ * the identical call kills the shell and every process under it — an agent CLI mid-turn included.
+ *
+ * Reported as issue #126: switching projects terminated a working Claude agent, which then
+ * auto-resumed from wherever the kill landed ("terminated mid action"). Three of the four levers
+ * are the park's (window expiry, LRU cap, memory-pressure drop — see `park-budget.ts`); the fourth
+ * is the offscreen viewer release (`offscreen-policy.ts`). They differ in everything except this
+ * question, which is why it lives here on its own rather than in whichever module happened to
+ * need it first.
+ *
+ * The predicate is deliberately the NARROWEST one that closes the bug: it takes both halves, and
+ * either half alone leaves today's behavior untouched. A tmux-backed session is never protected
+ * (the kill costs a redraw, and protecting it would forfeit real memory on the setups where
+ * reclaiming it is free); a plain terminal, a finished agent and an unknown state are never
+ * protected either (nothing is running to lose).
+ */
+import type { AgentState } from '@shared/agents/normalize'
+
+/**
+ * Agent states that mean the CLI is mid-task or holding something open for the user. The same set
+ * hibernation refuses to `/exit` (`hibernation-policy.ts`) and for the same reasons: `working` is
+ * a turn in flight, `waiting`/`blocked` is a question or a permission request the user is being
+ * asked to come back for. `done` and unknown are not evidence of live work.
+ */
+const LIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set<AgentState>([
+  'working',
+  'waiting',
+  'blocked'
+])
+
+export interface LiveWorkInput {
+  /**
+   * The session survives losing this client — a tmux session, local or remote
+   * (`PtyCreateResult.persistent`). False = the plain-shell fallback, where the pty is the shell.
+   */
+  tmuxBacked: boolean
+  /** The node's live agent state (`agentStatus.byId[nodeId].state`); absent = a plain terminal, or
+   *  no hook event seen for it yet. */
+  agentState?: AgentState
+}
+
+/** Would tearing down this terminal's PTY client destroy work that is still running? */
+export function wouldKillLiveWork(i: LiveWorkInput): boolean {
+  return !i.tmuxBacked && !!i.agentState && LIVE_AGENT_STATES.has(i.agentState)
+}

--- a/src/renderer/terminal/live-work.ts
+++ b/src/renderer/terminal/live-work.ts
@@ -50,3 +50,29 @@ export interface LiveWorkInput {
 export function wouldKillLiveWork(i: LiveWorkInput): boolean {
   return !i.tmuxBacked && !!i.agentState && LIVE_AGENT_STATES.has(i.agentState)
 }
+
+/**
+ * The state to judge a PARKED terminal by: the live store read, with the state captured at park
+ * time as a FLOOR under it.
+ *
+ * A snapshot alone would be stale and a live read alone is not available — because the unmount
+ * that parks a terminal is the same unmount that CLEARS its agent status. TerminalNode's
+ * departure-only effect exists so a project switch doesn't leave a stale RUNNING badge behind, and
+ * it runs right after the lifecycle cleanup that created the park. Every park lever reads the
+ * store later than that — the LRU in a microtask, the expiry minutes on — so every one of them saw
+ * `undefined` and called a working agent disposable. That is the reported #126 case (a project
+ * switch past `PARK_MAX`) and, worse, it made `waiting`/`blocked` parks unprotectable in
+ * principle: an agent holding a question open emits no further hook events, so nothing would ever
+ * repopulate the store for it.
+ *
+ * The floor is only a floor, never a latch: hook events for a parked node still land in the store
+ * (Canvas's `agent:status` listener is keyed by node id, not by what is mounted), so a turn that
+ * ENDS while parked releases the protection on the next re-check, and one that starts adds it.
+ * Live truth always wins; the snapshot only answers when there is no live truth to have.
+ */
+export function effectiveAgentState(
+  live: AgentState | undefined,
+  atParkTime: AgentState | undefined
+): AgentState | undefined {
+  return live ?? atParkTime
+}

--- a/src/renderer/terminal/live-work.ts
+++ b/src/renderer/terminal/live-work.ts
@@ -21,6 +21,7 @@
  * reclaiming it is free); a plain terminal, a finished agent and an unknown state are never
  * protected either (nothing is running to lose).
  */
+import { WORKING_STALE_MS } from '@shared/agents/stale'
 import type { AgentState } from '@shared/agents/normalize'
 
 /**
@@ -75,4 +76,38 @@ export function effectiveAgentState(
   atParkTime: AgentState | undefined
 ): AgentState | undefined {
   return live ?? atParkTime
+}
+
+/**
+ * The park-time snapshot, AGED: a `working` snapshot stops counting once it is older than
+ * `WORKING_STALE_MS`; every other state keeps counting indefinitely.
+ *
+ * WHY THE SNAPSHOT NEEDS AN EXPIRY THE LIVE STATE DOES NOT. A `working` session that dies without
+ * saying so is an ordinary event (Esc during a tool call runs no Stop hook, a killed CLI, a slept
+ * machine, a dropped link), and the product already has one answer for it: the stale-working
+ * sweep. Neither copy of that sweep can reach a PARKED node's snapshot, though — the renderer's
+ * matches `state === 'working'` in the store, and the departure clear on the parking unmount has
+ * already blanked that entry; the core's mirror fires an `onNodeStateChange` edge that reaches its
+ * own consumers but never the renderer's `agent:status` IPC. So nothing would ever retire this
+ * evidence, and the park would re-arm its expiry for the rest of the run, permanently holding one
+ * of `PARK_MAX` slots for a session that no longer exists.
+ *
+ * The window is the SHARED constant, not a new number: this is the same judgment call about the
+ * same signal ("a working node this quiet is presumed gone"), and two numbers for one question
+ * drift apart. A LIVE `working` reading is deliberately never aged here — the store still knows
+ * about that node, so the renderer sweep can and does correct it, and second-guessing a store that
+ * says "working" right now would kill a real turn.
+ *
+ * `waiting`/`blocked` never expires, and that asymmetry is the point: a question held open is not
+ * a stale signal, it is a session waiting for the user, and no elapsed time makes ending it right.
+ * A snapshot with no timestamp cannot be aged and is treated as fresh — the safe direction, since
+ * the alternative drops a live agent's protection over a bookkeeping omission.
+ */
+export function parkedStateFloor(
+  atParkTime: AgentState | undefined,
+  parkedAt: number | undefined,
+  now: number
+): AgentState | undefined {
+  if (atParkTime !== 'working' || parkedAt === undefined) return atParkTime
+  return now - parkedAt > WORKING_STALE_MS ? undefined : atParkTime
 }

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -6,7 +6,8 @@ import {
   mayDisposeOffscreen,
   offscreenCoreIsRemote,
   planOffscreenVisibility,
-  shouldDeferReleaseForEco
+  shouldDeferReleaseForEco,
+  shouldDeferReleaseForLiveWork
 } from './offscreen-policy'
 
 describe('offscreen dispose policy', () => {
@@ -147,6 +148,46 @@ describe('shouldDeferReleaseForEco — hibernate first, then release the viewer'
     expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 40 * 60_000 - 1 })).toBe(true)
     expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 40 * 60_000 })).toBe(false)
     expect(shouldDeferReleaseForEco({ ...base, offscreenElapsedMs: 90 * 60_000 })).toBe(false)
+  })
+})
+
+describe('shouldDeferReleaseForLiveWork — the fourth kill lever behind issue #126', () => {
+  it('defers a PLAIN-SHELL terminal whose agent is mid-task, where the release would end it', () => {
+    for (const agentState of ['working', 'waiting', 'blocked'] as const) {
+      expect(shouldDeferReleaseForLiveWork({ tmuxBacked: false, agentState })).toBe(true)
+    }
+  })
+
+  it('releases the same terminal once the agent goes idle — the deferral drains itself', () => {
+    // The retry cadence re-asks, so "protected" is a state the node LEAVES; nothing has to
+    // remember that it was ever deferred.
+    expect(shouldDeferReleaseForLiveWork({ tmuxBacked: false, agentState: 'working' })).toBe(true)
+    expect(shouldDeferReleaseForLiveWork({ tmuxBacked: false, agentState: 'done' })).toBe(false)
+  })
+
+  it('never defers a TMUX-BACKED terminal, even one mid-turn — that release is safe', () => {
+    // The whole point of the distinction: with tmux the dispose detaches a client and the CLI
+    // keeps working. Deferring here would forfeit the memory this feature exists to reclaim, on
+    // the setups where reclaiming it is free.
+    expect(shouldDeferReleaseForLiveWork({ tmuxBacked: true, agentState: 'working' })).toBe(false)
+    expect(shouldDeferReleaseForLiveWork({ tmuxBacked: true, agentState: 'waiting' })).toBe(false)
+  })
+
+  it('never defers a plain terminal or an agent-less node', () => {
+    expect(shouldDeferReleaseForLiveWork({ tmuxBacked: false })).toBe(false)
+  })
+
+  it('is UNCAPPED, unlike the Eco deferral — there is no elapsed time that makes the kill safe', () => {
+    // shouldDeferReleaseForEco takes `offscreenElapsedMs` and gives up at the cap because it waits
+    // for a hibernation that may never come. This one waits for the user's own turn to end, and
+    // "give up and kill it anyway" is precisely the reported bug — so time is not an input at all.
+    // Pinned structurally: the input carries no clock, so no caller can grow a cap by passing one.
+    const input: Parameters<typeof shouldDeferReleaseForLiveWork>[0] = {
+      tmuxBacked: false,
+      agentState: 'working'
+    }
+    expect(Object.keys(input).sort()).toEqual(['agentState', 'tmuxBacked'])
+    expect(shouldDeferReleaseForLiveWork(input)).toBe(true)
   })
 })
 

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
 import {
   OFFSCREEN_DISPOSE_MS_DEFAULT,
   offscreenDisposeMs,
@@ -177,17 +179,30 @@ describe('shouldDeferReleaseForLiveWork — the fourth kill lever behind issue #
     expect(shouldDeferReleaseForLiveWork({ tmuxBacked: false })).toBe(false)
   })
 
-  it('is UNCAPPED, unlike the Eco deferral — there is no elapsed time that makes the kill safe', () => {
-    // shouldDeferReleaseForEco takes `offscreenElapsedMs` and gives up at the cap because it waits
-    // for a hibernation that may never come. This one waits for the user's own turn to end, and
-    // "give up and kill it anyway" is precisely the reported bug — so time is not an input at all.
-    // Pinned structurally: the input carries no clock, so no caller can grow a cap by passing one.
-    const input: Parameters<typeof shouldDeferReleaseForLiveWork>[0] = {
-      tmuxBacked: false,
-      agentState: 'working'
-    }
-    expect(Object.keys(input).sort()).toEqual(['agentState', 'tmuxBacked'])
-    expect(shouldDeferReleaseForLiveWork(input)).toBe(true)
+  /**
+   * UNCAPPED, unlike the Eco deferral one screen up — and that is a decision, not an oversight, so
+   * it is pinned rather than described. `shouldDeferReleaseForEco` takes `offscreenElapsedMs` and
+   * gives up at a cap because it waits for a hibernation that may never come; this one waits for
+   * the user's own turn to end, and "give up and release anyway" is precisely the bug (#126).
+   *
+   * A behavioural test cannot state this: the claim is about an input that must NOT exist, and any
+   * argument object a test writes itself passes trivially. So it is pinned over the source — the
+   * same move `canvas/agent-status-rescue.test.ts` and `core/no-electron.test.ts` make for
+   * invariants no call can express — and it fails the moment someone threads a clock through.
+   */
+  it('is UNCAPPED: no clock reaches the predicate, so no caller can grow a cap', () => {
+    const src = fs.readFileSync(path.resolve(__dirname, 'offscreen-policy.ts'), 'utf8')
+    const start = src.indexOf('export function shouldDeferReleaseForLiveWork')
+    expect(start, 'the predicate must still exist').toBeGreaterThan(-1)
+    const body = src.slice(start, src.indexOf('\n}', start))
+    // Its whole input is LiveWorkInput (tmuxBacked + agentState). Nothing time-shaped may appear:
+    // an elapsed reading, a deadline, a Date.now() — each of those is a cap in the making.
+    expect(body).toMatch(/shouldDeferReleaseForLiveWork\(\s*i: LiveWorkInput\s*\)/)
+    expect(body).not.toMatch(/elapsed|Ms\b|Date\.now|cap|minutes/i)
+    // …and the shared input type itself carries no clock either (the other end of the same claim).
+    const live = fs.readFileSync(path.resolve(__dirname, 'live-work.ts'), 'utf8')
+    const iface = live.slice(live.indexOf('export interface LiveWorkInput'))
+    expect(iface.slice(0, iface.indexOf('\n}'))).not.toMatch(/elapsed|Date\.now|cap|minutes/i)
   })
 })
 

--- a/src/renderer/terminal/offscreen-policy.ts
+++ b/src/renderer/terminal/offscreen-policy.ts
@@ -8,7 +8,12 @@
  * REMOTE (SSH) nodes are excluded in v1: their spawn path runs the requireRemote/offline
  * machinery and a re-spawn while the ControlMaster is down would surface the offline overlay for
  * a node the user never touched. Follow-up once demand exists.
+ *
+ * "The tmux session keeps running and re-attach redraws" is the load-bearing sentence, and it is
+ * FALSE without tmux — where this release kills the shell and the agent CLI in it. See
+ * `shouldDeferReleaseForLiveWork`.
  */
+import { wouldKillLiveWork, type LiveWorkInput } from './live-work'
 import type { SessionSource } from '../session/session'
 
 export const OFFSCREEN_DISPOSE_MS_DEFAULT = 10 * 60_000
@@ -55,8 +60,37 @@ export function releaseStillEnabled(settingMinutes: number | undefined): boolean
 }
 
 /** How often a DEFERRED release re-asks. The hibernation sweep's own cadence, because that is
- *  exactly what the deferral is waiting for: one sweep after the node hibernates, the viewer goes. */
+ *  exactly what the deferral is waiting for: one sweep after the node hibernates, the viewer goes.
+ *  The live-work deferral below rides the same retry, and a minute suits it for the same kind of
+ *  reason — what it waits for is a human-scale event (an agent turn ending). */
 export const OFFSCREEN_DEFER_RETRY_MS = 60_000
+
+/**
+ * THE FOURTH KILL LEVER (issue #126). Defer this release — indefinitely — while disposing the
+ * terminal would destroy work that is still running.
+ *
+ * This module's whole premise is that a release is cheap: the node stays mounted, the tmux session
+ * keeps running, and the revive is a warm re-attach that redraws. Without tmux underneath none of
+ * that holds — the pty IS the shell — so releasing an offscreen agent node on a plain-shell setup
+ * terminates the CLI mid-turn and the node's restart machinery resumes it from wherever the kill
+ * landed. Panning away from a working agent is not a request to stop it.
+ *
+ * Expressed as a DEFERRAL rather than a refusal because this fire path already has exactly that
+ * shape and cadence (`shouldDeferReleaseForEco` → re-arm at `OFFSCREEN_DEFER_RETRY_MS`): every
+ * input is re-asked a minute later, so "protected" is a state the node LEAVES on its own the
+ * moment its agent goes idle, and the release then proceeds normally. No new timer, no new state,
+ * nothing to remember.
+ *
+ * UNCAPPED, and that is the one place it deliberately differs from the Eco deferral above. That
+ * one caps because it waits for a hibernation that may never come, and stranding a viewer forever
+ * for an event that cannot happen would be worse than the memory it saves. This one waits for the
+ * user's own turn to end — a thing that always ends — and "give up and release anyway" is
+ * precisely the reported bug. So no clock is an input here at all. The exposure is bounded by
+ * what it protects: only non-tmux sessions, only while an agent is actually mid-task.
+ */
+export function shouldDeferReleaseForLiveWork(i: LiveWorkInput): boolean {
+  return wouldKillLiveWork(i)
+}
 
 /**
  * PHASE 5 ORDERING: with Eco on, releasing an offscreen terminal's viewer WAITS for its agent to

--- a/src/renderer/terminal/offscreen-policy.ts
+++ b/src/renderer/terminal/offscreen-policy.ts
@@ -83,10 +83,23 @@ export const OFFSCREEN_DEFER_RETRY_MS = 60_000
  *
  * UNCAPPED, and that is the one place it deliberately differs from the Eco deferral above. That
  * one caps because it waits for a hibernation that may never come, and stranding a viewer forever
- * for an event that cannot happen would be worse than the memory it saves. This one waits for the
- * user's own turn to end — a thing that always ends — and "give up and release anyway" is
- * precisely the reported bug. So no clock is an input here at all. The exposure is bounded by
- * what it protects: only non-tmux sessions, only while an agent is actually mid-task.
+ * for an event that cannot happen would be worse than the memory it saves. Here the thing waited
+ * for is the user's own session ending, and "give up and release anyway" IS the reported bug — a
+ * cap would just be the same kill with a delay in front of it. So no clock is an input at all.
+ *
+ * BE HONEST ABOUT WHAT THAT COSTS. `working` always resolves — the stale-working sweep
+ * (`shared/agents/stale.ts`, 20 minutes) fires a synthetic end edge for a session that died
+ * without saying so, and that reaches this store like any other event. `waiting`/`blocked` has no
+ * such sweep, and legitimately so: a question held open for the user is not stale, it is waiting
+ * for them. A user who never answers therefore holds this node's viewer for as long as the app
+ * runs.
+ *
+ * That is accepted, because the exposure is bounded in the dimension that matters. It is not
+ * unbounded growth: it is at most one held viewer (~15 MB) per non-tmux node that is actually
+ * sitting on an unanswered prompt — a count the user creates by hand and can see on the canvas,
+ * where the badge is telling them the node needs them. Bounded by node count, not by time. The
+ * alternative is trading a bounded amount of memory for the user's running work, which is the
+ * trade this whole change exists to stop making.
  */
 export function shouldDeferReleaseForLiveWork(i: LiveWorkInput): boolean {
   return wouldKillLiveWork(i)

--- a/src/renderer/terminal/offscreen-policy.ts
+++ b/src/renderer/terminal/offscreen-policy.ts
@@ -87,12 +87,14 @@ export const OFFSCREEN_DEFER_RETRY_MS = 60_000
  * for is the user's own session ending, and "give up and release anyway" IS the reported bug — a
  * cap would just be the same kill with a delay in front of it. So no clock is an input at all.
  *
- * BE HONEST ABOUT WHAT THAT COSTS. `working` always resolves — the stale-working sweep
- * (`shared/agents/stale.ts`, 20 minutes) fires a synthetic end edge for a session that died
- * without saying so, and that reaches this store like any other event. `waiting`/`blocked` has no
- * such sweep, and legitimately so: a question held open for the user is not stale, it is waiting
- * for them. A user who never answers therefore holds this node's viewer for as long as the app
- * runs.
+ * BE HONEST ABOUT WHAT THAT COSTS. `working` resolves within `WORKING_STALE_MS` even when the CLI
+ * dies without saying so: Canvas's 60-second `sweepStaleWorking` blanks a working entry that has
+ * gone that quiet, and this predicate reads that entry. (It works HERE because the node is still
+ * MOUNTED, so its store entry is intact — the park path cannot rely on the same sweep, which is
+ * why the park's snapshot ages itself out instead; see `live-work.ts`'s `parkedStateFloor`.)
+ * `waiting`/`blocked` has no such sweep, and legitimately so: a question held open for the user is
+ * not stale, it is waiting for them. A user who never answers therefore holds this node's viewer
+ * for as long as the app runs.
  *
  * That is accepted, because the exposure is bounded in the dimension that matters. It is not
  * unbounded growth: it is at most one held viewer (~15 MB) per non-tmux node that is actually

--- a/src/renderer/terminal/park-budget.test.ts
+++ b/src/renderer/terminal/park-budget.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { WORKING_STALE_MS } from '@shared/agents/stale'
 import {
   PARK_MAX,
   PARK_RECHECK_MS,
@@ -124,6 +125,38 @@ describe('a parked plain-shell agent survives the departure clear (#126)', () =>
     park('ask', { tmuxBacked: false, parkedAgentState: 'waiting', liveAgentState: 'waiting' })
     departureClear('ask')
     expect(disposable('ask')).toBe(false)
+  })
+
+  /**
+   * The one bound the snapshot needs, because no sweep can supply it.
+   *
+   * A `working` snapshot outlives its evidence when the CLI dies without saying so (Esc mid-tool,
+   * a killed process, a slept machine). Neither stale-working sweep can correct a PARKED node: the
+   * renderer's matches `state === 'working'` and the departure clear already blanked the entry;
+   * the core's fires an `onNodeStateChange` edge that never reaches the renderer's agent:status
+   * IPC. Unaged, that park re-arms its expiry forever and permanently eats a PARK_MAX slot.
+   */
+  describe('the working snapshot ages out at WORKING_STALE_MS', () => {
+    const parkedAt = 5_000_000
+    const working: ParkedEntryState = { tmuxBacked: false, parkedAgentState: 'working', parkedAt }
+
+    it('protects inside the window and releases past it', () => {
+      expect(canDisposeParkedEntry(working, parkedAt + WORKING_STALE_MS)).toBe(false)
+      expect(canDisposeParkedEntry(working, parkedAt + WORKING_STALE_MS + 1)).toBe(true)
+    })
+
+    it('keeps protecting a waiting snapshot past the same window', () => {
+      const waiting: ParkedEntryState = { ...working, parkedAgentState: 'waiting' }
+      expect(canDisposeParkedEntry(waiting, parkedAt + 10 * WORKING_STALE_MS)).toBe(false)
+    })
+
+    it('never ages a LIVE working reading — the live sweep owns that case', () => {
+      // The store says it is working NOW, so the snapshot's age is irrelevant: this is a real
+      // session mid-turn (and the renderer sweep CAN reach a node the store still knows about).
+      expect(
+        canDisposeParkedEntry({ ...working, liveAgentState: 'working' }, parkedAt + 10 * WORKING_STALE_MS)
+      ).toBe(false)
+    })
   })
 
   it('still disposes the cases that were always disposable, snapshot or not', () => {

--- a/src/renderer/terminal/park-budget.test.ts
+++ b/src/renderer/terminal/park-budget.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import {
   PARK_MAX,
   PARK_RECHECK_MS,
   armParkExpiry,
   canDisposePark,
+  canDisposeParkedEntry,
   disposableParks,
-  planParkEviction
+  planParkEviction,
+  type ParkedEntryState
 } from './park-budget'
 
 describe('planParkEviction', () => {
@@ -48,6 +50,94 @@ describe('canDisposePark', () => {
   it('disposes a TMUX-backed park even while its agent works — the kill only detaches a client', () => {
     expect(canDisposePark({ tmuxBacked: true, agentState: 'working' })).toBe(true)
     expect(canDisposePark({ tmuxBacked: true, agentState: 'waiting' })).toBe(true)
+  })
+})
+
+/**
+ * THE REPRO, at the level the logic lives on.
+ *
+ * The park levers do not read a state, they read a REGISTRY of parked entries; so does the real
+ * `parkDisposable` in TerminalNode. This fakes that registry and drives all three levers through
+ * the same predicate they use in production, because the bug was never in any one lever — it was
+ * in what they all read.
+ *
+ * Sequence: a plain-shell terminal parks while its agent is WORKING, then TerminalNode's departure
+ * effect clears the node's agent status (the unmount that parks is the same unmount that clears),
+ * so every later live read answers `undefined`.
+ */
+describe('a parked plain-shell agent survives the departure clear (#126)', () => {
+  const registry = new Map<string, ParkedEntryState>()
+  const disposable = (key: string): boolean => {
+    const e = registry.get(key)
+    return e ? canDisposeParkedEntry(e) : true
+  }
+  /** Park `key`, snapshotting the state the node had at that moment. */
+  const park = (key: string, e: ParkedEntryState): void => void registry.set(key, e)
+  /** What the departure effect does: the store forgets the node entirely. */
+  const departureClear = (key: string): void => {
+    const e = registry.get(key)
+    if (e) registry.set(key, { ...e, liveAgentState: undefined })
+  }
+
+  beforeEach(() => registry.clear())
+
+  it('LRU eviction: the just-parked working terminal is not evicted past the cap', () => {
+    park('victim', { tmuxBacked: false, parkedAgentState: 'working', liveAgentState: 'working' })
+    departureClear('victim')
+    for (let i = 0; i < PARK_MAX; i++) park(`other${i}`, { tmuxBacked: true })
+    // 13 parks against a cap of 12, oldest ('victim') first — the exact >PARK_MAX project switch.
+    const plan = planParkEviction([...registry.keys()], PARK_MAX, disposable)
+    expect(plan).not.toContain('victim')
+    expect(plan).toEqual(['other0']) // the cap still holds, paid by the next-oldest disposable park
+  })
+
+  it('window expiry: re-arms instead of disposing, then disposes when the agent reports done', () => {
+    park('victim', { tmuxBacked: false, parkedAgentState: 'working', liveAgentState: 'working' })
+    departureClear('victim')
+    const armed: Array<{ fn: () => void; ms: number }> = []
+    let disposed = 0
+    armParkExpiry(() => disposable('victim'), () => disposed++, 5000, {
+      set: (fn, ms) => armed.push({ fn, ms }) - 1,
+      clear: () => {}
+    })
+    armed[0].fn()
+    expect(disposed).toBe(0)
+    expect(armed[1].ms).toBe(PARK_RECHECK_MS)
+    // A `done` hook event lands while the node is still parked — Canvas's listener is keyed by
+    // node id, not by mount, so the store CAN learn this — and the live read overrides the floor.
+    registry.set('victim', { ...registry.get('victim')!, liveAgentState: 'done' })
+    armed[1].fn()
+    expect(disposed).toBe(1)
+  })
+
+  it('memory-pressure lever: drops every other park and leaves this one', () => {
+    park('victim', { tmuxBacked: false, parkedAgentState: 'working', liveAgentState: 'working' })
+    departureClear('victim')
+    park('plain', { tmuxBacked: false })
+    park('tmux-working', { tmuxBacked: true, parkedAgentState: 'working' })
+    expect(disposableParks([...registry.keys()], disposable)).toEqual(['plain', 'tmux-working'])
+  })
+
+  it('protects a WAITING park, which no later hook event would ever repopulate', () => {
+    // `waiting`/`blocked` is a question held open for the user: the agent emits nothing more until
+    // they answer, so the store clear is permanent and the snapshot is the ONLY evidence left.
+    park('ask', { tmuxBacked: false, parkedAgentState: 'waiting', liveAgentState: 'waiting' })
+    departureClear('ask')
+    expect(disposable('ask')).toBe(false)
+  })
+
+  it('still disposes the cases that were always disposable, snapshot or not', () => {
+    expect(canDisposeParkedEntry({ tmuxBacked: true, parkedAgentState: 'working' })).toBe(true)
+    expect(canDisposeParkedEntry({ tmuxBacked: false, parkedAgentState: 'done' })).toBe(true)
+    expect(canDisposeParkedEntry({ tmuxBacked: false })).toBe(true)
+    // A live `done` overrides a `working` snapshot — the protection must not be one-way.
+    expect(
+      canDisposeParkedEntry({
+        tmuxBacked: false,
+        parkedAgentState: 'working',
+        liveAgentState: 'done'
+      })
+    ).toBe(true)
   })
 })
 

--- a/src/renderer/terminal/park-budget.test.ts
+++ b/src/renderer/terminal/park-budget.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { PARK_MAX, planParkEviction } from './park-budget'
+import {
+  PARK_MAX,
+  PARK_RECHECK_MS,
+  armParkExpiry,
+  canDisposePark,
+  disposableParks,
+  planParkEviction
+} from './park-budget'
 
 describe('planParkEviction', () => {
   it('returns nothing at or under the cap', () => {
@@ -13,5 +20,99 @@ describe('planParkEviction', () => {
     expect(PARK_MAX).toBe(12)
     const keys = Array.from({ length: 13 }, (_, i) => `k${i}`)
     expect(planParkEviction(keys, PARK_MAX)).toEqual(['k0'])
+  })
+  it('skips protected parks and takes the next disposable one instead', () => {
+    // 'a' is protected → the cap is still met, by evicting the next-oldest disposable park.
+    expect(planParkEviction(['a', 'b', 'c', 'd'], 2, (k) => k !== 'a')).toEqual(['b', 'c'])
+  })
+  it('lets the cap be exceeded rather than kill protected parks', () => {
+    // Nothing disposable left: the plan is empty and the park runs over PARK_MAX. Documented
+    // tradeoff — a cache overrun costs RAM, killing a plain shell costs the user's running work.
+    expect(planParkEviction(['a', 'b', 'c', 'd'], 2, () => false)).toEqual([])
+    expect(planParkEviction(['a', 'b', 'c', 'd'], 2, (k) => k === 'd')).toEqual(['d'])
+  })
+})
+
+describe('canDisposePark', () => {
+  it('protects a NON-tmux park whose agent is working/waiting/blocked', () => {
+    for (const agentState of ['working', 'waiting', 'blocked'] as const) {
+      expect(canDisposePark({ tmuxBacked: false, agentState })).toBe(false)
+    }
+  })
+  it('disposes a non-tmux park whose agent is done', () => {
+    expect(canDisposePark({ tmuxBacked: false, agentState: 'done' })).toBe(true)
+  })
+  it('disposes a non-tmux park with no agent at all (a plain terminal)', () => {
+    expect(canDisposePark({ tmuxBacked: false })).toBe(true)
+  })
+  it('disposes a TMUX-backed park even while its agent works — the kill only detaches a client', () => {
+    expect(canDisposePark({ tmuxBacked: true, agentState: 'working' })).toBe(true)
+    expect(canDisposePark({ tmuxBacked: true, agentState: 'waiting' })).toBe(true)
+  })
+})
+
+describe('disposableParks', () => {
+  it('drops everything except the protected parks', () => {
+    expect(disposableParks(['a', 'b', 'c'], (k) => k !== 'b')).toEqual(['a', 'c'])
+    expect(disposableParks(['a', 'b'], () => true)).toEqual(['a', 'b'])
+    expect(disposableParks(['a', 'b'], () => false)).toEqual([])
+  })
+})
+
+describe('armParkExpiry', () => {
+  /** Minimal injectable timer pair: fire(n) runs the nth armed callback. */
+  function fakeTimers(): {
+    timers: { set: (fn: () => void, ms: number) => number; clear: (h: number) => void }
+    armed: Array<{ fn: () => void; ms: number; cleared: boolean }>
+  } {
+    const armed: Array<{ fn: () => void; ms: number; cleared: boolean }> = []
+    return {
+      armed,
+      timers: {
+        set: (fn, ms) => armed.push({ fn, ms, cleared: false }) - 1,
+        clear: (h) => {
+          armed[h].cleared = true
+        }
+      }
+    }
+  }
+
+  it('disposes when the window expires and the park is disposable', () => {
+    const { timers, armed } = fakeTimers()
+    let disposed = 0
+    armParkExpiry(() => true, () => disposed++, 5000, timers)
+    expect(armed[0].ms).toBe(5000)
+    armed[0].fn()
+    expect(disposed).toBe(1)
+    expect(armed).toHaveLength(1) // nothing re-armed
+  })
+
+  it('re-arms at PARK_RECHECK_MS instead of disposing while the park is protected', () => {
+    const { timers, armed } = fakeTimers()
+    let disposable = false
+    let disposed = 0
+    armParkExpiry(() => disposable, () => disposed++, 5000, timers)
+    armed[0].fn()
+    expect(disposed).toBe(0)
+    expect(armed).toHaveLength(2)
+    expect(armed[1].ms).toBe(PARK_RECHECK_MS)
+    // Still protected → still re-checking, never leaked into a permanent park.
+    armed[1].fn()
+    expect(disposed).toBe(0)
+    expect(armed[2].ms).toBe(PARK_RECHECK_MS)
+    // The agent finished: the next re-check disposes for real.
+    disposable = true
+    armed[2].fn()
+    expect(disposed).toBe(1)
+    expect(armed).toHaveLength(3)
+  })
+
+  it('cancel() clears the timer currently armed, re-armed or not', () => {
+    const { timers, armed } = fakeTimers()
+    const t = armParkExpiry(() => false, () => {}, 5000, timers)
+    armed[0].fn() // re-arm
+    t.cancel()
+    expect(armed[0].cleared).toBe(false) // already fired; the live one is the re-armed timer
+    expect(armed[1].cleared).toBe(true)
   })
 })

--- a/src/renderer/terminal/park-budget.ts
+++ b/src/renderer/terminal/park-budget.ts
@@ -1,4 +1,9 @@
-import { effectiveAgentState, wouldKillLiveWork, type LiveWorkInput } from './live-work'
+import {
+  effectiveAgentState,
+  parkedStateFloor,
+  wouldKillLiveWork,
+  type LiveWorkInput
+} from './live-work'
 import type { AgentState } from '@shared/agents/normalize'
 
 /**
@@ -25,13 +30,13 @@ export const PARK_MAX = 12
  * changed. The cost of the coarseness is bounded and small — one already-parked xterm held at
  * most a minute past the moment it became disposable.
  *
- * How long a protected park can live in the worst case: a `working` one resolves within the
- * stale-working sweep's window (`shared/agents/stale.ts`, 20 minutes) even if the CLI died without
- * saying so, because that sweep's synthetic end edge reaches the store like any other event. A
- * `waiting`/`blocked` one has no such sweep and is held until the user answers the question the
- * badge is showing them — possibly for the whole run. Accepted, and bounded by NODE COUNT rather
- * than by time: at most one held xterm buffer per non-tmux node actually sitting on an unanswered
- * prompt. See `offscreen-policy.ts`'s live-work deferral for the same argument at more length.
+ * How long a protected park can live in the worst case. A `working` one is bounded at
+ * `WORKING_STALE_MS` — NOT because a sweep corrects it (neither sweep can reach a parked entry;
+ * see `parkedStateFloor`, which is why the snapshot ages itself out) but because the floor stops
+ * counting there. A `waiting`/`blocked` one is NOT bounded in time at all: it is held until the
+ * user answers the question the badge is showing them, possibly for the whole run. Accepted, and
+ * bounded by NODE COUNT instead — at most one held xterm buffer per non-tmux node actually sitting
+ * on an unanswered prompt. See `offscreen-policy.ts`'s live-work deferral for the longer argument.
  */
 export const PARK_RECHECK_MS = 60_000
 
@@ -58,17 +63,23 @@ export interface ParkedEntryState {
   /** The node's agent state AT PARK TIME. The floor — see `effectiveAgentState` for why a park
    *  cannot rely on a live read alone. */
   parkedAgentState?: AgentState
+  /** When the snapshot was taken. Absent ⇒ it cannot be aged (see `parkedStateFloor`). */
+  parkedAt?: number
   /** The node's agent state RIGHT NOW, read from that node's own agent-status store. */
   liveAgentState?: AgentState
 }
 
-/** `canDisposePark` for a park entry: the live read with the park-time snapshot under it. This is
- *  the form all three park levers actually ask (they hold entries, not states), and the one place
- *  the floor is applied — a lever that assembled the state itself could forget it. */
-export function canDisposeParkedEntry(e: ParkedEntryState): boolean {
+/** `canDisposePark` for a park entry: the live read, with the AGED park-time snapshot under it.
+ *  This is the form all three park levers actually ask (they hold entries, not states), and the
+ *  one place the floor is assembled — a lever that built the state itself could forget half of
+ *  it. `now` is injected for tests. */
+export function canDisposeParkedEntry(e: ParkedEntryState, now: number = Date.now()): boolean {
   return canDisposePark({
     tmuxBacked: e.tmuxBacked,
-    agentState: effectiveAgentState(e.liveAgentState, e.parkedAgentState)
+    agentState: effectiveAgentState(
+      e.liveAgentState,
+      parkedStateFloor(e.parkedAgentState, e.parkedAt, now)
+    )
   })
 }
 

--- a/src/renderer/terminal/park-budget.ts
+++ b/src/renderer/terminal/park-budget.ts
@@ -1,4 +1,4 @@
-import type { AgentState } from '@shared/agents/normalize'
+import { wouldKillLiveWork, type LiveWorkInput } from './live-work'
 
 /**
  * Count cap for parked terminals (see TerminalNode's parkedTerminals). The park window
@@ -26,52 +26,21 @@ export const PARK_MAX = 12
  */
 export const PARK_RECHECK_MS = 60_000
 
-/** Agent states that mean the CLI is mid-task or holding a question open for the user. Same set
- *  hibernation refuses to `/exit` (`hibernation-policy.ts`), for the same reason: `working` is a
- *  turn in flight, `waiting`/`blocked` is a question the user is being asked to come back to. */
-const LIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set<AgentState>([
-  'working',
-  'waiting',
-  'blocked'
-])
-
-export interface ParkProtectionInput {
-  /**
-   * The session survives losing this client — a tmux session, local or remote
-   * (`PtyCreateResult.persistent`). With tmux, disposing a park KILLS ONLY OUR CLIENT: the tmux
-   * session, its pane and everything running in it keep going, and the next mount is a warm
-   * reattach. Without it (the plain-shell fallback — no tmux installed, tmux switched off, or a
-   * tmux whose install path `findTmux` missed) the pty IS the shell, and the same dispose kills
-   * the shell and every process under it.
-   */
-  tmuxBacked: boolean
-  /** The node's live agent state (`agentStatus.byId[nodeId].state`); absent = plain terminal or
-   *  no hook event seen yet. */
-  agentState?: AgentState
-}
-
 /**
  * May this parked terminal be disposed by a BUDGET lever — the park window expiring, the LRU cap
  * evicting, or the memory-pressure "drop every park" lever?
  *
- * Reported (issue #126): switching projects killed a Claude agent mid-task and it came back
- * "terminated mid action", auto-resuming on return. The park is a CACHE and its dispose is
- * "detach the client", which is exactly what it costs — but only where tmux is underneath. On the
- * plain-shell fallback the very same dispose is the whole session: the shell dies, the agent CLI
- * dies with it, and the node's restart machinery resumes the conversation from wherever the kill
- * landed. Three levers reached that kill and none of them looked at what was running.
- *
- * So the protection is the narrowest one that closes it: BOTH no tmux underneath AND live agent
- * work on the node. A plain terminal, a `done`/unknown agent, and every tmux-backed session keep
- * today's behavior bit for bit.
+ * The park's name for the shared safety question (`wouldKillLiveWork`, see `live-work.ts`): its
+ * dispose is "detach the client", which is exactly what a cache eviction should cost — but only
+ * where tmux is underneath. On the plain-shell fallback the very same dispose is the whole
+ * session, so a park holding a working agent there is protected (issue #126).
  *
  * This is only about the budget levers. A deliberate dispose — node deleted, session closed by
  * another client, respawn into a worktree, a dead pty — goes through `disposeParkedTerminal` and
  * is never gated: there the session is already gone or is meant to be.
  */
-export function canDisposePark(p: ParkProtectionInput): boolean {
-  if (p.tmuxBacked) return true
-  return !(p.agentState && LIVE_AGENT_STATES.has(p.agentState))
+export function canDisposePark(p: LiveWorkInput): boolean {
+  return !wouldKillLiveWork(p)
 }
 
 /** Keys to dispose so the park stays within `max`, oldest first. Caller passes keys in park

--- a/src/renderer/terminal/park-budget.ts
+++ b/src/renderer/terminal/park-budget.ts
@@ -1,3 +1,5 @@
+import type { AgentState } from '@shared/agents/normalize'
+
 /**
  * Count cap for parked terminals (see TerminalNode's parkedTerminals). The park window
  * (TERM_PARK_MS) bounds each entry in TIME but nothing bounded the COUNT: switching through N
@@ -10,9 +12,135 @@
  */
 export const PARK_MAX = 12
 
+/**
+ * How long a PROTECTED park (see `canDisposePark`) waits before asking again whether it may be
+ * disposed. A protection must never turn a park into a permanent leak, so an expiry it blocks
+ * RE-ARMS rather than being cancelled — the park is disposed the first re-check after the agent
+ * stops working.
+ *
+ * A minute, matching the hibernation sweep's cadence (HIBERNATE_SWEEP_MS) and for the same
+ * reason: the re-check is a Map lookup plus a store read, but what it waits for is a human-scale
+ * event (an agent turn ending), so a faster poll would only pay for an answer that cannot have
+ * changed. The cost of the coarseness is bounded and small — one already-parked xterm held at
+ * most a minute past the moment it became disposable.
+ */
+export const PARK_RECHECK_MS = 60_000
+
+/** Agent states that mean the CLI is mid-task or holding a question open for the user. Same set
+ *  hibernation refuses to `/exit` (`hibernation-policy.ts`), for the same reason: `working` is a
+ *  turn in flight, `waiting`/`blocked` is a question the user is being asked to come back to. */
+const LIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set<AgentState>([
+  'working',
+  'waiting',
+  'blocked'
+])
+
+export interface ParkProtectionInput {
+  /**
+   * The session survives losing this client — a tmux session, local or remote
+   * (`PtyCreateResult.persistent`). With tmux, disposing a park KILLS ONLY OUR CLIENT: the tmux
+   * session, its pane and everything running in it keep going, and the next mount is a warm
+   * reattach. Without it (the plain-shell fallback — no tmux installed, tmux switched off, or a
+   * tmux whose install path `findTmux` missed) the pty IS the shell, and the same dispose kills
+   * the shell and every process under it.
+   */
+  tmuxBacked: boolean
+  /** The node's live agent state (`agentStatus.byId[nodeId].state`); absent = plain terminal or
+   *  no hook event seen yet. */
+  agentState?: AgentState
+}
+
+/**
+ * May this parked terminal be disposed by a BUDGET lever — the park window expiring, the LRU cap
+ * evicting, or the memory-pressure "drop every park" lever?
+ *
+ * Reported (issue #126): switching projects killed a Claude agent mid-task and it came back
+ * "terminated mid action", auto-resuming on return. The park is a CACHE and its dispose is
+ * "detach the client", which is exactly what it costs — but only where tmux is underneath. On the
+ * plain-shell fallback the very same dispose is the whole session: the shell dies, the agent CLI
+ * dies with it, and the node's restart machinery resumes the conversation from wherever the kill
+ * landed. Three levers reached that kill and none of them looked at what was running.
+ *
+ * So the protection is the narrowest one that closes it: BOTH no tmux underneath AND live agent
+ * work on the node. A plain terminal, a `done`/unknown agent, and every tmux-backed session keep
+ * today's behavior bit for bit.
+ *
+ * This is only about the budget levers. A deliberate dispose — node deleted, session closed by
+ * another client, respawn into a worktree, a dead pty — goes through `disposeParkedTerminal` and
+ * is never gated: there the session is already gone or is meant to be.
+ */
+export function canDisposePark(p: ParkProtectionInput): boolean {
+  if (p.tmuxBacked) return true
+  return !(p.agentState && LIVE_AGENT_STATES.has(p.agentState))
+}
+
 /** Keys to dispose so the park stays within `max`, oldest first. Caller passes keys in park
- *  order (Map insertion order — TerminalNode always deletes before re-inserting on re-park). */
-export function planParkEviction(keysInParkOrder: string[], max: number): string[] {
-  if (keysInParkOrder.length <= max) return []
-  return keysInParkOrder.slice(0, keysInParkOrder.length - max)
+ *  order (Map insertion order — TerminalNode always deletes before re-inserting on re-park).
+ *
+ *  `canDispose` (default: everything) is the live-work protection above. A protected park is
+ *  SKIPPED, not counted out: the plan takes the next-oldest disposable park instead, so the cap
+ *  still holds whenever anything may be dropped at all. When it cannot — every park protected —
+ *  THE CAP YIELDS: the plan comes back short and the park runs over `max`. That is the same value
+ *  judgment hibernation's exclusions make (a bounded cache overrun costs RAM; killing a plain
+ *  shell costs the user's running work), and it is self-limiting: each protected park is released
+ *  by its own expiry re-check (PARK_RECHECK_MS) as soon as its agent stops. */
+export function planParkEviction(
+  keysInParkOrder: string[],
+  max: number,
+  canDispose: (key: string) => boolean = () => true
+): string[] {
+  const overflow = keysInParkOrder.length - max
+  if (overflow <= 0) return []
+  const plan: string[] = []
+  for (const key of keysInParkOrder) {
+    if (plan.length >= overflow) break
+    if (canDispose(key)) plan.push(key)
+  }
+  return plan
+}
+
+/** The parks the memory-pressure lever may drop: everything except the protected ones. */
+export function disposableParks(keys: string[], canDispose: (key: string) => boolean): string[] {
+  return keys.filter(canDispose)
+}
+
+/** A park's expiry timer. Opaque because it RE-ARMS (see `armParkExpiry`), so the handle the
+ *  caller must eventually clear is not the one it started with. */
+export interface ParkTimer {
+  cancel(): void
+}
+
+interface ParkTimers<H> {
+  set(fn: () => void, ms: number): H
+  clear(handle: H): void
+}
+
+/**
+ * Arm the park window, RE-ARMING at `PARK_RECHECK_MS` for as long as `canDispose` says no.
+ *
+ * The re-arm is the whole point: a protection that merely skipped the dispose would leak the
+ * park forever (no other timer would ever look at it again), and one that cancelled itself would
+ * hold a live agent's xterm until the app closed. Instead an expiry that finds live work
+ * postpones itself, and the park is disposed on the first re-check after the agent goes idle.
+ *
+ * `timers` is injectable so the re-arm is testable without real time; production passes none.
+ */
+export function armParkExpiry<H>(
+  canDispose: () => boolean,
+  dispose: () => void,
+  windowMs: number,
+  timers: ParkTimers<H> = {
+    set: (fn, ms) => setTimeout(fn, ms) as unknown as H,
+    clear: (h) => clearTimeout(h as unknown as ReturnType<typeof setTimeout>)
+  }
+): ParkTimer {
+  const tick = (): void => {
+    if (canDispose()) {
+      dispose()
+      return
+    }
+    handle = timers.set(tick, PARK_RECHECK_MS)
+  }
+  let handle = timers.set(tick, windowMs)
+  return { cancel: () => timers.clear(handle) }
 }

--- a/src/renderer/terminal/park-budget.ts
+++ b/src/renderer/terminal/park-budget.ts
@@ -1,4 +1,5 @@
-import { wouldKillLiveWork, type LiveWorkInput } from './live-work'
+import { effectiveAgentState, wouldKillLiveWork, type LiveWorkInput } from './live-work'
+import type { AgentState } from '@shared/agents/normalize'
 
 /**
  * Count cap for parked terminals (see TerminalNode's parkedTerminals). The park window
@@ -23,6 +24,14 @@ export const PARK_MAX = 12
  * event (an agent turn ending), so a faster poll would only pay for an answer that cannot have
  * changed. The cost of the coarseness is bounded and small — one already-parked xterm held at
  * most a minute past the moment it became disposable.
+ *
+ * How long a protected park can live in the worst case: a `working` one resolves within the
+ * stale-working sweep's window (`shared/agents/stale.ts`, 20 minutes) even if the CLI died without
+ * saying so, because that sweep's synthetic end edge reaches the store like any other event. A
+ * `waiting`/`blocked` one has no such sweep and is held until the user answers the question the
+ * badge is showing them — possibly for the whole run. Accepted, and bounded by NODE COUNT rather
+ * than by time: at most one held xterm buffer per non-tmux node actually sitting on an unanswered
+ * prompt. See `offscreen-policy.ts`'s live-work deferral for the same argument at more length.
  */
 export const PARK_RECHECK_MS = 60_000
 
@@ -41,6 +50,26 @@ export const PARK_RECHECK_MS = 60_000
  */
 export function canDisposePark(p: LiveWorkInput): boolean {
   return !wouldKillLiveWork(p)
+}
+
+export interface ParkedEntryState {
+  /** `PtyCreateResult.persistent` for the parked session. */
+  tmuxBacked: boolean
+  /** The node's agent state AT PARK TIME. The floor — see `effectiveAgentState` for why a park
+   *  cannot rely on a live read alone. */
+  parkedAgentState?: AgentState
+  /** The node's agent state RIGHT NOW, read from that node's own agent-status store. */
+  liveAgentState?: AgentState
+}
+
+/** `canDisposePark` for a park entry: the live read with the park-time snapshot under it. This is
+ *  the form all three park levers actually ask (they hold entries, not states), and the one place
+ *  the floor is applied — a lever that assembled the state itself could forget it. */
+export function canDisposeParkedEntry(e: ParkedEntryState): boolean {
+  return canDisposePark({
+    tmuxBacked: e.tmuxBacked,
+    agentState: effectiveAgentState(e.liveAgentState, e.parkedAgentState)
+  })
 }
 
 /** Keys to dispose so the park stays within `max`, oldest first. Caller passes keys in park
@@ -103,6 +132,9 @@ export function armParkExpiry<H>(
     clear: (h) => clearTimeout(h as unknown as ReturnType<typeof setTimeout>)
   }
 ): ParkTimer {
+  // Declared BEFORE `tick` closes over it: a `timers.set` that ran its callback synchronously
+  // (a fake, a shimmed scheduler) would otherwise hit the temporal dead zone and throw.
+  let handle: H | undefined
   const tick = (): void => {
     if (canDispose()) {
       dispose()
@@ -110,6 +142,10 @@ export function armParkExpiry<H>(
     }
     handle = timers.set(tick, PARK_RECHECK_MS)
   }
-  let handle = timers.set(tick, windowMs)
-  return { cancel: () => timers.clear(handle) }
+  handle = timers.set(tick, windowMs)
+  return {
+    cancel: () => {
+      if (handle !== undefined) timers.clear(handle)
+    }
+  }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -127,6 +127,21 @@ export interface PtyCreateResult {
    */
   coAttachMouse?: boolean
   /**
+   * This session is TMUX-BACKED (local or remote) — it survives losing this client, so killing our
+   * pty client only detaches us and everything running in the session keeps going.
+   *
+   * False = the plain-shell fallback (no tmux installed, tmux switched off, or a node with no
+   * persistKey): the pty IS the shell, and killing it kills the shell and every process under it —
+   * an agent CLI mid-task included. The renderer needs the difference because several of its
+   * levers dispose a terminal purely as a CACHE (the park window, the park LRU cap, the
+   * memory-pressure drop), a call that is only cheap when tmux is underneath. See
+   * `renderer/terminal/park-budget.ts` (`canDisposePark`) and issue #126.
+   *
+   * Absent = unknown (a core older than this field, over the relay): the renderer must then assume
+   * the historical behavior (persistent), never protect on a guess.
+   */
+  persistent?: boolean
+  /**
    * REFUSED: this node's session was permanently destroyed by ANOTHER client, so nothing was
    * spawned (`sessionId` is empty) — the terminal shows the "closed by <name>" state instead.
    *


### PR DESCRIPTION
## Summary

Fixes #126. On sessions without tmux underneath (plain-shell fallback — tmux not installed, disabled, or missed by the fixed lookup paths), four resource levers killed the running agent CLI mid-task: park expiry (5min), the PARK_MAX LRU eviction, the memory-pressure park lever, and the offscreen release (10min). All four are now gated by a shared predicate: a session that is NOT tmux-backed whose agent is working/waiting/blocked is never reclaimed.

- `wouldKillLiveWork` (src/renderer/terminal/live-work.ts) shared by park-budget and offscreen-policy; tmux-backedness threaded to the renderer as `PtyCreateResult.persistent` (both spawn and co-attach paths).
- Park-time **snapshot floor**: the unmount that parks also clears the agent-status store, so levers reading later saw undefined — the parked entry snapshots the state, live store reads override in both directions, and a `working` snapshot ages out at the shared `WORKING_STALE_MS` (a silently-dead CLI cannot hold a park slot forever). `waiting`/`blocked` hold until the user answers — documented, bounded by node count × buffer.
- Protected parks re-arm at 60s; the LRU cap takes the next-oldest disposable and yields when nothing may be dropped; deliberate disposes (delete/close/respawn) bypass protection.
- Eco interplay: hibernation already refuses working/waiting (verified); the live-work deferral re-stamps the offscreen clock so a long turn can't forfeit hibernation.
- tmux discovery widened 4→9 fixed paths (MacPorts, NixOS, ~/.nix-profile, per-user nix profiles, Linuxbrew); the late login-shell PATH probe upgrade is now pinned by tests.
- Honest limitation (documented in-code + docs/remote-sessions.md): relay-hosted parks stay unprotected until relay agent-status is wired into the per-session stores (`useSessionStores` is the seam).

## Test plan

3 review rounds (1 Critical + 2 Important found and fixed, all mutation-verified: floor-vs-latch, snapshot-drop, uncapped source-pin, eviction filter, re-arm, late-probe). Full suite 5056 passed / 8 skipped; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01No8UHtXZ9eNwkQ2BZPh6Xf