### PR TITLE
feat(canvas): trackpad wheel routing, image paste/drop, and file copy to the OS pasteboard

### DIFF
--- a/src/core/canvas-images.test.ts
+++ b/src/core/canvas-images.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import { promises as fs } from 'fs'
 import { mkdtemp, rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { appImagesDir, canvasImageTarget, projectImagesDir, saveCanvasImage } from './canvas-images'
-import { uploadsRoot } from './uploads'
+import { UPLOAD_MAX_BYTES, uploadsRoot } from './uploads'
 
 const png = Buffer.from('fake-png-bytes').toString('base64')
 
@@ -86,16 +86,81 @@ describe('saveCanvasImage', () => {
   })
 
   it('answers null for bytes it will not store, rather than throwing', async () => {
+    // null is the whole contract with the caller: it filters the path out and reports the loss,
+    // so a throw here would take the other images in the same drop down with it.
     expect(await saveCanvasImage({ projectCwd, userDataDir, name: 'a.png', dataBase64: '' })).toBe(
       null
     )
+    // Refused on the ENCODED length, before any decode — measuring it by allocating it is the
+    // exact thing the limit exists to prevent, so the test must not allocate the payload either.
     expect(
       await saveCanvasImage({
         projectCwd,
         userDataDir,
         name: 'a.png',
-        dataBase64: 'x'.repeat(64 * 1024 * 1024 * 2)
+        dataBase64: 'x'.repeat(Math.ceil(UPLOAD_MAX_BYTES * 1.4) + 1)
       })
     ).toBe(null)
+    // Nothing was left behind by either refusal.
+    await expect(fs.readdir(projectImagesDir(projectCwd))).rejects.toThrow()
+  })
+
+  it('falls back to the app folder when the project folder will not take the file', async () => {
+    // `.nodeterm` as a FILE reproduces ENOTDIR, which is the same shape as EACCES on a read-only
+    // checkout, a root-owned `.nodeterm`, or a read-only mount. Before the retry this lost the
+    // image silently — a regression against the pre-durability behavior, where the write went to
+    // userData and essentially could not fail.
+    await fs.writeFile(join(projectCwd, '.nodeterm'), 'not a directory')
+    const path = await saveCanvasImage({
+      projectCwd,
+      userDataDir,
+      name: 'shot.png',
+      dataBase64: png
+    })
+    expect(path).toBe(join(appImagesDir(userDataDir), 'shot.png'))
+    expect(await fs.readFile(path!, 'utf8')).toBe('fake-png-bytes')
+  })
+
+  it('does not resurrect a project folder that has been deleted', async () => {
+    await rm(projectCwd, { recursive: true, force: true })
+    const path = await saveCanvasImage({
+      projectCwd,
+      userDataDir,
+      name: 'shot.png',
+      dataBase64: png
+    })
+    // Saved app-locally, and — the point — `mkdir -p` did not recreate the folder the user removed.
+    expect(path).toBe(join(appImagesDir(userDataDir), 'shot.png'))
+    await expect(fs.stat(projectCwd)).rejects.toThrow()
+  })
+
+  it('leaves no truncated file behind when the write fails partway', async () => {
+    // `wx` creates the file and then writes it, so a disk that fills in between leaves a partial
+    // image holding a name — indistinguishable from a whole one to whoever reads it next.
+    const buf = Buffer.from('fake-png-bytes')
+    const real = fs.writeFile
+    // Faithful to the failure mode: the file IS created and partially written, and THEN the write
+    // fails. Rejecting without creating anything would leave nothing for the cleanup to remove and
+    // the assertion below would pass whether or not the cleanup exists.
+    const writeFile = vi
+      .spyOn(fs, 'writeFile')
+      .mockImplementationOnce(async (target, _data, options) => {
+        await real(target, 'partial', options)
+        throw Object.assign(new Error('no space left on device'), { code: 'ENOSPC' })
+      })
+    const partial = join(projectImagesDir(projectCwd), 'shot.png')
+    const path = await saveCanvasImage({
+      projectCwd,
+      userDataDir,
+      name: 'shot.png',
+      dataBase64: buf.toString('base64')
+    })
+    writeFile.mockRestore()
+    // The project write failed, so it landed app-locally, whole...
+    expect(path).toBe(join(appImagesDir(userDataDir), 'shot.png'))
+    expect(await fs.readFile(path!, 'utf8')).toBe('fake-png-bytes')
+    // ...and the half-written project file was removed rather than left holding the name.
+    await expect(fs.readFile(partial, 'utf8')).rejects.toThrow()
+    await expect(fs.readdir(projectImagesDir(projectCwd))).resolves.toEqual([])
   })
 })

--- a/src/core/canvas-images.test.ts
+++ b/src/core/canvas-images.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { appImagesDir, canvasImageTarget, projectImagesDir, saveCanvasImage } from './canvas-images'
+import { uploadsRoot } from './uploads'
+
+const png = Buffer.from('fake-png-bytes').toString('base64')
+
+let root: string
+let userDataDir: string
+let projectCwd: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'nt-canvas-images-'))
+  userDataDir = join(root, 'userData')
+  projectCwd = join(root, 'project')
+  await fs.mkdir(projectCwd, { recursive: true })
+})
+afterEach(() => rm(root, { recursive: true, force: true }))
+
+describe('canvasImageTarget', () => {
+  it('uses the project folder when it has a local cwd, and a durable app folder when it does not', () => {
+    expect(canvasImageTarget(projectCwd, userDataDir)).toEqual({
+      dir: projectImagesDir(projectCwd),
+      inProject: true
+    })
+    // No local cwd: an SSH project (its cwd is on the host), a relay tab, or an inline canvas.
+    expect(canvasImageTarget(undefined, userDataDir)).toEqual({
+      dir: appImagesDir(userDataDir),
+      inProject: false
+    })
+  })
+
+  it('never lands inside the swept uploads staging area', () => {
+    // The whole reason this module exists: a canvas image node is persisted, so its file must not
+    // sit where UPLOAD_TTL_MS deletes it after a week.
+    const sweptRoot = uploadsRoot(userDataDir)
+    expect(canvasImageTarget(projectCwd, userDataDir).dir.startsWith(sweptRoot)).toBe(false)
+    expect(canvasImageTarget(undefined, userDataDir).dir.startsWith(sweptRoot)).toBe(false)
+  })
+})
+
+describe('saveCanvasImage', () => {
+  it('writes into the project’s git-shared .nodeterm/images/', async () => {
+    const path = await saveCanvasImage({
+      projectCwd,
+      userDataDir,
+      name: 'shot.png',
+      dataBase64: png
+    })
+    expect(path).toBe(join(projectCwd, '.nodeterm', 'images', 'shot.png'))
+    expect(await fs.readFile(path!, 'utf8')).toBe('fake-png-bytes')
+  })
+
+  it('falls back to the app folder for a project with no local cwd, instead of refusing', async () => {
+    const path = await saveCanvasImage({ userDataDir, name: 'shot.png', dataBase64: png })
+    expect(path).toBe(join(appImagesDir(userDataDir), 'shot.png'))
+    expect(await fs.readFile(path!, 'utf8')).toBe('fake-png-bytes')
+  })
+
+  it('never clobbers an existing image, and keeps the extension on the renamed one', async () => {
+    const first = await saveCanvasImage({ projectCwd, userDataDir, name: 'shot.png', dataBase64: png })
+    const second = await saveCanvasImage({
+      projectCwd,
+      userDataDir,
+      name: 'shot.png',
+      dataBase64: Buffer.from('second').toString('base64')
+    })
+    expect(first).toBe(join(projectCwd, '.nodeterm', 'images', 'shot.png'))
+    expect(second).toBe(join(projectCwd, '.nodeterm', 'images', 'shot (2).png'))
+    expect(await fs.readFile(first!, 'utf8')).toBe('fake-png-bytes')
+    expect(await fs.readFile(second!, 'utf8')).toBe('second')
+  })
+
+  it('cannot be steered out of the images directory by the pasted name', async () => {
+    const path = await saveCanvasImage({
+      projectCwd,
+      userDataDir,
+      name: '../../.bashrc',
+      dataBase64: png
+    })
+    expect(path).toBe(join(projectCwd, '.nodeterm', 'images', '.bashrc'))
+    await expect(fs.readFile(join(root, '.bashrc'), 'utf8')).rejects.toThrow()
+  })
+
+  it('answers null for bytes it will not store, rather than throwing', async () => {
+    expect(await saveCanvasImage({ projectCwd, userDataDir, name: 'a.png', dataBase64: '' })).toBe(
+      null
+    )
+    expect(
+      await saveCanvasImage({
+        projectCwd,
+        userDataDir,
+        name: 'a.png',
+        dataBase64: 'x'.repeat(64 * 1024 * 1024 * 2)
+      })
+    ).toBe(null)
+  })
+})

