### PR TITLE
docs: add CONTRIBUTING.md, and publish CLAUDE.md alongside it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ build/icon.png
 # local publish helper — never exported to the public repo
 /publish.sh
 /kanban-launch.mp4
-/CLAUDE.md
 /agents-tour.mp4
 /unplug-tour.mp4
 /remote-tour.mp4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1729 @@
+# CLAUDE.md
+
+This is the deep-reference for working in this repo: the invariants, why each exists, and the
+measurements behind them. It is loaded automatically by Claude Code.
+
+**Contributors: start with `CONTRIBUTING.md`** — the short version (setup, boundaries, house rules,
+testing habits). This file is what you reach for when you need to know *why* a rule is the way it
+is, or you are changing a subsystem it describes. A change that other developers must know about
+belongs in BOTH (see Conventions).
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+**Node-based terminal manager** (BUSL-1.1, converts to MIT after 4 years — see `LICENSE`): multiple real terminals live on a single
+pan/zoom canvas as draggable nodes. Target users are people with ADHD / disorganized
+workflows who benefit from a spatial layout over stacked tabs. Long-term vision includes
+remote access and paid features — the architecture is built so those slot in without a
+UI rewrite (see Transport abstraction below).
+
+## Commands
+
+```bash
+npm install        # deps + rebuilds node-pty against Electron's ABI (postinstall hook)
+npm run dev        # dev mode with renderer HMR
+npm run build      # production build into out/
+npm start          # preview the production build (electron-vite preview)
+npm run typecheck  # tsc for both node (main/preload) and web (renderer) projects
+npm run rebuild    # re-run electron-rebuild for node-pty if you hit ABI/native errors
+```
+
+**`rebuild` and `postinstall` both run `scripts/patch-node-pty.mjs` first, and that is not
+optional.** node-pty 1.1.0's darwin `pty_posix_spawn` leaks a ptmx device on every SUCCESSFUL spawn
+(an off-by-one in the low-fd cleanup) and master+slave on every FAILED one; on this app's spawn
+churn that exhausts `kern.tty.ptmx_max` within hours, and terminals then simply stop opening. The
+script rewrites `node_modules/node-pty/src/unix/pty.cc` before electron-rebuild compiles it.
+
+`src/main/node-pty-patch.test.ts` asserts the marker is present in those sources, so a node-pty
+upgrade that silently drops the patch fails loudly. **If that test is red, your `node_modules` is
+unpatched, not your code** — run `npm run rebuild`. It deliberately does not measure descriptors
+(that is environment-dependent); it checks the source the native module is built from. Upstream:
+microsoft/node-pty#950 — if the fix lands there, delete the script, its wiring and that test.
+```
+```
+
+`npm test` runs the vitest suite (unit + integration; the remote e2e suites skip when the
+companion server repo isn't checked out). `npm run typecheck` is the fastest correctness gate.
+
+## Process model (Electron, three contexts)
+
+The codebase is split by Electron process boundary — keep code on the correct side:
+
+- **`src/main/`** — Node/Electron main process. The **shell** around `src/core/`: owns
+  Electron/window/IPC wiring, dialogs, and the `CorePlatform` implementation
+  (`platform-electron.ts`). The renderer must never import these.
+- **`src/core/`** — Electron-free service core (pty, workspace/settings stores, git,
+  hook server + hooks cluster, context/subagent tails, transcripts,
+  model-window, license, context-link, and the pure ssh leaves under `src/core/remote-ssh/`
+  — control-master, remote-git). Talks to its shell ONLY via the `CorePlatform` interface
+  (`src/core/platform.ts`); importing `electron` (or `../main/*`) inside `src/core` is
+  forbidden and enforced by `src/core/no-electron.test.ts`. The Electron implementation is
+  `src/main/platform-electron.ts`. This is the seam the Server Edition's `src/server/` shell
+  plugs into.
+- **`src/server/`** — Server Edition shell (Phase 2): plain `node:http` + `ws`
+  serve the built renderer to a browser and speak a WS-RPC protocol
+  (`src/shared/rpc.ts`) that a browser-side `window.nodeTerminal` shim
+  (`src/renderer/bridge/`) consumes. Boots the same core services via
+  `ServerPlatform` (`src/server/platform-server.ts`). Single-user auth
+  (scrypt + httpOnly cookie + Origin check). `npm run server:dev` to try;
+  docs/SERVER.md for details. `src/server` must not import electron or
+  `src/main` (enforced by `src/server/no-electron.test.ts`). **Phase 3a** also
+  serves fs/git/commit handlers (editor/diff/source-control now work in the
+  browser) plus a web folder/file picker (in-app server-directory browser,
+  replacing the native dialog) and WS backpressure; the renderer detects the
+  bridge in `src/renderer/main.tsx` (desktop preload path is untouched).
+  **Phase 3b** boots the loopback **hook server** (`hookServer.start()`) + installs
+  the managed hook scripts, and `wireAgentStatus` (`src/server/agent-status.ts`)
+  broadcasts `agent:status` / `agent:subagent-activity` / `context:update` over the
+  bridge, so agent-status badges, subagent cards, and the context meter now work in the
+  browser (transcript-path jailed against forged POSTs). It also serves the two transcript READ
+  channels (`registerTranscriptIpc` — the ⌘M chat view + the find-bar's transcript index; see the
+  ⌘M bullet under Agent support). Still deferred:
+  **canvas-control** (`agent:control`) is not wired. (The SDK **chat node** — once listed here
+  as deferred — was removed entirely, 2026-07; see the chat-node note in the node-kinds list.)
+- **`src/preload/`** — the only bridge. `index.ts` uses `contextBridge` to expose a
+  narrow API on `window.nodeTerminal` (typed in `index.d.ts`). `contextIsolation` is on,
+  `nodeIntegration` off.
+- **`src/renderer/`** — React UI. Talks to main *only* through `window.nodeTerminal`.
+- **`src/shared/`** — types and IPC channel names imported by all three sides. `ipc.ts`
+  is the single source of truth for channel strings; never hardcode a channel elsewhere.
+
+PTY output flows main → renderer over per-session channels (`pty:data:<sessionId>`),
+input flows renderer → main over `pty:write`. node-pty is kept **external** in the bundle
+(`externalizeDepsPlugin` in `electron.vite.config.ts`) because it's a native module.
+
+## Key abstraction: TerminalTransport
+
+This is the load-bearing design decision. The renderer depends only on the
+`TerminalTransport` interface (`src/renderer/terminal/transport.ts`), never on IPC or
+node-pty directly. The current implementation is `LocalTransport` (IPC → node-pty). A
+future `RemoteTransport` (WebSocket to a remote agent) implements the same interface, so
+remote access / paid tiers can be added without touching the canvas or terminal UI. When
+adding terminal-session features, extend the interface — do not reach around it.
+
+## State & persistence model
+
+**React Flow is the single live source of truth** for nodes. There is intentionally no
+separate store mirroring node state — earlier dual-source designs caused sync bugs.
+`src/renderer/state/workspace.ts` holds only pure helpers: the color palette, the node
+factories (`createTerminalNode`, `createAgentNode(agentId, …)`, `createStickyNode`, `createGroupNode`,
+`createEditorNode`, `createDiffNode`), the group transforms (`groupSelectedNodes`,
+`ungroupNodes`, `duplicateNode`), and the `nodeStatesToFlow` / `flowToNodeStates`
+serializers. Node kinds: `terminal | sticky | group | editor | diff`. A node's `data`
+carries `title, color, group, tags, collapsed, expandedHeight, shell, cwd, text,
+initialCommand, filePath, diffStaged`, `agentId` (which agent CLI a terminal node runs —
+persisted), and `accountId` (which managed Claude account a terminal node runs under — immutable,
+resolved at creation, persisted; see **Managed Claude accounts**). `nodeStatesToFlow` defaults a
+missing `kind` to `terminal` for backward compat and migrates the legacy `tags:['claude']` marker
+to `data.agentId = 'claude'`. The SDK **chat node** was removed (2026-07); `nodeStatesToFlow` also
+migrates a persisted `chat` node into a **sticky tombstone** in place, reading its legacy
+`chatSessionId` to print a `claude --resume <id>` hint (a chat is an ordinary resumable Claude
+session).
+
+Persistence has two layers:
+
+- **Layout + config**: schema v3. `workspace.json` (in `app.getPath('userData')`) is now an
+  **index**: local folder projects are refs to `<cwd>/.nodeterm/project.json` (the source of
+  truth — git-shareable, machine-portable; pretty-printed, portable `./` node cwds, monotonic
+  `rev`), SSH projects are refs to the same file on the server (offline `cache` in the index,
+  reconciled by rev on connect, mirrored via `SshFs` with a 5 s write throttle), cwd-less
+  canvases stay inline. The renderer contract is untouched: `workspace.load()/save()` still
+  speak an assembled v2-shaped `Workspace`; all fan-out lives in `core/workspace-store.ts` +
+  pure `core/workspace-files.ts`. v2 files migrate on first save (backup `workspace.v2.bak`,
+  one-time renderer note). Outside edits (git pull/sync) are detected by
+  `core/workspace-watcher.ts` → silent reload, or a Reload/Keep-mine conflict bar when dirty.
+  Unreadable refs render as greyed **unavailable** tabs (never dropped); corrupt project files
+  are set aside as `project.json.corrupt-<ts>`. "Open folder…" adopts an existing
+  `.nodeterm/project.json` (fresh project id on collision; node ids — tmux names — kept).
+  **SSH mirror safety** (the ".nodeterm reset itself" bug — 12 fresh project ids and 45 orphaned
+  tmux sessions in one field report): remote writes are atomic (`cat > f.tmp && mv`, `sshWriteArgs`);
+  a mirror is never blind-written before the entry has read-compared the server file once
+  (`WorkspaceStore.reconcileSsh` — the single decider; a checked read's `error` ≠ `absent`, and on
+  error it decides NOTHING); cross-lineage conflicts (re-added folder, second machine, git checkout:
+  the server file carries a different project id) are settled by content, not rev alone — an empty
+  side never beats a populated one, adoption re-keys the file to the local project id (node ids =
+  tmux session names are kept so terminals reattach), and a push outbids the losing lineage's rev;
+  a throttled trailing write that drops after its optimistic ack re-owes the mirror
+  (`markUnmirrored`); pending mirrors are flushed before the ControlMasters die at quit; and the
+  SSH dialog **dedupes by endpoint+remoteCwd** (`openSshProject`, same contract as
+  `openFolderProject`) instead of minting a fresh empty project for a folder that already has one.
+- **Live terminal sessions** (tmux): terminals continue where they left off across node
+  remounts *and* full app restarts, including running processes. See below.
+
+`settings.json` is a separate store (`main/settings-store.ts`, `state/settings.ts`).
+
+## Projects (tabs)
+
+Each project is one canvas/page; terminals and notes belong to a project. The `projects`
+zustand store (`renderer/state/projects.ts`) holds project metadata + the *serialized* nodes
+of all projects. **React Flow remains the single live source of truth for the *active*
+project's nodes only.** The contract:
+
+- The active-project effect in `Canvas.tsx` (keyed on `activeProjectId`) loads that project's
+  serialized nodes into React Flow. `loadingRef` suppresses dirty-marking during this load.
+  A real switch applies the project's saved viewport; an **in-place reload**
+  (`reloadActiveProject` — external file change / SSH reconcile) sets `preserveViewportRef` so
+  the load **keeps the user's current camera** — the incoming file's viewport is wherever
+  another machine last saved, and restoring it mid-work teleported the camera (most visibly
+  right after a cross-project sidebar focus, when the connect-time SSH reconcile landed a
+  second after fitView centered the node).
+- **Project order = array order**, and it is ONE order shared by the tab bar and the sessions
+  sidebar (the sidebar no longer hoists the active project to the top). Both surfaces reorder
+  via drag-drop through `reorderProject(draggedId, beforeId|null)` (null = to the end; tab
+  strip empty area and sidebar body are the end-drop zones), persisted like any node reorder.
+  Sidebar collapse behavior is `settings.sidebarAutoCollapse` (default on = historical: a
+  project switch resets manual toggles and collapses inactive projects; off = everything
+  defaults to expanded and switches never touch the user's choices — `isGroupCollapsed`).
+- The bottom-left **canvas lock** freezes the CAMERA only (pan/zoom): nodes stay draggable,
+  resizable and connectable while locked — the point is "stop the map sliding", not "freeze
+  the work".
+- Before any project switch / add / delete, `commitActiveToStore()` serializes the live
+  React Flow nodes back into the store, so nothing is lost. Then disk is written.
+- Switching away unmounts the old project's `TerminalNode`s → their tmux clients detach but
+  the sessions keep running; switching back reattaches. tmux session names are per-node-id
+  (globally unique), so projects never collide.
+- The tab caret menu's **Close project** (`closeProject`) is **non-destructive**: it sets
+  `project.closed = true` (hidden from the tab bar, kept on disk with all nodes) and leaves the
+  tmux sessions running, so closing just detaches like a project switch. Closed projects are
+  reopenable from the **"Recently closed"** list on `WelcomeScreen` (`reopenProject` → restores
+  nodes, which reattach warm or cold-restore). `hasProjects` counts only **open** projects, so
+  closing the last open one shows the welcome screen. **Permanent** deletion (`deleteProject`:
+  `transport.destroy(nodeId)` per terminal + drop agent status + SSH teardown) now only happens
+  via the `×` on a "Recently closed" entry.
+- A project's `cwd` (folder picker, `dialog:select-folder`) is passed to terminal/Claude
+  node factories so new terminals open there. **Folder ↔ project is deduped:** "Open folder…"
+  reuses the existing project with that `cwd` (and its nodes) instead of creating a duplicate.
+
+## Terminal session continuity (tmux)
+
+`src/core/pty-manager.ts` runs each terminal inside a persistent tmux session
+(`tmux new-session -A -D -s nt-<nodeId>`) on a dedicated socket (`-L node-terminal`) with
+a generated config (`-f <userData>/tmux.conf`, so the user's `~/.tmux.conf` never
+interferes; status bar off, **mouse on**, 50k history, `set-clipboard on` + `terminal-features
+",*:clipboard"`, and the copy-mode mouse bindings). Because the tmux *server* outlives the app,
+sessions survive when no client is attached. `src/shared/ssh.ts`'s `remoteTmuxConf` is the same
+config for an SSH project's remote tmux.
+
+**tmux owns the mouse — scrolling, selection, and the alternate screen are all its job.** This is
+the native behavior, and it is deliberate:
+- **The wheel scrolls tmux's own history** (`history-limit`), not the emulator's buffer.
+- **The pane is on the alternate screen** (`\e[?1049h`) — capabilities are NOT blanked — which is
+  what keeps a full-screen TUI's input box *put* instead of scrolling away with the text.
+- **Selection is tmux copy-mode.** A drag copies; apps that request mouse tracking themselves
+  (vim, htop) still get their own mouse events — tmux forwards those regardless.
+
+**Do not take scrolling away from tmux again.** A previous design did exactly that (`mouse off` +
+`terminal-overrides ',*:smcup@:rmcup@:indn@'` to keep tmux on the *normal* screen, so its output
+flowed into xterm's scrollback, which was then hydrated from `tmux capture-pane` on reattach). It
+failed structurally: **tmux is a screen PAINTER, not a stream.** Every redraw (attach, resize,
+refresh) erases and repaints, so blank and duplicated rows leaked into the emulator's scrollback —
+users saw black bands and duplicated screens when scrolling up — and the pane stopped behaving
+natively. The hydration that design needed is gone (see the reattach seeding below).
+
+**Copy → the system clipboard, via OSC 52.** `set-clipboard on` **plus** `set -as terminal-features
+",*:clipboard"`: on copy, tmux emits OSC 52 to the attached client, and the renderer's OSC 52
+handler (`TerminalNode.tsx`, `parseOsc52`) writes the system clipboard. Two traps, both measured on
+tmux 3.4:
+- **The `terminal-overrides ',xterm*:Ms=…'` entry does NOT work on tmux 3.2+** — with it, a copy
+  emitted **zero** OSC 52 to the client. `terminal-features` is what actually enables the sequence.
+  Do not "fix" the `Ms=` override back; it is why copying from SSH sessions never worked.
+- **No `pbcopy` pipe.** The copy-mode bindings are bare `copy-pipe-and-cancel` (no command): piping
+  to `pbcopy` was macOS-only, and over SSH it would have copied on the *remote* host anyway. OSC 52
+  is cross-platform and works over SSH.
+
+**A tmux client is not necessarily a watcher.** `SessionInfo.clients` is a COUNT
+(`#{session_attached}`), never a boolean, because one session can hold several: the app's painter,
+the user's own `tmux -L node-terminal attach`, a second nodeterm on the same socket, and our own
+**control-mode shadows** (`PtyManager.shadowAttach`, used for background writes without spawning a
+painter). The session reaper subtracts ours via the `shadowed` seam — a shadow is a real client but
+not a watcher, so a shadowed session must stay exactly as cullable as an idle detached one.
+
+The count is carried numerically rather than collapsed at parse time **because the subtraction
+needs it**: a session holding our shadow AND a real client must still read as attached, and a
+boolean could only be forced to false — reaping the session out from under whoever that other
+client belongs to. **Any future reader of `list-clients` / `session_attached` owes the same
+subtraction.**
+
+Lifecycle, by intent:
+- **Offscreen release (in place, 2026-08-11)** → a mounted node fully offscreen past
+  `settings.offscreenTerminalMinutes` detaches its PTY client and disposes its xterm without
+  unmounting (plate shown; tmux keeps running; reattach-redraw on approach, measured <500 ms).
+  See the Terminal node lifecycle section for the two invariants (mount-stable observer;
+  `session.source` remote gate). Note the released node is a DETACHED tmux session — it joins
+  the session reaper's candidate pool (6 h grace still protects it).
+- **Every memory lever must ask whether the kill ends live work** (`terminal/live-work.ts`). The
+  renderer reclaims terminal memory in FOUR places — park window expiry, the park's LRU cap, the
+  memory-pressure drop (all three in `park-budget.ts`) and the offscreen viewer release
+  (`offscreen-policy.ts`) — and all four were written as if dropping a PTY client were free,
+  because "the tmux session keeps running and re-attach redraws". **That sentence is only true
+  where tmux is actually underneath.** On the plain-shell fallback (no tmux installed, tmux
+  switched off in settings, or an install path `findTmux` missed) the pty IS the shell, so the
+  identical call kills it and everything under it — an agent CLI mid-turn included. Issue #126: a
+  project switch terminated a working Claude agent, which then auto-resumed from wherever the kill
+  landed. The predicate is deliberately the narrowest one that closes it — a tmux-backed session is
+  never protected (the kill costs a redraw), and neither is a plain terminal, a finished agent or
+  an unknown state (nothing is running to lose). **A fifth lever owes the same gate.**
+- **Node unmount (project switch)** → the RENDERER **parks** the terminal (`TerminalNode.tsx`
+  `parkedTerminals`): the xterm instance + its attached PTY stay alive with the `.xterm` element
+  detached from the DOM, so a remount within `TERM_PARK_MS` (5 min) re-adopts them — instant, and
+  exact (the tmux client never detaches, so mouse-tracking/alternate-screen modes and scrollback
+  carry over; do NOT "optimize" this into a respawn+redraw — a fresh xterm on a reused client
+  misses the attach-time mode sequences and breaks scrolling). The park timer then runs the real
+  teardown: `kill()` detaches the PTY client; the tmux session keeps running. WebGL contexts are
+  **viewport-scoped and budgeted** (browsers cap ~16 live contexts, and a canvas holds far more
+  terminals). A per-terminal `IntersectionObserver` (`rootMargin` pre-announces approach) only
+  REPORTS visibility to a **module-level budget coordinator** (`terminal/webgl-budget.ts`) that owns
+  every grant decision and all timing: it keeps the contexts WE hold at/under the live budget
+  (`WEBGL_BUDGET` 12 default — the browser Server Edition; on DESKTOP main raises Chromium's cap
+  itself via `--max-active-webgl-contexts` = 32 and boot raises the budget to 24 via
+  `setWebglBudget`, constants in `src/shared/webgl.ts`) so
+  the browser never has to **force-evict** — which is the bug that flashed Chromium's dead
+  "lost context" placeholder (white box + sad-face) on a visible terminal during a fast pan / zoom
+  out, because the old per-node observers each acquired independently and momentarily overshot the
+  cap. Rules: a client granted only after an **acquire debounce** (`WEBGL_ACQUIRE_DEBOUNCE_MS`, so a
+  pan-through never grabs a context for a two-frame flash); if granting would exceed the budget,
+  **reclaim on demand from the least-recently-visible HIDDEN holder** (bypassing its release delay);
+  if every holder is currently visible (zoomed way out), the newcomer is NOT granted and **stays on
+  the DOM renderer** — we never push past the budget. A hidden holder keeps its context for
+  `WEBGL_RELEASE_DELAY_MS` (warm for a pan-back) but is the first reclaim candidate. `acquire()`
+  returning false (WebGL2 unavailable) doesn't burn a slot; an externally-lost context
+  (`onContextLoss`) is reported via `handle.contextLost()`, drops from the accounting, and — for a
+  still-VISIBLE client — schedules ONE delayed budget-gated re-grant (sleep/wake GPU resets lose
+  every context at once with no visibility change; without this every woken terminal sat on the
+  DOM renderer until panned out and back). The NODE still never re-acquires itself (that loop is
+  the eviction fight the design fears): the retry goes through `tryGrant` — never exceeds the
+  budget, never reclaims a visible holder — and stops after `WEBGL_LOSS_STREAK_MAX` consecutive
+  losses (visibility transition resets). The node registers via `registerWebglClient` on mount
+  and `handle.dispose()`s on unmount (which releases + cancels timers). A parked terminal is
+  off-screen so it holds no context. Permanent-delete paths call `disposeTerminalOnUnmount(id)` so a
+  deleted node disposes instead of parking.
+  **Which renderer a terminal uses** is `settings.terminalGpuRendering`, resolved by the single
+  resolver `resolveTerminalRenderer(value, isMac)` (`src/shared/webgl.ts`) to `dom | webgl | shared`:
+  `'off'` = xterm's DOM renderer, `'on'` = one budgeted WebGL context per terminal (everything the
+  paragraph above describes), `'shared'` = **glyphgrid**, ONE canvas-wide WebGL2 context every
+  terminal paints into (`src/renderer/glyphgrid/`, reached through `terminal/glyphgrid-attach.ts`;
+  the per-terminal budget is OFF in this mode). `'auto'` (the default, and what legacy/unknown values
+  fall back to) = **`shared` on macOS, `webgl` everywhere else**. macOS used to resolve to `dom`
+  because many simultaneous WebGL canvases made its compositor flicker the window or composite
+  terminals black with no JS-visible error; one context does not create that pressure, and the
+  shared renderer was promoted on 2026-08-05 after the full device checklist plus a ≥30-minute soak
+  (`docs/superpowers/plans/2026-08-03-phase1b-device-checklist.md`) — it is **no longer experimental**,
+  and it falls back to the DOM renderer on failure. Non-macOS is deliberately not promoted (no such
+  reports there, so no evidence to move it). The four-way setting stays as the escape hatch.
+- **Window close / app quit** → clients detach (`PtyManager.killAll()`); the tmux session keeps
+  running. `killAll()` deliberately does NOT kill sessions.
+- **Node reopen / app relaunch** (nothing parked) → a new PTY attaches to the same
+  `nt-<nodeId>` session and tmux redraws current state.
+- **User clicks ×** → `destroy(persistKey)` runs `tmux kill-session`, permanently ending it. For a
+  REMOTE node it kills the remote session **and then the local one of the same name** — normally a
+  no-op, but it reaps the orphan the pre-`requireRemote` local fallback below could leave behind.
+- **A remote node is NEVER spawned locally** (`PtyCreateOptions.requireRemote`). `sshRemote` says
+  "here is the master to run over"; `requireRemote` says "and if there isn't one, spawn NOTHING".
+  Without it, a create with no `sshRemote` falls through to core's local tmux/plain-shell branches
+  — which is how an SSH project's terminal opened while the ControlMaster was down (no network,
+  host unreachable, `ssh` missing) quietly became a LOCAL shell in the local `$HOME`: same node id,
+  same `SSH user@host` header chip, the REMOTE session's scrollback snapshot replayed into it, and
+  — for an agent node — a cold-restore `claude --resume <remote session id>` running on the wrong
+  machine under the local account, leaving an orphaned local `nt-<id>` behind. Refused on both
+  sides: the renderer never calls `create` when `resolveSshRemote` came back empty
+  (`CoState.offline` + the node's Reconnect button), and core refuses in `spawnNew`
+  (`PtyCreateResult.unavailable`) so a master that dies inside the round-trip can't sneak through.
+  The refusal is **only** in `spawnNew` — a co-attach JOIN to a live session for that node id is
+  still correct. An offline node reports itself to `SshReconnector`, so the canvas heals itself;
+  `retryNow` (banner Reconnect / node Reconnect) skips the backoff and clears the refuse window.
+- **"Restart agent (resume)"** → deliberately NOT a session lifecycle event: `terminal/
+  agent-restart.ts` restarts the agent CLI *inside* the pane and leaves the PTY, the tmux session
+  and its scrollback untouched. It exists for **new-model pickup** — a freshly released model only
+  shows up in a CLI's model list on a fresh launch, and doing that by hand means closing and
+  re-resuming every agent node on the canvas. Choreography: write the CLI's own exit line (`/exit`
+  for claude, `/quit` for codex — that table is also the gate, an agent not in it can never be
+  restarted in place), poll `pty:pane-command` (`#{pane_current_command}`, local tmux socket or the
+  project's SSH ControlMaster; any failure reads as "not a shell yet") every `RESTART_POLL_MS`
+  (250 ms) until a SHELL owns the pane, then echo-deliver `resumeCommand(...)` — the same
+  `claude --resume` / `codex resume` the cold restore uses. **Nothing is ever killed**: if the CLI
+  has not quit within `RESTART_EXIT_TIMEOUT_MS` (6 s) the run reports `exit-timeout` and leaves the
+  session running. A `working` **or `blocked`** session is refused — `/exit` typed into a
+  permission prompt would ANSWER it, not quit — and a node is held one-restart-at-a-time until the
+  resume line has actually LEFT the pane (an un-submitted line is where a second `/exit` would be
+  spliced in). The bulk action runs the same per-node closure sequentially over every idle agent
+  node in canvas order and reports one summary line. `performRestartResume` is now a COMPOSITION of
+  `performExitPhase` + `performResumePhase` (2026-08-12, behavior-pinned split) — hibernation
+  drives the halves separately; each half refuses independently.
+- **Agent hibernation ("Eco", 2026-08-12, OPT-IN default off)** → `settings.agentHibernationEnabled`
+  (+ `agentHibernationIdleMinutes`, default 30; Settings → Agents): a 60 s renderer sweep
+  (`Canvas`) exits the CLI of up to **2** agent nodes per pass that are hook-idle in state `done`,
+  fully offscreen (`isNodeWatched` — an open kanban card modal counts as watched), local, idle ≥
+  window, non-recurring, without live subagents (`planHibernation` +
+  `lib/hibernationCandidates.ts`, both pure/tested). tmux + shell survive; node shows a clickable
+  SLEEPING chip; wake (view / chip / modal open) verifies a SHELL owns the pane
+  (`isShellCommand` OR the persisted `hibernatedPane` the exit settled on — nu/pwsh users) before
+  the KILL_LINE'd, echo-verified `withPermissionMode(resumeCommand(...))`. Sweep/wake/menu-restart
+  share ONE `guardConcurrentRestart` set. Load-bearing rules a refactor must not undo:
+  (1) **recurring fact is durable** — both loop-card dismiss surfaces route through
+  `lib/loopCard.ts`, which HIDES a cron/schedule card but retains `agentStatus.loop`
+  (`dismissed: true`); clearing it would let Eco `/exit` a CLI whose cron wakeup lives in that
+  process. (2) **Fire-time re-asks**: still-offscreen, remote, eligibility — a plan-time verdict
+  is stale by seconds. (3) `hibernated` **self-heals** on live hook states + SessionStart (never
+  on `done` — a late Stop POST must not undo a just-performed hibernate); cold restore (`fresh`)
+  clears it and lets the normal auto-resume own the node. (4) **Ordering with offscreen release**:
+  Eco defers the Phase-2 viewer release until the node hibernates (hard cap idle+offscreen), but
+  ONLY when the idle clock is known (`idleKnown` — `lastEventAt` is transient, so after an app
+  restart nothing can hibernate and deferring would make Eco a memory regression). Eco is
+  structurally inert for sessions with no turn in the current app run — documented follow-up.
+  Device checklist (8 items) in PR #130 — owed before recommending Eco to anyone.
+
+The node id is the `persistKey` (passed to `transport.create`), so it must stay stable.
+If tmux is unavailable, `PtyManager` falls back to a plain shell (no cross-restart
+continuity). `findTmux()` resolves an absolute path because GUI apps don't inherit the
+shell PATH, and it tries three sources **in this order: fixed system paths → the shell's
+PATH → the tmux the macOS app SHIPS** (`bundledTmuxPath`). System first is deliberate — a
+machine that already has tmux keeps using its own, so the bundled copy is a floor, never an
+override. `resourcesPath` is `undefined` on the **Server Edition**, so the bundled binary is
+unreachable there by construction; a Linux host is expected to have its own. Under
+`electron-vite dev` the last candidate resolves against `process.cwd()`, which is where
+`scripts/build-tmux.mjs` writes its artifact. If tmux is unavailable from all three,
+`PtyManager` still falls back to a plain shell; `TMUX`/`TMUX_PANE` are stripped from the child env to avoid nesting refusal.
+
+### Cold restore (machine reboot)
+
+tmux only survives an **app** restart — a **machine reboot kills the tmux server**, so every
+`nt-<nodeId>` session is gone. To bridge that, `create()` returns `PtyCreateResult` with a
+`fresh` flag: it runs `tmux has-session` *before* spawning, so `fresh=false` means a warm
+reattach (tmux redraws) and `fresh=true` means a cold start (first open OR post-reboot). On a
+cold start the renderer (`TerminalNode.tsx`) reconstructs state instead of relying on the dead
+session (you can't keep a live OS process across a reboot):
+- **Scrollback replay** — `main/scrollback-store.ts` keeps a byte-capped (`256 KB`) snapshot of
+  each tmux session's recent output under `<userData>/terminal-scrollback/`, refreshed on a
+  timer (`SCROLLBACK_SNAPSHOT_MS`) + on detach/quit (`tmux capture-pane -e`). On a cold start the
+  renderer reads it via `pty.readScrollback` and writes it back into xterm (with a "session
+  restored" separator). Warm reattach skips it (tmux already redraws). Deleted with the node in
+  `destroySession`.
+- **Agent resume** — on a cold start of a node whose `agentId` is in `RESUMABLE_AGENTS`, the
+  renderer re-launches the agent CLI: `resumeCommand(agentId, sessionId)` (from the session id
+  persisted in `agentStatus` localStorage — `claude --resume`, `codex resume`, `gemini
+  --resume`) when known, else the bare `launchCmd`. The one-shot `data.initialCommand` still wins
+  on the very first open, so the agent is never double-launched.
+
+### Seeding a fresh xterm (`attachReplay` / `seedPaint` in `terminal/terminal-config.ts`)
+
+A newly mounted xterm is empty. Since tmux paints its own client, there is usually **nothing to
+seed** — the cases are:
+- **`none`** — the terminal was **parked** (its buffer is still live and correct), or it is a
+  brand-new node with an `initialCommand`. Seeding either would duplicate content.
+- **`cold-snapshot`** (`fresh` — reboot/first open) — the tmux session is genuinely gone, so replay
+  the persisted `scrollback-store` snapshot, with a "session restored" separator.
+- **`warm-attach`** (`!fresh` — app restart, tmux still alive) — **seed nothing.** tmux is attached
+  to this client: it redraws the visible screen and owns the history under the wheel. This is where
+  a `warm-history` hydration (`transport.captureHistory` → `tmux capture-pane`) used to run; it was
+  **removed**, because writing into a buffer that tmux then repaints is what produced the black
+  bands and duplicated screens. The single exception is a **co-attach joiner** (`seedPaint` →
+  `create-screen`): tmux only repaints on SIGWINCH, so a joiner that did not resize never gets a
+  redraw, and the screen captured server-side inside `create()` (`PtyCreateResult.screen`) is the
+  only thing that paints it — see docs/team-presence.md. **A co-attach joiner also misses tmux's
+  MOUSE-TRACKING modes** (`?1000h/?1002h/?1006h`): tmux emits them only at its OWN attach, and
+  neither the `screen` capture (`capture-pane` carries no private modes) nor a SIGWINCH redraw
+  re-sends them — so the joiner's wheel can't scroll tmux history until a keystroke makes the app
+  re-request mouse. `join()` therefore sets `PtyCreateResult.coAttachMouse` for tmux-backed joins
+  (gated on `persistKey`, on BOTH the screen and resize branches) and the renderer writes
+  `CO_ATTACH_MOUSE_SEQ` into the fresh xterm (both `ModalTerminal` and `TerminalNode`). tmux is
+  always `mouse on`, so this matches its invariant client state; the enable is idempotent. Was the
+  "can't scroll the kanban card-modal terminal until you press a key" bug.
+
+xterm's own `scrollback` (`xtermScrollback(settings.tmuxScrollback)`, floored at 1000, capped at
+`XTERM_SCROLLBACK_MAX` = 10000) is kept for the sessions tmux does *not* back (a plain shell when
+tmux is unavailable) and for the cold-snapshot replay — it is not what the user scrolls in a tmux
+session.
+
+## Terminal node lifecycle (gotchas)
+
+`src/renderer/nodes/TerminalNode.tsx` is the trickiest file:
+
+- The xterm instance + PTY session are created once in a `useEffect(…, [data.respawnNonce,
+  offscreenEpoch])` and torn down on unmount. The component persists across re-renders because
+  React Flow keys nodes by `id` — never change a node's id, or you'll respawn its terminal.
+  **Third in-place state — "released" (2026-08-11, offscreen dispose):** a node fully offscreen
+  in the canvas viewport for `settings.offscreenTerminalMinutes` (default 10, `0` = never;
+  Settings → tmux) has its xterm + PTY client torn down IN PLACE — node stays mounted showing a
+  plate, tmux session untouched — and revives (warm reattach) when it re-approaches the viewport.
+  Pure policy: `terminal/offscreen-policy.ts`. Two load-bearing rules a refactor must not undo:
+  (1) the **visibility IntersectionObserver lives in its own mount-stable `[termKey]` effect**,
+  NOT the lifecycle effect — the down transition re-runs the lifecycle effect, and an observer
+  owned there dies with it, making revive unreachable (permanent plate; caught in review). The
+  lifecycle run publishes to it through refs (`visibilityReportRef`, `offscreenLiveRef`,
+  identity-checked on clear). (2) The remote exclusion asks `offscreenCoreIsRemote(session.source)`
+  (`'local'` only is eligible — relay/server tabs excluded), NOT `data.remote`, **a field nothing
+  sets on node data** (a gate on it was constant false and type-invisible; pinned by tests).
+  SSH-project nodes are also excluded; collapsed = hidden (same convention as the WebGL budget);
+  a `respawnNonce` bump while released revives first. Agent-status/fan-out clears live in a
+  dedicated unmount-only effect (a release or respawn must not blank a live badge).
+- **React StrictMode is deliberately not used** (`main.tsx`) — double-mount would spawn
+  two PTYs per node.
+- The xterm container is `nodrag nowheel`; a transparent **hover-guard** overlay sits on top
+  until you dwell `settings.panHoverDelay` (so quick drag = move node, scroll = pan). After
+  the dwell the guard is removed and xterm takes input. The header stays draggable.
+- A `ResizeObserver` drives `FitAddon.fit()` + `transport.resize`. Canvas zoom is a CSS
+  transform, so it does *not* change `clientWidth` — cols/rows stay stable across zoom.
+  `scale-fix.ts` patches xterm's mouse coords so text selection stays aligned when zoomed.
+
+## Node kinds (all rendered by React Flow custom nodes)
+
+- **terminal** (`TerminalNode.tsx`) — xterm + tmux (see above). Header: collapse, color,
+  click-to-rename title, ✦ AI-name, ×. Body has a **hover guard** overlay: dwell
+  `settings.panHoverDelay` (default 600 ms) before the terminal takes focus — before that,
+  drag = move node, scroll = pan canvas. **Cmd/Ctrl+M** (while hovered) toggles a markdown
+  render of the captured output. Tag chips via `NodeTags`.
+  **Selection + copy is tmux's** (its mouse is on — see the tmux section): drag to select, wheel to
+  scroll tmux's history. A drag copies via copy-mode, and tmux emits **OSC 52** to the client, whose
+  handler writes the **system clipboard** — the one copy path on every platform *and* over SSH (no
+  `pbcopy`). OSC 52 writes an app emits itself (vim `"+y`, gh, yazi) reach the clipboard through the
+  same handler (write-only — a read query is refused). The emulator's own copy chords stay for a
+  selection xterm *does* own (`copyKeyAction`/`isCopyShortcut`): **Cmd+C** (mac), **Ctrl+Shift+C**
+  and **Ctrl+Insert** (Linux/Windows) — matched on `e.key` *or* the physical `KeyC`, so non-Latin
+  layouts still copy. A copy chord is **always swallowed**, selection or not: letting Ctrl+Shift+C
+  fall through would reach the pty as `\x03` (SIGINT). Ctrl+Insert exists because Chromium reserves
+  Ctrl+Shift+C for the inspector and a page cannot `preventDefault()` it — which is where Server
+  Edition users land. Plain **Ctrl+C** is never intercepted. To select in **xterm** instead of tmux
+  (or inside an app that grabs the mouse, like vim/htop), hold **Option** (mac —
+  xterm's `macOptionClickForcesSelection`) or **Shift** (Linux/Windows) while dragging.
+  **Copying now says so**: the OSC 52 handler floats a transient `Copied N lines` pill over the
+  terminal's BOTTOM-RIGHT corner (`.term-copy-pill`, the same class on the canvas node and the
+  kanban card modal — one session seen twice must not speak in two voices; bottom-right because
+  every agent CLI writes its input line bottom-left, and `pointer-events: none` because it sits on
+  the terminal and fires on every copy), because tmux's `copy-pipe-and-cancel`
+  clears the highlight at the exact instant it copies — which read as "the copy failed" to a user
+  whose other pane ran claude. And a drag that produced NEITHER an OSC 52 nor an xterm selection
+  means the pane's app captured the mouse (claude does, codex does not), so a one-time
+  `Hold ⌥ to select text` hint fires instead (`nodeterm.seenSelectHint`). **The whole layer is
+  OFF for an agent in `SELF_REPORTS_COPY` (`reportsOwnCopy` — claude, which prints its own
+  "copied N chars to tmux buffer" line): a second message for one gesture is noise, and a claude
+  terminal is byte-identical to before the feature. **One owner per pill:**
+  the `copied` receipt is raised ONLY by the OSC 52 path, the hint ONLY by the drag path — the two
+  never race for the same slot. The emulator's own copy **chord** (Cmd+C / Ctrl+Shift+C) deliberately
+  raises nothing: Claude Code prints its own copy line ("copied N chars to tmux buffer"), and a
+  second message for one gesture is noise. Decision logic is the pure `terminal/copy-feedback.ts`;
+  `useCopyFeedback` is the glue (it also yields to a clipboard-failure `nodeterm:toast`, so the
+  Server Edition never shows a green receipt beside a red banner), and the node publishes its sink
+  through the module-level `copySubs` map because the OSC handler survives a park.
+  **Shift+Enter** is remapped to `\x1b\r` (ESC+CR / M-Enter) so agent CLIs insert a newline
+  instead of submitting (`terminalKeyAction` / `SHIFT_ENTER_SEQ` in `terminal-config.ts`; sent in
+  all terminals — harmless in a plain shell). **Cmd (mac) / Ctrl+click** opens links in the
+  output: URLs → default browser (`@xterm/addon-web-links`), file paths → editor node and
+  directories → Explorer reveal (`terminal/file-links.ts`, existence-verified against the project
+  fs via cached parent-dir listings, with `path:line[:col]` compiler-output suffixes; relay-remote
+  nodes have no client fs so they are URL-only).
+- **Agent** (`createAgentNode(agentId, …)`) — a terminal preset that runs an agent CLI as its
+  `initialCommand` (runs once on open via `transport.write`, then cleared), with `data.agentId`
+  set. Builtins (`claude`/`codex`/`gemini`) come from `AGENT_CONFIG` (clay color etc.).
+  Agent nodes get extra behavior **gated by the
+  agent's capabilities** (see **Agent support** below): a busy/working badge + unread dot +
+  completion notification + session-name chip (hook-capable agents), content search, and the
+  Claude-only **Branch conversation** action. Custom user-defined agents spawn + show
+  process/terminal-title status only.
+- **sticky** (`StickyNode.tsx`) — colored note, free text, collapsible. Has link handles:
+  connect a sticky to any terminal node to attach the note as context (see Context Link).
+- **group** (`GroupNode.tsx`) — real React Flow parent/child frame; `groupSelectedNodes`
+  reparents children (`parentId` + `extent:'parent'`, relative positions), `ungroupNodes`
+  restores absolute. `nodeStatesToFlow` sorts parents first (React Flow requirement).
+  Visually: a dashed rounded frame in the group color with a floating label pill (color dot
+  + editable name) on the top border and ungroup/× top-right (on hover/selected). The
+  `NodeResizer` line is hidden (`lineStyle` transparent) so it can't draw a sharp-cornered
+  box; the selection ring is a `box-shadow` instead, which follows the same `border-radius`.
+- **editor** (`EditorNode.tsx`) — Monaco code editor for a `filePath`; reads/writes via
+  `fs:read`/`fs:write`, auto-detects language from the path, ⌘S saves, dirty dot. A
+  **Preview / Edit** toggle (or ⌘M while hovered) renders the live content as markdown.
+  **Image files** (png/jpg/gif/webp/bmp/ico/svg/avif) skip Monaco and show an `<img>`
+  preview instead — read as base64 via `fs:read-binary` into a `data:` URL (CSP allows
+  `img-src data:`), on a checkerboard backdrop with the pixel dimensions in the header.
+- **diff** (`DiffNode.tsx`) — Monaco diff editor; `diffStaged` chooses HEAD↔index (staged)
+  vs index↔working (unstaged) via `git:show-file` + `fs:read`. Read-only.
+- **chat** — **REMOVED 2026-07.** The SDK-driven Claude chat node (`ChatNode.tsx`, `main/chat-driver.ts`,
+  the `@anthropic-ai/claude-agent-sdk` dependency, and the whole chat-events/chatSessions stack) is
+  gone — dropping the bundled SDK also removed a ~240 MB native binary per platform. A persisted `chat`
+  node is migrated by `nodeStatesToFlow` into a **sticky tombstone** in place, carrying a
+  `claude --resume <chatSessionId>` hint so the conversation continues in any terminal (a chat was an
+  ordinary resumable Claude session). `CHAT_CAPABLE` / `canChat` survive but now gate **only** the
+  ⌘M **ChatPanel** transcript view on a Claude *terminal* node (see the terminal bullet's Cmd/Ctrl+M),
+  not any SDK chat node.
+
+Monaco is wired in `renderer/editor/monaco-setup.ts` (language workers bundled via Vite
+`?worker` — no CDN; CSP `worker-src` allows them). Markdown rendering is shared in
+`renderer/lib/markdown.ts` (`marked` + DOMPurify sanitize).
+
+## Agent support (Claude / Codex / Gemini / opencode / Grok / custom)
+
+The app is a pluggable multi-agent system: Claude Code is one builtin of
+several. Extra terminal-node behavior is driven per agent by a registry + capability lists, a
+shared 4-state model, and a **transient** zustand store `state/agentStatus.ts`
+(`{state, agentId, unread, session, sessionId, loop}` per node id; the live `state` is **not**
+persisted — only `unread`/`session`/`sessionId` go to localStorage under
+`nodeterm.agentStatus`, migrated once from the legacy `nodeterm.claudeStatus` key).
+
+- **Agent registry + capabilities** — `src/shared/agents/config.ts` holds `AGENT_CONFIG`
+  (claude/codex/gemini/opencode/grok: id, label, spawn command, color, `promptInjectionMode`, …) keyed
+  by an **open** `AgentId`
+  type (so custom ids fit). Capabilities are membership lists, not flags:
+  `AGENT_HOOK_TARGETS`, `RESUMABLE_AGENTS`, `SUBAGENT_CAPABLE`, `RECURRING_CAPABLE`,
+  `BRANCH_CAPABLE`, `CONTEXT_LINK_CAPABLE`, `USAGE_CAPABLE`, `CHAT_CAPABLE`,
+  `TRANSFER_SOURCE_CAPABLE`, `RENAME_CAPABLE`, `TITLE_READ_CAPABLE`, `CANVAS_CONTROL_CAPABLE`,
+  `PERMISSION_MODE_CAPABLE`, with helpers (`hasHooks`,
+  `canBranch`, `canContextLink`, `canChat`, `canRename`, `canReadTitle`, `hasPermissionMode`, …).
+  Branch and the ⌘M **ChatPanel** transcript view (`CHAT_CAPABLE` / `canChat` — since the SDK chat
+  node was removed, 2026-07, this is all `canChat` now gates) stay **Claude-only** purely by
+  being in only `BRANCH_CAPABLE` / `CHAT_CAPABLE`. The other lists span more agents, and the
+  memberships below are the ones to check before assuming "claude-only" (all verified against
+  `config.ts`, 2026-08-09): the per-node **context meter** is `USAGE_CAPABLE = claude/codex/gemini`;
+  the **permission mode** is `PERMISSION_MODE_CAPABLE = claude/grok/gemini/codex`; the session-name
+  sync is **split in two** — `TITLE_READ_CAPABLE = claude/grok/gemini` (read) ⊇ `RENAME_CAPABLE =
+  claude/grok` (write), because gemini names its own sessions but has no rename command;
+  **Context Link** spans four builtins
+  (`CONTEXT_LINK_CAPABLE = claude/codex/gemini/opencode`, NOT grok). UI gates
+  on these helpers — no hardcoded `=== 'claude'`. **Custom agents** (user-defined in Settings, `customAgents`) are in
+  no capability list: spawn + terminal-title + process status only. Per-agent write-ups:
+  **`docs/grok-agent.md`**, **`docs/gemini-agent.md`** (there is none for codex — its approval mapping
+  and every value's reasoning live in `src/shared/agents/approval-mode.ts`);
+  the distilled rules are **Adding a new agent** at the end of this section.
+- **Grok** (`@xai-official/grok` 1.0.0, builtin since 2026-08) — in `AGENT_HOOK_TARGETS`,
+  `RESUMABLE_AGENTS`, `RENAME_CAPABLE`, `PERMISSION_MODE_CAPABLE` and `CANVAS_CONTROL_CAPABLE`; NOT in
+  `USAGE_CAPABLE` / `CONTEXT_LINK_CAPABLE` / `SUBAGENT_CAPABLE` (each blocked on a fixture that needs a
+  logged-in grok session — the context meter, context links and subagent cards are **not implemented**
+  for grok). Its hook config is a **directory** (`$GROK_HOME/hooks/*.json`, all merged), so nodeterm
+  **owns one file outright** (`nodeterm-status.json`) instead of merging into a shared settings file —
+  which is also why a malformed copy of it is *healed* rather than preserved, locally and on an SSH
+  host (`RemoteHooks.installGrokRemote`, under the host's own `$GROK_HOME`). Its dialect is
+  **camelCase keys with snake_case event VALUES** (`{"hookEventName":"pre_tool_use"}`) — the SDK path
+  flips the keys to snake_case, so `normalizeGrok` canonicalizes the event name and reads every field
+  twice, and the shells share one decoder (`grokRawFields`). It carries **no `transcript_path`**, so a
+  session directory is DERIVED from `cwd` + `sessionId` (`core/agents/grok-paths.ts`, the one
+  `$GROK_HOME` rule — `core/usage/grok-usage.ts` delegates to it) and remembered in the shells' raw
+  listener; the name read is `core/grok-session.ts` over `summary.json`, routed per agent by
+  `core/agent-session-name.ts`. **The tool-event `matcher` is a regex: `.*`, never `*`** — a bare `*`
+  is invalid and silently stops tool events firing (hence `ManagedHookEvent`). Grok also reads
+  **`~/.claude/skills`** (Claude compat), which is why canvas control needed no new installer, and
+  **`~/.claude/settings.json`**, so every grok event ALSO fires nodeterm's claude hook — an **inert**
+  cross-fire (`normalizeClaude` finds neither grok's camelCase keys nor, in the SDK dialect, its
+  lowercase event values), pinned by tests; canonicalizing claude's event-name compare would make it
+  harmful. The `auto` permission-mode **version gate is claude's alone** (it is fed by a `claude
+  --version` probe), and grok's mode flag must go **BEFORE** its `--` separator, which is
+  end-of-options. Full picture, dialect traps and the device checklist: **`docs/grok-agent.md`**.
+- **Gemini + codex parity** (2026-08-09) — brought both up to grok's level in the lists above. Unlike
+  grok, **both CLIs are installed** and gemini **ships its own hook reference**
+  (`/usr/lib/node_modules/@google/gemini-cli/bundle/docs/hooks/reference.md`), so almost every fact is
+  measured. The load-bearing ones:
+  - **Gemini's envelope IS claude-shaped** — `session_id`/`transcript_path`/`cwd`/`hook_event_name`
+    (`reference.md:46-58`), the exact opposite of grok's missing `transcript_path`, so the shells just
+    jail the path they are handed. The **event names** are gemini's own: eleven exist, `GEMINI_HOOK_EVENTS`
+    subscribes **seven**. `AfterModel` is excluded because it fires **per streamed chunk**
+    (`reference.md:236`) = one hook process per chunk; `BeforeModel` is **not** per-chunk (it fires once
+    per request) and is excluded only because it reports nothing we render.
+  - **`Notification` → `blocked`, matched as a CLOSED set** (`notification_type === 'ToolPermission'`).
+    Before this, a gemini node sat on RUNNING while it waited for a permission answer. The closed match
+    is measured, not cautious: gemini's `NotificationType` enum has exactly ONE member, and it fires
+    only after `shouldConfirmExecute` returns details — i.e. only for a real dialog, so an
+    auto-approved/`yolo` call fires nothing. **Grok's `includes('permission')` strobed on every tool
+    call**; widening this "to be safe" is the unsafe direction.
+  - **Context meter from each agent's own transcript** — one tail per agent, each with its own `parse`
+    dep on `createContextTail` (`core/gemini-session.ts`, `core/codex-session.ts`), in **both** shells.
+    Gemini: `tokens.input` and a window from `geminiWindowFor`, which mirrors the CLI's own
+    `tokenLimit()` — a **family rule with a 1M catch-all default**, so an unknown model gets the right
+    answer instead of a confident wrong denominator. Codex: `last_token_usage.input_tokens` and its own
+    stated `model_context_window`. Two traps: `total_token_usage` is **CUMULATIVE** (would render a
+    13%-full session at 79%), and `cached` is **INSIDE** `input` for both — while claude's input
+    *excludes* cache reads, which is why claude sums them. **The formulas must not be unified.**
+    The transcript jail is widened **per root** (`~/.gemini/tmp`, `<codexHome>/sessions`), never to
+    `$HOME` — that predicate exists so a forged hook POST cannot aim a read at `~/.ssh/id_rsa`.
+  - **`hasUsage` gated THREE features, not one.** Joining `USAGE_CAPABLE` also switched on
+    `context.ensure` and the find bar's transcript index, both of which go through claude's
+    `resolveTranscript` — whose **cwd fallback** then handed a codex node *the newest claude transcript
+    for that cwd*: a stranger's session as its meter and its search hits. Now gated by the pure
+    `readsClaudeTranscript` (`renderer/lib/transcriptGates.ts`), which reuses `CHAT_CAPABLE` rather than
+    adding a fourth list. Non-claude agents lose only the mount-time head start.
+  - **`TITLE_READ_CAPABLE` was created here**: gemini names its own sessions through its `update_topic`
+    tool (the title is in that call's `args.title`, NOT a top-level field) but has no rename command, so
+    the read and write legs split. Its read path is the transcript the context tail already tracks
+    (injected as `AgentSessionNameDeps.geminiPathFor`, held in a `let` in `src/main/index.ts` to avoid a
+    TDZ throw that would kill a node's whole poll chain).
+  - **In-place restart** works for gemini: `EXIT_SEQUENCES.gemini = '/quit'` — and it must stay **bare**,
+    because `/quit --delete` exits *and permanently deletes* the session history, i.e. exactly what the
+    restart exists to resume (pinned by its own test).
+  Full picture, measurements, gaps and a device checklist: **`docs/gemini-agent.md`**.
+- **Permission mode** (agents in `PERMISSION_MODE_CAPABLE` — claude, grok, **gemini**, **codex**) —
+  the mode a session **starts** in (`claude --permission-mode <mode>`; Shift+Tab still cycles it at
+  runtime). Membership no longer implies claude's flag spelling: **the per-agent translation lives in
+  `src/shared/agents/approval-mode.ts`** (`approvalFlags` / `modeSupported`), which is also where
+  `withPermissionMode` now lives — it moved one layer up out of `config.ts` to break a cycle.
+  gemini = `--approval-mode default|auto_edit|yolo|plan`, codex = `--ask-for-approval
+  untrusted|on-request|never`. Two rules the mapping exists to enforce: a mode the CLI **cannot
+  express emits NO flag**, never a substituted nearest match (codex has no `plan` and no
+  edit-specific mode; **gemini has no `auto`** — nothing in its vocabulary means "approve most things
+  but not edits", and since `auto` is the DEFAULT mode, mapping it to `auto_edit` would have switched
+  auto-approve-edits on for every existing gemini node at upgrade time, silently), and "supports"
+  must not be a lie either — codex's `manual` maps to
+  `untrusted` because its built-in default is `OnRequest` (measured: `codex doctor`, no `approval`
+  key in `~/.codex/config.toml`), so leaving it unflagged would deliver "the model decides when to
+  ask" under an "Ask each time" label. **codex is the first agent where `manual` emits a flag.** The
+  UI copy is DERIVED from the mapping (`permissionModeAgentIds` / `permissionModeAgentsLabel` /
+  `unsupportedModesNote` / `bypassSandboxCaveat`) so a sentence cannot drift from what the table
+  does — so the note now reads "Auto has no Gemini equivalent…" beside codex's two gaps, and the
+  residual wart is only that `auto` and `manual` land on the same gemini policy (the *prompting* one).
+  `--sandbox` is a separate axis and deliberately untouched (`--ask-for-approval never`
+  still sandboxes).
+  `settings.claudePermissionMode` (global, default **`auto`** — a behavior change for existing
+  users, who previously got a prompt per action) is overridden per project by
+  `project.defaultPermissionMode` (persisted to `.nodeterm/project.json`, so a `bypassPermissions`
+  override travels to everyone who clones the repo — the tab menu warns). Modes are
+  `manual | auto | acceptEdits | plan | bypassPermissions`, labelled once in
+  `PERMISSION_MODE_LABELS` (from which `ALL_PERMISSION_MODES` is derived — the dropdown and the
+  validator can't desync). `resolvePermissionMode(project, settings)` is the resolver
+  (`renderer/state/permissionMode.ts` `activePermissionMode(agentId)` binds it to the live stores **and
+  applies the version gate below — for `agentId === 'claude'` only**), and
+  **`withPermissionMode(cmd, agentId, mode)` is the single
+  funnel through which every agent-node launch site appends the flag** (new node, cold-restore
+  resume, Branch, handoff/transfer, explain-commit, add-agent, canvas-control open-agent + team
+  spawn). **WHERE the flag lands is decided at the composed layer** (`createAgentNode`), not in
+  `withPermissionMode`: with no `argvPromptSeparator` (claude) it goes LAST, keeping the historical
+  command byte-identical; with one (grok's `--`) it must go **BEFORE** the separator, because `--` is
+  end-of-options and a flag after it is a positional — silently swallowed into the prompt or a clap
+  usage error. Assert that at `createAgentNode`; a `withPermissionMode` test passes while the composed
+  line is wrong. (gemini and codex declare no separator, so their flag goes last and their command
+  lines stay byte-identical; grok is still the only agent taking the other branch.)
+  UI: Settings → Agents, and the tab ⌄ menu for the per-project override.
+  **Version gate (`auto` only) — CLAUDE's alone:** `--permission-mode auto` exists only in **Claude Code ≥ 2.1.71**;
+  older CLIs validate the value against their own choices list and **exit 1** — and `auto` is the
+  default, so an ungated flag would kill every Claude launch on an older CLI. So the CLI is probed
+  (`core/claude-cli.ts` → `claude --version`, memoized, registered on `CorePlatform` so **both**
+  shells serve it; reached from the renderer via `window.nodeTerminal.claude.cliCaps()`, with a
+  **real** ws-bridge implementation) and `gatePermissionMode(mode, autoSupported)` degrades **only
+  `auto`**, and only to `manual` = **no flag** = the bare pre-feature command. Everything **fails
+  open**: unknown/unreadable version, a probe that failed or hasn't answered yet ⇒ bare command,
+  never a blocked launch; the other four modes are never touched by the gate, and the user's
+  *setting* stays `auto` (only the emitted command line changes). **SSH projects** are gated on the
+  **remote** host's CLI, never the local one: `SshProjectManager.connect` probes `claude --version`
+  on the host (through a login shell — an ssh exec channel's rc file usually bails out early — with
+  `$HOME/.local/bin` + `$HOME/.claude/local` prepended to PATH: the official installer targets
+  `~/.local/bin`, which a stock root `.profile` never adds, so a host whose interactive shells run
+  claude fine still probed "not found" and silently degraded `auto` to manual) and
+  caches the answer on the connection → `useSshConn`; not connected / not yet probed ⇒ no `auto`
+  flag. A FAILED remote probe (claude not found — often a transient login-shell hiccup) **retries
+  on a bounded backoff** (`PROBE_RETRY_DELAYS_MS`; every attempt pushes its answer immediately so
+  launch waiters never block on the retry tail; a definite version — old or new — never retries),
+  and the status event carries `remoteClaudeVersion` (`null` = probe failed) beside the boolean.
+  The cold-restore relaunch `await`s the (shell-warmed) local probe because it fires on mount —
+  and on an SSH project whose resolved mode is `auto` it also waits (`SSH_AUTO_PROBE_WAIT_MS`,
+  bounded, fail-open) for the REMOTE probe's first answer, which races the same mount. Because
+  the degrade is silent by design, the tab menu's Auto rows surface it: `sshAutoModeHint`
+  (tri-state `useSshConn.autoPermAnswer` + probed version) puts a ⚠︎ + tooltip on "Auto" / "Use
+  global (Auto)" for an SSH project whose remote CLI is too old / missing / not yet probed.
+  **Security:** mode values come from hand-editable, git-shared JSON and end up interpolated into
+  a shell command line (tmux `send-keys`), so `permissionModeFlag` **re-validates** the mode at the
+  interpolation site (the type is compile-time only) — an unrecognized mode yields **no flag**, i.e.
+  the bare, safe command. `'manual'` likewise yields no flag, reproducing the pre-feature command
+  bit-for-bit. The setting and the per-project override apply to **terminal (CLI) agent nodes only**
+  (the SDK **chat node**, which never honored it, was removed 2026-07). **No other agent inherits this
+  gate:** grok has accepted every mode since 1.0.0 and gemini/codex accept theirs on the versions we
+  measured, so gating any of them on a `claude --version` probe would
+  downgrade their sessions on a machine whose claude is old or absent — `activePermissionMode` gates
+  only `'claude'`, `ensureActivePermissionMode` awaits the probes only for `'claude'`, and
+  `sshAutoModeHint`'s copy names Claude in every sentence for the same reason. An agent needing its
+  own gate adds one beside claude's.
+- **State via each agent's hooks → shared 4-state model** — detection uses the agent's own
+  hooks, **not** output parsing. `src/shared/agents/normalize.ts` has per-agent normalizers
+  (`normalizeClaude`/`normalizeCodex`/`normalizeGemini`/`normalizeOpencode`/`normalizeGrok`) that map each agent's native hook
+  events to a `NormalizedAgentEvent` over the shared `AgentState` (`working | waiting | blocked
+  | done`) plus subagent/recurring/session kinds. Canvas's listener consumes
+  `NormalizedAgentEvent` from `agent:status`, drives the `agentStatus` store, fires throttled
+  (5s/node) background notifications, and records the session id. Header shows a pulsing
+  **RUNNING** (working) / **NEEDS YOU** (waiting/blocked) badge.
+- **Hook server (loopback HTTP)** — `src/main/agents/hook-server.ts` is a main-process
+  loopback HTTP server (per-session bearer token, fail-open) that the installed hook scripts
+  POST to; it replaced the old `fs.watch` signal-log mechanism. `buildPtyEnv` injects the
+  node id + endpoint/token into each spawned session's env; because tmux sessions **outlive
+  the app**, the server also writes `<userData>/hook-endpoint.env` so a relaunched main
+  process re-advertises the same endpoint (restart handoff). A `setRawListener` channel feeds
+  the per-node context-window meter (`context-tail.ts` — **one tail per agent**, each with its own
+  `parse` dep: claude's usage records, `codexContextParse`, `geminiContextParse`) and the subagent
+  live-transcript (`subagent-tail.ts`, claude only). The same events feed the **agent-status mirror**
+  (`core/agent-status-mirror.ts`) the mobile companion reads; the mirror carries an optional
+  `settings` block (`claudePermissionMode`/`autoSupported`/`claudeAccounts`) so the phone can
+  launch agents with the desktop's permission mode + managed accounts, and SSH slices get their
+  **per-host** settings (remote CLI caps + host-matched accounts) injected via
+  `remote-status-push`'s `settingsFor` dep.
+- **Hook installers** — `src/main/agents/hooks/` holds per-agent hook services + an installer
+  registry `MANAGED_HOOK_INSTALLERS`. `managed-script.ts` builds the POSIX hook script that
+  POSTs to the server (env-gated: a no-op in the user's normal terminals, active only in
+  sessions nodeterm spawns; the `claude-signals` string is kept as the idempotency marker that
+  migrates users off the old hook). claude → `~/.claude/settings.json` and gemini →
+  `~/.gemini/settings.json` (shared `install-helper.ts`, merged/idempotent, preserving other
+  tools' hooks); codex → `~/.codex/hooks.json` + `~/.codex/config.toml` trust entries
+  (`codex-trust.ts` — the hash gates whether codex runs the hook); **grok → our OWN file
+  `$GROK_HOME/hooks/nodeterm-status.json`** (its hook config is a directory whose files are all
+  merged, so there is nothing of the user's inside ours — which is also why a malformed copy is
+  *healed*, not preserved, on both the local and the SSH path). The per-event **`matcher`** the grok
+  installer needs is why events are typed `ManagedHookEvent` (`string | {event, matcher}`): grok's
+  tool matcher is a REGEX and must be `.*` — a bare `*` is invalid and silently stops tool events
+  firing. Plain-string events keep their byte-identical output for every other agent.
+- **Fullscreen TUI (Claude)** — through the SAME `settings.json` seam the hook installer uses,
+  nodeterm ensures Claude's `"tui": "fullscreen"` so a session takes the alternate screen + mouse
+  and behaves natively in tmux (else a drag falls into copy-mode). Two guardrails: **write-if-absent**
+  (any existing `tui` value — e.g. a user's `/tui default` — is never touched;
+  `core/agents/hooks/claude-tui.ts` `ensureFullscreenTui`) and **version-gated** to CLI ≥ 2.1.89
+  (`supportsFullscreenTui` / `claudeCliCaps().fullscreenTui`; unknown ⇒ don't write). Runs
+  everywhere the hook seam does: local `~/.claude` + managed account dirs at launch/add-account
+  (`ensureClaudeFullscreenTui{,Into}`), and the remote host + account dirs on SSH connect
+  (`RemoteHooks.ensureFullscreenTui{,InAccountDir}`, gated on the connection's cached remote probe).
+  **Grok has no analogue** — it runs full-screen by default, so there is nothing to write.
+- **Unread + notification** — on a busy→idle edge while the window is unfocused
+  (`document.hasFocus()`), the node is marked unread (header dot, minimap stroke, project-tab
+  dot). If notifications are enabled, `window.nodeTerminal.notify()` → main `app:notify`
+  (shown only when `mainWin.isFocused()` is false); clicking it focuses the window and sends
+  `app:focus-node` → `Canvas.focusNodeById` (selects + centers, switching projects via
+  `pendingFocusRef` if needed). A one-time consent prompt gates notifications; toggle in
+  Settings (`notifyOnClaudeDone`). Unread clears on focus/select.
+- **Session name ⇄ node title** — **two lists, because the two directions are separate facts**:
+  `TITLE_READ_CAPABLE` (`canReadTitle` — claude, grok, **gemini**) is the READ leg, `RENAME_CAPABLE`
+  (`canRename` — claude, grok) the WRITE leg, and **read ⊇ write** is an invariant pinned in
+  `config.capabilities.test.ts`. Gemini is the reason: it names its own sessions but has **no rename
+  command** (`/chat save <tag>` is a checkpoint, not a title), so one list for both legs would light
+  the rename UI on a node where the write silently does nothing. The **write** is the same literal
+  `/rename <name>` for claude and grok; the **read** legs are per-agent and none may ever
+  search another's tree, so the routing lives in ONE place, `core/agent-session-name.ts`
+  (`readAgentSessionName(sessionId, accountId?, agentId?, deps?)` — trailing/optional so every pre-grok
+  caller is unchanged), serving the desktop IPC handler **and** both shells' session-name sweeps.
+  Grok's read leg is `core/grok-session.ts` over `summary.json` in the session dir a hook told us
+  about; gemini's is `pickGeminiTitle` (`core/gemini-session.ts`) over the transcript path its context
+  tail already tracks — including the `$set` history a **resume** replays, which is exactly the case the
+  read leg exists for. Routing is not cosmetic — claude's resolver *scans* `~/.claude/projects` on a
+  cache miss, so an unrouted grok/gemini node paid that scan every 60 s for a guaranteed null.
+  **The sweep's gate lives in core, not in the shells:** `startSessionNameSweep` defaults `supports` to
+  `supportsTitleRead` (`core/session-name-sweep.ts`) and neither shell passes it — the duplicated copies
+  drifted, and reverting both to `canRename` left the whole suite green while silently skipping every
+  gemini node.
+  - **session → title (read, claude):** the authoritative name lives in the transcript `.jsonl`, not the
+    OSC terminal title (`/rename` does **not** update OSC — a known Claude gap — so reading the
+    file is the only thing that works after a **resume**). `main/transcript-reader.ts`
+    `readSessionName(sessionId)` resolves the session file **strictly by sessionId** (no cwd
+    fallback — that would make every Claude node in one folder resolve to the same newest transcript
+    and adopt each other's names) and `pickSessionName` returns the latest `custom-title`'s
+    `customTitle` (the `/rename` name) else the latest `ai-title`'s `aiTitle` (auto name). Exposed
+    over `pty.readSessionName`. `TerminalNode` polls it (~4 s) **only once this node's own sessionId
+    is known** and **while the title still auto-tracks** (`data.titleAuto`, default true on agent
+    nodes), and adopts it as the `title`. `term.onTitleChange` now feeds the `session` chip only.
+  - **title → session (write):** the moment the user renames the node by hand (header rename box /
+    ✦ AI-name / sidebar / command palette → all funnel through `applyManualTitle` or
+    `renameSession`), `titleAuto` flips to **false** (polling stops overwriting) and the chosen name
+    is pushed into the live session as `/rename <name>` via `pty.sendText` (tmux `send-keys`, same
+    one-way bridge as Branch's `/branch`; works whether or not the node is mounted).
+  - The launch command is left bare (no `-n`) — Claude's own name is canonical until the user
+    overrides it; `titleAuto` is persisted so an overridden name survives reload/resume.
+- **Search** — the command palette (⌘K) matches the session name + tags + `nt-<id>` in the
+  hint, and substring-searches each terminal's **visible buffer** (captured via `pty.capture`
+  on palette open, cached ~3s); content matches show "found in output".
+- **⌘M transcript view (`ChatPanel`) — resolution is three-legged, and each leg fails differently.**
+  `chat.readTranscript(sessionId, cwd, accountId, nodeId)` returns `ChatTranscriptResult
+  {messages, found}`, NOT a bare array: an empty thread and an unresolvable transcript are
+  different facts, and rendering both as "No conversation yet." is what made every failure below
+  look like an empty session. (1) **Remote (SSH) nodes** — `remoteTranscriptBySession` is fed
+  ONLY by hook POSTs, and a tmux session outlives the app, so after a restart an idle remote node
+  has no ref and the local resolvers search the WRONG MACHINE. `remoteTranscriptRefFor` (main)
+  therefore asks the host itself: the pure `core/remote-transcript-locate.ts` builds one `sh` line
+  (exact `<root>/<encoded cwd>/<id>.jsonl` per root, then a glob; account root before the system
+  one; `*` outside the quotes; **exits 0 on a clean miss** — "no transcript" is an answer, not a
+  failed ssh), it runs over the ControlMaster, and the reply is jailed by
+  `isSafeRemoteTranscriptPath` before it is read. A ref WE located is tracked in
+  `locatedTranscriptSessions` so a dead one can be dropped on an empty read (the panel's Retry
+  would otherwise replay it forever) — a HOOK-fed ref is never dropped that way, since an empty
+  read there is usually a transient master hiccup and forgetting it sends the next read local.
+  It is generated shell, so `remote-transcript-locate.test.ts` runs it for real under `/bin/sh`
+  against a fake host tree — keep it that way. (2) **The cwd fallback keeps `accountId`** in BOTH
+  `resolveTranscript` and `contextEnsure`; without it a managed-account node fell back to the
+  system root and could adopt an unrelated session's newest transcript. (3) **Relay tabs** stay
+  local-only (a transcript read over the relay would read the GUEST's disk) and reject with
+  `E_UNSUPPORTED`; ChatPanel catches it and says so instead of leaving the initial `[]` on screen
+  as an empty conversation. Same `nodeId` rides `claude.readTranscript`, so the find-bar searches
+  a remote node's transcript too.
+  **Both channels live in `core/transcript-ipc.ts` (`registerTranscriptIpc`), so the Server
+  Edition serves them too** — it used to have no handler at all, which is why ⌘M in the browser
+  read as an empty conversation on EVERY session. The remote leg is an injected dep
+  (`readRemote` — `null` = "not a remote session"): `src/main` supplies it, the server passes
+  none, which is complete there because it runs ON the host whose transcripts it reads. The
+  server registers it in `src/server/index.ts` right after `wireAgentStatus` (which now returns
+  its `contextTail`, the hook-fed path authority). The browser's real reader is
+  `buildTranscriptApi` in ws-bridge — deliberately NOT folded into `buildClaudeApi`, which the
+  relay shares and must not adopt it.
+- **Subagent visualization** (agents in `SUBAGENT_CAPABLE`) — `subagent-start`/`subagent-end`
+  normalized events (from Claude's `PreToolUse`/`PostToolUse` on tool `Agent`/`Task`, correlated
+  by `tool_use_id`) drive a transient `state/agentNodes.ts` store. Claude launches subagents
+  **async by default**: that PostToolUse is only a launch ack (`status:'async_launched'`), NOT the
+  end — normalize keeps the card working, the transcript tail keeps streaming, and the real end is
+  the `<task-notification>` queued into the parent transcript (sniffed by the context tails →
+  synthetic `subagent-end` in `index.ts`; the notification's `UserPromptSubmit` is also not a
+  `newTurn`, so it doesn't clear the fan-out). Canvas renders each subagent
+  as an **ephemeral** `SubagentNode` (display-only card: type + task + working/done) connected by
+  an **edge** to its parent agent node. These ephemeral nodes/edges live outside the React Flow
+  `nodes` state (merged only at the `<ReactFlow>` prop), so they're never persisted
+  (`flowToNodeStates`) nor in undo/dirty. Fan-out is cleared on the next new turn / session-end /
+  node close. (Subagents share the parent's process — no PTY.) Each card shows
+  duration/tokens/tool-uses and **expands** (click) to a **live transcript**:
+  `main/subagent-tail.ts` resolves the subagent's own transcript file
+  (`<…>/<sessionId>/subagents/agent-<id>.jsonl`, matched by `tool_use_id` via the sibling
+  `.meta.json`), tails it read-only, formats each line (assistant text + tool calls + results),
+  and streams chunks over `agent:subagent-activity` into the store.
+- **/loop, /schedule & /cron node** (agents in `RECURRING_CAPABLE`) — detected from the **tools**
+  the agent invokes (robust; users often phrase it in natural language so the prompt rarely starts
+  with the slash): `PreToolUse` for `Skill` (skill ∈ loop/schedule/cron), `CronCreate` (→ cron,
+  label = cron expr · prompt), or `ScheduleWakeup` (→ loop) — plus a `UserPromptSubmit`
+  `/loop|/schedule|/cron` prompt-prefix fallback, all surfaced as `recurring` normalized events.
+  Sets `agentStatus.loop` ({count, prompt, items, kind}); for in-session `loop` each turn-done
+  bumps the count + appends `lastMessage` (schedule/cron run in the background, so they aren't
+  counted). Lifetime by kind: `loop` dies with its session; `cron`/`schedule` **outlive turns,
+  sessions and app restarts** (`loop` is persisted in the agentStatus localStorage) and are
+  cleared by a `CronDelete` `recurring`-end event or the card's own × (dismisses the card only).
+  `clearForParent` (new turn) leaves the loop card's dragged position alone. Renders an ephemeral
+  **LoopNode** labelled by kind, connected by an edge to the parent, plus a small header badge.
+- **Branch conversation** — node action (`IconBranch`, Claude-only via `BRANCH_CAPABLE`): sends `/branch` into the
+  existing terminal via `pty.sendText` (tmux `send-keys`) and opens a new Claude node that
+  resumes the parked original with `claude --settings … -r <ORIGINAL_ID>`. The original id is
+  the session id already known from hooks; `lib/claudeBranch.ts` is the fallback that parses
+  `pty.capture` output when the id isn't known. The source node stays on the new branch.
+- **Canvas control (manage-nodeterm-canvas)** — agents in `CANVAS_CONTROL_CAPABLE`
+  (claude/codex/gemini/opencode/grok) can create/organize/control canvas nodes from inside their
+  session: a POSIX **sh+curl** shim (`nodeterm.sh`, `CONTROL_SHIM_SCRIPT` in
+  `main/canvas-control-core.ts` — the Electron-as-Node CLI is retired) POSTs
+  **form-urlencoded** (`nodeId` + `arg.<flag>` fields; `curl --data-urlencode` is the only
+  escaping sh can be trusted with — `parseControlBody` reads both this and the JSON dialect) to
+  the hook server's `/control/<verb>` routes; `Accept: text/plain` makes the server render the
+  reply (sh has no JSON parser). Env-gated on `NODETERM_CANVAS_CONTROL` (set by
+  `buildPtyEnv`/`remoteHookEnvArgs` per `canControlCanvas`). Discovery: claude gets a
+  `skills/manage-nodeterm-canvas/SKILL.md` (system `~/.claude` + each managed account dir);
+  codex/gemini/opencode get a marker block (`<!-- nodeterm:manage-canvas:start/end -->`); **grok needs
+  no installer at all** — it scans `~/.claude/skills` by default for Claude compat, so membership alone
+  (which sets `NODETERM_CANVAS_CONTROL`) is the whole wiring. That premise rests on grok's shipped
+  docs and is **unverified** (`grok inspect --json` never run); if it does not hold, grok takes the
+  marker-block route instead — see docs/grok-agent.md.
+  **SSH projects** (docs/ssh-agent-skills.md): the SAME shim + skill + blocks are installed on
+  the remote host at connect (`RemoteHooks.installCanvasControl` + per-account
+  `installCanvasSkillIntoAccountDir`), gated on the VERIFIED reverse hook tunnel — the shim
+  carries no machine-specific paths and POSTs through the tunnel's unix socket, so remote agents
+  control the desktop's canvas. The shim is generated source no compiler checks:
+  `canvas-control-shim.test.ts` runs it for real (/bin/sh against a real hook server, port AND
+  unix-socket transports) — keep it that way.
+  **Grouping verbs** (`group` / `ungroup` / `move` / `arrange` / `align`): `group` only wraps
+  **top-level** nodes into a new frame (children already in a frame are skipped — the reply says
+  how many + points at `move`); `ungroup --group <id>` dissolves a frame (nodes kept); `move
+  --nodes <id,id> [--group <id>]` reparents nodes INTO a frame (or `top`/`none`/omit → out to top
+  level) via `reparentNode` — the ONE way to move a node between frames, which `group` won't do.
+  `arrange`/`align` now run in ONE coordinate space: all top-level, OR all children of one frame
+  (`commonParentId` decides; a mixed set is refused, not silently subset-arranged — the old
+  behavior). When the ids are a frame's children, the frame is shrunk to hug the tidied layout
+  (`fitGroupToChildren`) — the fix for "grouping keeps scattered positions so the frame is too
+  wide". `move` also re-fits the source + destination frames. All pure + tested in
+  `state/workspace.test.ts` + `workspace.layout.test.ts`.
+  **Fan-in (`link`, 2026-07):** a spawned fan-out was previously write-only — nodes an agent
+  opened were joined to it by a **rope** (`project.ropes`, explicitly *"Display-only — never
+  context links"*), so an orchestrator could not read back what its own team produced and the
+  skill told it to have the USER relay results. Now `open-claude`/`open-agent`/`spawn-team` also
+  draw a real **context bridge** (`project.bridges`) to each agent session they open, and the
+  `link --to <id,id> [--from <id>]` verb links nodes the agent did not open (or two other nodes).
+  The rope stays — the two edges mean different things (lineage vs readable context) and a
+  non-context-capable target still gets only the rope. Deliberately **silent**: the manual
+  `onConnect` path pushes a discovery note into both endpoints, but doing that per team member
+  would inject a prompt into every session an agent just spawned — the exact intrusion that push
+  was reverted for. Links are pull-based, so nothing is lost. The refusal matrix is the pure
+  `planBridges` (`renderer/lib/noteLink.ts`, unit-tested); Canvas only wraps it in setState.
+  Callers that create and link nodes **in the same tick** must pass their own `lookup` — `setNodes`
+  is async, so resolving fresh nodes off `nodesRef` would skip every one as "no such node".
+  **Dependency edges (`--after`, 2026-07):** `open-terminal`/`open-claude`/`open-agent` accept
+  `--after <id,id>`, which opens the node **armed** — `data.pendingLaunch` ({after, command},
+  `PendingLaunch` in shared/types) holds the launch the factory built, and Canvas fires it once
+  every dep reports `done`. This is what makes the canvas a DAG instead of a fan-out. Load-bearing
+  details: (1) **an unknown agent state is NOT "satisfied"** — right after a fan-out no upstream has
+  emitted a hook event yet, and reading "no news" as "finished" would fire every dependent
+  instantly; a **deleted** dep IS satisfied (it can never report). (2) Only `hasHooks` agents may be
+  waited on — a plain terminal never reports done, so `resolveAfter` **refuses** it rather than
+  letting `launchesToFire` (which cannot tell "never will" from "not yet") hang the node forever.
+  (3) If the deps are **already satisfied at creation**, the node is NOT armed: the command stays
+  `initialCommand` so the node's own mount path delivers it through `writeWhenShellReady` —
+  arming would hand delivery to the canvas effect, which races the node's PTY into existence.
+  (4) Delivery is **exactly-once via `launchInFlight`** (an id stays in the set forever once
+  `sendText` resolved true — clearing `pendingLaunch` is a state update that can lag a re-render),
+  and a **refused** `sendText` retries (`LAUNCH_DELIVERY_ATTEMPTS`) instead of vanishing.
+  (5) `pendingLaunch` **is persisted** (unlike `initialCommand`), but agent state is not — so after
+  a restart nothing will ever report `done` and the node carries a manual ▶ **run-now** escape in
+  its QUEUED badge. (6) Canvas subscribes to `armedDepSig`, NOT `useAgentStatus(s => s.byId)` —
+  the same discipline as `loopSig`; the full map re-renders the canvas on every hook event.
+  Pure logic + refusal matrix in `renderer/lib/pendingLaunch.ts` (unit-tested); the dashed dep→node
+  edges are **derived, never persisted** (a pending dependency is a state that ends when the launch
+  fires — the durable relation is the context bridge `--after` also draws).
+  **Review panel (`verify`, 2026-07):** `verify --node <id> [--lenses …] [--focus …] [--agent …]
+  [--synthesis off]` opens one reviewer per LENS, each armed behind the target (`--after`) and
+  bridged to it, wrapped in a `Verify: <title>` group, plus a judge armed behind the whole panel.
+  It is **composition, not new machinery** — the two primitives above are the whole implementation.
+  Prompt/lens logic is the pure, unit-tested `renderer/lib/verifyPanel.ts`; two wordings there are
+  load-bearing and must not be "tightened away": reviewers are told **not to edit** (a panel is N
+  agents pointed at ONE checkout — review and repair are different jobs, and only repair needs
+  worktree isolation) and are explicitly **licensed to find nothing** (a reviewer under implicit
+  pressure to produce findings invents them, and an invented finding costs someone else the time to
+  disprove it). Unknown lens words are **kept** with a generic brief, not rejected — a table that
+  only accepts what it already knows would be useless for the review nobody anticipated. Reviewers
+  inherit the TARGET's `accountId` (its transcript resolves inside that account dir), not the
+  caller's. The judge is armed on ids that exist only in that tick, which is why `armAfter` takes
+  `extraLive` — without it the reviewers would look *deleted*, deletion counts as satisfied, and
+  the judge would fire before a single review existed.
+- **Context Link** — a node action gated by `CONTEXT_LINK_CAPABLE` (claude/codex/gemini/opencode;
+  **grok**, custom agents + plain terminals excluded — grok's `updates.jsonl` parser is unbuilt): drawing an edge between two builtin-agent nodes lets each
+  READ the other's context on demand (pull, not push). Architecture (2026-07, SSH-capable — see
+  docs/ssh-agent-skills.md): the **desktop does the reading AND the parsing**; the CLI the agent
+  runs (`context.sh`) is a thin POSIX **sh+curl** shim that POSTs to the hook server's
+  `/context-link/<verb>` route and prints the text/plain reply (the Electron-as-Node CLI is
+  retired — its embedded-JS parser now lives as tested TS in `core/context-link-render.ts`:
+  parsers for **all four** formats — claude JSONL / codex rollout / gemini event-sourced chat /
+  opencode export — plus `renderContextLink` over injected fetchers). `src/core/context-link.ts`
+  holds the link docs in memory (per-node files under `<userData>/context-links/` remain as a
+  debug aid), carries per-entry `agentId`/`sessionId`/`accountId`, and answers the route;
+  **authorization** = the doc is selected by the REQUESTER's node id, so a token-holding caller
+  can only read nodes in its own (directional) link map. Codex/gemini paths resolve via the
+  handoff locators (`locateCodex`/`locateGemini` by sessionId); claude keeps the hook-fed path +
+  `locateClaude(sessionId, accountId)` fallback (cwd-newest is claude-only); Canvas rewrites link
+  files when a linked node's sessionId appears (`linkSessionSig`). **SSH projects:** the shim +
+  skill are installed on the remote host at connect (`RemoteHooks.installContextLink`, gated on
+  the VERIFIED reverse hook tunnel; POSTs ride `--unix-socket` through it); a remote node's
+  transcript is read over the ControlMaster (`initContextLink(ptyManager, deps)` — `src/main`
+  injects `isRemoteNode`/`readRemoteFile`/`runRemoteCommand`, bounded tail reads), its hook-fed
+  path is jailed at ingest (`isSafeRemoteTranscriptPath`), and `resolveLinkTranscript` REFUSES
+  the local locators for remote nodes (they'd resolve a stranger's local transcript). Server
+  Edition passes no deps → local-only (context link is NOT wired there at all — `initContextLink`
+  is never called from `src/server`). Discovery is per-agent: claude installs a
+  `get-linked-context` skill; codex/gemini get an idempotent marker block
+  (`<!-- nodeterm:get-linked-context:start/end -->`) merged into `~/.codex/AGENTS.md` /
+  `~/.gemini/GEMINI.md`. On connect an idle-gated one-line note is injected into each endpoint
+  (claude → skill pointer; codex/gemini → inline CLI command via `contextLink.info()`).
+  (Replaced the earlier MCP-based bridge.)
+  **Note links:** a sticky note can be connected to ANY terminal node (one-way, sticky →
+  terminal). On connect, agent sessions get a one-shot idle-gated push of the note text
+  (`buildNotePushMessage`, single-line, truncated at 2000 chars); plain terminals get no
+  push (sendText appends Enter — the text would execute). The note's live text also rides
+  the link file (`ContextLinkInfo.note`), so Claude reads the current text via the
+  get-linked-context CLI (`summary`/`transcript` print it; `list` marks `(note)`). Pure
+  edge/push/map logic in `renderer/lib/noteLink.ts`.
+- **Managed Claude accounts** (Claude-only) — run several logged-in Claude identities side by
+  side by giving each its own config dir. `settings.claudeAccounts` is a list of `ClaudeAccount
+  {id, label, email?, host?, pending?, createdAt}` (in `settings.json`; the account **list** is
+  config, not credentials). Isolation is **config-dir**, not token storage: a local account's dir
+  is `{userData}/claude-accounts/<id>` (`claudeConfigDirFor` / pure `localAccountConfigDir`),
+  a **remote** account's is `~/.nodeterm/claude-accounts/<id>` on its `host` (keyed by
+  `sshHostKey` = `user@host`; `remoteAccountConfigDir` is `~`-relative for ssh expansion,
+  `remoteAccountConfigDirAbs` resolves it against the connection's `remoteHome`). The **claude
+  CLI owns login, credential storage, and token refresh** inside that dir — the app NEVER writes
+  credentials. On macOS this works because Claude Code **≥ 2.1** scopes its Keychain service per
+  config dir (`Claude Code-credentials-<sha256(configDir)[:8]>`, `claudeKeychainService`); on
+  < 2.1 one unscoped service is shared → accounts collide, so add-account **warns** (`claude
+  --version`, `isSupportedClaudeVersion`).
+  - **`data.accountId` (terminal nodes)** — resolved **once at node creation**
+    (`resolveNewNodeAccount`: explicit submenu pick → `project.defaultAccountId` → system default
+    `~/.claude`), then **immutable** and **persisted** (serializers). `undefined` = system default
+    = **bit-for-bit legacy behavior** (no env touched). Inherited by **Branch** (the
+    terminal→chat fork it also fed is gone — the SDK chat node was removed 2026-07). A pending
+    (not-yet-logged-in) account resolves to `undefined` until it completes.
+  - **Env injection** — `pty-manager` sets `CLAUDE_CONFIG_DIR` in the spawn env AND as a tmux `-e`
+    (local); for a remote node it emits an **absolute-path** remote tmux `-e` built from the
+    connection-cached `remoteHome` (skipped **fail-open** if home is unresolved). `AUTH_ENV_STRIP`
+    (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN`) is deleted from the
+    child env so a stray env key can't shadow the account. A **missing** account dir → warn +
+    silent system fallback.
+  - **Login flow** — Settings → Accounts → **Add** creates a `pending` account and drops a canvas
+    **login node** that runs `claude /login` under the account dir. Main polls the dir's
+    `.claude.json` (`LOGIN_POLL_MS` 2 s, up to `LOGIN_TIMEOUT_MS` 5 min) for `oauthAccount.email`;
+    on capture the account flips out of `pending` with its email as the default label. Account
+    removal cancels any pending wait + `markDirty`.
+  - **Hook install** — the managed hook is merged into **each account dir's** `settings.json` at
+    add-account **and** at app launch (local, shared `install-helper.ts`) / via
+    `RemoteHooks.installIntoAccountDir` (remote), so every identity reports agent status.
+  - **Account-aware readers** — transcript resolution is scoped per account (`transcriptRootFor`
+    picks the account dir's `projects/`, composite cache key includes `accountId`); the same
+    threading runs through the session-name poll, restart handoff, and `ChatPanel` (the ⌘M
+    transcript view, `chat.readTranscript`). The **usage indicator** is per account (`claude-usage.ts`: scoped Keychain
+    service first, legacy unscoped fallback; popover lists a row per account with **System**
+    first). **Remote (SSH host) accounts are included** — see **Remote usage** below.
+  - **Pickers** — New Claude exposes an account **submenu** (pane menu; flat entries in
+    the dock; palette commands; TabBar sets the **per-project default**). A **local** project
+    lists local accounts, an **SSH** project lists only accounts whose `host` matches its
+    connection; both offer a **System account** option. An SSH project whose host has **no**
+    matching accounts gets a disabled hint row instead of a bare System-only list
+    (`sshAccountsHint` — pane submenu, dock, TabBar; the palette deliberately omits it: a
+    disabled row would surface as a search result) saying accounts for this host are added in
+    Settings → Accounts while the project is connected — local accounts being invisible there is
+    correct (their credentials aren't on the host) but read as "multi-account is broken on SSH".
+  - **Remote accounts** — selection + login + env injection, plus **usage** (below); no
+    per-account transcript readers beyond env.
+
+- **The usage indicator is scoped to the ACTIVE project** (`renderer/lib/usageScope.ts`, pure +
+  unit-tested) — it describes **the machine that project runs on**, and nothing else. A local
+  project shows this machine (system + managed local accounts + the billing providers, whose
+  credentials are all local); an **SSH project shows only that host's Claude accounts** — no local
+  Claude, no local providers, no other host. Without this the panel showed every source at once:
+  each addition was individually reasonable and the sum was unreadable, numbers from three
+  machines sharing one line with nothing saying which was which. Deliberately NOT narrowed to the
+  project's `defaultAccountId`: the local side lists every local identity, so the machine is the
+  scope and the account is a row within it. The pill spells out the scoped machine's **system**
+  account (falling back to the first identity with data, so a host used only through a managed
+  login isn't blank), managed accounts stay popover-only — the rule the local side always had.
+  `usageScopeKey`/`scopeFromKey` exist because the active project object is rebuilt on every node
+  serialization: the zustand selector returns ONE primitive so the indicator doesn't re-render on
+  every canvas edit. ⟳ refreshes only what is on screen, and `usage.remote({hostKey})` reads only
+  that host (cache eviction still runs against the FULL target list, so switching between two SSH
+  projects doesn't throw each host's cache away).
+
+- **Remote usage** (SSH hosts, `src/core/usage/remote-claude-usage.ts`) — the source behind the
+  SSH scope above. v1 excluded remote accounts, which left a user whose Claude only ever runs on a
+  server staring at an empty indicator while the host had perfectly good numbers.
+  **The token never leaves the host.** The desktop could `cat` the remote `.credentials.json` and
+  call the API itself — it already reads remote transcripts over the same master — but a bearer
+  token pulled off a (possibly shared) server into another machine's memory buys nothing: the host
+  can make the request itself. So core generates a POSIX **sh+curl** command, the shell runs it
+  over the project's ControlMaster, and only the JSON answer comes back. Three details are
+  load-bearing:
+  1. **The token is piped into `curl --config -`, never `-H` on the command line** — argv is
+     world-readable via `ps` on a shared host.
+  2. **`.credentials.json` holds more than one `accessToken`** — every MCP server the CLI has
+     authorized keeps its own under `mcpOAuth`. The extraction narrows to the `claudeAiOauth`
+     object first (exactly as the local `parseCreds` does), because grabbing the file's first match
+     sends an MCP token to the endpoint, earns a 401, and reports a signed-in host as signed out.
+     Caught only by running the command against a REAL credentials file — which is why
+     `remote-claude-usage.test.ts` runs the generated script under a real `/bin/sh` against a fake
+     `$HOME` + fake `curl`, the same discipline as the canvas-control shim.
+  3. **A read that could not run is `error`, never `unavailable`** — a dead master says nothing
+     about whether the account has a subscription, and 'unavailable' silently drops the row.
+  Shape: `remoteUsageTargets` (pure) elects ONE connected project per host (several projects share
+  a host's `$HOME`) and offers its system `~/.claude` plus every managed account pinned to that
+  host. The service (`usage:remote`) caches per target under the usual debounce, evicts targets
+  whose host disconnected, and coalesces concurrent reads. **On demand, never polled** — each row
+  is an ssh exec plus an HTTPS request on someone else's machine; the renderer asks on mount, on
+  popover open, on ⟳, and when the active project's connection comes up (an SSH project is opened
+  before its master is ready). Deps are injected exactly like
+  Context Link's (`src/main` supplies the ControlMaster; **Server Edition passes none** ⇒ `[]`, so
+  the UI needs no capability check). Own Settings switch (`claude-remote`), because hiding local
+  Claude usage must not silently take the hosts down with it. **Mobile: N/A** — the
+  slice pushed to a host still drops `usage` (a host reading its own numbers back off us is
+  pointless), and no keychain leg exists remotely (a headless macOS host would hang on the prompt,
+  so a mac host reports nothing).
+
+### Adding a new agent (or a new model) — what to watch out for
+
+Every rule below is a mistake the grok branch or the codex/gemini-parity branch **actually made**, and
+each one cost a review round or shipped a wrong number to the user. Read the concrete failure, not the
+principle. Per-agent write-ups: `docs/grok-agent.md`, `docs/gemini-agent.md`.
+
+**The mechanism**
+
+1. **A capability is a membership list plus ONE leaf.** Add the id to the list in
+   `src/shared/agents/config.ts`, write the one per-agent thing that list gates (a normalizer, a
+   reader, a table row), and every consumer lights up — the whole point of the design. What you must
+   never do is fork behavior at a call site with `=== 'claude'`; ask through the helper.
+2. **Ask what ELSE the list gates before joining it.** `hasUsage` gated **three** features, not one.
+   Joining `USAGE_CAPABLE` for the context meter also switched on `context.ensure` and the find bar's
+   transcript index, both of which resolve through *claude's* `resolveTranscript` — whose **cwd
+   fallback** then handed a codex node **the newest claude transcript for that cwd**: a stranger's
+   session as its meter (wrong numerator *and* denominator, flapping against the correct tail) and that
+   session's messages as its search hits. Preconditions were default-true, so it would have shipped.
+   The fix was a new pure predicate (`readsClaudeTranscript`) reusing an existing list, not a fourth
+   list meaning the same thing. **Grep every consumer of the helper before you add an id to its list.**
+3. **A read leg and a write leg are different facts, and may need different lists.** Gemini names its
+   own sessions but has **no rename command**, so `TITLE_READ_CAPABLE` (read) split from
+   `RENAME_CAPABLE` (write), with `read ⊇ write` pinned as an invariant. One list would have lit the
+   rename UI on a node where the write silently does nothing — the worst kind of feature, one that
+   looks like it worked.
+4. **State Desktop / Server Edition / Mobile for the capability, even when the answer is "N/A".**
+   Put the logic in `src/core` behind `CorePlatform` or the Server Edition silently doesn't have it,
+   and give `window.nodeTerminal` a REAL bridge implementation or a documented degrade — a `noop` stub
+   compiles fine while doing nothing. (Live example: the session-title READ has no server handler at
+   all, so it is stubbed for **claude too** — a pre-existing gap that keeps being rediscovered per
+   agent.)
+
+**Measuring the CLI**
+
+5. **Measure the CLI; do not assume claude's shape.** Three real bugs, all from assuming:
+   - grok's `--` is **end-of-options**, so a flag appended *after* the prompt separator is a
+     positional — silently swallowed into the prompt, or a clap usage error that kills the launch.
+     Where the flag lands is decided at the **composed** layer (`createAgentNode`); a
+     `withPermissionMode` unit test passes while the composed line is wrong.
+   - codex's `total_token_usage` is **CUMULATIVE**, not the live context: against its own window it
+     rendered a 13%-full session at **79%** and would have crossed 100% two turns later. The right
+     field is `last_token_usage`.
+   - `cached` tokens are **INSIDE** `input` for codex and gemini, and **OUTSIDE** it for claude (whose
+     reader therefore sums them). Copying claude's formula double-counts. **Do not unify the
+     formulas.**
+6. **Prefer the agent's own stated number over one you infer.** Codex prints
+   `model_context_window` right beside its usage — use it. When there is none, mirror the CLI's own
+   resolver rather than building a per-model allowlist: gemini's `tokenLimit()` is a family rule with
+   a **1M catch-all default**, so an unreleased model gets the *right* answer where an allowlist would
+   be confidently wrong, silently. **And if you cannot establish a trustworthy denominator, ship no
+   meter** — a percentage over a guessed window is a wrong number presented as a fact (this is exactly
+   why grok has no meter).
+7. **A closed set beats a substring, for notification/event types.** Grok's
+   `type.includes('permission')` matched a notification grok fires before *every* tool call, so a
+   working node strobed NEEDS YOU: unread dot + chime + OS notification + phone inbox card, per tool
+   call. Gemini is matched `=== 'ToolPermission'` and stays quiet on an unknown type. A badge stuck on
+   a finished node has no later hook to clear it, so widening "to be safe" is the unsafe direction.
+8. **"Supports" can be as dishonest as "doesn't support."** Codex claimed `manual` / "Ask each time"
+   while emitting **no flag** — but its built-in default is `OnRequest` ("the model decides when to
+   ask"), so two dropdown entries collapsed onto one behavior under a label that promised otherwise.
+   Rule: a mode the CLI cannot express emits **no flag** (never a substituted nearest match), and a
+   mode it *can* express must actually emit it. Derive the UI copy from the mapping
+   (`unsupportedModesNote`, `permissionModeAgentIds`) so a sentence cannot drift from the table.
+   **The nearest match is most dangerous on the DEFAULT mode:** gemini has no value for `auto`, and
+   `auto` is `DEFAULT_PERMISSION_MODE`, so translating it to `auto_edit` ("auto-approve edit tools")
+   would have widened permissions for every existing gemini node at upgrade, with `modeSupported`
+   answering `true` so the derived copy stayed silent. Check what an UNTOUCHED setting emits before
+   you accept any mapping.
+9. **A capability gate that is fed by a version probe belongs to the agent it probes.** Claude's
+   `auto` gate is fed by `claude --version`; applying it to any other agent downgrades that agent's
+   sessions on a machine whose *claude* is old or absent. `activePermissionMode` gates only
+   `'claude'`, and every hint string names Claude for the same reason. An agent needing its own gate
+   adds one beside claude's.
+
+**Not writing the same rule twice**
+
+10. **A duplicated rule drifts, and this branch was bitten three times.** The remote installer's hook
+    event lists (it subscribed gemini to *claude's* event names, so remote gemini reported nothing at
+    all), grok's raw-listener field decoding, and the two shells' session-name sweep gates (reverting
+    both to `canRename` left the entire suite **green** while silently skipping every gemini node).
+    The fix each time was **one definition in `src/core`** consumed by both shells — a default inside
+    core beats an argument each shell passes correctly today.
+11. **Both shells' raw hook listeners must stay in parity** (`src/main/index.ts`,
+    `src/server/agent-status.ts`). If you add a branch to one, add it to the other or write down why
+    not (the desktop's extra skip for remote SSH nodes is a legitimate asymmetry: the server has no
+    SSH-project manager).
+12. **Widen the transcript-path jail per ROOT, never to `$HOME`.** Hook POSTs can arrive over the
+    remote reverse tunnel, and `isSafeLocalTranscriptPath` exists so a forged one cannot aim a read at
+    `~/.ssh/id_rsa`. Add the narrowest directory that holds the transcripts (`~/.gemini/tmp`,
+    `<codexHome>/sessions`) and honor the agent's own relocation env var — getting that wrong fails
+    **closed** (the meter silently never fills), which is the quieter and therefore worse failure.
+13. **Re-validate a hand-editable value at the interpolation site, not by its type.** Modes come from
+    git-shared JSON and end up on a tmux `send-keys` line. A table lookup guarded only by
+    `mode in table` accepted a forged `constructor` and returned a **Function** headed for that
+    command line; `isPermissionMode` at the top of `approvalFlags` is what closes it. Same rule as
+    `SAFE_SESSION_ID`. An unrecognized value must yield the **bare, safe** command.
+
+**Degrading, and admitting what you did not measure**
+
+14. **A guess must degrade to nothing, never to something wrong.** A title reader that cannot resolve
+    returns `null` (the node keeps its own name); an unknown notification type is a no-op; a failed
+    probe means the bare command, never a blocked launch. Say in the code which facts are *composed*
+    rather than captured (gemini's resumed-transcript shape is) and what the wrong-guess cost is.
+15. **Kill the "in place" actions carefully.** An exit sequence must be the CLI's documented primary
+    and **bare**: gemini's `/quit` also takes `--delete`, which exits *and permanently deletes the
+    session history* — the very conversation the restart exists to resume. It has its own test.
+    Refuse the restart while the node is `working` **or** `blocked`: an exit line typed into a
+    permission prompt **answers** it.
+16. **Write the device checklist for what you could not run.** Every unverified claim becomes a
+    numbered item; group the ones that fall out of a single capture run. `docs/grok-agent.md` §9 and
+    `docs/gemini-agent.md` §9 are the format.
+
+## Session memory (the RAM pill + the per-session panel)
+
+A bottom-left **RAM pill** (`components/SystemResourcePill.tsx`) beside the usage pill, and the
+**session-memory panel** it opens (`components/SessionMemoryPanel.tsx`): used/total RAM of the
+machine the **active project** runs on, and every `nt-*` tmux session on that machine sorted by the
+memory its whole process TREE holds, each row travelable (`goToNode`) and killable. Scope is
+`usageScopeKey` — the same helper the usage indicator uses, so the two pills can never disagree
+about which machine they describe. Reading + parsing is `core/session-memory.ts` (this machine) and
+`core/session-memory-remote.ts` (an SSH project's host), served over one RPC by
+`core/session-memory-service.ts`, which BOTH shells boot. Full write-up + the device checklist:
+**`docs/session-memory.md`**.
+
+- **The memory is the agent CLI's own V8 heap — nodeterm does not allocate it, and it is not a
+  leak.** Measured on the production host that prompted this (64 GB, 95 live `claude` processes): a
+  `claude` process alone averages **335 MB** and peaked at **1159 MB**; 95 of them held **31.1 GB**;
+  MCP children add 30–200 MB per session (playwright-mcp + Chrome ≈ 200 MB alone), so one "Claude
+  terminal" tree is **440 MB – 1.2 GB**. `RssAnon` is essentially all of the RSS (1165 MB of 1187 MB
+  on the largest process) and the repo sets no `NODE_OPTIONS`, so V8 sizes its heap off system RAM
+  (`heap_size_limit` 4144 MB there). It is flat with process age — 0–24 h avg **340 MB** vs 7 day+
+  avg **326 MB** — so each process takes a baseline and never returns it. **Write those numbers down
+  rather than re-deriving them.** The user's number was right and their attribution was wrong; what
+  the product was missing was not the allocation but the **blindness** — nothing told them 18
+  sessions were live, that one was 1.2 GB, or that six belonged to a project they closed weeks ago.
+- **The reaper is deliberately unchanged.** `core/session-budget.ts` reaps only **detached** sessions
+  past a grace window, so on that host its kill list was **EMPTY** — 60 `nt-` sessions, 50 attached,
+  0 eligible — while 31 GB sat there. An open canvas is attached, and attached is untouchable.
+  Retargeting it is a separate change with separate risk; this feature adds **sight**, not policy.
+- **`ok:false` is not `ok:true` with no rows** — the rule the whole feature exists to honour, and
+  every layer preserves it. A sweep fails (no tmux, unreadable process table, **no socket answered**,
+  a missing or out-of-order marker in the SSH reply, a rejected call) ⇒ `ok:false` and no rows; the
+  panel then says "Could not measure sessions on this machine", and the grand total and the "*n*
+  sessions" count are gated on a `measured` flag so a failure can never render as `0 B / 0 sessions`.
+  "We looked and there is nothing" is its own sentence. A socket with **no tmux server** is an
+  ANSWER, not a failure (`isNoServerError`), and that classifier is **anchored to tmux's own connect
+  message**: `promisify(execFile)` folds stderr into `err.message`, and a bare `no such file or
+  directory` also matches a tmux client missing a shared library (exit 127 on *every* socket) and a
+  dead ssh ControlMaster — laundering either into "no sessions here" prints an empty panel over 20
+  live ones. **The SSH leg applies the SAME classifier to the same rule**: each socket is fenced in
+  the reply with its tmux exit status and its stderr (`##SOCK <name>` … `##SOCKRC <n>`, `2>&1`), and
+  zero answers ⇒ `ok:false`. Its first form threw both away (`{ tmux …; tmux …; } || true`), so a
+  host whose tmux client could not start emitted a stream byte-identical to an idle host's and the
+  panel reported thirty live sessions as "No sessions are running here.". Do not "simplify" the
+  fence back out — and do not replace the classifier with a blunt "any error ⇒ ok:false" either: on
+  a host with no tmux server at all EVERY socket fails, and there "there are no sessions" is the
+  honest answer.
+- **`readMemInfo` has exactly one home** (`core/session-memory.ts`); `session-budget.ts` imports and
+  re-exports it. The reaper's watermark and the pill must never disagree about how much RAM is free,
+  and a second copy is exactly the drift this file warns about elsewhere. `null` = could not read,
+  never zero.
+- **The local reader reads `/proc/<pid>/status`, never `statm`.** `status` carries `PPid` and `VmRSS`
+  in one file, already in kB; `statm` reports RSS in **pages**, forcing a page-size assumption — a
+  hard-coded 4096 under-reports **4×** on a 16 KiB-page arm64 kernel and **16×** on the 64 KiB-page
+  enterprise arm64 builds (40 MB printed for a 640 MB session). **Do not optimise this back to
+  `statm`.** Non-Linux falls through to one `ps -eo pid,ppid,rss` call, through the same injectable
+  seam as tmux.
+- **`childCount` counts ALL descendants**, the agent CLI included: `pane_pid` is the pane's SHELL, so
+  a claude session with two MCP servers reports **3**. The UI therefore says "**child processes**",
+  never "MCP" — a plain `npm run dev` has children too.
+- **The cadence split follows the cost.** A **local** scope polls the pill's number every 30 s
+  (`HOST_POLL_MS`, one file read, free). An **SSH** scope is **never polled**: one read on scope
+  entry, one when that project's ControlMaster comes up (an SSH project is opened before its master
+  is ready, and with no timer behind it a first read against a dead master leaves the pill blank),
+  and one per panel open / `⟳`. Same rule this file already sets for **Remote usage**, for the same
+  reason: every remote read is an ssh exec plus a `ps` of somebody else's whole process table. The
+  full sweep runs on the panel's MOUNT (it is unmounted while closed) and on `⟳` — never on a timer,
+  never from the pill.
+- **The pill is the single owner of the store's `startHostPoll` / `stopHostPoll`** — the timer and the
+  active-scope stamp are MODULE SINGLETONS. The panel must never call them: a `stopHostPoll` on
+  unmount would clear the pill's interval with nothing left to restart it, and the number would
+  silently freeze until the next scope change.
+- **A closed project is not an orphan.** `closeProject` keeps the project and its nodes on disk, so
+  its sessions resolve to a real title and are labelled with their project; calling them orphans
+  would invite the user to kill sessions they deliberately parked. `resolveSessionRows` is therefore
+  fed EVERY project — filtering to the open tabs defeats the rule silently, from outside the file
+  that states it. And **`orphan` is the distinguishing field, NOT `state === null`**: a plain
+  terminal never enters the agent-status map, so deriving orphan-ness from a missing agent state
+  would flag every one of them. Orphans are the point — they are what the reaper cannot see and no
+  canvas can show.
+- **On an SSH scope the kill routes over the ACTIVE project's master** (`lib/sessionKill.ts` →
+  `sshProject.killSessions`), because `transport.destroy(nodeId)` reaches a remote session only
+  through a LIVE local client carrying `sshRemote` — which an orphan has not, and neither has a node
+  owned by a non-active project. Before this, every orphan row's `×` on an SSH project **promised a
+  kill it could not perform**: the local socket was touched, the host's `nt-<id>` kept running, and
+  the row came back on the next refresh unexplained. It is safe because it is a **round trip, not a
+  lookup** — the row's `nodeId` is literally `session.slice('nt-')` from the sweep and `killSessions`
+  maps it back through the same idempotent `sessionName()`, so the exact session name the sweep
+  observed is killed on the host it observed it on (node ids are only per-launch unique, and nothing
+  here rests on more). Ownership is re-resolved at click time, not taken from the row's stale
+  `orphan` flag, so a node created since the sweep is not killed as an orphan.
+- **The name and the host were never the hard part — the SOCKET was.** Two nodeterm tmux sockets
+  live on one machine at once (`node-terminal` for a nodeterm running ON it, `nodeterm-rmt` for one
+  SSH-ing INTO it) and the sweep lists **both**, while the kill targeted one — so every row off the
+  other socket got "this stops its tmux session" and a kill that landed nowhere. Not exotic: a host
+  running its own `nodeterm-server` while being SSH'd into is exactly that, and the local mirror
+  (this machine's panel listing the `nodeterm-rmt` sessions another machine's nodeterm spawned here,
+  all orphans locally) is the same shape. A kill that knows only a NAME therefore goes to **every
+  socket that name could be on** (`KILL_TMUX_SOCKETS` → `remoteTmuxKillEverySocketArgs` /
+  `localKillSockets`), which is safe because tmux's "can't find session" was already the ignored
+  case, because the target is **exact** (`-t =nt-<id>`: without `=` tmux falls back to fnmatch then
+  PREFIX matching on a miss, and `nt-…-1` is a prefix of `nt-…-12`, so a miss could kill a different
+  session), and because the fan-out is **opt-in and asked for by exactly one caller**: it needs both
+  "we do not know the socket" AND `everySocket` from the caller (`localKillSockets(live, everySocket)`,
+  `sshProject.killSessions(…, {everySocket:true})`, `transport.destroy(id, {everySocket:true})` —
+  the wire legs demand a literal `true`). A destroy for a session we HOLD still fires exactly one
+  kill; and the unheld branch is not rare — an ordinary node-× on a node never mounted in this
+  process takes it, which is the norm after an app restart — so project deletion and every ordinary
+  × stay narrow rather than inheriting the panel's blast radius. The sweep and the reaper keep their own copies of
+  the socket list **on purpose**: for them the ORDER decides first-wins de-duplication, for a kill
+  it means nothing.
+- **The generated SSH shell is tested under a real `/bin/sh`** (`session-memory-remote.test.ts`
+  against a fake host tree, same discipline as `remote-claude-usage.test.ts` and
+  `canvas-control-shim.test.ts`) — and it is not ceremony: the plan's own script said `echo ##MEM`,
+  which prints an **EMPTY LINE** under POSIX sh (an unquoted `#` starts a word-initial comment) and
+  would have made **every healthy host report `ok:false`**. The markers are quoted for that reason,
+  every section header is printed unconditionally (a missing one means the stream was cut short, not
+  that the host had nothing), and the socket names + `-F` format come from the shared constants so
+  the two legs cannot look at different sockets.
+- **Which machine answers** is decided in `session-memory-service.ts` by OR-ing two independent
+  claims of remoteness — the renderer's `remote` flag and the shell's `isRemoteProject` — because a
+  source that answers "no" while momentarily uninformed (index not loaded, master just dropped)
+  would turn a remote query into a LOCAL sweep and publish this machine's sessions under the host's
+  name. `sshScopePredicate` answers from **identity, not liveness** (`workspaceStore.sshProjectIds()`
+  — a DISCONNECTED SSH project is still someone else's machine), OR-ed with the live masters. The
+  `remote` option pair is deliberately asymmetric: `run` is optional, `isRemoteProject` is
+  **required** — reading-without-knowing is a compile error.
+- **Surfaces.** **Desktop**: full. **Server Edition**: the service runs and the ws-bridge has a REAL
+  implementation, so the pill and panel describe the machine the server is served from; an SSH scope
+  answers `ok:false` (no ControlMaster injected) and says so **by identity** via `sshScopePredicate`
+  rather than trusting the renderer's flag — see docs/SERVER.md, including the silent dependency on
+  the boot-time `workspaceStore.load()`. **Relay tabs**: the stub answers `ok:false` and the panel
+  says session memory is not available there, which is a different story from a failure. **Kanban**:
+  Canvas passes `overBoard={kanbanOpen}` (the same prop `UsageIndicator` takes), raising the pill to
+  z 26 over the board's opaque 25, and an open panel to 60; with the board CLOSED the open panel
+  still has to clear the sessions sidebar (z 12), which is the separate
+  `.sysres-indicator:has(.sessmem-panel) { z-index: 13 }` — both `:has()` rules work only because
+  the pill cluster is mounted OUTSIDE `<ReactFlow>`, whose wrapper's inline `z-index: 0` would trap
+  any value inside it. **Mobile**: **N/A for v1** — *nodeterm
+  mobile* attaches to tmux sessions over the transport protocol and has no per-session host-memory
+  concept; adding one means extending that protocol (follow-up in the iOS repo).
+
+**Offscreen release makes the macOS reaper bug far more visible, and the two shipped days apart.**
+A node released while offscreen detaches its PTY client — so it becomes a DETACHED tmux session and
+joins the reaper's candidate pool once past the 6 h grace. On a Mac reading `os.freemem()` the
+watermark was permanently tripped, so those sessions were culled on the next sweep. More automatic
+detaching + an always-true pressure signal is why the symptom read as "my sessions keep
+disappearing" rather than as an occasional cull. The `vm_stat` reader is what makes the pool safe
+again; the grace window was never the thing that was wrong.
+
+
+## Canvas interaction & panels (`Canvas.tsx` is the hub)
+
+- **Context menus** (`components/ContextMenu.tsx`, portal, icons from `components/icons.tsx`):
+  pane right-click = add nodes at cursor (terminal / Claude / sticky / open file) + select
+  all + fit + restart-idle-agents (the bulk in-place agent restart, mirrored in ⌘K; both hidden
+  when the canvas holds no restartable agent node, where they could only report "0 restarted");
+  node/selection right-click = group, color, duplicate, align-to-grid, collapse,
+  markdown-view (terminals), refresh-terminal (terminals — bumps `respawnNonce`: fresh PTY attach
+  to the SAME tmux session; manual recovery for a stuck/unpainted terminal, and the same action
+  sits in the node header as `term-node__refresh` since a dead view is a bad place to hunt for a
+  right-click; nothing running is interrupted), restart-agent
+  (single agent node — the in-place CLI restart above; absent for a CLI we cannot quit + resume,
+  disabled with a hint while the session is busy or has no id yet), delete. Actions live
+  in `Canvas.tsx`, operate on `targetIds`. The non-destructive rows are user-hideable from
+  **Settings → Appearance** ("Node menu items" / "Terminal header buttons"), stored as HIDDEN
+  lists in `settings.hiddenNodeMenuItems` / `settings.hiddenHeaderButtons` (empty = everything
+  shows). `lib/ui-visibility.ts` owns the two inventories and `isHidden`, which only answers for
+  ids it knows — so Delete, restart-agent, branch/transfer, terminal Search and Close can never
+  be hidden, whatever settings.json says. The group-frame menu's colors strip answers to the same
+  `colors` id; builders run through `tidySeparators` so a hidden row leaves no dangling rule.
+- **Add menu** = bottom dock (`Dock.tsx`) `+`, mirrored by the pane menu and command palette.
+- **Undo/redo**: debounced snapshot of the nodes array on settle (drag/edit), `pastRef`/
+  `futureRef` stacks, ⌘Z / ⌘⇧Z + dock buttons. History resets per project load; skipped
+  while typing in inputs/terminals.
+- **Selection/pan**: box-select on left-drag (`SelectionMode.Partial` — touch to select);
+  pan = middle-drag or trackpad two-finger (`panOnScroll`, `zoomOnScroll:false`); pinch
+  zoom. Right mouse is free for the context menu.
+- **Delete** (Delete/Backspace) opens `ConfirmDialog` before removing selected nodes.
+- **"Go to node" (`goToNode`)** — the one camera-travel path (notification click, sessions
+  sidebar, ⌘K jump, presence travel, minimap double-click, double-click focus). It frames the node
+  with `fitView({nodes:[{id}]})` **only when React Flow has MEASURED it**: `getFitViewNodes` filters
+  the fit set by `measured` (no `width`/`height` fallback in there), so an unmeasured node leaves the
+  set EMPTY, its bounds collapse to `{0,0,0,0}` and the camera lands on the canvas **ORIGIN** at max
+  zoom — empty canvas, node off-screen. That is the state every node is in for the first tick after
+  its project loads, which is why **cross-project** focus (the load and the focus happen in the same
+  tick, and measuring can lose the race — heavier canvas = more likely) used to land on nothing and
+  only work on a second try. `renderer/lib/nodeFocus.ts` computes the identical framing from the
+  node's PERSISTED size for that window (`nodeFitRect` resolves the group-parent chain →
+  `viewportForRect` → `setViewport`), and the measured check reads React Flow's **store**
+  (`getInternalNode`), not our node object — `measured` reaches our state one render later (via
+  `onNodesChange`), so our copy lies about nodes the store has long sized. Unknowable size ⇒ the
+  camera **stands still**; never fall back to a bare `fitView` there, that IS the origin jump.
+- **Command palette** (`CommandPalette.tsx`): ⌘/Ctrl+K; `Canvas.buildCommands` (create,
+  switch project, jump to node by title/tag, open file…).
+- **Explorer** (`ExplorerPanel.tsx`, 🗂 / ⌘⇧E): lazy file tree of the active project `cwd`
+  (`fs:list`); click a file → opens an editor node; right-click → Copy Path / Reveal /
+  **New File… / New Folder…** (empty-area right-click targets the root; SSH projects create on the
+  host). Canvas pane right-click and ⌘K also expose **New file…** (creates under the project cwd,
+  opens an editor node). These use `mkdir` + `exists` added to `FsApi`/`SshFsApi` across
+  desktop/server/SSH (`core/fs-ops.ts`, `main/ssh-fs.ts`; relay remote-fs degrades to `false`).
+  Expanded dirs **persist per project** across drawer close + app restart (`state/explorer.ts`
+  zustand store, localStorage `nodeterm.explorerExpanded`).
+- **Source Control** (`main/git-service.ts` system `git` + `gh`, `SourceControlPanel.tsx`,
+  ⎇): file-level **stage/unstage** (+/−), **discard**, click a file → **diff node**,
+  **branch switch/create**, commit (message box at top) + push / sync / publish, **gh
+  sign-in** banner (runs `gh auth login` in a new terminal via `initialCommand`), recent
+  commits. **AI commit message** (✦ Generate) and **AI terminal naming** both use
+  `main/commit-message.ts`: a BYO local agent CLI (claude/codex/custom) spawned read-only on
+  the staged diff / captured terminal output (no built-in model); agent + extra prompt in
+  Settings. The panel operates on a **selected scope**, not on the project cwd — see Worktrees.
+  **Open latency + reopen**: `status()` must never await `gh auth status` — it hits the GitHub
+  API (~700ms) and used to hold the panel's first paint hostage; `ghAuthedSwr()` returns the
+  cached answer and refreshes in the background (the accurate `ghAuthed()` is still awaited on
+  the publish flow). Status/history live in the per-cwd `state/scmCache.ts` store (same pattern
+  as `scmDraft`), so the close→reopen cycle paints the last-known data instantly while the
+  mount refresh replaces it silently — do not move them back into component `useState`.
+- **Worktrees** (bound to **group frames**) — a git worktree binds to a group node
+  (`data.worktree: GroupWorktree {repoPath, branch, baseRef, path, createdByApp}`, persisted), and
+  every node created inside that frame inherits the worktree path as its `cwd`
+  (`cwdForNewNodeIn`) — the frame *is* the binding, so an agent per branch is just a group per
+  branch. Creation is **one step** — **"New worktree…"** from the pane menu / command palette /
+  Source Control — with the repo resolved from the project cwd via `git.repoRoot()` and existing
+  worktrees listed for adoption. (Both git IPCs existed before this feature and had **zero**
+  renderer callers, which is why it was unusable: the dialog's repo field was always empty and had
+  to be typed by hand. Don't re-strand them.)
+  - **One store, one poller** — `renderer/state/worktrees.ts` is the **only** caller of the worktree
+    /status *read* IPCs (`git.repoRoot`, `git.worktreeList`, `git.status`); the group chip, the
+    creation dialog and the Source Control panel all read that store. Three independent pollers would
+    triple the `git` subprocess load and drift out of sync. It is **epoch-guarded** (a project switch
+    bumps the epoch, so a stale in-flight refresh can never overwrite the newer project's
+    `repoRoot`/orphans — worktrees are *created* under `repoRoot` and orphans are offered for
+    *deletion*) and **fails open**. Exactly **two** direct `git.status` reads live outside it, both in
+    `Canvas.tsx` and both deliberate: the one-shot probes on the **Remove** confirm (the dirty-file
+    count in the warning) and on **↪ Move into worktree** (staleness only arrives by poll, so the
+    directory is re-checked immediately before an irreversible session kill). Anything recurring
+    belongs in the store.
+  - **Scoped Source Control** — the panel operates on a selected `ScmScope` (the main checkout or a
+    bound worktree). A worktree scope's **id is its group node id**, which is what lets the canvas
+    selection preselect it. `scmScopes` / `defaultScmScope` / `selectedScmGroupId`
+    (`shared/scm-scope.ts`) decide the list and the default. The panel derives its `cwd` **once** so
+    its ~49 call sites follow — and every Canvas callback it invokes (`onOpenDiff`,
+    `onOpenCommitDiff`, `onExplainCommit`, `onRunInTerminal`) must take the **scope's** cwd, never
+    the project's.
+  - **Reconciliation** (`shared/worktree-reconcile.ts`) — bindings are reconciled against `git
+    worktree list`: a worktree deleted outside the app makes its group **stale** (chip reads
+    "· missing", Merge/Remove hide, ↪ hides, and nothing spawns into the dead path — Unbind is the
+    only action, and it takes the dead cwd off the children with it); a worktree bound to no group
+    is an **orphan**, recoverable from the creation dialog.
+  - **Two non-obvious facts the code depends on — do not "simplify" these away:**
+    1. `git worktree list --porcelain` **keeps listing a worktree whose directory was deleted
+       behind git's back**, tagging it `prunable` — and that tag only exists on **git ≥ 2.36**. So
+       `worktreeList` additionally **stats** each path through an injected `pathExists` seam
+       (`prunable: e.prunable || !pathExists(path)`; `git-service` wires `fs.existsSync`), or the
+       whole stale/orphan story silently fails on the Server Edition's own target platform (Debian 11
+       / Ubuntu 20.04 ship git 2.30).
+    2. **A failed git read is never evidence of absence.** `listWorktrees` returns `{ok, entries}`
+       so "git failed" (spawn EAGAIN, NFS hiccup, corrupt index) stays distinguishable from "git
+       listed nothing" — a transient failure must never be read as "the worktree is gone", at any
+       layer (`ok:false` changes no facts). Staleness from the status poll likewise needs **two
+       consecutive** failed reads (`WORKTREE_STALE_STRIKES`), and the streak is scoped per project
+       so a there-and-back tab switch cannot forget it.
+  - **Destructive safety** — `createdByApp` gates removal: nodeterm deletes only worktrees it
+    created; one the user merely **adopted** unbinds by default, and deleting its directory is an
+    explicit opt-in that **defaults to off** (its branch is kept either way).
+    `isDangerousWorktreeRemovalPath` refuses a path that is the repo, `$HOME`, `/`, or an ancestor
+    of any of them, on **every** removal path. **Merge** always confirms — it merges into the base's
+    *working tree* (`decideMergeStrategy`: merge in the base's checkout when it is clean, else a
+    `fetch . branch:base` when the base is checked out nowhere, else blocked) — and its push to
+    `origin/<base>` is disclosed in that dialog and **opt-in, default off**: a push to origin cannot
+    be politely undone.
+  - **Every path that drops a bound group goes through unbind** — Unbind, Remove, **Ungroup** and
+    **Delete** all route through `releaseWorktreeBinding`, the one place that knows what a dropped
+    binding owes: `displacedByWorktree`'s descendants (terminals whose cwd sits inside the
+    worktree) get that cwd taken off them, and git's registration gets a `pruneOnly` prune. Ungroup
+    and group-delete *keep* the children, so skipping this left a **dead cwd persisted in
+    `project.json`** — invisible until a reboot cold-starts the terminal into a directory that is not
+    there — and left a stale registration that makes a later `worktree add` at the same path fail.
+  - **SSH projects: not supported in v1** — every affordance is shown **disabled with that reason**
+    (a silently-missing row teaches nothing). The gate asks whether the node is a **remote session**
+    (`data.ssh` / `data.sshRemoteTmux`) or the project is an SSH project — **not** `data.remote`,
+    which only *relay* nodes carry: guarding the wrong field let a live remote tmux session be
+    killed into a local path that does not exist on the host (`isRemoteSessionNode` asks about all
+    three). The ops themselves **refuse** a remote repo (`git-service.isRemoteRepo`, via
+    `resolveGitRemote`) rather than guess: the `git` executor routes over the project's ControlMaster
+    while `pathExists` is a **local** `fs.existsSync`, so answering would stat the wrong machine and
+    report *everything is gone* — a refusal is a plain failed op and, crucially, never `worktreeGone`,
+    so nothing is destroyed on a bad guess. Real support needs the worktree path to derive from the
+    connection's cached `remoteHome` and `pathExists` to stat the **remote** fs (a `test -e` over the
+    ControlMaster).
+  - **Mobile companion: not applicable in v1** (the three-surfaces call, made deliberately). A
+    worktree binds to a **group frame** on the canvas, and *nodeterm mobile* (separate repo, `nodeterm-ios`)
+    has no canvas — it attaches to tmux sessions over the `TerminalTransport` protocol, which carries
+    no group/binding concept at all. So there is nothing to degrade gracefully: a worktree's terminals
+    are ordinary tmux sessions and mobile already reaches them, it simply cannot see that they belong
+    to a worktree. Surfacing the binding (a read-only "worktree: <branch>" label per session, say)
+    would mean extending the transport protocol — a **follow-up in the iOS repo**, not this branch.
+    Creation/merge/remove stay desktop+server only: they are destructive git operations, and a phone
+    is the last place to confirm one.
+  - **Known follow-up** — the Explorer tree and the ⌘K file index stay scoped to the **project cwd**,
+    so a bound worktree's files are not browsable/searchable from them (its terminals and editor
+    nodes work fine). Deliberately out of scope here: both index a single root, and making them
+    scope-aware is the same "which checkout am I looking at?" question Source Control already answers
+    with `ScmScope` — that is the seam to reuse when it is built.
+- **Kanban view** (`components/kanban/KanbanView.tsx`; toggle is a Trello-style icon ON the
+  **active project tab** (`.tab__board-toggle`, after the name, before the caret — the view
+  belongs to the project; earlier homes were the tab-strip end, then the controls-cluster,
+  both rejected in use) plus ⌘⇧B / ⌘K): per-project
+  full-page SESSION board OVER the canvas — cards ARE the project's session nodes (React Flow
+  type `terminal`), derived LIVE from the canvas nodes (title/color/kind/agentId), with
+  RUNNING / NEEDS YOU badges + unread dot from the default `agentStatus` store; click = back to
+  canvas + `focusNodeById`. The canvas stays MOUNTED under the opaque overlay (agent-status
+  listeners live in Canvas.tsx; `display:none` would 0×0-resize every terminal into a tmux
+  SIGWINCH), and canvas-only shortcuts (undo, ⌘T/⌘⇧C, Delete) early-return via `isKanbanOpen`.
+  Board data is `project.kanban` ({columns, assignments: [{nodeId, columnId}]}, order = array
+  order) in `.nodeterm/project.json` — git-shared, rides rev/mirror/watcher; absent until the
+  first edit (`defaultKanban` seeds To Do / In Progress / Done). The virtual **Ungrouped**
+  column (never persisted, undeletable/unrenamable, always first) holds every session with no —
+  or dangling — assignment, in canvas order, so the board never opens empty. **Assignment is
+  board metadata only**: drags never move canvas nodes or change groups; dead nodes' assignments
+  prune lazily on each board change (`pruneAssignments`). Column delete is confirm-free (cards
+  return to Ungrouped; no last-column rule — Ungrouped remains). The one shape rule is
+  `validKanban` (`core/workspace-files.ts`), applied on EVERY load path — `fileToProject` AND
+  `loadV3`'s inline (cwd-less) branch, which bypasses fileToProject — so a v1 `{columns, cards}`
+  or hand-mangled board drops to the fresh default instead of crashing the render (view choice
+  persists in localStorage, so a render throw would boot-loop). Pure transforms in
+  `renderer/lib/kanban.ts`; view choice is personal (`state/viewMode.ts`, localStorage
+  `nodeterm.projectView`). The board opens with a **title strip** (`.kanban-header`: project
+  dot + name) whose height clears the floating controls-cluster icons — columns never sit under
+  them. **Cards collapse/expand on single click** (transient state); the expanded detail row
+  reuses `ContextMeter` (model + % pill, per the node header) + session chip + an ↗
+  open-on-canvas button; double-click opens the node directly. Z-order contract: overlay 25 <
+  `.controls-cluster` 26 (Explorer/SC/Settings stay clickable ON the board) < `.top-banners` 27
+  (a mandatory-update card must not hide behind the board) < tabbar 30. An assigned session
+  node shows its column as a **half-pill flush on the node's TOP edge** — see the pill sentence
+  below. A card's ↗ / double-click opens the **card modal** (`components/kanban/CardModal.tsx`, body
+  portal on the dialog-stack, scrim z 55, scrim/Esc close — Esc in CAPTURE phase, and an Esc
+  during a header rename only cancels the edit). Terminal cards get a LIVE second view of the
+  tmux session (`ModalTerminal.tsx`): the pty subscriber ledger is keyed by the composite
+  `(ClientId, viewerId ?? PRIMARY)` (`core/pty-manager.ts` — **viewer identity**; viewerId is an
+  optional TRAILING arg through preload/ws-bridge/LocalTransport, absent = bit-for-bit legacy, and
+  a client's per-connection socket pause survives a single view's departure). The modal viewer
+  seed-paints from the joiner screen (`toXtermText` transforms — raw capture-pane staircases),
+  handles fresh-cold via scrollback snapshot + hint (agent auto-resume stays canvas-only), has
+  deliberately no park/WebGL/hover/flow-control, and kills ONLY its own viewer on close. Sticky
+  cards edit their text in the modal (live both ways).
+  The modal header carries the terminal node's actions (search via `useTerminalSearch`+
+  `FindBar` on the modal xterm; dictate via the same `nodeterm:dictate` event — `.dictation`
+  overlay z is 60, ABOVE the modal scrim; ✦ `pty.generateName` through the modal rename funnel).
+  **The 💬 icon means COMMENTS on both surfaces** (repurposed from the markdown view — ⌘M still
+  toggles markdown/chat on the canvas node): on a terminal node it opens a right-side comments
+  flyout (`.term-node__comments`, a sibling of the overflow:hidden root, hosting BoardLogPanel
+  with `card: Pick<KanbanSession,'id'>`); in the modal it collapses/reopens the panel, which is
+  OPEN BY DEFAULT there. Under the modal header sits the **card metadata strip** (`CardMetaBar.tsx`): Members (assign) —
+  colored initial avatars, picker pool = me + live presence peers + board-log authors (name-keyed,
+  NO separate membership system) — and a Due date (`datetime-local`, red Overdue chip past due;
+  cards show mini avatars + a due chip). Data = `kanban.meta [{nodeId, assignees, dueAt, priority}]` (priority low/medium/high/urgent, colored chips)
+  (tolerant readers via `cardMeta`; pruned with dead nodes; empty entries dropped). Assign/due
+  changes are logged through the SAME diff funnel (`member-assigned/unassigned`, `due-set/cleared`;
+  unknown future event types render neutrally). Feed rows show ABSOLUTE Trello-style stamps
+  (relative in the tooltip). The modal's right third is the **board log** panel (`BoardLogPanel.tsx`, `state/boardLog.ts`):
+  per-person comments + card activity from `<cwd>/.nodeterm/board-log.jsonl` — append-only JSONL
+  (`core/board-log.ts`: tolerant newest-first parse cap 500; text clamped `BOARD_LOG_TEXT_MAX`
+  16KB — an SSH append is ONE printf arg, ARG_MAX would silently drop it), author = presence
+  identity, registered via `core/board-log-handlers.ts` in BOTH shells (client sends only a
+  projectId — the path always derives from the server's own registry, no jail needed). Events
+  come from ONE pure funnel (`lib/boardLogDiff.ts` — binding invariant: its `cardTitle` arg
+  returns '' for and ONLY for dead nodes; column deletion suppresses per-card moved-to-Ungrouped
+  noise; prunes/reorders log nothing) + `createNodeInColumn`'s card-created. Local projects push
+  changes via fs.watch; desktop SSH projects poll 5s while subscribed; inline projects show a
+  hint. Relay tabs BRIDGE boardLog to the host (pre-dispatch `sharedProjectId` scope guard in the
+  relay dispatch — an out-of-scope projectId is refused before any registry/path resolution; a
+  connection drop replays its outstanding onChanged unsubscribes). Deliberate v1 gaps: column-level
+  events are stored but no card feed shows them; canvas-born nodes get no card-created; no
+  card-deleted type.
+  Per-column "+ New session" menus create agents/terminal/sticky nodes assigned to the column
+  (assignment written UN-pruned — the fresh node isn't in the derived list yet). The column
+  half-pill itself: (`components/kanban/ColumnPill.tsx`, `columnForNode` in lib/kanban; rendered
+  as a SIBLING of the node root — the roots are overflow:hidden — hidden for Ungrouped/dangling,
+  click opens the board). Server Edition works as-is (pure renderer + workspace.save). Scope: no
+  agent-driven card movement yet, no board undo, mobile N/A.
+- **Settings** (`SettingsPage.tsx`, ⚙ / ⌘,): font/cursor (live to xterm + Monaco), default
+  shell, grid + snap, **default node size** (`defaultNodeWidth`/`defaultNodeHeight` — new
+  terminal/agent nodes only, clamped in `terminalNodeSize()` in `state/workspace.ts`),
+  pan-hover delay, double-click focus, accent, tmux on/scrollback, commit agent,
+  `seenShortcuts`.
+- **Shortcuts** (`ShortcutsPanel.tsx`, ? / ⌘/): shown once on first launch (`seenShortcuts`).
+- **Welcome** (`WelcomeScreen.tsx`): shown when no projects exist.
+- **Window chrome**: macOS integrated title bar (`titleBarStyle: 'hiddenInset'`); the tab
+  bar (`TabBar.tsx`) is the drag region with the `nodeterm` logo + a rounded pill of project
+  tabs. Cmd+M is intercepted in `main/index.ts` `before-input-event` (else macOS minimizes)
+  and forwarded to the renderer via `app:toggle-markdown`.
+- **Theme**: macOS dark palette as CSS tokens in `styles.css` `:root` (`--accent` = systemBlue,
+  label/separator opacities, SF font stack). Canvas background is black with dot grid.
+
+## Remote access (phone relay) — free, not Pro
+
+- Phone relay remote access ("Reach this Mac from anywhere") is a **Core (free) feature** as of
+  2026-08-01 — the iOS app is itself paid, so a desktop Pro gate double-charged the same feature.
+  The former Pro gate AND the free-tier monthly quota (`core/relay-quota.ts`, `RelayQuotaBanner`,
+  the ProCompare meter, the `relayQuota` IPC/preload/bridge surface, docs/relay-quota.md) were all
+  **removed**. The toggle (`settings.phoneAccessEnabled`, Settings → Phone + quick-pair popover)
+  shows for everyone; the standing host reconciles on `enabled && relayAllowed()` alone, with no
+  quota metering at `onPeerReady`. **Entitlement passthrough remains**: a stored Pro entitlement is
+  sent on mints, else the `{deviceId,…}` body (host-token `{deviceId, hostPublicKeyB64}`, device
+  mint `{deviceId, hostDeviceId, hostPublicKeyB64, label}`). **The backend is the real gate now**:
+  `POST /v1/relay/host-token` / `/v1/relay/device` must admit deviceId (no-entitlement) mints, and
+  the relay server may rate-limit free hosts independently — a client-side gate must NOT be
+  reintroduced to work around a backend refusal (fix the backend policy instead).
+
+## Speech / dictation (desktop + server)
+
+Voice-to-text input captured via microphone, turned into terminal text via on-device Whisper. Works on desktop (Electron) and Server Edition (browser); iOS support is separate (`nodeterm-ios`).
+
+- **Service seam** (`src/core/speech/`) — `SpeechService` (core) + `PlatformSpeechProvider` interface + shell implementations (`PlatformElectron` / `PlatformServer`). Models are stored under `${dataDir}/speech-models/`, with fenced downloads + orphan sweep (`removeUnusedModels`). Core validates license: **tiny** free (always); **base·small·large-v3-turbo** Pro (via `isPremium()`). One model loaded at a time (FIFO memory management), lazy smart-whisper import degrades to a friendly error if the native dep is unavailable (`"Local whisper is unavailable…"`).
+- **Cloud contract (iOS parity)** — `/v1/transcribe` multipart endpoint (not built yet; SDK `transcribe()` call matches iOS byte-for-byte) for future remote transcription. IPC channels `speech:*` wired in **both** Electron (`src/main/platform-electron.ts`) and Server (`src/server/platform-server.ts`): `speech:request-consent` (Electron mic-prompt only, server always true), `speech:synthesize`, `speech:cancel`, returning `Promise<{text, audio}>`.
+- **Renderer capture** — `PcmCapture` AudioWorklet (16kHz single-channel PCM, WebAudio or fallback SPN) + DictationOverlay (⌘⇧D dock mic / Cmd key; Settings → Speech section for model choice + progress). **Send** appends text + Enter to the terminal; **Insert** sends text-only via `sendText(…, {enter: false})`. **Nothing auto-submits** (user always decides when to send).
+- **Browser constraints** — `getUserMedia` requires HTTPS or `localhost`; mic permission prompt is the browser's own (not handled by nodeterm). Model downloads land on the **server's data dir** (accessible across sessions).
+- **Electron + native dep** — smart-whisper is externalized + `asarUnpack`'d (not bundled); `postinstall` rebuilds it against Electron's ABI. Device verification of the ABI rebuild is not yet exercised on a dev machine — test paths exist but have not been run in CI.
+
+## Packaging & auto-update
+
+Built with **electron-builder** (config in the `package.json` `build` block: appId
+`com.nodeterm.app`, productName `nodeterm`, mac dmg+zip for arm64 **and** x64, `asarUnpack`
+node-pty, output `dist/`). The app icon is generated from the nodeterm mark by
+`scripts/make-icon.mjs` (sharp → `build/icon.png`, 1024², gitignored — regenerated by
+`make-icon`); electron-builder derives the `.icns`. Scripts: `npm run make-icon`, `npm run dist`
+(local **unsigned** arm64 `.dmg` smoke test). Production release signing/notarization and the
+update-feed hosting are handled outside this repo.
+
+Auto-update uses **electron-updater** (`src/main/updater.ts`, `initUpdater(win)` from `index.ts`):
+runs **only when `app.isPackaged`** (dev = no-op), checks on launch + every 6h, auto-downloads,
+forwards the lifecycle (`update-available` / `download-progress` / `update-downloaded` / errors)
+to the renderer over IPC. `components/UpdateCard.tsx` shows the strip + **Restart to update** →
+`updates.restart()` → `autoUpdater.quitAndInstall()`; on `update-downloaded` an OS notification
+also fires when the window is unfocused. Exposed via `window.nodeTerminal.updates` (`UpdateApi`).
+macOS *silent* self-install requires a signed+notarized build; unsigned builds still surface
+the card for a manual download.
+
+**Backend check feed** (`src/main/check.ts`, successor to the static `announcements.json`): the
+**main process** calls `GET https://api.nodeterm.dev/v1/check?version=&os=&channel=stable` (so the
+renderer CSP stays `'self'`) on launch + every 6h, cached 5 min, returning `{ messages, update }`.
+Exposed split over two IPC handlers: `announcements.fetch()` → `messages`, `appUpdatePolicy` →
+`update`. `components/AnnouncementBanner.tsx` (stacked above `UpdateCard` under the tab bar in a
+`.top-banners` column) shows the newest message the user hasn't dismissed (dismissed `id`s persist
+in `localStorage`); `update.mandatory`/`minSupported` flips `UpdateCard` into a blocking required-
+update state. The call no-ops under `DO_NOT_TRACK`/`NODETERM_TELEMETRY_DISABLED` or in unpackaged
+builds (unless `NODETERM_API_BASE` targets a local server). Schema example:
+`docs/announcements.example.json`. **Telemetry** (`src/main/telemetry.ts`) is a separate opt-out
+ping to `api.nodeterm.dev/v1/telemetry` (version/OS on launch + daily), gated on
+`settings.telemetryEnabled` + the same build/DNT guards; toggle in Settings → Privacy.
+
+## Conventions
+
+- **Two docs, two audiences — keep both.** This file holds the deep invariants with their
+  reasoning and measurements; it is dense on purpose and is loaded automatically by coding agents.
+  **`CONTRIBUTING.md` is the short human door**: setup, the process-boundary rules, the house rules
+  that get a PR sent back, and the testing habits. When you change or discover something **other
+  developers must know before touching the code** — a boundary that is now enforced, a trap that
+  costs an hour to diagnose, a habit that catches a class of bug — **add it to `CONTRIBUTING.md`
+  too, not only here.** An invariant that lives only in this file (or worse, only in a commit
+  message) is one refactor away from being violated by a contributor who never opened it. Keep the
+  split by audience, not by topic: the *why it must be this way* stays here, the *what you need to
+  know before your first PR* goes there.
+
+
+- Code comments, UI strings, and identifiers are all in **English**. Match this when editing.
+- Path aliases: `@shared/*`, `@renderer/*` (see the tsconfig files / vite config).
+- **Subagent model:** when dispatching subagents (implementers, reviewers, etc. — e.g. in
+  the subagent-driven-development workflow), use the latest model, **Opus 5**
+  (`claude-opus-5`). This overrides any cheaper-model defaults in a skill's model-selection
+  guidance.
+- **Three surfaces — design every feature for all of them.** nodeterm now ships on three
+  fronts, and a feature is not "done" until you've decided how it behaves on each (even if
+  the decision is "not applicable here"):
+  1. **Desktop** (Electron) — the primary app (`src/main` + `src/renderer` via the preload).
+  2. **Server Edition** (Linux, browser) — `src/server` + the `src/renderer/bridge` shim (see
+     the `src/server/` bullet above and docs/SERVER.md).
+  3. **Mobile companion** — *nodeterm mobile*, a **separate repo** (`nodeterm-ios`)
+     (SwiftUI + SwiftTerm/Citadel, tmux-integrated, talks the `TerminalTransport`/RemoteTransport
+     protocol).
+
+  **The canvas and the kanban board are TWO VIEWS of the same nodes — treat the board as a
+  first-class surface, not an afterthought.** Every session/node feature you add to a canvas node
+  (a header action, a context-menu item, a status badge, file drop, dictation, …) should be
+  considered for the kanban **card** and its **card modal** too, so we don't keep shipping a
+  feature on one view and then bolting it onto the other in a follow-up. The board already mirrors
+  most of the node's surface: the card modal co-attaches the same tmux session (`ModalTerminal`),
+  carries the node's actions (search / dictate / AI-name / comments), accepts file drops
+  (`terminal/file-drop.ts`), renders browser webviews (`BrowserSurface`), and its cards support
+  right-click actions + `+ New`. When you touch a node's UI, ask "does the board need this too?"
+  and wire it through `KanbanView`/`SessionCard`/`CardModal` in the SAME change. Kanban itself is
+  desktop+Server-Edition (pure renderer + `workspace.save`); the iOS board is a separate read/move
+  mirror (`nodeterm-ios`, `KanbanGrouping`/`ProjectBoardView`).
+
+  Practical rules that keep the surfaces in sync:
+  - **Put new service/main-process logic in `src/core` behind `CorePlatform`, never inline in
+    `src/main`.** That is the seam the Server Edition boots from — logic left in `src/main`
+    silently doesn't exist on the server (the `no-electron` tests enforce the boundary, but
+    they can't tell you a feature is *missing* server-side).
+  - **A feature that touches `window.nodeTerminal` needs a real `src/renderer/bridge`
+    implementation, not just a stub** — or a deliberate, documented graceful degrade
+    (`E_UNSUPPORTED` + the affordance hidden, like the Electron-only `shell.reveal`). The
+    bridge's `satisfies NodeTerminalApi` gate forces you to *declare* every member, but a
+    `noopUnsub`/`unsupported` stub compiles fine while doing nothing — decide per member.
+  - **Consider whether the mobile companion should surface the feature** over its
+    transport/protocol. It's a different repo and stack (Swift), so this is usually a
+    follow-up note rather than same-PR work — but flag it so it isn't forgotten.
+  When a change is genuinely desktop-only (native menus, auto-update, Keychain), say so; the
+  point is to make the call consciously, not to leave the other surfaces to rot.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1629,7 +1629,7 @@ again; the grace window was never the thing that was wrong.
 
 ## Speech / dictation (desktop + server)
 
