### PR TITLE
feat(keybindings): shared command registry and matching engine

### DIFF
--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { COMMAND_DEFINITIONS, COMMANDS_BY_ID, isCommandId } from './keybindings'
+import { parseShortcut } from './shortcut'
+
+describe('registry invariants', () => {
+  it('has unique ids and a map that covers them all', () => {
+    const ids = COMMAND_DEFINITIONS.map((d) => d.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(COMMANDS_BY_ID.size).toBe(ids.length)
+    for (const d of COMMAND_DEFINITIONS) expect(COMMANDS_BY_ID.get(d.id)).toBe(d)
+  })
+
+  it('every default binding parses, and keyed defaults carry a key', () => {
+    for (const d of COMMAND_DEFINITIONS) {
+      for (const s of [...d.defaultBindings.darwin, ...d.defaultBindings.other]) {
+        const p = parseShortcut(s)
+        if (d.allowHoldChord) continue
+        expect(p.key, `${d.id}: ${s}`).not.toBeNull()
+      }
+    }
+  })
+
+  it('pins the defaults that PR 2 will wire (behavior contract)', () => {
+    expect(COMMANDS_BY_ID.get('app.commandPalette')?.defaultBindings.darwin).toEqual(['Cmd+K'])
+    expect(COMMANDS_BY_ID.get('node.close')?.defaultBindings.other).toEqual(['Cmd+W'])
+    expect(COMMANDS_BY_ID.get('canvas.redo')?.defaultBindings.other).toEqual(['Cmd+Shift+Z', 'Cmd+Y'])
+    expect(COMMANDS_BY_ID.get('terminal.copySelection')?.defaultBindings.other).toEqual([
+      'Cmd+Shift+C', 'Ctrl+Insert'
+    ])
+    expect(COMMANDS_BY_ID.get('speech.dictation')?.defaultBindings.darwin).toEqual(['Cmd+Alt'])
+    expect(COMMANDS_BY_ID.get('canvas.fitAll')?.defaultBindings.darwin).toEqual([])
+  })
+
+  it('isCommandId accepts known ids and rejects unknowns', () => {
+    expect(isCommandId('node.newTerminal')).toBe(true)
+    expect(isCommandId('node.selfDestruct')).toBe(false)
+  })
+})

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -27,6 +27,7 @@ describe('registry invariants', () => {
     expect(COMMANDS_BY_ID.get('terminal.copySelection')?.defaultBindings.other).toEqual([
       'Cmd+Shift+C', 'Ctrl+Insert'
     ])
+    expect(COMMANDS_BY_ID.get('canvas.deleteSelection')?.defaultBindings.other).toEqual(['Delete', 'Backspace'])
     expect(COMMANDS_BY_ID.get('speech.dictation')?.defaultBindings.darwin).toEqual(['Cmd+Alt'])
     expect(COMMANDS_BY_ID.get('canvas.fitAll')?.defaultBindings.darwin).toEqual([])
   })

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -285,11 +285,18 @@ describe('resolveCommandForKeyEvent', () => {
     expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'Enter' }), ctx(), {}, true))
       .toBeNull()
   })
-  it('registry order breaks cross-bucket identity ties deterministically', () => {
-    // Cmd+F sits on terminal.find (terminal bucket); an app-bucket override may share it.
+  it('terminal focus admits terminal scope over a canvas command sharing the chord', () => {
+    // Cmd+F sits on terminal.find; a canvas-scope override claims the same chord. The
+    // terminal-focus gate drops canvas.fitAll before its bindings are ever read — this
+    // witnesses the gate, NOT registry order (that is the tie test below).
     const o = { 'canvas.fitAll': ['Cmd+F'] }
     expect(resolveCommandForKeyEvent(
       ev({ metaKey: true, key: 'f' }), ctx({ terminal: true }), o, true
     )).toBe('terminal.find')
+  })
+  it('first matching definition in registry source order wins a tie', () => {
+    // Deliberately unsanitized colliding override — the resolver must order the tie deterministically.
+    const o = { 'canvas.redo': ['Cmd+Z'] }
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'z' }), ctx(), o, true)).toBe('canvas.undo')
   })
 })

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -3,7 +3,10 @@ import {
   COMMAND_DEFINITIONS,
   COMMANDS_BY_ID,
   isCommandId,
-  normalizeBindingForCommand
+  normalizeBindingForCommand,
+  getEffectiveBindings,
+  bindingIdentity,
+  findKeybindingConflicts
 } from './keybindings'
 import { parseShortcut } from './shortcut'
 
@@ -91,5 +94,58 @@ describe('normalizeBindingForCommand', () => {
         }
       }
     }
