### PR TITLE
feat(browser): interaction — click, type, press, scroll, wait

### DIFF
--- a/docs/superpowers/probes/2026-08-browser-scroll.md
+++ b/docs/superpowers/probes/2026-08-browser-scroll.md
@@ -1,0 +1,54 @@
+# Probe — `--scroll` wheel translation ( [UNVERIFIED] 1 )
+
+**Design claim under test:** S8 browser-control design, `[UNVERIFIED] 1` — S8's comment that
+*"Electron acknowledges Chromium's synthetic mouse gesture without scrolling a webview"*, i.e.
+`Input.synthesizeScrollGesture` does not scroll an Electron `<webview>` guest, and the salvage is to
+translate the intent into an `Input.dispatchMouseEvent { type:'mouseWheel', x, y, deltaX, deltaY }`.
+
+The design's own warning: gesture *distance* is the OPPOSITE sense to wheel *delta*, so a naive
+translation flips the sign — the page scrolls the wrong way and it looks like a coordinate bug.
+
+## What PR 8 implements
+
+`browser-actions.ts:scrollDeltaY` / `browserScroll`:
+
+- `Input.synthesizeScrollGesture` stays **excluded** from the CDP allowlist (it is in the refused
+  list in `browser-cdp-allowlist.test.ts`), so the ONLY scroll door is a `mouseWheel` event through
+  the existing, viewport-bounded `Input.dispatchMouseEvent` entry — no new CDP method is added for
+  scroll.
+- The wheel delta is authored **directly in the DOM wheel convention** — positive `deltaY` scrolls the
+  page DOWN (`scrollY` grows) — rather than by translating a gesture *distance*. So the sign-inversion
+  S8 warned about (gesture-distance → wheel-delta) is **not present**: there is no gesture distance
+  being converted. `down` → `+0.9·viewport`, `up` → `−0.9·viewport`, `top`/`bottom` → to the edge from
+  the current offset, a signed pixel count taken literally.
+- **The reply is built from the re-measured movement, never the requested delta.** After the wheel
+  event, `browserScroll` re-reads `Page.getLayoutMetrics` and reports the ACTUAL `scrollY` delta and
+  position: `scrolled browser-3 down 600px (at 1200/4400)`. A command that succeeds and does nothing
+  (wrong sign, non-scrollable page, already at the edge) surfaces as `0px` or an opposite-direction
+  delta the agent can see — the "succeeds and does nothing" failure shape cannot hide.
+
+## Measured result
+
+**NOT re-measured against a real Electron 42.8.1 `<webview>` in the implementation environment.**
+The implementer's environment is headless with no display; the same reason the reader/pointer
+end-to-end `<webview>` harness (Global Constraint 8) is deferred in this repo's vitest suite (see the
+note in `src/main/browser-actions.test.ts`). Running this probe needs `xvfb-run` + a real
+`BrowserWindow(webviewTag:true)` hosting a `<webview>` — the same rig used for the
+`2026-08-browser-debugger.md` probe — which is not available here.
+
+Per Global Constraint 8 ("a probe that cannot be run on the implementer's machine is not silently
+skipped: the task stops and reports"), this is **reported, not skipped**: the implementation is
+written to the design's translation and, critically, the read-back reply makes any residual sign/no-op
+error observable to the agent rather than silent.
+
+## To verify (owed, device/display run)
+
+On a machine with a display (or `xvfb-run`), Electron 42.8.1:
+
+1. Load a tall page (content height ≫ viewport) into a canvas `<webview>` browser node.
+2. `browser --node <id> --scroll down` → expect the reply's delta POSITIVE (`down N px`) and `scrollY`
+   to have increased by ~N; confirm the page visibly moved down.
+3. `--scroll up`, `--scroll top`, `--scroll bottom`, `--scroll 600`, `--scroll -600` → each reply's
+   direction/delta matches the observed movement.
+4. If any direction is inverted, flip the sign in `scrollDeltaY` only — the read-back reply already
+   named the error, so the fix is one line and the test that pins the reply shape stays green.

--- a/src/main/browser-actions.ts
+++ b/src/main/browser-actions.ts
@@ -20,8 +20,8 @@
  * proteus-dev); the nav/read shape here is new.
  */
 import { NT_SCRIPTS } from './browser-nt-scripts'
-import type { RefTable } from './browser-refs'
-import type { BrowserReadMode } from '../core/browser-verb'
+import type { RefTable, RefItem } from './browser-refs'
+import type { BrowserReadMode, BrowserKey } from '../core/browser-verb'
 
 /** A one-line agent-facing outcome. `ok:false` is a NAMED refusal, never a hang and never a raw
  *  Electron error. */
