### PR TITLE
feat(sidebar): text tabs instead of the Project/Status pill

### DIFF
--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -18,7 +18,6 @@ import {
   type StatusSection
 } from '../lib/sessionList'
 import { SessionRow } from './SessionRow'
-import { SegmentedPill } from '@renderer/ui/SegmentedPill'
 import { IconBellFilled, IconCircleCheck, IconPin } from './icons'
 import { useProjects } from '../state/projects'
 import { useSettings } from '../state/settings'
@@ -461,15 +460,6 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
       <div className="sessions-sidebar__head">
         <span className="sessions-sidebar__title">Sessions</span>
         <span className="sessions-sidebar__count">{total}</span>
-        <SegmentedPill<'project' | 'status'>
-          value={grouping}
-          ariaLabel="Group sessions by"
-          options={[
-            { value: 'project', label: 'Project' },
-            { value: 'status', label: 'Status' }
-          ]}
-          onChange={(v) => updateSettings({ sidebarGrouping: v })}
-        />
         <div className="sessions-sidebar__head-actions">
           <button
             className={pinned ? 'is-on' : ''}
@@ -482,6 +472,27 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
             ×
           </button>
         </div>
+      </div>
+
+      {/* Grouping tabs: plain text with a 2px accent underline on the active one, sitting on the
+          hairline that separates the header from the list — quieter than a pill toggle. */}
+      <div className="ss-tabs" role="tablist" aria-label="Group sessions by">
+        <button
+          role="tab"
+          aria-selected={grouping === 'project'}
+          className={`ss-tab${grouping === 'project' ? ' is-active' : ''}`}
+          onClick={() => updateSettings({ sidebarGrouping: 'project' })}
+        >
+          Project
+        </button>
+        <button
+          role="tab"
+          aria-selected={grouping === 'status'}
+          className={`ss-tab${grouping === 'status' ? ' is-active' : ''}`}
+          onClick={() => updateSettings({ sidebarGrouping: 'status' })}
+        >
+          Status
+        </button>
       </div>
 
       <div className="sessions-sidebar__search">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6457,9 +6457,37 @@ body,
   box-shadow: 0 12px 40px rgba(0, 0, 0, calc(0.45 * var(--shadow-k)));
   overflow: hidden;
 }
-.sessions-sidebar__head { display: flex; align-items: center; gap: 6px; padding: 8px 10px; border-bottom: 1px solid var(--border); }
-.sessions-sidebar__title { font-size: 12.5px; font-weight: 600; color: var(--text); }
-.sessions-sidebar__count { font-size: 10.5px; color: var(--muted); }
+.sessions-sidebar__head { display: flex; align-items: baseline; gap: 8px; padding: 10px 10px 8px; }
+.sessions-sidebar__title { font-size: 14px; font-weight: 700; color: var(--text); letter-spacing: -0.01em; }
+.sessions-sidebar__count { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
+/* Grouping tabs: text with a 2px accent underline on the active tab, sitting on the hairline that
+   separates the header from the list (see the "Metin sekmesi" design). */
+.ss-tabs { display: flex; gap: 18px; padding: 0 12px; border-bottom: 1px solid var(--border); }
+.ss-tab {
+  position: relative;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--muted);
+  padding: 4px 1px 8px;
+  margin-bottom: -1px; /* overlap the container border so the underline lands on the hairline */
+  transition: color 120ms ease;
+}
+.ss-tab:hover { color: var(--text); }
+.ss-tab.is-active { color: var(--text); }
+.ss-tab.is-active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+}
+.ss-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
 .sessions-sidebar__head-actions { margin-left: auto; display: flex; gap: 4px; }
 .sessions-sidebar__head-actions button { width: 24px; height: 24px; display: inline-flex; align-items: center; justify-content: center; background: transparent; border: none; color: var(--text); cursor: pointer; border-radius: 6px; }
 .sessions-sidebar__head-actions button:hover { background: var(--panel-header); }
@@ -6583,8 +6611,6 @@ body,
 .ss-group.is-drop-before::before { content: ''; position: absolute; top: -1px; left: 6px; right: 6px; height: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; z-index: 1; }
 
 /* Sidebar head grouping toggle: a compact SegmentedPill (Project | Status). */
-.sessions-sidebar__head .seg-pill { padding: 1px; gap: 1px; }
-.sessions-sidebar__head .seg-pill-opt { font-size: 10.5px; padding: 2px 8px; }
 
 /* Status-grouped sections (sidebar grouped by status). Always expanded — no chevron, no
    collapse; the whole point is that sessions awaiting a response are visible at a glance. */


### PR DESCRIPTION
Replaces the segmented **pill** toggle for Project / Status with plain **text tabs** — a 2px accent underline marks the active one, sitting on the hairline that separates the header from the list (the "Metin sekmesi" design).

- Header row now holds just the title + count (left) and pin/close (right).
- The tabs are their own row below, quieter than a pill for a two-way switch.
- `SegmentedPill` import and the head-scoped pill CSS removed; new `.ss-tabs` / `.ss-tab` styles (hover, active underline, focus ring).

typecheck clean, style guards + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)