### PR TITLE
fix(ssh): keep large saved-server lists usable

### DIFF
--- a/docs/superpowers/plans/2026-08-13-ssh-server-picker.md
+++ b/docs/superpowers/plans/2026-08-13-ssh-server-picker.md
@@ -1,0 +1,216 @@
+# SSH Server Picker Overflow and Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every saved SSH server reachable in the Connect over SSH dialog and add fast case-insensitive filtering for large imported server collections.
+
+**Architecture:** Keep the change within `SshProjectDialog`. The pick step becomes a bounded flex column whose server-list child owns vertical scrolling, while local React state filters the existing Zustand server collection without changing persistence or connection behaviour. The Settings surface remains unchanged because its parent page already scrolls.
+
+**Tech Stack:** React 18, TypeScript, Zustand, Vitest, jsdom, inline layout styles consistent with the existing component.
+
+## Global Constraints
+
+- Implement against `eneskirca/nodeterm` main at commit `711f34b1656a370c673b02e2b63a4bde699953d4`.
+- Keep the change restricted to issue 141, its tests, and the approved design and plan.
+- Preserve existing SSH connection, cancellation, browse-master teardown, folder browsing, and Add server behaviour.
+- Only the server-row list scrolls. The title, explanatory text, filter, Cancel, and Add server actions remain outside the scroll region.
+- Match label, host, user, and `user@host` case-insensitively after trimming the query.
+- Do not modify Settings because `SettingsPage` already supplies page-level `overflow-y-auto`.
+- Use test-first development and watch every new regression test fail for the expected missing behaviour before changing production code.
+- Required final gates are the focused component test, `npm run typecheck`, full `npm test`, `npm run build`, and `git diff --check`.
+
+---
+
+### Task 1: Pin the overflow and filtering regressions, then implement the picker fix
+
+**Files:**
+- Modify: `src/renderer/components/SshProjectDialog.test.tsx`
+- Modify: `src/renderer/components/SshProjectDialog.tsx`
+
+**Interfaces:**
+- Consumes: `useSshServers((state) => state.servers)` and the existing `SshServer` fields `label`, `host`, and `user`.
+- Produces: no new public TypeScript interface. The rendered pick step gains an input labelled `Filter saved SSH servers` and a server list labelled `Saved SSH servers`.
+
+- [ ] **Step 1: Generalise the test harness without changing production code**
+
+Keep the existing real component and store setup. Add these helpers below `buttonByText`.
+
+```tsx
+  const setInputValue = (input: HTMLInputElement, value: string): void => {
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(input, value)
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  const serverButtons = (): HTMLButtonElement[] =>
+    [...document.querySelectorAll<HTMLButtonElement>('[aria-label="Saved SSH servers"] button')]
+```
+
+- [ ] **Step 2: Write the failing layout regression test**
+
+```tsx
+  it('keeps a large server collection in its own scroll region above the actions', () => {
+    useSshServers.setState({
+      servers: Array.from({ length: 25 }, (_, index) => ({
+        id: `server-${index}`,
+        label: `Server ${index}`,
+        host: `host-${index}.example.com`,
+        user: 'matt'
+      }))
+    })
+    render()
+
+    const list = document.querySelector<HTMLElement>('[aria-label="Saved SSH servers"]')!
+    const cancel = buttonByText('Cancel')
+    expect(serverButtons()).toHaveLength(25)
+    expect(list.style.flex).toBe('1 1 auto')
+    expect(list.style.minHeight).toBe('0px')
+    expect(list.style.overflowY).toBe('auto')
+    expect(serverButtons().every((button) => button.style.flexShrink === '0')).toBe(true)
+    expect(list.contains(cancel)).toBe(false)
+    expect(cancel.parentElement?.style.flexShrink).toBe('0')
+    expect(list.compareDocumentPosition(cancel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+```
+
+Run `npx vitest run src/renderer/components/SshProjectDialog.test.tsx`. The new test must fail because the current list has no accessible label, flexible scroll contract, or non-shrinking rows.
+
+- [ ] **Step 3: Write the failing filtering tests**
+
+```tsx
+  it('filters saved servers by label, host, user, and user-at-host without case sensitivity', () => {
+    useSshServers.setState({ servers: [
+      { id: 'prod', label: 'Production', host: 'api.example.com', user: 'deploy' },
+      { id: 'stage', label: 'Staging', host: 'stage.internal', user: 'ubuntu' }
+    ] })
+    render()
+    const filter = document.querySelector<HTMLInputElement>('[aria-label="Filter saved SSH servers"]')!
+
+    setInputValue(filter, 'PRODUCTION')
+    expect(serverButtons().map((button) => button.textContent)).toEqual([expect.stringContaining('Production')])
+    setInputValue(filter, 'API.EXAMPLE.COM')
+    expect(serverButtons().map((button) => button.textContent)).toEqual([expect.stringContaining('Production')])
+    setInputValue(filter, 'ubuntu@stage.internal')
+    expect(serverButtons().map((button) => button.textContent)).toEqual([expect.stringContaining('Staging')])
+    setInputValue(filter, '')
+    expect(serverButtons()).toHaveLength(2)
+  })
+
+  it('shows a no-results message instead of server rows when the filter has no match', () => {
+    render()
+    const filter = document.querySelector<HTMLInputElement>('[aria-label="Filter saved SSH servers"]')!
+    setInputValue(filter, 'missing-host')
+    expect(serverButtons()).toHaveLength(0)
+    expect(document.body.textContent).toContain('No saved servers match')
+  })
+```
+
+Run `npx vitest run src/renderer/components/SshProjectDialog.test.tsx`. Both tests must fail because the filter input and derived visible collection do not yet exist.
+
+- [ ] **Step 4: Implement the minimal approved behaviour**
+
+In `SshProjectDialog.tsx` import `useMemo`, add local `serverFilter` state, and derive `visibleServers`.
+
+```tsx
+  const [serverFilter, setServerFilter] = useState('')
+  const visibleServers = useMemo(() => {
+    const query = serverFilter.trim().toLowerCase()
+    if (!query) return servers
+    return servers.filter((saved) =>
+      [saved.label, saved.host, saved.user, `${saved.user}@${saved.host}`]
+        .some((value) => value.toLowerCase().includes(query))
+    )
+  }, [servers, serverFilter])
+```
+
+Wrap the pick step in a flex column with `flex: '1 1 auto'` and `minHeight: 0`. Set `flex: '0 0 auto'` and `overflow: 'visible'` on the title and explanatory paragraphs so the list, rather than the copy, gives up height. Render the shared `Input` above the list when at least one server exists.
+
+```tsx
+<Input
+  autoFocus
+  aria-label="Filter saved SSH servers"
+  placeholder="Filter by label, host, or user"
+  value={serverFilter}
+  onChange={(event) => setServerFilter(event.target.value)}
+  className="mb-2"
+  style={{ flexShrink: 0 }}
+/>
+```
+
+Give the list `role="group"`, `aria-label="Saved SSH servers"`, and these critical inline styles.
+
+```tsx
+{
+  display: 'flex',
+  flex: '1 1 auto',
+  minHeight: 0,
+  overflowY: 'auto',
+  overscrollBehavior: 'contain',
+  flexDirection: 'column',
+  gap: 6,
+  margin: '6px 0 14px'
+}
+```
+
+Map `visibleServers`, show `No saved servers match “{serverFilter.trim()}”.` when the saved collection is non-empty and the visible collection is empty, and preserve `No saved servers yet.` for an empty saved collection. Add `flexShrink: 0` to `ROW_STYLE` so constrained list rows overflow instead of compressing. Set `flexShrink: 0` on the existing action row so it cannot be compressed into the scrolling list's height budget.
+
+- [ ] **Step 5: Run the focused test and mutation check**
+
+Run `npx vitest run src/renderer/components/SshProjectDialog.test.tsx` and require all tests to pass without warnings.
+
+Temporarily remove `overflowY: 'auto'` from the list and rerun the focused test. Confirm the layout regression test fails specifically on the `overflowY` assertion, then restore the property and rerun to green. This proves the test detects a realistic reintroduction of issue 141.
+
+- [ ] **Step 6: Run the task gate and commit**
+
+Run `npm run typecheck` and `git diff --check`. Inspect `git diff -- src/renderer/components/SshProjectDialog.tsx src/renderer/components/SshProjectDialog.test.tsx` for unrelated changes.
+
+Commit the component and regression tests with `fix(ssh): make the saved-server picker searchable`.
+
+---
+
+### Task 2: Verify the complete change and publish the upstream pull request
+
+**Files:**
+- Include: `docs/superpowers/specs/2026-08-13-ssh-server-picker-design.md`
+- Include: `docs/superpowers/plans/2026-08-13-ssh-server-picker.md`
+- Verify: all files changed on the feature branch
+
+**Interfaces:**
+- Consumes: Task 1's complete implementation and tests.
+- Produces: a pushed feature branch and a draft pull request targeting `eneskirca/nodeterm:main` that closes issue 141.
+
+- [ ] **Step 1: Review scope and documentation**
+
+Run `git status --short`, `git diff main...HEAD --stat`, and `git diff main...HEAD`. Confirm the branch contains only the approved picker behaviour, regression tests, design, and plan. Confirm Settings has no changes and the design records why.
+
+- [ ] **Step 2: Run all required verification**
+
+Run these commands from the repository root.
+
+```bash
+npx vitest run src/renderer/components/SshProjectDialog.test.tsx
+npm run typecheck
+npm test
+npm run build
+git diff --check main...HEAD
+```
+
+Every command must exit successfully. If the full suite exposes a pre-existing environmental failure, investigate it using the repository guidance and rerun the complete suite before claiming completion.
+
+- [ ] **Step 3: Commit the approved design and plan**
+
+Because `docs/superpowers/` is ignored by default, stage these two exact files with `git add -f` and commit them with `docs: record the SSH server picker fix` if they were not included in the Task 1 commit.
+
+- [ ] **Step 4: Publish through the contributor fork**
+
+Confirm `gh auth status`. If direct push access to `eneskirca/nodeterm` is unavailable, ensure the authenticated user's fork exists, add or reuse a fork remote, and push `codex/fix-ssh-picker-overflow-141` there without changing the authoritative `origin` fetch target.
+
+- [ ] **Step 5: Open the upstream draft pull request**
+
+Create a draft PR against `eneskirca/nodeterm:main`. The title should be `fix(ssh): keep large saved-server lists usable`. The body must explain the flex-list root cause, the dedicated scroll region, the matching fields, the unchanged Settings surface, all verification commands, and the three-surface decision. Include `Closes #141`.
+
+- [ ] **Step 6: Confirm remote state**
+
+Fetch the created PR and confirm its URL, draft state, base branch, head branch, changed-file scope, and current checks. Report any checks still running without describing them as passed.

