### PR TITLE
feat(canvas): user-facing "Spawn a team…" entry — a conductor node, no new model plumbing

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -161,6 +161,8 @@ import { promptDialog } from '../components/promptDialog'
 import { UpgradeDialog } from '../components/UpgradeDialog'
 import { RemotePicker } from '../components/RemotePicker'
 import { WorktreeDialog } from '../components/WorktreeDialog'
+import { SpawnTeamDialog } from '../components/SpawnTeamDialog'
+import { conductorPrompt } from '../lib/spawnTeamPrompt'
 import { NotifyConsentDialog } from '../components/NotifyConsentDialog'
 import { SessionsSidebar } from '../components/SessionsSidebar'
 import type { SessionNodeInput } from '../lib/sessionList'
@@ -3570,7 +3572,13 @@ export function Canvas() {
   useEffect(() => useSystemAccount.getState().ensure(), [])
 
   const addAgentNode = useCallback(
-    (agentId: AgentId, center?: { x: number; y: number }, groupId?: string, accountId?: string) => {
+    (
+      agentId: AgentId,
+      center?: { x: number; y: number },
+      groupId?: string,
+      accountId?: string,
+      initialPrompt?: string
+    ) => {
       const project = useProjects.getState().getProject(activeProjectId)
       const cwd = cwdForNewNodeIn(groupId) ?? project?.cwd
       // Funnel through resolveNewNodeAccount so the project default applies even without an
@@ -3586,7 +3594,7 @@ export function Canvas() {
           ns.length,
           cwd,
           center ?? emptyNodePos(),
-          undefined,
+          initialPrompt,
           project?.ssh,
           account,
           activePermissionMode(agentId)
@@ -3596,6 +3604,27 @@ export function Canvas() {
       markDirty()
     },
     [setNodes, markDirty, activeProjectId, emptyNodePos, cwdForNewNodeIn, parentInto]
+  )
+
+  // "Spawn a team…" (issue #78): the dialog collects the task; this opens ONE conductor node
+  // pre-prompted with it. The conductor's own manage-nodeterm-canvas skill does the role split
+  // and the fan-out — the app ships no model, so the entry point deliberately adds no plumbing.
+  const [spawnTeamDialog, setSpawnTeamDialog] = useState<{ at?: { x: number; y: number } } | null>(
+    null
+  )
+  const spawnTeam = useCallback(
+    (v: { task: string; worktrees: boolean }) => {
+      const at = spawnTeamDialog?.at
+      setSpawnTeamDialog(null)
+      addAgentNode(
+        useSettings.getState().settings.defaultAgent ?? 'claude',
+        at,
+        undefined,
+        undefined,
+        conductorPrompt({ task: v.task, worktrees: v.worktrees })
+      )
+    },
+    [addAgentNode, spawnTeamDialog]
   )
 
   // Open a terminal node that ssh's into a saved server. `screenPos` (a pane/dock cursor) is
@@ -5765,6 +5794,7 @@ export function Canvas() {
       dino: (at) => addDino(at),
       openFile: (at) => void openFileDialog(at),
       newFile: (at) => void newProjectFile(at),
+      spawnTeam: (at) => setSpawnTeamDialog({ at }),
       worktree: (at) => openWorktreeDialog(null, at)
     }),
     [
@@ -8855,6 +8885,14 @@ export function Canvas() {
         note: isSshProject ? WORKTREE_SSH_HINT : undefined,
         run: () => openWorktreeDialog(null)
       },
+      {
+        id: 'spawn-team',
+        label: 'Spawn a team…',
+        // Searchable synonyms — this is the entry people will look for by intent, not by name.
+        hint: 'orchestrate parallelize delegate agents conductor',
+        icon: <IconGroup />,
+        run: () => setSpawnTeamDialog({})
+      },
       { id: 'new-project', label: 'New project', icon: <IconProject />, run: () => addProject() },
       { id: 'clone-repo', label: 'Clone repository…', icon: <IconProject />, run: () => setCloneDialogOpen(true) },
       {
@@ -9689,6 +9727,15 @@ export function Canvas() {
         />
       )}
 
+      {spawnTeamDialog && (
+        <SpawnTeamDialog
+          worktreesAvailable={!isSshProject && !!worktreeRepoRoot}
+          worktreeNote={isSshProject ? WORKTREE_SSH_HINT : 'not a git repository'}
+          onSubmit={spawnTeam}
+          onCancel={() => setSpawnTeamDialog(null)}
+        />
+      )}
+
       {moveTarget && (
         <ConfirmDialog
           message="Move this terminal into the worktree? Its session restarts and any running process ends."
@@ -9791,6 +9838,7 @@ export function Canvas() {
         onRedo={redo}
         onAddTerminal={addTerminal}
         onAddSticky={addSticky}
+        onSpawnTeam={() => setSpawnTeamDialog({})}
         onAddDino={addDino}
         onAddAgent={(aid, accountId) => addAgentNode(aid, undefined, undefined, accountId)}
         onOpenFile={() => void openFileDialog()}

--- a/src/renderer/components/Dock.tsx
+++ b/src/renderer/components/Dock.tsx
@@ -19,6 +19,8 @@ interface DockProps {
   canRedo: boolean
   onAddTerminal: () => void
   onAddSticky: () => void
+  /** Opens the Spawn-a-team dialog (issue #78) — the conductor lands at the Dock's default spot. */
+  onSpawnTeam: () => void
   onAddDino: () => void
   onAddAgent: (agentId: AgentId, accountId?: string) => void
   onOpenFile: () => void
@@ -51,6 +53,7 @@ export function Dock({
   canRedo,
   onAddTerminal,
   onAddSticky,
+  onSpawnTeam,
   onAddDino,
   onAddAgent,
   onOpenFile,
@@ -126,6 +129,7 @@ export function Dock({
     browser: onAddBrowser,
     web: onAddWeb,
     sticky: onAddSticky,
+    spawnTeam: onSpawnTeam,
     dino: onAddDino,
     openFile: onOpenFile,
     newFile: onNewFile,

--- a/src/renderer/components/SpawnTeamDialog.tsx
+++ b/src/renderer/components/SpawnTeamDialog.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useDialogStack } from './dialog-stack'
+
+interface SpawnTeamDialogProps {
+  /** False on SSH projects / non-repos — the toggle renders disabled with `worktreeNote` beside it. */
+  worktreesAvailable: boolean
+  /** Why worktrees are unavailable (e.g. the SSH notice). Shown only when they are. */
+  worktreeNote?: string
+  onSubmit: (v: { task: string; worktrees: boolean }) => void
+  onCancel: () => void
+}
+
+/**
+ * "Spawn a team…" (issue #78): the user types a task, and ONE conductor agent node is opened
+ * pre-prompted with it — the conductor's own manage-nodeterm-canvas skill does the role split
+ * and the fan-out, so no model plumbing lives in the app. Reuses the `.confirm*` shell like
+ * InputDialog; the input is a textarea (Enter inserts a newline — tasks are prose), so submit
+ * is ⌘/Ctrl+Enter or the button.
+ */
+export function SpawnTeamDialog({
+  worktreesAvailable,
+  worktreeNote,
+  onSubmit,
+  onCancel
+}: SpawnTeamDialogProps) {
+  const [task, setTask] = useState('')
+  const [worktrees, setWorktrees] = useState(false)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  // In the modal stack so a ConfirmDialog underneath does not also answer Escape (its listener
+  // is on `window`); Enter never leaves the textarea, so nothing else is needed.
+  useDialogStack()
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const canSubmit = task.trim().length > 0
+  const submit = (): void => {
+    if (canSubmit) onSubmit({ task, worktrees: worktreesAvailable && worktrees })
+  }
+
+  return createPortal(
+    <div className="confirm-overlay" onClick={onCancel}>
+      <div className="confirm" onClick={(e) => e.stopPropagation()}>
+        <p className="confirm__msg">
+          Spawn a team — describe the task, and a conductor agent will split it into workstreams
+          and open the team on the canvas.
+        </p>
+        <textarea
+          ref={inputRef}
+          className="confirm__input confirm__textarea"
+          value={task}
+          placeholder="What should the team build?"
+          rows={4}
+          spellCheck={false}
+          onChange={(e) => setTask(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault()
+              submit()
+            } else if (e.key === 'Escape') {
+              e.preventDefault()
+              onCancel()
+            }
+          }}
+        />
+        <label className="confirm__option">
+          <input
+            type="checkbox"
+            checked={worktreesAvailable && worktrees}
+            disabled={!worktreesAvailable}
+            onChange={(e) => setWorktrees(e.target.checked)}
+          />
+          Give each workstream its own git worktree
+          {!worktreesAvailable && worktreeNote ? ` — ${worktreeNote}` : ''}
+        </label>
+        <div className="confirm__actions">
+          <button className="confirm__btn" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="confirm__btn primary" disabled={!canSubmit} onClick={submit}>
+            Spawn team
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/lib/addMenuSpec.test.tsx
+++ b/src/renderer/lib/addMenuSpec.test.tsx
@@ -17,6 +17,7 @@ const handlers = (overrides: Partial<AddHandlers> = {}): AddHandlers => ({
   dino: noop,
   openFile: noop,
   newFile: noop,
+  spawnTeam: noop,
   worktree: noop,
   ...overrides
 })
@@ -30,6 +31,7 @@ const allKinds: AddItem['kind'][] = [
   'dino',
   'open-file',
   'new-file',
+  'spawn-team',
   'worktree'
 ]
 
@@ -56,6 +58,7 @@ describe('contentAddItemsToMenuItems', () => {
       'New dino game',
       'Open file…',
       'New file…',
+      'Spawn a team…',
       'New worktree…'
     ])
   })
@@ -87,6 +90,7 @@ describe('contentAddItemsToMenuItems', () => {
       web: () => calls.push('web'),
       sticky: () => calls.push('sticky'),
       dino: () => calls.push('dino'),
+      spawnTeam: () => calls.push('spawnTeam'),
       worktree: () => calls.push('worktree')
     })
     const items = contentAddItemsToMenuItems(CONTENT_ADD_ITEMS, h, {
@@ -96,7 +100,7 @@ describe('contentAddItemsToMenuItems', () => {
     for (const item of items) {
       if ('onClick' in item) item.onClick()
     }
-    expect(calls.sort()).toEqual(['browser', 'dino', 'sticky', 'terminal', 'web', 'worktree'])
+    expect(calls.sort()).toEqual(['browser', 'dino', 'spawnTeam', 'sticky', 'terminal', 'web', 'worktree'])
   })
 })
 
@@ -115,6 +119,7 @@ describe('contentAddItemsToDockRows', () => {
       'dino',
       'open-file',
       'new-file',
+      'spawn-team',
       'worktree'
     ])
     expect(rows.some((r) => r.kind === 'terminal')).toBe(false)

--- a/src/renderer/lib/addMenuSpec.tsx
+++ b/src/renderer/lib/addMenuSpec.tsx
@@ -24,6 +24,7 @@ import {
   IconBranch,
   IconDino,
   IconEditor,
+  IconGroup,
   IconNote,
   IconRemote,
   IconTerminal,
@@ -47,6 +48,7 @@ export type AddItem =
   | { kind: 'dino' }
   | { kind: 'open-file' }
   | { kind: 'new-file' } // requiresCwd
+  | { kind: 'spawn-team' }
   | { kind: 'worktree' } // disabledOnSsh
 
 /**
@@ -65,6 +67,7 @@ export const CONTENT_ADD_ITEMS: readonly AddItem[] = [
   { kind: 'dino' },
   { kind: 'open-file' },
   { kind: 'new-file' },
+  { kind: 'spawn-team' },
   { kind: 'worktree' }
 ] as const
 
@@ -93,6 +96,8 @@ export interface AddHandlers {
   dino: (at?: AddPos) => void
   openFile: (at?: AddPos) => void
   newFile: (at?: AddPos) => void
+  /** Opens the Spawn-a-team dialog (issue #78); `at` is where the conductor node will land. */
+  spawnTeam: (at?: AddPos) => void
   worktree: (at?: AddPos) => void
 }
 
@@ -147,6 +152,9 @@ export function contentAddItemsToMenuItems(
         if (ctx.hasCwd) {
           out.push({ label: 'New file…', icon: <IconEditor />, onClick: () => void handlers.newFile(at) })
         }
+        break
+      case 'spawn-team':
+        out.push({ label: 'Spawn a team…', icon: <IconGroup />, onClick: () => handlers.spawnTeam(at) })
         break
       case 'worktree':
         out.push({
@@ -218,6 +226,9 @@ export function contentAddItemsToDockRows(
         if (ctx.hasCwd) {
           out.push({ kind: 'new-file', label: 'New file…', icon: <IconEditor />, onClick: () => void handlers.newFile() })
         }
+        break
+      case 'spawn-team':
+        out.push({ kind: 'spawn-team', label: 'Spawn a team…', icon: <IconGroup />, onClick: () => handlers.spawnTeam() })
         break
       case 'worktree':
         out.push({

--- a/src/renderer/lib/spawnTeamPrompt.test.ts
+++ b/src/renderer/lib/spawnTeamPrompt.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { conductorPrompt, MAX_TEAM_ROLES } from './spawnTeamPrompt'
+
+describe('conductorPrompt', () => {
+  it('leads with the skill trigger phrase — the orchestration doctrine hangs off it', () => {
+    const p = conductorPrompt({ task: 'build a REST API', worktrees: true })
+    expect(p.startsWith('Build with Nodeterm orchestration: ')).toBe(true)
+    expect(p).toContain('build a REST API')
+  })
+
+  it('carries the worktree decision, which is the dialog checkbox, not the conductor', () => {
+    expect(conductorPrompt({ task: 't', worktrees: true })).toContain('open-worktree')
+    const off = conductorPrompt({ task: 't', worktrees: false })
+    expect(off).toContain('Do not create git worktrees')
+    expect(off).not.toContain('open-worktree ')
+  })
+
+  it('flattens whitespace — the launch argv collapses it anyway, so mangling must not depend on input shape', () => {
+    const p = conductorPrompt({ task: '  line one\n\n  line two\t end  ', worktrees: false })
+    expect(p).toContain('line one line two end')
+    expect(p).not.toMatch(/\n|\t| {2}/)
+  })
+
+  it('team cap matches the spawn-team handler cap', () => {
+    expect(MAX_TEAM_ROLES).toBe(8)
+  })
+})

--- a/src/renderer/lib/spawnTeamPrompt.ts
+++ b/src/renderer/lib/spawnTeamPrompt.ts
@@ -1,0 +1,29 @@
+// The conductor prompt behind the user-facing "Spawn a team…" entry (issue #78). The app ships
+// no built-in model, so the role split is BYO by design: the entry point opens ONE agent node
+// pre-prompted with the task, and that conductor uses its own manage-nodeterm-canvas skill to
+// plan and spawn the team. Kept out of React (verifyPanel.ts precedent) so the wording is
+// unit-testable.
+
+/** Hard cap on team size — must match the spawn-team handler's `.slice(0, 8)` in Canvas.tsx. */
+export const MAX_TEAM_ROLES = 8
+
+/**
+ * The prompt the conductor node launches with.
+ *
+ * "Build with Nodeterm orchestration" is load-bearing: it is the trigger phrase the
+ * manage-nodeterm-canvas skill documents (canvas-control-core.ts, "Nodeterm orchestration"
+ * section), and the whole station/worktree/collect-and-synthesize doctrine hangs off it —
+ * re-stating that doctrine here would just be a second copy to drift. The only thing this
+ * prompt adds is the worktree decision, which is the user's (the dialog checkbox), not the
+ * conductor's.
+ *
+ * Written as prose on one line: createAgentNode collapses all whitespace to single spaces when
+ * it bakes the prompt into the launch argv, so bullets or newlines would arrive mangled.
+ */
+export function conductorPrompt(opts: { task: string; worktrees: boolean }): string {
+  const task = opts.task.replace(/\s+/g, ' ').trim()
+  const worktreeSentence = opts.worktrees
+    ? 'Give each independent workstream its own worktree station (open-worktree per stream).'
+    : 'Do not create git worktrees for this run — open the team in the shared working tree instead (spawn-team, or open-agent per stream).'
+  return `Build with Nodeterm orchestration: ${task} ${worktreeSentence}`
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -4793,6 +4793,15 @@ body,
   padding: 8px 10px;
 }
 
+.confirm__textarea {
+  /* Task prose, not a one-liner: fixed comfortable height, user-growable. `font-family` because
+     a bare textarea falls back to the UA monospace default, unlike input. */
+  font-family: inherit;
+  line-height: 1.45;
+  min-height: 76px;
+  resize: vertical;
+}
+
 .confirm__input:focus {
   outline: none;
   border-color: var(--accent);


### PR DESCRIPTION
First feature from the #78 roadmap, in the shape agreed there: the app ships no built-in model, so the role split is BYO — the entry point opens ONE conductor agent node pre-prompted with the task, and the conductor's own `manage-nodeterm-canvas` skill does the fan-out. No new control verbs, no renderer→hook-server calls, nothing typed into a live pane (the sessionRename splice hazard never arises: the prompt rides the launch argv).

## What's here
- **Entry points**: the shared add-menu spec (`addMenuSpec`) gains a `spawn-team` item, so the pane right-click, the sidebar `+` and the Dock pick it up in lockstep; plus a palette entry with searchable intent synonyms ("orchestrate parallelize delegate").
- **Dialog** (`SpawnTeamDialog`, `.confirm` shell): task textarea (⌘Enter submits — Enter stays a newline, tasks are prose) + a "worktree per workstream" toggle that renders disabled with the shared SSH hint when worktrees can't apply.
- **Conductor prompt** (`lib/spawnTeamPrompt.ts`, pure + tested): leads with the skill's load-bearing trigger phrase ("Build with Nodeterm orchestration") so the existing station/collect/synthesize doctrine drives everything; the only thing the prompt adds is the user's worktree decision. Written as one-line prose because `createAgentNode` collapses whitespace into the argv.
- `addAgentNode` gains an optional `initialPrompt` param (was hardcoded `undefined`); the conductor uses the default agent from Settings and lands at the clicked position when opened from the pane menu.

## Try it
⌘K → "Spawn a team…", type a task, submit → a conductor node opens and starts planning/spawning on the canvas.

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)