### PR TITLE
feat(browser): partition identity and the ownership ledger

### DIFF
--- a/docs/superpowers/probes/2026-08-browser-partition.md
+++ b/docs/superpowers/probes/2026-08-browser-partition.md
@@ -1,0 +1,56 @@
+# Probe — webview `partition` identity and discard/restore
+
+**Date:** 2026-08 · **Electron:** 42.8.1 (`package.json` `"electron": "^42.8.1"`) · **Platform:** Linux
+(headless, `xvfb`, `--no-sandbox`, `--disable-gpu`) · **S8 PR 4 Task 4.0**
+
+Two structural claims of the browser-control design were marked `[UNVERIFIED]` and neither had been
+run. This probe drives a **real Electron `<webview>`** (never a JSDOM/hand-rolled fixture, per global
+constraint 8): a real `BrowserWindow` with `webviewTag: true`, a real local HTTP origin
+(`http://127.0.0.1:<port>`, because `data:` URLs cannot hold cookies), real `session` cookie APIs,
+and real guest `document.cookie` reads. Harness: `scratchpad/s8probe/main.cjs`.
+
+## Results — the design HELD on all three
+
+### Probe A ([UNVERIFIED] 4) — is a `partition`-less `<webview>` really on `session.defaultSession`?
+
+**YES — genuinely shared with the app window, both directions.**
+
+- A cookie set in `session.defaultSession` (`appwin=1`) is visible as `document.cookie` in a
+  `partition`-less guest for the same origin.
+- A cookie set from *inside* the `partition`-less guest (`fromguest=1`) is then present in
+  `session.defaultSession.cookies.get()`.
+
+So §9's "…and the app's own window" clause is **correct and stays** — a partition-less (user-opened)
+browser node shares the exact jar the app window uses. This is precisely why agent-opened nodes must
+get their **own** named partition: a partition-less agent node would otherwise read whatever the user
+is already logged into.
+
+### Probe B ([UNVERIFIED] 3) — does a discarded+restored named-partition webview rejoin the same jar?
+
+**YES.** Logged in (`jar=B`) in a `persist:nt-agent-browser-probe` webview; unmounted the element
+(exactly what the memory saver does — `BrowserSurface` removes the `<webview>` to end the guest);
+remounted a fresh `<webview>` with the **same** named partition → `jar=B` is still sent.
+
+Consequence: the memory saver does **not** silently log the agent out on discard. **No stop-and-report.**
+Task 5.4's discard suppressor is therefore load-bearing for *state* (avoiding a reload flash / lease
+churn), **not** for correctness. A `persist:` partition is a durable, named session keyed by its name.
+
+### Probe C — is a `partition` *mutation* after attach ignored?
+
+**YES — ignored, silently (no throw).** A guest attached on `persist:nt-agent-browser-probe`
+(holding `jar=B`); after attach the element's `partition` attribute was mutated to
+`persist:nt-agent-browser-other` (an empty jar) and the guest reloaded → it **still** reports
+`jar=B`, i.e. it stayed on the original partition. Electron honours `partition` **only at attach**.
+
+This is the measured justification for Task 4.1 setting the node's `partition` **once at creation and
+never mutating it**: a post-attach mutation would be a no-op anyway, so the immutable field matches
+the platform's real behaviour instead of implying a control it does not have.
+
+## Raw measurement
+
+```
+PROBE_RESULT electronVersion "42.8.1"
+PROBE_RESULT probeA {"partitionlessGuestCookie":"appwin=1","appwinVisibleInPartitionless":true,"guestCookieInDefault":true}
+PROBE_RESULT probeB {"beforeDiscard":"jar=B","afterRestore":"jar=B","rejoinsSameJar":true}
+PROBE_RESULT probeC {"cookieAfterMutation":"jar=B","mutationThrew":false,"stillOnOriginalJar":true}
+```

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -217,7 +217,17 @@ class HookServer {
   /** Node ids the materialiser refuses to mint for (see `markNodeIdentityUnmintable`). */
   private unmintableNodes = new Set<string>()
   private controlHandler:
-    | ((cmd: { verb: string; nodeId: string; args: Record<string, string> }) => Promise<{
+    | ((cmd: {
+        verb: string
+        nodeId: string
+        args: Record<string, string>
+        // The caller's IDENTITY verdict for THIS request, decided at the gate above and passed on
+        // rather than re-derived in main. `true` only when the caller presented a per-node token
+        // this instance minted for this node id. The browser ownership ledger (PR 4 Task 4.3)
+        // claims a node ONLY when this is true — a `legacy`/warned caller opens a browser but owns
+        // nothing, so it can drive nothing. `browser-ownership-source.test.ts` guards the source.
+        verified: boolean
+      }) => Promise<{
         ok: boolean
         message?: string
         result?: unknown
@@ -536,7 +546,7 @@ class HookServer {
             return
           }
           const result = this.controlHandler
-            ? await this.controlHandler({ verb, nodeId, args })
+            ? await this.controlHandler({ verb, nodeId, args, verified: verdict === 'verified' })
             : { ok: false, error: 'control unavailable' }
           // Which note, not whether: an unmintable node warned with the restart line is sent round
           // the same loop the refusal path already knows better than to send it round.

--- a/src/core/workspace-files.test.ts
+++ b/src/core/workspace-files.test.ts
@@ -64,6 +64,41 @@ describe('projectToFile / fileToProject round-trip', () => {
   })
 })
 
+describe('browser partition is re-validated on the hostile load path', () => {
+  // project.json is git-shared, hand-editable and auto-adopted (constraint 10); `data.partition` is
+  // copied verbatim to <webview partition>. A stored partition survives fileToProject ONLY when it
+  // is exactly the jar THIS project (base.id) would mint — anything else drops to un-owned.
+  const browser = (partition?: string): CanvasNodeState =>
+    node({ id: 'browser-1', kind: 'browser', url: 'https://x.test/', ...(partition ? { partition } : {}) })
+
+  it("drops a FOREIGN project's jar — a cloned project.json cannot name persist:...-<victim>", () => {
+    const f = projectToFile(project({ nodes: [browser('persist:nt-agent-browser-victim')] }), 1, 'ts', 'file-id')
+    const back = fileToProject(f, { id: 'p-mine' })
+    // The webview would have received the victim's jar; it now gets none (default session).
+    expect(back.nodes[0].partition).toBeUndefined()
+  })
+
+  it('drops an UNSAFE storage-key string (not persist:...-<isSafeNodeId>)', () => {
+    for (const bad of ['persist:nt-agent-browser-../../x', 'evil', 'persist:nt-agent-browser-a b', '']) {
+      const f = projectToFile(project({ nodes: [browser(bad)] }), 1, 'ts', 'file-id')
+      expect(fileToProject(f, { id: 'p-mine' }).nodes[0].partition).toBeUndefined()
+    }
+  })
+
+  it('KEEPS the jar that THIS project would mint for itself (same-machine reload)', () => {
+    const own = 'persist:nt-agent-browser-p-mine'
+    const f = projectToFile(project({ nodes: [browser(own)] }), 1, 'ts', 'file-id')
+    expect(fileToProject(f, { id: 'p-mine' }).nodes[0].partition).toBe(own)
+  })
+
+  it('leaves a user-opened (partition-less) browser node and non-browser nodes untouched', () => {
+    const f = projectToFile(project({ nodes: [browser(), node({ id: 't1', partition: 'x' } as never)] }), 1, 'ts', 'file-id')
+    const back = fileToProject(f, { id: 'p-mine' })
+    expect(back.nodes[0].partition).toBeUndefined() // user-opened browser: stays absent
+    expect((back.nodes[1] as { partition?: string }).partition).toBe('x') // non-browser: not our concern
+  })
+})
+
 describe('per-project capability fields in the shared file', () => {
   it('a capability round-trips through projectToFile/fileToProject, and a non-literal-true does not', () => {
     const p = project({ agentBrowserControl: true })

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -9,6 +9,24 @@ import {
 } from '../shared/node-exec'
 import type { BridgeLink, CanvasNodeState, Project, ProjectKanban, Viewport, Workspace } from '../shared/types'
 import { projectCapabilityFields, readProjectCapabilities } from '../shared/project-capabilities'
+import { loadedAgentBrowserPartition } from '../shared/browser-partition'
+
+/**
+ * Drop a browser node's persisted `partition` unless it is exactly the jar THIS project (its
+ * machine-local id) would mint. `project.json` is hostile input and `partition` is copied straight
+ * to `<webview partition>`, so a foreign/cloned/unsafe stored value is jar forgery; it falls back to
+ * the un-owned default session. Non-browser nodes and un-partitioned browser nodes are untouched.
+ * See `loadedAgentBrowserPartition`. Pure and side-effect free (only clones the nodes it changes).
+ */
+function sanitizeBrowserPartitions(nodes: CanvasNodeState[], projectId: string): CanvasNodeState[] {
+  return nodes.map((n) => {
+    if (n.kind !== 'browser' || n.partition === undefined) return n
+    const safe = loadedAgentBrowserPartition(n.partition, projectId)
+    if (safe === n.partition) return n
+    const { partition: _dropped, ...rest } = n
+    return safe === undefined ? rest : { ...rest, partition: safe }
+  })
+}
 
 export const PROJECT_DIR = '.nodeterm'
 export const PROJECT_FILE = 'project.json'
@@ -256,8 +274,15 @@ export function fileToProject(
     color: f.color,
     viewport: base.viewport ?? f.viewport ?? framingViewport(f.nodes),
     // applyLocalNodeExec DROPS whatever the file carried in the exec fields (it is not ours) and
-    // re-attaches only what this machine typed. See @shared/node-exec.
-    nodes: applyLocalNodeExec(base.cwd ? resolveNodes(f.nodes, base.cwd) : f.nodes, base.localExec),
+    // re-attaches only what this machine typed. See @shared/node-exec. `sanitizeBrowserPartitions`
+    // is the same "the file is hostile input" treatment for a browser node's session jar: a stored
+    // `partition` survives only when it is exactly the one THIS project (base.id, machine-local)
+    // would mint — a foreign/cloned/unsafe one drops to un-owned default session. See
+    // loadedAgentBrowserPartition; without it a cloned project.json forges another project's jar.
+    nodes: sanitizeBrowserPartitions(
+      applyLocalNodeExec(base.cwd ? resolveNodes(f.nodes, base.cwd) : f.nodes, base.localExec),
+      base.id
+    ),
     ...(f.bridges ? { bridges: f.bridges } : {}),
     ...(f.ropes ? { ropes: f.ropes } : {}),
     ...(defaultAccountId ? { defaultAccountId } : {}),

--- a/src/main/browser-control-ledger.test.ts
+++ b/src/main/browser-control-ledger.test.ts
@@ -48,6 +48,15 @@ describe('BrowserControlLedger', () => {
     expect(l.get('browser-3', '')).toBe(null)
   })
 
+  it('claim refuses a blank projectId — a project-less entry is meaningless and would poison releaseByProject(\'\')', () => {
+    // Belt to main's wiring guard: if a future open-browser reply ever drops the project id, no
+    // ownership is recorded rather than an entry that releaseByProject('') would sweep.
+    const l = new BrowserControlLedger()
+    expect(l.claim('browser-3', entry({ projectId: '' }))).toBe(false)
+    expect(l.get('browser-3', 'claude-1')).toBe(null)
+    expect(l.releaseByProject('')).toEqual([])
+  })
+
   it('release drops ownership — a released id is undrivable and re-claimable', () => {
     const l = new BrowserControlLedger()
     l.claim('browser-3', entry({ ownerNodeId: 'claude-1' }))

--- a/src/main/browser-control-ledger.test.ts
+++ b/src/main/browser-control-ledger.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { BrowserControlLedger, type AgentBrowserEntry } from './browser-control-ledger'
+
+function entry(over: Partial<AgentBrowserEntry> = {}): AgentBrowserEntry {
+  return {
+    ownerNodeId: 'claude-1',
+    projectId: 'p-1',
+    partition: 'persist:nt-agent-browser-p-1',
+    navGeneration: 0,
+    leaseActiveUntil: 0,
+    openedAt: 1,
+    ...over
+  }
+}
+
+describe('BrowserControlLedger', () => {
+  it('get() requires the SAME owner, and a stranger is indistinguishable from absent', () => {
+    // Rule from S8's requireTab, adopted verbatim: the identical answer for "does not exist" and
+    // "exists but is not yours". A different message is a node-enumeration oracle.
+    const l = new BrowserControlLedger()
+    l.claim('browser-3', entry({ ownerNodeId: 'claude-1' }))
+    expect(l.get('browser-3', 'claude-2')).toBe(null)
+    expect(l.get('browser-9', 'claude-2')).toBe(null)
+  })
+
+  it('get() returns the entry ONLY for the owner that opened it', () => {
+    const l = new BrowserControlLedger()
+    l.claim('browser-3', entry({ ownerNodeId: 'claude-1' }))
+    expect(l.get('browser-3', 'claude-1')?.ownerNodeId).toBe('claude-1')
+  })
+
+  it('a second claim on a live id is refused — there is NO handoff, claim or transfer', () => {
+    // S8 had claimUserTab. Dropped: an agent drives only what it itself opened, and there is no
+    // verb by which the user's own browsing becomes an agent's. Deleting the feature also deletes
+    // S8's child-session-invalidation-on-handoff case.
+    const l = new BrowserControlLedger()
+    expect(l.claim('browser-3', entry({ ownerNodeId: 'claude-1' }))).toBe(true)
+    expect(l.claim('browser-3', entry({ ownerNodeId: 'claude-2' }))).toBe(false)
+    // The original owner still owns it; the second claimant owns nothing.
+    expect(l.get('browser-3', 'claude-1')?.ownerNodeId).toBe('claude-1')
+    expect(l.get('browser-3', 'claude-2')).toBe(null)
+  })
+
+  it('claim refuses a blank browser id or a blank owner — there is no anonymous owner', () => {
+    const l = new BrowserControlLedger()
+    expect(l.claim('', entry())).toBe(false)
+    expect(l.claim('browser-3', entry({ ownerNodeId: '' }))).toBe(false)
+    expect(l.get('browser-3', '')).toBe(null)
+  })
+
+  it('release drops ownership — a released id is undrivable and re-claimable', () => {
+    const l = new BrowserControlLedger()
+    l.claim('browser-3', entry({ ownerNodeId: 'claude-1' }))
+    l.release('browser-3')
+    expect(l.get('browser-3', 'claude-1')).toBe(null)
+    // Re-claimable by anyone now (its session ended); ownership is not sticky past release.
+    expect(l.claim('browser-3', entry({ ownerNodeId: 'claude-2' }))).toBe(true)
+  })
+
+  it('releaseByOwner / releaseByProject / releaseAll return what they released, for detach', () => {
+    const l = new BrowserControlLedger()
+    l.claim('b-1', entry({ ownerNodeId: 'claude-1', projectId: 'p-1' }))
+    l.claim('b-2', entry({ ownerNodeId: 'claude-1', projectId: 'p-2' }))
+    l.claim('b-3', entry({ ownerNodeId: 'claude-9', projectId: 'p-2' }))
+
+    expect(l.releaseByOwner('claude-1').sort()).toEqual(['b-1', 'b-2'])
+    // b-1/b-2 gone, b-3 remains.
+    expect(l.get('b-1', 'claude-1')).toBe(null)
+    expect(l.get('b-3', 'claude-9')?.projectId).toBe('p-2')
+
+    expect(l.releaseByProject('p-2')).toEqual(['b-3'])
+    expect(l.get('b-3', 'claude-9')).toBe(null)
+
+    l.claim('b-4', entry({ ownerNodeId: 'claude-1' }))
+    expect(l.releaseAll()).toEqual(['b-4'])
+    expect(l.releaseAll()).toEqual([])
+  })
+
+  it('activeLeases reports only nodes whose lease is live at now, with their owner', () => {
+    const l = new BrowserControlLedger()
+    l.claim('b-live', entry({ ownerNodeId: 'claude-1', leaseActiveUntil: 0 }))
+    l.claim('b-dead', entry({ ownerNodeId: 'claude-2', leaseActiveUntil: 0 }))
+    l.touchLease('b-live', 1000)
+    l.touchLease('b-missing', 5000) // no-op: unclaimed
+    expect(l.activeLeases(500)).toEqual([{ browserNodeId: 'b-live', ownerNodeId: 'claude-1' }])
+    // Exactly AT the deadline the lease has lapsed — `until > now`, not `>=` (a lease is live up to
+    // but not including its expiry, or a stale lease leaks one tick past its end).
+    expect(l.activeLeases(1000)).toEqual([])
+    // And well after.
+    expect(l.activeLeases(2000)).toEqual([])
+  })
+
+  it('nothing is persisted: a fresh ledger owns nothing', () => {
+    // Ownership does not survive a restart, by design. See the ropes test in Task 4.4 for why.
+    expect(new BrowserControlLedger().get('browser-3', 'claude-1')).toBe(null)
+  })
+
+  it('claim stores a COPY — mutating the caller\'s entry afterwards cannot rewrite ownership', () => {
+    // The owner arriving by reference would let a later caller flip ownerNodeId post-claim.
+    const l = new BrowserControlLedger()
+    const e = entry({ ownerNodeId: 'claude-1' })
+    l.claim('browser-3', e)
+    e.ownerNodeId = 'claude-evil'
+    expect(l.get('browser-3', 'claude-1')?.ownerNodeId).toBe('claude-1')
+    expect(l.get('browser-3', 'claude-evil')).toBe(null)
+  })
+})

--- a/src/main/browser-control-ledger.ts
+++ b/src/main/browser-control-ledger.ts
@@ -48,10 +48,12 @@ export class BrowserControlLedger {
    * Record ownership of a freshly opened browser node. Returns false — and changes NOTHING — if the
    * id is already claimed: there is NO handoff, claim or transfer (S8's `claimUserTab` is dropped),
    * so a live browser node's owner never changes and the user's own browsing never becomes an
-   * agent's. A blank `browserNodeId` or `ownerNodeId` is refused (there is no anonymous owner).
+   * agent's. A blank `browserNodeId`, `ownerNodeId` or `projectId` is refused: there is no anonymous
+   * owner, and a project-less entry is meaningless (it would also make `releaseByProject('')` match
+   * it) — the belt to main's wiring guard against a future reply-shape that drops the project id.
    */
   claim(browserNodeId: string, e: AgentBrowserEntry): boolean {
-    if (!browserNodeId || !e.ownerNodeId) return false
+    if (!browserNodeId || !e.ownerNodeId || !e.projectId) return false
     if (this.entries.has(browserNodeId)) return false
     this.entries.set(browserNodeId, { ...e })
     return true

--- a/src/main/browser-control-ledger.ts
+++ b/src/main/browser-control-ledger.ts
@@ -1,0 +1,114 @@
+/**
+ * Who may drive which browser node, for THIS APP RUN ONLY.
+ *
+ * IN MEMORY, IN MAIN, NEVER PERSISTED, AND NEVER READ FROM project.json. The obvious
+ * implementation — "the agent may drive the browser node it opened, so read the rope" — is the same
+ * supply-chain class as bypassPermissions, which the owner already ruled out for exactly this
+ * reason. `Project.ropes` is documented as DISPLAY-ONLY but PERSISTED (shared/types.ts), so a
+ * hostile cloned project.json can ship a pre-declared rope from claude-1 to browser-1, and any
+ * ownership check that reads `ropes` grants on it. `browser-ownership-source.test.ts` (Task 4.4)
+ * fails if any ownership path ever reads `ropes`.
+ *
+ * The cost is real and is paid deliberately: browser control does not survive an app restart. An
+ * agent mid-task across a restart must open-browser again and log in again.
+ *
+ * Only a successful `open-browser` from a VERIFIED caller creates an entry (`claim`, called on the
+ * renderer's `{ id }` reply, gated on the request's `verified` verdict in main). A node the user
+ * opened is never in here and is therefore invisible and undrivable — including the "New browser"
+ * menu item, a pop-up captured from a user-opened node, and EVERY browser node restored from
+ * project.json at load. Kept from S8, which had this one property right.
+ *
+ * This is the browser sibling of `core/agents/pane-ownership.ts` (messaging's runtime ledger): same
+ * shape, same fail-closed lessons — record at CREATE from a non-forgeable source (main's own
+ * `verified` verdict, not the file), an absent entry and a disagreement are both REFUSED, and
+ * `get` deliberately cannot distinguish "not yours" from "does not exist". It lives in `src/main`,
+ * not `src/core`, because its clients are Electron-adjacent (webContents leases, PR 5/6) and it is
+ * never needed on the Server Edition, where browser control cannot exist.
+ */
+
+export interface AgentBrowserEntry {
+  /** The agent node that ran open-browser. Drives are admitted only for THIS owner. */
+  ownerNodeId: string
+  /** The project that owned the open. */
+  projectId: string
+  /** The session jar the guest attached on (`persist:nt-agent-browser-<projectId>`). */
+  partition: string
+  /** Bumped by Page.frameNavigated; invalidates every @ref (PR 5 Task 5.5). */
+  navGeneration: number
+  /** Drives the indicator (PR 6) and the discard suppression (PR 5 Task 5.4). */
+  leaseActiveUntil: number
+  openedAt: number
+}
+
+export class BrowserControlLedger {
+  /** browserNodeId → its ownership entry, for browser nodes an agent opened THIS run. */
+  private readonly entries = new Map<string, AgentBrowserEntry>()
+
+  /**
+   * Record ownership of a freshly opened browser node. Returns false — and changes NOTHING — if the
+   * id is already claimed: there is NO handoff, claim or transfer (S8's `claimUserTab` is dropped),
+   * so a live browser node's owner never changes and the user's own browsing never becomes an
+   * agent's. A blank `browserNodeId` or `ownerNodeId` is refused (there is no anonymous owner).
+   */
+  claim(browserNodeId: string, e: AgentBrowserEntry): boolean {
+    if (!browserNodeId || !e.ownerNodeId) return false
+    if (this.entries.has(browserNodeId)) return false
+    this.entries.set(browserNodeId, { ...e })
+    return true
+  }
+
+  /**
+   * The entry IF this exact owner opened this exact node this run, else null. The answer for "does
+   * not exist" and "exists but is not yours" is IDENTICAL by design (both null): a distinct message
+   * would be a node-enumeration oracle. Rule adopted verbatim from S8's requireTab.
+   */
+  get(browserNodeId: string, ownerNodeId: string): AgentBrowserEntry | null {
+    const entry = this.entries.get(browserNodeId)
+    if (!entry || entry.ownerNodeId !== ownerNodeId) return null
+    return entry
+  }
+
+  /** Drop one node's ownership — its session is ending. Undrivable again until a fresh claim. */
+  release(browserNodeId: string): void {
+    this.entries.delete(browserNodeId)
+  }
+
+  /** Release every node this owner opened (the owner node was deleted/detached); returns their ids. */
+  releaseByOwner(ownerNodeId: string): string[] {
+    return this.releaseWhere((e) => e.ownerNodeId === ownerNodeId)
+  }
+
+  /** Release every node opened under this project (the project closed); returns their ids. */
+  releaseByProject(projectId: string): string[] {
+    return this.releaseWhere((e) => e.projectId === projectId)
+  }
+
+  /** Release everything (app teardown); returns every released id. */
+  releaseAll(): string[] {
+    return this.releaseWhere(() => true)
+  }
+
+  /** Extend a node's lease (drives the indicator + discard suppression). No-op if unclaimed. */
+  touchLease(browserNodeId: string, until: number): void {
+    const entry = this.entries.get(browserNodeId)
+    if (entry) entry.leaseActiveUntil = until
+  }
+
+  /** Nodes whose lease is still live at `now` — the indicator (PR 6) and discard-suppression set. */
+  activeLeases(now: number): { browserNodeId: string; ownerNodeId: string }[] {
+    const live: { browserNodeId: string; ownerNodeId: string }[] = []
+    for (const [browserNodeId, e] of this.entries) {
+      if (e.leaseActiveUntil > now) live.push({ browserNodeId, ownerNodeId: e.ownerNodeId })
+    }
+    return live
+  }
+
+  private releaseWhere(pred: (e: AgentBrowserEntry) => boolean): string[] {
+    const released: string[] = []
+    for (const [browserNodeId, e] of this.entries) {
+      if (pred(e)) released.push(browserNodeId)
+    }
+    for (const id of released) this.entries.delete(id)
+    return released
+  }
+}

--- a/src/main/browser-ownership-source.test.ts
+++ b/src/main/browser-ownership-source.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { BrowserControlLedger } from './browser-control-ledger'
+import { projectToFile, fileToProject, serializeProjectFile } from '../core/workspace-files'
+import type { Project } from '@shared/types'
+
+// Ownership of an agent-opened browser node is decided ONLY by the in-memory ledger a `verified`
+// open-browser filled THIS app run. It is NEVER read from `Project.ropes`, which is documented
+// display-only but IS persisted and git-shared — so a cloned project.json can ship the exact lineage
+// (`claude-1 -> browser-1`) an ownership check that trusted ropes would grant on.
+
+function projectWithHostileRope(): Project {
+  return {
+    id: 'p-local-1',
+    name: 'Web',
+    color: '#0a84ff',
+    cwd: '/tmp/repo',
+    viewport: { x: 0, y: 0, zoom: 1 },
+    nodes: [
+      { id: 'claude-1', kind: 'terminal', title: 'A', position: { x: 0, y: 0 }, agentId: 'claude' },
+      { id: 'browser-1', kind: 'browser', title: 'B', position: { x: 0, y: 300 }, url: 'https://x.test/' }
+    ] as unknown as Project['nodes'],
+    // The attack: a pre-declared rope that says claude-1 opened browser-1.
+    ropes: [{ id: 'r1', source: 'claude-1', target: 'browser-1' }]
+  } as Project
+}
+
+describe('ownership is never read out of Project.ropes — behavioural', () => {
+  it('a pre-declared rope grants nothing on a freshly loaded project (empty ledger)', () => {
+    const project = projectWithHostileRope()
+    // The rope really is present — this is a genuine, persisted attack input, not a strawman.
+    expect(project.ropes).toEqual([{ id: 'r1', source: 'claude-1', target: 'browser-1' }])
+
+    // The ledger every run starts empty; nothing claimed browser-1 this run.
+    const ledger = new BrowserControlLedger()
+    expect(ledger.get('browser-1', 'claude-1')).toBe(null)
+    expect(ledger.get('browser-1', 'claude-2')).toBe(null)
+    expect(ledger.activeLeases(Date.now())).toEqual([])
+  })
+
+  it('the rope survives a save/reload round-trip, and STILL grants nothing', () => {
+    // Prove the rope is durable (a hostile clone keeps it across the file boundary), and that the
+    // ledger — which never consulted the project — is unaffected either way.
+    const project = projectWithHostileRope()
+    const file = projectToFile(project, 1, new Date().toISOString(), project.id)
+    const reparsed = JSON.parse(serializeProjectFile(file))
+    const reloaded = fileToProject(reparsed, { id: project.id, cwd: project.cwd })
+
+    expect(reloaded.ropes).toEqual([{ id: 'r1', source: 'claude-1', target: 'browser-1' }])
+
+    const ledger = new BrowserControlLedger()
+    expect(ledger.get('browser-1', 'claude-1')).toBe(null)
+
+    // Only a real claim (a verified open-browser) grants — and only to the claimant, never to the
+    // owner the rope names when they differ.
+    ledger.claim('browser-1', {
+      ownerNodeId: 'claude-9',
+      projectId: reloaded.id,
+      partition: 'persist:nt-agent-browser-p-local-1',
+      navGeneration: 0,
+      leaseActiveUntil: 0,
+      openedAt: Date.now()
+    })
+    expect(ledger.get('browser-1', 'claude-1')).toBe(null) // the rope's claimed owner: still nothing
+    expect(ledger.get('browser-1', 'claude-9')?.ownerNodeId).toBe('claude-9') // the real claimant
+  })
+})
+
+/**
+ * A structural assertion on purpose. The behavioural half above proves the current code does not
+ * read ropes; this half is what fails when someone ADDS the read, which is the realistic future —
+ * "the rope already says who opened it" is a genuinely tempting one-liner. Same enforcement style
+ * as hook-verified-parity.test.ts.
+ */
+describe('ownership is never read out of Project.ropes — structural', () => {
+  const root = path.resolve(__dirname, '..', '..')
+
+  /** Strip block + line comments only (NOT string literals — `project['ropes']` is a real read and
+   *  must still trip the check). The ledger's own doc comment explains why ropes is refused; that
+   *  explanation lives in a comment and is correctly removed here. */
+  function stripComments(src: string): string {
+    return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+  }
+
+  function browserSurfaceSources(): { name: string; code: string }[] {
+    const out: { name: string; code: string }[] = []
+
+    // 1. Every main-side browser-*.ts (the ledger + the guest registry), excluding tests.
+    const mainDir = path.join(root, 'src', 'main')
+    for (const f of fs.readdirSync(mainDir)) {
+      if (/^browser-.*\.ts$/.test(f) && !f.endsWith('.test.ts')) {
+        out.push({ name: `src/main/${f}`, code: fs.readFileSync(path.join(mainDir, f), 'utf8') })
+      }
+    }
+
+    // 2. The renderer's `open-browser` dispatch block only — the whole of Canvas.tsx legitimately
+    //    draws ropes (control edges), so we scope to the case that opens a browser + records it.
+    const canvas = fs.readFileSync(path.join(root, 'src', 'renderer', 'canvas', 'Canvas.tsx'), 'utf8')
+    const disp = canvas.slice(canvas.indexOf("case 'open-browser'"), canvas.indexOf("case 'group'"))
+    expect(disp).toContain('open-browser: ') // guard: the slice actually captured the dispatch
+    out.push({ name: 'Canvas open-browser dispatch', code: disp })
+
+    // 3. The main-side claim wiring in index.ts (the setControlHandler open-browser claim block).
+    const index = fs.readFileSync(path.join(root, 'src', 'main', 'index.ts'), 'utf8')
+    const start = index.indexOf("if (verb === 'open-browser' && verified")
+    expect(start).toBeGreaterThan(-1) // guard: the claim block is where the test expects
+    out.push({ name: 'main open-browser claim', code: index.slice(start, start + 900) })
+
+    return out
+  }
+
+  it('no ownership-surface source references the identifier `ropes`', () => {
+    for (const { name, code } of browserSurfaceSources()) {
+      expect(/\bropes\b/.test(stripComments(code)), `${name} must not read ropes`).toBe(false)
+    }
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2360,10 +2360,14 @@ app.whenReady().then(async () => {
     // browser-ownership-source.test.ts (ownership is NEVER read from Project.ropes).
     if (verb === 'open-browser' && verified && result.ok) {
       const opened = result.result as { id?: string; projectId?: string; partition?: string } | undefined
-      if (opened?.id && opened.partition) {
+      // Refuse to record an entry with no owning project: `releaseByProject('')` would match it, and
+      // a project-less ownership record is meaningless. Fail-closed against future reply-shape drift
+      // — today `partition` is present only when agentBrowserPartition(projectId) succeeded, so a
+      // non-empty safe projectId always rides with it.
+      if (opened?.id && opened.partition && opened.projectId) {
         browserLedger.claim(opened.id, {
           ownerNodeId: nodeId,
-          projectId: opened.projectId ?? '',
+          projectId: opened.projectId,
           partition: opened.partition,
           navGeneration: 0,
           leaseActiveUntil: 0,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,7 @@ const logBuffer = new LogBuffer()
 installLogSink(logBuffer)
 import { writeFilesToClipboard } from './clipboard-files'
 import { allowGuestNavigation } from './webview-nav'
+import { BrowserControlLedger } from './browser-control-ledger'
 import { registerFsHandlers } from '../core/fs-handlers'
 import { LogBuffer } from '../core/log-buffer'
 import { installLogSink, splitTag } from '../core/log-sink'
@@ -2322,6 +2323,9 @@ app.whenReady().then(async () => {
       timer: NodeJS.Timeout
     }
   >()
+  // Who owns which agent-opened browser node, THIS app run only. In-memory, never persisted, never
+  // read from project.json (Task 4.3/4.4). Consumed by PR 5 (attach/lease), PR 6 (indicator/Stop).
+  const browserLedger = new BrowserControlLedger()
   ipcMain.on(
     IPC.agentControlResult,
     (
@@ -2335,11 +2339,11 @@ app.whenReady().then(async () => {
       pending.resolve(payload)
     }
   )
-  hookServer.setControlHandler(async ({ verb, nodeId, args }) => {
+  hookServer.setControlHandler(async ({ verb, nodeId, args, verified }) => {
     const target = getMainWindow()
     if (!target) return { ok: false, error: 'window unavailable' }
     const requestId = randomUUID()
-    return await new Promise((resolve) => {
+    const result = await new Promise<{ ok: boolean; message?: string; result?: unknown; error?: string }>((resolve) => {
       const timer = setTimeout(() => {
         pendingControl.delete(requestId)
         resolve({ ok: false, error: 'timed out (no response / not confirmed)' })
@@ -2347,6 +2351,27 @@ app.whenReady().then(async () => {
       pendingControl.set(requestId, { resolve, timer })
       target.webContents.send(IPC.agentControl, { requestId, sourceNodeId: nodeId, verb, args })
     })
+    // Record browser ownership the moment an open-browser succeeds — and ONLY when the caller's
+    // identity verdict for THIS request was `verified` (main's own verdict, not anything off the
+    // wire or project.json). A `legacy`/warned caller may open a browser but owns nothing, so it
+    // can drive nothing. The owner is the verified caller (`nodeId`); the project id + partition
+    // ride along from the renderer's reply for release-by-project and the indicator. This is the
+    // browser sibling of pane-ownership's record-at-fresh-spawn. See browser-control-ledger.ts and
+    // browser-ownership-source.test.ts (ownership is NEVER read from Project.ropes).
+    if (verb === 'open-browser' && verified && result.ok) {
+      const opened = result.result as { id?: string; projectId?: string; partition?: string } | undefined
+      if (opened?.id && opened.partition) {
+        browserLedger.claim(opened.id, {
+          ownerNodeId: nodeId,
+          projectId: opened.projectId ?? '',
+          partition: opened.partition,
+          navGeneration: 0,
+          leaseActiveUntil: 0,
+          openedAt: Date.now()
+        })
+      }
+    }
+    return result
   })
   initMediaProtocol()
 

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -6960,7 +6960,11 @@ export function Canvas() {
               return
             }
             const id = addAndConnect(createBrowserNode(nodesRef.current.length, browserUrl, placeBelow(), partition))
-            reply({ ok: true, message: `opened browser ${id}`, result: { id } })
+            // Return the project id + partition so main can record ownership in its in-memory
+            // ledger (browser-control-ledger.ts). Main gates the claim on its OWN `verified` verdict
+            // and keys it to the verified caller — these fields are descriptive (release-by-project,
+            // the indicator), never the authorization boundary.
+            reply({ ok: true, message: `opened browser ${id}`, result: { id, projectId: ctlProject?.id, partition } })
             return
           }
           case 'group': {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -217,6 +217,7 @@ import { buildHibernationCandidates } from '../lib/hibernationCandidates'
 import { applyLoopDismiss } from '../lib/loopCard'
 import { prepareQuickOpenFiles, type QuickOpenIndexedFile } from '../lib/quickOpenSearch'
 import { isSafeQuickOpenRelPath } from '@shared/quick-open-filter'
+import { agentBrowserPartition } from '@shared/browser-partition'
 
 /** The real `sshProject.connect`, bound once. Passed into `connectHostAttachment` rather than
  *  reached for inside it, so that helper stays testable without an Electron preload. */
@@ -585,6 +586,7 @@ function toKanbanSession(n: CanvasNode): KanbanSession | null {
       color: (n.data.color as string) ?? NODE_COLORS[0],
       kind: 'browser',
       url: n.data.url as string | undefined,
+      partition: n.data.partition as string | undefined,
       spawn: {}
     }
   }
@@ -6947,7 +6949,17 @@ export function Canvas() {
               reply({ ok: false, error: 'open-browser requires a valid http(s) --url' })
               return
             }
-            const id = addAndConnect(createBrowserNode(nodesRef.current.length, browserUrl, placeBelow()))
+            // An agent-opened browser gets its OWN per-project session jar — never the default
+            // session the user's own browsing lives in (Probe A: a partition-less <webview> shares
+            // session.defaultSession). The project id becomes a persisted storage key, so it must
+            // pass isSafeNodeId; agentBrowserPartition returns null when it does not, and we refuse
+            // the open rather than fall back to the shared jar (fail-closed).
+            const partition = agentBrowserPartition(ctlProject?.id ?? '')
+            if (!partition) {
+              reply({ ok: false, error: "open-browser: this project's id cannot be used as a browser session key" })
+              return
+            }
+            const id = addAndConnect(createBrowserNode(nodesRef.current.length, browserUrl, placeBelow(), partition))
             reply({ ok: true, message: `opened browser ${id}`, result: { id } })
             return
           }

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -270,6 +270,7 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
                     key={session.id}
                     nodeId={session.id}
                     url={session.url ?? ''}
+                    partition={session.partition}
                     onUrlChange={(u) => onBrowserNav({ url: u })}
                     onTitleChange={(t) => onBrowserNav({ title: t })}
                   />

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -43,6 +43,9 @@ export interface KanbanSession {
   textUpdatedBy?: string
   /** Browser node URL (kind 'browser' only) — shown on the card, opened in the modal webview. */
   url?: string
+  /** Browser node session partition (kind 'browser' only) — threaded to the modal webview so it
+   *  shares the canvas node's jar (`browser-partition-parity.test.tsx`). Absent = default session. */
+  partition?: string
   /** The subset of the node's `data` the card modal's co-attach terminal needs to spawn/join the
    *  same session (kind 'terminal' only; sticky passes `{}`). */
   spawn: ModalSpawn

--- a/src/renderer/nodes/BrowserNode.tsx
+++ b/src/renderer/nodes/BrowserNode.tsx
@@ -45,6 +45,7 @@ export default function BrowserNode({ id, data, selected }: NodeProps<CanvasNode
         <BrowserSurface
           nodeId={id}
           url={(data.url as string) ?? ''}
+          partition={data.partition as string | undefined}
           onUrlChange={(u) => updateNodeData(id, { url: u })}
           onTitleChange={(t) => updateNodeData(id, { title: t })}
         />

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -24,6 +24,15 @@ interface BrowserSurfaceProps {
   nodeId: string
   /** Initial URL (seeded once at mount). */
   url: string
+  /**
+   * The Electron session partition. Set for an AGENT-opened node
+   * (`persist:nt-agent-browser-<projectId>`), absent for a USER-opened node (default session).
+   * Applied straight to `<webview partition>`, which is honoured only at attach — the discard/restore
+   * remount re-applies the SAME value, so the guest rejoins its jar ([MEASURED, Electron 42.8.1],
+   * Probe B). Threaded identically here and in the card modal so the two mounts share one jar
+   * (`browser-partition-parity.test.tsx`); a mismatch reads to a user as "my login vanished".
+   */
+  partition?: string
   /** Persist the top-level URL after a navigation. */
   onUrlChange: (url: string) => void
   /** Persist the page title. */
@@ -37,7 +46,7 @@ interface BrowserSurfaceProps {
  * webview never emits dom-ready, so imperative loadURL before then is a no-op); `did-navigate` only
  * updates the address, so in-page navigation can't loop.
  */
-export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: BrowserSurfaceProps) {
+export function BrowserSurface({ nodeId, url, partition, onUrlChange, onTitleChange }: BrowserSurfaceProps) {
   const ref = useRef<WebviewEl | null>(null)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const lastUrlRef = useRef('')
@@ -256,6 +265,7 @@ export function BrowserSurface({ nodeId, url, onUrlChange, onTitleChange }: Brow
           <webview
             ref={ref as unknown as React.Ref<HTMLElement>}
             src={src || undefined}
+            partition={partition || undefined}
             allowpopups={true}
             style={{ width: '100%', height: '100%' }}
           />

--- a/src/renderer/nodes/browser-partition-parity.test.tsx
+++ b/src/renderer/nodes/browser-partition-parity.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+//
+// One node, two mounts: the canvas BrowserNode and the kanban CardModal both render the SHARED
+// BrowserSurface. This pins that they hand it the SAME `partition`, so the two mounts share one
+// session jar. A mismatch is not cosmetic — it is the modal being a different, logged-out browser,
+// which a user reads as "my login vanished".
+//
+// The shared leaf BrowserSurface is replaced by a spy that renders a real <webview partition>, so
+// the assertion is against the actual attribute each wrapper's real data->prop plumbing produces
+// (the bug surface lives in the wrappers, never in the identical leaf).
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ReactFlowProvider, type NodeProps } from '@xyflow/react'
+import type { CanvasNode } from '../state/workspace'
+import type { KanbanSession } from '../components/kanban/KanbanView'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// The shared surface both mounts use: render the partition straight onto a real <webview> so the
+// test reads the same attribute a real guest would attach on.
+vi.mock('./BrowserSurface', () => ({
+  BrowserSurface: ({ partition }: { partition?: string }) => (
+    // eslint-disable-next-line react/no-unknown-property
+    <webview partition={partition || undefined} data-testid="surface" />
+  )
+}))
+// CardModal's non-browser children are irrelevant to partition parity — stub them so the modal
+// renders without their store/context burden.
+vi.mock('../session/session', () => ({ useSession: () => ({ api: { pty: { generateName: vi.fn() } } }) }))
+vi.mock('../components/kanban/BoardLogPanel', () => ({ BoardLogPanel: () => null }))
+vi.mock('../components/kanban/CardMetaBar', () => ({ CardMetaBar: () => null }))
+vi.mock('../components/kanban/ModalTerminal', () => ({ ModalTerminal: () => null }))
+vi.mock('../components/ContextMeter', () => ({ ContextMeter: () => null }))
+
+import BrowserNode from './BrowserNode'
+import { CardModal } from '../components/kanban/CardModal'
+
+function partitionFromCanvas(nodePartition: string | undefined): string | null {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const root = createRoot(host)
+  const data = { title: 'B', color: '#0a84ff', group: null, url: 'https://x.test/', partition: nodePartition }
+  act(() =>
+    root.render(
+      <ReactFlowProvider>
+        <BrowserNode {...({ id: 'browser-1', data, selected: false } as unknown as NodeProps<CanvasNode>)} />
+      </ReactFlowProvider>
+    )
+  )
+  const wv = host.querySelector('webview')!
+  const p = wv.getAttribute('partition')
+  act(() => root.unmount())
+  host.remove()
+  return p
+}
+
+function partitionFromModal(sessionPartition: string | undefined): string | null {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const root = createRoot(host)
+  const session: KanbanSession = {
+    id: 'browser-1',
+    title: 'B',
+    color: '#0a84ff',
+    kind: 'browser',
+    url: 'https://x.test/',
+    partition: sessionPartition,
+    spawn: {}
+  }
+  act(() =>
+    root.render(
+      <CardModal
+        session={session}
+        columnTitle={null}
+        board={{ columns: [], assignments: {} } as never}
+        onChangeBoard={vi.fn()}
+        onClose={vi.fn()}
+        onOpenCanvas={vi.fn()}
+        onRename={vi.fn()}
+        onEditSticky={vi.fn()}
+        onBrowserNav={vi.fn()}
+      />
+    )
+  )
+  const wv = document.body.querySelector('webview')!
+  const p = wv.getAttribute('partition')
+  act(() => root.unmount())
+  host.remove()
+  return p
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('canvas + modal webviews for one node share one partition', () => {
+  it('an agent-opened node: both mounts carry the identical named partition', () => {
+    const part = 'persist:nt-agent-browser-p1'
+    const canvas = partitionFromCanvas(part)
+    const modal = partitionFromModal(part)
+    expect(canvas).toBe(part)
+    expect(modal).toBe(part)
+    expect(canvas).toBe(modal)
+  })
+
+  it('a user-opened node: BOTH mounts omit the attribute (default session, not two jars)', () => {
+    // The undefined case is the one a naive fix breaks: passing '' on one side and nothing on the
+    // other makes the modal a fresh default-session browser while the canvas node is on its own.
+    expect(partitionFromCanvas(undefined)).toBe(null)
+    expect(partitionFromModal(undefined)).toBe(null)
+  })
+})

--- a/src/renderer/state/workspace.browser.test.ts
+++ b/src/renderer/state/workspace.browser.test.ts
@@ -13,4 +13,22 @@ describe('browser node', () => {
     const b = round.find((n) => n.type === 'browser')!
     expect(b.data.url).toBe('https://a.dev')
   })
+
+  it('createBrowserNode without a partition is the USER-opened node — unchanged, default session', () => {
+    expect(createBrowserNode(0, 'https://x.test/').data.partition).toBeUndefined()
+  })
+
+  it('an agent-opened node carries its partition, set once at creation', () => {
+    const n = createBrowserNode(0, 'https://x.test/', undefined, 'persist:nt-agent-browser-p1')
+    expect(n.data.partition).toBe('persist:nt-agent-browser-p1')
+  })
+
+  it("an agent node's partition survives the persistence round-trip; a user node's stays absent", () => {
+    // The jar must outlive a reopen, or the agent is logged out on the next app start.
+    const agent = createBrowserNode(0, 'https://a.dev', undefined, 'persist:nt-agent-browser-p1')
+    const user = createBrowserNode(1, 'https://b.dev')
+    const round = nodeStatesToFlow(flowToNodeStates([agent, user]))
+    expect(round.find((n) => n.id === agent.id)!.data.partition).toBe('persist:nt-agent-browser-p1')
+    expect(round.find((n) => n.id === user.id)!.data.partition).toBeUndefined()
+  })
 })

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -92,6 +92,14 @@ export interface NodeData {
   fileMissing?: boolean
   /** web-only: live URL to load in the web (webview) node. */
   url?: string
+  /**
+   * browser-only: the Electron session partition for this <webview>. Set ONCE at creation for an
+   * AGENT-opened node (`agentBrowserPartition`, `persist:nt-agent-browser-<projectId>`) and never
+   * mutated — [MEASURED, Electron 42.8.1] `partition` is honoured only at attach. Absent (undefined)
+   * for a USER-opened node, which keeps the default session (no migration, no lost logins). Carried
+   * through persistence untouched on Server Edition / mobile, where a browser node has no <webview>.
+   */
+  partition?: string
   diffStaged?: boolean
   commitOid?: string
   /** dino-only: best score reached in the T-Rex Runner game. */
@@ -633,11 +641,20 @@ export function createWebNode(
   }
 }
 
-/** Creates a navigable browser node (Electron <webview>) starting at `url` ('' = blank). */
+/**
+ * Creates a navigable browser node (Electron <webview>) starting at `url` ('' = blank).
+ *
+ * `partition` is set ONLY for an AGENT-opened node (`open-browser`), to its per-project session jar
+ * (`agentBrowserPartition`). A USER-opened node passes none and keeps the default session, unchanged
+ * — the zero-migration path, so nobody loses a login on upgrade. It is written once here and never
+ * mutated: [MEASURED, Electron 42.8.1] `<webview partition>` is honoured only at attach, so a later
+ * change would be a silent no-op anyway (docs/superpowers/probes/2026-08-browser-partition.md).
+ */
 export function createBrowserNode(
   index: number,
   url: string,
-  center?: { x: number; y: number }
+  center?: { x: number; y: number },
+  partition?: string
 ): CanvasNode {
   const title = url ? url.replace(/^https?:\/\//, '').slice(0, 40) : 'Browser'
   return {
@@ -651,7 +668,8 @@ export function createBrowserNode(
       title,
       color: '#0a84ff',
       group: null,
-      ...(url ? { url } : {})
+      ...(url ? { url } : {}),
+      ...(partition ? { partition } : {})
     }
   }
 }
@@ -1307,6 +1325,7 @@ export function nodeStatesToFlow(states: CanvasNodeState[]): CanvasNode[] {
         filePath: n.filePath,
         fileMissing: n.fileMissing,
         url: n.url,
+        partition: n.partition,
         diffStaged: n.diffStaged,
         commitOid: n.commitOid,
         highScore: n.highScore,
@@ -1375,6 +1394,7 @@ export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
         filePath: n.data.filePath,
         fileMissing: n.data.fileMissing,
         url: n.data.url,
+        partition: n.data.partition,
         diffStaged: n.data.diffStaged,
         commitOid: n.data.commitOid,
         highScore: n.data.highScore,

--- a/src/shared/browser-partition.test.ts
+++ b/src/shared/browser-partition.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { agentBrowserPartition } from './browser-partition'
+import { agentBrowserPartition, loadedAgentBrowserPartition } from './browser-partition'
 
 describe('agentBrowserPartition', () => {
   it('is per-project and prefixed persist:', () => {
@@ -12,5 +12,27 @@ describe('agentBrowserPartition', () => {
     for (const bad of ['..', '.', '', 'a/b', 'a b', '../../x', 'x'.repeat(300)]) {
       expect(agentBrowserPartition(bad), bad).toBe(null)
     }
+  })
+})
+
+describe('loadedAgentBrowserPartition — the hostile-load gate', () => {
+  it('keeps a partition that is EXACTLY the one this project would mint', () => {
+    expect(loadedAgentBrowserPartition('persist:nt-agent-browser-p1', 'p1')).toBe('persist:nt-agent-browser-p1')
+  })
+  it("drops a FOREIGN project's jar — project.json cannot name persist:...-<victim>", () => {
+    // The whole finding: a cloned file shipping another project's jar name must not reach the webview.
+    expect(loadedAgentBrowserPartition('persist:nt-agent-browser-victim', 'p1')).toBeUndefined()
+  })
+  it('drops an unsafe/oddly-shaped storage-key string', () => {
+    for (const bad of ['persist:nt-agent-browser-../x', 'evil', 'persist:nt-agent-browser-a b', 'persist:other-p1']) {
+      expect(loadedAgentBrowserPartition(bad, 'p1'), bad).toBeUndefined()
+    }
+  })
+  it('a partition-less (user-opened) node stays partition-less', () => {
+    expect(loadedAgentBrowserPartition(undefined, 'p1')).toBeUndefined()
+  })
+  it('an unsafe PROJECT id can never match, so nothing is kept', () => {
+    // agentBrowserPartition('..') is null, so no stored string can equal it.
+    expect(loadedAgentBrowserPartition('persist:nt-agent-browser-..', '..')).toBeUndefined()
   })
 })

--- a/src/shared/browser-partition.test.ts
+++ b/src/shared/browser-partition.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { agentBrowserPartition } from './browser-partition'
+
+describe('agentBrowserPartition', () => {
+  it('is per-project and prefixed persist:', () => {
+    expect(agentBrowserPartition('p-1')).toBe('persist:nt-agent-browser-p-1')
+  })
+  it('REFUSES an id isSafeNodeId refuses — this becomes a persisted storage key', () => {
+    // Project ids come from project.json, which travels in cloned repos. A partition name is not a
+    // path segment, but it IS a persisted-storage key, and the class of mistake is identical to
+    // docs/node-identity.md §"Ids are path segments".
+    for (const bad of ['..', '.', '', 'a/b', 'a b', '../../x', 'x'.repeat(300)]) {
+      expect(agentBrowserPartition(bad), bad).toBe(null)
+    }
+  })
+})

--- a/src/shared/browser-partition.ts
+++ b/src/shared/browser-partition.ts
@@ -1,0 +1,35 @@
+import { isSafeNodeId } from './safe-id'
+
+/**
+ * The session partition for a browser node an AGENT opened.
+ *
+ * User-opened nodes keep the default session, unchanged — that is what makes this a zero-migration
+ * change: every existing browser node was user-opened (or restored, hence un-owned), so nobody
+ * loses a login on upgrade. A blanket per-node partitioning WOULD have logged everyone out once.
+ * [MEASURED 2026-08, Electron 42.8.1] a partition-less `<webview>` genuinely shares
+ * `session.defaultSession` with the app window — so an agent node left on the default session would
+ * read whatever the user is already logged into (see the probe doc, Probe A).
+ *
+ * PER-PROJECT, not per-node: per-node means re-logging-in for every open-browser, which makes
+ * multi-tab agentic work (compare two pages, open a link in a second node) impractical. Not global:
+ * a login an agent made for project A has no business being available to an agent in project B.
+ *
+ * The property this buys, and it is the one the owner asked about: an agent driving node A cannot
+ * reach node B's logins, where B is anything the user opened. The cost is the mirror image — the
+ * user cannot log in on the agent's behalf from their OWN node; they must log in inside the agent's
+ * node, which is where the indicator is.
+ *
+ * `projectId` is validated because it arrives from git-shared project.json and becomes a PERSISTED
+ * STORAGE KEY. Returns null rather than throwing: the caller refuses the open, it does not crash.
+ * The guard is load-bearing and pinned by `browser-partition.test.ts` ("REFUSES an id isSafeNodeId
+ * refuses"); drop it and that test goes red.
+ *
+ * [MEASURED 2026-08, Electron 42.8.1 — see docs/superpowers/probes/2026-08-browser-partition.md]
+ * A discarded+restored webview rejoins the same named partition (Probe B), and `partition` is
+ * honoured only at attach — a post-attach mutation is silently ignored (Probe C) — which is why the
+ * node's field is set once at creation and never mutated.
+ */
+export function agentBrowserPartition(projectId: string): string | null {
+  if (!isSafeNodeId(projectId)) return null
+  return `persist:nt-agent-browser-${projectId}`
+}

--- a/src/shared/browser-partition.ts
+++ b/src/shared/browser-partition.ts
@@ -33,3 +33,30 @@ export function agentBrowserPartition(projectId: string): string | null {
   if (!isSafeNodeId(projectId)) return null
   return `persist:nt-agent-browser-${projectId}`
 }
+
+/**
+ * The partition a PERSISTED browser node is allowed to keep when it is LOADED.
+ *
+ * `agentBrowserPartition` validates the id at CREATE, but `data.partition` is then persisted and
+ * `.nodeterm/project.json` is hostile input (git-shared, hand-editable, auto-adopted — constraint
+ * 10), and the field is copied verbatim to `<webview partition>`. Without a load-path gate a hostile
+ * clone could ship a browser node whose stored `partition` names ANOTHER project's jar
+ * (`persist:nt-agent-browser-<victim>`) or is a non-`isSafeNodeId` storage-key string, and it would
+ * reach Electron unchecked — forging jar identity the per-project isolation exists to prevent.
+ *
+ * The rule: a stored partition survives ONLY when it is EXACTLY the one THIS project would mint for
+ * itself (`agentBrowserPartition(projectId)`). Anything else — a foreign project's id, a different
+ * machine's id from a clone, an unsafe/oddly-shaped string — drops to `undefined`, i.e. partition-
+ * less / default session / un-owned (the probe's user-opened clause). This is the single load gate:
+ * the value is not re-validated after it, so it runs at the adopt boundary (`fileToProject`, which
+ * is where the machine-local `projectId` is authoritative and never the file's own id). Pinned by
+ * `browser-partition.test.ts` and the hostile-project.json case in `workspace-files.test.ts`; a
+ * missing gate lets `persist:nt-agent-browser-victim` reach the webview.
+ */
+export function loadedAgentBrowserPartition(
+  partition: string | undefined,
+  projectId: string
+): string | undefined {
+  if (!partition) return undefined
+  return partition === agentBrowserPartition(projectId) ? partition : undefined
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -285,6 +285,13 @@ export interface CanvasNodeState {
   fileMissing?: boolean
   /** web-only: when set, the web node loads this live URL (else it loads `filePath` as local html). */
   url?: string
+  /**
+   * browser-only: the Electron session partition for an AGENT-opened browser node
+   * (`persist:nt-agent-browser-<projectId>`), set once at creation and never mutated. Absent for a
+   * USER-opened node (default session, no migration). Persisted so the jar survives reopen; carried
+   * through untouched on Server Edition / mobile, where a browser node renders with no <webview>.
+   */
+  partition?: string
   /** diff-only: true = staged diff (HEAD vs index), false = unstaged (index vs working). */
   diffStaged?: boolean
   /** diff-only: when set, the diff shows parent (<oid>^) vs commit (<oid>) for a file from history. */


### PR DESCRIPTION
S8 PR 4 of 5 for external PR #112 (@Corvin). Establishes **who owns a browser node**, so a project's
grant cannot drive a browser it did not create — the browser analogue of the confused-deputy just
closed for messaging. Depends on merged PRs #205/#206/#213. Independent of all CDP work.

## Probe first (Task 4.0) — the design HELD

Two design claims were `[UNVERIFIED]` and had never been run. I drove a **real Electron 42.8.1
`<webview>`** (real local http origin, real `session` cookie APIs, real guest `document.cookie`) —
`docs/superpowers/probes/2026-08-browser-partition.md`:

- **Probe A:** a partition-less `<webview>` **genuinely shares `session.defaultSession`** with the app
  window, both directions — so an agent node left on the default session would read the user's
  logins. The "…and the app's own window" clause stands.
- **Probe B:** a discarded+restored named-partition webview **rejoins the same jar** — the memory
  saver does **not** log the agent out. No stop-and-report; PR 5's suppressor is for state, not
  correctness.
- **Probe C:** a `partition` mutation after attach is **silently ignored** — justifying the
  immutable, set-once field.

## Tasks → commits

| Task | Commit | What |
|------|--------|------|
| 4.0 probe | `docs(browser): probe webview partition identity and discard/restore` | measured all three, recorded in the probe doc + `browser-partition.ts` |
| 4.1 partition | `feat(browser): nodes an agent opens get their own per-project session jar` | `agentBrowserPartition` (`persist:nt-agent-browser-<projectId>`, `isSafeNodeId`-guarded), immutable `data.partition`, `open-browser` refuses an unsafe id; user-opened nodes untouched (zero-migration) |
| 4.2 parity | `test(browser): the canvas and modal webviews for one node share one partition` | CardModal threads `session.partition`; both mounts pinned to the identical `<webview partition>` |
| 4.3 ledger | `feat(main): an in-memory ownership ledger for agent-opened browser nodes` | `BrowserControlLedger` (in-memory, main, never persisted); claims only on a `verified` open-browser; `verified` plumbed from the hook-server gate into the control handler |
| 4.4 ropes | `test(browser): ownership can never be read out of Project.ropes` | behavioural (pre-declared rope survives a round-trip, grants nothing) + structural (fails on the tempting one-liner) |

## Security posture

- Ownership is recorded at **create** from a **non-forgeable source** (main's own `verified` verdict
  + the verified caller's node id), never from attacker-writable `project.json`. Sibling of the
  merged `core/agents/pane-ownership.ts`.
- **Fail-closed:** an absent entry and an owner mismatch both return `null`; `get()` cannot tell "not
  yours" from "does not exist" (no enumeration oracle).
- **`ropes` is never an ownership input** — pinned by both halves of Task 4.4.
- No handoff / claim / transfer: `claimUserTab` stays dropped.
- `src/main` for the ledger (not `src/core`): its clients are Electron-adjacent (webContents leases,
  PR 5/6) and it never ships on the Server Edition, where browser control cannot exist.

## Verification

- `npm run typecheck` clean. Full `npx vitest run`: **7004 passed, 12 skipped, 0 failed** (no
  environmental flakes this run).
- **Mutation checks** (revert → red → restore), all caught:
  - 4.1 — 4/4 (drop `isSafeNodeId`; global-not-per-project; drop partition from forward serialize; from reverse load)
  - 4.2 — 2/2 (drop the prop on the CardModal side; on the BrowserNode side)
  - 4.3 — 6/6 (get ignores owner; claim overwrites; claim stores by reference; lease `>` vs `>=`; releaseWhere never deletes; blank-owner not refused)
  - 4.4 — 2/2 (a `ropes` read added to the ledger; `get` invents an entry for an absent node)

Three surfaces: **Desktop** is the whole subject. **Server Edition** — no ledger, the verb is refused
by name; the partition field rides persistence untouched. **Mobile** — never claims; see-and-revoke
is explicitly owed, not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
