### PR TITLE
fix(codex): gate shared identity on an install that can actually run an app-server

### DIFF
--- a/docs/codex-shared-identity.md
+++ b/docs/codex-shared-identity.md
@@ -20,6 +20,35 @@ The node ↔ thread mapping is what makes that survivable. It has to outlive the
 sessions do: a running Codex client can outlive the Electron process that started it, and after a
 restart nothing in memory knows whose conversation is whose.
 
+### What it requires: an install channel, not a version
+
+`codex app-server daemon start` — the whole feature's foundation — runs the app-server out of a
+**standalone runtime the Codex installer manages**, at the fixed path
+`<CODEX_HOME>/packages/standalone/current/codex`. An install that does not put a runtime there
+cannot host a shared app-server **at any version**:
+
+```
+$ codex --version
+codex-cli 0.146.0
+$ codex app-server daemon start
+Error: managed standalone Codex install not found at /root/.codex/packages/standalone/current/codex
+
+This command requires the standalone install managed by the Codex installer, because the daemon
+starts and updates app-server from that fixed path.
+
+Install it with:
+  curl -fsSL https://chatgpt.com/codex/install.sh | sh
+```
+
+That is codex **0.146.0 installed via npm** — the mainstream channel, and the one
+`docs/troubleshooting-codex-snap.md` steers users toward. It is not an old CLI: its `--help` lists
+`--remote` and `--remote-auth-token-env`, `codex app-server daemon --help` lists every subcommand,
+and `codex app-server daemon stop` reports the requirement itself as JSON
+(`"managedCodexPath":"/root/.codex/packages/standalone/current/codex","managedCodexVersion":null`).
+
+So the population that gets a shared identity is **the standalone-installer channel**, and every
+other install runs plain `codex`. §3 is what makes that a quiet degrade instead of a noisy one.
+
 ## 2. The pieces
 
 | File | Job |
