### PR TITLE
feat(canvas): ⌘0 zooms to 100%, Shift+1 fits the view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1425,6 +1425,18 @@ again; the grace window was never the thing that was wrong.
   pan = middle-drag or trackpad two-finger (`panOnScroll`, `zoomOnScroll:false`); pinch
   zoom. Right mouse is free for the context menu.
 - **Delete** (Delete/Backspace) opens `ConfirmDialog` before removing selected nodes.
+- **Zoom chords** (`renderer/lib/zoomShortcut.ts`): **⌘/Ctrl+0 → `zoomTo100`** (actual size — what
+  the browser AND Electron's default View menu already mean by that key) and **Shift+1 → `fitAll`**
+  (the Figma/tldraw/Excalidraw "zoom to fit"). Matched on `e.code`, like the project-jump chord,
+  which excludes `Digit0` so the two can never collide. The module is a PURE decision because both
+  chords move the camera and a camera move here is not read-only — `onMove` → `markDirty` persists
+  the viewport and casts it to the team session — so it refuses while the kanban board is up and
+  while focus is in a text surface (input/textarea/contenteditable/Monaco/xterm, where Shift+1 is
+  just the `!` key), and on auto-repeat (both actions animate; a held chord would restart the tween).
+  Desktop ⌘0 does NOT arrive as a keydown: the default menu's `resetZoom` accelerator wins, so
+  `main/index.ts` intercepts it in `before-input-event` and forwards `app:zoom-actual-size`, which
+  re-asks the same refusals. Server Edition needs no intercept (no menu; Chrome/Firefox hand ⌘0 to
+  the page) and stubs the subscription.
 - **"Go to node" (`goToNode`)** — the one camera-travel path (notification click, sessions
   sidebar, ⌘K jump, presence travel, minimap double-click, double-click focus). It frames the node
   with `fitView({nodes:[{id}]})` **only when React Flow has MEASURED it**: `getFitViewNodes` filters
@@ -1637,7 +1649,11 @@ again; the grace window was never the thing that was wrong.
 - **Window chrome**: macOS integrated title bar (`titleBarStyle: 'hiddenInset'`); the tab
   bar (`TabBar.tsx`) is the drag region with the `nodeterm` logo + a rounded pill of project
   tabs. Cmd+M is intercepted in `main/index.ts` `before-input-event` (else macOS minimizes)
-  and forwarded to the renderer via `app:toggle-markdown`.
+  and forwarded to the renderer via `app:toggle-markdown`; Cmd+W (`app:close-node`) and Cmd+0
+  (`app:zoom-actual-size`) are taken back from the same default menu the same way. We never call
+  `Menu.setApplicationMenu`, so Electron's DEFAULT menu is live and owns every accelerator in it —
+  a chord that collides with one never reaches the renderer at all
+  (`main/menu-accelerator-intercepts.test.ts` pins the three we steal).
 - **Theme**: macOS dark palette as CSS tokens in `styles.css` `:root` (`--accent` = systemBlue,
   label/separator opacities, SF font stack). Canvas background is black with dot grid.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,13 @@ empty line because `#` starts a comment.
 screen. A previous design moved that into the emulator and failed structurally; `CLAUDE.md` explains
 why in detail.
 
+**A new keyboard chord has to survive the shells, not just the renderer.** Electron's default
+application menu is live (we never replace it) and owns ⌘0, ⌘M, ⌘W, ⌘Q, ⌘R and friends — a menu
+accelerator is handled before the page, so your `keydown` branch simply never runs. Steal it back in
+`main/index.ts`'s `before-input-event` and forward it, like the three already there. Browsers own a
+different set. And any chord that reaches the canvas needs the two refusals every canvas shortcut
+here has: not while the kanban board covers it, not while the user is typing.
+
 **Comments explain WHY, and name the failure they prevent.** The codebase is deliberately dense with
 reasoning. A comment that restates the code is noise; one that says "do not simplify this back,
 here is what broke" is the point.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -479,6 +479,17 @@ function createWindow(): BrowserWindow {
       // selected it asks us to close the window (the standard behavior).
       event.preventDefault()
       win.webContents.send(IPC.appCloseNode)
+    } else if (input.code === 'Digit0' && !input.shift && !input.alt) {
+      // Repurpose Cmd/Ctrl+0 the same way. We never call `Menu.setApplicationMenu`, so Electron
+      // installs its DEFAULT menu, whose View → Actual Size binds this accelerator to `resetZoom`
+      // — the window's page zoom, not the canvas's. A menu accelerator is handled before the page
+      // sees the key, so without this the renderer's Digit0 branch would simply never run on the
+      // desktop. `before-input-event`'s preventDefault suppresses both the menu item and the page
+      // event, so exactly one thing happens: the canvas goes to 100%.
+      event.preventDefault()
+      // Auto-repeat is dropped here rather than in the renderer, so a held chord cannot restart
+      // the 200ms zoom tween — the same rule `zoomShortcutChord` applies to the keydown path.
+      if (!input.isAutoRepeat) win.webContents.send(IPC.appZoomActualSize)
     }
   })
 

