### PR TITLE
fix(usage): shared context thresholds + percent-mode setting on every surface

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1258,7 +1258,12 @@ app.whenReady().then(async () => {
   // 'show' guarantees a regular window has established the app's Dock presence first.
   const notchTunables = (): NotchHudTunables => {
     const s = settingsStore.get()
-    return { enabled: s.notchHud, notchWidth: s.notchWidth, hoverExpand: s.notchHoverExpand }
+    return {
+      enabled: s.notchHud,
+      notchWidth: s.notchWidth,
+      hoverExpand: s.notchHoverExpand,
+      percentMode: s.usagePercentMode
+    }
   }
   const startNotchHud = (): void =>
     initNotchHud({ getNodeTitle: displayTitleFor }, notchTunables())

--- a/src/main/notch-hud.ts
+++ b/src/main/notch-hud.ts
@@ -102,6 +102,8 @@ export interface NotchHudTunables {
   notchWidth: number
   /** Expand the panel on hover (else click-only). */
   hoverExpand: boolean
+  /** settings.usagePercentMode — how the rows' context percentages render ("42% used" / "58% left"). */
+  percentMode: 'used' | 'remaining'
 }
 
 /** Clamp a hand-editable width to something that can't push the capsule off the display. */
@@ -123,7 +125,7 @@ class NotchHudController {
 
   constructor(
     private deps: NotchHudDeps,
-    private tunables: { notchWidth: number; hoverExpand: boolean }
+    private tunables: { notchWidth: number; hoverExpand: boolean; percentMode: 'used' | 'remaining' }
   ) {
     this.onSetIgnoreMouse = (_e, ignore) => {
       // Ignore-mouse ON = click-through (the strip is transparent to the app beneath); OFF while the
@@ -241,8 +243,8 @@ class NotchHudController {
   }
 
   /** Apply live tunables and re-push, so a slider drag moves the capsule as you drag. */
-  setTunables(t: { notchWidth: number; hoverExpand: boolean }): void {
-    this.tunables = { notchWidth: t.notchWidth, hoverExpand: t.hoverExpand }
+  setTunables(t: { notchWidth: number; hoverExpand: boolean; percentMode: 'used' | 'remaining' }): void {
+    this.tunables = { notchWidth: t.notchWidth, hoverExpand: t.hoverExpand, percentMode: t.percentMode }
     this.schedulePush()
   }
 
@@ -382,6 +384,7 @@ class NotchHudController {
       width: g.width,
       notchWidth: g.notchWidth,
       hoverExpand: this.tunables.hoverExpand,
+      percentMode: this.tunables.percentMode,
       notchCenterX: g.notchCenterX,
       hasNotch: g.hasNotch && !clamped
     })

--- a/src/preload/hud.ts
+++ b/src/preload/hud.ts
@@ -36,6 +36,8 @@ export interface HudPush {
   hasNotch: boolean
   /** Expand the panel on hover (settings.notchHoverExpand); false = click-only. */
   hoverExpand: boolean
+  /** settings.usagePercentMode — how a row's context percentage renders ("42% used" / "58% left"). */
+  percentMode: 'used' | 'remaining'
 }
 
 export interface HudApi {

--- a/src/renderer/components/ContextMeter.tsx
+++ b/src/renderer/components/ContextMeter.tsx
@@ -1,13 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useContextWindow } from '../state/contextWindow'
-import { formatModelLabel, formatTimeAgo } from '../lib/usageFormat'
-
-/** Fullness scale (inverse of the usage indicator): green low, yellow mid, red near-full. */
-function meterColor(usedPercent: number): string {
-  if (usedPercent > 85) return '#ff453a'
-  if (usedPercent >= 60) return '#ffd60a'
-  return '#30d158'
-}
+import { useSettings } from '../state/settings'
+import { barFillPercent, contextFillColor, formatModelLabel, formatTimeAgo, percentNumber, percentText } from '../lib/usageFormat'
 
 /** Humanize a token count: 48000 → "48k", 1_000_000 → "1M", 850 → "850". */
 function formatTokens(n: number): string {
@@ -22,6 +16,7 @@ function formatTokens(n: number): string {
  */
 export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.Element | null {
   const usage = useContextWindow((s) => (sessionId ? s.bySessionId[sessionId] : undefined))
+  const percentMode = useSettings((s) => s.settings.usagePercentMode)
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -35,8 +30,10 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
   }, [open])
 
   if (!usage) return null
-  const pct = Math.round(usage.usedPercent)
-  const color = meterColor(usage.usedPercent)
+  // The NUMBER honours the used/remaining display setting; the bar and its color stay keyed to
+  // context FILL, so the severity colors keep meaning the same thing in both modes (issue #78).
+  const pct = percentNumber(usage.usedPercent, percentMode)
+  const color = contextFillColor(usage.usedPercent)
   const modelLabel = formatModelLabel(usage.model)
 
   return (
@@ -45,7 +42,7 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
         <div className="ctx-popover">
           <div className="ctx-popover__title">Context</div>
           <div className="ctx-bar">
-            <div className="ctx-bar__fill" style={{ width: `${usage.usedPercent}%`, background: color }} />
+            <div className="ctx-bar__fill" style={{ width: `${barFillPercent(usage.usedPercent, percentMode)}%`, background: color }} />
           </div>
           <div className="ctx-popover__meta">
             ~{formatTokens(usage.usedTokens)} / {formatTokens(usage.windowTokens)} tokens
@@ -60,7 +57,7 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
       )}
       <button
         className="ctx-pill"
-        title="Context window"
+        title={`Context window — ${percentText(usage.usedPercent, percentMode)}`}
         onClick={(e) => {
           e.stopPropagation()
           setOpen((v) => !v)
@@ -68,7 +65,7 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
       >
         {modelLabel && <span className="ctx-pill__model">{modelLabel}</span>}
         <span className="ctx-pill__bar">
-          <span className="ctx-pill__fill" style={{ width: `${usage.usedPercent}%`, background: color }} />
+          <span className="ctx-pill__fill" style={{ width: `${barFillPercent(usage.usedPercent, percentMode)}%`, background: color }} />
         </span>
         <span className="ctx-pill__num">{pct}%</span>
       </button>

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -3,6 +3,8 @@ import { IconBellFilled, IconCircleCheck } from './icons'
 import type { SessionRowVM } from '../lib/sessionList'
 import { useContextWindow } from '../state/contextWindow'
 import { useSessionNaming } from '../state/sessionNaming'
+import { useSettings } from '../state/settings'
+import { contextFillColor, percentNumber, percentText } from '../lib/usageFormat'
 
 export interface SessionRowProps {
   row: SessionRowVM
@@ -15,12 +17,6 @@ export interface SessionRowProps {
   onDragEnd(): void
   /** Status-group mode only: elapsed time since the current state began. */
   stateAgeLabel?: string
-}
-
-function ctxColor(pct: number): string {
-  if (pct > 85) return '#ff453a'
-  if (pct >= 60) return '#ffd60a'
-  return '#30d158'
 }
 
 function dirName(p?: string): string {
@@ -46,6 +42,7 @@ export function SessionRow({
   // unmounting (sidebar close / hover-peek collapse) while the name is still generating.
   const naming = useSessionNaming((s) => !!s.byId[row.id])
   const usage = useContextWindow((s) => (row.sessionId ? s.bySessionId[row.sessionId] : undefined))
+  const percentMode = useSettings((s) => s.settings.usagePercentMode)
 
   const commit = (): void => {
     const t = draft.trim()
@@ -135,8 +132,12 @@ export function SessionRow({
             </span>
           )}
           {row.usesContext && usage && (
-            <span className="ss-ctx" style={{ background: ctxColor(usage.usedPercent) }}>
-              {Math.round(usage.usedPercent)}%
+            <span
+              className="ss-ctx"
+              title={`Context window — ${percentText(usage.usedPercent, percentMode)}`}
+              style={{ background: contextFillColor(usage.usedPercent) }}
+            >
+              {percentNumber(usage.usedPercent, percentMode)}%
             </span>
           )}
           <button

--- a/src/renderer/hud/main.ts
+++ b/src/renderer/hud/main.ts
@@ -9,6 +9,7 @@ import { HUD_BRAND_PULSE_CLASS, brandPulseBackground, brandPulsePlan } from '../
 import { createGrokMarkSvg } from '../lib/grokMark'
 import { createCopilotMarkSvg } from '../lib/copilotMark'
 import { buildIndicator, orderIndicatorAgents } from './indicator'
+import { percentText } from '../lib/usageFormat'
 import codexPet from '../assets/pet-codex.webp'
 
 // Local mirror of the preload's HUD contract (src/preload/hud.ts) — kept self-contained so this
@@ -38,6 +39,7 @@ interface HudPush {
   notchCenterX: number
   hasNotch: boolean
   hoverExpand: boolean
+  percentMode?: 'used' | 'remaining'
 }
 interface HudApi {
   onRows(cb: (push: HudPush) => void): () => void
@@ -74,6 +76,8 @@ let latestRows: HudRow[] = []
 let notchWidthPx = 168
 // Hover-to-expand (settings.notchHoverExpand). Off = the capsule only expands on click.
 let hoverExpand = true
+// settings.usagePercentMode — the same number/label the other context surfaces render (issue #78).
+let percentMode: 'used' | 'remaining' = 'remaining'
 // Which subagent disclosures the user has opened (by nodeId), preserved across re-renders.
 const openSubs = new Set<string>()
 
@@ -277,7 +281,9 @@ function buildRow(row: HudRow): HTMLElement {
   const parts: string[] = []
   if (row.model) parts.push(row.model)
   parts.push(reltime(row.updatedAt))
-  if (typeof row.contextPercent === 'number') parts.push(`${Math.round(row.contextPercent)}%`)
+  // Labeled, not a bare number: "42% used" / "58% left" per the display setting — the label is
+  // what keeps a context percentage from reading as provider quota.
+  if (typeof row.contextPercent === 'number') parts.push(percentText(row.contextPercent, percentMode))
   tag.textContent = parts.join(' · ')
 
   const sub = document.createElement('div')
@@ -400,6 +406,7 @@ function applyGeometry(push: HudPush): void {
   }
   if (typeof push.notchCenterX === 'number') rs.setProperty('--notch-center-x', `${push.notchCenterX}px`)
   if (typeof push.hoverExpand === 'boolean') hoverExpand = push.hoverExpand
+  if (push.percentMode === 'used' || push.percentMode === 'remaining') percentMode = push.percentMode
   // No physical notch → draw a standalone floating pill instead of fusing to y=0.
   document.documentElement.classList.toggle('notchless', push.hasNotch === false)
 }

--- a/src/renderer/lib/usageFormat.test.ts
+++ b/src/renderer/lib/usageFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { barFillPercent, formatModelLabel, percentNumber, severityColor } from './usageFormat'
+import { barFillPercent, contextFillColor, formatModelLabel, percentNumber, severityColor } from './usageFormat'
 
 describe('formatModelLabel', () => {
   it('formats family + version ids', () => {
@@ -58,5 +58,23 @@ describe('barFillPercent', () => {
     const left = 100 - 92
     expect(severityColor(null, left)).toBe('#ff453a')
     expect(barFillPercent(92, 'used')).not.toBe(barFillPercent(92, 'remaining'))
+  })
+})
+
+// One definition for every context surface — ContextMeter, the session-row chip and the notch
+// HUD each carried their own copy of these thresholds before issue #78.
+describe('contextFillColor', () => {
+  it('is keyed to USED context: green low, yellow from 60, red past 85', () => {
+    expect(contextFillColor(0)).toBe('#30d158')
+    expect(contextFillColor(59)).toBe('#30d158')
+    expect(contextFillColor(60)).toBe('#ffd60a')
+    expect(contextFillColor(85)).toBe('#ffd60a')
+    expect(contextFillColor(86)).toBe('#ff453a')
+  })
+
+  it('is the inverse scale of the quota colors — the two must not be conflated', () => {
+    // 90% USED context is red; 90% REMAINING quota is green. Same number, opposite meaning.
+    expect(contextFillColor(90)).toBe('#ff453a')
+    expect(severityColor(null, 90)).toBe('#30d158')
   })
 })

--- a/src/renderer/lib/usageFormat.ts
+++ b/src/renderer/lib/usageFormat.ts
@@ -44,6 +44,19 @@ export function formatModelLabel(model: string | null): string | null {
   return version ? `${family} ${version}` : family
 }
 
+/**
+ * Fill color for a CONTEXT-WINDOW meter: green while low, yellow from 60% used, red past 85%.
+ * Keyed to USED percent — the inverse scale of `barColor`/`severityColor`, which are keyed to
+ * REMAINING provider quota. The two measure different things and must not share thresholds.
+ * One definition for every context surface (ContextMeter, session rows, the notch HUD) — each
+ * used to carry its own copy of these numbers (issue #78).
+ */
+export function contextFillColor(usedPercent: number): string {
+  if (usedPercent > 85) return '#ff453a'
+  if (usedPercent >= 60) return '#ffd60a'
+  return '#30d158'
+}
+
 /** Bar color by remaining quota: green > 40%, yellow 20–40%, red < 20%. */
 export function barColor(leftPercent: number): string {
   if (leftPercent > 40) return '#30d158'


### PR DESCRIPTION
Third bug on the #78 roadmap: the `usagePercentMode` setting ("42% used" vs "58% left") only ever reached the bottom-left usage pill, while ContextMeter, the session-row chip and the notch HUD printed bare unlabeled percentages — each with its own duplicated copy of the color thresholds. (The pill's fill-vs-number disagreement called out in the issue was already fixed upstream by `barFillPercent`.)

## What changed
- `contextFillColor()` in `usageFormat.ts` is now the single definition of the context-fill scale (green <60, yellow 60–85, red >85, keyed to **used**). It is deliberately separate from `barColor`/`severityColor`, which are keyed to **remaining provider quota** — the semantic distinction from the issue discussion is preserved, and a test pins it (90% used context = red; 90% remaining quota = green).
- **ContextMeter** and **SessionRow** route the number through `percentNumber()` and carry a `Context window — 42% used` tooltip, so the flipped number stays labeled and can't read as provider quota. ContextMeter's bars adopt `barFillPercent()` (fill agrees with the adjacent number, color stays keyed to fill level).
- **Notch HUD** row tags render `percentText()` ("42% used" / "58% left") instead of a bare number; `usagePercentMode` rides the existing tunables push, so a settings change applies live without restart.

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)