### PR TITLE
feat(browser): the driving indicator and Stop

### DIFF
--- a/src/main/browser-control-ledger.ts
+++ b/src/main/browser-control-ledger.ts
@@ -26,6 +26,14 @@
  * never needed on the Server Edition, where browser control cannot exist.
  */
 
+/**
+ * The refusal a drive gets after the USER stopped control of a node (PR 6 Task 6.4). Named after the
+ * human act, not a permissions verdict, so the agent REPORTS it ("the user stopped me") instead of
+ * retrying an outage. Consulted by the drive path in PR 7 via {@link BrowserControlLedger.wasStoppedByUser};
+ * the `browser-3:` prefix matches the numbered refusal family (`browser-1`/`browser-2` in the shim).
+ */
+export const BROWSER_USER_STOPPED = 'browser-3: the user stopped agent control of this node'
+
 export interface AgentBrowserEntry {
   /** The agent node that ran open-browser. Drives are admitted only for THIS owner. */
   ownerNodeId: string
@@ -43,6 +51,15 @@ export interface AgentBrowserEntry {
 export class BrowserControlLedger {
   /** browserNodeId → its ownership entry, for browser nodes an agent opened THIS run. */
   private readonly entries = new Map<string, AgentBrowserEntry>()
+  /**
+   * browserNodeId → the owner the USER stopped control for. A tombstone, not an entry: it outlives
+   * the deleted ownership so a subsequent drive from that same owner answers {@link BROWSER_USER_STOPPED}
+   * instead of the generic not-owned null (which reads as "retryable"). Set ONLY by {@link stopByUser}
+   * (chip/menu/Settings/switch-off — the human acts), never by lifecycle revocation (node/project
+   * close, owner gone, quit), and cleared by a fresh {@link claim} so re-opening a node is a clean
+   * slate. In-memory like the ledger itself — a restart forgets it, which is correct.
+   */
+  private readonly userStopped = new Map<string, string>()
 
   /**
    * Record ownership of a freshly opened browser node. Returns false — and changes NOTHING — if the
@@ -56,6 +73,10 @@ export class BrowserControlLedger {
     if (!browserNodeId || !e.ownerNodeId || !e.projectId) return false
     if (this.entries.has(browserNodeId)) return false
     this.entries.set(browserNodeId, { ...e })
+    // A fresh, verified open is a clean slate: a node the user stopped earlier and then genuinely
+    // re-opened is drivable again. (Ids are not reused within a run, so in practice this clears a
+    // stale tombstone rather than masking a live refusal.)
+    this.userStopped.delete(browserNodeId)
     return true
   }
 
@@ -103,6 +124,65 @@ export class BrowserControlLedger {
       if (e.leaseActiveUntil > now) live.push({ browserNodeId, ownerNodeId: e.ownerNodeId })
     }
     return live
+  }
+
+  /** The same live set, shaped for the renderer push (adds `leaseActiveUntil` so the chip can apply
+   *  its linger). Separate from {@link activeLeases} so that method's asserted shape is untouched. */
+  activeLeasesForPush(now: number): {
+    browserNodeId: string
+    ownerNodeId: string
+    leaseActiveUntil: number
+  }[] {
+    const live: { browserNodeId: string; ownerNodeId: string; leaseActiveUntil: number }[] = []
+    for (const [browserNodeId, e] of this.entries) {
+      if (e.leaseActiveUntil > now) {
+        live.push({ browserNodeId, ownerNodeId: e.ownerNodeId, leaseActiveUntil: e.leaseActiveUntil })
+      }
+    }
+    return live
+  }
+
+  /**
+   * The USER stopped control of this node (chip/menu/Settings/switch-off). Records the tombstone
+   * against its current owner FIRST, then drops the entry — so a later drive from that owner is
+   * refused with the named human act, not the generic null. A no-op tombstone-wise if the node was
+   * already unclaimed (nothing to name an owner). Lifecycle revocation uses {@link release}, which
+   * leaves no tombstone.
+   */
+  stopByUser(browserNodeId: string): void {
+    const entry = this.entries.get(browserNodeId)
+    if (entry) this.userStopped.set(browserNodeId, entry.ownerNodeId)
+    this.entries.delete(browserNodeId)
+  }
+
+  /** Did the user stop control of this node for THIS exact owner? The drive path (PR 7) asks this to
+   *  choose {@link BROWSER_USER_STOPPED} over a retry. Owner-scoped so it can never leak node
+   *  existence to a different agent than the one that was driving. */
+  wasStoppedByUser(browserNodeId: string, ownerNodeId: string): boolean {
+    return this.userStopped.get(browserNodeId) === ownerNodeId
+  }
+
+  /** Every browser node this owner opened (claimed, live-lease or not) — the set to revoke when the
+   *  owner node closes or restarts. */
+  idsByOwner(ownerNodeId: string): string[] {
+    return this.idsWhere((e) => e.ownerNodeId === ownerNodeId)
+  }
+
+  /** Every browser node opened under this project — the set to revoke when the project's switch goes
+   *  off (a project close revokes per-node via the guest teardown instead). */
+  idsByProject(projectId: string): string[] {
+    return this.idsWhere((e) => e.projectId === projectId)
+  }
+
+  /** Every claimed browser node — the set to revoke on app quit. */
+  allIds(): string[] {
+    return [...this.entries.keys()]
+  }
+
+  private idsWhere(pred: (e: AgentBrowserEntry) => boolean): string[] {
+    const ids: string[] = []
+    for (const [browserNodeId, e] of this.entries) if (pred(e)) ids.push(browserNodeId)
+    return ids
   }
 
   private releaseWhere(pred: (e: AgentBrowserEntry) => boolean): string[] {

--- a/src/main/browser-lease.ts
+++ b/src/main/browser-lease.ts
@@ -24,12 +24,14 @@
  */
 import type { CdpContext } from './browser-cdp-allowlist'
 import { type DebuggerLike, sendCdp } from './browser-cdp-send'
+// The indicator's linger now lives in `src/shared` (PR 6 consumes it from the renderer too, and a
+// renderer→main import is forbidden — global constraint 4). Re-exported here so the debugger-lease
+// timings still read together at this one call site and every existing importer is unaffected.
+import { INDICATOR_LINGER_MS } from '@shared/browser-indicator'
 
 /** The lease outlives the last verb by this long; a verb within the window does not re-attach. */
 export const LEASE_IDLE_MS = 60_000
-/** How long the indicator (PR 6) lingers after a lease ends, so a burst of verbs does not flicker
- *  the chip off between them. Consumed by PR 6, exported here so the two constants live together. */
-export const INDICATOR_LINGER_MS = 5_000
+export { INDICATOR_LINGER_MS }
 
 /** Pure, so the ledger, the indicator and the discard-suppression sweep all agree on "still live". */
 export function leaseIsActive(now: number, leaseActiveUntil: number): boolean {

--- a/src/main/browser-revocation.test.ts
+++ b/src/main/browser-revocation.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import {
+  revokeBrowserNode,
+  revokeBrowserByOwner,
+  revokeBrowserByProject,
+  revokeAllBrowser,
+  type RevocationTargets
+} from './browser-revocation'
+import { BrowserControlLedger, BROWSER_USER_STOPPED } from './browser-control-ledger'
+import { BrowserSession, BrowserLeaseManager, BROWSER_LEASE_DETACHED } from './browser-lease'
+import type { DebuggerLike } from './browser-cdp-send'
+import type { CdpContext } from './browser-cdp-allowlist'
+
+// A debugger that records attach/detach and can hold a command in flight — the same shape
+// browser-lease.test.ts drives, because a revocation is only proven if it hits a REAL
+// BrowserSession's real detach/reject, not a stub.
+class FakeDebugger implements DebuggerLike {
+  attached = false
+  detachCalls = 0
+  hangNext = false
+  private detachListener: ((e: unknown, reason: string) => void) | null = null
+  isAttached(): boolean {
+    return this.attached
+  }
+  attach(): void {
+    this.attached = true
+  }
+  detach(): void {
+    this.detachCalls++
+    this.attached = false
+  }
+  sendCommand(_m: string, _p?: object): Promise<unknown> {
+    if (this.hangNext) {
+      this.hangNext = false
+      return new Promise<never>(() => {}) // never settles — an in-flight verb
+    }
+    return Promise.resolve({ ok: true })
+  }
+  on(event: 'detach' | 'message', listener: (...a: never[]) => void): void {
+    if (event === 'detach') this.detachListener = listener as (e: unknown, reason: string) => void
+  }
+}
+
+const VIEWPORT: CdpContext = { viewport: { width: 1280, height: 800 } }
+
+/** A ledger + lease manager wired to one DRIVEN node: entry claimed, a live BrowserSession attached,
+ *  and a command left in flight so the rejection is observable. */
+function drivenNode(opts: {
+  browserNodeId: string
+  ownerNodeId: string
+  projectId: string
+}): { targets: RevocationTargets; dbg: FakeDebugger; inFlight: Promise<unknown>; ledger: BrowserControlLedger } {
+  const ledger = new BrowserControlLedger()
+  ledger.claim(opts.browserNodeId, {
+    ownerNodeId: opts.ownerNodeId,
+    projectId: opts.projectId,
+    partition: `persist:nt-agent-browser-${opts.projectId}`,
+    navGeneration: 0,
+    leaseActiveUntil: 0,
+    openedAt: 1_000
+  })
+  const leases = new BrowserLeaseManager()
+  const dbg = new FakeDebugger()
+  const session = new BrowserSession({
+    nodeId: opts.browserNodeId,
+    debugger: dbg,
+    viewport: () => VIEWPORT,
+    now: () => 1_000_000
+  })
+  leases.set(opts.browserNodeId, session)
+  // Drive it: attaches, and leaves a command hanging so revocation must reject it.
+  dbg.hangNext = true
+  const inFlight = session.send('Page.navigate', { url: 'https://x.test/' })
+  ledger.touchLease(opts.browserNodeId, 1_000_000 + 60_000)
+  expect(session.isAttached()).toBe(true)
+  return { targets: { leases, ledger }, dbg, inFlight, ledger }
+}
+
+const NODE = { browserNodeId: 'browser-3', ownerNodeId: 'claude-2', projectId: 'p-1' }
+
+describe('Stop actually revokes — every surface drops the entry, detaches, and cancels in flight', () => {
+  it('1. Stop in the chip / context menu: entry gone, debugger detached, in-flight rejected', async () => {
+    const { targets, dbg, inFlight, ledger } = drivenNode(NODE)
+
+    revokeBrowserNode(NODE.browserNodeId, targets, { userStopped: true })
+
+    // The lease is provably GONE, not merely hidden:
+    expect(dbg.detachCalls).toBe(1) // the debugger let go of the page
+    await expect(inFlight).rejects.toThrow(BROWSER_LEASE_DETACHED) // the pending verb was cancelled
+    expect(ledger.get(NODE.browserNodeId, NODE.ownerNodeId)).toBe(null) // ownership dropped
+  })
+
+  it('and every subsequent call from that owner answers the human-act refusal, not a retry', () => {
+    const { targets, ledger, inFlight } = drivenNode(NODE)
+    inFlight.catch(() => {}) // this test asserts the refusal, not the (also-cancelled) in-flight verb
+    revokeBrowserNode(NODE.browserNodeId, targets, { userStopped: true })
+
+    expect(ledger.wasStoppedByUser(NODE.browserNodeId, NODE.ownerNodeId)).toBe(true)
+    expect(BROWSER_USER_STOPPED).toBe('browser-3: the user stopped agent control of this node')
+    // Owner-scoped: a DIFFERENT agent gets no signal that the node ever existed.
+    expect(ledger.wasStoppedByUser(NODE.browserNodeId, 'claude-9')).toBe(false)
+  })
+
+  it('2. closing the node (lifecycle): detaches + drops, but leaves NO human-act tombstone', async () => {
+    const { targets, dbg, inFlight, ledger } = drivenNode(NODE)
+
+    revokeBrowserNode(NODE.browserNodeId, targets, { userStopped: false })
+
+    expect(dbg.detachCalls).toBe(1)
+    await expect(inFlight).rejects.toThrow(BROWSER_LEASE_DETACHED)
+    expect(ledger.get(NODE.browserNodeId, NODE.ownerNodeId)).toBe(null)
+    // Closing a node is not "the user stopped control" — no browser-3 tombstone.
+    expect(ledger.wasStoppedByUser(NODE.browserNodeId, NODE.ownerNodeId)).toBe(false)
+  })
+
+  it('4. the project switch off: revoke-by-project detaches, drops, and IS a human act (tombstone)', async () => {
+    const { targets, dbg, inFlight, ledger } = drivenNode(NODE)
+
+    revokeBrowserByProject(NODE.projectId, targets)
+
+    expect(dbg.detachCalls).toBe(1)
+    await expect(inFlight).rejects.toThrow(BROWSER_LEASE_DETACHED)
+    expect(ledger.get(NODE.browserNodeId, NODE.ownerNodeId)).toBe(null)
+    expect(ledger.wasStoppedByUser(NODE.browserNodeId, NODE.ownerNodeId)).toBe(true)
+  })
+
+  it('5. the owner node closing/restarting: revoke-by-owner detaches + drops (lifecycle, no tombstone)', async () => {
+    const { targets, dbg, inFlight, ledger } = drivenNode(NODE)
+
+    revokeBrowserByOwner(NODE.ownerNodeId, targets)
+
+    expect(dbg.detachCalls).toBe(1)
+    await expect(inFlight).rejects.toThrow(BROWSER_LEASE_DETACHED)
+    expect(ledger.get(NODE.browserNodeId, NODE.ownerNodeId)).toBe(null)
+    expect(ledger.wasStoppedByUser(NODE.browserNodeId, NODE.ownerNodeId)).toBe(false)
+  })
+
+  it('6. app quit: revoke-all detaches + drops every claimed node', async () => {
+    const { targets, dbg, inFlight, ledger } = drivenNode(NODE)
+
+    revokeAllBrowser(targets, { userStopped: false })
+
+    expect(dbg.detachCalls).toBe(1)
+    await expect(inFlight).rejects.toThrow(BROWSER_LEASE_DETACHED)
+    expect(ledger.get(NODE.browserNodeId, NODE.ownerNodeId)).toBe(null)
+  })
+
+  it('the Settings kill row Stop-all detaches EVERY driven node and tombstones each', async () => {
+    // Two owners, two projects, both driven — Stop-all is the one obvious place.
+    const a = drivenNode({ browserNodeId: 'browser-1', ownerNodeId: 'claude-1', projectId: 'p-1' })
+    // Reuse a's ledger + leases so allIds() spans both.
+    const ledger = a.ledger
+    const leases = a.targets.leases
+    ledger.claim('browser-2', {
+      ownerNodeId: 'codex-4',
+      projectId: 'p-2',
+      partition: 'persist:nt-agent-browser-p-2',
+      navGeneration: 0,
+      leaseActiveUntil: 0,
+      openedAt: 1_000
+    })
+    const dbg2 = new FakeDebugger()
+    const s2 = new BrowserSession({ nodeId: 'browser-2', debugger: dbg2, viewport: () => VIEWPORT, now: () => 1_000_000 })
+    ;(leases as BrowserLeaseManager).set('browser-2', s2)
+    dbg2.hangNext = true
+    const inFlight2 = s2.send('Page.navigate', { url: 'https://y.test/' })
+
+    const stopped = revokeAllBrowser({ leases, ledger }, { userStopped: true })
+
+    expect(new Set(stopped)).toEqual(new Set(['browser-1', 'browser-2']))
+    expect(a.dbg.detachCalls).toBe(1)
+    expect(dbg2.detachCalls).toBe(1)
+    await expect(a.inFlight).rejects.toThrow(BROWSER_LEASE_DETACHED)
+    await expect(inFlight2).rejects.toThrow(BROWSER_LEASE_DETACHED)
+    expect(ledger.allIds()).toEqual([])
+    expect(ledger.wasStoppedByUser('browser-1', 'claude-1')).toBe(true)
+    expect(ledger.wasStoppedByUser('browser-2', 'codex-4')).toBe(true)
+  })
+
+  it('a fresh verified claim clears a prior user-stop tombstone (a genuine re-open is drivable)', () => {
+    const { targets, ledger, inFlight } = drivenNode(NODE)
+    inFlight.catch(() => {}) // the cancelled verb is proven elsewhere; here we test re-claim
+    revokeBrowserNode(NODE.browserNodeId, targets, { userStopped: true })
+    expect(ledger.wasStoppedByUser(NODE.browserNodeId, NODE.ownerNodeId)).toBe(true)
+
+    ledger.claim(NODE.browserNodeId, {
+      ownerNodeId: NODE.ownerNodeId,
+      projectId: NODE.projectId,
+      partition: 'persist:nt-agent-browser-p-1',
+      navGeneration: 0,
+      leaseActiveUntil: 0,
+      openedAt: 2_000
+    })
+    expect(ledger.wasStoppedByUser(NODE.browserNodeId, NODE.ownerNodeId)).toBe(false)
+  })
+})

--- a/src/main/browser-revocation.ts
+++ b/src/main/browser-revocation.ts
@@ -1,0 +1,77 @@
+/**
+ * Revoking browser control — the security-relevant half of the indicator (S8 PR 6 of #112, @Corvin).
+ *
+ * A Stop that only hides the chip is a Critical-class bug: the debugger would stay attached and the
+ * page still drivable. So every revocation here does BOTH, in one place, whatever triggered it:
+ *   1. drop the ownership entry (undrivable — the ledger's `get` now returns null), and
+ *   2. release the lease, which DETACHES the debugger and rejects any in-flight verb with a named
+ *      outcome (`BrowserSession.release` → `detach()` + `BROWSER_LEASE_DETACHED`).
+ *
+ * A USER-initiated stop (chip, node menu, Settings kill row, the project switch going off) also
+ * leaves a tombstone, so the next drive from that owner is refused with {@link BROWSER_USER_STOPPED}
+ * — a message naming the human act, so the agent reports it rather than retrying. LIFECYCLE
+ * revocation (node close, project close, owner gone, app quit) leaves no tombstone: nothing there is
+ * "the user stopped control of this node".
+ *
+ * Ownership is read ONLY from the injected ledger — never from `Project` edges (that identifier is
+ * forbidden in every `src/main/browser-*.ts`, pinned by browser-ownership-source.test.ts). This file
+ * knows nothing of project.json.
+ *
+ * `src/main`, never Server Edition: it releases a `webContents.debugger`, which cannot exist there.
+ */
+import type { BrowserControlLedger } from './browser-control-ledger'
+
+/** The two runtime holders a revocation touches, injected so the whole thing unit-tests against a
+ *  real {@link BrowserControlLedger} and a real `BrowserLeaseManager` (or fakes) with no Electron. */
+export interface RevocationTargets {
+  /** The lease manager. `release(nodeId)` detaches the debugger + rejects in-flight (a no-op for a
+   *  node with no live session — true today, before PR 7 attaches any). */
+  leases: { release(nodeId: string): void }
+  /** The ownership + tombstone ledger. */
+  ledger: BrowserControlLedger
+}
+
+/** Revoke a set of browser nodes. `userStopped` chooses the tombstone (human act) vs a plain drop
+ *  (lifecycle). Returns the ids acted on, so the caller can push them to the renderer as `stopped`
+ *  (drop the chip at once, skipping the linger). */
+export function revokeBrowserNodes(
+  browserNodeIds: readonly string[],
+  t: RevocationTargets,
+  opts: { userStopped: boolean }
+): string[] {
+  for (const id of browserNodeIds) {
+    // Ledger first so the node is undrivable the instant the debugger lets go; the tombstone must be
+    // recorded BEFORE the entry is dropped, which `stopByUser` does internally.
+    if (opts.userStopped) t.ledger.stopByUser(id)
+    else t.ledger.release(id)
+    t.leases.release(id)
+  }
+  return [...browserNodeIds]
+}
+
+/** One node — the chip's Stop and the node context menu (userStopped), or a single node closing
+ *  (lifecycle). */
+export function revokeBrowserNode(
+  browserNodeId: string,
+  t: RevocationTargets,
+  opts: { userStopped: boolean }
+): string[] {
+  return revokeBrowserNodes([browserNodeId], t, opts)
+}
+
+/** Every node an owner opened — the owner agent node closing or restarting (lifecycle). */
+export function revokeBrowserByOwner(ownerNodeId: string, t: RevocationTargets): string[] {
+  return revokeBrowserNodes(t.ledger.idsByOwner(ownerNodeId), t, { userStopped: false })
+}
+
+/** Every node in a project — the project switch going OFF (userStopped: a human act, refused with
+ *  the named message afterwards). A project CLOSE is handled per-node by the guest teardown instead,
+ *  and is not a "stop", so it does not come through here. */
+export function revokeBrowserByProject(projectId: string, t: RevocationTargets): string[] {
+  return revokeBrowserNodes(t.ledger.idsByProject(projectId), t, { userStopped: true })
+}
+
+/** Every claimed node — the Settings kill row's Stop-all (userStopped). */
+export function revokeAllBrowser(t: RevocationTargets, opts: { userStopped: boolean }): string[] {
+  return revokeBrowserNodes(t.ledger.allIds(), t, opts)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,13 @@ import { writeFilesToClipboard } from './clipboard-files'
 import { allowGuestNavigation } from './webview-nav'
 import { BrowserControlLedger } from './browser-control-ledger'
 import { BrowserLeaseManager } from './browser-lease'
+import {
+  revokeBrowserNode,
+  revokeBrowserByOwner,
+  revokeBrowserByProject,
+  revokeAllBrowser,
+  type RevocationTargets
+} from './browser-revocation'
 import { registerFsHandlers } from '../core/fs-handlers'
 import { LogBuffer } from '../core/log-buffer'
 import { installLogSink, splitTag } from '../core/log-sink'
@@ -817,7 +824,12 @@ app.whenReady().then(async () => {
     }
   )
   ipcMain.on(IPC.browserUnregister, (_e, webContentsId: number) => {
+    // The browser node's guest is going away (node closed, project closed/switched, or a discard).
+    // Revoke any control lease on it — LIFECYCLE, so no user-stop tombstone. Read the node id BEFORE
+    // dropping the guest. A no-op for a node that was never driven.
+    const nodeId = browserNodeIdForGuest(webContentsId)
     browserGuests.delete(webContentsId)
+    if (nodeId) pushBrowserLeases(revokeBrowserNode(nodeId, browserRevocation, { userStopped: false }))
   })
 
   // The naming agent runs LOCALLY on captured output, so it needs a cwd that exists on THIS
@@ -2327,12 +2339,59 @@ app.whenReady().then(async () => {
   // Who owns which agent-opened browser node, THIS app run only. In-memory, never persisted, never
   // read from project.json (Task 4.3/4.4). Consumed by PR 5 (attach/lease), PR 6 (indicator/Stop).
   const browserLedger = new BrowserControlLedger()
-  // Holds the debugger lease per driven browser node. Built and unit-tested in PR 5 but INERT here:
-  // no `browser` verb exists until PR 7, so nothing attaches a guest to it yet. PR 7 wires each
-  // guest's `webContents.debugger` into a BrowserSession, starts the idle sweep, and releases on
-  // owner/project/app teardown. Owned here so that wiring has one home. See browser-lease.ts.
+  // Holds the debugger lease per driven browser node. Built and unit-tested in PR 5. PR 7 wires each
+  // guest's `webContents.debugger` into a BrowserSession and starts the idle sweep; a driving verb
+  // there will call `browserLedger.touchLease(...)` + `pushBrowserLeases()` so the chip lights up.
+  // No verb attaches a guest yet, so nothing sets a live lease today — but revocation (Stop + the
+  // automatic triggers) is fully live, because `release` is a no-op-safe detach for a node with no
+  // session. Owned here so all the wiring has one home. See browser-lease.ts / browser-revocation.ts.
   const browserLeases = new BrowserLeaseManager()
-  void browserLeases
+  const browserRevocation: RevocationTargets = { leases: browserLeases, ledger: browserLedger }
+  // Push the current driven-lease set to the renderer (chip / rope / kill row). `stopped` ids drop
+  // from the chip immediately, skipping the anti-flicker linger — that is how an explicit Stop hides
+  // at once while a merely-idle lease fades.
+  const pushBrowserLeases = (stopped: string[] = []): void => {
+    const w = getMainWindow()
+    if (!w || w.isDestroyed()) return
+    w.webContents.send(IPC.browserLeaseChanged, {
+      active: browserLedger.activeLeasesForPush(Date.now()),
+      stopped
+    })
+  }
+  // Reverse the guest map: which node id owns this <webview> guest? Used to revoke on a browser
+  // node's teardown (its guest unregisters). Absent guest → no id → nothing to revoke.
+  const browserNodeIdForGuest = (webContentsId: number): string | undefined =>
+    browserGuests.get(webContentsId)?.nodeId
+  // Stop agent control of ONE node — the chip button and the node context menu. USER-initiated, so
+  // it leaves the tombstone: a later drive from that owner is refused by the named human act.
+  ipcMain.on(IPC.browserStop, (_e, nodeId: string) => {
+    pushBrowserLeases(revokeBrowserNode(nodeId, browserRevocation, { userStopped: true }))
+  })
+  // Stop-all — the Settings kill row. Also user-initiated.
+  ipcMain.on(IPC.browserStopAll, () => {
+    pushBrowserLeases(revokeAllBrowser(browserRevocation, { userStopped: true }))
+  })
+  // A project's browser-control switch went OFF (read live in the renderer, never cached at lease
+  // start). User-initiated: a human turned it off.
+  ipcMain.on(IPC.browserStopProject, (_e, projectId: string) => {
+    pushBrowserLeases(revokeBrowserByProject(projectId, browserRevocation))
+  })
+  // The OWNER agent node closed or restarted (pty teardown/recycle) → its browser leases die with
+  // its verified identity. A SECOND listener on these channels alongside releaseNodeTails above;
+  // both fire. LIFECYCLE, so no user-stop tombstone. A restart mints a fresh identity that cannot
+  // drive the old node anyway, so revoking is the honest state.
+  corePlatform.on(IPC.ptyDestroy, (nodeId: string) =>
+    pushBrowserLeases(revokeBrowserByOwner(nodeId, browserRevocation))
+  )
+  corePlatform.on(IPC.ptyRecycle, (nodeId: string) =>
+    pushBrowserLeases(revokeBrowserByOwner(nodeId, browserRevocation))
+  )
+  // App quit: detach every debugger lease. A second `before-quit` listener alongside the module-
+  // level flush one (both fire); scoped here so it can reach `browserRevocation`. No push — the
+  // window is going away. LIFECYCLE, so no tombstone (the in-memory ledger is gone on quit anyway).
+  app.on('before-quit', () => {
+    revokeAllBrowser(browserRevocation, { userStopped: false })
+  })
   ipcMain.on(
     IPC.agentControlResult,
     (
@@ -2380,6 +2439,9 @@ app.whenReady().then(async () => {
           leaseActiveUntil: 0,
           openedAt: Date.now()
         })
+        // A claim carries no live lease (a verb sets that in PR 7), so this does not light the chip;
+        // it keeps the renderer's view consistent from the moment ownership exists.
+        pushBrowserLeases()
       }
     }
     return result

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -322,7 +322,15 @@ const api: NodeTerminalApi = {
       const handler = (_e: unknown, ev: { url: string; sourceNodeId: string }) => listener(ev)
       ipcRenderer.on(IPC.browserNewWindow, handler)
       return () => ipcRenderer.removeListener(IPC.browserNewWindow, handler)
-    }
+    },
+    onLeaseChanged: (listener) => {
+      const handler = (_e: unknown, push: Parameters<typeof listener>[0]) => listener(push)
+      ipcRenderer.on(IPC.browserLeaseChanged, handler)
+      return () => ipcRenderer.removeListener(IPC.browserLeaseChanged, handler)
+    },
+    stop: (nodeId: string) => ipcRenderer.send(IPC.browserStop, nodeId),
+    stopAll: () => ipcRenderer.send(IPC.browserStopAll),
+    stopProject: (projectId: string) => ipcRenderer.send(IPC.browserStopProject, projectId)
   },
   files: {
     quickOpen: (cwd: string) => ipcRenderer.invoke(IPC.filesQuickOpen, cwd),

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -194,7 +194,13 @@ export function buildStubApi(): Omit<
     browser: {
       register: noop,
       unregister: noop,
-      onBrowserNewWindow: noopUnsub
+      onBrowserNewWindow: noopUnsub,
+      // Browser control does not exist off the desktop shell (no <webview>, no CDP), so there is no
+      // lease to push and nothing to stop — the chip simply never appears.
+      onLeaseChanged: noopUnsub,
+      stop: noop,
+      stopAll: noop,
+      stopProject: noop
     },
     updates: {
       onAvailable: noopUnsub,

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -229,6 +229,7 @@ import { opensInEditor } from '../lib/openTarget'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
 import { useProjects } from '../state/projects'
 import { useAgentStatus } from '../state/agentStatus'
+import { useBrowserLease, drivingNodeIds } from '../state/browserLease'
 import { useTerminalFocus } from '../state/terminalFocus'
 import { useCodexIdentity, codexFallbackText } from '../state/codexIdentity'
 import { useTeamAccessEvents } from '../state/teamAccess'
@@ -1514,8 +1515,14 @@ export function Canvas() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- depEdgeSig IS the ref's signature
     [depEdgeSig]
   )
+  // Which browser nodes are being DRIVEN (Task 6.2) — for the rope highlight only. Membership comes
+  // from the ownership-backed lease store; a rope whose target is NOT here is never highlighted, so a
+  // hostile pre-declared rope (a cloned project.json can ship one) lights up nothing. Rendering-only:
+  // ownership is still decided in main, never from `controlEdges`.
+  const drivenLeaseEntries = useBrowserLease((s) => s.entries)
   const displayEdges = useMemo(() => {
     const stickyIds = new Set(stickySig ? stickySig.split('|') : [])
+    const drivenTargets = drivingNodeIds(drivenLeaseEntries, Date.now())
     // ONE edge per pair. A node an agent opens gets both a rope (lineage) and a context bridge
     // (readable context), which drew two near-identical arrows between the same two nodes. The
     // rope keeps the pixels; the bridge still exists in data (it is what authorizes reading) and
@@ -1550,22 +1557,31 @@ export function Canvas() {
     const ropeCoversLink = new Set(
       linkEdges.filter((e) => hidden.has(e.id)).map((e) => pairKey(e.source, e.target))
     )
-    const ropes = controlEdges.map((e) =>
-      e.selected
-        ? {
-            ...e,
-            label: ropeCoversLink.has(pairKey(e.source, e.target))
-              ? '⇄ context · ⌫ to remove'
-              : '⌫ to remove',
-            labelStyle: { fill: '#ffffff', fontSize: 11, fontWeight: 600 },
-            labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
-            labelBgPadding: [6, 3] as [number, number],
-            labelBgBorderRadius: 5,
-            style: { ...e.style, stroke: '#ffffff', strokeWidth: 3 },
-            markerEnd: { type: MarkerType.ArrowClosed, color: '#ffffff', width: 14, height: 14 }
-          }
-        : e
-    )
+    const ropes = controlEdges.map((e) => {
+      if (e.selected)
+        return {
+          ...e,
+          label: ropeCoversLink.has(pairKey(e.source, e.target))
+            ? '⇄ context · ⌫ to remove'
+            : '⌫ to remove',
+          labelStyle: { fill: '#ffffff', fontSize: 11, fontWeight: 600 },
+          labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
+          labelBgPadding: [6, 3] as [number, number],
+          labelBgBorderRadius: 5,
+          style: { ...e.style, stroke: '#ffffff', strokeWidth: 3 },
+          markerEnd: { type: MarkerType.ArrowClosed, color: '#ffffff', width: 14, height: 14 }
+        }
+      // Driven: the same clay the RUNNING badge uses, thicker and flowing — legible on a zoomed-out
+      // canvas where the header chip is unreadable. This is the whole point of highlighting the rope.
+      if (drivenTargets.has(e.target))
+        return {
+          ...e,
+          animated: true,
+          style: { ...e.style, stroke: '#d97757', strokeWidth: 2.5 },
+          markerEnd: { type: MarkerType.ArrowClosed, color: '#d97757', width: 14, height: 14 }
+        }
+      return e
+    })
     // Waiting edges for armed nodes (`--after`): dep → dependent, dashed and animated while the
     // wait is on. Derived from node data rather than persisted — a pending dependency is a STATE
     // that ends when the launch fires, unlike the context bridge `--after` also draws, which is a
@@ -1576,7 +1592,7 @@ export function Canvas() {
         ? [...ephemeralEdges, ...ropes, ...depEdges]
         : []
     return extra.length ? [...decorated, ...extra] : decorated
-  }, [linkEdges, ephemeralEdges, controlEdges, accent, stickySig, depEdges])
+  }, [linkEdges, ephemeralEdges, controlEdges, accent, stickySig, depEdges, drivenLeaseEntries])
 
   // Header pin button (and ⌘⇧L): toggle the persisted pin preference. Clears the transient
   // dismiss so (re)pinning shows the docked panel; unpinning collapses it to hover-peek.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -5339,8 +5339,22 @@ export function Canvas() {
     // Destructive/recovery rows (Delete, Restart agent, Branch/Transfer) are not hideable at all:
     // `isHidden` only answers for ids in its own inventory.
     const hidden = useSettings.getState().settings.hiddenNodeMenuItems
+    // Stop agent control — the node context-menu surface for Stop (Task 6.4). Shown only for a
+    // single browser node that is actually being driven; it revokes for real (main detaches the
+    // debugger + drops the ledger entry), not just hides the chip. Read fresh, like every other row.
+    const drivenHere =
+      ids.length === 1 && drivingNodeIds(useBrowserLease.getState().entries, Date.now()).has(ids[0])
     return tidySeparators([
       { type: 'label', label: ids.length > 1 ? `${ids.length} nodes` : '1 node' },
+      ...(drivenHere
+        ? ([
+            {
+              label: 'Stop agent control',
+              onClick: () => window.nodeTerminal.browser.stop(ids[0])
+            },
+            { type: 'separator' }
+          ] as MenuItem[])
+        : []),
       ...((): MenuItem[] => {
         // "Group …" wraps objects that share ONE container — existing frames are valid members
         // now that frames nest. A box-selection that caught a frame AND its children is

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -12,6 +12,7 @@ import { BoardLogPanel } from './BoardLogPanel'
 import { CardMetaBar } from './CardMetaBar'
 import { ModalTerminal } from './ModalTerminal'
 import { BrowserSurface } from '../../nodes/BrowserSurface'
+import { BrowserDrivingIndicator } from '../../nodes/BrowserDrivingChip'
 import { NoteMarkdown } from '../NoteMarkdown'
 import { relativeTime } from '../../lib/relativeTime'
 
@@ -145,6 +146,11 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
             </span>
           )}
           <span className="kanban-modal__column">{columnTitle ?? 'Ungrouped'}</span>
+          {/* The driving chip, so a user watching a browser card THROUGH the modal is not
+              driving-blind. The lease is keyed by node id (not by webview object), so this shows
+              when the node is being driven even though the drive lands on the CANVAS webview, not
+              this modal's — which is what the user needs to know (Task 6.3). */}
+          {isBrowser && <BrowserDrivingIndicator nodeId={session.id} />}
           {isTerminal && (
             <>
               {/* Same context-window pill + popover as the node header (null until usage data). */}

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useSettings } from '../../../state/settings'
 import { useProjects } from '../../../state/projects'
+import { useBrowserLease, drivingNodeIds } from '../../../state/browserLease'
 import {
   PROJECT_CAPABILITIES,
   PROJECT_CAPABILITY_COPY,
@@ -106,6 +107,21 @@ const ROWS = {
       'refused'
     ]
   },
+  browserControl: {
+    title: 'Browser control',
+    keywords: [
+      'browser',
+      'control',
+      'drive',
+      'driving',
+      'stop',
+      'revoke',
+      'agent',
+      'web',
+      'page',
+      'security'
+    ]
+  },
   hibernation: {
     title: 'Hibernate idle agents',
     keywords: [
@@ -203,6 +219,25 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
   const activeProjectId = useProjects((s) => s.activeProjectId)
   const activeProject = useProjects((s) => s.projects.find((p) => p.id === activeProjectId))
   const setProjectCapability = useProjects((s) => s.setProjectCapability)
+  // The kill row (Task 6.4): browser nodes an agent is driving RIGHT NOW, across every open project,
+  // each with a Stop and one Stop-all. The precedent is the identity escape hatch — a user who
+  // notices their browser doing something needs one obvious place to end it, not a per-node hunt.
+  // Stop revokes for real in main (detach + drop), and there is deliberately NO global "disable
+  // browser control" toggle here: one concept, one switch (the per-project capability below).
+  const browserLeaseEntries = useBrowserLease((s) => s.entries)
+  const allProjects = useProjects((s) => s.projects)
+  const nodeTitleById = (id: string): string => {
+    for (const p of allProjects) {
+      const n = p.nodes.find((node) => node.id === id)
+      if (n) return n.title || id
+    }
+    return id
+  }
+  const drivenRows = [...drivingNodeIds(browserLeaseEntries, Date.now())].map((nodeId) => ({
+    nodeId,
+    nodeTitle: nodeTitleById(nodeId),
+    ownerTitle: nodeTitleById(browserLeaseEntries[nodeId].ownerNodeId)
+  }))
   const rows: { id: AgentId; label: string; isBuiltin: boolean }[] = [
     ...BUILTIN_AGENT_IDS.map((id) => ({ id, label: AGENT_CONFIG[id].label, isBuiltin: true })),
     ...settings.customAgents.map((c) => ({ id: c.id, label: c.label || c.id, isBuiltin: false }))
@@ -376,6 +411,37 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
           }
         />
       </SearchableRow>
+      <SearchableRow {...ROWS.browserControl}>
+        <FieldRow
+          label="Browser control"
+          description="Browser nodes an agent is driving right now, across every open project. Stop ends it immediately — the debugger is detached and the agent is told you stopped it, so it reports that instead of retrying. One place to stop it, so you never have to hunt from node to node."
+          control={
+            <Button
+              variant="default"
+              disabled={drivenRows.length === 0}
+              onClick={() => window.nodeTerminal.browser.stopAll()}
+            >
+              Stop all
+            </Button>
+          }
+        />
+        <div className="space-y-2">
+          {drivenRows.length === 0 ? (
+            <span className="text-[13px] text-muted">No agent is driving a browser node right now.</span>
+          ) : (
+            drivenRows.map((r) => (
+              <div key={r.nodeId} className="flex items-center gap-3 py-1">
+                <span className="flex-1 text-[13px] text-text">
+                  {r.ownerTitle} is driving {r.nodeTitle}
+                </span>
+                <Button variant="default" onClick={() => window.nodeTerminal.browser.stop(r.nodeId)}>
+                  Stop
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+      </SearchableRow>
       {CAPABILITY_ROWS.map(({ cap, title, keywords }) => (
         <SearchableRow key={cap} title={title} keywords={keywords}>
           <FieldRow
@@ -402,6 +468,12 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
                   // value any other way (a string, a stored false) is the bug the validators
                   // exist to refuse.
                   if (activeProject) setProjectCapability(activeProject.id, cap, on)
+                  // Turning browser control OFF revokes any live lease in this project immediately
+                  // (Task 6.4) — detach now, don't wait for the next drive to read the switch. Read
+                  // live off this toggle, never cached at lease start.
+                  if (activeProject && cap === 'agentBrowserControl' && !on) {
+                    window.nodeTerminal?.browser?.stopProject?.(activeProject.id)
+                  }
                 }}
               />
             }

--- a/src/renderer/nodes/BrowserDrivingChip.tsx
+++ b/src/renderer/nodes/BrowserDrivingChip.tsx
@@ -1,0 +1,62 @@
+import { useProjects } from '../state/projects'
+import { useDrivingLease } from '../state/browserLease'
+
+/**
+ * The "…is driving" chip (S8 PR 6 of #112, @Corvin): shown on a browser node header (and in the
+ * kanban card modal) the whole time an agent holds a control lease on it — plus a short linger so a
+ * burst of fast verbs reads as one continuous state. It carries the one obvious Stop.
+ *
+ * Decision 4: this is ALWAYS ON. There is deliberately no setting that hides it and none to add — a
+ * user cannot be driving-blind by preference. It is not gated on `agentBrowserControl` either: that
+ * switch decides whether an agent MAY drive; once one IS driving, the badge is unconditional.
+ */
+
+/** Presentational only — no store, so it renders in isolation under test. `ownerTitle` is the
+ *  VERIFIED owner node's title (resolved from the ledger's `ownerNodeId`, never a caller label). */
+export function BrowserDrivingChip({
+  ownerTitle,
+  onStop
+}: {
+  ownerTitle: string
+  onStop: () => void
+}): React.JSX.Element {
+  return (
+    <span className="term-node__status term-node__status--driven nodrag" role="status">
+      <span className="term-node__status-dot" />
+      <span className="browser-driving__label">{ownerTitle} is driving</span>
+      <button
+        className="browser-driving__stop"
+        title="Stop agent control of this browser node"
+        onClick={(e) => {
+          e.stopPropagation()
+          onStop()
+        }}
+      >
+        Stop
+      </button>
+    </span>
+  )
+}
+
+/**
+ * The node/modal container: reads the live lease for `nodeId`, resolves the owner's title, and wires
+ * Stop to main (which detaches the debugger + drops the ledger entry — a real revocation, never a
+ * hide). Renders nothing when the node is not being driven.
+ */
+export function BrowserDrivingIndicator({ nodeId }: { nodeId: string }): React.JSX.Element | null {
+  const lease = useDrivingLease(nodeId)
+  const ownerTitle = useProjects((s) => {
+    if (!lease) return ''
+    for (const p of s.projects) {
+      const owner = p.nodes.find((n) => n.id === lease.ownerNodeId)
+      if (owner) return owner.title || lease.ownerNodeId
+    }
+    // The owner is gone from every canvas (closed/restarted) but the lease has not yet been
+    // revoked: name it by id rather than blanking the chip.
+    return lease.ownerNodeId
+  })
+  if (!lease) return null
+  return (
+    <BrowserDrivingChip ownerTitle={ownerTitle} onStop={() => window.nodeTerminal.browser.stop(nodeId)} />
+  )
+}

--- a/src/renderer/nodes/BrowserNode.tsx
+++ b/src/renderer/nodes/BrowserNode.tsx
@@ -2,6 +2,7 @@ import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xy
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
 import { BrowserSurface } from './BrowserSurface'
+import { BrowserDrivingIndicator } from './BrowserDrivingChip'
 
 /**
  * A navigable Chromium browser node: node chrome (frame/header/resize/close) wrapping the shared
@@ -35,6 +36,10 @@ export default function BrowserNode({ id, data, selected }: NodeProps<CanvasNode
         <span className="term-node__title-text" title={(data.url as string) || ''}>
           {(data.title as string) || 'Browser'}
         </span>
+        {/* The driving chip — present the whole time an agent holds a control lease on this node,
+            with the one obvious Stop. Renders nothing otherwise (and, until PR 7 ships the verb that
+            drives a lease, in every case today). */}
+        <BrowserDrivingIndicator nodeId={id} />
         <span className="term-node__spacer" />
         <button className="term-node__close" title="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
           ×

--- a/src/renderer/nodes/browser-indicator.test.tsx
+++ b/src/renderer/nodes/browser-indicator.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+//
+// The driving chip (S8 PR 6 of #112, @Corvin): it appears while an agent holds a lease, names the
+// VERIFIED owner, carries a Stop, LINGERS past a lease's end so a burst of fast verbs reads as one
+// continuous state, and drops AT ONCE on an explicit Stop. And no setting hides it (decision 4).
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { chipVisibleAt, INDICATOR_LINGER_MS } from '@shared/browser-indicator'
+import { applyLeasePush, drivingNodeIds, type LeaseEntries } from '../state/browserLease'
+import { BrowserDrivingChip } from './BrowserDrivingChip'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const T0 = 1_000_000
+const active = (leaseActiveUntil: number, id = 'browser-3', ownerNodeId = 'claude-2') => ({
+  active: [{ browserNodeId: id, ownerNodeId, leaseActiveUntil }],
+  stopped: [] as string[]
+})
+
+describe('the chip lingers, because a 50ms flicker has informed nobody', () => {
+  it('a lease that was live for ~50ms keeps the chip up for INDICATOR_LINGER_MS after it ends', () => {
+    // A --read completes in ~50ms: the lease is barely in the future when we learn of it.
+    const entries: LeaseEntries = applyLeasePush({}, active(T0 + 50), T0)
+    const e = entries['browser-3']
+    expect(e.ownerNodeId).toBe('claude-2')
+
+    // Still driving well after the 50ms lease ended — this is the whole point of the linger.
+    expect(chipVisibleAt(e, T0 + 50)).toBe(true)
+    expect(chipVisibleAt(e, T0 + 2_000)).toBe(true)
+    // …and gone once the linger itself lapses.
+    expect(chipVisibleAt(e, T0 + 50 + INDICATOR_LINGER_MS + 1)).toBe(false)
+    // A burst reads as continuous: the SAME entry is visible across the gap between two 50ms verbs.
+    expect(chipVisibleAt(e, T0 + 4_000)).toBe(true)
+  })
+
+  it('a natural expiry is swept only once the linger is truly past', () => {
+    const entries = applyLeasePush({}, active(T0 + 50), T0)
+    // A later push at a time still inside the linger keeps the entry (an unrelated change).
+    const still = applyLeasePush(entries, { active: [], stopped: [] }, T0 + 2_000)
+    expect(still['browser-3']).toBeTruthy()
+    // A push after the linger sweeps it.
+    const gone = applyLeasePush(entries, { active: [], stopped: [] }, T0 + 50 + INDICATOR_LINGER_MS + 1)
+    expect(gone['browser-3']).toBeUndefined()
+  })
+})
+
+describe('an explicit Stop drops the chip immediately, skipping the linger', () => {
+  it('a stopped id is removed at once, even mid-linger', () => {
+    const entries = applyLeasePush({}, active(T0 + 60_000), T0) // a normal 60s lease
+    expect(entries['browser-3']).toBeTruthy()
+    // Stop arrives: the node is in `stopped`. It must be gone NOW, not in 5s.
+    const afterStop = applyLeasePush(entries, { active: [], stopped: ['browser-3'] }, T0 + 10)
+    expect(afterStop['browser-3']).toBeUndefined()
+  })
+
+  it('the rope-highlight set is exactly the visible-lease set (a rope with no entry is never in it)', () => {
+    const entries = applyLeasePush({}, active(T0 + 60_000, 'browser-9'), T0)
+    const driven = drivingNodeIds(entries, T0 + 5)
+    expect(driven.has('browser-9')).toBe(true)
+    // A browser node with no ledger-backed entry (e.g. a hostile pre-declared rope's target).
+    expect(driven.has('browser-unclaimed')).toBe(false)
+  })
+})
+
+describe('the chip names the owner and carries a Stop', () => {
+  it('renders "<owner> is driving" and Stop calls back', () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root = createRoot(host)
+    const onStop = vi.fn()
+    act(() => root.render(<BrowserDrivingChip ownerTitle="Claude 2" onStop={onStop} />))
+
+    expect(host.textContent).toContain('Claude 2 is driving')
+    const stop = host.querySelector('button.browser-driving__stop') as HTMLButtonElement
+    expect(stop).toBeTruthy()
+    act(() => stop.click())
+    expect(onStop).toHaveBeenCalledTimes(1)
+
+    act(() => root.unmount())
+    host.remove()
+  })
+})
+
+describe('no setting hides it (decision 4 — there is no toggle to look for and none to add)', () => {
+  it('visibility is a pure function of lease state — the chip renders whenever a lease is present', () => {
+    // There is no `enabled`/`setting` input to chipVisibleAt: give it any live entry and it shows.
+    expect(chipVisibleAt({ ownerNodeId: 'x', leaseActiveUntil: T0 + 1 }, T0)).toBe(true)
+  })
+
+  it('neither the chip nor the lease store consults settings / the capability switch', () => {
+    // A structural guard: the moment someone adds a `useSettings`/`agentBrowserControl` gate to the
+    // indicator, this fails. The chip is gated ONLY on the presence of a verified lease.
+    const root = path.resolve(process.cwd(), 'src', 'renderer')
+    const chip = readFileSync(path.join(root, 'nodes', 'BrowserDrivingChip.tsx'), 'utf8')
+    const store = readFileSync(path.join(root, 'state', 'browserLease.ts'), 'utf8')
+    // Strip comments — the chip's doc comment explains that it is NOT gated on the capability
+    // switch, and that explanation is a comment, correctly ignored here (same style as
+    // browser-ownership-source.test.ts).
+    const stripComments = (s: string): string =>
+      s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+    for (const src of [chip, store]) {
+      expect(stripComments(src)).not.toMatch(/useSettings|agentBrowserControl|hiddenNodeMenuItems/)
+    }
+  })
+})

--- a/src/renderer/state/browserLease.ts
+++ b/src/renderer/state/browserLease.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand'
+import { useEffect, useReducer } from 'react'
+import {
+  chipVisibleAt,
+  INDICATOR_LINGER_MS,
+  type BrowserLeaseEntry,
+  type BrowserLeasePush
+} from '@shared/browser-indicator'
+
+/**
+ * The renderer's view of which browser nodes an agent is DRIVING (S8 PR 6 of #112, @Corvin). Fed by
+ * a `browser:lease-changed` push from main, which owns the debugger lease + the ownership ledger;
+ * this store never decides ownership, it only paints what main verified. The chip, the rope
+ * highlight and the Settings kill row all read it, so they can never disagree.
+ *
+ * The `browser` verb that MAKES a lease active lands in PR 7 — until then main pushes nothing with a
+ * live `leaseActiveUntil`, so `entries` stays empty in practice while every path below is real and
+ * tested. Stop, however, is live now: main pushes the stopped node in `stopped` and it drops here at
+ * once.
+ */
+export type LeaseEntries = Record<string, BrowserLeaseEntry>
+
+/**
+ * Fold one push into the entry map. Two rules that must never merge:
+ *  - `stopped` ids drop IMMEDIATELY, skipping the linger — the user (or a lifecycle event) ended
+ *    control, so the chip must vanish now, not fade.
+ *  - `active` ids upsert with their fresh window; a node that merely goes idle is NOT in `stopped`
+ *    and keeps lingering {@link INDICATOR_LINGER_MS} past its `leaseActiveUntil` (the anti-flicker
+ *    rule), then gets swept here once it is truly done.
+ * Pure, so the flicker and the stop-is-immediate behaviours are unit-tested without the IPC.
+ */
+export function applyLeasePush(prev: LeaseEntries, push: BrowserLeasePush, now: number): LeaseEntries {
+  const next: LeaseEntries = { ...prev }
+  for (const id of push.stopped) delete next[id]
+  for (const a of push.active) {
+    next[a.browserNodeId] = { ownerNodeId: a.ownerNodeId, leaseActiveUntil: a.leaseActiveUntil }
+  }
+  // Sweep entries whose lease AND linger have both elapsed (a natural expiry, not a stop).
+  for (const [id, e] of Object.entries(next)) if (!chipVisibleAt(e, now)) delete next[id]
+  return next
+}
+
+interface BrowserLeaseState {
+  entries: LeaseEntries
+  /** Apply a push (also the test seam — components never call it). */
+  apply: (push: BrowserLeasePush) => void
+}
+
+export const useBrowserLease = create<BrowserLeaseState>((set) => {
+  const apply = (push: BrowserLeasePush): void =>
+    set((s) => ({ entries: applyLeasePush(s.entries, push, Date.now()) }))
+  // One subscription for the app's lifetime. Guarded so the store imports cleanly under jsdom /
+  // Server Edition, where the bridge is absent.
+  window.nodeTerminal?.browser?.onLeaseChanged?.(apply)
+  return { entries: {}, apply }
+})
+
+/**
+ * Is this node being driven RIGHT NOW (including the linger), and by whom? Returns the entry while
+ * the chip should show, else null. Schedules a single re-render at the exact moment the linger
+ * lapses, so the chip disappears on its own without a per-second poll.
+ */
+export function useDrivingLease(nodeId: string): BrowserLeaseEntry | null {
+  const entry = useBrowserLease((s) => s.entries[nodeId])
+  const [, bump] = useReducer((n: number) => n + 1, 0)
+  useEffect(() => {
+    if (!entry) return
+    const remaining = entry.leaseActiveUntil + INDICATOR_LINGER_MS - Date.now()
+    if (remaining <= 0) return
+    const t = setTimeout(bump, remaining + 20)
+    return () => clearTimeout(t)
+  }, [entry])
+  if (!entry) return null
+  return chipVisibleAt(entry, Date.now()) ? entry : null
+}
+
+/** The set of browser node ids currently being driven — the rope highlight (Task 6.2) and the
+ *  Settings kill row read this. A node with no ledger-backed entry is never in it, so a hostile
+ *  pre-declared rope is never highlighted. */
+export function drivingNodeIds(entries: LeaseEntries, now: number): Set<string> {
+  const ids = new Set<string>()
+  for (const [id, e] of Object.entries(entries)) if (chipVisibleAt(e, now)) ids.add(id)
+  return ids
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1364,6 +1364,55 @@ body,
   animation: nt-pulse 1.1s ease-in-out infinite;
 }
 
+/* DRIVING: an agent holds a control lease on this browser node (S8 PR 6). Same clay as RUNNING so
+   it reads as agent activity, but it carries a label + a Stop button, so it is wider than the plain
+   status badges. Always on — no setting hides it (decision 4). */
+.term-node__status--driven {
+  color: #d97757;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.term-node__status--driven .term-node__status-dot {
+  animation: nt-pulse 1.1s ease-in-out infinite;
+}
+
+.browser-driving__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* The one obvious Stop. Quiet by default, clay on hover — it is a deliberate act, so it should read
+   as available without shouting. */
+.browser-driving__stop {
+  flex-shrink: 0;
+  margin-left: 2px;
+  padding: 0 6px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  background: rgba(var(--tint-rgb), 0.08);
+  border: 1px solid transparent;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.browser-driving__stop:hover {
+  color: #d97757;
+  border-color: rgba(217, 119, 87, 0.5);
+}
+
+/* The dot's pulse is decoration; the state still reads frozen at the lit end (matches the mascot
+   pulse contract above). */
+@media (prefers-reduced-motion: reduce) {
+  .term-node__status--driven .term-node__status-dot {
+    animation: none;
+  }
+}
+
 /* Walking mascot (docs/mascot-sprites.md): sits where the pulsing dot would, INSIDE the RUNNING
    badge, pure CSS spritesheet stepping — no per-node JS timers. Sizes come from lib/mascot.ts via
    the inline CSS vars so the animation and the rendered sheet can never desync. Fixed heights ≤

--- a/src/shared/browser-indicator.ts
+++ b/src/shared/browser-indicator.ts
@@ -1,0 +1,49 @@
+/**
+ * The DRIVING indicator's shared vocabulary — the one fact both main (which owns the lease) and the
+ * renderer (which paints the chip and highlights the rope) must agree on. Lives in `src/shared`
+ * because both shells import it (global constraint 4: anything both sides need lives here, never a
+ * renderer→main import). Pure — no electron, no DOM — so the visibility rule is unit-tested on its
+ * own.
+ *
+ * S8 PR 6 of external PR #112 (@Corvin / proteus-dev): the on-node "…is driving" chip + Stop. The
+ * lease that FEEDS this (the `browser` verb) lands in PR 7; until then nothing sets a live
+ * `leaseActiveUntil`, so the chip stays hidden in practice while every mechanism below is real.
+ */
+
+
+/**
+ * How long the chip lingers AFTER a lease's `leaseActiveUntil` has passed. A single verb (a
+ * `--read` that completes in ~50 ms) would otherwise flicker the chip for 50 ms and inform nobody; a
+ * burst of verbs must read as one continuous "is driving", which is also the truth (the debugger is
+ * still attached for the whole idle window). The debugger's own idle window (`LEASE_IDLE_MS`, 60 s)
+ * is a separate, invisible perf concern; this is purely how long the badge outlives it so the
+ * transition to "gone" is a fade, not a blink. An EXPLICIT Stop bypasses this entirely (see the
+ * store): the user stopped it, so the chip must vanish at once, not linger.
+ */
+export const INDICATOR_LINGER_MS = 5_000
+
+/** One driven browser node, as main pushes it and the renderer store keeps it. `ownerNodeId` is the
+ *  VERIFIED owner from the in-memory ledger (never a rope, never a caller label); the renderer
+ *  resolves its title for the chip. `leaseActiveUntil` is the ledger's live window. */
+export interface BrowserLeaseEntry {
+  ownerNodeId: string
+  leaseActiveUntil: number
+}
+
+/** The main→renderer push payload. `active` is the CURRENT live-lease set (upserted); `stopped` are
+ *  nodes whose control was just revoked and must drop from the chip immediately, skipping the
+ *  linger — that is the difference between "a verb finished" (fade) and "the user pressed Stop"
+ *  (gone). */
+export interface BrowserLeasePush {
+  active: { browserNodeId: string; ownerNodeId: string; leaseActiveUntil: number }[]
+  stopped: string[]
+}
+
+/**
+ * Is the chip visible for this entry at `now`? True while the lease is live OR within
+ * {@link INDICATOR_LINGER_MS} of it ending. The single rule the chip, the rope highlight and the
+ * kill-row list all read, so they can never disagree about whether a node "is driving".
+ */
+export function chipVisibleAt(entry: BrowserLeaseEntry, now: number): boolean {
+  return now < entry.leaseActiveUntil + INDICATOR_LINGER_MS
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -357,6 +357,13 @@ export const IPC = {
   browserRegister: 'browser:register',
   browserUnregister: 'browser:unregister',
   browserNewWindow: 'browser:new-window',
+  // Browser control indicator + Stop (S8 PR 6). Main pushes the current driven-lease set to the
+  // renderer (the chip / rope / kill row); the renderer asks main to revoke — per node, all, or a
+  // whole project's — and main detaches the debugger + drops the ledger entry for real.
+  browserLeaseChanged: 'browser:lease-changed',
+  browserStop: 'browser:stop-control',
+  browserStopAll: 'browser:stop-control-all',
+  browserStopProject: 'browser:stop-control-project',
   remoteHostStart: 'remote:host:start',
   remoteHostStop: 'remote:host:stop',
   // Connection approval gate: main → renderer when a client finishes the handshake (carries the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,6 +5,7 @@ import type { CloneProgress } from './clone-url'
 import type { NormalizedAgentEvent } from './agents/normalize'
 import type { AgentId, AgentPermissionMode, BuiltinAgentId, PromptInjectionMode } from './agents/config'
 import type { AgentMessageDeliverRequest, AgentMessageReply } from './agents/agent-messaging'
+import type { BrowserLeasePush } from './browser-indicator'
 import type { GroupWorktree } from './worktree'
 import type { ClientId, DinoSnapshot, PeerDiff, PeerIdentity, PeerState } from './presence'
 import type { WhisperModelInfo } from './speech'
@@ -840,6 +841,16 @@ export interface BrowserApi {
   unregister(webContentsId: number): void
   /** Fires when a browser guest requested a new window; the renderer opens another browser node. */
   onBrowserNewWindow(listener: (e: { url: string; sourceNodeId: string }) => void): () => void
+  /** Push: the current set of browser nodes an agent is driving (chip / rope / kill row). `stopped`
+   *  ids drop from the chip immediately, skipping the anti-flicker linger. */
+  onLeaseChanged(listener: (push: BrowserLeasePush) => void): () => void
+  /** Stop agent control of ONE browser node — the chip button and the node context menu. Detaches
+   *  the debugger + drops the lease in main; a later drive from that owner is refused by name. */
+  stop(nodeId: string): void
+  /** Stop agent control of EVERY driven node — the Settings kill row's Stop-all. */
+  stopAll(): void
+  /** Stop agent control of every node in a project — the project's browser-control switch going off. */
+  stopProject(projectId: string): void
 }
 
 /** A user-defined agent (BYO CLI). With no `baseAgent` it is in no capability list, so it gets


### PR DESCRIPTION
S8 PR 6 of external PR #112 (@Corvin / proteus-dev). Makes an active browser-control lease **visible** and **stoppable**. PR 5 built the lease + CDP allowlist (inert); the `browser` verb that actually *drives* a page — and therefore lights a lease — still lands in **PR 7**, so the chip here is driven by lease state that only goes live then. Every mechanism below is real and tested now; in practice nothing is driven yet, so the chip stays hidden until PR 7.

## Tasks → commits

- **6.1 — the on-node chip** (`the on-node "…is driving" chip and its lease store`): header chip that names the **verified owner** (from the in-memory ledger's `ownerNodeId`, never a rope/label), carries Stop, and **lingers 5s** past a lease's end so a burst of fast verbs reads as one continuous state. Always on — no setting hides it (decision 4). New `useBrowserLease` store fed by a main→renderer `browser:lease-changed` push; `INDICATOR_LINGER_MS` moved to `src/shared` (both shells read it) and re-exported from `browser-lease.ts`.
- **6.2 — the rope highlights** (`highlight the spawned-by rope while a lease is live`): the owner→browser rope takes the RUNNING clay and flows while driven, so the state is legible zoomed out. Membership comes **only** from the ledger-backed lease set — a hostile pre-declared rope from a cloned `project.json` is never highlighted. Rendering-only; ownership is never read from an edge.
- **6.3 — the chip in the kanban modal** (`show the driving chip in the kanban card modal too`): keyed by node id, so it shows through the modal even though the drive lands on the canvas webview.
- **6.4 — Stop, everywhere** (`Stop — in the chip, in the menu, in Settings, and on six automatic triggers`): the chip button, the node context menu, and a **Settings → Agents kill row** with Stop-all. Automatic revocation on: node close, project close, the **project switch going off** (read live off the toggle, never cached), the owner node **closing or restarting**, and **app quit**. Every path detaches the debugger and cancels the in-flight verb (`BrowserSession.release` → `detach()` + a named rejection) — never a chip-only hide. A **user** stop leaves a ledger tombstone so the next drive from that owner is refused with `browser-3: the user stopped agent control of this node` (naming the human act so the agent reports it, not retries); lifecycle revocation leaves no tombstone. No separate global "disable browser control" toggle — one concept, one switch.

## Stop provably revokes (the security-relevant half)

`src/main/browser-revocation.ts` runs **both** the ledger drop **and** the lease release for every trigger. `browser-revocation.test.ts` drives a real `BrowserSession` (fake `webContents.debugger`) with a command **in flight**, then revokes from each surface and asserts: `detach()` was called, the in-flight promise rejected with `BROWSER_LEASE_DETACHED`, and `ledger.get()` is null.

## Mutation checks

- Revocation skips `leases.release` (Stop hides chip but leaves debugger attached) → **6/8 red**.
- Revocation ignores `userStopped` (no tombstone → agent retries) → **4/8 red**.
- `chipVisibleAt` drops the linger → **2/7 red** (flicker tests).
- Store ignores `stopped` ids (Stop swallowed by the linger) → **1/7 red**.

## Gates

`npm run typecheck` clean. Full `npx vitest run`: **7100 passed / 12 skipped, 0 errors**. New: `src/main/browser-revocation.test.ts` (8), `src/renderer/nodes/browser-indicator.test.tsx` (7). `browser-ownership-source.test.ts` (the "never read ownership from an edge" structural guard) still green — the new `browser-revocation.ts` reads only the ledger.

## Wired vs deferred

- **Wired & live now:** Stop from every surface + all six automatic triggers (they call the real detach), the store/push plumbing, the chip/rope/modal/kill-row surfaces.
- **Deferred to PR 7 (by design):** the `browser` verb that *sets* a live lease (`touchLease` + push on drive) — so the chip is dark until then; and the drive-path consulting the `browser-3` tombstone before a drive. Both are the lease *producer*; this PR is the *consumer*.

Mobile see/revoke remains owed work, explicitly not built here (global constraint 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)