### PR TITLE
fix(control): a flag must not swallow the next flag as its value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -970,6 +970,16 @@ persisted — only `unread`/`session`/`sessionId` go to localStorage under
   control the desktop's canvas. The shim is generated source no compiler checks:
   `canvas-control-shim.test.ts` runs it for real (/bin/sh against a real hook server, port AND
   unix-socket transports) — keep it that way.
+  **Flag syntax**: `--flag value`, `--flag=value`, or a valueless flag anywhere on the line. The
+  shim used to consume the next token after any `--flag` *unconditionally*, so `--read --node b1`
+  became `arg.read=--node` with `b1` silently dropped and the server answering about the wrong
+  flag; it now peeks. The trade: a value that itself starts with `--` must use the `=` form
+  (`--cmd=--version`), which was previously unexpressible in either direction. Two parsers are in
+  play and both are tested — the sh loop (`control-shim-parse.test.ts`, real `sh` + a fake `curl`
+  that records argv) and `parseControlBody` reading what it built (`canvas-control-shim.test.ts`).
+  **A new verb must not DEPEND on the fix**: the shim is rewritten locally every app boot but onto
+  an SSH host only inside `RemoteHooks.setup()` (on connect), so an already-connected project keeps
+  the old loop with no signal on the wire. Give every flag a value and both loops agree.
   **Grouping verbs** (`group` / `ungroup` / `move` / `arrange` / `align`): `group` wraps **sibling**
   objects — nodes or frames — into a new frame in their shared container (a mixed-container set, or
   an ancestor plus its descendant, is refused with that reason); `ungroup --group <id>` dissolves a

--- a/docs/ssh-agent-skills.md
+++ b/docs/ssh-agent-skills.md
@@ -66,6 +66,26 @@ at it (`NODETERM_HOOK_ENDPOINT`) along with `NODETERM_NODE_ID`. So the design ru
    installed. It now mirrors the local `hookServer.buildPtyEnv` exactly, `canControlCanvas`
    gate included.
 