-Voice-to-text input captured via microphone, turned into terminal text via on-device Whisper. Works on desktop (Electron) and Server Edition (browser); iOS support is separate (`nodeterm-ios`).
+Voice-to-text input captured via microphone, turned into terminal text via on-device Whisper. Works on desktop (Electron) and Server Edition (browser); iOS support is separate (`nodeterm-ios`, private — see the three-surfaces entry under Conventions).
 
 - **Service seam** (`src/core/speech/`) — `SpeechService` (core) + `PlatformSpeechProvider` interface + shell implementations (`PlatformElectron` / `PlatformServer`). Models are stored under `${dataDir}/speech-models/`, with fenced downloads + orphan sweep (`removeUnusedModels`). Core validates license: **tiny** free (always); **base·small·large-v3-turbo** Pro (via `isPremium()`). One model loaded at a time (FIFO memory management), lazy smart-whisper import degrades to a friendly error if the native dep is unavailable (`"Local whisper is unavailable…"`).
 - **Cloud contract (iOS parity)** — `/v1/transcribe` multipart endpoint (not built yet; SDK `transcribe()` call matches iOS byte-for-byte) for future remote transcription. IPC channels `speech:*` wired in **both** Electron (`src/main/platform-electron.ts`) and Server (`src/server/platform-server.ts`): `speech:request-consent` (Electron mic-prompt only, server always true), `speech:synthesize`, `speech:cancel`, returning `Promise<{text, audio}>`.
