### PR TITLE
feat(agents): messaging rides the per-project capability switch

### DIFF
--- a/src/core/agents/agent-message-decide.ts
+++ b/src/core/agents/agent-message-decide.ts
@@ -30,6 +30,11 @@ export type NotPermittedReason =
   | 'self-send'
   | 'unsupported-edition'
   | 'unaddressable-node-id'
+  /** The target id names nodes in MORE THAN ONE project while panes are keyed by the bare id —
+   *  one global pane, several possible owners, and one of them may be ungranted. Refused because
+   *  the per-project grant cannot be attributed (PR #237 review I-1); its own word because the
+   *  human's fix is de-duplicating ids, not moving nodes. See `agent-message-scope.ts`. */
+  | 'ambiguous-target-node-id'
 
 /** Which signal satisfied the delivery receipt (Task 3.4). */
 export type ReceiptSignal = 'newTurn' | 'working'

--- a/src/core/agents/agent-message-decide.ts
+++ b/src/core/agents/agent-message-decide.ts
@@ -35,6 +35,13 @@ export type NotPermittedReason =
    *  the per-project grant cannot be attributed (PR #237 review I-1); its own word because the
    *  human's fix is de-duplicating ids, not moving nodes. See `agent-message-scope.ts`. */
   | 'ambiguous-target-node-id'
+  /** No RUNTIME proof of which project spawned the target pane: the ledger has no entry (never
+   *  spawned this run, or only re-attached after a restart), or its owner disagrees with the sole
+   *  store claimant (a project.json listing a pane it did not spawn). The store's node-set is
+   *  attacker-writable, so ownership is proven at spawn, not read from the file (PR #237 fix
+   *  round 2 — the confused deputy driven end-to-end); unprovable ⇒ refuse. Not retryable: the
+   *  pane must be freshly (re)spawned by its real owner before it can be messaged. */
+  | 'unproven-target-owner'
 
 /** Which signal satisfied the delivery receipt (Task 3.4). */
 export type ReceiptSignal = 'newTurn' | 'working'

--- a/src/core/agents/agent-message-scope.test.ts
+++ b/src/core/agents/agent-message-scope.test.ts
@@ -91,22 +91,52 @@ describe('resolveDeliveryScope', () => {
     })
   })
 
-  it('resolves a DUPLICATE node id to the sender’s own project', () => {
-    // A cloned `project.json` gives two projects the same node id — this repo has shipped that bug
-    // once. The sender addresses the node it can see. This is a ROUTING answer only: sessions are
-    // keyed by the bare node id, so the two ids still name one pane, and no resolver can change
-    // that from here.
+  it('REFUSES a DUPLICATE target id — the one global pane cannot be attributed to one project’s grant', () => {
+    // A `project.json` that merely LISTS another project's node id (a clone, or a hostile file)
+    // resolves "same-project" by node-set membership, but the session namespace is the BARE id:
+    // both listings name ONE tmux pane, and only one of the projects may hold the messaging grant.
+    // PR #237 review I-1 proved the escalation by execution (granted A delivered into ungranted
+    // B's pane), so ambiguity is now a refusal in BOTH directions — the resolver cannot prove
+    // which project's pane the caller means, and "pick the sender's" was exactly the hole.
     const cloned: ScopeProject[] = [
       { id: 'p-alpha', nodes: [{ id: 'a-1' }, { id: 'dup' }] },
       { id: 'p-clone', nodes: [{ id: 'c-1' }, { id: 'dup' }] }
     ]
     expect(resolveDeliveryScope(cloned, 'a-1', 'dup')).toEqual({
-      kind: 'same-project',
-      projectId: 'p-alpha'
+      kind: 'refused',
+      reason: 'ambiguous-target-node-id',
+      targetFound: true
     })
     expect(resolveDeliveryScope(cloned, 'c-1', 'dup')).toEqual({
+      kind: 'refused',
+      reason: 'ambiguous-target-node-id',
+      targetFound: true
+    })
+  })
+
+  it('the ambiguity refusal names its own reason, not cross-project — different fact, different action', () => {
+    // cross-project = "you two do not share a project"; ambiguous = "the id names panes in more
+    // than one, and one of them may be ungranted". The human fixes the second by de-duplicating
+    // ids (re-adding the cloned folder mints fresh ones), not by moving nodes between projects.
+    const cloned: ScopeProject[] = [
+      { id: 'p-alpha', nodes: [{ id: 'a-1' }, { id: 'dup' }] },
+      { id: 'p-clone', nodes: [{ id: 'dup' }] }
+    ]
+    const scope = resolveDeliveryScope(cloned, 'a-1', 'dup')
+    const outcome = decideDelivery(facts({ notPermitted: scopeRefusal(scope) }))
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'ambiguous-target-node-id' })
+    expect(RETRYABLE.notPermitted).toBe(false)
+  })
+
+  it('a UNIQUE target still resolves, whatever else the projects carry', () => {
+    // The refusal must not cost the legitimate population: same store shape, no duplicate.
+    const cloned: ScopeProject[] = [
+      { id: 'p-alpha', nodes: [{ id: 'a-1' }, { id: 'mine' }] },
+      { id: 'p-clone', nodes: [{ id: 'c-1' }] }
+    ]
+    expect(resolveDeliveryScope(cloned, 'a-1', 'mine')).toEqual({
       kind: 'same-project',
-      projectId: 'p-clone'
+      projectId: 'p-alpha'
     })
   })
 

--- a/src/core/agents/agent-message-scope.ts
+++ b/src/core/agents/agent-message-scope.ts
@@ -59,10 +59,13 @@ export interface ScopeProject {
 
 export type ScopeRefusal = Extract<
   NotPermittedReason,
-  'self-send' | 'cross-project' | 'unaddressable-node-id'
+  'self-send' | 'cross-project' | 'unaddressable-node-id' | 'ambiguous-target-node-id'
 >
 
 export type DeliveryScope =
+  /** `projectId` is the target pane's UNIQUE owning project (which the sender provably shares) —
+   *  the project whose `agentMessaging` grant authorizes the delivery. Uniqueness is part of the
+   *  contract: a target id claimed by two projects never produces this arm. */
   | { kind: 'same-project'; projectId: string }
   | {
       kind: 'refused'
@@ -102,23 +105,26 @@ export type DeliveryScope =
  * backstop so that no future caller can forget this one. Both produce the identical
  * `notPermitted{reason:'self-send'}`, which the test asserts by running them.
  *
- * ── A DUPLICATE NODE ID IS RESOLVED, NOT DISAMBIGUATED ──────────────────────────────────────────
+ * ── A DUPLICATE TARGET ID IS REFUSED, NOT DISAMBIGUATED ─────────────────────────────────────────
  *
- * A duplicate id across two projects (a cloned `project.json` — this repo has shipped that bug
- * once) resolves to the SOURCE's project when the source's project is one of them: the sender
- * addresses the node it can see.
+ * A session's only key is the bare node id (`PtyManager.byPersistKey`, `paneOwner(persistKey)`,
+ * tmux `nt-<nodeId>`); no project id appears anywhere in that namespace and nothing de-duplicates
+ * ids when a second project carrying them is opened (a cloned `project.json` — this repo has
+ * shipped that bug once). So a duplicate id across projects is ONE global pane with several
+ * claimed owners, and the messaging grant is PER PROJECT: a hostile file for granted project A
+ * that merely LISTS ungranted project B's node id would resolve "same-project" to A by node-set
+ * membership, pass A's switch, and land in B's running pane — the confused deputy PR #237's
+ * review proved by execution (I-1), live from the moment the user keeps A's clone notice.
  *
- * That is a routing answer, NOT an isolation guarantee, and the earlier claim here that "the
- * ambiguity never reaches the pane" was false. A session's only key is the bare node id
- * (`PtyManager.byPersistKey`, `paneOwner(persistKey)`, tmux `nt-<nodeId>`); no project id appears
- * anywhere in that namespace and nothing de-duplicates ids when a second project carrying them is
- * opened. So a `project.json` that merely LISTS another project's node id resolves `same-project`
- * here and lands in that node's one global pane — verified by execution, not reasoned about.
+ * Therefore: the grant must gate the project that OWNS the target pane, and when the target id
+ * appears in more than one persisted project no single owner can be proved, so the pair is
+ * refused as `ambiguous-target-node-id` — never "pick the sender's". A unique target's owning
+ * project is by construction the same project the sender shares, which is what `projectId` names.
+ * The cost falls only on stores that already carry duplicate ids, which the id-repair path
+ * (re-adding a folder mints fresh ids) exists to fix.
  *
- * This resolver cannot close that: the ambiguity is in the session namespace, not in the scope
- * question. What it can do is refuse the ids that make it worse, which is the check above.
  * **PR 5's delivery call must run `isSafeNodeId(targetNodeId)` before `paneOwner`** — a direct
- * caller that skips this resolver gets neither guard.
+ * caller that skips this resolver gets neither that guard nor this one.
  *
  * `closed` and `unavailable` projects are deliberately NOT filtered out. A closed project's tmux
  * sessions keep running and are re-adopted on the next start — that is the whole premise of
@@ -131,12 +137,23 @@ export function resolveDeliveryScope(
   targetNodeId: string
 ): DeliveryScope {
   const has = (p: ScopeProject, id: string): boolean => p.nodes.some((n) => n.id === id)
-  const targetFound = projects.some((p) => has(p, targetNodeId))
+  // Every project claiming the target id — the pane's POSSIBLE owners. The grant is evaluated
+  // against the pane's owning project, so this set deciding the answer is the point, not a detail.
+  const targetOwners = projects.filter((p) => has(p, targetNodeId))
+  const targetFound = targetOwners.length > 0
   if (!isSafeNodeId(sourceNodeId) || !isSafeNodeId(targetNodeId))
     return { kind: 'refused', reason: 'unaddressable-node-id', targetFound }
   if (sourceNodeId === targetNodeId) return { kind: 'refused', reason: 'self-send', targetFound }
   const owner = projects.find((p) => has(p, sourceNodeId))
-  if (owner && has(owner, targetNodeId)) return { kind: 'same-project', projectId: owner.id }
+  if (owner && has(owner, targetNodeId)) {
+    // The id names panes in more than one project: ONE global tmux pane, several claimed owners,
+    // and the sender's grant must not speak for the others (PR #237 review I-1). Refused with its
+    // own word — "pick the sender's project" was exactly the confused-deputy hole.
+    if (targetOwners.length > 1)
+      return { kind: 'refused', reason: 'ambiguous-target-node-id', targetFound: true }
+    // Unique: the target's owning project, which the sender provably shares.
+    return { kind: 'same-project', projectId: targetOwners[0].id }
+  }
   return { kind: 'refused', reason: 'cross-project', targetFound }
 }
 

--- a/src/core/agents/pane-ownership.test.ts
+++ b/src/core/agents/pane-ownership.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  recordFreshSpawnOwner,
+  paneOwnerProject,
+  forgetPaneOwner,
+  resetPaneOwnershipForTests
+} from './pane-ownership'
+
+beforeEach(() => resetPaneOwnershipForTests())
+
+describe('pane-ownership ledger', () => {
+  it('records and returns the project that freshly spawned a node', () => {
+    recordFreshSpawnOwner('n1', 'proj-a')
+    expect(paneOwnerProject('n1')).toBe('proj-a')
+  })
+
+  it('an unrecorded node is UNPROVEN (undefined) — the fail-closed default after a restart', () => {
+    // The whole cold-state contract: nothing recorded ⇒ the delivery gate must refuse. This is the
+    // state every node is in immediately after an app restart (re-attach records nothing).
+    expect(paneOwnerProject('never-spawned')).toBeUndefined()
+  })
+
+  it('a genuine respawn OVERWRITES — the live pane is the one that just came into being', () => {
+    recordFreshSpawnOwner('n1', 'proj-a')
+    recordFreshSpawnOwner('n1', 'proj-b')
+    expect(paneOwnerProject('n1')).toBe('proj-b')
+  })
+
+  it('a missing owner is a no-op — an old caller passing none leaves the pane unproven, not owned', () => {
+    recordFreshSpawnOwner('n1', undefined)
+    expect(paneOwnerProject('n1')).toBeUndefined()
+    recordFreshSpawnOwner('', 'proj-a')
+    expect(paneOwnerProject('')).toBeUndefined()
+  })
+
+  it('forget drops ownership back to unproven — a deleted/recycled session is no longer owned', () => {
+    recordFreshSpawnOwner('n1', 'proj-a')
+    forgetPaneOwner('n1')
+    expect(paneOwnerProject('n1')).toBeUndefined()
+  })
+
+  it('nodes are independent — forgetting one leaves the others', () => {
+    recordFreshSpawnOwner('n1', 'proj-a')
+    recordFreshSpawnOwner('n2', 'proj-a')
+    forgetPaneOwner('n1')
+    expect(paneOwnerProject('n1')).toBeUndefined()
+    expect(paneOwnerProject('n2')).toBe('proj-a')
+  })
+})