@@ -133,18 +162,47 @@ that is a later slice — so a launcher-named line there would be `command not f
 dead node this exists to prevent.) The default `false` means every call site that has not opted in
 emits today's command.
 
-`shared` is the AND of three things, and the third is the interesting one: the installed `codex`
-must accept **`--remote`**. That is the only precondition with no runtime recovery — the launcher's
-preflight proves `codex app-server daemon start` exits 0 and then **execs**, and a CLI with an
-app-server but no `--remote` dies on a clap usage error where no fallback is left. It is
-feature-detected from the CLI's own `--help` (and `codex resume --help` if the first does not say),
-never version-compared, for the same reason claude's `--session-id` is: an unrecognised flag does
-not degrade, it makes the CLI exit. Unknown — no CLI on the login PATH, a failed or timed-out
-spawn, help text that never mentions the flag — means **false**, i.e. plain codex. A wrong "yes"
-costs the node; a wrong "no" costs only the shared app-server. The probe runs **once per app run,
-inside `refreshCodexIdentityCaps()`, entirely off the launch path**: a per-launch probe would be
-visible latency in the pane every time, to answer a question whose answer cannot change while the
-app runs.
+`shared` is the AND of **four** things, and the last two are the interesting ones.
+
+**Can this install run an app-server at all?** (`appServer`, `codexManagedRuntimeInstalled`.) The
+question §1 poses, answered by a **stat** of `<CODEX_HOME>/packages/standalone/current/codex`. The
+first cut of this file asked a different question — does `--help` mention `--remote` — which an
+npm-installed codex 0.146.0 answers *yes* while `daemon start` refuses, so on the mainstream
+channel we wrote `nodeterm-codex` into every launch line and only found out at runtime: a wasted
+curl round trip, a `plain codex` chip, and the first-fallback banner, per node, forever, for a
+feature that cannot function there. The feature is meant to be **inert** off the standalone
+channel, not noisily inert.
+
+Why a stat, and not the authoritative command:
+
+| Candidate | Why not |
+| --- | --- |
+| `codex app-server daemon start` | It **starts a daemon**. The probe runs at boot on every machine with codex installed, including the runs where no Codex node is ever opened; a capability probe must not create the very process the feature exists to create lazily. |
+| `codex app-server daemon version` | Read-only, but it connects to the control socket, so it fails on a perfectly capable install whose daemon merely is not up yet — i.e. after every boot. The probe runs ONCE, so that pins the feature off for the session on exactly the machines it is for. |
+| `codex app-server daemon stop` | Prints the authoritative JSON (`managedCodexPath`, `managedCodexVersion`) and exits 0 even when nothing is running — but it **stops a running daemon**, which is the shared app-server every other node is attached to. |
+
+The path is not inferred: the CLI names it verbatim in its refusal and reports it as
+`managedCodexPath`. It is resolved through `codexHome()`, so `$CODEX_HOME` is honored (with §8.5's
+caveat that the pane may resolve it differently). Anything unestablished — a missing path, a
+non-executable file, a permission error, a layout we do not recognise — is **false**.
+
+**Does the installed `codex` accept `--remote`?** (`remoteFlag`, `codexCliSupportsRemote`.) The
+only precondition with no runtime recovery — the launcher's preflight proves `daemon start` exits 0
+and then **execs**, and a CLI with an app-server but no `--remote` dies on a clap usage error where
+no fallback is left. Feature-detected from the CLI's own `--help` (and `codex resume --help` if the
+first does not say), never version-compared, for the same reason claude's `--session-id` is: an
+unrecognised flag does not degrade, it makes the CLI exit.
+
+The install check runs **first** and short-circuits the help spawns: with no app-server to reach
+there is nothing to learn about a flag we will never use, so `remoteFlag` reads false there as
+"not probed" — unknown, like every other unknown in this file.
+
+Unknown anywhere in the chain — no CLI on the login PATH, a failed or timed-out spawn, no standalone
+runtime, help text that never mentions the flag — means **false**, i.e. plain codex. A wrong "yes"
+costs the node (or at minimum a banner on every one of them); a wrong "no" costs only the shared
+app-server. Both probes run **once per app run, inside `refreshCodexIdentityCaps()`, entirely off
+the launch path**: a per-launch probe would be visible latency in the pane every time, to answer a
+question whose answer cannot change while the app runs.
 
 Unlike claude's, this probe cannot compute anything until the shell hands the hook server its
 secret, so the shell **pushes** the answer in and an early caller **waits**. A sync getter would
@@ -177,9 +235,22 @@ The mode is **transient**, never persisted: it describes one launch of one proce
 | `broker-unreachable` | the hook server's coordinates are unusable |
 | `node-token-unavailable` | no per-node capability — usually no secure storage |
 | `thread-id-unavailable` | the session id to resume is not shaped like one |
-| `app-server-unavailable` | `codex app-server daemon start` failed — an older CLI |
+| `app-server-unavailable` | `daemon start` failed with a standalone runtime present — an older CLI, or a daemon that would not come up |
+| `codex-standalone-missing` | `daemon start` failed and there is no standalone runtime — an npm or snap install (§1), not a version problem |
 | `thread-bind-refused` | the thread is unknown to the server, or a live node already owns it |
 | `thread-start-failed` | the server would not mint a thread |
+
+The last two used to be one reason whose copy said *"an older CLI"*, which sent anyone reading it on
+a codex 0.146.0 node hunting for a version problem that did not exist — the
+misleading-error-message class this repo has lost diagnosis time to before. The launcher runs
+`daemon start` first, unchanged and authoritative, and only then stats
+`${CODEX_HOME:-$HOME/.codex}/packages/standalone/current/codex` to decide **which** of the two it
+hit. That ordering matters: a stat that ran first would let a future codex that no longer needs the
+standalone runtime fall back on evidence we have no business trusting over the command itself.
+
+Caps normally keeps `codex-standalone-missing` away from the launcher entirely, so seeing it means
+something the boot probe could not: the standalone install was removed while the app was running,
+or the pane's `CODEX_HOME` differs from the desktop's (§8.5).
 
 ### What the fallback does NOT cover
 
@@ -266,6 +337,14 @@ PR #112, all still to be sliced.
 1. **Post-`exec` failures are unrecoverable** (§3). The `--remote` case is closed at caps time;
    what remains is §9.2 (the composed `resume <id> <prompt> --ask-for-approval never` line) and
    §9.3 (the persisted session id being the app-server's thread id).
+   - **The install-channel gate is a stat, not the command it stands for.**
+     `codexManagedRuntimeInstalled` asserts the standalone runtime exists at the path today's CLI
+     requires; it does not prove `daemon start` will succeed (a corrupt runtime, a wedged socket, a
+     sandbox that blocks the spawn all still fail at the launcher, correctly, as
+     `app-server-unavailable`). And should a future codex drop the standalone requirement, this
+     answers a wrong **no** — plain codex, the direction everything here degrades in, but it would
+     need re-measuring rather than assuming. The alternatives, and why none of them is cheaper
+     *and* conclusive, are the table in §3.
 2. **The launcher requires a hook PORT**, not a unix socket — it POSTs to
    `http://localhost:$NODETERM_HOOK_PORT`. Fine today (the desktop's hook server is a loopback TCP
    listener), but the Server Edition wiring will have to revisit it alongside `NODETERM_HOOK_SOCK`,
@@ -293,13 +372,19 @@ Everything below needs a machine with a logged-in `codex`. Items 1-3 are the ass
 implementation could not verify; a failure in any of them is a **dead node**, not a degrade, so they
 come first. Items 1, 2 and 5 fall out of a single capture run on one fresh node.
 
