### PR TITLE
feat(license): show the key, count the devices, and make Remove revoke Pro

### DIFF
--- a/src/core/license.test.ts
+++ b/src/core/license.test.ts
@@ -486,6 +486,9 @@ describe('license detail + release', () => {
     // server makes zero keygen calls for it and answers 200 with no key and no machines — those
     // zeros mean "device counting does not apply here", NOT "the read failed". `source` is the
     // only thing that tells the two apart, and the UI hides the release action on it.
+    //
+    // This is also the fixture that stops the malformed-2xx guard below from OVER-firing: these
+    // zeros are stated numbers, so they must still read as a success.
     storeToken()
     await boot(vi.fn(async () => jsonResponse({ key: null, used: 0, seats: 0, source: 'apple' })))
 
@@ -586,15 +589,33 @@ describe('license detail + release', () => {
     expect(d.seats).toBe(3)
   })
 
-  it('accepts only real numbers as counts, so nothing renders as NaN or as a string', async () => {
-    // The contract says numbers. A body that says otherwise is malformed, and `json.used ?? 0`
-    // would forward whatever it holds — "3" into a meter, or NaN out of arithmetic on it.
+  it('a 2xx whose counts are not numbers is a FAILED READ, not a license with no devices', async () => {
+    // The scenario: a captive portal or corporate proxy answers the POST with a 200 HTML page, or
+    // a bad deploy answers `200 {}` / `200 {"used":"3"}`. Coercing those to zeros with error null
+    // renders "0 of 0 devices" and an empty key as fact — a subscriber told they have no license.
     storeToken()
     await boot(vi.fn(async () => jsonResponse({ key: 'K', used: '3', seats: null, source: 'keygen' })))
 
-    const d = await detail()
-    expect(d.used).toBe(0)
-    expect(d.seats).toBe(0)
+    expect(await detail()).toEqual({
+      key: null,
+      used: 0,
+      seats: 0,
+      source: null,
+      error: 'network'
+    })
+
+    // The 200 HTML page: the body does not parse at all.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token <')
+        }
+      }))
+    )
+    expect((await detail()).error).toBe('network')
   })
 
   it('refuses to call the server with no stored entitlement', async () => {
@@ -635,6 +656,11 @@ describe('license detail + release', () => {
     await boot(
       vi.fn(async () => jsonResponse({ key: 'K', used: 1, seats: 3, source: 'paddle' }))
     )
-    expect((await detail()).source).toBeNull()
+    const d = await detail()
+    expect(d.source).toBeNull()
+    // …and it stays a SUCCESS. Stamping an error here would hide the whole panel over a reply that
+    // carried a perfectly good key and device count.
+    expect(d.error).toBeNull()
+    expect(d.key).toBe('K')
   })
 })

--- a/src/core/license.test.ts
+++ b/src/core/license.test.ts
@@ -5,7 +5,7 @@ import { promises as fsp } from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
 import { IPC } from '../shared/ipc'
