### PR TITLE
fix(window): leave fullscreen before hide-on-close (black Space on close)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,7 +58,7 @@ import {
   isValidPendingId,
   syntheticAnsweredEvent
 } from '../core/agents/pending-approvals'
-import { setMainWindow, getMainWindow, sendToMain, shouldHideOnClose, createCrashReloadPolicy } from './main-window'
+import { setMainWindow, getMainWindow, sendToMain, closeAction, createCrashReloadPolicy } from './main-window'
 import { installKeydownIntercepts } from './keydown-intercept'
 import {
   initNotchHud,
@@ -611,10 +611,24 @@ function createWindow(): BrowserWindow {
   // outlives its window (tmux sessions, hook server, updater); destroying the window
   // would leave every window-bound subsystem (agent-status forwarding, tails, updater,
   // license events) pointing at a dead webContents after a dock-reopen.
+  // A fullscreen window must LEAVE fullscreen before it hides: hiding in place strands the
+  // window's empty Space as a black screen (issue #78 / electron/electron#20263). The
+  // transition is async, so the hide waits for `leave-full-screen`; `leavingFullScreen`
+  // keeps a second ⌘W during the transition from stacking another listener.
+  let leavingFullScreen = false
   win.on('close', (e) => {
-    if (shouldHideOnClose(process.platform, quitting)) {
-      e.preventDefault()
+    const action = closeAction(process.platform, quitting, win.isFullScreen())
+    if (action === 'default') return
+    e.preventDefault()
+    if (action === 'hide') {
       win.hide()
+    } else if (!leavingFullScreen) {
+      leavingFullScreen = true
+      win.once('leave-full-screen', () => {
+        leavingFullScreen = false
+        if (!win.isDestroyed() && !quitting) win.hide()
+      })
+      win.setFullScreen(false)
     }
   })
 

--- a/src/main/main-window.test.ts
+++ b/src/main/main-window.test.ts
@@ -5,6 +5,7 @@ import {
   sendToMain,
   mainWindowClientIds,
   shouldHideOnClose,
+  closeAction,
   createCrashReloadPolicy,
   type MainWindowLike
 } from './main-window'
@@ -156,5 +157,22 @@ describe('shouldHideOnClose', () => {
   it('never intercepts close on other platforms', () => {
     expect(shouldHideOnClose('win32', false)).toBe(false)
     expect(shouldHideOnClose('linux', false)).toBe(false)
+  })
+})
+
+describe('closeAction', () => {
+  it('hides a windowed macOS close', () => {
+    expect(closeAction('darwin', false, false)).toBe('hide')
+  })
+  it('leaves fullscreen before hiding — hiding in place strands a black Space (issue #78)', () => {
+    expect(closeAction('darwin', false, true)).toBe('leave-fullscreen-then-hide')
+  })
+  it('lets the close through when quitting, fullscreen or not', () => {
+    expect(closeAction('darwin', true, true)).toBe('default')
+    expect(closeAction('darwin', true, false)).toBe('default')
+  })
+  it('never intercepts on other platforms, fullscreen included', () => {
+    expect(closeAction('linux', false, true)).toBe('default')
+    expect(closeAction('win32', false, true)).toBe('default')
   })
 })

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -73,3 +73,21 @@ export function createCrashReloadPolicy(
 export function shouldHideOnClose(platform: NodeJS.Platform | string, quitting: boolean): boolean {
   return platform === 'darwin' && !quitting
 }
+
+export type CloseAction = 'default' | 'hide' | 'leave-fullscreen-then-hide'
+
+/**
+ * What the close-event handler should do. Hiding a FULLSCREEN window without leaving fullscreen
+ * first strands its empty Space as a black screen the user can still swipe to (issue #78, the
+ * known Electron behavior electron/electron#20263) — so fullscreen must be exited, the async
+ * `leave-full-screen` transition awaited, and only THEN the window hidden. The quit path is not
+ * affected: there the window really closes and the app (and its Space) goes away with it.
+ */
+export function closeAction(
+  platform: NodeJS.Platform | string,
+  quitting: boolean,
+  isFullScreen: boolean
+): CloseAction {
+  if (!shouldHideOnClose(platform, quitting)) return 'default'
+  return isFullScreen ? 'leave-fullscreen-then-hide' : 'hide'
+}


### PR DESCRIPTION
Fixes the first bug on the #78 roadmap: closing the app while in macOS fullscreen hid the window in place, stranding its empty Space as a black screen (the known Electron behavior electron/electron#20263).

## What changed
- `closeAction()` (pure, unit-tested, in `main-window.ts`) decides the close handler's move: windowed close hides immediately as before; fullscreen close exits fullscreen first, waits for the async `leave-full-screen` transition, then hides. A guard keeps a second ⌘W during the transition from stacking listeners.
- Quit path untouched: there the window really closes and the Space goes away with the app (`shouldHideOnClose` already lets it through).

## Manual repro (needs a real Mac)
1. Put the app window into native fullscreen (green traffic light).
2. ⌘W (or close) — before: the Space stays behind as a black screen you can swipe to; after: the window slides out of fullscreen, then hides, and no black Space remains.
3. Reopen from the Dock — window comes back windowed.
4. ⌘Q from fullscreen still quits cleanly.

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)