+  })
+})
+
+describe('getEffectiveBindings', () => {
+  it('returns platform defaults with no override', () => {
+    expect(getEffectiveBindings('terminal.copySelection', {}, true)).toEqual(['Cmd+C'])
+    expect(getEffectiveBindings('terminal.copySelection', {}, false)).toEqual([
+      'Cmd+Shift+C', 'Ctrl+Insert'
+    ])
+  })
+  it('an override replaces defaults; [] disables', () => {
+    const o = { 'node.newTerminal': ['Cmd+Shift+T'], 'canvas.undo': [] as string[] }
+    expect(getEffectiveBindings('node.newTerminal', o, true)).toEqual(['Cmd+Shift+T'])
+    expect(getEffectiveBindings('canvas.undo', o, true)).toEqual([])
+  })
+})
+
+describe('bindingIdentity', () => {
+  it('resolves Cmd and literal Ctrl to the same identity on non-mac', () => {
+    expect(bindingIdentity('Cmd+K', false)).toBe(bindingIdentity('Ctrl+K', false))
+  })
+  it('keeps them distinct on mac', () => {
+    expect(bindingIdentity('Cmd+K', true)).not.toBe(bindingIdentity('Ctrl+K', true))
+  })
+})
+
+describe('findKeybindingConflicts', () => {
+  it('reports nothing for pure defaults', () => {
+    expect(findKeybindingConflicts({}, true)).toEqual([])
+    expect(findKeybindingConflicts({}, false)).toEqual([])
+  })
+  it('the shipped default table is conflict-free even under full scrutiny', () => {
+    expect(findKeybindingConflicts({}, true, { includeDefaults: true })).toEqual([])
+    expect(findKeybindingConflicts({}, false, { includeDefaults: true })).toEqual([])
+  })
+  it('flags an override colliding with a default in the same bucket', () => {
+    const conflicts = findKeybindingConflicts({ 'canvas.fitAll': ['Cmd+K'] }, true)
+    expect(conflicts).toEqual([
+      { binding: 'Cmd+K', commandIds: ['app.commandPalette', 'canvas.fitAll'] }
+    ])
+  })
+  it('flags a cross-spelling collision on non-mac (Ctrl+K vs Cmd+K)', () => {
+    const conflicts = findKeybindingConflicts({ 'canvas.fitAll': ['Ctrl+K'] }, false)
+    expect(conflicts.map((c) => c.commandIds)).toEqual([['app.commandPalette', 'canvas.fitAll']])
+  })
+  it('does not flag collisions across buckets', () => {
+    // terminal.find is Cmd+F in the terminal bucket; an app-bucket Cmd+F is legal.
+    expect(findKeybindingConflicts({ 'canvas.fitAll': ['Cmd+F'] }, true)).toEqual([])
+  })
+  it('two disabled commands never conflict', () => {
+    expect(
+      findKeybindingConflicts({ 'canvas.fitAll': [], 'canvas.groupSelection': [] }, true)
+    ).toEqual([])
   })
 })

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -118,6 +118,14 @@ describe('bindingIdentity', () => {
   it('keeps them distinct on mac', () => {
     expect(bindingIdentity('Cmd+K', true)).not.toBe(bindingIdentity('Ctrl+K', true))
   })
+  it('collapses alias key spellings onto one identity', () => {
+    expect(bindingIdentity('Cmd+Esc', true)).toBe(bindingIdentity('Cmd+Escape', true))
+    expect(bindingIdentity('Cmd+Return', true)).toBe(bindingIdentity('Cmd+Enter', true))
+  })
+  it('still separates a modifier from a bare key, and a hold chord from a keyed one', () => {
+    expect(bindingIdentity('Cmd+Delete', true)).not.toBe(bindingIdentity('Delete', true))
+    expect(bindingIdentity('Cmd+Alt', true)).not.toBe(bindingIdentity('Cmd+Alt+D', true))
+  })
 })
 
 describe('findKeybindingConflicts', () => {
@@ -133,6 +141,16 @@ describe('findKeybindingConflicts', () => {
     const conflicts = findKeybindingConflicts({ 'canvas.fitAll': ['Cmd+K'] }, true)
     expect(conflicts).toEqual([
       { binding: 'Cmd+K', commandIds: ['app.commandPalette', 'canvas.fitAll'] }
+    ])
+  })
+  it('reports the canonical spelling, not the override as written', () => {
+    expect(findKeybindingConflicts({ 'canvas.fitAll': ['cmd+k'] }, true)).toEqual([
+      { binding: 'Cmd+K', commandIds: ['app.commandPalette', 'canvas.fitAll'] }
+    ])
+    // canvas.fitAll precedes node.newTerminal in the registry, so the override is the
+    // entry-creating spelling here — the assertion above cannot see the canonicalization.
+    expect(findKeybindingConflicts({ 'canvas.fitAll': ['cmd+t'] }, true)).toEqual([
+      { binding: 'Cmd+T', commandIds: ['canvas.fitAll', 'node.newTerminal'] }
     ])
   })
   it('flags a cross-spelling collision on non-mac (Ctrl+K vs Cmd+K)', () => {

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { COMMAND_DEFINITIONS, COMMANDS_BY_ID, isCommandId } from './keybindings'
+import {
+  COMMAND_DEFINITIONS,
+  COMMANDS_BY_ID,
+  isCommandId,
+  normalizeBindingForCommand
+} from './keybindings'
 import { parseShortcut } from './shortcut'
 
 describe('registry invariants', () => {
@@ -35,5 +40,56 @@ describe('registry invariants', () => {
   it('isCommandId accepts known ids and rejects unknowns', () => {
     expect(isCommandId('node.newTerminal')).toBe(true)
     expect(isCommandId('node.selfDestruct')).toBe(false)
+  })
+})
+
+const def = (id: string) => {
+  const d = COMMANDS_BY_ID.get(id as never)
+  if (!d) throw new Error(`missing ${id}`)
+  return d
+}
+
+describe('normalizeBindingForCommand', () => {
+  it('canonicalizes token order and casing', () => {
+    const r = normalizeBindingForCommand(def('node.newTerminal'), 'shift+t+cmd', true)
+    expect(r).toEqual({ ok: true, value: 'Cmd+Shift+T' })
+  })
+  it('rejects a chord with no modifier for a normal command', () => {
+    const r = normalizeBindingForCommand(def('node.newTerminal'), 'T', true)
+    expect(r.ok).toBe(false)
+  })
+  it('rejects shift-only chords (stealing typed text)', () => {
+    expect(normalizeBindingForCommand(def('node.newTerminal'), 'Shift+T', true).ok).toBe(false)
+  })
+  it('allows safe bare keys only with allowBareKey', () => {
+    expect(normalizeBindingForCommand(def('canvas.deleteSelection'), 'Delete', true)).toEqual({
+      ok: true, value: 'Delete'
+    })
+    expect(normalizeBindingForCommand(def('canvas.deleteSelection'), 'X', true).ok).toBe(false)
+    expect(normalizeBindingForCommand(def('node.newTerminal'), 'Delete', true).ok).toBe(false)
+  })
+  it('allows hold chords only with allowHoldChord', () => {
+    expect(normalizeBindingForCommand(def('speech.dictation'), 'Cmd+Alt', true)).toEqual({
+      ok: true, value: 'Cmd+Alt'
+    })
+    expect(normalizeBindingForCommand(def('node.newTerminal'), 'Cmd+Alt', true).ok).toBe(false)
+  })
+  it('rejects Cmd combined with literal Ctrl on non-mac', () => {
+    expect(normalizeBindingForCommand(def('node.newTerminal'), 'Cmd+Ctrl+T', false).ok).toBe(false)
+    expect(normalizeBindingForCommand(def('node.newTerminal'), 'Cmd+Ctrl+T', true).ok).toBe(true)
+  })
+  it('rejects garbage', () => {
+    expect(normalizeBindingForCommand(def('node.newTerminal'), '', true).ok).toBe(false)
+    expect(normalizeBindingForCommand(def('node.newTerminal'), '+++', true).ok).toBe(false)
+  })
+  it('every default in the registry survives its own validation', () => {
+    for (const d of COMMAND_DEFINITIONS) {
+      for (const isMac of [true, false]) {
+        for (const s of d.defaultBindings[isMac ? 'darwin' : 'other']) {
+          const r = normalizeBindingForCommand(d, s, isMac)
+          expect(r, `${d.id}: ${s} (isMac=${isMac})`).toEqual({ ok: true, value: s })
+        }
+      }
+    }
   })
 })

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -6,7 +6,8 @@ import {
   normalizeBindingForCommand,
   getEffectiveBindings,
   bindingIdentity,
-  findKeybindingConflicts
+  findKeybindingConflicts,
+  sanitizeKeybindingOverrides
 } from './keybindings'
 import { parseShortcut } from './shortcut'
 
@@ -165,5 +166,63 @@ describe('findKeybindingConflicts', () => {
     expect(
       findKeybindingConflicts({ 'canvas.fitAll': [], 'canvas.groupSelection': [] }, true)
     ).toEqual([])
+  })
+})
+
+describe('sanitizeKeybindingOverrides', () => {
+  it('passes through a clean override map', () => {
+    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['Cmd+Shift+T'] }, true)
+    expect(r).toEqual({ overrides: { 'node.newTerminal': ['Cmd+Shift+T'] }, warnings: [] })
+  })
+  it('canonicalizes spellings', () => {
+    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['shift+cmd+t'] }, true)
+    expect(r.overrides).toEqual({ 'node.newTerminal': ['Cmd+Shift+T'] })
+  })
+  it('drops unknown ids with a warning, keeps the rest', () => {
+    const r = sanitizeKeybindingOverrides(
+      { 'node.selfDestruct': ['Cmd+X'], 'canvas.undo': [] }, true
+    )
+    expect(r.overrides).toEqual({ 'canvas.undo': [] })
+    expect(r.warnings.some((w) => w.includes('node.selfDestruct'))).toBe(true)
+  })
+  it('drops an invalid binding string but keeps valid siblings', () => {
+    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['Cmd+Shift+T', 'T'] }, true)
+    expect(r.overrides).toEqual({ 'node.newTerminal': ['Cmd+Shift+T'] })
+    expect(r.warnings.length).toBe(1)
+  })
+  it('a non-empty list that is entirely invalid falls back to defaults, not disabled', () => {
+    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['T', '+++'] }, true)
+    expect(r.overrides).toEqual({})
+    expect(r.warnings.length).toBeGreaterThan(0)
+  })
+  it('an explicit empty array still means disabled', () => {
+    expect(sanitizeKeybindingOverrides({ 'canvas.undo': [] }, true).overrides).toEqual({
+      'canvas.undo': []
+    })
+  })
+  it('strips BOTH sides of a conflicting override pair, naming the titles', () => {
+    const r = sanitizeKeybindingOverrides(
+      { 'canvas.fitAll': ['Cmd+P'], 'canvas.groupSelection': ['Cmd+P'] }, true
+    )
+    expect(r.overrides).toEqual({})
+    expect(r.warnings.some((w) =>
+      w.includes('Fit all nodes in view') && w.includes('Group selection')
+    )).toBe(true)
+  })
+  it('an override conflicting with a DEFAULT strips only the override', () => {
+    const r = sanitizeKeybindingOverrides({ 'canvas.fitAll': ['Cmd+K'] }, true)
+    expect(r.overrides).toEqual({})
+    expect(r.warnings.some((w) => w.includes('Command palette'))).toBe(true)
+  })
+  it('non-object / non-array shapes degrade to empty with a warning', () => {
+    expect(sanitizeKeybindingOverrides('nope', true).overrides).toEqual({})
+    expect(sanitizeKeybindingOverrides({ 'canvas.undo': 'Cmd+Z' }, true).overrides).toEqual({})
+  })
+  it('is a fixpoint: sanitizing its own output adds nothing', () => {
+    const once = sanitizeKeybindingOverrides(
+      { 'canvas.fitAll': ['Cmd+P'], 'node.newTerminal': ['Cmd+Shift+T'] }, true
+    )
+    const twice = sanitizeKeybindingOverrides(once.overrides, true)
+    expect(twice).toEqual({ overrides: once.overrides, warnings: [] })
   })
 })

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -43,6 +43,66 @@ describe('registry invariants', () => {
     expect(COMMANDS_BY_ID.get('canvas.fitAll')?.defaultBindings.darwin).toEqual([])
   })
 
