### PR TITLE
feat(browser): the CDP allowlist, the lease, and the memory-saver interlock

### DIFF
--- a/docs/superpowers/probes/2026-08-browser-debugger.md
+++ b/docs/superpowers/probes/2026-08-browser-debugger.md
@@ -1,0 +1,48 @@
+# Probe — `webContents.debugger.attach()` vs an open DevTools window
+
+**Design claim under test:** S8 browser-control design, `[UNVERIFIED] 2` — the worry that a
+programmatic debugger attachment and a user-opened DevTools window are *mutually exclusive* on the
+same `<webview>` guest, i.e.
+
+1. `webContents.debugger.attach()` **fails** while the user has DevTools open on that guest, and/or
+2. an active attachment **blocks** the user from opening DevTools.
+
+If (1) held, Task 5.3's attach-failure path had to surface *that* cause verbatim
+(*"browser-3 has DevTools open; close them to let an agent drive it"*), never "not drivable"
+(design §2.3 rule 1). If (2) held, that usability cost had to be recorded in PR 6's indicator
+tooltip.
+
+## Environment
+
+- **Electron 42.8.1** (`package.json:142`, `node_modules/electron/dist/version` = `42.8.1`).
+- Linux, headless, `xvfb-run` + `--no-sandbox --disable-gpu`.
+- Real `BrowserWindow` (`webviewTag: true`) hosting a real `<webview>` guest; guest `webContents`
+  obtained from the `did-attach-webview` event — the same object the app drives.
+- Probe source: `scratchpad/probe/main.js` (`attach('1.3')`, `openDevTools({ mode: 'detach' })`,
+  `isDevToolsOpened()`, `debugger.isAttached()`, `debugger` `detach` event). Reproduced twice,
+  identical results.
+
+## Measured result
+
+| Test | Action | Outcome |
+|------|--------|---------|
+| **A** | DevTools opened first (`isDevToolsOpened() === true`), then `debugger.attach('1.3')` | **attach SUCCEEDED** — no "Another debugger is already attached" throw |
+| **B** | `debugger.attach('1.3')` first (`isAttached() === true`), then `openDevTools()` | **DevTools opened** (`isDevToolsOpened() === true`) **and the programmatic attachment stayed live** (`isAttached() === true`); no `detach` event during the DevTools window (the only `detach` seen, reason `target closed`, fired at webContents teardown) |
+
+## Conclusion
+
+**On Electron 42.8.1 the two are NOT mutually exclusive — they coexist.** A programmatic CDP client
+and the user's DevTools frontend attach to the same guest at the same time (modern Chromium
+multiplexes multiple protocol clients per target). Neither branch of `[UNVERIFIED] 2` reproduces:
+
+- attach does **not** fail because DevTools is open, so Task 5.3's DevTools-specific sentence is
+  **unreachable on this version** — it is documented and kept out of the hot path rather than
+  emitted. The generic attach-failure path remains (attach can still throw for a destroyed /
+  crashed / detached target), and it names a **named** outcome, never "not drivable".
+- attaching does **not** block the user's DevTools, so there is **no usability cost** to record in
+  PR 6's tooltip.
+
+This **refines** the design (one conditional branch measured unnecessary); it does **not**
+contradict the lease mechanism, so PR 5 proceeds. If a future Electron bump reintroduces the
+single-client rule, re-run this probe: the attach-failure handler in `browser-lease.ts` already
+degrades to a named refusal, and only the DevTools-specific wording would need re-enabling.

