### PR TITLE
Load local file:// pages in browser nodes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'crypto'
 import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, Notification, powerMonitor, safeStorage, shell, systemPreferences, webContents } from 'electron'
 import { IPC } from '../shared/ipc'
 import { writeFilesToClipboard } from './clipboard-files'
+import { allowGuestNavigation } from './webview-nav'
 import { registerFsHandlers } from '../core/fs-handlers'
 import {
   registerBrowserGuest,
@@ -657,10 +658,10 @@ app.whenReady().then(async () => {
   // startup for all current and future guests.
   app.on('web-contents-created', (_e, contents) => {
     if (contents.getType() !== 'webview') return
-    // Web nodes may only show http(s) pages or local content we serve via the jailed
-    // nt-media:// scheme.
+    // Web nodes may only show http(s) pages, jailed nt-media:// content, or origin-gated
+    // local file:// pages (policy + tests in webview-nav.ts).
     contents.on('will-navigate', (e, url) => {
-      if (!/^https?:\/\//i.test(url) && !/^nt-media:\/\//i.test(url)) e.preventDefault()
+      if (!allowGuestNavigation(contents.getURL(), url)) e.preventDefault()
     })
     // A browser node's guest requested a new window → open it as another browser node
     // (never a real popup). Only http(s); other schemes are dropped. The map is consulted

--- a/src/main/webview-nav.test.ts
+++ b/src/main/webview-nav.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { allowGuestNavigation } from './webview-nav'
+
+describe('allowGuestNavigation', () => {
+  it('allows http(s) from anywhere', () => {
+    expect(allowGuestNavigation('https://a.com/', 'https://b.com/')).toBe(true)
+    expect(allowGuestNavigation('file:///home/me/x.html', 'http://localhost:3000/')).toBe(true)
+    expect(allowGuestNavigation('', 'https://a.com/')).toBe(true)
+  })
+  it('allows nt-media:// from anywhere', () => {
+    expect(allowGuestNavigation('https://a.com/', 'nt-media://abc/video.mp4')).toBe(true)
+  })
+  it('allows file:// only from a local page or a fresh guest', () => {
+    expect(allowGuestNavigation('file:///home/me/index.html', 'file:///home/me/other.html')).toBe(true)
+    expect(allowGuestNavigation('', 'file:///home/me/index.html')).toBe(true)
+    expect(allowGuestNavigation('about:blank', 'file:///home/me/index.html')).toBe(true)
+  })
+  it('blocks file:// from a remote page', () => {
+    expect(allowGuestNavigation('https://evil.com/', 'file:///etc/passwd')).toBe(false)
+  })
+  it('blocks other schemes from anywhere', () => {
+    expect(allowGuestNavigation('https://a.com/', 'javascript:alert(1)')).toBe(false)
+    expect(allowGuestNavigation('file:///home/me/x.html', 'javascript:alert(1)')).toBe(false)
+    expect(allowGuestNavigation('https://a.com/', 'data:text/html,x')).toBe(false)
+    expect(allowGuestNavigation('https://a.com/', 'smb://server/share')).toBe(false)
+  })
+})

--- a/src/main/webview-nav.ts
+++ b/src/main/webview-nav.ts
@@ -1,0 +1,14 @@
+// Navigation policy for <webview> guests (browser/web nodes).
+//
+// Guests may show http(s) pages, local content served via the jailed nt-media:// scheme, and —
+// since #251 — local file:// pages typed into the address bar. file:// is origin-gated: a link
+// inside a local page may go to another local page, but a remote page must never be able to
+// navigate the guest to a local file. First loads (empty/about:blank guest) arrive via loadURL
+// and normally bypass will-navigate; the fresh-guest allowance only mirrors that path.
+export function allowGuestNavigation(currentUrl: string, targetUrl: string): boolean {
+  if (/^https?:\/\//i.test(targetUrl) || /^nt-media:\/\//i.test(targetUrl)) return true
+  if (/^file:\/\//i.test(targetUrl)) {
+    return currentUrl === '' || currentUrl === 'about:blank' || /^file:\/\//i.test(currentUrl)
+  }
+  return false
+}

--- a/src/renderer/nodes/browserUrl.test.ts
+++ b/src/renderer/nodes/browserUrl.test.ts
@@ -35,7 +35,15 @@ describe('searchOrUrl', () => {
   it('Google-searches free text and non-http schemes', () => {
     expect(searchOrUrl('how to code')).toBe('https://www.google.com/search?q=how%20to%20code')
     expect(searchOrUrl('weather')).toBe('https://www.google.com/search?q=weather')
-    expect(searchOrUrl('file:///etc/passwd')).toBe('https://www.google.com/search?q=file%3A%2F%2F%2Fetc%2Fpasswd')
+    expect(searchOrUrl('javascript:alert(1)')).toBe('https://www.google.com/search?q=javascript%3Aalert(1)')
+    expect(searchOrUrl('data:text/html,x')).toBe('https://www.google.com/search?q=data%3Atext%2Fhtml%2Cx')
+  })
+  it('navigates file:// URLs to local files', () => {
+    expect(searchOrUrl('file:///home/me/page.html')).toBe('file:///home/me/page.html')
+  })
+  it('folds a mistyped file host into the path (file://path/… → file:///path/…)', () => {
+    expect(searchOrUrl('file://path/to/my/file.html')).toBe('file:///path/to/my/file.html')
+    expect(searchOrUrl('file://localhost/x.html')).toBe('file:///x.html')
   })
   it('returns null for empty', () => {
     expect(searchOrUrl('   ')).toBeNull()

--- a/src/renderer/nodes/browserUrl.ts
+++ b/src/renderer/nodes/browserUrl.ts
@@ -27,9 +27,11 @@ function googleSearch(query: string): string {
 }
 
 /**
- * Turn an address-bar / start-page entry into a navigable http(s) URL, or a Google search for
- * free text. Returns null only for empty input. localhost/127.0.0.1 default to http (dev servers);
- * other bare hosts to https. Non-http schemes (file:/javascript:/…) are searched, never navigated.
+ * Turn an address-bar / start-page entry into a navigable http(s)/file URL, or a Google search
+ * for free text. Returns null only for empty input. localhost/127.0.0.1 default to http (dev
+ * servers); other bare hosts to https. file:// loads local pages; a non-localhost "host" in a
+ * file URL (file://path/to/x) is folded into the path — on this local-only browser it can only
+ * be a mistyped absolute path. Other schemes (javascript:/data:/…) are searched, never navigated.
  */
 export function searchOrUrl(input: string): string | null {
   const raw = input.trim()
@@ -40,6 +42,14 @@ export function searchOrUrl(input: string): string | null {
     if (/^https?:\/\//i.test(raw)) {
       try {
         return new URL(raw).toString()
+      } catch {
+        return googleSearch(raw)
+      }
+    }
+    if (/^file:/i.test(raw)) {
+      try {
+        const u = new URL(raw)
+        return u.host ? new URL(`file:///${u.host}${u.pathname}${u.search}${u.hash}`).toString() : u.toString()
       } catch {
         return googleSearch(raw)
       }


### PR DESCRIPTION
Fixes #251.

Typing a `file://` URL into a browser node's address bar sent it to Google search, because `searchOrUrl` treated every non-http scheme as free text.

## Changes

- **`browserUrl.ts`**: `file:` URLs now navigate. A mistyped host (`file://path/to/x.html`, as in the issue) is folded into the path — a file host is meaningless in this local-only browser — yielding `file:///path/to/x.html`. `javascript:`/`data:`/other schemes are still searched, never navigated.
- **`webview-nav.ts` (new)**: the webview guest `will-navigate` guard, extracted from `index.ts` into a tested pure function. It now permits `file://` targets, but only from another `file://` page or a fresh guest — a remote http(s) page still cannot steer the node to local files. This also makes relative links inside a loaded local page work.

## Tests

- `browserUrl.test.ts`: file URL pass-through, host folding, localhost normalization; javascript:/data: still googled.
- `webview-nav.test.ts`: http(s)/nt-media allowed everywhere, file→file allowed, remote→file blocked, other schemes blocked.

`npm run typecheck` clean; vitest suite green apart from 4 pre-existing environment failures (node-pty patch + webgl addon-pair checks against local `node_modules`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)