### PR TITLE
fix(inbox): retain newest per-node done + unresolved ask past the 50-event cap (P2-7)

### DIFF
--- a/src/core/agent-status-mirror.test.ts
+++ b/src/core/agent-status-mirror.test.ts
@@ -30,6 +30,7 @@ import {
   onNodeNowChange,
   onInboxActionable,
   isEventUnresolved,
+  trimInboxFeed,
   workingNodes,
   _resetForTest,
   _snapshot,
@@ -44,6 +45,7 @@ import {
   type MirrorUsage,
   type NodeStateChange,
   type NodeNowChange,
+  type InboxEvent,
   sweepStaleWorking
 } from './agent-status-mirror'
 
@@ -632,6 +634,105 @@ describe('inbox event production (via recordAgentEvent)', () => {
     expect(ib.nodes.x).toBeUndefined()
     expect(ib.events).toHaveLength(1)
     expect(ib.events[0].resolved).toBe(true)
+  })
+})
+
+// P2-7: on a busy multi-agent host the global 50-event cap evicted a node's `done` (and its live
+// ask) within minutes, so `ackDone` no-op'd (a retained DONE card on the phone never dismissed) and
+// the phone lost that node's newest-done / end-reason. The feed now keeps each node's newest done +
+// newest UNRESOLVED ask past the cut, in the same `events` array every reader already walks.
+describe('per-node retention past the cap (P2-7)', () => {
+  beforeEach(() => _resetForTest())
+  afterEach(() => _resetForTest())
+
+  /** Push one `done` inbox event for `nodeId` (a working-start pushes no feed event). */
+  function pushDone(nodeId: string, detail: string): void {
+    recordAgentEvent(ev({ nodeId, state: 'working', newTurn: true }))
+    recordAgentEvent(ev({ nodeId, state: 'done', lastMessage: detail }))
+  }
+
+  it("keeps a node's newest done when >CAP newer events from other nodes would evict it", () => {
+    pushDone('slow', 'Slow node finished') // the load-bearing done, pushed first (oldest)
+    // A busy sibling floods the feed well past the cap.
+    for (let i = 0; i < INBOX_EVENTS_CAP + 10; i++) pushDone('busy', `busy turn ${i}`)
+
+    const events = _inboxSnapshot().events
+    const slow = events.filter((e) => e.nodeId === 'slow')
+    // The slow node's single done SURVIVES despite being far outside the newest-CAP window.
+    expect(slow).toHaveLength(1)
+    expect(slow[0].kind).toBe('done')
+    expect(slow[0].detail).toBe('Slow node finished')
+
+    // ...and ackDone now finds + resolves it and fires exactly one ack 'end' seam (the bug: a no-op).
+    const changes: NodeStateChange[] = []
+    const off = onNodeStateChange((c) => changes.push(c))
+    ackDone('slow')
+    off()
+    expect(_inboxSnapshot().events.find((e) => e.nodeId === 'slow')!.resolved).toBe(true)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]).toMatchObject({ nodeId: 'slow', event: 'end', state: 'done', ack: true })
+  })
+
+  it("keeps a node's newest UNRESOLVED ask past the cap (isEventUnresolved stays true)", () => {
+    recordAgentEvent(ev({ nodeId: 'ask', state: 'blocked', lastMessage: 'Approve deploy?' }))
+    const askId = _inboxSnapshot().events.find((e) => e.nodeId === 'ask')!.id
+    for (let i = 0; i < INBOX_EVENTS_CAP + 10; i++) pushDone('busy', `busy turn ${i}`)
+
+    const ask = _inboxSnapshot().events.filter((e) => e.nodeId === 'ask')
+    expect(ask).toHaveLength(1)
+    expect(ask[0].kind).toBe('approval')
+    expect(ask[0].resolved).toBeUndefined()
+    // The push-notify present→away hold reads this — it must still see the held event as live.
+    expect(isEventUnresolved('ask', askId)).toBe(true)
+  })
+
+  it('does NOT retain a RESOLVED ask past the cap — it drops with plain history', () => {
+    recordAgentEvent(ev({ nodeId: 'ask', state: 'blocked', lastMessage: 'Approve deploy?' }))
+    recordAgentEvent(ev({ nodeId: 'ask', state: 'working', newTurn: true })) // leaves blocked → resolved
+    expect(_inboxSnapshot().events.find((e) => e.nodeId === 'ask')!.resolved).toBe(true)
+    for (let i = 0; i < INBOX_EVENTS_CAP + 10; i++) pushDone('busy', `busy turn ${i}`)
+
+    // The resolved ask is no longer protected, so the cap evicts it like any other history.
+    expect(_inboxSnapshot().events.some((e) => e.nodeId === 'ask')).toBe(false)
+  })
+
+  it('still bounds plain history to the cap (only the load-bearing extras survive)', () => {
+    pushDone('slow', 'Slow node finished') // one protected out-of-window survivor
+    for (let i = 0; i < INBOX_EVENTS_CAP + 10; i++) pushDone('busy', `busy turn ${i}`)
+
+    const events = _inboxSnapshot().events
+    const busy = events.filter((e) => e.nodeId === 'busy')
+    // The busy node's own history is still capped — the oldest turns fell off the front.
+    expect(busy).toHaveLength(INBOX_EVENTS_CAP)
+    expect(busy.some((e) => e.detail === 'busy turn 0')).toBe(false)
+    expect(busy[busy.length - 1].detail).toBe(`busy turn ${INBOX_EVENTS_CAP + 9}`)
+    // Total = the CAP window + the single protected survivor, not unbounded growth.
+    expect(events).toHaveLength(INBOX_EVENTS_CAP + 1)
+  })
+
+  it('trimInboxFeed (pure): drops resolved asks & old history, keeps newest done + unresolved ask', () => {
+    const mk = (id: string, nodeId: string, kind: InboxEvent['kind'], resolved?: boolean): InboxEvent => ({
+      id,
+      ts: Number(id.split('-')[0]),
+      nodeId,
+      kind,
+      title: id,
+      ...(resolved ? { resolved: true } : {})
+    })
+    // oldest→newest; cap 3 keeps the last 3 wholesale, older survive only if protected.
+    const feed = [
+      mk('1-1', 'A', 'approval', true), // resolved ask, out of window → DROP
+      mk('2-1', 'B', 'question'), // unresolved ask, out of window → KEEP
+      mk('3-1', 'C', 'done'), // newest done for C, out of window → KEEP
+      mk('4-1', 'D', 'done'),
+      mk('5-1', 'D', 'done'),
+      mk('6-1', 'D', 'done')
+    ]
+    const kept = trimInboxFeed(feed, 3)
+    expect(kept.map((e) => e.id)).toEqual(['2-1', '3-1', '4-1', '5-1', '6-1'])
+    // A no-op below the cap returns the same reference (order untouched).
+    const small = [mk('1-1', 'A', 'done')]
+    expect(trimInboxFeed(small, 3)).toBe(small)
   })
 })
 

