### PR TITLE
feat(project-settings): core data layer — shared settings.json, local overlay, content-hash trust store

### DIFF
--- a/src/core/project-settings-files.test.ts
+++ b/src/core/project-settings-files.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { readProjectSettingsFile, writeProjectSettingsFile, projectSettingsPath } from './project-settings-files'
+
+let root: string
+beforeEach(async () => { root = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-psf-')) })
+afterEach(async () => { await fs.rm(root, { recursive: true, force: true }) })
+
+describe('project settings file IO', () => {
+  it('reports absent when the file (or .nodeterm) does not exist', async () => {
+    expect((await readProjectSettingsFile(root)).status).toBe('absent')
+  })
+  it('write → read round-trips and bumps rev only on content change', async () => {
+    const v1 = await writeProjectSettingsFile(root, { terminal: { shell: '/bin/zsh' } }, null, 't1')
+    expect(v1.rev).toBe(1)
+    const same = await writeProjectSettingsFile(root, { terminal: { shell: '/bin/zsh' } }, v1, 't2')
+    expect(same.rev).toBe(1) // unchanged content: no rewrite
+    const v2 = await writeProjectSettingsFile(root, { terminal: { shell: '/bin/bash' } }, v1, 't3')
+    expect(v2.rev).toBe(2)
+    const read = await readProjectSettingsFile(root)
+    expect(read.status).toBe('ok')
+    if (read.status === 'ok') expect(read.file.terminal?.shell).toBe('/bin/bash')
+  })
+  it('sidelines an unparsable file to .corrupt-<ts> and reports invalid', async () => {
+    await fs.mkdir(path.join(root, '.nodeterm'), { recursive: true })
+    await fs.writeFile(projectSettingsPath(root), '{broken', 'utf-8')
+    expect((await readProjectSettingsFile(root)).status).toBe('invalid')
+    const names = await fs.readdir(path.join(root, '.nodeterm'))
+    expect(names.some((n) => n.startsWith('settings.json.corrupt-'))).toBe(true)
+    expect(names.includes('settings.json')).toBe(false)
+  })
+  it('leaves a git-conflict-marked file in place and reports conflict', async () => {
+    await fs.mkdir(path.join(root, '.nodeterm'), { recursive: true })
+    const raw = '<<<<<<< HEAD\n{}\n=======\n{}\n>>>>>>> theirs\n'
+    await fs.writeFile(projectSettingsPath(root), raw, 'utf-8')
+    expect((await readProjectSettingsFile(root)).status).toBe('conflict')
+    expect(await fs.readFile(projectSettingsPath(root), 'utf-8')).toBe(raw)
+  })
+})

--- a/src/core/project-settings-files.test.ts
+++ b/src/core/project-settings-files.test.ts
@@ -38,4 +38,17 @@ describe('project settings file IO', () => {
     expect((await readProjectSettingsFile(root)).status).toBe('conflict')
     expect(await fs.readFile(projectSettingsPath(root), 'utf-8')).toBe(raw)
   })
+  it('bumps rev over prev even when the caller passes back the previously-read file as doc', async () => {
+    const v1 = await writeProjectSettingsFile(root, { terminal: { shell: '/bin/zsh' } }, null, 't1')
+    const read = await readProjectSettingsFile(root)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok') return
+    // A caller may pass the READ FILE straight back as `doc` (it structurally satisfies
+    // ProjectSettingsDoc) — its stale version/rev/savedAt must not survive into the write.
+    const edited = { ...read.file, terminal: { shell: '/bin/fish' } }
+    const v2 = await writeProjectSettingsFile(root, edited, v1, 't2')
+    expect(v2.rev).toBe(v1.rev + 1)
+    expect(v2.savedAt).toBe('t2')
+    expect(v2.terminal?.shell).toBe('/bin/fish')
+  })
 })

--- a/src/core/project-settings-files.ts
+++ b/src/core/project-settings-files.ts
@@ -1,0 +1,61 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import {
+  parseProjectSettingsFile,
+  sameProjectSettingsContent,
+  serializeProjectSettingsFile,
+  PROJECT_SETTINGS_FILE,
+  type ProjectSettingsDoc,
+  type ProjectSettingsFileV1
+} from '../shared/project-settings'
+import { PROJECT_DIR } from './workspace-files'
+import { writeAtomic } from './workspace-store'
+
+/**
+ * Local disk IO for <cwd>/.nodeterm/settings.json — the sibling of workspace-store's project.json
+ * handling, same trust boundary (the file is git-shared hostile input; see shared/project-settings.ts).
+ */
+export type ProjectSettingsRead =
+  | { status: 'ok'; file: ProjectSettingsFileV1 }
+  | { status: 'absent' }
+  | { status: 'conflict' } // left in place, user must resolve
+  | { status: 'invalid' } // sidelined to .corrupt-<ts> (only copy protected)
+  | { status: 'error' } // fs error other than ENOENT
+
+export function projectSettingsPath(cwd: string): string {
+  return path.join(cwd, PROJECT_DIR, PROJECT_SETTINGS_FILE)
+}
+
+export async function readProjectSettingsFile(cwd: string): Promise<ProjectSettingsRead> {
+  const file = projectSettingsPath(cwd)
+  let raw: string
+  try {
+    raw = await fs.readFile(file, 'utf-8')
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === 'ENOENT' ? { status: 'absent' } : { status: 'error' }
+  }
+  const parsed = parseProjectSettingsFile(raw)
+  if (parsed.status === 'ok') return parsed
+  if (parsed.status === 'conflict') return { status: 'conflict' } // left in place — user must resolve
+  // invalid: sideline the only copy so a later write can't overwrite unrecoverable content.
+  try {
+    await fs.rename(file, `${file}.corrupt-${Date.now()}`)
+  } catch { /* best effort — never destroy data */ }
+  return { status: 'invalid' }
+}
+
+/** Whole-document write. Bumps rev over `prev`; skips the write (returns prev) when content is
+ *  unchanged. Creates .nodeterm/ if missing. */
+export async function writeProjectSettingsFile(
+  cwd: string,
+  doc: ProjectSettingsDoc,
+  prev: ProjectSettingsFileV1 | null,
+  savedAt: string
+): Promise<ProjectSettingsFileV1> {
+  const candidate: ProjectSettingsFileV1 = { version: 1, rev: (prev?.rev ?? 0) + 1, savedAt, ...doc }
+  if (prev && sameProjectSettingsContent(prev, candidate)) return prev
+  const file = projectSettingsPath(cwd)
+  await fs.mkdir(path.dirname(file), { recursive: true })
+  await writeAtomic(file, serializeProjectSettingsFile(candidate))
+  return candidate
+}

--- a/src/core/project-settings-files.ts
+++ b/src/core/project-settings-files.ts
@@ -52,7 +52,10 @@ export async function writeProjectSettingsFile(
   prev: ProjectSettingsFileV1 | null,
   savedAt: string
 ): Promise<ProjectSettingsFileV1> {
-  const candidate: ProjectSettingsFileV1 = { version: 1, rev: (prev?.rev ?? 0) + 1, savedAt, ...doc }
+  // `doc` spreads FIRST: a caller may pass back a previously-read ProjectSettingsFileV1 (it
+  // structurally satisfies ProjectSettingsDoc), and its stale version/rev/savedAt must never win
+  // over the bookkeeping this function computes — that would silently defeat rev monotonicity.
+  const candidate: ProjectSettingsFileV1 = { ...doc, version: 1, rev: (prev?.rev ?? 0) + 1, savedAt }
   if (prev && sameProjectSettingsContent(prev, candidate)) return prev
   const file = projectSettingsPath(cwd)
   await fs.mkdir(path.dirname(file), { recursive: true })

--- a/src/core/project-settings-files.ts
+++ b/src/core/project-settings-files.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import {
   parseProjectSettingsFile,
   sameProjectSettingsContent,
+  sanitizeProjectSettingsDoc,
   serializeProjectSettingsFile,
   PROJECT_SETTINGS_FILE,
   type ProjectSettingsDoc,
@@ -52,10 +53,21 @@ export async function writeProjectSettingsFile(
   prev: ProjectSettingsFileV1 | null,
   savedAt: string
 ): Promise<ProjectSettingsFileV1> {
-  // `doc` spreads FIRST: a caller may pass back a previously-read ProjectSettingsFileV1 (it
-  // structurally satisfies ProjectSettingsDoc), and its stale version/rev/savedAt must never win
-  // over the bookkeeping this function computes — that would silently defeat rev monotonicity.
-  const candidate: ProjectSettingsFileV1 = { ...doc, version: 1, rev: (prev?.rev ?? 0) + 1, savedAt }
+  // CANONICAL SHAPE — bookkeeping first, then the sanitized doc, i.e. exactly what
+  // `parseProjectSettingsFile` builds. Two properties ride on that:
+  //  - `sameProjectSettingsContent` compares JSON.stringify output, which is key-ORDER sensitive.
+  //    `prev` almost always comes from a parse (every save reads first), so a doc-first candidate
+  //    would compare unequal to identical content and bump rev + rewrite a git-tracked file on
+  //    every no-op save.
+  //  - sanitizing here (not only at the callers) means a passed-back ProjectSettingsFileV1 — which
+  //    structurally satisfies ProjectSettingsDoc — loses its stale version/rev/savedAt instead of
+  //    overwriting the bookkeeping below, and no unsanitized byte ever reaches the user's repo.
+  const candidate: ProjectSettingsFileV1 = {
+    version: 1,
+    rev: (prev?.rev ?? 0) + 1,
+    savedAt,
+    ...sanitizeProjectSettingsDoc(doc)
+  }
   if (prev && sameProjectSettingsContent(prev, candidate)) return prev
   const file = projectSettingsPath(cwd)
   await fs.mkdir(path.dirname(file), { recursive: true })

--- a/src/core/project-trust-store.test.ts
+++ b/src/core/project-trust-store.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { promises as fs } from 'fs'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs, readFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
 import { initPlatform, resetPlatformForTests } from './platform'
@@ -58,5 +58,28 @@ describe('ProjectTrustStore', () => {
     expect(await store.isTrusted(key, 'setup', hashTrustContent('x'))).toBe(false)
     await store.record(key, 'setup', hashTrustContent('x'), 't')
     expect(await new ProjectTrustStore().isTrusted(key, 'setup', hashTrustContent('x'))).toBe(true)
+  })
+  it('a non-ENOENT read failure fails closed WITHOUT clobbering the file, and heals once readable', async () => {
+    const key = localTrustKey('/proj')
+    const h = hashTrustContent('x')
+    const filePath = path.join(userData, 'project-trust.json')
+    // Seed an intact, persisted approval with a fresh store instance (its own uncorrupted cache).
+    await new ProjectTrustStore().record(key, 'setup', h, 't1')
+    const original = readFileSync(filePath, 'utf-8')
+
+    const store = new ProjectTrustStore() // fresh instance: cache is empty, forces a real read
+    const err = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    const spy = vi.spyOn(fs, 'readFile').mockRejectedValue(err)
+    try {
+      expect(await store.isTrusted(key, 'setup', h)).toBe(false)
+      await expect(store.record(key, 'setup', h, 't2')).rejects.toThrow()
+      // The failed record() must not have written anything — readFileSync bypasses the mocked
+      // promises API, so this reads the real on-disk bytes.
+      expect(readFileSync(filePath, 'utf-8')).toBe(original)
+    } finally {
+      spy.mockRestore()
+    }
+    // Once the fs is readable again, the original (never-clobbered) approval is still there.
+    expect(await store.isTrusted(key, 'setup', h)).toBe(true)
   })
 })

--- a/src/core/project-trust-store.test.ts
+++ b/src/core/project-trust-store.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform } from './platform-fake'
+import { ProjectTrustStore, localTrustKey, sshTrustKey, hashTrustContent } from './project-trust-store'
+
+let userData: string
+beforeEach(async () => {
+  userData = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-trust-'))
+  initPlatform(fakePlatform({ userDataDir: userData }))
+})
+afterEach(async () => { resetPlatformForTests(); await fs.rm(userData, { recursive: true, force: true }) })
+
+describe('trust keys', () => {
+  it('are location identities, distinct per kind and per folder', () => {
+    expect(localTrustKey('/a/b')).not.toBe(localTrustKey('/a/c'))
+    const ssh = sshTrustKey({ server: { host: 'h', user: 'u' }, remoteCwd: '/srv/x' })
+    expect(ssh).toContain('u@h')
+    expect(ssh).not.toBe(localTrustKey('/srv/x'))
+  })
+})
+
+describe('ProjectTrustStore', () => {
+  it('approval round-trips and survives a new store instance (persisted)', async () => {
+    const key = localTrustKey('/proj')
+    const hash = hashTrustContent('npm ci')
+    const store = new ProjectTrustStore()
+    expect(await store.isTrusted(key, 'setup', hash)).toBe(false)
+    await store.record(key, 'setup', hash, '2026-08-19T00:00:00Z')
+    expect(await store.isTrusted(key, 'setup', hash)).toBe(true)
+    expect(await new ProjectTrustStore().isTrusted(key, 'setup', hash)).toBe(true)
+  })
+  it('changed content is NOT trusted; other families are independent', async () => {
+    const key = localTrustKey('/proj')
+    const store = new ProjectTrustStore()
+    await store.record(key, 'setup', hashTrustContent('npm ci'), 't')
+    expect(await store.isTrusted(key, 'setup', hashTrustContent('npm ci && evil'))).toBe(false)
+    expect(await store.isTrusted(key, 'agents', hashTrustContent('npm ci'))).toBe(false)
+  })
+  it('revoke drops one family or the whole key', async () => {
+    const key = localTrustKey('/proj')
+    const h = hashTrustContent('x')
+    const store = new ProjectTrustStore()
+    await store.record(key, 'setup', h, 't')
+    await store.record(key, 'shell', h, 't')
+    await store.revoke(key, 'setup')
+    expect(await store.isTrusted(key, 'setup', h)).toBe(false)
+    expect(await store.isTrusted(key, 'shell', h)).toBe(true)
+    await store.revoke(key)
+    expect(await store.isTrusted(key, 'shell', h)).toBe(false)
+  })
+  it('a malformed trust file fails closed (empty store), then heals on next record', async () => {
+    await fs.writeFile(path.join(userData, 'project-trust.json'), '{oops', 'utf-8')
+    const store = new ProjectTrustStore()
+    const key = localTrustKey('/proj')
+    expect(await store.isTrusted(key, 'setup', hashTrustContent('x'))).toBe(false)
+    await store.record(key, 'setup', hashTrustContent('x'), 't')
+    expect(await new ProjectTrustStore().isTrusted(key, 'setup', hashTrustContent('x'))).toBe(true)
+  })
+})

--- a/src/core/project-trust-store.test.ts
+++ b/src/core/project-trust-store.test.ts
@@ -39,6 +39,17 @@ describe('ProjectTrustStore', () => {
     expect(await store.isTrusted(key, 'setup', hashTrustContent('npm ci && evil'))).toBe(false)
     expect(await store.isTrusted(key, 'agents', hashTrustContent('npm ci'))).toBe(false)
   })
