### PR TITLE
feat(canvas): give a session an emoji or picture icon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,8 @@ Fire-time `TriggerArmStore.isArmed` re-ask everywhere; every rule test-pinned. T
 machine-local, content-bound `core/trigger-arm-store.ts` (a spec that arrives or CHANGES via git
 reads as disarmed until armed on this machine). A node's `data`
 carries `title, color, group, tags, collapsed, expandedHeight, shell, cwd, text,
-initialCommand, filePath, diffStaged`, `agentId` (which agent CLI a terminal node runs —
+initialCommand, filePath, diffStaged`, `icon` (a user-chosen emoji or picture — see **Node icons**
+below), `agentId` (which agent CLI a terminal node runs —
 persisted), and `accountId` (which managed Claude account a terminal node runs under — immutable,
 resolved at creation, persisted; see **Managed Claude accounts**). `nodeStatesToFlow` defaults a
 missing `kind` to `terminal` for backward compat and migrates the legacy `tags:['claude']` marker
@@ -1988,6 +1989,56 @@ disappearing" rather than as an occasional cull. The `vm_stat` reader is what ma
 again; the grace window was never the thing that was wrong.
 
 
+## Node icons (emoji or picture)
+
+A node may carry `data.icon` (`NodeIcon` in `@shared/node-icon`): `{type:'emoji', value}` or
+`{type:'image', path}`. Absent = the node draws exactly as it did before the feature, which is the
+degrade every failure path falls back to. Set from the node right-click menu ("Set icon…", hideable
+like Colors — id `icon`), from the icon itself in the terminal node header, and from the kanban card
+modal's header slot; drawn by the one `NodeIconView` on all four surfaces that list a node (canvas
+header, kanban card, card modal, sessions sidebar row), because a session seen in four places must
+not look like four sessions. **Terminal (session) nodes only in v1** — the menu row is gated on the
+kind, deliberately: offering it on an editor or a group frame would persist a value nothing draws,
+which is the "looks like it worked" failure this file warns about elsewhere. Extending it to sticky
+or browser nodes means adding the draw and the set together, in one change.
+
+- **`.nodeterm/project.json` is hostile input, so the icon is validated at BOTH serializer seams.**
+  `normalizeNodeIcon` runs in `nodeStatesToFlow` (a cloned file becoming live state) *and* in
+  `flowToNodeStates` (live state becoming the next reader's file — live node data is reachable by a
+  peer canvas mutation, and whatever we write is what the next machine trusts). One-sided validation
+  passes every round-trip test while leaving the other direction open; both seams are mutation-pinned
+  in `workspace.test.ts`.
+- **An emoji is ONE grapheme** (`Intl.Segmenter`, with a UTF-16 cap as the fallback, never as the
+  primary rule — slicing units cuts a ZWJ sequence into a fragment). Uncapped, a shared file could
+  put a 40 kB "emoji" into every header, card and sidebar row.
+- **An image path must LOOK like an image** (extension → MIME). That gate is what stops a hand-edited
+  project file from aiming `fs.readBinary` at `~/.ssh/id_rsa`. It is not a full jail — the path can
+  still name any `*.png` on the machine, exactly as an editor node's `filePath` always could — but
+  the bytes only ever become an `<img>` under a `'self'` CSP with no network, so the reachable
+  outcome is "an icon fails to draw". A `./` path may not traverse (same rule as
+  `isSafeQuickOpenRelPath`).
+- **The bytes are COPIED, not referenced.** The picker reads the chosen file and writes it through
+  `files.saveCanvasImage` — the same seam canvas image nodes use — so it lands in the project's
+  git-shared `.nodeterm/images/`. A path inside the project cwd is then stored `./`-relative
+  (`portableIconPath`) and resolved on read (`resolveIconPath`), which is the convention
+  `toPortableNodes` already set for node cwds. **This is the one place that convention is applied to
+  a `filePath`-like field**: canvas image nodes still store theirs absolutely, so their file travels
+  with the repo while the node naming it does not — an existing gap, not one this introduced.
+  A cwd-less canvas, an SSH project (its cwd is on the host; the image is written app-locally) and
+  the app-local fallback all keep an absolute path and simply do not travel. Not an error.
+- **A relay tab is refused** (`canvasImportRefusal`, the same message and the same reason as canvas
+  image import): the write is this machine's preload while the read is the peer's core, so the node
+  would name a file only this machine has. Reads otherwise go through the PROJECT's session api, not
+  `window.nodeTerminal` — which is what makes a peer-authored `./` icon resolve on the peer.
+- Image reads are cached per `(projectId, absPath)` in `lib/nodeIconImage.ts`, because four surfaces
+  mount independently and a thirty-card board would otherwise re-read the same bytes thirty times per
+  open. Caching by path is safe: `saveCanvasImage` creates exclusively, so re-picking yields
+  `logo (2).png` rather than overwriting.
+- **Surfaces.** Desktop: full. **Server Edition**: full — every leg is already core (`fs.readBinary`,
+  `files.saveCanvasImage`) or has a real browser implementation (`dialog.selectFile` → the web
+  picker), so no new IPC was added and nothing is stubbed. **Mobile**: N/A for v1 — *nodeterm mobile*
+  attaches to tmux sessions over the transport protocol and carries no per-node icon concept;
+  surfacing one means extending that protocol (follow-up in the iOS repo).
 ## Keybindings (registry, overrides, dispatch)
 
 Every user-facing chord is a registry command, and the whole engine is **one module**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2017,6 +2017,42 @@ or browser nodes means adding the draw and the set together, in one change.
   the bytes only ever become an `<img>` under a `'self'` CSP with no network, so the reachable
   outcome is "an icon fails to draw". A `./` path may not traverse (same rule as
   `isSafeQuickOpenRelPath`).
+- **Two dialects in, one dialect out — and the traversal guard splits on BOTH separators, always.**
+  The value is written by one machine and read by another, so `normalizeNodeIcon` ACCEPTS a Windows
+  absolute (`C:\…`, `C:/…`) and a POSIX one wherever the check runs, while everything STORED is
+  POSIX-separated. Both halves are load-bearing. Refuse `C:\…` on a mac and a mac user merely
+  opening the shared canvas and saving it **silently strips a Windows teammate's icons** from
+  `project.json` — such a path does not resolve on a mac, but not-drawing is a degrade and a degrade
+  is not a reason to destroy the value on the way past. Store `.\a\b.png` and it means a file
+  called `a\b.png` on POSIX and `b.png` inside `a` on Windows, so a relative path is canonicalized
+  to `./` with forward slashes (the same way an emoji is canonicalized to its first grapheme).
+  **`isSafeRelIconPath` splits on `[\\/]` on every platform**, because splitting on `/` alone made
+  `./a\..\..\secret.png` ONE segment — neither `''`, `.` nor `..` — so it passed the guard
+  everywhere and escaped the project root the moment a Windows reader resolved it; a segment may
+  also not contain `:` (a drive qualifier, or an NTFS alternate data stream). **UNC is refused**,
+  matching `renderer/terminal/file-links.ts`, which consumes UNC specifically so it can refuse it:
+  reading one reaches another machine over SMB.
+- **`localIconCwd` is the ONE definition of which cwd a `./` icon may resolve against**, asked by
+  the picker's write side and by `useNodeIconSrc`'s read side. It was written twice and drifted: an
+  SSH project's `cwd` is a path on the REMOTE host while the icon is read through the LOCAL `api.fs`
+  (an SSH project runs on the local session — only a RELAY tab's api belongs to another machine), so
+  the read side resolved a remote-rooted `./` path against this machine's filesystem and drew
+  whatever happened to sit there. Undefined = the icon does not draw, which is the honest answer for
+  a file on a filesystem this reader cannot see; absolute paths are unaffected, and absolute is what
+  the write side stores for SSH.
+- **A picked image is downscaled before it is written** (`lib/nodeIconThumbnail.ts`, 256 px long
+  edge = 16× the drawn size). What lands in `.nodeterm/images/` is committed and cloned by everyone
+  on the repo, and it draws at 13–16 px. SVG is passed through (rasterizing it would make it worse
+  at every size, not merely smaller), as is anything already small in both dimensions and bytes (a
+  canvas round-trip can make a hand-made 32 px PNG *bigger*) and any re-encode that came out larger.
+  An animated GIF becomes a static PNG. The decision (`thumbnailPlan`) is pure so it tests under
+  vitest's default `node` environment — jsdom has no canvas — and the browser half's decode/encode
+  is injected. It **fails open in every direction**, including a decode that never settles
+  (`DECODE_TIMEOUT_MS`): `chooseImage` awaits it before writing, so a hanging promise would leave
+  the button stuck on "Copying…".
+- **The extension is checked BEFORE the copy.** `dialog.selectFile` applies no filter, so an
+  unsupported file is one click away — and validating after `saveCanvasImage` left an orphan file in
+  the user's git-shared folder on every refusal, which nothing later removes.
 - **The bytes are COPIED, not referenced.** The picker reads the chosen file and writes it through
   `files.saveCanvasImage` — the same seam canvas image nodes use — so it lands in the project's
   git-shared `.nodeterm/images/`. A path inside the project cwd is then stored `./`-relative
@@ -2026,6 +2062,11 @@ or browser nodes means adding the draw and the set together, in one change.
   with the repo while the node naming it does not — an existing gap, not one this introduced.
   A cwd-less canvas, an SSH project (its cwd is on the host; the image is written app-locally) and
   the app-local fallback all keep an absolute path and simply do not travel. Not an error.
+- **The picker owns Escape while it is the top dialog** (`useDialogStack()`'s answer, which was
+  previously discarded). The gate is `isTop()` ALONE, matching `confirmKeyAction`, where `inDialog`
+  guards Enter and never Escape: Enter is the affirmative key and must be aimed at the dialog, while
+  requiring focus inside the box for Escape reproduces the original bug for a user whose focus sits
+  on the body.
 - **A relay tab is refused** (`canvasImportRefusal`, the same message and the same reason as canvas
   image import): the write is this machine's preload while the read is the peer's core, so the node
   would name a file only this machine has. Reads otherwise go through the PROJECT's session api, not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,20 @@ inherit a builtin harness, so add the capability and its one shared leaf (`src/s
 let every UI ask the helper. Repeating Claude/Codex/etc. cases in menus breaks that inheritance and
 eventually drifts.
 
+**Never put a raw NUL byte in a source file — write `\x00`.** Git classifies a file containing one
+as *binary*, so it renders as "Binary files differ" in every diff surface (the PR page, `git diff`,
+`git log -p`) and `git grep` skips it. It still compiles and its tests still pass, so nothing fails
+— the file just becomes invisible to review, which is the worst way for this to go wrong. A
+separator or sentinel is a fine reason to want the byte; the escape is the same byte and keeps the
+file text. `src/shared/source-hygiene.test.ts` enforces this across every tracked `.ts`/`.tsx`.
+
+**Paths cross machines, so treat `\` as a separator wherever you split one.** A value persisted in
+`.nodeterm/project.json` is written by one machine and validated on another, so a guard that reads
+`\` as an ordinary filename character is simply wrong about the machine that will resolve it. This
+has already produced a real hole: a traversal check that split on `/` alone saw `./a\..\..\x.png`
+as a single harmless segment on *every* platform. Split on `[\\/]`, and prefer accepting both
+dialects while storing only one (see **Node icons** in CLAUDE.md for the worked example).
+
 ## Testing
 
 `npm test` must pass, and `npm run typecheck` is the fastest gate.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { Canvas } from './canvas/Canvas'
 import { PromptDialogHost } from './components/promptDialog'
+import { NodeIconDialogHost } from './components/NodeIconPicker'
 import { SessionProvider } from './session/session'
 import { localSession } from './session/localSession'
 import { useSettings } from './state/settings'
@@ -75,6 +76,9 @@ export default function App() {
         <Canvas />
         {/* In-app window.prompt replacement (Electron has no prompt); driven by promptDialog(). */}
         <PromptDialogHost />
+        {/* The node-icon picker, opened from the node menu, a node header and the kanban card
+            modal — one dialog for all three, driven by nodeIconDialog(). */}
+        <NodeIconDialogHost />
       </ReactFlowProvider>
     </SessionProvider>
   )

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -106,6 +106,7 @@ import {
   IconLock,
   IconMarkdown,
   IconReload,
+  IconSmiley,
   IconPower,
   IconNote,
   IconPhone,
@@ -385,6 +386,9 @@ import { promptFilePathError } from '@shared/agents/launch'
 import { parseTeamSpec } from '../lib/teamSpec'
 import { relativeTime } from '../lib/relativeTime'
 import { AgentIcon } from '../lib/agentIcons'
+import { nodeIconDialog } from '../components/NodeIconPicker'
+import { applyIconChoice } from '../lib/nodeIconChoice'
+import type { NodeIcon } from '@shared/node-icon'
 import { branchClaudeSession } from '../lib/claudeBranch'
 import {
   useSession,
@@ -2091,6 +2095,7 @@ export function Canvas() {
               title: n.data.title ?? n.id,
               color: n.data.color ?? '#888',
               agentId: n.data.agentId,
+              icon: n.data.icon as NodeIcon | undefined,
               cwd: n.data.cwd,
               ssh: n.data.ssh,
               parentId: n.parentId
@@ -6193,6 +6198,35 @@ export function Canvas() {
     [setNodes, markDirty]
   )
 
+  /** Write a node's icon (`undefined` clears it). The single funnel for every surface that sets
+   *  one — the node menu, the node header and the kanban card modal — so the canvas is marked
+   *  dirty exactly once per change and in one place. */
+  const setNodeIcon = useCallback(
+    (nodeId: string, icon: NodeIcon | undefined) => {
+      setNodes((ns) => ns.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, icon } } : n)))
+      markDirty()
+    },
+    [setNodes, markDirty]
+  )
+
+  /**
+   * Open the icon picker for ONE node and apply the answer. Single-target on purpose: an icon is
+   * how you tell two sessions apart, so setting the same one across a multi-selection is the
+   * opposite of what the feature is for — the menu row is offered only for a single node.
+   */
+  const pickNodeIcon = useCallback(
+    (nodeId: string) => {
+      const node = nodesRef.current.find((n) => n.id === nodeId)
+      if (!node) return
+      void nodeIconDialog({
+        nodeId,
+        title: (node.data.title as string) ?? '',
+        icon: node.data.icon as NodeIcon | undefined
+      }).then((choice) => applyIconChoice(choice, (icon) => setNodeIcon(nodeId, icon)))
+    },
+    [setNodeIcon]
+  )
+
   const alignToGrid = useCallback(
     (ids: string[]) => {
       const g = useSettings.getState().settings.gridSize || GRID
@@ -7216,6 +7250,23 @@ export function Canvas() {
       ...(isHidden('colors', hidden)
         ? []
         : ([{ type: 'colors', onPick: (c) => setNodesColor(ids, c) }] as MenuItem[])),
+      // Single target, and only a SESSION node: an icon is how you tell two sessions apart, so
+      // setting one across a multi-selection is the opposite of the point — and offering it on a
+      // kind that draws no icon (an editor, a diff, a group frame) would be a row that persists a
+      // value nothing ever shows, which is worse than no row at all.
+      ...(ids.length === 1 &&
+      !isHidden('icon', hidden) &&
+      nodesRef.current.find((n) => n.id === ids[0])?.type === 'terminal'
+        ? ([
+            {
+              label: nodesRef.current.find((n) => n.id === ids[0])?.data.icon
+                ? 'Change icon…'
+                : 'Set icon…',
+              icon: <IconSmiley />,
+              onClick: () => pickNodeIcon(ids[0])
+            }
+          ] as MenuItem[])
+        : []),
       { type: 'separator' },
       ...(isHidden('duplicate', hidden)
         ? []
@@ -12162,6 +12213,7 @@ export function Canvas() {
           onDeleteNode={deleteNodeFromKanban}
           onModalNodeChange={setKanbanModalNode}
           onBrowserNav={browserNavFromKanban}
+          onSetIcon={setNodeIcon}
         />
       )}
       <UpdateCard />

--- a/src/renderer/canvas/toKanbanSession.ts
+++ b/src/renderer/canvas/toKanbanSession.ts
@@ -1,4 +1,5 @@
 import type { SshConnection } from '@shared/ssh'
+import type { NodeIcon } from '@shared/node-icon'
 import { NODE_COLORS, type CanvasNode } from '../state/workspace'
 import type { KanbanSession } from '../components/kanban/KanbanView'
 
@@ -44,6 +45,7 @@ export function toKanbanSession(n: CanvasNode): KanbanSession | null {
     color: (n.data.color as string) ?? NODE_COLORS[0],
     kind: 'terminal',
     agentId: n.data.agentId as string | undefined,
+    icon: n.data.icon as NodeIcon | undefined,
     // What the card modal's co-attach terminal needs to join THIS node's session the same way the
     // canvas TerminalNode does.
     spawn: {

--- a/src/renderer/components/NodeIcon.tsx
+++ b/src/renderer/components/NodeIcon.tsx
@@ -1,0 +1,52 @@
+/**
+ * Drawing a node's icon. One component, used by every surface that lists a node — the canvas
+ * header, the kanban card, the card modal and the sessions sidebar — so an icon cannot look like
+ * four different things depending on where you happen to be looking at the session.
+ *
+ * Renders NOTHING (not a placeholder, not an empty box) when the node has no icon, when the icon
+ * is an image that is still loading, and when that image could not be read. All three are the same
+ * thing from the user's side: the node looks exactly as it did before the feature. An icon is
+ * decoration — it must never occupy space it cannot fill, and it must never announce its own
+ * failure in a header that is already carrying six chips.
+ */
+import type { NodeIcon } from '@shared/node-icon'
+import { useNodeIconSrc } from '../lib/nodeIconImage'
+
+export interface NodeIconViewProps {
+  icon?: NodeIcon
+  /** Rendered box in px. The emoji's font-size is derived from it so both forms agree optically. */
+  size?: number
+  /** Extra class for surface-specific spacing (the card and the header sit differently). */
+  className?: string
+  /** The node's project, for surfaces that list nodes across projects. See `useNodeIconSrc`. */
+  projectId?: string
+}
+
+export function NodeIconView({
+  icon,
+  size = 14,
+  className,
+  projectId
+}: NodeIconViewProps): React.JSX.Element | null {
+  // Called unconditionally (hook rules) — it answers null for an emoji icon and for no icon.
+  const src = useNodeIconSrc(icon, projectId)
+  if (!icon) return null
+  const cls = `node-icon${className ? ` ${className}` : ''}`
+  if (icon.type === 'emoji') {
+    return (
+      <span
+        className={cls}
+        style={{ width: size, height: size, fontSize: Math.round(size * 0.92) }}
+        aria-hidden
+      >
+        {icon.value}
+      </span>
+    )
+  }
+  if (!src) return null
+  return (
+    <span className={cls} style={{ width: size, height: size }} aria-hidden>
+      <img src={src} alt="" draggable={false} />
+    </span>
+  )
+}

--- a/src/renderer/components/NodeIconPicker.test.tsx
+++ b/src/renderer/components/NodeIconPicker.test.tsx
@@ -18,6 +18,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NodeIconDialogHost, nodeIconDialog, type NodeIconChoice } from './NodeIconPicker'
 import { useProjects } from '../state/projects'
+import { popDialog, pushDialog, resetDialogStack } from './dialog-stack'
 
 // React refuses act() outside a configured test environment without this flag.
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -127,5 +128,83 @@ describe('NodeIconPicker image pick', () => {
       type: 'image',
       path: 'C:\\Users\\me\\AppData\\nodeterm\\canvas-images\\logo.png'
     })
+  })
+})
+
+// Escape, which was reachable only while the text input had focus — `useDialogStack()` was called
+// and its answer thrown away. The gate matches `confirmKeyAction`: top-of-stack only, with no
+// focus requirement, because Escape is the safe direction and Enter is the affirmative one.
+describe('NodeIconPicker escape', () => {
+  let root: Root | undefined
+  let host: HTMLElement
+
+  // The pending choice is returned WRAPPED. An async function returning a promise flattens it, so
+  // `await open()` would wait for the dialog's own promise — which nothing has dismissed yet.
+  const open = async (): Promise<{ choice: Promise<NodeIconChoice> }> => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    useProjects.setState({ activeProjectId: 'p1', getProject: () => PROJECT } as never)
+    const choice = nodeIconDialog({ nodeId: 'n1', title: 'Build' })
+    root = createRoot(host)
+    await act(async () => {
+      root!.render(<NodeIconDialogHost />)
+    })
+    return { choice }
+  }
+
+  const pressEscape = async (target: EventTarget): Promise<void> => {
+    await act(async () => {
+      target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+  }
+
+  afterEach(async () => {
+    await act(async () => root?.unmount())
+    root = undefined
+    host?.remove()
+    resetDialogStack()
+  })
+
+  it('closes when the press lands outside the input — the reported bug', async () => {
+    const { choice } = await open()
+    // Focus is NOT in the text input: a swatch is the realistic case, since clicking one is how
+    // most people arrive here.
+    const swatch = document.querySelector('.node-icon-dialog__swatch')
+    expect(swatch).toBeTruthy()
+    await pressEscape(swatch!)
+    // `undefined` is CANCEL, distinct from `null` (remove the icon). Collapsing the two is how a
+    // dismissed dialog silently clears an icon the user wanted to keep.
+    await expect(choice).resolves.toBeUndefined()
+  })
+
+  it('still closes from the input, and from the document body', async () => {
+    for (const pick of [
+      () => document.querySelector('.node-icon-dialog__input')!,
+      () => document.body
+    ]) {
+      const { choice } = await open()
+      await pressEscape(pick())
+      await expect(choice).resolves.toBeUndefined()
+      await act(async () => root?.unmount())
+      host.remove()
+    }
+  })
+
+  it('ignores Escape while another dialog is stacked on top of it', async () => {
+    const { choice } = await open()
+    let settled = false
+    void choice.then(() => {
+      settled = true
+    })
+
+    pushDialog('dialog-above')
+    await pressEscape(document.body)
+    await act(async () => {})
+    expect(settled).toBe(false)
+
+    // ...and takes it back once that dialog closes.
+    popDialog('dialog-above')
+    await pressEscape(document.body)
+    await expect(choice).resolves.toBeUndefined()
   })
 })

--- a/src/renderer/components/NodeIconPicker.test.tsx
+++ b/src/renderer/components/NodeIconPicker.test.tsx
@@ -30,6 +30,15 @@ const readBinary = vi.fn<(path: string) => Promise<string | null>>()
 const saveCanvasImage =
   vi.fn<(projectId: string, name: string, b64: string) => Promise<string | null>>()
 
+// The downscale is stubbed to a pass-through: its own behaviour is covered in
+// nodeIconThumbnail.test.ts against injected deps, and the REAL one here would reach for
+// `new Image()` — which jsdom never settles, so the picker would simply hang. What is under test
+// on this side is the WIRING: that the picker saves what the downscale handed back.
+vi.mock('../lib/nodeIconThumbnail', () => ({
+  browserThumbnailDeps: {},
+  downscaleIconImage: async (picked: { base64: string; name: string }) => picked
+}))
+
 vi.mock('../session/session', () => ({
   sessionForProject: () => ({
     api: {

--- a/src/renderer/components/NodeIconPicker.test.tsx
+++ b/src/renderer/components/NodeIconPicker.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+//
+// The picker's image path, on a machine that is not a mac.
+//
+// Two things are pinned here and both were review findings on #293:
+//
+//  1. **The extension is checked BEFORE the copy.** `selectFile` applies no filter, so an
+//     unsupported file is one click away — and validating after `saveCanvasImage` meant the bytes
+//     were already written into the project's git-shared `.nodeterm/images/`. Nothing removes
+//     them afterwards, so every refusal left a file behind in the user's repo.
+//
+//  2. **A Windows path from `saveCanvasImage` is usable.** `saveCanvasImage` answers with the
+//     host's own `path.join`, i.e. `C:\...` on Windows. The old POSIX-only `startsWith('/')`
+//     check refused it, and `chooseImage` then reported "that file type cannot be used" about a
+//     perfectly good PNG — sending Windows users after a format problem that did not exist.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NodeIconDialogHost, nodeIconDialog, type NodeIconChoice } from './NodeIconPicker'
+import { useProjects } from '../state/projects'
+
+// React refuses act() outside a configured test environment without this flag.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const selectFile = vi.fn<() => Promise<string | null>>()
+const readBinary = vi.fn<(path: string) => Promise<string | null>>()
+// Arguments are FORWARDED, not swallowed: the name this is called with is itself under test
+// (`iconFileName` vs the old `split('/')`), and a mock that drops its args cannot fail for it.
+const saveCanvasImage =
+  vi.fn<(projectId: string, name: string, b64: string) => Promise<string | null>>()
+
+vi.mock('../session/session', () => ({
+  sessionForProject: () => ({
+    api: {
+      dialog: { selectFile: () => selectFile() },
+      fs: { readBinary: (p: string) => readBinary(p) },
+      files: {
+        saveCanvasImage: (id: string, name: string, b64: string) =>
+          saveCanvasImage(id, name, b64)
+      }
+    }
+  })
+}))
+
+const PROJECT = { id: 'p1', name: 'proj', color: '#888', cwd: 'C:\\proj', viewport: {}, nodes: [] }
+
+/** Click "Choose image…" and let the promise chain inside `chooseImage` settle. */
+async function clickChooseImage(): Promise<void> {
+  const button = [...document.querySelectorAll('button')].find(
+    (b) => b.textContent?.startsWith('Choose image')
+  )
+  expect(button).toBeTruthy()
+  await act(async () => {
+    button!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+const errorText = (): string =>
+  document.querySelector('.node-icon-dialog__error')?.textContent ?? ''
+
+describe('NodeIconPicker image pick', () => {
+  let root: Root | undefined
+  let host: HTMLElement
+  let choice: Promise<NodeIconChoice>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    useProjects.setState({
+      activeProjectId: 'p1',
+      getProject: () => PROJECT
+    } as never)
+    choice = nodeIconDialog({ nodeId: 'n1', title: 'Build' })
+    root = createRoot(host)
+    await act(async () => {
+      root!.render(<NodeIconDialogHost />)
+    })
+  })
+
+  afterEach(async () => {
+    await act(async () => root?.unmount())
+    root = undefined
+    host.remove()
+    // Every test resolves the dialog so the module-level singleton does not leak into the next.
+    void choice
+  })
+
+  it('refuses an unsupported file WITHOUT copying it into the project', async () => {
+    selectFile.mockResolvedValue('C:\\Users\\me\\photo.heic')
+    await clickChooseImage()
+
+    expect(saveCanvasImage).not.toHaveBeenCalled()
+    // Not even read: there is nothing to do with the bytes once the extension is refused.
+    expect(readBinary).not.toHaveBeenCalled()
+    expect(errorText()).toContain('cannot be used as an icon')
+  })
+
+  it('accepts a Windows path and names the copy after the file, not the whole path', async () => {
+    selectFile.mockResolvedValue('C:\\Users\\me\\logo.png')
+    readBinary.mockResolvedValue('aGVsbG8=')
+    saveCanvasImage.mockResolvedValue('C:\\proj\\.nodeterm\\images\\logo.png')
+    await clickChooseImage()
+
+    // The COPY is named after the file, not the whole path. `split('/')` on a Windows path
+    // returns it whole, so the saved file was named `C:\\Users\\me\\logo.png` and only
+    // `safeUploadName` stopped that being a directory escape.
+    expect(saveCanvasImage).toHaveBeenCalledWith('p1', 'logo.png', 'aGVsbG8=')
+    expect(errorText()).toBe('')
+    // Inside the project root, so it is stored `./`-relative and POSIX-separated: the icon
+    // travels with the repo that names it.
+    await expect(choice).resolves.toEqual({
+      type: 'image',
+      path: './.nodeterm/images/logo.png'
+    })
+  })
+
+  it('keeps a Windows path outside the project absolute rather than refusing it', async () => {
+    selectFile.mockResolvedValue('C:\\Users\\me\\logo.png')
+    readBinary.mockResolvedValue('aGVsbG8=')
+    // The app-local fallback `saveCanvasImage` takes when the project folder will not accept it.
+    saveCanvasImage.mockResolvedValue('C:\\Users\\me\\AppData\\nodeterm\\canvas-images\\logo.png')
+    await clickChooseImage()
+
+    expect(errorText()).toBe('')
+    await expect(choice).resolves.toEqual({
+      type: 'image',
+      path: 'C:\\Users\\me\\AppData\\nodeterm\\canvas-images\\logo.png'
+    })
+  })
+})

--- a/src/renderer/components/NodeIconPicker.tsx
+++ b/src/renderer/components/NodeIconPicker.tsx
@@ -1,0 +1,229 @@
+/**
+ * Choosing a node's icon: an emoji from a small palette, any character typed by hand, or an image
+ * file from disk.
+ *
+ * Driven by the promise-based singleton `nodeIconDialog()` — the same shape as `promptDialog()` —
+ * so every surface that can set an icon (the node context menu, the node header, the kanban card
+ * modal) opens the SAME dialog and none of them has to own its state.
+ *
+ * The three outcomes are distinct on purpose, and the caller must keep them distinct:
+ *   `NodeIcon` → set this icon.  `null` → remove the icon.  `undefined` → cancelled, change nothing.
+ * Collapsing "remove" into "cancel" is how a Remove button silently does nothing.
+ *
+ * **Where an image goes.** Not where the user picked it from: a path outside the project would
+ * break for everyone who clones the repo, and would break here the moment the file moves. The
+ * bytes are copied through `files.saveCanvasImage`, the same seam canvas image nodes use, which
+ * puts them in the project's git-shared `.nodeterm/images/` (or a durable app-local folder when
+ * the project has no local cwd). The stored path is then made `./`-relative by `portableIconPath`
+ * so the icon travels with the canvas that names it.
+ *
+ * **Relay tabs are refused**, with the same message and for the same reason canvas image import
+ * is: the write is this machine's preload while the read is the peer's core, so the node would end
+ * up naming a file only this machine has. A clear refusal beats an icon that can never draw.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { create } from 'zustand'
+import { type NodeIcon, normalizeNodeIcon, portableIconPath } from '@shared/node-icon'
+import { canvasImportRefusal } from '../canvas/canvas-image-import'
+import { useProjects } from '../state/projects'
+import { sessionForProject } from '../session/session'
+import { useDialogStack } from './dialog-stack'
+
+/**
+ * A small, deliberately opinionated palette rather than a full emoji keyboard. Grouped by what
+ * people actually label a terminal with — state, kind of work, subject matter — because the point
+ * is to tell twelve sessions apart at a glance, not to browse Unicode. Anything not here is one
+ * keystroke away in the input beside it, which is also where every platform's own emoji picker
+ * lands its result.
+ */
+const PALETTE: readonly string[] = [
+  '\u{1F680}', '\u{1F525}', '\u{2B50}', '\u{26A1}', '\u{1F41B}', '\u{1F527}',
+  '\u{1F9EA}', '\u{1F4E6}', '\u{1F310}', '\u{1F512}', '\u{1F5C4}', '\u{1F4CA}',
+  '\u{1F3AF}', '\u{1F4DD}', '\u{1F4DA}', '\u{1F9E0}', '\u{1F916}', '\u{1F441}',
+  '\u{1F3D7}', '\u{1F9F9}', '\u{1F6A8}', '\u{1F6A7}', '\u{2705}', '\u{1F534}',
+  '\u{1F7E2}', '\u{1F535}', '\u{1F7E1}', '\u{1F7E3}', '\u{1F3A8}', '\u{1F3B5}',
+  '\u{2615}', '\u{1F31E}', '\u{1F319}', '\u{1F332}', '\u{1F433}', '\u{1F431}'
+]
+
+/** `undefined` = cancelled (change nothing); `null` = remove the icon; a value = set it. */
+export type NodeIconChoice = NodeIcon | null | undefined
+
+interface DialogState {
+  current: {
+    nodeId: string
+    title: string
+    icon?: NodeIcon
+    resolve: (choice: NodeIconChoice) => void
+  } | null
+}
+
+const useStore = create<DialogState>(() => ({ current: null }))
+
+/**
+ * Open the icon dialog for one node and resolve with the user's choice. Opening a second one
+ * cancels the first (resolving `undefined`), matching `promptDialog`.
+ */
+export function nodeIconDialog(opts: {
+  nodeId: string
+  title: string
+  icon?: NodeIcon
+}): Promise<NodeIconChoice> {
+  return new Promise((resolve) => {
+    const prev = useStore.getState().current
+    if (prev) {
+      useStore.setState({ current: null })
+      prev.resolve(undefined)
+    }
+    useStore.setState({ current: { ...opts, resolve } })
+  })
+}
+
+/** Mount once, at the app root. Renders the active icon dialog, if any. */
+export function NodeIconDialogHost(): React.JSX.Element | null {
+  const current = useStore((s) => s.current)
+  if (!current) return null
+  const finish = (choice: NodeIconChoice): void => {
+    useStore.setState({ current: null })
+    current.resolve(choice)
+  }
+  return <NodeIconPicker title={current.title} icon={current.icon} onDone={finish} />
+}
+
+function NodeIconPicker({
+  title,
+  icon,
+  onDone
+}: {
+  title: string
+  icon?: NodeIcon
+  onDone: (choice: NodeIconChoice) => void
+}): React.JSX.Element {
+  const [typed, setTyped] = useState(icon?.type === 'emoji' ? icon.value : '')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  useDialogStack()
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const commitTyped = (raw: string): void => {
+    // The same validator the persisted file goes through, so what the picker accepts and what a
+    // reload accepts cannot drift: type three characters, keep the first grapheme.
+    const next = normalizeNodeIcon({ type: 'emoji', value: raw })
+    onDone(next ?? null)
+  }
+
+  /**
+   * Copy the chosen file into the project and hand back a portable path. Every failure resolves to
+   * a message rather than a thrown error or a silently-missing icon: the user picked a file and is
+   * owed an answer about it.
+   */
+  const chooseImage = async (): Promise<void> => {
+    setError('')
+    const { activeProjectId, getProject } = useProjects.getState()
+    const project = activeProjectId ? getProject(activeProjectId) : undefined
+    if (!project) return
+    const refusal = canvasImportRefusal(!!project.remote)
+    if (refusal) {
+      setError(refusal)
+      return
+    }
+    const api = sessionForProject(project.id).api
+    const picked = await api.dialog.selectFile()
+    if (!picked) return
+    setBusy(true)
+    try {
+      const b64 = await api.fs.readBinary(picked)
+      if (!b64) {
+        setError('Could not read that file.')
+        return
+      }
+      const name = picked.split('/').pop() || 'icon.png'
+      const saved = await api.files.saveCanvasImage(project.id, name, b64)
+      if (!saved) {
+        setError('Could not save the image — check that this project’s folder is writable.')
+        return
+      }
+      // An SSH project writes app-locally (its cwd is on another machine), so `portableIconPath`
+      // is handed the LOCAL cwd only — for an SSH project that is undefined and the path stays
+      // absolute, which is exactly the non-travelling icon that case can honestly offer.
+      const stored = portableIconPath(saved, project.ssh ? undefined : project.cwd)
+      const next = normalizeNodeIcon({ type: 'image', path: stored })
+      if (!next) {
+        // Reachable when the picked file has an extension we do not render (a .heic, say). Saying
+        // which formats work is more use than "invalid".
+        setError('That file type cannot be used as an icon. Try PNG, JPEG, GIF, WEBP or SVG.')
+        return
+      }
+      onDone(next)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return createPortal(
+    <div className="confirm-overlay" onClick={() => onDone(undefined)}>
+      <div className="confirm node-icon-dialog" onClick={(e) => e.stopPropagation()}>
+        <p className="confirm__msg">Icon for {title || 'this node'}</p>
+        <div className="node-icon-dialog__grid">
+          {PALETTE.map((e) => (
+            <button
+              key={e}
+              type="button"
+              className={`node-icon-dialog__swatch${
+                icon?.type === 'emoji' && icon.value === e ? ' is-current' : ''
+              }`}
+              onClick={() => onDone({ type: 'emoji', value: e })}
+            >
+              {e}
+            </button>
+          ))}
+        </div>
+        <div className="node-icon-dialog__row">
+          <input
+            ref={inputRef}
+            className="confirm__input node-icon-dialog__input"
+            value={typed}
+            placeholder="Or type any emoji or character"
+            spellCheck={false}
+            onChange={(e) => setTyped(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                commitTyped(typed)
+              } else if (e.key === 'Escape') {
+                e.preventDefault()
+                onDone(undefined)
+              }
+            }}
+          />
+          <button
+            type="button"
+            className="confirm__btn"
+            disabled={busy}
+            onClick={() => void chooseImage()}
+          >
+            {busy ? 'Copying…' : 'Choose image…'}
+          </button>
+        </div>
+        {error && <p className="node-icon-dialog__error">{error}</p>}
+        <div className="confirm__actions">
+          {/* Distinct from Cancel: one clears the icon, the other leaves it alone. */}
+          <button type="button" className="confirm__btn" disabled={!icon} onClick={() => onDone(null)}>
+            Remove icon
+          </button>
+          <button type="button" className="confirm__btn" onClick={() => onDone(undefined)}>
+            Cancel
+          </button>
+          <button type="button" className="confirm__btn primary" onClick={() => commitTyped(typed)}>
+            Use
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/components/NodeIconPicker.tsx
+++ b/src/renderer/components/NodeIconPicker.tsx
@@ -24,7 +24,13 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { create } from 'zustand'
-import { type NodeIcon, normalizeNodeIcon, portableIconPath } from '@shared/node-icon'
+import {
+  iconFileName,
+  type NodeIcon,
+  nodeIconMime,
+  normalizeNodeIcon,
+  portableIconPath
+} from '@shared/node-icon'
 import { canvasImportRefusal } from '../canvas/canvas-image-import'
 import { useProjects } from '../state/projects'
 import { sessionForProject } from '../session/session'
@@ -134,6 +140,15 @@ function NodeIconPicker({
     const api = sessionForProject(project.id).api
     const picked = await api.dialog.selectFile()
     if (!picked) return
+    // Checked BEFORE the copy, not after it. `selectFile` applies no filter, so a .heic is one
+    // click away — and validating afterwards meant the bytes had already been written into the
+    // project's git-shared `.nodeterm/images/`, leaving an orphan file behind every refusal.
+    // Nothing later removes it: `saveCanvasImage` creates exclusively, so the next pick would sit
+    // beside it as `photo (2).heic`.
+    if (!nodeIconMime(picked)) {
+      setError('That file type cannot be used as an icon. Try PNG, JPEG, GIF, WEBP or SVG.')
+      return
+    }
     setBusy(true)
     try {
       const b64 = await api.fs.readBinary(picked)
@@ -141,7 +156,10 @@ function NodeIconPicker({
         setError('Could not read that file.')
         return
       }
-      const name = picked.split('/').pop() || 'icon.png'
+      // Both separators, because `selectFile` answers in the HOST's dialect: on Windows it is
+      // `C:\\Users\\me\\logo.png`, which `split('/')` returned whole — so the copy was named after
+      // the entire path and `safeUploadName` then had to salvage it.
+      const name = iconFileName(picked) || 'icon.png'
       const saved = await api.files.saveCanvasImage(project.id, name, b64)
       if (!saved) {
         setError('Could not save the image — check that this project’s folder is writable.')
@@ -153,9 +171,12 @@ function NodeIconPicker({
       const stored = portableIconPath(saved, project.ssh ? undefined : project.cwd)
       const next = normalizeNodeIcon({ type: 'image', path: stored })
       if (!next) {
-        // Reachable when the picked file has an extension we do not render (a .heic, say). Saying
-        // which formats work is more use than "invalid".
-        setError('That file type cannot be used as an icon. Try PNG, JPEG, GIF, WEBP or SVG.')
+        // The extension was already accepted above, so this is no longer "wrong file type" — it
+        // means the SAVED path is one the validator will not vouch for (a UNC share, a path with
+        // no root). Blaming the file type here is what sent Windows users hunting for a format
+        // problem that did not exist: `saveCanvasImage` returns `C:\\...`, which the old
+        // POSIX-only check refused.
+        setError('Could not use that file’s location as an icon path.')
         return
       }
       onDone(next)

--- a/src/renderer/components/NodeIconPicker.tsx
+++ b/src/renderer/components/NodeIconPicker.tsx
@@ -109,11 +109,36 @@ function NodeIconPicker({
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
-  useDialogStack()
+  const isTop = useDialogStack()
 
   useEffect(() => {
     inputRef.current?.focus()
   }, [])
+
+  /**
+   * Escape belongs to the dialog, not to its text input.
+   *
+   * It was handled only in the input's `onKeyDown`, so the moment focus moved anywhere else — the
+   * emoji grid, "Choose image…", a swatch the user had just clicked — Escape did nothing and the
+   * dialog could only be dismissed with the mouse. `useDialogStack()` was already called; its
+   * answer was simply discarded.
+   *
+   * `isTop()` is the ONLY gate, deliberately matching `confirmKeyAction`: there, `inDialog` guards
+   * Enter and never Escape. The asymmetry is the point — Enter is the affirmative key and must be
+   * aimed at the dialog, while Escape is the safe direction, and requiring focus to be inside the
+   * box would reproduce exactly the bug this fixes for a user whose focus sits on the body. Being
+   * top is what keeps it honest: with a dialog stacked above, the key is not ours, and we must not
+   * `preventDefault` it either or we would swallow it from the dialog the user can see.
+   */
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape' || !isTop()) return
+      e.preventDefault()
+      onDone(undefined)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isTop, onDone])
 
   const commitTyped = (raw: string): void => {
     // The same validator the persisted file goes through, so what the picker accepts and what a
@@ -212,12 +237,12 @@ function NodeIconPicker({
             spellCheck={false}
             onChange={(e) => setTyped(e.target.value)}
             onKeyDown={(e) => {
+              // Escape is deliberately NOT handled here: the window listener above owns it for
+              // the whole dialog, and a second handler on one press is the double-answer the
+              // dialog stack exists to prevent.
               if (e.key === 'Enter') {
                 e.preventDefault()
                 commitTyped(typed)
-              } else if (e.key === 'Escape') {
-                e.preventDefault()
-                onDone(undefined)
               }
             }}
           />

--- a/src/renderer/components/NodeIconPicker.tsx
+++ b/src/renderer/components/NodeIconPicker.tsx
@@ -33,6 +33,7 @@ import {
   portableIconPath
 } from '@shared/node-icon'
 import { canvasImportRefusal } from '../canvas/canvas-image-import'
+import { browserThumbnailDeps, downscaleIconImage } from '../lib/nodeIconThumbnail'
 import { useProjects } from '../state/projects'
 import { sessionForProject } from '../session/session'
 import { useDialogStack } from './dialog-stack'
@@ -186,7 +187,12 @@ function NodeIconPicker({
       // `C:\\Users\\me\\logo.png`, which `split('/')` returned whole — so the copy was named after
       // the entire path and `safeUploadName` then had to salvage it.
       const name = iconFileName(picked) || 'icon.png'
-      const saved = await api.files.saveCanvasImage(project.id, name, b64)
+      // Shrunk BEFORE the write, not after: what goes into `.nodeterm/images/` is committed and
+      // cloned by everyone on the repo, and it draws at 13-16px. Fails open — a decode or encode
+      // that does not work hands back the original bytes, because losing the user's pick to save
+      // some disk is the wrong trade.
+      const small = await downscaleIconImage({ base64: b64, name }, browserThumbnailDeps)
+      const saved = await api.files.saveCanvasImage(project.id, small.name, small.base64)
       if (!saved) {
         setError('Could not save the image — check that this project’s folder is writable.')
         return

--- a/src/renderer/components/NodeIconPicker.tsx
+++ b/src/renderer/components/NodeIconPicker.tsx
@@ -26,6 +26,7 @@ import { createPortal } from 'react-dom'
 import { create } from 'zustand'
 import {
   iconFileName,
+  localIconCwd,
   type NodeIcon,
   nodeIconMime,
   normalizeNodeIcon,
@@ -193,7 +194,9 @@ function NodeIconPicker({
       // An SSH project writes app-locally (its cwd is on another machine), so `portableIconPath`
       // is handed the LOCAL cwd only — for an SSH project that is undefined and the path stays
       // absolute, which is exactly the non-travelling icon that case can honestly offer.
-      const stored = portableIconPath(saved, project.ssh ? undefined : project.cwd)
+      // `localIconCwd` is that rule, and the READ side asks the same function: written twice, the
+      // two copies drifted and the read side resolved a remote-rooted path against the local fs.
+      const stored = portableIconPath(saved, localIconCwd(project))
       const next = normalizeNodeIcon({ type: 'image', path: stored })
       if (!next) {
         // The extension was already accepted above, so this is no longer "wrong file type" — it

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { IconBellFilled, IconCircleCheck } from './icons'
+import { NodeIconView } from './NodeIcon'
 import { ProjectGlyph } from './ProjectGlyph'
 import type { SessionRowVM } from '../lib/sessionList'
 import { useContextWindow } from '../state/contextWindow'
@@ -98,6 +99,11 @@ export function SessionRow({
       )}
       <div className="ss-row__body">
         <div className="ss-row__titleline">
+          {/* Ahead of the project monogram: the icon identifies the SESSION, and a row that is
+              already carrying a status dot, a monogram and a context pill needs its most specific
+              mark first. `projectId` is passed because status mode flattens rows across projects,
+              so the active project is not necessarily this row's. */}
+          <NodeIconView icon={row.icon} size={13} className="ss-row__icon" projectId={row.projectId} />
           {row.projectColor ? (
             // Status mode: rows are flattened across projects, so each row shows its project's
             // icon (or, absent one, the monogram — colored circle with the project initial)

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -85,6 +85,17 @@ export const IconColor = () => (
   </svg>
 )
 
+/** "Set icon" — a face, for the emoji-or-picture the row actually sets. Deliberately unlike
+ *  IconColor (a palette of dots), which sits directly above it in the same menu. */
+export const IconSmiley = () => (
+  <svg {...S}>
+    <circle cx="12" cy="12" r="8.5" />
+    <circle cx="9.2" cy="10" r="1.1" fill="currentColor" stroke="none" />
+    <circle cx="14.8" cy="10" r="1.1" fill="currentColor" stroke="none" />
+    <path d="M8.4 14.2a4.4 4.4 0 0 0 7.2 0" />
+  </svg>
+)
+
 export const IconGrid = () => (
   <svg {...S}>
     <path d="M4 9h16M4 15h16M9 4v16M15 4v16" />

--- a/src/renderer/components/kanban/CardModal.test.tsx
+++ b/src/renderer/components/kanban/CardModal.test.tsx
@@ -92,6 +92,7 @@ describe('CardModal', () => {
           onOpenCanvas={vi.fn()}
           onRename={vi.fn()}
           onEditSticky={onEditSticky}
+          onSetIcon={vi.fn()}
           onBrowserNav={vi.fn()}
         />
       )
@@ -172,6 +173,7 @@ describe('CardModal', () => {
           onOpenCanvas={vi.fn()}
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
+          onSetIcon={vi.fn()}
           onBrowserNav={vi.fn()}
         />
       )
@@ -214,6 +216,7 @@ describe('CardModal', () => {
           onOpenCanvas={vi.fn()}
           onRename={onRename}
           onEditSticky={vi.fn()}
+          onSetIcon={vi.fn()}
           onBrowserNav={vi.fn()}
         />
       )
@@ -289,6 +292,7 @@ describe('CardModal', () => {
           onOpenCanvas={onOpenCanvas}
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
+          onSetIcon={vi.fn()}
           onBrowserNav={vi.fn()}
         />
       )
@@ -342,6 +346,7 @@ describe('CardModal', () => {
           onOpenCanvas={vi.fn()}
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
+          onSetIcon={vi.fn()}
           onBrowserNav={vi.fn()}
         />
       )
@@ -383,6 +388,7 @@ describe('CardModal', () => {
           onOpenCanvas={vi.fn()}
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
+          onSetIcon={vi.fn()}
           onBrowserNav={vi.fn()}
         />
       )
@@ -436,6 +442,7 @@ describe('CardModal', () => {
           onOpenCanvas={vi.fn()}
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
+          onSetIcon={vi.fn()}
           onBrowserNav={vi.fn()}
         />
       )

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
-import { IconChat, IconMic, IconSearch } from '../icons'
+import { IconChat, IconMic, IconSearch, IconSmiley } from '../icons'
+import { NodeIconView } from '../NodeIcon'
+import { nodeIconDialog } from '../NodeIconPicker'
+import { applyIconChoice } from '../../lib/nodeIconChoice'
+import type { NodeIcon } from '@shared/node-icon'
 import { ContextMeter } from '../ContextMeter'
 import { useAgentStatus } from '../../state/agentStatus'
 import { useCardPanel } from '../../state/cardPanel'
@@ -45,12 +49,14 @@ interface CardModalProps {
   onEditSticky: (text: string) => void
   /** Browser navigation write-through (only called for kind 'browser'). */
   onBrowserNav: (patch: { url?: string; title?: string }) => void
+  /** Icon write-through. `undefined` clears it — the dialog's cancel never reaches here. */
+  onSetIcon: (icon: NodeIcon | undefined) => void
 }
 
 /** Trello-style card popup over the board. Scrim click / Esc close it; the board (and the
  *  canvas under it) stay mounted. Terminal cards carry the node header's actions too:
  *  search / dictate / AI-name / markdown view (the node itself is hidden under the board). */
-export function CardModal({ session, columnTitle, board, onChangeBoard, onClose, onOpenCanvas, onRename, onEditSticky, onBrowserNav }: CardModalProps) {
+export function CardModal({ session, columnTitle, board, onChangeBoard, onClose, onOpenCanvas, onRename, onEditSticky, onBrowserNav, onSetIcon }: CardModalProps) {
   const { api } = useSession()
   const idRef = useRef<string>()
   if (!idRef.current) idRef.current = nextDialogId()
@@ -230,6 +236,19 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
           }}
         >
           <span className="kanban-card__nodedot" style={{ background: session.color }} />
+          <button
+            className={`kanban-modal__icon${session.icon ? '' : ' kanban-modal__icon--empty'}`}
+            title={session.icon ? 'Change icon' : 'Set icon'}
+            onClick={() =>
+              void nodeIconDialog({
+                nodeId: session.id,
+                title: session.title,
+                icon: session.icon
+              }).then((choice) => applyIconChoice(choice, onSetIcon))
+            }
+          >
+            {session.icon ? <NodeIconView icon={session.icon} size={16} /> : <IconSmiley />}
+          </button>
           {editingTitle ? (
             <input
               className="kanban-modal__rename"

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { KanbanLabel, ProjectKanban } from '@shared/types'
+import type { NodeIcon } from '@shared/node-icon'
 import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type AgentId } from '@shared/agents/config'
 import { useViewMode } from '../../state/viewMode'
 import { useProjects } from '../../state/projects'
@@ -50,6 +51,11 @@ export interface KanbanSession {
   /** Browser node session partition (kind 'browser' only) — threaded to the modal webview so it
    *  shares the canvas node's jar (`browser-partition-parity.test.tsx`). Absent = default session. */
   partition?: string
+  /** The node's user-chosen icon (see @shared/node-icon). The board is the canvas's other view of
+   *  the same session, so a session the user marked with an icon carries it here too. Terminal
+   *  cards only in v1 — that is the only kind whose canvas node offers the action, and a card
+   *  showing an icon its node cannot set would be a dead end on the board. */
+  icon?: NodeIcon
   /** The subset of the node's `data` the card modal's co-attach terminal needs to spawn/join the
    *  same session (kind 'terminal' only; sticky passes `{}`). */
   spawn: ModalSpawn
@@ -89,6 +95,8 @@ export interface KanbanViewProps {
   onModalNodeChange: (nodeId: string | null) => void
   /** Persist a browser card's navigation (url/title) from the modal webview to the node. */
   onBrowserNav: (nodeId: string, patch: { url?: string; title?: string }) => void
+  /** Set (or clear, with `undefined`) a node's icon — the card modal's icon button. */
+  onSetIcon: (nodeId: string, icon: NodeIcon | undefined) => void
 }
 
 type Drag =
@@ -117,7 +125,7 @@ const NO_CARDS: KanbanSession[] = []
  *  renders stop at this boundary. */
 export const KanbanView = memo(function KanbanView({
   board, sessions, onChange, onOpenNode, onCreateNode, onRenameNode, onEditSticky, onDeleteNode,
-  onModalNodeChange, onBrowserNav
+  onModalNodeChange, onBrowserNav, onSetIcon
 }: KanbanViewProps) {
   const { api } = useSession()
   const dragRef = useRef<Drag>(null)
@@ -663,6 +671,7 @@ export const KanbanView = memo(function KanbanView({
           onRename={(t) => onRenameNode(modalNodeId, t)}
           onEditSticky={(t) => onEditSticky(modalNodeId, t)}
           onBrowserNav={(patch) => onBrowserNav(modalNodeId, patch)}
+          onSetIcon={(icon) => onSetIcon(modalNodeId, icon)}
         />
       )}
       {modalIssue && (

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -2,6 +2,7 @@ import { memo, useState } from 'react'
 import type { KanbanCardMeta, KanbanLabel, KanbanPriority } from '@shared/types'
 import { useAgentStatus } from '../../state/agentStatus'
 import { ContextMeter } from '../ContextMeter'
+import { NodeIconView } from '../NodeIcon'
 import { LabelChips } from './LabelChips'
 import type { KanbanSession } from './KanbanView'
 
@@ -105,6 +106,7 @@ export const SessionCard = memo(function SessionCard({
     >
       <div className="kanban-card__row">
         <span className="kanban-card__nodedot" style={{ background: session.color }} />
+        <NodeIconView icon={session.icon} size={14} className="kanban-card__icon" />
         <span className="kanban-card__title">{session.title}</span>
         {session.kind === 'sticky' && <span className="kanban-card__kind">note</span>}
         {session.kind === 'browser' && <span className="kanban-card__kind">web</span>}

--- a/src/renderer/lib/nodeIconChoice.test.ts
+++ b/src/renderer/lib/nodeIconChoice.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyIconChoice } from './nodeIconChoice'
+
+describe('applyIconChoice', () => {
+  it('sets the chosen icon', () => {
+    const apply = vi.fn()
+    applyIconChoice({ type: 'emoji', value: '\u{1F680}' }, apply)
+    expect(apply).toHaveBeenCalledWith({ type: 'emoji', value: '\u{1F680}' })
+  })
+
+  // The distinction the whole module exists for: `if (!choice) return` passes every test above
+  // and breaks exactly this one.
+  it('clears the icon on remove', () => {
+    const apply = vi.fn()
+    applyIconChoice(null, apply)
+    expect(apply).toHaveBeenCalledTimes(1)
+    expect(apply).toHaveBeenCalledWith(undefined)
+  })
+
+  it('does nothing at all on cancel, so a cancel cannot mark the canvas dirty', () => {
+    const apply = vi.fn()
+    applyIconChoice(undefined, apply)
+    expect(apply).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/nodeIconChoice.ts
+++ b/src/renderer/lib/nodeIconChoice.ts
@@ -1,0 +1,29 @@
+/**
+ * What the icon dialog's answer MEANS, in one place.
+ *
+ * The dialog has three outcomes and two of them are easy to confuse, because JavaScript makes
+ * `null` and `undefined` look interchangeable right up until they are not:
+ *
+ *   a `NodeIcon`  → set this icon
+ *   `null`        → remove the icon the node has
+ *   `undefined`   → cancelled; the node keeps whatever it had
+ *
+ * Written inline at each call site, "remove" and "cancel" collapse the moment someone writes
+ * `if (!choice) return` — which reads as obviously correct and silently turns the Remove button
+ * into a second Cancel. Three surfaces open this dialog, so the rule lives here once and is
+ * pinned by a test rather than by three identical conditionals.
+ */
+import type { NodeIcon } from '@shared/node-icon'
+import type { NodeIconChoice } from '../components/NodeIconPicker'
+
+/**
+ * Apply a dialog answer. `apply` is called with the new icon, or with `undefined` to clear it —
+ * and is NOT called at all when the user cancelled, so a cancel never marks the canvas dirty.
+ */
+export function applyIconChoice(
+  choice: NodeIconChoice,
+  apply: (icon: NodeIcon | undefined) => void
+): void {
+  if (choice === undefined) return
+  apply(choice ?? undefined)
+}

--- a/src/renderer/lib/nodeIconImage.ts
+++ b/src/renderer/lib/nodeIconImage.ts
@@ -20,7 +20,7 @@
  */
 import { useEffect, useState } from 'react'
 import type { FsApi } from '@shared/types'
-import { type NodeIcon, nodeIconMime, resolveIconPath } from '@shared/node-icon'
+import { localIconCwd, type NodeIcon, nodeIconMime, resolveIconPath } from '@shared/node-icon'
 import { sessionForProject } from '../session/session'
 import { useProjects } from '../state/projects'
 
@@ -84,7 +84,11 @@ export function useNodeIconSrc(icon: NodeIcon | undefined, projectId?: string): 
   const activeProjectId = useProjects((s) => s.activeProjectId)
   const pid = projectId ?? activeProjectId
   const storedPath = icon?.type === 'image' ? icon.path : null
-  const cwd = useProjects((s) => (pid ? s.getProject(pid)?.cwd : undefined))
+  // `localIconCwd`, not `project.cwd` — the single definition of "which cwd may a `./` icon be
+  // resolved against", shared with the picker's write side so the two cannot drift again. Selected
+  // down to ONE primitive here on purpose: the project object is rebuilt on every node
+  // serialization, so returning it would re-run this effect on every canvas edit.
+  const cwd = useProjects((s) => (pid ? localIconCwd(s.getProject(pid)) : undefined))
   const [src, setSrc] = useState<string | null>(null)
 
   useEffect(() => {

--- a/src/renderer/lib/nodeIconImage.ts
+++ b/src/renderer/lib/nodeIconImage.ts
@@ -1,0 +1,112 @@
+/**
+ * Turning a node's icon IMAGE into something an `<img>` can show, once per file rather than once
+ * per place it is drawn.
+ *
+ * The same icon appears on the canvas node header, on its kanban card, in the card modal and in
+ * the sessions sidebar — four components that mount and unmount independently. Read per component
+ * and a board of thirty sessions issues thirty duplicate `readBinary` round trips on every open,
+ * for bytes that have not changed. So the promise is cached by absolute path and every caller
+ * awaits the same one.
+ *
+ * Caching by PATH is safe because a picked image is never overwritten in place: `saveCanvasImage`
+ * creates exclusively (`wx`) and walks `candidateName`, so re-picking produces `logo (2).png`, a
+ * different key. An icon the user points at an arbitrary file they later edit is the one case a
+ * stale entry could survive, and it costs an app restart — the trade a per-render re-read is not
+ * worth.
+ *
+ * Reads go through the PROJECT's own session api, not `window.nodeTerminal`: a relay tab's project
+ * lives on a peer's core, and its `./`-relative icon resolves against the peer's cwd. Reading it
+ * locally would ask this machine for a path only that one has.
+ */
+import { useEffect, useState } from 'react'
+import type { FsApi } from '@shared/types'
+import { type NodeIcon, nodeIconMime, resolveIconPath } from '@shared/node-icon'
+import { sessionForProject } from '../session/session'
+import { useProjects } from '../state/projects'
+
+/**
+ * Bounded so a long session that visits many projects cannot grow it without limit. Icons are
+ * small and few per canvas; 128 is far above any real board and still a fixed ceiling.
+ */
+const CACHE_MAX = 128
+
+/**
+ * An icon big enough to be worth refusing. `readBinary` already returns a sentinel STRING above
+ * its own cap rather than base64, and that sentinel is not valid base64 — an `<img>` fed it shows
+ * a broken-image glyph on every surface, which is worse than no icon. This bound catches both
+ * that case and a merely huge file, and its unit is base64 characters (~3/4 of a byte each).
+ */
+const SRC_MAX_CHARS = 4_000_000
+
+const cache = new Map<string, Promise<string | null>>()
+
+/** The cache key includes the reader: two projects can resolve the same `./` path against
+ *  different roots, and a relay project's read lands on another machine entirely. */
+const keyFor = (projectId: string, absPath: string): string => `${projectId}\x00${absPath}`
+
+/** Test seam, and the escape hatch for "I replaced the file on disk". */
+export function clearNodeIconCache(): void {
+  cache.clear()
+}
+
+/**
+ * Read `absPath` as a data URL, or null when it could not be read. Never rejects: an icon that
+ * cannot be drawn falls back to no icon, which is the pre-feature node.
+ */
+export function loadNodeIconSrc(
+  fs: FsApi,
+  projectId: string,
+  absPath: string
+): Promise<string | null> {
+  const key = keyFor(projectId, absPath)
+  const hit = cache.get(key)
+  if (hit) return hit
+  const mime = nodeIconMime(absPath)
+  // Unreachable through `normalizeNodeIcon` (which already refuses a non-image extension), and
+  // deliberately still checked: this function is exported and the next caller may not have gone
+  // through it.
+  if (!mime) return Promise.resolve(null)
+  const pending = Promise.resolve()
+    .then(() => fs.readBinary(absPath))
+    .then((b64) => (b64 && b64.length < SRC_MAX_CHARS ? `data:${mime};base64,${b64}` : null))
+    .catch(() => null)
+  if (cache.size >= CACHE_MAX) cache.delete(cache.keys().next().value as string)
+  cache.set(key, pending)
+  return pending
+}
+
+/**
+ * The `src` for an icon image, or null while it loads / when it cannot be read. `projectId`
+ * defaults to the active project — pass it explicitly from any surface that lists nodes across
+ * projects (the sessions sidebar's status mode does), or the icon resolves against the wrong root.
+ */
+export function useNodeIconSrc(icon: NodeIcon | undefined, projectId?: string): string | null {
+  const activeProjectId = useProjects((s) => s.activeProjectId)
+  const pid = projectId ?? activeProjectId
+  const storedPath = icon?.type === 'image' ? icon.path : null
+  const cwd = useProjects((s) => (pid ? s.getProject(pid)?.cwd : undefined))
+  const [src, setSrc] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!storedPath || !pid) {
+      setSrc(null)
+      return
+    }
+    const abs = resolveIconPath(storedPath, cwd)
+    if (!abs) {
+      // A `./` icon on a project with no local cwd: the file belongs to a checkout this machine
+      // does not have. Nothing to read, and nothing worth guessing at.
+      setSrc(null)
+      return
+    }
+    let live = true
+    void loadNodeIconSrc(sessionForProject(pid).api.fs, pid, abs).then((v) => {
+      if (live) setSrc(v)
+    })
+    return () => {
+      live = false
+    }
+  }, [storedPath, pid, cwd])
+
+  return src
+}

--- a/src/renderer/lib/nodeIconThumbnail.test.ts
+++ b/src/renderer/lib/nodeIconThumbnail.test.ts
@@ -1,0 +1,167 @@
+// The decision half runs here under the default `node` environment — no jsdom, no canvas. That
+// is the reason the module is split: a rule that could only be exercised in a browser would not
+// be exercised at all.
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DECODE_TIMEOUT_MS,
+  downscaleIconImage,
+  ICON_MAX_EDGE,
+  ICON_SKIP_BYTES,
+  thumbnailPlan,
+  type ThumbnailDeps
+} from './nodeIconThumbnail'
+
+const BIG = 200 * 1024
+
+describe('thumbnailPlan', () => {
+  it('shrinks a large photo to the long-edge bound, keeping its aspect ratio', () => {
+    const plan = thumbnailPlan({
+      mime: 'image/jpeg',
+      width: 4000,
+      height: 3000,
+      byteLength: 4_000_000,
+      name: 'photo.jpg'
+    })
+    expect(plan).toEqual({
+      downscale: true,
+      width: ICON_MAX_EDGE,
+      height: 192, // 3000 * (256/4000)
+      name: 'photo.png'
+    })
+  })
+
+  it('renames to .png, because the re-encode IS png whatever went in', () => {
+    // A file called `photo.jpg` holding PNG bytes reads back through `nodeIconMime` as
+    // image/jpeg, and the data URL would then declare the wrong type.
+    const plan = thumbnailPlan({
+      mime: 'image/jpeg',
+      width: 2000,
+      height: 2000,
+      byteLength: BIG,
+      name: 'C:\\Users\\me\\photo.JPEG'
+    })
+    expect(plan).toMatchObject({ downscale: true, name: 'photo.png' })
+  })
+
+  it('leaves SVG alone — the original is strictly the better artifact', () => {
+    // Rasterizing it to 256px would make it WORSE at every size, not just bigger-file-worse.
+    expect(
+      thumbnailPlan({
+        mime: 'image/svg+xml',
+        width: 4000,
+        height: 4000,
+        byteLength: 4_000_000,
+        name: 'mark.svg'
+      })
+    ).toEqual({ downscale: false, reason: 'vector' })
+  })
+
+  it('leaves an already-small icon alone, so a hand-made 32px PNG is untouched', () => {
+    expect(
+      thumbnailPlan({ mime: 'image/png', width: 32, height: 32, byteLength: 900, name: 'a.png' })
+    ).toEqual({ downscale: false, reason: 'already-small' })
+  })
+
+  it('still shrinks small DIMENSIONS carrying big BYTES (an animated gif)', () => {
+    const plan = thumbnailPlan({
+      mime: 'image/gif',
+      width: 64,
+      height: 64,
+      byteLength: ICON_SKIP_BYTES + 1,
+      name: 'spin.gif'
+    })
+    // Under the edge bound, so it is not scaled DOWN — but it is re-encoded, which is what drops
+    // the frames nobody can see at 16px.
+    expect(plan).toEqual({ downscale: true, width: 64, height: 64, name: 'spin.png' })
+  })
+
+  it('refuses to scale against a dimension it does not trust', () => {
+    expect(
+      thumbnailPlan({ mime: 'image/png', width: 0, height: 0, byteLength: BIG, name: 'a.png' })
+    ).toEqual({ downscale: false, reason: 'unsupported' })
+  })
+
+  it('never produces a zero edge for an extreme banner', () => {
+    const plan = thumbnailPlan({
+      mime: 'image/png',
+      width: 2000,
+      height: 3,
+      byteLength: BIG,
+      name: 'bar.png'
+    })
+    expect(plan).toMatchObject({ downscale: true, width: ICON_MAX_EDGE, height: 1 })
+  })
+})
+
+/** A deps double: decodes to fixed dimensions, encodes to a data URL of a chosen size. */
+const deps = (dim: { width: number; height: number }, encodedChars: number): ThumbnailDeps => ({
+  decode: vi.fn(async () => dim),
+  encode: vi.fn(() => `data:image/png;base64,${'x'.repeat(encodedChars)}`)
+})
+
+describe('downscaleIconImage', () => {
+  const picked = { base64: 'y'.repeat(400_000), name: 'photo.jpg' }
+
+  it('returns the shrunk bytes and the .png name', async () => {
+    const d = deps({ width: 4000, height: 3000 }, 5_000)
+    const out = await downscaleIconImage(picked, d)
+    expect(out.name).toBe('photo.png')
+    expect(out.base64).toHaveLength(5_000)
+    expect(d.encode).toHaveBeenCalledWith({ width: 4000, height: 3000 }, ICON_MAX_EDGE, 192)
+  })
+
+  it('keeps the ORIGINAL when the re-encode came out larger', async () => {
+    const out = await downscaleIconImage(picked, deps({ width: 4000, height: 3000 }, 999_999))
+    expect(out).toBe(picked)
+  })
+
+  it('keeps the ORIGINAL when decoding throws — a failure must not cost the user their pick', async () => {
+    const out = await downscaleIconImage(picked, {
+      decode: async () => {
+        throw new Error('not an image')
+      },
+      encode: () => 'data:image/png;base64,zzz'
+    })
+    expect(out).toBe(picked)
+  })
+
+  it('keeps the ORIGINAL when there is no canvas to draw on', async () => {
+    const out = await downscaleIconImage(picked, {
+      decode: async () => ({ width: 4000, height: 3000 }),
+      encode: () => {
+        throw new Error('no 2d context')
+      }
+    })
+    expect(out).toBe(picked)
+  })
+
+  it('never touches an SVG, without even decoding it', async () => {
+    const svg = { base64: 'PHN2Zz48L3N2Zz4=', name: 'mark.svg' }
+    const d = deps({ width: 4000, height: 4000 }, 10)
+    expect(await downscaleIconImage(svg, d)).toBe(svg)
+    expect(d.decode).not.toHaveBeenCalled()
+  })
+
+  it('keeps the ORIGINAL when the decode never settles at all', async () => {
+    // `chooseImage` awaits this before it writes, so a hanging promise would leave the button
+    // stuck on "Copying…" with no way out but closing the dialog.
+    vi.useFakeTimers()
+    try {
+      const pending = downscaleIconImage(picked, {
+        decode: () => new Promise<never>(() => {}),
+        encode: () => 'data:image/png;base64,zzz'
+      })
+      await vi.advanceTimersByTimeAsync(DECODE_TIMEOUT_MS + 1)
+      expect(await pending).toBe(picked)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('never touches a file whose extension is not an icon type', async () => {
+    const other = { base64: 'zzzz', name: 'photo.heic' }
+    const d = deps({ width: 4000, height: 4000 }, 10)
+    expect(await downscaleIconImage(other, d)).toBe(other)
+    expect(d.decode).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/nodeIconThumbnail.ts
+++ b/src/renderer/lib/nodeIconThumbnail.ts
@@ -1,0 +1,195 @@
+/**
+ * Shrinking a picked icon image before it is written into the project.
+ *
+ * An icon draws at 13–16 px. What the picker copied was whatever the user chose — routinely a
+ * 4 MB phone photo — and that file went into the project's git-shared `.nodeterm/images/`, so it
+ * was committed, cloned by everyone on the repo, and held in renderer memory by
+ * `nodeIconImage`'s cache for the life of the session. Nobody ever saw more than 16 px of it.
+ *
+ * The bound is 256 px on the long edge: 16× the drawn size, so it still looks right on a HiDPI
+ * display and if icons ever get bigger, while turning that 4 MB photo into tens of kilobytes.
+ *
+ * **Split in two on purpose.** `thumbnailPlan` is the whole DECISION and is pure, so it runs under
+ * vitest's default `node` environment — jsdom has no canvas, and a rule that could only be tested
+ * in a browser would not be tested. `downscaleIconImage` is the part that must touch one, and its
+ * decode/encode is injected.
+ *
+ * **It fails open, always.** Any failure — a decode error, a canvas the browser would not give us,
+ * a re-encode that came out larger — yields the ORIGINAL bytes. Losing the user's pick to save
+ * some disk is a bad trade; storing a big file is merely the status quo. That includes a decode
+ * that never settles AT ALL (`DECODE_TIMEOUT_MS`): `chooseImage` awaits this before it writes, so
+ * a promise that hangs would leave the button stuck on "Copying…" with no way out but closing the
+ * dialog. A bounded wait turns the worst case back into "the icon is just the file you picked".
+ */
+import { iconFileName, nodeIconMime } from '@shared/node-icon'
+
+/**
+ * How long to wait for a decode before giving up and keeping the original. Decoding a local data
+ * URL is near-instant, so this is not a budget — it is a backstop against a decoder that never
+ * calls back at all.
+ */
+export const DECODE_TIMEOUT_MS = 3_000
+
+/** Long-edge bound, in pixels. See the module comment for why 256. */
+export const ICON_MAX_EDGE = 256
+
+/**
+ * Below this, re-encoding is not worth attempting. A hand-made 32 px PNG or a small favicon is
+ * already smaller than anything we would produce, and a canvas round-trip could easily make it
+ * BIGGER (it re-encodes at default quality, and it flattens any format cleverness the original
+ * had). Sized so an ordinary icon file passes straight through untouched.
+ */
+export const ICON_SKIP_BYTES = 32 * 1024
+
+/** What `downscaleIconImage` should do with a picked image. */
+export type ThumbnailPlan =
+  | { downscale: false; reason: 'vector' | 'already-small' | 'unsupported' }
+  | { downscale: true; width: number; height: number; name: string }
+
+export interface ThumbnailInput {
+  /** The MIME type of the picked file, as `nodeIconMime` answered it. */
+  mime: string | undefined
+  width: number
+  height: number
+  /** Decoded size of the picked file, in bytes. */
+  byteLength: number
+  /** The picked file's name, in either path dialect. */
+  name: string
+}
+
+/**
+ * Decide whether a picked image is worth shrinking, and to what.
+ *
+ * SVG is passed through untouched: it is already resolution-independent and tiny, and
+ * rasterizing it to 256 px would make it *worse* at every size — a smaller file that looks blurry
+ * when a future canvas draws icons larger. It is the one format where the original is strictly
+ * the better artifact.
+ */
+export function thumbnailPlan(input: ThumbnailInput): ThumbnailPlan {
+  const { mime, width, height, byteLength, name } = input
+  if (!mime) return { downscale: false, reason: 'unsupported' }
+  if (mime === 'image/svg+xml') return { downscale: false, reason: 'vector' }
+  // A zero dimension means the decoder could not tell us anything useful; treat it as "leave it
+  // alone" rather than scaling against a number we do not trust.
+  if (width <= 0 || height <= 0) return { downscale: false, reason: 'unsupported' }
+
+  const longEdge = Math.max(width, height)
+  if (longEdge <= ICON_MAX_EDGE && byteLength <= ICON_SKIP_BYTES) {
+    return { downscale: false, reason: 'already-small' }
+  }
+
+  // Aspect ratio is preserved; a non-square icon stays non-square. `Math.round` with a floor of 1
+  // so an extreme banner (2000x3) cannot produce a zero-height canvas.
+  const scale = Math.min(1, ICON_MAX_EDGE / longEdge)
+  return {
+    downscale: true,
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+    // The re-encode is PNG whatever went in, so the name has to say so — a file called `photo.jpg`
+    // holding PNG bytes would be read back through `nodeIconMime` as `image/jpeg` and handed to an
+    // `<img>` with the wrong data URL type.
+    name: `${stripExtension(iconFileName(name)) || 'icon'}.png`
+  }
+}
+
+/** `logo.jpeg` → `logo`. A name with no dot is returned whole. */
+function stripExtension(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot > 0 ? name.slice(0, dot) : name
+}
+
+export interface ThumbnailImage {
+  width: number
+  height: number
+}
+
+/** The browser work, injected so the caller can be tested without one. */
+export interface ThumbnailDeps {
+  /** Decode a data URL into something drawable. Rejects if the bytes are not an image. */
+  decode(dataUrl: string): Promise<ThumbnailImage>
+  /** Draw `image` at `width`x`height` and return a `image/png` data URL. */
+  encode(image: ThumbnailImage, width: number, height: number): string
+}
+
+export interface PickedImage {
+  /** Base64 (no data-URL prefix), as `fs.readBinary` returns it. */
+  base64: string
+  name: string
+}
+
+/**
+ * Shrink `picked` if it is worth shrinking. Returns the bytes and name to save — the ORIGINAL
+ * ones whenever the plan says no, or anything at all goes wrong.
+ */
+export async function downscaleIconImage(
+  picked: PickedImage,
+  deps: ThumbnailDeps
+): Promise<PickedImage> {
+  const mime = nodeIconMime(picked.name)
+  if (!mime || mime === 'image/svg+xml') return picked
+  try {
+    const image = await withTimeout(deps.decode(`data:${mime};base64,${picked.base64}`))
+    const plan = thumbnailPlan({
+      mime,
+      width: image.width,
+      height: image.height,
+      // base64 carries 3 bytes per 4 characters; padding makes this a slight over-estimate, which
+      // is the harmless direction (it can only make us try to shrink something borderline).
+      byteLength: Math.floor((picked.base64.length * 3) / 4),
+      name: picked.name
+    })
+    if (!plan.downscale) return picked
+
+    const dataUrl = deps.encode(image, plan.width, plan.height)
+    const base64 = dataUrl.slice(dataUrl.indexOf(',') + 1)
+    if (!base64) return picked
+    // A re-encode that came out LARGER is not an improvement, and it would cost the user their
+    // original file for nothing. Screenshots of flat UI hit this: PNG-of-a-PNG at a smaller size
+    // is usually smaller, but not always.
+    if (base64.length >= picked.base64.length) return picked
+    return { base64, name: plan.name }
+  } catch {
+    return picked
+  }
+}
+
+/** Reject rather than hang. The rejection lands in `downscaleIconImage`'s catch, i.e. the
+ *  original bytes — the same outcome as any other decode failure. */
+function withTimeout(p: Promise<ThumbnailImage>): Promise<ThumbnailImage> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('decode timed out')), DECODE_TIMEOUT_MS)
+    p.then(
+      (v) => {
+        clearTimeout(timer)
+        resolve(v)
+      },
+      (e) => {
+        clearTimeout(timer)
+        reject(e)
+      }
+    )
+  })
+}
+
+/**
+ * The real browser implementation. Kept beside the pure logic rather than inline in the picker so
+ * the seam is obvious, and so a second caller (a future project-icon picker, say) reuses it.
+ */
+export const browserThumbnailDeps: ThumbnailDeps = {
+  decode: (dataUrl) =>
+    new Promise((resolve, reject) => {
+      const img = new Image()
+      img.onload = () => resolve(img)
+      img.onerror = () => reject(new Error('decode failed'))
+      img.src = dataUrl
+    }),
+  encode: (image, width, height) => {
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('no 2d context')
+    ctx.drawImage(image as CanvasImageSource, 0, 0, width, height)
+    return canvas.toDataURL('image/png')
+  }
+}

--- a/src/renderer/lib/sessionList.ts
+++ b/src/renderer/lib/sessionList.ts
@@ -1,6 +1,7 @@
 import type { AgentNodeStatus } from '../state/agentStatus'
 import type { AgentId } from '@shared/agents/config'
 import type { NodeKind } from '@shared/types'
+import type { NodeIcon } from '@shared/node-icon'
 import { hasUsage } from '@shared/agents/config'
 import type { SshConnection } from '@shared/ssh'
 import type { ProjectIcon } from '@shared/project-icon'
@@ -16,6 +17,8 @@ export interface SessionNodeInput {
   ssh?: SshConnection
   /** Parent group node id when this node lives inside a canvas group frame. */
   parentId?: string
+  /** The node's user-chosen icon (see @shared/node-icon). */
+  icon?: NodeIcon
 }
 
 export interface ProjectInput {
@@ -223,6 +226,7 @@ export interface SessionRowVM {
   title: string
   color: string
   agentId?: AgentId
+  icon?: NodeIcon
   isAgent: boolean
   statusKind: StatusKind
   stateLabel: string
@@ -292,6 +296,7 @@ function toRow(
     title: n.title,
     color: n.color,
     agentId: n.agentId,
+    icon: n.icon,
     isAgent: !!n.agentId,
     statusKind,
     stateLabel: STATE_LABEL[statusKind],

--- a/src/renderer/lib/ui-visibility.test.ts
+++ b/src/renderer/lib/ui-visibility.test.ts
@@ -23,7 +23,7 @@ describe('isHidden', () => {
 describe('hideable inventories', () => {
   it('list the agreed ids and nothing destructive', () => {
     expect(HIDEABLE_MENU_ITEMS.map((r) => r.id)).toEqual([
-      'group', 'remove-from-group', 'colors', 'duplicate', 'snap-zone', 'collapse',
+      'group', 'remove-from-group', 'colors', 'icon', 'duplicate', 'snap-zone', 'collapse',
       'markdown-view', 'refresh-terminal'
     ])
     expect(HIDEABLE_HEADER_BUTTONS.map((r) => r.id)).toEqual([

--- a/src/renderer/lib/ui-visibility.ts
+++ b/src/renderer/lib/ui-visibility.ts
@@ -22,6 +22,7 @@ export const HIDEABLE_MENU_ITEMS: readonly HideableRow[] = [
   { id: 'group', label: 'Group node / Group selection' },
   { id: 'remove-from-group', label: 'Remove from group' },
   { id: 'colors', label: 'Colors' },
+  { id: 'icon', label: 'Set icon' },
   { id: 'duplicate', label: 'Duplicate' },
   { id: 'snap-zone', label: 'Snap to zone' },
   { id: 'collapse', label: 'Collapse / Expand' },

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -191,6 +191,10 @@ import { ColumnPill } from '../components/kanban/ColumnPill'
 import { BoardLogPanel } from '../components/kanban/BoardLogPanel'
 import { AgentMascot } from './AgentMascot'
 import { MaximizeButton } from './MaximizeButton'
+import { NodeIconView } from '../components/NodeIcon'
+import { nodeIconDialog } from '../components/NodeIconPicker'
+import { applyIconChoice } from '../lib/nodeIconChoice'
+import type { NodeIcon } from '@shared/node-icon'
 import { connectHostAttachment } from '../lib/sshAttachments'
 
 /** Which physical modifier the registry's abstract `Cmd` resolves to for the find-bar chord. */
@@ -4698,6 +4702,24 @@ export function TerminalNode({
             ))}
           </div>
         )}
+        {data.icon ? (
+          <button
+            className="term-node__icon nodrag"
+            title="Change icon"
+            onClick={(e) => {
+              e.stopPropagation()
+              void nodeIconDialog({
+                nodeId: id,
+                title: (data.title as string) ?? '',
+                icon: data.icon as NodeIcon
+              }).then((choice) =>
+                applyIconChoice(choice, (icon) => updateNodeData(id, { icon }))
+              )
+            }}
+          >
+            <NodeIconView icon={data.icon as NodeIcon} size={15} />
+          </button>
+        ) : null}
         {editingTitle ? (
           <input
             className="term-node__title nodrag"

--- a/src/renderer/nodes/browser-partition-parity.test.tsx
+++ b/src/renderer/nodes/browser-partition-parity.test.tsx
@@ -79,6 +79,7 @@ function partitionFromModal(sessionPartition: string | undefined): string | null
         onOpenCanvas={vi.fn()}
         onRename={vi.fn()}
         onEditSticky={vi.fn()}
+        onSetIcon={vi.fn()}
         onBrowserNav={vi.fn()}
       />
     )

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -541,6 +541,66 @@ describe('group worktree serialization', () => {
   })
 })
 
+describe('node icon serialization', () => {
+  const withIcon = (icon: unknown): CanvasNode =>
+    ({
+      id: 't1',
+      type: 'terminal',
+      position: { x: 0, y: 0 },
+      width: 320,
+      height: 240,
+      data: { title: 'T', color: '#888', group: null, icon }
+    }) as unknown as CanvasNode
+
+  const stateWithIcon = (icon: unknown) => ({
+    id: 't1',
+    kind: 'terminal' as const,
+    position: { x: 0, y: 0 },
+    size: { width: 320, height: 240 },
+    title: 'T',
+    color: '#888',
+    group: null,
+    icon
+  })
+
+  it('round-trips an emoji icon', () => {
+    const icon = { type: 'emoji', value: '\u{1F680}' }
+    const states = flowToNodeStates([withIcon(icon)])
+    expect(states[0].icon).toEqual(icon)
+    expect(nodeStatesToFlow(states)[0].data.icon).toEqual(icon)
+  })
+
+  it('round-trips an image icon', () => {
+    const icon = { type: 'image', path: './.nodeterm/images/logo.png' }
+    const states = flowToNodeStates([withIcon(icon)])
+    expect(states[0].icon).toEqual(icon)
+    expect(nodeStatesToFlow(states)[0].data.icon).toEqual(icon)
+  })
+
+  it('leaves a node without one undefined, so an untouched canvas serializes as it always did', () => {
+    expect(flowToNodeStates([withIcon(undefined)])[0].icon).toBeUndefined()
+  })
+
+  // project.json is git-shared and hand-editable, so hydration is a trust boundary. A path that is
+  // not an image would otherwise reach `fs.readBinary` on load.
+  it('drops a hostile icon on the way IN', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const hydrate = (icon: unknown) => nodeStatesToFlow([stateWithIcon(icon) as any])[0].data.icon
+    expect(hydrate({ type: 'image', path: '/home/u/.ssh/id_rsa' })).toBeUndefined()
+    expect(hydrate({ type: 'image', path: './../../.ssh/id_rsa.png' })).toBeUndefined()
+    expect(hydrate({ type: 'nonsense' })).toBeUndefined()
+    expect(hydrate('\u{1F680}')).toBeUndefined()
+    expect(hydrate({ type: 'emoji', value: 'abcdef' })).toEqual({ type: 'emoji', value: 'a' })
+  })
+
+  // And on the way OUT too: live node data can be reached by a peer canvas mutation, and whatever
+  // is written here becomes the next reader's "trusted" file.
+  it('drops a hostile icon on the way OUT', () => {
+    expect(flowToNodeStates([withIcon({ type: 'image', path: '/etc/passwd' })])[0].icon).toBeUndefined()
+    expect(flowToNodeStates([withIcon({ type: 'emoji', value: '' })])[0].icon).toBeUndefined()
+  })
+})
+
 describe('resolveNewNodeAccount', () => {
   const accounts = [{ id: 'a1', label: 'work', createdAt: 0 }]
   it('prefers the explicit pick', () =>

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -19,6 +19,7 @@ import { projectLaunchInfoNow } from './projectLaunchInfo'
 import { isAgentEnabled, launchableDefaultAgent } from './agentAvailability'
 import { codexSharedIdentity } from './codexIdentity'
 import { sshHostKey } from '@shared/ssh'
+import { normalizeNodeIcon } from '@shared/node-icon'
 import { useSettings } from './settings'
 
 // Re-exported so Canvas (and anything else in the renderer) keeps importing it from here, while the
@@ -1795,6 +1796,10 @@ export function nodeStatesToFlow(states: CanvasNodeState[]): CanvasNode[] {
         tags: n.tags,
         collapsed,
         hideFanout: n.hideFanout,
+        // Validated HERE, at the seam where a git-shared, hand-editable project file becomes live
+        // node data — so every surface that renders an icon gets a value this module vouched for
+        // rather than each one re-deciding. An unrecognized icon becomes no icon.
+        icon: normalizeNodeIcon(n.icon),
         expandedHeight: n.size.height,
         premaxRect: n.premaxRect,
         shell: n.shell,
@@ -1869,6 +1874,11 @@ export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
         tags: n.data.tags,
         collapsed: n.data.collapsed,
         hideFanout: n.data.hideFanout,
+        // React Flow's node `data` is `Record<string, unknown>`, so the icon comes back out
+        // untyped. Re-validating on the way OUT (not just on the way in) also means a value a
+        // peer canvas mutation or a future caller put on live node data cannot be written to the
+        // shared file unchecked — the file is only ever as trustworthy as its last writer.
+        icon: normalizeNodeIcon(n.data.icon),
         parentId: n.parentId,
         shell: n.data.shell,
         cwd: n.data.cwd,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -11750,3 +11750,126 @@ body.focus-mode .dock:hover {
   color: var(--muted);
   font-size: 13px;
 }
+
+/* ── Node icons (emoji or picture) ─────────────────────────────────────────────────────────
+   One shared box for every surface that draws a node's icon — canvas header, kanban card, card
+   modal, sessions sidebar — so the same session reads the same in all four. Sized by the caller
+   (inline width/height) because a 13px sidebar row and a 16px modal header want different boxes;
+   everything else about how it draws is here.
+
+   `line-height: 1` matters more than it looks: an emoji inherits the surrounding line box, and a
+   header row that is exactly its own text height grows by a couple of px when one is inserted —
+   which nudges every chip beside it. */
+.node-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  line-height: 1;
+  overflow: hidden;
+  /* Emoji fonts differ in how much of the em they fill; centering the glyph in a fixed box keeps
+     a 🚀 and a 🟢 optically the same size rather than the same font-size. */
+  text-align: center;
+}
+
+.node-icon img {
+  width: 100%;
+  height: 100%;
+  /* `contain`, not `cover`: an icon the user picked is usually a logo, and cropping a logo to a
+     square is the one thing that makes it unrecognizable at 14px. */
+  object-fit: contain;
+  border-radius: 3px;
+  display: block;
+}
+
+/* The canvas node header's icon is a button (click re-opens the picker) but must not look like
+   one — it sits between the color swatch and the title, which are both flat. */
+.term-node__icon {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  opacity: 0.95;
+}
+.term-node__icon:hover {
+  opacity: 1;
+}
+
+.kanban-card__row > .node-icon.kanban-card__icon {
+  margin-top: 4px; /* optically centers on the first title line, like the color dot beside it */
+}
+
+/* The card modal always offers the action, so its slot is present even with no icon set — muted
+   until it has one, so an unset icon reads as an affordance rather than as a missing image. */
+.kanban-modal__icon {
+  background: none;
+  border: none;
+  padding: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--muted);
+  border-radius: 5px;
+  flex-shrink: 0;
+}
+.kanban-modal__icon:hover {
+  background: rgba(var(--tint-rgb), 0.1);
+  color: var(--text);
+}
+.kanban-modal__icon--empty {
+  opacity: 0.5;
+}
+.kanban-modal__icon--empty:hover {
+  opacity: 1;
+}
+
+/* ── The icon picker dialog ───────────────────────────────────────────────────────────────── */
+.node-icon-dialog {
+  min-width: 340px;
+}
+
+.node-icon-dialog__grid {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 2px;
+  margin: 10px 0 4px;
+}
+
+.node-icon-dialog__swatch {
+  background: none;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 0;
+  font-size: 18px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+.node-icon-dialog__swatch:hover {
+  background: rgba(var(--tint-rgb), 0.12);
+}
+.node-icon-dialog__swatch.is-current {
+  background: color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.node-icon-dialog__row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 6px;
+}
+
+.node-icon-dialog__input {
+  flex: 1;
+  min-width: 0;
+}
+
+.node-icon-dialog__error {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--danger);
+}

--- a/src/shared/node-icon.test.ts
+++ b/src/shared/node-icon.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   iconFileName,
+  localIconCwd,
   nodeIconMime,
   normalizeNodeIcon,
   portableIconPath,
@@ -263,5 +264,31 @@ describe('iconFileName', () => {
   it('is what lets nodeIconMime read a Windows path', () => {
     expect(nodeIconMime('C:\\Users\\me\\logo.PNG')).toBe('image/png')
     expect(nodeIconMime('C:\\dir.with.dots\\README')).toBeUndefined()
+  })
+})
+
+// The read side and the write side must agree about which cwd a `./` icon may resolve against.
+// They disagreed: the picker excluded an SSH project, `useNodeIconSrc` did not — so a `./` icon
+// authored by someone with the repo checked out locally resolved, on the SSH client, to the same
+// relative path under a REMOTE root and was then read through the LOCAL fs.
+describe('localIconCwd', () => {
+  it('gives a local project its own cwd', () => {
+    expect(localIconCwd({ cwd: '/repo' })).toBe('/repo')
+  })
+
+  it('refuses an SSH project’s cwd — that path is on the host, the read is not', () => {
+    expect(localIconCwd({ cwd: '/srv/repo', ssh: { server: {}, remoteCwd: '/srv/repo' } })).toBeUndefined()
+    // ...which makes a `./` icon simply not draw, rather than read an unrelated local file.
+    expect(
+      resolveIconPath('./images/a.png', localIconCwd({ cwd: '/srv/repo', ssh: {} }))
+    ).toBeUndefined()
+    // An absolute path is unaffected — and absolute is what the write side stores for SSH.
+    expect(resolveIconPath('/appdata/canvas-images/a.png', localIconCwd({ cwd: '/srv/repo', ssh: {} })))
+      .toBe('/appdata/canvas-images/a.png')
+  })
+
+  it('answers undefined for a cwd-less or unknown project rather than guessing', () => {
+    expect(localIconCwd({})).toBeUndefined()
+    expect(localIconCwd(undefined)).toBeUndefined()
   })
 })

--- a/src/shared/node-icon.test.ts
+++ b/src/shared/node-icon.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  iconFileName,
   nodeIconMime,
   normalizeNodeIcon,
   portableIconPath,
@@ -173,5 +174,94 @@ describe('portable round trip', () => {
       expect(icon).toBeDefined()
       expect(resolveIconPath((icon as { path: string }).path, cwd)).toBe(abs)
     }
+  })
+})
+
+// The path seams, on a machine that is not the one that wrote the value. `.nodeterm/project.json`
+// is git-shared, so a Windows teammate's icon reaches a mac's serializer and back; and a hostile
+// value written for Windows is CHECKED here, wherever "here" happens to be. Both directions are
+// pinned, because getting either wrong is silent: one deletes a colleague's icons, the other
+// leaves the project root escapable.
+describe('path dialects', () => {
+  it('keeps a Windows drive-absolute path, so a mac save does not strip a colleague’s icon', () => {
+    for (const path of ['C:\\Users\\me\\proj\\.nodeterm\\images\\a.png', 'D:/work/b.jpg']) {
+      expect(normalizeNodeIcon({ type: 'image', path })).toEqual({ type: 'image', path })
+    }
+  })
+
+  it('refuses a UNC path — reading one reaches another machine over the network', () => {
+    for (const path of ['\\\\host\\share\\a.png', '//host/share/a.png']) {
+      expect(normalizeNodeIcon({ type: 'image', path })).toBeUndefined()
+    }
+  })
+
+  it('refuses a drive-RELATIVE path, which has no root of its own to resolve against', () => {
+    expect(normalizeNodeIcon({ type: 'image', path: 'C:a.png' })).toBeUndefined()
+  })
+
+  // The one that was broken: `\` was not a separator here, so this was a single segment that was
+  // neither '', '.' nor '..' — it passed on every platform and escaped the project on Windows.
+  it('refuses a relative path that traverses out via BACKSLASH separators', () => {
+    for (const path of [
+      './a\\..\\..\\secret.png',
+      '.\\..\\..\\secret.png',
+      './sub\\..\\..\\..\\etc\\passwd.png'
+    ]) {
+      expect(normalizeNodeIcon({ type: 'image', path })).toBeUndefined()
+    }
+  })
+
+  it('refuses a relative segment carrying a drive qualifier or an NTFS data stream', () => {
+    expect(normalizeNodeIcon({ type: 'image', path: './C:/Windows/a.png' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'image', path: './icon.png:payload.png' })).toBeUndefined()
+  })
+
+  it('canonicalizes a relative path to one stored dialect, so its next reader is not guessing', () => {
+    expect(normalizeNodeIcon({ type: 'image', path: '.\\images\\a.png' })).toEqual({
+      type: 'image',
+      path: './images/a.png'
+    })
+  })
+
+  it('relativizes under a Windows project root, and stores it POSIX-separated', () => {
+    expect(portableIconPath('C:\\proj\\.nodeterm\\images\\a.png', 'C:\\proj')).toBe(
+      './.nodeterm/images/a.png'
+    )
+    // A trailing separator on the root is not a reason to give up on portability.
+    expect(portableIconPath('C:\\proj\\images\\a.png', 'C:\\proj\\')).toBe('./images/a.png')
+  })
+
+  it('leaves a Windows path outside the project absolute', () => {
+    expect(portableIconPath('C:\\other\\a.png', 'C:\\proj')).toBe('C:\\other\\a.png')
+  })
+
+  it('resolves a ./ path against a Windows root', () => {
+    expect(resolveIconPath('./images/a.png', 'C:\\proj')).toBe('C:\\proj/images/a.png')
+  })
+
+  it('survives store -> normalize -> resolve on Windows', () => {
+    const abs = 'C:\\proj\\.nodeterm\\images\\a.png'
+    const cwd = 'C:\\proj'
+    const stored = portableIconPath(abs, cwd)
+    const icon = normalizeNodeIcon({ type: 'image', path: stored })
+    expect(icon).toBeDefined()
+    // Same FILE as `abs`; Node accepts forward slashes on Windows, so the spelling differs and
+    // the target does not.
+    expect(resolveIconPath((icon as { path: string }).path, cwd)).toBe(
+      'C:\\proj/.nodeterm/images/a.png'
+    )
+  })
+})
+
+describe('iconFileName', () => {
+  it('answers the last segment in either dialect', () => {
+    expect(iconFileName('/a/b/c.png')).toBe('c.png')
+    expect(iconFileName('C:\\Users\\me\\logo.png')).toBe('logo.png')
+    expect(iconFileName('logo.png')).toBe('logo.png')
+  })
+
+  it('is what lets nodeIconMime read a Windows path', () => {
+    expect(nodeIconMime('C:\\Users\\me\\logo.PNG')).toBe('image/png')
+    expect(nodeIconMime('C:\\dir.with.dots\\README')).toBeUndefined()
   })
 })

--- a/src/shared/node-icon.test.ts
+++ b/src/shared/node-icon.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+import {
+  nodeIconMime,
+  normalizeNodeIcon,
+  portableIconPath,
+  resolveIconPath
+} from './node-icon'
+
+// The value under test arrives from `.nodeterm/project.json` — git-shared, hand-editable, and on
+// an SSH project a file on someone else's host. Every case below is a thing that file can say.
+describe('normalizeNodeIcon', () => {
+  it('keeps a single emoji', () => {
+    expect(normalizeNodeIcon({ type: 'emoji', value: 'rocket'.length ? '\u{1F680}' : '' })).toEqual({
+      type: 'emoji',
+      value: '\u{1F680}'
+    })
+  })
+
+  it('keeps a ZWJ sequence whole', () => {
+    // 11 UTF-16 units. A naive length cap would reject it; a naive slice would cut it into a
+    // fragment that renders as two lone people. Neither is acceptable.
+    const family = '\u{1F468}‍\u{1F469}‍\u{1F467}‍\u{1F466}'
+    expect(normalizeNodeIcon({ type: 'emoji', value: family })).toEqual({
+      type: 'emoji',
+      value: family
+    })
+  })
+
+  it('truncates a multi-character value to its first grapheme', () => {
+    expect(normalizeNodeIcon({ type: 'emoji', value: 'abc' })).toEqual({ type: 'emoji', value: 'a' })
+  })
+
+  it('caps a blob from a shared file instead of rendering it into every surface', () => {
+    const blob = '\u{1F680}'.repeat(5000)
+    const out = normalizeNodeIcon({ type: 'emoji', value: blob })
+    expect(out).toEqual({ type: 'emoji', value: '\u{1F680}' })
+  })
+
+  it('strips control characters rather than letting a paste carry them into a header', () => {
+    const withNewline = `${String.fromCharCode(10)}${String.fromCharCode(7)}\u{1F41B}`
+    expect(normalizeNodeIcon({ type: 'emoji', value: withNewline })).toEqual({
+      type: 'emoji',
+      value: '\u{1F41B}'
+    })
+  })
+
+  it('refuses an emoji that is only whitespace or control characters', () => {
+    expect(normalizeNodeIcon({ type: 'emoji', value: '   ' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'emoji', value: String.fromCharCode(9) })).toBeUndefined()
+  })
+
+  it('refuses shapes that are not an icon at all', () => {
+    expect(normalizeNodeIcon(undefined)).toBeUndefined()
+    expect(normalizeNodeIcon(null)).toBeUndefined()
+    expect(normalizeNodeIcon('\u{1F680}')).toBeUndefined()
+    expect(normalizeNodeIcon(42)).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'svg', markup: '<script/>' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'emoji', value: 7 })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'image', path: 7 })).toBeUndefined()
+  })
+
+  it('keeps an absolute image path with a known extension', () => {
+    expect(normalizeNodeIcon({ type: 'image', path: '/tmp/a/logo.PNG' })).toEqual({
+      type: 'image',
+      path: '/tmp/a/logo.PNG'
+    })
+  })
+
+  it('keeps a project-relative image path', () => {
+    expect(normalizeNodeIcon({ type: 'image', path: './.nodeterm/images/logo.png' })).toEqual({
+      type: 'image',
+      path: './.nodeterm/images/logo.png'
+    })
+  })
+
+  // The gate that stops a cloned project.json from aiming fs.readBinary at a private key.
+  it('refuses a path that is not an image', () => {
+    expect(normalizeNodeIcon({ type: 'image', path: '/home/u/.ssh/id_rsa' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'image', path: '/etc/passwd' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'image', path: '/home/u/README' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'image', path: '/home/u/notes.png.txt' })).toBeUndefined()
+  })
+
+  it('refuses a relative path that traverses out of the project', () => {
+    expect(normalizeNodeIcon({ type: 'image', path: './../../.ssh/id_rsa.png' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'image', path: './a/../../b.png' })).toBeUndefined()
+  })
+
+  it('refuses a rootless path, which has nothing to resolve against', () => {
+    expect(normalizeNodeIcon({ type: 'image', path: 'logo.png' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'image', path: '../logo.png' })).toBeUndefined()
+    expect(normalizeNodeIcon({ type: 'image', path: '' })).toBeUndefined()
+  })
+
+  it('refuses a path carrying control characters', () => {
+    const sneaky = `/tmp/a${String.fromCharCode(0)}.png`
+    expect(normalizeNodeIcon({ type: 'image', path: sneaky })).toBeUndefined()
+  })
+})
+
+describe('nodeIconMime', () => {
+  it('maps known extensions case-insensitively', () => {
+    expect(nodeIconMime('/a/b.PNG')).toBe('image/png')
+    expect(nodeIconMime('/a/b.jpeg')).toBe('image/jpeg')
+    expect(nodeIconMime('./x.svg')).toBe('image/svg+xml')
+  })
+
+  it('answers undefined for a name with no extension', () => {
+    expect(nodeIconMime('/a/README')).toBeUndefined()
+    expect(nodeIconMime('/a/.gitignore')).toBeUndefined()
+    expect(nodeIconMime('/a/b.key')).toBeUndefined()
+  })
+})
+
+describe('portableIconPath', () => {
+  it('rewrites a path inside the project to ./ form so it travels with the repo', () => {
+    expect(portableIconPath('/repo/.nodeterm/images/a.png', '/repo')).toBe(
+      './.nodeterm/images/a.png'
+    )
+    // A trailing slash on the cwd must not produce a doubled separator or a missed match.
+    expect(portableIconPath('/repo/.nodeterm/images/a.png', '/repo/')).toBe(
+      './.nodeterm/images/a.png'
+    )
+  })
+
+  it('leaves a path outside the project absolute', () => {
+    expect(portableIconPath('/elsewhere/a.png', '/repo')).toBe('/elsewhere/a.png')
+    // A sibling directory that merely shares a prefix is NOT inside the project.
+    expect(portableIconPath('/repo-two/a.png', '/repo')).toBe('/repo-two/a.png')
+  })
+
+  it('leaves everything absolute when the project has no local cwd', () => {
+    expect(portableIconPath('/appdata/canvas-images/a.png', undefined)).toBe(
+      '/appdata/canvas-images/a.png'
+    )
+  })
+})
+
+describe('resolveIconPath', () => {
+  it('resolves a ./ path against the project cwd', () => {
+    expect(resolveIconPath('./.nodeterm/images/a.png', '/repo')).toBe('/repo/.nodeterm/images/a.png')
+    expect(resolveIconPath('./.nodeterm/images/a.png', '/repo/')).toBe(
+      '/repo/.nodeterm/images/a.png'
+    )
+  })
+
+  it('passes an absolute path through', () => {
+    expect(resolveIconPath('/appdata/a.png', '/repo')).toBe('/appdata/a.png')
+    expect(resolveIconPath('/appdata/a.png', undefined)).toBe('/appdata/a.png')
+  })
+
+  // The icon simply does not draw. It must never fall back to reading something else.
+  it('answers undefined for a ./ path on a project with no local cwd', () => {
+    expect(resolveIconPath('./.nodeterm/images/a.png', undefined)).toBeUndefined()
+  })
+
+  it('answers undefined for a traversing or rootless path', () => {
+    expect(resolveIconPath('./../secrets/a.png', '/repo')).toBeUndefined()
+    expect(resolveIconPath('a.png', '/repo')).toBeUndefined()
+  })
+})
+
+// Round-tripping is the property the portability story actually rests on: what we store must be
+// what we can read back, for both a project-local and an app-local icon.
+describe('portable round trip', () => {
+  it('survives store -> normalize -> resolve', () => {
+    for (const [abs, cwd] of [
+      ['/repo/.nodeterm/images/a.png', '/repo'],
+      ['/appdata/canvas-images/b.png', undefined]
+    ] as const) {
+      const stored = portableIconPath(abs, cwd)
+      const icon = normalizeNodeIcon({ type: 'image', path: stored })
+      expect(icon).toBeDefined()
+      expect(resolveIconPath((icon as { path: string }).path, cwd)).toBe(abs)
+    }
+  })
+})

--- a/src/shared/node-icon.ts
+++ b/src/shared/node-icon.ts
@@ -271,3 +271,26 @@ export function resolveIconPath(storedPath: string, projectCwd?: string): string
   // two entries for one file.
   return `${root}/${rel.replace(/\\/g, '/')}`
 }
+
+/**
+ * The cwd a `./` icon path may be resolved against, given a project — or undefined when there
+ * isn't one it can honestly use.
+ *
+ * This exists because the rule was written TWICE and the two copies drifted, which is the failure
+ * this repo warns about elsewhere. The picker's write side already said
+ * `project.ssh ? undefined : project.cwd`; the read side said only `project.cwd`. For an SSH
+ * project those are different facts: `cwd` is a path on the REMOTE host, while the icon is read
+ * through the LOCAL `api.fs` (an SSH project runs on the local session — only a RELAY tab's api
+ * belongs to another machine). So a `./` icon written by someone who has that repo checked out
+ * locally resolved, on the SSH client, to the same relative path under a remote root — and asked
+ * this machine to read it. That is a local file that has nothing to do with the icon, and it is
+ * shown if it happens to exist.
+ *
+ * Answering undefined means the icon does not draw, which is the honest outcome: that file is on
+ * a machine whose filesystem this reader cannot see. Absolute paths are unaffected, and absolute
+ * is exactly what the write side stores for an SSH project.
+ */
+export function localIconCwd(project: { cwd?: string; ssh?: unknown } | undefined): string | undefined {
+  if (!project || project.ssh) return undefined
+  return project.cwd
+}

--- a/src/shared/node-icon.ts
+++ b/src/shared/node-icon.ts
@@ -24,7 +24,25 @@
  *
  *  3. **A relative path may not traverse.** `./` paths are resolved against the project cwd (see
  *     below), so a `./..`-prefixed one would walk straight out of the project. Same rule, and the
- *     same reasoning, as `isSafeQuickOpenRelPath` on the remote quick-open index.
+ *     same reasoning, as `isSafeQuickOpenRelPath` on the remote quick-open index. **Both `/` and
+ *     `\\` count as separators when that rule is applied, on every platform** — see
+ *     `isSafeRelIconPath`.
+ *
+ * **Two dialects in, one dialect out.** The value is written by one machine and read by another,
+ * so validation ACCEPTS a Windows path (`C:\\...`) and a POSIX one (`/...`) regardless of where
+ * the check runs, while everything this module STORES is POSIX-separated. Both halves are
+ * load-bearing:
+ *
+ *  • Accepting both everywhere is what stops a mac's `flowToNodeStates` from silently deleting a
+ *    Windows teammate's icons: refuse `C:\\...` on mac and a mac user merely opening the shared
+ *    canvas and saving it strips them from `project.json`. A Windows absolute path on a mac does
+ *    not RESOLVE, of course — it just does not draw, exactly as a POSIX absolute path from someone
+ *    else's machine already does not. That is a degrade, and a degrade is not a reason to destroy
+ *    the value on the way past.
+ *  • Storing one dialect is what makes the `./` form portable at all. A stored `.\\a\\b.png` would
+ *    mean "a file called `a\\b.png`" on POSIX and "`b.png` inside `a`" on Windows. So
+ *    `normalizeNodeIcon` canonicalizes a relative path to `./` with forward slashes, the same way
+ *    it canonicalizes an emoji to its first grapheme.
  *
  * **Portability.** An icon image lives beside the canvas that names it, in the project's own
  * git-shared `.nodeterm/images/` (see core/canvas-images.ts). A path stored absolutely would
@@ -80,9 +98,52 @@ interface GraphemeSegmenter {
   segment(input: string): Iterable<{ segment: string }>
 }
 
+/**
+ * A path separator. BOTH are separators everywhere, never "`\` only on Windows": the value is
+ * written by one machine and validated on another, so a check that reads `\` as an ordinary
+ * filename character on the validating machine is simply wrong about the machine that will read
+ * it. Applying the strict rule on every platform costs a POSIX user only the ability to name an
+ * icon file with a literal backslash in it.
+ */
+const SEP_RE = /[\\/]/
+
+/** `./` or `.\` — the marker for a path stored relative to the project root. */
+const REL_PREFIX_RE = /^\.[\\/]/
+
+/**
+ * A drive-qualified absolute path: `C:\...` or `C:/...`. The separator is REQUIRED, because
+ * `C:x.png` is drive-RELATIVE — it resolves against whatever directory that drive happens to be
+ * sitting on in the reading process, which is precisely the guess this module refuses to make.
+ */
+const DRIVE_ABS_RE = /^[A-Za-z]:[\\/]/
+
+/**
+ * A UNC path: `\\host\share\...` or `//host/share/...`. Refused, matching the decision already
+ * made for terminal file links (`renderer/terminal/file-links.ts`, which consumes UNC
+ * specifically so it can refuse it). Reading one reaches ANOTHER MACHINE over SMB, which is a
+ * long way outside "an icon beside the canvas" and is exactly the reach the extension gate exists
+ * to keep narrow. Note this also refuses a POSIX `//foo/bar`, where a leading `//` is
+ * implementation-defined anyway — no real icon path is lost.
+ */
+const UNC_RE = /^(?:\\\\|\/\/)/
+
+/** Absolute in EITHER dialect, and not a network path. The one predicate all three exported
+ *  functions ask, so they cannot disagree about what "absolute" means. */
+function isAbsoluteIconPath(path: string): boolean {
+  if (UNC_RE.test(path)) return false
+  return path.startsWith('/') || DRIVE_ABS_RE.test(path)
+}
+
+/** The final segment of a path in either dialect — `C:\a\b.png` and `/a/b.png` both give
+ *  `b.png`. Exported because the picker needs the same answer when it names the copied file. */
+export function iconFileName(path: string): string {
+  const segments = path.split(SEP_RE)
+  return segments[segments.length - 1] ?? ''
+}
+
 /** The MIME type for an icon image path, or undefined when the extension is not an image one. */
 export function nodeIconMime(path: string): string | undefined {
-  const name = path.split('/').pop() ?? ''
+  const name = iconFileName(path)
   // A name with no dot has no extension: `.split('.').pop()` would return the whole name, so
   // `README` would resolve as an extension and only miss by luck.
   if (!name.includes('.')) return undefined
@@ -110,9 +171,24 @@ function firstGrapheme(raw: string): string {
   return clean.slice(0, EMOJI_MAX_UNITS)
 }
 
-/** True when a `./`-relative icon path stays inside the project root. */
+/**
+ * True when a `./`-relative icon path stays inside the project root.
+ *
+ * Splitting on BOTH separators is the whole point, and it is not a Windows nicety. Splitting on
+ * `/` alone, `./a\..\..\secret.png` is ONE segment — not `''`, not `.`, not `..` — so it passed
+ * this guard on every platform and then walked two directories out of the project the moment a
+ * Windows reader resolved it. One machine writes this value and another reads it, so the rule has
+ * to hold where it is CHECKED, not only where it happens to be dangerous.
+ *
+ * A segment may also not contain `:`. On Windows that is either a drive qualifier (`./C:/Windows`)
+ * or an NTFS alternate data stream (`./icon.png:payload`), and a project-relative icon path has no
+ * business expressing either.
+ */
 function isSafeRelIconPath(rel: string): boolean {
-  return rel.split('/').every((seg) => seg !== '' && seg !== '..' && seg !== '.')
+  const segments = rel.split(SEP_RE)
+  return segments.every(
+    (seg) => seg !== '' && seg !== '.' && seg !== '..' && !seg.includes(':')
+  )
 }
 
 /**
@@ -132,13 +208,19 @@ export function normalizeNodeIcon(raw: unknown): NodeIcon | undefined {
     if (typeof v.path !== 'string') return undefined
     const path = v.path.trim()
     if (!path || hasControl(path) || !nodeIconMime(path)) return undefined
-    if (path.startsWith('./')) {
-      return isSafeRelIconPath(path.slice(2)) ? { type: 'image', path } : undefined
+    if (REL_PREFIX_RE.test(path)) {
+      const rel = path.slice(2)
+      if (!isSafeRelIconPath(rel)) return undefined
+      // Canonicalize to the one stored dialect. A hand-edited `.\a\b.png` means two different
+      // files on the two platforms; rewriting it here (the same way an emoji is rewritten to its
+      // first grapheme) is what keeps the shared file unambiguous for its next reader.
+      return { type: 'image', path: `./${rel.replace(/\\/g, '/')}` }
     }
-    // Anything else must be an absolute POSIX path: a bare `foo.png` has no root to resolve
+    // Anything else must be absolute, in either dialect: a bare `foo.png` has no root to resolve
     // against, and resolving it against the cwd of whatever process happens to be running is
-    // precisely the kind of guess this module refuses to make.
-    return path.startsWith('/') ? { type: 'image', path } : undefined
+    // precisely the kind of guess this module refuses to make. An absolute path is kept BYTE FOR
+    // BYTE — it belongs to one machine's filesystem and is not ours to rewrite.
+    return isAbsoluteIconPath(path) ? { type: 'image', path } : undefined
   }
   return undefined
 }
@@ -150,9 +232,22 @@ export function normalizeNodeIcon(raw: unknown): NodeIcon | undefined {
  */
 export function portableIconPath(absPath: string, projectCwd?: string): string {
   if (!projectCwd) return absPath
-  const root = projectCwd.replace(/\/+$/, '')
-  if (!root || !absPath.startsWith(`${root}/`)) return absPath
-  const rel = absPath.slice(root.length + 1)
+  const root = projectCwd.replace(/[\\/]+$/, '')
+  if (!root) return absPath
+  // The prefix test is separator-INSENSITIVE: `saveCanvasImage` builds its answer with the host's
+  // own `path.join`, so on Windows it comes back `C:\proj\.nodeterm\images\x.png` while
+  // `project.cwd` may carry either separator. Comparing raw strings there simply never matched,
+  // and the icon silently stayed absolute — travelling nowhere, with nothing said about it.
+  //
+  // The comparison stays CASE-sensitive even though Windows filesystems usually are not: both
+  // sides come from the same `project.cwd` in practice, so they match exactly, and a
+  // case-insensitive test would wrongly relativize on a case-sensitive filesystem. Not matching
+  // costs only portability; matching wrongly costs correctness.
+  const toPosix = (p: string): string => p.replace(/\\/g, '/')
+  const posixRoot = toPosix(root)
+  const posixAbs = toPosix(absPath)
+  if (!posixAbs.startsWith(`${posixRoot}/`)) return absPath
+  const rel = posixAbs.slice(posixRoot.length + 1)
   return rel && isSafeRelIconPath(rel) ? `./${rel}` : absPath
 }
 
@@ -162,9 +257,17 @@ export function portableIconPath(absPath: string, projectCwd?: string): string {
  * means the icon does not draw; it must never mean "read something else".
  */
 export function resolveIconPath(storedPath: string, projectCwd?: string): string | undefined {
-  if (!storedPath.startsWith('./')) return storedPath.startsWith('/') ? storedPath : undefined
+  // Re-asked rather than assumed: this is exported, and the next caller may not have come through
+  // `normalizeNodeIcon` (the same reasoning `loadNodeIconSrc` gives for re-checking the MIME).
+  if (!REL_PREFIX_RE.test(storedPath)) {
+    return isAbsoluteIconPath(storedPath) ? storedPath : undefined
+  }
   const rel = storedPath.slice(2)
   if (!isSafeRelIconPath(rel)) return undefined
-  const root = projectCwd?.replace(/\/+$/, '')
-  return root ? `${root}/${rel}` : undefined
+  const root = projectCwd?.replace(/[\\/]+$/, '')
+  if (!root) return undefined
+  // Joined with `/` even when `root` is a Windows path: Node's fs accepts forward slashes on
+  // Windows, and one deterministic spelling keeps `nodeIconImage`'s per-path cache from holding
+  // two entries for one file.
+  return `${root}/${rel.replace(/\\/g, '/')}`
 }

--- a/src/shared/node-icon.ts
+++ b/src/shared/node-icon.ts
@@ -1,0 +1,170 @@
+/**
+ * A canvas node's user-chosen icon: one emoji/character, or a small image file.
+ *
+ * The value is persisted in `.nodeterm/project.json`, which is git-shared, hand-editable and —
+ * for an SSH project — a file on the remote host. So nothing here trusts its input: every value
+ * that reaches a render or a filesystem read goes through `normalizeNodeIcon` FIRST, at the point
+ * of use, exactly as `permissionModeFlag` re-validates a permission mode and `safeSessionProgram`
+ * re-validates a session program. The TypeScript type is a compile-time claim about our own
+ * writers; it says nothing about a file someone cloned.
+ *
+ * Three rules, and each one is the answer to a specific way this could go wrong:
+ *
+ *  1. **An emoji is ONE grapheme.** Without a cap, `"icon": {"type":"emoji","value":"<40kB>"}`
+ *     in a shared project file is a blob rendered into every node header, every kanban card and
+ *     every sidebar row. Truncating is safe (the user sees a shorter icon than they typed);
+ *     refusing outright would drop a perfectly good four-person ZWJ family emoji, which is 11
+ *     UTF-16 units and would fail any naive length check.
+ *
+ *  2. **An image path must LOOK like an image.** The extension gate is what stops a hostile
+ *     project.json from aiming `fs.readBinary` at `~/.ssh/id_rsa`. It is not a complete jail —
+ *     the file can still name any *.png on the machine, exactly as an editor node's `filePath`
+ *     always could — but the bytes only ever become an `<img>` in a renderer with a `'self'` CSP
+ *     and no network, so the reachable outcome is "an icon fails to draw", not exfiltration.
+ *
+ *  3. **A relative path may not traverse.** `./` paths are resolved against the project cwd (see
+ *     below), so a `./..`-prefixed one would walk straight out of the project. Same rule, and the
+ *     same reasoning, as `isSafeQuickOpenRelPath` on the remote quick-open index.
+ *
+ * **Portability.** An icon image lives beside the canvas that names it, in the project's own
+ * git-shared `.nodeterm/images/` (see core/canvas-images.ts). A path stored absolutely would
+ * therefore travel to a teammate as a path only the author's machine has — the file arrives, the
+ * icon does not. So a path under the project cwd is stored `./`-relative and resolved on read,
+ * which is the convention `toPortableNodes` already established for node cwds. Everything else
+ * (a cwd-less canvas, an SSH project, the app-local fallback `saveCanvasImage` takes when the
+ * project folder will not accept the write) stays absolute and simply does not travel — the same
+ * degrade canvas image nodes take, and not an error.
+ */
+
+/** Extensions an icon image may have, mapped to the MIME type its data URL is built with. */
+export const NODE_ICON_MIME: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  svg: 'image/svg+xml',
+  avif: 'image/avif'
+}
+
+/** A node's icon: one emoji/character, or an image file beside the project. */
+export type NodeIcon =
+  | { type: 'emoji'; value: string }
+  | { type: 'image'; path: string }
+
+/**
+ * Hard ceiling on an emoji's UTF-16 length, applied when `Intl.Segmenter` is unavailable so the
+ * grapheme walk below cannot be the only thing standing between a shared file and a blob. Sized
+ * to fit the longest emoji anyone actually types: a four-person ZWJ family is 11 units, a flag
+ * sequence with modifiers a little more.
+ */
+const EMOJI_MAX_UNITS = 24
+
+/**
+ * Control characters (C0 + DEL) are matched by code point rather than by a regex character class,
+ * so this file stays pure ASCII and no tool between here and the repo can mangle the range.
+ */
+const isControlCodePoint = (cp: number): boolean => cp < 0x20 || cp === 0x7f
+
+const stripControl = (s: string): string =>
+  Array.from(s)
+    .filter((ch) => !isControlCodePoint(ch.codePointAt(0) ?? 0))
+    .join('')
+
+const hasControl = (s: string): boolean =>
+  Array.from(s).some((ch) => isControlCodePoint(ch.codePointAt(0) ?? 0))
+
+interface GraphemeSegmenter {
+  segment(input: string): Iterable<{ segment: string }>
+}
+
+/** The MIME type for an icon image path, or undefined when the extension is not an image one. */
+export function nodeIconMime(path: string): string | undefined {
+  const name = path.split('/').pop() ?? ''
+  // A name with no dot has no extension: `.split('.').pop()` would return the whole name, so
+  // `README` would resolve as an extension and only miss by luck.
+  if (!name.includes('.')) return undefined
+  return NODE_ICON_MIME[name.split('.').pop()!.toLowerCase()]
+}
+
+/**
+ * The first grapheme cluster of `raw`, with control characters (including the newlines a paste
+ * can carry) removed first. `Intl.Segmenter` is the correct tool and is present in both shells'
+ * runtimes; the length cap is the fallback for a runtime without it, never the primary rule —
+ * slicing UTF-16 units would cut a ZWJ sequence in half and render a fragment.
+ */
+function firstGrapheme(raw: string): string {
+  const clean = stripControl(raw).trim()
+  if (!clean) return ''
+  const ctor = (
+    Intl as unknown as {
+      Segmenter?: new (locale?: string, options?: { granularity: string }) => GraphemeSegmenter
+    }
+  ).Segmenter
+  if (ctor) {
+    for (const s of new ctor(undefined, { granularity: 'grapheme' }).segment(clean)) return s.segment
+    return ''
+  }
+  return clean.slice(0, EMOJI_MAX_UNITS)
+}
+
+/** True when a `./`-relative icon path stays inside the project root. */
+function isSafeRelIconPath(rel: string): boolean {
+  return rel.split('/').every((seg) => seg !== '' && seg !== '..' && seg !== '.')
+}
+
+/**
+ * Validate an icon value read from a persisted (hostile) source. Returns the value to use, or
+ * **undefined** — which renders as no icon at all, i.e. the pre-feature node. Never throws, and
+ * never substitutes a nearest match: an unrecognized icon is no icon.
+ */
+export function normalizeNodeIcon(raw: unknown): NodeIcon | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const v = raw as { type?: unknown; value?: unknown; path?: unknown }
+  if (v.type === 'emoji') {
+    if (typeof v.value !== 'string') return undefined
+    const value = firstGrapheme(v.value)
+    return value ? { type: 'emoji', value } : undefined
+  }
+  if (v.type === 'image') {
+    if (typeof v.path !== 'string') return undefined
+    const path = v.path.trim()
+    if (!path || hasControl(path) || !nodeIconMime(path)) return undefined
+    if (path.startsWith('./')) {
+      return isSafeRelIconPath(path.slice(2)) ? { type: 'image', path } : undefined
+    }
+    // Anything else must be an absolute POSIX path: a bare `foo.png` has no root to resolve
+    // against, and resolving it against the cwd of whatever process happens to be running is
+    // precisely the kind of guess this module refuses to make.
+    return path.startsWith('/') ? { type: 'image', path } : undefined
+  }
+  return undefined
+}
+
+/**
+ * How an absolute image path is STORED on a node: `./`-relative when it sits inside the project's
+ * own folder (so it travels with the repo), absolute otherwise. `projectCwd` is undefined for a
+ * cwd-less canvas and for an SSH project, where the image is written app-locally.
+ */
+export function portableIconPath(absPath: string, projectCwd?: string): string {
+  if (!projectCwd) return absPath
+  const root = projectCwd.replace(/\/+$/, '')
+  if (!root || !absPath.startsWith(`${root}/`)) return absPath
+  const rel = absPath.slice(root.length + 1)
+  return rel && isSafeRelIconPath(rel) ? `./${rel}` : absPath
+}
+
+/**
+ * The absolute path to read an icon image from, or undefined when it cannot be resolved — a
+ * `./` path on a project that has no local cwd (it was written by a machine that did). Undefined
+ * means the icon does not draw; it must never mean "read something else".
+ */
+export function resolveIconPath(storedPath: string, projectCwd?: string): string | undefined {
+  if (!storedPath.startsWith('./')) return storedPath.startsWith('/') ? storedPath : undefined
+  const rel = storedPath.slice(2)
+  if (!isSafeRelIconPath(rel)) return undefined
+  const root = projectCwd?.replace(/\/+$/, '')
+  return root ? `${root}/${rel}` : undefined
+}

--- a/src/shared/source-hygiene.test.ts
+++ b/src/shared/source-hygiene.test.ts
@@ -1,0 +1,41 @@
+/**
+ * A tracked source file must not contain a raw NUL byte.
+ *
+ * Git classifies a file containing a NUL as BINARY. It then renders as "Binary files differ" in
+ * every diff surface — the PR page, `git diff`, `git log -p`, a review UI — and `git grep` skips
+ * it entirely. The file still compiles and its tests still pass, so nothing fails; it simply
+ * becomes invisible to review.
+ *
+ * That is how it actually happened here: `renderer/lib/nodeIconImage.ts` wrote its cache-key
+ * separator as a literal NUL (`` `${projectId}<NUL>${absPath}` ``) rather than the escape
+ * `\x00`. Identical at runtime — and by bad luck it hid the one new file performing `readBinary`
+ * reads driven by persisted data, i.e. the file a reviewer most needed to see.
+ *
+ * A separator, a delimiter or a sentinel is a perfectly good reason to WANT a NUL; write it as an
+ * escape and the file stays text. There is no legitimate reason for the raw byte to sit in source.
+ */
+import { execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = join(__dirname, '..', '..')
+
+/** Tracked `.ts` / `.tsx` under `src/`. Asking git (not the filesystem) keeps build output,
+ *  `node_modules` and anything gitignored out without a hand-maintained ignore list. */
+function trackedSources(): string[] {
+  return execFileSync('git', ['ls-files', '--', 'src'], { cwd: repoRoot, encoding: 'utf8' })
+    .split('\n')
+    .filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'))
+}
+
+describe('source hygiene', () => {
+  it('has no tracked TypeScript source that git would classify as binary', () => {
+    const files = trackedSources()
+    // A guard that silently scanned nothing would pass forever. Pin that we actually looked.
+    expect(files.length).toBeGreaterThan(100)
+
+    const offenders = files.filter((f) => readFileSync(join(repoRoot, f)).includes(0x00))
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -327,6 +327,13 @@ export interface CanvasNodeState {
   collapsed?: boolean
   /** Agent nodes only: when true, this node's subagent/loop fan-out cards are hidden. */
   hideFanout?: boolean
+  /**
+   * A user-chosen icon shown wherever this node is listed (canvas header, kanban card, sessions
+   * sidebar): one emoji/character, or an image file. Absent = the node draws exactly as it did
+   * before the feature. Validate with `normalizeNodeIcon` at the point of use — this value comes
+   * from a git-shared, hand-editable project file. See @shared/node-icon.
+   */
+  icon?: import('./node-icon').NodeIcon
   /** Parent group node id, if this node belongs to a group frame. */
   parentId?: string
   // terminal-only


### PR DESCRIPTION
## What

A session node can carry an icon — one emoji, or a picture from disk.

Twelve terminals on one canvas are currently told apart by a colour dot and a title. This adds a
stronger mark, drawn by a single `NodeIconView` on **all four surfaces that list a session** — the
canvas node header, the kanban card, the card modal, and the sessions sidebar row — so one session
can't read as four different things depending on where you're looking at it.

Set it from the node right-click menu ("Set icon…", hideable like Colors), by clicking the icon in
the node header, or from the card modal's header slot.

Terminal (session) nodes only. The menu row is gated on the kind on purpose: offering it on an
editor or a group frame would persist a value nothing draws — a row that looks like it worked.

## Why the two non-obvious decisions

**The value is validated at *both* serializer seams.** `.nodeterm/project.json` is git-shared,
hand-editable, and on an SSH project a file on someone else's host. So `normalizeNodeIcon` runs in
`nodeStatesToFlow` (a cloned file becoming live state) *and* in `flowToNodeStates` (live state
becoming the next reader's file — live node data is reachable by a peer canvas mutation, and what
we write is what the next machine trusts). Validating one side passes every round-trip test while
leaving the other open; both seams are mutation-pinned in `workspace.test.ts`.

Three rules the validator enforces, each answering a specific failure:

- **An emoji is ONE grapheme** (`Intl.Segmenter`; the UTF-16 cap is only a fallback, never the
  primary rule — slicing units cuts a ZWJ sequence into a fragment). Uncapped, a shared project
  file could put a 40 kB "emoji" into every header, card and sidebar row.
- **An image path must look like an image** (extension → MIME). That gate is what stops a
  hand-edited project file from aiming `fs.readBinary` at `~/.ssh/id_rsa`. It isn't a full jail —
  the path can still name any `*.png` on the machine, exactly as an editor node's `filePath`
  always could — but the bytes only ever become an `<img>` under a `'self'` CSP with no network,
  so the reachable outcome is "an icon fails to draw".
- **A `./` path may not traverse** — the same rule as `isSafeQuickOpenRelPath`.

**Picture bytes are copied, not referenced.** The picker writes through `files.saveCanvasImage` —
the seam canvas image nodes already use — so the file lands in the project's git-shared
`.nodeterm/images/`, and a path inside the project cwd is stored `./`-relative and resolved on
read. That's the convention `toPortableNodes` already set for node cwds, applied so the icon
travels with the canvas that names it. A cwd-less canvas, an SSH project and the app-local
fallback keep an absolute path and simply don't travel — a degrade, not an error. A relay tab is
refused outright with the same message as canvas image import, because the write is this machine's
preload while the read is the peer's core.

**Trade-off I'll name rather than hide:** canvas *image nodes* still store their `filePath`
absolutely, so today their file travels with the repo but the node naming it doesn't. This PR
doesn't fix that — it just doesn't repeat it. Happy to follow up if you want them aligned.

Image reads are cached per `(projectId, absPath)`: four surfaces mount independently, so a
thirty-card board would otherwise re-read the same bytes thirty times per open.

## Surfaces

- **Desktop** — full.
- **Server Edition** — full, and **no new IPC was added**. Every leg is already core
  (`fs.readBinary`, `files.saveCanvasImage`) or has a real browser implementation
  (`dialog.selectFile` → the web picker). Nothing is stubbed.
- **Mobile** — N/A for v1. The transport protocol carries no per-node icon concept; surfacing one
  means extending it. Flagging for @eneskirca rather than assuming.

## Testing

`npm run typecheck`, the full `vitest` suite, and a production build all pass.

I also **ran the app** (Electron under an isolated `--user-data-dir`, so no real workspace or tmux
server was touched): set an emoji, watched it reach the header, the sidebar row, the kanban card
and the card modal, and confirmed it landed in `project.json` on disk.

I mutation-tested every guard added here — the extension gate, the traversal check, the grapheme
cap, and both validation seams — and confirmed each one turns a test red when removed.

**Not verified:** the Server Edition and relay paths. Both are argued from the code (no new IPC;
reads go through the project's session api rather than `window.nodeTerminal`), not exercised on a
running server or a real peer.

Three `local-send-keys.realtmux` tests fail on my machine and fail identically on a clean `main` —
macOS's temp path exceeds the unix socket length limit. Unrelated to this change.
