### PR TITLE
fix(terminal): DOM and WebGL renderers agree on the cell width

### DIFF
--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { SearchAddon } from '@xterm/addon-search'
+import { quantizeCharSize } from '../../terminal/char-size-quantize'
 import { reportsOwnCopy } from '@shared/agents/config'
 import type { AgentId } from '@shared/agents/config'
 import { readsClaudeTranscript } from '../../lib/transcriptGates'
@@ -163,6 +164,9 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
     fitRef.current = fit
     transportRef.current = transport
     term.open(hostRef.current!)
+    // Renderer-parity with the canvas terminals (see char-size-quantize): the modal co-views
+    // the same session, so its column math must match what the canvas draws.
+    quantizeCharSize(term)
     fit.fit()
 
     let sessionId: string | null = null

--- a/src/renderer/components/settings/TerminalPreview.tsx
+++ b/src/renderer/components/settings/TerminalPreview.tsx
@@ -4,6 +4,7 @@ import { useSettings } from '../../state/settings'
 import { applyLiveOptions, xtermOptionsFromSettings } from '../../terminal/terminal-config'
 import { useXtermVisualSettings } from '../../terminal/useXtermVisualSettings'
 import { activateUnicode11 } from '../../terminal/unicode-width'
+import { quantizeCharSize } from '../../terminal/char-size-quantize'
 
 /** Fixed grid — the preview is a sample, not a fitted terminal, so there is no FitAddon and no
  *  ResizeObserver to keep in sync. Wide enough for the sample lines below without wrapping. */
