### PR TITLE
fix(github-issues): base the auth row on the active provider, not the raw gh flag

### DIFF
--- a/src/renderer/components/settings/sections/GitHubIssuesSection.tsx
+++ b/src/renderer/components/settings/sections/GitHubIssuesSection.tsx
@@ -13,6 +13,7 @@ import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
 import { Select } from '@renderer/ui/Select'
 import { Switch } from '@renderer/ui/Switch'
+import { describeGitHubAuth, tokenFieldIsPrimary } from '../../../lib/githubAuthView'
 
 const ROWS = {
   enable: {
@@ -154,7 +155,17 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
   const completionReady = !!githubConfig?.completionColumnId &&
     mappings.has(githubConfig.completionColumnId)
   const ready = approved && authenticated && completionReady
-  const ghSignedIn = !!view?.auth.ghAuthenticated
+  // What the Authentication row should say/show — decided once, off the ACTIVE provider (not the
+  // raw ghAuthenticated flag, which lies for an unapproved project and for a gh-up/token-pinned
+  // session). See githubAuthView.ts.
+  const authView = describeGitHubAuth({
+    approved,
+    provider: view?.control.authProvider ?? 'auto',
+    activeProvider: view?.auth.activeProvider ?? null,
+    tokenPresent: !!view?.auth.tokenPresent,
+    ...(view?.auth.login ? { login: view.auth.login } : {})
+  })
+  const tokenPrimary = tokenFieldIsPrimary(authView)
 
   // The personal access token control, defined once and placed either prominently (when the GitHub
   // CLI is NOT signed in — it's the only way in) or tucked inside "Advanced" (when gh already works,
@@ -319,29 +330,53 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
 
           <SearchableRow {...ROWS.authentication}>
             <div className="space-y-3">
-              {ghSignedIn ? (
-                // Happy path: the CLI already authenticates every request — no token, no dropdown.
-                // (Unless the user has explicitly pinned the provider to token-only, below.)
-                <p className="text-[13px] text-text">
-                  ✓ Signed in via GitHub CLI
-                  {view?.auth.activeProvider === 'gh' && view?.auth.login ? ` as @${view.auth.login}` : ''}.
-                  {view?.control.authProvider === 'token' ? '' : ' No token needed.'}
-                </p>
-              ) : (
+              {authView.kind === 'unapproved' && (
+                // Approval gates credential resolution, so we genuinely can't check yet — say that,
+                // never "not signed in" (the setup flow approves right above this row).
                 <p className="text-[13px] text-muted">
-                  GitHub CLI is not signed in. Run <code>gh auth login</code> in a terminal, or paste a
-                  personal access token below.
+                  Approve this repository above to check GitHub authentication.
+                </p>
+              )}
+              {authView.kind === 'gh' && (
+                <p className="text-[13px] text-text">
+                  ✓ Signed in via GitHub CLI{authView.login ? ` as @${authView.login}` : ''}.
+                  {authView.pinned ? '' : ' No token needed.'}
+                  {authView.tokenPresent ? ' A saved token is kept as a fallback.' : ''}
+                </p>
+              )}
+              {authView.kind === 'token' && (
+                <p className="text-[13px] text-text">
+                  ✓ Authenticated with a saved personal access token.
+                </p>
+              )}
+              {authView.kind === 'need-gh' && (
+                <p className="text-[13px] text-muted">
+                  GitHub CLI is not signed in. Run <code>gh auth login</code> in a terminal
+                  {authView.allowToken ? ', or paste a personal access token below' : ''}.{' '}
+                  <button
+                    type="button"
+                    className="github-auth-recheck"
+                    disabled={busy !== ''}
+                    onClick={() => void refreshStatus()}
+                  >
+                    Check again
+                  </button>
+                </p>
+              )}
+              {authView.kind === 'need-token' && (
+                <p className="text-[13px] text-muted">
+                  Authentication is pinned to a personal access token — paste one below to authenticate.
                 </p>
               )}
 
-              {/* Token is the only way in when gh is absent, so surface it; otherwise hide it away. */}
-              {!ghSignedIn && tokenFieldRow}
+              {/* Token in the foreground only when it's actionable; otherwise tucked into Advanced. */}
+              {tokenPrimary && tokenFieldRow}
 
               <details className="github-auth-advanced">
-                <summary>{ghSignedIn ? 'Advanced — use a personal access token instead' : 'Advanced'}</summary>
+                <summary>Advanced — authentication provider &amp; token</summary>
                 <div className="space-y-4" style={{ marginTop: 12 }}>
                   {providerFieldRow}
-                  {ghSignedIn && tokenFieldRow}
+                  {!tokenPrimary && tokenFieldRow}
                 </div>
               </details>
             </div>

--- a/src/renderer/lib/githubAuthView.test.ts
+++ b/src/renderer/lib/githubAuthView.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { describeGitHubAuth, tokenFieldIsPrimary, type GitHubAuthInput } from './githubAuthView'
+
+const base: GitHubAuthInput = {
+  approved: true,
+  provider: 'auto',
+  activeProvider: null,
+  tokenPresent: false
+}
+
+describe('describeGitHubAuth', () => {
+  it('is neutral (unapproved) before approval, never "signed out" — even if the flag says so', () => {
+    // The host masks the auth block to ghAuthenticated:false/activeProvider:null pre-approval; the
+    // row must not read that as "not signed in" and tell the user to run gh auth login.
+    expect(describeGitHubAuth({ ...base, approved: false, activeProvider: 'gh' })).toEqual({ kind: 'unapproved' })
+    expect(describeGitHubAuth({ ...base, approved: false })).toEqual({ kind: 'unapproved' })
+  })
+
+  it('reports the CLI happy path only when gh is the ACTIVE provider', () => {
+    expect(describeGitHubAuth({ ...base, activeProvider: 'gh', login: 'enes' }))
+      .toEqual({ kind: 'gh', login: 'enes', pinned: false, tokenPresent: false })
+  })
+
+  it('marks the CLI path as pinned when the user forced gh-only', () => {
+    const v = describeGitHubAuth({ ...base, provider: 'gh', activeProvider: 'gh' })
+    expect(v).toMatchObject({ kind: 'gh', pinned: true })
+  })
+
+  it('surfaces a saved token as a fallback fact on the CLI path', () => {
+    const v = describeGitHubAuth({ ...base, activeProvider: 'gh', tokenPresent: true })
+    expect(v).toMatchObject({ kind: 'gh', tokenPresent: true })
+  })
+
+  it('reports the token path when a saved token authenticates requests', () => {
+    expect(describeGitHubAuth({ ...base, provider: 'token', activeProvider: 'token', tokenPresent: true }))
+      .toEqual({ kind: 'token' })
+  })
+
+  it('does NOT claim CLI sign-in when gh is up but the provider is pinned to a missing token', () => {
+    // The regression: ghAuthenticated could be true while activeProvider is null (token pinned, no
+    // token) — a request would fail, so this must be a "need-token", not a green check.
+    expect(describeGitHubAuth({ ...base, provider: 'token', activeProvider: null }))
+      .toEqual({ kind: 'need-token' })
+  })
+
+  it('points at gh auth login when nothing authenticates and gh is allowed', () => {
+    expect(describeGitHubAuth({ ...base, provider: 'auto', activeProvider: null }))
+      .toEqual({ kind: 'need-gh', allowToken: true })
+    // gh-only pinning: a pasted token would be inert, so allowToken is false.
+    expect(describeGitHubAuth({ ...base, provider: 'gh', activeProvider: null }))
+      .toEqual({ kind: 'need-gh', allowToken: false })
+  })
+})
+
+describe('tokenFieldIsPrimary', () => {
+  it('foregrounds the token field only when a token is actionable', () => {
+    expect(tokenFieldIsPrimary({ kind: 'need-token' })).toBe(true)
+    expect(tokenFieldIsPrimary({ kind: 'need-gh', allowToken: true })).toBe(true)
+    expect(tokenFieldIsPrimary({ kind: 'need-gh', allowToken: false })).toBe(false)
+    expect(tokenFieldIsPrimary({ kind: 'gh', pinned: false, tokenPresent: false })).toBe(false)
+    expect(tokenFieldIsPrimary({ kind: 'token' })).toBe(false)
+    expect(tokenFieldIsPrimary({ kind: 'unapproved' })).toBe(false)
+  })
+})

--- a/src/renderer/lib/githubAuthView.ts
+++ b/src/renderer/lib/githubAuthView.ts
@@ -1,0 +1,57 @@
+// What the GitHub Issues "Authentication" row should SAY and SHOW, decided once from the resolved
+// control view. Pulled out of the component so the branch logic is unit-testable — the settings UI
+// only maps each kind to copy + which controls to surface.
+//
+// Why this exists (two bugs the naive `ghAuthenticated` flag caused):
+//  1. The host masks the auth block to `{ghAuthenticated:false, activeProvider:null}` for an
+//     UNAPPROVED project (it won't resolve credentials before the user consents), and approval
+//     comes AFTER this row in the setup flow — so a signed-in user briefly saw "not signed in, run
+//     gh auth login". `unapproved` is its own neutral state, never "signed out".
+//  2. What actually authenticates a request is `activeProvider`, not `ghAuthenticated`. gh can be
+//     signed in while the provider is pinned to `token` with no token saved (`activeProvider:null`)
+//     — a request would fail, so we must NOT show the green "✓ signed in via CLI" there.
+
+export type GitHubAuthProviderPref = 'auto' | 'gh' | 'token'
+
+export interface GitHubAuthInput {
+  /** The repository must be approved on this machine before the host resolves any credential. */
+  approved: boolean
+  /** The user's provider preference (`view.control.authProvider`). */
+  provider: GitHubAuthProviderPref
+  /** Which provider actually authenticates requests right now, or null if none does. */
+  activeProvider: 'gh' | 'token' | null
+  /** Whether a saved personal access token exists (independent of whether it's the active one). */
+  tokenPresent: boolean
+  /** The authenticated login, when known. */
+  login?: string
+}
+
+export type GitHubAuthView =
+  // Can't tell yet — approval gates credential resolution. Neutral, never "signed out".
+  | { kind: 'unapproved' }
+  // A request authenticates via the GitHub CLI. `pinned` = the user forced gh-only.
+  | { kind: 'gh'; login?: string; pinned: boolean; tokenPresent: boolean }
+  // A request authenticates via the saved personal access token.
+  | { kind: 'token' }
+  // Nothing authenticates and the preference allows gh → point at `gh auth login`.
+  // `allowToken` (auto only) = a pasted token would also work, so surface the field.
+  | { kind: 'need-gh'; allowToken: boolean }
+  // Nothing authenticates and the preference is pinned to token → a token is the only way in.
+  | { kind: 'need-token' }
+
+export function describeGitHubAuth(input: GitHubAuthInput): GitHubAuthView {
+  if (!input.approved) return { kind: 'unapproved' }
+  if (input.activeProvider === 'gh') {
+    return { kind: 'gh', login: input.login, pinned: input.provider === 'gh', tokenPresent: input.tokenPresent }
+  }
+  if (input.activeProvider === 'token') return { kind: 'token' }
+  // Nothing authenticates. A token only helps when the preference would actually consult it.
+  if (input.provider === 'token') return { kind: 'need-token' }
+  return { kind: 'need-gh', allowToken: input.provider === 'auto' }
+}
+
+/** Whether the token field belongs in the FOREGROUND (it's the way in) rather than tucked into
+ *  "Advanced". True only when a token is currently actionable. */
+export function tokenFieldIsPrimary(view: GitHubAuthView): boolean {
+  return view.kind === 'need-token' || (view.kind === 'need-gh' && view.allowToken)
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8038,6 +8038,25 @@ body,
 .github-auth-advanced > summary:hover {
   color: var(--text-strong);
 }
+.github-auth-advanced > summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+/* Inline "Check again" affordance next to the not-signed-in hint — a link, not a chunky button. */
+.github-auth-recheck {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.github-auth-recheck:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
 
 .kanban-col__newmenu {
   position: absolute;


### PR DESCRIPTION
Follow-up to #115, addressing a review (Opus + a second reviewer, corroborating).

## What was wrong

#115 relocated the token controls correctly, but the new copy keyed off `auth.ghAuthenticated`, which lies in two common states:

1. **High — an unapproved project reads as "signed out."** `src/core/github/host.ts` masks the auth block to `{ghAuthenticated:false, activeProvider:null}` until the repository is **approved** (it won't resolve credentials before consent). Approval happens right above this row in the setup flow, so during setup a signed-in user saw *"GitHub CLI is not signed in. Run `gh auth login`…"* with the token field front and center — the exact noise #115 set out to remove, plus a wrong instruction.
2. **Medium — `ghAuthenticated` ≠ what authenticates a request.** Requests authenticate via `activeProvider`. With `provider:'token'` and no token saved, `activeProvider` is null (requests fail), yet the section still rendered the green *"✓ Signed in via GitHub CLI."*
3. **Medium — the Advanced summary over-promised.** "use a personal access token instead" implied saving a token switches auth off the CLI; under the default `auto` provider it does **not** (auto keeps preferring the signed-in CLI).

## Fix

- The row's decision is now a pure, unit-tested **`describeGitHubAuth`** (`src/renderer/lib/githubAuthView.ts`) over `{approved, provider, activeProvider, tokenPresent}` → one of `unapproved | gh | token | need-gh | need-token`. `tokenFieldIsPrimary` decides whether the token field is foregrounded (it's the only way in) or tucked into Advanced.
  - `unapproved` → neutral *"Approve this repository above to check GitHub authentication."* — never "signed out".
  - `gh` → the green check, gated on `activeProvider === 'gh'`; "No token needed" dropped when gh-pinned; a "saved token kept as a fallback" note when one exists.
  - `token` → *"✓ Authenticated with a saved personal access token."*
  - `need-gh` / `need-token` → correct, provider-aware guidance (a token hint only when it would actually be consulted).
- Honest Advanced summary: **"Advanced — authentication provider & token"**.
- A **"Check again"** link in the `need-gh` state (status() bypasses the 30 s credential cache, so it reflects a just-run `gh auth login` immediately).
- `:focus-visible` outline on the disclosure summary.

## Testing

- New `githubAuthView.test.ts` — 8 cases pinning every branch, incl. the two regressions above (unapproved-is-not-signed-out; gh-up-but-token-pinned-missing is `need-token`, not a green check).
- `styles.theme.test.ts` guard passes (`--accent` is a defined token).
- `npm run typecheck` + `npm run build` clean.
- Not browser-verified (Playwright MCP unavailable this session) — visual pass owed on Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
