### PR TITLE
fix(terminal): pin addon-webgl to 0.18.0 and heal a renderer-less release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,14 @@ updates:
         update-types: [version-update:semver-major]
       - dependency-name: node-pty
         update-types: [version-update:semver-major]
+      # The @xterm family must move in LOCKSTEP, by hand: the addons reach into the core's
+      # internals, so an addon bump against an older core crashes at runtime with no compile
+      # error. addon-webgl 0.19.0 on the 5.5 core read `_core._store` (a 5.6+ field) in its
+      # dispose path and aborted the DOM-renderer restore — every context release left a
+      # renderer-less, permanently black terminal (the zoom-out blackout). Guarded by
+      # src/renderer/terminal/webgl-addon-pair.test.ts; upgrade the whole family together
+      # (next vehicle: the xterm 6.x major).
+      - dependency-name: "@xterm/*"
 
   # Keep the GitHub Actions pinned in the workflows current (security patches to
   # checkout / setup-node / codeql-action land here).

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@vitejs/plugin-react": "^4.3.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
-        "@xterm/addon-webgl": "^0.19.0",
+        "@xterm/addon-webgl": "0.18.0",
         "@xterm/xterm": "^5.5.0",
         "@xyflow/react": "^12.11.2",
         "electron": "^42.7.1",
@@ -3219,11 +3219,14 @@
       }
     },
     "node_modules/@xterm/addon-webgl": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
-      "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
+      "integrity": "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
     },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
-    "@xterm/addon-webgl": "^0.19.0",
+    "@xterm/addon-webgl": "0.18.0",
     "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.11.2",
     "electron": "^42.7.1",

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -1674,14 +1674,36 @@ export function TerminalNode({
       const canvases = term.element ? Array.from(term.element.querySelectorAll('canvas')) : null
       try {
         webgl.dispose()
-      } catch {
-        // already disposed via context loss
+      } catch (err) {
+        // A second dispose after onContextLoss already ran is a silent no-op — a THROW here is
+        // never that. The addon's dispose is ALSO its put-xterm-back-on-a-DOM-renderer path (a
+        // disposable registered at activate), so a throw aborts the restore and would leave the
+        // terminal with NO renderer at all: zero canvases, zero `.xterm-rows`, a permanently
+        // black node no repaint can reach. Seen in the field as the zoom-out blackout when
+        // addon-webgl 0.19.0's dispose guard read xterm-5.6 internals (`_core._store`) on the
+        // 5.5 core and crashed on EVERY release. The renderer-less check below is the heal; the
+        // warn is its field trace.
+        console.warn('[nodeterm] webgl dispose threw mid-release', err)
       }
       webgl = null
       loseWebglContexts(canvases)
       // A dispose that died midway leaves its (now context-lost, permanently BLACK) canvas
       // attached OVER the DOM rows — sweep it before the repaint (see the safety-net note).
       verifyCleanDomState('release')
+      // The other way a dispose dies midway: canvases already gone but the DOM renderer never
+      // installed (the throw above). `verifyCleanDomState` cannot see that state — it keys on
+      // stray canvases, and here there are none — so probe for the renderer's row container
+      // directly and rebuild what the addon's aborted restore owed. Skipped while a glyph
+      // attachment owns the screen (no rows there by design, and `setRenderer` would dispose
+      // the glyph addon — see the both-renderers invariant).
+      if (!disposed && !glyphAttach && term.element && !term.element.querySelector('.xterm-rows')) {
+        if (restoreDomRenderer()) {
+          console.warn('[nodeterm] healed a renderer-less webgl release: DOM renderer restored')
+        } else {
+          escalateRespawn('webgl release left no renderer and the DOM restore failed')
+          return
+        }
+      }
       // The DOM renderer that replaced the addon starts from an EMPTY row container, and this
       // release almost always runs while the node is HIDDEN — the swap's own refresh defers
       // behind xterm's pause flag, which is exactly where it can be lost. Re-arm it explicitly.

--- a/src/renderer/terminal/webgl-addon-pair.test.ts
+++ b/src/renderer/terminal/webgl-addon-pair.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Guard for a runtime-only version coupling that bit for real: `@xterm/addon-webgl` reaches
+ * into `@xterm/xterm`'s INTERNALS, so the pair compiles cleanly at any version skew and only
+ * fails in the field. 0.19.0's dispose guard reads `_core._store._isDisposed` — a field the
+ * 5.6+ core has and the 5.5 core does not — so on xterm 5.5.0 EVERY `WebglAddon.dispose()`
+ * threw before its own put-xterm-back-on-a-DOM-renderer disposable ran. Every budget release
+ * (zoom gate, LRU reclaim, hidden-release delay, memory pressure) then left that terminal with
+ * no renderer at all: zero canvases, zero `.xterm-rows`, a permanently black node. Field
+ * signature: zoom-out across the 40% gate blacked out every visible terminal at once.
+ *
+ * The dependabot config ignores `@xterm/*` for the same reason (a grouped minor bump is what
+ * shipped 0.19.0). This test is the in-repo half of that guard: it pins the exact pair, so a
+ * bump that slips past dependabot — or a hand edit that moves one half — fails the suite with
+ * this story attached. Upgrading is fine, deliberately, and as a FAMILY: verify the release
+ * path end-to-end (zoom a busy canvas across the 40%/45% band, terminals must fall back to
+ * readable DOM rows, not black), then update both sides of this expectation together.
+ */
+describe('@xterm/addon-webgl ↔ @xterm/xterm version pair', () => {
+  it('stays on the exact pair the release path was verified against', () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8')
+    ) as { devDependencies: Record<string, string> }
+    expect(pkg.devDependencies['@xterm/addon-webgl']).toBe('0.18.0')
+    expect(pkg.devDependencies['@xterm/xterm']).toBe('^5.5.0')
+  })
+
+  it('the installed addon has no dispose-time core-internals guard the 5.5 core cannot satisfy', () => {
+    // The exact expression that crashed: a dispose-path read of `_core._store`. 0.18.0 does not
+    // contain it; if a future addon build does, the core must be new enough to carry the field —
+    // re-verify the release path before loosening this.
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../../../node_modules/@xterm/addon-webgl/lib/addon-webgl.js'),
+      'utf8'
+    )
+    expect(src.includes('_store._isDisposed')).toBe(false)
+  })
+})


