### PR TITLE
fix(sidebar): clicking a project row switches to it (supersedes #121)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -8466,6 +8466,7 @@ export function Canvas() {
         onReorder={reorderSession}
         onRowContextMenu={onRowContextMenu}
         onProjectContextMenu={onProjectContextMenu}
+        onSwitchProject={switchProject}
         onAddToProject={addToProject}
         onMouseEnter={openSessionsPeek}
         onMouseLeave={closeSessionsPeekSoon}

--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -46,6 +46,7 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
   // Closed projects are hidden from the tab bar; hide them from the sidebar too.
   const projects = useMemo(() => allProjects.filter((p) => !p.closed), [allProjects])
   const activeProjectId = useProjects((s) => s.activeProjectId)
+  const setActiveProject = useProjects((s) => s.setActive)
   const statusById = useAgentStatus((s) => s.byId)
   const namingById = useSessionNaming((s) => s.byId)
   // This sidebar's core api (a stable context read — the branch lookups run on the session's git).
@@ -275,7 +276,10 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
             >
               <div
                 className={`ss-group__head${dropClass(g.projectId, null)}`}
-                onClick={() => toggleCollapse(g.projectId, isCollapsed)}
+                onClick={() => {
+                  if (!g.isActive) setActiveProject(g.projectId)
+                  if (isCollapsed) toggleCollapse(g.projectId, isCollapsed)
+                }}
                 onContextMenu={(e) => props.onProjectContextMenu(e, g.projectId)}
                 title={drag?.projectId === g.projectId ? 'Drop here to remove from group' : undefined}
                 draggable
@@ -289,7 +293,16 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
                 }}
                 {...dropProps(g.projectId, null)}
               >
-                <span className="ss-group__chev">{isCollapsed ? '▶' : '▼'}</span>
+                <span
+                  className="ss-group__chev"
+                  title={isCollapsed ? 'Expand' : 'Collapse'}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    toggleCollapse(g.projectId, isCollapsed)
+                  }}
+                >
+                  {isCollapsed ? '▶' : '▼'}
+                </span>
                 <span className="ss-group__monogram" style={{ background: g.projectColor }}>
                   {(g.projectName.trim() || '?').charAt(0).toUpperCase()}
                 </span>

--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   buildSessionList,
   isGroupCollapsed,
+  projectHeadClickAction,
   projectSignalCounts,
   type SessionNodeInput
 } from '../lib/sessionList'
@@ -26,6 +27,11 @@ export interface SessionsSidebarProps {
   onRowContextMenu(e: React.MouseEvent, projectId: string, id: string): void
   /** Right-click on a project header: the project actions menu (switch/rename/folder/close). */
   onProjectContextMenu(e: React.MouseEvent, projectId: string): void
+  /** Make a project active. MUST be Canvas's `switchProject`, never `useProjects.setActive`:
+   *  a switch has to commit the live React Flow nodes back into the store and persist first,
+   *  or the outgoing project's unsaved edits are dropped by the active-project reload and the
+   *  new activeProjectId never reaches disk (the app reopens on the old project). */
+  onSwitchProject(projectId: string): void
   onAddToProject(projectId: string): void
   /** Move a node into a canvas group (groupId) or out to the top level (null). */
   onMoveToGroup(projectId: string, nodeId: string, groupId: string | null): void
@@ -46,7 +52,6 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
   // Closed projects are hidden from the tab bar; hide them from the sidebar too.
   const projects = useMemo(() => allProjects.filter((p) => !p.closed), [allProjects])
   const activeProjectId = useProjects((s) => s.activeProjectId)
-  const setActiveProject = useProjects((s) => s.setActive)
   const statusById = useAgentStatus((s) => s.byId)
   const namingById = useSessionNaming((s) => s.byId)
   // This sidebar's core api (a stable context read — the branch lookups run on the session's git).
@@ -276,9 +281,13 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
             >
               <div
                 className={`ss-group__head${dropClass(g.projectId, null)}`}
+                // One click, one action (projectHeadClickAction documents why it is never both):
+                // an inactive project switches — through Canvas, so the outgoing project's live
+                // nodes are committed and the new active id is persisted — and the active one
+                // toggles its own collapse, so the row keeps no dead zone.
                 onClick={() => {
-                  if (!g.isActive) setActiveProject(g.projectId)
-                  if (isCollapsed) toggleCollapse(g.projectId, isCollapsed)
+                  if (projectHeadClickAction(g.isActive) === 'switch') props.onSwitchProject(g.projectId)
+                  else toggleCollapse(g.projectId, isCollapsed)
                 }}
                 onContextMenu={(e) => props.onProjectContextMenu(e, g.projectId)}
                 title={drag?.projectId === g.projectId ? 'Drop here to remove from group' : undefined}
@@ -293,16 +302,22 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
                 }}
                 {...dropProps(g.projectId, null)}
               >
