### PR TITLE
feat(settings): configurable keyboard shortcuts with a Shortcuts section

### DIFF
--- a/src/core/settings-store.ts
+++ b/src/core/settings-store.ts
@@ -15,6 +15,10 @@ import { DEFAULT_SETTINGS, type Settings } from '../shared/types'
 function mergeSettings(saved: Partial<Settings> | null | undefined): Settings {
   const merged = { ...DEFAULT_SETTINGS, ...saved }
   merged.speech = { ...DEFAULT_SETTINGS.speech, ...saved?.speech }
+  // `shortcuts` is a nested map seeded from DEFAULT_SHORTCUTS. Merge one level deep so an old
+  // settings.json that predates a newly-added action still picks up its shipped default, exactly
+  // like `speech`. A missing map on old files falls back to the full default map.
+  merged.shortcuts = { ...DEFAULT_SETTINGS.shortcuts, ...saved?.shortcuts }
   // Legacy `terminalGpuRendering` was a boolean whose default (true) was merged into every saved
   // file — so a stored `true` is indistinguishable from "never touched" and maps to the new
   // 'auto' (platform-aware) default, while a stored `false` was always an explicit escape-hatch

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'crypto'
 import { app, BrowserWindow, clipboard, dialog, ipcMain, Notification, powerMonitor, safeStorage, shell, systemPreferences } from 'electron'
 import { IPC } from '../shared/ipc'
 import { writeFilesToClipboard } from './clipboard-files'
+import { matchesShortcut } from '../shared/shortcut'
 import { registerFsHandlers } from '../core/fs-handlers'
 import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
 import type { RemoteLogExec } from '../core/board-log'
@@ -192,6 +193,10 @@ app.commandLine.appendSwitch('max-active-webgl-contexts', String(WEBGL_CONTEXT_C
 // documented plaintext fallback. Never set this for a real build: it would silently downgrade
 // at-rest encryption of that key.
 if (NT_MULTI && process.platform === 'darwin') app.commandLine.appendSwitch('use-mock-keychain')
+
+// Platform-abstracted primary modifier target for shortcut matching in the main process
+// (⌘ on mac, Ctrl elsewhere) — mirrors the renderer's `isMac` reader.
+const isMacMain = process.platform === 'darwin'
 
 // First thing in bootstrap: install the Electron CorePlatform so anything in src/core
 // (wired in later tasks) can resolve platform() at boot. Placed after the NT_MULTI
@@ -467,14 +472,22 @@ function createWindow(): BrowserWindow {
   })
 
   // Intercept Cmd/Ctrl+M (default = minimize) and route it to the renderer for the
-  // markdown-view toggle instead.
+  // markdown-view toggle instead; and Cmd/Ctrl+W for closing the selected node. The combos come
+  // from settings.shortcuts (Keyboard Shortcuts section) so a rebind is honoured here too.
   win.webContents.on('before-input-event', (event, input) => {
-    if (input.type !== 'keyDown' || !(input.meta || input.control)) return
-    const key = input.key.toLowerCase()
-    if (key === 'm') {
+    if (input.type !== 'keyDown') return
+    const shortcuts = settingsStore.get().shortcuts
+    const evt = {
+      metaKey: input.meta,
+      ctrlKey: input.control,
+      shiftKey: input.shift,
+      altKey: input.alt,
+      key: input.key
+    }
+    if (matchesShortcut(evt, shortcuts.toggleMarkdown, isMacMain)) {
       event.preventDefault()
       win.webContents.send(IPC.appToggleMarkdown)
-    } else if (key === 'w' && !input.shift) {
+    } else if (matchesShortcut(evt, shortcuts.closeNode, isMacMain)) {
       // Repurpose Cmd/Ctrl+W: the renderer closes the selected node(s); if none are
       // selected it asks us to close the window (the standard behavior).
       event.preventDefault()

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -2303,17 +2303,22 @@ export function Canvas() {
     bumpHist((v) => v + 1)
   }, [setNodes, bumpDirty])
 
-  // Cmd/Ctrl+Z = undo, Cmd/Ctrl+Shift+Z or Cmd/Ctrl+Y = redo (ignored while typing).
+  // Undo / redo via the configured shortcuts (defaults ⌘Z / ⌘⇧Z; ⌘Y stays as a legacy redo
+  // alias for people who learned it elsewhere — it is not separately configurable).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (isKanbanOpen(useProjects.getState().activeProjectId)) return
       if (!(e.metaKey || e.ctrlKey)) return
-      const k = e.key.toLowerCase()
-      if (k !== 'z' && k !== 'y') return
+      const shortcuts = useSettings.getState().settings.shortcuts
+      const isRedo =
+        matchesShortcut(e, shortcuts.redo, isMac) ||
+        (!e.shiftKey && e.key.toLowerCase() === 'y')
+      const isUndo = matchesShortcut(e, shortcuts.undo, isMac)
+      if (!isRedo && !isUndo) return
       const tag = (document.activeElement?.tagName || '').toLowerCase()
       if (tag === 'input' || tag === 'textarea') return
       e.preventDefault()
-      if (k === 'y' || (k === 'z' && e.shiftKey)) redo()
+      if (isRedo) redo()
       else undo()
     }
     window.addEventListener('keydown', onKey)
@@ -3517,11 +3522,11 @@ export function Canvas() {
         toggleDictation()
         return
       }
-      const k = e.key.toLowerCase()
-      if (k === 't' && !e.shiftKey) {
+      const shortcuts = useSettings.getState().settings.shortcuts
+      if (matchesShortcut(e, shortcuts.newTerminal, isMac)) {
         e.preventDefault()
         addTerminal()
-      } else if (k === 'c' && e.shiftKey) {
+      } else if (matchesShortcut(e, shortcuts.newAgent, isMac)) {
         e.preventDefault()
         addAgentNode(useSettings.getState().settings.defaultAgent)
       }
@@ -4886,12 +4891,11 @@ export function Canvas() {
     [goToNode]
   )
 
-  // ---- project (tab) actions ----
+  // Command palette, Settings, and the canvas-level toggles. All combos come from
+  // `settings.shortcuts` so Keyboard Shortcuts can rebind them. Read live from the store (not a
+  // closure) so a settings change takes effect on the next keypress without a listener re-run.
   // Declared here (ahead of the keydown effect below, rather than near the other project
-  // actions further down) so the Cmd/Ctrl+digit shortcut can list it as a dependency without
-  // a TDZ violation: `useCallback`/`const` bindings are not hoisted like function declarations,
-  // so referencing switchProject in that effect's deps array before this point would throw
-  // "used before its declaration".
+  // actions further down) so the digit-project-jump can reference it without a TDZ violation.
   const switchProject = useCallback(
     (id: string) => {
       if (id === useProjects.getState().activeProjectId) return
@@ -4901,31 +4905,30 @@ export function Canvas() {
     },
     [commitActiveToStore, writeDisk]
   )
-
-  // Cmd/Ctrl+K toggles the command palette; Cmd/Ctrl+, opens settings.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      const shortcuts = useSettings.getState().settings.shortcuts
+      if (matchesShortcut(e, shortcuts.commandPalette, isMac)) {
         e.preventDefault()
         setPaletteOpen((v) => !v)
-      } else if ((e.metaKey || e.ctrlKey) && e.key === ',') {
+      } else if (matchesShortcut(e, shortcuts.settings, isMac)) {
         e.preventDefault()
         setSettingsSection(undefined)
         setSettingsOpen(true)
-      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'e') {
+      } else if (matchesShortcut(e, shortcuts.toggleExplorer, isMac)) {
         e.preventDefault()
         setExplorerOpen((v) => !v)
-      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'g') {
+      } else if (matchesShortcut(e, shortcuts.toggleSourceControl, isMac)) {
         e.preventDefault()
         setScOpen((v) => !v)
-      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'b') {
+      } else if (matchesShortcut(e, shortcuts.toggleViewMode, isMac)) {
         e.preventDefault()
         const id = useProjects.getState().activeProjectId
         if (id) useViewMode.getState().toggle(id)
-      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
+      } else if (matchesShortcut(e, shortcuts.toggleSessionsPin, isMac)) {
         e.preventDefault()
         toggleSessionsPin()
-      } else if ((e.metaKey || e.ctrlKey) && e.key === '/') {
+      } else if (matchesShortcut(e, shortcuts.shortcutsPanel, isMac)) {
         e.preventDefault()
         setShortcutsOpen((v) => !v)
       } else if (projectJumpDigit(e) !== null) {
@@ -4940,6 +4943,8 @@ export function Canvas() {
         }
       } else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'c') {
         // Native text selection wins (markdown, editor and terminal keep their normal copy path).
+      } else if (matchesShortcut(e, shortcuts.copySelection, isMac)) {
+        // Copy the current page selection (e.g. markdown view) to the clipboard.
         const tag = (document.activeElement?.tagName || '').toLowerCase()
         if (
           tag === 'input' ||

--- a/src/renderer/components/ShortcutsPanel.test.tsx
+++ b/src/renderer/components/ShortcutsPanel.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import { SHORTCUT_DEFS } from '@shared/shortcuts'
+import { shortcutKeyParts } from '@shared/shortcut'
+import { useSettings } from '../state/settings'
+import { ShortcutsPanel } from './ShortcutsPanel'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
+
+/** ShortcutsPanel portals into document.body; read the rendered rows there. */
+function renderedText(): string {
+  return document.body.textContent ?? ''
+}
+
+describe('ShortcutsPanel', () => {
+  let root: Root
+  let host: HTMLElement
+
+  beforeEach(async () => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    useSettings.setState({ settings: DEFAULT_SETTINGS, hydrated: true })
+    root = createRoot(host)
+    await act(async () => {
+      root.render(<ShortcutsPanel onClose={() => {}} />)
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    document.body.innerHTML = ''
+  })
+
+  it('renders a row for every configurable shortcut from the registry, grouped', () => {
+    const text = renderedText()
+    for (const d of SHORTCUT_DEFS) {
+      expect(text, `row for ${d.label}`).toContain(d.label)
+    }
+    for (const title of ['General', 'Canvas', 'Terminal', 'Source Control']) {
+      expect(text, `group ${title}`).toContain(title)
+    }
+  })
+
+  it('shows the current combo from settings.shortcuts, so a rebind reflects immediately', async () => {
+    // The kbd badges render each part as its own element (keyLabel), so the textContent is the
+    // parts concatenated — e.g. Ctrl + K for the palette on a non-mac test host.
+    const badgeFor = (combo: string): string => shortcutKeyParts(combo, isMac).join('')
+    const defaultBadge = badgeFor(DEFAULT_SETTINGS.shortcuts.commandPalette)
+    expect(renderedText()).toContain(defaultBadge)
+
+    // Rebinding the palette shortcut re-renders the panel's badge on the next frame — no
+    // reload, no re-open needed.
+    await act(async () => {
+      useSettings.getState().update({
+        shortcuts: { ...useSettings.getState().settings.shortcuts, commandPalette: 'Cmd+Shift+P' }
+      })
+    })
+    expect(renderedText()).toContain(badgeFor('Cmd+Shift+P'))
+    expect(renderedText()).not.toContain(defaultBadge)
+  })
+
+  it('leads the General group with the dictation row from settings.speech.shortcut', () => {
+    const text = renderedText()
+    expect(text).toContain('Dictate')
+    expect(text).toContain(shortcutKeyParts(DEFAULT_SETTINGS.speech.shortcut, isMac).join(''))
+  })
+
+  it('documents the fixed mouse-gesture reference rows under their groups', () => {
+    const text = renderedText()
+    expect(text).toContain('Right-click')
+    expect(text).toContain('Box-select')
+    expect(text).toContain('Pan the canvas')
+    expect(text).toContain('Zoom in / out')
+    expect(text).toContain('Actions menu (empty space or node)')
+  })
+})

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { isHoldChord, shortcutKeyParts } from '@shared/shortcut'
 import { isBrowserRuntime } from '../bridge/runtime'
 import { useSettings } from '../state/settings'
+import { shortcutGroups } from '@shared/shortcuts'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 import { keyLabel } from '@shared/platform-utils'
@@ -16,65 +17,58 @@ interface Row {
   label: string
 }
 
-/** Everything but "Dictate" is fixed; that row's keys/label depend on `settings.speech.shortcut`
- *  (a modifier-only chord is hold-to-talk — no trailing key badge, so the label spells that out),
- *  so the sections are built at render time instead of module scope. */
-function buildSections(dictationKeys: string[], dictationLabel: string): { title: string; rows: Row[] }[] {
-  return [
-    {
-      title: 'General',
-      rows: [
-        { keys: ['⌘', 'K'], label: 'Command palette' },
-        { keys: ['⌘', ','], label: 'Settings' },
-        { keys: ['⌘', '/'], label: 'This shortcuts panel' },
-        // Desktop only: browsers own Cmd/Ctrl+1-9 for tab switching and a page cannot take it
-        // back, so listing it in the Server Edition would promise a shortcut that never fires.
-        ...(isBrowserRuntime() ? [] : [{ keys: ['⌘', '1-9'], label: 'Jump to project' }]),
-        { keys: dictationKeys, label: dictationLabel },
-        { keys: ['⌘', 'Z'], label: 'Undo' },
-        { keys: ['⌘', '⇧', 'Z'], label: 'Redo' }
-      ]
-    },
-    {
-      title: 'Canvas',
-      rows: [
-        { keys: ['⌘', 'T'], label: 'New terminal' },
-        { keys: ['⌘', '⇧', 'C'], label: 'New Claude Code' },
-        { keys: ['⌘', 'W'], label: 'Close selected node' },
-        { keys: ['Right-click'], label: 'Actions menu (empty space or node)' },
-        { keys: ['Left-drag'], label: 'Box-select (touch to select)' },
-        { keys: ['Middle / Right-drag'], label: 'Pan the canvas' },
-        { keys: ['Double-click'], label: 'Center & focus a node' },
-        { keys: ['⌘', 'wheel'], label: 'Zoom in / out' }
-      ]
-    },
-    {
-      title: 'Terminal',
-      rows: [
-        { keys: ['Hover ~0.6s'], label: 'Enter the terminal (type/select)' },
-        { keys: ['Quick drag'], label: 'Move the terminal (before it focuses)' },
-        { keys: ['⌘', 'M'], label: 'Toggle markdown view' },
-        { keys: ['⌘', 'C'], label: 'Copy selection (markdown view)' },
-        { keys: ['✦'], label: 'Name the terminal with AI' }
-      ]
-    },
-    {
-      title: 'Source Control',
-      rows: [
-        { keys: ['⌘', '⇧', 'G'], label: 'Open Source Control' },
-        { keys: ['⌘', '↵'], label: 'Commit the staged changes' }
-      ]
-    }
-  ]
+/** Fixed reference rows shown under each group AFTER the configurable hotkeys: mouse gestures
+ *  and one-off UI keys that have no combo string to configure. The actual key combos (⌘K, ⌘T,
+ *  ⌘⇧G, …) are NOT here — they come from the shortcuts registry and render from current
+ *  settings, so a rebind shows here immediately. */
+const GESTURE_ROWS: Record<string, Row[]> = {
+  General: [],
+  Canvas: [
+    { keys: ['Right-click'], label: 'Actions menu (empty space or node)' },
+    { keys: ['Left-drag'], label: 'Box-select (touch to select)' },
+    { keys: ['Middle / Right-drag'], label: 'Pan the canvas' },
+    { keys: ['Double-click'], label: 'Center & focus a node' },
+    { keys: ['⌘', 'wheel'], label: 'Zoom in / out' }
+  ],
+  Terminal: [
+    { keys: ['Hover ~0.6s'], label: 'Enter the terminal (type/select)' },
+    { keys: ['Quick drag'], label: 'Move the terminal (before it focuses)' },
+    { keys: ['✦'], label: 'Name the terminal with AI' }
+  ],
+  // Source Control has no fixed gesture rows: Open Source Control and Commit are configurable
+  // (toggleSourceControl / commitStaged) and render from the registry.
+  'Source Control': []
 }
 
-/** Keyboard shortcuts reference; shown on first launch and via ⌘/ or the ? button. */
+/**
+ * Keyboard shortcuts reference; shown on first launch and via ⌘/ or the ? button.
+ * Configurable hotkeys render from the CURRENT settings (so a rebind in Keyboard Shortcuts
+ * shows here immediately); mouse gestures are fixed reference rows. The dictation row reflects
+ * `settings.speech.shortcut` (a modifier-only chord is hold-to-talk — no trailing key badge).
+ */
 export function ShortcutsPanel({ onClose }: ShortcutsPanelProps) {
   const speechShortcut = useSettings((s) => s.settings.speech.shortcut)
-  const SECTIONS = buildSections(
-    shortcutKeyParts(speechShortcut, isMac),
-    isHoldChord(speechShortcut) ? 'Dictate (hold)' : 'Dictate'
-  )
+  const shortcutsMap = useSettings((s) => s.settings.shortcuts)
+
+  const sections = shortcutGroups().map((group) => ({
+    title: group.title,
+    rows: [
+      ...group.defs.map((d) => ({
+        keys: shortcutKeyParts(shortcutsMap[d.id], isMac),
+        label: d.label
+      })),
+      ...(GESTURE_ROWS[group.title] ?? [])
+    ]
+  }))
+
+  // General group also leads with the dictation row (speech shortcut) before the rest.
+  const general = sections.find((s) => s.title === 'General')
+  if (general) {
+    general.rows.unshift({
+      keys: shortcutKeyParts(speechShortcut, isMac),
+      label: isHoldChord(speechShortcut) ? 'Dictate (hold)' : 'Dictate'
+    })
+  }
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -94,7 +88,7 @@ export function ShortcutsPanel({ onClose }: ShortcutsPanelProps) {
           </button>
         </div>
         <div className="shortcuts__body">
-          {SECTIONS.map((s) => (
+          {sections.map((s) => (
             <section key={s.title}>
               <h3>{s.title}</h3>
               {s.rows.map((r) => (

--- a/src/renderer/components/SourceControlPanel.tsx
+++ b/src/renderer/components/SourceControlPanel.tsx
@@ -7,6 +7,7 @@ import type { GitHistoryItem, GitHistoryResult } from '@shared/git-history'
 import { promptDialog } from './promptDialog'
 import { useProjects } from '../state/projects'
 import { useSettings } from '../state/settings'
+import { matchesShortcut } from '@shared/shortcut'
 import { useSshConn } from '../state/sshConn'
 import { useScmDraft } from '../state/scmDraft'
 import { useScmCache } from '../state/scmCache'
@@ -54,6 +55,8 @@ function DiffStat({ added, deleted }: { added: number; deleted: number }) {
     </span>
   )
 }
+
+const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 
 /** Visual Studio-style Source Control: file-level stage/diff/discard + branch switcher. */
 export function SourceControlPanel({
@@ -507,7 +510,8 @@ export function SourceControlPanel({
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}
                     onKeyDown={(e) => {
-                      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') commitAndPush()
+                      const commitShortcut = useSettings.getState().settings.shortcuts.commitStaged
+                      if (matchesShortcut(e, commitShortcut, isMac)) commitAndPush()
                     }}
                   />
                   <button

--- a/src/renderer/components/settings/SettingsIcons.tsx
+++ b/src/renderer/components/settings/SettingsIcons.tsx
@@ -42,6 +42,13 @@ const PATHS: Record<SettingsSectionId, React.JSX.Element> = {
       <path d="M4 8.2a4 4 0 0 0 8 0M8 12.2v1.6M6.2 13.8h3.6" />
     </>
   ),
+  // A keycap — the obvious glyph for configurable keyboard shortcuts.
+  shortcuts: (
+    <>
+      <rect x="2.2" y="4" width="11.6" height="8" rx="1.8" />
+      <path d="M5.4 8h.01M8 8h.01M10.6 8h.01" />
+    </>
+  ),
   agents: (
     <path d="M8 2.3 9.4 5.9 13 7.3 9.4 8.7 8 12.3 6.6 8.7 3 7.3 6.6 5.9z" />
   ),

--- a/src/renderer/components/settings/SettingsPage.tsx
+++ b/src/renderer/components/settings/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { AppearanceSection } from './sections/AppearanceSection'
 import { NotchSection } from './sections/NotchSection'
 import { PhoneSection } from './sections/PhoneSection'
 import { SpeechSection } from './sections/SpeechSection'
+import { ShortcutsSection } from './sections/ShortcutsSection'
 import { AgentsSection } from './sections/AgentsSection'
 import { UsageSection } from './sections/UsageSection'
 import { AccountsSection } from './sections/AccountsSection'
@@ -77,6 +78,7 @@ export function SettingsPage({
             {isMac && <NotchSection isActive={active === 'notch'} />}
             <PhoneSection isActive={active === 'phone'} />
             <SpeechSection isActive={active === 'speech'} onNavigate={setActive} />
+            <ShortcutsSection isActive={active === 'shortcuts'} />
             <AgentsSection isActive={active === 'agents'} />
             <UsageSection isActive={active === 'usage'} />
             <AccountsSection isActive={active === 'accounts'} />

--- a/src/renderer/components/settings/ShortcutCaptureField.tsx
+++ b/src/renderer/components/settings/ShortcutCaptureField.tsx
@@ -1,0 +1,136 @@
+import { useRef, useState } from 'react'
+import {
+  buildModifierChord,
+  captureToShortcut,
+  formatShortcut,
+  isModifierEventKey,
+  type ChordModifiers,
+  type ShortcutKeyEvent
+} from '@shared/shortcut'
+import { Button } from '@renderer/ui/Button'
+
+const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
+
+/**
+ * A capture field for a keyboard shortcut: click -> \"Press keys…\" -> capture -> commit the
+ * canonical combo. Two shapes commit differently (v3):
+ *  - A real key (Cmd/Ctrl + a non-modifier key) commits IMMEDIATELY on keydown — toggle mode.
+ *  - Modifier keys only (Cmd/Ctrl [+ Alt] [+ Shift], no other key yet) commit on KEYUP, once
+ *    every key has been released — hold-to-talk mode (only meaningful for dictation). Each
+ *    modifier keydown remembers the strongest state seen (`modsRef`) and previews it, since the
+ *    keyup event itself no longer carries that state once everything's up.
+ * Esc cancels; blur cancels; a Reset button restores `defaultValue`. Reset renders to the LEFT
+ * of the combo so the combo badge stays anchored at the field's right edge — appearing or
+ * hiding Reset never shifts the combo or throws a column of capture badges out of alignment.
+ * Pure combo logic lives in `@shared/shortcut`.
+ *
+ * Generic over what kind of shortcut it captures: `allowChord` enables the modifier-only
+ * (hold-to-talk) commit shape for dictation; for plain hotkeys it is off, so a modifier-only
+ * press keeps waiting on a real key (which is what a hotkey must have).
+ */
+export function ShortcutCaptureField({
+  value,
+  onChange,
+  defaultValue = '',
+  allowChord = false
+}: {
+  value: string
+  onChange: (combo: string) => void
+  /** The combo the Reset button restores; empty hides Reset. */
+  defaultValue?: string
+  /** Whether a modifier-only chord commits (dictation hold-to-talk). Default off. */
+  allowChord?: boolean
+}): React.JSX.Element {
+  const [capturing, setCapturing] = useState(false)
+  const [hint, setHint] = useState('')
+  const modsRef = useRef<ChordModifiers | null>(null)
+
+  const stopCapturing = (): void => {
+    setCapturing(false)
+    setHint('')
+    modsRef.current = null
+  }
+
+  const startCapturing = (): void => {
+    modsRef.current = null
+    setCapturing(true)
+    setHint('')
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (!capturing) return
+    e.preventDefault()
+    if (e.key === 'Escape') {
+      stopCapturing()
+      return
+    }
+
+    if (isModifierEventKey(e.key)) {
+      if (!allowChord) {
+        // Plain hotkey: modifiers alone never commit — keep waiting on a real key.
+        const primaryPressed = isMac ? e.metaKey : e.ctrlKey
+        setHint(primaryPressed ? 'Press a key…' : isMac ? 'Hold ⌘…' : 'Hold Ctrl…')
+        return
+      }
+      const primaryPressed = isMac ? e.metaKey : e.ctrlKey
+      if (!primaryPressed) {
+        setHint(isMac ? `Hold ⌘…` : `Hold Ctrl…`)
+        return
+      }
+      const mods: ChordModifiers = { cmd: true, alt: e.altKey, shift: e.shiftKey }
+      modsRef.current = mods
+      const preview = buildModifierChord(mods)
+      setHint(
+        preview
+          ? `Release now for hold-to-talk (${formatShortcut(preview, isMac)}) — or press a key for toggle`
+          : ''
+      )
+      return
+    }
+
+    const evt: ShortcutKeyEvent = {
+      metaKey: e.metaKey,
+      ctrlKey: e.ctrlKey,
+      shiftKey: e.shiftKey,
+      altKey: e.altKey,
+      key: e.key
+    }
+    const combo = captureToShortcut(evt, isMac)
+    if (!combo) {
+      setHint(isMac ? `Hold ⌘ and press a key` : `Hold Ctrl and press a key`)
+      return
+    }
+    onChange(combo)
+    stopCapturing()
+  }
+
+  const onKeyUp = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (!capturing || !modsRef.current) return
+    const anyModDown = (isMac ? e.metaKey : e.ctrlKey) || e.altKey || e.shiftKey
+    if (anyModDown) return // not fully released yet — keep waiting
+    const combo = buildModifierChord(modsRef.current)
+    if (!combo) return
+    onChange(combo)
+    stopCapturing()
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {defaultValue !== '' && defaultValue !== value ? (
+        <Button variant="ghost" onClick={() => onChange(defaultValue)}>
+          Reset
+        </Button>
+      ) : null}
+      <button
+        type="button"
+        className="min-w-[140px] cursor-pointer rounded-md border border-border bg-panel-header px-3 py-1.5 text-[13px] font-medium text-text outline-none hover:bg-[rgba(255,255,255,0.06)]"
+        onClick={startCapturing}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        onBlur={stopCapturing}
+      >
+        {capturing ? hint || 'Press keys…' : value ? formatShortcut(value, isMac) : 'Unbound'}
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/settings/nav.test.ts
+++ b/src/renderer/components/settings/nav.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { SETTINGS_GROUPS, allSectionIds, FIRST_SECTION_ID, visibleSettingsGroups } from './nav'
 
 describe('SETTINGS_GROUPS', () => {
-  it('lists exactly 22 sections with no duplicates', () => {
+  it('lists exactly 23 sections with no duplicates', () => {
     const ids = allSectionIds()
-    expect(ids).toHaveLength(22)
-    expect(new Set(ids).size).toBe(22)
+    expect(ids).toHaveLength(23)
+    expect(new Set(ids).size).toBe(23)
   })
   it('starts at a section that exists in the groups', () => {
     expect(allSectionIds()).toContain(FIRST_SECTION_ID)
@@ -13,7 +13,7 @@ describe('SETTINGS_GROUPS', () => {
   it('hides mac-only sections off macOS, keeps them on', () => {
     const off = visibleSettingsGroups(false).flatMap((g) => g.sections.map((s) => s.id))
     expect(off).not.toContain('notch')
-    expect(off).toHaveLength(21)
+    expect(off).toHaveLength(22)
     expect(visibleSettingsGroups(true)).toEqual(SETTINGS_GROUPS)
     // No group is left empty by the filter.
     expect(visibleSettingsGroups(false).every((g) => g.sections.length > 0)).toBe(true)

--- a/src/renderer/components/settings/nav.ts
+++ b/src/renderer/components/settings/nav.ts
@@ -6,6 +6,7 @@ export type SettingsSectionId =
   | 'notch'
   | 'phone'
   | 'speech'
+  | 'shortcuts'
   | 'agents'
   | 'usage'
   | 'accounts'
@@ -67,7 +68,8 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
       { id: 'appearance', title: 'Appearance' },
       { id: 'notch', title: 'Notch', macOnly: true },
       { id: 'notifications', title: 'Notifications' },
-      { id: 'speech', title: 'Speech' }
+      { id: 'speech', title: 'Speech' },
+      { id: 'shortcuts', title: 'Shortcuts' }
     ]
   },
   {

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import { SHORTCUT_DEFS } from '@shared/shortcuts'
+import { formatShortcut } from '@shared/shortcut'
+import { useSettings } from '../../../state/settings'
+import { ShortcutsSection } from './ShortcutsSection'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
+
+describe('ShortcutsSection', () => {
+  let root: Root
+  let host: HTMLElement
+
+  beforeEach(async () => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    useSettings.setState({ settings: DEFAULT_SETTINGS, hydrated: true })
+    root = createRoot(host)
+    await act(async () => {
+      root.render(<ShortcutsSection isActive />)
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it('renders a row for every configurable shortcut, grouped', () => {
+    for (const d of SHORTCUT_DEFS) {
+      expect(host.textContent).toContain(d.label)
+    }
+    for (const title of ['General', 'Canvas', 'Terminal', 'Source Control']) {
+      expect(host.textContent).toContain(title)
+    }
+  })
+
+  it('shows the current combo keyed off settings.shortcuts (rebind reflected)', async () => {
+    // The default combo renders with the platform's primary modifier label (⌘ on mac,
+    // Ctrl elsewhere) — formatShortcut is the same formatter the capture field uses.
+    const defaultBadge = formatShortcut(DEFAULT_SETTINGS.shortcuts.commandPalette, isMac)
+    expect(host.textContent).toContain(defaultBadge)
+
+    // Rebinding the palette shortcut in the store re-renders the row's badge.
+    await act(async () => {
+      useSettings.getState().update({
+        shortcuts: { ...useSettings.getState().settings.shortcuts, commandPalette: 'Cmd+Shift+P' }
+      })
+    })
+    expect(host.textContent).toContain(formatShortcut('Cmd+Shift+P', isMac))
+  })
+})

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import {
+  findShortcutConflicts,
+  shortcutGroups,
+  type ShortcutAction,
+  type ShortcutDef
+} from '@shared/shortcuts'
+import { useSettings } from '../../../state/settings'
+import { SettingsSection } from '../SettingsSection'
+import { SearchableRow } from '../SearchableRow'
+import { FieldRow } from '../FieldRow'
+import { ShortcutCaptureField } from '../ShortcutCaptureField'
+
+const DEFAULT_MAP = DEFAULT_SETTINGS.shortcuts
+
+/** Combo strings that are duplicated across the current map, e.g. `Cmd+K` -> ['settings']. */
+function conflictsByCombo(map: Record<ShortcutAction, string>): Map<string, ShortcutAction[]> {
+  const by = new Map<string, ShortcutAction[]>()
+  for (const [a, b] of findShortcutConflicts(map)) {
+    const combo = map[a]
+    const seen = by.get(combo)
+    if (!seen) by.set(combo, [a, b])
+    else if (!seen.includes(a)) seen.push(a)
+    else if (!seen.includes(b)) seen.push(b)
+  }
+  return by
+}
+
+/** `'commandPalette'` -> `'Command palette'`. */
+function shortcutName(defs: ShortcutDef[], id: ShortcutAction): string {
+  return defs.find((d) => d.id === id)?.label ?? id
+}
+
+/**
+ * Shortcuts: every configurable hotkey with a capture field, grouped like the ShortcutsPanel.
+ * Changing a combo updates `settings.shortcuts`; the dispatch sites read the same map, so the
+ * change takes effect immediately and ShortcutsPanel reflects it. A combo that collides with
+ * another action's is flagged inline (the first match wins at runtime — a silent duplicate
+ * would be a trap).
+ *
+ * Layout mirrors the house pattern for a labeled group of rows (see AppearanceSection): the
+ * section body divides and pads every DIRECT child, so each group arrives as a single node
+ * (SearchableRow) containing an h4 heading and its rows in a left-bordered sub-list.
+ */
+export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX.Element {
+  const settings = useSettings((s) => s.settings)
+  const update = useSettings((s) => s.update)
+
+  const conflicts = useMemo(() => conflictsByCombo(settings.shortcuts), [settings.shortcuts])
+  const allDefs = shortcutGroups().flatMap((g) => g.defs)
+
+  const setShortcut = (id: ShortcutAction, combo: string): void => {
+    update({ shortcuts: { ...settings.shortcuts, [id]: combo } })
+  }
+
+  return (
+    <SettingsSection
+      id="shortcuts"
+      title="Shortcuts"
+      description="Every hotkey in the app, with the key it is bound to. Click a combo to capture a new one; Reset restores the shipped default. Mouse gestures (right-click, drags, double-click, ⌘ wheel) are fixed and listed in the Shortcuts panel (⌘/)."
+      isActive={isActive}
+      searchEntries={shortcutGroups().flatMap((g) => ({
+        title: g.title,
+        keywords: g.defs.flatMap((d) => [d.label, ...d.keywords])
+      }))}
+    >
+      {shortcutGroups().map((group) => (
+        <SearchableRow
+          key={group.title}
+          title={group.title}
+          keywords={group.defs.flatMap((d) => [d.label, ...d.keywords])}
+        >
+          <div>
+            <h4 className="text-[13px] font-medium text-text">{group.title}</h4>
+            <div className="mt-3 space-y-3 border-l border-border pl-4">
+              {group.defs.map((d) => {
+                const clash = conflicts.get(settings.shortcuts[d.id])
+                const clashLabel =
+                  clash && clash.length > 1
+                    ? clash
+                        .filter((other) => other !== d.id)
+                        .map((id) => shortcutName(allDefs, id))
+                        .join(', ')
+                    : ''
+                return (
+                  <FieldRow
+                    key={d.id}
+                    label={d.label}
+                    htmlFor={`shortcut-${d.id}`}
+                    description={
+                      clashLabel
+                        ? `Also bound to: ${clashLabel}. The first one to match wins — pick a different key.`
+                        : undefined
+                    }
+                    control={
+                      <ShortcutCaptureField
+                        value={settings.shortcuts[d.id]}
+                        onChange={(combo) => setShortcut(d.id, combo)}
+                        defaultValue={DEFAULT_MAP[d.id]}
+                      />
+                    }
+                  />
+                )
+              })}
+            </div>
+          </div>
+        </SearchableRow>
+      ))}
+    </SettingsSection>
+  )
+}

--- a/src/renderer/components/settings/sections/SpeechSection.tsx
+++ b/src/renderer/components/settings/sections/SpeechSection.tsx
@@ -1,16 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { SpeechModelInfo } from '@shared/types'
 import { modelAfterDelete, modelAfterDownload } from '@shared/speech'
 import { DEFAULT_SETTINGS } from '@shared/types'
-import {
-  buildModifierChord,
-  captureToShortcut,
-  formatShortcut,
-  isHoldChord,
-  isModifierEventKey,
-  type ChordModifiers,
-  type ShortcutKeyEvent
-} from '@shared/shortcut'
 import { useSettings } from '../../../state/settings'
 import { useEntitlement } from '../../../state/entitlement'
 import { SettingsSection } from '../SettingsSection'
@@ -19,6 +10,8 @@ import { FieldRow } from '../FieldRow'
 import { Select } from '@renderer/ui/Select'
 import { SegmentedPill } from '@renderer/ui/SegmentedPill'
 import { Button } from '@renderer/ui/Button'
+import { formatShortcut, isHoldChord } from '@shared/shortcut'
+import { ShortcutCaptureField } from '../ShortcutCaptureField'
 import type { SettingsSectionId } from '../nav'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
@@ -55,113 +48,10 @@ const ROWS = {
 const ENTRIES = Object.values(ROWS)
 
 /**
- * Focus -> "Press keys…" -> capture -> saves the canonical combo. Two shapes commit
- * differently (v3):
- *  - A real key (Cmd/Ctrl + a non-modifier key) commits IMMEDIATELY on keydown, same as before
- *    — toggle mode.
- *  - Modifier keys only (Cmd/Ctrl [+ Alt] [+ Shift], no other key yet) commit on KEYUP, once
- *    every key has been released — hold-to-talk mode. Each modifier keydown along the way
- *    remembers the strongest state seen (`modsRef`) and previews it, since the keyup event
- *    itself no longer carries that state once everything's up (see `buildModifierChord`'s doc).
- * Esc cancels; blur cancels; a separate Reset button restores the default (`Cmd+Alt`, itself a
- * hold-to-talk chord). Pure combo logic lives in `@shared/shortcut`.
+ * Dictation (desktop/server): engine, model, language, and the press/hold-to-talk shortcut.
+ * The ShortcutCaptureField is the shared settings capture control (also used by Keyboard
+ * Shortcuts); here it is wired hold-to-talk-capable (`allowChord`) with the speech default.
  */
-function ShortcutCaptureField({
-  value,
-  onChange
-}: {
-  value: string
-  onChange: (combo: string) => void
-}): React.JSX.Element {
-  const [capturing, setCapturing] = useState(false)
-  const [hint, setHint] = useState('')
-  const modsRef = useRef<ChordModifiers | null>(null)
-
-  const stopCapturing = (): void => {
-    setCapturing(false)
-    setHint('')
-    modsRef.current = null
-  }
-
-  const startCapturing = (): void => {
-    modsRef.current = null
-    setCapturing(true)
-    setHint('')
-  }
-
-  const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
-    if (!capturing) return
-    e.preventDefault()
-    if (e.key === 'Escape') {
-      stopCapturing()
-      return
-    }
-
-    if (isModifierEventKey(e.key)) {
-      // Only modifier keys pressed so far — remember the strongest state for a possible keyUp
-      // commit (hold-to-talk) and preview it; still lets the user continue on to press a real
-      // key instead (toggle mode) below.
-      const primaryPressed = isMac ? e.metaKey : e.ctrlKey
-      if (!primaryPressed) {
-        setHint(isMac ? `Hold ⌘…` : `Hold Ctrl…`)
-        return
-      }
-      const mods: ChordModifiers = { cmd: true, alt: e.altKey, shift: e.shiftKey }
-      modsRef.current = mods
-      const preview = buildModifierChord(mods)
-      setHint(preview ? `Release now for hold-to-talk (${formatShortcut(preview, isMac)}) — or press a key for toggle` : '')
-      return
-    }
-
-    const evt: ShortcutKeyEvent = {
-      metaKey: e.metaKey,
-      ctrlKey: e.ctrlKey,
-      shiftKey: e.shiftKey,
-      altKey: e.altKey,
-      key: e.key
-    }
-    const combo = captureToShortcut(evt, isMac)
-    if (!combo) {
-      setHint(isMac ? `Hold ⌘ and press a key` : `Hold Ctrl and press a key`)
-      return
-    }
-    onChange(combo)
-    stopCapturing()
-  }
-
-  const onKeyUp = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
-    if (!capturing || !modsRef.current) return
-    const anyModDown = (isMac ? e.metaKey : e.ctrlKey) || e.altKey || e.shiftKey
-    if (anyModDown) return // not fully released yet — keep waiting
-    const combo = buildModifierChord(modsRef.current)
-    if (!combo) return
-    onChange(combo)
-    stopCapturing()
-  }
-
-  return (
-    <div className="flex items-center gap-2">
-      <button
-        type="button"
-        className="min-w-[140px] cursor-pointer rounded-md border border-border bg-panel-header px-3 py-1.5 text-[13px] font-medium text-text outline-none hover:bg-[rgba(255,255,255,0.06)]"
-        onClick={startCapturing}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onBlur={stopCapturing}
-      >
-        {capturing ? hint || 'Press keys…' : formatShortcut(value, isMac)}
-      </button>
-      <Button
-        variant="ghost"
-        disabled={value === DEFAULT_SHORTCUT}
-        onClick={() => onChange(DEFAULT_SHORTCUT)}
-      >
-        Reset
-      </Button>
-    </div>
-  )
-}
-
 const LANGUAGES: { value: string; label: string }[] = [
   { value: 'auto', label: 'Auto-detect' },
   { value: 'en', label: 'English' },
@@ -346,7 +236,14 @@ export function SpeechSection({
               ? `Currently hold-to-talk: hold ${formatShortcut(settings.speech.shortcut, isMac)}.`
               : `Currently toggle: press ${formatShortcut(settings.speech.shortcut, isMac)}.`
           }
-          control={<ShortcutCaptureField value={settings.speech.shortcut} onChange={setShortcut} />}
+          control={
+            <ShortcutCaptureField
+              value={settings.speech.shortcut}
+              onChange={setShortcut}
+              defaultValue={DEFAULT_SHORTCUT}
+              allowChord
+            />
+          }
         />
       </SearchableRow>
 

--- a/src/renderer/components/settings/sections/shortcuts-dispatch-wiring.test.ts
+++ b/src/renderer/components/settings/sections/shortcuts-dispatch-wiring.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+//
+// The rebind contract: a shortcut changed in Settings -> Shortcuts must apply IMMEDIATELY —
+// the next keypress, without a listener re-run or reload. That lives in the dispatch sites,
+// which must read the LIVE settings store on every keydown instead of closing over a copy
+// (the feature commit's own convention: `useSettings.getState().settings.shortcuts` inside the
+// handler). Canvas is a monolith with no render harness, so like canvas-wiring.test.tsx this
+// pins the call sites by source read — the only thing between a one-character deletion back to
+// a hardcoded combo and a silent regression where rebinds stop working.
+import fs from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+const read = (rel: string): string => fs.readFileSync(path.join(__dirname, rel), 'utf8')
+
+const CANVAS = read('../../../canvas/Canvas.tsx')
+const TERMINAL_NODE = read('../../../nodes/TerminalNode.tsx')
+const SOURCE_CONTROL = read('../../SourceControlPanel.tsx')
+const MAIN = read('../../../../main/index.ts')
+
+describe('shortcut dispatch sites read the LIVE settings store (rebind applies immediately)', () => {
+  it('Canvas reads the live map inside every keydown handler, keyed off the registry', () => {
+    // The handler must resolve the map at event time — a closure-captured copy (`const
+    // shortcuts = useSettings.getState()...` in the effect body, outside `onKey`) would serve
+    // the OLD combo forever. Counting occurrences pins both that the read is inside the handler
+    // and that every configurable canvas action goes through it.
+    const liveReads = (CANVAS.match(/const shortcuts = useSettings\.getState\(\)\.settings\.shortcuts/g) ?? [])
+      .length
+    expect(liveReads).toBeGreaterThanOrEqual(3)
+    for (const action of [
+      'commandPalette',
+      'settings',
+      'shortcutsPanel',
+      'undo',
+      'redo',
+      'newTerminal',
+      'newAgent',
+      'toggleExplorer',
+      'toggleSourceControl',
+      'toggleViewMode',
+      'toggleSessionsPin',
+      'copySelection'
+    ]) {
+      expect(CANVAS, `Canvas dispatches ${action}`).toContain(`matchesShortcut(e, shortcuts.${action}, isMac)`)
+    }
+  })
+
+  it('TerminalNode find-bar reads the live map and dispatches findInTerminal', () => {
+    expect(TERMINAL_NODE).toContain(
+      'const findShortcut = useSettings.getState().settings.shortcuts.findInTerminal'
+    )
+    expect(TERMINAL_NODE).toContain('matchesShortcut(e, findShortcut, isMac)')
+  })
+
+  it('SourceControlPanel commit reads the live map and dispatches commitStaged', () => {
+    expect(SOURCE_CONTROL).toContain(
+      'const commitShortcut = useSettings.getState().settings.shortcuts.commitStaged'
+    )
+    expect(SOURCE_CONTROL).toContain('matchesShortcut(e, commitShortcut, isMac)')
+  })
+
+  it('main-process markdown/close intercepts read the settings store live', () => {
+    // Main has no zustand; it reads the persisted settings store on every before-input-event.
+    expect(MAIN).toContain('const shortcuts = settingsStore.get().shortcuts')
+    expect(MAIN).toContain('matchesShortcut(evt, shortcuts.toggleMarkdown, isMacMain)')
+    expect(MAIN).toContain('matchesShortcut(evt, shortcuts.closeNode, isMacMain)')
+  })
+})

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -128,6 +128,7 @@ import { liveProjectJumpTarget } from '../lib/projectJump'
 import { useSettings } from '../state/settings'
 import { useCodexIdentity, codexSharedIdentity, codexFallbackText } from '../state/codexIdentity'
 import { useAgentStatus, agentStatusForApi, inferInterruptAfterSettle } from '../state/agentStatus'
+import { matchesShortcut } from '@shared/shortcut'
 import type { AgentState } from '@shared/agents/normalize'
 import type { ClientId } from '@shared/presence'
 import { PresenceChips } from '../components/PresenceChips'
@@ -855,6 +856,8 @@ function setCo(key: string, patch: Partial<CoState>): void {
   coStates.set(key, next)
   coSubs.get(key)?.(next)
 }
+
+const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 
 /**
  * A single terminal node: header (collapse + color + title + close), optional tag chips,
@@ -3885,11 +3888,13 @@ export function TerminalNode({
     sa.findNext(search.query, findOpts)
   }, [search.query, searchOpen])
 
-  // Cmd/Ctrl+F toggles the find-bar while this node is hovered. No main-process interception
-  // needed (the Electron renderer has no native find UI), unlike Cmd+M.
+  // Find-bar toggle (default ⌘F) while this node is hovered. No main-process interception
+  // needed (the Electron renderer has no native find UI), unlike the markdown toggle. Combo is
+  // configurable via settings.shortcuts.findInTerminal.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === 'f' && hoveredRef.current) {
+      const findShortcut = useSettings.getState().settings.shortcuts.findInTerminal
+      if (matchesShortcut(e, findShortcut, isMac) && hoveredRef.current) {
         e.preventDefault()
         setSearchOpen((v) => !v)
       }

--- a/src/shared/shortcuts.test.ts
+++ b/src/shared/shortcuts.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_SHORTCUTS,
+  findShortcutConflicts,
+  shortcutGroups,
+  shortcutLabel,
+  SHORTCUT_DEFS
+} from './shortcuts'
+import { formatShortcut, parseShortcut, shortcutKeyParts, captureToShortcut, matchesShortcut } from './shortcut'
+
+describe('shortcuts registry', () => {
+  it('every def has a parseable, primary-modified default', () => {
+    for (const d of SHORTCUT_DEFS) {
+      const p = parseShortcut(d.default)
+      // These are hotkeys, not dictation hold-chords — a trailing key is mandatory.
+      expect(p.key, `${d.id} default ${d.default} has a trailing key`).not.toBeNull()
+      expect(p.cmd, `${d.id} default uses the primary modifier`).toBe(true)
+    }
+  })
+
+  it('defaults map matches the registry, one entry per action', () => {
+    expect(Object.keys(DEFAULT_SHORTCUTS).sort()).toEqual(
+      SHORTCUT_DEFS.map((d) => d.id).sort()
+    )
+    for (const d of SHORTCUT_DEFS) expect(DEFAULT_SHORTCUTS[d.id]).toBe(d.default)
+  })
+
+  it('defaults have no duplicates (they are the shipped hotkeys)', () => {
+    expect(findShortcutConflicts(DEFAULT_SHORTCUTS)).toEqual([])
+  })
+
+  it('groups every def exactly once, in display order', () => {
+    const groups = shortcutGroups()
+    const flat = groups.flatMap((g) => g.defs)
+    expect(flat).toHaveLength(SHORTCUT_DEFS.length)
+    expect(new Set(flat.map((d) => d.id)).size).toBe(SHORTCUT_DEFS.length)
+    expect(groups.map((g) => g.title)).toEqual([
+      'General',
+      'Canvas',
+      'Terminal',
+      'Source Control'
+    ])
+  })
+
+  it('shortcutLabel falls back to the id for unknown actions', () => {
+    expect(shortcutLabel('commandPalette')).toBe('Command palette')
+    expect(shortcutLabel('does-not-exist' as never)).toBe('does-not-exist')
+  })
+
+  it('findShortcutConflicts pairs duplicates (incl. 3-way)', () => {
+    const conflicts = findShortcutConflicts({
+      ...DEFAULT_SHORTCUTS,
+      commandPalette: 'Cmd+K',
+      settings: 'Cmd+K',
+      undo: 'Cmd+K'
+    })
+    // The three-way clash yields three pairs, all involving Cmd+K.
+    expect(conflicts).toHaveLength(3)
+    const pairs = conflicts.map(([a, b]) => [a, b].sort().join(','))
+    expect(pairs).toEqual(['commandPalette,settings', 'commandPalette,undo', 'settings,undo'])
+  })
+
+  // Cross-platform: the whole feature keys off the shared engine's platform abstraction
+  // (`Cmd` = ⌘/metaKey on macOS, Ctrl/ctrlKey elsewhere). Every SHIPPED default must survive
+  // the full parse -> format -> match/capture cycle on BOTH branches, so a Windows or macOS
+  // user gets the same behaviour and the settings capture field renders the right badge.
+  // (The generic engine is already tested on both branches in shortcut.test.ts; this pins the
+  // exact defaults — including the punctuation keys like `Cmd+,` — on both.)
+  for (const isMac of [true, false]) {
+    describe(`defaults on ${isMac ? 'macOS (⌘/meta)' : 'Windows/Linux (Ctrl)'}`, () => {
+      it('parse -> format round-trips every default to a renderable badge', () => {
+        for (const d of SHORTCUT_DEFS) {
+          const parsed = parseShortcut(d.default)
+          // The formatted badge must contain the key token, however the modifier renders.
+          const badge = formatShortcut(d.default, isMac)
+          expect(badge, `${d.id}: ${d.default} formats on ${isMac}`).toContain(
+            shortcutKeyParts(d.default, isMac).at(-1) ?? ''
+          )
+          // Non-empty and never collapses to a bare modifier on either platform.
+          expect(badge.length).toBeGreaterThan(0)
+          // `Cmd` must always render as the platform primary modifier (⌘ on mac, Ctrl off).
+          if (parsed.cmd) {
+            expect(badge).toContain(isMac ? '⌘' : 'Ctrl')
+          }
+        }
+      })
+
+      it('a keydown with the platform primary modifier matches every default', () => {
+        for (const d of SHORTCUT_DEFS) {
+          const parsed = parseShortcut(d.default)
+          const evt = {
+            metaKey: isMac && parsed.cmd,
+            ctrlKey: !isMac && parsed.cmd,
+            shiftKey: parsed.shift,
+            altKey: parsed.alt,
+            key: parsed.key ?? ''
+          }
+          expect(
+            matchesShortcut(evt, d.default, isMac),
+            `${d.id}: ${d.default} matches on ${isMac ? 'macOS' : 'Win/Linux'}`
+          ).toBe(true)
+        }
+      })
+
+      it('captureToShortcut accepts every default (primary modifier + key)', () => {
+        for (const d of SHORTCUT_DEFS) {
+          const parsed = parseShortcut(d.default)
+          const captured = captureToShortcut(
+            {
+              metaKey: isMac,
+              ctrlKey: !isMac,
+              shiftKey: parsed.shift,
+              altKey: parsed.alt,
+              key: parsed.key ?? ''
+            },
+            isMac
+          )
+          // Same modifiers + key as the default, modulo canonical casing (e.g. 'Cmd+Enter').
+          expect(captured, `${d.id}: ${d.default} is capturable on ${isMac}`).not.toBeNull()
+          if (captured) expect(parseShortcut(captured)).toEqual(parsed)
+        }
+      })
+    })
+  }
+})

--- a/src/shared/shortcuts.ts
+++ b/src/shared/shortcuts.ts
@@ -1,0 +1,109 @@
+/**
+ * The configurable keyboard-shortcut registry. One entry per hotkey the app ships with;
+ * the canonical combo string (see `shared/shortcut.ts`) is the value, keyed by a stable
+ * action id so settings survive renames and the UI never has to know a combo by heart.
+ *
+ * Kept OUT of `shared/types.ts` so the registry (labels, groups, defaults, conflict
+ * detection) stays with the shortcut engine it describes; `types.ts` only imports the
+ * `ShortcutMap` type and `DEFAULT_SHORTCUTS` to seed `Settings.shortcuts`.
+ *
+ * A shortcut becomes user-configurable by (1) adding its action here with the CURRENT
+ * hardcoded combo as the default, (2) wiring the dispatch site to
+ * `settings.shortcuts.<action>` via `matchesShortcut`, and (3) the section renders it
+ * automatically from SHORTCUT_DEFS.
+ */
+
+/** Stable ids — one per configurable hotkey. Mouse gestures (right-click, drags,
+ *  double-click, wheel zoom) are NOT here: they have no combo string to configure and
+ *  stay fixed; ShortcutsPanel still documents them as reference rows. */
+export type ShortcutAction =
+  | 'commandPalette' // ⌘K
+  | 'settings' // ⌘,
+  | 'shortcutsPanel' // ⌘/
+  | 'undo' // ⌘Z
+  | 'redo' // ⌘⇧Z (⌘Y kept as a legacy alias in the handler)
+  | 'newTerminal' // ⌘T
+  | 'newAgent' // ⌘⇧C
+  | 'closeNode' // ⌘W — intercepted in main, forwarded to the renderer
+  | 'toggleMarkdown' // ⌘M — intercepted in main (native minimize is repurposed)
+  | 'toggleExplorer' // ⌘⇧E
+  | 'toggleSourceControl' // ⌘⇧G
+  | 'toggleViewMode' // ⌘⇧B
+  | 'toggleSessionsPin' // ⌘⇧L
+  | 'findInTerminal' // ⌘F
+  | 'commitStaged' // ⌘↵ (inside the Source Control textarea)
+  | 'copySelection' // ⌘C (markdown-view copy fallback)
+
+/** `Record<ShortcutAction, string>` — the shape stored in `Settings.shortcuts`. */
+export type ShortcutMap = Record<ShortcutAction, string>
+
+/** Group titles for the settings section + ShortcutsPanel (same ordering). */
+export type ShortcutGroup = 'General' | 'Canvas' | 'Terminal' | 'Source Control'
+
+export interface ShortcutDef {
+  id: ShortcutAction
+  group: ShortcutGroup
+  /** Human label — the ShortcutsPanel row name and the settings row title. */
+  label: string
+  /** The combo the app ships with. Changing the default here = changing the shipped hotkey. */
+  default: string
+  /** Settings-search keywords. */
+  keywords: string[]
+}
+
+export const SHORTCUT_DEFS: ShortcutDef[] = [
+  { id: 'commandPalette', group: 'General', label: 'Command palette', default: 'Cmd+K', keywords: ['command', 'palette', 'quick', 'open'] },
+  { id: 'settings', group: 'General', label: 'Settings', default: 'Cmd+,', keywords: ['settings', 'preferences', 'open'] },
+  { id: 'shortcutsPanel', group: 'General', label: 'Shortcuts panel', default: 'Cmd+/', keywords: ['shortcuts', 'panel', 'help', 'reference'] },
+  { id: 'undo', group: 'General', label: 'Undo', default: 'Cmd+Z', keywords: ['undo', 'revert'] },
+  { id: 'redo', group: 'General', label: 'Redo', default: 'Cmd+Shift+Z', keywords: ['redo', 'forward', 'y'] },
+  { id: 'newTerminal', group: 'Canvas', label: 'New terminal', default: 'Cmd+T', keywords: ['terminal', 'new', 'create', 'node'] },
+  { id: 'newAgent', group: 'Canvas', label: 'New agent', default: 'Cmd+Shift+C', keywords: ['agent', 'claude', 'codex', 'gemini', 'new', 'add'] },
+  { id: 'closeNode', group: 'Canvas', label: 'Close selected node', default: 'Cmd+W', keywords: ['close', 'node', 'window'] },
+  { id: 'toggleExplorer', group: 'Canvas', label: 'Toggle explorer', default: 'Cmd+Shift+E', keywords: ['explorer', 'files', 'sidebar'] },
+  { id: 'toggleSourceControl', group: 'Source Control', label: 'Open Source Control', default: 'Cmd+Shift+G', keywords: ['source', 'control', 'git', 'scm'] },
+  { id: 'toggleViewMode', group: 'Canvas', label: 'Toggle view mode', default: 'Cmd+Shift+B', keywords: ['view', 'mode', 'canvas', 'kanban', 'board'] },
+  { id: 'toggleSessionsPin', group: 'Canvas', label: 'Pin sessions sidebar', default: 'Cmd+Shift+L', keywords: ['sessions', 'pin', 'sidebar', 'collapse'] },
+  { id: 'toggleMarkdown', group: 'Terminal', label: 'Toggle markdown view', default: 'Cmd+M', keywords: ['markdown', 'md', 'toggle', 'view'] },
+  { id: 'findInTerminal', group: 'Terminal', label: 'Find in terminal', default: 'Cmd+F', keywords: ['find', 'search', 'terminal'] },
+  { id: 'commitStaged', group: 'Source Control', label: 'Commit staged changes', default: 'Cmd+Enter', keywords: ['commit', 'staged', 'push', 'enter'] },
+  { id: 'copySelection', group: 'Terminal', label: 'Copy selection (markdown view)', default: 'Cmd+C', keywords: ['copy', 'selection', 'markdown', 'clipboard'] }
+]
+
+/** The shipped map — seeds `DEFAULT_SETTINGS.shortcuts` and the section's Reset buttons. */
+export const DEFAULT_SHORTCUTS: ShortcutMap = Object.fromEntries(
+  SHORTCUT_DEFS.map((d) => [d.id, d.default])
+) as ShortcutMap
+
+/** `'commandPalette'` -> `'Command palette'`. */
+export function shortcutLabel(id: ShortcutAction): string {
+  return SHORTCUT_DEFS.find((d) => d.id === id)?.label ?? id
+}
+
+/** Groups in display order, each with its defs. */
+export function shortcutGroups(): { title: ShortcutGroup; defs: ShortcutDef[] }[] {
+  const order: ShortcutGroup[] = ['General', 'Canvas', 'Terminal', 'Source Control']
+  return order.map((title) => ({ title, defs: SHORTCUT_DEFS.filter((d) => d.group === title) }))
+}
+
+/**
+ * Pairs of actions that share a combo string (duplicates) in `map`. The settings section
+ * flags these so a user who maps two hotkeys to the same keys sees the collision — the
+ * first matched dispatch site wins at runtime, so a silent duplicate is a real trap.
+ * Pure + structural so it is unit-testable without a DOM.
+ */
+export function findShortcutConflicts(map: ShortcutMap): [ShortcutAction, ShortcutAction][] {
+  const byCombo = new Map<string, ShortcutAction[]>()
+  for (const [id, combo] of Object.entries(map) as [ShortcutAction, string][]) {
+    const list = byCombo.get(combo) ?? []
+    list.push(id)
+    byCombo.set(combo, list)
+  }
+  const conflicts: [ShortcutAction, ShortcutAction][] = []
+  for (const list of byCombo.values()) {
+    for (let i = 0; i < list.length; i++) {
+      for (let j = i + 1; j < list.length; j++) conflicts.push([list[i], list[j]])
+    }
+  }
+  return conflicts
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,6 +7,8 @@ import type { GroupWorktree } from './worktree'
 import type { ClientId, DinoSnapshot, PeerDiff, PeerIdentity, PeerState } from './presence'
 import type { WhisperModelInfo } from './speech'
 import type { ProjectKanbanGitHub } from './github-issues'
+import type { ShortcutMap } from './shortcuts'
+import { DEFAULT_SHORTCUTS } from './shortcuts'
 
 export interface PtyCreateOptions {
   shell?: string
@@ -1040,6 +1042,9 @@ export interface Settings {
   notchHoverExpand: boolean
   /** Dictation (desktop/server). Written as a whole object by the renderer. */
   speech: SpeechSettings
+  /** User-configurable keyboard shortcuts, keyed by action id. Seeded from DEFAULT_SHORTCUTS;
+   *  merged over defaults on load so a new action simply appears with its shipped combo. */
+  shortcuts: ShortcutMap
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -1128,6 +1133,7 @@ export const DEFAULT_SETTINGS: Settings = {
   notchWidth: 168,
   notchHoverExpand: true,
   speech: { engine: 'whisper', model: 'tiny', language: 'auto', shortcut: 'Cmd+Alt' },
+  shortcuts: DEFAULT_SHORTCUTS,
 }
 
 export interface SettingsApi {

--- a/test/server/shortcuts-e2e.test.ts
+++ b/test/server/shortcuts-e2e.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import WebSocket from 'ws'
+import { startServer } from '../../src/server/index'
+import { SESSION_COOKIE } from '../../src/server/http'
+import { IPC } from '../../src/shared/ipc'
+import { DEFAULT_SETTINGS } from '../../src/shared/types'
+import { DEFAULT_SHORTCUTS, type ShortcutMap } from '../../src/shared/shortcuts'
+
+/**
+ * End-to-end: the Keyboard Shortcuts feature through the REAL Server Edition stack — HTTP
+ * login -> WS-RPC -> filesystem-backed SettingsStore. Verifies the three behaviours the
+ * rendered section + dispatch sites depend on:
+ *   1. A fresh boot serves DEFAULT_SHORTCUTS (the shipped hotkeys) with no settings.json.
+ *   2. Saving a rebind round-trips: settings:save the new combo, settings:load returns it,
+ *      and the on-disk settings.json actually contains it (persistence, not just memory).
+ *   3. Loading a settings.json that predates the feature (no `shortcuts` key) still yields a
+ *      full map — mergeSettings fills every action from DEFAULT_SHORTCUTS, so an old file's
+ *      terminals/speech survive and the new hotkeys just appear with their shipped defaults.
+ * Two WS calls run over the SAME connection so the save is visible to the load (one session).
+ */
+describe('server e2e: keyboard shortcuts settings round-trip', () => {
+  let dataDir: string
+  let close: () => Promise<void>
+  let port: number
+  let cookie: string
+
+  beforeAll(async () => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-shortcuts-e2e-'))
+    // Pre-seed a LEGACY settings.json — the pre-feature shape with NO `shortcuts` key. Its
+    // terminal font and speech object must survive the merge; the hotkeys must be filled in.
+    fs.writeFileSync(
+      path.join(dataDir, 'settings.json'),
+      JSON.stringify({
+        fontSize: 15,
+        speech: { engine: 'whisper', model: 'tiny', language: 'auto' }
+      }),
+      'utf-8'
+    )
+
+    const srv = await startServer({
+      port: 0,
+      host: '127.0.0.1',
+      dataDir,
+      rendererDir: path.join(dataDir, 'no-renderer'),
+      insecureHttp: false,
+      passwordSeed: 'shortcuts-e2e-password',
+      installHooks: false
+    })
+    port = srv.port
+    close = srv.close
+
+    const res = await fetch(`http://127.0.0.1:${port}/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'password=shortcuts-e2e-password',
+      redirect: 'manual'
+    })
+    expect(res.status).toBe(303)
+    cookie = res.headers.get('set-cookie')!.split(';')[0]
+    expect(cookie).toContain(SESSION_COOKIE)
+  }, 30_000)
+
+  afterAll(async () => {
+    await close?.()
+    fs.rmSync(dataDir, { recursive: true, force: true })
+  })
+
+  /** Open a WS with the session cookie; resolve once the socket is live. */
+  async function openWs(): Promise<WebSocket> {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, { headers: { cookie } })
+    await new Promise<void>((res, rej) => {
+      ws.on('open', () => res())
+      ws.on('error', rej)
+    })
+    return ws
+  }
+
+  /** Send one req over `ws`, resolve the matching `res` frame. */
+  function call<A extends unknown[], R>(
+    ws: WebSocket,
+    method: string,
+    args: A
+  ): Promise<{ ok: boolean; result: R }> {
+    const id = Math.floor(Math.random() * 1e9)
+    return new Promise((resolve, reject) => {
+      const onMsg = (d: Buffer): void => {
+        let m: { t?: string; id?: number; ok?: boolean; result?: R; error?: unknown }
+        try {
+          m = JSON.parse(d.toString())
+        } catch {
+          return
+        }
+        if (m.t !== 'res' || m.id !== id) return
+        ws.off('message', onMsg)
+        resolve({ ok: m.ok ?? false, result: m.result as R })
+      }
+      ws.on('message', onMsg)
+      ws.send(JSON.stringify({ t: 'req', id, method, args }))
+    })
+  }
+
+  it('fresh boot + legacy settings.json yields DEFAULT_SHORTCUTS for every action', async () => {
+    const ws = await openWs()
+    try {
+      const { ok, result } = await call<[], Record<string, unknown>>(
+        ws,
+        IPC.settingsLoad,
+        []
+      )
+      expect(ok).toBe(true)
+      // settings:load returns the FULL settings object; its `.shortcuts` was filled by merge.
+      const shortcuts = result.shortcuts as ShortcutMap
+      expect(shortcuts).toBeDefined()
+      // Every default action present, no missing keys.
+      expect(Object.keys(shortcuts).sort()).toEqual(Object.keys(DEFAULT_SHORTCUTS).sort())
+      // Each matches the shipped default (the feature is on by default).
+      for (const [action, combo] of Object.entries(DEFAULT_SHORTCUTS) as [keyof ShortcutMap, string][]) {
+        expect(shortcuts[action]).toBe(combo)
+      }
+      // Top-level + nested legacy fields survive the merge.
+      expect((result as { fontSize?: number }).fontSize).toBe(15)
+      const speech = (result as { speech?: { engine?: string } }).speech
+      expect(speech?.engine).toBe('whisper')
+    } finally {
+      ws.close()
+    }
+  }, 30_000)
+
+  it('rebinding a shortcut persists to disk and reloads', async () => {
+    const ws = await openWs()
+    let savedCombo = ''
+    try {
+      // Rebind the command palette (⌘K default) to Cmd+Shift+P and change nothing else.
+      const { ok } = await call<[Record<string, unknown>], null>(ws, IPC.settingsSave, [
+        {
+          ...DEFAULT_SETTINGS,
+          shortcuts: { ...DEFAULT_SHORTCUTS, commandPalette: 'Cmd+Shift+P' }
+        }
+      ])
+      expect(ok).toBe(true)
+
+      const load = await call<[], { shortcuts: ShortcutMap }>(ws, IPC.settingsLoad, [])
+      expect(load.ok).toBe(true)
+      expect(load.result.shortcuts.commandPalette).toBe('Cmd+Shift+P')
+      // Sibling actions untouched.
+      expect(load.result.shortcuts.newTerminal).toBe(DEFAULT_SHORTCUTS.newTerminal)
+      savedCombo = load.result.shortcuts.commandPalette
+    } finally {
+      ws.close()
+    }
+
+    // Persistence: a NEW connection (fresh session cookie already in hand) reads the file that
+    // the write produced — not a cached in-memory value.
+    const ws2 = await openWs()
+    try {
+      const again = await call<[], { shortcuts: ShortcutMap }>(ws2, IPC.settingsLoad, [])
+      expect(again.ok).toBe(true)
+      expect(again.result.shortcuts.commandPalette).toBe(savedCombo)
+    } finally {
+      ws2.close()
+    }
+
+    // And what mergeSettings wrote to disk literally contains the rebind (file-level check).
+    const onDisk = JSON.parse(fs.readFileSync(path.join(dataDir, 'settings.json'), 'utf-8'))
+    expect(onDisk.shortcuts.commandPalette).toBe('Cmd+Shift+P')
+  }, 30_000)
+})


### PR DESCRIPTION
## What changed

Adds a new **Settings → Shortcuts** section that lets you rebind every hotkey the app ships with. The combos live in a single shared registry (`src/shared/shortcuts.ts`) that seeds `Settings.shortcuts` and drives both the section's capture rows and the ShortcutsPanel (`⌘/`) badge rows — so a rebind applies immediately and the reference panel always reflects it.

Rebindable actions: command palette (`⌘K`), settings (`⌘,`), shortcuts panel (`⌘/`), undo/redo, canvas toggles, new terminal/agent, close node, markdown view, find, commit, copy.

Scope of the change (19 files, +858 / −202):

- `src/shared/shortcuts.ts` (+`shortcuts.test.ts`) — the registry of defaults and the both-branch cross-platform proof.
- New `ShortcutsSection.tsx` (+ test). Extracts the Speech section's capture field into a shared control `src/renderer/components/settings/ShortcutCaptureField.tsx` with `allowChord`/`defaultValue` knobs, so dictation (hold-to-talk) and plain hotkeys share one control. Conflict detection flags a combo mapped to two actions inline.
- Wiring: every dispatch site now reads `settings.shortcuts` through the existing `matchesShortcut` engine instead of hardcoded key checks — `Canvas.tsx` (chords), main-process `⌘M`/`⌘W` intercepts in `src/main/index.ts`, `TerminalNode.tsx` (`⌘F`), `SourceControlPanel.tsx` (commit).
- `src/shared/types.ts` — `Settings.shortcuts` field, seeded in `DEFAULT_SETTINGS` from the registry.
- `src/core/settings-store.ts` — deep-merges `.shortcuts` exactly like `.speech`, so an existing `settings.json` without the new key keeps the shipped defaults (new actions just appear).
- New section registration: `nav.ts`, `SettingsIcons.tsx`, `SettingsPage.tsx`, `nav.test.ts`.

## The fix / design

The existing shared shortcut engine already abstracts platform variance via an `isMac` flag — `Cmd` renders and matches as `⌘`/`metaKey` on macOS and `Ctrl`/`ctrlKey` on Windows/Linux, so one stored combo behaves and displays correctly on every OS. This is the same mechanism the already-shipped dictation chord uses. No new OS-specific code paths were added; each dispatch just passes its `isMac` through the engine.

Dictionary-style conflict detection: if a user binds a combo that already maps to another action, both rows show an inline conflict flag rather than silently overwriting.

## Measured

- typecheck: clean on both `tsconfig.node.json` and `tsconfig.web.json`.
- Full suite green on the rebased tree: **5079 passed / 12 skipped / 0 failed** (the 12 skips are the docker-only SSH tests).
- New tests:
  - `shortcuts.test.ts` round-trips every shipped default through parse → format → match → capture on both the macOS and Windows/Linux branches (pins punctuation combos like `Cmd+,`).
  - `ShortcutsSection.test.tsx` component test (jsdom).
  - `test/server/shortcuts-e2e.test.ts` — a server-level E2E driving a settings round-trip through the real HTTP + WS-RPC stack, including a legacy `settings.json` migration case.
- `npm run build` (electron-vite): ✓.
- Deployed to a running Server Edition and the served bundle manually verified to carry the new section.

## Not in scope

- Mouse gestures remain fixed (not hotkeys).
- Dictation stays in its existing Speech section (it was already configurable; this only extracts the shared capture control, preserving its hold-to-talk shape).
- Live runtime verification was performed on **Linux only** (host + the repo's CI run ubuntu-latest). The both-branch unit test pins the cross-platform logic on macOS and Windows/Linux branches, but true Windows/macOS runtime coverage is left for a future CI matrix — ci.yml currently has no Windows/macOS test job.

## Testing

`npm run typecheck` · `npx vitest` (5079 passed / 12 skipped / 0 failed) · `npm run build`, plus a manual pass on a running Server Edition via the browser.

## References

- The platform-abstracted chord engine (`matchesShortcut` / `formatShortcut`) predates this PR and is the same one the dictation (Speech) setting uses.