### PR TITLE
feat(ssh): host attachment — a remote node inside a local project (extracted from #112)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -56,6 +56,7 @@ import {
   useSharedGlyphActive
 } from './SharedGlyphLayer'
 import { SshReconnector } from '../lib/sshReconnect'
+import { hostAttachmentsFor } from '../lib/sshAttachments'
 import { terminalKey } from '../terminal/terminal-config'
 import {
   setWebglGesture,
@@ -1710,6 +1711,32 @@ export function Canvas() {
     } else {
       // Local active project: ensure all git ops run local (no stale remote from a prior SSH tab).
       void api.git.setActiveRemote(null)
+    }
+    // HOST ATTACHMENTS: remote nodes on this canvas whose machine is not the project's own — every
+    // remote node when the project is LOCAL. They have no project row to be connected from, so
+    // their masters are opened here, alongside the project's, under the stable attachment scope
+    // their terminals resolve (`sshConnectionIdForProject`). Idempotent in main, so a tab switch
+    // back is a no-op; failures are silent by design — the node's own 20s wait then its offline
+    // overlay is the user-visible half, and `requireRemote` guarantees nothing starts locally.
+    // NOTE: git routing is deliberately NOT armed for an attachment. The project's own cwd is what
+    // the Source Control panel is about, and an attached node must not repoint it at another host.
+    for (const attachment of hostAttachmentsFor(project.id, project.nodes, project.ssh?.server)) {
+      window.nodeTerminal.sshProject
+        .connect(attachment.scopeId, attachment.conn, attachment.remoteCwd)
+        .then((info) =>
+          useSshConn.getState().setConn(attachment.scopeId, {
+            ...info,
+            attachment: {
+              conn: attachment.conn,
+              hostKey: attachment.hostKey,
+              remoteCwd: attachment.remoteCwd,
+              ownerProjectId: project.id
+            }
+          })
+        )
+        .catch(() => {
+          /* the node's offline overlay + the reconnect coordinator own the retry */
+        })
     }
     loadingRef.current = true
     const flow = nodeStatesToFlow(project.nodes)
@@ -7680,7 +7707,21 @@ export function Canvas() {
   const sshReconnectorRef = useRef<SshReconnector | null>(null)
   useEffect(() => {
     const rec = new SshReconnector({
-      connect: async (projectId) => {
+      connect: async (scopeId) => {
+        // A HOST ATTACHMENT has no project row to read its endpoint from — the scope carries it.
+        // Reconnect it on its own loop (its master is its own) and leave git routing alone: the
+        // owning project is local, or points somewhere else entirely.
+        const attached = useSshConn.getState().getAttachment(scopeId)
+        if (attached) {
+          const info = await window.nodeTerminal.sshProject.connect(
+            scopeId,
+            attached.conn,
+            attached.remoteCwd
+          )
+          useSshConn.getState().setConn(scopeId, { ...info, attachment: attached })
+          return true
+        }
+        const projectId = scopeId
         const project = useProjects.getState().getProject(projectId)
         if (!project?.ssh) return false
         const ssh = project.ssh
@@ -7693,7 +7734,9 @@ export function Canvas() {
         useSshConn.getState().setConn(projectId, info)
         return true
       },
-      respawn: (projectId, nodeIds) => {
+      respawn: (scopeId, nodeIds) => {
+        // The nodes live on the OWNING canvas, which for an attachment is not the scope id.
+        const projectId = useSshConn.getState().ownerProjectId(scopeId)
         if (useProjects.getState().activeProjectId !== projectId) {
           // The project was switched away between the drop and the reconnect: nothing is mounted,
           // and any park is holding the DEAD pty (the node unmount-parked before the master came
@@ -8030,6 +8073,21 @@ export function Canvas() {
           .catch(() => {})
           .finally(() => void window.nodeTerminal.sshProject.disconnect(id))
         useSshConn.getState().clear(id)
+      }
+      // Host attachments this project owns: nothing else knows they exist (no project row), so
+      // deleting the canvas is the only chance to tear their masters down. Same order as above —
+      // kill the remote sessions over the live master, then drop it.
+      for (const scopeId of useSshConn.getState().attachmentScopesOf(id)) {
+        const nodeIds = project
+          ? hostAttachmentsFor(id, project.nodes, project.ssh?.server).find(
+              (a) => a.scopeId === scopeId
+            )?.nodeIds ?? []
+          : []
+        void window.nodeTerminal.sshProject
+          .killSessions(scopeId, nodeIds)
+          .catch(() => {})
+          .finally(() => void window.nodeTerminal.sshProject.disconnect(scopeId))
+        useSshConn.getState().clear(scopeId)
       }
       disposeRelayTabForProject(id)
       store.deleteProject(id)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -196,6 +196,8 @@ import { isSafeQuickOpenRelPath } from '@shared/quick-open-filter'
  *  reached for inside it, so that helper stays testable without an Electron preload. */
 const sshConnect: SshConnectFn = (scopeId, conn, remoteCwd) =>
   window.nodeTerminal.sshProject.connect(scopeId, conn, remoteCwd)
+const sshDisconnect = (scopeId: string): Promise<unknown> =>
+  window.nodeTerminal.sshProject.disconnect(scopeId)
 import { opensInEditor } from '../lib/openTarget'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
 import { useProjects } from '../state/projects'
@@ -1740,7 +1742,8 @@ export function Canvas() {
           remoteCwd: attachment.remoteCwd,
           ownerProjectId: project.id
         },
-        sshConnect
+        sshConnect,
+        sshDisconnect
       )
     }
     loadingRef.current = true
@@ -7718,7 +7721,7 @@ export function Canvas() {
         // still reachable here. Reconnect it on its own loop (its master is its own) and leave git
         // routing alone: the owning project is local, or points somewhere else entirely.
         const attached = useSshConn.getState().getAttachment(scopeId)
-        if (attached) return connectHostAttachment(scopeId, attached, sshConnect)
+        if (attached) return connectHostAttachment(scopeId, attached, sshConnect, sshDisconnect)
         const projectId = scopeId
         const project = useProjects.getState().getProject(projectId)
         if (!project?.ssh) return false

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -56,7 +56,11 @@ import {
   useSharedGlyphActive
 } from './SharedGlyphLayer'
 import { SshReconnector } from '../lib/sshReconnect'
-import { hostAttachmentsFor } from '../lib/sshAttachments'
+import {
+  hostAttachmentsFor,
+  connectHostAttachment,
+  type SshConnectFn
+} from '../lib/sshAttachments'
 import { terminalKey } from '../terminal/terminal-config'
 import {
   setWebglGesture,
@@ -187,6 +191,11 @@ import { buildHibernationCandidates } from '../lib/hibernationCandidates'
 import { applyLoopDismiss } from '../lib/loopCard'
 import { prepareQuickOpenFiles, type QuickOpenIndexedFile } from '../lib/quickOpenSearch'
 import { isSafeQuickOpenRelPath } from '@shared/quick-open-filter'
+
+/** The real `sshProject.connect`, bound once. Passed into `connectHostAttachment` rather than
+ *  reached for inside it, so that helper stays testable without an Electron preload. */
+const sshConnect: SshConnectFn = (scopeId, conn, remoteCwd) =>
+  window.nodeTerminal.sshProject.connect(scopeId, conn, remoteCwd)
 import { opensInEditor } from '../lib/openTarget'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
 import { useProjects } from '../state/projects'
@@ -1715,28 +1724,24 @@ export function Canvas() {
     // HOST ATTACHMENTS: remote nodes on this canvas whose machine is not the project's own — every
     // remote node when the project is LOCAL. They have no project row to be connected from, so
     // their masters are opened here, alongside the project's, under the stable attachment scope
-    // their terminals resolve (`sshConnectionIdForProject`). Idempotent in main, so a tab switch
-    // back is a no-op; failures are silent by design — the node's own 20s wait then its offline
-    // overlay is the user-visible half, and `requireRemote` guarantees nothing starts locally.
+    // their terminals resolve (`sshConnectionIdForProject`). This is a PRE-WARM only: a node added
+    // at runtime dials for itself from `resolveSshRemote`, and `connectHostAttachment` collapses
+    // both into one connect. Failures are silent by design — the node's own 20s wait then its
+    // offline overlay is the user-visible half, and `requireRemote` guarantees nothing starts
+    // locally.
     // NOTE: git routing is deliberately NOT armed for an attachment. The project's own cwd is what
     // the Source Control panel is about, and an attached node must not repoint it at another host.
     for (const attachment of hostAttachmentsFor(project.id, project.nodes, project.ssh?.server)) {
-      window.nodeTerminal.sshProject
-        .connect(attachment.scopeId, attachment.conn, attachment.remoteCwd)
-        .then((info) =>
-          useSshConn.getState().setConn(attachment.scopeId, {
-            ...info,
-            attachment: {
-              conn: attachment.conn,
-              hostKey: attachment.hostKey,
-              remoteCwd: attachment.remoteCwd,
-              ownerProjectId: project.id
-            }
-          })
-        )
-        .catch(() => {
-          /* the node's offline overlay + the reconnect coordinator own the retry */
-        })
+      void connectHostAttachment(
+        attachment.scopeId,
+        {
+          conn: attachment.conn,
+          hostKey: attachment.hostKey,
+          remoteCwd: attachment.remoteCwd,
+          ownerProjectId: project.id
+        },
+        sshConnect
+      )
     }
     loadingRef.current = true
     const flow = nodeStatesToFlow(project.nodes)
@@ -7708,19 +7713,12 @@ export function Canvas() {
   useEffect(() => {
     const rec = new SshReconnector({
       connect: async (scopeId) => {
-        // A HOST ATTACHMENT has no project row to read its endpoint from — the scope carries it.
-        // Reconnect it on its own loop (its master is its own) and leave git routing alone: the
-        // owning project is local, or points somewhere else entirely.
+        // A HOST ATTACHMENT has no project row to read its endpoint from — `registerAttachment`
+        // put it on record before the first dial, precisely so a connect that never succeeded is
+        // still reachable here. Reconnect it on its own loop (its master is its own) and leave git
+        // routing alone: the owning project is local, or points somewhere else entirely.
         const attached = useSshConn.getState().getAttachment(scopeId)
-        if (attached) {
-          const info = await window.nodeTerminal.sshProject.connect(
-            scopeId,
-            attached.conn,
-            attached.remoteCwd
-          )
-          useSshConn.getState().setConn(scopeId, { ...info, attachment: attached })
-          return true
-        }
+        if (attached) return connectHostAttachment(scopeId, attached, sshConnect)
         const projectId = scopeId
         const project = useProjects.getState().getProject(projectId)
         if (!project?.ssh) return false
@@ -8087,7 +8085,7 @@ export function Canvas() {
           .killSessions(scopeId, nodeIds)
           .catch(() => {})
           .finally(() => void window.nodeTerminal.sshProject.disconnect(scopeId))
-        useSshConn.getState().clear(scopeId)
+        useSshConn.getState().clearAttachment(scopeId)
       }
       disposeRelayTabForProject(id)
       store.deleteProject(id)

--- a/src/renderer/components/SshProjectDialog.test.tsx
+++ b/src/renderer/components/SshProjectDialog.test.tsx
@@ -94,3 +94,87 @@ describe('SshProjectDialog browse-master teardown', () => {
     expect(onClose).toHaveBeenCalled()
   })
 })
+
+// Where the browse LANDS when the machine has a default folder configured. `listDir` cannot report
+// a missing directory — it echoes the path back with `dirs: []` whether the folder is gone or
+// merely empty — so existence is checked against the PARENT's listing. Getting that wrong drops
+// the user into a nonexistent path with "Use this folder" enabled.
+describe('SshProjectDialog default folder', () => {
+  let root: Root | undefined
+  let host: HTMLElement
+  let listDir: ReturnType<typeof vi.fn>
+
+  const WITH_DEFAULT: SshServer = { ...SERVER, remoteCwd: '/home/u/projects/app' }
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    listDir = vi.fn(async (_id: string, dir: string) => ({ path: dir, dirs: [] }))
+    ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+      sshProject: {
+        connect: vi.fn(async () => ({ controlPath: '/tmp/cm' })),
+        disconnect: vi.fn(async () => {}),
+        listDir,
+        mkdir: vi.fn(async () => true)
+      }
+    }
+    useSshServers.setState({ servers: [WITH_DEFAULT] })
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = undefined
+    host.remove()
+  })
+
+  const open = async (): Promise<void> => {
+    root = createRoot(host)
+    await act(async () => {
+      root!.render(<SshProjectDialog onCreate={vi.fn()} onManage={vi.fn()} onClose={vi.fn()} />)
+    })
+    await act(async () => {
+      const row = [...document.querySelectorAll('button')].find((b) =>
+        b.textContent?.includes('testbox')
+      )!
+      row.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+  }
+
+  it('lands in the configured default folder when it exists', async () => {
+    listDir.mockImplementation(async (_id: string, dir: string) => ({
+      path: dir,
+      dirs: dir === '/home/u/projects' ? ['app'] : []
+    }))
+
+    await open()
+
+    expect(listDir).toHaveBeenCalledWith(expect.any(String), '/home/u/projects/app')
+  })
+
+  it('an EMPTY default folder is still the right place to land', async () => {
+    // The regression a `dirs.length === 0` test would introduce: a real, empty default folder is
+    // indistinguishable from a missing one by its own listing, so it must be judged by the parent.
+    listDir.mockImplementation(async (_id: string, dir: string) => ({
+      path: dir,
+      dirs: dir === '/home/u/projects' ? ['app'] : []
+    }))
+
+    await open()
+
+    const landed = listDir.mock.calls.at(-1)
+    expect(landed?.[1]).toBe('/home/u/projects/app')
+  })
+
+  it('falls back to ~ when the configured default is gone', async () => {
+    // The parent lists without it: the folder was renamed or deleted on the host since it was set.
+    listDir.mockImplementation(async (_id: string, dir: string) => ({
+      path: dir,
+      dirs: dir === '/home/u/projects' ? ['something-else'] : []
+    }))
+
+    await open()
+
+    expect(listDir).not.toHaveBeenCalledWith(expect.any(String), '/home/u/projects/app')
+    expect(listDir.mock.calls.at(-1)?.[1]).toBe('~')
+  })
+})

--- a/src/renderer/components/SshProjectDialog.tsx
+++ b/src/renderer/components/SshProjectDialog.tsx
@@ -98,6 +98,21 @@ export function SshProjectDialog({ onCreate, onManage, onClose }: SshProjectDial
   // Disconnect the browse master if the dialog unmounts without an explicit close.
   useEffect(() => () => disconnectBrowse(), [disconnectBrowse])
 
+  /** Does `dir` exist on the remote? Asked of its PARENT's listing, because a `listDir` of a
+   *  missing directory succeeds and answers `{ path: dir, dirs: [] }`. `~` is taken on faith. */
+  const dirExists = useCallback(async (dir: string): Promise<boolean> => {
+    if (dir === '~') return true
+    try {
+      const parent = await window.nodeTerminal.sshProject.listDir(
+        browseIdRef.current,
+        parentDir(dir)
+      )
+      return parent.dirs.includes(baseName(dir))
+    } catch {
+      return false
+    }
+  }, [])
+
   const list = useCallback(async (dir: string) => {
     const res = await window.nodeTerminal.sshProject.listDir(browseIdRef.current, dir)
     setPath(res.path)
@@ -134,10 +149,15 @@ export function SshProjectDialog({ onCreate, onManage, onClose }: SshProjectDial
         connectBegunRef.current = true
         await window.nodeTerminal.sshProject.connect(browseIdRef.current, srv)
         // Land in the machine's DEFAULT folder when it has one (Settings → Remote (SSH)); the
-        // point of configuring it is not to browse from `~` to the same place every time. Fall
-        // back to `~` if it no longer exists — a stale default must not dead-end the dialog.
+        // point of configuring it is not to browse from `~` to the same place every time.
+        //
+        // A stale default must not dead-end the dialog, and `listDir` cannot say so on its own:
+        // it echoes the path back and returns `dirs: []` whether the folder is missing or merely
+        // empty (`ls` failing is not an error it surfaces). So EXISTENCE is checked against the
+        // parent's listing before landing there — which also keeps a real, empty default working,
+        // unlike treating an empty listing as the failure signal.
         const start = srv.remoteCwd?.trim() || '~'
-        await list(start).catch(() => list('~'))
+        await list((await dirExists(start)) ? start : '~')
         setStep('browse')
       } catch (err) {
         setError((err as Error)?.message || 'Could not connect to the server.')

--- a/src/renderer/components/SshProjectDialog.tsx
+++ b/src/renderer/components/SshProjectDialog.tsx
@@ -133,7 +133,11 @@ export function SshProjectDialog({ onCreate, onManage, onClose }: SshProjectDial
         // outlived the dialog for the rest of the app run.
         connectBegunRef.current = true
         await window.nodeTerminal.sshProject.connect(browseIdRef.current, srv)
-        await list('~')
+        // Land in the machine's DEFAULT folder when it has one (Settings → Remote (SSH)); the
+        // point of configuring it is not to browse from `~` to the same place every time. Fall
+        // back to `~` if it no longer exists — a stale default must not dead-end the dialog.
+        const start = srv.remoteCwd?.trim() || '~'
+        await list(start).catch(() => list('~'))
         setStep('browse')
       } catch (err) {
         setError((err as Error)?.message || 'Could not connect to the server.')

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -31,7 +31,7 @@ import {
   CO_ATTACH_MOUSE_SEQ
 } from '../../terminal/terminal-config'
 import { useXtermVisualSettings } from '../../terminal/useXtermVisualSettings'
-import { resolveSshRemote, reportSshDrop } from '../../nodes/TerminalNode'
+import { resolveSshRemote, reportSshDrop, sshConnectionScope } from '../../nodes/TerminalNode'
 import { buildSshArgs, type SshConnection } from '@shared/ssh'
 
 /** The subset of a node's `data` a SECOND client needs to attach to its session the same way the
@@ -200,8 +200,13 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
 
     void (async () => {
       // Read here, not at click time: a modal only ever opens over the ACTIVE project, and the
-      // reconnect coordinator is keyed by project (same assumption as resolveSshRemote's).
-      const projectId = useProjects.getState().activeProjectId
+      // reconnect coordinator is keyed by CONNECTION SCOPE (same choice resolveSshRemote makes) —
+      // the project's own id, or the host attachment when this card's session is on a machine the
+      // project isn't.
+      const projectId =
+        spawn.sshRemoteTmux && spawn.ssh
+          ? sshConnectionScope(spawn.ssh)
+          : useProjects.getState().activeProjectId
       // SSH-project node: resolve the live ControlMaster (may not be up yet on a cold load).
       const sshRemote =
         spawn.sshRemoteTmux && spawn.ssh
@@ -367,7 +372,10 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
     const needsWrite = files.some((f) => !window.nodeTerminal.getPathForFile(f))
     let paths: string[]
     if (spawn.sshRemoteTmux) {
-      const projectId = useProjects.getState().activeProjectId
+      // Uploads go over the master this card's PTY runs on — its scope, not the project's.
+      const projectId = spawn.ssh
+        ? sshConnectionScope(spawn.ssh)
+        : useProjects.getState().activeProjectId
       setUploading(true)
       try {
         paths = await droppedPaths(files, { sshRemoteTmux: true, projectId })

--- a/src/renderer/components/settings/sections/SshSection.test.tsx
+++ b/src/renderer/components/settings/sections/SshSection.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SshServer } from '@shared/ssh'
+import { useSshServers } from '../../../state/sshServers'
+import { SshSection } from './SshSection'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const SERVER: SshServer = {
+  id: 'ubuntu-1',
+  label: 'Ubuntu WSL',
+  host: 'devbox',
+  user: 'corvin',
+  port: 2222,
+  remoteCwd: '/home/corvin/projects/app'
+}
+
+describe('SshSection', () => {
+  let root: Root | undefined
+  let host: HTMLElement
+  let connect: ReturnType<typeof vi.fn>
+  let disconnect: ReturnType<typeof vi.fn>
+  let save: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    connect = vi.fn(async () => ({ controlPath: '/tmp/control' }))
+    disconnect = vi.fn(async () => {})
+    save = vi.fn(async () => [SERVER])
+    ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+      ssh: {
+        list: vi.fn(async () => [SERVER]),
+        save,
+        remove: vi.fn(async () => []),
+        importCandidates: vi.fn(async () => [])
+      },
+      sshProject: { connect, disconnect },
+      dialog: { selectFile: vi.fn(async () => null) }
+    }
+    useSshServers.setState({ servers: [SERVER] })
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = undefined
+    host.remove()
+  })
+
+  const mount = (): void => {
+    root = createRoot(host)
+    act(() => root!.render(<SshSection isActive />))
+  }
+
+  const button = (label: string): HTMLButtonElement => {
+    const match = [...host.querySelectorAll('button')].find((el) => el.textContent?.includes(label))
+    if (!match) throw new Error(`button not found: ${label}`)
+    return match
+  }
+
+  const click = (el: Element): void => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  }
+
+  it('shows each machine’s default folder in the list', () => {
+    mount()
+    expect(host.textContent).toContain('Default folder: /home/corvin/projects/app')
+  })
+
+  it('tests the machine with its configured default folder and always disconnects', async () => {
+    mount()
+    act(() => click(button('Edit')))
+    await act(async () => click(button('Test connection')))
+
+    // Its OWN scope id — never a project's: joining a live project connection would report
+    // success without testing anything, and the disconnect would drop that project's terminals.
+    expect(connect).toHaveBeenCalledWith(
+      'ssh-settings-test-ubuntu-1',
+      expect.objectContaining({ host: 'devbox', user: 'corvin', port: 2222 }),
+      '/home/corvin/projects/app'
+    )
+    expect(disconnect).toHaveBeenCalledWith('ssh-settings-test-ubuntu-1')
+    expect(host.textContent).toContain('Connection successful')
+  })
+
+  it('reports the failure and still tears the half-open master down', async () => {
+    connect.mockRejectedValueOnce(new Error('Permission denied (publickey)'))
+    mount()
+    act(() => click(button('Edit')))
+    await act(async () => click(button('Test connection')))
+
+    expect(host.textContent).toContain('Connection failed: Permission denied (publickey)')
+    expect(disconnect).toHaveBeenCalledWith('ssh-settings-test-ubuntu-1')
+  })
+
+  it('saves a blank default folder as `~` rather than an empty remote path', async () => {
+    mount()
+    act(() => click(button('Edit')))
+    const cwd = [...host.querySelectorAll('input')].find(
+      (el) => el.value === '/home/corvin/projects/app'
+    )!
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value'
+      )!.set!
+      setter.call(cwd, '   ')
+      cwd.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => click(button('Save')))
+
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ remoteCwd: '~' }))
+  })
+})

--- a/src/renderer/components/settings/sections/SshSection.tsx
+++ b/src/renderer/components/settings/sections/SshSection.tsx
@@ -11,7 +11,10 @@ import { uuid } from '@renderer/lib/uuid'
 const ROWS = {
   servers: {
     title: 'Saved SSH servers',
-    keywords: ['ssh', 'remote', 'server', 'host', 'connect', 'identity', 'key']
+    keywords: [
+      'ssh', 'remote', 'server', 'host', 'connect', 'identity', 'key',
+      'test', 'folder', 'directory', 'cwd', 'working directory'
+    ]
   }
 }
 const ENTRIES = Object.values(ROWS)
@@ -20,6 +23,8 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
   const sshServers = useSshServers((s) => s.servers)
   const [sshDraft, setSshDraft] = useState<SshServer | null>(null)
   const [importMsg, setImportMsg] = useState<string | null>(null)
+  const [testMsg, setTestMsg] = useState<string | null>(null)
+  const [testing, setTesting] = useState(false)
 
   useEffect(() => {
     void useSshServers.getState().hydrate()
@@ -71,11 +76,39 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
     !sshDraft.host.trim() ||
     !sshDraft.user.trim()
 
+  /**
+   * Open a ControlMaster to the draft's endpoint, then close it — the same connect a project (or a
+   * host attachment) makes, so a green answer here means those will work too. It runs under its
+   * OWN scope id, never a project's: joining a live project connection would report success
+   * without testing anything, and disconnecting afterwards would drop that project's terminals.
+   */
+  const testConnection = async (): Promise<void> => {
+    if (!sshDraft || saveDisabled || testing) return
+    const connectionId = `ssh-settings-test-${sshDraft.id}`
+    setTesting(true)
+    setTestMsg(`Connecting to ${sshDraft.label}…`)
+    try {
+      await window.nodeTerminal.sshProject.connect(
+        connectionId,
+        sshDraft,
+        sshDraft.remoteCwd?.trim() || '~'
+      )
+      setTestMsg('Connection successful.')
+    } catch (error) {
+      setTestMsg(`Connection failed: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      // Always: a partially-established master left behind would be silently reused by the next
+      // test (and by anything else asking for this id), reporting a stale answer.
+      await window.nodeTerminal.sshProject.disconnect(connectionId).catch(() => {})
+      setTesting(false)
+    }
+  }
+
   return (
     <SettingsSection
       id="ssh"
       title="Remote (SSH)"
-      description="Saved SSH servers appear under “New remote”. Opening remote terminals over SSH is free."
+      description="Saved SSH servers appear under “New remote”, and can host nodes on a local canvas. Opening remote terminals over SSH is free."
       isActive={isActive}
       searchEntries={ENTRIES}
     >
@@ -86,12 +119,24 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
               key={server.id}
               className="flex items-center justify-between gap-4 rounded-md border border-border p-3"
             >
-              <span className="min-w-0 truncate text-sm text-text">
-                {server.label} — {server.user}@{server.host}
-                {server.port && server.port !== 22 ? `:${server.port}` : ''}
-              </span>
+              <div className="min-w-0">
+                <div className="truncate text-sm text-text">
+                  {server.label} — {server.user}@{server.host}
+                  {server.port && server.port !== 22 ? `:${server.port}` : ''}
+                </div>
+                <div className="truncate text-xs text-muted">
+                  Default folder: {server.remoteCwd || '~'}
+                </div>
+              </div>
               <div className="flex shrink-0 gap-2">
-                <Button onClick={() => setSshDraft(server)}>Edit</Button>
+                <Button
+                  onClick={() => {
+                    setTestMsg(null)
+                    setSshDraft(server)
+                  }}
+                >
+                  Edit
+                </Button>
                 <Button
                   variant="ghost"
                   onClick={() => void useSshServers.getState().remove(server.id)}
@@ -151,6 +196,18 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
                 }
               />
               <FieldRow
+                label="Default working directory"
+                description="Folder new terminals on this machine open in, including ones attached to a local canvas."
+                control={
+                  <Input
+                    className="w-72 font-mono"
+                    placeholder="~/projects/my-project"
+                    value={sshDraft.remoteCwd ?? '~'}
+                    onChange={(e) => setSshDraft({ ...sshDraft, remoteCwd: e.target.value })}
+                  />
+                }
+              />
+              <FieldRow
                 label="Identity file"
                 description="Optional private key passed with -i."
                 control={
@@ -186,16 +243,24 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
                   />
                 }
               />
-              <div className="flex justify-end gap-2 pt-1">
+              {testMsg ? <p className="text-xs text-muted">{testMsg}</p> : null}
+              <div className="flex flex-wrap justify-end gap-2 pt-1">
                 <Button variant="ghost" onClick={() => setSshDraft(null)}>
                   Cancel
+                </Button>
+                <Button disabled={saveDisabled || testing} onClick={() => void testConnection()}>
+                  {testing ? 'Testing…' : 'Test connection'}
                 </Button>
                 <Button
                   variant="primary"
                   disabled={saveDisabled}
                   onClick={async () => {
-                    await useSshServers.getState().save(sshDraft)
+                    await useSshServers.getState().save({
+                      ...sshDraft,
+                      remoteCwd: sshDraft.remoteCwd?.trim() || '~'
+                    })
                     setSshDraft(null)
+                    setTestMsg(null)
                   }}
                 >
                   Save
@@ -211,7 +276,8 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
                     label: '',
                     host: '',
                     user: '',
-                    port: 22
+                    port: 22,
+                    remoteCwd: '~'
                   })
                 }
               >

--- a/src/renderer/components/settings/sections/SshSection.tsx
+++ b/src/renderer/components/settings/sections/SshSection.tsx
@@ -196,8 +196,8 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
                 }
               />
               <FieldRow
-                label="Default working directory"
-                description="Folder new terminals on this machine open in, including ones attached to a local canvas."
+                label="Default folder"
+                description="Where browsing this machine starts: the folder “New remote” opens at, and the one Test connection dials."
                 control={
                   <Input
                     className="w-72 font-mono"

--- a/src/renderer/lib/sshAttachments.test.ts
+++ b/src/renderer/lib/sshAttachments.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { sshAttachmentId, type SshConnection } from '@shared/ssh'
-import { hostAttachmentsFor, type AttachableNode } from './sshAttachments'
+import { useSshConn } from '../state/sshConn'
+import {
+  connectHostAttachment,
+  hostAttachmentsFor,
+  resetHostAttachmentDials,
+  type AttachableNode
+} from './sshAttachments'
 
 const DEVBOX: SshConnection = { host: 'devbox', user: 'corvin', port: 2222 }
 const OTHER: SshConnection = { host: 'other', user: 'corvin' }
@@ -63,5 +69,104 @@ describe('hostAttachmentsFor', () => {
     for (const scope of hostAttachmentsFor('local-1', [remote('n1', DEVBOX), remote('n2', OTHER)])) {
       expect(scope.scopeId).not.toBe('local-1')
     }
+  })
+})
+
+describe('connectHostAttachment', () => {
+  const ATTACHMENT = {
+    conn: DEVBOX,
+    hostKey: 'corvin@devbox',
+    remoteCwd: '/srv/app',
+    ownerProjectId: 'local-1'
+  }
+
+  beforeEach(() => {
+    resetHostAttachmentDials()
+    useSshConn.setState({
+      byProject: {},
+      attachments: {},
+      autoPermByProject: {},
+      remoteClaudeVersionByProject: {}
+    })
+  })
+
+  it('records the endpoint BEFORE dialing, not after it succeeds', async () => {
+    // Ordering, not end state: main emits `status:'connected'` from inside its connect, over the
+    // same IPC pipe, so that event lands BEFORE this promise resolves. Anything reading the scope
+    // at that moment — `ownerProjectId`, which decides whether respawn bumps the nonce or takes
+    // the "switched away" branch — must already find the record.
+    let seenDuringDial: unknown
+    const connect = vi.fn(async () => {
+      seenDuringDial = useSshConn.getState().getAttachment('a1')
+      return { controlPath: '/tmp/cm' }
+    })
+
+    await connectHostAttachment('a1', ATTACHMENT, connect)
+
+    expect(seenDuringDial).toEqual(ATTACHMENT)
+    expect(useSshConn.getState().ownerProjectId('a1')).toBe('local-1')
+  })
+
+  it('keeps the endpoint on record when the FIRST connect fails', async () => {
+    // A cold load against a sleeping host. The reconnect coordinator's connect dep reads the
+    // endpoint back out of the store; without this it returns false on every backoff step and
+    // the offline overlay's Reconnect is inert for the rest of the app run.
+    const connect = vi.fn(async () => {
+      throw new Error('ssh: connect to host devbox port 2222: Host is down')
+    })
+
+    await expect(connectHostAttachment('a1', ATTACHMENT, connect)).resolves.toBe(false)
+
+    expect(useSshConn.getState().getAttachment('a1')).toEqual(ATTACHMENT)
+    expect(useSshConn.getState().getControlPath('a1')).toBeUndefined()
+  })
+
+  it('a failed dial does not poison the scope against the retry', async () => {
+    const connect = vi
+      .fn<() => Promise<{ controlPath: string }>>()
+      .mockRejectedValueOnce(new Error('Host is down'))
+      .mockResolvedValueOnce({ controlPath: '/tmp/cm' })
+
+    expect(await connectHostAttachment('a1', ATTACHMENT, connect)).toBe(false)
+    expect(await connectHostAttachment('a1', ATTACHMENT, connect)).toBe(true)
+
+    expect(connect).toHaveBeenCalledTimes(2)
+    expect(useSshConn.getState().getControlPath('a1')).toBe('/tmp/cm')
+  })
+
+  it('collapses concurrent callers into ONE dial', async () => {
+    // Every node on the machine calls this at spawn, on top of Canvas's pre-warm.
+    const connect = vi.fn(async () => ({ controlPath: '/tmp/cm' }))
+
+    const all = await Promise.all([
+      connectHostAttachment('a1', ATTACHMENT, connect),
+      connectHostAttachment('a1', ATTACHMENT, connect),
+      connectHostAttachment('a1', ATTACHMENT, connect)
+    ])
+
+    expect(all).toEqual([true, true, true])
+    expect(connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('short-circuits on a live master but still refreshes the record', async () => {
+    const connect = vi.fn(async () => ({ controlPath: '/tmp/other' }))
+    useSshConn.getState().setConn('a1', { controlPath: '/tmp/live' })
+
+    expect(await connectHostAttachment('a1', ATTACHMENT, connect)).toBe(true)
+
+    expect(connect).not.toHaveBeenCalled()
+    // A tab switch back adopts the live master; the NEXT drop still needs the endpoint on record.
+    expect(useSshConn.getState().getAttachment('a1')).toEqual(ATTACHMENT)
+  })
+
+  it('dials each machine separately', async () => {
+    const connect = vi.fn(async () => ({ controlPath: '/tmp/cm' }))
+
+    await Promise.all([
+      connectHostAttachment('a1', ATTACHMENT, connect),
+      connectHostAttachment('a2', { ...ATTACHMENT, conn: OTHER, hostKey: 'corvin@other' }, connect)
+    ])
+
+    expect(connect).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/lib/sshAttachments.test.ts
+++ b/src/renderer/lib/sshAttachments.test.ts
@@ -148,15 +148,36 @@ describe('connectHostAttachment', () => {
     expect(connect).toHaveBeenCalledTimes(1)
   })
 
-  it('short-circuits on a live master but still refreshes the record', async () => {
-    const connect = vi.fn(async () => ({ controlPath: '/tmp/other' }))
-    useSshConn.getState().setConn('a1', { controlPath: '/tmp/live' })
+  it('still dials when a controlPath is already cached — the reconnect path depends on it', async () => {
+    // The regression this guards: treating a cached path as "already connected". NOTHING in the
+    // renderer clears it when a connection drops, so the reconnect coordinator's connect dep
+    // would answer true forever after one success — no `-O check`, no redial — and the respawned
+    // ptys would run against a dead socket, which `ControlMaster=auto` silently turns into a
+    // DIRECT connection per node (the ~72k-logins/day pattern). Only main can tell a live master
+    // from a dead one, and its reuse branch costs one mux'd `-O check`.
+    const connect = vi.fn(async () => ({ controlPath: '/tmp/fresh' }))
+    useSshConn.getState().setConn('a1', { controlPath: '/tmp/stale-after-a-drop' })
 
     expect(await connectHostAttachment('a1', ATTACHMENT, connect)).toBe(true)
 
-    expect(connect).not.toHaveBeenCalled()
-    // A tab switch back adopts the live master; the NEXT drop still needs the endpoint on record.
+    expect(connect).toHaveBeenCalledTimes(1)
+    expect(useSshConn.getState().getControlPath('a1')).toBe('/tmp/fresh')
     expect(useSshConn.getState().getAttachment('a1')).toEqual(ATTACHMENT)
+  })
+
+  it('a dial that lands after the canvas was deleted is handed back, not recorded', async () => {
+    let release: (v: { controlPath: string }) => void
+    const connect = vi.fn(() => new Promise<{ controlPath: string }>((r) => (release = r)))
+    const disconnect = vi.fn(async () => {})
+
+    const pending = connectHostAttachment('a1', ATTACHMENT, connect, disconnect)
+    useSshConn.getState().clearAttachment('a1') // the project was deleted mid-dial
+    release!({ controlPath: '/tmp/cm' })
+
+    expect(await pending).toBe(false)
+    // Neither resurrected in the store nor leaked on the host.
+    expect(useSshConn.getState().getControlPath('a1')).toBeUndefined()
+    expect(disconnect).toHaveBeenCalledWith('a1')
   })
 
   it('dials each machine separately', async () => {

--- a/src/renderer/lib/sshAttachments.test.ts
+++ b/src/renderer/lib/sshAttachments.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { sshAttachmentId, type SshConnection } from '@shared/ssh'
+import { hostAttachmentsFor, type AttachableNode } from './sshAttachments'
+
+const DEVBOX: SshConnection = { host: 'devbox', user: 'corvin', port: 2222 }
+const OTHER: SshConnection = { host: 'other', user: 'corvin' }
+
+const remote = (id: string, ssh: SshConnection, cwd?: string): AttachableNode => ({
+  id,
+  ssh,
+  sshRemoteTmux: true,
+  cwd
+})
+
+describe('hostAttachmentsFor', () => {
+  it('attaches every remote node of a LOCAL project to its host', () => {
+    const found = hostAttachmentsFor('local-1', [remote('n1', DEVBOX, '/srv/app')])
+    expect(found).toHaveLength(1)
+    expect(found[0].scopeId).toBe(sshAttachmentId('local-1', DEVBOX))
+    expect(found[0].hostKey).toBe('corvin@devbox')
+    expect(found[0].remoteCwd).toBe('/srv/app')
+    expect(found[0].nodeIds).toEqual(['n1'])
+  })
+
+  it('leaves an SSH project alone: its own master already serves its nodes', () => {
+    expect(hostAttachmentsFor('ssh-1', [remote('n1', DEVBOX)], DEVBOX)).toEqual([])
+  })
+
+  it('attaches a node inside an SSH project that points at a DIFFERENT machine', () => {
+    const found = hostAttachmentsFor('ssh-1', [remote('n1', DEVBOX), remote('n2', OTHER)], DEVBOX)
+    expect(found.map((a) => a.hostKey)).toEqual(['corvin@other'])
+  })
+
+  it('opens ONE master per machine, however many nodes are on it', () => {
+    const found = hostAttachmentsFor('local-1', [
+      remote('n1', DEVBOX, '/srv/app'),
+      remote('n2', { ...DEVBOX }, '/srv/other'),
+      remote('n3', OTHER)
+    ])
+    expect(found).toHaveLength(2)
+    const devbox = found.find((a) => a.hostKey === 'corvin@devbox')!
+    expect(devbox.nodeIds).toEqual(['n1', 'n2'])
+    // The connection is opened at the FIRST node's cwd; each node still spawns in its own.
+    expect(devbox.remoteCwd).toBe('/srv/app')
+  })
+
+  it('ignores a plain `ssh <host>` node — it runs ssh as its own local pty, no master needed', () => {
+    const local: AttachableNode = { id: 'n1', ssh: DEVBOX, sshRemoteTmux: false }
+    expect(hostAttachmentsFor('local-1', [local])).toEqual([])
+  })
+
+  it('ignores nodes with no ssh binding at all', () => {
+    expect(hostAttachmentsFor('local-1', [{ id: 'n1', cwd: '/home/me' }])).toEqual([])
+  })
+
+  it('gives two projects on the same machine their own scope', () => {
+    const a = hostAttachmentsFor('local-1', [remote('n1', DEVBOX)])[0]
+    const b = hostAttachmentsFor('local-2', [remote('n1', DEVBOX)])[0]
+    expect(a.scopeId).not.toBe(b.scopeId)
+  })
+
+  it('never returns the project id as a scope (that master is not this node’s)', () => {
+    for (const scope of hostAttachmentsFor('local-1', [remote('n1', DEVBOX), remote('n2', OTHER)])) {
+      expect(scope.scopeId).not.toBe('local-1')
+    }
+  })
+})

--- a/src/renderer/lib/sshAttachments.ts
+++ b/src/renderer/lib/sshAttachments.ts
@@ -88,22 +88,34 @@ const dialing = new Map<string, Promise<boolean>>()
  * 3. Concurrent callers share one dial. Every node on a machine calls this at spawn; without the
  *    in-flight map they would each open a master.
  *
- * Idempotent and safe to call on every spawn: a live `controlPath` short-circuits.
+ * It ALWAYS dials — a cached `controlPath` is deliberately not treated as "already connected".
+ * Nothing in the renderer clears that path when a connection drops, so a short-circuit on it made
+ * the reconnect coordinator a permanent no-op for attachments: after one successful connect it
+ * would answer `true` forever, and a sleep/wake respawn would run its pty against a dead socket
+ * under `ControlMaster=auto`, which silently falls back to a DIRECT connection per node — the
+ * ~72k-logins/day pattern documented on `SshProjectManager.startWatchdog`. Main is the thing that
+ * knows whether the master is alive: its connect coalesces per scope and reuse costs one mux'd
+ * `-O check`, which doubles as the keepalive that resets the ControlPersist counter. A redundant
+ * dial through main is cheap and self-healing; a skipped one is the failure above.
  */
 export function connectHostAttachment(
   scopeId: string,
   attachment: SshAttachment,
-  connect: SshConnectFn
+  connect: SshConnectFn,
+  disconnect?: (scopeId: string) => Promise<unknown>
 ): Promise<boolean> {
-  const store = useSshConn.getState()
-  // Registered even on the short-circuit path: an attachment adopted from an already-live master
-  // (a tab switch back) still needs its endpoint on record for the NEXT drop.
-  store.registerAttachment(scopeId, attachment)
-  if (store.getControlPath(scopeId)) return Promise.resolve(true)
+  useSshConn.getState().registerAttachment(scopeId, attachment)
   const inFlight = dialing.get(scopeId)
   if (inFlight) return inFlight
   const attempt = connect(scopeId, attachment.conn, attachment.remoteCwd)
     .then((info) => {
+      // The canvas was deleted while we were dialing: its teardown pass already ran, and writing
+      // the connection back now would resurrect a scope nothing owns — a live master that no
+      // delete path will ever visit again. Hand it straight back instead.
+      if (!useSshConn.getState().getAttachment(scopeId)) {
+        void disconnect?.(scopeId)
+        return false
+      }
       useSshConn.getState().setConn(scopeId, info)
       return true
     })

--- a/src/renderer/lib/sshAttachments.ts
+++ b/src/renderer/lib/sshAttachments.ts
@@ -1,4 +1,5 @@
 import { sshConnectionIdForProject, sshHostKey, type SshConnection } from '@shared/ssh'
+import { useSshConn, type SshAttachment, type SshConnInfo } from '../state/sshConn'
 
 /** One host a project's canvas has REMOTE nodes on, other than the project's own endpoint. */
 export interface HostAttachment {
@@ -59,4 +60,64 @@ export function hostAttachmentsFor(
       })
   }
   return [...byScope.values()]
+}
+
+/** `window.nodeTerminal.sshProject.connect`, injected so this is testable without Electron. */
+export type SshConnectFn = (
+  scopeId: string,
+  conn: SshConnection,
+  remoteCwd?: string
+) => Promise<SshConnInfo>
+
+/** Dials in flight, keyed by scope: several nodes on one machine must produce ONE connect. */
+const dialing = new Map<string, Promise<boolean>>()
+
+/**
+ * Ensure an attachment's ControlMaster is up, and make sure the scope is REACHABLE either way.
+ *
+ * Three orderings this gets right, each of which was a live bug:
+ *
+ * 1. The attachment is registered BEFORE the dial. A first connect that fails is exactly what the
+ *    reconnect coordinator is for, and its `connect` dep has nowhere else to learn the endpoint —
+ *    recording on success only left a cold load against a sleeping host permanently offline, the
+ *    offline overlay's Reconnect included.
+ * 2. Also before the dial, because main emits `status:'connected'` from inside its connect — over
+ *    the same IPC pipe, so it ARRIVES BEFORE the invoke reply. The reconnector's `onConnected`
+ *    then maps scope → owning canvas through `ownerProjectId`, and a record written afterwards is
+ *    written too late: the respawn takes the "switched away" branch and never bumps the nonce.
+ * 3. Concurrent callers share one dial. Every node on a machine calls this at spawn; without the
+ *    in-flight map they would each open a master.
+ *
+ * Idempotent and safe to call on every spawn: a live `controlPath` short-circuits.
+ */
+export function connectHostAttachment(
+  scopeId: string,
+  attachment: SshAttachment,
+  connect: SshConnectFn
+): Promise<boolean> {
+  const store = useSshConn.getState()
+  // Registered even on the short-circuit path: an attachment adopted from an already-live master
+  // (a tab switch back) still needs its endpoint on record for the NEXT drop.
+  store.registerAttachment(scopeId, attachment)
+  if (store.getControlPath(scopeId)) return Promise.resolve(true)
+  const inFlight = dialing.get(scopeId)
+  if (inFlight) return inFlight
+  const attempt = connect(scopeId, attachment.conn, attachment.remoteCwd)
+    .then((info) => {
+      useSshConn.getState().setConn(scopeId, info)
+      return true
+    })
+    .catch(() => false)
+    // Cleared whatever happened: a failed dial must not poison the scope against the retry the
+    // reconnect coordinator is about to make.
+    .finally(() => {
+      dialing.delete(scopeId)
+    })
+  dialing.set(scopeId, attempt)
+  return attempt
+}
+
+/** Test seam only: forget in-flight dials between cases. */
+export function resetHostAttachmentDials(): void {
+  dialing.clear()
 }

--- a/src/renderer/lib/sshAttachments.ts
+++ b/src/renderer/lib/sshAttachments.ts
@@ -1,0 +1,62 @@
+import { sshConnectionIdForProject, sshHostKey, type SshConnection } from '@shared/ssh'
+
+/** One host a project's canvas has REMOTE nodes on, other than the project's own endpoint. */
+export interface HostAttachment {
+  /** Connection scope: `sshAttachmentId(projectId, conn)`. Keys `useSshConn`, the ControlMaster,
+   *  and the reconnect loop, exactly as an SSH project's id does for its own nodes. */
+  scopeId: string
+  /** `user@host` — the machine, ignoring port/identity (same remote `$HOME`). */
+  hostKey: string
+  conn: SshConnection
+  /** The cwd the connection itself is opened with (the Explorer/scp base). The individual nodes
+   *  still spawn in their OWN `cwd`; this is the first attached node's, as the representative. */
+  remoteCwd?: string
+  /** Node ids on this host — the connect banner and the reconnect flush work per scope. */
+  nodeIds: string[]
+}
+
+/** The subset of a persisted canvas node this needs. Deliberately structural: the caller passes
+ *  either persisted node states or live React Flow `data`, and both satisfy it. */
+export interface AttachableNode {
+  id: string
+  ssh?: SshConnection
+  sshRemoteTmux?: boolean
+  cwd?: string
+}
+
+/**
+ * Which host attachments a project's canvas needs opened.
+ *
+ * A remote node whose endpoint IS the project's own is served by the project's ControlMaster and
+ * is not listed — that is main's whole model, and it stays untouched. Everything else is an
+ * attachment: every remote node on a LOCAL project, and a node pointed at a second host inside an
+ * SSH project. Grouped by scope, so one master serves every node on the same machine.
+ *
+ * `sshRemoteTmux` is required: a plain `ssh <host>` node (`createSshTerminalNode`) runs ssh as its
+ * own local PTY program and needs no master at all — opening one for it would be a connection the
+ * user never asked for.
+ */
+export function hostAttachmentsFor(
+  projectId: string,
+  nodes: readonly AttachableNode[],
+  projectServer?: SshConnection
+): HostAttachment[] {
+  const byScope = new Map<string, HostAttachment>()
+  for (const node of nodes) {
+    const conn = node.ssh
+    if (!conn || !node.sshRemoteTmux) continue
+    const scopeId = sshConnectionIdForProject(projectId, conn, projectServer)
+    if (scopeId === projectId) continue // the project's own master already serves this node
+    const existing = byScope.get(scopeId)
+    if (existing) existing.nodeIds.push(node.id)
+    else
+      byScope.set(scopeId, {
+        scopeId,
+        hostKey: sshHostKey(conn),
+        conn,
+        remoteCwd: node.cwd,
+        nodeIds: [node.id]
+      })
+  }
+  return [...byScope.values()]
+}

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -142,7 +142,7 @@ import { accountChipLabel, COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from
 import { hasHooks, canRecur, canContextLink, hasUsage, canChat, canResume, canRename, canReadTitle, createdAgentId, reportsOwnCopy, resumeCommand, agentConfig, agentLaunchProgram } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
 import { ensureActivePermissionMode } from '../state/permissionMode'
-import { buildSshArgs, type SshConnection } from '@shared/ssh'
+import { buildSshArgs, sshConnectionIdForProject, type SshConnection } from '@shared/ssh'
 import { hintLabel } from '@shared/platform-utils'
 import { ColumnPill } from '../components/kanban/ColumnPill'
 import { BoardLogPanel } from '../components/kanban/BoardLogPanel'
@@ -154,17 +154,36 @@ import { AgentMascot } from './AgentMascot'
  *  overlay it falls back to is cheap and self-healing, so waiting longer buys nothing. */
 export const SSH_REMOTE_WAIT_MS = 20000
 
-/** The active project's live ControlMaster path, if any. Lets the caller tell "we will resolve in
- *  a microtask" from "we are about to sit in the wait below" without duplicating the lookup. */
-export function currentControlPath(): string | undefined {
-  return useSshConn.getState().getControlPath(useProjects.getState().activeProjectId)
+/**
+ * Which connection scope a remote node in the ACTIVE project runs over: the project's own id when
+ * the project IS that SSH endpoint, otherwise the project × endpoint host attachment — a remote
+ * node living in a local canvas (or in an SSH project pointed at a different host).
+ *
+ * A node only ever exists in the active project's React Flow, so the active project is its owner.
+ */
+export function sshConnectionScope(conn: SshConnection): string {
+  const { activeProjectId, getProject } = useProjects.getState()
+  return sshConnectionIdForProject(activeProjectId, conn, getProject(activeProjectId)?.ssh?.server)
+}
+
+/** The live ControlMaster path a remote node would run over, if any. Lets the caller tell "we will
+ *  resolve in a microtask" from "we are about to sit in the wait below" without duplicating the
+ *  lookup. Without a `conn` it answers for the active project's own connection. */
+export function currentControlPath(conn?: SshConnection): string | undefined {
+  return useSshConn
+    .getState()
+    .getControlPath(conn ? sshConnectionScope(conn) : useProjects.getState().activeProjectId)
 }
 
 /**
- * Resolve the `sshRemote` create option for an SSH-project terminal: the owning project's live
+ * Resolve the `sshRemote` create option for a remote terminal: its connection scope's live
  * ControlMaster `controlPath` (set by Canvas's active-project effect on connect) plus the inline
  * connection and remote cwd. The controlPath may not be ready yet on a cold app load (child
  * effects run before the parent's connect resolves), so wait for it — briefly — before spawning.
+ *
+ * The scope is the OWNING PROJECT for an SSH project's own nodes and a HOST ATTACHMENT for a node
+ * whose endpoint isn't the project's — never a bare `activeProjectId`, which for an attached node
+ * would resolve the local project's (absent, or worse: a DIFFERENT host's) master.
  *
  * Returns undefined if no master appears within the window (connection failed). The caller must
  * then spawn NOTHING — see `PtyCreateOptions.requireRemote`: a create without `sshRemote` does
@@ -184,7 +203,7 @@ export async function resolveSshRemote(
     }
   | undefined
 > {
-  const projectId = useProjects.getState().activeProjectId
+  const projectId = sshConnectionScope(conn)
   let controlPath = useSshConn.getState().getControlPath(projectId)
   if (!controlPath) {
     controlPath = await new Promise<string | undefined>((resolve) => {
@@ -1390,7 +1409,10 @@ export function TerminalNode({
   // `respawnNonce` ourselves: a respawn before the master is back would just re-run the same
   // 20s wait and land right back here.
   const reconnectOffline = (): void => {
-    const projectId = useProjects.getState().activeProjectId
+    // The SCOPE, not the project: an attached node's master belongs to its host attachment, and
+    // retrying the local project's (nonexistent) connection would never bring this node back.
+    const conn = data.ssh as SshConnection | undefined
+    const projectId = conn ? sshConnectionScope(conn) : useProjects.getState().activeProjectId
     if (projectId) sshRetryHandler?.(projectId, [id])
   }
 
@@ -2296,10 +2318,11 @@ export function TerminalNode({
     // `ssh` as a LOCAL pty program. Only the latter sets shell:'ssh' + buildSshArgs.
     const sshRemoteTmux = !!data.sshRemoteTmux
     const localSsh = !!ssh && !sshRemoteTmux
-    // Owning project of an SSH-project terminal, captured at spawn time for the exit-255 drop
-    // report below (a node only exists in the active project's React Flow, so the active
-    // project is its owner — same assumption as resolveSshRemote).
-    const sshProjectId = sshRemoteTmux ? useProjects.getState().activeProjectId : null
+    // Connection SCOPE of a remote terminal, captured at spawn time for the exit-255 drop report
+    // below. Same choice `resolveSshRemote` makes: the owning project for an SSH project's own
+    // node, the host attachment for a node attached to another endpoint — so the reconnect
+    // coordinator re-establishes the master this node actually died on.
+    const sshProjectId = sshRemoteTmux && ssh ? sshConnectionScope(ssh) : null
     // Prefetch the persisted scrollback in parallel with the spawn so it's ready to replay the
     // instant the session resolves (a cold restart after a reboot recreates the tmux session
     // empty — see the `fresh` handling below). Cheap no-op ('') when there's no snapshot.
@@ -2328,7 +2351,7 @@ export function TerminalNode({
       // or an unreachable host, and a terminal that is silently blank for that long reads as
       // broken. Only when there is nothing to wait FOR is nothing printed (the common case: the
       // master is already up and this resolves in a microtask).
-      if (sshRemoteTmux && ssh && !currentControlPath()) {
+      if (sshRemoteTmux && ssh && !currentControlPath(ssh)) {
         // Drop the overlay for the duration of the attempt (this respawn IS the retry the user or
         // the coordinator asked for) so the line below is visible; it comes back if we fail.
         setCo(termKey, { offline: false })
@@ -3664,7 +3687,12 @@ export function TerminalNode({
       // Remote terminal: uploading over the ControlMaster takes seconds and pastes nothing until
       // it's done, so show an overlay while it runs — without it a drop looks like it silently did
       // nothing. (The upload + REMOTE-path resolution itself lives in the shared droppedPaths.)
-      const projectId = useProjects.getState().activeProjectId
+      // Uploads go over the master this node's PTY runs on — its scope, which for an attached
+      // node is the host attachment, not the (local) project.
+      const dropConn = data.ssh as SshConnection | undefined
+      const projectId = dropConn
+        ? sshConnectionScope(dropConn)
+        : useProjects.getState().activeProjectId
       if (uploadNoteTimer.current) clearTimeout(uploadNoteTimer.current)
       setUploadNote({
         text: `Uploading ${files.length === 1 ? files[0].name : `${files.length} files`}…`,

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -221,7 +221,8 @@ export async function resolveSshRemote(
         remoteCwd: cwd,
         ownerProjectId: activeProjectId
       },
-      (scopeId, c, remoteCwd) => window.nodeTerminal.sshProject.connect(scopeId, c, remoteCwd)
+      (scopeId, c, remoteCwd) => window.nodeTerminal.sshProject.connect(scopeId, c, remoteCwd),
+      (scopeId) => window.nodeTerminal.sshProject.disconnect(scopeId)
     )
   }
   let controlPath = useSshConn.getState().getControlPath(projectId)

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -142,11 +142,12 @@ import { accountChipLabel, COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from
 import { hasHooks, canRecur, canContextLink, hasUsage, canChat, canResume, canRename, canReadTitle, createdAgentId, reportsOwnCopy, resumeCommand, agentConfig, agentLaunchProgram } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
 import { ensureActivePermissionMode } from '../state/permissionMode'
-import { buildSshArgs, sshConnectionIdForProject, type SshConnection } from '@shared/ssh'
+import { buildSshArgs, sshConnectionIdForProject, sshHostKey, type SshConnection } from '@shared/ssh'
 import { hintLabel } from '@shared/platform-utils'
 import { ColumnPill } from '../components/kanban/ColumnPill'
 import { BoardLogPanel } from '../components/kanban/BoardLogPanel'
 import { AgentMascot } from './AgentMascot'
+import { connectHostAttachment } from '../lib/sshAttachments'
 
 /** How long a remote terminal waits for its project's ControlMaster before giving up and showing
  *  the offline overlay. Sized for the SLOW-but-fine case (a cold app load whose connect is still
@@ -203,7 +204,26 @@ export async function resolveSshRemote(
     }
   | undefined
 > {
+  const activeProjectId = useProjects.getState().activeProjectId
   const projectId = sshConnectionScope(conn)
+  // A HOST ATTACHMENT dials for itself, HERE, because nothing else will. Canvas's active-project
+  // effect pre-warms the attachments it can SEE in the stored canvas, but a node created at
+  // runtime — the remote account-login retry drops one into whatever tab is active — never
+  // appears in that pass, and would otherwise wait out the window under a scope no master exists
+  // for and then sit offline forever. Idempotent and deduped, so the pre-warm and every node on
+  // the machine collapse into one connect; the wait below is what actually blocks on it.
+  if (projectId !== activeProjectId) {
+    void connectHostAttachment(
+      projectId,
+      {
+        conn,
+        hostKey: sshHostKey(conn),
+        remoteCwd: cwd,
+        ownerProjectId: activeProjectId
+      },
+      (scopeId, c, remoteCwd) => window.nodeTerminal.sshProject.connect(scopeId, c, remoteCwd)
+    )
+  }
   let controlPath = useSshConn.getState().getControlPath(projectId)
   if (!controlPath) {
     controlPath = await new Promise<string | undefined>((resolve) => {

--- a/src/renderer/state/sshConn.test.ts
+++ b/src/renderer/state/sshConn.test.ts
@@ -106,3 +106,56 @@ describe('useSshConn — tri-state probe answer + remote version (tab-menu hint)
     expect(useSshConn.getState().getRemoteClaudeVersion('p1')).toBe('2.1.90 (Claude Code)')
   })
 })
+
+// A HOST ATTACHMENT — a remote node inside a canvas that is not that endpoint's SSH project —
+// has no project row anywhere. Its scope entry is the only record of how to reach the machine and
+// which canvas its nodes are on, so the reconnect coordinator reads it back out of here.
+describe('useSshConn — host attachments', () => {
+  const ATTACHMENT = {
+    conn: { host: 'devbox', user: 'corvin', port: 2222 },
+    hostKey: 'corvin@devbox',
+    remoteCwd: '/srv/app',
+    ownerProjectId: 'local-1'
+  }
+
+  it('answers the owning canvas for an attachment scope, and itself for an SSH project', () => {
+    const s = useSshConn.getState()
+    s.setConn('attached-local-1-deadbeef', { controlPath: '/tmp/a', attachment: ATTACHMENT })
+    s.setConn('ssh-project-1', { controlPath: '/tmp/b' })
+
+    expect(useSshConn.getState().ownerProjectId('attached-local-1-deadbeef')).toBe('local-1')
+    expect(useSshConn.getState().ownerProjectId('ssh-project-1')).toBe('ssh-project-1')
+    // Never undefined: an unknown scope answers itself, so a caller keyed on it still has an id.
+    expect(useSshConn.getState().ownerProjectId('nope')).toBe('nope')
+  })
+
+  it('an SSH project scope is not an attachment', () => {
+    useSshConn.getState().setConn('ssh-project-1', { controlPath: '/tmp/b' })
+    expect(useSshConn.getState().getAttachment('ssh-project-1')).toBeUndefined()
+  })
+
+  it('a RE-connect (bare IPC coordinates) keeps the routing facts', () => {
+    // The regression this guards: the reconnect loop heals the master, setConn overwrites the
+    // entry with what IPC returned, and the scope loses the only record of its endpoint — so the
+    // NEXT drop can never be reconnected, and the respawn goes to the wrong canvas.
+    const s = useSshConn.getState()
+    s.setConn('attached-local-1-deadbeef', { controlPath: '/tmp/a', attachment: ATTACHMENT })
+
+    s.setConn('attached-local-1-deadbeef', { controlPath: '/tmp/a2' })
+
+    const after = useSshConn.getState()
+    expect(after.getControlPath('attached-local-1-deadbeef')).toBe('/tmp/a2')
+    expect(after.getAttachment('attached-local-1-deadbeef')).toEqual(ATTACHMENT)
+  })
+
+  it('lists a project’s attachment scopes so its masters can be torn down with it', () => {
+    const s = useSshConn.getState()
+    s.setConn('a1', { controlPath: '/tmp/1', attachment: ATTACHMENT })
+    s.setConn('a2', { controlPath: '/tmp/2', attachment: { ...ATTACHMENT, hostKey: 'u@other' } })
+    s.setConn('a3', { controlPath: '/tmp/3', attachment: { ...ATTACHMENT, ownerProjectId: 'p2' } })
+    s.setConn('ssh-project-1', { controlPath: '/tmp/4' })
+
+    expect(useSshConn.getState().attachmentScopesOf('local-1').sort()).toEqual(['a1', 'a2'])
+    expect(useSshConn.getState().attachmentScopesOf('p2')).toEqual(['a3'])
+  })
+})

--- a/src/renderer/state/sshConn.test.ts
+++ b/src/renderer/state/sshConn.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { useSshConn } from './sshConn'
 
 beforeEach(() => {
-  useSshConn.setState({ byProject: {}, autoPermByProject: {}, remoteClaudeVersionByProject: {} })
+  useSshConn.setState({
+    byProject: {},
+    attachments: {},
+    autoPermByProject: {},
+    remoteClaudeVersionByProject: {}
+  })
 })
 
 // If a project's SSH server gets repointed to a DIFFERENT host whose claude CLI is older, the
@@ -107,9 +112,9 @@ describe('useSshConn — tri-state probe answer + remote version (tab-menu hint)
   })
 })
 
-// A HOST ATTACHMENT — a remote node inside a canvas that is not that endpoint's SSH project —
-// has no project row anywhere. Its scope entry is the only record of how to reach the machine and
-// which canvas its nodes are on, so the reconnect coordinator reads it back out of here.
+// A HOST ATTACHMENT — a remote node inside a canvas that is not that endpoint's SSH project — has
+// no project row anywhere. The record here is the ONLY way back to the machine, and it is kept in
+// its own map (not on the connection) precisely so it survives a connect that never succeeded.
 describe('useSshConn — host attachments', () => {
   const ATTACHMENT = {
     conn: { host: 'devbox', user: 'corvin', port: 2222 },
@@ -120,7 +125,7 @@ describe('useSshConn — host attachments', () => {
 
   it('answers the owning canvas for an attachment scope, and itself for an SSH project', () => {
     const s = useSshConn.getState()
-    s.setConn('attached-local-1-deadbeef', { controlPath: '/tmp/a', attachment: ATTACHMENT })
+    s.registerAttachment('attached-local-1-deadbeef', ATTACHMENT)
     s.setConn('ssh-project-1', { controlPath: '/tmp/b' })
 
     expect(useSshConn.getState().ownerProjectId('attached-local-1-deadbeef')).toBe('local-1')
@@ -134,28 +139,48 @@ describe('useSshConn — host attachments', () => {
     expect(useSshConn.getState().getAttachment('ssh-project-1')).toBeUndefined()
   })
 
-  it('a RE-connect (bare IPC coordinates) keeps the routing facts', () => {
-    // The regression this guards: the reconnect loop heals the master, setConn overwrites the
-    // entry with what IPC returned, and the scope loses the only record of its endpoint — so the
-    // NEXT drop can never be reconnected, and the respawn goes to the wrong canvas.
+  it('a registered attachment survives with NO connection at all', () => {
+    // The regression this guards: recording the routing facts on the connect RESULT. A cold load
+    // against a sleeping host then has no endpoint on record, so the reconnect coordinator's
+    // connect dep returns false on every backoff step and the offline overlay's Reconnect is
+    // inert for the rest of the app run.
+    useSshConn.getState().registerAttachment('a1', ATTACHMENT)
+
+    expect(useSshConn.getState().getControlPath('a1')).toBeUndefined()
+    expect(useSshConn.getState().getAttachment('a1')).toEqual(ATTACHMENT)
+    expect(useSshConn.getState().ownerProjectId('a1')).toBe('local-1')
+  })
+
+  it('a RE-connect does not disturb the routing facts', () => {
     const s = useSshConn.getState()
-    s.setConn('attached-local-1-deadbeef', { controlPath: '/tmp/a', attachment: ATTACHMENT })
+    s.registerAttachment('a1', ATTACHMENT)
 
-    s.setConn('attached-local-1-deadbeef', { controlPath: '/tmp/a2' })
+    s.setConn('a1', { controlPath: '/tmp/a2' })
 
-    const after = useSshConn.getState()
-    expect(after.getControlPath('attached-local-1-deadbeef')).toBe('/tmp/a2')
-    expect(after.getAttachment('attached-local-1-deadbeef')).toEqual(ATTACHMENT)
+    expect(useSshConn.getState().getControlPath('a1')).toBe('/tmp/a2')
+    expect(useSshConn.getState().getAttachment('a1')).toEqual(ATTACHMENT)
   })
 
   it('lists a project’s attachment scopes so its masters can be torn down with it', () => {
     const s = useSshConn.getState()
-    s.setConn('a1', { controlPath: '/tmp/1', attachment: ATTACHMENT })
-    s.setConn('a2', { controlPath: '/tmp/2', attachment: { ...ATTACHMENT, hostKey: 'u@other' } })
-    s.setConn('a3', { controlPath: '/tmp/3', attachment: { ...ATTACHMENT, ownerProjectId: 'p2' } })
+    s.registerAttachment('a1', ATTACHMENT)
+    s.registerAttachment('a2', { ...ATTACHMENT, hostKey: 'u@other' })
+    s.registerAttachment('a3', { ...ATTACHMENT, ownerProjectId: 'p2' })
     s.setConn('ssh-project-1', { controlPath: '/tmp/4' })
 
     expect(useSshConn.getState().attachmentScopesOf('local-1').sort()).toEqual(['a1', 'a2'])
     expect(useSshConn.getState().attachmentScopesOf('p2')).toEqual(['a3'])
+  })
+
+  it('clearAttachment forgets both the routing facts and the connection', () => {
+    const s = useSshConn.getState()
+    s.registerAttachment('a1', ATTACHMENT)
+    s.setConn('a1', { controlPath: '/tmp/a' })
+
+    s.clearAttachment('a1')
+
+    expect(useSshConn.getState().getAttachment('a1')).toBeUndefined()
+    expect(useSshConn.getState().getControlPath('a1')).toBeUndefined()
+    expect(useSshConn.getState().attachmentScopesOf('local-1')).toEqual([])
   })
 })

--- a/src/renderer/state/sshConn.ts
+++ b/src/renderer/state/sshConn.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand'
+import type { SshConnection } from '@shared/ssh'
 
-/** Live connection coordinates for one SSH project, returned by `sshProject.connect`. */
+/** Live connection coordinates for one connection scope, returned by `sshProject.connect`.
+ *  A scope is an SSH PROJECT's id, or a host ATTACHMENT id — see `sshConnectionIdForProject`. */
 export interface SshConnInfo {
   /** ControlMaster socket path the project's terminals run their PTYs over. */
   controlPath: string
@@ -22,6 +24,26 @@ export interface SshConnInfo {
   /** The probed remote `claude --version` output (`null` = probe ran, claude not found). Feeds
    *  the tab menu's Auto hint; only present on a reused (already probed) connection. */
   remoteClaudeVersion?: string | null
+  /**
+   * Routing facts for a HOST ATTACHMENT — a remote node living in a project that is not that
+   * endpoint's own SSH project. An SSH project can re-derive all of this from `getProject(id)`;
+   * an attachment has no project row of its own, so its scope carries them. Absent on a plain
+   * SSH-project entry, which is how the two are told apart.
+   */
+  attachment?: SshAttachment
+}
+
+/** What an attachment scope needs in order to be RE-connected (the reconnect coordinator) and to
+ *  find the canvas its nodes are on (the respawn). Renderer-only: never persisted. */
+export interface SshAttachment {
+  /** The endpoint, snapshotted — the saved server may be edited or deleted underneath us. */
+  conn: SshConnection
+  /** `user@host` (`sshHostKey`) — for "am I already connected to this machine?" lookups. */
+  hostKey: string
+  /** Default remote folder for this attachment; `~` when the host has none configured. */
+  remoteCwd?: string
+  /** The LOCAL canvas project the attached nodes live on. */
+  ownerProjectId: string
 }
 
 /** What the remote probe has said so far — the tab menu's Auto hint reads differently for "not
@@ -30,11 +52,16 @@ export interface SshConnInfo {
 export type SshAutoPermAnswer = 'yes' | 'no' | 'unknown'
 
 /**
- * Transient map of SSH project id → its live connection info (ControlMaster `controlPath` +
+ * Transient map of CONNECTION SCOPE → its live connection info (ControlMaster `controlPath` +
  * optional remote `hookEndpointPath`) returned by `sshProject.connect`. Not persisted: it's
  * re-established on every launch by Canvas's active-project effect. A remote terminal node reads
- * its project's entry here to pass `sshRemote` into `transport.create`, so the PTY runs over the
- * project's master and (when present) the remote hook env is injected.
+ * its scope's entry here to pass `sshRemote` into `transport.create`, so the PTY runs over that
+ * master and (when present) the remote hook env is injected.
+ *
+ * A scope is USUALLY an SSH project's id. It is a host ATTACHMENT id (`sshAttachmentId`) when the
+ * node's endpoint is not its project's own — a remote node inside a LOCAL canvas. Both kinds live
+ * in this one map because everything downstream (connect, resolve, reconnect, disconnect) treats
+ * them identically; `attachment` is what distinguishes them.
  */
 interface SshConnState {
   byProject: Record<string, SshConnInfo>
@@ -53,6 +80,12 @@ interface SshConnState {
   getHookEndpointPath(projectId: string): string | undefined
   getTmuxConfPath(projectId: string): string | undefined
   getRemoteHome(projectId: string): string | undefined
+  /** The routing facts of a HOST ATTACHMENT scope; undefined for an SSH project's own scope
+   *  (which re-derives everything from its project row) and for anything not connected. */
+  getAttachment(scopeId: string): SshAttachment | undefined
+  /** The canvas project a connection scope's nodes live on: the owner for an attachment, the
+   *  scope itself for an SSH project. Never undefined — callers key React Flow off it. */
+  ownerProjectId(scopeId: string): string
   /** True ONLY when the remote CLI was probed and is known to accept `--permission-mode auto`.
    *  Not connected / never probed / older CLI all answer false (conservative — omit the flag). */
   supportsAutoPermissionMode(projectId: string): boolean
@@ -68,6 +101,9 @@ interface SshConnState {
    *  design means "unknown" should win until the next probe lands, never a stale "yes". */
   invalidateAutoPermissionMode(projectId: string): void
   clear(projectId: string): void
+  /** Every attachment scope a project owns. Used to tear its masters down when the project is
+   *  deleted — nothing else knows they exist (they have no project row). */
+  attachmentScopesOf(ownerProjectId: string): string[]
 }
 
 export const useSshConn = create<SshConnState>((set, get) => ({
@@ -76,7 +112,15 @@ export const useSshConn = create<SshConnState>((set, get) => ({
   remoteClaudeVersionByProject: {},
   setConn(projectId, info) {
     set((s) => ({
-      byProject: { ...s.byProject, [projectId]: info },
+      byProject: {
+        ...s.byProject,
+        // A RE-connect returns bare IPC coordinates with no attachment block; keep the one the
+        // scope already had, or the reconnect that just healed the master would erase the only
+        // record of how to reach it (and which canvas its nodes are on).
+        [projectId]: info.attachment
+          ? info
+          : { ...info, attachment: s.byProject[projectId]?.attachment }
+      },
       // A reused (already probed) connection returns the answer with the connect result.
       autoPermByProject:
         info.claudeAutoPermissionMode === undefined
@@ -108,6 +152,12 @@ export const useSshConn = create<SshConnState>((set, get) => ({
   },
   getRemoteHome(projectId) {
     return get().byProject[projectId]?.remoteHome
+  },
+  getAttachment(scopeId) {
+    return get().byProject[scopeId]?.attachment
+  },
+  ownerProjectId(scopeId) {
+    return get().byProject[scopeId]?.attachment?.ownerProjectId ?? scopeId
   },
   supportsAutoPermissionMode(projectId) {
     return get().autoPermByProject[projectId] === true
@@ -141,5 +191,10 @@ export const useSshConn = create<SshConnState>((set, get) => ({
       delete nextVersion[projectId]
       return { byProject: next, autoPermByProject: nextAuto, remoteClaudeVersionByProject: nextVersion }
     })
+  },
+  attachmentScopesOf(ownerProjectId) {
+    return Object.entries(get().byProject)
+      .filter(([, info]) => info.attachment?.ownerProjectId === ownerProjectId)
+      .map(([scopeId]) => scopeId)
   }
 }))

--- a/src/renderer/state/sshConn.ts
+++ b/src/renderer/state/sshConn.ts
@@ -24,23 +24,25 @@ export interface SshConnInfo {
   /** The probed remote `claude --version` output (`null` = probe ran, claude not found). Feeds
    *  the tab menu's Auto hint; only present on a reused (already probed) connection. */
   remoteClaudeVersion?: string | null
-  /**
-   * Routing facts for a HOST ATTACHMENT — a remote node living in a project that is not that
-   * endpoint's own SSH project. An SSH project can re-derive all of this from `getProject(id)`;
-   * an attachment has no project row of its own, so its scope carries them. Absent on a plain
-   * SSH-project entry, which is how the two are told apart.
-   */
-  attachment?: SshAttachment
 }
 
-/** What an attachment scope needs in order to be RE-connected (the reconnect coordinator) and to
- *  find the canvas its nodes are on (the respawn). Renderer-only: never persisted. */
+/**
+ * Routing facts for a HOST ATTACHMENT — a remote node living in a project that is not that
+ * endpoint's own SSH project. An SSH project can re-derive all of this from `getProject(id)`; an
+ * attachment has no project row of its own, so this is the only record of it.
+ *
+ * Kept in its OWN map, not on `SshConnInfo`, because it must exist BEFORE the connection does and
+ * must SURVIVE its failure: the reconnect coordinator reads the endpoint back out of here to
+ * redial, and the respawn reads the owning canvas out of here to know where the nodes are. Both
+ * of those run precisely when there is no live connection to hang the facts off. Renderer-only:
+ * never persisted.
+ */
 export interface SshAttachment {
   /** The endpoint, snapshotted — the saved server may be edited or deleted underneath us. */
   conn: SshConnection
   /** `user@host` (`sshHostKey`) — for "am I already connected to this machine?" lookups. */
   hostKey: string
-  /** Default remote folder for this attachment; `~` when the host has none configured. */
+  /** The folder the CONNECTION is opened at (the scp/Explorer base); nodes spawn in their own. */
   remoteCwd?: string
   /** The LOCAL canvas project the attached nodes live on. */
   ownerProjectId: string
@@ -65,6 +67,9 @@ export type SshAutoPermAnswer = 'yes' | 'no' | 'unknown'
  */
 interface SshConnState {
   byProject: Record<string, SshConnInfo>
+  /** Attachment scope id → how to reach it and whose canvas it serves. Written BEFORE the dial
+   *  (see `registerAttachment`), so it outlives a failed connect. */
+  attachments: Record<string, SshAttachment>
   /** project id → "the remote CLI accepts `--permission-mode auto`". Kept OUTSIDE `byProject`
    *  because the remote probe runs after connect and can land before OR after the connect promise
    *  writes the entry — a separate map makes the two orders equivalent. */
@@ -80,12 +85,21 @@ interface SshConnState {
   getHookEndpointPath(projectId: string): string | undefined
   getTmuxConfPath(projectId: string): string | undefined
   getRemoteHome(projectId: string): string | undefined
+  /**
+   * Record how to reach an attachment scope. Call this BEFORE dialing, not after: a first connect
+   * that FAILS is exactly the case the reconnect coordinator exists for, and it has nowhere else
+   * to learn the endpoint from. Recording on success only made a cold load against a sleeping
+   * host unrecoverable for the rest of the app run.
+   */
+  registerAttachment(scopeId: string, attachment: SshAttachment): void
   /** The routing facts of a HOST ATTACHMENT scope; undefined for an SSH project's own scope
-   *  (which re-derives everything from its project row) and for anything not connected. */
+   *  (which re-derives everything from its project row) and for a scope never registered. */
   getAttachment(scopeId: string): SshAttachment | undefined
   /** The canvas project a connection scope's nodes live on: the owner for an attachment, the
    *  scope itself for an SSH project. Never undefined — callers key React Flow off it. */
   ownerProjectId(scopeId: string): string
+  /** Forget an attachment entirely (its canvas was deleted). Also drops any live connection info. */
+  clearAttachment(scopeId: string): void
   /** True ONLY when the remote CLI was probed and is known to accept `--permission-mode auto`.
    *  Not connected / never probed / older CLI all answer false (conservative — omit the flag). */
   supportsAutoPermissionMode(projectId: string): boolean
@@ -108,19 +122,12 @@ interface SshConnState {
 
 export const useSshConn = create<SshConnState>((set, get) => ({
   byProject: {},
+  attachments: {},
   autoPermByProject: {},
   remoteClaudeVersionByProject: {},
   setConn(projectId, info) {
     set((s) => ({
-      byProject: {
-        ...s.byProject,
-        // A RE-connect returns bare IPC coordinates with no attachment block; keep the one the
-        // scope already had, or the reconnect that just healed the master would erase the only
-        // record of how to reach it (and which canvas its nodes are on).
-        [projectId]: info.attachment
-          ? info
-          : { ...info, attachment: s.byProject[projectId]?.attachment }
-      },
+      byProject: { ...s.byProject, [projectId]: info },
       // A reused (already probed) connection returns the answer with the connect result.
       autoPermByProject:
         info.claudeAutoPermissionMode === undefined
@@ -153,11 +160,23 @@ export const useSshConn = create<SshConnState>((set, get) => ({
   getRemoteHome(projectId) {
     return get().byProject[projectId]?.remoteHome
   },
+  registerAttachment(scopeId, attachment) {
+    set((s) => ({ attachments: { ...s.attachments, [scopeId]: attachment } }))
+  },
   getAttachment(scopeId) {
-    return get().byProject[scopeId]?.attachment
+    return get().attachments[scopeId]
   },
   ownerProjectId(scopeId) {
-    return get().byProject[scopeId]?.attachment?.ownerProjectId ?? scopeId
+    return get().attachments[scopeId]?.ownerProjectId ?? scopeId
+  },
+  clearAttachment(scopeId) {
+    set((s) => {
+      const next = { ...s.attachments }
+      delete next[scopeId]
+      const conns = { ...s.byProject }
+      delete conns[scopeId]
+      return { attachments: next, byProject: conns }
+    })
   },
   supportsAutoPermissionMode(projectId) {
     return get().autoPermByProject[projectId] === true
@@ -193,8 +212,8 @@ export const useSshConn = create<SshConnState>((set, get) => ({
     })
   },
   attachmentScopesOf(ownerProjectId) {
-    return Object.entries(get().byProject)
-      .filter(([, info]) => info.attachment?.ownerProjectId === ownerProjectId)
+    return Object.entries(get().attachments)
+      .filter(([, a]) => a.ownerProjectId === ownerProjectId)
       .map(([scopeId]) => scopeId)
   }
 }))

--- a/src/shared/ssh.test.ts
+++ b/src/shared/ssh.test.ts
@@ -9,6 +9,8 @@ import {
   remoteTmuxCommand,
   remoteTmuxConf,
   parseLsDirs,
+  sshAttachmentId,
+  sshConnectionIdForProject,
   sshHostKey
 } from './ssh'
 
@@ -20,6 +22,62 @@ describe('sshHostKey', () => {
     expect(sshHostKey({ host: 'h', user: 'u', port: 22 } as never)).toBe(
       sshHostKey({ host: 'h', user: 'u', port: 2222 } as never)
     )
+  })
+})
+
+describe('sshAttachmentId', () => {
+  it('shares one scope per project and endpoint without exposing the host in a filename', () => {
+    const a = sshAttachmentId('project-1', { host: 'ubuntu.lan', user: 'corvin', port: 22 })
+    expect(a).toBe(sshAttachmentId('project-1', { host: 'ubuntu.lan', user: 'corvin' }))
+    expect(a).not.toContain('ubuntu.lan')
+    expect(a).not.toBe(sshAttachmentId('project-2', { host: 'ubuntu.lan', user: 'corvin' }))
+    expect(a).not.toBe(sshAttachmentId('project-1', { host: 'ubuntu.lan', user: 'other' }))
+  })
+
+  it('separates two ports on the same host (two different sshd instances)', () => {
+    expect(sshAttachmentId('p', { host: 'h', user: 'u', port: 22 })).not.toBe(
+      sshAttachmentId('p', { host: 'h', user: 'u', port: 2222 })
+    )
+  })
+
+  it('is filesystem-safe: the ControlMaster socket path is built from it', () => {
+    expect(sshAttachmentId('p1', { host: 'a.very.long.hostname.example.com', user: 'u' })).toMatch(
+      /^attached-p1-[0-9a-f]{8}$/
+    )
+  })
+})
+
+describe('sshConnectionIdForProject', () => {
+  const ubuntu = { host: 'devbox', user: 'corvin', port: 2222 }
+
+  it('uses the project id when the project itself lives on that SSH endpoint', () => {
+    expect(sshConnectionIdForProject('project-1', ubuntu, { ...ubuntu })).toBe('project-1')
+  })
+
+  it('treats an omitted port as 22 on BOTH sides (same endpoint, one master)', () => {
+    const plain = { host: 'devbox', user: 'corvin' }
+    expect(sshConnectionIdForProject('p1', plain, { ...plain, port: 22 })).toBe('p1')
+    expect(sshConnectionIdForProject('p1', { ...plain, port: 22 }, plain)).toBe('p1')
+  })
+
+  it('uses the host attachment when a remote node lives in a local project', () => {
+    expect(sshConnectionIdForProject('project-1', ubuntu)).toBe(sshAttachmentId('project-1', ubuntu))
+  })
+
+  it("does not reuse an SSH project's connection for a node on another endpoint", () => {
+    expect(
+      sshConnectionIdForProject('project-1', ubuntu, {
+        host: 'another-host',
+        user: 'corvin',
+        port: 2222
+      })
+    ).toBe(sshAttachmentId('project-1', ubuntu))
+  })
+
+  it('never returns the project id for a node the project cannot serve', () => {
+    // The regression this guards: an attached node resolving the LOCAL project's (absent) master
+    // and, with no `sshRemote`, degrading into a local shell wearing the remote node's identity.
+    expect(sshConnectionIdForProject('local-project', ubuntu)).not.toBe('local-project')
   })
 })
 

--- a/src/shared/ssh.test.ts
+++ b/src/shared/ssh.test.ts
@@ -54,14 +54,28 @@ describe('sshConnectionIdForProject', () => {
     expect(sshConnectionIdForProject('project-1', ubuntu, { ...ubuntu })).toBe('project-1')
   })
 
-  it('treats an omitted port as 22 on BOTH sides (same endpoint, one master)', () => {
-    const plain = { host: 'devbox', user: 'corvin' }
-    expect(sshConnectionIdForProject('p1', plain, { ...plain, port: 22 })).toBe('p1')
-    expect(sshConnectionIdForProject('p1', { ...plain, port: 22 }, plain)).toBe('p1')
+  it('a LOCAL project has no binding, so every remote node on it is an attachment', () => {
+    expect(sshConnectionIdForProject('local-1', ubuntu, undefined)).toBe(
+      sshAttachmentId('local-1', ubuntu)
+    )
   })
 
   it('uses the host attachment when a remote node lives in a local project', () => {
     expect(sshConnectionIdForProject('project-1', ubuntu)).toBe(sshAttachmentId('project-1', ubuntu))
+  })
+
+  it('serves a node naming the same HOST from the project, whatever user it was saved with', () => {
+    // An SSH project's canvas lives in `<remoteCwd>/.nodeterm/project.json` ON THE HOST, shared
+    // with everyone who opens that folder — so a node's persisted `user` is whoever CREATED it.
+    // If alice's nodes sent bob off to open a second master as `alice@box`, bob's whole canvas
+    // would fail (or sit on an askpass prompt) the moment he opened the project.
+    expect(
+      sshConnectionIdForProject('project-1', { host: 'devbox', user: 'alice', port: 2222 }, ubuntu)
+    ).toBe('project-1')
+    // Same for a port saved from a setup that reaches the machine differently.
+    expect(
+      sshConnectionIdForProject('project-1', { host: 'devbox', user: 'corvin', port: 22 }, ubuntu)
+    ).toBe('project-1')
   })
 
   it("does not reuse an SSH project's connection for a node on another endpoint", () => {

--- a/src/shared/ssh.test.ts
+++ b/src/shared/ssh.test.ts
@@ -54,6 +54,21 @@ describe('sshConnectionIdForProject', () => {
     expect(sshConnectionIdForProject('project-1', ubuntu, { ...ubuntu })).toBe('project-1')
   })
 
+  it('a node with no host is never served from the project (unroutable fails safe)', () => {
+    // `undefined === undefined` would otherwise hand a hostless node a LOCAL project's id — a
+    // master that was never opened for it. Failing as an attachment ends at `requireRemote`.
+    // `undefined` specifically: a LOCAL project passes no server at all, so `projectServer?.host`
+    // is also undefined and the two compare EQUAL.
+    const hostless = { host: undefined, user: 'corvin' } as unknown as typeof ubuntu
+    expect(sshConnectionIdForProject('local-1', hostless)).not.toBe('local-1')
+    expect(sshConnectionIdForProject('local-1', hostless)).toBe(
+      sshAttachmentId('local-1', hostless)
+    )
+    // An empty host is just as unroutable.
+    const empty = { host: '', user: 'corvin' } as unknown as typeof ubuntu
+    expect(sshConnectionIdForProject('local-1', empty)).not.toBe('local-1')
+  })
+
   it('a LOCAL project has no binding, so every remote node on it is an attachment', () => {
     expect(sshConnectionIdForProject('local-1', ubuntu, undefined)).toBe(
       sshAttachmentId('local-1', ubuntu)

--- a/src/shared/ssh.ts
+++ b/src/shared/ssh.ts
@@ -169,7 +169,13 @@ export function sshConnectionIdForProject(
   conn: SshConnection,
   projectServer?: SshConnection
 ): string {
-  return projectServer?.host === conn.host ? projectId : sshAttachmentId(projectId, conn)
+  // `conn.host` is checked explicitly: a node whose binding lost its host (bad persisted data)
+  // must not match a LOCAL project's absent one through `undefined === undefined` and get served
+  // from a master that was never opened for it. Unroutable either way — but failing as an
+  // attachment ends at `requireRemote` refusing the spawn, which is the safe direction.
+  return conn.host && projectServer?.host === conn.host
+    ? projectId
+    : sshAttachmentId(projectId, conn)
 }
 
 /**

--- a/src/shared/ssh.ts
+++ b/src/shared/ssh.ts
@@ -113,6 +113,54 @@ export function sshExtraArgsEnableLocalExec(extraArgs: string | undefined): bool
 export interface SshServer extends SshConnection {
   id: string
   label: string
+  /** Default remote folder for anything opened on this machine — the "New remote" dialog's
+   *  prefill, and the cwd of a node attached to this host from a LOCAL canvas project (which has
+   *  no `remoteCwd` of its own to inherit). Optional; absent means `~`. */
+  remoteCwd?: string
+}
+
+/**
+ * Stable live-connection scope for an SSH host ATTACHED to a canvas project — i.e. a remote node
+ * living in a project that is not itself that endpoint's SSH project.
+ *
+ * Scoped by project AND endpoint, so two projects attaching the same host get their own
+ * ControlMaster (and their own reconnect loop), and one project attaching two hosts gets two. The
+ * endpoint is FNV-1a hashed rather than embedded: this id reaches the filesystem as part of the
+ * ControlMaster socket path, where a raw `user@host:port` would both leak the inventory and blow
+ * the sun_path length budget on a long hostname.
+ */
+export function sshAttachmentId(projectId: string, conn: SshConnection): string {
+  const input = `${conn.user}\0${conn.host}\0${conn.port ?? 22}`
+  let hash = 2166136261
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `attached-${projectId}-${(hash >>> 0).toString(16).padStart(8, '0')}`
+}
+
+/**
+ * Connection scope used by a remote node inside a project.
+ *
+ * An SSH PROJECT owns its ControlMaster under the project id — that is the whole of today's
+ * model, and this returns exactly that whenever the node's endpoint is the project's own. A
+ * remote node embedded in a LOCAL project (or in an SSH project pointed at a DIFFERENT host) owns
+ * a host attachment instead, under the stable project × endpoint id.
+ *
+ * Every consumer of that connection — spawn (`resolveSshRemote`), reconnect (`SshReconnector`),
+ * upload — must make the same choice, or a node resolves a master that was opened for someone
+ * else. Hence one function rather than the rule written out at each site.
+ */
+export function sshConnectionIdForProject(
+  projectId: string,
+  conn: SshConnection,
+  projectServer?: SshConnection
+): string {
+  const sameEndpoint =
+    projectServer?.host === conn.host &&
+    projectServer.user === conn.user &&
+    (projectServer.port ?? 22) === (conn.port ?? 22)
+  return sameEndpoint ? projectId : sshAttachmentId(projectId, conn)
 }
 
 /**

--- a/src/shared/ssh.ts
+++ b/src/shared/ssh.ts
@@ -113,9 +113,9 @@ export function sshExtraArgsEnableLocalExec(extraArgs: string | undefined): bool
 export interface SshServer extends SshConnection {
   id: string
   label: string
-  /** Default remote folder for anything opened on this machine — the "New remote" dialog's
-   *  prefill, and the cwd of a node attached to this host from a LOCAL canvas project (which has
-   *  no `remoteCwd` of its own to inherit). Optional; absent means `~`. */
+  /** Where browsing this machine STARTS: the folder the "New remote" project dialog opens at, and
+   *  the folder Test connection dials. It is a starting point, not an inherited default — a node's
+   *  cwd comes from the project or node it was created in, never from here. Absent means `~`. */
   remoteCwd?: string
 }
 
@@ -143,24 +143,33 @@ export function sshAttachmentId(projectId: string, conn: SshConnection): string 
  * Connection scope used by a remote node inside a project.
  *
  * An SSH PROJECT owns its ControlMaster under the project id — that is the whole of today's
- * model, and this returns exactly that whenever the node's endpoint is the project's own. A
- * remote node embedded in a LOCAL project (or in an SSH project pointed at a DIFFERENT host) owns
- * a host attachment instead, under the stable project × endpoint id.
+ * model, and this returns exactly that whenever the project's own binding already reaches the
+ * node's machine. A remote node embedded in a LOCAL project (or in an SSH project bound to a
+ * DIFFERENT machine) owns a host attachment instead, under the stable project × endpoint id.
  *
  * Every consumer of that connection — spawn (`resolveSshRemote`), reconnect (`SshReconnector`),
  * upload — must make the same choice, or a node resolves a master that was opened for someone
  * else. Hence one function rather than the rule written out at each site.
+ *
+ * ## Why the project's binding wins on a HOST match, user and port included
+ *
+ * A node's `ssh` is a SNAPSHOT persisted into the canvas, and an SSH project's canvas lives in
+ * `<remoteCwd>/.nodeterm/project.json` ON THE HOST — shared with everyone who opens that folder.
+ * So the `user` (and port) on a node is whoever created it, not whoever is reading it: alice's
+ * nodes say `alice@box`, and when bob opens the same project as `bob@box` every one of them would
+ * ask for a second master dialing `alice@box` — which fails for bob, or worse sits on an askpass
+ * prompt. The project's binding is the authority on how THIS user reaches that machine, so a node
+ * naming the same host is served by it.
+ *
+ * The cost is a deliberate one: inside an SSH project you cannot pin a node to a second ACCOUNT on
+ * the same host. A different machine still gets its own attachment, which is the case this is for.
  */
 export function sshConnectionIdForProject(
   projectId: string,
   conn: SshConnection,
   projectServer?: SshConnection
 ): string {
-  const sameEndpoint =
-    projectServer?.host === conn.host &&
-    projectServer.user === conn.user &&
-    (projectServer.port ?? 22) === (conn.port ?? 22)
-  return sameEndpoint ? projectId : sshAttachmentId(projectId, conn)
+  return projectServer?.host === conn.host ? projectId : sshAttachmentId(projectId, conn)
 }
 
 /**


### PR DESCRIPTION
Extracts the **SSH host attachment** portion of #112 (by @proteus-dev / Corvin) onto current `main`, hand-applied file by file rather than cherry-picked — that branch is based on `af8ff3be` and picking from it silently reverts everything merged since.

**Zero Codex content.** `git diff origin/main | grep -ic codex` → **0**, context lines included. No `installRemoteCodexRuntime`, no relay/app-server deployment, no `nodeterm-codex` / `codex-relay`, and **no `ssh-project.ts` changes at all** — an SSH connect on this branch does exactly what an SSH connect on `main` does today, plus nothing.

## What it does

Today a remote terminal only works inside an SSH **project**: `resolveSshRemote` looks the ControlMaster up under `activeProjectId`, so a node whose machine is not its project's finds nothing, waits `SSH_REMOTE_WAIT_MS`, and lands on the offline overlay.

That state is already reachable on `main`. The account-login retry (`nodeterm:add-account-login`) spawns a node carrying another host's `ssh` into whatever tab happens to be active, and says so in its own comment: *"Retry can fire from any project, so the active one may be local or a different host."* It resolves the wrong project's connection every time.

This gives such a node a connection of its own. A remote node whose endpoint is not its project's now runs over a **host attachment**: a ControlMaster scoped by project × endpoint (`sshAttachmentId`), opened alongside the project's by Canvas's active-project effect, reconnected on its own `SshReconnector` loop, and torn down with the canvas.

`sshConnectionIdForProject(projectId, conn, projectServer)` is the single place that decides project-id vs attachment. It has to be one function: spawn, the exit-255 drop report, reconnect, and drag-drop upload all key off that id, and if any of them disagrees a node resolves a master opened for someone else.

It matches on **host**, not on the full endpoint. A node's `ssh` is a snapshot persisted into the canvas, and an SSH project's `project.json` lives in `<remoteCwd>/.nodeterm/` **on the host** — shared with everyone who opens that folder. So a node's `user` is whoever *created* it: matching user too meant alice's nodes sent bob's entire canvas off to open a second master dialing `alice@box`, which fails for bob or sits on an askpass prompt. The project's own binding is the authority on how *this* user reaches that machine. The deliberate cost: inside an SSH project you cannot pin a node to a second *account* on the same host. A different machine still gets its own attachment, which is the case this is for.

**An SSH project whose nodes name its own host takes the project-id branch unchanged — for an ordinary SSH canvas this is a no-op.** The behaviour that changes is the one that was broken: a remote node in a local project (or on a second machine) now gets a connection instead of timing out.

Settings → Remote (SSH) also grows the two affordances that make a machine usable *before* any node points at it:
- **Default folder** per saved machine — a starting point for browsing, not an inherited cwd. The "New remote" folder browser opens there instead of `~` every time. `listDir` cannot report a missing directory (it echoes the path back with `dirs: []` whether the folder is gone or merely empty), so existence is checked against the parent's listing before landing — which keeps a stale default from dead-ending the dialog *and* keeps a genuinely empty default working.
- **Test connection**, which opens and closes a master under its own `ssh-settings-test-<id>` scope — never a project's, which would report success without testing anything and then drop that project's terminals on the way out. It always disconnects, including on failure: a half-open master would be silently reused by the next test.

## Composition with main's remote discipline

CLAUDE.md's rule — *a remote node is NEVER spawned locally* — is the thing most at risk here, so:

- The routing facts of an attachment are recorded **before** the dial and survive its failure — the reconnect coordinator and the respawn's scope → canvas mapping both run precisely when there is no live connection to read them off. This also beats an ordering trap: main emits `status:'connected'` from inside `connectOnce`, over the same IPC pipe, so it lands *before* the invoke reply that records the connection.
- A node created at runtime dials for itself from `resolveSshRemote`; Canvas's project-load pass is a pre-warm. One `connectHostAttachment` with an in-flight map collapses the pre-warm and every node on a machine into a single connect. It **always dials** — a cached `controlPath` is not treated as "already connected", because nothing in the renderer clears that path on a drop, and only main can tell a live master from a dead one (its reuse branch costs one mux'd `-O check`, which doubles as the ControlPersist keepalive).
- `requireRemote` is **untouched** and still the backstop. An attachment that fails to connect refuses the spawn exactly like a project that fails to connect: the near-side guard in `TerminalNode` prints `[not connected — …nothing was started locally]`, and core refuses again. There is no new path into the local-tmux branch.
- The branch's version predates none of this — it never had a spawn path at all (see below), so the wiring here is written against main's current `resolveSshRemote` / `requireRemote` / `SshReconnector` shape rather than ported.
- `SshReconnector` gains nothing structural: an attachment scope reconnects through the same `connect`/`respawn` deps, reading its endpoint back out of `useSshConn` (an attachment has no project row to read it from) and mapping scope → owning canvas for the respawn.
- The attachment deliberately does **not** arm remote git routing (`api.git.setActiveRemote`). The Source Control panel is about the project's own cwd; an attached node must not repoint it at another host.

## On separability

The examiner's read was right, with one correction worth recording: on `origin/integration/codex-112` the *only* production consumer of `sshAttachmentId` is `switchCodexAccount`, and `sshConnectionIdForProject` is **not called anywhere** — it ships as a helper plus a test. So the branch's helpers are Codex-free but also unwired.

Shipping them dead would have been a non-feature, so this PR wires the routing itself (`resolveSshRemote`, the drop report, uploads, the Canvas connect + reconnect + teardown). That is the only place this goes beyond the four files the extraction brief named, and none of it touches `ssh-project.ts` or main-process code.

## Three surfaces

- **Desktop (Electron)** — where the feature lives and where it is reachable.
- **Server Edition** — the renderer bundle is shared, so the code ships; the SSH stack behaves as it does today (the server's own SSH support is unchanged, and nothing here is main-process). No new server surface.
- **Mobile (iOS)** — **not covered.** The iOS client has no canvas-side SSH scope concept and the attachment is a renderer-side routing fact; an attached node on a phone-visible canvas will behave as it does on main. A follow-up on the iOS side, not a blocker for this.

## Files

| File | What |
|---|---|
| `src/shared/ssh.ts` | `SshServer.remoteCwd`, `sshAttachmentId`, `sshConnectionIdForProject` |
| `src/renderer/lib/sshAttachments.ts` | *(new)* `hostAttachmentsFor` — which attachments a canvas needs, grouped per machine — and `connectHostAttachment`, the one register-then-dial entry point |
| `src/renderer/state/sshConn.ts` | attachments get their own map (`registerAttachment` / `getAttachment` / `ownerProjectId` / `attachmentScopesOf` / `clearAttachment`), written before the dial so they outlive its failure |
| `src/renderer/nodes/TerminalNode.tsx` | `sshConnectionScope`; `resolveSshRemote` dials the attachment on demand; the drop report, the offline retry and drag-drop upload all use the scope |
| `src/renderer/components/kanban/ModalTerminal.tsx` | same scope for a card's spawn and uploads |
| `src/renderer/canvas/Canvas.tsx` | connect attachments on project load; scope-aware reconnect/respawn; tear attachments down with the canvas |
| `src/renderer/components/settings/sections/SshSection.tsx` | default working directory + Test connection |
| `src/renderer/components/SshProjectDialog.tsx` | "New remote" browse starts at the machine's default folder, with a real existence check |

## Tests

`+79` assertions across five files (`ssh.test.ts`, `sshAttachments.test.ts`, `sshConn.test.ts`, `SshSection.test.tsx`, `SshProjectDialog.test.tsx` — the component ones following the existing `CustomAgentsSection` / `GitHubIssuesSection` jsdom pattern). The branch's 82-line shared-helper test is ported and extended.

The wiring is tested at `connectHostAttachment`, which is where the ordering actually lives:

- `records the endpoint BEFORE dialing, not after it succeeds` — asserts from *inside* the fake connect, so it pins the ordering rather than the end state (a pre-populated store structurally cannot catch this).
- `keeps the endpoint on record when the FIRST connect fails`
- `a failed dial does not poison the scope against the retry`
- `collapses concurrent callers into ONE dial`
- `still dials when a controlPath is already cached — the reconnect path depends on it`
- `a dial that lands after the canvas was deleted is handed back, not recorded`
- `serves a node naming the same HOST from the project, whatever user it was saved with` — the shared-`project.json` case
- `a node with no host is never served from the project (unroutable fails safe)`
- `an EMPTY default folder is still the right place to land` / `falls back to ~ when the configured default is gone`

Mutation-checked, not just green. Reverting each fix in turn — registering after the dial, dropping the in-flight map, matching user as well as host, restoring the dead `.catch()` fallback, reinstating the `controlPath` short-circuit, dropping the read-after-clear guard, dropping the hostless guard — fails exactly the tests named above, and nothing else.

**Untested, honestly:** the Canvas call sites themselves (the project-load pre-warm loop, the reconnector's `connect`/`respawn` deps, the delete-path teardown). They are inline closures inside a 8k-line component with no seam short of rendering React Flow under Electron; the logic they carry is in the tested helpers, but their *wiring* is verified only by reading. Flagging it rather than writing a test that mocks the whole component and proves nothing.

- `npm run typecheck` — clean
- `npx vitest run src/shared src/renderer` — 199/200 files, 2759 passed
- `npx vitest run` — 5303 passed, 4 failed

The 4 failures are environmental (a symlinked `node_modules` in the extraction clone): 3 × `node-pty-patch`, plus `webgl-addon-pair`, which was confirmed failing identically on a clean `origin/main` worktree against the same `node_modules`.

## Not verified

No device run. Wanted before merge: a remote node in a **local** canvas connecting and surviving a sleep/wake drop; the same node against a host that is **down at first load**, then reachable (the recovery path the second commit is entirely about); a runtime-created remote node (the account-login retry) in a local tab; Test connection against a reachable and an unreachable host; and that an ordinary SSH project is untouched (one master, one reconnect loop, no attachment registered).

## Review rounds

**Round 1** (`96acaeb`) — three blockers, one high, one medium. All were one bug wearing several faces: the attachment's routing facts were written from the connect *result*, so a failed first connect left the scope permanently unreachable, and main's `connected` event (emitted from inside `connectOnce`, ahead of the invoke reply) beat the record into place. Facts now live in their own map written before the dial. Plus: runtime-created nodes dial for themselves; host-only endpoint matching for shared `project.json`; a real existence check in the folder browser; corrected copy.

**Round 2** (`9c7894b`) — one regression introduced by round 1's fix, caught with a reproduction test. `connectHostAttachment` short-circuited on a cached `controlPath`, and the reconnector's connect dep routed through it — but nothing clears that path on a drop, so after one success the coordinator could never dial again and a sleep/wake respawn would land on a dead socket and fall back to direct connections per node. The short-circuit is removed rather than flagged: main already coalesces per scope and its `-O check` reuse is both cheap and the ControlPersist keepalive, so a redundant dial costs nothing and a skipped one is the failure. Two nits fixed in the same commit (read-after-clear on a deleted canvas; `undefined === undefined` in the host comparison).

The pure layers review confirmed clean (one reconnector not two, `requireRemote` intact, quoting, serialization, `ModalTerminal` lifetime, test-connection cleanup) are unchanged throughout.