### PR TITLE
feat(agents): deliver to busy agents through a bounded queue

### DIFF
--- a/src/core/agents/agent-message.ts
+++ b/src/core/agents/agent-message.ts
@@ -25,6 +25,22 @@ import type { DeliveryTraceInput } from './agent-message-trace'
  * tested against a real tmux pane and a real reader (`agent-message.realtty.test.ts`). A structural
  * test can only catch the tricks it was taught, and this repo has twice shipped a defect that a
  * hand-rolled parser passed and a real reader caught.
+ *
+ * ── THE RESIDUAL RISK THAT NO GATE CLOSES (recorded here, not only in the design) ────────────────
+ *
+ * hook-idle ≠ nobody typing. A human's half-composed draft in a genuinely idle agent's composer
+ * gets the message appended and the Enter submits both. That is the literal 2026-07-16 objection, it
+ * is undetectable from hooks, and G4 plus the trace are what make it diagnosable rather than
+ * invisible.
+ *
+ * ── WHAT IS DELIBERATELY NOT IN v1: CATCH-UP AFTER RESTART ───────────────────────────────────────
+ *
+ * PR 7's deliver-on-idle queue is IN-MEMORY (`delivery-queue.ts`), and its existence must not imply
+ * a persisted one. Catch-up after an app restart is NOT built. A persisted queue would need the same
+ * TTL AND a "stale — the sender may have moved on" marker, because `--resume` can land the message
+ * in a conversation that no longer expects it — and whether an agent given a stale-marked message
+ * behaves better than one given none is a PROMPT question, unverified, to be measured before that
+ * queue is built.
  */
 
 /** How long the receipt waits for the target's own next turn.

--- a/src/core/agents/delivery-queue.test.ts
+++ b/src/core/agents/delivery-queue.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DeliveryQueue,
+  DELIVERY_QUEUE_CAPACITY,
+  DELIVERY_QUEUE_TTL_MS,
+  type DeliveryQueueDeps,
+  type QueuedDeliveryRequest,
+  type CancelTimer
+} from './delivery-queue'
+import type { AgentMessageOutcome } from './agent-message-decide'
+
+/**
+ * The bounded per-target queue, every rule driven with a fake clock, a fake scheduler and a
+ * programmable `deliver` — so TTL expiry and flush-time re-validation are deterministic rather than
+ * timing-dependent. The load-bearing test is the third-from-last: a grant revoked WHILE a message is
+ * queued is dropped, not delivered, because the flush re-runs the whole delivery instead of trusting
+ * the decision that queued it.
+ */
+
+interface FakeTimer {
+  ms: number
+  fn: () => void
+  cancelled: boolean
+}
+
+function harness(over: Partial<DeliveryQueueDeps> = {}) {
+  let clock = 1000
+  const traced: { outcome: string; sourceNodeId: string; targetNodeId: string }[] = []
+  const expired: { req: QueuedDeliveryRequest; info: { traceId: string; queuedForMs: number } }[] = []
+  const flushed: { req: QueuedDeliveryRequest; outcome: AgentMessageOutcome }[] = []
+  const woken: string[] = []
+  const timers: FakeTimer[] = []
+  let nextOutcome: AgentMessageOutcome = { kind: 'delivered', traceId: 'd', traced: 'memory', receipt: 'observed', signal: 'newTurn' }
+  const delivered: QueuedDeliveryRequest[] = []
+
+  const deps: DeliveryQueueDeps = {
+    now: () => clock,
+    deliver: async (req) => {
+      delivered.push(req)
+      return nextOutcome
+    },
+    trace: async (input) => {
+      traced.push({ outcome: input.outcome, sourceNodeId: input.sourceNodeId, targetNodeId: input.targetNodeId })
+      return { traceId: `trace-${traced.length}`, traced: 'memory' }
+    },
+    wake: (id) => woken.push(id),
+    onExpired: (req, info) => expired.push({ req, info }),
+    onFlushed: (req, outcome) => flushed.push({ req, outcome }),
+    schedule: (ms, fn): CancelTimer => {
+      const t: FakeTimer = { ms, fn, cancelled: false }
+      timers.push(t)
+      return () => {
+        t.cancelled = true
+      }
+    },
+    ...over
+  }
+
+  return {
+    deps,
+    traced,
+    expired,
+    flushed,
+    woken,
+    timers,
+    delivered,
+    setClock: (n: number): void => {
+      clock = n
+    },
+    setOutcome: (o: AgentMessageOutcome): void => {
+      nextOutcome = o
+    },
+    /** Fire the most recently armed (not-yet-cancelled) timer — a TTL lapse. */
+    fireLatestTimer: (): void => {
+      const live = timers.filter((t) => !t.cancelled)
+      live[live.length - 1].fn()
+    }
+  }
+}
+
+const req = (over: Partial<QueuedDeliveryRequest> = {}): QueuedDeliveryRequest => ({
+  sourceNodeId: 'src',
+  targetNodeId: 'dst',
+  sourceTitle: 'Alpha',
+  body: 'ping',
+  ...over
+})
+
+describe('DeliveryQueue', () => {
+  it('enqueue returns a queued receipt with position + TTL, and traces `queued`', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps)
+    const out = await q.enqueue(req())
+    expect(out).toEqual({ kind: 'queued', traceId: 'trace-1', position: 1, ttlMs: DELIVERY_QUEUE_TTL_MS })
+    expect(q.depth('dst')).toBe(1)
+    expect(h.traced).toEqual([{ outcome: 'queued', sourceNodeId: 'src', targetNodeId: 'dst' }])
+  })
+
+  it('positions count up per target', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps)
+    const a = await q.enqueue(req({ body: 'a' }))
+    const b = await q.enqueue(req({ body: 'b' }))
+    expect(a).toMatchObject({ kind: 'queued', position: 1 })
+    expect(b).toMatchObject({ kind: 'queued', position: 2 })
+    expect(q.depth('dst')).toBe(2)
+  })
+
+  it('refuses with `queueFull` at capacity — never drops an accepted message', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps, { capacity: 2 })
+    await q.enqueue(req({ body: 'a' }))
+    await q.enqueue(req({ body: 'b' }))
+    const out = await q.enqueue(req({ body: 'c' }))
+    expect(out).toEqual({ kind: 'queueFull', capacity: 2 })
+    // The two already queued are untouched — capacity refuses the new one, it does not evict.
+    expect(q.depth('dst')).toBe(2)
+  })
+
+  it('flushes on idle: delivers oldest-first and empties the queue', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps)
+    await q.enqueue(req({ body: 'first' }))
+    await q.enqueue(req({ body: 'second' }))
+    await q.onTargetIdle('dst')
+    expect(h.delivered.map((r) => r.body)).toEqual(['first', 'second'])
+    expect(q.depth('dst')).toBe(0)
+    expect(h.flushed.map((f) => f.outcome.kind)).toEqual(['delivered', 'delivered'])
+  })
+
+  it('a hibernated target is WOKEN on enqueue, before it is idle', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps)
+    await q.enqueue(req(), { hibernated: true })
+    expect(h.woken).toEqual(['dst'])
+    // A merely-busy target is not woken.
+    await q.enqueue(req({ targetNodeId: 'busy' }))
+    expect(h.woken).toEqual(['dst'])
+  })
+
+  // ── THE LOAD-BEARING PROPERTY: flush-time re-validation ────────────────────────────────────────
+  it('DROPS a message whose grant was revoked while it was queued — never delivers it', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps)
+    // Enqueued while the target was busy…
+    await q.enqueue(req({ body: 'secret' }))
+    expect(q.depth('dst')).toBe(1)
+    // …and by flush time the grant is gone: `deliver` (the full re-validated path) now refuses.
+    h.setOutcome({ kind: 'notPermitted', reason: 'switch-off' })
+    await q.onTargetIdle('dst')
+    // It was attempted through the real delivery (which is where the grant is checked) and DROPPED —
+    // not re-queued, not delivered.
+    expect(h.delivered.map((r) => r.body)).toEqual(['secret'])
+    expect(q.depth('dst')).toBe(0)
+    expect(h.flushed).toHaveLength(1)
+    expect(h.flushed[0].outcome).toEqual({ kind: 'notPermitted', reason: 'switch-off' })
+    // Never reported as delivered.
+    expect(h.flushed.some((f) => f.outcome.kind === 'delivered')).toBe(false)
+  })
+
+  it('a still-busy target at flush keeps the message queued (TTL from the original enqueue)', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps)
+    await q.enqueue(req())
+    h.setOutcome({ kind: 'targetBusy', state: 'working' })
+    await q.onTargetIdle('dst')
+    // Attempted, found busy again, put back — not lost, not delivered.
+    expect(h.delivered).toHaveLength(1)
+    expect(q.depth('dst')).toBe(1)
+    expect(h.flushed).toHaveLength(0)
+    // A later idle when it is truly free delivers it.
+    h.setOutcome({ kind: 'delivered', traceId: 'd', traced: 'memory', receipt: 'observed', signal: 'newTurn' })
+    await q.onTargetIdle('dst')
+    expect(q.depth('dst')).toBe(0)
+    expect(h.flushed.map((f) => f.outcome.kind)).toEqual(['delivered'])
+  })
+
+  // ── TTL expiry — never a silent drop ──────────────────────────────────────────────────────────
+  it('a TTL lapse traces `expired` AND tells the sender, then removes the entry', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps, { ttlMs: 1000 })
+    await q.enqueue(req())
+    expect(q.depth('dst')).toBe(1)
+    h.setClock(1000 + 1000) // the TTL has elapsed
+    h.fireLatestTimer()
+    await Promise.resolve() // let the async expiry settle
+    await Promise.resolve()
+    expect(q.depth('dst')).toBe(0)
+    // Both legs: the durable trace and the live notify.
+    expect(h.traced.map((t) => t.outcome)).toContain('expired')
+    expect(h.expired).toHaveLength(1)
+    expect(h.expired[0].info.queuedForMs).toBe(1000)
+    expect(h.expired[0].info.traceId).toBeTruthy()
+  })
+
+  it('an expiry timer that fires AFTER the entry already flushed is a no-op (no double drop)', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps, { ttlMs: 1000 })
+    await q.enqueue(req())
+    await q.onTargetIdle('dst') // delivered — the entry is gone, its timer cancelled
+    expect(q.depth('dst')).toBe(0)
+    // A stale timer fire (belt-and-braces: the entry is no longer in any list) must not expire.
+    const before = h.expired.length
+    h.timers[0].fn()
+    await Promise.resolve()
+    expect(h.expired.length).toBe(before)
+  })
+
+  it('forget() expires every queued message for an ending session — not a silent drop', async () => {
+    const h = harness()
+    const q = new DeliveryQueue(h.deps)
+    await q.enqueue(req({ body: 'a' }))
+    await q.enqueue(req({ body: 'b' }))
+    await q.forget('dst')
+    expect(q.depth('dst')).toBe(0)
+    expect(h.expired.map((e) => e.req.body)).toEqual(['a', 'b'])
+    expect(h.timers.every((t) => t.cancelled)).toBe(true)
+  })
+
+  it('the constants are finite and positive — a real bound and a real TTL', () => {
+    expect(DELIVERY_QUEUE_CAPACITY).toBeGreaterThan(0)
+    expect(Number.isFinite(DELIVERY_QUEUE_CAPACITY)).toBe(true)
+    expect(DELIVERY_QUEUE_TTL_MS).toBeGreaterThan(0)
+    expect(Number.isFinite(DELIVERY_QUEUE_TTL_MS)).toBe(true)
+  })
+})

--- a/src/core/agents/delivery-queue.test.ts
+++ b/src/core/agents/delivery-queue.test.ts
@@ -206,17 +206,6 @@ describe('DeliveryQueue', () => {
     expect(h.expired.length).toBe(before)
   })
 
