### PR TITLE
feat(canvas): tidy-canvas action to grid-pack all top-level nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1593,8 +1593,13 @@ again; the grace window was never the thing that was wrong.
 
 - **Context menus** (`components/ContextMenu.tsx`, portal, icons from `components/icons.tsx`):
   pane right-click = add nodes at cursor (terminal / Claude / sticky / open file) + select
-  all + fit + restart-idle-agents (the bulk in-place agent restart, mirrored in ⌘K; both hidden
-  when the canvas holds no restartable agent node, where they could only report "0 restarted");
+  all + fit + **Tidy canvas** (`arrangeAllNodes` — packs every top-level node, including group
+  frames as rigid units, into a non-overlapping grid via `arrangeNodes`, sorted by current
+  (y, x) so the pack roughly preserves reading order; mirrored in ⌘K as "Tidy canvas"; both
+  hidden below 2 top-level nodes, where it could only be a visual no-op that still writes
+  `project.json`) + restart-idle-agents (the bulk in-place agent restart, mirrored in ⌘K; both
+  hidden when the canvas holds no restartable agent node, where they could only report "0
+  restarted");
   node/selection right-click = group, color, duplicate, align-to-grid, collapse,
   markdown-view (terminals), refresh-terminal (terminals — bumps `respawnNonce`: fresh PTY attach
   to the SAME tmux session; manual recovery for a stuck/unpainted terminal, and the same action

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -5068,6 +5068,32 @@ export function Canvas() {
     setNodes((ns) => ns.map((n) => ({ ...n, selected: true })))
   }, [setNodes])
 
+  // Pane-level "Tidy canvas": packs every top-level node (terminal, agent, sticky, editor, diff,
+  // group frame — a frame moves as one unit, its children ride along untouched) into a
+  // non-overlapping grid via the same `arrangeNodes` selection/canvas-control already use.
+  // `arrangeNodes` no-ops on a mixed-container id set (workspace.ts commonParentId), which is why
+  // only top-level ids (`!n.parentId`) are collected here — a populated group frame would
+  // otherwise silently block the whole action. Sorted by current (y, x) first so the packed grid
+  // roughly preserves the canvas's existing reading order instead of falling back to array/
+  // persistence order (which puts every group frame first).
+  const hasArrangeableNodes = useCallback((): boolean => {
+    return nodesRef.current.filter((n) => !n.parentId).length >= 2
+  }, [])
+  const arrangeAllNodes = useCallback(() => {
+    if (isKanbanOpen(useProjects.getState().activeProjectId)) return
+    const targets = nodesRef.current
+      .filter((n) => !n.parentId)
+      .sort((a, b) => a.position.y - b.position.y || a.position.x - b.position.x)
+    // Fewer than 2 nodes: nothing to tidy — and running arrangeNodes anyway would still emit a
+    // fresh node array (a no-op position rewrite), triggering an undo entry + markDirty + a
+    // project.json write for a canvas that visibly didn't change.
+    if (targets.length < 2) return
+    const ids = targets.map((n) => n.id)
+    setNodes((ns) => arrangeNodes(ns, ids, { layout: 'grid' }))
+    markDirty()
+    fitAll()
+  }, [setNodes, markDirty, fitAll])
+
   const toggleCollapseNodes = useCallback(
     (ids: string[]) => {
       const set = new Set(ids)
@@ -5850,6 +5876,11 @@ export function Canvas() {
           // wrapper the command palette's Fit view uses). #227 swapped this to bare fitView, which
           // loses that framing and lets sidebar/HUD chrome cover part of the fitted content.
           { label: 'Fit view', icon: <IconFit />, onClick: fitAll },
+          // Hidden below 2 top-level nodes — same reasoning as restart-idle-agents just below:
+          // with 0 or 1 node the action can only be a visual no-op that still writes project.json.
+          ...(hasArrangeableNodes()
+            ? [{ label: 'Tidy canvas', icon: <IconGrid />, onClick: arrangeAllNodes } as MenuItem]
+            : []),
           // Project-wide: restart every idle agent CLI in place (new model pickup). Hidden on a
           // canvas with no restartable agent node — there it could only ever report "0 restarted".
           ...(hasRestartableAgents()
@@ -5872,6 +5903,8 @@ export function Canvas() {
       addCtx,
       selectAll,
       fitAll,
+      arrangeAllNodes,
+      hasArrangeableNodes,
       hasRestartableAgents,
       restartIdleAgents
     ]
@@ -8925,6 +8958,18 @@ export function Canvas() {
         run: () => void connectRemote()
       },
       { id: 'fit', label: 'Fit view', icon: <IconFit />, run: fitAll },
+      // Hidden below 2 top-level nodes — see arrangeAllNodes.
+      ...(hasArrangeableNodes()
+        ? [
+            {
+              id: 'arrange-all',
+              label: 'Tidy canvas',
+              hint: 'arrange grid layout organize clean up',
+              icon: <IconGrid />,
+              run: arrangeAllNodes
+            } as Command
+          ]
+        : []),
       { id: 'zoom-100', label: 'Zoom to 100%', icon: <IconFit />, run: zoomTo100 },
       { id: 'save', label: 'Save', icon: <IconSave />, run: () => void persist() },
       // Hidden when the canvas has no restartable agent node — the row would have nothing to act
@@ -9030,7 +9075,9 @@ export function Canvas() {
     addSshTerminal,
     hasRestartableAgents,
     restartIdleAgents,
-    zoomTo100
+    zoomTo100,
+    arrangeAllNodes,
+    hasArrangeableNodes
   ])
 
   // Build the palette's command list only when its inputs change — the inline `buildCommands()`


### PR DESCRIPTION
## Summary
- Adds "Tidy canvas" to the pane right-click menu and the ⌘K command palette
- Reuses the existing pure `arrangeNodes()` to pack every top-level node (group frames move as rigid units, children untouched) into a non-overlapping grid
- Ids sorted by current `(y, x)` before packing so the result roughly preserves reading order instead of falling back to persistence order
- Hidden below 2 arrangeable nodes and while the kanban board is open — either state would make the action a visual no-op that still writes `project.json`
- Camera reframes via `fitAll()` after packing

## Test plan
- [x] `npm run typecheck` clean
- [x] `workspace.test.ts` passes (73/73, `arrangeNodes` itself untouched)
- [x] Opus code review pass, all findings addressed (guard on <2 nodes, kanban gate, reading-order sort, renamed to avoid clashing with existing "Snap to grid" auto-align mode, palette hint synonyms, CLAUDE.md updated)
- [ ] Manual click-through in dev app (not run this session — Electron desktop app)