### PR TITLE
feat(codex): shared per-account identity for codex nodes, with a plain-codex fallback

### DIFF
--- a/docs/codex-shared-identity.md
+++ b/docs/codex-shared-identity.md
@@ -77,6 +77,11 @@ thing it reports is *"there was no capability to present"*, so requiring one wou
 exactly the case it exists for. A report that **does** carry a token must carry the right one, so
 only a tokenless caller is trusted on the node id it names.
 
+A cold app-server is handled on both routes: `codex app-server daemon start` exiting 0 does not
+mean the control socket is accepting connections yet, so `waitForCodexAppServer` (3 × 200 ms)
+precedes the mint, and the bind check retries only when it could not REACH the server — a server
+that answered "I do not have that thread" is never retried, because that is an answer.
+
 If secure storage is unavailable the whole feature stays off — `codexIdentityCaps()` answers
 `shared: false`, every launch line stays the bare `codex`, and nothing is half-armed.
 
@@ -127,6 +132,19 @@ installed + armed launcher **and** the session is local. (An SSH host has no lau
 that is a later slice — so a launcher-named line there would be `command not found`, i.e. the exact
 dead node this exists to prevent.) The default `false` means every call site that has not opted in
 emits today's command.
+
+`shared` is the AND of three things, and the third is the interesting one: the installed `codex`
+must accept **`--remote`**. That is the only precondition with no runtime recovery — the launcher's
+preflight proves `codex app-server daemon start` exits 0 and then **execs**, and a CLI with an
+app-server but no `--remote` dies on a clap usage error where no fallback is left. It is
+feature-detected from the CLI's own `--help` (and `codex resume --help` if the first does not say),
+never version-compared, for the same reason claude's `--session-id` is: an unrecognised flag does
+not degrade, it makes the CLI exit. Unknown — no CLI on the login PATH, a failed or timed-out
+spawn, help text that never mentions the flag — means **false**, i.e. plain codex. A wrong "yes"
+costs the node; a wrong "no" costs only the shared app-server. The probe runs **once per app run,
+inside `refreshCodexIdentityCaps()`, entirely off the launch path**: a per-launch probe would be
+visible latency in the pane every time, to answer a question whose answer cannot change while the
+app runs.
 
 Unlike claude's, this probe cannot compute anything until the shell hands the hook server its
 secret, so the shell **pushes** the answer in and an early caller **waits**. A sync getter would
@@ -245,7 +263,9 @@ PR #112, all still to be sliced.
 
 ## 8. Known gaps
 
