### PR TITLE
fix(hook-server): a confirmation-gated control request must not be killed by the receive-phase timeout

### DIFF
--- a/src/core/agents/hook-server.slowloris.test.ts
+++ b/src/core/agents/hook-server.slowloris.test.ts
@@ -57,7 +57,10 @@ afterAll(() => {
   rmSync(dir, { recursive: true, force: true })
 })
 
-describe('hook server: the slowloris guard is receive-phase only', () => {
+// Concurrent: the two routes are independent, and each has to sit out the guard in real time.
+// Run serially this file parks for 2 x HANDLER_PARK_MS of pure wall clock, which is dead weight
+// on every suite run and needless scheduling pressure on the other files sharing the machine.
+describe.concurrent('hook server: the slowloris guard is receive-phase only', () => {
   it('/control/ survives a handler that parks longer than the guard', async () => {
     const res = await post('/control/write', 'nodeId=n1&arg.node=n2&arg.text=hi')
     expect(res.status).toBe(200)

--- a/src/core/agents/hook-server.slowloris.test.ts
+++ b/src/core/agents/hook-server.slowloris.test.ts
@@ -1,0 +1,72 @@
+// The slowloris guard is a RECEIVE-phase guard, and this pins that it stays one.
+//
+// A destructive /control/ verb (write, close) parks in the renderer for as long as the user takes
+// to answer the confirmation dialog — by design, up to the desktop's 120s `pendingControl` bound.
+// The 2s guard used to apply to the whole request lifetime, so it destroyed that socket mid-dialog:
+// the sh shim reported "control endpoint unreachable" (curl exit 52 at ~2019ms) while a late
+// confirm STILL delivered the text — the agent was told nothing happened when it had, and may
+// retry, which is a silent duplicate delivery.
+//
+// The guard is raised, not removed: nothing may park forever, so both routes keep a bounded
+// ceiling and the context-link route additionally races its handler. Spins the real hookServer,
+// same harness precedent as context-link.cli.test.ts.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { hookServer } from './hook-server'
+import { initPlatform, resetPlatformForTests } from '../platform'
+import { fakePlatform } from '../platform-fake'
+
+// Comfortably past the 2s receive-phase guard, and short enough to keep the suite quick.
+const HANDLER_PARK_MS = 3500
+
+let dir = ''
+
+function post(path: string, body: string): Promise<Response> {
+  return fetch(`http://127.0.0.1:${hookServer.getPort()}${path}`, {
+    method: 'POST',
+    headers: {
+      'X-Nodeterm-Hook-Token': hookServer.getToken(),
+      'content-type': 'application/x-www-form-urlencoded',
+      accept: 'text/plain'
+    },
+    body
+  })
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'hooksrv-slowloris-'))
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: dir }))
+  await hookServer.start()
+  // Stands in for the renderer holding the request open on the confirmation dialog.
+  hookServer.setControlHandler(async () => {
+    await new Promise((r) => setTimeout(r, HANDLER_PARK_MS))
+    return { ok: true, message: 'sent' }
+  })
+  // Stands in for a linked-transcript read whose remote leg is slow (but not wedged).
+  hookServer.setContextLinkHandler(async () => {
+    await new Promise((r) => setTimeout(r, HANDLER_PARK_MS))
+    return 'linked transcript'
+  })
+})
+
+afterAll(() => {
+  hookServer.stop()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('hook server: the slowloris guard is receive-phase only', () => {
+  it('/control/ survives a handler that parks longer than the guard', async () => {
+    const res = await post('/control/write', 'nodeId=n1&arg.node=n2&arg.text=hi')
+    expect(res.status).toBe(200)
+    expect((await res.text()).trim()).toBe('sent')
+  }, 15000)
+
+  it('/context-link/ survives a read that takes longer than the guard', async () => {
+    const res = await post('/context-link/transcript', 'nodeId=n1&arg.node=n2')
+    expect(res.status).toBe(200)
+    expect((await res.text()).trim()).toBe('linked transcript')
+  }, 15000)
+})

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -9,6 +9,23 @@ import { normalizeFor, type NormalizedAgentEvent } from '../../shared/agents/nor
 export const NODETERM_HOOK_PROTOCOL_VERSION = '1'
 const SLOWLORIS_MS = 2000
 
+// Once the body is fully read the slowloris guard has done its job — it exists for the RECEIVE
+// phase (a client that dribbles bytes to pin a socket), not for the handler. But it is replaced
+// with a HIGHER ceiling, never removed: a confirmation-gated control verb legitimately parks
+// while the renderer waits for the user's answer, yet nothing may park forever. The desktop shell
+// bounds a control request at 120s (`pendingControl` in src/main/index.ts) — a bound that lives
+// OUTSIDE core, so a future core-side handler with no bound of its own would inherit an unbounded
+// socket if this were `setTimeout(0)`. 130s sits comfortably above that, so in the desktop the
+// handler's own timeout always wins and this only ever fires as a backstop.
+const CONTROL_CEILING_MS = 130_000
+
+// The context-link handler has no timeout of its own, and its remote leg reads over an SSH
+// ControlMaster that can wedge (ConnectTimeout only covers the connect). Race it so the agent
+// gets the same prose failure it would get from any other read error, instead of a session that
+// blocks indefinitely — pre-fix the 2s destroy at least unblocked the agent's curl.
+const CONTEXT_LINK_READ_MS = 30_000
+const CONTEXT_LINK_TIMEOUT_TEXT = 'Could not read linked context.'
+
 // Default seconds the managed permission hook holds for a phone/canvas answer before falling
 // through to Claude's interactive prompt (must stay under Claude's own hook timeout). Injected
 // into a claude session's env as NODETERM_PERM_WAIT_SECS when hook-reply approvals are enabled.
@@ -30,6 +47,24 @@ function readBody(req: IncomingMessage): Promise<string> {
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')))
     req.on('error', () => resolve(''))
   })
+}
+
+/**
+ * Resolve to `fallback` if `p` has not settled within `ms`. The timer is always cleared, so a
+ * losing race never holds the process open. There is nothing to cancel in a read already in
+ * flight, so a rejection must be swallowed either way — otherwise it surfaces as an unhandled
+ * rejection once the timeout has already answered. A rejection that loses no race therefore also
+ * yields `fallback`, which for the context-link route means the caller reads the same prose
+ * failure it gets from any other read error instead of a bare 204.
+ */
+function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  let timer: NodeJS.Timeout
+  return Promise.race([
+    p.catch(() => fallback),
+    new Promise<T>((resolve) => {
+      timer = setTimeout(() => resolve(fallback), ms)
+    })
+  ]).finally(() => clearTimeout(timer))
 }
 
 // Parses application/x-www-form-urlencoded bodies (what the managed script posts).