+  it('pins the WHOLE table — every row PR 2 will dispatch on, in source order', () => {
+    // Source order is contractual (first match wins in the resolver), so the array order is
+    // asserted too. A dropped flag — allowInTerminal above all — reds this test.
+    const table = COMMAND_DEFINITIONS.map((d) => ({
+      id: d.id,
+      title: d.title,
+      group: d.group,
+      scope: d.scope,
+      darwin: d.defaultBindings.darwin,
+      other: d.defaultBindings.other,
+      allowWhileTyping: d.allowWhileTyping,
+      allowInTerminal: d.allowInTerminal,
+      allowBareKey: d.allowBareKey,
+      allowHoldChord: d.allowHoldChord
+    }))
+    expect(table).toEqual([
+      { id: 'app.commandPalette', title: 'Command palette', group: 'General', scope: 'app',
+        darwin: ['Cmd+K'], other: ['Cmd+K'], allowInTerminal: true },
+      { id: 'app.settings', title: 'Open settings', group: 'General', scope: 'app',
+        darwin: ['Cmd+Comma'], other: ['Cmd+Comma'], allowInTerminal: true },
+      { id: 'app.shortcutsPanel', title: 'Keyboard shortcuts panel', group: 'General', scope: 'app',
+        darwin: ['Cmd+Slash'], other: ['Cmd+Slash'], allowInTerminal: true },
+      { id: 'view.kanbanToggle', title: 'Toggle kanban board', group: 'General', scope: 'app',
+        darwin: ['Cmd+Shift+B'], other: ['Cmd+Shift+B'], allowInTerminal: true },
+      { id: 'panel.explorer', title: 'Toggle explorer panel', group: 'General', scope: 'app',
+        darwin: ['Cmd+Shift+E'], other: ['Cmd+Shift+E'], allowInTerminal: true },
+      { id: 'panel.sourceControl', title: 'Toggle source control panel', group: 'General',
+        scope: 'app', darwin: ['Cmd+Shift+G'], other: ['Cmd+Shift+G'], allowInTerminal: true },
+      { id: 'panel.sessions', title: 'Pin sessions sidebar', group: 'General', scope: 'app',
+        darwin: ['Cmd+Shift+L'], other: ['Cmd+Shift+L'], allowInTerminal: true },
+      { id: 'canvas.undo', title: 'Undo', group: 'Canvas', scope: 'canvas',
+        darwin: ['Cmd+Z'], other: ['Cmd+Z'] },
+      { id: 'canvas.redo', title: 'Redo', group: 'Canvas', scope: 'canvas',
+        darwin: ['Cmd+Shift+Z'], other: ['Cmd+Shift+Z', 'Cmd+Y'] },
+      { id: 'canvas.deleteSelection', title: 'Delete selection', group: 'Canvas', scope: 'canvas',
+        darwin: ['Delete', 'Backspace'], other: ['Delete', 'Backspace'], allowBareKey: true },
+      { id: 'canvas.fitAll', title: 'Fit all nodes in view', group: 'Canvas', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'canvas.groupSelection', title: 'Group selection', group: 'Canvas', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newTerminal', title: 'New terminal node', group: 'Nodes', scope: 'canvas',
+        darwin: ['Cmd+T'], other: ['Cmd+T'] },
+      { id: 'node.newAgent', title: 'New agent node', group: 'Nodes', scope: 'canvas',
+        darwin: ['Cmd+Shift+C'], other: ['Cmd+Shift+C'] },
+      { id: 'node.close', title: 'Close node / window', group: 'Nodes', scope: 'app',
+        darwin: ['Cmd+W'], other: ['Cmd+W'], allowInTerminal: true, allowWhileTyping: true },
+      { id: 'node.toggleMarkdown', title: 'Toggle markdown view', group: 'Nodes', scope: 'app',
+        darwin: ['Cmd+M'], other: ['Cmd+M'], allowInTerminal: true, allowWhileTyping: true },
+      { id: 'terminal.find', title: 'Find in terminal', group: 'Terminal', scope: 'terminal',
+        darwin: ['Cmd+F'], other: ['Cmd+F'] },
+      { id: 'terminal.copySelection', title: 'Copy terminal selection', group: 'Terminal',
+        scope: 'terminal', darwin: ['Cmd+C'], other: ['Cmd+Shift+C', 'Ctrl+Insert'] },
+      { id: 'scm.commit', title: 'Commit', group: 'Source Control', scope: 'scm',
+        darwin: ['Cmd+Enter'], other: ['Cmd+Enter'], allowWhileTyping: true },
+      { id: 'speech.dictation', title: 'Dictate', group: 'Speech', scope: 'app',
+        darwin: ['Cmd+Alt'], other: ['Cmd+Alt'],
+        allowHoldChord: true, allowInTerminal: true, allowWhileTyping: true }
+    ])
+  })
+
   it('isCommandId accepts known ids and rejects unknowns', () => {
     expect(isCommandId('node.newTerminal')).toBe(true)
     expect(isCommandId('node.selfDestruct')).toBe(false)
@@ -164,6 +224,12 @@ describe('findKeybindingConflicts', () => {
     // terminal.find is Cmd+F in the terminal bucket; an app-bucket Cmd+F is legal.
     expect(findKeybindingConflicts({ 'canvas.fitAll': ['Cmd+F'] }, true)).toEqual([])
   })
+  it('the scm bucket is its own keyspace, not part of global', () => {
+    // scm.commit holds Cmd+Enter; a canvas (global-bucket) override on the same chord is legal,
+    // because Commit dispatches from the focused composer. Reds if conflictBucket folds 'scm'
+    // into 'global'.
+    expect(findKeybindingConflicts({ 'canvas.fitAll': ['Cmd+Enter'] }, true)).toEqual([])
+  })
   it('two disabled commands never conflict', () => {
     expect(
       findKeybindingConflicts({ 'canvas.fitAll': [], 'canvas.groupSelection': [] }, true)
@@ -215,6 +281,22 @@ describe('sanitizeKeybindingOverrides', () => {
     const r = sanitizeKeybindingOverrides({ 'canvas.fitAll': ['Cmd+K'] }, true)
     expect(r.overrides).toEqual({})
     expect(r.warnings.some((w) => w.includes('Command palette'))).toBe(true)
+  })
+  it('keeps stripping when a REVERTED default uncovers a second conflict', () => {
+    // Pass 1: Cmd+P collides between the two overrides, so both are dropped — which reverts
+    // app.commandPalette to its Cmd+K default, and THAT now collides with canvas.fitAll's
+    // override. Pass 2 strips it. A single-shot strip would leave canvas.fitAll on Cmd+K,
+    // ambiguous against the palette.
+    const r = sanitizeKeybindingOverrides(
+      {
+        'app.commandPalette': ['Cmd+P'],
+        'canvas.groupSelection': ['Cmd+P'],
+        'canvas.fitAll': ['Cmd+K']
+      },
+      true
+    )
+    expect(r.overrides).toEqual({})
+    expect(r.warnings.length).toBeGreaterThanOrEqual(2)
   })
   it('non-object / non-array shapes degrade to empty with a warning', () => {
     expect(sanitizeKeybindingOverrides('nope', true).overrides).toEqual({})
@@ -293,6 +375,25 @@ describe('resolveCommandForKeyEvent', () => {
     expect(resolveCommandForKeyEvent(
       ev({ metaKey: true, key: 'f' }), ctx({ terminal: true }), o, true
     )).toBe('terminal.find')
+  })
+  it('resolves the non-mac-only alternate default (Ctrl+Y → redo)', () => {
+    expect(resolveCommandForKeyEvent(ev({ ctrlKey: true, key: 'y' }), ctx(), {}, false))
+      .toBe('canvas.redo')
+  })
+  it('non-mac Ctrl+Shift+C is copy in a terminal and New agent outside one', () => {
+    // By design, the two buckets double-book this chord: node.newAgent (global) and
+    // terminal.copySelection (terminal) both default to it off-mac, and the focus gates — not
+    // the conflict detector — are what keep them apart at dispatch time.
+    const e = ev({ ctrlKey: true, shiftKey: true, key: 'C' })
+    expect(resolveCommandForKeyEvent(e, ctx({ terminal: true }), {}, false))
+      .toBe('terminal.copySelection')
+    expect(resolveCommandForKeyEvent(e, ctx(), {}, false)).toBe('node.newAgent')
+  })
+  it('a bare key resolves, and typing still blocks it', () => {
+    expect(resolveCommandForKeyEvent(ev({ key: 'Delete' }), ctx(), {}, true))
+      .toBe('canvas.deleteSelection')
+    expect(resolveCommandForKeyEvent(ev({ key: 'Delete' }), ctx({ typing: true }), {}, true))
+      .toBeNull()
   })
   it('first matching definition in registry source order wins a tie', () => {
     // Deliberately unsanitized colliding override — the resolver must order the tie deterministically.

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -7,9 +7,11 @@ import {
   getEffectiveBindings,
   bindingIdentity,
   findKeybindingConflicts,
-  sanitizeKeybindingOverrides
+  sanitizeKeybindingOverrides,
+  resolveCommandForKeyEvent
 } from './keybindings'
 import { parseShortcut } from './shortcut'
+import type { ShortcutKeyEvent } from './shortcut'
 
 describe('registry invariants', () => {
   it('has unique ids and a map that covers them all', () => {
@@ -224,5 +226,70 @@ describe('sanitizeKeybindingOverrides', () => {
     )
     const twice = sanitizeKeybindingOverrides(once.overrides, true)
     expect(twice).toEqual({ overrides: once.overrides, warnings: [] })
+  })
+})
+
+const ev = (over: Partial<ShortcutKeyEvent>): ShortcutKeyEvent => ({
+  metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, key: '', ...over
+})
+const ctx = (over: Partial<{ typing: boolean; terminal: boolean; kanbanOpen: boolean }> = {}) => ({
+  typing: false, terminal: false, kanbanOpen: false, ...over
+})
+
+describe('resolveCommandForKeyEvent', () => {
+  it('matches a default app chord', () => {
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'k' }), ctx(), {}, true))
+      .toBe('app.commandPalette')
+  })
+  it('typing blocks commands without allowWhileTyping, allows the flagged ones', () => {
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, key: 't' }), ctx({ typing: true }), {}, true
+    )).toBeNull()
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, key: 'w' }), ctx({ typing: true }), {}, true
+    )).toBe('node.close')
+  })
+  it('terminal focus blocks canvas commands but passes allowInTerminal + terminal scope', () => {
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, key: 't' }), ctx({ terminal: true }), {}, true
+    )).toBeNull()
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, key: 'k' }), ctx({ terminal: true }), {}, true
+    )).toBe('app.commandPalette')
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, key: 'f' }), ctx({ terminal: true }), {}, true
+    )).toBe('terminal.find')
+  })
+  it('kanban open makes canvas-scope commands inert, app scope still fires', () => {
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, key: 'z' }), ctx({ kanbanOpen: true }), {}, true
+    )).toBeNull()
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, shiftKey: true, key: 'b' }), ctx({ kanbanOpen: true }), {}, true
+    )).toBe('view.kanbanToggle')
+  })
+  it('terminal.find does NOT fire outside terminal focus (scope-gated)', () => {
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'f' }), ctx(), {}, true)).toBeNull()
+  })
+  it('respects overrides and disabled commands', () => {
+    const o = { 'app.commandPalette': [] as string[], 'canvas.fitAll': ['Cmd+K'] }
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'k' }), ctx(), o, true))
+      .toBe('canvas.fitAll')
+  })
+  it('never resolves a hold chord', () => {
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, altKey: true, key: 'Alt' }), ctx(), {}, true
+    )).toBeNull()
+  })
+  it('never resolves scm-scope commands — they dispatch from their own composer', () => {
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'Enter' }), ctx(), {}, true))
+      .toBeNull()
+  })
+  it('registry order breaks cross-bucket identity ties deterministically', () => {
+    // Cmd+F sits on terminal.find (terminal bucket); an app-bucket override may share it.
+    const o = { 'canvas.fitAll': ['Cmd+F'] }
+    expect(resolveCommandForKeyEvent(
+      ev({ metaKey: true, key: 'f' }), ctx({ terminal: true }), o, true
+    )).toBe('terminal.find')
   })
 })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -189,7 +189,10 @@ export function getEffectiveBindings(
 }
 
 /** Platform-resolved identity: two spellings that press the same physical modifiers + key get
- *  the same identity (`Cmd+K` === `Ctrl+K` on non-mac, but not on mac). */
+ *  the same identity (`Cmd+K` === `Ctrl+K` on non-mac, but not on mac). The key segment runs
+ *  through `serializeShortcut` so ALIAS spellings collapse too (`Cmd+Esc` === `Cmd+Escape`,
+ *  `Cmd+Return` === `Cmd+Enter`) — without that a hand-edited `Cmd+Return` override would sit
+ *  invisibly on top of the `Cmd+Enter` default. */
 export function bindingIdentity(binding: string, isMac: boolean): string {
   const p = parseShortcut(binding)
   const m = resolvedModifiers(p, isMac)
@@ -199,7 +202,9 @@ export function bindingIdentity(binding: string, isMac: boolean): string {
     m.alt ? 'A' : '',
     m.shift ? 'S' : '',
     ':',
-    p.key ?? '(hold)'
+    p.key === null
+      ? '(hold)'
+      : serializeShortcut({ cmd: false, ctrl: false, alt: false, shift: false, key: p.key })
   ].join('')
 }
 
