### PR TITLE
feat(agents): per-agent launch command override (wrapper scripts)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -330,6 +330,7 @@ import { canvasSyncTarget } from './collab-sync'
 import {
   applyCanvasMutation,
   applyMutationToFlow,
+  agentLaunchOverride,
   claudeLaunchCommand,
   COLLAPSED_HEIGHT,
   alignNodes,
@@ -5982,7 +5983,7 @@ export function Canvas() {
         return
       }
       // No live node — open a resume node in the active project, using the transcript's cwd.
-      const cmd = resumeCommand('claude', hit.sessionId)
+      const cmd = resumeCommand('claude', hit.sessionId, false, agentLaunchOverride('claude'))
       if (!cmd) return
       const node = createAgentNode('claude', nodesRef.current.length, hit.cwd, viewCenter())
       // The resume command replaces (never wraps) the factory's command, so it is flagged once.

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -18,9 +18,11 @@ import {
   ALL_PERMISSION_MODES,
   AUTO_PERMISSION_MODE_MIN_VERSION,
   BUILTIN_AGENT_IDS,
+  hasSharedIdentity,
   PERMISSION_MODE_LABELS,
   type AgentId,
-  type AgentPermissionMode
+  type AgentPermissionMode,
+  type BuiltinAgentId
 } from '@shared/agents/config'
 import {
   permissionModeAgentIds,
@@ -32,6 +34,7 @@ import { hintLabel } from '@shared/platform-utils'
 import { NODE_IDENTITY_STRICT_DATE } from '@shared/node-identity'
 import { SegmentedPill } from '@renderer/ui/SegmentedPill'
 import { Button } from '@renderer/ui/Button'
+import { Input } from '@renderer/ui/Input'
 import { Select } from '@renderer/ui/Select'
 import { Switch } from '@renderer/ui/Switch'
 import { NumberField } from '@renderer/ui/NumberField'
@@ -43,6 +46,25 @@ const ROWS = {
   agents: {
     title: 'Agents',
     keywords: ['agent', 'claude', 'codex', 'gemini', 'enable', 'disable', 'default']
+  },
+  launchCommands: {
+    title: 'Launch commands',
+    keywords: [
+      'launch',
+      'command',
+      'wrapper',
+      'cli',
+      'binary',
+      'path',
+      'account',
+      'switch',
+      'custom command',
+      'claude',
+      'codex',
+      'gemini',
+      'grok',
+      'opencode'
+    ]
   },
   permissionMode: {
     title: 'Permission mode',
@@ -255,6 +277,45 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
               </div>
             )
           })}
+        </div>
+      </SearchableRow>
+      <SearchableRow {...ROWS.launchCommands}>
+        <FieldRow
+          label="Launch commands"
+          description={
+            'Launch an agent with your own command — e.g. a wrapper script that switches accounts or sets env vars. ' +
+            'Used everywhere the agent is launched (new sessions, resumes, restarts), with flags like --resume appended after it, ' +
+            'so the command must pass its arguments through — a shell script should end with `exec claude "$@"`. ' +
+            'Leave empty for the default. SSH projects run the same command on the remote host.'
+          }
+          control={null}
+        />
+        <div className="space-y-2">
+          {BUILTIN_AGENT_IDS.map((id: BuiltinAgentId) => (
+            <div key={id} className="flex items-center gap-3 py-1">
+              <AgentIcon agentId={id} size={18} />
+              <span className="w-28 text-[13px] text-text">{AGENT_CONFIG[id].label}</span>
+              <Input
+                className="w-72"
+                placeholder={AGENT_CONFIG[id].launchCmd}
+                aria-label={`${AGENT_CONFIG[id].label} launch command`}
+                value={settings.agentLaunchCommands[id] ?? ''}
+                onChange={(e) => {
+                  // A cleared field DELETES its key rather than storing '' — absent is the one
+                  // spelling of "default" every consumer (and a hand-read settings.json) agrees on.
+                  const next = { ...settings.agentLaunchCommands }
+                  if (e.target.value) next[id] = e.target.value
+                  else delete next[id]
+                  update({ agentLaunchCommands: next })
+                }}
+              />
+              {hasSharedIdentity(id) && settings.agentLaunchCommands[id]?.trim() ? (
+                <span className="text-[12px] text-muted">
+                  Overrides the managed per-node launcher — sessions join as plain clients.
+                </span>
+              ) : null}
+            </div>
+          ))}
         </div>
       </SearchableRow>
       <SearchableRow {...ROWS.permissionMode}>

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -140,7 +140,7 @@ import { useSshConn } from '../state/sshConn'
 import { useWorktrees } from '../state/worktrees'
 import { isRemoteSessionNode } from '@shared/worktree'
 import { useSession, useActiveSessionPresence } from '../session/session'
