### PR TITLE
fix(agents): custom agents can be the default — a disabled claude stays un-defaulted

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -287,6 +287,7 @@ import { pushSessionRename } from '../lib/sessionRename'
 import { oneLine } from '@shared/one-line'
 import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
 import { useSettings } from '../state/settings'
+import { launchableDefaultAgent } from '../state/agentAvailability'
 import { activePermissionMode } from '../state/permissionMode'
 import { useContextWindow } from '../state/contextWindow'
 import { useSessionNaming } from '../state/sessionNaming'
@@ -3614,7 +3615,9 @@ export function Canvas() {
         addTerminal()
       } else if (k === 'c' && e.shiftKey) {
         e.preventDefault()
-        addAgentNode(useSettings.getState().settings.defaultAgent)
+        // launchableDefaultAgent, not the raw setting: a default naming a since-removed custom
+        // agent would otherwise type its bare `custom:<uuid>` id into the new node's shell.
+        addAgentNode(launchableDefaultAgent(useSettings.getState().settings))
       }
     }
     window.addEventListener('keydown', onKey)

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -256,15 +256,15 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
               <div key={row.id} className="flex items-center gap-3 py-1.5">
                 <AgentIcon agentId={row.id} size={18} />
                 <span className="flex-1 text-[13px] text-text">{row.label}</span>
-                {row.isBuiltin && (
-                  <Button
-                    variant={isDefault ? 'primary' : 'default'}
-                    aria-pressed={isDefault}
-                    onClick={() => update(setDefaultAgent(settings, row.id))}
-                  >
-                    {isDefault ? 'Default' : 'Set default'}
-                  </Button>
-                )}
+                {/* Custom agents included — a user living on their own CLI aliases must be able
+                    to make one the default (⌘⇧C / Add menu) instead of a disabled claude. */}
+                <Button
+                  variant={isDefault ? 'primary' : 'default'}
+                  aria-pressed={isDefault}
+                  onClick={() => update(setDefaultAgent(settings, row.id))}
+                >
+                  {isDefault ? 'Default' : 'Set default'}
+                </Button>
                 <SegmentedPill<'enabled' | 'disabled'>
                   value={enabled ? 'enabled' : 'disabled'}
                   ariaLabel={`${row.label} availability`}

--- a/src/renderer/components/settings/sections/CustomAgentsSection.tsx
+++ b/src/renderer/components/settings/sections/CustomAgentsSection.tsx
@@ -1,4 +1,5 @@
 import { useSettings } from '../../../state/settings'
+import { removeCustomAgent } from '../../../state/agentAvailability'
 import type { CustomAgent } from '@shared/types'
 import type { PromptInjectionMode } from '@shared/agents/config'
 import { SettingsSection } from '../SettingsSection'
@@ -19,8 +20,10 @@ export function CustomAgentsSection({ isActive }: { isActive: boolean }): React.
   const update = useSettings((s) => s.update)
   const patchAgent = (id: string, patch: Partial<CustomAgent>) =>
     update({ customAgents: customAgents.map((a) => (a.id === id ? { ...a, ...patch } : a)) })
