### PR TITLE
fix(startup): avoid keychain access at boot when no device is paired (from #112)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1073,14 +1073,21 @@ app.whenReady().then(async () => {
   let pushHasPairedPhone = false
   const refreshPushIdentity = async (): Promise<void> => {
     try {
-      pushHostKeyB64 = publicKeyToB64((await loadOrCreateKeyPair()).publicKey)
-    } catch {
-      // Keyring locked / transient read error: keep the last-known key (never clobber identity).
-    }
-    try {
       pushHasPairedPhone = (await loadApprovedDevices()).pubkeys.length > 0
     } catch {
       pushHasPairedPhone = false
+    }
+    // No paired destination means no host-mode push can be sent. Avoid touching macOS
+    // Safe Storage at boot in that state: locally signed development builds otherwise trigger
+    // a Keychain ACL prompt even though there is nobody to notify.
+    if (!pushHasPairedPhone) {
+      pushHostKeyB64 = null
+      return
+    }
+    try {
+      pushHostKeyB64 = publicKeyToB64((await loadOrCreateKeyPair()).publicKey)
+    } catch {
+      // Keyring locked / transient read error: keep the last-known key (never clobber identity).
     }
   }
   void refreshPushIdentity()


### PR DESCRIPTION
## Symptom

On a dev / locally-signed macOS build, launching the app raises a **macOS Keychain ACL prompt at boot** even when no phone has ever been paired. Nothing is waiting on the other end of that key — the prompt is pure noise.

The cause is ordering inside `refreshPushIdentity()` (`src/main/index.ts`). It called `loadOrCreateKeyPair()` **first** and only then checked whether any device is paired, so every boot touched macOS Safe Storage unconditionally.

## The change

Reorder: read `loadApprovedDevices()` first, and return early when the pinned-device list is empty. `loadOrCreateKeyPair()` is only reached on a machine that actually has an approved device. ~15 lines, one function, no signature changes.

## Side-effect analysis

- **`loadApprovedDevices()` on a virgin machine returns an empty list, it does not throw.** `src/main/remote/approved-devices.ts` wraps the whole read+parse in `try/catch` and falls back to `emptyApprovedDevices()` for a missing *or* malformed file. So a fresh install takes the early return deterministically rather than falling into the outer `catch`.
- **The early return cannot skip key creation on a paired machine.** The guard is `pubkeys.length > 0`; when it holds, control reaches the exact same `loadOrCreateKeyPair()` call as before. Only the empty-list case short-circuits.
- **Nothing at boot depends on `loadOrCreateKeyPair()` having run as a side effect.** Every other consumer loads it on demand at the moment it needs it: the pairing flow (`createPairingService({ loadHostKeyPair: loadOrCreateKeyPair })` → `buildRelayContext()` and the QR `hostKey` block, both inside `pairingService.start()`), and the standing relay host (`standing-host.ts: connectOne()`). A first pairing therefore still creates the key on demand — that is the correct time to raise the Keychain prompt, because the user is actively pairing.
- **Setting `pushHostKeyB64 = null` on the unpaired path is behaviourally inert.** `resolveTarget()` in `src/core/push-notify.ts` selects host mode only via `if (id && id.hasPairedPhone)`, so an identity object carrying `hasPairedPhone: false` was already never chosen — it fell through to the granted-mode path exactly as a `null` identity does. Granted-mode push for plain-SSH phones is unaffected.

## Tests

No new test. `refreshPushIdentity` is a closure created inside `app.whenReady()` in `src/main/index.ts`, which has no test seam — nothing imports that module (it is the Electron main entry), so exercising it would require an actual Electron boot. Writing a test here would mean re-implementing the function in the test file, which pins nothing.

The load-bearing invariant *is* already covered: `src/core/push-notify.test.ts` asserts symmetrically that `getHostIdentity: () => null` and `getHostIdentity: () => ({ ...IDENTITY, hasPairedPhone: false })` both produce no host-mode post and both fall through to grants (lines 289/292, 481/576, 986/989). That is the pair of behaviours this reorder relies on.

**Gates run:**
- `npm run typecheck` — clean
- `npx vitest run src/main` — 643 passed, 3 failed (all `node-pty-patch`, environmental)
- `npx vitest run` — 5265 passed, 12 skipped, 4 failed

The 4 failures are pre-existing and environmental to this verification clone (which symlinks `node_modules`): 3 × `node-pty-patch` (native patch not applied) and 1 × `webgl-addon-pair` (installed addon version). Both were confirmed to fail identically on an unmodified `origin/main` checkout.

## Provenance

Extracted from #112 (`integration/codex-112`), commit `210d3b4d` by **Corvin <corvin@streamlain.com>**, with authorship preserved on the commit and a `cherry picked from` trailer. `src/main/index.ts` applied cleanly; the original commit's other half touched `src/main/browser-use-backend.ts`, which does not exist on `main` and is an unrelated stale-socket cleanup — deliberately **not** included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