@@ -64,6 +65,8 @@ export function TerminalPreview(): React.JSX.Element {
     activateUnicode11(term)
     termRef.current = term
     term.open(hostRef.current!)
+    // Same cell width as the real terminals, so the preview shows the layout users get.
+    quantizeCharSize(term)
     term.write(SAMPLE)
     return () => {
       termRef.current = null

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -59,6 +59,7 @@ import {
 } from '../terminal/terminal-config'
 import { useXtermVisualSettings } from '../terminal/useXtermVisualSettings'
 import { loseWebglContexts, registerWebglClient, type WebglClientHandle } from '../terminal/webgl-budget'
+import { quantizeCharSize } from '../terminal/char-size-quantize'
 import {
   PARK_MAX,
   armParkExpiry,
@@ -2207,6 +2208,9 @@ export function TerminalNode({
       term.loadAddon(fit)
       term.loadAddon(searchAddon)
       term.open(container)
+      // Renderer-parity: quantize the char measurement to the device-pixel grid, so a budget
+      // grant/release swaps renderers without the text visibly reflowing (see the helper).
+      quantizeCharSize(term)
       applyFit()
       patchTerminalScale(term, getZoom)
       // OSC 52 clipboard write: route the decoded text to the local clipboard. This is the PRIMARY

--- a/src/renderer/terminal/char-size-quantize.test.ts
+++ b/src/renderer/terminal/char-size-quantize.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+import { quantizeCharSize } from './char-size-quantize'
+
+/**
+ * The wrap targets xterm's CharSizeService internals, so the harness is a structural fake of
+ * exactly the fields the helper reaches for — the same seam the guarded-internals style
+ * (`restoreDomRenderer`) tests against. What matters behaviourally:
+ *  - measurements land on the device-pixel grid (this is the whole renderer-parity fix);
+ *  - the service is re-measured once at install so the live renderer picks the quantized width;
+ *  - a second install is a no-op (mount/adopt call it repeatedly);
+ *  - any missing internal fails open with `false` and leaves the strategy untouched.
+ */
+function fakeTerm(rawWidth: number, dpr?: number) {
+  const calls = { strategyMeasures: 0, serviceMeasures: 0 }
+  const strategy = {
+    measure() {
+      calls.strategyMeasures++
+      return { width: rawWidth, height: 17 }
+    }
+  }
+  const svc = {
+    width: 0,
+    height: 0,
+    _measureStrategy: strategy,
+    measure() {
+      calls.serviceMeasures++
+      const r = this._measureStrategy.measure()
+      this.width = r.width
+      this.height = r.height
+    }
+  }
+  const term = {
+    _core: { _charSizeService: svc, _coreBrowserService: dpr === undefined ? undefined : { dpr } }
+  } as unknown as Terminal
+  return { term, svc, strategy, calls }
+}
+
+describe('quantizeCharSize', () => {
+  it('quantizes the measured width to the device-pixel grid (the WebGL floor loses nothing)', () => {
+    const { term, svc } = fakeTerm(8.43, 2)
+    expect(quantizeCharSize(term)).toBe(true)
+    // floor(8.43 × 2) / 2 = 8.0 — exactly what the WebGL renderer's floor lands on.
+    expect(svc.width).toBe(8)
+    expect(svc.height).toBe(17) // height untouched
+  })
+
+  it('re-measures the service once at install, so a live renderer sees the quantized width', () => {
+    const { term, calls } = fakeTerm(8.43, 2)
+    quantizeCharSize(term)
+    expect(calls.serviceMeasures).toBe(1)
+  })
+
+  it('is idempotent — a second install neither re-wraps nor re-measures', () => {
+    const { term, svc, calls } = fakeTerm(8.43, 2)
+    quantizeCharSize(term)
+    expect(quantizeCharSize(term)).toBe(true)
+    expect(calls.serviceMeasures).toBe(1)
+    svc.measure()
+    // Still quantized exactly once (a double wrap would floor an already-floored value — same
+    // number, but the measure-call count would betray the second wrapper).
+    expect(svc.width).toBe(8)
+    expect(calls.strategyMeasures).toBe(2)
+  })
+
+  it('falls back to the window dpr when the core browser service is absent', () => {
+    const { term, svc } = fakeTerm(8.43, undefined)
+    quantizeCharSize(term, { devicePixelRatio: 2 })
+    expect(svc.width).toBe(8)
+  })
+
+  it('reads the dpr live at each measure, not once at install', () => {
+    const dprBox = { dpr: 2 }
+    const { term, svc } = fakeTerm(8.43)
+    ;(term as unknown as { _core: { _coreBrowserService: { dpr: number } } })._core._coreBrowserService = dprBox
+    quantizeCharSize(term)
+    expect(svc.width).toBe(8) // floor(16.86)/2
+    dprBox.dpr = 1
+    svc.measure()
+    expect(svc.width).toBe(8) // floor(8.43)/1 — re-quantized on the new grid
+  })
+
+  it('keeps the raw measurement when quantizing would zero the width', () => {
+    const { term, svc } = fakeTerm(0.4, 1)
+    quantizeCharSize(term)
+    expect(svc.width).toBe(0.4)
+  })
+
+  it('fails open (returns false, touches nothing) when the internals are missing', () => {
+    expect(quantizeCharSize({} as Terminal)).toBe(false)
+    expect(
+      quantizeCharSize({ _core: { _charSizeService: {} } } as unknown as Terminal)
+    ).toBe(false)
+  })
+})

--- a/src/renderer/terminal/char-size-quantize.ts
+++ b/src/renderer/terminal/char-size-quantize.ts
@@ -1,0 +1,84 @@
+import type { Terminal } from '@xterm/xterm'
+
+/**
+ * Make the DOM and WebGL renderers agree on the cell width, so a renderer swap (budget grant or
+ * release) is horizontally pixel-stable instead of visibly reflowing the text.
+ *
+ * The disagreement is a rounding split inside xterm: the WebGL renderer FLOORS the measured char
+ * width to whole device pixels (`Math.floor(charWidth × dpr)` — its glyph atlas needs an integer
+ * grid), while the DOM renderer uses the RAW fractional measurement and pins each row's advance
+ * to it via `letter-spacing`. A char measured at 8.43px therefore lays out on an 8.0px cell under
+ * WebGL and an 8.43px cell under DOM — ~30px of drift across 80 columns, which is what a swap
+ * flashes as "the text got wider".
+ *
+ * The fix quantizes at the SOURCE both renderers read: `CharSizeService`'s measure strategy is
+ * wrapped so every measurement lands on the device-pixel grid (`floor(width × dpr) / dpr`).
+ * The WebGL floor then loses nothing (it floors an already-integer product) and the DOM renderer
+ * lays out on the identical cell — and `fit`/`proposeDimensions` read the same service, so the
+ * column math stays consistent with what either renderer draws. Height is left alone: both
+ * renderers already ceil it through the same formula.
+ *
+ * Costs and edges, called out because they are deliberate:
+ *  - A cell can narrow by at most 1/dpr px (≤0.5px on retina) versus the unquantized DOM cell.
+ *  - The dpr is read at MEASURE time (live, via the core's browser service with a window
+ *    fallback). Moving the window to a display with a different dpr re-quantizes on the next
+ *    measure (font/size changes, refresh); until one runs, the widths sit on the old grid —
+ *    exactly the pre-existing xterm behaviour for its own dpr-derived dimensions.
+ *  - This pokes xterm internals (`_core._charSizeService._measureStrategy`), in the same
+ *    guarded, fail-open style as TerminalNode's `restoreDomRenderer`: if any field is missing
+ *    on a future xterm, the wrap silently does not install and both renderers keep xterm's
+ *    stock behaviour — nothing regresses but the swap parity.
+ *
+ * Idempotent per terminal (a marker on the strategy), safe to call on every mount/adopt. Returns
+ * whether the quantizing wrap is installed.
+ */
+interface MeasureResult {
+  width: number
+  height: number
+}
+interface MeasureStrategyLike {
+  measure(): Readonly<MeasureResult>
+  __ntQuantized?: boolean
+}
+interface CharSizeServiceLike {
+  measure(): void
+  _measureStrategy?: MeasureStrategyLike
+}
+interface CoreLike {
+  _charSizeService?: CharSizeServiceLike
+  _coreBrowserService?: { dpr?: number }
+}
+
+export function quantizeCharSize(
+  term: Terminal,
+  win: { devicePixelRatio?: number } | undefined = typeof window === 'undefined' ? undefined : window
+): boolean {
+  try {
+    const core = (term as unknown as { _core?: CoreLike })._core
+    const svc = core?._charSizeService
+    const strategy = svc?._measureStrategy
+    if (!svc || typeof svc.measure !== 'function' || !strategy || typeof strategy.measure !== 'function') {
+      return false
+    }
+    if (strategy.__ntQuantized) return true
+    const original = strategy.measure.bind(strategy)
+    strategy.measure = () => {
+      const result = original()
+      const dpr = core?._coreBrowserService?.dpr || win?.devicePixelRatio || 1
+      if (!result || !Number.isFinite(result.width) || !Number.isFinite(dpr) || dpr <= 0) return result
+      const quantized = Math.floor(result.width * dpr) / dpr
+      // A sub-device-pixel font would quantize to 0 and invalidate the whole char size — keep
+      // the raw measurement there (the renderers disagree again, but they draw).
+      if (quantized <= 0) return result
+      return { width: quantized, height: result.height }
+    }
+    strategy.__ntQuantized = true
+    // Re-measure NOW: `term.open()` already measured unquantized, and the renderer built from
+    // that measurement is live. The service change-gates internally, so this fires its
+    // char-size-change event (renderers recompute dimensions) only when the width actually moves.
+    svc.measure()
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## The reflow

Every renderer swap (budget grant/release) visibly reflowed the text: xterm's WebGL renderer **floors** the measured char width to whole device pixels (`Math.floor(charWidth × dpr)` — the glyph atlas needs an integer grid), while the DOM renderer lays rows out on the **raw fractional** measurement via its letter-spacing correction. Measured on a mixed canvas in the headless rig: WebGL 7.0000px/cell vs DOM 7.7864px/cell — **0.786px/cell, ~50px across 64 columns**. That is the "text gets wider on DOM" flash at every swap.

## The fix

`quantizeCharSize` (new, `src/renderer/terminal/char-size-quantize.ts`) wraps the terminal's `CharSizeService` measure strategy so every measurement lands on the device-pixel grid: `floor(width × dpr) / dpr`. The WebGL floor then loses nothing and the DOM renderer lays out on the identical cell. `fit`/`proposeDimensions` read the same service, so the column math stays consistent with what either renderer draws. Height is untouched (both renderers already ceil it identically).

Guarded-internals poke in the `restoreDomRenderer` house style: if a future xterm renames a field, the wrap silently does not install and stock behaviour returns — nothing regresses but the swap parity. Wired at the three mount paths (TerminalNode, ModalTerminal, TerminalPreview); idempotent per terminal; dpr read live at each measure.

## Measured result

| | webgl cell | dom cell | delta |
| --- | --- | --- | --- |
| before | 7.0000px | 7.7864px | **0.786px/cell** |
| after | 7.0000px | 6.9894px | 0.0106px/cell (Range measurement noise) |

Cells quantize slightly narrower (≤1/dpr px), so the same node fits 72 columns where it fit 64 — fit and both renderers agreeing on the number is the point.

## Verification

typecheck + full suite green (5314 passed, incl. 7 new unit tests: quantization, install-time re-measure, idempotence, live dpr re-quantize, zero-width guard, fail-open on missing internals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)