### PR TITLE
fix(terminal): truecolor end-to-end — COLORTERM + tmux RGB terminal-features

### DIFF
--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -219,6 +219,10 @@ set -su terminal-overrides
 set -su terminal-features
 set -g set-clipboard on
 set -as terminal-features ",*:clipboard"
+# Truecolor passthrough: tmux clamps 24-bit SGR to the 256 palette unless the OUTER terminal is
+# known to speak RGB. xterm.js does, so declare it — via terminal-features like the clipboard
+# entry above, never terminal-overrides (see the MIGRATION note). Issue #78.
+set -as terminal-features ",*:RGB"
 # Mouse copy: on release tmux copies to its buffer AND (thanks to the two lines above) emits OSC 52,
 # which the client writes to the system clipboard. No pipe-to-a-local-command here, deliberately.
 bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel
@@ -2018,7 +2022,11 @@ export class PtyManager {
 
     // Strip TMUX so tmux doesn't refuse to nest if the app itself was launched
     // from inside a tmux session.
-    const env = { ...process.env, TERM: 'xterm-256color' } as Record<string, string>
+    // COLORTERM is the truecolor handshake half the ecosystem checks before emitting 24-bit
+    // SGR (the other half asks tmux/terminfo). xterm.js renders truecolor natively, so
+    // advertise it — without this, zsh themes and TUIs quietly clamp to the 256 palette and
+    // the canvas terminals never match the user's real terminal colors (issue #78).
+    const env = { ...process.env, TERM: 'xterm-256color', COLORTERM: 'truecolor' } as Record<string, string>
     delete env.TMUX
     delete env.TMUX_PANE
 
@@ -2288,6 +2296,9 @@ export class PtyManager {
       // Same reasoning for LANG: force the UTF-8 locale per new session so a session created on a
       // shared/stale tmux server (started before this fix) still gets UTF-8 box-drawing.
       const langEnvArgs = env.LANG ? ['-e', `LANG=${env.LANG}`] : []
+      // And for COLORTERM: panes read the SESSION env, not the client's, so the truecolor
+      // handshake must ride `-e` to reach programs on a shared/stale server (issue #78).
+      const colortermEnvArgs = ['-e', 'COLORTERM=truecolor']
       // The account config dir must ride `-e` like the hook env: the tmux server is shared
       // and long-lived, so session env comes from creation args, not client inheritance.
       const accountEnvArgs = accountDir ? accountTmuxEnvArgs(accountDir) : []
@@ -2311,6 +2322,7 @@ export class PtyManager {
         ...hookEnvArgs,
         ...pathEnvArgs,
         ...langEnvArgs,
+        ...colortermEnvArgs,
         ...accountEnvArgs,
         '-c',
         cwd,

--- a/src/core/tmux-conf.test.ts
+++ b/src/core/tmux-conf.test.ts
@@ -27,6 +27,14 @@ describe('tmuxConf', () => {
     expect(c).not.toContain('Ms=')
   })
 
+  it('declares RGB via terminal-features so truecolor is not clamped to 256 colors (issue #78)', () => {
+    // Without an RGB terminal-features (or Tc) entry for the outer terminal, tmux quantizes every
+    // 24-bit SGR to the 256-color palette — canvas terminals never match the user's real terminal.
+    expect(c).toContain('set -as terminal-features ",*:RGB"')
+    // Only via terminal-features: the overrides array must stay unset (see the MIGRATION note).
+    expect(c).not.toMatch(/set -a[gs]? terminal-overrides/)
+  })
+
   it('copies mouse selections through tmux (OSC 52), with no macOS-only pbcopy pipe', () => {
     expect(c).toContain('bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel')
     expect(c).toContain('bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel')

--- a/src/shared/ssh.test.ts
+++ b/src/shared/ssh.test.ts
@@ -252,6 +252,13 @@ describe('remoteTmuxConf', () => {
     expect(c).not.toMatch(/set -g[a]? terminal-overrides/)
     expect(c).not.toMatch(/set -a[gs]? terminal-overrides/)
   })
+  it('declares RGB via terminal-features and sets COLORTERM so truecolor survives SSH (issue #78)', () => {
+    // Without RGB, the remote tmux quantizes 24-bit SGR to 256 colors before it ever reaches our
+    // renderer. COLORTERM rides the server's GLOBAL env (this conf is source-filed at connect,
+    // before sessions exist), so programs inside the panes see the handshake too.
+    expect(c).toContain('set -as terminal-features ",*:RGB"')
+    expect(c).toContain('set-environment -g COLORTERM truecolor')
+  })
   it('clears the override/feature arrays a long-lived server accumulated from older versions', () => {
     // A tmux server outlives the app and keeps every entry ever sourced into it; the stale
     // smcup@/rmcup@/indn@ entries would otherwise keep breaking scrolling forever. Measured:

--- a/src/shared/ssh.ts
+++ b/src/shared/ssh.ts
@@ -296,6 +296,15 @@ set -su terminal-overrides
 set -su terminal-features
 set -g set-clipboard on
 set -as terminal-features ",*:clipboard"
+# Truecolor passthrough: tmux clamps 24-bit SGR to the 256 palette unless the OUTER terminal is
+# known to speak RGB. The attached client is our xterm.js renderer, which does — declare it via
+# terminal-features like the clipboard entry, never terminal-overrides (see MIGRATION). Issue #78.
+set -as terminal-features ",*:RGB"
+# And advertise it to the programs INSIDE the panes: half the ecosystem checks COLORTERM before
+# emitting 24-bit SGR. Global env, copied into each session at creation — this conf is written and
+# source-filed at connect (warm server) and rides -f on cold start, so it lands before sessions do.
+# The local path passes COLORTERM per session via tmux -e instead (the PATH/LANG precedent).
+set-environment -g COLORTERM truecolor
 # Mouse copy: tmux copies to its buffer AND emits OSC 52. No pipe to a local command — it would run
 # on the REMOTE host, which is nobody's clipboard.
 bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel


### PR DESCRIPTION
The two still-valid pieces of the terminal-colors item on the #78 roadmap (the ANSI-palette theme setting itself landed earlier in `259425d`): canvas terminals clamped 24-bit color to the 256 palette, so they never matched the user's real terminal.

## What changed
- **tmux RGB passthrough**: both generated confs (local `tmuxConf` and `remoteTmuxConf`) now carry `set -as terminal-features ",*:RGB"` next to the existing clipboard entry — via `terminal-features`, never `terminal-overrides`, per the MIGRATION doctrine in the conf headers (which is untouched). Warm servers pick it up through the existing source-file-at-connect/init path.
- **COLORTERM** (never set before): the local PTY env advertises `truecolor`; local tmux sessions get it per session via `-e` (the PATH/LANG precedent — panes read the session env, not the client's, on the shared long-lived server); the remote conf seeds it into the server's global env (`set-environment -g`) so remote panes inherit it at session creation.

xterm.js renders truecolor natively, so nothing changes on the renderer side; theme/palette data continues to flow through the single appearance source, and in shared-GPU mode the glyph layer consumes the same decoded RGB cells.

## Verify
`printf "\x1b[38;2;255;100;0mTRUECOLOR\x1b[0m\n"` renders orange (not a rounded 256-palette shade) in a local node, an SSH node, and inside a running TUI. `echo $COLORTERM` prints `truecolor` in both.

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)