-1. **`codex --remote unix://` works, and the caps probe reads the flag correctly.** The flag's
-   PRESENCE is now answered per machine (`codexCliSupportsRemote`, §3), so a CLI without it gets a
-   plain-codex node instead of a dead one — but nothing has confirmed that the flag we detect is
-   the flag we then use. Run `codex --help` and check `--remote`'s argument form against the two
-   `exec` lines in the launcher; then open a fresh Codex node and confirm the pane shows a working
-   session rather than a clap usage error. Also confirm the negative: on a CLI without `--remote`
-   (or with the probe forced false), the node runs plain codex and says so.
+1. **`codex --remote unix://` works — the part the probe cannot answer by itself.**
+   What no longer needs a device: whether this machine gets a shared identity at all. Both halves
+   of that gate are answered per machine and pinned by tests — `codexManagedRuntimeInstalled`
+   (§1's install-channel requirement, **measured false** on codex-cli 0.146.0 installed via npm,
+   where `daemon start` refuses with "managed standalone Codex install not found") and
+   `codexCliSupportsRemote` (the flag's presence). An install that fails either runs plain codex,
+   silently, with no launcher ever named — so the negative case is closed on paper.
+   What still needs a machine on the **standalone-installer** channel: that the flag we detect is
+   the flag we then use. Check `--remote`'s argument form in `codex --help` against the two `exec`
+   lines in the launcher, open a fresh Codex node, and confirm the pane shows a working session
+   rather than a clap usage error. And confirm the whole gate one level up: on that machine the
+   node comes up **shared**, while on an npm install the same build opens a plain codex node with
+   **no chip and no banner at all** (not a `plain codex` chip — the launcher must never have run).
 2. **`codex resume <id> <prompt> --ask-for-approval never` accepts a positional prompt AND a global
    flag after the subcommand.** This is the composed line `createAgentNode` builds, and it is
    CLAUDE.md rule 5's grok-`--` lesson exactly: a `withPermissionMode` unit test passes while the

--- a/src/core/codex-identity-caps.test.ts
+++ b/src/core/codex-identity-caps.test.ts
@@ -6,12 +6,16 @@ import { randomBytes } from 'node:crypto'
 import {
   codexCliSupportsRemote,
   codexIdentityCaps,
+  codexManagedRuntimeInstalled,
+  codexManagedRuntimePath,
   refreshCodexIdentityCaps,
   resetCodexIdentityCapsForTests
 } from './codex-identity-caps'
 
 /** Stand-in for the `codex --help` probe. Every test says explicitly what the CLI answered. */
 const remote = (yes: boolean) => () => Promise.resolve(yes)
+/** Stand-in for the managed-runtime stat — "can this INSTALL run an app-server at all?". */
+const appServer = (yes: boolean) => () => yes
 import {
   resetCodexThreadIdentityAuthSecret,
   setCodexThreadIdentityAuthSecret
@@ -39,7 +43,7 @@ afterEach(() => {
 describe('codexIdentityCaps', () => {
   it('says yes, and installs the launcher, once the secret is in and the CLI has --remote', async () => {
     setCodexThreadIdentityAuthSecret(randomBytes(32))
-    const caps = await refreshCodexIdentityCaps(remote(true))
+    const caps = await refreshCodexIdentityCaps(remote(true), appServer(true))
     expect(caps.shared).toBe(true)
     expect(fs.existsSync(caps.launcherPath as string)).toBe(true)
   })
@@ -47,8 +51,13 @@ describe('codexIdentityCaps', () => {
   it('says no without the secret, and installs nothing', () => {
     // Half-armed is the state to avoid: a launcher on PATH with no capability to present would
     // reach the routes, be refused, and fall back one process later. Better to never name it.
-    return refreshCodexIdentityCaps(remote(true)).then((caps) => {
-      expect(caps).toEqual({ shared: false, launcherPath: null, remoteFlag: true })
+    return refreshCodexIdentityCaps(remote(true), appServer(true)).then((caps) => {
+      expect(caps).toEqual({
+        shared: false,
+        launcherPath: null,
+        remoteFlag: true,
+        appServer: true
+      })
       expect(fs.existsSync(path.join(dir, 'codex-bin', 'nodeterm-codex'))).toBe(false)
     })
   })
@@ -58,8 +67,66 @@ describe('codexIdentityCaps', () => {
     // app-server but no --remote dies on a usage error where nothing can fall back. Answering it
     // here turns a dead node into a plain-codex node on every machine, not just the tester's.
     setCodexThreadIdentityAuthSecret(randomBytes(32))
-    const caps = await refreshCodexIdentityCaps(remote(false))
-    expect(caps).toEqual({ shared: false, launcherPath: null, remoteFlag: false })
+    const caps = await refreshCodexIdentityCaps(remote(false), appServer(true))
+    expect(caps).toEqual({
+      shared: false,
+      launcherPath: null,
+      remoteFlag: false,
+      appServer: true
+    })
+    expect(fs.existsSync(path.join(dir, 'codex-bin', 'nodeterm-codex'))).toBe(false)
+  })
+
+  // THE MEASURED CASE. codex-cli 0.146.0 installed via npm — the mainstream channel, and the one
+  // docs/troubleshooting-codex-snap.md steers users toward — advertises `--remote` in `codex --help`
+  // and in `codex resume --help`, and then answers `codex app-server daemon start` with
+  //   Error: managed standalone Codex install not found at ~/.codex/packages/standalone/current/codex
+  // Gating on the help text alone wrote `nodeterm-codex` into the launch line of every Codex node on
+  // such a machine: a wasted curl round trip, a `plain codex` chip, and the first-fallback warning
+  // banner, per node, forever, for a feature that cannot work there. Inert is fine; noisily inert is
+  // not, and this row is what keeps it inert.
+  it('says no on an npm install — `--remote` in help, no standalone runtime — and writes no launcher', async () => {
+    setCodexThreadIdentityAuthSecret(randomBytes(32))
+    const caps = await refreshCodexIdentityCaps(remote(true), appServer(false))
+    expect(caps).toEqual({
+      shared: false,
+      launcherPath: null,
+      // Not probed: with no app-server to reach there is nothing to learn from a help page about a
+      // flag we will never use, and "unknown" is false here like everywhere else in this file.
+      remoteFlag: false,
+      appServer: false
+    })
+    expect(fs.existsSync(path.join(dir, 'codex-bin', 'nodeterm-codex'))).toBe(false)
+  })
+
+  it('does not even spawn the help probe when the install cannot run an app-server', async () => {
+    setCodexThreadIdentityAuthSecret(randomBytes(32))
+    let asked = 0
+    await refreshCodexIdentityCaps(() => {
+      asked += 1
+      return Promise.resolve(true)
+    }, appServer(false))
+    expect(asked).toBe(0)
+  })
+
+  it('says no when the install probe itself fails or times out', async () => {
+    // Fail-closed is the whole contract: anything we could not establish means the bare `codex`
+    // this feature degrades to everywhere else, never an optimistic launcher path.
+    setCodexThreadIdentityAuthSecret(randomBytes(32))
+    const threw = await refreshCodexIdentityCaps(remote(true), () => {
+      throw new Error('stat failed')
+    })
+    expect(threw).toEqual({
+      shared: false,
+      launcherPath: null,
+      remoteFlag: false,
+      appServer: false
+    })
+    resetCodexIdentityCapsForTests()
+    const rejected = await refreshCodexIdentityCaps(remote(true), () =>
+      Promise.reject(new Error('probe timed out'))
+    )
+    expect(rejected.shared).toBe(false)
     expect(fs.existsSync(path.join(dir, 'codex-bin', 'nodeterm-codex'))).toBe(false)
   })
 
@@ -73,17 +140,41 @@ describe('codexIdentityCaps', () => {
     await Promise.resolve()
     expect(settled).toBe(false)
     setCodexThreadIdentityAuthSecret(randomBytes(32))
-    await refreshCodexIdentityCaps(remote(true))
+    await refreshCodexIdentityCaps(remote(true), appServer(true))
     expect((await asked).shared).toBe(true)
   })
 
   it('answers immediately once refreshed', async () => {
-    await refreshCodexIdentityCaps(remote(false))
+    await refreshCodexIdentityCaps(remote(false), appServer(true))
     expect(await codexIdentityCaps()).toEqual({
       shared: false,
       launcherPath: null,
-      remoteFlag: false
+      remoteFlag: false,
+      appServer: true
     })
+  })
+})
+
+describe('codexManagedRuntimeInstalled', () => {
+  // The path is not inferred: `codex app-server daemon start` names it verbatim in its refusal, and
+  // `codex app-server daemon stop` reports it as `managedCodexPath` in JSON.
+  it('is the fixed path the CLI itself names, under CODEX_HOME', () => {
+    expect(codexManagedRuntimePath('/somewhere/.codex')).toBe(
+      path.join('/somewhere/.codex', 'packages', 'standalone', 'current', 'codex')
+    )
+  })
+
+  it('answers yes only for an executable runtime at that path', () => {
+    // An npm install has ~/.codex (auth, config, sessions) and no `packages/` at all — which is
+    // exactly the shape measured on the machine this fix was written on.
+    expect(codexManagedRuntimeInstalled(dir)).toBe(false)
+    const runtime = codexManagedRuntimePath(dir)
+    fs.mkdirSync(path.dirname(runtime), { recursive: true })
+    fs.writeFileSync(runtime, '#!/bin/sh\nexit 0\n', { mode: 0o644 })
+    // Present but not executable is not a runtime the daemon can exec, so it is still no.
+    expect(codexManagedRuntimeInstalled(dir)).toBe(false)
+    fs.chmodSync(runtime, 0o755)
+    expect(codexManagedRuntimeInstalled(dir)).toBe(true)
   })
 })
 

--- a/src/core/codex-identity-caps.ts
+++ b/src/core/codex-identity-caps.ts
@@ -14,12 +14,24 @@
  * `codexIdentityCaps` below for why waiting, rather than answering "no", is the only safe default
  * here.
  *
- * Three things have to be true, and none is knowable from the renderer:
+ * FOUR things have to be true, and none is knowable from the renderer:
  *  1. the hook server holds the per-node auth secret (no secret ⇒ no capability token ⇒ the
  *     launcher would fall back anyway, one process later),
  *  2. the generated launcher could actually be written (a read-only or full data dir is a real
- *     failure mode, and it is the one the renderer cannot see at all), and
- *  3. the installed `codex` accepts `--remote` — see `codexCliSupportsRemote`. This is the only
+ *     failure mode, and it is the one the renderer cannot see at all),
+ *  3. this INSTALL of codex can run a shared app-server at all — see
+ *     `codexManagedRuntimeInstalled`. This is the precondition the first cut got wrong: it asked
+ *     `--help` for a `--remote` flag, which an npm-installed codex 0.146.0 advertises perfectly
+ *     happily while `codex app-server daemon start` answers
+ *
+ *       Error: managed standalone Codex install not found at
+ *       ~/.codex/packages/standalone/current/codex
+ *
+ *     So on the mainstream install channel we wrote `nodeterm-codex` into the launch line and only
+ *     discovered at runtime that it could never work: a wasted curl round trip, a `plain codex`
+ *     chip, and a warning banner on the first fallback of EVERY node, forever, for a feature that
+ *     cannot function on that install. Noisily inert. Answered here it is genuinely inert, and
+ *  4. the installed `codex` accepts `--remote` — see `codexCliSupportsRemote`. This is the only
  *     one that cannot be recovered from at runtime: the launcher's preflight proves that
  *     `codex app-server daemon start` exits 0, and then EXECS. A CLI with an app-server but no
  *     `--remote` dies on a clap usage error after that exec, where there is no fallback left. So
@@ -30,15 +42,61 @@
  * than an accident.
  */
 import { execFile } from 'child_process'
+import { accessSync, constants } from 'fs'
+import path from 'path'
 import { promisify } from 'util'
 import { IPC } from '../shared/ipc'
 import { platform } from './platform'
 import { type CodexIdentityCaps } from '../shared/types'
 import { installCodexLauncher, codexThreadIdentityAvailable } from './codex-identity-proxy'
+import { codexHome } from './usage/codex-usage'
 import { findInLoginPath } from './pty-manager'
 
 const execFileP = promisify(execFile)
 const PROBE_TIMEOUT_MS = 5000
+
+/**
+ * The fixed path `codex app-server daemon start` requires, under the CLI's own `CODEX_HOME`.
+ *
+ * Not a guess: the CLI names this exact path in the error it refuses with, and reports it as
+ * `managedCodexPath` in `codex app-server daemon stop`'s JSON. Its own words are "the daemon starts
+ * and updates app-server from that fixed path".
+ */
+export function codexManagedRuntimePath(home = codexHome()): string {
+  return path.join(home, 'packages', 'standalone', 'current', 'codex')
+}
+
+/**
+ * Can this install run a shared app-server? A STAT, and deliberately not `codex app-server daemon
+ * start`.
+ *
+ * The three candidates, and why this one:
+ *  - `codex app-server daemon start` is the authoritative answer, and it STARTS A DAEMON. This
+ *    probe runs once per app run at boot, on every machine with codex installed, including the
+ *    runs where no Codex node is ever opened. A capability probe must not create the very process
+ *    the feature exists to create lazily.
+ *  - `codex app-server daemon version` is read-only but connects to the control socket, so it
+ *    fails on a perfectly capable install whose daemon merely is not running yet — i.e. after
+ *    every boot. Fail-closed, but uselessly so: the probe runs ONCE, so it would pin the feature
+ *    off for the session on the machines it is meant to be on.
+ *  - `codex app-server daemon stop` prints the authoritative JSON (`managedCodexPath`,
+ *    `managedCodexVersion`) and exits 0 even when nothing is running — but it stops a RUNNING
+ *    daemon, which is the shared app-server every other node is attached to. Refused outright.
+ *
+ * So: the same fact, read the cheapest conclusive way, with no side effect and no spawn. Anything
+ * we cannot establish — a relocated home, a permission error, a layout we do not recognise —
+ * throws or misses and answers `false`, which is the bare `codex` this feature degrades to
+ * everywhere else. A wrong "no" costs only the shared app-server; a wrong "yes" costs a round trip
+ * and a banner on every node.
+ */
+export function codexManagedRuntimeInstalled(home = codexHome()): boolean {
+  try {
+    accessSync(codexManagedRuntimePath(home), constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
 
 /**
  * Pure: help text → does this CLI accept `--remote`?
@@ -85,19 +143,27 @@ let announce: ((c: CodexIdentityCaps) => void) | null = null
 
 /**
  * Compute the answer and publish it. Called once by the shell, AFTER the node-auth secret has been
- * set (or has definitively failed), because the secret is a third of what "shared" means.
+ * set (or has definitively failed), because the secret is one quarter of what "shared" means.
  *
  * Async because of the `--remote` probe, which is a login-shell lookup plus up to two `--help`
  * spawns. That cost is paid HERE — once, during boot, with nothing waiting on it but the first
  * Codex launch line — and never on the launch path itself, where it would be visible latency in
  * the pane every single time, to answer a question whose answer cannot change while the app runs.
+ *
+ * The install check runs FIRST and short-circuits the spawns: on an npm install it is a single
+ * failed stat, and there is nothing to learn from a help page about a flag we will never reach.
  */
 export async function refreshCodexIdentityCaps(
-  probeRemote: () => Promise<boolean> = probeRemoteFlag
+  probeRemote: () => Promise<boolean> = probeRemoteFlag,
+  probeAppServer: () => boolean | Promise<boolean> = codexManagedRuntimeInstalled
 ): Promise<CodexIdentityCaps> {
-  const remoteFlag = await probeRemote()
-  const launcher = remoteFlag && codexThreadIdentityAvailable() ? installCodexLauncher() : null
-  latest = { shared: !!launcher, launcherPath: launcher, remoteFlag }
+  const appServer = await Promise.resolve()
+    .then(() => probeAppServer())
+    .catch(() => false)
+  const remoteFlag = appServer ? await probeRemote() : false
+  const launcher =
+    appServer && remoteFlag && codexThreadIdentityAvailable() ? installCodexLauncher() : null
+  latest = { shared: !!launcher, launcherPath: launcher, remoteFlag, appServer }
   if (announce) {
     announce(latest)
     announce = null

--- a/src/core/codex-identity-proxy.ts
+++ b/src/core/codex-identity-proxy.ts
@@ -318,8 +318,25 @@ nt_preflight() {
   if [ "\${1-}" = resume ]; then
     case "\${2-}" in ''|*[!A-Za-z0-9._-]*) nt_fail thread-id-unavailable; return ;; esac
   fi
-  ${appServerStartCommand} || { nt_fail app-server-unavailable; return; }
-  return 0
+  # The authoritative check runs FIRST and unchanged; the stat below only decides WHICH reason to
+  # report. Ordering it the other way would let a codex that no longer needs the standalone runtime
+  # fall back on a stat we had no business trusting more than the command itself.
+  #
+  # Two different facts wore one name before: an older CLI with no app-server at all, and a current
+  # CLI installed off a channel that ships no standalone runtime (npm, snap) — where the daemon
+  # refuses with "managed standalone Codex install not found at
+  # <CODEX_HOME>/packages/standalone/current/codex". Caps normally keeps that second case away from
+  # here entirely, but the pane resolves CODEX_HOME from its OWN environment (§8.5) and an install
+  # can be removed after boot, so the launcher still has to be able to say which it hit.
+  if ${appServerStartCommand}; then
+    return 0
+  fi
+  if [ -x "\${CODEX_HOME:-$HOME/.codex}/packages/standalone/current/codex" ]; then
+    nt_fail app-server-unavailable
+  else
+    nt_fail codex-standalone-missing
+  fi
+  return
 }
 
 # Best effort, and never fatal: tell the desktop this node is running plain codex, so the UI can

--- a/src/core/codex-launcher-sh.test.ts
+++ b/src/core/codex-launcher-sh.test.ts
@@ -176,11 +176,43 @@ describe('falls back to plain codex', () => {
     })
   }
 
+  // Two facts wore one reason before, and the string named only the first ("an older CLI"), which
+  // sent a reader of a codex 0.146.0 node hunting for a version problem it did not have.
   it('an older codex with no app-server → plain codex, not a dead node', async () => {
-    const noServer = path.join(dir, 'nodeterm-codex-no-server')
+    const runtime = path.join(dir, '.codex', 'packages', 'standalone', 'current')
+    fs.mkdirSync(runtime, { recursive: true })
+    fs.writeFileSync(path.join(runtime, 'codex'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    try {
+      const noServer = path.join(dir, 'nodeterm-codex-no-server')
+      fs.writeFileSync(noServer, buildCodexLauncherScript('false'), { mode: 0o755 })
+      await callLauncher(['hello'], {}, noServer)
+      expect(codexArgv()).toEqual(['hello'])
+      expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'app-server-unavailable' }])
+    } finally {
+      fs.rmSync(path.join(dir, '.codex'), { recursive: true, force: true })
+    }
+  })
+
+  it('an npm/snap codex with no standalone runtime → its own reason, not "an older CLI"', async () => {
+    // MEASURED: codex-cli 0.146.0 installed via npm answers `app-server daemon start` with
+    // "managed standalone Codex install not found at ~/.codex/packages/standalone/current/codex".
+    // The caps probe normally keeps this case away from the launcher entirely — but the pane
+    // resolves CODEX_HOME from its OWN environment (§8.5) and an install can be removed after boot.
+    const noServer = path.join(dir, 'nodeterm-codex-no-standalone')
     fs.writeFileSync(noServer, buildCodexLauncherScript('false'), { mode: 0o755 })
     await callLauncher(['hello'], {}, noServer)
     expect(codexArgv()).toEqual(['hello'])
+    expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'codex-standalone-missing' }])
+  })
+
+  it('honors CODEX_HOME when deciding which of the two it hit', async () => {
+    const home = path.join(dir, 'relocated-codex')
+    const runtime = path.join(home, 'packages', 'standalone', 'current')
+    fs.mkdirSync(runtime, { recursive: true })
+    fs.writeFileSync(path.join(runtime, 'codex'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    const noServer = path.join(dir, 'nodeterm-codex-relocated')
+    fs.writeFileSync(noServer, buildCodexLauncherScript('false'), { mode: 0o755 })
+    await callLauncher(['hello'], { CODEX_HOME: home }, noServer)
     expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'app-server-unavailable' }])
   })
 

--- a/src/renderer/state/codexIdentity.ts
+++ b/src/renderer/state/codexIdentity.ts
@@ -86,7 +86,12 @@ export const CODEX_FALLBACK_REASONS: Record<string, string> = {
   'broker-unreachable': "nodeterm's hook server was unreachable",
   'node-token-unavailable': 'this build could not mint a node identity key',
   'thread-id-unavailable': 'the session id to resume was not usable',
-  'app-server-unavailable': 'this codex CLI has no shared app-server',
+  // Two different facts, and the single old string named only the first — "an older CLI" sent a
+  // reader looking for a version problem on a codex 0.146.0 whose real problem was its install
+  // channel. That is the misleading-error-message class this repo has lost diagnosis time to.
+  'app-server-unavailable': 'this codex CLI could not start its app-server (it may be too old)',
+  'codex-standalone-missing':
+    'this codex was installed without the standalone runtime the shared app-server needs (npm or snap install)',
   'thread-bind-refused': 'another live node already owns that conversation',
   'thread-start-failed': 'the shared app-server would not start a conversation'
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1883,15 +1883,23 @@ export interface CodexIdentityCaps {
   launcherPath: string | null
   /** Does the installed `codex` accept `--remote`? Feature-detected from its own `--help`. The one
    *  precondition that cannot be recovered from at runtime: the launcher execs, and a CLI without
-   *  the flag dies on a usage error where no fallback is left. Unknown ⇒ false ⇒ plain codex. */
+   *  the flag dies on a usage error where no fallback is left. Unknown ⇒ false ⇒ plain codex, and
+   *  "not probed" counts as unknown: when `appServer` is false the help spawns are skipped, so this
+   *  reads false whatever the CLI's help page would have said. */
   remoteFlag: boolean
+  /** Can this INSTALL run a shared app-server at all? `codex app-server daemon start` needs the
+   *  standalone runtime the Codex installer manages; an npm (or snap) install has the `--remote`
+   *  flag in its help and no such runtime, so it can never serve a shared identity. Unknown ⇒
+   *  false ⇒ plain codex. */
+  appServer: boolean
 }
 
 /** The answer before the probe has run, and the one the Server Edition gives on purpose. */
 export const UNKNOWN_CODEX_IDENTITY_CAPS: CodexIdentityCaps = {
   shared: false,
   launcherPath: null,
-  remoteFlag: false
+  remoteFlag: false,
+  appServer: false
 }
 
 /** A Codex node's identity mode, as reported by the node's own launcher at spawn time.


### PR DESCRIPTION
## The defect, measured on a real host

PR #167 gates the shared-codex-identity launcher on `codexCliSupportsRemote`, which only greps `codex --help` for `--remote`. On this machine that check **passes** — and the launcher's actual preflight fails:

```
$ codex --version
codex-cli 0.146.0                       # installed via npm

$ codex --help | grep -- --remote
      --remote <ADDR>                   # so the old probe answers TRUE
      --remote-auth-token-env <ENV_VAR>

$ codex app-server daemon start
Error: managed standalone Codex install not found at /root/.codex/packages/standalone/current/codex

This command requires the standalone install managed by the Codex installer, because the daemon
starts and updates app-server from that fixed path.

Install it with:
  curl -fsSL https://chatgpt.com/codex/install.sh | sh
```

This is not an old CLI. `codex app-server daemon --help` lists every subcommand, and the CLI reports the requirement itself as JSON:

```
$ codex app-server daemon stop
{"status":"notRunning","managedCodexPath":"/root/.codex/packages/standalone/current/codex",
 "managedCodexVersion":null,"socketPath":"/root/.codex/app-server-control/app-server-control.sock",
 "cliVersion":"0.146.0"}
```

npm is the mainstream install path, and the one `docs/troubleshooting-codex-snap.md` steers users toward. So on npm installs nodeterm wrote `nodeterm-codex` into the launch line, then discovered at runtime that it could never work: a wasted curl round trip, a `plain codex` chip, and **the warning banner on the first fallback of every node**, forever, for a feature that cannot function on that install. The feature was meant to be inert off the standalone channel — it was *noisily* inert.

## What the probe checks now

`codexManagedRuntimeInstalled()` — a **stat** of `<CODEX_HOME>/packages/standalone/current/codex`, surfaced as a new `CodexIdentityCaps.appServer` field and ANDed into `shared`.

The path is not inferred: the CLI names it verbatim in the refusal above and reports it as `managedCodexPath`. Resolved through the existing `codexHome()`, so `$CODEX_HOME` is honored.

Why a stat rather than the authoritative command — the three candidates, all run on this host:

| Candidate | Why not |
| --- | --- |
| `codex app-server daemon start` | It **starts a daemon**. This probe runs once per app run at boot, on every machine with codex installed, including the runs where no Codex node is ever opened. A capability probe must not create the very process the feature exists to create lazily. |
| `codex app-server daemon version` | Read-only, but connects to the control socket → `failed to connect to …/app-server-control.sock` whenever the daemon is merely not up yet, i.e. after every boot. Fail-closed but uselessly: the probe runs ONCE, so it would pin the feature off on exactly the machines it is for. |
| `codex app-server daemon stop` | Prints the authoritative JSON above and exits 0 even when nothing is running — but it **stops a running daemon**, which is the shared app-server every other node is attached to. |

Contract kept: **fail-closed**. A missing path, a non-executable file, a permission error, a probe that throws or rejects — all `shared: false` ⇒ the launcher is never named ⇒ bare `codex`, exactly as before the feature existed. Still one probe per app run, still entirely off the launch path; it runs *before* the `--help` spawns and short-circuits them, so an npm install now pays a single failed stat instead of two process spawns (`remoteFlag` reads `false` there as "not probed", which is what unknown already means everywhere in that file).

**Verified on this machine, through the real exported functions:**

```
version              : codex-cli 0.146.0
OLD probe (--remote) : true            ← the bug
daemon start         : exit 1: Error: managed standalone Codex install not found at /root/.codex/packages/standalone/current/codex
runtime path         : /root/.codex/packages/standalone/current/codex
NEW probe (appServer): false           ← genuinely inert
```

## The reason-string correction

`app-server-unavailable` was documented as *"`codex app-server daemon start` failed — an older CLI"*. Here it is a **newer** CLI on a different install channel — the misleading-error-message class this repo has lost diagnosis time to before.

The launcher still runs `daemon start` **first and unchanged** (behavior is byte-identical); the stat only decides *which* reason is reported. That ordering is deliberate: a stat that ran first would let a future codex that no longer needs the standalone runtime fall back on evidence we have no business trusting over the command itself.

- `app-server-unavailable` → "this codex CLI could not start its app-server (it may be too old)" — reported when a standalone runtime IS present.
- `codex-standalone-missing` (new) → "this codex was installed without the standalone runtime the shared app-server needs (npm or snap install)".

Caps normally keeps the second away from the launcher entirely, so seeing it means something the boot probe could not: the install was removed while the app ran, or the pane's `CODEX_HOME` differs from the desktop's (§8.5).

## Docs

`docs/codex-shared-identity.md`: the install-channel requirement is now a §1 subsection with the measured transcript (it is a channel requirement, not a version one); §3 documents the four-way `shared` AND plus the candidate table above; §8 gains the honest limits of a stat; the reasons table splits; and §9.1 now separates what the probe answers **by itself** (the whole negative case — an install that fails either half runs plain codex with no launcher ever named) from what still needs a machine on the standalone channel (that the `--remote` we detect is the `--remote` we exec with).

## Tests

`codex-identity-caps.test.ts` — npm-install shape (`--remote` yes, no standalone) ⇒ `shared:false` and no launcher on disk; standalone-capable shape ⇒ `shared:true` + launcher written; probe throw and probe rejection ⇒ `shared:false`; the help probe is not spawned at all when the install cannot run an app-server; plus `codexManagedRuntimePath` / `codexManagedRuntimeInstalled` (absent → present-but-not-executable → executable).

`codex-launcher-sh.test.ts` — the generated sh runs for real under `/bin/sh` as before, now asserting **both** reasons: standalone present + `daemon start` failing ⇒ `app-server-unavailable`; no standalone ⇒ `codex-standalone-missing`; and `CODEX_HOME` honored when deciding which.

**Mutation-checked:**
- gate made optimistic again (`shared` ignoring `appServer`) → the npm-install row plus 2 others fail.
- `codexManagedRuntimeInstalled` forced to `true` → its own row fails.

**Gates:** `npm run typecheck` clean. `npx vitest run src/core src/main` → 2337 passed, 3 failed. Full `npx vitest run` → 5272 passed, 4 failed. All 4 failures (`node-pty-patch.test.ts` ×3, `webgl-addon-pair.test.ts` ×1) are node_modules-shape assertions, environmental in a symlinked clone — confirmed identical on a clean `origin/main` checkout with the changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
