### PR TITLE
feat(browser): the browser verb — routing, --nav, and --read

### DIFF
--- a/src/core/browser-verb.test.ts
+++ b/src/core/browser-verb.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseBrowserArgs,
+  BROWSER_KEYS,
+  BROWSER_READ_MODES,
+  BROWSER_TIMEOUT_DEFAULT_MS,
+  BROWSER_TIMEOUT_MAX_MS
+} from './browser-verb'
+
+describe('parseBrowserArgs — the whole flag table (design §2.2)', () => {
+  // ── one case per action row ─────────────────────────────────────────────────────────────────
+  it('--nav takes an http(s) URL and refuses non-http schemes', () => {
+    expect(parseBrowserArgs({ node: 'b1', nav: 'https://x.test/' })).toMatchObject({
+      action: { kind: 'nav', url: 'https://x.test/' }
+    })
+    expect(parseBrowserArgs({ node: 'b1', nav: 'javascript:alert(1)' })).toHaveProperty('error')
+    expect(parseBrowserArgs({ node: 'b1', nav: 'file:///etc/passwd' })).toHaveProperty('error')
+    expect(parseBrowserArgs({ node: 'b1', nav: 'data:text/html,x' })).toHaveProperty('error')
+  })
+
+  it('--read takes each of text|map|links|title', () => {
+    for (const mode of BROWSER_READ_MODES) {
+      expect(parseBrowserArgs({ node: 'b1', read: mode })).toMatchObject({
+        action: { kind: 'read', mode }
+      })
+    }
+  })
+
+  it('--click / --wait take a ref or selector', () => {
+    expect(parseBrowserArgs({ node: 'b1', click: '@7' })).toMatchObject({ action: { kind: 'click', target: '@7' } })
+    expect(parseBrowserArgs({ node: 'b1', wait: '#results' })).toMatchObject({ action: { kind: 'wait', target: '#results' } })
+    expect(parseBrowserArgs({ node: 'b1', click: '' })).toHaveProperty('error')
+  })
+
+  it('--type carries its text; --press carries a named key', () => {
+    expect(parseBrowserArgs({ node: 'b1', type: 'hello' })).toMatchObject({ action: { kind: 'type', text: 'hello' } })
+    expect(parseBrowserArgs({ node: 'b1', press: 'Enter' })).toMatchObject({ action: { kind: 'press', key: 'Enter' } })
+  })
+
+  it('--scroll takes a word or a signed pixel count, and refuses anything else', () => {
+    for (const w of ['up', 'down', 'top', 'bottom']) {
+      expect(parseBrowserArgs({ node: 'b1', scroll: w })).toMatchObject({ action: { kind: 'scroll', where: w } })
+    }
+    expect(parseBrowserArgs({ node: 'b1', scroll: '-600' })).toMatchObject({ action: { kind: 'scroll', where: '-600' } })
+    expect(parseBrowserArgs({ node: 'b1', scroll: 'sideways' })).toHaveProperty('error')
+  })
+
+  it('--screenshot takes a path; --cookies takes a domain', () => {
+    expect(parseBrowserArgs({ node: 'b1', screenshot: 'shot.png' })).toMatchObject({ action: { kind: 'screenshot', path: 'shot.png' } })
+    expect(parseBrowserArgs({ node: 'b1', cookies: 'github.com' })).toMatchObject({ action: { kind: 'cookies', domain: 'github.com' } })
+    expect(parseBrowserArgs({ node: 'b1', cookies: '' })).toEqual({
+      error: 'browser: --cookies takes one domain (use "current" for the page\'s own)'
+    })
+  })
+
+  // ── the plan's explicit cases ───────────────────────────────────────────────────────────────
+  it('refuses ZERO actions and refuses TWO — an ambiguous call must never guess', () => {
+    expect(parseBrowserArgs({ node: 'b1' })).toEqual({ error: expect.stringContaining('one action') })
+    expect(parseBrowserArgs({ node: 'b1', nav: 'https://x.test/', read: 'text' })).toEqual({
+      error: expect.stringContaining('one action')
+    })
+  })
+
+  it('--node is always required and never inferred', () => {
+    expect(parseBrowserArgs({ nav: 'https://x.test/' })).toEqual({ error: expect.stringContaining('--node') })
+  })
+
+  it('every flag takes a value — there are no booleans and no bare switches', () => {
+    expect(parseBrowserArgs({ node: 'b1', type: 'x', clear: 'true' })).toMatchObject({ clear: true })
+    expect(parseBrowserArgs({ node: 'b1', type: 'x', clear: '' })).toMatchObject({ clear: false })
+    expect(parseBrowserArgs({ node: 'b1', read: 'text', full: 'true' })).toMatchObject({ full: true })
+    expect(parseBrowserArgs({ node: 'b1', read: 'text', full: '' })).toMatchObject({ full: false })
+  })
+
+  it('--timeout defaults to 15000 and is clamped to 60000', () => {
+    expect(parseBrowserArgs({ node: 'b1', nav: 'https://x.test/' })).toMatchObject({ timeoutMs: BROWSER_TIMEOUT_DEFAULT_MS })
+    expect(parseBrowserArgs({ node: 'b1', nav: 'https://x.test/', timeout: '999999' })).toMatchObject({
+      timeoutMs: BROWSER_TIMEOUT_MAX_MS
+    })
+    // A zero/garbage timeout falls back to the default rather than hanging the route with 0.
+    expect(parseBrowserArgs({ node: 'b1', nav: 'https://x.test/', timeout: '0' })).toMatchObject({ timeoutMs: 15_000 })
+    expect(parseBrowserArgs({ node: 'b1', nav: 'https://x.test/', timeout: 'abc' })).toMatchObject({ timeoutMs: 15_000 })
+    expect(parseBrowserArgs({ node: 'b1', nav: 'https://x.test/', timeout: '3000' })).toMatchObject({ timeoutMs: 3000 })
+  })
+
+  it('--read takes exactly title|map|links|text', () => {
+    expect(parseBrowserArgs({ node: 'b1', read: 'html' })).toEqual({
+      error: 'browser: --read takes text|map|links|title'
+    })
+  })
+
+  it('--press takes only the named keys', () => {
+    for (const k of BROWSER_KEYS) expect(parseBrowserArgs({ node: 'b1', press: k })).not.toHaveProperty('error')
+    expect(parseBrowserArgs({ node: 'b1', press: 'F5' })).toHaveProperty('error')
+    expect(parseBrowserArgs({ node: 'b1', press: 'a' })).toHaveProperty('error')
+  })
+
+  it('--node must satisfy isSafeNodeId BEFORE it indexes anything', () => {
+    // Salvaged from S8's requiredTabId/requiredString: validate before a map lookup.
+    expect(parseBrowserArgs({ node: '../x', read: 'title' })).toHaveProperty('error')
+    expect(parseBrowserArgs({ node: 'a/b', read: 'title' })).toHaveProperty('error')
+    // …and node safety is decided BEFORE the action count, so a bad node with a valid action still
+    // reports the node.
+    expect(parseBrowserArgs({ node: '../x', read: 'title' })).toEqual({
+      error: expect.stringContaining('--node')
+    })
+  })
+
+  it('carries the modifier flags through onto the call', () => {
+    const call = parseBrowserArgs({ node: 'b1', type: 'hi', into: '@3', clear: 'true' })
+    expect(call).toMatchObject({ into: '@3', clear: true, action: { kind: 'type', text: 'hi' } })
+    const read = parseBrowserArgs({ node: 'b1', read: 'text', selector: 'main', max: '5000' })
+    expect(read).toMatchObject({ selector: 'main', max: 5000 })
+    const press = parseBrowserArgs({ node: 'b1', press: 'ArrowDown', times: '4' })
+    expect(press).toMatchObject({ times: 4 })
+  })
+})