@@ -230,7 +235,11 @@ export function findKeybindingConflicts(
   for (const def of COMMAND_DEFINITIONS) {
     for (const binding of getEffectiveBindings(def.id, overrides, isMac)) {
       const key = `${conflictBucket(def.scope)} ${bindingIdentity(binding, isMac)}`
-      const entry = byBucketAndIdentity.get(key) ?? { binding, ids: new Set<CommandId>() }
+      const entry = byBucketAndIdentity.get(key) ?? {
+        // Canonicalized, so a hand-edited `cmd+k` override is reported as `Cmd+K`.
+        binding: serializeShortcut(parseShortcut(binding)),
+        ids: new Set<CommandId>()
+      }
       entry.ids.add(def.id)
       byBucketAndIdentity.set(key, entry)
     }

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -129,3 +129,45 @@ export const COMMANDS_BY_ID: ReadonlyMap<CommandId, CommandDefinition> = new Map
 export function isCommandId(v: string): v is CommandId {
   return COMMANDS_BY_ID.has(v as CommandId)
 }
+
+/** Modifier-less keys that are safe to bind bare — they don't type a character. */
+export const SAFE_BARE_KEYS: ReadonlySet<string> = new Set([
+  'DELETE', 'BACKSPACE', 'ESCAPE', 'ENTER', 'TAB',
+  'ARROWUP', 'ARROWDOWN', 'ARROWLEFT', 'ARROWRIGHT', 'PAGEUP', 'PAGEDOWN',
+  'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12'
+])
+
+export type NormalizedBinding = { ok: true; value: string } | { ok: false; error: string }
+
+/** Parse + validate one binding string against a command's flags; returns the canonical
+ *  serialized form on success. The single validation path for defaults (pinned by a registry
+ *  test), Settings-recorder captures, and hand-edited settings.json overrides. */
+export function normalizeBindingForCommand(
+  def: CommandDefinition,
+  raw: string,
+  isMac: boolean
+): NormalizedBinding {
+  const p = parseShortcut(raw)
+  const hasAnyToken = p.cmd || p.ctrl || p.alt || p.shift || p.key !== null
+  if (!hasAnyToken) return { ok: false, error: 'Use a shortcut like Cmd+K or Cmd+Shift+P.' }
+  if (!isMac && p.cmd && p.ctrl) {
+    return { ok: false, error: 'Cmd already means Ctrl on this platform; use one of them.' }
+  }
+  if (p.key === null) {
+    if (!def.allowHoldChord) {
+      return { ok: false, error: 'This command needs a key, not a modifier-only chord.' }
+    }
+    if (!p.cmd && !p.ctrl && !p.alt) {
+      return { ok: false, error: 'A hold chord needs at least one non-shift modifier.' }
+    }
+    return { ok: true, value: serializeShortcut(p) }
+  }
+  const hasStrongModifier = p.cmd || p.ctrl || p.alt
+  if (!hasStrongModifier) {
+    if (p.shift) return { ok: false, error: 'Shift-only shortcuts would steal typed text.' }
+    if (!def.allowBareKey || !SAFE_BARE_KEYS.has(p.key)) {
+      return { ok: false, error: 'Include a modifier key.' }
+    }
+  }
+  return { ok: true, value: serializeShortcut(p) }
+}

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -6,7 +6,13 @@
  * canonical binding strings are shortcut.ts strings (`Cmd` = abstract primary modifier,
  * `Ctrl` = literal Control, modifier-only chords = hold-to-talk).
  */
-import { parseShortcut, serializeShortcut, resolvedModifiers } from './shortcut'
+import {
+  parseShortcut,
+  serializeShortcut,
+  resolvedModifiers,
+  matchesShortcut,
+  isHoldChord
+} from './shortcut'
 import type { ParsedShortcut, ShortcutKeyEvent } from './shortcut'
 
 export type CommandScope = 'app' | 'canvas' | 'terminal' | 'scm'
@@ -312,4 +318,39 @@ export function sanitizeKeybindingOverrides(
     }
   }
   return { overrides, warnings }
+}
+
+export interface KeyDispatchContext {
+  /** A real input/textarea/contentEditable has focus (xterm's hidden textarea excluded). */
+  typing: boolean
+  /** An xterm has focus. */
+  terminal: boolean
+  /** The kanban board is open for the active project. */
+  kanbanOpen: boolean
+}
+
+/** Pure dispatch core: the first registry command (source order) whose effective bindings
+ *  match `e` and whose flags permit the context. Keyed chords only — hold chords are the
+ *  dedicated hold listener's job (`chordHeld`). Callers preventDefault only when the
+ *  returned command's handler actually claims the chord. */
+export function resolveCommandForKeyEvent(
+  e: ShortcutKeyEvent,
+  ctx: KeyDispatchContext,
+  overrides: KeybindingOverrides,
+  isMac: boolean
+): CommandId | null {
+  for (const def of COMMAND_DEFINITIONS) {
+    // scm commands dispatch from their own focused composer (local onKeyDown), never from
+    // the window listener — resolving them here would fire Commit with no composer focused.
+    if (def.scope === 'scm') continue
+    if (ctx.typing && !def.allowWhileTyping) continue
+    if (ctx.terminal && !(def.scope === 'terminal' || def.allowInTerminal)) continue
+    if (!ctx.terminal && def.scope === 'terminal') continue
+    if (ctx.kanbanOpen && def.scope === 'canvas') continue
+    for (const binding of getEffectiveBindings(def.id, overrides, isMac)) {
+      if (isHoldChord(binding)) continue
+      if (matchesShortcut(e, binding, isMac)) return def.id
+    }
+  }
+  return null
 }

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1,0 +1,131 @@
+/**
+ * The keybinding registry + engine, shared by main, renderer, and the Server Edition bridge.
+ * Registry, validation, effective-binding resolution, conflict detection, override
+ * sanitization, and the pure event→command resolver all live in this one module so the
+ * dispatchers, Settings UI, and ShortcutsPanel cannot drift apart. Builds on shortcut.ts —
+ * canonical binding strings are shortcut.ts strings (`Cmd` = abstract primary modifier,
+ * `Ctrl` = literal Control, modifier-only chords = hold-to-talk).
+ */
+import { parseShortcut, serializeShortcut, resolvedModifiers } from './shortcut'
+import type { ParsedShortcut, ShortcutKeyEvent } from './shortcut'
+
+export type CommandScope = 'app' | 'canvas' | 'terminal' | 'scm'
+export type CommandGroup = 'General' | 'Canvas' | 'Nodes' | 'Terminal' | 'Source Control' | 'Speech'
+
+export interface CommandDefinition {
+  id: CommandId
+  /** English row label for ShortcutsPanel and the Settings section. */
+  title: string
+  group: CommandGroup
+  scope: CommandScope
+  /** Canonical shortcut.ts strings. `other` covers linux + win32 — widen to three buckets
+   *  only when a real default needs to differ between them. Empty array = unassigned. */
+  defaultBindings: { darwin: readonly string[]; other: readonly string[] }
+  /** May fire while a real input/textarea/contentEditable is focused (xterm excluded). */
+  allowWhileTyping?: boolean
+  /** May fire while an xterm has focus. Scope 'terminal' implies it. */
+  allowInTerminal?: boolean
+  /** Permits modifier-less bindings, restricted to SAFE_BARE_KEYS. */
+  allowBareKey?: boolean
+  /** Permits modifier-only hold chords (hold-to-talk). */
+  allowHoldChord?: boolean
+}
+
+export type CommandId =
+  | 'app.commandPalette'
+  | 'app.settings'
+  | 'app.shortcutsPanel'
+  | 'view.kanbanToggle'
+  | 'panel.explorer'
+  | 'panel.sourceControl'
+  | 'panel.sessions'
+  | 'canvas.undo'
+  | 'canvas.redo'
+  | 'canvas.deleteSelection'
+  | 'canvas.fitAll'
+  | 'canvas.groupSelection'
+  | 'node.newTerminal'
+  | 'node.newAgent'
+  | 'node.close'
+  | 'node.toggleMarkdown'
+  | 'terminal.find'
+  | 'terminal.copySelection'
+  | 'scm.commit'
+  | 'speech.dictation'
+
+/** Same defaults on every platform. */
+const both = (...bindings: string[]): { darwin: string[]; other: string[] } => ({
+  darwin: bindings,
+  other: [...bindings]
+})
+
+export const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
+  // General — the Canvas.tsx:4491 block today; fires while an xterm has focus, and (bug,
+  // fixed in the dispatch PR) also while typing. allowWhileTyping is deliberately absent.
+  { id: 'app.commandPalette', title: 'Command palette', group: 'General', scope: 'app',
+    defaultBindings: both('Cmd+K'), allowInTerminal: true },
+  { id: 'app.settings', title: 'Open settings', group: 'General', scope: 'app',
+    defaultBindings: both('Cmd+Comma'), allowInTerminal: true },
+  { id: 'app.shortcutsPanel', title: 'Keyboard shortcuts panel', group: 'General', scope: 'app',
+    defaultBindings: both('Cmd+Slash'), allowInTerminal: true },
+  { id: 'view.kanbanToggle', title: 'Toggle kanban board', group: 'General', scope: 'app',
+    defaultBindings: both('Cmd+Shift+B'), allowInTerminal: true },
+  { id: 'panel.explorer', title: 'Toggle explorer panel', group: 'General', scope: 'app',
+    defaultBindings: both('Cmd+Shift+E'), allowInTerminal: true },
+  { id: 'panel.sourceControl', title: 'Toggle source control panel', group: 'General', scope: 'app',
+    defaultBindings: both('Cmd+Shift+G'), allowInTerminal: true },
+  { id: 'panel.sessions', title: 'Pin sessions sidebar', group: 'General', scope: 'app',
+    defaultBindings: both('Cmd+Shift+L'), allowInTerminal: true },
+
+  // Canvas — inert while the kanban board is open (scope 'canvas'), blocked while typing.
+  { id: 'canvas.undo', title: 'Undo', group: 'Canvas', scope: 'canvas',
+    defaultBindings: both('Cmd+Z') },
+  { id: 'canvas.redo', title: 'Redo', group: 'Canvas', scope: 'canvas',
+    defaultBindings: { darwin: ['Cmd+Shift+Z'], other: ['Cmd+Shift+Z', 'Cmd+Y'] } },
+  { id: 'canvas.deleteSelection', title: 'Delete selection', group: 'Canvas', scope: 'canvas',
+    // Backspace off-mac deletes text too often to risk as a bare default.
+    defaultBindings: { darwin: ['Delete', 'Backspace'], other: ['Delete'] },
+    allowBareKey: true },
+  { id: 'canvas.fitAll', title: 'Fit all nodes in view', group: 'Canvas', scope: 'canvas',
+    defaultBindings: both() },
+  { id: 'canvas.groupSelection', title: 'Group selection', group: 'Canvas', scope: 'canvas',
+    defaultBindings: both() },
+
+  // Nodes
+  { id: 'node.newTerminal', title: 'New terminal node', group: 'Nodes', scope: 'canvas',
+    defaultBindings: both('Cmd+T') },
+  { id: 'node.newAgent', title: 'New agent node', group: 'Nodes', scope: 'canvas',
+    // Non-mac note: Ctrl+Shift+C is a common terminal-copy convention; kept for parity
+    // with current behavior, revisit with telemetry.
+    defaultBindings: both('Cmd+Shift+C') },
+  // Main-process intercepted today (unconditional): keep firing everywhere.
+  { id: 'node.close', title: 'Close node / window', group: 'Nodes', scope: 'app',
+    defaultBindings: both('Cmd+W'), allowInTerminal: true, allowWhileTyping: true },
+  { id: 'node.toggleMarkdown', title: 'Toggle markdown view', group: 'Nodes', scope: 'app',
+    defaultBindings: both('Cmd+M'), allowInTerminal: true, allowWhileTyping: true },
+
+  // Terminal
+  { id: 'terminal.find', title: 'Find in terminal', group: 'Terminal', scope: 'terminal',
+    defaultBindings: both('Cmd+F') },
+  { id: 'terminal.copySelection', title: 'Copy terminal selection', group: 'Terminal',
+    scope: 'terminal',
+    // Plain Ctrl+C stays SIGINT off-mac; Cmd+Shift+C resolves to Ctrl+Shift+C there.
+    defaultBindings: { darwin: ['Cmd+C'], other: ['Cmd+Shift+C', 'Ctrl+Insert'] } },
+
+  // Source control (local handler; registry supplies label + remap)
+  { id: 'scm.commit', title: 'Commit', group: 'Source Control', scope: 'scm',
+    defaultBindings: both('Cmd+Enter'), allowWhileTyping: true },
+
+  // Speech — the migrated dictation chord; hold-to-talk by default.
+  { id: 'speech.dictation', title: 'Dictate', group: 'Speech', scope: 'app',
+    defaultBindings: both('Cmd+Alt'),
+    allowHoldChord: true, allowInTerminal: true, allowWhileTyping: true }
+]
+
+export const COMMANDS_BY_ID: ReadonlyMap<CommandId, CommandDefinition> = new Map(
+  COMMAND_DEFINITIONS.map((d) => [d.id, d])
+)
+
+export function isCommandId(v: string): v is CommandId {
+  return COMMANDS_BY_ID.has(v as CommandId)
+}

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -13,7 +13,7 @@ import {
   matchesShortcut,
   isHoldChord
 } from './shortcut'