@@ -149,6 +184,12 @@ class HookServer {
             await readBody(req),
             String(req.headers['content-type'] ?? '')
           )
+          // Body fully received: hand the socket from the receive-phase guard to the much larger
+          // handler ceiling. A destructive control verb parks here for as long as the user takes
+          // to answer the confirmation dialog, and the 2s guard used to destroy the socket mid-
+          // dialog — the caller saw "endpoint unreachable" while the dialog was still up, and a
+          // late confirm still delivered, so the agent was told nothing happened when it had.
+          req.setTimeout(CONTROL_CEILING_MS, () => req.destroy())
           const result = this.controlHandler
             ? await this.controlHandler({ verb, nodeId, args })
             : { ok: false, error: 'control unavailable' }
@@ -172,10 +213,18 @@ class HookServer {
             await readBody(req),
             String(req.headers['content-type'] ?? '')
           )
+          // Same hand-off as /control/: the receive phase is over, so raise the guard to the
+          // handler ceiling rather than dropping it. The effective bound here is the race below;
+          // the socket ceiling is only the backstop behind it.
+          req.setTimeout(CONTROL_CEILING_MS, () => req.destroy())
           // Always text: the caller is the sh shim, and the payload IS prose (a rendered
           // transcript). The handler owns the authorization — see context-link.ts.
           const text = this.contextLinkHandler