--- a/src/core/browser-verb.ts
+++ b/src/core/browser-verb.ts
@@ -1,0 +1,224 @@
+/**
+ * The `browser` verb's PURE argument table — the whole flag surface, decided once, in `src/core` so
+ * both shells compile it and every consumer (the main drive path here in PR 7, the interaction and
+ * cookie verbs in PRs 8-9) reads ONE parser rather than re-deriving the rules.
+ *
+ * WHY IT IS PURE AND SEPARATE FROM THE DRIVE. The security decision — owner, capability, the CDP
+ * allowlist — is main-side and must never be reachable from the renderer or a shim (global
+ * constraint 4, design §3.3). This file decides only the SHAPE of a request: which single action it
+ * is, whether `--node` is present and safe, the timeout clamp, and the per-flag value rules. Nothing
+ * here attaches a debugger, reads a page or trusts a caller field; a malformed call is a NAMED error,
+ * never a guess.
+ *
+ * TWO RULES THAT OUTLIVE THE SHIM BUG (design §2.1). The canvas-control shim consumes the token after
+ * a bare `--flag` (fixed in PR 1, but an already-connected SSH host keeps the old loop until it
+ * reconnects — a stale window with no signal on the wire), so this verb is designed to parse
+ * IDENTICALLY under both loops:
+ *   1. every flag takes a value — there are no bare switches. `--clear`/`--full` take the literal
+ *      string `"true"`, and `--press <key>` exists because `--enter true` would be a bare switch.
+ *   2. exactly ONE action per call — zero is an empty request and two is an ambiguous one; both are
+ *      refused rather than guessed, because a guess that drives a logged-in page is the wrong kind.
+ *
+ * `--node` is ALWAYS required and never inferred ("the one you have" is a guess), and it is validated
+ * with `isSafeNodeId` BEFORE it is ever used to index a map — the salvage from S8's
+ * requiredTabId/requiredString, which validated after the lookup.
+ */
+import { isSafeNodeId } from './remote-safety'
+import { normalizeAddress } from '@shared/browserUrl'
+
+/** The default and the hard ceiling for a per-verb timeout. The route's own ceiling is
+ *  CONTROL_CEILING_MS (130s) and main's pending-control timeout is 120s, so a verb must never
+ *  approach either — 60s leaves a wide margin. */
+export const BROWSER_TIMEOUT_DEFAULT_MS = 15_000
+export const BROWSER_TIMEOUT_MAX_MS = 60_000
+
+/** The named keys `--press` accepts. No function keys, no chords — only what a real form needs
+ *  (Enter/Tab to move and submit, the arrows/paging to move a caret or a list selection). A key
+ *  outside this set is a NAMED refusal, never passed through to `Input.dispatchKeyEvent`. */
+export const BROWSER_KEYS = [
+  'Enter',
+  'Tab',
+  'Escape',
+  'Backspace',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End'
+] as const
+export type BrowserKey = (typeof BROWSER_KEYS)[number]
+
+/** The four read modes. There is deliberately NO `html` mode and no full-DOM mode (design §2.4,
+ *  enforced again at the allowlist): innerText semantics exclude the hidden inputs, data-* attributes
+ *  and inline <script> blobs where sites keep tokens; an HTML mode re-includes all of it. */
+export const BROWSER_READ_MODES = ['text', 'map', 'links', 'title'] as const
+export type BrowserReadMode = (typeof BROWSER_READ_MODES)[number]
+
+/** The valid `--scroll` targets: a named edge/step or a signed pixel count. */
+const SCROLL_WORDS = ['up', 'down', 'top', 'bottom'] as const
+
+/** Exactly one of these is the call's action. The order is the refusal-listing order, but presence,
+ *  not order, is what "exactly one" counts. */
+export const BROWSER_ACTION_KEYS = [
+  'nav',
+  'read',
+  'click',
+  'type',
+  'press',
+  'scroll',
+  'wait',
+  'screenshot',
+  'cookies'
+] as const
+
+export type BrowserAction =
+  | { kind: 'nav'; url: string }
+  | { kind: 'read'; mode: BrowserReadMode }
+  | { kind: 'click'; target: string }
+  | { kind: 'type'; text: string }
+  | { kind: 'press'; key: BrowserKey }
+  | { kind: 'scroll'; where: string }
+  | { kind: 'wait'; target: string }
+  | { kind: 'screenshot'; path: string }
+  | { kind: 'cookies'; domain: string }
+
+export interface BrowserCall {
+  /** The drivable browser node. Required, safe-id-validated, never inferred. */
+  node: string
+  /** The single action this call performs. */
+  action: BrowserAction
+  /** The clamped timeout, always in `[_, BROWSER_TIMEOUT_MAX_MS]`, defaulting to the default. */
+  timeoutMs: number
+  /** `--clear true` — clear a field before `--type`. A modifier, never an action. */
+  clear: boolean
+  /** `--full true` — a full-page variant (read/screenshot). A modifier, never an action. */
+  full: boolean
+  /** `--into <ref>` — the field `--type` targets. */
+  into?: string
+  /** `--selector <css>` — scopes `--read text`; also a click/wait handle. */
+  selector?: string
+  /** `--max <n>` — the `--read text` cap (drive-side clamps to its own ceiling). */
+  max?: number
+  /** `--times <n>` — repeat count for `--press`. */
+  times?: number
+}
+
+const err = (message: string): { error: string } => ({ error: message })
+
+function presentActionKeys(args: Record<string, string>): string[] {
+  return BROWSER_ACTION_KEYS.filter((k) => Object.prototype.hasOwnProperty.call(args, k))
+}
+
+/** `--timeout`: absent/invalid → the default; anything valid clamped to the ceiling. Never below
+ *  1ms and never above the ceiling, so a caller can neither hang the route nor pass 0. */
+function clampTimeout(raw: string | undefined): number {
+  if (raw === undefined) return BROWSER_TIMEOUT_DEFAULT_MS
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n <= 0) return BROWSER_TIMEOUT_DEFAULT_MS
+  return Math.min(n, BROWSER_TIMEOUT_MAX_MS)
+}
+
+/** A positive integer flag (`--max`, `--times`), or undefined when absent/invalid — the drive path
+ *  supplies its own default rather than trusting a partial parse. */
+function positiveInt(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+function buildAction(key: string, value: string): BrowserAction | { error: string } {
+  switch (key) {
+    case 'nav': {
+      // The SAME scheme check the address bar and the allowlist use — javascript:/file:/data: all
+      // normalize to null, so this refuses them here with a readable message rather than at the gate.
+      if (normalizeAddress(value) === null) {
+        return err('browser: --nav needs an http(s) URL')
+      }
+      return { kind: 'nav', url: value }
+    }
+    case 'read': {
+      if (!(BROWSER_READ_MODES as readonly string[]).includes(value)) {
+        // The exact wording is a contract (the tests pin it): text|map|links|title.
+        return err('browser: --read takes text|map|links|title')
+      }
+      return { kind: 'read', mode: value as BrowserReadMode }
+    }
+    case 'click': {
+      if (!value) return err('browser: --click takes a @ref or a CSS selector')
+      return { kind: 'click', target: value }
+    }
+    case 'type': {
+      // Empty text is allowed (a --clear with no new text is a legitimate call); the drive path caps
+      // the length at the allowlist's 8192.
+      return { kind: 'type', text: value }
+    }
+    case 'press': {
+      if (!(BROWSER_KEYS as readonly string[]).includes(value)) {
+        return err(`browser: --press takes one of: ${BROWSER_KEYS.join(', ')}`)
+      }
+      return { kind: 'press', key: value as BrowserKey }
+    }
+    case 'scroll': {
+      const named = (SCROLL_WORDS as readonly string[]).includes(value)
+      const pixels = /^-?\d+$/.test(value)
+      if (!named && !pixels) {
+        return err('browser: --scroll takes up, down, top, bottom, or a signed pixel count')
+      }
+      return { kind: 'scroll', where: value }
+    }
+    case 'wait': {
+      if (!value) return err('browser: --wait takes a @ref or a CSS selector')
+      return { kind: 'wait', target: value }
+    }
+    case 'screenshot': {
+      if (!value) return err('browser: --screenshot takes a file path')
+      return { kind: 'screenshot', path: value }
+    }
+    case 'cookies': {
+      // The PR 9 wording, kept here so the parser owns the whole table and the message never drifts.
+      if (!value) return err('browser: --cookies takes one domain (use "current" for the page\'s own)')
+      return { kind: 'cookies', domain: value }
+    }
+    default:
+      return err(`browser: unknown action --${key}`)
+  }
+}
+
+/**
+ * Validate a raw `browser` arg map into a {@link BrowserCall}, or return `{ error }`. Pure and
+ * total — every path returns one or the other, and a throw inside a value check is impossible because
+ * every value is already a string off the form body.
+ *
+ * Order matters and is asserted: `--node` presence, then `--node` SAFETY (before any map lookup can
+ * ever use it), then the exactly-one-action count, then the single action's own value rule. A caller
+ * missing `--node` is told about `--node` even when it also passed a valid action, because the node
+ * is the thing that decides WHICH logged-in page this drives.
+ */
+export function parseBrowserArgs(args: Record<string, string>): BrowserCall | { error: string } {
+  const node = args.node
+  if (!node) return err('browser: --node <id> is required')
+  if (!isSafeNodeId(node)) return err(`browser: --node "${node}" is not a valid node id`)
+
+  const actions = presentActionKeys(args)
+  if (actions.length !== 1) {
+    return err('browser: pass exactly one action (--nav, --read, --click, --type, --press, --scroll, --wait, --screenshot or --cookies)')
+  }
+
+  const action = buildAction(actions[0], args[actions[0]] ?? '')
+  if ('error' in action) return action
+
+  return {
+    node,
+    action,
+    timeoutMs: clampTimeout(args.timeout),
+    clear: args.clear === 'true',
+    full: args.full === 'true',
+    into: args.into || undefined,
+    selector: args.selector || undefined,
+    max: positiveInt(args.max),
+    times: positiveInt(args.times)
+  }
+}

--- a/src/main/browser-actions.test.ts
+++ b/src/main/browser-actions.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { BrowserSession } from './browser-lease'
+import type { DebuggerLike } from './browser-cdp-send'
+import type { CdpContext } from './browser-cdp-allowlist'
+import { NT_SCRIPTS } from './browser-nt-scripts'
+import { RefTable } from './browser-refs'
+import {
+  CdpEventBus,
+  browserNav,
+  browserRead,
+  browserReadTitle,
+  browserReadLinks,
+  browserReadMap,
+  browserReadText
+} from './browser-actions'
+
+/**
+ * These drive the REAL production code — a real {@link BrowserSession}, real `sendCdp`, the real CDP
+ * allowlist and the real frozen NT_SCRIPTS readers — against a fake `webContents.debugger` whose
+ * `sendCommand` returns canned page data. So every command an action issues actually passes the
+ * allowlist gate (a disallowed method or bad params would reject and fail the test), and the readers
+ * used are the byte-for-byte frozen strings. The only thing faked is the guest's response.
+ *
+ * A real Electron `<webview>` end-to-end (Global Constraint 8) additionally proves the readers'
+ * in-page behaviour (the hidden-input / aria-hidden exclusion). That harness needs Electron + a
+ * display and is not run in this headless suite; see the PR body's deferral note.
+ */
+
+interface PageModel {
+  url: string
+  title: string
+  status: number
+  links: { href: string; text: string }[]
+  mapItems: Record<string, unknown>[]
+  bodyText: string
+  selectorText: Record<string, string | null>
+}
+
+class FakeDebugger implements DebuggerLike {
+  attached = false
+  attachCount = 0
+  sends: { method: string; params: Record<string, unknown> }[] = []
+  private msg: ((e: unknown, method: string, params: unknown) => void)[] = []
+  private det: ((e: unknown, reason: string) => void)[] = []
+  autoLoad = true
+
+  constructor(public page: PageModel) {}
+
+  isAttached(): boolean {
+    return this.attached
+  }
+  attach(): void {
+    this.attached = true
+    this.attachCount++
+  }
+  detach(): void {
+    this.attached = false
+    for (const f of this.det) f({}, 'user')
+  }
+  on(event: 'detach' | 'message', listener: never): void {
+    if (event === 'detach') this.det.push(listener)
+    else this.msg.push(listener)
+  }
+  emit(method: string, params: unknown): void {
+    for (const f of this.msg) f({}, method, params)
+  }
+  async sendCommand(method: string, params: object = {}): Promise<unknown> {
+    const p = params as Record<string, unknown>
+    this.sends.push({ method, params: p })
+    switch (method) {
+      case 'DOM.getDocument':
+        return { root: { nodeId: 1 } }
+      case 'DOM.resolveNode':
+        return { object: { objectId: 'doc-obj' } }
+      case 'Runtime.callFunctionOn':
+        return { result: { value: this.evalReader(p) } }
+      case 'Page.getNavigationHistory':
+        return { currentIndex: 0, entries: [{ url: this.page.url }] }
+      case 'Page.navigate':
+        if (this.autoLoad) {
+          // A macrotask, so it fires AFTER browserNav has reached `bus.once` — a real debugger's
+          // events arrive over IPC (a macrotask) too, never synchronously inside sendCommand.
+          setTimeout(() => {
+            this.emit('Network.responseReceived', { type: 'Document', response: { status: this.page.status } })
+            this.emit('Page.frameNavigated', { frame: { id: 'main' } })
+            this.emit('Page.loadEventFired', {})
+          }, 0)
+        }
+        return { frameId: 'main' }
+      default:
+        return {}
+    }
+  }
+
+  private evalReader(p: Record<string, unknown>): unknown {
+    const fn = p.functionDeclaration
+    const args = (p.arguments as { value: unknown }[] | undefined) ?? []
+    if (fn === NT_SCRIPTS.readTitle) return this.page.title
+    if (fn === NT_SCRIPTS.readLinks) return this.page.links
+    if (fn === NT_SCRIPTS.readMap) return this.page.mapItems
+    if (fn === NT_SCRIPTS.readText) {
+      const sel = args[0]?.value as string | undefined
+      const t = sel ? this.page.selectorText[sel] ?? null : this.page.bodyText
+      return t === null ? null : { text: t.slice(0, 60000), total: t.length }
+    }
+    return null
+  }
+}
+
+const viewport = (): CdpContext => ({ viewport: { width: 1280, height: 800 } })
+
+function makeSession(page: PageModel): { session: BrowserSession; dbg: FakeDebugger; bus: CdpEventBus; refs: RefTable } {
+  const dbg = new FakeDebugger(page)
+  const session = new BrowserSession({ nodeId: 'browser-3', debugger: dbg, viewport })
+  const refs = new RefTable()
+  const bus = new CdpEventBus(() => refs.bumpGeneration('browser-3'))
+  dbg.on('message', ((_e: unknown, m: string, prm: unknown) => bus.emit(m, prm)) as never)
+  return { session, dbg, bus, refs }
+}
+
+function basePage(over: Partial<PageModel> = {}): PageModel {
+  return {
+    url: 'https://example.com/login',
+    title: 'Sign in',
+    status: 200,
+    links: [],
+    mapItems: [],
+    bodyText: '',
+    selectorText: {},
+    ...over
+  }
+}
+
+describe('--nav', () => {
+  it('navigates, reads the main-frame status + final URL + title, and replies one line', async () => {
+    const { session, bus } = makeSession(basePage())
+    const r = await browserNav(session, bus, 'browser-3', 'https://example.com/login', 15_000)
+    expect(r).toEqual({ ok: true, message: 'navigated browser-3 → https://example.com/login (200, "Sign in")' })
+  })
+
+  it('a load that never fires is a NAMED timeout that names the URL it is still at — not a hang', async () => {
+    const { session, dbg, bus } = makeSession(basePage({ url: 'https://slow.test/' }))
+    dbg.autoLoad = false // never emit loadEventFired
+    const r = await browserNav(session, bus, 'browser-3', 'https://slow.test/', 20)
+    expect(r.ok).toBe(false)
+    expect(r.message).toBe('browser: browser-3 did not finish loading within 20ms (still at https://slow.test/)')
+  })
+
+  it('bumps the ref generation on the main-frame navigation (Task 5.5)', async () => {
+    const { session, bus, refs } = makeSession(basePage())
+    expect(refs.currentGeneration('browser-3')).toBe(0)
+    await browserNav(session, bus, 'browser-3', 'https://example.com/login', 15_000)
+    expect(refs.currentGeneration('browser-3')).toBe(1)
+  })
+
+  it('there is no passive channel out of the page — extra CDP events never reach the reply', async () => {
+    const { session, dbg, bus } = makeSession(basePage())
+    dbg.autoLoad = false
+    const navP = browserNav(session, bus, 'browser-3', 'https://example.com/login', 15_000)
+    await new Promise((r) => setTimeout(r, 0)) // let browserNav reach `bus.once`
+    // A firehose of events an S8-style forwarder would have streamed to the agent:
+    dbg.emit('Network.responseReceived', { type: 'Image', response: { status: 404, url: 'https://tracker.test/x.gif' } })
+    dbg.emit('Network.dataReceived', { dataLength: 999, secret: 'PAGE-DATA-LEAK' })
+    dbg.emit('Runtime.consoleAPICalled', { args: [{ value: 'CONSOLE-LEAK' }] })
+    dbg.emit('Network.responseReceived', { type: 'Document', response: { status: 200 } })
+    dbg.emit('Page.loadEventFired', {})
+    const r = await navP
+    expect(r.message).not.toContain('LEAK')
+    expect(r.message).not.toContain('404')
+    expect(r.message).toBe('navigated browser-3 → https://example.com/login (200, "Sign in")')
+  })
+})
+
+describe('--read family', () => {
+  let spySends: { method: string; params: Record<string, unknown> }[]
+
+  beforeEach(() => {
+    spySends = []
+  })
+
+  it('NO agent-derived character reaches an `expression` field — ever (Task 7.4)', async () => {
+    const page = basePage({
+      links: [{ href: 'https://example.com/pricing', text: 'Pricing' }],
+      mapItems: [{ ref: 0, tag: 'button', role: 'button', name: 'Sign in', filled: null }],
+      bodyText: 'hello world'
+    })
+    const { session, dbg, bus, refs } = makeSession(page)
+    for (const mode of ['title', 'links', 'map', 'text'] as const) {
+      await browserRead(session, bus, refs, 'browser-3', mode, { selector: 'main.injection"attempt' })
+    }
+    // The read chain uses ONLY functionDeclaration (identity-pinned) + our objectId + scalar args.
+    for (const s of dbg.sends) {
+      expect(s.params).not.toHaveProperty('expression')
+    }
+    // Runtime.evaluate is never issued at all.
+    expect(dbg.sends.some((s) => s.method === 'Runtime.evaluate')).toBe(false)
+  })
+
+  it('--read title: URL + title + status, one line', async () => {
+    const { session, bus } = makeSession(basePage())
+    // seed a status the way a prior nav would
+    bus.emit('Network.responseReceived', { type: 'Document', response: { status: 200 } })
+    const r = await browserReadTitle(session, bus)
+    expect(r).toEqual({ ok: true, message: 'https://example.com/login "Sign in" (200)' })
+  })
+
+  it('--read links: text → absolute url, one per line, deduped', async () => {
+    const page = basePage({
+      links: [
+        { href: 'https://example.com/a', text: 'A' },
+        { href: 'https://example.com/a', text: 'A again (dupe href)' },
+        { href: 'https://example.com/b', text: 'B' }
+      ]
+    })
+    const { session } = makeSession(page)
+    const r = await browserReadLinks(session)
+    expect(r.message).toBe('A → https://example.com/a\nB → https://example.com/b')
+  })
+
+  it('--read map: numbered, mints refs, reports FILL STATE never the value (Task 7.5)', async () => {
+    const page = basePage({
+      mapItems: [
+        { ref: 0, tag: 'a', role: 'link', name: 'Pricing', href: 'https://example.com/pricing', filled: null },
+        // A password field that IS filled — the reader returns `filled:true` and NEVER a value.
+        { ref: 1, tag: 'input', role: 'input', id: 'password', type: 'password', name: '', filled: true },
+        { ref: 2, tag: 'button', role: 'button', name: 'Sign in', filled: null }
+      ]
+    })
+    const { session, refs } = makeSession(page)
+    const r = await browserReadMap(session, refs, 'browser-3')
+    expect(r.message).toBe(
+      '@1 link "Pricing" → https://example.com/pricing\n@2 input#password (password, filled)\n@3 button "Sign in"'
+    )
+    // The value 'hunter2' is nowhere in the reply because the reader never returned it.
+    expect(r.message).not.toContain('hunter2')
+    // Refs were minted for this node at the current generation.
+    expect(refs.resolve('browser-3', refs.currentGeneration('browser-3'), '@2').ok).toBe(true)
+  })
+
+  it('--read text: capped by --max with an IN-BAND truncation announcement', async () => {
+    const big = 'x'.repeat(84213)
+    const { session } = makeSession(basePage({ bodyText: big }))
+    const r = await browserReadText(session, 'browser-3', undefined, 20_000)
+    expect(r.ok).toBe(true)
+    expect(r.message.endsWith('[truncated at 20000 of 84213 chars — narrow it with --selector]')).toBe(true)
+    expect(r.message.length).toBeLessThan(big.length)
+  })
+
+  it('--read text: --max is clamped to the 60000 ceiling', async () => {
+    const big = 'y'.repeat(70000)
+    const { session } = makeSession(basePage({ bodyText: big }))
+    const r = await browserReadText(session, 'browser-3', undefined, 999999)
+    expect(r.message).toContain('[truncated at 60000 of 70000 chars')
+  })
+
+  it('--read text: a selector matching nothing is a named refusal, not empty text', async () => {
+    const { session } = makeSession(basePage({ selectorText: { '#missing': null } }))
+    const r = await browserReadText(session, 'browser-3', '#missing', undefined)
+    expect(r).toEqual({ ok: false, message: 'browser: browser-3 has nothing matching #missing' })
+  })
+})

--- a/src/main/browser-actions.ts
+++ b/src/main/browser-actions.ts
@@ -1,0 +1,318 @@
+/**
+ * The CDP execution for the `browser` verb's PR-7 actions — `--nav` and the `--read` family. Every
+ * command here goes through the injected `send` (a {@link import('./browser-lease').BrowserSession}'s
+ * `send`, which routes through `sendCdp` → the allowlist), so this module cannot reach a CDP method
+ * the gate refuses. Main-side only (it reads a real page); never Server Edition.
+ *
+ * THE EVENT BOUNDARY (design §3.2, Task 7.3). We subscribe to a FIXED set of CDP events —
+ * Page.frameNavigated, Page.loadEventFired, Network.responseReceived (main frame),
+ * Runtime.executionContextsCleared — and NOTHING is streamed to the agent. S8 forwarded every CDP
+ * event to its client as a firehose; here events feed our own state (the {@link CdpEventBus}) only,
+ * and the agent sees verb REPLIES. `browser-actions.test.ts` asserts there is no passive channel out
+ * of the page: extra events emitted during a nav never appear in the reply.
+ *
+ * THE READ BOUNDARY (design §3.1, Task 7.4). Page-side logic runs ONLY as a frozen NT_SCRIPTS entry,
+ * by identity, through Runtime.callFunctionOn with returnByValue — NO agent-derived character ever
+ * reaches an `expression` field, because this module never issues Runtime.evaluate at all. A test
+ * spies on every send and fails on any `expression` key.
+ *
+ * CDP child-session bookkeeping and the wheel/scroll salvage come from PR #112's S8 (@Corvin,
+ * proteus-dev); the nav/read shape here is new.
+ */
+import { NT_SCRIPTS } from './browser-nt-scripts'
+import type { RefTable } from './browser-refs'
+import type { BrowserReadMode } from '../core/browser-verb'
+
+/** A one-line agent-facing outcome. `ok:false` is a NAMED refusal, never a hang and never a raw
+ *  Electron error. */
+export interface ActionResult {
+  ok: boolean
+  message: string
+}
+
+/** The one capability the actions need from a lease: send a (gated) CDP command. */
+export interface Sendable {
+  send(method: string, params: object): Promise<unknown>
+}
+
+/** The `--read text` hard ceiling and default; the parser clamps `--max` to the ceiling too. */
+export const READ_TEXT_DEFAULT_MAX = 20_000
+export const READ_TEXT_CEILING = 60_000
+const LIST_CAP = 200
+const LIST_BYTES = 8192
+
+type CdpEvent = { method: string; params: Record<string, unknown> }
+
+/**
+ * The fixed-set event sink for one guest. Fed by `debugger.on('message')` in index.ts; read by
+ * {@link browserNav}. It records only the main-frame document status and drives ref invalidation on
+ * a navigation — it has NO path that hands an event to an agent-facing channel.
+ */
+export class CdpEventBus {
+  private readonly waiters = new Set<{ match: (e: CdpEvent) => boolean; resolve: (e: CdpEvent | null) => void }>()
+  private mainFrameStatus: number | undefined
+
+  /** `onNavigation` bumps the node's ref generation (Task 5.5) — the single invalidation path both
+   *  Page.frameNavigated and Runtime.executionContextsCleared funnel through. */
+  constructor(private readonly onNavigation?: () => void) {}
+
+  emit(method: string, rawParams: unknown): void {
+    const params = (rawParams && typeof rawParams === 'object' ? rawParams : {}) as Record<string, unknown>
+    if (method === 'Page.frameNavigated') {
+      const frame = params.frame as { parentId?: string } | undefined
+      // The MAIN frame only (no parent). A sub-frame navigation is not a page navigation.
+      if (frame && frame.parentId === undefined) this.onNavigation?.()
+    } else if (method === 'Runtime.executionContextsCleared') {
+      this.onNavigation?.()
+    } else if (method === 'Network.responseReceived') {
+      // Main-frame DOCUMENT response only — the status the agent means by "did it load".
+      if (params.type === 'Document') {
+        const resp = params.response as { status?: number } | undefined
+        if (resp && typeof resp.status === 'number') this.mainFrameStatus = resp.status
+      }
+    }
+    const e: CdpEvent = { method, params }
+    for (const w of [...this.waiters]) {
+      if (w.match(e)) {
+        this.waiters.delete(w)
+        w.resolve(e)
+      }
+    }
+  }
+
+  /** Await the next event matching `match`, or null after `timeoutMs`. Never throws, never hangs. */
+  once(match: (e: CdpEvent) => boolean, timeoutMs: number): Promise<CdpEvent | null> {
+    return new Promise((resolve) => {
+      const waiter = {
+        match,
+        resolve: (e: CdpEvent | null) => {
+          clearTimeout(timer)
+          resolve(e)
+        }
+      }
+      const timer = setTimeout(() => {
+        this.waiters.delete(waiter)
+        resolve(null)
+      }, timeoutMs)
+      this.waiters.add(waiter)
+    })
+  }
+
+  /** Forget the last main-frame status — called at the start of a nav so a stale status can't be
+   *  reported for the new page. */
+  clearStatus(): void {
+    this.mainFrameStatus = undefined
+  }
+
+  mainStatus(): number | undefined {
+    return this.mainFrameStatus
+  }
+}
+
+/**
+ * The read chain, once: DOM.getDocument(depth:0) → DOM.resolveNode → Runtime.callFunctionOn(a FROZEN
+ * NT_SCRIPTS reader, returnByValue, scalar args) → Runtime.releaseObject. The nodeId and objectId are
+ * OURS (from our own getDocument/resolveNode), never the agent's; the only agent-derived data that
+ * ever reaches a reader is a scalar `arguments[].value`, checked by the allowlist.
+ */
+async function callReader(s: Sendable, fn: string, args: readonly (string | number)[] = []): Promise<unknown> {
+  const doc = (await s.send('DOM.getDocument', { depth: 0 })) as { root?: { nodeId?: number } }
+  const nodeId = doc?.root?.nodeId
+  if (typeof nodeId !== 'number') throw new Error('read: could not read the document root')
+  const resolved = (await s.send('DOM.resolveNode', { nodeId })) as { object?: { objectId?: string } }
+  const objectId = resolved?.object?.objectId
+  if (typeof objectId !== 'string' || !objectId) throw new Error('read: could not resolve the document node')
+  try {
+    const res = (await s.send('Runtime.callFunctionOn', {
+      objectId,
+      functionDeclaration: fn,
+      arguments: args.map((v) => ({ value: v })),
+      returnByValue: true
+    })) as { result?: { value?: unknown } }
+    return res?.result?.value
+  } finally {
+    // Best-effort release; a failed release must not turn a good read into an error.
+    await s.send('Runtime.releaseObject', { objectId }).catch(() => {})
+  }
+}
+
+/** The final URL after navigation/redirects, from OUR navigation-history read. */
+async function currentUrl(s: Sendable): Promise<string> {
+  const h = (await s.send('Page.getNavigationHistory', {})) as {
+    currentIndex?: number
+    entries?: { url?: string }[]
+  }
+  const idx = typeof h?.currentIndex === 'number' ? h.currentIndex : -1
+  const url = h?.entries?.[idx]?.url
+  return typeof url === 'string' ? url : ''
+}
+
+async function readTitleValue(s: Sendable): Promise<string> {
+  const v = await callReader(s, NT_SCRIPTS.readTitle)
+  return typeof v === 'string' ? v : ''
+}
+
+/**
+ * `--nav`. Navigate, wait for the load (main's own clock, never a hang), and report the final URL,
+ * the main-frame status and the title. The timeout message NAMES the URL it is still at, because the
+ * worst failure shape is a page that half-loaded and the agent not knowing where it is.
+ */
+export async function browserNav(
+  s: Sendable,
+  bus: CdpEventBus,
+  nodeId: string,
+  url: string,
+  timeoutMs: number
+): Promise<ActionResult> {
+  await s.send('Page.enable', {})
+  await s.send('Network.enable', {})
+  bus.clearStatus()
+  await s.send('Page.navigate', { url })
+  const loaded = await bus.once((e) => e.method === 'Page.loadEventFired', timeoutMs)
+  const finalUrl = await currentUrl(s)
+  if (!loaded) {
+    return {
+      ok: false,
+      message: `browser: ${nodeId} did not finish loading within ${timeoutMs}ms (still at ${finalUrl})`
+    }
+  }
+  const status = bus.mainStatus()
+  const title = await readTitleValue(s)
+  const statusPart = status !== undefined ? String(status) : '?'
+  return { ok: true, message: `navigated ${nodeId} → ${finalUrl} (${statusPart}, ${JSON.stringify(title)})` }
+}
+
+/** `--read title`: URL + document.title + HTTP status, one line. */
+export async function browserReadTitle(s: Sendable, bus: CdpEventBus): Promise<ActionResult> {
+  const title = await readTitleValue(s)
+  const url = await currentUrl(s)
+  const status = bus.mainStatus()
+  const statusPart = status !== undefined ? ` (${status})` : ''
+  return { ok: true, message: `${url} ${JSON.stringify(title)}${statusPart}`.trim() }
+}
+
+interface LinkItem {
+  href?: unknown
+  text?: unknown
+}
+
+/** `--read links`: `text → absolute url`, deduped, capped at 200 links / 8 KB. */
+export async function browserReadLinks(s: Sendable): Promise<ActionResult> {
+  const raw = (await callReader(s, NT_SCRIPTS.readLinks)) as LinkItem[] | null
+  const seen = new Set<string>()
+  const lines: string[] = []
+  let bytes = 0
+  for (const l of raw ?? []) {
+    const href = typeof l?.href === 'string' ? l.href : ''
+    if (!href || seen.has(href)) continue
+    seen.add(href)
+    const text = (typeof l?.text === 'string' ? l.text : '').replace(/\s+/g, ' ').trim()
+    const line = `${text || '(no text)'} → ${href}`
+    if (lines.length >= LIST_CAP || bytes + line.length + 1 > LIST_BYTES) break
+    lines.push(line)
+    bytes += line.length + 1
+  }
+  return { ok: true, message: lines.length ? lines.join('\n') : 'no links on this page' }
+}
+
+interface MapItem {
+  tag?: unknown
+  role?: unknown
+  id?: unknown
+  type?: unknown
+  name?: unknown
+  href?: unknown
+  filled?: unknown
+}
+
+function formatMapItem(label: string, it: MapItem): string {
+  const tag = typeof it.tag === 'string' ? it.tag : ''
+  const role = (typeof it.role === 'string' && it.role) || tag || 'element'
+  const name = (typeof it.name === 'string' ? it.name : '').replace(/\s+/g, ' ').trim()
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') {
+    const id = typeof it.id === 'string' && it.id ? `#${it.id}` : ''
+    const type = (typeof it.type === 'string' && it.type) || tag
+    // The FILL STATE, never the value (design §2.4 / Task 7.5).
+    const state = it.filled ? 'filled' : 'empty'
+    return `${label} ${tag}${id} (${type}, ${state})`
+  }
+  if (tag === 'a') {
+    const href = typeof it.href === 'string' && it.href ? ` → ${it.href}` : ''
+    return `${label} ${role} ${JSON.stringify(name)}${href}`
+  }
+  return `${label} ${role} ${JSON.stringify(name)}`
+}
+
+/**
+ * `--read map`: a numbered inventory of INTERACTABLE elements only, capped 200 / 8 KB. Mints `@1…@n`
+ * bound to (nodeId, current navigation generation) so a later click can spend them (Task 5.5). Role,
+ * accessible name, and for a field its type and whether it is FILLED — never its value.
+ */
+export async function browserReadMap(s: Sendable, refs: RefTable, nodeId: string): Promise<ActionResult> {
+  const raw = (await callReader(s, NT_SCRIPTS.readMap)) as MapItem[] | null
+  const items = (raw ?? []).slice(0, LIST_CAP)
+  // Mint at the CURRENT generation — the one this page is on, which a navigation will have bumped.
+  refs.mint(nodeId, refs.currentGeneration(nodeId), items as Record<string, unknown>[])
+  const lines: string[] = []
+  let bytes = 0
+  for (let i = 0; i < items.length; i++) {
+    const line = formatMapItem(`@${i + 1}`, items[i])
+    if (bytes + line.length + 1 > LIST_BYTES) break
+    lines.push(line)
+    bytes += line.length + 1
+  }
+  return { ok: true, message: lines.length ? lines.join('\n') : 'no interactable elements found' }
+}
+
+/**
+ * `--read text`: rendered VISIBLE text (innerText semantics), whitespace as the page has it, scoped
+ * by `--selector`. Capped by `--max` (default 20 000, ceiling 60 000); a truncation is announced
+ * IN-BAND so the agent learns to narrow it. There is deliberately NO html/full-DOM mode.
+ */
+export async function browserReadText(
+  s: Sendable,
+  nodeId: string,
+  selector: string | undefined,
+  max: number | undefined
+): Promise<ActionResult> {
+  const res = (await callReader(s, NT_SCRIPTS.readText, selector ? [selector] : [])) as
+    | { text?: unknown; total?: unknown }
+    | null
+  if (res === null) {
+    return {
+      ok: false,
+      message: selector
+        ? `browser: ${nodeId} has nothing matching ${selector}`
+        : `browser: ${nodeId} has no readable document body`
+    }
+  }
+  const cap = Math.min(max ?? READ_TEXT_DEFAULT_MAX, READ_TEXT_CEILING)
+  const full = typeof res.text === 'string' ? res.text : ''
+  const total = typeof res.total === 'number' ? res.total : full.length
+  const text = full.slice(0, cap)
+  if (total > cap) {
+    return { ok: true, message: `${text}\n[truncated at ${cap} of ${total} chars — narrow it with --selector]` }
+  }
+  return { ok: true, message: text }
+}
+
+/** Dispatch the `--read <mode>` family. */
+export async function browserRead(
+  s: Sendable,
+  bus: CdpEventBus,
+  refs: RefTable,
+  nodeId: string,
+  mode: BrowserReadMode,
+  opts: { selector?: string; max?: number }
+): Promise<ActionResult> {
+  switch (mode) {
+    case 'title':
+      return browserReadTitle(s, bus)
+    case 'links':
+      return browserReadLinks(s)
+    case 'map':
+      return browserReadMap(s, refs, nodeId)
+    case 'text':
+      return browserReadText(s, nodeId, opts.selector, opts.max)
+  }
+}