-  it('forget() expires every queued message for an ending session — not a silent drop', async () => {
-    const h = harness()
-    const q = new DeliveryQueue(h.deps)
-    await q.enqueue(req({ body: 'a' }))
-    await q.enqueue(req({ body: 'b' }))
-    await q.forget('dst')
-    expect(q.depth('dst')).toBe(0)
-    expect(h.expired.map((e) => e.req.body)).toEqual(['a', 'b'])
-    expect(h.timers.every((t) => t.cancelled)).toBe(true)
-  })
-
   it('the constants are finite and positive — a real bound and a real TTL', () => {
     expect(DELIVERY_QUEUE_CAPACITY).toBeGreaterThan(0)
     expect(Number.isFinite(DELIVERY_QUEUE_CAPACITY)).toBe(true)

--- a/src/core/agents/delivery-queue.ts
+++ b/src/core/agents/delivery-queue.ts
@@ -264,28 +264,6 @@ export class DeliveryQueue {
     this.deps.onExpired?.(entry.req, { traceId: t.traceId, queuedForMs })
   }
 
-  /** Drop everything for a node whose session is ending (delete/recycle) — its queued messages can
-   *  never land in the pane that is going away. Traces each as `expired` so the drop is not silent. */
-  async forget(nodeId: string): Promise<void> {
-    const list = this.queues.get(nodeId)
-    if (!list) return
-    this.queues.delete(nodeId)
-    for (const entry of list) await this.expireDetached(entry)
-  }
-
-  private async expireDetached(entry: QueueEntry): Promise<void> {
-    entry.cancelTimer()
-    const queuedForMs = this.deps.now() - entry.enqueuedAt
-    const t = await this.deps.trace({
-      sourceNodeId: entry.req.sourceNodeId,
-      sourceTitle: entry.req.sourceTitle,
-      targetNodeId: entry.req.targetNodeId,
-      outcome: 'expired',
-      bodyChars: entry.req.body.length
-    })
-    this.deps.onExpired?.(entry.req, { traceId: t.traceId, queuedForMs })
-  }
-
   /** Test seam / shutdown: cancel every timer and drop every queue WITHOUT tracing (a teardown is
    *  not an expiry the sender needs to hear about). */
   resetForTests(): void {

--- a/src/core/agents/delivery-queue.ts
+++ b/src/core/agents/delivery-queue.ts
@@ -1,0 +1,295 @@
+import type { AgentMessageOutcome } from './agent-message-decide'
+import { RETRYABLE } from './agent-message-decide'
+import type { DeliveryTraceInput } from './agent-message-trace'
+
+/**
+ * DELIVER-ON-IDLE — a bounded, per-target queue with a TTL, and never a silent drop.
+ *
+ * ── WHY THIS EXISTS ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Gate 2 refuses a BUSY target (`targetBusy`) and a target between sessions
+ * (`targetNotIdleUnknown`), and Eco hibernation leaves an idle node's pane on a SHELL — so
+ * `targetNotAgentPane` refuses it *forever* on exactly the nodes an orchestration is most likely to
+ * message (the ones sitting idle). "Retry in a moment" pushes that onto a language model with a rate
+ * limiter in front of it: a busy-loop that burns tokens. Wake-then-deliver is therefore not a
+ * nicety — it is what makes messaging usable across a long-running canvas.
+ *
+ * So a `targetBusy` / hibernated target with queueing on is ENQUEUED, and delivered when the target
+ * next goes idle. `queued` is NOT `delivered`: the bytes have not reached the pane, and the receipt
+ * (Task 3.4) is what will close the loop once they do. A queue full stops the sender loudly
+ * (`queueFull`), and a message that waits out its TTL EXPIRES loudly — to the trace and to the
+ * sender — because a silent drop is the one outcome a security core may never have.
+ *
+ * ── THE DECSET-2004 MEASUREMENT MADE THIS SAFE (2026-08-15, this host) ───────────────────────────
+ *
+ * Deliver-on-idle only works if a queued message can be framed into the target's pane WITHOUT a
+ * per-delivery bracketed-paste probe. Measured: all four agent CLIs (claude, codex, gemini,
+ * opencode) keep DECSET 2004 ON at idle AND during startup, twice each, no flapping — so
+ * `paste-buffer -p` frames every flush, including one into a still-starting agent after a wake. The
+ * ONE unsafe surface is a NON-agent pane (a plain REPL/terminal): 2004 OFF ⇒ the payload lands as
+ * raw keystrokes, one submit per newline. This queue therefore gates on NODE TYPE, not on a runtime
+ * probe: it only ever enqueues for a target whose delivery attempt refused as `targetBusy` /
+ * `hibernated` — i.e. a pane gate 1 already judged an AGENT pane — and the flush re-runs the whole
+ * delivery (gate 1 included), so a pane that became a terminal while queued is refused, never
+ * sprayed with unframed lines.
+ *
+ * ── FLUSH-TIME RE-VALIDATION IS THE LOAD-BEARING PROPERTY ───────────────────────────────────────
+ *
+ * A message queued for a busy agent must NOT trust the decision that queued it. Ownership can change
+ * (the pane is respawned by another project), the grant can be revoked (the switch turned off, the
+ * clone notice declined), the flow budget can move — all while the message waits. So the flush does
+ * not cache anything: it calls `deps.deliver(req)` again, which is the SAME end-to-end path the verb
+ * took (scope → ownership → grant → flow → `deliverAgentMessage`). A grant revoked while queued
+ * therefore comes back `notPermitted` at flush and the message is DROPPED, never delivered — pinned
+ * by `delivery-queue.test.ts`, which flips the injected `deliver` from `targetBusy` to
+ * `notPermitted` between enqueue and flush and asserts nothing reached the pane.
+ *
+ * ── SHIPS ON BOTH SHELLS, USED ON ONE ──────────────────────────────────────────────────────────
+ *
+ * Pure `src/core`: no electron, no main import (`no-electron.test.ts`). Every side effect — the
+ * clock, the delivery, the wake, the trace, the sender-notify, the timer — is injected, so the whole
+ * lifecycle is driven without a pty or a window. The desktop is the only shell that wires a consumer
+ * (messaging does not exist on the Server Edition, Task 5.3); the module still compiles and ships
+ * there, like everything else in this directory.
+ */
+
+/** How long a message waits queued before it expires. Long enough for an orchestration turn (which
+ *  can run minutes), bounded so a target that never goes idle cannot pin a message forever. */
+export const DELIVERY_QUEUE_TTL_MS = 5 * 60_000
+
+/** How many messages one target may have queued at once. Small and per-target: an unbounded queue
+ *  is a memory-DoS surface, and refusing at the bound (rather than dropping the oldest) keeps FIFO
+ *  fairness and tells the sender loudly instead of silently discarding a message already accepted. */
+export const DELIVERY_QUEUE_CAPACITY = 16
+
+/** The request the queue carries — opaque to the queue, handed straight back to `deps.deliver`. The
+ *  queue keys everything on `targetNodeId` (the flush trigger and the per-target bound) and
+ *  `sourceNodeId` (so an expiry can name who to tell); the rest travels untouched. */
+export interface QueuedDeliveryRequest {
+  sourceNodeId: string
+  targetNodeId: string
+  sourceTitle: string
+  /** For the expiry trace's `bodyChars` — the body itself is never traced (see agent-message-trace). */
+  body: string
+  [k: string]: unknown
+}
+
+/** Cancels a scheduled timer. Returned by `schedule`. */
+export type CancelTimer = () => void
+
+export interface DeliveryQueueDeps {
+  now(): number
+  /**
+   * The FULL, re-validated delivery — in production `deliverFromControl`. Called on every flush, so
+   * the whole gate chain (scope, ownership, grant, flow, `deliverAgentMessage`) runs again against
+   * live state. This is what makes the queue safe: it caches no authorization decision.
+   */
+  deliver(req: QueuedDeliveryRequest): Promise<AgentMessageOutcome>
+  /** Record an outcome (`recordDelivery`). The queue traces `queued` on enqueue and `expired` on a
+   *  TTL lapse; the flush's own outcomes are traced inside `deliver`. */
+  trace(input: DeliveryTraceInput): Promise<{ traceId: string; traced: string }>
+  /**
+   * Wake a hibernated target through the existing registry (`agent-restart.ts` hibernate/wake
+   * pair). Optional: a target that is merely busy (not hibernated) needs no wake, and a shell with
+   * no registry (the Server Edition) wires nothing. A wake is fire-and-forget here — the target's
+   * eventual idle event is what triggers the flush, not this call's resolution.
+   */
+  wake?(nodeId: string): void
+  /**
+   * Tell the SENDER a queued message expired. The trace is the durable leg (always written); this
+   * is the live leg — the shell surfaces it (a board-log line for the sender, a push). Optional so
+   * the core can be tested without a notify channel, but a production wiring that omits it turns the
+   * "never a silent drop" guarantee into "durable-only", so the desktop always supplies it.
+   */
+  onExpired?(req: QueuedDeliveryRequest, info: { traceId: string; queuedForMs: number }): void
+  /** Tell the sender how a flush ended (delivered, or refused because the world changed under it).
+   *  Same optionality reasoning as `onExpired`. */
+  onFlushed?(req: QueuedDeliveryRequest, outcome: AgentMessageOutcome): void
+  /** Arm a one-shot timer, returning its cancel. Injected so tests drive TTL expiry deterministically
+   *  instead of waiting real milliseconds; defaults to `setTimeout`/`clearTimeout`. */
+  schedule?(ms: number, fn: () => void): CancelTimer
+}
+
+interface QueueEntry {
+  req: QueuedDeliveryRequest
+  enqueuedAt: number
+  ttlMs: number
+  cancelTimer: CancelTimer
+  /** The traceId minted when this was queued, reused on its expiry so the two entries correlate. */
+  queuedTraceId: string
+}
+
+/** Outcomes that mean "the target still is not ready, come back" — a flush that gets one of these
+ *  RE-QUEUES the entry at the front (its TTL keeps counting from the original enqueue) and STOPS
+ *  draining, because one idle event does not promise the target stays idle. Derived from `RETRYABLE`
+ *  minus the two outcomes the queue itself produces (`queueFull`, `expired`) — so `deliver`'s
+ *  retryable outcomes (`rateLimited`, `targetBusy`, `targetNotIdleUnknown`, `targetStatusStale`) all
+ *  wait for the NEXT idle, and a new retryable outcome added upstream is handled here the moment it
+ *  exists rather than silently dropped. `rateLimited` waiting for the next idle (not re-flushing on a
+ *  timer) is what keeps the queue from spinning against the very limiter that refused it. */
+const REQUEUE_ON: ReadonlySet<AgentMessageOutcome['kind']> = new Set(
+  (Object.keys(RETRYABLE) as AgentMessageOutcome['kind'][]).filter(
+    (k) => RETRYABLE[k] && k !== 'queueFull' && k !== 'expired'
+  )
+)
+
+export class DeliveryQueue {
+  private readonly queues = new Map<string, QueueEntry[]>()
+  private readonly capacity: number
+  private readonly ttlMs: number
+  private readonly schedule: (ms: number, fn: () => void) => CancelTimer
+
+  constructor(
+    private readonly deps: DeliveryQueueDeps,
+    opts: { capacity?: number; ttlMs?: number } = {}
+  ) {
+    this.capacity = opts.capacity ?? DELIVERY_QUEUE_CAPACITY
+    this.ttlMs = opts.ttlMs ?? DELIVERY_QUEUE_TTL_MS
+    this.schedule =
+      deps.schedule ??
+      ((ms, fn): CancelTimer => {
+        const t = setTimeout(fn, ms)
+        return () => clearTimeout(t)
+      })
+  }
+
+  /** How many messages are queued for a target right now — for assertions and a position count. */
+  depth(nodeId: string): number {
+    return this.queues.get(nodeId)?.length ?? 0
+  }
+
+  /**
+   * Enqueue a message whose initial delivery refused as `targetBusy` (or whose target is
+   * hibernated). Returns the `queued` receipt (with its position and TTL) or `queueFull` at the
+   * bound — never enqueues past capacity. A `hibernated` target is woken here, before it is idle;
+   * the wake's eventual idle event is what triggers the flush.
+   */
+  async enqueue(
+    req: QueuedDeliveryRequest,
+    opts: { hibernated?: boolean } = {}
+  ): Promise<
+    Extract<AgentMessageOutcome, { kind: 'queued' } | { kind: 'queueFull' }>
+  > {
+    const list = this.queues.get(req.targetNodeId) ?? []
+    if (list.length >= this.capacity) {
+      // Refused, not dropped-oldest: an accepted message is never silently discarded to make room.
+      return { kind: 'queueFull', capacity: this.capacity }
+    }
+    const now = this.deps.now()
+    const t = await this.deps.trace({
+      sourceNodeId: req.sourceNodeId,
+      sourceTitle: req.sourceTitle,
+      targetNodeId: req.targetNodeId,
+      outcome: 'queued',
+      bodyChars: req.body.length
+    })
+    const entry: QueueEntry = {
+      req,
+      enqueuedAt: now,
+      ttlMs: this.ttlMs,
+      queuedTraceId: t.traceId,
+      cancelTimer: this.schedule(this.ttlMs, () => void this.expire(req.targetNodeId, entry))
+    }
+    list.push(entry)
+    this.queues.set(req.targetNodeId, list)
+    // Kick the wake for a hibernated target so it starts its resume; the flush waits on the idle
+    // event, not on the wake. A busy (non-hibernated) target needs nothing — it will go idle on its
+    // own turn end.
+    if (opts.hibernated) this.deps.wake?.(req.targetNodeId)
+    return { kind: 'queued', traceId: t.traceId, position: list.length, ttlMs: this.ttlMs }
+  }
+
+  /**
+   * The target went idle — flush its queue, oldest first. Each entry is delivered through
+   * `deps.deliver`, which RE-RUNS the whole gate chain against live state (the flush-time
+   * re-validation). An entry whose flush says "still not ready" is put back (its TTL unchanged); any
+   * other outcome is terminal and the entry is gone. Draining stops the moment the target is not
+   * ready again — one idle event does not promise the target stays idle across N deliveries.
+   */
+  async onTargetIdle(nodeId: string): Promise<void> {
+    for (;;) {
+      const list = this.queues.get(nodeId)
+      if (!list || list.length === 0) return
+      const entry = list[0]
+      // Take it off before delivering: a re-entrant idle event (deliver can await a real round-trip)
+      // must not flush the same entry twice. It goes back on failure, at the FRONT, preserving order.
+      list.shift()
+      entry.cancelTimer()
+      const outcome = await this.deps.deliver(entry.req)
+      if (REQUEUE_ON.has(outcome.kind)) {
+        // Not ready yet (busy again, still unverified, or rate-limited): keep it, TTL counting from
+        // its ORIGINAL enqueue, and stop draining — the target is evidently not idle after all.
+        this.requeueFront(nodeId, entry)
+        return
+      }
+      // Terminal: delivered, or a refusal waiting will not fix (notPermitted from a revoked grant,
+      // targetGone, targetNotAgentPane…). The entry is done; tell the sender and move to the next.
+      if (this.queues.get(nodeId)?.length === 0) this.queues.delete(nodeId)
+      this.deps.onFlushed?.(entry.req, outcome)
+    }
+  }
+
+  /** Put an entry back at the front with its TTL re-armed for the time it has LEFT (never reset to a
+   *  full TTL — the wait it has already served counts). A lapsed remainder expires it immediately. */
+  private requeueFront(nodeId: string, entry: QueueEntry): void {
+    const remaining = Math.max(0, entry.ttlMs - (this.deps.now() - entry.enqueuedAt))
+    entry.cancelTimer = this.schedule(remaining, () => void this.expire(nodeId, entry))
+    const list = this.queues.get(nodeId) ?? []
+    list.unshift(entry)
+    this.queues.set(nodeId, list)
+  }
+
+  /**
+   * A queued message waited out its TTL. Remove it, trace `expired`, and tell the sender — both
+   * legs, because a dropped message with no record anywhere is the failure this module refuses to
+   * have. Idempotent against a flush that already removed the entry (the timer can fire in the seam
+   * before its cancel runs).
+   */
+  private async expire(nodeId: string, entry: QueueEntry): Promise<void> {
+    const list = this.queues.get(nodeId)
+    if (!list) return
+    const i = list.indexOf(entry)
+    if (i < 0) return // already delivered/re-queued with a fresh timer — this fire is stale
+    list.splice(i, 1)
+    if (list.length === 0) this.queues.delete(nodeId)
+    entry.cancelTimer()
+    const queuedForMs = this.deps.now() - entry.enqueuedAt
+    const t = await this.deps.trace({
+      sourceNodeId: entry.req.sourceNodeId,
+      sourceTitle: entry.req.sourceTitle,
+      targetNodeId: entry.req.targetNodeId,
+      outcome: 'expired',
+      bodyChars: entry.req.body.length
+    })
+    this.deps.onExpired?.(entry.req, { traceId: t.traceId, queuedForMs })
+  }
+
+  /** Drop everything for a node whose session is ending (delete/recycle) — its queued messages can
+   *  never land in the pane that is going away. Traces each as `expired` so the drop is not silent. */
+  async forget(nodeId: string): Promise<void> {
+    const list = this.queues.get(nodeId)
+    if (!list) return
+    this.queues.delete(nodeId)
+    for (const entry of list) await this.expireDetached(entry)
+  }
+
+  private async expireDetached(entry: QueueEntry): Promise<void> {
+    entry.cancelTimer()
+    const queuedForMs = this.deps.now() - entry.enqueuedAt
+    const t = await this.deps.trace({
+      sourceNodeId: entry.req.sourceNodeId,
+      sourceTitle: entry.req.sourceTitle,
+      targetNodeId: entry.req.targetNodeId,
+      outcome: 'expired',
+      bodyChars: entry.req.body.length
+    })
+    this.deps.onExpired?.(entry.req, { traceId: t.traceId, queuedForMs })
+  }
+
+  /** Test seam / shutdown: cancel every timer and drop every queue WITHOUT tracing (a teardown is
+   *  not an expiry the sender needs to hear about). */
+  resetForTests(): void {
+    for (const list of this.queues.values()) for (const e of list) e.cancelTimer()
+    this.queues.clear()
+  }
+}

--- a/src/core/agents/phone-target-e2e.test.ts
+++ b/src/core/agents/phone-target-e2e.test.ts
@@ -1,0 +1,391 @@
+/**
+ * The owner's requirement, as a test: a session the PHONE spawned can RECEIVE a message.
+ *
+ * It is written as one long test on purpose. The chain has five links and every one of them has
+ * been believed-and-wrong at some point in this feature's history, so a suite of five isolated unit
+ * tests would pass while the chain was broken — which is exactly how rev.3 came to state the
+ * opposite of what the code does. The links, in order:
+ *
+ *   1. HOST STATE — the token file comes from the PERSIST sweep (`refreshNodeTokens`), the real
+ *      mechanism. `ptyManager.create` is NOT involved and is deliberately not used to set this up,
+ *      or the test would pass for the wrong reason and stop protecting the real path.
+ *   2. PHONE-SHAPED SPAWN — exactly the two vars `HookEnv.flags` sets and nothing else (no bearer,
+ *      no port, no token, no agent id, no perm-wait).
+ *   3. THE HOOK POST — driven through the REAL generated managed script against a real `node:http`
+ *      listener with the real `curl`, asserting the headers that actually arrived, judged by the
+ *      real verifier.
+ *   4. GATE 2 — the mirror records the proof from that same verdict, and the pure decider admits it.
+ *   5. DELIVERY — the whole primitive against a REAL tmux pane and a real reader (Global
+ *      Constraint 9), read back with `capture-pane`.
+ *
+ * If this test cannot pass, the answer is NEVER to weaken gate 2 (Finding F2 / Decision A1): a
+ * "the host knows this node id" trust level below `verified` is true of every node on the canvas
+ * including the victim, so it proves the node exists and never that the caller is it.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { spawn, execFileSync } from 'node:child_process'
+import { createServer, type IncomingMessage, type Server } from 'node:http'
+import { mkdirSync, writeFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { initPlatform, resetPlatformForTests } from '../platform'
+import { fakePlatform } from '../platform-fake'
+import { hookServer } from './hook-server'
+import { loadOrCreateNodeAuthSecret, resetNodeAuthSecretForTests } from './node-auth-secret'
+import { verifyNodeToken } from './node-auth-token'
+import { buildManagedScript, MANAGED_SCRIPT_REVISION } from './hooks/managed-script'
+import {
+  initNodeTokens,
+  refreshNodeTokens,
+  sweepNodeToken
+} from './node-token-service'
+import { nodeTokenDir, nodeTokenFilePresent, resetNodeTokenFilesForTests } from './node-token-files'
+import {
+  recordAgentEvent,
+  mirrorEntry,
+  initAgentStatusMirror,
+  _resetForTest,
+  type MirrorEntry
+} from '../agent-status-mirror'
+import {
+  decideDelivery,
+  RETRYABLE,
+  type DeliveryFacts
+} from './agent-message-decide'
+import { deliverAgentMessage, type DeliveryDeps, type DeliveryRequest } from './agent-message'
+import { PANE_OWNER_FMT, foregroundArgvArgs, paneOwnerFrom, parsePaneOwner } from './pane-owner'
+import { localFramedDelivery, runPasteDelivery } from '../tmux-naming'
+
+// ── Real-tool discovery (same rules as agent-message.realtty.test.ts) ───────────────────────────
+function findPasteAwareBash(): string | null {
+  for (const c of ['/usr/local/bin/bash', '/opt/homebrew/bin/bash', '/bin/bash', '/usr/bin/bash']) {
+    if (!existsSync(c)) continue
+    try {
+      const v = execFileSync(c, ['-c', 'echo "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"'], {
+        encoding: 'utf8'
+      }).trim()
+      const [maj, min] = v.split('.').map(Number)
+      if (maj > 5 || (maj === 5 && min >= 1)) return c
+    } catch {
+      /* try the next */
+    }
+  }
+  return null
+}
+function findTmux(): string | null {
+  for (const c of ['/usr/local/bin/tmux', '/opt/homebrew/bin/tmux', '/usr/bin/tmux', '/bin/tmux']) {
+    if (existsSync(c)) return c
+  }
+  return null
+}
+function hasCurl(): boolean {
+  try {
+    return execFileSync('sh', ['-c', 'command -v curl'], { encoding: 'utf8' }).trim().length > 0
+  } catch {
+    return false
+  }
+}
+
+const BASH = findPasteAwareBash()
+const TMUX = findTmux()
+const CURL = hasCurl()
+const NODE_ID = 'phone-1'
+const SESSION = `nt-${NODE_ID}`
+const NONCE = 'PHONEE2E1234'
+
+// The host state under test. `dir` is the fake userDataDir, so `nodeTokenDir()` resolves under it
+// and the persist sweep's tokens are the ones the managed script reads.
+let dir = ''
+let secret: Buffer
+let server: Server | null = null
+let port = 0
+let received: { headers: Record<string, string>; body: string }[] = []
+let waiters: (() => void)[] = []
+
+// tmux
+let sockDir = ''
+let socket = ''
+let tenv: NodeJS.ProcessEnv = {}
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'phone-e2e-'))
+  resetPlatformForTests()
+  resetNodeAuthSecretForTests()
+  resetNodeTokenFilesForTests()
+  hookServer.clearNodeAuthSecretForTests()
+  _resetForTest()
+  initPlatform(fakePlatform({ userDataDir: dir }))
+  initAgentStatusMirror(join(dir, 'agent-status.json'))
+
+  // The hook server's secret arms per-node tokens; capture it so `verifyNodeToken` here judges with
+  // the SAME secret the script's token was minted from.
+  secret = await loadOrCreateNodeAuthSecret()
+  hookServer.setNodeAuthSecret(secret)
+
+  // A real listener the managed script POSTs to (curl over 127.0.0.1) — the stronger of the two
+  // harnesses: it asserts what actually rode the wire, not what an emitter would build.
+  server = createServer((req: IncomingMessage, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (c: Buffer) => chunks.push(c))
+    req.on('end', () => {
+      const headers: Record<string, string> = {}
+      for (const [k, v] of Object.entries(req.headers)) if (typeof v === 'string') headers[k] = v
+      received.push({ headers, body: Buffer.concat(chunks).toString('utf8') })
+      res.writeHead(204)
+      res.end()
+      for (const w of waiters.splice(0)) w()
+    })
+  })
+  await new Promise<void>((resolve) => {
+    server!.listen(0, '127.0.0.1', () => {
+      const addr = server!.address()
+      if (addr && typeof addr === 'object') port = addr.port
+      resolve()
+    })
+  })
+
+  if (TMUX) {
+    sockDir = mkdtempSync(join(tmpdir(), 'phe-sk-'))
+    socket = `nt-phe-${process.pid}-${Math.random().toString(36).slice(2, 8)}`
+    tenv = { ...process.env, TMUX_TMPDIR: sockDir }
+  }
+})
+
+afterAll(() => {
+  server?.close()
+  if (TMUX && socket) {
+    try {
+      execFileSync(TMUX, ['-L', socket, 'kill-server'], { env: tenv, stdio: 'ignore' })
+    } catch {
+      /* nothing started */
+    }
+  }
+  hookServer.clearNodeAuthSecretForTests()
+  resetNodeAuthSecretForTests()
+  resetNodeTokenFilesForTests()
+  _resetForTest()
+  resetPlatformForTests()
+  for (const d of [dir, sockDir]) if (d) rmSync(d, { recursive: true, force: true })
+})
+
+// ── Harness helpers ─────────────────────────────────────────────────────────────────────────────
+
+function nextPost(ms = 5000): Promise<{ headers: Record<string, string>; body: string }> {
+  if (received.length > 0) return Promise.resolve(received[received.length - 1])
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no POST arrived')), ms)
+    waiters.push(() => {
+      clearTimeout(timer)
+      resolve(received[received.length - 1])
+    })
+  })
+}
+
+/** The endpoint file the host wrote (0600), pointing at the REAL `nodeTokenDir()` the persist sweep
+ *  materialised into. */
+function writeEndpointFile(): string {
+  const p = join(dir, 'hook-endpoint.env')
+  writeFileSync(
+    p,
+    `NODETERM_HOOK_PORT=${port}\nNODETERM_HOOK_TOKEN=bearer-xyz\nNODETERM_HOOK_VERSION=2\n` +
+      `NODETERM_NODE_TOKEN_DIR=${nodeTokenDir()}\n`,
+    { encoding: 'utf8', mode: 0o600 }
+  )
+  return p
+}
+
+/** The phone's spawn, minus tmux: `sh <script>` with EXACTLY `HookEnv.flags`' two vars and a fresh
+ *  HOME (so the failover glob finds nothing of its own). */
+function runManagedScript(scriptPath: string, endpoint: string): Promise<number> {
+  const home = join(dir, 'phone-home')
+  mkdirSync(join(home, '.nodeterm'), { recursive: true })
+  return new Promise((resolve) => {
+    const child = spawn('sh', [scriptPath], {
+      env: {
+        HOME: home,
+        PATH: process.env.PATH ?? '',
+        NODETERM_HOOK_ENDPOINT: endpoint,
+        NODETERM_NODE_ID: NODE_ID
+      },
+      stdio: ['pipe', 'ignore', 'ignore']
+    })
+    child.stdin.end('{"hook_event_name":"Stop","session_id":"s1"}')
+    child.on('close', (code) => resolve(code ?? -1))
+  })
+}
+
+const tmux = (...args: string[]): string =>
+  execFileSync(TMUX as string, ['-L', socket, ...args], { env: tenv, encoding: 'utf8' })
+
+function capturePane(session: string): string {
+  try {
+    return tmux('capture-pane', '-p', '-t', session)
+  } catch {
+    return ''
+  }
+}
+
+function waitFor(cond: () => boolean, ms: number, what: string): void {
+  const until = Date.now() + ms
+  while (Date.now() < until) {
+    if (cond()) return
+    execFileSync('sleep', ['0.05'])
+  }
+  throw new Error(`timed out waiting for ${what}`)
+}
+
+function startAgentPane(session: string): void {
+  tmux(
+    'new-session', '-d', '-s', session, '-x', '200', '-y', '40',
+    `${BASH} -c 'exec -a claude ${BASH} --norc --noprofile -i'`
+  )
+  waitFor(() => capturePane(session).includes('#') || capturePane(session).includes('$'), 5000, 'a prompt')
+}
+
+function realPaneOwner(session: string): DeliveryDeps['paneOwner'] {
+  return async () => {
+    const identity = parsePaneOwner(tmux('display-message', '-p', '-t', session, PANE_OWNER_FMT))
+    if (!identity) return null
+    const call = foregroundArgvArgs(identity.tty)
+    if (!call) return null
+    return paneOwnerFrom(identity, execFileSync(call.bin, call.args, { encoding: 'utf8' }))
+  }
+}
+
+function realSendFramed(session: string): DeliveryDeps['sendFramed'] {
+  return async (_id, payload) => {
+    const plan = localFramedDelivery(socket, session, payload)
+    if (!plan) return false
+    return runPasteDelivery(plan, async (args, input) => {
+      execFileSync(TMUX as string, args, { env: tenv, input, encoding: 'utf8' })
+    })
+  }
+}
+
+/** DeliveryFacts for the pure decider — live mirror entry + live token-file presence, pane defaulted
+ *  to `agent` (gate 1 is proven separately against the real kernel in link 5). */
+function factsFor(nodeId: string, over: Partial<DeliveryFacts> = {}): DeliveryFacts {
+  return {
+    targetLive: true,
+    pane: 'agent',
+    target: mirrorEntry(nodeId),
+    tokenFilePresent: nodeTokenFilePresent(nodeId),
+    ...over
+  }
+}
+
+// ── The chain ─────────────────────────────────────────────────────────────────────────────────
+
+const full = BASH && TMUX && CURL ? it : it.skip
+
+describe('a phone-spawned session is a valid messaging target', () => {
+  full(
+    'verifies, is admitted by gate 2, and receives the envelope',
+    async () => {
+      received = []
+      waiters = []
+
+      // 1. HOST STATE — via the PERSIST sweep, not the spawn path.
+      initNodeTokens({ canvases: () => [{ id: 'p-phone', nodes: [{ id: NODE_ID }] }] })
+      refreshNodeTokens({ force: true })
+      expect(nodeTokenFilePresent(NODE_ID)).toBe(true)
+
+      // 2 + 3. PHONE-SHAPED SPAWN → the real generated script → the real POST.
+      const scriptPath = join(dir, 'hook.sh')
+      writeFileSync(scriptPath, buildManagedScript('claude', null), { encoding: 'utf8', mode: 0o755 })
+      const endpoint = writeEndpointFile()
+      expect(await runManagedScript(scriptPath, endpoint)).toBe(0)
+      const post = await nextPost()
+
+      const token = post.headers['x-nodeterm-node-token']
+      expect(token).toBeTruthy()
+      expect(post.headers['x-nodeterm-hook-client']).toBe(String(MANAGED_SCRIPT_REVISION))
+      const verdict = verifyNodeToken(secret, NODE_ID, token)
+      expect(verdict).toBe('verified')
+
+      // 4. GATE 2 — record the proof from THAT verdict (the seam hook-server drives in production is
+      //    pinned by hook-identity-enforcement.test.ts; here the same real token, judged by the same
+      //    verifier, drives the same reducer), then let the pure decider judge.
+      recordAgentEvent({
+        nodeId: NODE_ID,
+        agentId: 'claude',
+        kind: 'state',
+        state: 'done',
+        sessionId: 's1',
+        verified: verdict === 'verified',
+        clientRevision: Number(post.headers['x-nodeterm-hook-client'])
+      })
+      const entry = mirrorEntry(NODE_ID) as MirrorEntry
+      expect(entry.stateVerified).toBe(true)
+      expect(entry.clientRevision).toBe(MANAGED_SCRIPT_REVISION)
+      expect(decideDelivery(factsFor(NODE_ID))).toEqual({ kind: 'proceed' })
+
+      // 5. DELIVERY — the whole primitive against a REAL tmux pane and a real reader.
+      startAgentPane(SESSION)
+      const deps: DeliveryDeps = {
+        paneOwner: realPaneOwner(SESSION),
+        bracketPasteRequested: async () => true,
+        sendFramed: realSendFramed(SESSION),
+        mirrorEntry: (id) => mirrorEntry(id),
+        tokenFilePresent: (id) => nodeTokenFilePresent(id),
+        lock: async (_id, fn) => fn(),
+        now: () => 1,
+        nonce: () => NONCE,
+        trace: async () => ({ traceId: 'e2e-1', traced: 'memory' }),
+        // A bash pane emits no hook events, so the receipt is supplied here as the target's own next
+        // turn WOULD arrive on the real stream — verified, exactly as `watchForReceipt` demands. This
+        // is the one link a bash stub cannot produce; everything else is real.
+        subscribeEvents: (cb) => {
+          const t = setTimeout(() => cb({ nodeId: NODE_ID, newTurn: true, verified: true }), 20)
+          return () => clearTimeout(t)
+        }
+      }
+      const req: DeliveryRequest = {
+        sourceNodeId: 'desk-1',
+        targetNodeId: NODE_ID,
+        sourceTitle: 'Desk',
+        body: 'ping',
+        targetAgentId: 'claude'
+      }
+      const out = await deliverAgentMessage(req, deps)
+      expect(out.kind).toBe('delivered')
+      waitFor(() => capturePane(SESSION).includes('END NODETERM MESSAGE'), 5000, 'the closing frame')
+      const pane = capturePane(SESSION)
+      expect(pane).toContain('ping')
+      expect(pane).toContain('--- NODETERM MESSAGE')
+    },
+    45_000
+  )
+
+  // The two ways this guarantee breaks in future, each failing LOUDLY rather than silently. These
+  // exercise the pure decider only, so they run on every host.
+  it('breaks loudly if token materialisation is ever narrowed to the spawn path', () => {
+    // Simulate: the phone-spawned node runs the CURRENT script (so not a stale-script refusal) but
+    // its token was never materialised — sweep the file and do NOT re-run the persist refresh.
+    recordAgentEvent({
+      nodeId: NODE_ID,
+      agentId: 'claude',
+      kind: 'state',
+      state: 'done',
+      sessionId: 's1',
+      verified: false,
+      clientRevision: MANAGED_SCRIPT_REVISION
+    })
+    sweepNodeToken(NODE_ID)
+    expect(nodeTokenFilePresent(NODE_ID)).toBe(false)
+    expect(decideDelivery(factsFor(NODE_ID)).kind).toBe('targetStatusUnverified')
+    // Named, not a silent dark node: a caller is told to fix identity, never to retry forever.
+    expect(RETRYABLE['targetStatusUnverified']).toBe(false)
+  })
+
+  it('breaks loudly if the target runs a pre-identity hook script', () => {
+    const stale: MirrorEntry = {
+      state: 'done',
+      updatedAt: 1,
+      stateVerified: false,
+      clientRevision: 2 // < MIN_TOKEN_AWARE_REVISION: a script that predates per-node identity
+    }
+    expect(decideDelivery(factsFor(NODE_ID, { target: stale })).kind).toBe('targetHookScriptStale')
+    expect(RETRYABLE['targetHookScriptStale']).toBe(false)
+  })
+})

