### PR TITLE
fix(license): stop racing the un-awaited refresh in the entitlement test

### DIFF
--- a/src/core/license.test.ts
+++ b/src/core/license.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import crypto from 'node:crypto'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { promises as fsp } from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
 import { IPC } from '../shared/ipc'
@@ -44,9 +45,17 @@ function jsonResponse(body: unknown): { ok: boolean; status: number; json: () =>
 
 const HOUR = 60 * 60 * 1000
 
-/** Let real I/O (fs writes in save()) and microtasks settle — setTimeout stays unfaked. */
-async function flush(): Promise<void> {
-  for (let i = 0; i < 3; i++) await new Promise((r) => setTimeout(r, 25))
+/**
+ * Await the refresh initLicense() actually started (launch + anything the 6h interval fired),
+ * via the handle license.ts parks it on. This used to be a bounded `flush()` of timed sleeps, and
+ * a loaded CI runner beat it: the assertions saw zero broadcasts, and the continuation then landed
+ * after afterEach's resetPlatformForTests() and threw with nobody awaiting. There is no timing
+ * guess left here — the refresh is awaited, so it is also guaranteed done before teardown.
+ * Resolves against the post-resetModules instance the test itself imported.
+ */
+async function refreshed(): Promise<void> {
+  const { __licenseRefreshesForTests } = await import('./license')
+  await __licenseRefreshesForTests()
 }
 
 describe('license entitlement refresh', () => {
@@ -92,7 +101,7 @@ describe('license entitlement refresh', () => {
     fetchMock.mockResolvedValue(jsonResponse({ active: true, token }))
     const { initLicense } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(sent().length).toBe(1)
@@ -108,13 +117,13 @@ describe('license entitlement refresh', () => {
     )
     const { initLicense } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     // A day passes in-session: the app must have polled again on its own —
     // launch-only refresh means the token silently expires after 7 days.
     await vi.advanceTimersByTimeAsync(24 * HOUR)
-    await flush()
+    await refreshed()
     expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2)
     const last = sent().at(-1)!
     expect(last.active).toBe(true)
@@ -126,13 +135,13 @@ describe('license entitlement refresh', () => {
     )
     const { initLicense } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
     expect(sent().at(-1)!.active).toBe(true)
 
     // From now on the server says: not entitled (canceled subscription).
     fetchMock.mockResolvedValue(jsonResponse({ active: false }))
     await vi.advanceTimersByTimeAsync(24 * HOUR)
-    await flush()
+    await refreshed()
     expect(sent().at(-1)!.active).toBe(false)
   })
 
@@ -143,10 +152,33 @@ describe('license entitlement refresh', () => {
     )
     const { initLicense } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
 
     expect(sent().length).toBeGreaterThan(0)
     expect(sent().at(-1)!.active).toBe(false)
+  })
+
+  it('broadcasts even when the refresh lands long after a bounded flush would have given up', async () => {
+    // Regression for a CI flake that reddened unrelated PRs. initLicense() starts refresh()
+    // UN-AWAITED; the assertions above used to race it with ~75 ms of timed sleeps, and a loaded
+    // runner won: `sent()` was still empty (`expected 0 to be greater than 0`) and the
+    // continuation then landed after afterEach had run resetPlatformForTests(), so broadcast() →
+    // platform() threw with nobody awaiting — an unhandled rejection, which fails the whole file.
+    // Here the response deliberately lands 300 ms in, i.e. past ANY flush budget, so the ordering
+    // the flake needs is forced rather than hoped for. Passing means the assertion is awaiting the
+    // real refresh, not a timeout.
+    fetchMock.mockImplementation(
+      async () =>
+        await new Promise((r) =>
+          setTimeout(() => r(jsonResponse({ active: true, token: mint(7 * 24 * 60 * 60) })), 300)
+        )
+    )
+    const { initLicense } = await import('./license')
+    initLicense()
+    await refreshed()
+
+    expect(sent().length).toBe(1)
+    expect(sent()[0].active).toBe(true)
   })
 
   it('does not revive an expired token when the system clock is rolled back', async () => {
@@ -155,19 +187,66 @@ describe('license entitlement refresh', () => {
     )
     const { initLicense } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
     expect(sent().at(-1)!.active).toBe(true)
 
     // Server unreachable from now on (offline grace path), and the token expires in-session.
     fetchMock.mockRejectedValue(new Error('offline'))
     await vi.advanceTimersByTimeAsync(7 * 24 * HOUR + 12 * HOUR)
-    await flush()
+    await refreshed()
 
     // Attacker rolls the clock back before the expiry: exp is "in the future" again,
     // but the app has already observed a later time — the token must stay dead.
     vi.setSystemTime(Date.now() - 9 * 24 * HOUR)
     const status = (await fake.handlers[IPC.licenseStatus]()) as LicenseStatus
     expect(status.active).toBe(false)
+  })
+
+  it('a slow early write cannot walk the clock anchor backwards past a later one', async () => {
+    // Regression for the SECOND flake in this file (it made the rollback test above fail ~4 runs
+    // in 15 on a loaded box). bumpLastSeen is a read-modify-write of license.json, and the refresh
+    // runs used to be started independently, so a burst of them — which is what advancing days of
+    // fake time produces — could have an OLDER lastSeen write complete LAST and walk the anchor
+    // backwards. That is precisely what the anchor exists to prevent.
+    //
+    // Forced deterministically here: the first two writes of the periodic burst take 200 ms while
+    // every later one is immediate. Runs that overlap therefore ALWAYS finish out of order (an
+    // early, small lastSeen lands last); runs that are queued cannot overlap at all, so the delay
+    // only slows the chain down and the newest value still lands last.
+    let slowWrites = 0
+    const realWrite = fsp.writeFile.bind(fsp)
+    const writeSpy = vi
+      .spyOn(fsp, 'writeFile')
+      .mockImplementation(async (...args: Parameters<typeof fsp.writeFile>) => {
+        if (slowWrites > 0) {
+          slowWrites--
+          await new Promise((r) => setTimeout(r, 200))
+        }
+        return realWrite(...args)
+      })
+    try {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ active: true, token: mint(7 * 24 * 60 * 60) }))
+      const { initLicense } = await import('./license')
+      initLicense()
+      await refreshed()
+
+      fetchMock.mockRejectedValue(new Error('offline'))
+      slowWrites = 2 // …i.e. the first two of the burst below, nothing the launch refresh wrote
+      await vi.advanceTimersByTimeAsync(7 * 24 * HOUR + 12 * HOUR)
+      await refreshed()
+
+      // The anchor must hold the LARGEST time observed, whatever order the writes completed in.
+      const stored = JSON.parse(readFileSync(path.join(h.userData, 'license.json'), 'utf-8')) as {
+        lastSeen?: number
+      }
+      expect(stored.lastSeen).toBe(Math.floor(Date.now() / 1000))
+
+      vi.setSystemTime(Date.now() - 9 * 24 * HOUR)
+      const status = (await fake.handlers[IPC.licenseStatus]()) as LicenseStatus
+      expect(status.active).toBe(false)
+    } finally {
+      writeSpy.mockRestore()
+    }
   })
 })
 
