### PR TITLE
fix(control): strict verbs bypass the escape hatch, and two webview guards

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -484,7 +484,13 @@ Consequences worth knowing:
 
 - The SDK **chat node** is still **deferred** — it is not wired into the server bridge.
 - **Canvas-control** (`agent:control`, the Claude-only `nodeterm` CLI verbs) is **not
-  wired** over the server.
+  wired** over the server, and since the strict-verb work it says so **by name**:
+  `/control/<verb>` answers HTTP 400 with `error: control-unsupported-on-this-edition`
+  and a sentence containing the literal *"do not retry"*. The old generic
+  `control unavailable` read to an agent like a transient outage, and an agent retries an
+  outage. `browser` additionally names why it is **structural** rather than unimplemented —
+  a browser node on this edition renders in the **viewer's own** browser tab, which this
+  server has no debugger for, and never can. See `src/server/control-unsupported.ts`.
 - The **`ptyDestroy` tail-teardown** — *resolved in Phase 3c.* Phase 3b left this skipped
   (agent tails self-cleared only on `SessionEnd`, so a node closed *without* one left an
   idle file-tail); the server now untracks agent tails on node close, at desktop parity.
@@ -510,7 +516,8 @@ desktop parity on agent-tail cleanup and first-connect behavior:
   and the app reloads on reopen, so first-load failure now behaves like a mid-session drop.
 
 **Still deferred** (unchanged from Phase 3b): the SDK **chat node**, **canvas-control**
-(`agent:control` / the `nodeterm` CLI verbs), full **two-master flow-control coordination**
+(`agent:control` / the `nodeterm` CLI verbs — now a *named, non-retryable* refusal rather
+than a generic failure, see above), full **two-master flow-control coordination**
 (the server still re-asserts its WS backpressure pause on each send rather than co-managing
 a single actuator with the renderer), and the web folder picker's **hardcoded start
 directory**.

--- a/docs/node-identity.md
+++ b/docs/node-identity.md
@@ -295,6 +295,12 @@ around. Anyone who can set the header can present an unjudgeable one, and the ap
 it takes to set the header. So: the latch is a good bug-catcher and worth keeping; it is not a
 boundary, and neither is the dated cutoff (the same probe walks past both).
 