+  it('getRecord answers the stored approval, or null when there is none', async () => {
+    const key = localTrustKey('/proj')
+    const hash = hashTrustContent('npm ci')
+    const store = new ProjectTrustStore()
+    expect(await store.getRecord(key, 'setup')).toBeNull()
+    await store.record(key, 'setup', hash, '2026-08-19T00:00:00Z')
+    expect(await store.getRecord(key, 'setup')).toEqual({ contentHash: hash, approvedAt: '2026-08-19T00:00:00Z' })
+    expect(await store.getRecord(key, 'agents')).toBeNull() // another family is not this one
+    expect(await store.getRecord(localTrustKey('/other'), 'setup')).toBeNull()
+  })
+
   it('revoke drops one family or the whole key', async () => {
     const key = localTrustKey('/proj')
     const h = hashTrustContent('x')

--- a/src/core/project-trust-store.ts
+++ b/src/core/project-trust-store.ts
@@ -1,0 +1,99 @@
+import { promises as fs } from 'fs'
+import { createHash } from 'node:crypto'
+import path from 'path'
+import type { ProjectTrustFamily } from '../shared/project-settings'
+import type { SshConnection } from '../shared/ssh'
+import { sshHostKey } from '../shared/ssh'
+import { platform } from './platform'
+import { writeAtomic } from './workspace-store'
+
+export interface ProjectTrustRecord {
+  contentHash: string
+  approvedAt: string
+}
+
+/** Location identity, NEVER a project id (ids are attacker-controlled — hostile-project-json). */
+export function localTrustKey(cwd: string): string {
+  return `local\0${path.resolve(cwd)}`
+}
+
+export function sshTrustKey(ssh: { server: Pick<SshConnection, 'host' | 'user'>; remoteCwd: string }): string {
+  return `ssh\0${sshHostKey(ssh.server)}\0${ssh.remoteCwd}`
+}
+
+export function hashTrustContent(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex')
+}
+
+type TrustFileEntry = Partial<Record<ProjectTrustFamily, ProjectTrustRecord>>
+type TrustFile = Record<string, TrustFileEntry>
+
+/**
+ * File: {userData}/project-trust.json. Lazy-loaded, cached; malformed file → empty store (fail
+ * closed — an unreadable trust record must never be read back as "trusted").
+ *
+ * `record`/`revoke` serialize through an internal promise chain: both are read-modify-write over
+ * the same in-memory + on-disk store, and two overlapping calls racing the read half would let the
+ * later write silently clobber the earlier one's change.
+ */
+export class ProjectTrustStore {
+  private cache: TrustFile | null = null
+  private chain: Promise<unknown> = Promise.resolve()
+
+  private get filePath(): string {
+    return path.join(platform().userDataDir, 'project-trust.json')
+  }
+
+  private async load(): Promise<TrustFile> {
+    if (this.cache) return this.cache
+    let raw: string
+    try {
+      raw = await fs.readFile(this.filePath, 'utf-8')
+    } catch {
+      this.cache = {}
+      return this.cache
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      this.cache = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as TrustFile) : {}
+    } catch {
+      this.cache = {}
+    }
+    return this.cache
+  }
+
+  async isTrusted(key: string, family: ProjectTrustFamily, contentHash: string): Promise<boolean> {
+    const store = await this.load()
+    return store[key]?.[family]?.contentHash === contentHash
+  }
+
+  async record(key: string, family: ProjectTrustFamily, contentHash: string, approvedAt: string): Promise<void> {
+    return this.mutate((store) => {
+      store[key] = { ...store[key], [family]: { contentHash, approvedAt } }
+    })
+  }
+
+  async revoke(key: string, family?: ProjectTrustFamily): Promise<void> {
+    return this.mutate((store) => {
+      if (!store[key]) return
+      if (!family) {
+        delete store[key]
+        return
+      }
+      const { [family]: _dropped, ...rest } = store[key]
+      if (Object.keys(rest).length) store[key] = rest
+      else delete store[key]
+    })
+  }
+
+  private mutate(fn: (store: TrustFile) => void): Promise<void> {
+    const run = this.chain.then(async () => {
+      const store = await this.load()
+      fn(store)
+      this.cache = store
+      await writeAtomic(this.filePath, JSON.stringify(store, null, 2))
+    })
+    this.chain = run.catch(() => {})
+    return run
+  }
+}

--- a/src/core/project-trust-store.ts
+++ b/src/core/project-trust-store.ts
@@ -29,8 +29,12 @@ type TrustFileEntry = Partial<Record<ProjectTrustFamily, ProjectTrustRecord>>
 type TrustFile = Record<string, TrustFileEntry>
 
 /**
- * File: {userData}/project-trust.json. Lazy-loaded, cached; malformed file → empty store (fail
- * closed — an unreadable trust record must never be read back as "trusted").
+ * File: {userData}/project-trust.json. Lazy-loaded, cached; malformed (unparsable/wrong-shape)
+ * file → empty store (fail closed — an unreadable trust record must never be read back as
+ * "trusted"). A read ERROR (EACCES/EMFILE/EIO…) is different from ABSENT/malformed: it is not
+ * evidence the file is empty, so it is never cached and never healed by a write — `isTrusted` fails
+ * closed without caching the emptiness, and `record`/`revoke` reject rather than writeAtomic an
+ * empty store over the intact on-disk file.
  *
  * `record`/`revoke` serialize through an internal promise chain: both are read-modify-write over
  * the same in-memory + on-disk store, and two overlapping calls racing the read half would let the
@@ -49,9 +53,16 @@ export class ProjectTrustStore {
     let raw: string
     try {
       raw = await fs.readFile(this.filePath, 'utf-8')
-    } catch {
-      this.cache = {}
-      return this.cache
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.cache = {}
+        return this.cache
+      }
+      // A non-ENOENT failure (EACCES/EMFILE/EIO…) is not evidence the file is absent — caching {}
+      // here would let the next mutate() writeAtomic an empty store over the intact on-disk file,
+      // silently destroying every recorded approval. Leave the cache unset so the next call
+      // retries the read, and let this failure propagate to the caller.
+      throw e
     }
     try {
       const parsed: unknown = JSON.parse(raw)
@@ -63,7 +74,13 @@ export class ProjectTrustStore {
   }
 
   async isTrusted(key: string, family: ProjectTrustFamily, contentHash: string): Promise<boolean> {
-    const store = await this.load()
+    let store: TrustFile
+    try {
+      store = await this.load()
+    } catch {
+      // Fail closed on a read error — never cached, so the next call retries the read.
+      return false
+    }
     return store[key]?.[family]?.contentHash === contentHash
   }
 

--- a/src/core/project-trust-store.ts
+++ b/src/core/project-trust-store.ts
@@ -84,6 +84,25 @@ export class ProjectTrustStore {
     return store[key]?.[family]?.contentHash === contentHash
   }
 
+  /**
+   * The stored approval for one family, or null when there is none. For DIALOG COPY only — "you
+   * approved this on <date>, and it has changed since" — never as the basis of a grant: a caller
+   * deciding whether something may RUN asks `isTrusted`, which compares the hash itself.
+   *
+   * Mirrors `isTrusted`'s posture on a read failure (catch → null, nothing cached) rather than
+   * `record`/`revoke`'s (propagate): the same fail-closed answer as "no approval on file", which
+   * for this caller costs a re-prompt, never an unearned yes.
+   */
+  async getRecord(key: string, family: ProjectTrustFamily): Promise<ProjectTrustRecord | null> {
+    let store: TrustFile
+    try {
+      store = await this.load()
+    } catch {
+      return null
+    }
+    return store[key]?.[family] ?? null
+  }
+
   async record(key: string, family: ProjectTrustFamily, contentHash: string, approvedAt: string): Promise<void> {
     return this.mutate((store) => {
       store[key] = { ...store[key], [family]: { contentHash, approvedAt } }

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -138,6 +138,20 @@ export interface IndexEntryV3 {
    *  live in this same machine-local file already. */
   localExec?: LocalNodeExecMap
   /**
+   * MACHINE-LOCAL settings overlay for this entry — the half of the project settings that is NOT
+   * git-shared (`.nodeterm/settings.json` is the shared half). Same rule as `localExec`: it lives in
+   * userData because a shell, a launch command or an env var this user chose for THIS checkout is
+   * not something a repo may carry — and, read the other way, a repo may not put values here.
+   * Re-sanitized on every load (`sanitizeProjectLocalSettings`): workspace.json is hand-editable,
+   * so what comes back out of it is input, not state we wrote.
+   */
+  localSettings?: import('../shared/project-settings').ProjectLocalSettings
+  /** The last shared settings.json seen for an SSH entry — the settings twin of `cache`, used while
+   *  the server is unreachable. Never set for a local/inline entry (their shared doc is one disk
+   *  read away). Validated on load by re-parsing it, exactly like a file read off the remote host:
+   *  what sits in workspace.json is no more trusted than what sits on the server. */
+  settingsCache?: import('../shared/project-settings').ProjectSettingsFileV1
+  /**
    * The one-time exec migration has run for this entry: its project file has been searched once for
    * the exec values it carried from BEFORE the trust boundary existed (a jump host's `ProxyCommand`
    * put there by `createSshTerminalNode`), and they were hoisted into `localExec` above.

--- a/src/core/workspace-store.settings.test.ts
+++ b/src/core/workspace-store.settings.test.ts
@@ -247,6 +247,61 @@ describe('project settings — ssh leg', () => {
     expect(idx.entries[0].settingsCache.setup.setupScript).toBe('kept')
   })
 
+  it('a write landing mid-read is not downgraded by the older doc that read was already fetching', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((r) => { release = r })
+    const store = new WorkspaceStore({
+      ...fakeIO,
+      readSettings: async () => {
+        await gate
+        return { status: 'ok' as const, content: JSON.stringify(
+          { version: 1, rev: 1, savedAt: 't', setup: { setupScript: 'remote-rev1' } }) }
+      }
+    })
+    await store.save(ws([sshProject()]))
+    await store.writeProjectSettings('ps1', { setup: { setupScript: 'v1' } }) // cache rev 1
+    const reading = store.readProjectSettings('ps1') // in flight, host still answering rev 1
+    await store.writeProjectSettings('ps1', { setup: { setupScript: 'v2' } }) // cache rev 2
+    release()
+    const s = await reading
+    expect(s?.shared?.setup?.setupScript).toBe('v2') // NOT the rev-1 doc the read was carrying
+    const idx = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
+    expect(idx.entries[0].settingsCache.rev).toBe(2) // and no downgrade was persisted
+  })
+
+  it('refuses to write while the host file is conflict-marked, and resumes once it is resolved', async () => {
+    const writes: string[] = []
+    let remote = '<<<<<<< a\n{}\n=======\n{}\n>>>>>>> b\n'
+    const store = new WorkspaceStore({
+      ...fakeIO,
+      readSettings: async () => ({ status: 'ok' as const, content: remote }),
+      writeSettings: async (_id: string, _ssh: { remoteCwd: string }, content: string) => {
+        writes.push(content); return true
+      }
+    })
+    await store.save(ws([sshProject()]))
+    expect((await store.readProjectSettings('ps1'))?.conflict).toBe(true)
+    expect(await store.writeProjectSettings('ps1', { setup: { setupScript: 'nope' } })).toBe(false)
+    expect(writes).toEqual([]) // nothing was pushed over the merge
+    remote = JSON.stringify({ version: 1, rev: 3, savedAt: 't', setup: { setupScript: 'resolved' } })
+    expect((await store.readProjectSettings('ps1'))?.shared?.setup?.setupScript).toBe('resolved')
+    expect(await store.writeProjectSettings('ps1', { setup: { setupScript: 'after' } })).toBe(true)
+    expect(writes.join('|')).toContain('after')
+  })
+
+  it('an adopted remote doc is persisted to the index and served after a reload', async () => {
+    const store = new WorkspaceStore(fakeIO)
+    await store.save(ws([sshProject()]))
+    remoteFs.set('/srv/app/.nodeterm/settings.json', JSON.stringify(
+      { version: 1, rev: 4, savedAt: 't', setup: { setupScript: 'from-host' } }))
+    expect((await store.readProjectSettings('ps1'))?.shared?.setup?.setupScript).toBe('from-host')
+    const store2 = new WorkspaceStore({ ...fakeIO, readSettings: async () => ({ status: 'error' as const }) })
+    await store2.load()
+    const s = await store2.readProjectSettings('ps1')
+    expect(s?.shared?.setup?.setupScript).toBe('from-host')
+    expect(s?.shared?.rev).toBe(4)
+  })
+
   it('an ssh project with no remote IO at all still reads and writes its cache', async () => {
     const store = new WorkspaceStore()
     await store.save(ws([sshProject()]))

--- a/src/core/workspace-store.settings.test.ts
+++ b/src/core/workspace-store.settings.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform } from './platform-fake'
+import { WorkspaceStore } from './workspace-store'
+import type { Project, Workspace } from '../shared/types'
+
+let userData: string
+let projRoot: string
+let fake: ReturnType<typeof fakePlatform>
+
+const project = (over: Partial<Project> = {}): Project => ({
+  id: 'p1', name: 'foo', color: '#7aa2f7', viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: [{ id: 'term-1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null }],
+  ...over
+})
+const ws = (projects: Project[], active = projects[0]?.id ?? ''): Workspace =>
+  ({ version: 2, activeProjectId: active, projects })
+
+beforeEach(async () => {
+  userData = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-ws-'))
+  projRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-proj-'))
+  fake = fakePlatform({ userDataDir: userData })
+  initPlatform(fake)
+})
+afterEach(async () => {
+  resetPlatformForTests()
+  await fs.rm(userData, { recursive: true, force: true })
+  await fs.rm(projRoot, { recursive: true, force: true })
+})
+
+describe('project settings — local leg', () => {
+  it('write → read round-trips through the store', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    expect(await store.writeProjectSettings('p1', { terminal: { shell: '/bin/zsh' } })).toBe(true)
+    const s = await store.readProjectSettings('p1')
+    expect(s?.shared?.terminal?.shell).toBe('/bin/zsh')
+    const onDisk = JSON.parse(await fs.readFile(path.join(projRoot, '.nodeterm', 'settings.json'), 'utf-8'))
+    expect(onDisk.rev).toBe(1)
+  })
+
+  it('local overlay persists across store instances without a canvas save', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    await store.updateLocalProjectSettings('p1', { ignoreShared: { setup: true } })
+    const store2 = new WorkspaceStore()
+    await store2.load()
+    const s = await store2.readProjectSettings('p1')
+    expect(s?.local).toEqual({ ignoreShared: { setup: true } })
+  })
+
+  it('a canvas save does not drop the overlay (survives splitWorkspace round trip)', async () => {
+    const store = new WorkspaceStore()
+    const w = ws([project({ cwd: projRoot })])
+    await store.save(w)
+    await store.updateLocalProjectSettings('p1', { terminal: { shell: '/bin/fish' } })
+    await store.save(w) // canvas autosave rebuilds the index
+    const idx = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
+    expect(idx.entries[0].localSettings).toEqual({ terminal: { shell: '/bin/fish' } })
+  })
+
+  it('clearing the overlay removes it from the index', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    const idxPath = path.join(userData, 'workspace.json')
+    await store.updateLocalProjectSettings('p1', { terminal: { shell: '/bin/fish' } })
+    const set = JSON.parse(await fs.readFile(idxPath, 'utf-8'))
+    expect(set.entries[0].localSettings).toEqual({ terminal: { shell: '/bin/fish' } })
+    await store.updateLocalProjectSettings('p1', undefined)
+    const idx = JSON.parse(await fs.readFile(idxPath, 'utf-8'))
+    expect(idx.entries[0].localSettings).toBeUndefined()
+    const s = await store.readProjectSettings('p1')
+    expect(s?.local).toBeUndefined()
+  })
+
+  it('a git-conflicted settings.json reads as conflict with shared null', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    await fs.mkdir(path.join(projRoot, '.nodeterm'), { recursive: true })
+    await fs.writeFile(path.join(projRoot, '.nodeterm', 'settings.json'),
+      '<<<<<<< a\n{}\n=======\n{}\n>>>>>>> b\n', 'utf-8')
+    const s = await store.readProjectSettings('p1')
+    expect(s?.conflict).toBe(true)
+    expect(s?.shared).toBeNull()
+  })
+
+  it('an inline (cwd-less) project has no shared doc and cannot be written to', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ id: 'inline1', name: 'inline' })]))
+    await store.updateLocalProjectSettings('inline1', { terminal: { theme: 'dark' } })
+    const s = await store.readProjectSettings('inline1')
+    expect(s?.shared).toBeNull()
+    expect(s?.local).toEqual({ terminal: { theme: 'dark' } })
+    expect(await store.writeProjectSettings('inline1', { terminal: { shell: '/bin/zsh' } })).toBe(false)
+  })
+
+  it('returns null for an unknown project id', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    expect(await store.readProjectSettings('nope')).toBeNull()
+    expect(await store.writeProjectSettings('nope', {})).toBe(false)
+    expect(await store.updateLocalProjectSettings('nope', {})).toBe(false)
+  })
+
+  it('a hostile localSettings shape in workspace.json is sanitized on load', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    const idxPath = path.join(userData, 'workspace.json')
+    const idx = JSON.parse(await fs.readFile(idxPath, 'utf-8'))
+    // JSON.parse (not an object literal): only the parser creates `__proto__` as a real OWN
+    // property — a literal would set the prototype and the key would never reach the file.
+    idx.entries[0].localSettings = JSON.parse('{"agents":{"env":{"__proto__":"x","OK":"v"}},"bogus":1}')
+    const rawIndex = JSON.stringify(idx)
+    expect(rawIndex).toContain('__proto__') // the hostile key really is on disk
+    await fs.writeFile(idxPath, rawIndex, 'utf-8')
+    const store2 = new WorkspaceStore()
+    await store2.load()
+    const s = await store2.readProjectSettings('p1')
+    expect(s?.local).toEqual({ agents: { env: { OK: 'v' } } })
+  })
+
+  it('a hostile settingsCache in workspace.json is rejected on load', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([
+      project({ id: 'ssh1', name: 'remote', ssh: { server: { host: 'h', user: 'u' }, remoteCwd: '~/x' } })
+    ]))
+    const idxPath = path.join(userData, 'workspace.json')
+    const idx = JSON.parse(await fs.readFile(idxPath, 'utf-8'))
+    idx.entries[0].settingsCache = { version: 2, rev: 'nope', terminal: { shell: '/bin/evil' } }
+    await fs.writeFile(idxPath, JSON.stringify(idx), 'utf-8')
+    const store2 = new WorkspaceStore()
+    await store2.load()
+    const s = await store2.readProjectSettings('ssh1')
+    expect(s?.shared).toBeNull()
+  })
+})

--- a/src/core/workspace-store.settings.test.ts
+++ b/src/core/workspace-store.settings.test.ts
@@ -164,3 +164,94 @@ describe('project settings — local leg', () => {
     expect(s?.shared).toBeNull()
   })
 })
+
+const remoteFs = new Map<string, string>()
+const fakeIO = {
+  read: async () => ({ status: 'absent' as const }),
+  write: async () => true,
+  readSettings: async (_id: string, ssh: { remoteCwd: string }) => {
+    const c = remoteFs.get(ssh.remoteCwd + '/.nodeterm/settings.json')
+    return c === undefined ? { status: 'absent' as const } : { status: 'ok' as const, content: c }
+  },
+  writeSettings: async (_id: string, ssh: { remoteCwd: string }, content: string) => {
+    remoteFs.set(ssh.remoteCwd + '/.nodeterm/settings.json', content); return true
+  }
+}
+const sshProject = () => project({ id: 'ps1', cwd: undefined, ssh: { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' } })
+
+describe('project settings — ssh leg', () => {
+  beforeEach(() => remoteFs.clear())
+  it('write lands in the cache AND on the remote; read adopts the higher remote rev', async () => {
+    const store = new WorkspaceStore(fakeIO)
+    await store.save(ws([sshProject()]))
+    expect(await store.writeProjectSettings('ps1', { setup: { setupScript: 'make' } })).toBe(true)
+    expect(remoteFs.get('/srv/app/.nodeterm/settings.json')).toContain('make')
+    remoteFs.set('/srv/app/.nodeterm/settings.json', JSON.stringify(
+      { version: 1, rev: 9, savedAt: 't', setup: { setupScript: 'newer-remote' } }))
+    const s = await store.readProjectSettings('ps1')
+    expect(s?.shared?.setup?.setupScript).toBe('newer-remote')
+  })
+  it('remote read failure serves the cache (offline)', async () => {
+    const store = new WorkspaceStore({ ...fakeIO, readSettings: async () => ({ status: 'error' as const }) })
+    await store.save(ws([sshProject()]))
+    await store.writeProjectSettings('ps1', { setup: { setupScript: 'cached' } })
+    const s = await store.readProjectSettings('ps1')
+    expect(s?.shared?.setup?.setupScript).toBe('cached')
+  })
+  it('an absent remote file is healed from the cache on read', async () => {
+    const store = new WorkspaceStore(fakeIO)
+    await store.save(ws([sshProject()]))
+    await store.writeProjectSettings('ps1', { setup: { setupScript: 'mine' } })
+    remoteFs.clear()
+    await store.readProjectSettings('ps1')
+    expect(remoteFs.get('/srv/app/.nodeterm/settings.json')).toContain('mine')
+  })
+  it('settings cache survives a store reload via the index entry', async () => {
+    const store = new WorkspaceStore(fakeIO)
+    await store.save(ws([sshProject()]))
+    await store.writeProjectSettings('ps1', { setup: { setupScript: 'persisted' } })
+    const store2 = new WorkspaceStore({ ...fakeIO, readSettings: async () => ({ status: 'error' as const }) })
+    await store2.load()
+    const s = await store2.readProjectSettings('ps1')
+    expect(s?.shared?.setup?.setupScript).toBe('persisted')
+  })
+
+  it('an offline edit (cache newer than the remote) is pushed back and wins the read', async () => {
+    const store = new WorkspaceStore(fakeIO)
+    await store.save(ws([sshProject()]))
+    await store.writeProjectSettings('ps1', { setup: { setupScript: 'a' } }) // rev 1
+    await store.writeProjectSettings('ps1', { setup: { setupScript: 'offline-edit' } }) // rev 2
+    remoteFs.set('/srv/app/.nodeterm/settings.json', JSON.stringify(
+      { version: 1, rev: 1, savedAt: 't', setup: { setupScript: 'stale-remote' } }))
+    const s = await store.readProjectSettings('ps1')
+    expect(s?.shared?.setup?.setupScript).toBe('offline-edit')
+    expect(remoteFs.get('/srv/app/.nodeterm/settings.json')).toContain('offline-edit')
+  })
+
+  it('a conflict-marked remote file is reported as such and never overwritten', async () => {
+    const store = new WorkspaceStore(fakeIO)
+    await store.save(ws([sshProject()]))
+    const conflicted = '<<<<<<< a\n{}\n=======\n{}\n>>>>>>> b\n'
+    remoteFs.set('/srv/app/.nodeterm/settings.json', conflicted)
+    const s = await store.readProjectSettings('ps1')
+    expect(s?.conflict).toBe(true)
+    expect(s?.shared).toBeNull()
+    expect(remoteFs.get('/srv/app/.nodeterm/settings.json')).toBe(conflicted)
+  })
+
+  it('a remote write failure still keeps the edit (cache-first) and reports success', async () => {
+    const store = new WorkspaceStore({ ...fakeIO, writeSettings: async () => false })
+    await store.save(ws([sshProject()]))
+    expect(await store.writeProjectSettings('ps1', { setup: { setupScript: 'kept' } })).toBe(true)
+    const idx = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
+    expect(idx.entries[0].settingsCache.setup.setupScript).toBe('kept')
+  })
+
+  it('an ssh project with no remote IO at all still reads and writes its cache', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([sshProject()]))
+    expect(await store.writeProjectSettings('ps1', { setup: { setupScript: 'no-io' } })).toBe(true)
+    const s = await store.readProjectSettings('ps1')
+    expect(s?.shared?.setup?.setupScript).toBe('no-io')
+  })
+})

--- a/src/core/workspace-store.settings.test.ts
+++ b/src/core/workspace-store.settings.test.ts
@@ -58,6 +58,32 @@ describe('project settings — local leg', () => {
     expect(onDisk.terminal.shell).toBe('/bin/bash')
   })
 
+  it('re-saving identical content neither bumps rev nor rewrites the bytes', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    await store.writeProjectSettings('p1', { terminal: { shell: '/bin/zsh' } })
+    const file = path.join(projRoot, '.nodeterm', 'settings.json')
+    await store.readProjectSettings('p1') // the panel always reads before it saves
+    const before = await fs.readFile(file, 'utf-8')
+    expect(await store.writeProjectSettings('p1', { terminal: { shell: '/bin/zsh' } })).toBe(true)
+    // A no-op save must not churn a git-tracked file: same bytes, same rev.
+    expect(await fs.readFile(file, 'utf-8')).toBe(before)
+    expect(JSON.parse(before).rev).toBe(1)
+  })
+
+  it('re-reads before every write, so a file conflicted since the last read is left alone', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    await store.writeProjectSettings('p1', { terminal: { shell: '/bin/zsh' } })
+    await store.readProjectSettings('p1') // warms the rev source
+    const file = path.join(projRoot, '.nodeterm', 'settings.json')
+    // …and then a git pull leaves conflict markers behind our back.
+    const conflicted = '<<<<<<< a\n{}\n=======\n{}\n>>>>>>> b\n'
+    await fs.writeFile(file, conflicted, 'utf-8')
+    expect(await store.writeProjectSettings('p1', { terminal: { shell: '/bin/bash' } })).toBe(false)
+    expect(await fs.readFile(file, 'utf-8')).toBe(conflicted)
+  })
+
   it('refuses to write over a git-conflicted settings.json, leaving the bytes untouched', async () => {
     const store = new WorkspaceStore()
     await store.save(ws([project({ cwd: projRoot })]))
@@ -250,9 +276,13 @@ describe('project settings — ssh leg', () => {
   it('a write landing mid-read is not downgraded by the older doc that read was already fetching', async () => {
     let release!: () => void
     const gate = new Promise<void>((r) => { release = r })
+    // The FIRST call is the cold write's own read-before-write (the host has no file yet); only the
+    // read under test — the one racing the second write — waits on the gate.
+    let coldPreflight = true
     const store = new WorkspaceStore({
       ...fakeIO,
       readSettings: async () => {
+        if (coldPreflight) { coldPreflight = false; return { status: 'absent' as const } }
         await gate
         return { status: 'ok' as const, content: JSON.stringify(
           { version: 1, rev: 1, savedAt: 't', setup: { setupScript: 'remote-rev1' } }) }
@@ -300,6 +330,22 @@ describe('project settings — ssh leg', () => {
     const s = await store2.readProjectSettings('ps1')
     expect(s?.shared?.setup?.setupScript).toBe('from-host')
     expect(s?.shared?.rev).toBe(4)
+  })
+
+  it('a cold store reads the host before its first ssh write, and refuses a conflict-marked file', async () => {
+    const writes: string[] = []
+    const conflicted = '<<<<<<< a\n{}\n=======\n{}\n>>>>>>> b\n'
+    const store = new WorkspaceStore({
+      ...fakeIO,
+      readSettings: async () => ({ status: 'ok' as const, content: conflicted }),
+      writeSettings: async (_id: string, _ssh: { remoteCwd: string }, content: string) => {
+        writes.push(content); return true
+      }
+    })
+    await store.save(ws([sshProject()]))
+    // Nothing has been read this run, so the runtime conflict flag is cold — the write must look.
+    expect(await store.writeProjectSettings('ps1', { setup: { setupScript: 'nope' } })).toBe(false)
+    expect(writes).toEqual([])
   })
 
   it('an ssh project with no remote IO at all still reads and writes its cache', async () => {

--- a/src/core/workspace-store.settings.test.ts
+++ b/src/core/workspace-store.settings.test.ts
@@ -42,6 +42,33 @@ describe('project settings — local leg', () => {
     expect(onDisk.rev).toBe(1)
   })
 
+  it('a cold store reads before writing, so the rev sequence continues instead of restarting', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    await store.writeProjectSettings('p1', { terminal: { shell: '/bin/zsh' } }) // rev 1
+    const file = path.join(projRoot, '.nodeterm', 'settings.json')
+    expect(JSON.parse(await fs.readFile(file, 'utf-8')).rev).toBe(1)
+
+    // A fresh process: nothing has been read this run, so the write must look at the file first.
+    const store2 = new WorkspaceStore()
+    await store2.load()
+    expect(await store2.writeProjectSettings('p1', { terminal: { shell: '/bin/bash' } })).toBe(true)
+    const onDisk = JSON.parse(await fs.readFile(file, 'utf-8'))
+    expect(onDisk.rev).toBe(2)
+    expect(onDisk.terminal.shell).toBe('/bin/bash')
+  })
+
+  it('refuses to write over a git-conflicted settings.json, leaving the bytes untouched', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    const file = path.join(projRoot, '.nodeterm', 'settings.json')
+    const conflicted = '<<<<<<< a\n{}\n=======\n{}\n>>>>>>> b\n'
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await fs.writeFile(file, conflicted, 'utf-8')
+    expect(await store.writeProjectSettings('p1', { terminal: { shell: '/bin/zsh' } })).toBe(false)
+    expect(await fs.readFile(file, 'utf-8')).toBe(conflicted)
+  })
+
   it('local overlay persists across store instances without a canvas save', async () => {
     const store = new WorkspaceStore()
     await store.save(ws([project({ cwd: projRoot })]))

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -47,7 +47,7 @@ interface LoadedEntry {
 }
 
 let tmpSeq = 0
-async function writeAtomic(filePath: string, content: string): Promise<void> {
+export async function writeAtomic(filePath: string, content: string): Promise<void> {
   // Unique per write: writers that bypass each other's queue (a second app instance, the SSH
   // poll's index write) must never share a tmp file — interleaved writes into one shared tmp
   // published spliced JSON under the atomic rename.

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -158,10 +158,12 @@ export class WorkspaceStore {
   /** ssh project id -> last shared settings.json seen on that host (offline copy). Only entries that
    *  round-tripped through `parseProjectSettingsFile` are in here. */
   private settingsCacheByProject = new Map<string, ProjectSettingsFileV1>()
-  /** ssh project ids whose settings.json was git-conflict-marked on the last read, so a write must
-   *  refuse instead of picking a side of the merge (the local leg refuses the same way, straight off
-   *  the file). Cleared as soon as a read finds the file parsing again — or gone. Runtime-only: a
-   *  fresh run's first read re-establishes it before any write can be issued from the panel. */
+  /** ssh project ids whose settings.json was git-conflict-marked on the last read: `writeSshSettings`
+   *  refuses while an id is in here instead of picking a side of the merge (the local leg refuses
+   *  the same way, straight off the file it re-reads). Cleared as soon as a read finds the file
+   *  parsing again — or gone. Runtime-only, and deliberately NOT relied on to be populated: a write
+   *  that finds both settings maps cold does its own read first, because "a read established this
+   *  flag before any write" is an assumption about panel order, not something this store enforces. */
   private settingsConflictByProject = new Set<string>()
   /** project id -> the shared settings file as last read/written, i.e. the rev source for the NEXT
    *  write. Runtime-only: a write that has not read first starts at rev 1, which is the same thing
@@ -573,10 +575,16 @@ export class WorkspaceStore {
    * persisted into workspace.json; running it through the same sanitizer a read applies keeps one
    * definition of "a valid settings file" whichever side the bytes came from.
    *
-   * REFUSES while the last read found the host's file git-conflict-marked, exactly like the local
-   * leg refuses a conflicted settings.json: a conflicted file is the user's to resolve, and pushing
-   * over it would silently pick a side of a merge nobody has looked at. The flag clears itself the
-   * moment a read finds the file parsing (or gone).
+   * REFUSES a git-conflict-marked host file, exactly like the local leg refuses a conflicted
+   * settings.json: a conflicted file is the user's to resolve, and pushing over it would silently
+   * pick a side of a merge nobody has looked at. Two mechanisms enforce that, because the ssh leg
+   * cannot afford the local leg's read-before-every-write (a round trip per save):
+   *  - WARM (this run has a cache or a last-read doc): the runtime flag a read left behind, which
+   *    clears itself the moment a read finds the file parsing again — or gone.
+   *  - COLD (neither map knows this project, so no read has ever compared): one read here, or the
+   *    refusal would be a promise nothing checks — the first save of a session would blind-write
+   *    the mirror over a merge. `absent` writes rev 1 as before; a read `error` proceeds
+   *    cache-first, since being unable to reach the host is exactly what the cache exists for.
    */
   private async writeSshSettings(
     projectId: string,
@@ -584,14 +592,39 @@ export class WorkspaceStore {
     doc: ProjectSettingsDoc
   ): Promise<boolean> {
     if (this.settingsConflictByProject.has(projectId)) return false
-    // `doc` spreads FIRST for the same reason writeProjectSettingsFile does it: a caller may hand
-    // back a document it read, and its stale rev must not defeat monotonicity.
-    const prev = this.settingsCacheByProject.get(projectId) ?? this.lastSharedSettings.get(projectId) ?? null
+    let prev = this.settingsCacheByProject.get(projectId) ?? this.lastSharedSettings.get(projectId) ?? null
+    if (!prev && this.remoteIO?.readSettings) {
+      // A throwing IO is an unreachable host, not a verdict on the file — same fail-open shape as
+      // `pushSshSettings`, and the cache-first write below is what makes that survivable.
+      let cold: RemoteReadResult = { status: 'error' }
+      try {
+        cold = await this.remoteIO.readSettings(projectId, ssh)
+      } catch { /* offline: fall through to the cache-first write */ }
+      if (cold.status === 'ok') {
+        const parsed = parseProjectSettingsFile(cold.content)
+        if (parsed.status === 'conflict') {
+          this.settingsConflictByProject.add(projectId)
+          return false
+        }
+        // `invalid` is left as prev=null: the host's bytes are unusable as a rev source, and the
+        // cache-first write is what gives the user a readable file again.
+        if (parsed.status === 'ok') {
+          prev = parsed.file
+          this.lastSharedSettings.set(projectId, parsed.file)
+          this.settingsConflictByProject.delete(projectId)
+        }
+      }
+    }
+    // Canonical shape (bookkeeping first, then the sanitized doc) — the same order
+    // `parseProjectSettingsFile` produces, so a cache built here compares equal to the identical
+    // document read back from the host instead of looking like a change. Sanitizing on the way in
+    // keeps one definition of "a valid settings file" whichever side the bytes came from, and drops
+    // the stale version/rev/savedAt of a document a caller hands straight back.
     const next: ProjectSettingsFileV1 = {
-      ...sanitizeProjectSettingsDoc(doc),
       version: 1,
       rev: (prev?.rev ?? 0) + 1,
-      savedAt: new Date().toISOString()
+      savedAt: new Date().toISOString(),
+      ...sanitizeProjectSettingsDoc(doc)
     }
     this.settingsCacheByProject.set(projectId, next)
     this.lastSharedSettings.set(projectId, next)
@@ -610,11 +643,13 @@ export class WorkspaceStore {
    * user's editor) may have changed since the caller read it, and silently merging into a file the
    * caller never saw is how the shared half stops meaning what the repo says.
    *
-   * READS FIRST when this run has never read the file. Without that, a fresh process writes with
-   * `prev = null` — rev restarts at 1 over a file that was at rev N, and, worse, the write lands on
-   * whatever is there, including the git-conflict-marked file `readProjectSettings` deliberately
-   * refuses to parse. Same rule the project.json path already lives by: never write a file this
-   * store has not looked at.
+   * ALWAYS READS FIRST — not just when this run has never read the file. A remembered rev is not
+   * evidence of the file's current STATE: `.nodeterm/settings.json` is git-tracked, so between the
+   * panel's read and the user's save a pull/merge can leave conflict markers, and a write off the
+   * warm rev would overwrite them (the same file `readProjectSettings` deliberately refuses to
+   * parse). Without any read a fresh process is worse still — rev restarts at 1 over a file that was
+   * at rev N. Settings are cold (a panel save, not a keystroke), so one read per write is the ruled
+   * cost of never writing a file this store has not just looked at.
    *
    * An ssh project takes the cache-first remote leg instead (`writeSshSettings`).
    *
@@ -631,16 +666,14 @@ export class WorkspaceStore {
     if (!e) return false
     if (e.ssh) return this.writeSshSettings(projectId, e.ssh, doc)
     if (!e.cwd) return false
-    let prev = this.lastSharedSettings.get(projectId) ?? null
-    if (!prev) {
-      const read = await readProjectSettingsFile(e.cwd)
-      // absent → nothing to lose, start at rev 1. invalid → the read already sidelined the only
-      // copy to `.corrupt-<ts>`, so this write destroys nothing either.
-      if (read.status === 'conflict' || read.status === 'error') return false
-      if (read.status === 'ok') {
-        prev = read.file
-        this.lastSharedSettings.set(projectId, read.file)
-      }
+    const read = await readProjectSettingsFile(e.cwd)
+    // absent → nothing to lose, start at rev 1. invalid → the read already sidelined the only
+    // copy to `.corrupt-<ts>`, so this write destroys nothing either.
+    if (read.status === 'conflict' || read.status === 'error') return false
+    let prev: ProjectSettingsFileV1 | null = null
+    if (read.status === 'ok') {
+      prev = read.file
+      this.lastSharedSettings.set(projectId, read.file)
     }
     try {
       const written = await writeProjectSettingsFile(

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -14,7 +14,8 @@ import {
 } from './workspace-files'
 import { readProjectSettingsFile, writeProjectSettingsFile } from './project-settings-files'
 import {
-  parseProjectSettingsFile, sanitizeProjectLocalSettings,
+  parseProjectSettingsFile, sameProjectSettingsContent, sanitizeProjectLocalSettings,
+  sanitizeProjectSettingsDoc, serializeProjectSettingsFile,
   type ProjectLocalSettings, type ProjectSettingsDoc, type ProjectSettingsFileV1
 } from '../shared/project-settings'
 import { readProjectCapabilities, type ProjectCapability } from '../shared/project-capabilities'
@@ -31,6 +32,11 @@ export type RemoteReadResult = { status: 'ok'; content: string } | { status: 'ab
 export interface RemoteWorkspaceIO {
   read(projectId: string, ssh: NonNullable<Project['ssh']>): Promise<RemoteReadResult>
   write(projectId: string, ssh: NonNullable<Project['ssh']>, content: string): Promise<boolean>
+  /** `.nodeterm/settings.json` on the same host. Optional: an IO that predates the settings leg (or
+   *  a test fake that only cares about project.json) simply leaves the project on its offline cache,
+   *  which is exactly the disconnected behaviour. */
+  readSettings?(projectId: string, ssh: NonNullable<Project['ssh']>): Promise<RemoteReadResult>
+  writeSettings?(projectId: string, ssh: NonNullable<Project['ssh']>, content: string): Promise<boolean>
 }
 
 const projectFilePath = (cwd: string): string => path.join(cwd, PROJECT_DIR, PROJECT_FILE)
@@ -41,7 +47,9 @@ const projectFilePath = (cwd: string): string => path.join(cwd, PROJECT_DIR, PRO
 export interface ProjectSettingsState {
   shared: ProjectSettingsFileV1 | null
   local: ProjectLocalSettings | undefined
-  /** Shared file exists but is git-conflict-marked; `shared` is null until the user resolves it. */
+  /** The shared file exists but is git-conflict-marked, so it is left untouched for the user to
+   *  resolve. `shared` is null for a local ref; for an ssh project the last-known-good offline cache
+   *  is still served alongside the flag (it is the only readable copy of that document). */
   conflict?: true
 }
 
@@ -457,8 +465,7 @@ export class WorkspaceStore {
     const e = this.index?.entries.find((x) => x.id === projectId)
     if (!e) return null
     const local = this.localSettingsByProject.get(projectId)
-    // SSH: the offline cache is all this task can answer with — the remote read lands in Task 7.
-    if (e.ssh) return { shared: this.settingsCacheByProject.get(projectId) ?? null, local }
+    if (e.ssh) return this.readSshSettings(projectId, e.ssh, local)
     // An inline canvas has no folder, so there is no shared document to have.
     if (!e.cwd) return { shared: null, local }
     const read = await readProjectSettingsFile(e.cwd)
@@ -475,6 +482,105 @@ export class WorkspaceStore {
   }
 
   /**
+   * The ssh half of `readProjectSettings`: reconcile the host's settings.json against the offline
+   * cache, then answer with whichever is authoritative. Same rules the project.json mirror lives by:
+   *
+   *  - no settings IO / read `error` → serve the cache. A failed read is never evidence of absence,
+   *    so nothing is pushed and nothing is dropped; the project stays usable offline.
+   *  - `absent` → the host has no file; heal it from the cache (the mirror direction) and serve the
+   *    cache. Without a cache there is simply no shared document yet.
+   *  - `ok` → the bytes are HOSTILE INPUT (a git-shared file on a machine we do not control) and go
+   *    through `parseProjectSettingsFile` alone. The higher rev wins, ties to the host, so a
+   *    teammate's push is adopted rather than fought over, while a STRICTLY newer cache (this
+   *    machine edited while disconnected) is pushed back instead of being silently overwritten.
+   *  - `conflict`/`invalid` → the remote copy cannot be trusted and must not be clobbered; the cache
+   *    is served as the last known good, with `conflict` flagged so a caller can say "resolve this".
+   */
+  private async readSshSettings(
+    projectId: string,
+    ssh: NonNullable<Project['ssh']>,
+    local: ProjectLocalSettings | undefined
+  ): Promise<ProjectSettingsState> {
+    const cached = this.settingsCacheByProject.get(projectId) ?? null
+    const res = await this.remoteIO?.readSettings?.(projectId, ssh)
+    if (!res || res.status === 'error') return { shared: cached, local }
+    if (res.status === 'absent') {
+      if (cached) await this.pushSshSettings(projectId, ssh, cached)
+      return { shared: cached, local }
+    }
+    const parsed = parseProjectSettingsFile(res.content)
+    if (parsed.status === 'conflict') return { shared: cached, local, conflict: true }
+    if (parsed.status === 'invalid') return { shared: cached, local }
+    const file = parsed.file
+    if (cached && file.rev < cached.rev) {
+      // Offline edits outrank the host's older copy — push them rather than letting the next read
+      // adopt a document the user already replaced here.
+      await this.pushSshSettings(projectId, ssh, cached)
+      return { shared: cached, local }
+    }
+    this.lastSharedSettings.set(projectId, file)
+    // Only persist when the cache actually moved: a read is the common case, and rewriting
+    // workspace.json on every panel open would be a disk write per glance.
+    if (!cached || cached.rev !== file.rev || !sameProjectSettingsContent(cached, file)) {
+      this.settingsCacheByProject.set(projectId, file)
+      await this.persistIndexNow().catch(() => {})
+    }
+    return { shared: file, local }
+  }
+
+  /** Best-effort mirror of one settings document to the host. A failure is not an error anywhere:
+   *  the cache is the durable copy and the next read reconciles (heal / push again). */
+  private async pushSshSettings(
+    projectId: string,
+    ssh: NonNullable<Project['ssh']>,
+    file: ProjectSettingsFileV1
+  ): Promise<boolean> {
+    const io = this.remoteIO
+    if (!io?.writeSettings) return false
+    try {
+      return await io.writeSettings(projectId, ssh, serializeProjectSettingsFile(file))
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * The ssh half of `writeProjectSettings`, CACHE-FIRST: the rev-bumped document lands in the
+   * offline cache and workspace.json BEFORE it is offered to the host, so a connection that dies
+   * mid-save loses a round trip, never the user's edit. The remote write is then best-effort —
+   * `true` here means "this edit is safely recorded", and an unreachable host is reconciled by the
+   * next read (which heals an absent file and pushes a cache that outranks the remote).
+   *
+   * The doc is sanitized on the way in because this cache is served straight from memory and
+   * persisted into workspace.json; running it through the same sanitizer a read applies keeps one
+   * definition of "a valid settings file" whichever side the bytes came from.
+   */
+  private async writeSshSettings(
+    projectId: string,
+    ssh: NonNullable<Project['ssh']>,
+    doc: ProjectSettingsDoc
+  ): Promise<boolean> {
+    // `doc` spreads FIRST for the same reason writeProjectSettingsFile does it: a caller may hand
+    // back a document it read, and its stale rev must not defeat monotonicity.
+    const prev = this.settingsCacheByProject.get(projectId) ?? this.lastSharedSettings.get(projectId) ?? null
+    const next: ProjectSettingsFileV1 = {
+      ...sanitizeProjectSettingsDoc(doc),
+      version: 1,
+      rev: (prev?.rev ?? 0) + 1,
+      savedAt: new Date().toISOString()
+    }
+    this.settingsCacheByProject.set(projectId, next)
+    this.lastSharedSettings.set(projectId, next)
+    try {
+      await this.persistIndexNow()
+    } catch {
+      return false // the edit is live in this session, but it did not durably land
+    }
+    await this.pushSshSettings(projectId, ssh, next)
+    return true
+  }
+
+  /**
    * Whole-document write of the GIT-SHARED settings file. Whole-document on purpose: a per-field
    * patch grammar would have to merge against a file that another writer (a teammate's commit, the
    * user's editor) may have changed since the caller read it, and silently merging into a file the
@@ -486,14 +592,18 @@ export class WorkspaceStore {
    * refuses to parse. Same rule the project.json path already lives by: never write a file this
    * store has not looked at.
    *
+   * An ssh project takes the cache-first remote leg instead (`writeSshSettings`).
+   *
    * False = there is nowhere to write it, or writing would destroy something: an unknown id, an
-   * inline canvas (no folder), an ssh project (Task 7 gives it the remote leg), a conflicted file
-   * (the user's to resolve — untouched), an unreadable one (a failed read is never evidence of
-   * absence, so it may not be clobbered either), or a write that failed.
+   * inline canvas (no folder), a conflicted file (the user's to resolve — untouched), an unreadable
+   * one (a failed read is never evidence of absence, so it may not be clobbered either), or a write
+   * that failed.
    */
   async writeProjectSettings(projectId: string, doc: ProjectSettingsDoc): Promise<boolean> {
     const e = this.index?.entries.find((x) => x.id === projectId)
-    if (!e || e.ssh || !e.cwd) return false
+    if (!e) return false
+    if (e.ssh) return this.writeSshSettings(projectId, e.ssh, doc)
+    if (!e.cwd) return false
     let prev = this.lastSharedSettings.get(projectId) ?? null
     if (!prev) {
       const read = await readProjectSettingsFile(e.cwd)

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -12,6 +12,11 @@ import {
   serializeProjectFile, splitWorkspace, validKanban,
   type IndexEntryV3, type ProjectFileV1, type WorkspaceIndexV3
 } from './workspace-files'
+import { readProjectSettingsFile, writeProjectSettingsFile } from './project-settings-files'
+import {
+  parseProjectSettingsFile, sanitizeProjectLocalSettings,
+  type ProjectLocalSettings, type ProjectSettingsDoc, type ProjectSettingsFileV1
+} from '../shared/project-settings'
 import { readProjectCapabilities, type ProjectCapability } from '../shared/project-capabilities'
 import type { CapabilityAckMap } from './project-capability-consent'
 import { hoistLegacyNodeExec, type LocalNodeExecMap } from '../shared/node-exec'
@@ -29,6 +34,16 @@ export interface RemoteWorkspaceIO {
 }
 
 const projectFilePath = (cwd: string): string => path.join(cwd, PROJECT_DIR, PROJECT_FILE)
+
+/** What one project's settings look like right now: the git-shared document (null when there is
+ *  none, or it cannot be trusted/read) plus this machine's own overlay. `resolveProjectSettings`
+ *  turns the pair into effective values; this type only reports what each side says. */
+export interface ProjectSettingsState {
+  shared: ProjectSettingsFileV1 | null
+  local: ProjectLocalSettings | undefined
+  /** Shared file exists but is git-conflict-marked; `shared` is null until the user resolves it. */
+  conflict?: true
+}
 
 /** A parsed project file together with the exact bytes it was parsed from. `lastWritten` must
  *  record `raw` — see the field it caches. */
@@ -127,6 +142,18 @@ export class WorkspaceStore {
    *  node we never had, and the tie is broken toward rescuing (a resurrected node is visible and
    *  deletable again; a deleted session node is gone with no trace of where it went). */
   private clearedNodes = new Map<string, Set<string>>()
+  /** project id -> this machine's settings overlay, already sanitized. The map — not the index
+   *  entry — is the live copy: `splitWorkspace` rebuilds entries from the renderer's Workspace,
+   *  which has never carried machine-local state, so every save would otherwise drop the overlay
+   *  (the same reason `localExec`/`cache` are re-attached below). Absent = no overlay. */
+  private localSettingsByProject = new Map<string, ProjectLocalSettings>()
+  /** ssh project id -> last shared settings.json seen on that host (offline copy). Only entries that
+   *  round-tripped through `parseProjectSettingsFile` are in here. */
+  private settingsCacheByProject = new Map<string, ProjectSettingsFileV1>()
+  /** project id -> the shared settings file as last read/written, i.e. the rev source for the NEXT
+   *  write. Runtime-only: a write that has not read first starts at rev 1, which is the same thing
+   *  a fresh file means. */
+  private lastSharedSettings = new Map<string, ProjectSettingsFileV1>()
   /** Last index written/loaded — lets readLocalRef/refresh resolve entries without a full load. */
   private index: WorkspaceIndexV3 | null = null
   /** Optional hook fired after every load()/save() — the watcher re-syncs its watch set (Task 5). */
@@ -276,6 +303,8 @@ export class WorkspaceStore {
       }
     }
     await this.repairDuplicateIds(built, sideline)
+    // AFTER the repair: it re-keys entries in place, and the maps are keyed by project id.
+    this.adoptSettingsFromIndex(index)
     const projects = built.map((b) => b.project)
     const active = projects.some((p) => p.id === index.activeProjectId && !p.unavailable)
       ? index.activeProjectId
@@ -380,6 +409,130 @@ export class WorkspaceStore {
   }
 
   /**
+   * Loads the settings halves out of a just-read index into the two runtime maps.
+   *
+   * workspace.json is hand-editable (and, on Server Edition, sits next to other users' reach), so
+   * neither field is trusted on the way in: the overlay goes through the same sanitizer a settings
+   * file gets, and a cached SHARED file is accepted only if it still parses as one — the parser is
+   * reused as the validator so there is exactly one definition of "a valid settings file",
+   * wherever the bytes came from.
+   */
+  private adoptSettingsFromIndex(index: WorkspaceIndexV3): void {
+    this.localSettingsByProject.clear()
+    this.settingsCacheByProject.clear()
+    for (const e of index.entries) {
+      const local = sanitizeProjectLocalSettings(e.localSettings)
+      if (local && Object.keys(local).length) this.localSettingsByProject.set(e.id, local)
+      if (!e.ssh || !e.settingsCache) continue
+      const parsed = parseProjectSettingsFile(JSON.stringify(e.settingsCache))
+      if (parsed.status === 'ok') this.settingsCacheByProject.set(e.id, parsed.file)
+    }
+  }
+
+  /** Writes the maps back onto an index about to be persisted — the machine-local half that
+   *  `splitWorkspace` cannot know about. Runs on every index write, so an entry the maps no longer
+   *  cover loses the field rather than keeping a stale copy of it. */
+  private applySettingsToIndex(index: WorkspaceIndexV3): void {
+    for (const e of index.entries) {
+      const local = this.localSettingsByProject.get(e.id)
+      if (local) e.localSettings = local
+      else delete e.localSettings
+      // Only an ssh entry has anywhere to cache: a local ref's shared file is one disk read away,
+      // and an inline canvas has no shared file at all.
+      const cached = e.ssh ? this.settingsCacheByProject.get(e.id) : undefined
+      if (cached) e.settingsCache = cached
+      else delete e.settingsCache
+    }
+  }
+
+  /**
+   * The shared + local settings of one project. `null` means the id names no entry (never "no
+   * settings" — an entry with neither file nor overlay answers `{shared: null, local: undefined}`).
+   *
+   * The shared doc is read from disk on every call rather than cached: `.nodeterm/settings.json` is
+   * a git-tracked file a checkout/merge/teammate rewrites behind our back, and a settings read is
+   * rare enough (a panel opening, a launch) that a stale answer would cost more than the read does.
+   */
+  async readProjectSettings(projectId: string): Promise<ProjectSettingsState | null> {
+    const e = this.index?.entries.find((x) => x.id === projectId)
+    if (!e) return null
+    const local = this.localSettingsByProject.get(projectId)
+    // SSH: the offline cache is all this task can answer with — the remote read lands in Task 7.
+    if (e.ssh) return { shared: this.settingsCacheByProject.get(projectId) ?? null, local }
+    // An inline canvas has no folder, so there is no shared document to have.
+    if (!e.cwd) return { shared: null, local }
+    const read = await readProjectSettingsFile(e.cwd)
+    if (read.status === 'ok') {
+      // The rev source for the next write — a write that skipped the read would restart at rev 1
+      // and lose the counter a remote/offline comparison depends on.
+      this.lastSharedSettings.set(projectId, read.file)
+      return { shared: read.file, local }
+    }
+    // conflict: the file exists but is mid-merge; it is left untouched for the user to resolve and
+    // reported as such, so a caller shows "resolve this" instead of "this project has no settings".
+    if (read.status === 'conflict') return { shared: null, local, conflict: true }
+    return { shared: null, local } // absent / invalid (sidelined) / unreadable
+  }
+
+  /**
+   * Whole-document write of the GIT-SHARED settings file. Whole-document on purpose: a per-field
+   * patch grammar would have to merge against a file that another writer (a teammate's commit, the
+   * user's editor) may have changed since the caller read it, and silently merging into a file the
+   * caller never saw is how the shared half stops meaning what the repo says.
+   *
+   * False = there is nowhere to write it: an unknown id, an inline canvas (no folder), an ssh
+   * project (Task 7 gives it the remote leg), or the write itself failed.
+   */
+  async writeProjectSettings(projectId: string, doc: ProjectSettingsDoc): Promise<boolean> {
+    const e = this.index?.entries.find((x) => x.id === projectId)
+    if (!e || e.ssh || !e.cwd) return false
+    try {
+      const written = await writeProjectSettingsFile(
+        e.cwd, doc, this.lastSharedSettings.get(projectId) ?? null, new Date().toISOString()
+      )
+      this.lastSharedSettings.set(projectId, written)
+      return true
+    } catch {
+      // Folder gone / read-only checkout: the caller is told the doc did not land, exactly like a
+      // failed project.json write leaves the entry stale rather than pretending it saved.
+      return false
+    }
+  }
+
+  /**
+   * Replaces this machine's overlay for one project (undefined = clear it) and persists the index
+   * NOW, without waiting for a canvas save: a settings edit is often the only thing the user did in
+   * that session, and an overlay that lives only in memory until the next node is dragged is an
+   * overlay that quietly disappears when the app quits.
+   */
+  async updateLocalProjectSettings(
+    projectId: string,
+    local: ProjectLocalSettings | undefined
+  ): Promise<boolean> {
+    const e = this.index?.entries.find((x) => x.id === projectId)
+    if (!e) return false
+    const clean = local === undefined ? undefined : sanitizeProjectLocalSettings(local)
+    if (clean && Object.keys(clean).length) this.localSettingsByProject.set(projectId, clean)
+    else this.localSettingsByProject.delete(projectId)
+    await this.persistIndexNow()
+    return true
+  }
+
+  /** Rewrites the CURRENT index with the settings maps applied. On `saveChain` like every other
+   *  index write, so it can neither interleave with a save's own rewrite nor invent entries: it
+   *  persists exactly what `this.index` already holds (and does nothing before the first load). */
+  private persistIndexNow(): Promise<void> {
+    const run = this.saveChain.then(async () => {
+      const index = this.index
+      if (!index) return
+      this.applySettingsToIndex(index)
+      await writeAtomic(this.indexPath, JSON.stringify(index))
+    })
+    this.saveChain = run.catch(() => {})
+    return run
+  }
+
+  /**
    * Reads + parses one project file. Only the authoritative loadV3 path passes `sideline: true`,
    * which renames an unparsable/wrong-shape file to `.corrupt-<ts>` so a later save can't overwrite
    * the only copy. Read-only callers (probeFolder — an RPC reachable with arbitrary paths on Server
@@ -459,6 +612,11 @@ export class WorkspaceStore {
       const previous = this.index?.entries.find((candidate) => candidate.id === entry.id)
       entry.localApprovalId = previous?.localApprovalId || randomUUID()
     }
+
+    // The settings overlay / ssh settings cache ride every index write, like `localExec` and
+    // `cache`: `splitWorkspace` builds entries from the renderer's Workspace, which carries no
+    // machine-local state, so without this each autosave would erase them from disk.
+    this.applySettingsToIndex(index)
 
     // An unavailable placeholder carries no real data. splitWorkspace already dropped its file
     // and cache; here we restore the machine-local payload (ssh offline cache) from the previous

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -158,6 +158,11 @@ export class WorkspaceStore {
   /** ssh project id -> last shared settings.json seen on that host (offline copy). Only entries that
    *  round-tripped through `parseProjectSettingsFile` are in here. */
   private settingsCacheByProject = new Map<string, ProjectSettingsFileV1>()
+  /** ssh project ids whose settings.json was git-conflict-marked on the last read, so a write must
+   *  refuse instead of picking a side of the merge (the local leg refuses the same way, straight off
+   *  the file). Cleared as soon as a read finds the file parsing again — or gone. Runtime-only: a
+   *  fresh run's first read re-establishes it before any write can be issued from the panel. */
+  private settingsConflictByProject = new Set<string>()
   /** project id -> the shared settings file as last read/written, i.e. the rev source for the NEXT
    *  write. Runtime-only: a write that has not read first starts at rev 1, which is the same thing
    *  a fresh file means. */
@@ -494,23 +499,36 @@ export class WorkspaceStore {
    *    teammate's push is adopted rather than fought over, while a STRICTLY newer cache (this
    *    machine edited while disconnected) is pushed back instead of being silently overwritten.
    *  - `conflict`/`invalid` → the remote copy cannot be trusted and must not be clobbered; the cache
-   *    is served as the last known good, with `conflict` flagged so a caller can say "resolve this".
+   *    is served as the last known good, with `conflict` flagged so a caller can say "resolve this"
+   *    (and, for a conflict, remembered so a WRITE refuses too — see `settingsConflictByProject`).
+   *
+   * The cache is read AFTER the round trip, never before: a cache-first write can land while this
+   * read is in flight, and comparing the host's answer against a snapshot taken before the await
+   * would adopt an older remote doc over an edit the user has already been told was saved.
    */
   private async readSshSettings(
     projectId: string,
     ssh: NonNullable<Project['ssh']>,
     local: ProjectLocalSettings | undefined
   ): Promise<ProjectSettingsState> {
-    const cached = this.settingsCacheByProject.get(projectId) ?? null
     const res = await this.remoteIO?.readSettings?.(projectId, ssh)
+    const cached = this.settingsCacheByProject.get(projectId) ?? null
     if (!res || res.status === 'error') return { shared: cached, local }
     if (res.status === 'absent') {
+      // The host has no file to be mid-merge: whatever conflict a previous read saw is gone.
+      this.settingsConflictByProject.delete(projectId)
       if (cached) await this.pushSshSettings(projectId, ssh, cached)
       return { shared: cached, local }
     }
     const parsed = parseProjectSettingsFile(res.content)
-    if (parsed.status === 'conflict') return { shared: cached, local, conflict: true }
+    if (parsed.status === 'conflict') {
+      this.settingsConflictByProject.add(projectId)
+      return { shared: cached, local, conflict: true }
+    }
+    // `invalid` deliberately leaves the flag alone: unparsable is not "resolved", and refusing to
+    // write is the conservative side of a file we still cannot read.
     if (parsed.status === 'invalid') return { shared: cached, local }
+    this.settingsConflictByProject.delete(projectId) // the host's file parses again — resolved
     const file = parsed.file
     if (cached && file.rev < cached.rev) {
       // Offline edits outrank the host's older copy — push them rather than letting the next read
@@ -554,12 +572,18 @@ export class WorkspaceStore {
    * The doc is sanitized on the way in because this cache is served straight from memory and
    * persisted into workspace.json; running it through the same sanitizer a read applies keeps one
    * definition of "a valid settings file" whichever side the bytes came from.
+   *
+   * REFUSES while the last read found the host's file git-conflict-marked, exactly like the local
+   * leg refuses a conflicted settings.json: a conflicted file is the user's to resolve, and pushing
+   * over it would silently pick a side of a merge nobody has looked at. The flag clears itself the
+   * moment a read finds the file parsing (or gone).
    */
   private async writeSshSettings(
     projectId: string,
     ssh: NonNullable<Project['ssh']>,
     doc: ProjectSettingsDoc
   ): Promise<boolean> {
+    if (this.settingsConflictByProject.has(projectId)) return false
     // `doc` spreads FIRST for the same reason writeProjectSettingsFile does it: a caller may hand
     // back a document it read, and its stale rev must not defeat monotonicity.
     const prev = this.settingsCacheByProject.get(projectId) ?? this.lastSharedSettings.get(projectId) ?? null
@@ -594,10 +618,13 @@ export class WorkspaceStore {
    *
    * An ssh project takes the cache-first remote leg instead (`writeSshSettings`).
    *
-   * False = there is nowhere to write it, or writing would destroy something: an unknown id, an
-   * inline canvas (no folder), a conflicted file (the user's to resolve — untouched), an unreadable
-   * one (a failed read is never evidence of absence, so it may not be clobbered either), or a write
-   * that failed.
+   * False = there is nowhere to write it, or writing would destroy something. On BOTH legs: an
+   * unknown id, an inline canvas (no folder), and a git-conflicted shared file — the user's to
+   * resolve, left untouched (the local leg sees it in the read-before-write, the ssh leg remembers
+   * it from the last read, since looking again would cost a round trip per keystroke). Local leg
+   * only: an unreadable file (a failed read is never evidence of absence, so it may not be
+   * clobbered either) or a failed write. SSH leg only: an index write that did not persist —
+   * a failed REMOTE write is not false there, because the cache already holds the edit.
    */
   async writeProjectSettings(projectId: string, doc: ProjectSettingsDoc): Promise<boolean> {
     const e = this.index?.entries.find((x) => x.id === projectId)

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -480,15 +480,34 @@ export class WorkspaceStore {
    * user's editor) may have changed since the caller read it, and silently merging into a file the
    * caller never saw is how the shared half stops meaning what the repo says.
    *
-   * False = there is nowhere to write it: an unknown id, an inline canvas (no folder), an ssh
-   * project (Task 7 gives it the remote leg), or the write itself failed.
+   * READS FIRST when this run has never read the file. Without that, a fresh process writes with
+   * `prev = null` — rev restarts at 1 over a file that was at rev N, and, worse, the write lands on
+   * whatever is there, including the git-conflict-marked file `readProjectSettings` deliberately
+   * refuses to parse. Same rule the project.json path already lives by: never write a file this
+   * store has not looked at.
+   *
+   * False = there is nowhere to write it, or writing would destroy something: an unknown id, an
+   * inline canvas (no folder), an ssh project (Task 7 gives it the remote leg), a conflicted file
+   * (the user's to resolve — untouched), an unreadable one (a failed read is never evidence of
+   * absence, so it may not be clobbered either), or a write that failed.
    */
   async writeProjectSettings(projectId: string, doc: ProjectSettingsDoc): Promise<boolean> {
     const e = this.index?.entries.find((x) => x.id === projectId)
     if (!e || e.ssh || !e.cwd) return false
+    let prev = this.lastSharedSettings.get(projectId) ?? null
+    if (!prev) {
+      const read = await readProjectSettingsFile(e.cwd)
+      // absent → nothing to lose, start at rev 1. invalid → the read already sidelined the only
+      // copy to `.corrupt-<ts>`, so this write destroys nothing either.
+      if (read.status === 'conflict' || read.status === 'error') return false
+      if (read.status === 'ok') {
+        prev = read.file
+        this.lastSharedSettings.set(projectId, read.file)
+      }
+    }
     try {
       const written = await writeProjectSettingsFile(
-        e.cwd, doc, this.lastSharedSettings.get(projectId) ?? null, new Date().toISOString()
+        e.cwd, doc, prev, new Date().toISOString()
       )
       this.lastSharedSettings.set(projectId, written)
       return true

--- a/src/main/remote-workspace-io.test.ts
+++ b/src/main/remote-workspace-io.test.ts
@@ -79,6 +79,57 @@ describe('write', () => {
   })
 })
 
+/** The read fake above is declared param-less, so its recorded arguments need a cast to be read. */
+const readPaths = (fs: ReturnType<typeof fakeFs>['fs']): string[] =>
+  (fs.readTextChecked.mock.calls as unknown as [SshFsRef, string][]).map((c) => c[1])
+
+describe('settings IO', () => {
+  it('targets <remoteCwd>/.nodeterm/settings.json, not project.json', async () => {
+    const { fs, sshFs } = fakeFs()
+    const io = makeRemoteWorkspaceIO(() => ref, sshFs)
+    await io.readSettings!('p1', ssh)
+    await io.writeSettings!('p1', ssh, 'body')
+    // project.json's own path is unchanged by the refactor.
+    await io.read('p1', ssh)
+    expect(readPaths(fs)).toEqual(['~/app/.nodeterm/settings.json', '~/app/.nodeterm/project.json'])
+    expect(fs.writeText.mock.calls[0][1]).toBe('~/app/.nodeterm/settings.json')
+  })
+
+  it('is NOT throttled: settings are cold, so two writes in a row both hit the wire', async () => {
+    const { fs, sshFs } = fakeFs()
+    const io = makeRemoteWorkspaceIO(() => ref, sshFs)
+    expect(await io.writeSettings!('p1', ssh, 'c1')).toBe(true)
+    expect(await io.writeSettings!('p1', ssh, 'c2')).toBe(true)
+    expect(fs.writeText.mock.calls.map((c) => c[2])).toEqual(['c1', 'c2'])
+  })
+
+  it('disconnected → read errors (never absent) and the write is a quiet no-op', async () => {
+    const { fs, sshFs } = fakeFs()
+    const io = makeRemoteWorkspaceIO(() => null, sshFs)
+    expect(await io.readSettings!('p1', ssh)).toEqual({ status: 'error' })
+    expect(await io.writeSettings!('p1', ssh, 'c1')).toBe(false)
+    expect(fs.writeText).not.toHaveBeenCalled()
+  })
+
+  it('a throwing settings write reports false instead of rejecting', async () => {
+    const { fs, sshFs } = fakeFs()
+    const io = makeRemoteWorkspaceIO(() => ref, sshFs)
+    fs.writeText.mockRejectedValueOnce(new Error('conn reset'))
+    expect(await io.writeSettings!('p1', ssh, 'c1')).toBe(false)
+  })
+
+  it('a settings write does not disturb project.json throttling', async () => {
+    const { fs, sshFs } = fakeFs()
+    const io = makeRemoteWorkspaceIO(() => ref, sshFs)
+    await io.write('p1', ssh, 'p1-immediate')
+    await io.writeSettings!('p1', ssh, 'settings')
+    await io.write('p1', ssh, 'p1-trailing') // still inside the 5s window
+    expect(fs.writeText.mock.calls.map((c) => c[2])).toEqual(['p1-immediate', 'settings'])
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(fs.writeText.mock.calls.map((c) => c[2])).toEqual(['p1-immediate', 'settings', 'p1-trailing'])
+  })
+})
+
 describe('flush', () => {
   it('fires every pending trailing write immediately (quit path: masters die right after)', async () => {
     const { fs, sshFs } = fakeFs()

--- a/src/main/remote-workspace-io.ts
+++ b/src/main/remote-workspace-io.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import type { Project } from '../shared/types'
 import type { RemoteReadResult, RemoteWorkspaceIO } from '../core/workspace-store'
 import { PROJECT_DIR, PROJECT_FILE } from '../core/workspace-files'
+import { PROJECT_SETTINGS_FILE } from '../shared/project-settings'
 import type { SshFs, SshFsRef } from './ssh-fs'
 
 /** Resolves an SSH project's live control master; null while disconnected. */
@@ -21,6 +22,10 @@ export interface RemoteWorkspaceIOWithFlush extends RemoteWorkspaceIO {
  * round-trip per keystroke burst is still too chatty — spec says ~5 s). A throttled write is
  * acked optimistically; if the trailing run later fails, `onDropped` reports it back so the
  * store re-owes the mirror instead of believing it landed.
+ *
+ * The settings pair (`readSettings`/`writeSettings`, `.nodeterm/settings.json`) rides the same
+ * connection but NOT the throttle — see `writeSettings`. `flush()` therefore still covers only
+ * project.json's pending writes: a settings write has already been on the wire when it returns.
  */
 export function makeRemoteWorkspaceIO(
   resolveRef: RefResolver,
@@ -31,14 +36,14 @@ export function makeRemoteWorkspaceIO(
   const pending = new Map<string, { timer: ReturnType<typeof setTimeout>; run: () => Promise<void> }>()
   const WRITE_THROTTLE_MS = 5000
 
-  const remotePath = (ssh: NonNullable<Project['ssh']>): string =>
-    path.posix.join(ssh.remoteCwd, PROJECT_DIR, PROJECT_FILE)
+  const remotePath = (ssh: NonNullable<Project['ssh']>, file: string): string =>
+    path.posix.join(ssh.remoteCwd, PROJECT_DIR, file)
 
   return {
     async read(projectId, ssh): Promise<RemoteReadResult> {
       const ref = resolveRef(projectId)
       if (!ref) return { status: 'error' }
-      return sshFs.readTextChecked(ref, remotePath(ssh))
+      return sshFs.readTextChecked(ref, remotePath(ssh, PROJECT_FILE))
     },
     async write(projectId, ssh, content) {
       const run = async (): Promise<boolean> => {
@@ -48,7 +53,7 @@ export function makeRemoteWorkspaceIO(
         const ref = resolveRef(projectId)
         if (!ref) return false
         try {
-          return await sshFs.writeText(ref, remotePath(ssh), content)
+          return await sshFs.writeText(ref, remotePath(ssh, PROJECT_FILE), content)
         } catch {
           return false
         }
@@ -73,6 +78,25 @@ export function makeRemoteWorkspaceIO(
       if (prev) clearTimeout(prev.timer)
       pending.set(projectId, { timer: setTimeout(() => void fire(), WRITE_THROTTLE_MS - since), run: fire })
       return true
+    },
+    async readSettings(projectId, ssh): Promise<RemoteReadResult> {
+      const ref = resolveRef(projectId)
+      if (!ref) return { status: 'error' }
+      return sshFs.readTextChecked(ref, remotePath(ssh, PROJECT_SETTINGS_FILE))
+    },
+    // Deliberately NOT throttled, and deliberately not sharing project.json's throttle bookkeeping:
+    // the 5 s window exists for canvas churn (a node dragged across the screen), while a settings
+    // save is a cold, user-initiated act. Delaying or reordering one behind a canvas write would
+    // make "Save" mean "maybe, in five seconds" — so this goes straight to the wire and reports the
+    // real outcome. The store's cache-first write already makes a false here non-fatal.
+    async writeSettings(projectId, ssh, content) {
+      const ref = resolveRef(projectId)
+      if (!ref) return false
+      try {
+        return await sshFs.writeText(ref, remotePath(ssh, PROJECT_SETTINGS_FILE), content)
+      } catch {
+        return false
+      }
     },
     async flush() {
       const flushed = [...pending.values()]

--- a/src/shared/project-settings.test.ts
+++ b/src/shared/project-settings.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
   parseProjectSettingsFile, sanitizeProjectSettingsDoc, sanitizeProjectLocalSettings,
-  serializeProjectSettingsFile, sameProjectSettingsContent, resolveProjectSettings
+  serializeProjectSettingsFile, sameProjectSettingsContent, resolveProjectSettings,
+  projectTrustContent
 } from './project-settings'
 
 describe('sanitizeProjectSettingsDoc', () => {
@@ -117,5 +118,24 @@ describe('resolveProjectSettings', () => {
   it('handles both sides undefined', () => {
     expect(resolveProjectSettings(undefined, undefined)).toEqual(
       { setup: {}, worktree: {}, agents: {}, terminal: {} })
+  })
+})
+
+describe('projectTrustContent', () => {
+  it('covers both scripts and is insensitive to key order', () => {
+    expect(projectTrustContent('setup', { setup: { setupScript: 'a' } }))
+      .toBe(JSON.stringify({ setupScript: 'a', archiveScript: '' }))
+    expect(projectTrustContent('setup', {})).toBeNull()
+  })
+  it('agents hash covers launchCmd AND env with sorted keys', () => {
+    const a = projectTrustContent('agents', { agents: { launchCmd: 'x', env: { B: '2', A: '1' } } })
+    const b = projectTrustContent('agents', { agents: { env: { A: '1', B: '2' }, launchCmd: 'x' } })
+    expect(a).toBe(b)
+    expect(a).toContain('"A":"1"')
+    expect(projectTrustContent('agents', { agents: { defaultAgentId: 'claude' } })).toBeNull()
+  })
+  it('shell content is the bare shell or null', () => {
+    expect(projectTrustContent('shell', { terminal: { shell: '/bin/sh' } })).toBe('/bin/sh')
+    expect(projectTrustContent('shell', { terminal: { theme: 'dark' } })).toBeNull()
   })
 })

--- a/src/shared/project-settings.test.ts
+++ b/src/shared/project-settings.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   parseProjectSettingsFile, sanitizeProjectSettingsDoc, sanitizeProjectLocalSettings,
-  serializeProjectSettingsFile, sameProjectSettingsContent
+  serializeProjectSettingsFile, sameProjectSettingsContent, resolveProjectSettings
 } from './project-settings'
 
 describe('sanitizeProjectSettingsDoc', () => {
@@ -89,5 +89,33 @@ describe('serialize + content equality', () => {
     expect(parseProjectSettingsFile(serializeProjectSettingsFile(a)).status).toBe('ok')
     expect(sameProjectSettingsContent(a, b)).toBe(true)
     expect(sameProjectSettingsContent(a, c)).toBe(false)
+  })
+})
+
+describe('resolveProjectSettings', () => {
+  const shared = {
+    setup: { setupScript: 'npm ci', waitForSetup: true },
+    terminal: { shell: '/bin/bash', theme: 'dark' }
+  }
+  it('local wins per key; shared fills the rest with provenance', () => {
+    const r = resolveProjectSettings({ terminal: { shell: '/bin/fish' } }, shared)
+    expect(r.terminal.shell).toEqual({ value: '/bin/fish', source: 'local' })
+    expect(r.terminal.theme).toEqual({ value: 'dark', source: 'shared' })
+    expect(r.setup.setupScript).toEqual({ value: 'npm ci', source: 'shared' })
+  })
+  it('ignoreShared blanks a family without needing local values', () => {
+    const r = resolveProjectSettings({ ignoreShared: { setup: true } }, shared)
+    expect(r.setup).toEqual({})
+    expect(r.terminal.shell).toEqual({ value: '/bin/bash', source: 'shared' })
+  })
+  it('ignoreShared still lets a local value through', () => {
+    const r = resolveProjectSettings(
+      { setup: { setupScript: 'make' }, ignoreShared: { setup: true } }, shared)
+    expect(r.setup.setupScript).toEqual({ value: 'make', source: 'local' })
+    expect(r.setup.waitForSetup).toBeUndefined()
+  })
+  it('handles both sides undefined', () => {
+    expect(resolveProjectSettings(undefined, undefined)).toEqual(
+      { setup: {}, worktree: {}, agents: {}, terminal: {} })
   })
 })

--- a/src/shared/project-settings.test.ts
+++ b/src/shared/project-settings.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseProjectSettingsFile, sanitizeProjectSettingsDoc, sanitizeProjectLocalSettings,
+  serializeProjectSettingsFile, sameProjectSettingsContent
+} from './project-settings'
+
+describe('sanitizeProjectSettingsDoc', () => {
+  it('keeps well-formed families and drops unknown keys', () => {
+    const doc = sanitizeProjectSettingsDoc({
+      setup: { setupScript: 'npm ci', archiveScript: 'echo bye', waitForSetup: true, extra: 1 },
+      agents: { launchCmd: 'claude --resume', env: { FOO: 'bar' } },
+      bogus: { a: 1 }
+    })
+    expect(doc).toEqual({
+      setup: { setupScript: 'npm ci', archiveScript: 'echo bye', waitForSetup: true },
+      agents: { launchCmd: 'claude --resume', env: { FOO: 'bar' } }
+    })
+  })
+  it('drops non-string scalars, oversized strings, and non-true waitForSetup', () => {
+    const doc = sanitizeProjectSettingsDoc({
+      setup: { setupScript: 42, waitForSetup: 'true' },
+      terminal: { shell: 'x'.repeat(1025), theme: 'dark' }
+    })
+    expect(doc).toEqual({ terminal: { theme: 'dark' } })
+  })
+  it('rejects env keys that are not valid variable names (incl. __proto__)', () => {
+    const doc = sanitizeProjectSettingsDoc({
+      agents: { env: { GOOD_1: 'v', 'bad-key': 'v', __proto__: 'x', 'a b': 'v' } }
+    })
+    expect(doc.agents?.env).toEqual({ GOOD_1: 'v' })
+    expect(Object.getPrototypeOf(doc.agents!.env)).toBe(Object.prototype)
+  })
+  it('drops a hostile __proto__ own-key from a JSON-parsed env object', () => {
+    // A literal `__proto__:` in an object initializer sets the prototype rather than an own
+    // property, so it can never reach the sanitizer as a key to reject — this is how a hostile
+    // settings.json actually delivers the attack: JSON.parse DOES create it as an own property.
+    const hostileEnv = JSON.parse('{"__proto__":"x","OK_KEY":"v"}')
+    const doc = sanitizeProjectSettingsDoc({ agents: { env: hostileEnv } })
+    expect(doc.agents?.env).toEqual({ OK_KEY: 'v' })
+    expect(Object.getPrototypeOf(doc.agents!.env)).toBe(Object.prototype)
+  })
+  it('drops absolute and traversal sharedPaths and dedupes', () => {
+    const doc = sanitizeProjectSettingsDoc({
+      worktree: { sharedPaths: ['.env', '/etc/passwd', '../up', 'a/../b', 'C:\\x', '.env', 'node_modules'] }
+    })
+    expect(doc.worktree?.sharedPaths).toEqual(['.env', 'node_modules'])
+  })
+  it('omits a family whose every field was dropped', () => {
+    expect(sanitizeProjectSettingsDoc({ setup: { setupScript: 42 } })).toEqual({})
+  })
+})
+
+describe('sanitizeProjectLocalSettings', () => {
+  it('keeps only literal-true known-family ignoreShared flags', () => {
+    const local = sanitizeProjectLocalSettings({
+      terminal: { shell: '/bin/fish' },
+      ignoreShared: { setup: true, agents: 'yes', bogus: true }
+    })
+    expect(local).toEqual({ terminal: { shell: '/bin/fish' }, ignoreShared: { setup: true } })
+  })
+  it('returns undefined for a non-object', () => {
+    expect(sanitizeProjectLocalSettings('nope')).toBeUndefined()
+  })
+})
+
+describe('parseProjectSettingsFile', () => {
+  const file = { version: 1, rev: 3, savedAt: '2026-08-19T00:00:00Z', setup: { setupScript: 'make' } }
+  it('parses a valid file', () => {
+    const r = parseProjectSettingsFile(JSON.stringify(file))
+    expect(r.status).toBe('ok')
+    if (r.status === 'ok') expect(r.file.setup?.setupScript).toBe('make')
+  })
+  it('reports conflict for a git-conflict-marked file without parsing', () => {
+    const raw = '<<<<<<< HEAD\n{"version":1}\n=======\n{"version":1}\n>>>>>>> theirs\n'
+    expect(parseProjectSettingsFile(raw).status).toBe('conflict')
+  })
+  it('reports invalid for wrong version, bad rev, or non-JSON', () => {
+    expect(parseProjectSettingsFile(JSON.stringify({ ...file, version: 2 })).status).toBe('invalid')
+    expect(parseProjectSettingsFile(JSON.stringify({ ...file, rev: -1 })).status).toBe('invalid')
+    expect(parseProjectSettingsFile('{oops').status).toBe('invalid')
+  })
+})
+
+describe('serialize + content equality', () => {
+  it('round-trips and ignores rev/savedAt in content comparison', () => {
+    const a = { version: 1 as const, rev: 1, savedAt: 't1', terminal: { shell: '/bin/zsh' } }
+    const b = { version: 1 as const, rev: 9, savedAt: 't2', terminal: { shell: '/bin/zsh' } }
+    const c = { version: 1 as const, rev: 1, savedAt: 't1', terminal: { shell: '/bin/bash' } }
+    expect(parseProjectSettingsFile(serializeProjectSettingsFile(a)).status).toBe('ok')
+    expect(sameProjectSettingsContent(a, b)).toBe(true)
+    expect(sameProjectSettingsContent(a, c)).toBe(false)
+  })
+})

--- a/src/shared/project-settings.test.ts
+++ b/src/shared/project-settings.test.ts
@@ -51,6 +51,46 @@ describe('sanitizeProjectSettingsDoc', () => {
   })
 })
 
+describe('sanitizeProjectSettingsDoc field caps (at-cap survives, over-cap drops)', () => {
+  it('setupScript/archiveScript: 64000 survives, 64001 drops', () => {
+    const atCap = 'a'.repeat(64000)
+    const overCap = 'a'.repeat(64001)
+    expect(sanitizeProjectSettingsDoc({ setup: { setupScript: atCap } }).setup?.setupScript).toBe(atCap)
+    expect(sanitizeProjectSettingsDoc({ setup: { setupScript: overCap } }).setup).toBeUndefined()
+  })
+  it('launchCmd: 4096 survives, 4097 drops', () => {
+    const atCap = 'x'.repeat(4096)
+    const overCap = 'x'.repeat(4097)
+    expect(sanitizeProjectSettingsDoc({ agents: { launchCmd: atCap } }).agents?.launchCmd).toBe(atCap)
+    expect(sanitizeProjectSettingsDoc({ agents: { launchCmd: overCap } }).agents).toBeUndefined()
+  })
+  it('env value: 4096 survives, 4097 drops the whole entry', () => {
+    const atCap = 'v'.repeat(4096)
+    const overCap = 'v'.repeat(4097)
+    expect(sanitizeProjectSettingsDoc({ agents: { env: { K: atCap } } }).agents?.env).toEqual({ K: atCap })
+    expect(sanitizeProjectSettingsDoc({ agents: { env: { K: overCap } } }).agents).toBeUndefined()
+  })
+  it('env entries: 64 survive, the 65th (key-sorted) is dropped', () => {
+    const env: Record<string, string> = {}
+    for (let i = 0; i < 65; i++) env[`K${String(i).padStart(2, '0')}`] = String(i)
+    const out = sanitizeProjectSettingsDoc({ agents: { env } }).agents?.env ?? {}
+    expect(Object.keys(out).length).toBe(64)
+    expect(out.K00).toBe('0')
+    expect(out.K64).toBeUndefined() // K64 sorts last of the 65 keys, so it is the one dropped
+  })
+  it('sharedPaths: 128 entries survive, the 129th is dropped', () => {
+    const paths = Array.from({ length: 129 }, (_, i) => `p${i}`)
+    const out = sanitizeProjectSettingsDoc({ worktree: { sharedPaths: paths } }).worktree?.sharedPaths
+    expect(out).toEqual(paths.slice(0, 128))
+  })
+  it('sharedPaths entry length: 1024 survives, 1025 drops that entry', () => {
+    const atCap = 'a'.repeat(1024)
+    const overCap = 'b'.repeat(1025)
+    const out = sanitizeProjectSettingsDoc({ worktree: { sharedPaths: [atCap, overCap] } }).worktree?.sharedPaths
+    expect(out).toEqual([atCap])
+  })
+})
+
 describe('sanitizeProjectLocalSettings', () => {
   it('keeps only literal-true known-family ignoreShared flags', () => {
     const local = sanitizeProjectLocalSettings({

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -18,8 +18,6 @@
  * for node-exec.ts).
  */
 
-import * as path from 'path'
-
 export const PROJECT_SETTINGS_FILE = 'settings.json'
 
 export type ProjectSettingsFamily = 'setup' | 'worktree' | 'agents' | 'terminal'
@@ -160,7 +158,10 @@ function sanitizeSharedPaths(v: unknown): string[] | undefined {
   for (const entry of v) {
     if (typeof entry !== 'string') continue
     if (entry.length === 0 || entry.length > SHARED_PATH_STRING_CAP) continue
-    if (path.posix.isAbsolute(entry) || WINDOWS_DRIVE_RE.test(entry)) continue
+    // `entry.startsWith('/')` stands in for `path.posix.isAbsolute` — src/shared is bundled for the
+    // renderer as plain browser code (no Node builtins), and emptiness is already rejected above,
+    // so the two are equivalent for every string that reaches this line.
+    if (entry.startsWith('/') || WINDOWS_DRIVE_RE.test(entry)) continue
     if (hasTraversalSegment(entry)) continue
     if (seen.has(entry)) continue
     seen.add(entry)

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -320,3 +320,40 @@ export function resolveProjectSettings(
   }
   return out
 }
+
+export type ProjectTrustFamily = 'setup' | 'agents' | 'shell'
+
+/**
+ * Canonical string covering EVERYTHING executable a family ships — the same shape of problem
+ * `execTrusted` (node-exec.ts) solves for shell/ssh fields: a caller compares this against what it
+ * last saw to decide whether re-approval is needed. `null` means the family has nothing executable
+ * right now, so there is nothing to (re-)approve.
+ *
+ * Deliberately excludes fields that cannot introduce code: `waitForSetup` (a boolean gate, not a
+ * command) and `defaultAgentId` (selects among locally-configured agents; it cannot name new code
+ * to run). `env` IS included in `agents` — an env var is attack surface (PATH/LD_PRELOAD hijack),
+ * so it is part of the launch family's blast radius even though it never appears as a command line.
+ */
+export function projectTrustContent(family: ProjectTrustFamily, doc: ProjectSettingsDoc): string | null {
+  switch (family) {
+    case 'setup': {
+      const s = doc.setup
+      if (s?.setupScript === undefined && s?.archiveScript === undefined) return null
+      return JSON.stringify({ setupScript: s?.setupScript ?? '', archiveScript: s?.archiveScript ?? '' })
+    }
+    case 'agents': {
+      const a = doc.agents
+      const envKeys = a?.env ? Object.keys(a.env).sort() : []
+      if (a?.launchCmd === undefined && envKeys.length === 0) return null
+      const env: Record<string, string> = {}
+      for (const k of envKeys) env[k] = a!.env![k]
+      return JSON.stringify({ launchCmd: a?.launchCmd ?? '', env })
+    }
+    case 'shell': {
+      const shell = doc.terminal?.shell
+      return shell ? shell : null
+    }
+    default:
+      return null
+  }
+}

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -277,3 +277,46 @@ export function sameProjectSettingsContent(a: ProjectSettingsFileV1, b: ProjectS
   const { rev: _revB, savedAt: _savedAtB, ...contentB } = b
   return JSON.stringify(contentA) === JSON.stringify(contentB)
 }
+
+export type ProjectSettingSource = 'local' | 'shared'
+export interface ResolvedProjectSetting<T> {
+  value: T
+  source: ProjectSettingSource
+}
+type R<T> = ResolvedProjectSetting<T>
+export interface ResolvedProjectSettings {
+  setup: { setupScript?: R<string>; archiveScript?: R<string>; waitForSetup?: R<boolean> }
+  worktree: { basePath?: R<string>; baseRef?: R<string>; sharedPaths?: R<string[]> }
+  agents: { defaultAgentId?: R<string>; launchCmd?: R<string>; env?: R<Record<string, string>> }
+  terminal: { shell?: R<string>; theme?: R<string>; fontFamily?: R<string> }
+}
+
+/**
+ * Local-over-shared, per key, with provenance — NOT global/default layering. Consumption sites
+ * apply `?? globalSetting` themselves on top of this (they know their own global); this function
+ * only decides between what THIS project's local and shared docs say. Walks the same
+ * `FAMILY_FIELDS` table the Task 1 sanitizer uses, so a field is still declared exactly once.
+ */
+export function resolveProjectSettings(
+  local: ProjectLocalSettings | undefined,
+  shared: ProjectSettingsDoc | undefined
+): ResolvedProjectSettings {
+  const out = { setup: {}, worktree: {}, agents: {}, terminal: {} } as ResolvedProjectSettings
+  for (const family of KNOWN_FAMILIES) {
+    const localFamily = local?.[family] as Record<string, unknown> | undefined
+    const sharedFamily = shared?.[family] as Record<string, unknown> | undefined
+    const ignoreThisFamily = local?.ignoreShared?.[family] === true
+    const target = out[family] as Record<string, unknown>
+    for (const key of Object.keys(FAMILY_FIELDS[family])) {
+      const localValue = localFamily?.[key]
+      if (localValue !== undefined) {
+        target[key] = { value: localValue, source: 'local' }
+        continue
+      }
+      if (ignoreThisFamily) continue
+      const sharedValue = sharedFamily?.[key]
+      if (sharedValue !== undefined) target[key] = { value: sharedValue, source: 'shared' }
+    }
+  }
+  return out
+}

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -1,0 +1,279 @@
+/**
+ * Per-project settings document — sibling of `.nodeterm/project.json`, same trust boundary.
+ *
+ * `.nodeterm/settings.json` (this file's shape) is GIT-SHARED hostile input exactly like
+ * project.json: hand-editable, auto-adopted by "Open folder…", and for an SSH project it lives on
+ * the remote host. Every sanitizer here therefore NEVER THROWS on malformed input — an unrecognized
+ * or foreign shape degrades to "field absent", never an exception that would block a load — and
+ * drops anything it does not recognize rather than passing it through.
+ *
+ * Two documents layer over this schema (see `resolveProjectSettings`):
+ *  - the SHARED doc (this file, `ProjectSettingsFileV1`) — what the repo ships.
+ *  - a LOCAL doc (`ProjectLocalSettings`) — this machine's own overrides, never git-shared, which
+ *    can also blank a whole family via `ignoreShared` without needing to override every key in it.
+ *
+ * `projectTrustContent` (Task 3) is the *other* half of the trust boundary: a canonical string of
+ * everything a family could actually EXECUTE, for a caller that needs to know whether a family's
+ * meaning has changed since it was last approved (the same shape of problem `execTrusted` solves
+ * for node-exec.ts).
+ */
+
+import * as path from 'path'
+
+export const PROJECT_SETTINGS_FILE = 'settings.json'
+
+export type ProjectSettingsFamily = 'setup' | 'worktree' | 'agents' | 'terminal'
+
+export interface ProjectSetupSettings {
+  setupScript?: string
+  archiveScript?: string
+  waitForSetup?: boolean
+}
+export interface ProjectWorktreeSettings {
+  basePath?: string
+  baseRef?: string
+  sharedPaths?: string[]
+}
+export interface ProjectAgentSettings {
+  defaultAgentId?: string
+  launchCmd?: string
+  env?: Record<string, string>
+}
+export interface ProjectTerminalSettings {
+  shell?: string
+  theme?: string
+  fontFamily?: string
+}
+
+export interface ProjectSettingsDoc {
+  setup?: ProjectSetupSettings
+  worktree?: ProjectWorktreeSettings
+  agents?: ProjectAgentSettings
+  terminal?: ProjectTerminalSettings
+}
+
+export interface ProjectSettingsFileV1 extends ProjectSettingsDoc {
+  version: 1
+  /** Monotonic save counter, same role as `ProjectFileV1.rev`. */
+  rev: number
+  savedAt: string
+}
+
+export interface ProjectLocalSettings extends ProjectSettingsDoc {
+  /** This machine ignores the shared family even when it sets no local value. */
+  ignoreShared?: Partial<Record<ProjectSettingsFamily, true>>
+}
+
+export type ProjectSettingsParse =
+  | { status: 'ok'; file: ProjectSettingsFileV1 }
+  | { status: 'invalid' }
+  | { status: 'conflict' }
+
+const STRING_CAP = 1024
+const BIG_STRING_CAP = 64000
+const LAUNCH_CMD_CAP = 4096
+const ENV_VALUE_CAP = 4096
+const ENV_MAX_ENTRIES = 64
+const SHARED_PATHS_CAP = 128
+const SHARED_PATH_STRING_CAP = 1024
+
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/
+
+type FieldKind = 'string' | 'bigString' | 'trueOnly' | 'env' | 'paths'
+
+interface FieldSpec {
+  kind: FieldKind
+}
+
+/**
+ * One row per settable field, shared by the sanitizer (this file, Task 1) and the resolver
+ * (`resolveProjectSettings`, Task 2) so a field is declared exactly once. Iteration order here is
+ * the order fields are considered everywhere else that walks this table.
+ */
+const FAMILY_FIELDS: Record<ProjectSettingsFamily, Record<string, FieldSpec>> = {
+  setup: {
+    setupScript: { kind: 'bigString' },
+    archiveScript: { kind: 'bigString' },
+    waitForSetup: { kind: 'trueOnly' }
+  },
+  worktree: {
+    basePath: { kind: 'string' },
+    baseRef: { kind: 'string' },
+    sharedPaths: { kind: 'paths' }
+  },
+  agents: {
+    defaultAgentId: { kind: 'string' },
+    launchCmd: { kind: 'string' }, // cap overridden to LAUNCH_CMD_CAP below
+    env: { kind: 'env' }
+  },
+  terminal: {
+    shell: { kind: 'string' },
+    theme: { kind: 'string' },
+    fontFamily: { kind: 'string' }
+  }
+}
+
+function sanitizeString(v: unknown, cap: number): string | undefined {
+  if (typeof v !== 'string' || v.length > cap) return undefined
+  return v
+}
+
+function sanitizeTrueOnly(v: unknown): true | undefined {
+  return v === true ? true : undefined
+}
+
+/** Plain object, clean-prototype keys/values only — see the file header on env as attack surface. */
+function sanitizeEnv(v: unknown): Record<string, string> | undefined {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return undefined
+  const kept: Record<string, string> = Object.create(null)
+  let count = 0
+  for (const key of Object.keys(v as object)) {
+    // `__proto__` matches ENV_KEY_RE lexically (it's just underscores/letters) but a settings.json
+    // is parsed with JSON.parse, which — unlike an object literal — DOES create it as a real own
+    // property (verified: Object.getOwnPropertyDescriptor). Reject it by name explicitly rather
+    // than relying on a plain-object assignment silently swallowing it later.
+    if (key === '__proto__' || !ENV_KEY_RE.test(key)) continue
+    const val = (v as Record<string, unknown>)[key]
+    if (typeof val !== 'string' || val.length > ENV_VALUE_CAP) continue
+    kept[key] = val
+    count++
+  }
+  if (count === 0) return undefined
+  // Cap AFTER collecting everything conforming, dropping extras in key-sorted order so the result
+  // is deterministic regardless of the input's own key order.
+  const keys = Object.keys(kept).sort()
+  const capped = keys.slice(0, ENV_MAX_ENTRIES)
+  const out: Record<string, string> = {}
+  for (const k of capped) out[k] = kept[k]
+  return out
+}
+
+function hasTraversalSegment(p: string): boolean {
+  return p.split(/[/\\]/).includes('..')
+}
+
+function sanitizeSharedPaths(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const entry of v) {
+    if (typeof entry !== 'string') continue
+    if (entry.length === 0 || entry.length > SHARED_PATH_STRING_CAP) continue
+    if (path.posix.isAbsolute(entry) || WINDOWS_DRIVE_RE.test(entry)) continue
+    if (hasTraversalSegment(entry)) continue
+    if (seen.has(entry)) continue
+    seen.add(entry)
+    out.push(entry)
+    if (out.length >= SHARED_PATHS_CAP) break
+  }
+  return out.length ? out : undefined
+}
+
+function sanitizeField(kind: FieldKind, key: string, v: unknown): unknown {
+  switch (kind) {
+    case 'string':
+      return sanitizeString(v, key === 'launchCmd' ? LAUNCH_CMD_CAP : STRING_CAP)
+    case 'bigString':
+      return sanitizeString(v, BIG_STRING_CAP)
+    case 'trueOnly':
+      return sanitizeTrueOnly(v)
+    case 'env':
+      return sanitizeEnv(v)
+    case 'paths':
+      return sanitizeSharedPaths(v)
+    default:
+      return undefined
+  }
+}
+
+function sanitizeFamily<F extends ProjectSettingsFamily>(
+  family: F,
+  raw: unknown
+): ProjectSettingsDoc[F] {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return undefined
+  const spec = FAMILY_FIELDS[family]
+  const out: Record<string, unknown> = {}
+  let any = false
+  for (const key of Object.keys(spec)) {
+    const v = sanitizeField(spec[key].kind, key, (raw as Record<string, unknown>)[key])
+    if (v !== undefined) {
+      out[key] = v
+      any = true
+    }
+  }
+  return (any ? out : undefined) as ProjectSettingsDoc[F]
+}
+
+export function sanitizeProjectSettingsDoc(v: unknown): ProjectSettingsDoc {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return {}
+  const raw = v as Record<string, unknown>
+  const out: ProjectSettingsDoc = {}
+  const setup = sanitizeFamily('setup', raw.setup)
+  if (setup) out.setup = setup
+  const worktree = sanitizeFamily('worktree', raw.worktree)
+  if (worktree) out.worktree = worktree
+  const agents = sanitizeFamily('agents', raw.agents)
+  if (agents) out.agents = agents
+  const terminal = sanitizeFamily('terminal', raw.terminal)
+  if (terminal) out.terminal = terminal
+  return out
+}
+
+const KNOWN_FAMILIES: readonly ProjectSettingsFamily[] = ['setup', 'worktree', 'agents', 'terminal']
+
+function sanitizeIgnoreShared(v: unknown): Partial<Record<ProjectSettingsFamily, true>> | undefined {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return undefined
+  const raw = v as Record<string, unknown>
+  const out: Partial<Record<ProjectSettingsFamily, true>> = {}
+  let any = false
+  for (const family of KNOWN_FAMILIES) {
+    if (raw[family] === true) {
+      out[family] = true
+      any = true
+    }
+  }
+  return any ? out : undefined
+}
+
+export function sanitizeProjectLocalSettings(v: unknown): ProjectLocalSettings | undefined {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return undefined
+  const doc = sanitizeProjectSettingsDoc(v)
+  const ignoreShared = sanitizeIgnoreShared((v as Record<string, unknown>).ignoreShared)
+  const out: ProjectLocalSettings = { ...doc }
+  if (ignoreShared) out.ignoreShared = ignoreShared
+  return out
+}
+
+// A git-conflicted settings.json must be left for the user to resolve, never guessed at by
+// parsing whichever half JSON.parse happens to tolerate.
+const CONFLICT_START_RE = /^<{7} /m
+const CONFLICT_END_RE = /^>{7} /m
+
+export function parseProjectSettingsFile(raw: string): ProjectSettingsParse {
+  if (CONFLICT_START_RE.test(raw) && CONFLICT_END_RE.test(raw)) return { status: 'conflict' }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { status: 'invalid' }
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return { status: 'invalid' }
+  const obj = parsed as Record<string, unknown>
+  if (obj.version !== 1) return { status: 'invalid' }
+  const rev = obj.rev
+  if (typeof rev !== 'number' || !Number.isFinite(rev) || rev < 0) return { status: 'invalid' }
+  const savedAt = typeof obj.savedAt === 'string' ? obj.savedAt : ''
+  const doc = sanitizeProjectSettingsDoc(obj)
+  return { status: 'ok', file: { version: 1, rev, savedAt, ...doc } }
+}
+
+export function serializeProjectSettingsFile(f: ProjectSettingsFileV1): string {
+  return JSON.stringify(f, null, 2)
+}
+
+export function sameProjectSettingsContent(a: ProjectSettingsFileV1, b: ProjectSettingsFileV1): boolean {
+  const { rev: _revA, savedAt: _savedAtA, ...contentA } = a
+  const { rev: _revB, savedAt: _savedAtB, ...contentB } = b
+  return JSON.stringify(contentA) === JSON.stringify(contentB)
+}


### PR DESCRIPTION
## Summary

PR1 of the Project Settings series (spec: `docs/superpowers/specs/2026-08-19-project-settings-design.md`, kept untracked per repo convention). This is the **data layer only** — no UI yet (that is PR2).

- **`src/shared/project-settings.ts`** — schema for a new cold, git-shared `<cwd>/.nodeterm/settings.json` (`setup` / `worktree` / `agents` / `terminal` families), hostile-input sanitizers (exact caps, env-key guard incl. JSON-parsed `__proto__` own keys, sharedPaths traversal rejection), a local-over-shared resolver with per-key provenance, and canonical trust-content builders covering the full executable blast radius (`setup` scripts; `launchCmd` **and** `env`; `shell`).
- **`src/core/project-settings-files.ts`** — settings file IO with the same discipline as `project.json`: atomic writes, `.corrupt-<ts>` sideline for unparsable files, git-conflict-marked files left in place, `rev` bumps only on real content change (canonical candidate construction makes unchanged saves byte-stable).
- **`src/core/project-trust-store.ts`** — `{userData}/project-trust.json`, SHA-256 content-hash approvals per family, keyed by **location identity** (resolved cwd / `user@host` + remoteCwd), never by project id (ids are attacker-controlled — clones and moves re-prompt). Fails closed on unreadable input; non-ENOENT read errors can never clobber the approvals file. `getRecord` exposes the prior approval for PR3's "changed since you approved" dialog copy.
- **`WorkspaceStore` integration** — machine-local overlay (`IndexEntryV3.localSettings`, the project-level analogue of `localExec`) persisted through the save chain; `readProjectSettings` / `writeProjectSettings` / `updateLocalProjectSettings`; every write reads the file first and refuses to overwrite a conflicted (or unreadable) shared file on both legs.
- **SSH leg** — optional `readSettings`/`writeSettings` on `RemoteWorkspaceIO` (un-throttled: settings are cold), offline `settingsCache` in the index, read-triggered reconcile (higher rev wins, absent remote healed from cache, cache-first writes survive drops), conflict refusal mirrored on the remote leg, and a mid-read/concurrent-write race guard.

## Review

Built spec-first with per-task adversarial review + scoped re-reviews and a whole-branch final review; every review finding was either fixed (4 fix commits) or explicitly triaged to a later PR of the series. Deferred items are listed in the series spec workspace notes; notable rides: reconcile-on-reconnect wiring (PR3, home: `refreshSshProject`), Windows UNC-path defensive joins (PR5).

## Test plan

- 67 new unit tests across the five touched modules (sanitizers incl. cap boundaries verified by mutation, trust-store fail-closed + clobber-refusal, IO sideline/conflict, overlay round-trips through `workspace.json`, ssh reconcile branches incl. the race and conflict refusal).
- Full suite: 7350 passed / 12 skipped; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)