@@ -33,6 +33,24 @@ export interface ActionResult {
 /** The one capability the actions need from a lease: send a (gated) CDP command. */
 export interface Sendable {
   send(method: string, params: object): Promise<unknown>
+}
+
+/** The page geometry `Page.getLayoutMetrics` reports: the visible viewport (what bounds a pointer
+ *  coordinate), the current scroll offset, and the full content size (what `--scroll` reads back). */
+export interface LayoutMetrics {
+  width: number
+  height: number
+  scrollX: number
+  scrollY: number
+  contentWidth: number
+  contentHeight: number
+}
+
+/** The extra capability the POINTER verbs (`--click`, `--type`, `--scroll`) need beyond {@link Sendable}:
+ *  measure + cache the viewport so a synthesized coordinate validates against the REAL page, not the
+ *  0×0 placeholder. A {@link import('./browser-lease').BrowserSession} implements it. */
+export interface Driver extends Sendable {
+  refreshViewport(): Promise<LayoutMetrics>
 }
 
 /** The `--read text` hard ceiling and default; the parser clamps `--max` to the ceiling too. */
@@ -294,6 +312,266 @@ export async function browserReadText(
     return { ok: true, message: `${text}\n[truncated at ${cap} of ${total} chars — narrow it with --selector]` }
   }
   return { ok: true, message: text }
+}
+
+// ── Interaction (PR 8): --click, --type, --press, --scroll, --wait ──────────────────────────────
+//
+// Every effect below is a real CDP event through the ONE gated `send` — a bounded mouse event, a
+// capped insertText, a fixed-table key event — never page-side JS: the NT_SCRIPTS this path calls
+// (resolveRef/resolveSelector/activeField/isVisible) are PURE READERS that only report coordinates and
+// visibility, and every actual effect goes through Input.* so it is bounded by the allowlist AND
+// traceable. Agent-supplied text is DATA (Input.insertText), and a key is one of a fixed table.
+//
+// The CDP child-session/wheel bookkeeping this leans on is lifted from PR #112's S8 (@Corvin,
+// proteus-dev); the verb shapes and the read-back replies here are new.
+
+/** The fixed key table `--press` maps onto (Task 8.3). A key outside {@link BrowserKey} never reaches
+ *  here — the verb parser and the allowlist both gate on the same `BROWSER_KEYS` set — so this is a
+ *  total map, not a lookup that can miss. */
+const KEY_TABLE: Record<BrowserKey, { key: string; code: string; windowsVirtualKeyCode: number }> = {
+  Enter: { key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 },
+  Tab: { key: 'Tab', code: 'Tab', windowsVirtualKeyCode: 9 },
+  Escape: { key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 },
+  Backspace: { key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8 },
+  ArrowUp: { key: 'ArrowUp', code: 'ArrowUp', windowsVirtualKeyCode: 38 },
+  ArrowDown: { key: 'ArrowDown', code: 'ArrowDown', windowsVirtualKeyCode: 40 },
+  ArrowLeft: { key: 'ArrowLeft', code: 'ArrowLeft', windowsVirtualKeyCode: 37 },
+  ArrowRight: { key: 'ArrowRight', code: 'ArrowRight', windowsVirtualKeyCode: 39 },
+  PageUp: { key: 'PageUp', code: 'PageUp', windowsVirtualKeyCode: 33 },
+  PageDown: { key: 'PageDown', code: 'PageDown', windowsVirtualKeyCode: 34 },
+  Home: { key: 'Home', code: 'Home', windowsVirtualKeyCode: 36 },
+  End: { key: 'End', code: 'End', windowsVirtualKeyCode: 35 }
+}
+
+/** `--press --times` is capped so a single verb cannot fire an unbounded keystroke storm. */
+const PRESS_MAX_TIMES = 50
+/** The poll interval `--wait` uses on OUR clock (never a page timer). */
+const WAIT_POLL_MS = 150
+
+/** A one-line, value-free description of a minted map item for a reply: `input#email` for a field
+ *  (its identity, never its value), `button "Sign in"` for a control (role + accessible name). */
+function describeItem(it: RefItem): string {
+  const tag = typeof it.tag === 'string' ? it.tag : ''
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') {
+    const id = typeof it.id === 'string' && it.id ? `#${it.id}` : ''
+    return `${tag}${id}`
+  }
+  const role = (typeof it.role === 'string' && it.role) || tag || 'element'
+  const name = (typeof it.name === 'string' ? it.name : '').replace(/\s+/g, ' ').trim()
+  return name ? `${role} ${JSON.stringify(name)}` : role
+}
+
+type Resolved =
+  | { ok: true; x: number; y: number; desc: string }
+  | { ok: false; message: string }
+
+/**
+ * Resolve a `@ref` OR a raw CSS selector to CURRENT viewport-centre coordinates plus a value-free
+ * description. A `@ref` is SPENT through the RefTable (node- and generation-scoped): a stale ref — the
+ * page navigated since the map that minted it — is a REFUSAL, never a re-resolution against a newer
+ * map (the PR 5 correctness property). A selector is resolved live. Coordinates come from a pure
+ * reader (getBoundingClientRect), never from the agent.
+ */
+async function resolveTarget(s: Sendable, refs: RefTable, nodeId: string, target: string): Promise<Resolved> {
+  if (target.startsWith('@')) {
+    const res = refs.spend(nodeId, target)
+    if (!res.ok) return { ok: false, message: res.message }
+    const item = res.item
+    const idx = typeof item.ref === 'number' ? item.ref : Number(item.ref)
+    const coords = (await callReader(s, NT_SCRIPTS.resolveRef, [idx])) as { x?: unknown; y?: unknown } | null
+    if (!coords || typeof coords.x !== 'number' || typeof coords.y !== 'number') {
+      return { ok: false, message: `browser: ${target} (${describeItem(item)}) is no longer on ${nodeId} — re-read the map` }
+    }
+    return { ok: true, x: coords.x, y: coords.y, desc: `${target} (${describeItem(item)})` }
+  }
+  const coords = (await callReader(s, NT_SCRIPTS.resolveSelector, [target])) as { x?: unknown; y?: unknown; tag?: unknown } | null
+  if (!coords || typeof coords.x !== 'number' || typeof coords.y !== 'number') {
+    return { ok: false, message: `browser: nothing matches ${target} on ${nodeId}` }
+  }
+  const tag = typeof coords.tag === 'string' ? coords.tag.toLowerCase() : 'element'
+  return { ok: true, x: coords.x, y: coords.y, desc: `${target} (${tag})` }
+}
+
+/** Inside the last-measured viewport? A coordinate off-screen is either a bug or an attempt to reach
+ *  chrome the user cannot see; the allowlist enforces this independently, this gives a clear message. */
+function inViewport(x: number, y: number, m: LayoutMetrics): boolean {
+  return x >= 0 && y >= 0 && x <= m.width && y <= m.height
+}
+
+/** A synthesized left click: press then release at (x, y). Both events are bounded by the allowlist. */
+async function dispatchClick(s: Sendable, x: number, y: number): Promise<void> {
+  const at = { x, y, button: 'left', clickCount: 1 }
+  await s.send('Input.dispatchMouseEvent', { type: 'mousePressed', buttons: 1, ...at })
+  await s.send('Input.dispatchMouseEvent', { type: 'mouseReleased', buttons: 0, ...at })
+}
+
+/**
+ * `--click <ref|selector>` (Task 8.1). Resolve the handle to a current centre, refresh the viewport,
+ * refuse an off-screen target, then dispatch a bounded left click. Reply names WHAT was clicked, never
+ * a coordinate: `clicked @7 (button "Sign in") on browser-3`.
+ */
+export async function browserClick(s: Driver, refs: RefTable, nodeId: string, target: string): Promise<ActionResult> {
+  const t = await resolveTarget(s, refs, nodeId, target)
+  if (!t.ok) return { ok: false, message: t.message }
+  const m = await s.refreshViewport()
+  if (!inViewport(t.x, t.y, m)) {
+    return { ok: false, message: `browser: ${t.desc} is off-screen on ${nodeId} — scroll it into view first` }
+  }
+  await dispatchClick(s, t.x, t.y)
+  return { ok: true, message: `clicked ${t.desc} on ${nodeId}` }
+}
+
+/**
+ * `--type <text>` with `--into <ref|selector>` and `--clear true` (Task 8.2). The text is DATA: it goes
+ * to `Input.insertText` and is NEVER echoed in the reply — the reply says how MANY characters, not
+ * which. With `--into`, the field is focused the way a user would (a click); without it, an already
+ * focused editable field is typed into, and nothing focused is a NAMED refusal. `--clear` selects the
+ * field (a fixed editing command) so the insert replaces it.
+ */
+export async function browserType(
+  s: Driver,
+  refs: RefTable,
+  nodeId: string,
+  opts: { text: string; into?: string; clear: boolean }
+): Promise<ActionResult> {
+  const { text, into, clear } = opts
+  let desc: string
+  if (into) {
+    const t = await resolveTarget(s, refs, nodeId, into)
+    if (!t.ok) return { ok: false, message: t.message }
+    const m = await s.refreshViewport()
+    if (!inViewport(t.x, t.y, m)) {
+      return { ok: false, message: `browser: ${t.desc} is off-screen on ${nodeId} — scroll it into view first` }
+    }
+    await dispatchClick(s, t.x, t.y) // focus the field the way a user does
+    desc = t.desc
+  } else {
+    const active = (await callReader(s, NT_SCRIPTS.activeField)) as { tag?: unknown; id?: unknown } | null
+    if (!active || typeof active.tag !== 'string') {
+      return { ok: false, message: 'browser: --type needs --into, or a focused field (nothing is focused)' }
+    }
+    const id = typeof active.id === 'string' && active.id ? `#${active.id}` : ''
+    desc = `the focused ${active.tag}${id}`
+  }
+  if (clear) {
+    await s.send('Input.dispatchKeyEvent', { type: 'keyDown', commands: ['selectAll'] })
+    if (text === '') await s.send('Input.dispatchKeyEvent', { type: 'keyDown', commands: ['deleteBackward'] })
+  }
+  if (text !== '') await s.send('Input.insertText', { text })
+  if (text === '' && clear) return { ok: true, message: `cleared ${desc} on ${nodeId}` }
+  // The character COUNT only — never the characters themselves.
+  return { ok: true, message: `typed ${text.length} chars into ${desc} on ${nodeId}` }
+}
+
+/**
+ * `--press <key>` with `--times <n>` (Task 8.3). The key is one of the fixed {@link KEY_TABLE} entries
+ * (`--enter true` is not expressible under the old shim loop, and no real form is fillable without
+ * Enter/Tab); each press is a keyDown+keyUp, repeated up to a capped count.
+ */
+export async function browserPress(s: Sendable, nodeId: string, key: BrowserKey, times: number): Promise<ActionResult> {
+  const n = Math.min(Math.max(Math.floor(times) || 1, 1), PRESS_MAX_TIMES)
+  const spec = KEY_TABLE[key]
+  for (let i = 0; i < n; i++) {
+    await s.send('Input.dispatchKeyEvent', { type: 'keyDown', ...spec })
+    await s.send('Input.dispatchKeyEvent', { type: 'keyUp', ...spec })
+  }
+  return { ok: true, message: `pressed ${key}${n > 1 ? ` x${n}` : ''} on ${nodeId}` }
+}
+
+/**
+ * The wheel delta for a `--scroll` target. `down`/`up` move ~90% of a viewport; `top`/`bottom` move to
+ * the edge from the current offset; a signed pixel count is taken literally (positive = down).
+ *
+ * [UNVERIFIED] 1 — the wheel-translation salvage (Task 8.4). S8 could not scroll a `<webview>` with
+ * `Input.synthesizeScrollGesture` (Electron acknowledged the synthetic gesture without scrolling) and
+ * translated it into an `Input.dispatchMouseEvent { type:'mouseWheel', deltaY }`. We author the wheel
+ * delta directly in the DOM wheel convention (positive deltaY scrolls the page DOWN — scrollY grows),
+ * so the sign is NOT the gesture-distance inversion S8 warned about. This was NOT re-measured against a
+ * real Electron 42.8.1 `<webview>` in the implementation environment (headless, no display — the same
+ * reason the reader end-to-end harness is deferred, see the file header); the mitigation is that the
+ * reply ALWAYS reads the scroll position back from `Page.getLayoutMetrics`, so a wrong sign or a
+ * command that silently does nothing shows up as a 0px / opposite-direction delta the agent can see.
+ * See docs/superpowers/probes/2026-08-browser-scroll.md.
+ */
+function scrollDeltaY(where: string, m: LayoutMetrics): number {
+  const page = Math.round(m.height * 0.9)
+  switch (where) {
+    case 'down':
+      return page
+    case 'up':
+      return -page
+    case 'top':
+      return -Math.round(m.scrollY)
+    case 'bottom':
+      return Math.round(m.contentHeight - m.height - m.scrollY)
+    default: {
+      const n = Number.parseInt(where, 10)
+      return Number.isFinite(n) ? n : 0
+    }
+  }
+}
+
+/**
+ * `--scroll <where>` (Task 8.4). Measure, dispatch one bounded `mouseWheel` at the viewport centre,
+ * then RE-READ `Page.getLayoutMetrics` and report the ACTUAL delta and position:
+ * `scrolled browser-3 down 600px (at 1200/4400)`. The reply is built from the measured movement, never
+ * the requested delta, because the worst failure shape here is a command that succeeds and does
+ * nothing — and a requested-delta reply would hide exactly that (it shows as `0px`).
+ */
+export async function browserScroll(s: Driver, nodeId: string, where: string): Promise<ActionResult> {
+  const before = await s.refreshViewport()
+  const deltaY = scrollDeltaY(where, before)
+  const cx = Math.floor(before.width / 2)
+  const cy = Math.floor(before.height / 2)
+  await s.send('Input.dispatchMouseEvent', { type: 'mouseWheel', x: cx, y: cy, deltaX: 0, deltaY })
+  const after = await s.refreshViewport()
+  const moved = Math.round(after.scrollY - before.scrollY)
+  const posPart = `(at ${Math.round(after.scrollY)}/${Math.round(after.contentHeight)})`
+  const movePart = moved === 0 ? '0px' : `${moved > 0 ? 'down' : 'up'} ${Math.abs(moved)}px`
+  return { ok: true, message: `scrolled ${nodeId} ${movePart} ${posPart}` }
+}
+
+/**
+ * `--wait <ref|selector>` with `--timeout` (Task 8.5). Polls on OUR OWN clock — a `@ref`'s element
+ * re-resolving, or a selector reporting visible — so the trace shows a verb that says what it is
+ * waiting for, instead of every agent hand-rolling a poll loop out of `--read`. Reply names the wait
+ * and how long it took; a timeout is a NAMED refusal. Clock/sleep are injected for deterministic tests.
+ */
+export async function browserWait(
+  s: Sendable,
+  refs: RefTable,
+  nodeId: string,
+  target: string,
+  timeoutMs: number,
+  opts: { now?: () => number; sleep?: (ms: number) => Promise<void> } = {}
+): Promise<ActionResult> {
+  const now = opts.now ?? Date.now
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
+  const start = now()
+  const probe = async (): Promise<boolean> => {
+    try {
+      if (target.startsWith('@')) {
+        const res = refs.spend(nodeId, target)
+        if (!res.ok) return false
+        const idx = typeof res.item.ref === 'number' ? res.item.ref : Number(res.item.ref)
+        const c = (await callReader(s, NT_SCRIPTS.resolveRef, [idx])) as { x?: unknown } | null
+        return !!c && typeof c.x === 'number'
+      }
+      return (await callReader(s, NT_SCRIPTS.isVisible, [target])) === true
+    } catch {
+      // A transient read failure (e.g. mid-navigation) is "not yet", never an abort of the wait.
+      return false
+    }
+  }
+  for (;;) {
+    if (await probe()) {
+      return { ok: true, message: `${target} appeared on ${nodeId} after ${now() - start}ms` }
+    }
+    if (now() - start >= timeoutMs) {
+      return { ok: false, message: `browser: ${target} did not appear on ${nodeId} within ${timeoutMs}ms` }
+    }
+    await sleep(Math.min(WAIT_POLL_MS, Math.max(1, timeoutMs - (now() - start))))
+  }
 }
 
 /** Dispatch the `--read <mode>` family. */

