### PR TITLE
fix(github-issues): describe what actually authenticates, not one flag

### DIFF
--- a/src/renderer/components/settings/sections/GitHubIssuesSection.test.tsx
+++ b/src/renderer/components/settings/sections/GitHubIssuesSection.test.tsx
@@ -2,39 +2,76 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitHubAuthStatus, GitHubControlView } from '@shared/github-issues'
 import { useProjects } from '../../../state/projects'
+import { SettingsSearchContext } from '../context'
 import { GitHubIssuesSection } from './GitHubIssuesSection'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const AUTH: GitHubAuthStatus = {
+  selectedProvider: 'auto', activeProvider: 'token', ghAuthenticated: false,
+  tokenPresent: true, storage: 'encrypted', login: 'octocat'
+}
+
+function viewWith(auth: Partial<GitHubAuthStatus>, approved = false): GitHubControlView {
+  return {
+    control: { revision: 0, authProvider: auth.selectedProvider ?? AUTH.selectedProvider },
+    auth: { ...AUTH, ...auth },
+    project: {
+      projectId: 'p1', repository: 'owner/repo', detectedRepository: 'owner/repo', approved
+    }
+  }
+}
+
+/** What `GitHubHostController.status(projectId)` returns for a project that is not approved: the
+ *  auth block is masked, so it says nothing about whether the user is signed in. */
+function masked(selected: GitHubAuthStatus['selectedProvider'] = 'auto'): GitHubControlView {
+  return {
+    control: { revision: 0, authProvider: selected },
+    auth: {
+      selectedProvider: selected, activeProvider: null, ghAuthenticated: false,
+      tokenPresent: false, storage: 'encrypted'
+    },
+    project: {
+      projectId: 'p1', repository: 'owner/repo', detectedRepository: 'owner/repo', approved: false
+    }
+  }
+}
 
 describe('GitHubIssuesSection', () => {
   let root: Root
   let host: HTMLElement
   let saveToken: ReturnType<typeof vi.fn>
+  let status: ReturnType<typeof vi.fn>
+
+  const mount = async (query = ''): Promise<void> => {
+    root = createRoot(host)
+    await act(async () => {
+      root.render(
+        <SettingsSearchContext.Provider value={query}>
+          <GitHubIssuesSection isActive />
+        </SettingsSearchContext.Provider>
+      )
+    })
+  }
+
+  /** `status(projectId)` answers the project view, `status()` the project-independent auth block. */
+  const stub = (projectView: GitHubControlView, global = projectView): void => {
+    status = vi.fn(async (projectId?: string) => (projectId ? projectView : { ...global, project: undefined }))
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.githubControl.status = status
+  }
+
+  const advanced = (): HTMLDetailsElement =>
+    host.querySelector<HTMLDetailsElement>('details.github-auth-advanced')!
 
   beforeEach(async () => {
     host = document.createElement('div')
     document.body.appendChild(host)
-    saveToken = vi.fn(async () => ({
-      control: { revision: 0, authProvider: 'auto' },
-      auth: {
-        selectedProvider: 'auto', activeProvider: 'token', ghAuthenticated: false,
-        tokenPresent: true, storage: 'encrypted', login: 'octocat'
-      }
-    }))
+    saveToken = vi.fn(async () => viewWith({}))
     ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
       githubControl: {
-        status: vi.fn(async () => ({
-          control: { revision: 0, authProvider: 'auto' },
-          auth: {
-            selectedProvider: 'auto', activeProvider: 'token', ghAuthenticated: false,
-            tokenPresent: true, storage: 'encrypted', login: 'octocat'
-          },
-          project: {
-            projectId: 'p1', repository: 'owner/repo', detectedRepository: 'owner/repo',
-            approved: false
-          }
-        })),
+        status: vi.fn(),
         approve: vi.fn(),
         revoke: vi.fn(),
         selectProvider: vi.fn(),
@@ -45,6 +82,7 @@ describe('GitHubIssuesSection', () => {
         createMissingLabels: vi.fn(), refresh: vi.fn(), clearCache: vi.fn()
       }
     }
+    stub(viewWith({}))
     useProjects.setState({
       activeProjectId: 'p1',
       projects: [{
@@ -66,10 +104,6 @@ describe('GitHubIssuesSection', () => {
         }
       }]
     })
-    root = createRoot(host)
-    await act(async () => {
-      root.render(<GitHubIssuesSection isActive />)
-    })
   })
 
   afterEach(() => {
@@ -78,6 +112,7 @@ describe('GitHubIssuesSection', () => {
   })
 
   it('clears the write-only token field after Save and never renders the stored token', async () => {
+    await mount()
     const input = host.querySelector<HTMLInputElement>('#github-personal-access-token')!
     await act(async () => {
       const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
@@ -92,6 +127,7 @@ describe('GitHubIssuesSection', () => {
   })
 
   it('updates exact label mappings in the shared project board', async () => {
+    await mount()
     const input = host.querySelector<HTMLInputElement>('#github-label-todo')!
     await act(async () => {
       const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
@@ -100,5 +136,80 @@ describe('GitHubIssuesSection', () => {
     })
     expect(useProjects.getState().getProject('p1')?.kanban?.github?.columnMappings)
       .toContainEqual({ columnId: 'todo', label: 'workflow:ready' })
+  })
+
+  it('moves the single token control into Advanced when the GitHub CLI signs the user in', async () => {
+    stub(viewWith({ activeProvider: 'gh', ghAuthenticated: true, tokenPresent: false }, true))
+    await mount()
+    const inputs = host.querySelectorAll('#github-personal-access-token')
+    expect(inputs).toHaveLength(1)
+    expect(advanced().contains(inputs[0])).toBe(true)
+    expect(host.textContent).toContain('✓ Signed in via GitHub CLI as @octocat')
+    expect(host.textContent).not.toContain('gh auth login')
+  })
+
+  it('says a saved token is kept as a fallback instead of pretending none exists', async () => {
+    stub(viewWith({ activeProvider: 'gh', ghAuthenticated: true, tokenPresent: true }, true))
+    await mount()
+    expect(host.textContent).toContain('A saved token is kept as a fallback.')
+  })
+
+  it('reads the unmasked auth block for a project that is not approved yet', async () => {
+    // The project view masks auth to all-false; the signed-in truth only exists in status().
+    stub(masked(), viewWith({ activeProvider: 'gh', ghAuthenticated: true, tokenPresent: false }))
+    await mount()
+    expect(host.textContent).toContain('✓ Signed in via GitHub CLI')
+    expect(host.textContent).not.toContain('GitHub CLI is not signed in')
+    expect(status.mock.calls).toContainEqual([])
+  })
+
+  it('falls back to "not checked yet" rather than "signed out" when the auth read fails', async () => {
+    status = vi.fn(async (projectId?: string) => {
+      if (!projectId) throw new Error('boom')
+      return masked()
+    })
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.githubControl.status = status
+    await mount()
+    expect(host.textContent).toContain('GitHub authentication has not been checked yet.')
+    expect(host.textContent).not.toContain('GitHub CLI is not signed in')
+  })
+
+  it('does not claim the CLI signs the user in when authentication is pinned to a token', async () => {
+    stub(viewWith({
+      selectedProvider: 'token', activeProvider: null, ghAuthenticated: true, tokenPresent: false,
+      login: undefined
+    }, true))
+    await mount()
+    expect(host.textContent).not.toContain('✓ Signed in via GitHub CLI')
+    expect(host.textContent).toContain('pinned to a personal access token')
+    expect(host.textContent).toContain('it is signed in, but ignored')
+  })
+
+  it('does not offer an inert token when authentication is pinned to the GitHub CLI', async () => {
+    stub(viewWith({
+      selectedProvider: 'gh', activeProvider: null, ghAuthenticated: false, tokenPresent: false,
+      login: undefined
+    }, true))
+    await mount()
+    expect(host.textContent).toContain('pinned to the GitHub CLI')
+    expect(host.textContent).not.toContain('paste a personal access token below')
+    expect(advanced().contains(host.querySelector('#github-personal-access-token')!)).toBe(true)
+  })
+
+  it('re-reads the status when the user checks again after signing in', async () => {
+    stub(viewWith({ selectedProvider: 'gh', activeProvider: null, ghAuthenticated: false }, true))
+    await mount()
+    expect(host.textContent).toContain('GitHub CLI is not signed in')
+    stub(viewWith({ selectedProvider: 'gh', activeProvider: 'gh', ghAuthenticated: true }, true))
+    const again = [...host.querySelectorAll('button')].find((button) => button.textContent === 'Check again')!
+    await act(async () => { again.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    expect(host.textContent).toContain('✓ Signed in via GitHub CLI as @octocat')
+  })
+
+  it('opens Advanced while a settings search is active so a matched control is reachable', async () => {
+    stub(viewWith({ activeProvider: 'gh', ghAuthenticated: true, tokenPresent: false }, true))
+    await mount('token')
+    expect(advanced().open).toBe(true)
+    expect(host.querySelector('#github-personal-access-token')).not.toBeNull()
   })
 })

--- a/src/renderer/components/settings/sections/GitHubIssuesSection.tsx
+++ b/src/renderer/components/settings/sections/GitHubIssuesSection.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useState } from 'react'
 import type {
   GitHubAuthProvider,
+  GitHubAuthStatus,
   GitHubControlView,
   ProjectKanbanGitHub
 } from '@shared/github-issues'
 import { useProjects } from '../../../state/projects'
 import { SettingsSection } from '../SettingsSection'
 import { SearchableRow } from '../SearchableRow'
+import { useSettingsSearch } from '../context'
 import { FieldRow } from '../FieldRow'
 import { ConfirmDialog } from '../../ConfirmDialog'
 import { Button } from '@renderer/ui/Button'
@@ -69,24 +71,53 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
   const board = project?.kanban
   const githubConfig = board?.github
   const [view, setView] = useState<GitHubControlView | null>(null)
+  // The auth block this screen DESCRIBES — see authBlockFor: it is not always `view.auth`.
+  const [auth, setAuth] = useState<GitHubAuthStatus | null>(null)
   const [token, setToken] = useState('')
   const [repositoryDraft, setRepositoryDraft] = useState('')
   const [busy, setBusy] = useState('')
   const [notice, setNotice] = useState('')
   const [confirmation, setConfirmation] = useState<Confirmation>(null)
+  const searchQuery = useSettingsSearch()
+
+  /** `GitHubHostController.status(projectId)` MASKS the auth block for a project that is not
+   *  approved on this machine (`ghAuthenticated: false, activeProvider: null, tokenPresent: false`)
+   *  — a deliberate credential boundary, but it means "not approved yet" is indistinguishable from
+   *  "signed out". Approval comes AFTER authentication in the visible flow, so reading the masked
+   *  block put "GitHub CLI is not signed in. Run `gh auth login`" in front of every signed-in user
+   *  during setup. Ask for the project-independent block in exactly that case; when the project IS
+   *  approved the view already carries the real one, so the approved path spawns nothing extra. */
+  const authBlockFor = async (next: GitHubControlView): Promise<GitHubAuthStatus | null> => {
+    if (!next.project || next.project.approved) return next.auth
+    try {
+      return (await window.nodeTerminal.githubControl.status()).auth
+    } catch {
+      // Unknown beats a confident wrong answer: the copy falls back to its neutral branch.
+      return null
+    }
+  }
 
   const refreshStatus = async (): Promise<void> => {
     if (!projectId) return
     const next = await window.nodeTerminal.githubControl.status(projectId)
     setView(next)
+    setAuth(await authBlockFor(next))
   }
 
   useEffect(() => {
     if (!isActive || !projectId || project?.remote) return
     let live = true
-    void window.nodeTerminal.githubControl.status(projectId)
-      .then((next) => { if (live) setView(next) })
-      .catch((error) => { if (live) setNotice(messageFor(error)) })
+    void (async () => {
+      try {
+        const next = await window.nodeTerminal.githubControl.status(projectId)
+        if (!live) return
+        setView(next)
+        const block = await authBlockFor(next)
+        if (live) setAuth(block)
+      } catch (error) {
+        if (live) setNotice(messageFor(error))
+      }
+    })()
     return () => { live = false }
   }, [isActive, projectId, project?.remote])
 
@@ -154,7 +185,19 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
   const completionReady = !!githubConfig?.completionColumnId &&
     mappings.has(githubConfig.completionColumnId)
   const ready = approved && authenticated && completionReady
-  const ghSignedIn = !!view?.auth.ghAuthenticated
+
+  // What actually authenticates a request is `activeProvider` — the RESULT of the selected provider
+  // meeting the credentials that exist. `ghAuthenticated` alone lies in both directions: pinned to
+  // token-only it can be true while nothing authenticates, and pinned to gh-only a saved token is
+  // inert however present it is.
+  const activeProvider = auth?.activeProvider ?? null
+  const selectedProvider = auth?.selectedProvider ?? view?.control.authProvider ?? 'auto'
+  const ghActive = activeProvider === 'gh'
+  /** The token control is noise wherever a token cannot be what signs the user in: the CLI already
+   *  does it, or the user pinned authentication to the CLI. It moves into Advanced, never away. */
+  const tokenIsAside = !auth || ghActive || selectedProvider === 'gh'
+  // A control the user searched for must not be hidden behind a collapsed disclosure.
+  const searching = searchQuery.trim() !== ''
 
   // The personal access token control, defined once and placed either prominently (when the GitHub
   // CLI is NOT signed in — it's the only way in) or tucked inside "Advanced" (when gh already works,
@@ -319,29 +362,74 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
 
           <SearchableRow {...ROWS.authentication}>
             <div className="space-y-3">
-              {ghSignedIn ? (
-                // Happy path: the CLI already authenticates every request — no token, no dropdown.
-                // (Unless the user has explicitly pinned the provider to token-only, below.)
-                <p className="text-[13px] text-text">
-                  ✓ Signed in via GitHub CLI
-                  {view?.auth.activeProvider === 'gh' && view?.auth.login ? ` as @${view.auth.login}` : ''}.
-                  {view?.control.authProvider === 'token' ? '' : ' No token needed.'}
-                </p>
-              ) : (
+              <div className="flex flex-wrap items-center gap-2">
+                {!auth ? (
+                  // Unknown, not signed out — the status read has not landed (or could not run).
+                  <p className="text-[13px] text-muted">
+                    GitHub authentication has not been checked yet.
+                  </p>
+                ) : ghActive ? (
+                  // Happy path: the CLI already authenticates every request — no token, no dropdown.
+                  <p className="text-[13px] text-text">
+                    ✓ Signed in via GitHub CLI{auth.login ? ` as @${auth.login}` : ''}. No token needed.
+                    {auth.tokenPresent ? ' A saved token is kept as a fallback.' : ''}
+                  </p>
+                ) : activeProvider === 'token' ? (
+                  <p className="text-[13px] text-text">
+                    ✓ Signed in with the saved personal access token{auth.login ? ` as @${auth.login}` : ''}.
+                  </p>
+                ) : selectedProvider === 'gh' ? (
+                  <p className="text-[13px] text-muted">
+                    GitHub CLI is not signed in. Run <code>gh auth login</code> in a terminal.
+                  </p>
+                ) : selectedProvider === 'token' ? (
+                  <p className="text-[13px] text-muted">
+                    No valid personal access token is saved. Paste one below.
+                  </p>
+                ) : (
+                  <p className="text-[13px] text-muted">
+                    GitHub CLI is not signed in. Run <code>gh auth login</code> in a terminal, or paste a
+                    personal access token below.
+                  </p>
+                )}
+                {/* The hint above tells the user to run a command in a terminal, so it needs a way
+                    back. The resolver's status read bypasses the credential cache, so this is
+                    accurate the moment `gh auth login` finishes. */}
+                <Button disabled={busy !== ''} onClick={() => void run(
+                  'recheck',
+                  async () => { /* the refresh inside run() is the whole action */ },
+                  'Authentication re-checked.'
+                )}>
+                  Check again
+                </Button>
+              </div>
+
+              {/* A pinned provider decides which credential is even consulted, and the dropdown that
+                  changes it now lives inside Advanced — so the pinning has to be said out loud. */}
+              {selectedProvider !== 'auto' && (
                 <p className="text-[13px] text-muted">
-                  GitHub CLI is not signed in. Run <code>gh auth login</code> in a terminal, or paste a
-                  personal access token below.
+                  {selectedProvider === 'gh'
+                    ? 'Authentication is pinned to the GitHub CLI, so a saved token is never used.'
+                    : 'Authentication is pinned to a personal access token, so the GitHub CLI is never used'}
+                  {selectedProvider === 'token' && auth?.ghAuthenticated
+                    ? ' — it is signed in, but ignored.'
+                    : selectedProvider === 'token' ? '.' : ''}
+                  {' '}Change this under Advanced.
                 </p>
               )}
 
-              {/* Token is the only way in when gh is absent, so surface it; otherwise hide it away. */}
-              {!ghSignedIn && tokenFieldRow}
+              {/* Token is a way in only where it can authenticate; otherwise it is tucked away. */}
+              {!tokenIsAside && tokenFieldRow}
 
-              <details className="github-auth-advanced">
-                <summary>{ghSignedIn ? 'Advanced — use a personal access token instead' : 'Advanced'}</summary>
-                <div className="space-y-4" style={{ marginTop: 12 }}>
+              <details className="github-auth-advanced" open={searching || undefined}>
+                <summary>
+                  {tokenIsAside
+                    ? 'Advanced — authentication provider and personal access token'
+                    : 'Advanced — authentication provider'}
+                </summary>
+                <div className="mt-3 space-y-4">
                   {providerFieldRow}
-                  {ghSignedIn && tokenFieldRow}
+                  {tokenIsAside && tokenFieldRow}
                 </div>
               </details>
             </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8084,6 +8084,14 @@ body,
 .github-auth-advanced > summary:hover {
   color: var(--text-strong);
 }
+/* `list-style: none` above removes the native marker, and with it the browser's own focus ring on
+   some engines — a keyboard user must still be able to see where they are. */
+.github-auth-advanced > summary:focus-visible {
+  color: var(--text-strong);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
 
 .kanban-col__newmenu {
   position: absolute;


### PR DESCRIPTION
Follow-up to the review on #115, which was already merged when the findings landed — so the fixes needed their own PR. The branch is reset to `origin/main` plus one commit.

`ghAuthenticated` lies in two states that both occur during normal setup, and the new layout keyed off it:

- **[High] An unapproved project read as "signed out".** `GitHubHostController.status(projectId)` masks the whole auth block behind the approval boundary, and approval comes *after* authentication in the visible flow — so every signed-in user was told to run `gh auth login` while setting up, with the token field in front of them. The section now asks for the project-independent block in exactly that case (the approved path spawns nothing extra), and a read that could not run is **unknown** ("GitHub authentication has not been checked yet."), never "signed out".
- **[Medium] Copy now derives from `activeProvider` × `selectedProvider`.** The green CLI tick is gated on `activeProvider === "gh"` (pinned to token-only it used to render while nothing authenticated); a pinned provider is stated inline now that the dropdown lives in Advanced; and a token the pinning makes inert is tucked into Advanced instead of being offered as the way in.
- **[Medium] Tests.** Ten render tests, including the two states the flag got wrong, the unapproved-but-signed-in case, the failed-read fallback, and "exactly one `#github-personal-access-token`, reachable inside `<details>`" on the gh-signed-in render.
- **[Low]** "Check again" button (the resolver's status read bypasses the credential cache, so it is accurate the moment `gh auth login` finishes); a saved token is named as the fallback it is instead of hiding under "No token needed."; Advanced opens while a settings search is active.
- **[Nit]** `:focus-visible` ring on the summary to replace the marker `list-style: none` removed; the inline `marginTop` is now `mt-3`.

Gates: `npm run typecheck` clean; `npx vitest run src/renderer/components src/core/github` = 27 files / 203 tests pass; full `npx vitest run` = 5125 pass, 3 fail (the environmental `node-pty-patch` checks, which fail in any clone with symlinked `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)