### PR TITLE
feat(projects): the per-project capability mechanism

### DIFF
--- a/src/core/project-capability-consent.test.ts
+++ b/src/core/project-capability-consent.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import type { Project } from '../shared/types'
+import {
+  needsCapabilityNotice,
+  projectCapabilityGranted,
+  recordCapabilityAck
+} from './project-capability-consent'
+import * as shared from '../shared/project-capability-consent'
+import { projectToFile, type IndexEntryV3 } from './workspace-files'
+
+const baseProject: Project = {
+  id: 'p1',
+  name: 'p',
+  color: '#fff',
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: []
+}
+
+describe('needsCapabilityNotice', () => {
+  const cap = 'agentBrowserControl' as const
+  it('off in the file ⇒ never a notice', () => {
+    expect(needsCapabilityNotice({ capability: cap, enabledInFile: false, acknowledged: false })).toBe(false)
+  })
+  it('on in the file and never acknowledged ON THIS MACHINE ⇒ notice', () => {
+    expect(needsCapabilityNotice({ capability: cap, enabledInFile: true, acknowledged: false })).toBe(true)
+  })
+  it('on and acknowledged ⇒ silent forever after', () => {
+    expect(needsCapabilityNotice({ capability: cap, enabledInFile: true, acknowledged: true })).toBe(false)
+  })
+})
+
+describe('projectCapabilityGranted — a pending notice is a refusal, not a grant', () => {
+  const cap = 'agentBrowserControl' as const
+  it('a switch that is on but unanswered grants nothing', () => {
+    // This is what the ledger (browser PR 4) and messagingEnabled (messaging PR 6) consult: the
+    // window between a hostile clone's `agentBrowserControl: true` arriving and the user answering
+    // the notice must be a refusal. Deleting the `acknowledged` condition makes this red.
+    expect(projectCapabilityGranted({ capability: cap, enabledInFile: true, acknowledged: false })).toBe(false)
+  })
+  it('off in the file grants nothing, acknowledged or not', () => {
+    expect(projectCapabilityGranted({ capability: cap, enabledInFile: false, acknowledged: true })).toBe(false)
+  })
+  it('on and acknowledged is the one granting combination', () => {
+    expect(projectCapabilityGranted({ capability: cap, enabledInFile: true, acknowledged: true })).toBe(true)
+  })
+})
+
+describe('the acknowledgment is MACHINE-LOCAL', () => {
+  it('recordCapabilityAck writes to the index entry, never to the project file', () => {
+    const e = recordCapabilityAck({ id: 'p1', name: 'p', color: '#fff' } as IndexEntryV3, 'agentBrowserControl')
+    expect(e.capabilityAck).toEqual({ agentBrowserControl: true })
+    // The shared file must not learn about it: projectToFile writes only the capability FIELDS.
+    expect(Object.keys(projectToFile({ ...baseProject, agentBrowserControl: true }, 1, 't', 'l')))
+      .not.toContain('capabilityAck')
+  })
+
+  it('does not mutate its input and keeps earlier acks', () => {
+    const before: IndexEntryV3 = {
+      id: 'p1',
+      name: 'p',
+      color: '#fff',
+      capabilityAck: { agentBrowserControl: true }
+    }
+    const after = recordCapabilityAck(before, 'agentBrowserControl')
+    expect(after).not.toBe(before)
+    expect(before.capabilityAck).toEqual({ agentBrowserControl: true })
+    expect(after.capabilityAck).toEqual({ agentBrowserControl: true })
+  })
+
+  it('a SECOND WORKTREE of the same repo notifies again', () => {
+    // node ids and project.json re-materialise in a second folder (git worktree add / checkout /
+    // reset --hard), and workspace-files.ts is explicit that the index entry id is the only
+    // authority for project identity. A second folder is a second entry, hence a second notice —
+    // which is correct: it is a different working copy the user has not vetted.
+    const a = recordCapabilityAck({ id: 'p1', name: 'p', color: '#fff' } as IndexEntryV3, 'agentBrowserControl')
+    const b = { id: 'p2', name: 'p', color: '#fff' } // same repo, second worktree, fresh entry
+    expect(
+      needsCapabilityNotice({
+        capability: 'agentBrowserControl',
+        enabledInFile: true,
+        acknowledged: !!a.capabilityAck?.agentBrowserControl
+      })
+    ).toBe(false)
+    expect(
+      needsCapabilityNotice({
+        capability: 'agentBrowserControl',
+        enabledInFile: true,
+        acknowledged: !!(b as IndexEntryV3).capabilityAck?.agentBrowserControl
+      })
+    ).toBe(true)
+  })
+})
+
+describe('one decider, two consumers', () => {
+  it('core re-exports the SAME functions the renderer imports from @shared — no drift possible', () => {
+    // Same rule as isSafeNodeId: the renderer may not import src/core, so the implementation lives
+    // in @shared/project-capability-consent and this core path re-exports it for main/core callers
+    // (agent-messaging PR 6 Task 6.2 must not reimplement either function).
+    expect(needsCapabilityNotice).toBe(shared.needsCapabilityNotice)
+    expect(recordCapabilityAck).toBe(shared.recordCapabilityAck)
+    expect(projectCapabilityGranted).toBe(shared.projectCapabilityGranted)
+  })
+})

--- a/src/core/project-capability-consent.test.ts
+++ b/src/core/project-capability-consent.test.ts
@@ -3,6 +3,7 @@ import type { Project } from '../shared/types'
 import {
   needsCapabilityNotice,
   projectCapabilityGranted,
+  projectCapabilityGrantedFor,
   recordCapabilityAck
 } from './project-capability-consent'
 import * as shared from '../shared/project-capability-consent'