+**The one place the probe stops.** A verb in `STRICT_CONTROL_VERBS` admits `verified` and nothing
+else, so a foreign kid — `legacy` by invariant 3 — is refused there with a flat sentence and no
+diagnosis. That is the only route in this document where the invented-kid escape does not apply, and
+it is affordable exactly because those verbs are new: there is no legacy population to strand, so
+nothing has to fail open. It buys nothing for the routes above, which keep the posture they have.
+
 **The real hardening, if it is ever wanted.** Scope the remote token dir as
 `node-tokens/<kid>/<nodeId>` (already sketched in `writeNodeTokens`' own doc comment). The *only*
 scenario the foreign-kid escape exists for is two instances sharing one host account overwriting
@@ -330,7 +336,13 @@ because it is a tri-state:
 | `false` | Not required | Keep the warning window open past the date **and** release the latch. |
 
 `false` is for a user whose upgrade strands a live session: it gets the canvas back without
-downgrading the app. Neither value ever admits a `forged` token. Both shells wire it as a **live
+downgrading the app. Neither value ever admits a `forged` token, and neither releases a verb in
+**`STRICT_CONTROL_VERBS`** (today: `browser`) — that bucket is decided one line below the `forged`
+check, above every branch the hatch or the dated window can reach, and it admits `verified` only.
+The hatch exists to rescue a session that cannot present an identity; it must not double as a grant
+of the one capability where identity *is* the admission control. The cost is named rather than
+hidden: cross-instance failover loses those verbs, because another instance's token is a foreign
+kid and therefore `legacy`. Both shells wire it as a **live
 getter** (`setIdentityStrictOverride`), so a change takes effect on the next request, not the next
 launch — a stranded user must not have to restart the thing that is already broken.
 

--- a/docs/node-identity.md
+++ b/docs/node-identity.md
@@ -295,11 +295,14 @@ around. Anyone who can set the header can present an unjudgeable one, and the ap
 it takes to set the header. So: the latch is a good bug-catcher and worth keeping; it is not a
 boundary, and neither is the dated cutoff (the same probe walks past both).
 
-**The one place the probe stops.** A verb in `STRICT_CONTROL_VERBS` admits `verified` and nothing
-else, so a foreign kid — `legacy` by invariant 3 — is refused there with a flat sentence and no
-diagnosis. That is the only route in this document where the invented-kid escape does not apply, and
-it is affordable exactly because those verbs are new: there is no legacy population to strand, so
-nothing has to fail open. It buys nothing for the routes above, which keep the posture they have.
+**The one place the probe will stop — once there is anything in it.** A verb in
+`STRICT_CONTROL_VERBS` admits `verified` and nothing else, so a foreign kid — `legacy` by invariant
+3 — is refused there with a flat sentence and no diagnosis. That will be the only route in this
+document where the invented-kid escape does not apply, and it is affordable exactly because the
+verbs it is for are new: no legacy population to strand, so nothing has to fail open. **Today the
+set names a verb that does not exist yet** (see [The escape hatch](#the-escape-hatch)), so this
+changes nothing for any route currently reachable — every claim above still holds in full, and the
+probe still reaches `/control/list` and every `/context-link/*` verb.
 
 **The real hardening, if it is ever wanted.** Scope the remote token dir as
 `node-tokens/<kid>/<nodeId>` (already sketched in `writeNodeTokens`' own doc comment). The *only*
@@ -336,13 +339,29 @@ because it is a tri-state:
 | `false` | Not required | Keep the warning window open past the date **and** release the latch. |
 
 `false` is for a user whose upgrade strands a live session: it gets the canvas back without
-downgrading the app. Neither value ever admits a `forged` token, and neither releases a verb in
-**`STRICT_CONTROL_VERBS`** (today: `browser`) — that bucket is decided one line below the `forged`
-check, above every branch the hatch or the dated window can reach, and it admits `verified` only.
-The hatch exists to rescue a session that cannot present an identity; it must not double as a grant
-of the one capability where identity *is* the admission control. The cost is named rather than
-hidden: cross-instance failover loses those verbs, because another instance's token is a foreign
-kid and therefore `legacy`. Both shells wire it as a **live
+downgrading the app. Neither value ever admits a `forged` token.
+
+Neither releases a verb in **`STRICT_CONTROL_VERBS`** either — but **that set is pre-positioned and
+gates nothing today, and nobody's hatch has narrowed.** It contains one name, `browser`, which is
+**not a verb this app has**: `ControlVerb` lists 24 and the browser one is `open-browser`, which is
+deliberately *not* in the set. Measured over the real verb list, the set of verbs the hatch stops
+releasing is empty. What exists now is the ORDERING: the bucket is decided one line below the
+`forged` check, above every branch the hatch or the dated window can reach, and it admits `verified`
+only — so the verb it is for cannot arrive through the `override === false` branch, which returns
+`allow-with-warning` for every non-tolerant verb. The user-visible change begins in the PR that
+creates the verb, not here.
+
+`open-browser` stays out on purpose, and the distinction is worth stating because the sentence above
+says "browser": **opening a node is not driving one.** The threat is an agent acting inside a page
+the user is logged into (cookies, typing, script); `open-browser` only creates the surface and
+navigates it, like `show-web`. It is also a shipped verb with a live legacy population, and a strict
+gate would leave a pre-token session — or an SSH host whose project has not reconnected — unable to
+open a browser node with no way back, since the hatch by design cannot reach into this bucket. The
+residual is named rather than hidden: an unverified caller can open a node onto a logged-in page and
+the page's title then shows up in `list`. That is `list`'s tolerance, unchanged by this bucket.
+
+The cost, when the verb does land: cross-instance failover loses it, because another instance's
+token is a foreign kid and therefore `legacy`. Both shells wire it as a **live
 getter** (`setIdentityStrictOverride`), so a change takes effect on the next request, not the next
 launch — a stranded user must not have to restart the thing that is already broken.
 

--- a/src/core/agents/hook-identity-enforcement.test.ts
+++ b/src/core/agents/hook-identity-enforcement.test.ts
@@ -26,6 +26,8 @@ import {
   IDENTITY_UNMINTABLE_NOTE,
   IDENTITY_UNMINTABLE_WARN_NOTE,
   NODE_IDENTITY_STRICT_AFTER,
+  STRICT_CONTROL_REFUSAL,
+  STRICT_CONTROL_VERBS,
   TOLERANT_CONTROL_VERBS
 } from './node-identity-policy'
 import { CONTEXT_LINK_VERBS } from '../context-link-render'
@@ -654,5 +656,124 @@ describe('the injected clock', () => {
     expect((await control('open-terminal', 'n-edge')).status).toBe(200)
     hookServer.setIdentityClockForTests(() => new Date(NODE_IDENTITY_STRICT_AFTER.getTime()))
     expect((await control('open-terminal', 'n-edge2')).status).toBe(403)
+  })
+})
+
+/**
+ * The strict bucket, proven on the wire rather than only in `controlPolicy`'s table.
+ *
+ * `browser` is the first verb whose admission control IS the identity, so the two escapes this
+ * file documents elsewhere — the dated window and `hookIdentityStrict: false` — must both stop at
+ * it, and the third (an invented kid, which walks past the latch into /control/list) must stop too.
+ * "Refused" here means the handler never ran, not that the reply looked unhappy.
+ */
+describe('/control/<strict verb> admits only a verified caller', () => {
+  const STRICT = 'browser'
+  // Same shape as the invented kid above: eight arbitrary characters, a dot, an arbitrary tail.
+  const INVENTED = 'CCCCCCCC.DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD'
+
+  it('is in the strict bucket and not in the tolerant one', () => {
+    expect(STRICT_CONTROL_VERBS.has(STRICT)).toBe(true)
+    expect(TOLERANT_CONTROL_VERBS.has(STRICT)).toBe(false)
+  })
+
+  it('refuses a tokenless caller INSIDE the warning window', async () => {
+    // Every other mutation still executes here until 2026-10-13. This one never did.
+    const res = await control(STRICT, 'n-strict-window')
+    expect(res.status).toBe(403)
+    expect(await res.text()).toBe(`${STRICT_CONTROL_REFUSAL}\n`)
+    expect(controlCalls).toEqual([])
+  })
+
+  it('refuses even with the escape hatch OFF — the hatch must not double as a grant', async () => {
+    // settings.hookIdentityStrict:false is what docs/node-identity.md tells a stranded user to
+    // reach for. Before the bucket it returned allow-with-warning for every non-tolerant verb, so
+    // it handed browser control to any holder of the app-wide bearer, permanently.
+    hookServer.setIdentityStrictOverride(() => false)
+    const res = await control(STRICT, 'n-strict-hatch')
+    expect(res.status).toBe(403)
+    expect(await res.text()).toBe(`${STRICT_CONTROL_REFUSAL}\n`)
+    expect(controlCalls).toEqual([])
+    // …while the hatch keeps doing its actual job for an ordinary mutation past the cutoff.
+    hookServer.setIdentityClockForTests(() => PAST_CUTOFF)
+    const ordinary = await control('open-terminal', 'n-hatch-ordinary')
+    expect(ordinary.status).toBe(200)
+    expect(controlCalls).toEqual([{ verb: 'open-terminal', nodeId: 'n-hatch-ordinary' }])
+  })
+
+  it('lets a VERIFIED caller through, on both sides of the cutoff and with any hatch setting', async () => {
+    for (const clock of [IN_WINDOW, PAST_CUTOFF]) {
+      for (const override of [undefined, true, false] as const) {
+        controlCalls = []
+        hookServer.setIdentityClockForTests(() => clock)
+        hookServer.setIdentityStrictOverride(() => override)
+        const node = `n-strict-ok-${clock.getTime()}-${String(override)}`
+        const res = await control(STRICT, node, nodeAuthToken(SECRET, node))
+        expect(res.status, node).toBe(200)
+        expect(controlCalls, node).toEqual([{ verb: STRICT, nodeId: node }])
+      }
+    }
+  })
+
+  it('403s a forged token, as everywhere else', async () => {
+    const res = await control(STRICT, 'n-strict-forged', nodeAuthToken(SECRET, 'somebody-else'))
+    expect(res.status).toBe(403)
+    expect(controlCalls).toEqual([])
+  })
+
+  it('the invented-kid escape does NOT reach a strict verb', async () => {
+    // docs/node-identity.md and the test above pin that an invented kid walks past the latch and
+    // the cutoff into /control/list and every /context-link/* verb, because a FOREIGN kid must be
+    // `legacy` (invariant 3) and `legacy` is admitted there. Here `legacy` is a refusal — one of
+    // the very few routes where that escape does not apply. Stated because the surrounding doc's
+    // honest pessimism would otherwise be read as covering this verb too.
+    const res = await control(STRICT, 'n-strict-invented', INVENTED)
+    expect(res.status).toBe(403)
+    expect(await res.text()).toBe(`${STRICT_CONTROL_REFUSAL}\n`)
+    expect(controlCalls).toEqual([])
+    // The contrast, in one test: the SAME token, the same instant, on a tolerant verb.
+    const list = await control('list', 'n-strict-invented', INVENTED)
+    expect(list.status).toBe(200)
+    expect(controlCalls).toEqual([{ verb: 'list', nodeId: 'n-strict-invented' }])
+  })
+
+  it('answers a JSON caller with the same sentence in the same shape', async () => {
+    const res = await control(STRICT, 'n-strict-json', undefined, 'application/json')
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ ok: false, error: STRICT_CONTROL_REFUSAL })
+    expect(controlCalls).toEqual([])
+  })
+
+  it('says nothing about tokens, kids or restarts — not even to an unmintable node', async () => {
+    // An id `isSafeNodeId` refuses normally earns IDENTITY_UNMINTABLE_NOTE, which names the cause
+    // and the escape hatch. On a strict verb that sentence would be both an instruction that
+    // cannot help (the hatch does not release this) and a map for whoever is probing.
+    const res = await control(STRICT, '../etc')
+    expect(res.status).toBe(403)
+    const body = await res.text()
+    expect(body).toBe(`${STRICT_CONTROL_REFUSAL}\n`)
+    expect(body).not.toContain(IDENTITY_UNMINTABLE_NOTE)
+    expect(body).not.toContain(IDENTITY_REFUSED_NOTE)
+    expect(controlCalls).toEqual([])
+  })
+
+  it('leaves every other verb on its old table — window, hatch and tolerance all intact', async () => {
+    // The regression net for the bucket being a THIRD branch rather than a re-shaping.
+    const inWindow = await control('open-terminal', 'n-unchanged-window')
+    expect(inWindow.status).toBe(200)
+    expect((await inWindow.text()).startsWith(IDENTITY_RESTART_NOTE)).toBe(true)
+
+    hookServer.setIdentityClockForTests(() => PAST_CUTOFF)
+    expect((await control('open-terminal', 'n-unchanged-cutoff')).status).toBe(403)
+    expect((await control('list', 'n-unchanged-list')).status).toBe(200)
+
+    hookServer.setIdentityStrictOverride(() => false)
+    expect((await control('open-terminal', 'n-unchanged-hatch')).status).toBe(200)
+
+    expect(controlCalls).toEqual([
+      { verb: 'open-terminal', nodeId: 'n-unchanged-window' },
+      { verb: 'list', nodeId: 'n-unchanged-list' },
+      { verb: 'open-terminal', nodeId: 'n-unchanged-hatch' }
+    ])
   })
 })

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -472,9 +472,13 @@ class HookServer {
           // The POSIX-sh shim asks for text/plain: it has no JSON parser, so the server does the
           // rendering the Node CLI used to do client-side. Everything else keeps the JSON shape.
           if (wantsText) {
+            // A FAILURE may now carry both: `error` is the machine-readable name a JSON client
+            // keys on, `message` the sentence a human (or a language model) reads. The text
+            // dialect has no fields, so it prefers the sentence and falls back to the name — which
+            // is what every existing handler still sends, so this is inert for all of them.
             const text = result.ok
               ? result.message ?? JSON.stringify(result.result ?? {})
-              : result.error ?? 'control request failed'
+              : result.message ?? result.error ?? 'control request failed'
             res.writeHead(result.ok ? 200 : 400, { 'content-type': 'text/plain; charset=utf-8' })
             res.end(note ? `${note}\n${text}\n` : `${text}\n`)
             return

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -17,6 +17,8 @@ import {
   IDENTITY_RESTART_NOTE,
   IDENTITY_UNMINTABLE_NOTE,
   IDENTITY_UNMINTABLE_WARN_NOTE,
+  STRICT_CONTROL_REFUSAL,
+  STRICT_CONTROL_VERBS,
   type IdentityDecision
 } from './node-identity-policy'
 
@@ -444,7 +446,14 @@ class HookServer {
             // Which sentence: a node in a case-folding collision group, or with an id
             // `isSafeNodeId` refuses, can NEVER pick up an identity, and telling it to restart is
             // an instruction to loop forever. See `identityRefusalNote`.
-            const note = this.identityRefusalNote(nodeId)
+            //
+            // A STRICT verb answers with its own flat sentence instead: those refusals are not a
+            // rollout accident to be talked through, they are the designed state for anything but
+            // a verified caller, and naming tokens or restarts there is advice to whoever is
+            // probing. See STRICT_CONTROL_VERBS.
+            const note = STRICT_CONTROL_VERBS.has(verb)
+              ? STRICT_CONTROL_REFUSAL
+              : this.identityRefusalNote(nodeId)
             if (wantsText) {
               res.writeHead(403, { 'content-type': 'text/plain; charset=utf-8' })
               res.end(`${note}\n`)

--- a/src/core/agents/node-identity-policy.test.ts
+++ b/src/core/agents/node-identity-policy.test.ts
@@ -10,6 +10,8 @@ import {
   isStrictInstant,
   NODE_IDENTITY_CLOCK_HORIZON_MS,
   NODE_IDENTITY_STRICT_AFTER,
+  STRICT_CONTROL_REFUSAL,
+  STRICT_CONTROL_VERBS,
   TOLERANT_CONTROL_VERBS
 } from './node-identity-policy'
 import { NODE_IDENTITY_STRICT_DATE } from '@shared/node-identity'
@@ -232,5 +234,74 @@ describe('controlPolicy', () => {
         controlPolicy({ verdict: 'forged', proven: false, verb: TOLERANT, now: BEFORE, override: false })
       ).toBe('refuse')
     })
+  })
+})
+
+// The third bucket. Everything above this line is the two-move rollout for verbs that already had
+// a population; this is the posture for a verb that never did.
+describe('STRICT_CONTROL_VERBS admits `verified` and nothing else', () => {
+  const STRICT = 'browser'
+
+  for (const now of [BEFORE, AFTER]) {
+    for (const override of [undefined, true, false] as const) {
+      for (const proven of [true, false]) {
+        const where = `now=${now.toISOString()} override=${override} proven=${proven}`
+        it(`verified ⇒ allow (${where})`, () => {
+          expect(controlPolicy({ verdict: 'verified', proven, verb: STRICT, now, override })).toBe(
+            'allow'
+          )
+        })
+        for (const verdict of ['legacy', 'forged'] as const) {
+          it(`${verdict} ⇒ refuse (${where})`, () => {
+            expect(controlPolicy({ verdict, proven, verb: STRICT, now, override })).toBe('refuse')
+          })
+        }
+      }
+    }
+  }
+
+  it('the escape hatch does NOT release it — this is the whole point of the bucket', () => {
+    // settings.hookIdentityStrict:false is the switch docs/node-identity.md tells a stranded user
+    // to reach for. It releases the latch and the dated cutoff. It must not release this.
+    expect(
+      controlPolicy({ verdict: 'legacy', proven: false, verb: STRICT, now: BEFORE, override: false })
+    ).toBe('refuse')
+  })
+
+  it('the dated window does not release it either — refused from day one, not from the cutoff', () => {
+    // A tokenless caller would otherwise have driven a browser for the whole warning window.
+    expect(
+      controlPolicy({ verdict: 'legacy', proven: false, verb: STRICT, now: BEFORE, override: undefined })
+    ).toBe('refuse')
+  })
+
+  it('a strict verb is in NEITHER tolerant path, ever', () => {
+    expect(TOLERANT_CONTROL_VERBS.has(STRICT)).toBe(false)
+    expect(STRICT_CONTROL_VERBS.has(STRICT)).toBe(true)
+    expect([...STRICT_CONTROL_VERBS].some((v) => TOLERANT_CONTROL_VERBS.has(v))).toBe(false)
+  })
+
+  it('leaves every other verb exactly as it was', () => {
+    // The regression net: the bucket is a THIRD branch, not a re-shaping of the other two.
+    expect(
+      controlPolicy({ verdict: 'legacy', proven: false, verb: TOLERANT, now: AFTER, override: undefined })
+    ).toBe('allow')
+    expect(
+      controlPolicy({ verdict: 'legacy', proven: false, verb: MUTATION, now: BEFORE, override: undefined })
+    ).toBe('allow-with-warning')
+    expect(
+      controlPolicy({ verdict: 'legacy', proven: false, verb: MUTATION, now: AFTER, override: undefined })
+    ).toBe('refuse')
+    expect(
+      controlPolicy({ verdict: 'legacy', proven: true, verb: MUTATION, now: AFTER, override: false })
+    ).toBe('allow-with-warning')
+  })
+
+  it('says one sentence and diagnoses nothing — advice here is advice to whoever is probing', () => {
+    expect(STRICT_CONTROL_REFUSAL).toBe('Browser control refused.')
+    expect(STRICT_CONTROL_REFUSAL).not.toContain('\n')
+    for (const leak of ['token', 'kid', 'Restart', 'identity']) {
+      expect(STRICT_CONTROL_REFUSAL).not.toContain(leak)
+    }
   })
 })