-            ? await this.contextLinkHandler({ verb, nodeId, args })
+            ? await withTimeout(
+                this.contextLinkHandler({ verb, nodeId, args }),
+                CONTEXT_LINK_READ_MS,
+                CONTEXT_LINK_TIMEOUT_TEXT
+              )
             : 'Context link is unavailable in this session.'
           res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
           res.end(`${text}\n`)


### PR DESCRIPTION
## Reproduction

An agent issues a canvas-control `write` to another node. The user takes more than 2 seconds to answer the confirmation dialog. The shim reports:

```
control endpoint unreachable
```

curl exits **52 (empty reply from server) at ~2019 ms** — while the dialog is still on screen. A **late confirm STILL delivers the text**. So the agent is told the endpoint was unreachable when the write actually landed, and may retry: **silent duplicate delivery**. Stacked confirmations wedge agent messaging entirely.

The cause is that the hook server's 2 s slowloris guard (`req.setTimeout(SLOWLORIS_MS, () => req.destroy())`) was armed for the **whole request lifetime**, not just the receive phase. A destructive `/control/` verb parks in the renderer by design, up to the desktop's 120 s `pendingControl` bound (`src/main/index.ts`) — far past 2 s.

## The fix

The guard is a **RECEIVE-phase** guard: it exists for a client that dribbles bytes to pin a socket, not for the handler. So once the body is fully read, both the `/control/` and `/context-link/` routes hand the socket off from the guard to a much larger ceiling.

## Why a bounded ceiling, not `setTimeout(0)`

Removing the ceiling outright would be a real behavior regression in two places:

- **`/control/`** would then be bounded only by `pendingControl`'s 120 s — a bound that lives **outside core**, in the desktop shell. A future core-side control handler would silently inherit an unbounded socket.
- **`/context-link/`** would get **no bound at all**. `handleContextLinkRequest` has no timeout of its own, and its remote leg reads over an SSH ControlMaster that can wedge (`ConnectTimeout` only covers the connect). Pre-fix, the 2 s destroy at least unblocked the agent's curl; with no ceiling the agent's session blocks indefinitely — a worse failure than the one being fixed.

So:

- `CONTROL_CEILING_MS = 130_000` — a named constant sitting comfortably above the desktop's 120 s bound, so in practice the handler's own timeout always wins and this only ever fires as a backstop. Applied to both routes. A confirmation-gated handler may legitimately park; nothing may park forever.
- `/context-link/` additionally **races its handler at 30 s** (`CONTEXT_LINK_READ_MS`), resolving to the existing `"Could not read linked context."` string. The race is the effective bound there; the socket ceiling is only the backstop behind it. The helper also swallows a rejection — it must, or a read that rejects after the timeout already answered surfaces as an unhandled rejection — which as a side effect turns a rejecting handler into that same prose failure instead of a bare 204.

## Test

`src/core/agents/hook-server.slowloris.test.ts` spins the **real** `hookServer` (same harness precedent as `context-link.cli.test.ts`) with handlers that park 3.5 s — past the 2 s guard — and asserts both routes still answer 200 with their payload.

Verified by stashing the production change:

- **without the fix:** 2 failed — `TypeError: fetch failed` / `SocketError: other side closed` (`UND_ERR_SOCKET`) on both routes
- **with the fix:** 2 passed

## Gates

- `npm run typecheck` — clean
- `npx vitest run src/core/agents src/core/context-link.cli.test.ts src/main/canvas-control-core.test.ts src/main/canvas-control-shim.test.ts` — 13 files, **172 passed**
- `npx vitest run` — 396 passed / 1 failed (398 files), **5114 passed / 3 failed** (5129 tests). The 3 failures are all `src/main/node-pty-patch.test.ts`, environmental in this clone (symlinked `node_modules`); confirmed identical on the untouched tree at `origin/main`.

---

This carries the **fix half of #113**, with credit to @austinschneider (`Co-Authored-By` on the commit). That PR's `agentSeamlessWrites` setting and its Canvas write-path bypass are **not** included here — that half is being redesigned separately. #113 is left open for the owner; our fork policy is fast-forward-only on contributor branches, so the fix half is landed here rather than by rewriting theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
