### PR TITLE
feat(agents): rate limit, fan-out cap, and cross-project refusal

### DIFF
--- a/src/core/agents/agent-message-decide.ts
+++ b/src/core/agents/agent-message-decide.ts
@@ -18,7 +18,18 @@ import { MIN_TOKEN_AWARE_REVISION } from './hooks/managed-script'
  * the policy without either.
  */
 
-export type NotPermittedReason = 'switch-off' | 'cross-project' | 'self-send' | 'unsupported-edition'
+/**
+ * `unaddressable-node-id` is deliberately its own word rather than a shade of `cross-project`: an
+ * id outside `isSafeNodeId` may well be listed in the sender's OWN project file (nothing validates
+ * ids on the load path), so calling it a project-scope failure would be a false statement about
+ * why it was refused — and it needs a different action from the human. See `agent-message-scope.ts`.
+ */
+export type NotPermittedReason =
+  | 'switch-off'
+  | 'cross-project'
+  | 'self-send'
+  | 'unsupported-edition'
+  | 'unaddressable-node-id'
 
 /** Which signal satisfied the delivery receipt (Task 3.4). */
 export type ReceiptSignal = 'newTurn' | 'working'

--- a/src/core/agents/agent-message-flow.test.ts
+++ b/src/core/agents/agent-message-flow.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  PAIR_MIN_INTERVAL_MS,
+  FANOUT_PER_TURN,
+  FANOUT_RETRY_AFTER_MS,
+  TURN_STALE_MS,
+  checkFanOut,
+  checkFlowLimits,
+  checkPairRate,
+  flowStats,
+  noteNewTurn,
+  noteSent,
+  pairKey,
+  resetMessageFlow,
+  type FlowVerdict
+} from './agent-message-flow'
+import { decidePreProbe, RETRYABLE } from './agent-message-decide'
+import { deliverAgentMessage, type DeliveryDeps } from './agent-message'
+import { MANAGED_SCRIPT_REVISION } from './hooks/managed-script'
+import type { MirrorEntry } from '../agent-status-mirror'
+
+const T0 = 1_700_000_000_000
+
+/** The `retryAfterMs` of a refusal, or `null` when the verdict was `ok`. Asserted by RUNNING the
+ *  checks — nothing in this file reads the module's source. */
+const wait = (v: FlowVerdict): number | null => ('ok' in v ? null : v.retryAfterMs)
+
+beforeEach(() => resetMessageFlow())
+
+describe('the per-pair rate limit', () => {
+  it('lets the first delivery of a pair through', () => {
+    expect(wait(checkPairRate('a', 'b', T0))).toBeNull()
+  })
+
+  it('refuses the second inside the window, and the wait is the exact remainder', () => {
+    noteSent('a', 'b', T0)
+    expect(wait(checkPairRate('a', 'b', T0 + 1))).toBe(PAIR_MIN_INTERVAL_MS - 1)
+    expect(wait(checkPairRate('a', 'b', T0 + 4000))).toBe(PAIR_MIN_INTERVAL_MS - 4000)
+    expect(wait(checkPairRate('a', 'b', T0 + PAIR_MIN_INTERVAL_MS - 1))).toBe(1)
+  })
+
+  it('opens again exactly AT the interval, not one tick later', () => {
+    noteSent('a', 'b', T0)
+    expect(wait(checkPairRate('a', 'b', T0 + PAIR_MIN_INTERVAL_MS - 1))).toBe(1)
+    expect(wait(checkPairRate('a', 'b', T0 + PAIR_MIN_INTERVAL_MS))).toBeNull()
+  })
+
+  it('throttles the PAIR, not the sender: A→B says nothing about A→C', () => {
+    // The failure this pins: keyed by sender alone, an orchestrator fanning out to four workers
+    // starves itself — three of its four sends are refused for being correct behaviour.
+    noteSent('a', 'b', T0)
+    expect(wait(checkPairRate('a', 'c', T0 + 1))).toBeNull()
+    expect(wait(checkPairRate('a', 'b', T0 + 1))).toBe(PAIR_MIN_INTERVAL_MS - 1)
+  })
+
+  it('throttles the PAIR, not the target: A→B says nothing about C→B', () => {
+    // The failure this pins: keyed by target alone, one node's window is held shut by whoever
+    // wrote to it last, and every other conversation with that node pays for it.
+    noteSent('a', 'b', T0)
+    expect(wait(checkPairRate('c', 'b', T0 + 1))).toBeNull()
+  })
+
+  it('the REVERSE pair is a different pair — a reply is never throttled by the message it answers', () => {
+    noteSent('a', 'b', T0)
+    expect(wait(checkPairRate('b', 'a', T0 + 1))).toBeNull()
+    // …and the reply's own window is likewise the reply's own.
+    noteSent('b', 'a', T0 + 1)
+    expect(wait(checkPairRate('b', 'a', T0 + 2))).toBe(PAIR_MIN_INTERVAL_MS - 1)
+    expect(wait(checkPairRate('a', 'b', T0 + 2))).toBe(PAIR_MIN_INTERVAL_MS - 2)
+  })
+
+  it('the key composes both ids so no two distinct conversations share one', () => {
+    // The separator is a NUL because a node id cannot contain one. A hyphen or a space could:
+    // 'a-b'\u2192'c' and 'a'\u2192'b-c' would be the SAME key under either, and one conversation
+    // would silently throttle another.
+    // The set must contain ids that DO collide under a weaker key, or this proves nothing: 'ab'+'c'
+    // and 'a'+'bc' are the same string once the separator is dropped. (Found by mutation: without
+    // these four the whole test stayed green with the separator removed entirely.)
+    const ids = ['a', 'b', 'c', 'ab', 'bc', 'a-b', 'b-c', 'a b', 'b c']
+    const seen = new Map<string, string>()
+    for (const src of ids)
+      for (const dst of ids) {
+        const key = pairKey(src, dst)
+        const pair = `${src}\u2192${dst}`
+        expect(seen.get(key) ?? pair, `${seen.get(key)} collided with ${pair}`).toBe(pair)
+        seen.set(key, pair)
+      }
+    expect(seen.size).toBe(ids.length * ids.length)
+    // The reverse pair in particular — the one people get wrong.
+    expect(pairKey('a', 'b')).not.toBe(pairKey('b', 'a'))
+  })
+
+  it('a CHECK never starts a window — only a delivered message does', () => {
+    // Otherwise a delivery refused for any other reason (a busy target, an unverified identity —
+    // the two commonest refusals there are) would burn the budget it never used, and the caller
+    // told to retry would be rate-limited for doing what it was told.
+    expect(wait(checkPairRate('a', 'b', T0))).toBeNull()
+    expect(wait(checkPairRate('a', 'b', T0 + 1))).toBeNull()
+    expect(flowStats().pairs).toBe(0)
+  })
+})
+
+describe('the per-turn fan-out cap', () => {
+  it('passes FANOUT_PER_TURN deliveries in one turn and refuses the next', () => {
+    // Four DIFFERENT targets, so nothing here can be the per-pair limiter firing.
+    for (let i = 0; i < FANOUT_PER_TURN; i++) {
+      expect(wait(checkFanOut('a', T0 + i)), `send ${i + 1} of the turn`).toBeNull()
+      noteSent('a', `dst-${i}`, T0 + i)
+    }
+    expect(wait(checkFanOut('a', T0 + FANOUT_PER_TURN))).toBe(FANOUT_RETRY_AFTER_MS)
+  })
+
+  it("resets on the SOURCE's own newTurn", () => {
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    expect(wait(checkFanOut('a', T0 + 10))).toBe(FANOUT_RETRY_AFTER_MS)
+    noteNewTurn('a')
+    expect(wait(checkFanOut('a', T0 + 10))).toBeNull()
+  })
+
+  it("another node's newTurn does not reset it", () => {
+    // If it did, every delivery would refill the budget that sent it: a delivery is precisely what
+    // starts the TARGET's next turn.
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    noteNewTurn('b')
+    noteNewTurn('dst-0')
+    expect(wait(checkFanOut('a', T0 + 10))).toBe(FANOUT_RETRY_AFTER_MS)
+  })
+
+  it('a tool-event burst does not reset it — nothing but a newTurn does', () => {
+    // The renderer's own per-turn fan-out is keyed on `newTurn` for this reason: a working→done→
+    // working cycle happens many times inside one turn. This module is given no state signal at
+    // all, so the assertion is that everything else it accepts leaves the budget standing.
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    for (let t = 1; t < 60; t++) {
+      checkFanOut('a', T0 + t * 1000)
+      checkPairRate('a', 'dst-0', T0 + t * 1000)
+      noteNewTurn('someone-else')
+    }
+    // Still inside the same turn (well under TURN_STALE_MS), still capped.
+    expect(wait(checkFanOut('a', T0 + 60_000))).toBe(FANOUT_RETRY_AFTER_MS)
+  })
+
+  it('the budget is per SENDER: one node using it up does not silence another', () => {
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    expect(wait(checkFanOut('a', T0 + 10))).toBe(FANOUT_RETRY_AFTER_MS)
+    expect(wait(checkFanOut('b', T0 + 10))).toBeNull()
+  })
+
+  it('expires on its own if the turn signal never arrives — the stuck-limiter backstop', () => {
+    // A shell that never wires `noteNewTurn` would otherwise silence every sender after four
+    // messages, for the rest of the run, with no way to wait it out.
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    const lastSend = T0 + FANOUT_PER_TURN - 1
+    expect(wait(checkFanOut('a', lastSend + TURN_STALE_MS - 1))).toBe(FANOUT_RETRY_AFTER_MS)
+    expect(wait(checkFanOut('a', lastSend + TURN_STALE_MS))).toBeNull()
+  })
+
+  it('the backstop measures the LAST send, not the first — a slow turn is still capped', () => {
+    noteSent('a', 'dst-0', T0)
+    for (let i = 1; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i * (TURN_STALE_MS - 1))
+    const last = T0 + (FANOUT_PER_TURN - 1) * (TURN_STALE_MS - 1)
+    expect(wait(checkFanOut('a', last + 1))).toBe(FANOUT_RETRY_AFTER_MS)
+  })
+})
+
+describe('the refusals are the union member, and they refuse for real', () => {
+  it('a fan-out refusal survives the trip through decidePreProbe', () => {
+    // The trap: `decidePreProbe` refuses on `retryAfterMs > 0`, so a cap reporting 0 would be a cap
+    // that silently stopped existing. Asserted by running the decider on the number this module
+    // actually produces.
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    const v = checkFanOut('a', T0 + 10)
+    expect('ok' in v).toBe(false)
+    const outcome = decidePreProbe({
+      targetLive: true,
+      tokenFilePresent: true,
+      target: { state: 'done', updatedAt: T0, stateVerified: true, clientRevision: MANAGED_SCRIPT_REVISION },
+      retryAfterMs: (v as { retryAfterMs: number }).retryAfterMs
+    })
+    expect(outcome).toEqual({ kind: 'rateLimited', retryAfterMs: FANOUT_RETRY_AFTER_MS })
+    expect(RETRYABLE.rateLimited).toBe(true)
+  })
+
+  it('a pair refusal likewise, with its own remaining wait', () => {
+    noteSent('a', 'b', T0)
+    const v = checkPairRate('a', 'b', T0 + 2500)
+    const outcome = decidePreProbe({
+      targetLive: true,
+      tokenFilePresent: true,
+      target: { state: 'done', updatedAt: T0, stateVerified: true, clientRevision: MANAGED_SCRIPT_REVISION },
+      retryAfterMs: (v as { retryAfterMs: number }).retryAfterMs
+    })
+    expect(outcome).toEqual({ kind: 'rateLimited', retryAfterMs: PAIR_MIN_INTERVAL_MS - 2500 })
+  })
+})
+
+describe('checkFlowLimits — both budgets in one call', () => {
+  it('passes when both do', () => {
+    expect(checkFlowLimits('a', 'b', T0)).toEqual({ ok: true })
+  })
+
+  it('names the pair limit when only the pair is over', () => {
+    noteSent('a', 'b', T0)
+    expect(checkFlowLimits('a', 'b', T0 + 1)).toEqual({
+      ok: false,
+      limit: 'pair',
+      outcome: { kind: 'rateLimited', retryAfterMs: PAIR_MIN_INTERVAL_MS - 1 }
+    })
+  })
+
+  it('names the fan-out cap when only the cap is over', () => {
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    expect(checkFlowLimits('a', 'fresh-target', T0 + 10)).toEqual({
+      ok: false,
+      limit: 'fan-out',
+      outcome: { kind: 'rateLimited', retryAfterMs: FANOUT_RETRY_AFTER_MS }
+    })
+  })
+
+  it('reports the FAN-OUT cap when both refuse — its wait is never the shorter one', () => {
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    // dst-0's pair window has 2 ms left; the fan-out floor is the whole interval. Reporting the
+    // smaller of two live limits would invite a retry that is already known to fail.
+    const nearlyOpen = T0 + PAIR_MIN_INTERVAL_MS - 2
+    expect(checkFlowLimits('a', 'dst-0', nearlyOpen)).toEqual({
+      ok: false,
+      limit: 'fan-out',
+      outcome: { kind: 'rateLimited', retryAfterMs: FANOUT_RETRY_AFTER_MS }
+    })
+  })
+
+  it('and the precedence is only sound while the fan-out floor is the longer wait', () => {
+    // The invariant behind the branch above, pinned so that changing either constant fails here
+    // rather than silently telling a caller to come back before it can be served.
+    expect(FANOUT_RETRY_AFTER_MS).toBeGreaterThanOrEqual(PAIR_MIN_INTERVAL_MS)
+  })
+})
+
+describe('eviction — the entries go away, not just the verdicts', () => {
+  it('drops a pair entry once its window has passed', () => {
+    // Asserted on the MAP, not through a read that shares the window's bound: a limiter that
+    // decides expiry at read time while the map keeps growing passes every verdict test and leaks.
+    noteSent('a', 'b', T0)
+    noteSent('c', 'd', T0)
+    expect(flowStats().pairs).toBe(2)
+    checkPairRate('x', 'y', T0 + PAIR_MIN_INTERVAL_MS)
+    expect(flowStats().pairs).toBe(0)
+  })
+
+  it('keeps a pair entry that is still inside its window', () => {
+    noteSent('a', 'b', T0)
+    checkPairRate('x', 'y', T0 + PAIR_MIN_INTERVAL_MS - 1)
+    expect(flowStats().pairs).toBe(1)
+  })
+
+  it('drops a sender budget once it goes stale, and on a newTurn', () => {
+    noteSent('a', 'b', T0)
+    expect(flowStats().senders).toBe(1)
+    noteNewTurn('a')
+    expect(flowStats().senders).toBe(0)
+    noteSent('a', 'b', T0)
+    checkFanOut('z', T0 + TURN_STALE_MS)
+    expect(flowStats().senders).toBe(0)
+  })
+
+  it('a clock that jumps BACKWARDS drops the entry instead of parking it in the future', () => {
+    // An NTP step back would otherwise leave `PAIR_MIN_INTERVAL_MS - (now - at)` refusing for as
+    // long as the step was large — an agent silenced for an hour by a time correction. Over-sending
+    // by one message is the direction this module always takes.
+    noteSent('a', 'b', T0)
+    expect(wait(checkPairRate('a', 'b', T0 - 60 * 60_000))).toBeNull()
+    expect(flowStats().pairs).toBe(0)
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    expect(wait(checkFanOut('a', T0 - 60 * 60_000))).toBeNull()
+    expect(flowStats().senders).toBe(0)
+  })
+
+  it('resetMessageFlow really empties both maps', () => {
+    noteSent('a', 'b', T0)
+    resetMessageFlow()
+    expect(flowStats()).toEqual({ pairs: 0, senders: 0 })
+    expect(wait(checkPairRate('a', 'b', T0 + 1))).toBeNull()
+  })
+})
+
+describe('the limiter is consulted BEFORE any pane probe', () => {
+  // The point of a pre-probe refusal: on an SSH project whose ControlMaster has died, a probe is a
+  // real login, and a busy-looping sender turns that into the 72k-logins/day shape this repo has
+  // already lived through. Asserted by RUNNING a delivery with a probe that counts its calls.
+  const idle: MirrorEntry = {
+    state: 'done',
+    updatedAt: T0,
+    stateVerified: true,
+    clientRevision: MANAGED_SCRIPT_REVISION
+  }
+
+  function countingDeps(): { deps: DeliveryDeps; probes: number[]; writes: number[] } {
+    const probes: number[] = []
+    const writes: number[] = []
+    return {
+      probes,
+      writes,
+      deps: {
+        paneOwner: async () => {
+          probes.push(1)
+          return null
+        },
+        bracketPasteRequested: async () => true,
+        sendFramed: async () => {
+          writes.push(1)
+          return true
+        },
+        mirrorEntry: () => idle,
+        tokenFilePresent: () => true,
+        lock: async (_id, fn) => fn(),
+        now: () => T0,
+        nonce: () => 'NONCE0123456',
+        trace: async () => ({ traceId: 't-1', traced: 'memory' as const }),
+        subscribeEvents: () => () => {}
+      }
+    }
+  }
+
+  it('a rate-limited delivery touches no pane and writes nothing', async () => {
+    noteSent('n-src', 'n-dst', T0)
+    const check = checkFlowLimits('n-src', 'n-dst', T0 + 1)
+    expect(check.ok).toBe(false)
+    const { deps, probes, writes } = countingDeps()
+    const outcome = await deliverAgentMessage(
+      {
+        targetNodeId: 'n-dst',
+        sourceNodeId: 'n-src',
+        sourceTitle: 'Alpha',
+        body: 'do the thing',
+        targetAgentId: 'claude',
+        retryAfterMs: (check as { outcome: { retryAfterMs: number } }).outcome.retryAfterMs
+      },
+      deps
+    )
+    expect(outcome).toEqual({ kind: 'rateLimited', retryAfterMs: PAIR_MIN_INTERVAL_MS - 1 })
+    expect(probes).toEqual([])
+    expect(writes).toEqual([])
+  })
+
+  it('and the same delivery DOES probe once the budget is clear — the counter is real', async () => {
+    // The control. Without it the assertion above would pass just as well against a delivery that
+    // never probes anything, which would make it evidence of nothing.
+    expect(wait(checkPairRate('n-src', 'n-dst', T0))).toBeNull()
+    const { deps, probes, writes } = countingDeps()
+    const outcome = await deliverAgentMessage(
+      {
+        targetNodeId: 'n-dst',
+        sourceNodeId: 'n-src',
+        sourceTitle: 'Alpha',
+        body: 'do the thing',
+        targetAgentId: 'claude'
+      },
+      deps
+    )
+    expect(probes.length).toBe(1)
+    // An unreadable pane is refused, so still no write — the probe is the thing being counted.
+    expect(outcome).toEqual({ kind: 'targetNotAgentPane', observed: 'unknown' })
+    expect(writes).toEqual([])
+  })
+})