@@ -19,52 +20,113 @@ const baseProject: Project = {
 describe('needsCapabilityNotice', () => {
   const cap = 'agentBrowserControl' as const
   it('off in the file ⇒ never a notice', () => {
-    expect(needsCapabilityNotice({ capability: cap, enabledInFile: false, acknowledged: false })).toBe(false)
+    expect(needsCapabilityNotice({ capability: cap, enabledInFile: false, answer: undefined })).toBe(false)
+    expect(needsCapabilityNotice({ capability: cap, enabledInFile: false, answer: 'declined' })).toBe(false)
   })
-  it('on in the file and never acknowledged ON THIS MACHINE ⇒ notice', () => {
-    expect(needsCapabilityNotice({ capability: cap, enabledInFile: true, acknowledged: false })).toBe(true)
+  it('on in the file and never answered ON THIS MACHINE ⇒ notice', () => {
+    expect(needsCapabilityNotice({ capability: cap, enabledInFile: true, answer: undefined })).toBe(true)
   })
-  it('on and acknowledged ⇒ silent forever after', () => {
-    expect(needsCapabilityNotice({ capability: cap, enabledInFile: true, acknowledged: true })).toBe(false)
+  it('on and KEPT ⇒ silent thereafter', () => {
+    expect(needsCapabilityNotice({ capability: cap, enabledInFile: true, answer: 'kept' })).toBe(false)
+  })
+  it('on and previously DECLINED ⇒ a NEW notice — the file re-arrived against a recorded no', () => {
+    // C1 (PR #213 review): "Turn it off" deletes the field only in this working copy; a
+    // `git checkout`/pull restores the hostile `true` and the watcher re-reads it. A recorded
+    // decline must produce a fresh notice, never silence.
+    expect(needsCapabilityNotice({ capability: cap, enabledInFile: true, answer: 'declined' })).toBe(true)
   })
 })
 
-describe('projectCapabilityGranted — a pending notice is a refusal, not a grant', () => {
+describe('projectCapabilityGranted — only an explicit KEPT grants', () => {
   const cap = 'agentBrowserControl' as const
   it('a switch that is on but unanswered grants nothing', () => {
     // This is what the ledger (browser PR 4) and messagingEnabled (messaging PR 6) consult: the
     // window between a hostile clone's `agentBrowserControl: true` arriving and the user answering
-    // the notice must be a refusal. Deleting the `acknowledged` condition makes this red.
-    expect(projectCapabilityGranted({ capability: cap, enabledInFile: true, acknowledged: false })).toBe(false)
+    // the notice must be a refusal. Deleting the answer condition makes this red.
+    expect(projectCapabilityGranted({ capability: cap, enabledInFile: true, answer: undefined })).toBe(false)
   })
-  it('off in the file grants nothing, acknowledged or not', () => {
-    expect(projectCapabilityGranted({ capability: cap, enabledInFile: false, acknowledged: true })).toBe(false)
+  it('a DECLINED switch grants nothing even when the file says true again', () => {
+    // C1's grant leg: decline → hostile true re-arrives → the standing "no" must refuse. An ack
+    // that does not carry the answer cannot express this; treating any answer as consent is the
+    // exact mutation this test exists to catch.
+    expect(projectCapabilityGranted({ capability: cap, enabledInFile: true, answer: 'declined' })).toBe(false)
   })
-  it('on and acknowledged is the one granting combination', () => {
-    expect(projectCapabilityGranted({ capability: cap, enabledInFile: true, acknowledged: true })).toBe(true)
+  it('off in the file grants nothing, whatever was answered', () => {
+    expect(projectCapabilityGranted({ capability: cap, enabledInFile: false, answer: 'kept' })).toBe(false)
+  })
+  it('on and kept is the one granting combination', () => {
+    expect(projectCapabilityGranted({ capability: cap, enabledInFile: true, answer: 'kept' })).toBe(true)
   })
 })
 
-describe('the acknowledgment is MACHINE-LOCAL', () => {
-  it('recordCapabilityAck writes to the index entry, never to the project file', () => {
-    const e = recordCapabilityAck({ id: 'p1', name: 'p', color: '#fff' } as IndexEntryV3, 'agentBrowserControl')
-    expect(e.capabilityAck).toEqual({ agentBrowserControl: true })
+describe('projectCapabilityGrantedFor — the ONE consumer-facing wiring (PR 4 ledger, PR 6 messagingEnabled)', () => {
+  const cap = 'agentBrowserControl' as const
+  it('derives both halves from the project and refuses every non-granting shape', () => {
+    expect(projectCapabilityGrantedFor(undefined, cap)).toBe(false)
+    expect(projectCapabilityGrantedFor({ ...baseProject }, cap)).toBe(false)
+    // pending notice (hostile clone window)
+    expect(projectCapabilityGrantedFor({ ...baseProject, agentBrowserControl: true }, cap)).toBe(false)
+    // recorded decline + re-arrived true
+    expect(
+      projectCapabilityGrantedFor(
+        { ...baseProject, agentBrowserControl: true, capabilityAck: { [cap]: 'declined' } },
+        cap
+      )
+    ).toBe(false)
+    // non-literal-true file value never grants, answer or no answer
+    expect(
+      projectCapabilityGrantedFor(
+        { ...baseProject, agentBrowserControl: 'true', capabilityAck: { [cap]: 'kept' } } as never,
+        cap
+      )
+    ).toBe(false)
+  })
+  it('grants exactly for literal true + kept', () => {
+    expect(
+      projectCapabilityGrantedFor(
+        { ...baseProject, agentBrowserControl: true, capabilityAck: { [cap]: 'kept' } },
+        cap
+      )
+    ).toBe(true)
+  })
+  it('ignores a prototype-inherited flag or answer — own properties only', () => {
+    // M-1 (PR #213 review): unreachable from JSON.parse, but in-process objects can inherit.
+    const inheritedFlag = Object.create({ agentBrowserControl: true }) as Project
+    expect(projectCapabilityGrantedFor({ ...baseProject, ...inheritedFlag, capabilityAck: { [cap]: 'kept' } }, cap)).toBe(false)
+    const proto = Object.create({ agentBrowserControl: true, capabilityAck: { [cap]: 'kept' } }) as Project
+    expect(projectCapabilityGrantedFor(proto, cap)).toBe(false)
+  })
+})
+
+describe('the acknowledgment is MACHINE-LOCAL and carries the answer', () => {
+  it('recordCapabilityAck writes the given answer to the index entry, never to the project file', () => {
+    const kept = recordCapabilityAck({ id: 'p1', name: 'p', color: '#fff' } as IndexEntryV3, 'agentBrowserControl', 'kept')
+    expect(kept.capabilityAck).toEqual({ agentBrowserControl: 'kept' })
+    const declined = recordCapabilityAck({ id: 'p1', name: 'p', color: '#fff' } as IndexEntryV3, 'agentBrowserControl', 'declined')
+    expect(declined.capabilityAck).toEqual({ agentBrowserControl: 'declined' })
     // The shared file must not learn about it: projectToFile writes only the capability FIELDS.
-    expect(Object.keys(projectToFile({ ...baseProject, agentBrowserControl: true }, 1, 't', 'l')))
-      .not.toContain('capabilityAck')
+    // The project here CARRIES an ack (M-3: an ack-less input could never catch a leak).
+    const file = projectToFile(
+      { ...baseProject, agentBrowserControl: true, capabilityAck: { agentBrowserControl: 'kept' } },
+      1,
+      't',
+      'l'
+    )
+    expect(Object.keys(file)).not.toContain('capabilityAck')
+    expect(JSON.stringify(file)).not.toContain('capabilityAck')
   })
 
-  it('does not mutate its input and keeps earlier acks', () => {
+  it('a later answer overwrites an earlier one, without mutating the input', () => {
     const before: IndexEntryV3 = {
       id: 'p1',
       name: 'p',
       color: '#fff',
-      capabilityAck: { agentBrowserControl: true }
+      capabilityAck: { agentBrowserControl: 'declined' }
     }
-    const after = recordCapabilityAck(before, 'agentBrowserControl')
+    const after = recordCapabilityAck(before, 'agentBrowserControl', 'kept')
     expect(after).not.toBe(before)
-    expect(before.capabilityAck).toEqual({ agentBrowserControl: true })
-    expect(after.capabilityAck).toEqual({ agentBrowserControl: true })
+    expect(before.capabilityAck).toEqual({ agentBrowserControl: 'declined' })
+    expect(after.capabilityAck).toEqual({ agentBrowserControl: 'kept' })
   })
 
   it('a SECOND WORKTREE of the same repo notifies again', () => {
@@ -72,20 +134,20 @@ describe('the acknowledgment is MACHINE-LOCAL', () => {
     // reset --hard), and workspace-files.ts is explicit that the index entry id is the only
     // authority for project identity. A second folder is a second entry, hence a second notice —
     // which is correct: it is a different working copy the user has not vetted.
-    const a = recordCapabilityAck({ id: 'p1', name: 'p', color: '#fff' } as IndexEntryV3, 'agentBrowserControl')
-    const b = { id: 'p2', name: 'p', color: '#fff' } // same repo, second worktree, fresh entry
+    const a = recordCapabilityAck({ id: 'p1', name: 'p', color: '#fff' } as IndexEntryV3, 'agentBrowserControl', 'kept')
+    const b: IndexEntryV3 = { id: 'p2', name: 'p', color: '#fff' } // same repo, second worktree, fresh entry
     expect(
       needsCapabilityNotice({
         capability: 'agentBrowserControl',
         enabledInFile: true,
-        acknowledged: !!a.capabilityAck?.agentBrowserControl
+        answer: a.capabilityAck?.agentBrowserControl
       })
     ).toBe(false)
     expect(
       needsCapabilityNotice({
         capability: 'agentBrowserControl',
         enabledInFile: true,
-        acknowledged: !!(b as IndexEntryV3).capabilityAck?.agentBrowserControl
+        answer: b.capabilityAck?.agentBrowserControl
       })
     ).toBe(true)
   })
@@ -99,5 +161,6 @@ describe('one decider, two consumers', () => {
     expect(needsCapabilityNotice).toBe(shared.needsCapabilityNotice)
     expect(recordCapabilityAck).toBe(shared.recordCapabilityAck)
     expect(projectCapabilityGranted).toBe(shared.projectCapabilityGranted)
+    expect(projectCapabilityGrantedFor).toBe(shared.projectCapabilityGrantedFor)
   })
 })

--- a/src/core/project-capability-consent.ts
+++ b/src/core/project-capability-consent.ts
@@ -1,0 +1,14 @@
+/**
+ * Core/main-side path to the clone-notice decider. The IMPLEMENTATION lives in
+ * `@shared/project-capability-consent` because the renderer raises the dialog and may not import
+ * `src/core`; this re-export exists so core/main callers (agent-messaging PR 6 Task 6.2 among
+ * them) have a core-local name without a second implementation.
+ * `project-capability-consent.test.ts` pins that both paths are the same function objects.
+ */
+export {
+  needsCapabilityNotice,
+  projectCapabilityGranted,
+  recordCapabilityAck,
+  type CapabilityAckMap,
+  type CapabilityConsentState
+} from '../shared/project-capability-consent'

--- a/src/core/project-capability-consent.ts
+++ b/src/core/project-capability-consent.ts
@@ -6,9 +6,12 @@
  * `project-capability-consent.test.ts` pins that both paths are the same function objects.
  */
 export {
+  capabilityAnswerOf,
   needsCapabilityNotice,
   projectCapabilityGranted,
+  projectCapabilityGrantedFor,
   recordCapabilityAck,
   type CapabilityAckMap,
+  type CapabilityAnswer,
   type CapabilityConsentState
 } from '../shared/project-capability-consent'

--- a/src/core/remote-safety.test.ts
+++ b/src/core/remote-safety.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import { NODE_ID_MAX, isSafeNodeId, isSafeRemoteHome } from './remote-safety'
+import { NODE_ID_MAX as SHARED_NODE_ID_MAX, isSafeNodeId as sharedIsSafeNodeId } from '@shared/safe-id'
 
 describe('isSafeNodeId', () => {
+  it('core re-exports the SAME function object — one predicate, not two that drift', () => {
+    // The definition moved to @shared/safe-id so the renderer can validate a project id before it
+    // becomes a session-partition storage key without importing src/core. This pin is what makes
+    // "moved, not copied" a property rather than a claim: if anyone re-declares the predicate here,
+    // the two function objects diverge and this fails.
+    expect(isSafeNodeId).toBe(sharedIsSafeNodeId)
+    expect(NODE_ID_MAX).toBe(SHARED_NODE_ID_MAX)
+  })
+
   it('accepts every shape the app actually mints', () => {
     // `nextId()` in state/workspace.ts: `<prefix>-<base36 time>-<counter>`.
     for (const id of ['term-mabc123-7', 'ssh-mabc123-1', 'node-1', 'a', 'A_b.c-1', '9'])

--- a/src/core/remote-safety.ts
+++ b/src/core/remote-safety.ts
@@ -10,32 +10,15 @@
  * No node/electron imports: usable from core, main, and the server shell alike.
  */
 
-/** Generous cap on a node id — longer than anything the app mints, short enough to bound. */
-export const NODE_ID_MAX = 128
+// `isSafeNodeId` / `NODE_ID_MAX` MOVED to `@shared/safe-id` (re-exported here so no existing
+// import path changes): the renderer needs this exact predicate to validate a project id before it
+// becomes a session-partition storage key, and the renderer may not import `src/core`. One
+// predicate, two consumers — `remote-safety.test.ts` pins that this name and the shared one are
+// the same function object, so the two cannot drift.
+export { NODE_ID_MAX, isSafeNodeId } from '../shared/safe-id'
+
 /** Generous cap on a host-reported `$HOME`; longer than any real path (PATH_MAX on Linux). */
 export const REMOTE_HOME_MAX = 4096
-
-/**
- * Is this a node id (a `persistKey`) safe to carry into a remote command line and a filesystem
- * path?
- *
- * Charset is deliberately narrower than "no metacharacters": `[A-Za-z0-9._-]` covers every id the
- * app actually produces — `nextId()` emits `<prefix>-<base36 time>-<counter>` and `uuid()` emits
- * hex-with-dashes — so the answer to "could this refuse something legitimate?" is a list, not a
- * guess. `.` and `..` are refused on top of the charset: they pass it but name a directory, and
- * these ids are also used as path components (session files, per-node remote state). It is also
- * the charset the codex identity shim ALREADY enforces on `$NODETERM_NODE_ID` before it will use
- * it (`codex-identity-proxy.ts`: `*[!A-Za-z0-9._-]*) nt_fail node-id-unavailable`), so this is the
- * existing rule moved to the boundary rather than a new one invented here.
- *
- * An EMPTY id is refused here and must be handled by the caller as "not persistent" rather than as
- * a violation — `PtyManager.create` already branches on a falsy `persistKey` before it asks.
- */
-export function isSafeNodeId(id: string | undefined | null): boolean {
-  if (!id || id.length > NODE_ID_MAX) return false
-  if (id === '.' || id === '..') return false
-  return /^[A-Za-z0-9._-]+$/.test(id)
-}
 
 /**
  * Every character that is live shell syntax at a `$HOME` interpolation site, plus every control

--- a/src/core/workspace-files.test.ts
+++ b/src/core/workspace-files.test.ts
@@ -64,6 +64,28 @@ describe('projectToFile / fileToProject round-trip', () => {
   })
 })
 
+describe('per-project capability fields in the shared file', () => {
+  it('a capability round-trips through projectToFile/fileToProject, and a non-literal-true does not', () => {
+    const p = project({ agentBrowserControl: true })
+    expect(projectToFile(p, 1, 'ts').agentBrowserControl).toBe(true)
+    const baseFile = projectToFile(project(), 1, 'ts')
+    expect(fileToProject({ ...baseFile, agentBrowserControl: true }, { id: 'x' }).agentBrowserControl).toBe(
+      true
+    )
+    // A hand-edited/hostile file carrying "true" (the string), 1 or {} is OFF — the field simply
+    // does not survive the read. projectCapabilityEnabled would answer false either way; this pins
+    // that the sanitisation happens at the FILE boundary, not only at the consumption site.
+    expect(
+      fileToProject({ ...baseFile, agentBrowserControl: 'true' } as never, { id: 'x' }).agentBrowserControl
+    ).toBeUndefined()
+  })
+  it('an off capability adds no bytes to the committed file', () => {
+    const f = projectToFile(project(), 1, 'ts')
+    expect('agentBrowserControl' in f).toBe(false)
+    expect(serializeProjectFile(f)).not.toContain('agentBrowserControl')
+  })
+})
+
 describe('sameProjectContent', () => {
   it('ignores rev and savedAt, sees node changes', () => {
     const a = projectToFile(project(), 1, '2026-01-01T00:00:00.000Z')

--- a/src/core/workspace-files.test.ts
+++ b/src/core/workspace-files.test.ts
@@ -84,6 +84,25 @@ describe('per-project capability fields in the shared file', () => {
     expect('agentBrowserControl' in f).toBe(false)
     expect(serializeProjectFile(f)).not.toContain('agentBrowserControl')
   })
+  it('the ack is machine-local: index entry carries it, the shared file never does', () => {
+    const p = project({ cwd: '/a/foo', agentBrowserControl: true, capabilityAck: { agentBrowserControl: true } })
+    const { index, files } = splitWorkspace(
+      { version: 2, activeProjectId: 'p1', projects: [p] },
+      () => 1,
+      '2026-08-15T00:00:00.000Z'
+    )
+    expect(index.entries[0].capabilityAck).toEqual({ agentBrowserControl: true })
+    expect(serializeProjectFile(files.get('/a/foo')!)).not.toContain('capabilityAck')
+    // Load: the ack comes from the entry; a file-borne `capabilityAck` (forgery — a repo carrying
+    // its own consent) is never read.
+    const restored = fileToProject(files.get('/a/foo')!, { id: 'p1', cwd: '/a/foo', capabilityAck: { agentBrowserControl: true } })
+    expect(restored.capabilityAck).toEqual({ agentBrowserControl: true })
+    const forged = fileToProject(
+      { ...files.get('/a/foo')!, capabilityAck: { agentBrowserControl: true } } as never,
+      { id: 'p1', cwd: '/a/foo' }
+    )
+    expect(forged.capabilityAck).toBeUndefined()
+  })
 })
 
 describe('sameProjectContent', () => {

--- a/src/core/workspace-files.test.ts
+++ b/src/core/workspace-files.test.ts
@@ -85,20 +85,20 @@ describe('per-project capability fields in the shared file', () => {
     expect(serializeProjectFile(f)).not.toContain('agentBrowserControl')
   })
   it('the ack is machine-local: index entry carries it, the shared file never does', () => {
-    const p = project({ cwd: '/a/foo', agentBrowserControl: true, capabilityAck: { agentBrowserControl: true } })
+    const p = project({ cwd: '/a/foo', agentBrowserControl: true, capabilityAck: { agentBrowserControl: 'kept' as const } })
     const { index, files } = splitWorkspace(
       { version: 2, activeProjectId: 'p1', projects: [p] },
       () => 1,
       '2026-08-15T00:00:00.000Z'
     )
-    expect(index.entries[0].capabilityAck).toEqual({ agentBrowserControl: true })
+    expect(index.entries[0].capabilityAck).toEqual({ agentBrowserControl: 'kept' })
     expect(serializeProjectFile(files.get('/a/foo')!)).not.toContain('capabilityAck')
     // Load: the ack comes from the entry; a file-borne `capabilityAck` (forgery — a repo carrying
     // its own consent) is never read.
-    const restored = fileToProject(files.get('/a/foo')!, { id: 'p1', cwd: '/a/foo', capabilityAck: { agentBrowserControl: true } })
-    expect(restored.capabilityAck).toEqual({ agentBrowserControl: true })
+    const restored = fileToProject(files.get('/a/foo')!, { id: 'p1', cwd: '/a/foo', capabilityAck: { agentBrowserControl: 'kept' as const } })
+    expect(restored.capabilityAck).toEqual({ agentBrowserControl: 'kept' })
     const forged = fileToProject(
-      { ...files.get('/a/foo')!, capabilityAck: { agentBrowserControl: true } } as never,
+      { ...files.get('/a/foo')!, capabilityAck: { agentBrowserControl: 'kept' as const } } as never,
       { id: 'p1', cwd: '/a/foo' }
     )
     expect(forged.capabilityAck).toBeUndefined()

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -8,6 +8,7 @@ import {
   type LocalNodeExecMap
 } from '../shared/node-exec'
 import type { BridgeLink, CanvasNodeState, Project, ProjectKanban, Viewport, Workspace } from '../shared/types'
+import { projectCapabilityFields, readProjectCapabilities } from '../shared/project-capabilities'
 
 export const PROJECT_DIR = '.nodeterm'
 export const PROJECT_FILE = 'project.json'
@@ -66,6 +67,12 @@ export interface ProjectFileV1 {
    */
   defaultAccountId?: string
   defaultPermissionMode?: AgentPermissionMode
+  /**
+   * Per-project capability switch (see @shared/project-capabilities): deliberately IN the
+   * git-shared file — the team shares the policy — which is exactly why reads are strict
+   * (`readProjectCapabilities`, literal `true` only) and why the switch alone grants nothing.
+   */
+  agentBrowserControl?: boolean
   dinoHighScore?: number
   kanban?: ProjectKanban
 }
@@ -182,6 +189,10 @@ export function projectToFile(
     ...(p.bridges ? { bridges: p.bridges } : {}),
     ...(p.ropes ? { ropes: p.ropes } : {}),
     ...(p.defaultPermissionMode ? { defaultPermissionMode: p.defaultPermissionMode } : {}),
+    // Strict-normalised (literal true only, known keys only) and omitted when off — an off
+    // capability adds no bytes to the committed file. `capabilityAck` is deliberately NOT here:
+    // the acknowledgment is machine-local (IndexEntryV3.capabilityAck) and must never travel.
+    ...projectCapabilityFields(p),
     ...(p.dinoHighScore ? { dinoHighScore: p.dinoHighScore } : {}),
     ...(p.kanban ? { kanban: p.kanban } : {})
   }
@@ -239,6 +250,9 @@ export function fileToProject(
     ...(f.ropes ? { ropes: f.ropes } : {}),
     ...(defaultAccountId ? { defaultAccountId } : {}),
     ...(f.defaultPermissionMode ? { defaultPermissionMode: f.defaultPermissionMode } : {}),
+    // The file is hostile input: only a literal `true` under a known key survives the read
+    // (readProjectCapabilities). `"true"`, 1, {} et al. vanish here, at the boundary.
+    ...readProjectCapabilities(f),
     ...(f.dinoHighScore ? { dinoHighScore: f.dinoHighScore } : {}),
     ...(validKanban(f.kanban) ? { kanban: f.kanban } : {}),
     ...(base.cwd ? { cwd: base.cwd } : {}),

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -99,6 +99,13 @@ export interface IndexEntryV3 {
   /** MACHINE-LOCAL default managed Claude account for a ref'd project: the id names a credential
    *  dir in THIS machine's userData, so it is meaningless in anyone else's checkout. */
   defaultAccountId?: string
+  /**
+   * MACHINE-LOCAL record that this machine's user has acknowledged each capability switch for THIS
+   * entry (the one-time clone notice, @shared/project-capability-consent). Never copied into the
+   * shared project file — a repo must not be able to carry its own consent — and keyed to the
+   * entry, so a second worktree of the same repo (a second entry) notifies again, on purpose.
+   */
+  capabilityAck?: import('../shared/project-capability-consent').CapabilityAckMap
   cwd?: string
   ssh?: Project['ssh']
   cache?: ProjectFileV1
@@ -231,6 +238,8 @@ export function fileToProject(
     viewport?: Viewport
     /** This machine's default managed account; falls back to the file's legacy value. */
     defaultAccountId?: string
+    /** This machine's clone-notice acknowledgments for this entry (never from the file). */
+    capabilityAck?: import('../shared/project-capability-consent').CapabilityAckMap
     /** This machine's own exec values for these nodes (from the local index entry). A file read
      *  WITHOUT them — an adopted/cloned folder, a probe — gets the safe defaults, never the file's
      *  own `shell`/`ssh.extraArgs`. */
@@ -257,7 +266,10 @@ export function fileToProject(
     ...(validKanban(f.kanban) ? { kanban: f.kanban } : {}),
     ...(base.cwd ? { cwd: base.cwd } : {}),
     ...(base.ssh ? { ssh: base.ssh } : {}),
-    ...(base.closed ? { closed: true } : {})
+    ...(base.closed ? { closed: true } : {}),
+    // Machine-local, from the index entry ONLY: a file field named `capabilityAck` is a forgery
+    // attempt (the shared file cannot carry this machine's consent) and is simply never read.
+    ...(base.capabilityAck ? { capabilityAck: base.capabilityAck } : {})
   }
 }
 
@@ -343,7 +355,10 @@ export function splitWorkspace(
     // Inline entries need none of this: they store the whole Project verbatim.
     const localState = {
       ...(p.viewport ? { viewport: p.viewport } : {}),
-      ...(p.defaultAccountId ? { defaultAccountId: p.defaultAccountId } : {})
+      ...(p.defaultAccountId ? { defaultAccountId: p.defaultAccountId } : {}),
+      // The clone-notice acknowledgment rides the machine-local entry, never the shared file
+      // (projectToFile does not emit it — pinned by project-capability-consent.test.ts).
+      ...(p.capabilityAck ? { capabilityAck: p.capabilityAck } : {})
     }
     if (p.unavailable) {
       // Placeholder (folder missing / server unreachable at load): its nodes:[] is not real

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -244,6 +244,7 @@ export class WorkspaceStore {
               closed: e.closed,
               viewport: e.viewport,
               defaultAccountId: e.defaultAccountId,
+              capabilityAck: e.capabilityAck,
               localExec: this.execOverlay(e, p)
             })
           })
@@ -262,6 +263,7 @@ export class WorkspaceStore {
               closed: e.closed,
               viewport: e.viewport,
               defaultAccountId: e.defaultAccountId,
+              capabilityAck: e.capabilityAck,
               localExec: this.execOverlay(e, e.cache)
             })
           })
@@ -482,6 +484,9 @@ export class WorkspaceStore {
         // moment a folder is briefly unmounted.
         if (old?.viewport) e.viewport = old.viewport
         if (old?.defaultAccountId) e.defaultAccountId = old.defaultAccountId
+        // The clone-notice acknowledgment must also survive an unavailable window: forgetting it
+        // would re-raise a notice the user already answered the moment the folder remounts.
+        if (old?.capabilityAck) e.capabilityAck = old.capabilityAck
       }
     }
 
@@ -615,6 +620,7 @@ export class WorkspaceStore {
       closed: e.closed,
       viewport: e.viewport,
       defaultAccountId: e.defaultAccountId,
+      capabilityAck: e.capabilityAck,
       localExec: e.localExec
     })
   }
@@ -860,6 +866,7 @@ export class WorkspaceStore {
           closed: e.closed,
           viewport: e.viewport,
           defaultAccountId: e.defaultAccountId,
+          capabilityAck: e.capabilityAck,
           localExec: e.localExec
         })
       )
@@ -921,7 +928,8 @@ export class WorkspaceStore {
     this.revs.set(e.id, e.cache.rev)
     return fileToProject(e.cache, {
       id: e.id, ssh: e.ssh, closed: e.closed,
-      viewport: e.viewport, defaultAccountId: e.defaultAccountId, localExec: e.localExec
+      viewport: e.viewport, defaultAccountId: e.defaultAccountId,
+      capabilityAck: e.capabilityAck, localExec: e.localExec
     })
   }
 
@@ -1027,7 +1035,8 @@ export class WorkspaceStore {
       else this.unmirrored.delete(e.id) // pure adopt: the server copy IS the truth now — nothing owed
       return fileToProject(adopted, {
         id: e.id, ssh: e.ssh, closed: e.closed,
-        viewport: e.viewport, defaultAccountId: e.defaultAccountId, localExec: e.localExec
+        viewport: e.viewport, defaultAccountId: e.defaultAccountId,
+        capabilityAck: e.capabilityAck, localExec: e.localExec
       })
     }
     // Our cache stood. Before it clobbers the server, merge in any remote-only session nodes (the
@@ -1041,7 +1050,8 @@ export class WorkspaceStore {
         this.unmirrored.add(e.id) // the merged set must land on the server
         merged = fileToProject(e.cache, {
           id: e.id, ssh: e.ssh, closed: e.closed,
-          viewport: e.viewport, defaultAccountId: e.defaultAccountId, localExec: e.localExec
+          viewport: e.viewport, defaultAccountId: e.defaultAccountId,
+          capabilityAck: e.capabilityAck, localExec: e.localExec
         })
       }
     }

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -145,6 +145,7 @@ import { TmuxBanner } from '../components/TmuxBanner'
 import { PtyPressureBanner } from '../components/PtyPressureBanner'
 import { ConflictBar } from '../components/ConflictBar'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import { CapabilityNotice } from '../components/CapabilityNotice'
 import { ConsentNotice } from '../remote/ConsentNotice'
 import { peerApprovalView } from '@shared/remote/approval'
 import { promptDialog } from '../components/promptDialog'
@@ -9062,6 +9063,12 @@ export function Canvas() {
         onMouseEnter={openSessionsPeek}
         onMouseLeave={closeSessionsPeekSoon}
       />
+
+      {/* The one-time clone notice for a project whose git-shared capability switch arrived
+          already on (PR 3 Task 3.4). Self-contained against the projects store: it re-evaluates on
+          every active-project change (the project-load path), is click-only, and records its
+          answer machine-locally — see components/CapabilityNotice.tsx and its test. */}
+      <CapabilityNotice />
 
       {confirm && (
         <ConfirmDialog

--- a/src/renderer/components/CapabilityNotice.tsx
+++ b/src/renderer/components/CapabilityNotice.tsx
@@ -1,0 +1,86 @@
+import { useProjects } from '../state/projects'
+import type { Project } from '@shared/types'
+import {
+  PROJECT_CAPABILITIES,
+  PROJECT_CAPABILITY_COPY,
+  projectCapabilityEnabled,
+  type ProjectCapability
+} from '@shared/project-capabilities'
+import { needsCapabilityNotice } from '@shared/project-capability-consent'
+import { ConfirmDialog } from './ConfirmDialog'
+
+/**
+ * The first capability whose git-shared switch is on for this project while this machine's user
+ * has never answered for it. Pure and per-capability so agent messaging's switch (its PR 6) gets
+ * this dialog by adding a copy entry — there is nothing per-feature below.
+ */
+export function pendingCapabilityNotice(p: Project | undefined): ProjectCapability | null {
+  if (!p) return null
+  for (const cap of PROJECT_CAPABILITIES) {
+    const pending = needsCapabilityNotice({
+      capability: cap,
+      // Strict read: a hand-edited "true"/1/{} is off, so it can never raise (or need) a notice.
+      enabledInFile: projectCapabilityEnabled(p, cap),
+      acknowledged: p.capabilityAck?.[cap] === true
+    })
+    if (pending) return cap
+  }
+  return null
+}
+
+/**
+ * THE ONE-TIME CLONE NOTICE — the one thing standing between a hostile `.nodeterm/project.json`
+ * and a grant, so every property here is security-shaped and test-named:
+ *
+ *  - It exists because a capability switch is git-shared: a teammate (or a stranger's repo) can
+ *    commit `agentBrowserControl: true`, and the user who cloned it was never asked. The warning
+ *    at the point of SETTING (Settings → Agents) cannot reach them; this dialog can.
+ *  - CLICK-ONLY (`enterConfirms={false}` — confirm-key.ts's rule for dialogs the user did not
+ *    open): it was raised by a FILE, and an Enter aimed at a terminal must not answer it.
+ *    capability-notice.test.tsx "is CLICK-ONLY" fails if this prop is dropped.
+ *  - Once per project EVER, proven by persistence, not by session state: the answer lands in
+ *    `Project.capabilityAck` → `IndexEntryV3.capabilityAck` (machine-local), never in the shared
+ *    file — "a second open does not re-notify" and workspace-files.test.ts pin both halves.
+ *  - While it is unanswered the capability GRANTS NOTHING: every consumer reads
+ *    `projectCapabilityGranted`, which refuses a pending notice ("does not grant while
+ *    unanswered"). This component never needs to race anyone.
+ *
+ * Renders against the ACTIVE project (the project-load path re-evaluates it on every switch), so
+ * a background project's hostile file cannot pop a dialog about a canvas the user is not looking
+ * at — they are told when they actually open it.
+ */
+export function CapabilityNotice(): React.JSX.Element | null {
+  const activeProjectId = useProjects((s) => s.activeProjectId)
+  const projects = useProjects((s) => s.projects)
+  const setProjectCapability = useProjects((s) => s.setProjectCapability)
+  const recordProjectCapabilityAck = useProjects((s) => s.recordProjectCapabilityAck)
+  const project = projects.find((p) => p.id === activeProjectId)
+  const cap = project ? pendingCapabilityNotice(project) : null
+  if (!project || !cap) return null
+  const copy = PROJECT_CAPABILITY_COPY[cap]
+  return (
+    <ConfirmDialog
+      body={
+        <div className="confirm__msg">
+          <p>{copy.description}</p>
+          <p>{copy.cloneWarning}</p>
+        </div>
+      }
+      message={`The project "${project.name}" arrived with "${copy.label}" already switched on — it came from the project file, not from you. Keep it on?`}
+      confirmLabel="Keep it on"
+      cancelLabel="Turn it off"
+      // "Keep it on" is the grant, so it carries the danger styling and — per ConfirmDialog's
+      // rule — never the autofocus; Escape and the overlay click take the safe "Turn it off" path.
+      danger
+      enterConfirms={false}
+      onConfirm={() => recordProjectCapabilityAck(project.id, cap)}
+      onCancel={() => {
+        // Answered too: the ack makes "once per project ever" true for this entry, and clearing
+        // the field means the capability stays a refusal (and the file sheds the stranger's grant
+        // on the next save this user makes).
+        recordProjectCapabilityAck(project.id, cap)
+        setProjectCapability(project.id, cap, false)
+      }}
+    />
+  )
+}

--- a/src/renderer/components/CapabilityNotice.tsx
+++ b/src/renderer/components/CapabilityNotice.tsx
@@ -1,18 +1,21 @@
+import { useState } from 'react'
 import { useProjects } from '../state/projects'
 import type { Project } from '@shared/types'
 import {
   PROJECT_CAPABILITIES,
   PROJECT_CAPABILITY_COPY,
-  projectCapabilityEnabled,
+  projectCapabilityFlagInFile,
   type ProjectCapability
 } from '@shared/project-capabilities'
-import { needsCapabilityNotice } from '@shared/project-capability-consent'
+import { capabilityAnswerOf, needsCapabilityNotice } from '@shared/project-capability-consent'
 import { ConfirmDialog } from './ConfirmDialog'
 
 /**
  * The first capability whose git-shared switch is on for this project while this machine's user
- * has never answered for it. Pure and per-capability so agent messaging's switch (its PR 6) gets
- * this dialog by adding a copy entry — there is nothing per-feature below.
+ * has not KEPT it — never answered, or previously DECLINED and the file's `true` re-arrived via
+ * git (C1: a recorded "no" makes a re-appearing switch a new event, not a settled one). Pure and
+ * per-capability so agent messaging's switch (its PR 6) gets this dialog by adding a copy entry —
+ * there is nothing per-feature below.
  */
 export function pendingCapabilityNotice(p: Project | undefined): ProjectCapability | null {
   if (!p) return null
@@ -20,8 +23,8 @@ export function pendingCapabilityNotice(p: Project | undefined): ProjectCapabili
     const pending = needsCapabilityNotice({
       capability: cap,
       // Strict read: a hand-edited "true"/1/{} is off, so it can never raise (or need) a notice.
-      enabledInFile: projectCapabilityEnabled(p, cap),
-      acknowledged: p.capabilityAck?.[cap] === true
+      enabledInFile: projectCapabilityFlagInFile(p, cap),
+      answer: capabilityAnswerOf(p, cap)
     })
     if (pending) return cap
   }
@@ -35,15 +38,19 @@ export function pendingCapabilityNotice(p: Project | undefined): ProjectCapabili
  *  - It exists because a capability switch is git-shared: a teammate (or a stranger's repo) can
  *    commit `agentBrowserControl: true`, and the user who cloned it was never asked. The warning
  *    at the point of SETTING (Settings → Agents) cannot reach them; this dialog can.
- *  - CLICK-ONLY (`enterConfirms={false}` — confirm-key.ts's rule for dialogs the user did not
- *    open): it was raised by a FILE, and an Enter aimed at a terminal must not answer it.
- *    capability-notice.test.tsx "is CLICK-ONLY" fails if this prop is dropped.
- *  - Once per project EVER, proven by persistence, not by session state: the answer lands in
- *    `Project.capabilityAck` → `IndexEntryV3.capabilityAck` (machine-local), never in the shared
- *    file — "a second open does not re-notify" and workspace-files.test.ts pin both halves.
- *  - While it is unanswered the capability GRANTS NOTHING: every consumer reads
- *    `projectCapabilityGranted`, which refuses a pending notice ("does not grant while
- *    unanswered"). This component never needs to race anyone.
+ *  - ONLY THE TWO BUTTONS ARE ANSWERS (PR #213 review, I1). "Keep it on" records 'kept'; "Turn it
+ *    off" records 'declined' and sheds the field. Escape, an overlay misclick, and a keystroke
+ *    aimed at a terminal are NON-answers: `enterConfirms={false}` blocks the window-listener path,
+ *    `autoFocusButtons={false}` means no button holds focus for a native Enter/Space to activate,
+ *    and `onDismiss` closes the dialog for this app session without recording anything — it
+ *    re-shows on the next launch (capability-notice.test.tsx "dismissal is not an answer").
+ *  - The answers are machine-local and carry WHICH answer was given: `Project.capabilityAck` →
+ *    `IndexEntryV3.capabilityAck`, never the shared file. 'kept' silences the notice for this
+ *    entry forever; 'declined' + a re-arriving `true` re-notices AND stays refused (C1) — a
+ *    routine `git checkout` restoring the hostile flag can never convert a "no" into a grant.
+ *  - While it is unanswered (or declined) the capability GRANTS NOTHING: every consumer reads
+ *    `projectCapabilityGrantedFor`, which requires the recorded 'kept' ("does not grant while
+ *    unanswered", "a DECLINED switch grants nothing even when the file says true again").
  *
  * Renders against the ACTIVE project (the project-load path re-evaluates it on every switch), so
  * a background project's hostile file cannot pop a dialog about a canvas the user is not looking
@@ -54,9 +61,13 @@ export function CapabilityNotice(): React.JSX.Element | null {
   const projects = useProjects((s) => s.projects)
   const setProjectCapability = useProjects((s) => s.setProjectCapability)
   const recordProjectCapabilityAck = useProjects((s) => s.recordProjectCapabilityAck)
+  // Dismissed-this-session (Escape / overlay click): hides the dialog without recording an
+  // answer, so it re-shows next launch. Component state, not the store — a dismissal is exactly
+  // the thing that must NOT persist.
+  const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set())
   const project = projects.find((p) => p.id === activeProjectId)
   const cap = project ? pendingCapabilityNotice(project) : null
-  if (!project || !cap) return null
+  if (!project || !cap || dismissed.has(`${project.id}:${cap}`)) return null
   const copy = PROJECT_CAPABILITY_COPY[cap]
   return (
     <ConfirmDialog
@@ -69,17 +80,23 @@ export function CapabilityNotice(): React.JSX.Element | null {
       message={`The project "${project.name}" arrived with "${copy.label}" already switched on — it came from the project file, not from you. Keep it on?`}
       confirmLabel="Keep it on"
       cancelLabel="Turn it off"
-      // "Keep it on" is the grant, so it carries the danger styling and — per ConfirmDialog's
-      // rule — never the autofocus; Escape and the overlay click take the safe "Turn it off" path.
+      // "Keep it on" is the grant, so it carries the danger styling; and NO button takes focus
+      // (autoFocusButtons={false}) — this dialog appears under the user's hands, and a native
+      // Enter/Space on an autofocused button would be an answer they never aimed here.
       danger
       enterConfirms={false}
-      onConfirm={() => recordProjectCapabilityAck(project.id, cap)}
+      autoFocusButtons={false}
+      onConfirm={() => recordProjectCapabilityAck(project.id, cap, 'kept')}
       onCancel={() => {
-        // Answered too: the ack makes "once per project ever" true for this entry, and clearing
-        // the field means the capability stays a refusal (and the file sheds the stranger's grant
-        // on the next save this user makes).
-        recordProjectCapabilityAck(project.id, cap)
+        // The explicit decline: records 'declined' AND sheds the stranger's grant from the file
+        // on the next save. The recorded 'declined' is what keeps a re-arriving `true` refused
+        // and re-noticed instead of silently granted (C1).
         setProjectCapability(project.id, cap, false)
+      }}
+      onDismiss={() => {
+        // NOT an answer: no ack, no field change — the capability stays refused (no 'kept') and
+        // the notice returns next launch.
+        setDismissed((s) => new Set(s).add(`${project.id}:${cap}`))
       }}
     />
   )

--- a/src/renderer/components/ConfirmDialog.tsx
+++ b/src/renderer/components/ConfirmDialog.tsx
@@ -25,8 +25,25 @@ interface ConfirmDialogProps {
    * Escape still cancels either way.
    */
   enterConfirms?: boolean
+  /**
+   * When false, NEITHER button takes `autoFocus`. Default true (historical behavior). Pass false
+   * for a dialog that appears under the user's hands (the capability clone notice): `autoFocus`
+   * steals focus from whatever they were typing in, and their next Enter/Space then NATIVELY
+   * activates the focused button — a path `enterConfirms`/confirm-key never sees, because the
+   * browser's default button activation is not the window keydown listener (PR #213 review, I1).
+   */
+  autoFocusButtons?: boolean
   onConfirm: () => void
   onCancel: () => void
+  /**
+   * When provided, Escape and an overlay click call THIS instead of `onCancel`, and the cancel
+   * button remains the only path to `onCancel`. For a dialog where cancel is itself a recorded
+   * ANSWER (the capability clone notice's "Turn it off"), a stray Escape aimed at a terminal or a
+   * misclick outside the box must be a non-answer — close for now, decide nothing — not a
+   * consent-recording cancel (PR #213 review, I1). Absent = historical behavior (dismissal
+   * cancels).
+   */
+  onDismiss?: () => void
 }
 
 /**
@@ -44,9 +61,13 @@ export function ConfirmDialog({
   alert = false,
   option,
   enterConfirms = true,
+  autoFocusButtons = true,
   onConfirm,
-  onCancel
+  onCancel,
+  onDismiss
 }: ConfirmDialogProps) {
+  // Escape / overlay-click land here: the caller's dismiss channel when it has one, else cancel.
+  const dismiss = onDismiss ?? onCancel
   // An alert has nothing destructive to warn about and nothing to cancel; anything else keeps the
   // historical destructive defaults ("Delete", danger styling, focus parked on the safe button).
   const danger = dangerProp ?? !alert
@@ -82,14 +103,14 @@ export function ConfirmDialog({
       if (!action) return
       e.preventDefault()
       if (action === 'confirm') onConfirm()
-      else onCancel()
+      else dismiss()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [id, enterConfirms, onConfirm, onCancel])
+  }, [id, enterConfirms, onConfirm, dismiss])
 
   return createPortal(
-    <div className="confirm-overlay" onClick={onCancel}>
+    <div className="confirm-overlay" onClick={dismiss}>
       <div className="confirm" ref={boxRef} onClick={(e) => e.stopPropagation()}>
         {body}
         <p className="confirm__msg">{message}</p>
@@ -108,13 +129,13 @@ export function ConfirmDialog({
               (or Space) into a deletion. On a danger dialog the safe button is the focused one; on a
               harmless one the primary action may keep it. */}
           {!alert && (
-            <button className="confirm__btn" autoFocus={danger} onClick={onCancel}>
+            <button className="confirm__btn" autoFocus={autoFocusButtons && danger} onClick={onCancel}>
               {cancelLabel}
             </button>
           )}
           <button
             className={`confirm__btn${danger ? ' danger' : ' primary'}`}
-            autoFocus={!danger}
+            autoFocus={autoFocusButtons && !danger}
             onClick={onConfirm}
           >
             {confirmText}

--- a/src/renderer/components/capability-notice.test.tsx
+++ b/src/renderer/components/capability-notice.test.tsx
@@ -1,20 +1,25 @@
 // @vitest-environment jsdom
 //
-// THE one thing standing between a hostile project.json and a grant (PR 3 Task 3.4): a cloned repo
-// can arrive with `agentBrowserControl: true` already in its git-shared file. The notice must
-//  - appear on the project whose switch is on and whose machine-local entry holds no ack,
+// THE one thing standing between a hostile project.json and a grant (PR 3 Task 3.4 + PR #213
+// review fixes C1/I1): a cloned repo can arrive with `agentBrowserControl: true` already in its
+// git-shared file. The notice must
+//  - appear on the project whose switch is on and whose machine-local entry holds no KEPT answer,
 //  - name the project and what the switch permits (the capability's own copy, not a paraphrase),
-//  - be CLICK-ONLY (it was raised by a file, not by the user — confirm-key.ts's enterConfirms rule),
-//  - record the answer machine-locally (Project.capabilityAck → IndexEntryV3.capabilityAck; the
-//    shared file's bytes are pinned unchanged by workspace-files.test.ts "the ack is machine-local"
-//    and project-capability-consent.test.ts — the renderer cannot import src/core to re-assert it),
-//  - never grant while unanswered: projectCapabilityGranted is false until the click.
+//  - accept ONLY the two buttons as answers: Enter never confirms, Escape/overlay dismissal
+//    records NOTHING and re-shows next launch, and no button holds focus for a native Enter/Space
+//    to activate (I1),
+//  - record WHICH answer was given ('kept'/'declined') machine-locally (Project.capabilityAck →
+//    IndexEntryV3.capabilityAck; the shared file's bytes are pinned unchanged by
+//    workspace-files.test.ts "the ack is machine-local" — the renderer cannot import src/core to
+//    re-assert it),
+//  - never grant while unanswered or declined: a declined switch whose hostile `true` re-arrives
+//    via git is refused AND re-noticed, never silently granted (C1).
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { Project } from '@shared/types'
-import { PROJECT_CAPABILITY_COPY, projectCapabilityEnabled } from '@shared/project-capabilities'
-import { projectCapabilityGranted } from '@shared/project-capability-consent'
+import { PROJECT_CAPABILITY_COPY } from '@shared/project-capabilities'
+import { projectCapabilityGrantedFor } from '@shared/project-capability-consent'
 import { useProjects } from '../state/projects'
 import { CONFIRM_ARM_MS } from './confirm-key'
 import { CapabilityNotice } from './CapabilityNotice'
@@ -59,14 +64,9 @@ function button(label: string): HTMLButtonElement {
   return el!
 }
 
-/** The grantedness the ledger/messaging wiring would compute from the live store, per call. */
+/** The grantedness the ledger/messaging wiring computes from the live store, per call. */
 function grantedNow(): boolean {
-  const p = useProjects.getState().getProject('p1')
-  return projectCapabilityGranted({
-    capability: cap,
-    enabledInFile: projectCapabilityEnabled(p, cap),
-    acknowledged: p?.capabilityAck?.[cap] === true
-  })
+  return projectCapabilityGrantedFor(useProjects.getState().getProject('p1'), cap)
 }
 
 beforeEach(() => {
@@ -83,7 +83,7 @@ afterEach(() => {
 })
 
 describe('the one-time clone notice', () => {
-  it('renders for an on-in-file, never-acknowledged project, naming the project and the grant', () => {
+  it('renders for an on-in-file, never-answered project, naming the project and the grant', () => {
     mount()
     expect(dialog()).toBeTruthy()
     const text = dialog()!.textContent ?? ''
@@ -108,32 +108,94 @@ describe('the one-time clone notice', () => {
     expect(useProjects.getState().getProject('p1')?.capabilityAck).toBeUndefined()
   })
 
+  it('holds focus on NO button, so a native Enter/Space mid-typing cannot answer it (I1)', () => {
+    // The real-browser hole: autoFocus would steal focus from whatever the user was typing in,
+    // and their next Enter/Space would NATIVELY activate the focused button — a path the window
+    // keydown listener (and enterConfirms) never sees. With autoFocusButtons={false} nothing in
+    // the dialog takes focus, so there is no button for that keystroke to land on.
+    const typing = document.createElement('input')
+    document.body.appendChild(typing)
+    typing.focus()
+    mount()
+    expect(dialog()).toBeTruthy()
+    expect(document.activeElement).toBe(typing)
+    for (const b of document.querySelectorAll('.confirm button')) {
+      expect(document.activeElement).not.toBe(b)
+    }
+    typing.remove()
+  })
+
   it('does not grant while unanswered — the switch alone is not consent', () => {
     mount()
     expect(grantedNow()).toBe(false)
   })
 
-  it('"Keep it on": records the machine-local ack, leaves the shared field untouched, then grants', () => {
+  it('"Keep it on": records the machine-local KEPT, leaves the shared field untouched, then grants', () => {
     mount()
     act(() => button('Keep it on').click())
     const p = useProjects.getState().getProject('p1')!
-    expect(p.capabilityAck).toEqual({ [cap]: true })
+    expect(p.capabilityAck).toEqual({ [cap]: 'kept' })
     expect(p[cap]).toBe(true) // the git-shared half did not change — no bytes moved in the file
     expect(grantedNow()).toBe(true)
     expect(dialog()).toBeNull()
   })
 
-  it('"Turn it off": clears the field, records the answer, and still grants nothing', () => {
+  it('"Turn it off": clears the field, records DECLINED, and still grants nothing', () => {
     mount()
     act(() => button('Turn it off').click())
     const p = useProjects.getState().getProject('p1')!
     expect(p[cap]).toBeUndefined()
-    expect(p.capabilityAck).toEqual({ [cap]: true })
+    expect(p.capabilityAck).toEqual({ [cap]: 'declined' })
     expect(grantedNow()).toBe(false)
     expect(dialog()).toBeNull()
   })
 
-  it('a second open does not re-notify — the ack is once per project ever', () => {
+  it('C1: a declined switch whose hostile true RE-ARRIVES is refused AND re-noticed — never a silent grant', () => {
+    mount()
+    act(() => button('Turn it off').click())
+    unmount()
+    // The user's field-deletion was only an uncommitted diff. A `git checkout`/pull restores the
+    // hostile `true`; the watcher's re-read rebuilds the project from the file with the
+    // machine-local ack threaded back in from the index entry — exactly this shape:
+    act(() => {
+      useProjects
+        .getState()
+        .replaceProject(project({ [cap]: true, capabilityAck: { [cap]: 'declined' } }))
+    })
+    expect(grantedNow()).toBe(false) // the standing "no" refuses; the bare-bit ack would grant here
+    mount()
+    expect(dialog()).toBeTruthy() // and the user is told AGAIN — a new notice, not silence
+  })
+
+  it('Escape is a NON-answer: nothing recorded, nothing granted, and the notice returns next launch (I1)', () => {
+    mount()
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(dialog()).toBeNull() // closed for this session…
+    const p = useProjects.getState().getProject('p1')!
+    expect(p.capabilityAck).toBeUndefined() // …but no answer was recorded
+    expect(p[cap]).toBe(true) // and the user's working copy was not silently edited
+    expect(grantedNow()).toBe(false)
+    unmount()
+    mount() // next launch
+    expect(dialog()).toBeTruthy()
+  })
+
+  it('an overlay misclick is a NON-answer too (I1)', () => {
+    mount()
+    act(() => {
+      document.querySelector<HTMLElement>('.confirm-overlay')!.click()
+    })
+    expect(dialog()).toBeNull()
+    expect(useProjects.getState().getProject('p1')?.capabilityAck).toBeUndefined()
+    expect(grantedNow()).toBe(false)
+    unmount()
+    mount()
+    expect(dialog()).toBeTruthy()
+  })
+
+  it('a second open does not re-notify after an explicit KEEP — answered is answered', () => {
     mount()
     act(() => button('Keep it on').click())
     unmount()
@@ -141,7 +203,7 @@ describe('the one-time clone notice', () => {
     expect(dialog()).toBeNull()
   })
 
-  it('never appears for a switch the user set personally — the setter is its own acknowledgment', () => {
+  it('never appears for a switch the user set personally — the setter records its own KEPT', () => {
     useProjects.setState({ projects: [project()], activeProjectId: 'p1' })
     useProjects.getState().setProjectCapability('p1', cap, true)
     mount()

--- a/src/renderer/components/capability-notice.test.tsx
+++ b/src/renderer/components/capability-notice.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+//
+// THE one thing standing between a hostile project.json and a grant (PR 3 Task 3.4): a cloned repo
+// can arrive with `agentBrowserControl: true` already in its git-shared file. The notice must
+//  - appear on the project whose switch is on and whose machine-local entry holds no ack,
+//  - name the project and what the switch permits (the capability's own copy, not a paraphrase),
+//  - be CLICK-ONLY (it was raised by a file, not by the user — confirm-key.ts's enterConfirms rule),
+//  - record the answer machine-locally (Project.capabilityAck → IndexEntryV3.capabilityAck; the
+//    shared file's bytes are pinned unchanged by workspace-files.test.ts "the ack is machine-local"
+//    and project-capability-consent.test.ts — the renderer cannot import src/core to re-assert it),
+//  - never grant while unanswered: projectCapabilityGranted is false until the click.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { Project } from '@shared/types'
+import { PROJECT_CAPABILITY_COPY, projectCapabilityEnabled } from '@shared/project-capabilities'
+import { projectCapabilityGranted } from '@shared/project-capability-consent'
+import { useProjects } from '../state/projects'
+import { CONFIRM_ARM_MS } from './confirm-key'
+import { CapabilityNotice } from './CapabilityNotice'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const cap = 'agentBrowserControl' as const
+
+const project = (over: Partial<Project> = {}): Project => ({
+  id: 'p1',
+  name: 'cloned-repo',
+  color: '#7aa2f7',
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: [],
+  ...over
+})
+
+let root: Root
+let host: HTMLElement
+
+function mount(): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => root.render(<CapabilityNotice />))
+}
+
+function unmount(): void {
+  act(() => root.unmount())
+  host.remove()
+}
+
+function dialog(): HTMLElement | null {
+  return document.querySelector('.confirm')
+}
+
+function button(label: string): HTMLButtonElement {
+  const el = [...document.querySelectorAll<HTMLButtonElement>('.confirm button')].find(
+    (b) => b.textContent === label
+  )
+  expect(el, `button "${label}"`).toBeTruthy()
+  return el!
+}
+
+/** The grantedness the ledger/messaging wiring would compute from the live store, per call. */
+function grantedNow(): boolean {
+  const p = useProjects.getState().getProject('p1')
+  return projectCapabilityGranted({
+    capability: cap,
+    enabledInFile: projectCapabilityEnabled(p, cap),
+    acknowledged: p?.capabilityAck?.[cap] === true
+  })
+}
+
+beforeEach(() => {
+  useProjects.setState({
+    projects: [project({ [cap]: true })],
+    activeProjectId: 'p1',
+    reloadNonce: 0
+  })
+})
+
+afterEach(() => {
+  unmount()
+  useProjects.setState({ projects: [], activeProjectId: '' })
+})
+
+describe('the one-time clone notice', () => {
+  it('renders for an on-in-file, never-acknowledged project, naming the project and the grant', () => {
+    mount()
+    expect(dialog()).toBeTruthy()
+    const text = dialog()!.textContent ?? ''
+    expect(text).toContain('cloned-repo')
+    expect(text).toContain(PROJECT_CAPABILITY_COPY[cap].description)
+    expect(text).toContain(PROJECT_CAPABILITY_COPY[cap].cloneWarning)
+  })
+
+  it('is CLICK-ONLY: Enter aimed into the dialog confirms nothing', async () => {
+    mount()
+    // Outwait CONFIRM_ARM_MS first: a fresh dialog ignores Enter for 500ms REGARDLESS of
+    // enterConfirms, so dispatching immediately would pass even if the click-only prop were
+    // dropped. Past the arm window, only `enterConfirms={false}` stands between this Enter and a
+    // confirmation — which is exactly the mutation this test exists to catch.
+    await new Promise((r) => setTimeout(r, CONFIRM_ARM_MS + 150))
+    const box = dialog()!
+    act(() => {
+      box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    })
+    expect(dialog()).toBeTruthy()
+    expect(useProjects.getState().getProject('p1')?.capabilityAck).toBeUndefined()
+  })
+
+  it('does not grant while unanswered — the switch alone is not consent', () => {
+    mount()
+    expect(grantedNow()).toBe(false)
+  })
+
+  it('"Keep it on": records the machine-local ack, leaves the shared field untouched, then grants', () => {
+    mount()
+    act(() => button('Keep it on').click())
+    const p = useProjects.getState().getProject('p1')!
+    expect(p.capabilityAck).toEqual({ [cap]: true })
+    expect(p[cap]).toBe(true) // the git-shared half did not change — no bytes moved in the file
+    expect(grantedNow()).toBe(true)
+    expect(dialog()).toBeNull()
+  })
+
+  it('"Turn it off": clears the field, records the answer, and still grants nothing', () => {
+    mount()
+    act(() => button('Turn it off').click())
+    const p = useProjects.getState().getProject('p1')!
+    expect(p[cap]).toBeUndefined()
+    expect(p.capabilityAck).toEqual({ [cap]: true })
+    expect(grantedNow()).toBe(false)
+    expect(dialog()).toBeNull()
+  })
+
+  it('a second open does not re-notify — the ack is once per project ever', () => {
+    mount()
+    act(() => button('Keep it on').click())
+    unmount()
+    mount()
+    expect(dialog()).toBeNull()
+  })
+
+  it('never appears for a switch the user set personally — the setter is its own acknowledgment', () => {
+    useProjects.setState({ projects: [project()], activeProjectId: 'p1' })
+    useProjects.getState().setProjectCapability('p1', cap, true)
+    mount()
+    expect(dialog()).toBeNull()
+    expect(grantedNow()).toBe(true)
+  })
+
+  it('stays silent when the switch is off', () => {
+    useProjects.setState({ projects: [project()], activeProjectId: 'p1' })
+    mount()
+    expect(dialog()).toBeNull()
+  })
+})

--- a/src/renderer/components/settings/agents-capabilities.test.tsx
+++ b/src/renderer/components/settings/agents-capabilities.test.tsx
@@ -11,9 +11,9 @@ import type { Project } from '@shared/types'
 import {
   PROJECT_CAPABILITIES,
   PROJECT_CAPABILITY_COPY,
-  projectCapabilityEnabled
+  projectCapabilityFlagInFile
 } from '@shared/project-capabilities'
-import { projectCapabilityGranted } from '@shared/project-capability-consent'
+import { projectCapabilityGrantedFor } from '@shared/project-capability-consent'
 import { useProjects } from '../../state/projects'
 import { AgentsSection } from './sections/AgentsSection'
 
@@ -79,10 +79,10 @@ describe('per-project capability rows, generated from PROJECT_CAPABILITIES', () 
       mount()
       act(() => capSwitch(PROJECT_CAPABILITY_COPY[cap].label).click())
       const p = useProjects.getState().getProject('p1')!
-      expect(p[cap]).toBe(true) // === true, not "true"/1 — projectCapabilityEnabled is strict
-      // Setting it yourself is its own acknowledgment: no clone notice for the user's own switch.
-      expect(p.capabilityAck?.[cap]).toBe(true)
-      expect(projectCapabilityEnabled(p, cap)).toBe(true)
+      expect(p[cap]).toBe(true) // === true, not "true"/1 — projectCapabilityFlagInFile is strict
+      // Setting it yourself records its own KEPT: no clone notice for the user's own switch.
+      expect(p.capabilityAck?.[cap]).toBe('kept')
+      expect(projectCapabilityFlagInFile(p, cap)).toBe(true)
     }
   )
 
@@ -92,7 +92,11 @@ describe('per-project capability rows, generated from PROJECT_CAPABILITIES', () 
       useProjects.getState().setProjectCapability('p1', cap, true)
       mount()
       act(() => capSwitch(PROJECT_CAPABILITY_COPY[cap].label).click())
-      expect(useProjects.getState().getProject('p1')![cap]).toBeUndefined()
+      const p = useProjects.getState().getProject('p1')!
+      expect(p[cap]).toBeUndefined()
+      // …and records DECLINED (PR #213 C1/M-2): if a teammate re-commits `true`, the project is
+      // re-noticed and refused instead of silently re-granted through the old consent.
+      expect(p.capabilityAck?.[cap]).toBe('declined')
     }
   )
 
@@ -102,14 +106,8 @@ describe('per-project capability rows, generated from PROJECT_CAPABILITIES', () 
     // the refusal immediately — no lease-start snapshot may answer for it.
     const cap = PROJECT_CAPABILITIES[0]
     useProjects.getState().setProjectCapability('p1', cap, true)
-    const grantedNow = (): boolean => {
-      const p = useProjects.getState().getProject('p1')
-      return projectCapabilityGranted({
-        capability: cap,
-        enabledInFile: projectCapabilityEnabled(p, cap),
-        acknowledged: p?.capabilityAck?.[cap] === true
-      })
-    }
+    const grantedNow = (): boolean =>
+      projectCapabilityGrantedFor(useProjects.getState().getProject('p1'), cap)
     expect(grantedNow()).toBe(true)
     mount()
     act(() => capSwitch(PROJECT_CAPABILITY_COPY[cap].label).click())

--- a/src/renderer/components/settings/agents-capabilities.test.tsx
+++ b/src/renderer/components/settings/agents-capabilities.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+//
+// Settings → Agents: the per-project capability rows are GENERATED from PROJECT_CAPABILITIES.
+// Every assertion below iterates the array rather than naming rows: a capability added to the
+// union without a rendered row (the hand-written-list failure this repo has already documented)
+// fails here, and agent messaging's row (its PR 6) must appear by adding a copy entry only.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { Project } from '@shared/types'
+import {
+  PROJECT_CAPABILITIES,
+  PROJECT_CAPABILITY_COPY,
+  projectCapabilityEnabled
+} from '@shared/project-capabilities'
+import { projectCapabilityGranted } from '@shared/project-capability-consent'
+import { useProjects } from '../../state/projects'
+import { AgentsSection } from './sections/AgentsSection'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const project = (over: Partial<Project> = {}): Project => ({
+  id: 'p1',
+  name: 'my-canvas',
+  color: '#7aa2f7',
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: [],
+  ...over
+})
+
+let root: Root
+let host: HTMLElement
+
+function mount(): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => root.render(<AgentsSection isActive />))
+}
+
+function capSwitch(label: string): HTMLElement {
+  const el = host.querySelector<HTMLElement>(`[role="switch"][aria-label="${label}"]`)
+  expect(el, `a rendered switch for "${label}"`).toBeTruthy()
+  return el!
+}
+
+beforeEach(() => {
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+    settings: { save: vi.fn(async () => undefined) },
+    claude: { cliCaps: vi.fn(async () => null) }
+  }
+  useProjects.setState({ projects: [project()], activeProjectId: 'p1', reloadNonce: 0 })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  useProjects.setState({ projects: [], activeProjectId: '' })
+})
+
+describe('per-project capability rows, generated from PROJECT_CAPABILITIES', () => {
+  it('renders one row per capability, naming the active project, the grant and what travels', () => {
+    mount()
+    const text = host.textContent ?? ''
+    for (const cap of PROJECT_CAPABILITIES) {
+      const copy = PROJECT_CAPABILITY_COPY[cap]
+      capSwitch(copy.label)
+      expect(text).toContain(copy.description)
+      // The same "this is in the project file" sentence the clone notice shows: the two
+      // git-shared grants read alike wherever the switch is set.
+      expect(text).toContain(copy.cloneWarning)
+    }
+    expect(text).toContain('my-canvas')
+  })
+
+  it.each([...PROJECT_CAPABILITIES])(
+    'toggling %s on writes the literal true the strict validators accept, plus this machine’s ack',
+    (cap) => {
+      mount()
+      act(() => capSwitch(PROJECT_CAPABILITY_COPY[cap].label).click())
+      const p = useProjects.getState().getProject('p1')!
+      expect(p[cap]).toBe(true) // === true, not "true"/1 — projectCapabilityEnabled is strict
+      // Setting it yourself is its own acknowledgment: no clone notice for the user's own switch.
+      expect(p.capabilityAck?.[cap]).toBe(true)
+      expect(projectCapabilityEnabled(p, cap)).toBe(true)
+    }
+  )
+
+  it.each([...PROJECT_CAPABILITIES])(
+    'toggling %s off deletes the field outright — no bytes, and never a stored false',
+    (cap) => {
+      useProjects.getState().setProjectCapability('p1', cap, true)
+      mount()
+      act(() => capSwitch(PROJECT_CAPABILITY_COPY[cap].label).click())
+      expect(useProjects.getState().getProject('p1')![cap]).toBeUndefined()
+    }
+  )
+
+  it('turning a capability off takes effect LIVE: every read consults the store, nothing caches', () => {
+    // PR 6 Task 6.4 depends on this shape: the browser ledger / messagingEnabled read the switch
+    // per call. Simulate two consecutive calls around an off-toggle and require the second to see
+    // the refusal immediately — no lease-start snapshot may answer for it.
+    const cap = PROJECT_CAPABILITIES[0]
+    useProjects.getState().setProjectCapability('p1', cap, true)
+    const grantedNow = (): boolean => {
+      const p = useProjects.getState().getProject('p1')
+      return projectCapabilityGranted({
+        capability: cap,
+        enabledInFile: projectCapabilityEnabled(p, cap),
+        acknowledged: p?.capabilityAck?.[cap] === true
+      })
+    }
+    expect(grantedNow()).toBe(true)
+    mount()
+    act(() => capSwitch(PROJECT_CAPABILITY_COPY[cap].label).click())
+    expect(grantedNow()).toBe(false)
+  })
+
+  it('with no project open the switch is disabled — a capability needs a project to belong to', () => {
+    useProjects.setState({ projects: [], activeProjectId: '' })
+    mount()
+    for (const cap of PROJECT_CAPABILITIES) {
+      const el = capSwitch(PROJECT_CAPABILITY_COPY[cap].label)
+      expect(el.getAttribute('aria-disabled') === 'true' || el.hasAttribute('disabled')).toBe(true)
+    }
+  })
+})

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -4,7 +4,7 @@ import { useProjects } from '../../../state/projects'
 import {
   PROJECT_CAPABILITIES,
   PROJECT_CAPABILITY_COPY,
-  projectCapabilityEnabled
+  projectCapabilityFlagInFile
 } from '@shared/project-capabilities'
 import {
   isAgentEnabled,
@@ -330,7 +330,10 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
             description={`${PROJECT_CAPABILITY_COPY[cap].description} ${PROJECT_CAPABILITY_COPY[cap].cloneWarning}`}
             control={
               <Switch
-                checked={projectCapabilityEnabled(activeProject, cap)}
+                // The raw FILE FLAG is the right thing for a settings switch to display — it
+                // mirrors what is written in .nodeterm/project.json. It is NEVER the grant check:
+                // grants require the machine-local 'kept' too (projectCapabilityGrantedFor).
+                checked={projectCapabilityFlagInFile(activeProject, cap)}
                 ariaLabel={title}
                 disabled={!activeProject}
                 onChange={(on) => {

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react'
 import { useSettings } from '../../../state/settings'
+import { useProjects } from '../../../state/projects'
+import {
+  PROJECT_CAPABILITIES,
+  PROJECT_CAPABILITY_COPY,
+  projectCapabilityEnabled
+} from '@shared/project-capabilities'
 import {
   isAgentEnabled,
   setAgentEnabled,
@@ -94,7 +100,26 @@ const ROWS = {
     ]
   }
 }
-const ENTRIES = Object.values(ROWS)
+/**
+ * The per-project capability rows are GENERATED from PROJECT_CAPABILITIES — search registry
+ * included. A hand-written row list that happens to match the union is the documented
+ * claims-ahead-of-mechanism failure: agent messaging's row (its PR 6) must appear by adding a copy
+ * entry, and agents-capabilities.test.tsx iterates the array so a capability without a row is red.
+ */
+const CAPABILITY_ROWS = PROJECT_CAPABILITIES.map((cap) => ({
+  cap,
+  title: PROJECT_CAPABILITY_COPY[cap].label,
+  keywords: [
+    'project',
+    'capability',
+    'permission',
+    ...PROJECT_CAPABILITY_COPY[cap].label.toLowerCase().split(/\s+/)
+  ]
+}))
+const ENTRIES = [
+  ...Object.values(ROWS),
+  ...CAPABILITY_ROWS.map(({ title, keywords }) => ({ title, keywords }))
+]
 
 /**
  * Every fact in this sentence is DERIVED from the per-agent mapping (`@shared/agents/approval-mode`):
@@ -149,6 +174,13 @@ function identityValue(choice: IdentityChoice): boolean | undefined {
 export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.Element {
   const settings = useSettings((s) => s.settings)
   const update = useSettings((s) => s.update)
+  // Per-project capability rows act on the ACTIVE project. Subscribed (not getState()) so an
+  // off-toggle re-renders immediately — and consumers read the switch per call from the store,
+  // never from a snapshot taken when a lease started (agents-capabilities.test.tsx "takes effect
+  // LIVE"; browser PR 4 / messaging PR 6 rely on that shape).
+  const activeProjectId = useProjects((s) => s.activeProjectId)
+  const activeProject = useProjects((s) => s.projects.find((p) => p.id === activeProjectId))
+  const setProjectCapability = useProjects((s) => s.setProjectCapability)
   const rows: { id: AgentId; label: string; isBuiltin: boolean }[] = [
     ...BUILTIN_AGENT_IDS.map((id) => ({ id, label: AGENT_CONFIG[id].label, isBuiltin: true })),
     ...settings.customAgents.map((c) => ({ id: c.id, label: c.label || c.id, isBuiltin: false }))
@@ -283,6 +315,35 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
           }
         />
       </SearchableRow>
+      {CAPABILITY_ROWS.map(({ cap, title, keywords }) => (
+        <SearchableRow key={cap} title={title} keywords={keywords}>
+          <FieldRow
+            label={title}
+            note={
+              activeProject
+                ? `Applies to the active project: ${activeProject.name}.`
+                : 'Open a project to change this — the switch belongs to a project, not to the app.'
+            }
+            // The description carries the capability's own copy AND its cloneWarning — the same
+            // "this is in the project file" sentence the clone notice shows, so the two git-shared
+            // grants read alike wherever they appear (pinned by agents-capabilities.test.tsx).
+            description={`${PROJECT_CAPABILITY_COPY[cap].description} ${PROJECT_CAPABILITY_COPY[cap].cloneWarning}`}
+            control={
+              <Switch
+                checked={projectCapabilityEnabled(activeProject, cap)}
+                ariaLabel={title}
+                disabled={!activeProject}
+                onChange={(on) => {
+                  // The ONE strict setter: literal `true` on, field deleted on off. Writing the
+                  // value any other way (a string, a stored false) is the bug the validators
+                  // exist to refuse.
+                  if (activeProject) setProjectCapability(activeProject.id, cap, on)
+                }}
+              />
+            }
+          />
+        </SearchableRow>
+      ))}
       <SearchableRow {...ROWS.hibernation}>
         <FieldRow
           label="Hibernate idle agents"

--- a/src/renderer/state/projects.ts
+++ b/src/renderer/state/projects.ts
@@ -11,7 +11,7 @@ import type {
 } from '@shared/types'
 import { collisionSeed, derivedProjectId } from '@shared/project-id'
 import type { ProjectCapability } from '@shared/project-capabilities'
-import { recordCapabilityAck } from '@shared/project-capability-consent'
+import { recordCapabilityAck, type CapabilityAnswer } from '@shared/project-capability-consent'
 import { applyCanvasMutation, createProject, reorderGroupWithinParent } from './workspace'
 
 interface ProjectsState {
@@ -70,17 +70,18 @@ interface ProjectsState {
   setProjectDefaultPermissionMode(id: string, mode: AgentPermissionMode | undefined): void
   /**
    * THE strict per-project capability setter (@shared/project-capabilities). `on` writes the
-   * literal `true` the validators accept AND records the machine-local ack — setting a switch
-   * yourself is its own acknowledgment, so the clone notice never fires on your own decision.
-   * `off` deletes the field outright (an off capability adds no bytes to the shared file); the
-   * ack, once earned, stays. */
+   * literal `true` the validators accept AND records this machine's 'kept' answer — setting a
+   * switch yourself is its own consent, so the clone notice never fires on your own decision.
+   * `off` deletes the field outright (an off capability adds no bytes to the shared file) AND
+   * records 'declined': if a teammate's (or a hostile) `true` re-arrives via git, the capability
+   * is refused and re-noticed rather than silently re-granted (PR #213 C1/M-2). */
   setProjectCapability(id: string, cap: ProjectCapability, on: boolean): void
   /**
-   * Records this machine's answer to the one-time clone notice. MACHINE-LOCAL by construction:
-   * `Project.capabilityAck` rides `IndexEntryV3.capabilityAck` through splitWorkspace on the next
-   * save and is never written into .nodeterm/project.json (workspace-files.test.ts pins the file
-   * bytes; capability-notice.test.tsx pins this path). */
-  recordProjectCapabilityAck(id: string, cap: ProjectCapability): void
+   * Records this machine's ANSWER ('kept' | 'declined') to the one-time clone notice.
+   * MACHINE-LOCAL by construction: `Project.capabilityAck` rides `IndexEntryV3.capabilityAck`
+   * through splitWorkspace on the next save and is never written into .nodeterm/project.json
+   * (workspace-files.test.ts pins the file bytes; capability-notice.test.tsx pins this path). */
+  recordProjectCapabilityAck(id: string, cap: ProjectCapability, answer: CapabilityAnswer): void
   /** Raises the project's dino high score (never lowers it). */
   setDinoHighScore(id: string, score: number): void
   /** Replaces the project's kanban board (the UI computes the next board via lib/kanban). */
@@ -352,17 +353,19 @@ export const useProjects = create<ProjectsState>((set, get) => ({
     set((s) => ({
       projects: s.projects.map((p) => {
         if (p.id !== id) return p
-        if (on) return recordCapabilityAck({ ...p, [cap]: true }, cap)
+        if (on) return recordCapabilityAck({ ...p, [cap]: true }, cap, 'kept')
         const next = { ...p }
         delete next[cap]
-        return next
+        // 'declined', not silence: the deletion lives only in this working copy, so a re-arriving
+        // `true` (teammate commit, git checkout) must re-notice instead of meeting a bare ack.
+        return recordCapabilityAck(next, cap, 'declined')
       })
     }))
   },
 
-  recordProjectCapabilityAck(id, cap) {
+  recordProjectCapabilityAck(id, cap, answer) {
     set((s) => ({
-      projects: s.projects.map((p) => (p.id === id ? recordCapabilityAck(p, cap) : p))
+      projects: s.projects.map((p) => (p.id === id ? recordCapabilityAck(p, cap, answer) : p))
     }))
   },
 

--- a/src/renderer/state/projects.ts
+++ b/src/renderer/state/projects.ts
@@ -10,6 +10,8 @@ import type {
   Workspace
 } from '@shared/types'
 import { collisionSeed, derivedProjectId } from '@shared/project-id'
+import type { ProjectCapability } from '@shared/project-capabilities'
+import { recordCapabilityAck } from '@shared/project-capability-consent'
 import { applyCanvasMutation, createProject, reorderGroupWithinParent } from './workspace'
 
 interface ProjectsState {
@@ -66,6 +68,19 @@ interface ProjectsState {
   /** Sets (or clears, with undefined = fall back to the global setting) the project's default
    *  permission mode for new Claude terminal (CLI) sessions. Chat nodes are not covered. */
   setProjectDefaultPermissionMode(id: string, mode: AgentPermissionMode | undefined): void
+  /**
+   * THE strict per-project capability setter (@shared/project-capabilities). `on` writes the
+   * literal `true` the validators accept AND records the machine-local ack — setting a switch
+   * yourself is its own acknowledgment, so the clone notice never fires on your own decision.
+   * `off` deletes the field outright (an off capability adds no bytes to the shared file); the
+   * ack, once earned, stays. */
+  setProjectCapability(id: string, cap: ProjectCapability, on: boolean): void
+  /**
+   * Records this machine's answer to the one-time clone notice. MACHINE-LOCAL by construction:
+   * `Project.capabilityAck` rides `IndexEntryV3.capabilityAck` through splitWorkspace on the next
+   * save and is never written into .nodeterm/project.json (workspace-files.test.ts pins the file
+   * bytes; capability-notice.test.tsx pins this path). */
+  recordProjectCapabilityAck(id: string, cap: ProjectCapability): void
   /** Raises the project's dino high score (never lowers it). */
   setDinoHighScore(id: string, score: number): void
   /** Replaces the project's kanban board (the UI computes the next board via lib/kanban). */
@@ -330,6 +345,24 @@ export const useProjects = create<ProjectsState>((set, get) => ({
   setProjectDefaultPermissionMode(id, mode) {
     set((s) => ({
       projects: s.projects.map((p) => (p.id === id ? { ...p, defaultPermissionMode: mode } : p))
+    }))
+  },
+
+  setProjectCapability(id, cap, on) {
+    set((s) => ({
+      projects: s.projects.map((p) => {
+        if (p.id !== id) return p
+        if (on) return recordCapabilityAck({ ...p, [cap]: true }, cap)
+        const next = { ...p }
+        delete next[cap]
+        return next
+      })
+    }))
+  },
+
+  recordProjectCapabilityAck(id, cap) {
+    set((s) => ({
+      projects: s.projects.map((p) => (p.id === id ? recordCapabilityAck(p, cap) : p))
     }))
   },
 

--- a/src/renderer/ui/Switch.tsx
+++ b/src/renderer/ui/Switch.tsx
@@ -3,11 +3,15 @@ import { cn } from './cn'
 export function Switch({
   checked,
   onChange,
-  ariaLabel
+  ariaLabel,
+  disabled = false
 }: {
   checked: boolean
   onChange: (v: boolean) => void
   ariaLabel?: string
+  /** Renders inert (native `disabled` + aria): for a switch whose subject does not currently
+   *  exist, e.g. a per-project capability while no project is open. */
+  disabled?: boolean
 }): React.JSX.Element {
   return (
     <button
@@ -15,9 +19,12 @@ export function Switch({
       role="switch"
       aria-checked={checked}
       aria-label={ariaLabel}
+      disabled={disabled}
+      aria-disabled={disabled || undefined}
       onClick={() => onChange(!checked)}
       className={cn(
-        'relative box-border block h-[24px] w-[42px] shrink-0 cursor-pointer rounded-full border-0 p-0 outline-none transition-colors duration-200',
+        'relative box-border block h-[24px] w-[42px] shrink-0 rounded-full border-0 p-0 outline-none transition-colors duration-200',
+        disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
         checked ? 'bg-accent' : 'bg-fill'
       )}
     >

--- a/src/shared/project-capabilities.test.ts
+++ b/src/shared/project-capabilities.test.ts
@@ -2,24 +2,29 @@ import { describe, it, expect } from 'vitest'
 import {
   PROJECT_CAPABILITIES,
   PROJECT_CAPABILITY_COPY,
-  projectCapabilityEnabled,
+  projectCapabilityFlagInFile,
   readProjectCapabilities,
   projectCapabilityFields
 } from './project-capabilities'
 
-describe('projectCapabilityEnabled is STRICT', () => {
+describe('projectCapabilityFlagInFile is STRICT (and NEVER a grant check — see project-capability-consent)', () => {
   it('true enables', () => {
-    expect(projectCapabilityEnabled({ agentBrowserControl: true }, 'agentBrowserControl')).toBe(true)
+    expect(projectCapabilityFlagInFile({ agentBrowserControl: true }, 'agentBrowserControl')).toBe(true)
   })
   it.each([undefined, false, null, 0, 1, 'true', 'yes', {}, [], 'false'])(
     'everything else is OFF (%j) — project.json is hostile input, not a truthiness exercise',
     (v) => {
-      expect(projectCapabilityEnabled({ agentBrowserControl: v } as never, 'agentBrowserControl')).toBe(false)
+      expect(projectCapabilityFlagInFile({ agentBrowserControl: v } as never, 'agentBrowserControl')).toBe(false)
     }
   )
   it('an absent project is off, never a throw', () => {
-    expect(projectCapabilityEnabled(undefined, 'agentBrowserControl')).toBe(false)
-    expect(projectCapabilityEnabled(null, 'agentBrowserControl')).toBe(false)
+    expect(projectCapabilityFlagInFile(undefined, 'agentBrowserControl')).toBe(false)
+    expect(projectCapabilityFlagInFile(null, 'agentBrowserControl')).toBe(false)
+  })
+  it('a prototype-inherited true is OFF — own properties only (M-1)', () => {
+    const inherited = Object.create({ agentBrowserControl: true }) as Record<string, unknown>
+    expect(projectCapabilityFlagInFile(inherited, 'agentBrowserControl')).toBe(false)
+    expect(readProjectCapabilities(inherited)).toEqual({})
   })
 })
 

--- a/src/shared/project-capabilities.test.ts
+++ b/src/shared/project-capabilities.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PROJECT_CAPABILITIES,
+  PROJECT_CAPABILITY_COPY,
+  projectCapabilityEnabled,
+  readProjectCapabilities,
+  projectCapabilityFields
+} from './project-capabilities'
+
+describe('projectCapabilityEnabled is STRICT', () => {
+  it('true enables', () => {
+    expect(projectCapabilityEnabled({ agentBrowserControl: true }, 'agentBrowserControl')).toBe(true)
+  })
+  it.each([undefined, false, null, 0, 1, 'true', 'yes', {}, [], 'false'])(
+    'everything else is OFF (%j) — project.json is hostile input, not a truthiness exercise',
+    (v) => {
+      expect(projectCapabilityEnabled({ agentBrowserControl: v } as never, 'agentBrowserControl')).toBe(false)
+    }
+  )
+  it('an absent project is off, never a throw', () => {
+    expect(projectCapabilityEnabled(undefined, 'agentBrowserControl')).toBe(false)
+    expect(projectCapabilityEnabled(null, 'agentBrowserControl')).toBe(false)
+  })
+})
+
+describe('readProjectCapabilities normalises whatever the file carried', () => {
+  it('keeps only literal true, and only known keys', () => {
+    expect(readProjectCapabilities({ agentBrowserControl: 'true', nope: true })).toEqual({})
+    expect(readProjectCapabilities({ agentBrowserControl: true })).toEqual({ agentBrowserControl: true })
+    expect(readProjectCapabilities({ agentBrowserControl: true, nope: true })).toEqual({
+      agentBrowserControl: true
+    })
+  })
+  it('survives a non-object file', () => {
+    expect(readProjectCapabilities(null)).toEqual({})
+    expect(readProjectCapabilities('x')).toEqual({})
+    expect(readProjectCapabilities(undefined)).toEqual({})
+  })
+})
+
+describe('projectCapabilityFields — the spread projectToFile uses', () => {
+  it('omits an off capability entirely (no bytes, no git churn) and survives null', () => {
+    expect(projectCapabilityFields({ agentBrowserControl: false })).toEqual({})
+    expect(projectCapabilityFields(null)).toEqual({})
+    expect(projectCapabilityFields({ agentBrowserControl: true })).toEqual({ agentBrowserControl: true })
+  })
+})
+
+describe('every capability has copy, and the copy says what travels', () => {
+  it.each(PROJECT_CAPABILITIES)('%s has label, description and cloneWarning', (cap) => {
+    const c = PROJECT_CAPABILITY_COPY[cap]
+    expect(c.label.length).toBeGreaterThan(0)
+    expect(c.description.length).toBeGreaterThan(0)
+    // The same wording class as TabBar's bypassPermissions title: the two git-shared grants read alike.
+    expect(c.cloneWarning).toContain('.nodeterm/project.json')
+  })
+})

--- a/src/shared/project-capabilities.ts
+++ b/src/shared/project-capabilities.ts
@@ -50,23 +50,38 @@ export const PROJECT_CAPABILITY_COPY: Record<ProjectCapability, ProjectCapabilit
   }
 }
 
-/** Is this capability on for this project? STRICT `=== true`: .nodeterm/project.json is hostile
- *  input — git-shared, hand-editable, auto-adopted (@shared/node-exec) — so `"true"`, `1` and `{}`
- *  are off. Every consumption site goes through this function; a bare `if (project.x)` is a bug.
- *  (`project-capabilities.test.ts` fails on any of those values enabling.) */
-export function projectCapabilityEnabled(
+/**
+ * Is the capability's raw switch set in this project's shared file? STRICT `=== true`, own
+ * properties only: .nodeterm/project.json is hostile input — git-shared, hand-editable,
+ * auto-adopted (@shared/node-exec) — so `"true"`, `1`, `{}` and a prototype-inherited `true` are
+ * all off (`project-capabilities.test.ts` fails on any of them enabling).
+ *
+ * NEVER A GRANT CHECK (PR #213 review, I2). This reads the FILE BIT only and knows nothing of the
+ * clone notice: during the pending-notice window — and after a recorded decline — it answers
+ * `true` while the capability must refuse. It exists for exactly two kinds of caller: display (a
+ * Settings switch showing the file's state) and the notice decider's `enabledInFile` input.
+ * Grants go through `projectCapabilityGrantedFor` (@shared/project-capability-consent), pinned by
+ * project-capability-consent.test.ts "a switch that is on but unanswered grants nothing".
+ */
+export function projectCapabilityFlagInFile(
   p: Partial<Record<ProjectCapability, unknown>> | undefined | null,
   cap: ProjectCapability
 ): boolean {
-  return p?.[cap] === true
+  if (!p || !Object.prototype.hasOwnProperty.call(p, cap)) return false
+  return p[cap] === true
 }
 
-/** The capability half of a ProjectFileV1, normalised: known keys only, literal `true` only. */
+/** The capability half of a ProjectFileV1, normalised: known keys only, literal `true` only,
+ *  own properties only (M-1: no consent inherited through a prototype chain). */
 export function readProjectCapabilities(f: unknown): Partial<Record<ProjectCapability, true>> {
   const out: Partial<Record<ProjectCapability, true>> = {}
   if (!f || typeof f !== 'object') return out
   for (const cap of PROJECT_CAPABILITIES) {
-    if ((f as Record<string, unknown>)[cap] === true) out[cap] = true
+    if (
+      Object.prototype.hasOwnProperty.call(f, cap) &&
+      (f as Record<string, unknown>)[cap] === true
+    )
+      out[cap] = true
   }
   return out
 }

--- a/src/shared/project-capabilities.ts
+++ b/src/shared/project-capabilities.ts
@@ -1,0 +1,80 @@
+/**
+ * Per-project capability switches — the FIRST of their kind in nodeterm.
+ *
+ * Before this file, `Project` carried exactly two policy fields (defaultAccountId,
+ * defaultPermissionMode) and there was no per-project settings surface at all. Browser control
+ * needed one and agent-to-agent messaging needs the same one, so the mechanism lives here ONCE:
+ * the key set, the copy, the strict read, and the file round-trip. Adding a capability is a line in
+ * PROJECT_CAPABILITIES plus an entry in PROJECT_CAPABILITY_COPY — no persistence code changes and,
+ * critically, no second clone-notice implementation (see core/project-capability-consent.ts).
+ *
+ * THESE FIELDS LIVE IN .nodeterm/project.json, WHICH IS GIT-SHARED. That is a hazard to be handled,
+ * not noted: a hostile cloned repo ships `agentBrowserControl: true` and the clone's first agent
+ * turn would otherwise hold the capability. Two things make that survivable and BOTH are required:
+ *
+ *  1. The switch alone grants nothing. Every capability must additionally require state this app
+ *     run built and never persisted (browser control: the in-memory ownership ledger; a cloned
+ *     project.json cannot pre-populate it, and `Project.ropes` — which IS persisted and git-shared —
+ *     is deliberately never consulted for ownership).
+ *  2. First use in a project the user has not personally switched on raises a one-time notice,
+ *     recorded MACHINE-LOCALLY (IndexEntryV3.capabilityAck), never in project.json.
+ *
+ * If (2) is ever dropped as friction, this field must move to a machine-local store. That is the
+ * trigger, written down where the decision is, not only in the design doc.
+ */
+export type ProjectCapability = 'agentBrowserControl'
+// Agent-to-agent messaging adds 'agentMessaging' here (its plan's PR 6 Task 6.1).
+
+export const PROJECT_CAPABILITIES: readonly ProjectCapability[] = ['agentBrowserControl'] as const
+
+export interface ProjectCapabilityCopy {
+  label: string
+  description: string
+  /** Shown wherever the switch is set AND in the clone notice. Same wording class as TabBar's
+   *  bypassPermissions title, so the two git-shared grants read alike. */
+  cloneWarning: string
+}
+
+export const PROJECT_CAPABILITY_COPY: Record<ProjectCapability, ProjectCapabilityCopy> = {
+  agentBrowserControl: {
+    label: 'Let agents drive browser nodes they open',
+    description:
+      'Agents in this project can navigate, read, click and type in browser nodes THEY opened — ' +
+      'never in browser nodes you opened. Any page an agent reads can try to steer it: a page can ' +
+      'contain instructions, and the same agent can navigate anywhere and type anywhere. Nodes an ' +
+      'agent opens use their own logged-out session, separate from your own browsing. A badge on ' +
+      'the node shows when one is being driven, with a Stop button.',
+    cloneWarning:
+      'This setting is saved in the project file (.nodeterm/project.json), so if you commit it, ' +
+      'everyone who clones the repo gets it too.'
+  }
+}
+
+/** Is this capability on for this project? STRICT `=== true`: .nodeterm/project.json is hostile
+ *  input — git-shared, hand-editable, auto-adopted (@shared/node-exec) — so `"true"`, `1` and `{}`
+ *  are off. Every consumption site goes through this function; a bare `if (project.x)` is a bug.
+ *  (`project-capabilities.test.ts` fails on any of those values enabling.) */
+export function projectCapabilityEnabled(
+  p: Partial<Record<ProjectCapability, unknown>> | undefined | null,
+  cap: ProjectCapability
+): boolean {
+  return p?.[cap] === true
+}
+
+/** The capability half of a ProjectFileV1, normalised: known keys only, literal `true` only. */
+export function readProjectCapabilities(f: unknown): Partial<Record<ProjectCapability, true>> {
+  const out: Partial<Record<ProjectCapability, true>> = {}
+  if (!f || typeof f !== 'object') return out
+  for (const cap of PROJECT_CAPABILITIES) {
+    if ((f as Record<string, unknown>)[cap] === true) out[cap] = true
+  }
+  return out
+}
+
+/** The spread `projectToFile` uses. Absent keys are omitted, so an off capability adds no bytes to
+ *  the committed file and no churn to anyone's git diff. */
+export function projectCapabilityFields(
+  p: Partial<Record<ProjectCapability, unknown>> | undefined | null
+): Partial<Record<ProjectCapability, true>> {
+  return readProjectCapabilities(p ?? {})
+}

--- a/src/shared/project-capability-consent.ts
+++ b/src/shared/project-capability-consent.ts
@@ -1,0 +1,59 @@
+/**
+ * The one-time clone notice, decided ONCE for every capability — pure, shared, and the only
+ * decider either feature may use (browser control here in PR 3; agent messaging adopts it in its
+ * PR 6 without reimplementing anything).
+ *
+ * A switch that arrives from a clone is not the same thing as a switch the user set:
+ * `.nodeterm/project.json` is git-shared and hand-editable, so `agentBrowserControl: true` in a
+ * freshly cloned repo is a stranger's decision until this machine's user has seen it. The
+ * acknowledgment is therefore recorded MACHINE-LOCALLY (`IndexEntryV3.capabilityAck` — the index
+ * entry is the only authority for project identity), never in the shared file; a second worktree
+ * of the same repo is a second entry, hence a second notice, on purpose.
+ *
+ * Lives in `src/shared` for the same reason as `safe-id.ts`: the renderer raises the dialog and may
+ * not import `src/core`; `core/project-capability-consent.ts` re-exports these for main/core
+ * callers, and its test pins that the two paths are the same function objects.
+ */
+import type { ProjectCapability } from './project-capabilities'
+
+/** The machine-local ack record, keyed like the capability fields but never written to the shared
+ *  project file (`projectToFile` does not know this shape exists — pinned by the consent test). */
+export type CapabilityAckMap = Partial<Record<ProjectCapability, true>>
+
+export interface CapabilityConsentState {
+  capability: ProjectCapability
+  /** The strict read of the shared file's switch (`projectCapabilityEnabled` — literal true only). */
+  enabledInFile: boolean
+  /** Has THIS MACHINE's user answered the notice for this project entry (or personally set the
+   *  switch, which is its own acknowledgment)? */
+  acknowledged: boolean
+}
+
+/** On in the file + never acknowledged on this machine ⇒ notice. Everything else is silence:
+ *  off needs no warning, and an answered notice is answered forever (per index entry). */
+export function needsCapabilityNotice(s: CapabilityConsentState): boolean {
+  return s.enabledInFile === true && s.acknowledged !== true
+}
+
+/**
+ * May the capability act RIGHT NOW? A pending notice is a refusal, not a grant: the window between
+ * a hostile clone's `agentBrowserControl: true` arriving and the user answering the notice must
+ * refuse (`project-capability-consent.test.ts` — "a switch that is on but unanswered grants
+ * nothing"). This is the predicate the browser ledger's admission check (PR 4) and messaging's
+ * `messagingEnabled` wiring (PR 6) consult per call — never cached at lease start.
+ */
+export function projectCapabilityGranted(s: CapabilityConsentState): boolean {
+  return s.enabledInFile === true && !needsCapabilityNotice(s)
+}
+
+/**
+ * Returns `entry` with the capability acknowledged — a new object, input untouched. Works on any
+ * entry-shaped record (`IndexEntryV3` in main, the renderer's `Project` mirror of the same
+ * machine-local field) so both sides record the ack through the one function.
+ */
+export function recordCapabilityAck<E extends { capabilityAck?: CapabilityAckMap }>(
+  entry: E,
+  cap: ProjectCapability
+): E {
+  return { ...entry, capabilityAck: { ...entry.capabilityAck, [cap]: true } }
+}

--- a/src/shared/project-capability-consent.ts
+++ b/src/shared/project-capability-consent.ts
@@ -10,50 +10,105 @@
  * entry is the only authority for project identity), never in the shared file; a second worktree
  * of the same repo is a second entry, hence a second notice, on purpose.
  *
+ * THE ACK CARRIES THE ANSWER, not just the fact of one (PR #213 review, C1). "Turn it off" can
+ * only delete the field from THIS working copy — the hostile `true` survives in git and a routine
+ * `git checkout`/pull restores it. If the ack were a bare bit, that restored `true` would meet a
+ * standing acknowledgment and grant silently to a user who explicitly said no. So:
+ *   - `'kept'`     — explicit consent; enabled+kept is the ONE granting combination.
+ *   - `'declined'` — explicit refusal; if the file's `true` ever re-arrives it is refused AND a
+ *                    NEW notice is raised (never silence, never a grant without a fresh "keep").
+ *   - absent       — never answered (or dismissed without answering — dismissal is not an answer);
+ *                    enabled+absent is a pending notice and a refusal.
+ * Each rule is pinned by `project-capability-consent.test.ts`.
+ *
  * Lives in `src/shared` for the same reason as `safe-id.ts`: the renderer raises the dialog and may
  * not import `src/core`; `core/project-capability-consent.ts` re-exports these for main/core
  * callers, and its test pins that the two paths are the same function objects.
  */
-import type { ProjectCapability } from './project-capabilities'
+import {
+  projectCapabilityFlagInFile,
+  type ProjectCapability
+} from './project-capabilities'
 
-/** The machine-local ack record, keyed like the capability fields but never written to the shared
- *  project file (`projectToFile` does not know this shape exists — pinned by the consent test). */
-export type CapabilityAckMap = Partial<Record<ProjectCapability, true>>
+/** What this machine's user answered when told about a capability switch. */
+export type CapabilityAnswer = 'kept' | 'declined'
+
+/** The machine-local answer record, keyed like the capability fields but never written to the
+ *  shared project file (`projectToFile` does not know this shape exists — pinned by the consent
+ *  test with an ack-carrying project as input). */
+export type CapabilityAckMap = Partial<Record<ProjectCapability, CapabilityAnswer>>
 
 export interface CapabilityConsentState {
   capability: ProjectCapability
-  /** The strict read of the shared file's switch (`projectCapabilityEnabled` — literal true only). */
+  /** The strict read of the shared file's switch (`projectCapabilityFlagInFile` — literal true
+   *  only). NEVER a grant by itself. */
   enabledInFile: boolean
-  /** Has THIS MACHINE's user answered the notice for this project entry (or personally set the
-   *  switch, which is its own acknowledgment)? */
-  acknowledged: boolean
+  /** This machine's recorded answer for this project entry, if any. */
+  answer: CapabilityAnswer | undefined
 }
 
-/** On in the file + never acknowledged on this machine ⇒ notice. Everything else is silence:
- *  off needs no warning, and an answered notice is answered forever (per index entry). */
+/** On in the file + not explicitly KEPT on this machine ⇒ notice. That covers both the
+ *  never-answered clone window and the re-arrival of a `true` the user declined (C1): a recorded
+ *  "no" makes a re-appearing switch a NEW event to be told about, not a settled one. Off needs no
+ *  warning, whatever was answered. */
 export function needsCapabilityNotice(s: CapabilityConsentState): boolean {
-  return s.enabledInFile === true && s.acknowledged !== true
+  return s.enabledInFile === true && s.answer !== 'kept'
 }
 
 /**
- * May the capability act RIGHT NOW? A pending notice is a refusal, not a grant: the window between
- * a hostile clone's `agentBrowserControl: true` arriving and the user answering the notice must
- * refuse (`project-capability-consent.test.ts` — "a switch that is on but unanswered grants
- * nothing"). This is the predicate the browser ledger's admission check (PR 4) and messaging's
- * `messagingEnabled` wiring (PR 6) consult per call — never cached at lease start.
+ * May the capability act RIGHT NOW? Only `enabledInFile && answer === 'kept'`: a pending notice is
+ * a refusal, and a recorded DECLINE is a refusal even when the hostile `true` re-arrives via git
+ * (`project-capability-consent.test.ts` — "a switch that is on but unanswered grants nothing",
+ * "a DECLINED switch grants nothing even when the file says true again"). This is the predicate
+ * the browser ledger's admission check (PR 4) and messaging's `messagingEnabled` wiring (PR 6)
+ * consult per call — never cached at lease start.
  */
 export function projectCapabilityGranted(s: CapabilityConsentState): boolean {
-  return s.enabledInFile === true && !needsCapabilityNotice(s)
+  return s.enabledInFile === true && s.answer === 'kept'
 }
 
 /**
- * Returns `entry` with the capability acknowledged — a new object, input untouched. Works on any
+ * THE consumer-facing grant check: derives both halves (strict file flag, own-property answer)
+ * from a Project-shaped object, so a consumer cannot pick the raw file flag by mistake (PR #213
+ * review, I2). PR 6 wires `messagingEnabled(projectId)` as
+ * `projectCapabilityGrantedFor(getProject(projectId), 'agentMessaging')` — one call, nothing else.
+ */
+export function projectCapabilityGrantedFor(
+  p:
+    | (Partial<Record<ProjectCapability, unknown>> & { capabilityAck?: CapabilityAckMap })
+    | undefined
+    | null,
+  cap: ProjectCapability
+): boolean {
+  return projectCapabilityGranted({
+    capability: cap,
+    enabledInFile: projectCapabilityFlagInFile(p, cap),
+    answer: capabilityAnswerOf(p, cap)
+  })
+}
+
+/** This machine's recorded answer, own properties only (M-1: an in-process object must not inherit
+ *  consent through its prototype; JSON never produces one, but callers are not only JSON). */
+export function capabilityAnswerOf(
+  p: { capabilityAck?: CapabilityAckMap } | undefined | null,
+  cap: ProjectCapability
+): CapabilityAnswer | undefined {
+  const ack = p?.capabilityAck
+  if (!ack || !Object.prototype.hasOwnProperty.call(ack, cap)) return undefined
+  const v = ack[cap]
+  return v === 'kept' || v === 'declined' ? v : undefined
+}
+
+/**
+ * Returns `entry` with the capability answered — a new object, input untouched; a later answer
+ * overwrites an earlier one (decline → later explicit keep must win, and vice versa). Works on any
  * entry-shaped record (`IndexEntryV3` in main, the renderer's `Project` mirror of the same
- * machine-local field) so both sides record the ack through the one function.
+ * machine-local field) so both sides record the answer through the one function.
  */
 export function recordCapabilityAck<E extends { capabilityAck?: CapabilityAckMap }>(
   entry: E,
-  cap: ProjectCapability
+  cap: ProjectCapability,
+  answer: CapabilityAnswer
 ): E {
-  return { ...entry, capabilityAck: { ...entry.capabilityAck, [cap]: true } }
+  return { ...entry, capabilityAck: { ...entry.capabilityAck, [cap]: answer } }
 }

--- a/src/shared/safe-id.test.ts
+++ b/src/shared/safe-id.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { NODE_ID_MAX, isSafeNodeId } from './safe-id'
+
+describe('isSafeNodeId (shared home)', () => {
+  it('refuses dot segments, separators, spaces, empties and over-length ids', () => {
+    // The exact corpus node-auth-token.test.ts pins through the re-export, kept here at the
+    // definition site so the predicate cannot be weakened without a red test in BOTH places.
+    for (const bad of ['..', '.', '../x', 'a b', 'a/b', '', 'x'.repeat(300)]) {
+      expect(isSafeNodeId(bad), bad).toBe(false)
+    }
+  })
+
+  it('accepts every shape the app actually mints', () => {
+    for (const good of ['a', 'browser-3', 'p_1.2', 'node-1', 'term_abc.9', 'A.B-C_d']) {
+      expect(isSafeNodeId(good), good).toBe(true)
+    }
+  })
+
+  it('refuses undefined/null and enforces the exact NODE_ID_MAX boundary', () => {
+    expect(isSafeNodeId(undefined)).toBe(false)
+    expect(isSafeNodeId(null)).toBe(false)
+    expect(isSafeNodeId('x'.repeat(NODE_ID_MAX))).toBe(true)
+    expect(isSafeNodeId('x'.repeat(NODE_ID_MAX + 1))).toBe(false)
+  })
+
+  // The "core re-exports the SAME function object" identity assertion lives in
+  // core/remote-safety.test.ts: this file is part of the WEB typecheck program
+  // (tsconfig.web.json), which deliberately cannot see src/core — the very layering rule that
+  // forced the move. The pin exists; it just sits on the side of the boundary that may import both.
+})

--- a/src/shared/safe-id.ts
+++ b/src/shared/safe-id.ts
@@ -1,0 +1,35 @@
+/**
+ * THE node-id predicate, in `src/shared` because both sides of the process boundary need the SAME
+ * one: core/main validate an id before it crosses into a remote shell or a filesystem path, and the
+ * renderer must validate a project id before it becomes a session-partition storage key
+ * (`persist:nt-agent-browser-<projectId>`) — and the renderer may not import `src/core`.
+ *
+ * Moved here from `core/remote-safety.ts`, which re-exports it so every existing import path is
+ * untouched; `safe-id.test.ts` pins that the two names are one function object. No imports at all:
+ * usable from core, main, renderer and the server shell alike.
+ */
+
+/** Generous cap on a node id — longer than anything the app mints, short enough to bound. */
+export const NODE_ID_MAX = 128
+
+/**
+ * Is this a node id (a `persistKey`) safe to carry into a remote command line and a filesystem
+ * path?
+ *
+ * Charset is deliberately narrower than "no metacharacters": `[A-Za-z0-9._-]` covers every id the
+ * app actually produces — `nextId()` emits `<prefix>-<base36 time>-<counter>` and `uuid()` emits
+ * hex-with-dashes — so the answer to "could this refuse something legitimate?" is a list, not a
+ * guess. `.` and `..` are refused on top of the charset: they pass it but name a directory, and
+ * these ids are also used as path components (session files, per-node remote state). It is also
+ * the charset the codex identity shim ALREADY enforces on `$NODETERM_NODE_ID` before it will use
+ * it (`codex-identity-proxy.ts`: `*[!A-Za-z0-9._-]*) nt_fail node-id-unavailable`), so this is the
+ * existing rule moved to the boundary rather than a new one invented here.
+ *
+ * An EMPTY id is refused here and must be handled by the caller as "not persistent" rather than as
+ * a violation — `PtyManager.create` already branches on a falsy `persistKey` before it asks.
+ */
+export function isSafeNodeId(id: string | undefined | null): boolean {
+  if (!id || id.length > NODE_ID_MAX) return false
+  if (id === '.' || id === '..') return false
+  return /^[A-Za-z0-9._-]+$/.test(id)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -468,6 +468,20 @@ export interface Project {
   /** Permission mode for new Claude TERMINAL (CLI) sessions in this project. SDK chat nodes are
    *  not covered — the chat driver still runs in `default`. Unset = use the global setting. */
   defaultPermissionMode?: AgentPermissionMode
+  /**
+   * Per-project capability switch: agents may drive browser nodes THEY opened in this project.
+   * GIT-SHARED (rides .nodeterm/project.json) and therefore hostile input — read it ONLY through
+   * `projectCapabilityEnabled` (@shared/project-capabilities, strict `=== true`); the switch alone
+   * grants nothing (see that module's header for the two required halves).
+   */
+  agentBrowserControl?: boolean
+  /**
+   * MACHINE-LOCAL record that this machine's user has seen (or personally set) each capability
+   * switch — the "once per project ever" half of the clone notice. Persisted on
+   * `IndexEntryV3.capabilityAck`, NEVER written into the shared project file
+   * (workspace-files.test.ts / capability-notice tests pin that the file bytes are unchanged).
+   */
+  capabilityAck?: Partial<Record<import('./project-capabilities').ProjectCapability, true>>
   /** Best dino-game score in this project — new dino nodes seed from it, so the record survives closing the node. */
   dinoHighScore?: number
   /** Kanban task board — shared via .nodeterm/project.json like nodes. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -471,18 +471,21 @@ export interface Project {
   defaultPermissionMode?: AgentPermissionMode
   /**
    * Per-project capability switch: agents may drive browser nodes THEY opened in this project.
-   * GIT-SHARED (rides .nodeterm/project.json) and therefore hostile input — read it ONLY through
-   * `projectCapabilityEnabled` (@shared/project-capabilities, strict `=== true`); the switch alone
-   * grants nothing (see that module's header for the two required halves).
+   * GIT-SHARED (rides .nodeterm/project.json) and therefore hostile input — the raw bit is read
+   * ONLY through `projectCapabilityFlagInFile` (@shared/project-capabilities, strict `=== true`,
+   * own-property), and it is NEVER a grant by itself: grants go through
+   * `projectCapabilityGrantedFor` (@shared/project-capability-consent), which also requires this
+   * machine's recorded 'kept' answer below.
    */
   agentBrowserControl?: boolean
   /**
-   * MACHINE-LOCAL record that this machine's user has seen (or personally set) each capability
-   * switch — the "once per project ever" half of the clone notice. Persisted on
-   * `IndexEntryV3.capabilityAck`, NEVER written into the shared project file
+   * MACHINE-LOCAL record of what this machine's user ANSWERED for each capability switch —
+   * 'kept' or 'declined', not a bare bit, because a declined switch whose hostile `true`
+   * re-arrives via git must be refused and re-noticed, never silently granted (PR #213 C1).
+   * Persisted on `IndexEntryV3.capabilityAck`, NEVER written into the shared project file
    * (workspace-files.test.ts / capability-notice tests pin that the file bytes are unchanged).
    */
-  capabilityAck?: Partial<Record<import('./project-capabilities').ProjectCapability, true>>
+  capabilityAck?: import('./project-capability-consent').CapabilityAckMap
   /** Best dino-game score in this project — new dino nodes seed from it, so the record survives closing the node. */
   dinoHighScore?: number
   /** Kanban task board — shared via .nodeterm/project.json like nodes. */


### PR DESCRIPTION
PR 3 of the browser-control (S8) plan — the coordination point both browser control (PR 4) and agent-to-agent messaging (its PR 6) adopt. It introduces nodeterm's first per-project capability switch as a **shared mechanism**: the key set, the copy, the strict read, the file round-trip, the machine-local clone-notice ack, and the generated Settings rows all live once.

**Messaging stays OFF in this PR.** PR #212's verbs ship fail-closed (`messagingEnabled: () => false`); wiring them to `projectCapabilityEnabled(project, 'agentMessaging')` — and adding `'agentMessaging'` to the union/array/copy record — is messaging PR 6's job, and after this PR that is an array entry plus a copy entry, with no new persistence, consent or settings code.

## Tasks → commits

| Task | Commit | What landed |
|---|---|---|
| 3.1 `isSafeNodeId` → `src/shared/safe-id.ts` | 53f9a76f | Moved, not copied: `core/remote-safety.ts` re-exports, every existing import path untouched; a test pins the two names are ONE function object. (The identity pin sits in `core/remote-safety.test.ts` because the web typecheck program deliberately cannot see `src/core` — the very layering rule behind the move.) |
| 3.2 `@shared/project-capabilities` | 2ec2d3fe | `ProjectCapability`, `PROJECT_CAPABILITIES`, `PROJECT_CAPABILITY_COPY`, `projectCapabilityEnabled` (strict `=== true`), `readProjectCapabilities`, `projectCapabilityFields`; `Project`/`ProjectFileV1` gain `agentBrowserControl?`; `projectToFile`/`fileToProject` round-trip it, off = zero bytes in the file. |
| 3.3 `IndexEntryV3.capabilityAck` + pure decider | 6c748abe | `needsCapabilityNotice`, `recordCapabilityAck`, and `projectCapabilityGranted` (a pending notice is a refusal). Implementation in `@shared/project-capability-consent` (the renderer raises the dialog and may not import core); `core/project-capability-consent.ts` re-exports, identity-pinned. Ack persists entry-ward through `splitWorkspace`, restores from the entry only — a file-borne `capabilityAck` is never read. |
| 3.4 The clone notice | e59c8c18 | `CapabilityNotice.tsx`, raised from Canvas beside the confirm machinery. Click-only (`enterConfirms={false}` — raised by a file, not the user), once per project per machine (proved by the ack persistence, incl. across an unavailable window), and the capability grants nothing until answered. A second worktree notifies again, on purpose. Setting a switch yourself is its own acknowledgment. |
| 3.5 Settings → Agents rows | 665f2f91 | Rows GENERATED from `PROJECT_CAPABILITIES` (search registry included); each carries the capability's description + the same `.nodeterm/project.json` cloneWarning the notice shows. Writes through the one strict setter (literal `true` on; field deleted on off); an off-toggle takes effect live — grantedness is read from the store per call, never cached at lease start. |

## Security shape

- **Strict `=== true` everywhere.** `"true"`, `1`, `{}`, `[]`, `"yes"` are OFF — pinned per value; the sanitisation also happens at the file boundary (`fileToProject` drops a non-literal-true field).
- **The switch alone grants nothing.** `projectCapabilityGranted` refuses while a clone notice is pending; the ack is machine-local (`IndexEntryV3.capabilityAck`), never in the git-shared file — `projectToFile`'s key set and the serialized bytes are both test-pinned.
- **Content vs. machine identity split kept (#196):** the capability *field* rides the git-shared `project.json` (team policy); the *ack* rides the machine-local index entry (this machine's consent). A repo cannot carry its own consent.
- `src/core` still imports no electron/main (no-electron test), and the renderer still imports no `src/core` — enforced structurally by `tsconfig.web.json`.

## Mutation checks (introduced/caught)

- 3.1: 2/2 (copy-instead-of-re-export; dot-segment refusal dropped)
- 3.2: 3/3 (`=== true` → truthiness; reader keeps non-literal-true; `projectToFile` spread dropped)
- 3.3: 4/4 (ack-blind notice; granted-ignores-notice; ack write dropped; file-borne ack adopted)
- 3.4: 3/3 (confirm ack dropped; `enterConfirms` flipped — asserted past the `CONFIRM_ARM_MS` window so the arm timer could not mask it; notice suppressed)
- 3.5: 4/4 (setter writes `'true'` string; off stores `false`; rows truncated; cloneWarning dropped)

## Verification

`npm run typecheck` clean after every task; full `npx vitest run`: **462 files passed, 6405 tests passed, 0 failed** (1 file / 12 tests skipped, pre-existing opt-in Docker suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Fix round 1 (review findings, commit 64b2e63d)

- **C1 (Critical): the ack now carries the ANSWER** — `CapabilityAckMap` values are `'kept' | 'declined'`, never a bare bit. Granting requires `enabledInFile && answer === 'kept'`; a recorded decline whose hostile `true` re-arrives via `git checkout`/pull is **refused AND re-noticed** (test drives the exact scenario: decline → file restores `true` → watcher-shaped `replaceProject` → refused, dialog back).
- **I1 (Important): only the two buttons are answers** — `ConfirmDialog` gains `onDismiss` (Escape/overlay channel; default keeps historical behavior) and `autoFocusButtons` (false = no button holds focus, so a native Enter/Space mid-typing has nothing to activate — the path `enterConfirms` never sees). The notice dismisses without recording anything and re-shows next launch; focus is asserted with a real focused input across mount.
- **I2 (Important): the predicate trap is closed** — `projectCapabilityEnabled` → `projectCapabilityFlagInFile` (doc: NEVER a grant check; display/notice input only). The one consumer-facing grant predicate is **`projectCapabilityGrantedFor(project, cap)`** — PR 6 wires `messagingEnabled(projectId)` as `projectCapabilityGrantedFor(getProject(projectId), 'agentMessaging')`, one call, nothing else.
- **M-1** own-property-only reads (no prototype-inherited consent); **M-2** the settings off-toggle records `'declined'` (a teammate re-committing `true` re-notices); **M-3** the consent test's `projectToFile` assertion now feeds an ack-carrying project so it can catch a leak.
- Merged origin/main (PR #212) — no overlapping files.
- Fix-round mutations: any-answer-grants (3 red), declined-stays-silent (2 red), dismiss-records-ack (2 red), autofocus restored (1 red), prototype flag accepted (2 red), setter forgets declined (2 red) — **6/6 caught**.
- Gates after fixes: typecheck clean; full `npx vitest run` **464 files / 6457 tests passed, 0 failed** (1 file / 12 tests skipped, opt-in Docker suite).