--- a/src/core/agent-status-mirror.ts
+++ b/src/core/agent-status-mirror.ts
@@ -595,6 +595,38 @@ function newestUnresolved(events: ReadonlyArray<InboxEvent>, nodeId: string): In
   return undefined
 }
 
+/**
+ * Trim the feed to the rolling history `cap`, but PRESERVE the load-bearing per-node events that
+ * `ackDone` / `isEventUnresolved` / the phone's newest-done depend on — the newest `done` per node
+ * and the newest UNRESOLVED approval/question per node — even when they fall OUTSIDE the newest-`cap`
+ * window (audit P2-7). Without this, on a busy multi-agent host a node's `done` (or live ask) ages
+ * off the front within minutes: `ackDone` then no-ops (a retained DONE card on the phone never
+ * dismisses) and the phone loses that node's end-reason / newest-done. A RESOLVED ask is not
+ * protected — it drops with plain history as before — so the retained-past-cap set is bounded by
+ * ~2 per node. Order (oldest→newest) is preserved, and the wire shape is unchanged: the extra
+ * survivors ride the same `events` array every reader already walks. Pure — `events` untouched.
+ */
+export function trimInboxFeed(events: InboxEvent[], cap: number): InboxEvent[] {
+  if (events.length <= cap) return events
+  // The newest write per node wins each map (feed is oldest→newest, so a later match overwrites).
+  const newestDoneId = new Map<string, string>()
+  const newestUnresolvedAskId = new Map<string, string>()
+  for (const e of events) {
+    if (e.kind === 'done') newestDoneId.set(e.nodeId, e.id)
+    else if (!e.resolved && (e.kind === 'approval' || e.kind === 'question')) {
+      newestUnresolvedAskId.set(e.nodeId, e.id)
+    }
+  }
+  const protectedIds = new Set<string>([...newestDoneId.values(), ...newestUnresolvedAskId.values()])
+  // Keep the newest-`cap` window wholesale (history); older events survive only if protected.
+  const windowStart = events.length - cap
+  const kept: InboxEvent[] = []
+  for (let i = 0; i < events.length; i++) {
+    if (i >= windowStart || protectedIds.has(events[i].id)) kept.push(events[i])
+  }
+  return kept
+}
+
 // ---- Stateful singleton (production side) --------------------------------------------------
 
 const state = new Map<string, MirrorEntry>()