-import type { ParsedShortcut, ShortcutKeyEvent } from './shortcut'
+import type { ShortcutKeyEvent } from './shortcut'
 
 export type CommandScope = 'app' | 'canvas' | 'terminal' | 'scm'
 export type CommandGroup = 'General' | 'Canvas' | 'Nodes' | 'Terminal' | 'Source Control' | 'Speech'
@@ -261,9 +261,12 @@ export function findKeybindingConflicts(
 }
 
 /** Validate a raw `settings.keybindings` value (hand-editable JSON) into a safe override map.
- *  Loops until conflict-free so one bad edit cannot leave ambiguous dispatch. The load path
- *  applies the result and warns; the Settings UI runs the same function pre-save and BLOCKS
- *  instead — one detector, two surfacings (design.md D3). */
+ *  Loops until conflict-free so one bad edit cannot leave ambiguous dispatch. This is the
+ *  SETTINGS-LOAD path: it applies what survives and warns about what it dropped. It is not the
+ *  pre-save gate — its warnings are unstructured strings, which cannot tell a UI which field to
+ *  block on. The future Settings UI blocks pre-save by calling `normalizeBindingForCommand` and
+ *  `findKeybindingConflicts` directly, per candidate binding: same detector, different surfacing
+ *  (design.md D3). */
 export function sanitizeKeybindingOverrides(
   raw: unknown,
   isMac: boolean
@@ -304,6 +307,10 @@ export function sanitizeKeybindingOverrides(
   }
   // Strip overridden participants of any remaining conflict until none are left. Bounded:
   // each pass removes at least one override or exits.
+  // NEVER pass `includeDefaults: true` here. Termination rests on the touchesOverride reporting
+  // gate: every reported conflict has at least one OVERRIDE to delete, so a pass always shrinks
+  // the map. A default-vs-default conflict has no deletable participant, so it would be reported
+  // forever and the loop would spin.
   for (;;) {
     const conflicts = findKeybindingConflicts(overrides, isMac)
     if (conflicts.length === 0) break
@@ -320,6 +327,9 @@ export function sanitizeKeybindingOverrides(
   return { overrides, warnings }
 }
 
+/** `typing` and `terminal` are expected to be DISJOINT — xterm's hidden textarea is a terminal,
+ *  not a typing surface, so a caller classifying focus must not report both. If one does anyway,
+ *  `typing` wins (it is checked first) and every terminal-scope command becomes unreachable. */
 export interface KeyDispatchContext {
   /** A real input/textarea/contentEditable has focus (xterm's hidden textarea excluded). */
   typing: boolean
@@ -348,6 +358,10 @@ export function resolveCommandForKeyEvent(
     if (!ctx.terminal && def.scope === 'terminal') continue
     if (ctx.kanbanOpen && def.scope === 'canvas') continue
     for (const binding of getEffectiveBindings(def.id, overrides, isMac)) {
+      // Hold chords belong to the dedicated hold listener, and this skip STATES that contract
+      // rather than relying on it being unreachable: `matchesShortcut` also refuses a key-null
+      // chord today (`parsed.key !== null`), so removing this line changes nothing — until the
+      // day it does.
       if (isHoldChord(binding)) continue
       if (matchesShortcut(e, binding, isMac)) return def.id
     }

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -253,3 +253,63 @@ export function findKeybindingConflicts(
   }
   return conflicts
 }
+
+/** Validate a raw `settings.keybindings` value (hand-editable JSON) into a safe override map.
+ *  Loops until conflict-free so one bad edit cannot leave ambiguous dispatch. The load path
+ *  applies the result and warns; the Settings UI runs the same function pre-save and BLOCKS
+ *  instead — one detector, two surfacings (design.md D3). */
+export function sanitizeKeybindingOverrides(
+  raw: unknown,
+  isMac: boolean
+): { overrides: KeybindingOverrides; warnings: string[] } {
+  const warnings: string[] = []
+  const overrides: Partial<Record<CommandId, string[]>> = {}
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    if (raw !== undefined && raw !== null) warnings.push('keybindings must be an object; ignored.')
+    return { overrides, warnings }
+  }
+  for (const [id, value] of Object.entries(raw)) {
+    if (!isCommandId(id)) {
+      warnings.push(`Unknown command "${id}" ignored.`)
+      continue
+    }
+    if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
+      warnings.push(`Bindings for "${id}" must be an array of strings; ignored.`)
+      continue
+    }
+    const def = COMMANDS_BY_ID.get(id)!
+    const normalized: string[] = []
+    for (const s of value as string[]) {
+      const r = normalizeBindingForCommand(def, s, isMac)
+      if (r.ok) {
+        if (!normalized.includes(r.value)) normalized.push(r.value)
+      } else {
+        warnings.push(`Binding "${s}" for "${id}" ignored: ${r.error}`)
+      }
+    }
+    // A list that HAD entries and lost every one of them falls back to defaults rather than
+    // being stored as `[]`: `[]` means "disabled", so a typo in a hand-edited settings.json
+    // would silently turn a working shortcut off. An explicit `[]` in the input still disables.
+    if (value.length > 0 && normalized.length === 0) {
+      warnings.push(`All bindings for "${id}" were invalid; falling back to defaults.`)
+      continue
+    }
+    overrides[id] = normalized
+  }
+  // Strip overridden participants of any remaining conflict until none are left. Bounded:
+  // each pass removes at least one override or exits.
+  for (;;) {
+    const conflicts = findKeybindingConflicts(overrides, isMac)
+    if (conflicts.length === 0) break
+    for (const conflict of conflicts) {
+      const titles = conflict.commandIds
+        .map((cid) => COMMANDS_BY_ID.get(cid)?.title ?? cid)
+        .join(', ')
+      warnings.push(`Conflicting shortcut ${conflict.binding} between: ${titles}. Overrides dropped.`)
+      for (const cid of conflict.commandIds) {
+        if (overrides[cid] !== undefined) delete overrides[cid]
+      }
+    }
+  }
+  return { overrides, warnings }
+}

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -83,8 +83,8 @@ export const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
   { id: 'canvas.redo', title: 'Redo', group: 'Canvas', scope: 'canvas',
     defaultBindings: { darwin: ['Cmd+Shift+Z'], other: ['Cmd+Shift+Z', 'Cmd+Y'] } },
   { id: 'canvas.deleteSelection', title: 'Delete selection', group: 'Canvas', scope: 'canvas',
-    // Backspace off-mac deletes text too often to risk as a bare default.
-    defaultBindings: { darwin: ['Delete', 'Backspace'], other: ['Delete'] },
+    // Mirrors the current platform-blind handler; the typing guard keeps Backspace safe.
+    defaultBindings: both('Delete', 'Backspace'),
     allowBareKey: true },
   { id: 'canvas.fitAll', title: 'Fit all nodes in view', group: 'Canvas', scope: 'canvas',
     defaultBindings: both() },

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -171,3 +171,76 @@ export function normalizeBindingForCommand(
   }
   return { ok: true, value: serializeShortcut(p) }
 }
