### PR TITLE
feat(keybindings): registry-driven shortcut dispatch

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -88,7 +88,11 @@ import {
   syntheticAnsweredEvent
 } from '../core/agents/pending-approvals'
 import { setMainWindow, getMainWindow, sendToMain, closeAction, createCrashReloadPolicy } from './main-window'
-import { installKeydownIntercepts } from './keydown-intercept'
+import {
+  installKeydownIntercepts,
+  resolveInterceptBindings,
+  type KeydownInterceptBindings
+} from './keydown-intercept'
 import {
   initNotchHud,
   applyNotchHudSettings,
@@ -276,6 +280,18 @@ function isSafeExternalUrl(url: unknown): url is string {
 }
 
 const settingsStore = new SettingsStore()
+// ⌘M / ⌘W are registry commands (`node.toggleMarkdown` / `node.close`), so what the window
+// intercepts follows the user's settings. Resolved LAZILY (first keystroke, long after
+// `settingsStore.init()` in `whenReady`) rather than at module load, where `get()` would still be
+// DEFAULT_SETTINGS and every override would be missed until the next save; recomputed on
+// `onChange`, which fires after a successful save. Never per keystroke — sanitize is real work.
+const interceptIsMac = process.platform === 'darwin'
+let interceptBindings: KeydownInterceptBindings | null = null
+const currentInterceptBindings = (): KeydownInterceptBindings =>
+  (interceptBindings ??= resolveInterceptBindings(settingsStore.get().keybindings, interceptIsMac))
+settingsStore.onChange((s) => {
+  interceptBindings = resolveInterceptBindings(s.keybindings, interceptIsMac)
+})
 const sshStore = new SshStore()
 const ptyManager = new PtyManager()
 // Dictation: local whisper.cpp models live under userData, one dir per install (same convention
@@ -668,8 +684,9 @@ function createWindow(): BrowserWindow {
 
   // Steal ⌘M / ⌘W / ⌘0 back from Electron's default application menu (minimize / close /
   // resetZoom) and forward each to the renderer instead. The decision — and, importantly, what it
-  // must REFUSE — is in `keydown-intercept.ts`, where it can be pressed by a test.
-  installKeydownIntercepts(win)
+  // must REFUSE — is in `keydown-intercept.ts`, where it can be pressed by a test. The first two
+  // are the user's effective `node.toggleMarkdown` / `node.close` bindings (⌘0 is not remappable).
+  installKeydownIntercepts(win, currentInterceptBindings, interceptIsMac)
 
   // Open external links in the system browser — only safe schemes (no file://, no custom
   // protocol handlers). Reachable from remotely-fetched announcement URLs and rendered

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -3,6 +3,8 @@ import { IPC } from '../shared/ipc'
 import {
   installKeydownIntercepts,
   keydownIntercept,
+  resolveInterceptBindings,
+  type KeydownInterceptBindings,
   type KeydownInterceptInput,
   type KeydownInterceptTarget
 } from './keydown-intercept'
@@ -38,12 +40,23 @@ function input(over: Partial<KeydownInterceptInput> = {}): KeydownInterceptInput
   }
 }
 
+/** The shipped bindings, per platform. `node.close` / `node.toggleMarkdown` default to `Cmd+W` /
+ *  `Cmd+M` on both, but `Cmd` RESOLVES differently — ⌘ on mac, Control elsewhere — which is what
+ *  makes `press(…, { isMac: false })` below the Windows/Linux run of the same chord. */
+const DEFAULTS = resolveInterceptBindings(undefined, true)
+const DEFAULTS_PC = resolveInterceptBindings(undefined, false)
+
 /**
  * Press a key at the real installation seam: register the handler on a fake window exactly as
  * `createWindow` does, then dispatch. Covers the wiring (`preventDefault` is called, the channel is
  * sent on `webContents`), not just the pure decision.
  */
-function press(over: Partial<KeydownInterceptInput> = {}): { prevented: boolean; sent: string[] } {
+function press(
+  over: Partial<KeydownInterceptInput> = {},
+  opts: { bindings?: KeydownInterceptBindings; isMac?: boolean } = {}
+): { prevented: boolean; sent: string[] } {
+  const isMac = opts.isMac ?? true
+  const bindings = opts.bindings ?? (isMac ? DEFAULTS : DEFAULTS_PC)
   let handler:
     | ((event: { preventDefault(): void }, input: KeydownInterceptInput) => void)
     | null = null
@@ -58,7 +71,7 @@ function press(over: Partial<KeydownInterceptInput> = {}): { prevented: boolean;
       }
     }
   }