--- a/src/main/browser-cdp-allowlist.test.ts
+++ b/src/main/browser-cdp-allowlist.test.ts
@@ -55,6 +55,27 @@ describe('checkCdpCommand', () => {
     expect(checkCdpCommand('Input.insertText', { text: 'x'.repeat(8193) }, ctx)).toBe(false)
   })
 
+  it('Input.dispatchKeyEvent is a FIXED-TABLE key, or a fixed editing command — never free key injection (Tasks 8.2-8.3)', () => {
+    // A --press key from the table (the same set the verb parser gates on).
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Enter' }, ctx)).toBe(true)
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyUp', key: 'ArrowDown' }, ctx)).toBe(true)
+    // A key OUTSIDE the table is refused — no arbitrary key injection.
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', key: 'a' }, ctx)).toBe(false)
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', key: 'F5' }, ctx)).toBe(false)
+    // The two --clear editing commands are allowed; anything else is refused.
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', commands: ['selectAll'] }, ctx)).toBe(true)
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', commands: ['deleteBackward'] }, ctx)).toBe(true)
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', commands: ['insertText'] }, ctx)).toBe(false)
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', commands: ['delete', 'selectAll'] }, ctx)).toBe(false)
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', commands: [] }, ctx)).toBe(false)
+    // `text` is FORBIDDEN outright — a character that reaches the page is Input.insertText's job.
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown', key: 'Enter', text: '\r' }, ctx)).toBe(false)
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'char', text: 'q' }, ctx)).toBe(false)
+    // A meaningless empty event (no key, no commands) is refused; a bad type is refused.
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDown' }, ctx)).toBe(false)
+    expect(checkCdpCommand('Input.dispatchKeyEvent', { type: 'keyDrag', key: 'Enter' }, ctx)).toBe(false)
+  })
+
   it('cookie READS take one explicit domain; the jar-emptying call does not exist here', () => {
     expect(checkCdpCommand('Network.getCookies', { urls: ['https://github.com/'] }, ctx)).toBe(true)
     expect(checkCdpCommand('Network.getCookies', {}, ctx)).toBe(false)      // no domain ⇒ the whole jar

--- a/src/main/browser-cdp-allowlist.ts
+++ b/src/main/browser-cdp-allowlist.ts
@@ -24,6 +24,7 @@
  */
 import { isNtScript } from './browser-nt-scripts'
 import { normalizeAddress } from '@shared/browserUrl'
+import { BROWSER_KEYS } from '../core/browser-verb'
 
 /** What the gate needs to know about the page beyond the command itself: the viewport from the last
  *  `Page.getLayoutMetrics`, so a mouse coordinate can be bounded to what is actually on screen. */
@@ -58,6 +59,16 @@ function valueOnlyArgs(args: unknown): boolean {
 const MAX_SELECTOR = 1024
 const MAX_INSERT_TEXT = 8192
 
+/** The dispatch types a key event may carry — a key-down, a key-up, or a raw key-down. There is
+ *  deliberately NO `char` type: a character that types into the page belongs to `Input.insertText`
+ *  (its own capped, data-only path), never to a key event. */
+const KEY_EVENT_TYPES = new Set(['keyDown', 'keyUp', 'rawKeyDown'])
+
+/** The ONLY editing commands a key event may drive — the two `--type --clear true` needs (select the
+ *  field's contents, delete a selection). Anything else (`delete`, `insertText`, `moveToEndOfLine`…)
+ *  is a strange, unaudited effect and is default-denied. */
+const EDIT_COMMANDS = new Set(['selectAll', 'deleteBackward'])
+
 /**
  * The table. Every entry is a (method, validator) pair. A Map — not a plain object — so a method
  * named `__proto__` / `constructor` can never resolve a validator off Object.prototype.
@@ -82,7 +93,10 @@ const ALLOW = new Map<string, Validator>([
   ],
 
   // A synthesized mouse event must land inside the reported viewport — a coordinate off-screen is
-  // either a bug or an attempt to reach chrome the user cannot see.
+  // either a bug or an attempt to reach chrome the user cannot see. This one entry covers the click
+  // (mousePressed/mouseReleased, Task 8.1) AND the scroll (a `mouseWheel` at the viewport centre,
+  // Task 8.4): `Input.synthesizeScrollGesture` stays EXCLUDED (it is in the refused list), so the
+  // wheel translation is the only scroll door and it is bounded by the same viewport check.
   [
     'Input.dispatchMouseEvent',
     (p, ctx) =>
@@ -98,6 +112,33 @@ const ALLOW = new Map<string, Validator>([
 
   // Typed text is capped; the text goes to insertText, never to a shell and never spliced anywhere.
   ['Input.insertText', (p) => isRecord(p) && typeof p.text === 'string' && p.text.length <= MAX_INSERT_TEXT],
+
+  // A key event is NOT free key injection (PR 8, Tasks 8.2-8.3). It is default-deny in three ways at
+  // once, and any one of them failing is a refusal:
+  //   - `key`, if present, must be one of the fixed BROWSER_KEYS `--press` accepts (the SAME table the
+  //     verb parser gates on — one source of truth) — never an arbitrary key;
+  //   - `commands`, if present, must be a NON-EMPTY subset of the two editing commands `--clear` needs
+  //     — never `insertText`/`delete`/a caret walk;
+  //   - `text` is FORBIDDEN outright: a character that reaches the page is `Input.insertText`'s
+  //     capped, data-only job, so a key event may never smuggle one.
+  // At least one of key/commands must be present — an empty key event is meaningless — and the type
+  // must be a real key-event type (no `char`).
+  [
+    'Input.dispatchKeyEvent',
+    (p) => {
+      if (!isRecord(p)) return false
+      if (typeof p.type !== 'string' || !KEY_EVENT_TYPES.has(p.type)) return false
+      if (p.text !== undefined) return false
+      const keyOk = p.key === undefined || (typeof p.key === 'string' && (BROWSER_KEYS as readonly string[]).includes(p.key))
+      if (!keyOk) return false
+      const cmds = p.commands
+      const hasCmds = cmds !== undefined
+      const cmdsOk =
+        !hasCmds || (Array.isArray(cmds) && cmds.length > 0 && cmds.every((c) => typeof c === 'string' && EDIT_COMMANDS.has(c)))
+      if (!cmdsOk) return false
+      return p.key !== undefined || (Array.isArray(cmds) && cmds.length > 0)
+    }
+  ],
 
   // A bounded selector against a known node.
   [

--- a/src/main/browser-drive.ts
+++ b/src/main/browser-drive.ts
@@ -30,7 +30,19 @@ import {
 } from './browser-control-ledger'
 import { STRICT_CONTROL_REFUSAL } from '../core/agents/node-identity-policy'
 import { browserDiscardedMessage } from './browser-guest-registry'
-import { browserNav, browserRead, type ActionResult, type Sendable, type CdpEventBus } from './browser-actions'
+import {
+  browserNav,
+  browserRead,
+  browserClick,
+  browserType,
+  browserPress,
+  browserScroll,
+  browserWait,
+  type ActionResult,
+  type Sendable,
+  type Driver,
+  type CdpEventBus
+} from './browser-actions'
 import type { RefTable } from './browser-refs'
 import type { BrowserCall } from '../core/browser-verb'
 
@@ -154,6 +166,8 @@ async function runAction(
   nodeId: string
 ): Promise<ActionResult> {
   const a = call.action
+  // The pointer verbs need the viewport-refreshing capability; the session is a Driver at runtime.
+  const driver = guest.session as Driver
   switch (a.kind) {
     case 'nav':
       return browserNav(guest.session, guest.bus, nodeId, a.url, call.timeoutMs)
@@ -162,9 +176,19 @@ async function runAction(
         selector: call.selector,
         max: call.max
       })
+    case 'click':
+      return browserClick(driver, refs, nodeId, a.target)
+    case 'type':
+      return browserType(driver, refs, nodeId, { text: a.text, into: call.into, clear: call.clear })
+    case 'press':
+      return browserPress(guest.session, nodeId, a.key, call.times ?? 1)
+    case 'scroll':
+      return browserScroll(driver, nodeId, a.where)
+    case 'wait':
+      return browserWait(guest.session, refs, nodeId, a.target, call.timeoutMs)
     default:
-      // Interaction (PR 8) and cookies/screenshot (PR 9) parse today but do not drive yet: a NAMED,
-      // non-retryable refusal, never a silent success.
+      // cookies/screenshot (PR 9) parse today but do not drive yet: a NAMED, non-retryable refusal,
+      // never a silent success.
       return { ok: false, message: `browser: --${a.kind} is not available yet (it lands in a later update)` }
   }
 }

--- a/src/main/browser-interaction.test.ts
+++ b/src/main/browser-interaction.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest'
+import { BrowserSession } from './browser-lease'
+import type { DebuggerLike } from './browser-cdp-send'
+import type { CdpContext } from './browser-cdp-allowlist'
+import { NT_SCRIPTS } from './browser-nt-scripts'
+import { RefTable, type RefItem } from './browser-refs'
+import {
+  browserClick,
+  browserType,
+  browserPress,
+  browserScroll,
+  browserWait,
+  browserReadMap,
+  type Driver
+} from './browser-actions'
+
+/**
+ * The PR 8 interaction verbs, driven through the REAL production stack — a real {@link BrowserSession},
+ * real `sendCdp`, the real CDP allowlist and the real frozen NT_SCRIPTS — against a fake
+ * `webContents.debugger` that returns canned page data and applies a wheel event to a mutable scroll
+ * offset. So EVERY command an action issues actually passes the allowlist gate: a method that were not
+ * allowlisted, or a bad-params send, would reject and fail the test. That is the security spine under
+ * test — the same one PR 7 established — and the click/type/press/scroll verbs all drive through it.
+ *
+ * The readers' in-page behaviour (a real <webview>) is deferred with the rest of the pointer harness
+ * (Global Constraint 8) — headless, no display; see the --scroll probe doc.
+ */
+
+interface FakePage {
+  width: number
+  height: number
+  scrollY: number
+  contentHeight: number
+  refCoords: Record<number, { x: number; y: number; tag: string } | null>
+  selectorCoords: Record<string, { x: number; y: number; tag: string } | null>
+  activeField: { tag: string; id: string } | null
+  visible: Record<string, boolean>
+  mapItems: RefItem[]
+}
+
+class FakeDebugger implements DebuggerLike {
+  attached = false
+  attachCount = 0
+  sends: { method: string; params: Record<string, unknown> }[] = []
+  private det: ((e: unknown, reason: string) => void)[] = []
+
+  constructor(public page: FakePage) {}
+
+  isAttached(): boolean {
+    return this.attached
+  }
+  attach(): void {
+    this.attached = true
+    this.attachCount++
+  }
+  detach(): void {
+    this.attached = false
+    for (const f of this.det) f({}, 'user')
+  }
+  on(event: 'detach' | 'message', listener: never): void {
+    if (event === 'detach') this.det.push(listener)
+  }
+  async sendCommand(method: string, params: object = {}): Promise<unknown> {
+    const p = params as Record<string, unknown>
+    this.sends.push({ method, params: p })
+    switch (method) {
+      case 'Page.getLayoutMetrics':
+        return {
+          cssLayoutViewport: { clientWidth: this.page.width, clientHeight: this.page.height },
+          cssVisualViewport: { clientWidth: this.page.width, clientHeight: this.page.height, pageX: 0, pageY: this.page.scrollY },
+          cssContentSize: { width: this.page.width, height: this.page.contentHeight }
+        }
+      case 'DOM.getDocument':
+        return { root: { nodeId: 1 } }
+      case 'DOM.resolveNode':
+        return { object: { objectId: 'doc-obj' } }
+      case 'Runtime.callFunctionOn':
+        return { result: { value: this.evalReader(p) } }
+      case 'Input.dispatchMouseEvent': {
+        if (p.type === 'mouseWheel') {
+          const max = Math.max(0, this.page.contentHeight - this.page.height)
+          this.page.scrollY = Math.min(Math.max(0, this.page.scrollY + (p.deltaY as number)), max)
+        }
+        return {}
+      }
+      default:
+        return {}
+    }
+  }
+
+  private evalReader(p: Record<string, unknown>): unknown {
+    const fn = p.functionDeclaration
+    const args = (p.arguments as { value: unknown }[] | undefined) ?? []
+    if (fn === NT_SCRIPTS.readMap) return this.page.mapItems
+    if (fn === NT_SCRIPTS.resolveRef) return this.page.refCoords[args[0]?.value as number] ?? null
+    if (fn === NT_SCRIPTS.resolveSelector) return this.page.selectorCoords[args[0]?.value as string] ?? null
+    if (fn === NT_SCRIPTS.activeField) return this.page.activeField
+    if (fn === NT_SCRIPTS.isVisible) return this.page.visible[args[0]?.value as string] === true
+    return null
+  }
+}
+
+const NODE = 'browser-3'
+
+function basePage(over: Partial<FakePage> = {}): FakePage {
+  return {
+    width: 1000,
+    height: 800,
+    scrollY: 0,
+    contentHeight: 4400,
+    refCoords: {},
+    selectorCoords: {},
+    activeField: null,
+    visible: {},
+    mapItems: [],
+    ...over
+  }
+}
+
+function make(page: FakePage): { s: Driver; dbg: FakeDebugger; refs: RefTable } {
+  const dbg = new FakeDebugger(page)
+  // The injected viewport is the 0×0 placeholder — refreshViewport() must override it, exactly as in
+  // production. If it did not, every bounded click would be refused.
+  const viewport = (): CdpContext => ({ viewport: { width: 0, height: 0 } })
+  const session = new BrowserSession({ nodeId: NODE, debugger: dbg, viewport })
+  return { s: session as unknown as Driver, dbg, refs: new RefTable() }
+}
+
+const mouseEvents = (dbg: FakeDebugger): Record<string, unknown>[] =>
+  dbg.sends.filter((x) => x.method === 'Input.dispatchMouseEvent').map((x) => x.params)
+const keyEvents = (dbg: FakeDebugger): Record<string, unknown>[] =>
+  dbg.sends.filter((x) => x.method === 'Input.dispatchKeyEvent').map((x) => x.params)
+
+const MAP = [
+  { ref: 0, tag: 'button', role: 'button', id: '', type: null, name: 'Sign in', href: null, filled: null },
+  { ref: 1, tag: 'input', role: 'input', id: 'email', type: 'email', name: '', href: null, filled: false }
+] as RefItem[]
+
+// ── 8.1 --click ─────────────────────────────────────────────────────────────────────────────────
+describe('--click', () => {
+  it('clicks a @ref at its current centre and names WHAT was clicked (not a coordinate)', async () => {
+    const page = basePage({ mapItems: MAP, refCoords: { 0: { x: 500, y: 100, tag: 'BUTTON' } } })
+    const { s, dbg, refs } = make(page)
+    await browserReadMap(s, refs, NODE) // mint @1,@2
+    const r = await browserClick(s, refs, NODE, '@1')
+    expect(r).toEqual({ ok: true, message: 'clicked @1 (button "Sign in") on browser-3' })
+    const me = mouseEvents(dbg)
+    expect(me.map((e) => e.type)).toEqual(['mousePressed', 'mouseReleased'])
+    expect(me[0]).toMatchObject({ x: 500, y: 100, button: 'left' })
+  })
+
+  it('clicks a raw CSS selector too (the derived-handle escape hatch)', async () => {
+    const page = basePage({ selectorCoords: { '#submit': { x: 400, y: 300, tag: 'BUTTON' } } })
+    const { s, refs } = make(page)
+    const r = await browserClick(s, refs, NODE, '#submit')
+    expect(r).toEqual({ ok: true, message: 'clicked #submit (button) on browser-3' })
+  })
+
+  it('a stale @ref (page navigated since the map) is REFUSED and dispatches NO click (PR 5)', async () => {
+    const page = basePage({ mapItems: MAP, refCoords: { 0: { x: 500, y: 100, tag: 'BUTTON' } } })
+    const { s, dbg, refs } = make(page)
+    await browserReadMap(s, refs, NODE)
+    refs.bumpGeneration(NODE) // Page.frameNavigated
+    const r = await browserClick(s, refs, NODE, '@1')
+    expect(r.ok).toBe(false)
+    expect(r.message).toContain('the page navigated since the last --read map')
+    expect(mouseEvents(dbg)).toEqual([]) // never clicked a re-resolved element
+  })
+
+  it('an off-screen target is refused and dispatches NO click', async () => {
+    const page = basePage({ mapItems: MAP, refCoords: { 0: { x: 5000, y: 100, tag: 'BUTTON' } } })
+    const { s, dbg, refs } = make(page)
+    await browserReadMap(s, refs, NODE)
+    const r = await browserClick(s, refs, NODE, '@1')
+    expect(r.ok).toBe(false)
+    expect(r.message).toContain('off-screen')
+    expect(mouseEvents(dbg)).toEqual([])
+  })
+
+  it('a selector matching nothing is a named refusal', async () => {
+    const { s, refs } = make(basePage())
+    const r = await browserClick(s, refs, NODE, '#missing')
+    expect(r).toEqual({ ok: false, message: 'browser: nothing matches #missing on browser-3' })
+  })
+})
+
+// ── 8.2 --type ──────────────────────────────────────────────────────────────────────────────────
+describe('--type', () => {
+  const SECRET = 'S3CR3T-pw'
+
+  it('focuses --into and inserts the text — the reply reports the COUNT, never the text', async () => {
+    const page = basePage({ mapItems: MAP, refCoords: { 1: { x: 500, y: 200, tag: 'INPUT' } } })
+    const { s, dbg, refs } = make(page)
+    await browserReadMap(s, refs, NODE)
+    const r = await browserType(s, refs, NODE, { text: SECRET, into: '@2', clear: false })
+    expect(r).toEqual({ ok: true, message: 'typed 9 chars into @2 (input#email) on browser-3' })
+    // The typed text is NEVER echoed anywhere in the reply.
+    expect(r.message).not.toContain(SECRET)
+    // It went to insertText (data), not to any expression/key event.
+    const inserts = dbg.sends.filter((x) => x.method === 'Input.insertText')
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0].params).toEqual({ text: SECRET })
+    // Focused the field the way a user does.
+    expect(mouseEvents(dbg).map((e) => e.type)).toEqual(['mousePressed', 'mouseReleased'])
+  })
+
+  it('--clear true selects the field before inserting', async () => {
+    const page = basePage({ mapItems: MAP, refCoords: { 1: { x: 500, y: 200, tag: 'INPUT' } } })
+    const { s, dbg, refs } = make(page)
+    await browserReadMap(s, refs, NODE)
+    const r = await browserType(s, refs, NODE, { text: 'hi', into: '@2', clear: true })
+    expect(r.message).toBe('typed 2 chars into @2 (input#email) on browser-3')
+    expect(keyEvents(dbg).some((e) => Array.isArray(e.commands) && (e.commands as string[]).includes('selectAll'))).toBe(true)
+  })
+
+  it('--clear with empty text clears the field and says so (no insert)', async () => {
+    const page = basePage({ mapItems: MAP, refCoords: { 1: { x: 500, y: 200, tag: 'INPUT' } } })
+    const { s, dbg, refs } = make(page)
+    await browserReadMap(s, refs, NODE)
+    const r = await browserType(s, refs, NODE, { text: '', into: '@2', clear: true })
+    expect(r).toEqual({ ok: true, message: 'cleared @2 (input#email) on browser-3' })
+    expect(dbg.sends.some((x) => x.method === 'Input.insertText')).toBe(false)
+    const cmds = keyEvents(dbg).flatMap((e) => (Array.isArray(e.commands) ? (e.commands as string[]) : []))
+    expect(cmds).toEqual(['selectAll', 'deleteBackward'])
+  })
+
+  it('no --into and NOTHING focused is the exact named refusal', async () => {
+    const { s, refs } = make(basePage({ activeField: null }))
+    const r = await browserType(s, refs, NODE, { text: 'x', clear: false })
+    expect(r).toEqual({ ok: false, message: 'browser: --type needs --into, or a focused field (nothing is focused)' })
+  })
+
+  it('no --into but a field IS focused: types into it with no click', async () => {
+    const page = basePage({ activeField: { tag: 'input', id: 'email' } })
+    const { s, dbg, refs } = make(page)
+    const r = await browserType(s, refs, NODE, { text: SECRET, clear: false })
+    expect(r).toEqual({ ok: true, message: 'typed 9 chars into the focused input#email on browser-3' })
+    expect(r.message).not.toContain(SECRET)
+    expect(mouseEvents(dbg)).toEqual([]) // nothing to focus — no click
+  })
+})
+
+// ── 8.3 --press ─────────────────────────────────────────────────────────────────────────────────
+describe('--press', () => {
+  it('Enter is a keyDown+keyUp from the fixed table', async () => {
+    const { s, dbg } = make(basePage())
+    const r = await browserPress(s, NODE, 'Enter', 1)
+    expect(r).toEqual({ ok: true, message: 'pressed Enter on browser-3' })
+    const ke = keyEvents(dbg)
+    expect(ke.map((e) => e.type)).toEqual(['keyDown', 'keyUp'])
+    expect(ke[0]).toMatchObject({ key: 'Enter', windowsVirtualKeyCode: 13 })
+  })
+
+  it('--times repeats and is reported', async () => {
+    const { s, dbg } = make(basePage())
+    const r = await browserPress(s, NODE, 'ArrowDown', 3)
+    expect(r.message).toBe('pressed ArrowDown x3 on browser-3')
+    expect(keyEvents(dbg)).toHaveLength(6) // 3 × (down+up)
+  })
+
+  it('--times is capped so one verb cannot fire an unbounded storm', async () => {
+    const { s, dbg } = make(basePage())
+    const r = await browserPress(s, NODE, 'PageDown', 100)
+    expect(r.message).toBe('pressed PageDown x50 on browser-3')
+    expect(keyEvents(dbg)).toHaveLength(100)
+  })
+})
+
+// ── 8.4 --scroll ────────────────────────────────────────────────────────────────────────────────
+describe('--scroll', () => {
+  it('scrolls via a bounded mouseWheel and reports the ACTUAL delta read back, not the requested one', async () => {
+    const page = basePage({ scrollY: 0, height: 800, contentHeight: 4400 })
+    const { s, dbg } = make(page)
+    const r = await browserScroll(s, NODE, 'down')
+    // 0.9 × 800 = 720 requested; the fake applied it; the reply is the MEASURED result.
+    expect(r).toEqual({ ok: true, message: 'scrolled browser-3 down 720px (at 720/4400)' })
+    const wheel = mouseEvents(dbg).find((e) => e.type === 'mouseWheel')
+    expect(wheel).toMatchObject({ x: 500, y: 400, deltaY: 720 }) // centre of the viewport
+  })
+
+  it('a signed pixel count matches the design example shape', async () => {
+    const { s } = make(basePage({ scrollY: 0, height: 800, contentHeight: 4400 }))
+    const r = await browserScroll(s, NODE, '600')
+    expect(r.message).toBe('scrolled browser-3 down 600px (at 600/4400)')
+  })
+
+  it('a scroll that MOVES NOTHING shows as 0px — the worst failure shape cannot hide', async () => {
+    // A page no taller than the viewport cannot scroll: the reply must make that visible.
+    const { s } = make(basePage({ scrollY: 0, height: 800, contentHeight: 800 }))
+    const r = await browserScroll(s, NODE, 'down')
+    expect(r.message).toBe('scrolled browser-3 0px (at 0/800)')
+  })
+})
+
+// ── 8.5 --wait ──────────────────────────────────────────────────────────────────────────────────
+describe('--wait', () => {
+  it('a selector already visible returns at once, naming the wait', async () => {
+    const { s, refs } = make(basePage({ visible: { '#results': true } }))
+    const r = await browserWait(s, refs, NODE, '#results', 15_000, { now: () => 0, sleep: async () => {} })
+    expect(r).toEqual({ ok: true, message: '#results appeared on browser-3 after 0ms' })
+  })
+
+  it('a timeout is a NAMED refusal on our own clock', async () => {
+    let clock = 0
+    const now = (): number => clock
+    const sleep = async (ms: number): Promise<void> => {
+      clock += ms
+    }
+    const { s, refs } = make(basePage({ visible: { '#results': false } }))
+    const r = await browserWait(s, refs, NODE, '#results', 300, { now, sleep })
+    expect(r).toEqual({ ok: false, message: 'browser: #results did not appear on browser-3 within 300ms' })
+  })
+
+  it('reports how long a selector took to appear', async () => {
+    const page = basePage({ visible: { '#late': false } })
+    let clock = 0
+    const now = (): number => clock
+    const sleep = async (ms: number): Promise<void> => {
+      clock += ms
+      if (clock >= 300) page.visible['#late'] = true // appears mid-wait
+    }
+    const { s, refs } = make(page)
+    const r = await browserWait(s, refs, NODE, '#late', 15_000, { now, sleep })
+    expect(r.ok).toBe(true)
+    expect(r.message).toMatch(/^#late appeared on browser-3 after \d+ms$/)
+  })
+})

--- a/src/main/browser-lease.ts
+++ b/src/main/browser-lease.ts
@@ -23,6 +23,7 @@
  * Electron-adjacent (holds a debugger on a page with real logins) → `src/main`, never Server Edition.
  */
 import type { CdpContext } from './browser-cdp-allowlist'
+import type { LayoutMetrics } from './browser-actions'
 import { type DebuggerLike, sendCdp } from './browser-cdp-send'
 // The indicator's linger now lives in `src/shared` (PR 6 consumes it from the renderer too, and a
 // renderer→main import is forbidden — global constraint 4). Re-exported here so the debugger-lease
@@ -89,6 +90,14 @@ export class BrowserSession {
   private attached = false
   private _leaseActiveUntil = 0
   /**
+   * The last viewport measured from `Page.getLayoutMetrics` ({@link refreshViewport}). PR 8's pointer
+   * verbs bound a mouse coordinate to what is actually on screen, and the constructor-injected
+   * viewport is a 0×0 placeholder until then — so once a real measurement lands, it OVERRIDES the
+   * injected closure at send time (see {@link currentCtx}). Reset on any detach: a released/re-navigated
+   * page's old size must never bound a coordinate on the next one.
+   */
+  private _viewport: { width: number; height: number } | null = null
+  /**
    * CDP child-session ids are scoped to the debugger attachment. They are invalid after either an
    * explicit detach or webContents teardown and must never survive a reattach.
    */
@@ -132,6 +141,36 @@ export class BrowserSession {
    *  detach so it can never hang past a release. */
   send(method: string, params: object): Promise<unknown> {
     return this.dispatch(method, params, undefined)
+  }
+
+  /**
+   * Measure the page from `Page.getLayoutMetrics`, cache the viewport size so subsequent bounded
+   * pointer events ({@link import('./browser-actions').browserClick}/`browserScroll`) validate against
+   * the REAL page, and return the full scroll geometry (viewport + current scroll offset + content
+   * size) the scroll reply reads back. A pointer verb calls this immediately before it dispatches, so
+   * a resize/scroll between verbs is always reflected.
+   */
+  async refreshViewport(): Promise<LayoutMetrics> {
+    const raw = (await this.send('Page.getLayoutMetrics', {})) as {
+      cssLayoutViewport?: { clientWidth?: number; clientHeight?: number }
+      cssVisualViewport?: { clientWidth?: number; clientHeight?: number; pageX?: number; pageY?: number }
+      cssContentSize?: { width?: number; height?: number }
+    }
+    const num = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
+    const lv = raw?.cssLayoutViewport
+    const vv = raw?.cssVisualViewport
+    const cs = raw?.cssContentSize
+    const width = num(lv?.clientWidth) ?? num(vv?.clientWidth) ?? 0
+    const height = num(lv?.clientHeight) ?? num(vv?.clientHeight) ?? 0
+    this._viewport = { width, height }
+    return {
+      width,
+      height,
+      scrollX: num(vv?.pageX) ?? 0,
+      scrollY: num(vv?.pageY) ?? 0,
+      contentWidth: num(cs?.width) ?? width,
+      contentHeight: num(cs?.height) ?? height
+    }
   }
 
   /** Send a command to a flat-mode child target, using its LIVE session id (never a caller-supplied
@@ -201,7 +240,13 @@ export class BrowserSession {
       return Promise.reject(e)
     }
     this.extendLease()
-    return this.race(sendCdp(this.dbg, method, params, this.viewport(), sessionId))
+    return this.race(sendCdp(this.dbg, method, params, this.currentCtx(), sessionId))
+  }
+
+  /** The viewport the allowlist bounds a coordinate against: the last real measurement when we have
+   *  one, else the injected placeholder. */
+  private currentCtx(): CdpContext {
+    return this._viewport ? { viewport: this._viewport } : this.viewport()
   }
 
   private ensureAttached(): void {
@@ -236,6 +281,9 @@ export class BrowserSession {
   private onDetached(): void {
     this.attached = false
     this.targets.clear()
+    // A measured viewport belongs to the page we were attached to; drop it so it can never bound a
+    // coordinate on a different page after a reattach.
+    this._viewport = null
     this.rejectInFlight()
   }
 

--- a/src/main/browser-nt-scripts.ts
+++ b/src/main/browser-nt-scripts.ts
@@ -41,8 +41,10 @@ export const NT_SCRIPTS = Object.freeze({
   /** The visible text of a selector (or the whole body when none is given), plus the untruncated
    *  length so main can announce an in-band truncation. Capped at the hard ceiling (60000) so a huge
    *  page never ships megabytes over CDP; main applies the caller's --max (<= ceiling) to the text.
-   *  innerText semantics exclude <script>, <style>, display:none and aria-hidden BY CONSTRUCTION.
-   *  Read-only. */
+   *  innerText semantics exclude <script>, <style> and display:none BY CONSTRUCTION (they are the
+   *  RENDERED text). They do NOT drop aria-hidden content — that lives in the accessibility tree, not
+   *  in innerText — so this reader makes no aria-hidden promise; its real property is that no hidden
+   *  input value and no <script> body ride along. Read-only. */
   readText:
     'function(sel){ var el = sel ? document.querySelector(sel) : document.body; if (!el) return null; var t = el.innerText || ""; return { text: t.slice(0, 60000), total: t.length } }',
 
@@ -65,7 +67,14 @@ export const NT_SCRIPTS = Object.freeze({
 
   /** A readiness probe: is the document loaded, and (optionally) is a selector present yet? */
   waitProbe:
-    'function(s){ if (document.readyState !== "complete") return false; if (!s) return true; return document.querySelector(s) != null }'
+    'function(s){ if (document.readyState !== "complete") return false; if (!s) return true; return document.querySelector(s) != null }',
+
+  /** The currently-focused EDITABLE field, or null — used by --type with no --into to tell "type into
+   *  the focused field" from "nothing is focused" (Task 8.2). Returns only the tag + id, never a
+   *  value: reading document.activeElement is a read, and a text/select/contenteditable focus is the
+   *  only thing that makes a bare --type well-defined. Read-only. */
+  activeField:
+    'function(){ var el = document.activeElement; if (!el || el === document.body) return null; var tag = el.tagName ? el.tagName.toLowerCase() : ""; var editable = tag === "input" || tag === "textarea" || tag === "select" || el.isContentEditable === true; if (!editable) return null; return { tag: tag, id: el.id || "" } }'
 })
 
 export type NtScriptName = keyof typeof NT_SCRIPTS

--- a/src/main/browser-refs.test.ts
+++ b/src/main/browser-refs.test.ts
@@ -88,3 +88,53 @@ describe('RefTable — @refs are scoped to a node AND a navigation generation', 
     if (!r.ok) expect(r.stale).toBe(false) // present generation, but no such ref — not a nav-stale
   })
 })
+
+describe('RefTable.spend — how PR 8 verbs (--click/--type/--wait) redeem a ref', () => {
+  it('spends a live ref against the generation its map was minted on', () => {
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    const r = t.spend('browser-1', '@2')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.item).toMatchObject({ tag: 'BUTTON', text: 'Delete account' })
+  })
+
+  it('a ref spent AFTER a navigation is STALE — never re-resolved against a newer map (PR 5)', () => {
+    // This is the property a --click must uphold: clicking @2 ("Delete account") after the page
+    // navigated must be refused, not silently re-resolved to whatever is @2 on the new page.
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    t.bumpGeneration('browser-1') // Page.frameNavigated
+    const r = t.spend('browser-1', '@2')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.stale).toBe(true)
+      expect(r.message).toBe(
+        '@2 is not on the current page (the page navigated since the last --read map; re-read it)'
+      )
+      expect(r).not.toHaveProperty('item')
+    }
+  })
+
+  it('a fresh map after the navigation makes its refs spendable again', () => {
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    t.bumpGeneration('browser-1')
+    t.mint('browser-1', 1, items()) // --read map at the new generation
+    expect(t.spend('browser-1', '@2').ok).toBe(true)
+  })
+
+  it('a ref from ANOTHER node is refused, and a node that never read a map has nothing to spend', () => {
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    expect(t.spend('browser-2', '@1').ok).toBe(false)
+    expect(t.spend('never-read', '@1').ok).toBe(false)
+  })
+
+  it('an out-of-range label on the current page is a refusal, not a guess', () => {
+    const t = new RefTable()
+    t.mint('browser-1', 0, items())
+    const r = t.spend('browser-1', '@99')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.stale).toBe(false) // present, unknown — not nav-stale
+  })
+})

--- a/src/main/browser-refs.ts
+++ b/src/main/browser-refs.ts
@@ -44,6 +44,10 @@ interface NodeRefs {
 
 export class RefTable {
   private readonly byNode = new Map<string, NodeRefs>()
+  /** The generation each node's CURRENT labels were minted at. Kept alongside — and NOT cleared by a
+   *  bump — so a ref spent after a navigation resolves against the generation the agent read it on and
+   *  is therefore reported STALE (the page navigated), not merely "unknown". See {@link spend}. */
+  private readonly mintedAt = new Map<string, number>()
 
   /** The generation the node is currently on (0 before anything is minted or bumped). */
   currentGeneration(nodeId: string): number {
@@ -63,7 +67,21 @@ export class RefTable {
       map.set(label, items[i])
     }
     this.byNode.set(nodeId, { gen, items: map })
+    this.mintedAt.set(nodeId, gen)
     return { gen, labels }
+  }
+
+  /**
+   * SPEND a ref an agent is holding (`--click @7`, `--type --into @3`, `--wait @9`). It resolves the
+   * label at the generation its CURRENT map was minted on — so a navigation since that read (which
+   * bumped the generation) surfaces as the STALE refusal (`the page navigated … re-read it`), while a
+   * label that was simply never minted on this page is the UNKNOWN refusal. Both are refusals; a stale
+   * ref is NEVER silently re-resolved against a newer map (the correctness property PR 5 pins). A node
+   * that never read a map at all resolves as stale-shaped (there is nothing to spend), which is still a
+   * refusal.
+   */
+  spend(nodeId: string, label: string): RefResolution {
+    return this.resolve(nodeId, this.mintedAt.get(nodeId) ?? 0, label)
   }
 
   /**
@@ -99,5 +117,6 @@ export class RefTable {
   /** Forget a node entirely (its guest is gone / owner released). */
   forget(nodeId: string): void {
     this.byNode.delete(nodeId)
+    this.mintedAt.delete(nodeId)
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2424,8 +2424,9 @@ app.whenReady().then(async () => {
     const session = new BrowserSession({
       nodeId: browserNodeId,
       debugger: wc.debugger,
-      // Coordinates are unused by --nav/--read; PR 8's pointer verbs refresh this from
-      // Page.getLayoutMetrics before dispatching a bounded mouse event.
+      // A 0×0 placeholder: coordinates are unused by --nav/--read, and the pointer verbs (PR 8) call
+      // BrowserSession.refreshViewport() from Page.getLayoutMetrics before every dispatch, which
+      // OVERRIDES this at send time — so a bounded mouse event validates against the real page.
       viewport: () => ({ viewport: { width: 0, height: 0 } }),
       isDevToolsOpen: () => {
         try {


### PR DESCRIPTION
## S8 PR 8 of #112 — Interaction

Adds the five INTERACTION flags to the `browser` verb — `--click`, `--type`, `--press`, `--scroll`, `--wait` — driving through the **same security spine** PR 7 established: the default-deny CDP allowlist (`checkCdpCommand`, the one `sendCdp` gate), ledger ownership, and the drive-time live-capability check. No new drive entrypoint; no gate bypass. The pure arg parser (`src/core/browser-verb.ts`) already accepted these flags — this PR is the main-side drive.

### Tasks → commits
- **8.1 `--click`, 8.2 `--type`, 8.3 `--press`, 8.4 `--scroll`, 8.5 `--wait`** → `feat(browser): interaction verbs — click, type, press, scroll, wait` (browser-actions.ts, browser-drive.ts, browser-interaction.test.ts)
- **Shared spine + #308 minor-1 cleanup** → `feat(browser): interaction spine — dispatchKeyEvent gate, viewport refresh, ref spend` (allowlist, lease, refs, nt-scripts, index)
- **8.4 probe report** → `docs(browser): record the --scroll wheel-translation probe`

### New CDP methods added to the allowlist (each with a params-validator)
| Method | Validator? | What it checks |
|---|---|---|
| `Input.dispatchKeyEvent` | **yes** | `key` ∈ fixed `BROWSER_KEYS` (same set the parser gates on) **or** `commands` ⊆ {selectAll, deleteBackward}; free `text` **forbidden**; real key-event type only; empty event refused |

That is the **only** new CDP method. Everything else reuses methods PR 7 already allowlisted:
- **click / scroll** → `Input.dispatchMouseEvent` (existing; the click is mousePressed/mouseReleased, the scroll a `mouseWheel` — both bounded to the viewport). `Input.synthesizeScrollGesture` stays **excluded**, so the wheel translation is the only scroll door.
- **type** → `Input.insertText` (existing, capped at 8192, data-only).
- **ref/selector/focus/visibility resolution** → `Runtime.callFunctionOn` on **frozen NT_SCRIPTS** by identity (existing); added one pure reader `activeField` (bare-`--type` focus detection) to the frozen table.
- **viewport/scroll geometry** → `Page.getLayoutMetrics` (existing).

### Security properties held (mutation-checked — 7 introduced / 7 caught)
- **Default-deny allowlist**: arbitrary `key` allowed → red; free `text` allowed → red; `Input.dispatchKeyEvent` removed from the table → red (press/type break at the gate).
- **`--type` text is DATA**: goes to `Input.insertText`, **never echoed** — the reply reports the char count, not the text (mutation: echo text → red). Never `Runtime.evaluate`/an interpolated expression.
- **`--press` is a fixed key table**: an unknown key is default-denied at both the parser and the allowlist.
- **`@ref` scope (PR 5)**: a `--click`/`--type --into` ref spent after a navigation is the STALE refusal, never re-resolved against a newer map (mutation: spend at currentGeneration → red; mutation: click ignores stale ref → red). A foreign-node ref never resolves.
- **One CDP gate**: every interaction command routes through `BrowserSession.send` → `sendCdp` → `checkCdpCommand`; the structural "one `sendCommand(` call site in all of `src/main`" test stays green.
- **Coordinates bounded to the real viewport**: `refreshViewport()` measures `Page.getLayoutMetrics` before each pointer dispatch (overriding the 0×0 placeholder); an off-screen target is refused.

### `--scroll` wheel probe result
**Not re-measured here.** The probe (real Electron 42.8.1 `<webview>` + xvfb) cannot run in this headless, displayless environment — the same reason the reader/pointer end-to-end harness is deferred in the vitest suite. Per Global Constraint 8 this is **reported, not skipped** (`docs/superpowers/probes/2026-08-browser-scroll.md`). Mitigation, in code: `Input.synthesizeScrollGesture` stays excluded; the wheel delta is authored in the DOM convention (positive `deltaY` = down) rather than by inverting a gesture distance; and **the reply reads the scroll position back** from `Page.getLayoutMetrics` and reports the ACTUAL delta — so a wrong sign or a silent no-op shows as `0px` / an opposite-direction delta the agent can see, never a command that "succeeds and does nothing". Device-run verification steps are recorded in the probe doc (owed).

### Surfaces
- **Desktop (Electron)**: the only surface — all CDP drive is main-side.
- **Server Edition**: unchanged — no `setControlHandler`, browser control does not exist there.
- **Mobile**: unchanged — never originates control.

### Tests
`npm run typecheck` clean; full `npx vitest run` green (**7180 passed, 12 skipped, 0 failed**). New/extended: `browser-interaction.test.ts` (drives the real BrowserSession + sendCdp + allowlist + frozen NT_SCRIPTS), `browser-cdp-allowlist.test.ts` (dispatchKeyEvent), `browser-refs.test.ts` (`spend`).

Interaction/wheel/CDP child-session groundwork lifted from PR #112 (**@Corvin**, proteus-dev); the verb shapes, replies, and the read-back scroll are new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
