### PR TITLE
feat(browser): --screenshot, --cookies, and the audit trace

### DIFF
--- a/src/core/board-log-handlers.test.ts
+++ b/src/core/board-log-handlers.test.ts
@@ -53,6 +53,21 @@ describe('registerBoardLogHandlers — routing', () => {
     expect(await read(f, 'p1')).toEqual({ entries: [], unsupported: true })
   })
 
+  it('returns an in-process append that writes THROUGH the same router (no IPC round-trip) — Task 9.2', async () => {
+    const f = fakePlatform()
+    const handlers = registerBoardLogHandlers(f, routerFor({ kind: 'local', cwd: dir }))
+    // The main-side caller (the cookie trace) appends without going through the renderer.
+    expect(await handlers.append('p1', entry({ id: 'trace', kind: 'event', text: undefined }))).toBe(true)
+    const res = await read(f, 'p1')
+    expect(res.entries.map((e) => e.id)).toContain('trace')
+  })
+
+  it('the in-process append reports false on an unsupported project (fail-closed feeds the cookie gate)', async () => {
+    const f = fakePlatform()
+    const handlers = registerBoardLogHandlers(f, routerFor({ kind: 'unsupported' }))
+    expect(await handlers.append('p1', entry())).toBe(false)
+  })
+
   it('remote: routes through the injected exec (append + tail)', async () => {
     const store: string[] = []
     const exec: RemoteLogExec = {

--- a/src/core/board-log-handlers.ts
+++ b/src/core/board-log-handlers.ts
@@ -48,7 +48,15 @@ export function appendBoardLogVia(
   return Promise.resolve(false)
 }
 
-export function registerBoardLogHandlers(platform: CorePlatform, router: BoardLogRouter): void {
+/** What `registerBoardLogHandlers` hands back: an in-process `append` that a MAIN-side caller (the
+ *  `browser --cookies` trace, PR 9 Task 9.2) uses to write a board-log line WITHOUT an IPC round-trip
+ *  through the renderer — the same local/remote/unsupported routing the `boardLogAppend` handler
+ *  performs, sharing the one `localStore`. */
+export interface BoardLogHandlers {
+  append(projectId: string, entry: BoardLogEntry): Promise<boolean>
+}
+
+export function registerBoardLogHandlers(platform: CorePlatform, router: BoardLogRouter): BoardLogHandlers {
   const localStore = new BoardLogStore({})
 
   platform.handle(IPC.boardLogAppend, async (projectId: string, entry: BoardLogEntry): Promise<boolean> => {
@@ -119,4 +127,11 @@ export function registerBoardLogHandlers(platform: CorePlatform, router: BoardLo
       subs.delete(projectId)
     }
   })
+
+  // The in-process append: shares this registration's router + localStore, so a main-side writer and
+  // the IPC handler can never route a project's log differently.
+  return {
+    append: (projectId: string, entry: BoardLogEntry): Promise<boolean> =>
+      appendBoardLogVia(router, projectId, entry, localStore)
+  }
 }

--- a/src/main/browser-actions.ts
+++ b/src/main/browser-actions.ts
@@ -155,7 +155,7 @@ async function callReader(s: Sendable, fn: string, args: readonly (string | numb
 }
 
 /** The final URL after navigation/redirects, from OUR navigation-history read. */
-async function currentUrl(s: Sendable): Promise<string> {
+export async function currentUrl(s: Sendable): Promise<string> {
   const h = (await s.send('Page.getNavigationHistory', {})) as {
     currentIndex?: number
     entries?: { url?: string }[]

--- a/src/main/browser-cdp-allowlist.test.ts
+++ b/src/main/browser-cdp-allowlist.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
-import { checkCdpCommand, type CdpContext } from './browser-cdp-allowlist'
+import { checkCdpCommand, COOKIE_WRITE_METHODS, type CdpContext } from './browser-cdp-allowlist'
 import { NT_SCRIPTS } from './browser-nt-scripts'
 
 const ctx: CdpContext = { viewport: { width: 1280, height: 800 } }
@@ -84,10 +84,29 @@ describe('checkCdpCommand', () => {
 
   it('cookie WRITES are listed (owner decision 5) and unreachable in v1', () => {
     // The methods stay listed so the allowlist RECORDS the decision; PR 9 Task 9.4 pins that no
-    // verb reaches them, because a write verb needs a design nobody has done: where does the agent
-    // get the value, and what stops it planting accounts.google.com so a later human visit is a
-    // login the attacker controls?
+    // verb reaches them (browser-cookie-write-guard.test.ts), because a write verb needs a design
+    // nobody has done: where does the agent get the value, and what stops it planting
+    // accounts.google.com so a later human visit is a login the attacker controls?
     expect(checkCdpCommand('Network.setCookie', { name: 'a', value: 'b', domain: 'x.test' }, ctx)).toBe(true)
+    // The jar-mutating set is enumerated in one place; setCookie is the only one the ALLOW table
+    // admits, and it is unreachable from every verb (the reachability guard proves that).
+    expect(COOKIE_WRITE_METHODS).toContain('Network.setCookie')
+    expect(COOKIE_WRITE_METHODS).toContain('Network.deleteCookies')
+    expect(COOKIE_WRITE_METHODS).toContain('Storage.setCookies')
+  })
+
+  it('a screenshot is PNG-only, and its clip must be a numeric rectangle we authored (Task 9.1)', () => {
+    expect(checkCdpCommand('Page.captureScreenshot', {}, ctx)).toBe(true)
+    expect(checkCdpCommand('Page.captureScreenshot', { format: 'png' }, ctx)).toBe(true)
+    // No jpeg/pdf surface — a caller cannot pick the format (and never supplies params anyway).
+    expect(checkCdpCommand('Page.captureScreenshot', { format: 'jpeg' }, ctx)).toBe(false)
+    expect(checkCdpCommand('Page.captureScreenshot', { format: 'pdf' }, ctx)).toBe(false)
+    // A well-formed numeric clip (our own box model) passes; a structured/garbage clip is refused.
+    expect(
+      checkCdpCommand('Page.captureScreenshot', { clip: { x: 0, y: 0, width: 100, height: 50, scale: 1 } }, ctx)
+    ).toBe(true)
+    expect(checkCdpCommand('Page.captureScreenshot', { clip: { x: 0, y: 0, width: 100 } }, ctx)).toBe(false)
+    expect(checkCdpCommand('Page.captureScreenshot', { clip: 'whole-page' }, ctx)).toBe(false)
   })
 
   it('an unknown method is refused with NO per-method detail', () => {

--- a/src/main/browser-cdp-allowlist.ts
+++ b/src/main/browser-cdp-allowlist.ts
@@ -59,6 +59,28 @@ function valueOnlyArgs(args: unknown): boolean {
 const MAX_SELECTOR = 1024
 const MAX_INSERT_TEXT = 8192
 
+/**
+ * The cookie-JAR-MUTATING CDP methods, listed in ONE place so the decision is recorded, and pinned
+ * UNREACHABLE by the verb-reachability guard in browser-cdp-allowlist.test.ts (PR 9 Task 9.4).
+ *
+ * `Network.setCookie` stays ADMITTED by the ALLOW table below (owner decision 5) so a future write
+ * verb inherits a validated entry rather than a fresh, unreviewed one — but v1 ships NO verb that
+ * emits any of these. The reason it is not merely "not built yet": a write verb needs a design nobody
+ * has done — where does the agent get the cookie value, and what stops it planting an attacker's
+ * session cookie for `accounts.google.com` so a later human visit to that node is a login the attacker
+ * controls? A cookie write, when designed, needs a LOUDER trace than a read: a write is persistent and
+ * silent, where a read is at least a one-time disclosure. So the list records the decision; the guard
+ * proves no action reaches it.
+ */
+export const COOKIE_WRITE_METHODS = [
+  'Network.setCookie',
+  'Network.setCookies',
+  'Network.deleteCookies',
+  'Network.clearBrowserCookies',
+  'Storage.setCookies',
+  'Storage.clearCookies'
+] as const
+
 /** The dispatch types a key event may carry — a key-down, a key-up, or a raw key-down. There is
  *  deliberately NO `char` type: a character that types into the page belongs to `Input.insertText`
  *  (its own capped, data-only path), never to a key event. */
@@ -178,6 +200,29 @@ const ALLOW = new Map<string, Validator>([
       typeof p.value === 'string' &&
       typeof p.domain === 'string' &&
       p.domain.length > 0
+  ],
+
+  // A screenshot is PNG-only and its clip comes from OUR OWN box model (the layout metrics), never
+  // from agent input — the path the agent supplies is jailed to the project dir in browser-screenshot.ts
+  // and never reaches CDP. So the only agent influence here is "take a picture"; format is pinned to
+  // png (no pdf/jpeg surface), and a clip, if present, must be numeric — a well-formed rectangle we
+  // authored, not a structured re-entry point.
+  [
+    'Page.captureScreenshot',
+    (p) => {
+      if (!isRecord(p)) return false
+      if (p.format !== undefined && p.format !== 'png') return false
+      if (p.captureBeyondViewport !== undefined && typeof p.captureBeyondViewport !== 'boolean') return false
+      if (p.clip !== undefined) {
+        const c = p.clip
+        if (!isRecord(c)) return false
+        for (const k of ['x', 'y', 'width', 'height']) {
+          if (typeof c[k] !== 'number') return false
+        }
+        if (c.scale !== undefined && typeof c.scale !== 'number') return false
+      }
+      return true
+    }
   ],
 
   // ---- Session lifecycle (issued by the lease, browser-lease.ts, not by an agent verb). Still gated

--- a/src/main/browser-cookie-write-guard.test.ts
+++ b/src/main/browser-cookie-write-guard.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { driveBrowser, type BrowserResolve, type DriveDeps, type LiveGuest } from './browser-drive'
+import { CdpEventBus, type Driver, type LayoutMetrics } from './browser-actions'
+import { COOKIE_WRITE_METHODS } from './browser-cdp-allowlist'
+import { BrowserControlLedger } from './browser-control-ledger'
+import { RefTable } from './browser-refs'
+import { BROWSER_ACTION_KEYS, parseBrowserArgs, type BrowserCall } from '../core/browser-verb'
+
+const OWNER = 'claude-1'
+const NODE = 'browser-3'
+
+const okResolve: BrowserResolve = {
+  ok: true,
+  projectId: 'proj-1',
+  projectCwd: '/proj',
+  sourceControlCapable: true,
+  capabilityOn: true,
+  sourceTitle: 'claude-1',
+  browserTitle: 'browser-3'
+}
+
+/** A Driver that RECORDS every method it is asked to send — INTENT, before any allowlist — and
+ *  answers generically so each action runs far enough to emit its full method set. */
+function recordingGuest(): { guest: LiveGuest; sent: string[] } {
+  const sent: string[] = []
+  const m: LayoutMetrics = { width: 800, height: 600, scrollX: 0, scrollY: 0, contentWidth: 800, contentHeight: 2000 }
+  const session: Driver = {
+    async send(method) {
+      sent.push(method)
+      switch (method) {
+        case 'DOM.getDocument':
+          return { root: { nodeId: 1 } }
+        case 'DOM.resolveNode':
+          return { object: { objectId: 'o' } }
+        case 'Runtime.callFunctionOn':
+          // Satisfy the readers that need coordinates AND the ones that need a value; a superset object.
+          return { result: { value: { x: 10, y: 10, tag: 'button', text: 'ok' } } }
+        case 'Page.getNavigationHistory':
+          return { currentIndex: 0, entries: [{ url: 'https://x.test/' }] }
+        case 'Page.captureScreenshot':
+          return { data: Buffer.from('PNG').toString('base64') }
+        case 'Network.getCookies':
+          return { cookies: [] }
+        case 'Page.getLayoutMetrics':
+          return { cssLayoutViewport: { clientWidth: 800, clientHeight: 600 }, cssContentSize: { width: 800, height: 2000 } }
+        default:
+          return {}
+      }
+    },
+    async refreshViewport() {
+      return m
+    }
+  }
+  return { guest: { session, bus: new CdpEventBus() }, sent }
+}
+
+function ledgerOwning(): BrowserControlLedger {
+  const l = new BrowserControlLedger()
+  l.claim(NODE, { ownerNodeId: OWNER, projectId: 'proj-1', partition: 'p', navGeneration: 0, leaseActiveUntil: 0, openedAt: 0 })
+  return l
+}
+
+/** One representative call per action key — the whole action surface parseBrowserArgs admits. */
+function callFor(action: string): BrowserCall {
+  const base: Record<string, string> = { node: NODE, timeout: '10' }
+  const args: Record<string, Record<string, string>> = {
+    nav: { ...base, nav: 'https://x.test/' },
+    read: { ...base, read: 'map' },
+    click: { ...base, click: '#go' },
+    type: { ...base, type: 'hello', into: '#f' },
+    press: { ...base, press: 'Enter' },
+    scroll: { ...base, scroll: 'down' },
+    wait: { ...base, wait: '#done' },
+    screenshot: { ...base, screenshot: 'shot.png' },
+    cookies: { ...base, cookies: 'github.com' }
+  }
+  const parsed = parseBrowserArgs(args[action])
+  if ('error' in parsed) throw new Error(`could not build a call for ${action}: ${parsed.error}`)
+  return parsed
+}
+
+describe('Task 9.4 — no verb reaches a cookie WRITE (the set is listed & unreachable)', () => {
+  it('enumerates every action and records the CDP methods each emits; the write intersection is empty', async () => {
+    // A real project dir so the screenshot jail resolves; writeFile is a no-op spy.
+    const project = await fsp.mkdtemp(path.join(os.tmpdir(), 'guard-'))
+    const screenshotIO = {
+      realpath: (p: string) => fsp.realpath(p),
+      lstat: (p: string) => fsp.lstat(p),
+      writeFile: vi.fn(async () => {})
+    }
+    const resolve: BrowserResolve = { ...okResolve, projectCwd: project }
+
+    const emittedByAction: Record<string, string[]> = {}
+    for (const action of BROWSER_ACTION_KEYS) {
+      const { guest, sent } = recordingGuest()
+      const deps: DriveDeps = {
+        ledger: ledgerOwning(),
+        refs: new RefTable(),
+        sessionFor: () => guest,
+        revoke: vi.fn(),
+        appendBoardLog: async () => true, // the cookie trace succeeds so the read is reached
+        screenshotIO
+      }
+      await driveBrowser({ call: callFor(action), ownerNodeId: OWNER, verified: true, resolve }, deps)
+      emittedByAction[action] = sent
+    }
+
+    // Every action was actually exercised (a new action can't be added without appearing here).
+    expect(Object.keys(emittedByAction).sort()).toEqual([...BROWSER_ACTION_KEYS].sort())
+
+    // The union of everything any verb emits, intersected with the write set, must be empty.
+    const writeSet = new Set<string>(COOKIE_WRITE_METHODS)
+    const allEmitted = new Set<string>(Object.values(emittedByAction).flat())
+    const reachableWrites = [...allEmitted].filter((m) => writeSet.has(m))
+    expect(reachableWrites).toEqual([])
+
+    // And, positively: the cookie READ path DID reach getCookies (so the emptiness above is not just
+    // because nothing ran).
+    expect(emittedByAction.cookies).toContain('Network.getCookies')
+
+    await fsp.rm(project, { recursive: true, force: true })
+  })
+})

--- a/src/main/browser-cookies.test.ts
+++ b/src/main/browser-cookies.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  browserCookies,
+  COOKIES_NOT_RECORDED,
+  COOKIES_NO_CURRENT_DOMAIN
+} from './browser-cookies'
+import type { Sendable } from './browser-actions'
+
+/** A session that records every method sent, answers getCookies with `count` cookies, and reports a
+ *  current URL for `--cookies current`. */
+function fakeSession(opts: { count?: number; currentUrl?: string } = {}): { s: Sendable; sent: string[] } {
+  const sent: string[] = []
+  const s: Sendable = {
+    async send(method) {
+      sent.push(method)
+      if (method === 'Network.getCookies') {
+        return { cookies: Array.from({ length: opts.count ?? 0 }, (_, i) => ({ name: `c${i}` })) }
+      }
+      if (method === 'Page.getNavigationHistory') {
+        return { currentIndex: 0, entries: [{ url: opts.currentUrl ?? 'https://x.test/' }] }
+      }
+      return {}
+    }
+  }
+  return { s, sent }
+}
+
+describe('browserCookies — allowed, but LOUDLY traced (Task 9.3)', () => {
+  it('the trace is appended BEFORE the read; if the append fails, the read does not happen', async () => {
+    // Fail-closed, deliberately. A cookie read that happened but was not recorded is the one outcome
+    // this section exists to prevent.
+    const { s, sent } = fakeSession({ count: 4 })
+    const recordTrace = vi.fn(async () => false) // no reachable log / write failed
+    const r = await browserCookies(s, 'browser-3', 'github.com', { recordTrace })
+    expect(r).toEqual({ ok: false, message: COOKIES_NOT_RECORDED })
+    expect(recordTrace).toHaveBeenCalledWith('github.com')
+    expect(sent).not.toContain('Network.getCookies') // the read NEVER happened
+  })
+
+  it('the trace runs strictly before the read (ordering, not just presence)', async () => {
+    const order: string[] = []
+    const { s } = ((): { s: Sendable } => {
+      const sess: Sendable = {
+        async send(method) {
+          order.push(`send:${method}`)
+          if (method === 'Network.getCookies') return { cookies: [] }
+          return {}
+        }
+      }
+      return { s: sess }
+    })()
+    const recordTrace = vi.fn(async () => {
+      order.push('trace')
+      return true
+    })
+    await browserCookies(s, 'browser-3', 'github.com', { recordTrace })
+    expect(order).toEqual(['trace', 'send:Network.getCookies'])
+  })
+
+  it('the reply tells the agent it was recorded', async () => {
+    const { s } = fakeSession({ count: 4 })
+    const r = await browserCookies(s, 'browser-3', 'github.com', { recordTrace: async () => true })
+    // An agent that knows it is being watched behaves better, and an agent that prints that line into
+    // its transcript has told the user too.
+    expect(r.message).toBe("read 4 cookies for github.com — this was recorded in the project's activity log.")
+  })
+
+  it('getAllCookies is unreachable — the read NAMES a domain (a SHAPE restriction, not a ban)', async () => {
+    // One call that empties the jar for every site the profile has ever touched would name no domain,
+    // so no useful trace line exists for it. This path only ever issues getCookies with an explicit,
+    // single-domain url list.
+    const { s, sent } = fakeSession({ count: 2 })
+    const getCookiesParams: unknown[] = []
+    const spy: Sendable = {
+      async send(method, params) {
+        sent.push(method)
+        if (method === 'Network.getCookies') {
+          getCookiesParams.push(params)
+          return { cookies: [{}, {}] }
+        }
+        return {}
+      }
+    }
+    await browserCookies(spy, 'browser-3', 'github.com', { recordTrace: async () => true })
+    expect(sent).toContain('Network.getCookies')
+    expect(sent).not.toContain('Network.getAllCookies')
+    expect(getCookiesParams[0]).toEqual({ urls: ['https://github.com/', 'http://github.com/'] })
+  })
+
+  it('"current" reads the page\'s own domain', async () => {
+    const { s } = fakeSession({ count: 1, currentUrl: 'https://mail.google.com/inbox' })
+    const r = await browserCookies(s, 'browser-3', 'current', { recordTrace: async () => true })
+    expect(r.message).toBe("read 1 cookie for mail.google.com — this was recorded in the project's activity log.")
+  })
+
+  it('"current" on a page with no http(s) origin is a named refusal, and never traces or reads', async () => {
+    const { s, sent } = fakeSession({ currentUrl: 'about:blank' })
+    const recordTrace = vi.fn(async () => true)
+    const r = await browserCookies(s, 'browser-3', 'current', { recordTrace })
+    expect(r).toEqual({ ok: false, message: COOKIES_NO_CURRENT_DOMAIN })
+    expect(recordTrace).not.toHaveBeenCalled()
+    expect(sent).not.toContain('Network.getCookies')
+  })
+
+  it('a non-host domain (a URL, a smuggled newline) is refused before any trace or read', async () => {
+    const { s, sent } = fakeSession()
+    const recordTrace = vi.fn(async () => true)
+    const r = await browserCookies(s, 'browser-3', 'https://evil.test/@github.com', { recordTrace })
+    expect(r.ok).toBe(false)
+    expect(recordTrace).not.toHaveBeenCalled()
+    expect(sent).not.toContain('Network.getCookies')
+
+    const nl = await browserCookies(s, 'browser-3', 'github.com\nplanted', { recordTrace })
+    expect(nl.ok).toBe(false)
+  })
+})

--- a/src/main/browser-cookies.ts
+++ b/src/main/browser-cookies.ts
@@ -1,0 +1,112 @@
+/**
+ * `--cookies <domain>` (PR 9 Task 9.3). Reading a site's cookies hands the raw session token to the
+ * agent AS DATA — a string it can print to its transcript, write to a file, or paste into a curl — so
+ * from that moment the session is portable and revoking it means logging out on the site, not closing
+ * the node. The owner asked for this (agentic login needs it), so it is ALLOWED — but it MUST be
+ * LOUDLY TRACED, and the trace is appended BEFORE the read, fail-closed: a cookie read that happened
+ * but was not recorded is the one outcome this module exists to prevent.
+ *
+ * USING a session is not READING one, and that distinction is why one is silent and the other loud.
+ * A --nav to a logged-in site sends the jar's cookies automatically and renders the page logged in —
+ * the agent gets the BENEFIT without the token ever being handed to it, and none of the five core
+ * actions touches a cookie API. `Network.getCookies` hands the raw token over; `Network.getAllCookies`
+ * (the jar-emptying call that names no domain and so informs nobody) is not in the allowlist at all,
+ * and this module only ever issues `getCookies` with an explicit, single-domain URL list.
+ *
+ * Three limits on this trace, none of them a reason not to have it:
+ *  1. NOT TAMPER-PROOF. board-log.jsonl is a file in a project the agent usually has write access to.
+ *     This is an audit trail against an agent that is not hiding — the realistic case for a
+ *     prompt-injected agent following instructions it believes are legitimate — not forensics.
+ *  2. NOT THE ONLY WAY. An agent with shell access can read Chromium's cookie DB out of the user data
+ *     dir with no CDP and no trace. This covers THIS PATH, not cookies in general.
+ *  3. IT MAY BE COMMITTED. .nodeterm/ is gitignored in nodeterm's own repo, but nothing guarantees
+ *     that in a user's project — project.json in the same directory is expected to be committed. A
+ *     line naming a domain is mild, but it is a domain the user visited, in a commit.
+ *
+ * Main-side only (it holds a debugger on a page with real logins); never Server Edition.
+ */
+import { currentUrl, type Sendable, type ActionResult } from './browser-actions'
+
+/** The parser already refuses an empty domain; kept here so the message never drifts between them. */
+export const COOKIES_NO_DOMAIN =
+  'browser: --cookies takes one domain (use "current" for the page\'s own)'
+
+/** Fail-closed: the trace could not be durably written, so the read is refused. Naming the cause
+ *  (no reachable activity log) tells the agent this is not a permissions verdict on cookies. */
+export const COOKIES_NOT_RECORDED =
+  "browser: the cookie read could not be recorded in the project's activity log, so it did not happen"
+
+/** `--cookies current` on a page with no resolvable http(s) origin (about:blank, a data: URL). */
+export const COOKIES_NO_CURRENT_DOMAIN =
+  "browser: --cookies current needs a page on an http(s) site (this one has no domain)"
+
+/** The whole trace side of the read, injected so the ordering (trace BEFORE read, fail-closed) is
+ *  unit-testable without a board log. `recordTrace` returns false when there is no reachable log OR
+ *  the write failed — both mean "not recorded". */
+export interface CookieReadDeps {
+  recordTrace(domain: string): Promise<boolean>
+}
+
+/** A plain host (optionally with a port). The domain is DATA, so a value that is not a host — a URL,
+ *  a path, whitespace, a newline that would smuggle a second board-log field — is refused, never
+ *  interpolated into a URL or a trace line. */
+const HOST_RE = /^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?(:\d+)?$/
+
+function hostFromUrl(url: string): string | null {
+  try {
+    const u = new URL(url)
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return null
+    return u.host || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read the cookies for one domain, LOUDLY. Resolve the target host (an explicit domain, or the page's
+ * own for `current`), append the trace FIRST — and only if that trace was durably recorded, issue the
+ * single-domain `Network.getCookies`. The reply tells the agent it was recorded, so an agent that
+ * prints that line into its transcript has told the user too.
+ */
+export async function browserCookies(
+  s: Sendable,
+  nodeId: string,
+  domain: string,
+  deps: CookieReadDeps
+): Promise<ActionResult> {
+  if (!domain) return { ok: false, message: COOKIES_NO_DOMAIN }
+
+  let host: string
+  if (domain === 'current') {
+    const h = hostFromUrl(await currentUrl(s))
+    if (!h) return { ok: false, message: COOKIES_NO_CURRENT_DOMAIN }
+    host = h
+  } else {
+    if (!HOST_RE.test(domain)) {
+      return { ok: false, message: `browser: --cookies domain "${domain}" is not a valid host` }
+    }
+    host = domain
+  }
+
+  // TRACE BEFORE READ, fail-closed. An exception from the appender is the same fact as `false`.
+  let recorded = false
+  try {
+    recorded = await deps.recordTrace(host)
+  } catch {
+    recorded = false
+  }
+  if (!recorded) return { ok: false, message: COOKIES_NOT_RECORDED }
+
+  // A single, domain-naming read — never the jar-emptying getAllCookies. Both schemes so an
+  // http-only cookie on a plain-http site is not silently missed.
+  const res = (await s.send('Network.getCookies', {
+    urls: [`https://${host}/`, `http://${host}/`]
+  })) as { cookies?: unknown }
+  const cookies = Array.isArray(res?.cookies) ? res.cookies : []
+  const n = cookies.length
+  const plural = n === 1 ? 'cookie' : 'cookies'
+  return {
+    ok: true,
+    message: `read ${n} ${plural} for ${host} — this was recorded in the project's activity log.`
+  }
+}

--- a/src/main/browser-drive.test.ts
+++ b/src/main/browser-drive.test.ts
@@ -195,6 +195,105 @@ describe('a user-Stopped node refuses to re-drive until a fresh verified claim (
   })
 })
 
+// ── PR 9: --cookies drives through the SAME gate and is loudly traced ───────────────────────────
+describe('--cookies drives through the gate and traces BEFORE it reads (Task 9.3)', () => {
+  function cookiesCall(): BrowserCall {
+    const c = parseBrowserArgs({ node: NODE, cookies: 'github.com' })
+    if ('error' in c) throw new Error(c.error)
+    return c
+  }
+
+  it('the owner reads cookies, and the board-log trace is appended before the read', async () => {
+    const ledger = freshLedgerOwning()
+    const { guest, dbg } = makeGuest()
+    const order: string[] = []
+    const origSend = dbg.sendCommand.bind(dbg)
+    dbg.sendCommand = async (m: string, p?: object) => {
+      if (m === 'Network.getCookies') order.push('read')
+      return m === 'Network.getCookies' ? { cookies: [{}, {}, {}, {}] } : origSend(m, p)
+    }
+    const appendBoardLog = vi.fn(async (_projectId: string, _entry: unknown) => {
+      order.push('trace')
+      return true
+    })
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn(), appendBoardLog }
+    const r = await driveBrowser(
+      { call: cookiesCall(), ownerNodeId: OWNER, verified: true, resolve: { ...okResolve, sourceTitle: 'claude-1', browserTitle: 'browser-3' } },
+      deps
+    )
+    expect(r).toEqual({ ok: true, message: "read 4 cookies for github.com — this was recorded in the project's activity log." })
+    expect(order).toEqual(['trace', 'read']) // the trace strictly precedes the read
+    // The entry files under the OWNER's card, names the owner in `from`, the domain in `to`.
+    const entry = appendBoardLog.mock.calls[0][1]
+    expect(entry).toMatchObject({
+      nodeId: OWNER,
+      kind: 'event',
+      event: { type: 'agent-read-cookies', from: 'claude-1', to: 'github.com', title: 'browser-3' }
+    })
+  })
+
+  it('if the trace cannot be recorded, the read does not happen (fail-closed)', async () => {
+    const ledger = freshLedgerOwning()
+    const { guest, dbg } = makeGuest()
+    const reads: string[] = []
+    const origSend = dbg.sendCommand.bind(dbg)
+    dbg.sendCommand = async (m: string, p?: object) => {
+      if (m === 'Network.getCookies') reads.push(m)
+      return origSend(m, p)
+    }
+    // No appendBoardLog wired at all ⇒ the read cannot be recorded ⇒ refuse without reading.
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn() }
+    const r = await driveBrowser({ call: cookiesCall(), ownerNodeId: OWNER, verified: true, resolve: okResolve }, deps)
+    expect(r.ok).toBe(false)
+    expect(reads).toEqual([]) // the jar was never read
+  })
+})
+
+// ── PR 9: --screenshot is jailed to the project dir end-to-end ───────────────────────────────────
+describe('--screenshot is jailed to the project dir through the gate (Task 9.1)', () => {
+  function shotCall(p: string): BrowserCall {
+    const c = parseBrowserArgs({ node: NODE, screenshot: p })
+    if ('error' in c) throw new Error(c.error)
+    return c
+  }
+  const screenshotIO = () => ({
+    realpath: async (p: string) => p, // identity: no symlinks in this unit
+    lstat: async () => ({ isSymbolicLink: () => false }),
+    writeFile: vi.fn(async () => {})
+  })
+
+  it('a path inside the project writes and replies with the show-image line', async () => {
+    const ledger = freshLedgerOwning()
+    const { guest, dbg } = makeGuest()
+    const origSend = dbg.sendCommand.bind(dbg)
+    dbg.sendCommand = async (m: string, p?: object) =>
+      m === 'Page.captureScreenshot' ? { data: Buffer.from('PNG').toString('base64') } : origSend(m, p)
+    const io = screenshotIO()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn(), screenshotIO: io }
+    const r = await driveBrowser(
+      { call: shotCall('shot.png'), ownerNodeId: OWNER, verified: true, resolve: { ...okResolve, projectCwd: '/proj' } },
+      deps
+    )
+    expect(r.ok).toBe(true)
+    expect(r.message).toContain('/proj/shot.png')
+    expect(r.message).toContain('show-image /proj/shot.png')
+    expect(io.writeFile).toHaveBeenCalled()
+  })
+
+  it('a traversal path is refused and never writes', async () => {
+    const ledger = freshLedgerOwning()
+    const { guest } = makeGuest()
+    const io = screenshotIO()
+    const deps: DriveDeps = { ledger, refs: new RefTable(), sessionFor: () => guest, revoke: vi.fn(), screenshotIO: io }
+    const r = await driveBrowser(
+      { call: shotCall('../../etc/x.png'), ownerNodeId: OWNER, verified: true, resolve: { ...okResolve, projectCwd: '/proj' } },
+      deps
+    )
+    expect(r).toEqual({ ok: false, message: 'browser: --screenshot path must be inside the project directory' })
+    expect(io.writeFile).not.toHaveBeenCalled()
+  })
+})
+
 describe('driveBrowser end-to-end refusals', () => {
   it('a discarded guest (sessionFor → null) is the named discard refusal', async () => {
     const ledger = freshLedgerOwning()

--- a/src/main/browser-drive.ts
+++ b/src/main/browser-drive.ts
@@ -43,8 +43,12 @@ import {
   type Driver,
   type CdpEventBus
 } from './browser-actions'
+import { browserScreenshot, type ScreenshotDeps } from './browser-screenshot'
+import { browserCookies } from './browser-cookies'
 import type { RefTable } from './browser-refs'
 import type { BrowserCall } from '../core/browser-verb'
+import type { BoardLogEntry } from '../shared/types'
+import { randomUUID } from 'node:crypto'
 
 /** The design's verbatim capability-off sentence. The last clause STOPS an agent burning a turn
  *  trying to enable it. Exported so the wiring and the tests share the one string. */
@@ -63,7 +67,18 @@ export const noDrivableNodeMessage = (id: string): string => `no drivable browse
  *  source, whether the source is control-capable, and the LIVE per-project capability value. Main
  *  makes the security DECISION from this; the renderer never runs a CDP command. */
 export type BrowserResolve =
-  | { ok: true; projectId: string; projectCwd?: string; sourceControlCapable: boolean; capabilityOn: boolean }
+  | {
+      ok: true
+      projectId: string
+      projectCwd?: string
+      sourceControlCapable: boolean
+      capabilityOn: boolean
+      /** The owner agent node's title and the browser node's title — what the renderer alone knows,
+       *  used ONLY to make the cookie-read trace human-readable (`from` / `title`). Never a security
+       *  input; the gate decides from projectId/capability/ownership. */
+      sourceTitle?: string
+      browserTitle?: string
+    }
   | { ok: false; refusal: string }
 
 /** The resolve round-trip's own short ceiling. Kept far under main's 120s pending-control budget and
@@ -157,15 +172,53 @@ export interface DriveDeps {
   sessionFor(browserNodeId: string): LiveGuest | null
   /** Detach + drop ownership + tombstone — invoked when a live capability read comes back OFF. */
   revoke(browserNodeId: string): void
+  /** Append one line to a project's board log, in-process (no IPC round-trip) — the cookie-read
+   *  trace (PR 9). Returns false when there is no reachable log or the write failed; the cookie read
+   *  is refused in that case (fail-closed). Absent ⇒ tracing is unavailable and `--cookies` refuses. */
+  appendBoardLog?(projectId: string, entry: BoardLogEntry): Promise<boolean>
+  /** The filesystem the screenshot path-jail + write use (PR 9). Absent ⇒ `--screenshot` refuses. */
+  screenshotIO?: ScreenshotDeps
+}
+
+/** What only the resolve knows, threaded to the two PR-9 actions: the project the trace/screenshot
+ *  belong to, its cwd (the screenshot jail root), and the titles the cookie trace reads. */
+interface RunContext {
+  browserNodeId: string
+  ownerNodeId: string
+  projectId: string
+  projectCwd?: string
+  sourceTitle?: string
+  browserTitle?: string
+}
+
+/** Build the cookie-read trace entry: it files under the OWNER agent node's card (`nodeId`), names
+ *  the owner in `from`, the domain in `to`, and the browser node in `title`. */
+function cookieTraceEntry(ctx: RunContext, domain: string): BoardLogEntry {
+  const from = ctx.sourceTitle || ctx.ownerNodeId
+  return {
+    id: randomUUID(),
+    ts: Date.now(),
+    author: { name: from, color: '#c2703d' },
+    nodeId: ctx.ownerNodeId,
+    kind: 'event',
+    event: {
+      type: 'agent-read-cookies',
+      from,
+      to: domain,
+      title: ctx.browserTitle || ctx.browserNodeId
+    }
+  }
 }
 
 async function runAction(
   call: BrowserCall,
   guest: LiveGuest,
   refs: RefTable,
-  nodeId: string
+  ctx: RunContext,
+  deps: DriveDeps
 ): Promise<ActionResult> {
   const a = call.action
+  const nodeId = ctx.browserNodeId
   // The pointer verbs need the viewport-refreshing capability; the session is a Driver at runtime.
   const driver = guest.session as Driver
   switch (a.kind) {
@@ -186,10 +239,18 @@ async function runAction(
       return browserScroll(driver, nodeId, a.where)
     case 'wait':
       return browserWait(guest.session, refs, nodeId, a.target, call.timeoutMs)
-    default:
-      // cookies/screenshot (PR 9) parse today but do not drive yet: a NAMED, non-retryable refusal,
-      // never a silent success.
-      return { ok: false, message: `browser: --${a.kind} is not available yet (it lands in a later update)` }
+    case 'screenshot':
+      if (!deps.screenshotIO) return { ok: false, message: 'browser: screenshots are unavailable in this build' }
+      return browserScreenshot(driver, nodeId, ctx.projectCwd, a.path, { full: call.full }, deps.screenshotIO)
+    case 'cookies':
+      // The trace goes through the board log; if there is no appender wired, the read cannot be
+      // recorded, so it must not happen (fail-closed, same as an append that returns false).
+      return browserCookies(guest.session, nodeId, a.domain, {
+        recordTrace: (domain) =>
+          deps.appendBoardLog
+            ? deps.appendBoardLog(ctx.projectId, cookieTraceEntry(ctx, domain))
+            : Promise.resolve(false)
+      })
   }
 }
 
@@ -217,8 +278,16 @@ export async function driveBrowser(
   }
   // guestPresent was true, so `guest` is non-null; the check keeps the type honest.
   if (!guest) return { ok: false, message: browserDiscardedMessage(input.call.node) }
+  const ctx: RunContext = {
+    browserNodeId: input.call.node,
+    ownerNodeId: input.ownerNodeId,
+    projectId: gate.entry.projectId,
+    projectCwd: input.resolve.ok ? input.resolve.projectCwd : undefined,
+    sourceTitle: input.resolve.ok ? input.resolve.sourceTitle : undefined,
+    browserTitle: input.resolve.ok ? input.resolve.browserTitle : undefined
+  }
   try {
-    return await runAction(input.call, guest, deps.refs, input.call.node)
+    return await runAction(input.call, guest, deps.refs, ctx, deps)
   } catch (e) {
     return { ok: false, message: e instanceof Error ? e.message : 'browser: the command failed' }
   }

--- a/src/main/browser-screenshot.test.ts
+++ b/src/main/browser-screenshot.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  resolveScreenshotPath,
+  browserScreenshot,
+  SCREENSHOT_OUTSIDE_PROJECT,
+  SCREENSHOT_NO_PROJECT_DIR
+} from './browser-screenshot'
+import type { Driver, LayoutMetrics } from './browser-actions'
+
+// The jail is proven against a REAL filesystem tree (constraint 8): a real project dir, a real
+// escaping symlink, a real sibling `proj-evil` — not a hand-rolled path model.
+let root: string
+let project: string
+let realpath: (p: string) => Promise<string>
+let lstat: (p: string) => Promise<{ isSymbolicLink(): boolean }>
+
+beforeEach(async () => {
+  root = await fsp.mkdtemp(path.join(os.tmpdir(), 'shot-'))
+  project = path.join(root, 'proj')
+  await fsp.mkdir(project, { recursive: true })
+  realpath = (p) => fsp.realpath(p)
+  lstat = (p) => fsp.lstat(p)
+})
+afterEach(async () => {
+  await fsp.rm(root, { recursive: true, force: true })
+})
+
+describe('resolveScreenshotPath — the jail (Task 9.1)', () => {
+  it('a relative path resolves against the project cwd', async () => {
+    const r = await resolveScreenshotPath(project, 'shot.png', { realpath, lstat })
+    expect(r).toEqual({ ok: true, abs: path.join(await fsp.realpath(project), 'shot.png') })
+  })
+
+  it('a relative path into a subdir stays inside the project', async () => {
+    await fsp.mkdir(path.join(project, 'sub'))
+    const r = await resolveScreenshotPath(project, 'sub/shot.png', { realpath, lstat })
+    expect(r).toEqual({ ok: true, abs: path.join(await fsp.realpath(project), 'sub', 'shot.png') })
+  })
+
+  it('a `..` traversal out of the project is refused', async () => {
+    const r = await resolveScreenshotPath(project, '../../etc/x.png', { realpath, lstat })
+    expect(r).toEqual({ ok: false, message: SCREENSHOT_OUTSIDE_PROJECT })
+  })
+
+  it('an absolute path outside the project is refused', async () => {
+    const r = await resolveScreenshotPath(project, '/tmp/x.png', { realpath, lstat })
+    expect(r).toEqual({ ok: false, message: SCREENSHOT_OUTSIDE_PROJECT })
+  })
+
+  it('a symlink whose PARENT resolves outside the project is refused', async () => {
+    // proj/escape -> root (outside proj). A path "escape/x.png" has parent proj/escape, which
+    // realpath resolves to `root` — outside the jail.
+    await fsp.symlink(root, path.join(project, 'escape'), 'dir')
+    const r = await resolveScreenshotPath(project, 'escape/x.png', { realpath, lstat })
+    expect(r).toEqual({ ok: false, message: SCREENSHOT_OUTSIDE_PROJECT })
+  })
+
+  it('the separator-terminated prefix stops a sibling `proj-evil` passing the `proj` check', async () => {
+    // A real sibling dir whose name is a prefix of the project dir must not be treated as inside it.
+    const evil = path.join(root, 'proj-evil')
+    await fsp.mkdir(evil)
+    // Point into it via a symlink parent so the raw resolve lands under proj but realpath escapes.
+    await fsp.symlink(evil, path.join(project, 'peer'), 'dir')
+    const r = await resolveScreenshotPath(project, 'peer/x.png', { realpath, lstat })
+    expect(r).toEqual({ ok: false, message: SCREENSHOT_OUTSIDE_PROJECT })
+  })
+
+  it('a final-component symlink pointing outside is refused (the write would follow it)', async () => {
+    // proj/shot.png is itself a symlink to root/loot.png — a plain writeFile would follow it out.
+    await fsp.writeFile(path.join(root, 'loot.png'), 'x')
+    await fsp.symlink(path.join(root, 'loot.png'), path.join(project, 'shot.png'))
+    const r = await resolveScreenshotPath(project, 'shot.png', { realpath, lstat })
+    expect(r).toEqual({ ok: false, message: SCREENSHOT_OUTSIDE_PROJECT })
+  })
+
+  it('an inline project with no cwd is a named refusal, not a crash', async () => {
+    const r = await resolveScreenshotPath(undefined, 'shot.png', { realpath, lstat })
+    expect(r).toEqual({ ok: false, message: SCREENSHOT_NO_PROJECT_DIR })
+  })
+})
+
+/** A Driver that answers the capture + a fixed viewport, and records every method it is sent. */
+function fakeDriver(metrics: Partial<LayoutMetrics> = {}): { s: Driver; sent: string[] } {
+  const m: LayoutMetrics = {
+    width: 1280,
+    height: 800,
+    scrollX: 0,
+    scrollY: 0,
+    contentWidth: 1280,
+    contentHeight: 5000,
+    ...metrics
+  }
+  const sent: string[] = []
+  const s: Driver = {
+    async send(method) {
+      sent.push(method)
+      if (method === 'Page.captureScreenshot') return { data: Buffer.from('PNGDATA').toString('base64') }
+      return {}
+    },
+    async refreshViewport() {
+      return m
+    }
+  }
+  return { s, sent }
+}
+
+describe('browserScreenshot — capture + jail + reply (Task 9.1)', () => {
+  it('writes inside the project and replies with the show-image line', async () => {
+    const { s } = fakeDriver()
+    const writeFile = vi.fn(async () => {})
+    const r = await browserScreenshot(s, 'browser-3', project, 'shot.png', {}, { realpath, lstat, writeFile })
+    const abs = path.join(await fsp.realpath(project), 'shot.png')
+    expect(r.ok).toBe(true)
+    expect(r.message).toBe(`wrote ${abs} (1280×800, 1 KB) — show it with: show-image ${abs}`)
+    expect(writeFile).toHaveBeenCalledWith(abs, expect.any(Buffer))
+  })
+
+  it('a traversal path never captures and never writes', async () => {
+    const { s, sent } = fakeDriver()
+    const writeFile = vi.fn(async () => {})
+    const r = await browserScreenshot(s, 'browser-3', project, '../../etc/x.png', {}, { realpath, lstat, writeFile })
+    expect(r).toEqual({ ok: false, message: SCREENSHOT_OUTSIDE_PROJECT })
+    expect(writeFile).not.toHaveBeenCalled()
+    expect(sent).not.toContain('Page.captureScreenshot') // refused BEFORE any CDP work
+  })
+
+  it('--full captures the whole content box and reports its dimensions', async () => {
+    const { s, sent } = fakeDriver({ contentHeight: 5000 })
+    const writeFile = vi.fn(async () => {})
+    const r = await browserScreenshot(s, 'browser-3', project, 'full.png', { full: true }, { realpath, lstat, writeFile })
+    expect(r.ok).toBe(true)
+    expect(r.message).toContain('1280×5000')
+    expect(sent).toContain('Page.captureScreenshot')
+  })
+
+  it('writes real bytes to a real file end-to-end', async () => {
+    const { s } = fakeDriver()
+    const writeFile = (p: string, d: Buffer) => fsp.writeFile(p, d)
+    const r = await browserScreenshot(s, 'browser-3', project, 'real.png', {}, { realpath, lstat, writeFile })
+    expect(r.ok).toBe(true)
+    const written = fs.readFileSync(path.join(project, 'real.png'))
+    expect(written.toString()).toBe('PNGDATA')
+  })
+})

--- a/src/main/browser-screenshot.ts
+++ b/src/main/browser-screenshot.ts
@@ -1,0 +1,134 @@
+/**
+ * `--screenshot <path>` (PR 9 Task 9.1). Capture the guest's page and write a PNG to a caller-named
+ * path — and that path is the whole risk: UNJAILED, this is an arbitrary-file-write primitive with
+ * attacker-chosen PNG content. So the path is DATA, resolved against the project cwd and refused if it
+ * escapes: `..`, an absolute path outside the project, or a symlink whose parent resolves outside.
+ *
+ * The jail is `fs.realpath` on the target's PARENT (the file does not exist yet — we are about to
+ * write it) compared to the canonicalized project root with a SEPARATOR-TERMINATED prefix, so
+ * `/proj-evil` never passes the `/proj` check. A final-component symlink (planted at the exact target
+ * name, pointing outside) is caught by an `lstat` belt. Only the format `png` is issued, and the
+ * `clip` comes from OUR OWN box model (the layout metrics), never from agent input.
+ *
+ * Main-side only (it holds a debugger and writes a real file); never Server Edition.
+ */
+import path from 'node:path'
+import type { Driver, ActionResult } from './browser-actions'
+
+/** Refused: the resolved path (or a symlink on the way to it) is not inside the project directory. */
+export const SCREENSHOT_OUTSIDE_PROJECT =
+  'browser: --screenshot path must be inside the project directory'
+
+/** Refused: this canvas/project has no working directory to jail a path to (an inline/no-cwd project). */
+export const SCREENSHOT_NO_PROJECT_DIR =
+  'browser: --screenshot needs a project folder (this canvas has none)'
+
+/** The filesystem the jail consults, injected so the traversal refusals are unit-testable without a
+ *  real tree (a fake `realpath` models a symlink whose parent resolves outside). */
+export interface ScreenshotPathDeps {
+  /** Canonicalize a path, following every symlink. Rejects when the path does not exist. */
+  realpath(p: string): Promise<string>
+  /** lstat WITHOUT following the final link — used to refuse a final-component symlink. */
+  lstat(p: string): Promise<{ isSymbolicLink(): boolean }>
+}
+
+export type ResolvedScreenshotPath = { ok: true; abs: string } | { ok: false; message: string }
+
+/**
+ * Resolve a caller-supplied screenshot path into a concrete absolute path INSIDE the project, or a
+ * named refusal. Pure of capture/IO beyond the injected `realpath`/`lstat`.
+ */
+export async function resolveScreenshotPath(
+  projectCwd: string | undefined,
+  rawPath: string,
+  deps: ScreenshotPathDeps
+): Promise<ResolvedScreenshotPath> {
+  if (!projectCwd) return { ok: false, message: SCREENSHOT_NO_PROJECT_DIR }
+  // A relative path resolves against the project cwd; an absolute path stays absolute (and is refused
+  // below unless it already lands inside the project).
+  const abs = path.resolve(projectCwd, rawPath)
+  const parent = path.dirname(abs)
+  let realBase: string
+  let realParent: string
+  try {
+    realBase = await deps.realpath(projectCwd)
+    // realpath the PARENT — following every link — so a symlink whose parent resolves outside the
+    // project is caught. The file itself does not exist yet, so we cannot realpath it directly.
+    realParent = await deps.realpath(parent)
+  } catch {
+    return { ok: false, message: SCREENSHOT_OUTSIDE_PROJECT }
+  }
+  // Separator-terminated prefix: `/proj-evil` must NOT pass the `/proj` check. Equality is the root
+  // itself (a file written directly in the project dir).
+  const baseWithSep = realBase.endsWith(path.sep) ? realBase : realBase + path.sep
+  if (realParent !== realBase && !realParent.startsWith(baseWithSep)) {
+    return { ok: false, message: SCREENSHOT_OUTSIDE_PROJECT }
+  }
+  const target = path.join(realParent, path.basename(abs))
+  // Belt against a final-component symlink planted at the exact target name pointing outside: a
+  // plain writeFile would follow it. A missing file (ENOENT) is the normal case and passes.
+  try {
+    const st = await deps.lstat(target)
+    if (st.isSymbolicLink()) return { ok: false, message: SCREENSHOT_OUTSIDE_PROJECT }
+  } catch {
+    /* does not exist yet — the expected case for a new screenshot */
+  }
+  return { ok: true, abs: target }
+}
+
+/** The IO the action needs beyond the jail: capture goes through the gated `Driver.send`; the file
+ *  write is injected so the action is testable without touching disk. */
+export interface ScreenshotDeps extends ScreenshotPathDeps {
+  writeFile(p: string, data: Buffer): Promise<void>
+}
+
+/**
+ * `--screenshot <path>` with the optional `--full true` modifier. Jail the path, measure the page
+ * from OUR layout metrics, capture a PNG (viewport by default, the whole content box with `--full`),
+ * write it, and reply with the path, dimensions, size, and the exact `show-image` line the agent can
+ * echo to put the shot on the canvas.
+ */
+export async function browserScreenshot(
+  s: Driver,
+  nodeId: string,
+  projectCwd: string | undefined,
+  rawPath: string,
+  opts: { full?: boolean },
+  deps: ScreenshotDeps
+): Promise<ActionResult> {
+  const resolved = await resolveScreenshotPath(projectCwd, rawPath, deps)
+  if (!resolved.ok) return { ok: false, message: resolved.message }
+  const m = await s.refreshViewport()
+  const full = opts.full === true
+  // The clip is OURS — from the measured page, never a caller field. Default is the visible viewport
+  // (no clip); --full captures the whole content box.
+  const params = full
+    ? {
+        format: 'png',
+        captureBeyondViewport: true,
+        clip: {
+          x: 0,
+          y: 0,
+          width: Math.round(m.contentWidth),
+          height: Math.round(m.contentHeight),
+          scale: 1
+        }
+      }
+    : { format: 'png' }
+  const res = (await s.send('Page.captureScreenshot', params)) as { data?: unknown }
+  const b64 = typeof res?.data === 'string' ? res.data : ''
+  if (!b64) return { ok: false, message: `browser: ${nodeId} returned no screenshot data` }
+  const buf = Buffer.from(b64, 'base64')
+  try {
+    await deps.writeFile(resolved.abs, buf)
+  } catch {
+    return { ok: false, message: `browser: could not write the screenshot to ${resolved.abs}` }
+  }
+  const w = full ? Math.round(m.contentWidth) : Math.round(m.width)
+  const h = full ? Math.round(m.contentHeight) : Math.round(m.height)
+  const kb = Math.max(1, Math.round(buf.length / 1024))
+  return {
+    ok: true,
+    message: `wrote ${resolved.abs} (${w}×${h}, ${kb} KB) — show it with: show-image ${resolved.abs}`
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
 import { join, resolve, posix } from 'path'
 import { startSessionNameSweep, displayNodeTitle } from '../core/session-name-sweep'
 import { readAgentSessionName, type AgentSessionNameDeps } from '../core/agent-session-name'
-import { readFile } from 'fs/promises'
+import { readFile, realpath as fsRealpath, lstat as fsLstat, writeFile as fsWriteFile } from 'fs/promises'
 import { existsSync, statSync } from 'fs'
 import { homedir, hostname } from 'os'
 import { randomUUID } from 'crypto'
@@ -1149,7 +1149,7 @@ app.whenReady().then(async () => {
       return { kind: 'unsupported' }
     }
   }
-  registerBoardLogHandlers(corePlatform, boardLogRouter)
+  const boardLog = registerBoardLogHandlers(corePlatform, boardLogRouter)
   registerLogHandlers(corePlatform, logBuffer, () => settingsStore.get().debugLogPanel)
 
   // Agent messaging (the `send`/`reply` control verbs). Canvas.tsx forwards the validated verb
@@ -2530,6 +2530,8 @@ app.whenReady().then(async () => {
         projectCwd?: string
         sourceControlCapable?: boolean
         capabilityOn?: boolean
+        sourceTitle?: string
+        browserTitle?: string
       }
     ) => {
       const resolve = pendingBrowserResolve.get(payload.requestId)
@@ -2542,7 +2544,9 @@ app.whenReady().then(async () => {
               projectId: payload.projectId ?? '',
               projectCwd: payload.projectCwd,
               sourceControlCapable: payload.sourceControlCapable === true,
-              capabilityOn: payload.capabilityOn === true
+              capabilityOn: payload.capabilityOn === true,
+              sourceTitle: payload.sourceTitle,
+              browserTitle: payload.browserTitle
             }
           : { ok: false, refusal: payload.refusal ?? 'source node is not on an open canvas' }
       )
@@ -2551,7 +2555,7 @@ app.whenReady().then(async () => {
   // Ask the renderer to resolve a source node — the `ask` closure `resolveBrowserTarget` races
   // against its own 2s timeout. The renderer NEVER runs a CDP command; it answers existence + project
   // + capability only.
-  const askRendererResolve = (sourceNodeId: string): Promise<BrowserResolve> => {
+  const askRendererResolve = (sourceNodeId: string, browserNodeId: string): Promise<BrowserResolve> => {
     const w = getMainWindow()
     if (!w || w.isDestroyed()) {
       return Promise.resolve({ ok: false, refusal: 'source node is not on an open canvas' })
@@ -2560,7 +2564,9 @@ app.whenReady().then(async () => {
     const answered = new Promise<BrowserResolve>((resolve) => {
       pendingBrowserResolve.set(requestId, resolve)
     })
-    w.webContents.send(IPC.browserControlResolve, { requestId, sourceNodeId })
+    // `browserNodeId` rides along so the renderer can report the browser node's title for the cookie
+    // trace; it is NOT part of the security decision (owner + capability + allowlist stay main-side).
+    w.webContents.send(IPC.browserControlResolve, { requestId, sourceNodeId, browserNodeId })
     return answered.finally(() => pendingBrowserResolve.delete(requestId))
   }
   // The `browser` verb's whole main-side drive: parse (pure), identity belt, resolve round-trip, then
@@ -2576,14 +2582,24 @@ app.whenReady().then(async () => {
     // Identity is checked first (the belt to hook-server's verified-only gate for STRICT verbs): a
     // non-verified caller learns nothing, and no resolve round-trip is even made.
     if (!verified) return { ok: false, error: STRICT_CONTROL_REFUSAL, message: STRICT_CONTROL_REFUSAL }
-    const resolve = await resolveBrowserTarget(parsed.node, () => askRendererResolve(nodeId))
+    const resolve = await resolveBrowserTarget(parsed.node, () => askRendererResolve(nodeId, parsed.node))
     const result = await driveBrowser(
       { call: parsed, ownerNodeId: nodeId, verified, resolve },
       {
         ledger: browserLedger,
         refs: browserRefs,
         sessionFor: browserSessionFor,
-        revoke: (id) => pushBrowserLeases(revokeBrowserNode(id, browserRevocation, { userStopped: true }))
+        revoke: (id) => pushBrowserLeases(revokeBrowserNode(id, browserRevocation, { userStopped: true })),
+        // The cookie-read trace (PR 9): appended in-process, BEFORE the read, through the same board-log
+        // routing the IPC handler uses. A false return (no reachable log / write failed) refuses the read.
+        appendBoardLog: (projectId, entry) => boardLog.append(projectId, entry),
+        // The screenshot jail + write (PR 9). realpath/lstat canonicalize the project-dir jail; writeFile
+        // lands the PNG. All node:fs — never a caller path reaching CDP.
+        screenshotIO: {
+          realpath: (p) => fsRealpath(p),
+          lstat: (p) => fsLstat(p),
+          writeFile: (p, d) => fsWriteFile(p, d)
+        }
       }
     )
     return result.ok

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -6392,14 +6392,16 @@ export function Canvas() {
   // drive — and we NEVER run a CDP command. Main makes the security decision (owner + capability +
   // the CDP allowlist) and does the driving itself (browser-drive.ts / browser-actions.ts).
   useEffect(() => {
-    return api.onBrowserControlResolve(({ requestId, sourceNodeId }) => {
+    return api.onBrowserControlResolve(({ requestId, sourceNodeId, browserNodeId }) => {
       const { projects, activeProjectId } = useProjects.getState()
       const route = routeControlSource(projects, activeProjectId, sourceNodeId)
       // Bring the owning project's canvas up so main can find the live guest (needsLiveCanvas is true
       // for `browser`). A closed/blocked/unknown owner just yields the refusal below.
       if (route.kind === 'switch' || route.kind === 'reopen') travelToProjectRef.current(route.projectId)
       const owner = projects.find((p) => p.nodes.some((n) => n.id === sourceNodeId))
-      const answer = answerBrowserResolve(owner as unknown as BrowserResolveProject | undefined, sourceNodeId)
+      // `browserNodeId` is passed so the answer can carry the browser node's title for the cookie
+      // trace; the security decision main makes never reads it.
+      const answer = answerBrowserResolve(owner as unknown as BrowserResolveProject | undefined, sourceNodeId, browserNodeId)
       api.sendBrowserControlResolveResult({ requestId, ...answer })
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/renderer/components/kanban/BoardLogPanel.tsx
+++ b/src/renderer/components/kanban/BoardLogPanel.tsx
@@ -16,7 +16,7 @@ interface BoardLogPanelProps {
 /** The activity sentence WITHOUT the leading author name — the name is rendered separately in
  *  the author's color, so the feed reads like Trello (colored actor + muted action). column-*
  *  events carry no nodeId and so never reach a card-scoped feed; kept for completeness. */
-function eventBody(e: BoardLogEvent): string {
+export function eventBody(e: BoardLogEvent): string {
   switch (e.type) {
     case 'card-created':
       return `created this card in ${e.to ?? 'Ungrouped'}`
@@ -42,6 +42,10 @@ function eventBody(e: BoardLogEvent): string {
       return `removed the priority`
     case 'agent-message':
       return `sent a message to ${e.to ?? 'another node'} (${e.title ?? 'unknown outcome'})`
+    case 'agent-read-cookies':
+      // A loud, human-visible line for a cookie read (the whole point of the trace). `from` names the
+      // agent, `to` the domain it read; `title` names the browser node it drove.
+      return `read cookies for ${e.to ?? 'a site'}${e.title ? ` via ${e.title}` : ''}`
     default:
       // A newer peer may write event types this build doesn't know — show them neutrally.
       return `updated this card`

--- a/src/renderer/components/kanban/board-log-panel.test.tsx
+++ b/src/renderer/components/kanban/board-log-panel.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { eventBody } from './BoardLogPanel'
+import type { BoardLogEvent } from '@shared/types'
+
+describe('eventBody — the activity sentence', () => {
+  it('renders the new agent-read-cookies type as a loud, domain-naming line (Task 9.2)', () => {
+    const e: BoardLogEvent = { type: 'agent-read-cookies', from: 'claude-1', to: 'github.com', title: 'browser-3' }
+    expect(eventBody(e)).toBe('read cookies for github.com via browser-3')
+  })
+
+  it('names the domain even without a browser title', () => {
+    expect(eventBody({ type: 'agent-read-cookies', from: 'claude-1', to: 'github.com' })).toBe(
+      'read cookies for github.com'
+    )
+  })
+
+  it('a known peer type still renders its own sentence (not the neutral fallback)', () => {
+    // Guards against the new case accidentally swallowing a sibling type.
+    expect(eventBody({ type: 'agent-message', to: 'claude-2', title: 'delivered' })).toBe(
+      'sent a message to claude-2 (delivered)'
+    )
+  })
+
+  it('an unknown future type falls back neutrally', () => {
+    expect(eventBody({ type: 'something-new' as BoardLogEvent['type'] })).toBe('updated this card')
+  })
+})

--- a/src/renderer/lib/controlRouting.test.ts
+++ b/src/renderer/lib/controlRouting.test.ts
@@ -147,8 +147,28 @@ describe('answerBrowserResolve — the renderer answers ONLY what it alone knows
       projectId: 'proj-1',
       projectCwd: '/home/u/p',
       sourceControlCapable: true,
-      capabilityOn: true
+      capabilityOn: true,
+      sourceTitle: '',
+      browserTitle: ''
     })
+  })
+
+  it('reports the source and browser node titles for the cookie trace (PR 9)', () => {
+    const granted = proj({
+      agentBrowserControl: true,
+      capabilityAck: { agentBrowserControl: 'kept' },
+      nodes: [
+        { id: 'claude-1', agentId: 'claude', title: 'Research agent' },
+        { id: 'browser-3', title: 'GitHub' }
+      ]
+    })
+    expect(answerBrowserResolve(granted, 'claude-1', 'browser-3')).toMatchObject({
+      ok: true,
+      sourceTitle: 'Research agent',
+      browserTitle: 'GitHub'
+    })
+    // An unknown browser node is an empty string (main falls back to the id), never a throw.
+    expect(answerBrowserResolve(granted, 'claude-1', 'browser-nope')).toMatchObject({ browserTitle: '' })
   })
 
   it('a switch that is ON in the file but only PENDING (never kept) is not on — a pending notice is a refusal', () => {

--- a/src/renderer/lib/controlRouting.ts
+++ b/src/renderer/lib/controlRouting.ts
@@ -138,6 +138,9 @@ export function sourceIsControlCapable(agentId: unknown): boolean {
 export interface BrowserResolveNode {
   id: string
   agentId?: unknown
+  /** The node's display title — reported so main can make the cookie-read trace human-readable
+   *  (PR 9). Never a security input. */
+  title?: string
 }
 export interface BrowserResolveProject {
   id: string
@@ -154,17 +157,23 @@ export type BrowserResolveAnswer =
       projectCwd?: string
       sourceControlCapable: boolean
       capabilityOn: boolean
+      /** The owner (source) agent node's title and the driven browser node's title — for the cookie
+       *  trace only. Empty string when unknown; main falls back to the node id. */
+      sourceTitle: string
+      browserTitle: string
     }
 
 export function answerBrowserResolve(
   project: BrowserResolveProject | undefined,
-  sourceNodeId: string
+  sourceNodeId: string,
+  browserNodeId?: string
 ): BrowserResolveAnswer {
   // No open project owns the source, or the node is not on its canvas: a named, non-revoking
   // refusal. (Same class as every other verb's "source node is not on an open canvas".)
   if (!project) return { ok: false, refusal: 'source node is not on an open canvas' }
   const node = project.nodes.find((n) => n.id === sourceNodeId)
   if (!node) return { ok: false, refusal: 'source node is not on an open canvas' }
+  const browserNode = browserNodeId ? project.nodes.find((n) => n.id === browserNodeId) : undefined
   return {
     ok: true,
     projectId: project.id,
@@ -173,7 +182,9 @@ export function answerBrowserResolve(
     // LIVE read — the drive-time capability check the whole feature's safety rests on. A project.json
     // hand-edit that flipped the switch off is reflected here the next time an agent drives, which is
     // exactly drive time.
-    capabilityOn: projectCapabilityGrantedFor(project, 'agentBrowserControl')
+    capabilityOn: projectCapabilityGrantedFor(project, 'agentBrowserControl'),
+    sourceTitle: typeof node.title === 'string' ? node.title : '',
+    browserTitle: typeof browserNode?.title === 'string' ? browserNode.title : ''
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -435,6 +435,12 @@ export interface BoardLogEvent {
      *  is the delivery's outcome kind — a trace that cannot answer "did it land?" answers the only
      *  question anyone asks it with silence. Written by `agent-message-trace.recordDelivery`. */
     | 'agent-message'
+    /** An agent read a site's cookies through `browser --cookies` — a data-exfiltration surface the
+     *  owner allowed but that MUST be loudly traced (PR 9 Task 9.2/9.3). `from` = the owner agent
+     *  node's title, `to` = the domain read, `title` = the browser node's title; `nodeId` = the owner
+     *  agent node so it files under that agent's card. Written BEFORE the read (fail-closed): a cookie
+     *  read that happened but was not recorded is the one outcome this trace exists to prevent. */
+    | 'agent-read-cookies'
   from?: string
   to?: string
   /** Column title for column-added/deleted; card title for card-created; outcome for agent-message. */
@@ -2592,9 +2598,12 @@ export interface NodeTerminalApi {
   /** The `browser` verb resolve round-trip (S8 PR 7): main asks the renderer to resolve a source
    *  node's owning project, control-capability and the LIVE per-project capability value. The
    *  renderer answers over `sendBrowserControlResolveResult` and NEVER runs a CDP command. */
-  onBrowserControlResolve(listener: (req: { requestId: string; sourceNodeId: string }) => void): () => void
+  onBrowserControlResolve(
+    listener: (req: { requestId: string; sourceNodeId: string; browserNodeId?: string }) => void
+  ): () => void
   /** Answer a browser-control resolve. `ok:false` carries a named refusal; `ok:true` carries the
-   *  facts main turns into its own (owner + capability + CDP-gate) decision. */
+   *  facts main turns into its own (owner + capability + CDP-gate) decision. `sourceTitle`/
+   *  `browserTitle` are for the cookie-read trace only (PR 9) — never a security input. */
   sendBrowserControlResolveResult(payload: {
     requestId: string
     ok: boolean
@@ -2603,6 +2612,8 @@ export interface NodeTerminalApi {
     projectCwd?: string
     sourceControlCapable?: boolean
     capabilityOn?: boolean
+    sourceTitle?: string
+    browserTitle?: string
   }): void
   /** Agent messaging (the `send`/`reply` control verbs): run one delivery in main, where the
    *  scope check, the per-project switch, flow control and the pane probes all live. The reply is


### PR DESCRIPTION
S8 PR 9 of #112 (@Corvin). Adds the last two `browser` verbs — `--screenshot` and
`--cookies` — and the audit trace that makes a cookie read safe to allow. Both
drive through the existing `gateBrowserDrive` + drive-time-capability + `checkCdpCommand`
default-deny path; no new bypass, and the structural "all of src/main sendCommand →
checkCdpCommand" test stays green over the new send sites. Verified-only,
per-project-gated, tombstone-honored, same as the other verbs.

## Tasks → commits
- **9.2** board-log `'agent-read-cookies'` + main-side append → `85eff0ac`
- **9.1** `--screenshot` jail + `Page.captureScreenshot` allowlist entry → `5b5ed4cf`
- **9.4** cookie-write set recorded (allowlist half) → `5b5ed4cf`; reachability guard → `06fe9d79`
- **9.3** `--cookies` — allowed, loudly traced → `9d27b0ab`
- wiring: drive both verbs through the gate + resolve node titles → `06fe9d79`

## New allowlisted CDP methods (each with a validator)
- **`Page.captureScreenshot`** — validator: **yes**. Format pinned to `png` (no
  jpeg/pdf surface); `captureBeyondViewport` must be boolean; a `clip`, if present,
  must be a numeric rectangle (x/y/width/height numbers, optional numeric scale) —
  a structured/garbage clip is refused. The clip is always OUR OWN box model; the
  caller path never reaches CDP (it is jailed and only names the output file).
- **`Network.getCookies`** was already admitted (validator: **yes** — requires a
  non-empty `urls` list, so a read always names a domain). This PR is the first to
  reach it, from `--cookies`.

## Cookie WRITEs — listed & unreachable (Task 9.4)
`COOKIE_WRITE_METHODS` (new, in `browser-cdp-allowlist.ts`) records the jar-mutating
set in one place: `Network.setCookie`, `Network.setCookies`, `Network.deleteCookies`,
`Network.clearBrowserCookies`, `Storage.setCookies`, `Storage.clearCookies`.
`Network.setCookie` **stays admitted** by the ALLOW table (owner decision 5, so a
future write verb inherits a validated entry) but **no verb reaches any of them in
v1**. Guard test: **`browser-cookie-write-guard.test.ts`** →
*"enumerates every action and records the CDP methods each emits; the write
intersection is empty"* — it drives every `BROWSER_ACTION_KEYS` action through
`driveBrowser` with a recording session and asserts the union of emitted methods ∩
the write set is `[]` (and positively, that the cookie READ path does reach
`Network.getCookies`). A write verb needs a design nobody has done and a LOUDER
trace than a read (a write is persistent and silent).

## Screenshot jail (Task 9.1)
The caller path is data: resolved against the project cwd, `fs.realpath` on the
target's PARENT compared to the canonicalized project root with a
separator-terminated prefix (`/proj-evil` never passes `/proj`), plus an lstat belt
against a final-component symlink. Tests in **`browser-screenshot.test.ts`** (real
temp-fs tree): *a `..` traversal out of the project is refused*, *an absolute path
outside the project is refused*, *a symlink whose PARENT resolves outside the
project is refused*, *the separator-terminated prefix stops a sibling `proj-evil`
passing the `proj` check*, *a final-component symlink pointing outside is refused*,
*a relative path resolves against the project cwd*, plus a real end-to-end write.
End-to-end through the gate: **`browser-drive.test.ts`** → *"a traversal path is
refused and never writes"*.

## Cookie-read trace (Task 9.3)
The trace is appended **before** the read, fail-closed: a read that cannot be
durably recorded does not happen. Test: **`browser-cookies.test.ts`** → *"the trace
is appended BEFORE the read; if the append fails, the read does not happen"* and
*"the trace runs strictly before the read (ordering, not just presence)"*; the
reply names the recording: *"the reply tells the agent it was recorded"*
(`read 4 cookies for github.com — this was recorded in the project's activity
log.`). `getAllCookies` is unreachable — *"the read NAMES a domain (a SHAPE
restriction, not a ban)"*. End-to-end through the gate: **`browser-drive.test.ts`**
→ *"the owner reads cookies, and the board-log trace is appended before the read"*
and *"if the trace cannot be recorded, the read does not happen (fail-closed)"*.

## Mutation checks (5 introduced / 5 caught)
1. cookie read skips the fail-closed trace gate → `browser-drive.test.ts` reddens ✅
2. screenshot jail prefix check removed → `browser-screenshot.test.ts` reddens (3 cases) ✅
3. an action reaches `Network.setCookie` → write-guard reddens ✅
4. screenshot allowlist accepts any format → `browser-cdp-allowlist.test.ts` reddens ✅
5. cookie trace moved AFTER the read → ordering tests redden ✅

## Tests
`npm run typecheck` clean; full `npx vitest run` = 7211 passed, 12 skipped, 1
unrelated real-TTY flake (`sessionRename.realtty.test.ts`, passes in isolation —
touches no file in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
