### PR TITLE
fix(server): terminate live WS clients on shutdown

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -542,6 +542,10 @@ export async function startServer(
         // node env is torn down aborts the process. See SpeechService.shutdown.
         await speechService.shutdown()
         hookServer.stop()
+        // No WS teardown counterpart to the serving branch's below, and none is owed: this branch
+        // returns BEFORE `http.createServer`/`attachWsServer`, so there is no listener and no
+        // upgraded socket that could hold a close open. `startServer` has two returns and a
+        // shutdown step usually belongs in both — this one belongs in exactly one.
       }
     }
   }
@@ -556,7 +560,7 @@ export async function startServer(
   )
   // A closed browser tab is the NORMAL way to leave the Server Edition and sends no `pty:kill`,
   // so the WS close hook is what unsubscribes that client from the sessions it was watching.
-  attachWsServer(server, {
+  const wsServer = attachWsServer(server, {
     platform,
     auth,
     onClientGone: (uiId) => {
@@ -591,6 +595,11 @@ export async function startServer(
       await speechService.shutdown()
       // Close the loopback hook-server listener (it would otherwise die with the process anyway).
       hookServer.stop()
+      // Upgraded WebSockets are not ordinary HTTP connections: server.close() waits for them but
+      // does not end them. Own the WS lifecycle explicitly so a client close racing shutdown
+      // cannot hang the Server Edition (or its tests) forever.
+      for (const client of wsServer.clients) client.terminate()
+      await new Promise<void>((resolve) => wsServer.close(() => resolve()))
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()))
       })

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -101,7 +101,7 @@ function upgradeAllowed(
   return true
 }
 
-export function attachWsServer(server: http.Server, opts: WsServerOpts): void {
+export function attachWsServer(server: http.Server, opts: WsServerOpts): WebSocketServer {
   const { platform, auth, onClientGone, heartbeatMs = WS_HEARTBEAT_MS, trustProxy } = opts
   const wss = new WebSocketServer({ noServer: true, maxPayload: WS_MAX_PAYLOAD })
 
@@ -211,4 +211,5 @@ export function attachWsServer(server: http.Server, opts: WsServerOpts): void {
 
     ws.on('close', () => teardown(uiId))
   })
+  return wss
 }

--- a/test/server/server-e2e.test.ts
+++ b/test/server/server-e2e.test.ts
@@ -104,3 +104,46 @@ describe.skipIf(!hasTmux)('server e2e: login → ws → pty echo round-trip', ()
     ws.close()
   }, 30_000)
 })
+
+describe('server shutdown with a live websocket', () => {
+  it('terminates the upgraded client before closing the HTTP server', async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-e2e-shutdown-'))
+    const srv = await startServer({
+      port: 0, host: '127.0.0.1', dataDir,
+      rendererDir: path.join(dataDir, 'no-renderer'), insecureHttp: false,
+      passwordSeed: 'e2e-shutdown-password-123', installHooks: false
+    })
+    const res = await fetch(`http://127.0.0.1:${srv.port}/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'password=e2e-shutdown-password-123',
+      redirect: 'manual'
+    })
+    const cookie = res.headers.get('set-cookie')!.split(';')[0]
+    const ws = new WebSocket(`ws://127.0.0.1:${srv.port}/ws`, { headers: { cookie } })
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', resolve)
+      ws.once('error', reject)
+    })
+    const clientClosed = new Promise<void>((resolve) => ws.once('close', () => resolve()))
+    let closeTimer: ReturnType<typeof setTimeout> | undefined
+
+    try {
+      await Promise.race([
+        srv.close(),
+        new Promise<never>((_resolve, reject) => {
+          closeTimer = setTimeout(
+            () => reject(new Error('server close hung on upgraded websocket')),
+            2_000
+          )
+        })
+      ])
+      await clientClosed
+      expect(ws.readyState).toBe(WebSocket.CLOSED)
+    } finally {
+      if (closeTimer) clearTimeout(closeTimer)
+      ws.terminate()
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    }
+  }, 10_000)
+})


### PR DESCRIPTION
**Slice 2 of #112**, cut by us from `integration/codex-112` (the PR's content merged onto current main, de-Prettier-ed). Original work by **Corvin (@proteus-dev)** — commits `5c782d4a` (fix) and `149eb039` (test); credited via `Co-Authored-By`. #112 stays open; this lands the one piece of it that has nothing to do with Codex.

The whole slice is ~50 lines in `src/server/` plus its e2e test. The full `origin/main…integration/codex-112` diff for `src/server/` **is** this change and nothing else — two other commits on that branch touched `src/server/index.ts` (`a1b54068` added two lines, `faf466bd` removed the same two), so they cancel out in the net diff. No Codex-related server change was left behind.

## The bug

`startServer`'s serving branch ends its `close()` with:

