### PR TITLE
feat(usage): add token-count display mode for context meters

### DIFF
--- a/src/main/notch-hud.ts
+++ b/src/main/notch-hud.ts
@@ -103,7 +103,7 @@ export interface NotchHudTunables {
   /** Expand the panel on hover (else click-only). */
   hoverExpand: boolean
   /** settings.usagePercentMode — how the rows' context percentages render ("42% used" / "58% left"). */
-  percentMode: 'used' | 'remaining'
+  percentMode: 'used' | 'remaining' | 'tokens'
 }
 
 /** Clamp a hand-editable width to something that can't push the capsule off the display. */
@@ -125,7 +125,7 @@ class NotchHudController {
 
   constructor(
     private deps: NotchHudDeps,
-    private tunables: { notchWidth: number; hoverExpand: boolean; percentMode: 'used' | 'remaining' }
+    private tunables: { notchWidth: number; hoverExpand: boolean; percentMode: 'used' | 'remaining' | 'tokens' }
   ) {
     this.onSetIgnoreMouse = (_e, ignore) => {
       // Ignore-mouse ON = click-through (the strip is transparent to the app beneath); OFF while the
@@ -243,7 +243,7 @@ class NotchHudController {
   }
 
   /** Apply live tunables and re-push, so a slider drag moves the capsule as you drag. */
-  setTunables(t: { notchWidth: number; hoverExpand: boolean; percentMode: 'used' | 'remaining' }): void {
+  setTunables(t: { notchWidth: number; hoverExpand: boolean; percentMode: 'used' | 'remaining' | 'tokens' }): void {
     this.tunables = { notchWidth: t.notchWidth, hoverExpand: t.hoverExpand, percentMode: t.percentMode }
     this.schedulePush()
   }

--- a/src/preload/hud.ts
+++ b/src/preload/hud.ts
@@ -40,7 +40,7 @@ export interface HudPush {
   /** Expand the panel on hover (settings.notchHoverExpand); false = click-only. */
   hoverExpand: boolean
   /** settings.usagePercentMode — how a row's context percentage renders ("42% used" / "58% left"). */
-  percentMode: 'used' | 'remaining'
+  percentMode: 'used' | 'remaining' | 'tokens'
 }
 
 export interface HudApi {

--- a/src/renderer/components/ContextMeter.tsx
+++ b/src/renderer/components/ContextMeter.tsx
@@ -1,14 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useContextWindow } from '../state/contextWindow'
 import { useSettings } from '../state/settings'
-import { barFillPercent, contextFillColor, formatModelLabel, formatTimeAgo, percentNumber, percentText } from '../lib/usageFormat'
-
-/** Humanize a token count: 48000 → "48k", 1_000_000 → "1M", 850 → "850". */
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${Number((n / 1_000_000).toFixed(1)).toString()}M`
-  if (n >= 1000) return `${Math.round(n / 1000)}k`
-  return String(n)
-}
+import { barFillPercent, contextFillColor, contextPillText, formatModelLabel, formatTimeAgo, formatTokensShort, percentText } from '../lib/usageFormat'
 
 /**
  * Per-Claude-node context-window meter. A small header pill (mini-bar + "NN%") that toggles
@@ -30,9 +23,10 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
   }, [open])
 
   if (!usage) return null
-  // The NUMBER honours the used/remaining display setting; the bar and its color stay keyed to
-  // context FILL, so the severity colors keep meaning the same thing in both modes (issue #78).
-  const pct = percentNumber(usage.usedPercent, percentMode)
+  // The NUMBER honours the used/remaining/tokens display setting; the bar and its color stay
+  // keyed to context FILL, so the severity colors keep meaning the same thing in every mode
+  // (issue #78).
+  const pillText = contextPillText(usage.usedTokens, usage.windowTokens, usage.usedPercent, percentMode)
   const color = contextFillColor(usage.usedPercent)
   const modelLabel = formatModelLabel(usage.model)
 
@@ -45,7 +39,7 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
             <div className="ctx-bar__fill" style={{ width: `${barFillPercent(usage.usedPercent, percentMode)}%`, background: color }} />
           </div>
           <div className="ctx-popover__meta">
-            ~{formatTokens(usage.usedTokens)} / {formatTokens(usage.windowTokens)} tokens
+            ~{formatTokensShort(usage.usedTokens)} / {formatTokensShort(usage.windowTokens)} tokens
           </div>
           <div className="ctx-popover__sub">
             {/* No model read ⇒ say nothing. This used to fall back to the literal 'claude', which
@@ -67,7 +61,7 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
         <span className="ctx-pill__bar">
           <span className="ctx-pill__fill" style={{ width: `${barFillPercent(usage.usedPercent, percentMode)}%`, background: color }} />
         </span>
-        <span className="ctx-pill__num">{pct}%</span>
+        <span className="ctx-pill__num">{pillText}</span>
       </button>
     </div>
   )

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -4,7 +4,7 @@ import type { SessionRowVM } from '../lib/sessionList'
 import { useContextWindow } from '../state/contextWindow'
 import { useSessionNaming } from '../state/sessionNaming'
 import { useSettings } from '../state/settings'
-import { contextFillColor, percentNumber, percentText } from '../lib/usageFormat'
+import { contextFillColor, contextPillText, percentText } from '../lib/usageFormat'
 
 export interface SessionRowProps {
   row: SessionRowVM
@@ -137,7 +137,7 @@ export function SessionRow({
               title={`Context window — ${percentText(usage.usedPercent, percentMode)}`}
               style={{ background: contextFillColor(usage.usedPercent) }}
             >
-              {percentNumber(usage.usedPercent, percentMode)}%
+              {contextPillText(usage.usedTokens, usage.windowTokens, usage.usedPercent, percentMode)}
             </span>
           )}
           <button

--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -34,7 +34,7 @@ const USAGE_HOVER_CLOSE_MS = 220
  * beside it; its color stays keyed to the TRUE remaining percentage via `severityColor`, so
  * severity red/yellow/green never flips meaning when the mode does.
  */
-function LimitRow({ limit, mode }: { limit: UsageLimit; mode: 'used' | 'remaining' }) {
+function LimitRow({ limit, mode }: { limit: UsageLimit; mode: 'used' | 'remaining' | 'tokens' }) {
   const left = 100 - limit.usedPercent
   const fill = barFillPercent(limit.usedPercent, mode)
   return (
@@ -110,7 +110,7 @@ function AccountUsageBlock({
   label: string
   email?: string
   u: ClaudeUsage | null
-  mode: 'used' | 'remaining'
+  mode: 'used' | 'remaining' | 'tokens'
   isDefault?: boolean
   onUse?: () => void
 }) {
@@ -146,7 +146,7 @@ function RemoteUsageBlock({
   onUse
 }: {
   row: RemoteAccountUsage
-  mode: 'used' | 'remaining'
+  mode: 'used' | 'remaining' | 'tokens'
   isDefault?: boolean
   onUse?: () => void
 }) {
@@ -186,7 +186,7 @@ function labelFor(provider: string): string {
   return providerLabel(provider, agentLabel)
 }
 
-function ProviderBlock({ u, mode }: { u: ProviderUsage; mode: 'used' | 'remaining' }) {
+function ProviderBlock({ u, mode }: { u: ProviderUsage; mode: 'used' | 'remaining' | 'tokens' }) {
   if (u.status === 'unavailable') return null
   const label = labelFor(u.provider)
   return (

--- a/src/renderer/components/settings/sections/UsageSection.tsx
+++ b/src/renderer/components/settings/sections/UsageSection.tsx
@@ -169,13 +169,14 @@ export function UsageSection({ isActive }: { isActive: boolean }): React.JSX.Ele
       <SearchableRow {...ROWS.percentMode}>
         <FieldRow
           label="Usage percentages"
-          description="Whether provider limits show the percentage used or remaining."
+          description="Whether provider limits and context meters show percentage used, percentage remaining, or (context meters only) raw token counts. Provider limits have no token count and fall back to Used."
           control={
             <SegmentedPill
               value={settings.usagePercentMode}
               options={[
                 { value: 'used', label: 'Used' },
-                { value: 'remaining', label: 'Remaining' }
+                { value: 'remaining', label: 'Remaining' },
+                { value: 'tokens', label: 'Tokens' }
               ]}
               onChange={(v) => update({ usagePercentMode: v })}
               ariaLabel="Usage percentage display"

--- a/src/renderer/hud/main.ts
+++ b/src/renderer/hud/main.ts
@@ -42,7 +42,7 @@ interface HudPush {
   notchCenterX: number
   hasNotch: boolean
   hoverExpand: boolean
-  percentMode?: 'used' | 'remaining'
+  percentMode?: 'used' | 'remaining' | 'tokens'
 }
 interface HudApi {
   onRows(cb: (push: HudPush) => void): () => void
@@ -80,7 +80,7 @@ let notchWidthPx = 168
 // Hover-to-expand (settings.notchHoverExpand). Off = the capsule only expands on click.
 let hoverExpand = true
 // settings.usagePercentMode — the same number/label the other context surfaces render (issue #78).
-let percentMode: 'used' | 'remaining' = 'remaining'
+let percentMode: 'used' | 'remaining' | 'tokens' = 'remaining'
 // Which subagent disclosures the user has opened (by nodeId), preserved across re-renders.
 const openSubs = new Set<string>()
 // The user clicked "+N more" — draw every pushed row instead of the first HUD_ROW_CAP. Reset when
@@ -452,7 +452,7 @@ function applyGeometry(push: HudPush): void {
   }
   if (typeof push.notchCenterX === 'number') rs.setProperty('--notch-center-x', `${push.notchCenterX}px`)
   if (typeof push.hoverExpand === 'boolean') hoverExpand = push.hoverExpand
-  if (push.percentMode === 'used' || push.percentMode === 'remaining') percentMode = push.percentMode
+  if (push.percentMode === 'used' || push.percentMode === 'remaining' || push.percentMode === 'tokens') percentMode = push.percentMode
   // No physical notch → draw a standalone floating pill instead of fusing to y=0.
   document.documentElement.classList.toggle('notchless', push.hasNotch === false)
 }

--- a/src/renderer/lib/usageFormat.ts
+++ b/src/renderer/lib/usageFormat.ts
@@ -84,24 +84,47 @@ export function severityColor(severity: string | null, leftPercent: number): str
   }
 }
 
-/** The percentage a limit renders as, honouring the used/remaining display setting. */
-export function percentText(usedPercent: number, mode: 'used' | 'remaining'): string {
-  return mode === 'used'
-    ? `${Math.round(usedPercent)}% used`
-    : `${Math.round(100 - usedPercent)}% left`
+/**
+ * The percentage a limit renders as, honouring the used/remaining/tokens display setting.
+ * 'tokens' has no meaning for a percent-only surface (provider quota limits carry no raw token
+ * count), so it folds to the 'used' wording there — never silently treated as 'remaining'.
+ */
+export function percentText(usedPercent: number, mode: 'used' | 'remaining' | 'tokens'): string {
+  return mode === 'remaining'
+    ? `${Math.round(100 - usedPercent)}% left`
+    : `${Math.round(usedPercent)}% used`
 }
 
 /** Compact form for the pill: the bare number, no suffix (the segment label follows it). */
-export function percentNumber(usedPercent: number, mode: 'used' | 'remaining'): number {
-  return Math.round(mode === 'used' ? usedPercent : 100 - usedPercent)
+export function percentNumber(usedPercent: number, mode: 'used' | 'remaining' | 'tokens'): number {
+  return Math.round(mode === 'remaining' ? 100 - usedPercent : usedPercent)
 }
 
 /**
- * Bar fill, honouring the used/remaining display setting — the fill tracks the same quantity as
- * the adjacent number, so "92% used" shows a nearly-full bar instead of a barely-visible sliver.
+ * Bar fill, honouring the used/remaining/tokens display setting — the fill tracks the same
+ * quantity as the adjacent number, so "92% used" shows a nearly-full bar instead of a
+ * barely-visible sliver. 'tokens' fills the same as 'used' (it just relabels the number).
  * Color is a separate call (`severityColor`/`barColor`) keyed to the true remaining percentage,
  * never to this value, so severity red/yellow/green doesn't flip meaning with the mode.
  */
-export function barFillPercent(usedPercent: number, mode: 'used' | 'remaining'): number {
-  return mode === 'used' ? usedPercent : 100 - usedPercent
+export function barFillPercent(usedPercent: number, mode: 'used' | 'remaining' | 'tokens'): number {
+  return mode === 'remaining' ? 100 - usedPercent : usedPercent
+}
+
+/** Humanize a token count: 48000 → "48k", 1_000_000 → "1M", 850 → "850". */
+export function formatTokensShort(n: number): string {
+  if (n >= 1_000_000) return `${Number((n / 1_000_000).toFixed(1)).toString()}M`
+  if (n >= 1000) return `${Math.round(n / 1000)}k`
+  return String(n)
+}
+
+/**
+ * Context-window pill text: token fraction in 'tokens' mode ("48k/200k"), else the percent
+ * number with no suffix (caller appends "%"). Only context-window surfaces (ContextMeter,
+ * SessionRow) have usedTokens/windowTokens to show; nothing else should call this.
+ */
+export function contextPillText(usedTokens: number, windowTokens: number, usedPercent: number, mode: 'used' | 'remaining' | 'tokens'): string {
+  return mode === 'tokens'
+    ? `${formatTokensShort(usedTokens)}/${formatTokensShort(windowTokens)}`
+    : `${percentNumber(usedPercent, mode)}%`
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1098,9 +1098,11 @@ export interface Settings {
   /** Ids of terminal node header buttons the user has hidden; empty = everything visible. Gated by
    *  HIDEABLE_HEADER_BUTTONS the same way. */
   hiddenHeaderButtons: string[]
-  /** Whether usage percentages render as consumed ("32% used") or remaining ("68% left").
-   *  'remaining' is the historical default; users coming from other tools expect 'used'. */
-  usagePercentMode: 'used' | 'remaining'
+  /** Whether usage percentages render as consumed ("32% used"), remaining ("68% left"), or raw
+   *  token counts ("48k/200k tokens" — context-window surfaces only; provider quota surfaces
+   *  have no token counts and fall back to 'used' display). 'remaining' is the historical
+   *  default; users coming from other tools expect 'used'. */
+  usagePercentMode: 'used' | 'remaining' | 'tokens'
   /** Which agent the ⌘⇧C shortcut / quick-add launches. Always a launchable builtin. */
   defaultAgent: AgentId
   /** The permission mode Claude TERMINAL (CLI) sessions START in — passed as `--permission-mode`


### PR DESCRIPTION
## Summary
- `settings.usagePercentMode` gains a third value, `'tokens'`, alongside `used`/`remaining`
- Context-window surfaces (canvas node pill, session sidebar chip) render it as a raw `48k/200k` fraction instead of a percentage, since "% left" was being read ambiguously as context-left vs some other left
- Provider quota pill (subscription limits, no token counts) falls back to `used` display in this mode
- Bar fill and severity color untouched — still keyed to used-percent

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/lib/usageFormat.test.ts src/renderer/components`
- [ ] Manual: Settings → Usage → "Usage percentages" → Tokens, check canvas node pill + sidebar chip