--- a/src/main/menu-accelerator-intercepts.test.ts
+++ b/src/main/menu-accelerator-intercepts.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// GUARD, not a unit test. `src/main/index.ts` imports `electron` at module scope, so its
+// `before-input-event` handler cannot be loaded here — but that handler is the only thing standing
+// between three chords and Electron's DEFAULT application menu, which we never replace
+// (`Menu.setApplicationMenu` is not called anywhere) and which claims all three:
+//
+//   ⌘M → Window ▸ Minimize        ⌘W → Window ▸ Close        ⌘0 → View ▸ Actual Size (resetZoom)
+//
+// A menu accelerator is handled before the page sees the key, so deleting a branch here does not
+// break a test or throw — the shortcut just quietly starts minimizing the window / closing it /
+// resetting the WINDOW's page zoom instead of doing the app's thing. That is the failure this
+// pins. (`before-input-event`'s preventDefault suppresses the menu item AND the page event, which
+// is why each branch has to forward the intent to the renderer itself.)
+const MAIN_SRC = fs.readFileSync(path.join(__dirname, 'index.ts'), 'utf8')
+
+describe('the main window steals its chords back from the default menu', () => {
+  it('still intercepts before the page and the menu', () => {
+    expect(MAIN_SRC).toContain("win.webContents.on('before-input-event'")
+  })
+
+  it('forwards ⌘M and ⌘W to the renderer', () => {
+    expect(MAIN_SRC).toContain('win.webContents.send(IPC.appToggleMarkdown)')
+    expect(MAIN_SRC).toContain('win.webContents.send(IPC.appCloseNode)')
+  })
+
+  it('forwards ⌘0 to the renderer, and only on a FRESH press', () => {
+    // Matched on the physical `code`, like the renderer's half of the chord: on a non-US layout
+    // the zero key's `key` is not necessarily "0".
+    expect(MAIN_SRC).toContain("input.code === 'Digit0' && !input.shift && !input.alt")
+    // The repeat drop lives HERE because the forwarded signal carries no event: without it, a held
+    // ⌘0 would restart the 200ms zoom tween on every OS repeat.
+    expect(MAIN_SRC).toContain('if (!input.isAutoRepeat) win.webContents.send(IPC.appZoomActualSize)')
+  })
+})

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -561,6 +561,7 @@ const api: NodeTerminalApi = {
   // ipcRenderer listeners and trip the MaxListeners warning.
   onMarkdownToggle: subscribe(IPC.appToggleMarkdown),
   onCloseNode: subscribe(IPC.appCloseNode),
+  onZoomActualSize: subscribe(IPC.appZoomActualSize),
   closeWindow: () => ipcRenderer.send(IPC.appCloseWindow),
   focusWindow: () => ipcRenderer.send(IPC.appFocusWindow),
   setBadgeCount: (count) => ipcRenderer.send(IPC.appSetBadge, count),

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -333,6 +333,9 @@ export function buildStubApi(): Omit<
     },
     onMarkdownToggle: noopUnsub,
     onCloseNode: noopUnsub,
+    // Deliberate no-op (not a gap): a browser tab has no application menu to steal ⌘0, so the
+    // renderer's own keydown handler is the whole path there.
+    onZoomActualSize: noopUnsub,
     closeWindow: noop,
     // Best-effort: a browser tab can't force itself frontmost the way the desktop BrowserWindow
     // can, but `window.focus()` still helps when the page is merely blurred (not another OS app).

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -150,6 +150,12 @@ import { NotifyConsentDialog } from '../components/NotifyConsentDialog'
 import { SessionsSidebar } from '../components/SessionsSidebar'
 import type { SessionNodeInput } from '../lib/sessionList'
 import { liveProjectJumpTarget, projectJumpDigit } from '../lib/projectJump'