@@ -1695,7 +1695,9 @@ ping to `api.nodeterm.dev/v1/telemetry` (version/OS on launch + daily), gated on
   1. **Desktop** (Electron) — the primary app (`src/main` + `src/renderer` via the preload).
   2. **Server Edition** (Linux, browser) — `src/server` + the `src/renderer/bridge` shim (see
      the `src/server/` bullet above and docs/SERVER.md).
-  3. **Mobile companion** — *nodeterm mobile*, a **separate repo** (`nodeterm-ios`)
+  3. **Mobile companion** — *nodeterm mobile*, a **separate PRIVATE repo** (`nodeterm-ios`)
+     — outside contributors cannot see or PR it, so a mobile implication is raised in the
+     desktop PR and **@eneskirca** is mentioned to carry it over
      (SwiftUI + SwiftTerm/Citadel, tmux-integrated, talks the `TerminalTransport`/RemoteTransport
      protocol).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,10 @@ applicable here":
 
 1. **Desktop** (Electron)
 2. **Server Edition** (Linux, browser)
-3. **Mobile companion** — a separate repo, usually a follow-up note rather than same-PR work
+3. **Mobile companion** — *nodeterm mobile*, a **private** repo (`nodeterm-ios`, SwiftUI). You
+   cannot open a PR against it, so this is normally a follow-up note rather than same-PR
+   work: say in your PR what the mobile side would need, and **mention @eneskirca** so it
+   gets picked up there. "Not applicable" is a fine answer — just make it a stated one.
 
 Anything reachable from `window.nodeTerminal` needs a **real** implementation in
 `src/renderer/bridge/`, or a deliberate, documented degrade. The `satisfies NodeTerminalApi` gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to nodeterm
