### PR TITLE
feat(agents): background shell tasks protect their node from Eco and bulk restart

### DIFF
--- a/docs/superpowers/plans/2026-08-10-ram-optimization.md
+++ b/docs/superpowers/plans/2026-08-10-ram-optimization.md
@@ -856,6 +856,7 @@ describe('planHibernation', () => {
 5. Kanban card modal co-attached while hibernation fires (modal viewer sees the exit; acceptable? decide + document).
 6. Managed-account node (CLAUDE_CONFIG_DIR) resumes into the right account dir.
 7. A `/loop` node (ScheduleWakeup) and a `/cron` node stay untouched through several sweeps while eligible-looking (done + offscreen + idle) — the `recurring` guard holds end-to-end, and their next scheduled wakeup fires on time.
+8. A node with a running **background shell task** (`Bash` with `run_in_background: true`) is not hibernated by an enabled Eco sweep; after the task completes and its turn runs, hibernation happens one idle window later. (Background-task guard — `docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md`.)
 
 ---
 

--- a/docs/superpowers/plans/2026-08-12-background-task-guard.md
+++ b/docs/superpowers/plans/2026-08-12-background-task-guard.md
@@ -1,0 +1,176 @@
+# Background-Task Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A live Claude Code background shell task (`Bash` with `run_in_background: true`) protects its node from Eco hibernation and from the bulk "Restart idle agents" action — closing the one signal-less `/exit`-kills-work gap left by PR #130.
+
+**Architecture:** Approved spec: `docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md` (on disk beside this plan; force-add BOTH files in this PR — `/docs/superpowers/` is gitignored, plans/specs ride feature PRs by convention). Approach A: normalize emits a `background-task` event from Claude's `PreToolUse` (replacing the generic "working" for that one call — harmless, the turn is full of other working events); `agentStatus` stamps transient `backgroundTaskAt`, cleared only at a **turn START** (`done`/`undefined` → `working`; a `blocked`/`waiting` → `working` resumption keeps it — see the spec's §2); `planHibernation` and `planBulkRestart` exclude stamped nodes (bulk counts them in the frozen `skipped.working` bucket). Single-node restart untouched (user decision).
+
+**Tech Stack:** TypeScript, vitest. Two tasks, one PR.
+
+## Global Constraints
+
+- Branch off **origin/main** in a worktree; anchors below were read from origin/main on 2026-08-12 (`git show origin/main:<path>` — the main checkout is stale and belongs to a parallel session; NEVER commit there).
+- Gates per task: `npm run typecheck` + the named vitest files; full `npm test` before the PR.
+- English code/comments, constraint-style; CLAUDE.md rule 7 (closed sets — claude-only signal, no speculative widening) and rule 2 (grep what else a list/type gates before joining it).
+- `agent-restart.test.ts` pre-existing tests must stay green **unmodified** (the Task 8 pin discipline).
+- The bulk summary line is spec-frozen at four parts — background-task skips land in `skipped.working`, never a fifth part.
+
+---
+
+### Task 1: Signal + store (normalize event, agentStatus stamp/clear, Canvas wiring)
+
+**Files:**
+- Modify: `src/shared/agents/normalize.ts` (kind union at `:10`; `ClaudePayload.tool_input` type at `:92`; the claude `PreToolUse` branch — insert BEFORE the `// Any other tool use is just "working".` fallback)
+- Modify: `src/renderer/state/agentStatus.ts` (transient field + action + clear in `setState`'s transition branch)
+- Modify: `src/renderer/canvas/Canvas.tsx` (the `agent:status` listener — add a case beside the `recurring` handling; grep `kind === 'recurring'`)
+- Test: `src/shared/agents/normalize.test.ts` (extend), `src/renderer/state/agentStatus` test files (extend the persistence + setState suites; grep `agentStatus.persist.test.ts` / `agentStatus-session.test.ts` for the house harness)
+
+**Interfaces:**
+- Produces: `NormalizedAgentEvent.kind` gains `'background-task'`; `useAgentStatus` gains `backgroundTaskAt?: number` (transient) and action `markBackgroundTask(id: string): void`.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Write the failing normalize tests**
+
+```ts
+// in normalize.test.ts, beside the existing claude PreToolUse cases (match the file's envelope helper)
+it('claude PreToolUse Bash with run_in_background=true is a background-task event', () => {
+  const e = normalizeClaude({ nodeId: 'n1', agentId: 'claude', payload: {
+    hook_event_name: 'PreToolUse', tool_name: 'Bash',
+    tool_input: { command: 'sleep 999', run_in_background: true }
+  }})
+  expect(e?.kind).toBe('background-task')
+})
+it('foreground Bash, false/absent flag, PostToolUse, and other tools stay generic working', () => {
+  for (const payload of [
+    { hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'ls' } },
+    { hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'ls', run_in_background: false } },
+    { hook_event_name: 'PostToolUse', tool_name: 'Bash', tool_input: { command: 'ls', run_in_background: true } },
+    { hook_event_name: 'PreToolUse', tool_name: 'Read', tool_input: { run_in_background: true } }
+  ]) {
+    const e = normalizeClaude({ nodeId: 'n1', agentId: 'claude', payload })
+    expect(e?.kind).toBe('state')
+    expect(e?.state).toBe('working')
+  }
+})
+```
+
+(Adapt the call shape to the file's existing helpers — it may wrap payloads. The four negative rows are the mutation guard: a `tool_name` check dropped, an `ev` check dropped, or a truthiness check instead of `=== true` each flips one row.)
+
+- [ ] **Step 2: Run to verify failure** — `npx vitest run src/shared/agents/normalize.test.ts` — the first test fails (`kind` is `'state'`).
+
+- [ ] **Step 3: Implement the normalize branch**
+
+`kind` union (`:10`): add `'background-task'`. `ClaudePayload.tool_input` (`:92`): add `run_in_background?: boolean`. In the claude `PreToolUse|PostToolUse` block, directly before the `// Any other tool use is just "working".` line:
+
+```ts
+    // A background shell task lives INSIDE the CLI process: /exit kills it silently. This event
+    // is the stamp Eco hibernation and the bulk restart exclude on (see hibernation-policy /
+    // planBulkRestart). PreToolUse only, and `=== true` — an absent or false flag is a foreground
+    // command, which the generic "working" below already covers. Claude-only: no other dialect
+    // carries the field (closed set, CLAUDE.md agent rule 7).
+    if (ev === 'PreToolUse' && tool === 'Bash' && p.tool_input?.run_in_background === true) {
+      return { ...base, kind: 'background-task' }
+    }
+```
+
+- [ ] **Step 4: Run** — normalize tests PASS.
+
+- [ ] **Step 5: Write the failing store tests**
+
+In the agentStatus suite (match its store-reset harness):
+
+```ts
+it('markBackgroundTask stamps; only a transition TO working clears it', () => {
+  const s = useAgentStatus.getState()
+  s.setState('n1', 'done', 'claude')
+  s.markBackgroundTask('n1')
+  expect(useAgentStatus.getState().byId['n1']?.backgroundTaskAt).toBeTypeOf('number')
+  s.setState('n1', 'waiting', 'claude') // done -> waiting: NOT cleared
+  expect(useAgentStatus.getState().byId['n1']?.backgroundTaskAt).toBeTypeOf('number')
+  s.setState('n1', 'working', 'claude') // -> working: cleared
+  expect(useAgentStatus.getState().byId['n1']?.backgroundTaskAt).toBeUndefined()
+})
+it('backgroundTaskAt is never persisted', () => {
+  // extend the existing "never written" persistence assertions (lastEventAt/stateAt pattern)
+})
+```
+
+- [ ] **Step 6: Implement the store**
+
+`backgroundTaskAt?: number` on the entry type with a comment (transient — same rationale as `lastEventAt`: after a relaunch Eco is inert until a turn, and any turn's `working` would have cleared it). `markBackgroundTask(id)` in house action style (stamp `Date.now()`, no save — transient). In `setState`'s transition branch, beside the hibernated self-heal: `if (state === 'working') delete entry.backgroundTaskAt` (or set undefined, matching the file's idiom) — comment: a turn start follows the completed task's `<task-notification>`; clearing on `done` would drop the guard while the task still runs.
+
+- [ ] **Step 7: Wire Canvas** — in the `agent:status` listener, beside the `recurring` case: `if (e.kind === 'background-task') { cs.markBackgroundTask(e.nodeId); return }` (match the listener's local naming). No re-render concern: the store write touches one entry and nothing subscribes to `backgroundTaskAt` reactively.
+
+- [ ] **Step 8: Gates + commit**
+
+`npx vitest run src/shared/agents/normalize.test.ts src/renderer/state && npm run typecheck`
+Commit: `feat(agents): background-task hook signal + transient stamp` + Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+
+---
+
+### Task 2: Consumers (hibernation exclusion + bulk-restart skip) + spec/plan force-add
+
+**Files:**
+- Modify: `src/renderer/lib/hibernationCandidates.ts` (`HibernationStatusInput` + candidate assembly), `src/renderer/terminal/hibernation-policy.ts` (required field + exclusion), `src/renderer/terminal/agent-restart.ts` (`BulkRestartCandidate` + `planBulkRestart`), `src/renderer/canvas/Canvas.tsx` (both feeds: the sweep's status narrowing + the bulk action's candidate build — grep `planBulkRestart(`)
+- Test: `src/renderer/lib/hibernationCandidates.test.ts`, `src/renderer/terminal/hibernation-policy.test.ts`, `src/renderer/terminal/agent-restart.test.ts` (ADDITIONS ONLY — zero deletions)
+- Add to git: `docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md` + this plan (`git add -f`, both live on disk in the stale main checkout — copy them into the worktree first)
+
+**Interfaces:**
+- Consumes: Task 1's `backgroundTaskAt`.
+- Produces: `HibernationCandidate.liveBackgroundTask: boolean` (required); `BulkRestartCandidate.backgroundTask: boolean` (required — typecheck forces the call sites, per the `remote`/`liveBackgroundTask` precedent).
+
+- [ ] **Step 1: Failing tests, all three files**
+
+```ts
+// hibernation-policy.test.ts — the oldest-node-surfaces mutation pattern used by every exclusion row
+it('never hibernates a node with a live background task', () => {
+  expect(planHibernation([base('a', { liveBackgroundTask: true, lastEventAt: 0 })], NOW, cfg)).toEqual([])
+})
+// + add liveBackgroundTask: false to base() so every existing fixture still compiles
+
+// hibernationCandidates.test.ts
+it('liveBackgroundTask mirrors backgroundTaskAt presence', () => {
+  // statusById: { a: { ...done..., backgroundTaskAt: 123 }, b: { ...done... } }
+  // expect candidate a.liveBackgroundTask true, b false
+})
+
+// agent-restart.test.ts (append only)
+it('bulk restart files a background-task node under the working skips', () => {
+  const plan = planBulkRestart([
+    { id: 'a', agentId: 'claude', state: 'done', sessionId: 's1', wired: true, backgroundTask: true },
+    { id: 'b', agentId: 'claude', state: 'done', sessionId: 's2', wired: true, backgroundTask: false }
+  ])
+  expect(plan.runnable).toEqual(['b'])
+  expect(plan.skipped.working).toBe(1)
+})
+```
+
+- [ ] **Step 2: Run to verify failures** (type errors on the new required fields count as the red).
+
+- [ ] **Step 3: Implement**
+
+- `HibernationStatusInput` += `backgroundTaskAt?: number` (doc comment: the third safety fact this adapter exists for — see the header's pattern); candidate assembly: `liveBackgroundTask: st?.backgroundTaskAt !== undefined`.
+- `HibernationCandidate` += required `liveBackgroundTask: boolean`; conjunction gains `!c.liveBackgroundTask` with a header sentence (a background shell dies with the CLI; no hook fires while it runs, so the stamp is the only signal).
+- `BulkRestartCandidate` += required `backgroundTask: boolean`; in `planBulkRestart`, AFTER the eligibility gate and BEFORE the wired check: `if (c.backgroundTask) { plan.skipped.working++; continue }` — comment: counted as `working` ("busy, try again in a moment" — exactly what a live background task is), because the summary line is frozen at four parts. A not-resumable background-task node stays uncounted, as today.
+- Canvas: the sweep's `statusById` narrowing passes `backgroundTaskAt` through; the bulk action's candidate build adds `backgroundTask: !!st?.backgroundTaskAt`.
+
+- [ ] **Step 4: Gates**
+
+`npx vitest run src/renderer/lib src/renderer/terminal src/renderer/state src/shared && npm run typecheck` — and verify `git diff --numstat` on `agent-restart.test.ts` shows **0 deletions**.
+
+- [ ] **Step 5: Force-add the docs + commit + PR**
+
+```bash
+git add -f docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md docs/superpowers/plans/2026-08-12-background-task-guard.md
+git add <code files>
+git commit -m "feat(renderer): exclude background-task nodes from Eco and bulk restart" # + Co-Authored-By
+```
+
+PR body must include: the concurrent-tasks accepted edge (first completion's turn clears the stamp; mitigated by the idle-window reset), claude-only rationale, the frozen-four-parts accounting decision, and the new device-checklist item 9 (a node with a running background shell is not hibernated; after the task completes and its turn runs, hibernation happens one idle window later).
+
+---
+
+## Out of scope (spec §Out of scope)
+
+Single-node restart guard; non-Claude agents; completion sniffing (named escalation: approach C); any "why didn't this hibernate" UI.

--- a/docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md
+++ b/docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md
@@ -27,7 +27,7 @@ Both shells get this for free: normalize is shared, and the raw listeners forwar
 Transient `backgroundTaskAt?: number` per node. **Not persisted** — same rationale as `lastEventAt`: after an app relaunch Eco is structurally inert until the node takes a turn, so a persisted stamp would only assert staleness with confidence.
 
 - **Set:** Canvas's `agent:status` listener stamps `Date.now()` on a `background-task` event (a dedicated store action in house style, bail-when-unchanged not needed — re-stamping on every launch is correct).
-- **Clear:** in `setState`'s transition branch, only at a turn **START** (`done`/`undefined` → `working`; `blocked`/`waiting` → `working` is a mid-turn resumption and KEEPS the stamp). Rationale: a background task's completion queues a `<task-notification>` into the parent transcript, which re-invokes the agent — a turn starts — `working` fires. Clearing on `done` would be wrong: a turn can end while the task still runs. And clearing on *every* `working` transition would be wrong too: a background `Bash` whose command needs approval runs UserPromptSubmit(working) → PreToolUse(stamp) → PermissionRequest(blocked) → approve → PostToolUse(working), so the resumption edge would clear the stamp milliseconds after it was set, for exactly the task this guard exists for.
+- **Clear:** in `setState`'s transition branch, only at a turn **START** — `done` → `working`, and nothing else. `blocked`/`waiting` → `working` is a mid-turn resumption and KEEPS the stamp; so does `undefined` → `working`, because an unknown previous state is reachable mid-turn (a renderer reload starts with an empty table; `sweepStaleWorking` blanks a working entry) and is therefore no evidence of a turn start. Rationale: a background task's completion queues a `<task-notification>` into the parent transcript, which re-invokes the agent — a turn starts — `working` fires. Clearing on `done` would be wrong: a turn can end while the task still runs. And clearing on *every* `working` transition would be wrong too: a background `Bash` whose command needs approval runs UserPromptSubmit(working) → PreToolUse(stamp) → PermissionRequest(blocked) → approve → PostToolUse(working), so the resumption edge would clear the stamp milliseconds after it was set, for exactly the task this guard exists for.
 
 ### 3. Consumers
 
@@ -40,14 +40,15 @@ Transient `backgroundTaskAt?: number` per node. **Not persisted** — same ratio
 - **App relaunch:** stamp is gone (transient) — consistent, because Eco cannot act until a turn happens, and any turn's `working` would have cleared the stamp anyway.
 - **A task reporting back while the node sits `waiting`/`blocked`:** the clear needs a turn START, so a `<task-notification>` that lands while the session holds a question open (`waiting`/`blocked` → `working` is a resumption) leaves the stamp in place until the turn after that. Bounded and in the fail-safe direction — and such a node is never a hibernation candidate anyway, since `planHibernation` requires `state === 'done'`.
 - **Manual task kill without a turn:** the stamp stays until the next turn — the node simply isn't hibernated. Fail-safe direction (memory not reclaimed; work never killed).
+- **A stamp set while the node's state is unknown** (renderer reload, or `sweepStaleWorking` having blanked the entry): since only `done` → `working` clears, the completing `<task-notification>` turn is a resumption from `undefined` and does NOT clear — the stamp survives until the turn AFTER that, i.e. the node's hibernation is deferred by one more turn. Accepted: the cost is memory reclaimed one turn late, whereas clearing on `undefined` would delete the guard for a task that is still running.
 
 ### 5. Testing
 
 - Normalize: a `PreToolUse` Bash payload with `run_in_background: true` yields the event; without the field (or with `false`, or another tool) yields nothing — mutation-sensitive both ways.
-- Store: stamp set on event; cleared on transition to `working`; NOT cleared on `done`/`waiting`; never persisted (extend the existing persistence tests).
+- Store: stamp set on event; cleared on a turn start (`done` → `working`); NOT cleared on `done`/`waiting`, on a `blocked`/`waiting` resumption, or from an unknown state; never persisted (extend the existing persistence tests).
 - Adapter/policy: `liveBackgroundTask` row in `hibernationCandidates` + exclusion row in `planHibernation` (the oldest-node-surfaces mutation pattern already used there).
 - Bulk plan: a background-task candidate lands in `skipped.working` and not in `runnable`.
-- Device checklist (append to PR #130's list as item 9): a node with a running background shell is not hibernated by an enabled Eco sweep; after the task completes and its turn runs, hibernation happens one idle window later.
+- Device checklist: appended as **item 8** to the tracked Eco list in `docs/superpowers/plans/2026-08-10-ram-optimization.md` (Phase 5, which has 7 items) — a node with a running background shell is not hibernated by an enabled Eco sweep; after the task completes and its turn runs, hibernation happens one idle window later.
 
 ### 6. Surfaces
 

--- a/docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md
+++ b/docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md
@@ -1,0 +1,61 @@
+# Background-Task Guard for Eco Hibernation and Bulk Restart — Design
+
+**Date:** 2026-08-12 · **Status:** approved by enes (scope + approach A) · **Follow-up to:** PR #130 (agent hibernation)
+
+## Problem
+
+Both Eco hibernation (opt-in, PR #130) and the bulk "Restart idle agents" action end an agent CLI by typing its exit command. A Claude Code **background shell task** (`Bash` with `run_in_background: true`) runs inside that CLI process and dies with it — silently lost work. Every other hazard has a guard (subagents, loop/cron, working/blocked); background shells are the one signal-less gap, because they produce no hook events while running and no subagent card. The window is real: a background task that runs >30 minutes with no other activity makes its node look exactly like Eco's target profile (done, offscreen, idle).
+
+## Decision record
+
+- **Scope (user decision):** Eco hibernation + bulk restart are guarded. The single-node "Restart agent (resume)" is deliberately untouched — the user clicks that node knowingly.
+- **Approach (user decision, option A):** hook stamp + clear-on-turn. Alternatives rejected: process-tree inspection at fire time (every claude has MCP-server children — false positive on all nodes, guard would disable Eco), and transcript completion-sniffing (correct model, disproportionate machinery; the fallback if A proves insufficient).
+- **Bulk-restart accounting (controller decision):** background-task skips are counted in the existing `skipped.working` bucket. The summary line is spec-frozen at four parts (see `agent-restart.ts` comments), and `'working'`'s documented meaning — "busy, try again in a moment" — is exactly what a live background task is.
+
+## Design
+
+### 1. Signal — `src/shared/agents/normalize.ts` (Claude only)
+
+In `normalizeClaude`'s `PreToolUse` branch: `tool_name === 'Bash' && tool_input.run_in_background === true` emits a new `NormalizedAgentEvent` kind **`background-task`** (carrying the node id, like the recurring events). The Claude payload type gains `run_in_background?: boolean` under `tool_input`.
+
+Claude-only in v1: the codex/gemini/grok dialects carry no equivalent field, and the house rule (CLAUDE.md "Adding a new agent" #7) is a closed set — no speculative widening. Their behavior stays byte-identical. A background task launched by a Claude *subagent* fires the same hook with the same node id, so protection extends there automatically — the safe direction.
+
+Both shells get this for free: normalize is shared, and the raw listeners forward whole events.
+
+### 2. Store — `src/renderer/state/agentStatus.ts`
+
+Transient `backgroundTaskAt?: number` per node. **Not persisted** — same rationale as `lastEventAt`: after an app relaunch Eco is structurally inert until the node takes a turn, so a persisted stamp would only assert staleness with confidence.
+
+- **Set:** Canvas's `agent:status` listener stamps `Date.now()` on a `background-task` event (a dedicated store action in house style, bail-when-unchanged not needed — re-stamping on every launch is correct).
+- **Clear:** in `setState`'s transition branch, only at a turn **START** (`done`/`undefined` → `working`; `blocked`/`waiting` → `working` is a mid-turn resumption and KEEPS the stamp). Rationale: a background task's completion queues a `<task-notification>` into the parent transcript, which re-invokes the agent — a turn starts — `working` fires. Clearing on `done` would be wrong: a turn can end while the task still runs. And clearing on *every* `working` transition would be wrong too: a background `Bash` whose command needs approval runs UserPromptSubmit(working) → PreToolUse(stamp) → PermissionRequest(blocked) → approve → PostToolUse(working), so the resumption edge would clear the stamp milliseconds after it was set, for exactly the task this guard exists for.
+
+### 3. Consumers
+
+- **Eco:** `buildHibernationCandidates` gains a **required** `liveBackgroundTask: boolean` field (`backgroundTaskAt !== undefined`), and `planHibernation` excludes it. Required-field discipline per the `remote` precedent: typecheck forces every call site, an omission can never read as "no task".
+- **Bulk restart:** `planBulkRestart`'s `BulkRestartCandidate` gains `backgroundTask: boolean`; a true value is counted as `skipped.working` (frozen four-part summary unchanged). Canvas's bulk action feeds it from the store. `restartEligibility` itself is untouched (the single-node menu path must not change).
+
+### 4. Edge cases (accepted, documented)
+
+- **Concurrent background tasks:** the first completion's turn clears the stamp while a second task may still run. Mitigation: that same turn resets `lastEventAt`, so Eco waits another full idle window (30 min default) — the residual exposure is a second task still running >30 min after the first one's completion turn, with no further hook activity. Documented here and in the Eco device checklist; approach C (completion counting) is the named escalation if this bites in practice.
+- **App relaunch:** stamp is gone (transient) — consistent, because Eco cannot act until a turn happens, and any turn's `working` would have cleared the stamp anyway.
+- **A task reporting back while the node sits `waiting`/`blocked`:** the clear needs a turn START, so a `<task-notification>` that lands while the session holds a question open (`waiting`/`blocked` → `working` is a resumption) leaves the stamp in place until the turn after that. Bounded and in the fail-safe direction — and such a node is never a hibernation candidate anyway, since `planHibernation` requires `state === 'done'`.
+- **Manual task kill without a turn:** the stamp stays until the next turn — the node simply isn't hibernated. Fail-safe direction (memory not reclaimed; work never killed).
+
+### 5. Testing
+
+- Normalize: a `PreToolUse` Bash payload with `run_in_background: true` yields the event; without the field (or with `false`, or another tool) yields nothing — mutation-sensitive both ways.
+- Store: stamp set on event; cleared on transition to `working`; NOT cleared on `done`/`waiting`; never persisted (extend the existing persistence tests).
+- Adapter/policy: `liveBackgroundTask` row in `hibernationCandidates` + exclusion row in `planHibernation` (the oldest-node-surfaces mutation pattern already used there).
+- Bulk plan: a background-task candidate lands in `skipped.working` and not in `runnable`.
+- Device checklist (append to PR #130's list as item 9): a node with a running background shell is not hibernated by an enabled Eco sweep; after the task completes and its turn runs, hibernation happens one idle window later.
+
+### 6. Surfaces
+
+Shared normalize + renderer store/policy: Desktop and Server Edition both covered with no shell-specific work. Mobile: N/A (no sweep on the phone).
+
+## Out of scope
+
+- Single-node restart guard (user decision).
+- Non-Claude agents (no signal in their dialects).
+- Completion sniffing / task counting (escalation path, not v1).
+- Any UI surface for "why didn't this node hibernate" (YAGNI).

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7109,6 +7109,12 @@ export function Canvas() {
               result: e.result
             })
           break
+        case 'background-task':
+          // A background shell task runs INSIDE the CLI process, so the `/exit` Eco hibernation
+          // and the bulk restart type would kill it silently. Stamp the node so both skip it.
+          // Cheap: the write touches one entry and nothing subscribes to `backgroundTaskAt`.
+          cs.markBackgroundTask(e.nodeId)
+          break
         case 'recurring':
           if (e.recurringEnd) {
             // The recurring job itself was removed (CronDelete) — take the card down.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7197,6 +7197,9 @@ export function Canvas() {
           nodes: nodesRef.current
             .filter((n) => n.type === 'terminal')
             .map((n) => ({ id: n.id, agentId: createdAgentId(n.data) })),
+          // Pass the store entries WHOLE: every optional field here (backgroundTaskAt,
+          // lastEventAt, loop) is read by the policy; narrowing this to a hand-picked literal
+          // would silently kill those guards with the suite still green.
           statusById: useAgentStatus.getState().byId,
           // Any card that has not finished pins its parent — see the adapter's header.
           subagents: Object.values(useAgentNodes.getState().byId).map((v) => ({

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4343,7 +4343,10 @@ export function Canvas() {
         sessionId: byId[n.id]?.sessionId,
         // Registration is unconditional for every terminal node, so this says only "mounted and
         // wired", never "is an agent" — `agentId` above is what decides that.
-        wired: !!agentRestartFn(n.id)
+        wired: !!agentRestartFn(n.id),
+        // A background shell launched by this session is still running (no turn has started since):
+        // the exit line would kill it silently. Presence of the stamp is the whole signal.
+        backgroundTask: !!byId[n.id]?.backgroundTaskAt
       }))
     )
   }, [])

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7112,7 +7112,8 @@ export function Canvas() {
         case 'background-task':
           // A background shell task runs INSIDE the CLI process, so the `/exit` Eco hibernation
           // and the bulk restart type would kill it silently. Stamp the node so both skip it.
-          // Cheap: the write touches one entry and nothing subscribes to `backgroundTaskAt`.
+          // The write mints a new entry object, so whole-map subscribers (minimap, the node) do
+          // re-render — once per background launch, which is rarer than any state event.
           cs.markBackgroundTask(e.nodeId)
           break
         case 'recurring':

--- a/src/renderer/lib/hibernationCandidates.test.ts
+++ b/src/renderer/lib/hibernationCandidates.test.ts
@@ -31,9 +31,32 @@ describe('buildHibernationCandidates', () => {
         remote: false,
         recurring: false,
         liveSubagents: false,
+        liveBackgroundTask: false,
         lastEventAt: IDLE
       }
     ])
+  })
+
+  it('liveBackgroundTask mirrors backgroundTaskAt presence', () => {
+    const rows = buildHibernationCandidates(
+      inputs({
+        nodes: [
+          { id: 'a', agentId: 'claude' },
+          { id: 'b', agentId: 'claude' }
+        ],
+        statusById: {
+          a: { state: 'done', sessionId: 'sid-a', lastEventAt: IDLE, backgroundTaskAt: 123 },
+          b: { state: 'done', sessionId: 'sid-b', lastEventAt: IDLE }
+        }
+      })
+    )
+    expect(rows.map((r) => [r.id, r.liveBackgroundTask])).toEqual([
+      ['a', true],
+      ['b', false]
+    ])
+    // …and end to end: a node with a live background shell is refused, however idle it looks.
+    expect(planHibernation([rows[0]], NOW, { enabled: true, idleMinutes: 30 })).toEqual([])
+    expect(planHibernation([rows[1]], NOW, { enabled: true, idleMinutes: 30 })).toEqual(['b'])
   })
 
   it('reads a DISMISSED cron entry as recurring — the card is hidden, the job is not gone', () => {

--- a/src/renderer/lib/hibernationCandidates.ts
+++ b/src/renderer/lib/hibernationCandidates.ts
@@ -3,14 +3,21 @@
  * canvas nodes, the agent-status table, the subagent cards, and the node's own wiring/visibility)
  * and the pure policy in `terminal/hibernation-policy.ts`.
  *
- * It exists as its own tested function rather than as a `.map()` inside the sweep because two of
- * the four facts are SAFETY facts, and an untested inline expression is exactly where they rot:
+ * It exists as its own tested function rather than as a `.map()` inside the sweep because three of
+ * the facts it lifts are SAFETY facts, and an untested inline expression is exactly where they rot:
  *
  *  - **`recurring` is `!!loop`, dismissed or not.** A dismissed cron/schedule card keeps its entry
  *    precisely so this row stays true (see `agentStatus`'s `loop.dismissed`): the card is hidden,
  *    the job is not gone, and `/exit` would kill the CLI its wakeup lives in. Reading the render
  *    filter here — "no card, so nothing recurring" — silently cancels the job Eco mode was never
  *    allowed to touch. That hole is the reason this file has a test.
+ *  - **`liveBackgroundTask` is "a background shell was launched and no turn has started since".**
+ *    A Claude `Bash` with `run_in_background` runs INSIDE the CLI process and emits nothing while
+ *    it works, so `agentStatus.backgroundTaskAt` is the only evidence it exists; `/exit` kills it
+ *    with no output and no error. Note the coupling this depends on: a renderer reload drops
+ *    `backgroundTaskAt` AND `lastEventAt` together (both transient), which is safe only because Eco
+ *    is inert without an idle clock — that coupling is now load-bearing for two features, so
+ *    neither field may be persisted on its own.
  *  - **`liveSubagents` is "any card for this parent that is NOT done".** Claude launches subagents
  *    async and their completion is queued into the PARENT's transcript, which a dead parent CLI
  *    never reads. An unknown/absent state counts as LIVE — the conservative direction, and the
@@ -38,6 +45,9 @@ export interface HibernationStatusInput {
   /** Present = this node has a `/loop`, `/schedule` or `/cron` on it. Its `dismissed` flag is
    *  deliberately NOT consulted — see the header. */
   loop?: unknown
+  /** When this node last launched a background shell task, if no turn has started since — the
+   *  third safety fact this adapter exists for (see the header). Present at all = live task. */
+  backgroundTaskAt?: number
 }
 
 /** One subagent card, narrowed: whose it is, and whether it has finished. */
@@ -81,6 +91,7 @@ export function buildHibernationCandidates(
       remote: inputs.isRemote(n.id),
       recurring: !!st?.loop,
       liveSubagents: liveParents.has(n.id),
+      liveBackgroundTask: st?.backgroundTaskAt !== undefined,
       lastEventAt: st?.lastEventAt
     }
   })

--- a/src/renderer/state/agentStatus.persist.test.ts
+++ b/src/renderer/state/agentStatus.persist.test.ts
@@ -189,6 +189,23 @@ describe('loop persistence (cron/schedule survive an app restart)', () => {
     expect(saved.n5.state).toBeUndefined()
   })
 
+  it('never persists `backgroundTaskAt` — a stale stamp would exempt a node from Eco forever', async () => {
+    // Same rationale as `lastEventAt`: after a relaunch nothing is running that we know of, and any
+    // turn's `working` would have cleared it anyway.
+    const store = memStorage()
+    vi.stubGlobal('localStorage', store)
+    const { useAgentStatus } = await import('./agentStatus')
+    useAgentStatus.getState().markBackgroundTask('n15')
+    expect(useAgentStatus.getState().byId['n15'].backgroundTaskAt).toBeTypeOf('number')
+    // The stamp alone is not durable, so it writes nothing at all…
+    expect(store.getItem('nodeterm.agentStatus')).toBeNull()
+    // …and it stays out of the file when a durable field does get written.
+    useAgentStatus.getState().setSessionId('n15', 'sess-2')
+    const saved = JSON.parse(store.getItem('nodeterm.agentStatus')!)
+    expect(saved.n15.sessionId).toBe('sess-2')
+    expect(saved.n15.backgroundTaskAt).toBeUndefined()
+  })
+
   it('stamps `lastEventAt` on a state transition only (same-state refresh keeps the idle clock)', async () => {
     vi.stubGlobal('localStorage', memStorage())
     const { useAgentStatus } = await import('./agentStatus')

--- a/src/renderer/state/agentStatus.test.ts
+++ b/src/renderer/state/agentStatus.test.ts
@@ -109,7 +109,7 @@ describe('interrupt inference (Esc/Ctrl-C with no final hook)', () => {
 })
 
 describe('background-task stamp (Eco / bulk-restart guard)', () => {
-  it('markBackgroundTask stamps; only a transition TO working clears it', () => {
+  it('markBackgroundTask stamps, and a non-working transition never clears it', () => {
     const id = nid()
     const s = useAgentStatus.getState()
     s.setState(id, 'done', 'claude')
@@ -118,9 +118,45 @@ describe('background-task stamp (Eco / bulk-restart guard)', () => {
     // done → waiting is a transition, but the task is still running: the guard must hold.
     s.setState(id, 'waiting', 'claude')
     expect(useAgentStatus.getState().byId[id]?.backgroundTaskAt).toBeTypeOf('number')
-    // A turn START is what clears it — the completed task's <task-notification> precedes it.
-    s.setState(id, 'working', 'claude')
-    expect(useAgentStatus.getState().byId[id]?.backgroundTaskAt).toBeUndefined()
+  })
+
+  // Only a turn START clears the stamp. A `working` arriving from blocked/waiting is a MID-TURN
+  // RESUMPTION — the same turn picking back up — and clearing there would drop the guard for
+  // exactly the task it exists for (see the approval walk-through below).
+  it('clears only on a turn start (from done/idle), never on a mid-turn resumption', () => {
+    for (const { from, cleared } of [
+      { from: 'blocked' as const, cleared: false },
+      { from: 'waiting' as const, cleared: false },
+      { from: 'done' as const, cleared: true },
+      { from: undefined, cleared: true }
+    ]) {
+      const id = nid()
+      const s = useAgentStatus.getState()
+      if (from) s.setState(id, from, 'claude')
+      s.markBackgroundTask(id)
+      // A `done` predecessor needs the holdoff to lapse, or the working event is dropped whole.
+      if (from === 'done') vi.advanceTimersByTime(DONE_HOLDOFF_MS + 500)
+      useAgentStatus.getState().setState(id, 'working', 'claude')
+      const label = String(from)
+      expect(useAgentStatus.getState().byId[id].state, label).toBe('working')
+      const stamp = useAgentStatus.getState().byId[id].backgroundTaskAt
+      if (cleared) expect(stamp, label).toBeUndefined()
+      else expect(stamp, label).toBeTypeOf('number')
+    }
+  })
+
+  // The scenario the predicate exists for: a background Bash whose command needs approval runs
+  // UserPromptSubmit(working) → PreToolUse(stamp) → PermissionRequest(blocked) → approve →
+  // PostToolUse(working). That last edge IS a transition, and clearing on it would drop the guard
+  // milliseconds after the stamp was set, while the task runs on.
+  it('a background task that needed approval keeps its stamp across the approve edge', () => {
+    const id = nid()
+    const s = useAgentStatus.getState()
+    s.setState(id, 'working', 'claude', true) // UserPromptSubmit — the turn starts
+    s.markBackgroundTask(id) // PreToolUse Bash, run_in_background
+    s.setState(id, 'blocked', 'claude') // PermissionRequest
+    s.setState(id, 'working', 'claude') // approved, the turn resumes
+    expect(useAgentStatus.getState().byId[id].backgroundTaskAt).toBeTypeOf('number')
   })
 
   it('stamps a node with no entry yet (the task can precede any state event)', () => {

--- a/src/renderer/state/agentStatus.test.ts
+++ b/src/renderer/state/agentStatus.test.ts
@@ -108,6 +108,29 @@ describe('interrupt inference (Esc/Ctrl-C with no final hook)', () => {
   })
 })
 
+describe('background-task stamp (Eco / bulk-restart guard)', () => {
+  it('markBackgroundTask stamps; only a transition TO working clears it', () => {
+    const id = nid()
+    const s = useAgentStatus.getState()
+    s.setState(id, 'done', 'claude')
+    s.markBackgroundTask(id)
+    expect(useAgentStatus.getState().byId[id]?.backgroundTaskAt).toBeTypeOf('number')
+    // done → waiting is a transition, but the task is still running: the guard must hold.
+    s.setState(id, 'waiting', 'claude')
+    expect(useAgentStatus.getState().byId[id]?.backgroundTaskAt).toBeTypeOf('number')
+    // A turn START is what clears it — the completed task's <task-notification> precedes it.
+    s.setState(id, 'working', 'claude')
+    expect(useAgentStatus.getState().byId[id]?.backgroundTaskAt).toBeUndefined()
+  })
+
+  it('stamps a node with no entry yet (the task can precede any state event)', () => {
+    const id = nid()
+    useAgentStatus.getState().markBackgroundTask(id)
+    expect(useAgentStatus.getState().byId[id]?.backgroundTaskAt).toBeTypeOf('number')
+    expect(useAgentStatus.getState().byId[id]?.unread).toBe(false)
+  })
+})
+
 describe('clearUnread — cross-surface ack vs. external (host-driven) clear', () => {
   it('a normal clear of a done+unread node ACKs the read (dismisses the phone activity)', () => {
     const acked: string[] = []

--- a/src/renderer/state/agentStatus.test.ts
+++ b/src/renderer/state/agentStatus.test.ts
@@ -120,15 +120,17 @@ describe('background-task stamp (Eco / bulk-restart guard)', () => {
     expect(useAgentStatus.getState().byId[id]?.backgroundTaskAt).toBeTypeOf('number')
   })
 
-  // Only a turn START clears the stamp. A `working` arriving from blocked/waiting is a MID-TURN
-  // RESUMPTION — the same turn picking back up — and clearing there would drop the guard for
-  // exactly the task it exists for (see the approval walk-through below).
-  it('clears only on a turn start (from done/idle), never on a mid-turn resumption', () => {
+  // Only a turn START — a `working` arriving from `done` — clears the stamp. Everything else keeps
+  // it. blocked/waiting → working is a MID-TURN RESUMPTION (the same turn picking back up; see the
+  // approval walk-through below), and an UNKNOWN previous state is not evidence of a turn start
+  // at all: it is what a renderer reload or the stale-working sweeper leaves behind MID-TURN, so
+  // clearing there would delete the stamp for a task that is still running.
+  it('clears only on a turn start (done → working), never on a resumption or from an unknown state', () => {
     for (const { from, cleared } of [
       { from: 'blocked' as const, cleared: false },
       { from: 'waiting' as const, cleared: false },
-      { from: 'done' as const, cleared: true },
-      { from: undefined, cleared: true }
+      { from: undefined, cleared: false },
+      { from: 'done' as const, cleared: true }
     ]) {
       const id = nid()
       const s = useAgentStatus.getState()

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -355,25 +355,34 @@ export function createAgentStatusSession(
         // the sweep) exempts that session from Eco for good.
         // `done` deliberately does NOT clear it — a hibernated node's last known state IS done,
         // and a late Stop POST arriving after the exit would undo the hibernation we just did.
-        // A background task's guard is dropped at the START OF THE NEXT TURN — and only there.
         //
-        // Not on `done`: that is the launching turn ending while the task runs on, which is
+        // ---- a different field, and the opposite rule ----
+        //
+        // The BACKGROUND-TASK guard is dropped at the START OF THE NEXT TURN — `done` → `working`,
+        // and nothing else.
+        //
+        // Not on `done` itself: that is the launching turn ending while the task runs on, which is
         // precisely the window Eco / the bulk restart would kill it in. A turn start is safe
         // because Claude delivers a finished background task back as a <task-notification>, whose
         // own turn is exactly this `working` — so by the time one begins, the task has reported.
         //
-        // And not on EVERY `working` transition, because `blocked`/`waiting` → `working` is a
-        // MID-TURN RESUMPTION, not a turn start. A background Bash whose command needs approval
-        // runs UserPromptSubmit(working) → PreToolUse(stamp) → PermissionRequest(blocked) →
-        // approve → PostToolUse(working): that last edge would clear the stamp milliseconds after
-        // it was set, for exactly the task this guard exists for. A turn start comes from `done`
-        // or from no known state at all.
+        // Not on EVERY `working` transition either, because `blocked`/`waiting` → `working` is a
+        // MID-TURN RESUMPTION. A background Bash whose command needs approval runs
+        // UserPromptSubmit(working) → PreToolUse(stamp) → PermissionRequest(blocked) → approve →
+        // PostToolUse(working): that last edge would clear the stamp milliseconds after it was
+        // set, for exactly the task this guard exists for.
+        //
+        // And NOT from an unknown previous state, which is the same hole from the other side:
+        // `undefined` is reachable MID-TURN — a renderer reload starts with an empty table, and
+        // `sweepStaleWorking` blanks a working entry after the stale window — so post-reload a
+        // background launch would stamp an entry with no state, and the very next tool event's
+        // `working` would read as a turn start and delete it. Requiring `done` makes the miss
+        // fail SAFE: every real turn ends Stop → `done`, so the clear still happens, at most one
+        // turn late.
         //
         // Deliberately NOT keyed on `newTurn`: the <task-notification> prompt is explicitly not
         // flagged as one (see normalizeClaude), so the intended clear would never fire.
-        if (state === 'working' && (prev.state === 'done' || prev.state === undefined)) {
-          next.backgroundTaskAt = undefined
-        }
+        if (state === 'working' && prev.state === 'done') next.backgroundTaskAt = undefined
         const alive = state === 'working' || state === 'blocked' || state === 'waiting'
         if (alive && prev.hibernated) {
           next.hibernated = undefined

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -355,13 +355,25 @@ export function createAgentStatusSession(
         // the sweep) exempts that session from Eco for good.
         // `done` deliberately does NOT clear it — a hibernated node's last known state IS done,
         // and a late Stop POST arriving after the exit would undo the hibernation we just did.
-        // A background task's guard is dropped at the START OF THE NEXT TURN, not when the node
-        // goes idle: Claude delivers a finished background task back as a <task-notification>,
-        // whose own turn is exactly the `working` below — so by the time a turn begins, whatever
-        // the task was doing has been reported. Clearing on `done` instead would drop the guard
-        // the instant the launching turn ended, i.e. while the task is still running, which is
-        // precisely the window Eco / the bulk restart would kill it in.
-        if (state === 'working') next.backgroundTaskAt = undefined
+        // A background task's guard is dropped at the START OF THE NEXT TURN — and only there.
+        //
+        // Not on `done`: that is the launching turn ending while the task runs on, which is
+        // precisely the window Eco / the bulk restart would kill it in. A turn start is safe
+        // because Claude delivers a finished background task back as a <task-notification>, whose
+        // own turn is exactly this `working` — so by the time one begins, the task has reported.
+        //
+        // And not on EVERY `working` transition, because `blocked`/`waiting` → `working` is a
+        // MID-TURN RESUMPTION, not a turn start. A background Bash whose command needs approval
+        // runs UserPromptSubmit(working) → PreToolUse(stamp) → PermissionRequest(blocked) →
+        // approve → PostToolUse(working): that last edge would clear the stamp milliseconds after
+        // it was set, for exactly the task this guard exists for. A turn start comes from `done`
+        // or from no known state at all.
+        //
+        // Deliberately NOT keyed on `newTurn`: the <task-notification> prompt is explicitly not
+        // flagged as one (see normalizeClaude), so the intended clear would never fire.
+        if (state === 'working' && (prev.state === 'done' || prev.state === undefined)) {
+          next.backgroundTaskAt = undefined
+        }
         const alive = state === 'working' || state === 'blocked' || state === 'waiting'
         if (alive && prev.hibernated) {
           next.hibernated = undefined

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -53,6 +53,17 @@ export interface AgentNodeStatus {
    */
   lastEventAt?: number
   /**
+   * When this node last launched a BACKGROUND shell task (Claude's `Bash` with
+   * `run_in_background: true`). Such a task lives inside the CLI process, so `/exit` — Eco
+   * hibernation and the bulk in-place restart both type it — kills it silently, with no output and
+   * no error. The stamp is what those two exclude on.
+   *
+   * TRANSIENT — never persisted, same rationale as `lastEventAt`: after a relaunch Eco is inert
+   * until a turn happens anyway, and any turn's `working` would have cleared this. A stale stamp
+   * restored from disk would exempt the node from Eco for good.
+   */
+  backgroundTaskAt?: number
+  /**
    * The agent CLI was exited to reclaim its RAM ("Eco" mode) and its conversation is waiting to be
    * resumed when the node is next viewed. PERSISTED beside unread/session/sessionId: the tmux
    * session outlives the app, so after a relaunch this flag is the only thing that knows the pane
@@ -140,6 +151,9 @@ export interface AgentStatusStore {
   /** Record what the pane settled to when this node's CLI let go of it (`null` = forget: a stale
    *  value must never permit a wake into a pane we did not measure). See `hibernatedPane`. */
   setHibernatedPane(id: string, pane: string | null): void
+  /** Record that this node just launched a background shell task (see `backgroundTaskAt`).
+   *  Transient — nothing is written to localStorage. */
+  markBackgroundTask(id: string): void
   markUnread(id: string): void
   /**
    * Drop a node's unread flag. By default a clear of a FINISHED (done) node also ACKs the read
@@ -341,6 +355,13 @@ export function createAgentStatusSession(
         // the sweep) exempts that session from Eco for good.
         // `done` deliberately does NOT clear it — a hibernated node's last known state IS done,
         // and a late Stop POST arriving after the exit would undo the hibernation we just did.
+        // A background task's guard is dropped at the START OF THE NEXT TURN, not when the node
+        // goes idle: Claude delivers a finished background task back as a <task-notification>,
+        // whose own turn is exactly the `working` below — so by the time a turn begins, whatever
+        // the task was doing has been reported. Clearing on `done` instead would drop the guard
+        // the instant the launching turn ended, i.e. while the task is still running, which is
+        // precisely the window Eco / the bulk restart would kill it in.
+        if (state === 'working') next.backgroundTaskAt = undefined
         const alive = state === 'working' || state === 'blocked' || state === 'waiting'
         if (alive && prev.hibernated) {
           next.hibernated = undefined
@@ -421,6 +442,14 @@ export function createAgentStatusSession(
         const byId = { ...s.byId, [id]: { ...prev, hibernatedPane: next } }
         save(byId)
         return { byId }
+      }),
+
+    markBackgroundTask: (id) =>
+      set((s) => {
+        const prev = s.byId[id] ?? EMPTY
+        // Transient (see `backgroundTaskAt`) — no save(): a stamp restored from disk would exempt
+        // the node from Eco forever.
+        return { byId: { ...s.byId, [id]: { ...prev, backgroundTaskAt: Date.now() } } }
       }),
 
     markUnread: (id) =>

--- a/src/renderer/terminal/agent-restart.test.ts
+++ b/src/renderer/terminal/agent-restart.test.ts
@@ -757,9 +757,9 @@ describe('restartEligibility — grok', () => {
 
   it('keeps a busy grok node out of the bulk run', () => {
     const plan = planBulkRestart([
-      { id: 'idle', agentId: 'grok', state: 'done', sessionId: 'sid-1', wired: true },
-      { id: 'busy', agentId: 'grok', state: 'working', sessionId: 'sid-2', wired: true },
-      { id: 'prompt', agentId: 'grok', state: 'blocked', sessionId: 'sid-3', wired: true }
+      { id: 'idle', agentId: 'grok', state: 'done', sessionId: 'sid-1', wired: true, backgroundTask: false },
+      { id: 'busy', agentId: 'grok', state: 'working', sessionId: 'sid-2', wired: true, backgroundTask: false },
+      { id: 'prompt', agentId: 'grok', state: 'blocked', sessionId: 'sid-3', wired: true, backgroundTask: false }
     ])
     expect(plan.runnable).toEqual(['idle'])
     expect(plan.skipped).toEqual({ working: 2, noSession: 0 })
@@ -834,9 +834,9 @@ describe('restartEligibility — gemini', () => {
 
   it('keeps a busy gemini node out of the bulk run', () => {
     const plan = planBulkRestart([
-      { id: 'idle', agentId: 'gemini', state: 'done', sessionId: 'sid-1', wired: true },
-      { id: 'busy', agentId: 'gemini', state: 'working', sessionId: 'sid-2', wired: true },
-      { id: 'prompt', agentId: 'gemini', state: 'blocked', sessionId: 'sid-3', wired: true }
+      { id: 'idle', agentId: 'gemini', state: 'done', sessionId: 'sid-1', wired: true, backgroundTask: false },
+      { id: 'busy', agentId: 'gemini', state: 'working', sessionId: 'sid-2', wired: true, backgroundTask: false },
+      { id: 'prompt', agentId: 'gemini', state: 'blocked', sessionId: 'sid-3', wired: true, backgroundTask: false }
     ])
     expect(plan.runnable).toEqual(['idle'])
     expect(plan.skipped).toEqual({ working: 2, noSession: 0 })
@@ -1041,6 +1041,7 @@ describe('planBulkRestart', () => {
     state: 'waiting',
     sessionId: `sid-${over.id}`,
     wired: true,
+    backgroundTask: false,
     ...over
   })
 
@@ -1076,6 +1077,36 @@ describe('planBulkRestart', () => {
   it('keeps canvas order', () => {
     const plan = planBulkRestart([cand({ id: 'z' }), cand({ id: 'm' }), cand({ id: 'a' })])
     expect(plan.runnable).toEqual(['z', 'm', 'a'])
+  })
+
+  it('bulk restart files a background-task node under the working skips', () => {
+    // A background shell dies with the CLI the exit line quits, and nothing about it is visible to
+    // the eligibility gate — the node reports `done` for as long as the task runs.
+    const plan = planBulkRestart([
+      cand({ id: 'a', state: 'done', backgroundTask: true }),
+      cand({ id: 'b', state: 'done', backgroundTask: false })
+    ])
+    expect(plan.runnable).toEqual(['b'])
+    expect(plan.skipped.working).toBe(1)
+    expect(plan.skipped.noSession).toBe(0)
+  })
+
+  it('leaves a NOT-RESUMABLE background-task node uncounted, as today', () => {
+    // The eligibility gate runs first, so a node the action never claimed stays out of the counts
+    // whatever else is true of it — the background check may not turn a non-target into a skip.
+    const plan = planBulkRestart([
+      cand({ id: 'shell', agentId: undefined, backgroundTask: true }),
+      cand({ id: 'oc', agentId: 'opencode', backgroundTask: true })
+    ])
+    expect(plan.runnable).toEqual([])
+    expect(plan.skipped).toEqual({ working: 0, noSession: 0 })
+  })
+
+  it('files a background task under working even when the node is unwired', () => {
+    // Ordering guard: the background check sits BEFORE the wired check, so a parked node with a
+    // live task reads as busy rather than as "no session".
+    const plan = planBulkRestart([cand({ id: 'a', wired: false, backgroundTask: true })])
+    expect(plan.skipped).toEqual({ working: 1, noSession: 0 })
   })
 })
 

--- a/src/renderer/terminal/agent-restart.ts
+++ b/src/renderer/terminal/agent-restart.ts
@@ -462,6 +462,14 @@ export interface BulkRestartCandidate {
    *  is unconditional for every terminal node, so this answers only "can I reach this pane", never
    *  "is this an agent" — `agentId` above is the one that decides that. */
   wired: boolean
+  /** Is a background shell task running inside this node's CLI (Claude's `Bash` with
+   *  `run_in_background`)? It dies with the CLI the exit line quits — silently, with no output and
+   *  no error — and the eligibility gate cannot see it: the node reports `done` the whole time.
+   *
+   *  Required, not optional: typecheck is what forces every call site to answer the question (the
+   *  `remote` / `liveBackgroundTask` precedent), and an omitted field would read as "no task" —
+   *  the one wrong direction. Fed from `agentStatus.backgroundTaskAt`. */
+  backgroundTask: boolean
 }
 
 export interface BulkRestartPlan {
@@ -489,6 +497,17 @@ export function planBulkRestart(candidates: BulkRestartCandidate[]): BulkRestart
       if (gate.reason === 'working') plan.skipped.working++
       else if (gate.reason === 'no-session') plan.skipped.noSession++
       // 'not-resumable' — never a target, see above.
+      continue
+    }
+    // AFTER the eligibility gate, so a node that was never a target stays uncounted whatever else
+    // is true of it — and BEFORE the wired check, because a live background task is the sharper
+    // fact: "no session" would send the user looking for a pane that is fine.
+    //
+    // Counted as `working`, not as a fifth part: the summary line is spec-frozen at four, and
+    // `'working'`'s documented meaning — "busy, try again in a moment" — is exactly what a running
+    // background task is.
+    if (c.backgroundTask) {
+      plan.skipped.working++
       continue
     }
     if (!c.wired) {

--- a/src/renderer/terminal/hibernation-policy.test.ts
+++ b/src/renderer/terminal/hibernation-policy.test.ts
@@ -12,6 +12,7 @@ const base = (id: string, over: object = {}) => ({
   remote: false,
   recurring: false,
   liveSubagents: false,
+  liveBackgroundTask: false,
   lastEventAt: 0,
   ...over
 })
@@ -32,7 +33,8 @@ describe('planHibernation', () => {
         base('h', { wired: false }),
         base('i', { state: 'waiting' }),
         base('j', { recurring: true }),
-        base('k', { liveSubagents: true })
+        base('k', { liveSubagents: true }),
+        base('l', { liveBackgroundTask: true })
       ],
       NOW,
       cfg
@@ -49,6 +51,15 @@ describe('planHibernation', () => {
     expect(planHibernation([base('a', { liveSubagents: true, lastEventAt: 0 })], NOW, cfg)).toEqual(
       []
     )
+  })
+
+  it('never hibernates a node with a live background task', () => {
+    // A background shell (`Bash` with run_in_background) lives inside the CLI process, so `/exit`
+    // kills it with no output and no error — and while it runs it emits nothing, so this stamp is
+    // the only evidence the node is not idle at all.
+    expect(
+      planHibernation([base('a', { liveBackgroundTask: true, lastEventAt: 0 })], NOW, cfg)
+    ).toEqual([])
   })
 
   it('never hibernates a waiting node — the question would be swallowed', () => {

--- a/src/renderer/terminal/hibernation-policy.ts
+++ b/src/renderer/terminal/hibernation-policy.ts
@@ -21,6 +21,12 @@
  *  - **Never a node with live subagents.** Claude launches subagents async: the completion of an
  *    async-launched subagent is queued into the PARENT's transcript, and a dead parent CLI never
  *    reads it. Hibernating the parent orphans every subagent still running under it.
+ *  - **Never a node with a live BACKGROUND TASK.** A Claude `Bash` launched with
+ *    `run_in_background` runs inside the CLI process, so `/exit` kills it silently — no output, no
+ *    error, no record. And no hook fires while it runs, so a node whose only activity is a long
+ *    background job looks EXACTLY like the target profile (`done`, offscreen, idle for hours): the
+ *    stamp the launch left behind (`agentStatus.backgroundTaskAt`, cleared at the next turn start)
+ *    is the only signal there is.
  *  - **Unknown idle is NOT idle.** A candidate with no `lastEventAt` (no hook event has ever been
  *    seen for it in this run) is never eligible — the same rule as pendingLaunch's "an unknown
  *    dependency state is not satisfied". Guessing here costs the user a live session.
@@ -73,6 +79,10 @@ export interface HibernationCandidate {
   recurring: boolean
   /** Any non-done subagent card whose parent is this node (from `state/agentNodes.ts`). */
   liveSubagents: boolean
+  /** A background shell task is running inside this node's CLI (from `agentStatus.backgroundTaskAt`
+   *  — set on the launch hook, cleared at the next turn start). Required, like `remote`: typecheck
+   *  is what forces every call site to answer, and an omitted field would read as "no task". */
+  liveBackgroundTask: boolean
   /** When this node's last hook event landed. Absent = never seen ⇒ never eligible. */
   lastEventAt?: number
 }
@@ -106,6 +116,7 @@ export function planHibernation(
         c.state === 'done' &&
         !c.recurring &&
         !c.liveSubagents &&
+        !c.liveBackgroundTask &&
         restartEligibility(c.agentId, c.state, c.sessionId).ok &&
         // `?? Infinity`: no event ever seen ⇒ the difference is -Infinity ⇒ never eligible.
         nowMs - (c.lastEventAt ?? Infinity) >= idleMs

--- a/src/shared/agents/normalize.test.ts
+++ b/src/shared/agents/normalize.test.ts
@@ -150,6 +150,44 @@ describe('normalizeClaude — recurring (cron/schedule/loop)', () => {
   })
 })
 
+describe('normalizeClaude — background shell tasks', () => {
+  // A background shell task lives INSIDE the CLI process, so `/exit` (Eco hibernation, the bulk
+  // restart) kills it silently. This event is the stamp those two exclude on.
+  it('claude PreToolUse Bash with run_in_background=true is a background-task event', () => {
+    const e = normalizeClaude(
+      env({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'sleep 999', run_in_background: true }
+      })
+    )
+    expect(e?.kind).toBe('background-task')
+  })
+
+  // The mutation guard: dropping the `tool_name` check, the `ev` check, or matching truthily
+  // instead of `=== true` each flips exactly one of these rows.
+  it('foreground Bash, false/absent flag, PostToolUse, and other tools stay generic working', () => {
+    for (const payload of [
+      { hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'ls' } },
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls', run_in_background: false }
+      },
+      {
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls', run_in_background: true }
+      },
+      { hook_event_name: 'PreToolUse', tool_name: 'Read', tool_input: { run_in_background: true } }
+    ]) {
+      const e = normalizeClaude(env(payload))
+      expect(e?.kind, JSON.stringify(payload)).toBe('state')
+      expect(e?.state, JSON.stringify(payload)).toBe('working')
+    }
+  })
+})
+
 describe('normalizeClaude — permission signals', () => {
   it('PermissionRequest → blocked', () => {
     const e = normalizeClaude(env({ hook_event_name: 'PermissionRequest' }))

--- a/src/shared/agents/normalize.test.ts
+++ b/src/shared/agents/normalize.test.ts
@@ -165,14 +165,27 @@ describe('normalizeClaude — background shell tasks', () => {
   })
 
   // The mutation guard: dropping the `tool_name` check, the `ev` check, or matching truthily
-  // instead of `=== true` each flips exactly one of these rows.
-  it('foreground Bash, false/absent flag, PostToolUse, and other tools stay generic working', () => {
+  // instead of `=== true` each flips exactly one of these rows. The truthy-but-not-`true` row is
+  // what pins the strict compare — the two boolean rows below are both falsy, so on their own they
+  // would pass a `!!p.tool_input?.run_in_background` implementation too.
+  it('foreground Bash, false/absent/truthy-non-true flags, PostToolUse and other tools stay generic working', () => {
     for (const payload of [
       { hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'ls' } },
       {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
         tool_input: { command: 'ls', run_in_background: false }
+      },
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        // A hand-rolled/forwarded payload could carry 1 or "true"; only a real boolean counts.
+        tool_input: { command: 'ls', run_in_background: 1 }
+      },
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls', run_in_background: 'true' }
       },
       {
         hook_event_name: 'PostToolUse',

--- a/src/shared/agents/normalize.test.ts
+++ b/src/shared/agents/normalize.test.ts
@@ -165,9 +165,9 @@ describe('normalizeClaude — background shell tasks', () => {
   })
 
   // The mutation guard: dropping the `tool_name` check, the `ev` check, or matching truthily
-  // instead of `=== true` each flips exactly one of these rows. The truthy-but-not-`true` row is
-  // what pins the strict compare — the two boolean rows below are both falsy, so on their own they
-  // would pass a `!!p.tool_input?.run_in_background` implementation too.
+  // instead of `=== true` each flips a row here — the truthy match flips two. Those two
+  // truthy-but-not-`true` rows are what pin the strict compare: the boolean rows below are both
+  // falsy, so on their own they would pass a `!!p.tool_input?.run_in_background` implementation.
   it('foreground Bash, false/absent/truthy-non-true flags, PostToolUse and other tools stay generic working', () => {
     for (const payload of [
       { hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'ls' } },

--- a/src/shared/agents/normalize.ts
+++ b/src/shared/agents/normalize.ts
@@ -7,7 +7,7 @@ export type AgentState = 'working' | 'waiting' | 'blocked' | 'done'
 export interface NormalizedAgentEvent {
   nodeId: string
   agentId: AgentId
-  kind: 'state' | 'subagent-start' | 'subagent-end' | 'recurring' | 'session'
+  kind: 'state' | 'subagent-start' | 'subagent-end' | 'recurring' | 'session' | 'background-task'
   state?: AgentState
   // done only: the turn ended because the user interrupted (Esc/Ctrl-C) — the renderer
   // skips the completion alert/unread for these (the user was right there).
@@ -95,6 +95,8 @@ interface ClaudePayload {
     prompt?: string
     skill?: string
     cron?: string
+    /** Bash only: the task was launched as a background shell (`run_in_background: true`). */
+    run_in_background?: boolean
   }
   tool_response?: {
     status?: string
@@ -184,6 +186,14 @@ export function normalizeClaude(env: RawHookEnvelope): NormalizedAgentEvent | nu
           task: p.tool_input?.prompt
         }
       }
+    }
+    // A background shell task lives INSIDE the CLI process: /exit kills it silently. This event
+    // is the stamp Eco hibernation and the bulk restart exclude on (see hibernation-policy /
+    // planBulkRestart). PreToolUse only, and `=== true` — an absent or false flag is a foreground
+    // command, which the generic "working" below already covers. Claude-only: no other dialect
+    // carries the field (closed set, CLAUDE.md agent rule 7).
+    if (ev === 'PreToolUse' && tool === 'Bash' && p.tool_input?.run_in_background === true) {
+      return { ...base, kind: 'background-task' }
     }
     // Any other tool use is just "working".
     return { ...base, kind: 'state', state: 'working' }


### PR DESCRIPTION
Follow-up to #130. A Claude Code background shell (`Bash` with `run_in_background: true`) runs inside the CLI process and dies with it — it was the one `/exit`-kills-work hazard with no guard, because a running background task produces no hook events and no subagent card. Spec (user-approved, in this PR): `docs/superpowers/specs/2026-08-12-background-task-hibernation-guard-design.md`.

## Behavior

- Claude's `PreToolUse` for `Bash` + `run_in_background === true` (strict `=== true`, mutation-pinned) emits a new `background-task` event; the node gets a transient `backgroundTaskAt` stamp.
- **Cleared only at a genuine turn start (`done → working`).** Two review rounds tightened this predicate, both catches real: (1) any-transition-to-working cleared the stamp on the post-approval `blocked → working` edge — milliseconds after it was set, for exactly the permission-gated task the guard exists for; (2) the `undefined → working` arm was reachable mid-turn (renderer reload, stale-working sweep) and re-opened the same hole from the other side. Every real turn ends `Stop → done`, so the clear happens at most one turn late and never early.
- **Eco hibernation:** `planHibernation` refuses a stamped node (required `liveBackgroundTask` field — typecheck forces every call site).
- **Bulk "Restart idle agents":** a stamped node is skipped and counted in the existing `working` bucket ("busy, try again in a moment" — exactly what a live background task is; the summary line stays frozen at four parts).
- **Single-node restart untouched** (user decision: a deliberate click on that node).

## Scope decisions (from the spec)

- Claude-only signal: no other dialect carries the field (closed-set rule); other agents byte-identical.
- Accepted edges (spec §4): concurrent tasks (first completion's turn clears the stamp; mitigated by the idle-window reset), a task reporting back while the node sits waiting/blocked clears one turn later (such a node is never a candidate anyway), unknown-state stamps clear one turn late, renderer reload drops the stamp together with the idle clock (Eco is inert without one).
- Escalation path if the stamp model ever proves insufficient: completion counting via transcript task-notifications (approach C, rejected for v1 as disproportionate).

## Testing

- TDD throughout; both shells forward the new event unfiltered (rule-11 parity verified in review); mirror/HUD land it in their identity-only buckets (kind-union consumer sweep ran twice).
- Full suite at HEAD: 5083 passed / 394 files (the 3 failures are `node-pty-patch.test.ts`, environmental on the dev box's shared node_modules — the postinstall patch script makes them pass on a fresh install; verified untouched by this branch).
- Device check: appended as **item 8** to the tracked Eco checklist (`docs/superpowers/plans/2026-08-10-ram-optimization.md`) — a node with a running background shell is not hibernated; after the task completes and its turn runs, hibernation happens one idle window later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)