### PR TITLE
fix(build): keep every local package off the production update feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "server:dev": "npm run build && npm run server:build && node out/server/main.cjs",
     "make-icon": "node scripts/make-icon.mjs",
     "make-social": "node scripts/make-social.mjs",
-    "dist": "npm run make-icon && electron-vite build && electron-builder --mac --arm64 -c.mac.identity=null -c.mac.notarize=false",
-    "dist:linux": "npm run make-icon && electron-vite build && electron-builder --linux",
+    "dist": "npm run make-icon && electron-vite build && electron-builder --mac --arm64 --publish never -c.mac.identity=null -c.mac.notarize=false -c.extraMetadata.nodeTermUpdates=disabled",
+    "dist:linux": "npm run make-icon && electron-vite build && electron-builder --linux --publish never -c.extraMetadata.nodeTermUpdates=disabled",
     "release": "npm run make-icon && electron-vite build && sh -c 'electron-builder --mac --arm64 --x64 --publish never; s=$?; npm run rebuild; exit $s'",
     "postinstall": "node scripts/patch-node-pty.mjs && electron-rebuild -f -w node-pty,smart-whisper"
   },

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -5,15 +5,49 @@
 // requires a signed + notarized build; unsigned builds still surface the card for a manual
 // download.
 import { app, ipcMain, Notification } from 'electron'
+import fs from 'fs'
+import path from 'path'
 // Named import — the default-import + destructure pattern returns undefined under
 // electron-vite v5's CJS interop.
 import { autoUpdater } from 'electron-updater'
 import { IPC } from '../shared/ipc'
-import { isManualUpdatePlatform, toUpdateAvailablePayload } from '../shared/update-platform'
+import {
+  isManualUpdatePlatform,
+  shouldEnableUpdater,
+  toUpdateAvailablePayload
+} from '../shared/update-platform'
 import { getMainWindow, sendToMain } from './main-window'
 import { retainUntilDismissed } from './notifications'
 
 const SIX_HOURS = 6 * 60 * 60 * 1000
+
+/**
+ * The `nodeTermUpdates` marker a LOCAL package carries in its packaged package.json, injected by
+ * the `dist*` scripts via electron-builder's `extraMetadata`. `release` does not set it, so a
+ * promoted build is untouched and keeps updating itself.
+ *
+ * It exists because a locally packaged app is indistinguishable from a release at runtime —
+ * `app.isPackaged` is true for both — so it polled the production feed for a version that was
+ * never published there and logged a 404 on `latest*.yml` every six hours.
+ *
+ * The trade-off, stated plainly: a `dist*` package can no longer smoke-test the updater wiring
+ * itself — a manual check there now answers "up to date" without going near the network. The old
+ * behaviour at least proved the wiring was live, at the cost of a recurring 404 in every local
+ * build's log. Verifying the real feed is the job of a `release` package, which carries no marker.
+ */
+function packagedUpdateMode(): unknown {
+  if (!app.isPackaged) return undefined
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(app.getAppPath(), 'package.json'), 'utf8')) as {
+      nodeTermUpdates?: unknown
+    }
+    return pkg.nodeTermUpdates
+  } catch (err) {
+    // A normal release without the marker must preserve the established updater behavior.
+    console.warn('[updater] could not read packaged update mode:', err)
+    return undefined
+  }
+}
 
 /**
  * The window is resolved AT EVENT TIME (getMainWindow/sendToMain) — never captured in a closure.
@@ -37,9 +71,9 @@ export function initUpdater(onBeforeRestart?: () => void): void {
     autoUpdater.quitAndInstall()
   })
 
-  if (!app.isPackaged) {
-    // Dev: there is no update server. A manual check reports "up to date" so the Settings
-    // button still gives feedback; automatic checks are skipped entirely.
+  if (!shouldEnableUpdater(app.isPackaged, packagedUpdateMode())) {
+    // Dev and explicitly local/unsigned packages have no update channel. A manual check reports
+    // "up to date" for feedback; automatic networking and updater event wiring stay disabled.
     ipcMain.on(IPC.appCheckForUpdates, () => send(IPC.appUpdateNotAvailable))
     return
   }

--- a/src/shared/update-platform.test.ts
+++ b/src/shared/update-platform.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { isManualUpdatePlatform, toUpdateAvailablePayload } from './update-platform'
+import fs from 'fs'
+import path from 'path'
+import {
+  isManualUpdatePlatform,
+  shouldEnableUpdater,
+  toUpdateAvailablePayload
+} from './update-platform'
 
 describe('isManualUpdatePlatform', () => {
   it('linux with APPIMAGE set → auto (self-installs)', () => {
@@ -17,6 +23,43 @@ describe('isManualUpdatePlatform', () => {
 
   it('win32 → auto', () => {
     expect(isManualUpdatePlatform('win32', false)).toBe(false)
+  })
+})
+
+describe('shouldEnableUpdater', () => {
+  it('disables checks in development and in explicitly local packaged builds', () => {
+    expect(shouldEnableUpdater(false, undefined)).toBe(false)
+    expect(shouldEnableUpdater(true, 'disabled')).toBe(false)
+  })
+
+  it('keeps updater behavior unchanged for normal packaged releases', () => {
+    expect(shouldEnableUpdater(true, undefined)).toBe(true)
+    expect(shouldEnableUpdater(true, 'enabled')).toBe(true)
+  })
+})
+
+/**
+ * `shouldEnableUpdater` is only half the fix — it reads a marker the BUILD has to set. A `dist*`
+ * script that forgets it produces a package indistinguishable from a release (`app.isPackaged` is
+ * true for both), which then polls the production feed for a version nobody published and logs a
+ * 404 on `latest*.yml` every six hours. That is a build-config mistake no unit test of the pure
+ * function can catch, so assert it against the real package.json — the same guard-test shape as
+ * `src/core/no-electron.test.ts`.
+ */
+describe('local dist scripts opt out of the production update feed', () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf8')
+  ) as { scripts: Record<string, string> }
+  const MARKER = '-c.extraMetadata.nodeTermUpdates=disabled'
+
+  it('every dist script carries the marker — not just the one whose 404 was noticed', () => {
+    const dist = Object.keys(pkg.scripts).filter((s) => s === 'dist' || s.startsWith('dist:'))
+    expect(dist.length).toBeGreaterThanOrEqual(2) // dist, dist:linux
+    expect(dist.filter((s) => !pkg.scripts[s].includes(MARKER))).toEqual([])
+  })
+
+  it('release does NOT carry it — a promoted build must keep updating itself', () => {
+    expect(pkg.scripts.release).not.toContain(MARKER)
   })
 })
 