@@ -208,7 +287,7 @@ describe('license seats entitlement', () => {
     storeToken(mint(7 * 24 * 60 * 60, 'test-device', 5))
     const { initLicense, licensedSeats } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
     const status = (await fake.handlers[IPC.licenseStatus]()) as LicenseStatus
     expect(status.active).toBe(true)
     expect(status.seats).toBe(5)
@@ -219,7 +298,7 @@ describe('license seats entitlement', () => {
     storeToken(mint(7 * 24 * 60 * 60))
     const { initLicense, licensedSeats } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
     const status = (await fake.handlers[IPC.licenseStatus]()) as LicenseStatus
     expect(status.active).toBe(true)
     expect(status.seats).toBe(3) // Pro includes 3 seats; existing tokens get them with no re-mint
@@ -230,7 +309,7 @@ describe('license seats entitlement', () => {
     storeToken(mint(7 * 24 * 60 * 60, 'test-device', 2))
     const { initLicense, licensedSeats } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
     const status = (await fake.handlers[IPC.licenseStatus]()) as LicenseStatus
     expect(status.seats).toBe(3) // never fewer than the 3 included with Pro
     expect(licensedSeats()).toBe(3)
@@ -240,7 +319,7 @@ describe('license seats entitlement', () => {
     storeToken(undefined)
     const { initLicense, licensedSeats } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
     const status = (await fake.handlers[IPC.licenseStatus]()) as LicenseStatus
     expect(status.active).toBe(false)
     expect(status.seats).toBe(0)
@@ -251,7 +330,7 @@ describe('license seats entitlement', () => {
     storeToken(mint(-60, 'test-device', 5))
     const { initLicense, licensedSeats } = await import('./license')
     initLicense()
-    await flush()
+    await refreshed()
     const status = (await fake.handlers[IPC.licenseStatus]()) as LicenseStatus
     expect(status.active).toBe(false)
     expect(status.seats).toBe(0)
@@ -264,7 +343,7 @@ describe('license seats entitlement', () => {
     try {
       const { initLicense } = await import('./license')
       initLicense()
-      await flush() // let the launch refresh settle so its rejection isn't left unhandled
+      await refreshed() // the launch refresh (rejecting → offline grace) is awaited, never raced
       await fake.handlers[IPC.licenseUpgrade]() // default → base Pro
       await fake.handlers[IPC.licenseUpgrade]('seats') // add-seats link
       // Each carries this device's id for the device-bound webhook binding.
@@ -284,7 +363,7 @@ describe('license seats entitlement', () => {
     try {
       const { initLicense } = await import('./license')
       initLicense()
-      await flush() // let the launch refresh settle so its rejection isn't left unhandled
+      await refreshed() // the launch refresh (rejecting → offline grace) is awaited, never raced
       await fake.handlers[IPC.licenseUpgrade]('seats')
       // 'seats' opens the dedicated seats Payment Link — NOT the base Pro link — with the deviceId.
       const opened = fake.opened[0]

--- a/src/core/license.ts
+++ b/src/core/license.ts
@@ -171,6 +171,29 @@ export function isPremium(): boolean {
   return verify(load().token) !== null
 }
 
+// Every refresh started so far (the launch one + whatever the 6h interval fired), chained. The
+// refresh is deliberately fire-and-forget — nothing at boot may block on the network — which has
+// two consequences this handle exists to own:
+//   1. a TEST can only observe it by racing a timed flush, and a loaded CI runner wins that race:
+//      the assertion sees zero broadcasts, and the continuation then lands after the test has torn
+//      the platform down, so platform() throws with nobody awaiting. One cause, two red symptoms.
+//      __licenseRefreshesForTests() lets the test await the real thing instead.
+//   2. a throw anywhere in the chain would be an UNHANDLED REJECTION in a process that stays up for
+//      days, so the runner below logs instead of dropping it.
+// It is a QUEUE, not merely "the latest run": see runRefresh below for why overlapping runs are
+// wrong on their own terms, and note that awaiting only the newest would still leave an older run
+// in flight — free to land after the test has torn its platform down.
+let refreshes: Promise<void> = Promise.resolve()
+
+/**
+ * TEST ONLY (house pattern: webgl-budget's `__resetWebglBudgetForTests`) — resolves once every
+ * refresh initLicense() has started so far has settled. Tests await this instead of guessing a
+ * timeout; see the note on `refreshes`.
+ */
+export function __licenseRefreshesForTests(): Promise<void> {
+  return refreshes
+}
+
 export function initLicense(onChange?: () => void): void {
   const deviceId = getDeviceId()
   const broadcast = (s: LicenseStatus) => {
@@ -271,7 +294,25 @@ export function initLicense(onChange?: () => void): void {
     }
   }
 
+  // One refresh run: still fire-and-forget for the caller, but QUEUED behind the previous run,
+  // parked on `refreshes` so tests can await it, and with its errors logged rather than left to
+  // the unhandled-rejection handler.
+  //
+  // Queued, not merely tracked: bumpLastSeen is a read-modify-write of license.json (load() then
+  // save()), so two overlapping runs can interleave and let the OLDER `lastSeen` land last —
+  // which walks the clock-rollback anchor BACKWARDS, the one thing it exists to prevent. In the
+  // real app the runs are 6h apart and never overlap (an 8s fetch abort bounds each one), so this
+  // is a resolved promise plus a microtask; the overlap is reachable only where the clock is
+  // compressed — a test advancing days of fake time — and it made the rollback test flaky.
+  const runRefresh = (): void => {
+    refreshes = refreshes
+      .then(() => bumpLastSeen().then(refresh))
+      .catch((err) =>
+        console.warn('[license] refresh failed', err instanceof Error ? err.message : String(err))
+      )
+  }
+
   // On launch + every 6h while the app stays open (see REFRESH_INTERVAL_MS).
-  void bumpLastSeen().then(refresh)
-  setInterval(() => void bumpLastSeen().then(refresh), REFRESH_INTERVAL_MS).unref()
+  runRefresh()
+  setInterval(runRefresh, REFRESH_INTERVAL_MS).unref()
 }


### PR DESCRIPTION
## The flake

`src/core/license.test.ts > "rejects a token minted for a different device (copied license.json)"`
fails at random in CI as `expected 0 to be greater than 0`, and the same run emits
`Unhandled Rejection: core platform not initialized — call initPlatform() at boot`
(frames in `license.ts` `broadcast`/`refresh`, and `allowed` → `getJson` → `refresh`).
Vitest fails the run on the unhandled errors alone, so this reddens **unrelated PRs**.
Re-running the *identical commit* went green — which is what proves it is non-determinism, not a
real regression. It does not reproduce on an unloaded box (full suite ×4 under 24 CPU hogs, the
file isolated ×12 under load, full suite ×3 unloaded — all clean).

**Mechanism (one cause, two symptoms).** `initLicense()` starts `refresh()` **un-awaited**. The test
asserted `sent().length > 0` after a bounded `await flush()` (3 × 25 ms of sleeps). Under runner
load the refresh continuation misses that window → the assertion sees zero broadcasts (symptom 1);
it then lands after `afterEach` has run `resetPlatformForTests()`, so `broadcast()` → `platform()`
throws with nobody awaiting (symptom 2).

## What changed

**Test side is the real fix — production behaviour is fine as shipped.** Nothing in the app ever
tears the platform down (`resetPlatformForTests` is test-only; the Server Edition never calls
`initLicense`), and the Electron broadcast path is already guarded (`sendToMain` resolves through
`getMainWindow()`, which returns null for a missing/destroyed window; peer sends are individually
try/caught). So the "late continuation into a torn-down platform" is a test artifact, and the fix is
to stop racing the refresh, not to add a guard that would paper over it.

- `src/core/license.ts` — every refresh run is parked on a module-level promise with a test-only
  accessor `__licenseRefreshesForTests()` (the house pattern of `webgl-budget`'s
  `__resetWebglBudgetForTests`). The tests `await` the real work; **no timing guess is left**, which
  also means the refresh is provably finished before teardown.
- `src/core/license.test.ts` — `flush()` is gone; all 15 sites now `await refreshed()`.

Two smaller things came with it, both stated deliberately:

1. **The fire-and-forget chain now logs its errors** (`.catch` → `console.warn`) instead of leaving
   an unhandled rejection in a main process that stays up for days. This is not the flake fix (the
   test no longer produces a late continuation at all) — it is the honest handling of a
   `void p.then(f)` in a long-lived process.
2. **The runs are QUEUED, not merely tracked** — which fixes a *second, pre-existing* flake found
   while proving the first. `bumpLastSeen` is a read-modify-write of `license.json`, and the runs
   used to start independently, so a burst of them (a test advancing days of fake time) could have
   an **older** `lastSeen` write complete **last** and walk the clock-rollback anchor *backwards* —
   exactly what that anchor exists to prevent. It made
   `"does not revive an expired token when the system clock is rolled back"` fail **4 runs in 15 at
   HEAD under load** (measured, see below). In the real app the runs are 6 h apart and can never
   overlap (an 8 s fetch abort bounds each one), so queuing costs one microtask on an
   already-resolved promise.

## Evidence — the ordering is forced, not hoped for

A green run proves nothing about a flake, so each symptom is reproduced deterministically.

**1. The reported flake.** The shipped test, unchanged except that the mocked response lands 300 ms
in (past any `flush()` budget) — i.e. what a loaded runner does to the continuation. Against the
**pre-fix** code, both CI symptoms appear every single time:

```
FAIL  src/core/license.flakerepro.test.ts > rejects a token minted for a different device — SLOW RUNNER
AssertionError: expected 0 to be greater than 0
 ❯ src/core/license.flakerepro.test.ts:86:27

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
Error: core platform not initialized — call initPlatform() at boot
 ❯ platform src/core/platform.ts:44:23
 ❯ file src/core/license.ts:47:20
 ❯ save src/core/license.ts:57:22
 ❯ refresh src/core/license.ts:260:15
```

That scenario ships as a committed regression test
(`"broadcasts even when the refresh lands long after a bounded flush would have given up"`). Run
against the pre-fix production behaviour (un-awaited, nothing to await) it fails the same way —
`expected +0 to be 1` plus the unhandled `core platform not initialized`; with the change it passes.

**2. The write-ordering flake.** Committed as
`"a slow early write cannot walk the clock anchor backwards past a later one"`: the first two writes
of the periodic burst are delayed 200 ms via a `fs.writeFile` spy while later ones are immediate, so
independent runs *always* finish out of order. Against unqueued runs it fails deterministically with
the stale anchor:

```
AssertionError: expected 1786663097 to be 1787267897
```

Queued runs cannot overlap, so the delay only slows the chain and the newest value still lands last.

**3. Load runs** (12-core box, 32 spinning CPU hogs, whole file):

| | pass / runs |
|---|---|
| HEAD, under load | 11 / 15 (4 × clock-rollback) |
| this branch, under load | **25 / 25** |
| this branch, unloaded | **20 / 20** |

## Gates

- `npm run typecheck` — clean.
- `npx vitest run src/core/license.test.ts` — **14 passed** (12 before; +2 regression tests).
- `npx vitest run` — **5116 passed**, 12 skipped, 3 failed: all three are the environmental
  `src/main/node-pty-patch.test.ts` failures expected in a clone with symlinked `node_modules`.