+### Flag syntax, and why a verb must not depend on it
+
+Flags are `--flag value` or `--flag=value`, and a flag may carry no value at all, anywhere on the
+line. The `=` form is the **only** way to pass a value that itself starts with `--`
+(`open-terminal --cmd=--version`); written as two tokens, a leading `--` is read as the next flag,
+so `--text --oops` sends an empty `--text` plus a stray `--oops`.
+
+That is a deliberate trade. The loop used to consume the token after any `--flag`
+*unconditionally*, so `--read --node b1` became `arg.read=--node` with `b1` dropped, and a
+valueless flag was expressible only as the last token on the line. Both failures were **silent** —
+the request stayed well-formed and the server answered about the wrong flag, which sends the next
+debugger to the verb table instead of to the shim.
+
+**The staleness window this lives in:** the shim is rewritten locally at every app boot, but onto
+an SSH host only inside `RemoteHooks.setup()`, i.e. **on connect**. An already-connected SSH
+project keeps the shim it was handed, so a parser improvement reaches remote agent nodes only
+after a reconnect, with nothing on the wire to say which loop is running — the same shape as the
+managed hook script's stale window. New verbs are therefore designed to parse identically under
+both loops: give every flag a value and the old and new loops agree.
+
 ### Gating and failure behavior
 
 Install is gated on **both** a resolved remote `$HOME` (every remote path must be absolute — a

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -3,7 +3,8 @@ import {
   parseControlRequest,
   isDestructiveVerb,
   mergeCanvasControlBlock,
-  buildCanvasControlInstructions
+  buildCanvasControlInstructions,
+  buildCanvasSkillBody
 } from './canvas-control-core'
 
 describe('parseControlRequest', () => {
@@ -181,6 +182,21 @@ describe('parseControlRequest', () => {
       expect(body).toContain(verb)
     }
     expect(body.toLowerCase()).toContain('confirm')
+  })
+
+  // The parser change in this commit's sibling is only half a fix: an agent that never learns the
+  // `=` form simply cannot express a value beginning with `--`, and the failure stays silent for it.
+  // So both agent-facing texts must carry the rule, not just one of them.
+  it('the skill text documents --flag=value and warns about values starting with --', () => {
+    const body = buildCanvasSkillBody('/x/shim.sh')
+    expect(body).toContain('--flag=value')
+    expect(body).toMatch(/starts? with `--`/)
+  })
+
+  it('the codex/gemini instructions carry the same rule', () => {
+    const body = buildCanvasControlInstructions('/tmp/nodeterm.sh')
+    expect(body).toContain('--flag=value')
+    expect(body).toMatch(/starts? with `--`/)
   })
 
   it('spawn-team requires --team and none of the layout verbs are destructive', () => {

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -254,10 +254,34 @@ nt_i=0
 while [ "$nt_i" -lt "$nt_count" ]; do
   nt_a="$1"; shift; nt_i=$((nt_i + 1))
   case "$nt_a" in
+    --*=*)
+      # \`--flag=value\`: the only unambiguous form, and the ONLY way to pass a value that itself
+      # starts with \`--\`. Split on the FIRST \`=\` so a value may contain more of them.
+      nt_k=\${nt_a#--}
+      nt_v=\${nt_k#*=}
+      nt_k=\${nt_k%%=*}
+      set -- "$@" --data-urlencode "arg.$nt_k=$nt_v"
+      ;;
     --*)
+      # PEEK before consuming. The old code took the next token unconditionally, so \`--a --b v\`
+      # parsed as arg.a=--b plus a silently dropped \`v\`, and a valueless flag was expressible only
+      # as the LAST token on the line. Both failures were silent: the server saw a well-formed
+      # request carrying nonsense, and answered about the wrong flag.
+      #
+      # The peek matches \`--\` and NOT a single \`-\`, so a negative number stays a value.
+      #
+      # The cost, deliberately taken: a value that legitimately begins with \`--\` is no longer
+      # consumed positionally. \`--text --oops\` now sends arg.text= plus arg.oops=. Write it as
+      # \`--text=--oops\`, which the branch above exists for and which was previously unexpressible
+      # in either direction.
       nt_k=\${nt_a#--}
       nt_v=""
-      if [ "$nt_i" -lt "$nt_count" ]; then nt_v="$1"; shift; nt_i=$((nt_i + 1)); fi
+      if [ "$nt_i" -lt "$nt_count" ]; then
+        case "$1" in
+          --*) : ;;
+          *) nt_v="$1"; shift; nt_i=$((nt_i + 1)) ;;
+        esac
+      fi
       set -- "$@" --data-urlencode "arg.$nt_k=$nt_v"
       ;;
     *)

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -138,6 +138,10 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     `sh "${shimPath}" <verb> [args]`,
     '```',
     '',
+    'Flags take a value: `--flag value`, or `--flag=value`. Use the `=` form when the value itself',
+    'starts with `--` (`--cmd=--version`); written as two tokens, a leading `--` is read as the next',
+    'flag. A flag with no value is allowed anywhere on the line.',
+    '',
     'Verbs:',
     '- `list` — current nodes (id, kind, title). Start here when you need a node id.',
     '- `open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>]` — open N plain terminals.',
@@ -215,6 +219,13 @@ export function buildCanvasControlInstructions(shimPath: string): string {
 // request is form-urlencoded rather than JSON because `curl --data-urlencode` does the escaping
 // for us — emitting valid JSON from sh for arbitrary values (`--prompt`, `--html`, `--team`)
 // could not be made safe.
+//
+// INSTALL LIFECYCLE, and why a verb must not depend on this parser's fixes: the shim is rewritten
+// locally at every app boot, but onto an SSH host ONLY inside RemoteHooks.setup(), i.e. on connect.
+// An already-connected SSH project keeps the shim it was handed. So a parsing improvement reaches
+// remote agent nodes only after a reconnect, with no signal on the wire — the same shape as the
+// managed hook script's stale window. Verbs are therefore designed to parse identically under both
+// the old and the new loop: give every flag a value, and the two loops agree.
 export const CONTROL_SHIM_SCRIPT = `#!/bin/sh
 # nodeterm canvas-control CLI (auto-generated — do not edit).
 
@@ -347,6 +358,11 @@ Run the shim (absolute path):
 \`\`\`sh
 sh "${shimPath}" <verb> [args]
 \`\`\`
+
+Flags take a value: \`--flag value\`, or \`--flag=value\`. Use the \`=\` form when the value itself
+starts with \`--\` (\`--cmd=--version\`); written as two tokens, a leading \`--\` is read as the
+next flag, so \`--text --oops\` sends an empty \`--text\` plus a stray \`--oops\`. A flag with no
+value is allowed anywhere on the line, not only at the end.
 
 Verbs:
 - \`list\` — list current nodes (id, kind, title). Start here when you need a node id.

--- a/src/main/canvas-control-shim.test.ts
+++ b/src/main/canvas-control-shim.test.ts
@@ -105,6 +105,40 @@ describe('canvas-control shim', () => {
     expect(received.at(-1)?.args).toEqual({ node: 'n1', title: '' })
   })
 
+  // TWO parsers stand between an agent's command line and a verb's args: the sh loop that BUILDS
+  // the form body, and parseControlBody that READS it. src/main/control-shim-parse.test.ts pins the
+  // first alone (argv, via a fake curl); these pin the pair, because a flag can survive the shim
+  // and still be dropped by the reader — `arg.<name>` with an empty value is exactly the shape
+  // that would be plausible to discard.
+  it('a --flag does not swallow the next --flag, all the way through to parsed args', async () => {
+    await callShim(['open-terminal', '--count', '2', '--verbose', '--cwd', '/tmp'])
+    expect(received.at(-1)?.args).toEqual({ count: '2', verbose: '', cwd: '/tmp' })
+  })
+
+  it('--flag=value carries a value that itself starts with -- (unexpressible before)', async () => {
+    await callShim(['open-terminal', '--cmd=--version', '--cwd', '/srv'])
+    expect(received.at(-1)?.args).toEqual({ cmd: '--version', cwd: '/srv' })
+  })
+
+  it('--flag=value splits on the FIRST =, and the rest survives urlencoding', async () => {
+    await callShim(['open-terminal', '--cmd=env A=1 B="2 3"'])
+    expect(received.at(-1)?.args).toEqual({ cmd: 'env A=1 B="2 3"' })
+  })
+
+  // The peek looks for `--`, not `-`. A single-dash value must still be consumed positionally.
+  it('a value beginning with a single dash is still a value', async () => {
+    await callShim(['rename', '--node', 'n1', '--title', '-7'])
+    expect(received.at(-1)?.args).toEqual({ node: 'n1', title: '-7' })
+  })
+
+  // The regression the fix takes deliberately, and its escape — pinned so neither half drifts.
+  it('a --value passed as a separate token becomes its own flag; the = form is the escape', async () => {
+    await callShim(['write', '--node', 'n1', '--text', '--oops'])
+    expect(received.at(-1)?.args).toEqual({ node: 'n1', text: '', oops: '' })
+    await callShim(['write', '--node', 'n1', '--text=--oops'])
+    expect(received.at(-1)?.args).toEqual({ node: 'n1', text: '--oops' })
+  })
+
   it('carries the kanban verbs (board / assign) through', async () => {
     await callShim(['board'])
     expect(received.at(-1)).toMatchObject({ verb: 'board', args: {} })

--- a/src/main/control-shim-parse.test.ts
+++ b/src/main/control-shim-parse.test.ts
@@ -1,0 +1,128 @@
+// The REAL shim, under REAL `sh`, with a FAKE `curl` that records its argv.
+//
+// A TypeScript re-implementation of the `--*` loop would assert what we THINK the loop does, and
+// the whole bug this file pins is the gap between what it does and what everyone believes it does.
+// So the script is executed, not modelled.
+//
+// Why the fake curl logs to a FILE rather than printing its argv: the shim captures curl's stdout
+// in a command substitution (`nt_code=$(… | curl …)`) to read `-w '%{http_code}'`. Anything the
+// fake printed on stdout would land in `nt_code`, the shim would treat the run as a non-200
+// failure and exit 1, and every case here would fail for a reason that has nothing to do with
+// parsing. stderr is no good either — the shim sends curl's stderr to /dev/null.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { CONTROL_SHIM_SCRIPT } from './canvas-control-core'
+
+let dir = ''
+
+/** Run the shim and return the `arg.<name>=<value>` pairs it handed curl, in order. */
+const run = (args: string[]): string[] => {
+  const log = path.join(dir, 'argv.log')
+  fs.writeFileSync(log, '')
+  execFileSync('sh', [path.join(dir, 'shim.sh'), ...args], {
+    env: {
+      PATH: `${path.join(dir, 'bin')}:${process.env.PATH ?? ''}`,
+      NODETERM_CANVAS_CONTROL: '1',
+      NODETERM_HOOK_PORT: '1',
+      NODETERM_NODE_ID: 'n1',
+      NT_ARGV_LOG: log,
+      HOME: dir
+    },
+    encoding: 'utf8'
+  })
+  // One argv element per line; keep only the translated pairs (`nodeId=…` and curl's own flags
+  // are not part of what this file is about).
+  return fs
+    .readFileSync(log, 'utf8')
+    .split('\n')
+    .filter((l) => l.startsWith('arg.'))
+}
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctlshim-'))
+  fs.mkdirSync(path.join(dir, 'bin'))
+  fs.writeFileSync(path.join(dir, 'shim.sh'), CONTROL_SHIM_SCRIPT, { mode: 0o755 })
+  // A curl that drains the header config off stdin, records its argv, and reports 200 so the shim
+  // takes its success path. `-o <file>` is left as mktemp made it: empty, which the shim prints.
+  fs.writeFileSync(
+    path.join(dir, 'bin', 'curl'),
+    '#!/bin/sh\ncat >/dev/null\nfor a in "$@"; do printf \'%s\\n\' "$a"; done >> "$NT_ARGV_LOG"\necho 200\n',
+    { mode: 0o755 }
+  )
+})
+
+afterAll(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+describe('the control shim translates flags', () => {
+  it('a --flag followed by another --flag does NOT eat it', () => {
+    // THE BUG: this used to yield ['arg.read=--node'] and `b1` was lost with no error anywhere.
+    expect(run(['browser', '--read', '--node', 'b1'])).toEqual(['arg.read=', 'arg.node=b1'])
+  })
+
+  it('a valueless flag in the middle of a line is expressible', () => {
+    expect(run(['open-terminal', '--count', '2', '--verbose', '--cwd', '/tmp'])).toEqual([
+      'arg.count=2',
+      'arg.verbose=',
+      'arg.cwd=/tmp'
+    ])
+  })
+
+  it('--flag=value is the escape for a value that starts with --', () => {
+    expect(run(['open-terminal', '--cmd=--version'])).toEqual(['arg.cmd=--version'])
+  })
+
+  it('--flag=value splits on the FIRST = so the value may contain more of them', () => {
+    expect(run(['open-terminal', '--cmd=env A=1 B=2'])).toEqual(['arg.cmd=env A=1 B=2'])
+  })
+
+  it('--flag= is an explicit empty value', () => {
+    expect(run(['rename', '--node', 'n1', '--title='])).toEqual(['arg.node=n1', 'arg.title='])
+  })
+
+  // The peek tests for `--`, not for `-`: a single-dash token is a VALUE. `--scroll -600` must
+  // keep working, or the fix trades one silent misparse for another.
+  it('a negative number is still consumed as a value', () => {
+    expect(run(['browser', '--scroll', '-600'])).toEqual(['arg.scroll=-600'])
+  })
+
+  it('an ordinary --flag value pair is unchanged', () => {
+    expect(run(['open-agent', '--agent', 'codex', '--count', '3'])).toEqual([
+      'arg.agent=codex',
+      'arg.count=3'
+    ])
+  })
+
+  it('a value containing spaces, quotes and = survives intact', () => {
+    expect(run(['rename', '--node', 'n1', '--title', 'a b="c" d'])).toEqual([
+      'arg.node=n1',
+      'arg.title=a b="c" d'
+    ])
+  })
+
+  // Order is the order the tokens were translated in, so the positional comes first here. It is
+  // asserted because the loop's accumulator (originals off the front, pairs onto the back) is the
+  // subtle part of this script and a reordering would mean the drain went wrong.
+  it('the bare positional forms still work', () => {
+    expect(run(['write', 'n7', '--text', 'hi'])).toEqual(['arg.node=n7', 'arg.text=hi'])
+  })
+
+  it('a trailing flag with no value is still empty, as it always was', () => {
+    expect(run(['rename', '--node', 'n1', '--title'])).toEqual(['arg.node=n1', 'arg.title='])
+  })
+
+  // The regression the fix deliberately takes, pinned so nobody "fixes" it back by accident.
+  it('a --value passed as a separate token becomes its own flag — use the = form', () => {
+    expect(run(['write', '--node', 'n1', '--text', '--oops'])).toEqual([
+      'arg.node=n1',
+      'arg.text=',
+      'arg.oops='
+    ])
+    expect(run(['write', '--node', 'n1', '--text=--oops'])).toEqual([
+      'arg.node=n1',
+      'arg.text=--oops'
+    ])
+  })
+})


### PR DESCRIPTION
## The bug: a flag swallows the next flag, silently

`CONTROL_SHIM_SCRIPT`'s `--*` branch consumed the token after any `--flag` **unconditionally, even
when that token was another flag**:

```sh
--*)
  nt_k=${nt_a#--}
  nt_v=""
  if [ "$nt_i" -lt "$nt_count" ]; then nt_v="$1"; shift; nt_i=$((nt_i + 1)); fi
```

So `open-terminal --cwd --cmd npm` sent `arg.cwd=--cmd` and dropped `npm` entirely. This is not
hypothetical and not new — it affects **shipping verbs today**, and a valueless flag was
expressible only as the last token on the line.

The failure is **silent**, which is the part that costs. `arg.cwd=--cmd` is not an error anywhere:
the server receives a well-formed request carrying a nonsense value and answers with a validation
message about `--cwd`, which sends the next person debugging it to the verb's own table rather than
to the shim. That is the `misleading-error-messages` class this repo has already paid for.

## The fix

The `--*` branch now **peeks** before consuming, and a `--*=*` branch is added ahead of it:

- `--flag value` — unchanged.
- `--flag=value` — **new**, split on the first `=` so the value may contain more. This is the only
  way to pass a value that itself starts with `--` (`open-terminal --cmd=--version`), which was
  previously unexpressible in either direction.
- `--flag` with no value — now legal **anywhere** on the line, not only in last position.
- The peek matches `--`, **not** a single `-`, so a negative number (`--scroll -600`) is still
  consumed as a value.

## The regression, stated up front

A value that begins with `--` and is passed as a separate token stops being consumed.
`write --node n1 --text --oops` used to set `arg.text=--oops`; it now sets `arg.text=` plus
`arg.oops=`. **The escape is `--text=--oops`.** Both halves are pinned by tests so neither drifts,
and the rule is in the SKILL.md body, the codex/gemini instructions block, `docs/ssh-agent-skills.md`
and `CLAUDE.md`.

Swept for existing callers that would change meaning: none. No caller in the repo (skill text,
instruction block, `docs/`, `README.md`, `CLAUDE.md`, `verifyPanel.ts`'s generated command lines,
test fixtures) passes a value beginning with `--`. The shim has no `--help` of its own — the SKILL
body and the instructions block are its documentation, and both were updated. The context-link
twin (`src/core/context-link-core.ts`) has the same loop shape but a single recognised flag
(`--node`/`-n`) whose value is a node id, so it cannot exhibit the swallow; it is left alone.

## Why `browser` (PR 7-9) will still take a value on every flag anyway

The shim is rewritten to disk locally at **every app boot**, but onto an SSH host **only inside
`RemoteHooks.setup()`, i.e. on connect**. An already-connected SSH project keeps the shim it was
handed, so this improvement reaches remote agent nodes only after a reconnect — with no signal on
the wire, the same stale window the managed hook script has. A verb whose parsing *depended* on
this fix would work on the desktop and silently misparse on a remote agent node until the user
reconnected. So verbs stay designed to parse identically under both loops (every flag takes a
value), and this fix is an independent improvement rather than a prerequisite — which is why it
ships first and alone. That lifecycle is now recorded in the shim's own doc comment.

## How it is proven — real `sh`, real script, fake `curl`

Two parsers stand between an agent's command line and a verb's args, and both are tested:

1. `src/main/control-shim-parse.test.ts` (new) runs the **real `CONTROL_SHIM_SCRIPT` under real
   `sh`** with a **fake `curl` first on `PATH`** that records its argv, and asserts the
   `arg.<name>=<value>` pairs the loop produced. No TypeScript re-implementation of the loop — the
   bug *is* the gap between what the loop does and what everyone believes it does.
   (The fake curl logs argv to a **file**: the shim captures curl's stdout in a command
   substitution to read `-w '%{http_code}'`, so a fake that printed argv on stdout would poison
   `nt_code` and fail every case for an unrelated reason.)
2. `src/main/canvas-control-shim.test.ts` (extended) drives the same real shim against the **real
   hook server** and asserts what **`parseControlBody`** made of it — the pair end to end. A flag
   can survive the shim and still be dropped by the reader; `arg.<name>` with an empty value is
   exactly the shape that would be plausible to discard.

## Mutation results

**4 introduced, 3 caught, 1 proven equivalent** (Task 1.2), plus **2/2 caught** for the
documentation assertions (Task 1.3).

| # | Mutation | Result |
| --- | --- | --- |
| a | Delete the `--*=*` branch entirely | **caught** — 7 failed / 39 passed |
| b | Peek on `-*` instead of `--*` (breaks `--scroll -600`) | **caught** — 2 failed / 44 passed |
| c | Restore the unconditional consume (the original bug) | **caught** — 5 failed / 41 passed |
| d | Split `--flag=value` on the **last** `=` instead of the first | **not caught — equivalent mutant** |
| e | Drop the flag-syntax rule from the codex/gemini instructions block | **caught** — 1 failed / 21 passed |
| f | Drop the flag-syntax rule from the SKILL.md body | **caught** — 1 failed / 21 passed |

On (d): it is not a test gap. The shim emits `arg.$nt_k=$nt_v`, and `nt_k + "=" + nt_v`
reconstructs the original token identically under either split, because **curl** is what finally
splits the `--data-urlencode` argument — and curl splits on the first `=`. The first-`=` split in
the shim is therefore the readable spelling of a behaviour curl enforces regardless. The behaviour
the comment claims (`--cmd=env A=1 B="2 3"` arrives as one value with its `=` signs intact) *is*
asserted end to end through `parseControlBody`, and mutation (a) kills it.

## Tests

- `src/main/control-shim-parse.test.ts` — 11 new cases (4 of them green before the fix: the
  regression net).
- `src/main/canvas-control-shim.test.ts` — 5 new cases through the real server.
- `src/main/canvas-control-core.test.ts` — 2 new cases on the agent-facing texts.
- Red-then-green was recorded: 10 failing before the fix commit, all green after.
- `npm run typecheck` clean. Full `npx vitest run`: **5824 passed, 4 failed, 12 skipped
  (437 files)** — the 4 are the known environmental ones on this host (3 × `node-pty-patch`,
  1 × `webgl-addon-pair`), identical at `origin/main`.

## Surfaces

- **Desktop (Electron)** — installs this string at every boot; the fix is live on next launch.
- **Server Edition** — installs the same shim string and the same skill/instruction text. Note
  `/control/*` has **no handler** there (`src/server/index.ts` never calls `setControlHandler`), so
  every verb still falls through to `hook-server.ts`'s generic `control unavailable`; naming that
  refusal is PR 2's Task 2.4, not this PR. The shim text is shared regardless, which is why the
  change is in `src/main/canvas-control-core.ts` only and not duplicated per shell.
- **Mobile** — N/A, the phone never runs the shim (it drives canvas control over relay → IPC).

No credential moved to argv: `HOOK_CURL_HEADERS_SH` and both `curl --config -` call sites are
untouched, and `canvas-control-shim.test.ts`'s argv-leak suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