-  installKeydownIntercepts(win)
+  installKeydownIntercepts(win, () => bindings, isMac)
   if (!handler) throw new Error('installKeydownIntercepts registered no before-input-event listener')
   let prevented = false
   ;(handler as (e: { preventDefault(): void }, i: KeydownInterceptInput) => void)(
@@ -116,6 +129,10 @@ describe('⌘0 → canvas back to 100%', () => {
 
   it('is intercepted under Ctrl too (Windows / Linux)', () => {
     expect(press({ control: true })).toEqual({ prevented: true, sent: [IPC.appZoomActualSize] })
+    expect(press({ control: true }, { isMac: false })).toEqual({
+      prevented: true,
+      sent: [IPC.appZoomActualSize]
+    })
   })
 
   // Matched on the physical key, so the chord survives a layout where the zero key prints
@@ -147,24 +164,22 @@ describe('⌘M → markdown view, stolen back from Window ▸ Minimize', () => {
       prevented: true,
       sent: [IPC.appToggleMarkdown]
     })
-    expect(press({ control: true, key: 'm', code: 'KeyM' })).toEqual({
+    // Windows / Linux: the same `Cmd+M` binding resolves to Control there.
+    expect(press({ control: true, key: 'm', code: 'KeyM' }, { isMac: false })).toEqual({
       prevented: true,
       sent: [IPC.appToggleMarkdown]
     })
   })
 
-  // The shipped breadth of this branch: unlike ⌘W and ⌘0 it tests no Shift/Alt, so ⌘⇧M and ⌘⌥M
-  // toggle too. Pinned as-is — narrowing it is a real behaviour change (⌘⇧M would go back to the
-  // menu) and should turn this red on purpose rather than slip through.
-  it('also claims ⌘⇧M and ⌘⌥M', () => {
-    expect(press({ meta: true, shift: true, key: 'M', code: 'KeyM' })).toEqual({
-      prevented: true,
-      sent: [IPC.appToggleMarkdown]
-    })
-    expect(press({ meta: true, alt: true, key: 'm', code: 'KeyM' })).toEqual({
-      prevented: true,
-      sent: [IPC.appToggleMarkdown]
-    })
+  // D-STRICT DELTA (named in the PR body). The old branch was `key === 'm'` under a
+  // `meta || control` guard, so ⌘⇧M, ⌘⌥M and — on mac — ⌃M all toggled too. Matching a real
+  // binding is exact on all four modifier flags, so each of those is now a different chord and
+  // goes back to the page/menu. This is the behaviour change; assert it rather than leave it to
+  // a reader of the diff.
+  it('no longer claims ⌘⇧M, ⌘⌥M, or ⌃M on mac', () => {
+    expect(press({ meta: true, shift: true, key: 'M', code: 'KeyM' })).toEqual(UNTOUCHED)
+    expect(press({ meta: true, alt: true, key: 'm', code: 'KeyM' })).toEqual(UNTOUCHED)
+    expect(press({ control: true, key: 'm', code: 'KeyM' })).toEqual(UNTOUCHED)
   })
 
   it('repeats keep toggling (no auto-repeat rule here, unlike ⌘0)', () => {
@@ -181,7 +196,7 @@ describe('⌘W → close the selected node, stolen back from Window ▸ Close', 
       prevented: true,
       sent: [IPC.appCloseNode]
     })
-    expect(press({ control: true, key: 'w', code: 'KeyW' })).toEqual({
+    expect(press({ control: true, key: 'w', code: 'KeyW' }, { isMac: false })).toEqual({
       prevented: true,
       sent: [IPC.appCloseNode]
     })
@@ -190,14 +205,87 @@ describe('⌘W → close the selected node, stolen back from Window ▸ Close', 
   it('leaves ⌘⇧W to the menu (Close All Windows)', () => {
     expect(press({ meta: true, shift: true, key: 'W', code: 'KeyW' })).toEqual(UNTOUCHED)
   })
+
+  // Same D-strict delta as ⌘M's: ⌃W was swallowed app-wide on mac (where it is readline's
+  // delete-word, not a menu accelerator) and now reaches the page.
+  it('no longer claims ⌃W on mac', () => {
+    expect(press({ control: true, key: 'w', code: 'KeyW' })).toEqual(UNTOUCHED)
+  })
 })
 
 describe('the decision is pure', () => {
   // Same function, called directly: a caller that is not a BrowserWindow (a future menu, a test,
   // the next intercept) gets the same answer, and `null` unambiguously means "not ours".
   it('returns null for anything unclaimed and an action for a claimed chord', () => {
-    expect(keydownIntercept(input())).toBeNull()
-    expect(keydownIntercept(input({ meta: true }))).toEqual({ action: 'zoom-actual-size' })
-    expect(keydownIntercept(input({ meta: true, isAutoRepeat: true }))).toEqual({ action: null })
+    expect(keydownIntercept(input(), DEFAULTS, true)).toBeNull()
+    expect(keydownIntercept(input({ meta: true }), DEFAULTS, true)).toEqual({
+      action: 'zoom-actual-size'
+    })
+    expect(keydownIntercept(input({ meta: true, isAutoRepeat: true }), DEFAULTS, true)).toEqual({
+      action: null
+    })
+  })
+})
+
+describe('binding-driven intercept', () => {
+  it('defaults reproduce today: Cmd+M and Cmd+W intercept, Shift variants do not', () => {
+    expect(keydownIntercept(input({ meta: true, key: 'm', code: 'KeyM' }), DEFAULTS, true)).toEqual({
+      action: 'toggle-markdown'
+    })
+    expect(keydownIntercept(input({ meta: true, key: 'w', code: 'KeyW' }), DEFAULTS, true)).toEqual({
+      action: 'close-node'
+    })
+    expect(keydownIntercept(input({ meta: true, shift: true, key: 'w', code: 'KeyW' }), DEFAULTS, true)).toBeNull()
+    // D-strict delta, named in the PR body: ⌘⇧M no longer intercepts (old code ignored shift on m).
+    expect(keydownIntercept(input({ meta: true, shift: true, key: 'm', code: 'KeyM' }), DEFAULTS, true)).toBeNull()
+  })
+
+  it('an unbound command stops intercepting (Electron default returns)', () => {
+    const unbound = resolveInterceptBindings({ 'node.close': [] }, true)
+    expect(keydownIntercept(input({ meta: true, key: 'w', code: 'KeyW' }), unbound, true)).toBeNull()
+    expect(keydownIntercept(input({ meta: true, key: 'm', code: 'KeyM' }), unbound, true)).toEqual({
+      action: 'toggle-markdown'
+    })
+  })
+
+  it('a remap moves the interception', () => {
+    const remapped = resolveInterceptBindings({ 'node.toggleMarkdown': ['Cmd+Shift+M'] }, true)
+    expect(keydownIntercept(input({ meta: true, key: 'm', code: 'KeyM' }), remapped, true)).toBeNull()
+    expect(keydownIntercept(input({ meta: true, shift: true, key: 'm', code: 'KeyM' }), remapped, true)).toEqual({
+      action: 'toggle-markdown'
+    })
+  })
+
+  // The reason the primary-modifier half of the old shared gate could NOT stay where it was: an
+  // Alt-only chord is a valid binding per the registry's rules, this intercept is its only
+  // dispatcher (the chord never reaches the renderer — the page does not see a claimed key), so a
+  // `meta || control` gate above the matchers would make the remap dead everywhere with no error.
+  it('an Alt-only remap fires, and the bare key still does not', () => {
+    const alt = resolveInterceptBindings({ 'node.toggleMarkdown': ['Alt+M'] }, true)
+    expect(keydownIntercept(input({ alt: true, key: 'm', code: 'KeyM' }), alt, true)).toEqual({
+      action: 'toggle-markdown'
+    })
+    expect(keydownIntercept(input({ key: 'm', code: 'KeyM' }), alt, true)).toBeNull()
+  })
+
+  it('garbage overrides fall back to defaults', () => {
+    expect(resolveInterceptBindings({ 'node.close': ['garbage+++'] }, true)).toEqual(DEFAULTS)
+  })
+
+  it('the Digit0 zoom gesture is untouched by bindings', () => {
+    const unbound = resolveInterceptBindings({ 'node.close': [], 'node.toggleMarkdown': [] }, true)
+    expect(keydownIntercept(input({ meta: true, code: 'Digit0' }), unbound, true)).toEqual({
+      action: 'zoom-actual-size'
+    })
+    // ...and it keeps the primary-modifier requirement it used to inherit from the shared gate.
+    expect(keydownIntercept(input({ code: 'Digit0' }), unbound, true)).toBeNull()
+  })
+
+  it('a remapped binding is dispatched at the install seam too', () => {
+    const remapped = resolveInterceptBindings({ 'node.close': ['Cmd+Shift+K'] }, true)
+    expect(press({ meta: true, shift: true, key: 'K', code: 'KeyK' }, { bindings: remapped })).toEqual(
+      { prevented: true, sent: [IPC.appCloseNode] }
+    )
+    expect(press({ meta: true, key: 'w', code: 'KeyW' }, { bindings: remapped })).toEqual(UNTOUCHED)
   })
 })

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -260,12 +260,24 @@ describe('binding-driven intercept', () => {
   // Alt-only chord is a valid binding per the registry's rules, this intercept is its only
   // dispatcher (the chord never reaches the renderer — the page does not see a claimed key), so a
   // `meta || control` gate above the matchers would make the remap dead everywhere with no error.
-  it('an Alt-only remap fires, and the bare key still does not', () => {
-    const alt = resolveInterceptBindings({ 'node.toggleMarkdown': ['Alt+M'] }, true)
-    expect(keydownIntercept(input({ alt: true, key: 'm', code: 'KeyM' }), alt, true)).toEqual({
+  // Pressed with **isMac: false** on purpose: `Alt+M` is a Windows/Linux chord. macOS composes
+  // Option+letter into a character (⌥M reports `key: 'µ'`), so this exact remap could not fire
+  // there whatever this module did — mac's stake in the gate is Alt+non-letter (F-keys, arrows).
+  it('an Alt-only remap fires off-mac, and the bare key still does not', () => {
+    const alt = resolveInterceptBindings({ 'node.toggleMarkdown': ['Alt+M'] }, false)
+    expect(keydownIntercept(input({ alt: true, key: 'm', code: 'KeyM' }), alt, false)).toEqual({
       action: 'toggle-markdown'
     })
-    expect(keydownIntercept(input({ key: 'm', code: 'KeyM' }), alt, true)).toBeNull()
+    expect(keydownIntercept(input({ key: 'm', code: 'KeyM' }), alt, false)).toBeNull()
+  })
+
+  // The mac half of the same gate, on a key macOS does NOT compose: ⌥F5 stays `key: 'F5'`.
+  it('a mac Alt+non-letter remap fires (what Option composition leaves reachable there)', () => {
+    const alt = resolveInterceptBindings({ 'node.toggleMarkdown': ['Alt+F5'] }, true)
+    expect(keydownIntercept(input({ alt: true, key: 'F5', code: 'F5' }), alt, true)).toEqual({
+      action: 'toggle-markdown'
+    })
+    expect(keydownIntercept(input({ key: 'F5', code: 'F5' }), alt, true)).toBeNull()
   })
 
   it('garbage overrides fall back to defaults', () => {

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -1,4 +1,6 @@
 import { IPC } from '../shared/ipc'
+import { getEffectiveBindings, sanitizeKeybindingOverrides } from '../shared/keybindings'
+import { matchesShortcut } from '../shared/shortcut'
 
 /**
  * The main window's `before-input-event` decision as ONE pure function — the desktop half of the
@@ -18,10 +20,15 @@ import { IPC } from '../shared/ipc'
  * **Why it is pure and lives here rather than in the callback.** Deleting a branch from an inline
  * callback breaks nothing and throws nothing — the shortcut just quietly starts minimizing the
  * window / closing it / resetting the WINDOW's page zoom instead of doing the app's thing. Worse,
- * the guard below is *shared* by three branches, so a change to it silently re-decides chords it
- * was not aimed at: loosen it and this window starts swallowing **bare** keystrokes app-wide, and
- * `index.ts` merges that kind of edit without a conflict. Both failures are invisible to a test
- * that reads the source; they are one assertion each against this function.
+ * a modifier test here is what keeps a branch off ordinary typing, so loosening one silently makes
+ * this window swallow **bare** keystrokes app-wide, and `index.ts` merges that kind of edit without
+ * a conflict. Both failures are invisible to a test that reads the source; they are one assertion
+ * each against this function.
+ *
+ * **This module stays the closed list of main-intercepted chords.** ⌘M and ⌘W are now resolved
+ * from the keybinding registry (`node.toggleMarkdown` / `node.close`), so the USER decides which
+ * chord they are — but nothing else is intercepted here, because everything else reaches the
+ * renderer's dispatcher on its own.
  *
  * Desktop-only by construction (it exists to fight a native menu), so it stays in `src/main` next
  * to `main-window.ts` rather than moving to `src/core` — the Server Edition's browser shell has no
@@ -53,26 +60,88 @@ export interface KeydownInterceptDecision {
   action: KeydownInterceptAction | null
 }
 
+/** The effective chords for the two REMAPPABLE commands this module intercepts. `readonly
+ *  string[]` in shortcut.ts's canonical spelling; `[]` means the user unbound the command, which
+ *  must read as "do not claim the key" — Electron's own menu item comes back. */
+export interface KeydownInterceptBindings {
+  closeNode: readonly string[]
+  toggleMarkdown: readonly string[]
+}
+
+/**
+ * Effective M/W chords from raw settings overrides (sanitized here so a hand-edited settings.json
+ * cannot crash or hijack the intercept — this runs on the way to `before-input-event`, the one
+ * code path where a throw eats every keystroke in the window).
+ */
+export function resolveInterceptBindings(
+  rawOverrides: unknown,
+  isMac: boolean
+): KeydownInterceptBindings {
+  const { overrides } = sanitizeKeybindingOverrides(rawOverrides, isMac)
+  return {
+    closeNode: getEffectiveBindings('node.close', overrides, isMac),
+    toggleMarkdown: getEffectiveBindings('node.toggleMarkdown', overrides, isMac)
+  }
+}
+
+/** Electron's `Input` flags in the shape `matchesShortcut` reads. */
+function toShortcutEvent(input: KeydownInterceptInput): {
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+  key: string
+} {
+  return {
+    metaKey: input.meta,
+    ctrlKey: input.control,
+    shiftKey: input.shift,
+    altKey: input.alt,
+    key: input.key
+  }
+}
+
 /**
  * PURE. What this `before-input-event` input means, or `null` to leave the key completely alone
  * (no `preventDefault` — the page and, failing that, the menu get it).
  *
- * The primary-modifier requirement is deliberately in the shared guard *and* is the only thing
- * standing between the branches below and ordinary typing: `m`, `w` and `0` are all characters a
- * user types. Any rewrite that moves the modifier decision into the individual branches has to
- * give **every** branch one — see `keydown-intercept.test.ts`, which presses each of them bare.
+ * **Every branch owns its own modifier requirement, and must.** The old shared guard was
+ * `type !== 'keyDown' || !(input.meta || input.control)`, which is exactly the check standing
+ * between these branches and ordinary typing — `m`, `w` and `0` are all characters a user types.
+ * It could not survive user-remappable bindings: `Alt+M` is a VALID binding per the registry's
+ * rules, and this module is its ONLY dispatcher (a chord we claim never reaches the renderer),
+ * so a primary-modifier gate above the matchers would make such a remap silently dead everywhere.
+ * So the two remappable chords are matched EXACTLY (all four modifier flags, `matchesShortcut`),
+ * which is a modifier requirement per binding, and the hardcoded `Digit0` branch below carries
+ * the `meta || control` test it used to inherit. `keydown-intercept.test.ts` presses each of them
+ * bare; keep it that way.
  */
-export function keydownIntercept(input: KeydownInterceptInput): KeydownInterceptDecision | null {
-  if (input.type !== 'keyDown' || !(input.meta || input.control)) return null
-  const key = input.key.toLowerCase()
-  if (key === 'm') return { action: 'toggle-markdown' }
+export function keydownIntercept(
+  input: KeydownInterceptInput,
+  bindings: KeydownInterceptBindings,
+  isMac: boolean
+): KeydownInterceptDecision | null {
+  if (input.type !== 'keyDown') return null
+  // Matched against the user's effective bindings (defaults ⌘M / ⌘W). `matchesShortcut` is exact
+  // on meta/ctrl/alt/shift, so ⌘⇧M and ⌘⌥M — which the old `key === 'm'` branch also swallowed —
+  // are now different chords and go back to the page. Parsing is memoized in shortcut.ts, so this
+  // stays cheap on main's input path.
+  const ev = toShortcutEvent(input)
+  if (bindings.toggleMarkdown.some((s) => matchesShortcut(ev, s, isMac))) {
+    return { action: 'toggle-markdown' }
+  }
   // Repurpose Cmd/Ctrl+W: the renderer closes the selected node(s); if none are selected it asks
-  // us to close the window (the standard behavior). ⇧ is left to the menu's Close All Windows.
-  if (key === 'w' && !input.shift) return { action: 'close-node' }
-  // Matched on the physical `code`, like the renderer's half of the chord (`zoomShortcutChord`):
-  // on a non-US layout the zero key's `key` is not necessarily "0". Alt is excluded because AltGr
-  // reports as ctrl+alt and must keep typing a real character.
-  if (input.code === 'Digit0' && !input.shift && !input.alt) {
+  // us to close the window (the standard behavior). ⇧ is left to the menu's Close All Windows —
+  // now by the binding being `Cmd+W` and the match being exact, rather than by a `!input.shift`.
+  if (bindings.closeNode.some((s) => matchesShortcut(ev, s, isMac))) {
+    return { action: 'close-node' }
+  }
+  // NOT remappable: this is the renderer's `zoomShortcutChord` half of a canvas gesture, not a
+  // registry command. Matched on the physical `code`, like that half: on a non-US layout the zero
+  // key's `key` is not necessarily "0". Alt is excluded because AltGr reports as ctrl+alt and must
+  // keep typing a real character; `meta || control` is the primary-modifier test it used to
+  // inherit from the shared guard, and without it every bare `0` in the app is swallowed (#193).
+  if (input.code === 'Digit0' && (input.meta || input.control) && !input.shift && !input.alt) {
     // Auto-repeat is dropped here rather than in the renderer, so a held chord cannot restart the
     // 200ms zoom tween — the same rule `zoomShortcutChord` applies to the keydown path. Still
     // claimed, so a held ⌘0 does not fall through to `resetZoom` on the second repeat.
@@ -104,10 +173,18 @@ export interface KeydownInterceptTarget {
  * Wire `keydownIntercept` to `win`. The whole side-effecting half is these four lines, so a test
  * that calls this with a fake window exercises registration, the refusal, the `preventDefault` and
  * the forwarded channel together — everything except the single call site in `index.ts`.
+ *
+ * `getBindings` is read per event rather than captured: settings change while the window lives, and
+ * it returns a cached object (`index.ts` recomputes it on `settingsStore.onChange`, not here — a
+ * sanitize per keystroke would be real work on the input path).
  */
-export function installKeydownIntercepts(win: KeydownInterceptTarget): void {
+export function installKeydownIntercepts(
+  win: KeydownInterceptTarget,
+  getBindings: () => KeydownInterceptBindings,
+  isMac: boolean
+): void {
   win.webContents.on('before-input-event', (event, input) => {
-    const decision = keydownIntercept(input)
+    const decision = keydownIntercept(input, getBindings(), isMac)
     if (!decision) return
     event.preventDefault()
     if (decision.action) win.webContents.send(keydownInterceptChannel(decision.action))

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -108,9 +108,13 @@ function toShortcutEvent(input: KeydownInterceptInput): {
  * **Every branch owns its own modifier requirement, and must.** The old shared guard was
  * `type !== 'keyDown' || !(input.meta || input.control)`, which is exactly the check standing
  * between these branches and ordinary typing — `m`, `w` and `0` are all characters a user types.
- * It could not survive user-remappable bindings: `Alt+M` is a VALID binding per the registry's
+ * It could not survive user-remappable bindings: an Alt-only chord is VALID per the registry's
  * rules, and this module is its ONLY dispatcher (a chord we claim never reaches the renderer),
  * so a primary-modifier gate above the matchers would make such a remap silently dead everywhere.
+ * Who that actually buys something for: **Windows/Linux Alt chords** (`Alt+M`, `Alt+W` — plain
+ * letter combos there), and on **macOS the Alt+non-letter ones** (`Alt+F5`, `Alt+ArrowUp`). It is
+ * NOT mac Option+letter: macOS composes those into a character, so ⌥M arrives as `key: 'µ'` and an
+ * `Alt+M` binding could never match there whatever this gate did.
  * So the two remappable chords are matched EXACTLY (all four modifier flags, `matchesShortcut`),
  * which is a modifier requirement per binding, and the hardcoded `Digit0` branch below carries
  * the `meta || control` test it used to inherit. `keydown-intercept.test.ts` presses each of them

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -173,6 +173,13 @@ import {
   zoomShortcutAllowed,
   zoomShortcutChord
 } from '../lib/zoomShortcut'
+import {
+  dispatchGlobalKeydown,
+  type GlobalKeyEvent,
+  type GlobalKeydownDeps
+} from '../lib/globalKeybindings'
+import type { ContextElement } from '../lib/keyContext'
+import { activeKeybindingOverrides } from '../lib/keybindingOverrides'
 import { UsageIndicator } from '../components/UsageIndicator'
 import { SystemResourcePill } from '../components/SystemResourcePill'
 import { PresenceLayer } from '../components/PresenceLayer'
@@ -2441,23 +2448,6 @@ export function Canvas() {
     bumpHist((v) => v + 1)
   }, [setNodes, bumpDirty])
 
-  // Cmd/Ctrl+Z = undo, Cmd/Ctrl+Shift+Z or Cmd/Ctrl+Y = redo (ignored while typing).
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (isKanbanOpen(useProjects.getState().activeProjectId)) return
-      if (!(e.metaKey || e.ctrlKey)) return
-      const k = e.key.toLowerCase()
-      if (k !== 'z' && k !== 'y') return
-      const tag = (document.activeElement?.tagName || '').toLowerCase()
-      if (tag === 'input' || tag === 'textarea') return
-      e.preventDefault()
-      if (k === 'y' || (k === 'z' && e.shiftKey)) redo()
-      else undo()
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [undo, redo])
-
   // ---- canvas interactions ----
 
   /** The position of the agent node a card hangs off, in the CARD's own coordinate space (they
@@ -3678,37 +3668,6 @@ export function Canvas() {
     setRemotePicker(screenPos)
   }, [])
 
-  // ⌘T = new terminal, ⌘⇧C = new default agent, a KEYED dictation shortcut (e.g. "Cmd+Alt+D") =
-  // toggle dictation (ignored while typing in a field/terminal). A modifier-only shortcut (the
-  // new default, "Cmd+Alt") is hold-to-talk instead — matchesShortcut always returns false for
-  // that shape (its `key` is null), so this effect is naturally a no-op for it; see the
-  // dedicated hold-mode effect below, which is what fires in that case.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (isKanbanOpen(useProjects.getState().activeProjectId)) return
-      if (!(e.metaKey || e.ctrlKey)) return
-      const tag = (document.activeElement?.tagName || '').toLowerCase()
-      if (tag === 'input' || tag === 'textarea') return
-      if (matchesShortcut(e, useSettings.getState().settings.speech.shortcut, isMac)) {
-        e.preventDefault()
-        toggleDictation()
-        return
-      }
-      const k = e.key.toLowerCase()
-      if (k === 't' && !e.shiftKey) {
-        e.preventDefault()
-        addTerminal()
-      } else if (k === 'c' && e.shiftKey) {
-        e.preventDefault()
-        // launchableDefaultAgent, not the raw setting: a default naming a since-removed custom
-        // agent would otherwise type its bare `custom:<uuid>` id into the new node's shell.
-        addAgentNode(launchableDefaultAgent(useSettings.getState().settings))
-      }
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [addTerminal, addAgentNode, toggleDictation])
-
   // v3 hold-to-talk: active only while the configured dictation shortcut is a modifier-only
   // chord (isHoldChord — the new default, "Cmd+Alt"). Walkie-talkie semantics: the chord held
   // down starts recording immediately (armed on the keydown that completes the exact modifier
@@ -3989,6 +3948,40 @@ export function Canvas() {
     [setNodes, markDirty, refreshWorktreeStore, releaseWorktreeBinding]
   )
 
+  /** `canvas.deleteSelection` (Delete / Backspace): confirm-then-delete the selected nodes, or —
+   *  with no node selected — drop the selected context link(s) / control rope(s). Returns whether
+   *  the chord was CLAIMED: an empty selection claims nothing, so the key falls through to the
+   *  platform exactly as the old handler's bare `return` left it. */
+  const deleteSelectionCommand = useCallback((): boolean => {
+    const ids = nodesRef.current.filter((n) => n.selected).map((n) => n.id)
+    if (!ids.length) {
+      const edgeIds = linkEdgesRef.current.filter((b) => b.selected).map((b) => b.id)
+      const ropeIds = controlEdgesRef.current.filter((b) => b.selected).map((b) => b.id)
+      if (!edgeIds.length && !ropeIds.length) return false
+      // A selected rope may be standing in for a hidden context bridge — drop both, or the
+      // pair stays linked with no edge left to click (see displayEdges).
+      const drop = new Set([
+        ...edgeIds,
+        ...linkIdsCoveredByRopes(ropeIds, controlEdgesRef.current, linkEdgesRef.current)
+      ])
+      if (drop.size) setLinkEdges((es) => es.filter((b) => !drop.has(b.id)))
+      if (ropeIds.length) {
+        const dropRopes = new Set(ropeIds)
+        setControlEdges((es) => es.filter((b) => !dropRopes.has(b.id)))
+      }
+      markDirty()
+      return true
+    }
+    setConfirm({
+      message: `Delete ${ids.length} ${ids.length > 1 ? 'nodes' : 'node'}? Open terminal sessions will end.`,
+      onConfirm: () => {
+        deleteNodes(ids)
+        setConfirm(null)
+      }
+    })
+    return true
+  }, [deleteNodes, setLinkEdges, setControlEdges, markDirty, setConfirm])
+
   // When an account is removed in Settings, patch the ACTIVE project's live nodes (the projects
   // store only holds the other projects' serialized copies). The account's login node is
   // permanently DELETED — left alive with its accountId cleared, a cold restart would respawn
@@ -4022,50 +4015,6 @@ export function Canvas() {
     window.addEventListener('nodeterm:account-removed', onAccountRemoved)
     return () => window.removeEventListener('nodeterm:account-removed', onAccountRemoved)
   }, [setNodes, markDirty, deleteNodes])
-
-  // Delete / Backspace asks for confirmation, then deletes the selected nodes.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (isKanbanOpen(useProjects.getState().activeProjectId)) return
-      if (e.key !== 'Delete' && e.key !== 'Backspace') return
-      const tag = (document.activeElement?.tagName || '').toLowerCase()
-      if (tag === 'input' || tag === 'textarea') return
-      const ids = nodesRef.current.filter((n) => n.selected).map((n) => n.id)
-      if (!ids.length) {
-        // No node selected → remove any selected context link(s) / control rope(s).
-        const edgeIds = linkEdgesRef.current.filter((b) => b.selected).map((b) => b.id)
-        const ropeIds = controlEdgesRef.current.filter((b) => b.selected).map((b) => b.id)
-        if (edgeIds.length || ropeIds.length) {
-          e.preventDefault()
-          // A selected rope may be standing in for a hidden context bridge — drop both, or the
-          // pair stays linked with no edge left to click (see displayEdges).
-          const drop = new Set([
-            ...edgeIds,
-            ...linkIdsCoveredByRopes(ropeIds, controlEdgesRef.current, linkEdgesRef.current)
-          ])
-          if (drop.size) {
-            setLinkEdges((es) => es.filter((b) => !drop.has(b.id)))
-          }
-          if (ropeIds.length) {
-            const dropRopes = new Set(ropeIds)
-            setControlEdges((es) => es.filter((b) => !dropRopes.has(b.id)))
-          }
-          markDirty()
-        }
-        return
-      }
-      e.preventDefault()
-      setConfirm({
-        message: `Delete ${ids.length} ${ids.length > 1 ? 'nodes' : 'node'}? Open terminal sessions will end.`,
-        onConfirm: () => {
-          deleteNodes(ids)
-          setConfirm(null)
-        }
-      })
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [deleteNodes, setLinkEdges, markDirty])
 
   // Cmd/Ctrl+W (forwarded from main) closes the selected node(s) immediately, like the
   // node's × button. With nothing selected it falls back to closing the window.
@@ -5210,101 +5159,155 @@ export function Canvas() {
     [commitActiveToStore, writeDisk]
   )
 
-  // Cmd/Ctrl+K toggles the command palette; Cmd/Ctrl+, opens settings.
+  // ---- global shortcuts ----
+  // The three trailing gestures below are registry-LESS chords (design D2: declared gestures,
+  // deliberately not remappable in this PR). The dispatcher hands them the RAW event with no
+  // context, so each keeps its OWN guards exactly as today's if-chain branch carried them.
+  // Zoom and project-jump are POSITIONAL chords (`e.code`, auto-repeat aware) — fields the
+  // dispatcher's structural `GlobalKeyEvent` does not model — and the only dispatch site is the
+  // window listener below, which always hands them a real KeyboardEvent.
+
+  // ⌘/Ctrl+0 = back to 100%, Shift+1 = fit everything. `liveZoomShortcutAction` is the whole
+  // decision (see `lib/zoomShortcut.ts`), including the typing refusal, and the ⌘0 desktop route
+  // below asks the same one, so the two paths can never disagree about when the chord is allowed
+  // to move the camera. A null answer means "leave the key alone" — no `preventDefault`, which is
+  // what keeps Shift+1 typing a `!` wherever the user is actually typing.
+  const zoomGesture = useCallback((raw: GlobalKeyEvent): boolean => {
+    const e = raw as KeyboardEvent
+    if (zoomShortcutChord(e) === null) return false
+    const action = liveZoomShortcutAction(e)
+    if (!action) return false
+    e.preventDefault()
+    if (action === 'zoom-100') zoomTo100()
+    else fitAll()
+    return true
+  }, [zoomTo100, fitAll])
+
+  // Cmd/Ctrl+1-9 jumps to the Nth project — but only when the app actually owns the key (desktop
+  // shell, and the digit addresses an open project). `liveProjectJumpTarget` is the same decision
+  // the terminals' swallow asks, so the two can't disagree; a null target leaves the key to
+  // whatever has focus. `switchProject` no-ops on the active id.
+  const projectJumpGesture = useCallback((raw: GlobalKeyEvent): boolean => {
+    const e = raw as KeyboardEvent
+    if (projectJumpDigit(e) === null) return false
+    const targetId = liveProjectJumpTarget(e)
+    if (!targetId) return false
+    e.preventDefault()
+    switchProject(targetId)
+    return true
+  }, [switchProject])
+
+  const copyGesture = useCallback((e: GlobalKeyEvent): boolean => {
+    if (!((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'c')) return false
+    // Native text selection wins (markdown, editor and terminal keep their normal copy path).
+    const tag = (document.activeElement?.tagName || '').toLowerCase()
+    if (
+      tag === 'input' ||
+      tag === 'textarea' ||
+      document.activeElement?.getAttribute('contenteditable') === 'true' ||
+      document.activeElement?.closest('.monaco-editor, .xterm')
+    )
+      return false
+    const sel = window.getSelection?.()?.toString()
+    if (sel) {
+      window.nodeTerminal.clipboard.writeText(sel)
+      // Claimed, but deliberately WITHOUT preventDefault — exactly as today: the native copy is
+      // let through as well.
+      return true
+    }
+    // Nothing selected as text: copy the selected file-backed nodes as FILE REFERENCES, so
+    // Finder (or any file-aware app) pastes the actual files.
+    //
+    // Gated to where it can actually succeed, because the failure path raises a banner that
+    // stays until dismissed — and before this feature the keystroke was a silent no-op, which
+    // is what every other machine must keep getting. `writeFilesToClipboard` is darwin-gated
+    // in main and the browser bridge stub answers false, so on a non-mac renderer (desktop OR
+    // Server Edition) this branch could only ever produce that banner, wearing macOS-specific
+    // copy on a Linux box. The board is an opaque overlay over the canvas, so a copy there
+    // would act on a selection the user cannot see (the canvas-only-shortcut discipline).
+    const projects = useProjects.getState()
+    if (!isMac || isKanbanOpen(projects.activeProjectId)) return false
+    const paths = selectedLocalFilePaths(nodesRef.current, {
+      projectIsRelay: !!projects.getProject(projects.activeProjectId ?? '')?.remote
+    })
+    if (!paths.length) return false
+    e.preventDefault()
+    void window.nodeTerminal.clipboard
+      .writeFiles(paths)
+      .then((copied) => {
+        setCopyError(
+          copied
+            ? null
+            : 'Copy failed — only existing local files can be copied from the macOS desktop app.'
+        )
+      })
+      .catch(() => setCopyError('Copy failed — the system clipboard is unavailable.'))
+    return true
+  }, [setCopyError])
+
+  // ONE window keydown for every registry command + the legacy gestures. The deps live in a
+  // ref refreshed each render so the listener is registered once; handlers return whether
+  // they claimed the chord (an unavailable surface falls through to the platform).
+  const globalKeyDeps = useRef<GlobalKeydownDeps | null>(null)
+  globalKeyDeps.current = {
+    activeElement: () => document.activeElement as unknown as ContextElement | null,
+    kanbanOpen: () => isKanbanOpen(useProjects.getState().activeProjectId),
+    overrides: activeKeybindingOverrides,
+    isMac,
+    handlers: {
+      'app.commandPalette': () => { setPaletteOpen((v) => !v); return true },
+      'app.settings': () => { setSettingsSection(undefined); setSettingsOpen(true); return true },
+      'app.shortcutsPanel': () => { setShortcutsOpen((v) => !v); return true },
+      'view.kanbanToggle': () => {
+        const id = useProjects.getState().activeProjectId
+        if (!id) return false
+        useViewMode.getState().toggle(id)
+        return true
+      },
+      'panel.explorer': () => { setExplorerOpen((v) => !v); return true },
+      'panel.sourceControl': () => { setScOpen((v) => !v); return true },
+      'panel.sessions': () => { toggleSessionsPin(); return true },
+      'canvas.undo': () => { undo(); return true },
+      'canvas.redo': () => { redo(); return true },
+      'canvas.fitAll': () => { fitAll(); return true },
+      'canvas.deleteSelection': deleteSelectionCommand,
+      'node.newTerminal': () => { addTerminal(); return true },
+      'node.newAgent': () => {
+        // launchableDefaultAgent, not the raw setting: a default naming a since-removed custom
+        // agent would otherwise type its bare `custom:<uuid>` id into the new node's shell.
+        addAgentNode(launchableDefaultAgent(useSettings.getState().settings))
+        return true
+      }
+      // node.close / node.toggleMarkdown: main-process intercepted on desktop; deliberately
+      // no renderer handler (the browser owns ⌘W in the Server Edition — see bridge/stubs.ts).
+      // terminal.* / scm.commit / speech.dictation: owned by their local listeners.
+    },
+    gestures: {
+      // A KEYED dictation shortcut (e.g. "Cmd+Alt+D") toggles dictation. A modifier-only
+      // shortcut (the new default, "Cmd+Alt") is hold-to-talk instead — matchesShortcut always
+      // returns false for that shape (its `key` is null), so this gesture is naturally a no-op
+      // for it; see the dedicated hold-mode effect above, which is what fires in that case.
+      // The dispatcher only offers it in plain app focus (not typing / terminal / kanban).
+      keyedDictation: (e) => {
+        if (!matchesShortcut(e, useSettings.getState().settings.speech.shortcut, isMac)) return false
+        e.preventDefault()
+        toggleDictation()
+        return true
+      },
+      zoom: zoomGesture,
+      projectJump: projectJumpGesture,
+      copy: copyGesture
+    }
+  }
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
-        e.preventDefault()
-        setPaletteOpen((v) => !v)
-      } else if ((e.metaKey || e.ctrlKey) && e.key === ',') {
-        e.preventDefault()
-        setSettingsSection(undefined)
-        setSettingsOpen(true)
-      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'e') {
-        e.preventDefault()
-        setExplorerOpen((v) => !v)
-      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'g') {
-        e.preventDefault()
-        setScOpen((v) => !v)
-      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'b') {
-        e.preventDefault()
-        const id = useProjects.getState().activeProjectId
-        if (id) useViewMode.getState().toggle(id)
-      } else if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
-        e.preventDefault()
-        toggleSessionsPin()
-      } else if ((e.metaKey || e.ctrlKey) && e.key === '/') {
-        e.preventDefault()
-        setShortcutsOpen((v) => !v)
-      } else if (zoomShortcutChord(e) !== null) {
-        // ⌘/Ctrl+0 = back to 100%, Shift+1 = fit everything. `liveZoomShortcutAction` is the
-        // whole decision (see `lib/zoomShortcut.ts`), and the ⌘0 desktop route below asks the same
-        // one, so the two paths can never disagree about when the chord is allowed to move the
-        // camera. A null answer means "leave the key alone" — no `preventDefault`, which is what
-        // keeps Shift+1 typing a `!` wherever the user is actually typing.
-        const action = liveZoomShortcutAction(e)
-        if (action) {
-          e.preventDefault()
-          if (action === 'zoom-100') zoomTo100()
-          else fitAll()
-        }
-      } else if (projectJumpDigit(e) !== null) {
-        // Cmd/Ctrl+1-9 jumps to the Nth project — but only when the app actually owns the key
-        // (desktop shell, and the digit addresses an open project). `liveProjectJumpTarget`
-        // is the same decision the terminals' swallow asks, so the two can't disagree; a null
-        // target leaves the key to whatever has focus. `switchProject` no-ops on the active id.
-        const targetId = liveProjectJumpTarget(e)
-        if (targetId) {
-          e.preventDefault()
-          switchProject(targetId)
-        }
-      } else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'c') {
-        // Native text selection wins (markdown, editor and terminal keep their normal copy path).
-        const tag = (document.activeElement?.tagName || '').toLowerCase()
-        if (
-          tag === 'input' ||
-          tag === 'textarea' ||
-          document.activeElement?.getAttribute('contenteditable') === 'true' ||
-          document.activeElement?.closest('.monaco-editor, .xterm')
-        )
-          return
-        const sel = window.getSelection?.()?.toString()
-        if (sel) {
-          window.nodeTerminal.clipboard.writeText(sel)
-          return
-        }
-        // Nothing selected as text: copy the selected file-backed nodes as FILE REFERENCES, so
-        // Finder (or any file-aware app) pastes the actual files.
-        //
-        // Gated to where it can actually succeed, because the failure path raises a banner that
-        // stays until dismissed — and before this feature the keystroke was a silent no-op, which
-        // is what every other machine must keep getting. `writeFilesToClipboard` is darwin-gated
-        // in main and the browser bridge stub answers false, so on a non-mac renderer (desktop OR
-        // Server Edition) this branch could only ever produce that banner, wearing macOS-specific
-        // copy on a Linux box. The board is an opaque overlay over the canvas, so a copy there
-        // would act on a selection the user cannot see (the canvas-only-shortcut discipline).
-        const projects = useProjects.getState()
-        if (!isMac || isKanbanOpen(projects.activeProjectId)) return
-        const paths = selectedLocalFilePaths(nodesRef.current, {
-          projectIsRelay: !!projects.getProject(projects.activeProjectId ?? '')?.remote
-        })
-        if (!paths.length) return
-        e.preventDefault()
-        void window.nodeTerminal.clipboard
-          .writeFiles(paths)
-          .then((copied) => {
-            setCopyError(
-              copied
-                ? null
-                : 'Copy failed — only existing local files can be copied from the macOS desktop app.'
-            )
-          })
-          .catch(() => setCopyError('Copy failed — the system clipboard is unavailable.'))
-      }
+      const deps = globalKeyDeps.current
+      if (deps) dispatchGlobalKeydown(e, deps)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [toggleSessionsPin, switchProject, fitAll, zoomTo100])
+  }, [])
 
   // ⌘/Ctrl+0 on the DESKTOP never reaches the keydown handler above: Electron's default View menu
   // binds the accelerator to `resetZoom`, and a menu accelerator is handled before the page sees

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -179,7 +179,7 @@ import {
   type GlobalKeydownDeps
 } from '../lib/globalKeybindings'
 import type { ContextElement } from '../lib/keyContext'
-import { activeKeybindingOverrides } from '../lib/keybindingOverrides'
+import { activeKeybindingOverrides, chipFor, commandTooltip } from '../lib/keybindingOverrides'
 import { UsageIndicator } from '../components/UsageIndicator'
 import { SystemResourcePill } from '../components/SystemResourcePill'
 import { PresenceLayer } from '../components/PresenceLayer'
@@ -262,7 +262,6 @@ import {
 } from '@shared/worktree'
 import { normWorktreePath, type BoundGroup } from '@shared/worktree-reconcile'
 import { boundGroups, scmScopes, defaultScmScope, selectedScmGroupId } from '@shared/scm-scope'
-import { hintLabel } from '@shared/platform-utils'
 import {
   canvasImageFiles,
   canvasImageSink,
@@ -9164,6 +9163,11 @@ export function Canvas() {
     [paletteOpen, buildCommands, nodes]
   )
 
+  // The palette's chord appears as a bare chip in two places (the cluster's search button and the
+  // empty-canvas hint). Empty means the user unbound it: the chip is dropped rather than rendered
+  // as an empty <kbd>, and the hint's sentence loses that clause with it.
+  const paletteChip = chipFor('app.commandPalette')
+
   return (
     <div className="canvas-root">
       <TabBar
@@ -9357,7 +9361,7 @@ export function Canvas() {
         onMouseEnter={openSessionsPeek}
         onMouseLeave={closeSessionsPeekSoon}
       >
-        <button title={hintLabel('Sessions (⌘⇧L)')} onClick={onSessionsIconClick}>
+        <button title={commandTooltip('Sessions', 'panel.sessions')} onClick={onSessionsIconClick}>
           <IconSessions />
         </button>
       </div>
@@ -9375,12 +9379,12 @@ export function Canvas() {
           onClick={() => setPaletteOpen(true)}
         >
           <span className="cluster-search__icon">⌕</span>
-          <span className="kbd">{hintLabel('⌘K')}</span>
+          {paletteChip && <span className="kbd">{paletteChip}</span>}
         </button>
-        <button title={hintLabel('Explorer (⌘⇧E)')} onClick={() => setExplorerOpen(true)}>
+        <button title={commandTooltip('Explorer', 'panel.explorer')} onClick={() => setExplorerOpen(true)}>
           <IconExplorer />
         </button>
-        <button title={hintLabel('Source Control (⌘⇧G)')} onClick={() => setScOpen(true)}>
+        <button title={commandTooltip('Source Control', 'panel.sourceControl')} onClick={() => setScOpen(true)}>
           <IconBranch />
         </button>
         <button
@@ -9393,7 +9397,7 @@ export function Canvas() {
           <IconPhone />
         </button>
         <button
-          title={hintLabel('Settings (⌘,)')}
+          title={commandTooltip('Settings', 'app.settings')}
           onClick={() => {
             setSettingsSection(undefined)
             setSettingsOpen(true)
@@ -9410,7 +9414,7 @@ export function Canvas() {
               x: Math.max(8, r.right - 220),
               y: r.bottom + 6,
               items: [
-                { label: 'Keyboard shortcuts', hint: hintLabel('⌘/'), onClick: () => setShortcutsOpen(true) },
+                { label: 'Keyboard shortcuts', hint: chipFor('app.shortcutsPanel') || undefined, onClick: () => setShortcutsOpen(true) },
                 { label: 'Report a bug…', onClick: () => setBugReportOpen(true) },
                 {
                   label: 'Documentation',
@@ -9442,7 +9446,7 @@ export function Canvas() {
           <div className="empty-canvas-hint" aria-hidden>
             <div>Right-click to add a terminal or agent</div>
             <div>
-              <span className="kbd">{hintLabel('⌘K')}</span> command palette · <span className="kbd">+</span> in the dock below
+              {paletteChip && <><span className="kbd">{paletteChip}</span> command palette · </>}<span className="kbd">+</span> in the dock below
             </div>
           </div>
         )}

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -96,6 +96,20 @@ describe('the zoom chords go through their guarded decision, on both routes', ()
   })
 })
 
+describe('the trailing gestures are handed to the dispatcher', () => {
+  // The checks above read the gesture BODIES, which is one hop short: `zoomGesture` can be
+  // perfectly wired internally and simply never reach `dispatchGlobalKeydown`. Deleting
+  // `zoom: zoomGesture,` from the gestures object keeps every assertion in this file — and in
+  // globalKeybindings.test.ts, which supplies its own fakes — green while Shift+1 and the
+  // keydown ⌘0 route quietly stop moving the camera. Same shape for the other two: the project
+  // jump and the file-reference copy have no other call site either.
+  it('wires zoom, projectJump and copy into the dispatcher deps', () => {
+    expect(CANVAS_SRC).toContain('zoom: zoomGesture')
+    expect(CANVAS_SRC).toContain('projectJump: projectJumpGesture')
+    expect(CANVAS_SRC).toContain('copy: copyGesture')
+  })
+})
+
 describe('the end-session confirm describes both things it does', () => {
   // `closeSession` stops the tmux session AND deletes the canvas node. The wording is inherited
   // from the sessions sidebar, where deleting the node is the obvious intent — but the

--- a/src/renderer/components/Dock.tsx
+++ b/src/renderer/components/Dock.tsx
@@ -3,7 +3,7 @@ import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type AgentId, type BuiltinAgentId } fr
 import type { CustomAgent } from '@shared/types'
 import { formatShortcut, isHoldChord } from '@shared/shortcut'
 import { hasSpeechModel } from '@shared/speech'
-import { hintLabel } from '@shared/platform-utils'
+import { commandTooltip } from '../lib/keybindingOverrides'
 import { AgentIcon } from '../lib/agentIcons'
 import { useSettings } from '../state/settings'
 import { useProjects } from '../state/projects'
@@ -281,10 +281,10 @@ export function Dock({
 
         <span className="dock-sep" />
 
-        <button className="dock-btn" title={hintLabel('Undo (⌘Z)')} disabled={!canUndo} onClick={onUndo}>
+        <button className="dock-btn" title={commandTooltip('Undo', 'canvas.undo')} disabled={!canUndo} onClick={onUndo}>
           <UndoIcon />
         </button>
-        <button className="dock-btn" title={hintLabel('Redo (⌘⇧Z)')} disabled={!canRedo} onClick={onRedo}>
+        <button className="dock-btn" title={commandTooltip('Redo', 'canvas.redo')} disabled={!canRedo} onClick={onRedo}>
           <RedoIcon />
         </button>
 

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -21,11 +21,11 @@ interface Row {
 /** Registry rows derive their keys from the effective binding, so a remap in settings.json
  *  shows up here without touching this file — and a command the user unbound (or that ships
  *  unassigned) drops off the panel instead of advertising a chord that no longer fires.
- *  That promise only holds while every row's KEYBOARD path also reads the registry, which is
- *  what makes the panel and the key agree. One row does not yet: `terminal.find` still matches
- *  a hardcoded Cmd/Ctrl+F in TerminalNode — it becomes registry-backed in the next change.
- *  Gesture/mouse rows stay literal: they are not commands and the registry knows nothing
- *  about them. "Dictate" also stays literal — its chord still lives in
+ *  That promise holds because every row's KEYBOARD path also reads the registry, which is
+ *  what makes the panel and the key agree — `terminal.find` included, whose match in
+ *  TerminalNode now reads `effectiveBindings('terminal.find')` instead of a hardcoded
+ *  Cmd/Ctrl+F. Gesture/mouse rows stay literal: they are not commands and the registry knows
+ *  nothing about them. "Dictate" also stays literal — its chord still lives in
  *  `settings.speech.shortcut` (the registry's `speech.dictation` row is display-only for now),
  *  and a modifier-only chord is hold-to-talk, which the label spells out. */
 function buildSections(dictationKeys: string[], dictationLabel: string): { title: string; rows: Row[] }[] {

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -21,6 +21,9 @@ interface Row {
 /** Registry rows derive their keys from the effective binding, so a remap in settings.json
  *  shows up here without touching this file — and a command the user unbound (or that ships
  *  unassigned) drops off the panel instead of advertising a chord that no longer fires.
+ *  That promise only holds while every row's KEYBOARD path also reads the registry, which is
+ *  what makes the panel and the key agree. One row does not yet: `terminal.find` still matches
+ *  a hardcoded Cmd/Ctrl+F in TerminalNode — it becomes registry-backed in the next change.
  *  Gesture/mouse rows stay literal: they are not commands and the registry knows nothing
  *  about them. "Dictate" also stays literal — its chord still lives in
  *  `settings.speech.shortcut` (the registry's `speech.dictation` row is display-only for now),

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { isHoldChord, shortcutKeyParts } from '@shared/shortcut'
+import type { CommandId } from '@shared/keybindings'
 import { isBrowserRuntime } from '../bridge/runtime'
+import { commandKeys } from '../lib/keybindingOverrides'
 import { useSettings } from '../state/settings'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
@@ -16,31 +18,44 @@ interface Row {
   label: string
 }
 
-/** Everything but "Dictate" is fixed; that row's keys/label depend on `settings.speech.shortcut`
- *  (a modifier-only chord is hold-to-talk — no trailing key badge, so the label spells that out),
- *  so the sections are built at render time instead of module scope. */
+/** Registry rows derive their keys from the effective binding, so a remap in settings.json
+ *  shows up here without touching this file — and a command the user unbound (or that ships
+ *  unassigned) drops off the panel instead of advertising a chord that no longer fires.
+ *  Gesture/mouse rows stay literal: they are not commands and the registry knows nothing
+ *  about them. "Dictate" also stays literal — its chord still lives in
+ *  `settings.speech.shortcut` (the registry's `speech.dictation` row is display-only for now),
+ *  and a modifier-only chord is hold-to-talk, which the label spells out. */
 function buildSections(dictationKeys: string[], dictationLabel: string): { title: string; rows: Row[] }[] {
+  const cmd = (id: CommandId, label: string): Row[] => {
+    const keys = commandKeys(id)
+    return keys.length ? [{ keys, label }] : []
+  }
   return [
     {
       title: 'General',
       rows: [
-        { keys: ['⌘', 'K'], label: 'Command palette' },
-        { keys: ['⌘', ','], label: 'Settings' },
-        { keys: ['⌘', '/'], label: 'This shortcuts panel' },
+        ...cmd('app.commandPalette', 'Command palette'),
+        ...cmd('app.settings', 'Settings'),
+        ...cmd('app.shortcutsPanel', 'This shortcuts panel'),
+        ...cmd('panel.explorer', 'Explorer'),
+        ...cmd('panel.sourceControl', 'Source Control'),
+        ...cmd('view.kanbanToggle', 'Kanban board'),
+        ...cmd('panel.sessions', 'Pin the sessions sidebar'),
         // Desktop only: browsers own Cmd/Ctrl+1-9 for tab switching and a page cannot take it
         // back, so listing it in the Server Edition would promise a shortcut that never fires.
         ...(isBrowserRuntime() ? [] : [{ keys: ['⌘', '1-9'], label: 'Jump to project' }]),
         { keys: dictationKeys, label: dictationLabel },
-        { keys: ['⌘', 'Z'], label: 'Undo' },
-        { keys: ['⌘', '⇧', 'Z'], label: 'Redo' }
+        ...cmd('canvas.undo', 'Undo'),
+        ...cmd('canvas.redo', 'Redo')
       ]
     },
     {
       title: 'Canvas',
       rows: [
-        { keys: ['⌘', 'T'], label: 'New terminal' },
-        { keys: ['⌘', '⇧', 'C'], label: 'New Claude Code' },
-        { keys: ['⌘', 'W'], label: 'Close selected node' },
+        ...cmd('node.newTerminal', 'New terminal'),
+        ...cmd('node.newAgent', 'New Claude Code'),
+        ...cmd('node.close', 'Close selected node'),
+        ...cmd('canvas.deleteSelection', 'Delete selection'),
         { keys: ['Right-click'], label: 'Actions menu (empty space or node)' },
         { keys: ['Left-drag'], label: 'Box-select (touch to select)' },
         { keys: ['Middle / Right-drag'], label: 'Pan the canvas' },
@@ -60,7 +75,8 @@ function buildSections(dictationKeys: string[], dictationLabel: string): { title
       rows: [
         { keys: ['Hover ~0.6s'], label: 'Enter the terminal (type/select)' },
         { keys: ['Quick drag'], label: 'Move the terminal (before it focuses)' },
-        { keys: ['⌘', 'M'], label: 'Toggle markdown view' },
+        ...cmd('node.toggleMarkdown', 'Toggle markdown view'),
+        ...cmd('terminal.find', 'Find in terminal'),
         { keys: ['⌘', 'C'], label: 'Copy selection (markdown view)' },
         { keys: ['✦'], label: 'Name the terminal with AI' }
       ]
@@ -68,8 +84,8 @@ function buildSections(dictationKeys: string[], dictationLabel: string): { title
     {
       title: 'Source Control',
       rows: [
-        { keys: ['⌘', '⇧', 'G'], label: 'Open Source Control' },
-        { keys: ['⌘', '↵'], label: 'Commit the staged changes' }
+        ...cmd('panel.sourceControl', 'Open Source Control'),
+        ...cmd('scm.commit', 'Commit the staged changes')
       ]
     }
   ]

--- a/src/renderer/components/SourceControlPanel.tsx
+++ b/src/renderer/components/SourceControlPanel.tsx
@@ -16,7 +16,9 @@ import { buildCommitMenuItems } from './git-history/git-history-menu'
 import { ContextMenu, type MenuItem } from './ContextMenu'
 import { PublishDialog } from './PublishDialog'
 import { defaultScmScope, type ScmScope } from '@shared/scm-scope'
-import { chipFor } from '../lib/keybindingOverrides'
+import { chipFor, effectiveBindings } from '../lib/keybindingOverrides'
+import { matchesShortcut } from '@shared/shortcut'
+import { isMacPlatform } from '@shared/platform-utils'
 
 export interface SourceControlPanelProps {
   onClose: () => void
@@ -36,6 +38,9 @@ export interface SourceControlPanelProps {
 }
 
 const AUTO_FETCH_MS = 180_000
+
+/** Which physical modifier the registry's abstract `Cmd` resolves to for the commit chord. */
+const isMac = isMacPlatform()
 
 const STATUS_COLOR: Record<string, string> = {
   M: '#ffd60a',
@@ -404,8 +409,9 @@ export function SourceControlPanel({
     )
   }
 
-  // Whatever Commit is bound to; '' when unbound, in which case the box is just "Message" —
-  // the button below it still commits.
+  // Whatever Commit is bound to; '' when unbound — in which case the box is just "Message" AND
+  // the keyboard path below is disabled with it (no binding to match), so the placeholder never
+  // promises a chord the textarea would ignore. The Commit button is the fallback either way.
   const commitChip = chipFor('scm.commit')
 
   return createPortal(
@@ -511,7 +517,13 @@ export function SourceControlPanel({
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}
                     onKeyDown={(e) => {
-                      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') commitAndPush()
+                      // Registry-driven (L2: a local listener reads its binding from the registry),
+                      // so a remapped scm.commit changes the KEY as well as the placeholder above.
+                      // Matching is exact on all four modifiers, unlike the old
+                      // `metaKey || ctrlKey` — see the named losses in the keybindings notes.
+                      if (effectiveBindings('scm.commit').some((s) => matchesShortcut(e, s, isMac))) {
+                        commitAndPush()
+                      }
                     }}
                   />
                   <button

--- a/src/renderer/components/SourceControlPanel.tsx
+++ b/src/renderer/components/SourceControlPanel.tsx
@@ -16,7 +16,7 @@ import { buildCommitMenuItems } from './git-history/git-history-menu'
 import { ContextMenu, type MenuItem } from './ContextMenu'
 import { PublishDialog } from './PublishDialog'
 import { defaultScmScope, type ScmScope } from '@shared/scm-scope'
-import { hintLabel } from '@shared/platform-utils'
+import { chipFor } from '../lib/keybindingOverrides'
 
 export interface SourceControlPanelProps {
   onClose: () => void
@@ -404,6 +404,10 @@ export function SourceControlPanel({
     )
   }
 
+  // Whatever Commit is bound to; '' when unbound, in which case the box is just "Message" —
+  // the button below it still commits.
+  const commitChip = chipFor('scm.commit')
+
   return createPortal(
     <div className="drawer-overlay" onClick={onClose}>
       <aside className="drawer scm" onClick={(e) => e.stopPropagation()}>
@@ -503,7 +507,7 @@ export function SourceControlPanel({
                 <div className="scm-compose">
                   <textarea
                     className="scm-message"
-                    placeholder={hintLabel('Message (⌘↵ to commit)')}
+                    placeholder={commitChip ? `Message (${commitChip} to commit)` : 'Message'}
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}
                     onKeyDown={(e) => {

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -31,7 +31,7 @@ import {
   unsupportedModesNote
 } from '@shared/agents/approval-mode'
 import { AgentIcon } from '../../../lib/agentIcons'
-import { hintLabel } from '@shared/platform-utils'
+import { chipFor } from '../../../lib/keybindingOverrides'
 import { NODE_IDENTITY_STRICT_DATE } from '@shared/node-identity'
 import { SegmentedPill } from '@renderer/ui/SegmentedPill'
 import { Button } from '@renderer/ui/Button'
@@ -274,11 +274,16 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
           .join(' ')
       : undefined
 
+  // Whatever "new agent node" is bound to; '' when unbound, and the sentence drops the chord.
+  const agentChip = chipFor('node.newAgent')
+
   return (
     <SettingsSection
       id="agents"
       title="Agents"
-      description={hintLabel('Enable or disable agents in the Add menus, and pick the default (⌘⇧C).')}
+      description={agentChip
+        ? `Enable or disable agents in the Add menus, and pick the default (${agentChip}).`
+        : 'Enable or disable agents in the Add menus, and pick the default.'}
       isActive={isActive}
       searchEntries={ENTRIES}
     >

--- a/src/renderer/lib/globalKeybindings.test.ts
+++ b/src/renderer/lib/globalKeybindings.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest'
+import { dispatchGlobalKeydown, type GlobalKeydownDeps, type GlobalKeyEvent } from './globalKeybindings'
+import { XTERM_INPUT_CLASS } from './keyContext'
+
+const ev = (over: Partial<GlobalKeyEvent>): GlobalKeyEvent => ({
+  metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, key: '',
+  defaultPrevented: false,
+  preventDefault() { this.defaultPrevented = true },
+  ...over
+})
+const noGesture = () => false
+const deps = (over: Partial<GlobalKeydownDeps> = {}): GlobalKeydownDeps => ({
+  activeElement: () => null,
+  kanbanOpen: () => false,
+  overrides: () => ({}),
+  isMac: true,
+  handlers: {},
+  gestures: { keyedDictation: noGesture, zoom: noGesture, projectJump: noGesture, copy: noGesture },
+  ...over
+})
+
+describe('dispatchGlobalKeydown', () => {
+  it('bails on defaultPrevented without touching anything', () => {
+    const dictation = vi.fn()
+    const d = deps({ gestures: { keyedDictation: dictation, zoom: noGesture, projectJump: noGesture, copy: noGesture } })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 'k', defaultPrevented: true }), d)).toBe(false)
+    expect(dictation).not.toHaveBeenCalled()
+  })
+  it('runs a claimed registry handler and preventDefaults', () => {
+    const e = ev({ metaKey: true, key: 'k' })
+    const palette = vi.fn(() => true)
+    expect(dispatchGlobalKeydown(e, deps({ handlers: { 'app.commandPalette': palette } }))).toBe(true)
+    expect(e.defaultPrevented).toBe(true)
+  })
+  it('a declining handler leaves the key alone (falls through to the platform)', () => {
+    const e = ev({ metaKey: true, key: 'k' })
+    expect(dispatchGlobalKeydown(e, deps({ handlers: { 'app.commandPalette': () => false } }))).toBe(false)
+    expect(e.defaultPrevented).toBe(false)
+  })
+  it('a resolved command with no registered handler is not claimed', () => {
+    const e = ev({ metaKey: true, key: 'w' })  // node.close: main-intercepted on desktop, browser-owned in SE
+    expect(dispatchGlobalKeydown(e, deps())).toBe(false)
+    expect(e.defaultPrevented).toBe(false)
+  })
+  it('keyed dictation wins over a colliding registry default, but not while typing or in terminal', () => {
+    const dictation = vi.fn((e: GlobalKeyEvent) => { e.preventDefault(); return true })
+    const term = vi.fn(() => true)
+    const g = { keyedDictation: dictation, zoom: noGesture, projectJump: noGesture, copy: noGesture }
+    const d = deps({ gestures: g, handlers: { 'node.newTerminal': term } })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 't' }), d)).toBe(true)
+    expect(term).not.toHaveBeenCalled()
+    const typing = deps({ gestures: g, activeElement: () => ({ tagName: 'INPUT' }) })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 't' }), typing)).toBe(false)
+    const terminal = deps({
+      gestures: g,
+      activeElement: () => ({ tagName: 'TEXTAREA', classList: { contains: (n: string) => n === XTERM_INPUT_CLASS } })
+    })
+    dispatchGlobalKeydown(ev({ metaKey: true, key: 't' }), terminal)
+    expect(dictation).toHaveBeenCalledTimes(1)
+  })
+  it('typing blocks canvas AND app commands (the announced D-typing guard fix)', () => {
+    const palette = vi.fn(() => true)
+    const undo = vi.fn(() => true)
+    const typing = deps({
+      activeElement: () => ({ tagName: 'DIV', isContentEditable: true }),
+      handlers: { 'app.commandPalette': palette, 'canvas.undo': undo }
+    })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 'z' }), typing)).toBe(false)
+    expect(undo).not.toHaveBeenCalled()
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 'k' }), typing)).toBe(false)
+    expect(palette).not.toHaveBeenCalled()
+    // NOTE: app-scope commands lack allowWhileTyping in the registry, so typing blocks them
+    // too — that IS the announced D-typing delta (today Cmd+K fires while renaming a node).
+  })
+  it('kanban keeps app commands live and canvas commands inert', () => {
+    const toggle = vi.fn(() => true)
+    const undo = vi.fn(() => true)
+    const d = deps({ kanbanOpen: () => true, handlers: { 'view.kanbanToggle': toggle, 'canvas.undo': undo } })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, shiftKey: true, key: 'b' }), d)).toBe(true)
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 'z' }), d)).toBe(false)
+    expect(undo).not.toHaveBeenCalled()
+  })
+  // The claim protocol's second half: a RESOLVED chord is spent, whoever declined it. The two
+  // tests above only prove it is not claimed — with claiming gestures wired in, a fall-through
+  // into them would reinterpret the same chord as a zoom/jump/copy.
+  it('a resolved command never reaches a gesture, declined or unhandled', () => {
+    const claimAll = vi.fn(() => true)
+    const g = { keyedDictation: noGesture, zoom: claimAll, projectJump: claimAll, copy: claimAll }
+    const declined = ev({ metaKey: true, key: 'k' })
+    expect(dispatchGlobalKeydown(declined, deps({ gestures: g, handlers: { 'app.commandPalette': () => false } }))).toBe(false)
+    const unhandled = ev({ metaKey: true, key: 'w' })
+    expect(dispatchGlobalKeydown(unhandled, deps({ gestures: g }))).toBe(false)
+    expect(claimAll).not.toHaveBeenCalled()
+  })
+  it('gestures run after a registry miss, in zoom → projectJump → copy order', () => {
+    const order: string[] = []
+    const g = {
+      keyedDictation: noGesture,
+      zoom: () => { order.push('zoom'); return false },
+      projectJump: () => { order.push('jump'); return false },
+      copy: () => { order.push('copy'); return false }
+    }
+    expect(dispatchGlobalKeydown(ev({ key: '!' , shiftKey: true }), deps({ gestures: g }))).toBe(false)
+    expect(order).toEqual(['zoom', 'jump', 'copy'])
+  })
+  it('overrides reroute dispatch', () => {
+    const fit = vi.fn(() => true)
+    const d = deps({
+      overrides: () => ({ 'app.commandPalette': [], 'canvas.fitAll': ['Cmd+K'] }),
+      handlers: { 'canvas.fitAll': fit }
+    })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 'k' }), d)).toBe(true)
+    expect(fit).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/globalKeybindings.test.ts
+++ b/src/renderer/lib/globalKeybindings.test.ts
@@ -103,6 +103,28 @@ describe('dispatchGlobalKeydown', () => {
     expect(dispatchGlobalKeydown(ev({ key: '!' , shiftKey: true }), deps({ gestures: g }))).toBe(false)
     expect(order).toEqual(['zoom', 'jump', 'copy'])
   })
+  it('the kanban board blocks the keyed-dictation gesture entirely', () => {
+    // The gate is `!typing && !terminal && !kanbanOpen`. Dropping the kanban half leaves a
+    // dictation overlay firing over the board with nothing on screen that asked for it — and
+    // the board is exactly where the canvas-only-shortcut discipline says gestures go quiet.
+    const dictation = vi.fn(() => true)
+    const g = { keyedDictation: dictation, zoom: noGesture, projectJump: noGesture, copy: noGesture }
+    const d = deps({ kanbanOpen: () => true, gestures: g })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, altKey: true, key: 'd' }), d)).toBe(false)
+    expect(dictation).not.toHaveBeenCalled()
+  })
+  it('a claiming trailing gesture short-circuits: the later ones never run', () => {
+    // The `if (...) return true` chain, not a run-them-all fan-out. Turning any of the three
+    // into an unconditional call would let one chord be interpreted twice (zoom AND jump).
+    const zoom = vi.fn(() => true)
+    const projectJump = vi.fn(() => true)
+    const copy = vi.fn(() => true)
+    const g = { keyedDictation: noGesture, zoom, projectJump, copy }
+    expect(dispatchGlobalKeydown(ev({ shiftKey: true, key: '!' }), deps({ gestures: g }))).toBe(true)
+    expect(zoom).toHaveBeenCalledTimes(1)
+    expect(projectJump).not.toHaveBeenCalled()
+    expect(copy).not.toHaveBeenCalled()
+  })
   it('overrides reroute dispatch', () => {
     const fit = vi.fn(() => true)
     const d = deps({

--- a/src/renderer/lib/globalKeybindings.ts
+++ b/src/renderer/lib/globalKeybindings.ts
@@ -10,13 +10,22 @@
  * 1. **Gesture order.** Keyed dictation runs BEFORE the registry (a custom keyed chord may
  *    deliberately collide with a registry default and must keep winning — it predates the
  *    registry), and zoom → projectJump → copy run AFTER a registry miss, in that exact order.
- *    This mirrors today's if-chain in Canvas, so consolidating the listeners changes no outcome.
+ *    This mirrors today's if-chain ORDERING in Canvas, so consolidation changes no ordering
+ *    outcome; the typing-guard delta is separate and deliberate (see the registry's
+ *    `allowWhileTyping` flags — app-scope rows lack it, so typing now blocks them too).
  *
  * 2. **Claim protocol.** `preventDefault()` is called ONLY when a handler actually claims the key
  *    (returns true). A command that resolved but whose handler declined — or that has no handler
  *    registered at all — falls through to the PLATFORM (the focused surface, the terminal, the
  *    browser/main-process accelerator), and NEVER to a gesture that could reinterpret the same
  *    chord as something else.
+ *
+ *    The third fall-through path is the one to watch: a chord BLOCKED by the resolver's context
+ *    gates (typing, terminal, kanban) returns null exactly like an unbound chord, so the two are
+ *    indistinguishable here and BOTH reach the trailing gestures — Cmd+Z while typing misses the
+ *    registry and is offered to zoom → projectJump → copy. Those gestures receive the RAW event
+ *    with no context, so **each trailing gesture closure owes its own focus/typing guard**; keyed
+ *    dictation is the only gesture this module guards.
  */
 import { resolveCommandForKeyEvent, type CommandId, type KeybindingOverrides } from '@shared/keybindings'
 import { keyDispatchContextFor, type ContextElement } from './keyContext'

--- a/src/renderer/lib/globalKeybindings.ts
+++ b/src/renderer/lib/globalKeybindings.ts
@@ -1,0 +1,78 @@
+/**
+ * The single window-keydown dispatcher for registry commands plus the registry-less gestures
+ * Canvas carries (keyed dictation, Cmd+0 / Shift+1 zoom, Cmd+1-9 project jump, Cmd+C copy). One
+ * pass, documented order; an unclaimed chord falls through to the focused surface / PTY — never to
+ * another command. Pure so node-env tests can drive it without a DOM; Canvas supplies the live
+ * accessors and handler closures.
+ *
+ * Two contracts this module exists to state, both load-bearing:
+ *
+ * 1. **Gesture order.** Keyed dictation runs BEFORE the registry (a custom keyed chord may
+ *    deliberately collide with a registry default and must keep winning — it predates the
+ *    registry), and zoom → projectJump → copy run AFTER a registry miss, in that exact order.
+ *    This mirrors today's if-chain in Canvas, so consolidating the listeners changes no outcome.
+ *
+ * 2. **Claim protocol.** `preventDefault()` is called ONLY when a handler actually claims the key
+ *    (returns true). A command that resolved but whose handler declined — or that has no handler
+ *    registered at all — falls through to the PLATFORM (the focused surface, the terminal, the
+ *    browser/main-process accelerator), and NEVER to a gesture that could reinterpret the same
+ *    chord as something else.
+ */
+import { resolveCommandForKeyEvent, type CommandId, type KeybindingOverrides } from '@shared/keybindings'
+import { keyDispatchContextFor, type ContextElement } from './keyContext'
+
+/** Structural key event so node-env tests need no DOM (a real KeyboardEvent satisfies it). */
+export interface GlobalKeyEvent {
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+  key: string
+  defaultPrevented: boolean
+  preventDefault(): void
+}
+
+/** A handler returns true when it CLAIMED the key; false leaves the chord to the platform. */
+export type CommandHandlers = Partial<Record<CommandId, () => boolean>>
+
+export interface GlobalKeydownDeps {
+  activeElement: () => ContextElement | null
+  kanbanOpen: () => boolean
+  overrides: () => KeybindingOverrides
+  isMac: boolean
+  handlers: CommandHandlers
+  /** Registry-less chords, tried in this exact order (matches today's if-chain order):
+   *  keyed dictation BEFORE the registry (a custom keyed chord may collide with a default
+   *  and must keep winning), zoom/projectJump/copy AFTER a registry miss. Each returns true
+   *  when it claimed the key (and did its own preventDefault where it needs one). */
+  gestures: {
+    keyedDictation: (e: GlobalKeyEvent) => boolean
+    zoom: (e: GlobalKeyEvent) => boolean
+    projectJump: (e: GlobalKeyEvent) => boolean
+    copy: (e: GlobalKeyEvent) => boolean
+  }
+}
+
+export function dispatchGlobalKeydown(e: GlobalKeyEvent, deps: GlobalKeydownDeps): boolean {
+  // A child handler (find bar, dialogs, terminal) that already claimed the key wins outright.
+  if (e.defaultPrevented) return false
+  const ctx = keyDispatchContextFor(deps.activeElement(), deps.kanbanOpen())
+  // Keyed dictation predates the registry and may deliberately collide with a default; it
+  // keeps first claim, but only in plain app focus (its old guard blocked inputs AND xterm).
+  if (!ctx.typing && !ctx.terminal && !ctx.kanbanOpen && deps.gestures.keyedDictation(e)) return true
+  const id = resolveCommandForKeyEvent(e, ctx, deps.overrides(), deps.isMac)
+  if (id) {
+    const handler = deps.handlers[id]
+    if (handler && handler()) {
+      e.preventDefault()
+      return true
+    }
+    // Resolved but unhandled/declined: fall through to the platform, never to a gesture that
+    // could reinterpret the same chord.
+    return false
+  }
+  if (deps.gestures.zoom(e)) return true
+  if (deps.gestures.projectJump(e)) return true
+  if (deps.gestures.copy(e)) return true
+  return false
+}

--- a/src/renderer/lib/keyContext.test.ts
+++ b/src/renderer/lib/keyContext.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import {
+  XTERM_INPUT_CLASS,
+  isTerminalTarget,
+  isTypingTarget,
+  keyDispatchContextFor
+} from './keyContext'
+
+const el = (
+  tagName: string,
+  extra: Partial<{ isContentEditable: boolean; classes: string[] }> = {}
+) => ({
+  tagName,
+  isContentEditable: extra.isContentEditable,
+  classList: { contains: (n: string) => (extra.classes ?? []).includes(n) }
+})
+
+describe('isTerminalTarget', () => {
+  it('true only for the xterm helper textarea', () => {
+    expect(isTerminalTarget(el('TEXTAREA', { classes: [XTERM_INPUT_CLASS] }))).toBe(true)
+    expect(isTerminalTarget(el('TEXTAREA'))).toBe(false)
+    expect(isTerminalTarget(null)).toBe(false)
+  })
+})
+
+describe('isTypingTarget', () => {
+  it('inputs, textareas and contentEditable are typing', () => {
+    expect(isTypingTarget(el('INPUT'))).toBe(true)
+    expect(isTypingTarget(el('TEXTAREA'))).toBe(true)
+    expect(isTypingTarget(el('DIV', { isContentEditable: true }))).toBe(true)
+  })
+  it('the xterm helper textarea is NOT typing (it is the terminal)', () => {
+    expect(isTypingTarget(el('TEXTAREA', { classes: [XTERM_INPUT_CLASS] }))).toBe(false)
+  })
+  it('plain elements and null are not typing', () => {
+    expect(isTypingTarget(el('DIV'))).toBe(false)
+    expect(isTypingTarget(null)).toBe(false)
+  })
+})
+
+describe('keyDispatchContextFor', () => {
+  it('typing and terminal are disjoint by construction', () => {
+    expect(keyDispatchContextFor(el('TEXTAREA', { classes: [XTERM_INPUT_CLASS] }), false)).toEqual({
+      typing: false,
+      terminal: true,
+      kanbanOpen: false
+    })
+    expect(keyDispatchContextFor(el('INPUT'), true)).toEqual({
+      typing: true,
+      terminal: false,
+      kanbanOpen: true
+    })
+  })
+})
+
+describe('xterm version pin', () => {
+  it('the installed xterm dist still renders the helper-textarea class', () => {
+    // The entire terminal-vs-typing split keys off this class name. If an xterm upgrade
+    // renames it, this test fails instead of every terminal keystroke silently becoming 'app'.
+    const dist = readFileSync('node_modules/@xterm/xterm/lib/xterm.js', 'utf8')
+    expect(dist.includes(XTERM_INPUT_CLASS)).toBe(true)
+  })
+})

--- a/src/renderer/lib/keyContext.ts
+++ b/src/renderer/lib/keyContext.ts
@@ -2,6 +2,16 @@
  * One shared answer to "who owns this keystroke's focus" for the global-keybinding
  * dispatcher. Replaces the three inline `tagName` guards the Canvas keydown effects carried
  * (which disagreed about contentEditable and counted xterm's hidden textarea as typing).
+ *
+ * **This is not the codebase's only "in terminal" notion, and the difference is the point.**
+ * `presenceKeys.ts` (`closest(TYPING_ZONES)`, `.xterm` among them) and the copy gesture
+ * (inline `closest('.monaco-editor, .xterm')`) both ask an ANCESTRY question, because they are
+ * about a "/" keystroke or a mouse selection landing somewhere inside a terminal REGION, which
+ * the `.xterm` wrapper answers and this module's class check would not.
+ * DISPATCH asks a different question: who receives this keystroke. Whenever xterm owns the
+ * keyboard the focused element IS the helper textarea, so the class check here is exact — and it
+ * is what keeps `terminal` and `typing` disjoint (an ancestry check would report BOTH, and
+ * `typing` wins, making every terminal-scope command unreachable).
  */
 import type { KeyDispatchContext } from '@shared/keybindings'
 

--- a/src/renderer/lib/keyContext.ts
+++ b/src/renderer/lib/keyContext.ts
@@ -1,0 +1,37 @@
+/**
+ * One shared answer to "who owns this keystroke's focus" for the global-keybinding
+ * dispatcher. Replaces the three inline `tagName` guards the Canvas keydown effects carried
+ * (which disagreed about contentEditable and counted xterm's hidden textarea as typing).
+ */
+import type { KeyDispatchContext } from '@shared/keybindings'
+
+/** xterm.js takes keyboard input through a hidden <textarea> with this class. Pinned against
+ *  the installed dist by keyContext.test.ts — an upgrade that renames it must fail loudly. */
+export const XTERM_INPUT_CLASS = 'xterm-helper-textarea'
+
+/** Structural element shape so node-env tests need no DOM. */
+export interface ContextElement {
+  tagName: string
+  isContentEditable?: boolean
+  classList?: { contains(name: string): boolean }
+}
+
+export function isTerminalTarget(el: ContextElement | null): boolean {
+  return el?.classList?.contains(XTERM_INPUT_CLASS) === true
+}
+
+/** True when the keystroke belongs to text the user is editing. The xterm textarea is
+ *  deliberately excluded — a focused terminal is `terminal`, never `typing`, and the two
+ *  must stay disjoint (see KeyDispatchContext). */
+export function isTypingTarget(el: ContextElement | null): boolean {
+  if (!el || isTerminalTarget(el)) return false
+  if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') return true
+  return el.isContentEditable === true
+}
+
+export function keyDispatchContextFor(
+  el: ContextElement | null,
+  kanbanOpen: boolean
+): KeyDispatchContext {
+  return { typing: isTypingTarget(el), terminal: isTerminalTarget(el), kanbanOpen }
+}

--- a/src/renderer/lib/keybindingOverrides.test.ts
+++ b/src/renderer/lib/keybindingOverrides.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import { useSettings } from '../state/settings'
+import { activeKeybindingOverrides, effectiveBindings, commandKeys, commandTooltip } from './keybindingOverrides'
+
+const setKb = (kb: unknown) =>
+  useSettings.setState({ settings: { ...DEFAULT_SETTINGS, keybindings: kb as never } })
+
+beforeEach(() => setKb(undefined))
+
+describe('activeKeybindingOverrides', () => {
+  it('absent key means no overrides, silently', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(activeKeybindingOverrides()).toEqual({})
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+  it('sanitizes and memoizes by reference, warning once per change', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setKb({ 'node.newTerminal': ['Cmd+Shift+T'], 'bogus.command': ['Cmd+X'] })
+    const first = activeKeybindingOverrides()
+    expect(first).toEqual({ 'node.newTerminal': ['Cmd+Shift+T'] })
+    expect(activeKeybindingOverrides()).toBe(first)
+    expect(warn).toHaveBeenCalledTimes(1)
+    warn.mockRestore()
+  })
+})
+
+describe('effectiveBindings / commandKeys / commandTooltip', () => {
+  it('defaults flow through when no override exists', () => {
+    expect(effectiveBindings('app.commandPalette')).toEqual(['Cmd+K'])
+  })
+  it('an override replaces the default everywhere', () => {
+    setKb({ 'panel.sessions': ['Cmd+Alt+L'] })
+    expect(commandKeys('panel.sessions', true)).toEqual(['⌘', '⌥', 'L'])
+    expect(commandTooltip('Sessions', 'panel.sessions', true)).toBe('Sessions (⌘⌥L)')
+  })
+  it('matches the legacy hintLabel formatting on both platforms for the defaults', () => {
+    expect(commandTooltip('Sessions', 'panel.sessions', true)).toBe('Sessions (⌘⇧L)')
+    expect(commandTooltip('Sessions', 'panel.sessions', false)).toBe('Sessions (Ctrl+Shift+L)')
+  })
+  it('resolves the defaults with the SAME platform it formats with', () => {
+    // terminal.copySelection is the one command whose defaults differ per platform, so it is
+    // the only case that can catch a commandKeys that resolves with isMacPlatform() (true in
+    // node) while formatting for the caller's platform.
+    expect(commandKeys('terminal.copySelection', true)).toEqual(['⌘', 'C'])
+    expect(commandKeys('terminal.copySelection', false)).toEqual(['Ctrl', 'Shift', 'C'])
+  })
+  it('unbound commands render without a chord suffix', () => {
+    expect(commandTooltip('Fit all', 'canvas.fitAll', true)).toBe('Fit all')
+    expect(commandKeys('canvas.fitAll', true)).toEqual([])
+  })
+})

--- a/src/renderer/lib/keybindingOverrides.test.ts
+++ b/src/renderer/lib/keybindingOverrides.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { DEFAULT_SETTINGS } from '@shared/types'
+import { matchesShortcut, type ShortcutKeyEvent } from '@shared/shortcut'
 import { useSettings } from '../state/settings'
 import {
   activeKeybindingOverrides, effectiveBindings, commandKeys, commandTooltip, chipFor
@@ -51,6 +52,43 @@ describe('effectiveBindings / commandKeys / commandTooltip', () => {
   it('unbound commands render without a chord suffix', () => {
     expect(commandTooltip('Fit all', 'canvas.fitAll', true)).toBe('Fit all')
     expect(commandKeys('canvas.fitAll', true)).toEqual([])
+  })
+})
+
+// The exact composition SourceControlPanel's commit textarea now runs on keydown. It replaced a
+// lax `(e.metaKey || e.ctrlKey) && e.key === 'Enter'`, so the D-strict losses below are pinned
+// here rather than asserted in prose: matching is EXACT on all four modifiers.
+describe('the commit textarea matcher (scm.commit)', () => {
+  const key = (over: Partial<ShortcutKeyEvent> = {}): ShortcutKeyEvent =>
+    ({ metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, key: 'Enter', ...over })
+  const commits = (e: ShortcutKeyEvent, isMac: boolean) =>
+    effectiveBindings('scm.commit').some((s) => matchesShortcut(e, s, isMac))
+
+  it('commits on the platform chord', () => {
+    expect(commits(key({ metaKey: true }), true)).toBe(true)
+    expect(commits(key({ ctrlKey: true }), false)).toBe(true)
+  })
+  it('no longer commits on the OTHER platform primary (the named D-strict losses)', () => {
+    expect(commits(key({ ctrlKey: true }), true)).toBe(false) // mac Ctrl+Enter
+    expect(commits(key({ metaKey: true }), false)).toBe(false) // non-mac Meta+Enter
+  })
+  it('no longer commits with an extra modifier held on top', () => {
+    expect(commits(key({ metaKey: true, shiftKey: true }), true)).toBe(false)
+    expect(commits(key({ metaKey: true, altKey: true }), true)).toBe(false)
+  })
+  it('follows a remap, so the key agrees with the placeholder chip', () => {
+    setKb({ 'scm.commit': ['Cmd+Shift+Enter'] })
+    expect(commits(key({ metaKey: true }), true)).toBe(false)
+    expect(commits(key({ metaKey: true, shiftKey: true }), true)).toBe(true)
+    expect(chipFor('scm.commit', true)).toBe('⌘⇧Enter')
+  })
+  it('is inert when unbound — the placeholder drops its chord for the same reason', () => {
+    setKb({ 'scm.commit': [] })
+    expect(commits(key({ metaKey: true }), true)).toBe(false)
+    expect(chipFor('scm.commit', true)).toBe('')
+  })
+  it('plain Enter never commits (it types a newline)', () => {
+    expect(commits(key(), true)).toBe(false)
   })
 })
 

--- a/src/renderer/lib/keybindingOverrides.test.ts
+++ b/src/renderer/lib/keybindingOverrides.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { DEFAULT_SETTINGS } from '@shared/types'
 import { useSettings } from '../state/settings'
-import { activeKeybindingOverrides, effectiveBindings, commandKeys, commandTooltip } from './keybindingOverrides'
+import {
+  activeKeybindingOverrides, effectiveBindings, commandKeys, commandTooltip, chipFor
+} from './keybindingOverrides'
 
 const setKb = (kb: unknown) =>
   useSettings.setState({ settings: { ...DEFAULT_SETTINGS, keybindings: kb as never } })
@@ -49,5 +51,19 @@ describe('effectiveBindings / commandKeys / commandTooltip', () => {
   it('unbound commands render without a chord suffix', () => {
     expect(commandTooltip('Fit all', 'canvas.fitAll', true)).toBe('Fit all')
     expect(commandKeys('canvas.fitAll', true)).toEqual([])
+  })
+})
+
+describe('chipFor', () => {
+  it('renders the bare chord the way each platform spells it', () => {
+    expect(chipFor('app.commandPalette', true)).toBe('⌘K')
+    expect(chipFor('app.commandPalette', false)).toBe('Ctrl+K')
+  })
+  it('follows a remap', () => {
+    setKb({ 'app.commandPalette': ['Cmd+Shift+P'] })
+    expect(chipFor('app.commandPalette', true)).toBe('⌘⇧P')
+  })
+  it('is empty for an unbound command, so callers can fall back', () => {
+    expect(chipFor('canvas.fitAll', true)).toBe('')
   })
 })

--- a/src/renderer/lib/keybindingOverrides.ts
+++ b/src/renderer/lib/keybindingOverrides.ts
@@ -45,3 +45,11 @@ export function commandTooltip(text: string, id: CommandId, isMac: boolean = isM
   if (!parts.length) return text
   return `${text} (${isMac ? parts.join('') : parts.join('+')})`
 }
+
+/** The bare chord, as a chip: `'⌘K'` (mac) / `'Ctrl+K'`. **`''` when unbound** — every caller
+ *  embeds this in a sentence (`⌘M to exit`, `Message (⌘Enter to commit)`), so they must test it
+ *  and fall back to chord-less copy rather than rendering a stray fragment. */
+export function chipFor(id: CommandId, isMac: boolean = isMacPlatform()): string {
+  const parts = commandKeys(id, isMac)
+  return isMac ? parts.join('') : parts.join('+')
+}

--- a/src/renderer/lib/keybindingOverrides.ts
+++ b/src/renderer/lib/keybindingOverrides.ts
@@ -1,0 +1,47 @@
+/**
+ * The renderer's single read path for shortcut overrides: sanitize once per settings change
+ * (memoized by the raw object's reference — `useSettings.update` replaces the settings object
+ * but keeps untouched sub-objects), warn once, and serve effective bindings + display strings
+ * from it. Everything that shows or matches a registry chord goes through here so dispatch,
+ * ShortcutsPanel, and tooltips cannot disagree.
+ */
+import {
+  getEffectiveBindings, sanitizeKeybindingOverrides,
+  type CommandId, type KeybindingOverrides
+} from '@shared/keybindings'
+import { shortcutKeyParts } from '@shared/shortcut'
+import { isMacPlatform } from '@shared/platform-utils'
+import { useSettings } from '../state/settings'
+
+const UNSET = Symbol('unset')
+let lastRaw: unknown = UNSET
+let lastSanitized: KeybindingOverrides = {}
+
+export function activeKeybindingOverrides(): KeybindingOverrides {
+  const raw = useSettings.getState().settings.keybindings
+  if (raw === lastRaw) return lastSanitized
+  const { overrides, warnings } = sanitizeKeybindingOverrides(raw, isMacPlatform())
+  if (warnings.length) console.warn(`[keybindings] ${warnings.join(' ')}`)
+  lastRaw = raw
+  lastSanitized = overrides
+  return overrides
+}
+
+export function effectiveBindings(id: CommandId): readonly string[] {
+  return getEffectiveBindings(id, activeKeybindingOverrides(), isMacPlatform())
+}
+
+/** Display parts of the command's first effective binding; [] when unbound. */
+export function commandKeys(id: CommandId, isMac: boolean = isMacPlatform()): string[] {
+  const first = getEffectiveBindings(id, activeKeybindingOverrides(), isMac)[0]
+  return first ? shortcutKeyParts(first, isMac) : []
+}
+
+/** `('Sessions', 'panel.sessions')` -> `'Sessions (⌘⇧L)'` (mac) / `'Sessions (Ctrl+Shift+L)'`
+ *  — the same strings hintLabel produced for the defaults, but following remaps; bare text
+ *  when unbound. */
+export function commandTooltip(text: string, id: CommandId, isMac: boolean = isMacPlatform()): string {
+  const parts = commandKeys(id, isMac)
+  if (!parts.length) return text
+  return `${text} (${isMac ? parts.join('') : parts.join('+')})`
+}

--- a/src/renderer/nodes/ChatPanel.tsx
+++ b/src/renderer/nodes/ChatPanel.tsx
@@ -3,7 +3,7 @@ import { renderMarkdown } from '../lib/markdown'
 import { useAgentStatus } from '../state/agentStatus'
 import { useSession } from '../session/session'
 import type { ChatMessage } from '@shared/types'
-import { hintLabel } from '@shared/platform-utils'
+import { chipFor } from '../lib/keybindingOverrides'
 import { E_UNSUPPORTED } from '@shared/rpc'
 
 // Memoized bubble: marked+DOMPurify re-ran for EVERY message on each ChatPanel render (each
@@ -121,11 +121,15 @@ export function ChatPanel({ nodeId, sessionId, cwd, accountId }: ChatPanelProps)
     }
   }
 
+  // Whatever the markdown/chat toggle is bound to; '' when unbound, in which case the bar names
+  // the action instead of promising a chord that never fires.
+  const mdChip = chipFor('node.toggleMarkdown')
+
   return (
     <div className="term-chat nodrag nowheel">
       <div className="term-chat__bar">
         <span>Chat</span>
-        <span className="term-chat__hint">{hintLabel('⌘M to exit')}</span>
+        <span className="term-chat__hint">{mdChip ? `${mdChip} to exit` : 'Exit'}</span>
       </div>
       <div className="term-chat__msgs" ref={msgsRef}>
         {messages.length === 0 && loadState !== 'loading' && (

--- a/src/renderer/nodes/EditorNode.tsx
+++ b/src/renderer/nodes/EditorNode.tsx
@@ -12,6 +12,7 @@ import { useSession } from '../session/session'
 import type { CanvasNode } from '../state/workspace'
 import { tooLargeSize, formatBytes } from '@shared/fsLimits'
 import { hintLabel } from '@shared/platform-utils'
+import { chipFor, commandTooltip } from '../lib/keybindingOverrides'
 import { pdfBlobUrl } from '../lib/pdfBlob'
 
 // Image extensions get a visual preview instead of the Monaco text editor.
@@ -239,6 +240,10 @@ export function EditorNode({ id, data, selected }: NodeProps<CanvasNode>) {
     if (hoveredRef.current) toggleRef.current()
   }), [])
 
+  // Whatever the markdown toggle is bound to; '' when the user unbound it, in which case the
+  // preview's hint names the action instead of promising a chord that never fires.
+  const mdChip = chipFor('node.toggleMarkdown')
+
   return (
     <div
       className={`term-node editor-node${selected ? ' selected' : ''}`}
@@ -268,7 +273,7 @@ export function EditorNode({ id, data, selected }: NodeProps<CanvasNode>) {
           <>
             <button
               className="editor-node__toggle"
-              title={hintLabel('Toggle markdown preview (⌘M)')}
+              title={commandTooltip('Toggle markdown preview', 'node.toggleMarkdown')}
               onClick={togglePreview}
             >
               {preview ? 'Edit' : 'Preview'}
@@ -336,7 +341,7 @@ export function EditorNode({ id, data, selected }: NodeProps<CanvasNode>) {
               <div className="term-md nodrag nowheel">
                 <div className="term-md__bar">
                   <span>Preview</span>
-                  <span className="term-md__hint">{hintLabel('⌘M to edit')}</span>
+                  <span className="term-md__hint">{mdChip ? `${mdChip} to edit` : 'Edit'}</span>
                 </div>
                 <div
                   className="term-md__content"

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -166,11 +166,16 @@ import { agentEnvSnapshot } from '@renderer/lib/agentEnv'
 import { normalizedAgentModel } from '@shared/agents/model-gateway'
 import { ensureActivePermissionMode } from '../state/permissionMode'
 import { buildSshArgs, sshConnectionIdForProject, sshHostKey, type SshConnection } from '@shared/ssh'
-import { chipFor } from '../lib/keybindingOverrides'
+import { chipFor, effectiveBindings } from '../lib/keybindingOverrides'
+import { matchesShortcut } from '@shared/shortcut'
+import { isMacPlatform } from '@shared/platform-utils'
 import { ColumnPill } from '../components/kanban/ColumnPill'
 import { BoardLogPanel } from '../components/kanban/BoardLogPanel'
 import { AgentMascot } from './AgentMascot'
 import { connectHostAttachment } from '../lib/sshAttachments'
+
+/** Which physical modifier the registry's abstract `Cmd` resolves to for the find-bar chord. */
+const isMac = isMacPlatform()
 
 /** How long a remote terminal waits for its project's ControlMaster before giving up and showing
  *  the offline overlay. Sized for the SLOW-but-fine case (a cold app load whose connect is still
@@ -4117,7 +4122,7 @@ export function TerminalNode({
   // needed (the Electron renderer has no native find UI), unlike Cmd+M.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === 'f' && hoveredRef.current) {
+      if (hoveredRef.current && effectiveBindings('terminal.find').some((s) => matchesShortcut(e, s, isMac))) {
         e.preventDefault()
         setSearchOpen((v) => !v)
       }

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -166,7 +166,7 @@ import { agentEnvSnapshot } from '@renderer/lib/agentEnv'
 import { normalizedAgentModel } from '@shared/agents/model-gateway'
 import { ensureActivePermissionMode } from '../state/permissionMode'
 import { buildSshArgs, sshConnectionIdForProject, sshHostKey, type SshConnection } from '@shared/ssh'
-import { hintLabel } from '@shared/platform-utils'
+import { chipFor } from '../lib/keybindingOverrides'
 import { ColumnPill } from '../components/kanban/ColumnPill'
 import { BoardLogPanel } from '../components/kanban/BoardLogPanel'
 import { AgentMascot } from './AgentMascot'
@@ -4150,6 +4150,10 @@ export function TerminalNode({
     status?.state !== 'waiting' &&
     status?.state !== 'blocked'
 
+  // Whatever the markdown toggle is bound to; '' when the user unbound it, in which case the
+  // markdown view's hint names the action instead of promising a chord that never fires.
+  const mdChip = chipFor('node.toggleMarkdown')
+
   return (
     <>
     {/* Sibling of the root: .term-node is overflow:hidden and would clip the half-pill. */}
@@ -4632,7 +4636,7 @@ export function TerminalNode({
             <div className="term-md nodrag nowheel">
               <div className="term-md__bar">
                 <span>Markdown</span>
-                <span className="term-md__hint">{hintLabel('⌘M to exit')}</span>
+                <span className="term-md__hint">{mdChip ? `${mdChip} to exit` : 'Exit'}</span>
               </div>
               <div className="term-md__content" dangerouslySetInnerHTML={{ __html: mdHtml }} />
             </div>

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -367,6 +367,15 @@ describe('resolveCommandForKeyEvent', () => {
     expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'Enter' }), ctx(), {}, true))
       .toBeNull()
   })
+  it('never resolves speech.dictation — even a hand-edited KEYED override', () => {
+    // The registry row is display-only; dictation dispatches from its own listeners reading
+    // settings.speech.shortcut, so nothing here would ever handle it. Without the resolver skip
+    // this override RESOLVES, finds no handler, and the chord is spent — the trailing gestures
+    // (zoom / projectJump / copy) never see it, so a `Cmd+0` override kills zoom-to-100%.
+    // Passed straight in, bypassing sanitize: this is exactly the hand-edited settings.json case.
+    const o = { 'speech.dictation': ['Cmd+0'] }
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: '0' }), ctx(), o, true)).toBeNull()
+  })
   it('terminal focus admits terminal scope over a canvas command sharing the chord', () => {
     // Cmd+F sits on terminal.find; a canvas-scope override claims the same chord. The
     // terminal-focus gate drops canvas.fitAll before its bindings are ever read — this

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -353,6 +353,13 @@ export function resolveCommandForKeyEvent(
     // scm commands dispatch from their own focused composer (local onKeyDown), never from
     // the window listener — resolving them here would fire Commit with no composer focused.
     if (def.scope === 'scm') continue
+    // speech.dictation dispatches from its own dedicated listeners (the keyed gesture and the
+    // hold-mode effect, both reading settings.speech.shortcut), never from the registry — its
+    // row here is display-only, for ShortcutsPanel and the Settings section. A hand-edited KEYED
+    // override would otherwise RESOLVE, find no handler, and spend the chord: the dispatcher's
+    // claim protocol stops a resolved command from reaching the trailing gestures, so
+    // `{"speech.dictation": ["Cmd+0"]}` would silently kill zoom-to-100%.
+    if (def.id === 'speech.dictation') continue
     if (ctx.typing && !def.allowWhileTyping) continue
     if (ctx.terminal && !(def.scope === 'terminal' || def.allowInTerminal)) continue
     if (!ctx.terminal && def.scope === 'terminal') continue

--- a/src/shared/shortcut.test.ts
+++ b/src/shared/shortcut.test.ts
@@ -478,3 +478,12 @@ describe('resolvedModifiers', () => {
     expect(resolvedModifiers(p, false)).toEqual({ meta: false, ctrl: true, alt: false, shift: true })
   })
 })
+
+describe('parseShortcut memoization', () => {
+  it('returns the same frozen object for repeated input', () => {
+    const a = parseShortcut('Cmd+Shift+D')
+    const b = parseShortcut('Cmd+Shift+D')
+    expect(b).toBe(a)
+    expect(Object.isFrozen(a)).toBe(true)
+  })
+})

--- a/src/shared/shortcut.ts
+++ b/src/shared/shortcut.ts
@@ -71,15 +71,17 @@ export function isModifierEventKey(key: string): boolean {
   return MODIFIER_KEYS.has(normalizeKey(key))
 }
 
+// Memo: dispatch re-parses every candidate binding on every keydown once the registry sits on
+// a window listener; distinct binding strings are few, so a small frozen-value cache removes
+// the hot-path cost for every consumer at once. The returned object's IDENTITY is stable only
+// until the size-cap clear below — never key a Map/WeakMap or a React dep array off a
+// `ParsedShortcut`; compare its fields, or the string it came from.
+const parseCache = new Map<string, ParsedShortcut>()
+
 /** Parse a canonical combo string, e.g. `"Cmd+Shift+D"` -> `{cmd:true, ctrl:false, shift:true,
  *  alt:false, key:'D'}`; a modifier-only chord, e.g. `"Cmd+Alt"` -> `{cmd:true, ctrl:false,
  *  shift:false, alt:true, key:null}` (see `isHoldChord`). `Ctrl`/`Control` set the LITERAL `ctrl`
  *  field — they are no longer a spelling of the abstract `Cmd`. */
-// Memo: dispatch re-parses every candidate binding on every keydown once the registry sits on
-// a window listener; distinct binding strings are few, so a small frozen-value cache removes
-// the hot-path cost for every consumer at once.
-const parseCache = new Map<string, ParsedShortcut>()
-
 export function parseShortcut(s: string): ParsedShortcut {
   const hit = parseCache.get(s)
   if (hit) return hit

--- a/src/shared/shortcut.ts
+++ b/src/shared/shortcut.ts
@@ -75,7 +75,14 @@ export function isModifierEventKey(key: string): boolean {
  *  alt:false, key:'D'}`; a modifier-only chord, e.g. `"Cmd+Alt"` -> `{cmd:true, ctrl:false,
  *  shift:false, alt:true, key:null}` (see `isHoldChord`). `Ctrl`/`Control` set the LITERAL `ctrl`
  *  field — they are no longer a spelling of the abstract `Cmd`. */
+// Memo: dispatch re-parses every candidate binding on every keydown once the registry sits on
+// a window listener; distinct binding strings are few, so a small frozen-value cache removes
+// the hot-path cost for every consumer at once.
+const parseCache = new Map<string, ParsedShortcut>()
+
 export function parseShortcut(s: string): ParsedShortcut {
+  const hit = parseCache.get(s)
+  if (hit) return hit
   const parts = s
     .split('+')
     .map((p) => p.trim())
@@ -100,7 +107,10 @@ export function parseShortcut(s: string): ParsedShortcut {
       key = normalizeKey(part)
     }
   }
-  return { cmd, ctrl, shift, alt, key }
+  const parsed = Object.freeze({ cmd, ctrl, shift, alt, key })
+  if (parseCache.size > 512) parseCache.clear() // hand-edited garbage churn guard
+  parseCache.set(s, parsed)
+  return parsed
 }
 
 /** Canonical spellings for the key tokens that are not a single character. Serializing through

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,6 +2,7 @@
 
 import { DEFAULT_WORKTREE_PATH_TEMPLATE } from './worktree'
 import type { CloneProgress } from './clone-url'
+import type { KeybindingOverrides } from './keybindings'
 import type { NormalizedAgentEvent } from './agents/normalize'
 import type { AgentId, AgentPermissionMode, BuiltinAgentId, PromptInjectionMode } from './agents/config'
 import type { AgentMessageDeliverRequest, AgentMessageReply } from './agents/agent-messaging'
@@ -1194,6 +1195,11 @@ export interface Settings {
   notchHoverExpand: boolean
   /** Dictation (desktop/server). Written as a whole object by the renderer. */
   speech: SpeechSettings
+  /** Keyboard-shortcut overrides by command id (see shared/keybindings.ts). Absent id = the
+   *  command's default bindings; `[]` = disabled. Hand-editable; invalid or conflicting
+   *  entries are dropped with a console warning at read time (sanitizeKeybindingOverrides).
+   *  Optional and deliberately not in DEFAULT_SETTINGS: absent simply means "no overrides". */
+  keybindings?: KeybindingOverrides
   /** Per-node hook identity enforcement (src/core/agents/node-identity-policy.ts).
    *
    *  The ONLY optional key in this interface, and deliberately so: it is a TRI-state, and the two

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1202,7 +1202,7 @@ export interface Settings {
   keybindings?: KeybindingOverrides
   /** Per-node hook identity enforcement (src/core/agents/node-identity-policy.ts).
    *
-   *  The ONLY optional key in this interface, and deliberately so: it is a TRI-state, and the two
+   *  One of the two optional keys in this interface, and deliberately so: it is a TRI-state, and the two
    *  non-default states are opposite escape hatches. Absent (the default — it is not in
    *  DEFAULT_SETTINGS) follows `NODE_IDENTITY_STRICT_AFTER`, so the rollout has one schedule for
    *  everybody. `true` opts in to strict enforcement before that date. `false` keeps the warning


### PR DESCRIPTION
Consolidates every registry command onto the shared keybinding engine from #311:

- **One window listener** in Canvas replaces four hardcoded keydown effects (a pure `dispatchGlobalKeydown` resolves registry commands; the legacy gestures — keyed dictation, ⌘0/⇧1 zoom, ⌘1-9 project jump, ⌘C copy — keep their exact semantics and documented order).
- **Main-process intercept** (`keydown-intercept.ts`) resolves `node.close` / `node.toggleMarkdown` from settings; unbound = no interception; Alt-only remaps now reach the matcher (the old shared modifier gate would have killed them).
- **ShortcutsPanel + 15 tooltip sites** render from effective bindings — a remap or unbind shows up everywhere, and the panel gains the previously missing rows (Explorer, Source Control, Kanban, Sessions pin, Find in terminal, Delete selection).
- **`terminal.find` and `scm.commit`** local matchers went registry-driven (single owner unchanged).
- **Hand-editable overrides**: optional `settings.keybindings` (`{"node.newTerminal": ["Cmd+Shift+T"], "app.commandPalette": []}` — absent id = default, `[]` = disabled). Invalid or conflicting entries are dropped with a console warning at read time. The Settings UI for this arrives in the next PR.

### Behavior deltas (deliberate)

**Strict matching (the rule):** chord matching is now exact on all four modifier flags, and `Cmd` is platform-exact (⌘ on macOS, Ctrl elsewhere). Any extra modifier held on top of a converted chord, or the other platform's primary, no longer matches. Examples (not exhaustive — the rule is the contract): mac Ctrl+K / ⌘⌃K no longer open the palette, ⌘Y no longer redoes, ⌘⌥Z is no longer undo, ⌘⇧M / ⌘⌥M no longer toggle markdown, ⌘⇧F and mac Ctrl+F no longer open terminal find (Ctrl+F now reaches readline), mac Ctrl+Enter / ⌘⇧Enter no longer commit, ⌥/⇧+Delete no longer delete nodes, non-mac Super+M/W are ignored.
**Typing guard:** the palette/settings/panel-toggle block no longer fires while typing in a real input (it did — e.g. while renaming a node); the undo/redo/delete/new-node guards now also cover `contentEditable`. A focused terminal is NOT "typing": those chords still work over xterm exactly as before. Two micro-corrections in the same class: ⌘⇧B with no active project no longer swallows the key, and the keyed dictation chord's guard follows the same typing rules.
**Display:** `scm.commit` renders as ⌘Enter / Ctrl+Enter (was ⌘↵).

### Known limitations (documented, not silent)

- A remap of the main-intercepted commands onto another surface's chord (e.g. `node.close` → `Cmd+F`) is swallowed app-wide and the conflict detector cannot see it across buckets — the Settings UI PR will warn on this.
- Surfaces that do **not** yet follow a remap: the TabBar kanban tooltip, one palette hint, and the onboarding tour's kanban step (they keep today's literals; follow-up with the Settings UI).
- `speech.dictation` stays driven by Settings → Speech (`speech.shortcut`); its registry row is display-only and the resolver skips it by construction.
- Server Edition unchanged: no ⌘M/⌘W path is added there (the browser owns ⌘W un-preventably).

Part 2 of the remappable-shortcuts series (registry: #311; next: Settings UI + dictation migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)