-1. **Post-`exec` failures are unrecoverable** (§3, and §9.1-9.3).
+1. **Post-`exec` failures are unrecoverable** (§3). The `--remote` case is closed at caps time;
+   what remains is §9.2 (the composed `resume <id> <prompt> --ask-for-approval never` line) and
+   §9.3 (the persisted session id being the app-server's thread id).
 2. **The launcher requires a hook PORT**, not a unix socket — it POSTs to
    `http://localhost:$NODETERM_HOOK_PORT`. Fine today (the desktop's hook server is a loopback TCP
    listener), but the Server Edition wiring will have to revisit it alongside `NODETERM_HOOK_SOCK`,
@@ -253,7 +273,14 @@ PR #112, all still to be sliced.
 3. **The node token rides tmux `-e` on the local path**, i.e. it is in the tmux session env like
    every other `NODETERM_*` value. Same exposure as the hook bearer already has; noted rather than
    changed, because changing it means changing how all of them are delivered.
-4. **`CODEX_HOME` is resolved twice**: the desktop resolves the app-server socket from the Electron
+4. **Two residual orphan classes**, both inherent rather than bugs, neither covered by the budget
+   ordering in §2. (a) A client that dies for a non-timeout reason — the pane killed, `tmux
+   kill-session`, Ctrl-C mid-mint — still leaves the handler to finish and write its record. That is
+   bounded now: §2's pruning removes it with the node, and the next launch mints a fresh thread
+   anyway. (b) An app-server that aborts mid-conversation can leave the seed and/or the forked
+   thread alive on ITS side, because the closing `thread/delete` may never be sent. Orphan
+   *threads* have no reaper anywhere — not here and not in codex.
+5. **`CODEX_HOME` is resolved twice**: the desktop resolves the app-server socket from the Electron
    process's environment, the pane resolves `--remote unix://` from its own. Identical unless a user
    sets `CODEX_HOME` in a shell rc only, in which case start succeeds and resume misses. Managed
    accounts make this explicit; until then it is a narrow, real mismatch.
@@ -266,11 +293,13 @@ Everything below needs a machine with a logged-in `codex`. Items 1-3 are the ass
 implementation could not verify; a failure in any of them is a **dead node**, not a degrade, so they
 come first. Items 1, 2 and 5 fall out of a single capture run on one fresh node.
 
-1. **`codex --remote unix://` exists on the installed CLI.** The preflight only proves
-   `codex app-server daemon start` exits 0 — it says nothing about the `--remote` flag. Run
-   `codex --help` and confirm `--remote` and its argument form; then open a fresh Codex node and
-   confirm the pane shows a working session rather than a clap usage error. If the flag differs,
-   the launcher's two `exec` lines are what change.
+1. **`codex --remote unix://` works, and the caps probe reads the flag correctly.** The flag's
+   PRESENCE is now answered per machine (`codexCliSupportsRemote`, §3), so a CLI without it gets a
+   plain-codex node instead of a dead one — but nothing has confirmed that the flag we detect is
+   the flag we then use. Run `codex --help` and check `--remote`'s argument form against the two
+   `exec` lines in the launcher; then open a fresh Codex node and confirm the pane shows a working
+   session rather than a clap usage error. Also confirm the negative: on a CLI without `--remote`
+   (or with the probe forced false), the node runs plain codex and says so.
 2. **`codex resume <id> <prompt> --ask-for-approval never` accepts a positional prompt AND a global
    flag after the subcommand.** This is the composed line `createAgentNode` builds, and it is
    CLAUDE.md rule 5's grok-`--` lesson exactly: a `withPermissionMode` unit test passes while the
@@ -297,6 +326,17 @@ come first. Items 1, 2 and 5 fall out of a single capture run on one fresh node.
    `<userDataDir>/codex-thread-nodes/` while other nodes' remain.
 9. **Two nodes, one thread.** Point a second node at a thread the first still owns (a `resume` with
    a copied id) and confirm it falls back to plain codex instead of both clients attaching.
-10. **A cold app-server.** Kill the app-server, then open a Codex node. This is the H1 case: confirm
-    it waits for the mint (which can take seconds) and comes up shared, rather than falling back
-    with `thread-start-failed` while an orphan thread is created behind it.
+10. **A cold app-server, on the START path.** Kill the app-server, then open a fresh Codex node.
+    Confirm it waits for the mint (which can take seconds) and comes up shared, rather than falling
+    back with `thread-start-failed` while an orphan thread is created behind it.
+11. **A cold app-server, on the RESUME/BIND path.** Kill the app-server, then cold-start an
+    EXISTING Codex node (restart the app, or reboot). Bind now makes a mandatory app-server round
+    trip, so a daemon whose socket binds a beat late would turn a legitimate resume into
+    `thread-bind-refused` → plain codex. `waitForCodexAppServer` is meant to absorb that; confirm
+    the node comes up shared and that a genuinely absent server still falls back promptly rather
+    than hanging.
+12. **`CODEX_HOME` set in a shell rc only** (§8.5). Put `export CODEX_HOME=…` in `~/.zshrc` (not in
+    the app's environment) and open a Codex node. The desktop resolves the app-server socket from
+    Electron's environment while the pane resolves `--remote unix://` from its own, so this is where
+    they diverge: confirm what actually happens — shared against the wrong home, or a start that
+    succeeds followed by a resume that misses.

--- a/docs/codex-shared-identity.md
+++ b/docs/codex-shared-identity.md
@@ -1,0 +1,302 @@
+# Codex shared identity
+
+How many Codex canvas nodes share one `codex app-server`, how each node keeps a stable identity
+inside it, and — the part that matters most in practice — what happens when none of that is
+available.
+
+Companion to `docs/grok-agent.md` and `docs/gemini-agent.md`; §9 is the device checklist those
+files' §9 sets the format for. Sliced from external PR #112 by **Corvin**
+(`corvin@streamlain.com`).
+
+---
+
+## 1. What it buys
+
+A Codex terminal node used to spawn a full `codex` process tree — an app-server each. A canvas with
+a dozen Codex nodes paid for a dozen servers against one account. Now every node on a machine talks
+to **one** `codex app-server` and owns one **thread** inside it.
+
+The node ↔ thread mapping is what makes that survivable. It has to outlive the app, because tmux
+sessions do: a running Codex client can outlive the Electron process that started it, and after a
+restart nothing in memory knows whose conversation is whose.
+
+## 2. The pieces
+
+| File | Job |
+| --- | --- |
+| `src/core/codex-identity-proxy.ts` | The thread → node record store (signed), and the generated launcher. |
+| `src/core/codex-thread-identity-sh.ts` | The POSIX-sh prelude prepended to every managed hook script. |
+| `src/core/codex-session-name.ts` | The app-server protocol client: mint a thread, check one exists, read its name. |
+| `src/core/codex-identity-caps.ts` | "Can a node on this machine get a managed identity?" — the construction-time gate. |
+| `src/core/agents/hook-server.ts` | The `/codex-thread/{start,bind,fallback}` routes and the per-node capability. |
+| `src/main/codex-node-auth-secret.ts` | The keychain-backed secret both of the above are keyed on. |
+| `src/renderer/state/codexIdentity.ts` | The renderer's gate + the transient per-node mode the UI shows. |
+
+### The records
+
+One file per thread under `<userDataDir>/codex-thread-nodes/<threadId>`:
+
+```
+nodeId=term-17
+endpoint=/Users/x/Library/Application Support/nodeterm/hook-endpoint.env
+signature=<base64url HMAC-SHA256>
+```
+
+Through `CorePlatform.userDataDir`, **not** `homedir()` — that was the original shape and it is why
+the Server Edition had no story at all. The generated sh gets the same path baked in, POSIX-quoted
+(the real one contains a space on macOS), so the two cannot disagree.
+
+Account scoping is deliberately absent: managed Codex accounts are a later slice, and scoping adds
+a directory level above this without changing anything the format promises.
+
+### Why the records are signed
+
+The hook prelude reads a record and **re-exports both fields into an agent's environment**. An
+attacker who could write one would be choosing a session's node id and hook endpoint. So each
+record carries an HMAC over `(threadId, nodeId, endpoint)`; a record that does not verify is
+ignored, never repaired, and never deleted by the pruner either.
+
+The sh side cannot verify that HMAC — there is no key in an agent's shell — so the prelude
+re-validates the *shape* of both fields (`L1` in the review: the signature is a desktop-side
+guarantee, and the prelude's charset checks are the second layer, not a redundancy).
+
+### The per-node capability — the security fix
+
+The hook server's bearer token proves only *"this request came from some nodeterm-spawned
+session"*. It cannot prove **which**. Every identity route takes a caller-supplied `nodeId`, so with
+the shared bearer alone any agent session could bind **its own** thread to a **sibling** node —
+reparenting that node's status, and (via the prelude) aiming its hook traffic.
+
+Each `/codex-thread/*` route therefore also requires `X-NodeTerm-Node-Token` =
+`HMAC(secret, nodeId)`: restart-stable, scoped to one node, injected only into that node's session
+env by `buildPtyEnv`, and never written to the shared endpoint file every session can read. The
+same secret signs the records.
+
+`/codex-thread/fallback` is the one exemption, and it is as narrow as it can be made: the commonest
+thing it reports is *"there was no capability to present"*, so requiring one would silence it in
+exactly the case it exists for. A report that **does** carry a token must carry the right one, so
+only a tokenless caller is trusted on the node id it names.
+
+If secure storage is unavailable the whole feature stays off — `codexIdentityCaps()` answers
+`shared: false`, every launch line stays the bare `codex`, and nothing is half-armed.
+
+### The routes
+
+| Route | Token | Handler |
+| --- | --- | --- |
+| `POST /codex-thread/start` | required | mint a thread on the app-server, write its record, return the id |
+| `POST /codex-thread/bind` | required | verify the thread exists, then record that this node owns it |
+| `POST /codex-thread/fallback` | tokenless, or matching | mark the node as running plain codex |
+
+`start` mints through a five-step conversation (`initialize`, `thread/start`, an empty
+`turn/start`, `turn/interrupt`, `thread/fork` before that turn, `thread/delete` of the seed).
+`thread/start` alone creates only app-server metadata and does **not** materialize the rollout file
+— a second client's `thread/resume` then fails with "no rollout found", which is precisely what the
+launcher does one line later. The fork-and-delete dance produces a thread with zero user turns and
+a valid rollout without the deprecated rollback API.
+
+That conversation runs against a server that is typically **cold** (the first Codex node after
+boot). Three budgets have to stay ordered, and the ordering is the whole point:
+
+```
+launcher curl (30 s)  >  server handler (CODEX_THREAD_START_TIMEOUT_MS, 20 s)  <  socket guard (CONTROL_CEILING_MS, 130 s)
+```
+
+Get the first comparison backwards and curl quits while the server carries on to create a thread
+and write a record nothing will ever resume — an orphan pair per attempt. Get the second wrong and
+the route inherits the 2 s **slowloris** guard, which is a RECEIVE-phase guard: it destroys the
+socket while the handler is still working, on the most common launch there is. `handleCodexThread`
+hands off to `CONTROL_CEILING_MS` after `readBody`, exactly as `/control/` and `/context-link/` do,
+and `codex-launcher-sh.test.ts` pins it with a start handler that sleeps.
+
+---
+
+## 3. The fallback
+
+**Every failure path ends in `exec codex "$@"`, arguments intact.** Upstream exited 69 "identity
+unavailable", which turns a missing app-server, an older `codex`, a stale tmux session or a
+locked-down data dir into a **dead node**. The repo's own precedent is `gatePermissionMode`: an
+unknown or failed probe degrades to the bare command, never to a blocked launch.
+
+The decision lives in two places at different granularity, and **the script is the authority**.
+
+**1. Construction time** — `codexIdentityCaps()`. `AGENT_CONFIG.codex.launchCmd` stays `'codex'`,
+byte-identical; `agentLaunchProgram(id, base, sharedIdentity = false)` names the launcher only when
+the caller opts in, and `codexSharedIdentity(remote)` says yes only when the probe reports an
+installed + armed launcher **and** the session is local. (An SSH host has no launcher installed —
+that is a later slice — so a launcher-named line there would be `command not found`, i.e. the exact
+dead node this exists to prevent.) The default `false` means every call site that has not opted in
+emits today's command.
+
+Unlike claude's, this probe cannot compute anything until the shell hands the hook server its
+secret, so the shell **pushes** the answer in and an early caller **waits**. A sync getter would
+answer "no" to anything that asked first, and a "no" pins the feature off for the whole run with no
+chip, no toast and no log line — one boot-chain reordering away, invisibly.
+
+**2. Runtime** — the launcher. Only the script can see the pane's env, whether the endpoint file is
+readable, whether the broker answers, or whether the installed `codex` even has an app-server. It
+preflights all of that and, on any miss, execs plain codex.
+
+### Where it surfaces
+
+Not silent, and **never in the pane** — text pushed into an agent's terminal is prompt injection,
+which this repo forbids.
+
+- the launcher POSTs `/codex-thread/fallback` with a machine-readable reason before exec'ing;
+- the node header shows a muted **`plain codex`** chip whose tooltip says why;
+- the **first** fallback per node also raises the warning banner, because a chip on a node you are
+  not looking at teaches nothing.
+
+The mode is **transient**, never persisted: it describes one launch of one process, and a stale
+"plain" badge on a reloaded node would be a lie.
+
+### The reasons
+
+| Reason | Means |
+| --- | --- |
+| `node-id-unavailable` | not a nodeterm-spawned session (the launcher was run by hand) |
+| `hook-endpoint-unavailable` | the endpoint file is missing or unreadable |
+| `broker-unreachable` | the hook server's coordinates are unusable |
+| `node-token-unavailable` | no per-node capability — usually no secure storage |
+| `thread-id-unavailable` | the session id to resume is not shaped like one |
+| `app-server-unavailable` | `codex app-server daemon start` failed — an older CLI |
+| `thread-bind-refused` | the thread is unknown to the server, or a live node already owns it |
+| `thread-start-failed` | the server would not mint a thread |
+
+### What the fallback does NOT cover
+
+**Everything after `exec` is unrecoverable.** Once the launcher runs
+`codex --remote unix:// resume "$thread" "$@"`, a clap usage error or a "no rollout found" is a dead
+node — the outcome this whole design exists to prevent, arrived at by a different door.
+
+One class of that is closed defensively: **bind verifies the thread exists** on the app-server
+before writing a record. The id reaching us is whatever the node persisted, and it can be stale or
+left over from a session that ran under plain codex; binding it anyway wrote a record and then
+exec'd a resume that died where nothing could catch it. Refusing here *is* the fallback. A server we
+cannot reach answers "does not exist", which is the safe direction: refusing costs a plain codex
+session, accepting costs the node.
+
+The rest needs a real machine — §9.1-9.3.
+
+### One deliberate non-use
+
+**"Restart agent (resume)" keeps emitting the bare `codex resume <id>`.** It types into a pane that
+already exists, and a tmux session created before the launcher was installed does not carry its
+directory on PATH. A restarted node rejoins as a plain client until its next cold start.
+
+---
+
+## 4. The hook prelude
+
+A shared app-server spawns a Codex **tool**'s shell itself, so that shell inherits `CODEX_THREAD_ID`
+but none of the `NODETERM_*` env we set on the pane — the hook it runs would have no idea which
+canvas node it belongs to, and the node's badge would simply never move. The prelude recovers the
+binding from the thread id.
+
+It is prepended to **every** agent's managed hook script, not just codex's. That is intentional: it
+is inert without `CODEX_THREAD_ID` (which no other agent's tool shell sets), and one builder beats a
+codex-only fork of it. It does change every agent's generated script, which is why
+`managed-script.test.ts` asserts both its presence for all five builtins and that a missing identity
+root yields the legacy script unchanged. **Remote (SSH) hosts get `null`** — the default root is
+this machine's data dir, and baking it into a script on someone else's host leaks the desktop's
+layout for no benefit.
+
+---
+
+## 5. Session names
+
+`TITLE_READ_CAPABLE` gained `codex`; `RENAME_CAPABLE` did not. With the shared server a node owns a
+thread, and that thread carries a `Thread.name` readable over the server's own socket — but there is
+no measured rename command, so the read and write legs split exactly as they did for gemini. One
+list for both would light the rename UI on a node where the write silently does nothing.
+
+`readAgentSessionName` routes codex to its own reader **before** claude's: claude's resolver SCANS
+`~/.claude/projects` on a cache miss, and its cwd fallback can hand back a stranger's session name.
+Both shells' session-name sweeps take core's `supportsTitleRead` default, so codex is enrolled in
+both without either shell being edited (the two drifted once before — see CLAUDE.md rule 10).
+
+---
+
+## 6. Three surfaces
+
+- **Desktop** — full support.
+- **Server Edition** — a deliberate, documented degrade to plain `codex`. The blocker is the
+  *secret*, not the plumbing: the per-node capability is keychain-backed on desktop (Electron
+  `safeStorage`) and there is no equivalent on a headless Linux host, so arming it means a secret at
+  rest in the data dir — a security decision this slice is not entitled to make quietly. Everything
+  it would need already lives in `src/core` and boots from `CorePlatform`; the wiring is three calls
+  plus the two handler registrations, at the marked spot in `src/server/handlers/index.ts`. The
+  renderer bridge already has a **real** `codex` namespace, so that side needs no change.
+- **Mobile companion** (`~/projects/nodeterm-ios`) — N/A. It attaches to tmux sessions over the
+  transport protocol; which app-server a Codex session talks to is invisible to it, and the
+  `plain codex` chip is a canvas-node affordance the phone has no slot for. No protocol change owed.
+- **Kanban** — the mode lives in a store the card modal could read; the chip is on the canvas node
+  header only. Adding it to the card's expanded detail row is a small follow-up.
+
+---
+
+## 7. Not in this slice
+
+The relay daemon, managed Codex accounts (including account-scoped record directories, which the
+flat layout extends into cleanly), SSH hosts, browser control, and the mailbox/loop work — all from
+PR #112, all still to be sliced.
+
+---
+
+## 8. Known gaps
+
+1. **Post-`exec` failures are unrecoverable** (§3, and §9.1-9.3).
+2. **The launcher requires a hook PORT**, not a unix socket — it POSTs to
+   `http://localhost:$NODETERM_HOOK_PORT`. Fine today (the desktop's hook server is a loopback TCP
+   listener), but the Server Edition wiring will have to revisit it alongside `NODETERM_HOOK_SOCK`,
+   which the launcher already reads for curl but not for the URL.
+3. **The node token rides tmux `-e` on the local path**, i.e. it is in the tmux session env like
+   every other `NODETERM_*` value. Same exposure as the hook bearer already has; noted rather than
+   changed, because changing it means changing how all of them are delivered.
+4. **`CODEX_HOME` is resolved twice**: the desktop resolves the app-server socket from the Electron
+   process's environment, the pane resolves `--remote unix://` from its own. Identical unless a user
+   sets `CODEX_HOME` in a shell rc only, in which case start succeeds and resume misses. Managed
+   accounts make this explicit; until then it is a narrow, real mismatch.
+
+---
+
+## 9. Device checklist
+
+Everything below needs a machine with a logged-in `codex`. Items 1-3 are the assumptions the
+implementation could not verify; a failure in any of them is a **dead node**, not a degrade, so they
+come first. Items 1, 2 and 5 fall out of a single capture run on one fresh node.
+
+1. **`codex --remote unix://` exists on the installed CLI.** The preflight only proves
+   `codex app-server daemon start` exits 0 — it says nothing about the `--remote` flag. Run
+   `codex --help` and confirm `--remote` and its argument form; then open a fresh Codex node and
+   confirm the pane shows a working session rather than a clap usage error. If the flag differs,
+   the launcher's two `exec` lines are what change.
+2. **`codex resume <id> <prompt> --ask-for-approval never` accepts a positional prompt AND a global
+   flag after the subcommand.** This is the composed line `createAgentNode` builds, and it is
+   CLAUDE.md rule 5's grok-`--` lesson exactly: a `withPermissionMode` unit test passes while the
+   composed line is wrong. Create a Codex node with an initial prompt while the permission mode is
+   anything but `manual`, and confirm the prompt reaches the model and the flag is honored (not
+   swallowed into the prompt text, not a usage error).
+3. **The session id nodeterm persists from hooks is the id the app-server accepts as a thread.**
+   Let a Codex node run a turn, note `agentStatus.sessionId`, restart the app, and confirm the cold
+   restore resumes the same conversation rather than falling back. If they are different
+   namespaces, `bind` will refuse every resume and every restored node quietly runs plain codex.
+4. **RAM, the thing this is for.** Open six Codex nodes; confirm `ps` shows ONE `codex app-server`
+   and six thin clients, and compare RSS against six independent `codex` processes.
+5. **The chip and the toast.** Force a fallback (rename `~/.nodeterm`… no — simplest: launch a node
+   with `CODEX_HOME` pointed at a directory with no app-server, or use a CLI without
+   `app-server`), and confirm the node shows `plain codex`, the tooltip names the reason, the
+   banner appears once, and **nothing is written into the pane**.
+6. **The session name.** Let codex name a thread, confirm the node title adopts it within a poll
+   cycle, and confirm a hand-renamed node (`titleAuto` false) is left alone.
+7. **Restart and reboot.** Restart the app with Codex nodes running: the tmux clients survive, the
+   records are still trusted, and hooks from a Codex TOOL shell (which has only `CODEX_THREAD_ID`)
+   still move the right node's badge — that last one is the prelude, and it is only exercised by a
+   tool call, not by a plain turn.
+8. **Deletion prunes.** Delete a Codex node permanently and confirm its records are gone from
+   `<userDataDir>/codex-thread-nodes/` while other nodes' remain.
+9. **Two nodes, one thread.** Point a second node at a thread the first still owns (a `resume` with
+   a copied id) and confirm it falls back to plain codex instead of both clients attaching.
+10. **A cold app-server.** Kill the app-server, then open a Codex node. This is the H1 case: confirm
+    it waits for the mint (which can take seconds) and comes up shared, rather than falling back
+    with `thread-start-failed` while an orphan thread is created behind it.

--- a/src/core/agent-session-name.test.ts
+++ b/src/core/agent-session-name.test.ts
@@ -28,8 +28,18 @@ describe('readAgentSessionName', () => {
     rememberGrokSessionDir('shared-id', path.join(root, 'gs1'))
     expect(await readAgentSessionName('shared-id', undefined, 'claude')).toBeNull()
     expect(await readAgentSessionName('shared-id')).toBeNull()
-    expect(await readAgentSessionName('shared-id', undefined, 'codex')).toBeNull()
     forgetGrokSession('shared-id')
+  })
+
+  it("routes codex to its app-server reader, never to claude's transcript scan", async () => {
+    // codex's name lives in the shared app-server's Thread.name — there is no file to find. With
+    // no server listening the honest answer is null; what matters is that it did not fall through
+    // to claude's resolver, which SCANS ~/.claude/projects on a cache miss (once a minute, per
+    // node, for a guaranteed miss) and can hand back a stranger's session name via its cwd leg.
+    process.env.CODEX_HOME = path.join(root, 'no-such-codex-home')
+    expect(await readAgentSessionName('thread-1', undefined, 'codex')).toBeNull()
+    expect(await readAgentSessionName('thread-1', 'acct-2', 'codex')).toBeNull()
+    delete process.env.CODEX_HOME
   })
 
   it('answers null for an empty session id without asking either reader', async () => {

--- a/src/core/agent-session-name.ts
+++ b/src/core/agent-session-name.ts
@@ -11,11 +11,15 @@
 //   grok   → `summary.json` in the session directory a hook told us about (core/grok-session.ts)
 //   gemini → its own transcript `.jsonl`, at the path the context tail already tracks, read for the
 //            `update_topic` tool call that carries the name (core/gemini-session.ts)
+//   codex  → `Thread.name`, read over the shared app-server's own socket (core/codex-session-name.ts).
+//            There is no file to read: with the shared server the name lives in the server, and the
+//            node's session id IS the thread id.
 // Anything else has no readable session name; the claude reader answers null for it, which is what
 // every pre-grok caller already got.
 import { readSessionName, readSmallTail, TITLE_TAIL_BYTES } from './transcript-reader'
 import { readGrokSessionName } from './grok-session'
 import { pickGeminiTitle } from './gemini-session'
+import { readCodexSessionName } from './codex-session-name'
 
 /**
  * Per-agent associations this router cannot own itself, injected by the shell.
@@ -69,5 +73,8 @@ export function readAgentSessionName(
   if (!sessionId) return Promise.resolve(null)
   if (agentId === 'grok') return readGrokSessionName(sessionId)
   if (agentId === 'gemini') return readGeminiSessionName(sessionId, deps?.geminiPathFor)
+  // Never falls through to claude's reader: that one SCANS ~/.claude/projects on a cache miss, so
+  // an unrouted codex node would pay that scan once a minute for a guaranteed null.
+  if (agentId === 'codex') return readCodexSessionName(sessionId)
   return readSessionName(sessionId, accountId)
 }

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -378,6 +378,18 @@ class HookServer {
   ): Promise<void> {
     const verb = pathname.replace(/^\/codex-thread\//, '')
     const form = parseForm(await readBody(req))
+    // SAME HAND-OFF as /control/ and /context-link/, and for the same reason — this route needs it
+    // MOST. The receive phase is over, so the 2s slowloris guard has done its job; leaving it armed
+    // destroys the socket while the HANDLER is still working. `/codex-thread/start` mints a thread
+    // through a five-step conversation with the app-server (initialize, start, a turn, an
+    // interrupt, a fork, a delete) against a server that is typically COLD — the first codex node
+    // after boot is the common case, not the edge one. At 2s that fails every time, and it fails in
+    // the worst possible way: curl gives up, the launcher falls back to plain codex, and main goes
+    // on to create the thread and write a record for it — an orphan thread plus an orphan record
+    // per attempt. The client budget is deliberately set ABOVE the server's own (see
+    // CODEX_THREAD_START_TIMEOUT_MS / the launcher's --max-time) so the server is always the one
+    // that gives up first and can clean up after itself.
+    req.setTimeout(CONTROL_CEILING_MS, () => req.destroy())
     const nodeId = form.nodeId ?? ''
     if (!/^[A-Za-z0-9._-]+$/.test(nodeId)) {
       res.writeHead(400)
@@ -385,6 +397,19 @@ class HookServer {
       return
     }
     if (verb === 'fallback') {
+      // This is the ONE route that may be called without the per-node capability, because the
+      // commonest thing it reports is "there was no capability to present" — requiring one would
+      // silence it in exactly the case it exists for. That exemption is as narrow as it can be
+      // made: a report that DOES carry a token must have the right one, so only a tokenless caller
+      // is trusted on the nodeId it names. Without this a session holding the shared bearer could
+      // flag a sibling node as fallen back. Cosmetic (the flag is transient and downgrade-only),
+      // but a claim in a comment has to be true.
+      const token = req.headers['x-nodeterm-node-token']
+      if (token !== undefined && !this.codexNodeTokenMatches(nodeId, token)) {
+        res.writeHead(403)
+        res.end()
+        return
+      }
       // A reason is free text from a generated script we wrote; bound it and let the UI show it.
       const reason = (form.reason ?? '').slice(0, 64).replace(/[^A-Za-z0-9._-]/g, '') || 'unknown'
       this.codexIdentityListener?.({ nodeId, mode: 'plain', reason })

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -1,10 +1,11 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http'
-import { randomUUID, timingSafeEqual } from 'crypto'
+import { createHmac, randomUUID, timingSafeEqual } from 'crypto'
 import { writeFileSync, mkdirSync } from 'fs'
 import path from 'path'
 import { platform } from '../platform'
-import { canControlCanvas, type AgentId } from '../../shared/agents/config'
+import { canControlCanvas, hasSharedIdentity, type AgentId } from '../../shared/agents/config'
 import { normalizeFor, type NormalizedAgentEvent } from '../../shared/agents/normalize'
+import type { CodexIdentityEvent } from '../../shared/types'
 
 export const NODETERM_HOOK_PROTOCOL_VERSION = '1'
 const SLOWLORIS_MS = 2000
@@ -125,7 +126,20 @@ class HookServer {
   private contextLinkHandler:
     | ((req: { verb: string; nodeId: string; args: Record<string, string> }) => Promise<string>)
     | null = null
+  /**
+   * The shared-identity spine's handlers (see core/codex-identity-proxy.ts). Both are injected by
+   * the shell, and BOTH routes below additionally require a per-node capability — see
+   * `codexNodeAuthToken`.
+   */
+  private codexThreadStartHandler:
+    | ((req: { nodeId: string; cwd: string; hookEndpoint: string }) => Promise<string>)
+    | null = null
+  private codexThreadBindHandler:
+    | ((req: { nodeId: string; threadId: string; hookEndpoint: string }) => Promise<void>)
+    | null = null
+  private codexIdentityListener: ((e: CodexIdentityEvent) => void) | null = null
   private endpointPath = ''
+  private codexNodeAuthSecret: Buffer | null = null
 
   endpointFilePath(): string {
     if (!this.endpointPath) this.endpointPath = path.join(platform().userDataDir, 'hook-endpoint.env')
@@ -160,6 +174,48 @@ class HookServer {
     this.contextLinkHandler = cb
   }
 
+  setCodexThreadStartHandler(cb: NonNullable<HookServer['codexThreadStartHandler']>): void {
+    this.codexThreadStartHandler = cb
+  }
+
+  setCodexThreadBindHandler(cb: NonNullable<HookServer['codexThreadBindHandler']>): void {
+    this.codexThreadBindHandler = cb
+  }
+
+  /** Where a node's identity mode goes on its way to the UI (both shells forward it). */
+  setCodexIdentityListener(cb: (e: CodexIdentityEvent) => void): void {
+    this.codexIdentityListener = cb
+  }
+
+  /**
+   * Mint the capability a Codex process must present for node-scoped identity operations.
+   *
+   * THIS IS THE SECURITY FIX. The global hook bearer proves only "this request came from some
+   * NodeTerm-spawned session"; it cannot prove WHICH session. Every identity route takes a
+   * caller-supplied `nodeId`, so with the shared bearer alone any agent session could bind ITS
+   * OWN codex thread to a SIBLING node — reparenting another node's status, and (through the hook
+   * prelude, which re-exports the recorded node id and endpoint) aiming that node's hook traffic.
+   * This token is HMAC(secret, nodeId): stable across app restarts, scoped to one node, injected
+   * only into that node's session env, and never written to the shared endpoint file that every
+   * session can read.
+   */
+  codexNodeAuthToken(nodeId: string): string {
+    if (!/^[A-Za-z0-9._-]+$/.test(nodeId)) return ''
+    if (!this.codexNodeAuthSecret)
+      throw new Error('NodeTerm Codex node authentication is unavailable')
+    return createHmac('sha256', this.codexNodeAuthSecret).update(nodeId).digest('base64url')
+  }
+
+  /** The shell injects a keychain-backed, restart-stable secret before any Codex PTY is created. */
+  setCodexNodeAuthSecret(secret: Uint8Array): void {
+    if (secret.byteLength < 32) throw new Error('Invalid NodeTerm Codex node-auth secret')
+    this.codexNodeAuthSecret = Buffer.from(secret)
+  }
+
+  hasCodexNodeAuth(): boolean {
+    return !!this.codexNodeAuthSecret
+  }
+
   async start(): Promise<void> {
     if (this.server) return
     this.token = randomUUID()
@@ -178,6 +234,10 @@ class HookServer {
         }
         req.setTimeout(SLOWLORIS_MS, () => req.destroy())
         const reqUrl = new URL(req.url ?? '/', 'http://127.0.0.1')
+        if (reqUrl.pathname.startsWith('/codex-thread/')) {
+          await this.handleCodexThread(reqUrl.pathname, req, res)
+          return
+        }
         if (reqUrl.pathname.startsWith('/control/')) {
           const verb = decodeURIComponent(reqUrl.pathname.replace(/^\/control\//, ''))
           const { nodeId, args } = parseControlBody(
@@ -289,6 +349,105 @@ class HookServer {
     return a.length === b.length && timingSafeEqual(a, b)
   }
 
+  private codexNodeTokenMatches(nodeId: string, provided: string | string[] | undefined): boolean {
+    if (typeof provided !== 'string') return false
+    let expected = ''
+    try {
+      expected = this.codexNodeAuthToken(nodeId)
+    } catch {
+      return false
+    }
+    if (!expected) return false
+    const a = Buffer.from(provided)
+    const b = Buffer.from(expected)
+    return a.length === b.length && timingSafeEqual(a, b)
+  }
+
+  /**
+   * `/codex-thread/{start,bind,fallback}`.
+   *
+   * start/bind are the identity spine and require the per-node capability on top of the shared
+   * bearer. `fallback` deliberately does NOT: it is the launcher telling us it gave up and is
+   * running plain codex, it grants nothing, and requiring a token there would silence the report
+   * in exactly the case (no token) it exists to surface.
+   */
+  private async handleCodexThread(
+    pathname: string,
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> {
+    const verb = pathname.replace(/^\/codex-thread\//, '')
+    const form = parseForm(await readBody(req))
+    const nodeId = form.nodeId ?? ''
+    if (!/^[A-Za-z0-9._-]+$/.test(nodeId)) {
+      res.writeHead(400)
+      res.end()
+      return
+    }
+    if (verb === 'fallback') {
+      // A reason is free text from a generated script we wrote; bound it and let the UI show it.
+      const reason = (form.reason ?? '').slice(0, 64).replace(/[^A-Za-z0-9._-]/g, '') || 'unknown'
+      this.codexIdentityListener?.({ nodeId, mode: 'plain', reason })
+      res.writeHead(204)
+      res.end()
+      return
+    }
+    if (verb !== 'start' && verb !== 'bind') {
+      res.writeHead(404)
+      res.end()
+      return
+    }
+    if (!this.codexNodeTokenMatches(nodeId, req.headers['x-nodeterm-node-token'])) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
+    if (verb === 'start') {
+      const cwd = form.cwd ?? ''
+      if (!path.isAbsolute(cwd)) {
+        res.writeHead(400)
+        res.end()
+        return
+      }
+      try {
+        if (!this.codexThreadStartHandler) throw new Error('start handler unavailable')
+        const threadId = await this.codexThreadStartHandler({
+          nodeId,
+          cwd,
+          hookEndpoint: this.endpointFilePath()
+        })
+        if (!/^[A-Za-z0-9._-]+$/.test(threadId)) throw new Error('invalid thread id')
+        this.codexIdentityListener?.({ nodeId, mode: 'shared' })
+        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
+        res.end(`${threadId}\n`)
+      } catch {
+        res.writeHead(503)
+        res.end()
+      }
+      return
+    }
+    const threadId = form.threadId ?? ''
+    if (!/^[A-Za-z0-9._-]+$/.test(threadId)) {
+      res.writeHead(400)
+      res.end()
+      return
+    }
+    try {
+      if (!this.codexThreadBindHandler) throw new Error('bind handler unavailable')
+      await this.codexThreadBindHandler({
+        nodeId,
+        threadId,
+        hookEndpoint: this.endpointFilePath()
+      })
+      this.codexIdentityListener?.({ nodeId, mode: 'shared' })
+      res.writeHead(204)
+      res.end()
+    } catch {
+      res.writeHead(409)
+      res.end()
+    }
+  }
+
   // The managed script sources this file at invocation to get the LIVE port/token.
   // tmux sessions outlive the app, so env-baked coords go stale after a restart.
   private writeEndpointFile(): void {
@@ -321,7 +480,12 @@ class HookServer {
       NODETERM_NODE_ID: nodeId,
       NODETERM_AGENT_ID: agentId,
       ...(permWaitSecs > 0 ? { NODETERM_PERM_WAIT_SECS: String(permWaitSecs) } : {}),
-      ...(canControlCanvas(agentId) ? { NODETERM_CANVAS_CONTROL: '1' } : {})
+      ...(canControlCanvas(agentId) ? { NODETERM_CANVAS_CONTROL: '1' } : {}),
+      // The per-node capability for the identity routes. Gated by the CAPABILITY LIST, never by
+      // `agentId === 'codex'`. No secret ⇒ no token ⇒ the launcher falls back to plain codex.
+      ...(hasSharedIdentity(agentId) && this.codexNodeAuthSecret
+        ? { NODETERM_CODEX_NODE_TOKEN: this.codexNodeAuthToken(nodeId) }
+        : {})
     }
   }
 

--- a/src/core/agents/hooks/managed-script.test.ts
+++ b/src/core/agents/hooks/managed-script.test.ts
@@ -92,6 +92,26 @@ describe('buildManagedScript', () => {
     })
   })
 
+  describe('the Codex thread-identity prelude', () => {
+    // It is prepended for EVERY agent, not just codex — the generated scripts all change. That is
+    // intended: the block is inert without CODEX_THREAD_ID, which no other agent's tool shell
+    // sets, and one builder beats a codex-only fork of it. (Its behavior is exercised for real
+    // under /bin/sh in core/codex-thread-identity-sh.test.ts.)
+    it('is present in every agent script when an identity root is known', () => {
+      for (const agent of ['claude', 'codex', 'gemini', 'grok', 'opencode']) {
+        expect(buildManagedScript(agent, '/data/codex-thread-nodes')).toContain(
+          "nt_codex_map='/data/codex-thread-nodes'/\"$CODEX_THREAD_ID\""
+        )
+      }
+    })
+
+    it('is omitted entirely when there is no identity root, leaving the legacy script', () => {
+      const legacy = buildManagedScript('claude', null as unknown as string)
+      expect(legacy).not.toContain('CODEX_THREAD_ID')
+      expect(legacy.split('\n')[1]).toBe('if [ -n "$NODETERM_HOOK_ENDPOINT" ] && [ -r "$NODETERM_HOOK_ENDPOINT" ]; then')
+    })
+  })
+
   describe('endpoint failover (dead-primary retry against a live sibling endpoint)', () => {
     it('lists the three known candidate endpoint files', () => {
       expect(s).toContain('"$HOME/.nodeterm-server/hook-endpoint.env"')

--- a/src/core/agents/hooks/managed-script.ts
+++ b/src/core/agents/hooks/managed-script.ts
@@ -67,7 +67,10 @@ function safeIdentityRoot(): string | null {
   }
 }
 
-export function buildManagedScript(agentId: string, identityRoot = safeIdentityRoot()): string {
+export function buildManagedScript(
+  agentId: string,
+  identityRoot: string | null = safeIdentityRoot()
+): string {
   return [
     '#!/bin/sh',
     ...(identityRoot ? [codexThreadIdentityResolverSh(identityRoot)] : []),

--- a/src/core/agents/hooks/managed-script.ts
+++ b/src/core/agents/hooks/managed-script.ts
@@ -47,9 +47,30 @@
 // NEEDS YOU badge flips to working immediately rather than lingering until the agent's next hook. The
 // whole branch is a NO-OP when the env var is absent (a user's own terminals, older
 // nodeterm, non-claude agents), so behavior is bit-for-bit legacy there.
-export function buildManagedScript(agentId: string): string {
+/**
+ * `identityRoot` is where the Codex thread → node records live (`codexThreadIdentityRoot()`).
+ * It is a PARAMETER because this builder is also called from tests that never boot a platform,
+ * and because the prelude has to bake the path in — the shell it runs in has no idea where the
+ * app's data dir is. Undefined (no platform yet) ⇒ no prelude, i.e. today's script exactly.
+ *
+ * The prelude is prepended for EVERY agent, not just codex. It is inert without `CODEX_THREAD_ID`,
+ * which no other agent's tool shell sets, and one builder beats a codex-only fork of it.
+ */
+import { codexThreadIdentityResolverSh } from '../../codex-thread-identity-sh'
+import { codexThreadIdentityRoot } from '../../codex-identity-proxy'
+
+function safeIdentityRoot(): string | null {
+  try {
+    return codexThreadIdentityRoot()
+  } catch {
+    return null
+  }
+}
+
+export function buildManagedScript(agentId: string, identityRoot = safeIdentityRoot()): string {
   return [
     '#!/bin/sh',
+    ...(identityRoot ? [codexThreadIdentityResolverSh(identityRoot)] : []),
     'if [ -n "$NODETERM_HOOK_ENDPOINT" ] && [ -r "$NODETERM_HOOK_ENDPOINT" ]; then',
     '  . "$NODETERM_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',

--- a/src/core/codex-identity-caps.test.ts
+++ b/src/core/codex-identity-caps.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { randomBytes } from 'node:crypto'
+import {
+  codexIdentityCaps,
+  refreshCodexIdentityCaps,
+  resetCodexIdentityCapsForTests
+} from './codex-identity-caps'
+import {
+  resetCodexThreadIdentityAuthSecret,
+  setCodexThreadIdentityAuthSecret
+} from './codex-identity-proxy'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform } from './platform-fake'
+
+let dir = ''
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-caps-'))
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: dir }))
+  resetCodexIdentityCapsForTests()
+  resetCodexThreadIdentityAuthSecret()
+})
+
+afterEach(() => {
+  resetCodexThreadIdentityAuthSecret()
+  resetCodexIdentityCapsForTests()
+  resetPlatformForTests()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('codexIdentityCaps', () => {
+  it('says yes, and installs the launcher, once the secret is in', () => {
+    setCodexThreadIdentityAuthSecret(randomBytes(32))
+    const caps = refreshCodexIdentityCaps()
+    expect(caps.shared).toBe(true)
+    expect(fs.existsSync(caps.launcherPath as string)).toBe(true)
+  })
+
+  it('says no without the secret, and installs nothing', () => {
+    // Half-armed is the state to avoid: a launcher on PATH with no capability to present would
+    // reach the routes, be refused, and fall back one process later. Better to never name it.
+    const caps = refreshCodexIdentityCaps()
+    expect(caps).toEqual({ shared: false, launcherPath: null })
+    expect(fs.existsSync(path.join(dir, 'codex-bin', 'nodeterm-codex'))).toBe(false)
+  })
+
+  it('makes an early caller WAIT rather than answering no', async () => {
+    // The ordering trap this exists for: a sync getter would answer `false` to anything that asked
+    // before the shell refreshed, and a `false` pins the feature off for the whole run — with no
+    // launcher run there is no chip, no toast and no log line to say it happened.
+    const asked = codexIdentityCaps()
+    let settled = false
+    void asked.then(() => (settled = true))
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    setCodexThreadIdentityAuthSecret(randomBytes(32))
+    refreshCodexIdentityCaps()
+    expect((await asked).shared).toBe(true)
+  })
+
+  it('answers immediately once refreshed', async () => {
+    refreshCodexIdentityCaps()
+    expect(await codexIdentityCaps()).toEqual({ shared: false, launcherPath: null })
+  })
+})

--- a/src/core/codex-identity-caps.test.ts
+++ b/src/core/codex-identity-caps.test.ts
@@ -4,10 +4,14 @@ import os from 'node:os'
 import path from 'node:path'
 import { randomBytes } from 'node:crypto'
 import {
+  codexCliSupportsRemote,
   codexIdentityCaps,
   refreshCodexIdentityCaps,
   resetCodexIdentityCapsForTests
 } from './codex-identity-caps'
+
+/** Stand-in for the `codex --help` probe. Every test says explicitly what the CLI answered. */
+const remote = (yes: boolean) => () => Promise.resolve(yes)
 import {
   resetCodexThreadIdentityAuthSecret,
   setCodexThreadIdentityAuthSecret
@@ -33,9 +37,9 @@ afterEach(() => {
 })
 
 describe('codexIdentityCaps', () => {
-  it('says yes, and installs the launcher, once the secret is in', () => {
+  it('says yes, and installs the launcher, once the secret is in and the CLI has --remote', async () => {
     setCodexThreadIdentityAuthSecret(randomBytes(32))
-    const caps = refreshCodexIdentityCaps()
+    const caps = await refreshCodexIdentityCaps(remote(true))
     expect(caps.shared).toBe(true)
     expect(fs.existsSync(caps.launcherPath as string)).toBe(true)
   })
@@ -43,8 +47,19 @@ describe('codexIdentityCaps', () => {
   it('says no without the secret, and installs nothing', () => {
     // Half-armed is the state to avoid: a launcher on PATH with no capability to present would
     // reach the routes, be refused, and fall back one process later. Better to never name it.
-    const caps = refreshCodexIdentityCaps()
-    expect(caps).toEqual({ shared: false, launcherPath: null })
+    return refreshCodexIdentityCaps(remote(true)).then((caps) => {
+      expect(caps).toEqual({ shared: false, launcherPath: null, remoteFlag: true })
+      expect(fs.existsSync(path.join(dir, 'codex-bin', 'nodeterm-codex'))).toBe(false)
+    })
+  })
+
+  it('says no when the installed codex has no --remote, however armed everything else is', async () => {
+    // The one precondition with no runtime recovery: the launcher execs, and a CLI with an
+    // app-server but no --remote dies on a usage error where nothing can fall back. Answering it
+    // here turns a dead node into a plain-codex node on every machine, not just the tester's.
+    setCodexThreadIdentityAuthSecret(randomBytes(32))
+    const caps = await refreshCodexIdentityCaps(remote(false))
+    expect(caps).toEqual({ shared: false, launcherPath: null, remoteFlag: false })
     expect(fs.existsSync(path.join(dir, 'codex-bin', 'nodeterm-codex'))).toBe(false)
   })
 
@@ -58,12 +73,32 @@ describe('codexIdentityCaps', () => {
     await Promise.resolve()
     expect(settled).toBe(false)
     setCodexThreadIdentityAuthSecret(randomBytes(32))
-    refreshCodexIdentityCaps()
+    await refreshCodexIdentityCaps(remote(true))
     expect((await asked).shared).toBe(true)
   })
 
   it('answers immediately once refreshed', async () => {
-    refreshCodexIdentityCaps()
-    expect(await codexIdentityCaps()).toEqual({ shared: false, launcherPath: null })
+    await refreshCodexIdentityCaps(remote(false))
+    expect(await codexIdentityCaps()).toEqual({
+      shared: false,
+      launcherPath: null,
+      remoteFlag: false
+    })
+  })
+})
+
+describe('codexCliSupportsRemote', () => {
+  it('reads the flag out of help text, and is not fooled by a longer flag or by prose', () => {
+    expect(codexCliSupportsRemote('  --remote <URL>   connect to an app-server')).toBe(true)
+    expect(codexCliSupportsRemote('  --remote=<URL>')).toBe(true)
+    // `--remote-auth-token-env` exists and is NOT the flag we need; nor is a mention of it.
+    expect(codexCliSupportsRemote('  --remote-auth-token-env <VAR>')).toBe(false)
+    expect(codexCliSupportsRemote('use with --remotely-hosted servers')).toBe(false)
+    expect(codexCliSupportsRemote(null, undefined, '')).toBe(false)
+  })
+
+  it('accepts an answer from either help page', () => {
+    // Some CLIs list a global flag only under the subcommand that takes it.
+    expect(codexCliSupportsRemote('no flags here', '  --remote <URL>')).toBe(true)
   })
 })

--- a/src/core/codex-identity-caps.ts
+++ b/src/core/codex-identity-caps.ts
@@ -1,0 +1,45 @@
+/**
+ * "Can a node on THIS machine get a managed Codex identity?" — the construction-time half of the
+ * fallback.
+ *
+ * Shaped exactly like `core/claude-cli.ts`: a memoized probe behind one CorePlatform RPC channel,
+ * registered by BOTH shells, whose unknown answer is the conservative one. The renderer asks it
+ * before it writes a launch line, and a `false` means the line stays the bare `codex` it has
+ * always been — never a launcher path that might not resolve, which would be a dead node.
+ *
+ * Two things have to be true, and neither is knowable from the renderer:
+ *  1. the hook server holds the per-node auth secret (no secret ⇒ no capability token ⇒ the
+ *     launcher would fall back anyway, one process later), and
+ *  2. the generated launcher could actually be written (a read-only or full data dir is a real
+ *     failure mode, and it is the one the renderer cannot see at all).
+ *
+ * SERVER EDITION: `src/server` deliberately registers this and answers `false` — see the comment
+ * at its registration site. That is what makes "Server Edition runs plain codex" a decision rather
+ * than an accident.
+ */
+import { IPC } from '../shared/ipc'
+import { platform } from './platform'
+import { UNKNOWN_CODEX_IDENTITY_CAPS, type CodexIdentityCaps } from '../shared/types'
+import { installCodexLauncher, codexThreadIdentityAvailable } from './codex-identity-proxy'
+
+let cached: CodexIdentityCaps | null = null
+
+/** Recompute now. Called at wiring time and again whenever the launcher is (re)installed. */
+export function refreshCodexIdentityCaps(): CodexIdentityCaps {
+  const launcher = codexThreadIdentityAvailable() ? installCodexLauncher() : null
+  cached = { shared: !!launcher, launcherPath: launcher }
+  return cached
+}
+
+export function codexIdentityCaps(): CodexIdentityCaps {
+  return cached ?? UNKNOWN_CODEX_IDENTITY_CAPS
+}
+
+/** Wire the answer onto the platform's RPC surface (Electron ipcMain / server WS-RPC alike). */
+export function registerCodexIdentityIpc(answer: () => CodexIdentityCaps = codexIdentityCaps): void {
+  platform().handle(IPC.codexIdentityCaps, () => answer())
+}
+
+export function resetCodexIdentityCapsForTests(): void {
+  cached = null
+}

--- a/src/core/codex-identity-caps.ts
+++ b/src/core/codex-identity-caps.ts
@@ -14,20 +14,70 @@
  * `codexIdentityCaps` below for why waiting, rather than answering "no", is the only safe default
  * here.
  *
- * Two things have to be true, and neither is knowable from the renderer:
+ * Three things have to be true, and none is knowable from the renderer:
  *  1. the hook server holds the per-node auth secret (no secret ⇒ no capability token ⇒ the
- *     launcher would fall back anyway, one process later), and
+ *     launcher would fall back anyway, one process later),
  *  2. the generated launcher could actually be written (a read-only or full data dir is a real
- *     failure mode, and it is the one the renderer cannot see at all).
+ *     failure mode, and it is the one the renderer cannot see at all), and
+ *  3. the installed `codex` accepts `--remote` — see `codexCliSupportsRemote`. This is the only
+ *     one that cannot be recovered from at runtime: the launcher's preflight proves that
+ *     `codex app-server daemon start` exits 0, and then EXECS. A CLI with an app-server but no
+ *     `--remote` dies on a clap usage error after that exec, where there is no fallback left. So
+ *     it is answered here, once per app run, entirely off the launch path.
  *
  * SERVER EDITION: `src/server` deliberately registers this and answers `false` — see the comment
  * at its registration site. That is what makes "Server Edition runs plain codex" a decision rather
  * than an accident.
  */
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { IPC } from '../shared/ipc'
 import { platform } from './platform'
-import { UNKNOWN_CODEX_IDENTITY_CAPS, type CodexIdentityCaps } from '../shared/types'
+import { type CodexIdentityCaps } from '../shared/types'
 import { installCodexLauncher, codexThreadIdentityAvailable } from './codex-identity-proxy'
+import { findInLoginPath } from './pty-manager'
+
+const execFileP = promisify(execFile)
+const PROBE_TIMEOUT_MS = 5000
+
+/**
+ * Pure: help text → does this CLI accept `--remote`?
+ *
+ * FEATURE-detected from `--help`, never version-compared, for the same reason claude's
+ * `--session-id` is: the release it appeared in is not documented anywhere this repo can check,
+ * and an unrecognised flag does not degrade — it makes the CLI exit. Anchored on a word boundary
+ * so `--remote-auth-token-env`, or prose mentioning the flag inside another option's description,
+ * cannot answer yes for it.
+ *
+ * Absent help output ⇒ false ⇒ no shared identity ⇒ the bare `codex` command, exactly as before
+ * this feature. That is the same direction every other unknown in this file degrades in: a wrong
+ * "yes" here costs the node, a wrong "no" costs only the shared app-server.
+ */
+export function codexCliSupportsRemote(...helpOutputs: Array<string | null | undefined>): boolean {
+  return helpOutputs.some((h) => /(^|\s)--remote(\s|=|$)/m.test(h ?? ''))
+}
+
+async function probeRemoteFlag(): Promise<boolean> {
+  try {
+    // GUI apps don't inherit the shell PATH — resolve through the login shell like every other
+    // CLI lookup in the app (pty-manager, claude-cli, commit-message).
+    const bin = await findInLoginPath('codex')
+    if (!bin) return false
+    const help = await execFileP(bin, ['--help'], { timeout: PROBE_TIMEOUT_MS })
+      .then((r) => r.stdout)
+      .catch(() => null)
+    if (codexCliSupportsRemote(help)) return true
+    // Some CLIs list a global flag only under the subcommand that takes it. One extra spawn, paid
+    // once per app run and only when the top-level help did not already answer yes.
+    const resumeHelp = await execFileP(bin, ['resume', '--help'], { timeout: PROBE_TIMEOUT_MS })
+      .then((r) => r.stdout)
+      .catch(() => null)
+    return codexCliSupportsRemote(resumeHelp)
+  } catch {
+    // Missing CLI, timeout, non-zero exit — all mean "unknown", which means "no shared identity".
+    return false
+  }
+}
 
 let latest: CodexIdentityCaps | null = null
 let ready: Promise<CodexIdentityCaps> | null = null
@@ -35,11 +85,19 @@ let announce: ((c: CodexIdentityCaps) => void) | null = null
 
 /**
  * Compute the answer and publish it. Called once by the shell, AFTER the node-auth secret has been
- * set (or has definitively failed), because the secret is half of what "shared" means.
+ * set (or has definitively failed), because the secret is a third of what "shared" means.
+ *
+ * Async because of the `--remote` probe, which is a login-shell lookup plus up to two `--help`
+ * spawns. That cost is paid HERE — once, during boot, with nothing waiting on it but the first
+ * Codex launch line — and never on the launch path itself, where it would be visible latency in
+ * the pane every single time, to answer a question whose answer cannot change while the app runs.
  */
-export function refreshCodexIdentityCaps(): CodexIdentityCaps {
-  const launcher = codexThreadIdentityAvailable() ? installCodexLauncher() : null
-  latest = { shared: !!launcher, launcherPath: launcher }
+export async function refreshCodexIdentityCaps(
+  probeRemote: () => Promise<boolean> = probeRemoteFlag
+): Promise<CodexIdentityCaps> {
+  const remoteFlag = await probeRemote()
+  const launcher = remoteFlag && codexThreadIdentityAvailable() ? installCodexLauncher() : null
+  latest = { shared: !!launcher, launcherPath: launcher, remoteFlag }
   if (announce) {
     announce(latest)
     announce = null

--- a/src/core/codex-identity-caps.ts
+++ b/src/core/codex-identity-caps.ts
@@ -2,10 +2,17 @@
  * "Can a node on THIS machine get a managed Codex identity?" — the construction-time half of the
  * fallback.
  *
- * Shaped exactly like `core/claude-cli.ts`: a memoized probe behind one CorePlatform RPC channel,
- * registered by BOTH shells, whose unknown answer is the conservative one. The renderer asks it
- * before it writes a launch line, and a `false` means the line stays the bare `codex` it has
- * always been — never a launcher path that might not resolve, which would be a dead node.
+ * Modelled on `core/claude-cli.ts`: one answer behind one CorePlatform RPC channel, registered by
+ * BOTH shells, whose unknown answer is the conservative one. The renderer asks it before it writes
+ * a launch line, and a `false` means the line stays the bare `codex` it has always been — never a
+ * launcher path that might not resolve, which would be a dead node.
+ *
+ * It differs from claude's in WHERE the work happens: claude's probe is lazy and self-starting
+ * (`claude --version` can run whenever someone first asks), while this one cannot compute anything
+ * until the shell has handed the hook server its node-auth secret. So the shell PUSHES the answer
+ * in (`refreshCodexIdentityCaps`) and a caller that arrives first WAITS for it — see
+ * `codexIdentityCaps` below for why waiting, rather than answering "no", is the only safe default
+ * here.
  *
  * Two things have to be true, and neither is knowable from the renderer:
  *  1. the hook server holds the per-node auth secret (no secret ⇒ no capability token ⇒ the
@@ -22,24 +29,51 @@ import { platform } from './platform'
 import { UNKNOWN_CODEX_IDENTITY_CAPS, type CodexIdentityCaps } from '../shared/types'
 import { installCodexLauncher, codexThreadIdentityAvailable } from './codex-identity-proxy'
 
-let cached: CodexIdentityCaps | null = null
+let latest: CodexIdentityCaps | null = null
+let ready: Promise<CodexIdentityCaps> | null = null
+let announce: ((c: CodexIdentityCaps) => void) | null = null
 
-/** Recompute now. Called at wiring time and again whenever the launcher is (re)installed. */
+/**
+ * Compute the answer and publish it. Called once by the shell, AFTER the node-auth secret has been
+ * set (or has definitively failed), because the secret is half of what "shared" means.
+ */
 export function refreshCodexIdentityCaps(): CodexIdentityCaps {
   const launcher = codexThreadIdentityAvailable() ? installCodexLauncher() : null
-  cached = { shared: !!launcher, launcherPath: launcher }
-  return cached
+  latest = { shared: !!launcher, launcherPath: launcher }
+  if (announce) {
+    announce(latest)
+    announce = null
+  } else if (!ready) {
+    ready = Promise.resolve(latest)
+  }
+  return latest
 }
 
-export function codexIdentityCaps(): CodexIdentityCaps {
-  return cached ?? UNKNOWN_CODEX_IDENTITY_CAPS
+/**
+ * The answer, ASYNC — like `claudeCliCaps()`, and for the same reason.
+ *
+ * An early caller must WAIT rather than be told "no". A sync getter would answer `false` to
+ * anything that asked before `refreshCodexIdentityCaps()` ran, and since a `false` means no
+ * launcher ever runs, it would pin the feature off for the whole session with no chip, no toast
+ * and no log line to say so — one reordering of the boot chain away, invisibly. Waiting makes the
+ * ordering a latency question instead of a correctness one. The renderer races this against its
+ * own bounded timeout, so a shell that never refreshes costs a plain-codex session, not a hang.
+ */
+export function codexIdentityCaps(): Promise<CodexIdentityCaps> {
+  if (latest) return Promise.resolve(latest)
+  if (!ready) ready = new Promise((resolve) => (announce = resolve))
+  return ready
 }
 
 /** Wire the answer onto the platform's RPC surface (Electron ipcMain / server WS-RPC alike). */
-export function registerCodexIdentityIpc(answer: () => CodexIdentityCaps = codexIdentityCaps): void {
+export function registerCodexIdentityIpc(
+  answer: () => CodexIdentityCaps | Promise<CodexIdentityCaps> = codexIdentityCaps
+): void {
   platform().handle(IPC.codexIdentityCaps, () => answer())
 }
 
 export function resetCodexIdentityCapsForTests(): void {
-  cached = null
+  latest = null
+  ready = null
+  announce = null
 }

--- a/src/core/codex-identity-proxy.test.ts
+++ b/src/core/codex-identity-proxy.test.ts
@@ -19,10 +19,20 @@ import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform } from './platform-fake'
 
 let dir = ''
+/**
+ * The record store this file operates on, named EXPLICITLY rather than resolved through
+ * `platform()`. Every function under test takes the root as a parameter, and passing it has two
+ * benefits: each test says which store it is touching, and no file here is created at a path
+ * derived from `fakePlatform`'s hardcoded `/tmp/nodeterm-test` default — a predictable temp path,
+ * which is symlink-attackable on a shared machine and which CodeQL's `js/insecure-temporary-file`
+ * correctly flags. The mkdtemp directory below is the only source of paths in this file.
+ */
+let recordsRoot = ''
 const live = (ids: string[]) => (id: string) => ids.includes(id)
 
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-identity-'))
+  recordsRoot = path.join(dir, 'codex-thread-nodes')
   resetPlatformForTests()
   initPlatform(fakePlatform({ userDataDir: dir }))
   setCodexThreadIdentityAuthSecret(randomBytes(32))
@@ -43,61 +53,61 @@ describe('codex thread identity store', () => {
   })
 
   it('round-trips a record and resolves its owning node', () => {
-    writeCodexThreadIdentity('thread-1', 'node-1', '/data/hook-endpoint.env')
-    expect(resolveCodexThreadNodeIdentity('thread-1')).toBe('node-1')
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/hook-endpoint.env', recordsRoot)
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBe('node-1')
   })
 
   it('ignores a record whose node id was rewritten (the signature no longer matches)', () => {
-    writeCodexThreadIdentity('thread-1', 'node-1', '/data/hook-endpoint.env')
-    const file = path.join(codexThreadIdentityRoot(), 'thread-1')
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/hook-endpoint.env', recordsRoot)
+    const file = path.join(recordsRoot, 'thread-1')
     fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace('node-1', 'node-evil'))
     // Not repaired, not trusted: the prelude re-exports both fields into an agent's environment,
     // so an attacker-writable record is an attacker-chosen hook target.
-    expect(readCodexThreadIdentity('thread-1')).toBeUndefined()
-    expect(resolveCodexThreadNodeIdentity('thread-1')).toBeUndefined()
+    expect(readCodexThreadIdentity('thread-1', recordsRoot)).toBeUndefined()
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBeUndefined()
   })
 
   it('ignores an unsigned record', () => {
-    fs.mkdirSync(codexThreadIdentityRoot(), { recursive: true })
+    fs.mkdirSync(recordsRoot, { recursive: true })
     fs.writeFileSync(
-      path.join(codexThreadIdentityRoot(), 'thread-1'),
+      path.join(recordsRoot, 'thread-1'),
       'nodeId=node-1\nendpoint=/data/hook-endpoint.env\n'
     )
-    expect(resolveCodexThreadNodeIdentity('thread-1')).toBeUndefined()
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBeUndefined()
   })
 
   it('refuses ids and endpoints that are not shaped like ids and endpoints', () => {
-    expect(() => writeCodexThreadIdentity('../escape', 'node-1', '/data/e')).toThrow()
-    expect(() => writeCodexThreadIdentity('thread-1', 'node 1; rm -rf /', '/data/e')).toThrow()
-    expect(() => writeCodexThreadIdentity('thread-1', 'node-1', 'relative/e')).toThrow()
+    expect(() => writeCodexThreadIdentity('../escape', 'node-1', '/data/e', recordsRoot)).toThrow()
+    expect(() => writeCodexThreadIdentity('thread-1', 'node 1; rm -rf /', '/data/e', recordsRoot)).toThrow()
+    expect(() => writeCodexThreadIdentity('thread-1', 'node-1', 'relative/e', recordsRoot)).toThrow()
   })
 
   it('writes nothing at all without the auth secret', () => {
     resetCodexThreadIdentityAuthSecret()
-    expect(() => writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')).toThrow()
-    expect(fs.existsSync(path.join(codexThreadIdentityRoot(), 'thread-1'))).toBe(false)
+    expect(() => writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot)).toThrow()
+    expect(fs.existsSync(path.join(recordsRoot, 'thread-1'))).toBe(false)
   })
 })
 
 describe('binding a thread to a node', () => {
   it('refuses to take a thread away from a node that is still live', () => {
-    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot)
     expect(() =>
-      bindCodexThreadIdentity('thread-1', 'node-2', '/data/e', live(['node-1']))
+      bindCodexThreadIdentity('thread-1', 'node-2', '/data/e', live(['node-1']), recordsRoot)
     ).toThrow()
-    expect(resolveCodexThreadNodeIdentity('thread-1')).toBe('node-1')
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBe('node-1')
   })
 
   it('re-claims a thread whose owner is gone', () => {
-    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
-    bindCodexThreadIdentity('thread-1', 'node-2', '/data/e', live([]))
-    expect(resolveCodexThreadNodeIdentity('thread-1')).toBe('node-2')
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot)
+    bindCodexThreadIdentity('thread-1', 'node-2', '/data/e', live([]), recordsRoot)
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBe('node-2')
   })
 
   it('is idempotent for the node that already owns it (a restart re-binds its own thread)', () => {
-    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
-    bindCodexThreadIdentity('thread-1', 'node-1', '/data/e', live(['node-1']))
-    expect(resolveCodexThreadNodeIdentity('thread-1')).toBe('node-1')
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot)
+    bindCodexThreadIdentity('thread-1', 'node-1', '/data/e', live(['node-1']), recordsRoot)
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBe('node-1')
   })
 })
 
@@ -121,25 +131,25 @@ describe('installCodexLauncher', () => {
 
 describe('forgetting a permanently deleted node', () => {
   it('removes every record naming it, and leaves the others alone', () => {
-    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
-    writeCodexThreadIdentity('thread-2', 'node-1', '/data/e')
-    writeCodexThreadIdentity('thread-3', 'node-2', '/data/e')
-    forgetCodexThreadIdentitiesForNode('node-1')
-    expect(resolveCodexThreadNodeIdentity('thread-1')).toBeUndefined()
-    expect(resolveCodexThreadNodeIdentity('thread-2')).toBeUndefined()
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot)
+    writeCodexThreadIdentity('thread-2', 'node-1', '/data/e', recordsRoot)
+    writeCodexThreadIdentity('thread-3', 'node-2', '/data/e', recordsRoot)
+    forgetCodexThreadIdentitiesForNode('node-1', recordsRoot)
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBeUndefined()
+    expect(resolveCodexThreadNodeIdentity('thread-2', recordsRoot)).toBeUndefined()
     // Without this the directory grows a file per thread forever, AND a dead node's record keeps
     // re-exporting its node id into any tool shell still carrying that thread id.
-    expect(resolveCodexThreadNodeIdentity('thread-3')).toBe('node-2')
+    expect(resolveCodexThreadNodeIdentity('thread-3', recordsRoot)).toBe('node-2')
   })
 
   it('never deletes a record it does not trust, and never throws', () => {
-    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
-    const file = path.join(codexThreadIdentityRoot(), 'thread-1')
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot)
+    const file = path.join(recordsRoot, 'thread-1')
     fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace('node-1', 'node-2'))
-    forgetCodexThreadIdentitiesForNode('node-2')
+    forgetCodexThreadIdentitiesForNode('node-2', recordsRoot)
     expect(fs.existsSync(file)).toBe(true)
     // A node deletion must never fail on this: no directory at all is simply nothing to forget.
-    fs.rmSync(codexThreadIdentityRoot(), { recursive: true, force: true })
-    expect(() => forgetCodexThreadIdentitiesForNode('node-1')).not.toThrow()
+    fs.rmSync(recordsRoot, { recursive: true, force: true })
+    expect(() => forgetCodexThreadIdentitiesForNode('node-1', recordsRoot)).not.toThrow()
   })
 })

--- a/src/core/codex-identity-proxy.test.ts
+++ b/src/core/codex-identity-proxy.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { randomBytes } from 'node:crypto'
+import {
+  bindCodexThreadIdentity,
+  codexLauncherDir,
+  codexThreadIdentityRoot,
+  installCodexLauncher,
+  readCodexThreadIdentity,
+  resetCodexThreadIdentityAuthSecret,
+  resolveCodexThreadNodeIdentity,
+  setCodexThreadIdentityAuthSecret,
+  writeCodexThreadIdentity
+} from './codex-identity-proxy'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform } from './platform-fake'
+
+let dir = ''
+const live = (ids: string[]) => (id: string) => ids.includes(id)
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-identity-'))
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: dir }))
+  setCodexThreadIdentityAuthSecret(randomBytes(32))
+})
+
+afterEach(() => {
+  resetCodexThreadIdentityAuthSecret()
+  resetPlatformForTests()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('codex thread identity store', () => {
+  it('lives under the platform data dir, not $HOME', () => {
+    // The wrong seam is why the Server Edition had no story at all: `homedir()` is not where a
+    // server keeps its state, and nothing behind CorePlatform can be swapped for it.
+    expect(codexThreadIdentityRoot()).toBe(path.join(dir, 'codex-thread-nodes'))
+    expect(codexLauncherDir()).toBe(path.join(dir, 'codex-bin'))
+  })
+
+  it('round-trips a record and resolves its owning node', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/hook-endpoint.env')
+    expect(resolveCodexThreadNodeIdentity('thread-1')).toBe('node-1')
+  })
+
+  it('ignores a record whose node id was rewritten (the signature no longer matches)', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/hook-endpoint.env')
+    const file = path.join(codexThreadIdentityRoot(), 'thread-1')
+    fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace('node-1', 'node-evil'))
+    // Not repaired, not trusted: the prelude re-exports both fields into an agent's environment,
+    // so an attacker-writable record is an attacker-chosen hook target.
+    expect(readCodexThreadIdentity('thread-1')).toBeUndefined()
+    expect(resolveCodexThreadNodeIdentity('thread-1')).toBeUndefined()
+  })
+
+  it('ignores an unsigned record', () => {
+    fs.mkdirSync(codexThreadIdentityRoot(), { recursive: true })
+    fs.writeFileSync(
+      path.join(codexThreadIdentityRoot(), 'thread-1'),
+      'nodeId=node-1\nendpoint=/data/hook-endpoint.env\n'
+    )
+    expect(resolveCodexThreadNodeIdentity('thread-1')).toBeUndefined()
+  })
+
+  it('refuses ids and endpoints that are not shaped like ids and endpoints', () => {
+    expect(() => writeCodexThreadIdentity('../escape', 'node-1', '/data/e')).toThrow()
+    expect(() => writeCodexThreadIdentity('thread-1', 'node 1; rm -rf /', '/data/e')).toThrow()
+    expect(() => writeCodexThreadIdentity('thread-1', 'node-1', 'relative/e')).toThrow()
+  })
+
+  it('writes nothing at all without the auth secret', () => {
+    resetCodexThreadIdentityAuthSecret()
+    expect(() => writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')).toThrow()
+    expect(fs.existsSync(path.join(codexThreadIdentityRoot(), 'thread-1'))).toBe(false)
+  })
+})
+
+describe('binding a thread to a node', () => {
+  it('refuses to take a thread away from a node that is still live', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
+    expect(() =>
+      bindCodexThreadIdentity('thread-1', 'node-2', '/data/e', live(['node-1']))
+    ).toThrow()
+    expect(resolveCodexThreadNodeIdentity('thread-1')).toBe('node-1')
+  })
+
+  it('re-claims a thread whose owner is gone', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
+    bindCodexThreadIdentity('thread-1', 'node-2', '/data/e', live([]))
+    expect(resolveCodexThreadNodeIdentity('thread-1')).toBe('node-2')
+  })
+
+  it('is idempotent for the node that already owns it (a restart re-binds its own thread)', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
+    bindCodexThreadIdentity('thread-1', 'node-1', '/data/e', live(['node-1']))
+    expect(resolveCodexThreadNodeIdentity('thread-1')).toBe('node-1')
+  })
+})
+
+describe('installCodexLauncher', () => {
+  it('writes an executable launcher and answers with its path', () => {
+    const file = installCodexLauncher()
+    expect(file).toBe(path.join(codexLauncherDir(), 'nodeterm-codex'))
+    expect(fs.statSync(file as string).mode & 0o777).toBe(0o700)
+  })
+
+  it('answers null instead of throwing when it cannot be written', () => {
+    // A read-only data dir is a real failure mode, and null is what makes the caps probe say "no
+    // shared identity" — which keeps every launch line on the bare `codex` instead of naming a
+    // launcher that is not there.
+    resetPlatformForTests()
+    initPlatform(fakePlatform({ userDataDir: path.join(dir, 'file-not-a-dir') }))
+    fs.writeFileSync(path.join(dir, 'file-not-a-dir'), 'x')
+    expect(installCodexLauncher()).toBeNull()
+  })
+})

--- a/src/core/codex-identity-proxy.test.ts
+++ b/src/core/codex-identity-proxy.test.ts
@@ -6,6 +6,7 @@ import { randomBytes } from 'node:crypto'
 import {
   bindCodexThreadIdentity,
   codexLauncherDir,
+  forgetCodexThreadIdentitiesForNode,
   codexThreadIdentityRoot,
   installCodexLauncher,
   readCodexThreadIdentity,
@@ -115,5 +116,30 @@ describe('installCodexLauncher', () => {
     initPlatform(fakePlatform({ userDataDir: path.join(dir, 'file-not-a-dir') }))
     fs.writeFileSync(path.join(dir, 'file-not-a-dir'), 'x')
     expect(installCodexLauncher()).toBeNull()
+  })
+})
+
+describe('forgetting a permanently deleted node', () => {
+  it('removes every record naming it, and leaves the others alone', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
+    writeCodexThreadIdentity('thread-2', 'node-1', '/data/e')
+    writeCodexThreadIdentity('thread-3', 'node-2', '/data/e')
+    forgetCodexThreadIdentitiesForNode('node-1')
+    expect(resolveCodexThreadNodeIdentity('thread-1')).toBeUndefined()
+    expect(resolveCodexThreadNodeIdentity('thread-2')).toBeUndefined()
+    // Without this the directory grows a file per thread forever, AND a dead node's record keeps
+    // re-exporting its node id into any tool shell still carrying that thread id.
+    expect(resolveCodexThreadNodeIdentity('thread-3')).toBe('node-2')
+  })
+
+  it('never deletes a record it does not trust, and never throws', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e')
+    const file = path.join(codexThreadIdentityRoot(), 'thread-1')
+    fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace('node-1', 'node-2'))
+    forgetCodexThreadIdentitiesForNode('node-2')
+    expect(fs.existsSync(file)).toBe(true)
+    // A node deletion must never fail on this: no directory at all is simply nothing to forget.
+    fs.rmSync(codexThreadIdentityRoot(), { recursive: true, force: true })
+    expect(() => forgetCodexThreadIdentitiesForNode('node-1')).not.toThrow()
   })
 })

--- a/src/core/codex-identity-proxy.ts
+++ b/src/core/codex-identity-proxy.ts
@@ -21,11 +21,30 @@
  * storage shape is one file per thread id; scoping adds a directory level above it without
  * changing anything this file promises.
  */
-import { chmodSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync
+} from 'fs'
 import path from 'path'
 import { createHmac, timingSafeEqual } from 'crypto'
 import { platform } from './platform'
-import { posixQuote } from '../shared/ssh'
+
+/**
+ * How long the SERVER gives itself to mint a thread (`startCodexThreadAt`'s default).
+ *
+ * The launcher's own curl budget is derived from this and is deliberately LARGER
+ * (`CODEX_THREAD_START_CLIENT_MAX_S`), so the server is always the side that gives up first.
+ * Get that ordering backwards and a slow app-server produces the worst outcome available: curl
+ * quits, the launcher falls back to plain codex, and the server carries on to create a thread and
+ * write a record for it that nothing will ever resume.
+ */
+export const CODEX_THREAD_START_TIMEOUT_MS = 20_000
+const CODEX_THREAD_START_CLIENT_MAX_S = CODEX_THREAD_START_TIMEOUT_MS / 1000 + 10
 
 const SAFE_NODE_ID = /^[A-Za-z0-9._-]+$/
 const SAFE_ENDPOINT = /^\/[A-Za-z0-9._/ -]+$/
@@ -193,13 +212,37 @@ export function bindCodexThreadIdentity(
   writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, root)
 }
 
-/** Drop a node's record when the node is permanently deleted. Best effort. */
-export function forgetCodexThreadIdentity(threadId: string, root = codexThreadIdentityRoot()): void {
-  if (!SAFE_THREAD_ID.test(threadId)) return
+/**
+ * Drop every record naming `nodeId`, when that node is permanently deleted.
+ *
+ * Two reasons this is not just housekeeping. The directory would otherwise grow one file per
+ * thread forever, and — worse — a dead node's record keeps re-exporting its node id and hook
+ * endpoint into any tool shell that still carries the thread id, so a deleted node's identity
+ * outlives it. Keyed by node, not by thread, because the caller (`destroySession`) knows the node
+ * id and nothing else; the directory is one flat level, so the scan is a single readdir.
+ *
+ * Best effort throughout: a record we cannot read or remove must never fail a node deletion.
+ */
+export function forgetCodexThreadIdentitiesForNode(
+  nodeId: string,
+  root = codexThreadIdentityRoot()
+): void {
+  if (!SAFE_NODE_ID.test(nodeId)) return
+  let entries: string[]
   try {
-    unlinkSync(path.join(root, threadId))
+    entries = readdirSync(root)
   } catch {
-    /* nothing to forget */
+    return
+  }
+  for (const threadId of entries) {
+    if (!SAFE_THREAD_ID.test(threadId)) continue
+    // Reads through the signature check, so a record we do not trust is also one we do not delete.
+    if (readCodexThreadIdentity(threadId, root)?.nodeId !== nodeId) continue
+    try {
+      unlinkSync(path.join(root, threadId))
+    } catch {
+      /* nothing to forget */
+    }
   }
 }
 
@@ -280,7 +323,10 @@ nt_preflight() {
 }
 
 # Best effort, and never fatal: tell the desktop this node is running plain codex, so the UI can
-# say so without the user reading a log. Requires only the shared bearer — it names no sibling.
+# say so without the user reading a log. Sent WITHOUT the per-node capability on purpose — the
+# commonest thing it reports is that there was no capability to present. The server only trusts a
+# TOKENLESS report on the node it names (see handleCodexThread), so a session that does hold a
+# token cannot use this route to flag a sibling.
 nt_report_fallback() {
   [ -n "\${NODETERM_HOOK_PORT-}" ] || return 0
   [ -n "\${NODETERM_HOOK_TOKEN-}" ] || return 0
@@ -298,16 +344,21 @@ if [ -n "$nt_reason" ]; then
   exec codex "$@"
 fi
 
+# $1 is the client budget in seconds; the rest is curl's. Start gets a budget LARGER than the
+# server's own (CODEX_THREAD_START_TIMEOUT_MS) so the server, not curl, is what times out — a curl
+# that quits first leaves behind a thread and a record nothing will ever resume.
 nt_post() {
+  nt_budget=$1
+  shift
   printf 'header = "X-NodeTerm-Hook-Token: %s"\\nheader = "X-NodeTerm-Node-Token: %s"\\n' \\
     "$NODETERM_HOOK_TOKEN" "$NODETERM_CODEX_NODE_TOKEN" |
-    nt_hook_curl --silent --show-error --fail --max-time 10 --config - --request POST "$@"
+    nt_hook_curl --silent --show-error --fail --max-time "$nt_budget" --config - --request POST "$@"
 }
 
 if [ "\${1-}" = resume ]; then
   # Claim the caller-supplied thread for THIS node before Codex opens it. A refusal means another
   # live node owns it; two clients on one thread is worse than one plain session, so we fall back.
-  if nt_post --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "threadId=\${2-}" \\
+  if nt_post 20 --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "threadId=\${2-}" \\
       "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/bind" >/dev/null; then
     exec codex --remote unix:// "$@"
   fi
@@ -315,7 +366,7 @@ if [ "\${1-}" = resume ]; then
   exec codex "$@"
 fi
 
-nt_thread=$(nt_post --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "cwd=$PWD" \\
+nt_thread=$(nt_post ${CODEX_THREAD_START_CLIENT_MAX_S} --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "cwd=$PWD" \\
   "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/start") || nt_thread=''
 nt_thread=$(printf %s "$nt_thread" | tr -d '\\r\\n')
 case "$nt_thread" in
@@ -344,9 +395,4 @@ export function installCodexLauncher(): string | null {
   } catch {
     return null
   }
-}
-
-/** The launcher directory as a single POSIX-sh token, for embedding in generated scripts. */
-export function quotedCodexLauncherDir(): string {
-  return posixQuote(codexLauncherDir())
 }

--- a/src/core/codex-identity-proxy.ts
+++ b/src/core/codex-identity-proxy.ts
@@ -1,0 +1,352 @@
+/**
+ * Shared-identity spine for Codex canvas nodes.
+ *
+ * WHY: a Codex terminal node used to spawn a full `codex` process tree per node — one app-server
+ * each. A canvas with a dozen Codex nodes paid a dozen servers' worth of RAM for one account. With
+ * this, every node on a machine talks to ONE `codex app-server` and owns one THREAD inside it, and
+ * the node ↔ thread mapping is what survives resumes, in-pane restarts and app restarts.
+ *
+ * The mapping is a tiny file per thread under `<userDataDir>/codex-thread-nodes/`. It is read by
+ * generated POSIX sh (the hook prelude in `codex-thread-identity-sh.ts`), so it is a flat
+ * `key=value` text file — parsed as DATA, never sourced.
+ *
+ * WHY IT IS SIGNED: the records name a node id and a hook endpoint, and the hook prelude
+ * re-exports both into the agent's environment. An attacker who could write one of these files
+ * could aim a session's hook traffic at a node (or an endpoint) of their choosing. Every record
+ * therefore carries an HMAC over (threadId, nodeId, endpoint) keyed by the same restart-stable
+ * secret the hook server uses to mint per-node capabilities (`src/main/codex-node-auth-secret.ts`).
+ * Unsigned/mis-signed records are ignored, not repaired.
+ *
+ * ACCOUNT SCOPING is deliberately absent here: managed Codex accounts are a later slice. The
+ * storage shape is one file per thread id; scoping adds a directory level above it without
+ * changing anything this file promises.
+ */
+import { chmodSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
+import path from 'path'
+import { createHmac, timingSafeEqual } from 'crypto'
+import { platform } from './platform'
+import { posixQuote } from '../shared/ssh'
+
+const SAFE_NODE_ID = /^[A-Za-z0-9._-]+$/
+const SAFE_ENDPOINT = /^\/[A-Za-z0-9._/ -]+$/
+const SAFE_THREAD_ID = /^[A-Za-z0-9._-]+$/
+
+let identityAuthSecret: Buffer | null = null
+
+/** Injected by the shell once, from the same keychain-backed secret the hook server signs with. */
+export function setCodexThreadIdentityAuthSecret(secret: Uint8Array): void {
+  if (secret.byteLength < 32) throw new Error('Invalid NodeTerm Codex identity-auth secret')
+  identityAuthSecret = Buffer.from(secret)
+}
+
+/** Test-only: forget the injected secret so a suite can assert the unavailable path. */
+export function resetCodexThreadIdentityAuthSecret(): void {
+  identityAuthSecret = null
+}
+
+export function codexThreadIdentityAvailable(): boolean {
+  return !!identityAuthSecret
+}
+
+/**
+ * Where the thread → node records live. Through `CorePlatform`, NOT `homedir()`: this is state the
+ * app owns, and the Server Edition's data dir is not `~`. The generated sh gets this exact path
+ * baked in (quoted), so the two never disagree.
+ */
+export function codexThreadIdentityRoot(): string {
+  return path.join(platform().userDataDir, 'codex-thread-nodes')
+}
+
+function identitySignature(threadId: string, nodeId: string, hookEndpoint: string): string {
+  if (!identityAuthSecret) throw new Error('NodeTerm Codex identity authentication is unavailable')
+  return createHmac('sha256', identityAuthSecret)
+    .update(`${threadId}\0${nodeId}\0${hookEndpoint}`)
+    .digest('base64url')
+}
+
+function signatureMatches(threadId: string, identity: CodexThreadIdentity): boolean {
+  if (!identity.signature || !identityAuthSecret) return false
+  let expected = ''
+  try {
+    expected = identitySignature(threadId, identity.nodeId, identity.hookEndpoint)
+  } catch {
+    return false
+  }
+  const actual = Buffer.from(identity.signature)
+  const wanted = Buffer.from(expected)
+  return actual.length === wanted.length && timingSafeEqual(actual, wanted)
+}
+
+export interface CodexThreadIdentity {
+  nodeId: string
+  hookEndpoint: string
+  signature: string
+}
+
+export function validCodexIdentity(nodeId: string, hookEndpoint: string): boolean {
+  return SAFE_NODE_ID.test(nodeId) && SAFE_ENDPOINT.test(hookEndpoint)
+}
+
+function identityFile(threadId: string, root = codexThreadIdentityRoot()): string {
+  if (!SAFE_THREAD_ID.test(threadId)) throw new Error('Invalid NodeTerm Codex thread identity')
+  return path.join(root, threadId)
+}
+
+function parseCodexThreadIdentity(raw: string): CodexThreadIdentity {
+  const values: Record<string, string> = {}
+  for (const line of raw.split('\n')) {
+    const separator = line.indexOf('=')
+    if (separator < 1) continue
+    values[line.slice(0, separator)] = line.slice(separator + 1)
+  }
+  return {
+    nodeId: values.nodeId ?? '',
+    hookEndpoint: values.endpoint ?? '',
+    signature: values.signature ?? ''
+  }
+}
+
+/** The record for a thread, or undefined when it is absent, malformed or badly signed. */
+export function readCodexThreadIdentity(
+  threadId: string,
+  root = codexThreadIdentityRoot()
+): CodexThreadIdentity | undefined {
+  if (!SAFE_THREAD_ID.test(threadId)) return undefined
+  let raw: string
+  try {
+    raw = readFileSync(path.join(root, threadId), 'utf8')
+  } catch {
+    return undefined
+  }
+  const identity = parseCodexThreadIdentity(raw)
+  if (!validCodexIdentity(identity.nodeId, identity.hookEndpoint)) return undefined
+  if (!signatureMatches(threadId, identity)) return undefined
+  return identity
+}
+
+/**
+ * Recover a thread's owning node after the app restarts. tmux sessions outlive the app, so a
+ * running Codex client can outlive every in-memory map we hold; the file is the only thing that
+ * still knows which node it belongs to.
+ */
+export function resolveCodexThreadNodeIdentity(
+  threadId: string,
+  root = codexThreadIdentityRoot()
+): string | undefined {
+  return readCodexThreadIdentity(threadId, root)?.nodeId
+}
+
+/** Write (or replace) the record for `threadId`, atomically. */
+export function writeCodexThreadIdentity(
+  threadId: string,
+  nodeId: string,
+  hookEndpoint: string,
+  root = codexThreadIdentityRoot()
+): void {
+  if (!SAFE_THREAD_ID.test(threadId) || !validCodexIdentity(nodeId, hookEndpoint)) {
+    throw new Error('Invalid NodeTerm Codex thread identity')
+  }
+  const signature = identitySignature(threadId, nodeId, hookEndpoint)
+  const file = identityFile(threadId, root)
+  const tmp = path.join(root, `.${threadId}.${process.pid}.${Date.now()}`)
+  mkdirSync(root, { recursive: true, mode: 0o700 })
+  let renamed = false
+  try {
+    writeFileSync(tmp, `nodeId=${nodeId}\nendpoint=${hookEndpoint}\nsignature=${signature}\n`, {
+      encoding: 'utf8',
+      mode: 0o600
+    })
+    renameSync(tmp, file)
+    renamed = true
+  } finally {
+    if (!renamed) {
+      try {
+        unlinkSync(tmp)
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+}
+
+/**
+ * One canvas node owns one Codex conversation, and one conversation belongs to one node. A resume
+ * that would steal a thread from a node that is still LIVE is refused — the caller (the launcher)
+ * then falls back to a plain `codex`, which is a working session rather than two clients fighting
+ * over one thread. A STALE owner (node deleted, app restarted without it) is simply replaced.
+ */
+export function bindCodexThreadIdentity(
+  threadId: string,
+  nodeId: string,
+  hookEndpoint: string,
+  isNodeLive: (nodeId: string) => boolean,
+  root = codexThreadIdentityRoot()
+): void {
+  if (!SAFE_THREAD_ID.test(threadId) || !validCodexIdentity(nodeId, hookEndpoint)) {
+    throw new Error('Invalid NodeTerm Codex thread identity')
+  }
+  const existing = readCodexThreadIdentity(threadId, root)
+  if (existing && existing.nodeId !== nodeId && isNodeLive(existing.nodeId)) {
+    throw new Error('Codex thread is already bound to another live node')
+  }
+  if (existing && existing.nodeId === nodeId && existing.hookEndpoint === hookEndpoint) return
+  writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, root)
+}
+
+/** Drop a node's record when the node is permanently deleted. Best effort. */
+export function forgetCodexThreadIdentity(threadId: string, root = codexThreadIdentityRoot()): void {
+  if (!SAFE_THREAD_ID.test(threadId)) return
+  try {
+    unlinkSync(path.join(root, threadId))
+  } catch {
+    /* nothing to forget */
+  }
+}
+
+export function codexLauncherDir(): string {
+  return path.join(platform().userDataDir, 'codex-bin')
+}
+
+export const CODEX_LAUNCHER_NAME = 'nodeterm-codex'
+
+export function codexLauncherPath(): string {
+  return path.join(codexLauncherDir(), CODEX_LAUNCHER_NAME)
+}
+
+/**
+ * The generated launcher.
+ *
+ * EVERY failure path here ends in `exec codex "$@"` — the caller's arguments untouched. That is
+ * the owner's decision and it follows the repo's own precedent (`gatePermissionMode`: an unknown
+ * or failed probe degrades to the bare command, never to a blocked launch). The upstream version
+ * of this script exited 69 "identity unavailable", which turns a missing app-server, an older
+ * `codex`, a stale tmux session or a locked-down `$HOME` into a DEAD node.
+ *
+ * The fallback is not silent: before exec'ing plain codex the script POSTs `/codex-thread/fallback`
+ * with a machine-readable reason, and the desktop marks the node. Nothing is ever written into the
+ * pane — text injected into an agent's terminal is prompt injection, which this repo forbids.
+ *
+ * `appServerStartCommand` is injected so the test suite can run this script for real under
+ * `/bin/sh` (the discipline `canvas-control-shim.test.ts` and `remote-claude-usage.test.ts` set).
+ */
+export function buildCodexLauncherScript(
+  appServerStartCommand = 'codex app-server daemon start >/dev/null 2>&1'
+): string {
+  return `#!/bin/sh
+# Generated by NodeTerm. Do not edit — it is rewritten on every launch.
+# Runs a Codex session against the ONE shared app-server, bound to this canvas node's thread.
+# Anything missing => plain 'codex' with the same arguments. A node that cannot get a managed
+# identity must still be a working node.
+
+nt_reason=''
+nt_fail() { nt_reason=$1; return 1; }
+
+nt_hook_curl() { curl "$@"; }
+if [ -n "\${NODETERM_HOOK_SOCK-}" ]; then
+  case "$NODETERM_HOOK_SOCK" in
+    /*) nt_hook_curl() { curl --unix-socket "$NODETERM_HOOK_SOCK" "$@"; } ;;
+    *) nt_reason=broker-unreachable ;;
+  esac
+fi
+
+# A path we are willing to source. Written with tr rather than a case bracket class because the
+# endpoint lives under the app's data dir, which on macOS contains a space ("Application Support")
+# — escaping a space inside a case pattern's bracket expression is exactly the kind of quoting
+# that reads fine and matches nothing.
+nt_safe_path() {
+  case "\${1-}" in /*) ;; *) return 1 ;; esac
+  [ "$(printf %s "$1" | tr -cd 'A-Za-z0-9._/ -')" = "$1" ]
+}
+
+# Runs in THIS shell, never a command substitution: it sources the endpoint file, and that file is
+# what carries the live hook port/token. Sourcing it in a subshell would leave both unset here and
+# every launch would "fall back" for the wrong reason.
+nt_preflight() {
+  case "\${NODETERM_NODE_ID-}" in ''|*[!A-Za-z0-9._-]*) nt_fail node-id-unavailable; return ;; esac
+  nt_safe_path "\${NODETERM_HOOK_ENDPOINT-}" || { nt_fail hook-endpoint-unavailable; return; }
+  [ -r "$NODETERM_HOOK_ENDPOINT" ] || { nt_fail hook-endpoint-unavailable; return; }
+  . "$NODETERM_HOOK_ENDPOINT" 2>/dev/null || { nt_fail broker-unreachable; return; }
+  case "\${NODETERM_HOOK_PORT-}" in ''|*[!0-9]*) nt_fail broker-unreachable; return ;; esac
+  case "\${NODETERM_HOOK_TOKEN-}" in ''|*[!A-Za-z0-9-]*) nt_fail broker-unreachable; return ;; esac
+  # The per-node capability. Absent => this build/shell has no managed identity to give.
+  case "\${NODETERM_CODEX_NODE_TOKEN-}" in
+    ''|*[!A-Za-z0-9_-]*) nt_fail node-token-unavailable; return ;;
+  esac
+  if [ "\${1-}" = resume ]; then
+    case "\${2-}" in ''|*[!A-Za-z0-9._-]*) nt_fail thread-id-unavailable; return ;; esac
+  fi
+  ${appServerStartCommand} || { nt_fail app-server-unavailable; return; }
+  return 0
+}
+
+# Best effort, and never fatal: tell the desktop this node is running plain codex, so the UI can
+# say so without the user reading a log. Requires only the shared bearer — it names no sibling.
+nt_report_fallback() {
+  [ -n "\${NODETERM_HOOK_PORT-}" ] || return 0
+  [ -n "\${NODETERM_HOOK_TOKEN-}" ] || return 0
+  [ -n "\${NODETERM_NODE_ID-}" ] || return 0
+  printf 'header = "X-NodeTerm-Hook-Token: %s"\\n' "$NODETERM_HOOK_TOKEN" |
+    nt_hook_curl --silent --show-error --fail --max-time 3 --config - --request POST \\
+      --data-urlencode "nodeId=$NODETERM_NODE_ID" \\
+      --data-urlencode "reason=$1" \\
+      "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/fallback" >/dev/null 2>&1 || :
+}
+
+[ -n "$nt_reason" ] || nt_preflight "$@" || :
+if [ -n "$nt_reason" ]; then
+  nt_report_fallback "$nt_reason"
+  exec codex "$@"
+fi
+
+nt_post() {
+  printf 'header = "X-NodeTerm-Hook-Token: %s"\\nheader = "X-NodeTerm-Node-Token: %s"\\n' \\
+    "$NODETERM_HOOK_TOKEN" "$NODETERM_CODEX_NODE_TOKEN" |
+    nt_hook_curl --silent --show-error --fail --max-time 10 --config - --request POST "$@"
+}
+
+if [ "\${1-}" = resume ]; then
+  # Claim the caller-supplied thread for THIS node before Codex opens it. A refusal means another
+  # live node owns it; two clients on one thread is worse than one plain session, so we fall back.
+  if nt_post --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "threadId=\${2-}" \\
+      "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/bind" >/dev/null; then
+    exec codex --remote unix:// "$@"
+  fi
+  nt_report_fallback thread-bind-refused
+  exec codex "$@"
+fi
+
+nt_thread=$(nt_post --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "cwd=$PWD" \\
+  "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/start") || nt_thread=''
+nt_thread=$(printf %s "$nt_thread" | tr -d '\\r\\n')
+case "$nt_thread" in
+  ''|*[!A-Za-z0-9._-]*)
+    nt_report_fallback thread-start-failed
+    exec codex "$@"
+    ;;
+esac
+exec codex --remote unix:// resume "$nt_thread" "$@"
+`
+}
+
+/**
+ * Write the launcher and return its path, or null when it could not be installed (read-only home,
+ * no permission). Null is a first-class answer: it is what makes `codexIdentityCaps()` say "no"
+ * and every launch line stay the bare `codex` it has always been.
+ */
+export function installCodexLauncher(): string | null {
+  try {
+    const dir = codexLauncherDir()
+    const file = path.join(dir, CODEX_LAUNCHER_NAME)
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+    writeFileSync(file, buildCodexLauncherScript(), { encoding: 'utf8', mode: 0o700 })
+    chmodSync(file, 0o700)
+    return file
+  } catch {
+    return null
+  }
+}
+
+/** The launcher directory as a single POSIX-sh token, for embedding in generated scripts. */
+export function quotedCodexLauncherDir(): string {
+  return posixQuote(codexLauncherDir())
+}

--- a/src/core/codex-launcher-sh.test.ts
+++ b/src/core/codex-launcher-sh.test.ts
@@ -28,6 +28,7 @@ let started: Array<{ nodeId: string; cwd: string }> = []
 let bound: Array<{ nodeId: string; threadId: string }> = []
 let fallbacks: Array<{ nodeId: string; reason?: string }> = []
 let startAnswer: (() => string) | null = null
+let startDelayMs = 0
 let bindAnswer: (() => void) | null = null
 
 /** A stand-in for the real `codex`, which records how it was invoked and exits 0. */
@@ -54,6 +55,7 @@ beforeAll(async () => {
   hookServer.setCodexNodeAuthSecret(randomBytes(32))
   hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd }) => {
     started.push({ nodeId, cwd })
+    if (startDelayMs) await new Promise((r) => setTimeout(r, startDelayMs))
     if (!startAnswer) throw new Error('start refused')
     return startAnswer()
   })
@@ -78,6 +80,7 @@ beforeEach(() => {
   bound = []
   fallbacks = []
   startAnswer = () => 'thread-abc'
+  startDelayMs = 0
   bindAnswer = () => {}
   fs.writeFileSync(argvLog, '')
 })
@@ -203,7 +206,52 @@ describe('falls back to plain codex', () => {
   })
 })
 
+describe('a start handler that takes real time', () => {
+  // REGRESSION. `/codex-thread/start` mints a thread through a five-step conversation with an
+  // app-server that is typically COLD — the first codex node after boot. The route inherited the
+  // 2s slowloris guard (a RECEIVE-phase guard), so the socket was destroyed while the handler was
+  // still working: curl failed, the launcher fell back to plain codex, and the server went on to
+  // create the thread and write a record for it. An orphan thread and an orphan record, per
+  // attempt, in the most common case there is. A handler that resolves synchronously — which is
+  // what this suite used to have — cannot see any of that.
+  it('is waited for, and its thread is the one codex resumes', async () => {
+    startDelayMs = 3000
+    await callLauncher([])
+    expect(codexArgv()).toEqual(['--remote unix:// resume thread-abc'])
+    expect(fallbacks).toEqual([])
+  }, 20_000)
+})
+
 describe('per-node capability (the authorization the shared bearer cannot give)', () => {
+  it('the fallback report is trusted only when it presents no token at all', async () => {
+    // The one route the capability is not required on — because the commonest thing it reports is
+    // that there was no capability to present. The exemption is exactly that narrow: a report that
+    // DOES carry a token must carry the right one, or a session holding only the shared bearer
+    // could flag a sibling node as fallen back.
+    const post = (nodeId: string, headers: Record<string, string>) =>
+      fetch(`http://127.0.0.1:${hookServer.getPort()}/codex-thread/fallback`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'x-nodeterm-hook-token': hookServer.getToken(),
+          ...headers
+        },
+        body: `nodeId=${nodeId}&reason=broker-unreachable`
+      })
+    expect((await post('node-1', {})).status).toBe(204)
+    expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'broker-unreachable' }])
+    const wrong = await post('node-1', {
+      'x-nodeterm-node-token': hookServer.codexNodeAuthToken('node-2')
+    })
+    expect(wrong.status).toBe(403)
+    expect(fallbacks).toHaveLength(1)
+    const right = await post('node-1', {
+      'x-nodeterm-node-token': hookServer.codexNodeAuthToken('node-1')
+    })
+    expect(right.status).toBe(204)
+    expect(fallbacks).toHaveLength(2)
+  })
+
   it("refuses a token minted for a SIBLING node, and falls back rather than binding it", async () => {
     await callLauncher(['resume', 'thread-xyz'], {
       NODETERM_CODEX_NODE_TOKEN: hookServer.codexNodeAuthToken('node-2')

--- a/src/core/codex-launcher-sh.test.ts
+++ b/src/core/codex-launcher-sh.test.ts
@@ -1,0 +1,216 @@
+// The generated Codex launcher, run by the real /bin/sh against the real hook server.
+//
+// This script is source no compiler checks, it is the ONLY thing standing between a Codex node and
+// a shell, and its most important job is the one that is hardest to assert on paper: FALLING BACK.
+// Every branch below therefore runs for real, with a fake `codex` on PATH that records the argv it
+// was exec'd with — because "did it fall back with the arguments intact?" is exactly the question
+// a string assertion cannot answer. Same discipline as canvas-control-shim.test.ts and
+// remote-claude-usage.test.ts.
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { randomBytes } from 'node:crypto'
+import { buildCodexLauncherScript } from './codex-identity-proxy'
+import { hookServer } from './agents/hook-server'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform } from './platform-fake'
+
+const run = promisify(execFile)
+
+let dir = ''
+let launcher = ''
+let binDir = ''
+let argvLog = ''
+let started: Array<{ nodeId: string; cwd: string }> = []
+let bound: Array<{ nodeId: string; threadId: string }> = []
+let fallbacks: Array<{ nodeId: string; reason?: string }> = []
+let startAnswer: (() => string) | null = null
+let bindAnswer: (() => void) | null = null
+
+/** A stand-in for the real `codex`, which records how it was invoked and exits 0. */
+function writeFakeCodex(): void {
+  fs.writeFileSync(
+    path.join(binDir, 'codex'),
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(argvLog)}\nexit 0\n`,
+    { mode: 0o755 }
+  )
+}
+
+beforeAll(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-launcher-'))
+  binDir = path.join(dir, 'bin')
+  fs.mkdirSync(binDir)
+  argvLog = path.join(dir, 'codex-argv.log')
+  writeFakeCodex()
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: dir }))
+  launcher = path.join(dir, 'nodeterm-codex')
+  // `true` stands in for `codex app-server daemon start`; the "no app-server" case overrides it.
+  fs.writeFileSync(launcher, buildCodexLauncherScript('true'), { mode: 0o755 })
+  await hookServer.start()
+  hookServer.setCodexNodeAuthSecret(randomBytes(32))
+  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd }) => {
+    started.push({ nodeId, cwd })
+    if (!startAnswer) throw new Error('start refused')
+    return startAnswer()
+  })
+  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId }) => {
+    bound.push({ nodeId, threadId })
+    if (!bindAnswer) throw new Error('bind refused')
+    bindAnswer()
+  })
+  hookServer.setCodexIdentityListener((e) => {
+    if (e.mode === 'plain') fallbacks.push({ nodeId: e.nodeId, reason: e.reason })
+  })
+})
+
+afterAll(() => {
+  hookServer.stop()
+  resetPlatformForTests()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  started = []
+  bound = []
+  fallbacks = []
+  startAnswer = () => 'thread-abc'
+  bindAnswer = () => {}
+  fs.writeFileSync(argvLog, '')
+})
+
+function baseEnv(): Record<string, string> {
+  return {
+    PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    HOME: dir,
+    NODETERM_NODE_ID: 'node-1',
+    NODETERM_HOOK_ENDPOINT: hookServer.endpointFilePath(),
+    // buildPtyEnv injects these at spawn too. The endpoint FILE is still required (it carries the
+    // live coordinates after an app restart), but their presence is why a node whose endpoint file
+    // vanished can still report that it fell back.
+    NODETERM_HOOK_PORT: String(hookServer.getPort()),
+    NODETERM_HOOK_TOKEN: hookServer.getToken(),
+    NODETERM_CODEX_NODE_TOKEN: hookServer.codexNodeAuthToken('node-1')
+  }
+}
+
+function callLauncher(
+  args: string[],
+  env: Record<string, string> = {},
+  script = launcher
+): Promise<{ stdout: string; stderr: string }> {
+  const merged = { ...baseEnv(), ...env }
+  for (const [k, v] of Object.entries(merged)) if (v === '') delete (merged as any)[k]
+  return run('/bin/sh', [script, ...args], { env: merged, cwd: dir })
+}
+
+/** What the fake `codex` was exec'd with, one line per invocation. */
+function codexArgv(): string[] {
+  return fs.readFileSync(argvLog, 'utf8').split('\n').slice(0, -1)
+}
+
+describe('generated Codex launcher', () => {
+  it('is valid POSIX sh', async () => {
+    await expect(run('/bin/sh', ['-n', launcher])).resolves.toBeTruthy()
+  })
+
+  it('starts a thread for a fresh node and resumes it on the shared app-server', async () => {
+    await callLauncher([])
+    expect(started).toEqual([{ nodeId: 'node-1', cwd: fs.realpathSync(dir) }])
+    expect(codexArgv()).toEqual(['--remote unix:// resume thread-abc'])
+    expect(fallbacks).toEqual([])
+  })
+
+  it('keeps the caller arguments after the thread it resolved', async () => {
+    await callLauncher(['--ask-for-approval', 'never', 'fix the bug'])
+    expect(codexArgv()).toEqual([
+      '--remote unix:// resume thread-abc --ask-for-approval never fix the bug'
+    ])
+  })
+
+  it('binds a caller-supplied thread on resume instead of starting a new one', async () => {
+    await callLauncher(['resume', 'thread-xyz'])
+    expect(bound).toEqual([{ nodeId: 'node-1', threadId: 'thread-xyz' }])
+    expect(started).toEqual([])
+    expect(codexArgv()).toEqual(['--remote unix:// resume thread-xyz'])
+  })
+})
+
+// Each case below is a way the managed identity can be unavailable on a real machine. The
+// assertion is always the same pair: plain `codex` ran WITH THE ORIGINAL ARGUMENTS, and the
+// desktop was told why. Upstream, every one of these exited 69 — a dead node.
+describe('falls back to plain codex', () => {
+  const cases: Array<[string, Record<string, string>, string]> = [
+    ['no node id (a session nodeterm did not spawn)', { NODETERM_NODE_ID: '' }, 'node-id-unavailable'],
+    [
+      'no hook endpoint',
+      { NODETERM_HOOK_ENDPOINT: '' },
+      'hook-endpoint-unavailable'
+    ],
+    [
+      'hook endpoint points at nothing (app restarted, tmux session outlived it)',
+      { NODETERM_HOOK_ENDPOINT: '/nonexistent/hook-endpoint.env' },
+      'hook-endpoint-unavailable'
+    ],
+    [
+      'no per-node capability token (secure storage unavailable)',
+      { NODETERM_CODEX_NODE_TOKEN: '' },
+      'node-token-unavailable'
+    ]
+  ]
+
+  for (const [name, env, reason] of cases) {
+    it(`${name} → exec codex with the same args`, async () => {
+      await callLauncher(['--ask-for-approval', 'never', 'do the thing'], env)
+      expect(codexArgv()).toEqual(['--ask-for-approval never do the thing'])
+      expect(started).toEqual([])
+      // A node id is the ONLY thing the fallback report cannot be made without.
+      if (env.NODETERM_NODE_ID === '') expect(fallbacks).toEqual([])
+      else expect(fallbacks).toEqual([{ nodeId: 'node-1', reason }])
+    })
+  }
+
+  it('an older codex with no app-server → plain codex, not a dead node', async () => {
+    const noServer = path.join(dir, 'nodeterm-codex-no-server')
+    fs.writeFileSync(noServer, buildCodexLauncherScript('false'), { mode: 0o755 })
+    await callLauncher(['hello'], {}, noServer)
+    expect(codexArgv()).toEqual(['hello'])
+    expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'app-server-unavailable' }])
+  })
+
+  it('a thread owned by another live node → plain codex, never two clients on one thread', async () => {
+    bindAnswer = null
+    await callLauncher(['resume', 'thread-xyz'])
+    expect(codexArgv()).toEqual(['resume thread-xyz'])
+    expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'thread-bind-refused' }])
+  })
+
+  it('the app-server refusing to start a thread → plain codex', async () => {
+    startAnswer = null
+    await callLauncher([])
+    expect(codexArgv()).toEqual([''])
+    expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'thread-start-failed' }])
+  })
+
+  it('a resume with an unusable session id → plain codex, id left alone', async () => {
+    await callLauncher(['resume', 'not a; thread'])
+    expect(codexArgv()).toEqual(['resume not a; thread'])
+    expect(bound).toEqual([])
+    expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'thread-id-unavailable' }])
+  })
+})
+
+describe('per-node capability (the authorization the shared bearer cannot give)', () => {
+  it("refuses a token minted for a SIBLING node, and falls back rather than binding it", async () => {
+    await callLauncher(['resume', 'thread-xyz'], {
+      NODETERM_CODEX_NODE_TOKEN: hookServer.codexNodeAuthToken('node-2')
+    })
+    // The route rejected it before the handler ran: no binding was recorded for node-1.
+    expect(bound).toEqual([])
+    expect(codexArgv()).toEqual(['resume thread-xyz'])
+    expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'thread-bind-refused' }])
+  })
+})

--- a/src/core/codex-session-name.test.ts
+++ b/src/core/codex-session-name.test.ts
@@ -53,8 +53,13 @@ function handle(ws: WebSocket): void {
 }
 
 beforeAll(async () => {
-  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-appserver-'))
-  sock = path.join(dir, 'app-server-control.sock')
+  // Short prefix and short socket name ON PURPOSE. Unix socket paths are capped at `sun_path`
+  // (104 bytes on macOS), and macOS's `os.tmpdir()` is already ~49 of them
+  // (`/var/folders/ab/…/T/`); a descriptive prefix plus `app-server-control.sock` lands exactly on
+  // the limit and fails to bind on a developer's machine while passing in CI. Everything still
+  // lives inside the mkdtemp directory, so the path stays unpredictable.
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-cx-'))
+  sock = path.join(dir, 'as.sock')
   server = http.createServer()
   wss = new WebSocketServer({ server })
   wss.on('connection', handle)
@@ -90,7 +95,7 @@ describe('codexThreadExistsAt', () => {
     // this check runs immediately after it on the cold/reboot path. Without the retry, a daemon
     // that binds a beat late turns a legitimate resume into `thread-bind-refused` → plain codex:
     // a NEW way to lose shared identity on exactly the path the feature exists for.
-    const latePath = path.join(dir, 'late.sock')
+    const latePath = path.join(dir, 'lt.sock')
     const late = http.createServer()
     const lateWss = new WebSocketServer({ server: late })
     lateWss.on('connection', handle)

--- a/src/core/codex-session-name.test.ts
+++ b/src/core/codex-session-name.test.ts
@@ -13,7 +13,8 @@ import { WebSocketServer, type WebSocket } from 'ws'
 import {
   codexThreadExistsAt,
   codexUnixWebSocketUrl,
-  readCodexSessionNameAt
+  readCodexSessionNameAt,
+  waitForCodexAppServer
 } from './codex-session-name'
 
 let dir = ''
@@ -79,7 +80,38 @@ describe('codexThreadExistsAt', () => {
   })
 
   it('refuses when the app-server is not running at all', async () => {
-    expect(await codexThreadExistsAt(path.join(dir, 'nope.sock'), 'thread-known', 500)).toBe(false)
+    expect(await codexThreadExistsAt(path.join(dir, 'nope.sock'), 'thread-known', 500, 1)).toBe(
+      false
+    )
+  })
+
+  it('waits out a daemon whose socket is still binding, instead of refusing a good resume', async () => {
+    // `codex app-server daemon start` exiting 0 does not mean the socket is listening yet, and
+    // this check runs immediately after it on the cold/reboot path. Without the retry, a daemon
+    // that binds a beat late turns a legitimate resume into `thread-bind-refused` → plain codex:
+    // a NEW way to lose shared identity on exactly the path the feature exists for.
+    const latePath = path.join(dir, 'late.sock')
+    const late = http.createServer()
+    const lateWss = new WebSocketServer({ server: late })
+    lateWss.on('connection', handle)
+    const listening = new Promise<void>((resolve) =>
+      setTimeout(() => late.listen(latePath, resolve), 250)
+    )
+    try {
+      expect(await codexThreadExistsAt(latePath, 'thread-known', 500)).toBe(true)
+    } finally {
+      await listening
+      await new Promise<void>((resolve) => lateWss.close(() => resolve()))
+      await new Promise<void>((resolve) => late.close(() => resolve()))
+    }
+  })
+
+  it('does NOT retry a server that answered — "I do not have it" is an answer', async () => {
+    // Retrying a definite no just delays it. Measured by the clock: three attempts with the
+    // default 200ms gap could not come back this fast.
+    const started = Date.now()
+    expect(await codexThreadExistsAt(sock, 'thread-from-a-past-life')).toBe(false)
+    expect(Date.now() - started).toBeLessThan(200)
   })
 
   it('refuses an id that is not shaped like one, without opening a socket', async () => {
@@ -93,6 +125,13 @@ describe('codexThreadExistsAt', () => {
     } finally {
       initializeFails = false
     }
+  })
+})
+
+describe('waitForCodexAppServer', () => {
+  it('answers true for a live socket and false for a dead one, without throwing', async () => {
+    expect(await waitForCodexAppServer(sock, 1)).toBe(true)
+    expect(await waitForCodexAppServer(path.join(dir, 'nope.sock'), 2, 10)).toBe(false)
   })
 })
 

--- a/src/core/codex-session-name.test.ts
+++ b/src/core/codex-session-name.test.ts
@@ -1,0 +1,118 @@
+// The app-server protocol client, against a real WebSocket server on a real unix socket.
+//
+// Two of its answers are load-bearing in ways a mocked test would not show: `codexThreadExistsAt`
+// is what stands between a stale session id and a node that dies AFTER exec (where no fallback is
+// left), and both readers must answer the conservative thing when the server is simply not there —
+// which, for a CLI whose app-server starts on demand, is a completely ordinary state.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import http from 'node:http'
+import path from 'node:path'
+import { WebSocketServer, type WebSocket } from 'ws'
+import {
+  codexThreadExistsAt,
+  codexUnixWebSocketUrl,
+  readCodexSessionNameAt
+} from './codex-session-name'
+
+let dir = ''
+let sock = ''
+let server: http.Server
+let wss: WebSocketServer
+/** Threads the fake app-server knows about, id → name. */
+const threads = new Map<string, string | null>([
+  ['thread-known', 'Named by codex'],
+  ['thread-nameless', null]
+])
+let initializeFails = false
+
+function handle(ws: WebSocket): void {
+  ws.on('message', (raw) => {
+    const msg = JSON.parse(raw.toString()) as Record<string, any>
+    if (msg.method === 'initialize') {
+      ws.send(
+        JSON.stringify(
+          initializeFails
+            ? { id: msg.id, error: { message: 'not authenticated' } }
+            : { id: msg.id, result: {} }
+        )
+      )
+      return
+    }
+    if (msg.method === 'thread/read') {
+      const id = msg.params?.threadId as string
+      if (!threads.has(id)) {
+        ws.send(JSON.stringify({ id: msg.id, error: { message: 'no rollout found' } }))
+        return
+      }
+      ws.send(JSON.stringify({ id: msg.id, result: { thread: { id, name: threads.get(id) } } }))
+    }
+  })
+}
+
+beforeAll(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-appserver-'))
+  sock = path.join(dir, 'app-server-control.sock')
+  server = http.createServer()
+  wss = new WebSocketServer({ server })
+  wss.on('connection', handle)
+  await new Promise<void>((resolve) => server.listen(sock, resolve))
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => wss.close(() => resolve()))
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('codexThreadExistsAt', () => {
+  it('confirms a thread the app-server knows', async () => {
+    expect(await codexThreadExistsAt(sock, 'thread-known')).toBe(true)
+    expect(await codexThreadExistsAt(sock, 'thread-nameless')).toBe(true)
+  })
+
+  it('refuses an id the app-server never heard of (the stale-session-id case)', async () => {
+    // This is the whole point: the launcher's bind falls back to plain codex instead of exec'ing
+    // a resume that dies with "no rollout found" where nothing can catch it.
+    expect(await codexThreadExistsAt(sock, 'thread-from-a-past-life')).toBe(false)
+  })
+
+  it('refuses when the app-server is not running at all', async () => {
+    expect(await codexThreadExistsAt(path.join(dir, 'nope.sock'), 'thread-known', 500)).toBe(false)
+  })
+
+  it('refuses an id that is not shaped like one, without opening a socket', async () => {
+    expect(await codexThreadExistsAt(sock, '../../etc/passwd')).toBe(false)
+  })
+
+  it('refuses when the server will not initialize (a logged-out CLI)', async () => {
+    initializeFails = true
+    try {
+      expect(await codexThreadExistsAt(sock, 'thread-known')).toBe(false)
+    } finally {
+      initializeFails = false
+    }
+  })
+})
+
+describe('readCodexSessionNameAt', () => {
+  it("reads the thread's own name", async () => {
+    expect(await readCodexSessionNameAt(sock, 'thread-known')).toBe('Named by codex')
+  })
+
+  it('answers null for a nameless or unknown thread, and for a dead server', async () => {
+    // Null means "the node keeps its own title" — never a wrong one.
+    expect(await readCodexSessionNameAt(sock, 'thread-nameless')).toBeNull()
+    expect(await readCodexSessionNameAt(sock, 'thread-from-a-past-life')).toBeNull()
+    expect(await readCodexSessionNameAt(path.join(dir, 'nope.sock'), 'thread-known', 500)).toBeNull()
+  })
+})
+
+describe('codexUnixWebSocketUrl', () => {
+  it('refuses a socket path that could not survive being put in a URL', () => {
+    expect(() => codexUnixWebSocketUrl('relative/app-server.sock')).toThrow()
+    expect(() => codexUnixWebSocketUrl('/tmp/with space/app.sock')).toThrow()
+    expect(() => codexUnixWebSocketUrl('/tmp/a?b/app.sock')).toThrow()
+  })
+})

--- a/src/core/codex-session-name.ts
+++ b/src/core/codex-session-name.ts
@@ -1,0 +1,337 @@
+/**
+ * The desktop's client for the ONE shared `codex app-server`.
+ *
+ * Two jobs, both of which the sh launcher cannot do itself:
+ *  - `startCodexThreadAt` — mint the thread a fresh Codex node will own.
+ *  - `readCodexSessionName` — the READ leg of codex's session name (`TITLE_READ_CAPABLE`).
+ *
+ * The name lives in the app-server's `Thread.name`, not in a file on disk, so this is the only
+ * place it can be read from. There is no WRITE leg: codex has no rename command NodeTerm can
+ * drive, which is exactly the gemini situation `TITLE_READ_CAPABLE` was split out for.
+ *
+ * Everything here fails to `null`/reject rather than throwing into a caller's poll loop: a name we
+ * cannot read means the node keeps its own title, and a thread we cannot start means the launcher
+ * falls back to plain codex.
+ */
+import { homedir } from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+
+const SAFE_THREAD_ID = /^[A-Za-z0-9._-]+$/
+const CACHE_MS = 3_000
+const REQUEST_TIMEOUT_MS = 2_000
+/** Minting a thread is a multi-step conversation with a cold server; it needs a real budget. */
+const START_TIMEOUT_MS = 20_000
+
+const names = new Map<string, { name: string | null; at: number }>()
+const inflight = new Map<string, Promise<string | null>>()
+
+/** The app-server's control socket, under the CLI's own `CODEX_HOME` (default `~/.codex`). */
+export function defaultCodexAppServerSocket(): string {
+  const configured = process.env.CODEX_HOME
+  const codexHome =
+    configured && path.isAbsolute(configured) ? configured : path.join(homedir(), '.codex')
+  return path.join(codexHome, 'app-server-control', 'app-server-control.sock')
+}
+
+export function codexUnixWebSocketUrl(socketPath: string): string {
+  if (!path.isAbsolute(socketPath) || /[\s:%?#]/.test(socketPath)) {
+    throw new Error('Unsupported Codex app-server socket path')
+  }
+  return `ws+unix://${socketPath}:/rpc`
+}
+
+function connectCodexAppServer(socketPath: string): WebSocket {
+  return new WebSocket(codexUnixWebSocketUrl(socketPath), { perMessageDeflate: false })
+}
+
+/** Seed the name cache from a name we were handed out of band (a hook, a bind). */
+export function rememberCodexSessionName(
+  threadId: string,
+  name: unknown,
+  socketPath = defaultCodexAppServerSocket()
+): void {
+  if (!threadId) return
+  const value = typeof name === 'string' && name.trim() ? name.trim() : null
+  names.set(`${socketPath}\0${threadId}`, { name: value, at: Date.now() })
+}
+
+export function readCodexSessionNameAt(
+  socketPath: string,
+  threadId: string,
+  timeoutMs = REQUEST_TIMEOUT_MS
+): Promise<string | null> {
+  if (!SAFE_THREAD_ID.test(threadId)) return Promise.resolve(null)
+  return new Promise((resolve) => {
+    let settled = false
+    let ws: WebSocket
+    const finish = (name: string | null): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {
+        /* the connection may never have opened */
+      }
+      resolve(name)
+    }
+    const timer = setTimeout(() => finish(null), timeoutMs)
+    timer.unref?.()
+    try {
+      ws = connectCodexAppServer(socketPath)
+    } catch {
+      clearTimeout(timer)
+      resolve(null)
+      return
+    }
+    ws.once('open', () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'initialize',
+          params: { clientInfo: { name: 'nodeterm', version: '1' } }
+        })
+      )
+    })
+    ws.on('message', (raw) => {
+      let message: Record<string, any>
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.id === 1) {
+        if (message.error) return finish(null)
+        ws.send(JSON.stringify({ method: 'initialized' }))
+        ws.send(
+          JSON.stringify({
+            id: 2,
+            method: 'thread/read',
+            params: { threadId, includeTurns: false }
+          })
+        )
+      } else if (message.id === 2) {
+        const name = message.result?.thread?.name
+        finish(typeof name === 'string' && name.trim() ? name.trim() : null)
+      }
+    })
+    ws.once('error', () => finish(null))
+    ws.once('close', () => finish(null))
+  })
+}
+
+/**
+ * Create one new, immediately RESUMABLE thread on the shared app-server and return its id.
+ *
+ * `thread/start` alone only creates app-server metadata: it deliberately does not materialize the
+ * rollout file, and a second client's `thread/resume` then fails with "no rollout found" — which
+ * is precisely what the launcher does one line later. So the rollout is materialized by running
+ * one empty turn, interrupting it the moment the server announces it, forking immediately BEFORE
+ * that turn, and deleting the seed. The result is a thread with zero user turns and a valid
+ * rollout, without the deprecated rollback API.
+ */
+export function startCodexThreadAt(
+  socketPath: string,
+  cwd: string,
+  timeoutMs = START_TIMEOUT_MS
+): Promise<string> {
+  if (!path.isAbsolute(cwd) || cwd.includes('\0')) {
+    return Promise.reject(new Error('Unsupported Codex thread cwd'))
+  }
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let ws: WebSocket
+    const finish = (error: Error | null, threadId?: string): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {
+        /* the connection may never have opened */
+      }
+      if (error) reject(error)
+      else resolve(threadId as string)
+    }
+    const timer = setTimeout(
+      () => finish(new Error('Codex app-server thread start timed out')),
+      timeoutMs
+    )
+    timer.unref?.()
+    try {
+      ws = connectCodexAppServer(socketPath)
+    } catch {
+      clearTimeout(timer)
+      reject(new Error('Codex app-server is unavailable'))
+      return
+    }
+    ws.once('open', () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'initialize',
+          params: {
+            clientInfo: { name: 'nodeterm', version: '1' },
+            capabilities: { experimentalApi: true }
+          }
+        })
+      )
+    })
+    let threadId = ''
+    let bootstrapTurnId = ''
+    let announcedBootstrapTurnId = ''
+    let announcedCompletedTurnId = ''
+    let bootstrapStarted = false
+    let interruptSent = false
+    let interruptAcknowledged = false
+    let bootstrapCompleted = false
+    let cleanupForkSent = false
+    const maybeInterrupt = (): void => {
+      if (!bootstrapTurnId || !bootstrapStarted || bootstrapCompleted || interruptSent) return
+      interruptSent = true
+      ws.send(
+        JSON.stringify({
+          id: 4,
+          method: 'turn/interrupt',
+          params: { threadId, turnId: bootstrapTurnId }
+        })
+      )
+    }
+    const maybeCreateCleanThread = (): void => {
+      if (!bootstrapCompleted || cleanupForkSent) return
+      if (interruptSent && !interruptAcknowledged) return
+      cleanupForkSent = true
+      ws.send(
+        JSON.stringify({
+          id: 5,
+          method: 'thread/fork',
+          params: { threadId, beforeTurnId: bootstrapTurnId, cwd, ephemeral: false }
+        })
+      )
+    }
+    ws.on('message', (raw) => {
+      let message: Record<string, any>
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.id === 1) {
+        if (message.error) {
+          finish(new Error('Codex app-server initialization failed'))
+          return
+        }
+        ws.send(JSON.stringify({ method: 'initialized' }))
+        ws.send(JSON.stringify({ id: 2, method: 'thread/start', params: { cwd } }))
+      } else if (message.id === 2) {
+        const startedThreadId = message.result?.thread?.id
+        if (
+          message.error ||
+          typeof startedThreadId !== 'string' ||
+          !SAFE_THREAD_ID.test(startedThreadId)
+        ) {
+          finish(new Error('Codex app-server returned no valid thread identity'))
+          return
+        }
+        threadId = startedThreadId
+        ws.send(JSON.stringify({ id: 3, method: 'turn/start', params: { threadId, input: [] } }))
+      } else if (message.id === 3) {
+        const turnId = message.result?.turn?.id
+        if (message.error || typeof turnId !== 'string' || !SAFE_THREAD_ID.test(turnId)) {
+          finish(new Error('Codex app-server could not materialize the new thread'))
+          return
+        }
+        bootstrapTurnId = turnId
+        if (announcedBootstrapTurnId === turnId) bootstrapStarted = true
+        if (announcedCompletedTurnId === turnId) bootstrapCompleted = true
+        maybeInterrupt()
+        maybeCreateCleanThread()
+      } else if (message.method === 'turn/started') {
+        const turnId = message.params?.turn?.id
+        if (typeof turnId === 'string') {
+          announcedBootstrapTurnId = turnId
+          if (turnId === bootstrapTurnId) {
+            bootstrapStarted = true
+            maybeInterrupt()
+          }
+        }
+      } else if (message.id === 4) {
+        if (message.error) {
+          finish(new Error('Codex app-server could not interrupt thread materialization'))
+          return
+        }
+        interruptAcknowledged = true
+        maybeCreateCleanThread()
+      } else if (message.method === 'turn/completed') {
+        const turnId = message.params?.turn?.id
+        if (typeof turnId === 'string') {
+          announcedCompletedTurnId = turnId
+          if (turnId === bootstrapTurnId) {
+            bootstrapCompleted = true
+            maybeCreateCleanThread()
+          }
+        }
+      } else if (message.id === 5) {
+        const readyThreadId = message.result?.thread?.id
+        if (
+          message.error ||
+          typeof readyThreadId !== 'string' ||
+          !SAFE_THREAD_ID.test(readyThreadId)
+        ) {
+          finish(new Error('Codex app-server could not clean up thread materialization'))
+          return
+        }
+        const seedThreadId = threadId
+        threadId = readyThreadId
+        ws.send(JSON.stringify({ id: 6, method: 'thread/delete', params: { threadId: seedThreadId } }))
+      } else if (message.id === 6) {
+        if (message.error) {
+          finish(new Error('Codex app-server could not remove thread materialization seed'))
+          return
+        }
+        finish(null, threadId)
+      }
+    })
+    ws.once('error', () => finish(new Error('Codex app-server is unavailable')))
+    ws.once('close', () => finish(new Error('Codex app-server closed before thread start')))
+  })
+}
+
+export function startCodexThread(cwd: string): Promise<string> {
+  return startCodexThreadAt(defaultCodexAppServerSocket(), cwd)
+}
+
+/**
+ * The READ leg for `TITLE_READ_CAPABLE`. Memoized for `CACHE_MS` and coalesced, because the
+ * session-name sweep asks once a minute PER NODE and every ask is a socket connect.
+ */
+export function readCodexSessionName(
+  threadId: string,
+  socketPath = defaultCodexAppServerSocket()
+): Promise<string | null> {
+  if (!SAFE_THREAD_ID.test(threadId)) return Promise.resolve(null)
+  const key = `${socketPath}\0${threadId}`
+  const cached = names.get(key)
+  if (cached && Date.now() - cached.at < CACHE_MS) return Promise.resolve(cached.name)
+  const running = inflight.get(key)
+  if (running) return running
+  const request = readCodexSessionNameAt(socketPath, threadId).then(
+    (name) => {
+      names.set(key, { name, at: Date.now() })
+      inflight.delete(key)
+      return name
+    },
+    () => {
+      inflight.delete(key)
+      return null
+    }
+  )
+  inflight.set(key, request)
+  return request
+}
+
+export function forgetCodexSessionNames(): void {
+  names.clear()
+  inflight.clear()
+}