--- a/src/main/browser-cdp-allowlist.test.ts
+++ b/src/main/browser-cdp-allowlist.test.ts
@@ -73,21 +73,52 @@ describe('checkCdpCommand', () => {
     // An allowlist that explains itself is a probing aid.
     expect(checkCdpCommand('Made.Up', {}, ctx)).toBe(false)
   })
+
+  it('the read/nav infra methods PR 7 adds are gated, not blanket-allowed', () => {
+    // Enabling the Network domain (needed for the main-frame status) is fine; it carries no read.
+    expect(checkCdpCommand('Network.enable', {}, ctx)).toBe(true)
+    expect(checkCdpCommand('Page.getNavigationHistory', {}, ctx)).toBe(true)
+    // resolveNode takes OUR document nodeId (a number), never an agent objectId.
+    expect(checkCdpCommand('DOM.resolveNode', { nodeId: 1 }, ctx)).toBe(true)
+    expect(checkCdpCommand('DOM.resolveNode', { objectId: 'agent-picked' }, ctx)).toBe(false)
+    expect(checkCdpCommand('DOM.resolveNode', {}, ctx)).toBe(false)
+    expect(checkCdpCommand('Runtime.releaseObject', { objectId: 'o1' }, ctx)).toBe(true)
+    expect(checkCdpCommand('Runtime.releaseObject', {}, ctx)).toBe(false)
+  })
+
+  it('the full-DOM read cannot arrive by another door (Task 7.6)', () => {
+    // `--read html` is refused in the verb parser; here we pin that the CDP methods an HTML/full-DOM
+    // read would need are refused by the allowlist too, so the same read cannot arrive by another
+    // door — deep getDocument, getOuterHTML and getAttributes are all default-denied.
+    expect(checkCdpCommand('DOM.getOuterHTML', { nodeId: 1 }, ctx)).toBe(false)
+    expect(checkCdpCommand('DOM.getAttributes', { nodeId: 1 }, ctx)).toBe(false)
+    expect(checkCdpCommand('DOM.getDocument', { depth: -1 }, ctx)).toBe(false) // -1 = whole tree
+    expect(checkCdpCommand('DOM.getDocument', { depth: 0 }, ctx)).toBe(true)
+    expect(checkCdpCommand('DOM.getDocument', { depth: 1, pierce: true }, ctx)).toBe(false)
+  })
 })
 
 /**
  * Structural pin (the analogue of Task 4.4's second half). `checkCdpCommand` is only THE gate if it
- * is unbypassable: every `sendCommand(` in the main-side browser surface must live inside the one
- * wrapper, `browser-cdp-send.ts`, which calls this function. A direct `debugger.sendCommand` anywhere
- * else is arbitrary CDP that never met the allowlist.
+ * is unbypassable: every `sendCommand(` in `src/main` must live inside the one wrapper,
+ * `browser-cdp-send.ts`, which calls this function. A direct `debugger.sendCommand` anywhere else is
+ * arbitrary CDP that never met the allowlist.
+ *
+ * WIDENED IN PR 7 (carried obligation, PR 5/#306 MINOR-1). Until the `browser` VERB existed, the only
+ * CDP callers were `browser-*.ts` files and the grep scanned only those. PR 7 adds the drive path
+ * (`browser-drive.ts`, `browser-actions.ts`) and wires the real `webContents.debugger` into a
+ * `BrowserSession` from `index.ts` — so a stray `sendCommand` could now be introduced in a
+ * non-`browser-`prefixed main file too. The grep therefore scans ALL of `src/main`, so the single-gate
+ * property is enforced across the whole surface the verb path now touches, not just the files that
+ * happen to be named `browser-*`.
  */