--- a/src/main/browser-cdp-allowlist.test.ts
+++ b/src/main/browser-cdp-allowlist.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { checkCdpCommand, type CdpContext } from './browser-cdp-allowlist'
+import { NT_SCRIPTS } from './browser-nt-scripts'
+
+const ctx: CdpContext = { viewport: { width: 1280, height: 800 } }
+
+describe('checkCdpCommand', () => {
+  it('an allowlist keyed on METHOD NAME is not what this is', () => {
+    // The danger in Runtime.evaluate is not its name, it is one parameter. So the list is
+    // (method, params-validator) pairs — which is also what buys the URL check on Page.navigate
+    // that a name-only list cannot express.
+    expect(checkCdpCommand('Page.navigate', { url: 'https://x.test/' }, ctx)).toBe(true)
+    expect(checkCdpCommand('Page.navigate', { url: 'javascript:alert(1)' }, ctx)).toBe(false)
+    expect(checkCdpCommand('Page.navigate', { url: 'file:///etc/passwd' }, ctx)).toBe(false)
+    expect(checkCdpCommand('Page.navigate', { url: 'data:text/html,<x>' }, ctx)).toBe(false)
+  })
+
+  it.each([
+    'Runtime.evaluate', 'Runtime.compileScript', 'Runtime.runScript', 'Runtime.addBinding',
+    'Debugger.enable', 'Debugger.setBreakpoint', 'Profiler.enable', 'Tracing.start',
+    'Fetch.enable', 'Emulation.setUserAgentOverride', 'Storage.clearDataForOrigin',
+    'Browser.close', 'Security.setIgnoreCertificateErrors',
+    'IndexedDB.requestData', 'DOMStorage.getDOMStorageItems',
+    'Network.getAllCookies', 'Page.bringToFront',
+    'DOM.getOuterHTML', 'DOM.getAttributes', 'Input.synthesizeScrollGesture'
+  ])('%s is refused', (m) => {
+    expect(checkCdpCommand(m, {}, ctx)).toBe(false)
+  })
+
+  it('callFunctionOn requires IDENTITY with an NT_SCRIPTS entry and value-only arguments', () => {
+    const ok = { objectId: 'o1', functionDeclaration: NT_SCRIPTS.readMap, arguments: [{ value: '#x' }], returnByValue: true }
+    expect(checkCdpCommand('Runtime.callFunctionOn', ok, ctx)).toBe(true)
+    expect(checkCdpCommand('Runtime.callFunctionOn', { ...ok, functionDeclaration: 'function(){return 1}' }, ctx)).toBe(false)
+    expect(checkCdpCommand('Runtime.callFunctionOn', { ...ok, arguments: [{ objectId: 'o2' }] }, ctx)).toBe(false)
+    expect(checkCdpCommand('Runtime.callFunctionOn', { ...ok, arguments: [{ value: { a: 1 } }] }, ctx)).toBe(false)
+    expect(checkCdpCommand('Runtime.callFunctionOn', { ...ok, returnByValue: false }, ctx)).toBe(false)
+  })
+
+  it('mouse coordinates must be inside the reported viewport', () => {
+    expect(checkCdpCommand('Input.dispatchMouseEvent', { type: 'mousePressed', x: 10, y: 10 }, ctx)).toBe(true)
+    expect(checkCdpCommand('Input.dispatchMouseEvent', { type: 'mousePressed', x: -1, y: 10 }, ctx)).toBe(false)
+    expect(checkCdpCommand('Input.dispatchMouseEvent', { type: 'mousePressed', x: 99999, y: 10 }, ctx)).toBe(false)
+  })
+
+  it('selector length and DOM depth are bounded', () => {
+    expect(checkCdpCommand('DOM.querySelector', { nodeId: 1, selector: 'a'.repeat(1024) }, ctx)).toBe(true)
+    expect(checkCdpCommand('DOM.querySelector', { nodeId: 1, selector: 'a'.repeat(1025) }, ctx)).toBe(false)
+    expect(checkCdpCommand('DOM.getDocument', { depth: 2 }, ctx)).toBe(false)
+  })
+
+  it('Input.insertText is capped', () => {
+    expect(checkCdpCommand('Input.insertText', { text: 'x'.repeat(8192) }, ctx)).toBe(true)
+    expect(checkCdpCommand('Input.insertText', { text: 'x'.repeat(8193) }, ctx)).toBe(false)
+  })
+
+  it('cookie READS take one explicit domain; the jar-emptying call does not exist here', () => {
+    expect(checkCdpCommand('Network.getCookies', { urls: ['https://github.com/'] }, ctx)).toBe(true)
+    expect(checkCdpCommand('Network.getCookies', {}, ctx)).toBe(false)      // no domain ⇒ the whole jar
+    expect(checkCdpCommand('Network.getAllCookies', {}, ctx)).toBe(false)
+  })
+
+  it('cookie WRITES are listed (owner decision 5) and unreachable in v1', () => {
+    // The methods stay listed so the allowlist RECORDS the decision; PR 9 Task 9.4 pins that no
+    // verb reaches them, because a write verb needs a design nobody has done: where does the agent
+    // get the value, and what stops it planting accounts.google.com so a later human visit is a
+    // login the attacker controls?
+    expect(checkCdpCommand('Network.setCookie', { name: 'a', value: 'b', domain: 'x.test' }, ctx)).toBe(true)
+  })
+
+  it('an unknown method is refused with NO per-method detail', () => {
+    // An allowlist that explains itself is a probing aid.
+    expect(checkCdpCommand('Made.Up', {}, ctx)).toBe(false)
+  })
+})
+
+/**
+ * Structural pin (the analogue of Task 4.4's second half). `checkCdpCommand` is only THE gate if it
+ * is unbypassable: every `sendCommand(` in the main-side browser surface must live inside the one
+ * wrapper, `browser-cdp-send.ts`, which calls this function. A direct `debugger.sendCommand` anywhere
+ * else is arbitrary CDP that never met the allowlist.
+ */
+describe('debugger.sendCommand has exactly one call site', () => {
+  const mainDir = path.resolve(__dirname)
+
+  it('every sendCommand( in src/main/browser-*.ts is inside browser-cdp-send.ts', () => {
+    const offenders: string[] = []
+    for (const f of fs.readdirSync(mainDir)) {
+      if (!/^browser-.*\.ts$/.test(f) || f.endsWith('.test.ts')) continue
+      if (f === 'browser-cdp-send.ts') continue
+      const src = fs.readFileSync(path.join(mainDir, f), 'utf8')
+      // Strip comments so a mention in prose is not a false positive; a real call is not a comment.
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+      if (/\bsendCommand\s*\(/.test(code)) offenders.push(f)
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/main/browser-cdp-allowlist.ts
+++ b/src/main/browser-cdp-allowlist.ts
@@ -1,0 +1,168 @@
+/**
+ * THE CDP allowlist. The single gate every command bound for `debugger.sendCommand` passes through
+ * (the one caller is `browser-cdp-send.ts`, pinned structurally by this file's test). Default-DENY:
+ * an unknown method, or a known method with a parameter the validator rejects, is REFUSED — nothing
+ * falls through.
+ *
+ * It is NOT a set of method names. The danger in a page-side-eval command is not its name, it is one
+ * parameter — and a name-keyed list also cannot express the URL check on Page.navigate. So the table
+ * is (method, params-validator) pairs, each validator inspecting exactly the parameters that make its
+ * method safe or not.
+ *
+ * Lives in `src/main`, enforced on the way into the debugger — NEVER in the renderer (the half an
+ * XSS-in-a-node-title style bug lands in) and never in the shim or a skill document. Browser control
+ * exists only on the Electron desktop; Server Edition / Mobile never reach here.
+ *
+ * Excluded outright and for stated reasons: arbitrary page-side evaluation
+ * (Runtime.evaluate/compileScript/runScript/addBinding) and the whole Debugger domain (a second route
+ * to it), Fetch (request interception is a proxy for the user's session), Security (can disable
+ * certificate errors), Storage / IndexedDB / DOMStorage (the token stores this whole design exists to
+ * keep out), DOM.getOuterHTML / getAttributes (the full-DOM read arriving by another door),
+ * Page.bringToFront (a page that can raise itself can steal a click the user aimed elsewhere) and
+ * Network.getAllCookies (one call empties the jar for every site the profile ever touched, and no
+ * useful audit line names a domain). None of these is in the table, so default-deny refuses them.
+ */
+import { isNtScript } from './browser-nt-scripts'
+import { normalizeAddress } from '@shared/browserUrl'
+
+/** What the gate needs to know about the page beyond the command itself: the viewport from the last
+ *  `Page.getLayoutMetrics`, so a mouse coordinate can be bounded to what is actually on screen. */
+export interface CdpContext {
+  viewport: { width: number; height: number }
+}
+
+type Validator = (params: unknown, ctx: CdpContext) => boolean
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** A CDP argument for the call-a-function-on-object method is safe ONLY if it carries a single scalar
+ *  `value` — never an `objectId` (an agent-chosen live handle) and never a structured value (an
+ *  object literal is a re-entry point for logic the NT_SCRIPTS scan never saw). */
+function isScalar(v: unknown): boolean {
+  return v === null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean'
+}
+function valueOnlyArgs(args: unknown): boolean {
+  if (args === undefined) return true
+  if (!Array.isArray(args)) return false
+  return args.every(
+    (a) =>
+      isRecord(a) &&
+      Object.keys(a).length === 1 &&
+      Object.prototype.hasOwnProperty.call(a, 'value') &&
+      isScalar(a.value)
+  )
+}
+
+const MAX_SELECTOR = 1024
+const MAX_INSERT_TEXT = 8192
+
+/**
+ * The table. Every entry is a (method, validator) pair. A Map — not a plain object — so a method
+ * named `__proto__` / `constructor` can never resolve a validator off Object.prototype.
+ */
+const ALLOW = new Map<string, Validator>([
+  // ---- Agent-facing verbs (PRs 7-8). Each validator inspects the parameters that make it safe. ----
+
+  // The only navigation the agent can drive is to an http(s) URL, decided by the SAME
+  // `normalizeAddress` the address bar uses — javascript:/file:/data: all normalize to null.
+  ['Page.navigate', (p) => isRecord(p) && typeof p.url === 'string' && normalizeAddress(p.url) !== null],
+
+  // Page-side logic runs ONLY as an NT_SCRIPTS entry, by identity, returning a value, with scalar
+  // arguments. This is where the exclusion of arbitrary evaluation is actually enforced.
+  [
+    'Runtime.callFunctionOn',
+    (p) =>
+      isRecord(p) &&
+      typeof p.functionDeclaration === 'string' &&
+      isNtScript(p.functionDeclaration) &&
+      p.returnByValue === true &&
+      valueOnlyArgs(p.arguments)
+  ],
+
+  // A synthesized mouse event must land inside the reported viewport — a coordinate off-screen is
+  // either a bug or an attempt to reach chrome the user cannot see.
+  [
+    'Input.dispatchMouseEvent',
+    (p, ctx) =>
+      isRecord(p) &&
+      typeof p.type === 'string' &&
+      typeof p.x === 'number' &&
+      typeof p.y === 'number' &&
+      p.x >= 0 &&
+      p.y >= 0 &&
+      p.x <= ctx.viewport.width &&
+      p.y <= ctx.viewport.height
+  ],
+
+  // Typed text is capped; the text goes to insertText, never to a shell and never spliced anywhere.
+  ['Input.insertText', (p) => isRecord(p) && typeof p.text === 'string' && p.text.length <= MAX_INSERT_TEXT],
+
+  // A bounded selector against a known node.
+  [
+    'DOM.querySelector',
+    (p) =>
+      isRecord(p) &&
+      typeof p.nodeId === 'number' &&
+      typeof p.selector === 'string' &&
+      p.selector.length <= MAX_SELECTOR
+  ],
+
+  // A shallow document read only (depth <= 1, no pierce) — the deep read is the full-DOM door that
+  // getOuterHTML/getAttributes are excluded to keep shut.
+  [
+    'DOM.getDocument',
+    (p) =>
+      isRecord(p) &&
+      (p.depth === undefined || (typeof p.depth === 'number' && p.depth <= 1)) &&
+      p.pierce !== true
+  ],
+
+  // A cookie READ must name at least one URL — never the whole jar (that is getAllCookies, excluded).
+  [
+    'Network.getCookies',
+    (p) => isRecord(p) && Array.isArray(p.urls) && p.urls.length > 0 && p.urls.every((u) => typeof u === 'string')
+  ],
+
+  // Cookie WRITES stay LISTED so the allowlist records owner decision 5, but no verb reaches them in
+  // v1 (pinned by PR 9 Task 9.4). A write needs one explicit domain — never a jar-wide write.
+  [
+    'Network.setCookie',
+    (p) =>
+      isRecord(p) &&
+      typeof p.name === 'string' &&
+      typeof p.value === 'string' &&
+      typeof p.domain === 'string' &&
+      p.domain.length > 0
+  ],
+
+  // ---- Session lifecycle (issued by the lease, browser-lease.ts, not by an agent verb). Still gated
+  //      here so the "single gate" property is literal: every sendCommand, infra or not, is checked. ----
+
+  ['Page.enable', () => true],
+  ['DOM.enable', () => true],
+  ['Runtime.enable', () => true],
+  ['Page.getLayoutMetrics', () => true],
+  // Flat-mode child attach only (S8): a nested/auto-attach mode is a different, unaudited surface.
+  [
+    'Target.attachToTarget',
+    (p) => isRecord(p) && p.flatten === true && typeof p.targetId === 'string' && p.targetId.length > 0
+  ],
+  ['Target.detachFromTarget', (p) => isRecord(p) && typeof p.sessionId === 'string']
+])
+
+/**
+ * Is this exact (method, params) pair allowed, for this page context? Default-deny: an unknown
+ * method returns false with NO per-method detail (an allowlist that explains itself is a probing
+ * aid), and a validator that throws on a malformed payload is treated as a refusal.
+ */
+export function checkCdpCommand(method: string, params: unknown, ctx: CdpContext): boolean {
+  const validate = ALLOW.get(method)
+  if (!validate) return false
+  try {
+    return validate(params, ctx) === true
+  } catch {
+    return false
+  }
+}

--- a/src/main/browser-cdp-send.test.ts
+++ b/src/main/browser-cdp-send.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { sendCdp, cdpRefusedMessage, type DebuggerLike } from './browser-cdp-send'
+import type { CdpContext } from './browser-cdp-allowlist'
+
+const ctx: CdpContext = { viewport: { width: 1280, height: 800 } }
+
+function fakeDebugger(): DebuggerLike & { sent: string[] } {
+  const sent: string[] = []
+  return {
+    sent,
+    isAttached: () => true,
+    attach: () => {},
+    detach: () => {},
+    sendCommand: (method: string) => {
+      sent.push(method)
+      return Promise.resolve({ ok: true })
+    },
+    on: () => {}
+  }
+}
+
+describe('sendCdp — the one gate every command passes', () => {
+  it('an allowed command reaches the debugger', async () => {
+    const dbg = fakeDebugger()
+    await sendCdp(dbg, 'Page.navigate', { url: 'https://x.test/' }, ctx)
+    expect(dbg.sent).toEqual(['Page.navigate'])
+  })
+
+  it('a refused command NEVER reaches the debugger, and rejects with a named message', async () => {
+    const dbg = fakeDebugger()
+    await expect(sendCdp(dbg, 'Runtime.evaluate', { expression: '1' }, ctx)).rejects.toThrow(
+      cdpRefusedMessage('Runtime.evaluate')
+    )
+    // The refusal is a rejected promise, not a hang and not a silent drop.
+    expect(dbg.sent).toEqual([])
+  })
+
+  it('a refused parameter is caught even on an allowed method', async () => {
+    const dbg = fakeDebugger()
+    await expect(sendCdp(dbg, 'Page.navigate', { url: 'javascript:alert(1)' }, ctx)).rejects.toThrow(
+      /not permitted/
+    )
+    expect(dbg.sent).toEqual([])
+  })
+})

--- a/src/main/browser-cdp-send.ts
+++ b/src/main/browser-cdp-send.ts
@@ -1,0 +1,44 @@
+/**
+ * The ONE wrapper around `debugger.sendCommand`. Every CDP command the app ever issues to a guest
+ * goes through here and through `checkCdpCommand` first — that is what makes the allowlist THE gate
+ * rather than one of several. A structural test (browser-cdp-allowlist.test.ts) fails the build if a
+ * `sendCommand(` appears in any other `src/main/browser-*.ts`.
+ *
+ * Default-deny: a command the allowlist refuses never reaches the debugger; the caller gets a NAMED
+ * rejection, not a silent drop and not a raw Electron error.
+ */
+import { checkCdpCommand, type CdpContext } from './browser-cdp-allowlist'
+
+/** The slice of Electron's `webContents.debugger` this layer needs, injected so the wrapper and the
+ *  lease are unit-testable without Electron (`src/main` cannot import the real module under vitest). */
+export interface DebuggerLike {
+  isAttached(): boolean
+  attach(protocolVersion?: string): void
+  detach(): void
+  sendCommand(method: string, commandParams?: object, sessionId?: string): Promise<unknown>
+  on(event: 'detach', listener: (event: unknown, reason: string) => void): void
+  on(event: 'message', listener: (event: unknown, method: string, params: unknown) => void): void
+}
+
+/** A refused command names the method — but never WHY, and never per-method detail: an allowlist
+ *  that explains itself is a probing aid. One line, like every control reply. */
+export const cdpRefusedMessage = (method: string): string =>
+  `browser: the command ${method} is not permitted for agent control`
+
+/**
+ * Check, then send. The single choke point. `sessionId` targets a flat-mode child session; omitting
+ * it targets the root. Throws `Error(cdpRefusedMessage(method))` — a rejected promise, never a hang —
+ * when the allowlist refuses, so the refusal is a first-class outcome the caller must handle.
+ */
+export function sendCdp(
+  dbg: DebuggerLike,
+  method: string,
+  params: object,
+  ctx: CdpContext,
+  sessionId?: string
+): Promise<unknown> {
+  if (!checkCdpCommand(method, params, ctx)) {
+    return Promise.reject(new Error(cdpRefusedMessage(method)))
+  }
+  return dbg.sendCommand(method, params, sessionId)
+}

--- a/src/main/browser-lease.test.ts
+++ b/src/main/browser-lease.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  BrowserSession,
+  BrowserLeaseManager,
+  leaseIsActive,
+  LEASE_IDLE_MS,
+  INDICATOR_LINGER_MS,
+  BROWSER_LEASE_DETACHED,
+  BROWSER_NO_LIVE_SESSION,
+  browserAttachFailedMessage,
+  browserDevToolsOpenMessage
+} from './browser-lease'
+import type { DebuggerLike } from './browser-cdp-send'
+import type { CdpContext } from './browser-cdp-allowlist'
+
+class FakeDebugger implements DebuggerLike {
+  attached = false
+  attachCalls = 0
+  detachCalls = 0
+  sends: { method: string; params?: object; sessionId?: string }[] = []
+  attachThrows = false
+  hangNext = false
+  private sessionSeq = 0
+  private detachListener: ((e: unknown, reason: string) => void) | null = null
+
+  isAttached(): boolean {
+    return this.attached
+  }
+  attach(): void {
+    this.attachCalls++
+    if (this.attachThrows) throw new Error('Another debugger is already attached')
+    this.attached = true
+  }
+  detach(): void {
+    this.detachCalls++
+    this.attached = false
+  }
+  sendCommand(method: string, params?: object, sessionId?: string): Promise<unknown> {
+    this.sends.push({ method, params, sessionId })
+    if (this.hangNext) {
+      this.hangNext = false
+      return new Promise<never>(() => {}) // never settles — models an in-flight command
+    }
+    if (method === 'Target.attachToTarget') {
+      return Promise.resolve({ sessionId: `sess-${++this.sessionSeq}` })
+    }
+    return Promise.resolve({ ok: true })
+  }
+  on(event: 'detach' | 'message', listener: (...a: never[]) => void): void {
+    if (event === 'detach') this.detachListener = listener as (e: unknown, reason: string) => void
+  }
+  fireDetach(reason = 'target closed'): void {
+    this.detachListener?.(null, reason)
+  }
+}
+
+const VIEWPORT: CdpContext = { viewport: { width: 1280, height: 800 } }
+
+function makeSession(overrides: Partial<{ isDevToolsOpen: () => boolean }> = {}): {
+  session: BrowserSession
+  dbg: FakeDebugger
+  setNow: (n: number) => void
+} {
+  const dbg = new FakeDebugger()
+  let now = 1_000_000
+  const session = new BrowserSession({
+    nodeId: 'browser-3',
+    debugger: dbg,
+    viewport: () => VIEWPORT,
+    now: () => now,
+    isDevToolsOpen: overrides.isDevToolsOpen
+  })
+  return { session, dbg, setNow: (n) => (now = n) }
+}
+
+const nav = (url = 'https://x.test/'): ['Page.navigate', { url: string }] => ['Page.navigate', { url }]
+
+describe('leaseIsActive + constants', () => {
+  it('is active only while now < leaseActiveUntil', () => {
+    expect(leaseIsActive(100, 200)).toBe(true)
+    expect(leaseIsActive(200, 200)).toBe(false)
+    expect(leaseIsActive(300, 200)).toBe(false)
+  })
+  it('the timings are the design values', () => {
+    expect(LEASE_IDLE_MS).toBe(60_000)
+    expect(INDICATOR_LINGER_MS).toBe(5_000)
+  })
+})
+
+describe('BrowserSession attach lifecycle', () => {
+  it('the first verb attaches; a second within LEASE_IDLE_MS does NOT re-attach', async () => {
+    const { session, dbg, setNow } = makeSession()
+    await session.send(...nav())
+    expect(dbg.attachCalls).toBe(1)
+    expect(dbg.sends.map((s) => s.method)).toEqual(['Page.navigate'])
+
+    setNow(1_000_000 + LEASE_IDLE_MS - 1)
+    await session.send(...nav('https://y.test/'))
+    expect(dbg.attachCalls).toBe(1) // still one attachment
+  })
+
+  it('no verb for LEASE_IDLE_MS detaches; the next verb re-attaches cleanly', async () => {
+    const { session, dbg, setNow } = makeSession()
+    await session.send(...nav())
+    expect(session.isAttached()).toBe(true)
+
+    // Idle past the window: the sweep detaches.
+    const idle = 1_000_000 + LEASE_IDLE_MS + 1
+    expect(session.maybeDetachIdle(idle)).toBe(true)
+    expect(dbg.detachCalls).toBe(1)
+    expect(session.isAttached()).toBe(false)
+
+    // A verb still inside the window does NOT detach.
+    setNow(idle)
+    await session.send(...nav())
+    expect(dbg.attachCalls).toBe(2) // re-attached
+    setNow(idle + 10)
+    expect(session.maybeDetachIdle(idle + 10)).toBe(false)
+  })
+
+  it('release() detaches, and a send in flight rejects with a NAMED outcome, not a hang', async () => {
+    const { session, dbg } = makeSession()
+    dbg.hangNext = true
+    const inFlight = session.send(...nav('https://hang.test/'))
+    expect(session.isAttached()).toBe(true)
+
+    session.release()
+    await expect(inFlight).rejects.toThrow(BROWSER_LEASE_DETACHED)
+    expect(dbg.detachCalls).toBe(1)
+    expect(session.leaseActiveUntil).toBe(0)
+  })
+
+  it('a webContents teardown (the debugger `detach` event) invalidates everything', async () => {
+    const { session, dbg } = makeSession()
+    await session.send(...nav())
+    dbg.hangNext = true
+    const inFlight = session.send(...nav('https://hang.test/'))
+    dbg.fireDetach('target closed') // Electron fires this on teardown
+    expect(session.isAttached()).toBe(false)
+    await expect(inFlight).rejects.toThrow(BROWSER_LEASE_DETACHED)
+  })
+})
+
+describe('BrowserSession attach failure', () => {
+  it('a generic attach failure is NAMED, never "not drivable"', async () => {
+    const { session, dbg } = makeSession()
+    dbg.attachThrows = true
+    await expect(session.send(...nav())).rejects.toThrow(browserAttachFailedMessage('browser-3'))
+  })
+
+  it('attach failure while DevTools is open names DevTools (unreachable on 42.8.1 — see the probe)', async () => {
+    const { session, dbg } = makeSession({ isDevToolsOpen: () => true })
+    dbg.attachThrows = true
+    await expect(session.send(...nav())).rejects.toThrow(browserDevToolsOpenMessage('browser-3'))
+  })
+})
+
+describe('BrowserSession child sessions (salvaged from S8, with credit)', () => {
+  it('attachToTarget records a flat-mode session id under (target)', async () => {
+    const { session, dbg } = makeSession()
+    const id = await session.attachTarget('t1')
+    expect(id).toBe('sess-1')
+    expect(session.sessionFor('t1')).toBe('sess-1')
+    expect(session.isValidSession('t1', 'sess-1')).toBe(true)
+    // It went out in flat mode.
+    const attach = dbg.sends.find((s) => s.method === 'Target.attachToTarget')
+    expect(attach?.params).toMatchObject({ targetId: 't1', flatten: true })
+  })
+
+  it('an explicit detach (idle) clears child sessions; a reused post-reattach id is REFUSED', async () => {
+    const { session, setNow } = makeSession()
+    await session.attachTarget('t1')
+    expect(session.isValidSession('t1', 'sess-1')).toBe(true)
+
+    // Idle detach — the attachment and its session ids die.
+    const idle = 1_000_000 + LEASE_IDLE_MS + 1
+    session.maybeDetachIdle(idle)
+    expect(session.sessionFor('t1')).toBeUndefined()
+    expect(session.isValidSession('t1', 'sess-1')).toBe(false)
+
+    // Re-attach and re-attach the target: a NEW id. The OLD id stays refused.
+    setNow(idle)
+    const fresh = await session.attachTarget('t1')
+    expect(fresh).toBe('sess-2')
+    expect(session.isValidSession('t1', 'sess-1')).toBe(false)
+    expect(session.isValidSession('t1', 'sess-2')).toBe(true)
+  })
+
+  it('a webContents teardown clears child sessions too', async () => {
+    const { session, dbg } = makeSession()
+    await session.attachTarget('t1')
+    session.handleTeardown()
+    expect(session.sessionFor('t1')).toBeUndefined()
+    // handleTeardown must NOT call detach() on a gone target.
+    expect(dbg.detachCalls).toBe(0)
+  })
+
+  it('sendToTarget refuses when the target has no live session', async () => {
+    const { session } = makeSession()
+    await expect(session.sendToTarget('t1', 'Page.getLayoutMetrics', {})).rejects.toThrow(
+      BROWSER_NO_LIVE_SESSION
+    )
+  })
+})
+
+describe('there is NO handoff-invalidation path (the feature was removed, not the care)', () => {
+  it('the source states the third S8 trigger is designed away', () => {
+    const src = readFileSync(new URL('./browser-lease.ts', import.meta.url), 'utf8')
+    expect(src).toMatch(/no handoff/i)
+    expect(src).toMatch(/removed the feature that[\s*/]+needed the care/i)
+    expect(src).toMatch(/designed away/i)
+    // And there is no handoff/claim machinery — the S8 names for it are gone.
+    expect(src).not.toMatch(/invalidateOnHandoff|onHandoff|claimUserTab|transferControl/)
+  })
+})
+
+describe('BrowserLeaseManager', () => {
+  it('owns sessions by node id, sweeps idle ones, and releases all on teardown', async () => {
+    const mgr = new BrowserLeaseManager()
+    const dbg = new FakeDebugger()
+    let now = 500
+    const s = new BrowserSession({ nodeId: 'browser-1', debugger: dbg, viewport: () => VIEWPORT, now: () => now })
+    mgr.set('browser-1', s)
+    expect(mgr.get('browser-1')).toBe(s)
+
+    await s.send(...nav())
+    expect(s.isAttached()).toBe(true)
+
+    now = 500 + LEASE_IDLE_MS + 1
+    mgr.sweepIdle(now)
+    expect(s.isAttached()).toBe(false)
+
+    mgr.releaseAll()
+    expect(mgr.get('browser-1')).toBeUndefined()
+  })
+})

--- a/src/main/browser-lease.ts
+++ b/src/main/browser-lease.ts
@@ -1,0 +1,293 @@
+/**
+ * The debugger LEASE: attach on the first verb, detach after {@link LEASE_IDLE_MS} of idleness,
+ * re-attach on the next verb. The attachment is deliberately NOT the indicator — an attach is
+ * invisible by itself and a detach-on-idle would blank a chip for a lease that is still live — so the
+ * chip binds to the ledger's `leaseActiveUntil` instead (PR 6). Every command routes through the one
+ * send wrapper ({@link import('./browser-cdp-send').sendCdp}) and therefore through the allowlist.
+ *
+ * PROBE (Task 5.0, docs/superpowers/probes/2026-08-browser-debugger.md), measured on Electron 42.8.1:
+ * a programmatic `webContents.debugger.attach()` and a user-opened DevTools window on the same
+ * <webview> guest are NOT mutually exclusive — attach succeeds with DevTools already open, and
+ * DevTools opens while a programmatic attachment stays live. So on this version the DevTools-specific
+ * attach-failure sentence ({@link browserDevToolsOpenMessage}) is UNREACHABLE: it stays wired behind
+ * an injected `isDevToolsOpen` check (design §2.3 rule 1 — name the cause, never "not drivable") in
+ * case a future Electron bump reintroduces the single-client rule, but attach does not fail for that
+ * reason today. The generic named attach-failure path is the one that runs.
+ *
+ * CDP child-session bookkeeping is lifted from PR #112's S8 with credit to @Corvin (proteus-dev) —
+ * the flat-mode `Target.attachToTarget`, the per-target session map, and BOTH invalidation points.
+ * Its THIRD invalidation trigger — a handoff to a different controlling session — is designed away
+ * rather than reimplemented: there is no handoff in this design (Task 4.3), so removing the feature
+ * that needed the care beats reimplementing the care.
+ *
+ * Electron-adjacent (holds a debugger on a page with real logins) → `src/main`, never Server Edition.
+ */
+import type { CdpContext } from './browser-cdp-allowlist'
+import { type DebuggerLike, sendCdp } from './browser-cdp-send'
+
+/** The lease outlives the last verb by this long; a verb within the window does not re-attach. */
+export const LEASE_IDLE_MS = 60_000
+/** How long the indicator (PR 6) lingers after a lease ends, so a burst of verbs does not flicker
+ *  the chip off between them. Consumed by PR 6, exported here so the two constants live together. */
+export const INDICATOR_LINGER_MS = 5_000
+
+/** Pure, so the ledger, the indicator and the discard-suppression sweep all agree on "still live". */
+export function leaseIsActive(now: number, leaseActiveUntil: number): boolean {
+  return leaseActiveUntil > now
+}
+
+/** Name the cause — a DevTools window, not a permissions failure. UNREACHABLE on Electron 42.8.1
+ *  (see the probe above); kept for a future Electron that restores the single-client rule. */
+export const browserDevToolsOpenMessage = (id: string): string =>
+  `browser: ${id} has DevTools open; close them to let an agent drive it`
+
+/** A generic, NAMED attach failure — the page likely just closed. Never "not drivable" (that reads
+ *  as a permissions verdict and sends the next debugger to the identity code). */
+export const browserAttachFailedMessage = (id: string): string =>
+  `browser: ${id} could not be attached for control (its page may have just closed); ` +
+  `bring it on screen or open a new one`
+
+/** The named outcome for a command still in flight when the lease detaches — never a hang. */
+export const BROWSER_LEASE_DETACHED =
+  'browser: the control lease detached while a command was in flight; the page was released — try again'
+
+/** The named outcome for a child-target command with no live session (invalid after a detach). */
+export const BROWSER_NO_LIVE_SESSION =
+  'browser: that page target is no longer attached (the page navigated or was released); re-read it'
+
+export interface BrowserSessionOpts {
+  /** The browser node this session drives (validated upstream in the guest registry). */
+  nodeId: string
+  /** Injected `webContents.debugger`. */
+  debugger: DebuggerLike
+  /** The current viewport, refreshed by PR 7 from `Page.getLayoutMetrics`; read at send time so a
+   *  resize between verbs is reflected in the coordinate bound. */
+  viewport: () => CdpContext
+  /** Clock, injected for tests. */
+  now?: () => number
+  /** Does the user have DevTools open on this guest? Only consulted on an attach failure. */
+  isDevToolsOpen?: () => boolean
+  /** Push the new `leaseActiveUntil` to the ledger (drives the indicator + discard suppression). */
+  onLeaseChange?: (leaseActiveUntil: number) => void
+}
+
+/**
+ * One guest's control session. Owns the attach lifecycle, the flat-mode child sessions, and the
+ * in-flight rejection on detach. Pure enough to unit-test with a fake {@link DebuggerLike}; the real
+ * attach/detach is exercised in the Electron harness.
+ */
+export class BrowserSession {
+  private readonly nodeId: string
+  private readonly dbg: DebuggerLike
+  private readonly viewport: () => CdpContext
+  private readonly now: () => number
+  private readonly isDevToolsOpen: () => boolean
+  private readonly onLeaseChange: (until: number) => void
+
+  private attached = false
+  private _leaseActiveUntil = 0
+  /**
+   * CDP child-session ids are scoped to the debugger attachment. They are invalid after either an
+   * explicit detach or webContents teardown and must never survive a reattach.
+   */
+  private readonly targets = new Map<string, string>()
+  private readonly detachRejectors = new Set<(e: Error) => void>()
+
+  constructor(opts: BrowserSessionOpts) {
+    this.nodeId = opts.nodeId
+    this.dbg = opts.debugger
+    this.viewport = opts.viewport
+    this.now = opts.now ?? Date.now
+    this.isDevToolsOpen = opts.isDevToolsOpen ?? (() => false)
+    this.onLeaseChange = opts.onLeaseChange ?? (() => {})
+    // A detach from ANY cause — our own detach, an idle detach, or a webContents teardown (which
+    // fires `detach` with reason "target closed") — invalidates the attachment and every child
+    // session, and must reject anything still in flight. One handler covers all of them.
+    this.dbg.on('detach', () => this.onDetached())
+  }
+
+  get leaseActiveUntil(): number {
+    return this._leaseActiveUntil
+  }
+
+  isAttached(): boolean {
+    return this.attached
+  }
+
+  /** The live session id for a target, or undefined. A caller must ALWAYS read this fresh — never
+   *  cache a session id across a possible detach. */
+  sessionFor(targetId: string): string | undefined {
+    return this.targets.get(targetId)
+  }
+
+  /** Is this exact session id still the live one for this target? False after any detach — which is
+   *  how a reused post-reattach session id is refused. */
+  isValidSession(targetId: string, sessionId: string): boolean {
+    return this.targets.get(targetId) === sessionId
+  }
+
+  /** Send a root-target command: attach if needed, extend the lease, and race the send against a
+   *  detach so it can never hang past a release. */
+  send(method: string, params: object): Promise<unknown> {
+    return this.dispatch(method, params, undefined)
+  }
+
+  /** Send a command to a flat-mode child target, using its LIVE session id (never a caller-supplied
+   *  one). Refused with a named outcome if the target has no live session. */
+  sendToTarget(targetId: string, method: string, params: object): Promise<unknown> {
+    const sessionId = this.targets.get(targetId)
+    if (!sessionId) return Promise.reject(new Error(BROWSER_NO_LIVE_SESSION))
+    return this.dispatch(method, params, sessionId)
+  }
+
+  /** Attach to a child target in FLAT mode, record its session id, return it. */
+  async attachTarget(targetId: string): Promise<string> {
+    const res = (await this.send('Target.attachToTarget', { targetId, flatten: true })) as {
+      sessionId?: string
+    }
+    const sessionId = res?.sessionId
+    if (typeof sessionId !== 'string' || !sessionId) {
+      throw new Error(BROWSER_NO_LIVE_SESSION)
+    }
+    this.targets.set(targetId, sessionId)
+    return sessionId
+  }
+
+  /** Detach a child target and forget its session id. No-op if it has none. */
+  async detachTarget(targetId: string): Promise<void> {
+    const sessionId = this.targets.get(targetId)
+    if (!sessionId) return
+    // Delete FIRST: even if the detach send rejects, the id must not stay usable.
+    this.targets.delete(targetId)
+    await this.send('Target.detachFromTarget', { sessionId })
+  }
+
+  /** Detach if the lease has gone idle. Returns whether it detached (for the sweep's logging). */
+  maybeDetachIdle(now: number = this.now()): boolean {
+    if (this.attached && !leaseIsActive(now, this._leaseActiveUntil)) {
+      this.detachInternal()
+      return true
+    }
+    return false
+  }
+
+  /** The session is ending (owner gone, project closed, app teardown): detach and reject in-flight. */
+  release(): void {
+    this.detachInternal()
+    this._leaseActiveUntil = 0
+    this.onLeaseChange(0)
+  }
+
+  /** The webContents was torn down under us: the attachment and every session id are already dead —
+   *  forget them and reject in-flight, but do NOT call `detach()` on a gone target. (This is the
+   *  second of the two invalidation points; the `detach` event usually beats us here, and this makes
+   *  the teardown path correct even if it does not.) */
+  handleTeardown(): void {
+    this.onDetached()
+    this._leaseActiveUntil = 0
+    this.onLeaseChange(0)
+  }
+
+  // There is deliberately NO handoff-invalidation path: this design has no handoff (Task 4.3), so the
+  // class of bug S8's third trigger guarded against cannot occur here. We removed the feature that
+  // needed the care rather than reimplementing the care.
+
+  private dispatch(method: string, params: object, sessionId: string | undefined): Promise<unknown> {
+    try {
+      this.ensureAttached()
+    } catch (e) {
+      return Promise.reject(e)
+    }
+    this.extendLease()
+    return this.race(sendCdp(this.dbg, method, params, this.viewport(), sessionId))
+  }
+
+  private ensureAttached(): void {
+    if (this.attached) return
+    try {
+      this.dbg.attach('1.3')
+    } catch {
+      const msg = this.isDevToolsOpen()
+        ? browserDevToolsOpenMessage(this.nodeId)
+        : browserAttachFailedMessage(this.nodeId)
+      throw new Error(msg)
+    }
+    this.attached = true
+  }
+
+  private extendLease(): void {
+    this._leaseActiveUntil = this.now() + LEASE_IDLE_MS
+    this.onLeaseChange(this._leaseActiveUntil)
+  }
+
+  private detachInternal(): void {
+    if (this.attached) {
+      try {
+        this.dbg.detach()
+      } catch {
+        // A detach on an already-gone target throws; the state cleanup below is what matters.
+      }
+    }
+    this.onDetached()
+  }
+
+  private onDetached(): void {
+    this.attached = false
+    this.targets.clear()
+    this.rejectInFlight()
+  }
+
+  private rejectInFlight(): void {
+    const rejectors = [...this.detachRejectors]
+    this.detachRejectors.clear()
+    for (const reject of rejectors) reject(new Error(BROWSER_LEASE_DETACHED))
+  }
+
+  private race<T>(p: Promise<T>): Promise<T> {
+    let rejector!: (e: Error) => void
+    const guard = new Promise<never>((_, reject) => {
+      rejector = reject
+      this.detachRejectors.add(rejector)
+    })
+    return Promise.race([p, guard]).finally(() => {
+      this.detachRejectors.delete(rejector)
+    }) as Promise<T>
+  }
+}
+
+/**
+ * Owns every live {@link BrowserSession}, keyed by node id. index.ts holds one of these (PR 7 wires
+ * real guests to it; in PR 5 it is inert but real). Its `targetSessions` view — nodeId → (targetId →
+ * sessionId) — is the S8 aggregate the child-session bookkeeping lives under.
+ */
+export class BrowserLeaseManager {
+  private readonly sessions = new Map<string, BrowserSession>()
+
+  get(nodeId: string): BrowserSession | undefined {
+    return this.sessions.get(nodeId)
+  }
+
+  set(nodeId: string, session: BrowserSession): void {
+    this.sessions.set(nodeId, session)
+  }
+
+  /** Release + drop one node's session (its guest is gone or its owner was released). */
+  release(nodeId: string): void {
+    const session = this.sessions.get(nodeId)
+    if (!session) return
+    session.release()
+    this.sessions.delete(nodeId)
+  }
+
+  /** Idle sweep: detach every session whose lease has expired. Sessions stay in the map (they
+   *  re-attach on the next verb); only the debugger attachment is dropped. */
+  sweepIdle(now: number): void {
+    for (const session of this.sessions.values()) session.maybeDetachIdle(now)
+  }
+
+  /** App teardown: release everything. */
+  releaseAll(): void {
+    for (const session of this.sessions.values()) session.release()
+    this.sessions.clear()
+  }
+}

--- a/src/main/browser-nt-scripts.source.test.ts
+++ b/src/main/browser-nt-scripts.source.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { NT_SCRIPTS, isNtScript } from './browser-nt-scripts'
+
+/**
+ * A SOURCE-LEVEL test, same enforcement style as hook-verified-parity.test.ts.
+ *
+ * The residual risk of excluding Runtime.evaluate is that OUR wrapper scripts still run in the
+ * page's origin with full authority. A stray template literal, a `new Function`, an innerHTML sink
+ * in one of them is a complete escape and hands the agent everything Runtime.evaluate would have.
+ * Three things pay that down and they are requirements, not suggestions; this is the second.
+ */
+const BANNED = ['`', '${', 'eval', 'Function', 'innerHTML', 'outerHTML', 'setTimeout(', 'import(', 'document.cookie', 'localStorage', 'sessionStorage', 'fetch(', 'XMLHttpRequest']
+
+describe('NT_SCRIPTS is a frozen table of literals', () => {
+  const src = readFileSync(new URL('./browser-nt-scripts.ts', import.meta.url), 'utf8')
+
+  it.each(BANNED)('the source contains no %s', (needle) => {
+    expect(src.includes(needle)).toBe(false)
+  })
+
+  it('contains no string concatenation inside the table', () => {
+    // `expression: 'document.querySelector("' + sel + '")'` is the injection this whole design
+    // exists to make unrepresentable. The selector arrives as arguments[].value, never as source.
+    const table = src.slice(src.indexOf('export const NT_SCRIPTS'))
+    expect(table).not.toMatch(/'\s*\+|\+\s*'/)
+  })
+
+  it('is frozen at runtime, deeply', () => {
+    expect(Object.isFrozen(NT_SCRIPTS)).toBe(true)
+    expect(() => {
+      // @ts-expect-error deliberate
+      NT_SCRIPTS.readMap = 'x'
+    }).toThrow()
+  })
+
+  it('isNtScript is IDENTITY membership, not a shape check', () => {
+    expect(isNtScript(NT_SCRIPTS.readMap)).toBe(true)
+    expect(isNtScript(NT_SCRIPTS.readMap + ' ')).toBe(false)
+    expect(isNtScript('function(){return 1}')).toBe(false)
+  })
+
+  it('every script is a pure reader — none clicks, navigates, submits or writes', () => {
+    // Every EFFECT goes through Input.* or Page.*, which is also why the effects are traceable.
+    for (const s of Object.values(NT_SCRIPTS)) {
+      for (const bad of ['.click(', '.submit(', 'location =', 'location.href', '.value =', '.remove(']) {
+        expect(s.includes(bad), `${bad} in ${s.slice(0, 40)}`).toBe(false)
+      }
+    }
+  })
+})

--- a/src/main/browser-nt-scripts.ts
+++ b/src/main/browser-nt-scripts.ts
@@ -1,0 +1,75 @@
+/**
+ * The page-side script table.
+ *
+ * Arbitrary page-side script running is excluded from the CDP allowlist (browser-cdp-allowlist.ts),
+ * so all page-side logic runs through CDP's call-a-function-on-object method against THIS table, and
+ * agent input reaches a script only as an argument value, never as source. That moves the risk from
+ * "arbitrary JS in the page's origin" to "a bug in OUR scripts" — a much smaller surface, but not
+ * zero: a stray template literal or a dynamic-code sink in one of these is a complete escape.
+ *
+ * Three things hold the line and each is a requirement:
+ *   1. every entry is a plain single-quoted string literal with NO interpolation and NO
+ *      concatenation — the selector is passed in, never spliced into source;
+ *   2. a source-level test (browser-nt-scripts.source.test.ts) fails the build if this file gains a
+ *      backtick, a dollar-brace interpolation, a dynamic-code token, an HTML-writing sink or a
+ *      token-store reference, if the table stops being frozen, or if isNtScript stops being identity
+ *      membership;
+ *   3. every script is a PURE READER — it clicks nothing, navigates nothing, submits nothing and
+ *      assigns nothing. Every EFFECT goes through Input.* / Page.* instead, which is also what makes
+ *      an effect traceable.
+ *
+ * The table holds only what PRs 7-8 need. Each reader takes its inputs as ordinary parameters,
+ * supplied as argument VALUES by the CDP call — the string in arguments[].value, checked scalar in
+ * the allowlist, is the only agent-controlled data that ever reaches these functions.
+ */
+export const NT_SCRIPTS = Object.freeze({
+  /** The document title. */
+  readTitle: 'function(){ return document.title }',
+
+  /** A map of interactable elements: a ref index, a tag, a short label and the element centre in
+   *  viewport coordinates (what a later Input.dispatchMouseEvent aims at). Read-only. */
+  readMap:
+    'function(){ var els = document.querySelectorAll("a,button,input,textarea,select,[role=button],[role=link],[onclick]"); var out = []; for (var i = 0; i < els.length; i++) { var el = els[i]; var r = el.getBoundingClientRect(); if (r.width <= 0 || r.height <= 0) continue; out.push({ ref: i, tag: el.tagName, type: el.getAttribute("type"), text: (el.innerText || el.getAttribute("aria-label") || el.getAttribute("placeholder") || "").replace(/\\s+/g, " ").trim().slice(0, 80), x: r.left + r.width / 2, y: r.top + r.height / 2, w: r.width, h: r.height }); } return out }',
+
+  /** Every visible link as { href, text }. Read-only. */
+  readLinks:
+    'function(){ var as = document.querySelectorAll("a[href]"); var out = []; for (var i = 0; i < as.length; i++) { out.push({ href: as[i].href, text: (as[i].innerText || "").replace(/\\s+/g, " ").trim().slice(0, 120) }); } return out }',
+
+  /** The visible text of a selector (or the whole body when none is given). Read-only, capped. */
+  readText:
+    'function(sel){ var el = sel ? document.querySelector(sel) : document.body; return el ? (el.innerText || "").slice(0, 20000) : null }',
+
+  /** Re-locate a ref from readMap and return its current centre and tag, or null if it is gone. The
+   *  ref is re-resolved against the SAME enumeration; generation staleness is enforced in main. */
+  resolveRef:
+    'function(i){ var els = document.querySelectorAll("a,button,input,textarea,select,[role=button],[role=link],[onclick]"); var el = els[i]; if (!el) return null; var r = el.getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2, tag: el.tagName, w: r.width, h: r.height } }',
+
+  /** Resolve a CSS selector to its current centre and tag, or null. Read-only. */
+  resolveSelector:
+    'function(s){ var el = document.querySelector(s); if (!el) return null; var r = el.getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2, tag: el.tagName, w: r.width, h: r.height } }',
+
+  /** Describe a selector's element without exposing its markup: tag, id, role, label, short text. */
+  describeElement:
+    'function(s){ var el = document.querySelector(s); if (!el) return null; return { tag: el.tagName, id: el.id, role: el.getAttribute("role"), label: el.getAttribute("aria-label"), disabled: !!el.disabled, text: (el.innerText || "").replace(/\\s+/g, " ").trim().slice(0, 120) } }',
+
+  /** Is a selector's element on-screen and displayed? Read-only. */
+  isVisible:
+    'function(s){ var el = document.querySelector(s); if (!el) return false; var r = el.getBoundingClientRect(); var st = getComputedStyle(el); return r.width > 0 && r.height > 0 && st.visibility !== "hidden" && st.display !== "none" }',
+
+  /** A readiness probe: is the document loaded, and (optionally) is a selector present yet? */
+  waitProbe:
+    'function(s){ if (document.readyState !== "complete") return false; if (!s) return true; return document.querySelector(s) != null }'
+})
+
+export type NtScriptName = keyof typeof NT_SCRIPTS
+
+const NT_SCRIPT_VALUES: ReadonlySet<string> = new Set(Object.values(NT_SCRIPTS))
+
+/**
+ * IDENTITY membership: is fn byte-for-byte one of the table's entries? Never a shape check, never
+ * a prefix match — a value that merely LOOKS like a reader is refused. This is what the allowlist's
+ * call-a-function check leans on, so a trailing space or an added statement makes it a stranger.
+ */
+export function isNtScript(fn: string): boolean {
+  return NT_SCRIPT_VALUES.has(fn)
+}

--- a/src/main/browser-refs.test.ts
+++ b/src/main/browser-refs.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { RefTable, refStaleMessage } from './browser-refs'
+
+const items = () => [
+  { ref: 0, tag: 'A', text: 'Home' },
+  { ref: 1, tag: 'BUTTON', text: 'Delete account' },
+  { ref: 2, tag: 'A', text: 'Next page' }
+]
+
+describe('RefTable — @refs are scoped to a node AND a navigation generation', () => {
+  it('--read map mints @1…@n bound to (nodeId, gen)', () => {
+    const t = new RefTable()
+    const { gen, labels } = t.mint('browser-1', 0, items())
+    expect(gen).toBe(0)
+    expect(labels).toEqual(['@1', '@2', '@3'])
+    const r = t.resolve('browser-1', 0, '@2')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.item).toMatchObject({ tag: 'BUTTON', text: 'Delete account' })
+  })
+
+  it('a stale ref is a REFUSAL, not a re-resolution — this is a correctness property first', () => {
+    // A stale ref that silently re-resolves is how an agent clicks "Delete account" while meaning
+    // "Next page".
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    // Page.frameNavigated bumps the generation and invalidates EVERY ref.
+    t.bumpGeneration('browser-1')
+    const r = t.resolve('browser-1', 0, '@2')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.stale).toBe(true)
+      // It is the design's exact sentence, and it never carries a re-resolved item.
+      expect(r.message).toBe(
+        '@2 is not on the current page (the page navigated since the last --read map; re-read it)'
+      )
+      expect(r).not.toHaveProperty('item')
+    }
+  })
+
+  it('Runtime.executionContextsCleared bumps the generation too (same single invalidation path)', () => {
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    // Both Page.frameNavigated and Runtime.executionContextsCleared are wired to bumpGeneration.
+    t.bumpGeneration('browser-1')
+    t.bumpGeneration('browser-1')
+    expect(t.currentGeneration('browser-1')).toBe(2)
+    expect(t.resolve('browser-1', 0, '@1').ok).toBe(false)
+  })
+
+  it('a bump DROPS the old items, so a ref does not resolve even at the NEW generation', () => {
+    // Without clearing, an agent that already knows the new gen could resolve a handle that
+    // described the page BEFORE it navigated — the exact "@ref is silently stale" bug.
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    t.bumpGeneration('browser-1') // now on gen 1, no fresh map read yet
+    const r = t.resolve('browser-1', 1, '@1')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.message).not.toContain('Delete account')
+  })
+
+  it('after a fresh --read map at the new generation, its refs resolve again', () => {
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    t.bumpGeneration('browser-1') // now on gen 1
+    t.mint('browser-1', 1, items()) // re-read map at gen 1
+    expect(t.resolve('browser-1', 1, '@3').ok).toBe(true)
+    // The old-generation ref is still refused.
+    expect(t.resolve('browser-1', 0, '@3').ok).toBe(false)
+  })
+
+  it('the exact stale sentence is exported and reusable', () => {
+    expect(refStaleMessage('@7')).toBe(
+      '@7 is not on the current page (the page navigated since the last --read map; re-read it)'
+    )
+  })
+
+  it('a ref from ANOTHER node never resolves', () => {
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    expect(t.resolve('browser-2', 0, '@1').ok).toBe(false)
+  })
+
+  it('a label that was never minted at the current generation is refused (not a guess)', () => {
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    const r = t.resolve('browser-1', 0, '@99')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.stale).toBe(false) // present generation, but no such ref — not a nav-stale
+  })
+})

