### PR TITLE
[superseded by #193] feat(canvas): Cmd/Ctrl+0 fits view

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4682,6 +4682,12 @@ export function Canvas() {
       } else if ((e.metaKey || e.ctrlKey) && e.key === '/') {
         e.preventDefault()
         setShortcutsOpen((v) => !v)
+      } else if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.code === 'Digit0') {
+        // Fit view. Matched on `e.code` (physical key), same as the Cmd/Ctrl+1-9 project-jump
+        // chord, so it fires from a non-US keyboard layout too. Digit0 is deliberately excluded
+        // from that chord's regex, so the two can never collide.
+        e.preventDefault()
+        fitAll()
       } else if (projectJumpDigit(e) !== null) {
         // Cmd/Ctrl+1-9 jumps to the Nth project — but only when the app actually owns the key
         // (desktop shell, and the digit addresses an open project). `liveProjectJumpTarget`
@@ -4702,7 +4708,7 @@ export function Canvas() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [toggleSessionsPin, switchProject])
+  }, [toggleSessionsPin, switchProject, fitAll])
 
   // Apply the accent color as a CSS variable.
   useEffect(() => {

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -45,7 +45,8 @@ function buildSections(dictationKeys: string[], dictationLabel: string): { title
         { keys: ['Left-drag'], label: 'Box-select (touch to select)' },
         { keys: ['Middle / Right-drag'], label: 'Pan the canvas' },
         { keys: ['Double-click'], label: 'Center & focus a node' },
-        { keys: ['⌘', 'wheel'], label: 'Zoom in / out' }
+        { keys: ['⌘', 'wheel'], label: 'Zoom in / out' },
+        { keys: ['⌘', '0'], label: 'Fit view' }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Bind existing `fitAll()` to Cmd/Ctrl+0. Digit0 was deliberately excluded from the Cmd/Ctrl+1-9 project-jump chord's regex, so no collision.
- Matched on `e.code` (physical key), same convention as the project-jump chord, so it fires on non-US layouts too.
- Added row to the shortcuts panel.

## Test plan
- [x] `npm run typecheck` passes
- [ ] Manual: press Cmd/Ctrl+0 on canvas, confirm fit view triggers same as dock/Controls button/⌘K "Fit view"