-describe('debugger.sendCommand has exactly one call site', () => {
+describe('debugger.sendCommand has exactly one call site in ALL of src/main', () => {
   const mainDir = path.resolve(__dirname)
 
-  it('every sendCommand( in src/main/browser-*.ts is inside browser-cdp-send.ts', () => {
+  it('every sendCommand( in src/main is inside browser-cdp-send.ts', () => {
     const offenders: string[] = []
     for (const f of fs.readdirSync(mainDir)) {
-      if (!/^browser-.*\.ts$/.test(f) || f.endsWith('.test.ts')) continue
+      if (!f.endsWith('.ts') || f.endsWith('.test.ts')) continue
       if (f === 'browser-cdp-send.ts') continue
       const src = fs.readFileSync(path.join(mainDir, f), 'utf8')
       // Strip comments so a mention in prose is not a false positive; a real call is not a comment.

--- a/src/main/browser-cdp-allowlist.ts
+++ b/src/main/browser-cdp-allowlist.ts
@@ -109,13 +109,15 @@ const ALLOW = new Map<string, Validator>([
       p.selector.length <= MAX_SELECTOR
   ],
 
-  // A shallow document read only (depth <= 1, no pierce) — the deep read is the full-DOM door that
-  // getOuterHTML/getAttributes are excluded to keep shut.
+  // A shallow document read only (0 <= depth <= 1, no pierce) — the deep read is the full-DOM door
+  // that getOuterHTML/getAttributes are excluded to keep shut. NEGATIVE depth is refused too: in CDP
+  // `depth: -1` means the ENTIRE subtree, the same full-DOM read arriving by a signed-number door
+  // (Task 7.6). Our own read code passes depth:0; this is the belt.
   [
     'DOM.getDocument',
     (p) =>
       isRecord(p) &&
-      (p.depth === undefined || (typeof p.depth === 'number' && p.depth <= 1)) &&
+      (p.depth === undefined || (typeof p.depth === 'number' && p.depth >= 0 && p.depth <= 1)) &&
       p.pierce !== true
   ],
 
@@ -144,6 +146,18 @@ const ALLOW = new Map<string, Validator>([
   ['DOM.enable', () => true],
   ['Runtime.enable', () => true],
   ['Page.getLayoutMetrics', () => true],
+  // Enable the Network domain so `--nav` can read the MAIN-FRAME response status from
+  // Network.responseReceived (an event feeding our own state — nothing is streamed to the agent,
+  // asserted in browser-actions.test.ts). It carries no read power itself; getAllCookies stays out.
+  ['Network.enable', () => true],
+  // The final URL after a `--nav` (redirects resolved). Read-only, no parameters that matter.
+  ['Page.getNavigationHistory', () => true],
+  // The read family's chain: getDocument(depth<=1) → resolveNode(nodeId) → callFunctionOn → releaseObject.
+  // resolveNode turns OUR shallow document node into an execution-context object handle for the frozen
+  // NT_SCRIPTS reader; the nodeId comes from our own getDocument, never from the agent.
+  ['DOM.resolveNode', (p) => isRecord(p) && typeof p.nodeId === 'number'],
+  // Free the object handle callFunctionOn ran against. objectId is our own, from resolveNode.
+  ['Runtime.releaseObject', (p) => isRecord(p) && typeof p.objectId === 'string' && p.objectId.length > 0],
   // Flat-mode child attach only (S8): a nested/auto-attach mode is a different, unaudited surface.
   [
     'Target.attachToTarget',

--- a/src/main/browser-control-route.test.ts
+++ b/src/main/browser-control-route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  resolveBrowserTarget,
+  browserResolveTimedOut,
+  type BrowserResolve
+} from './browser-drive'
+
+/**
+ * Task 7.2 — `browser` is answered in MAIN, and the renderer only says what it alone knows. The
+ * security decision (owner + capability + the CDP allowlist) is main-side; the renderer is asked
+ * three facts and NEVER runs a CDP command. These tests pin both halves: the resolve round-trip
+ * cannot hang the pending-control budget, and the renderer half holds no CDP surface.
+ */
+
+const repoRoot = path.resolve(__dirname, '..', '..')
+
+describe('the resolve round-trip is a NAMED failure, never a hang (does not eat the 120s budget)', () => {
+  it('a canvas that never answers times out to a named refusal well under the budget', async () => {
+    const never = () => new Promise<BrowserResolve>(() => {}) // hangs forever
+    const start = Date.now()
+    const r = await resolveBrowserTarget('browser-3', never, 30)
+    expect(Date.now() - start).toBeLessThan(1000)
+    expect(r).toEqual({ ok: false, refusal: browserResolveTimedOut('browser-3') })
+  })
+
+  it('a renderer that rejects (the window went away) is the same named failure', async () => {
+    const rejects = () => Promise.reject(new Error('window gone'))
+    const r = await resolveBrowserTarget('browser-3', rejects, 1000)
+    expect(r).toEqual({ ok: false, refusal: browserResolveTimedOut('browser-3') })
+  })
+
+  it('a prompt answer is passed straight through', async () => {
+    const answer: BrowserResolve = { ok: true, projectId: 'p', sourceControlCapable: true, capabilityOn: true }
+    const r = await resolveBrowserTarget('browser-3', () => Promise.resolve(answer), 1000)
+    expect(r).toEqual(answer)
+  })
+})
+
+describe("Canvas.tsx holds NO part of the CDP surface (it is the more attackable half)", () => {
+  const canvas = fs.readFileSync(path.join(repoRoot, 'src/renderer/canvas/Canvas.tsx'), 'utf8')
+  // Strip comments so a mention in prose is not a false positive.
+  const code = canvas.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+
+  it('never calls sendCommand', () => {
+    expect(/\bsendCommand\s*\(/.test(code)).toBe(false)
+  })
+
+  it('never imports the NT_SCRIPTS table', () => {
+    expect(code.includes('browser-nt-scripts')).toBe(false)
+    expect(/\bNT_SCRIPTS\b/.test(code)).toBe(false)
+  })
+
+  it('never imports the CDP allowlist', () => {
+    expect(code.includes('browser-cdp-allowlist')).toBe(false)
+    expect(code.includes('browser-cdp-send')).toBe(false)
+    expect(/\bcheckCdpCommand\b/.test(code)).toBe(false)
+  })
+
+  it('never imports the main-side drive/gate module', () => {
+    // The allowlist and the ledger must not be reachable from the renderer at all.
+    expect(code.includes('browser-drive')).toBe(false)
+    expect(code.includes('browser-control-ledger')).toBe(false)
+  })
+})
+
+/**
+ * Carried obligation (PR 6/#307 MINOR-1): there is NO second global browser-control toggle — the ONLY
+ * gate is the per-project switch (`agentBrowserControl`). A machine-wide "browser control on/off"
+ * setting would be a second, coarser authority that could silently override the per-project consent
+ * the whole design is built on. This was true by grep but unguarded; here it is pinned.
+ */
+describe('there is exactly ONE browser-control gate — the per-project switch, no second global toggle', () => {
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (e.name === 'node_modules' || e.name.startsWith('.')) continue
+      const full = path.join(dir, e.name)
+      if (e.isDirectory()) walk(full, out)
+      else if (/\.(ts|tsx)$/.test(e.name) && !/\.test\.(ts|tsx)$/.test(e.name)) out.push(full)
+    }
+    return out
+  }
+
+  it('no settings/store key names a GLOBAL browser-control toggle', () => {
+    // A global toggle would surface as a settings key like these. The per-project field is
+    // `agentBrowserControl` (a project.json field), which is deliberately NOT matched here.
+    const globalTogglePatterns = [
+      /browserControlEnabled/i,
+      /enableBrowserControl/i,
+      /globalBrowserControl/i,
+      /browserControlGlobal/i,
+      /allowBrowserControl/i,
+      /disableBrowserControl/i
+    ]
+    const offenders: string[] = []
+    for (const f of walk(path.join(repoRoot, 'src'))) {
+      const src = fs.readFileSync(f, 'utf8')
+      for (const re of globalTogglePatterns) {
+        if (re.test(src)) offenders.push(`${path.relative(repoRoot, f)} :: ${re}`)
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/main/browser-drive.test.ts
+++ b/src/main/browser-drive.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from 'vitest'
+import { BrowserControlLedger, BROWSER_USER_STOPPED } from './browser-control-ledger'
+import { BrowserSession } from './browser-lease'
+import type { DebuggerLike } from './browser-cdp-send'
+import type { CdpContext } from './browser-cdp-allowlist'
+import { NT_SCRIPTS } from './browser-nt-scripts'
+import { RefTable } from './browser-refs'
+import { CdpEventBus, type Sendable } from './browser-actions'
+import { STRICT_CONTROL_REFUSAL } from '../core/agents/node-identity-policy'
+import { browserDiscardedMessage } from './browser-guest-registry'
+import {
+  driveBrowser,
+  gateBrowserDrive,
+  BROWSER_CAPABILITY_OFF_MESSAGE,
+  BROWSER_SOURCE_NOT_CAPABLE,
+  noDrivableNodeMessage,
+  type BrowserResolve,
+  type DriveDeps,
+  type LiveGuest
+} from './browser-drive'
+import { parseBrowserArgs, type BrowserCall } from '../core/browser-verb'
+
+const OWNER = 'claude-1'
+const NODE = 'browser-3'
+const okResolve: BrowserResolve = {
+  ok: true,
+  projectId: 'proj-1',
+  sourceControlCapable: true,
+  capabilityOn: true
+}
+
+/** A fake debugger that tracks whether it was ever ATTACHED — the whole point of "ledger.get before
+ *  any attach" is that a refused caller causes zero attachments. */
+class FakeDebugger implements DebuggerLike {
+  attached = false
+  attachCount = 0
+  isAttached(): boolean {
+    return this.attached
+  }
+  attach(): void {
+    this.attached = true
+    this.attachCount++
+  }
+  detach(): void {
+    this.attached = false
+  }
+  on(): void {}
+  async sendCommand(method: string, params: object = {}): Promise<unknown> {
+    const p = params as Record<string, unknown>
+    switch (method) {
+      case 'DOM.getDocument':
+        return { root: { nodeId: 1 } }
+      case 'DOM.resolveNode':
+        return { object: { objectId: 'o' } }
+      case 'Runtime.callFunctionOn':
+        return { result: { value: p.functionDeclaration === NT_SCRIPTS.readTitle ? 'Home' : null } }
+      case 'Page.getNavigationHistory':
+        return { currentIndex: 0, entries: [{ url: 'https://x.test/' }] }
+      default:
+        return {}
+    }
+  }
+}
+
+function freshLedgerOwning(): BrowserControlLedger {
+  const ledger = new BrowserControlLedger()
+  ledger.claim(NODE, { ownerNodeId: OWNER, projectId: 'proj-1', partition: 'p', navGeneration: 0, leaseActiveUntil: 0, openedAt: 0 })
+  return ledger
+}
+
+function makeGuest(): { guest: LiveGuest; dbg: FakeDebugger } {
+  const dbg = new FakeDebugger()
+  const viewport = (): CdpContext => ({ viewport: { width: 800, height: 600 } })
+  const session = new BrowserSession({ nodeId: NODE, debugger: dbg, viewport })
+  return { guest: { session: session as Sendable, bus: new CdpEventBus() }, dbg }
+}
+
+function readTitleCall(): BrowserCall {
+  const c = parseBrowserArgs({ node: NODE, read: 'title' })
+  if ('error' in c) throw new Error(c.error)
+  return c
+}
+
+// ── the pure ordering ─────────────────────────────────────────────────────────────────────────
+describe('gateBrowserDrive — the refusal ORDER is the requirement', () => {
+  const base = () => ({
+    browserNodeId: NODE,
+    ownerNodeId: OWNER,
+    verified: true,
+    resolve: okResolve,
+    ledger: freshLedgerOwning(),
+    guestPresent: true
+  })
+
+  it('1. identity first — an unverified caller is refused before anything else', () => {
+    // Even with a broken everything-else, identity wins: nothing happened.
+    const g = gateBrowserDrive({ ...base(), verified: false, resolve: { ok: false, refusal: 'x' }, ledger: new BrowserControlLedger(), guestPresent: false })
+    expect(g).toEqual({ kind: 'refuse', message: STRICT_CONTROL_REFUSAL, revoke: false })
+  })
+
+  it('2. then canControlCanvas', () => {
+    const g = gateBrowserDrive({ ...base(), resolve: { ...okResolve, sourceControlCapable: false } })
+    expect(g).toEqual({ kind: 'refuse', message: BROWSER_SOURCE_NOT_CAPABLE, revoke: false })
+  })
+
+  it('3. then the per-project capability — verbatim sentence, and it REVOKES', () => {
+    const g = gateBrowserDrive({ ...base(), resolve: { ...okResolve, capabilityOn: false } })
+    expect(g).toEqual({ kind: 'refuse', message: BROWSER_CAPABILITY_OFF_MESSAGE, revoke: true })
+  })
+
+  it('4. then ledger ownership — "not yours" and "does not exist" are the SAME message', () => {
+    const notYours = gateBrowserDrive({ ...base(), ownerNodeId: 'claude-9' })
+    const notExist = gateBrowserDrive({ ...base(), browserNodeId: 'browser-9', ledger: freshLedgerOwning() })
+    expect(notYours).toEqual({ kind: 'refuse', message: noDrivableNodeMessage(NODE), revoke: false })
+    expect(notExist).toEqual({ kind: 'refuse', message: noDrivableNodeMessage('browser-9'), revoke: false })
+  })
+
+  it('5. finally discard — a released page is a lifecycle refusal, never a permissions one', () => {
+    const g = gateBrowserDrive({ ...base(), guestPresent: false })
+    expect(g).toEqual({ kind: 'refuse', message: browserDiscardedMessage(NODE), revoke: false })
+  })
+
+  it('all gates pass → drive, carrying the ledger entry', () => {
+    const g = gateBrowserDrive(base())
+    expect(g.kind).toBe('drive')
+  })
+})
+
+// ── carried obligation: ledger-gated ATTACH (PR 5/#306 MINOR-2) ─────────────────────────────────
+describe('the ledger gates the ATTACH, not just the reply', () => {
+  it('an unowned caller cannot drive AND never causes a debugger attach', async () => {
+    const ledger = new BrowserControlLedger() // nobody owns NODE
+    const { guest, dbg } = makeGuest()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn() }
+    const r = await driveBrowser({ call: readTitleCall(), ownerNodeId: OWNER, verified: true, resolve: okResolve }, deps)
+    expect(r).toEqual({ ok: false, message: noDrivableNodeMessage(NODE) })
+    expect(dbg.attachCount).toBe(0) // the debugger was NEVER attached for a non-owner
+  })
+
+  it('the ledger-confirmed owner drives, and only THEN does the debugger attach', async () => {
+    const ledger = freshLedgerOwning()
+    const { guest, dbg } = makeGuest()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn() }
+    const r = await driveBrowser({ call: readTitleCall(), ownerNodeId: OWNER, verified: true, resolve: okResolve }, deps)
+    expect(r.ok).toBe(true)
+    expect(dbg.attachCount).toBe(1)
+  })
+})
+
+// ── carried obligation: DRIVE-TIME live capability read + revoke (PR 6/#307 MINOR-2) ─────────────
+describe('capability is read LIVE at drive time and a now-off switch refuses AND revokes', () => {
+  it('a valid-at-attach lease is re-checked each drive; capability now off → refuse + revoke + no attach', async () => {
+    const ledger = freshLedgerOwning()
+    const { guest, dbg } = makeGuest()
+    const revoke = vi.fn()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke }
+
+    // First drive: capability ON → drives.
+    const on = await driveBrowser({ call: readTitleCall(), ownerNodeId: OWNER, verified: true, resolve: { ...okResolve, capabilityOn: true } }, deps)
+    expect(on.ok).toBe(true)
+
+    // Same lease, next verb: a project.json hand-edit flipped the switch OFF (a FRESH resolve says so).
+    const off = await driveBrowser({ call: readTitleCall(), ownerNodeId: OWNER, verified: true, resolve: { ...okResolve, capabilityOn: false } }, deps)
+    expect(off).toEqual({ ok: false, message: BROWSER_CAPABILITY_OFF_MESSAGE })
+    expect(revoke).toHaveBeenCalledWith(NODE) // detaches + drops + tombstones
+    // The off-drive attempts no new attach of its own.
+    expect(dbg.attachCount).toBe(1)
+  })
+})
+
+// ── carried obligation: honor the #307 tombstone ────────────────────────────────────────────────
+describe('a user-Stopped node refuses to re-drive until a fresh verified claim (#307 tombstone)', () => {
+  it('after the USER stops control, its owner is refused with the named human act — not a retryable null', async () => {
+    const ledger = freshLedgerOwning()
+    ledger.stopByUser(NODE) // chip / menu / Settings / switch-off
+    const { guest, dbg } = makeGuest()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn() }
+    const r = await driveBrowser({ call: readTitleCall(), ownerNodeId: OWNER, verified: true, resolve: okResolve }, deps)
+    expect(r).toEqual({ ok: false, message: BROWSER_USER_STOPPED })
+    expect(dbg.attachCount).toBe(0)
+  })
+
+  it('the tombstone clears ONLY via a fresh claim — then the same owner drives again', async () => {
+    const ledger = freshLedgerOwning()
+    ledger.stopByUser(NODE)
+    expect(ledger.wasStoppedByUser(NODE, OWNER)).toBe(true)
+    // A fresh, verified open-browser re-claims the node (ids are not reused in practice, but the
+    // tombstone-clear on claim is the contract).
+    ledger.claim(NODE, { ownerNodeId: OWNER, projectId: 'proj-1', partition: 'p', navGeneration: 0, leaseActiveUntil: 0, openedAt: 0 })
+    expect(ledger.wasStoppedByUser(NODE, OWNER)).toBe(false)
+    const { guest } = makeGuest()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn() }
+    const r = await driveBrowser({ call: readTitleCall(), ownerNodeId: OWNER, verified: true, resolve: okResolve }, deps)
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe('driveBrowser end-to-end refusals', () => {
+  it('a discarded guest (sessionFor → null) is the named discard refusal', async () => {
+    const ledger = freshLedgerOwning()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => null, revoke: vi.fn() }
+    const r = await driveBrowser({ call: readTitleCall(), ownerNodeId: OWNER, verified: true, resolve: okResolve }, deps)
+    expect(r).toEqual({ ok: false, message: browserDiscardedMessage(NODE) })
+  })
+
+  it('an unverified caller is refused with the flat strict sentence', async () => {
+    const ledger = freshLedgerOwning()
+    const { guest } = makeGuest()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn() }
+    const r = await driveBrowser({ call: readTitleCall(), ownerNodeId: OWNER, verified: false, resolve: okResolve }, deps)
+    expect(r).toEqual({ ok: false, message: STRICT_CONTROL_REFUSAL })
+  })
+})

--- a/src/main/browser-drive.ts
+++ b/src/main/browser-drive.ts
@@ -1,0 +1,201 @@
+/**
+ * THE drive gate and orchestration for the `browser` verb. This is where browser driving goes live:
+ * everything before PR 7 was inert machinery, and this module is the producer that attaches a lease
+ * and drives a real guest. So it is the highest-stakes security surface of the set, and its whole
+ * job is to REFUSE before it drives, in a fixed order, main-side, trusting no caller field.
+ *
+ * THE ORDER IS THE REQUIREMENT (design §2.3, Task 7.2), and every step fails closed:
+ *   1. IDENTITY — a non-`verified` caller is refused before anything else, because the promise of a
+ *      refusal is that nothing happened. (`browser` is verified-only via STRICT_CONTROL_VERBS, which
+ *      hook-server enforces before this handler; this is the belt.)
+ *   2. canControlCanvas — the source agent kind must be canvas-control-capable.
+ *   3. the PER-PROJECT capability, read LIVE at drive time — a switch on at attach but now off
+ *      (including a project.json hand-edit) REFUSES and REVOKES (carried obligation, PR 6/#307
+ *      MINOR-2). The message is the design's verbatim sentence: the agent cannot turn it on itself.
+ *   4. LEDGER OWNERSHIP — before ANY attach, `browser-control-ledger.get()` keyed on the
+ *      cryptographically-verified caller node id must return this owner's entry (carried obligation,
+ *      PR 5/#306 MINOR-2). "Does not exist" and "exists but is not yours" are the SAME message —
+ *      a different one is a node-enumeration oracle. A node the USER stopped (#307 tombstone) is
+ *      refused with the named human act and cannot re-drive until a fresh verified `claim()`.
+ *   5. DISCARD — a node whose page the memory saver released is a lifecycle refusal, never a
+ *      permissions one.
+ *
+ * Only after all five does a debugger attach (lazily, on the first send inside {@link browserNav}/
+ * the reads), so a refused caller never causes an attachment. `src/main`, never Server Edition.
+ */
+import {
+  BrowserControlLedger,
+  BROWSER_USER_STOPPED,
+  type AgentBrowserEntry
+} from './browser-control-ledger'
+import { STRICT_CONTROL_REFUSAL } from '../core/agents/node-identity-policy'
+import { browserDiscardedMessage } from './browser-guest-registry'
+import { browserNav, browserRead, type ActionResult, type Sendable, type CdpEventBus } from './browser-actions'
+import type { RefTable } from './browser-refs'
+import type { BrowserCall } from '../core/browser-verb'
+
+/** The design's verbatim capability-off sentence. The last clause STOPS an agent burning a turn
+ *  trying to enable it. Exported so the wiring and the tests share the one string. */
+export const BROWSER_CAPABILITY_OFF_MESSAGE =
+  "Browser control is off for this project. The user can turn it on in the project's Agents settings; you cannot."
+
+/** The refusal when the source node is not a control-capable agent (step 2). Same wording every
+ *  other verb's renderer path uses, so the caller learns the same way. */
+export const BROWSER_SOURCE_NOT_CAPABLE = 'source node is not a control-capable agent'
+
+/** "Does not exist" AND "exists but is not yours" — ONE message, adopted verbatim from S8's
+ *  requireTab, because a distinct message is a node-enumeration oracle. */
+export const noDrivableNodeMessage = (id: string): string => `no drivable browser node "${id}"`
+
+/** What the renderer alone knows, answered over the resolve round-trip: the owning project of the
+ *  source, whether the source is control-capable, and the LIVE per-project capability value. Main
+ *  makes the security DECISION from this; the renderer never runs a CDP command. */
+export type BrowserResolve =
+  | { ok: true; projectId: string; projectCwd?: string; sourceControlCapable: boolean; capabilityOn: boolean }
+  | { ok: false; refusal: string }
+
+/** The resolve round-trip's own short ceiling. Kept far under main's 120s pending-control budget and
+ *  the route's 130s ceiling: a canvas that does not answer is a NAMED failure in 2s, never a hang
+ *  that eats the whole budget while the agent waits. */
+export const BROWSER_RESOLVE_TIMEOUT_MS = 2000
+
+/** The resolve failed to come back in time. A named, retryable refusal — not a hang, not a
+ *  permissions verdict. */
+export const browserResolveTimedOut = (id: string): string =>
+  `browser: the canvas did not answer for ${id} in time — try again`
+
+/**
+ * Ask the renderer to resolve a browser target, but never let that round-trip hang: it races the
+ * renderer's answer against a 2s timeout, and a rejection (the window went away) is the same named
+ * failure. This is the piece that keeps a slow/absent canvas from consuming the 120s pending-control
+ * budget — injected `ask` so the timeout behaviour is unit-testable without Electron.
+ */
+export async function resolveBrowserTarget(
+  browserNodeId: string,
+  ask: () => Promise<BrowserResolve>,
+  timeoutMs: number = BROWSER_RESOLVE_TIMEOUT_MS
+): Promise<BrowserResolve> {
+  const timedOut: BrowserResolve = { ok: false, refusal: browserResolveTimedOut(browserNodeId) }
+  const timeout = new Promise<BrowserResolve>((resolve) => setTimeout(() => resolve(timedOut), timeoutMs))
+  const answer = ask().catch((): BrowserResolve => timedOut)
+  return Promise.race([answer, timeout])
+}
+
+export interface DriveGateInput {
+  browserNodeId: string
+  /** The cryptographically-verified caller node id (main's own verdict, #304). */
+  ownerNodeId: string
+  /** main's own `verdict === 'verified'` for THIS request — never a wire/caller field. */
+  verified: boolean
+  resolve: BrowserResolve
+  ledger: BrowserControlLedger
+  /** Is there a live canvas guest for this node (else the memory saver released it)? */
+  guestPresent: boolean
+}
+
+export type DriveGate =
+  | { kind: 'refuse'; message: string; revoke: boolean }
+  | { kind: 'drive'; entry: AgentBrowserEntry }
+
+/**
+ * The pure decision. Returns the single refusal (with whether to also revoke) or a go-ahead carrying
+ * the ledger entry. No I/O, no attach — so the ordering is unit-testable exactly.
+ */
+export function gateBrowserDrive(input: DriveGateInput): DriveGate {
+  // 1. identity
+  if (!input.verified) return { kind: 'refuse', message: STRICT_CONTROL_REFUSAL, revoke: false }
+  // (resolve failed → the source is not on an open canvas at all; a named, non-revoking refusal)
+  if (!input.resolve.ok) return { kind: 'refuse', message: input.resolve.refusal, revoke: false }
+  // 2. canControlCanvas
+  if (!input.resolve.sourceControlCapable) {
+    return { kind: 'refuse', message: BROWSER_SOURCE_NOT_CAPABLE, revoke: false }
+  }
+  // 3. per-project capability, LIVE — and a now-off switch revokes as well as refuses.
+  if (!input.resolve.capabilityOn) {
+    return { kind: 'refuse', message: BROWSER_CAPABILITY_OFF_MESSAGE, revoke: true }
+  }
+  // 4. ledger ownership — before any attach. Tombstone (user-Stopped) is named; everything else is
+  //    the one non-enumerating message.
+  const entry = input.ledger.get(input.browserNodeId, input.ownerNodeId)
+  if (!entry) {
+    if (input.ledger.wasStoppedByUser(input.browserNodeId, input.ownerNodeId)) {
+      return { kind: 'refuse', message: BROWSER_USER_STOPPED, revoke: false }
+    }
+    return { kind: 'refuse', message: noDrivableNodeMessage(input.browserNodeId), revoke: false }
+  }
+  // 5. discard
+  if (!input.guestPresent) {
+    return { kind: 'refuse', message: browserDiscardedMessage(input.browserNodeId), revoke: false }
+  }
+  return { kind: 'drive', entry }
+}
+
+/** The live control session + event bus for a node's CANVAS guest (Task 2.2: the canvas surface is
+ *  the only drivable one). Attaching is LAZY inside the session, so getting one costs no debugger
+ *  attach — that is what keeps "ledger.get before any attach" true. */
+export interface LiveGuest {
+  session: Sendable
+  bus: CdpEventBus
+}
+
+export interface DriveDeps {
+  ledger: BrowserControlLedger
+  refs: RefTable
+  /** The canvas guest's session+bus, or null when its page was released (discard). MUST NOT attach. */
+  sessionFor(browserNodeId: string): LiveGuest | null
+  /** Detach + drop ownership + tombstone — invoked when a live capability read comes back OFF. */
+  revoke(browserNodeId: string): void
+}
+
+async function runAction(
+  call: BrowserCall,
+  guest: LiveGuest,
+  refs: RefTable,
+  nodeId: string
+): Promise<ActionResult> {
+  const a = call.action
+  switch (a.kind) {
+    case 'nav':
+      return browserNav(guest.session, guest.bus, nodeId, a.url, call.timeoutMs)
+    case 'read':
+      return browserRead(guest.session, guest.bus, refs, nodeId, a.mode, {
+        selector: call.selector,
+        max: call.max
+      })
+    default:
+      // Interaction (PR 8) and cookies/screenshot (PR 9) parse today but do not drive yet: a NAMED,
+      // non-retryable refusal, never a silent success.
+      return { ok: false, message: `browser: --${a.kind} is not available yet (it lands in a later update)` }
+  }
+}
+
+/**
+ * Gate, then drive. The one entry point main wires the verb to. A refusal that carries `revoke`
+ * detaches+drops first; a go-ahead runs the action, converting any thrown allowlist/lease refusal
+ * into a named `ok:false` (never a hang, never a raw Electron error).
+ */
+export async function driveBrowser(
+  input: { call: BrowserCall; ownerNodeId: string; verified: boolean; resolve: BrowserResolve },
+  deps: DriveDeps
+): Promise<ActionResult> {
+  const guest = deps.sessionFor(input.call.node)
+  const gate = gateBrowserDrive({
+    browserNodeId: input.call.node,
+    ownerNodeId: input.ownerNodeId,
+    verified: input.verified,
+    resolve: input.resolve,
+    ledger: deps.ledger,
+    guestPresent: guest !== null
+  })
+  if (gate.kind === 'refuse') {
+    if (gate.revoke) deps.revoke(input.call.node)
+    return { ok: false, message: gate.message }
+  }
+  // guestPresent was true, so `guest` is non-null; the check keeps the type honest.
+  if (!guest) return { ok: false, message: browserDiscardedMessage(input.call.node) }
+  try {
+    return await runAction(input.call, guest, deps.refs, input.call.node)
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : 'browser: the command failed' }
+  }
+}

--- a/src/main/browser-nt-scripts.source.test.ts
+++ b/src/main/browser-nt-scripts.source.test.ts
@@ -40,6 +40,14 @@ describe('NT_SCRIPTS is a frozen table of literals', () => {
     expect(isNtScript('function(){return 1}')).toBe(false)
   })
 
+  it('readMap reports whether a field is FILLED but never returns its value (Task 7.5)', () => {
+    // The whole point of `--read map`: a password's fill STATE is useful, its value is a credential.
+    // The returned object literal must never carry a `value:` key. Reading `el.value` to compute the
+    // boolean is fine (no assignment); RETURNING it is the leak this pins against.
+    expect(NT_SCRIPTS.readMap).toContain('filled:')
+    expect(NT_SCRIPTS.readMap).not.toMatch(/value\s*:/)
+  })
+
   it('every script is a pure reader — none clicks, navigates, submits or writes', () => {
     // Every EFFECT goes through Input.* or Page.*, which is also why the effects are traceable.
     for (const s of Object.values(NT_SCRIPTS)) {

--- a/src/main/browser-nt-scripts.ts
+++ b/src/main/browser-nt-scripts.ts
@@ -26,18 +26,25 @@ export const NT_SCRIPTS = Object.freeze({
   /** The document title. */
   readTitle: 'function(){ return document.title }',
 
-  /** A map of interactable elements: a ref index, a tag, a short label and the element centre in
-   *  viewport coordinates (what a later Input.dispatchMouseEvent aims at). Read-only. */
+  /** A map of interactable elements: a ref index, role, accessible NAME (never a field's value), id,
+   *  input type, whether a field is FILLED (a boolean — never the value), a link's absolute href, and
+   *  the element centre in viewport coordinates (what a later Input.dispatchMouseEvent aims at).
+   *  Read-only. Off-screen (zero-box), display:none and aria-hidden elements are skipped by
+   *  construction, which is what keeps a hidden CSRF input and an aria-hidden block out of the map. */
   readMap:
-    'function(){ var els = document.querySelectorAll("a,button,input,textarea,select,[role=button],[role=link],[onclick]"); var out = []; for (var i = 0; i < els.length; i++) { var el = els[i]; var r = el.getBoundingClientRect(); if (r.width <= 0 || r.height <= 0) continue; out.push({ ref: i, tag: el.tagName, type: el.getAttribute("type"), text: (el.innerText || el.getAttribute("aria-label") || el.getAttribute("placeholder") || "").replace(/\\s+/g, " ").trim().slice(0, 80), x: r.left + r.width / 2, y: r.top + r.height / 2, w: r.width, h: r.height }); } return out }',
+    'function(){ var els = document.querySelectorAll("a,button,input,textarea,select,[role=button],[role=link],[onclick]"); var out = []; for (var i = 0; i < els.length; i++) { var el = els[i]; var r = el.getBoundingClientRect(); if (r.width <= 0 || r.height <= 0) continue; if (el.closest && el.closest("[aria-hidden=true]")) continue; var tag = el.tagName.toLowerCase(); var role = el.getAttribute("role") || (tag === "a" ? "link" : tag === "button" ? "button" : tag); var isField = tag === "input" || tag === "textarea" || tag === "select"; var name = (el.innerText || el.getAttribute("aria-label") || el.getAttribute("placeholder") || "").replace(/\\s+/g, " ").trim().slice(0, 80); out.push({ ref: i, tag: tag, role: role, id: el.id || "", type: el.getAttribute("type"), name: name, href: tag === "a" ? el.href : null, filled: isField ? (el.value ? true : false) : null, x: r.left + r.width / 2, y: r.top + r.height / 2, w: r.width, h: r.height }); } return out }',
 
   /** Every visible link as { href, text }. Read-only. */
   readLinks:
     'function(){ var as = document.querySelectorAll("a[href]"); var out = []; for (var i = 0; i < as.length; i++) { out.push({ href: as[i].href, text: (as[i].innerText || "").replace(/\\s+/g, " ").trim().slice(0, 120) }); } return out }',
 
-  /** The visible text of a selector (or the whole body when none is given). Read-only, capped. */
+  /** The visible text of a selector (or the whole body when none is given), plus the untruncated
+   *  length so main can announce an in-band truncation. Capped at the hard ceiling (60000) so a huge
+   *  page never ships megabytes over CDP; main applies the caller's --max (<= ceiling) to the text.
+   *  innerText semantics exclude <script>, <style>, display:none and aria-hidden BY CONSTRUCTION.
+   *  Read-only. */
   readText:
-    'function(sel){ var el = sel ? document.querySelector(sel) : document.body; return el ? (el.innerText || "").slice(0, 20000) : null }',
+    'function(sel){ var el = sel ? document.querySelector(sel) : document.body; if (!el) return null; var t = el.innerText || ""; return { text: t.slice(0, 60000), total: t.length } }',
 
   /** Re-locate a ref from readMap and return its current centre and tag, or null if it is gone. The
    *  ref is re-resolved against the SAME enumeration; generation staleness is enforced in main. */

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -301,10 +301,18 @@ describe('parseControlRequest', () => {
  * day the real `browser` verb lands, which is exactly when the PR body, the changelog and the
  * Settings copy all have to stop saying "nothing changes for anyone".
  */
-describe('the strict identity bucket is pre-positioned, not live', () => {
-  it('`browser` is not a verb this app has, so the bucket gates nothing today', () => {
+describe('the strict identity bucket now gates a real verb', () => {
+  it('`browser` IS a real verb (PR 7) AND is in the verified-only bucket', () => {
+    // The day the real `browser` verb lands, this assertion FLIPS from "not a verb" to "a real,
+    // strict verb" — which is exactly when the PR body, the changelog and the Settings copy stop
+    // saying "nothing changes for anyone". It requires `--node` and is otherwise validated by the
+    // pure `parseBrowserArgs` in the drive path.
     expect(STRICT_CONTROL_VERBS.has('browser')).toBe(true)
-    expect(parseControlRequest('browser', {})).toEqual({ error: 'Unknown verb: browser' })
+    expect(parseControlRequest('browser', {})).toEqual({ error: 'browser: --node <id> is required' })
+    expect(parseControlRequest('browser', { node: 'browser-1', read: 'title' })).toEqual({
+      verb: 'browser',
+      args: { node: 'browser-1', read: 'title' }
+    })
   })
 
   it('`open-browser` IS a real verb and is deliberately NOT in the bucket', () => {

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -55,6 +55,7 @@ export type ControlVerb =
   | 'reply'
   | 'notify'
   | 'sticky'
+  | 'browser'
 
 export interface ControlCommand {
   verb: ControlVerb
@@ -89,7 +90,8 @@ const VERBS: ControlVerb[] = [
   'send',
   'reply',
   'notify',
-  'sticky'
+  'sticky',
+  'browser'
 ]
 
 /**
@@ -154,6 +156,12 @@ export function parseControlRequest(
   if (v === 'sticky' && args.text !== undefined && args.append !== undefined) {
     return { error: 'sticky: pass either --text or --append, not both' }
   }
+  // `browser` requires `--node`; the full flag table (exactly one action, timeout clamp, per-flag
+  // value rules) is decided by the pure `parseBrowserArgs` (`src/core/browser-verb.ts`), which main's
+  // drive path runs after this presence gate. The verb is verified-only (STRICT_CONTROL_VERBS,
+  // enforced in hook-server before it ever reaches a handler) and refused by name on the Server
+  // Edition (control-unsupported-on-this-edition), where there is no webview to drive.
+  if (v === 'browser' && !args.node) return { error: 'browser: --node <id> is required' }
   return { verb: v, args }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,7 +16,17 @@ installLogSink(logBuffer)
 import { writeFilesToClipboard } from './clipboard-files'
 import { allowGuestNavigation } from './webview-nav'
 import { BrowserControlLedger } from './browser-control-ledger'
-import { BrowserLeaseManager } from './browser-lease'
+import { BrowserLeaseManager, BrowserSession } from './browser-lease'
+import { CdpEventBus, type Sendable } from './browser-actions'
+import { RefTable } from './browser-refs'
+import {
+  driveBrowser,
+  resolveBrowserTarget,
+  type BrowserResolve,
+  type LiveGuest
+} from './browser-drive'
+import { parseBrowserArgs } from '../core/browser-verb'
+import { STRICT_CONTROL_REFUSAL } from '../core/agents/node-identity-policy'
 import {
   revokeBrowserNode,
   revokeBrowserByOwner,
@@ -2346,7 +2356,104 @@ app.whenReady().then(async () => {
   // automatic triggers) is fully live, because `release` is a no-op-safe detach for a node with no
   // session. Owned here so all the wiring has one home. See browser-lease.ts / browser-revocation.ts.
   const browserLeases = new BrowserLeaseManager()
-  const browserRevocation: RevocationTargets = { leases: browserLeases, ledger: browserLedger }
+  // @ref bookkeeping (Task 5.5), one table for every driven node; nav bumps a node's generation.
+  const browserRefs = new RefTable()
+  // Per-node event bus (fixed CDP event set → our own state) and the `debugger.on('message')`
+  // listener we registered for it, kept so a teardown removes exactly that listener (a released and
+  // re-created session must not leave a duplicate listener firing on the same debugger).
+  const browserBuses = new Map<string, CdpEventBus>()
+  const browserMsgListeners = new Map<
+    string,
+    { dbg: { removeListener(event: string, fn: (...a: unknown[]) => void): void }; fn: (...a: unknown[]) => void }
+  >()
+  // Tear down the driver-side state for one node (its lease/session is being released). Removes the
+  // exact message listener and forgets the bus + refs, so nothing keeps driving a released node.
+  const browserDriverTeardown = (nodeId: string): void => {
+    const l = browserMsgListeners.get(nodeId)
+    if (l) {
+      try {
+        l.dbg.removeListener('message', l.fn)
+      } catch {
+        /* a destroyed debugger throws; the map cleanup below is what matters */
+      }
+      browserMsgListeners.delete(nodeId)
+    }
+    browserBuses.delete(nodeId)
+    browserRefs.forget(nodeId)
+  }
+  // Revocation releases the lease (detach + reject in-flight) AND tears down the driver state, in one
+  // place, whatever triggered it — so a Stop can never leave a page still drivable.
+  const browserRevocation: RevocationTargets = {
+    leases: {
+      release: (nodeId: string) => {
+        browserLeases.release(nodeId)
+        browserDriverTeardown(nodeId)
+      }
+    },
+    ledger: browserLedger
+  }
+  // The live control session + event bus for a node's CANVAS <webview> guest (Task 2.2: the canvas
+  // surface is the only drivable one — a modal guest is never driven). Attaching is LAZY inside the
+  // session, so getting one costs no debugger attach; that is what keeps "ledger.get() before any
+  // attach" literally true. Returns null when the guest's page is gone (the memory saver released
+  // it), which the drive gate turns into the named discard refusal.
+  const canvasGuestWcId = (browserNodeId: string): number | undefined => {
+    let unknownSurface: number | undefined
+    for (const [wcId, g] of browserGuests) {
+      if (g.nodeId !== browserNodeId) continue
+      if (g.surface === 'canvas') return wcId
+      // `surface` is `undefined` until both mount sites are threaded (guest-registry): treat it as
+      // the canvas fallback (the common case is one canvas guest), but NEVER drive a `'modal'` one.
+      if (g.surface === undefined) unknownSurface = wcId
+    }
+    return unknownSurface
+  }
+  const browserSessionFor = (browserNodeId: string): LiveGuest | null => {
+    const wcId = canvasGuestWcId(browserNodeId)
+    if (wcId === undefined) return null
+    const wc = webContents.fromId(wcId)
+    if (!wc || wc.isDestroyed()) return null
+    const existing = browserLeases.get(browserNodeId)
+    const existingBus = browserBuses.get(browserNodeId)
+    if (existing && existingBus) return { session: existing as unknown as Sendable, bus: existingBus }
+    // Fresh driver: the bus bumps this node's ref generation on a main-frame navigation / context
+    // clear (Task 5.5), the session pushes its lease to the ledger + renderer on every verb (which is
+    // what lights the driving chip), and the message listener feeds the fixed CDP event set into the
+    // bus — nothing is streamed to the agent.
+    const bus = new CdpEventBus(() => browserRefs.bumpGeneration(browserNodeId))
+    const session = new BrowserSession({
+      nodeId: browserNodeId,
+      debugger: wc.debugger,
+      // Coordinates are unused by --nav/--read; PR 8's pointer verbs refresh this from
+      // Page.getLayoutMetrics before dispatching a bounded mouse event.
+      viewport: () => ({ viewport: { width: 0, height: 0 } }),
+      isDevToolsOpen: () => {
+        try {
+          return wc.isDevToolsOpened()
+        } catch {
+          return false
+        }
+      },
+      onLeaseChange: (until) => {
+        browserLedger.touchLease(browserNodeId, until)
+        pushBrowserLeases()
+      }
+    })
+    const fn = (_e: unknown, method: string, params: unknown): void => bus.emit(method, params)
+    wc.debugger.on('message', fn)
+    browserLeases.set(browserNodeId, session)
+    browserBuses.set(browserNodeId, bus)
+    browserMsgListeners.set(browserNodeId, {
+      dbg: wc.debugger as unknown as { removeListener(e: string, f: (...a: unknown[]) => void): void },
+      fn: fn as unknown as (...a: unknown[]) => void
+    })
+    return { session: session as unknown as Sendable, bus }
+  }
+  // The 60s idle detach (browser-lease.ts): drop the debugger attachment on nodes gone quiet, so an
+  // attachment never outlives its usefulness. The session stays in the map and re-attaches on the
+  // next verb; only the debugger handle is released. Unref'd so it never holds the process open.
+  const browserIdleSweep = setInterval(() => browserLeases.sweepIdle(Date.now()), 30_000)
+  browserIdleSweep.unref?.()
   // Push the current driven-lease set to the renderer (chip / rope / kill row). `stopped` ids drop
   // from the chip immediately, skipping the anti-flicker linger — that is how an explicit Stop hides
   // at once while a merely-idle lease fades.
@@ -2405,7 +2512,88 @@ app.whenReady().then(async () => {
       pending.resolve(payload)
     }
   )
+  // The `browser` verb resolve round-trip (Task 7.2). Main asks the renderer to resolve a source
+  // node's owning project, control-capability and the LIVE per-project capability value; the renderer
+  // answers here. Modelled on `pendingControl`, but its own map with its own short (2s) timeout so a
+  // slow canvas can NEVER consume the 120s pending-control budget.
+  const pendingBrowserResolve = new Map<string, (r: BrowserResolve) => void>()
+  ipcMain.on(
+    IPC.browserControlResolveResult,
+    (
+      _e,
+      payload: {
+        requestId: string
+        ok: boolean
+        refusal?: string
+        projectId?: string
+        projectCwd?: string
+        sourceControlCapable?: boolean
+        capabilityOn?: boolean
+      }
+    ) => {
+      const resolve = pendingBrowserResolve.get(payload.requestId)
+      if (!resolve) return
+      pendingBrowserResolve.delete(payload.requestId)
+      resolve(
+        payload.ok
+          ? {
+              ok: true,
+              projectId: payload.projectId ?? '',
+              projectCwd: payload.projectCwd,
+              sourceControlCapable: payload.sourceControlCapable === true,
+              capabilityOn: payload.capabilityOn === true
+            }
+          : { ok: false, refusal: payload.refusal ?? 'source node is not on an open canvas' }
+      )
+    }
+  )
+  // Ask the renderer to resolve a source node — the `ask` closure `resolveBrowserTarget` races
+  // against its own 2s timeout. The renderer NEVER runs a CDP command; it answers existence + project
+  // + capability only.
+  const askRendererResolve = (sourceNodeId: string): Promise<BrowserResolve> => {
+    const w = getMainWindow()
+    if (!w || w.isDestroyed()) {
+      return Promise.resolve({ ok: false, refusal: 'source node is not on an open canvas' })
+    }
+    const requestId = randomUUID()
+    const answered = new Promise<BrowserResolve>((resolve) => {
+      pendingBrowserResolve.set(requestId, resolve)
+    })
+    w.webContents.send(IPC.browserControlResolve, { requestId, sourceNodeId })
+    return answered.finally(() => pendingBrowserResolve.delete(requestId))
+  }
+  // The `browser` verb's whole main-side drive: parse (pure), identity belt, resolve round-trip, then
+  // the gate + drive (owner + LIVE capability + CDP allowlist all decided here in MAIN). A capability
+  // read that comes back OFF revokes as it refuses (detach + drop + tombstone). See browser-drive.ts.
+  const handleBrowserVerb = async (
+    nodeId: string,
+    args: Record<string, string>,
+    verified: boolean
+  ): Promise<{ ok: boolean; message?: string; error?: string }> => {
+    const parsed = parseBrowserArgs(args)
+    if ('error' in parsed) return { ok: false, error: parsed.error, message: parsed.error }
+    // Identity is checked first (the belt to hook-server's verified-only gate for STRICT verbs): a
+    // non-verified caller learns nothing, and no resolve round-trip is even made.
+    if (!verified) return { ok: false, error: STRICT_CONTROL_REFUSAL, message: STRICT_CONTROL_REFUSAL }
+    const resolve = await resolveBrowserTarget(parsed.node, () => askRendererResolve(nodeId))
+    const result = await driveBrowser(
+      { call: parsed, ownerNodeId: nodeId, verified, resolve },
+      {
+        ledger: browserLedger,
+        refs: browserRefs,
+        sessionFor: browserSessionFor,
+        revoke: (id) => pushBrowserLeases(revokeBrowserNode(id, browserRevocation, { userStopped: true }))
+      }
+    )
+    return result.ok
+      ? { ok: true, message: result.message }
+      : { ok: false, error: result.message, message: result.message }
+  }
   hookServer.setControlHandler(async ({ verb, nodeId, args, verified }) => {
+    // `browser` is answered in MAIN and never forwarded to the renderer's agent-control dispatch:
+    // the debugger handle and the CDP allowlist are main-side, and the renderer is the more
+    // attackable half. Every other verb still round-trips to the renderer below.
+    if (verb === 'browser') return handleBrowserVerb(nodeId, args, verified)
     const target = getMainWindow()
     if (!target) return { ok: false, error: 'window unavailable' }
     const requestId = randomUUID()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -650,6 +650,15 @@ const api: NodeTerminalApi = {
     return () => ipcRenderer.removeListener(IPC.agentControl, handler)
   },
   sendAgentControlResult: (payload) => ipcRenderer.send(IPC.agentControlResult, payload),
+  // The `browser` verb resolve round-trip (S8 PR 7): main asks the renderer which project owns the
+  // source, whether it is control-capable, and whether the capability is on right now — the renderer
+  // NEVER runs a CDP command.
+  onBrowserControlResolve: (listener) => {
+    const handler = (_e: unknown, req: unknown) => listener(req as never)
+    ipcRenderer.on(IPC.browserControlResolve, handler)
+    return () => ipcRenderer.removeListener(IPC.browserControlResolve, handler)
+  },
+  sendBrowserControlResolveResult: (payload) => ipcRenderer.send(IPC.browserControlResolveResult, payload),
   agentMessage: {
     deliver: (req) => ipcRenderer.invoke(IPC.agentMessageDeliver, req)
   }

--- a/src/renderer/bridge/relay-api.ts
+++ b/src/renderer/bridge/relay-api.ts
@@ -149,6 +149,9 @@ export function buildRelayApi(connectionId: string, transport?: FrameTransport):
     // Edition); inert no-ops rather than a local subscription that never carries the host's events.
     onAgentControl: stub.onAgentControl,
     sendAgentControlResult: stub.sendAgentControlResult,
+    // Browser control never rides the relay either (no CDP off the desktop) — inert no-ops.
+    onBrowserControlResolve: stub.onBrowserControlResolve,
+    sendBrowserControlResolveResult: stub.sendBrowserControlResolveResult,
     // Messaging rides the same decision: the browser client is never a sender (constraint 5 of
     // the messaging plan — the phone drives canvas control over relay→IPC, not /control/*).
     agentMessage: stub.agentMessage

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -407,6 +407,10 @@ export function buildStubApi(): Omit<
     }),
     onAgentControl: noopUnsub,
     sendAgentControlResult: noop,
+    // Browser control is desktop-only (no <webview>, no CDP on the Server Edition / relay), so the
+    // resolve round-trip is inert here — the verb is refused by name before it reaches a handler.
+    onBrowserControlResolve: noopUnsub,
+    sendBrowserControlResolveResult: noop,
     // Messaging never runs in the browser: `onAgentControl` above is inert here, so no dispatch
     // can ever reach this. It answers the honest terminal refusal all the same, so a stray call
     // can never look like it delivered.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -183,7 +183,9 @@ import {
   routeControlSource,
   needsLiveCanvas,
   sourceIsControlCapable,
-  storedNodeListing
+  storedNodeListing,
+  answerBrowserResolve,
+  type BrowserResolveProject
 } from '../lib/controlRouting'
 import { applyStickyWrite, parseStickyArgs, resolveStickyRef } from '../lib/stickyWrite'
 import {
@@ -6378,6 +6380,27 @@ export function Canvas() {
       setNodes((ns) => [...ns, placed])
       setControlEdges((es) => [...es, ropeEdge(`ctrl-${sourceNodeId}-${placed.id}`, sourceNodeId, placed.id, '#0a84ff')])
       markDirty()
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // The `browser` verb's resolve round-trip (S8 PR 7). Main intercepts `browser` and asks us the
+  // two-and-a-half things ONLY the renderer knows: which project owns the source node, whether that
+  // source is a control-capable agent, and whether the per-project browser-control capability is on
+  // RIGHT NOW (read live via projectCapabilityGrantedFor). We answer over the SAME source routing
+  // every verb uses — travelling to the owning project so its <webview> guest is live for main to
+  // drive — and we NEVER run a CDP command. Main makes the security decision (owner + capability +
+  // the CDP allowlist) and does the driving itself (browser-drive.ts / browser-actions.ts).
+  useEffect(() => {
+    return api.onBrowserControlResolve(({ requestId, sourceNodeId }) => {
+      const { projects, activeProjectId } = useProjects.getState()
+      const route = routeControlSource(projects, activeProjectId, sourceNodeId)
+      // Bring the owning project's canvas up so main can find the live guest (needsLiveCanvas is true
+      // for `browser`). A closed/blocked/unknown owner just yields the refusal below.
+      if (route.kind === 'switch' || route.kind === 'reopen') travelToProjectRef.current(route.projectId)
+      const owner = projects.find((p) => p.nodes.some((n) => n.id === sourceNodeId))
+      const answer = answerBrowserResolve(owner as unknown as BrowserResolveProject | undefined, sourceNodeId)
+      api.sendBrowserControlResolveResult({ requestId, ...answer })
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/renderer/lib/controlRouting.test.ts
+++ b/src/renderer/lib/controlRouting.test.ts
@@ -4,7 +4,9 @@ import {
   needsLiveCanvas,
   sourceIsControlCapable,
   storedNodeListing,
-  type ControlProject
+  answerBrowserResolve,
+  type ControlProject,
+  type BrowserResolveProject
 } from './controlRouting'
 
 const P = (
@@ -104,6 +106,64 @@ describe('sourceIsControlCapable', () => {
 
   it('rejects an agent that never gets NODETERM_CANVAS_CONTROL', () => {
     expect(sourceIsControlCapable('cursor')).toBe(false)
+  })
+})
+
+describe('the `browser` verb needs the LIVE canvas', () => {
+  it('needsLiveCanvas(browser) is true — the node lives in a specific project canvas, like open-browser', () => {
+    // It drives a real <webview> that only exists on the live canvas; it is NOT store-answerable.
+    expect(needsLiveCanvas('browser')).toBe(true)
+    expect(needsLiveCanvas('open-browser')).toBe(true)
+    // Contrast with the store-answered verbs.
+    expect(needsLiveCanvas('list')).toBe(false)
+    expect(needsLiveCanvas('send')).toBe(false)
+  })
+})
+
+describe('answerBrowserResolve — the renderer answers ONLY what it alone knows', () => {
+  const proj = (over: Partial<BrowserResolveProject> = {}): BrowserResolveProject => ({
+    id: 'proj-1',
+    cwd: '/home/u/p',
+    nodes: [{ id: 'claude-1', agentId: 'claude' }],
+    ...over
+  })
+
+  it('a missing project or an off-canvas source is a named, non-CDP refusal', () => {
+    expect(answerBrowserResolve(undefined, 'claude-1')).toEqual({
+      ok: false,
+      refusal: 'source node is not on an open canvas'
+    })
+    expect(answerBrowserResolve(proj(), 'ghost-9')).toEqual({
+      ok: false,
+      refusal: 'source node is not on an open canvas'
+    })
+  })
+
+  it('reports project, cwd, source-capability and the LIVE per-project capability value', () => {
+    // Switch on in the file AND kept on this machine ⇒ granted.
+    const granted = proj({ agentBrowserControl: true, capabilityAck: { agentBrowserControl: 'kept' } })
+    expect(answerBrowserResolve(granted, 'claude-1')).toEqual({
+      ok: true,
+      projectId: 'proj-1',
+      projectCwd: '/home/u/p',
+      sourceControlCapable: true,
+      capabilityOn: true
+    })
+  })
+
+  it('a switch that is ON in the file but only PENDING (never kept) is not on — a pending notice is a refusal', () => {
+    const pending = proj({ agentBrowserControl: true })
+    expect(answerBrowserResolve(pending, 'claude-1')).toMatchObject({ ok: true, capabilityOn: false })
+  })
+
+  it('a DECLINED switch is off even when the file says true (C1: the hostile clone must not grant)', () => {
+    const declined = proj({ agentBrowserControl: true, capabilityAck: { agentBrowserControl: 'declined' } })
+    expect(answerBrowserResolve(declined, 'claude-1')).toMatchObject({ ok: true, capabilityOn: false })
+  })
+
+  it('a non-control-capable source is reported as such (main turns it into the refusal)', () => {
+    const p = proj({ nodes: [{ id: 'x-1', agentId: 'cursor' }], agentBrowserControl: true, capabilityAck: { agentBrowserControl: 'kept' } })
+    expect(answerBrowserResolve(p, 'x-1')).toMatchObject({ ok: true, sourceControlCapable: false })
   })
 })
 

--- a/src/renderer/lib/controlRouting.ts
+++ b/src/renderer/lib/controlRouting.ts
@@ -15,6 +15,10 @@
 
 import { canControlCanvas, type AgentId } from '@shared/agents/config'
 import { projectTravel } from './presenceTravel'
+import {
+  projectCapabilityGrantedFor,
+  type CapabilityAckMap
+} from '@shared/project-capability-consent'
 
 /** The little the routing needs to know about a project (a structural subset of `Project`). */
 export interface ControlProject {
@@ -117,6 +121,60 @@ export function needsLiveCanvas(verb: string): boolean {
 export function sourceIsControlCapable(agentId: unknown): boolean {
   const id = typeof agentId === 'string' && agentId ? agentId : 'claude'
   return canControlCanvas(id as AgentId)
+}
+
+/**
+ * The `browser` verb's resolve answer — the two things ONLY the renderer knows, computed purely so
+ * Canvas.tsx's IPC handler is a thin wrapper testable here. Main asks over `browserControlResolve`,
+ * makes the security decision itself (owner + capability + CDP gate), and does the CDP work; this
+ * function NEVER touches a debugger.
+ *
+ * WHY MAIN STILL DECIDES from these facts: an XSS-in-a-node-title-style bug lands in the renderer,
+ * the more attackable half, so the allowlist and the ledger stay main-side. The renderer reports
+ * facts (does this node's project exist, is the source control-capable, is the capability on right
+ * now — read LIVE via `projectCapabilityGrantedFor`, never cached); main re-orders them into the
+ * refusal decision in `browser-drive.ts`.
+ */
+export interface BrowserResolveNode {
+  id: string
+  agentId?: unknown
+}
+export interface BrowserResolveProject {
+  id: string
+  cwd?: string
+  agentBrowserControl?: boolean
+  capabilityAck?: CapabilityAckMap
+  nodes: readonly BrowserResolveNode[]
+}
+export type BrowserResolveAnswer =
+  | { ok: false; refusal: string }
+  | {
+      ok: true
+      projectId: string
+      projectCwd?: string
+      sourceControlCapable: boolean
+      capabilityOn: boolean
+    }
+
+export function answerBrowserResolve(
+  project: BrowserResolveProject | undefined,
+  sourceNodeId: string
+): BrowserResolveAnswer {
+  // No open project owns the source, or the node is not on its canvas: a named, non-revoking
+  // refusal. (Same class as every other verb's "source node is not on an open canvas".)
+  if (!project) return { ok: false, refusal: 'source node is not on an open canvas' }
+  const node = project.nodes.find((n) => n.id === sourceNodeId)
+  if (!node) return { ok: false, refusal: 'source node is not on an open canvas' }
+  return {
+    ok: true,
+    projectId: project.id,
+    projectCwd: project.cwd,
+    sourceControlCapable: sourceIsControlCapable(node.agentId),
+    // LIVE read — the drive-time capability check the whole feature's safety rests on. A project.json
+    // hand-edit that flipped the switch off is reflected here the next time an agent drives, which is
+    // exactly drive time.
+    capabilityOn: projectCapabilityGrantedFor(project, 'agentBrowserControl')
+  }
 }
 
 /** `list`'s rows, built from serialized nodes — the same shape the live canvas answers with

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -364,6 +364,13 @@ export const IPC = {
   browserStop: 'browser:stop-control',
   browserStopAll: 'browser:stop-control-all',
   browserStopProject: 'browser:stop-control-project',
+  // The `browser` VERB resolve round-trip (S8 PR 7). Main intercepts `browser` and asks the renderer
+  // the two things ONLY it knows — which project owns the source node, whether that source is a
+  // control-capable agent, and whether the per-project capability is on RIGHT NOW — over the same
+  // routing every verb uses. Main makes the security decision (owner + capability + CDP gate) and
+  // does the CDP work itself; the renderer never runs a CDP command.
+  browserControlResolve: 'browser:control-resolve',
+  browserControlResolveResult: 'browser:control-resolve-result',
   remoteHostStart: 'remote:host:start',
   remoteHostStop: 'remote:host:stop',
   // Connection approval gate: main → renderer when a client finishes the handshake (carries the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2589,6 +2589,21 @@ export interface NodeTerminalApi {
     result?: unknown
     error?: string
   }): void
+  /** The `browser` verb resolve round-trip (S8 PR 7): main asks the renderer to resolve a source
+   *  node's owning project, control-capability and the LIVE per-project capability value. The
+   *  renderer answers over `sendBrowserControlResolveResult` and NEVER runs a CDP command. */
+  onBrowserControlResolve(listener: (req: { requestId: string; sourceNodeId: string }) => void): () => void
+  /** Answer a browser-control resolve. `ok:false` carries a named refusal; `ok:true` carries the
+   *  facts main turns into its own (owner + capability + CDP-gate) decision. */
+  sendBrowserControlResolveResult(payload: {
+    requestId: string
+    ok: boolean
+    refusal?: string
+    projectId?: string
+    projectCwd?: string
+    sourceControlCapable?: boolean
+    capabilityOn?: boolean
+  }): void
   /** Agent messaging (the `send`/`reply` control verbs): run one delivery in main, where the
    *  scope check, the per-project switch, flow control and the pane probes all live. The reply is
    *  already rendered as a control reply — Canvas forwards it verbatim. */


### PR DESCRIPTION
## S8 PR 7 of #112 (@Corvin) — the browser verb goes live

The producer that actually attaches a lease and drives a real guest. PRs 1–6 were inert machinery;
here the `browser` control verb, its main-side routing, `--nav` and the `--read` family become
reachable by an agent — behind every gate the earlier PRs built.

### Tasks → commits
- **7.1** `browser` joins the verb model; the whole flag table is the pure `parseBrowserArgs`
  (`src/core/browser-verb.ts`) — `78530f10`.
- **7.3–7.6** `--nav` + `--read title|links|map|text` execute over CDP through the allowlist gate;
  the CDP event set is fixed and one-directional; readMap/readText enriched — `8596b033`.
- **7.2** `browser` is answered in MAIN via a resolve round-trip; the renderer answers only
  existence + project + live capability and never runs a CDP command; the drive gate + wiring —
  `7a7fa929`.

### How each CARRIED obligation is satisfied and tested
1. **Ledger-gated ATTACH (PR 5/#306 MINOR-2).** `gateBrowserDrive` calls `BrowserControlLedger.get()`
   keyed on the cryptographically-verified caller node id BEFORE any attach; attach is lazy inside
   the session, so a refused caller causes zero attachments. Tests: `browser-drive.test.ts` — "an
   unowned caller cannot drive AND never causes a debugger attach" (`attachCount === 0`) and "the
   ledger-confirmed owner drives, and only THEN does the debugger attach". Mutation (drop the
   `ledger.get` gate) → 3 red.
2. **Drive-time LIVE capability read + revoke (PR 6/#307 MINOR-2).** The capability is re-read every
   verb via `projectCapabilityGrantedFor` (renderer resolve, `answerBrowserResolve`), never cached at
   lease start; a now-off switch (a project.json hand-edit included) REFUSES with the verbatim
   sentence AND revokes (detach + drop + tombstone). Tests: `browser-drive.test.ts` — "a
   valid-at-attach lease is re-checked each drive; capability now off → refuse + revoke + no attach"
   (two drives, same lease, second refuses+revokes); `controlRouting.test.ts` — pending/declined
   switches report `capabilityOn:false`. Mutations (skip the capability check; skip the revoke) → red.
3. **Widened single-gate grep.** `browser-cdp-allowlist.test.ts`'s "every sendCommand( in src/main is
   inside browser-cdp-send.ts" now scans ALL of `src/main`, not just `browser-*.ts`, because the verb
   path added `browser-drive.ts`/`browser-actions.ts` and wired a real debugger from `index.ts`.
4. **No second global toggle (PR 6/#307 MINOR-1).** `browser-control-route.test.ts` — "there is
   exactly ONE browser-control gate": a repo-wide scan finds no global browser-control settings key
   (only the per-project `agentBrowserControl` switch).
5. **#307 tombstone honored.** `gateBrowserDrive` consults `wasStoppedByUser` before driving: a
   user-Stopped node is refused with `BROWSER_USER_STOPPED` (named human act, not a retryable null)
   and cannot re-drive until a fresh verified `claim()` clears the tombstone. Tests:
   `browser-drive.test.ts` — the tombstone describe block. Mutation (drop the tombstone check) → red.

### Other security properties pinned
- **Verified-only + per-project-gated from day one.** `browser` is in `STRICT_CONTROL_VERBS`
  (hook-server refuses a non-verified caller before the handler); `gateBrowserDrive` re-checks
  `verified` as a belt (unverified → `STRICT_CONTROL_REFUSAL`).
- **Refusal ordering** (identity → canControlCanvas → capability → ledger → discard), asserted
  explicitly and in order; "does not exist" and "not yours" share ONE message (no node-enumeration
  oracle).
- **Main-side decision, never the renderer.** `browser-control-route.test.ts` structurally pins that
  `Canvas.tsx` contains no `sendCommand`, no `NT_SCRIPTS`/allowlist import, and no drive/ledger import.
- **No passive channel out of the page** (Task 7.3): the fixed CDP event set feeds our own state only;
  `browser-actions.test.ts` fires a firehose of events during a nav and asserts none reach the reply.
- **No agent-derived character reaches an `expression` field** (Task 7.4): readers run identity-pinned
  via `callFunctionOn`; Runtime.evaluate is never issued. `browser-actions.test.ts` spies on every
  send and fails on any `expression` key. Mutation (smuggle an `expression`) → red.
- **`--read map` reports FILL STATE, never the value** (Task 7.5): the frozen `readMap` never RETURNS
  a value (`browser-nt-scripts.source.test.ts` pins no `value:` key; mutation → red), and the
  formatter emits `(type, filled|empty)`.
- **No html / full-DOM mode** (Task 7.6): `--read html` is refused in the parser, and
  `DOM.getOuterHTML`/`getAttributes` plus deep/negative-depth `DOM.getDocument` are refused by the
  allowlist so the same read cannot arrive by another door.

### Three surfaces
Desktop — the whole thing. Server Edition — `serverEditionControlHandler` refuses `browser` by name
(`control-unsupported-on-this-edition`) before any handler; the pure parser still ships and runs.
Mobile — never originates (a phone cannot mint `verified`).

### Verification
- `npm run typecheck` clean. Full `npx vitest run`: **7155 passed / 12 skipped, 0 failures** (the
  usually-flaky node-pty / webgl env tests passed here too).
- Mutation checks (introduced/caught): 7.1 **5/5**; drive gate **5/5**; actions **6/6** (readText
  truncation 2, ceiling clamp 1, nav ref-bump 1, `expression` smuggle 1, readMap value-return 1).

### Deferred / flagged
- **Real-`<webview>` E2E of the readers' in-page behaviour** (Global Constraint 8 — the password /
  hidden-input / aria-hidden exclusion) is NOT run in this headless suite: there is no committed
  webview harness and it needs Electron + a display (PR 5/6 ran theirs ad-hoc). Instead the actions
  drive the REAL `BrowserSession` + REAL allowlist + REAL frozen readers against a fake debugger, and
  the value-never-leaves property is pinned at the source (readMap returns no value) and formatter
  levels. This is called out as owed device verification.
- **Agent-facing skill copy** for the `browser` verb (flag teaching, refs) is not added here — the
  verb is fully handled main-side; the skill wording the design specifies spans PRs 7–9 and its
  parity tests are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
