### PR TITLE
feat(quit): confirm before quitting the app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ permissions:
 
 jobs:
   quality:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -361,6 +361,39 @@ let activeRemote: { cwd: string; ref: GitRemoteRef } | null = null
 // True from the first before-quit on: lets window close-events through (see hide-on-close).
 let quitting = false
 
+// Confirm-before-quit gate. Set once the user has answered "Quit" in the dialog below, or when
+// a quit is app-initiated rather than user-initiated (auto-update restart) and should not be
+// interrupted by a prompt for a decision already made. `pending` dedupes concurrent triggers
+// (shortcut + menu + window-close firing in the same tick) into a single dialog.
+let quitConfirmed = false
+let skipQuitConfirmation = false
+let quitConfirmationPending = false
+
+/** Resolves true once quitting may proceed. Shows a native confirm dialog (all platforms) on
+ * first call; a Quit answer is remembered so the re-issued app.quit() below is not re-prompted. */
+function confirmQuit(parentWin: BrowserWindow | null): Promise<boolean> {
+  if (quitConfirmed || skipQuitConfirmation) return Promise.resolve(true)
+  if (quitConfirmationPending) return Promise.resolve(false)
+  quitConfirmationPending = true
+  const opts = {
+    type: 'question' as const,
+    buttons: ['Cancel', 'Quit'],
+    defaultId: 0,
+    cancelId: 0,
+    title: 'Quit nodeterm?',
+    message: 'Quit nodeterm?',
+    detail: 'Terminal sessions keep running in the background and will still be here next time you open nodeterm.'
+  }
+  const p =
+    parentWin && !parentWin.isDestroyed() ? dialog.showMessageBox(parentWin, opts) : dialog.showMessageBox(opts)
+  return p.then(({ response }) => {
+    quitConfirmationPending = false
+    const confirmed = response === 1
+    if (confirmed) quitConfirmed = true
+    return confirmed
+  })
+}
+
 // Browser <webview> guest webContents id → the browser node (and which of its two surfaces) it
 // belongs to. Used today for new-window capture; every entry is proven to BE a <webview> before it
 // lands here — see `registerBrowserGuest`.
@@ -628,17 +661,32 @@ function createWindow(): BrowserWindow {
   let leavingFullScreen = false
   win.on('close', (e) => {
     const action = closeAction(process.platform, quitting, win.isFullScreen())
-    if (action === 'default') return
-    e.preventDefault()
     if (action === 'hide') {
+      e.preventDefault()
       win.hide()
-    } else if (!leavingFullScreen) {
-      leavingFullScreen = true
-      win.once('leave-full-screen', () => {
-        leavingFullScreen = false
-        if (!win.isDestroyed() && !quitting) win.hide()
+      return
+    }
+    if (action === 'leave-fullscreen-then-hide') {
+      e.preventDefault()
+      if (!leavingFullScreen) {
+        leavingFullScreen = true
+        win.once('leave-full-screen', () => {
+          leavingFullScreen = false
+          if (!win.isDestroyed() && !quitting) win.hide()
+        })
+        win.setFullScreen(false)
+      }
+      return
+    }
+    // action === 'default': the window is really closing. On Windows/Linux the native title-bar
+    // × reaches this directly (no app.quit() first), so the confirm gate must sit here too, not
+    // only in before-quit — otherwise the window (and with it the only place to show a dialog)
+    // would already be gone by the time we asked.
+    if (!quitConfirmed && !skipQuitConfirmation) {
+      e.preventDefault()
+      void confirmQuit(win).then((ok) => {
+        if (ok) app.quit()
       })
-      win.setFullScreen(false)
     }
   })
 
@@ -1252,8 +1300,11 @@ app.whenReady().then(async () => {
   if (NT_MULTI && process.platform === 'darwin') app.dock?.setBadge('TEST')
   // Flip `quitting` before quitAndInstall so the window's close-event actually closes (not hides);
   // quitAndInstall closes all windows then calls app.quit(), which our hide-on-close would block.
+  // Also skip the confirm dialog — this is a restart-to-update the user already asked for via the
+  // "Restart to update" card, not an exit, and a modal here would just block the install.
   initUpdater(() => {
     quitting = true
+    skipQuitConfirmation = true
   })
   // Mirror live agent status to <userData>/agent-status.json for the external mobile host agent.
   initAgentStatusMirror()
@@ -2696,6 +2747,16 @@ app.on('window-all-closed', () => {
 // the quit just long enough for them to land, capped so a hung tmux can never block quit.
 let quitFlushed = false
 app.on('before-quit', (e) => {
+  // Menu Quit / Cmd+Q / Ctrl+Q reach here directly (no window-close event first), so the confirm
+  // gate is repeated here for that path. quitConfirmed short-circuits this on the re-issued
+  // app.quit() below once the user has answered, and on the win.close() gate's own re-issue.
+  if (!quitConfirmed && !skipQuitConfirmation) {
+    e.preventDefault()
+    void confirmQuit(getMainWindow() as unknown as BrowserWindow | null).then((ok) => {
+      if (ok) app.quit()
+    })
+    return
+  }
   quitting = true // from here on, window close-events must NOT be turned into hide
   destroyNotchHud()
   workspaceWatcher.dispose()


### PR DESCRIPTION
## Summary
- Adds a native confirm dialog before the app actually quits, cross-platform (mac/win/linux)
- Gates both quit paths: the native title-bar close on Windows/Linux (closes the window directly, no `app.quit()` first) and `app.quit()` itself (Cmd/Ctrl+Q, menu Quit, `window-all-closed`)
- macOS's traffic-light close (hide, not quit) is untouched
- Auto-update's restart-to-install skips the dialog, since that's not a user exit needing re-confirmation
- CI: run the quality job (typecheck/test/build) on `windows-latest` too, not just `ubuntu-latest`

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/main/main-window.test.ts`
- [ ] CI green on ubuntu-latest + windows-latest
- [ ] Manual: Cmd+Q on mac shows dialog; Cancel keeps app open; Quit exits
- [ ] Manual: title-bar × on Windows/Linux shows dialog before window closes