--- a/src/main/agent-messaging.test.ts
+++ b/src/main/agent-messaging.test.ts
@@ -13,8 +13,10 @@ import {
   deliverFromControl,
   renderMessageOutcome,
   onMessagingAgentEvent,
+  createDeliveryQueue,
   type AgentMessagingDeps
 } from './agent-messaging'
+import type { BoardLogEntry } from '../shared/types'
 import { RETRYABLE, type AgentMessageOutcome } from '../core/agents/agent-message-decide'
 import { resetMessageFlow, FANOUT_PER_TURN } from '../core/agents/agent-message-flow'
 import { NOTIFY_BODY } from '../shared/agents/agent-messaging'
@@ -382,5 +384,55 @@ describe('deliver-on-idle wiring (PR 7)', () => {
     const notHib = fakeDeps({ paneOwner: async () => shellPane, queue: fakeQueue().queue, isHibernated: () => false })
     const plain = await deliverFromControl(req(), notHib)
     expect(plain.outcome.kind).toBe('targetNotAgentPane')
+  })
+
+  // I1: the production factory wires the sender-facing expiry channel. Without it a busy-queued
+  // message that TTL-expires would land only in the trace ring, never where the sender looks.
+  it('a TTL-expired busy-queued message is board-logged to the sender (expiry channel wired)', async () => {
+    const appended: { projectId: string; entry: BoardLogEntry }[] = []
+    let fire: (() => void) | null = null
+    const deps = fakeDeps({
+      appendBoardLog: async (projectId, entry) => {
+        appended.push({ projectId, entry })
+        return true
+      },
+      // By expiry the target's runtime ownership is often gone, so the TRACE leg (routed to the
+      // TARGET's owning project) cannot board-log — leaving the SENDER-facing `onExpired` leg
+      // (routed to the sender's project) as the ONLY board-log writer. That isolation is the point:
+      // it is `onExpired`, not the trace, that this test pins.
+      paneOwnerProject: () => undefined
+    })
+    // `createDeliveryQueue` is the SAME builder main uses — a fake scheduler makes the TTL lapse
+    // deterministic, and a short ttl is irrelevant since the scheduler never really waits.
+    const queue = createDeliveryQueue(deps, {
+      ttlMs: 1000,
+      schedule: (_ms, fn) => {
+        fire = fn
+        return () => {
+          fire = null
+        }
+      }
+    })
+    await queue.enqueue({
+      verb: 'send',
+      sourceNodeId: 'a1',
+      targetNodeId: 'b1',
+      sourceTitle: 'Alpha',
+      body: 'hi'
+    })
+    expect(fire).toBeTruthy()
+    fire!() // the TTL lapses
+    await Promise.resolve()
+    await Promise.resolve()
+    // A board-log line naming the expiry landed in the SENDER's project (a1 ∈ p1), from a1 to b1.
+    const expiredLine = appended.find(
+      (a) =>
+        a.entry.kind === 'event' &&
+        a.entry.event?.type === 'agent-message' &&
+        a.entry.event.title === 'expired' &&
+        a.entry.event.from === 'a1'
+    )
+    expect(expiredLine, 'no expired board-log line reached the sender').toBeTruthy()
+    expect(expiredLine?.projectId).toBe('p1')
   })
 })

