### PR TITLE
chore(ts): make the path aliases self-sufficient without baseUrl

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,9 +8,11 @@
     "strict": true,
     "skipLibCheck": true,
     "types": ["node", "electron-vite/node"],
-    "baseUrl": ".",
+    // Path values are relative to this file's own directory, so no "baseUrl" is
+    // needed to anchor them. TypeScript 7 drops "baseUrl" entirely; this form
+    // resolves identically on 5.x and 7.x.
     "paths": {
-      "@shared/*": ["src/shared/*"]
+      "@shared/*": ["./src/shared/*"]
     }
   },
   "include": [

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -10,10 +10,12 @@
     "strict": true,
     "skipLibCheck": true,
     "types": ["node"],
-    "baseUrl": ".",
+    // Path values are relative to this file's own directory, so no "baseUrl" is
+    // needed to anchor them. TypeScript 7 drops "baseUrl" entirely; this form
+    // resolves identically on 5.x and 7.x.
     "paths": {
-      "@renderer/*": ["src/renderer/*"],
-      "@shared/*": ["src/shared/*"]
+      "@renderer/*": ["./src/renderer/*"],
+      "@shared/*": ["./src/shared/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## What `baseUrl` was doing

Nothing but anchoring the `paths` values. Both project configs had:

```jsonc
"baseUrl": ".",
"paths": { "@shared/*": ["src/shared/*"] }   // + "@renderer/*" in tsconfig.web.json
```

`paths` values are non-relative, so TypeScript resolved them against `baseUrl` — which was `"."`, i.e. the very directory the tsconfig already lives in. `baseUrl` also acts as a root for bare module specifiers, but nothing in the tree uses that: there is not a single `from 'src/...'` import, and a `--traceResolution` run over both projects mentions `baseUrl` **zero** times. So its only real job was supplying the `./` that the `paths` entries omitted.

## Why TypeScript 7 forces the issue

TS 7 removed the option outright. On unmodified `main`, `tsc@7.0.2` reports:

```
tsconfig.node.json(11,5): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
tsconfig.node.json(13,21): error TS5090: Non-relative paths are not allowed. Did you forget a leading './'?
tsconfig.web.json(13,5): error TS5102: ...
tsconfig.web.json(15,23): error TS5090: ...
tsconfig.web.json(16,21): error TS5090: ...
```

Two coupled errors: the option is gone, and without it `paths` values must be relative to the tsconfig's own directory.

## The change

Drop `baseUrl` and give each `paths` value the leading `./` it was implicitly getting. Same directory, same target, one less indirection:

```jsonc
"paths": {
  "@renderer/*": ["./src/renderer/*"],
  "@shared/*":   ["./src/shared/*"]
}
```

Nine lines across the two configs, three of them comment. **No TypeScript bump here** — this form is valid on 5.x and 7.x alike.

## Evidence it is a no-op

Measured on this branch against `origin/main` as baseline, with the repo's installed TypeScript 5.9.3:

| Check | Baseline (`origin/main`) | This branch |
|---|---|---|
| `npm run typecheck` (both projects) | clean | clean |
| `npx vitest run` | 433 passed / 2 failed files, 5789 passed / 4 failed / 12 skipped | **identical** |
| `npm run build` + `npm run server:build` | 131 files in `out/` | 131 files, **every md5 identical** |

The four failing tests are environmental in the verification clone (3 × `node-pty-patch`, 1 × `webgl-addon-pair` version skew) and fail the same way on unmodified `main`.

`out/` being **byte-identical across all 131 emitted files** — including `out/server/main.cjs`, which esbuild bundles with `--tsconfig=tsconfig.node.json` and therefore resolves `@shared/*` through exactly these entries — is the strongest form of the claim: the compilers and bundlers see the same modules before and after.

Alias resolution was confirmed per project via `--traceResolution`, since the three source trees sit under different tsconfigs:

- `src/main/remote/canvas-sync.ts` → `@shared/types` → `./src/shared/*` → `src/shared/types.ts`
- `src/server/index.ts` → `@shared/ipc` → `./src/shared/*` → `src/shared/ipc.ts`
- `src/renderer/components/PresenceLayer.tsx` → `@shared/presence` → `./src/shared/*` → `src/shared/presence.ts`

## The other alias declarations

These aliases are declared in three places, and tsconfig is only one of them: `electron.vite.config.ts` (main / preload / renderer blocks) and `vitest.config.ts` both declare `@shared` and `@renderer` as `resolve(__dirname, 'src/shared')`. Those are absolute paths built at config-evaluation time and never consulted `baseUrl`, so they needed **no change** — and the two declarations agreed with tsconfig before this PR and still agree after. Nothing drifted.

## Why now

This unblocks #40 (dependabot: TypeScript 5.9.3 → 7.0.2). With this on `main`, `tsc@7.0.2` reports **zero** diagnostics across both projects — verified here by running a sandboxed 7.0.2 against this branch. #40 needs no edit of its own; a rebase should be enough to turn it green.