-  const removeAgent = (id: string) =>
-    update({ customAgents: customAgents.filter((a) => a.id !== id) })
+  // Through removeCustomAgent, never a bare filter: a removed agent that was the default (or
+  // disabled) would otherwise leave its dead id in `defaultAgent` / `disabledAgents`, and ⌘⇧C
+  // would type the raw `custom:<uuid>` into a shell.
+  const removeAgent = (id: string) => update(removeCustomAgent(useSettings.getState().settings, id))
   const addAgent = () =>
     update({
       customAgents: [

--- a/src/renderer/state/agentAvailability.test.ts
+++ b/src/renderer/state/agentAvailability.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  firstEnabledAgent,
+  launchableDefaultAgent,
+  removeCustomAgent,
+  setAgentEnabled,
+  setDefaultAgent
+} from './agentAvailability'
+import type { CustomAgent } from '@shared/types'
+
+const custom = (id: string, label = id): CustomAgent => ({
+  id: `custom:${id}`,
+  label,
+  launchCmd: label,
+  promptInjectionMode: 'argv'
+})
+
+/**
+ * The reported bug (2026-08-15): "when I add a custom agent and disable claude it still seems to
+ * take claude as default". The old reassignment only considered BUILTINS, so a user who disabled
+ * every builtin to live on their own CLI aliases had the default snap back to 'claude' — the one
+ * agent they had just switched off.
+ */
+describe('firstEnabledAgent', () => {
+  it('prefers the first enabled builtin, in claude → codex order', () => {
+    expect(firstEnabledAgent({ disabledAgents: [], customAgents: [] })).toBe('claude')
+    expect(firstEnabledAgent({ disabledAgents: ['claude'], customAgents: [] })).toBe('codex')
+  })
+
+  it('falls through to an enabled CUSTOM agent when every builtin is disabled — the bug', () => {
+    const all = ['claude', 'codex', 'gemini', 'opencode', 'grok']
+    expect(firstEnabledAgent({ disabledAgents: all, customAgents: [custom('work')] })).toBe(
+      'custom:work'
+    )
+  })
+
+  it('skips a disabled custom agent too', () => {
+    const all = ['claude', 'codex', 'gemini', 'opencode', 'grok', 'custom:work']
+    expect(
+      firstEnabledAgent({ disabledAgents: all, customAgents: [custom('work'), custom('personal')] })
+    ).toBe('custom:personal')
+  })
+
+  it("answers 'claude' only when literally everything is disabled", () => {
+    const all = ['claude', 'codex', 'gemini', 'opencode', 'grok', 'custom:work']
+    expect(firstEnabledAgent({ disabledAgents: all, customAgents: [custom('work')] })).toBe('claude')
+  })
+})
+
+describe('setAgentEnabled — default reassignment', () => {
+  it('hands the default to a custom agent when the last builtin goes dark', () => {
+    const s = {
+      disabledAgents: ['codex', 'gemini', 'opencode', 'grok'],
+      defaultAgent: 'claude',
+      customAgents: [custom('work')]
+    }
+    expect(setAgentEnabled(s, 'claude', false).defaultAgent).toBe('custom:work')
+  })
+
+  it('leaves the default alone when a non-default agent is disabled', () => {
+    const s = { disabledAgents: [], defaultAgent: 'claude', customAgents: [custom('work')] }
+    expect(setAgentEnabled(s, 'codex', false).defaultAgent).toBe('claude')
+  })
+})
+
+describe('setDefaultAgent — custom agents are eligible', () => {
+  it('sets a custom agent as default and re-enables it', () => {
+    const s = {
+      disabledAgents: ['custom:work'],
+      defaultAgent: 'claude',
+      customAgents: [custom('work')]
+    }
+    const next = setDefaultAgent(s, 'custom:work')
+    expect(next.defaultAgent).toBe('custom:work')
+    expect(next.disabledAgents).not.toContain('custom:work')
+  })
+})
+
+describe('removeCustomAgent', () => {
+  it('reassigns a default that pointed at the removed agent', () => {
+    const s = {
+      disabledAgents: [],
+      defaultAgent: 'custom:work',
+      customAgents: [custom('work')]
+    }
+    const next = removeCustomAgent(s, 'custom:work')
+    expect(next.customAgents).toEqual([])
+    expect(next.defaultAgent).toBe('claude')
+  })
+
+  it('drops the id from disabledAgents and leaves an unrelated default alone', () => {
+    const s = {
+      disabledAgents: ['custom:work'],
+      defaultAgent: 'gemini',
+      customAgents: [custom('work'), custom('personal')]
+    }
+    const next = removeCustomAgent(s, 'custom:work')
+    expect(next.disabledAgents).toEqual([])
+    expect(next.defaultAgent).toBe('gemini')
+    expect(next.customAgents.map((c) => c.id)).toEqual(['custom:personal'])
+  })
+})
+
+describe('launchableDefaultAgent', () => {
+  it('passes through a builtin or an existing custom default', () => {
+    expect(
+      launchableDefaultAgent({ disabledAgents: [], defaultAgent: 'gemini', customAgents: [] })
+    ).toBe('gemini')
+    expect(
+      launchableDefaultAgent({
+        disabledAgents: [],
+        defaultAgent: 'custom:work',
+        customAgents: [custom('work')]
+      })
+    ).toBe('custom:work')
+  })
+
+  // The stale-id case exists in the wild: older builds removed custom agents with a bare filter,
+  // leaving `defaultAgent: 'custom:<uuid>'` behind in settings.json.
+  it('refuses a dangling custom id — the raw uuid must never reach a shell', () => {
+    expect(
+      launchableDefaultAgent({ disabledAgents: [], defaultAgent: 'custom:gone', customAgents: [] })
+    ).toBe('claude')
+  })
+})

--- a/src/renderer/state/agentAvailability.ts
+++ b/src/renderer/state/agentAvailability.ts
@@ -1,15 +1,24 @@
 import type { Settings } from '@shared/types'
-import { BUILTIN_AGENT_IDS, type AgentId } from '@shared/agents/config'
+import { agentConfig, BUILTIN_AGENT_IDS, type AgentId } from '@shared/agents/config'
 
-type Avail = Pick<Settings, 'disabledAgents' | 'defaultAgent'>
+type Avail = Pick<Settings, 'disabledAgents' | 'defaultAgent' | 'customAgents'>
 
 export function isAgentEnabled(settings: Pick<Settings, 'disabledAgents'>, id: AgentId): boolean {
   return !settings.disabledAgents.includes(id)
 }
 
-// First non-disabled builtin in claude → codex → gemini order; 'claude' if all disabled.
-export function firstEnabledBuiltin(disabled: AgentId[]): AgentId {
-  return BUILTIN_AGENT_IDS.find((id) => !disabled.includes(id)) ?? 'claude'
+/**
+ * First enabled agent in claude → codex → gemini → … order, then the user's custom agents in
+ * their own order; 'claude' only when literally everything is disabled. Custom agents are real
+ * candidates here — a user who disables every builtin to live on their own CLI aliases must not
+ * have the default snap back to a claude they just switched off (reported 2026-08-15: "disable
+ * claude and it still seems to take claude as default").
+ */
+export function firstEnabledAgent(settings: Pick<Settings, 'disabledAgents' | 'customAgents'>): AgentId {
+  const builtin = BUILTIN_AGENT_IDS.find((id) => !settings.disabledAgents.includes(id))
+  if (builtin) return builtin
+  const custom = settings.customAgents.find((c) => !settings.disabledAgents.includes(c.id))
+  return custom?.id ?? 'claude'
 }
 
 // Enable/disable an agent; if the current default gets disabled, reassign it.
@@ -20,11 +29,47 @@ export function setAgentEnabled(settings: Avail, id: AgentId, enabled: boolean):
       ? settings.disabledAgents
       : [...settings.disabledAgents, id]
   const defaultAgent =
-    !enabled && settings.defaultAgent === id ? firstEnabledBuiltin(disabled) : settings.defaultAgent
-  return { disabledAgents: disabled, defaultAgent }
+    !enabled && settings.defaultAgent === id
+      ? firstEnabledAgent({ disabledAgents: disabled, customAgents: settings.customAgents })
+      : settings.defaultAgent
+  return { disabledAgents: disabled, defaultAgent, customAgents: settings.customAgents }
 }
 
-// Make an agent the default; re-enable it if it was disabled.
+// Make an agent the default; re-enable it if it was disabled. Custom agents are eligible.
 export function setDefaultAgent(settings: Avail, id: AgentId): Avail {
-  return { disabledAgents: settings.disabledAgents.filter((a) => a !== id), defaultAgent: id }
+  return {
+    disabledAgents: settings.disabledAgents.filter((a) => a !== id),
+    defaultAgent: id,
+    customAgents: settings.customAgents
+  }
+}
+
+/**
+ * Remove a custom agent WITHOUT leaving dangling references: its id is dropped from
+ * `disabledAgents` (a dead id there is inert but would resurrect oddly if a same-id agent ever
+ * reappeared), and a default pointing at it is reassigned — otherwise ⌘⇧C would type the raw
+ * `custom:<uuid>` into a shell (resolveAgent's unknown-id fallback launches the id itself).
+ */
+export function removeCustomAgent(settings: Avail, id: AgentId): Avail {
+  const customAgents = settings.customAgents.filter((c) => c.id !== id)
+  const disabledAgents = settings.disabledAgents.filter((a) => a !== id)
+  const defaultAgent =
+    settings.defaultAgent === id
+      ? firstEnabledAgent({ disabledAgents, customAgents })
+      : settings.defaultAgent
+  return { customAgents, disabledAgents, defaultAgent }
+}
+
+/**
+ * The default agent as something that can actually LAUNCH: the setting itself when it names a
+ * builtin or an existing custom agent, else the first enabled agent. Guards the launch sites
+ * (⌘⇧C, the Add menu's default) against a persisted default whose custom agent was since
+ * removed — settings.json is hand-editable and older builds deleted custom agents without
+ * reassigning the default, so the stale-id case exists in the wild, not only in theory.
+ */
+export function launchableDefaultAgent(settings: Avail): AgentId {
+  const id = settings.defaultAgent
+  if (agentConfig(id)) return id
+  if (settings.customAgents.some((c) => c.id === id)) return id
+  return firstEnabledAgent(settings)
 }


### PR DESCRIPTION
## Report

> looks fine but when i add a custom agent and disable claude it still seems to take claude as default... but i have one personal and company under different cli aliases and need to switch - how?

Confirmed — three holes, one cause: custom agents were not default-eligible anywhere.

1. **The "Set default" button only rendered on builtin rows** (`AgentsSection`), so a custom agent could never be chosen at all — the visible half of the report.
2. **Disabling the default agent reassigned via `firstEnabledBuiltin`**, which only knows builtins and answers `'claude'` when all five are off. A user who disables every builtin to live on their own CLI aliases had the default snap back to the exact agent they just switched off.
3. **Removing a custom agent was a bare `filter`**, leaving a dangling id in `defaultAgent` / `disabledAgents`; ⌘⇧C then typed the raw `custom:<uuid>` into a shell (`resolveAgent`'s unknown-id fallback launches the id itself).

## Fix

- `firstEnabledAgent` replaces `firstEnabledBuiltin`: builtins first (claude → codex → … order unchanged), then the user's custom agents in their own order; `'claude'` only when literally everything is disabled.
- The Set default button renders for custom rows too; `setDefaultAgent` already handled the rest.
- `removeCustomAgent` cleans all three lists in one step, and `launchableDefaultAgent` guards the ⌘⇧C launch site against stale custom ids already persisted in the wild (older builds deleted without reassigning).

Defaults for everyone not using custom agents are byte-identical — pinned by 11 new tests in `agentAvailability.test.ts`; typecheck + full renderer state/components suites green.

## The user's actual question ("personal + company aliases — how to switch?")

Suggested reply, best option first: (1) **managed Claude accounts** (Settings → Accounts) — both logins isolated under their own `CLAUDE_CONFIG_DIR`, picked per node / per project, full Claude features, no wrappers; (2) the new **Launch commands** field (#240) for a single wrapper that decides the account itself (end it with `exec claude "$@"`); (3) two custom agents work after this fix, but custom agents don't get Claude's integrations, so 1–2 serve better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)