### PR TITLE
fix(sidebar): focus the terminal when you go to a session

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -225,6 +225,7 @@ import { opensInEditor } from '../lib/openTarget'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
 import { useProjects } from '../state/projects'
 import { useAgentStatus } from '../state/agentStatus'
+import { useTerminalFocus } from '../state/terminalFocus'
 import { useCodexIdentity, codexFallbackText } from '../state/codexIdentity'
 import { useTeamAccessEvents } from '../state/teamAccess'
 import { useAgentNodes } from '../state/agentNodes'
@@ -1862,6 +1863,9 @@ export function Canvas() {
           } else {
             setNodes((ns) => ns.map((n) => ({ ...n, selected: n.id === pending })))
             goToNode(node)
+            // Same as focusNodeById: after the cross-project switch lands, hand the keyboard to the
+            // target terminal so the user can type without a second click.
+            useTerminalFocus.getState().request(pending)
           }
           useAgentStatus.getState().setActive(pending, true)
           useAgentStatus.getState().clearUnread(pending)
@@ -6013,6 +6017,10 @@ export function Canvas() {
         }
         setNodes((ns) => ns.map((n) => ({ ...n, selected: n.id === nodeId })))
         goToNode(node)
+        // Hand the keyboard to the node's terminal so the user can type immediately — the zoom
+        // frames it but does not focus xterm on its own (the pan/hover guard owns that), which is
+        // why a sidebar click used to need a second click/hover before typing worked.
+        useTerminalFocus.getState().request(nodeId)
         // Mark this node as watched and its completion as read. Read state is independent of the
         // live `done` workflow state, so it remains under Waiting for your response.
         useAgentStatus.getState().setActive(nodeId, true)

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -137,6 +137,7 @@ import type { AgentState } from '@shared/agents/normalize'
 import type { ClientId } from '@shared/presence'
 import { PresenceChips } from '../components/PresenceChips'
 import { useAgentNodes } from '../state/agentNodes'
+import { useTerminalFocus } from '../state/terminalFocus'
 import { useProjects } from '../state/projects'
 import { useViewMode, viewFor } from '../state/viewMode'
 import { useSshConn } from '../state/sshConn'
@@ -3827,6 +3828,23 @@ export function TerminalNode({
     useAgentStatus.getState().clearUnread(id)
     presence.reportFocus(id)
   }
+
+  // "Go to node" focus (a sidebar session click, a notification tap): the canvas frames the node
+  // but does not move keyboard focus into it — xterm only takes the keyboard on a hover-dwell or a
+  // click (the pan/hover guard). Without this the first keystroke after a sidebar click went
+  // nowhere until the user clicked or hovered the terminal. `enterNow()` takes the keyboard now,
+  // skipping the dwell. One-shot: the request is cleared on consume so a later remount cannot
+  // re-grab focus for a node the user has since left.
+  const focusReq = useTerminalFocus((s) => (s.nodeId === id ? s.nonce : 0))
+  const lastFocusReqRef = useRef(0)
+  useEffect(() => {
+    if (focusReq === 0 || focusReq === lastFocusReqRef.current) return
+    lastFocusReqRef.current = focusReq
+    useTerminalFocus.setState({ nodeId: null })
+    enterNow()
+    // enterNow closes over live refs/setters; re-running on its identity would fire spuriously.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusReq])
   const onBodyEnter = () => {
     if (dwellRef.current) clearTimeout(dwellRef.current)
     const enter = () => {

--- a/src/renderer/state/terminalFocus.test.ts
+++ b/src/renderer/state/terminalFocus.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useTerminalFocus } from './terminalFocus'
+
+afterEach(() => useTerminalFocus.setState({ nodeId: null, nonce: 0 }))
+
+describe('useTerminalFocus', () => {
+  it('records the requested node and bumps the nonce each time', () => {
+    useTerminalFocus.getState().request('node-a')
+    expect(useTerminalFocus.getState().nodeId).toBe('node-a')
+    const n1 = useTerminalFocus.getState().nonce
+
+    // Re-requesting the SAME node still bumps the nonce — that is what a subscriber effect watches,
+    // so a second sidebar click on an already-selected session re-focuses it.
+    useTerminalFocus.getState().request('node-a')
+    expect(useTerminalFocus.getState().nodeId).toBe('node-a')
+    expect(useTerminalFocus.getState().nonce).toBeGreaterThan(n1)
+  })
+
+  it('is one-shot by convention: the consumer clears nodeId so a remount cannot re-grab focus', () => {
+    useTerminalFocus.getState().request('node-b')
+    expect(useTerminalFocus.getState().nodeId).toBe('node-b')
+
+    // The target terminal clears the request after taking focus.
+    useTerminalFocus.setState({ nodeId: null })
+    expect(useTerminalFocus.getState().nodeId).toBeNull()
+    // The nonce is untouched, so no node's `s.nodeId === id ? s.nonce : 0` selector fires again.
+  })
+})

--- a/src/renderer/state/terminalFocus.ts
+++ b/src/renderer/state/terminalFocus.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand'
+
+/**
+ * A one-shot "please take the keyboard" request for a node, keyed by node id with a monotonic
+ * nonce so the SAME node can be re-requested (the nonce is what a subscriber effect watches).
+ *
+ * Why it exists: the "go to node" paths (a sidebar session click, a notification tap) select and
+ * zoom to a node but do NOT move keyboard focus into it — a terminal's xterm only takes focus on a
+ * deliberate hover-dwell or click (the pan/hover guard). So after a sidebar click the canvas framed
+ * the session beautifully but the first keystroke went nowhere until the user clicked or hovered the
+ * terminal. This store lets the canvas hand focus straight to the target so typing works
+ * immediately. A terminal that is not mounted (off-screen/virtualized) simply misses the request —
+ * fail-open, never an error.
+ */
+export const useTerminalFocus = create<{
+  /** The node whose terminal should take the keyboard, or null. */
+  nodeId: string | null
+  /** Bumped on every request so re-requesting the same node still fires a subscriber effect. */
+  nonce: number
+  /** Ask a node's terminal to take the keyboard now. */
+  request(nodeId: string): void
+}>((set) => ({
+  nodeId: null,
+  nonce: 0,
+  request: (nodeId) => set((s) => ({ nodeId, nonce: s.nonce + 1 }))
+}))


### PR DESCRIPTION
Clicking a session in the sidebar (or tapping a notification) zooms to the node nicely, but keyboard focus stayed put — you had to click or hover the terminal before the first keystroke landed. xterm only takes the keyboard on a hover-dwell or a click (the pan/hover guard), and the "go to node" path never moved focus into it.

**Fix:** a one-shot focus-request store (`useTerminalFocus`). `focusNodeById` and the cross-project deferred-focus path request focus for the target node right after the zoom; `TerminalNode` consumes it — taking the keyboard immediately (skipping the dwell) and clearing the request so a later remount can't re-grab focus for a node you've since left. All active-project nodes are mounted (no viewport virtualization), so the target terminal is always there to receive it.

typecheck clean, node tests + store test + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)