--- a/src/shared/update-platform.ts
+++ b/src/shared/update-platform.ts
@@ -15,6 +15,11 @@ export function isManualUpdatePlatform(platform: string, hasAppImage: boolean): 
   return platform === 'linux' && !hasAppImage
 }
 
+/** True when updater networking should be initialized for this runtime/build. */
+export function shouldEnableUpdater(isPackaged: boolean, updateMode: unknown): boolean {
+  return isPackaged && updateMode !== 'disabled'
+}
+
 /** Reduce an electron-updater update-available info to the renderer's UpdateInfo payload. */
 export function toUpdateAvailablePayload(
   info: { version: string; releaseNotes?: unknown },


### PR DESCRIPTION
Split out of #111 at your request — this is the part with nothing Windows-specific in it.

## Problem

A locally packaged app is indistinguishable from a release at runtime — `app.isPackaged` is true for both — so any `dist`-produced build initialized electron-updater against the production feed, polled it for a version nobody published, and logged a 404 on `latest*.yml` at boot and every six hours after.

## Change

- `shouldEnableUpdater(isPackaged, updateMode)` gates the packaged path on a `nodeTermUpdates` marker, which `packagedUpdateMode()` reads back from the packaged `package.json`;
- `dist` and `dist:linux` inject that marker through electron-builder's `extraMetadata`;
- `--publish never` comes with it: electron-builder defaults to `onTagOrDraft`, which on a tagged checkout with a token in the environment would try to publish a local smoke build;
- `release` does not set the marker, so a promoted build wires up and updates itself exactly as before. The CI release workflow packages Linux through `electron-builder` directly and never goes through `dist:linux`, so it is unaffected either way.

The trade-off, stated plainly: a `dist` package can no longer smoke-test the updater wiring itself — a manual check now answers "up to date" without going near the network. The old behaviour at least proved the wiring was live, at the cost of a recurring 404 in every local build's log. Verifying against the real feed is a release package's job.

The guard test asserts the **scripts themselves**, not just the pure function: a `dist` script that forgets the marker is a build-config mistake no unit test of `shouldEnableUpdater` can catch, and the failure mode is silent. Same shape as `src/core/no-electron.test.ts`.

## Verification

Run on Windows with Node 22 (CI on `ubuntu-latest` is the real check — nothing here is platform-dependent):

- `npm run typecheck` passes;
- `src/shared/update-platform.test.ts` — 10/10;
- `npm run test:unit` — 49/49 across 9 files;
- `npm run build` passes;
- the guard test was checked by **mutation**: dropping the marker from `dist:linux` fails it with `["dist:linux"]`, and restoring it passes. A build-config guard that can pass vacuously guards nothing.