-import type { LicenseStatus } from '../shared/types'
+import type { LicenseDetail, LicenseStatus } from '../shared/types'
 
 // One temp userData dir per run; hoisted so the entitlement-key mock factory can see it.
 const h = vi.hoisted(() => ({
@@ -373,5 +373,268 @@ describe('license seats entitlement', () => {
     } finally {
       delete process.env.NODETERM_CHECKOUT_URL
     }
+  })
+})
+
+describe('license detail + release', () => {
+  let fake: import('./platform-fake').FakePlatform
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'Date'] })
+    h.userData = mkdtempSync(path.join(tmpdir(), 'nt-license-detail-'))
+    writeFileSync(path.join(h.userData, 'device-id'), 'test-device')
+    delete process.env.DO_NOT_TRACK
+    delete process.env.NODETERM_TELEMETRY_DISABLED
+    process.env.NODETERM_API_BASE = 'http://127.0.0.1:1'
+    // The launch refresh must not succeed here: rejecting it keeps the stored token intact
+    // (offline grace) so every assertion below runs against the token the test wrote.
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    vi.resetModules()
+    const { initPlatform } = await import('./platform')
+    const { fakePlatform } = await import('./platform-fake')
+    fake = fakePlatform({ userDataDir: h.userData, isPackaged: false })
+    initPlatform(fake)
+  })
+
+  afterEach(async () => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    const { resetPlatformForTests } = await import('./platform')
+    resetPlatformForTests()
+    delete process.env.DO_NOT_TRACK
+    rmSync(h.userData, { recursive: true, force: true })
+  })
+
+  const TOKEN = mint(HOUR / 1000)
+
+  function storeToken(token = TOKEN): void {
+    writeFileSync(path.join(h.userData, 'license.json'), JSON.stringify({ token }))
+  }
+
+  /** Non-2xx reply shaped like our API's error bodies. */
+  function errorResponse(status: number, body: unknown): {
+    ok: boolean
+    status: number
+    json: () => Promise<unknown>
+  } {
+    return { ok: false, status, json: async () => body }
+  }
+
+  /**
+   * Boot the service, let its launch refresh SETTLE, and only then install the fetch mock the
+   * assertions are about. initLicense() fires an un-awaited refresh; installing the mock first
+   * would make `mock.calls[0]` that refresh — so a handler that never called fetch at all could
+   * still satisfy a "the request carried X" assertion.
+   */
+  async function boot(fetchMock: ReturnType<typeof vi.fn>): Promise<void> {
+    const { initLicense } = await import('./license')
+    initLicense()
+    await refreshed()
+    vi.stubGlobal('fetch', fetchMock)
+  }
+
+  const detail = (): Promise<LicenseDetail> =>
+    fake.handlers[IPC.licenseDetail]() as Promise<LicenseDetail>
+  const release = (): Promise<LicenseDetail> =>
+    fake.handlers[IPC.licenseRelease]() as Promise<LicenseDetail>
+
+  it('sends the stored entitlement token, never a deviceId', async () => {
+    storeToken()
+    const fetchMock = vi.fn(async (_url: string, _init: { method: string; body: string }) =>
+      jsonResponse({ key: 'KEY-ABC', used: 2, seats: 3, source: 'keygen' })
+    )
+    await boot(fetchMock)
+
+    expect(await detail()).toEqual({
+      key: 'KEY-ABC',
+      used: 2,
+      seats: 3,
+      source: 'keygen',
+      error: null
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/v1/license/detail')
+    // A key works on ANY machine, so the request that reveals one is authorized by the signed
+    // entitlement and by nothing else. deviceId rides query strings, telemetry and relay pairing.
+    expect(String(url)).not.toContain(TOKEN)
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body) as Record<string, unknown>
+    expect(body.entitlement).toBe(TOKEN) // the stored token itself, not merely "something truthy"
+    expect(Object.keys(body)).toEqual(['entitlement']) // …and nothing else travels with it
+  })
+
+  it('release posts to its own route, not to detail', async () => {
+    storeToken()
+    const fetchMock = vi.fn(async (_url: string, _init: { body: string }) =>
+      jsonResponse({ used: 1, seats: 3 })
+    )
+    await boot(fetchMock)
+
+    const r = await release()
+    expect(r.error).toBeNull()
+    expect(r.used).toBe(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/v1/license/release')
+    expect(String(url)).not.toContain('/v1/license/detail')
+    expect((JSON.parse(init.body) as { entitlement: string }).entitlement).toBe(TOKEN)
+  })
+
+  it('carries the source, so a non-keygen entitlement is not read as a failed count', async () => {
+    // An App Store purchase on a paired phone bridges Pro to the desktop as `apple:<txn>`. The
+    // server makes zero keygen calls for it and answers 200 with no key and no machines — those
+    // zeros mean "device counting does not apply here", NOT "the read failed". `source` is the
+    // only thing that tells the two apart, and the UI hides the release action on it.
+    storeToken()
+    await boot(vi.fn(async () => jsonResponse({ key: null, used: 0, seats: 0, source: 'apple' })))
+
+    expect(await detail()).toEqual({
+      key: null,
+      used: 0,
+      seats: 0,
+      source: 'apple',
+      error: null
+    })
+  })
+
+  it('a 200 with key null is a success, not the 402 inactive story', async () => {
+    // A keygen policy may hide keys, and licenses predating the `key` column have none stored.
+    // Reporting that as a failure would tell a paying subscriber their license is inactive.
+    storeToken()
+    await boot(vi.fn(async () => jsonResponse({ key: null, used: 2, seats: 3, source: 'keygen' })))
+
+    expect(await detail()).toEqual({ key: null, used: 2, seats: 3, source: 'keygen', error: null })
+  })
+
+  it('402 inactive is an error with no source claimed', async () => {
+    storeToken()
+    await boot(vi.fn(async () => errorResponse(402, { error: 'inactive' })))
+
+    expect(await detail()).toEqual({
+      key: null,
+      used: 0,
+      seats: 0,
+      source: null,
+      error: 'inactive'
+    })
+  })
+
+  it('401 unauthorized keeps the server-stated reason instead of a generic network error', async () => {
+    storeToken()
+    await boot(vi.fn(async () => errorResponse(401, { error: 'unauthorized' })))
+    expect((await detail()).error).toBe('unauthorized')
+  })
+
+  it('reports an error instead of zero devices when the read fails', async () => {
+    storeToken()
+    await boot(
+      vi.fn(async () => {
+        throw new Error('down')
+      })
+    )
+
+    expect(await detail()).toEqual({
+      key: null,
+      used: 0,
+      seats: 0,
+      source: null,
+      error: 'offline'
+    })
+  })
+
+  it('surfaces the 30-day throttle with its retry window', async () => {
+    storeToken()
+    await boot(vi.fn(async () => errorResponse(429, { error: 'too_soon', retryAfterDays: 12 })))
+
+    // toEqual, not toMatchObject: the retry window is the whole point of this reply, and the
+    // server side asserts only the error code — so if `retryAfterDays` is dropped anywhere
+    // between the wire and the renderer, this is what fails.
+    expect(await release()).toEqual({
+      key: null,
+      used: 0,
+      seats: 0,
+      source: null,
+      error: 'too_soon',
+      retryAfterDays: 12
+    })
+  })
+
+  it('keeps not_applicable distinguishable from a plain bad request', async () => {
+    // 'not_applicable' = this entitlement is not keygen-backed, so releasing means nothing. The
+    // UI hides the action on `source`; this is the server-side floor under that, not a failure.
+    storeToken()
+    await boot(vi.fn(async () => errorResponse(400, { error: 'not_applicable' })))
+    expect((await release()).error).toBe('not_applicable')
+
+    vi.stubGlobal('fetch', vi.fn(async () => errorResponse(400, { error: 'bad_request' })))
+    expect((await release()).error).toBe('bad_request')
+  })
+
+  it('an error body with no reason code falls back to network, and never to success', async () => {
+    storeToken()
+    await boot(vi.fn(async () => errorResponse(500, {})))
+    expect((await detail()).error).toBe('network')
+  })
+
+  it('reports used above seats verbatim — a cap can be lowered after activation', async () => {
+    storeToken()
+    await boot(vi.fn(async () => jsonResponse({ key: 'K', used: 5, seats: 3, source: 'keygen' })))
+
+    const d = await detail()
+    expect(d.used).toBe(5) // never clamped to the cap: over-cap is a real, reportable state
+    expect(d.seats).toBe(3)
+  })
+
+  it('accepts only real numbers as counts, so nothing renders as NaN or as a string', async () => {
+    // The contract says numbers. A body that says otherwise is malformed, and `json.used ?? 0`
+    // would forward whatever it holds — "3" into a meter, or NaN out of arithmetic on it.
+    storeToken()
+    await boot(vi.fn(async () => jsonResponse({ key: 'K', used: '3', seats: null, source: 'keygen' })))
+
+    const d = await detail()
+    expect(d.used).toBe(0)
+    expect(d.seats).toBe(0)
+  })
+
+  it('refuses to call the server with no stored entitlement', async () => {
+    // No license.json at all.
+    const fetchMock = vi.fn()
+    await boot(fetchMock)
+
+    expect(await detail()).toEqual({
+      key: null,
+      used: 0,
+      seats: 0,
+      source: null,
+      error: 'unauthorized'
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('honors the telemetry kill switch without inventing a device count', async () => {
+    storeToken()
+    const fetchMock = vi.fn(async () => jsonResponse({ key: 'K', used: 2, seats: 3, source: 'keygen' }))
+    await boot(fetchMock)
+    process.env.DO_NOT_TRACK = '1'
+
+    expect(await detail()).toEqual({
+      key: null,
+      used: 0,
+      seats: 0,
+      source: null,
+      error: 'disabled'
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores a source it does not recognize rather than passing it through', async () => {
+    // The value decides whether a destructive-ish action is offered, so an unknown word degrades
+    // to "no source stated" (the action stays hidden) instead of reaching the UI as data.
+    storeToken()
+    await boot(
+      vi.fn(async () => jsonResponse({ key: 'K', used: 1, seats: 3, source: 'paddle' }))
+    )
+    expect((await detail()).source).toBeNull()
   })
 })

--- a/src/core/license.test.ts
+++ b/src/core/license.test.ts
@@ -529,6 +529,44 @@ describe('license detail + release', () => {
     expect((await detail()).error).toBe('unauthorized')
   })
 
+  it('times out a response whose BODY never arrives, instead of hanging the handler forever', async () => {
+    // The 8s abort has to cover the body, not just the headers. A captive portal or a proxy that
+    // holds the connection open answers 200 and then stalls; with the timer cleared as soon as the
+    // headers land, this handler never settles — and the renderer's Release button sits on
+    // "Releasing…" for the rest of the session, with no failure to report and no way back.
+    storeToken()
+    // Captured while setTimeout is still real (this describe fakes only setInterval + Date), so
+    // the guard below can fail FAST if the handler hangs rather than idling until vitest's own
+    // test timeout.
+    const realSetTimeout = globalThis.setTimeout
+    let aborted = false
+    await boot(
+      vi.fn(async (_url: string, init: { signal: AbortSignal }) => ({
+        ok: true,
+        status: 200,
+        // A real fetch body rejects when the request is aborted; before that it just never settles.
+        json: () =>
+          new Promise((_resolve, reject) => {
+            init.signal.addEventListener('abort', () => {
+              aborted = true
+              reject(new Error('The operation was aborted'))
+            })
+          })
+      }))
+    )
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'Date'] })
+    const pending = release()
+    await vi.advanceTimersByTimeAsync(8000)
+    const guard = new Promise<'hung'>((resolve) => realSetTimeout(() => resolve('hung'), 500))
+    const outcome = await Promise.race([pending, guard])
+
+    expect(outcome, 'the release handler never settled').not.toBe('hung')
+    expect(aborted).toBe(true)
+    // A read that could not run is an error — never a license with no devices.
+    expect(outcome).toEqual({ key: null, used: 0, seats: 0, source: null, error: 'network' })
+  })
+
   it('reports an error instead of zero devices when the read fails', async () => {
     storeToken()
     await boot(

--- a/src/core/license.ts
+++ b/src/core/license.ts
@@ -8,7 +8,7 @@ import path from 'path'
 import crypto from 'node:crypto'
 import { platform } from './platform'
 import { IPC } from '../shared/ipc'
-import type { LicenseStatus } from '../shared/types'
+import type { LicenseDetail, LicenseSource, LicenseStatus } from '../shared/types'
 import { getDeviceId } from './device-id'
 import { ENTITLEMENT_PUBLIC_KEY } from './entitlement-key'
 
@@ -104,6 +104,23 @@ function verify(token: string | undefined): Payload | null {
 // count. Inactive/free/invalid → 0.
 function seatsFrom(p: Payload | null): number {
   return p ? Math.max(PRO_FREE_SEATS, p.seats ?? PRO_FREE_SEATS) : 0
+}
+
+/** Every failure answers with this shape plus a reason code: zeros that are NEVER a device count.
+ * The renderer must read `error` first — "we could not look" and "you have no devices" are
+ * different facts, and rendering the first as the second is the bug this whole route exists for. */
+const EMPTY_DETAIL: LicenseDetail = { key: null, used: 0, seats: 0, source: null, error: null }
+
+const LICENSE_SOURCES: readonly string[] = ['keygen', 'apple', 'free']
+
+/** The source decides whether the UI offers "release other devices" at all, so an unrecognized
+ * word degrades to "none stated" (action hidden) rather than reaching the renderer as data. */
+function licenseSourceOf(v: unknown): LicenseSource | null {
+  return typeof v === 'string' && LICENSE_SOURCES.includes(v) ? (v as LicenseSource) : null
+}
+
+function countOf(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0
 }
 
 function statusFrom(token: string | undefined, error: string | null = null): LicenseStatus {
@@ -206,6 +223,60 @@ export function initLicense(onChange?: () => void): void {
   }
 
   platform().handle(IPC.licenseStatus, () => statusFrom(load().token))
+
+  // Both routes are authorized by the stored entitlement token. Sending a deviceId instead would
+  // hand a key — which works on ANY machine — to whoever learned an id that rides query strings,
+  // telemetry and relay pairing. The token is the only credential on the wire here, and it goes
+  // in the BODY, never the URL.
+  const licenseCall = async (route: string): Promise<LicenseDetail> => {
+    const token = load().token
+    if (!token) return { ...EMPTY_DETAIL, error: 'unauthorized' }
+    if (!allowed()) return { ...EMPTY_DETAIL, error: 'disabled' }
+    try {
+      const ctrl = new AbortController()
+      const t = setTimeout(() => ctrl.abort(), 8000)
+      const res = await fetch(`${API_BASE}${route}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ entitlement: token }),
+        signal: ctrl.signal
+      }).finally(() => clearTimeout(t))
+      const json = (await res.json().catch(() => ({}))) as {
+        key?: unknown
+        used?: unknown
+        seats?: unknown
+        source?: unknown
+        error?: unknown
+        retryAfterDays?: unknown
+      }
+      if (!res.ok) {
+        // The server's own reason code (401 unauthorized / 402 inactive / 429 too_soon /
+        // 400 not_applicable) is kept verbatim: the UI tells those four apart. `retryAfterDays`
+        // rides only 429 and is the whole content of that answer.
+        const days = countOf(json.retryAfterDays)
+        return {
+          ...EMPTY_DETAIL,
+          error: typeof json.error === 'string' && json.error ? json.error : 'network',
+          ...(days > 0 ? { retryAfterDays: days } : {})
+        }
+      }
+      return {
+        // `key: null` on a 200 is a real state (a keygen policy that hides keys, a license older
+        // than the column, a non-keygen source) — a success, not a failed read.
+        key: typeof json.key === 'string' ? json.key : null,
+        // Never clamped against seats: a cap lowered after activation makes used > seats real.
+        used: countOf(json.used),
+        seats: countOf(json.seats),
+        source: licenseSourceOf(json.source),
+        error: null
+      }
+    } catch {
+      return { ...EMPTY_DETAIL, error: 'offline' }
+    }
+  }
+
+  platform().handle(IPC.licenseDetail, () => licenseCall('/v1/license/detail'))
+  platform().handle(IPC.licenseRelease, () => licenseCall('/v1/license/release'))
 
   // Device-bound upgrade: open Stripe checkout (carrying our deviceId), then poll the status
   // endpoint until the webhook has bound + minted the entitlement. Status arrives via broadcast.

--- a/src/core/license.ts
+++ b/src/core/license.ts
@@ -119,8 +119,10 @@ function licenseSourceOf(v: unknown): LicenseSource | null {
   return typeof v === 'string' && LICENSE_SOURCES.includes(v) ? (v as LicenseSource) : null
 }
 
-function countOf(v: unknown): number {
-  return typeof v === 'number' && Number.isFinite(v) ? v : 0
+/** A count the server actually stated. A string, null or NaN is not one — see the 2xx guard in
+ * `licenseCall`, where "we could not read the body" must stay distinct from "no devices". */
+function isCount(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
 }
 
 function statusFrom(token: string | undefined, error: string | null = null): LicenseStatus {
@@ -253,20 +255,29 @@ export function initLicense(onChange?: () => void): void {
         // The server's own reason code (401 unauthorized / 402 inactive / 429 too_soon /
         // 400 not_applicable) is kept verbatim: the UI tells those four apart. `retryAfterDays`
         // rides only 429 and is the whole content of that answer.
-        const days = countOf(json.retryAfterDays)
+        const days = isCount(json.retryAfterDays) ? json.retryAfterDays : 0
         return {
           ...EMPTY_DETAIL,
           error: typeof json.error === 'string' && json.error ? json.error : 'network',
           ...(days > 0 ? { retryAfterDays: days } : {})
         }
       }
+      // A 2xx we could not READ is a failed read, not a license with no devices. A captive portal
+      // or corporate proxy answers this POST with a 200 HTML page, and a bad deploy can answer
+      // `200 {}` or `200 {"used":"3"}` — coercing any of those to 0 while leaving `error` null
+      // renders "0 of 0 devices" and an empty key AS FACT, which is the one thing this route
+      // exists to prevent. Both counts must be real numbers; the legitimate non-keygen 200 states
+      // exactly that (`{key:null, used:0, seats:0, source:'apple'}`) and is untouched.
+      if (!isCount(json.used) || !isCount(json.seats)) {
+        return { ...EMPTY_DETAIL, error: 'network' }
+      }
       return {
         // `key: null` on a 200 is a real state (a keygen policy that hides keys, a license older
         // than the column, a non-keygen source) — a success, not a failed read.
         key: typeof json.key === 'string' ? json.key : null,
         // Never clamped against seats: a cap lowered after activation makes used > seats real.
-        used: countOf(json.used),
-        seats: countOf(json.seats),
+        used: json.used,
+        seats: json.seats,
         source: licenseSourceOf(json.source),
         error: null
       }

--- a/src/core/license.ts
+++ b/src/core/license.ts
@@ -141,38 +141,53 @@ export function licensedSeats(): number {
   return seatsFrom(verify(load().token))
 }
 
+/**
+ * How long a license request may take IN TOTAL — headers and body.
+ *
+ * The timer must outlive the `fetch` promise and be cleared only once the body has been read.
+ * Clearing it when the headers arrive (`fetch(…).finally(clearTimeout)`) disarms the abort while
+ * the interesting half is still outstanding, and a response whose body never completes — a captive
+ * portal, a proxy that holds the connection open — then hangs the awaiting IPC handler FOREVER:
+ * the Release button sits on "Releasing…" with no failure and no way back.
+ */
+const REQUEST_TIMEOUT_MS = 8000
+
 async function call(path: string, body: unknown): Promise<{ token?: string; error?: string }> {
   if (!allowed()) return { error: 'disabled' }
+  const ctrl = new AbortController()
+  const t = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS)
   try {
-    const ctrl = new AbortController()
-    const t = setTimeout(() => ctrl.abort(), 8000)
     const res = await fetch(`${API_BASE}${path}`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
       signal: ctrl.signal
-    }).finally(() => clearTimeout(t))
+    })
     if (res.status === 204) return {}
     const json = (await res.json().catch(() => ({}))) as { token?: string; error?: string }
     if (!res.ok) return { error: json.error ?? 'network' }
     return json
   } catch {
     return { error: 'offline' }
+  } finally {
+    clearTimeout(t)
   }
 }
 
 // GET helper for the device-bound status poll.
 async function getJson(path: string): Promise<{ active?: boolean; token?: string; error?: string }> {
   if (!allowed()) return { error: 'disabled' }
+  const ctrl = new AbortController()
+  const t = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS)
   try {
-    const ctrl = new AbortController()
-    const t = setTimeout(() => ctrl.abort(), 8000)
-    const res = await fetch(`${API_BASE}${path}`, { signal: ctrl.signal }).finally(() => clearTimeout(t))
+    const res = await fetch(`${API_BASE}${path}`, { signal: ctrl.signal })
     const json = (await res.json().catch(() => ({}))) as { active?: boolean; token?: string; error?: string }
     if (!res.ok) return { error: json.error ?? 'network' }
     return json
   } catch {
     return { error: 'offline' }
+  } finally {
+    clearTimeout(t)
   }
 }
 
@@ -234,15 +249,17 @@ export function initLicense(onChange?: () => void): void {
     const token = load().token
     if (!token) return { ...EMPTY_DETAIL, error: 'unauthorized' }
     if (!allowed()) return { ...EMPTY_DETAIL, error: 'disabled' }
+    // The timer covers the BODY too — see REQUEST_TIMEOUT_MS. This is the route the Release
+    // button awaits, so a request that never finishes leaves that button spinning for good.
+    const ctrl = new AbortController()
+    const t = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS)
     try {
-      const ctrl = new AbortController()
-      const t = setTimeout(() => ctrl.abort(), 8000)
       const res = await fetch(`${API_BASE}${route}`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ entitlement: token }),
         signal: ctrl.signal
-      }).finally(() => clearTimeout(t))
+      })
       const json = (await res.json().catch(() => ({}))) as {
         key?: unknown
         used?: unknown
@@ -283,6 +300,8 @@ export function initLicense(onChange?: () => void): void {
       }
     } catch {
       return { ...EMPTY_DETAIL, error: 'offline' }
+    } finally {
+      clearTimeout(t)
     }
   }
 

--- a/src/main/pairing-core.test.ts
+++ b/src/main/pairing-core.test.ts
@@ -285,6 +285,63 @@ describe('device registry helpers', () => {
   })
 })
 
+describe('DeviceEntry.relayDeviceId', () => {
+  // The desktop mints its OWN device id (it stamps the authorized_keys comment) and the phone
+  // sends its own — and only the phone's is what the server keys `relay_devices` on. Keeping
+  // just the local one made a paired device unnameable to the server, so a removal could never
+  // say WHICH row to revoke.
+  const entry: DeviceEntry = {
+    id: 'local-uuid',
+    name: 'iPhone',
+    token: 'agent-token',
+    pairedAt: 1,
+    lastSeenAt: 0,
+    relayDeviceId: 'phone-1'
+  }
+
+  it('round-trips through upsertDevice (it is persisted, not derived)', () => {
+    expect(upsertDevice([], entry)[0].relayDeviceId).toBe('phone-1')
+    const replaced = upsertDevice([{ ...entry, relayDeviceId: 'stale' }], entry)
+    expect(replaced).toEqual([entry])
+  })
+
+  it('is exposed to the renderer (an id, not a secret) while the token still is not', () => {
+    const [pub] = toPublicDevices([entry])
+    expect(pub.relayDeviceId).toBe('phone-1')
+    // Whole shape, not a subset: a mapper that spread the record would satisfy the line above
+    // AND leak `token`. Both assertions below fail on `devices.map((d) => ({ ...d }))`.
+    expect(pub).toEqual({
+      id: 'local-uuid',
+      name: 'iPhone',
+      pairedAt: 1,
+      lastSeenAt: 0,
+      relayDeviceId: 'phone-1'
+    })
+    expect(Object.keys(pub).sort()).toEqual([
+      'id',
+      'lastSeenAt',
+      'name',
+      'pairedAt',
+      'relayDeviceId'
+    ])
+    expect((pub as Record<string, unknown>).token).toBeUndefined()
+  })
+
+  it('is optional — a device paired before the field existed still maps, with no id and no token', () => {
+    const legacy: DeviceEntry = {
+      id: 'old',
+      name: 'Old Phone',
+      token: 'agent-token',
+      pairedAt: 1,
+      lastSeenAt: 0
+    }
+    expect(readDevices({ devices: [legacy] })).toEqual([legacy])
+    const [pub] = toPublicDevices([legacy])
+    expect(pub.relayDeviceId).toBeUndefined()
+    expect(Object.keys(pub)).not.toContain('token')
+  })
+})
+
 describe('pickLanIPv4', () => {
   it('picks the first non-internal, non-link-local IPv4', () => {
     const picked = pickLanIPv4({

--- a/src/main/pairing-core.ts
+++ b/src/main/pairing-core.ts
@@ -135,6 +135,15 @@ export interface DeviceEntry {
   token: string
   pairedAt: number
   lastSeenAt: number
+  /**
+   * The PHONE's own device id, as sent to `/v1/relay/device` — the key `relay_devices` is stored
+   * under. `id` above is ours (it stamps the authorized_keys comment) and means nothing to the
+   * backend, so without this a removal could not tell the server WHICH row to revoke.
+   * Absent for devices paired before this field existed; equal to `id` when the phone sent no id
+   * of its own. Recorded for a LAN-only pairing too — the phone identifies itself either way — so
+   * its presence names a row the server MAY hold, not one it certainly does.
+   */
+  relayDeviceId?: string
 }
 
 /** The device shape safe to expose to the renderer (no `token`). */
@@ -169,9 +178,18 @@ export function removeDevice(devices: DeviceEntry[], id: string): DeviceEntry[] 
   return devices.filter((d) => d.id !== id)
 }
 
-/** Strip the secret `token` from each device before handing the list to the renderer. */
+/**
+ * Strip the secret `token` from each device before handing the list to the renderer. Built field
+ * by field on purpose: spreading the entry would carry the token out with every future field.
+ */
 export function toPublicDevices(devices: DeviceEntry[]): PublicDevice[] {
-  return devices.map(({ id, name, pairedAt, lastSeenAt }) => ({ id, name, pairedAt, lastSeenAt }))
+  return devices.map(({ id, name, pairedAt, lastSeenAt, relayDeviceId }) => ({
+    id,
+    name,
+    pairedAt,
+    lastSeenAt,
+    relayDeviceId
+  }))
 }
 
 /** Minimal shape of `os.networkInterfaces()` we need — kept structural so tests can fake it. */

--- a/src/main/pairing-revoke.test.ts
+++ b/src/main/pairing-revoke.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest'
+import { promises as fs, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import path from 'path'
+
+const TEMP_HOME_MARKER = 'nt-revoke-'
+
+// Same hoisted redirect as pairing-service.test.ts: the service resolves AGENT_JSON_PATH /
+// AUTH_KEYS_PATH from `os.homedir()` at MODULE LOAD, so the temp home has to exist before the
+// import. Everything else about `os` stays real.
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>()
+  const { mkdtempSync } = await import('node:fs')
+  const { join } = await import('node:path')
+  // Literal, not TEMP_HOME_MARKER: this factory is hoisted above every module-level binding.
+  const home = mkdtempSync(join(actual.tmpdir(), 'nt-revoke-'))
+  const homedir = (): string => home
+  const base = (actual as unknown as { default?: typeof actual }).default ?? actual
+  return { ...actual, homedir, default: { ...base, homedir } }
+})
+
+vi.mock('../core/device-id', () => ({ getDeviceId: () => 'test-host-device-id' }))
+
+import os from 'os'
+import {
+  createPairingService,
+  revokeRelayDevice,
+  type PairingRelayDeps
+} from './pairing-service'
+import { rewriteKeyComment, type DeviceEntry } from './pairing-core'
+import type { Settings } from '../shared/types'
+
+const HOME = os.homedir()
+const AGENT_JSON = path.join(HOME, '.nodeterm', 'agent.json')
+const AUTH_KEYS = path.join(HOME, '.ssh', 'authorized_keys')
+
+/** Refuse to run (and to delete anything) unless HOME is demonstrably our mkdtemp dir. */
+function assertTempHome(): void {
+  if (!path.basename(HOME).startsWith(TEMP_HOME_MARKER)) {
+    throw new Error(
+      `pairing-revoke.test refuses to run: homedir() is "${HOME}", not a ${TEMP_HOME_MARKER}* ` +
+        'temp dir. The os mock is not in effect and this file would delete the real ~/.ssh.'
+    )
+  }
+}
+assertTempHome()
+
+const KEY_A = rewriteKeyComment('ssh-ed25519 AAAAblobAAAA phone-a@ios', 'dev-a')
+const KEY_OTHER = 'ssh-rsa AAAAlaptopblob jdub@laptop'
+
+const device = (id: string, relayDeviceId?: string): DeviceEntry => ({
+  id,
+  name: `Phone ${id}`,
+  token: `agent-token-${id}`,
+  pairedAt: 1_700_000_000_000,
+  lastSeenAt: 0,
+  relayDeviceId
+})
+
+/** Seed a registry holding ONE device; `relayDeviceId` is what the phone called itself. */
+const seed = (relayDeviceId?: string): void => {
+  rmSync(path.join(HOME, '.nodeterm'), { recursive: true, force: true })
+  rmSync(path.join(HOME, '.ssh'), { recursive: true, force: true })
+  mkdirSync(path.join(HOME, '.nodeterm'), { recursive: true, mode: 0o700 })
+  mkdirSync(path.join(HOME, '.ssh'), { recursive: true, mode: 0o700 })
+  writeFileSync(
+    AGENT_JSON,
+    JSON.stringify({ hostId: 'host-keep-me', devices: [device('dev-a', relayDeviceId)] }, null, 2) +
+      '\n',
+    { mode: 0o600 }
+  )
+  writeFileSync(AUTH_KEYS, `${KEY_OTHER}\n${KEY_A}\n`, { mode: 0o600 })
+}
+
+const agentJson = (): { devices?: DeviceEntry[] } => JSON.parse(readFileSync(AGENT_JSON, 'utf8'))
+const deviceIds = (): string[] => (agentJson().devices ?? []).map((d) => d.id)
+const authKeys = (): string => readFileSync(AUTH_KEYS, 'utf8')
+
+/** Relay deps carrying an entitlement, i.e. a Pro desktop that CAN authorize a revoke. */
+const relayDeps = (entitlement: string | null): PairingRelayDeps => ({
+  getSettings: () => ({ phoneAccessEnabled: true }) as unknown as Settings,
+  getEntitlement: () => entitlement,
+  loadHostKeyPair: async () => {
+    throw new Error('not used by revoke')
+  },
+  relayEndpoint: 'wss://relay.example',
+  apiBase: 'https://api.x',
+  relayAllowed: () => true
+})
+
+const fetchBody = (mock: ReturnType<typeof vi.fn>): unknown =>
+  JSON.parse((mock.mock.calls[0][1] as { body: string }).body)
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+afterAll(() => {
+  assertTempHome()
+  rmSync(HOME, { recursive: true, force: true })
+})
+
+describe('revokeRelayDevice', () => {
+  it('posts the phone id with the host entitlement and reports ok on 204', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(await revokeRelayDevice('https://api.x', 'phone-1', 'TOKEN')).toBe('ok')
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      { method: string; body: string }
+    ]
+    // The deviceId is phone-supplied, unvalidated text: it rides the JSON BODY, never a URL.
+    expect(String(url)).toBe('https://api.x/v1/relay/device/revoke')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ deviceId: 'phone-1', entitlement: 'TOKEN' })
+  })
+
+  // 403 is the route's only real refusal ("that row is someone else's"), 401 a token that did not
+  // verify. Both are things we TRIED and were told no — never 'skipped', which claims we didn't ask.
+  it.each([403, 401, 500])('reports failed — never a silent success — on %i', async (status) => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status })))
+    expect(await revokeRelayDevice('https://api.x', 'phone-1', 'TOKEN')).toBe('failed')
+  })
+
+  it('reports failed when the request throws (offline)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('down')
+      })
+    )
+    expect(await revokeRelayDevice('https://api.x', 'phone-1', 'TOKEN')).toBe('failed')
+  })
+
+  it('gives up on a hung server rather than hanging the revoke forever', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () => reject(new Error('aborted')))
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const pending = revokeRelayDevice('https://api.x', 'phone-1', 'TOKEN')
+    await vi.advanceTimersByTimeAsync(9000)
+    expect(await pending).toBe('failed')
+  })
+
+  // 'skipped' means "we did not ask, and that is fine" — a free-tier desktop holds no entitlement
+  // to sign the request with, and has no Pro of ours on that phone to reclaim.
+  it('skips — without calling the server — when there is no entitlement to sign with', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await revokeRelayDevice('https://api.x', 'phone-1', null)).toBe('skipped')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when there is no relay device id to name', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await revokeRelayDevice('https://api.x', '', 'TOKEN')).toBe('skipped')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when there is no API base, instead of fetching a relative URL', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await revokeRelayDevice('', 'phone-1', 'TOKEN')).toBe('skipped')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('createPairingService().revokeDevice', () => {
+  beforeEach(() => {
+    seed('phone-relay-1')
+  })
+
+  it('names the PHONE’s relay device id, not our local one, and reports both legs', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const service = createPairingService(relayDeps('TOKEN'))
+
+    expect(await service.revokeDevice('dev-a')).toEqual({ local: true, server: 'ok' })
+
+    // 'dev-a' is OUR id; the backend keys its row on the id the phone sent.
+    expect(fetchBody(fetchMock)).toEqual({ deviceId: 'phone-relay-1', entitlement: 'TOKEN' })
+    expect(deviceIds()).toEqual([])
+    expect(authKeys()).toBe(`${KEY_OTHER}\n`)
+  })
+
+  it('skips the server when the device predates relayDeviceId (nothing we can name)', async () => {
+    seed(undefined)
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const service = createPairingService(relayDeps('TOKEN'))
+
+    expect(await service.revokeDevice('dev-a')).toEqual({ local: true, server: 'skipped' })
+    // Falling back to our own id would ask the backend about a row that cannot exist.
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(deviceIds()).toEqual([])
+  })
+
+  it('skips the server on a free-tier desktop, and still removes the device locally', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const service = createPairingService(relayDeps(null))
+
+    expect(await service.revokeDevice('dev-a')).toEqual({ local: true, server: 'skipped' })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(deviceIds()).toEqual([])
+  })
+
+  it('skips the server when the service has no relay deps at all', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const service = createPairingService()
+
+    expect(await service.revokeDevice('dev-a')).toEqual({ local: true, server: 'skipped' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('reports the server leg as failed while the local removal still stuck', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 403 })))
+    const service = createPairingService(relayDeps('TOKEN'))
+
+    expect(await service.revokeDevice('dev-a')).toEqual({ local: true, server: 'failed' })
+    expect(deviceIds()).toEqual([])
+    expect(authKeys()).toBe(`${KEY_OTHER}\n`)
+  })
+
+  // A half-finished revoke must never render as a clean one (the discipline remote/revocation.ts
+  // states in its header), and the Pro is still worth reclaiming when the local files would not
+  // budge — the entitlement is what authorizes the server leg, not the local write's success.
+  it('reports local:false when the registry write fails, and still reclaims the Pro', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const service = createPairingService(relayDeps('TOKEN'))
+    vi.spyOn(fs, 'rename').mockImplementation(async (_from, to) => {
+      if (String(to).includes('agent.json')) {
+        throw Object.assign(new Error('EXDEV: cross-device link'), { code: 'EXDEV' })
+      }
+    })
+
+    expect(await service.revokeDevice('dev-a')).toEqual({ local: false, server: 'ok' })
+    expect(fetchBody(fetchMock)).toEqual({ deviceId: 'phone-relay-1', entitlement: 'TOKEN' })
+  })
+
+  it('skips the server for an id that is not in the registry', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const service = createPairingService(relayDeps('TOKEN'))
+
+    expect(await service.revokeDevice('never-paired')).toEqual({ local: true, server: 'skipped' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/pairing-revoke.test.ts
+++ b/src/main/pairing-revoke.test.ts
@@ -192,15 +192,19 @@ describe('createPairingService().revokeDevice', () => {
     expect(authKeys()).toBe(`${KEY_OTHER}\n`)
   })
 
-  it('skips the server when the device predates relayDeviceId (nothing we can name)', async () => {
+  // A device paired before `relayDeviceId` was recorded is the population this whole task exists
+  // to protect, and skipping it was a real leak: when the phone sent no id of its own, the mint
+  // keyed the row on OUR per-pairing id — the same value `revokeDevice` is called with — so the
+  // row can be named after all. (That id is a randomUUID per pairing, never this desktop's own
+  // `getDeviceId()`, which is not a key in relay_devices at all.)
+  it('falls back to our own id for a device paired before relayDeviceId was recorded', async () => {
     seed(undefined)
     const fetchMock = vi.fn(async () => ({ ok: true, status: 204 }))
     vi.stubGlobal('fetch', fetchMock)
     const service = createPairingService(relayDeps('TOKEN'))
 
-    expect(await service.revokeDevice('dev-a')).toEqual({ local: true, server: 'skipped' })
-    // Falling back to our own id would ask the backend about a row that cannot exist.
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(await service.revokeDevice('dev-a')).toEqual({ local: true, server: 'ok' })
+    expect(fetchBody(fetchMock)).toEqual({ deviceId: 'dev-a', entitlement: 'TOKEN' })
     expect(deviceIds()).toEqual([])
   })
 
@@ -249,6 +253,9 @@ describe('createPairingService().revokeDevice', () => {
     expect(fetchBody(fetchMock)).toEqual({ deviceId: 'phone-relay-1', entitlement: 'TOKEN' })
   })
 
+  // The fallback above is licensed by there BEING a device — an id that names no pairing names no
+  // row either, and asking about it would be a request we cannot justify (and a 204 we would then
+  // report as 'ok').
   it('skips the server for an id that is not in the registry', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)

--- a/src/main/pairing-service.atomic-write.test.ts
+++ b/src/main/pairing-service.atomic-write.test.ts
@@ -122,7 +122,7 @@ describe('pairing-service revoke: atomic writes', () => {
     expect(await tmpsIn(sshDir())).toEqual([])
   })
 
-  it('a failed agent.json rename removes its own temp, rejects, and leaves the old device list intact', async () => {
+  it('a failed agent.json rename removes its own temp, reports local:false, and leaves the old device list intact', async () => {
     const svc = await service()
     const before = await fs.readFile(agentJson(), 'utf-8')
     // EXDEV is the realistic one: ~/.nodeterm on another filesystem than the temp.
@@ -130,7 +130,9 @@ describe('pairing-service revoke: atomic writes', () => {
       Object.assign(new Error('EXDEV: cross-device link not permitted, rename'), { code: 'EXDEV' })
     )
 
-    await expect(svc.revokeDevice('a')).rejects.toThrow(/EXDEV/)
+    // Reported rather than thrown since the revoke grew its server leg — `local:false` is the
+    // caller-visible failure now, and it must never come back `true` on an unpublished write.
+    expect((await svc.revokeDevice('a')).local).toBe(false)
 
     // A leaked temp here is a leaked credential: it holds every device's `agentToken`, at 0600,
     // under a unique name nothing will ever write again.
@@ -141,7 +143,7 @@ describe('pairing-service revoke: atomic writes', () => {
     expect(await fs.readFile(authKeys(), 'utf-8')).toContain('nodeterm-ios-a')
   })
 
-  it('a failed authorized_keys rename removes its own temp and still rejects', async () => {
+  it('a failed authorized_keys rename removes its own temp and still reports local:false', async () => {
     const svc = await service()
     const before = await fs.readFile(authKeys(), 'utf-8')
     const realRename = fs.rename
@@ -154,7 +156,7 @@ describe('pairing-service revoke: atomic writes', () => {
       return (realRename as any)(from, to)
     }) as any)
 
-    await expect(svc.revokeDevice('a')).rejects.toThrow(/EACCES/)
+    expect((await svc.revokeDevice('a')).local).toBe(false)
     vi.restoreAllMocks()
 
     expect(await tmpsIn(sshDir())).toEqual([])

--- a/src/main/pairing-service.test.ts
+++ b/src/main/pairing-service.test.ts
@@ -37,9 +37,16 @@ vi.mock('os', async (importOriginal) => {
   }
 })
 
+// The relay mint stamps this host's anonymous device id, which is read out of the CorePlatform's
+// userData dir — uninitialized here, and its throw would be swallowed into a silent LAN-only
+// pairing. Pinned to a constant so the mint body is fully assertable.
+vi.mock('../core/device-id', () => ({ getDeviceId: () => 'test-host-device-id' }))
+
 import os from 'os'
-import { createPairingService } from './pairing-service'
+import { createPairingService, type PairingRelayDeps } from './pairing-service'
 import { rewriteKeyComment, type DeviceEntry } from './pairing-core'
+import { genKeyPair, publicKeyToB64 } from './remote/e2ee'
+import type { Settings } from '../shared/types'
 
 const HOME = os.homedir()
 const AGENT_JSON = path.join(HOME, '.nodeterm', 'agent.json')
@@ -293,6 +300,110 @@ describe('pairing POST vs revoke', () => {
       expect(keys).toContain(`nodeterm-ios-${deviceId}`) // …and so did the pairing
       expect(keys).toContain(KEY_OTHER)
       expect(deviceIds()).toEqual(['dev-b', deviceId])
+    } finally {
+      service.stop()
+    }
+  })
+})
+
+describe('pairing remembers the phone’s relay device id', () => {
+  // Two ids are in play and only ONE of them means anything to the relay backend: the desktop
+  // mints a local `deviceId` (it stamps the authorized_keys comment), while `relay_devices` is
+  // keyed on the id the PHONE sends. agent.json used to keep only the local one — the phone's was
+  // computed for the mint and thrown away — so "Remove device" had no way to name the row the
+  // server holds.
+  const hostKeys = genKeyPair()
+  const relayDeps = (): PairingRelayDeps => ({
+    getSettings: () => ({ phoneAccessEnabled: true }) as unknown as Settings,
+    getEntitlement: () => null,
+    loadHostKeyPair: async () => hostKeys,
+    relayEndpoint: 'wss://relay.example/ws',
+    apiBase: 'https://api.example',
+    relayAllowed: () => true
+  })
+
+  const devices = (): DeviceEntry[] => (agentJson().devices as DeviceEntry[] | undefined) ?? []
+  const paired = (id: string): DeviceEntry => {
+    const entry = devices().find((d) => d.id === id)
+    if (!entry) throw new Error(`no agent.json entry for ${id}`)
+    return entry
+  }
+
+  it('persists the id the phone sent, alongside the local one it does not replace', async () => {
+    const service = createPairingService()
+    try {
+      const started = await service.start(() => {})
+      const { token, pairPort } = JSON.parse(started.payload) as { token: string; pairPort: number }
+
+      const respText = await post(pairPort, {
+        token,
+        publicKey: freshEd25519Line(),
+        deviceName: 'New Phone',
+        deviceId: 'phone-abc'
+      })
+
+      const { deviceId } = JSON.parse(respText) as { deviceId: string }
+      expect(paired(deviceId).relayDeviceId).toBe('phone-abc')
+      // The local id still stamps the key line and still identifies the entry — the new field is
+      // an addition, not a rename.
+      expect(deviceId).not.toBe('phone-abc')
+      expect(authKeys()).toContain(`nodeterm-ios-${deviceId}`)
+    } finally {
+      service.stop()
+    }
+  })
+
+  it('falls back to the local id when the phone sent none, so the two coincide', async () => {
+    const service = createPairingService()
+    try {
+      const started = await service.start(() => {})
+      const { token, pairPort } = JSON.parse(started.payload) as { token: string; pairPort: number }
+
+      const respText = await post(pairPort, {
+        token,
+        publicKey: freshEd25519Line(),
+        deviceName: 'Quiet Phone'
+      })
+
+      const { deviceId } = JSON.parse(respText) as { deviceId: string }
+      expect(paired(deviceId).relayDeviceId).toBe(deviceId)
+    } finally {
+      service.stop()
+    }
+  })
+
+  it('sends the SAME id to /v1/relay/device that it records, and sends nothing else new', async () => {
+    // Computing `phoneDeviceId` earlier (so persistDevice can have it) must not change one byte
+    // of the mint body — this pins the whole body, so a reorder that accidentally passed the
+    // LOCAL id, or added a field, fails here rather than in production.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ deviceToken: 'device-token', hostId: 'host-id', exp: 0 })
+    } as unknown as Response)
+    const service = createPairingService(relayDeps())
+    try {
+      const started = await service.start(() => {})
+      const { token, pairPort } = JSON.parse(started.payload) as { token: string; pairPort: number }
+
+      const respText = await post(pairPort, {
+        token,
+        publicKey: freshEd25519Line(),
+        deviceName: 'Relay Phone',
+        deviceId: 'phone-relay-1'
+      })
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+      expect(url).toBe('https://api.example/v1/relay/device')
+      expect(JSON.parse(String(init.body))).toEqual({
+        deviceId: 'phone-relay-1',
+        hostDeviceId: 'test-host-device-id',
+        hostPublicKeyB64: publicKeyToB64(hostKeys.publicKey),
+        label: 'Relay Phone'
+      })
+
+      const { deviceId } = JSON.parse(respText) as { deviceId: string }
+      expect(paired(deviceId).relayDeviceId).toBe('phone-relay-1')
     } finally {
       service.stop()
     }

--- a/src/main/pairing-service.test.ts
+++ b/src/main/pairing-service.test.ts
@@ -222,14 +222,16 @@ describe('revokeDevice', () => {
     expect(results.map((r) => r.status)).toEqual(['fulfilled', 'fulfilled'])
   })
 
-  it('a failed revoke rejects to its caller and does not block the next one', async () => {
+  it('a failed revoke reports local:false to its caller and does not block the next one', async () => {
     const service = createPairingService()
     // First rename is agent.json's, inside the failing revoke.
     vi.spyOn(fs, 'rename').mockRejectedValueOnce(
       Object.assign(new Error('EXDEV: cross-device link not permitted, rename'), { code: 'EXDEV' })
     )
 
-    await expect(service.revokeDevice('dev-a')).rejects.toThrow(/EXDEV/)
+    // The failure is REPORTED, not thrown (the server leg still has to run, and the UI turns
+    // `local:false` into a retry note — a rejection here reached nobody).
+    expect((await service.revokeDevice('dev-a')).local).toBe(false)
     // A serializer that chains failures onto its successors would strand every later revoke.
     await service.revokeDevice('dev-b')
 
@@ -254,7 +256,8 @@ describe('revokeDevice', () => {
       return realRename(from, to)
     })
 
-    await expect(service.revokeDevice('dev-a')).rejects.toThrow(/EXDEV/)
+    // …and the half-finished revoke says so (`local:false`) instead of resolving like a clean one.
+    expect((await service.revokeDevice('dev-a')).local).toBe(false)
 
     expect(authKeys()).not.toContain('nodeterm-ios-dev-a') // SSH access really was cut
     expect(deviceIds()).toContain('dev-a') // still listed, so the owner can retry

--- a/src/main/pairing-service.ts
+++ b/src/main/pairing-service.ts
@@ -570,6 +570,12 @@ export function createPairingService(relayDeps?: PairingRelayDeps): PairingServi
         const deviceId = randomUUID()
         const agentToken = randomBytes(24).toString('base64url')
         const name = normalizeDeviceName(body.deviceName)
+        // The phone's OWN id — the key the relay backend stores its device row under, and the
+        // only one it would recognize in a later revoke. Resolved here rather than at the mint
+        // below so the registry entry can carry it; the fallback (phone sent none ⇒ our id) is
+        // unchanged, and the mint still reads this same value.
+        const phoneDeviceId =
+          typeof body.deviceId === 'string' && body.deviceId.trim() ? body.deviceId.trim() : deviceId
         // One unit, and queued behind any in-flight revoke: a pairing that interleaves with one
         // would either append onto the inode the revoke is about to rename over, or lose its
         // agent.json entry to the revoke's stale read.
@@ -580,17 +586,14 @@ export function createPairingService(relayDeps?: PairingRelayDeps): PairingServi
             name,
             token: agentToken,
             pairedAt: Date.now(),
-            lastSeenAt: 0
+            lastSeenAt: 0,
+            relayDeviceId: phoneDeviceId
           })
         })
         // Provision relay access for the phone when enabled + Pro. Any failure ⇒ LAN-only: we
         // never fail the pairing over a relay hiccup (the phone still got its SSH key installed).
         let relayFields: { relay?: RelayPairingBlock; relayDeviceToken?: string } = {}
         if (relayCtx) {
-          const phoneDeviceId =
-            typeof body.deviceId === 'string' && body.deviceId.trim()
-              ? body.deviceId.trim()
-              : deviceId
           const minted = await mintRelayDevice(relayDeps!.apiBase, {
             entitlement: relayCtx.entitlement,
             deviceId: phoneDeviceId,

--- a/src/main/pairing-service.ts
+++ b/src/main/pairing-service.ts
@@ -131,7 +131,7 @@ const REVOKE_TIMEOUT_MS = 8000
  *              verify) or could not reach the server. The caller must NOT report a clean removal.
  *  - 'skipped' we did not ask, and that is a normal state: a free-tier desktop holds no
  *              entitlement to sign the request with (and has no Pro of ours on that phone to
- *              reclaim), and a device paired before `relayDeviceId` existed has no row we can name.
+ *              reclaim), or there is no device (and so no row) to name at all.
  *
  * `relayDeviceId` is phone-supplied, unvalidated text, so it rides the JSON body — never a URL.
  */
@@ -721,28 +721,48 @@ export function createPairingService(relayDeps?: PairingRelayDeps): PairingServi
   // entitlement is what authorizes the server leg, not the local write's success, and a phone the
   // user asked to remove should stop being minted Pro either way.
   const revokeDevice = async (id: string): Promise<DeviceRevokeResult> => {
-    const { local, relayId } = await serialize(async () => {
-      const relayId = readDevices(await readAgentJson()).find((d) => d.id === id)?.relayDeviceId
+    const { local, relayId, found } = await serialize(async () => {
+      const entry = readDevices(await readAgentJson()).find((d) => d.id === id)
+      const relayId = entry?.relayDeviceId
+      const found = !!entry
       try {
         await removeAuthorizedKeysForDevice(id)
         const obj = await readAgentJson()
         const devices = removeDevice(readDevices(obj), id)
         await writeAgentJson({ ...obj, devices })
-        return { local: true, relayId }
+        return { local: true, relayId, found }
       } catch (err) {
         // Reported, not thrown: `local:false` is what the UI turns into "try again", and the
         // server leg below is still worth running. The detail belongs in the log.
         console.warn('[pairing] local revoke failed:', err)
-        return { local: false, relayId }
+        return { local: false, relayId, found }
       }
     })
+    // A device paired before `relayDeviceId` was recorded still falls back to OUR id — which is
+    // not a guess. `id` is the per-pairing `randomUUID()` above, and when the phone sent no id of
+    // its own the mint sent exactly this value as the row's `deviceId` (see `phoneDeviceId`), so
+    // the row really is keyed on it. It is NOT this desktop's machine id (`getDeviceId()`), which
+    // is never a key in `relay_devices` — it lives only in the non-key `host_device_id` column,
+    // and /v1/relay/host-token writes no row at all — so this cannot reach the desktop's own
+    // registration. Nor can it reach a stranger's: the route authorizes by the row's licenseId /
+    // hostDeviceId and answers 403 otherwise, and 204 (no write) for a row carrying a
+    // 'free:'/'apple:' id — which is what keeps an Apple purchase bridged to this desktop safe.
+    //
+    // RESIDUAL LEAK, deliberately not closed here: a pre-Task-12 pairing where the phone DID send
+    // its own id (every iOS build since 2026-07-10 does) has a row keyed by a value we never
+    // recorded, and the backend's 204 reveals nothing — so this reports 'ok' having asked about a
+    // row that is not that phone's, and the phone keeps Pro. The desktop cannot name that row at
+    // all; re-pairing the phone records its id (the phone's id is stable and the mint upserts on
+    // it), after which a removal revokes for real. Closing it properly needs a
+    // server-side "devices for this host" read, which does not exist yet.
+    //
     // Deliberately OUTSIDE the mutation chain: this is a network round trip, and holding the
     // agent.json/authorized_keys queue open for it would stall a concurrent pairing POST behind
     // an unreachable backend. No local state depends on the answer.
-    const server = relayId
+    const server = found
       ? await revokeRelayDevice(
           relayDeps?.apiBase ?? '',
-          relayId,
+          relayId ?? id,
           relayDeps?.getEntitlement() ?? null
         )
       : 'skipped'

--- a/src/main/pairing-service.ts
+++ b/src/main/pairing-service.ts
@@ -34,7 +34,7 @@ import {
   type PublicDevice,
   type RelayPairingBlock
 } from './pairing-core'
-import type { Settings } from '../shared/types'
+import type { DeviceRevokeResult, DeviceRevokeServerOutcome, Settings } from '../shared/types'
 import { publicKeyToB64, deriveSharedKey, encrypt, decrypt, type KeyPair } from './remote/e2ee'
 import { hostIdFromPublicKeyB64 } from './remote/relay-id'
 import { getDeviceId } from '../core/device-id'
@@ -114,6 +114,51 @@ async function mintRelayDevice(
   }
 }
 
+/** How long a revoke waits for the backend before calling it unreachable. */
+const REVOKE_TIMEOUT_MS = 8000
+
+/**
+ * Take a paired phone's Pro entitlement back. Until this existed, Remove was purely local — the
+ * peer key was unpinned and the socket cut, while the server kept minting Pro for that phone
+ * forever.
+ *
+ * Three outcomes, because two cannot tell the truth here:
+ *  - 'ok'      the route answered 204. It is deliberately idempotent and reveals nothing about
+ *              WHICH of its four cases applied (revoked it / unknown device / the row carries a
+ *              'free:'/'apple:' id so there was nothing of ours on it / already revoked) — all
+ *              four mean the phone holds no entitlement of ours, which is what we asked for.
+ *  - 'failed'  we asked and were refused (403 = someone else's row, 401 = the token did not
+ *              verify) or could not reach the server. The caller must NOT report a clean removal.
+ *  - 'skipped' we did not ask, and that is a normal state: a free-tier desktop holds no
+ *              entitlement to sign the request with (and has no Pro of ours on that phone to
+ *              reclaim), and a device paired before `relayDeviceId` existed has no row we can name.
+ *
+ * `relayDeviceId` is phone-supplied, unvalidated text, so it rides the JSON body — never a URL.
+ */
+export async function revokeRelayDevice(
+  apiBase: string,
+  relayDeviceId: string,
+  entitlement: string | null
+): Promise<DeviceRevokeServerOutcome> {
+  // Authorization for anything that moves a license is the signed entitlement, never a deviceId.
+  if (!entitlement || !relayDeviceId || !apiBase) return 'skipped'
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), REVOKE_TIMEOUT_MS)
+  try {
+    const res = await fetch(`${apiBase}/v1/relay/device/revoke`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ deviceId: relayDeviceId, entitlement }),
+      signal: ctrl.signal
+    })
+    return res.ok ? 'ok' : 'failed'
+  } catch {
+    return 'failed'
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 /**
  * Compute this host's relay reachability block WITHOUT any network call (just the host key →
  * hostId), so the QR renders instantly. Returns null (LAN-only) when phone access is off or
@@ -179,8 +224,13 @@ export interface PairingService {
   stop(): void
   /** All paired devices (token stripped) from ~/.nodeterm/agent.json. */
   listDevices(): Promise<PublicDevice[]>
-  /** Revoke a device: drop its agent.json entry AND delete its authorized_keys line. */
-  revokeDevice(id: string): Promise<void>
+  /**
+   * Revoke a device: drop its agent.json entry, delete its authorized_keys line, AND take its Pro
+   * entitlement back on the relay backend. The two legs are reported separately — see
+   * `DeviceRevokeResult`; this never throws, because a failure the caller cannot see is exactly
+   * how the server leg went missing in the first place.
+   */
+  revokeDevice(id: string): Promise<DeviceRevokeResult>
   /** Live re-probe of sshd (127.0.0.1:22), for the Remote Login warning's auto-clear. */
   probeSsh(): Promise<boolean>
 }
@@ -666,13 +716,38 @@ export function createPairingService(relayDeps?: PairingRelayDeps): PairingServi
   // device still listed — visible to its owner, with the Revoke button still there to finish the
   // job. The reverse order fails the other way: the device disappears from the list while its key
   // is still live, so the owner believes it revoked and has no way left to retry.
-  const revokeDevice = (id: string): Promise<void> =>
-    serialize(async () => {
-      await removeAuthorizedKeysForDevice(id)
-      const obj = await readAgentJson()
-      const devices = removeDevice(readDevices(obj), id)
-      await writeAgentJson({ ...obj, devices })
+  //
+  // The relay device id is read BEFORE either write and kept even when the local leg fails: the
+  // entitlement is what authorizes the server leg, not the local write's success, and a phone the
+  // user asked to remove should stop being minted Pro either way.
+  const revokeDevice = async (id: string): Promise<DeviceRevokeResult> => {
+    const { local, relayId } = await serialize(async () => {
+      const relayId = readDevices(await readAgentJson()).find((d) => d.id === id)?.relayDeviceId
+      try {
+        await removeAuthorizedKeysForDevice(id)
+        const obj = await readAgentJson()
+        const devices = removeDevice(readDevices(obj), id)
+        await writeAgentJson({ ...obj, devices })
+        return { local: true, relayId }
+      } catch (err) {
+        // Reported, not thrown: `local:false` is what the UI turns into "try again", and the
+        // server leg below is still worth running. The detail belongs in the log.
+        console.warn('[pairing] local revoke failed:', err)
+        return { local: false, relayId }
+      }
     })
+    // Deliberately OUTSIDE the mutation chain: this is a network round trip, and holding the
+    // agent.json/authorized_keys queue open for it would stall a concurrent pairing POST behind
+    // an unreachable backend. No local state depends on the answer.
+    const server = relayId
+      ? await revokeRelayDevice(
+          relayDeps?.apiBase ?? '',
+          relayId,
+          relayDeps?.getEntitlement() ?? null
+        )
+      : 'skipped'
+    return { local, server }
+  }
 
   return { start, stop, listDevices, revokeDevice, probeSsh }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -370,6 +370,8 @@ const api: NodeTerminalApi = {
     activate: (key: string) => ipcRenderer.invoke(IPC.licenseActivate, key),
     deactivate: () => ipcRenderer.invoke(IPC.licenseDeactivate),
     getStatus: () => ipcRenderer.invoke(IPC.licenseStatus),
+    detail: () => ipcRenderer.invoke(IPC.licenseDetail),
+    releaseOthers: () => ipcRenderer.invoke(IPC.licenseRelease),
     onChange: (listener) => {
       const handler = (_e: unknown, s: Parameters<typeof listener>[0]) => listener(s)
       ipcRenderer.on(IPC.licenseChanged, handler)

--- a/src/renderer/bridge/stubs.test.ts
+++ b/src/renderer/bridge/stubs.test.ts
@@ -72,6 +72,11 @@ describe('bridge stubs', () => {
     await expect(s.sessionMemory.read()).resolves.toEqual({ ok: false, rows: [], mem: null })
     await expect(s.sessionMemory.host()).resolves.toBeNull()
     await expect(s.license.getStatus()).rejects.toMatchObject({ code: E_UNSUPPORTED })
+    // The license layer runs only in src/main, so the key + device cap cannot be read here. These
+    // must REJECT rather than resolve a fabricated LicenseDetail — an `{used:0, seats:0}` with a
+    // null error would render "0 of 0 devices" and an empty key as fact in Settings → License.
+    await expect(s.license.detail()).rejects.toMatchObject({ code: E_UNSUPPORTED })
+    await expect(s.license.releaseOthers()).rejects.toMatchObject({ code: E_UNSUPPORTED })
   })
 
   it('shell.openExternal opens a new browser tab; reveal/openPath are documented no-ops', () => {

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -220,6 +220,10 @@ export function buildStubApi(): Omit<
       deactivate: U('license.deactivate'),
       // Renderer has no catch here and silently degrades to the free tier on rejection.
       getStatus: U('license.getStatus'),
+      // Server Edition has no license layer at all (initLicense runs only in src/main), so these
+      // reject rather than answer a fabricated "0 devices" — the same degrade as getStatus above.
+      detail: U('license.detail'),
+      releaseOthers: U('license.releaseOthers'),
       onChange: noopUnsub
     },
     contextLink: {

--- a/src/renderer/components/settings/sections/LicenseSection.test.tsx
+++ b/src/renderer/components/settings/sections/LicenseSection.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+//
+// Settings → License, rendered. The pure copy is pinned in `renderer/lib/licenseCopy.test.ts`; what
+// this file exists for is the wiring around it, where every defect in the final review round lived:
+// which sentence lands beside which data, what a destructive button does before it does it, and
+// whether a failed ACTION is reported as a failed READ.
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { LicenseDetail, LicenseStatus } from '@shared/types'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const PRO: LicenseStatus = { tier: 'pro', active: true, expiresAt: null, seats: 3, error: null }
+const FREE: LicenseStatus = { tier: null, active: false, expiresAt: null, seats: 0, error: null }
+/** A healthy keygen read with room to spare. */
+const KEYGEN: LicenseDetail = { key: 'NT-KEY-1', used: 2, seats: 3, source: 'keygen', error: null }
+
+let root: Root
+let host: HTMLElement
+let detail: Mock<() => Promise<LicenseDetail>>
+let releaseOthers: Mock<() => Promise<LicenseDetail>>
+let deactivate: Mock<() => Promise<LicenseStatus>>
+let activate: Mock<(key: string) => Promise<LicenseStatus>>
+let writeText: Mock<(text: string) => void>
+
+/**
+ * The store subscribes to `license.onChange` at IMPORT time, so the bridge has to exist before the
+ * module graph does — hence the reset + dynamic import, the same shape as `entitlement.test.ts`.
+ * Returns the section already mounted with `status` applied, so the mount-time `loadDetail` effect
+ * runs exactly as it does in the app.
+ */
+async function mount(status: LicenseStatus, read: LicenseDetail = KEYGEN): Promise<void> {
+  vi.resetModules()
+  detail = vi.fn(async () => read)
+  releaseOthers = vi.fn(async () => ({ key: null, used: 1, seats: 3, source: null, error: null }))
+  deactivate = vi.fn(async () => FREE)
+  activate = vi.fn(async () => FREE)
+  writeText = vi.fn()
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+    license: {
+      getStatus: vi.fn(async () => status),
+      onChange: vi.fn(() => () => undefined),
+      // Indirected so a test can swap the resolved value AFTER mounting (the store captured the
+      // bridge object at import time, not these mocks).
+      detail: () => detail(),
+      releaseOthers: () => releaseOthers(),
+      deactivate,
+      activate,
+      upgrade: vi.fn(async () => status)
+    },
+    clipboard: { writeText }
+  }
+  const { useEntitlement } = await import('../../../state/entitlement')
+  const { LicenseSection } = await import('./LicenseSection')
+  await act(async () => {
+    await useEntitlement.getState().hydrate()
+  })
+  await act(async () => {
+    root.render(<LicenseSection isActive />)
+  })
+  await act(async () => undefined) // the mount-time detail read
+}
+
+/** Everything on screen, the portalled dialogs included. */
+function screenText(): string {
+  return document.body.textContent ?? ''
+}
+
+function click(label: string, from: ParentNode = document.body): void {
+  const el = [...from.querySelectorAll('button')].find((b) => b.textContent?.trim() === label)
+  expect(el, `a rendered "${label}" button`).toBeTruthy()
+  ;(el as HTMLButtonElement).click()
+}
+
+/** The confirm dialog's own button, which portals onto body after everything else. */
+function confirmDialog(label: string): void {
+  const all = [...document.body.querySelectorAll('.confirm button')].filter(
+    (b) => b.textContent?.trim() === label
+  )
+  expect(all.length, `a "${label}" button inside the confirm dialog`).toBeGreaterThan(0)
+  ;(all[all.length - 1] as HTMLButtonElement).click()
+}
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('LicenseSection — a release that did not land', () => {
+  it('reports the RELEASE, and keeps saying the truth about the license', async () => {
+    await mount(PRO)
+    expect(screenText()).toContain('2 of 3 devices in use')
+
+    // The laptop lost wifi between opening Settings and pressing the button.
+    releaseOthers.mockResolvedValue({ key: null, used: 0, seats: 0, source: null, error: 'offline' })
+    await act(async () => click('Release other devices'))
+    await act(async () => confirmDialog('Release others'))
+    await act(async () => undefined)
+
+    const text = screenText()
+    // 1. The user is told about the thing they just pressed…
+    expect(text).toMatch(/Could not confirm the release/)
+    // …including that it may in fact have happened. "Nothing was changed" here sends them to a
+    // retry that hits the 30-day throttle with their one release already spent.
+    expect(text).toMatch(/may or may not/)
+    // 2. …and is told nothing FALSE about the license. This is the shipped bug: the offline code
+    // was merged onto `detail`, so the device-count line was replaced by "Could not read this
+    // license right now" while the real key sat in the box directly above it.
+    expect(text).not.toMatch(/Could not read this license/)
+    expect(text).toContain('2 of 3 devices in use')
+    expect((document.querySelector('input[readonly]') as HTMLInputElement).value).toBe('NT-KEY-1')
+    // 3. …and the button is usable again, not stuck on "Releasing…".
+    expect(text).toContain('Release other devices')
+  })
+
+  it('leaves the throttle refusal to the license sentence, with no second voice', async () => {
+    await mount(PRO)
+    releaseOthers.mockResolvedValue({
+      key: null,
+      used: 0,
+      seats: 0,
+      source: null,
+      error: 'too_soon',
+      retryAfterDays: 12
+    })
+    await act(async () => click('Release other devices'))
+    await act(async () => confirmDialog('Release others'))
+    await act(async () => undefined)
+
+    const text = screenText()
+    expect(text).toContain('You can release devices again in 12 days.')
+    // The refusal rides `detail`; a release note beside it would print the same fact twice in two
+    // different wordings.
+    expect(text).not.toMatch(/Could not confirm the release/)
+    expect(text).not.toMatch(/Could not release the other devices/)
+  })
+
+  it('clears the last failure when the release is tried again', async () => {
+    await mount(PRO)
+    releaseOthers.mockResolvedValue({ key: null, used: 0, seats: 0, source: null, error: 'offline' })
+    await act(async () => click('Release other devices'))
+    await act(async () => confirmDialog('Release others'))
+    await act(async () => undefined)
+    expect(screenText()).toMatch(/Could not confirm the release/)
+
+    releaseOthers.mockResolvedValue({ key: null, used: 1, seats: 3, source: null, error: null })
+    await act(async () => click('Release other devices'))
+    await act(async () => confirmDialog('Release others'))
+    await act(async () => undefined)
+
+    // A stale warning over a release that just worked is its own false statement.
+    expect(screenText()).not.toMatch(/Could not confirm the release/)
+    expect(screenText()).toContain('1 of 3 devices in use')
+  })
+})
+
+describe('LicenseSection — confirming the destructive actions', () => {
+  it('does not release anything until the user confirms, and says what will be released', async () => {
+    await mount(PRO)
+    await act(async () => click('Release other devices'))
+
+    // One click used to deactivate every other machine AND every paired phone, irreversibly for
+    // 30 days, with nothing on screen saying so beforehand.
+    expect(releaseOthers).not.toHaveBeenCalled()
+    const dialog = screenText()
+    expect(dialog).toMatch(/paired phone/)
+    expect(dialog).toMatch(/once every 30 days/)
+    expect(dialog).toMatch(/this Mac keeps it/)
+
+    await act(async () => confirmDialog('Cancel'))
+    expect(releaseOthers).not.toHaveBeenCalled()
+    expect(screenText()).not.toMatch(/once every 30 days/)
+
+    await act(async () => click('Release other devices'))
+    await act(async () => confirmDialog('Release others'))
+    await act(async () => undefined)
+    expect(releaseOthers).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns to copy the key before deactivating, and deactivates only on confirm', async () => {
+    await mount(PRO)
+    await act(async () => click('Deactivate on this device'))
+
+    // After deactivating, the detail read has no entitlement to authorize it — the key is
+    // unrecoverable in-app, which is exactly the support queue this screen exists to end.
+    expect(deactivate).not.toHaveBeenCalled()
+    expect(screenText()).toMatch(/Copy your license key first/)
+
+    await act(async () => confirmDialog('Deactivate'))
+    expect(deactivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not tell a license with no key to copy one', async () => {
+    // An App Store entitlement: nothing to copy, so that sentence would be nonsense.
+    await mount(PRO, { key: null, used: 0, seats: 0, source: 'apple', error: null })
+    await act(async () => click('Deactivate on this device'))
+
+    expect(screenText()).not.toMatch(/Copy your license key first/)
+    expect(screenText()).toMatch(/Pro features stop here/)
+  })
+})
+
+describe('LicenseSection — the key field and the paste-elsewhere line', () => {
+  it('copies through the app clipboard channel and says it copied', async () => {
+    await mount(PRO)
+    await act(async () => click('Copy'))
+
+    expect(writeText).toHaveBeenCalledWith('NT-KEY-1')
+    expect(screenText()).toContain('Copied')
+  })
+
+  it('offers no key field at all when the stated source has none', async () => {
+    await mount(PRO, { key: null, used: 0, seats: 0, source: 'apple', error: null })
+
+    const text = screenText()
+    // "not available" means "exists, could not be fetched" — beside a sentence that says there is
+    // no key at all, the two halves of the first screen an App Store subscriber sees disagree.
+    expect(text).not.toContain('not available')
+    expect(text).not.toContain('License key')
+    expect(document.querySelector('input[readonly]')).toBeNull()
+    expect(text).toContain('comes from the App Store subscription on your paired phone')
+  })
+
+  it('stops inviting the user to paste the key elsewhere once the cap is full', async () => {
+    await mount(PRO, { ...KEYGEN, used: 3, seats: 3 })
+
+    const text = screenText()
+    expect(text).toContain('All 3 devices are in use.')
+    // The line used to render on `detail.key` alone — directly under that sentence. Following it
+    // lands the user on `seat_limit` on the other Mac, which is where this whole task started.
+    expect(text).not.toMatch(/paste this key/)
+    // The key itself is still shown and copyable; it is the ADVICE that is wrong here.
+    expect((document.querySelector('input[readonly]') as HTMLInputElement).value).toBe('NT-KEY-1')
+  })
+
+  it('still invites it while there is room', async () => {
+    await mount(PRO)
+    expect(screenText()).toMatch(/paste this key/)
+  })
+})
+
+describe('LicenseSection — activation failures', () => {
+  it('renders seat_limit as a way out, never as a code', async () => {
+    await mount({ ...FREE, error: 'seat_limit' })
+
+    const text = screenText()
+    expect(text).not.toContain('seat_limit')
+    expect(text).toContain('This license already has all its devices in use.')
+    expect(text).toMatch(/Release other devices/)
+  })
+
+  it('renders an unknown reason as an apology with an action, not as a code', async () => {
+    await mount({ ...FREE, error: 'gremlins' })
+
+    const text = screenText()
+    expect(text).not.toContain('gremlins')
+    expect(text).toContain('Could not activate this key.')
+  })
+})

--- a/src/renderer/components/settings/sections/LicenseSection.tsx
+++ b/src/renderer/components/settings/sections/LicenseSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useEntitlement } from '../../../state/entitlement'
 import { SettingsSection } from '../SettingsSection'
 import { SearchableRow } from '../SearchableRow'
@@ -6,6 +6,7 @@ import { FieldRow } from '../FieldRow'
 import { ProCompare } from './ProCompare'
 import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
+import { licenseSentence, canReleaseDevices } from '@renderer/lib/licenseCopy'
 
 const ROWS = {
   license: {
@@ -20,7 +21,11 @@ const ROWS = {
       'compare',
       'core',
       'remote access',
-      'quota'
+      'quota',
+      'devices',
+      'seats',
+      'release',
+      'copy key'
     ]
   }
 }
@@ -30,6 +35,22 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
   const ent = useEntitlement()
   const [licenseKey, setLicenseKey] = useState('')
   const [upgrading, setUpgrading] = useState(false)
+  const [releasing, setReleasing] = useState(false)
+  const [releaseFailed, setReleaseFailed] = useState(false)
+  // `loadDetail` REJECTS on the Server Edition (`E_UNSUPPORTED` — there is no license layer in
+  // src/server), and the store deliberately does not swallow it. Catching here is not optional:
+  // uncaught, this is an unhandled rejection on every browser session. And what we show there is
+  // NOTHING — a read that could not run is not "no key, 0 devices".
+  const [detailUnavailable, setDetailUnavailable] = useState(false)
+  useEffect(() => {
+    if (!ent.isPremium) return
+    void ent.loadDetail().catch(() => setDetailUnavailable(true))
+    // `ent.loadDetail` is a stable zustand action; the entitlement becoming premium is the event.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ent.isPremium])
+
+  const detail = detailUnavailable ? null : ent.detail
+  const sentence = licenseSentence(detail)
   return (
     <SettingsSection
       id="license"
@@ -49,6 +70,61 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
                 : ''}
               .
             </p>
+            {detail ? (
+              <>
+                <FieldRow
+                  label="License key"
+                  control={
+                    <div className="flex items-center gap-2">
+                      <Input
+                        className="w-64"
+                        readOnly
+                        value={detail.key ?? ''}
+                        placeholder={detail.key ? undefined : 'not available'}
+                      />
+                      <Button
+                        disabled={!detail.key}
+                        onClick={() => {
+                          if (detail.key) void navigator.clipboard.writeText(detail.key)
+                        }}
+                      >
+                        Copy
+                      </Button>
+                    </div>
+                  }
+                />
+                {sentence ? <p className="text-sm text-muted">{sentence}</p> : null}
+                {detail.key ? (
+                  <p className="text-sm text-muted">
+                    To use Pro on another Mac, open Settings → License there and paste this key.
+                  </p>
+                ) : null}
+                {canReleaseDevices(detail) ? (
+                  <div className="space-y-2">
+                    <Button
+                      disabled={releasing}
+                      onClick={() => {
+                        setReleasing(true)
+                        setReleaseFailed(false)
+                        void ent
+                          .releaseOthers()
+                          // Same uncaught-rejection rule as `loadDetail` above — plus an ordinary
+                          // IPC failure here would otherwise leave the button stuck on "Releasing…".
+                          .catch(() => setReleaseFailed(true))
+                          .finally(() => setReleasing(false))
+                      }}
+                    >
+                      {releasing ? 'Releasing…' : 'Release other devices'}
+                    </Button>
+                    {releaseFailed ? (
+                      <p className="text-sm" style={{ color: '#ff9f0a' }}>
+                        Could not release the other devices. Nothing was changed.
+                      </p>
+                    ) : null}
+                  </div>
+                ) : null}
+              </>
+            ) : null}
             <Button onClick={() => void ent.deactivate()}>Deactivate on this device</Button>
           </div>
         ) : (

--- a/src/renderer/components/settings/sections/LicenseSection.tsx
+++ b/src/renderer/components/settings/sections/LicenseSection.tsx
@@ -3,10 +3,20 @@ import { useEntitlement } from '../../../state/entitlement'
 import { SettingsSection } from '../SettingsSection'
 import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
+import { ConfirmDialog } from '../../ConfirmDialog'
 import { ProCompare } from './ProCompare'
 import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
-import { licenseSentence, canReleaseDevices } from '@renderer/lib/licenseCopy'
+import {
+  licenseSentence,
+  canReleaseDevices,
+  canUseKeyElsewhere,
+  releaseFailureSentence,
+  activationErrorSentence
+} from '@renderer/lib/licenseCopy'
+
+/** How long the Copy button reports success before returning to its label. */
+const COPIED_MS = 1600
 
 const ROWS = {
   license: {
@@ -36,7 +46,12 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
   const [licenseKey, setLicenseKey] = useState('')
   const [upgrading, setUpgrading] = useState(false)
   const [releasing, setReleasing] = useState(false)
-  const [releaseFailed, setReleaseFailed] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [confirming, setConfirming] = useState<'release' | 'deactivate' | null>(null)
+  // The reason code of a release that did not land — NOT a boolean, and NOT merged into `detail`:
+  // "offline" and "this Mac is not authorized" owe the user different sentences, and neither of
+  // them is a statement about the license the panel is displaying. See `releaseFailureSentence`.
+  const [releaseError, setReleaseError] = useState<string | null>(null)
   // `loadDetail` REJECTS on the Server Edition (`E_UNSUPPORTED` — there is no license layer in
   // src/server), and the store deliberately does not swallow it. Catching here is not optional:
   // uncaught, this is an unhandled rejection on every browser session. And what we show there is
@@ -49,8 +64,44 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ent.isPremium])
 
+  // The receipt yields to a clipboard FAILURE. Only the browser build can fail (the desktop
+  // preload writes synchronously and cannot), and it reports that as a `nodeterm:toast` error
+  // banner — a green "Copied" beside a red banner is the app contradicting itself in one glance.
+  // Same rule as the terminal's copy pill (`terminal/useCopyFeedback.ts`).
+  useEffect(() => {
+    if (!copied) return
+    const timer = setTimeout(() => setCopied(false), COPIED_MS)
+    const onToast = (e: Event): void => {
+      if ((e as CustomEvent<{ kind?: string }>).detail?.kind === 'error') setCopied(false)
+    }
+    window.addEventListener('nodeterm:toast', onToast)
+    return () => {
+      clearTimeout(timer)
+      window.removeEventListener('nodeterm:toast', onToast)
+    }
+  }, [copied])
+
   const detail = detailUnavailable ? null : ent.detail
   const sentence = licenseSentence(detail)
+  const releaseNote = releaseFailureSentence(releaseError)
+  // Read out here, not off `detail` inside the click handler: TypeScript drops a property
+  // narrowing at a closure boundary, and the key must not be re-read at click time anyway.
+  const keyOnFile = detail?.key ?? null
+
+  const runRelease = (): void => {
+    setConfirming(null)
+    setReleasing(true)
+    setReleaseError(null)
+    void ent
+      .releaseOthers()
+      // Resolves to null when the release landed (or was refused on terms the sentence above
+      // already carries), else the reason code. Same uncaught-rejection rule as `loadDetail` —
+      // plus an IPC failure here would otherwise leave the button stuck on "Releasing…". A
+      // rejection is not a code, so it takes the "we do not know what happened" branch.
+      .then((code) => setReleaseError(code))
+      .catch(() => setReleaseError('unknown'))
+      .finally(() => setReleasing(false))
+  }
   return (
     <SettingsSection
       id="license"
@@ -72,60 +123,52 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
             </p>
             {detail ? (
               <>
-                <FieldRow
-                  label="License key"
-                  control={
-                    <div className="flex items-center gap-2">
-                      <Input
-                        className="w-64"
-                        readOnly
-                        value={detail.key ?? ''}
-                        placeholder={detail.key ? undefined : 'not available'}
-                      />
-                      <Button
-                        disabled={!detail.key}
-                        onClick={() => {
-                          if (detail.key) void navigator.clipboard.writeText(detail.key)
-                        }}
-                      >
-                        Copy
-                      </Button>
-                    </div>
-                  }
-                />
+                {/* No key ⇒ no field. A row reading "not available" beside a sentence saying there
+                    IS no key (an App Store subscription, a failed read) contradicts itself on the
+                    first screen those users ever see — "not available" means "exists, could not be
+                    fetched". The sentence below is the whole story in every keyless case. */}
+                {keyOnFile ? (
+                  <FieldRow
+                    label="License key"
+                    control={
+                      <div className="flex items-center gap-2">
+                        <Input className="w-64" readOnly value={keyOnFile} />
+                        <Button
+                          onClick={() => {
+                            // The app's own clipboard channel, not `navigator.clipboard`: it
+                            // returns void (no unhandled rejection) and the browser bridge raises
+                            // its own error banner when a copy cannot happen.
+                            window.nodeTerminal.clipboard.writeText(keyOnFile)
+                            setCopied(true)
+                          }}
+                        >
+                          {copied ? 'Copied' : 'Copy'}
+                        </Button>
+                      </div>
+                    }
+                  />
+                ) : null}
                 {sentence ? <p className="text-sm text-muted">{sentence}</p> : null}
-                {detail.key ? (
+                {canUseKeyElsewhere(detail) ? (
                   <p className="text-sm text-muted">
                     To use Pro on another Mac, open Settings → License there and paste this key.
                   </p>
                 ) : null}
                 {canReleaseDevices(detail) ? (
                   <div className="space-y-2">
-                    <Button
-                      disabled={releasing}
-                      onClick={() => {
-                        setReleasing(true)
-                        setReleaseFailed(false)
-                        void ent
-                          .releaseOthers()
-                          // Same uncaught-rejection rule as `loadDetail` above — plus an ordinary
-                          // IPC failure here would otherwise leave the button stuck on "Releasing…".
-                          .catch(() => setReleaseFailed(true))
-                          .finally(() => setReleasing(false))
-                      }}
-                    >
+                    <Button disabled={releasing} onClick={() => setConfirming('release')}>
                       {releasing ? 'Releasing…' : 'Release other devices'}
                     </Button>
-                    {releaseFailed ? (
+                    {releaseNote ? (
                       <p className="text-sm" style={{ color: '#ff9f0a' }}>
-                        Could not release the other devices. Nothing was changed.
+                        {releaseNote}
                       </p>
                     ) : null}
                   </div>
                 ) : null}
               </>
             ) : null}
-            <Button onClick={() => void ent.deactivate()}>Deactivate on this device</Button>
+            <Button onClick={() => setConfirming('deactivate')}>Deactivate on this device</Button>
           </div>
         ) : (
           <div className="space-y-3">
@@ -165,9 +208,12 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
                 >
                   Activate
                 </Button>
+                {/* The server's reason code is never rendered raw. A buyer at the device cap is
+                    exactly who this screen exists for, and `Could not activate (seat_limit).` is
+                    a dead end: the word is unsearchable and names no way out. */}
                 {ent.status.error ? (
                   <p className="text-sm" style={{ color: '#ff9f0a' }}>
-                    Could not activate ({ent.status.error}).
+                    {activationErrorSentence(ent.status.error)}
                   </p>
                 ) : null}
               </div>
@@ -175,6 +221,35 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
           </div>
         )}
       </SearchableRow>
+
+      {/* Both actions are destructive, one-click and hard to undo, so both are confirmed — the
+          house pattern (a single phone revoke gets a ConfirmDialog; these are larger). */}
+      {confirming === 'release' ? (
+        <ConfirmDialog
+          message="Release every other device on this license? Your other Macs and every paired phone lose Pro until they are activated again — this Mac keeps it. Devices can only be released once every 30 days."
+          confirmLabel="Release others"
+          onConfirm={runRelease}
+          onCancel={() => setConfirming(null)}
+        />
+      ) : null}
+      {confirming === 'deactivate' ? (
+        <ConfirmDialog
+          // Deactivating clears the stored entitlement, and with it the only in-app copy of the
+          // key: the detail read that produced it needs that entitlement to authorize. Without
+          // this sentence the buyer is back in the support queue this whole screen exists to end.
+          message={
+            keyOnFile
+              ? 'Deactivate Pro on this Mac? Copy your license key first — it is shown here only while Pro is active, and you need it to activate again.'
+              : 'Deactivate Pro on this Mac? Pro features stop here until this device is activated again.'
+          }
+          confirmLabel="Deactivate"
+          onConfirm={() => {
+            setConfirming(null)
+            void ent.deactivate()
+          }}
+          onCancel={() => setConfirming(null)}
+        />
+      ) : null}
     </SettingsSection>
   )
 }

--- a/src/renderer/components/settings/sections/PhoneSection.revoke.test.tsx
+++ b/src/renderer/components/settings/sections/PhoneSection.revoke.test.tsx
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
 //
-// Settings → Phone, the Revoke button: which of the three revoke outcomes the user is TOLD about.
-// The rule is asymmetric on purpose — 'skipped' is a normal state (a free-tier desktop holds no
-// entitlement to revoke with, and a phone paired before we recorded its relay id has no row we can
-// name), so warning there would tell a free user their phone's Pro is stuck when it never had any.
+// Settings → Phone, the Revoke button: which of the three revoke outcomes the user is TOLD about,
+// and in which voice.
+//   'skipped' → nothing. It is a normal state: a free-tier desktop holds no entitlement to revoke
+//               with, or there was no device left to name. Warning there would tell a free user
+//               their phone's Pro is stuck when it never had any of ours. (A phone paired before
+//               we recorded its relay id is NOT this case — the revoke falls back to our own
+//               pairing id and the server leg does run.)
+//   'ok'      → a receipt, not silence: the phone keeps the pass it already holds for up to 7
+//               days, and users who were told nothing filed that as "removal didn't work".
+//   'failed'  → a warning that does not prescribe waiting, because a 403 never clears by waiting.
 // Only a leg that actually failed may warn, and a failed one always must.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { act } from 'react'
@@ -102,16 +108,22 @@ describe('PhoneSection revoke feedback', () => {
     expect(revokeDevice).toHaveBeenCalledWith('dev-a')
     expect(text).not.toMatch(/Pro access/i)
     expect(text).not.toMatch(/try again/i)
+    // Nor the 7-day receipt: there was no Pro of ours on that phone, so there is nothing that
+    // ends in 7 days. An implementation that prints the receipt for every non-failure passes the
+    // two assertions above.
+    expect(text).not.toMatch(/7 days/i)
   })
 
-  it('says nothing on a clean revoke', async () => {
+  it('says WHEN the phone actually loses Pro on a clean revoke — removal is not instant', async () => {
     stubBridge({ local: true, server: 'ok' })
     mount()
     await act(async () => undefined)
 
     const text = await revokeFlow()
-    expect(text).not.toMatch(/Pro access/i)
+    expect(text).toMatch(/within 7 days/i)
+    // A receipt, not a warning: nothing here asks the user to do anything.
     expect(text).not.toMatch(/try again/i)
+    expect(text).not.toMatch(/Couldn’t/i)
   })
 
   it('warns that the phone kept its Pro when the server leg failed', async () => {
@@ -121,7 +133,12 @@ describe('PhoneSection revoke feedback', () => {
 
     const text = await revokeFlow()
     expect(text).toMatch(/Pro access/i)
-    expect(text).toMatch(/try again/i)
+    // 'failed' also covers a 403 ("not your row") and a 401, which no amount of waiting fixes —
+    // so the copy must not promise that being back online is the fix.
+    expect(text).not.toMatch(/back online/i)
+    // And the retry it does offer must disclose its cost: pairing the phone again RESTORES its Pro.
+    expect(text).toMatch(/pairing restores its Pro/i)
+    expect(text).toMatch(/get in touch/i)
   })
 
   it('warns about the local removal when that is the leg that failed', async () => {

--- a/src/renderer/components/settings/sections/PhoneSection.revoke.test.tsx
+++ b/src/renderer/components/settings/sections/PhoneSection.revoke.test.tsx
@@ -25,10 +25,16 @@ let root: Root
 let host: HTMLElement
 let revokeDevice: ReturnType<typeof vi.fn>
 
-/** The narrow slice of `window.nodeTerminal` this section touches on mount + revoke. */
+/**
+ * The narrow slice of `window.nodeTerminal` this section touches on mount + revoke. A successful
+ * local leg really does empty the list (the ordinary case: one paired phone), because that is what
+ * the note has to survive — it renders beside a list that no longer has a row.
+ */
 function stubBridge(result: DeviceRevokeResult | Error): void {
+  let devices: PairedDevice[] = [DEVICE]
   revokeDevice = vi.fn(async () => {
     if (result instanceof Error) throw result
+    if (result.local) devices = []
     return result
   })
   ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
@@ -38,7 +44,7 @@ function stubBridge(result: DeviceRevokeResult | Error): void {
       onDone: vi.fn(() => () => undefined),
       probeSsh: vi.fn(async () => true),
       openRemoteLoginSettings: vi.fn(),
-      listDevices: vi.fn(async () => [DEVICE]),
+      listDevices: vi.fn(async () => devices),
       revokeDevice
     },
     remoteHost: { setPhoneAccess: vi.fn() },
@@ -129,6 +135,32 @@ describe('PhoneSection revoke feedback', () => {
     expect(text).toMatch(/remove/i)
     expect(text).toMatch(/try again/i)
     expect(text).not.toMatch(/Pro access/i)
+  })
+
+  // The ordinary case is ONE paired phone, so the successful local leg empties the list — and the
+  // warning has to outlive it. A note rendered inside the list's non-empty branch would vanish at
+  // exactly the moment it is needed.
+  it('keeps the server warning visible after the last device leaves the list', async () => {
+    stubBridge({ local: true, server: 'failed' })
+    mount()
+    await act(async () => undefined)
+
+    const text = await revokeFlow()
+    expect(text).toContain('No devices paired yet')
+    expect(text).toMatch(/Pro access/i)
+  })
+
+  it('reports BOTH legs when both fail', async () => {
+    stubBridge({ local: false, server: 'failed' })
+    mount()
+    await act(async () => undefined)
+
+    const text = await revokeFlow()
+    expect(text).toMatch(/Couldn’t remove/i)
+    expect(text).toMatch(/Pro access/i)
+    // The device is still on this machine, so the "Removed … from this machine" clause must not
+    // appear beside the failure that says it was not removed.
+    expect(text).not.toMatch(/Removed “/)
   })
 
   it('warns when the call itself never answered', async () => {

--- a/src/renderer/components/settings/sections/PhoneSection.revoke.test.tsx
+++ b/src/renderer/components/settings/sections/PhoneSection.revoke.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+//
+// Settings → Phone, the Revoke button: which of the three revoke outcomes the user is TOLD about.
+// The rule is asymmetric on purpose — 'skipped' is a normal state (a free-tier desktop holds no
+// entitlement to revoke with, and a phone paired before we recorded its relay id has no row we can
+// name), so warning there would tell a free user their phone's Pro is stuck when it never had any.
+// Only a leg that actually failed may warn, and a failed one always must.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { DeviceRevokeResult, PairedDevice } from '@shared/types'
+import { PhoneSection } from './PhoneSection'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const DEVICE: PairedDevice = {
+  id: 'dev-a',
+  name: 'Enes’ iPhone',
+  pairedAt: 1_700_000_000_000,
+  lastSeenAt: 0,
+  relayDeviceId: 'phone-relay-1'
+}
+
+let root: Root
+let host: HTMLElement
+let revokeDevice: ReturnType<typeof vi.fn>
+
+/** The narrow slice of `window.nodeTerminal` this section touches on mount + revoke. */
+function stubBridge(result: DeviceRevokeResult | Error): void {
+  revokeDevice = vi.fn(async () => {
+    if (result instanceof Error) throw result
+    return result
+  })
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+    pairing: {
+      start: vi.fn(),
+      stop: vi.fn(async () => undefined),
+      onDone: vi.fn(() => () => undefined),
+      probeSsh: vi.fn(async () => true),
+      openRemoteLoginSettings: vi.fn(),
+      listDevices: vi.fn(async () => [DEVICE]),
+      revokeDevice
+    },
+    remoteHost: { setPhoneAccess: vi.fn() },
+    shell: { openExternal: vi.fn() }
+  }
+}
+
+function button(label: string): HTMLButtonElement {
+  const el = [...document.body.querySelectorAll('button')].find(
+    (b) => b.textContent?.trim() === label
+  )
+  expect(el, `a rendered "${label}" button`).toBeTruthy()
+  return el as HTMLButtonElement
+}
+
+/** Click Revoke → confirm → let the (async) revoke settle. Returns the section's visible text. */
+async function revokeFlow(): Promise<string> {
+  await act(async () => {
+    button('Revoke').click()
+  })
+  await act(async () => {
+    // The ConfirmDialog's own confirm button carries the same label; it portals onto body last.
+    const confirms = [...document.body.querySelectorAll('button')].filter(
+      (b) => b.textContent?.trim() === 'Revoke'
+    )
+    confirms[confirms.length - 1].click()
+  })
+  await act(async () => undefined)
+  return host.textContent ?? ''
+}
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.restoreAllMocks()
+})
+
+function mount(): void {
+  act(() => root.render(<PhoneSection isActive />))
+}
+
+describe('PhoneSection revoke feedback', () => {
+  it('says nothing when the server leg was skipped — there was nothing of ours to revoke', async () => {
+    stubBridge({ local: true, server: 'skipped' })
+    mount()
+    await act(async () => undefined) // the mount-time listDevices
+
+    const text = await revokeFlow()
+    expect(revokeDevice).toHaveBeenCalledWith('dev-a')
+    expect(text).not.toMatch(/Pro access/i)
+    expect(text).not.toMatch(/try again/i)
+  })
+
+  it('says nothing on a clean revoke', async () => {
+    stubBridge({ local: true, server: 'ok' })
+    mount()
+    await act(async () => undefined)
+
+    const text = await revokeFlow()
+    expect(text).not.toMatch(/Pro access/i)
+    expect(text).not.toMatch(/try again/i)
+  })
+
+  it('warns that the phone kept its Pro when the server leg failed', async () => {
+    stubBridge({ local: true, server: 'failed' })
+    mount()
+    await act(async () => undefined)
+
+    const text = await revokeFlow()
+    expect(text).toMatch(/Pro access/i)
+    expect(text).toMatch(/try again/i)
+  })
+
+  it('warns about the local removal when that is the leg that failed', async () => {
+    stubBridge({ local: false, server: 'ok' })
+    mount()
+    await act(async () => undefined)
+
+    const text = await revokeFlow()
+    // The device is still on this machine — saying "its Pro could not be revoked" would be a
+    // different (and here untrue) story.
+    expect(text).toMatch(/remove/i)
+    expect(text).toMatch(/try again/i)
+    expect(text).not.toMatch(/Pro access/i)
+  })
+
+  it('warns when the call itself never answered', async () => {
+    stubBridge(new Error('E_UNSUPPORTED'))
+    mount()
+    await act(async () => undefined)
+
+    const text = await revokeFlow()
+    expect(text).toMatch(/try again/i)
+  })
+})

--- a/src/renderer/components/settings/sections/PhoneSection.tsx
+++ b/src/renderer/components/settings/sections/PhoneSection.tsx
@@ -86,17 +86,24 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
     setRevokeNote('')
     try {
       const result = await window.nodeTerminal.pairing.revokeDevice(device.id)
+      // Additive, not exclusive: both legs can fail at once (an unwritable ~/.ssh while offline),
+      // and being told only half of that leaves the other half to be discovered by accident.
+      const notes: string[] = []
       if (!result.local) {
-        setRevokeNote(`Couldn’t remove “${device.name}” from this machine — try again.`)
-      } else if (result.server === 'failed') {
-        // Not "try again" on its own: the row is already gone from the list, so there is no button
-        // left to press. Name the one thing that does re-run the server leg.
-        setRevokeNote(
-          `Removed “${device.name}” from this machine, but its Pro access couldn’t be revoked, ` +
-            'so that phone may keep Pro. Once this machine is back online, pair it and remove it ' +
-            'again to try again.'
+        notes.push(`Couldn’t remove “${device.name}” from this machine — try again.`)
+      }
+      if (result.server === 'failed') {
+        // Not a bare "try again": on a successful local removal the row is already gone from the
+        // list, so there is no button left to press. Name the one thing that does re-run the
+        // server leg — the phone sends the same stable device id every time it pairs, and the
+        // backend upserts the row on that id, so pairing again makes the next Revoke land.
+        notes.push(
+          (result.local ? `Removed “${device.name}” from this machine, but its` : 'Its') +
+            ' Pro access couldn’t be revoked, so that phone may keep Pro. Once this machine is' +
+            ' back online, pair it and remove it again to try again.'
         )
       }
+      setRevokeNote(notes.join(' '))
     } catch {
       // The call itself never got an answer (main is gone, or the surface doesn't support it).
       setRevokeNote(`Couldn’t remove “${device.name}” — try again.`)

--- a/src/renderer/components/settings/sections/PhoneSection.tsx
+++ b/src/renderer/components/settings/sections/PhoneSection.tsx
@@ -41,6 +41,7 @@ const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Element {
   const [devices, setDevices] = useState<PairedDevice[]>([])
   const [pendingRevoke, setPendingRevoke] = useState<PairedDevice | null>(null)
+  const [revokeNote, setRevokeNote] = useState('')
 
   const phoneAccessEnabled = useSettings((s) => s.settings.phoneAccessEnabled)
   const updateSettings = useSettings((s) => s.update)
@@ -75,10 +76,30 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
     void refreshDevices()
   }, [refreshDevices])
 
+  // Removing local access and taking the phone's Pro back are DIFFERENT facts, and the second one
+  // used to be missing entirely — Remove unpinned the key here while the server kept minting Pro
+  // for that phone forever. So both legs are surfaced, and only a leg that actually FAILED warns:
+  // 'skipped' means we had nothing to revoke (a free-tier desktop, or a device paired before we
+  // recorded the phone's relay id), and warning there would tell a free user their phone is stuck.
   const revokeDevice = async (device: PairedDevice): Promise<void> => {
     setPendingRevoke(null)
+    setRevokeNote('')
     try {
-      await window.nodeTerminal.pairing.revokeDevice(device.id)
+      const result = await window.nodeTerminal.pairing.revokeDevice(device.id)
+      if (!result.local) {
+        setRevokeNote(`Couldn’t remove “${device.name}” from this machine — try again.`)
+      } else if (result.server === 'failed') {
+        // Not "try again" on its own: the row is already gone from the list, so there is no button
+        // left to press. Name the one thing that does re-run the server leg.
+        setRevokeNote(
+          `Removed “${device.name}” from this machine, but its Pro access couldn’t be revoked, ` +
+            'so that phone may keep Pro. Once this machine is back online, pair it and remove it ' +
+            'again to try again.'
+        )
+      }
+    } catch {
+      // The call itself never got an answer (main is gone, or the surface doesn't support it).
+      setRevokeNote(`Couldn’t remove “${device.name}” — try again.`)
     } finally {
       void refreshDevices()
     }
@@ -260,6 +281,11 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
               ))}
             </ul>
           )}
+          {revokeNote ? (
+            <p className="text-sm" style={{ color: '#ff9f0a' }}>
+              {revokeNote}
+            </p>
+          ) : null}
         </div>
       </SearchableRow>
 

--- a/src/renderer/components/settings/sections/PhoneSection.tsx
+++ b/src/renderer/components/settings/sections/PhoneSection.tsx
@@ -41,7 +41,10 @@ const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Element {
   const [devices, setDevices] = useState<PairedDevice[]>([])
   const [pendingRevoke, setPendingRevoke] = useState<PairedDevice | null>(null)
-  const [revokeNote, setRevokeNote] = useState('')
+  // What the last revoke has to say, and whether it is a WARNING or a receipt. A successful
+  // removal owes the user a sentence too (the phone keeps Pro for a few days), and printing that
+  // in the warning colour would read as a failure.
+  const [revokeNote, setRevokeNote] = useState<{ text: string; warn: boolean } | null>(null)
 
   const phoneAccessEnabled = useSettings((s) => s.settings.phoneAccessEnabled)
   const updateSettings = useSettings((s) => s.update)
@@ -55,9 +58,13 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
   }, [])
 
   // The shared pairing machine (also behind the top-right quick-pair popover); a completed
-  // pairing refreshes the device list below.
+  // pairing refreshes the device list below — and drops the last revoke note, which names a device
+  // by name and would otherwise outlive the very phone it warns about being re-paired.
   const { phase, qr, sshOpen, sshHealed, relayResult, relayPlan, error, busy, start, stop, reset } = usePhonePairing(
-    () => void refreshDevices()
+    () => {
+      setRevokeNote(null)
+      void refreshDevices()
+    }
   )
 
   const togglePhoneAccess = (next: boolean): void => {
@@ -78,12 +85,21 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
 
   // Removing local access and taking the phone's Pro back are DIFFERENT facts, and the second one
   // used to be missing entirely — Remove unpinned the key here while the server kept minting Pro
-  // for that phone forever. So both legs are surfaced, and only a leg that actually FAILED warns:
-  // 'skipped' means we had nothing to revoke (a free-tier desktop, or a device paired before we
-  // recorded the phone's relay id), and warning there would tell a free user their phone is stuck.
+  // for that phone forever. So both legs are surfaced:
+  //  - 'skipped' says nothing. It means we had nothing of ours to revoke — a free-tier desktop
+  //    holds no entitlement to sign the request with, or the device was already gone from the
+  //    registry — and warning there would tell a free user their phone's Pro is stuck when it
+  //    never had any of ours. (A device paired before we recorded the phone's relay id does NOT
+  //    land here: it falls back to our own pairing id, which is the row's key in that case, so the
+  //    server leg really does run — see `revokeDevice` in main/pairing-service.ts.)
+  //  - 'ok' still owes a sentence: the phone keeps the entitlement it already holds until that
+  //    expires, so Pro does not stop the instant the row goes. Saying nothing produced exactly the
+  //    support mail this branch exists to end ("I removed it and it still has Pro").
+  //  - 'failed' warns — and does not prescribe waiting. It collapses a 403 (not our row), a 401,
+  //    a 5xx and an unreachable server, and only the last of those clears by itself.
   const revokeDevice = async (device: PairedDevice): Promise<void> => {
     setPendingRevoke(null)
-    setRevokeNote('')
+    setRevokeNote(null)
     try {
       const result = await window.nodeTerminal.pairing.revokeDevice(device.id)
       // Additive, not exclusive: both legs can fail at once (an unwritable ~/.ssh while offline),
@@ -93,20 +109,30 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
         notes.push(`Couldn’t remove “${device.name}” from this machine — try again.`)
       }
       if (result.server === 'failed') {
-        // Not a bare "try again": on a successful local removal the row is already gone from the
-        // list, so there is no button left to press. Name the one thing that does re-run the
-        // server leg — the phone sends the same stable device id every time it pairs, and the
-        // backend upserts the row on that id, so pairing again makes the next Revoke land.
+        // Deliberately not "pair it and remove it again": that used to be the whole advice, and it
+        // is wrong twice over — a 403 will never clear however long you wait, and pairing RESTORES
+        // the phone's Pro (the mint upserts its row) before the second removal tries again. It is
+        // offered as what it is — a retry that costs something — with support as the reliable path.
         notes.push(
           (result.local ? `Removed “${device.name}” from this machine, but its` : 'Its') +
-            ' Pro access couldn’t be revoked, so that phone may keep Pro. Once this machine is' +
-            ' back online, pair it and remove it again to try again.'
+            ' Pro access couldn’t be revoked — we were refused or couldn’t reach the server — so' +
+            ' that phone may keep Pro. Pairing it again and removing it retries the revoke, though' +
+            ' pairing restores its Pro in the meantime. Get in touch if it keeps failing.'
         )
       }
-      setRevokeNote(notes.join(' '))
+      if (notes.length) {
+        setRevokeNote({ text: notes.join(' '), warn: true })
+      } else if (result.server === 'ok') {
+        // Not instant, and we say so. The phone holds a signed entitlement minted for up to seven
+        // days; revoking the row stops the NEXT one, it cannot reach into the phone.
+        setRevokeNote({
+          text: `Removed “${device.name}”. Its Pro ends when the pass it already holds expires — within 7 days.`,
+          warn: false
+        })
+      }
     } catch {
       // The call itself never got an answer (main is gone, or the surface doesn't support it).
-      setRevokeNote(`Couldn’t remove “${device.name}” — try again.`)
+      setRevokeNote({ text: `Couldn’t remove “${device.name}” — try again.`, warn: true })
     } finally {
       void refreshDevices()
     }
@@ -289,8 +315,11 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
             </ul>
           )}
           {revokeNote ? (
-            <p className="text-sm" style={{ color: '#ff9f0a' }}>
-              {revokeNote}
+            <p
+              className={revokeNote.warn ? 'text-sm' : 'text-sm text-muted'}
+              style={revokeNote.warn ? { color: '#ff9f0a' } : undefined}
+            >
+              {revokeNote.text}
             </p>
           ) : null}
         </div>
@@ -298,7 +327,10 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
 
       {pendingRevoke ? (
         <ConfirmDialog
-          message={`Revoke “${pendingRevoke.name}”? Its key is removed from this machine and it will no longer be able to connect.`}
+          // Both legs, and the timing of the one that is not instant. "If" rather than a flat
+          // claim: a free-tier desktop has no Pro of ours on that phone to take back, and this
+          // dialog cannot tell — the server leg reports that only after the fact ('skipped').
+          message={`Revoke “${pendingRevoke.name}”? Its key is removed from this machine and it will no longer be able to connect. If its Pro comes from this Mac’s license, that is revoked too — the phone loses Pro within 7 days.`}
           confirmLabel="Revoke"
           onConfirm={() => void revokeDevice(pendingRevoke)}
           onCancel={() => setPendingRevoke(null)}

--- a/src/renderer/lib/licenseCopy.test.ts
+++ b/src/renderer/lib/licenseCopy.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import type { LicenseDetail } from '@shared/types'
+import { licenseSentence, canReleaseDevices } from './licenseCopy'
+
+// `detail.error` carries TWO families and only the code word separates them: a read that FAILED
+// (its counts are placeholder zeros) and a release that was REFUSED (its counts are the last good
+// read — real, current, worth showing). Most of what follows exists to pin that seam, because
+// every wrong ordering of the checks still produces a plausible-looking sentence.
+
+const keygen = (over: Partial<LicenseDetail> = {}): LicenseDetail => ({
+  key: 'NT-KEY-1',
+  used: 2,
+  seats: 3,
+  source: 'keygen',
+  error: null,
+  ...over
+})
+
+describe('licenseSentence — a keygen license that read cleanly', () => {
+  it('reports usage against the cap and names phones as devices', () => {
+    const s = licenseSentence(keygen({ used: 2, seats: 3 }))
+    expect(s).toBe('2 of 3 devices in use — this Mac and each paired phone counts as a device.')
+    // The numbers are the DATA's, not a template that happens to read well: a swapped pair or a
+    // hardcoded cap would still match a looser assertion.
+    expect(licenseSentence(keygen({ used: 1, seats: 5 }))).toBe(
+      '1 of 5 devices in use — this Mac and each paired phone counts as a device.'
+    )
+  })
+
+  it('names the cap being full and points at the release action', () => {
+    expect(licenseSentence(keygen({ used: 3, seats: 3 }))).toBe(
+      'All 3 devices are in use. Release the others below to free them up.'
+    )
+  })
+
+  it('does not claim "all N" when MORE than N are in use (a cap lowered after activation)', () => {
+    // `used > seats` is reachable and must not be flattened into the full-cap sentence: "All 3
+    // devices are in use" under a 4-device reality is a wrong number stated as a fact. A `>=`
+    // that falls through to the full-cap branch passes every other test in this file.
+    expect(licenseSentence(keygen({ used: 4, seats: 3 }))).toBe(
+      '4 devices are in use, more than the 3 this license allows. Release the others below to free them up.'
+    )
+  })
+
+  it('is honest when the read succeeded but no key is on file', () => {
+    // Legitimate: a keygen policy that hides keys, or a license predating the key column. This is
+    // the ONLY case this sentence may appear in — see the apple/free/error tests below.
+    expect(licenseSentence(keygen({ key: null }))).toBe(
+      'No key is on file for this license yet — get in touch and we will send yours.'
+    )
+  })
+})
+
+describe('licenseSentence — sources that have no key and no device count', () => {
+  it('says an App Store subscription bridged Pro here, and prints no counts', () => {
+    const s = licenseSentence({ key: null, used: 0, seats: 0, source: 'apple', error: null })
+    expect(s).toBe(
+      'Pro on this Mac comes from the App Store subscription on your paired phone, so there is no license key or device count to show here.'
+    )
+    // The zeros are "not applicable", not a measurement. Rendering them here is the exact
+    // misdirection this branch exists to prevent.
+    expect(s).not.toContain('0')
+    // …and it must not borrow the keygen "no key on file" line, which would send an App Store
+    // subscriber to support asking for a key that will never exist.
+    expect(s).not.toContain('get in touch')
+  })
+
+  it('says plainly that a `free` source is not backed by a key, inventing no origin story', () => {
+    const s = licenseSentence({ key: null, used: 0, seats: 0, source: 'free', error: null })
+    expect(s).toBe('Pro on this device is not backed by a license key.')
+    expect(s).not.toContain('get in touch')
+    expect(s).not.toContain('0')
+  })
+
+  it('says nothing when a clean read stated no source at all', () => {
+    // Only reachable through a release merge over an empty detail (counts real, source unknown).
+    // With no stated source there is no sentence the data supports — so, none.
+    expect(licenseSentence({ key: null, used: 1, seats: 3, source: null, error: null })).toBe('')
+  })
+})
+
+describe('licenseSentence — a read that FAILED', () => {
+  // Every code in this family arrives with placeholder zeros and a null key.
+  const failures = ['unauthorized', 'inactive', 'offline', 'disabled', 'network'] as const
+  const FAILED = 'Could not read this license right now, so the key and device count are unknown. Your Pro access is unaffected.'
+
+  for (const error of failures) {
+    it(`renders "${error}" as a failed read, never as a device count`, () => {
+      const s = licenseSentence({ key: null, used: 0, seats: 0, source: null, error })
+      expect(s).toBe(FAILED)
+      // A failed read is not "0 of 0 devices" and not "no key on file".
+      expect(s).not.toContain('0 of 0')
+      expect(s).not.toContain('get in touch')
+    })
+  }
+
+  it('still renders the failure when the failed read carried a source and stale-looking counts', () => {
+    // ORDERING PIN: if the `source` check ran before the `error` check, this would render the
+    // keygen usage sentence over a read that never came back — a fabricated device count.
+    const s = licenseSentence({ key: 'NT-KEY-1', used: 2, seats: 3, source: 'keygen', error: 'offline' })
+    expect(s).toBe(FAILED)
+    expect(s).not.toContain('2 of 3')
+  })
+})
+
+describe('licenseSentence — a release that was REFUSED', () => {
+  it('says when releasing is possible again, in days', () => {
+    // ORDERING PIN, the other direction: this detail is a clean keygen read with a refusal code on
+    // top. Falling through to the read-failure sentence would tell the user their license could
+    // not be read, when in fact it was read fine and only the ACTION was refused.
+    const s = licenseSentence(keygen({ error: 'too_soon', retryAfterDays: 12 }))
+    expect(s).toBe('You can release devices again in 12 days.')
+    expect(s).not.toContain('Could not read')
+  })
+
+  it('says "1 day", not "1 days"', () => {
+    expect(licenseSentence(keygen({ error: 'too_soon', retryAfterDays: 1 }))).toBe(
+      'You can release devices again in 1 day.'
+    )
+  })
+
+  it('invents no window when the server stated no retryAfterDays', () => {
+    // A default like `?? 30` is a number the server never sent, printed as a date the user will
+    // plan around. Degrade to nothing, never to something wrong.
+    expect(licenseSentence(keygen({ error: 'too_soon' }))).toBe(
+      'You cannot release devices again yet.'
+    )
+    expect(licenseSentence(keygen({ error: 'too_soon', retryAfterDays: 0 }))).toBe(
+      'You cannot release devices again yet.'
+    )
+  })
+
+  it('renders not_applicable as a refused action, not as a failed read', () => {
+    // Unreachable through the UI (the release action is shown only for a STATED 'keygen' source,
+    // and that is the one source the route never answers 400 for), but a route contract is not a
+    // render-time guarantee — so it gets a sentence rather than the failed-read one.
+    const s = licenseSentence({ key: null, used: 0, seats: 0, source: 'apple', error: 'not_applicable' })
+    expect(s).toBe('Releasing devices does not apply to this license.')
+    expect(s).not.toContain('Could not read')
+  })
+})
+
+describe('licenseSentence — before the first read', () => {
+  it('says nothing', () => {
+    expect(licenseSentence(null)).toBe('')
+  })
+})
+
+describe('canReleaseDevices', () => {
+  it('is true only for a STATED keygen source', () => {
+    expect(canReleaseDevices(keygen())).toBe(true)
+  })
+
+  it('is false for every other stated source', () => {
+    expect(canReleaseDevices({ key: null, used: 0, seats: 0, source: 'apple', error: null })).toBe(
+      false
+    )
+    expect(canReleaseDevices({ key: null, used: 0, seats: 0, source: 'free', error: null })).toBe(
+      false
+    )
+  })
+
+  it('is false when no source was stated — an unknown source HIDES the action', () => {
+    // The gate must be `=== 'keygen'`, never `!== 'apple'`: a null source (every error reply, and
+    // the release route's own 200) would then SHOW a release the server can only refuse, and a
+    // future source word would inherit the button by default. Both of these pass a `!== 'apple'`.
+    expect(canReleaseDevices({ key: null, used: 0, seats: 0, source: null, error: 'offline' })).toBe(
+      false
+    )
+    expect(
+      canReleaseDevices({
+        key: null,
+        used: 0,
+        seats: 0,
+        source: 'ios' as unknown as LicenseDetail['source'],
+        error: null
+      })
+    ).toBe(false)
+  })
+
+  it('is false before the first read', () => {
+    expect(canReleaseDevices(null)).toBe(false)
+  })
+
+  it('stays true while a release is throttled — the action is refused, not inapplicable', () => {
+    // The user must still see the button (and the "in N days" sentence beside it); hiding it here
+    // would read as "this license cannot release devices at all".
+    expect(canReleaseDevices(keygen({ error: 'too_soon', retryAfterDays: 12 }))).toBe(true)
+  })
+})

--- a/src/renderer/lib/licenseCopy.test.ts
+++ b/src/renderer/lib/licenseCopy.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import type { LicenseDetail } from '@shared/types'
-import { licenseSentence, canReleaseDevices } from './licenseCopy'
+import {
+  licenseSentence,
+  canReleaseDevices,
+  canUseKeyElsewhere,
+  isReleaseRefusal,
+  releaseFailureSentence,
+  activationErrorSentence
+} from './licenseCopy'
 
 // `detail.error` carries TWO families and only the code word separates them: a read that FAILED
 // (its counts are placeholder zeros) and a release that was REFUSED (its counts are the last good
@@ -81,10 +88,10 @@ describe('licenseSentence — sources that have no key and no device count', () 
 
 describe('licenseSentence — a read that FAILED', () => {
   // Every code in this family arrives with placeholder zeros and a null key.
-  const failures = ['unauthorized', 'inactive', 'offline', 'disabled', 'network'] as const
+  const couldNotLook = ['offline', 'disabled', 'network'] as const
   const FAILED = 'Could not read this license right now, so the key and device count are unknown. Your Pro access is unaffected.'
 
-  for (const error of failures) {
+  for (const error of couldNotLook) {
     it(`renders "${error}" as a failed read, never as a device count`, () => {
       const s = licenseSentence({ key: null, used: 0, seats: 0, source: null, error })
       expect(s).toBe(FAILED)
@@ -93,6 +100,37 @@ describe('licenseSentence — a read that FAILED', () => {
       expect(s).not.toContain('get in touch')
     })
   }
+
+  // "Your Pro access is unaffected." is a PROMISE ABOUT THE FUTURE, and only these three codes back
+  // it: we never got to look, so nothing about the license changed. The two below are answers.
+  it('does not promise Pro is unaffected when the server said the license is inactive', () => {
+    const s = licenseSentence({ key: null, used: 0, seats: 0, source: null, error: 'inactive' })
+    expect(s).toBe(
+      'This license is not active, so there is no key or device count to show — and Pro on this Mac will stop when its current entitlement expires.'
+    )
+    // A suspended/refunded license DOES drop Pro at the next refresh — the old shared sentence
+    // told that user the opposite, in the one place they came to find out.
+    expect(s).not.toContain('unaffected')
+    expect(s).not.toContain('0 of 0')
+  })
+
+  it('does not promise Pro is unaffected when this Mac was refused', () => {
+    const s = licenseSentence({ key: null, used: 0, seats: 0, source: null, error: 'unauthorized' })
+    expect(s).toBe(
+      'This Mac is not authorized on this license, so the key and device count are unavailable — and Pro here may stop when its current entitlement expires.'
+    )
+    expect(s).not.toContain('unaffected')
+    // "may", not "will": a later refresh can re-mint. Overstating is the other half of the lie.
+    expect(s).toContain('may stop')
+  })
+
+  it('makes no promise at all for a code it does not recognize', () => {
+    // A reason word the server grew after this build shipped. Saying "unaffected" would be a
+    // guess about a state we cannot read; saying nothing more than what happened is not.
+    const s = licenseSentence({ key: null, used: 0, seats: 0, source: null, error: 'teapot' })
+    expect(s).toBe('Could not read this license right now, so the key and device count are unknown.')
+    expect(s).not.toContain('unaffected')
+  })
 
   it('still renders the failure when the failed read carried a source and stale-looking counts', () => {
     // ORDERING PIN: if the `source` check ran before the `error` check, this would render the
@@ -186,5 +224,140 @@ describe('canReleaseDevices', () => {
     // The user must still see the button (and the "in N days" sentence beside it); hiding it here
     // would read as "this license cannot release devices at all".
     expect(canReleaseDevices(keygen({ error: 'too_soon', retryAfterDays: 12 }))).toBe(true)
+  })
+})
+
+describe('canUseKeyElsewhere', () => {
+  it('is true while the license still has room', () => {
+    expect(canUseKeyElsewhere(keygen({ used: 2, seats: 3 }))).toBe(true)
+  })
+
+  it('is false AT the cap — the activation it invites would be refused', () => {
+    // This line used to render under "All 3 devices are in use": we told the user to go and paste
+    // the key on another Mac, where the server answers seat_limit. Advice that cannot work.
+    expect(canUseKeyElsewhere(keygen({ used: 3, seats: 3 }))).toBe(false)
+  })
+
+  it('is false OVER the cap (a cap lowered after activation)', () => {
+    // `used > seats` is further from having room, not closer. A `!==` or a `used === seats` check
+    // reads it as "not at the cap" and shows the line again.
+    expect(canUseKeyElsewhere(keygen({ used: 4, seats: 3 }))).toBe(false)
+  })
+
+  it('is false with no key to paste, whatever the counts say', () => {
+    expect(canUseKeyElsewhere(keygen({ key: null, used: 0, seats: 3 }))).toBe(false)
+    expect(canUseKeyElsewhere(null)).toBe(false)
+  })
+})
+
+describe('isReleaseRefusal — which codes are about the LICENSE', () => {
+  it('is true for exactly the two the release route answers about the license itself', () => {
+    expect(isReleaseRefusal('too_soon')).toBe(true)
+    expect(isReleaseRefusal('not_applicable')).toBe(true)
+  })
+
+  it('is false for every transport / standing code', () => {
+    // These are the codes the release route ALSO produces (core/license.ts). Treating them as
+    // refusals is what merged an offline release onto `detail` and rendered it as a failed READ,
+    // with a real key sitting in the box above it.
+    for (const code of ['unauthorized', 'inactive', 'offline', 'disabled', 'network', 'teapot']) {
+      expect(isReleaseRefusal(code), code).toBe(false)
+    }
+  })
+
+  it('is false for "no error at all"', () => {
+    expect(isReleaseRefusal(null)).toBe(false)
+    expect(isReleaseRefusal(undefined)).toBe(false)
+    expect(isReleaseRefusal('')).toBe(false)
+  })
+})
+
+describe('releaseFailureSentence', () => {
+  it('says nothing when the release did not fail', () => {
+    expect(releaseFailureSentence(null)).toBe('')
+    expect(releaseFailureSentence(undefined)).toBe('')
+  })
+
+  it('says nothing for a refusal — those ride the detail and licenseSentence owns them', () => {
+    // Two owners for one message would print the throttle twice, in two different wordings.
+    expect(releaseFailureSentence('too_soon')).toBe('')
+    expect(releaseFailureSentence('not_applicable')).toBe('')
+  })
+
+  it('states that nothing was released when the server ANSWERED and refused', () => {
+    expect(releaseFailureSentence('unauthorized')).toBe(
+      'Could not release the other devices — this Mac is not authorized on this license. Nothing was released.'
+    )
+    expect(releaseFailureSentence('inactive')).toBe(
+      'Could not release the other devices — this license is not active. Nothing was released.'
+    )
+    expect(releaseFailureSentence('disabled')).toBe(
+      'Could not release the other devices — license requests are switched off in this build. Nothing was released.'
+    )
+  })
+
+  it('does NOT claim nothing happened when the reply was merely lost', () => {
+    // The request may have landed and only the answer gone missing. "Nothing was changed" sends
+    // the user to a retry that hits the 30-day throttle, having already spent their one release.
+    for (const code of ['offline', 'network', 'teapot']) {
+      const s = releaseFailureSentence(code)
+      expect(s, code).not.toContain('Nothing was released')
+      expect(s, code).toContain('may or may not')
+      // …and it must say what to do next, including the cost of the ambiguity.
+      expect(s, code).toContain('30 days')
+    }
+  })
+
+  it('never renders the bare code', () => {
+    for (const code of ['unauthorized', 'inactive', 'disabled', 'offline', 'network', 'teapot']) {
+      // Same rule as the activation copy: what would read as machine output is the snake_case
+      // shape, and none of these sentences may carry one.
+      expect(releaseFailureSentence(code), code).not.toMatch(/[a-z]+_[a-z]+/)
+    }
+  })
+})
+
+describe('activationErrorSentence', () => {
+  it('says nothing when the activation did not fail', () => {
+    expect(activationErrorSentence(null)).toBe('')
+    expect(activationErrorSentence('')).toBe('')
+  })
+
+  it('turns seat_limit into the remedy, and points it at a machine that HAS Pro', () => {
+    // The flow this whole feature exists for. It used to dead-end in `Could not activate
+    // (seat_limit).` — a word the buyer cannot look up, on the screen where they are stuck.
+    const s = activationErrorSentence('seat_limit')
+    expect(s).toBe(
+      'This license already has all its devices in use. On a Mac (or phone) where Pro is active, open Settings → License and choose “Release other devices”, then activate here again.'
+    )
+    // The release action does not exist on THIS machine (it has no Pro yet), so the sentence must
+    // send the user elsewhere — advice to "release below" would point at a button that isn't there.
+    expect(s).toContain('where Pro is active')
+  })
+
+  it('gives every other named code its own sentence, none of them a code', () => {
+    const codes = ['suspended', 'expired', 'not_found', 'invalid', 'offline', 'network', 'disabled']
+    const seen = new Set<string>()
+    for (const code of codes) {
+      const s = activationErrorSentence(code)
+      expect(s, code).not.toBe('')
+      // A raw reason code is snake_case; English is not. `not.toContain(code)` cannot be used for
+      // codes that are also ordinary words ("suspended", "expired"), and this catches the ones
+      // that would actually read as machine output.
+      expect(s, code).not.toMatch(/[a-z]+_[a-z]+/)
+      // Not one apology reused for everything: a shared string would tell an expired license and
+      // an offline laptop the same untrue thing.
+      seen.add(s)
+    }
+    // offline and network are deliberately ONE sentence (both mean "we could not check"), so six.
+    expect(seen.size).toBe(codes.length - 1)
+  })
+
+  it('falls back to an actionable sentence for a code it does not know, printing no code', () => {
+    const s = activationErrorSentence('gremlins')
+    expect(s).toBe(
+      'Could not activate this key. Check it was pasted in full and try again — get in touch if it keeps failing.'
+    )
+    expect(s).not.toContain('gremlins')
   })
 })

--- a/src/renderer/lib/licenseCopy.ts
+++ b/src/renderer/lib/licenseCopy.ts
@@ -4,16 +4,24 @@ import type { LicenseDetail } from '@shared/types'
  * Settings → License wording, derived from the data in ONE place so a sentence cannot promise
  * something the numbers do not say.
  *
- * Two facts shape every branch below:
+ * Three facts shape the branches below:
  *
- * 1. **`error` carries TWO families and only the code word separates them.** A READ that failed
- *    (`unauthorized` | `inactive` | `offline` | `disabled` | `network`) arrives with placeholder
- *    zeros and a null key — rendering those as a device count is the bug this module exists to
- *    prevent. A refused RELEASE (`too_soon` | `not_applicable`) rides on top of the LAST GOOD
- *    read, so its key, source and counts are real; telling that user "could not read your
- *    license" would be equally wrong in the other direction. Hence: error first, then which
- *    family, then the source.
- * 2. **Seats and devices are the same thing by design**, so the copy says "devices" and names
+ * 1. **A reason code is either about the LICENSE or about the CALL, and both arrive in the same
+ *    `error` field.** A refused RELEASE (`too_soon` | `not_applicable`) is about the license: it
+ *    rides on top of the LAST GOOD read, so its key, source and counts are real, and it belongs
+ *    beside them. Everything else — `unauthorized` | `inactive` | `offline` | `disabled` |
+ *    `network` — is about a call that did not deliver, and the route it failed on decides what to
+ *    say: on a READ it means the key and counts are unknown, on a RELEASE it means the action did
+ *    not happen (and, offline, may or may not have). The store therefore never merges a release's
+ *    transport failure onto `detail` (it hands the code back instead), and `releaseFailureSentence`
+ *    is the one place that speaks for it. `isReleaseRefusal` is the shared split so the store and
+ *    the panel cannot disagree about which family a code is in.
+ * 2. **"Your Pro access is unaffected" is a forward-looking promise, so only codes that back it may
+ *    say it.** `offline`/`network`/`disabled` mean we could not look — the entitlement is verified
+ *    locally and nothing changed. `inactive`/`unauthorized` are ANSWERS that this license is not in
+ *    good standing, and the very next refresh may drop Pro; telling that user they are unaffected
+ *    is the same class of lie as rendering a placeholder zero as a device count.
+ * 3. **Seats and devices are the same thing by design**, so the copy says "devices" and names
  *    phones explicitly — a paired phone holds a seat too, and a user who does not know that reads
  *    the cap as broken.
  */
@@ -21,7 +29,7 @@ export function licenseSentence(detail: LicenseDetail | null): string {
   if (!detail) return '' // Before the first read there is nothing to say.
 
   if (detail.error) {
-    // --- Family 2 first: the read was FINE, the action was refused. -----------------------------
+    // --- The read was FINE, the release was refused on terms about the license itself. ----------
     if (detail.error === 'too_soon') {
       const days = detail.retryAfterDays
       // No `?? 30` fallback: a window the server never stated is a date the user would plan
@@ -39,11 +47,28 @@ export function licenseSentence(detail: LicenseDetail | null): string {
       return 'Releasing devices does not apply to this license.'
     }
 
-    // --- Family 1: the READ failed. The counts beside this are placeholders, not a measurement. --
-    // Deliberately not "could not reach the server": `unauthorized` / `inactive` / `disabled` are
-    // answers we DID receive. What is true across the whole family is that we do not know the key
-    // or the count — and that Pro keeps working either way (the entitlement is verified locally).
-    return 'Could not read this license right now, so the key and device count are unknown. Your Pro access is unaffected.'
+    // --- The READ failed. The counts beside this are placeholders, not a measurement. -----------
+    // A RELEASE failure never reaches here: the store keeps those off `detail` (see the module doc
+    // and `isReleaseRefusal`), because "could not read this license" printed over a real key and
+    // real counts is false in both halves.
+    if (detail.error === 'inactive') {
+      // A server ANSWER, not a failure to look. Pro is verified locally so it still works right
+      // now, and saying "unaffected" would promise it keeps working — which it will not.
+      return 'This license is not active, so there is no key or device count to show — and Pro on this Mac will stop when its current entitlement expires.'
+    }
+    if (detail.error === 'unauthorized') {
+      // Also an answer: the server refused this Mac's entitlement. It may recover on the next
+      // refresh, hence "may" — but it is not the "nothing changed" story the codes below tell.
+      return 'This Mac is not authorized on this license, so the key and device count are unavailable — and Pro here may stop when its current entitlement expires.'
+    }
+    if (detail.error === 'offline' || detail.error === 'network' || detail.error === 'disabled') {
+      // Deliberately not "could not reach the server": `disabled` is a build that never asked.
+      // What is true across these three is that we did not get to LOOK — and that Pro keeps
+      // working either way, because the entitlement is verified locally.
+      return 'Could not read this license right now, so the key and device count are unknown. Your Pro access is unaffected.'
+    }
+    // An unrecognized code. Say the part that is certainly true and make no promise we cannot back.
+    return 'Could not read this license right now, so the key and device count are unknown.'
   }
 
   // --- A clean read. What can be said depends entirely on the source the SERVER stated. ---------
@@ -87,4 +112,92 @@ export function licenseSentence(detail: LicenseDetail | null): string {
  */
 export function canReleaseDevices(detail: LicenseDetail | null): boolean {
   return detail?.source === 'keygen'
+}
+
+/**
+ * Whether to tell the user they can paste this key on another Mac.
+ *
+ * A key with no free device is an invitation to an activation that CANNOT succeed — the server
+ * answers `seat_limit` and the user is left holding a key and an error. So the line appears only
+ * while the license has room. `used > seats` (a cap lowered after activation) is over the cap, not
+ * under it, and is excluded by the same comparison.
+ */
+export function canUseKeyElsewhere(detail: LicenseDetail | null): boolean {
+  return !!detail?.key && detail.used < detail.seats
+}
+
+/**
+ * Is this reason code a REFUSAL of the release (about the license), rather than a failure of the
+ * call (about the network / this Mac's standing)?
+ *
+ * The store asks this to decide what may be merged onto `detail`, and the panel's release note is
+ * the complement of it. One definition, because two copies of "which codes are refusals" is
+ * exactly how a transport failure ended up rendered as "could not read this license".
+ */
+export function isReleaseRefusal(code: string | null | undefined): boolean {
+  return code === 'too_soon' || code === 'not_applicable'
+}
+
+/**
+ * What to tell the user when "Release other devices" did not deliver.
+ *
+ * Two families, and conflating them is the whole point of this function existing:
+ *  - the server ANSWERED and refused (`unauthorized` | `inactive`) or we never asked (`disabled`)
+ *    ⇒ nothing was released, and we can say so.
+ *  - the reply never arrived (`offline` | `network`, and any code we do not recognize) ⇒ the
+ *    request may well have LANDED. Claiming "nothing was changed" there sends the user to a retry
+ *    that hits the 30-day throttle, having already spent their release.
+ *
+ * A refusal code returns '' — those ride `detail` and `licenseSentence` speaks for them. One owner
+ * per message; two would print the throttle twice.
+ */
+export function releaseFailureSentence(code: string | null | undefined): string {
+  if (!code || isReleaseRefusal(code)) return ''
+  if (code === 'unauthorized') {
+    return 'Could not release the other devices — this Mac is not authorized on this license. Nothing was released.'
+  }
+  if (code === 'inactive') {
+    return 'Could not release the other devices — this license is not active. Nothing was released.'
+  }
+  if (code === 'disabled') {
+    return 'Could not release the other devices — license requests are switched off in this build. Nothing was released.'
+  }
+  return 'Could not confirm the release — the server could not be reached, so the other devices may or may not have been released. Close and reopen Settings to see the current device count; if the release did land, the next one is only possible after 30 days.'
+}
+
+/**
+ * What to tell someone whose key would not activate.
+ *
+ * The codes come from the server verbatim (`core/license.ts` keeps them), and rendering them
+ * verbatim is what left the flow this whole feature exists for — a buyer at the device cap —
+ * dead-ended in `Could not activate (seat_limit).` Every branch below names an ACTION; the
+ * fallback names one too, and never prints the code, because a word the user cannot look up is
+ * worse than a plain apology.
+ */
+export function activationErrorSentence(code: string | null | undefined): string {
+  if (!code) return ''
+  if (code === 'seat_limit') {
+    // The one code this feature was built around. The remedy lives on a machine that HAS Pro —
+    // this one does not, so "release devices here" would be advice the user cannot follow.
+    return 'This license already has all its devices in use. On a Mac (or phone) where Pro is active, open Settings → License and choose “Release other devices”, then activate here again.'
+  }
+  if (code === 'suspended') {
+    return 'This license has been suspended, so it cannot be activated. Get in touch and we will sort it out.'
+  }
+  if (code === 'expired') {
+    return 'This license has expired. Renew it and then activate again.'
+  }
+  if (code === 'not_found') {
+    return 'No license was found for that key. Check it was pasted in full, or copy it again from your purchase email.'
+  }
+  if (code === 'invalid') {
+    return 'That is not a valid license key. Check it was pasted in full, or copy it again from your purchase email.'
+  }
+  if (code === 'offline' || code === 'network') {
+    return 'Could not reach the server, so the key could not be checked. Check your connection and try again.'
+  }
+  if (code === 'disabled') {
+    return 'License activation is switched off in this build.'
+  }
+  return 'Could not activate this key. Check it was pasted in full and try again — get in touch if it keeps failing.'
 }

--- a/src/renderer/lib/licenseCopy.ts
+++ b/src/renderer/lib/licenseCopy.ts
@@ -1,0 +1,90 @@
+import type { LicenseDetail } from '@shared/types'
+
+/**
+ * Settings → License wording, derived from the data in ONE place so a sentence cannot promise
+ * something the numbers do not say.
+ *
+ * Two facts shape every branch below:
+ *
+ * 1. **`error` carries TWO families and only the code word separates them.** A READ that failed
+ *    (`unauthorized` | `inactive` | `offline` | `disabled` | `network`) arrives with placeholder
+ *    zeros and a null key — rendering those as a device count is the bug this module exists to
+ *    prevent. A refused RELEASE (`too_soon` | `not_applicable`) rides on top of the LAST GOOD
+ *    read, so its key, source and counts are real; telling that user "could not read your
+ *    license" would be equally wrong in the other direction. Hence: error first, then which
+ *    family, then the source.
+ * 2. **Seats and devices are the same thing by design**, so the copy says "devices" and names
+ *    phones explicitly — a paired phone holds a seat too, and a user who does not know that reads
+ *    the cap as broken.
+ */
+export function licenseSentence(detail: LicenseDetail | null): string {
+  if (!detail) return '' // Before the first read there is nothing to say.
+
+  if (detail.error) {
+    // --- Family 2 first: the read was FINE, the action was refused. -----------------------------
+    if (detail.error === 'too_soon') {
+      const days = detail.retryAfterDays
+      // No `?? 30` fallback: a window the server never stated is a date the user would plan
+      // around. Degrade to the shape of the fact we do have ("not yet"), never to a made-up number.
+      if (typeof days === 'number' && Number.isFinite(days) && days > 0) {
+        return `You can release devices again in ${days} ${days === 1 ? 'day' : 'days'}.`
+      }
+      return 'You cannot release devices again yet.'
+    }
+    if (detail.error === 'not_applicable') {
+      // The panel only offers the release for a stated 'keygen' source, and that is the one source
+      // the route never refuses this way — so this should be unreachable. It still gets its own
+      // sentence rather than falling into the failed-read one, because a route contract is not a
+      // render-time guarantee and "we could not read your license" would be a false alarm.
+      return 'Releasing devices does not apply to this license.'
+    }
+
+    // --- Family 1: the READ failed. The counts beside this are placeholders, not a measurement. --
+    // Deliberately not "could not reach the server": `unauthorized` / `inactive` / `disabled` are
+    // answers we DID receive. What is true across the whole family is that we do not know the key
+    // or the count — and that Pro keeps working either way (the entitlement is verified locally).
+    return 'Could not read this license right now, so the key and device count are unknown. Your Pro access is unaffected.'
+  }
+
+  // --- A clean read. What can be said depends entirely on the source the SERVER stated. ---------
+  if (detail.source === 'apple') {
+    // No keygen call was made for this license, so `used`/`seats` are zeros meaning "not
+    // applicable". Printing them would read as a cap that is somehow both empty and full.
+    return 'Pro on this Mac comes from the App Store subscription on your paired phone, so there is no license key or device count to show here.'
+  }
+  if (detail.source === 'free') {
+    // A defensive value. Say only what is certain — where it came from is not.
+    return 'Pro on this device is not backed by a license key.'
+  }
+  if (detail.source === 'keygen') {
+    if (!detail.key) {
+      // Legitimate on a 200: a keygen policy that hides keys, or a license predating the column.
+      // This is the only case in which this sentence is true.
+      return 'No key is on file for this license yet — get in touch and we will send yours.'
+    }
+    if (detail.used > detail.seats) {
+      // Reachable: a cap lowered after activation. "All N devices are in use" would understate it.
+      return `${detail.used} devices are in use, more than the ${detail.seats} this license allows. Release the others below to free them up.`
+    }
+    if (detail.used === detail.seats) {
+      return `All ${detail.seats} devices are in use. Release the others below to free them up.`
+    }
+    return `${detail.used} of ${detail.seats} devices in use — this Mac and each paired phone counts as a device.`
+  }
+
+  // A clean read that stated no source (only reachable by merging a release reply over an empty
+  // detail). The counts may be real, but with no source there is no sentence they support.
+  return ''
+}
+
+/**
+ * Whether to offer "Release other devices".
+ *
+ * Gated on a STATED `'keygen'` — never on `!== 'apple'`. A null source is what every error reply
+ * and the release route's own 200 carry, and a source word added later would inherit the button by
+ * default; both would offer an action the server can only refuse. A refused release (`too_soon`)
+ * still returns true: the action exists, it is merely throttled, and the sentence beside it says so.
+ */
+export function canReleaseDevices(detail: LicenseDetail | null): boolean {
+  return detail?.source === 'keygen'
+}

--- a/src/renderer/state/entitlement.test.ts
+++ b/src/renderer/state/entitlement.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { LicenseDetail, NodeTerminalApi } from '@shared/types'
+
+// The license routes answer two DIFFERENT shapes, and that asymmetry is what these tests are about:
+// `detail` states every field, while `release` answers with COUNTS ONLY — no key, no source (and a
+// FAILED release changed nothing on the server at all). So the store replaces on the first and
+// merges on the second; getting that backwards silently blanks the key the user came to copy, or
+// renders "0 of 0 devices" from a call that never ran.
+
+const detail = vi.fn<() => Promise<LicenseDetail>>()
+const releaseOthers = vi.fn<() => Promise<LicenseDetail>>()
+
+/** The last good read: a keygen license with its cap full. */
+const LOADED: LicenseDetail = { key: 'KEY-ABC', used: 3, seats: 3, source: 'keygen', error: null }
+
+/** Every failure (and every counts-only success) arrives shaped like this — zeros that are NOT a
+ *  device count. What the store does with them is the whole point below. */
+const ZEROS = { key: null, used: 0, seats: 0, source: null } as const
+
+type Store = typeof import('./entitlement').useEntitlement
+
+/** Fresh module graph per test: the store is created at import time and subscribes to
+ *  window.nodeTerminal.license.onChange there, so the stub has to exist first. */
+async function freshStore(): Promise<Store> {
+  vi.resetModules()
+  vi.stubGlobal('window', {
+    nodeTerminal: {
+      license: { detail, releaseOthers, onChange: () => () => {} }
+    } as unknown as NodeTerminalApi
+  })
+  const { useEntitlement } = await import('./entitlement')
+  return useEntitlement
+}
+
+beforeEach(() => {
+  detail.mockReset()
+  releaseOthers.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('entitlement store — detail read vs release merge', () => {
+  it('a successful release keeps the key and the source, and updates the counts', async () => {
+    const useEntitlement = await freshStore()
+    detail.mockResolvedValue(LOADED)
+    await useEntitlement.getState().loadDetail()
+
+    // The wire's answer to a successful release: counts only.
+    releaseOthers.mockResolvedValue({ ...ZEROS, used: 1, seats: 3, error: null })
+    await useEntitlement.getState().releaseOthers()
+
+    const d = useEntitlement.getState().detail!
+    // The key is the ORIGINAL string — not merely truthy, and not absent. A merge that wrote the
+    // reply's `key: null` and one that dropped the field entirely both fail here.
+    expect(d.key).toBe('KEY-ABC')
+    // …and the source survives too: it is what decides whether this very action is offered.
+    expect(d.source).toBe('keygen')
+    expect(d).toEqual({ key: 'KEY-ABC', used: 1, seats: 3, source: 'keygen', error: null })
+  })
+
+  it('a 429 too_soon leaves the counts untouched and surfaces the retry window', async () => {
+    const useEntitlement = await freshStore()
+    detail.mockResolvedValue(LOADED)
+    await useEntitlement.getState().loadDetail()
+
+    releaseOthers.mockResolvedValue({ ...ZEROS, error: 'too_soon', retryAfterDays: 12 })
+    await useEntitlement.getState().releaseOthers()
+
+    const d = useEntitlement.getState().detail!
+    // Specifically the PRE-release values: 3, not 0. "Kept the old detail" and "wrote the reply's
+    // zeros" are different outcomes, and only asserting the exact numbers tells them apart.
+    expect(d.used).toBe(3)
+    expect(d.seats).toBe(3)
+    expect(d.key).toBe('KEY-ABC')
+    expect(d.error).toBe('too_soon')
+    expect(d.retryAfterDays).toBe(12)
+  })
+
+  it('a 400 not_applicable likewise does not zero the counts', async () => {
+    const useEntitlement = await freshStore()
+    detail.mockResolvedValue(LOADED)
+    await useEntitlement.getState().loadDetail()
+
+    releaseOthers.mockResolvedValue({ ...ZEROS, error: 'not_applicable' })
+    await useEntitlement.getState().releaseOthers()
+
+    const d = useEntitlement.getState().detail!
+    expect(d).toEqual({
+      key: 'KEY-ABC',
+      used: 3,
+      seats: 3,
+      source: 'keygen',
+      error: 'not_applicable'
+    })
+    expect(d.retryAfterDays).toBeUndefined()
+  })
+
+  it('a successful release clears a previous throttle, window and all', async () => {
+    const useEntitlement = await freshStore()
+    detail.mockResolvedValue(LOADED)
+    await useEntitlement.getState().loadDetail()
+
+    releaseOthers.mockResolvedValue({ ...ZEROS, error: 'too_soon', retryAfterDays: 12 })
+    await useEntitlement.getState().releaseOthers()
+    expect(useEntitlement.getState().detail!.retryAfterDays).toBe(12)
+
+    releaseOthers.mockResolvedValue({ ...ZEROS, used: 1, seats: 3, error: null })
+    await useEntitlement.getState().releaseOthers()
+
+    const d = useEntitlement.getState().detail!
+    expect(d.error).toBeNull()
+    // A stale window would tell the user to come back in 12 days for a release that just succeeded.
+    expect(d.retryAfterDays).toBeUndefined()
+  })
+
+  it('a release with nothing read yet merges over empties instead of throwing', async () => {
+    const useEntitlement = await freshStore()
+    expect(useEntitlement.getState().detail).toBeNull()
+
+    releaseOthers.mockResolvedValue({ ...ZEROS, used: 1, seats: 3, error: null })
+    await useEntitlement.getState().releaseOthers()
+
+    expect(useEntitlement.getState().detail).toEqual({
+      key: null,
+      used: 1,
+      seats: 3,
+      source: null,
+      error: null
+    })
+  })
+
+  it('loadDetail REPLACES wholesale — it is the one call that states every field', async () => {
+    const useEntitlement = await freshStore()
+    detail.mockResolvedValue(LOADED)
+    await useEntitlement.getState().loadDetail()
+
+    // The same install re-read after the entitlement moved to an App Store purchase: no key, no
+    // machines, source 'apple'. Merging here would keep a key that is no longer this license's
+    // and a source that would keep offering a release the server can only refuse.
+    const apple: LicenseDetail = { key: null, used: 0, seats: 0, source: 'apple', error: null }
+    detail.mockResolvedValue(apple)
+    await useEntitlement.getState().loadDetail()
+
+    expect(useEntitlement.getState().detail).toEqual(apple)
+  })
+
+  it('a failed read replaces too — its error is the state, not a footnote on stale counts', async () => {
+    const useEntitlement = await freshStore()
+    detail.mockResolvedValue(LOADED)
+    await useEntitlement.getState().loadDetail()
+
+    detail.mockResolvedValue({ ...ZEROS, error: 'offline' })
+    await useEntitlement.getState().loadDetail()
+
+    const d = useEntitlement.getState().detail!
+    expect(d.error).toBe('offline')
+    // The UI reads `error` first and must not render these as a device count — but they are the
+    // read's own answer, so the store forwards them rather than papering over with the last ones.
+    expect(d.key).toBeNull()
+    expect(d.used).toBe(0)
+  })
+})

--- a/src/renderer/state/entitlement.test.ts
+++ b/src/renderer/state/entitlement.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { LicenseDetail, NodeTerminalApi } from '@shared/types'
 
 // The license routes answer two DIFFERENT shapes, and that asymmetry is what these tests are about:
-// `detail` states every field, while `release` answers with COUNTS ONLY — no key, no source (and a
-// FAILED release changed nothing on the server at all). So the store replaces on the first and
-// merges on the second; getting that backwards silently blanks the key the user came to copy, or
-// renders "0 of 0 devices" from a call that never ran.
+// `detail` states every field, while `release` answers with COUNTS ONLY — no key, no source. So the
+// store replaces on the first and merges on the second; getting that backwards silently blanks the
+// key the user came to copy, or renders "0 of 0 devices" from a call that never ran.
+//
+// The release's ERROR is split a second time, and that split is the other half of this file: a
+// refusal (`too_soon` / `not_applicable`) is a fact about the license and rides `detail`; anything
+// else is a fact about the CALL, is handed back to the caller, and must leave `detail` alone. Note
+// what is NOT claimed anywhere below: that a failed release changed nothing on the server. For
+// `offline`/`network` the request may well have landed and only the reply been lost.
 
 const detail = vi.fn<() => Promise<LicenseDetail>>()
 const releaseOthers = vi.fn<() => Promise<LicenseDetail>>()
@@ -49,7 +54,7 @@ describe('entitlement store — detail read vs release merge', () => {
 
     // The wire's answer to a successful release: counts only.
     releaseOthers.mockResolvedValue({ ...ZEROS, used: 1, seats: 3, error: null })
-    await useEntitlement.getState().releaseOthers()
+    expect(await useEntitlement.getState().releaseOthers()).toBeNull()
 
     const d = useEntitlement.getState().detail!
     // The key is the ORIGINAL string — not merely truthy, and not absent. A merge that wrote the
@@ -66,7 +71,9 @@ describe('entitlement store — detail read vs release merge', () => {
     await useEntitlement.getState().loadDetail()
 
     releaseOthers.mockResolvedValue({ ...ZEROS, error: 'too_soon', retryAfterDays: 12 })
-    await useEntitlement.getState().releaseOthers()
+    // Null: a refusal is a fact about the license, it rides `detail`, and licenseSentence speaks
+    // for it. Returning it here as well would print the throttle twice, in two wordings.
+    expect(await useEntitlement.getState().releaseOthers()).toBeNull()
 
     const d = useEntitlement.getState().detail!
     // Specifically the PRE-release values: 3, not 0. "Kept the old detail" and "wrote the reply's
@@ -76,6 +83,48 @@ describe('entitlement store — detail read vs release merge', () => {
     expect(d.key).toBe('KEY-ABC')
     expect(d.error).toBe('too_soon')
     expect(d.retryAfterDays).toBe(12)
+  })
+
+  it('a release that FAILED leaves the detail untouched and hands the code back', async () => {
+    const useEntitlement = await freshStore()
+    detail.mockResolvedValue(LOADED)
+    await useEntitlement.getState().loadDetail()
+
+    // Pressing "Release other devices" on a laptop that just lost wifi. Before this split, the
+    // 'offline' code was merged onto `detail` and the panel replaced the device-count line with
+    // "Could not read this license right now…" — while the real key sat in the box above it and
+    // nothing on screen mentioned the release at all.
+    releaseOthers.mockResolvedValue({ ...ZEROS, error: 'offline' })
+    expect(await useEntitlement.getState().releaseOthers()).toBe('offline')
+
+    // Byte for byte the last good read: not the reply's zeros, and not the last read plus an
+    // `error`. An implementation that merges the code and ALSO returns it passes a bare
+    // "returns the code" assertion and still shows the user a failed-read sentence.
+    expect(useEntitlement.getState().detail).toEqual(LOADED)
+  })
+
+  it('does the same for every non-refusal code the release route can answer', async () => {
+    const useEntitlement = await freshStore()
+    detail.mockResolvedValue(LOADED)
+    await useEntitlement.getState().loadDetail()
+
+    // core/license.ts produces all of these on the release route too — the module doc that named
+    // only too_soon/not_applicable was wrong about its own seam, which is how this shipped.
+    for (const error of ['unauthorized', 'inactive', 'disabled', 'network']) {
+      releaseOthers.mockResolvedValue({ ...ZEROS, error })
+      expect(await useEntitlement.getState().releaseOthers(), error).toBe(error)
+      expect(useEntitlement.getState().detail, error).toEqual(LOADED)
+    }
+  })
+
+  it('a failed release with nothing read yet leaves detail null rather than inventing zeros', async () => {
+    const useEntitlement = await freshStore()
+    releaseOthers.mockResolvedValue({ ...ZEROS, error: 'offline' })
+
+    expect(await useEntitlement.getState().releaseOthers()).toBe('offline')
+    // Merging over EMPTY_DETAIL here would publish "0 of 0 devices, no key" as the license's
+    // state, produced entirely by a call that never reached the server.
+    expect(useEntitlement.getState().detail).toBeNull()
   })
 
   it('a 400 not_applicable likewise does not zero the counts', async () => {

--- a/src/renderer/state/entitlement.test.ts
+++ b/src/renderer/state/entitlement.test.ts
@@ -135,6 +135,12 @@ describe('entitlement store — detail read vs release merge', () => {
     const useEntitlement = await freshStore()
     detail.mockResolvedValue(LOADED)
     await useEntitlement.getState().loadDetail()
+    // Leave an OPTIONAL field in state first. Every other field is stated by the incoming reply,
+    // so `{...prev, ...next}` is byte-identical to a replace and nothing could tell them apart;
+    // `retryAfterDays` is the one thing a merge would carry over, so it is the discriminator.
+    releaseOthers.mockResolvedValue({ ...ZEROS, error: 'too_soon', retryAfterDays: 12 })
+    await useEntitlement.getState().releaseOthers()
+    expect(useEntitlement.getState().detail!.retryAfterDays).toBe(12)
 
     // The same install re-read after the entitlement moved to an App Store purchase: no key, no
     // machines, source 'apple'. Merging here would keep a key that is no longer this license's
@@ -144,12 +150,15 @@ describe('entitlement store — detail read vs release merge', () => {
     await useEntitlement.getState().loadDetail()
 
     expect(useEntitlement.getState().detail).toEqual(apple)
+    expect(useEntitlement.getState().detail!.retryAfterDays).toBeUndefined()
   })
 
   it('a failed read replaces too — its error is the state, not a footnote on stale counts', async () => {
     const useEntitlement = await freshStore()
     detail.mockResolvedValue(LOADED)
     await useEntitlement.getState().loadDetail()
+    releaseOthers.mockResolvedValue({ ...ZEROS, error: 'too_soon', retryAfterDays: 12 })
+    await useEntitlement.getState().releaseOthers()
 
     detail.mockResolvedValue({ ...ZEROS, error: 'offline' })
     await useEntitlement.getState().loadDetail()
@@ -160,5 +169,7 @@ describe('entitlement store — detail read vs release merge', () => {
     // read's own answer, so the store forwards them rather than papering over with the last ones.
     expect(d.key).toBeNull()
     expect(d.used).toBe(0)
+    // …and the refused release's retry window does not survive a fresh read (see above).
+    expect(d.retryAfterDays).toBeUndefined()
   })
 })

--- a/src/renderer/state/entitlement.ts
+++ b/src/renderer/state/entitlement.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { LicenseDetail, LicenseStatus } from '@shared/types'
+import { isReleaseRefusal } from '@renderer/lib/licenseCopy'
 
 interface EntitlementState {
   status: LicenseStatus
@@ -11,7 +12,8 @@ interface EntitlementState {
   /**
    * The license key + device usage, or null before the first read.
    *
-   * **`detail.error` carries TWO different facts, and only the code word separates them:**
+   * **`detail.error` here means ONE thing: the last DETAIL READ, or a release refusal about the
+   * license itself.** Only two kinds of code can be in it:
    * - **The read failed** — `unauthorized` | `inactive` | `offline` | `disabled` | `network`.
    *   Everything beside it is a placeholder: the zeros are NOT a device count and the null key is
    *   not "no key". Render the failure, never the numbers.
@@ -20,6 +22,11 @@ interface EntitlementState {
    *   `source` and the counts are real and worth showing — say the action was refused, not that
    *   the license could not be read. (The counts are the last good read's; if nothing was ever
    *   read successfully they are still EMPTY_DETAIL's zeros, so call `loadDetail` first.)
+   *
+   * A release that failed for any OTHER reason never lands here — `releaseOthers` hands that code
+   * back to its caller instead. It said nothing about the license, and merging it made the panel
+   * replace a real key and real counts with "could not read this license", while saying nothing
+   * about the action the user had just pressed.
    */
   detail: LicenseDetail | null
   hydrate(): Promise<void>
@@ -34,9 +41,18 @@ interface EntitlementState {
    *  layer in `src/server`), and neither this nor `releaseOthers` catches it. A caller that fires
    *  this on mount must `.catch(…)`, or it is an unhandled rejection on every browser session. */
   loadDetail(): Promise<void>
-  /** Deactivate every other device on this license, then fold the new counts into `detail`.
-   *  Rejects on the Server Edition exactly like `loadDetail` — see there. */
-  releaseOthers(): Promise<void>
+  /**
+   * Deactivate every other device on this license, then fold the new counts into `detail`.
+   *
+   * Resolves to `null` when the release landed, or when the server refused it on terms `detail`
+   * can carry (`too_soon` / `not_applicable` — merged onto the last good read, where
+   * `licenseSentence` speaks for them). Any OTHER reason code is resolved AS the value and
+   * `detail` is left exactly as it was: that code is about the call, not the license, so only the
+   * caller — which knows a release was attempted — can say anything true about it.
+   *
+   * Rejects on the Server Edition exactly like `loadDetail` — see there.
+   */
+  releaseOthers(): Promise<string | null>
 }
 
 const EMPTY: LicenseStatus = { tier: null, active: false, expiresAt: null, seats: 0, error: null }
@@ -77,15 +93,22 @@ export const useEntitlement = create<EntitlementState>((set, get) => {
     async releaseOthers() {
       const r = await window.nodeTerminal.license.releaseOthers()
       const prev = get().detail ?? EMPTY_DETAIL
+      // A release that did not land tells us nothing about the license, and for `offline`/`network`
+      // it does not even tell us the server did nothing — the request may have arrived and only
+      // the reply been lost. So `detail` keeps the last good read untouched (its key and counts are
+      // still the best thing we know) and the code goes back to the caller, which is the only
+      // place that knows a RELEASE was pressed and can say so.
+      if (r.error && !isReleaseRefusal(r.error)) return r.error
       // The release route answers with COUNTS ONLY — no key, no source. Replacing `detail`
       // wholesale would blank the key the user came to this screen to copy, and drop the source
-      // that decides whether this action is offered at all. And a FAILED release changed nothing
-      // on the server, so its zeroed counts must not land either: only the reason code rides.
+      // that decides whether this action is offered at all. A refusal carries no counts either
+      // (its zeros are placeholders), so only its reason code rides.
       set({
         detail: r.error
           ? { ...prev, error: r.error, retryAfterDays: r.retryAfterDays }
           : { ...prev, used: r.used, seats: r.seats, error: null, retryAfterDays: undefined }
       })
+      return null
     }
   }
 })

--- a/src/renderer/state/entitlement.ts
+++ b/src/renderer/state/entitlement.ts
@@ -8,8 +8,19 @@ interface EntitlementState {
   /** Team seat cap (premium → max(3, N), premium-no-field → 3 = Pro's free seats, free/inactive
    *  → 0). Mirrors `status.seats` so the Team seats section can select it directly. */
   seats: number
-  /** The license key + device usage, or null before the first read. `detail.error` is the read's
-   *  verdict: non-null means we could not look, and its zeros are NOT a device count. */
+  /**
+   * The license key + device usage, or null before the first read.
+   *
+   * **`detail.error` carries TWO different facts, and only the code word separates them:**
+   * - **The read failed** — `unauthorized` | `inactive` | `offline` | `disabled` | `network`.
+   *   Everything beside it is a placeholder: the zeros are NOT a device count and the null key is
+   *   not "no key". Render the failure, never the numbers.
+   * - **The read was fine; the RELEASE was refused** — `too_soon` (with `retryAfterDays`) |
+   *   `not_applicable`. These ride on top of the last good read (see `releaseOthers`), so `key`,
+   *   `source` and the counts are real and worth showing — say the action was refused, not that
+   *   the license could not be read. (The counts are the last good read's; if nothing was ever
+   *   read successfully they are still EMPTY_DETAIL's zeros, so call `loadDetail` first.)
+   */
   detail: LicenseDetail | null
   hydrate(): Promise<void>
   /** Open Stripe checkout for this device; Pro arrives via onChange when the purchase lands.
@@ -18,9 +29,13 @@ interface EntitlementState {
   activate(key: string): Promise<void>
   deactivate(): Promise<void>
   /** Read the key + device usage (token-authorized). Replaces `detail` wholesale — it is the one
-   *  call that states every field. */
+   *  call that states every field.
+   *  **REJECTS on the Server Edition** (`E_UNSUPPORTED` from the bridge stub — there is no license
+   *  layer in `src/server`), and neither this nor `releaseOthers` catches it. A caller that fires
+   *  this on mount must `.catch(…)`, or it is an unhandled rejection on every browser session. */
   loadDetail(): Promise<void>
-  /** Deactivate every other device on this license, then fold the new counts into `detail`. */
+  /** Deactivate every other device on this license, then fold the new counts into `detail`.
+   *  Rejects on the Server Edition exactly like `loadDetail` — see there. */
   releaseOthers(): Promise<void>
 }
 

--- a/src/renderer/state/entitlement.ts
+++ b/src/renderer/state/entitlement.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { LicenseStatus } from '@shared/types'
+import type { LicenseDetail, LicenseStatus } from '@shared/types'
 
 interface EntitlementState {
   status: LicenseStatus
@@ -8,17 +8,33 @@ interface EntitlementState {
   /** Team seat cap (premium → max(3, N), premium-no-field → 3 = Pro's free seats, free/inactive
    *  → 0). Mirrors `status.seats` so the Team seats section can select it directly. */
   seats: number
+  /** The license key + device usage, or null before the first read. `detail.error` is the read's
+   *  verdict: non-null means we could not look, and its zeros are NOT a device count. */
+  detail: LicenseDetail | null
   hydrate(): Promise<void>
   /** Open Stripe checkout for this device; Pro arrives via onChange when the purchase lands.
    * `target: 'seats'` opens the add-seats (quantity) link instead of base Pro. */
   upgrade(target?: 'pro' | 'seats'): Promise<void>
   activate(key: string): Promise<void>
   deactivate(): Promise<void>
+  /** Read the key + device usage (token-authorized). Replaces `detail` wholesale — it is the one
+   *  call that states every field. */
+  loadDetail(): Promise<void>
+  /** Deactivate every other device on this license, then fold the new counts into `detail`. */
+  releaseOthers(): Promise<void>
 }
 
 const EMPTY: LicenseStatus = { tier: null, active: false, expiresAt: null, seats: 0, error: null }
 
-export const useEntitlement = create<EntitlementState>((set) => {
+const EMPTY_DETAIL: LicenseDetail = {
+  key: null,
+  used: 0,
+  seats: 0,
+  source: null,
+  error: null
+}
+
+export const useEntitlement = create<EntitlementState>((set, get) => {
   const apply = (status: LicenseStatus) =>
     set({ status, isPremium: status.active, seats: status.seats })
   // Live updates from the main process (launch refresh, offline grace).
@@ -27,6 +43,7 @@ export const useEntitlement = create<EntitlementState>((set) => {
     status: EMPTY,
     isPremium: false,
     seats: 0,
+    detail: null,
     async hydrate() {
       apply(await window.nodeTerminal.license.getStatus())
     },
@@ -38,6 +55,22 @@ export const useEntitlement = create<EntitlementState>((set) => {
     },
     async deactivate() {
       apply(await window.nodeTerminal.license.deactivate())
+    },
+    async loadDetail() {
+      set({ detail: await window.nodeTerminal.license.detail() })
+    },
+    async releaseOthers() {
+      const r = await window.nodeTerminal.license.releaseOthers()
+      const prev = get().detail ?? EMPTY_DETAIL
+      // The release route answers with COUNTS ONLY — no key, no source. Replacing `detail`
+      // wholesale would blank the key the user came to this screen to copy, and drop the source
+      // that decides whether this action is offered at all. And a FAILED release changed nothing
+      // on the server, so its zeroed counts must not land either: only the reason code rides.
+      set({
+        detail: r.error
+          ? { ...prev, error: r.error, retryAfterDays: r.retryAfterDays }
+          : { ...prev, used: r.used, seats: r.seats, error: null, retryAfterDays: undefined }
+      })
     }
   }
 })

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -158,6 +158,8 @@ export const IPC = {
   licenseStatus: 'license:status',
   licenseChanged: 'license:changed',
   licenseUpgrade: 'license:upgrade',
+  licenseDetail: 'license:detail',
+  licenseRelease: 'license:release',
   appRestartToUpdate: 'app:restart-to-update',
   announcementsFetch: 'announcements:fetch',
   usageFetch: 'usage:fetch',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2307,8 +2307,11 @@ export interface PairedDevice {
   lastSeenAt: number
   /**
    * The phone's OWN device id — what the relay backend keys its device row on, as opposed to
-   * `id`, which is ours. Absent for devices paired before this field existed, i.e. "there is no
-   * server row we can name". An id, not a secret, which is why it may cross to the renderer.
+   * `id`, which is ours. Absent for devices paired before this field existed; that is NOT "there
+   * is no server row we can name", because a revoke then falls back to `id`, which is the value
+   * the mint sent as the row's key whenever the phone supplied no id of its own (see
+   * `revokeDevice` in main/pairing-service.ts, including the residual case it cannot name). An id,
+   * not a secret, which is why it may cross to the renderer.
    */
   relayDeviceId?: string
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2317,8 +2317,12 @@ export interface PairedDevice {
  * The server leg of a device revoke — three states, because two cannot tell the truth apart.
  * 'ok' = the backend confirmed; 'failed' = we asked and were refused or could not reach it;
  * 'skipped' = we did not ask and that is fine (no entitlement to sign with — a free-tier desktop
- * has no Pro of ours on that phone to reclaim — or no relay device id to name). Only 'failed' is
- * a warning: reporting 'skipped' as a failure would tell a free user their phone's Pro is stuck.
+ * has no Pro of ours on that phone to reclaim — or no such device to name). Only 'failed' is a
+ * warning: reporting 'skipped' as a failure would tell a free user their phone's Pro is stuck.
+ *
+ * 'ok' is the backend's 204, which is idempotent and reveals nothing about WHICH row it applied
+ * to — see the residual-leak note on `revokeDevice` in main/pairing-service.ts before treating it
+ * as proof that a particular phone lost Pro.
  */
 export type DeviceRevokeServerOutcome = 'ok' | 'failed' | 'skipped'
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2313,6 +2313,26 @@ export interface PairedDevice {
   relayDeviceId?: string
 }
 
+/**
+ * The server leg of a device revoke — three states, because two cannot tell the truth apart.
+ * 'ok' = the backend confirmed; 'failed' = we asked and were refused or could not reach it;
+ * 'skipped' = we did not ask and that is fine (no entitlement to sign with — a free-tier desktop
+ * has no Pro of ours on that phone to reclaim — or no relay device id to name). Only 'failed' is
+ * a warning: reporting 'skipped' as a failure would tell a free user their phone's Pro is stuck.
+ */
+export type DeviceRevokeServerOutcome = 'ok' | 'failed' | 'skipped'
+
+/**
+ * Both legs of a device revoke, reported independently so a half-finished removal can never render
+ * as a clean one (the same discipline as remote/revocation.ts's persisted/killed).
+ */
+export interface DeviceRevokeResult {
+  /** The agent.json entry + authorized_keys line were removed from this machine. */
+  local: boolean
+  /** Whether the phone's Pro entitlement was taken back on the relay backend. */
+  server: DeviceRevokeServerOutcome
+}
+
 /** Phone-pairing (nodeterm iOS "scan a QR" flow) bridge. */
 export interface PairingApi {
   /** Start the one-shot LAN listener; resolves with the QR payload + an SSH-reachable hint. */
@@ -2330,8 +2350,11 @@ export interface PairingApi {
   openRemoteLoginSettings(): Promise<void>
   /** List paired devices from ~/.nodeterm/agent.json (never includes the token). */
   listDevices(): Promise<PairedDevice[]>
-  /** Revoke a device: remove its registry entry and delete its authorized_keys line. */
-  revokeDevice(id: string): Promise<void>
+  /**
+   * Revoke a device: remove its registry entry, delete its authorized_keys line, and take its Pro
+   * entitlement back on the relay backend. Never rejects for a leg that failed — read the result.
+   */
+  revokeDevice(id: string): Promise<DeviceRevokeResult>
 }
 
 /** Team presence (docs/team-presence.md). All of it is transient — nothing here is persisted. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2122,6 +2122,35 @@ export interface LicenseStatus {
   error: string | null
 }
 
+/**
+ * Where the entitlement behind this install came from. A verified entitlement's licenseId is NOT
+ * always a keygen license id: an App Store purchase on a paired phone bridges Pro to the desktop
+ * and mints `apple:<txn>`, and `free:` exists too. For those the server makes zero keygen calls
+ * and answers `key: null, used: 0, seats: 0` — genuinely "device counting does not apply here",
+ * which is a different fact from a failed read and from a keygen license with no devices yet.
+ */
+export type LicenseSource = 'keygen' | 'apple' | 'free'
+
+/** What Settings → License shows: the key to copy and how much of the device cap is in use.
+ *  A failed read is an ERROR, never "0 devices" — the two are different facts. */
+export interface LicenseDetail {
+  /** The license key to copy. `null` on a 200 is legitimate (a keygen policy that hides keys, a
+   *  license predating the column, a non-keygen source) — it is NOT an error. */
+  key: string | null
+  /** Devices currently activated. May EXCEED `seats` if a cap was lowered after activation. */
+  used: number
+  seats: number
+  /** The source the server stated, or null when it stated none — every error reply, and the
+   *  release route's 200, which answers with counts only. Never inferred locally. */
+  source: LicenseSource | null
+  /** Null on success; a stable reason code otherwise ('unauthorized' | 'inactive' | 'offline' |
+   *  'disabled' | 'too_soon' | 'not_applicable' | 'network'). A failed read is an error, never
+   *  "0 devices". */
+  error: string | null
+  /** Days until another release is allowed — only set with error === 'too_soon'. */
+  retryAfterDays?: number
+}
+
 export interface LicenseApi {
   /** Open Stripe checkout bound to this device and poll for the entitlement (no key paste).
    * `target` picks the link: 'seats' = the add-seats (quantity) link, else base Pro (default).
@@ -2135,6 +2164,13 @@ export interface LicenseApi {
   getStatus(): Promise<LicenseStatus>
   /** Fires when the license status changes. Returns unsubscribe. */
   onChange(listener: (s: LicenseStatus) => void): () => void
+  /** The license key + device usage for this machine's license. Authorized by the stored
+   *  entitlement token — never by deviceId. */
+  detail(): Promise<LicenseDetail>
+  /** Deactivate every device on this license except this one. Throttled server-side to once
+   *  per 30 days (error 'too_soon' + retryAfterDays). Answers with COUNTS only: no key and no
+   *  source ride a successful release, so callers must merge rather than replace. */
+  releaseOthers(): Promise<LicenseDetail>
 }
 
 export interface RemoteHostApi {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2305,6 +2305,12 @@ export interface PairedDevice {
   pairedAt: number
   /** epoch-ms the host agent last saw this device (0 = never). */
   lastSeenAt: number
+  /**
+   * The phone's OWN device id — what the relay backend keys its device row on, as opposed to
+   * `id`, which is ours. Absent for devices paired before this field existed, i.e. "there is no
+   * server row we can name". An id, not a secret, which is why it may cross to the renderer.
+   */
+  relayDeviceId?: string
 }
 
 /** Phone-pairing (nodeterm iOS "scan a QR" flow) bridge. */


### PR DESCRIPTION
The desktop half of the license-visibility work. Pairs with **eneskirca/nodeterm-server#1** — neither half is meaningful alone.

A paying Stripe subscriber wrote in: he never received a license key and could not run nodeterm on a second Mac. The app said "Pro" and showed him nothing he could carry anywhere. This adds the surface that answers him, and makes Settings → Phone's "Remove" button mean what it says.

## What this adds

- **Settings → License** now shows the license key with a copy button, the device count against the cap, and a **Release other devices** action for reclaiming seats a wiped or replaced Mac can no longer free itself.
- **Settings → Phone → Remove** finally tells the server. It previously unpinned the peer key and cut the socket locally while the server kept minting Pro for that phone forever. The desktop also now remembers which phone a paired device is — the phone's relay id was computed at pairing and thrown away, so there was no row to name.
- `license.detail()` / `license.releaseOthers()` across core → preload → the browser bridge → the store, with Server Edition rejecting rather than resolving a fabricated answer.

## The copy is the feature here

The panel's sentences are derived in one pure, tested module, because most of the ways this feature can fail are ways it can say something untrue:

- An **App Store subscriber** whose Pro comes from a paired phone is told exactly that, rather than "No key is on file — get in touch" about a key that does not exist for them.
- A **failed read** is never rendered as "0 of 3 devices in use". The guard that makes this safe keys on the *type*, not the value: a stated `0` is truth, an absent field is not — which is what lets a legitimate `apple` reply through while a captive portal's 200 HTML page does not.
- `error` carries two families and only the code word separates them: a failed read (the counts are placeholders) versus a refused release (the key and counts are the last good read and worth showing). Rendering "could not read" over a throttled release was the trap.

## What the final review caught

- **A failed release was rendered as a failed *read*, and the release itself was never mentioned.** Pressing Release while offline replaced the device-count line with "could not read this license" — while the key sat in the box above it — and returned the button to idle as if it had worked. The panel now owns release errors.
- **The flow the feature exists for dead-ended in a raw `seat_limit`**, and the "paste this key on another Mac" line rendered even at the cap, telling the user to do the thing that would fail.
- **A destructive, 30-day-throttled action had no confirmation**, in a repo that confirms revoking a single phone.
- **An App Store subscriber's first screen contradicted itself** — a "License key" field reading "not available" above a sentence saying no key exists.
- **The revoke copy prescribed a remedy that does not fit** (a 403 never clears by waiting, and the suggested re-pairing restores the phone's Pro), and the success path never said the phone keeps Pro for up to 7 days.
- **"Deactivate on this device" silently destroyed the only in-app copy of the key.**
- Two comments stated the opposite of shipped behaviour — the same defect class that had already cost a review round here, because a false comment stops the next reader looking.

## Deliberate

- **No auto-refresh after an uncertain release failure.** `loadDetail` replaces unconditionally, so reloading while offline would overwrite a valid last-good read with placeholder zeros and re-create the bug above. Reopening Settings genuinely re-reads.
- **Server Edition rejects** both new calls with `E_UNSUPPORTED` (there is no license layer in `src/server`), so the panel hides rather than showing a failed read. Mobile learns nothing new.

## Owed before this ships

- **Device verification** — 6 steps in the plan: two Macs on one license, the cap, release, phone pairing and removal, and pairing over the cap. Nothing here has been rendered in a running app.
- The server's keygen policy must actually allow 3 machines; the panel's denominator is a client-side constant.
- **Filed, not fixed:** the `fetch(...).finally(() => clearTimeout(t))` pattern this PR corrects in `core/license.ts` exists at seven other sites (four usage readers, `check.ts`, `telemetry.ts`, `hook-server.ts`). The timeout is cleared when *headers* arrive, so a stalled body hangs forever — and the usage ones are awaited by UI affordances.

6862 tests, `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