+import {
+  liveZoomShortcutAction,
+  liveZoomShortcutContext,
+  zoomShortcutAllowed,
+  zoomShortcutChord
+} from '../lib/zoomShortcut'
 import { UsageIndicator } from '../components/UsageIndicator'
 import { SystemResourcePill } from '../components/SystemResourcePill'
 import { PresenceLayer } from '../components/PresenceLayer'
@@ -4928,6 +4934,18 @@ export function Canvas() {
       } else if ((e.metaKey || e.ctrlKey) && e.key === '/') {
         e.preventDefault()
         setShortcutsOpen((v) => !v)
+      } else if (zoomShortcutChord(e) !== null) {
+        // ⌘/Ctrl+0 = back to 100%, Shift+1 = fit everything. `liveZoomShortcutAction` is the
+        // whole decision (see `lib/zoomShortcut.ts`), and the ⌘0 desktop route below asks the same
+        // one, so the two paths can never disagree about when the chord is allowed to move the
+        // camera. A null answer means "leave the key alone" — no `preventDefault`, which is what
+        // keeps Shift+1 typing a `!` wherever the user is actually typing.
+        const action = liveZoomShortcutAction(e)
+        if (action) {
+          e.preventDefault()
+          if (action === 'zoom-100') zoomTo100()
+          else fitAll()
+        }
       } else if (projectJumpDigit(e) !== null) {
         // Cmd/Ctrl+1-9 jumps to the Nth project — but only when the app actually owns the key
         // (desktop shell, and the digit addresses an open project). `liveProjectJumpTarget`
@@ -4984,7 +5002,22 @@ export function Canvas() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [toggleSessionsPin, switchProject])
+  }, [toggleSessionsPin, switchProject, fitAll, zoomTo100])
+
+  // ⌘/Ctrl+0 on the DESKTOP never reaches the keydown handler above: Electron's default View menu
+  // binds the accelerator to `resetZoom`, and a menu accelerator is handled before the page sees
+  // the key. `main/index.ts` intercepts it in `before-input-event` — exactly as it already does for
+  // ⌘M (else macOS minimizes) and ⌘W — and forwards it here, so the chord zooms the CANVAS to 100%
+  // instead of resetting the WINDOW's page zoom, which is not what a canvas app's user means by
+  // "actual size". The forwarded signal carries no event, so the refusals are re-asked here from
+  // the same module rather than re-derived. Server Edition has no menu and no intercept: there the
+  // keydown branch above is the whole path (the browser's own ⌘0 means the same thing, so the two
+  // agree rather than fight, and the bridge stubs this subscription out).
+  useEffect(() => {
+    return window.nodeTerminal.onZoomActualSize(() => {
+      if (zoomShortcutAllowed(liveZoomShortcutContext())) zoomTo100()
+    })
+  }, [zoomTo100])
 
   // Apply the accent color as a CSS variable.
   useEffect(() => {

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -78,6 +78,24 @@ describe('the session-memory panel is the one caller that fans a kill across soc
   })
 })
 