+
+/** User overrides, as stored in settings.json under `keybindings`. Absent id = defaults;
+ *  `[]` = disabled. */
+export type KeybindingOverrides = Partial<Record<CommandId, readonly string[]>>
+
+export function getEffectiveBindings(
+  id: CommandId,
+  overrides: KeybindingOverrides,
+  isMac: boolean
+): readonly string[] {
+  const override = overrides[id]
+  if (override !== undefined) return override
+  const def = COMMANDS_BY_ID.get(id)
+  if (!def) return []
+  return isMac ? def.defaultBindings.darwin : def.defaultBindings.other
+}
+
+/** Platform-resolved identity: two spellings that press the same physical modifiers + key get
+ *  the same identity (`Cmd+K` === `Ctrl+K` on non-mac, but not on mac). */
+export function bindingIdentity(binding: string, isMac: boolean): string {
+  const p = parseShortcut(binding)
+  const m = resolvedModifiers(p, isMac)
+  return [
+    m.meta ? 'M' : '',
+    m.ctrl ? 'C' : '',
+    m.alt ? 'A' : '',
+    m.shift ? 'S' : '',
+    ':',
+    p.key ?? '(hold)'
+  ].join('')
+}
+
+/** Commands sharing a bucket compete for the same keys. 'app' and 'canvas' share one global
+ *  keyspace (both dispatch from the window listener; canvas commands are merely inert while
+ *  the board is open); terminal and scm are their own focused surfaces. */
+export function conflictBucket(scope: CommandScope): 'global' | 'terminal' | 'scm' {
+  return scope === 'app' || scope === 'canvas' ? 'global' : scope
+}
+
+export interface KeybindingConflict {
+  /** Canonical string of one colliding spelling (the first seen). */
+  binding: string
+  /** Sorted ids of every command holding the identity. */
+  commandIds: CommandId[]
+}
+
+/** Collisions between effective bindings within a bucket. By default only collisions touching
+ *  at least one overridden command are reported (shipped defaults are asserted conflict-free
+ *  by a registry test using `includeDefaults: true` — user-facing surfaces never nag about
+ *  stock bindings). */
+export function findKeybindingConflicts(
+  overrides: KeybindingOverrides,
+  isMac: boolean,
+  opts: { includeDefaults?: boolean } = {}
+): KeybindingConflict[] {
+  const byBucketAndIdentity = new Map<string, { binding: string; ids: Set<CommandId> }>()
+  for (const def of COMMAND_DEFINITIONS) {
+    for (const binding of getEffectiveBindings(def.id, overrides, isMac)) {
+      const key = `${conflictBucket(def.scope)} ${bindingIdentity(binding, isMac)}`
+      const entry = byBucketAndIdentity.get(key) ?? { binding, ids: new Set<CommandId>() }
+      entry.ids.add(def.id)
+      byBucketAndIdentity.set(key, entry)
+    }
+  }
+  const conflicts: KeybindingConflict[] = []
+  for (const { binding, ids } of byBucketAndIdentity.values()) {
+    if (ids.size < 2) continue
+    const commandIds = [...ids].sort()
+    const touchesOverride = commandIds.some((id) => overrides[id] !== undefined)
+    if (opts.includeDefaults || touchesOverride) conflicts.push({ binding, commandIds })
+  }
+  return conflicts
+}

