### PR TITLE
feat(canvas): keyboard shortcut for Tidy canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1595,7 +1595,8 @@ again; the grace window was never the thing that was wrong.
   pane right-click = add nodes at cursor (terminal / Claude / sticky / open file) + select
   all + fit + **Tidy canvas** (`arrangeAllNodes` — packs every top-level node, including group
   frames as rigid units, into a non-overlapping grid via `arrangeNodes`, sorted by current
-  (y, x) so the pack roughly preserves reading order; mirrored in ⌘K as "Tidy canvas"; both
+  (y, x) so the pack roughly preserves reading order; mirrored in ⌘K as "Tidy canvas" and bound
+  to ⌘/Ctrl+Shift+A; both
   hidden below 2 top-level nodes, where it could only be a visual no-op that still writes
   `project.json`) + restart-idle-agents (the bulk in-place agent restart, mirrored in ⌘K; both
   hidden when the canvas holds no restartable agent node, where they could only report "0

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -5233,6 +5233,10 @@ export function Canvas() {
       } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
         e.preventDefault()
         toggleSessionsPin()
+      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'a') {
+        // arrangeAllNodes self-guards (kanban open, <2 top-level nodes) — no refusal needed here.
+        e.preventDefault()
+        arrangeAllNodes()
       } else if ((e.metaKey || e.ctrlKey) && e.key === '/') {
         e.preventDefault()
         setShortcutsOpen((v) => !v)
@@ -5304,7 +5308,7 @@ export function Canvas() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [toggleSessionsPin, switchProject, fitAll, zoomTo100])
+  }, [toggleSessionsPin, switchProject, fitAll, zoomTo100, arrangeAllNodes])
 
   // ⌘/Ctrl+0 on the DESKTOP never reaches the keydown handler above: Electron's default View menu
   // binds the accelerator to `resetZoom`, and a menu accelerator is handled before the page sees

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -52,7 +52,8 @@ function buildSections(dictationKeys: string[], dictationLabel: string): { title
         // where a browser insists on handling it too it means the same thing we do ("actual size")
         // instead of fighting us. Shift+1 is nobody else's key on any surface.
         { keys: ['⌘', '0'], label: 'Zoom to 100%' },
-        { keys: ['⇧', '1'], label: 'Fit view' }
+        { keys: ['⇧', '1'], label: 'Fit view' },
+        { keys: ['⌘', '⇧', 'A'], label: 'Tidy canvas' }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Binds ⌘/Ctrl+Shift+A to the "Tidy canvas" action (arrangeAllNodes, added in #275), alongside its existing pane-menu and ⌘K entries
- Added to the shortcuts panel (`?` / ⌘/) and CLAUDE.md
- Chord confirmed free (checked Canvas.tsx keydown dispatcher + main/menu-accelerator-intercepts.test.ts) — no collision with existing ⌘⇧C/E/G/B/L bindings or Electron's intercepted menu accelerators
- No new refusal logic: `arrangeAllNodes` already self-guards on kanban-open and <2 arrangeable nodes

## Test plan
- [x] `npm run typecheck` clean
- [ ] Manual click-through in dev app (not run this session — Electron desktop app)