### PR TITLE
feat(sidebar): add an Unread status section

### DIFF
--- a/src/renderer/lib/sessionList.test.ts
+++ b/src/renderer/lib/sessionList.test.ts
@@ -7,6 +7,7 @@ import {
   liveCollapseKeys,
   pruneCollapsedItems,
   sessionStatusKind,
+  sessionStatusGroup,
   sessionStateAgeLabel,
   projectIdAtIndex,
   isGroupCollapsed,
@@ -39,6 +40,25 @@ describe('sessionStatusKind', () => {
     // A done turn is its OWN kind, not attention: the unread mark already carries "new for you".
     expect(sessionStatusKind('done')).toBe('done')
     expect(sessionStatusKind(undefined)).toBe('unknown')
+  })
+})
+
+describe('sessionStatusGroup — the status-mode section, unread-aware', () => {
+  it('attention wins over everything, even an unread flag', () => {
+    expect(sessionStatusGroup('attention', false)).toBe('attention')
+    expect(sessionStatusGroup('attention', true)).toBe('attention')
+  })
+  it('a live turn is Running even when flagged unread (matches the project glyph)', () => {
+    expect(sessionStatusGroup('working', false)).toBe('working')
+    expect(sessionStatusGroup('working', true)).toBe('working')
+  })
+  it('a settled-but-unlooked-at session is Unread', () => {
+    expect(sessionStatusGroup('done', true)).toBe('unread')
+    expect(sessionStatusGroup('unknown', true)).toBe('unread')
+  })
+  it('a read, finished turn is Idle; a read no-state session is Unknown', () => {
+    expect(sessionStatusGroup('done', false)).toBe('idle')
+    expect(sessionStatusGroup('unknown', false)).toBe('unknown')
   })
 })
 