--- a/src/core/agents/node-identity-policy.ts
+++ b/src/core/agents/node-identity-policy.ts
@@ -181,6 +181,38 @@ export const IDENTITY_UNMINTABLE_WARN_NOTE =
 export const TOLERANT_CONTROL_VERBS = new Set(['list'])
 
 /**
+ * Control verbs that admit ONLY a `verified` caller — no window, no latch, no override.
+ *
+ * `browser` is the whole bucket. It is a route through which an agent acts as the user on the
+ * internet, inside a session jar that may hold real logins, and it is NEW — so unlike every verb
+ * the two-move rollout was built for, there is no legacy population to strand and nothing to fail
+ * open FOR. Same posture `/codex-thread/{start,bind}` already holds, for the same reason.
+ *
+ * Checked BEFORE the `override === false` branch, deliberately. That branch returns
+ * `allow-with-warning` for any non-tolerant verb, so `settings.hookIdentityStrict: false` — the
+ * switch docs/node-identity.md tells a stranded user to reach for — would otherwise hand browser
+ * control to any holder of the app-wide bearer, permanently. The escape hatch exists to rescue a
+ * session that cannot present an identity; it must not double as a grant of the one capability
+ * where identity is the entire admission control.
+ *
+ * WHAT IT BUYS, precisely: an invented `kid` is a FOREIGN kid, which invariant 3 requires to be
+ * `legacy` (or cross-instance failover dies), so it walks past the latch and the cutoff into
+ * /control/list and every /context-link/* read. Here `legacy` is a refusal, so that probe fails.
+ *
+ * WHAT IT COSTS: cross-instance failover loses browser control. A second instance's token is a
+ * foreign kid, therefore `legacy`, therefore refused. Accepted. A verb must NEVER be moved from
+ * here into TOLERANT_CONTROL_VERBS.
+ */
+export const STRICT_CONTROL_VERBS: ReadonlySet<string> = new Set(['browser'])
+
+/**
+ * The refusal for a strict verb: one sentence, no diagnosis, no hint about tokens or kids.
+ * Advice here is advice to an attacker and a lie to nobody else — the doc's own phrasing for the
+ * `forged` case, applied to the whole non-`verified` set.
+ */
+export const STRICT_CONTROL_REFUSAL = 'Browser control refused.'
+
+/**
  * The verb `/context-link/*` presents to `controlPolicy`.
  *
  * Every context-link verb is a READ — the route hands back a rendered transcript, summary or
@@ -225,7 +257,9 @@ export interface ControlPolicyInput {
  *
  * `override === false` is the escape hatch: it releases the LATCH as well as the cutoff, because
  * the latch is the likelier of the two to have stranded a user whose upgrade went wrong, and a
- * hatch that does not rescue them is not a hatch. It never releases `forged`.
+ * hatch that does not rescue them is not a hatch. It never releases `forged`, and it never
+ * releases a verb in `STRICT_CONTROL_VERBS` — that bucket is decided one line below `forged`,
+ * above every branch the hatch can reach.
  */
 export function controlPolicy({
   verdict,
@@ -235,6 +269,8 @@ export function controlPolicy({
   override
 }: ControlPolicyInput): IdentityDecision {
   if (verdict === 'forged') return 'refuse'
+  // BEFORE the override and BEFORE the dated window — see STRICT_CONTROL_VERBS.
+  if (STRICT_CONTROL_VERBS.has(verb)) return verdict === 'verified' ? 'allow' : 'refuse'
   if (verdict === 'verified') return 'allow'
   if (override === false) {
     return TOLERANT_CONTROL_VERBS.has(verb) ? 'allow' : 'allow-with-warning'

--- a/src/core/agents/node-identity-policy.ts
+++ b/src/core/agents/node-identity-policy.ts
@@ -183,10 +183,37 @@ export const TOLERANT_CONTROL_VERBS = new Set(['list'])
 /**
  * Control verbs that admit ONLY a `verified` caller — no window, no latch, no override.
  *
- * `browser` is the whole bucket. It is a route through which an agent acts as the user on the
- * internet, inside a session jar that may hold real logins, and it is NEW — so unlike every verb
- * the two-move rollout was built for, there is no legacy population to strand and nothing to fail
- * open FOR. Same posture `/codex-thread/{start,bind}` already holds, for the same reason.
+ * ⚠ **PRE-POSITIONED, AND INERT TODAY.** `browser` is the whole bucket, and `browser` is **not a
+ * verb this app has**: `ControlVerb` (`src/main/canvas-control-core.ts`) lists 24 and the browser
+ * one is `open-browser`, which is deliberately NOT in here (see below). So measured over the real
+ * verb list, this set changes nothing for anybody: no request that succeeds today starts failing,
+ * and `hookIdentityStrict: false` releases exactly what it released before. What it does is make
+ * the ordering correct BEFORE the verb exists, so the verb cannot arrive through the hole. The
+ * hole was real — the `override === false` branch below returns `allow-with-warning` for every
+ * non-tolerant verb — and a route that acts as the user on the internet must not be the thing that
+ * discovers it.
+ *
+ * The verb it is for is a route through which an agent acts as the user on the internet, inside a
+ * session jar that may hold real logins, and it is NEW — so unlike every verb the two-move rollout
+ * was built for, there is no legacy population to strand and nothing to fail open FOR. Same posture
+ * `/codex-thread/{start,bind}` already holds, for the same reason.
+ *
+ * **Why `open-browser` is NOT in here, deliberately.** OPENING a node is not DRIVING one. The
+ * threat this bucket answers is an agent acting *inside* a page the user is logged into — reading
+ * cookies, typing, evaluating script; `open-browser` only creates the surface and navigates it to
+ * a URL the caller supplied, which is the same class of act as `show-web`. And it is a SHIPPED
+ * verb with a live legacy population: adding it would mean an agent session that has not picked up
+ * a token (a pre-token tmux session, or an SSH host whose project has not reconnected) loses the
+ * ability to open a browser node with no way back — the hatch cannot rescue it, because the whole
+ * point of this bucket is that the hatch does not reach it. That is precisely the stranding the
+ * dated window exists to prevent, paid to defend a surface that holds nothing yet. The residual is
+ * named rather than hidden: an unverified caller can open a node onto a logged-in page, and the
+ * page's TITLE then appears in `list`. That leak belongs to `list`'s tolerance, is unchanged by
+ * this file, and is the pre-existing trade documented on TOLERANT_CONTROL_VERBS.
+ *
+ * So: this doc comment claims a gate on DRIVING a browser, never on opening one. When the real
+ * verb lands it joins this set in the PR that creates it, and that PR — not this one — is where a
+ * user-visible behaviour change begins.
  *
  * Checked BEFORE the `override === false` branch, deliberately. That branch returns
  * `allow-with-warning` for any non-tolerant verb, so `settings.hookIdentityStrict: false` — the

--- a/src/main/browser-guest-registry.test.ts
+++ b/src/main/browser-guest-registry.test.ts
@@ -1,0 +1,130 @@
+// The guard main did not have: `browserGuests` stored whatever integer arrived over IPC. Every
+// case below is a renderer-supplied value, because the renderer is the attackable half of this
+// boundary — a compromised or merely buggy one must not be able to nominate the app's own window.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  browserDiscardedMessage,
+  registerBrowserGuest,
+  type BrowserGuest,
+  type BrowserSurfaceKind
+} from './browser-guest-registry'
+
+const lookup =
+  (types: Record<number, string>) =>
+  (id: number): { getType: () => string } | null =>
+    types[id] ? { getType: () => types[id] } : null
+
+describe('registerBrowserGuest', () => {
+  it('stores a real webview guest', () => {
+    const m = new Map<number, BrowserGuest>()
+    expect(registerBrowserGuest(m, 7, 'browser-1', 'canvas', lookup({ 7: 'webview' }))).toBe(true)
+    expect(m.get(7)).toEqual({ nodeId: 'browser-1', surface: 'canvas' })
+  })
+
+  it('REFUSES an id naming the app window — this is the escalation the guard exists for', () => {
+    const m = new Map<number, BrowserGuest>()
+    expect(registerBrowserGuest(m, 1, 'browser-1', 'canvas', lookup({ 1: 'window' }))).toBe(false)
+    expect(m.size).toBe(0)
+  })
+
+  it('refuses every non-webview type Electron can hand back, not just `window`', () => {
+    const m = new Map<number, BrowserGuest>()
+    for (const type of ['window', 'browserView', 'remote', 'backgroundPage', 'offscreen']) {
+      expect(registerBrowserGuest(m, 5, 'browser-1', 'canvas', lookup({ 5: type })), type).toBe(
+        false
+      )
+    }
+    expect(m.size).toBe(0)
+  })
+
+  it('refuses an id that names nothing at all', () => {
+    const m = new Map<number, BrowserGuest>()
+    expect(registerBrowserGuest(m, 99, 'browser-1', 'canvas', lookup({}))).toBe(false)
+    expect(m.size).toBe(0)
+  })
+
+  it('refuses a lookup that throws — a destroyed id is not a guest', () => {
+    const m = new Map<number, BrowserGuest>()
+    const throwing = (): never => {
+      throw new Error('Object has been destroyed')
+    }
+    expect(registerBrowserGuest(m, 7, 'browser-1', 'canvas', throwing)).toBe(false)
+    expect(m.size).toBe(0)
+  })
+
+  it('refuses an id that is not a positive integer, before it ever reaches the lookup', () => {
+    const m = new Map<number, BrowserGuest>()
+    // A lookup that would happily call ANYTHING a webview: the id guard is the only thing under
+    // test here, so nothing else may be doing the refusing.
+    let lookups = 0
+    const anything = (): { getType: () => string } => {
+      lookups += 1
+      return { getType: () => 'webview' }
+    }
+    for (const id of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(registerBrowserGuest(m, id, 'browser-1', 'canvas', anything), `${id}`).toBe(false)
+    }
+    expect(m.size).toBe(0)
+    expect(lookups).toBe(0)
+  })
+
+  it('refuses a node id `isSafeNodeId` refuses — it is a map key and, later, a storage key', () => {
+    const m = new Map<number, BrowserGuest>()
+    for (const bad of ['../etc', '', '.', '..', 'a/b', 'a b', 'x'.repeat(200)]) {
+      expect(registerBrowserGuest(m, 7, bad, 'canvas', lookup({ 7: 'webview' })), bad).toBe(false)
+    }
+    expect(m.size).toBe(0)
+  })
+
+  it('refuses an unknown surface value', () => {
+    const m = new Map<number, BrowserGuest>()
+    // The renderer is the more attackable half; `surface` is what selects a debugger target later.
+    for (const bad of ['modal ', 'CANVAS', '', undefined, null, 1]) {
+      expect(
+        registerBrowserGuest(m, 7, 'browser-1', bad as unknown as BrowserSurfaceKind, lookup({ 7: 'webview' })),
+        String(bad)
+      ).toBe(false)
+    }
+    expect(m.size).toBe(0)
+  })
+
+  it('accepts the modal surface, and keeps both of a node`s guests apart', () => {
+    const m = new Map<number, BrowserGuest>()
+    expect(registerBrowserGuest(m, 11, 'browser-3', 'modal', lookup({ 11: 'webview' }))).toBe(true)
+    expect(registerBrowserGuest(m, 12, 'browser-3', 'canvas', lookup({ 12: 'webview' }))).toBe(true)
+    expect(m.get(11)).toEqual({ nodeId: 'browser-3', surface: 'modal' })
+    expect(m.get(12)).toEqual({ nodeId: 'browser-3', surface: 'canvas' })
+  })
+})
+
+describe('browserDiscardedMessage', () => {
+  it('names the memory saver rather than reading as a permissions failure', () => {
+    const msg = browserDiscardedMessage('browser-3')
+    expect(msg).toContain('browser-3')
+    expect(msg).toContain('memory')
+    // The rule it exists for: never blame permissions for a lifecycle event. "not drivable" would
+    // send the next debugger to the identity code for a bug in browser-discard-policy.ts.
+    expect(msg).not.toContain('drivable')
+    expect(msg).not.toMatch(/refus|permission|identity|token/i)
+    // It also has to say what to DO — a message with no way out is a dead end for the agent.
+    expect(msg).toContain('bring it on screen')
+    // Single line: every control reply is rendered as one.
+    expect(msg).not.toContain('\n')
+  })
+})
+
+/**
+ * The guard is only worth anything if it is on the path. `ipcMain.on` cannot be exercised without
+ * Electron, so this one claim — every write to `browserGuests` goes through the guard — is checked
+ * against the source. It is the failure a pure unit test cannot see: a guard nobody calls.
+ */
+describe('the IPC handler is wired through it', () => {
+  it('main never writes to browserGuests directly', () => {
+    const src = readFileSync(resolve(__dirname, 'index.ts'), 'utf8')
+    expect(src).toContain('registerBrowserGuest(browserGuests')
+    // `.set(` anywhere on this map would be a second, unguarded door.
+    expect(src).not.toContain('browserGuests.set(')
+  })
+})

--- a/src/main/browser-guest-registry.test.ts
+++ b/src/main/browser-guest-registry.test.ts
@@ -78,16 +78,29 @@ describe('registerBrowserGuest', () => {
     expect(m.size).toBe(0)
   })
 
-  it('refuses an unknown surface value', () => {
+  it('refuses a surface value that is present and unrecognised', () => {
     const m = new Map<number, BrowserGuest>()
     // The renderer is the more attackable half; `surface` is what selects a debugger target later.
-    for (const bad of ['modal ', 'CANVAS', '', undefined, null, 1]) {
+    for (const bad of ['modal ', 'CANVAS', '', null, 1]) {
       expect(
         registerBrowserGuest(m, 7, 'browser-1', bad as unknown as BrowserSurfaceKind, lookup({ 7: 'webview' })),
         String(bad)
       ).toBe(false)
     }
     expect(m.size).toBe(0)
+  })
+
+  it('records an ABSENT surface as unknown — never as canvas', () => {
+    // Both mount sites still call the 2-argument preload, so this is what every registration in
+    // the app looks like today. Defaulting to 'canvas' would file the kanban modal's guest as a
+    // canvas guest: a false claim, indistinguishable from the real thing, and two 'canvas' entries
+    // for one node id — the exact collision the field exists to prevent.
+    const m = new Map<number, BrowserGuest>()
+    expect(registerBrowserGuest(m, 7, 'browser-1', undefined, lookup({ 7: 'webview' }))).toBe(true)
+    const guest = m.get(7)
+    expect(guest?.nodeId).toBe('browser-1')
+    expect(guest?.surface).toBeUndefined()
+    expect(Object.prototype.hasOwnProperty.call(guest, 'surface')).toBe(false)
   })
 
   it('accepts the modal surface, and keeps both of a node`s guests apart', () => {
@@ -126,5 +139,13 @@ describe('the IPC handler is wired through it', () => {
     expect(src).toContain('registerBrowserGuest(browserGuests')
     // `.set(` anywhere on this map would be a second, unguarded door.
     expect(src).not.toContain('browserGuests.set(')
+  })
+
+  it('passes the surface through, absent and all — no default at the boundary either', () => {
+    // The unit test above pins the registry; this pins the caller. A `surface ?? 'canvas'` here
+    // would reintroduce the false claim one layer up, where no unit test can see it.
+    const src = readFileSync(resolve(__dirname, 'index.ts'), 'utf8')
+    expect(src).toContain('nodeId, surface, (id)')
+    expect(src).not.toMatch(/surface\s*(\?\?|\|\|)/)
   })
 })

--- a/src/main/browser-guest-registry.ts
+++ b/src/main/browser-guest-registry.ts
@@ -1,0 +1,78 @@
+/**
+ * Who is allowed into `browserGuests`, and what the answer is when the page an agent asked for is
+ * gone. The pure half of both, so it is testable without Electron.
+ */
+// `src/main` may import `src/core`; the renderer may not, which is why this predicate will move to
+// `@shared/safe-id` when the capability work needs it renderer-side. One predicate, never a copy.
+import { isSafeNodeId } from '../core/remote-safety'
+
+/**
+ * Which of a node's two possible webviews a registration is.
+ *
+ * One node id can have TWO live guests — the canvas one (`BrowserNode`) and the kanban card modal
+ * one (`CardModal`) — both mounting `BrowserSurface` with the SAME nodeId, so a reverse lookup by
+ * node id picks arbitrarily. The field is recorded here first; threading it from both mount sites
+ * is its own change.
+ */
+export type BrowserSurfaceKind = 'canvas' | 'modal'
+
+export interface BrowserGuest {
+  nodeId: string
+  surface: BrowserSurfaceKind
+}
+
+/** The minimum of Electron's `webContents` this module needs, injected so the guard is testable
+ *  without Electron (`src/main` is not unit-testable against the real module). */
+export type WebContentsLookup = (id: number) => { getType(): string } | null
+
+/**
+ * Record a browser guest, having first proven the renderer told the truth about it.
+ *
+ * WHY THE GUARD: main stored whatever integer the renderer sent. That was harmless while the map
+ * only routed new-window events — and it becomes a privilege escalation the moment the integer
+ * selects a `webContents` whose `.debugger` we attach to, because an unvalidated id can name the
+ * app's own window. Stolen from the external S8 backend (`browser-use-backend.ts`, which checked
+ * `contents.getType() !== 'webview'` before treating a renderer-supplied id as a guest) with credit
+ * to **proteus-dev**; the strongest single idea in that file, and the only part of it kept.
+ *
+ * The node id is validated too: it is a map key here and a lease/partition key later, and it comes
+ * from a canvas built out of git-shared `project.json`.
+ *
+ * Returns whether the registration was accepted, so the caller can say so in the log rather than
+ * failing silently — a refused guest shows up later as a popup that does not open, and there is
+ * nothing else on the wire to explain it.
+ */
+export function registerBrowserGuest(
+  guests: Map<number, BrowserGuest>,
+  webContentsId: number,
+  nodeId: string,
+  surface: BrowserSurfaceKind,
+  lookup: WebContentsLookup
+): boolean {
+  if (!Number.isInteger(webContentsId) || webContentsId <= 0) return false
+  if (!isSafeNodeId(nodeId)) return false
+  if (surface !== 'canvas' && surface !== 'modal') return false
+  // The lookup can throw for a destroyed id (Electron's own accessors do); a guest that cannot be
+  // looked at is not a guest.
+  let contents: { getType(): string } | null = null
+  try {
+    contents = lookup(webContentsId)
+  } catch {
+    return false
+  }
+  if (!contents || contents.getType() !== 'webview') return false
+  guests.set(webContentsId, { nodeId, surface })
+  return true
+}
+
+/**
+ * What to say when a node exists but its page does not, because the memory saver released it.
+ *
+ * NEVER blame permissions for a lifecycle event. A target killed by the hidden-webview discard
+ * reads as a permissions failure if we answer "not drivable", and that sends the next debugger to
+ * the identity code for a bug that lives in `browser-discard-policy.ts`. It names the cause, names
+ * the two ways out, and stays one line (every control reply is single-line by construction).
+ */
+export const browserDiscardedMessage = (id: string): string =>
+  `browser: ${id} was released to save memory while hidden and its page is gone; ` +
+  `bring it on screen or open a new one`

--- a/src/main/browser-guest-registry.ts
+++ b/src/main/browser-guest-registry.ts
@@ -11,14 +11,24 @@ import { isSafeNodeId } from '../core/remote-safety'
  *
  * One node id can have TWO live guests — the canvas one (`BrowserNode`) and the kanban card modal
  * one (`CardModal`) — both mounting `BrowserSurface` with the SAME nodeId, so a reverse lookup by
- * node id picks arbitrarily. The field is recorded here first; threading it from both mount sites
- * is its own change.
+ * node id picks arbitrarily.
  */
 export type BrowserSurfaceKind = 'canvas' | 'modal'
 
 export interface BrowserGuest {
   nodeId: string
-  surface: BrowserSurfaceKind
+  /**
+   * ABSENT until both mount sites are threaded, and absent is the only honest value: neither of
+   * them sends a surface yet, so this field is `undefined` for every registration the app makes
+   * today.
+   *
+   * It is deliberately NOT defaulted to `'canvas'`. Defaulting would record the kanban card
+   * modal's guest as a canvas guest — a positive false claim, indistinguishable from the real
+   * thing, producing two `'canvas'` entries for one node id: exactly the bug the field exists to
+   * prevent. `undefined` is detectable, so a future reverse lookup can refuse to guess. A consumer
+   * must treat it as "unknown", never as "canvas".
+   */
+  surface?: BrowserSurfaceKind
 }
 
 /** The minimum of Electron's `webContents` this module needs, injected so the guard is testable
@@ -46,12 +56,14 @@ export function registerBrowserGuest(
   guests: Map<number, BrowserGuest>,
   webContentsId: number,
   nodeId: string,
-  surface: BrowserSurfaceKind,
+  /** `undefined` = the caller does not know which surface this is; see {@link BrowserGuest.surface}.
+   *  A value that is PRESENT and unrecognised is refused rather than treated as unknown. */
+  surface: BrowserSurfaceKind | undefined,
   lookup: WebContentsLookup
 ): boolean {
   if (!Number.isInteger(webContentsId) || webContentsId <= 0) return false
   if (!isSafeNodeId(nodeId)) return false
-  if (surface !== 'canvas' && surface !== 'modal') return false
+  if (surface !== undefined && surface !== 'canvas' && surface !== 'modal') return false
   // The lookup can throw for a destroyed id (Electron's own accessors do); a guest that cannot be
   // looked at is not a guest.
   let contents: { getType(): string } | null = null
@@ -61,7 +73,10 @@ export function registerBrowserGuest(
     return false
   }
   if (!contents || contents.getType() !== 'webview') return false
-  guests.set(webContentsId, { nodeId, surface })
+  // The key is only written when it is known: an entry with no `surface` says "unknown", an entry
+  // with `surface: undefined` written explicitly says the same thing, and neither ever says
+  // "canvas" on a guess.
+  guests.set(webContentsId, surface === undefined ? { nodeId } : { nodeId, surface })
   return true
 }
 

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -6,6 +6,7 @@ import {
   buildCanvasControlInstructions,
   buildCanvasSkillBody
 } from './canvas-control-core'
+import { STRICT_CONTROL_VERBS } from '../core/agents/node-identity-policy'
 
 describe('parseControlRequest', () => {
   it('accepts known verbs', () => {
@@ -205,5 +206,31 @@ describe('parseControlRequest', () => {
     for (const v of ['group', 'arrange', 'align', 'spawn-team'] as const) {
       expect(isDestructiveVerb(v)).toBe(false)
     }
+  })
+})
+
+/**
+ * The claim `node-identity-policy.ts` makes about itself, checked against the real verb model.
+ *
+ * `STRICT_CONTROL_VERBS` is pre-positioned: the ordering is fixed before the verb it is for
+ * exists, so the verb cannot arrive through the `override === false` hole. These two tests are
+ * what stop that from quietly becoming a false claim in either direction — the first FAILS on the
+ * day the real `browser` verb lands, which is exactly when the PR body, the changelog and the
+ * Settings copy all have to stop saying "nothing changes for anyone".
+ */
+describe('the strict identity bucket is pre-positioned, not live', () => {
+  it('`browser` is not a verb this app has, so the bucket gates nothing today', () => {
+    expect(STRICT_CONTROL_VERBS.has('browser')).toBe(true)
+    expect(parseControlRequest('browser', {})).toEqual({ error: 'Unknown verb: browser' })
+  })
+
+  it('`open-browser` IS a real verb and is deliberately NOT in the bucket', () => {
+    // Opening a node is not driving one, and open-browser has a live legacy population that a
+    // strict gate would strand with no way back. See STRICT_CONTROL_VERBS' doc comment.
+    expect(parseControlRequest('open-browser', { url: 'https://example.com' })).toEqual({
+      verb: 'open-browser',
+      args: { url: 'https://example.com' }
+    })
+    expect(STRICT_CONTROL_VERBS.has('open-browser')).toBe(false)
   })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,10 +5,15 @@ import { readFile } from 'fs/promises'
 import { statSync } from 'fs'
 import { homedir, hostname } from 'os'
 import { randomUUID } from 'crypto'
-import { app, BrowserWindow, clipboard, dialog, ipcMain, Notification, powerMonitor, safeStorage, shell, systemPreferences } from 'electron'
+import { app, BrowserWindow, clipboard, dialog, ipcMain, Notification, powerMonitor, safeStorage, shell, systemPreferences, webContents } from 'electron'
 import { IPC } from '../shared/ipc'
 import { writeFilesToClipboard } from './clipboard-files'
 import { registerFsHandlers } from '../core/fs-handlers'
+import {
+  registerBrowserGuest,
+  type BrowserGuest,
+  type BrowserSurfaceKind
+} from './browser-guest-registry'
 import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
 import type { RemoteLogExec } from '../core/board-log'
 import { boardLogRemotePath } from '../core/board-log'
@@ -323,8 +328,10 @@ let activeRemote: { cwd: string; ref: GitRemoteRef } | null = null
 // True from the first before-quit on: lets window close-events through (see hide-on-close).
 let quitting = false
 
-// Browser <webview> guest webContents id → its browser node id (for new-window capture).
-const browserGuests = new Map<number, string>()
+// Browser <webview> guest webContents id → the browser node (and which of its two surfaces) it
+// belongs to. Used today for new-window capture; every entry is proven to BE a <webview> before it
+// lands here — see `registerBrowserGuest`.
+const browserGuests = new Map<number, BrowserGuest>()
 
 // Node → live tail bookkeeping, so closing a node (× → pty:destroy) releases its file tailers.
 // Without this, a node closed mid-run never emits SessionEnd/PostToolUse, so context-tail (1s
@@ -519,7 +526,7 @@ app.whenReady().then(async () => {
     // (never a real popup). Only http(s); other schemes are dropped. The map is consulted
     // live at call time, so a guest registered later (on dom-ready) is seen when a popup fires.
     contents.setWindowOpenHandler(({ url }) => {
-      const sourceNodeId = browserGuests.get(contents.id)
+      const sourceNodeId = browserGuests.get(contents.id)?.nodeId
       if (sourceNodeId && /^https?:\/\//i.test(url)) {
         sendToMain(IPC.browserNewWindow, { url, sourceNodeId })
       }
@@ -570,9 +577,24 @@ app.whenReady().then(async () => {
   ipcMain.handle(IPC.mediaAllow, (_e, absPath: string) => allowMediaPath(absPath))
   ipcMain.handle(IPC.mediaWriteHtml, (_e, html: string) => writeAgentHtml(html))
 
-  ipcMain.on(IPC.browserRegister, (_e, webContentsId: number, nodeId: string) => {
-    browserGuests.set(webContentsId, nodeId)
-  })
+  ipcMain.on(
+    IPC.browserRegister,
+    (_e, webContentsId: number, nodeId: string, surface?: BrowserSurfaceKind) => {
+      // `surface` is optional ON THE WIRE only: both mount sites still send two arguments, so an
+      // absent value means "the canvas one", which is what every registration was taken to be
+      // before the field existed. A value that is present and wrong is refused, not defaulted.
+      const kind = surface === undefined ? 'canvas' : surface
+      if (
+        !registerBrowserGuest(browserGuests, webContentsId, nodeId, kind, (id) =>
+          webContents.fromId(id) ?? null
+        )
+      ) {
+        // Loud, because the symptom otherwise is "popups from this node stopped opening" with
+        // nothing anywhere to explain it.
+        console.warn('[browser] refused guest registration', { webContentsId, nodeId, surface })
+      }
+    }
+  )
   ipcMain.on(IPC.browserUnregister, (_e, webContentsId: number) => {
     browserGuests.delete(webContentsId)
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -580,12 +580,12 @@ app.whenReady().then(async () => {
   ipcMain.on(
     IPC.browserRegister,
     (_e, webContentsId: number, nodeId: string, surface?: BrowserSurfaceKind) => {
-      // `surface` is optional ON THE WIRE only: both mount sites still send two arguments, so an
-      // absent value means "the canvas one", which is what every registration was taken to be
-      // before the field existed. A value that is present and wrong is refused, not defaulted.
-      const kind = surface === undefined ? 'canvas' : surface
+      // `surface` is passed through UNCHANGED, including when it is absent. Both mount sites
+      // (BrowserNode and the kanban CardModal) still send two arguments, so today it is always
+      // absent — and defaulting it to 'canvas' here would record every modal guest as a canvas
+      // guest, which is a false claim a later reverse lookup cannot detect. See `BrowserGuest`.
       if (
-        !registerBrowserGuest(browserGuests, webContentsId, nodeId, kind, (id) =>
+        !registerBrowserGuest(browserGuests, webContentsId, nodeId, surface, (id) =>
           webContents.fromId(id) ?? null
         )
       ) {

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -265,7 +265,7 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
       <SearchableRow {...ROWS.nodeIdentity}>
         <FieldRow
           label="Require verified node identity for canvas control"
-          description={`Commands that open, write to or close nodes — and that read a linked node's context — must present the identity NodeTerm issued to the node they say they came from. Automatic starts refusing the ones that can't from ${NODE_IDENTITY_STRICT_DATE}; until then they still run and the reply tells you to restart that node. Set this to "Not required" if an upgrade left a running session unable to drive the canvas: it restores the behaviour from before this feature, past ${NODE_IDENTITY_STRICT_DATE} as well. An identity that is actually forged is refused whatever you pick here.`}
+          description={`Commands that open, write to or close nodes — and that read a linked node's context — must present the identity NodeTerm issued to the node they say they came from. Automatic starts refusing the ones that can't from ${NODE_IDENTITY_STRICT_DATE}; until then they still run and the reply tells you to restart that node. Set this to "Not required" if an upgrade left a running session unable to drive the canvas: it restores the behaviour from before this feature, past ${NODE_IDENTITY_STRICT_DATE} as well. An identity that is actually forged is refused whatever you pick here. It does not release browser control, which always requires a verified identity.`}
           control={
             <Select
               aria-label="Require verified node identity"

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -265,7 +265,7 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
       <SearchableRow {...ROWS.nodeIdentity}>
         <FieldRow
           label="Require verified node identity for canvas control"
-          description={`Commands that open, write to or close nodes — and that read a linked node's context — must present the identity NodeTerm issued to the node they say they came from. Automatic starts refusing the ones that can't from ${NODE_IDENTITY_STRICT_DATE}; until then they still run and the reply tells you to restart that node. Set this to "Not required" if an upgrade left a running session unable to drive the canvas: it restores the behaviour from before this feature, past ${NODE_IDENTITY_STRICT_DATE} as well. An identity that is actually forged is refused whatever you pick here. It does not release browser control, which always requires a verified identity.`}
+          description={`Commands that open, write to or close nodes — and that read a linked node's context — must present the identity NodeTerm issued to the node they say they came from. Automatic starts refusing the ones that can't from ${NODE_IDENTITY_STRICT_DATE}; until then they still run and the reply tells you to restart that node. Set this to "Not required" if an upgrade left a running session unable to drive the canvas: it restores the behaviour from before this feature, past ${NODE_IDENTITY_STRICT_DATE} as well. An identity that is actually forged is refused whatever you pick here.`}
           control={
             <Select
               aria-label="Require verified node identity"

--- a/src/renderer/nodes/browser-discard-policy.test.ts
+++ b/src/renderer/nodes/browser-discard-policy.test.ts
@@ -28,3 +28,32 @@ describe('browser discard policy', () => {
     expect(BROWSER_DISCARD_MS).toBe(5 * 60_000)
   })
 })
+
+describe('an active lease suppresses the discard', () => {
+  const base = { hiddenMs: BROWSER_DISCARD_MS + 1, loading: false, enabled: true, audible: false }
+
+  it('a driven node is not discarded', () => {
+    // Today the target of a five-minute agent task is destroyed the moment the user pans away.
+    expect(shouldDiscard({ ...base, driven: true })).toBe(false)
+  })
+
+  it('driven is the THIRD suppressor, in the same category as the first two', () => {
+    // loading and audible mean "in use even though hidden". So does a live lease.
+    expect(shouldDiscard({ ...base, loading: true })).toBe(false)
+    expect(shouldDiscard({ ...base, audible: true })).toBe(false)
+    expect(shouldDiscard({ ...base, driven: true })).toBe(false)
+    expect(shouldDiscard(base)).toBe(true)
+  })
+
+  it('absent driven behaves exactly as today — a surface that cannot tell says nothing', () => {
+    expect(shouldDiscard(base)).toBe(true)
+    expect(shouldDiscard({ ...base, driven: false })).toBe(true)
+    expect(shouldDiscard({ ...base, driven: undefined })).toBe(true)
+  })
+
+  it('suppresses, it does not exempt: a lease is worth nothing once the window has NOT elapsed', () => {
+    // The predicate stays a conjunction — `driven` can only ever subtract a discard, never add one.
+    expect(shouldDiscard({ ...base, hiddenMs: BROWSER_DISCARD_MS - 1, driven: true })).toBe(false)
+    expect(shouldDiscard({ ...base, enabled: false, driven: true })).toBe(false)
+  })
+})

--- a/src/renderer/nodes/browser-discard-policy.ts
+++ b/src/renderer/nodes/browser-discard-policy.ts
@@ -9,6 +9,15 @@
  *    result or an interstitial would simply be lost).
  *  - **Never discard a page making noise.** Audible = in use, even off-screen (a call, music, a
  *    video the user is listening to). Chrome exempts audible tabs for the same reason.
+ *  - **Never discard a page an agent is driving.** A live control lease is "in use even though
+ *    hidden", the same category as loading and audible. Without this, an agent drives a node, the
+ *    user pans away, and five minutes later the target is destroyed mid-task with no signal: the
+ *    restore re-navigates to the stored URL, so cookies survive but form state, scroll position and
+ *    every post-login SPA state do not, and every element reference from the last read is silently
+ *    stale. The cost is a whole Chromium renderer held resident until the lease ends — bounded by
+ *    whatever idle timeout the driver enforces, and preferable to a feature that fails five minutes
+ *    into every long task. The input is optional, so a surface with no notion of a lease (every
+ *    surface today) behaves exactly as it did before it existed.
  *  - **The setting is re-read when the timer FIRES, not when it was armed** — so a user who
  *    switches the saver off during a hidden stretch is not discarded by an older timer. The
  *    symmetry is deliberately incomplete: switching the saver ON mid-hide does NOT discard that
@@ -29,6 +38,14 @@ export function shouldDiscard(i: {
   enabled: boolean
   /** Is the page making sound right now? Optional so a surface that cannot tell says nothing. */
   audible?: boolean
+  /**
+   * Is an agent driving this page right now (a live control lease)?
+   *
+   * Optional for the same reason as `audible`: a surface that cannot tell must behave exactly as it
+   * did before the input existed. It is a SUPPRESSOR, never an exemption — the caller re-reads it
+   * when the timer fires, so a page whose lease ended is discardable on the next pass.
+   */
+  driven?: boolean
 }): boolean {
-  return i.enabled && !i.loading && !i.audible && i.hiddenMs > BROWSER_DISCARD_MS
+  return i.enabled && !i.loading && !i.audible && !i.driven && i.hiddenMs > BROWSER_DISCARD_MS
 }

--- a/src/renderer/nodes/useDiscardWhenHidden.test.tsx
+++ b/src/renderer/nodes/useDiscardWhenHidden.test.tsx
@@ -42,6 +42,7 @@ function Harness(props: Partial<DiscardWhenHiddenOptions> & { onEl?: (el: HTMLEl
   useDiscardWhenHidden(ref, {
     isLoading: props.isLoading ?? (() => false),
     isAudible: props.isAudible,
+    isDriven: props.isDriven,
     hasContent: props.hasContent ?? (() => true),
     onDiscard: props.onDiscard ?? (() => {}),
     onRestore: props.onRestore ?? (() => {})
@@ -225,5 +226,62 @@ describe('useDiscardWhenHidden', () => {
   it('shares one decision with the pure policy', () => {
     // The hook must not grow its own copy of the threshold.
     expect(shouldDiscard({ hiddenMs: BROWSER_DISCARD_MS + DISCARD_SLACK_MS, loading: false, enabled: true })).toBe(true)
+  })
+})
+
+describe('a control lease is a transient blocker, like a load or a sound', () => {
+  let root: Root | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+    useSettings.setState({ settings: { ...DEFAULT_SETTINGS } })
+    observed = null
+  })
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('a lease that ENDS leaves the node discardable on the next retry — never exempt forever', () => {
+    // hidden → driven → fire (no discard, re-armed) → lease ends → retry fires → discarded.
+    const onDiscard = vi.fn()
+    let driven = true
+    let el!: HTMLElement
+    root = mount({ onDiscard, isDriven: () => driven, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+    expect(onDiscard).not.toHaveBeenCalled()
+    // Still driving a minute later — still exempt, and still re-armed.
+    advance(DISCARD_RETRY_MS)
+    expect(onDiscard).not.toHaveBeenCalled()
+    driven = false
+    advance(DISCARD_RETRY_MS)
+    expect(onDiscard).toHaveBeenCalledTimes(1)
+  })
+
+  it('is read at FIRE time, not at arm time', () => {
+    // A lease taken after the timer was armed must still be honoured — the whole point of reading
+    // every input through optsRef when the timer fires.
+    const onDiscard = vi.fn()
+    let driven = false
+    let el!: HTMLElement
+    root = mount({ onDiscard, isDriven: () => driven, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS - 1000)
+    driven = true
+    advance(DISCARD_SLACK_MS + 1000)
+    expect(onDiscard).not.toHaveBeenCalled()
+  })
+
+  it('a surface that passes no isDriven is discarded exactly as before', () => {
+    const onDiscard = vi.fn()
+    let el!: HTMLElement
+    root = mount({ onDiscard, onEl: (e) => (el = e) })
+    hide(el)
+    advance(BROWSER_DISCARD_MS + DISCARD_SLACK_MS)
+    expect(onDiscard).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/nodes/useDiscardWhenHidden.ts
+++ b/src/renderer/nodes/useDiscardWhenHidden.ts
@@ -41,6 +41,15 @@ export interface DiscardWhenHiddenOptions {
   /** Is the page making sound right now? Omitted = this surface cannot tell (never treated as
    *  audible — a surface with no webview has nothing playing). */
   isAudible?: () => boolean
+  /**
+   * Is an agent driving this page right now (a live control lease)?
+   *
+   * Read AT FIRE TIME like every other input, and treated as TRANSIENT: a lease that has ended
+   * leaves the node discardable on the next retry, never exempt for the whole hidden stretch.
+   * Omitted = this surface has no notion of a lease, which is every surface until one pushes lease
+   * state into the renderer.
+   */
+  isDriven?: () => boolean
   /** Is there anything to release? (A start page / empty node has no guest process.) */
   hasContent: () => boolean
   /** Release the page: the caller unmounts its `<webview>` and shows its plate. */
@@ -113,10 +122,13 @@ export function useDiscardWhenHidden(
       const enabled = useSettings.getState().settings.browserMemorySaver
       const loading = o.isLoading()
       const audible = o.isAudible?.() ?? false
-      if (!shouldDiscard({ hiddenMs: Date.now() - hiddenSince, loading, enabled, audible })) {
-        // Both blockers END BY THEMSELVES, so they earn a retry rather than disarming the saver for
-        // the whole hidden stretch. A disabled setting does not: see the policy's doc comment.
-        if (enabled && (loading || audible)) arm(DISCARD_RETRY_MS)
+      const driven = o.isDriven?.() ?? false
+      if (!shouldDiscard({ hiddenMs: Date.now() - hiddenSince, loading, enabled, audible, driven })) {
+        // All three blockers END BY THEMSELVES, so they earn a retry rather than disarming the
+        // saver for the whole hidden stretch. A disabled setting does not: see the policy's doc
+        // comment. `driven` belongs with the other two and NOT with the setting — an agent that
+        // stops driving must not leave the page exempt until its next hide→show cycle.
+        if (enabled && (loading || audible || driven)) arm(DISCARD_RETRY_MS)
         return
       }
       discarded = true

--- a/src/server/control-unsupported.test.ts
+++ b/src/server/control-unsupported.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The Server Edition's `/control/*` answer, proven on the wire.
+ *
+ * The defect being fixed is a WORDING one with a behavioural cost: `control unavailable` + HTTP 400
+ * is indistinguishable from a transient outage, and a language model retries an outage. So the
+ * assertions here are about what the caller can conclude — a stable machine name, and prose that
+ * contains the literal "do not retry" — not merely about a status code.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from '../core/platform'
+import { fakePlatform } from '../core/platform-fake'
+import { hookServer } from '../core/agents/hook-server'
+import { nodeAuthToken } from '../core/agents/node-auth-token'
+import { STRICT_CONTROL_REFUSAL } from '../core/agents/node-identity-policy'
+import {
+  BROWSER_UNSUPPORTED_CLAUSE,
+  CONTROL_UNSUPPORTED_ERROR,
+  CONTROL_UNSUPPORTED_SENTENCE,
+  controlUnsupportedMessage,
+  serverEditionControlHandler
+} from './control-unsupported'
+
+const SECRET = Buffer.alloc(32, 7)
+let dir = ''
+
+function control(verb: string, nodeId: string, accept = 'text/plain', token?: string) {
+  const headers: Record<string, string> = {
+    'X-Nodeterm-Hook-Token': hookServer.getToken(),
+    'content-type': 'application/x-www-form-urlencoded',
+    accept
+  }
+  if (token) headers['X-Nodeterm-Node-Token'] = token
+  return fetch(`http://127.0.0.1:${hookServer.getPort()}/control/${verb}`, {
+    method: 'POST',
+    headers,
+    body: `nodeId=${encodeURIComponent(nodeId)}`
+  })
+}
+
+beforeAll(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-ctl-unsupported-'))
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: dir }))
+  await hookServer.start()
+  hookServer.setNodeAuthSecret(SECRET)
+  // The exact registration `src/server/index.ts` performs after `hookServer.start()`.
+  hookServer.setControlHandler(serverEditionControlHandler)
+})
+
+afterAll(() => {
+  hookServer.clearNodeAuthSecretForTests()
+  hookServer.stop()
+  resetPlatformForTests()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('the Server Edition refuses canvas control by name', () => {
+  it('answers every verb with the same machine-readable error, in JSON', async () => {
+    for (const verb of ['list', 'open-terminal', 'write']) {
+      const res = await control(verb, 'n-1', 'application/json')
+      expect(res.status, verb).toBe(400)
+      const body = (await res.json()) as { ok: boolean; error: string; message: string }
+      expect(body.ok, verb).toBe(false)
+      // The name is EXACT and stable — this is the field a client is allowed to branch on.
+      expect(body.error, verb).toBe(CONTROL_UNSUPPORTED_ERROR)
+      expect(body.error, verb).not.toBe('control unavailable')
+    }
+  })
+
+  it('tells a text/plain caller, in words, not to retry', async () => {
+    // Verified, so the reply is the refusal alone: an unverified caller inside the warning window
+    // gets the identity note prefixed on top, which is existing behaviour and not what is measured
+    // here.
+    const res = await control('open-terminal', 'n-2', 'text/plain', nodeAuthToken(SECRET, 'n-2'))
+    expect(res.status).toBe(400)
+    const text = await res.text()
+    // The literal the whole change exists for.
+    expect(text).toContain('do not retry')
+    expect(text).toContain('permanent')
+    // …and the name, because the text dialect carries no fields.
+    expect(text).toContain(CONTROL_UNSUPPORTED_ERROR)
+    expect(text).toContain(CONTROL_UNSUPPORTED_SENTENCE)
+    // One line: the shim prints the body as-is.
+    expect(text.trimEnd()).not.toContain('\n')
+  })
+
+  it('names WHY browser control is structural, not merely unimplemented', async () => {
+    // `browser` is a strict verb, so it takes a verified identity even to be told no. That
+    // ordering is correct — identity runs before the handler — and it is why this test presents a
+    // token where the others do not.
+    const res = await control('browser', 'n-3', 'text/plain', nodeAuthToken(SECRET, 'n-3'))
+    expect(res.status).toBe(400)
+    const text = await res.text()
+    expect(text).toContain(CONTROL_UNSUPPORTED_ERROR)
+    expect(text).toContain(BROWSER_UNSUPPORTED_CLAUSE)
+    expect(text).toContain('renders in your own browser')
+  })
+
+  it('adds that clause to `browser` and to nothing else', () => {
+    expect(controlUnsupportedMessage('browser')).toContain(BROWSER_UNSUPPORTED_CLAUSE)
+    for (const verb of ['list', 'open-terminal', 'browsers', 'BROWSER']) {
+      expect(controlUnsupportedMessage(verb), verb).not.toContain(BROWSER_UNSUPPORTED_CLAUSE)
+      expect(controlUnsupportedMessage(verb), verb).toContain(CONTROL_UNSUPPORTED_ERROR)
+    }
+  })
+
+  it('still refuses an unverified `browser` on IDENTITY, before the edition ever answers', async () => {
+    // Order matters: the identity gate runs before the handler on both shells, so a tokenless
+    // caller learns nothing about the edition. Neither answer is a retryable outage.
+    const res = await control('browser', 'n-4')
+    expect(res.status).toBe(403)
+    expect((await res.text()).trim()).toBe(STRICT_CONTROL_REFUSAL)
+  })
+
+  it('never resolves ok — there is nothing on this host for a verb to act on', async () => {
+    expect(await serverEditionControlHandler({ verb: 'list' })).toEqual({
+      ok: false,
+      error: CONTROL_UNSUPPORTED_ERROR,
+      message: controlUnsupportedMessage('list')
+    })
+  })
+})
+
+describe('the Server Edition wires it at boot', () => {
+  it('registers the refusing handler instead of leaving the null branch', () => {
+    // A hook-server change made on one shell only has shipped wrong three times in this repo, and
+    // the null branch is invisible until an agent hits it in production.
+    const src = fs.readFileSync(path.resolve(__dirname, 'index.ts'), 'utf8')
+    expect(src).toContain('setControlHandler(serverEditionControlHandler)')
+  })
+})
+
+/**
+ * The reply shape this refusal needed: a FAILURE may now carry a machine name in `error` and a
+ * sentence in `message`, and the text dialect prefers the sentence. Every pre-existing handler
+ * sends `error` alone, so the fallback is what they all still take — pinned here because a silent
+ * change of dialect for every failing verb would be a much bigger deal than this feature.
+ */
+describe('a failing verb that carries only `error` is rendered exactly as before', () => {
+  it('falls back to the error string in text, and keeps the JSON field', async () => {
+    hookServer.setControlHandler(async () => ({ ok: false, error: 'boom' }))
+    try {
+      const text = await control('open-terminal', 'n-5', 'text/plain', nodeAuthToken(SECRET, 'n-5'))
+      expect(text.status).toBe(400)
+      expect((await text.text()).trim()).toBe('boom')
+      const json = await control('open-terminal', 'n-6', 'application/json', nodeAuthToken(SECRET, 'n-6'))
+      expect(await json.json()).toEqual({ ok: false, error: 'boom' })
+    } finally {
+      hookServer.setControlHandler(serverEditionControlHandler)
+    }
+  })
+})

--- a/src/server/control-unsupported.ts
+++ b/src/server/control-unsupported.ts
@@ -1,0 +1,60 @@
+/**
+ * The Server Edition's answer to `/control/*`: a NAMED, permanent refusal.
+ *
+ * `src/server/index.ts` starts the same hook server as the desktop but never calls
+ * `setControlHandler`, so every control verb fell through to the null branch's
+ * `{ ok: false, error: 'control unavailable' }` → HTTP 400. That sentence reads to a language model
+ * exactly like a transient outage, **and a model retries an outage** — so an agent on a headless
+ * host burned its turns re-sending a request that can never succeed, and the operator saw a stream
+ * of 400s with nothing naming the cause.
+ *
+ * Registering a refusing handler rather than leaving the branch null is deliberate: the refusal
+ * then travels the same reply shape as every other verb (JSON gets a machine-readable `error`, the
+ * POSIX-sh shim gets one printable line), and nobody has to special-case "unavailable" downstream.
+ *
+ * Shared with the agent-messaging plan by agreement — one string, one mechanism, every verb.
+ */
+
+/** The machine-readable name. Structured clients key on this, never on the prose. */
+export const CONTROL_UNSUPPORTED_ERROR = 'control-unsupported-on-this-edition'
+
+/**
+ * The prose, which must say the thing a retrying model needs to hear IN WORDS: the literal
+ * "do not retry". A refusal that only a status code distinguishes from an outage is not a refusal
+ * an agent can act on.
+ */
+export const CONTROL_UNSUPPORTED_SENTENCE =
+  'Canvas control is not available on the nodeterm Server Edition. This is permanent on this ' +
+  'host, not a temporary failure — do not retry.'
+
+/**
+ * `browser` gets one extra clause naming WHY it is structural, so nobody files it as unimplemented
+ * and nobody tries to implement it here. A browser node on this edition renders in the VIEWER's own
+ * Chrome tab: there is no Electron, no `webContents`, no `<webview>` and no CDP on this host, and
+ * the server has no debugger for a page in somebody else's browser and never can.
+ */
+export const BROWSER_UNSUPPORTED_CLAUSE =
+  'There is no browser control on this edition: a browser node here renders in your own browser ' +
+  'tab, which this server has no debugger for.'
+
+/**
+ * One line, always — control replies are rendered as a single line by the shim, and a multi-line
+ * body buries whichever half the reader stops at. The machine name is repeated inside the prose so
+ * the text/plain dialect (which carries no `error` field) still names the refusal.
+ */
+export function controlUnsupportedMessage(verb: string): string {
+  const why = verb === 'browser' ? ` ${BROWSER_UNSUPPORTED_CLAUSE}` : ''
+  return `${CONTROL_UNSUPPORTED_ERROR}: ${CONTROL_UNSUPPORTED_SENTENCE}${why}`
+}
+
+/**
+ * What `src/server/index.ts` hands to `hookServer.setControlHandler`. Never resolves `ok: true`:
+ * there is nothing on this host for a control verb to act on.
+ */
+export async function serverEditionControlHandler({ verb }: { verb: string }): Promise<{
+  ok: false
+  error: string
+  message: string
+}> {
+  return { ok: false, error: CONTROL_UNSUPPORTED_ERROR, message: controlUnsupportedMessage(verb) }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,6 +23,7 @@ import { DownloadTickets } from '../core/download-tickets'
 import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
 import os from 'os'
 import { hookServer } from '../core/agents/hook-server'
+import { serverEditionControlHandler } from './control-unsupported'
 import { loadOrCreateNodeAuthSecret } from '../core/agents/node-auth-secret'
 import { initNodeTokens, refreshNodeTokens } from '../core/agents/node-token-service'
 import {
@@ -418,6 +419,10 @@ export async function startServer(
     }
   }
   await hookServer.start()
+  // Canvas control does not exist on this edition, and saying so BY NAME is the whole point: the
+  // null handler answered `control unavailable`, which reads to an agent like a transient outage,
+  // and an agent retries an outage. See `control-unsupported.ts`.
+  hookServer.setControlHandler(serverEditionControlHandler)
 
   // ---- Node identity (src/core/agents/node-auth-secret.ts) ------------------------------------
   // First time the Server Edition arms node identity. Headless Linux has no OS keychain, so the


### PR DESCRIPTION
> **Read this first: item 1 is PRE-POSITIONING and is inert today.** `STRICT_CONTROL_VERBS` holds one name, `browser`, and **`browser` is not a control verb this app has** — `ControlVerb` lists 24 and the browser one is `open-browser`, which is deliberately *not* in the bucket. Measured over the real verb list, the set of verbs `hookIdentityStrict: false` stops releasing is **empty**. **No user's behaviour changes, no request that succeeds today starts failing, and nobody's escape hatch narrows.** What lands is the ordering, before the verb exists. Items 2–4 are live fixes.

Three defects that exist in shipped code whether or not agent-driven browser control ever ships, plus the Server Edition's named refusal. Ships alone; no verb is added.

## 1. The escape hatch's blanket `allow-with-warning` (pre-positioned)

`controlPolicy`'s hatch branch returns `allow-with-warning` for **any** verb outside `TOLERANT_CONTROL_VERBS`:

```ts
if (override === false) {
  return TOLERANT_CONTROL_VERBS.has(verb) ? 'allow' : 'allow-with-warning'
}
```

`docs/node-identity.md` tells a stranded user to reach for that switch, so the documented rescue for a bad upgrade is also a permanent grant of every non-tolerant verb to anyone holding the app-wide bearer — and until 2026-10-13 the dated window does the same with no switch at all. That is the hole a future verb which **acts as the user on the internet, inside a session jar holding real logins** must not be the thing to discover.

**What this PR does:** fixes the ordering now. `STRICT_CONTROL_VERBS` is decided one line below the `forged` check — above the hatch and above the dated window — and admits `verified` only; everything else (`legacy`, `forged`, foreign/invented kid, absent token, `override:false`) is refused with one flat sentence (`Browser control refused.`) and no diagnosis, because advice there is advice to whoever is probing.

**What this PR does NOT do:** change anybody's behaviour. The bucket names a verb that does not exist. Two tests in `canvas-control-core.test.ts` pin that, and the first of them **fails on the day the real `browser` verb lands** — which is exactly when this section, the docs and the Settings copy have to stop saying "nothing changes".

Proven on the wire anyway (`hook-identity-enforcement.test.ts`, real hook server, real POSTs, stub handler that accepts any verb so the route can be exercised): strict verb + `override:false` ⇒ 403, handler never ran; strict verb + verified ⇒ 200 on both sides of the cutoff under all three hatch settings; the tolerant verb, the window and the hatch unchanged for every other verb. The documented **invented-`kid` probe** — which walks past the latch into `/control/list` and every `/context-link/*` verb — is asserted to fail here, in the same test as the contrast that it still succeeds on `list`. Fail-open directions untouched: `/hook/*` still 204s a tokenless POST; a foreign kid is still `legacy`, never `forged`.

### `open-browser` is deliberately NOT in the bucket

It is the live verb, it opens a navigable Chromium node in the app's default session jar, and under the hatch it stays `allow-with-warning`. The decision, now written into the bucket's doc comment and into `docs/node-identity.md` rather than left implicit:

- **Opening a node is not driving one.** The threat this bucket answers is an agent acting *inside* a page the user is logged into — reading cookies, typing, evaluating script. `open-browser` only creates the surface and navigates it to a URL the caller supplied; that is the same class of act as `show-web`, which is not gated either.
- **It has a live legacy population.** Adding it would leave a pre-token tmux session — or an SSH host whose project has not reconnected — unable to open a browser node **with no way back**, because the whole point of this bucket is that the hatch cannot reach it. That is precisely the stranding the dated window exists to prevent, paid to defend a surface that holds nothing yet.
- **The residual is named, not hidden:** an unverified caller can open a node onto a logged-in page, and the page's *title* then appears in `list`. That leak belongs to `list`'s tolerance, is unchanged by this PR, and is the pre-existing trade documented on `TOLERANT_CONTROL_VERBS`.

If you weigh it the other way, the cost to state is: a user whose hatch is on loses the ability to have an agent open a browser node until that node is restarted with an identity.

The Settings → Agents row asserts **nothing** about browser control (the earlier draft's clause was removed: a user reading it today finds only `open-browser`, which the hatch *does* release). `docs/node-identity.md`'s escape-hatch and invented-kid sections now lead with the inertness.

## 2. `IPC.browserRegister` stored any integer the renderer sent

**Before:** `browserGuests.set(webContentsId, nodeId)` with no validation — unlike the S8 backend in PR #112, which did this correctly. Harmless while the map only routes new-window events; a **privilege escalation** the day that integer selects a `webContents` we attach a debugger to, because an unvalidated id can name the app's own window.

**After:** `registerBrowserGuest` (pure, injectable lookup, testable without Electron) refuses anything that is not a positive integer, a node id `isSafeNodeId` refuses, a *present* but unrecognised `surface`, a lookup that throws, and — the point — any `webContents` whose `getType() !== 'webview'`. Refusals are logged, never silent. The `getType()` guard is stolen from PR #112's `browser-use-backend.ts` **with credit to @proteus-dev**; the strongest single idea in that file and the only part kept. The node id is validated too: map key here, partition/lease key later, and it arrives from git-shared `project.json`.

`BrowserGuest.surface` is **optional and absent**, never defaulted. Both mount sites (`BrowserNode.tsx`, kanban `CardModal.tsx`) still call the 2-argument preload `register`, so defaulting to `'canvas'` would file every modal guest as a canvas guest — a positive false claim a later reverse lookup cannot detect, producing two `'canvas'` entries for one node id, which is the exact collision the field exists to prevent. Threading it from the two mount sites stays a later task; `undefined` means unknown and a consumer must refuse to guess.

## 3. The memory saver could destroy an agent's target mid-task

**Before:** `shouldDiscard` releases any hidden webview after `BROWSER_DISCARD_MS` (5 min) unless it is `loading` or `audible`, and the discard **unmounts the `<webview>`**, ending the guest. An agent drives a browser node, the user pans away, and five minutes later the page is gone with no signal — the restore re-navigates to the stored URL, so cookies survive but form state, scroll position and post-login SPA state do not.

**After:** an active lease is a third suppressor beside `loading` and `audible` — same category, "in use even though hidden" — and it joins them in the **transient** re-arm set, so a node whose lease ended is discardable on the next `DISCARD_RETRY_MS` pass rather than exempt forever. Read **at fire time** through `optsRef`, like every other input; the re-check discipline is added to, never bypassed. Both `shouldDiscard({ driven })` and `useDiscardWhenHidden({ isDriven })` are optional, so every surface today behaves bit-for-bit as before — this is the seam, not a speculative lease type.

And `browserDiscardedMessage`: a target killed by the memory saver now says so ("released to save memory while hidden… bring it on screen or open a new one") instead of reading as a permissions failure. "Not drivable" there would send the next debugger to the identity code for a bug that lives in `browser-discard-policy.ts`.

## 4. The Server Edition refuses by name

**Before:** `src/server/index.ts` starts the same hook server but never calls `setControlHandler`, so every `/control/*` fell to `{ ok: false, error: 'control unavailable' }` → HTTP 400. That reads to a language model like a transient outage, **and a model retries an outage**.

**After:** a refusing handler is registered, so the refusal travels the same reply shape as every other verb:

- JSON: `{ ok: false, error: 'control-unsupported-on-this-edition', message: … }`
- `text/plain`: `control-unsupported-on-this-edition: Canvas control is not available on the nodeterm Server Edition. This is permanent on this host, not a temporary failure — do not retry.`
- `browser` adds one clause naming why it is **structural**: *"There is no browser control on this edition: a browser node here renders in your own browser tab, which this server has no debugger for."*

One supporting change in `hook-server.ts`: a **failing** control reply may now carry both a machine name (`error`) and a sentence (`message`), and the text dialect prefers the sentence, falling back to the name. Every pre-existing handler sends `error` alone (all 60 `ok:false` sites in `Canvas.tsx` plus main's two), so this is inert for all of them — pinned by its own test. Shared with the agent-messaging plan's Task 5.3: one string, one mechanism.

## Mutation results (Global Constraint 9)

Every new assertion was mutation-checked — implementation broken deliberately in each way the tests claim to catch, suite confirmed red, code restored.

| Area | Mutations | Caught |
| --- | --- | --- |
| Strict verbs (`node-identity-policy.ts`, `hook-server.ts`) | bucket moved *after* the override branch; bucket returns `allow` for `legacy`; bucket removed entirely; refusal reuses `identityRefusalNote` | **4/4** |
| Guest registry (`browser-guest-registry.ts`, `index.ts`) | `getType()` removed; `isSafeNodeId` removed; `surface` accepted blindly; integer check removed; IPC handler bypasses the guard; absent surface defaulted to `'canvas'` in the registry; defaulted at the IPC boundary | **7/7** |
| Discard suppressor (`browser-discard-policy.ts`, `useDiscardWhenHidden.ts`) | `driven` dropped from the predicate; from the fire-time read; from the transient re-arm set; discard message reuses the permissions wording | **4/4** |
| Server refusal (`control-unsupported.ts`, `server/index.ts`, `hook-server.ts`) | back to `control unavailable`; "do not retry" dropped; browser clause dropped; browser clause on every verb; handler not registered at boot; text branch stops preferring `message` | **6/6** |

**21/21.** Two gaps found and closed while doing it: the "not a positive integer" case passed with the guard removed (the injected lookup refused it instead) — the assertion now sits on the guard, with a lookup that would call anything a webview; and defaulting the surface at the IPC boundary was invisible to the unit test, so the wiring test now pins the pass-through too.

## Three surfaces

- **Desktop** — items 2 and 3 (`webContents` and `<webview>` exist nowhere else); item 1 applies here through the same `src/core` policy.
- **Server Edition** — item 4 is the subject; item 1 is one `src/core` change so both shells move together (a one-shell hook-server change has shipped wrong three times in this repo); items 2–3 N/A, no `<webview>`.
- **Mobile** — N/A throughout: the phone drives canvas control over relay → IPC, never `/control/*`.

## Verification

- `npm run typecheck` clean.
- Named suites (`node-identity-policy`, `hook-identity-enforcement`, `browser-guest-registry`, `canvas-control-core`, `browser-discard-policy`, `useDiscardWhenHidden`, `control-unsupported`): all green.
- Full `npx vitest run`: **6000 passed, 12 skipped, 4 failed** — 3 × `node-pty-patch` + 1 × `webgl-addon-pair`, the documented environmental pair.
- A 5th intermittent failure (`src/server/handlers/index.test.ts > forwards localProjectCwd`) was **reproduced on a clean `origin/main` worktree** under full-suite load and passes in isolation 3/3: pre-existing flake on main, not this branch.
- Rebased onto current `origin/main` (through #205); no conflicts.

No credential on any argv or command line; no new `-H`. `TOLERANT_CONTROL_VERBS`' membership, the `write`/`close` confirm gate and the memory saver's re-check-at-fire-time discipline are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
