### PR TITLE
feat(usage): switch the project's default Claude account from the usage pill (fixes #142)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -9194,7 +9194,9 @@ export function Canvas() {
             onKillSession={killSessionById}
           />
         
-          <UsageIndicator overBoard={kanbanOpen} />
+          {/* Same write path as the TabBar caret menu (project.defaultAccountId + persist) — the
+              popover row is a second, better-placed entrance to the same action (issue #142). */}
+          <UsageIndicator overBoard={kanbanOpen} onSetDefaultAccount={setProjectDefaultAccount} />
 </div>
 
         <PresenceNamePrompt />

--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -4,7 +4,7 @@ import { AGENT_CONFIG } from '@shared/agents/config'
 import { useSettings } from '../state/settings'
 import { useProjects } from '../state/projects'
 import { useSshConn } from '../state/sshConn'
-import { scopeFromKey, scopeUsage, usageScopeKey } from '../lib/usageScope'
+import { accountRowAction, scopeFromKey, scopeUsage, usageScopeKey } from '../lib/usageScope'
 import {
   barFillPercent,
   formatResetCountdown,
@@ -59,6 +59,43 @@ function LimitRow({ limit, mode }: { limit: UsageLimit; mode: 'used' | 'remainin
 }
 
 /**
+ * The account-row affordance for issue #142 — the switch lives where the decision is made.
+ * It writes `project.defaultAccountId` and nothing else: `data.accountId` is resolved once at
+ * node creation and is immutable after, so the copy says "new sessions" and running sessions
+ * never move. `isDefault` marks the row the project currently resolves to; `onUse` is absent
+ * when there is nothing honest to offer (no active project, or a row whose account this
+ * project cannot launch).
+ */
+function DefaultAccountMark({
+  isDefault,
+  onUse
+}: {
+  isDefault: boolean
+  onUse?: () => void
+}) {
+  if (isDefault)
+    return (
+      <span
+        className="usage-account__default"
+        title="New Claude nodes in this project open under this account."
+      >
+        ✓ new sessions
+      </span>
+    )
+  if (!onUse) return null
+  return (
+    <button
+      type="button"
+      className="usage-account__use"
+      title="New Claude nodes in this project will open under this account. Running sessions keep theirs."
+      onClick={onUse}
+    >
+      Use for new sessions
+    </button>
+  )
+}
+
+/**
  * One account's limit bars under a label, for the multi-account popover. Reuses LimitRow's
  * markup — `u` is null while its on-demand fetch is in flight.
  */
@@ -66,16 +103,23 @@ function AccountUsageBlock({
   label,
   email,
   u,
-  mode
+  mode,
+  isDefault = false,
+  onUse
 }: {
   label: string
   email?: string
   u: ClaudeUsage | null
   mode: 'used' | 'remaining'
+  isDefault?: boolean
+  onUse?: () => void
 }) {
   return (
     <div className="usage-account">
-      <div className="usage-account__label">{label}</div>
+      <div className="usage-account__label">
+        {label}
+        <DefaultAccountMark isDefault={isDefault} onUse={onUse} />
+      </div>
       {(email ?? u?.email) && <div className="usage-account__email">{email ?? u?.email}</div>}
       {u?.limits.map((l) => (
         <LimitRow key={limitKey(l)} limit={l} mode={mode} />
@@ -95,7 +139,17 @@ function AccountUsageBlock({
  * `claude` has nothing to report, and listing it would turn "connect an SSH project" into "grow
  * a permanent empty section".
  */
-function RemoteUsageBlock({ row, mode }: { row: RemoteAccountUsage; mode: 'used' | 'remaining' }) {
+function RemoteUsageBlock({
+  row,
+  mode,
+  isDefault = false,
+  onUse
+}: {
+  row: RemoteAccountUsage
+  mode: 'used' | 'remaining'
+  isDefault?: boolean
+  onUse?: () => void
+}) {
   if (row.usage.status === 'unavailable') return null
   const showHost = row.label !== row.hostKey
   return (
@@ -105,6 +159,7 @@ function RemoteUsageBlock({ row, mode }: { row: RemoteAccountUsage; mode: 'used'
         <span className="usage-account__host" title={`Read on ${row.hostKey} over SSH`}>
           {showHost ? row.hostKey : 'SSH'}
         </span>
+        <DefaultAccountMark isDefault={isDefault} onUse={onUse} />
       </div>
       {row.usage.email && <div className="usage-account__email">{row.usage.email}</div>}
       {row.usage.limits.map((l) => (
@@ -156,7 +211,15 @@ function ProviderBlock({ u, mode }: { u: ProviderUsage; mode: 'used' | 'remainin
  * last-known data shown on stale/error. Compact pill = mini-bar + one "N% label" per limit,
  * e.g. "93% 5h · 39% wk · 13% Fable" — the bar tracks whichever limit is closest to biting.
  */
-export function UsageIndicator({ overBoard = false }: { overBoard?: boolean }): JSX.Element | null {
+export function UsageIndicator({
+  overBoard = false,
+  onSetDefaultAccount
+}: {
+  overBoard?: boolean
+  /** Writes `project.defaultAccountId` + persists (Canvas's own TabBar handler). When absent the
+   *  popover is a pure readout, exactly as before issue #142. */
+  onSetDefaultAccount?: (projectId: string, accountId: string | undefined) => void
+}): JSX.Element | null {
   const [usage, setUsage] = useState<ClaudeUsage | null>(null)
   const [open, setOpen] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
@@ -184,6 +247,37 @@ export function UsageIndicator({ overBoard = false }: { overBoard?: boolean }): 
     usageScopeKey(s.projects.find((p) => p.id === s.activeProjectId))
   )
   const scope = useMemo(() => scopeFromKey(scopeHostKey), [scopeHostKey])
+
+  // Issue #142 — "Use for new sessions" on the account rows. A PRIMITIVE selector on purpose
+  // (see scopeHostKey above): selecting the project object would re-render the pill on every
+  // canvas edit.
+  const projectDefaultId = useProjects(
+    (s) => s.projects.find((p) => p.id === s.activeProjectId)?.defaultAccountId
+  )
+  // The accounts THIS project can actually launch — the same host rule the whole panel follows
+  // (local project: local accounts; SSH project: that host's). The persisted default is validated
+  // against them, exactly as resolveNewNodeAccount does at node creation: a stale id (account
+  // since removed) marks the System row, never a ghost.
+  const eligibleAccounts = useMemo(
+    () =>
+      claudeAccounts.filter(
+        (a) => !a.pending && (scopeHostKey ? a.host === scopeHostKey : !a.host)
+      ),
+    [claudeAccounts, scopeHostKey]
+  )
+  // One rule for every row, local and remote alike — `accountRowAction` (pure, tested) decides
+  // default/offer/none; this pair just turns its answer into props. Absent handler / no project =
+  // pure readout, exactly as before. null = the System row (clears the override).
+  const rowMark = (accountId: string | null): { isDefault: boolean; onUse?: () => void } => {
+    const action = accountRowAction(accountId, eligibleAccounts, projectDefaultId)
+    return {
+      isDefault: action === 'default',
+      onUse:
+        action === 'offer' && onSetDefaultAccount && activeProjectId
+          ? () => onSetDefaultAccount(activeProjectId, accountId ?? undefined)
+          : undefined
+    }
+  }
 
   useEffect(() => {
     void window.nodeTerminal.usage.fetch().then(setUsage)
@@ -400,9 +494,17 @@ export function UsageIndicator({ overBoard = false }: { overBoard?: boolean }): 
                   // Avoid printing the email twice when it's already the display label.
                   email={systemLabelSetting.trim() ? (claudeUsage.email ?? undefined) : undefined}
                   u={claudeUsage}
+                  {...rowMark(null)}
                 />
                 {scoped.accounts.map((a) => (
-                  <AccountUsageBlock key={a.id} mode={percentMode} label={a.label} email={a.email} u={acctUsage[a.id] ?? null} />
+                  <AccountUsageBlock
+                    key={a.id}
+                    mode={percentMode}
+                    label={a.label}
+                    email={a.email}
+                    u={acctUsage[a.id] ?? null}
+                    {...rowMark(a.id)}
+                  />
                 ))}
               </>
             ) : (
@@ -426,8 +528,15 @@ export function UsageIndicator({ overBoard = false }: { overBoard?: boolean }): 
             ))}
           {/* On an SSH project these are the whole panel; the host badge is what says the numbers
               were read somewhere other than this machine. */}
+          {/* The same offer on an SSH project's rows — scoped as ever: only the host's system
+              identity and THIS host's managed accounts are actionable (accountRowAction). */}
           {visibleRemote.map((r) => (
-            <RemoteUsageBlock key={`${r.hostKey}#${r.accountId ?? ''}`} row={r} mode={percentMode} />
+            <RemoteUsageBlock
+              key={`${r.hostKey}#${r.accountId ?? ''}`}
+              row={r}
+              mode={percentMode}
+              {...rowMark(r.accountId)}
+            />
           ))}
           {scope.kind === 'ssh' && visibleRemote.length === 0 && (
             <div className="usage-popover__empty">

--- a/src/renderer/lib/usageScope.test.ts
+++ b/src/renderer/lib/usageScope.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  accountRowAction,
   scopeFromKey,
   scopeUsage,
   usageScopeFor,
@@ -168,5 +169,38 @@ describe('scopeUsage — SSH project', () => {
     const out = scopeUsage({ scope, claude: usage([limit()]), accounts: ACCOUNTS, providers: PROVIDERS, remote: [] })
     expect(out.pillLimits).toEqual([])
     expect(out.remote).toEqual([])
+  })
+})
+
+/**
+ * Issue #142 — the "Use for new sessions" affordance on the popover's account rows. The rules
+ * deliberately mirror resolveNewNodeAccount at node creation; drifting apart would mark one
+ * account here and launch another there.
+ */
+describe('accountRowAction', () => {
+  const eligible = [{ id: 'a1' }, { id: 'a2' }]
+
+  it('marks the System row as default when no override is set', () => {
+    expect(accountRowAction(null, eligible, undefined)).toBe('default')
+    expect(accountRowAction('a1', eligible, undefined)).toBe('offer')
+  })
+
+  it('marks the overriding account and offers the rest, System included', () => {
+    expect(accountRowAction('a1', eligible, 'a1')).toBe('default')
+    expect(accountRowAction('a2', eligible, 'a1')).toBe('offer')
+    expect(accountRowAction(null, eligible, 'a1')).toBe('offer')
+  })
+
+  it('treats a STALE default (account since removed) as System — never a ghost row', () => {
+    expect(accountRowAction(null, eligible, 'gone')).toBe('default')
+    expect(accountRowAction('a1', eligible, 'gone')).toBe('offer')
+  })
+
+  it("refuses to act on a row this project cannot launch (another host's account)", () => {
+    expect(accountRowAction('other-host-acct', eligible, undefined)).toBe('none')
+  })
+
+  it('with no managed accounts the System row is default and nothing is offered', () => {
+    expect(accountRowAction(null, [], undefined)).toBe('default')
   })
 })

--- a/src/renderer/lib/usageScope.ts
+++ b/src/renderer/lib/usageScope.ts
@@ -85,6 +85,33 @@ export interface ScopedUsage {
   pillLimits: ClaudeUsage['limits']
 }
 
+/**
+ * What the "Use for new sessions" affordance on one popover account row should be (issue #142).
+ *
+ * `rowAccountId` — null for a machine's system identity (~/.claude), else the managed account id.
+ * `eligible` — the accounts THIS project can launch (already host-filtered, the panel's own rule).
+ * `projectDefaultId` — the raw persisted `project.defaultAccountId`.
+ *
+ * Two decisions in one place, mirroring `resolveNewNodeAccount` at node creation:
+ *  - the persisted default is VALIDATED against `eligible` — a stale id (account since removed)
+ *    marks the System row as default, never a ghost row;
+ *  - a row is only actionable when the project could actually launch it: the system identity, or
+ *    one of the eligible accounts. Anything else (another host's row) is a plain readout.
+ */
+export function accountRowAction(
+  rowAccountId: string | null,
+  eligible: readonly { id: string }[],
+  projectDefaultId: string | undefined
+): 'default' | 'offer' | 'none' {
+  const activeDefault =
+    projectDefaultId && eligible.some((a) => a.id === projectDefaultId)
+      ? projectDefaultId
+      : undefined
+  const actionable = rowAccountId === null || eligible.some((a) => a.id === rowAccountId)
+  if (!actionable) return 'none'
+  return (rowAccountId ?? undefined) === activeDefault ? 'default' : 'offer'
+}
+
 export function scopeUsage(input: ScopeInput): ScopedUsage {
   const { scope, claude, accounts, providers, remote } = input
   if (scope.kind === 'local') {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5874,6 +5874,37 @@ body,
   background: rgba(var(--tint-rgb), 0.08);
   vertical-align: middle;
 }
+/* "Use for new sessions" affordance + current-default chip on an account row (issue #142).
+   Same chip grammar as __host above; the button reads as quiet text until hovered so the
+   readout stays a readout. */
+.usage-account__default {
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.usage-account__use {
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: none;
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  color: rgba(var(--tint-rgb), 0.45);
+  background: transparent;
+  cursor: pointer;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.usage-account__use:hover {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
 
 /* ---- Session-memory panel (opened by the system-resource pill) ----
    Same surface, border and shadow as `.usage-popover` above — the two panels open from adjacent


### PR DESCRIPTION
Fixes #142 — *"I'm running two Claude accounts and would be awesome to switch between them via this element."*

Implements the issue's sketch exactly:

- Each account row in the usage popover (System + managed, local and SSH-host alike) gets a **"Use for new sessions"** affordance; the project's current default carries a **✓ new sessions** chip.
- The click writes `project.defaultAccountId` through the **same handler the TabBar caret menu uses** (store write + `persist()`), so the popover row is a second, better-placed entrance to the same action — nothing new to keep in sync.
- **Honest semantics**: `data.accountId` is immutable after node creation, so nothing implies existing sessions move — the affordance copy and tooltips say "new sessions", and running sessions keep their account.
- **One pure rule for every row** — `accountRowAction` in `usageScope.ts`, unit-tested: the persisted default is validated against the accounts *this* project can launch (stale id ⇒ the System row is default, never a ghost), and a row is only actionable when the project could launch it — local accounts on a local project, the host's accounts on an SSH project, mirroring `resolveNewNodeAccount` and the panel's existing `usageScopeKey` scoping.
- Styling reuses the popover's chip grammar (`__host`), theme-aware via `var(--accent)` + `color-mix` (no new variables).
- Server Edition follows for free (pure renderer + settings/workspace writes), as the issue predicted — worth one look on a served client.

Renderer suite green (2428 passed; the one failure is the known worktree-environmental `webgl-addon-pair` node_modules path read), typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)