@@ -417,7 +437,7 @@ describe('buildStatusList', () => {
   const status: Record<string, AgentNodeStatus> = {
     a1: { unread: false, state: 'waiting', lastEventAt: 100 }, // attention, oldest
     a2: { unread: false, state: 'blocked', lastEventAt: 300 }, // attention, newest
-    d1: { unread: false, state: 'done', lastEventAt: 200 }, // completed turn → its own 'done' section
+    d1: { unread: false, state: 'done', lastEventAt: 200 }, // completed + READ turn → Idle
     w1: { unread: false, state: 'working', lastEventAt: 400 }, // working
     i1: { unread: false } // unknown (no state or transition time)
   }
@@ -437,16 +457,22 @@ describe('buildStatusList', () => {
     }
   ]
 
-  it('groups by workflow status in the fixed order attention → done → unknown → working', () => {
+  it('groups by status in the fixed order attention → unread → working → idle → unknown', () => {
     const sections = buildStatusList(proj, null, 'p1', status, '')
-    expect(sections.map((s) => s.kind)).toEqual(['attention', 'done', 'unknown', 'working'])
+    expect(sections.map((s) => s.kind)).toEqual([
+      'attention',
+      'unread',
+      'working',
+      'idle',
+      'unknown'
+    ])
   })
 
   it('flattens across projects and tags each row with its project', () => {
     const sections = buildStatusList(proj, null, 'p1', status, '')
     const attention = sections.find((s) => s.kind === 'attention')!
     expect(attention.rows.map((r) => r.id).sort()).toEqual(['a1', 'a2'])
-    expect(sections.find((s) => s.kind === 'done')!.rows.map((r) => r.id)).toEqual(['d1'])
+    expect(sections.find((s) => s.kind === 'idle')!.rows.map((r) => r.id)).toEqual(['d1'])
     const a1 = attention.rows.find((r) => r.id === 'a1')!
     expect(a1.projectId).toBe('p1')
     expect(a1.projectName).toBe('Alpha')
@@ -458,12 +484,12 @@ describe('buildStatusList', () => {
 
   it('sorts rows within a section by descending state-change time', () => {
     const sections = buildStatusList(proj, null, 'p1', status, '')
-    // a2 (300) before a1 (100); d1 now sits in its own 'done' section, not between them.
+    // a2 (300) before a1 (100); d1 (read + done) sits in Idle, not between them.
     expect(sections.find((s) => s.kind === 'attention')!.rows.map((r) => r.id)).toEqual([
       'a2',
       'a1'
     ])
-    expect(sections.find((s) => s.kind === 'done')!.rows.map((r) => r.id)).toEqual(['d1'])
+    expect(sections.find((s) => s.kind === 'idle')!.rows.map((r) => r.id)).toEqual(['d1'])
   })
 
   it('keeps only terminal nodes (drops stickies/editors)', () => {
@@ -482,42 +508,54 @@ describe('buildStatusList', () => {
   it('keeps empty sections while filtering rows by title/session', () => {
     // 'runner' only matches w1 (working)
     const filtered = buildStatusList(proj, null, 'p1', status, 'runner')
-    expect(filtered.map((s) => s.kind)).toEqual(['attention', 'done', 'unknown', 'working'])
+    expect(filtered.map((s) => s.kind)).toEqual([
+      'attention',
+      'unread',
+      'working',
+      'idle',
+      'unknown'
+    ])
     expect(filtered.find((s) => s.kind === 'working')!.rows.map((r) => r.id)).toEqual(['w1'])
     expect(filtered.filter((s) => s.kind !== 'working').every((s) => s.rows.length === 0)).toBe(true)
   })
 
   it('returns every section even when some headers have no sessions', () => {
-    // Waiting → attention, done → its own section; unknown/working stay present and empty.
+    // Waiting → attention, read-done → Idle; unread/working/unknown stay present and empty.
     const onlyTwo: ProjectInput[] = [
       { id: 'p1', name: 'Alpha', color: '#111', nodes: [node('a1'), node('d1')] }
     ]
     const two: Record<string, AgentNodeStatus> = { a1: { unread: false, state: 'waiting' }, d1: { unread: false, state: 'done' } }
     const sections = buildStatusList(onlyTwo, null, 'p1', two, '')
-    expect(sections.map((s) => s.kind)).toEqual(['attention', 'done', 'unknown', 'working'])
+    expect(sections.map((s) => s.kind)).toEqual([
+      'attention',
+      'unread',
+      'working',
+      'idle',
+      'unknown'
+    ])
     expect(sections.find((s) => s.kind === 'attention')!.rows.map((row) => row.id)).toEqual(['a1'])
-    expect(sections.find((s) => s.kind === 'done')!.rows.map((row) => row.id)).toEqual(['d1'])
-    expect(sections.find((s) => s.kind === 'unknown')!.rows).toEqual([])
+    expect(sections.find((s) => s.kind === 'idle')!.rows.map((row) => row.id)).toEqual(['d1'])
+    expect(sections.find((s) => s.kind === 'unread')!.rows).toEqual([])
     expect(sections.find((s) => s.kind === 'working')!.rows).toEqual([])
+    expect(sections.find((s) => s.kind === 'unknown')!.rows).toEqual([])
   })
 
-  it('keeps read state separate from workflow grouping', () => {
+  it('collects unlooked-at sessions into the Unread section — but a live turn stays in Running', () => {
     const glowing: Record<string, AgentNodeStatus> = {
-      d1: { unread: true, state: 'done' },
-      i1: { unread: true },
-      w1: { unread: true, state: 'working' }
+      d1: { unread: true, state: 'done' }, // finished + unread → Unread
+      i1: { unread: true }, // no state + unread → Unread
+      w1: { unread: true, state: 'working' } // actively working → Running (working wins over unread)
     }
     const sections = buildStatusList(proj, null, 'p1', glowing, '')
-    // d1 is done (+unread) → the Done section, NOT attention. Unread is carried on the row, not
-    // in the workflow bucket.
-    expect(sections.find((s) => s.kind === 'attention')!.rows).toEqual([])
-    const done = sections.find((s) => s.kind === 'done')!
-    expect(done.label).toBe('Done')
-    expect(done.rows.map((r) => r.id)).toEqual(['d1'])
-    expect(done.rows[0].unread).toBe(true)
-    // Unread alone is not a workflow state; a live turn is still Running.
-    expect(sections.find((s) => s.kind === 'unknown')!.rows.map((r) => r.id)).toContain('i1')
+    const unread = sections.find((s) => s.kind === 'unread')!
+    expect(unread.label).toBe('Unread')
+    expect(unread.rows.map((r) => r.id).sort()).toEqual(['d1', 'i1'])
+    expect(unread.rows.every((r) => r.unread)).toBe(true)
+    // A live turn is Running even when flagged unread — consistent with the project-mode glyph.
     expect(sections.find((s) => s.kind === 'working')!.rows.map((r) => r.id)).toEqual(['w1'])
+    // Nothing left over in Idle: both settled sessions were unread, so both are in Unread.
+    expect(sections.find((s) => s.kind === 'idle')!.rows).toEqual([])
+    expect(sections.find((s) => s.kind === 'attention')!.rows).toEqual([])
   })
 
   it('falls through to Unknown when no live state is known', () => {

--- a/src/renderer/lib/sessionList.ts
+++ b/src/renderer/lib/sessionList.ts
@@ -37,6 +37,43 @@ const STATE_LABEL: Record<StatusKind, string> = {
   unknown: 'Unknown'
 }
 
+/**
+ * The status-MODE section a row falls in. Distinct from `StatusKind` (which drives the project-mode
+ * dot/glyph) because a section also reflects the `unread` mark: a finished turn you have not looked
+ * at gets its own **Unread** section so it is easy to find, separate from the read-and-idle ones.
+ */
+export type StatusGroup = 'attention' | 'unread' | 'working' | 'idle' | 'unknown'
+
+/**
+ * Section display order in status-grouping mode: what needs you first, then what is new for you,
+ * then what is live, then the settled ones. Unread sits high (second) so unlooked-at results are
+ * prominent even though, by membership priority, a still-RUNNING session stays under Running.
+ */
+const STATUS_GROUP_ORDER: StatusGroup[] = ['attention', 'unread', 'working', 'idle', 'unknown']
+
+const STATUS_GROUP_LABEL: Record<StatusGroup, string> = {
+  attention: 'Need attention',
+  unread: 'Unread',
+  working: 'Running',
+  idle: 'Idle',
+  unknown: 'Unknown'
+}
+
+/**
+ * Bucket a row for the status-mode sections. Membership priority (first match wins), which is NOT
+ * the display order: `attention` (you must act) → `working` (a live turn is Running, not Unread,
+ * matching the project-mode glyph) → `unread` (finished/settled but unlooked-at) → `idle` (a
+ * finished turn already seen) → `unknown` (no hook signal). So a finished-and-unread session lands
+ * in Unread, a working one stays in Running even if flagged, and a read-done one is Idle.
+ */
+export function sessionStatusGroup(kind: StatusKind, unread: boolean): StatusGroup {
+  if (kind === 'attention') return 'attention'
+  if (kind === 'working') return 'working'
+  if (unread) return 'unread'
+  if (kind === 'done') return 'idle'
+  return 'unknown'
+}
+
 /** Disclosure key for a project row in the sessions tree. */
 export function projectCollapseKey(projectId: string): string {
   return `project:${projectId}`
@@ -46,13 +83,6 @@ export function projectCollapseKey(projectId: string): string {
 export function groupCollapseKey(projectId: string, groupId: string): string {
   return `project:${projectId}:group:${groupId}`
 }
-
-/**
- * Status section order when the sidebar is grouped by status. Anything needing you floats to the
- * top; working sinks to the bottom (a turn in flight is the least urgent to revisit). Unknown sits
- * between them: there is no current hook signal on which to infer a workflow state.
- */
-const STATUS_ORDER: StatusKind[] = ['attention', 'done', 'unknown', 'working']
 
 /**
  * Whether a project row is collapsed in the sessions sidebar. `settings.sidebarAutoCollapse`
@@ -365,10 +395,10 @@ export function buildSessionList(
   return needle ? groups.filter((g) => g.groups.length > 0 || g.ungrouped.length > 0) : groups
 }
 
-/** A status section in status-grouping mode: one live status kind and the sessions in it,
- *  flattened across all (local-core) projects. Order is fixed by STATUS_ORDER. */
+/** A status section in status-grouping mode: one status group and the sessions in it, flattened
+ *  across all (local-core) projects. Order is fixed by STATUS_GROUP_ORDER. */
 export interface StatusSection {
-  kind: StatusKind
+  kind: StatusGroup
   label: string
   rows: SessionRowVM[]
 }
@@ -452,13 +482,15 @@ export function buildStatusList(
     }
   }
 
-  // Bucket by status, then newest state transition first. An absent timestamp is genuinely unknown
-  // and sorts last; project store-order + title provide a deterministic tie-breaker.
-  const byStatus = new Map<StatusKind, { row: SessionRowVM; pidx: number }[]>()
+  // Bucket by status GROUP (unread-aware), then newest state transition first. An absent timestamp
+  // is genuinely unknown and sorts last; project store-order + title provide a deterministic
+  // tie-breaker.
+  const byStatus = new Map<StatusGroup, { row: SessionRowVM; pidx: number }[]>()
   for (const { row, pidx } of tagged) {
-    const list = byStatus.get(row.statusKind)
+    const group = sessionStatusGroup(row.statusKind, row.unread)
+    const list = byStatus.get(group)
     if (list) list.push({ row, pidx })
-    else byStatus.set(row.statusKind, [{ row, pidx }])
+    else byStatus.set(group, [{ row, pidx }])
   }
   for (const list of byStatus.values()) {
     list.sort((a, b) => {
@@ -471,9 +503,9 @@ export function buildStatusList(
 
   // Every section is always present. Stable headers make the grouping legible even when a bucket
   // is temporarily empty and prevent the sidebar from jumping as sessions move between states.
-  return STATUS_ORDER.map((kind) => ({
+  return STATUS_GROUP_ORDER.map((kind) => ({
     kind,
-    label: STATE_LABEL[kind],
+    label: STATUS_GROUP_LABEL[kind],
     rows: (byStatus.get(kind) ?? []).map((t) => t.row)
   }))
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6597,6 +6597,11 @@ body,
 .ss-status__icon--attention { width: auto; height: auto; border-radius: 0; color: var(--danger); display: inline-flex; }
 .ss-status__icon--attention svg { width: 11px; height: 11px; }
 .ss-status__icon--working { background: var(--accent); }
+/* Unread: the same accent-blue as the row's "new for you" check, ringed so the section header
+   reads as "these are the unlooked-at ones". */
+.ss-status__icon--unread { background: var(--accent); box-shadow: 0 0 0 2px rgba(var(--tint-rgb), 0.18); }
+/* Idle: a settled, already-seen turn — a quiet filled success dot. */
+.ss-status__icon--idle { background: var(--success); opacity: 0.7; }
 .ss-status__icon--unknown { background: rgba(var(--tint-rgb), 0.25); }
 .ss-status__rows { padding: 2px 0 2px 2px; }
 


### PR DESCRIPTION
Adds a dedicated **Unread** section to the status-grouping sidebar and reorders the sections:

**Need attention → Unread → Running → Idle → Unknown**

## Why
The status sidebar grouped sessions by workflow state (Running / Waiting / Done / Unknown) but had no home for finished-but-unlooked-at sessions — the unread mark lived on the row without a section of its own. This surfaces those sessions where you'd look for them.

## How
- `sessionStatusGroup(kind, unread)` — a new, unread-aware bucketer. Membership priority (first match wins): `attention` > `working` > `unread` > `done→idle` > `unknown`. So a finished-and-unread session lands in **Unread**, while a still-running one stays in **Running** even if flagged (consistent with the project-mode glyph).
- Display order puts Unread high (second) so unlooked-at results are prominent.
- `Done` → relabelled **Idle** (a read, settled turn); `Waiting for your response` → **Need attention**.
- Kept separate from `StatusKind` — the project-mode dot/glyph is unchanged. New section-header icon styles for unread/idle.

## Tests
Unit tests for `sessionStatusGroup` (attention-wins, working-wins-over-unread, settled-unread→unread, read→idle) and updated `buildStatusList` tests for the new order and the Unread bucket. Full suite green, typecheck clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)