### PR TITLE
fix(notch): capsule grows left-only, never over the menu-bar status items

### DIFF
--- a/docs/notch-hud.md
+++ b/docs/notch-hud.md
@@ -93,12 +93,13 @@ the click-through hotspot (`pointerenter` → main `setIgnoreMouse(false)`, leav
 the transparent rest of the window stays click-through. Hidden entirely when idle (no empty pill).
 
 - **Collapsed capsule**: never taller than the real notch (owner: "notch'a ekstra height vermek
-  istemiyorum"). It is `--bar` tall (`max-height`), shrink-to-fit wide, anchored at the notch's
-  horizontal centre, and the mascots are vertically centred in that strip — the notch reads as
-  WIDER, not taller, so the Dynamic-Island bulge below the bar line was dropped (`--capsule-drop` is
-  now `0px` and only survives for the expand math). The content occupies the strip LEFT of the
-  notch, so `syncCapsuleSymmetry` pads the right by `notchWidth + measured content width` and the
-  black sticks out by the same amount on both sides. The collapsed content is decided by ONE pure
+  istemiyorum"). It is `--bar` tall (`max-height`), shrink-to-fit wide, its RIGHT edge pinned
+  to the notch's right edge, and the mascots are vertically centred in that strip — the notch reads
+  as WIDER, not taller, so the Dynamic-Island bulge below the bar line was dropped (`--capsule-drop`
+  is now `0px` and only survives for the expand math). The content occupies the strip LEFT of the
+  notch and `syncCapsuleOverhang` pads the right by exactly the notch width, so the capsule grows
+  LEFT-ONLY. (It used to grow symmetrically; on a crowded menu bar the right-hand overhang covered
+  the status items and — being the click-through hotspot — swallowed their clicks. Issue #78.) The collapsed content is decided by ONE pure
   rule, `buildIndicator` (`src/renderer/hud/indicator.ts`, unit-tested with `orderIndicatorAgents`):
   a slot per agent kind that is working: claude → 2-frame coral pixel mascot walking; codex → the pet
   spritesheet first-row crop (`image-rendering: pixelated`); grok/gemini/opencode → their own brand

--- a/src/renderer/hud/hud.css
+++ b/src/renderer/hud/hud.css
@@ -60,11 +60,13 @@ body {
 .hud-capsule {
   position: absolute;
   top: 0;
-  /* CENTRED on the notch and widened SIDEWAYS, never taller (owner: "notch'a ekstra height
-     vermek istemiyorum"). The mascots occupy only the strip LEFT of the notch; main.ts pads the
-     right by `notch + content` so the black sticks out by the SAME amount on both sides. */
-  left: var(--notch-center-x, 50%);
-  transform: translateX(-50%);
+  /* Widened SIDEWAYS, never taller (owner: "notch'a ekstra height vermek istemiyorum") — and
+     LEFT-ONLY: the right edge is pinned to the notch's right edge, so the capsule can never
+     creep over the menu-bar status items (or swallow their clicks) however many mascots are
+     running. main.ts pads the right by exactly the notch width; the mascots occupy the strip
+     LEFT of it (issue #78). */
+  left: calc(var(--notch-center-x, 50%) + var(--notch-width, 200px) / 2);
+  transform: translateX(-100%);
   /* Shrink-to-fit so however many mascots are running, none clip. */
   width: auto;
   height: auto;
@@ -80,7 +82,9 @@ body {
   will-change: width, max-height;
   transition:
     max-height var(--capsule-dur) var(--capsule-ease),
-    border-radius var(--capsule-dur) var(--capsule-ease);
+    border-radius var(--capsule-dur) var(--capsule-ease),
+    left var(--capsule-dur) var(--capsule-ease),
+    transform var(--capsule-dur) var(--capsule-ease);
 }
 .hud-capsule--hidden {
   display: none; /* idle: no empty black pill */

--- a/src/renderer/hud/main.ts
+++ b/src/renderer/hud/main.ts
@@ -108,7 +108,7 @@ function setExpanded(next: boolean): void {
   if (expanded === next) return
   expanded = next
   capsule.classList.toggle('expanded', expanded)
-  syncCapsuleSymmetry() // expanded: drop the padding so the panel gets the full width
+  syncCapsuleOverhang() // expanded: drop the padding so the panel gets the full width
   window.hud.setExpanded(expanded)
 }
 
@@ -367,24 +367,26 @@ function buildSubItem(s: HudSubagentRow): HTMLElement {
 
 // ---- Render + geometry ---------------------------------------------------------------------
 
-// The capsule is CENTRED on the notch and its content (the mascots) occupies only the strip LEFT of
-// it, so we pad the right by `notch + content` — that makes the black stick out by exactly the same
-// amount on both sides (owner: "soldan ne kadar genişlettiysen sağdan da o kadar"). The content width
-// is measured, not guessed, so it stays symmetric as slots come and go.
-function syncCapsuleSymmetry(): void {
+// The capsule grows LEFT-ONLY: its right edge stays flush with the notch's right edge, and the
+// content (the mascots) occupies only the strip LEFT of the notch — the right padding covers
+// exactly the notch itself, nothing more. This retires the earlier symmetric growth ("soldan ne
+// kadar genişlettiysen sağdan da o kadar"): on a crowded menu bar the symmetric right-hand
+// overhang sat ON TOP of the status items, and because the capsule is the click-through hotspot,
+// hovering there also swallowed their clicks (issue #78 — grow-left approved by the owner there).
+function syncCapsuleOverhang(): void {
   if (expanded) {
     capsule.style.paddingRight = ''
     return
   }
   const ext = indicator.offsetWidth
-  capsule.style.paddingRight = ext > 0 ? `${notchWidthPx + ext}px` : ''
+  capsule.style.paddingRight = ext > 0 ? `${notchWidthPx}px` : ''
 }
 
 function render(rows: HudRow[]): void {
   latestRows = rows
   renderIndicator(rows)
   renderPanel(rows)
-  syncCapsuleSymmetry()
+  syncCapsuleOverhang()
   // Idle → hide the whole capsule (no empty black pill); active → the fused capsule shows.
   capsule.classList.toggle('hud-capsule--hidden', rows.length === 0)
   // Auto-collapse if there is nothing to show.


### PR DESCRIPTION
Fourth bug on the #78 roadmap, re-diagnosed against current main as asked: the collapsed capsule padded itself symmetrically (`notchWidth + measured content width` on the right), so every running mascot also widened the black over the status-item side of the menu bar — and because the capsule is the click-through hotspot, hovering that overhang swallowed the status items' clicks too.

## What changed
- Collapsed, the capsule's **right edge is pinned to the notch's right edge** (`left: calc(center + notch/2)` + `translateX(-100%)`; right padding = exactly the notch width). All growth goes left, where only the app menus live — grow-left as approved in the issue thread, retiring the earlier symmetric-growth call (`syncCapsuleSymmetry` → `syncCapsuleOverhang`).
- The expanded panel still re-centres under the notch; the horizontal move now rides the same transition as the vertical grow, so expand/collapse doesn't jump.
- Notchless (floating pill) mode is unchanged; `docs/notch-hud.md` updated.

## Verify on a Mac
With 3+ agents working (wide capsule) on a crowded menu bar: the black no longer reaches past the notch's right edge, status items stay visible and clickable, hover-expand and click-expand still work, and the expanded panel is centered as before.

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)