--- a/src/core/agents/pane-ownership.test.ts
+++ b/src/core/agents/pane-ownership.test.ts
@@ -3,7 +3,8 @@ import {
   recordFreshSpawnOwner,
   paneOwnerProject,
   forgetPaneOwner,
-  resetPaneOwnershipForTests
+  resetPaneOwnershipForTests,
+  shouldRecordOwnership
 } from './pane-ownership'
 
 beforeEach(() => resetPaneOwnershipForTests())
@@ -45,5 +46,23 @@ describe('pane-ownership ledger', () => {
     forgetPaneOwner('n1')
     expect(paneOwnerProject('n1')).toBeUndefined()
     expect(paneOwnerProject('n2')).toBe('proj-a')
+  })
+})
+
+describe('shouldRecordOwnership — the load-bearing fresh-gate, pure', () => {
+  it('records ONLY a genuine fresh spawn with a persistKey and a known owner', () => {
+    expect(shouldRecordOwnership(true, 'n1', 'proj-a')).toBe(true)
+  })
+  it('an ATTACH (fresh=false) never records — the confused-deputy hole this gate closes', () => {
+    // Recording on attach would let a project claim a pane it merely re-opened after a restart.
+    expect(shouldRecordOwnership(false, 'n1', 'proj-a')).toBe(false)
+  })
+  it('a spawn with no persistKey (a plain, non-persistent pty) does not record', () => {
+    expect(shouldRecordOwnership(true, undefined, 'proj-a')).toBe(false)
+    expect(shouldRecordOwnership(true, '', 'proj-a')).toBe(false)
+  })
+  it('a spawn with no known owner (old caller / relay) does not record — stays unproven, fails closed', () => {
+    expect(shouldRecordOwnership(true, 'n1', undefined)).toBe(false)
+    expect(shouldRecordOwnership(true, 'n1', '')).toBe(false)
   })
 })

--- a/src/core/agents/pane-ownership.ts
+++ b/src/core/agents/pane-ownership.ts
@@ -1,0 +1,72 @@
+/**
+ * The runtime pane-ownership ledger: nodeId → the project that actually SPAWNED that node's pane,
+ * this process run. It exists because the persisted store cannot be trusted to answer "who owns
+ * this pane?" — `.nodeterm/project.json` is git-shared and hand-editable, so a hostile/cloned
+ * project can LIST any node id, including one a different project is really running. A messaging
+ * grant is per project, and panes are keyed by the BARE node id globally (tmux `nt-<nodeId>`), so
+ * ownership derived from the file is a confused-deputy hole: PR #237's re-review drove it end to
+ * end (a granted project A delivered into ungranted project B's live pane just by listing B's id).
+ *
+ * THE ONE FACT THAT IS NOT FORGEABLE BY A CLONED FILE is which project's `create()` actually
+ * brought the tmux session into being. That is what this records, and only that:
+ *
+ *  - Recorded ONLY on a GENUINE FRESH SPAWN (`PtyManager.spawnNew` with `fresh === true` — no live
+ *    session existed to reattach to). An attach/co-attach to a session someone else spawned never
+ *    records, so a second project that merely OPENS a node id another project is running cannot
+ *    claim it. `fresh` is the manager's own signal, not anything off the wire or the file.
+ *  - The owner value is the machine-local project id the renderer passed at the create call
+ *    (`PtyCreateOptions.ownerProjectId`) — the entry id (`IndexEntryV3.id`), never the file's
+ *    git-copied `id`. A cloned repo gets a fresh entry id, so it cannot inherit another copy's
+ *    ownership either.
+ *
+ * ── COLD STATE / RESTART (stated honestly) ──────────────────────────────────────────────────────
+ * This ledger is IN-MEMORY and starts empty every run. After an app restart the tmux SERVER
+ * usually survives, so the renderer's re-open of a node ATTACHES (`fresh === false`) and records
+ * nothing — the pane is then UNPROVEN and messaging to it is REFUSED (fail-closed) until the
+ * session is truly respawned (or the machine reboots, killing the tmux server, after which the
+ * next open is a real fresh spawn and records correctly). We do NOT repopulate on attach: there is
+ * no cheap cross-restart signal a hostile agent could not also write (a tmux session-env var is
+ * settable from any pane's shell), and guessing the owner on attach is exactly how the attacker
+ * would re-acquire ownership by opening the victim's id first. Fail-closed is the safe direction
+ * and is pinned by a test (`ownerOf` empty ⇒ the delivery gate refuses).
+ *
+ * ── SCOPE ───────────────────────────────────────────────────────────────────────────────────────
+ * This is scoped to tmux-pane messaging ownership but is intentionally feature-neutral: S8 PR 4's
+ * BrowserControlLedger and messaging PR 7's deliver-on-idle queue want the same "who really spawned
+ * this node" answer and can consume `paneOwnerProject` directly. It lives in `src/core` (no
+ * electron, no main import) so it ships on both shells; the Server Edition never records or reads it
+ * because messaging does not exist there (`setControlHandler` is never called).
+ */
+
+/** nodeId → owning projectId (machine-local entry id), for panes freshly spawned THIS run. */
+const owners = new Map<string, string>()
+
+/**
+ * Record the owner of a node whose pane was just GENUINELY spawned. Call site: `spawnNew`, guarded
+ * by `fresh === true` and a present `persistKey` + `ownerProjectId`. A fresh spawn for an id that
+ * somehow already has an entry OVERWRITES it — the live pane is the one that just came into being.
+ * A missing owner is a no-op (old callers / tests that pass no `ownerProjectId` simply leave the
+ * pane unproven, which fails closed downstream — the correct direction).
+ */
+export function recordFreshSpawnOwner(nodeId: string, ownerProjectId: string | undefined): void {
+  if (!nodeId || !ownerProjectId) return
+  owners.set(nodeId, ownerProjectId)
+}
+
+/** The project that provably spawned this node's pane this run, or `undefined` when unproven
+ *  (never spawned here, or only ever attached — e.g. after a restart). Undefined MUST fail closed
+ *  at every gate: an unprovable owner is not an absent restriction. */
+export function paneOwnerProject(nodeId: string): string | undefined {
+  return owners.get(nodeId)
+}
+
+/** Drop a node's ownership — its session is ending (delete or recycle). A later genuine respawn
+ *  re-records; until then the id is unproven again, which fails closed. */
+export function forgetPaneOwner(nodeId: string): void {
+  owners.delete(nodeId)
+}
+
+/** Test seam only: wipe the ledger between cases. Never called in production. */
+export function resetPaneOwnershipForTests(): void {
+  owners.clear()
+}