--- a/src/core/agents/agent-message-flow.test.ts
+++ b/src/core/agents/agent-message-flow.test.ts
@@ -17,6 +17,7 @@ import {
 import { decidePreProbe, RETRYABLE } from './agent-message-decide'
 import { deliverAgentMessage, type DeliveryDeps } from './agent-message'
 import { MANAGED_SCRIPT_REVISION } from './hooks/managed-script'
+import { isSafeNodeId } from '../remote-safety'
 import type { MirrorEntry } from '../agent-status-mirror'
 
 const T0 = 1_700_000_000_000
@@ -88,6 +89,23 @@ describe('the per-pair rate limit', () => {
     expect(seen.size).toBe(ids.length * ids.length)
     // The reverse pair in particular — the one people get wrong.
     expect(pairKey('a', 'b')).not.toBe(pairKey('b', 'a'))
+  })
+
+  it('an id CONTAINING the separator would collide two conversations — and is refused upstream', () => {
+    // The uniqueness test above cannot see this: no id in its set can contain a NUL, so the shape
+    // moves one layer down instead of dying. Here it is, exhibited rather than asserted away — and
+    // then the validator that makes the premise true, refusing exactly the ids that cause it.
+    const SEP = String.fromCharCode(0)
+    expect(pairKey(`x${SEP}y`, 'z')).toBe(pairKey('x', `y${SEP}z`))
+    noteSent(`x${SEP}y`, 'z', T0)
+    // …a live mis-throttle: a conversation nobody has had is refused for 9999 ms.
+    expect(wait(checkPairRate('x', `y${SEP}z`, T0 + 1))).toBe(PAIR_MIN_INTERVAL_MS - 1)
+    // Node ids are not validated on the project.json load path, so the premise is enforced at the
+    // authorization boundary instead — `resolveDeliveryScope`, over this predicate.
+    expect(isSafeNodeId(`x${SEP}y`)).toBe(false)
+    expect(isSafeNodeId('x y')).toBe(false)
+    expect(isSafeNodeId('v/1')).toBe(false)
+    expect(isSafeNodeId('term-mabc-3')).toBe(true)
   })
 
   it('a CHECK never starts a window — only a delivered message does', () => {
@@ -273,6 +291,32 @@ describe('eviction — the entries go away, not just the verdicts', () => {
     for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
     expect(wait(checkFanOut('a', T0 - 60 * 60_000))).toBeNull()
     expect(flowStats().senders).toBe(0)
+  })
+
+  it('a NON-FINITE clock reading empties both maps instead of freezing them', () => {
+    // Every comparison in the sweep is FALSE for NaN, so without the guard the entry is immortal —
+    // and the two budgets then fail in opposite directions: the pair limiter's `retryAfterMs` is
+    // NaN (which `decidePreProbe` reads as "no limit", so it fails open) while the fan-out cap
+    // keeps returning a real number forever, silencing the sender for the rest of the run.
+    for (let i = 0; i < FANOUT_PER_TURN; i++) noteSent('a', `dst-${i}`, T0 + i)
+    expect(wait(checkFanOut('a', T0 + 10))).toBe(FANOUT_RETRY_AFTER_MS)
+    expect(wait(checkFanOut('a', Number.NaN))).toBeNull()
+    expect(flowStats()).toEqual({ pairs: 0, senders: 0 })
+    // …and the budget is genuinely released rather than merely reported open once.
+    expect(wait(checkFanOut('a', T0 + 11))).toBeNull()
+    expect(wait(checkPairRate('a', 'dst-0', T0 + 11))).toBeNull()
+  })
+
+  it('an INFINITE reading is safe too, though not because of that guard', () => {
+    // Measured, not assumed: +Infinity is dropped by the staleness arm and -Infinity by the future
+    // arm, so swapping `!Number.isFinite` for `Number.isNaN` is an EQUIVALENT mutation. NaN is the
+    // one value both comparisons are false for, which is what the previous test pins.
+    noteSent('a', 'b', T0)
+    expect(wait(checkPairRate('a', 'b', Number.POSITIVE_INFINITY))).toBeNull()
+    expect(flowStats()).toEqual({ pairs: 0, senders: 0 })
+    noteSent('a', 'b', T0)
+    expect(wait(checkPairRate('a', 'b', Number.NEGATIVE_INFINITY))).toBeNull()
+    expect(flowStats()).toEqual({ pairs: 0, senders: 0 })
   })
 
   it('resetMessageFlow really empties both maps', () => {

--- a/src/core/agents/agent-message-flow.ts
+++ b/src/core/agents/agent-message-flow.ts
@@ -39,8 +39,10 @@ import type { AgentMessageOutcome } from './agent-message-decide'
  *   refuses every future delivery with a number nobody can wait out. That is the failure mode this
  *   module refuses to have, so every path that could produce it fails OPEN: entries are evicted on
  *   read (`sweep`), a clock that jumps BACKWARDS drops the entry instead of parking it in the
- *   future, and a fan-out budget whose reset signal never arrives expires on its own after
- *   `TURN_STALE_MS`.
+ *   future, a NON-FINITE clock reading drops everything (every comparison is false for `NaN`, which
+ *   would otherwise make an entry immortal — and would silence the fan-out budget while the pair
+ *   budget failed open, the worst of both), and a fan-out budget whose reset signal never arrives
+ *   expires on its own after `TURN_STALE_MS`.
  *
  * Nothing here reads the clock, the filesystem or a socket; `now` is injected exactly as it is in
  * `decideDelivery`, so the whole thing is testable without fake timers.
@@ -76,6 +78,13 @@ export const TURN_STALE_MS = 5 * 60_000
  * existing — and something enormous would tell a caller to abandon a budget that clears the moment
  * its turn ends. The per-pair interval is the honest lower bound: nothing this sender does can land
  * sooner than that anyway.
+ *
+ * KNOWN COST, stated so it is not a surprise: in the degenerate case where `noteNewTurn` never
+ * arrives, a caller that obeys this floor exactly spends `TURN_STALE_MS / FANOUT_RETRY_AFTER_MS`
+ * = 30 refused attempts before the staleness backstop opens the budget. Those 30 are cheap for the
+ * host (pre-probe, no pane, no ssh) and expensive for the caller (30 tool calls). The alternative —
+ * reporting the true wait — is not available: the number does not exist while the reset is a turn
+ * boundary rather than a clock event.
  */
 export const FANOUT_RETRY_AFTER_MS = PAIR_MIN_INTERVAL_MS
 
@@ -96,6 +105,20 @@ export type FlowCheck = { ok: true } | { ok: false; limit: FlowLimit; outcome: R
  * A raw NUL in a source file makes git, grep and ripgrep skip the ENTIRE file in silence. This
  * repo has been bitten twice (commit 4c0e8c3); the plan this task comes from was written with a raw
  * one and was itself invisible to grep until it was caught.
+ *
+ * -- THE KEY IS INJECTIVE ONLY OVER IDS THAT PASS `isSafeNodeId`, AND THAT IS A PRECONDITION ------
+ *
+ * An id that CONTAINS the separator collides two different conversations: with S for the separator,
+ * `pairKey('x'+S+'y', 'z')` and `pairKey('x', 'y'+S+'z')` are the same string, and the second
+ * conversation is then throttled by the first. `isSafeNodeId` (`[A-Za-z0-9._-]`, so no NUL, no
+ * space, no slash) is what makes the premise true, and `resolveDeliveryScope` enforces it at the
+ * AUTHORIZATION BOUNDARY rather than here: a limiter is the wrong place to decide whether an id is
+ * addressable at all, and enforcing it in two places would leave one of them untested in practice.
+ *
+ * A DIRECT caller of this module that has not gone through `resolveDeliveryScope` — PR 5's verbs,
+ * PR 7's queue — must validate first. Nothing in the type system says so, which is why the test
+ * asserts the collision EXISTS and asserts the validator refuses exactly the ids that cause it: a
+ * precondition pinned by execution instead of by this paragraph.
  */
 export function pairKey(src: string, dst: string): string {
   return `${src}\u0000${dst}`
@@ -159,8 +182,28 @@ const senderTurns = new Map<string, TurnBudget>()
  * step was large — an agent silenced for an hour by a time correction, with no way to wait it out.
  * Dropping it over-sends by at most one message per pair. That is the direction this module always
  * takes.
+ *
+ * A NON-FINITE `now` gets the same treatment, and it is not a hypothetical tidy-up: EVERY comparison
+ * below is false for `NaN`, so without this line an entry becomes immortal — and the two budgets
+ * then fail in OPPOSITE directions, which is the worst of both. The pair limiter fails open by
+ * accident (its `retryAfterMs` is `NaN`, and `decidePreProbe` refuses on `retryAfterMs > 0`, which
+ * `NaN` is not), while a fan-out budget already at the cap returns a real `FANOUT_RETRY_AFTER_MS`
+ * forever — a permanently silent sender that only a `newTurn` can rescue, which is exactly the
+ * failure this module claims not to have. Unreachable while `now` is `Date.now()`; the guard costs
+ * one comparison and makes the claim true instead of true-by-luck.
+ *
+ * NaN is the only value this line is load-bearing for, and the test says so: `+Infinity` is already
+ * dropped by the staleness arm and `-Infinity` by the future arm below. It is written as
+ * `!Number.isFinite` rather than `Number.isNaN` because that is the intent — a clock reading that
+ * is not a position on the number line — and because a mutation swapping the two is EQUIVALENT
+ * rather than a defect the sweep would let through.
  */
 function sweep(now: number): void {
+  if (!Number.isFinite(now)) {
+    pairLastSentAt.clear()
+    senderTurns.clear()
+    return
+  }
   for (const [key, at] of pairLastSentAt)
     if (at > now || now - at >= PAIR_MIN_INTERVAL_MS) pairLastSentAt.delete(key)
   for (const [id, b] of senderTurns)

--- a/src/core/agents/agent-message-flow.ts
+++ b/src/core/agents/agent-message-flow.ts
@@ -1,0 +1,261 @@
+import type { AgentMessageOutcome } from './agent-message-decide'
+
+/**
+ * FLOW CONTROL — the first throttle the control surface has ever had.
+ *
+ * What exists today is timeouts (`SLOWLORIS_MS` → `CONTROL_CEILING_MS`, the 120 s `pendingControl`
+ * bound) and a one-at-a-time confirmation serializer (`confirmBusy()`). A timeout is not a throttle
+ * and a modal is not a budget — and messaging skips the modal entirely once the per-project switch
+ * is on, so even the accidental brake is gone. These two limits are the replacement.
+ *
+ * Both are PRE-PROBE by construction: they answer from a `Map` lookup, so a refusal costs no tmux
+ * round-trip and — on an SSH project whose ControlMaster has died — no real login. That is not a
+ * micro-optimisation; `-o ControlMaster=auto` turned exactly this shape into 72k logins/day once
+ * already (memory: ssh-controlmaster-fallback). Both refusals are the EXISTING `rateLimited` member
+ * of `AgentMessageOutcome`, never a new ad-hoc shape, so `RETRYABLE` already answers for them.
+ *
+ * ── THREE SURFACES ──────────────────────────────────────────────────────────────────────────────
+ *
+ * - **Desktop (Electron):** the only surface with the messaging verbs, so the only surface that
+ *   consumes budget. The state below is main-process memory, next to `deliverAgentMessage`.
+ * - **Server Edition:** this module ships (everything in `src/core` ships on both shells) and has
+ *   no consumer — messaging does not exist there, and Task 5.3 makes that a named, terminal
+ *   refusal rather than a throttle-shaped one. Nothing here needs a second wiring.
+ * - **Mobile (phone):** never a sender — it drives the canvas over relay→IPC, not `/control/*` —
+ *   so a phone action never calls `noteSent` and never consumes anyone's budget. It IS a valid
+ *   target (Correction C1), and as a target it is covered like any other: the pair budget belongs
+ *   to the PAIR, so a phone-spawned node being messaged by two different orchestrators gets two
+ *   independent windows, which is the correct answer for two independent conversations.
+ *
+ * ── WHERE THE STATE LIVES, AND WHICH WAY IT FAILS ───────────────────────────────────────────────
+ *
+ * Process memory, module scope, for the lifetime of the shell that owns the delivery. Nothing is
+ * persisted, and that is a decision rather than an omission:
+ *
+ * - **A LOST limiter is a brief over-send.** After a restart every pair starts clean, so a pair
+ *   that had just been written to could receive one extra message inside its 10 s window, and every
+ *   sender starts its next turn with a full fan-out budget. Bounded, self-healing, invisible.
+ * - **A STUCK limiter is a permanently silent agent** — an entry that outlives its meaning and
+ *   refuses every future delivery with a number nobody can wait out. That is the failure mode this
+ *   module refuses to have, so every path that could produce it fails OPEN: entries are evicted on
+ *   read (`sweep`), a clock that jumps BACKWARDS drops the entry instead of parking it in the
+ *   future, and a fan-out budget whose reset signal never arrives expires on its own after
+ *   `TURN_STALE_MS`.
+ *
+ * Nothing here reads the clock, the filesystem or a socket; `now` is injected exactly as it is in
+ * `decideDelivery`, so the whole thing is testable without fake timers.
+ */
+
+/** #98's 10 s, kept: the same number, now enforced. */
+export const PAIR_MIN_INTERVAL_MS = 10_000
+
+/** How many DIFFERENT deliveries one sender may make inside a single turn. */
+export const FANOUT_PER_TURN = 4
+
+/**
+ * The fan-out backstop, and the reason it exists is the failure direction above.
+ *
+ * The cap's real reset is the sender's own `newTurn`. If that signal never arrives — a shell that
+ * forgot to wire `noteNewTurn`, a normalizer that stopped flagging turn starts — the counter would
+ * stand forever and the sender would be silent for the rest of the run, which is precisely the
+ * stuck-limiter failure. So a budget that has seen no send for this long is treated as belonging to
+ * a turn that is over.
+ *
+ * It does not make the cap leaky: a burst is by definition sends seconds apart, and this window
+ * never elapses inside one. The worst case it admits is four extra messages per five idle minutes
+ * per sender — and each of those still has to clear the per-pair window.
+ */
+export const TURN_STALE_MS = 5 * 60_000
+
+/**
+ * What a fan-out refusal reports as `retryAfterMs`, and it is a FLOOR, not a promise.
+ *
+ * The budget resets on a turn boundary, which is not a clock event, so no number here is exactly
+ * right. The two obviously-wrong choices are worse than a floor: `0` would be read as "no limit at
+ * all" by `decidePreProbe`, whose refusal is `retryAfterMs > 0` — the cap would silently stop
+ * existing — and something enormous would tell a caller to abandon a budget that clears the moment
+ * its turn ends. The per-pair interval is the honest lower bound: nothing this sender does can land
+ * sooner than that anyway.
+ */
+export const FANOUT_RETRY_AFTER_MS = PAIR_MIN_INTERVAL_MS
+
+/** The `rateLimited` member of the delivery outcome union — reused, never re-declared. */
+export type RateLimited = Extract<AgentMessageOutcome, { kind: 'rateLimited' }>
+
+export type FlowVerdict = { ok: true } | RateLimited
+
+/** Which of the two budgets refused, for the trace. Deliberately NOT on the outcome: the sender is
+ *  told `rateLimited` and a number, because that is all it can act on. */
+export type FlowLimit = 'pair' | 'fan-out'
+
+export type FlowCheck = { ok: true } | { ok: false; limit: FlowLimit; outcome: RateLimited }
+
+/**
+ * The map key, and the separator is written as the ESCAPE `\u0000` — never as a raw byte.
+ *
+ * A raw NUL in a source file makes git, grep and ripgrep skip the ENTIRE file in silence. This
+ * repo has been bitten twice (commit 4c0e8c3); the plan this task comes from was written with a raw
+ * one and was itself invisible to grep until it was caught.
+ */
+export function pairKey(src: string, dst: string): string {
+  return `${src}\u0000${dst}`
+}
+
+/**
+ * WHY THE KEY IS THE PAIR, and what each of the two obvious alternatives breaks.
+ *
+ * - Keyed by SENDER alone, one budget covers everything an orchestrator does: a fan-out to four
+ *   workers is four sends inside a second, so three of them are refused and the orchestrator is
+ *   starved by its own correct behaviour. (A per-sender budget is the right shape for a *turn*
+ *   cap — which is what `checkFanOut` is, with a much larger allowance.)
+ * - Keyed by TARGET alone, one busy node throttles every conversation it is part of, and a sender
+ *   is refused for something another sender did. Worse, it is trivially abusable: a flooder holds
+ *   one target's window shut and nobody else can reach it.
+ * - Keyed by the PAIR, the budget belongs to the conversation. A→B being throttled says nothing
+ *   about A→C, and — asserted explicitly, because it is the one people get wrong — nothing about
+ *   B→A. A reply must never be throttled by the message it answers.
+ */
+const pairLastSentAt = new Map<string, number>()
+
+/**
+ * WHAT IDENTIFIES A TURN: the existence of this entry, delimited by the sender's own `newTurn`.
+ *
+ * There is no turn id to key on, and the three candidates that look like one are each wrong in a
+ * way that matters:
+ *
+ * - **A state transition (`working` → `done`)** would reset the cap several times inside one turn:
+ *   a tool-event burst flips the mirror repeatedly, which is exactly why the renderer's own
+ *   per-turn fan-out is keyed on `newTurn` and not on state (`normalize.ts` — *"true only for a
+ *   genuine new turn … so the renderer can clear per-turn fan-out without clearing on every
+ *   mid-turn tool event"*). A cap that resets mid-turn is not a cap.
+ * - **The session id** spans an entire session — hours, hundreds of turns. A cap keyed on it never
+ *   resets in practice: four messages per session is a permanent block wearing a budget's clothes.
+ * - **Wall-clock windows** refill in the middle of a long turn and refuse at the start of a short
+ *   one, which is the same objection as the first, plus arbitrariness.
+ *
+ * So the entry IS the turn: it is created by the turn's first send, incremented by each subsequent
+ * one, and destroyed by `noteNewTurn(src)` — the same edge `normalize.ts` already flags for exactly
+ * this purpose. `TURN_STALE_MS` is its only other exit, and that exit exists to fail open.
+ */
+interface TurnBudget {
+  /** Sends recorded in the current turn. */
+  sent: number
+  /** When the last of them was recorded — the staleness backstop's input, nothing else. */
+  lastSentAt: number
+}
+const senderTurns = new Map<string, TurnBudget>()
+
+/**
+ * EVICTION, not a read cap.
+ *
+ * Both maps are swept here and the checks below read whatever survives — so an entry that is still
+ * present is, by construction, still in force. There is deliberately no "is it expired?" branch in
+ * the readers: a limiter that decides expiry at read time while the map keeps growing looks correct
+ * from every test that reads through the same bound, and leaks. `flowStats()` exists so a test can
+ * assert the eviction directly instead of inferring it from a verdict.
+ *
+ * The `at > now` arm is the clock-jump guard. An NTP step backwards would otherwise leave an entry
+ * dated in the future, and `PAIR_MIN_INTERVAL_MS - (now - at)` would then refuse for as long as the
+ * step was large — an agent silenced for an hour by a time correction, with no way to wait it out.
+ * Dropping it over-sends by at most one message per pair. That is the direction this module always
+ * takes.
+ */
+function sweep(now: number): void {
+  for (const [key, at] of pairLastSentAt)
+    if (at > now || now - at >= PAIR_MIN_INTERVAL_MS) pairLastSentAt.delete(key)
+  for (const [id, b] of senderTurns)
+    if (b.lastSentAt > now || now - b.lastSentAt >= TURN_STALE_MS) senderTurns.delete(id)
+}
+
+/**
+ * May `src` write into `dst` right now? Pure read — a check NEVER starts a window.
+ *
+ * That matters: if merely asking extended the window, a delivery refused for any other reason (a
+ * busy target, an unverified identity — the two most common refusals in an orchestration session)
+ * would consume the budget it never used, and a caller told to retry would be rate-limited for
+ * doing what it was told. Only `noteSent` records, and only a delivery that actually reached the
+ * pane calls it.
+ */
+export function checkPairRate(src: string, dst: string, now: number): FlowVerdict {
+  sweep(now)
+  const last = pairLastSentAt.get(pairKey(src, dst))
+  if (last === undefined) return { ok: true }
+  return { kind: 'rateLimited', retryAfterMs: PAIR_MIN_INTERVAL_MS - (now - last) }
+}
+
+/** Has `src` used up this turn's fan-out budget? Pure read, same contract as `checkPairRate`. */
+export function checkFanOut(src: string, now: number): FlowVerdict {
+  sweep(now)
+  const budget = senderTurns.get(src)
+  if (!budget || budget.sent < FANOUT_PER_TURN) return { ok: true }
+  return { kind: 'rateLimited', retryAfterMs: FANOUT_RETRY_AFTER_MS }
+}
+
+/**
+ * Both budgets in one call, because two of them is one too many to remember.
+ *
+ * A caller that consults the pair limit and forgets the fan-out cap has shipped half a feature that
+ * looks whole, and nothing would fail.
+ *
+ * When BOTH refuse, the fan-out cap is the one reported, because its wait is never the shorter of
+ * the two: a pair remainder is at most `PAIR_MIN_INTERVAL_MS`, which is what the fan-out floor is.
+ * Reporting the smaller of two live limits would invite a retry already known to fail. The test
+ * pins that relationship between the constants, so weakening either one fails there rather than
+ * quietly turning this precedence into the wrong answer.
+ */
+export function checkFlowLimits(src: string, dst: string, now: number): FlowCheck {
+  const pair = checkPairRate(src, dst, now)
+  const fanOut = checkFanOut(src, now)
+  if (!('ok' in fanOut)) return { ok: false, limit: 'fan-out', outcome: fanOut }
+  if (!('ok' in pair)) return { ok: false, limit: 'pair', outcome: pair }
+  return { ok: true }
+}
+
+/**
+ * Record a delivery that ACTUALLY reached the pane — the single write path for both budgets.
+ *
+ * Called after the write, not before the gate. A refusal puts nothing in anybody's pane, so it
+ * costs nobody's budget; the cost of that choice is that refusals are unthrottled, which is
+ * acceptable precisely because they are pre-probe and free. The cost of the alternative is not: a
+ * sender whose four attempts were all refused as `targetBusy` — a RETRYABLE outcome it was told to
+ * come back from — would find itself silent for the rest of its turn, blocked by the retries the
+ * feature asked it to make.
+ */
+export function noteSent(src: string, dst: string, now: number): void {
+  sweep(now)
+  pairLastSentAt.set(pairKey(src, dst), now)
+  const budget = senderTurns.get(src)
+  if (budget) {
+    budget.sent += 1
+    budget.lastSentAt = now
+  } else {
+    senderTurns.set(src, { sent: 1, lastSentAt: now })
+  }
+}
+
+/**
+ * The sender started a new turn — its fan-out budget is gone with the old one.
+ *
+ * Wired (in Task 5.1) to the same `newTurn` edge the renderer's own per-turn fan-out uses. Deleting
+ * rather than zeroing keeps the map bounded by "senders with an in-flight turn" instead of "senders
+ * seen this run", and makes an absent entry mean exactly one thing.
+ *
+ * Only the SOURCE's own turn resets it. A `newTurn` on the target is another node's business — if
+ * it reset the sender's budget, every message would refill the budget that sent it, because a
+ * delivery is what starts the target's turn.
+ */
+export function noteNewTurn(nodeId: string): void {
+  senderTurns.delete(nodeId)
+}
+
+/** Live entry counts, so a test can assert EVICTION rather than infer it from a verdict. */
+export function flowStats(): { pairs: number; senders: number } {
+  return { pairs: pairLastSentAt.size, senders: senderTurns.size }
+}
+
+/** Drop every budget. Test isolation, and the honest teardown for a shell that is shutting down —
+ *  forgetting is always the safe direction here (see the failure directions above). */
+export function resetMessageFlow(): void {
+  pairLastSentAt.clear()
+  senderTurns.clear()
+}

--- a/src/core/agents/agent-message-scope.test.ts
+++ b/src/core/agents/agent-message-scope.test.ts
@@ -93,7 +93,9 @@ describe('resolveDeliveryScope', () => {
 
   it('resolves a DUPLICATE node id to the sender’s own project', () => {
     // A cloned `project.json` gives two projects the same node id — this repo has shipped that bug
-    // once. The sender addresses the node it can see, and the ambiguity never reaches a pane.
+    // once. The sender addresses the node it can see. This is a ROUTING answer only: sessions are
+    // keyed by the bare node id, so the two ids still name one pane, and no resolver can change
+    // that from here.
     const cloned: ScopeProject[] = [
       { id: 'p-alpha', nodes: [{ id: 'a-1' }, { id: 'dup' }] },
       { id: 'p-clone', nodes: [{ id: 'c-1' }, { id: 'dup' }] }
@@ -121,6 +123,75 @@ describe('resolveDeliveryScope', () => {
 
   it('ids are matched exactly — a case-folded near-miss is not the same node', () => {
     expect(resolveDeliveryScope(projects, 'a-1', 'A-2').kind).toBe('refused')
+  })
+})
+
+describe('an id the app could never have made is refused before anything else', () => {
+  // Node ids come off `.nodeterm/project.json` and the load path validates nothing, so this is the
+  // only place on the messaging path that asks. Two things break without it: the pair limiter's
+  // key stops being injective (its separator is a NUL), and tmux session names FOLD, because
+  // `sessionName()` sanitises rather than refuses — declared `v/1` and `v_1` are one session.
+  const SEP = String.fromCharCode(0)
+  const unsafe = ['a 1', `a${SEP}1`, 'v/1', '../etc', '..', '', 'a$1', 'x'.repeat(129)]
+
+  it.each(unsafe)('refuses %j as a TARGET', (id) => {
+    const scope = resolveDeliveryScope([{ id: 'p', nodes: [{ id: 'a-1' }, { id }] }], 'a-1', id)
+    expect(scope).toEqual({ kind: 'refused', reason: 'unaddressable-node-id', targetFound: true })
+  })
+
+  it.each(unsafe)('refuses %j as a SOURCE', (id) => {
+    const scope = resolveDeliveryScope([{ id: 'p', nodes: [{ id }, { id: 'a-1' }] }], id, 'a-1')
+    expect(scope.kind).toBe('refused')
+    expect((scope as { reason: string }).reason).toBe('unaddressable-node-id')
+  })
+
+  it('refuses it even when BOTH nodes are listed in the same project — this is not a scope failure', () => {
+    // Which is exactly why the word is its own: such an id can be sitting in the sender's own
+    // project file, so calling it `cross-project` would be a false statement about the reason.
+    const both = [{ id: 'p', nodes: [{ id: 'a 1' }, { id: 'a 2' }] }]
+    expect(resolveDeliveryScope(both, 'a 1', 'a 2').kind).toBe('refused')
+    expect(resolveDeliveryScope(both, 'a-1', 'a-2')).toEqual({
+      kind: 'refused',
+      reason: 'cross-project',
+      targetFound: false
+    })
+  })
+
+  it('is decided BEFORE the self-send arm — an unaddressable id is not a self-send', () => {
+    // Both refusals are terminal, so this is about the WORD: "that is not a node id" and "you may
+    // not message yourself" need different actions from whoever reads it.
+    expect(resolveDeliveryScope([{ id: 'p', nodes: [{ id: 'a 1' }] }], 'a 1', 'a 1')).toEqual({
+      kind: 'refused',
+      reason: 'unaddressable-node-id',
+      targetFound: true
+    })
+  })
+
+  it('the two ids that would FOLD to one tmux session are both refused', () => {
+    const folding = [{ id: 'p', nodes: [{ id: 'v/1' }, { id: 'v_1' }] }]
+    // `v_1` is a legal id; `v/1` is the one that sanitises onto it, and it never gets that far.
+    expect(resolveDeliveryScope(folding, 'v_1', 'v/1')).toEqual({
+      kind: 'refused',
+      reason: 'unaddressable-node-id',
+      targetFound: true
+    })
+  })
+
+  it('the ids the app actually emits are all still admitted', () => {
+    // The check must not cost a legitimate population: `nextId()` emits `<prefix>-<base36>-<n>`
+    // and `uuid()` hex-with-dashes.
+    const real = ['term-mabc-3', 'claude-mb1x2y-11', '3f9a1c22-7b0e-4a11-9f00-0c1d2e3f4a5b', 'a.b_c-1']
+    for (const id of real) {
+      const scope = resolveDeliveryScope([{ id: 'p', nodes: [{ id: 'src-1' }, { id }] }], 'src-1', id)
+      expect(scope, id).toEqual({ kind: 'same-project', projectId: 'p' })
+    }
+  })
+
+  it('carries through decideDelivery as its own notPermitted reason, and is terminal', () => {
+    const scope = resolveDeliveryScope([{ id: 'p', nodes: [{ id: 'a-1' }] }], 'a-1', 'a 2')
+    const outcome = decideDelivery(facts({ notPermitted: scopeRefusal(scope) }))
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'unaddressable-node-id' })
+    expect(RETRYABLE.notPermitted).toBe(false)
   })
 })
 

--- a/src/core/agents/agent-message-scope.test.ts
+++ b/src/core/agents/agent-message-scope.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+import { resolveDeliveryScope, scopeRefusal, type ScopeProject } from './agent-message-scope'
+import { decideDelivery, decidePreProbe, RETRYABLE } from './agent-message-decide'
+import { MANAGED_SCRIPT_REVISION } from './hooks/managed-script'
+import type { DeliveryFacts } from './agent-message-decide'
+
+/** Two projects, both with sessions running — the store holds every open AND closed project. */
+const projects: ScopeProject[] = [
+  { id: 'p-alpha', nodes: [{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }] },
+  { id: 'p-beta', nodes: [{ id: 'b-1' }, { id: 'b-2' }] }
+]
+
+/** Every other gate passing, so the only thing a refusal can be attributed to is the scope. */
+const facts = (over: Partial<DeliveryFacts> = {}): DeliveryFacts => ({
+  targetLive: true,
+  pane: 'agent',
+  target: { state: 'done', updatedAt: 1000, stateVerified: true, clientRevision: MANAGED_SCRIPT_REVISION },
+  tokenFilePresent: true,
+  pasteAware: true,
+  ...over
+})
+
+describe('resolveDeliveryScope', () => {
+  it('admits two nodes in the same project, and names it', () => {
+    expect(resolveDeliveryScope(projects, 'a-1', 'a-2')).toEqual({
+      kind: 'same-project',
+      projectId: 'p-alpha'
+    })
+    expect(resolveDeliveryScope(projects, 'b-1', 'b-2')).toEqual({
+      kind: 'same-project',
+      projectId: 'p-beta'
+    })
+  })
+
+  it('refuses a target in ANOTHER project, and says the target exists', () => {
+    expect(resolveDeliveryScope(projects, 'a-1', 'b-1')).toEqual({
+      kind: 'refused',
+      reason: 'cross-project',
+      targetFound: true
+    })
+  })
+
+  it('refuses a target that resolves nowhere, and says so', () => {
+    // Same refusal, different fact behind it: `targetFound: false` is what separates "aimed at
+    // another project" from "aimed at nothing", and only one of those is worth a human's time.
+    expect(resolveDeliveryScope(projects, 'a-1', 'ghost')).toEqual({
+      kind: 'refused',
+      reason: 'cross-project',
+      targetFound: false
+    })
+  })
+
+  it('refuses when the SOURCE belongs to no project the store knows — fail closed', () => {
+    // The thing being authorised is a write into someone else's terminal. Anything that cannot be
+    // positively resolved to one shared project is refused; there is no benefit of the doubt.
+    expect(resolveDeliveryScope(projects, 'ghost', 'a-1')).toEqual({
+      kind: 'refused',
+      reason: 'cross-project',
+      targetFound: true
+    })
+    expect(resolveDeliveryScope([], 'a-1', 'a-2')).toEqual({
+      kind: 'refused',
+      reason: 'cross-project',
+      targetFound: false
+    })
+  })
+
+  it('refuses a self-send wherever the id lives, or does not', () => {
+    expect(resolveDeliveryScope(projects, 'a-1', 'a-1')).toEqual({
+      kind: 'refused',
+      reason: 'self-send',
+      targetFound: true
+    })
+    expect(resolveDeliveryScope(projects, 'ghost', 'ghost')).toEqual({
+      kind: 'refused',
+      reason: 'self-send',
+      targetFound: false
+    })
+  })
+
+  it('a node the LIVE canvas has but the store does not is refused, not admitted', () => {
+    // The guarantee behind "resolved against the serialized store, not `nodesRef`": there is no
+    // parameter here for a live node list, so a node that exists only on the live canvas is simply
+    // absent — and absent fails closed. A freshly created node is not a verified idle agent yet
+    // either, so nothing deliverable is lost.
+    const justCreatedOnCanvas = 'a-9'
+    expect(resolveDeliveryScope(projects, 'a-1', justCreatedOnCanvas)).toEqual({
+      kind: 'refused',
+      reason: 'cross-project',
+      targetFound: false
+    })
+  })
+
+  it('resolves a DUPLICATE node id to the sender’s own project', () => {
+    // A cloned `project.json` gives two projects the same node id — this repo has shipped that bug
+    // once. The sender addresses the node it can see, and the ambiguity never reaches a pane.
+    const cloned: ScopeProject[] = [
+      { id: 'p-alpha', nodes: [{ id: 'a-1' }, { id: 'dup' }] },
+      { id: 'p-clone', nodes: [{ id: 'c-1' }, { id: 'dup' }] }
+    ]
+    expect(resolveDeliveryScope(cloned, 'a-1', 'dup')).toEqual({
+      kind: 'same-project',
+      projectId: 'p-alpha'
+    })
+    expect(resolveDeliveryScope(cloned, 'c-1', 'dup')).toEqual({
+      kind: 'same-project',
+      projectId: 'p-clone'
+    })
+  })
+
+  it('does not care whether the project tab is closed — a delivery goes to a pane', () => {
+    // A closed project's tmux sessions keep running and are re-adopted on the next start; that is
+    // the premise `routeControlSource` is built on. Filtering closed projects out would refuse a
+    // perfectly deliverable message on the grounds that a tab is shut.
+    const closed = [{ id: 'p-alpha', closed: true, nodes: [{ id: 'a-1' }, { id: 'a-2' }] }]
+    expect(resolveDeliveryScope(closed, 'a-1', 'a-2')).toEqual({
+      kind: 'same-project',
+      projectId: 'p-alpha'
+    })
+  })
+
+  it('ids are matched exactly — a case-folded near-miss is not the same node', () => {
+    expect(resolveDeliveryScope(projects, 'a-1', 'A-2').kind).toBe('refused')
+  })
+})
+
+describe('scopeRefusal feeds decideDelivery, and the refusal is terminal', () => {
+  it('a cross-project target is notPermitted{cross-project} and is NOT retryable', () => {
+    const scope = resolveDeliveryScope(projects, 'a-1', 'b-1')
+    const outcome = decideDelivery(facts({ notPermitted: scopeRefusal(scope) }))
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'cross-project' })
+    expect(RETRYABLE.notPermitted).toBe(false)
+  })
+
+  it('a same-project target contributes no refusal at all', () => {
+    const scope = resolveDeliveryScope(projects, 'a-1', 'a-2')
+    expect(scopeRefusal(scope)).toBeUndefined()
+    expect(decideDelivery(facts({ notPermitted: scopeRefusal(scope) })).kind).toBe('proceed')
+  })
+
+  it('the refusal is decided PRE-PROBE, with no pane fact at all', () => {
+    const scope = resolveDeliveryScope(projects, 'a-1', 'b-1')
+    expect(
+      decidePreProbe({
+        targetLive: true,
+        tokenFilePresent: true,
+        target: undefined,
+        notPermitted: scopeRefusal(scope)
+      })
+    ).toEqual({ kind: 'notPermitted', reason: 'cross-project' })
+  })
+})
+
+describe('the self-send guard that already exists in the decider (PR #207) still holds', () => {
+  it('refuses a self-send even when the caller passes no scope verdict at all', () => {
+    // Verified, not re-implemented: `decidePreProbe` carries its own backstop so that no future
+    // caller — PR 7's deliver-on-idle queue above all — can forget the outer guard and let a node
+    // message itself in a loop with a rate limiter for a brake.
+    expect(decideDelivery(facts({ sourceNodeId: 'a-1', targetNodeId: 'a-1' }))).toEqual({
+      kind: 'notPermitted',
+      reason: 'self-send'
+    })
+  })
+
+  it('the two guards agree on the word, so a trace cannot depend on which one fired', () => {
+    const outer = scopeRefusal(resolveDeliveryScope(projects, 'a-1', 'a-1'))
+    const inner = decideDelivery(facts({ sourceNodeId: 'a-1', targetNodeId: 'a-1' }))
+    expect(inner).toEqual({ kind: 'notPermitted', reason: outer })
+  })
+
+  it('the backstop is ahead of the rate limiter, so a self-send is never reported as a wait', () => {
+    expect(
+      decideDelivery(facts({ sourceNodeId: 'a-1', targetNodeId: 'a-1', retryAfterMs: 9999 })).kind
+    ).toBe('notPermitted')
+  })
+})

--- a/src/core/agents/agent-message-scope.ts
+++ b/src/core/agents/agent-message-scope.ts
@@ -1,3 +1,4 @@
+import { isSafeNodeId } from '../remote-safety'
 import type { NotPermittedReason } from './agent-message-decide'
 
 /**
@@ -15,12 +16,17 @@ import type { NotPermittedReason } from './agent-message-decide'
  * exists to fix on the source side, where it surfaced as a lost capability rather than as the wrong
  * canvas answering.
  *
- * The fix is NOT to travel to the target's project. `send` is declared outside `needsLiveCanvas`
- * precisely so it never can: travelling would yank the human's view to another tab on a background
- * agent's say-so, and `setActive` on the way would clear that node's unread badge — a delivery
- * silently erasing the signal a human relies on (G5). So this resolver takes the projects store and
- * NOTHING else. There is no parameter for a live node list, which is a guarantee a test can check
- * by running it: a node the live canvas has but the store has not is refused, not admitted.
+ * Nor is the fix to travel to the target's project, and THIS resolver is what makes that
+ * impossible: it takes the projects store and NOTHING else. There is no parameter for a live node
+ * list, so there is nothing to travel toward — a guarantee a test can check by running it, since a
+ * node the live canvas has but the store has not is refused rather than admitted.
+ *
+ * `needsLiveCanvas` is a different guarantee and must not be confused with this one: Canvas routes
+ * by SOURCE (`routeControlSource(projects, activeId, sourceNodeId)`), so declaring `send`/`reply`
+ * store-answered stops a travel to the SENDER's project — the one an off-canvas orchestrator would
+ * otherwise trigger on every message it sent. Both matter, for different halves of the pair, and
+ * either alone would leave a way for a background agent to yank the human's view and clear an
+ * unread badge on the way (G5).
  *
  * ── THREE SURFACES ──────────────────────────────────────────────────────────────────────────────
  *
@@ -34,21 +40,27 @@ import type { NotPermittedReason } from './agent-message-decide'
  * ── WHICH WAY IT FAILS ──────────────────────────────────────────────────────────────────────────
  *
  * CLOSED, because the thing being authorised is a write into someone else's terminal. Anything this
- * cannot positively resolve to a single shared project is refused: a source that belongs to no
- * project the store knows, a target that resolves nowhere, a target in a project the store has but
- * the sender does not share. `notPermitted` is not retryable, so a refusal here is terminal — which
- * is correct for a boundary and would be wrong for a timing problem, and none of these are timing
- * problems.
+ * cannot positively resolve to a single shared project is refused: an id outside `isSafeNodeId`, a
+ * source that belongs to no project the store knows, a target that resolves nowhere, a target in a
+ * project the store has but the sender does not share. `notPermitted` is not retryable, so a
+ * refusal here is terminal — which is correct for a boundary and would be wrong for a timing
+ * problem, and none of these are timing problems.
  */
 
 /** The little this needs from a project — a structural subset of both `Project` and the store's
- *  serialized `ProjectFileV1`, so either can be passed without adaptation. */
+ *  serialized `ProjectFileV1`, so either can be passed without adaptation.
+ *
+ *  `nodes` is required rather than optional on purpose, and the caller owns that: a synthesised
+ *  array with `nodes` absent throws here instead of failing closed. Every real `Project` has it. */
 export interface ScopeProject {
   id: string
   nodes: readonly { id: string }[]
 }
 
-export type ScopeRefusal = Extract<NotPermittedReason, 'self-send' | 'cross-project'>
+export type ScopeRefusal = Extract<
+  NotPermittedReason,
+  'self-send' | 'cross-project' | 'unaddressable-node-id'
+>
 
 export type DeliveryScope =
   | { kind: 'same-project'; projectId: string }
@@ -64,18 +76,49 @@ export type DeliveryScope =
 /**
  * Resolve a (source, target) pair to the project they share, or to the refusal that stops it.
  *
- * `self-send` is checked first and is the same rule, in the same words, that the manual
- * `onConnect` already applies to a canvas edge — a node may not be wired to itself. It is decided
- * before project membership because it is true regardless of where either id lives, including when
- * neither lives anywhere.
+ * ── THE ID ITSELF IS CHECKED FIRST, AND NOTHING ELSE ON THIS PATH DOES IT ───────────────────────
+ *
+ * Node ids come out of `.nodeterm/project.json` and `fileToProject` validates NOTHING — the repo
+ * says so at `node-identity-policy.ts:128` and `hook-server.ts:282`. `isSafeNodeId` exists and is
+ * applied at `PtyManager.create()`, which is not the load path this resolver reads. Two concrete
+ * consequences, and both are why the check is here rather than deeper:
+ *
+ *  - **The pair limiter's key stops being injective.** Its separator is a NUL, so an id CONTAINING
+ *    one collides two different conversations and each throttles the other (`agent-message-flow.ts`
+ *    spells out the shape). `isSafeNodeId`'s charset — `[A-Za-z0-9._-]` — is exactly what makes
+ *    that impossible.
+ *  - **tmux session names FOLD.** `sessionName()` sanitises rather than refuses, so declared ids
+ *    `v/1` and `v_1` name ONE session. An id that cannot be sanitised into a different node's
+ *    session is the only kind worth admitting.
+ *
+ * Refused as `unaddressable-node-id`, not as `cross-project`: such an id may be listed in the
+ * sender's own project, so the scope word would be a false statement about why it was refused.
+ *
+ * `self-send` is the same rule, in the same words, that the manual `onConnect` already applies to a
+ * canvas edge — a node may not be wired to itself. It is decided before project membership because
+ * it is true regardless of where either id lives, including when neither lives anywhere.
  *
  * Note that this is the OUTER guard, not the only one: `decidePreProbe` carries its own self-send
  * backstop so that no future caller can forget this one. Both produce the identical
  * `notPermitted{reason:'self-send'}`, which the test asserts by running them.
  *
- * A duplicate node id across two projects (a cloned `project.json` — this repo has shipped that
- * bug once) resolves to the SOURCE's project when the source's project is one of them: the sender
- * addresses the node it can see, and the ambiguity never reaches the pane.
+ * ── A DUPLICATE NODE ID IS RESOLVED, NOT DISAMBIGUATED ──────────────────────────────────────────
+ *
+ * A duplicate id across two projects (a cloned `project.json` — this repo has shipped that bug
+ * once) resolves to the SOURCE's project when the source's project is one of them: the sender
+ * addresses the node it can see.
+ *
+ * That is a routing answer, NOT an isolation guarantee, and the earlier claim here that "the
+ * ambiguity never reaches the pane" was false. A session's only key is the bare node id
+ * (`PtyManager.byPersistKey`, `paneOwner(persistKey)`, tmux `nt-<nodeId>`); no project id appears
+ * anywhere in that namespace and nothing de-duplicates ids when a second project carrying them is
+ * opened. So a `project.json` that merely LISTS another project's node id resolves `same-project`
+ * here and lands in that node's one global pane — verified by execution, not reasoned about.
+ *
+ * This resolver cannot close that: the ambiguity is in the session namespace, not in the scope
+ * question. What it can do is refuse the ids that make it worse, which is the check above.
+ * **PR 5's delivery call must run `isSafeNodeId(targetNodeId)` before `paneOwner`** — a direct
+ * caller that skips this resolver gets neither guard.
  *
  * `closed` and `unavailable` projects are deliberately NOT filtered out. A closed project's tmux
  * sessions keep running and are re-adopted on the next start — that is the whole premise of
@@ -89,6 +132,8 @@ export function resolveDeliveryScope(
 ): DeliveryScope {
   const has = (p: ScopeProject, id: string): boolean => p.nodes.some((n) => n.id === id)
   const targetFound = projects.some((p) => has(p, targetNodeId))
+  if (!isSafeNodeId(sourceNodeId) || !isSafeNodeId(targetNodeId))
+    return { kind: 'refused', reason: 'unaddressable-node-id', targetFound }
   if (sourceNodeId === targetNodeId) return { kind: 'refused', reason: 'self-send', targetFound }
   const owner = projects.find((p) => has(p, sourceNodeId))
   if (owner && has(owner, targetNodeId)) return { kind: 'same-project', projectId: owner.id }

--- a/src/core/agents/agent-message-scope.ts
+++ b/src/core/agents/agent-message-scope.ts
@@ -1,0 +1,102 @@
+import type { NotPermittedReason } from './agent-message-decide'
+
+/**
+ * WHO MAY BE ADDRESSED — the project boundary, resolved off the SERIALIZED store.
+ *
+ * A message crosses into another agent's session, so the question "is this target mine to write
+ * to?" has to be answered before anything else happens, and it has to be answered from a source of
+ * truth that covers every project rather than the one that happens to be on screen.
+ *
+ * ── WHY THE SERIALIZED STORE AND NOT THE LIVE CANVAS ────────────────────────────────────────────
+ *
+ * React Flow only ever holds the ACTIVE project's nodes (`nodesRef`), while the tmux sessions of
+ * every other open project keep running. Resolving a target against `nodesRef` therefore answers
+ * "not on the canvas" for every node outside the current tab — the same defect `routeControlSource`
+ * exists to fix on the source side, where it surfaced as a lost capability rather than as the wrong
+ * canvas answering.
+ *
+ * The fix is NOT to travel to the target's project. `send` is declared outside `needsLiveCanvas`
+ * precisely so it never can: travelling would yank the human's view to another tab on a background
+ * agent's say-so, and `setActive` on the way would clear that node's unread badge — a delivery
+ * silently erasing the signal a human relies on (G5). So this resolver takes the projects store and
+ * NOTHING else. There is no parameter for a live node list, which is a guarantee a test can check
+ * by running it: a node the live canvas has but the store has not is refused, not admitted.
+ *
+ * ── THREE SURFACES ──────────────────────────────────────────────────────────────────────────────
+ *
+ * - **Desktop (Electron):** the caller. It passes `useProjects.getState().projects`, the same
+ *   serialized array `routeControlSource` and `storedNodeListing` already read.
+ * - **Server Edition:** ships, unused — messaging does not exist there (Task 5.3). Pure, with no
+ *   electron or main-shell import, so it ships on both shells like everything else in `src/core`.
+ * - **Mobile (phone):** never a sender, so it never calls this. A phone-spawned node IS a valid
+ *   target and is resolved exactly like any other: it is a node id in a persisted project.
+ *
+ * ── WHICH WAY IT FAILS ──────────────────────────────────────────────────────────────────────────
+ *
+ * CLOSED, because the thing being authorised is a write into someone else's terminal. Anything this
+ * cannot positively resolve to a single shared project is refused: a source that belongs to no
+ * project the store knows, a target that resolves nowhere, a target in a project the store has but
+ * the sender does not share. `notPermitted` is not retryable, so a refusal here is terminal — which
+ * is correct for a boundary and would be wrong for a timing problem, and none of these are timing
+ * problems.
+ */
+
+/** The little this needs from a project — a structural subset of both `Project` and the store's
+ *  serialized `ProjectFileV1`, so either can be passed without adaptation. */
+export interface ScopeProject {
+  id: string
+  nodes: readonly { id: string }[]
+}
+
+export type ScopeRefusal = Extract<NotPermittedReason, 'self-send' | 'cross-project'>
+
+export type DeliveryScope =
+  | { kind: 'same-project'; projectId: string }
+  | {
+      kind: 'refused'
+      reason: ScopeRefusal
+      /** Does this target id exist in ANY project the store knows? `false` separates "aimed at
+       *  another project" from "aimed at nothing" — the same refusal, but only one of them is
+       *  worth telling a human about. */
+      targetFound: boolean
+    }
+
+/**
+ * Resolve a (source, target) pair to the project they share, or to the refusal that stops it.
+ *
+ * `self-send` is checked first and is the same rule, in the same words, that the manual
+ * `onConnect` already applies to a canvas edge — a node may not be wired to itself. It is decided
+ * before project membership because it is true regardless of where either id lives, including when
+ * neither lives anywhere.
+ *
+ * Note that this is the OUTER guard, not the only one: `decidePreProbe` carries its own self-send
+ * backstop so that no future caller can forget this one. Both produce the identical
+ * `notPermitted{reason:'self-send'}`, which the test asserts by running them.
+ *
+ * A duplicate node id across two projects (a cloned `project.json` — this repo has shipped that
+ * bug once) resolves to the SOURCE's project when the source's project is one of them: the sender
+ * addresses the node it can see, and the ambiguity never reaches the pane.
+ *
+ * `closed` and `unavailable` projects are deliberately NOT filtered out. A closed project's tmux
+ * sessions keep running and are re-adopted on the next start — that is the whole premise of
+ * `routeControlSource` — and a delivery goes to a pane, not to a canvas. Filtering them would
+ * refuse a perfectly deliverable message on the grounds that a tab is shut.
+ */
+export function resolveDeliveryScope(
+  projects: readonly ScopeProject[],
+  sourceNodeId: string,
+  targetNodeId: string
+): DeliveryScope {
+  const has = (p: ScopeProject, id: string): boolean => p.nodes.some((n) => n.id === id)
+  const targetFound = projects.some((p) => has(p, targetNodeId))
+  if (sourceNodeId === targetNodeId) return { kind: 'refused', reason: 'self-send', targetFound }
+  const owner = projects.find((p) => has(p, sourceNodeId))
+  if (owner && has(owner, targetNodeId)) return { kind: 'same-project', projectId: owner.id }
+  return { kind: 'refused', reason: 'cross-project', targetFound }
+}
+
+/** The `notPermitted` fact `decideDelivery` takes, or `undefined` when the pair may proceed.
+ *  Keeping the mapping here means a caller cannot invent a third answer. */
+export function scopeRefusal(scope: DeliveryScope): NotPermittedReason | undefined {
+  return scope.kind === 'refused' ? scope.reason : undefined
+}

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -234,3 +234,24 @@ describe('the strict identity bucket is pre-positioned, not live', () => {
     expect(STRICT_CONTROL_VERBS.has('open-browser')).toBe(false)
   })
 })
+
+/**
+ * The same pre-positioning, for messaging. `needsLiveCanvas` already declares `send`/`reply` as
+ * store-answered so that a delivery can never travel the camera — a routing decision made once,
+ * ahead of the dispatch that will consume it.
+ *
+ * This test is what stops "it ships inert" from becoming a false claim: it FAILS on the day the
+ * verbs land, which is exactly when the PR body has to stop saying nothing changes for anyone —
+ * and when Canvas's store-answered branch, which today only knows how to answer `list`, has to
+ * learn to deliver instead of replying with a node listing.
+ */
+describe('the messaging verbs are declared but do not exist yet', () => {
+  it('send and reply are refused by the parser, so nothing routes them today', () => {
+    expect(parseControlRequest('send', { node: 'n-1', text: 'hi' })).toEqual({
+      error: 'Unknown verb: send'
+    })
+    expect(parseControlRequest('reply', { node: 'n-1', text: 'hi' })).toEqual({
+      error: 'Unknown verb: reply'
+    })
+  })
+})

--- a/src/renderer/lib/controlRouting.test.ts
+++ b/src/renderer/lib/controlRouting.test.ts
@@ -74,9 +74,10 @@ describe('needsLiveCanvas', () => {
   })
 
   it('is false for send and reply — a delivery must never travel the camera', () => {
-    // Travelling to the target's project would hijack the human's view on a background agent's
-    // say-so, and the `setActive` on the way would clear that node's unread badge — a message
-    // silently erasing the signal a human relies on. A delivery goes to a pane; it needs no canvas.
+    // Routing here is by SOURCE, so what this stops is a trip to the SENDER's project — which an
+    // off-canvas orchestrator would otherwise trigger on every message it sent, hijacking the
+    // human's view and clearing an unread badge via `setActive` on the way (G5). Never travelling
+    // to the TARGET's project is a different guarantee, and it belongs to `resolveDeliveryScope`.
     expect(needsLiveCanvas('send')).toBe(false)
     expect(needsLiveCanvas('reply')).toBe(false)
   })

--- a/src/renderer/lib/controlRouting.test.ts
+++ b/src/renderer/lib/controlRouting.test.ts
@@ -72,6 +72,14 @@ describe('needsLiveCanvas', () => {
       expect(needsLiveCanvas(verb)).toBe(true)
     }
   })
+
+  it('is false for send and reply — a delivery must never travel the camera', () => {
+    // Travelling to the target's project would hijack the human's view on a background agent's
+    // say-so, and the `setActive` on the way would clear that node's unread badge — a message
+    // silently erasing the signal a human relies on. A delivery goes to a pane; it needs no canvas.
+    expect(needsLiveCanvas('send')).toBe(false)
+    expect(needsLiveCanvas('reply')).toBe(false)
+  })
 })
 
 describe('sourceIsControlCapable', () => {

--- a/src/renderer/lib/controlRouting.ts
+++ b/src/renderer/lib/controlRouting.ts
@@ -72,12 +72,17 @@ export function routeControlSource(
  * keeps a background agent's polling from yanking the user's view to another project tab on every
  * call.
  *
- * `send`/`reply` are here for a stronger reason than politeness. A delivery goes to a tmux PANE,
- * not to a canvas, so travelling to the target's project buys nothing — and it costs twice: it
- * hijacks the human's view on a background agent's say-so, and the `setActive` on the way clears
- * that node's unread badge, so a message silently erases the signal a human relies on. The target
- * is therefore resolved off the store (`resolveDeliveryScope`), which is also the only source of
- * truth that can see nodes outside the active tab at all.
+ * `send`/`reply` are here for a stronger reason than politeness, and it is worth being precise
+ * about WHICH travel this prevents: routing here is by SOURCE
+ * (`routeControlSource(projects, activeId, sourceNodeId)`), so what the declaration stops is a trip
+ * to the SENDER's project — which an off-canvas orchestrator would otherwise trigger on every
+ * message it sent, hijacking the human's view on a background agent's say-so and clearing that
+ * node's unread badge via `setActive` on the way (G5). A delivery goes to a tmux PANE, not to a
+ * canvas, so it needs no live canvas at either end.
+ *
+ * The other half — never travelling to the TARGET's project — is not this function's doing. It
+ * comes from `resolveDeliveryScope` (`src/core/agents/agent-message-scope.ts`) taking the
+ * serialized store and having no live-node parameter at all, so there is nothing to travel toward.
  *
  * INERT AS OF THIS COMMIT: neither verb is in `ControlVerb` yet, so `parseControlRequest` refuses
  * both before any of this is reached (asserted by running it, in `canvas-control-core.test.ts`).

--- a/src/renderer/lib/controlRouting.ts
+++ b/src/renderer/lib/controlRouting.ts
@@ -66,13 +66,32 @@ export function routeControlSource(
 }
 
 /**
+ * Verbs that are answered from the SERIALIZED store instead of the live canvas.
+ *
+ * `list` reads names only, and it is the verb an agent calls most — answering it out of the store
+ * keeps a background agent's polling from yanking the user's view to another project tab on every
+ * call.
+ *
+ * `send`/`reply` are here for a stronger reason than politeness. A delivery goes to a tmux PANE,
+ * not to a canvas, so travelling to the target's project buys nothing — and it costs twice: it
+ * hijacks the human's view on a background agent's say-so, and the `setActive` on the way clears
+ * that node's unread badge, so a message silently erases the signal a human relies on. The target
+ * is therefore resolved off the store (`resolveDeliveryScope`), which is also the only source of
+ * truth that can see nodes outside the active tab at all.
+ *
+ * INERT AS OF THIS COMMIT: neither verb is in `ControlVerb` yet, so `parseControlRequest` refuses
+ * both before any of this is reached (asserted by running it, in `canvas-control-core.test.ts`).
+ * The declaration lands first so the routing decision is made once, here, rather than inside the
+ * dispatch that Task 5.1 adds.
+ */
+const STORE_ANSWERED_VERBS: ReadonlySet<string> = new Set(['list', 'send', 'reply'])
+
+/**
  * Does this verb have to run against the LIVE canvas? Everything that creates, moves, writes to or
- * closes a node does. `list` reads names only, and it is the verb an agent calls most — answering
- * it out of the store keeps a background agent's polling from yanking the user's view to another
- * project tab on every call.
+ * closes a node does.
  */
 export function needsLiveCanvas(verb: string): boolean {
-  return verb !== 'list'
+  return !STORE_ANSWERED_VERBS.has(verb)
 }
 
 /**


### PR DESCRIPTION
PR 4 of the agent-messaging plan: flow control. **It ships inert** — `parseControlRequest` still
refuses `send` and `reply` as unknown verbs (asserted by running it), so nothing in this PR is
reachable by any agent until PR 5 lands the verbs. It builds directly on #207's `decidePreProbe`,
the 16-member outcome union, and `RETRYABLE`.

## The pair limit is keyed by the PAIR, and the two alternatives each break something

`checkPairRate(src, dst, now)`, `PAIR_MIN_INTERVAL_MS = 10_000` (#98's number, now enforced).

| Keying | What it produces |
| --- | --- |
| by SENDER | An orchestrator fanning out to four workers starves itself: four sends inside a second, three refused for being correct behaviour. (That shape is the right one for a *turn* cap, which is what the second limit is — with a much larger allowance.) |
| by TARGET | One node's window is held shut by whoever wrote to it last, and every other conversation with that node pays for it. Trivially abusable: a flooder makes a target unreachable for everyone. |
| **by PAIR** | The budget belongs to the conversation. A to B says nothing about A to C, and — asserted explicitly — nothing about B to A, so **a reply is never throttled by the message it answers**. |

The map key writes its separator as the six-character escape (backslash-u-0000), never a raw byte:
a raw NUL makes git, grep and ripgrep skip the entire source file in silence (commit 4c0e8c3,
twice).

## What identifies a turn

`checkFanOut(src, now)`, `FANOUT_PER_TURN = 4`, reset by `noteNewTurn(nodeId)`.

**A turn is the budget entry itself** — created by the turn's first send, destroyed by the sender's
own `newTurn`. That is the same edge the renderer's per-turn fan-out already uses (`normalize.ts`:
*"true only for a genuine new turn … so the renderer can clear per-turn fan-out without clearing on
every mid-turn tool event"*). The three things that look like turn ids and are not:

- **A state transition (`working` to `done`)** flips several times inside one turn on a tool-event
  burst. A cap that resets mid-turn is not a cap.
- **The session id** spans hours and hundreds of turns: four messages per session is a permanent
  block wearing a budget's clothes.
- **A wall-clock window** refills in the middle of a long turn and refuses at the start of a short
  one.

Only the SOURCE's own `newTurn` resets it — if the target's did, every delivery would refill the
budget that sent it, because a delivery is what starts the target's turn.

## Where the state lives, and which way it fails

Process memory, module scope, swept on read. Nothing persisted, deliberately:

- **A lost limiter is a brief over-send.** After a restart, one extra message per pair inside its
  10 s window and a full fan-out budget. Bounded, self-healing, invisible.
- **A stuck limiter is a permanently silent agent** — the failure this module refuses to have. So
  every path that could produce one fails OPEN:
  - entries are **evicted**, not filtered at read time (a limiter that decides expiry on read while
    the map grows looks correct to every test that reads through the same bound, and leaks);
  - a clock jumping **backwards** drops the entry instead of parking it in the future (an NTP step
    would otherwise silence an agent for the length of the step);
  - a fan-out budget whose reset signal never arrives expires by itself after `TURN_STALE_MS`
    (5 min) — so a shell that forgets to wire `noteNewTurn` over-sends four messages per idle five
    minutes instead of silencing every sender for the rest of the run.

Both limits are **pre-probe**: they answer from a `Map`, so a refusal costs no tmux round-trip and,
on an SSH project whose ControlMaster has died, no real login. Asserted by running a delivery with a
probe that counts its calls (0 when rate-limited, 1 on the control). Both refuse with the existing
`rateLimited` member, so `RETRYABLE` already answers for them. A fan-out refusal reports the pair
interval as `retryAfterMs` — a floor, not a promise: `0` would be read as "no limit" by
`decidePreProbe`, whose refusal is `retryAfterMs > 0`, and the cap would silently stop existing.

**A check never starts a window.** Only `noteSent` records, and only a delivery that actually reached
a pane calls it. Otherwise a delivery refused as `targetBusy` — a RETRYABLE outcome the caller was
told to come back from — would burn the budget it never used, and four such retries would silence
the sender for its whole turn. The cost of that choice: refusals themselves are unthrottled, which
is acceptable precisely because they are free.

## Cross-project, resolved off the store

`resolveDeliveryScope(projects, src, dst)` takes the serialized projects array — the same one
`routeControlSource` and `storedNodeListing` read — and **has no parameter for a live node list**.
That is the guarantee, and the test checks it by effect: a node the live canvas has but the store
does not is refused. It fails **closed** (a source in no known project, a target in no known
project, and a target in an unshared project are all `cross-project`, which is not retryable),
resolves a duplicate node id from a cloned `project.json` to the sender's own project, and does not
filter closed projects — their tmux sessions keep running and a delivery goes to a pane.

`send`/`reply` are declared outside `needsLiveCanvas`, so a delivery can never travel the camera:
travelling would hijack the human's view on a background agent's say-so and the `setActive` on the
way would clear that node's unread badge — a message silently erasing the signal a human relies on
(G5).

**The self-send half was already landed by #207** (`decidePreProbe`, ahead of everything but an
explicit `notPermitted`) and is **not** re-implemented here. It is verified by running it, including
that both guards produce the identical `notPermitted{reason:'self-send'}` so a trace cannot depend
on which one fired, and that the backstop sits ahead of the rate limiter so a self-send is never
reported as a wait. The guard is exactly as strong as the plan describes; its only softness is that
it skips when either id is absent, which is documented in #207 and is the correct reading of
"absent" (a caller that supplies neither id has not made a self-send claim to check).

## Three surfaces

- **Desktop (Electron):** the only surface with the verbs, so the only one that consumes budget.
- **Server Edition:** both modules ship (`src/core` ships on both shells) with no consumer —
  messaging does not exist there, and Task 5.3 makes that a named terminal refusal rather than a
  throttle-shaped one.
- **Mobile (phone):** never a sender, so it never consumes budget. It **is** a valid target
  (Correction C1) and is covered like any other: the budget belongs to the pair, so two
  orchestrators messaging one phone-spawned node get two independent windows.

## Mutation results

24 mutations applied one at a time (revert, run, restore) against the five suites this PR touches.
**24/24 killed. One SURVIVED on the first pass and is the false green:** dropping the separator from
`pairKey` entirely left the collision test green, because its id set contained no pair that collides
under plain concatenation (`'a-b'+'c'` is not `'a'+'b-c'`). Adding `'ab'`/`'bc'` — which do collide —
makes it red. The test looked exhaustive (81 pairs, all distinct) and proved nothing about the thing
it was named for.

Also caught while writing this: the test file itself was written with **raw NUL bytes** in that same
test — the exact hazard the key's docblock warns about, reproduced by the tool writing the file.
Both files were scanned for raw NULs before commit; there are none.

Killed mutations, in groups: `pairKey` without a separator; sweep without pair eviction; sweep
without the clock-backwards guard; sweep without turn-budget expiry; `retryAfterMs` reporting the
whole interval instead of the remainder; the fan-out cap off by one; the fan-out cap disabled;
`noteSent` forgetting the pair window; `noteSent` not incrementing; `noteNewTurn` as a no-op;
`noteNewTurn` resetting every sender; `FANOUT_RETRY_AFTER_MS = 0`; `checkFlowLimits` forgetting
either half; `resetMessageFlow` forgetting a map; `flowStats` returning a constant; the scope
resolver without its self-send arm, admitting any known target, resolving the owner off the target,
always claiming the target exists, and never refusing; #207's self-send backstop removed; and `send`
or `reply` dropped from the store-answered set.

One branch was **deleted rather than kept**: `checkFlowLimits` originally picked the larger of the
two waits, and the "pair is larger" arm is unreachable while `FANOUT_RETRY_AFTER_MS` equals
`PAIR_MIN_INTERVAL_MS`. It is now a fixed precedence (fan-out first) with a test pinning the
constant relationship that makes the precedence sound.

## Tests

New: `agent-message-flow.test.ts` (29), `agent-message-scope.test.ts` (15). Extended:
`controlRouting.test.ts` (+1), `canvas-control-core.test.ts` (+1). `npm run typecheck` clean; full
`npx vitest run` = 6199 passed, 4 failed — the 3 `node-pty-patch` and 1 `webgl-addon-pair`
assertions that are environmental on this Linux host and fail identically on `origin/main`.

## Deviation from the plan

Tasks 4.1 and 4.2 are **one commit**, not two: the sweep, the eviction contract and the failure
directions are shared between the two limits, and splitting the file down the middle would have
produced a first commit that could not state its own invariants.

## Review fixes (commit 633a8e6a)

**FIX A — non-finite `now`.** `sweep` now clears both maps when `now` is not finite. Every
comparison in it is false for `NaN`, so an entry became immortal and the budgets then failed in
opposite directions: the pair limiter open by accident (`retryAfterMs` is `NaN`, and
`decidePreProbe` refuses on `> 0`), the fan-out cap closed forever once at the cap — a permanently
silent sender, the failure the header claims immunity from. `NaN` is the only value the line is
load-bearing for; `+Infinity` is dropped by the staleness arm and `-Infinity` by the future arm, so
`!Number.isFinite` vs `Number.isNaN` is an **equivalent mutation** (measured), and the test now says
that instead of claiming to pin it.

**FIX B — `isSafeNodeId` at the boundary.** `resolveDeliveryScope` refuses either id outside
`[A-Za-z0-9._-]`, ahead of the self-send arm, as its own reason **`unaddressable-node-id`** rather
than `cross-project` — such an id can be listed in the sender's own project, so the scope word would
be a false statement about the reason (new member on `NotPermittedReason`; `RETRYABLE` is keyed by
outcome kind, so nothing else changes). This closes the separator collision in `pairKey` and the
`v/1` vs `v_1` tmux fold. **Did the widened id set kill the separator mutation? No — and it could
not:** with a NUL separator only a NUL-bearing id can collide, and no id in that 81-pair set can
contain one. The false green did move one layer down, exactly as the review said. It is now killed
by an explicit test that *exhibits* the collision (built with `String.fromCharCode(0)`, so no escape
survives a file write) and then pins the validator that makes the premise true.

**FIX C — the two false comments.** Corrected in place, not coded around: the duplicate-id note now
says it is a routing answer and not an isolation guarantee (sessions key on the bare node id, so a
`project.json` listing another project's id lands in that node's one global pane), and records that
**PR 5's delivery call must run `isSafeNodeId(targetNodeId)` before `paneOwner`**. The
`needsLiveCanvas` rationale now names the right half: Canvas routes by SOURCE, so the declaration
stops a trip to the *sender's* project; never travelling to the *target's* is `resolveDeliveryScope`
having no live-node parameter. Both files cross-reference each other so PR 5 cannot inherit the
wrong model.

Also added: the fan-out floor's known cost (30 refused attempts before the backstop opens when
`newTurn` never arrives), and a note that `ScopeProject.nodes` is required — a synthesised array
without it throws rather than failing closed, which is the caller's to own.

**Mutations after the fixes:** the original 24 re-run and all still red; 8 new ones on the fixed
lines, 7 red (guard removed, guard clears only one map, validator removed, validator checks only the
source, only the target, reports `cross-project`, runs after the self-send arm) and 1 **equivalent**
(`Number.isFinite` to `Number.isNaN`), documented in the code rather than papered over. 31 killed,
1 equivalent, 0 survivors.

**Tests:** `agent-message-flow.test.ts` 33, `agent-message-scope.test.ts` 36,
`controlRouting.test.ts` 13, `canvas-control-core.test.ts` 25. Full run 6223 passed, same 4
environmental failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