-                <span
+                {/* Collapse is now the chevron's job alone on an inactive row, so it has to be a
+                    real target: a button with its own hit area and keyboard focus, not the bare
+                    9px glyph. It stops propagation so peeking into a project never switches. */}
+                <button
+                  type="button"
                   className="ss-group__chev"
                   title={isCollapsed ? 'Expand' : 'Collapse'}
+                  aria-label={isCollapsed ? `Expand ${g.projectName}` : `Collapse ${g.projectName}`}
+                  aria-expanded={!isCollapsed}
                   onClick={(e) => {
                     e.stopPropagation()
                     toggleCollapse(g.projectId, isCollapsed)
                   }}
                 >
                   {isCollapsed ? '▶' : '▼'}
-                </span>
+                </button>
                 <span className="ss-group__monogram" style={{ background: g.projectColor }}>
                   {(g.projectName.trim() || '?').charAt(0).toUpperCase()}
                 </span>

--- a/src/renderer/lib/sessionList.test.ts
+++ b/src/renderer/lib/sessionList.test.ts
@@ -3,6 +3,7 @@ import {
   buildSessionList,
   sessionStatusKind,
   isGroupCollapsed,
+  projectHeadClickAction,
   projectSignalCounts,
   type ProjectInput
 } from './sessionList'
@@ -46,6 +47,30 @@ describe('isGroupCollapsed', () => {
     expect(isGroupCollapsed({}, 'p1', true, false)).toBe(false)
     expect(isGroupCollapsed({}, 'p2', false, false)).toBe(false) // inactive stays expanded
     expect(isGroupCollapsed({ p2: true }, 'p2', false, false)).toBe(true) // user collapsed
+  })
+})
+
+describe('projectHeadClickAction', () => {
+  it('switches to an inactive project and toggles the active one (never both, never nothing)', () => {
+    expect(projectHeadClickAction(false)).toBe('switch')
+    // No dead zone: the active row still does what the whole header used to do.
+    expect(projectHeadClickAction(true)).toBe('toggle-collapse')
+  })
+
+  it('needs no collapse write on a switch: the target expands from the DEFAULT', () => {
+    // With autoCollapse ON the sidebar wipes every override on the activeProjectId change, so
+    // a toggle written by the click would be clobbered a tick later anyway — and is pointless,
+    // because the newly active project is expanded by the default rule.
+    expect(projectHeadClickAction(false)).toBe('switch')
+    expect(isGroupCollapsed({}, 'p2', true)).toBe(false)
+  })
+
+  it("with autoCollapse off, a switch leaves the target's explicit collapse choice alone", () => {
+    // Documented contract: "off = switches never touch the user's choices". The click writes no
+    // override, so a project the user collapsed by hand stays collapsed after switching to it.
+    const overrides = { p2: true }
+    expect(projectHeadClickAction(false)).toBe('switch')
+    expect(isGroupCollapsed(overrides, 'p2', true, false)).toBe(true)
   })
 })
 

--- a/src/renderer/lib/sessionList.ts
+++ b/src/renderer/lib/sessionList.ts
@@ -50,6 +50,30 @@ export function isGroupCollapsed(
   return autoCollapse ? !isActive : false
 }
 
