### PR TITLE
feat(ui): polish pass — enter animations for every shared shell + quiet scrollbars

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -10619,3 +10619,108 @@ body,
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ================================ Polish pass (issue #78) ==================================
+   Enter animations for the shared overlay shells + quiet scrollbars. Rules of the pass:
+   transform/opacity ONLY (nothing that forces layout — terminals must keep streaming at 60fps),
+   one-shot on mount (no exit mechanism: every shell hard-unmounts via `{open && portal}`, and
+   keeping portals alive for an exit tween would thread a closing state through 15 dialogs — the
+   kanban modal set this precedent and it reads fine), and the existing token palette only. */
+
+@keyframes nt-overlay-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes nt-surface-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes nt-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes nt-drawer-in {
+  from {
+    opacity: 0;
+    transform: translateX(10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Scrims fade fast — they must never make the surface feel late. */
+.confirm-overlay,
+.sc-overlay,
+.palette-overlay,
+.drawer-overlay {
+  animation: nt-overlay-fade 0.12s ease-out;
+}
+/* Dialog-family surfaces pop with the kanban modal's spring curve. */
+.confirm,
+.shortcuts,
+.palette {
+  animation: nt-surface-pop 0.16s cubic-bezier(0.22, 1, 0.36, 1);
+}
+/* Menus are twitch surfaces — barely-there settle, never a bounce. */
+.ctx-menu,
+.tab-menu {
+  animation: nt-menu-in 0.12s ease-out;
+}
+/* Drawers slide in from their anchored edge (they open right-aligned). */
+.drawer {
+  animation: nt-drawer-in 0.16s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.tooltip {
+  animation: nt-overlay-fade 0.12s ease-out;
+}
+
+/* Same contract as the mascot pulse above: motion is decoration; everything must read without it. */
+@media (prefers-reduced-motion: reduce) {
+  .confirm-overlay,
+  .sc-overlay,
+  .palette-overlay,
+  .drawer-overlay,
+  .confirm,
+  .shortcuts,
+  .palette,
+  .ctx-menu,
+  .tab-menu,
+  .drawer,
+  .tooltip {
+    animation: none;
+  }
+}
+
+/* --- Quiet scrollbars everywhere -----------------------------------------------------------
+   The standard properties, not ::-webkit-scrollbar: `scrollbar-color` INHERITS (set once on
+   :root), `scrollbar-width` does not (hence the `*`), and on macOS they keep the native
+   overlay behavior — thumbs appear on scroll instead of reserving a chunky gutter, which is
+   what made the default bars read as foreign controls in every panel. Setting a standard
+   property also makes Chromium ignore an element's ::-webkit-scrollbar rules, so the three
+   deliberately-HIDDEN scrollbars (tab strip, xterm viewports) keep working through the
+   `scrollbar-width: none` they already declare, and the banner/menu custom thumbs converge on
+   this same thin themed look instead of their hand-rolled webkit variants. */
+:root {
+  scrollbar-color: rgba(var(--tint-rgb), 0.22) transparent;
+}
+* {
+  scrollbar-width: thin;
+}


### PR DESCRIPTION
The #78 polish item, in the reshaped scope agreed there: **no component-library adoption** — the hand-written macOS-native token CSS stays the identity. Two purely-CSS changes, zero TSX churn, all themed off the existing tokens:

- **Enter animations** (transform/opacity only, one-shot on mount): scrims fade 120ms; dialogs (`.confirm`/`.palette`/`.shortcuts`) pop with the kanban modal's spring curve; context/tab menus settle in 120ms; drawers slide from their anchored edge; tooltips fade. One rule per shared shell class covers every dialog and menu in the app, and `prefers-reduced-motion` turns all of it off (the mascot-pulse contract: motion is decoration). No exit animations on purpose — every shell hard-unmounts via `{open && portal}`, and threading a closing state through 15 dialogs isn't worth a 100ms tween; the kanban modal set this precedent.
- **Quiet scrollbars** via the STANDARD properties (`scrollbar-color` on `:root` — it inherits; `scrollbar-width: thin` on `*` — it doesn't), not `::-webkit-scrollbar`: macOS keeps its overlay behavior (no reserved gutter), the tint token themes both light and dark, the deliberately-hidden bars (tab strip, xterm viewports) keep working through the `scrollbar-width: none` they already declare, and the banner/menu hand-rolled webkit thumbs converge on the same thin themed look.

Theme guard (`styles.theme.test.ts`) green. Terminals keep streaming: nothing here animates layout, and everything is mount-time one-shot.

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)