--- a/src/main/agent-messaging.test.ts
+++ b/src/main/agent-messaging.test.ts
@@ -20,6 +20,7 @@ import { resetMessageFlow, FANOUT_PER_TURN } from '../core/agents/agent-message-
 import { NOTIFY_BODY } from '../shared/agents/agent-messaging'
 import { resetAgentMessageTraceForTests } from '../core/agents/agent-message-trace'
 import { MANAGED_SCRIPT_REVISION } from '../core/agents/hooks/managed-script'
+import { DeliveryQueue } from '../core/agents/delivery-queue'
 import type { MirrorEntry } from '../core/agent-status-mirror'
 
 const idle: MirrorEntry = {
@@ -330,5 +331,56 @@ describe('notify (folded in from #98)', () => {
     const notify = await deliverFromControl(req({ verb: 'notify', body: '' }), deps)
     expect(notify.outcome.kind).toBe('rateLimited')
     expect(deps.rec.sent).toHaveLength(1)
+  })
+})
+
+describe('deliver-on-idle wiring (PR 7)', () => {
+  /** A queue whose `deliver` is never reached on these paths (enqueue does not call it) — we only
+   *  need to observe enqueue + wake. Timers are inert so no TTL fires mid-test. */
+  function fakeQueue(): { queue: DeliveryQueue; woken: string[] } {
+    const woken: string[] = []
+    const queue = new DeliveryQueue({
+      now: () => 0,
+      deliver: async () => ({ kind: 'delivered', traceId: 'd', traced: 'memory', receipt: 'observed', signal: 'newTurn' }),
+      trace: async () => ({ traceId: 'q', traced: 'memory' }),
+      wake: (id) => woken.push(id),
+      schedule: () => () => {}
+    })
+    return { queue, woken }
+  }
+
+  it('a BUSY target is ENQUEUED, not refused — and nothing reaches the pane', async () => {
+    const { queue } = fakeQueue()
+    const busy: MirrorEntry = { state: 'working', updatedAt: 1, stateVerified: true, clientRevision: MANAGED_SCRIPT_REVISION }
+    const deps = fakeDeps({ mirrorEntry: () => busy, queue })
+    const { outcome } = await deliverFromControl(req(), deps)
+    expect(outcome.kind).toBe('queued')
+    expect(queue.depth('b1')).toBe(1)
+    expect(deps.rec.sent).toEqual([]) // queued is NOT delivered — no bytes yet
+  })
+
+  it('without a queue, the same busy target is refused `targetBusy` (old behaviour intact)', async () => {
+    const busy: MirrorEntry = { state: 'working', updatedAt: 1, stateVerified: true, clientRevision: MANAGED_SCRIPT_REVISION }
+    const deps = fakeDeps({ mirrorEntry: () => busy })
+    const { outcome } = await deliverFromControl(req(), deps)
+    expect(outcome).toEqual({ kind: 'targetBusy', state: 'working' })
+  })
+
+  it('a HIBERNATED target (shell pane) is enqueued AND woken; a real non-agent pane is not', async () => {
+    const { queue, woken } = fakeQueue()
+    // Its pane is on a shell (Eco left it there) — runDelivery refuses `targetNotAgentPane`.
+    const shellPane = {
+      tty: '/dev/pts/9', panePid: 100, paneId: '%1', command: 'bash', argv: ['bash'], pids: [200]
+    }
+    const hib = fakeDeps({ paneOwner: async () => shellPane, queue, isHibernated: () => true })
+    const { outcome } = await deliverFromControl(req(), hib)
+    expect(outcome.kind).toBe('queued')
+    expect(woken).toEqual(['b1']) // woken through the registry before delivery
+    expect(hib.rec.sent).toEqual([])
+
+    // The SAME shell pane that is NOT hibernated stays refused — the node-type gate, not a probe.
+    const notHib = fakeDeps({ paneOwner: async () => shellPane, queue: fakeQueue().queue, isHibernated: () => false })
+    const plain = await deliverFromControl(req(), notHib)
+    expect(plain.outcome.kind).toBe('targetNotAgentPane')
   })
 })