+describe('the zoom chords go through their guarded decision, on both routes', () => {
+  // `lib/zoomShortcut.ts` owns when ⌘0 / Shift+1 may move the camera (not while the kanban board
+  // covers the canvas, not while the user is typing). It is tested thoroughly on its own — what
+  // nothing else can see is Canvas calling round it. Both failures are silent: a raw
+  // `zoomShortcutChord` dispatch would fire under the board, and a bare `zoomTo100()` on the
+  // forwarded desktop route would fire mid-keystroke in a terminal.
+  it('asks the live decision on the keydown route', () => {
+    expect(CANVAS_SRC).toContain('const action = liveZoomShortcutAction(e)')
+    expect(CANVAS_SRC).toContain("if (action === 'zoom-100') zoomTo100()")
+  })
+
+  it('re-asks the refusals on the ⌘0 route forwarded from main', () => {
+    expect(CANVAS_SRC).toContain(
+      'if (zoomShortcutAllowed(liveZoomShortcutContext())) zoomTo100()'
+    )
+  })
+})
+
 describe('the end-session confirm describes both things it does', () => {
   // `closeSession` stops the tmux session AND deletes the canvas node. The wording is inherited
   // from the sessions sidebar, where deleting the node is the obvious intent — but the

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -45,7 +45,14 @@ function buildSections(dictationKeys: string[], dictationLabel: string): { title
         { keys: ['Left-drag'], label: 'Box-select (touch to select)' },
         { keys: ['Middle / Right-drag'], label: 'Pan the canvas' },
         { keys: ['Double-click'], label: 'Center & focus a node' },
-        { keys: ['⌘', 'wheel'], label: 'Zoom in / out' }
+        { keys: ['⌘', 'wheel'], label: 'Zoom in / out' },
+        // Advertised on BOTH surfaces, unlike "Jump to project" above. ⌘1-9 is dropped there
+        // because the browser RESERVES it (tab switching, un-preventable) for something unrelated;
+        // ⌘0 is neither — it is not in the reserved set, so the page gets the keydown, and even
+        // where a browser insists on handling it too it means the same thing we do ("actual size")
+        // instead of fighting us. Shift+1 is nobody else's key on any surface.
+        { keys: ['⌘', '0'], label: 'Zoom to 100%' },
+        { keys: ['⇧', '1'], label: 'Fit view' }
       ]
     },
     {

--- a/src/renderer/lib/zoomShortcut.test.ts
+++ b/src/renderer/lib/zoomShortcut.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+//
+// jsdom is here for ONE reason: `hasTextFocus` is the guard that decides whether Shift+1 zooms the
+// canvas or types a `!`, and the only honest way to test it is against real elements.
+import { afterEach, describe, expect, it } from 'vitest'
+import { projectJumpDigit } from './projectJump'
+import {
+  hasTextFocus,
+  zoomShortcutAction,
+  zoomShortcutAllowed,
+  zoomShortcutChord,
+  type ZoomShortcutEvent
+} from './zoomShortcut'
+
+function ev(over: Partial<ZoomShortcutEvent> = {}): ZoomShortcutEvent {
+  return {
+    type: 'keydown',
+    code: 'Digit0',
+    metaKey: true,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...over
+  }
+}
+
+const ZOOM_100 = ev()
+const FIT_ALL = ev({ code: 'Digit1', metaKey: false, shiftKey: true })
+const FREE = { boardOpen: false, textFocus: false }
+
+describe('zoomShortcutChord', () => {
+  it('reads ⌘/Ctrl+0 as "back to 100%", off the physical key code', () => {
+    expect(zoomShortcutChord(ZOOM_100)).toBe('zoom-100')
+    expect(zoomShortcutChord(ev({ metaKey: false, ctrlKey: true }))).toBe('zoom-100')
+  })
+
+  it('reads Shift+1 as "fit everything"', () => {
+    expect(zoomShortcutChord(FIT_ALL)).toBe('fit-all')
+  })
+
+  it('is not the chord without its exact modifiers', () => {
+    expect(zoomShortcutChord(ev({ metaKey: false }))).toBeNull() // bare 0
+    expect(zoomShortcutChord(ev({ shiftKey: true }))).toBeNull() // ⌘⇧0
+    expect(zoomShortcutChord(ev({ altKey: true }))).toBeNull() // ⌥⌘0 / AltGr
+    expect(zoomShortcutChord(ev({ code: 'Digit1', shiftKey: true, altKey: true }))).toBeNull()
+    expect(zoomShortcutChord(ev({ code: 'Digit1', metaKey: false, shiftKey: false }))).toBeNull()
+    expect(zoomShortcutChord(ev({ code: 'Digit1', shiftKey: true }))).toBeNull() // ⌘⇧1
+    expect(zoomShortcutChord(ev({ code: 'Digit2', metaKey: false, shiftKey: true }))).toBeNull()
+  })
+
+  it('only fires on a FRESH keydown', () => {
+    expect(zoomShortcutChord(ev({ type: 'keyup' }))).toBeNull()
+    // Both actions animate (200ms setViewport / 300ms fitView). Holding the chord must not
+    // restart the tween tens of times a second — that reads as a stutter, not a zoom.
+    expect(zoomShortcutChord(ev({ repeat: true }))).toBeNull()
+    expect(zoomShortcutChord({ ...FIT_ALL, repeat: true })).toBeNull()
+  })
+
+  // REGRESSION GUARD: the ⌘/Ctrl+1-9 project jump lives one `else if` away in the same handler.
+  // Neither matcher may ever claim a key the other one wants.
+  it('never claims a key the project-jump chord claims, and vice versa', () => {
+    for (let d = 0; d <= 9; d++) {
+      const plain = ev({ code: `Digit${d}`, shiftKey: false })
+      const shifted = ev({ code: `Digit${d}`, metaKey: false, shiftKey: true })
+      for (const e of [plain, shifted]) {
+        expect(zoomShortcutChord(e) !== null && projectJumpDigit(e) !== null).toBe(false)
+      }
+    }
+    expect(projectJumpDigit(ZOOM_100)).toBeNull()
+    expect(projectJumpDigit(FIT_ALL)).toBeNull()
+  })
+})
+
+describe('zoomShortcutAllowed', () => {
+  it('refuses while the kanban board is up', () => {
+    // The board is an OPAQUE overlay over a still-mounted canvas: the move would be invisible,
+    // yet `onMove` → `markDirty` still persists the viewport and casts it to the team session.
+    expect(zoomShortcutAllowed({ boardOpen: true, textFocus: false })).toBe(false)
+  })
+
+  it('refuses while the user is typing', () => {
+    expect(zoomShortcutAllowed({ boardOpen: false, textFocus: true })).toBe(false)
+  })
+
+  it('allows on a plain canvas', () => {
+    expect(zoomShortcutAllowed(FREE)).toBe(true)
+  })
+})
+
+describe('zoomShortcutAction', () => {
+  it('resolves each chord when nothing refuses it', () => {
+    expect(zoomShortcutAction(ZOOM_100, FREE)).toBe('zoom-100')
+    expect(zoomShortcutAction(FIT_ALL, FREE)).toBe('fit-all')
+  })
+
+  it('is null for BOTH chords under every refusal', () => {
+    for (const ctx of [
+      { boardOpen: true, textFocus: false },
+      { boardOpen: false, textFocus: true },
+      { boardOpen: true, textFocus: true }
+    ]) {
+      expect(zoomShortcutAction(ZOOM_100, ctx)).toBeNull()
+      expect(zoomShortcutAction(FIT_ALL, ctx)).toBeNull()
+    }
+  })
+
+  it('is null for a non-chord even on a free canvas', () => {
+    expect(zoomShortcutAction(ev({ code: 'KeyA' }), FREE)).toBeNull()
+  })
+})
+
+describe('hasTextFocus', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function focused(html: string, selector: string): Element {
+    document.body.innerHTML = html
+    return document.querySelector(selector)!
+  }
+
+  it('is true in the plain text inputs', () => {
+    expect(hasTextFocus(focused('<input />', 'input'))).toBe(true)
+    expect(hasTextFocus(focused('<textarea></textarea>', 'textarea'))).toBe(true)
+    expect(
+      hasTextFocus(focused('<div contenteditable="true">x</div>', 'div[contenteditable]'))
+    ).toBe(true)
+  })
+
+  it('is true anywhere inside Monaco or a terminal', () => {
+    // Shift+1 is a PRINTABLE chord: inside a terminal it is the `!` key, and a shell history
+    // expansion or a `!` in a commit message must not double as a camera move.
+    expect(
+      hasTextFocus(focused('<div class="xterm"><div class="row"></div></div>', '.row'))
+    ).toBe(true)
+    expect(
+      hasTextFocus(
+        focused('<div class="monaco-editor"><span class="view-line"></span></div>', '.view-line')
+      )
+    ).toBe(true)
+    // xterm's real focus target is its helper <textarea>; caught by the tag check too.
+    expect(
+      hasTextFocus(focused('<div class="xterm"><textarea></textarea></div>', 'textarea'))
+    ).toBe(true)
+  })
+
+  it('is false on the canvas itself, and with nothing focused', () => {
+    expect(hasTextFocus(focused('<div class="react-flow__pane"></div>', '.react-flow__pane'))).toBe(
+      false
+    )
+    expect(hasTextFocus(focused('<div contenteditable="false"></div>', 'div'))).toBe(false)
+    expect(hasTextFocus(null)).toBe(false)
+  })
+})

--- a/src/renderer/lib/zoomShortcut.ts
+++ b/src/renderer/lib/zoomShortcut.ts
@@ -1,0 +1,122 @@
+import { useProjects } from '../state/projects'
+import { isKanbanOpen } from '../state/viewMode'
+
+/**
+ * The two canvas ZOOM chords as ONE pure decision:
+ *
+ * - **⌘/Ctrl+0 → back to 100%.** The universal "actual size" key. Every browser means it, and so
+ *   does Electron's own default View menu (`resetZoom`), so binding the canvas's `zoomTo100` to it
+ *   is the app agreeing with its two shells rather than fighting them. `Digit0` is deliberately
+ *   excluded from the ⌘/Ctrl+1-9 project-jump chord (`projectJump.ts`), so the two can never
+ *   collide — `zoomShortcut.test.ts` pins that from this side too.
+ * - **Shift+1 → fit everything.** The Figma / tldraw / Excalidraw convention for "zoom to fit".
+ *   No modifier chord in this app claims a bare Shift+digit, and no menu accelerator can (menus
+ *   need a primary modifier), so the only thing Shift+1 competes with is *typing* `!` — which is
+ *   exactly what the `textFocus` refusal below is for.
+ *
+ * Matching is on `e.code` (the physical key), not `e.key`: on AZERTY the unshifted digit row
+ * prints letters and `Shift+1` prints `1`, and both shortcuts are positional. Same reasoning, and
+ * the same reason `@shared/shortcut` does not fit, as `projectJump.ts` — see its header.
+ *
+ * The refusals are the whole point of the module. Both chords move the camera, and a camera move
+ * on this canvas is not a read-only act: `onMove` → `markDirty` persists the viewport and casts it
+ * to everyone in the team-sync session. So the decision has to be made in one place that every
+ * entry point asks, rather than re-derived per call site.
+ */
+
+export type ZoomShortcutAction = 'zoom-100' | 'fit-all'
+
+/** The subset of `KeyboardEvent` the chord is decided from (so tests need no DOM). */
+export interface ZoomShortcutEvent {
+  type: string
+  code: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  /** OS auto-repeat: true on every keydown after the first while the chord is HELD. */
+  repeat: boolean
+}
+
+export interface ZoomShortcutContext {
+  /** The kanban board is up — an OPAQUE overlay over a still-mounted canvas. */
+  boardOpen: boolean
+  /** Focus is in a text surface (input / textarea / contenteditable / Monaco / xterm). */
+  textFocus: boolean
+}
+
+/**
+ * PURE, key-shape only: which zoom chord this keydown is, or null when it is not one.
+ *
+ * Alt is excluded on both because AltGr reports as ctrl+alt and must keep typing a real character
+ * on non-US layouts. Auto-repeat is excluded because both actions are ANIMATED (300ms fitView /
+ * 200ms setViewport): holding the chord would restart the tween on every repeat, which reads as a
+ * stutter rather than a zoom.
+ */
+export function zoomShortcutChord(e: ZoomShortcutEvent): ZoomShortcutAction | null {
+  if (e.type !== 'keydown' || e.repeat) return null
+  if (e.altKey) return null
+  const primary = e.metaKey || e.ctrlKey
+  if (primary && !e.shiftKey && e.code === 'Digit0') return 'zoom-100'
+  if (!primary && e.shiftKey && e.code === 'Digit1') return 'fit-all'
+  return null
+}
+
+/**
+ * PURE. Whether a zoom chord may act at all, given where the user is.
+ *
+ * Split out from `zoomShortcutAction` because the desktop ⌘0 arrives WITHOUT an event: Electron's
+ * default View menu owns the accelerator, so `main/index.ts` intercepts it and forwards a bare
+ * signal. That path has to ask the same two questions this one does.
+ */
+export function zoomShortcutAllowed(ctx: ZoomShortcutContext): boolean {
+  // The board covers the canvas completely, so a camera move there is invisible AND persisted —
+  // the user comes back to a canvas that jumped for no reason they saw. Same early-return
+  // discipline as undo/redo, dictation and Delete (`isKanbanOpen`).
+  if (ctx.boardOpen) return false
+  // In a text surface these are ordinary keystrokes: Shift+1 types `!`, and ⌘0 belongs to the
+  // editor/terminal. Stealing them would make the canvas jump mid-sentence.
+  if (ctx.textFocus) return false
+  return true
+}
+
+/** PURE. The action this keydown should run, or null to leave the key alone (no preventDefault). */
+export function zoomShortcutAction(
+  e: ZoomShortcutEvent,
+  ctx: ZoomShortcutContext
+): ZoomShortcutAction | null {
+  const chord = zoomShortcutChord(e)
+  if (chord === null) return null
+  return zoomShortcutAllowed(ctx) ? chord : null
+}
+
+/** Text surfaces the canvas must never steal a printable chord from. Mirrors the ⌘C branch. */
+const TEXT_SURFACE_SELECTOR = '.monaco-editor, .xterm'
+
+/** PURE over the element: is `active` somewhere the user is typing? */
+export function hasTextFocus(active: Element | null): boolean {
+  if (!active) return false
+  const tag = active.tagName.toLowerCase()
+  if (tag === 'input' || tag === 'textarea') return true
+  if (active.getAttribute('contenteditable') === 'true') return true
+  // xterm focuses its own helper <textarea> (caught above), but the terminal's other focusable
+  // bits and Monaco's inner widgets are plain elements — ask the ancestor chain like ⌘C does.
+  return !!active.closest(TEXT_SURFACE_SELECTOR)
+}
+
+/** The live shell state the refusals are decided against. */
+export function liveZoomShortcutContext(): ZoomShortcutContext {
+  return {
+    boardOpen: isKanbanOpen(useProjects.getState().activeProjectId),
+    textFocus: hasTextFocus(typeof document === 'undefined' ? null : document.activeElement)
+  }
+}
+
+/**
+ * `zoomShortcutAction` bound to the live board/focus state. The cheap key-shape test runs first so
+ * an ordinary keystroke never reaches into the store or walks the DOM.
+ */
+export function liveZoomShortcutAction(e: ZoomShortcutEvent): ZoomShortcutAction | null {
+  if (zoomShortcutChord(e) === null) return null
+  return zoomShortcutAction(e, liveZoomShortcutContext())
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -47,6 +47,10 @@ export const IPC = {
   transcriptSearch: 'transcript:search',
   appToggleMarkdown: 'app:toggle-markdown',
   appCloseNode: 'app:close-node',
+  /** main → renderer: ⌘/Ctrl+0 ("actual size"). Intercepted in `before-input-event` because
+   *  Electron's default View menu binds that accelerator to `resetZoom`, which resets the WINDOW's
+   *  page zoom rather than the canvas's. */
+  appZoomActualSize: 'app:zoom-actual-size',
   appCloseWindow: 'app:close-window',
   appFocusWindow: 'app:focus-window',
   /** Write text to the system clipboard from the MAIN process. Renderer-side `clipboard` access is

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2209,6 +2209,10 @@ export interface NodeTerminalApi {
   onMarkdownToggle(listener: () => void): () => void
   /** Fires when the user presses Cmd/Ctrl+W (close selected node). Returns unsubscribe. */
   onCloseNode(listener: () => void): () => void
+  /** Fires when the user presses Cmd/Ctrl+0 (zoom the canvas back to 100%). Desktop only: the
+   *  key is intercepted in main because Electron's default View menu owns the accelerator. In the
+   *  Server Edition the renderer's own keydown handler sees the key and this is a no-op stub. */
+  onZoomActualSize(listener: () => void): () => void
   /** Close the application window (Cmd/Ctrl+W fallback when no node is selected). */
   closeWindow(): void
   /** Bring the app window to the foreground (show + OS focus). Called after a file is DROPPED


### PR DESCRIPTION
Supersedes #161 (thanks @gor3a — the shortcut, the `e.code` matching and the panel row are his; the commit carries his `Co-authored-by`). The **binding was changed per maintainer decision**, and the guards a review of #161 asked for are in. Please close #161 when this lands rather than the other way round.

## The binding

| Chord | Action | Why |
| --- | --- | --- |
| **⌘/Ctrl+0** | `zoomTo100` | "Actual size / 100%" is the universal meaning of this key. A **browser** already means it, and so does **Electron's own default View ▸ Actual Size** (`resetZoom`). Binding the canvas's `zoomTo100` to it makes the app *agree* with both of its shells instead of competing with them — which is why the collisions #161's binding had simply evaporate. |
| **Shift+1** | `fitAll` | The Figma / tldraw / Excalidraw "zoom to fit". |

`zoomTo100` existed (`Canvas.tsx`) and was reachable only from the ⌘K palette (`zoom-100`); it now has the keyboard binding its convention implies. `fitAll` is the same callback the dock button, the React Flow Controls, ⌘K and the context menu already use.

Neither chord takes a key from anything else: `Digit0` is deliberately excluded from the ⌘/Ctrl+1-9 project-jump chord (and a test now pins the non-overlap from **both** sides), and nothing in the renderer or in any menu claims a bare Shift+digit.

## The guards, and what each prevents

All four live in one pure module, `src/renderer/lib/zoomShortcut.ts`, because both chords **move the camera — and a camera move on this canvas is not read-only**: `onMove` → `markDirty` persists the viewport and casts it to the team-sync session.

1. **Kanban board open → refuse.** The board is an opaque overlay over a canvas that stays mounted. Without this the chord fires on something the user cannot see *and* writes a viewport + a team-sync cast for it. Same early-return discipline as undo/redo, dictation and Delete (`isKanbanOpen`).
2. **Text focus → refuse.** input / textarea / contenteditable / Monaco / xterm, the same test the ⌘C branch uses. Shift+1 is a **printable** chord: in a terminal or an editor it is the `!` key, and the canvas must not jump mid-sentence.
3. **Auto-repeat → refuse.** Both actions animate (200 ms `setViewport`, 300 ms `fitView`). A held chord would restart the tween on every OS repeat, which reads as a stutter, not a zoom.
4. **`preventDefault` scoped to a matched *and allowed* chord.** A refused key is left entirely alone, so `!` still types and the shell keeps whatever ⌘0 meant to it.

## Three surfaces

**Desktop** — ⌘0 does **not** reach the renderer as a keydown. We never call `Menu.setApplicationMenu`, so Electron's **default** menu is live and its View ▸ Actual Size owns the accelerator; a menu accelerator is handled before the page. Left alone, the shortcut would quietly reset the *window's* page zoom and never touch the canvas. `main/index.ts` takes it back in `before-input-event` — exactly as it already does for ⌘M (else macOS minimizes) and ⌘W — and forwards `app:zoom-actual-size`, which re-asks the same refusals through the same module. Shift+1 needs no intercept (menus need a primary modifier).

**Server Edition (browser)** — no menu, no intercept; the keydown branch is the whole path. ⌘0 is *not* in the browsers' un-preventable reserved set (⌘T/⌘W/⌘N/⌘Tab/⌘1-9 are), so the page gets the key — and unlike ⌘1-9, even a browser that insisted on also handling it means the *same thing we do*. So both rows are advertised there, where `ShortcutsPanel.tsx` drops "Jump to project"; that precedent is about a reserved key doing something **unrelated**, which is not this case. `onZoomActualSize` is a deliberate `noopUnsub` in the bridge, documented as such.

**Mobile** — N/A.

## Tests

Repo pattern, no new harness: a pure module + its tests (`zoomShortcut.test.ts`, the shape of `projectJump.ts` + `.test.ts`) and source-read wiring assertions where rendering is impractical.

- `src/renderer/lib/zoomShortcut.test.ts` — which chord ⇒ which action, every modifier near-miss, and each refusal (board open, text focus, key repeat, keyup) for **both** chords; plus the non-overlap sweep against `projectJumpDigit` across Digit0-9 × {plain, shifted}.
- `src/renderer/canvas/canvas-wiring.test.tsx` — Canvas asks the guarded decision on **both** routes (the keydown branch and the forwarded desktop ⌘0). Both failures are otherwise silent.
- `src/main/menu-accelerator-intercepts.test.ts` — the three chords we steal back from the default menu are still stolen. Deleting a branch there does not throw; the shortcut just starts minimizing / closing / resetting page zoom again.

Each guard was mutation-tested (dropped or inverted, confirmed a test goes red).

`npm run typecheck` clean. Full `npx vitest run`: **5334 passed**, 12 skipped; the only failures are the 3 `node-pty-patch` + 1 `webgl-addon-pair` checks that read `node_modules`, which is symlinked in the clone this was built in.

## Not verified here

The desktop key path (Electron menu vs. `before-input-event`) has no CI coverage on any platform and was not run on a Mac — worth one manual pass: ⌘0 on the canvas, ⌘0 with the board open, ⌘0 with a terminal focused, and Shift+1 in the same three states.
