### PR TITLE
feat(canvas): file-manager node — a directory listing on the canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,12 +161,12 @@ separate store mirroring node state — earlier dual-source designs caused sync 
 `src/renderer/state/workspace.ts` holds only pure helpers: the color palette, the node
 factories (`createTerminalNode`, `createSshTerminalNode`, `createAgentNode(agentId, …)`,
 `createAccountLoginNode`, `createStickyNode`, `createGroupNode`, `createEditorNode`,
-`createDiffNode`, `createVideoNode`, `createWebNode`, `createBrowserNode`, `createDinoNode`,
-`createTriggerNode`), the
+`createDiffNode`, `createVideoNode`, `createWebNode`, `createBrowserNode`, `createFilesNode`,
+`createDinoNode`, `createTriggerNode`), the
 group transforms (`groupSelectedNodes`, `ungroupNodes`, `duplicateNode`), and the
 `nodeStatesToFlow` / `flowToNodeStates` serializers. Node kinds (`NodeKind` in
 `src/shared/types.ts`): `terminal | sticky | group | editor | diff | video | web | browser |
-subagent | loop | dino | trigger` — `subagent` and `loop` are render-only (ephemeral hook-driven
+files | subagent | loop | dino | trigger` — `subagent` and `loop` are render-only (ephemeral hook-driven
 viz) and never persisted. `trigger` (issue #493, all four
 phases landed) is a first-class PERSISTED kind. The whole host-side
 machine is composed ONCE in `core/trigger-service.ts` (`startTriggerService`) and booted
@@ -850,6 +850,44 @@ session.
 - **browser** (`BrowserNode.tsx`) — a navigable Chromium browser wrapping the shared
   `BrowserSurface` (webview + toolbar); the last top-level URL persists to `data.url`, and the same
   surface backs the kanban card modal's browser popup.
+- **files** (`FilesNode.tsx`) — a file-manager node: ONE directory listing (`data.cwd`, persisted),
+  pinned to the canvas beside the terminals working in it. Deliberately not a second Explorer: the
+  drawer is a single tree rooted at the project cwd that covers the canvas, so it gives you one
+  cursor and a lot of scrolling; several of these give you `src/renderer/nodes` next to the agent
+  editing it and another on `docs/`. Navigate in place (breadcrumbs collapse deep paths but every
+  crumb stays clickable), filter, create a file/folder, copy a path, reveal, and open a terminal in
+  the folder shown (a `nodeterm:open-terminal` event, the sibling of `nodeterm:open-file`).
+  - **It adds NO new IPC.** Everything runs on the existing `FsApi` (`list`/`mkdir`/`exists`/
+    `write`) — which is why it works on Desktop, the Server Edition, an SSH project and a relay tab
+    on day one. **Rename/move/delete are the deliberate v1 gap**: each needs a new leaf in
+    `core/fs-ops`, an IPC channel, preload, the ws-bridge, `main/ssh-fs` (remote quoting) and the
+    relay host-service, plus confirm dialogs and dangerous-path guards. That is a separate change
+    with separate risk, not a corner to cut inside this one.
+  - **Which filesystem** is `EditorNode`'s decision, read the same way: `data.sshFs` → the SSH
+    project's host over the ControlMaster; otherwise the node's own SESSION api, which is the local
+    core for a local project and the PEER's for a relay tab. Reading it off `useSession()` rather
+    than `window.nodeTerminal` is the entire reason a relay tab browses the right machine.
+  - **Opening is delegated, never reimplemented**: a file dispatches `nodeterm:open-file`, so
+    editor-vs-video-vs-image routing stays in Canvas's one `openFile` and this node never grows a
+    second opinion about what a `.png` is. `fileOpenTarget` decides only canvas-vs-OS, and a
+    REMOTE listing never reaches the OS branch — `shell.openPath` opens a path on THIS machine, so
+    handing it a host path either does nothing or, if that path exists here too, opens an unrelated
+    local file.
+  - **Four empty states stay four** (loading / could not read / the folder is empty / the filter
+    matches nothing). Collapsing any pair into one blank pane is the failure this file warns about
+    elsewhere, and an empty filter matches everything so select-all+delete cannot blank the list.
+  - The title tracks the folder only while `titleAuto` is unset — the same contract an agent node's
+    session name uses, so navigating never overwrites a name the user typed.
+  - A files node inside a REMOVED worktree is displaced like an editor, not like a terminal
+    (`displacedByWorktree`): it has no session to disturb, so it is caught by path wherever it sits,
+    and it gets its `cwd` re-pointed rather than an editor's `fileMissing` — a directory can be
+    re-pointed, a dead file cannot. Left out, it would show "Could not read this folder" forever
+    AND keep the dead path in `project.json`.
+  - Creation is gated on the project having a directory (`hasCwd`) on every surface — pane menu,
+    Dock, sidebar "+", ⌘K, and the group-frame menu, where it inherits a bound **worktree's** cwd
+    via `cwdForNewNodeIn`, so a frame per branch also means a file tree per branch.
+  - **Mobile**: N/A — *nodeterm mobile* attaches to tmux sessions over the transport protocol and
+    has no canvas or file-browsing concept; adding one means extending that protocol.
 - **dino** (`DinoNode.tsx`) — a small self-contained T-Rex-style runner on a canvas (no PTY);
   high score persists via `data.highScore`.
 - **trigger** (`TriggerNode.tsx`) — a canvas-owned schedule (cron / interval / once) that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -891,7 +891,14 @@ session.
     disambiguated by probing the PARENT's listing instead (`classifyEmptyListing`, pure,
     `lib/filesNode.ts` — the idiom `SshProjectDialog.tsx:112-125` and `file-links.ts`'s
     `makeDirListingLookup` already use), which answers `missing` / `empty` / `unknown`: an unreadable
-    parent answers `unknown`, and we keep saying "empty" rather than claim a deletion we can't prove.
+    parent answers `unknown`, and we keep saying "empty" rather than claim a deletion we can't
+    prove. **`unknown` also covers every path whose parent CANNOT answer** — a non-`/`-absolute cwd
+    (an SSH project's `remoteCwd` defaults to **`~`**, where `parentDir` is `/` and `/` has no entry
+    named `~`, so an empty remote HOME reported a deletion), a `.git` cwd (both listing legs strip
+    it on purpose), and `.`/`..` segments; a case-folded match counts as present, for the
+    case-insensitive filesystems where `readdir` answers with the on-disk spelling. `missing` must
+    be the conclusion we are SURE of. Nothing is published until the verdict is in, so a deleted
+    folder never flashes "empty" on its way to the error.
     (b) Nothing reset the list on navigation, so "Loading…" was reachable only on the very first
     mount — every later directory change showed the PREVIOUS directory's rows. Fixed by storing the
     listing WITH the cwd it belongs to, so a cwd change IS the loading state by construction; a
@@ -902,17 +909,25 @@ session.
     (`displacedByWorktree`): it has no session to disturb, so it is caught by path wherever it sits.
     The patch is the pure `displacedFilesPatch` (`lib/filesNode.ts`), where `null` means LEAVE IT
     ALONE on the dead path — the parent probe above then tells the truth — because
-    `resetDisplacedCwd`'s fallback can be `undefined` and `FilesNode` reads `data.cwd || '/'`:
-    writing `undefined` through would have silently listed the filesystem ROOT instead. The title
+    `resetDisplacedCwd`'s fallback can be `undefined`, and writing that through would
+    have cost the node the only thing it knows about itself. **The READ side is guarded too**: a
+    files node with no `cwd` says so instead of falling back to `'/'` — `project.json` is
+    git-shared, hand-editable input that nothing validates for this kind, so guarding only the
+    writer left the silent root-browse reachable anyway. And `createFilesNode` places through
+    `placeNode`, not `placeAt`, so snap-to-grid applies to its size as well as its position (React
+    Flow resizes by adding a grid multiple to the START size, so an unsnapped box never lands on
+    the grid later). The title
     rewrites alongside when `titleAuto` holds — the ONE cwd write that does not go through `navigate`.
   - **"New terminal here" was broken on BOTH remote kinds, and not by this node's own doing.**
     `addTerminal` resolves the project from `activeProjectId` and `createTerminalNode` does
     `cwd: ssh ? ssh.remoteCwd : cwd` (`state/workspace.ts`) — on an SSH project the folder on screen
     was silently DISCARDED and the terminal opened at the project root, a pre-existing hole in
-    `addTerminal`'s `cwdOverride` contract affecting every caller, not just this one. Fixed by the
-    pure `sshBindingForCwd`, which rebinds `remoteCwd` to the named directory and keys on an EXPLICIT
-    override only — an SSH project can still carry a local `project.cwd`, and promoting that would
-    root remote terminals at a path from the wrong machine. On a RELAY tab there is no `ssh` to
+    `addTerminal`'s `cwdOverride` contract affecting every caller, not just this one. Fixed by routing the call
+    through the EXISTING `nodeSshFor`, which already carries this exact reasoning ("passing the
+    project's ssh unchanged silently REPLACES the caller's cwd") and which `addTerminal` simply
+    never used; it is handed `cwdOverride` and never the resolved `cwd`, because an SSH project can
+    still carry a local `project.cwd` that `scmCwd` falls back to, and promoting that would root
+    remote terminals at a path from the wrong machine. On a RELAY tab there is no `ssh` to
     rebind, so the row used to spawn a plain LOCAL terminal at the peer's remote path; it is now
     withheld there instead — spawning onto a peer's core is a real feature, not a one-liner.
   - Creation needs a project directory (`hasCwd`), and **the row degrades EXPLICITLY rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -859,33 +859,85 @@ session.
   the folder shown (a `nodeterm:open-terminal` event, the sibling of `nodeterm:open-file`).
   - **It adds NO new IPC.** Everything runs on the existing `FsApi` (`list`/`mkdir`/`exists`/
     `write`) — which is why it works on Desktop, the Server Edition, an SSH project and a relay tab
-    on day one. **Rename/move/delete are the deliberate v1 gap**: each needs a new leaf in
-    `core/fs-ops`, an IPC channel, preload, the ws-bridge, `main/ssh-fs` (remote quoting) and the
-    relay host-service, plus confirm dialogs and dangerous-path guards. That is a separate change
-    with separate risk, not a corner to cut inside this one.
+    on day one; `mkdir`/`exists` are genuinely LIVE on a relay tab (see the Explorer bullet above —
+    that line used to claim otherwise), so "New folder…" works there too. **Rename/move/delete are
+    the deliberate v1 gap**: each needs a new leaf in `core/fs-ops`, an IPC channel, preload, the
+    ws-bridge, `main/ssh-fs` (remote quoting) and the relay host-service, plus confirm dialogs and
+    dangerous-path guards. That is a separate change with separate risk, not a corner to cut inside
+    this one.
   - **Which filesystem** is `EditorNode`'s decision, read the same way: `data.sshFs` → the SSH
     project's host over the ControlMaster; otherwise the node's own SESSION api, which is the local
     core for a local project and the PEER's for a relay tab. Reading it off `useSession()` rather
     than `window.nodeTerminal` is the entire reason a relay tab browses the right machine.
   - **Opening is delegated, never reimplemented**: a file dispatches `nodeterm:open-file`, so
     editor-vs-video-vs-image routing stays in Canvas's one `openFile` and this node never grows a
-    second opinion about what a `.png` is. `fileOpenTarget` decides only canvas-vs-OS, and a
-    REMOTE listing never reaches the OS branch — `shell.openPath` opens a path on THIS machine, so
-    handing it a host path either does nothing or, if that path exists here too, opens an unrelated
-    local file.
-  - **Four empty states stay four** (loading / could not read / the folder is empty / the filter
-    matches nothing). Collapsing any pair into one blank pane is the failure this file warns about
-    elsewhere, and an empty filter matches everything so select-all+delete cannot blank the list.
+    second opinion about what a `.png` is. `fileOpenTarget` decides only canvas-vs-OS, and a REMOTE
+    listing never reaches the OS branch — `shell.openPath` opens a path on THIS machine. **The OS
+    branch is now also gated on being ABLE to open locally**, not just on remoteness: `shell.openPath`
+    is a documented `noop` in the Server Edition (`bridge/stubs.ts:180-186`), and a browser tab's own
+    session `source` is `'local'` — `SessionSource` declares `'server'` but nothing ever constructs
+    it (`session/session.ts:8`), so `source` alone can never tell you you're in a browser, only
+    `isBrowserRuntime()` can. Opening a `.zip`/`.dmg` was therefore a silent dead click; closed by
+    `canUseLocalShell` (`lib/download.ts`) — ONE predicate for every `shell.*` path action, with
+    `canRevealLocally` kept as its older reveal-specific name so existing callers are untouched.
+    Reveal was gated and openPath was not, and writing that rule twice is how they drifted.
+  - **Two state bugs, both fixed.** (a) A directory a removed worktree took with it used to render
+    as "This folder is empty." — not "Could not read this folder" — because `FsApi.list` is
+    fail-open by contract (`core/fs-ops.listDir`/`SshFs.listDir` both end `catch { return [] }`, and
+    the SSH IPC resolves `[]` even for a dead ControlMaster). `fs.exists` cannot disambiguate either:
+    it's `stat`-based (true for a dir you can stat but not `readdir`), and on SSH its `false` can't
+    separate "gone" from "the ControlMaster died" — the same conflation `SshFs.readTextChecked`
+    (`main/ssh-fs.ts:164-176`) refuses, on the rule "a failed read is never evidence of absence". Now
+    disambiguated by probing the PARENT's listing instead (`classifyEmptyListing`, pure,
+    `lib/filesNode.ts` — the idiom `SshProjectDialog.tsx:112-125` and `file-links.ts`'s
+    `makeDirListingLookup` already use), which answers `missing` / `empty` / `unknown`: an unreadable
+    parent answers `unknown`, and we keep saying "empty" rather than claim a deletion we can't prove.
+    (b) Nothing reset the list on navigation, so "Loading…" was reachable only on the very first
+    mount — every later directory change showed the PREVIOUS directory's rows. Fixed by storing the
+    listing WITH the cwd it belongs to, so a cwd change IS the loading state by construction; a
+    re-list after a create deliberately keeps its rows (same directory, re-read).
   - The title tracks the folder only while `titleAuto` is unset — the same contract an agent node's
     session name uses, so navigating never overwrites a name the user typed.
   - A files node inside a REMOVED worktree is displaced like an editor, not like a terminal
-    (`displacedByWorktree`): it has no session to disturb, so it is caught by path wherever it sits,
-    and it gets its `cwd` re-pointed rather than an editor's `fileMissing` — a directory can be
-    re-pointed, a dead file cannot. Left out, it would show "Could not read this folder" forever
-    AND keep the dead path in `project.json`.
+    (`displacedByWorktree`): it has no session to disturb, so it is caught by path wherever it sits.
+    The patch is the pure `displacedFilesPatch` (`lib/filesNode.ts`), where `null` means LEAVE IT
+    ALONE on the dead path — the parent probe above then tells the truth — because
+    `resetDisplacedCwd`'s fallback can be `undefined` and `FilesNode` reads `data.cwd || '/'`:
+    writing `undefined` through would have silently listed the filesystem ROOT instead. The title
+    rewrites alongside when `titleAuto` holds — the ONE cwd write that does not go through `navigate`.
+  - **"New terminal here" was broken on BOTH remote kinds, and not by this node's own doing.**
+    `addTerminal` resolves the project from `activeProjectId` and `createTerminalNode` does
+    `cwd: ssh ? ssh.remoteCwd : cwd` (`state/workspace.ts`) — on an SSH project the folder on screen
+    was silently DISCARDED and the terminal opened at the project root, a pre-existing hole in
+    `addTerminal`'s `cwdOverride` contract affecting every caller, not just this one. Fixed by the
+    pure `sshBindingForCwd`, which rebinds `remoteCwd` to the named directory and keys on an EXPLICIT
+    override only — an SSH project can still carry a local `project.cwd`, and promoting that would
+    root remote terminals at a path from the wrong machine. On a RELAY tab there is no `ssh` to
+    rebind, so the row used to spawn a plain LOCAL terminal at the peer's remote path; it is now
+    withheld there instead — spawning onto a peer's core is a real feature, not a one-liner.
   - Creation is gated on the project having a directory (`hasCwd`) on every surface — pane menu,
     Dock, sidebar "+", ⌘K, and the group-frame menu, where it inherits a bound **worktree's** cwd
     via `cwdForNewNodeIn`, so a frame per branch also means a file tree per branch.
+  - **A node kind not registered in `lib/reopenNode.ts` is a trap, and this one fell in it.** Every
+    kind must sit in exactly one of `UNRESTORABLE` or a `buildBase` `case` — `files` was in neither,
+    so ⇧⌘T recorded a snapshot (and a persisted `closedSessions` twin) that `buildBase`'s
+    `default: return null` could never restore: a dead, clickable entry that compiles, typechecks and
+    passes every test. `files` now has a `case` (it IS restorable — its whole state is the directory
+    it shows), unlike `trigger`, excluded for the same missing-case reason
+    (`reopenNode.ts:58-60`, the comment that made this findable). Two kinds have fallen in this trap
+    now; treat registration as a checklist item for the next one.
+  - **Kanban: deliberately not a card.** `canvas/toKanbanSession.ts` maps `browser`, `sticky` and
+    `terminal` and returns `null` for everything else — cards do not "derive from terminal nodes",
+    they derive from that explicit list. A files node has no session to co-attach and no text to
+    edit; its value is spatial adjacency to the terminals working in the directory, which a column
+    layout would discard.
+  - `folderTitle` lives in `lib/explorerCreate.ts` (a zero-import leaf), not `lib/filesNode.ts`:
+    `filesNode.ts` imports `isVideoFile` FROM `state/workspace`, so importing back would close a
+    cycle. `filesNode.ts` re-exports it, so call sites are unchanged.
+  - **The `/`-separator assumption is a KNOWN gap, shared with `explorerCreate`** (the Explorer
+    drawer and canvas "New file…" already run on the same helpers) — `C:\x\y` reads as one segment.
+    To be closed in ONE place for both, using the core-owns-the-dialect rule `terminal/file-links.ts`
+    already implements.
   - **Mobile**: N/A — *nodeterm mobile* attaches to tmux sessions over the transport protocol and
     has no canvas or file-browsing concept; adding one means extending that protocol.
 - **dino** (`DinoNode.tsx`) — a small self-contained T-Rex-style runner on a canvas (no PTY);
@@ -2396,7 +2448,15 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   **New File… / New Folder…** (empty-area right-click targets the root; SSH projects create on the
   host). Canvas pane right-click and ⌘K also expose **New file…** (creates under the project cwd,
   opens an editor node). These use `mkdir` + `exists` added to `FsApi`/`SshFsApi` across
-  desktop/server/SSH (`core/fs-ops.ts`, `main/ssh-fs.ts`; relay remote-fs degrades to `false`).
+  desktop/server/SSH (`core/fs-ops.ts`, `main/ssh-fs.ts`). **Relay tabs are NOT degraded**: a
+  relay tab's `fs` routes through `bridge/relay-api.ts:86` (`fs: files.fs`) → `buildFilesApi`'s
+  `IPC.fsMkdir`/`IPC.fsExists` (`bridge/ws-bridge.ts:474-475`) → `core/fs-handlers.ts:43-44` →
+  the real `fsOps.makeDir`/`fsOps.pathExists` on the peer's core, so both verbs are live there.
+  What genuinely still lacks them is the legacy PHONE vocabulary
+  (`main/remote/host-service.ts`), whose `handleFs` switches on `fs.list`/`read`/`readBinary`/
+  `write` and nothing else, so `fs.mkdir`/`fs.exists` fall through to the dispatcher's
+  `Unknown method` **rejection** (line 695) rather than degrading to `false` — a different
+  dispatch path (`relay-host.ts:22-24`) from the relay tab above.
   Expanded dirs **persist per project** across drawer close + app restart (`state/explorer.ts`
   zustand store, localStorage `nodeterm.explorerExpanded`). The header pin docks it like the
   sessions sidebar (`lib/explorerPin.ts`, `nodeterm.explorerPinned`, default off): overlay

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -915,8 +915,14 @@ session.
     root remote terminals at a path from the wrong machine. On a RELAY tab there is no `ssh` to
     rebind, so the row used to spawn a plain LOCAL terminal at the peer's remote path; it is now
     withheld there instead — spawning onto a peer's core is a real feature, not a one-liner.
-  - Creation is gated on the project having a directory (`hasCwd`) on every surface — pane menu,
-    Dock, sidebar "+", ⌘K, and the group-frame menu, where it inherits a bound **worktree's** cwd
+  - Creation needs a project directory (`hasCwd`), and **the row degrades EXPLICITLY rather than
+    vanishing** — disabled, carrying `FILES_NO_CWD_HINT` (an alias of `NEW_FILE_NO_CWD_HINT`), on
+    the pane menu, the Dock and the sidebar "+". That is the rule #621 established for "New file…"
+    and the SSH worktree row: a cwd-less project is a supported, persisted canvas, so a row that
+    simply disappears takes its own reason with it while the fix ("Set folder…") sits one menu
+    away. **⌘K is the deliberate exception** and hides the entry, exactly as main's "New file…"
+    does — a disabled palette entry surfaces as a search result that does nothing, the same reason
+    `sshAccountsHint` is omitted there. Inside a group frame it inherits a bound **worktree's** cwd
     via `cwdForNewNodeIn`, so a frame per branch also means a file tree per branch.
   - **A node kind not registered in `lib/reopenNode.ts` is a trap, and this one fell in it.** Every
     kind must sit in exactly one of `UNRESTORABLE` or a `buildBase` `case` — `files` was in neither,

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -492,6 +492,7 @@ import {
   createDinoNode,
   createTriggerNode,
   createFilesNode,
+  sshBindingForCwd,
   createDiffNode,
   createEditorNode,
   createGroupNode,
@@ -3599,10 +3600,13 @@ export function Canvas() {
       console.info(
         `[nodeterm] node-create agent=- project=${targetProjectId} group=${groupId ?? '-'} cwd=${cwd ?? '-'}`
       )
+      // In an SSH project the node is stamped remote (runs over the project's master) and
+      // `createTerminalNode` roots it at `ssh.remoteCwd`, which silently discards a caller's
+      // "here" — see `sshBindingForCwd` for the whole reasoning. With no override this is
+      // byte-identical to before.
+      const ssh = sshBindingForCwd(project?.ssh, cwdOverride)
       setNodes((ns) => {
-        // In an SSH project the node is stamped remote (runs over the project's master); the
-        // factory takes the project's ssh and roots the terminal at its remoteCwd.
-        const node = createTerminalNode(ns.length, cwd, center ?? emptyNodePos(), initialCommand, project?.ssh)
+        const node = createTerminalNode(ns.length, cwd, center ?? emptyNodePos(), initialCommand, ssh)
         return [...ns, groupId ? parentInto(node, groupId) : node]
       })
       markDirty()

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -309,6 +309,7 @@ const sshConnect: SshConnectFn = (scopeId, conn, remoteCwd) =>
 const sshDisconnect = (scopeId: string): Promise<unknown> =>
   window.nodeTerminal.sshProject.disconnect(scopeId)
 import { opensInEditor } from '../lib/openTarget'
+import { displacedFilesPatch } from '../lib/filesNode'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
 import {
   explorerIsOpen,
@@ -4634,6 +4635,14 @@ export function Canvas() {
    * `data.fileMissing` instead of rewritten. The node stays on the canvas (never auto-closed: it
    * may hold unsaved Monaco edits the user hasn't copied out yet) and renders a persistent notice.
    *
+   * A files node is caught by path wherever it sits (it has no session to disturb, so the `under`
+   * restriction terminals get does not apply) and IS re-pointed — a directory can be, a dead file
+   * cannot. Two things are special because it SHOWS its cwd rather than merely running in it:
+   * with no fallback it is left alone rather than written `undefined`, since `FilesNode` reads
+   * `data.cwd || '/'` and would quietly start listing the filesystem root; and its title is
+   * rewritten alongside when `titleAuto` still holds, because this is the one cwd write that does
+   * not go through `navigate`, the only other place that pairs the two.
+   *
    * `respawn` separates the two callers (terminal only — editor/diff has no session to touch):
    *  - Remove (true): the directory is being deleted under live sessions, so their tmux sessions are
    *    destroyed and the terminals respawn straight into the fallback cwd.
@@ -4666,6 +4675,13 @@ export function Canvas() {
           if (!displaced.has(n.id)) return n
           if (n.type === 'editor' || n.type === 'diff') {
             return { ...n, data: { ...n.data, fileMissing: true } }
+          }
+          if (n.type === 'files') {
+            // A file manager SHOWS its cwd, so re-pointing it is not the same operation as
+            // re-pointing a terminal that merely runs in one. `null` = leave it alone; see
+            // `displacedFilesPatch` for both rules and why the no-fallback case must not write.
+            const patch = displacedFilesPatch(n.data, fallbackCwd)
+            return patch ? { ...n, data: { ...n.data, ...patch } } : n
           }
           return {
             ...n,

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -493,7 +493,6 @@ import {
   createDinoNode,
   createTriggerNode,
   createFilesNode,
-  sshBindingForCwd,
   createDiffNode,
   createEditorNode,
   createGroupNode,
@@ -3601,11 +3600,16 @@ export function Canvas() {
       console.info(
         `[nodeterm] node-create agent=- project=${targetProjectId} group=${groupId ?? '-'} cwd=${cwd ?? '-'}`
       )
-      // In an SSH project the node is stamped remote (runs over the project's master) and
-      // `createTerminalNode` roots it at `ssh.remoteCwd`, which silently discards a caller's
-      // "here" — see `sshBindingForCwd` for the whole reasoning. With no override this is
-      // byte-identical to before.
-      const ssh = sshBindingForCwd(project?.ssh, cwdOverride)
+      // In an SSH project the node is stamped remote and `createTerminalNode` roots it at
+      // `ssh.remoteCwd`, silently discarding a caller's "here" — which is exactly the trap
+      // `nodeSshFor` was written for ("passing the project's ssh unchanged silently REPLACES the
+      // caller's cwd"). `addTerminal` simply never used it.
+      //
+      // `cwdOverride`, NOT the resolved `cwd`: an SSH project can still carry a local
+      // `project.cwd`, and `scmCwd` falls back to it, so passing the resolved value would launder
+      // a path from this machine into `remoteCwd`. With no override this is byte-identical to
+      // passing `project?.ssh` straight through.
+      const ssh = nodeSshFor(project?.ssh, cwdOverride)
       setNodes((ns) => {
         const node = createTerminalNode(ns.length, cwd, center ?? emptyNodePos(), initialCommand, ssh)
         return [...ns, groupId ? parentInto(node, groupId) : node]

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -81,6 +81,7 @@ import { LazyEditorNode, LazyDiffNode } from '../nodes/lazyMonacoNodes'
 import { DinoNode } from '../nodes/DinoNode'
 import { TriggerNode } from '../nodes/TriggerNode'
 import BrowserNode from '../nodes/BrowserNode'
+import { FilesNode } from '../nodes/FilesNode'
 import { normalizeAddress } from '../nodes/browserUrl'
 import VideoNode from '../nodes/VideoNode'
 import WebNode from '../nodes/WebNode'
@@ -490,6 +491,7 @@ import {
   createBrowserNode,
   createDinoNode,
   createTriggerNode,
+  createFilesNode,
   createDiffNode,
   createEditorNode,
   createGroupNode,
@@ -1530,7 +1532,8 @@ export function Canvas() {
       trigger: withNodeBoundary(TriggerNode),
       video: withNodeBoundary(VideoNode),
       web: withNodeBoundary(WebNode),
-      browser: withNodeBoundary(BrowserNode)
+      browser: withNodeBoundary(BrowserNode),
+      files: withNodeBoundary(FilesNode)
     }),
     []
   )
@@ -3944,13 +3947,21 @@ export function Canvas() {
       const d = (e as CustomEvent<{ path: string }>).detail
       if (d?.path) revealProjectFile(d.path)
     }
+    // A file-manager node asking for a terminal in the folder it is showing. Same
+    // no-direct-line-to-the-canvas pattern as the two above.
+    const onTerminal = (e: Event): void => {
+      const d = (e as CustomEvent<{ cwd?: string }>).detail
+      if (d?.cwd) addTerminal(undefined, undefined, undefined, d.cwd)
+    }
     window.addEventListener('nodeterm:open-file', onOpen)
     window.addEventListener('nodeterm:reveal-file', onReveal)
+    window.addEventListener('nodeterm:open-terminal', onTerminal)
     return () => {
       window.removeEventListener('nodeterm:open-file', onOpen)
       window.removeEventListener('nodeterm:reveal-file', onReveal)
+      window.removeEventListener('nodeterm:open-terminal', onTerminal)
     }
-  }, [openFile, revealProjectFile])
+  }, [openFile, revealProjectFile, addTerminal])
 
   // Mic button on a terminal node's header (TerminalNode dispatches this — same
   // no-direct-line-to-canvas pattern as nodeterm:open-file above). Unlike toggleDictation's
@@ -4121,6 +4132,33 @@ export function Canvas() {
       void writeDisk()
     },
     [commitActiveToStore, writeDisk]
+  )
+
+  /**
+   * Open a file-manager node. It starts at the group's worktree cwd if it is being created inside
+   * a bound frame, else the project's own root — for an SSH project that is the REMOTE root, and
+   * the node is stamped `sshFs` so it lists the host rather than this machine (the same pairing
+   * `openFile` makes for an Explorer-opened remote file).
+   *
+   * Refused, rather than opened empty, when the project has no directory at all: a cwd-less canvas
+   * has nothing to browse, and a file manager rooted at `/` by default would be a worse answer
+   * than a sentence saying so.
+   */
+  const addFiles = useCallback(
+    (center?: { x: number; y: number }, groupId?: string, cwdOverride?: string) => {
+      const project = useProjects.getState().getProject(activeProjectId)
+      const cwd = cwdOverride ?? cwdForNewNodeIn(groupId) ?? project?.ssh?.remoteCwd ?? project?.cwd
+      if (!cwd) {
+        setCopyError('This canvas has no folder yet — open one from the project tab first.')
+        return
+      }
+      setNodes((ns) => {
+        const node = createFilesNode(ns.length, cwd, center ?? emptyNodePos(), !!project?.ssh)
+        return [...ns, groupId ? parentInto(node, groupId) : node]
+      })
+      markDirty()
+    },
+    [setNodes, markDirty, activeProjectId, emptyNodePos, cwdForNewNodeIn, parentInto]
   )
 
   const addSticky = useCallback(
@@ -7866,6 +7904,9 @@ export function Canvas() {
         },
         ...agentCreationItems(at, groupId),
         { label: 'New sticky note', icon: <IconNote />, onClick: () => addSticky(at, groupId) },
+        // Inside a worktree-bound frame this roots the manager at the WORKTREE, not the project —
+        // `cwdForNewNodeIn` is what makes a frame per branch also mean a file tree per branch.
+        { label: 'New file manager', icon: <IconExplorer />, onClick: () => addFiles(at, groupId) },
         { type: 'separator' },
         ...(isHidden('colors', useSettings.getState().settings.hiddenNodeMenuItems)
           ? []
@@ -7964,6 +8005,7 @@ export function Canvas() {
       browser: (at) => addBrowser(at),
       web: (at) => void addWebView(at),
       sticky: (at) => addSticky(at),
+      files: (at) => addFiles(at),
       dino: (at) => addDino(at),
       trigger: (at) => addTrigger(at),
       openFile: (at) => void openFileDialog(at),
@@ -7975,6 +8017,7 @@ export function Canvas() {
       addTerminal,
       openRemotePicker,
       addBrowser,
+      addFiles,
       addWebView,
       addSticky,
       addDino,
@@ -11924,6 +11967,17 @@ export function Canvas() {
           })
         ),
       { id: 'new-sticky', label: 'New sticky note', icon: <IconNote />, run: () => addSticky() },
+      // Needs a folder to root itself in, exactly like "New file…" below.
+      ...(newFileHasCwd
+        ? [
+            {
+              id: 'new-files',
+              label: 'New file manager',
+              icon: <IconExplorer />,
+              run: () => addFiles()
+            }
+          ]
+        : []),
       { id: 'new-dino', label: 'New dino game', icon: <IconDino />, run: () => addDino() },
       { id: 'open-file', label: 'Open file…', icon: <IconEditor />, run: () => void openFileDialog() },
       // "New file…" needs a project folder to create into — hidden when the project has no cwd.
@@ -13080,6 +13134,7 @@ export function Canvas() {
         onSpawnTeam={() => setSpawnTeamDialog({})}
         onAddDino={addDino}
         onAddTrigger={addTrigger}
+        onAddFiles={() => addFiles()}
         onAddAgent={(aid, accountId) => addAgentNode(aid, undefined, undefined, accountId)}
         onOpenFile={() => void openFileDialog()}
         onAddRemote={() => openRemotePicker({ x: window.innerWidth / 2, y: window.innerHeight / 2 })}

--- a/src/renderer/components/Dock.tsx
+++ b/src/renderer/components/Dock.tsx
@@ -26,6 +26,7 @@ interface DockProps {
   onSpawnTeam: () => void
   onAddDino: () => void
   onAddTrigger: () => void
+  onAddFiles: () => void
   onAddAgent: (agentId: AgentId, accountId?: string) => void
   onOpenFile: () => void
   onAddRemote: () => void
@@ -66,6 +67,7 @@ export function Dock({
   onSpawnTeam,
   onAddDino,
   onAddTrigger,
+  onAddFiles,
   onAddAgent,
   onOpenFile,
   onAddRemote,
@@ -158,6 +160,7 @@ export function Dock({
     spawnTeam: onSpawnTeam,
     dino: onAddDino,
     trigger: onAddTrigger,
+    files: onAddFiles,
     openFile: onOpenFile,
     newFile: onNewFile,
     worktree: onAddWorktree

--- a/src/renderer/lib/addMenuSpec.test.tsx
+++ b/src/renderer/lib/addMenuSpec.test.tsx
@@ -17,6 +17,7 @@ const handlers = (overrides: Partial<AddHandlers> = {}): AddHandlers => ({
   browser: noop,
   web: noop,
   sticky: noop,
+  files: noop,
   dino: noop,
   trigger: noop,
   openFile: noop,
@@ -32,6 +33,7 @@ const allKinds: AddItem['kind'][] = [
   'browser',
   'web',
   'sticky',
+  'files',
   'dino',
   'trigger',
   'open-file',
@@ -60,6 +62,7 @@ describe('contentAddItemsToMenuItems', () => {
       'New browser',
       'New web view…',
       'New sticky note',
+      'New file manager',
       'New dino game',
       'New trigger…',
       'Open file…',
@@ -67,6 +70,14 @@ describe('contentAddItemsToMenuItems', () => {
       'Spawn a team…',
       'New worktree…'
     ])
+  })
+
+  it('hides "New file manager" when the project has no cwd', () => {
+    const items = contentAddItemsToMenuItems(CONTENT_ADD_ITEMS, handlers(), {
+      hasCwd: false,
+      isSshProject: false
+    })
+    expect(items.some((i) => 'label' in i && i.label === 'New file manager')).toBe(false)
   })
 
   // A cwd-less project is a supported, persisted canvas — the folder-shaped rows must degrade
@@ -147,6 +158,7 @@ describe('contentAddItemsToDockRows', () => {
       'browser',
       'web',
       'sticky',
+      'files',
       'dino',
       'trigger',
       'open-file',
@@ -156,6 +168,14 @@ describe('contentAddItemsToDockRows', () => {
     ])
     expect(rows.some((r) => r.kind === 'terminal')).toBe(false)
     expect(rows.some((r) => r.kind === 'remote')).toBe(false)
+  })
+
+  it('hides "files" when there is no cwd', () => {
+    const rows = contentAddItemsToDockRows(CONTENT_ADD_ITEMS, handlers(), {
+      hasCwd: false,
+      isSshProject: false
+    })
+    expect(rows.some((r) => r.kind === 'files')).toBe(false)
   })
 
   it('DISABLES "new-file" with its reason when there is no cwd — the Dock keeps the row too', () => {

--- a/src/renderer/lib/addMenuSpec.test.tsx
+++ b/src/renderer/lib/addMenuSpec.test.tsx
@@ -3,6 +3,7 @@ import {
   CONTENT_ADD_ITEMS,
   contentAddItemsToMenuItems,
   contentAddItemsToDockRows,
+  FILES_NO_CWD_HINT,
   NEW_FILE_NO_CWD_HINT,
   WORKTREE_NO_CWD_HINT,
   WORKTREE_SSH_HINT,
@@ -72,12 +73,18 @@ describe('contentAddItemsToMenuItems', () => {
     ])
   })
 
-  it('hides "New file manager" when the project has no cwd', () => {
+  // Follows the rule main established for "New file…": a folder-shaped row on a cwd-less canvas
+  // degrades EXPLICITLY. This test previously asserted the row was HIDDEN, which is the behaviour
+  // that rule reversed.
+  it('DISABLES "New file manager" with its reason when the project has no cwd — never hides it', () => {
     const items = contentAddItemsToMenuItems(CONTENT_ADD_ITEMS, handlers(), {
       hasCwd: false,
       isSshProject: false
     })
-    expect(items.some((i) => 'label' in i && i.label === 'New file manager')).toBe(false)
+    const row = items.find((i) => 'label' in i && i.label === 'New file manager')
+    expect(row).toBeDefined()
+    expect(row && 'disabled' in row && row.disabled).toBe(true)
+    expect(row && 'hint' in row && row.hint).toBe(FILES_NO_CWD_HINT)
   })
 
   // A cwd-less project is a supported, persisted canvas — the folder-shaped rows must degrade
@@ -170,12 +177,15 @@ describe('contentAddItemsToDockRows', () => {
     expect(rows.some((r) => r.kind === 'remote')).toBe(false)
   })
 
-  it('hides "files" when there is no cwd', () => {
+  it('DISABLES "files" with its reason when there is no cwd — the Dock keeps the row too', () => {
     const rows = contentAddItemsToDockRows(CONTENT_ADD_ITEMS, handlers(), {
       hasCwd: false,
       isSshProject: false
     })
-    expect(rows.some((r) => r.kind === 'files')).toBe(false)
+    const row = rows.find((r) => r.kind === 'files')
+    expect(row).toBeDefined()
+    expect(row?.disabled).toBe(true)
+    expect(row?.hint).toBe(FILES_NO_CWD_HINT)
   })
 
   it('DISABLES "new-file" with its reason when there is no cwd — the Dock keeps the row too', () => {

--- a/src/renderer/lib/addMenuSpec.tsx
+++ b/src/renderer/lib/addMenuSpec.tsx
@@ -125,6 +125,8 @@ export const WORKTREE_SSH_HINT = 'Not supported in SSH projects yet'
  */
 export const NEW_FILE_NO_CWD_HINT = 'This project has no folder — set one first (tab ⌄ → “Set folder…”)'
 export const WORKTREE_NO_CWD_HINT = NEW_FILE_NO_CWD_HINT
+/** Same reason, same fix — a file manager has nothing to list without a project folder. */
+export const FILES_NO_CWD_HINT = NEW_FILE_NO_CWD_HINT
 
 /**
  * Map the canonical content list to {@link MenuItem}s for the `ContextMenu` component.
@@ -164,11 +166,18 @@ export function contentAddItemsToMenuItems(
         out.push({ label: 'New sticky note', icon: <IconNote />, onClick: () => handlers.sticky(at) })
         break
       case 'files':
-        // Needs a directory to root itself in — hidden on a cwd-less canvas for the same reason
-        // "New file…" is: an affordance that can only report "there is no folder" is not one.
-        if (ctx.hasCwd) {
-          out.push({ label: 'New file manager', icon: <IconExplorer />, onClick: () => handlers.files(at) })
-        }
+        // A file manager needs a directory to root itself in. This row used to be HIDDEN on a
+        // cwd-less canvas, reasoning that it was "the same as New file…" — and main has since
+        // reversed exactly that rule (`NEW_FILE_NO_CWD_HINT`): a cwd-less project is a supported,
+        // persisted canvas, so a folder-shaped row degrades EXPLICITLY rather than vanishing,
+        // because a row that is gone takes its reason with it and the fix is one menu away.
+        out.push({
+          label: 'New file manager',
+          icon: <IconExplorer />,
+          disabled: !ctx.hasCwd,
+          hint: ctx.hasCwd ? undefined : FILES_NO_CWD_HINT,
+          onClick: () => handlers.files(at)
+        })
         break
       case 'dino':
         out.push({ label: 'New dino game', icon: <IconDino />, onClick: () => handlers.dino(at) })
@@ -258,9 +267,14 @@ export function contentAddItemsToDockRows(
         out.push({ kind: 'sticky', label: 'Sticky Note', icon: <IconNote />, onClick: () => handlers.sticky() })
         break
       case 'files':
-        if (ctx.hasCwd) {
-          out.push({ kind: 'files', label: 'File Manager', icon: <IconExplorer />, onClick: () => handlers.files() })
-        }
+        out.push({
+          kind: 'files',
+          label: 'File Manager',
+          icon: <IconExplorer />,
+          disabled: !ctx.hasCwd,
+          hint: ctx.hasCwd ? undefined : FILES_NO_CWD_HINT,
+          onClick: () => handlers.files()
+        })
         break
       case 'dino':
         out.push({ kind: 'dino', label: 'Dino Game', icon: <IconDino />, onClick: () => handlers.dino() })

--- a/src/renderer/lib/addMenuSpec.tsx
+++ b/src/renderer/lib/addMenuSpec.tsx
@@ -24,6 +24,7 @@ import {
   IconBranch,
   IconDino,
   IconEditor,
+  IconExplorer,
   IconGroup,
   IconNote,
   IconRemote,
@@ -46,6 +47,7 @@ export type AddItem =
   | { kind: 'browser' }
   | { kind: 'web' }
   | { kind: 'sticky' }
+  | { kind: 'files' } // requiresCwd
   | { kind: 'dino' }
   | { kind: 'trigger' }
   | { kind: 'open-file' }
@@ -66,6 +68,7 @@ export const CONTENT_ADD_ITEMS: readonly AddItem[] = [
   { kind: 'browser' },
   { kind: 'web' },
   { kind: 'sticky' },
+  { kind: 'files' },
   { kind: 'dino' },
   { kind: 'trigger' },
   { kind: 'open-file' },
@@ -96,6 +99,7 @@ export interface AddHandlers {
   browser: (at?: AddPos) => void
   web: (at?: AddPos) => void
   sticky: (at?: AddPos) => void
+  files: (at?: AddPos) => void
   dino: (at?: AddPos) => void
   /** Adds a trigger node (issue #493) — a canvas-owned schedule that fires into another node. */
   trigger: (at?: AddPos) => void
@@ -158,6 +162,13 @@ export function contentAddItemsToMenuItems(
         break
       case 'sticky':
         out.push({ label: 'New sticky note', icon: <IconNote />, onClick: () => handlers.sticky(at) })
+        break
+      case 'files':
+        // Needs a directory to root itself in — hidden on a cwd-less canvas for the same reason
+        // "New file…" is: an affordance that can only report "there is no folder" is not one.
+        if (ctx.hasCwd) {
+          out.push({ label: 'New file manager', icon: <IconExplorer />, onClick: () => handlers.files(at) })
+        }
         break
       case 'dino':
         out.push({ label: 'New dino game', icon: <IconDino />, onClick: () => handlers.dino(at) })
@@ -245,6 +256,11 @@ export function contentAddItemsToDockRows(
         break
       case 'sticky':
         out.push({ kind: 'sticky', label: 'Sticky Note', icon: <IconNote />, onClick: () => handlers.sticky() })
+        break
+      case 'files':
+        if (ctx.hasCwd) {
+          out.push({ kind: 'files', label: 'File Manager', icon: <IconExplorer />, onClick: () => handlers.files() })
+        }
         break
       case 'dino':
         out.push({ kind: 'dino', label: 'Dino Game', icon: <IconDino />, onClick: () => handlers.dino() })

--- a/src/renderer/lib/download.test.ts
+++ b/src/renderer/lib/download.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { canRevealLocally, downloadRoute } from './download'
+import { canRevealLocally, canUseLocalShell, downloadRoute } from './download'
 
 describe('downloadRoute', () => {
   it('pulls an SSH project over scp on the desktop', () => {
@@ -33,5 +33,32 @@ describe('canRevealLocally', () => {
     expect(canRevealLocally({ browser: false, ssh: true, source: 'local' })).toBe(false)
     expect(canRevealLocally({ browser: true, ssh: false, source: 'local' })).toBe(false)
     expect(canRevealLocally({ browser: false, ssh: false, source: 'relay' })).toBe(false)
+  })
+})
+
+describe('canUseLocalShell', () => {
+  // The Server Edition bug this predicate was extracted for: a browser tab's session source is
+  // 'local' (SessionSource's 'server' is declared but never constructed), so `source` alone can
+  // never tell you you are in a browser — only `isBrowserRuntime()` can. `shell.openPath` is a
+  // `noop` stub there, so an ungated call on a .zip or .dmg was a silent dead click.
+  it('is false in a browser tab even though its session source is local', () => {
+    expect(canUseLocalShell({ browser: true, ssh: false, source: 'local' })).toBe(false)
+  })
+
+  it('is true only for a desktop shell acting on this machine', () => {
+    expect(canUseLocalShell({ browser: false, ssh: false, source: 'local' })).toBe(true)
+    expect(canUseLocalShell({ browser: false, ssh: true, source: 'local' })).toBe(false)
+    expect(canUseLocalShell({ browser: false, ssh: false, source: 'relay' })).toBe(false)
+  })
+
+  // One rule, not two that drift: reveal was gated and openPath was not, which is how the
+  // Server Edition ended up with a dead click on one member of the same namespace.
+  it('is the same rule reveal already used', () => {
+    for (const browser of [true, false])
+      for (const ssh of [true, false])
+        for (const source of ['local', 'relay', 'server'] as const)
+          expect(canUseLocalShell({ browser, ssh, source })).toBe(
+            canRevealLocally({ browser, ssh, source })
+          )
   })
 })

--- a/src/renderer/lib/download.ts
+++ b/src/renderer/lib/download.ts
@@ -42,14 +42,26 @@ export function downloadRoute({ browser, ssh, source }: DownloadContext): Downlo
 }
 
 /**
- * True when "Reveal in Finder" can actually do something: an Electron shell, showing paths that
- * are on THIS machine. It was previously offered unconditionally — on an SSH project it handed a
- * remote path to the local file manager, and in a browser tab it is an inert stub. Both were
- * silent no-ops, which reads as a broken app rather than as an unavailable feature.
+ * True when this machine's Electron `shell.*` can actually act on a path the UI is showing:
+ * an Electron shell (both members are `noop` stubs in a browser tab — see `bridge/stubs.ts`),
+ * and a path that is on THIS machine (an SSH host's or a relay peer's is not).
+ *
+ * ONE predicate for every `shell.*` path action, because they share one precondition for one
+ * reason. `reveal` was gated first; `openPath` was not, and a `.zip` in the Server Edition's file
+ * manager was therefore a silent dead click. Writing that rule a second time beside this one is
+ * how the two would drift apart again.
  */
-export function canRevealLocally({ browser, ssh, source }: DownloadContext): boolean {
+export function canUseLocalShell({ browser, ssh, source }: DownloadContext): boolean {
   return !browser && !ssh && source !== 'relay'
 }
+
+/**
+ * True when "Reveal in Finder" can actually do something. It was previously offered
+ * unconditionally — on an SSH project it handed a remote path to the local file manager, and in a
+ * browser tab it is an inert stub. Both were silent no-ops, which reads as a broken app rather
+ * than as an unavailable feature.
+ */
+export const canRevealLocally = canUseLocalShell
 
 /**
  * Start a browser download for `url` without navigating the page. An anchor with `download` is

--- a/src/renderer/lib/explorerCreate.ts
+++ b/src/renderer/lib/explorerCreate.ts
@@ -35,3 +35,16 @@ export function ancestorDirs(baseDir: string, name: string): string[] {
   }
   return out
 }
+
+/**
+ * The name of a directory — its last segment, or '/' at the root.
+ *
+ * Lives HERE rather than beside the file manager's other pure helpers because `state/workspace.ts`
+ * needs it too (`createFilesNode`'s title) and `lib/filesNode.ts` imports `isVideoFile` FROM
+ * workspace, so importing back would close a cycle. This module imports nothing, which is what
+ * makes it the right home. `lib/filesNode.ts` re-exports it, so every existing call site is
+ * unchanged.
+ */
+export function folderTitle(path: string): string {
+  return path.split('/').filter(Boolean).pop() ?? '/'
+}

--- a/src/renderer/lib/filesNode.test.ts
+++ b/src/renderer/lib/filesNode.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { breadcrumbs, childPath, fileOpenTarget, filterEntries, folderTitle, parentDir } from './filesNode'
+import {
+  breadcrumbs,
+  childPath,
+  classifyEmptyListing,
+  fileOpenTarget,
+  filterEntries,
+  folderTitle,
+  parentDir
+} from './filesNode'
 
 describe('breadcrumbs', () => {
   it('walks a shallow path in full', () => {
@@ -90,5 +98,45 @@ describe('fileOpenTarget', () => {
     expect(fileOpenTarget('/a/installer.dmg', { remote: true })).toBe('canvas')
     expect(fileOpenTarget('/a/bundle.zip', { remote: true })).toBe('canvas')
     expect(fileOpenTarget('/a/notes.md', { remote: true })).toBe('canvas')
+  })
+})
+
+describe('classifyEmptyListing', () => {
+  const parent = [{ name: 'docs' }, { name: 'src' }, { name: 'README.md' }]
+
+  // The case the fourth empty state exists for, and could not reach before: a removed worktree.
+  // `listDir` answers [] for a directory that is gone, exactly as it does for an empty one.
+  it('says missing when the parent lists real entries and ours is not among them', () => {
+    expect(classifyEmptyListing('/repo/gone', parent)).toBe('missing')
+  })
+
+  it('says empty when the parent lists us — the folder is there and simply has nothing in it', () => {
+    expect(classifyEmptyListing('/repo/docs', parent)).toBe('empty')
+    expect(classifyEmptyListing('/repo/docs/', parent)).toBe('empty')
+  })
+
+  // "A failed read is never evidence of absence" (SshFs.readTextChecked). Under the same
+  // fail-open contract an empty PARENT means unreadable-or-gone, not childless — so we learned
+  // nothing and must not tell the user their folder was deleted.
+  it('says unknown when the parent itself came back empty', () => {
+    expect(classifyEmptyListing('/repo/docs', [])).toBe('unknown')
+  })
+
+  it('says unknown when the parent could not be asked at all', () => {
+    expect(classifyEmptyListing('/repo/docs', null)).toBe('unknown')
+  })
+
+  // Root has no parent to interrogate and always exists.
+  it('says empty at the root rather than interrogating a parent that does not exist', () => {
+    expect(classifyEmptyListing('/', null)).toBe('empty')
+    expect(classifyEmptyListing('/', [])).toBe('empty')
+  })
+
+  // A symlinked directory can list as a non-dir entry depending on the leg; matching on `dir`
+  // would call it missing. Name matching is what keeps that false alarm out.
+  it('matches by name, not by entry kind', () => {
+    // Real callers pass `DirEntry[]`; a symlinked directory can arrive with `dir: false`.
+    const listed: { name: string; dir: boolean }[] = [{ name: 'link', dir: false }]
+    expect(classifyEmptyListing('/repo/link', listed)).toBe('empty')
   })
 })

--- a/src/renderer/lib/filesNode.test.ts
+++ b/src/renderer/lib/filesNode.test.ts
@@ -133,6 +133,35 @@ describe('classifyEmptyListing', () => {
     expect(classifyEmptyListing('/', [])).toBe('empty')
   })
 
+  // Every case below would name-match FAIL and be reported as a deletion. Each is a readable
+  // directory, so `unknown` (which renders as "empty") is the only honest answer.
+
+  // The one that shipped: an SSH project's remoteCwd DEFAULTS to `~`. `ls ~` works, but
+  // parentDir('~') is '/' and '/' has no entry named '~' — so an empty remote HOME reported
+  // "Could not read this folder."
+  it('never calls a non-absolute path missing — `~` is an SSH project default, not a deletion', () => {
+    expect(classifyEmptyListing('~', [{ name: 'bin' }, { name: 'etc' }])).toBe('unknown')
+    expect(classifyEmptyListing('~/src', [{ name: 'bin' }])).toBe('unknown')
+    expect(classifyEmptyListing('relative/dir', [{ name: 'bin' }])).toBe('unknown')
+  })
+
+  // Both listing legs strip `.git` on purpose, so a node pointed at one can never find itself.
+  it('never calls a .git directory missing — both listing legs filter it out', () => {
+    expect(classifyEmptyListing('/repo/.git', [{ name: 'src' }, { name: 'README.md' }])).toBe('unknown')
+  })
+
+  it('never calls a dot segment missing — readdir and `ls -A` do not emit them', () => {
+    expect(classifyEmptyListing('/repo/.', [{ name: 'src' }])).toBe('unknown')
+    expect(classifyEmptyListing('/repo/..', [{ name: 'src' }])).toBe('unknown')
+  })
+
+  // APFS/NTFS list a directory fine under the wrong case, but readdir answers with the on-disk
+  // spelling. "Missing" has to be the conclusion we are SURE of.
+  it('accepts a case-folded match on a case-insensitive filesystem', () => {
+    expect(classifyEmptyListing('/repo/Docs', [{ name: 'docs' }])).toBe('empty')
+    expect(classifyEmptyListing('/repo/docs', [{ name: 'DOCS' }])).toBe('empty')
+  })
+
   // A symlinked directory can list as a non-dir entry depending on the leg; matching on `dir`
   // would call it missing. Name matching is what keeps that false alarm out.
   it('matches by name, not by entry kind', () => {

--- a/src/renderer/lib/filesNode.test.ts
+++ b/src/renderer/lib/filesNode.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { breadcrumbs, childPath, fileOpenTarget, filterEntries, folderTitle, parentDir } from './filesNode'
+
+describe('breadcrumbs', () => {
+  it('walks a shallow path in full', () => {
+    expect(breadcrumbs('/a/b')).toEqual([
+      { name: '/', path: '/' },
+      { name: 'a', path: '/a' },
+      { name: 'b', path: '/a/b' }
+    ])
+  })
+
+  it('is just root at the root', () => {
+    expect(breadcrumbs('/')).toEqual([{ name: '/', path: '/' }])
+  })
+
+  it('collapses a deep path but keeps every crumb navigable', () => {
+    const crumbs = breadcrumbs('/one/two/three/four/five/six', 3)
+    expect(crumbs.map((c) => c.name)).toEqual(['/', '…', 'four', 'five', 'six'])
+    // The ellipsis is not decoration: it goes to the deepest directory it hid, so a user can
+    // climb back out one level at a time instead of being teleported to root.
+    expect(crumbs[1].path).toBe('/one/two/three')
+    expect(crumbs[crumbs.length - 1].path).toBe('/one/two/three/four/five/six')
+  })
+
+  it('does not collapse a path that exactly fits', () => {
+    expect(breadcrumbs('/a/b/c', 3).map((c) => c.name)).toEqual(['/', 'a', 'b', 'c'])
+  })
+})
+
+describe('folderTitle', () => {
+  it('names the directory', () => expect(folderTitle('/home/me/repo')).toBe('repo'))
+  it('names the root', () => expect(folderTitle('/')).toBe('/'))
+  it('ignores a trailing slash', () => expect(folderTitle('/home/me/repo/')).toBe('repo'))
+})
+
+describe('childPath', () => {
+  it('joins normally', () => expect(childPath('/a/b', 'c.ts')).toBe('/a/b/c.ts'))
+  it('does not double the separator at the root', () => expect(childPath('/', 'etc')).toBe('/etc'))
+  it('absorbs a trailing slash', () => expect(childPath('/a/', 'b')).toBe('/a/b'))
+})
+
+describe('parentDir', () => {
+  it('climbs one level', () => expect(parentDir('/a/b/c')).toBe('/a/b'))
+  it('stops at the root', () => expect(parentDir('/a')).toBe('/'))
+  it('stays at the root', () => expect(parentDir('/')).toBe('/'))
+})
+
+describe('filterEntries', () => {
+  const entries = [{ name: 'README.md' }, { name: 'src' }, { name: 'package.json' }]
+
+  it('matches case-insensitively anywhere in the name', () => {
+    expect(filterEntries(entries, 'age').map((e) => e.name)).toEqual(['package.json'])
+    expect(filterEntries(entries, 'readme').map((e) => e.name)).toEqual(['README.md'])
+  })
+
+  // The bug this pins: select-all + delete leaves '' (or a stray space), and a filter that treats
+  // that as "match nothing" blanks the whole listing with no way to tell why.
+  it('matches everything for an empty or whitespace query', () => {
+    expect(filterEntries(entries, '')).toEqual(entries)
+    expect(filterEntries(entries, '   ')).toEqual(entries)
+  })
+
+  it('can legitimately match nothing', () => {
+    expect(filterEntries(entries, 'zzz')).toEqual([])
+  })
+})
+
+describe('fileOpenTarget', () => {
+  it('opens text and images on the canvas', () => {
+    expect(fileOpenTarget('/a/notes.md')).toBe('canvas')
+    expect(fileOpenTarget('/a/logo.png')).toBe('canvas')
+    expect(fileOpenTarget('/a/Makefile')).toBe('canvas')
+  })
+
+  it('opens video on the canvas (the video node, not Monaco)', () => {
+    expect(fileOpenTarget('/a/clip.mp4')).toBe('canvas')
+    expect(fileOpenTarget('/a/clip.mov')).toBe('canvas')
+  })
+
+  it('hands binaries and archives to the OS', () => {
+    expect(fileOpenTarget('/a/installer.dmg')).toBe('os')
+    expect(fileOpenTarget('/a/bundle.zip')).toBe('os')
+    expect(fileOpenTarget('/a/data.sqlite')).toBe('os')
+  })
+
+  // shell.openPath opens a path on THIS machine. For a remote listing that is either a silent
+  // no-op or, if the path happens to exist locally too, an unrelated local file.
+  it('never hands a remote path to the OS', () => {
+    expect(fileOpenTarget('/a/installer.dmg', { remote: true })).toBe('canvas')
+    expect(fileOpenTarget('/a/bundle.zip', { remote: true })).toBe('canvas')
+    expect(fileOpenTarget('/a/notes.md', { remote: true })).toBe('canvas')
+  })
+})

--- a/src/renderer/lib/filesNode.test.ts
+++ b/src/renderer/lib/filesNode.test.ts
@@ -3,6 +3,7 @@ import {
   breadcrumbs,
   childPath,
   classifyEmptyListing,
+  displacedFilesPatch,
   fileOpenTarget,
   filterEntries,
   folderTitle,
@@ -138,5 +139,25 @@ describe('classifyEmptyListing', () => {
     // Real callers pass `DirEntry[]`; a symlinked directory can arrive with `dir: false`.
     const listed: { name: string; dir: boolean }[] = [{ name: 'link', dir: false }]
     expect(classifyEmptyListing('/repo/link', listed)).toBe('empty')
+  })
+})
+
+describe('displacedFilesPatch', () => {
+  it('re-points to the fallback and renames while the title still tracks the folder', () => {
+    expect(displacedFilesPatch({}, '/repo/src')).toEqual({ cwd: '/repo/src', title: 'src' })
+  })
+
+  // The `titleAuto` contract: a name the user typed is never overwritten by a cwd change,
+  // whether that change came from navigating or from a worktree being removed underneath.
+  it('leaves a hand-typed title alone', () => {
+    expect(displacedFilesPatch({ titleAuto: false }, '/repo/src')).toEqual({ cwd: '/repo/src' })
+  })
+
+  // The one that matters: FilesNode reads `data.cwd || '/'`, so writing undefined would make a
+  // displaced node silently list the filesystem ROOT. Doing nothing leaves it on the dead path,
+  // where the parent-listing probe tells the truth instead.
+  it('refuses to write anything when there is no fallback directory', () => {
+    expect(displacedFilesPatch({}, undefined)).toBeNull()
+    expect(displacedFilesPatch({ titleAuto: false }, '')).toBeNull()
   })
 })

--- a/src/renderer/lib/filesNode.ts
+++ b/src/renderer/lib/filesNode.ts
@@ -74,6 +74,32 @@ export function folderTitle(path: string): string {
  * entry depending on the leg, and mistaking one for "missing" is the false alarm this exists to
  * avoid.
  */
+/**
+ * How a files node is re-pointed when the worktree it was living in is removed
+ * (`resetDisplacedCwd`). It is caught by path wherever it sits, like an editor and unlike a
+ * terminal, because it has no session to disturb — and it is re-pointed rather than flagged
+ * `fileMissing`, because a directory can be re-pointed and a dead file cannot.
+ *
+ * `null` means LEAVE IT ALONE, and that is the interesting answer: with no fallback directory
+ * there is nowhere honest to send it, and writing `undefined` is worse than doing nothing —
+ * `FilesNode` reads `data.cwd || '/'`, so the node would silently begin listing the filesystem
+ * ROOT. Left on the dead path, the parent-listing probe says "Could not read this folder", which
+ * is the truth.
+ *
+ * The title rides along while `titleAuto` holds. This is the one cwd write that does NOT go
+ * through `navigate` — the only other place that pairs the two — so without it the node moves to
+ * a new directory still wearing the removed worktree's name.
+ */
+export function displacedFilesPatch(
+  data: { titleAuto?: unknown },
+  fallbackCwd: string | undefined
+): { cwd: string; title?: string } | null {
+  if (!fallbackCwd) return null
+  return data.titleAuto !== false
+    ? { cwd: fallbackCwd, title: folderTitle(fallbackCwd) }
+    : { cwd: fallbackCwd }
+}
+
 export type EmptyListingVerdict = 'empty' | 'missing' | 'unknown'
 
 export function classifyEmptyListing(

--- a/src/renderer/lib/filesNode.ts
+++ b/src/renderer/lib/filesNode.ts
@@ -45,6 +45,48 @@ export function folderTitle(path: string): string {
   return path.split('/').filter(Boolean).pop() ?? '/'
 }
 
+/**
+ * What an EMPTY listing actually means.
+ *
+ * `FsApi` is fail-open by contract — `core/fs-ops.listDir` and `SshFs.listDir` both end
+ * `catch { return [] }`, and the SSH IPC resolves `[]` even for a project whose ControlMaster is
+ * down. So a `.catch` on `list()` fires only when the transport itself rejects, and a directory
+ * that was deleted (a removed worktree, most obviously) comes back indistinguishable from one
+ * that is genuinely empty. That is why the node's "could not read" state was unreachable.
+ *
+ * We do not ask `fs.exists`. It is `stat`-based, so it answers TRUE for a directory you can stat
+ * but not `readdir`, and on SSH its `false` cannot separate "gone" from "the master died" — which
+ * `SshFs.readTextChecked` singles out precisely so it can refuse to conflate them: *a failed read
+ * is never evidence of absence*. Instead we ask the PARENT's listing, the same way
+ * `SshProjectDialog` and `file-links.ts`'s `makeDirListingLookup` already answer this question.
+ *
+ * Three answers, and the third is the point:
+ *  - `missing` — the parent listed real entries and ours is not among them. Only this earns the
+ *    error state.
+ *  - `empty`   — the parent lists us, so the directory is there and simply has nothing in it.
+ *    Root takes this too: it has no parent to ask and always exists.
+ *  - `unknown` — the parent itself came back empty, which under the same fail-open contract means
+ *    the parent is unreadable or gone rather than childless. We learned nothing, so we claim
+ *    nothing; the caller keeps saying "empty". Understating beats telling someone their folder
+ *    was deleted because a network hiccup ate one `ls`.
+ *
+ * Matching is by NAME, not by `dir`, deliberately: a symlinked directory can list as a non-dir
+ * entry depending on the leg, and mistaking one for "missing" is the false alarm this exists to
+ * avoid.
+ */
+export type EmptyListingVerdict = 'empty' | 'missing' | 'unknown'
+
+export function classifyEmptyListing(
+  cwd: string,
+  /** The parent's entries, or `null` when the parent was not asked or could not be read. */
+  parentEntries: readonly { name: string }[] | null
+): EmptyListingVerdict {
+  const name = folderTitle(cwd)
+  if (name === '/' || !cwd.replace(/\/+$/, '')) return 'empty' // root: no parent, always exists
+  if (!parentEntries || parentEntries.length === 0) return 'unknown'
+  return parentEntries.some((e) => e.name === name) ? 'empty' : 'missing'
+}
+
 /** Join a directory and an entry name. Trailing slashes on the dir are absorbed, so the root
  *  ('/') does not produce a doubled separator. */
 export function childPath(dir: string, name: string): string {

--- a/src/renderer/lib/filesNode.ts
+++ b/src/renderer/lib/filesNode.ts
@@ -1,0 +1,82 @@
+/**
+ * The decisions a file-manager node makes, kept pure so they can be pressed in a test rather than
+ * clicked in the app: which directory "up" is, what the breadcrumb shows, what a filter matches,
+ * and what happens when you open a thing.
+ *
+ * Paths are `/`-separated absolutes throughout, remote ones included — the node talks to an
+ * `FsApi`, which is the same shape for the local filesystem, an SSH project's host over the
+ * ControlMaster, and a relay peer's core.
+ */
+import { isVideoFile } from '../state/workspace'
+import { opensInEditor } from './openTarget'
+
+export { parentDir } from './explorerCreate'
+
+/** One breadcrumb: what to show, and where clicking it goes. */
+export interface Crumb {
+  name: string
+  path: string
+}
+
+/**
+ * A node header is a few hundred pixels wide and a real project path is not. `max` is the number
+ * of TRAILING segments kept; anything deeper is collapsed into a single leading crumb that still
+ * navigates (to the last dropped directory), because a breadcrumb you cannot click is just text.
+ * Root is always reachable as the first crumb for the same reason.
+ */
+export function breadcrumbs(path: string, max = 3): Crumb[] {
+  const segs = path.split('/').filter(Boolean)
+  const all: Crumb[] = [{ name: '/', path: '/' }]
+  let acc = ''
+  for (const s of segs) {
+    acc += `/${s}`
+    all.push({ name: s, path: acc })
+  }
+  if (all.length <= max + 1) return all
+  // Keep root, then an ellipsis crumb that navigates to the deepest hidden directory, then the
+  // tail. `max + 1` accounts for root, which is never dropped.
+  const hidden = all.slice(1, all.length - max)
+  const ellipsis: Crumb = { name: '…', path: hidden[hidden.length - 1].path }
+  return [all[0], ellipsis, ...all.slice(all.length - max)]
+}
+
+/** The node's title: the directory's own name, or '/' at the root. */
+export function folderTitle(path: string): string {
+  return path.split('/').filter(Boolean).pop() ?? '/'
+}
+
+/** Join a directory and an entry name. Trailing slashes on the dir are absorbed, so the root
+ *  ('/') does not produce a doubled separator. */
+export function childPath(dir: string, name: string): string {
+  return `${dir.replace(/\/+$/, '')}/${name}`
+}
+
+/**
+ * Filter listed entries by a substring, case-insensitively. An empty or whitespace-only query
+ * matches everything — a filter box that silently hides the whole listing when the user selects
+ * and deletes their text is the bug this guards.
+ */
+export function filterEntries<T extends { name: string }>(entries: T[], query: string): T[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return entries
+  return entries.filter((e) => e.name.toLowerCase().includes(q))
+}
+
+/**
+ * What opening a FILE should do.
+ *
+ *  `canvas` — open it as a node on the canvas (an editor for text and images, a video player for
+ *             media). This is what the canvas `nodeterm:open-file` listener already does.
+ *  `os`     — hand it to the operating system's default application, for the things Monaco can
+ *             only render as garbage: archives, installers, databases, binaries.
+ *
+ * `remote` (an SSH project, or a relay tab) forces `canvas`, and that is not a limitation dressed
+ * up as a choice: `shell.openPath` opens a path on THIS machine, so handing it a path that exists
+ * on another one either fails silently or — worse, if the path happens to exist here too — opens
+ * a completely unrelated local file. The same rule Canvas's own `openProjectFile` follows.
+ */
+export function fileOpenTarget(path: string, opts: { remote?: boolean } = {}): 'canvas' | 'os' {
+  if (opts.remote) return 'canvas'
+  if (isVideoFile(path)) return 'canvas'
+  return opensInEditor(path) ? 'canvas' : 'os'
+}

--- a/src/renderer/lib/filesNode.ts
+++ b/src/renderer/lib/filesNode.ts
@@ -57,10 +57,15 @@ export function breadcrumbs(path: string, max = 3): Crumb[] {
  * `fileMissing`, because a directory can be re-pointed and a dead file cannot.
  *
  * `null` means LEAVE IT ALONE, and that is the interesting answer: with no fallback directory
- * there is nowhere honest to send it, and writing `undefined` is worse than doing nothing —
- * `FilesNode` reads `data.cwd || '/'`, so the node would silently begin listing the filesystem
- * ROOT. Left on the dead path, the parent-listing probe says "Could not read this folder", which
- * is the truth.
+ * there is nowhere honest to send it, and writing `undefined` is worse than doing nothing — the
+ * node would lose the only thing it knows about itself. Left on the dead path, the parent-listing
+ * probe usually says "Could not read this folder", which is the truth.
+ *
+ * Two honest caveats. The branch is near-unreachable in practice (a worktree binding cannot exist
+ * without a project cwd, so a fallback almost always exists). And "usually": `git worktree remove`
+ * deletes the worktree but not the now-empty `<repo>.worktrees/` container, so removing the LAST
+ * one leaves the probe with an empty parent — `unknown`, which still renders as "empty". Doing
+ * nothing is still better than writing a path we cannot justify.
  *
  * The title rides along while `titleAuto` holds. This is the one cwd write that does NOT go
  * through `navigate` — the only other place that pairs the two — so without it the node moves to
@@ -112,10 +117,32 @@ export function classifyEmptyListing(
   /** The parent's entries, or `null` when the parent was not asked or could not be read. */
   parentEntries: readonly { name: string }[] | null
 ): EmptyListingVerdict {
+  const trimmed = cwd.replace(/\/+$/, '')
   const name = folderTitle(cwd)
-  if (name === '/' || !cwd.replace(/\/+$/, '')) return 'empty' // root: no parent, always exists
+  if (name === '/' || !trimmed) return 'empty' // root: no parent, always exists
+
+  // Below are the paths whose parent listing CANNOT answer the question. Each of them would
+  // otherwise fail to name-match and be reported as `missing` — a false "your folder is gone" on a
+  // directory that is perfectly readable, which is the one error this whole classifier exists to
+  // avoid making.
+  //
+  //  - Not `/`-absolute. `~` is the big one: an SSH project's `remoteCwd` DEFAULTS to `~`
+  //    (SshSection), `ls ~` works fine on the host, but `parentDir('~')` is `/` and `/` has no
+  //    entry called `~`. So an empty remote HOME reported "Could not read this folder."
+  //  - `.` / `..` segments — `readdir` and `ls -A` never emit them.
+  //  - `.git`, which BOTH listing legs strip on purpose (`core/fs-ops.ts`, `main/ssh-fs.ts`), so a
+  //    node pointed at one can never find itself in its parent.
+  if (!trimmed.startsWith('/') || name === '.' || name === '..' || name === '.git') return 'unknown'
+
   if (!parentEntries || parentEntries.length === 0) return 'unknown'
-  return parentEntries.some((e) => e.name === name) ? 'empty' : 'missing'
+  if (parentEntries.some((e) => e.name === name)) return 'empty'
+  // A case-insensitive filesystem (APFS, NTFS) lists a directory fine under a cwd whose case
+  // differs from the on-disk spelling, and `readdir` answers with the on-disk one. Treat that as
+  // present: a case-folded match is weaker evidence of existence, but "missing" needs to be the
+  // conclusion we are SURE of.
+  const lower = name.toLowerCase()
+  if (parentEntries.some((e) => e.name.toLowerCase() === lower)) return 'empty'
+  return 'missing'
 }
 
 /** Join a directory and an entry name. Trailing slashes on the dir are absorbed, so the root

--- a/src/renderer/lib/filesNode.ts
+++ b/src/renderer/lib/filesNode.ts
@@ -6,11 +6,21 @@
  * Paths are `/`-separated absolutes throughout, remote ones included — the node talks to an
  * `FsApi`, which is the same shape for the local filesystem, an SSH project's host over the
  * ControlMaster, and a relay peer's core.
+ *
+ * **Windows is a known, INHERITED gap.** Every split here is on `/` alone, so `C:\\x\\y` reads as a
+ * single segment: one breadcrumb, and `folderTitle` returning the whole path. This is shared with
+ * `lib/explorerCreate.ts` (`parentDir`, `newEntryPath`, `ancestorDirs`), which the Explorer drawer
+ * and the canvas "New file…" already run on, so a files node is not the thing that introduces it —
+ * but Windows is being brought up as a first-class desktop target, and `quality-windows` now runs
+ * on this branch. When it is closed, close it in ONE place for both: the path dialect belongs to
+ * the filesystem-owning CORE, not the viewer, which is the rule `terminal/file-links.ts` already
+ * implements and the one to copy.
  */
 import { isVideoFile } from '../state/workspace'
 import { opensInEditor } from './openTarget'
+import { folderTitle } from './explorerCreate'
 
-export { parentDir } from './explorerCreate'
+export { folderTitle, parentDir } from './explorerCreate'
 
 /** One breadcrumb: what to show, and where clicking it goes. */
 export interface Crumb {
@@ -40,10 +50,33 @@ export function breadcrumbs(path: string, max = 3): Crumb[] {
   return [all[0], ellipsis, ...all.slice(all.length - max)]
 }
 
-/** The node's title: the directory's own name, or '/' at the root. */
-export function folderTitle(path: string): string {
-  return path.split('/').filter(Boolean).pop() ?? '/'
+/**
+ * How a files node is re-pointed when the worktree it was living in is removed
+ * (`resetDisplacedCwd`). It is caught by path wherever it sits, like an editor and unlike a
+ * terminal, because it has no session to disturb — and it is re-pointed rather than flagged
+ * `fileMissing`, because a directory can be re-pointed and a dead file cannot.
+ *
+ * `null` means LEAVE IT ALONE, and that is the interesting answer: with no fallback directory
+ * there is nowhere honest to send it, and writing `undefined` is worse than doing nothing —
+ * `FilesNode` reads `data.cwd || '/'`, so the node would silently begin listing the filesystem
+ * ROOT. Left on the dead path, the parent-listing probe says "Could not read this folder", which
+ * is the truth.
+ *
+ * The title rides along while `titleAuto` holds. This is the one cwd write that does NOT go
+ * through `navigate` — the only other place that pairs the two — so without it the node moves to
+ * a new directory still wearing the removed worktree's name.
+ */
+export function displacedFilesPatch(
+  data: { titleAuto?: unknown },
+  fallbackCwd: string | undefined
+): { cwd: string; title?: string } | null {
+  if (!fallbackCwd) return null
+  return data.titleAuto !== false
+    ? { cwd: fallbackCwd, title: folderTitle(fallbackCwd) }
+    : { cwd: fallbackCwd }
 }
+
+export type EmptyListingVerdict = 'empty' | 'missing' | 'unknown'
 
 /**
  * What an EMPTY listing actually means.
@@ -74,34 +107,6 @@ export function folderTitle(path: string): string {
  * entry depending on the leg, and mistaking one for "missing" is the false alarm this exists to
  * avoid.
  */
-/**
- * How a files node is re-pointed when the worktree it was living in is removed
- * (`resetDisplacedCwd`). It is caught by path wherever it sits, like an editor and unlike a
- * terminal, because it has no session to disturb — and it is re-pointed rather than flagged
- * `fileMissing`, because a directory can be re-pointed and a dead file cannot.
- *
- * `null` means LEAVE IT ALONE, and that is the interesting answer: with no fallback directory
- * there is nowhere honest to send it, and writing `undefined` is worse than doing nothing —
- * `FilesNode` reads `data.cwd || '/'`, so the node would silently begin listing the filesystem
- * ROOT. Left on the dead path, the parent-listing probe says "Could not read this folder", which
- * is the truth.
- *
- * The title rides along while `titleAuto` holds. This is the one cwd write that does NOT go
- * through `navigate` — the only other place that pairs the two — so without it the node moves to
- * a new directory still wearing the removed worktree's name.
- */
-export function displacedFilesPatch(
-  data: { titleAuto?: unknown },
-  fallbackCwd: string | undefined
-): { cwd: string; title?: string } | null {
-  if (!fallbackCwd) return null
-  return data.titleAuto !== false
-    ? { cwd: fallbackCwd, title: folderTitle(fallbackCwd) }
-    : { cwd: fallbackCwd }
-}
-
-export type EmptyListingVerdict = 'empty' | 'missing' | 'unknown'
-
 export function classifyEmptyListing(
   cwd: string,
   /** The parent's entries, or `null` when the parent was not asked or could not be read. */

--- a/src/renderer/lib/nodeSizing.ts
+++ b/src/renderer/lib/nodeSizing.ts
@@ -19,6 +19,7 @@ export const NODE_MIN_SIZES: Record<NodeKind, { width: number; height: number }>
   video: { width: 320, height: 200 },
   web: { width: 320, height: 200 },
   browser: { width: 360, height: 240 },
+  files: { width: 220, height: 160 },
   subagent: { width: 180, height: 84 },
   loop: { width: 180, height: 84 },
   dino: { width: 400, height: 160 },

--- a/src/renderer/lib/reopenNode.test.ts
+++ b/src/renderer/lib/reopenNode.test.ts
@@ -124,4 +124,56 @@ describe('recreateNodeFromSnapshot', () => {
     )
     expect(node!.data.highScore).toBe(42)
   })
+
+  // A kind in neither UNRESTORABLE nor buildBase's switch is the trap the 'trigger' comment in
+  // reopenNode.ts warns about: snapshotNode happily records it, the ⇧⌘T entry and its persisted
+  // closedSessions twin are both written, and buildBase's `default` then returns null — a dead,
+  // clickable history entry that typechecks. So the pairing is asserted from BOTH ends.
+  it('recreates a files node from its cwd (a deleted file manager is not a dead reopen entry)', () => {
+    const node = recreateNodeFromSnapshot(
+      snap({
+        type: 'files',
+        data: { title: 'nodes', color: '#ffd60a', group: null, cwd: '/repo/src/renderer/nodes' }
+      }),
+      baseCtx()
+    )
+    expect(node).not.toBeNull()
+    expect(node!.type).toBe('files')
+    expect(node!.data.cwd).toBe('/repo/src/renderer/nodes')
+    expect(node!.data.title).toBe('nodes')
+  })
+
+  it('carries a files node’s sshFs flag, so a remote listing does not come back local', () => {
+    const node = recreateNodeFromSnapshot(
+      snap({
+        type: 'files',
+        data: { title: 'src', color: '#ffd60a', group: null, cwd: '/srv/app/src', sshFs: true }
+      }),
+      baseCtx()
+    )
+    expect(node!.data.sshFs).toBe(true)
+  })
+
+  it('returns null for a files snapshot missing cwd (never a silently blank listing)', () => {
+    const node = recreateNodeFromSnapshot(
+      snap({ type: 'files', data: { title: 'x', color: '#fff', group: null } }),
+      baseCtx()
+    )
+    expect(node).toBeNull()
+  })
+
+  it('snapshots a files node rather than treating it as unrestorable', () => {
+    const snapshot = snapshotNode(
+      {
+        type: 'files',
+        position: { x: 0, y: 0 },
+        width: 340,
+        height: 460,
+        data: { title: 'docs', color: '#ffd60a', group: null, cwd: '/repo/docs' }
+      },
+      []
+    )
+    expect(snapshot).not.toBeNull()
+    expect(snapshot!.type).toBe('files')
+  })
 })

--- a/src/renderer/lib/reopenNode.ts
+++ b/src/renderer/lib/reopenNode.ts
@@ -12,6 +12,7 @@ import {
   createDiffNode,
   createStickyNode,
   createDinoNode,
+  createFilesNode,
   isAccountLoginNode
 } from '@renderer/state/workspace'
 import { absolutePosition, type FocusableNode } from './nodeFocus'
@@ -167,6 +168,13 @@ function buildBase(snapshot: ReopenNodeSnapshot, ctx: RecreateContext): CanvasNo
       return d.filePath ? createEditorNode(0, d.filePath, undefined, d.sshFs) : null
     case 'video':
       return d.filePath ? createVideoNode(0, d.filePath, undefined, d.sshFs) : null
+    // A files node IS restorable — its whole state is the directory it shows — so it gets a case
+    // here rather than a seat in UNRESTORABLE beside 'trigger'. Registering it in neither list is
+    // the trap the 'trigger' comment above warns about: the snapshot is taken, the reopen entry is
+    // written, and `default: return null` then makes it a dead click. Compiles and typechecks
+    // either way, which is why the rule is written down rather than left to be noticed.
+    case 'files':
+      return d.cwd ? createFilesNode(0, d.cwd, undefined, d.sshFs) : null
     case 'diff':
       return d.cwd && d.filePath ? createDiffNode(0, d.cwd, d.filePath, !!d.diffStaged, undefined, d.commitOid) : null
     case 'web':

--- a/src/renderer/nodes/FilesNode.tsx
+++ b/src/renderer/nodes/FilesNode.tsx
@@ -65,6 +65,8 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const [showColors, setShowColors] = useState(false)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleBefore, setTitleBefore] = useState('')
+  /** `titleAuto` as it stood before the rename began — Escape has to put BOTH halves back. */
+  const [autoBefore, setAutoBefore] = useState(true)
   /** Kept WITH the directory it belongs to. Deriving `entries` from a cwd match is what makes
    *  "Loading…" reachable: before this, nothing ever reset the list, so navigating showed the
    *  PREVIOUS folder's rows until the new promise resolved and the loading state existed only on
@@ -335,7 +337,11 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
                 setEditingTitle(false)
               } else if (e.key === 'Escape') {
                 e.preventDefault()
-                updateNodeData(id, { title: titleBefore })
+                // Restore `titleAuto` as well as the text. `onChange` sets it false on the first
+                // keystroke, so cancelling a rename you never committed used to leave the title
+                // permanently detached from the folder — the node stopped following navigation
+                // and nothing said why.
+                updateNodeData(id, { title: titleBefore, titleAuto: autoBefore })
                 setEditingTitle(false)
               }
             }}
@@ -346,6 +352,7 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
             title="Click to rename"
             onClick={() => {
               setTitleBefore((data.title as string) ?? '')
+              setAutoBefore(data.titleAuto !== false)
               setEditingTitle(true)
             }}
           >

--- a/src/renderer/nodes/FilesNode.tsx
+++ b/src/renderer/nodes/FilesNode.tsx
@@ -40,6 +40,7 @@ import { useProjects } from '../state/projects'
 import { promptDialog } from '../components/promptDialog'
 import { ContextMenu, type MenuItem } from '../components/ContextMenu'
 import { isBrowserRuntime } from '../bridge/runtime'
+import { canUseLocalShell } from '../lib/download'
 
 /** Surface a transient error the way every other node does (Canvas listens for this). */
 const toast = (message: string): void => {
@@ -87,9 +88,10 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const fs = isSshFs && activeProjectId ? sshFs(activeProjectId) : api.fs
   /** A listing this machine's OS cannot act on: an SSH host's files, or a relay peer's. */
   const remote = isSshFs || source === 'relay'
-  /** `shell.*` is Electron-only — in the browser the reveal row would be a button that does
-   *  nothing, which teaches less than not offering it. */
-  const canReveal = !remote && !isBrowserRuntime()
+  /** The ONE precondition every `shell.*` path action shares: an Electron shell, and a path on
+   *  THIS machine. Both members are `noop` stubs in a browser tab, so an ungated call is a dead
+   *  click — which is what "Reveal" was written to avoid and what `openPath` still did. */
+  const localShell = canUseLocalShell({ browser: isBrowserRuntime(), ssh: isSshFs, source })
 
   useEffect(() => {
     let live = true
@@ -162,6 +164,14 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
         return
       }
       if (fileOpenTarget(path, { remote }) === 'os') {
+        // `fileOpenTarget` has already refused a remote path, so the only way to be here without
+        // a usable shell is a browser tab — where `openPath` is an inert stub and the click would
+        // simply do nothing. Say so instead: an unavailable feature that explains itself reads
+        // better than an app that looks broken.
+        if (!localShell) {
+          toast(`“${entry.name}” can only be opened by the desktop app — a browser tab cannot hand a file to your operating system.`)
+          return
+        }
         api.shell.openPath(path)
         return
       }
@@ -171,7 +181,7 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
         new CustomEvent('nodeterm:open-file', { detail: { path, ssh: isSshFs } })
       )
     },
-    [cwd, navigate, remote, api, isSshFs]
+    [cwd, navigate, remote, api, isSshFs, localShell]
   )
 
   /** Create a file or a folder under `dir`, then re-list. Shared by both menu rows because the
@@ -242,12 +252,12 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
         label: 'Copy path',
         onClick: () => api.clipboard.writeText(path)
       })
-      if (canReveal) {
+      if (localShell) {
         items.push({ label: 'Reveal in file manager', onClick: () => api.shell.reveal(path) })
       }
       setMenu({ x: e.clientX, y: e.clientY, items })
     },
-    [cwd, open, create, api, canReveal]
+    [cwd, open, create, api, localShell]
   )
 
   const toggleCollapse = () =>

--- a/src/renderer/nodes/FilesNode.tsx
+++ b/src/renderer/nodes/FilesNode.tsx
@@ -12,7 +12,13 @@
  * through the node's own session api — which is the local core for a local project and the PEER's
  * core for a relay tab, so a relay tab browses the machine its terminals are actually on. Getting
  * this from `useSession()` rather than `window.nodeTerminal` is the whole reason a relay tab works
- * here for free.
+ * here for free — **while `data.sshFs` is false.** When it is set, `sshFs(projectId)` reaches
+ * `window.nodeTerminal.sshFs`, i.e. THIS machine's preload, not the session's. That is inherited
+ * (`createEditorNode`/`createVideoNode` stamp and share the flag the same way) and it matters more
+ * here than for them: `sshFs` is written into the git-shared `project.json`, so a teammate who
+ * clones the repo locally gets a node flagged remote with a perfectly valid local cwd, and the
+ * unresolvable ref fails open to `[]` — a directory full of files reported as empty. Fixing it
+ * means routing `sshFs` through the session api for every consumer, which is its own change.
  *
  * **Opening is delegated, not reimplemented.** A file dispatches `nodeterm:open-file` — the event
  * `TerminalNode`'s Cmd+click links already use — so editor / image / video routing stays in
@@ -80,7 +86,18 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const [version, setVersion] = useState(0)
 
   const collapsed = !!data.collapsed
-  const cwd = (data.cwd as string) || '/'
+  /**
+   * The directory this node shows. It used to fall back to `'/'`, which meant a node with no `cwd`
+   * silently listed the FILESYSTEM ROOT — reachable with no bug on our side, because
+   * `.nodeterm/project.json` is git-shared, hand-editable input and nothing validates a files
+   * node's `cwd` on load. It is also the same failure `displacedFilesPatch` refuses on the WRITE
+   * side; guarding one end and not the other left the hole open under the commit named after it.
+   *
+   * No silent fallback now: with no cwd there is nothing to list and the node says so. `''` is
+   * inert for the rest of the component because the effect below never lists it, and reaching the
+   * root then takes a deliberate click on a crumb rather than happening by itself.
+   */
+  const cwd = typeof data.cwd === 'string' ? data.cwd.trim() : ''
   /** Null whenever the rows on screen do not belong to the directory being shown — i.e. the
    *  "Loading…" state, which is now reachable on every navigation and not just the first mount. */
   const entries = listing && listing.cwd === cwd ? listing.entries : null
@@ -98,6 +115,13 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
   useEffect(() => {
     let live = true
     setError('')
+    if (!cwd) {
+      // Nothing to list, and listing `'/'` instead would be the silent root-browse this guard
+      // exists to stop. Name the state rather than showing an empty directory.
+      setListing({ cwd, entries: [] })
+      setError('This file manager has no folder.')
+      return
+    }
     void (async () => {
       let list: DirEntry[]
       try {
@@ -112,10 +136,21 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
         return
       }
       if (!live) return
-      setListing({ cwd, entries: list })
-      if (list.length > 0) return
+      if (list.length > 0) {
+        setListing({ cwd, entries: list })
+        return
+      }
       // Empty is ambiguous under the fail-open `FsApi` contract, so ask the parent who is right.
-      // A second listing, no new IPC, and only a definite absence is allowed to raise the error.
+      // Only a definite absence is allowed to raise the error.
+      //
+      // This is a SECOND `fs.list` — no new IPC *channel*, but a real extra round trip, and on an
+      // SSH project a real extra remote command. It is bounded (exactly one, never recursive),
+      // fails open, and is skipped entirely whenever the directory has any content, so it costs
+      // nothing on the common path.
+      //
+      // Nothing is published until the verdict is in: setting the empty listing first made a
+      // deleted folder render "This folder is empty." for one paint and then correct itself. While
+      // we are still deciding, "Loading…" is the true answer.
       const parent = parentDir(cwd)
       let parentEntries: DirEntry[] | null = null
       try {
@@ -124,6 +159,7 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
         parentEntries = null // could not ask ⇒ claim nothing
       }
       if (!live) return
+      setListing({ cwd, entries: list })
       if (classifyEmptyListing(cwd, parentEntries) === 'missing') {
         setError('Could not read this folder.')
       }

--- a/src/renderer/nodes/FilesNode.tsx
+++ b/src/renderer/nodes/FilesNode.tsx
@@ -1,0 +1,386 @@
+/**
+ * A file-manager node: one directory listing, on the canvas, beside the terminals that work in it.
+ *
+ * This is NOT a second Explorer. The Explorer drawer is a single tree rooted at the active
+ * project's cwd, and it is modal in practice — it covers the canvas and you close it to get back
+ * to work. A file manager node is a persisted canvas object pinned to ONE directory, so you can
+ * keep `src/renderer/nodes` open next to the agent working in it and a second one on `docs/`,
+ * where a tree gives you one cursor and a lot of scrolling.
+ *
+ * **Which filesystem** is the same decision `EditorNode` makes, read the same way: an SSH project's
+ * node (`data.sshFs`) lists the project's HOST over the ControlMaster; everything else lists
+ * through the node's own session api — which is the local core for a local project and the PEER's
+ * core for a relay tab, so a relay tab browses the machine its terminals are actually on. Getting
+ * this from `useSession()` rather than `window.nodeTerminal` is the whole reason a relay tab works
+ * here for free.
+ *
+ * **Opening is delegated, not reimplemented.** A file dispatches `nodeterm:open-file` — the event
+ * `TerminalNode`'s Cmd+click links already use — so editor / image / video routing stays in
+ * Canvas's one `openFile`, and this node never grows a second opinion about what a `.png` is.
+ * Directories navigate in place (persisted, so a reload comes back where you were).
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
+import type { DirEntry } from '@shared/types'
+import { NODE_MIN_SIZES } from '../lib/nodeSizing'
+import { COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from '../state/workspace'
+import { breadcrumbs, childPath, fileOpenTarget, filterEntries, folderTitle, parentDir } from '../lib/filesNode'
+import { ancestorDirs, createTargetDir, newEntryPath } from '../lib/explorerCreate'
+import { sshFs } from '../terminal/ssh-fs'
+import { useSession } from '../session/session'
+import { useProjects } from '../state/projects'
+import { promptDialog } from '../components/promptDialog'
+import { ContextMenu, type MenuItem } from '../components/ContextMenu'
+import { isBrowserRuntime } from '../bridge/runtime'
+
+/** Surface a transient error the way every other node does (Canvas listens for this). */
+const toast = (message: string): void => {
+  window.dispatchEvent(new CustomEvent('nodeterm:toast', { detail: { kind: 'error', message } }))
+}
+
+function EntryGlyph({ dir }: { dir: boolean }) {
+  return dir ? (
+    <svg className="files-node__glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+      <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    </svg>
+  ) : (
+    <svg className="files-node__glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+      <path d="M6 3h8l4 4v14H6z" />
+      <path d="M14 3v4h4" />
+    </svg>
+  )
+}
+
+export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
+  const { updateNodeData, deleteElements, setNodes } = useReactFlow()
+  const [showColors, setShowColors] = useState(false)
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [titleBefore, setTitleBefore] = useState('')
+  const [entries, setEntries] = useState<DirEntry[] | null>(null)
+  const [error, setError] = useState('')
+  const [query, setQuery] = useState('')
+  const [menu, setMenu] = useState<{ x: number; y: number; items: MenuItem[] } | null>(null)
+  /** Bumped to force a re-list after a create; `cwd` alone cannot express "same dir, new content". */
+  const [version, setVersion] = useState(0)
+
+  const collapsed = !!data.collapsed
+  const cwd = (data.cwd as string) || '/'
+  const isSshFs = !!data.sshFs
+  const { api, source } = useSession()
+  const activeProjectId = useProjects((s) => s.activeProjectId)
+  const fs = isSshFs && activeProjectId ? sshFs(activeProjectId) : api.fs
+  /** A listing this machine's OS cannot act on: an SSH host's files, or a relay peer's. */
+  const remote = isSshFs || source === 'relay'
+  /** `shell.*` is Electron-only — in the browser the reveal row would be a button that does
+   *  nothing, which teaches less than not offering it. */
+  const canReveal = !remote && !isBrowserRuntime()
+
+  useEffect(() => {
+    let live = true
+    setError('')
+    void fs
+      .list(cwd)
+      .then((list) => {
+        if (live) setEntries(list)
+      })
+      .catch(() => {
+        if (!live) return
+        setEntries([])
+        setError('Could not read this folder.')
+      })
+    return () => {
+      live = false
+    }
+    // `fs` is rebuilt each render (sshFs returns a fresh object), so it is deliberately not a
+    // dependency — the identity that matters is the project + the sshFs flag, both of which
+    // change `cwd`'s meaning and are covered by the deps that are here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cwd, isSshFs, activeProjectId, version])
+
+  const navigate = useCallback(
+    (to: string) => {
+      // The title tracks the folder ONLY while the user has not renamed the node by hand — the
+      // same `titleAuto` contract agent nodes use for their session name. Renaming a file manager
+      // "assets" and then having it silently become "images" on the next click would be the node
+      // overwriting the user.
+      const patch: Record<string, unknown> = { cwd: to }
+      if (data.titleAuto !== false) patch.title = folderTitle(to)
+      updateNodeData(id, patch)
+      setQuery('')
+    },
+    [id, updateNodeData, data.titleAuto]
+  )
+
+  const open = useCallback(
+    (entry: DirEntry) => {
+      const path = childPath(cwd, entry.name)
+      if (entry.dir) {
+        navigate(path)
+        return
+      }
+      if (fileOpenTarget(path, { remote }) === 'os') {
+        api.shell.openPath(path)
+        return
+      }
+      // Canvas owns editor-vs-video routing; `ssh` tells its `openFile` to read over the
+      // project's remote fs rather than this machine's.
+      window.dispatchEvent(
+        new CustomEvent('nodeterm:open-file', { detail: { path, ssh: isSshFs } })
+      )
+    },
+    [cwd, navigate, remote, api, isSshFs]
+  )
+
+  /** Create a file or a folder under `dir`, then re-list. Shared by both menu rows because the
+   *  only difference is the last call — and the validation, the intermediate dirs and the
+   *  already-exists check are exactly the things that must not be written twice. */
+  const create = useCallback(
+    async (dir: string, kind: 'file' | 'folder') => {
+      const name = await promptDialog({
+        message: kind === 'file' ? 'New file name:' : 'New folder name:',
+        confirmLabel: 'Create'
+      })
+      if (name === null) return
+      const target = newEntryPath(dir, name)
+      if (!target) {
+        toast('That name cannot be used.')
+        return
+      }
+      if (await fs.exists(target)) {
+        toast(`${name.trim()} already exists.`)
+        return
+      }
+      // A nested name ("a/b/c.ts") needs its intermediate directories first — mkdir is recursive,
+      // so one call on the deepest one is enough.
+      const parents = ancestorDirs(dir, name)
+      if (parents.length && !(await fs.mkdir(parents[parents.length - 1]))) {
+        toast('Could not create that folder.')
+        return
+      }
+      const ok = kind === 'folder' ? await fs.mkdir(target) : await fs.write(target, '')
+      if (!ok) {
+        toast(kind === 'folder' ? 'Could not create that folder.' : 'Could not create that file.')
+        return
+      }
+      setVersion((v) => v + 1)
+      if (kind === 'file') {
+        window.dispatchEvent(
+          new CustomEvent('nodeterm:open-file', { detail: { path: target, ssh: isSshFs } })
+        )
+      }
+    },
+    [fs, isSshFs]
+  )
+
+  const openMenu = useCallback(
+    (e: React.MouseEvent, entry: DirEntry | null) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const path = entry ? childPath(cwd, entry.name) : cwd
+      const dir = entry ? createTargetDir(path, entry.dir) : cwd
+      const items: MenuItem[] = []
+      if (entry) {
+        items.push({ label: entry.dir ? 'Open folder' : 'Open', onClick: () => open(entry) })
+      }
+      if (!entry || entry.dir) {
+        items.push({
+          label: 'New terminal here',
+          onClick: () =>
+            window.dispatchEvent(
+              new CustomEvent('nodeterm:open-terminal', { detail: { cwd: entry ? path : cwd } })
+            )
+        })
+      }
+      items.push({ type: 'separator' })
+      items.push({ label: 'New file…', onClick: () => void create(dir, 'file') })
+      items.push({ label: 'New folder…', onClick: () => void create(dir, 'folder') })
+      items.push({ type: 'separator' })
+      items.push({
+        label: 'Copy path',
+        onClick: () => api.clipboard.writeText(path)
+      })
+      if (canReveal) {
+        items.push({ label: 'Reveal in file manager', onClick: () => api.shell.reveal(path) })
+      }
+      setMenu({ x: e.clientX, y: e.clientY, items })
+    },
+    [cwd, open, create, api, canReveal]
+  )
+
+  const toggleCollapse = () =>
+    setNodes((ns) =>
+      ns.map((n) => {
+        if (n.id !== id) return n
+        const next = !n.data.collapsed
+        const expandedHeight =
+          (n.data.expandedHeight as number) ?? n.measured?.height ?? (n.height as number) ?? 460
+        const height = next ? COLLAPSED_HEIGHT : expandedHeight
+        return {
+          ...n,
+          height,
+          style: { ...n.style, height },
+          data: { ...n.data, collapsed: next, expandedHeight }
+        }
+      })
+    )
+
+  const shown = useMemo(() => filterEntries(entries ?? [], query), [entries, query])
+  const crumbs = useMemo(() => breadcrumbs(cwd), [cwd])
+
+  return (
+    <div className={`files-node${selected ? ' selected' : ''}${collapsed ? ' collapsed' : ''}`}>
+      <NodeResizer
+        minWidth={NODE_MIN_SIZES.files.width}
+        minHeight={NODE_MIN_SIZES.files.height}
+        isVisible={selected && !collapsed}
+        color={data.color as string}
+      />
+
+      <div className="files-node__header" style={{ background: `${data.color}22` }}>
+        <button className="term-node__collapse" title={collapsed ? 'Expand' : 'Collapse'} onClick={toggleCollapse}>
+          {collapsed ? '▸' : '▾'}
+        </button>
+        <button
+          className="term-node__color"
+          style={{ background: data.color as string }}
+          title="Color"
+          onClick={() => setShowColors((v) => !v)}
+        />
+        {showColors && (
+          <div className="color-popover">
+            {NODE_COLORS.map((c) => (
+              <button
+                key={c}
+                style={{ background: c }}
+                onClick={() => {
+                  updateNodeData(id, { color: c })
+                  setShowColors(false)
+                }}
+              />
+            ))}
+          </div>
+        )}
+        {editingTitle ? (
+          <input
+            className="term-node__title nodrag"
+            value={(data.title as string) ?? ''}
+            spellCheck={false}
+            autoFocus
+            // A hand rename stops the title tracking the folder — same contract as an agent
+            // node's session name (`titleAuto`), so navigating never overwrites a chosen name.
+            onChange={(e) => updateNodeData(id, { title: e.target.value, titleAuto: false })}
+            onBlur={() => setEditingTitle(false)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                setEditingTitle(false)
+              } else if (e.key === 'Escape') {
+                e.preventDefault()
+                updateNodeData(id, { title: titleBefore })
+                setEditingTitle(false)
+              }
+            }}
+          />
+        ) : (
+          <span
+            className="term-node__title-text nodrag"
+            title="Click to rename"
+            onClick={() => {
+              setTitleBefore((data.title as string) ?? '')
+              setEditingTitle(true)
+            }}
+          >
+            {(data.title as string) || folderTitle(cwd)}
+          </span>
+        )}
+        {isSshFs && <span className="files-node__chip">SSH</span>}
+        {!editingTitle && <span className="term-node__spacer" />}
+        <button
+          className="files-node__btn nodrag"
+          title="Up one folder"
+          disabled={cwd === '/'}
+          onClick={() => navigate(parentDir(cwd))}
+        >
+          ↑
+        </button>
+        <button
+          className="files-node__btn nodrag"
+          title="Refresh"
+          onClick={() => setVersion((v) => v + 1)}
+        >
+          ⟳
+        </button>
+        <button className="term-node__close" title="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
+          ×
+        </button>
+      </div>
+
+      {!collapsed && (
+        <>
+          <div className="files-node__crumbs nodrag">
+            {crumbs.map((c, i) => (
+              <span key={`${c.path}-${i}`} className="files-node__crumb-wrap">
+                {/* No separator after the ROOT crumb — its own label is already "/", and a
+                    separator there renders the doubled "/ / …" this replaced. */}
+                {i > 0 && crumbs[i - 1].name !== '/' && <span className="files-node__sep">/</span>}
+                <button className="files-node__crumb" title={c.path} onClick={() => navigate(c.path)}>
+                  {c.name}
+                </button>
+              </span>
+            ))}
+          </div>
+
+          <input
+            className="files-node__filter nodrag"
+            value={query}
+            placeholder="Filter…"
+            spellCheck={false}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault()
+                setQuery('')
+              }
+            }}
+          />
+
+          <div
+            className="files-node__list nodrag nowheel"
+            onContextMenu={(e) => openMenu(e, null)}
+          >
+            {/* Four distinct states, kept distinct. "Still loading", "could not read", "the
+                folder is empty" and "your filter matches nothing" are different facts, and
+                collapsing any of them into a blank pane is exactly the failure this repo's
+                house rules call out. */}
+            {entries === null ? (
+              <div className="files-node__empty">Loading…</div>
+            ) : error ? (
+              <div className="files-node__empty files-node__empty--error">{error}</div>
+            ) : entries.length === 0 ? (
+              <div className="files-node__empty">This folder is empty.</div>
+            ) : shown.length === 0 ? (
+              <div className="files-node__empty">Nothing matches “{query.trim()}”.</div>
+            ) : (
+              shown.map((entry) => (
+                <div
+                  key={entry.name}
+                  className={`files-node__row${entry.ignored ? ' is-ignored' : ''}`}
+                  title={childPath(cwd, entry.name)}
+                  onClick={() => open(entry)}
+                  onContextMenu={(e) => openMenu(e, entry)}
+                >
+                  <EntryGlyph dir={entry.dir} />
+                  <span className="files-node__name">{entry.name}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </>
+      )}
+
+      {menu && (
+        <ContextMenu x={menu.x} y={menu.y} items={menu.items} onClose={() => setMenu(null)} />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/nodes/FilesNode.tsx
+++ b/src/renderer/nodes/FilesNode.tsx
@@ -24,7 +24,15 @@ import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
 import type { DirEntry } from '@shared/types'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import { COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from '../state/workspace'
-import { breadcrumbs, childPath, fileOpenTarget, filterEntries, folderTitle, parentDir } from '../lib/filesNode'
+import {
+  breadcrumbs,
+  childPath,
+  classifyEmptyListing,
+  fileOpenTarget,
+  filterEntries,
+  folderTitle,
+  parentDir
+} from '../lib/filesNode'
 import { ancestorDirs, createTargetDir, newEntryPath } from '../lib/explorerCreate'
 import { sshFs } from '../terminal/ssh-fs'
 import { useSession } from '../session/session'
@@ -56,7 +64,12 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const [showColors, setShowColors] = useState(false)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleBefore, setTitleBefore] = useState('')
-  const [entries, setEntries] = useState<DirEntry[] | null>(null)
+  /** Kept WITH the directory it belongs to. Deriving `entries` from a cwd match is what makes
+   *  "Loading…" reachable: before this, nothing ever reset the list, so navigating showed the
+   *  PREVIOUS folder's rows until the new promise resolved and the loading state existed only on
+   *  the very first mount. A `version` bump (re-list after a create) deliberately keeps the rows,
+   *  since that is the same directory being re-read. */
+  const [listing, setListing] = useState<{ cwd: string; entries: DirEntry[] } | null>(null)
   const [error, setError] = useState('')
   const [query, setQuery] = useState('')
   const [menu, setMenu] = useState<{ x: number; y: number; items: MenuItem[] } | null>(null)
@@ -65,6 +78,9 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
 
   const collapsed = !!data.collapsed
   const cwd = (data.cwd as string) || '/'
+  /** Null whenever the rows on screen do not belong to the directory being shown — i.e. the
+   *  "Loading…" state, which is now reachable on every navigation and not just the first mount. */
+  const entries = listing && listing.cwd === cwd ? listing.entries : null
   const isSshFs = !!data.sshFs
   const { api, source } = useSession()
   const activeProjectId = useProjects((s) => s.activeProjectId)
@@ -78,16 +94,36 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
   useEffect(() => {
     let live = true
     setError('')
-    void fs
-      .list(cwd)
-      .then((list) => {
-        if (live) setEntries(list)
-      })
-      .catch(() => {
+    void (async () => {
+      let list: DirEntry[]
+      try {
+        list = await fs.list(cwd)
+      } catch {
+        // Only a transport-level rejection lands here (a dropped ws/relay socket, an
+        // unsupported namespace). Every filesystem failure resolves `[]` instead — which is
+        // exactly what the empty branch below has to disambiguate.
         if (!live) return
-        setEntries([])
+        setListing({ cwd, entries: [] })
         setError('Could not read this folder.')
-      })
+        return
+      }
+      if (!live) return
+      setListing({ cwd, entries: list })
+      if (list.length > 0) return
+      // Empty is ambiguous under the fail-open `FsApi` contract, so ask the parent who is right.
+      // A second listing, no new IPC, and only a definite absence is allowed to raise the error.
+      const parent = parentDir(cwd)
+      let parentEntries: DirEntry[] | null = null
+      try {
+        if (parent !== cwd) parentEntries = await fs.list(parent)
+      } catch {
+        parentEntries = null // could not ask ⇒ claim nothing
+      }
+      if (!live) return
+      if (classifyEmptyListing(cwd, parentEntries) === 'missing') {
+        setError('Could not read this folder.')
+      }
+    })()
     return () => {
       live = false
     }
@@ -96,6 +132,14 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
     // change `cwd`'s meaning and are covered by the deps that are here.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cwd, isSshFs, activeProjectId, version])
+
+  // The filter belongs to the directory it was typed in, so ONE owner clears it — keyed on `cwd`
+  // rather than done inside `navigate`, because navigation is not the only way the cwd changes:
+  // a removed worktree re-points it through `resetDisplacedCwd`, which never calls `navigate`.
+  // A filter surviving that lands the user in a new folder showing "Nothing matches …".
+  useEffect(() => {
+    setQuery('')
+  }, [cwd])
 
   const navigate = useCallback(
     (to: string) => {
@@ -106,7 +150,6 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
       const patch: Record<string, unknown> = { cwd: to }
       if (data.titleAuto !== false) patch.title = folderTitle(to)
       updateNodeData(id, patch)
-      setQuery('')
     },
     [id, updateNodeData, data.titleAuto]
   )

--- a/src/renderer/nodes/FilesNode.tsx
+++ b/src/renderer/nodes/FilesNode.tsx
@@ -235,7 +235,13 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
       if (entry) {
         items.push({ label: entry.dir ? 'Open folder' : 'Open', onClick: () => open(entry) })
       }
-      if (!entry || entry.dir) {
+      // "here" has to be somewhere a terminal can actually be opened. `addTerminal` spawns
+      // against the ACTIVE project, and a relay project carries no `ssh` binding — so on a relay
+      // tab this would hand the PEER's path to a plain local terminal, the same wrong-machine
+      // mistake `fileOpenTarget` refuses for `shell.openPath`. Spawning onto a peer's core is a
+      // real feature, not a one-liner, so the row is withheld rather than faked. (An SSH project
+      // is fine: `addTerminal` now rebinds `remoteCwd` to the requested directory.)
+      if ((!entry || entry.dir) && source !== 'relay') {
         items.push({
           label: 'New terminal here',
           onClick: () =>
@@ -257,7 +263,7 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
       }
       setMenu({ x: e.clientX, y: e.clientY, items })
     },
-    [cwd, open, create, api, localShell]
+    [cwd, open, create, api, localShell, source]
   )
 
   const toggleCollapse = () =>

--- a/src/renderer/state/workspace.placement.test.ts
+++ b/src/renderer/state/workspace.placement.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { DEFAULT_SETTINGS } from '@shared/types'
 import { useSettings } from './settings'
-import { createStickyNode, createTerminalNode } from './workspace'
+import { createFilesNode, createStickyNode, createTerminalNode } from './workspace'
 
 const GRID = 20
 
@@ -60,5 +60,18 @@ describe('new node placement with snap-to-grid', () => {
 
     expect(node.width as number).toBeGreaterThanOrEqual(160)
     expect(node.height as number).toBeGreaterThanOrEqual(120)
+  })
+
+  // A factory that reaches for `placeAt` instead of `placeNode` silently opts out of snapping,
+  // and this file only covered terminal + sticky — which is exactly why the file-manager node
+  // shipped off-grid past a green suite. Position AND size, because React Flow resizes by adding
+  // a grid multiple to the START size: an unsnapped box can never be dragged onto the grid later.
+  it('snaps a file-manager node like every other kind', () => {
+    settings({ snapToGrid: true, gridSize: GRID })
+    const node = createFilesNode(0, '/repo/src', cursor)
+
+    expect([node.position.x % GRID, node.position.y % GRID]).toEqual([0, 0])
+    expect([(node.width as number) % GRID, (node.height as number) % GRID]).toEqual([0, 0])
+    expect(node.style).toEqual({ width: node.width, height: node.height })
   })
 })

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -20,7 +20,6 @@ import {
   reparentNode,
   resolveNewNodeAccount,
   selectedRootIds,
-  sshBindingForCwd,
   ungroupNodes
 } from './workspace'
 import type { CanvasNode } from './workspace'
@@ -1078,34 +1077,5 @@ describe('createAgentNode prompt injection', () => {
   it('keeps argv injection byte-identical for codex and gemini', () => {
     expect(createAgentNode('codex', 0, undefined, undefined, 'do X').data.initialCommand).toBe("codex 'do X'")
     expect(createAgentNode('gemini', 0, undefined, undefined, 'do X').data.initialCommand).toBe("gemini 'do X'")
-  })
-})
-
-describe('sshBindingForCwd', () => {
-  const ssh = { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' } as never
-
-  // The bug: "New terminal here" on an SSH project opened at the project root, because
-  // createTerminalNode does `cwd: ssh ? ssh.remoteCwd : cwd` and threw the request away.
-  it('rebinds remoteCwd to the directory the caller actually named', () => {
-    expect(sshBindingForCwd(ssh, '/srv/app/src/renderer')).toMatchObject({
-      remoteCwd: '/srv/app/src/renderer'
-    })
-  })
-
-  it('leaves the binding alone when no directory was named', () => {
-    expect(sshBindingForCwd(ssh, undefined)).toBe(ssh)
-  })
-
-  // An SSH project can still carry a LOCAL project.cwd. Promoting a resolved cwd instead of an
-  // explicit override would root remote terminals at a path from the wrong machine, so the
-  // trigger is the override and nothing else.
-  it('never invents a binding for a local project', () => {
-    expect(sshBindingForCwd(undefined, '/home/me/work')).toBeUndefined()
-  })
-
-  it('does not mutate the project\'s own binding', () => {
-    const before = { ...(ssh as object) }
-    sshBindingForCwd(ssh, '/elsewhere')
-    expect(ssh).toEqual(before)
   })
 })

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -20,6 +20,7 @@ import {
   reparentNode,
   resolveNewNodeAccount,
   selectedRootIds,
+  sshBindingForCwd,
   ungroupNodes
 } from './workspace'
 import type { CanvasNode } from './workspace'
@@ -1077,5 +1078,34 @@ describe('createAgentNode prompt injection', () => {
   it('keeps argv injection byte-identical for codex and gemini', () => {
     expect(createAgentNode('codex', 0, undefined, undefined, 'do X').data.initialCommand).toBe("codex 'do X'")
     expect(createAgentNode('gemini', 0, undefined, undefined, 'do X').data.initialCommand).toBe("gemini 'do X'")
+  })
+})
+
+describe('sshBindingForCwd', () => {
+  const ssh = { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' } as never
+
+  // The bug: "New terminal here" on an SSH project opened at the project root, because
+  // createTerminalNode does `cwd: ssh ? ssh.remoteCwd : cwd` and threw the request away.
+  it('rebinds remoteCwd to the directory the caller actually named', () => {
+    expect(sshBindingForCwd(ssh, '/srv/app/src/renderer')).toMatchObject({
+      remoteCwd: '/srv/app/src/renderer'
+    })
+  })
+
+  it('leaves the binding alone when no directory was named', () => {
+    expect(sshBindingForCwd(ssh, undefined)).toBe(ssh)
+  })
+
+  // An SSH project can still carry a LOCAL project.cwd. Promoting a resolved cwd instead of an
+  // explicit override would root remote terminals at a path from the wrong machine, so the
+  // trigger is the override and nothing else.
+  it('never invents a binding for a local project', () => {
+    expect(sshBindingForCwd(undefined, '/home/me/work')).toBeUndefined()
+  })
+
+  it('does not mutate the project\'s own binding', () => {
+    const before = { ...(ssh as object) }
+    sshBindingForCwd(ssh, '/elsewhere')
+    expect(ssh).toEqual(before)
   })
 })

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -23,6 +23,7 @@ import { mintFreeGrokSessionId } from '@shared/agents/grok-session-mint'
 import { projectLaunchInfoNow } from './projectLaunchInfo'
 import { isAgentEnabled, launchableDefaultAgent } from './agentAvailability'
 import { codexSharedIdentity } from './codexIdentity'
+import { folderTitle } from '../lib/explorerCreate'
 import { sshHostKey } from '@shared/ssh'
 import { normalizeNodeIcon } from '@shared/node-icon'
 import { useSettings } from './settings'
@@ -1062,7 +1063,7 @@ export function createFilesNode(
     height: FILES_SIZE.height,
     style: { width: FILES_SIZE.width, height: FILES_SIZE.height },
     data: {
-      title: cwd.split('/').filter(Boolean).pop() || '/',
+      title: folderTitle(cwd),
       color: '#ffd60a',
       group: null,
       cwd,

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -302,26 +302,6 @@ export function nodeSshFor(
   return { server: projectSsh.server, remoteCwd: cwd || projectSsh.remoteCwd }
 }
 
-/**
- * The ssh binding a terminal should be created with when the caller named a directory.
- *
- * `createTerminalNode` roots a remote node at `ssh.remoteCwd` and ignores its `cwd` argument
- * (`cwd: ssh ? ssh.remoteCwd : cwd`). That is right for a plain "new terminal" and wrong for
- * every caller that meant a SPECIFIC directory — a file manager's "New terminal here", a Source
- * Control action scoped to a checkout — because on an SSH project the request was discarded in
- * silence and the terminal opened at the project root.
- *
- * Keyed on an EXPLICIT override, never on a resolved cwd: an SSH project can still carry a local
- * `project.cwd`, and promoting that to `remoteCwd` would root remote terminals at a path from the
- * wrong machine. With no override the binding is returned untouched.
- */
-export function sshBindingForCwd(
-  ssh: Project['ssh'] | undefined,
-  cwdOverride: string | undefined
-): Project['ssh'] | undefined {
-  return ssh && cwdOverride ? { ...ssh, remoteCwd: cwdOverride } : ssh
-}
-
 export function createTerminalNode(
   index: number,
   cwd?: string,
@@ -1058,10 +1038,12 @@ export function createFilesNode(
   return {
     id: nextId('files'),
     type: 'files',
-    position: placeAt(center, index, FILES_SIZE.width, FILES_SIZE.height),
-    width: FILES_SIZE.width,
-    height: FILES_SIZE.height,
-    style: { width: FILES_SIZE.width, height: FILES_SIZE.height },
+    // `placeNode`, not `placeAt`: it snaps POSITION AND SIZE to `settings.gridSize` when
+    // snap-to-grid is on, which is what every other factory does. `placeAt` alone left a new file
+    // manager sitting off-grid beside snapped neighbours, and off-grid in SIZE too — React Flow
+    // resizes by adding a grid multiple to the start size, so an unsnapped box can never be
+    // dragged onto the grid afterwards.
+    ...placeNode('files', center, index, FILES_SIZE.width, FILES_SIZE.height),
     data: {
       title: folderTitle(cwd),
       color: '#ffd60a',

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -301,6 +301,26 @@ export function nodeSshFor(
   return { server: projectSsh.server, remoteCwd: cwd || projectSsh.remoteCwd }
 }
 
+/**
+ * The ssh binding a terminal should be created with when the caller named a directory.
+ *
+ * `createTerminalNode` roots a remote node at `ssh.remoteCwd` and ignores its `cwd` argument
+ * (`cwd: ssh ? ssh.remoteCwd : cwd`). That is right for a plain "new terminal" and wrong for
+ * every caller that meant a SPECIFIC directory — a file manager's "New terminal here", a Source
+ * Control action scoped to a checkout — because on an SSH project the request was discarded in
+ * silence and the terminal opened at the project root.
+ *
+ * Keyed on an EXPLICIT override, never on a resolved cwd: an SSH project can still carry a local
+ * `project.cwd`, and promoting that to `remoteCwd` would root remote terminals at a path from the
+ * wrong machine. With no override the binding is returned untouched.
+ */
+export function sshBindingForCwd(
+  ssh: Project['ssh'] | undefined,
+  cwdOverride: string | undefined
+): Project['ssh'] | undefined {
+  return ssh && cwdOverride ? { ...ssh, remoteCwd: cwdOverride } : ssh
+}
+
 export function createTerminalNode(
   index: number,
   cwd?: string,

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -59,6 +59,9 @@ const TRIGGER_SIZE = { width: 300, height: 170 }
 const VIDEO_SIZE = { width: 640, height: 420 }
 const WEB_SIZE = { width: 720, height: 520 }
 const BROWSER_SIZE = { width: 800, height: 560 }
+// Tall and narrow: a file manager is a LIST, and the thing that runs out first is vertical room
+// for entries, not horizontal room for names (which ellipsize).
+const FILES_SIZE = { width: 340, height: 460 }
 
 /** Height of a node when collapsed (header only). */
 export const COLLAPSED_HEIGHT = 40
@@ -1017,6 +1020,37 @@ export function createBrowserNode(
   }
 }
 
+/**
+ * Creates a file-manager node browsing `cwd`.
+ *
+ * `sshFs` is stamped for an SSH project so the node lists the PROJECT'S HOST over the
+ * ControlMaster instead of this machine — the same flag, read the same way, that `createEditorNode`
+ * and `createVideoNode` already use. Without it an SSH project's file manager would quietly browse
+ * the local filesystem at a path that means something else there.
+ */
+export function createFilesNode(
+  index: number,
+  cwd: string,
+  center?: { x: number; y: number },
+  sshFs?: boolean
+): CanvasNode {
+  return {
+    id: nextId('files'),
+    type: 'files',
+    position: placeAt(center, index, FILES_SIZE.width, FILES_SIZE.height),
+    width: FILES_SIZE.width,
+    height: FILES_SIZE.height,
+    style: { width: FILES_SIZE.width, height: FILES_SIZE.height },
+    data: {
+      title: cwd.split('/').filter(Boolean).pop() || '/',
+      color: '#ffd60a',
+      group: null,
+      cwd,
+      ...(sshFs ? { sshFs: true } : {})
+    }
+  }
+}
+
 /** Creates a diff editor node for a changed file (relative path + repo cwd). */
 export function createDiffNode(
   index: number,
@@ -1938,7 +1972,9 @@ export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
                     ? DINO_SIZE
                     : kind === 'trigger'
                       ? TRIGGER_SIZE
-                      : TERMINAL_SIZE
+                      : kind === 'files'
+                        ? FILES_SIZE
+                        : TERMINAL_SIZE
   return nodes
     .map((n) => {
       const kind: NodeKind = (n.type as NodeKind) ?? 'terminal'

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -11969,3 +11969,171 @@ body.focus-mode .dock:hover {
   font-size: 12px;
   color: var(--danger);
 }
+
+/* ── File manager node ─────────────────────────────────────────────────────────────────────
+   A directory listing pinned to the canvas. Shaped like the sticky note (card + grab header)
+   rather than the terminal, because it is content you arrange, not a session you attach to. */
+.files-node {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: rgba(var(--card-rgb), 0.96);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, calc(0.35 * var(--shadow-k)));
+}
+
+.files-node.selected {
+  box-shadow: 0 0 0 1px var(--accent), 0 8px 28px rgba(0, 0, 0, calc(0.4 * var(--shadow-k)));
+}
+
+.files-node__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  cursor: grab;
+  flex-shrink: 0;
+}
+
+.files-node__chip {
+  font-size: 10px;
+  letter-spacing: 0.4px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: rgba(var(--tint-rgb), 0.12);
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.files-node__btn {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.files-node__btn:hover:not(:disabled) {
+  background: rgba(var(--tint-rgb), 0.1);
+  color: var(--text);
+}
+.files-node__btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+/* The breadcrumb is one line and never wraps: a two-line path would push the listing down on
+   every navigation, and the listing is the thing the node exists to show. Deep paths are
+   collapsed upstream (see `breadcrumbs`), so this only has to refuse to grow. */
+.files-node__crumbs {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  padding: 0 8px 4px;
+  font-size: 11px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.files-node__crumb-wrap {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.files-node__sep {
+  opacity: 0.4;
+  margin: 0 2px;
+}
+
+.files-node__crumb {
+  background: none;
+  border: none;
+  padding: 1px 2px;
+  color: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  border-radius: 3px;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.files-node__crumb:hover {
+  color: var(--text);
+  background: rgba(var(--tint-rgb), 0.1);
+}
+
+.files-node__filter {
+  margin: 0 8px 6px;
+  padding: 3px 7px;
+  background: rgba(var(--tint-rgb), 0.06);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 12px;
+  outline: none;
+  flex-shrink: 0;
+}
+.files-node__filter:focus {
+  border-color: var(--accent);
+}
+
+.files-node__list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 4px 6px;
+  min-height: 0;
+}
+
+.files-node__row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 6px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text);
+}
+.files-node__row:hover {
+  background: rgba(var(--tint-rgb), 0.08);
+}
+/* Dimmed exactly like the Explorer drawer dims them — same fact (`DirEntry.ignored`), so it must
+   read the same way in both places. */
+.files-node__row.is-ignored {
+  opacity: 0.45;
+}
+
+.files-node__glyph {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+
+.files-node__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.files-node__empty {
+  padding: 10px 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.files-node__empty--error {
+  color: var(--danger);
+}
+
+.files-node.collapsed .files-node__header {
+  border-bottom: none;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -272,7 +272,7 @@ export interface RecycledInfo {
 // 'subagent' and 'loop' are render-only (ephemeral hook-driven viz) and never persisted.
 // 'trigger' is a first-class PERSISTED kind (issue #493) — the canvas-owned schedule node; its
 // spec rides `CanvasNodeState.trigger` and is sanitized on every load path (@shared/trigger).
-export type NodeKind = 'terminal' | 'sticky' | 'group' | 'editor' | 'diff' | 'video' | 'web' | 'browser' | 'subagent' | 'loop' | 'dino' | 'trigger'
+export type NodeKind = 'terminal' | 'sticky' | 'group' | 'editor' | 'diff' | 'video' | 'web' | 'browser' | 'files' | 'subagent' | 'loop' | 'dino' | 'trigger'
 
 /** Persisted state of a single canvas node (terminal, sticky note, group frame, or editor). */
 /**

--- a/src/shared/worktree.test.ts
+++ b/src/shared/worktree.test.ts
@@ -342,12 +342,18 @@ describe('displacedByWorktree', () => {
     // Shares the prefix but is a sibling directory, not really inside the worktree.
     { id: 'editor-prefix', type: 'editor', data: { filePath: '/wt/feature/index.ts' } },
     { id: 'diff-in', type: 'diff', data: { cwd: wt, filePath: 'src/index.ts' } },
-    { id: 'diff-out', type: 'diff', data: { cwd: '/repo', filePath: 'src/index.ts' } }
+    { id: 'diff-out', type: 'diff', data: { cwd: '/repo', filePath: 'src/index.ts' } },
+    // File-manager nodes: displaced by PATH wherever they sit (they have no session to disturb),
+    // so one outside the group counts where a terminal outside it does not.
+    { id: 'files-in', type: 'files', parentId: 'g', data: { cwd: `${wt}/src` } },
+    { id: 'files-outside-group', type: 'files', data: { cwd: wt } },
+    { id: 'files-out', type: 'files', data: { cwd: '/repo' } },
+    { id: 'files-prefix', type: 'files', data: { cwd: '/wt/feature' } }
   ]
 
   it('collects every descendant terminal living in the worktree, nested ones included', () => {
     expect([...displacedByWorktree(nodes, 'g', wt)].sort()).toEqual(
-      ['diff-in', 'editor-in', 'nested', 'term'].sort()
+      ['diff-in', 'editor-in', 'files-in', 'files-outside-group', 'nested', 'term'].sort()
     )
   })
 
@@ -363,10 +369,23 @@ describe('displacedByWorktree', () => {
       'inner',
       'editor-out',
       'editor-prefix',
-      'diff-out'
+      'diff-out',
+      'files-out',
+      'files-prefix'
     ]) {
       expect(got.has(id)).toBe(false)
     }
+  })
+
+  // A file manager left pointing into a removed worktree shows "Could not read this folder"
+  // forever AND keeps the dead path in project.json — the same persisted-dead-path failure the
+  // terminal branch exists to prevent. It has no session, so unlike a terminal it is displaced
+  // wherever it sits, and it gets its cwd re-pointed rather than an editor's `fileMissing`.
+  it('collects a file-manager node by path, in the group or not', () => {
+    const got = displacedByWorktree(nodes, 'g', wt)
+    expect(got.has('files-in')).toBe(true)
+    expect(got.has('files-outside-group')).toBe(true)
+    expect(nodes.find((n) => n.id === 'files-outside-group')?.parentId).toBeUndefined()
   })
 
   it('collects an editor/diff node by path even though it has no parentId at all', () => {

--- a/src/shared/worktree.ts
+++ b/src/shared/worktree.ts
@@ -448,7 +448,9 @@ interface WorktreeNodeLike {
 /**
  * The nodes a worktree teardown DISPLACES: every descendant of the bound group that carries a
  * working directory (a terminal or a chat) inside the worktree path, PLUS any editor/diff node
- * anywhere on the canvas whose file lives inside it.
+ * anywhere on the canvas whose file lives inside it, PLUS any file-manager node anywhere whose
+ * directory is inside it (see the `files` branch for why its rule is the editor one, not the
+ * terminal one).
  *
  * BOTH teardown paths derive from this — Remove (which also ends their sessions and respawns them)
  * and a stale group's Unbind (which touches no process at all). Unbind is the documented recovery
@@ -482,6 +484,20 @@ export function displacedByWorktree(
   for (const n of nodes) {
     if (n.type === 'terminal') {
       if (!under.has(n.id)) continue
+      const cwd = typeof n.data?.cwd === 'string' ? n.data.cwd : undefined
+      if (isInsideDir(cwd, worktreePath)) out.add(n.id)
+    } else if (n.type === 'files') {
+      // Checked ANYWHERE on the canvas, like editor/diff and unlike terminal — the `under`
+      // restriction on terminals is there because displacing one RESPAWNS it, and a session the
+      // user rooted here by hand should not be restarted from under them. A file manager has no
+      // session: the directory it is showing is simply gone, wherever the node happens to sit, and
+      // resetting its cwd costs the user nothing. Left alone it would show "Could not read this
+      // folder" forever AND keep the dead path in project.json, which is the same persisted-dead-
+      // path failure the terminal branch above exists to prevent.
+      //
+      // It gets `cwd` reset rather than `fileMissing`: a directory CAN be re-pointed at the
+      // fallback, which is exactly why editor/diff get the flag instead — there is nothing
+      // sensible to re-point a dead FILE at.
       const cwd = typeof n.data?.cwd === 'string' ? n.data.cwd : undefined
       if (isInsideDir(cwd, worktreePath)) out.add(n.id)
     } else if (n.type === 'editor' || n.type === 'diff') {


### PR DESCRIPTION
## What

A `files` node: **one directory listing** (`data.cwd`, persisted), pinned to the canvas beside the
terminals working in it. Navigate (clickable breadcrumbs, up), filter, open, create a file or
folder, copy a path, reveal, and open a terminal in the folder shown.

## Why not just the Explorer drawer

The drawer is a single tree rooted at the project cwd, and it's modal in practice — it covers the
canvas and you close it to get back to work. That gives you one cursor and a lot of scrolling.
Several of these give you `src/renderer/nodes` open next to the agent editing it and another on
`docs/` — which is the same argument the app already makes about terminals versus tabs.

## It adds NO new IPC

Everything runs on the existing `FsApi` (`list` / `mkdir` / `exists` / `write`). That's why
Desktop, the Server Edition, SSH projects and relay tabs all work on day one, with nothing stubbed.

**Rename / move / delete are a deliberate v1 gap, not an oversight.** Each needs a leaf in
`core/fs-ops`, an IPC channel, preload, the ws-bridge, `main/ssh-fs` (remote quoting) and the relay
host-service, plus confirm dialogs and dangerous-path guards to meet the destructive-safety rules
in `CONTRIBUTING.md`. That's a separate change with separate risk, and I'd rather propose it on its
own than bury it in this one. Happy to write it as a follow-up if you want it.

## Decisions worth the review time

- **Which filesystem** is `EditorNode`'s decision, read the same way: `data.sshFs` → the project's
  host over the ControlMaster; otherwise the node's **own session api**. Reading it off
  `useSession()` rather than `window.nodeTerminal` is the entire reason a relay tab browses the
  machine its terminals are actually on.
- **Opening is delegated, never reimplemented.** A file dispatches `nodeterm:open-file` — the event
  `TerminalNode`'s Cmd+click links already use — so editor/video/image routing stays in Canvas's
  one `openFile`, and this node never grows a second opinion about what a `.png` is.
  `fileOpenTarget` decides only canvas-vs-OS, and a **remote listing never reaches the OS branch**:
  `shell.openPath` opens a path on *this* machine, so handing it a host path either does nothing
  or — if that path happens to exist locally too — opens an unrelated local file.
- **Four empty states stay four**: loading / could not read / the folder is empty / the filter
  matches nothing. An empty filter matches everything, so select-all + delete can't blank the
  listing.
- **The title tracks the folder only while `titleAuto` is unset** — the same contract an agent
  node's session name uses, so navigating never overwrites a name you typed.
- Creation is gated on `hasCwd` on every surface (pane menu, Dock, sidebar `+`, ⌘K, group menu).
  Inside a group frame it inherits a bound **worktree's** cwd via `cwdForNewNodeIn`, so a frame per
  branch also means a file tree per branch.

## One bug fixed that this would otherwise have shipped

A files node inside a **removed worktree** kept a dead path in `project.json` and showed "Could not
read this folder" forever — the same persisted-dead-path failure the terminal branch of
`displacedByWorktree` exists to prevent.

It's now caught **by path wherever it sits**, like an editor and unlike a terminal: the `under`
restriction on terminals is there because displacing one *respawns* it, and a session you rooted
somewhere by hand shouldn't restart under you. A files node has no session. And it gets its `cwd`
re-pointed rather than an editor's `fileMissing`, because a directory can be re-pointed and a dead
file can't.

## Surfaces

- **Desktop** and **Server Edition** — full, no new IPC.
- **Mobile** — N/A. *nodeterm mobile* attaches to tmux sessions over the transport protocol and has
  no canvas or file-browsing concept; adding one means extending that protocol. Flagging for
  @eneskirca rather than assuming.

## Testing

`npm run typecheck`, the full `vitest` suite, and a production build all pass.

I also **ran the app** (Electron under an isolated `--user-data-dir`, so no real workspace or tmux
server was touched): created the node from the pane menu, listed the project, navigated in and out,
filtered to a miss and back, opened a file (an editor node appeared), read the entry context menu,
and confirmed the node and its cwd survive a restart. **That run found a real defect** — a doubled
`/ /` in the root breadcrumb — which is fixed here.

The pure logic (`lib/filesNode.ts`) has its own tests, and I mutation-tested the new
`displacedByWorktree` branch to confirm it turns tests red when removed.

**Not verified:** the SSH and relay paths, and the Server Edition. All three are argued from the
code (no new IPC; the filesystem is picked exactly as `EditorNode` picks it), not exercised against
a real host, peer, or browser session.

Three `local-send-keys.realtmux` tests fail on my machine and fail identically on a clean `main` —
macOS's temp path exceeds the unix socket length limit. Unrelated to this change.