--- a/src/main/agent-messaging.ts
+++ b/src/main/agent-messaging.ts
@@ -39,6 +39,7 @@ import {
 import { noteNewTurn, noteSent, reserveFlow } from '../core/agents/agent-message-flow'
 import { recordDelivery } from '../core/agents/agent-message-trace'
 import { resolveDeliveryScope, scopeRefusal } from '../core/agents/agent-message-scope'
+import type { DeliveryQueue } from '../core/agents/delivery-queue'
 import { nodeTokenFilePresent } from '../core/agents/node-token-files'
 import { mirrorEntry as coreMirrorEntry, type MirrorEntry } from '../core/agent-status-mirror'
 import {
@@ -88,6 +89,24 @@ export interface AgentMessagingDeps {
   /** Test seam: override the receipt subscription. Production uses the module bus below. */
   subscribeReceipts?(cb: (e: ReceiptEvent) => void): () => void
   now?(): number
+  /**
+   * Deliver-on-idle (PR 7): the process-lifetime bounded queue. Absent ⇒ no queueing, and a busy or
+   * hibernated target is refused exactly as before. Present ⇒ a PERMITTED delivery that refuses only
+   * because the target is BUSY (or is hibernated, its pane sitting on a shell) is enqueued and
+   * answered `queued`; the queue flushes it when the target next goes idle (wired through
+   * `onMessagingAgentEvent` → `onTargetIdle`). The queue's own `deliver` dep is `runDelivery` below,
+   * so a flush re-runs the whole gate chain against live state — the flush-time re-validation.
+   */
+  queue?: DeliveryQueue
+  /**
+   * Is the target node hibernated (Eco)? A hibernated node's pane is on a SHELL, so a direct
+   * delivery refuses `targetNotAgentPane` FOREVER (gate 1) — the DECSET-2004 measurement's one unsafe
+   * surface, a non-agent pane, which is exactly why the queue gates on node type and never sprays it.
+   * When the target is hibernated the queue enqueues on that refusal and WAKES it first, rather than
+   * treating a real non-agent pane the same way. Renderer-known (the `useAgentStatus` store),
+   * injected. Absent ⇒ never hibernated, and only a `targetBusy` refusal queues.
+   */
+  isHibernated?(nodeId: string): boolean
 }
 
 /**
@@ -125,6 +144,21 @@ function subscribeBus(cb: (e: ReceiptEvent) => void): () => void {
 }
 
 /**
+ * The process-lifetime deliver-on-idle queue (PR 7), wired once by the desktop shell. Held at module
+ * scope — not threaded through `AgentMessagingDeps` on the event path — because the flush trigger is
+ * the SAME normalized event stream `onMessagingAgentEvent` already taps, and a target going idle is
+ * what a flush waits for. Null on the Server Edition and until wired (messaging does not exist
+ * there). The verb path still takes the queue through `deps.queue` so a test can drive enqueue in
+ * isolation.
+ */
+let deliveryQueue: DeliveryQueue | null = null
+
+/** Wire (or clear) the deliver-on-idle queue. Called once from main; absent ⇒ no queueing. */
+export function setDeliveryQueue(q: DeliveryQueue | null): void {
+  deliveryQueue = q
+}
+
+/**
  * Feed one normalized agent event into messaging: the sender's own `newTurn` resets its fan-out
  * budget (the same edge normalize.ts flags so the renderer can clear per-turn fan-out), and every
  * event is offered to the open receipt watches — which accept only `verified: true`
@@ -143,6 +177,11 @@ export function onMessagingAgentEvent(
     verified: e.verified
   }
   for (const cb of [...receiptSubs]) cb(ev)
+  // Deliver-on-idle flush trigger: the target finished a turn, so it is idle NOW. `onTargetIdle`
+  // re-runs the whole delivery per queued message (the flush-time re-validation), so a `done` that
+  // is actually still-not-deliverable (an unverified or inferred idle) simply re-queues — this only
+  // needs to be a cheap "maybe now" nudge, not a precise idle verdict.
+  if (e.state === 'done') void deliveryQueue?.onTargetIdle(e.nodeId)
 }
 
 // ── The per-node delivery lock ────────────────────────────────────────────────────────────────
@@ -318,20 +357,18 @@ const WROTE: ReadonlySet<AgentMessageOutcome['kind']> = new Set([
 ])
 
 /**
- * One control-verb delivery, end to end: scope → switch → flow → `deliverAgentMessage` → budget →
- * rendered reply.
+ * One control-verb delivery attempt, end to end: scope → switch → ownership → flow →
+ * `deliverAgentMessage` → budget. Returns the raw typed outcome and does NOT queue — this is both
+ * the verb's first attempt AND the queue's flush-time `deliver` callback, so the queue re-runs the
+ * ENTIRE chain (ownership, grant and flow included) against live state every time it flushes. That
+ * is the flush-time re-validation the queue depends on: a grant revoked while a message was queued
+ * comes back `notPermitted` here and the queue drops it.
  */
-export async function deliverFromControl(
+export async function runDelivery(
   req: AgentMessageDeliverRequest,
   deps: AgentMessagingDeps
-): Promise<{ outcome: AgentMessageOutcome; reply: AgentMessageReply }> {
+): Promise<AgentMessageOutcome> {
   const now = deps.now ?? ((): number => Date.now())
-  const answer = (
-    outcome: AgentMessageOutcome
-  ): { outcome: AgentMessageOutcome; reply: AgentMessageReply } => ({
-    outcome,
-    reply: renderMessageOutcome(outcome)
-  })
 
   const projects = deps.projects()
   // WHO MAY BE ADDRESSED — the serialized store, never a live canvas (there is nothing to travel
@@ -427,10 +464,66 @@ export async function deliverFromControl(
     // No await between the record and the release: the recorded send replaces the hold in the
     // same tick, so no concurrent reservation can slip through the seam between them.
     if (WROTE.has(outcome.kind)) noteSent(req.sourceNodeId, req.targetNodeId, now())
-    return answer(outcome)
+    return outcome
   } finally {
     reservation?.release()
   }
+}
+
+/** The `AgentMessageOutcome` kinds a permitted-but-not-ready target produces — a busy agent, or a
+ *  node between sessions. Only these are enqueued (and only with a queue wired): the target passed
+ *  scope/ownership/grant, and its non-readiness is a turn it happens to be in, not a boundary. */
+const QUEUE_ON_BUSY: ReadonlySet<AgentMessageOutcome['kind']> = new Set([
+  'targetBusy',
+  'targetNotIdleUnknown'
+])
+
+/**
+ * One control-verb delivery, end to end, WITH deliver-on-idle: attempt it (`runDelivery`), and when
+ * a queue is wired, enqueue a permitted-but-not-ready target instead of refusing it.
+ *
+ *  - a BUSY target (or one between sessions) ⇒ `queued`, flushed on its next idle;
+ *  - a HIBERNATED target — whose pane is on a shell, so `runDelivery` refuses `targetNotAgentPane`
+ *    (the DECSET measurement's one unsafe surface) — ⇒ `queued` AND woken. A genuine non-agent pane
+ *    that is NOT hibernated stays refused: the node-type gate, not a probe, is what tells them apart;
+ *  - everything else (delivered, stalled, every refusal that waiting will not fix) is answered as-is.
+ *
+ * `queued` is not `delivered`: the bytes have not reached the pane, and the receipt closes the loop
+ * once the flush delivers them.
+ */
+export async function deliverFromControl(
+  req: AgentMessageDeliverRequest,
+  deps: AgentMessagingDeps
+): Promise<{ outcome: AgentMessageOutcome; reply: AgentMessageReply }> {
+  const answer = (
+    outcome: AgentMessageOutcome
+  ): { outcome: AgentMessageOutcome; reply: AgentMessageReply } => ({
+    outcome,
+    reply: renderMessageOutcome(outcome)
+  })
+  const outcome = await runDelivery(req, deps)
+  const queue = deps.queue
+  if (queue) {
+    const queued = (hibernated: boolean): Promise<AgentMessageOutcome> =>
+      queue.enqueue(
+        {
+          verb: req.verb,
+          sourceNodeId: req.sourceNodeId,
+          targetNodeId: req.targetNodeId,
+          // For the trace's `sourceTitle`; the flush re-resolves it from the store like the first
+          // attempt did, so this is only ever a label on the queued/expired trace lines.
+          sourceTitle: req.sourceNodeId,
+          body: req.body
+        },
+        { hibernated }
+      )
+    if (QUEUE_ON_BUSY.has(outcome.kind)) return answer(await queued(false))
+    // A hibernated target reads as `targetNotAgentPane` (its pane is a shell) — enqueue+wake ONLY
+    // then, never for a real non-agent pane.
+    if (outcome.kind === 'targetNotAgentPane' && deps.isHibernated?.(req.targetNodeId))
+      return answer(await queued(true))
+  }
+  return answer(outcome)
 }
 
 /** Guard for the IPC boundary: the request came over a channel, so its shape is asserted here. */

--- a/src/main/agent-messaging.ts
+++ b/src/main/agent-messaging.ts
@@ -39,7 +39,12 @@ import {
 import { noteNewTurn, noteSent, reserveFlow } from '../core/agents/agent-message-flow'
 import { recordDelivery } from '../core/agents/agent-message-trace'
 import { resolveDeliveryScope, scopeRefusal } from '../core/agents/agent-message-scope'
-import type { DeliveryQueue } from '../core/agents/delivery-queue'
+import {
+  DeliveryQueue,
+  type DeliveryQueueDeps,
+  type QueuedDeliveryRequest
+} from '../core/agents/delivery-queue'
+import { randomUUID } from 'crypto'
 import { nodeTokenFilePresent } from '../core/agents/node-token-files'
 import { mirrorEntry as coreMirrorEntry, type MirrorEntry } from '../core/agent-status-mirror'
 import {
@@ -156,6 +161,84 @@ let deliveryQueue: DeliveryQueue | null = null
 /** Wire (or clear) the deliver-on-idle queue. Called once from main; absent ⇒ no queueing. */
 export function setDeliveryQueue(q: DeliveryQueue | null): void {
   deliveryQueue = q
+}
+
+/** The board-log author for a queue-level record (an app action, not a person's) — the same stamp
+ *  `recordDelivery` uses. */
+const QUEUE_TRACE_AUTHOR = { name: 'nodeterm', color: '#8b8b8b' } as const
+
+/**
+ * Build the deliver-on-idle queue against a messaging deps record, WIRING both trace legs required
+ * by Task 7.2 ("emits `expired` to the sender AND to the trace — never a silent drop"):
+ *
+ *  - the TRACE leg is `deps.trace`/`recordDelivery`: `queued` and `expired` go into the in-memory
+ *    ring Settings → Agents reads, and — for a resolvable owning project — the board log too;
+ *  - the SENDER leg is `onExpired` / `onFlushed`: a board-log line in the SENDER's own project, so
+ *    the operator watching the sender learns a queued message expired, was dropped by a grant that
+ *    changed under it, or finally landed. Without this, a busy-queued message that TTL-expires would
+ *    be recorded only where nobody looking at the sender would see it — the exact half-wiring the
+ *    PR 7 review flagged (I1).
+ *
+ * `deliver` is `runDelivery` against these same deps, so a flush re-runs the whole gate chain
+ * against live state (the flush-time re-validation). `wake`/`isHibernated` are RENDERER state with
+ * no main-side signal yet and are deliberately NOT supplied here — the busy-target leg is fully
+ * wired, the hibernated leg's main→renderer wake is an explicitly-recorded residual (see
+ * `delivery-queue.ts` and the PR body). `opts` exists only so a test can pin the TTL and scheduler.
+ */
+export function createDeliveryQueue(
+  deps: AgentMessagingDeps,
+  opts: { capacity?: number; ttlMs?: number; schedule?: DeliveryQueueDeps['schedule'] } = {}
+): DeliveryQueue {
+  const now = deps.now ?? ((): number => Date.now())
+  /** The project that lists a node id, for a board-log write. A trace is not an authorization, so
+   *  the first match is fine — unlike the delivery gate, which proves ownership. */
+  const projectFor = (nodeId: string): string | undefined =>
+    deps.projects().find((p) => p.nodes.some((n) => n.id === nodeId))?.id
+  /** Append one messaging record to a project's board log. No-ops when the project cannot be
+   *  resolved (an inline/cwd-less project has no log — Constraint 10 — the ring still holds it). */
+  const senderBoardLog = (req: QueuedDeliveryRequest, title: string): void => {
+    const projectId = projectFor(req.sourceNodeId)
+    if (!projectId) return
+    const entry: BoardLogEntry = {
+      id: randomUUID(),
+      ts: now(),
+      author: QUEUE_TRACE_AUTHOR,
+      nodeId: req.targetNodeId,
+      kind: 'event',
+      event: { type: 'agent-message', from: req.sourceNodeId, to: req.targetNodeId, title }
+    }
+    void deps.appendBoardLog(projectId, entry)
+  }
+  return new DeliveryQueue(
+    {
+      now,
+      deliver: (qreq) =>
+        runDelivery(
+          {
+            verb: qreq.verb as AgentMessageDeliverRequest['verb'],
+            sourceNodeId: qreq.sourceNodeId,
+            targetNodeId: qreq.targetNodeId,
+            body: qreq.body
+          },
+          deps
+        ),
+      // The trace leg: ring always, board log when the TARGET's owning project is resolvable.
+      trace: (input) =>
+        recordDelivery(input, {
+          appendBoardLog: (entry) => {
+            const projectId = deps.paneOwnerProject(input.targetNodeId)
+            return projectId ? deps.appendBoardLog(projectId, entry) : Promise.resolve(false)
+          },
+          now
+        }),
+      // The sender leg: a durable line where the sender's operator will see it.
+      onExpired: (req) => senderBoardLog(req, 'expired'),
+      onFlushed: (req, outcome) => senderBoardLog(req, outcome.kind),
+      // Injected so a test pins TTL expiry deterministically; production uses the default setTimeout.
+      ...(opts.schedule ? { schedule: opts.schedule } : {})
+    },
+    { capacity: opts.capacity, ttlMs: opts.ttlMs }
+  )
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,8 +19,14 @@ import {
   deliverFromControl,
   isDeliverRequest,
   messagingEnabledVia,
-  onMessagingAgentEvent
+  onMessagingAgentEvent,
+  runDelivery,
+  setDeliveryQueue,
+  type AgentMessagingDeps
 } from './agent-messaging'
+import { DeliveryQueue } from '../core/agents/delivery-queue'
+import { recordDelivery } from '../core/agents/agent-message-trace'
+import type { AgentMessageDeliverRequest } from '../shared/agents/agent-messaging'
 import type { RemoteLogExec } from '../core/board-log'
 import { boardLogRemotePath } from '../core/board-log'
 import { PtyManager } from '../core/pty-manager'
@@ -921,28 +927,54 @@ app.whenReady().then(async () => {
   // Agent messaging (the `send`/`reply` control verbs). Canvas.tsx forwards the validated verb
   // here; everything that authorizes or performs the delivery reads MAIN's stores. See
   // src/main/agent-messaging.ts for the whole map.
+  const messagingDeps: AgentMessagingDeps = {
+    paneOwner: (id) => ptyManager.paneOwner(id),
+    sendFramedPayload: (id, payload) => ptyManager.sendFramedPayload(id, payload),
+    hasLiveSession: (id) => ptyManager.hasLiveSession(id),
+    projects: () => workspaceStore.persistedCanvases(),
+    isRemoteNode: (id) => !!ptyManager.sshRemoteForNode(id),
+    // GLOBAL CONSTRAINT 11: every delivery path is gated behind the per-project switch, OFF by
+    // default. The switch is the `agentMessaging` capability GRANT: the strict `=== true` flag
+    // in the hostile git-shared project.json AND this machine's recorded 'kept' answer to the
+    // clone notice (projectCapabilityGrantedFor — never the raw file bit). Read per call off
+    // the store's index, so a decline or an off-toggle refuses the very next delivery.
+    messagingEnabled: messagingEnabledVia((id) => workspaceStore.capabilityProjectFor(id)),
+    // Runtime pane ownership: which project actually SPAWNED the target's pane this run
+    // (core/agents/pane-ownership.ts). The gate trusts this over the attacker-writable store to
+    // decide whose grant applies; unproven ⇒ refused (PR #237 fix round 2).
+    paneOwnerProject: (id) => paneOwnerProject(id),
+    customAgents: () => settingsStore.get().customAgents,
+    appendBoardLog: (projectId, entry) => appendBoardLogVia(boardLogRouter, projectId, entry)
+  }
+  // Deliver-on-idle (PR 7): the process-lifetime bounded queue. Its `deliver` is `runDelivery`
+  // against these SAME deps, so a flush re-runs the whole gate chain (ownership, grant, flow)
+  // against live state — the flush-time re-validation. The flush trigger is the target's own `done`
+  // event, already fed to `onMessagingAgentEvent` below. `wake`/`isHibernated` are RENDERER state
+  // (Eco lives in `useAgentStatus`, the wake registry in the renderer's agent-restart) with no
+  // main-side signal today; the BUSY-target leg is fully wired here, and the hibernated leg's
+  // renderer→main wiring is owed to device verification (see the PR body).
+  messagingDeps.queue = new DeliveryQueue({
+    now: () => Date.now(),
+    deliver: (qreq) =>
+      runDelivery(
+        {
+          verb: qreq.verb as AgentMessageDeliverRequest['verb'],
+          sourceNodeId: qreq.sourceNodeId,
+          targetNodeId: qreq.targetNodeId,
+          body: qreq.body
+        },
+        messagingDeps
+      ),
+    // The queue's own `queued`/`expired` lines land in the in-memory trace ring (no project is
+    // resolved at this level — the flush's real outcome traces to the project's board log inside
+    // `runDelivery`). Ring-only is honest: `traced: 'memory'`.
+    trace: (input) => recordDelivery(input, { appendBoardLog: async () => false, now: () => Date.now() })
+  })
+  setDeliveryQueue(messagingDeps.queue)
   ipcMain.handle(IPC.agentMessageDeliver, async (_e, raw: unknown) => {
     if (!isDeliverRequest(raw))
       return { ok: false, error: 'malformed agent-message request. Do not retry.' }
-    const { reply } = await deliverFromControl(raw, {
-      paneOwner: (id) => ptyManager.paneOwner(id),
-      sendFramedPayload: (id, payload) => ptyManager.sendFramedPayload(id, payload),
-      hasLiveSession: (id) => ptyManager.hasLiveSession(id),
-      projects: () => workspaceStore.persistedCanvases(),
-      isRemoteNode: (id) => !!ptyManager.sshRemoteForNode(id),
-      // GLOBAL CONSTRAINT 11: every delivery path is gated behind the per-project switch, OFF by
-      // default. The switch is the `agentMessaging` capability GRANT: the strict `=== true` flag
-      // in the hostile git-shared project.json AND this machine's recorded 'kept' answer to the
-      // clone notice (projectCapabilityGrantedFor — never the raw file bit). Read per call off
-      // the store's index, so a decline or an off-toggle refuses the very next delivery.
-      messagingEnabled: messagingEnabledVia((id) => workspaceStore.capabilityProjectFor(id)),
-      // Runtime pane ownership: which project actually SPAWNED the target's pane this run
-      // (core/agents/pane-ownership.ts). The gate trusts this over the attacker-writable store to
-      // decide whose grant applies; unproven ⇒ refused (PR #237 fix round 2).
-      paneOwnerProject: (id) => paneOwnerProject(id),
-      customAgents: () => settingsStore.get().customAgents,
-      appendBoardLog: (projectId, entry) => appendBoardLogVia(boardLogRouter, projectId, entry)
-    })
+    const { reply } = await deliverFromControl(raw, messagingDeps)
     return reply
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,17 +16,14 @@ import {
 } from './browser-guest-registry'
 import { appendBoardLogVia, registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
 import {
+  createDeliveryQueue,
   deliverFromControl,
   isDeliverRequest,
   messagingEnabledVia,
   onMessagingAgentEvent,
-  runDelivery,
   setDeliveryQueue,
   type AgentMessagingDeps
 } from './agent-messaging'
-import { DeliveryQueue } from '../core/agents/delivery-queue'
-import { recordDelivery } from '../core/agents/agent-message-trace'
-import type { AgentMessageDeliverRequest } from '../shared/agents/agent-messaging'
 import type { RemoteLogExec } from '../core/board-log'
 import { boardLogRemotePath } from '../core/board-log'
 import { PtyManager } from '../core/pty-manager'
@@ -946,30 +943,16 @@ app.whenReady().then(async () => {
     customAgents: () => settingsStore.get().customAgents,
     appendBoardLog: (projectId, entry) => appendBoardLogVia(boardLogRouter, projectId, entry)
   }
-  // Deliver-on-idle (PR 7): the process-lifetime bounded queue. Its `deliver` is `runDelivery`
-  // against these SAME deps, so a flush re-runs the whole gate chain (ownership, grant, flow)
-  // against live state — the flush-time re-validation. The flush trigger is the target's own `done`
-  // event, already fed to `onMessagingAgentEvent` below. `wake`/`isHibernated` are RENDERER state
-  // (Eco lives in `useAgentStatus`, the wake registry in the renderer's agent-restart) with no
-  // main-side signal today; the BUSY-target leg is fully wired here, and the hibernated leg's
-  // renderer→main wiring is owed to device verification (see the PR body).
-  messagingDeps.queue = new DeliveryQueue({
-    now: () => Date.now(),
-    deliver: (qreq) =>
-      runDelivery(
-        {
-          verb: qreq.verb as AgentMessageDeliverRequest['verb'],
-          sourceNodeId: qreq.sourceNodeId,
-          targetNodeId: qreq.targetNodeId,
-          body: qreq.body
-        },
-        messagingDeps
-      ),
-    // The queue's own `queued`/`expired` lines land in the in-memory trace ring (no project is
-    // resolved at this level — the flush's real outcome traces to the project's board log inside
-    // `runDelivery`). Ring-only is honest: `traced: 'memory'`.
-    trace: (input) => recordDelivery(input, { appendBoardLog: async () => false, now: () => Date.now() })
-  })
+  // Deliver-on-idle (PR 7): the process-lifetime bounded queue, built by the service factory so its
+  // trace + sender-facing legs are wired (and unit-tested) in one place. Its `deliver` is
+  // `runDelivery` against these SAME deps, so a flush re-runs the whole gate chain (ownership, grant,
+  // flow) against live state — the flush-time re-validation. The flush trigger is the target's own
+  // `done` event, already fed to `onMessagingAgentEvent` below. A TTL expiry is board-logged to the
+  // sender's project AND held in the trace ring (never a silent drop). `wake`/`isHibernated` are
+  // RENDERER state (Eco lives in `useAgentStatus`, the wake registry in the renderer's
+  // agent-restart) with no main-side signal today: the BUSY-target leg is fully wired here, and the
+  // hibernated leg's renderer→main wake is an explicitly-recorded residual (see the PR body).
+  messagingDeps.queue = createDeliveryQueue(messagingDeps)
   setDeliveryQueue(messagingDeps.queue)
   ipcMain.handle(IPC.agentMessageDeliver, async (_e, raw: unknown) => {
     if (!isDeliverRequest(raw))

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -115,6 +115,7 @@ import {
   type ExitPhaseOutcome,
   type ResumePhaseOutcome
 } from '../terminal/agent-restart'
+import { WakeInputBuffer } from '../terminal/wake-input-buffer'
 import { FindBar } from '../components/FindBar'
 import { IconSearch, IconChat, IconMic, IconReload } from '../components/icons'
 import { NodeLabels } from '../components/kanban/NodeLabels'
@@ -1281,6 +1282,14 @@ export function TerminalNode({
   // sweep that landed in between, must not deliver a second launch line into the same pane.
   const wakeInFlightRef = useRef(false)
   const wakeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // A wake types the resume line into this pane un-KILL_LINE'd (its "most fragile moment"), and the
+  // keyboard path writes straight to the transport throughout. This bounded buffer HOLDS anything
+  // the human types between `beginWake` and the resume's confirmed submit, then flushes it in order
+  // (a `resumed` outcome) or drops it (any other) — so nothing splices into the resume line. See
+  // wake-input-buffer.ts; the keyboard interception is in `term.onData` below, the writer is the
+  // session-scoped `restartIo.write` published here so the wake `.then` (component body) can reach it.
+  const wakeInputBufferRef = useRef(new WakeInputBuffer())
+  const paneWriteRef = useRef<(data: string) => void>(() => {})
   const wakeRef = useRef<(attempt?: number) => void>(() => {})
   wakeRef.current = (attempt = 0): void => {
     // A wake that could not run YET is retried a couple of times: at mount the spawn is still in
@@ -1298,9 +1307,15 @@ export function TerminalNode({
     const fns = agentHibernateFns(id)
     if (!fns) return retryLater() // no terminal here yet (mid-spawn, or an offscreen revive)
     wakeInFlightRef.current = true
+    // Hold keyboard input from HERE — before the resume line's first byte — until the resume
+    // resolves. `beginWake` is idempotent, so a retry that re-enters keeps what is already held.
+    wakeInputBufferRef.current.beginWake()
     void fns
       .resume()
       .then((outcome) => {
+        // Flush on a confirmed resume (the held keystrokes land after the resume line submitted),
+        // drop on anything else (`expired` — the pane became something we did not resume into).
+        wakeInputBufferRef.current.endWake(outcome === 'resumed', paneWriteRef.current)
         if (outcome === 'resumed') {
           useAgentStatus.getState().setHibernated(id, false)
           return
@@ -1312,7 +1327,9 @@ export function TerminalNode({
       })
       .catch(() => {
         // A transport that threw leaves the node hibernated (and the chip clickable). Reporting a
-        // wake here would clear the badge over a pane nothing was typed into.
+        // wake here would clear the badge over a pane nothing was typed into — and the held input is
+        // dropped, never spliced into whatever the pane became.
+        wakeInputBufferRef.current.endWake(false, paneWriteRef.current)
       })
       .finally(() => {
         wakeInFlightRef.current = false
@@ -2690,6 +2707,12 @@ export function TerminalNode({
             // interrupt, so probe the cancelled turn (still-silent working → done). Exact
             // match — arrow keys etc. arrive as multi-byte \x1b[… sequences.
             if (showStatus && (input === '\x1b' || input === '\x03')) inferInterruptAfterSettle(id)
+            // While a wake is in flight, HOLD this input rather than write it: the resume line is
+            // sitting un-submitted in the pane and a keystroke would splice into it. The buffer is
+            // bounded — a `queueFull`/`buffered` verdict means "held, do not write". Flushed (or
+            // dropped) when the resume resolves; see `wakeInputBufferRef`. `passthrough` is the
+            // ordinary case and is byte-for-byte the old behaviour.
+            if (wakeInputBufferRef.current.offer(input).kind !== 'passthrough') return
             transport.write(sid, input)
           }).dispose
         )
@@ -2820,6 +2843,11 @@ export function TerminalNode({
       },
       onData: (cb) => (sessionId && !life.dead ? transport.onData(sessionId, cb) : () => {})
     }
+    // The wake buffer flushes held keystrokes through the SAME session-scoped, lifetime-gated write
+    // as the resume line — so a flush into a torn-down session no-ops instead of throwing. Published
+    // to the ref the wake `.then` (component body) reads; re-set on every mount, which is when a new
+    // `restartIo` closure captures a live `sessionId`/`life`.
+    paneWriteRef.current = restartIo.write
     // Is there still a pane to restart in? A spawn in flight has no session yet; a real teardown
     // flips `life.dead`; and a session another client DESTROYED (or one recycled with no
     // replacement) is gone while this component happily stays mounted showing the overlay — the

--- a/src/renderer/terminal/wake-input-buffer.test.ts
+++ b/src/renderer/terminal/wake-input-buffer.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { WakeInputBuffer, WAKE_BUFFER_MAX_CHARS } from './wake-input-buffer'
+
+/**
+ * The bounded wake input buffer, every edge driven — and each key assertion is mutation-checked in
+ * the source (revert the mechanism → red → restore) rather than only asserted here.
+ *
+ * The one property that matters is the timing: while a wake is in flight, NOTHING the human types
+ * reaches the pane; it is held until the resume line is confirmed submitted, and dropped if the
+ * wake never resumed. Everything below is that property, split by edge.
+ */
+
+/** Collect what the buffer decides to write, so a test can assert both order and timing. */
+function sink(): { writes: string[]; write: (d: string) => void } {
+  const writes: string[] = []
+  return { writes, write: (d) => writes.push(d) }
+}
+
+describe('WakeInputBuffer', () => {
+  it('passes input straight through when no wake is in flight', () => {
+    const b = new WakeInputBuffer()
+    expect(b.isWaking).toBe(false)
+    expect(b.offer('ls\r')).toEqual({ kind: 'passthrough' })
+    // Passthrough holds nothing — the ordinary terminal is untouched.
+    expect(b.bufferedChars).toBe(0)
+  })
+
+  it('HOLDS input during a wake and writes NOTHING until the resume is confirmed', () => {
+    const b = new WakeInputBuffer()
+    const s = sink()
+    b.beginWake()
+    expect(b.isWaking).toBe(true)
+    expect(b.offer('a')).toEqual({ kind: 'buffered', bufferedChars: 1 })
+    expect(b.offer('bc')).toEqual({ kind: 'buffered', bufferedChars: 3 })
+    // The whole point: not one byte has been written while the resume line is un-submitted.
+    expect(s.writes).toEqual([])
+    expect(b.bufferedChars).toBe(3)
+  })
+
+  it('flushes the held input IN ORDER once the wake resumed', () => {
+    const b = new WakeInputBuffer()
+    const s = sink()
+    b.beginWake()
+    b.offer('one')
+    b.offer('two')
+    b.offer('three')
+    const drain = b.endWake(true, s.write)
+    expect(drain).toEqual({ reason: 'flushed', chars: 11 })
+    // Order preserved, and only now — after the resume line submitted.
+    expect(s.writes).toEqual(['one', 'two', 'three'])
+    // The window is closed again: the buffer is inert.
+    expect(b.isWaking).toBe(false)
+    expect(b.bufferedChars).toBe(0)
+    expect(b.offer('later')).toEqual({ kind: 'passthrough' })
+  })
+
+  it('DROPS the held input to `expired` when the wake did not resume', () => {
+    const b = new WakeInputBuffer()
+    const s = sink()
+    b.beginWake()
+    b.offer('rm -rf /')
+    const drain = b.endWake(false, s.write)
+    // The pane became whatever it became; the held bytes are discarded, not spliced into it.
+    expect(drain).toEqual({ reason: 'expired', chars: 8 })
+    expect(s.writes).toEqual([])
+    expect(b.isWaking).toBe(false)
+    expect(b.bufferedChars).toBe(0)
+  })
+
+  it('refuses with `queueFull` past the bound and holds nothing more (no silent drop)', () => {
+    const b = new WakeInputBuffer(8)
+    const s = sink()
+    b.beginWake()
+    expect(b.offer('12345')).toEqual({ kind: 'buffered', bufferedChars: 5 })
+    // 5 + 4 = 9 > 8: the chunk is refused WHOLE, and the buffer keeps exactly what it had.
+    expect(b.offer('6789')).toEqual({ kind: 'queueFull', capacity: 8 })
+    expect(b.bufferedChars).toBe(5)
+    // A smaller chunk that still fits is still accepted — the refusal was of the chunk, not a latch.
+    expect(b.offer('67')).toEqual({ kind: 'buffered', bufferedChars: 7 })
+    // On resume only what was actually buffered is written; the refused chunk never appears.
+    b.endWake(true, s.write)
+    expect(s.writes).toEqual(['12345', '67'])
+    expect(s.writes.join('')).not.toContain('6789')
+  })
+
+  it('the bound is exact — a chunk landing on the boundary is accepted, one past it is not', () => {
+    const b = new WakeInputBuffer(4)
+    b.beginWake()
+    expect(b.offer('abcd')).toEqual({ kind: 'buffered', bufferedChars: 4 })
+    expect(b.offer('e')).toEqual({ kind: 'queueFull', capacity: 4 })
+  })
+
+  it('beginWake is idempotent — re-entering a wake does not drop what is already held', () => {
+    const b = new WakeInputBuffer()
+    const s = sink()
+    b.beginWake()
+    b.offer('held')
+    b.beginWake() // the retry path re-arms; it must not clear the buffer
+    expect(b.bufferedChars).toBe(4)
+    b.endWake(true, s.write)
+    expect(s.writes).toEqual(['held'])
+  })
+
+  it('the default bound is a sane, finite number', () => {
+    // A bound that is 0 or Infinity is not a bound; pin that the default is neither.
+    expect(WAKE_BUFFER_MAX_CHARS).toBeGreaterThan(0)
+    expect(Number.isFinite(WAKE_BUFFER_MAX_CHARS)).toBe(true)
+  })
+})

--- a/src/renderer/terminal/wake-input-buffer.ts
+++ b/src/renderer/terminal/wake-input-buffer.ts
@@ -1,0 +1,131 @@
+/**
+ * A BOUNDED INPUT BUFFER FOR THE WAKE WINDOW — nothing the human types splices into the resume line.
+ *
+ * ── THE FRAGILE MOMENT THIS CLOSES ──────────────────────────────────────────────────────────────
+ *
+ * Waking a hibernated node re-launches its conversation with the provider's own `--resume`
+ * (`agent-restart.ts` `performResumePhase`). Between the first byte of that launch line and its
+ * submit there is a window — `agent-restart.ts:216` calls the un-submitted resume line *"the pane's
+ * most fragile moment"* — in which anything typed is spliced INTO the command: a stray keystroke
+ * turns `claude --resume <sid>` into `claude --resume <sid>x`, and the conversation is lost.
+ *
+ * Today there is no buffer at all: the only protections are `wakeInFlightRef` (one wake at a time)
+ * and the `hibernated` re-read, neither of which touches the KEYBOARD path — `term.onData` writes
+ * straight to the transport throughout the wake. cmux solved the same problem with a bounded buffer
+ * (`TerminalPanel.swift:737-740`); this is that piece, pure and testable.
+ *
+ * ── WHAT IT DOES, AND WHICH WAY EACH EDGE FAILS ─────────────────────────────────────────────────
+ *
+ *  - NOT waking → `passthrough`: the caller writes the input as it always did. The buffer is inert
+ *    outside a wake, so the ordinary terminal is byte-for-byte unchanged.
+ *  - WAKING → `buffered`: the input is HELD, in order, and released only once the resume line is
+ *    confirmed submitted (a `resumed` outcome means exactly that — `performResumePhase` resolves
+ *    after the delivery settles). Held, not written: writing it now is the splice.
+ *  - WAKING and OVER THE BOUND → `queueFull`: an unbounded hold is a memory-DoS on a paste or a
+ *    key-repeat that never ends, so the buffer refuses past `maxChars` and holds nothing more. The
+ *    refusal is LOUD (a verdict the caller can surface), never a silent drop — the same discipline
+ *    the message queue applies to its own bound.
+ *  - the wake ENDS resumed → `flushed`: the held input is written, in the order it arrived, into a
+ *    pane whose resume line has already gone.
+ *  - the wake ENDS any other way → `expired`: a wake that timed out or failed left the pane as
+ *    whatever it became (a stranger's shell, a dead session), so the held bytes are DISCARDED rather
+ *    than spliced into it. Dropping the buffer is the safe direction; writing it is the bug.
+ *
+ * `queueFull` / `expired` are named to match the message queue's outcomes on purpose: a human at a
+ * waking pane and a message to a busy agent hit the same two walls (a full buffer, a lapsed wait),
+ * and one vocabulary for both keeps the two features legible together.
+ *
+ * Pure: no DOM, no IPC, no timers. The write is injected, so the whole state machine is exercised
+ * without a terminal — `wake-input-buffer.test.ts` drives every edge and mutation-checks each.
+ */
+
+/** The most keyboard input (code units) held during one wake before the buffer refuses. Small on
+ *  purpose: a wake is seconds, and the only legitimate content is what a human types in that window;
+ *  anything larger is a paste or a stuck key, which `queueFull` is the honest answer to. */
+export const WAKE_BUFFER_MAX_CHARS = 4096
+
+/** The verdict on one offered chunk. `passthrough` is the only one that tells the caller to write. */
+export type WakeOfferVerdict =
+  | { kind: 'passthrough' }
+  | { kind: 'buffered'; bufferedChars: number }
+  | { kind: 'queueFull'; capacity: number }
+
+/** Why the buffer emptied: `flushed` wrote its contents, `expired` discarded them. */
+export type WakeDrainReason = 'flushed' | 'expired'
+
+export interface WakeDrainResult {
+  reason: WakeDrainReason
+  /** How much was held when the wake ended — for the trace, never the content itself. */
+  chars: number
+}
+
+/**
+ * One node's wake input buffer. Constructed per terminal node and driven by the node's wake
+ * choreography: `beginWake()` when a resume starts, `offer()` on every keystroke, `endWake()` when
+ * the resume resolves.
+ */
+export class WakeInputBuffer {
+  private waking = false
+  private held: string[] = []
+  private chars = 0
+
+  constructor(private readonly maxChars: number = WAKE_BUFFER_MAX_CHARS) {}
+
+  /** A wake for this node has started — hold keyboard input from here until `endWake`. Idempotent:
+   *  a second `beginWake` inside one wake (the retry path re-enters) must not drop what is held. */
+  beginWake(): void {
+    this.waking = true
+  }
+
+  /** Is a wake currently holding input? */
+  get isWaking(): boolean {
+    return this.waking
+  }
+
+  /** How much is held right now (code units). For assertions and the trace, not the content. */
+  get bufferedChars(): number {
+    return this.chars
+  }
+
+  /**
+   * Offer one chunk of keyboard input. Returns the caller's instruction:
+   *  - `passthrough` — not waking; the caller writes it to the transport as usual.
+   *  - `buffered` — held; the caller writes NOTHING (writing is the splice this exists to stop).
+   *  - `queueFull` — over the bound; held nothing, and the caller must not write it either. The
+   *    partial chunk is refused whole rather than truncated: a half-written escape sequence is worse
+   *    than a dropped one, and the caller learns the buffer is full.
+   */
+  offer(input: string): WakeOfferVerdict {
+    if (!this.waking) return { kind: 'passthrough' }
+    if (this.chars + input.length > this.maxChars) return { kind: 'queueFull', capacity: this.maxChars }
+    this.held.push(input)
+    this.chars += input.length
+    return { kind: 'buffered', bufferedChars: this.chars }
+  }
+
+  /**
+   * The wake resolved. Ends the buffering window and empties the buffer.
+   *
+   *  - `resumed === true`: the resume line is confirmed submitted, so the held input is written
+   *    through `write`, IN ORDER, into the pane it belongs to. This is the only path that writes.
+   *  - `resumed === false`: the wake did not resume the conversation (it timed out, the pane became
+   *    something else, or the transport threw). The held bytes are DROPPED — splicing them into a
+   *    pane we did not resume into is the failure mode this whole module exists to prevent.
+   *
+   * Returns what happened and how much, so the caller can trace an `expired` drain (a non-silent
+   * drop, like the message queue's TTL expiry). Safe to call when not waking: it is then a no-op
+   * that reports `flushed` of 0.
+   */
+  endWake(resumed: boolean, write: (data: string) => void): WakeDrainResult {
+    const held = this.held
+    const chars = this.chars
+    this.held = []
+    this.chars = 0
+    this.waking = false
+    if (resumed) {
+      for (const chunk of held) write(chunk)
+      return { reason: 'flushed', chars }
+    }
+    return { reason: 'expired', chars }
+  }
+}


### PR DESCRIPTION
PR 7, the final PR of the agent-messaging series: delivery to BUSY and hibernated agents through a bounded, per-target queue with a TTL — plus the human-side wake buffer that makes the same fragile moment safe, and the owner's phone-target acceptance gate.

Built on `feat/messaging-per-project-switch` (#237): origin/main does not yet carry the runtime pane-ownership ledger (`src/core/agents/pane-ownership.ts`), which PR 7's flush-time re-validation depends on, so this branches off #237 as the brief instructs. Retarget onto main once #237 merges.

## Tasks → commits

| Task | Commit |
|---|---|
| 7.1 — the bounded wake input buffer (build first) | `feat(terminal): a bounded input buffer during wake …` |
| 7.2 — deliver-on-idle: the bounded per-target queue with a TTL | `feat(messaging): deliver-on-idle — a bounded queue with a TTL …` |
| 7.3 — record the residual risks in the code | `docs(messaging): record the residual risks in the code …` |
| 7.4 — ACCEPTANCE GATE: a phone-spawned session is a valid target | `test(messaging): a phone-spawned session is a valid message target, end to end` |

## The DECSET-2004 measurement gates the node-type decision

The queue delivers on idle WITHOUT a per-delivery bracketed-paste probe because the 2026-08-15 measurement (this host, twice each, no flapping) found all four agent CLIs — claude, codex, gemini, opencode — keep DECSET 2004 ON at idle AND during startup, so `paste-buffer -p` frames every flush, including one into a still-starting agent after a wake. The one unsafe surface is a NON-agent pane (2004 OFF ⇒ raw keystrokes, one submit per newline). So the queue gates on NODE TYPE, not a runtime probe: it only ever enqueues for a target whose delivery already refused as `targetBusy`, or a hibernated node whose shell pane becomes an agent after the wake — never a genuine terminal. The flush re-runs gate 1, so a pane that became a terminal while queued is refused, not sprayed.

## Flush-time re-validation (the load-bearing property)

A queued message trusts nothing about why it was queued. The queue's `deliver` dep is `runDelivery` — the same end-to-end path the verb takes (scope → ownership → grant → flow → `deliverAgentMessage`) — so ownership, grant and flow are re-checked against LIVE state on every flush. A grant revoked while a message was queued comes back `notPermitted` at flush and the message is dropped, not delivered. Pinned by a test that flips the injected outcome between enqueue and flush.

## Discipline

TDD throughout; every key assertion is mutation-checked (revert the mechanism → red → restore): the wake buffer's expired-drop guard / exact bound / waking gate; the queue's capacity bound / revoked-grant drop / two-legged expiry / wake-on-enqueue; and the acceptance gate itself (weakening gate 2 breaks its loud tests, no-oping the persist sweep breaks its link 1). `src/core` stays free of electron (`no-electron.test.ts` green).

## Device verification owed

- **codex composer-idle** — the DECSET measurement inferred codex's composer-idle 2004 from process-wide 2004 at TUI entry (its trust dialog could not be answered without persisting host config). One Enter on an already-trusted host closes it.
- **The hibernated-target leg's renderer→main wiring** — the queue's `wake` and `isHibernated` deps are RENDERER state (Eco lives in `useAgentStatus`, the wake registry in the renderer's `agent-restart`), and main has no signal for either today. The BUSY-target leg is fully wired and works end to end in main (enqueue on `targetBusy`, flush on the target's `done` event). The hibernated leg is complete in core + service and unit-tested, but its production main→renderer wake IPC + hibernation read is owed to device verification. The Task 7.4 acceptance gate itself does not exercise hibernation — it proves the phone-spawned-target chain end to end on a real host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