--- a/src/shared/shortcut.test.ts
+++ b/src/shared/shortcut.test.ts
@@ -8,29 +8,56 @@ import {
   isModifierEventKey,
   matchesShortcut,
   parseShortcut,
+  resolvedModifiers,
+  serializeShortcut,
   shortcutKeyParts
 } from './shortcut'
 
 describe('parseShortcut', () => {
   it('parses the default combo', () => {
-    expect(parseShortcut('Cmd+Shift+D')).toEqual({ cmd: true, shift: true, alt: false, key: 'D' })
+    expect(parseShortcut('Cmd+Shift+D')).toEqual({
+      cmd: true,
+      ctrl: false,
+      shift: true,
+      alt: false,
+      key: 'D'
+    })
   })
 
   it('parses a combo without Shift/Alt', () => {
-    expect(parseShortcut('Cmd+D')).toEqual({ cmd: true, shift: false, alt: false, key: 'D' })
+    expect(parseShortcut('Cmd+D')).toEqual({
+      cmd: true,
+      ctrl: false,
+      shift: false,
+      alt: false,
+      key: 'D'
+    })
   })
 
   it('parses Alt', () => {
-    expect(parseShortcut('Cmd+Alt+D')).toEqual({ cmd: true, shift: false, alt: true, key: 'D' })
+    expect(parseShortcut('Cmd+Alt+D')).toEqual({
+      cmd: true,
+      ctrl: false,
+      shift: false,
+      alt: true,
+      key: 'D'
+    })
   })
 
   it('parses a named key (F-key)', () => {
-    expect(parseShortcut('Cmd+F5')).toEqual({ cmd: true, shift: false, alt: false, key: 'F5' })
+    expect(parseShortcut('Cmd+F5')).toEqual({
+      cmd: true,
+      ctrl: false,
+      shift: false,
+      alt: false,
+      key: 'F5'
+    })
   })
 
   it('parses a named key (Space)', () => {
     expect(parseShortcut('Cmd+Shift+Space')).toEqual({
       cmd: true,
+      ctrl: false,
       shift: true,
       alt: false,
       key: 'SPACE'
@@ -40,6 +67,7 @@ describe('parseShortcut', () => {
   it('is tolerant of stray whitespace', () => {
     expect(parseShortcut(' Cmd + Shift + D ')).toEqual({
       cmd: true,
+      ctrl: false,
       shift: true,
       alt: false,
       key: 'D'
@@ -47,12 +75,19 @@ describe('parseShortcut', () => {
   })
 
   it('parses a modifier-only chord (no trailing key) — the v3 hold-to-talk shape', () => {
-    expect(parseShortcut('Cmd+Alt')).toEqual({ cmd: true, alt: true, shift: false, key: null })
+    expect(parseShortcut('Cmd+Alt')).toEqual({
+      cmd: true,
+      ctrl: false,
+      alt: true,
+      shift: false,
+      key: null
+    })
   })
 
   it('parses a modifier-only chord with all three modifiers', () => {
     expect(parseShortcut('Cmd+Alt+Shift')).toEqual({
       cmd: true,
+      ctrl: false,
       alt: true,
       shift: true,
       key: null
@@ -298,7 +333,13 @@ describe('buildModifierChord', () => {
   it('round-trips through parseShortcut', () => {
     const combo = buildModifierChord({ cmd: true, alt: true, shift: false })
     expect(combo).not.toBeNull()
-    expect(parseShortcut(combo as string)).toEqual({ cmd: true, alt: true, shift: false, key: null })
+    expect(parseShortcut(combo as string)).toEqual({
+      cmd: true,
+      ctrl: false,
+      alt: true,
+      shift: false,
+      key: null
+    })
     expect(isHoldChord(combo as string)).toBe(true)
   })
 })
@@ -345,5 +386,71 @@ describe('captureToShortcut', () => {
     const combo = captureToShortcut(e, true)
     expect(combo).not.toBeNull()
     expect(matchesShortcut(e, combo as string, true)).toBe(true)
+  })
+})
+
+describe('literal Ctrl token', () => {
+  it('parses Ctrl as literal control, not the abstract primary', () => {
+    expect(parseShortcut('Ctrl+Insert')).toEqual({
+      cmd: false, ctrl: true, shift: false, alt: false, key: 'INSERT'
+    })
+  })
+  it('matches literal Ctrl via ctrlKey on mac, with metaKey forbidden', () => {
+    const e = { metaKey: false, ctrlKey: true, shiftKey: false, altKey: false, key: 'Insert' }
+    expect(matchesShortcut(e, 'Ctrl+Insert', true)).toBe(true)
+    expect(matchesShortcut({ ...e, metaKey: true }, 'Ctrl+Insert', true)).toBe(false)
+  })
+  it('keeps non-mac behavior for Ctrl strings identical to Cmd strings', () => {
+    const e = { metaKey: false, ctrlKey: true, shiftKey: false, altKey: false, key: 'x' }
+    expect(matchesShortcut(e, 'Ctrl+X', false)).toBe(true)
+    expect(matchesShortcut(e, 'Cmd+X', false)).toBe(true)
+  })
+})
+
+describe('strict modifier matching', () => {
+  it('rejects a held Control on top of a Cmd chord on mac', () => {
+    const e = { metaKey: true, ctrlKey: true, shiftKey: false, altKey: false, key: 'k' }
+    expect(matchesShortcut(e, 'Cmd+K', true)).toBe(false)
+  })
+  it('rejects a held Meta on top of a Cmd chord on non-mac', () => {
+    const e = { metaKey: true, ctrlKey: true, shiftKey: false, altKey: false, key: 'k' }
+    expect(matchesShortcut(e, 'Cmd+K', false)).toBe(false)
+  })
+  it('chordHeld applies the same strictness', () => {
+    const e = { metaKey: true, ctrlKey: true, shiftKey: false, altKey: true, key: 'Control' }
+    expect(chordHeld(e, 'Cmd+Alt', true)).toBe(false)
+  })
+})
+
+describe('named punctuation keys', () => {
+  it('normalizes Comma and Slash tokens to their e.key characters', () => {
+    expect(parseShortcut('Cmd+Comma').key).toBe(',')
+    expect(parseShortcut('Cmd+Slash').key).toBe('/')
+  })
+  it('matches a comma keydown against Cmd+Comma', () => {
+    const e = { metaKey: true, ctrlKey: false, shiftKey: false, altKey: false, key: ',' }
+    expect(matchesShortcut(e, 'Cmd+Comma', true)).toBe(true)
+  })
+  it('renders punctuation parts as the character itself', () => {
+    expect(shortcutKeyParts('Cmd+Slash', true)).toEqual(['⌘', '/'])
+  })
+})
+
+describe('serializeShortcut', () => {
+  it('round-trips in canonical Cmd,Ctrl,Alt,Shift,key order', () => {
+    expect(serializeShortcut(parseShortcut('shift+d+cmd'))).toBe('Cmd+Shift+D')
+    expect(serializeShortcut(parseShortcut('Ctrl+Insert'))).toBe('Ctrl+Insert')
+    expect(serializeShortcut(parseShortcut('Alt+Cmd'))).toBe('Cmd+Alt')
+  })
+  it('round-trips a named key through its canonical spelling', () => {
+    expect(serializeShortcut(parseShortcut('Cmd+Enter'))).toBe('Cmd+Enter')
+  })
+})
+
+describe('resolvedModifiers', () => {
+  it('maps Cmd to meta on mac and ctrl elsewhere', () => {
+    const p = parseShortcut('Cmd+Shift+K')
+    expect(resolvedModifiers(p, true)).toEqual({ meta: true, ctrl: false, alt: false, shift: true })
+    expect(resolvedModifiers(p, false)).toEqual({ meta: false, ctrl: true, alt: false, shift: true })
   })
 })

--- a/src/shared/shortcut.test.ts
+++ b/src/shared/shortcut.test.ts
@@ -330,6 +330,10 @@ describe('buildModifierChord', () => {
     expect(buildModifierChord({ cmd: false, alt: true, shift: true })).toBeNull()
   })
 
+  it('emits the literal Ctrl token after Cmd when a Control was held too', () => {
+    expect(buildModifierChord({ cmd: true, ctrl: true, alt: false, shift: false })).toBe('Cmd+Ctrl')
+  })
+
   it('round-trips through parseShortcut', () => {
     const combo = buildModifierChord({ cmd: true, alt: true, shift: false })
     expect(combo).not.toBeNull()
@@ -386,6 +390,22 @@ describe('captureToShortcut', () => {
     const combo = captureToShortcut(e, true)
     expect(combo).not.toBeNull()
     expect(matchesShortcut(e, combo as string, true)).toBe(true)
+  })
+
+  it('records a Control held alongside Cmd on mac, and the capture still matches its own gesture', () => {
+    const e = { metaKey: true, ctrlKey: true, shiftKey: false, altKey: false, key: 'd' }
+    const combo = captureToShortcut(e, true)
+    expect(combo).toBe('Cmd+Ctrl+D')
+    expect(matchesShortcut(e, combo as string, true)).toBe(true)
+  })
+
+  it('returns null on non-mac when Meta (Super/Win) is held — the grammar cannot express it', () => {
+    expect(
+      captureToShortcut(
+        { metaKey: true, ctrlKey: true, shiftKey: false, altKey: false, key: 'd' },
+        false
+      )
+    ).toBeNull()
   })
 })
 
@@ -444,6 +464,10 @@ describe('serializeShortcut', () => {
   })
   it('round-trips a named key through its canonical spelling', () => {
     expect(serializeShortcut(parseShortcut('Cmd+Enter'))).toBe('Cmd+Enter')
+  })
+  it('collapses alias spellings onto one canonical identity', () => {
+    expect(serializeShortcut(parseShortcut('Cmd+Esc'))).toBe('Cmd+Escape')
+    expect(serializeShortcut(parseShortcut('Cmd+Return'))).toBe('Cmd+Enter')
   })
 })
 

--- a/src/shared/shortcut.ts
+++ b/src/shared/shortcut.ts
@@ -106,13 +106,19 @@ export function parseShortcut(s: string): ParsedShortcut {
 /** Canonical spellings for the key tokens that are not a single character. Serializing through
  *  this (rather than emitting the uppercased token) is what makes `serializeShortcut` the exact
  *  inverse of `parseShortcut`: `"Ctrl+Insert"` round-trips instead of becoming `"Ctrl+INSERT"`.
- *  Single letters, digits and F-keys are already canonical and pass through. */
+ *  Single letters, digits and F-keys are already canonical and pass through.
+ *  The ALIAS spellings `KEY_LABELS` also accepts (`ESC`, `RETURN`) map onto the canonical token,
+ *  so `"Cmd+Esc"` and `"Cmd+Escape"` serialize identically — without that, two spellings of one
+ *  chord would carry two conflict identities. Serializer-only: neither alias is ever produced by
+ *  `normalizeKey` from a real `e.key` (the DOM reports `"Escape"` / `"Enter"`). */
 const CANONICAL_KEY_NAMES: Record<string, string> = {
   ENTER: 'Enter',
   DELETE: 'Delete',
   BACKSPACE: 'Backspace',
   INSERT: 'Insert',
   ESCAPE: 'Escape',
+  ESC: 'Escape',
+  RETURN: 'Enter',
   TAB: 'Tab',
   SPACE: 'Space',
   ARROWUP: 'ArrowUp',
@@ -249,13 +255,20 @@ export function chordHeld(e: ShortcutKeyEvent, s: string, isMac: boolean): boole
  * modifier is missing. (A modifier-only chord is captured separately — see `buildModifierChord`
  * below — because it commits on keyUP once every key is released, by which point the keyup
  * event's own modifier flags are already false and can't be read off it directly.)
+ *
+ * **A capture must describe the whole gesture**, because matching is exact: on mac a Control held
+ * beside Cmd is recorded as the literal `Ctrl` token, and on non-mac a held Meta (Super/Win)
+ * REFUSES the capture — that chord has no spelling in this grammar, and storing the bare `Cmd+…`
+ * would save a binding the same gesture can never fire again.
  */
 export function captureToShortcut(e: ShortcutKeyEvent, isMac: boolean): string | null {
   const primaryPressed = isMac ? e.metaKey : e.ctrlKey
   if (!primaryPressed) return null
+  if (!isMac && e.metaKey) return null
   const key = normalizeKey(e.key)
   if (MODIFIER_KEYS.has(key)) return null
   const parts = ['Cmd']
+  if (isMac && e.ctrlKey) parts.push('Ctrl')
   if (e.altKey) parts.push('Alt')
   if (e.shiftKey) parts.push('Shift')
   parts.push(key)
@@ -266,18 +279,24 @@ export function captureToShortcut(e: ShortcutKeyEvent, isMac: boolean): string |
  *  `buildModifierChord`). */
 export interface ChordModifiers {
   cmd: boolean
+  /** A literal Control held beside the primary (mac ⌃). OPTIONAL so a caller that does not
+   *  collect it keeps its existing behavior — collecting it is the capture field's job. */
+  ctrl?: boolean
   alt: boolean
   shift: boolean
 }
 
 /** `{cmd:true, alt:true, shift:false}` -> `"Cmd+Alt"`; `{cmd:false, ...}` -> `null` (the primary
- *  modifier is mandatory, same as `captureToShortcut`). The Settings capture field calls this at
- *  keyUp, once every key has been released, using the modifier state it remembered from the last
- *  keyDown while only modifier keys had been pressed (`isModifierEventKey`) — the keyup event
- *  itself no longer carries that state. */
+ *  modifier is mandatory, same as `captureToShortcut`). A `ctrl` observed beside the primary
+ *  becomes the literal `Ctrl` token, for the same reason `captureToShortcut` records it: under
+ *  exact matching, a chord that omits a modifier the user was holding can never fire. The Settings
+ *  capture field calls this at keyUp, once every key has been released, using the modifier state it
+ *  remembered from the last keyDown while only modifier keys had been pressed
+ *  (`isModifierEventKey`) — the keyup event itself no longer carries that state. */
 export function buildModifierChord(mods: ChordModifiers): string | null {
   if (!mods.cmd) return null
   const parts = ['Cmd']
+  if (mods.ctrl) parts.push('Ctrl')
   if (mods.alt) parts.push('Alt')
   if (mods.shift) parts.push('Shift')
   return parts.join('+')

--- a/src/shared/shortcut.ts
+++ b/src/shared/shortcut.ts
@@ -5,9 +5,15 @@
  * Canonical string shape: modifier tokens joined by "+", optionally ending in one non-modifier
  * key token, e.g. `"Cmd+Shift+D"`, `"Cmd+F5"`, or (v3) a MODIFIER-ONLY chord with no trailing key,
  * e.g. `"Cmd+Alt"`. `Cmd` is a PLATFORM-ABSTRACTED primary modifier — it means "the primary
- * modifier for this platform": metaKey (⌘) on mac, ctrlKey elsewhere. There is no separate literal
- * "Ctrl" token; storing shortcuts in terms of the abstract "Cmd" is what lets one stored string
- * match on every platform via `matchesShortcut(e, s, isMac)`.
+ * modifier for this platform": metaKey (⌘) on mac, ctrlKey elsewhere. Storing shortcuts in terms
+ * of the abstract "Cmd" is what lets one stored string match on every platform via
+ * `matchesShortcut(e, s, isMac)`. `Ctrl` is a SEPARATE, LITERAL token meaning ctrlKey on every
+ * platform (⌃ on mac) — on non-mac it happens to resolve to the same physical key as `Cmd`, so a
+ * `Ctrl+X` string still behaves exactly like `Cmd+X` there.
+ *
+ * Modifier matching is EXACT on all four flags: a chord matches only when the event's meta/ctrl/
+ * alt/shift state is precisely what the chord resolves to, so an extra modifier held on top never
+ * fires a shorter binding.
  *
  * A modifier-only chord (`key === null`, see `isHoldChord`) means hold-to-talk: the chord is held
  * down to record and released to stop, instead of toggling on a keyed press. `chordHeld` (not
@@ -18,6 +24,9 @@
 export interface ParsedShortcut {
   /** Primary modifier required: metaKey on mac, ctrlKey elsewhere. */
   cmd: boolean
+  /** LITERAL Control required (⌃ on mac). On non-mac `Cmd` already resolves to Control, so a
+   *  chord never needs both; validation of both-at-once lives in keybindings.ts. */
+  ctrl: boolean
   shift: boolean
   alt: boolean
   /** Uppercased single char (e.g. "D") or named key (e.g. "F5", "SPACE", "ESCAPE"). `null` means
@@ -41,12 +50,17 @@ const KEY_LABELS: Record<string, string> = {
   ARROWRIGHT: '→'
 }
 
+/** Named tokens for keys whose `e.key` is punctuation, so canonical strings stay readable. */
+const KEY_ALIASES: Record<string, string> = { COMMA: ',', SLASH: '/', PERIOD: '.' }
+
 /** Modifier-only `e.key` values — never a valid trailing key on their own. */
 const MODIFIER_KEYS = new Set(['META', 'CONTROL', 'CTRL', 'SHIFT', 'ALT', 'ALTGRAPH', 'OS'])
 
-/** `"d"` / `"D"` / `"Escape"` / `"F5"` -> the uppercased canonical key token. */
+/** `"d"` / `"D"` / `"Escape"` / `"F5"` -> the uppercased canonical key token; a punctuation alias
+ *  (`"Comma"`) -> the character `e.key` actually reports (`","`). */
 function normalizeKey(key: string): string {
-  return key.toUpperCase()
+  const upper = key.toUpperCase()
+  return KEY_ALIASES[upper] ?? upper
 }
 
 /** True when `key` (a raw `e.key`, any case) names a modifier key itself rather than a
@@ -57,9 +71,10 @@ export function isModifierEventKey(key: string): boolean {
   return MODIFIER_KEYS.has(normalizeKey(key))
 }
 
-/** Parse a canonical combo string, e.g. `"Cmd+Shift+D"` -> `{cmd:true, shift:true, alt:false,
- *  key:'D'}`; a modifier-only chord, e.g. `"Cmd+Alt"` -> `{cmd:true, shift:false, alt:true,
- *  key:null}` (see `isHoldChord`). */
+/** Parse a canonical combo string, e.g. `"Cmd+Shift+D"` -> `{cmd:true, ctrl:false, shift:true,
+ *  alt:false, key:'D'}`; a modifier-only chord, e.g. `"Cmd+Alt"` -> `{cmd:true, ctrl:false,
+ *  shift:false, alt:true, key:null}` (see `isHoldChord`). `Ctrl`/`Control` set the LITERAL `ctrl`
+ *  field — they are no longer a spelling of the abstract `Cmd`. */
 export function parseShortcut(s: string): ParsedShortcut {
   const parts = s
     .split('+')
@@ -67,13 +82,16 @@ export function parseShortcut(s: string): ParsedShortcut {
     .filter(Boolean)
 
   let cmd = false
+  let ctrl = false
   let shift = false
   let alt = false
   let key: string | null = null
   for (const part of parts) {
     const lower = part.toLowerCase()
-    if (lower === 'cmd' || lower === 'command' || lower === 'ctrl' || lower === 'control') {
+    if (lower === 'cmd' || lower === 'command') {
       cmd = true
+    } else if (lower === 'ctrl' || lower === 'control') {
+      ctrl = true
     } else if (lower === 'shift') {
       shift = true
     } else if (lower === 'alt' || lower === 'option') {
@@ -82,7 +100,47 @@ export function parseShortcut(s: string): ParsedShortcut {
       key = normalizeKey(part)
     }
   }
-  return { cmd, shift, alt, key }
+  return { cmd, ctrl, shift, alt, key }
+}
+
+/** Canonical spellings for the key tokens that are not a single character. Serializing through
+ *  this (rather than emitting the uppercased token) is what makes `serializeShortcut` the exact
+ *  inverse of `parseShortcut`: `"Ctrl+Insert"` round-trips instead of becoming `"Ctrl+INSERT"`.
+ *  Single letters, digits and F-keys are already canonical and pass through. */
+const CANONICAL_KEY_NAMES: Record<string, string> = {
+  ENTER: 'Enter',
+  DELETE: 'Delete',
+  BACKSPACE: 'Backspace',
+  INSERT: 'Insert',
+  ESCAPE: 'Escape',
+  TAB: 'Tab',
+  SPACE: 'Space',
+  ARROWUP: 'ArrowUp',
+  ARROWDOWN: 'ArrowDown',
+  ARROWLEFT: 'ArrowLeft',
+  ARROWRIGHT: 'ArrowRight',
+  PAGEUP: 'PageUp',
+  PAGEDOWN: 'PageDown',
+  ',': 'Comma',
+  '/': 'Slash',
+  '.': 'Period'
+}
+
+function keyTokenForSerialize(key: string): string {
+  return CANONICAL_KEY_NAMES[key] ?? key
+}
+
+/** Canonical string for a parsed chord: `Cmd`,`Ctrl`,`Alt`,`Shift`, then the key token
+ *  (punctuation keys serialize back to their named alias). Two spellings of the same chord
+ *  always serialize identically — keybindings.ts keys its conflict identities off this. */
+export function serializeShortcut(p: ParsedShortcut): string {
+  const parts: string[] = []
+  if (p.cmd) parts.push('Cmd')
+  if (p.ctrl) parts.push('Ctrl')
+  if (p.alt) parts.push('Alt')
+  if (p.shift) parts.push('Shift')
+  if (p.key !== null) parts.push(keyTokenForSerialize(p.key))
+  return parts.join('+')
 }
 
 /** True when `s` is a modifier-only chord (no trailing key) — the v3 hold-to-talk shape. A
@@ -102,16 +160,18 @@ function keyLabel(key: string): string {
 
 /** `"Cmd+Shift+D"` + mac -> `["⌘", "⇧", "D"]`; + non-mac -> `["Ctrl", "Shift", "D"]`; a
  *  modifier-only chord (`"Cmd+Alt"`) -> `["⌘", "⌥"]` (no trailing key badge). One badge per
- *  element — used by ShortcutsPanel's `<kbd>` row rendering. */
+ *  element — used by ShortcutsPanel's `<kbd>` row rendering. The non-mac `cmd || ctrl` collapse
+ *  is safe because keybindings.ts validation forbids both in one chord. */
 export function shortcutKeyParts(s: string, isMac: boolean): string[] {
-  const { cmd, shift, alt, key } = parseShortcut(s)
+  const { cmd, ctrl, shift, alt, key } = parseShortcut(s)
   const parts: string[] = []
   if (isMac) {
     if (cmd) parts.push('⌘')
+    if (ctrl) parts.push('⌃')
     if (alt) parts.push('⌥')
     if (shift) parts.push('⇧')
   } else {
-    if (cmd) parts.push('Ctrl')
+    if (cmd || ctrl) parts.push('Ctrl')
     if (alt) parts.push('Alt')
     if (shift) parts.push('Shift')
   }
@@ -136,16 +196,31 @@ export interface ShortcutKeyEvent {
   key: string
 }
 
-/** Does `e` match the canonical combo `s`? `cmd` in `s` means metaKey on mac, ctrlKey elsewhere.
- *  For a keyed combo only — a modifier-only chord (`isHoldChord(s)`) never matches here (its
- *  `key` is `null`, which no `e.key` ever equals); the Canvas hold-mode listener uses
- *  `chordHeld` instead. */
+/** The concrete modifier flags a chord requires on `isMac`. `Cmd` resolves to meta on mac and
+ *  ctrl elsewhere; the literal `ctrl` field always demands ctrlKey. */
+export function resolvedModifiers(
+  p: ParsedShortcut,
+  isMac: boolean
+): { meta: boolean; ctrl: boolean; alt: boolean; shift: boolean } {
+  return {
+    meta: isMac && p.cmd,
+    ctrl: p.ctrl || (!isMac && p.cmd),
+    alt: p.alt,
+    shift: p.shift
+  }
+}
+
+/** Does `e` match the canonical combo `s`? `cmd` in `s` means metaKey on mac, ctrlKey elsewhere;
+ *  `ctrl` always means ctrlKey. All four modifier flags must match EXACTLY, so a chord never
+ *  fires with an extra modifier held on top of it (a Control held over `Cmd+K` on mac is a
+ *  different chord, not a sloppier one). For a keyed combo only — a modifier-only chord
+ *  (`isHoldChord(s)`) never matches here (its `key` is `null`, which no `e.key` ever equals); the
+ *  Canvas hold-mode listener uses `chordHeld` instead. */
 export function matchesShortcut(e: ShortcutKeyEvent, s: string, isMac: boolean): boolean {
   const parsed = parseShortcut(s)
-  const primaryPressed = isMac ? e.metaKey : e.ctrlKey
-  if (parsed.cmd !== primaryPressed) return false
-  if (parsed.shift !== e.shiftKey) return false
-  if (parsed.alt !== e.altKey) return false
+  const need = resolvedModifiers(parsed, isMac)
+  if (e.metaKey !== need.meta || e.ctrlKey !== need.ctrl) return false
+  if (e.shiftKey !== need.shift || e.altKey !== need.alt) return false
   return parsed.key !== null && normalizeKey(e.key) === parsed.key
 }
 
@@ -158,9 +233,13 @@ export function matchesShortcut(e: ShortcutKeyEvent, s: string, isMac: boolean):
  *  guard for modifier keys specifically (a non-modifier third key is guarded separately, since
  *  this function ignores `e.key` entirely). */
 export function chordHeld(e: ShortcutKeyEvent, s: string, isMac: boolean): boolean {
-  const parsed = parseShortcut(s)
-  const primaryPressed = isMac ? e.metaKey : e.ctrlKey
-  return parsed.cmd === primaryPressed && parsed.shift === e.shiftKey && parsed.alt === e.altKey
+  const need = resolvedModifiers(parseShortcut(s), isMac)
+  return (
+    e.metaKey === need.meta &&
+    e.ctrlKey === need.ctrl &&
+    e.shiftKey === need.shift &&
+    e.altKey === need.alt
+  )
 }
 
 /**


### PR DESCRIPTION
Adds `src/shared/keybindings.ts`: a command registry (20 commands with platform defaults), per-command binding validation, effective-binding resolution, a platform-resolved conflict detector, override sanitization for the upcoming `settings.keybindings` key, and a pure event→command resolver.

Extends `src/shared/shortcut.ts` with a literal `Ctrl` token (real Control, distinct from the abstract `Cmd`), strict modifier matching, `Comma`/`Slash` key aliases, and `serializeShortcut`.

No behavior change: nothing outside tests imports the new module yet. Four deliberate deltas in `shortcut.ts` (see the module doc): hand-edited mac `"Ctrl+…"` strings now mean real Control; chords no longer match with an extra unrelated modifier held; alias key spellings canonicalize; and capture now records a mac chord's held Control (and refuses a non-mac held Super) so captured chords always round-trip through the strict matcher.

Known follow-up (deliberately out of this PR's `src/shared/` scope): the hold-chord recorder in Settings → Speech does not yet collect the non-primary modifier the same way; it is owed alongside the dictation-setting migration in the settings PR.

Part 1 of the remappable-shortcuts series; the dispatch consolidation PR wires this registry into the window listener, the main process, and ShortcutsPanel next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)