### PR TITLE
fix: keep the bridge-handle hover ring from shifting the dot

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1117,7 +1117,10 @@ body,
 }
 
 /* Bridge link handles (Claude nodes): dots on the header row, on top of the node so they're
-   never buried under the terminal body. Subtle until you hover the node, then prominent. */
+   never buried under the terminal body. Subtle until you hover the node, then prominent.
+   Never set `transform` on a React Flow handle: the side classes (.react-flow__handle-left/right/
+   top/bottom) POSITION the dot with translate(±50%, ±50%), so any transform override replaces
+   that and shifts the dot away from the cursor mid-hover. Hover feedback is a ring, not a scale. */
 .react-flow__handle.bridge-handle {
   width: 13px;
   height: 13px;
@@ -1126,15 +1129,17 @@ body,
   box-shadow: 0 1px 4px rgba(0, 0, 0, calc(0.5 * var(--shadow-k)));
   opacity: 0.4;
   z-index: 20;
-  transition: opacity 0.12s ease, transform 0.12s ease;
+  transition: opacity 0.12s ease, box-shadow 0.12s ease;
 }
 .react-flow__node:hover .react-flow__handle.bridge-handle,
 .react-flow__node.selected .react-flow__handle.bridge-handle {
   opacity: 1;
 }
 .react-flow__handle.bridge-handle:hover {
-  transform: scale(1.6);
   opacity: 1;
+  box-shadow:
+    0 1px 4px rgba(0, 0, 0, calc(0.5 * var(--shadow-k))),
+    0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 /* Hover explanation for the bridge handles (CSS tooltip via the data-tip attribute). */

--- a/src/renderer/styles.handles.test.ts
+++ b/src/renderer/styles.handles.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * React Flow positions every handle through its side classes
+ * (`.react-flow__handle-left/right/top/bottom`), each of which centers the dot on the node edge
+ * with `transform: translate(±50%, ±50%)`. Any of OUR handle rules that declares `transform`
+ * therefore REPLACES that translate — which is how the bridge handle's hover "scale" shifted the
+ * dot half its size away from the cursor (and could push it out from under the pointer,
+ * flickering the hover state). Hover feedback on a handle is a box-shadow ring, never a
+ * transform. A rule that genuinely needs one opts out with a `handle-transform-exempt:` comment
+ * on the line above — restating the full translate chain is then that rule's own job.
+ */
+
+const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
+
+describe('React Flow handle rules never declare transform', () => {
+  it('finds no transform inside a handle-targeting rule block', () => {
+    const offenders: string[] = []
+    const lines = CSS.split('\n')
+    let selector = ''
+    let inHandleBlock = false
+    lines.forEach((line, i) => {
+      if (line.includes('{') && !line.trim().startsWith('@')) {
+        selector = line.split('{')[0].trim() || selector
+        inHandleBlock = /(^|[.\s,])(react-flow__handle|bridge-handle)/.test(selector)
+      }
+      if (line.includes('}') && !line.includes('{')) {
+        inHandleBlock = false
+        return
+      }
+      if (!inHandleBlock) return
+      if (!/^\s*transform\s*:/.test(line)) return
+      if (lines[i - 1]?.includes('handle-transform-exempt:')) return
+      offenders.push(`${selector} (line ${i + 1}): ${line.trim()}`)
+    })
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION

<img width="782" height="881" alt="image-1786693818227" src="https://github.com/user-attachments/assets/2f1cc8e1-04dd-4745-a4a6-b676048fa485" />


## The bug

Hovering the link/bridge connection dot on a terminal or sticky node made the dot jump away from the cursor.

React Flow positions every handle through its side classes — `.react-flow__handle-left/right/top/bottom` center the dot on the node edge with `transform: translate(±50%, ±50%)`. The hover rule set `transform: scale(1.6)`, which **replaces** that translate, so on hover the dot shifted roughly half its size diagonally — away from the pointer, sometimes right out from under it (flickering the hover state):

```css
.react-flow__handle.bridge-handle:hover {
  transform: scale(1.6);
  opacity: 1;
}
```

## The fix

Handle rules never declare `transform`. Hover feedback is now minimal and position-stable: full opacity plus a soft 3 px `box-shadow` ring (`color-mix` of the accent color), with the transition moved from `transform` to `box-shadow`.

Pinned by a new `styles.handles.test.ts`: any handle-targeting rule that declares `transform` fails the suite (opt-out escape hatch: a `handle-transform-exempt:` comment on the line above, for a rule that genuinely needs one and restates the translate itself). Run against the pre-fix CSS it flags exactly this one offender.

## Verified

- `npm run typecheck` clean.
- Style-pinned suites (theme/pills/kanban/handles) all green.
- Manually confirmed in a running build: the handle's hover ring renders with the dot's `getBoundingClientRect()` center identical before and during hover, and the positioning translate (`matrix(1,0,0,1,…)`) survives hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)