+
+Thanks for looking. This file is the short door: enough to get running, plus the house rules that
+actually get a pull request sent back. The long version — every subsystem and the reasoning behind
+its invariants — lives in `CLAUDE.md` at the repo root, which is also loaded automatically if you
+work with an AI coding agent.
+
+nodeterm is licensed **BUSL-1.1** (converts to MIT after four years — see `LICENSE`). Contributions
+are accepted under that license.
+
+## Getting set up
+
+```bash
+npm install        # also patches + rebuilds node-pty against Electron's ABI (postinstall)
+npm run dev        # dev mode with renderer HMR
+npm run typecheck  # tsc for both the node and web projects — the fastest correctness gate
+npm test           # vitest, unit + integration
+```
+
+`npm run server:dev` boots the Server Edition (browser UI) if you are working on that surface.
+
+**If `src/main/node-pty-patch.test.ts` is red, your `node_modules` is unpatched — not your code.**
+Run `npm run rebuild`. node-pty 1.1.0 leaks a pty device per spawn on macOS
+([node-pty#950](https://github.com/microsoft/node-pty/issues/950)); we patch its source before
+`electron-rebuild` compiles it, and that test guards the patch surviving upgrades.
+
+## Where code goes
+
+The repo is split by Electron process boundary and the split is enforced, not advisory:
+
+| Directory | What lives there |
+|---|---|
+| `src/core/` | Electron-free service core. Talks to its shell only through `CorePlatform`. |
+| `src/main/` | The Electron shell around `src/core` — windows, IPC, dialogs. |
+| `src/server/` | The Server Edition shell (browser UI over WS-RPC). |
+| `src/preload/` | The only bridge: `contextBridge` exposing `window.nodeTerminal`. |
+| `src/renderer/` | React UI. Reaches main *only* through `window.nodeTerminal`. |
+| `src/shared/` | Types and IPC channel names imported by all sides. |
+
+`src/core/no-electron.test.ts` and `src/server/no-electron.test.ts` fail if `src/core` or
+`src/server` import `electron` or `../main/*`.
+
+**Put new service logic in `src/core` behind `CorePlatform`, not inline in `src/main`.** That is the
+seam the Server Edition boots from; logic left in `src/main` silently does not exist there, and the
+boundary tests cannot tell you a feature is *missing*.
+
+## Three surfaces
+
+A feature is not done until you have decided how it behaves on each — even if the decision is "not
+applicable here":
+
+1. **Desktop** (Electron)
+2. **Server Edition** (Linux, browser)
+3. **Mobile companion** — a separate repo, usually a follow-up note rather than same-PR work
+
+Anything reachable from `window.nodeTerminal` needs a **real** implementation in
+`src/renderer/bridge/`, or a deliberate, documented degrade. The `satisfies NodeTerminalApi` gate
+forces you to *declare* every member, but a no-op stub compiles fine while doing nothing.
+
+The **canvas and the kanban board are two views of the same nodes.** When you add something to a
+canvas node — a header action, a badge, a menu item — ask whether the board's card and card modal
+need it too, and wire it in the same change.
+
+## House rules
+
+These are the ones that come up in review most often. Each exists because its absence caused a real
+bug.
+
+**A failed read is never evidence of absence.** "Could not measure" and "there is nothing" are
+different facts and must stay distinguishable at every layer. Collapsing them is how a panel ends up
+reporting "no sessions" on a host running thirty.
+
+**Degrade to nothing, never to something wrong.** A probe that fails means the bare, safe command —
+never a substituted nearest match. A hand-editable value that is unrecognised must yield the safe
+default, never something more destructive than the default.
+
+**Re-validate hand-editable values at the point of use**, not by their TypeScript type. Settings
+come from git-shared JSON and can end up interpolated into a shell command line.
+
+**Test generated shell for real.** If you generate a shell command, run it under an actual
+`/bin/sh` against a fixture tree. A composed fixture will not tell you that `echo ##MEM` prints an
+empty line because `#` starts a comment.
+
+**Do not take scrolling away from tmux.** It owns the mouse, the scrollback and the alternate
+screen. A previous design moved that into the emulator and failed structurally; `CLAUDE.md` explains
+why in detail.
+
+**Comments explain WHY, and name the failure they prevent.** The codebase is deliberately dense with
+reasoning. A comment that restates the code is noise; one that says "do not simplify this back,
+here is what broke" is the point.
+
+## Testing
+
+`npm test` must pass, and `npm run typecheck` is the fastest gate.
+
+Beyond that, one habit is worth more than any other here:
+
+**Mutation-test your guards.** Delete or invert the check you just added and confirm a test *fails*.
+A green suite is not evidence on its own — during one recent feature this caught nine tests that
+passed with the code they were meant to pin removed, including one mutation that survived the entire
+4,500-test suite because the class it touched had no test file at all.
+
+Watch for fixtures that cannot discriminate: if every row in your fixture happens to make the
+mutant's output identical to the real one, the test proves nothing while looking thorough.
+
+Where a behaviour can only be verified on hardware we do not have in CI (a Mac, a real SSH host, a
+GPU), say so explicitly rather than implying coverage. Several docs carry numbered device
+checklists for exactly this.
+
+## Pull requests
+
+- Branch from `main`. CI runs `quality`, `CodeQL` and `Dependency review`; all three are required.
+- Explain **why**, not just what. If a decision has a trade-off, name it and say what you rejected.
+- If you measured something, put the numbers in — they save the next person the same afternoon.
+- Say what you did **not** verify. That is more useful than a confident summary.
+
+## Documentation
+
+Two files, two audiences:
+
+- **`CONTRIBUTING.md`** (this file) — what another human needs before touching the code.
+- **`CLAUDE.md`** — the deep invariants, per subsystem, with the reasoning and the measurements.
+
+**If you change or discover something other contributors must know, update this file too.** An
+invariant that only lives in a commit message is one refactor away from being violated by someone
+who never saw it.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,10 @@ under [`docs/`](./docs) for deeper notes.
 
 ## 🤝 Contributing
 
-Issues and pull requests are welcome. Questions or bug reports are also happy at
+Issues and pull requests are welcome. **Start with [CONTRIBUTING.md](./CONTRIBUTING.md)** —
+setup, the process-boundary rules, and the house rules that come up in review.
+[CLAUDE.md](./CLAUDE.md) is the deep reference behind them (and is loaded automatically if
+you work with an AI coding agent). Questions or bug reports are also happy at
 [nodeterm.dev/support](https://nodeterm.dev/support) / support@nodeterm.dev. nodeterm is licensed under the
 [Business Source License 1.1](https://mariadb.com/bsl11/) — you can use, modify,
 and redistribute it freely, including in production, except offering it as a


### PR DESCRIPTION
The repo had no `CONTRIBUTING.md`, and the invariants that actually get a PR sent back lived only in a **gitignored** file on one machine. A contributor could not see rules like *"put service logic in `src/core` behind `CorePlatform`, or the Server Edition silently does not have it"*, *"a failed read is never evidence of absence"*, or *"test generated shell under a real `/bin/sh`"* until review told them.

**Two files, two audiences.**

- **`CONTRIBUTING.md`** — the short human door: setup (including why `node-pty-patch.test.ts` going red means unpatched `node_modules`, not broken code), the process-boundary map and the tests that enforce it, the three surfaces, the house rules, and the testing habit that matters most here.
- **`CLAUDE.md`** — the deep reference, now in the repo. Beyond documentation, this is functional: Claude Code loads it automatically, so anyone working in a clone with an agent gets the project's invariants instead of inferred ones.

**Publishing `CLAUDE.md` was checked, not assumed.** Scanned for credentials, tokens, personal paths, hostnames, IPs and identifiable user reports — none. Its security content describes *defences*, and the source it describes is already public under BUSL, so it adds no attack surface. Three cleanups came with it: a local `~/projects/...` path made repo-neutral, a hardcoded subagent model name made model-agnostic, and a header pointing readers at `CONTRIBUTING.md` first.

`CLAUDE.md`'s Conventions now carry the rule that keeps the two in sync: **something other developers must know belongs in BOTH.** An invariant that lives only in the deep reference — or only in a commit message — is one refactor away from being violated by someone who never opened it.

README's Contributing section now points at both. Docs only; gates run clean (5071 passed).