--- a/src/core/agents/pane-ownership.ts
+++ b/src/core/agents/pane-ownership.ts
@@ -42,6 +42,22 @@
 const owners = new Map<string, string>()
 
 /**
+ * THE FRESH-GATE, pure and pinned: may this create() record pane ownership? True ONLY for a
+ * genuine fresh spawn (`fresh === true`) of a persistent node (`persistKey`) whose owner is known
+ * (`ownerProjectId`). This is the load-bearing security property — recording on an ATTACH
+ * (`fresh === false`) would let a project claim a pane it merely re-opened after a restart, which
+ * is exactly the confused deputy this ledger closes. Extracted so the gate has its own unit test
+ * (`pane-ownership.test.ts`) rather than living only inside `spawnNew`.
+ */
+export function shouldRecordOwnership(
+  fresh: boolean,
+  persistKey: string | undefined,
+  ownerProjectId: string | undefined
+): boolean {
+  return fresh === true && !!persistKey && !!ownerProjectId
+}
+
+/**
  * Record the owner of a node whose pane was just GENUINELY spawned. Call site: `spawnNew`, guarded
  * by `fresh === true` and a present `persistKey` + `ownerProjectId`. A fresh spawn for an id that
  * somehow already has an entry OVERWRITES it — the live pane is the one that just came into being.

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -35,6 +35,7 @@ import {
   remotePaneCursorArgs
 } from './remote-ssh/control-master'
 import { parsePaneCursor } from './pane-cursor'
+import { recordFreshSpawnOwner, forgetPaneOwner } from './agents/pane-ownership'
 import { PANE_OWNER_FMT, foregroundArgvArgs, paneOwnerFrom, parsePaneOwner } from './agents/pane-owner'
 import type { PaneOwner } from '../shared/agents/pane-owner-predicate'
 import { readSpawnResources, spawnResourceNote } from './spawn-resources'
@@ -1648,6 +1649,12 @@ export class PtyManager {
     }
     const sessionId = this.spawnSession(options, clientId, undefined)
     const spawned = this.sessions.get(sessionId)
+    // PANE OWNERSHIP (agent messaging, PR #237 fix round 2): record the OWNING project of a pane
+    // this process just GENUINELY spawned. Gated on `fresh` — an attach/co-attach to a session
+    // someone else spawned (incl. an app-restart re-attach) leaves the pane UNPROVEN, so a second
+    // project that merely opens another's node id cannot claim it. The owner is the renderer's
+    // machine-local project id, never the git-shared file id. See `agents/pane-ownership.ts`.
+    if (fresh && options.persistKey) recordFreshSpawnOwner(options.persistKey, options.ownerProjectId)
     // Surface a missing-account-dir fallback so the renderer can flag the node's account chip.
     const accountFallback = spawned?.accountFallback
     // The session's `persistKey` is set iff the spawn actually landed on a tmux, local or remote
@@ -3137,6 +3144,10 @@ export class PtyManager {
     // Also drop any in-flight create for this node: a create racing the kill-session below must
     // spawn a fresh session, not await (and then join) the one we are ending.
     this.inflight.delete(persistKey)
+    // The session is ending (delete or recycle), so its pane ownership no longer holds — a later
+    // genuine respawn re-records it; until then the id is unproven, which fails closed for
+    // messaging (agents/pane-ownership.ts). Safe on either intent: recycle's respawn overwrites.
+    forgetPaneOwner(persistKey)
     // The tmux session is about to be killed, so everything attached to it goes now: a shadow would
     // otherwise linger until tmux dropped its client, and what we remembered about the released
     // session describes a pane that is about to stop existing.

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -35,7 +35,11 @@ import {
   remotePaneCursorArgs
 } from './remote-ssh/control-master'
 import { parsePaneCursor } from './pane-cursor'
-import { recordFreshSpawnOwner, forgetPaneOwner } from './agents/pane-ownership'
+import {
+  recordFreshSpawnOwner,
+  forgetPaneOwner,
+  shouldRecordOwnership
+} from './agents/pane-ownership'
 import { PANE_OWNER_FMT, foregroundArgvArgs, paneOwnerFrom, parsePaneOwner } from './agents/pane-owner'
 import type { PaneOwner } from '../shared/agents/pane-owner-predicate'
 import { readSpawnResources, spawnResourceNote } from './spawn-resources'
@@ -1654,7 +1658,8 @@ export class PtyManager {
     // someone else spawned (incl. an app-restart re-attach) leaves the pane UNPROVEN, so a second
     // project that merely opens another's node id cannot claim it. The owner is the renderer's
     // machine-local project id, never the git-shared file id. See `agents/pane-ownership.ts`.
-    if (fresh && options.persistKey) recordFreshSpawnOwner(options.persistKey, options.ownerProjectId)
+    if (shouldRecordOwnership(fresh, options.persistKey, options.ownerProjectId))
+      recordFreshSpawnOwner(options.persistKey as string, options.ownerProjectId)
     // Surface a missing-account-dir fallback so the renderer can flag the node's account chip.
     const accountFallback = spawned?.accountFallback
     // The session's `persistKey` is set iff the spawn actually landed on a tmux, local or remote

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -73,6 +73,9 @@ export interface ProjectFileV1 {
    * (`readProjectCapabilities`, literal `true` only) and why the switch alone grants nothing.
    */
   agentBrowserControl?: boolean
+  /** Per-project capability switch (@shared/project-capabilities): agents may message other agent
+   *  nodes in this project. Git-shared like `agentBrowserControl`, read with the same strictness. */
+  agentMessaging?: boolean
   dinoHighScore?: number
   kanban?: ProjectKanban
 }

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -12,6 +12,8 @@ import {
   serializeProjectFile, splitWorkspace, validKanban,
   type IndexEntryV3, type ProjectFileV1, type WorkspaceIndexV3
 } from './workspace-files'
+import { readProjectCapabilities, type ProjectCapability } from '../shared/project-capabilities'
+import type { CapabilityAckMap } from './project-capability-consent'
 import { hoistLegacyNodeExec, type LocalNodeExecMap } from '../shared/node-exec'
 import { collisionSeed, derivedProjectId, freshProjectId } from '../shared/project-id'
 import { appendProjectNode, type RemoteNodeInput } from './project-node-append'
@@ -780,6 +782,47 @@ export class WorkspaceStore {
       }
     }
     return out