@@ -937,10 +969,10 @@ function pushInboxEvent(e: Omit<InboxEvent, 'id'>): void {
   const id = `${e.ts}-${++inboxSeq}`
   const full: InboxEvent = { id, ...e }
   inboxEvents.push(full)
-  // Cap the feed from the front (oldest fall off).
-  if (inboxEvents.length > INBOX_EVENTS_CAP) {
-    inboxEvents = inboxEvents.slice(inboxEvents.length - INBOX_EVENTS_CAP)
-  }
+  // Cap the feed from the front (oldest fall off), but keep each node's newest done + newest
+  // unresolved ask past the cut so `ackDone` / `isEventUnresolved` / the phone's newest-done
+  // don't lose the load-bearing event on a busy multi-agent host (audit P2-7).
+  inboxEvents = trimInboxFeed(inboxEvents, INBOX_EVENTS_CAP)
   // Notify actionable-event subscribers (only reached AFTER the dedup early-returns above it).
   for (const cb of inboxActionableListeners) {
     try {
@@ -1105,8 +1137,9 @@ function loadPersisted(file: string): void {
       let events = doc.inbox.events.filter(
         (e): e is InboxEvent => !!e && typeof e === 'object' && typeof e.id === 'string'
       )
-      if (events.length > INBOX_EVENTS_CAP) events = events.slice(events.length - INBOX_EVENTS_CAP)
-      inboxEvents = events
+      // Same per-node retention as the live cap (audit P2-7): a restored feed keeps each node's
+      // newest done + newest unresolved ask past the cut, so a restart doesn't strand a DONE card.
+      inboxEvents = trimInboxFeed(events, INBOX_EVENTS_CAP)
       let maxSeq = 0
       for (const e of inboxEvents) {
         const m = /-(\d+)$/.exec(e.id)


### PR DESCRIPTION
## Problem (audit P2-7)

The agent-status mirror's inbox feed is bounded only by a single **global** cap of 50 events (`INBOX_EVENTS_CAP`, `src/core/agent-status-mirror.ts`). On a busy multi-agent host a node's `done` (and its unresolved `ask`/needs-you) ages off the front within minutes, so:

- **`ackDone` no-ops** — it scans the feed for the node's unresolved `done` and finds nothing, so a retained DONE card on the phone never dismisses;
- **`isEventUnresolved` returns false** for the evicted event, so a held present→away push is dropped rather than sent;
- the phone loses that node's newest-`done` / end-reason.

iOS already mitigated the *symptom* (`retainedDoneIsOrphaned` dismisses a card whose evidence was evicted). This PR stops the desktop from evicting the load-bearing events in the first place.

## Fix

A pure `trimInboxFeed(events, cap)` replaces the naive `slice` at both trim sites — the live `pushInboxEvent` and the `loadPersisted` restore. It keeps the newest-`cap` window wholesale for history, and **additionally preserves, per node, the newest `done` and the newest _unresolved_ approval/question** even when they fall outside the window.

- A **resolved** ask is not protected — it drops as before — so the retained-past-cap set is bounded by ~2 per node.
- The existing 6 h flush age-prune still clears these eventually, so nothing lives forever.

### Wire-compatible

The survivors ride the **same `inbox.events` array** every reader already walks — no new field, no shape change. Older phones and the current iOS decoder (which reads `newestDone` off `inbox.events`) both just see a slightly longer feed. No field was added, so a missing field cannot break older phones.

## Tests

- a node's newest `done` survives when >CAP newer sibling events exist — and `ackDone` then resolves it + fires exactly one ack `end` seam;
- a node's newest **unresolved** ask survives (`isEventUnresolved` stays true);
- a **resolved** ask still drops with plain history;
- plain history stays capped (total = CAP + protected survivors, not unbounded growth);
- a pure `trimInboxFeed` unit test (drops resolved asks & old history, keeps newest done + unresolved ask, order preserved, no-op below cap).

**158** mirror tests + **95** push-notify tests green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)