--- a/docs/superpowers/specs/2026-08-13-ssh-server-picker-design.md
+++ b/docs/superpowers/specs/2026-08-13-ssh-server-picker-design.md
@@ -1,0 +1,62 @@
+# SSH Server Picker Overflow and Filtering Design
+
+## Problem
+
+Issue 141 reports that the Connect over SSH picker becomes unusable when dozens of servers have been imported. The dialog shell is a capped flex column, but the server list is an unconstrained flex child with no scroll behaviour. Rows beyond the viewport remain rendered but unreachable, and the Cancel and Add server actions can be pushed below the visible dialog.
+
+The same saved-server collection is rendered in Settings. That surface is not affected because `SettingsPage` already makes its entire main content column vertically scrollable.
+
+## Approved scope
+
+- Give the Connect over SSH server rows a dedicated vertical scroll region.
+- Keep the picker title, explanatory copy, filter, Cancel action, and Add server action visible.
+- Add type-to-filter behaviour for large imported server collections.
+- Leave Settings unchanged because its page-level scroll region already handles long server lists.
+
+## Layout
+
+The pick step becomes one bounded flex column inside the existing `.confirm` shell. Its title, explanatory copy, filter, and action row do not shrink. The server list receives `flex: 1 1 auto`, `min-height: 0`, and `overflow-y: auto`, with contained overscroll. Each server row has `flex-shrink: 0`, ensuring the constrained list overflows and scrolls instead of compressing its rows.
+
+Only the server list scrolls. The dialog shell and actions retain the existing styling and interaction model.
+
+## Filtering
+
+The filter is transient React state local to `SshProjectDialog`. Matching is case-insensitive after trimming the query. A server remains visible when the query occurs in any of these values.
+
+- Label
+- Hostname
+- Username
+- Combined `user@host`
+
+An empty query shows every saved server. When saved servers exist but none match, the list shows a clear no-results message. The existing no-saved-servers message remains unchanged when the collection itself is empty.
+
+The filter state does not persist and does not modify saved-server data.
+
+## Accessibility and keyboard behaviour
+
+The filter uses the shared `Input` component, receives focus when the pick step opens, and has an explicit accessible label. Existing Escape handling continues to close the topmost dialog. Server rows remain native buttons and retain their current click behaviour.
+
+## Testing
+
+Renderer tests will exercise the real `SshProjectDialog` and Zustand server store.
+
+- A large server collection renders inside a dedicated list whose inline layout contract includes flexible shrinking, zero minimum height, vertical scrolling, and non-shrinking rows. The action row must remain a sibling outside that list.
+- Filtering matches labels, hosts, usernames, and `user@host` case-insensitively.
+- A non-matching query replaces server rows with the no-results message.
+- Clearing the query restores all server rows.
+- Existing connection and browse-master teardown tests remain green.
+
+The focused renderer test is followed by `npm run typecheck`, the full `npm test` suite, `npm run build`, and `git diff --check` before publication.
+
+## Surfaces
+
+- Desktop is covered because the picker is renderer UI.
+- Server Edition is covered because it uses the same renderer component.
+- Mobile is not applicable because the native companion does not render this project-creation dialog.
+
+## Out of scope
+
+- Changes to saved-server persistence or SSH connection behaviour.
+- Sorting, grouping, fuzzy scoring, or keyboard arrow navigation.
+- A generic quick-pick abstraction.
+- A second filter in Settings.