+  }
+
+  /**
+   * The capability view of one project, for `projectCapabilityGrantedFor`: the STRICT capability
+   * flags from the shared file (`readProjectCapabilities` — literal `true`, known keys only) plus
+   * this machine's recorded answers from the INDEX ENTRY. Same three-entry-kind scan and same id
+   * semantics as `persistedCanvases`, because the projectId a delivery resolved there must look up
+   * the same project here.
+   *
+   * The ack deliberately never comes from the parsed file: a repo hand-carrying `capabilityAck`
+   * is a forgery attempt (workspace-files.ts says the same at the fileToProject boundary), and
+   * `agent-messaging-switch.test.ts` drives that exact file through a real store. An inline entry
+   * stores the Project verbatim (ack included — splitWorkspace gives it no localState), so there
+   * the project object IS the entry-local record.
+   */
+  capabilityProjectFor(
+    projectId: string
+  ): (Partial<Record<ProjectCapability, true>> & { capabilityAck?: CapabilityAckMap }) | undefined {
+    for (const e of this.index?.entries ?? []) {
+      if (e.project) {
+        if (e.project.id !== projectId) continue
+        return {
+          ...readProjectCapabilities(e.project),
+          ...(e.project.capabilityAck ? { capabilityAck: e.project.capabilityAck } : {})
+        }
+      }
+      if (e.id !== projectId) continue
+      const ack = e.capabilityAck ? { capabilityAck: e.capabilityAck } : {}
+      if (e.cache) return { ...readProjectCapabilities(e.cache), ...ack }
+      if (e.cwd) {
+        const raw = this.lastWritten.get(projectFilePath(e.cwd))
+        if (!raw) return { ...ack } // file never read this run: no flag known, so nothing grants
+        try {
+          return { ...readProjectCapabilities(JSON.parse(raw)), ...ack }
+        } catch {
+          return { ...ack } // corrupt file: fail closed, like every other reader of this cache
+        }
+      }
+      return undefined
+    }
+    return undefined
   }
 
   getNodeTitle(nodeId: string): string | undefined {

--- a/src/main/agent-messaging-switch.test.ts
+++ b/src/main/agent-messaging-switch.test.ts
@@ -1,0 +1,245 @@
+/**
+ * PR 6's real work: `messagingEnabled` stops being the fail-closed `() => false` placeholder and
+ * becomes the per-project capability GRANT — `projectCapabilityGrantedFor(project,
+ * 'agentMessaging')`, which requires BOTH the strict `=== true` flag in the git-shared
+ * .nodeterm/project.json AND this machine's recorded 'kept' answer to the clone notice.
+ *
+ * Every test here drives the REAL control path (`deliverFromControl`) with `messagingEnabled`
+ * wired exactly as production wires it (`messagingEnabledVia`); the second half additionally runs
+ * a REAL WorkspaceStore over real files, so the store's `capabilityProjectFor` — the one reader
+ * the desktop wiring consults — is what decides.
+ *
+ * THE TRAP THIS FILE EXISTS TO CATCH (PR #213 review, I2): wiring the raw file bit
+ * (`projectCapabilityFlagInFile`) instead of the grant. The pending-notice and declined tests
+ * below go red on exactly that swap — the flag answers `true` in both, and delivery must refuse.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  deliverFromControl,
+  messagingEnabledVia,
+  type AgentMessagingDeps
+} from './agent-messaging'
+import type { CapabilityAckMap } from '../core/project-capability-consent'
+import { resetMessageFlow } from '../core/agents/agent-message-flow'
+import { resetAgentMessageTraceForTests } from '../core/agents/agent-message-trace'
+import { MANAGED_SCRIPT_REVISION } from '../core/agents/hooks/managed-script'
+import type { MirrorEntry } from '../core/agent-status-mirror'
+import { initPlatform, resetPlatformForTests } from '../core/platform'
+import { fakePlatform } from '../core/platform-fake'
+import { WorkspaceStore } from '../core/workspace-store'
+import type { Project, Workspace } from '../shared/types'
+
+const idle: MirrorEntry = {
+  state: 'done',
+  updatedAt: 1,
+  stateVerified: true,
+  clientRevision: MANAGED_SCRIPT_REVISION
+}
+
+/** The happy-path service deps from agent-messaging.test.ts, minus `messagingEnabled` and
+ *  `projects` — each test supplies those two, because they are what this file is about. */
+function baseDeps(
+  over: Partial<AgentMessagingDeps>
+): AgentMessagingDeps & { sent: { nodeId: string; payload: string }[] } {
+  const sent: { nodeId: string; payload: string }[] = []
+  return {
+    sent,
+    paneOwner: async () => ({
+      tty: '/dev/pts/9',
+      panePid: 100,
+      paneId: '%1',
+      command: 'claude',
+      argv: ['claude'],
+      pids: [200]
+    }),
+    sendFramedPayload: async (nodeId, payload) => {
+      sent.push({ nodeId, payload })
+      return true
+    },
+    hasLiveSession: () => true,
+    mirrorEntry: () => idle,
+    projects: () => [
+      {
+        id: 'p1',
+        nodes: [
+          { id: 'a1', title: 'Alpha', agentId: 'claude' },
+          { id: 'b1', title: 'Beta', agentId: 'claude' }
+        ]
+      }
+    ],
+    isRemoteNode: () => false,
+    messagingEnabled: () => {
+      throw new Error('each test wires messagingEnabled itself')
+    },
+    customAgents: () => undefined,
+    appendBoardLog: async () => false,
+    subscribeReceipts: (cb) => {
+      const t = setTimeout(() => cb({ nodeId: 'b1', newTurn: true, verified: true }), 5)
+      return () => clearTimeout(t)
+    },
+    now: () => 1_000_000,
+    ...over
+  }
+}
+
+const req = { verb: 'send', sourceNodeId: 'a1', targetNodeId: 'b1', body: 'hello' } as never
+
+beforeEach(() => {
+  resetMessageFlow()
+  resetAgentMessageTraceForTests()
+})
+
+describe('messagingEnabledVia — the grant, never the raw file bit', () => {
+  const run = (project: (Partial<Record<'agentMessaging', unknown>> & { capabilityAck?: CapabilityAckMap }) | undefined) =>
+    deliverFromControl(
+      req,
+      baseDeps({ messagingEnabled: messagingEnabledVia(() => project) })
+    )
+
+  it('flag true but the clone notice UNANSWERED: refused as switch-off, no pane touched', async () => {
+    const deps = baseDeps({ messagingEnabled: messagingEnabledVia(() => ({ agentMessaging: true })) })
+    const { outcome, reply } = await deliverFromControl(req, deps)
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+    expect(reply.ok).toBe(false)
+    expect(deps.sent).toEqual([])
+  })
+
+  it('flag true but DECLINED on this machine: still refused — a re-arriving hostile true is not a grant', async () => {
+    const { outcome } = await run({ agentMessaging: true, capabilityAck: { agentMessaging: 'declined' } })
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+  })
+
+  it('flag true + KEPT: the delivery proceeds all the way to the pane write', async () => {
+    const deps = baseDeps({
+      messagingEnabled: messagingEnabledVia(() => ({
+        agentMessaging: true,
+        capabilityAck: { agentMessaging: 'kept' as const }
+      }))
+    })
+    const { outcome, reply } = await deliverFromControl(req, deps)
+    expect(outcome.kind).toBe('delivered')
+    expect(reply.ok).toBe(true)
+    expect(deps.sent).toHaveLength(1)
+    expect(deps.sent[0].payload).toContain('hello')
+  })
+
+  it('a KEPT ack without the file flag grants nothing — consent alone cannot switch it on', async () => {
+    const { outcome } = await run({ capabilityAck: { agentMessaging: 'kept' } })
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+  })
+
+  it('an unknown project grants nothing', async () => {
+    const { outcome } = await run(undefined)
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+  })
+})
+
+describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus Electron', () => {
+  let userData: string
+  let projRoot: string
+
+  const project = (over: Partial<Project> = {}): Project => ({
+    id: 'p1',
+    name: 'msg',
+    color: '#7aa2f7',
+    viewport: { x: 0, y: 0, zoom: 1 },
+    nodes: [
+      { id: 'a1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 'Alpha', color: '#fff', group: null, agentId: 'claude' },
+      { id: 'b1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 'Beta', color: '#fff', group: null, agentId: 'claude' }
+    ] as Project['nodes'],
+    ...over
+  })
+  const ws = (p: Project): Workspace => ({ version: 2, activeProjectId: p.id, projects: [p] })
+
+  beforeEach(async () => {
+    userData = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-msgsw-'))
+    projRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-msgsw-proj-'))
+    initPlatform(fakePlatform({ userDataDir: userData }))
+  })
+  afterEach(async () => {
+    resetPlatformForTests()
+    await fs.rm(userData, { recursive: true, force: true })
+    await fs.rm(projRoot, { recursive: true, force: true })
+  })
+
+  /** Exactly the desktop's two lines: `projects` off the store, the switch off the store. */
+  const storeDeps = (store: WorkspaceStore) =>
+    baseDeps({
+      projects: () => store.persistedCanvases(),
+      messagingEnabled: messagingEnabledVia((id) => store.capabilityProjectFor(id))
+    })
+
+  it('flag committed in project.json + KEPT on this machine: delivered', async () => {
+    const store = new WorkspaceStore()
+    await store.save(
+      ws(project({ cwd: projRoot, agentMessaging: true, capabilityAck: { agentMessaging: 'kept' } }))
+    )
+    // The flag travelled to the git-shared file; the ack did not.
+    const raw = await fs.readFile(path.join(projRoot, '.nodeterm/project.json'), 'utf-8')
+    expect(raw).toContain('"agentMessaging": true')
+    expect(raw).not.toContain('capabilityAck')
+    const deps = storeDeps(store)
+    const { outcome } = await deliverFromControl(req, deps)
+    expect(outcome.kind).toBe('delivered')
+    expect(deps.sent).toHaveLength(1)
+  })
+
+  it('flag committed but the notice never answered: refused as switch-off', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws(project({ cwd: projRoot, agentMessaging: true })))
+    const deps = storeDeps(store)
+    const { outcome } = await deliverFromControl(req, deps)
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+    expect(deps.sent).toEqual([])
+  })
+
+  it('flag committed but DECLINED on this machine: refused as switch-off', async () => {
+    const store = new WorkspaceStore()
+    await store.save(
+      ws(project({ cwd: projRoot, agentMessaging: true, capabilityAck: { agentMessaging: 'declined' } }))
+    )
+    const { outcome } = await deliverFromControl(req, storeDeps(store))
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+  })
+
+  it('a FORGED file-borne capabilityAck is never read: the repo cannot carry this machine\'s consent', async () => {
+    // Save without an ack, then let a hostile repo hand-edit the shared file to claim consent.
+    const store = new WorkspaceStore()
+    await store.save(ws(project({ cwd: projRoot, agentMessaging: true })))
+    const filePath = path.join(projRoot, '.nodeterm/project.json')
+    const forged = JSON.parse(await fs.readFile(filePath, 'utf-8'))
+    forged.capabilityAck = { agentMessaging: 'kept' }
+    await fs.writeFile(filePath, JSON.stringify(forged))
+    // A fresh app run loads the forged file; the machine-local entry still holds no answer.
+    const fresh = new WorkspaceStore()
+    await fresh.load()
+    const { outcome } = await deliverFromControl(req, storeDeps(fresh))
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+  })
+
+  it('a hand-edited "true" (string) in the file never enables — the strict read holds through the store', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws(project({ cwd: projRoot, capabilityAck: { agentMessaging: 'kept' } })))
+    const filePath = path.join(projRoot, '.nodeterm/project.json')
+    const edited = JSON.parse(await fs.readFile(filePath, 'utf-8'))
+    edited.agentMessaging = 'true'
+    await fs.writeFile(filePath, JSON.stringify(edited))
+    const fresh = new WorkspaceStore()
+    await fresh.load()
+    const { outcome } = await deliverFromControl(req, storeDeps(fresh))
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+  })
+
+  it('an INLINE (cwd-less) project grants through its entry too', async () => {
+    const store = new WorkspaceStore()
+    await store.save(
+      ws(project({ agentMessaging: true, capabilityAck: { agentMessaging: 'kept' } }))
+    )
+    const deps = storeDeps(store)
+    const { outcome } = await deliverFromControl(req, deps)
+    expect(outcome.kind).toBe('delivered')
+  })
+})

--- a/src/main/agent-messaging-switch.test.ts
+++ b/src/main/agent-messaging-switch.test.ts
@@ -233,6 +233,44 @@ describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus
     expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
   })
 