-import { accountChipLabel, COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from '../state/workspace'
+import { accountChipLabel, agentLaunchOverride, COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from '../state/workspace'
 import { hasHooks, canRecur, canContextLink, hasUsage, canChat, canResume, canRename, canReadTitle, createdAgentId, reportsOwnCopy, resumeCommand, agentConfig, agentLaunchProgram } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
 import { ensureActivePermissionMode } from '../state/permissionMode'
@@ -2766,8 +2766,14 @@ export function TerminalNode({
           // re-claims its own thread instead of joining as an anonymous client. `data.ssh` is what
           // keeps a remote node on the bare command (no launcher on the host).
           const shared = codexSharedIdentity(data.ssh || data.sshRemoteTmux)
+          // The user's launch-command override rides every leg of this relaunch: threaded into
+          // `resumeCommand` (its `base` param), and standing in for the builtin launchCmd on the
+          // no-session fresh start — otherwise a wrapper user's node comes back on the bare CLI
+          // after a reboot, the one moment the wrapper (account env etc.) mattered most.
+          const launchOverride = agentLaunchOverride(agentId)
           const base =
-            (priorId && resumeCommand(agentId, priorId, shared)) ||
+            (priorId && resumeCommand(agentId, priorId, shared, launchOverride)) ||
+            launchOverride ||
             (agentConfig(agentId) &&
               agentLaunchProgram(agentId, agentConfig(agentId)!.launchCmd, shared))
           // Re-resolve the mode at relaunch: it's a property of how a session is launched, not
@@ -2841,8 +2847,9 @@ export function TerminalNode({
         // read — exactly as the cold-restore relaunch above does it. Without it a canvas running
         // in acceptEdits/plan would come back from a restart in the default mode, silently.
         // Re-resolved at call time for the same reason as there: the mode is a property of how a
-        // session is launched, not of the node.
-        const base = resumeCommand(agentId, agentSessionId)
+        // session is launched, not of the node. The launch-command override rides along for the
+        // same reason — it is a property of how the agent is launched, read fresh per restart.
+        const base = resumeCommand(agentId, agentSessionId, false, agentLaunchOverride(agentId))
         const command = base
           ? withPermissionMode(base, agentId, await ensureActivePermissionMode(agentId))
           : undefined
@@ -2940,7 +2947,9 @@ export function TerminalNode({
         // not carry its directory on PATH — naming it there would be `command not found` where a
         // plain `codex resume` works. A restarted codex node therefore rejoins as a plain client
         // until its next cold start. Fail open, same rule as everywhere else in this feature.
-        const base = resumeCommand(agentId, agentSessionId)
+        // The USER's launch-command override is different from the launcher: it lives on their
+        // own PATH (or is an absolute path), not in a generated dir, so it rides the wake too.
+        const base = resumeCommand(agentId, agentSessionId, false, agentLaunchOverride(agentId))
         // Refused BEFORE anything is written. `performResumePhase` gates on this same bare command
         // and would refuse too — but the KILL_LINE below is ours, so leaving this check to it
         // meant an unusable session id erased the pane's line (three times, once per wake trigger)

--- a/src/renderer/state/workspace.launch-override.test.ts
+++ b/src/renderer/state/workspace.launch-override.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { agentLaunchOverride, claudeLaunchCommand, createAgentNode } from './workspace'
+import { useSettings } from './settings'
+import { DEFAULT_SETTINGS, type Settings } from '@shared/types'
+
+/**
+ * The launch-command override (Settings → Agents → Launch commands): a wrapper the user launches
+ * an agent through — the "I switch accounts with a wrapper script" request. The load-bearing
+ * facts pinned here:
+ *  - the override replaces the program part of a NEW node's launch line, and every appended
+ *    piece (prompt quoting, permission-mode flag, grok's `--` separator) lands exactly where it
+ *    does on the bare command;
+ *  - an unset/blank override changes nothing, byte-for-byte — the default-path guarantee every
+ *    existing user is standing on.
+ *
+ * `useSettings.setState` (not `update`) on purpose: update() schedules a disk save through
+ * `window.nodeTerminal`, which does not exist in this test environment.
+ */
+const withOverrides = (agentLaunchCommands: Settings['agentLaunchCommands']): void => {
+  useSettings.setState({ settings: { ...DEFAULT_SETTINGS, agentLaunchCommands } })
+}
+
+afterEach(() => {
+  useSettings.setState({ settings: DEFAULT_SETTINGS })
+})
+
+const cmd = (agentId: string, prompt?: string): string =>
+  (createAgentNode(agentId, 0, undefined, undefined, prompt).data.initialCommand as string) ?? ''
+
+describe('agentLaunchOverride', () => {
+  it('is undefined out of the box and for blank values', () => {
+    expect(agentLaunchOverride('claude')).toBeUndefined()
+    withOverrides({ claude: '   ' })
+    expect(agentLaunchOverride('claude')).toBeUndefined()
+  })
+
+  it('returns the trimmed override', () => {
+    withOverrides({ claude: '  my-claude work  ' })
+    expect(agentLaunchOverride('claude')).toBe('my-claude work')
+  })
+
+  it('never answers for a custom agent — they own their launchCmd', () => {
+    withOverrides({ claude: 'cc' })
+    expect(agentLaunchOverride('custom:abc')).toBeUndefined()
+  })
+})
+
+describe('claudeLaunchCommand', () => {
+  it('stays byte-identical to the historical default when unset', () => {
+    expect(claudeLaunchCommand()).toBe('claude')
+  })
+
+  it('is the override when set — Branch’s `-r <id>` append rides it unchanged', () => {
+    withOverrides({ claude: 'my-claude work' })
+    expect(claudeLaunchCommand()).toBe('my-claude work')
+  })
+})
+
+describe('createAgentNode — launch-command override', () => {
+  it('launches claude through the wrapper, prompt appended as ever', () => {
+    withOverrides({ claude: 'my-claude work' })
+    expect(cmd('claude', 'fix the bug')).toBe("my-claude work 'fix the bug'")
+  })
+
+  it('keeps grok’s `--` separator after the override', () => {
+    withOverrides({ grok: 'grok-wrap' })
+    expect(cmd('grok', 'version')).toBe("grok-wrap -- 'version'")
+  })
+
+  it('keeps opencode’s --prompt flag after the override', () => {
+    withOverrides({ opencode: 'oc-wrap' })
+    expect(cmd('opencode', 'hello')).toBe("oc-wrap --prompt 'hello'")
+  })
+
+  it('leaves every agent without an override on its bare command', () => {
+    withOverrides({ claude: 'my-claude work' })
+    expect(cmd('codex', 'hello')).toBe("codex 'hello'")
+    expect(cmd('gemini')).toBe('gemini')
+  })
+})

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -1,6 +1,6 @@
 import type { Node } from '@xyflow/react'
 import type { CanvasMutation, CanvasNodeState, ClaudeAccount, NodeKind, PendingLaunch, Project } from '@shared/types'
-import type { AgentId, AgentPermissionMode } from '@shared/agents/config'
+import type { AgentId, AgentPermissionMode, BuiltinAgentId } from '@shared/agents/config'
 import { agentConfig, agentLaunchProgram, mintsSessionId, withSessionId } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
 import { uuid } from '@renderer/lib/uuid'
@@ -278,12 +278,31 @@ export function createSshTerminalNode(
 }
 
 /**
+ * The user's launch-command override for a builtin agent (Settings → Agents → Launch commands),
+ * or undefined when unset/blank. This is the ONE place the setting is read; every launch site
+ * (new node, cold restore, in-place restart, hibernation wake, transcript resume) either calls
+ * this or receives its result — shared/agents/config.ts cannot read settings (layering), so the
+ * renderer resolves the override and passes it down (`resumeCommand`'s `base` param).
+ *
+ * Trusted verbatim, like a custom agent's `launchCmd`: it comes from the local user's own
+ * settings.json and is typed into their own pane. Custom agents index past the builtin-keyed map
+ * to undefined — they already own their launchCmd.
+ */
+export function agentLaunchOverride(agentId: AgentId): string | undefined {
+  const raw = useSettings.getState().settings.agentLaunchCommands?.[agentId as BuiltinAgentId]
+  const cmd = typeof raw === 'string' ? raw.trim() : ''
+  return cmd || undefined
+}
+
+/**
  * Command that launches Claude Code. Detection works via hooks installed globally in
  * ~/.claude/settings.json (gated by NODETERM_* env that the PTY manager sets), so a plain
- * `claude` is enough. Append `-r <id>` to resume a specific session (used by Branch).
+ * `claude` is enough — which is also why an override wrapper (account switchers etc.) is safe
+ * here: hooks identify the session whatever the launch line was, as long as the wrapper ends up
+ * exec-ing the real CLI. Append `-r <id>` to resume a specific session (used by Branch).
  */
 export function claudeLaunchCommand(): string {
-  return 'claude'
+  return agentLaunchOverride('claude') ?? 'claude'
 }
 
 /** Fallback color for custom / unknown agents that have no config-provided color. */
@@ -365,10 +384,13 @@ export function createAgentNode(
   // machine actually has one — otherwise the bare CLI, byte-identical to before. Asked through the
   // capability helper, never `agentId === 'codex'`; `codexSharedIdentity` folds in the SSH answer
   // (a host has no launcher installed yet, so a remote node must stay on the bare command).
+  // A user launch-command override wins over BOTH the builtin default and the managed launcher —
+  // an explicit "launch it exactly like this" (see agentLaunchOverride / resumeCommand's `base`).
+  const override = agentLaunchOverride(agentId)
   const baseCmd =
     agentId === 'claude'
       ? claudeLaunchCommand()
-      : agentLaunchProgram(agentId, launchCmd, codexSharedIdentity(ssh))
+      : (override ?? agentLaunchProgram(agentId, launchCmd, codexSharedIdentity(ssh)))
   // A flag-prompt agent (opencode) takes the initial prompt via its flag — a bare positional
   // would be misread (opencode treats it as a project path). Everything else keeps the
   // historical argv append, INCLUDING stdin-after-start agents (gemini has always launched

--- a/src/shared/agents/config.ts
+++ b/src/shared/agents/config.ts
@@ -305,20 +305,34 @@ export function withSessionId(cmd: string, id: AgentId, sessionId: string): stri
  * `sharedIdentity` routes a SHARED_IDENTITY_CAPABLE agent's resume through the managed launcher,
  * so the resumed session re-claims the node's own thread instead of opening it as an anonymous
  * client. Default false = the bare command this has always emitted (see `agentLaunchProgram`).
+ *
+ * `base` is the user's launch-command override for this agent (`settings.agentLaunchCommands`,
+ * e.g. an account-switching wrapper), PASSED IN rather than read here: this module is imported by
+ * main/core/server and cannot reach the renderer's settings store, so the renderer resolves the
+ * override and threads it through — the same shape as `performRestartResume`'s `command` param.
+ * When set (non-blank) it replaces the program part outright, INCLUDING codex's shared-identity
+ * launcher: an explicit override is the user saying "launch it exactly like this", and silently
+ * substituting the managed launcher would un-say it. Blank/absent = unchanged behavior.
  */
-export function resumeCommand(id: AgentId, sessionId: string, sharedIdentity = false): string | null {
+export function resumeCommand(
+  id: AgentId,
+  sessionId: string,
+  sharedIdentity = false,
+  base?: string
+): string | null {
   if (!canResume(id)) return null
   const sid = sessionId.trim()
   if (!sid || !SAFE_SESSION_ID.test(sid)) return null
+  const custom = base?.trim() || undefined
   switch (id) {
     case 'codex':
-      return `${agentLaunchProgram('codex', 'codex', sharedIdentity)} resume ${sid}`
+      return `${custom ?? agentLaunchProgram('codex', 'codex', sharedIdentity)} resume ${sid}`
     case 'opencode':
-      return `opencode --session ${sid}`
+      return `${custom ?? 'opencode'} --session ${sid}`
     case 'claude':
     case 'gemini':
     case 'grok':
-      return `${id} --resume ${sid}`
+      return `${custom ?? id} --resume ${sid}`
     default:
       return null
   }

--- a/src/shared/agents/resume.test.ts
+++ b/src/shared/agents/resume.test.ts
@@ -73,3 +73,47 @@ describe('resumeCommand — grok', () => {
     expect(resumeCommand('grok', 'abc-123')).toBe('grok --resume abc-123')
   })
 })
+
+/**
+ * `base` is the user's launch-command override (settings.agentLaunchCommands — e.g. an
+ * account-switching wrapper), threaded in from the renderer because this shared module cannot
+ * read the settings store. It replaces the PROGRAM part only; each agent's resume grammar
+ * (`--resume` / `resume` / `--session`) stays put after it.
+ */
+describe('resumeCommand — launch-command override (base)', () => {
+  it('replaces the program part for the --resume family', () => {
+    expect(resumeCommand('claude', 'abc-123', false, 'my-claude work')).toBe(
+      'my-claude work --resume abc-123'
+    )
+    expect(resumeCommand('gemini', 'abc-123', false, 'gemini-wrap')).toBe(
+      'gemini-wrap --resume abc-123'
+    )
+  })
+
+  it('keeps codex’s subcommand and opencode’s flag spelling', () => {
+    expect(resumeCommand('codex', 'abc-123', false, '/opt/bin/codex-work')).toBe(
+      '/opt/bin/codex-work resume abc-123'
+    )
+    expect(resumeCommand('opencode', 'ses_a1', false, 'oc-wrap')).toBe('oc-wrap --session ses_a1')
+  })
+
+  // An explicit override is the user saying "launch it exactly like this" — substituting the
+  // managed launcher back in would un-say it (see resumeCommand's doc).
+  it('wins over codex’s shared-identity launcher', () => {
+    expect(resumeCommand('codex', 'abc-123', true, '/opt/bin/codex-work')).toBe(
+      '/opt/bin/codex-work resume abc-123'
+    )
+  })
+
+  it('ignores a blank override — the bare command, byte-identical', () => {
+    expect(resumeCommand('claude', 'abc-123', false, '   ')).toBe('claude --resume abc-123')
+    expect(resumeCommand('claude', 'abc-123', false, undefined)).toBe('claude --resume abc-123')
+  })
+
+  // SAFE_SESSION_ID is the gate whatever the caller passes — the override customizes the
+  // program, never the validation.
+  it('still refuses an unsafe session id, override or not', () => {
+    expect(resumeCommand('claude', 'a; rm -rf /', false, 'wrapper')).toBeNull()
+    expect(resumeCommand('claude', '', false, 'wrapper')).toBeNull()
+  })
+})

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,7 +2,7 @@
 
 import type { CloneProgress } from './clone-url'
 import type { NormalizedAgentEvent } from './agents/normalize'
-import type { AgentId, AgentPermissionMode, PromptInjectionMode } from './agents/config'
+import type { AgentId, AgentPermissionMode, BuiltinAgentId, PromptInjectionMode } from './agents/config'
 import type { AgentMessageDeliverRequest, AgentMessageReply } from './agents/agent-messaging'
 import type { GroupWorktree } from './worktree'
 import type { ClientId, DinoSnapshot, PeerDiff, PeerIdentity, PeerState } from './presence'
@@ -993,6 +993,13 @@ export interface Settings {
   soundVolume: number
   /** User-defined agents (BYO CLI) appended to the Add menus. */
   customAgents: CustomAgent[]
+  /** Per-builtin-agent launch command overrides (Settings → Agents → Launch commands). The value
+   *  replaces the bare CLI name everywhere a launch line is built — new sessions, cold-restore
+   *  relaunches and in-place restarts, with the usual flags (`--resume`, `--permission-mode`, the
+   *  prompt) appended after it — so a wrapper script that picks an account or sets env vars runs
+   *  wherever the agent would. Empty/absent = the builtin default, byte-identical to before this
+   *  setting existed. Keyed by builtin id only: custom agents already own their `launchCmd`. */
+  agentLaunchCommands: Partial<Record<BuiltinAgentId, string>>
   /** Managed Claude accounts (config-dir isolated). See ClaudeAccount. */
   claudeAccounts: ClaudeAccount[]
   /** Custom display label for the SYSTEM Claude account (~/.claude) in pickers/settings.
@@ -1137,6 +1144,7 @@ export const DEFAULT_SETTINGS: Settings = {
   soundEffects: true,
   soundVolume: 0.5,
   customAgents: [],
+  agentLaunchCommands: {},
   claudeAccounts: [],
   systemAccountLabel: '',
   // All three builtin agents (Claude/Codex/Gemini) show in the Add menus out of the box.


### PR DESCRIPTION
## Motivation

A user asked:

> I wonder if there is an option to customize claude code's command line - I use wrappers allowing me to switch between accounts, so it would be nice to customize it and allow it to run claude in several ways (or do like Orca and identify claude while it starts within a terminal)

Two halves to that:

1. **Identifying claude started by hand in a terminal** — nodeterm already does this, the same way Orca does (I cloned FatihErtugral/orca to confirm its mechanism: Claude Code hooks calling a bridge binary). Our hooks fire whatever the launch line was, so a wrapper-launched claude in a plain terminal node is already tracked. Nothing to build.
2. **Customizing the command the builtin Claude node types** — this was the real gap. `claudeLaunchCommand()` was a hardcoded `'claude'`, and custom agents (which do have a `launchCmd`) are in no capability list, so using one means losing resume, permission mode, usage, hooks, branch, etc.

## What

**Settings → Agents → Launch commands**: one override field per builtin agent. When set, it replaces the program part of the launch line at every site that builds one:

- new agent nodes (`createAgentNode` — prompt quoting, `--permission-mode`, and grok's `--` separator land after it exactly as on the bare command)
- cold-restore relaunch after a reboot (both the `--resume` leg and the no-session fresh-start leg)
- in-place restart (node menu / bulk) and hibernation wake
- transcript-search "resume a dead session" and Branch (`-r <id>`)

Empty/unset = the builtin default, byte-identical to today — pinned by tests.

## How

- `Settings.agentLaunchCommands: Partial<Record<BuiltinAgentId, string>>` (default `{}`; shallow settings merge covers old files).
- `shared/agents/config.ts` cannot read the settings store (layering), so `resumeCommand` grows an optional `base` param and the renderer threads the resolved override through — same shape as `performRestartResume`'s `command` param. `agentLaunchOverride()` in `workspace.ts` is the single read site.
- An explicit override wins over codex's shared-identity launcher ("launch it exactly like this"); the settings row shows a note when that applies.
- A cleared field deletes its key rather than storing `''`.

## Notes / known limitations

- The settings copy tells users a wrapper must pass args through (`exec claude "$@"`) — flags like `--resume` are appended to the override.
- `claude-cli.ts` still probes the raw `claude` on PATH for version caps. A wrapper-only install (no `claude` on PATH at all) degrades gracefully: `--permission-mode auto` and session-id minting are dropped, launch still works. Probing an arbitrary user command felt out of scope here.
- The account-login node keeps its literal `claude /login` — it belongs to nodeterm's managed-accounts feature (CLAUDE_CONFIG_DIR isolation), which an account-switching wrapper would fight anyway.
- SSH projects type the same override into the remote pane (same precedent as custom agents' `launchCmd`); the description says so.
- `npx vitest run src/shared/agents src/renderer/state src/renderer/terminal` + typecheck green (one pre-existing env failure: `webgl-addon-pair.test.ts` reads `node_modules` by path, absent in a fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)