--- a/src/core/canvas-images.ts
+++ b/src/core/canvas-images.ts
@@ -37,19 +37,24 @@ export interface CanvasImageTarget {
 }
 
 /**
- * `projectCwd` is the project's LOCAL cwd, or undefined. Undefined covers three cases, and the
- * answer is the same for all of them because in each one there is no local directory that both
- * this machine can write and the image node can later read:
+ * `projectCwd` is the project's LOCAL cwd, or undefined. Undefined covers three cases:
  *
  *  • a cwd-less / inline canvas — there is no project folder at all;
- *  • an SSH project — `<cwd>` is a path on the REMOTE host, and `files.saveUpload` has always
- *    written on the machine the terminals run on, i.e. here. The image node itself reads locally
- *    (the canvas opens it without `sshFs`), so writing the bytes to the host would produce a node
- *    that cannot read its own file;
- *  • a relay tab — not in this machine's workspace index at all.
+ *  • an SSH project — `<cwd>` is a path on the REMOTE host, while this write happens here, on the
+ *    machine the terminals run on (as `files.saveUpload` always has). Writing to the host would be
+ *    wrong anyway: the canvas opens an image node WITHOUT `sshFs`, so the node reads through the
+ *    local fs and would not be able to read its own file. App-local is the coherent answer;
+ *  • a project whose folder has been DELETED — see `saveCanvasImage`, which collapses it into this
+ *    branch rather than letting `mkdir -p` resurrect a directory the user removed.
  *
- * None of these is an error, so none of them refuses: the image is still saved, just somewhere
- * that only this machine can see. The caller is told which happened via `inProject`.
+ * None of these is an error, so none refuses: the image is saved, it just cannot travel with the
+ * project. The caller is told which happened via `inProject`.
+ *
+ * A RELAY TAB is deliberately NOT in that list — it is refused before it reaches here (see
+ * `canvasImportRefusal` in renderer/canvas/canvas-image-import.ts). The reasoning above turns on
+ * the node reading through the same fs this wrote to, and for a relay tab that is FALSE: the write
+ * is the local preload's while `EditorNode` reads through the session api, i.e. the PEER's core.
+ * Saving here would produce a node that asks another machine for a path only this one has.
  */
 export function canvasImageTarget(
   projectCwd: string | undefined,
@@ -60,10 +65,50 @@ export function canvasImageTarget(
     : { dir: appImagesDir(userDataDir), inProject: false }
 }
 
+const isDir = async (p: string): Promise<boolean> => {
+  try {
+    return (await fs.stat(p)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * One write attempt into `dir`. Throws whatever the filesystem threw — the caller decides whether
+ * that is worth a second directory. Resolves null only when the name collided every allowed time.
+ */
+async function writeInto(dir: string, safe: string, buf: Buffer): Promise<string | null> {
+  await fs.mkdir(dir, { recursive: true })
+  for (let attempt = 1; attempt <= MAX_COLLISION_ATTEMPTS; attempt++) {
+    const target = join(dir, candidateName(safe, attempt))
+    try {
+      await fs.writeFile(target, buf, { flag: 'wx' })
+      return target
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === 'EEXIST') continue
+      // `wx` CREATED the file and then the write failed partway (a disk that filled between the
+      // two). Nothing distinguishes a truncated image from a whole one to the reader, and the
+      // name is now taken, so the remains are removed before the error propagates.
+      await fs.rm(target, { force: true }).catch(() => undefined)
+      throw err
+    }
+  }
+  return null
+}
+
+const tryWrite = async (dir: string, safe: string, buf: Buffer): Promise<string | null> => {
+  try {
+    return await writeInto(dir, safe, buf)
+  } catch {
+    return null
+  }
+}
+
 /**
  * Write base64 `data` into the project's image folder and resolve its ABSOLUTE path, or null when
- * it could not be written (too large, undecodable, unwritable, or a name that collided 200 times).
- * Never throws — the caller drops what it could not save, exactly like a failed drop.
+ * it could not be written anywhere (too large, undecodable, or every candidate directory refused).
+ * Never throws — the caller drops what it could not save, exactly like a failed drop, and tells
+ * the user (an image that silently never appears is the failure this must not have).
  *
  * The name is basenamed by `safeUploadName` before it is joined, so a pasted `../../.bashrc`
  * cannot escape the directory, and the write is an EXCLUSIVE create (`wx`) walked through
@@ -76,28 +121,31 @@ export async function saveCanvasImage(opts: {
   name: string
   dataBase64: string
 }): Promise<string | null> {
+  // Guard the ENCODED length first: decoding a hostile 2 GB string to measure it is the
+  // allocation this limit exists to prevent (same rule as core/uploads.ts).
+  const { dataBase64 } = opts
+  if (typeof dataBase64 !== 'string' || dataBase64.length > UPLOAD_MAX_BYTES * 1.4) return null
+  let buf: Buffer
   try {
-    // Guard the ENCODED length first: decoding a hostile 2 GB string to measure it is the
-    // allocation this limit exists to prevent (same rule as core/uploads.ts).
-    const { dataBase64 } = opts
-    if (typeof dataBase64 !== 'string' || dataBase64.length > UPLOAD_MAX_BYTES * 1.4) return null
-    const buf = Buffer.from(dataBase64, 'base64')
-    if (!buf.length || buf.length > UPLOAD_MAX_BYTES) return null
-
-    const { dir } = canvasImageTarget(opts.projectCwd, opts.userDataDir)
-    await fs.mkdir(dir, { recursive: true })
-    const safe = safeUploadName(opts.name)
-    for (let attempt = 1; attempt <= MAX_COLLISION_ATTEMPTS; attempt++) {
-      const target = join(dir, candidateName(safe, attempt))
-      try {
-        await fs.writeFile(target, buf, { flag: 'wx' })
-        return target
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException)?.code !== 'EEXIST') throw err
-      }
-    }
-    return null
+    buf = Buffer.from(dataBase64, 'base64')
   } catch {
     return null
   }
+  if (!buf.length || buf.length > UPLOAD_MAX_BYTES) return null
+  const safe = safeUploadName(opts.name)
+
+  // A project folder that is GONE takes the app-local branch instead of the project one:
+  // `mkdir -p` would otherwise happily RESURRECT `<cwd>/.nodeterm/images` under a directory the
+  // user deleted, leaving a lone skeleton of a project behind as a side effect of a paste.
+  const cwd = opts.projectCwd && (await isDir(opts.projectCwd)) ? opts.projectCwd : undefined
+  const target = canvasImageTarget(cwd, opts.userDataDir)
+  const primary = await tryWrite(target.dir, safe, buf)
+  if (primary || !target.inProject) return primary
+
+  // The project folder exists but would not take the file: a read-only checkout or mount, a
+  // root-owned `.nodeterm`, `.nodeterm` present as a FILE (ENOTDIR), a full disk. Storing it
+  // app-locally costs the user only the ability to share it; refusing costs them the image. Note
+  // this retry is what keeps the durable-storage decision from being a REGRESSION — before it, the
+  // write went to userData, where it essentially could not fail.
+  return tryWrite(appImagesDir(opts.userDataDir), safe, buf)
 }

--- a/src/core/canvas-images.ts
+++ b/src/core/canvas-images.ts
@@ -1,0 +1,103 @@
+// Where an image pasted or dropped ONTO THE CANVAS is written.
+//
+// This is deliberately NOT `core/uploads.ts`. That directory is a staging area for a paste into a
+// terminal — the path is consumed within seconds and swept after `UPLOAD_TTL_MS` (7 days), which
+// is right for a path that was pasted into a prompt and wrong for a canvas image node: the node is
+// persisted in `project.json`, so after a week the canvas kept a node pointing at a file the
+// sweeper had deleted. Whatever holds the file has to be at least as durable as the thing that
+// remembers it.
+//
+// So a project with a local cwd gets `<cwd>/.nodeterm/images/`, beside the `project.json` that
+// names the node. That folder is already the git-shared one (project.json, board-log.jsonl), so
+// the image travels to everyone who clones the repo — which is the point: a canvas that arrives
+// with broken image nodes is a canvas that did not arrive.
+//
+// Everything else falls back to `<userData>/canvas-images/` — durable (no sweeper walks it) but
+// local to this machine. See `canvasImageTarget` for exactly which cases, and why.
+
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { candidateName } from './download-name'
+import { UPLOAD_MAX_BYTES, safeUploadName } from './uploads'
+
+/** Beside project.json, in the git-shared folder — so the image travels with the canvas. */
+export const projectImagesDir = (projectCwd: string): string =>
+  join(projectCwd, '.nodeterm', 'images')
+
+/** The fallback for a project with no local cwd. Outside `uploads/`, so no sweeper touches it. */
+export const appImagesDir = (userDataDir: string): string => join(userDataDir, 'canvas-images')
+
+/** Give up rather than spin: 200 files literally named `shot.png` is not a collision any more. */
+const MAX_COLLISION_ATTEMPTS = 200
+
+export interface CanvasImageTarget {
+  dir: string
+  /** True when the file landed in the project (and will therefore travel with it). */
+  inProject: boolean
+}
+
+/**
+ * `projectCwd` is the project's LOCAL cwd, or undefined. Undefined covers three cases, and the
+ * answer is the same for all of them because in each one there is no local directory that both
+ * this machine can write and the image node can later read:
+ *
+ *  • a cwd-less / inline canvas — there is no project folder at all;
+ *  • an SSH project — `<cwd>` is a path on the REMOTE host, and `files.saveUpload` has always
+ *    written on the machine the terminals run on, i.e. here. The image node itself reads locally
+ *    (the canvas opens it without `sshFs`), so writing the bytes to the host would produce a node
+ *    that cannot read its own file;
+ *  • a relay tab — not in this machine's workspace index at all.
+ *
+ * None of these is an error, so none of them refuses: the image is still saved, just somewhere
+ * that only this machine can see. The caller is told which happened via `inProject`.
+ */
+export function canvasImageTarget(
+  projectCwd: string | undefined,
+  userDataDir: string
+): CanvasImageTarget {
+  return projectCwd
+    ? { dir: projectImagesDir(projectCwd), inProject: true }
+    : { dir: appImagesDir(userDataDir), inProject: false }
+}
+
+/**
+ * Write base64 `data` into the project's image folder and resolve its ABSOLUTE path, or null when
+ * it could not be written (too large, undecodable, unwritable, or a name that collided 200 times).
+ * Never throws — the caller drops what it could not save, exactly like a failed drop.
+ *
+ * The name is basenamed by `safeUploadName` before it is joined, so a pasted `../../.bashrc`
+ * cannot escape the directory, and the write is an EXCLUSIVE create (`wx`) walked through
+ * `candidateName` — so a second `shot.png` becomes `shot (2).png` instead of overwriting the
+ * first, and there is no stat-then-write window for two pastes to both win.
+ */
+export async function saveCanvasImage(opts: {
+  projectCwd?: string
+  userDataDir: string
+  name: string
+  dataBase64: string
+}): Promise<string | null> {
+  try {
+    // Guard the ENCODED length first: decoding a hostile 2 GB string to measure it is the
+    // allocation this limit exists to prevent (same rule as core/uploads.ts).
+    const { dataBase64 } = opts
+    if (typeof dataBase64 !== 'string' || dataBase64.length > UPLOAD_MAX_BYTES * 1.4) return null
+    const buf = Buffer.from(dataBase64, 'base64')
+    if (!buf.length || buf.length > UPLOAD_MAX_BYTES) return null
+
+    const { dir } = canvasImageTarget(opts.projectCwd, opts.userDataDir)
+    await fs.mkdir(dir, { recursive: true })
+    const safe = safeUploadName(opts.name)
+    for (let attempt = 1; attempt <= MAX_COLLISION_ATTEMPTS; attempt++) {
+      const target = join(dir, candidateName(safe, attempt))
+      try {
+        await fs.writeFile(target, buf, { flag: 'wx' })
+        return target
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException)?.code !== 'EEXIST') throw err
+      }
+    }
+    return null
+  } catch {
+    return null
+  }
+}

--- a/src/core/fs-handlers.ts
+++ b/src/core/fs-handlers.ts
@@ -1,6 +1,7 @@
 import type { CorePlatform } from './platform'
 import * as fsOps from './fs-ops'
 import { saveUpload } from './uploads'
+import { saveCanvasImage } from './canvas-images'
 import { IPC } from '../shared/ipc'
 import type { DownloadTicket } from '../shared/types'
 
@@ -22,6 +23,15 @@ export function registerFsHandlers(
      * rather than as "not offered here".
      */
     issueDownloadTicket?: (path: string) => Promise<DownloadTicket | null>
+    /**
+     * The project's LOCAL cwd, or undefined for an SSH project / relay tab / cwd-less canvas.
+     * Injected rather than taken from the caller because the renderer sends only a `projectId`:
+     * the write path is always derived here, from this shell's own workspace index, so a canvas
+     * image can never be aimed at a directory the renderer names. (Same discipline as
+     * `registerBoardLogHandlers` — see core/board-log-handlers.ts.) Absent ⇒ every project takes
+     * the durable app-local fallback, which is a coherent degrade, not a failure.
+     */
+    localProjectCwd?: (projectId: string) => string | undefined
   } = {}
 ): void {
   platform.handle(IPC.fsList, (dirPath: string) => fsOps.listDir(dirPath))
@@ -37,6 +47,18 @@ export function registerFsHandlers(
   // the managed uploads dir so the terminal has something to name. See core/uploads.ts.
   platform.handle(IPC.filesSaveUpload, (name: string, dataBase64: string) =>
     saveUpload(platform.userDataDir, name, dataBase64)
+  )
+  // A canvas image node is persisted, so its bytes go somewhere equally durable — the project's
+  // own `.nodeterm/images/` when it has one. See core/canvas-images.ts for the fallbacks.
+  platform.handle(
+    IPC.filesSaveCanvasImage,
+    (projectId: string, name: string, dataBase64: string) =>
+      saveCanvasImage({
+        projectCwd: deps.localProjectCwd?.(projectId),
+        userDataDir: platform.userDataDir,
+        name,
+        dataBase64
+      })
   )
   platform.handle(IPC.filesDownloadTicket, (p: string) =>
     deps.issueDownloadTicket ? deps.issueDownloadTicket(p) : Promise.resolve(null)

--- a/src/main/clipboard-files.test.ts
+++ b/src/main/clipboard-files.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  FILE_LIST_PASTEBOARD_TYPE,
+  fileListPropertyList,
+  writeFilesToClipboard,
+  type FileClipboardDependencies
+} from './clipboard-files'
+
+const dependencies = (overrides: Partial<FileClipboardDependencies> = {}): FileClipboardDependencies => ({
+  platform: 'darwin',
+  isFile: () => true,
+  writeBuffer: vi.fn(),
+  ...overrides
+})
+
+describe('writeFilesToClipboard', () => {
+  it('writes unique existing absolute files as a macOS filename pasteboard list', () => {
+    const deps = dependencies()
+    expect(writeFilesToClipboard(['/tmp/a & b.png', '/tmp/a & b.png'], deps)).toBe(true)
+    expect(deps.writeBuffer).toHaveBeenCalledOnce()
+    const [format, buffer] = vi.mocked(deps.writeBuffer).mock.calls[0]
+    expect(format).toBe(FILE_LIST_PASTEBOARD_TYPE)
+    expect(buffer.toString()).toContain('<string>/tmp/a &amp; b.png</string>')
+    expect(buffer.toString().match(/<string>/g)).toHaveLength(1)
+  })
+
+  it('rejects unsupported platforms and any selection containing an invalid file', () => {
+    expect(writeFilesToClipboard(['/tmp/a'], dependencies({ platform: 'linux' }))).toBe(false)
+    expect(writeFilesToClipboard(['/tmp/a'], dependencies({ isFile: () => false }))).toBe(false)
+    expect(writeFilesToClipboard(['/tmp/a', 'relative'], dependencies())).toBe(false)
+    expect(writeFilesToClipboard('not-an-array', dependencies())).toBe(false)
+  })
+
+  it('fails closed when the OS clipboard write fails', () => {
+    expect(
+      writeFilesToClipboard(
+        ['/tmp/a'],
+        dependencies({
+          writeBuffer: () => {
+            throw new Error('clipboard unavailable')
+          }
+        })
+      )
+    ).toBe(false)
+  })
+})
+
+describe('fileListPropertyList', () => {
+  it('escapes every XML-significant path character', () => {
+    expect(fileListPropertyList([`/tmp/<a>\"'&`]).toString()).toContain(
+      '&lt;a&gt;&quot;&apos;&amp;'
+    )
+  })
+})

--- a/src/main/clipboard-files.test.ts
+++ b/src/main/clipboard-files.test.ts
@@ -31,6 +31,23 @@ describe('writeFilesToClipboard', () => {
     expect(writeFilesToClipboard('not-an-array', dependencies())).toBe(false)
   })
 
+  it('caps the selection, counting only the files it kept', () => {
+    const paths = (n: number): string[] => Array.from({ length: n }, (_, i) => `/tmp/f${i}`)
+    const at = dependencies()
+    // Exactly at the cap is still one copy, not a truncated one.
+    expect(writeFilesToClipboard(paths(64), at)).toBe(true)
+    expect(vi.mocked(at.writeBuffer).mock.calls[0][1].toString().match(/<string>/g)).toHaveLength(64)
+    // One over refuses outright — a partial pasteboard is worse than none, because the user
+    // cannot see which files it dropped.
+    expect(writeFilesToClipboard(paths(65), dependencies())).toBe(false)
+    // Duplicates are folded before the cap is charged, so 65 entries naming 64 files still fit.
+    const dupes = dependencies()
+    expect(writeFilesToClipboard([...paths(64), '/tmp/f0'], dupes)).toBe(true)
+    expect(vi.mocked(dupes.writeBuffer).mock.calls[0][1].toString().match(/<string>/g)).toHaveLength(
+      64
+    )
+  })
+
   it('fails closed when the OS clipboard write fails', () => {
     expect(
       writeFilesToClipboard(

--- a/src/main/clipboard-files.ts
+++ b/src/main/clipboard-files.ts
@@ -1,0 +1,64 @@
+import { isAbsolute } from 'path'
+
+export const FILE_LIST_PASTEBOARD_TYPE = 'NSFilenamesPboardType'
+const MAX_CLIPBOARD_FILES = 64
+
+export interface FileClipboardDependencies {
+  platform: string
+  isFile(path: string): boolean
+  writeBuffer(format: string, buffer: Buffer): void
+}
+
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+
+export function fileListPropertyList(paths: string[]): Buffer {
+  const entries = paths.map((path) => `    <string>${escapeXml(path)}</string>`).join('\n')
+  return Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+      `<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n` +
+      `<plist version="1.0">\n  <array>\n${entries}\n  </array>\n</plist>\n`,
+    'utf8'
+  )
+}
+
+/**
+ * Put existing local regular files on the macOS clipboard as Finder-compatible file references.
+ * Inputs cross an IPC trust boundary, so paths are capped, absolute-only, de-duplicated and
+ * re-checked in main. The operation is all-or-nothing so a multi-selection is never silently
+ * truncated or partially copied.
+ */
+export function writeFilesToClipboard(
+  input: unknown,
+  dependencies: FileClipboardDependencies
+): boolean {
+  if (dependencies.platform !== 'darwin' || !Array.isArray(input)) return false
+
+  const paths: string[] = []
+  const seen = new Set<string>()
+  for (const value of input) {
+    if (typeof value !== 'string' || !isAbsolute(value)) return false
+    if (seen.has(value)) continue
+    if (paths.length >= MAX_CLIPBOARD_FILES) return false
+    try {
+      if (!dependencies.isFile(value)) return false
+    } catch {
+      return false
+    }
+    seen.add(value)
+    paths.push(value)
+  }
+  if (!paths.length) return false
+
+  try {
+    dependencies.writeBuffer(FILE_LIST_PASTEBOARD_TYPE, fileListPropertyList(paths))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -784,7 +784,12 @@ app.whenReady().then(async () => {
   // The Explorer/Editor fs surface: ONE registrar (core/fs-handlers.ts) shared by this shell and
   // the Server Edition, over the same pure core/fs-ops — so local, browser and peer filesystem
   // behaviour cannot drift. Registered on the platform, so a remote tab's Explorer/editor works.
-  registerFsHandlers(corePlatform)
+  // `localProjectCwd` is how a canvas image finds the project's own `.nodeterm/images/`. It
+  // answers undefined for an SSH project (its cwd is on the host, and the image node reads
+  // locally) and for a relay tab (not in this index at all) — both take the app-local fallback.
+  registerFsHandlers(corePlatform, {
+    localProjectCwd: (projectId: string) => workspaceStore.localCwdForProject(projectId)
+  })
 
   const githubSecret = new ElectronGitHubSecretStore(app.getPath('userData'), safeStorage)
   const github = registerGitHubIntegration({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,10 +2,12 @@ import { join, resolve, posix } from 'path'
 import { startSessionNameSweep, displayNodeTitle } from '../core/session-name-sweep'
 import { readAgentSessionName, type AgentSessionNameDeps } from '../core/agent-session-name'
 import { readFile } from 'fs/promises'
+import { statSync } from 'fs'
 import { homedir, hostname } from 'os'
 import { randomUUID } from 'crypto'
 import { app, BrowserWindow, clipboard, dialog, ipcMain, Notification, powerMonitor, safeStorage, shell, systemPreferences } from 'electron'
 import { IPC } from '../shared/ipc'
+import { writeFilesToClipboard } from './clipboard-files'
 import { registerFsHandlers } from '../core/fs-handlers'
 import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
 import type { RemoteLogExec } from '../core/board-log'
@@ -645,6 +647,13 @@ app.whenReady().then(async () => {
   ipcMain.on(IPC.clipboardWrite, (_e, text: string) => {
     if (typeof text === 'string') clipboard.writeText(text)
   })
+  ipcMain.handle(IPC.clipboardWriteFiles, (_e, paths: unknown) =>
+    writeFilesToClipboard(paths, {
+      platform: process.platform,
+      isFile: (path) => statSync(path).isFile(),
+      writeBuffer: (format, buffer) => clipboard.writeBuffer(format, buffer)
+    })
+  )
 
   // Dock badge: number of Claude nodes with unread output (macOS only). '' clears it.
   ipcMain.on(IPC.appSetBadge, (_e, count: number) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -287,7 +287,8 @@ const api: NodeTerminalApi = {
   },
   clipboard: {
     // Route to the MAIN process: renderer-side `clipboard` access is deprecated in Electron.
-    writeText: (text: string) => ipcRenderer.send(IPC.clipboardWrite, text)
+    writeText: (text: string) => ipcRenderer.send(IPC.clipboardWrite, text),
+    writeFiles: (paths: string[]) => ipcRenderer.invoke(IPC.clipboardWriteFiles, paths)
   },
   shell: {
     reveal: (path: string) => ipcRenderer.send(IPC.shellReveal, path),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -326,7 +326,9 @@ const api: NodeTerminalApi = {
     // already on this machine" (local project).
     downloadTicket: (p: string) => ipcRenderer.invoke(IPC.filesDownloadTicket, p),
     saveUpload: (name: string, dataBase64: string) =>
-      ipcRenderer.invoke(IPC.filesSaveUpload, name, dataBase64)
+      ipcRenderer.invoke(IPC.filesSaveUpload, name, dataBase64),
+    saveCanvasImage: (projectId: string, name: string, dataBase64: string) =>
+      ipcRenderer.invoke(IPC.filesSaveCanvasImage, projectId, name, dataBase64)
   },
   updates: {
     onAvailable: (listener) => {

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -165,7 +165,9 @@ export function buildStubApi(): Omit<
           return
         }
         copyViaExecCommand(text)
-      }
+      },
+      // A browser cannot place host-local file references on the viewer's OS clipboard.
+      writeFiles: async (): Promise<boolean> => false
     },
     shell: {
       // no filesystem-reveal in a browser; intentionally inert (see docs/SERVER.md)

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -456,7 +456,13 @@ export function buildFilesApi(
     // Also real, and the direction that matters here: the browser holds the bytes, the terminal
     // runs on the server, so a pasted image only becomes nameable once the server has written it.
     saveUpload: (name, dataBase64) =>
-      client.request(IPC.filesSaveUpload, name, dataBase64) as Promise<string | null>
+      client.request(IPC.filesSaveUpload, name, dataBase64) as Promise<string | null>,
+    // Real too, and for the same reason: the browser holds the bytes and the project folder is on
+    // the server, so only the server can put a canvas image where the canvas will find it again.
+    saveCanvasImage: (projectId, name, dataBase64) =>
+      client.request(IPC.filesSaveCanvasImage, projectId, name, dataBase64) as Promise<
+        string | null
+      >
   }
 
   const context: ContextApi = {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -34,6 +34,13 @@ import {
   wakeHibernatedNode
 } from '../nodes/TerminalNode'
 import { solveFitPadding } from './fit-view'
+import { MacWheelGestureRouter } from './wheel-gesture'
+import { selectedLocalFilePaths } from './canvas-file-copy'
+import {
+  canvasImagePasteArmedAfterKey,
+  guardedCanvasImagePlacements,
+  isCanvasImageDropTarget
+} from './canvas-image-import'
 import {
   SharedGlyphLayer,
   flushOpaqueNodeIds,
@@ -204,6 +211,13 @@ import {
 import { normWorktreePath, type BoundGroup } from '@shared/worktree-reconcile'
 import { boundGroups, scmScopes, defaultScmScope, selectedScmGroupId } from '@shared/scm-scope'
 import { hintLabel } from '@shared/platform-utils'
+import {
+  canvasImageFiles,
+  clipboardImages,
+  localPathsForFiles,
+  pasteHasText,
+  pastedFiles
+} from '../terminal/file-drop'
 import { useWorktrees } from '../state/worktrees'
 import { activeSessionApi } from '../session/session'
 import {
@@ -676,6 +690,10 @@ export function Canvas() {
   // `nodeterm:toast` when neither the Clipboard API nor execCommand can copy — typically a
   // non-secure context (plain http over a LAN). It must be seen, not swallowed.
   const [copyError, setCopyError] = useState<string | null>(null)
+  // Cmd+V only drops an image on the canvas when the LAST pointer press was on the pane itself —
+  // otherwise a paste aimed at a panel or a dialog would spawn a node behind it. See
+  // canvas-image-import.ts for the arming rules.
+  const canvasImagePasteArmedRef = useRef(false)
   // Result of a worktree operation (merge / remove). These used to be `window.alert`s — a modal
   // that blocks the whole app to say "Merged feat into main." Shown as a strip in the existing
   // top-banner column instead; an 'info' one fades itself out, an 'error' stays until dismissed.
@@ -2533,20 +2551,28 @@ export function Canvas() {
   // zoom to the cursor. React Flow's own zoomOnPinch / zoomActivationKeyCode are disabled so
   // this is the single source of zoom (no double-zoom on the open canvas).
   //
-  // With settings.wheelZoom on, a PLAIN wheel zooms too (mouse-first workflow; scroll-to-pan
-  // is disabled on <ReactFlow> in that mode) — except inside a `nowheel` node body (focused
-  // xterm scrollback, Monaco, markdown/chat panes), which keeps its own scrolling. The hover
-  // guard overlay is NOT nowheel, so an unfocused terminal still zooms under the cursor.
+  // With settings.wheelZoom on, a PLAIN mouse wheel zooms too (mouse-first workflow) — except
+  // inside a `nowheel` node body (focused xterm scrollback, Monaco, markdown/chat panes), which
+  // keeps its own scrolling. The hover guard overlay is NOT nowheel, so an unfocused terminal
+  // still zooms under the cursor. On macOS a two-finger TRACKPAD scroll keeps panning even with
+  // wheelZoom on: Chromium reports both devices as an unmodified pixel-wheel, so
+  // MacWheelGestureRouter tells them apart (and stays sticky for the length of one physical
+  // gesture) and hands trackpad packets back to React Flow's own panOnScroll.
   const wheelZoom = settings.wheelZoom
   useEffect(() => {
     const wrap = flowWrapRef.current
     if (!wrap) return
+    const wheelRouting = new MacWheelGestureRouter()
     const onWheel = (e: WheelEvent) => {
       if (canvasLocked) return
       if (!e.ctrlKey && !e.metaKey) {
+        const overNativeScrollable = !!(e.target as HTMLElement | null)?.closest('.nowheel')
+        // A macOS trackpad's two-finger scroll pans the canvas outside native scroll surfaces;
+        // inside them (terminal, Monaco, markdown) it scrolls that surface as before.
+        if (wheelRouting.destination(e, isMac, overNativeScrollable) === 'flow-pan') return
+        if (overNativeScrollable) return
         // pinch (ctrl+wheel) / Cmd/Ctrl+scroll always zoom; plain wheel only when opted in
         if (!wheelZoom) return
-        if ((e.target as HTMLElement | null)?.closest('.nowheel')) return
       }
       e.preventDefault()
       e.stopPropagation()
@@ -2919,6 +2945,97 @@ export function Canvas() {
     },
     [setNodes, markDirty, viewCenter]
   )
+
+  // Reuse the same path resolver as terminal file paste/drop, then feed the existing Open-file
+  // node path. Desktop Finder drops retain their real path; clipboard/browser blobs are saved in
+  // NodeTerm's managed upload directory first. Multiple images fan out diagonally from the cursor.
+  const placeCanvasImages = useCallback(
+    async (files: File[], center: { x: number; y: number }, projectId: string) => {
+      const images = canvasImageFiles(files)
+      if (!images.length) return
+      const placements = await guardedCanvasImagePlacements(
+        () => localPathsForFiles(images),
+        projectId,
+        () => useProjects.getState().activeProjectId,
+        center
+      )
+      placements.forEach(({ filePath, center: placement }) => openFile(filePath, placement))
+    },
+    [openFile]
+  )
+
+  // Drop or paste an image onto empty canvas → an image preview node. Registered on `window`
+  // (not the wrapper) because a paste has no drop target, and gated by isCanvasImageDropTarget so
+  // panels, dialogs and node bodies keep their own drop/paste behavior.
+  useEffect(() => {
+    const wrap = flowWrapRef.current
+    if (!wrap) return
+    const editableTarget = (target: EventTarget | null): boolean => {
+      const element = target instanceof Element ? target : null
+      return !!element?.closest(
+        'input, textarea, select, button, [contenteditable], [role="dialog"], .monaco-editor, .xterm, .react-flow__node'
+      )
+    }
+    const onPointerDown = (event: PointerEvent) => {
+      canvasImagePasteArmedRef.current = isCanvasImageDropTarget(event.target, wrap)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      canvasImagePasteArmedRef.current = canvasImagePasteArmedAfterKey(
+        canvasImagePasteArmedRef.current,
+        event
+      )
+    }
+    const onDragOver = (event: DragEvent) => {
+      if (!isCanvasImageDropTarget(event.target, wrap)) return
+      if (!Array.from(event.dataTransfer?.types ?? []).includes('Files')) return
+      event.preventDefault()
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+    }
+    const onDrop = (event: DragEvent) => {
+      if (!isCanvasImageDropTarget(event.target, wrap)) return
+      const images = canvasImageFiles(Array.from(event.dataTransfer?.files ?? []))
+      if (!images.length) return
+      event.preventDefault()
+      event.stopPropagation()
+      const center = screenToFlowPosition({ x: event.clientX, y: event.clientY })
+      const projectId = useProjects.getState().activeProjectId
+      if (projectId) void placeCanvasImages(images, center, projectId)
+    }
+    const onPaste = (event: ClipboardEvent) => {
+      if (!canvasImagePasteArmedRef.current || !hasProjects || welcomeOpen || kanbanOpen) return
+      if (document.querySelector('[role="dialog"], .usage-popover')) return
+      if (editableTarget(event.target)) return
+      const projectId = useProjects.getState().activeProjectId
+      if (!projectId) return
+      const center = viewCenter()
+      if (!center) return
+      const files = canvasImageFiles(pastedFiles(event.clipboardData))
+      if (files.length) {
+        event.preventDefault()
+        event.stopPropagation()
+        void placeCanvasImages(files, center, projectId)
+        return
+      }
+      // A screenshot can arrive with an empty clipboardData when Chromium filters the paste
+      // target. Ordinary text must remain untouched; only the image-only case uses async read().
+      if (pasteHasText(event.clipboardData)) return
+      void clipboardImages().then((images) => {
+        if (images.length) void placeCanvasImages(images, center, projectId)
+      })
+    }
+    window.addEventListener('pointerdown', onPointerDown, true)
+    window.addEventListener('keydown', onKeyDown, true)
+    window.addEventListener('dragover', onDragOver)
+    window.addEventListener('drop', onDrop)
+    window.addEventListener('paste', onPaste)
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown, true)
+      window.removeEventListener('keydown', onKeyDown, true)
+      window.removeEventListener('dragover', onDragOver)
+      window.removeEventListener('drop', onDrop)
+      window.removeEventListener('paste', onPaste)
+    }
+  }, [hasProjects, kanbanOpen, placeCanvasImages, screenToFlowPosition, viewCenter, welcomeOpen])
 
   // Load the quick-open file index when the palette opens.
   useEffect(() => {
@@ -4693,11 +4810,36 @@ export function Canvas() {
           switchProject(targetId)
         }
       } else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'c') {
-        // Copy the current page selection (e.g. markdown view) to the clipboard.
+        // Native text selection wins (markdown, editor and terminal keep their normal copy path).
         const tag = (document.activeElement?.tagName || '').toLowerCase()
-        if (tag === 'input' || tag === 'textarea') return
+        if (
+          tag === 'input' ||
+          tag === 'textarea' ||
+          document.activeElement?.getAttribute('contenteditable') === 'true' ||
+          document.activeElement?.closest('.monaco-editor, .xterm')
+        )
+          return
         const sel = window.getSelection?.()?.toString()
-        if (sel) window.nodeTerminal.clipboard.writeText(sel)
+        if (sel) {
+          window.nodeTerminal.clipboard.writeText(sel)
+          return
+        }
+        // Nothing selected as text: copy the selected file-backed nodes as FILE REFERENCES, so
+        // Finder (or any file-aware app) pastes the actual files. Desktop/macOS only — the browser
+        // stub answers false and the banner says why.
+        const paths = selectedLocalFilePaths(nodesRef.current)
+        if (!paths.length) return
+        e.preventDefault()
+        void window.nodeTerminal.clipboard
+          .writeFiles(paths)
+          .then((copied) => {
+            setCopyError(
+              copied
+                ? null
+                : 'Copy failed — only existing local files can be copied from the macOS desktop app.'
+            )
+          })
+          .catch(() => setCopyError('Copy failed — the system clipboard is unavailable.'))
       }
     }
     window.addEventListener('keydown', onKey)
@@ -8243,7 +8385,7 @@ export function Canvas() {
                 ? [0, 1]
                 : [1]
           }
-          panOnScroll={canvasLocked ? false : !wheelZoom}
+          panOnScroll={canvasLocked ? false : isMac || !wheelZoom}
           zoomOnScroll={false}
           zoomOnPinch={false}
           // Off: a pane double-click is the overview-zoom gesture (see PANE_OVERVIEW_ZOOM) and a

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -2566,13 +2566,18 @@ export function Canvas() {
     const onWheel = (e: WheelEvent) => {
       if (canvasLocked) return
       if (!e.ctrlKey && !e.metaKey) {
-        const overNativeScrollable = !!(e.target as HTMLElement | null)?.closest('.nowheel')
+        // The ancestor walk is the expensive part of this handler at ~120 Hz, so it is memoized
+        // per packet AND never run for a packet no guard asks about (a plain wheel with wheelZoom
+        // off, which is the default, walks nothing at all).
+        const target = e.target as HTMLElement | null
+        let scroller: boolean | undefined
+        const overNativeScrollable = (): boolean => (scroller ??= !!target?.closest('.nowheel'))
         // A macOS trackpad's two-finger scroll pans the canvas outside native scroll surfaces;
         // inside them (terminal, Monaco, markdown) it scrolls that surface as before.
         if (wheelRouting.destination(e, isMac, overNativeScrollable) === 'flow-pan') return
-        if (overNativeScrollable) return
         // pinch (ctrl+wheel) / Cmd/Ctrl+scroll always zoom; plain wheel only when opted in
         if (!wheelZoom) return
+        if (overNativeScrollable()) return
       }
       e.preventDefault()
       e.stopPropagation()
@@ -4825,9 +4830,20 @@ export function Canvas() {
           return
         }
         // Nothing selected as text: copy the selected file-backed nodes as FILE REFERENCES, so
-        // Finder (or any file-aware app) pastes the actual files. Desktop/macOS only — the browser
-        // stub answers false and the banner says why.
-        const paths = selectedLocalFilePaths(nodesRef.current)
+        // Finder (or any file-aware app) pastes the actual files.
+        //
+        // Gated to where it can actually succeed, because the failure path raises a banner that
+        // stays until dismissed — and before this feature the keystroke was a silent no-op, which
+        // is what every other machine must keep getting. `writeFilesToClipboard` is darwin-gated
+        // in main and the browser bridge stub answers false, so on a non-mac renderer (desktop OR
+        // Server Edition) this branch could only ever produce that banner, wearing macOS-specific
+        // copy on a Linux box. The board is an opaque overlay over the canvas, so a copy there
+        // would act on a selection the user cannot see (the canvas-only-shortcut discipline).
+        const projects = useProjects.getState()
+        if (!isMac || isKanbanOpen(projects.activeProjectId)) return
+        const paths = selectedLocalFilePaths(nodesRef.current, {
+          projectIsRelay: !!projects.getProject(projects.activeProjectId ?? '')?.remote
+        })
         if (!paths.length) return
         e.preventDefault()
         void window.nodeTerminal.clipboard

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -34,7 +34,7 @@ import {
   wakeHibernatedNode
 } from '../nodes/TerminalNode'
 import { solveFitPadding } from './fit-view'
-import { MacWheelGestureRouter } from './wheel-gesture'
+import { MacWheelGestureRouter, trackpadRoutingEnabled } from './wheel-gesture'
 import { selectedLocalFilePaths } from './canvas-file-copy'
 import {
   canvasImagePasteArmedAfterKey,
@@ -213,6 +213,7 @@ import { boundGroups, scmScopes, defaultScmScope, selectedScmGroupId } from '@sh
 import { hintLabel } from '@shared/platform-utils'
 import {
   canvasImageFiles,
+  canvasImageSink,
   clipboardImages,
   localPathsForFiles,
   pasteHasText,
@@ -2559,6 +2560,9 @@ export function Canvas() {
   // MacWheelGestureRouter tells them apart (and stays sticky for the length of one physical
   // gesture) and hands trackpad packets back to React Flow's own panOnScroll.
   const wheelZoom = settings.wheelZoom
+  // The escape hatch, resolved ONCE: the router and React Flow's panOnScroll below must agree, or
+  // a gesture neither of them pans is a gesture that does nothing.
+  const trackpadRouting = trackpadRoutingEnabled(isMac, settings.trackpadPan)
   useEffect(() => {
     const wrap = flowWrapRef.current
     if (!wrap) return
@@ -2574,7 +2578,8 @@ export function Canvas() {
         const overNativeScrollable = (): boolean => (scroller ??= !!target?.closest('.nowheel'))
         // A macOS trackpad's two-finger scroll pans the canvas outside native scroll surfaces;
         // inside them (terminal, Monaco, markdown) it scrolls that surface as before.
-        if (wheelRouting.destination(e, isMac, overNativeScrollable) === 'flow-pan') return
+        if (wheelRouting.destination(e, trackpadRouting, overNativeScrollable) === 'flow-pan')
+          return
         // pinch (ctrl+wheel) / Cmd/Ctrl+scroll always zoom; plain wheel only when opted in
         if (!wheelZoom) return
         if (overNativeScrollable()) return
@@ -2594,7 +2599,7 @@ export function Canvas() {
     }
     wrap.addEventListener('wheel', onWheel, { capture: true, passive: false })
     return () => wrap.removeEventListener('wheel', onWheel, { capture: true })
-  }, [getViewport, setViewport, wheelZoom, canvasLocked])
+  }, [getViewport, setViewport, wheelZoom, trackpadRouting, canvasLocked])
 
   // Double-clicking EMPTY canvas pulls back to the overview zoom — the inverse of the node
   // double-click, which frames one node. A fixed zoom, not "the camera the last focus came from":
@@ -2959,7 +2964,10 @@ export function Canvas() {
       const images = canvasImageFiles(files)
       if (!images.length) return
       const placements = await guardedCanvasImagePlacements(
-        () => localPathsForFiles(images),
+        // Into the PROJECT's own `.nodeterm/images/`, not the 7-day uploads staging area: the node
+        // that names this file is persisted in project.json, so the file has to outlive a week and
+        // travel to whoever clones the repo.
+        () => localPathsForFiles(images, canvasImageSink(projectId)),
         projectId,
         () => useProjects.getState().activeProjectId,
         center
@@ -8401,7 +8409,7 @@ export function Canvas() {
                 ? [0, 1]
                 : [1]
           }
-          panOnScroll={canvasLocked ? false : isMac || !wheelZoom}
+          panOnScroll={canvasLocked ? false : trackpadRouting || !wheelZoom}
           zoomOnScroll={false}
           zoomOnPinch={false}
           // Off: a pane double-click is the overview-zoom gesture (see PANE_OVERVIEW_ZOOM) and a

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -38,6 +38,7 @@ import { MacWheelGestureRouter, trackpadRoutingEnabled } from './wheel-gesture'
 import { selectedLocalFilePaths } from './canvas-file-copy'
 import {
   canvasImagePasteArmedAfterKey,
+  canvasImportRefusal,
   guardedCanvasImagePlacements,
   isCanvasImageDropTarget
 } from './canvas-image-import'
@@ -2963,6 +2964,13 @@ export function Canvas() {
     async (files: File[], center: { x: number; y: number }, projectId: string) => {
       const images = canvasImageFiles(files)
       if (!images.length) return
+      // A relay tab writes here and reads on the peer, so the node could never render its own
+      // file — say so instead of creating it. Same fact, same source as the Cmd+C gate below.
+      const refusal = canvasImportRefusal(!!useProjects.getState().getProject(projectId)?.remote)
+      if (refusal) {
+        setCopyError(refusal)
+        return
+      }
       const placements = await guardedCanvasImagePlacements(
         // Into the PROJECT's own `.nodeterm/images/`, not the 7-day uploads staging area: the node
         // that names this file is persisted in project.json, so the file has to outlive a week and
@@ -2973,6 +2981,16 @@ export function Canvas() {
         center
       )
       placements.forEach(({ filePath, center: placement }) => openFile(filePath, placement))
+      // Unsaveable files are dropped silently one layer down, and core already retried in a second
+      // directory before giving up — so a shortfall here means the image is genuinely not on disk.
+      // Saying nothing would leave the user watching for a node that is never coming. (A project
+      // switch mid-save legitimately places nothing; that is the guard's job, not a failure.)
+      const lost = images.length - placements.length
+      if (lost > 0 && useProjects.getState().activeProjectId === projectId) {
+        setCopyError(
+          `Could not save ${lost === 1 ? 'the image' : `${lost} images`} — check that this project's folder is writable.`
+        )
+      }
     },
     [openFile]
   )

--- a/src/renderer/canvas/canvas-file-copy.test.ts
+++ b/src/renderer/canvas/canvas-file-copy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import type { CanvasNode } from '../state/workspace'
+import { selectedLocalFilePaths } from './canvas-file-copy'
+
+const node = (
+  id: string,
+  type: CanvasNode['type'],
+  filePath: string,
+  data: Record<string, unknown> = {}
+): CanvasNode =>
+  ({
+    id,
+    type,
+    selected: true,
+    position: { x: 0, y: 0 },
+    data: { title: id, color: '#fff', group: null, filePath, ...data }
+  }) as CanvasNode
+
+describe('selectedLocalFilePaths', () => {
+  it('returns selected local file-backed nodes once and in canvas order', () => {
+    expect(
+      selectedLocalFilePaths([
+        node('image', 'editor', '/tmp/image.png'),
+        node('video', 'video', '/tmp/video.mp4'),
+        node('html', 'web', '/tmp/page.html'),
+        node('duplicate', 'editor', '/tmp/image.png')
+      ])
+    ).toEqual(['/tmp/image.png', '/tmp/video.mp4', '/tmp/page.html'])
+  })
+
+  it('excludes unselected, remote, missing and non-file node kinds', () => {
+    const unselected = node('unselected', 'editor', '/tmp/a')
+    unselected.selected = false
+    expect(
+      selectedLocalFilePaths([
+        unselected,
+        node('remote', 'editor', '/tmp/b', { sshFs: true }),
+        node('missing', 'video', '/tmp/c', { fileMissing: true }),
+        node('diff', 'diff', '/tmp/d'),
+        node('url', 'web', '')
+      ])
+    ).toEqual([])
+  })
+})

--- a/src/renderer/canvas/canvas-file-copy.test.ts
+++ b/src/renderer/canvas/canvas-file-copy.test.ts
@@ -28,6 +28,21 @@ describe('selectedLocalFilePaths', () => {
     ).toEqual(['/tmp/image.png', '/tmp/video.mp4', '/tmp/page.html'])
   })
 
+  it('copies nothing at all from a relay tab, whose paths describe the PEER disk', () => {
+    // Not "filters the remote ones out": in a relay tab EVERY path is the peer's, and the local
+    // statSync can silently match a same-named local file. The whole gesture is off.
+    expect(
+      selectedLocalFilePaths([node('image', 'editor', '/home/me/proj/src/x.ts')], {
+        projectIsRelay: true
+      })
+    ).toEqual([])
+    expect(
+      selectedLocalFilePaths([node('image', 'editor', '/home/me/proj/src/x.ts')], {
+        projectIsRelay: false
+      })
+    ).toEqual(['/home/me/proj/src/x.ts'])
+  })
+
   it('excludes unselected, remote, missing and non-file node kinds', () => {
     const unselected = node('unselected', 'editor', '/tmp/a')
     unselected.selected = false

--- a/src/renderer/canvas/canvas-file-copy.ts
+++ b/src/renderer/canvas/canvas-file-copy.ts
@@ -1,0 +1,26 @@
+import type { CanvasNode } from '../state/workspace'
+
+const LOCAL_FILE_NODE_TYPES = new Set(['editor', 'video', 'web'])
+
+/** Paths represented by the selected local file-backed nodes, in canvas order and without dupes. */
+export function selectedLocalFilePaths(nodes: CanvasNode[]): string[] {
+  const seen = new Set<string>()
+  const paths: string[] = []
+  for (const node of nodes) {
+    const path = node.data.filePath
+    if (
+      !node.selected ||
+      !LOCAL_FILE_NODE_TYPES.has(node.type) ||
+      typeof path !== 'string' ||
+      !path ||
+      node.data.sshFs ||
+      node.data.fileMissing ||
+      seen.has(path)
+    ) {
+      continue
+    }
+    seen.add(path)
+    paths.push(path)
+  }
+  return paths
+}

--- a/src/renderer/canvas/canvas-file-copy.ts
+++ b/src/renderer/canvas/canvas-file-copy.ts
@@ -2,8 +2,25 @@ import type { CanvasNode } from '../state/workspace'
 
 const LOCAL_FILE_NODE_TYPES = new Set(['editor', 'video', 'web'])
 
+export interface LocalFileCopyScope {
+  /**
+   * The active project is a RELAY tab — a live client of another machine's core. Its nodes' paths
+   * describe the PEER's disk, but `window.nodeTerminal.clipboard` is this machine's preload, so
+   * copying them would hand peer paths to a local `statSync`: usually a miss, but when the same
+   * repo is checked out on both machines it silently puts a DIFFERENT file on the pasteboard.
+   * A relay tab is marked at the PROJECT level (`Project.remote`) and never on the node, so this
+   * fact cannot be read off `nodes` — it has to be passed in. Same hazard the `show-image`
+   * control verb documents ("or, worse, open a same-named local file").
+   */
+  projectIsRelay?: boolean
+}
+
 /** Paths represented by the selected local file-backed nodes, in canvas order and without dupes. */
-export function selectedLocalFilePaths(nodes: CanvasNode[]): string[] {
+export function selectedLocalFilePaths(
+  nodes: CanvasNode[],
+  scope: LocalFileCopyScope = {}
+): string[] {
+  if (scope.projectIsRelay) return []
   const seen = new Set<string>()
   const paths: string[] = []
   for (const node of nodes) {

--- a/src/renderer/canvas/canvas-image-import.test.ts
+++ b/src/renderer/canvas/canvas-image-import.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import {
+  canvasImagePasteArmedAfterKey,
+  guardedCanvasImagePlacements,
+  isCanvasImageDropTarget
+} from './canvas-image-import'
+
+describe('isCanvasImageDropTarget', () => {
+  it('accepts the real pane and rejects flow-wrap overlays and nodes', () => {
+    const wrap = document.createElement('div')
+    wrap.innerHTML = `
+      <div class="react-flow__pane"><div class="react-flow__node"><span>node</span></div></div>
+      <div class="welcome"><button>open</button></div>
+      <div class="usage-indicator"><div class="usage-popover">usage</div></div>
+    `
+    const pane = wrap.querySelector('.react-flow__pane')!
+    expect(isCanvasImageDropTarget(pane, wrap)).toBe(true)
+    expect(isCanvasImageDropTarget(wrap.querySelector('.react-flow__node span'), wrap)).toBe(false)
+    expect(isCanvasImageDropTarget(wrap.querySelector('.welcome'), wrap)).toBe(false)
+    expect(isCanvasImageDropTarget(wrap.querySelector('.usage-popover'), wrap)).toBe(false)
+  })
+
+  it('rejects dialogs and sidebars outside the canvas wrapper', () => {
+    const root = document.createElement('div')
+    root.innerHTML = `
+      <div class="flow-wrap"><div class="react-flow__pane"></div></div>
+      <div role="dialog">settings</div>
+      <aside class="sessions-sidebar">sessions</aside>
+    `
+    const wrap = root.querySelector('.flow-wrap')!
+    expect(isCanvasImageDropTarget(root.querySelector('[role="dialog"]'), wrap)).toBe(false)
+    expect(isCanvasImageDropTarget(root.querySelector('.sessions-sidebar'), wrap)).toBe(false)
+  })
+})
+
+describe('guardedCanvasImagePlacements', () => {
+  it('places every resolved path while the originating project remains active', async () => {
+    await expect(
+      guardedCanvasImagePlacements(
+        async () => ['/tmp/a.png', '/tmp/b.png'],
+        'project-a',
+        () => 'project-a',
+        { x: 10, y: 20 }
+      )
+    ).resolves.toEqual([
+      { filePath: '/tmp/a.png', center: { x: 10, y: 20 } },
+      { filePath: '/tmp/b.png', center: { x: 46, y: 56 } }
+    ])
+  })
+
+  it('abandons an async result after a project switch', async () => {
+    let release!: (paths: string[]) => void
+    const pending = new Promise<string[]>((resolve) => (release = resolve))
+    let active = 'project-a'
+    const placements = guardedCanvasImagePlacements(
+      () => pending,
+      'project-a',
+      () => active,
+      { x: 10, y: 20 }
+    )
+    active = 'project-b'
+    release(['/tmp/a.png'])
+    await expect(placements).resolves.toEqual([])
+  })
+})
+
+describe('canvasImagePasteArmedAfterKey', () => {
+  it('preserves a real Cmd+V sequence but revokes arming for a keyboard-opened overlay', () => {
+    const meta = { key: 'Meta', metaKey: true, ctrlKey: false }
+    const paste = { key: 'v', metaKey: true, ctrlKey: false }
+    const openSettings = { key: ',', metaKey: true, ctrlKey: false }
+
+    expect(canvasImagePasteArmedAfterKey(true, meta)).toBe(true)
+    expect(canvasImagePasteArmedAfterKey(true, paste)).toBe(true)
+    expect(canvasImagePasteArmedAfterKey(true, openSettings)).toBe(false)
+    expect(canvasImagePasteArmedAfterKey(false, paste)).toBe(false)
+  })
+})

--- a/src/renderer/canvas/canvas-image-import.test.ts
+++ b/src/renderer/canvas/canvas-image-import.test.ts
@@ -2,9 +2,19 @@
 import { describe, expect, it } from 'vitest'
 import {
   canvasImagePasteArmedAfterKey,
+  canvasImportRefusal,
   guardedCanvasImagePlacements,
   isCanvasImageDropTarget
 } from './canvas-image-import'
+
+describe('canvasImportRefusal', () => {
+  it('refuses a relay tab, whose write and read land on different machines', () => {
+    // The write is the LOCAL preload's, the node reads through the peer's core — so the node could
+    // never render its own file. A message beats a broken node.
+    expect(canvasImportRefusal(true)).toMatch(/remote tab/i)
+    expect(canvasImportRefusal(false)).toBe(null)
+  })
+})
 
 describe('isCanvasImageDropTarget', () => {
   it('accepts the real pane and rejects flow-wrap overlays and nodes', () => {

--- a/src/renderer/canvas/canvas-image-import.ts
+++ b/src/renderer/canvas/canvas-image-import.ts
@@ -1,0 +1,45 @@
+/** True only for the actual React Flow pane, never flow-wrap overlays such as Welcome/Usage. */
+export function isCanvasImageDropTarget(target: EventTarget | null, wrap: Element): boolean {
+  const element = target instanceof Element ? target : null
+  return !!(
+    element &&
+    wrap.contains(element) &&
+    element.closest('.react-flow__pane') &&
+    !element.closest('.react-flow__node, .react-flow__controls, .react-flow__minimap')
+  )
+}
+
+export interface CanvasImagePlacement {
+  filePath: string
+  center: { x: number; y: number }
+}
+
+/**
+ * Keyboard-opened UI must revoke a prior canvas click. Modifier keydown events are part of the
+ * normal Cmd+V sequence, so only they and the actual paste chord preserve the armed state.
+ */
+export function canvasImagePasteArmedAfterKey(
+  armed: boolean,
+  event: { key: string; metaKey: boolean; ctrlKey: boolean }
+): boolean {
+  if (!armed) return false
+  if (event.key === 'Meta' || event.key === 'Control' || event.key === 'Alt' || event.key === 'Shift') {
+    return true
+  }
+  return (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'v'
+}
+
+/** Resolve image files asynchronously, but abandon them if their originating project changed. */
+export async function guardedCanvasImagePlacements(
+  resolvePaths: () => Promise<string[]>,
+  originatingProjectId: string,
+  activeProjectId: () => string,
+  center: { x: number; y: number }
+): Promise<CanvasImagePlacement[]> {
+  const paths = await resolvePaths()
+  if (activeProjectId() !== originatingProjectId) return []
+  return paths.map((filePath, index) => ({
+    filePath,
+    center: { x: center.x + index * 36, y: center.y + index * 36 }
+  }))
+}

--- a/src/renderer/canvas/canvas-image-import.ts
+++ b/src/renderer/canvas/canvas-image-import.ts
@@ -9,6 +9,26 @@ export function isCanvasImageDropTarget(target: EventTarget | null, wrap: Elemen
   )
 }
 
+/**
+ * Why a canvas image import cannot proceed, or null when it may. One rule, one message, so the
+ * drop path and the paste path cannot disagree about either.
+ *
+ * A RELAY TAB is refused because the two halves of the feature would land on different machines:
+ * the write is `window.nodeTerminal.files.saveCanvasImage` — the LOCAL preload, even in a relay
+ * tab — while `EditorNode` reads through the session api, i.e. the PEER's core. The bytes would sit
+ * on this disk and the node would ask the peer for that path, producing a node that can never
+ * render. Refusing is not a limitation dressed up as a feature: a clear message is strictly better
+ * than a broken node, and it is the same fact (`Project.remote`), read the same way, that already
+ * gates Cmd+C's file copy. Routing the write to the peer instead is a real feature — it also needs
+ * the Finder-drop shortcut bypassed, since a local OS path is just as unreadable over there — and
+ * no file write in this app crosses that boundary today.
+ */
+export function canvasImportRefusal(projectIsRelay: boolean): string | null {
+  return projectIsRelay
+    ? 'Images can’t be added to a remote tab’s canvas — the file would stay on this machine, where that canvas can’t read it.'
+    : null
+}
+
 export interface CanvasImagePlacement {
   filePath: string
   center: { x: number; y: number }

--- a/src/renderer/canvas/wheel-gesture.test.ts
+++ b/src/renderer/canvas/wheel-gesture.test.ts
@@ -19,6 +19,9 @@ const gesture = (
   wheelDeltaY: o.wheelDeltaY
 })
 
+const yes = () => true
+const no = () => false
+
 describe('MacWheelGestureRouter', () => {
   it('keeps a notched macOS mouse wheel on the user-configured zoom path', () => {
     const router = new MacWheelGestureRouter()
@@ -42,18 +45,18 @@ describe('MacWheelGestureRouter', () => {
 
   it('keeps trackpad scrolling native over terminal and other native scroll surfaces', () => {
     const router = new MacWheelGestureRouter()
-    expect(router.destination(gesture(6.25), true, true, 1000)).toBe('native')
-    expect(router.destination(gesture(6.25), true, false, 1400)).toBe('flow-pan')
-    expect(router.destination(gesture(100, { wheelDeltaY: -120 }), true, true, 1800)).toBe('native')
+    expect(router.destination(gesture(6.25), true, yes, 1000)).toBe('native')
+    expect(router.destination(gesture(6.25), true, no, 1400)).toBe('flow-pan')
+    expect(router.destination(gesture(100, { wheelDeltaY: -120 }), true, yes, 1800)).toBe('native')
   })
 
   it('does not pan over a non-terminal native scroller, and still knows the gesture is a trackpad', () => {
     const router = new MacWheelGestureRouter()
     // A trackpad gesture that begins over Monaco / a markdown pane scrolls THAT surface...
-    expect(router.destination(gesture(6.25), true, true, 1000)).toBe('native')
+    expect(router.destination(gesture(6.25), true, yes, 1000)).toBe('native')
     // ...but the packet still classified the device, so continuing the same gesture off the
     // scroller pans the canvas instead of falling back to the mouse-notch (zoom) path.
-    expect(router.destination(gesture(75), true, false, 1100)).toBe('flow-pan')
+    expect(router.destination(gesture(75), true, no, 1100)).toBe('flow-pan')
   })
 
   it('keeps pinch, Cmd-wheel, line-mode wheel and other platforms off the override', () => {

--- a/src/renderer/canvas/wheel-gesture.test.ts
+++ b/src/renderer/canvas/wheel-gesture.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { MacWheelGestureRouter } from './wheel-gesture'
+
+const gesture = (
+  deltaY: number,
+  o: Partial<{
+    deltaX: number
+    deltaMode: number
+    ctrlKey: boolean
+    metaKey: boolean
+    wheelDeltaY: number
+  }> = {}
+) => ({
+  deltaY,
+  deltaX: o.deltaX ?? 0,
+  deltaMode: o.deltaMode ?? 0,
+  ctrlKey: o.ctrlKey ?? false,
+  metaKey: o.metaKey ?? false,
+  wheelDeltaY: o.wheelDeltaY
+})
+
+describe('MacWheelGestureRouter', () => {
+  it('keeps a notched macOS mouse wheel on the user-configured zoom path', () => {
+    const router = new MacWheelGestureRouter()
+    expect(router.shouldPan(gesture(100, { wheelDeltaY: -120 }), true, 1000)).toBe(false)
+    expect(router.shouldPan(gesture(-100, { wheelDeltaY: 120 }), true, 1100)).toBe(false)
+  })
+
+  it('routes smooth two-finger trackpad scroll and its momentum to panning', () => {
+    const router = new MacWheelGestureRouter()
+    expect(router.shouldPan(gesture(6.25), true, 1000)).toBe(true)
+    expect(router.shouldPan(gesture(75), true, 1080)).toBe(true)
+    expect(router.shouldPan(gesture(75), true, 1700)).toBe(false)
+  })
+
+  it('does not reclassify a quantized packet in an active trackpad gesture as mouse zoom', () => {
+    const router = new MacWheelGestureRouter()
+    expect(router.shouldPan(gesture(4.5), true, 1000)).toBe(true)
+    expect(router.shouldPan(gesture(100, { wheelDeltaY: -120 }), true, 1150)).toBe(true)
+    expect(router.shouldPan(gesture(70), true, 1500)).toBe(true)
+  })
+
+  it('keeps trackpad scrolling native over terminal and other native scroll surfaces', () => {
+    const router = new MacWheelGestureRouter()
+    expect(router.destination(gesture(6.25), true, true, 1000)).toBe('native')
+    expect(router.destination(gesture(6.25), true, false, 1400)).toBe('flow-pan')
+    expect(router.destination(gesture(100, { wheelDeltaY: -120 }), true, true, 1800)).toBe('native')
+  })
+
+  it('does not pan over a non-terminal native scroller, and still knows the gesture is a trackpad', () => {
+    const router = new MacWheelGestureRouter()
+    // A trackpad gesture that begins over Monaco / a markdown pane scrolls THAT surface...
+    expect(router.destination(gesture(6.25), true, true, 1000)).toBe('native')
+    // ...but the packet still classified the device, so continuing the same gesture off the
+    // scroller pans the canvas instead of falling back to the mouse-notch (zoom) path.
+    expect(router.destination(gesture(75), true, false, 1100)).toBe('flow-pan')
+  })
+
+  it('keeps pinch, Cmd-wheel, line-mode wheel and other platforms off the override', () => {
+    const router = new MacWheelGestureRouter()
+    expect(router.shouldPan(gesture(5, { ctrlKey: true }), true, 1000)).toBe(false)
+    expect(router.shouldPan(gesture(5, { metaKey: true }), true, 1000)).toBe(false)
+    expect(router.shouldPan(gesture(3, { deltaMode: 1 }), true, 1000)).toBe(false)
+    expect(router.shouldPan(gesture(5), false, 1000)).toBe(false)
+  })
+})

--- a/src/renderer/canvas/wheel-gesture.test.ts
+++ b/src/renderer/canvas/wheel-gesture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { MacWheelGestureRouter } from './wheel-gesture'
+import { MacWheelGestureRouter, trackpadRoutingEnabled } from './wheel-gesture'
 
 const gesture = (
   deltaY: number,
@@ -57,6 +57,24 @@ describe('MacWheelGestureRouter', () => {
     // ...but the packet still classified the device, so continuing the same gesture off the
     // scroller pans the canvas instead of falling back to the mouse-notch (zoom) path.
     expect(router.destination(gesture(75), true, no, 1100)).toBe('flow-pan')
+  })
+
+  it('hands every gesture back to the zoom path once the escape hatch is engaged', () => {
+    // trackpadPan off: `mac` is false for the router whatever machine this is, so nothing is
+    // ever routed to flow-pan and settings.wheelZoom alone decides — the pre-router behavior.
+    expect(trackpadRoutingEnabled(true, true)).toBe(true)
+    expect(trackpadRoutingEnabled(true, false)).toBe(false)
+    expect(trackpadRoutingEnabled(false, true)).toBe(false)
+
+    const hatch = trackpadRoutingEnabled(true, false)
+    const router = new MacWheelGestureRouter()
+    // A precise-pixel MOUSE (Magic Mouse, MX Master) emits exactly what a trackpad emits, so it
+    // classifies as one — this is the user's only way back to wheel zoom, and it must hold for a
+    // whole gesture, not just its first packet.
+    expect(router.destination(gesture(6.25), hatch, no, 1000)).toBe('native')
+    expect(router.destination(gesture(4.5), hatch, no, 1050)).toBe('native')
+    expect(router.destination(gesture(75), hatch, yes, 1100)).toBe('native')
+    expect(router.shouldPan(gesture(6.25), hatch, 1150)).toBe(false)
   })
 
   it('keeps pinch, Cmd-wheel, line-mode wheel and other platforms off the override', () => {

--- a/src/renderer/canvas/wheel-gesture.ts
+++ b/src/renderer/canvas/wheel-gesture.ts
@@ -1,0 +1,51 @@
+type WheelGesture = Pick<WheelEvent, 'ctrlKey' | 'metaKey' | 'deltaMode' | 'deltaX' | 'deltaY'> & {
+  wheelDeltaY?: number
+}
+
+export type MacWheelDestination = 'flow-pan' | 'native'
+
+const TRACKPAD_SEQUENCE_MS = 500
+const MOUSE_WHEEL_NOTCH = 120
+const LARGE_PIXEL_DELTA = 40
+
+/** Pixel mode alone is not a device identity: Chromium uses it for trackpads and many mice. */
+export class MacWheelGestureRouter {
+  private trackpadUntil = 0
+
+  shouldPan(event: WheelGesture, mac: boolean, now = performance.now()): boolean {
+    if (!mac || event.ctrlKey || event.metaKey || event.deltaMode !== 0) return false
+    // Device identity is sticky for one physical gesture. Chromium can quantize a later
+    // trackpad/momentum event to wheelDeltaY=120; treating that single packet as a mouse notch
+    // hands it to wheelZoom and creates the observed one-frame zoom inside an otherwise pure pan.
+    if (now <= this.trackpadUntil) {
+      this.trackpadUntil = now + TRACKPAD_SEQUENCE_MS
+      return true
+    }
+    const legacyDelta = Math.abs(event.wheelDeltaY ?? 0)
+    const mouseNotch = legacyDelta >= MOUSE_WHEEL_NOTCH && legacyDelta % MOUSE_WHEEL_NOTCH === 0
+    if (mouseNotch) {
+      this.trackpadUntil = 0
+      return false
+    }
+    const smooth =
+      event.deltaX !== 0 ||
+      !Number.isInteger(event.deltaX) ||
+      !Number.isInteger(event.deltaY) ||
+      Math.abs(event.deltaY) < LARGE_PIXEL_DELTA
+    if (smooth) {
+      this.trackpadUntil = now + TRACKPAD_SEQUENCE_MS
+      return true
+    }
+    return false
+  }
+
+  destination(
+    event: WheelGesture,
+    mac: boolean,
+    overNativeScrollable: boolean,
+    now = performance.now()
+  ): MacWheelDestination {
+    if (!this.shouldPan(event, mac, now)) return 'native'
+    return overNativeScrollable ? 'native' : 'flow-pan'
+  }
+}

--- a/src/renderer/canvas/wheel-gesture.ts
+++ b/src/renderer/canvas/wheel-gesture.ts
@@ -39,13 +39,19 @@ export class MacWheelGestureRouter {
     return false
   }
 
+  /**
+   * `overNativeScrollable` is a THUNK, not a boolean: the caller answers it with a DOM ancestor
+   * walk and this runs on every wheel packet (~120 Hz through a trackpad pan), so it must not be
+   * paid for the packets that never reach the question — a non-trackpad wheel is answered by
+   * `shouldPan` alone.
+   */
   destination(
     event: WheelGesture,
     mac: boolean,
-    overNativeScrollable: boolean,
+    overNativeScrollable: () => boolean,
     now = performance.now()
   ): MacWheelDestination {
     if (!this.shouldPan(event, mac, now)) return 'native'
-    return overNativeScrollable ? 'native' : 'flow-pan'
+    return overNativeScrollable() ? 'native' : 'flow-pan'
   }
 }

--- a/src/renderer/canvas/wheel-gesture.ts
+++ b/src/renderer/canvas/wheel-gesture.ts
@@ -4,6 +4,20 @@ type WheelGesture = Pick<WheelEvent, 'ctrlKey' | 'metaKey' | 'deltaMode' | 'delt
 
 export type MacWheelDestination = 'flow-pan' | 'native'
 
+/**
+ * Whether the trackpad override is live at all — the `mac` argument every method below takes.
+ *
+ * Two reasons it must be one named expression rather than an `isMac &&` at each call site: the
+ * router and React Flow's own `panOnScroll` have to agree exactly (disagreeing means a gesture
+ * that neither of them pans), and `trackpadPan` is the user's ESCAPE HATCH. Turning it off
+ * restores the pre-router behavior on macOS — `wheelZoom` alone decides, and a plain wheel zooms.
+ * That is the recourse for a precise-pixel MOUSE (Magic Mouse, MX Master), whose deltas are
+ * indistinguishable from a trackpad's here: it classifies as a trackpad and would otherwise have
+ * no way back to wheel zoom.
+ */
+export const trackpadRoutingEnabled = (mac: boolean, trackpadPan: boolean): boolean =>
+  mac && trackpadPan
+
 const TRACKPAD_SEQUENCE_MS = 500
 const MOUSE_WHEEL_NOTCH = 120
 const LARGE_PIXEL_DELTA = 40

--- a/src/renderer/components/settings/sections/BehaviorSection.tsx
+++ b/src/renderer/components/settings/sections/BehaviorSection.tsx
@@ -25,6 +25,10 @@ const ROWS = {
     keywords: ['sidebar', 'sessions', 'collapse', 'expand', 'project', 'switch']
   },
   wheelZoom: { title: 'Scroll wheel zooms', keywords: ['zoom', 'wheel', 'scroll', 'mouse', 'pan'] },
+  trackpadPan: {
+    title: 'Trackpad scroll pans',
+    keywords: ['trackpad', 'pan', 'scroll', 'zoom', 'magic', 'mouse', 'two-finger', 'macos']
+  },
   dragMode: {
     title: 'Canvas left-drag',
     keywords: ['pan', 'drag', 'select', 'canvas', 'mouse', 'grab', 'figma', 'miro']
@@ -155,6 +159,21 @@ export function BehaviorSection({ isActive }: { isActive: boolean }): React.JSX.
               checked={settings.wheelZoom}
               onChange={(v) => update({ wheelZoom: v })}
               ariaLabel="Scroll wheel zooms"
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.trackpadPan}>
+        <FieldRow
+          label="Trackpad scroll pans"
+          description={hintLabel(
+            'macOS: a two-finger trackpad scroll pans the canvas even with wheel zoom on. Turn off if a precise-pixel mouse (Magic Mouse, MX) pans when you meant to zoom.'
+          )}
+          control={
+            <Switch
+              checked={settings.trackpadPan}
+              onChange={(v) => update({ trackpadPan: v })}
+              ariaLabel="Trackpad scroll pans"
             />
           }
         />

--- a/src/renderer/terminal/file-drop.test.ts
+++ b/src/renderer/terminal/file-drop.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import {
+  canvasImageFiles,
   clipboardImages,
   escapeDroppedPath,
+  localPathsForFiles,
   pasteHasText,
   pastedFiles,
   uploadNameFor
@@ -58,6 +60,30 @@ describe('pastedFiles', () => {
   it('answers empty for a text paste, which is xterm s to handle', () => {
     expect(pastedFiles(clipboard({}))).toEqual([])
     expect(pastedFiles(null)).toEqual([])
+  })
+})
+
+describe('canvasImageFiles', () => {
+  it('keeps MIME images and known image extensions only', () => {
+    const png = new File(['png'], 'shot.png', { type: 'image/png' })
+    const avif = new File(['avif'], 'photo.AVIF')
+    const text = new File(['hello'], 'notes.txt', { type: 'text/plain' })
+    expect(canvasImageFiles([png, avif, text])).toEqual([png, avif])
+  })
+})
+
+describe('localPathsForFiles', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('reuses an Electron file path without shell escaping it', async () => {
+    vi.stubGlobal('window', {
+      nodeTerminal: {
+        getPathForFile: () => '/tmp/My image.png',
+        files: { saveUpload: vi.fn() }
+      }
+    })
+    const file = new File(['png'], 'My image.png', { type: 'image/png' })
+    expect(await localPathsForFiles([file])).toEqual(['/tmp/My image.png'])
   })
 })
 

--- a/src/renderer/terminal/file-drop.test.ts
+++ b/src/renderer/terminal/file-drop.test.ts
@@ -109,15 +109,20 @@ describe('localPathsForFiles', () => {
     expect(saveUpload).not.toHaveBeenCalled()
   })
 
-  it('reuses an Electron file path without shell escaping it', async () => {
+  it('reuses an Electron file path without shell escaping it, and never calls the sink', async () => {
+    const saveCanvasImage = vi.fn()
     vi.stubGlobal('window', {
       nodeTerminal: {
         getPathForFile: () => '/tmp/My image.png',
-        files: { saveUpload: vi.fn() }
+        files: { saveUpload: vi.fn(), saveCanvasImage }
       }
     })
     const file = new File(['png'], 'My image.png', { type: 'image/png' })
-    expect(await localPathsForFiles([file])).toEqual(['/tmp/My image.png'])
+    // A Finder drop already IS a file on this disk, so nothing is copied anywhere.
+    expect(await localPathsForFiles([file], canvasImageSink('project-a'))).toEqual([
+      '/tmp/My image.png'
+    ])
+    expect(saveCanvasImage).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/terminal/file-drop.test.ts
+++ b/src/renderer/terminal/file-drop.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import {
   canvasImageFiles,
+  canvasImageSink,
   clipboardImages,
   escapeDroppedPath,
   localPathsForFiles,
@@ -74,6 +75,39 @@ describe('canvasImageFiles', () => {
 
 describe('localPathsForFiles', () => {
   afterEach(() => vi.unstubAllGlobals())
+
+  it('routes pathless canvas bytes to the project image store, not the uploads staging area', async () => {
+    const saveUpload = vi.fn()
+    const saveCanvasImage = vi.fn().mockResolvedValue('/proj/.nodeterm/images/pasted.png')
+    // The suite runs on the node environment, which has no FileReader; only the base64 handoff
+    // matters here, so the read is the smallest stand-in that produces one.
+    vi.stubGlobal(
+      'FileReader',
+      class {
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        result: string | null = null
+        readAsDataURL(): void {
+          this.result = 'data:image/png;base64,cG5n'
+          this.onload?.()
+        }
+      }
+    )
+    vi.stubGlobal('window', {
+      nodeTerminal: {
+        // A clipboard screenshot: no OS path, so the sink is the only thing that decides where it
+        // lands — and a canvas node outlives the 7-day uploads sweep.
+        getPathForFile: () => null,
+        files: { saveUpload, saveCanvasImage }
+      }
+    })
+    const file = new File(['png'], 'pasted.png', { type: 'image/png' })
+    expect(await localPathsForFiles([file], canvasImageSink('project-a'))).toEqual([
+      '/proj/.nodeterm/images/pasted.png'
+    ])
+    expect(saveCanvasImage).toHaveBeenCalledWith('project-a', 'pasted.png', expect.any(String))
+    expect(saveUpload).not.toHaveBeenCalled()
+  })
 
   it('reuses an Electron file path without shell escaping it', async () => {
     vi.stubGlobal('window', {

--- a/src/renderer/terminal/file-drop.ts
+++ b/src/renderer/terminal/file-drop.ts
@@ -22,6 +22,37 @@ const EXT_BY_TYPE: Record<string, string> = {
   'text/plain': 'txt'
 }
 
+const CANVAS_IMAGE_EXTENSIONS = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'bmp',
+  'ico',
+  'svg',
+  'avif'
+])
+const CANVAS_IMAGE_MIME = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/x-icon',
+  'image/svg+xml',
+  'image/avif'
+])
+
+/** Only image files become canvas preview nodes; other dropped files keep the existing no-op. */
+export function canvasImageFiles(files: File[]): File[] {
+  return files.filter((file) => {
+    if (CANVAS_IMAGE_MIME.has(file.type.toLowerCase())) return true
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? ''
+    return CANVAS_IMAGE_EXTENSIONS.has(ext)
+  })
+}
+
 /** The name to store a file under. Clipboard bytes usually have none, so one is generated from
  *  the MIME type + a timestamp — recognizable in a prompt and unique enough to read back. */
 export function uploadNameFor(file: { name: string; type: string }): string {
@@ -116,6 +147,18 @@ async function localPathFor(file: File): Promise<string | null> {
   return window.nodeTerminal.files.saveUpload(uploadNameFor(file), data).catch(() => null)
 }
 
+async function localFilesWithPaths(files: File[]): Promise<Array<{ file: File; path: string }>> {
+  const local = await Promise.all(files.map((f) => localPathFor(f).catch(() => null)))
+  return files
+    .map((file, i) => ({ file, path: local[i] }))
+    .filter((pair): pair is { file: File; path: string } => !!pair.path)
+}
+
+/** Resolve local/clipboard/browser files to raw local paths for non-terminal consumers. */
+export async function localPathsForFiles(files: File[]): Promise<string[]> {
+  return (await localFilesWithPaths(files)).map((pair) => pair.path)
+}
+
 /**
  * Resolve dropped/pasted files to terminal-pasteable paths. For an SSH-project terminal a local
  * path is useless on the host, so each file is uploaded over the project's ControlMaster and its
@@ -126,10 +169,7 @@ export async function droppedPaths(
   files: File[],
   opts: { sshRemoteTmux: boolean; projectId: string }
 ): Promise<string[]> {
-  const local = await Promise.all(files.map((f) => localPathFor(f).catch(() => null)))
-  const pairs = files
-    .map((f, i) => ({ file: f, path: local[i] }))
-    .filter((p): p is { file: File; path: string } => !!p.path)
+  const pairs = await localFilesWithPaths(files)
   if (!opts.sshRemoteTmux) return pairs.map((p) => escapeDroppedPath(p.path))
   const uploaded = await Promise.all(
     pairs.map((p) =>

--- a/src/renderer/terminal/file-drop.ts
+++ b/src/renderer/terminal/file-drop.ts
@@ -139,24 +139,48 @@ const readAsBase64 = (file: File): Promise<string | null> =>
  * anywhere, and a browser client's file lives on a different machine entirely — so the bytes are
  * written into the managed uploads dir over there and THAT path is what the terminal gets.
  */
-async function localPathFor(file: File): Promise<string | null> {
+/**
+ * Where bytes with no usable path get written. The default is the managed uploads staging area,
+ * which is right for a terminal paste — the path is consumed within seconds. A CANVAS image is
+ * remembered in project.json instead, so it passes a sink that writes somewhere equally durable
+ * (`canvasImageSink`); the choice belongs to the caller because only it knows how long the path
+ * has to stay true.
+ */
+export type UploadSink = (name: string, dataBase64: string) => Promise<string | null>
+
+const uploadsSink: UploadSink = (name, data) => window.nodeTerminal.files.saveUpload(name, data)
+
+/** Store into the project's own `.nodeterm/images/` — see core/canvas-images.ts for the fallbacks
+ *  (SSH project / relay tab / cwd-less canvas all land in a durable app-local folder instead). */
+export const canvasImageSink =
+  (projectId: string): UploadSink =>
+  (name, data) =>
+    window.nodeTerminal.files.saveCanvasImage(projectId, name, data)
+
+async function localPathFor(file: File, sink: UploadSink): Promise<string | null> {
   const direct = window.nodeTerminal.getPathForFile(file)
   if (direct) return direct
   const data = await readAsBase64(file)
   if (!data) return null
-  return window.nodeTerminal.files.saveUpload(uploadNameFor(file), data).catch(() => null)
+  return sink(uploadNameFor(file), data).catch(() => null)
 }
 
-async function localFilesWithPaths(files: File[]): Promise<Array<{ file: File; path: string }>> {
-  const local = await Promise.all(files.map((f) => localPathFor(f).catch(() => null)))
+async function localFilesWithPaths(
+  files: File[],
+  sink: UploadSink
+): Promise<Array<{ file: File; path: string }>> {
+  const local = await Promise.all(files.map((f) => localPathFor(f, sink).catch(() => null)))
   return files
     .map((file, i) => ({ file, path: local[i] }))
     .filter((pair): pair is { file: File; path: string } => !!pair.path)
 }
 
 /** Resolve local/clipboard/browser files to raw local paths for non-terminal consumers. */
-export async function localPathsForFiles(files: File[]): Promise<string[]> {
-  return (await localFilesWithPaths(files)).map((pair) => pair.path)
+export async function localPathsForFiles(
+  files: File[],
+  sink: UploadSink = uploadsSink
+): Promise<string[]> {
+  return (await localFilesWithPaths(files, sink)).map((pair) => pair.path)
 }
 
 /**
@@ -169,7 +193,7 @@ export async function droppedPaths(
   files: File[],
   opts: { sshRemoteTmux: boolean; projectId: string }
 ): Promise<string[]> {
-  const pairs = await localFilesWithPaths(files)
+  const pairs = await localFilesWithPaths(files, uploadsSink)
   if (!opts.sshRemoteTmux) return pairs.map((p) => escapeDroppedPath(p.path))
   const uploaded = await Promise.all(
     pairs.map((p) =>

--- a/src/renderer/terminal/file-drop.ts
+++ b/src/renderer/terminal/file-drop.ts
@@ -175,11 +175,10 @@ async function localFilesWithPaths(
     .filter((pair): pair is { file: File; path: string } => !!pair.path)
 }
 
-/** Resolve local/clipboard/browser files to raw local paths for non-terminal consumers. */
-export async function localPathsForFiles(
-  files: File[],
-  sink: UploadSink = uploadsSink
-): Promise<string[]> {
+/** Resolve local/clipboard/browser files to raw local paths for non-terminal consumers. `sink` is
+ *  required: only the caller knows how long the returned path has to stay true, and defaulting it
+ *  to the 7-day staging area is exactly the wrong answer for the one caller there is. */
+export async function localPathsForFiles(files: File[], sink: UploadSink): Promise<string[]> {
   return (await localFilesWithPaths(files, sink)).map((pair) => pair.path)
 }
 

--- a/src/server/handlers/fs-handlers.test.ts
+++ b/src/server/handlers/fs-handlers.test.ts
@@ -4,13 +4,17 @@ import os from 'os'
 import path from 'path'
 import { ServerPlatform } from '../platform-server'
 import { registerFsHandlers } from '../../core/fs-handlers'
+import { appImagesDir, projectImagesDir } from '../../core/canvas-images'
 import { IPC } from '../../shared/ipc'
 
 let dir: string, platform: ServerPlatform, ui: number
+/** Project ids the injected `localProjectCwd` knows about, per test. */
+let projectCwds: Record<string, string>
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-fs-'))
   platform = new ServerPlatform({ userDataDir: dir, appVersion: '0' })
-  registerFsHandlers(platform)
+  projectCwds = {}
+  registerFsHandlers(platform, { localProjectCwd: (id) => projectCwds[id] })
   ui = platform.attach({ sendText: () => {}, sendBinary: () => {} })
 })
 afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
@@ -44,6 +48,28 @@ describe('server fs handlers', () => {
     expect(await call(IPC.fsMkdir, nested)).toBe(true)
     expect(await call(IPC.fsExists, nested)).toBe(true)
   })
+  // The canvas-image write directory is derived HERE, from this shell's own project registry —
+  // the renderer sends a projectId and never names a path. These pin the injection itself: it is
+  // one line per shell (src/main/index.ts and src/server/index.ts), and dropping either one sends
+  // every image to the app folder with nothing else in the suite noticing.
+  it('saveCanvasImage writes into the project cwd the shell resolved', async () => {
+    const cwd = path.join(dir, 'proj')
+    fs.mkdirSync(cwd)
+    projectCwds['p1'] = cwd
+    const data = Buffer.from('png').toString('base64')
+    expect(await call(IPC.filesSaveCanvasImage, 'p1', 'shot.png', data)).toBe(
+      path.join(projectImagesDir(cwd), 'shot.png')
+    )
+  })
+
+  it('saveCanvasImage falls back to the app folder for a project the shell does not place', async () => {
+    // An SSH project, a relay tab, or a cwd-less canvas: saved, never refused.
+    const data = Buffer.from('png').toString('base64')
+    expect(await call(IPC.filesSaveCanvasImage, 'unknown', 'shot.png', data)).toBe(
+      path.join(appImagesDir(dir), 'shot.png')
+    )
+  })
+
   it('quickOpen lists files under the root', async () => {
     fs.writeFileSync(path.join(dir, 'q.txt'), 'x')
     const files = (await call(IPC.filesQuickOpen, dir)) as string[]

--- a/src/server/handlers/index.test.ts
+++ b/src/server/handlers/index.test.ts
@@ -9,6 +9,7 @@ import { IPC } from '../../shared/ipc'
 import { DEFAULT_SETTINGS, type GitStatus } from '../../shared/types'
 import { initPlatform, resetPlatformForTests } from '../../core/platform'
 import { DownloadTickets } from '../../core/download-tickets'
+import { projectImagesDir } from '../../core/canvas-images'
 
 let repo: string, platform: ServerPlatform, ui: number
 beforeEach(() => {
@@ -61,6 +62,30 @@ describe('registerCoreHandlers (git)', () => {
     // The worktree dialog derives its default path from this: an empty answer would suggest
     // `/worktrees/…` at the filesystem ROOT, which the (often root-run) server would create.
     expect(await call(IPC.appUserDataDir)).toBe(repo)
+  })
+})
+
+describe('registerCoreHandlers (canvas images)', () => {
+  it('forwards localProjectCwd, so an image lands in the project the SHELL resolved', async () => {
+    // The dep is one line per shell (src/server/index.ts and src/main/index.ts) and nothing else
+    // in the suite notices if it goes missing — every image would just quietly stop travelling
+    // with its project. This pins the server's half; the desktop's is the matching line in
+    // src/main/index.ts, which has no unit-testable seam (it is inside app.whenReady's bootstrap).
+    resetPlatformForTests()
+    const p2 = new ServerPlatform({ userDataDir: repo, appVersion: '0' })
+    initPlatform(p2)
+    registerCoreHandlers(p2, {
+      getSettings: () => DEFAULT_SETTINGS,
+      localProjectCwd: (id) => (id === 'p2' ? repo : undefined)
+    })
+    const ui2 = p2.attach({ sendText: () => {}, sendBinary: () => {} })
+    const res = await p2.dispatch(ui2, {
+      t: 'req',
+      id: 1,
+      method: IPC.filesSaveCanvasImage,
+      args: ['p2', 'shot.png', Buffer.from('png').toString('base64')]
+    })
+    expect((res as { result: string }).result).toBe(path.join(projectImagesDir(repo), 'shot.png'))
   })
 })
 

--- a/src/server/handlers/index.ts
+++ b/src/server/handlers/index.ts
@@ -20,7 +20,12 @@ import { IPC } from '../../shared/ipc'
  *  routing on desktop, which the server edition does not have (terminals are local). */
 export function registerCoreHandlers(
   platform: ServerPlatform,
-  deps: { getSettings: () => Settings; downloadTickets?: DownloadTickets }
+  deps: {
+    getSettings: () => Settings
+    downloadTickets?: DownloadTickets
+    /** See fs-handlers' dep of the same name — the canvas-image write directory. */
+    localProjectCwd?: (projectId: string) => string | undefined
+  }
 ): { gitService: GitService } {
   // Explorer downloads: mint a one-shot ticket over this (authenticated) channel; the transfer
   // itself is a plain HTTP GET the browser performs (src/server/download.ts). Statting here keeps
@@ -38,7 +43,8 @@ export function registerCoreHandlers(
           const token = downloadTickets.issue(p, dir)
           return { url: `${DOWNLOAD_PATH}?t=${encodeURIComponent(token)}`, name: downloadName(p, dir) }
         }
-      : undefined
+      : undefined,
+    localProjectCwd: deps.localProjectCwd
   })
 
   const gitService = new GitService()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -223,7 +223,8 @@ export async function startServer(
   const downloadTickets = new DownloadTickets()
   const { gitService } = registerCoreHandlers(platform, {
     getSettings: () => settingsStore.get(),
-    downloadTickets
+    downloadTickets,
+    localProjectCwd: (projectId: string) => workspaceStore.localCwdForProject(projectId)
   })
   const github = registerGitHubIntegration({
     platform,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -218,6 +218,8 @@ export const IPC = {
   filesDownloadTicket: 'files:download-ticket',
   /** Persist pasted/dropped bytes that have no path here, and answer their absolute path. */
   filesSaveUpload: 'files:save-upload',
+  /** Write a canvas image into the project's own `.nodeterm/images/` (see core/canvas-images.ts). */
+  filesSaveCanvasImage: 'files:save-canvas-image',
   settingsLoad: 'settings:load',
   settingsSave: 'settings:save',
   sshList: 'ssh:list',

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -47,6 +47,8 @@ export const IPC = {
   /** Write text to the system clipboard from the MAIN process. Renderer-side `clipboard` access is
    *  deprecated in Electron; the renderer sends this instead (fire-and-forget). */
   clipboardWrite: 'clipboard:write',
+  /** Copy local files as file references (not bytes/text) to the macOS system clipboard. */
+  clipboardWriteFiles: 'clipboard:write-files',
   appNotify: 'app:notify',
   appOpenNotificationSettings: 'app:open-notification-settings',
   appFocusNode: 'app:focus-node',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -672,6 +672,8 @@ export interface DialogApi {
 
 export interface ClipboardApi {
   writeText(text: string): void
+  /** Copy local files so Finder and other file-aware macOS apps can paste them. */
+  writeFiles(paths: string[]): Promise<boolean>
 }
 
 export interface ShellApi {
@@ -861,8 +863,9 @@ export interface Settings {
    * tmux's buffer, and it never reached the browser.
    */
   terminalMiddleClickPaste: boolean
-  /** Plain mouse wheel zooms the canvas (no Cmd/Ctrl needed). Trades away scroll-to-pan,
-   *  so it's opt-in — best for mouse users; trackpads keep two-finger pan when off. */
+  /** Plain mouse wheel zooms the canvas (no Cmd/Ctrl needed). On macOS a two-finger trackpad
+   *  scroll keeps panning independently (see canvas/wheel-gesture.ts), so mouse and trackpad
+   *  coexist; elsewhere this still trades away scroll-to-pan, so it stays opt-in. */
   wheelZoom: boolean
   /** What a left-drag on EMPTY canvas does. 'select' (default) rubber-band selects, like
    *  Figma's move tool — pan stays on middle-drag / two-finger scroll. 'pan' drags the map

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -724,6 +724,15 @@ export interface FilesApi {
    * (too large, unwritable); callers drop that file the way a failed drop does.
    */
   saveUpload(name: string, dataBase64: string): Promise<string | null>
+  /**
+   * Persist raw bytes (base64) as a CANVAS image and resolve its ABSOLUTE path. Unlike
+   * `saveUpload` the file is durable: a canvas image node is persisted in `project.json`, so its
+   * file cannot live in a staging area that is swept after a week. The directory is derived from
+   * `projectId` on the receiving side — the caller never names a path — and is the project's own
+   * git-shared `.nodeterm/images/` when it has a local cwd, else a durable app-local folder.
+   * Resolves null when it could not be written; callers drop that file like a failed drop.
+   */
+  saveCanvasImage(projectId: string, name: string, dataBase64: string): Promise<string | null>
 }
 
 export interface MediaApi {
@@ -867,6 +876,10 @@ export interface Settings {
    *  scroll keeps panning independently (see canvas/wheel-gesture.ts), so mouse and trackpad
    *  coexist; elsewhere this still trades away scroll-to-pan, so it stays opt-in. */
   wheelZoom: boolean
+  /** macOS only: a two-finger trackpad scroll pans the canvas, independently of `wheelZoom`
+   *  (see canvas/wheel-gesture.ts). Off restores the pre-router behavior — `wheelZoom` alone
+   *  decides — which is also the recourse for a precise-pixel MOUSE that reads as a trackpad. */
+  trackpadPan: boolean
   /** What a left-drag on EMPTY canvas does. 'select' (default) rubber-band selects, like
    *  Figma's move tool — pan stays on middle-drag / two-finger scroll. 'pan' drags the map
    *  directly (grab cursor), for mouse users who pan constantly; box-select then moves to
@@ -1055,6 +1068,7 @@ export const DEFAULT_SETTINGS: Settings = {
   doubleClickFocus: true,
   terminalMiddleClickPaste: false,
   wheelZoom: false,
+  trackpadPan: true,
   canvasDragMode: 'select',
   browserMemorySaver: true,
   accent: '#0a84ff',


### PR DESCRIPTION
**Slice 1 of 8** out of #112 (author @proteus-dev), which welds ~8 independent features together. We cut it ourselves from `integration/codex-112` — the PR's content merged onto current main, with the semantic conflicts resolved in main's favour, ~5,600 lines of pure Prettier churn removed, and the PR's unrelated webgl revert dropped. **All the feature work here is @proteus-dev's**; we sliced it, ported the wiring onto main's `Canvas.tsx`, and did the review round below.

These three pieces have **no coupling to the Codex shared-identity work** that makes up the rest of #112 — that is the whole point of this slice.

---

## What each piece does

### 1. Trackpad vs mouse wheel router — `src/renderer/canvas/wheel-gesture.ts`

Chromium reports a macOS two-finger trackpad scroll and an ordinary mouse wheel as the *same* unmodified pixel-wheel event. So `settings.wheelZoom` (the mouse-first "plain wheel zooms" option) took scroll-to-pan away from trackpad users as collateral damage — the setting had to be one or the other.

`MacWheelGestureRouter` separates them by the legacy `wheelDeltaY` notch (`>= 120` and a multiple of 120 = a mouse detent) and the smoothness of the deltas. The classification is **sticky for the length of one physical gesture** (500 ms, refreshed per packet): Chromium can quantize a later trackpad/momentum packet to exactly 120, and reading that single packet as a mouse notch is what produced an observed one-frame zoom in the middle of an otherwise pure pan.

**Escape hatch: `settings.trackpadPan`** (macOS, default on, Settings → Behavior beside "Scroll wheel zooms"). Off disengages the router entirely — `wheelZoom` alone decides again and the pre-router behaviour is restored. This is also the recourse for a **precise-pixel MOUSE** (Magic Mouse, MX Master), which emits byte-for-byte what a trackpad emits here, classifies as one, and would otherwise lose wheel zoom on macOS with no way back. The hatch is one named expression (`trackpadRoutingEnabled`) shared by the router and React Flow's `panOnScroll`, because a gesture the two disagree about is a gesture neither of them pans. Pinned by a test that walks a whole gesture, not just its first packet — the classification is sticky, so a hatch that only held for the first packet would look fixed and then pan anyway.

Native scroll surfaces (`.nowheel` — focused xterm, Monaco, markdown/chat) keep scrolling themselves in every configuration.

### 2. Canvas image paste / drop — `src/renderer/canvas/canvas-image-import.ts`, `src/core/canvas-images.ts`

Drop or paste an image on empty canvas and it opens as an image preview node, reusing the machinery that already exists: `localPathsForFiles` is extracted out of `droppedPaths` (the terminal file-drop resolver), and placement goes through the existing Open-file node path.

**Where the bytes go.** A Finder drop keeps its real OS path and copies nothing, as it always has. Bytes with *no* path (a clipboard screenshot, a browser client's file) used to land in `core/uploads.ts` — a staging area swept after `UPLOAD_TTL_MS` (7 days). That is right for a path pasted into a prompt and consumed in seconds, and wrong for a canvas image node, which is **persisted in `project.json`**: a week later the canvas still remembered a file the sweeper had deleted. They now go to **`<cwd>/.nodeterm/images/`**, beside the `project.json` that names them, so the image is as durable as the node and travels to whoever clones the repo. The new module leaves the uploads staging area entirely, so no sweeper can reach it.

- **Name safety**: `safeUploadName`'s basenaming is kept — a pasted `../../.bashrc` writes `.bashrc` *inside* the images dir (pinned by a test). Collisions go through the existing `candidateName` (`shot.png` → `shot (2).png`) written with an **exclusive-create** flag, so there is no stat-then-write window in which two pastes both win and one silently overwrites the other.
- **Path derivation**: the renderer sends only a `projectId`; the directory is resolved on the **receiving** side from each shell's own workspace index (`localProjectCwd`, injected into `registerFsHandlers` in both shells). Same discipline `registerBoardLogHandlers` already uses — the renderer never names a write path.
- **No local cwd → a durable `<userData>/canvas-images/`**, not a refusal and not a crash. Three cases land here: a **cwd-less/inline canvas** (no project folder exists), an **SSH project** — because `<cwd>` is a path on the *host* while the image node reads **locally** (the canvas opens it without `sshFs`), so writing the bytes to the host would produce a node that cannot read its own file — and a project whose **folder has been deleted** (a gone cwd collapses into this branch rather than letting `mkdir -p` resurrect `<gone>/.nodeterm/images/` as a side effect of a paste). The image is still saved; it just cannot travel. **The degrade is loudest for SSH**: an SSH project's `project.json` *is* mirrored to the host, so the image NODE travels to anyone else opening that project while the file stays on the machine that pasted it — they get a node that cannot render. An inline canvas has no one to share with, so it loses nothing.
- **An unwritable project folder retries app-locally rather than losing the image.** A read-only checkout or mount, a root-owned `.nodeterm`, `.nodeterm` present as a file (ENOTDIR), a full disk: the write falls back to `<userData>/canvas-images/`, and only a failure of *both* is reported to the user. Without this the durability decision would have been a **regression** — before it the write went to userData, where it essentially could not fail. A write that fails *partway* also cleans up after itself: `wx` creates the file and then writes it, so a disk that fills in between would otherwise leave a truncated image holding the name.
- **Relay tabs are REFUSED**, with a message, not silently degraded — see the round-2 review below.
- **Git**: no `.gitignore` is written. Images follow `project.json` — if a repo tracks `.nodeterm/` they travel with the canvas (what the owner asked for); if a repo ignores it, `project.json` isn't travelling either, so images inherit the same fate coherently. That stays the repo's decision, not one nodeterm imposes. (Note this repo's own `.gitignore` has `.nodeterm/` — a per-repo choice about its own canvas, not a default.)

Paste is armed by the last pointer press landing on the pane itself (`isCanvasImageDropTarget` — the real `.react-flow__pane`, not flow-wrap overlays, nodes, controls or the minimap), and a keyboard-opened overlay disarms it; otherwise a Cmd+V aimed at a panel or dialog spawns a node behind it. An async resolve is abandoned if the project changed underneath it (`guardedCanvasImagePlacements`). Non-image files keep their existing no-op.

### 3. Cmd-C of file-backed nodes to the OS pasteboard — `src/renderer/canvas/canvas-file-copy.ts` + `src/main/clipboard-files.ts`

With **no** text selection, Cmd/Ctrl+C now puts the selected `editor` / `video` / `web` nodes' files on the macOS pasteboard as **file references** (`NSFilenamesPboardType`), so Finder and other file-aware apps paste the actual files. Native text selection still wins everywhere it did before (markdown view, Monaco, xterm, inputs), so nothing that used to copy stops copying.

The branch is gated to where it can succeed — **mac only**, **not on the kanban board**, **not in a relay tab** (see the review round below).

Paths cross an IPC trust boundary, so main re-checks them independently of the renderer: absolute-only, capped at `MAX_CLIPBOARD_FILES` (64), de-duplicated, `stat`-ed, and **all-or-nothing** — a partial pasteboard is worse than none, because the user cannot see which files it dropped.

---

## Review round (already applied)

- **[Medium-High] Non-mac and browser users got a persistent error banner on Ctrl+C.** The branch always called `writeFiles`, which is darwin-gated in main and answers `false` from the browser bridge stub, raising a warning banner that stays until dismissed — with copy naming macOS on a Linux box, where the keystroke used to be a silent no-op. Gated on `isMac` rather than having its message softened: it should not run where it cannot succeed.
- **[Medium] A relay tab could put the WRONG file on the pasteboard.** A relay tab is marked at the **project** level (`Project.remote`), never on the node, while `window.nodeTerminal.clipboard` is the **local** preload — so Cmd+C there handed the peer's paths to a local `statSync`. Usually a miss, but when the same repo is checked out on both machines (the normal case for this app) `/home/me/proj/src/x.ts` exists locally too and a **different file** went to the pasteboard silently. `Canvas.tsx`'s `show-image` verb already documents this exact hazard. The fact is now **threaded into** `selectedLocalFilePaths` as `LocalFileCopyScope.projectIsRelay` rather than checked at the call site — which is what makes it testable at all, since it cannot be read off `nodes`.
- **[Low] Missing kanban gate.** The paste handler early-returns on `isKanbanOpen`; the Cmd+C branch did not, so with the board open over the canvas it copied the hidden selection's file refs.
- **Cap test.** `MAX_CLIPBOARD_FILES` is the one branch with off-by-one risk (`>= 64` *after* the dedupe `continue`). Now pinned: 64 copies, 65 refuses outright, and 65 entries naming 64 files still fit.
- **Wheel perf.** Hoisting `closest('.nowheel')` above the `!wheelZoom` bail made a DOM ancestor walk run on every wheel packet (~120 Hz through a trackpad pan) even with the feature off. `destination` now takes the answer as a **thunk**: memoized per packet, and never run for a packet no guard asks about — with `wheelZoom` off, the default, it walks nothing at all.

---

## Three surfaces

| | Desktop (Electron) | Server Edition (browser) | Mobile companion |
|---|---|---|---|
| **Wheel router** | Full behavior; only ever engages on macOS, so Linux/Windows desktop is bit-for-bit unchanged. Escape hatch in Settings → Behavior. | Pure renderer code, ships as-is. Engages for a macOS browser client — the same physical device problem, same hatch. | **N/A** — no canvas. |
| **Image paste/drop** | Full behavior. Pathless bytes → the project's `.nodeterm/images/`; no local cwd → `<userData>/canvas-images/`. | Works, and is the case the durable store matters most for: the browser holds the bytes, the project folder is on the server, so only the server can put the image where the canvas will find it again. Real `ws-bridge` implementation, not a stub. | **N/A** — no canvas. |
| **File copy** | Full behavior, **macOS only** — `writeFilesToClipboard` returns `false` on any other platform, and the renderer no longer runs the branch there at all. | **Documented degrade already in place**: the bridge stub answers `writeFiles: async () => false` ("a browser cannot place host-local file references on the viewer's OS clipboard"), and the `isMac` gate means a non-mac browser client never reaches it. | **N/A** — no canvas nodes to select. |

---

## Defect fixed while slicing

`wheel-gesture.test.ts` shipped a test named `'does not manually pan over non-terminal native scrollers'` whose single assertion (`destination(smooth, mac, overNativeScrollable=false) === 'flow-pan'`) both duplicated the previous test and asserted the **opposite** of its own name — it never passed a native scroller at all.

Rewritten to test what the name promises *and* cover the case nothing else did: a trackpad gesture beginning over a non-terminal native scroller stays `'native'`, **and** the same gesture continuing off the scroller resolves to `'flow-pan'` — i.e. the sticky classification survives a packet that was routed to a scroller.

---

## Round-2 review (already applied)

- **[Medium] An unwritable project folder lost the image silently.** Any non-EEXIST failure returned `null`, the caller filtered it out, and no node appeared with nothing said — while the fallback directory that would have taken the file sat one line away, never even created. A **fragility this PR's own durability decision created**: before it the write went to userData, where it essentially could not fail. Now an `inProject` failure retries in `appImagesDir` and only a failure of both is surfaced. Reproduced in a test with `.nodeterm` present as a FILE (ENOTDIR), and mutation-checked — deleting the retry turns two tests red. Partial-file cleanup added for the ENOSPC-mid-write case, with a test that writes a real partial file first (rejecting without creating anything would leave nothing for the cleanup to remove and the assertion would pass either way).
- **[Medium] Relay tabs created an image node that could never render.** The write is the **local** preload's `saveCanvasImage` even in a relay tab, while `EditorNode` reads through the session api — the **peer's** core. Bytes on this disk, node asking the peer for that path. **Chosen: refuse with a clear message**, not route to the peer. Routing is a real feature rather than an edge fix — it also needs the Finder-drop shortcut bypassed (a local OS path is just as unreadable over there), and **no file write in this app crosses that boundary today** (`droppedPaths`, the terminal drop path, has exactly the same shape). A message beats a broken node, and it reuses the same fact (`Project.remote`), read the same way, that already gates Cmd+C's file copy — so the two canvas file gestures agree about the relay boundary. The rationale in `canvas-images.ts` that justified the app-local fallback with "the image node reads locally" is corrected: true for desktop SSH, **false for relay**; it now names the case it holds for.
- **[Low, CLAUDE.md rule 10] Nothing pinned the `localProjectCwd` wiring.** Drop the injection in either shell and every image silently goes to the app folder with the whole suite green. The server's half is now pinned twice — the core registrar's contract (with and without the dep) and `registerCoreHandlers`' passthrough, in the file that already exercises it against a live platform. The desktop's half is the matching line in `src/main/index.ts`, which has no unit-testable seam inside `app.whenReady`; the test says so rather than pretending otherwise.
- Plus: `mkdir -p` no longer **resurrects a deleted project folder**; `localPathsForFiles`' `sink` is now required (the default was dead and contradicted its own doc comment); the size-refusal test no longer allocates 128 MB to prove a limit whose entire point is not allocating.

---

## Gates

- `npm run typecheck` — clean.
- `npx vitest run src/renderer src/main src/shared` — 5087 passed, 3 failed (all `src/main/node-pty-patch.test.ts`, environmental: the suite ran in a clone with a symlinked `node_modules`, so the native patch check reads the unpatched upstream source).
- `npx vitest run` (full) — **5151 passed, 12 skipped, 3 failed** — the same 3 `node-pty-patch` and nothing else.

Not device-verified on a Mac — the wheel router (and its escape hatch) and the pasteboard write are both macOS-only paths and want a hands-on pass before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