--- a/src/core/codex-session-name.ts
+++ b/src/core/codex-session-name.ts
@@ -22,6 +22,64 @@ import { WebSocket } from 'ws'
 import { CODEX_THREAD_START_TIMEOUT_MS } from './codex-identity-proxy'
 
 const SAFE_THREAD_ID = /^[A-Za-z0-9._-]+$/
+/**
+ * `codex app-server daemon start` exiting 0 does NOT mean its control socket is accepting
+ * connections yet — the daemon binds a beat later. Everything here runs immediately after that
+ * command, on the cold/reboot path this feature exists for, so a single failed connect must not be
+ * read as an answer. Three tries over ~600 ms: long enough for a daemon that is coming up, short
+ * enough that a daemon that is not there costs nothing worth noticing.
+ */
+const SOCKET_WAIT_ATTEMPTS = 3
+const SOCKET_WAIT_MS = 200
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const t = setTimeout(resolve, ms)
+    t.unref?.()
+  })
+
+/** Resolve once the app-server's socket accepts a connection, or after the attempts run out. */
+export function waitForCodexAppServer(
+  socketPath: string,
+  attempts = SOCKET_WAIT_ATTEMPTS,
+  gapMs = SOCKET_WAIT_MS
+): Promise<boolean> {
+  const tryOnce = (): Promise<boolean> =>
+    new Promise((resolve) => {
+      let ws: WebSocket
+      let settled = false
+      const finish = (ok: boolean): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        try {
+          ws.close()
+        } catch {
+          /* the connection may never have opened */
+        }
+        resolve(ok)
+      }
+      const timer = setTimeout(() => finish(false), REQUEST_TIMEOUT_MS)
+      timer.unref?.()
+      try {
+        ws = connectCodexAppServer(socketPath)
+      } catch {
+        clearTimeout(timer)
+        resolve(false)
+        return
+      }
+      ws.once('open', () => finish(true))
+      ws.once('error', () => finish(false))
+      ws.once('close', () => finish(false))
+    })
+  return (async () => {
+    for (let i = 0; i < attempts; i++) {
+      if (await tryOnce()) return true
+      if (i < attempts - 1) await delay(gapMs)
+    }
+    return false
+  })()
+}
 const CACHE_MS = 3_000
 const REQUEST_TIMEOUT_MS = 2_000
 
