### PR TITLE
fix(kanban): spaces type again in the card modal's note editor

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -313,7 +313,7 @@ import { useSshServers } from '../state/sshServers'
 import { useSshConn } from '../state/sshConn'
 import { useSystemAccount } from '../state/systemAccount'
 import { useEntitlement } from '../state/entitlement'
-import type { SshServer, SshConnection } from '@shared/ssh'
+import type { SshServer } from '@shared/ssh'
 import { sshHostKey } from '@shared/ssh'
 import type {
   CanvasNodeState,
@@ -379,7 +379,6 @@ import {
   flowToNodeStates,
   addSelectionToGroup,
   groupSelectedNodes,
-  NODE_COLORS,
   nodeStatesToFlow,
   reorderGroupWithinParent,
   reorderNodeBefore,
@@ -391,6 +390,7 @@ import {
   ungroupNodes,
   type CanvasNode
 } from '../state/workspace'
+import { toKanbanSession } from './toKanbanSession'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 
@@ -576,58 +576,6 @@ const minimapNodeColor = (n: Node): string =>
  *  reads as `not-resumable`. */
 const restartAgentIdOf = (n: Node | undefined): AgentId | undefined =>
   !n || n.type !== 'terminal' ? undefined : createdAgentId(n.data)
-
-/** One canvas node as a board card, or null when this kind is not a card at all (a group frame, an
- *  editor, a diff). The board derives its cards from the canvas live, so this is the single
- *  definition of that mapping — the card list and the board-log's `cardTitle` lookup must agree on
- *  what a node is called, or a title change would log as a card appearing and disappearing. */
-function toKanbanSession(n: CanvasNode): KanbanSession | null {
-  if (n.type === 'browser') {
-    return {
-      id: n.id,
-      title: (n.data.title as string) || 'Browser',
-      color: (n.data.color as string) ?? NODE_COLORS[0],
-      kind: 'browser',
-      url: n.data.url as string | undefined,
-      partition: n.data.partition as string | undefined,
-      spawn: {}
-    }
-  }
-  if (n.type === 'sticky') {
-    const text = ((n.data.text as string) ?? '').trim()
-    return {
-      id: n.id,
-      // A note has no title of its own — its first line is the card label. Bodies are markdown
-      // now, so a leading heading marker is presentation, not part of the label.
-      title: text.split('\n')[0].replace(/^#{1,6}\s+/, '').slice(0, 80) || 'Note',
-      color: (n.data.color as string) ?? NODE_COLORS[2],
-      kind: 'sticky',
-      text,
-      textUpdatedAt: n.data.textUpdatedAt as number | undefined,
-      textUpdatedBy: n.data.textUpdatedBy as string | undefined,
-      // Sticky cards never open a live terminal — the modal reads no spawn info.
-      spawn: {}
-    }
-  }
-  if (n.type !== 'terminal') return null
-  return {
-    id: n.id,
-    title: (n.data.title as string) ?? '',
-    color: (n.data.color as string) ?? NODE_COLORS[0],
-    kind: 'terminal',
-    agentId: n.data.agentId as string | undefined,
-    // What the card modal's co-attach terminal needs to join THIS node's session the same way the
-    // canvas TerminalNode does.
-    spawn: {
-      shell: n.data.shell as string | undefined,
-      cwd: n.data.cwd as string | undefined,
-      agentId: n.data.agentId as string | undefined,
-      accountId: n.data.accountId as string | undefined,
-      ssh: n.data.ssh as SshConnection | undefined,
-      sshRemoteTmux: !!n.data.sshRemoteTmux
-    }
-  }
-}
 
 /** Stable empty card list, so the closed board's memo never churns array identity. */
 const NO_KANBAN_SESSIONS: KanbanSession[] = []

--- a/src/renderer/canvas/toKanbanSession.test.ts
+++ b/src/renderer/canvas/toKanbanSession.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { toKanbanSession } from './toKanbanSession'
+import type { CanvasNode } from '../state/workspace'
+
+const sticky = (text: string): CanvasNode =>
+  ({
+    id: 'n1',
+    type: 'sticky',
+    position: { x: 0, y: 0 },
+    data: { text }
+  }) as unknown as CanvasNode
+
+describe('toKanbanSession (sticky)', () => {
+  // Issue #285: the card modal's textarea is CONTROLLED by session.text. If the projection trims,
+  // every space/newline typed at the end of the note is stripped on the round-trip — the space key
+  // looks dead in the kanban note editor.
+  it('passes the note body through untrimmed (a trailing space survives the round-trip)', () => {
+    expect(toKanbanSession(sticky('hello '))?.text).toBe('hello ')
+  })
+
+  it('passes a trailing newline through (Enter at the end of a note)', () => {
+    expect(toKanbanSession(sticky('line one\n'))?.text).toBe('line one\n')
+  })
+
+  it('still derives the card label from the trimmed first line', () => {
+    expect(toKanbanSession(sticky('  hello world  \nsecond'))?.title).toBe('hello world')
+  })
+
+  it('labels an all-whitespace note "Note"', () => {
+    expect(toKanbanSession(sticky('   '))?.title).toBe('Note')
+  })
+})
+
+describe('toKanbanSession (sticky, markdown label)', () => {
+  it('strips a leading heading marker from the card label', () => {
+    expect(toKanbanSession(sticky('## Plan \nbody'))?.title).toBe('Plan')
+  })
+})

--- a/src/renderer/canvas/toKanbanSession.ts
+++ b/src/renderer/canvas/toKanbanSession.ts
@@ -1,0 +1,58 @@
+import type { SshConnection } from '@shared/ssh'
+import { NODE_COLORS, type CanvasNode } from '../state/workspace'
+import type { KanbanSession } from '../components/kanban/KanbanView'
+
+/** One canvas node as a board card, or null when this kind is not a card at all (a group frame, an
+ *  editor, a diff). The board derives its cards from the canvas live, so this is the single
+ *  definition of that mapping — the card list and the board-log's `cardTitle` lookup must agree on
+ *  what a node is called, or a title change would log as a card appearing and disappearing. */
+export function toKanbanSession(n: CanvasNode): KanbanSession | null {
+  if (n.type === 'browser') {
+    return {
+      id: n.id,
+      title: (n.data.title as string) || 'Browser',
+      color: (n.data.color as string) ?? NODE_COLORS[0],
+      kind: 'browser',
+      url: n.data.url as string | undefined,
+      partition: n.data.partition as string | undefined,
+      spawn: {}
+    }
+  }
+  if (n.type === 'sticky') {
+    // The card modal's textarea is CONTROLLED by this text: it must be the node's raw value.
+    // Trimming here strips the trailing space/newline the user just typed on every round-trip,
+    // which reads as "the space key doesn't work" in the kanban note editor (issue #285).
+    const text = (n.data.text as string) ?? ''
+    return {
+      id: n.id,
+      // A note has no title of its own — its trimmed first line is the card label. Bodies are
+      // markdown, so a leading heading marker is presentation, not part of the label.
+      title: text.trim().split('\n')[0].replace(/^#{1,6}\s+/, '').trim().slice(0, 80) || 'Note',
+      color: (n.data.color as string) ?? NODE_COLORS[2],
+      kind: 'sticky',
+      text,
+      textUpdatedAt: n.data.textUpdatedAt as number | undefined,
+      textUpdatedBy: n.data.textUpdatedBy as string | undefined,
+      // Sticky cards never open a live terminal — the modal reads no spawn info.
+      spawn: {}
+    }
+  }
+  if (n.type !== 'terminal') return null
+  return {
+    id: n.id,
+    title: (n.data.title as string) ?? '',
+    color: (n.data.color as string) ?? NODE_COLORS[0],
+    kind: 'terminal',
+    agentId: n.data.agentId as string | undefined,
+    // What the card modal's co-attach terminal needs to join THIS node's session the same way the
+    // canvas TerminalNode does.
+    spawn: {
+      shell: n.data.shell as string | undefined,
+      cwd: n.data.cwd as string | undefined,
+      agentId: n.data.agentId as string | undefined,
+      accountId: n.data.accountId as string | undefined,
+      ssh: n.data.ssh as SshConnection | undefined,
+      sshRemoteTmux: !!n.data.sshRemoteTmux
+    }
+  }
+}


### PR DESCRIPTION
Fixes #285.

## The bug

The kanban board derives its sticky cards from canvas nodes via `toKanbanSession`, which **trimmed** the note body — and the card modal's note `<textarea>` is *controlled* by that projected text. A space (or Enter) typed at the end of the note — which is where typing happens — was written through to the node, trimmed away on the very next render, and the controlled value snapped back. Net effect: the space key looked dead in the kanban note editor, while the same note edited fine on the canvas (whose editor reads the raw node text).

## The fix

- Extract `toKanbanSession` from the `Canvas.tsx` monolith into `src/renderer/canvas/toKanbanSession.ts` so the projection is testable (verbatim move otherwise).
- Pass the **raw** note body through as `session.text`; keep trimming only where it belongs — the derived card label (first line, heading marker stripped).
- `SessionCard` already trims its own preview, so no other consumer changes.

## Tests

New `toKanbanSession.test.ts`: trailing space and trailing newline survive the round-trip (both failed against the old projection), the card label stays trimmed + heading-stripped, and an all-whitespace note still labels as "Note".

🤖 Generated with [Claude Code](https://claude.com/claude-code)