### PR TITLE
test(messaging): stabilize phone-target-e2e on CI runners (fixes #241)

### DIFF
--- a/src/core/agents/phone-target-e2e.test.ts
+++ b/src/core/agents/phone-target-e2e.test.ts
@@ -234,12 +234,28 @@ function waitFor(cond: () => boolean, ms: number, what: string): void {
   throw new Error(`timed out waiting for ${what}`)
 }
 
+/**
+ * The fake agent is `cat` wearing claude's argv0 — NOT an interactive bash, and the difference is
+ * what made this test red on GitHub runners while green locally (issue #241, failed 4/4 there).
+ *
+ * An `exec -a claude bash -i` has JOB CONTROL: it executes the pasted envelope line by line, and
+ * every line forks a child into its OWN process group and hands it the tty's foreground. G3's
+ * post-write probe reads exactly that foreground group (`pane-owner.ts`), so a probe landing in
+ * one of those windows sees a different pgid/pid and reports `deliveredToReplacedTarget`. On a
+ * fast machine the window is microseconds and 16/16 local runs missed it; on a loaded 2-core
+ * runner the probe hit it every time. A real agent TUI never executes the payload — the envelope
+ * lands in its composer — so the fork storm was a test artifact, not the production shape.
+ *
+ * `cat` is still a REAL reader on a real tty (the point of this e2e): it sits in the foreground
+ * group reading the pane's stdin, never forks, and the tty's canonical-mode echo puts the pasted
+ * frame on the pane for the capture assertions below.
+ */
 function startAgentPane(session: string): void {
   tmux(
     'new-session', '-d', '-s', session, '-x', '200', '-y', '40',
-    `${BASH} -c 'exec -a claude ${BASH} --norc --noprofile -i'`
+    `${BASH} -c 'echo READY; exec -a claude cat'`
   )
-  waitFor(() => capturePane(session).includes('#') || capturePane(session).includes('$'), 5000, 'a prompt')
+  waitFor(() => capturePane(session).includes('READY'), 5000, 'the reader')
 }
 
 function realPaneOwner(session: string): DeliveryDeps['paneOwner'] {


### PR DESCRIPTION
`quality` is red on main since #239 — this unblocks it (branch protection currently blocks every merge, #240 included).

The e2e's fake agent was `exec -a claude bash -i`: a job-controlled shell that **executes** the pasted envelope, forking each line into its own process group and handing it the tty foreground. G3's post-write probe reads exactly that foreground group (`pane-owner.ts`), so on GitHub's 2-core runners it landed in the fork window every time — 4/4 red (main run 31905108806 + three PR #240 runs) — and reported `deliveredToReplacedTarget`, while 16/16 local runs (including `taskset -c 0`) missed the microsecond window. A real agent TUI never executes the payload, so the fork storm was a test artifact, not the production shape.

Fix: the fake agent is now `cat` wearing claude's argv0 — still a real foreground reader on a real tty (argv identity, tty echo for the frame assertions), but it never forks, so the foreground group cannot change. 5/5 local runs green incl. single-CPU pinned; this PR's own `quality` run is the CI-side proof.

Noted in #241: production's G3 check shares the benign blind spot (a target CLI briefly fork/exec-ing at probe time). That may deserve a re-probe-before-concluding pass, but it's a product decision for the messaging owner — this PR only stabilizes the test.

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)