@@ -124,16 +182,16 @@ export function readCodexSessionNameAt(
  * A server we cannot reach answers `false`, which is the safe direction here: refusing costs a
  * plain codex session, accepting costs the node.
  */
-export function codexThreadExistsAt(
+function probeCodexThread(
   socketPath: string,
   threadId: string,
-  timeoutMs = REQUEST_TIMEOUT_MS
-): Promise<boolean> {
-  if (!SAFE_THREAD_ID.test(threadId)) return Promise.resolve(false)
+  timeoutMs: number
+): Promise<'yes' | 'no' | 'unreachable'> {
   return new Promise((resolve) => {
     let settled = false
+    let answered = false
     let ws: WebSocket
-    const finish = (exists: boolean): void => {
+    const finish = (result: 'yes' | 'no' | 'unreachable'): void => {
       if (settled) return
       settled = true
       clearTimeout(timer)
@@ -142,15 +200,15 @@ export function codexThreadExistsAt(
       } catch {
         /* the connection may never have opened */
       }
-      resolve(exists)
+      resolve(result)
     }
-    const timer = setTimeout(() => finish(false), timeoutMs)
+    const timer = setTimeout(() => finish(answered ? 'no' : 'unreachable'), timeoutMs)
     timer.unref?.()
     try {
       ws = connectCodexAppServer(socketPath)
     } catch {
       clearTimeout(timer)
-      resolve(false)
+      resolve('unreachable')
       return
     }
     ws.once('open', () => {
@@ -170,7 +228,10 @@ export function codexThreadExistsAt(
         return
       }
       if (message.id === 1) {
-        if (message.error) return finish(false)
+        answered = true
+        // A server that will not initialize is a definite NO, not a transient one: retrying a
+        // logged-out CLI just delays the same answer.
+        if (message.error) return finish('no')
         ws.send(JSON.stringify({ method: 'initialized' }))
         ws.send(
           JSON.stringify({ id: 2, method: 'thread/read', params: { threadId, includeTurns: false } })
@@ -178,12 +239,45 @@ export function codexThreadExistsAt(
       } else if (message.id === 2) {
         // The id must come back UNCHANGED: a server that answers with some other thread has not
         // confirmed the one we asked about.
-        finish(!message.error && message.result?.thread?.id === threadId)
+        finish(!message.error && message.result?.thread?.id === threadId ? 'yes' : 'no')
       }
     })
-    ws.once('error', () => finish(false))
-    ws.once('close', () => finish(false))
+    ws.once('error', () => finish(answered ? 'no' : 'unreachable'))
+    ws.once('close', () => finish(answered ? 'no' : 'unreachable'))
   })
+}
+
+/**
+ * Does the shared app-server actually know this thread?
+ *
+ * The bind route writes a record claiming a node owns a conversation. Without this check ANY
+ * id the caller hands us binds happily — a stale session id, or one persisted from a
+ * plain-codex-era session that the app-server has never heard of — and the launcher then execs
+ * `codex --remote unix:// resume <id>`, which dies with "no rollout found" AFTER exec, where
+ * there is no fallback left. Asking first turns that dead node into an ordinary fallback.
+ *
+ * A server we could not REACH is retried (the daemon may still be binding its socket — see
+ * SOCKET_WAIT_ATTEMPTS), because this check runs on the cold path and a not-yet-listening daemon
+ * would otherwise turn a perfectly good resume into a fallback. A server that ANSWERED is never
+ * retried: "I do not have that thread" is an answer, and asking again just delays it.
+ *
+ * Out of retries, the answer is `false` — the safe direction: refusing costs a plain codex
+ * session, accepting costs the node.
+ */
+export async function codexThreadExistsAt(
+  socketPath: string,
+  threadId: string,
+  timeoutMs = REQUEST_TIMEOUT_MS,
+  attempts = SOCKET_WAIT_ATTEMPTS,
+  gapMs = SOCKET_WAIT_MS
+): Promise<boolean> {
+  if (!SAFE_THREAD_ID.test(threadId)) return false
+  for (let i = 0; i < attempts; i++) {
+    const result = await probeCodexThread(socketPath, threadId, timeoutMs)
+    if (result !== 'unreachable') return result === 'yes'
+    if (i < attempts - 1) await delay(gapMs)
+  }
+  return false
 }
 
 export function codexThreadExists(threadId: string): Promise<boolean> {
@@ -200,10 +294,21 @@ export function codexThreadExists(threadId: string): Promise<boolean> {
  * that turn, and deleting the seed. The result is a thread with zero user turns and a valid
  * rollout, without the deprecated rollback API.
  */
-export function startCodexThreadAt(
+export async function startCodexThreadAt(
   socketPath: string,
   cwd: string,
   timeoutMs = CODEX_THREAD_START_TIMEOUT_MS
+): Promise<string> {
+  // Same cold-socket window as the bind check: `daemon start` has exited, the socket may still be
+  // binding. Bounded (~600 ms) and charged against the 20 s budget below, which has room for it.
+  await waitForCodexAppServer(socketPath)
+  return startCodexThreadOnce(socketPath, cwd, timeoutMs)
+}
+
+function startCodexThreadOnce(
+  socketPath: string,
+  cwd: string,
+  timeoutMs: number
 ): Promise<string> {
   if (!path.isAbsolute(cwd) || cwd.includes('\0')) {
     return Promise.reject(new Error('Unsupported Codex thread cwd'))

--- a/src/core/codex-session-name.ts
+++ b/src/core/codex-session-name.ts
@@ -16,12 +16,14 @@
 import { homedir } from 'os'
 import path from 'path'
 import { WebSocket } from 'ws'
+// Minting a thread is a multi-step conversation with a typically COLD server, so it needs a real
+// budget — and the hook route serving it must raise its socket guard to match (handleCodexThread).
+// Shared with the launcher's client budget so the two cannot drift apart.
+import { CODEX_THREAD_START_TIMEOUT_MS } from './codex-identity-proxy'
 
 const SAFE_THREAD_ID = /^[A-Za-z0-9._-]+$/
 const CACHE_MS = 3_000
 const REQUEST_TIMEOUT_MS = 2_000
-/** Minting a thread is a multi-step conversation with a cold server; it needs a real budget. */
-const START_TIMEOUT_MS = 20_000
 
 const names = new Map<string, { name: string | null; at: number }>()
 const inflight = new Map<string, Promise<string | null>>()
@@ -43,17 +45,6 @@ export function codexUnixWebSocketUrl(socketPath: string): string {
 
 function connectCodexAppServer(socketPath: string): WebSocket {
   return new WebSocket(codexUnixWebSocketUrl(socketPath), { perMessageDeflate: false })
-}
-
-/** Seed the name cache from a name we were handed out of band (a hook, a bind). */
-export function rememberCodexSessionName(
-  threadId: string,
-  name: unknown,
-  socketPath = defaultCodexAppServerSocket()
-): void {
-  if (!threadId) return
-  const value = typeof name === 'string' && name.trim() ? name.trim() : null
-  names.set(`${socketPath}\0${threadId}`, { name: value, at: Date.now() })
 }
 
 export function readCodexSessionNameAt(
@@ -122,6 +113,84 @@ export function readCodexSessionNameAt(
 }
 
 /**
+ * Does the shared app-server actually know this thread?
+ *
+ * The bind route writes a record claiming a node owns a conversation. Without this check ANY
+ * id the caller hands us binds happily — a stale session id, or one persisted from a
+ * plain-codex-era session that the app-server has never heard of — and the launcher then execs
+ * `codex --remote unix:// resume <id>`, which dies with "no rollout found" AFTER exec, where
+ * there is no fallback left. Asking first turns that dead node into an ordinary fallback.
+ *
+ * A server we cannot reach answers `false`, which is the safe direction here: refusing costs a
+ * plain codex session, accepting costs the node.
+ */
+export function codexThreadExistsAt(
+  socketPath: string,
+  threadId: string,
+  timeoutMs = REQUEST_TIMEOUT_MS
+): Promise<boolean> {
+  if (!SAFE_THREAD_ID.test(threadId)) return Promise.resolve(false)
+  return new Promise((resolve) => {
+    let settled = false
+    let ws: WebSocket
+    const finish = (exists: boolean): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {
+        /* the connection may never have opened */
+      }
+      resolve(exists)
+    }
+    const timer = setTimeout(() => finish(false), timeoutMs)
+    timer.unref?.()
+    try {
+      ws = connectCodexAppServer(socketPath)
+    } catch {
+      clearTimeout(timer)
+      resolve(false)
+      return
+    }
+    ws.once('open', () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'initialize',
+          params: { clientInfo: { name: 'nodeterm', version: '1' } }
+        })
+      )
+    })
+    ws.on('message', (raw) => {
+      let message: Record<string, any>
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.id === 1) {
+        if (message.error) return finish(false)
+        ws.send(JSON.stringify({ method: 'initialized' }))
+        ws.send(
+          JSON.stringify({ id: 2, method: 'thread/read', params: { threadId, includeTurns: false } })
+        )
+      } else if (message.id === 2) {
+        // The id must come back UNCHANGED: a server that answers with some other thread has not
+        // confirmed the one we asked about.
+        finish(!message.error && message.result?.thread?.id === threadId)
+      }
+    })
+    ws.once('error', () => finish(false))
+    ws.once('close', () => finish(false))
+  })
+}
+
+export function codexThreadExists(threadId: string): Promise<boolean> {
+  return codexThreadExistsAt(defaultCodexAppServerSocket(), threadId)
+}
+
+/**
  * Create one new, immediately RESUMABLE thread on the shared app-server and return its id.
  *
  * `thread/start` alone only creates app-server metadata: it deliberately does not materialize the
@@ -134,7 +203,7 @@ export function readCodexSessionNameAt(
 export function startCodexThreadAt(
   socketPath: string,
   cwd: string,
-  timeoutMs = START_TIMEOUT_MS
+  timeoutMs = CODEX_THREAD_START_TIMEOUT_MS
 ): Promise<string> {
   if (!path.isAbsolute(cwd) || cwd.includes('\0')) {
     return Promise.reject(new Error('Unsupported Codex thread cwd'))
@@ -329,9 +398,4 @@ export function readCodexSessionName(
   )
   inflight.set(key, request)
   return request
-}
-
-export function forgetCodexSessionNames(): void {
-  names.clear()
-  inflight.clear()
 }

--- a/src/core/codex-thread-identity-sh.test.ts
+++ b/src/core/codex-thread-identity-sh.test.ts
@@ -1,0 +1,82 @@
+// The hook prelude, run by the real /bin/sh. It is prepended to every managed hook script, so a
+// quoting slip here does not break "codex identity recovery" — it breaks every agent's hooks on
+// every machine. It is also the one place where a data file's contents become environment
+// variables, which is why the negative cases below matter as much as the positive one.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { codexThreadIdentityResolverSh } from './codex-thread-identity-sh'
+
+const run = promisify(execFile)
+
+let dir = ''
+let root = ''
+let script = ''
+
+beforeAll(() => {
+  // A space in the path on purpose: the real one is macOS's "Application Support".
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm codex prelude '))
+  root = path.join(dir, 'codex-thread-nodes')
+  fs.mkdirSync(root, { recursive: true })
+  script = path.join(dir, 'prelude.sh')
+  fs.writeFileSync(
+    script,
+    `#!/bin/sh\n${codexThreadIdentityResolverSh(root)}\n` +
+      `printf '%s|%s|%s\\n' "\${NODETERM_NODE_ID-}" "\${NODETERM_HOOK_ENDPOINT-}" "\${NODETERM_CANVAS_CONTROL-}"\n`,
+    { mode: 0o755 }
+  )
+})
+
+afterAll(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+function record(threadId: string, body: string): void {
+  fs.writeFileSync(path.join(root, threadId), body)
+}
+
+async function resolve(env: Record<string, string>): Promise<string> {
+  const { stdout } = await run('/bin/sh', [script], {
+    env: { PATH: process.env.PATH ?? '', HOME: dir, ...env }
+  })
+  return stdout.trim()
+}
+
+describe('codex thread identity prelude', () => {
+  it('is valid POSIX sh', async () => {
+    await expect(run('/bin/sh', ['-n', script])).resolves.toBeTruthy()
+  })
+
+  it('recovers the node binding a tool shell never inherited', async () => {
+    record('thread-1', `nodeId=node-7\nendpoint=${dir}/hook-endpoint.env\nsignature=x\n`)
+    expect(await resolve({ CODEX_THREAD_ID: 'thread-1' })).toBe(
+      `node-7|${dir}/hook-endpoint.env|1`
+    )
+  })
+
+  it('changes nothing when the session already knows its node', async () => {
+    record('thread-1', `nodeId=node-7\nendpoint=${dir}/hook-endpoint.env\nsignature=x\n`)
+    expect(await resolve({ CODEX_THREAD_ID: 'thread-1', NODETERM_NODE_ID: 'node-own' })).toBe(
+      'node-own||'
+    )
+  })
+
+  it('is inert for every other agent (no CODEX_THREAD_ID, no record)', async () => {
+    expect(await resolve({})).toBe('||')
+    expect(await resolve({ CODEX_THREAD_ID: 'unknown-thread' })).toBe('||')
+  })
+
+  it('refuses a thread id that could escape the record directory', async () => {
+    expect(await resolve({ CODEX_THREAD_ID: '../../etc/passwd' })).toBe('||')
+  })
+
+  it('exports nothing when a record carries a node id or endpoint it should not', async () => {
+    record('thread-bad-node', `nodeId=node 7; rm -rf /\nendpoint=${dir}/e\n`)
+    expect(await resolve({ CODEX_THREAD_ID: 'thread-bad-node' })).toBe('||')
+    record('thread-bad-ep', 'nodeId=node-7\nendpoint=relative/e\n')
+    expect(await resolve({ CODEX_THREAD_ID: 'thread-bad-ep' })).toBe('||')
+    record('thread-bad-ep2', 'nodeId=node-7\nendpoint=/etc/$(id)\n')
+    expect(await resolve({ CODEX_THREAD_ID: 'thread-bad-ep2' })).toBe('||')
+  })
+})

--- a/src/core/codex-thread-identity-sh.ts
+++ b/src/core/codex-thread-identity-sh.ts
@@ -1,0 +1,58 @@
+/**
+ * POSIX-sh prelude prepended to every managed hook script.
+ *
+ * WHY IT EXISTS: with the shared app-server, the shell a Codex TOOL runs in is spawned by that
+ * server, not by the TUI client NodeTerm launched. It therefore inherits `CODEX_THREAD_ID` but
+ * none of the `NODETERM_*` env we set on the pane — so the hook it runs has no idea which canvas
+ * node it belongs to, and the node's badge/status would simply never move. This recovers the node
+ * binding from the thread id.
+ *
+ * The mapping file is parsed as DATA (`sed`), never sourced as shell code, and both recovered
+ * fields are re-validated before they are exported. The record itself is HMAC-signed by
+ * `codex-identity-proxy.ts`; this prelude cannot verify that signature (no key in an agent's
+ * shell), which is why the charset re-validation below is not redundant.
+ *
+ * Inert for every other agent: without `CODEX_THREAD_ID` the whole block is skipped, and the
+ * generated script is otherwise byte-identical to what it was. That is intentional — the prelude
+ * is prepended once in `buildManagedScript`, so it lands in claude/gemini/codex/grok/opencode
+ * scripts alike rather than in a codex-only fork of the builder.
+ *
+ * Deliberately free of Node/Electron imports beyond the path it is given: the generated-script
+ * cores are shared by the desktop and the Server Edition.
+ */
+import { posixQuote } from '../shared/ssh'
+
+/**
+ * @param identityRoot absolute path of the thread → node record directory
+ *   (`codexThreadIdentityRoot()`, i.e. under `CorePlatform.userDataDir` — NOT `~`).
+ */
+export function codexThreadIdentityResolverSh(identityRoot: string): string {
+  return `# A shared-app-server Codex tool shell inherits CODEX_THREAD_ID, not the TUI client's
+# NODETERM_* env. Recover this thread's exact node binding, or change nothing at all.
+if [ -z "\${NODETERM_NODE_ID-}" ] && [ -n "\${CODEX_THREAD_ID-}" ]; then
+  case "$CODEX_THREAD_ID" in
+    ''|*[!A-Za-z0-9._-]*) ;;
+    *)
+      nt_codex_map=${posixQuote(identityRoot)}/"$CODEX_THREAD_ID"
+      if [ -r "$nt_codex_map" ]; then
+        nt_codex_node=$(sed -n 's/^nodeId=//p' "$nt_codex_map" | head -n 1)
+        nt_codex_endpoint=$(sed -n 's/^endpoint=//p' "$nt_codex_map" | head -n 1)
+        case "$nt_codex_node" in ''|*[!A-Za-z0-9._-]*) nt_codex_node='' ;; esac
+        case "$nt_codex_endpoint" in /*) ;; *) nt_codex_endpoint='' ;; esac
+        if [ -n "$nt_codex_endpoint" ] &&
+           [ "$(printf %s "$nt_codex_endpoint" | tr -cd 'A-Za-z0-9._/ -')" != "$nt_codex_endpoint" ]
+        then
+          nt_codex_endpoint=''
+        fi
+        if [ -n "$nt_codex_node" ] && [ -n "$nt_codex_endpoint" ]; then
+          NODETERM_NODE_ID="$nt_codex_node"
+          NODETERM_HOOK_ENDPOINT="$nt_codex_endpoint"
+          NODETERM_AGENT_ID=codex
+          NODETERM_CANVAS_CONTROL=1
+          export NODETERM_NODE_ID NODETERM_HOOK_ENDPOINT NODETERM_AGENT_ID NODETERM_CANVAS_CONTROL
+        fi
+      fi
+      ;;
+  esac
+fi`
+}

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -53,6 +53,8 @@ import { claudeConfigDirFor } from './claude-config-dir'
 import { findExecutableSync, findInPathString, resolveShellPath, shellPathNow } from './exec-path'
 import { AUTH_ENV_STRIP, accountTmuxEnvArgs, remoteAccountConfigDirAbs } from './claude-accounts-core'
 import { presenceHub } from './presence/hub'
+import { codexLauncherDir, installCodexLauncher } from './codex-identity-proxy'
+import { hasSharedIdentity, type AgentId } from '../shared/agents/config'
 
 // How often we snapshot a live tmux session's scrollback to disk, so a machine reboot (which
 // kills the tmux server) can still replay recent output on cold restart. A final snapshot also
@@ -1574,6 +1576,12 @@ export class PtyManager {
     // Ensure the login-shell PATH is resolved (prewarmed in init(); usually already settled)
     // so the session env below picks it up — awaiting keeps the event loop free either way.
     await resolveShellPath()
+    // Rewrite the launcher on every create: it is generated, so an app upgrade must not leave an
+    // old copy behind. Failure is not fatal — `installCodexLauncher` answers null, the caps probe
+    // says "no shared identity", and the launch line the renderer already chose is the bare CLI.
+    if (hasSharedIdentity((options.agentId ?? 'claude') as AgentId) && !options.sshRemote) {
+      installCodexLauncher()
+    }
     const sessionId = this.spawnSession(options, clientId, undefined)
     const spawned = this.sessions.get(sessionId)
     // Surface a missing-account-dir fallback so the renderer can flag the node's account chip.
@@ -1886,6 +1894,14 @@ export class PtyManager {
         ? hookServer.buildPtyEnv(options.persistKey, options.agentId ?? 'claude', permWaitSecs)
         : {}
     for (const [k, v] of Object.entries(hookEnv)) env[k] = v
+
+    // Shared-identity agents (SHARED_IDENTITY_CAPABLE — never `agentId === 'codex'`) reach their
+    // managed launcher by NAME, so its directory goes first on THIS session's PATH only. A plain
+    // terminal, and every other agent, sees the PATH it always saw. The launcher itself falls back
+    // to the bare CLI, so a session that gets the PATH but no identity is still a working session.
+    if (hasSharedIdentity((options.agentId ?? 'claude') as AgentId) && !options.sshRemote) {
+      env.PATH = `${codexLauncherDir()}${path.delimiter}${env.PATH ?? ''}`
+    }
 
     // Managed Claude account: the whole session runs under the account's private config
     // dir. The claude CLI then reads/writes credentials + transcripts there. Also strip

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -53,7 +53,11 @@ import { claudeConfigDirFor } from './claude-config-dir'
 import { findExecutableSync, findInPathString, resolveShellPath, shellPathNow } from './exec-path'
 import { AUTH_ENV_STRIP, accountTmuxEnvArgs, remoteAccountConfigDirAbs } from './claude-accounts-core'
 import { presenceHub } from './presence/hub'
-import { codexLauncherDir, installCodexLauncher } from './codex-identity-proxy'
+import {
+  codexLauncherDir,
+  forgetCodexThreadIdentitiesForNode,
+  installCodexLauncher
+} from './codex-identity-proxy'
 import { hasSharedIdentity, type AgentId } from '../shared/agents/config'
 
 // How often we snapshot a live tmux session's scrollback to disk, so a machine reboot (which
@@ -3014,6 +3018,10 @@ export class PtyManager {
     // OLD cwd's session, and the respawn is a cold start (`fresh`), so replaying it would paint the
     // pre-move terminal into the new one.
     await deleteScrollback(persistKey)
+    // Same hook, same reason: a permanently deleted node's Codex thread records must go with it.
+    // Left behind they accumulate one file per thread forever, and the hook prelude keeps
+    // re-exporting a dead node's id into any tool shell that still carries that thread id.
+    forgetCodexThreadIdentitiesForNode(persistKey)
     if (sshRemote) {
       // Remote (ssh-project) node: end the REMOTE session.
       const ssh = findSsh()

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -3018,9 +3018,14 @@ export class PtyManager {
     // OLD cwd's session, and the respawn is a cold start (`fresh`), so replaying it would paint the
     // pre-move terminal into the new one.
     await deleteScrollback(persistKey)
-    // Same hook, same reason: a permanently deleted node's Codex thread records must go with it.
-    // Left behind they accumulate one file per thread forever, and the hook prelude keeps
-    // re-exporting a dead node's id into any tool shell that still carries that thread id.
+    // Same hook, same reason as the snapshot above: this node's Codex thread records go with the
+    // session. Left behind they accumulate one file per thread forever, and the hook prelude keeps
+    // re-exporting a DELETED node's id into any tool shell that still carries that thread id.
+    //
+    // Like the snapshot, this also runs for a RECYCLE (the worktree move), where the node lives on
+    // — and that is fine rather than intended: a recycle respawns cold, so the next launch mints or
+    // re-binds a record immediately. Worth stating because the two intents share this line: only
+    // `delete` means "gone for good".
     forgetCodexThreadIdentitiesForNode(persistKey)
     if (sshRemote) {
       // Remote (ssh-project) node: end the REMOTE session.

--- a/src/core/session-name-sweep.test.ts
+++ b/src/core/session-name-sweep.test.ts
@@ -150,22 +150,25 @@ describe('the default supports gate (TITLE_READ_CAPABLE)', () => {
     const { published, asked } = await sweepWithDefaultGate([
       { nodeId: 'c', sessionId: 'cs', agentId: 'claude' },
       { nodeId: 'g', sessionId: 'gs', agentId: 'grok' },
-      { nodeId: 'm', sessionId: 'ms', agentId: 'gemini' }
+      { nodeId: 'm', sessionId: 'ms', agentId: 'gemini' },
+      // codex joined the same way: with the shared app-server its node owns a thread, and that
+      // thread's `Thread.name` is readable over the server's socket. Read-only, like gemini.
+      { nodeId: 'x', sessionId: 'xs', agentId: 'codex' }
     ])
-    expect(asked).toEqual(['cs', 'gs', 'ms'])
+    expect(asked).toEqual(['cs', 'gs', 'ms', 'xs'])
     expect(published).toEqual([
       ['c', 'name of cs'],
       ['g', 'name of gs'],
-      ['m', 'name of ms']
+      ['m', 'name of ms'],
+      ['x', 'name of xs']
     ])
   })
 
   it('never asks about an agent whose name we cannot read', async () => {
-    // codex is in neither list (its command set was not enumerable, so neither leg has a measured
-    // basis) and a custom agent has no reader at all. Asking anyway would send them through
-    // claude's resolver, which SCANS ~/.claude/projects for an id that can never be there.
+    // A custom agent has no reader at all, and an entry with no agentId cannot be routed. Asking
+    // anyway would send them through claude's resolver, which SCANS ~/.claude/projects for an id
+    // that can never be there — once a minute, per node, forever.
     const { published, asked } = await sweepWithDefaultGate([
-      { nodeId: 'x', sessionId: 'xs', agentId: 'codex' },
       { nodeId: 'y', sessionId: 'ys', agentId: 'custom:mine' },
       { nodeId: 'z', sessionId: 'zs' }
     ])

--- a/src/main/codex-node-auth-secret.test.ts
+++ b/src/main/codex-node-auth-secret.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+
+let userData = ''
+let encryptionAvailable = true
+const flip = (value: Buffer) => Buffer.from(value.map((byte) => byte ^ 0xff))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => userData },
+  safeStorage: {
+    isEncryptionAvailable: () => encryptionAvailable,
+    encryptString: (value: string) => flip(Buffer.from(value, 'utf8')),
+    decryptString: (value: Buffer) => flip(value).toString('utf8')
+  }
+}))
+
+import { loadOrCreateCodexNodeAuthSecret, resetCodexNodeAuthSecretForTests } from './codex-node-auth-secret'
+
+const file = () => path.join(userData, 'codex-node-auth-key.json')
+
+describe('Codex node-auth secret', () => {
+  beforeEach(async () => {
+    userData = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-codex-node-auth-'))
+    encryptionAvailable = true
+    resetCodexNodeAuthSecretForTests()
+  })
+
+  afterEach(async () => {
+    await fs.rm(userData, { recursive: true, force: true })
+  })
+
+  it('persists only keychain ciphertext and restores the same secret after restart', async () => {
+    const first = await loadOrCreateCodexNodeAuthSecret()
+    const stored = JSON.parse(await fs.readFile(file(), 'utf8')) as Record<string, unknown>
+    expect(first).toHaveLength(32)
+    expect(stored).toEqual({ version: 1, secretKeyEnc: expect.any(String) })
+    expect(JSON.stringify(stored)).not.toContain(first.toString('base64'))
+    expect((await fs.stat(file())).mode & 0o777).toBe(0o600)
+    resetCodexNodeAuthSecretForTests()
+    expect(await loadOrCreateCodexNodeAuthSecret()).toEqual(first)
+  })
+
+  it('fails closed without an OS keychain and writes no plaintext fallback', async () => {
+    encryptionAvailable = false
+    await expect(loadOrCreateCodexNodeAuthSecret()).rejects.toThrow('OS keychain is unavailable')
+    await expect(fs.access(file())).rejects.toThrow()
+  })
+
+  it('fails closed on malformed persisted state instead of rotating ownership', async () => {
+    await fs.writeFile(file(), '{"version":1,"secretKeyEnc":"broken"}\n', {
+      mode: 0o600
+    })
+    await expect(loadOrCreateCodexNodeAuthSecret()).rejects.toThrow()
+    expect(await fs.readFile(file(), 'utf8')).toBe('{"version":1,"secretKeyEnc":"broken"}\n')
+  })
+})

--- a/src/main/codex-node-auth-secret.ts
+++ b/src/main/codex-node-auth-secret.ts
@@ -1,0 +1,84 @@
+import { randomBytes } from 'crypto'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { app, safeStorage } from 'electron'
+
+type StoredSecret = { version: 1; secretKeyEnc: string }
+
+let cached: Promise<Buffer> | null = null
+let cachedFile = ''
+
+function secretFile(): string {
+  return path.join(app.getPath('userData'), 'codex-node-auth-key.json')
+}
+
+function decode(raw: string): Buffer {
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error('OS keychain is unavailable')
+  }
+  let stored: StoredSecret
+  try {
+    stored = JSON.parse(raw) as StoredSecret
+  } catch {
+    throw new Error('Codex node-auth key is malformed')
+  }
+  if (stored?.version !== 1 || typeof stored.secretKeyEnc !== 'string') {
+    throw new Error('Codex node-auth key is malformed')
+  }
+  const secret = Buffer.from(safeStorage.decryptString(Buffer.from(stored.secretKeyEnc, 'base64')), 'base64')
+  if (secret.byteLength !== 32) throw new Error('Codex node-auth key is invalid')
+  return secret
+}
+
+async function persist(file: string, secret: Buffer): Promise<void> {
+  if (!safeStorage.isEncryptionAvailable()) throw new Error('OS keychain is unavailable')
+  const body: StoredSecret = {
+    version: 1,
+    secretKeyEnc: safeStorage.encryptString(secret.toString('base64')).toString('base64')
+  }
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`
+  await fs.mkdir(path.dirname(file), { recursive: true })
+  try {
+    await fs.writeFile(tmp, `${JSON.stringify(body)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+      flag: 'wx'
+    })
+    await fs.rename(tmp, file)
+    await fs.chmod(file, 0o600)
+  } finally {
+    await fs.unlink(tmp).catch(() => {})
+  }
+}
+
+async function load(file: string): Promise<Buffer> {
+  try {
+    return decode(await fs.readFile(file, 'utf8'))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  const secret = randomBytes(32)
+  await persist(file, secret)
+  return secret
+}
+
+/** Restart-stable node-capability key. Ciphertext only at rest; no plaintext fallback. */
+export function loadOrCreateCodexNodeAuthSecret(): Promise<Buffer> {
+  const file = secretFile()
+  if (cached && cachedFile === file) return cached
+  const pending = load(file)
+  cached = pending
+  cachedFile = file
+  pending.catch(() => {
+    if (cached === pending) {
+      cached = null
+      cachedFile = ''
+    }
+  })
+  return pending
+}
+
+export function resetCodexNodeAuthSecretForTests(): void {
+  cached = null
+  cachedFile = ''
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,7 +130,7 @@ import {
   setCodexThreadIdentityAuthSecret,
   writeCodexThreadIdentity
 } from '../core/codex-identity-proxy'
-import { startCodexThread } from '../core/codex-session-name'
+import { codexThreadExists, startCodexThread } from '../core/codex-session-name'
 import { loadOrCreateCodexNodeAuthSecret } from './codex-node-auth-secret'
 import { claudeConfigDirFor } from '../core/claude-config-dir'
 import {
@@ -916,7 +916,11 @@ app.whenReady().then(async () => {
   } catch (error) {
     console.error('[codex-identity] unavailable; Codex nodes run plain codex:', error)
   }
-  // Installs the launcher and answers the renderer's construction-time question.
+  // Installs the launcher and publishes the construction-time answer. MUST stay after the secret
+  // above and before the window: it is what unblocks `codexIdentityCaps()`, which the renderer's
+  // first Codex launch line waits on. Reordering it later only delays that answer now (callers
+  // wait rather than being told "no"), but leaving it out entirely would stall them until their
+  // own timeout, so it is not optional.
   refreshCodexIdentityCaps()
   hookServer.setCodexIdentityListener((ev) => sendToMain(IPC.codexIdentity, ev))
   // A node still on a canvas is "live". A thread whose recorded owner is gone (node deleted, or a
@@ -929,6 +933,14 @@ app.whenReady().then(async () => {
     return threadId
   })
   hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, hookEndpoint }) => {
+    // Ask the app-server whether this conversation exists BEFORE recording that a node owns it.
+    // The id reaching us is whatever the node persisted — it can be stale, or from a session that
+    // ran under plain codex and the shared server has never heard of. Binding it anyway writes a
+    // record and then execs `codex --remote unix:// resume <id>`, which dies with "no rollout
+    // found" AFTER exec, where nothing can fall back any more. Refusing here IS the fallback.
+    if (!(await codexThreadExists(threadId))) {
+      throw new Error('Codex thread is unknown to the shared app-server')
+    }
     bindCodexThreadIdentity(threadId, nodeId, hookEndpoint, codexNodeIsLive)
   })
   // SSH_ASKPASS relay (ssh-project.ts): lets the ControlMaster, which has no tty, route a

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -916,12 +916,14 @@ app.whenReady().then(async () => {
   } catch (error) {
     console.error('[codex-identity] unavailable; Codex nodes run plain codex:', error)
   }
-  // Installs the launcher and publishes the construction-time answer. MUST stay after the secret
-  // above and before the window: it is what unblocks `codexIdentityCaps()`, which the renderer's
-  // first Codex launch line waits on. Reordering it later only delays that answer now (callers
-  // wait rather than being told "no"), but leaving it out entirely would stall them until their
-  // own timeout, so it is not optional.
-  refreshCodexIdentityCaps()
+  // Probes the CLI for `--remote`, installs the launcher, and publishes the construction-time
+  // answer. MUST stay after the secret above and before the window: it is what unblocks
+  // `codexIdentityCaps()`, which the renderer's first Codex launch line waits on. NOT awaited —
+  // the probe is a login-shell lookup plus up to two `--help` spawns, and nothing in the boot
+  // chain should queue behind it; callers of `codexIdentityCaps()` wait for it instead of being
+  // told "no". Reordering it later only delays that answer; leaving it out would stall those
+  // callers until their own timeout, so it is not optional.
+  void refreshCodexIdentityCaps()
   hookServer.setCodexIdentityListener((ev) => sendToMain(IPC.codexIdentity, ev))
   // A node still on a canvas is "live". A thread whose recorded owner is gone (node deleted, or a
   // workspace that no longer holds it) is free to be re-claimed; one whose owner is still there is

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -124,6 +124,14 @@ import { SpeechService } from '../core/speech/speech-service'
 import { registerSpeechIpc } from '../core/speech/register-ipc'
 import { initClaudeAccounts } from './claude-accounts'
 import { claudeCliCaps, registerClaudeCliIpc, type ClaudeCliCaps } from '../core/claude-cli'
+import { refreshCodexIdentityCaps, registerCodexIdentityIpc } from '../core/codex-identity-caps'
+import {
+  bindCodexThreadIdentity,
+  setCodexThreadIdentityAuthSecret,
+  writeCodexThreadIdentity
+} from '../core/codex-identity-proxy'
+import { startCodexThread } from '../core/codex-session-name'
+import { loadOrCreateCodexNodeAuthSecret } from './codex-node-auth-secret'
 import { claudeConfigDirFor } from '../core/claude-config-dir'
 import {
   isSafeLocalTranscriptPath,
@@ -548,6 +556,7 @@ app.whenReady().then(async () => {
     process.platform === 'darwin' ? systemPreferences.askForMediaAccess('microphone') : true
   )
   registerClaudeCliIpc()
+  registerCodexIdentityIpc()
   // Warm the `claude --version` probe now (it spawns a login shell + node, ~sub-second) so the
   // renderer's first `claude.cliCaps()` — awaited on the launch path of a cold-restored agent
   // node — resolves from cache instead of racing the probe into a conservative "no auto".
@@ -894,6 +903,34 @@ app.whenReady().then(async () => {
   // listeners (setListener/setRawListener/setControlHandler) attach later, which the server
   // tolerates — early hook POSTs are simply dropped, never mis-routed.
   await hookServer.start()
+  // ---- Codex shared identity (src/core/codex-identity-proxy.ts) -------------------------------
+  // One keychain-backed secret does two jobs: it mints the per-node capability the identity routes
+  // require (closing the "shared bearer can name any sibling node" hole) and it signs the thread →
+  // node records the hook prelude reads back. If secure storage is unavailable the whole feature
+  // stays OFF — `codexIdentityCaps()` then answers `shared: false`, every launch line stays the
+  // bare `codex`, and nothing is half-armed.
+  try {
+    const codexNodeAuthSecret = await loadOrCreateCodexNodeAuthSecret()
+    hookServer.setCodexNodeAuthSecret(codexNodeAuthSecret)
+    setCodexThreadIdentityAuthSecret(codexNodeAuthSecret)
+  } catch (error) {
+    console.error('[codex-identity] unavailable; Codex nodes run plain codex:', error)
+  }
+  // Installs the launcher and answers the renderer's construction-time question.
+  refreshCodexIdentityCaps()
+  hookServer.setCodexIdentityListener((ev) => sendToMain(IPC.codexIdentity, ev))
+  // A node still on a canvas is "live". A thread whose recorded owner is gone (node deleted, or a
+  // workspace that no longer holds it) is free to be re-claimed; one whose owner is still there is
+  // not, and the launcher then falls back rather than putting two clients on one conversation.
+  const codexNodeIsLive = (nodeId: string): boolean => !!workspaceStore.getNode(nodeId)
+  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd, hookEndpoint }) => {
+    const threadId = await startCodexThread(cwd)
+    writeCodexThreadIdentity(threadId, nodeId, hookEndpoint)
+    return threadId
+  })
+  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, hookEndpoint }) => {
+    bindCodexThreadIdentity(threadId, nodeId, hookEndpoint, codexNodeIsLive)
+  })
   // SSH_ASKPASS relay (ssh-project.ts): lets the ControlMaster, which has no tty, route a
   // passphrase-protected identity file's prompt back through the app instead of failing auth.
   // MUST NOT be fatal: binding a unix socket under ~/.nodeterm can fail for filesystem reasons

--- a/src/main/remote-ssh/remote-hooks.ts
+++ b/src/main/remote-ssh/remote-hooks.ts
@@ -9,6 +9,16 @@ import { childArgs, hookForwardArgs, hookForwardCancelArgs, remoteEndpointFileCo
 import { CLAUDE_HOOK_EVENTS, GEMINI_HOOK_EVENTS, GROK_HOOK_EVENTS } from '@shared/agents/hook-events'
 import { GROK_HOOK_FILE, isSafeRemoteGrokHome } from '../../core/agents/grok-paths'
 import { buildManagedScript } from '../../core/agents/hooks/managed-script'
+
+/**
+ * Remote hook scripts get NO Codex thread-identity root.
+ *
+ * The default root is THIS machine's data dir, and baking it into a script written to someone
+ * else's host puts a path like `/Users/<you>/Library/Application Support/…` on that host — inert
+ * (nothing there can read it) but a needless leak of the desktop's layout. Shared identity for SSH
+ * hosts is a later slice; when it lands, this becomes the REMOTE host's root, not null.
+ */
+const REMOTE_IDENTITY_ROOT = null
 import { buildManagedHookCommand, mergeManagedHook, type HookSettings } from '../../core/agents/hooks/install-helper'
 import {
   buildCodexHooksAndTrust,
@@ -131,7 +141,7 @@ export class RemoteHooks {
         const config = `${home}/${t.config}`
         await this.r.run(
           childArgs(conn, controlPath, `mkdir -p ${remoteDir}/agent-hooks && cat > ${script} && chmod 755 ${script}`),
-          buildManagedScript(t.agentId)
+          buildManagedScript(t.agentId, REMOTE_IDENTITY_ROOT)
         )
         const { stdout: cfgRaw } = await this.r.run(childArgs(conn, controlPath, `cat ${config} 2>/dev/null || echo '{}'`))
         let cfg: HookSettings = {}
@@ -187,7 +197,7 @@ export class RemoteHooks {
           controlPath,
           `mkdir -p ${posixQuote(`${remoteDir}/agent-hooks`)} && cat > ${posixQuote(script)} && chmod 755 ${posixQuote(script)}`
         ),
-        buildManagedScript('codex')
+        buildManagedScript('codex', REMOTE_IDENTITY_ROOT)
       )
       const command = buildCodexManagedCommand(script)
       const codexHome = `${home}/.codex`
@@ -286,7 +296,7 @@ export class RemoteHooks {
           controlPath,
           `mkdir -p ${posixQuote(`${remoteDir}/agent-hooks`)} && cat > ${posixQuote(script)} && chmod 755 ${posixQuote(script)}`
         ),
-        buildManagedScript('grok')
+        buildManagedScript('grok', REMOTE_IDENTITY_ROOT)
       )
       // `|| echo '{}'` fires ONLY when the file is missing — still the read that distinguishes a
       // missing file from an unreadable one. An unreadable one is then HEALED, not preserved: this
@@ -337,7 +347,7 @@ export class RemoteHooks {
       // Idempotently (re)write the shared hook script — setup() may not have run (fail-open) yet.
       await this.r.run(
         childArgs(conn, controlPath, `mkdir -p ${posixQuote(`${remoteDir}/agent-hooks`)} && cat > ${posixQuote(script)} && chmod 755 ${posixQuote(script)}`),
-        buildManagedScript('claude')
+        buildManagedScript('claude', REMOTE_IDENTITY_ROOT)
       )
       const { stdout: cfgRaw } = await this.r.run(
         childArgs(conn, controlPath, `cat ${posixQuote(config)} 2>/dev/null || echo '{}'`)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -422,6 +422,14 @@ const api: NodeTerminalApi = {
       return () => ipcRenderer.removeListener(IPC.canvasMut, handler)
     }
   },
+  codex: {
+    identityCaps: () => ipcRenderer.invoke(IPC.codexIdentityCaps),
+    onIdentity: (listener) => {
+      const handler = (_e: unknown, payload: Parameters<typeof listener>[0]) => listener(payload)
+      ipcRenderer.on(IPC.codexIdentity, handler)
+      return () => ipcRenderer.removeListener(IPC.codexIdentity, handler)
+    }
+  },
   claude: {
     cliCaps: () => ipcRenderer.invoke(IPC.claudeCliCaps),
     readTranscript: (sessionId, cwd, accountId, nodeId) =>

--- a/src/renderer/boot.tsx
+++ b/src/renderer/boot.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import { ensureClaudeCliCaps } from './state/permissionMode'
+import { ensureCodexIdentityCaps } from './state/codexIdentity'
 import './styles.css'
 import './tailwind.css'
 
@@ -10,6 +11,11 @@ import './tailwind.css'
 // conservatively omit the flag. The shell warms the same memo at startup, so this normally
 // resolves immediately.
 void ensureClaudeCliCaps()
+
+// Same shape, same reason: a Codex launch line names the managed shared-identity launcher only if
+// this machine has one installed and armed. Unprobed ⇒ plain `codex`, which is what every Codex
+// node ran before this feature — never a launcher path that might not resolve.
+void ensureCodexIdentityCaps()
 
 // Note: StrictMode is intentionally not used — its double mount in dev would open
 // two PTY sessions per terminal node.

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -16,6 +16,7 @@
 
 import {
   UNKNOWN_CLAUDE_CLI_CAPS,
+  UNKNOWN_CODEX_IDENTITY_CAPS,
   type ClaudeUsage,
   type NodeTerminalApi,
   type NotifyPayload,
@@ -256,6 +257,13 @@ export function buildStubApi(): Omit<
       // measure" — the one honest answer, and never mistakable for "nothing is using memory".
       read: () => Promise.resolve({ ok: false, rows: [], mem: null }),
       host: () => Promise.resolve(null)
+    },
+    codex: {
+      // Overridden by the real WS-backed namespace in ws-bridge. The stub's answer is the same
+      // one the Server Edition gives on purpose (see server/handlers/index.ts): no shared
+      // identity, so every Codex launch line stays the bare `codex`.
+      identityCaps: () => Promise.resolve(UNKNOWN_CODEX_IDENTITY_CAPS),
+      onIdentity: noopUnsub
     },
     claude: {
       // Overridden by the real WS-backed namespace in ws-bridge; the stub still answers with the

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -22,6 +22,9 @@ import {
   type ChatTranscriptResult,
   type ClaudeApi,
   type ClaudeCliCaps,
+  type CodexApi,
+  type CodexIdentityCaps,
+  UNKNOWN_CODEX_IDENTITY_CAPS,
   type ContextApi,
   type DownloadTicket,
   type FilesApi,
@@ -659,6 +662,22 @@ export function buildSessionMemoryApi(client: RpcClient): Pick<NodeTerminalApi, 
  * only real member is a capability probe — the Server Edition gets the real reader from
  * `buildTranscriptApi` below instead, which the relay does not use.
  */
+/**
+ * The `codex` namespace over an RpcClient — a REAL implementation, not a stub, because the answer
+ * has to come from the machine the pty runs on. Today the Server Edition's handler deliberately
+ * answers `{ shared: false }` (see server/handlers/index.ts); wiring that side later needs nothing
+ * here. A failed request degrades to the same conservative answer: the launch path reads it.
+ */
+export function buildCodexApi(client: RpcClient): CodexApi {
+  return {
+    identityCaps: () =>
+      (client.request(IPC.codexIdentityCaps) as Promise<CodexIdentityCaps>).catch(
+        () => UNKNOWN_CODEX_IDENTITY_CAPS
+      ),
+    onIdentity: (listener) => client.subscribe(IPC.codexIdentity, listener as Listener)
+  }
+}
+
 export function buildClaudeApi(client: RpcClient, stub: ClaudeApi): ClaudeApi {
   return {
     ...stub,
@@ -819,6 +838,7 @@ export async function installWsBridge(): Promise<boolean> {
     ...buildUsageApi(client),
     ...buildSessionMemoryApi(client),
     ...buildGitHubApi(client),
+    codex: buildCodexApi(client),
     // `claude` is assembled from two builders: `cliCaps` from the relay-shared one, and the
     // transcript reader from the Server-Edition-only one (which also supplies `chat`).
     ...(() => {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -190,6 +190,7 @@ import { opensInEditor } from '../lib/openTarget'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
 import { useProjects } from '../state/projects'
 import { useAgentStatus } from '../state/agentStatus'
+import { useCodexIdentity, codexFallbackText } from '../state/codexIdentity'
 import { useTeamAccessEvents } from '../state/teamAccess'
 import { useAgentNodes } from '../state/agentNodes'
 import { SubagentNode } from '../nodes/SubagentNode'
@@ -691,9 +692,10 @@ export function Canvas() {
   // told here rather than being left with a note their teammates never see. Dismissible; re-armed
   // by the next refused cast (the publisher keeps retrying that node, so it syncs once trimmed).
   const [syncNote, setSyncNote] = useState<string | null>(null)
-  // Copy-to-clipboard failure (browser build only): the bridge clipboard stub dispatches
-  // `nodeterm:toast` when neither the Clipboard API nor execCommand can copy — typically a
-  // non-secure context (plain http over a LAN). It must be seen, not swallowed.
+  // A transient warning banner. Two producers, both of which must be SEEN rather than swallowed:
+  // a copy-to-clipboard failure (browser build only — the bridge clipboard stub dispatches
+  // `nodeterm:toast` when neither the Clipboard API nor execCommand can copy, typically a
+  // non-secure context over a LAN), and a Codex node reporting that it fell back to plain codex.
   const [copyError, setCopyError] = useState<string | null>(null)
   // Cmd+V only drops an image on the canvas when the LAST pointer press was on the pane itself —
   // otherwise a paste aimed at a panel or a dialog would spawn a node behind it. See
@@ -948,6 +950,20 @@ export function Canvas() {
     }
     window.addEventListener('nodeterm:toast', onToast)
     return () => window.removeEventListener('nodeterm:toast', onToast)
+  }, [])
+  // A Codex node's launcher reporting what it actually got. The 'plain' case is the fallback, and
+  // this is what stops it being silent: the node keeps a chip (see TerminalNode's header) and the
+  // FIRST fallback per node also raises a toast, because a chip on a node you are not looking at
+  // teaches nothing. Deliberately NOT written into the pane — text pushed into an agent's terminal
+  // is prompt injection, which this repo forbids.
+  useEffect(() => {
+    const seen = new Set<string>()
+    return window.nodeTerminal.codex.onIdentity((e) => {
+      useCodexIdentity.getState().setMode(e.nodeId, e.mode, e.reason)
+      if (e.mode !== 'plain' || seen.has(e.nodeId)) return
+      seen.add(e.nodeId)
+      setCopyError(codexFallbackText(e.reason))
+    })
   }, [])
   // Terminal node id awaiting confirmation to move into its group's worktree.
   const [moveTarget, setMoveTargetState] = useState<string | null>(null)

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -126,6 +126,7 @@ import { isHidden } from '../lib/ui-visibility'
 import { readsClaudeTranscript } from '../lib/transcriptGates'
 import { liveProjectJumpTarget } from '../lib/projectJump'
 import { useSettings } from '../state/settings'
+import { useCodexIdentity, codexSharedIdentity, codexFallbackText } from '../state/codexIdentity'
 import { useAgentStatus, agentStatusForApi, inferInterruptAfterSettle } from '../state/agentStatus'
 import type { AgentState } from '@shared/agents/normalize'
 import type { ClientId } from '@shared/presence'
@@ -138,7 +139,7 @@ import { useWorktrees } from '../state/worktrees'
 import { isRemoteSessionNode } from '@shared/worktree'
 import { useSession, useActiveSessionPresence } from '../session/session'
 import { accountChipLabel, COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from '../state/workspace'
-import { hasHooks, canRecur, canContextLink, hasUsage, canChat, canResume, canRename, canReadTitle, createdAgentId, reportsOwnCopy, resumeCommand, agentConfig } from '@shared/agents/config'
+import { hasHooks, canRecur, canContextLink, hasUsage, canChat, canResume, canRename, canReadTitle, createdAgentId, reportsOwnCopy, resumeCommand, agentConfig, agentLaunchProgram } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
 import { ensureActivePermissionMode } from '../state/permissionMode'
 import { buildSshArgs, type SshConnection } from '@shared/ssh'
@@ -1221,6 +1222,9 @@ export function TerminalNode({
     !remoteSession &&
     (data.cwd as string | undefined) !== parentWtPath
   const status = useAgentStatus((s) => s.byId[id])
+  // Transient, per-launch: what this node's Codex launcher reported it actually got. Undefined for
+  // every non-codex node and for a codex node whose launcher never spoke.
+  const codexIdentity = useCodexIdentity((s) => s.byId[id])
   // --- Eco / hibernation wake (see terminal/hibernation-policy.ts) ---
   // A hibernated node's CLI was asked to `/exit` while nobody was looking; its tmux session, pane
   // and scrollback are untouched, and the conversation comes back with the provider's own
@@ -2681,7 +2685,14 @@ export function TerminalNode({
           // relaunched empty while their transcripts sat on disk, unreachable.
           const st = useAgentStatus.getState().byId[id]
           const priorId = st?.sessionId || data.agentSessionId
-          const base = (priorId && resumeCommand(agentId, priorId)) || agentConfig(agentId)?.launchCmd
+          // Shared-identity agents resume THROUGH their launcher, so the cold-restored node
+          // re-claims its own thread instead of joining as an anonymous client. `data.ssh` is what
+          // keeps a remote node on the bare command (no launcher on the host).
+          const shared = codexSharedIdentity(data.ssh || data.sshRemoteTmux)
+          const base =
+            (priorId && resumeCommand(agentId, priorId, shared)) ||
+            (agentConfig(agentId) &&
+              agentLaunchProgram(agentId, agentConfig(agentId)!.launchCmd, shared))
           // Re-resolve the mode at relaunch: it's a property of how a session is launched, not
           // a persisted property of the node, so the current setting wins after a reboot. `base`
           // is always freshly built here — never a command string read back from node data — so
@@ -2847,6 +2858,11 @@ export function TerminalNode({
         // Same funnel, same await, same reasoning as the restart closure above: the permission
         // mode is a property of how a session is LAUNCHED, so it is re-resolved now (a wake can be
         // hours after the exit, and days after the node was created).
+        // Deliberately the BARE command, with no shared-identity launcher: this types into a pane
+        // that already exists, and a tmux session created before the launcher was installed does
+        // not carry its directory on PATH — naming it there would be `command not found` where a
+        // plain `codex resume` works. A restarted codex node therefore rejoins as a plain client
+        // until its next cold start. Fail open, same rule as everywhere else in this feature.
         const base = resumeCommand(agentId, agentSessionId)
         // Refused BEFORE anything is written. `performResumePhase` gates on this same bare command
         // and would refuse too — but the KILL_LINE below is ours, so leaving this check to it
@@ -3960,6 +3976,18 @@ export function TerminalNode({
         {status?.session && status.session !== data.title && (
           <span className="term-node__session" title={status.session}>
             {status.session}
+          </span>
+        )}
+        {/* The fallback, made visible. A Codex node that could not get a managed shared identity
+            runs a perfectly good plain `codex` — but the user has to be able to SEE that it did,
+            without reading a log, so the chip states it and its tooltip says why. Absent (and the
+            node byte-identical to before this feature) whenever identity is shared or unknown. */}
+        {codexIdentity?.mode === 'plain' && (
+          <span
+            className="node-account-chip node-account-chip--warning"
+            title={codexFallbackText(codexIdentity.reason)}
+          >
+            plain codex
           </span>
         )}
         {accountChip && (

--- a/src/renderer/state/codexIdentity.ts
+++ b/src/renderer/state/codexIdentity.ts
@@ -67,7 +67,6 @@ export type CodexIdentityMode = 'shared' | 'plain'
 interface CodexIdentityState {
   byId: Record<string, { mode: CodexIdentityMode; reason?: string }>
   setMode(nodeId: string, mode: CodexIdentityMode, reason?: string): void
-  clear(nodeId: string): void
 }
 
 export const useCodexIdentity = create<CodexIdentityState>((set) => ({
@@ -77,13 +76,6 @@ export const useCodexIdentity = create<CodexIdentityState>((set) => ({
       const prev = s.byId[nodeId]
       if (prev?.mode === mode && prev.reason === reason) return s
       return { byId: { ...s.byId, [nodeId]: { mode, reason } } }
-    }),
-  clear: (nodeId) =>
-    set((s) => {
-      if (!(nodeId in s.byId)) return s
-      const byId = { ...s.byId }
-      delete byId[nodeId]
-      return { byId }
     })
 }))
 

--- a/src/renderer/state/codexIdentity.ts
+++ b/src/renderer/state/codexIdentity.ts
@@ -1,0 +1,105 @@
+/**
+ * The renderer's half of the Codex shared-identity fallback.
+ *
+ * TWO questions, and they are not the same one:
+ *
+ *  1. "Should this launch line name the managed launcher?" — answered BEFORE the node exists, by
+ *     `codexSharedIdentity(ssh)` below. Same shape as the `--permission-mode auto` gate: a
+ *     memoized shell probe whose unknown answer is the conservative one, so an unprobed or failed
+ *     machine emits the bare `codex` it always did rather than a launcher path that may not
+ *     resolve. That is the difference between "no shared identity" and "a dead node".
+ *
+ *  2. "What did this node ACTUALLY get?" — answered AFTER it launched, by the node's own launcher
+ *     (`codex-identity:event`). Only the launcher can see the pane's env, whether the endpoint
+ *     file was readable, or whether the installed `codex` even has an app-server, so the script
+ *     is the authority and question 1 is only an optimistic gate in front of it.
+ *
+ * The mode is TRANSIENT — never persisted. It describes one launch of one process; a node reloaded
+ * from disk has not launched anything yet, and a stale "plain" badge on it would be a lie.
+ */
+import { create } from 'zustand'
+import { UNKNOWN_CODEX_IDENTITY_CAPS, type CodexIdentityCaps } from '@shared/types'
+
+const CAPS_WAIT_MS = 3000
+
+let caps: CodexIdentityCaps = UNKNOWN_CODEX_IDENTITY_CAPS
+let capsPromise: Promise<CodexIdentityCaps> | null = null
+
+/** Probe once per app run. Never rejects; a slow bridge resolves to what we have so far. */
+export function ensureCodexIdentityCaps(): Promise<CodexIdentityCaps> {
+  if (!capsPromise) {
+    const probe = Promise.resolve()
+      .then(() => window.nodeTerminal.codex.identityCaps())
+      .then((c) => (caps = c ?? UNKNOWN_CODEX_IDENTITY_CAPS))
+      .catch(() => UNKNOWN_CODEX_IDENTITY_CAPS)
+    const timeout = new Promise<CodexIdentityCaps>((resolve) =>
+      setTimeout(() => resolve(caps), CAPS_WAIT_MS)
+    )
+    capsPromise = Promise.race([probe, timeout])
+  }
+  return capsPromise
+}
+
+export function codexIdentityCapsNow(): CodexIdentityCaps {
+  return caps
+}
+
+/**
+ * Should a node use the shared-identity launcher? `remote` is anything truthy that marks the
+ * session as running on another machine (`project.ssh`, `data.ssh`, `data.sshRemoteTmux` — the
+ * caller passes whichever it holds; only its truthiness is read).
+ *
+ * An SSH project's session runs on the HOST, which has no launcher installed (that is a later
+ * slice), so a launcher-named launch line there would be `command not found` — a dead node, the
+ * exact failure this whole fallback exists to prevent. Remote ⇒ plain codex.
+ */
+export function codexSharedIdentity(remote?: unknown): boolean {
+  return !remote && codexIdentityCapsNow().shared
+}
+
+export function resetCodexIdentityCapsForTests(next?: CodexIdentityCaps): void {
+  caps = next ?? UNKNOWN_CODEX_IDENTITY_CAPS
+  capsPromise = null
+}
+
+export type CodexIdentityMode = 'shared' | 'plain'
+
+interface CodexIdentityState {
+  byId: Record<string, { mode: CodexIdentityMode; reason?: string }>
+  setMode(nodeId: string, mode: CodexIdentityMode, reason?: string): void
+  clear(nodeId: string): void
+}
+
+export const useCodexIdentity = create<CodexIdentityState>((set) => ({
+  byId: {},
+  setMode: (nodeId, mode, reason) =>
+    set((s) => {
+      const prev = s.byId[nodeId]
+      if (prev?.mode === mode && prev.reason === reason) return s
+      return { byId: { ...s.byId, [nodeId]: { mode, reason } } }
+    }),
+  clear: (nodeId) =>
+    set((s) => {
+      if (!(nodeId in s.byId)) return s
+      const byId = { ...s.byId }
+      delete byId[nodeId]
+      return { byId }
+    })
+}))
+
+/** Human copy for the reasons the generated launcher can report. */
+export const CODEX_FALLBACK_REASONS: Record<string, string> = {
+  'node-id-unavailable': 'this session was not started by nodeterm',
+  'hook-endpoint-unavailable': "nodeterm's hook endpoint was unreadable",
+  'broker-unreachable': "nodeterm's hook server was unreachable",
+  'node-token-unavailable': 'this build could not mint a node identity key',
+  'thread-id-unavailable': 'the session id to resume was not usable',
+  'app-server-unavailable': 'this codex CLI has no shared app-server',
+  'thread-bind-refused': 'another live node already owns that conversation',
+  'thread-start-failed': 'the shared app-server would not start a conversation'
+}
+
+export function codexFallbackText(reason?: string): string {
+  const why = (reason && CODEX_FALLBACK_REASONS[reason]) || 'the managed identity was unavailable'
+  return `Running plain codex — ${why}.`
+}

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -1,10 +1,11 @@
 import type { Node } from '@xyflow/react'
 import type { CanvasMutation, CanvasNodeState, ClaudeAccount, NodeKind, PendingLaunch, Project } from '@shared/types'
 import type { AgentId, AgentPermissionMode } from '@shared/agents/config'
-import { agentConfig, mintsSessionId, withSessionId } from '@shared/agents/config'
+import { agentConfig, agentLaunchProgram, mintsSessionId, withSessionId } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
 import { uuid } from '@renderer/lib/uuid'
 import { claudeCliCapsNow } from './permissionMode'
+import { codexSharedIdentity } from './codexIdentity'
 import { sshHostKey } from '@shared/ssh'
 import { useSettings } from './settings'
 
@@ -338,7 +339,14 @@ export function createAgentNode(
   permissionMode?: AgentPermissionMode
 ): CanvasNode {
   const { label, color, launchCmd } = resolveAgent(agentId)
-  const baseCmd = agentId === 'claude' ? claudeLaunchCommand() : launchCmd
+  // A SHARED_IDENTITY_CAPABLE agent (codex) launches through its managed launcher when this
+  // machine actually has one — otherwise the bare CLI, byte-identical to before. Asked through the
+  // capability helper, never `agentId === 'codex'`; `codexSharedIdentity` folds in the SSH answer
+  // (a host has no launcher installed yet, so a remote node must stay on the bare command).
+  const baseCmd =
+    agentId === 'claude'
+      ? claudeLaunchCommand()
+      : agentLaunchProgram(agentId, launchCmd, codexSharedIdentity(ssh))
   // A flag-prompt agent (opencode) takes the initial prompt via its flag — a bare positional
   // would be misread (opencode treats it as a project path). Everything else keeps the
   // historical argv append, INCLUDING stdin-after-start agents (gemini has always launched

--- a/src/server/handlers/index.ts
+++ b/src/server/handlers/index.ts
@@ -7,6 +7,8 @@ import { GitService } from '../../core/git-service'
 import { generateCommitMessage } from '../../core/commit-message'
 import { registerFsHandlers } from '../../core/fs-handlers'
 import { claudeCliCaps, registerClaudeCliIpc } from '../../core/claude-cli'
+import { registerCodexIdentityIpc } from '../../core/codex-identity-caps'
+import { UNKNOWN_CODEX_IDENTITY_CAPS } from '@shared/types'
 import { startUsageService } from '../../core/usage/usage-service'
 import {
   setMirrorUsageProvider,
@@ -67,6 +69,22 @@ export function registerCoreHandlers(
   // claude CLI is the one that will run the terminal nodes. Warm it so the first call is cached.
   registerClaudeCliIpc()
   void claudeCliCaps()
+
+  // ---- Codex shared identity: a DELIBERATE degrade, not an omission ----------------------------
+  // The Server Edition answers "no shared identity", so every Codex node here launches the bare
+  // `codex` it always did — a working node with its own app-server, just without the shared one.
+  //
+  // The blocker is the secret, not the plumbing: the per-node capability that closes the identity
+  // routes' authorization hole is keychain-backed on the desktop (Electron `safeStorage`, see
+  // src/main/codex-node-auth-secret.ts) and there is no equivalent on a headless Linux host. The
+  // only way to arm this here is a secret at rest in the data dir, which is a security decision
+  // this slice is not entitled to make quietly. Wiring it up is exactly three calls at this spot —
+  // `hookServer.setCodexNodeAuthSecret(secret)`, `setCodexThreadIdentityAuthSecret(secret)`,
+  // `refreshCodexIdentityCaps()` — plus the same two `setCodexThread*Handler` registrations
+  // src/main/index.ts makes; everything they call already lives in src/core and boots from
+  // CorePlatform. Until that secret question is answered, saying "no" here is what keeps the
+  // browser's Codex nodes identical to what they are today rather than half-armed.
+  registerCodexIdentityIpc(() => UNKNOWN_CODEX_IDENTITY_CAPS)
 
   // Claude subscription usage. Previously desktop-only — the browser bridge answered `null`, so
   // the pill never rendered in the Server Edition. The poll runs UNGATED here (the default), not

--- a/src/shared/agents/config.capabilities.test.ts
+++ b/src/shared/agents/config.capabilities.test.ts
@@ -17,7 +17,10 @@ import {
   hasPermissionMode,
   hasUsage,
   reportsOwnCopy,
-  RENAME_CAPABLE
+  RENAME_CAPABLE,
+  hasSharedIdentity,
+  agentLaunchProgram,
+  resumeCommand
 } from './config'
 
 describe('CONTEXT_LINK_CAPABLE', () => {
@@ -178,10 +181,33 @@ describe('title read vs rename write', () => {
     for (const id of RENAME_CAPABLE) expect(canReadTitle(id), id).toBe(true)
   })
 
-  it('codex claims neither, for want of evidence', () => {
-    // Its slash-command set was not enumerable from the CLI, so neither leg has a measured basis.
-    expect(canReadTitle('codex')).toBe(false)
+  it('codex reads but does not write — the same split gemini forced', () => {
+    // With the shared app-server a codex node owns a THREAD, and that thread has a `Thread.name`
+    // we can read over the server's own socket (core/codex-session-name.ts). There is still no
+    // measured rename command, and one list for both legs would light the rename UI on a node
+    // where the write silently does nothing.
+    expect(canReadTitle('codex')).toBe(true)
     expect(canRename('codex')).toBe(false)
+  })
+
+  it('only codex has a shared identity, and it is asked through the helper', () => {
+    expect(hasSharedIdentity('codex')).toBe(true)
+    for (const id of ['claude', 'gemini', 'grok', 'opencode', 'custom:abc'] as const) {
+      expect(hasSharedIdentity(id), id).toBe(false)
+    }
+  })
+
+  it('the launch program is the bare CLI unless the caller says shared identity is available', () => {
+    // The default is the pre-feature command, byte for byte: an unprobed machine, an SSH project,
+    // a test, a call site that never opted in — all emit `codex`. Same shape as gatePermissionMode.
+    expect(agentLaunchProgram('codex', 'codex')).toBe('codex')
+    expect(agentLaunchProgram('codex', 'codex', false)).toBe('codex')
+    expect(agentLaunchProgram('codex', 'codex', true)).toBe('nodeterm-codex')
+    // A non-member never gets rerouted, whatever the caller claims.
+    expect(agentLaunchProgram('claude', 'claude', true)).toBe('claude')
+    expect(resumeCommand('codex', 'thread-1')).toBe('codex resume thread-1')
+    expect(resumeCommand('codex', 'thread-1', true)).toBe('nodeterm-codex resume thread-1')
+    expect(resumeCommand('claude', 'abc', true)).toBe('claude --resume abc')
   })
 
   it('a custom agent claims neither', () => {

--- a/src/shared/agents/config.ts
+++ b/src/shared/agents/config.ts
@@ -145,9 +145,22 @@ export const RENAME_CAPABLE = ['claude', 'grok'] as const
 // INVARIANT (pinned in config.capabilities.test.ts): every RENAME_CAPABLE agent is also here. The
 // write leg pushes a name and the read leg is what confirms it settled.
 //
-// codex is in NEITHER: its slash-command set could not be enumerated from the CLI, so neither leg
-// has a measured basis — and a guess here costs a wrong node title, not a missing one.
-export const TITLE_READ_CAPABLE = ['claude', 'grok', 'gemini'] as const
+// codex joined the READ leg only, and for the same reason gemini did: with the shared app-server
+// (SHARED_IDENTITY_CAPABLE below) a node owns a THREAD, and that thread carries a `Thread.name` we
+// can read over the server's own socket (core/codex-session-name.ts). There is still no measured
+// rename command, so it stays out of RENAME_CAPABLE — the read⊇write invariant holds either way.
+export const TITLE_READ_CAPABLE = ['claude', 'codex', 'grok', 'gemini'] as const
+// Agents whose canvas nodes share ONE managed CLI server per machine and keep a stable per-node
+// identity inside it, instead of each node owning a whole process tree.
+//
+// Membership is what makes `buildPtyEnv` mint the per-node capability token, what makes
+// `pty-manager` install + PATH-expose the generated launcher, and what lets a launch line address
+// that launcher at all. Everything downstream asks `hasSharedIdentity(agentId)`; nothing may ask
+// `agentId === 'codex'`, which is how this started and is what CLAUDE.md forbids.
+//
+// Only codex today: it is the only builtin with an app-server mode NodeTerm can attach many
+// clients to. A second agent joins by being added here and writing its own launcher body.
+export const SHARED_IDENTITY_CAPABLE = ['codex'] as const
 // Agents allowed to drive the canvas via the `nodeterm` CLI (open/show/write/close).
 // Discovery differs per agent: claude gets the manage-nodeterm-canvas skill; codex/gemini/
 // opencode a marker block in ~/.codex/AGENTS.md / ~/.gemini/GEMINI.md /
@@ -207,6 +220,26 @@ export const canRename = (id: AgentId): boolean => includes(RENAME_CAPABLE, id)
 export const canReadTitle = (id: AgentId): boolean => includes(TITLE_READ_CAPABLE, id)
 export const canControlCanvas = (id: AgentId): boolean => includes(CANVAS_CONTROL_CAPABLE, id)
 export const hasPermissionMode = (id: AgentId): boolean => includes(PERMISSION_MODE_CAPABLE, id)
+export const hasSharedIdentity = (id: AgentId): boolean => includes(SHARED_IDENTITY_CAPABLE, id)
+
+/**
+ * The program a launch line should name for `id`.
+ *
+ * `sharedIdentity` is the caller's answer to "will the managed launcher actually be there?", and
+ * it is FALSE by default on purpose: every call site that has not opted in emits the bare CLI
+ * command it always did, byte for byte. This is the same shape as `gatePermissionMode` — an
+ * unknown or failed probe degrades to the bare command, never to a launch that cannot run.
+ *
+ * The launcher is addressed by NAME, not by path: `pty-manager` puts its directory first on the
+ * session's PATH for exactly the agents in SHARED_IDENTITY_CAPABLE, so the pane shows a readable
+ * command and a plain terminal's PATH is untouched.
+ */
+export const SHARED_IDENTITY_LAUNCHERS: Partial<Record<AgentId, string>> = { codex: 'nodeterm-codex' }
+
+export function agentLaunchProgram(id: AgentId, base: string, sharedIdentity = false): string {
+  if (!sharedIdentity || !hasSharedIdentity(id)) return base
+  return SHARED_IDENTITY_LAUNCHERS[id] ?? base
+}
 /** Does this agent's CLI report its own copies? Undefined (a plain terminal, a custom agent) is
  *  `false` — nobody speaks for those, so nodeterm's own feedback is the only feedback there is. */
 export const reportsOwnCopy = (id: AgentId | undefined): boolean =>
@@ -268,14 +301,18 @@ export function withSessionId(cmd: string, id: AgentId, sessionId: string): stri
  * Used on a cold restart (machine reboot) where the tmux session — and the live agent — are
  * gone, so the conversation must be reconstructed via the agent CLI's own `--resume`.
  * Returns null for non-resumable/custom agents or an unsafe/empty session id.
+ *
+ * `sharedIdentity` routes a SHARED_IDENTITY_CAPABLE agent's resume through the managed launcher,
+ * so the resumed session re-claims the node's own thread instead of opening it as an anonymous
+ * client. Default false = the bare command this has always emitted (see `agentLaunchProgram`).
  */
-export function resumeCommand(id: AgentId, sessionId: string): string | null {
+export function resumeCommand(id: AgentId, sessionId: string, sharedIdentity = false): string | null {
   if (!canResume(id)) return null
   const sid = sessionId.trim()
   if (!sid || !SAFE_SESSION_ID.test(sid)) return null
   switch (id) {
     case 'codex':
-      return `codex resume ${sid}`
+      return `${agentLaunchProgram('codex', 'codex', sharedIdentity)} resume ${sid}`
     case 'opencode':
       return `opencode --session ${sid}`
     case 'claude':

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -39,6 +39,11 @@ export const IPC = {
   claudeAccountsCancelWait: 'claude-accounts:cancel-wait',
   claudeAccountsRemove: 'claude-accounts:remove',
   claudeCliCaps: 'claude-cli:caps',
+  /** Can a node on this machine get a managed Codex identity? See core/codex-identity-caps.ts. */
+  codexIdentityCaps: 'codex-identity:caps',
+  /** main/server → renderer: a Codex node's identity mode changed ('shared' | 'plain'). The
+   *  'plain' events are what make the launcher's fallback visible instead of silent. */
+  codexIdentity: 'codex-identity:event',
   transcriptSearch: 'transcript:search',
   appToggleMarkdown: 'app:toggle-markdown',
   appCloseNode: 'app:close-node',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1873,6 +1873,36 @@ export const UNKNOWN_CLAUDE_CLI_CAPS: ClaudeCliCaps = {
   sessionIdFlag: false
 }
 
+/** Whether a Codex node launched on this machine right now would get a managed shared identity.
+ *  Fed by core/codex-identity-caps.ts; the unknown answer is `false`, i.e. plain `codex`. */
+export interface CodexIdentityCaps {
+  shared: boolean
+  /** Absolute path of the installed launcher, or null when it could not be written. */
+  launcherPath: string | null
+}
+
+/** The answer before the probe has run, and the one the Server Edition gives on purpose. */
+export const UNKNOWN_CODEX_IDENTITY_CAPS: CodexIdentityCaps = { shared: false, launcherPath: null }
+
+/** A Codex node's identity mode, as reported by the node's own launcher at spawn time.
+ *  `plain` carries the machine-readable reason the managed identity was unavailable. */
+export interface CodexIdentityEvent {
+  nodeId: string
+  mode: 'shared' | 'plain'
+  reason?: string
+}
+
+/** The Codex-specific surface. Small on purpose: everything else a Codex node needs already goes
+ *  through the shared agent/pty APIs. */
+export interface CodexApi {
+  /** Would a Codex node launched right now get a managed shared identity on this machine?
+   *  Never rejects — the unknown answer is `{ shared: false }`, i.e. plain `codex`. */
+  identityCaps(): Promise<CodexIdentityCaps>
+  /** Fires when a Codex node's launcher reports its identity mode. `plain` is the fallback, and
+   *  this event is what stops that fallback being silent. Returns unsubscribe. */
+  onIdentity(listener: (e: CodexIdentityEvent) => void): () => void
+}
+
 export interface ClaudeApi {
   /** Capabilities of the local Claude CLI (memoized in the shell; safe to call repeatedly).
    *  Never rejects — an unknown version resolves to the fail-open caps. */
@@ -2146,6 +2176,7 @@ export interface NodeTerminalApi {
   sessionMemory: SessionMemoryApi
   context: ContextApi
   canvas: CanvasApi
+  codex: CodexApi
   claude: ClaudeApi
   chat: ChatApi
   claudeAccounts: ClaudeAccountsApi

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1879,10 +1879,18 @@ export interface CodexIdentityCaps {
   shared: boolean
   /** Absolute path of the installed launcher, or null when it could not be written. */
   launcherPath: string | null
+  /** Does the installed `codex` accept `--remote`? Feature-detected from its own `--help`. The one
+   *  precondition that cannot be recovered from at runtime: the launcher execs, and a CLI without
+   *  the flag dies on a usage error where no fallback is left. Unknown ⇒ false ⇒ plain codex. */
+  remoteFlag: boolean
 }
 
 /** The answer before the probe has run, and the one the Server Edition gives on purpose. */
-export const UNKNOWN_CODEX_IDENTITY_CAPS: CodexIdentityCaps = { shared: false, launcherPath: null }
+export const UNKNOWN_CODEX_IDENTITY_CAPS: CodexIdentityCaps = {
+  shared: false,
+  launcherPath: null,
+  remoteFlag: false
+}
 
 /** A Codex node's identity mode, as reported by the node's own launcher at spawn time.
  *  `plain` carries the machine-readable reason the managed identity was unavailable. */


### PR DESCRIPTION
Slice **S4** of external PR #112 (eneskirca/nodeterm#112, by **@Corvin** — `corvin@streamlain.com`, credited in the commit trailer). Sliced from `integration/codex-112`, **re-applied by hand onto current `main`** rather than cherry-picked; see "Nothing of main's was reverted" below.

## What it buys

**RAM.** A Codex terminal node used to spawn a full `codex` process tree — an app-server each. A canvas with a dozen Codex nodes paid a dozen servers for one account. Now every node on a machine talks to ONE `codex app-server` and owns one *thread* inside it. The node ↔ thread mapping is a small signed file under `<userDataDir>/codex-thread-nodes/`, so it survives resumes, in-pane restarts and app restarts (tmux sessions outlive the app; the file is the only thing that still knows whose conversation is whose).

**A real authorization hole, closed.** The hook server's bearer token proves only "this request came from *some* nodeterm-spawned session"; it cannot prove *which*. Every identity route takes a caller-supplied `nodeId`, so with the shared bearer alone any agent session could bind **its own** codex thread to a **sibling** node — reparenting that node's status, and (through the hook prelude, which re-exports the recorded node id and hook endpoint into an agent's environment) aiming the sibling's hook traffic. Each `/codex-thread/*` route now also requires `X-NodeTerm-Node-Token` = HMAC(secret, nodeId): restart-stable, scoped to one node, injected only into that node's session env, and never written to the shared endpoint file every session can read. The identity **records are signed with the same key**, so a hand-edited record is ignored rather than repaired — an attacker-writable record would otherwise be an attacker-chosen hook target. Both are covered by tests that run the real script against the real server (`codex-launcher-sh.test.ts`: a token minted for `node-2` cannot bind anything for `node-1`).

## The fallback (the owner's decision)

Upstream made `AGENT_CONFIG.codex.launchCmd` unconditionally the launcher and had the launcher `exit 69 "identity unavailable"`. That turns a missing app-server, an older `codex`, a stale tmux session or a locked-down data dir into a **dead node**. Here every failure path ends in `exec codex "$@"` — arguments intact.

**Where the decision lives: in both places, at different granularity, and the script is the authority.**

1. **Construction time** — `codexIdentityCaps()` (`src/core/codex-identity-caps.ts`), shaped exactly like `core/claude-cli.ts`: one memoized probe behind one CorePlatform RPC channel, registered by *both* shells, whose unknown answer is the conservative one. `AGENT_CONFIG.codex.launchCmd` stays `'codex'`, byte-identical; the launcher is named only when the probe says the machine has one installed *and* armed, and the session is not remote (`codexSharedIdentity(remote)` — an SSH host has no launcher yet, so a launcher-named line there would be `command not found`, i.e. the exact dead node this exists to prevent). This is `gatePermissionMode`'s shape: unprobed / failed / unknown ⇒ the bare command, never a blocked launch. Every call site that does not opt in keeps today's command line — `agentLaunchProgram(id, base, sharedIdentity = false)`.
2. **Runtime** — only the script can see the pane's env, whether the endpoint file is readable, whether the broker answers, or whether the installed `codex` even has an app-server. So the launcher preflights and, on any miss, `exec codex "$@"`. It also never *starts* a second client on a thread another live node owns: a refused bind falls back too.

**Where it surfaces** (not silent, and not in the pane):
- The launcher POSTs `/codex-thread/fallback` with a machine-readable reason before exec'ing. That route is the one exemption from the per-node capability, because the commonest thing it reports is that there *was* no capability to present. The exemption is exactly that narrow: only a **tokenless** report is trusted on the node id it names, and a report that carries a token must carry the right one — otherwise a session holding only the shared bearer could flag a sibling node as fallen back (cosmetic, since the flag is transient and downgrade-only, but a claim in a comment has to be true).
- The node header shows a muted **`plain codex`** chip whose tooltip says why (`codexFallbackText`).
- The **first** fallback per node also raises the existing warning banner, because a chip on a node you are not looking at teaches nothing.
- Nothing is ever written into the terminal — text pushed into an agent's pane is prompt injection, which this repo forbids.

The mode is transient, never persisted: it describes one launch of one process, and a stale "plain" badge on a reloaded node would be a lie.

One deliberate non-use: the **in-place** "Restart agent (resume)" keeps emitting the bare `codex resume <id>`. It types into a pane that already exists, and a tmux session created before the launcher was installed does not carry its directory on PATH. A restarted node rejoins as a plain client until its next cold start — commented at the site.

## The four review findings

**V1 — Server Edition.** Registered with an explicit "no" (`registerCodexIdentityIpc(() => UNKNOWN_CODEX_IDENTITY_CAPS)`) plus a comment at the exact spot the wiring would go. The blocker is the *secret*, not the plumbing: the per-node capability is keychain-backed on desktop (Electron `safeStorage`) and there is no equivalent on a headless Linux host — arming it here means a secret at rest in the data dir, which is a security call this slice is not entitled to make quietly. Everything it would need already lives in `src/core` and boots from `CorePlatform`; it is three calls plus the two handler registrations `src/main/index.ts` makes. Until then, Server Edition runs plain `codex` — a working node, deliberately.

**V2 — `agentId === 'codex'` at call sites.** New capability list `SHARED_IDENTITY_CAPABLE` + `hasSharedIdentity()` in `src/shared/agents/config.ts`, used at every site in this slice: `hook-server.buildPtyEnv` (token minting), `pty-manager` (launcher install + PATH), `workspace.createAgentNode` and the cold-restore resume (launch program). `codex-accounts-core.needsCodexAccountScope` is **not** in this slice (managed Codex accounts are S6) — it should join the same helper when it lands.

**V3 — bypassing `CorePlatform`.** `codex-identity-proxy.ts` no longer hardcodes `homedir()/.nodeterm/…`: the record root is `platform().userDataDir/codex-thread-nodes` and the launcher lives in `platform().userDataDir/codex-bin`. The generated sh prelude gets that path baked in (POSIX-quoted — the real one contains a space on macOS), so the two cannot disagree; `codexThreadIdentityResolverSh(root)` is now a function of the root, and `buildManagedScript` passes it. Pinned by a test.

**Fix 4 — `TITLE_READ_CAPABLE` gains `codex`,** with a real read leg (`core/codex-session-name.ts`, `Thread.name` over the app-server socket) and **not** `RENAME_CAPABLE` — there is no measured rename command, exactly gemini's situation. Consumers grepped per CLAUDE.md rule 2:
- the read⊇write invariant test still holds (codex is read-only, so it cannot break it);
- **both shells' session-name sweeps agree** — neither passes `supports`, so both take core's `supportsTitleRead` default and codex is enrolled in both. `session-name-sweep.test.ts` was updated to assert that (it previously pinned codex as *not* swept);
- `readAgentSessionName` routes codex to its own reader **before** claude's, with a test — claude's resolver SCANS `~/.claude/projects` on a cache miss and its cwd leg can hand back a stranger's session name.

**Fix 5 — the prelude is injected into every agent's managed hook script,** not only codex's. Confirmed intended and documented at both ends: it is inert without `CODEX_THREAD_ID` (which no other agent's tool shell sets), and one builder beats a codex-only fork of it. It does change every agent's generated script, so `managed-script.test.ts` now asserts both its presence for all five builtins and that a missing identity root yields the legacy script unchanged.

## Nothing of main's was reverted

S3's lesson applied: **no shared file was cherry-picked.** `hook-server.ts` in particular — the integration branch's copy predates main's `CONTROL_CEILING_MS` / `withTimeout` / context-link timeout work and would have reverted all of it plus deleted `hook-server.slowloris.test.ts`. Everything here is hand-applied on top of main's current versions. `git diff origin/main` is additive in every source file (the only removed lines are the exact lines being edited), and the two updated test files are intentional.

## Three surfaces

- **Desktop** — full support.
- **Server Edition** — deliberate, documented degrade to plain `codex` (V1 above). The renderer bridge has a **real** `codex` namespace (not a stub), so wiring the server later needs no renderer change.
- **Mobile companion** (`~/projects/nodeterm-ios`) — N/A. It attaches to tmux sessions over the transport protocol; which app-server a codex session talks to is invisible to it, and the `plain codex` chip is a canvas-node affordance the phone has no slot for. No protocol change is owed.
- **Kanban** — the identity mode lives in a store the card modal could read; the chip is on the canvas node header only in this slice. Adding it to the card's expanded detail row (beside the session chip / ContextMeter) is a small follow-up.

## Not in this slice

Relay daemon (S5), managed Codex accounts (S6 — including account-scoped identity directories, which the flat record layout extends into cleanly), SSH hosts (S7 — remote nodes stay on plain `codex`), browser control (S8), mailbox/loop (S9).

## Gates

- `npm run typecheck` — clean (both projects).
- `npx vitest run src/core src/shared src/main` — 2859 passed, 3 failed (all `node-pty-patch`, environmental in a symlinked clone).
- `npx vitest run` — 5228 passed, 12 skipped, same 3 environmental failures.
- The generated shell is **executed for real under `/bin/sh`**, per this repo's discipline for generated scripts: `codex-launcher-sh.test.ts` (13 cases — happy start/resume, argument preservation, and every fallback path with a fake `codex` recording the argv it was exec'd with) and `codex-thread-identity-sh.test.ts` (the prelude, including a data dir containing a space, and records carrying an unsafe node id or endpoint).

---

## Review round 2 (all pushed)

**H1 — the start route ran a 20 s handler under the 2 s slowloris guard.** Correct, and it would have meant the feature essentially never engaged: `handleCodexThread` never handed off to `CONTROL_CEILING_MS` the way `/control/` and `/context-link/` do, so on the common case (a cold app-server, i.e. the first Codex node after boot) curl failed at ~2 s, the launcher fell back, **and main went on to create the thread and write a record for it**.
- `req.setTimeout(CONTROL_CEILING_MS, …)` after `readBody` in `handleCodexThread`, with the reasoning at the site.
- The two client budgets are reconciled and now derive from one constant: `CODEX_THREAD_START_TIMEOUT_MS` (20 s, the server's own budget, shared with `startCodexThreadAt`) and `CODEX_THREAD_START_CLIENT_MAX_S` = that + 10, so the **server** is always the side that gives up first and the orphan-record window closes with it (`startCodexThread` rejecting means no record is written at all). Bind keeps its own, smaller budget.
- **Test**: `codex-launcher-sh.test.ts` → "a start handler that takes real time" sleeps 3 s in the handler and asserts the launcher comes up **shared** with that thread. Verified it catches the bug — with the `setTimeout` line removed it fails `expected [ '' ] to deeply equal [ '--remote unix:// resume thread-abc' ]`, i.e. it observes exactly the fallback-plus-orphan the review described.

**H2 — post-`exec` is unrecoverable.** Took the cheap defensive fix: **bind now verifies the thread exists before writing a record.** `codexThreadExistsAt` (`core/codex-session-name.ts`) does a `thread/read` and requires the id to come back *unchanged*; main's bind handler refuses when it does not. So a stale id, or one persisted from a plain-codex-era session the shared server never heard of, becomes an ordinary `thread-bind-refused` fallback instead of a `codex --remote unix:// resume` that dies after exec. A server we cannot reach answers "does not exist" — the safe direction (refusing costs a plain session, accepting costs the node). New `codex-session-name.test.ts` runs the protocol client against a **real WebSocket server on a real unix socket** (known thread, unknown thread, dead server, unshaped id, a server that refuses to initialize). I did not add a `--remote` preflight probe: it costs a `codex --help` spawn per launch and only moves assumption 9.1 from "unverified" to "verified at a cost" — flagged for the checklist instead.

**M1 — `docs/codex-shared-identity.md`.** Design, the three budgets and why their ordering is the whole point, the auth model, the fallback and its reason table, the prelude, three-surfaces, known gaps, and a **§9 numbered device checklist** whose items 1-3 are H2's assumptions (`--remote` exists; `codex resume <id> <prompt> --ask-for-approval never` accepts a positional prompt *and* a global flag after the subcommand — CLAUDE.md rule 5's grok-`--` lesson, invisible to a `withPermissionMode` unit test; the hook-persisted session id is the id the app-server accepts as a thread).

**M2 — records are pruned.** `forgetCodexThreadIdentitiesForNode(nodeId)` on the same `destroySession` hook that already deletes the scrollback snapshot. Keyed by node because that is what the caller knows; it reads *through* the signature check, so a record we do not trust is also one we do not delete, and it never throws (a node deletion must not fail on housekeeping). Tested, including "leaves other nodes' records alone".

**M3 — the fallback route.** Fixed the behaviour and the claim: a report carrying `X-NodeTerm-Node-Token` must match, only a tokenless one is accepted unauthenticated. Both the route comment and the launcher comment now say what the code does. Tested (204 tokenless → 403 sibling token → 204 own token).

**L2 —** `remote-hooks.ts` passes an explicit `REMOTE_IDENTITY_ROOT = null` at all four sites; `buildManagedScript`'s parameter is honestly `string | null`. No desktop paths on SSH hosts.

**L5 —** covered above; `refreshCodexIdentityCaps()` in `src/main/index.ts` now carries a comment saying what depends on its position, and `codex-identity-caps.test.ts` pins that an early caller waits.

**L6 —** `quotedCodexLauncherDir`, `rememberCodexSessionName`, `forgetCodexSessionNames` and `useCodexIdentity.clear` removed (with the then-unused `posixQuote` import).

### Noted, not done

- **L7** — the `plain codex` chip is canvas-node-only; the mode already lives in a store the card modal can read, so the kanban card is a small follow-up.
- **L1** — the sh prelude cannot verify the record HMAC (no key in an agent's shell). It re-validates the *shape* of both recovered fields instead; the signature is a desktop-side guarantee and the charset checks are the second layer, not a redundancy. Documented in §2.
- **L4** — the node token rides tmux `-e` like every other `NODETERM_*` value, so it has the same exposure the hook bearer already has. Changing it means changing how all of them are delivered. §8.3.
- **L3** — the launcher POSTs to `http://localhost:$NODETERM_HOOK_PORT` and so needs a **port**, not a unix socket (it already reads `NODETERM_HOOK_SOCK` for curl's transport but not for the URL). Fine for the desktop's loopback listener; it has to be revisited when the Server Edition wiring lands. §8.2.
- **§8.4** — `CODEX_HOME` is resolved twice (Electron's env for the socket, the pane's for `--remote`). Identical unless a user sets it in a shell rc only; managed accounts make it explicit.

### Gates, round 2

- `npm run typecheck` — clean, both projects.
- `npx vitest run src/core src/shared src/main` — **2875 passed**, 3 failed (all `node-pty-patch`, environmental).
- `npx vitest run` — **5244 passed**, 12 skipped, same 3 environmental failures.
- New: `codex-identity-caps.test.ts`, `codex-session-name.test.ts` (real ws server on a real unix socket); `codex-launcher-sh.test.ts` is now 15 cases including the H1 regression and the M3 auth matrix.

---

## Review round 3 (all pushed)

**1 — `--remote` is now answered at caps time.** You were right that rejecting the *per-launch* probe did not settle the question. `refreshCodexIdentityCaps()` now probes the CLI once per app run, entirely off the launch path, and `shared` is the AND of three things instead of two.
- What it checks: `findInLoginPath('codex')` (GUI apps do not inherit the shell PATH), then `codex --help`, matched with an anchored `/(^|\s)--remote(\s|=|$)/m` — so `--remote-auth-token-env`, which does exist, and prose mentioning the flag inside another option's description, cannot answer yes. If the top-level help does not say, it tries `codex resume --help` once, since some CLIs list a global flag only under the subcommand that takes it. Feature-detected rather than version-compared, for the same reason claude's `--session-id` is: an unrecognised flag does not degrade, it makes the CLI exit.
- What it does when unknown — no codex on the login PATH, a failed or timed-out spawn, help text that never mentions the flag: **`remoteFlag: false` ⇒ `shared: false` ⇒ the launcher is not even installed ⇒ the bare `codex` command.** A wrong "yes" costs the node; a wrong "no" costs only the shared app-server, so unknown degrades toward "no". `CodexIdentityCaps` carries `remoteFlag` so the reason is inspectable rather than folded into a bare boolean.
- Cost: the probe is async, so `refreshCodexIdentityCaps()` is now async and `src/main/index.ts` fires it with `void` — nothing in the boot chain queues behind it, and callers of `codexIdentityCaps()` wait for the answer rather than being told "no" (round 2's L5 property, still pinned).
- Tests: `codexCliSupportsRemote` unit cases (the `--remote-auth-token-env` and prose traps, either-help-page), plus a caps case asserting that a CLI without the flag yields `{shared:false, launcherPath:null}` **and installs no launcher**, however armed everything else is. Checklist item 1 is rewritten accordingly — the flag's *presence* is now answered per machine; what still needs a device is that the form we detect is the form we use.

**2 — the cold-socket window, which round 2 opened.** Correct and well spotted: `bind`'s new mandatory round trip made a still-binding daemon indistinguishable from "thread unknown", i.e. a new way to lose shared identity on precisely the cold/reboot path.
- `waitForCodexAppServer(socketPath, 3, 200ms)` — a bare connect-and-close poll — now precedes the mint in `startCodexThreadAt` (charged against its 20 s budget, which has room).
- The bind check is more precise than a blanket retry: `probeCodexThread` returns `'yes' | 'no' | 'unreachable'`, and `codexThreadExistsAt` retries **only** `unreachable`. A server that answered is never retried — "I do not have that thread" is an answer, and a server that refuses to initialize (a logged-out CLI) is a definite no, not a transient one. Out of retries the answer is `false`, the safe direction.
- Test: a second app-server whose `listen()` fires 250 ms late, asserted to resolve `true`. Verified it fails without the retry (`SOCKET_WAIT_ATTEMPTS = 1` ⇒ `expected false to be true`). A companion test clocks the definite-no path at under 200 ms, so a future "just retry everything" would fail.

**3 — checklist is at 12 items.** (11) cold app-server on the **resume/bind** path — restart or reboot with an existing Codex node, confirm it comes up shared and that a genuinely absent server still falls back promptly rather than hanging; (12) `CODEX_HOME` exported in a shell rc **only**, which is exactly where the desktop's resolution (Electron's env, for the socket) and the pane's (its own, for `--remote unix://`) diverge — turned from a §8 note into a step that says what to look for.

**4 — §8.4 records both residual orphan classes**, as inherent rather than bugs: (a) a client that dies for a non-timeout reason (pane killed, `tmux kill-session`, Ctrl-C mid-mint) still leaves the handler to write its record — now bounded by the pruning, and the next launch mints fresh anyway; (b) an app-server that aborts mid-conversation can leave the seed and/or forked thread alive on its side because the closing `thread/delete` is never sent, and orphan *threads* have no reaper anywhere, here or in codex.

**5 — both trivia.** `UNKNOWN_CODEX_IDENTITY_CAPS` is gone from `codex-identity-caps.ts` (the import block was rewritten for the probe). The prune comment no longer claims to run only for permanent deletion: it now says it shares `endSession`'s teardown with the worktree-move **recycle**, that a recycle therefore wipes a live node's records, and why that is fine rather than intended (a recycle respawns cold, so the next launch re-mints or re-binds immediately) — the same overstatement class this round already fixed twice.

### Gates, round 3

- `npm run typecheck` — clean, both projects.
- `npx vitest run src/core src/shared src/main` — **2881 passed**, 3 failed (all `node-pty-patch`, environmental).
- `npx vitest run` — **5250 passed**, 12 skipped, same 3 environmental failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
