### PR TITLE
test: fix parallel-execution flakiness at its mechanism (fixes #160)

### DIFF
--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -115,6 +115,25 @@ vi.mock('child_process', () => {
 const SOLO = 42
 
 /**
+ * Hermetic tmux resolution (issue #160). Without this, `init()` → `ensureTmux()` → `findTmux()`
+ * probes the REAL machine: `fs.existsSync` on the fixed install paths, then the login-shell PATH,
+ * then the bundled binary. Two ways that made this file's answer depend on the host:
+ *  - a machine with no tmux installed never actually tested the tmux-backed manager (every
+ *    `tmuxManager()` silently exercised the plain-shell fallback instead);
+ *  - under ~16 parallel workers a transient EMFILE makes `existsSync` swallow the error and
+ *    answer FALSE for a tmux that IS installed — every candidate misses, the manager silently
+ *    falls back to a plain shell, and all of this file's "expected 1 tmux call, got 0"
+ *    assertions fail at once. That is issue #160's run A (44 failures), unreproducible alone.
+ * Pinning the first fixed candidate makes tmux resolution a function of the code under test, not
+ * of the host's fd budget. No real tmux is ever invoked: node-pty and child_process are mocked
+ * above, and ensureTmux's `source-file` push goes through the mocked execFileSync.
+ */
+vi.mock('./tmux-hint', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./tmux-hint')>()),
+  findFixedTmux: () => '/usr/bin/tmux'
+}))
+
+/**
  * A machine with pty devices to spare, always.
  *
  * Without this the real probe runs a `readdir('/dev')` against the DEVELOPER's host, and

--- a/src/renderer/terminal/webgl-addon-pair.test.ts
+++ b/src/renderer/terminal/webgl-addon-pair.test.ts
@@ -32,10 +32,22 @@ describe('@xterm/addon-webgl ↔ @xterm/xterm version pair', () => {
     // The exact expression that crashed: a dispose-path read of `_core._store`. 0.18.0 does not
     // contain it; if a future addon build does, the core must be new enough to carry the field —
     // re-verify the release path before loosening this.
-    const src = fs.readFileSync(
-      path.resolve(__dirname, '../../../node_modules/@xterm/addon-webgl/lib/addon-webgl.js'),
-      'utf8'
-    )
+    // require.resolve, not a fixed ../../../node_modules path: a git worktree checkout has no
+    // node_modules of its own and resolves modules from the main checkout, so the fixed path was
+    // ENOENT there — the same environment-dependence class as issue #160, red on every worktree.
+    //
+    // The INSTALLED version is asserted first, so a drifted node_modules fails with "you are on
+    // 0.19.0, run npm install" instead of a bare includes() mismatch. Not hypothetical: the very
+    // run that switched to require.resolve found the dev checkout serving 0.19.0 — the exact
+    // addon the 0.18.0 pin exists to keep away from the 5.5 core — because no install had run
+    // since the pin. That is this test doing its job; the assertion just has to say so legibly.
+    const installed = (
+      JSON.parse(
+        fs.readFileSync(require.resolve('@xterm/addon-webgl/package.json'), 'utf8')
+      ) as { version: string }
+    ).version
+    expect(installed, 'installed @xterm/addon-webgl drifted from the 0.18.0 pin — run npm install').toBe('0.18.0')
+    const src = fs.readFileSync(require.resolve('@xterm/addon-webgl/lib/addon-webgl.js'), 'utf8')
     expect(src.includes('_store._isDisposed')).toBe(false)
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,14 @@ export default defineConfig({
       // NODETERM_SSH_DOCKER is set, so a machine without Docker still runs a green suite.
       'test/ssh-docker/**/*.test.ts'
     ],
-    environment: 'node'
+    environment: 'node',
+    // Issue #160: with the default (one worker per core), a 10-core Mac runs ~10 fs-heavy suites
+    // at once and transient fd exhaustion (EMFILE) turns into silent test flakiness — probes like
+    // `fs.existsSync` swallow the error and answer false, so whole files fail in ways that never
+    // reproduce alone and vanish with --no-file-parallelism. Half the cores keeps wall-clock
+    // close (the suite is fs/IO-bound, not CPU-bound) while halving peak fd pressure. CI's 2-core
+    // runners resolve to 1 worker, which is what they effectively ran anyway.
+    maxWorkers: '50%'
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Fixes #160 — implements both directions the issue suggested, plus one more instance of the same environment-dependence class found en route.

## The mechanism

The reporter's evidence (fails only under full parallelism, the failing file moves between runs, vanishes with `--no-file-parallelism`, every assertion is "expected 1 tmux call, got 0") points at one mechanism: **transient fd exhaustion under ~16 workers**. `fs.existsSync` swallows errors — under EMFILE it answers `false` for a path that exists — so `findTmux()` misses every candidate, `ensureTmux()` leaves `tmuxPath` null, and the manager takes the silent plain-shell fallback. All 44 tmux-call assertions in `pty-single-user.test.ts` then fail at once, unreproducible in isolation.

## Fixes

1. **`pty-single-user.test.ts` is now hermetic** (issue direction 1): `vi.mock('./tmux-hint')` pins `findFixedTmux` to a fixed path, so tmux resolution is a function of the code under test, not the host's fd budget — no real tmux is invoked (node-pty + child_process were already mocked). Bonus: a machine *without* tmux installed now actually tests the tmux-backed manager, instead of silently running the plain-shell path under both harnesses.
2. **`maxWorkers: '50%'`** in vitest.config.ts (issue direction 2): the suite is fs/IO-bound, so half the workers halves peak fd pressure at near-identical wall clock (full suite 55s here). CI's 2-core runners effectively ran 1 worker anyway.
3. **`webgl-addon-pair.test.ts`** read the addon source via a fixed `../../../node_modules` path — ENOENT in every git worktree (worktrees have no `node_modules`). Now `require.resolve`, with the installed version asserted against the 0.18.0 pin first and an actionable message. **This immediately caught a real drift**: the dev checkout is serving `@xterm/addon-webgl` 0.19.0 — the exact version PR #173's pin exists to keep away from the xterm 5.5 core — because no `npm install` has run since the pin. On that machine the test now fails with *"installed @xterm/addon-webgl drifted from the 0.18.0 pin — run npm install"*, which is it doing its job; CI installs fresh and stays green.

Related: #243 fixed another instance of this class (the `phone-target-e2e` fork-window race on CI runners) two days ago.

Local verification: `pty-single-user` alone ×1 and `src/core` ×3 all green; full `npm test` 6755 passed with the one honest drift failure above.

⚠️ Note for the local dev machine: run `npm install` in the main checkout after this merges — the addon-webgl 0.18.0/0.19.0 drift is real and affects `electron-vite dev` on that machine, not just the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)