+/** What a left-click on a project header in the sessions sidebar does. */
+export type ProjectHeadAction = 'switch' | 'toggle-collapse'
+
+/**
+ * A project header's click does exactly ONE of two things, and never both.
+ *
+ * - An INACTIVE project **switches** to that project and leaves `overrides` alone. Touching
+ *   collapse here would be dead-or-wrong under both settings: with `sidebarAutoCollapse` ON
+ *   the sidebar's own effect wipes every override on the `activeProjectId` change, so any
+ *   toggle written here is clobbered a tick later (and unnecessary — the newly active project
+ *   is expanded by default); with it OFF, writing one would discard the user's explicit
+ *   choice, contradicting the documented "off = switches never touch the user's choices".
+ * - The ACTIVE project **toggles its own collapse** — the pre-existing behavior of the whole
+ *   header, kept so the row has no dead zone. It sets a normal override, which is transient
+ *   under auto-collapse (dropped at the next switch) and sticky without it, exactly like the
+ *   chevron button.
+ *
+ * The chevron is the escape hatch either way: it toggles collapse on ANY row (it
+ * stops propagation), so an inactive project can be peeked into without switching.
+ */
+export function projectHeadClickAction(isActive: boolean): ProjectHeadAction {
+  return isActive ? 'toggle-collapse' : 'switch'
+}
+
 /**
  * Header badges for a project group: how many sessions need the user right now
  * (waiting/blocked) and how many finished unseen. Mirrors the row glyph's precedence —

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6355,7 +6355,26 @@ body,
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
   flex: 0 0 auto;
 }
-.ss-group__chev { font-size: 9px; color: var(--muted); width: 10px; }
+/* The chevron is the ONLY collapse toggle on an inactive project row (the row itself switches),
+   so it is a real button with a clickable box around the 9px glyph, not the glyph alone. */
+.ss-group__chev {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  margin: -3px -2px -3px -3px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  font-size: 9px;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+}
+.ss-group__chev:hover { background: rgba(var(--tint-rgb), 0.12); color: var(--text); }
 .ss-group__dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
 .ss-group__name { font-size: 12px; font-weight: 600; color: var(--text); }
 .ss-group.is-active .ss-group__name { color: var(--accent); }


### PR DESCRIPTION
Supersedes #121. The original commit is carried over unchanged (authored by @gor3a — thanks!), with maintainer follow-up fixes on top. Opened as a new PR only because #121 has `maintainerCanModify = false`, so its branch could not be pushed to.

**Feature:** clicking a project row in the sessions sidebar switches to that project — previously that was hidden behind a right-click, and the left-click only toggled collapse.

## Follow-up fixes

**1. The switch goes through Canvas's `switchProject`, not `useProjects.setActive` (HIGH)**

The original called `setActive` straight from `SessionsSidebar`, bypassing the project-switch discipline documented in CLAUDE.md ("Projects (tabs)"). `switchProject` does `commitActiveToStore()` → `setActive()` → `writeDisk()`. Skipping it meant:

- live React Flow edits to the outgoing project since the last debounced persist were **discarded**, because the active-project effect reloads from the stale store copy;
- the new `activeProjectId` was never written to disk, so the app **reopened on the old project**.

Fixed with a new `onSwitchProject` prop wired to Canvas's `switchProject`, matching the sibling props (`onAddToProject`, `onFocusNode`, `onReorderProject`). Canvas's own `focusNodeById` already uses `switchProject` for exactly this case.

**2. One click, one action — the collapse half was dead-or-contradictory (MEDIUM)**

The original also toggled collapse on a switch. That is wrong under both settings:

- with `sidebarAutoCollapse` **on** (the default) the sidebar's effect wipes every override on the `activeProjectId` change, so the toggle is clobbered a tick later — and is pointless anyway, since the newly active project is expanded by the default rule;
- with it **off**, the click silently discarded the user's explicit collapse choice, contradicting the documented "off = switches never touch the user's choices".

The decision is now the pure, unit-tested `projectHeadClickAction(isActive)` in `lib/sessionList.ts`, with the reasoning in its doc comment: an **inactive** row switches and writes no override; the **active** row toggles its own collapse (the header's pre-existing behavior), so there is **no dead zone** on the active, expanded row. The chevron remains the escape hatch on any row — it stops propagation, so an inactive project can be peeked into without switching.

**3. The chevron is a real button (LOW)**

It was the only collapse toggle left on an inactive row but was a bare 10×9px `<span>` with no padding, no role and no keyboard focus. Now a `<button type="button">` with an 18×18 hit area, hover state, `aria-expanded` and an `aria-label`.

## Tests

`projectHeadClickAction` gets three cases in `src/renderer/lib/sessionList.test.ts`, including the two behaviours that were previously wrong (a switch needs no collapse write because the target expands from the default; with auto-collapse off a switch leaves the target's explicit choice alone). No test was forced into the Canvas monolith.

- `npm run typecheck` — clean
- `npx vitest run src/renderer` — 153 files, 2085 tests, all passing

Not device-verified (no GUI on this host).
