### PR TITLE
fix(usage): the quota bar fills by the used/remaining mode

### DIFF
--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -5,7 +5,14 @@ import { useSettings } from '../state/settings'
 import { useProjects } from '../state/projects'
 import { useSshConn } from '../state/sshConn'
 import { scopeFromKey, scopeUsage, usageScopeKey } from '../lib/usageScope'
-import { formatResetCountdown, formatTimeAgo, percentNumber, percentText, severityColor } from '../lib/usageFormat'
+import {
+  barFillPercent,
+  formatResetCountdown,
+  formatTimeAgo,
+  percentNumber,
+  percentText,
+  severityColor
+} from '../lib/usageFormat'
 import {
   enabledProviders,
   hasAnyUsage,
@@ -22,11 +29,14 @@ import { systemAccountDisplay } from '../state/workspace'
 const USAGE_HOVER_CLOSE_MS = 220
 
 /**
- * A single limit row in the popover: bar, "% left", reset countdown. Bars render REMAINING
- * quota (the limit carries percent USED), which is the convention this pill has always used.
+ * A single limit row in the popover: bar, "% left"/"% used", reset countdown. The bar's fill
+ * honours the display mode (`barFillPercent`) so it tracks the same quantity as the number
+ * beside it; its color stays keyed to the TRUE remaining percentage via `severityColor`, so
+ * severity red/yellow/green never flips meaning when the mode does.
  */
 function LimitRow({ limit, mode }: { limit: UsageLimit; mode: 'used' | 'remaining' }) {
   const left = 100 - limit.usedPercent
+  const fill = barFillPercent(limit.usedPercent, mode)
   return (
     <div className="usage-row">
       <div className="usage-row__title">
@@ -37,7 +47,7 @@ function LimitRow({ limit, mode }: { limit: UsageLimit; mode: 'used' | 'remainin
       <div className="usage-bar">
         <div
           className="usage-bar__fill"
-          style={{ width: `${left}%`, background: severityColor(limit.severity, left) }}
+          style={{ width: `${fill}%`, background: severityColor(limit.severity, left) }}
         />
       </div>
       <div className="usage-row__meta">
@@ -328,7 +338,7 @@ export function UsageIndicator({ overBoard = false }: { overBoard?: boolean }): 
             <span
               className="usage-pill__minibar-fill"
               style={{
-                width: `${100 - primary.usedPercent}%`,
+                width: `${barFillPercent(primary.usedPercent, percentMode)}%`,
                 background: severityColor(primary.severity, 100 - primary.usedPercent)
               }}
             />

--- a/src/renderer/lib/usageFormat.test.ts
+++ b/src/renderer/lib/usageFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatModelLabel } from './usageFormat'
+import { barFillPercent, formatModelLabel, percentNumber, severityColor } from './usageFormat'
 
 describe('formatModelLabel', () => {
   it('formats family + version ids', () => {
@@ -28,5 +28,35 @@ describe('formatModelLabel', () => {
   it('passes through unknown ids and keeps null', () => {
     expect(formatModelLabel('some-custom-model')).toBe('some-custom-model')
     expect(formatModelLabel(null)).toBeNull()
+  })
+})
+
+describe('barFillPercent', () => {
+  it('fills with what is used in "used" mode', () => {
+    expect(barFillPercent(92, 'used')).toBe(92)
+    expect(barFillPercent(8, 'used')).toBe(8)
+  })
+
+  it('fills with what is left in "remaining" mode', () => {
+    expect(barFillPercent(92, 'remaining')).toBe(8)
+    expect(barFillPercent(8, 'remaining')).toBe(92)
+  })
+
+  // The bar and the number beside it must describe the SAME quantity — a fill that disagreed
+  // with its own label ("92% used" over a near-empty bar) is the bug this helper exists to fix.
+  it('always agrees with the number rendered next to it', () => {
+    for (const used of [0, 8, 50, 92, 100]) {
+      for (const mode of ['used', 'remaining'] as const) {
+        expect(Math.round(barFillPercent(used, mode))).toBe(percentNumber(used, mode))
+      }
+    }
+  })
+
+  // Color is keyed to the TRUE remaining percentage, never to the fill, so severity keeps its
+  // meaning when the mode flips: 92% used is red in both modes even though the fill inverts.
+  it('does not carry the color — severity stays keyed to remaining quota', () => {
+    const left = 100 - 92
+    expect(severityColor(null, left)).toBe('#ff453a')
+    expect(barFillPercent(92, 'used')).not.toBe(barFillPercent(92, 'remaining'))
   })
 })

--- a/src/renderer/lib/usageFormat.ts
+++ b/src/renderer/lib/usageFormat.ts
@@ -71,11 +71,7 @@ export function severityColor(severity: string | null, leftPercent: number): str
   }
 }
 
-/**
- * The percentage a limit renders as, honouring the used/remaining display setting. Only the
- * NUMBER flips — the bar always fills with what is left (a fuel gauge), because inverting the
- * fill per mode would also invert what the severity colours appear to mean.
- */
+/** The percentage a limit renders as, honouring the used/remaining display setting. */
 export function percentText(usedPercent: number, mode: 'used' | 'remaining'): string {
   return mode === 'used'
     ? `${Math.round(usedPercent)}% used`
@@ -85,4 +81,14 @@ export function percentText(usedPercent: number, mode: 'used' | 'remaining'): st
 /** Compact form for the pill: the bare number, no suffix (the segment label follows it). */
 export function percentNumber(usedPercent: number, mode: 'used' | 'remaining'): number {
   return Math.round(mode === 'used' ? usedPercent : 100 - usedPercent)
+}
+
+/**
+ * Bar fill, honouring the used/remaining display setting — the fill tracks the same quantity as
+ * the adjacent number, so "92% used" shows a nearly-full bar instead of a barely-visible sliver.
+ * Color is a separate call (`severityColor`/`barColor`) keyed to the true remaining percentage,
+ * never to this value, so severity red/yellow/green doesn't flip meaning with the mode.
+ */
+export function barFillPercent(usedPercent: number, mode: 'used' | 'remaining'): number {
+  return mode === 'used' ? usedPercent : 100 - usedPercent
 }


### PR DESCRIPTION
## The bug

Settings → Usage lets a provider limit read as **"% used"** or **"% left"**, but the toggle only ever flipped the number. Both bars — the popover's `LimitRow` and the compact pill's minibar — were hardcoded to fill with what was left.

So at 92% used the UI showed **"92% used" beside a nearly-empty sliver**: a bar contradicting its own label. The severity red was already correct there, just too small to notice.

## The fix

One pure helper, `barFillPercent(usedPercent, mode)`, now backs both fills.

```
92% used, mode 'used'       ▓▓▓▓▓▓▓▓▓░   red
92% used, mode 'remaining'  ▓░░░░░░░░░   red
```

## Blast radius

`usagePercentMode` defaults to `remaining`, so nothing should move for anyone until the setting is switched, making the default rendering unchanged.

`ContextMeter`'s bars are a different feature (per-node context window, not subscription quota) and are deliberately untouched.

**Surfaces:** pure renderer, so Desktop and Server Edition both get it with no bridge work. The mobile companion renders its own usage UI and is unaffected — no protocol change here.

## Verified

- `npm run typecheck` — clean, both projects.
- `npx vitest run src/renderer` — **2026 tests pass**. New unit tests cover `barFillPercent`, including the invariant that the fill always agrees with the number `percentNumber` renders beside it, and that colour stays keyed to remaining quota.