+  it('CONFUSED DEPUTY (PR #237 review I-1): a granted project cannot reach an UNGRANTED project\'s pane through a duplicated node id', async () => {
+    // The reviewer's proved escalation: hostile/cloned project A sets `agentMessaging: true` AND
+    // lists a node id that legitimate, ungranted project B is actually running. Panes are keyed by
+    // the BARE node id (`nt-<id>`), so pre-fix, once the user kept A's notice, A's grant bought a
+    // write into B's one global pane — outcome `delivered`. Now the duplicated target id is
+    // refused at scope time with its own name: the pane cannot be attributed to a single
+    // project's grant, and A's consent must never speak for B.
+    const store = new WorkspaceStore()
+    const attacker = project({
+      id: 'attacker',
+      name: 'cloned-hostile',
+      cwd: projRoot,
+      agentMessaging: true,
+      capabilityAck: { agentMessaging: 'kept' },
+      nodes: [
+        { id: 'atk-1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 'Atk', color: '#fff', group: null, agentId: 'claude' },
+        // The hostile listing: victim-1 is NOT this project's node — it is B's.
+        { id: 'victim-1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 'Stolen', color: '#fff', group: null, agentId: 'claude' }
+      ] as Project['nodes']
+    })
+    const victimProject = project({
+      id: 'victim-proj',
+      name: 'legit-ungranted',
+      nodes: [
+        { id: 'victim-1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 'Victim', color: '#fff', group: null, agentId: 'claude' }
+      ] as Project['nodes']
+    })
+    await store.save({ version: 2, activeProjectId: 'attacker', projects: [attacker, victimProject] })
+    const deps = storeDeps(store)
+    const { outcome, reply } = await deliverFromControl(
+      { verb: 'send', sourceNodeId: 'atk-1', targetNodeId: 'victim-1', body: 'sneak' } as never,
+      deps
+    )
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'ambiguous-target-node-id' })
+    expect(reply.ok).toBe(false)
+    expect(deps.sent).toEqual([]) // NOT delivered — nothing reached any pane
+  })
+
   it('an INLINE (cwd-less) project grants through its entry too', async () => {
     const store = new WorkspaceStore()
     await store.save(

--- a/src/main/agent-messaging-switch.test.ts
+++ b/src/main/agent-messaging-switch.test.ts
@@ -24,6 +24,11 @@ import {
 } from './agent-messaging'
 import type { CapabilityAckMap } from '../core/project-capability-consent'
 import { resetMessageFlow } from '../core/agents/agent-message-flow'
+import {
+  recordFreshSpawnOwner,
+  paneOwnerProject,
+  resetPaneOwnershipForTests
+} from '../core/agents/pane-ownership'
 import { resetAgentMessageTraceForTests } from '../core/agents/agent-message-trace'
 import { MANAGED_SCRIPT_REVISION } from '../core/agents/hooks/managed-script'
 import type { MirrorEntry } from '../core/agent-status-mirror'
@@ -71,6 +76,10 @@ function baseDeps(
       }
     ],
     isRemoteNode: () => false,
+    // Default: the target (b1) is proven-owned by its store project (p1), so the pure-wiring tests
+    // exercise the GRANT, not the ownership gate. Tests that probe ownership override this or use
+    // the real ledger via storeDeps.
+    paneOwnerProject: () => 'p1',
     messagingEnabled: () => {
       throw new Error('each test wires messagingEnabled itself')
     },
@@ -90,6 +99,7 @@ const req = { verb: 'send', sourceNodeId: 'a1', targetNodeId: 'b1', body: 'hello
 beforeEach(() => {
   resetMessageFlow()
   resetAgentMessageTraceForTests()
+  resetPaneOwnershipForTests()
 })
 
 describe('messagingEnabledVia — the grant, never the raw file bit', () => {
@@ -165,14 +175,16 @@ describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus
     await fs.rm(projRoot, { recursive: true, force: true })
   })
 
-  /** Exactly the desktop's two lines: `projects` off the store, the switch off the store. */
+  /** Exactly the desktop's THREE lines: `projects` off the store, the switch off the store, and
+   *  the target's owner off the RUNTIME ledger (never the store). */
   const storeDeps = (store: WorkspaceStore) =>
     baseDeps({
       projects: () => store.persistedCanvases(),
-      messagingEnabled: messagingEnabledVia((id) => store.capabilityProjectFor(id))
+      messagingEnabled: messagingEnabledVia((id) => store.capabilityProjectFor(id)),
+      paneOwnerProject: (id) => paneOwnerProject(id)
     })
 
-  it('flag committed in project.json + KEPT on this machine: delivered', async () => {
+  it('flag committed in project.json + KEPT + owner PROVEN: delivered', async () => {
     const store = new WorkspaceStore()
     await store.save(
       ws(project({ cwd: projRoot, agentMessaging: true, capabilityAck: { agentMessaging: 'kept' } }))
@@ -181,6 +193,8 @@ describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus
     const raw = await fs.readFile(path.join(projRoot, '.nodeterm/project.json'), 'utf-8')
     expect(raw).toContain('"agentMessaging": true')
     expect(raw).not.toContain('capabilityAck')
+    // The runtime fact: this project's own create() freshly spawned the target pane.
+    recordFreshSpawnOwner('b1', 'p1')
     const deps = storeDeps(store)
     const { outcome } = await deliverFromControl(req, deps)
     expect(outcome.kind).toBe('delivered')
@@ -190,6 +204,7 @@ describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus
   it('flag committed but the notice never answered: refused as switch-off', async () => {
     const store = new WorkspaceStore()
     await store.save(ws(project({ cwd: projRoot, agentMessaging: true })))
+    recordFreshSpawnOwner('b1', 'p1') // ownership proven, so the refusal is the GRANT's, not the gate's
     const deps = storeDeps(store)
     const { outcome } = await deliverFromControl(req, deps)
     expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
@@ -201,6 +216,7 @@ describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus
     await store.save(
       ws(project({ cwd: projRoot, agentMessaging: true, capabilityAck: { agentMessaging: 'declined' } }))
     )
+    recordFreshSpawnOwner('b1', 'p1')
     const { outcome } = await deliverFromControl(req, storeDeps(store))
     expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
   })
@@ -216,6 +232,7 @@ describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus
     // A fresh app run loads the forged file; the machine-local entry still holds no answer.
     const fresh = new WorkspaceStore()
     await fresh.load()
+    recordFreshSpawnOwner('b1', 'p1')
     const { outcome } = await deliverFromControl(req, storeDeps(fresh))
     expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
   })
@@ -229,6 +246,7 @@ describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus
     await fs.writeFile(filePath, JSON.stringify(edited))
     const fresh = new WorkspaceStore()
     await fresh.load()
+    recordFreshSpawnOwner('b1', 'p1')
     const { outcome } = await deliverFromControl(req, storeDeps(fresh))
     expect(outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
   })
@@ -276,8 +294,151 @@ describe('end to end through a REAL WorkspaceStore — the desktop wiring, minus
     await store.save(
       ws(project({ agentMessaging: true, capabilityAck: { agentMessaging: 'kept' } }))
     )
+    recordFreshSpawnOwner('b1', 'p1')
     const deps = storeDeps(store)
     const { outcome } = await deliverFromControl(req, deps)
     expect(outcome.kind).toBe('delivered')
+  })
+})
+
+describe('runtime pane-ownership gate (PR #237 fix round 2) — over a REAL store + ledger', () => {
+  let userData: string
+  let projRoot: string
+
+  const project = (over: Partial<Project> = {}): Project => ({
+    id: 'p1',
+    name: 'msg',
+    color: '#7aa2f7',
+    viewport: { x: 0, y: 0, zoom: 1 },
+    nodes: [] as Project['nodes'],
+    ...over
+  })
+  const node = (id: string, title: string) =>
+    ({ id, kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title, color: '#fff', group: null, agentId: 'claude' })
+  const ws2 = (p: Project): Workspace => ({ version: 2, activeProjectId: p.id, projects: [p] })
+
+  beforeEach(async () => {
+    userData = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-own-'))
+    projRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-own-proj-'))
+    initPlatform(fakePlatform({ userDataDir: userData }))
+  })
+  afterEach(async () => {
+    resetPlatformForTests()
+    await fs.rm(userData, { recursive: true, force: true })
+    await fs.rm(projRoot, { recursive: true, force: true })
+  })
+
+  const storeDeps = (store: WorkspaceStore) =>
+    baseDeps({
+      projects: () => store.persistedCanvases(),
+      messagingEnabled: messagingEnabledVia((id) => store.capabilityProjectFor(id)),
+      paneOwnerProject: (id) => paneOwnerProject(id)
+    })
+
+  it('FAIL-OPEN CLOSED: victim project ABSENT from the store, its pane live — granted attacker listing the id is REFUSED, not delivered', async () => {
+    // The re-review's Critical, driven end to end. Project A is granted+kept and its (hostile)
+    // project.json is the SOLE store claimant of `victim-1` — the real owner B is not persisted at
+    // all, so the round-1 ambiguity check (which needs two store claimants) does NOT fire and scope
+    // resolves same-project=A. Pre-round-2 the switch then passed on A and the envelope reached
+    // victim-1's one global pane (outcome=delivered, reply.ok=true). Now the RUNTIME ledger is the
+    // authority: victim-1 was freshly spawned by B this run, so its proven owner is 'victim-proj',
+    // which is NOT A — refused, nothing written.
+    const store = new WorkspaceStore()
+    const attacker = project({
+      id: 'attacker',
+      name: 'cloned-hostile',
+      cwd: projRoot,
+      agentMessaging: true,
+      capabilityAck: { agentMessaging: 'kept' },
+      nodes: [node('atk-1', 'Atk'), node('victim-1', 'Stolen')] as Project['nodes']
+    })
+    // Victim B is NOT in the persisted store — only its pane runs. That is the whole point.
+    await store.save({ version: 2, activeProjectId: 'attacker', projects: [attacker] })
+    recordFreshSpawnOwner('victim-1', 'victim-proj') // B's create() genuinely spawned it this run
+    const deps = storeDeps(store)
+    const { outcome, reply } = await deliverFromControl(
+      { verb: 'send', sourceNodeId: 'atk-1', targetNodeId: 'victim-1', body: 'sneak' } as never,
+      deps
+    )
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'unproven-target-owner' })
+    expect(reply.ok).toBe(false)
+    expect(deps.sent).toEqual([]) // NOTHING reached the victim's pane
+  })
+
+  it('LEDGER EMPTY (post-restart re-attach): a live pane with no runtime owner is UNPROVEN → refused', async () => {
+    // After an app restart the tmux server survives, the renderer re-ATTACHES (fresh===false, so
+    // nothing is recorded), and the ledger is empty. A pane in that state is unproven and must be
+    // refused — the fail-closed cold-state direction. (Same store shape as the attack, minus the
+    // ledger record.)
+    const store = new WorkspaceStore()
+    const attacker = project({
+      id: 'attacker',
+      name: 'cloned-hostile',
+      cwd: projRoot,
+      agentMessaging: true,
+      capabilityAck: { agentMessaging: 'kept' },
+      nodes: [node('atk-1', 'Atk'), node('victim-1', 'Stolen')] as Project['nodes']
+    })
+    await store.save({ version: 2, activeProjectId: 'attacker', projects: [attacker] })
+    // resetPaneOwnershipForTests() in beforeEach already emptied it; record NOTHING.
+    const deps = storeDeps(store)
+    const { outcome } = await deliverFromControl(
+      { verb: 'send', sourceNodeId: 'atk-1', targetNodeId: 'victim-1', body: 'x' } as never,
+      deps
+    )
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'unproven-target-owner' })
+    expect(deps.sent).toEqual([])
+  })
+
+  it('LEGITIMATE self-delivery: a project messaging a node IT freshly spawned, granted+kept → delivered', async () => {
+    // Proves the fix is not "refuse everything": when the ledger owner matches the store project
+    // AND that project holds the grant, the delivery proceeds to the pane write.
+    const store = new WorkspaceStore()
+    await store.save(
+      ws2(
+        project({
+          id: 'p1',
+          cwd: projRoot,
+          agentMessaging: true,
+          capabilityAck: { agentMessaging: 'kept' },
+          nodes: [node('a1', 'Alpha'), node('b1', 'Beta')] as Project['nodes']
+        })
+      )
+    )
+    recordFreshSpawnOwner('b1', 'p1') // p1's own create() spawned b1
+    const deps = storeDeps(store)
+    const { outcome } = await deliverFromControl(
+      { verb: 'send', sourceNodeId: 'a1', targetNodeId: 'b1', body: 'hi' } as never,
+      deps
+    )
+    expect(outcome.kind).toBe('delivered')
+    expect(deps.sent).toHaveLength(1)
+  })
+
+  it('ledger owner DISAGREES with the sole store claimant → refused even when that claimant is granted', async () => {
+    // The cross-check leg: the store says p1 owns b1 and p1 is granted, but the RUNTIME ledger
+    // says someone else spawned b1 (a stale/forged store claim over a live foreign pane). The
+    // disagreement itself is disqualifying — the grant of a project that did not spawn the pane
+    // cannot authorize a write into it.
+    const store = new WorkspaceStore()
+    await store.save(
+      ws2(
+        project({
+          id: 'p1',
+          cwd: projRoot,
+          agentMessaging: true,
+          capabilityAck: { agentMessaging: 'kept' },
+          nodes: [node('a1', 'Alpha'), node('b1', 'Beta')] as Project['nodes']
+        })
+      )
+    )
+    recordFreshSpawnOwner('b1', 'someone-else')
+    const deps = storeDeps(store)
+    const { outcome } = await deliverFromControl(
+      { verb: 'send', sourceNodeId: 'a1', targetNodeId: 'b1', body: 'hi' } as never,
+      deps
+    )
+    expect(outcome).toEqual({ kind: 'notPermitted', reason: 'unproven-target-owner' })
+    expect(deps.sent).toEqual([])
   })
 })

