### PR TITLE
fix(terminal): DOM rows opt out of the app's grayscale font smoothing

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1869,6 +1869,19 @@ body,
   height: 100%;
 }
 
+/* Renderer parity, macOS: the app sets `-webkit-font-smoothing: antialiased` on :root (grayscale
+   AA — the right call for the chrome's UI font), and the DOM renderer's rows INHERIT it, while the
+   WebGL renderer never sees it: its glyphs are rasterized into a canvas atlas, which uses the
+   platform default. So the same text renders thinner/paler the moment a terminal falls back to the
+   DOM renderer, and a budget swap flashes that difference. Terminal rows opt back out to the
+   platform default so both renderers lay down comparable ink. Scoped to the rows only — the app
+   chrome keeps its grayscale AA — and inert on Linux/Windows Chromium, which ignores this property
+   (measured: DOM ink coverage unchanged there), so it is a macOS-targeted correction by
+   construction. */
+.xterm-rows {
+  -webkit-font-smoothing: auto;
+}
+
 /* Shared glyph renderer (experimental, `glyphgrid`): a glyph-attached terminal becomes a
    transparent WINDOW onto the one GPU canvas, which sits between the React Flow background and the
    nodes (z-index 0 against the renderer's 4 — it cannot simply be raised above them, or a


### PR DESCRIPTION
## The report

After #183 lined the cell widths up, the remaining swap tell is **weight**: the DOM renderer's text reads paler than the WebGL renderer's on macOS.

## What it is not

Not a palette problem. Measured on identical content in both modes (same node, same text, renderer flipped through the setting), peak glyph luminance matches: **webgl 226 vs dom 229-231**. Theme colours and the contrast options reach both renderers correctly.

## What it is

Antialiasing. The app sets `-webkit-font-smoothing: antialiased` on `:root` — the right call for the chrome's UI font — and the DOM renderer's rows **inherit** it, which on macOS means grayscale AA with thinner stems. The WebGL renderer never sees the property: its glyphs are rasterized into a canvas atlas that uses the platform default. Same text, two AA regimes, and the difference flashes at every budget swap. The ink numbers show the two renderers really do lay down different amounts of it (Linux rig: dom 7.8-8.0% coverage / 162-165 mean ink vs webgl 5.1-5.2% / 146-150).

## The change

`.xterm-rows { -webkit-font-smoothing: auto; }` — terminal rows return to the platform default; the app chrome keeps its grayscale AA.

## Honest scope, and the gate

This targets macOS, and the verification rig is Linux, where Chromium ignores the property. That cuts both ways:

- it **cannot be confirmed here** — a Mac device check is the gate: switch Terminal rendering to *Off*, compare the weight against *GPU per terminal*, and watch for colour fringing inside React Flow's transformed layer;
- the same run **proves it is inert elsewhere**: DOM ink coverage and mean ink are bit-identical before and after on Linux (7.83%/165.3 and 8.04%/162.2 on the two sampled nodes).

If fringing shows up on the device, this rule is a one-line revert. `styles.theme.test.ts` green (14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)