--- a/src/main/browser-refs.ts
+++ b/src/main/browser-refs.ts
@@ -1,0 +1,103 @@
+/**
+ * `@ref` bookkeeping for `--read map` / `--read text`. A ref (`@7`) is a HANDLE the agent later spends
+ * on a click or a describe, and its whole safety rests on two scopes:
+ *   1. it belongs to ONE node — a ref minted on browser-1 never resolves on browser-2;
+ *   2. it belongs to ONE navigation generation — the moment the page navigates, every ref from the
+ *      previous map is dead.
+ *
+ * A stale ref is a REFUSAL, never a best-effort re-resolution. A ref that silently re-resolves after a
+ * navigation is how an agent clicks "Delete account" while meaning "Next page" — so this is a
+ * correctness property before it is a security one. The generation is bumped by BOTH Page.frameNavigated
+ * and Runtime.executionContextsCleared (PR 7 wires those events to {@link RefTable.bumpGeneration});
+ * both funnel through the one invalidation path so neither can be forgotten independently.
+ *
+ * Main-side (its inputs come from CDP), never Server Edition.
+ */
+
+export type RefItem = Record<string, unknown>
+
+export interface MintResult {
+  /** The generation these refs are stamped with (echoes the `gen` passed in). */
+  gen: number
+  /** `['@1', '@2', …]`, in item order. */
+  labels: string[]
+}
+
+export type RefResolution =
+  | { ok: true; label: string; gen: number; item: RefItem }
+  | { ok: false; stale: boolean; message: string }
+
+/** The design's exact sentence for a ref killed by a navigation. Exported so PR 7's reply path and
+ *  the tests share one string — the wording is a contract (it tells the agent to re-read the map). */
+export const refStaleMessage = (label: string): string =>
+  `${label} is not on the current page (the page navigated since the last --read map; re-read it)`
+
+/** For a label that is simply not in the current map (out of range, or a node that never read a map).
+ *  Distinct from stale: nothing navigated, the handle was just never minted here. */
+export const refUnknownMessage = (label: string): string =>
+  `${label} is not a ref from the last --read map on this page`
+
+interface NodeRefs {
+  gen: number
+  items: Map<string, RefItem>
+}
+
+export class RefTable {
+  private readonly byNode = new Map<string, NodeRefs>()
+
+  /** The generation the node is currently on (0 before anything is minted or bumped). */
+  currentGeneration(nodeId: string): number {
+    return this.byNode.get(nodeId)?.gen ?? 0
+  }
+
+  /**
+   * Mint `@1…@n` for a fresh `--read map`, stamped with `gen`. A mint REPLACES the node's table (a new
+   * read supersedes the old one entirely) and establishes `gen` as the current generation.
+   */
+  mint(nodeId: string, gen: number, items: readonly RefItem[]): MintResult {
+    const map = new Map<string, RefItem>()
+    const labels: string[] = []
+    for (let i = 0; i < items.length; i++) {
+      const label = `@${i + 1}`
+      labels.push(label)
+      map.set(label, items[i])
+    }
+    this.byNode.set(nodeId, { gen, items: map })
+    return { gen, labels }
+  }
+
+  /**
+   * Resolve a ref for a node at the generation the agent read it on. Returns the item ONLY when the
+   * node's current generation still equals `gen` AND the label was minted then. Anything else is a
+   * refusal — a stale refusal (naming the navigation) when the generation moved on, an unknown refusal
+   * when the label was never a ref here. NEVER a re-resolution against a different generation's map.
+   */
+  resolve(nodeId: string, gen: number, label: string): RefResolution {
+    const entry = this.byNode.get(nodeId)
+    const current = entry?.gen ?? 0
+    if (!entry || gen !== current) {
+      return { ok: false, stale: true, message: refStaleMessage(label) }
+    }
+    const item = entry.items.get(label)
+    if (!item) {
+      return { ok: false, stale: false, message: refUnknownMessage(label) }
+    }
+    return { ok: true, label, gen: current, item }
+  }
+
+  /**
+   * The page navigated (or its execution contexts were cleared): advance the generation and drop every
+   * ref. The single invalidation path — both CDP events call this, so a ref cannot outlive the page it
+   * described.
+   */
+  bumpGeneration(nodeId: string): number {
+    const nextGen = this.currentGeneration(nodeId) + 1
+    this.byNode.set(nodeId, { gen: nextGen, items: new Map() })
+    return nextGen
+  }
+
+  /** Forget a node entirely (its guest is gone / owner released). */
+  forget(nodeId: string): void {
+    this.byNode.delete(nodeId)
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ installLogSink(logBuffer)
 import { writeFilesToClipboard } from './clipboard-files'
 import { allowGuestNavigation } from './webview-nav'
 import { BrowserControlLedger } from './browser-control-ledger'
+import { BrowserLeaseManager } from './browser-lease'
 import { registerFsHandlers } from '../core/fs-handlers'
 import { LogBuffer } from '../core/log-buffer'
 import { installLogSink, splitTag } from '../core/log-sink'
@@ -2326,6 +2327,12 @@ app.whenReady().then(async () => {
   // Who owns which agent-opened browser node, THIS app run only. In-memory, never persisted, never
   // read from project.json (Task 4.3/4.4). Consumed by PR 5 (attach/lease), PR 6 (indicator/Stop).
   const browserLedger = new BrowserControlLedger()
+  // Holds the debugger lease per driven browser node. Built and unit-tested in PR 5 but INERT here:
+  // no `browser` verb exists until PR 7, so nothing attaches a guest to it yet. PR 7 wires each
+  // guest's `webContents.debugger` into a BrowserSession, starts the idle sweep, and releases on
+  // owner/project/app teardown. Owned here so that wiring has one home. See browser-lease.ts.
+  const browserLeases = new BrowserLeaseManager()
+  void browserLeases
   ipcMain.on(
     IPC.agentControlResult,
     (

--- a/src/renderer/nodes/browserUrl.ts
+++ b/src/renderer/nodes/browserUrl.ts
@@ -1,26 +1,7 @@
-// Normalize an address-bar entry into an http(s) URL, or null when it can't be one.
-// Blocks file:/javascript:/data:/custom schemes; adds https:// to a bare host. No search fallback.
-export function normalizeAddress(input: string): string | null {
-  const raw = input.trim()
-  if (!raw) return null
-  // Already a URL with a scheme?
-  if (/^[a-z][a-z0-9+.-]*:/i.test(raw)) {
-    try {
-      const u = new URL(raw)
-      return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : null
-    } catch {
-      return null
-    }
-  }
-  // No scheme: only treat as a host if it has a dot and no spaces.
-  if (/\s/.test(raw) || !raw.includes('.')) return null
-  try {
-    const u = new URL(`https://${raw}`)
-    return u.toString()
-  } catch {
-    return null
-  }
-}
+// `normalizeAddress` now lives in `src/shared` so main's CDP allowlist can reuse the exact scheme
+// check the address bar uses (they must never disagree about javascript:/file:/data:). Re-exported
+// here so every existing `../nodes/browserUrl` import path is unchanged.
+export { normalizeAddress } from '@shared/browserUrl'
 
 function googleSearch(query: string): string {
   return `https://www.google.com/search?q=${encodeURIComponent(query)}`

--- a/src/shared/browserUrl.ts
+++ b/src/shared/browserUrl.ts
@@ -1,0 +1,29 @@
+// Address-bar normalization, in `src/shared` because BOTH shells need it: the renderer's address bar
+// (re-exported from `renderer/nodes/browserUrl.ts`, so no existing import path changes) and main's
+// CDP allowlist, whose `Page.navigate` validator reuses THIS scheme check rather than re-deriving it
+// — one place decides "is this an http(s) URL", so the address bar and the allowlist can never drift
+// into disagreeing about `javascript:`/`file:`/`data:`.
+
+// Normalize an address-bar entry into an http(s) URL, or null when it can't be one.
+// Blocks file:/javascript:/data:/custom schemes; adds https:// to a bare host. No search fallback.
+export function normalizeAddress(input: string): string | null {
+  const raw = input.trim()
+  if (!raw) return null
+  // Already a URL with a scheme?
+  if (/^[a-z][a-z0-9+.-]*:/i.test(raw)) {
+    try {
+      const u = new URL(raw)
+      return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : null
+    } catch {
+      return null
+    }
+  }
+  // No scheme: only treat as a host if it has a dot and no spaces.
+  if (/\s/.test(raw) || !raw.includes('.')) return null
+  try {
+    const u = new URL(`https://${raw}`)
+    return u.toString()
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## S8 PR 5 of #112 — the security core

Builds the gate CDP passes through before it can drive a browser: the allowlist, the page-side script
table, the debugger lease, and the `@ref` bookkeeping. **Ships inert-but-tested — no `browser` verb
exists yet (that is PR 7); nothing calls this machinery until then.** PRs 1–4 merged (#205/#206/#213/#304).

### Tasks → commits

| Task | Commit | What |
|------|--------|------|
| 5.0 PROBE | `docs(browser): probe …` | Measured `debugger.attach()` vs open DevTools on Electron 42.8.1 |
| 5.1 `NT_SCRIPTS` | `feat(browser): NT_SCRIPTS …` | Frozen table of pure-reader literals, pinned by a source-level test |
| 5.2 `checkCdpCommand` | `feat(browser): a CDP allowlist …` | (method, params-validator) pairs, default-deny, enforced in main |
| 5.3 the lease | `feat(browser): a debugger lease …` | Attach on first verb, detach after 60s idle; child sessions; one send wrapper |
| 5.4 memory-saver interlock | *(already merged at origin/main — see below)* | `driven` suppressor + discarded message |
| 5.5 `@refs` | `feat(browser): @refs are scoped …` | Node- and generation-scoped; a stale ref is a refusal |

### PROBE result (Task 5.0)

On **Electron 42.8.1**, a programmatic `webContents.debugger.attach()` and a user-opened DevTools
window on the same `<webview>` guest are **NOT mutually exclusive** — attach succeeds with DevTools
already open, and DevTools opens while a programmatic attachment stays live (measured twice on a real
webview under xvfb; `docs/superpowers/probes/2026-08-browser-debugger.md`). This **refines** the
design rather than contradicting it: the design's `[UNVERIFIED] 2` worry does not reproduce, so Task
5.3's DevTools-specific attach-failure sentence is unreachable on this version — it stays wired behind
an injected `isDevToolsOpen` check for a future Electron that restores the single-client rule, and the
generic **named** attach-failure path is the one that runs. Not blocked.

### The single gate

- `checkCdpCommand` is the **only** allowlist and it is **default-deny**: an unknown method or an
  unvalidated parameter is refused with no per-method detail. Excluded outright and for stated reasons:
  arbitrary page-side evaluation + the whole Debugger domain, Fetch, Security, Storage/IndexedDB/
  DOMStorage, `DOM.getOuterHTML`/`getAttributes`, `Page.bringToFront`, `Network.getAllCookies`.
- **Structural pin:** a test asserts the only `sendCommand(` in `src/main/browser-*.ts` lives in the
  one wrapper `browser-cdp-send.ts`, so the gate is unbypassable.
- `NT_SCRIPTS` is a frozen const of plain literals; a source-level test reddens on a backtick, a
  dollar-brace interpolation, a dynamic-code token, an HTML-writing sink or a token store, and every
  script is a pure reader. `isNtScript` is byte-for-byte identity, never a prefix.
- Real-webview harness confirmed the permitted CDP path against a live guest: attach → an actual
  `NT_SCRIPTS` reader via `Runtime.callFunctionOn` (`readTitle` → `"Hello NT"`, `readMap` → 3
  interactable items with sane centres) → detach.

### Task 5.4 note

The behavioural core of 5.4 — the `driven` discard suppressor (`browser-discard-policy.ts` /
`useDiscardWhenHidden.ts`) and `browserDiscardedMessage` — **is already merged at `origin/main`**
(commit `5b4a883b` + the guest-registry message), with its tests. This PR does not re-touch it. The
remaining renderer-side lease-push plumbing (`useBrowserLease` store + `browserLeaseChanged` IPC +
feeding `BrowserSurface`) is **deliberately deferred**: its producer (the lease broadcasting) is inert
until PR 7, and the store is consumed by PR 6's chip — landing dead plumbing here, disconnected from
any producer, would only invite conflicts with PR 6/7.

### Boundaries & discipline

- All CDP/lease/ref code is **`src/main`** (Electron-adjacent), off Server Edition; `no-electron.test.ts`
  still green. `normalizeAddress` moved to `src/shared/browserUrl.ts` (re-exported from the renderer
  path, no import churn) so the address bar and the allowlist cannot drift on scheme checks.
- The lease manager is **owned in `index.ts` but inert** (no guest attaches until PR 7).
- Ownership stays with the `#304` ledger keyed on the verified caller — nothing here reads a
  caller-supplied field or `project.json`.

### Verification

- `npm run typecheck` clean; full `npx vitest run` = **517 files / 7085 tests pass**, 0 failures.
- **Mutation-check** (revert → red → restore): 5.1 **3/3**, 5.2 **4/4**, 5.3 **4/4**, 5.5 **3/3**.

CDP child-session bookkeeping and the browser-use backend design are salvaged from @Corvin's #112 (S8)
with credit in the commit trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