--- a/src/main/agent-messaging.test.ts
+++ b/src/main/agent-messaging.test.ts
@@ -36,6 +36,12 @@ interface Recorded {
 
 function fakeDeps(over: Partial<AgentMessagingDeps> = {}): AgentMessagingDeps & { rec: Recorded } {
   const rec: Recorded = { paneOwnerCalls: [], sent: [] }
+  const projectsFn =
+    over.projects ??
+    (() => [
+      { id: 'p1', nodes: [{ id: 'a1', title: 'Alpha', agentId: 'claude' }, { id: 'b1', title: 'Beta', agentId: 'claude' }] },
+      { id: 'p2', nodes: [{ id: 'c2', title: 'Gamma', agentId: 'claude' }] }
+    ])
   return {
     rec,
     paneOwner: async (nodeId) => {
@@ -55,12 +61,13 @@ function fakeDeps(over: Partial<AgentMessagingDeps> = {}): AgentMessagingDeps & 
     },
     hasLiveSession: () => true,
     mirrorEntry: () => idle,
-    projects: () => [
-      { id: 'p1', nodes: [{ id: 'a1', title: 'Alpha', agentId: 'claude' }, { id: 'b1', title: 'Beta', agentId: 'claude' }] },
-      { id: 'p2', nodes: [{ id: 'c2', title: 'Gamma', agentId: 'claude' }] }
-    ],
+    projects: projectsFn,
     isRemoteNode: () => false,
     messagingEnabled: () => true,
+    // Ownership gate (PR #237 fix round 2): default to "proven-owned by whatever project the store
+    // lists it in", so these pre-existing tests keep exercising the flow/scope/switch they were
+    // written for. The ownership gate itself is proven in agent-messaging-switch.test.ts.
+    paneOwnerProject: (id) => projectsFn().find((p) => p.nodes.some((n) => n.id === id))?.id,
     customAgents: () => undefined,
     appendBoardLog: async () => false,
     subscribeReceipts: (cb) => {

--- a/src/main/agent-messaging.ts
+++ b/src/main/agent-messaging.ts
@@ -163,7 +163,11 @@ const NOT_PERMITTED_TEXT: Record<NotPermittedReason, string> = {
   'cross-project': 'the target node is not in the sending node\'s project.',
   'self-send': 'a node cannot message itself.',
   'unsupported-edition': 'agent messaging does not exist on this edition.',
-  'unaddressable-node-id': 'that node id cannot be addressed safely.'
+  'unaddressable-node-id': 'that node id cannot be addressed safely.',
+  'ambiguous-target-node-id':
+    'that node id exists in more than one project, so the target pane cannot be attributed to a ' +
+    'single project\'s messaging grant. De-duplicate the id (re-add the cloned folder to mint ' +
+    'fresh ids) before messaging it.'
 }
 
 /**

--- a/src/main/agent-messaging.ts
+++ b/src/main/agent-messaging.ts
@@ -74,6 +74,15 @@ export interface AgentMessagingDeps {
    * file bit. Read per call, so an off-toggle or a decline takes effect on the next delivery.
    */
   messagingEnabled(projectId: string): boolean
+  /**
+   * The project that PROVABLY spawned the target node's pane this run, or `undefined` when
+   * unproven (runtime ledger, `core/agents/pane-ownership.ts`). The delivery gate trusts THIS,
+   * not the persisted store's node-set, to decide whose grant applies — the store is
+   * attacker-writable (`project.json` lists any node id) and cannot tell a real owner from a
+   * project that merely listed a live pane it never spawned (PR #237 fix round 2). Undefined ⇒
+   * refuse `unproven-target-owner`.
+   */
+  paneOwnerProject(nodeId: string): string | undefined
   customAgents(): readonly { id: string; launchCmd: string }[] | undefined
   appendBoardLog(projectId: string, entry: BoardLogEntry): Promise<boolean>
   /** Test seam: override the receipt subscription. Production uses the module bus below. */
@@ -167,7 +176,11 @@ const NOT_PERMITTED_TEXT: Record<NotPermittedReason, string> = {
   'ambiguous-target-node-id':
     'that node id exists in more than one project, so the target pane cannot be attributed to a ' +
     'single project\'s messaging grant. De-duplicate the id (re-add the cloned folder to mint ' +
-    'fresh ids) before messaging it.'
+    'fresh ids) before messaging it.',
+  'unproven-target-owner':
+    'the target pane\'s owning project cannot be proven at runtime (it was not freshly spawned in ' +
+    'this session, or its ownership is disputed), so a per-project messaging grant cannot be ' +
+    'applied to it. Re-open the target node so its owner is recorded, then try again.'
 }
 
 /**
@@ -327,8 +340,18 @@ export async function deliverFromControl(
   const scope = resolveDeliveryScope(projects, req.sourceNodeId, req.targetNodeId)
   let notPermitted = scopeRefusal(scope)
   const projectId = scope.kind === 'same-project' ? scope.projectId : undefined
-  if (!notPermitted && (!projectId || !deps.messagingEnabled(projectId)))
-    notPermitted = 'switch-off'
+  if (!notPermitted) {
+    // OWNERSHIP IS PROVEN AT RUNTIME, NOT READ FROM THE STORE (PR #237 fix round 2). The scope
+    // above resolved `projectId` from the persisted node-set, which is attacker-writable — a
+    // hostile `project.json` can LIST a live pane's node id it never spawned, and when the real
+    // owner is absent from the store that hostile project is the sole claimant. The ledger records
+    // who actually SPAWNED the pane this run; the grant is evaluated against THAT owner, and the
+    // store's `projectId` is only a cross-check. Unprovable — no ledger entry (restart / never
+    // spawned here), or the ledger owner disagrees with the sole store claimant — fails closed.
+    const owner = projectId ? deps.paneOwnerProject(req.targetNodeId) : undefined
+    if (!projectId || !owner || owner !== projectId) notPermitted = 'unproven-target-owner'
+    else if (!deps.messagingEnabled(owner)) notPermitted = 'switch-off'
+  }
 
   // Flow control (PR #208), taken as a RESERVATION rather than a pure read: `checkFlowLimits`
   // followed later by `noteSent` is not atomic, and N parallel sends to N distinct targets would

--- a/src/main/agent-messaging.ts
+++ b/src/main/agent-messaging.ts
@@ -41,6 +41,11 @@ import { recordDelivery } from '../core/agents/agent-message-trace'
 import { resolveDeliveryScope, scopeRefusal } from '../core/agents/agent-message-scope'
 import { nodeTokenFilePresent } from '../core/agents/node-token-files'
 import { mirrorEntry as coreMirrorEntry, type MirrorEntry } from '../core/agent-status-mirror'
+import {
+  projectCapabilityGrantedFor,
+  type CapabilityAckMap
+} from '../core/project-capability-consent'
+import type { ProjectCapability } from '../shared/project-capabilities'
 
 /** The little the service needs to know about a stored node. */
 export interface MessagingStoredNode {
@@ -63,9 +68,10 @@ export interface AgentMessagingDeps {
   isRemoteNode(nodeId: string): boolean
   /**
    * The per-project switch (Global Constraint 11): messaging is OFF unless the project opted in.
-   * PR 6 gives `Project`/`ProjectFileV1` the `agentMessaging` field (validated `=== true` — the
-   * file is hostile input) and wires this to it; until then the desktop wires `() => false`, so
-   * the verbs ship fail-closed and every delivery answers `notPermitted (switch-off)`.
+   * The desktop wires this through `messagingEnabledVia` below — the capability GRANT
+   * (`projectCapabilityGrantedFor`: the strict `=== true` flag in the hostile git-shared
+   * project.json AND this machine's recorded 'kept' answer to the clone notice), never the raw
+   * file bit. Read per call, so an off-toggle or a decline takes effect on the next delivery.
    */
   messagingEnabled(projectId: string): boolean
   customAgents(): readonly { id: string; launchCmd: string }[] | undefined
@@ -73,6 +79,29 @@ export interface AgentMessagingDeps {
   /** Test seam: override the receipt subscription. Production uses the module bus below. */
   subscribeReceipts?(cb: (e: ReceiptEvent) => void): () => void
   now?(): number
+}
+
+/**
+ * The production `messagingEnabled`: the per-project capability GRANT, one call, nothing else.
+ *
+ * `projectCapabilityGrantedFor` — NEVER `projectCapabilityFlagInFile` (PR #213 review, I2): the
+ * raw file bit answers `true` during the pending-notice window and after a recorded decline,
+ * which are exactly the states where a hostile cloned project.json must not buy delivery. The
+ * grant requires the strict `=== true` flag AND this machine's 'kept' ack, both derived inside
+ * the one predicate. `agent-messaging-switch.test.ts` goes red on the flag-for-grant swap.
+ *
+ * `getProject` is main's ONE store reader for this purpose (`WorkspaceStore.capabilityProjectFor`
+ * on the desktop — the same index scan `persistedCanvases` resolves the delivery scope from);
+ * factored as a dep so the suite can drive the identical wiring over a real store.
+ */
+export function messagingEnabledVia(
+  getProject: (
+    projectId: string
+  ) =>
+    | (Partial<Record<ProjectCapability, unknown>> & { capabilityAck?: CapabilityAckMap })
+    | undefined
+): (projectId: string) => boolean {
+  return (projectId) => projectCapabilityGrantedFor(getProject(projectId), 'agentMessaging')
 }
 
 // ── The receipt bus ───────────────────────────────────────────────────────────────────────────

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,12 @@ import {
   type BrowserSurfaceKind
 } from './browser-guest-registry'
 import { appendBoardLogVia, registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
-import { deliverFromControl, isDeliverRequest, onMessagingAgentEvent } from './agent-messaging'
+import {
+  deliverFromControl,
+  isDeliverRequest,
+  messagingEnabledVia,
+  onMessagingAgentEvent
+} from './agent-messaging'
 import type { RemoteLogExec } from '../core/board-log'
 import { boardLogRemotePath } from '../core/board-log'
 import { PtyManager } from '../core/pty-manager'
@@ -925,11 +930,11 @@ app.whenReady().then(async () => {
       projects: () => workspaceStore.persistedCanvases(),
       isRemoteNode: (id) => !!ptyManager.sshRemoteForNode(id),
       // GLOBAL CONSTRAINT 11: every delivery path is gated behind the per-project switch, OFF by
-      // default. The switch itself (Project/ProjectFileV1 `agentMessaging`, validated `=== true`
-      // against a hostile project.json, plus the Settings row) is PR 6 — until it lands, nothing
-      // can turn messaging on, and every delivery answers `notPermitted (switch-off)`. PR 6
-      // replaces this closure with the validated read; it must not weaken the `=== true` rule.
-      messagingEnabled: () => false,
+      // default. The switch is the `agentMessaging` capability GRANT: the strict `=== true` flag
+      // in the hostile git-shared project.json AND this machine's recorded 'kept' answer to the
+      // clone notice (projectCapabilityGrantedFor — never the raw file bit). Read per call off
+      // the store's index, so a decline or an off-toggle refuses the very next delivery.
+      messagingEnabled: messagingEnabledVia((id) => workspaceStore.capabilityProjectFor(id)),
       customAgents: () => settingsStore.get().customAgents,
       appendBoardLog: (projectId, entry) => appendBoardLogVia(boardLogRouter, projectId, entry)
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -78,6 +78,7 @@ import {
   nodeSessionName,
   workingNodes
 } from '../core/agent-status-mirror'
+import { paneOwnerProject } from '../core/agents/pane-ownership'
 import { createPushNotify, createLiveUpdatePush } from '../core/push-notify'
 import { createGrantsAccessor, type PushGrant } from '../core/push-grants'
 import { createRemoteGrantsCache } from '../core/remote-push-grants'
@@ -935,6 +936,10 @@ app.whenReady().then(async () => {
       // clone notice (projectCapabilityGrantedFor — never the raw file bit). Read per call off
       // the store's index, so a decline or an off-toggle refuses the very next delivery.
       messagingEnabled: messagingEnabledVia((id) => workspaceStore.capabilityProjectFor(id)),
+      // Runtime pane ownership: which project actually SPAWNED the target's pane this run
+      // (core/agents/pane-ownership.ts). The gate trusts this over the attacker-writable store to
+      // decide whose grant applies; unproven ⇒ refused (PR #237 fix round 2).
+      paneOwnerProject: (id) => paneOwnerProject(id),
       customAgents: () => settingsStore.get().customAgents,
       appendBoardLog: (projectId, entry) => appendBoardLogVia(boardLogRouter, projectId, entry)
     })

--- a/src/renderer/components/capability-notice.test.tsx
+++ b/src/renderer/components/capability-notice.test.tsx
@@ -211,6 +211,25 @@ describe('the one-time clone notice', () => {
     expect(grantedNow()).toBe(true)
   })
 
+  it('fires for agentMessaging too — the machinery is per-capability, nothing above is browser-specific', () => {
+    // Messaging PR 6 adds only the registry entry; a cloned repo arriving with
+    // `agentMessaging: true` must get exactly this dialog, with messaging's own copy.
+    useProjects.setState({ projects: [project({ agentMessaging: true })], activeProjectId: 'p1' })
+    mount()
+    expect(dialog()).toBeTruthy()
+    const text = dialog()!.textContent ?? ''
+    expect(text).toContain(PROJECT_CAPABILITY_COPY.agentMessaging.label)
+    expect(text).toContain(PROJECT_CAPABILITY_COPY.agentMessaging.description)
+    // Unanswered = refused: the exact predicate messagingEnabled consults.
+    expect(
+      projectCapabilityGrantedFor(useProjects.getState().getProject('p1'), 'agentMessaging')
+    ).toBe(false)
+    act(() => button('Turn it off').click())
+    const p = useProjects.getState().getProject('p1')!
+    expect(p.agentMessaging).toBeUndefined()
+    expect(p.capabilityAck).toEqual({ agentMessaging: 'declined' })
+  })
+
   it('stays silent when the switch is off', () => {
     useProjects.setState({ projects: [project()], activeProjectId: 'p1' })
     mount()

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -238,6 +238,12 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
         shellArgs: localSsh ? buildSshArgs(spawn.ssh!) : undefined,
         cwd: spawn.cwd,
         persistKey: nodeId,
+        // Pane-ownership ledger parity with TerminalNode (agent messaging, PR #237 fix round 2):
+        // if this modal is ever the FIRST/sole fresh spawner of the node (a card for a node whose
+        // project is not the active canvas), the pane must still record its true owner. Use the
+        // CARD's project resolved above, NOT the active canvas id — the modal may be for a
+        // non-active project. Recorded main-side only on a genuine fresh spawn.
+        ownerProjectId: projectId,
         agentId: spawn.agentId,
         accountId: spawn.accountId,
         sshRemote,

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -2413,6 +2413,12 @@ export function TerminalNode({
           shellArgs: localSsh ? buildSshArgs(ssh) : undefined,
           cwd: data.cwd,
           persistKey: id,
+          // The project that OWNS this node, for the runtime pane-ownership ledger (agent
+          // messaging, src/core/agents/pane-ownership.ts): the ssh project's own scope for a remote
+          // node, else the active project whose canvas this node lives on. Recorded main-side ONLY
+          // on a genuine fresh spawn, so a second project opening another's live node id cannot
+          // claim it. Machine-local id, never the git-shared project.json id.
+          ownerProjectId: sshProjectId ?? useProjects.getState().activeProjectId,
           agentId: data.agentId,
           accountId: data.accountId,
           sshRemote,

--- a/src/shared/project-capabilities.test.ts
+++ b/src/shared/project-capabilities.test.ts
@@ -51,6 +51,18 @@ describe('projectCapabilityFields — the spread projectToFile uses', () => {
   })
 })
 
+describe('agentMessaging is a registry capability (messaging PR 6) — a line in the registry, zero new mechanism', () => {
+  it('is in PROJECT_CAPABILITIES, so every generated surface (round-trip, notice, Settings row) covers it', () => {
+    expect(PROJECT_CAPABILITIES).toContain('agentMessaging')
+  })
+  it('reads with the same strictness as every capability — project.json stays hostile input', () => {
+    expect(projectCapabilityFlagInFile({ agentMessaging: true }, 'agentMessaging')).toBe(true)
+    expect(projectCapabilityFlagInFile({ agentMessaging: 'true' } as never, 'agentMessaging')).toBe(false)
+    expect(readProjectCapabilities({ agentMessaging: 1 })).toEqual({})
+    expect(projectCapabilityFields({ agentMessaging: true })).toEqual({ agentMessaging: true })
+  })
+})
+
 describe('every capability has copy, and the copy says what travels', () => {
   it.each(PROJECT_CAPABILITIES)('%s has label, description and cloneWarning', (cap) => {
     const c = PROJECT_CAPABILITY_COPY[cap]

--- a/src/shared/project-capabilities.ts
+++ b/src/shared/project-capabilities.ts
@@ -22,10 +22,12 @@
  * If (2) is ever dropped as friction, this field must move to a machine-local store. That is the
  * trigger, written down where the decision is, not only in the design doc.
  */
-export type ProjectCapability = 'agentBrowserControl'
-// Agent-to-agent messaging adds 'agentMessaging' here (its plan's PR 6 Task 6.1).
+export type ProjectCapability = 'agentBrowserControl' | 'agentMessaging'
 
-export const PROJECT_CAPABILITIES: readonly ProjectCapability[] = ['agentBrowserControl'] as const
+export const PROJECT_CAPABILITIES: readonly ProjectCapability[] = [
+  'agentBrowserControl',
+  'agentMessaging'
+] as const
 
 export interface ProjectCapabilityCopy {
   label: string
@@ -44,6 +46,17 @@ export const PROJECT_CAPABILITY_COPY: Record<ProjectCapability, ProjectCapabilit
       'contain instructions, and the same agent can navigate anywhere and type anywhere. Nodes an ' +
       'agent opens use their own logged-out session, separate from your own browsing. A badge on ' +
       'the node shows when one is being driven, with a Stop button.',
+    cloneWarning:
+      'This setting is saved in the project file (.nodeterm/project.json), so if you commit it, ' +
+      'everyone who clones the repo gets it too.'
+  },
+  agentMessaging: {
+    label: 'Let agents message other agents in this project',
+    description:
+      'Agents in this project can send short messages to other agent nodes in the SAME project — ' +
+      'the text is delivered into the target’s composer and becomes part of its ' +
+      'conversation, so a message can try to steer the agent that reads it. Deliveries go only ' +
+      'to idle, verified agent panes, are rate-limited per sender, and every one leaves a trace.',
     cloneWarning:
       'This setting is saved in the project file (.nodeterm/project.json), so if you commit it, ' +
       'everyone who clones the repo gets it too.'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -478,6 +478,10 @@ export interface Project {
    * machine's recorded 'kept' answer below.
    */
   agentBrowserControl?: boolean
+  /** Per-project capability switch: agents may message other agent nodes in this project. Same
+   *  rules as `agentBrowserControl` above — git-shared hostile input, strict `=== true` read,
+   *  never a grant without this machine's recorded 'kept' (`projectCapabilityGrantedFor`). */
+  agentMessaging?: boolean
   /**
    * MACHINE-LOCAL record of what this machine's user ANSWERED for each capability switch —
    * 'kept' or 'declined', not a bare bit, because a declined switch whose hostile `true`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,6 +22,14 @@ export interface PtyCreateOptions {
    */
   persistKey?: string
   /**
+   * The machine-local id (`IndexEntryV3.id`) of the project this node belongs to, as the renderer
+   * knows it at the create call. Recorded in the runtime pane-ownership ledger on a GENUINE FRESH
+   * spawn (`agents/pane-ownership.ts`) so agent messaging can prove which project actually spawned
+   * a pane rather than trusting the git-shared, forgeable `project.json`. Optional: absent ⇒ the
+   * pane is left unproven and messaging to it fails closed (never derived from the file id).
+   */
+  ownerProjectId?: string
+  /**
    * Which agent runs in this session (claude/codex/gemini/custom). Drives the hook env
    * injected at spawn. Defaults to 'claude' for backward compat; the renderer passes a
    * real value in a later phase.


### PR DESCRIPTION
Messaging PR 6 of the agent-messaging series — now a small PR by design: the generic per-project capability mechanism landed in #213, and #212 shipped the `send`/`reply`/`notify` verbs fail-closed behind `messagingEnabled: () => false`. This PR is the wiring between the two.

**The verbs go live ONLY per project, and only with BOTH halves of the grant:** the strict `agentMessaging === true` flag in the git-shared `.nodeterm/project.json` AND this machine's recorded **'kept'** answer to the one-time clone notice (`projectCapabilityGrantedFor`). A flag that is on but unanswered, a recorded decline, a forged file-borne `capabilityAck`, and a hand-edited `"true"` all keep every delivery refused as `notPermitted (switch-off)`.

## Commits

**`fc1e1003` — feat(project): agentMessaging joins the capability registry**
One line in `PROJECT_CAPABILITIES` plus a `PROJECT_CAPABILITY_COPY` entry (`src/shared/project-capabilities.ts`), and `agentMessaging?: boolean` on `Project`/`ProjectFileV1`. Everything else appears generated by #213's mechanism, with zero new code:
- the strict `=== true` validation, hostile-input refusals, and the no-bytes-when-off file round-trip (the registry-iterating suites now run for the new key);
- the one-time clone notice with the machine-local kept/declined ack — a new test drives a cloned `agentMessaging: true` through the real dialog and pins messaging's own copy;
- the Settings → Agents row (rows are generated from the registry; no hand-written row, per the #213 design).

**`042aa409` — feat(agents): messagingEnabled is the capability GRANT, read per call off the store**
The real work:
- `WorkspaceStore.capabilityProjectFor(projectId)` — the capability view of one project: strict flags from the shared file, answers from the machine-local index entry only (a repo hand-carrying `capabilityAck` is a forgery and is never read). Same id semantics as `persistedCanvases`, so delivery scope and the switch agree on project identity.
- `messagingEnabledVia(getProject)` in `src/main/agent-messaging.ts` — the production wiring as one testable call: `projectCapabilityGrantedFor(getProject(projectId), 'agentMessaging')`. **Never `projectCapabilityFlagInFile`** — the raw file bit answers `true` in exactly the states that must refuse (pending notice, recorded decline), and the new suite goes red on that swap (the #213 review's I2 trap, mutation-checked).
- `src/main/index.ts` replaces `messagingEnabled: () => false` with the wired check. Read per call: a decline or an off-toggle refuses the very next delivery.

## Evidence

- `src/main/agent-messaging-switch.test.ts` runs the REAL control path (`deliverFromControl`), half of it over a REAL `WorkspaceStore` on disk: (a) switch absent → `switch-off` (the #212 test also stays green), (b) flag true + ack pending or declined → still refused, (c) flag true + 'kept' → delivered to the pane-write layer. Forged file-ack and hand-edited `"true"` cases run through a fresh store load.
- Mutation checks: registry-drop 3/3 red; wiring 4/4 red (grant→flag swap 5 tests red, file-borne ack accepted, entry ack dropped for cwd and for inline entries).
- `npm run typecheck` clean; full `npx vitest run` at HEAD: **465 files / 6474 tests passed, 0 failed** (1 file / 12 tests skipped = the opt-in Docker SSH suite).

Surfaces: Desktop is the only surface with the verbs; the Server Edition still answers `control-unsupported-on-this-edition` (untouched); mobile is unaffected (never a sender).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Fix round 1 (review: spec PASS / quality CHANGES-REQUIRED)

**I-1 (Important — confused deputy, closed): `6b867a6d`.** The switch was evaluated against the source's project while panes are keyed by the bare node id globally, so a granted project A whose file listed ungranted project B's node id could deliver into B's live pane once A's clone notice was kept (proved by execution in review). The grant now gates the project that OWNS the target pane: `resolveDeliveryScope` computes the set of projects claiming the target id — more than one owner is refused as the new, named `notPermitted (ambiguous-target-node-id)` (never "pick the sender's"), and a unique target resolves to its owning project, whose grant the switch then checks. The reviewer's exact scenario runs as a test over a REAL WorkspaceStore (granted A listing ungranted B's node id → refused, nothing written), plus scope-unit coverage for both directions, the named reason carried through `decideDelivery`, terminality, and the unique-target control. Mutation-checked: reverting to source-project resolution turns the attack test back into `delivered` (3 red); renaming the refusal to `cross-project` also goes red. The scope docblock's "cannot close" residual note is rewritten to state what now holds.

**M-1 (report tally):** corrected in the report — the registry-drop mutation's 3 red span two files (2 in `project-capabilities.test.ts`, 1 in the Settings-row suite).

**M-2 (CapabilityNotice mount pin):** carried forward as a tracked concern — a real reachability assertion needs a full Canvas.tsx mount (9.2k-line monolith, no harness), and a source-text grep test is this repo's documented anti-pattern. Fails safe if regressed (permanently switch-off). Listed for device verification.

Full `npx vitest run` at `6b867a6d`: **465 files / 6477 tests passed, 0 failed** (12 skipped = opt-in Docker suite).


---

## Fix round 2 (re-review: new CRITICAL — the round-1 residual was FAIL-OPEN)

**`9ecd0c5f` — prove pane ownership at runtime.** The round-1 ambiguity check needs two store claimants; when the victim's real project is ABSENT from the persisted store, a granted hostile project A that lists the live pane's node id is the SOLE store claimant, so ambiguity never fires, scope resolves same-project to A, A's switch passes, and the envelope reaches the victim's one global tmux pane (driven end-to-end: `delivered`, `reply.ok:true`). `project.json`'s node-set is attacker-writable, so it cannot be the ownership authority.

The distinguishing fact is runtime — which project's `create()` actually spawned the pane. A new in-memory ledger (`src/core/agents/pane-ownership.ts`) records `nodeId → owning projectId` on a GENUINE fresh spawn only (`spawnNew`, gated on the manager's existing `fresh` signal), so an attach/co-attach never claims a session another project spawned; the owner is the renderer's machine-local project id (`PtyCreateOptions.ownerProjectId`), never the file id. The delivery gate reads the LEDGER for the target's true owner and evaluates the grant against THAT, with the store as a cross-check. No entry (restart / never spawned here) or a disagreement → refused with the new terminal reason `unproven-target-owner`.

**Cold state is fail-CLOSED by decision:** after an app restart the tmux server survives and re-open ATTACHES (`fresh=false`, nothing recorded), so a re-attached pane is unproven and messaging to it is refused until a true respawn. No repopulation on attach — no cross-restart signal exists that a hostile agent's shell could not also write.

**Tests (real store + real ledger, mutation-checked):** the re-reviewer's exact attack → refused, `sent:[]` (red-first: pre-fix `delivered`); ledger-empty restart → refused; ledger owner disagrees with a granted sole claimant → refused; legitimate self-delivery → delivered. Mutations 2/2: bypass the ledger (fall back to store `projectId`) flips the attack to `delivered`; drop the `owner !== projectId` cross-check → attack+disagree red.

**Residual stated plainly:** re-attached-after-restart panes fail closed until respawn (safe, deliberate); a durable userData ledger would remove that cost at the `workspace.json` trust level (future work). The `fresh`-gate itself is covered by unit semantics + the documented `spawnNew` contract, not a `node-pty` spawn/attach integration test (environment-flaky) — flagged for device verification.

Full `npx vitest run` at `9ecd0c5f`: **466 files / 6487 tests passed, 0 failed** (12 skipped = opt-in Docker suite).


---

## Fix round 3 (re-review: SECURITY-CLOSED — two Minors before merge)

**`f2a99056` — kanban modal ownership parity + an automated pin for the fresh-gate.**

- **Minor 1 (parity):** `ModalTerminal.tsx` was the one renderer `transport.create` site not threading `ownerProjectId`. Harmless when it co-attaches to an already-proven pane, but as the FIRST/sole fresh spawner of a node (a card for a node whose project is not the active canvas) that pane recorded as unproven and messaging to it failed closed. It now passes the CARD's project (the one the modal already resolved), not the active canvas id. Both create sites thread the owner identically.
- **Minor 2 (doc):** corrected the residual note — phones spawn through the host renderer's `TerminalNode`, which threads `ownerProjectId`, so there is no phone/relay fresh-spawn path that fails closed. The only residual is the deliberate re-attach-after-restart refusal.
- **Optional (taken):** extracted the load-bearing fresh-gate as the pure `shouldRecordOwnership(fresh, persistKey, owner)` with its own unit suite; a mutation dropping the `fresh === true` leg (record on attach) turns it red — the fresh-gate now has an automated guard, not just a co-located comment.

Full `npx vitest run` at `f2a99056`: **466 files / 6491 tests passed, 0 failed** (12 skipped = opt-in Docker suite); typecheck clean.