```ts
await new Promise<void>((resolve, reject) => {
  server.close((err) => (err ? reject(err) : resolve()))
})
```

`http.Server#close` stops accepting new connections and fires its callback only once every **existing** connection has ended. An upgraded WebSocket is not an ordinary HTTP connection that finishes on its own: the browser tab holds it open, no FIN ever arrives, and node keeps counting the socket. So one open Server Edition tab makes `close()` hang.

**Measured, not assumed.** Applying only the new test to unmodified `main`:

```
FAIL  test/server/server-e2e.test.ts > server shutdown with a live websocket
Error: server close hung on upgraded websocket
```

A longer probe (start server → authenticate → open `/ws` → call `close()` → wait) confirmed it is indefinite, not slow: **still pending after 20 s**, with the socket `OPEN`. With the fix the same close completes in **113 ms**.

Everything that goes wrong is downstream of that one await:

* **The process never exits on a signal.** `src/server/main.ts` wires `SIGINT`/`SIGTERM` to `close().then(() => process.exit(0))`. The `then` never runs. The Dockerfile deliberately uses the exec form so "`docker stop`'s SIGTERM reaches it directly" — with a tab open, that SIGTERM is received, shutdown starts, and then the container sits out its grace period and is **SIGKILLed** instead of stopping cleanly. Same story for any systemd unit running in serving mode (`TimeoutStopSec` → SIGKILL, and a stop recorded as a failure).
* **The heartbeat outlives the shutdown.** `ws.ts` does `server.on('close', () => clearInterval(heartbeat))`, and the http server emits `close` only after the last connection ends — so pre-fix that interval kept pinging clients of a server that had already torn itself down (it is `unref`'d, so it did not by itself hold the loop open). Post-fix the sockets die, `close` is emitted, and the interval is actually cleared.
* **A half-dead window.** `sessionReaper.stop()`, `contextLink.stop()`, `ptyManager.killAll()`, `speechService.shutdown()` and `hookServer.stop()` all run *before* the await, so during the hang the clients are still connected to a server whose pty layer, hook server and context-link service are already gone.

Not a socket "leak" in the FD sense — the sockets are exactly as alive as they were — but the shutdown is unbounded, which is the same thing from the operator's side.

## The fix

`attachWsServer` now returns its `WebSocketServer` (it was `void`), and the serving branch's `close()` owns the WS lifecycle explicitly before awaiting the HTTP close:

```ts
for (const client of wsServer.clients) client.terminate()
await new Promise<void>((resolve) => wsServer.close(() => resolve()))
```

## Both close paths

`startServer` has two returns, and a shutdown step usually belongs in both (the recent memory-pressure change had to touch both). **Here it belongs in exactly one, by construction:** the headless branch returns *before* `http.createServer` / `attachWsServer` are ever reached — it binds no public listener at all (`NODETERM_HEADLESS=1`, "zero open ports"), so there is no `wss` and no upgraded socket that could hold anything open. I added a comment in the headless `close()` saying so, so the next reader who greps for the symmetric change gets an answer instead of a suspicion.

## Interaction with the WS machinery

* **`ui-sink-registry` / sink eviction** — `terminate()` fires `'close'` on the socket, which runs the existing `teardown(uiId)` (`presenceHub.leave` → `onClientGone` → `platform.detach`). That is the same path a closed tab and a sink-gone eviction take, and it is documented as idempotent, so a shutdown racing a real close is harmless.
* **`ptyManager.dropClient` after `killAll`** — `teardown` calls `dropClient`, and it now runs *after* `await ptyManager.killAll()`. Safe: `killAll()` ends with `this.sessions.clear()`, so `dropClient` iterates an empty map and is a no-op. Nothing is lost by the ordering either — `killAll` takes the final per-session scrollback snapshots itself, so the snapshot-on-detach that `dropClient` would have triggered has already happened.
* **Heartbeat eviction** — untouched. The heartbeat's own `ws.terminate()` for a peer that missed a round works exactly as before; shutdown just does the same thing to everyone at once, and the interval is now genuinely cleared (see above).
* **Backpressure / drop machinery** — untouched. Terminating at shutdown discards whatever was still buffered for a client, which is correct: the process is going away, and the alternative (`ws.close()` + drain) is what makes shutdown unbounded again.

## Gates

* `npm run typecheck` — clean.
* `npx vitest run src/server test/server` — **22 files, 150 tests, all passing.**
* Full `npx vitest run` — **396 files / 5115 tests passing**, 12 skipped; the only failures are the 3 known-environmental `src/main/node-pty-patch.test.ts` assertions (symlinked `node_modules` in a scratch clone). `src/core/license.test.ts` passed.
* The new test specifically: **fails on `main`** ("server close hung on upgraded websocket", 2 s timeout), **passes here in 113 ms**.
