### PR TITLE
feat(speech): dictation is optional — explicit None state, nothing downloads unasked (fixes #143)

### DIFF
--- a/src/renderer/components/DictationOverlay.test.ts
+++ b/src/renderer/components/DictationOverlay.test.ts
@@ -7,11 +7,19 @@ const terminalTarget: DictationTarget = { kind: 'terminal', nodeId: 'n1', title:
 // straight into the terminal, so there is no editable card (chat nodes, which had one, are gone).
 describe('dictationMode', () => {
   it('is "warning" whenever there is no target', () => {
-    expect(dictationMode(null)).toBe('warning')
+    expect(dictationMode(null, true)).toBe('warning')
   })
 
   it('is "pill" for a terminal target', () => {
-    expect(dictationMode(terminalTarget)).toBe('pill')
+    expect(dictationMode(terminalTarget, true)).toBe('pill')
+  })
+
+  // Dictation off (Whisper + the explicit None selection, #143): never records. It wins over a
+  // selected target too — otherwise the user speaks a whole take before transcribe refuses it,
+  // which reads as broken instead of off.
+  it('is "no-model" when dictation is off, target or not', () => {
+    expect(dictationMode(terminalTarget, false)).toBe('no-model')
+    expect(dictationMode(null, false)).toBe('no-model')
   })
 })
 

--- a/src/renderer/components/DictationOverlay.tsx
+++ b/src/renderer/components/DictationOverlay.tsx
@@ -17,6 +17,8 @@ import { createPortal } from 'react-dom'
 import { equalizerBars } from '../lib/dictation-equalizer'
 import { PcmCapture } from '../lib/pcm-capture'
 import { useSession } from '../session/session'
+import { useSettings } from '../state/settings'
+import { hasSpeechModel } from '@shared/speech'
 
 export interface DictationTarget {
   kind: 'terminal'
@@ -44,13 +46,20 @@ export function isProGateError(message: string): boolean {
 }
 
 type Phase = 'idle' | 'recording' | 'transcribing'
-/** 'warning' = no target at press time (never records). 'pill' = the compact recording/
- *  transcribing/error capsule — the whole surface for a terminal target, start to finish
- *  (the transcript is inserted straight into the terminal, so there is no editable card). */
-export type DictationMode = 'warning' | 'pill'
+/** 'no-model' = dictation is off (Whisper engine with the explicit None selection, issue #143) —
+ *  never records, explains where to turn it on. 'warning' = no target at press time (never
+ *  records). 'pill' = the compact recording/transcribing/error capsule — the whole surface for a
+ *  terminal target, start to finish (the transcript is inserted straight into the terminal, so
+ *  there is no editable card). */
+export type DictationMode = 'no-model' | 'warning' | 'pill'
 
-/** Pure — no side effects. Exported for its own unit coverage. */
-export function dictationMode(target: DictationTarget | null): DictationMode {
+/** Pure — no side effects. Exported for its own unit coverage.
+ *
+ *  'no-model' wins over everything, target included: with a model missing the failure would
+ *  otherwise surface only AFTER the user spoke a whole take (transcribe throws), which reads as
+ *  a broken feature rather than an off one. */
+export function dictationMode(target: DictationTarget | null, hasModel: boolean): DictationMode {
+  if (!hasModel) return 'no-model'
   return target ? 'pill' : 'warning'
 }
 
@@ -79,11 +88,15 @@ export function isAtRecordingCap(elapsedMs: number): boolean {
   return elapsedMs >= MAX_RECORDING_MS
 }
 
-/** How long the "no target selected" warning pill stays up before it auto-dismisses. */
+/** How long the "no target selected" / "no model" warning pill stays up before it auto-dismisses. */
 const NO_TARGET_DISMISS_MS = 2500
 
 export function DictationOverlay({ target, stopSignal, onClose, onOpenLicense }: DictationOverlayProps) {
   const { api } = useSession()
+  // The off state only exists for the local Whisper engine — cloud brings its own model. Read once
+  // per mount (the overlay is a fresh mount per shortcut press, like `target`).
+  const speech = useSettings((s) => s.settings.speech)
+  const modelReady = speech.engine !== 'whisper' || hasSpeechModel(speech.model)
 
   const [phase, setPhase] = useState<Phase>('idle')
   const [error, setError] = useState<string | null>(null)
@@ -212,7 +225,9 @@ export function DictationOverlay({ target, stopSignal, onClose, onOpenLicense }:
   // DictationOverlayProps — so this is correctly mount-only). No target means the warning pill;
   // it never records, and auto-dismisses on its own.
   useEffect(() => {
-    if (!target) {
+    // Both warning shapes never record and auto-dismiss: no target, and dictation-off (no model —
+    // recording a take that transcribe is guaranteed to refuse would waste the user's speech).
+    if (!target || !modelReady) {
       const t = setTimeout(() => onCloseRef.current(), NO_TARGET_DISMISS_MS)
       return () => clearTimeout(t)
     }
@@ -259,7 +274,7 @@ export function DictationOverlay({ target, stopSignal, onClose, onOpenLicense }:
     }
   }, [stopSignal, phase, stopRecording, handleClose])
 
-  const mode = dictationMode(target)
+  const mode = dictationMode(target, modelReady)
 
   const errorBlock = error && (
     <div className="dictation__error">
@@ -275,10 +290,14 @@ export function DictationOverlay({ target, stopSignal, onClose, onOpenLicense }:
     </div>
   )
 
-  if (mode === 'warning') {
+  if (mode === 'warning' || mode === 'no-model') {
     return createPortal(
       <div className="dictation dictation--warning nodrag nowheel" onMouseDown={(e) => e.stopPropagation()}>
-        <span className="dictation__warning-text">Select a terminal node first.</span>
+        <span className="dictation__warning-text">
+          {mode === 'no-model'
+            ? 'Dictation is off — choose a Whisper model in Settings → Speech.'
+            : 'Select a terminal node first.'}
+        </span>
         <button type="button" className="dictation__close" title="Dismiss" onClick={handleClose}>
           ×
         </button>

--- a/src/renderer/components/Dock.tsx
+++ b/src/renderer/components/Dock.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type AgentId, type BuiltinAgentId } from '@shared/agents/config'
 import type { CustomAgent } from '@shared/types'
 import { formatShortcut, isHoldChord } from '@shared/shortcut'
+import { hasSpeechModel } from '@shared/speech'
 import { hintLabel } from '@shared/platform-utils'
 import { AgentIcon } from '../lib/agentIcons'
 import { useSettings } from '../state/settings'
@@ -74,6 +75,12 @@ export function Dock({
   // button, byte-identical to before this nesting existed.
   const [openSub, setOpenSub] = useState<BuiltinAgentId | null>(null)
   const dictationShortcut = useSettings((s) => s.settings.speech.shortcut)
+  const speechEngine = useSettings((s) => s.settings.speech.engine)
+  const speechModel = useSettings((s) => s.settings.speech.model)
+  // Whisper with the explicit None selection = dictation off (issue #143). The mic stays visible
+  // and clickable — the overlay it opens says where to turn dictation on — but the tooltip is
+  // honest about the state instead of promising a shortcut that will only warn.
+  const dictationOff = speechEngine === 'whisper' && !hasSpeechModel(speechModel)
   const customAgents = useSettings((s) => s.settings.customAgents)
   const disabledAgents = useSettings((s) => s.settings.disabledAgents)
   const claudeAccounts = useSettings((s) => s.settings.claudeAccounts)
@@ -289,9 +296,11 @@ export function Dock({
         <button
           className={`dock-btn${dictateActive ? ' active' : ''}`}
           title={
-            isHoldChord(dictationShortcut)
-              ? `Dictate (hold ${formatShortcut(dictationShortcut, isMac)})`
-              : `Dictate (${formatShortcut(dictationShortcut, isMac)})`
+            dictationOff
+              ? 'Dictation off — choose a model in Settings → Speech'
+              : isHoldChord(dictationShortcut)
+                ? `Dictate (hold ${formatShortcut(dictationShortcut, isMac)})`
+                : `Dictate (${formatShortcut(dictationShortcut, isMac)})`
           }
           onClick={onDictate}
         >

--- a/src/renderer/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/components/onboarding/OnboardingFlow.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import type { SpeechModelInfo } from '@shared/types'
 import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type BuiltinAgentId } from '@shared/agents/config'
 import { isHoldChord, shortcutKeyParts } from '@shared/shortcut'
+import { hasSpeechModel, SPEECH_MODEL_NONE } from '@shared/speech'
 import { keyLabel } from '@shared/platform-utils'
 import { IOS_APP_STORE_URL } from '../../lib/links'
 import { useSettings } from '../../state/settings'
@@ -262,8 +263,22 @@ export function OnboardingFlow({ onClose }: { onClose: () => void }) {
                   anywhere to dictate — on-device Whisper turns speech into text. Nothing is
                   sent to the cloud, and nothing auto-submits.
                 </p>
-                <div className="onb-label">Whisper model</div>
+                <div className="onb-label">Whisper model — optional</div>
                 <div className="onb-models">
+                  {/* A real "I don't use dictation" choice (issue #143), not just the generic Next:
+                      selects None, downloads nothing. It is also the DEFAULT, so doing nothing on
+                      this step is the same honest opt-out. */}
+                  <button
+                    className={`onb-model ${!hasSpeechModel(settings.speech.model) ? 'is-selected' : ''}`}
+                    onClick={() => {
+                      setModelHint('')
+                      update({ speech: { ...settings.speech, model: SPEECH_MODEL_NONE } })
+                    }}
+                  >
+                    <span className="onb-model__radio" />
+                    <span className="onb-model__name">No dictation</span>
+                    <span className="onb-model__size">nothing downloads</span>
+                  </button>
                   {models.map((m) => {
                     const selected = settings.speech.model === m.id
                     const pct = progress[m.id]

--- a/src/renderer/components/settings/sections/SpeechSection.tsx
+++ b/src/renderer/components/settings/sections/SpeechSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { SpeechModelInfo } from '@shared/types'
-import { modelAfterDelete, modelAfterDownload } from '@shared/speech'
+import { hasSpeechModel, modelAfterDelete, modelAfterDownload, SPEECH_MODEL_NONE } from '@shared/speech'
 import { DEFAULT_SETTINGS } from '@shared/types'
 import {
   buildModifierChord,
@@ -35,7 +35,21 @@ const ROWS = {
   },
   models: {
     title: 'Whisper models',
-    keywords: ['whisper', 'model', 'download', 'delete', 'tiny', 'base', 'small', 'large', 'pro']
+    keywords: [
+      'whisper',
+      'model',
+      'download',
+      'delete',
+      'tiny',
+      'base',
+      'small',
+      'large',
+      'pro',
+      'none',
+      'off',
+      'disable',
+      'no dictation'
+    ]
   },
   language: {
     title: 'Language',
@@ -357,6 +371,26 @@ export function SpeechSection({
             <p className="text-[12px] text-muted">Loading models…</p>
           ) : (
             <div className="space-y-2">
+              {/* The honest off switch (issue #143): dictation is optional, and None is a real row
+                  in the same radio group — not a missing selection the heal helpers would fix. */}
+              <div className="flex items-center justify-between gap-3 rounded-md border border-border p-3">
+                <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3">
+                  <input
+                    type="radio"
+                    name="speech-model"
+                    className="shrink-0"
+                    checked={!hasSpeechModel(settings.speech.model)}
+                    onChange={() => update({ speech: { ...settings.speech, model: SPEECH_MODEL_NONE } })}
+                  />
+                  <div className="min-w-0">
+                    <span className="text-[13px] font-medium text-text">None</span>
+                    <p className="text-[12px] text-muted">
+                      Dictation off — the shortcut and the Dock mic explain instead of recording.
+                      Downloading a model below turns it on.
+                    </p>
+                  </div>
+                </label>
+              </div>
               {models.map((m) => {
                 const pct = progress[m.id]
                 const downloading = busy[m.id] && pct !== undefined

--- a/src/shared/speech.test.ts
+++ b/src/shared/speech.test.ts
@@ -3,8 +3,10 @@ import {
   WHISPER_MODELS,
   whisperModel,
   WHISPER_DOWNLOAD_BASE,
+  hasSpeechModel,
   modelAfterDownload,
   modelAfterDelete,
+  SPEECH_MODEL_NONE,
   type ModelDownloadState
 } from './speech'
 import { DEFAULT_SETTINGS } from './types'
@@ -28,13 +30,18 @@ describe('whisper model catalog', () => {
     expect(WHISPER_DOWNLOAD_BASE).toBe('https://huggingface.co/ggerganov/whisper.cpp/resolve/main/')
   })
 
-  it('speech settings default to free local dictation', () => {
+  it('speech settings default to dictation OFF — nothing downloads until the user asks (#143)', () => {
     expect(DEFAULT_SETTINGS.speech).toEqual({
       engine: 'whisper',
-      model: 'tiny',
+      model: SPEECH_MODEL_NONE,
       language: 'auto',
       shortcut: 'Cmd+Alt'
     })
+  })
+
+  it('hasSpeechModel reads None as off and any id as on', () => {
+    expect(hasSpeechModel(SPEECH_MODEL_NONE)).toBe(false)
+    expect(hasSpeechModel('tiny')).toBe(true)
   })
 })
 
@@ -60,6 +67,10 @@ describe('modelAfterDownload', () => {
     // A removed/renamed model in an old settings file has nothing behind it either.
     expect(modelAfterDownload(list(['base', true]), 'ancient', 'base')).toBe('base')
   })
+
+  it('adopts out of the None state — starting a download IS asking for dictation (#143)', () => {
+    expect(modelAfterDownload(list(['base', true]), SPEECH_MODEL_NONE, 'base')).toBe('base')
+  })
 })
 
 describe('modelAfterDelete', () => {
@@ -73,5 +84,11 @@ describe('modelAfterDelete', () => {
 
   it('answers null when nothing is downloaded — there is nothing truthful to select', () => {
     expect(modelAfterDelete(list(['tiny', false], ['small', false]), 'tiny')).toBeNull()
+  })
+
+  it('NEVER heals an explicit None — deleting a leftover model keeps dictation off (#143)', () => {
+    // With None selected and another model still on disk, the old fallback would have re-adopted
+    // it behind the user's back. An unset state is a legitimate value, not a dangling pointer.
+    expect(modelAfterDelete(list(['tiny', true], ['small', true]), SPEECH_MODEL_NONE)).toBeNull()
   })
 })

--- a/src/shared/speech.ts
+++ b/src/shared/speech.ts
@@ -16,6 +16,19 @@ export const WHISPER_MODELS: WhisperModelInfo[] = [
 
 export const WHISPER_DOWNLOAD_BASE = 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/'
 
+/**
+ * The "no dictation" selection: an EMPTY model id (issue #143). A legitimate, user-chosen state —
+ * the settings default, the onboarding "skip" choice, and the Settings → Speech "None" row all
+ * write it — never a dangling pointer for the heal helpers below to fix behind the user's back.
+ * Spelled '' so a hand-read settings.json says what it means.
+ */
+export const SPEECH_MODEL_NONE = ''
+
+/** Is dictation actually configured (a model chosen)? `false` = the explicit None/off state. */
+export function hasSpeechModel(model: string): boolean {
+  return model !== SPEECH_MODEL_NONE
+}
+
 export function whisperModel(id: string): WhisperModelInfo | undefined {
   return WHISPER_MODELS.find((m) => m.id === id)
 }
@@ -43,6 +56,8 @@ export function modelAfterDownload(
 ): string | null {
   if (current === justDownloaded) return null
   // An id that is not in the list at all (a renamed/removed model) has nothing behind it either.
+  // That deliberately includes SPEECH_MODEL_NONE: starting a download IS asking for dictation, so
+  // the fresh model is adopted and the off state ends — the one heal None does not opt out of.
   return models.find((m) => m.id === current)?.downloaded ? null : justDownloaded
 }
 
@@ -56,6 +71,9 @@ export function modelAfterDelete(
   models: readonly ModelDownloadState[],
   current: string
 ): string | null {
+  // An explicit None is not a dangling pointer (issue #143): deleting a leftover model file while
+  // dictation is OFF must leave it off, never silently re-adopt whatever else is on disk.
+  if (!hasSpeechModel(current)) return null
   if (models.find((m) => m.id === current)?.downloaded) return null
   return models.find((m) => m.downloaded)?.id ?? null
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1235,7 +1235,12 @@ export const DEFAULT_SETTINGS: Settings = {
   notchHud: true,
   notchWidth: 168,
   notchHoverExpand: true,
-  speech: { engine: 'whisper', model: 'tiny', language: 'auto', shortcut: 'Cmd+Alt' },
+  // model: '' = the explicit "no dictation" state (SPEECH_MODEL_NONE, issue #143). Dictation is
+  // opt-in: nothing is selected — and so nothing downloads and no shortcut records — until the
+  // user picks a model in onboarding or Settings → Speech. Existing installs keep whatever their
+  // settings.json already says (the merge only fills ABSENT keys), so nobody's working dictation
+  // is switched off by an upgrade.
+  speech: { engine: 'whisper', model: '', language: 'auto', shortcut: 'Cmd+Alt' },
 }
 
 export interface SettingsApi {


### PR DESCRIPTION
Fixes #143 — the email request behind it: *"Consider a no voice AI option, I had to pick one."*

## What

`SPEECH_MODEL_NONE` (`''`) becomes a legitimate, user-choosable selection everywhere `speech.model` lives:

- **Settings → Speech**: a **None** row joins the model radio group ("Dictation off — the shortcut and the Dock mic explain instead of recording. Downloading a model below turns it on."). Search keywords cover none/off/disable.
- **Onboarding, dictation step**: a real **"No dictation"** choice renders next to the models — selecting it downloads nothing. The step label now says "optional".
- **Default flipped to None**: a fresh install selects nothing, downloads nothing, records nothing until asked — the issue's point 3 verbatim. Existing installs keep their persisted `speech.model` (the settings merge only fills absent keys), so an upgrade never switches off working dictation.
- **Off-state behavior**: pressing the shortcut / Dock mic with Whisper + None shows the warning pill "Dictation is off — choose a Whisper model in Settings → Speech" and **never records** (`dictationMode` gains a `no-model` state that wins over a selected target — otherwise the failure lands only after the user spoke a whole take). The Dock mic tooltip reports the off state instead of promising a shortcut. Cloud engine untouched.

## The issue's care note (heal helpers)

- `modelAfterDelete` now refuses to heal an explicit None: deleting a leftover model file while dictation is off keeps it off, never re-adopts another downloaded model behind the user's back — pinned by a test that would have caught the old behavior.
- `modelAfterDownload` deliberately still adopts out of None: starting a download **is** asking for dictation. Documented at both helpers.

22 speech/overlay tests (5 new) + 778 shared/core-speech + 602 renderer component/state tests green; typecheck green.

Mobile has its own dictation setup (separate repo) — out of scope here, as the issue notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)