--- a/src/renderer/components/SshProjectDialog.test.tsx
+++ b/src/renderer/components/SshProjectDialog.test.tsx
@@ -18,7 +18,7 @@ import type { SshServer } from '@shared/ssh'
 
 const SERVER: SshServer = { id: 's1', label: 'testbox', host: 'h.example.com', user: 'u' }
 
-describe('SshProjectDialog browse-master teardown', () => {
+describe('SshProjectDialog', () => {
   let root: Root | undefined
   let host: HTMLElement
   let connect: ReturnType<typeof vi.fn>
@@ -65,6 +65,82 @@ describe('SshProjectDialog browse-master teardown', () => {
     if (!b) throw new Error(`no button containing "${text}"`)
     return b
   }
+  const setInputValue = (input: HTMLInputElement, value: string): void => {
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(input, value)
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+  const serverButtons = (): HTMLButtonElement[] =>
+    [...document.querySelectorAll<HTMLButtonElement>('[aria-label="Saved SSH servers"] button')]
+
+  it('keeps a large server collection in its own scroll region above the actions', () => {
+    useSshServers.setState({
+      servers: Array.from({ length: 25 }, (_, index) => ({
+        id: `server-${index}`,
+        label: `Server ${index}`,
+        host: `host-${index}.example.com`,
+        user: 'matt'
+      }))
+    })
+    render()
+
+    const list = document.querySelector<HTMLElement>('[aria-label="Saved SSH servers"]')
+    expect(list).not.toBeNull()
+    if (!list) return
+    const cancel = buttonByText('Cancel')
+    expect(serverButtons()).toHaveLength(25)
+    expect(list.style.flex).toBe('1 1 auto')
+    expect(list.style.minHeight).toBe('0px')
+    expect(list.style.overflowY).toBe('auto')
+    expect(serverButtons().every((button) => button.style.flexShrink === '0')).toBe(true)
+    expect(list.contains(cancel)).toBe(false)
+    expect(cancel.parentElement?.style.flexShrink).toBe('0')
+    expect(list.compareDocumentPosition(cancel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('filters saved servers by label, host, user, and user-at-host without case sensitivity', () => {
+    useSshServers.setState({
+      servers: [
+        { id: 'prod', label: 'Production', host: 'api.example.com', user: 'deploy' },
+        { id: 'stage', label: 'Staging', host: 'stage.internal', user: 'ubuntu' }
+      ]
+    })
+    render()
+    const filter = document.querySelector<HTMLInputElement>('[aria-label="Filter saved SSH servers"]')
+    expect(filter).not.toBeNull()
+    if (!filter) return
+
+    setInputValue(filter, 'PRODUCTION')
+    expect(serverButtons().map((button) => button.textContent)).toEqual([
+      expect.stringContaining('Production')
+    ])
+    setInputValue(filter, '  API.EXAMPLE.COM  ')
+    expect(serverButtons().map((button) => button.textContent)).toEqual([
+      expect.stringContaining('Production')
+    ])
+    setInputValue(filter, 'UBUNTU')
+    expect(serverButtons().map((button) => button.textContent)).toEqual([
+      expect.stringContaining('Staging')
+    ])
+    setInputValue(filter, 'ubuntu@stage.internal')
+    expect(serverButtons().map((button) => button.textContent)).toEqual([
+      expect.stringContaining('Staging')
+    ])
+    setInputValue(filter, '')
+    expect(serverButtons()).toHaveLength(2)
+  })
+
+  it('shows a no-results message instead of server rows when the filter has no match', () => {
+    render()
+    const filter = document.querySelector<HTMLInputElement>('[aria-label="Filter saved SSH servers"]')
+    expect(filter).not.toBeNull()
+    if (!filter) return
+    setInputValue(filter, 'missing-host')
+    expect(serverButtons()).toHaveLength(0)
+    expect(document.body.textContent).toContain('No saved servers match')
+  })
 
   it('cancelling DURING connecting still tears the browse master down (mark-before-await)', () => {
     const onClose = render()

--- a/src/renderer/components/SshProjectDialog.tsx
+++ b/src/renderer/components/SshProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useDialogStack } from './dialog-stack'
 import { useSshServers } from '../state/sshServers'
@@ -30,7 +30,8 @@ const ROW_STYLE: React.CSSProperties = {
   borderRadius: 8,
   color: 'var(--text)',
   fontSize: 13,
-  cursor: 'pointer'
+  cursor: 'pointer',
+  flexShrink: 0
 }
 
 /** Basename of an absolute remote path (for the project label). */
@@ -58,6 +59,7 @@ function parentDir(p: string): string {
  */
 export function SshProjectDialog({ onCreate, onManage, onClose }: SshProjectDialogProps) {
   const servers = useSshServers((s) => s.servers)
+  const [serverFilter, setServerFilter] = useState('')
   const [step, setStep] = useState<Step>('pick')
   const [server, setServer] = useState<SshServer | null>(null)
   const [path, setPath] = useState('~')
@@ -70,6 +72,15 @@ export function SshProjectDialog({ onCreate, onManage, onClose }: SshProjectDial
   // Stable id for the temporary browse master, generated once.
   const browseIdRef = useRef(`ssh-browse-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`)
   const connectBegunRef = useRef(false)
+  const visibleServers = useMemo(() => {
+    const query = serverFilter.trim().toLowerCase()
+    if (!query) return servers
+    return servers.filter((saved) =>
+      [saved.label, saved.host, saved.user, `${saved.user}@${saved.host}`].some((value) =>
+        value.toLowerCase().includes(query)
+      )
+    )
+  }, [servers, serverFilter])
 
   // Tear down the temporary browse master (best-effort) once it's no longer needed.
   const disconnectBrowse = useCallback(() => {
@@ -153,20 +164,55 @@ export function SshProjectDialog({ onCreate, onManage, onClose }: SshProjectDial
   const body = (() => {
     if (step === 'pick') {
       return (
-        <>
-          <p className="confirm__msg" style={{ fontWeight: 600 }}>
+        <div
+          style={{
+            display: 'flex',
+            flex: '1 1 auto',
+            flexDirection: 'column',
+            minHeight: 0
+          }}
+        >
+          <p className="confirm__msg" style={{ flex: '0 0 auto', overflow: 'visible', fontWeight: 600 }}>
             Connect over SSH
           </p>
-          <p className="confirm__msg">
+          <p className="confirm__msg" style={{ flex: '0 0 auto', overflow: 'visible' }}>
             Pick a saved server to host this project's terminals.
           </p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, margin: '6px 0 14px' }}>
+          {servers.length > 0 && (
+            <Input
+              autoFocus
+              aria-label="Filter saved SSH servers"
+              placeholder="Filter by label, host, or user"
+              value={serverFilter}
+              onChange={(event) => setServerFilter(event.target.value)}
+              className="mb-2"
+              style={{ flexShrink: 0 }}
+            />
+          )}
+          <div
+            role="group"
+            aria-label="Saved SSH servers"
+            style={{
+              display: 'flex',
+              flex: '1 1 auto',
+              minHeight: 0,
+              overflowY: 'auto',
+              overscrollBehavior: 'contain',
+              flexDirection: 'column',
+              gap: 6,
+              margin: '6px 0 14px'
+            }}
+          >
             {servers.length === 0 ? (
-              <p className="confirm__msg" style={{ opacity: 0.7 }}>
+              <p className="confirm__msg" style={{ flex: '0 0 auto', margin: 0, opacity: 0.7 }}>
                 No saved servers yet.
               </p>
+            ) : visibleServers.length === 0 ? (
+              <p className="confirm__msg" style={{ flex: '0 0 auto', margin: 0, opacity: 0.7 }}>
+                No saved servers match “{serverFilter.trim()}”.
+              </p>
             ) : (
-              servers.map((s) => (
+              visibleServers.map((s) => (
                 <button
                   key={s.id}
                   style={ROW_STYLE}
@@ -191,7 +237,7 @@ export function SshProjectDialog({ onCreate, onManage, onClose }: SshProjectDial
               ))
             )}
           </div>
-          <div className="confirm__actions">
+          <div className="confirm__actions" style={{ flexShrink: 0 }}>
             <Button onClick={close}>Cancel</Button>
             <Button
               variant="primary"
@@ -203,7 +249,7 @@ export function SshProjectDialog({ onCreate, onManage, onClose }: SshProjectDial
               Add server…
             </Button>
           </div>
-        </>
+        </div>
       )
     }
     if (step === 'connecting') {


### PR DESCRIPTION
## What changed

- Put the saved-server rows in a dedicated flexible scroll region while keeping the title, filter, Cancel, and Add server actions fixed in the dialog.
- Added a pinned type-to-filter input matching label, host, user, and `user@host` case-insensitively.
- Added a clear no-results state without changing the existing empty-list state or SSH connection flow.
- Left Settings unchanged because its main content surface already owns vertical scrolling.

## Root cause

The capped `.confirm` flex column contained an unconstrained server-list child. That child had neither `min-height: 0` nor vertical overflow, so a large imported host collection extended beyond the visible dialog and pushed its actions out of reach.

## Verification

- `npx vitest run src/renderer/components/SshProjectDialog.test.tsx` with 6 tests passing
- Mutation check confirmed the layout regression test fails when `overflowY: 'auto'` is removed
- `npm run typecheck`
- `npm test` with 5,200 tests passing and 8 skipped
- `npm run build`
- `git diff --check main...HEAD`

## Surfaces

- Desktop and Server Edition use the same renderer component and are covered by this change.
- Mobile is not applicable because the native companion does not render this dialog.

## Not verified

No live SSH connection or manual Electron screenshot was needed for this renderer-only list-layout change. Existing connect, cancel, and browse-master teardown tests remain green.

Closes #141