### PR DESCRIPTION
## The bug

Since the Jul 22 grouped dependency bump (4d17552d) took `@xterm/addon-webgl` to **0.19.0** while `@xterm/xterm` stayed on **5.5.0**, every WebGL context release has left the terminal permanently **black**. 0.19.0's dispose-time guard reads `_core._store._isDisposed` — a 5.6+ core field that doesn't exist on 5.5 — so `WebglAddon.dispose()` throws **before** its own put-xterm-back-on-a-DOM-renderer disposable runs. The terminal ends up with *no renderer at all* (zero canvases, zero `.xterm-rows`), a state no repaint can reach and which our `verifyCleanDomState` safety net cannot see (it keys on stray canvases).

Field signature, reproduced deterministically on a Linux Server Edition headless run (8-terminal canvas, GPU-per-terminal mode, 50%→35%→60% zoom dance):

- zoom-out across the **40% budget gate** blacks out every visible terminal at once (the gate releases every context through the broken dispose);
- the **45% re-grant crossing** and any LRU / hidden-delay / memory-pressure release blacken nodes the same way;
- panning a node out and back "fixes" it only because a fresh grant installs a fresh WebGL renderer.

This was never the macOS compositor — it reproduces identically on Linux SwiftShader, session-count-independent, bound to the 40/45 hysteresis band.

## The fix, three layers

1. **Pin `@xterm/addon-webgl` to exactly `0.18.0`** — the pair the 5.5 core supports; its restore closure has no core-internals guard (verified against the published tarball).
2. **Dependabot ignores `@xterm/*` entirely** — the family moves in lockstep by hand; an addon bump against an older core compiles clean and only fails at runtime. Next vehicle is the xterm 6.x major, taken as one family.
3. **`releaseWebgl` hardening** — a dispose throw is warned instead of swallowed, and a renderer-less probe (no webgl, no `.xterm-rows`) restores the DOM renderer, escalating to the once-per-mount respawn if that fails. Deliberately verified against the broken 0.19.0: all six visible terminals healed to readable DOM rows where they previously stranded black.

`src/renderer/terminal/webgl-addon-pair.test.ts` keeps the pair honest in-repo: it pins both sides and greps the installed addon for the exact expression that crashed, with the upgrade playbook in its header.

## Verification

| Check | Result |
| --- | --- |
| `npm run typecheck` + full vitest suite | green (5195 passed, incl. the new pair guard) |
| E2E on broken 0.19.0 **without** the heal | all visible terminals renderer-less black below the 40% gate |
| E2E on broken 0.19.0 **with** the heal | 6/6 releases healed to readable DOM rows (`dispose threw` ×6 → `DOM renderer restored` ×6) |
| E2E on pinned 0.18.0 (final) | readable DOM rows below the gate, clean WebGL re-grants above it, zero heal warnings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)