### PR TITLE
feat(project-settings): Settings → Projects panel — per-project sections, family editors, deep links

### DIFF
--- a/src/core/workspace-store.settings.test.ts
+++ b/src/core/workspace-store.settings.test.ts
@@ -356,3 +356,19 @@ describe('project settings — ssh leg', () => {
     expect(s?.shared?.setup?.setupScript).toBe('no-io')
   })
 })
+
+describe('project settings IPC registration', () => {
+  it('registers the three channels and round-trips through platform handlers', async () => {
+    // fakePlatform's `handle` already records into `fake.handlers` (a plain object keyed by
+    // channel) — no monkey-patching needed, just read handlers back off it.
+    const store = new WorkspaceStore()
+    store.registerIpc()
+    await store.save(ws([project({ cwd: projRoot })]))
+    const handlers = fake.handlers
+    expect(await handlers['project-settings:write-shared']('p1', { terminal: { shell: '/bin/zsh' } })).toBe(true)
+    const snap = (await handlers['project-settings:read']('p1')) as { shared: { terminal?: { shell?: string } } | null }
+    expect(snap.shared?.terminal?.shell).toBe('/bin/zsh')
+    expect(await handlers['project-settings:update-local']('p1', { ignoreShared: { setup: true } })).toBe(true)
+    expect(await handlers['project-settings:read']('nope')).toBeNull()
+  })
+})

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -16,7 +16,8 @@ import { readProjectSettingsFile, writeProjectSettingsFile } from './project-set
 import {
   parseProjectSettingsFile, sameProjectSettingsContent, sanitizeProjectLocalSettings,
   sanitizeProjectSettingsDoc, serializeProjectSettingsFile,
-  type ProjectLocalSettings, type ProjectSettingsDoc, type ProjectSettingsFileV1
+  type ProjectLocalSettings, type ProjectSettingsDoc, type ProjectSettingsFileV1,
+  type ProjectSettingsSnapshot
 } from '../shared/project-settings'
 import { readProjectCapabilities, type ProjectCapability } from '../shared/project-capabilities'
 import type { CapabilityAckMap } from './project-capability-consent'
@@ -41,17 +42,10 @@ export interface RemoteWorkspaceIO {
 
 const projectFilePath = (cwd: string): string => path.join(cwd, PROJECT_DIR, PROJECT_FILE)
 
-/** What one project's settings look like right now: the git-shared document (null when there is
- *  none, or it cannot be trusted/read) plus this machine's own overlay. `resolveProjectSettings`
- *  turns the pair into effective values; this type only reports what each side says. */
-export interface ProjectSettingsState {
-  shared: ProjectSettingsFileV1 | null
-  local: ProjectLocalSettings | undefined
-  /** The shared file exists but is git-conflict-marked, so it is left untouched for the user to
-   *  resolve. `shared` is null for a local ref; for an ssh project the last-known-good offline cache
-   *  is still served alongside the flag (it is the only readable copy of that document). */
-  conflict?: true
-}
+/** Alias of the shared `ProjectSettingsSnapshot` (moved to `shared/project-settings.ts` so the
+ *  renderer's `ProjectSettingsApi` can name the shape without importing core) — the store's
+ *  methods keep this name in their signatures. */
+export type ProjectSettingsState = ProjectSettingsSnapshot
 
 /** A parsed project file together with the exact bytes it was parsed from. `lastWritten` must
  *  record `raw` — see the field it caches. */
@@ -184,6 +178,13 @@ export class WorkspaceStore {
     platform().handle(IPC.workspaceLoad, () => this.load())
     platform().handle(IPC.workspaceSave, (workspace: Workspace) => this.save(workspace))
     platform().handle(IPC.workspaceProbeFolder, (folder: string) => this.probeFolder(folder))
+    platform().handle(IPC.projectSettingsRead, (projectId: unknown) =>
+      typeof projectId === 'string' ? this.readProjectSettings(projectId) : null)
+    platform().handle(IPC.projectSettingsWriteShared, (projectId: unknown, doc: ProjectSettingsDoc) =>
+      typeof projectId === 'string' ? this.writeProjectSettings(projectId, doc) : false)
+    platform().handle(IPC.projectSettingsUpdateLocal,
+      (projectId: unknown, local: ProjectLocalSettings | undefined) =>
+        typeof projectId === 'string' ? this.updateLocalProjectSettings(projectId, local) : false)
   }
 
   /**
@@ -655,11 +656,13 @@ export class WorkspaceStore {
    *
    * False = there is nowhere to write it, or writing would destroy something. On BOTH legs: an
    * unknown id, an inline canvas (no folder), and a git-conflicted shared file — the user's to
-   * resolve, left untouched (the local leg sees it in the read-before-write, the ssh leg remembers
-   * it from the last read, since looking again would cost a round trip per keystroke). Local leg
-   * only: an unreadable file (a failed read is never evidence of absence, so it may not be
-   * clobbered either) or a failed write. SSH leg only: an index write that did not persist —
-   * a failed REMOTE write is not false there, because the cache already holds the edit.
+   * resolve, left untouched (the local leg sees it in the read-before-write; the ssh leg sees it
+   * WARM from a cache or last-read doc this run already has, or — COLD, when neither map knows this
+   * project yet — from the one read `writeSshSettings` does itself before its first write, per its
+   * own docstring above). Local leg only: an unreadable file (a failed read is never evidence of
+   * absence, so it may not be clobbered either) or a failed write. SSH leg only: an index write that
+   * did not persist — a failed REMOTE write is not false there, because the cache already holds
+   * the edit.
    */
   async writeProjectSettings(projectId: string, doc: ProjectSettingsDoc): Promise<boolean> {
     const e = this.index?.entries.find((x) => x.id === projectId)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -137,6 +137,13 @@ const api: NodeTerminalApi = {
       return () => ipcRenderer.removeListener(IPC.workspaceExternalChange, h)
     }
   },
+  projectSettings: {
+    read: (projectId: string) => ipcRenderer.invoke(IPC.projectSettingsRead, projectId),
+    writeShared: (projectId: string, doc) =>
+      ipcRenderer.invoke(IPC.projectSettingsWriteShared, projectId, doc),
+    updateLocal: (projectId: string, local) =>
+      ipcRenderer.invoke(IPC.projectSettingsUpdateLocal, projectId, local)
+  },
   dialog: {
     selectFolder: () => ipcRenderer.invoke(IPC.dialogSelectFolder),
     selectFile: () => ipcRenderer.invoke(IPC.dialogSelectFile)

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -294,6 +294,15 @@ export function buildStubApi(): Omit<
       saveGatewayCredential: U('agent.saveGatewayCredential'),
       clearGatewayCredential: U('agent.clearGatewayCredential')
     },
+    projectSettings: {
+      // Overridden by the real WS-backed namespace in ws-bridge (same registerIpc() call as
+      // `workspace`); this fallback only matters if some future assembly spreads the stub alone.
+      // Fail-closed rather than reject: an unknown/unreachable project reads as "no settings" and
+      // a write/update as "did not happen", matching the real handlers' contract for an unknown id.
+      read: () => Promise.resolve(null),
+      writeShared: () => Promise.resolve(false),
+      updateLocal: () => Promise.resolve(false)
+    },
     chat: {
       readTranscript: U('chat.readTranscript')
     },

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -204,11 +204,12 @@ const AI_NAMING_UNAVAILABLE = {
   message: 'AI naming is not available in the server edition yet'
 }
 
-/** Build the real `pty` / `workspace` / `settings` namespaces (plus the top-level `userDataDir`)
- *  over an RpcClient, mirroring the preload's invoke(→request)/send(→cast) split exactly. */
+/** Build the real `pty` / `workspace` / `projectSettings` / `settings` namespaces (plus the
+ *  top-level `userDataDir`) over an RpcClient, mirroring the preload's
+ *  invoke(→request)/send(→cast) split exactly. */
 export function buildRealApi(
   client: RpcClient
-): Pick<NodeTerminalApi, 'pty' | 'workspace' | 'settings' | 'agent' | 'userDataDir'> {
+): Pick<NodeTerminalApi, 'pty' | 'workspace' | 'projectSettings' | 'settings' | 'agent' | 'userDataDir'> {
   const pty: PtyApi = {
     create: (options: PtyCreateOptions) =>
       client.request(IPC.ptyCreate, options) as ReturnType<PtyApi['create']>,
@@ -287,6 +288,19 @@ export function buildRealApi(
     onExternalChange: () => () => {}
   }
 
+  // REAL: WorkspaceStore (core) registers the project-settings:* channels too — same
+  // registerIpc() call as workspace above — so the server serves this on both shells.
+  const projectSettings: NodeTerminalApi['projectSettings'] = {
+    read: (projectId) =>
+      client.request(IPC.projectSettingsRead, projectId) as ReturnType<
+        NodeTerminalApi['projectSettings']['read']
+      >,
+    writeShared: (projectId, doc) =>
+      client.request(IPC.projectSettingsWriteShared, projectId, doc) as Promise<boolean>,
+    updateLocal: (projectId, local) =>
+      client.request(IPC.projectSettingsUpdateLocal, projectId, local) as Promise<boolean>
+  }
+
   const settings: SettingsApi = {
     load: () => client.request(IPC.settingsLoad) as Promise<Settings>,
     save: (s: Settings) => client.request(IPC.settingsSave, s) as Promise<void>
@@ -321,7 +335,7 @@ export function buildRealApi(
   // `/worktrees/…` at the filesystem root (the server usually runs as root, and git would create it).
   const userDataDir = (): Promise<string> => client.request(IPC.appUserDataDir) as Promise<string>
 
-  return { pty, workspace, settings, agent, userDataDir }
+  return { pty, workspace, projectSettings, settings, agent, userDataDir }
 }
 
 export function buildGitHubApi(

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -112,6 +112,7 @@ import {
   IconUnlock
 } from '../components/icons'
 import type { SettingsSectionId } from '../components/settings/nav'
+import { projectSectionId } from '../components/settings/project-settings-targets'
 // Overlay surfaces (settings, source control, explorer, kanban, onboarding, dictation, …) are
 // code-split: they render behind a flag and must not sit in the startup chunk. See lazyPanels.
 import {
@@ -836,6 +837,15 @@ export function Canvas() {
   const [welcomeOpen, setWelcomeOpen] = useState(false)
   // Optional deep-link target when opening settings (e.g. RemotePicker → the SSH section).
   const [settingsSection, setSettingsSection] = useState<SettingsSectionId | undefined>(undefined)
+  // Bumped ONLY by a deep link, so SettingsPage re-targets (and clears its search box) even when
+  // the requested section is the one it is already showing. Plain opens leave it alone.
+  const [settingsNonce, setSettingsNonce] = useState(0)
+  // Tab caret menu / sidebar right-click → this project's own pane in Settings.
+  const openProjectSettings = useCallback((id: string) => {
+    setSettingsSection(projectSectionId(id))
+    setSettingsNonce((n) => n + 1)
+    setSettingsOpen(true)
+  }, [])
   const [scOpen, setScOpen] = useState(false)
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
   // Debug log panel (issue #78). Settings' "Open" button fires the event (the dialog can't
@@ -8779,6 +8789,11 @@ export function Canvas() {
             }
           },
           { label: 'Set folder…', icon: <IconProject />, onClick: () => setProjectFolder(projectId) },
+          {
+            label: 'Project settings…',
+            icon: <IconGear />,
+            onClick: () => openProjectSettings(projectId)
+          },
           { type: 'separator' },
           { type: 'colors', onPick: (color) => setProjectColor(projectId, color) },
           { type: 'separator' },
@@ -8791,7 +8806,15 @@ export function Canvas() {
         ]
       })
     },
-    [activeProjectId, switchProject, renameProject, setProjectFolder, setProjectColor, closeProject]
+    [
+      activeProjectId,
+      switchProject,
+      renameProject,
+      setProjectFolder,
+      setProjectColor,
+      closeProject,
+      openProjectSettings
+    ]
   )
 
   // Reopen a previously closed project and make it active — the active-project effect reloads its
@@ -9174,6 +9197,7 @@ export function Canvas() {
         onRemoteAccess={() => setRemoteDialogOpen(true)}
         onSetDefaultAccount={setProjectDefaultAccount}
         onSetDefaultPermissionMode={setProjectDefaultPermissionMode}
+        onOpenProjectSettings={openProjectSettings}
       />
 
       <div className="top-banners">
@@ -9673,7 +9697,11 @@ export function Canvas() {
       )}
 
       {settingsOpen && (
-        <SettingsPage onClose={() => setSettingsOpen(false)} initialSection={settingsSection} />
+        <SettingsPage
+          onClose={() => setSettingsOpen(false)}
+          initialSection={settingsSection}
+          retargetNonce={settingsNonce}
+        />
       )}
 
       {scOpen && (

--- a/src/renderer/components/TabBar.test.tsx
+++ b/src/renderer/components/TabBar.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Project } from '@shared/types'
+import { useProjects } from '../state/projects'
+import { TabBar } from './TabBar'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+class NoopResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function project(over: Partial<Project> = {}): Project {
+  return {
+    id: 'p1',
+    name: 'Alpha',
+    color: '#0a84ff',
+    cwd: '/repo/alpha',
+    viewport: { x: 0, y: 0, zoom: 1 },
+    nodes: [],
+    ...over
+  }
+}
+
+describe('TabBar caret menu', () => {
+  let root: Root
+  let host: HTMLElement
+  let onOpenProjectSettings: ReturnType<typeof vi.fn<(id: string) => void>>
+
+  const click = async (el: HTMLElement): Promise<void> => {
+    await act(async () => {
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+  }
+
+  const menuButton = (label: string): HTMLButtonElement | undefined =>
+    Array.from(document.querySelectorAll<HTMLButtonElement>('.tab-menu button')).find(
+      (b) => b.textContent?.trim() === label
+    )
+
+  beforeEach(async () => {
+    // jsdom implements neither; TabBar uses both purely for presentation.
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = NoopResizeObserver
+    Element.prototype.scrollIntoView = (): void => {}
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {}
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    useProjects.setState({ projects: [project()], activeProjectId: 'p1' })
+    onOpenProjectSettings = vi.fn<(id: string) => void>()
+    root = createRoot(host)
+    await act(async () => {
+      root.render(
+        <TabBar
+          onSwitch={vi.fn()}
+          onReconnect={vi.fn()}
+          onReorder={vi.fn()}
+          onOpenWelcome={vi.fn()}
+          onRename={vi.fn()}
+          onSetFolder={vi.fn()}
+          onCloseProject={vi.fn()}
+          onRemoteAccess={vi.fn()}
+          onSetDefaultAccount={vi.fn()}
+          onSetDefaultPermissionMode={vi.fn()}
+          onOpenProjectSettings={onOpenProjectSettings}
+        />
+      )
+    })
+    await click(host.querySelector<HTMLButtonElement>('.tab__caret')!)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    useProjects.setState({ projects: [], activeProjectId: '' })
+  })
+
+  it('offers "Project settings…" and deep-links the project it was opened on', async () => {
+    const item = menuButton('Project settings…')
+    expect(item).toBeDefined()
+    await click(item!)
+    expect(onOpenProjectSettings).toHaveBeenCalledWith('p1')
+    // …and the menu closes behind it, like every other action in this menu.
+    expect(document.querySelector('.tab-menu')).toBeNull()
+  })
+})

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -39,6 +39,9 @@ interface TabBarProps {
   onSetDefaultAccount: (id: string, accountId: string | undefined) => void
   /** Set (or clear, with undefined = use the global setting) the project's default permission mode. */
   onSetDefaultPermissionMode: (id: string, mode: AgentPermissionMode | undefined) => void
+  /** Deep-link to this project's own pane in Settings — everything this menu can change plus the
+   *  shared/machine-local settings families, which have no other entry point. */
+  onOpenProjectSettings: (id: string) => void
 }
 
 /**
@@ -73,7 +76,8 @@ export function TabBar({
   onCloseProject,
   onRemoteAccess,
   onSetDefaultAccount,
-  onSetDefaultPermissionMode
+  onSetDefaultPermissionMode,
+  onOpenProjectSettings
 }: TabBarProps) {
   // Select the raw array and filter in a memo, a `.filter()` inside the selector returns a
   // fresh array every store snapshot, which re-rendered the TabBar on EVERY projects change.
@@ -504,6 +508,14 @@ export function TabBar({
                 ))}
               </div>
             )}
+            <button
+              onClick={() => {
+                onOpenProjectSettings(menuProject.id)
+                closeMenu()
+              }}
+            >
+              Project settings…
+            </button>
             <button
               onClick={() => {
                 onCloseProject(menuProject.id)

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -125,9 +125,12 @@ const FAMILIES = Object.keys(FAMILY_CONFIG) as ProjectSettingsFamily[]
  */
 function fieldEntry(family: ProjectSettingsFamily, f: FieldConfig): SettingsSearchEntry {
   return {
+    // Deliberately NOT keyworded 'project': it discriminates nothing (every entry here is a project
+    // setting) while making the query "project" match every field of every project — which mounts
+    // every project's pane at once, and with it an SSH settings read per project.
     title: f.label,
     description: f.description,
-    keywords: [family, FAMILY_CONFIG[family].title, f.key, 'project', 'this machine', 'override']
+    keywords: [family, FAMILY_CONFIG[family].title, f.key, 'this machine', 'override']
   }
 }
 
@@ -176,6 +179,7 @@ function textareaClass(disabled?: boolean): string {
 function StringField({
   id,
   label,
+  ariaLabel,
   description,
   note,
   multiline,
@@ -185,6 +189,10 @@ function StringField({
 }: {
   id: string
   label: string
+  /** Accessible name, when it must differ from the visible label — a LOCAL row carries
+   *  "(this machine)" so it does not present the same name as its shared twin (SwitchField's
+   *  `ariaLabel` does the same). Omitted on a shared row, which is named by its `<label>`. */
+  ariaLabel?: string
   description?: string
   note?: string
   multiline: boolean
@@ -207,6 +215,7 @@ function StringField({
           <textarea
             id={id}
             value={draft}
+            aria-label={ariaLabel}
             disabled={disabled}
             onChange={(e) => setDraft(e.target.value)}
             onBlur={commit}
@@ -217,6 +226,7 @@ function StringField({
             id={id}
             className="w-72"
             value={draft}
+            aria-label={ariaLabel}
             disabled={disabled}
             onChange={(e) => setDraft(e.target.value)}
             onBlur={commit}
@@ -234,6 +244,7 @@ function StringField({
 function EnvField({
   id,
   label,
+  ariaLabel,
   description,
   disabled,
   text,
@@ -242,6 +253,8 @@ function EnvField({
 }: {
   id: string
   label: string
+  /** See `StringField`'s `ariaLabel`: the local row's name carries "(this machine)". */
+  ariaLabel?: string
   description?: string
   disabled?: boolean
   text: string
@@ -266,6 +279,7 @@ function EnvField({
         <textarea
           id={id}
           value={draft}
+          aria-label={ariaLabel}
           disabled={disabled}
           onChange={(e) => setDraft(e.target.value)}
           onBlur={commit}
@@ -340,6 +354,14 @@ function nextLocalIgnoreShared(
   return Object.keys(out).length === 0 ? undefined : (out as ProjectLocalSettings)
 }
 
+/** What a refused write says. Shared and local fail for different reasons and are recoverable in
+ *  different ways, so they do not share one vague sentence. */
+const SAVE_FAILED_NOTE: Record<'shared' | 'local', string> = {
+  shared:
+    'Could not save — the shared settings file may be conflicted or unavailable; reload the project settings.',
+  local: 'Could not save this override on this machine; reload the project settings.'
+}
+
 function FamilySection({
   projectId,
   family,
@@ -349,8 +371,10 @@ function FamilySection({
   resolvedFamily,
   conflict,
   ready,
+  sharedEditable,
   saveShared,
-  saveLocal
+  saveLocal,
+  reload
 }: {
   projectId: string
   family: ProjectSettingsFamily
@@ -365,14 +389,25 @@ function FamilySection({
    *  network round-trip, not a render tick — a blur landing in it would write a doc built from
    *  `{}`/`undefined`, silently deleting every other family already on disk. */
   ready: boolean
+  /** False when this project has no file to share (see `ProjectFamilyEditors`). */
+  sharedEditable: boolean
   saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
   saveLocal: (
-    update: ProjectLocalSettings | undefined | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
+    update: (current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined
   ) => Promise<boolean>
+  /** Re-reads the project's settings. Rung after a REFUSED shared write: a refusal is usually the
+   *  file's answer, not ours (it went conflicted, or the folder went away, between our read and our
+   *  write), and only a fresh read can make the pane describe the file as it now is. */
+  reload: () => void
 }): React.JSX.Element | null {
   const config = FAMILY_CONFIG[family]
-  const sharedDisabled = conflict || !ready
+  const sharedDisabled = conflict || !ready || !sharedEditable
   const localDisabled = !ready
+  // Which half last refused a write, or null. Set from the saver's own answer — before this, a
+  // `false` was dropped on the floor and the row simply snapped back to its old value, which reads
+  // as "the app ignored me". Cleared by the next save of the same half that succeeds; NOT cleared
+  // by the reload a failure triggers (that would erase the message we just put up).
+  const [saveFailed, setSaveFailed] = useState<'shared' | 'local' | null>(null)
   // Row-level search filtering. Done here rather than with `SearchableRow` wrappers because every
   // field renders TWICE (shared + "this machine") from the same list — filtering the list keeps
   // the two copies in step by construction. An entirely unmatched family drops out, heading and
@@ -386,17 +421,34 @@ function FamilySection({
   // user interaction, but nothing stops a caller (or a test) from dispatching events on it
   // directly, and the merge-base hazard this guards against is a data-corruption risk, not a UX
   // nicety — it must hold even if the DOM attribute is bypassed.
+  // Every commit path routes its saver's answer through here: a dropped `false` is a silent data
+  // loss — the row reverts to the stored value with no explanation, which is indistinguishable
+  // from the app ignoring the edit.
+  const settle = (half: 'shared' | 'local', ok: boolean): void => {
+    if (ok) {
+      setSaveFailed((prev) => (prev === half ? null : prev))
+      return
+    }
+    setSaveFailed(half)
+    if (half === 'shared') reload()
+  }
   const commitShared = (key: string, value: unknown): void => {
     if (sharedDisabled) return
-    void saveShared({ [family]: { [key]: value } } as ProjectSettingsDoc)
+    void saveShared({ [family]: { [key]: value } } as ProjectSettingsDoc).then((ok) =>
+      settle('shared', ok)
+    )
   }
   const commitLocal = (key: string, value: unknown): void => {
     if (localDisabled) return
-    void saveLocal((current) => nextLocalField(current, family, key, value))
+    void saveLocal((current) => nextLocalField(current, family, key, value)).then((ok) =>
+      settle('local', ok)
+    )
   }
   const commitIgnoreShared = (on: boolean): void => {
     if (localDisabled) return
-    void saveLocal((current) => nextLocalIgnoreShared(current, family, on))
+    void saveLocal((current) => nextLocalIgnoreShared(current, family, on)).then((ok) =>
+      settle('local', ok)
+    )
   }
 
   const renderShared = (f: FieldConfig): React.JSX.Element => {
@@ -471,6 +523,7 @@ function FamilySection({
           id={id}
           label={f.label}
           description={f.description}
+          ariaLabel={`${f.label} (this machine)`}
           disabled={localDisabled}
           text={formatEnvLines(localFamily?.[f.key] as Record<string, string> | undefined)}
           overrideNote={activeNote}
@@ -483,6 +536,7 @@ function FamilySection({
         key={f.key}
         id={id}
         label={f.label}
+        ariaLabel={`${f.label} (this machine)`}
         description={f.description}
         multiline={f.kind === 'textarea' || f.kind === 'list'}
         note={activeNote}
@@ -496,6 +550,11 @@ function FamilySection({
   return (
     <div className="space-y-3 border-t border-border pt-4">
       <h3 className="text-[13px] font-semibold text-text">{config.title}</h3>
+      {saveFailed ? (
+        <p role="status" className="text-[12px] leading-relaxed text-[color:var(--warn)]">
+          {SAVE_FAILED_NOTE[saveFailed]}
+        </p>
+      ) : null}
       <div className="space-y-2.5">{fields.map(renderShared)}</div>
       <details>
         <summary className="cursor-pointer text-[13px] text-muted">This machine</summary>
@@ -525,17 +584,30 @@ export function ProjectFamilyEditors({
   snapshot,
   resolved,
   conflict,
+  sharedEditable,
   saveShared,
-  saveLocal
+  saveLocal,
+  reload
 }: {
   projectId: string
   snapshot: ProjectSettingsSnapshot | null | 'loading'
   resolved: ResolvedProjectSettings
   conflict: boolean
+  /**
+   * False for a project with no folder at all — an inline canvas tab (no `cwd`, no `ssh`). There is
+   * nowhere to put a `.nodeterm/settings.json`, so the store refuses every shared write
+   * (`writeProjectSettings` returns false on `!e.cwd`); rendering live editors there offers a save
+   * that can only ever fail. The shared rows go read-only with a sentence saying why.
+   *
+   * The "This machine" rows stay live: the local overlay lives in this machine's workspace index,
+   * not in the project folder, so `updateLocal` genuinely succeeds for a folderless project.
+   */
+  sharedEditable: boolean
   saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
   saveLocal: (
-    update: ProjectLocalSettings | undefined | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
+    update: (current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined
   ) => Promise<boolean>
+  reload: () => void
 }): React.JSX.Element {
   // Loading and failed-read (`null`) both mean "no doc it is safe to merge an edit into" — see
   // `FamilySection`'s `ready` doc comment.
@@ -544,6 +616,13 @@ export function ProjectFamilyEditors({
   const local: ProjectLocalSettings | undefined = snapshot && snapshot !== 'loading' ? snapshot.local : undefined
   return (
     <>
+      {!sharedEditable ? (
+        <p className="border-t border-border pt-4 text-[13px] leading-relaxed text-muted">
+          This project has no folder, so there is no shared <code>.nodeterm/settings.json</code> to
+          write: the shared rows below are read-only. Overrides under &ldquo;This machine&rdquo;
+          still apply.
+        </p>
+      ) : null}
       {FAMILIES.map((family) => (
         <FamilySection
           key={family}
@@ -555,8 +634,10 @@ export function ProjectFamilyEditors({
           resolvedFamily={resolved[family] as Record<string, { source: 'local' | 'shared' } | undefined>}
           conflict={conflict}
           ready={ready}
+          sharedEditable={sharedEditable}
           saveShared={saveShared}
           saveLocal={saveLocal}
+          reload={reload}
         />
       ))}
     </>

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -316,7 +316,7 @@ function FamilySection({
   ignoreShared,
   resolvedFamily,
   conflict,
-  fullLocal,
+  ready,
   saveShared,
   saveLocal
 }: {
@@ -327,20 +327,36 @@ function FamilySection({
   ignoreShared: boolean
   resolvedFamily: Record<string, { source: 'local' | 'shared' } | undefined>
   conflict: boolean
-  fullLocal: ProjectLocalSettings | undefined
+  /** False until `snapshot` is an actual object (not `'loading'`, not `null`). Gates EVERY editor
+   *  in this family, shared and local alike: before the first read answers (or after a failed
+   *  one), there is no reliable doc to merge an edit into, and for an SSH project that window is a
+   *  network round-trip, not a render tick — a blur landing in it would write a doc built from
+   *  `{}`/`undefined`, silently deleting every other family already on disk. */
+  ready: boolean
   saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
-  saveLocal: (local: ProjectLocalSettings | undefined) => Promise<boolean>
+  saveLocal: (
+    update: ProjectLocalSettings | undefined | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
+  ) => Promise<boolean>
 }): React.JSX.Element {
   const config = FAMILY_CONFIG[family]
+  const sharedDisabled = conflict || !ready
+  const localDisabled = !ready
 
+  // Guarded here too, not just via the `disabled` attribute below: a disabled control blocks real
+  // user interaction, but nothing stops a caller (or a test) from dispatching events on it
+  // directly, and the merge-base hazard this guards against is a data-corruption risk, not a UX
+  // nicety — it must hold even if the DOM attribute is bypassed.
   const commitShared = (key: string, value: unknown): void => {
+    if (sharedDisabled) return
     void saveShared({ [family]: { [key]: value } } as ProjectSettingsDoc)
   }
   const commitLocal = (key: string, value: unknown): void => {
-    void saveLocal(nextLocalField(fullLocal, family, key, value))
+    if (localDisabled) return
+    void saveLocal((current) => nextLocalField(current, family, key, value))
   }
   const commitIgnoreShared = (on: boolean): void => {
-    void saveLocal(nextLocalIgnoreShared(fullLocal, family, on))
+    if (localDisabled) return
+    void saveLocal((current) => nextLocalIgnoreShared(current, family, on))
   }
 
   const renderShared = (f: FieldConfig): React.JSX.Element => {
@@ -356,7 +372,7 @@ function FamilySection({
           note={overrideNote}
           ariaLabel={f.label}
           checked={sharedFamily?.[f.key] === true}
-          disabled={conflict}
+          disabled={sharedDisabled}
           onCommit={(on) => commitShared(f.key, on ? true : undefined)}
         />
       )
@@ -368,7 +384,7 @@ function FamilySection({
           id={id}
           label={f.label}
           description={f.description}
-          disabled={conflict}
+          disabled={sharedDisabled}
           text={formatEnvLines(sharedFamily?.[f.key] as Record<string, string> | undefined)}
           overrideNote={overrideNote}
           onCommitValue={(v) => commitShared(f.key, v)}
@@ -383,7 +399,7 @@ function FamilySection({
         description={f.description}
         multiline={f.kind === 'textarea' || f.kind === 'list'}
         note={overrideNote}
-        disabled={conflict}
+        disabled={sharedDisabled}
         text={textOf(f.kind, sharedFamily?.[f.key])}
         onCommit={(text) => commitShared(f.key, valueOf(f.kind, text))}
       />
@@ -403,6 +419,7 @@ function FamilySection({
           note={activeNote}
           ariaLabel={`${f.label} (this machine)`}
           checked={localFamily?.[f.key] === true}
+          disabled={localDisabled}
           onCommit={(on) => commitLocal(f.key, on ? true : undefined)}
         />
       )
@@ -414,6 +431,7 @@ function FamilySection({
           id={id}
           label={f.label}
           description={f.description}
+          disabled={localDisabled}
           text={formatEnvLines(localFamily?.[f.key] as Record<string, string> | undefined)}
           overrideNote={activeNote}
           onCommitValue={(v) => commitLocal(f.key, v)}
@@ -428,6 +446,7 @@ function FamilySection({
         description={f.description}
         multiline={f.kind === 'textarea' || f.kind === 'list'}
         note={activeNote}
+        disabled={localDisabled}
         text={textOf(f.kind, localFamily?.[f.key])}
         onCommit={(text) => commitLocal(f.key, valueOf(f.kind, text))}
       />
@@ -450,6 +469,7 @@ function FamilySection({
             description="Never use the git-shared values for this family on this machine, even where this machine sets none of its own."
             ariaLabel={`Ignore shared ${family} settings on this machine`}
             checked={ignoreShared}
+            disabled={localDisabled}
             onCommit={commitIgnoreShared}
           />
         </div>
@@ -471,8 +491,13 @@ export function ProjectFamilyEditors({
   resolved: ResolvedProjectSettings
   conflict: boolean
   saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
-  saveLocal: (local: ProjectLocalSettings | undefined) => Promise<boolean>
+  saveLocal: (
+    update: ProjectLocalSettings | undefined | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
+  ) => Promise<boolean>
 }): React.JSX.Element {
+  // Loading and failed-read (`null`) both mean "no doc it is safe to merge an edit into" — see
+  // `FamilySection`'s `ready` doc comment.
+  const ready = snapshot !== 'loading' && snapshot !== null
   const shared: ProjectSettingsDoc = snapshot && snapshot !== 'loading' && snapshot.shared ? snapshot.shared : {}
   const local: ProjectLocalSettings | undefined = snapshot && snapshot !== 'loading' ? snapshot.local : undefined
   return (
@@ -487,7 +512,7 @@ export function ProjectFamilyEditors({
           ignoreShared={local?.ignoreShared?.[family] === true}
           resolvedFamily={resolved[family] as Record<string, { source: 'local' | 'shared' } | undefined>}
           conflict={conflict}
-          fullLocal={local}
+          ready={ready}
           saveShared={saveShared}
           saveLocal={saveLocal}
         />

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -8,8 +8,10 @@ import type {
 } from '@shared/project-settings'
 import { Input } from '@renderer/ui/Input'
 import { Switch } from '@renderer/ui/Switch'
+import { useSettingsSearch } from './context'
 import { FieldRow } from './FieldRow'
 import { formatEnvLines, formatListLines, parseEnvLines, parseListLines } from './project-settings-env'
+import { matchesQuery, type SettingsSearchEntry } from './search'
 
 /**
  * The four per-family editors (setup / agents / worktree / terminal) that hang off
@@ -111,6 +113,36 @@ const FAMILY_CONFIG: Record<ProjectSettingsFamily, FamilyConfig> = {
 }
 
 const FAMILIES = Object.keys(FAMILY_CONFIG) as ProjectSettingsFamily[]
+
+/**
+ * Search metadata, derived from the config above so a field can never exist without one. Static
+ * (no project name in the keywords): a query naming the PROJECT is handled one level up, by the
+ * pane's `forceVisible` — see ProjectSettingsSection.
+ *
+ * Each family field yields ONE entry covering both of its rows (shared + "this machine"): the two
+ * are the same setting, and hiding the local override while its shared twin shows would read as
+ * the override having been lost.
+ */
+function fieldEntry(family: ProjectSettingsFamily, f: FieldConfig): SettingsSearchEntry {
+  return {
+    title: f.label,
+    description: f.description,
+    keywords: [family, FAMILY_CONFIG[family].title, f.key, 'project', 'this machine', 'override']
+  }
+}
+
+function ignoreSharedEntry(family: ProjectSettingsFamily): SettingsSearchEntry {
+  return {
+    title: `Ignore shared ${FAMILY_CONFIG[family].title.toLowerCase()} settings`,
+    keywords: [family, 'ignore', 'shared', 'override', 'this machine']
+  }
+}
+
+/** Every family row's search entry, for the pane's `searchEntries`. */
+export const FAMILY_SEARCH_ENTRIES: SettingsSearchEntry[] = FAMILIES.flatMap((family) => [
+  ...FAMILY_CONFIG[family].fields.map((f) => fieldEntry(family, f)),
+  ignoreSharedEntry(family)
+])
 
 /** Text a non-env, non-list field shows in its box: the raw string, or '' when unset. */
 function textOf(kind: FieldKind, raw: unknown): string {
@@ -337,10 +369,18 @@ function FamilySection({
   saveLocal: (
     update: ProjectLocalSettings | undefined | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
   ) => Promise<boolean>
-}): React.JSX.Element {
+}): React.JSX.Element | null {
   const config = FAMILY_CONFIG[family]
   const sharedDisabled = conflict || !ready
   const localDisabled = !ready
+  // Row-level search filtering. Done here rather than with `SearchableRow` wrappers because every
+  // field renders TWICE (shared + "this machine") from the same list — filtering the list keeps
+  // the two copies in step by construction. An entirely unmatched family drops out, heading and
+  // "This machine" disclosure included, so the search never leaves an empty shell behind.
+  const query = useSettingsSearch()
+  const fields = config.fields.filter((f) => matchesQuery(query, fieldEntry(family, f)))
+  const showIgnoreShared = matchesQuery(query, ignoreSharedEntry(family))
+  if (fields.length === 0 && !showIgnoreShared) return null
 
   // Guarded here too, not just via the `disabled` attribute below: a disabled control blocks real
   // user interaction, but nothing stops a caller (or a test) from dispatching events on it
@@ -456,22 +496,24 @@ function FamilySection({
   return (
     <div className="space-y-3 border-t border-border pt-4">
       <h3 className="text-[13px] font-semibold text-text">{config.title}</h3>
-      <div className="space-y-2.5">{config.fields.map(renderShared)}</div>
+      <div className="space-y-2.5">{fields.map(renderShared)}</div>
       <details>
         <summary className="cursor-pointer text-[13px] text-muted">This machine</summary>
         <div className="mt-3 space-y-2.5">
           <p className="text-[12px] leading-relaxed text-muted">
             Overrides that apply only on this machine. Never written to the shared file.
           </p>
-          {config.fields.map(renderLocal)}
-          <SwitchField
-            label={`Ignore shared ${config.title.toLowerCase()} settings`}
-            description="Never use the git-shared values for this family on this machine, even where this machine sets none of its own."
-            ariaLabel={`Ignore shared ${family} settings on this machine`}
-            checked={ignoreShared}
-            disabled={localDisabled}
-            onCommit={commitIgnoreShared}
-          />
+          {fields.map(renderLocal)}
+          {showIgnoreShared && (
+            <SwitchField
+              label={`Ignore shared ${config.title.toLowerCase()} settings`}
+              description="Never use the git-shared values for this family on this machine, even where this machine sets none of its own."
+              ariaLabel={`Ignore shared ${family} settings on this machine`}
+              checked={ignoreShared}
+              disabled={localDisabled}
+              onCommit={commitIgnoreShared}
+            />
+          )}
         </div>
       </details>
     </div>

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -1,0 +1,497 @@
+import { useEffect, useState } from 'react'
+import type {
+  ProjectLocalSettings,
+  ProjectSettingsDoc,
+  ProjectSettingsFamily,
+  ProjectSettingsSnapshot,
+  ResolvedProjectSettings
+} from '@shared/project-settings'
+import { Input } from '@renderer/ui/Input'
+import { Switch } from '@renderer/ui/Switch'
+import { FieldRow } from './FieldRow'
+import { formatEnvLines, formatListLines, parseEnvLines, parseListLines } from './project-settings-env'
+
+/**
+ * The four per-family editors (setup / agents / worktree / terminal) that hang off
+ * `ProjectSettingsSection`: for every field, a SHARED row (writes via `saveShared`, disabled while
+ * the shared file is git-conflicted) and, inside a "This machine" `<details>`, a LOCAL row for the
+ * same field (writes via `saveLocal`, never disabled — a machine-local override is independent of
+ * the shared file's conflict state) plus one `ignoreShared` Switch per family.
+ *
+ * Split out of `ProjectSettingsSection.tsx` per the Task 4 brief: four families' worth of fields
+ * would have pushed that file well past ~400 lines.
+ */
+
+type FieldKind = 'input' | 'textarea' | 'switch' | 'env' | 'list'
+
+interface FieldConfig {
+  key: string
+  label: string
+  description?: string
+  kind: FieldKind
+}
+
+interface FamilyConfig {
+  title: string
+  fields: FieldConfig[]
+}
+
+const FAMILY_CONFIG: Record<ProjectSettingsFamily, FamilyConfig> = {
+  setup: {
+    title: 'Setup',
+    fields: [
+      {
+        key: 'setupScript',
+        label: 'Setup script',
+        description: 'Runs once when a worktree for this project is created.',
+        kind: 'textarea'
+      },
+      {
+        key: 'archiveScript',
+        label: 'Archive script',
+        description: 'Runs when a worktree for this project is archived.',
+        kind: 'textarea'
+      },
+      {
+        key: 'waitForSetup',
+        label: 'Wait for setup to finish before opening a terminal',
+        kind: 'switch'
+      }
+    ]
+  },
+  agents: {
+    title: 'Agents',
+    fields: [
+      {
+        key: 'defaultAgentId',
+        label: 'Default agent',
+        description: 'Agent id used for new sessions in this project.',
+        kind: 'input'
+      },
+      {
+        key: 'launchCmd',
+        label: 'Launch command',
+        description: 'Overrides how the default agent is launched.',
+        kind: 'input'
+      },
+      {
+        key: 'env',
+        label: 'Environment variables',
+        description: 'KEY=VALUE, one per line.',
+        kind: 'env'
+      }
+    ]
+  },
+  worktree: {
+    title: 'Worktree',
+    fields: [
+      { key: 'basePath', label: 'Base path', kind: 'input' },
+      {
+        key: 'baseRef',
+        label: 'Base ref',
+        description: 'Branch or ref new worktrees are created from.',
+        kind: 'input'
+      },
+      {
+        key: 'sharedPaths',
+        label: 'Shared paths',
+        description: 'One relative path per line, symlinked into every worktree.',
+        kind: 'list'
+      }
+    ]
+  },
+  terminal: {
+    title: 'Terminal',
+    fields: [
+      { key: 'shell', label: 'Shell', kind: 'input' },
+      { key: 'theme', label: 'Theme', kind: 'input' },
+      { key: 'fontFamily', label: 'Font family', kind: 'input' }
+    ]
+  }
+}
+
+const FAMILIES = Object.keys(FAMILY_CONFIG) as ProjectSettingsFamily[]
+
+/** Text a non-env, non-list field shows in its box: the raw string, or '' when unset. */
+function textOf(kind: FieldKind, raw: unknown): string {
+  if (kind === 'list') return formatListLines(raw as string[] | undefined)
+  return typeof raw === 'string' ? raw : ''
+}
+
+/** Text -> value for a non-env field. Blank (or all-whitespace) text clears the field. An `input`
+ *  is trimmed on commit (matches the identity rows' name field); a `textarea` (script bodies)
+ *  keeps its interior whitespace verbatim — only "nothing but whitespace" counts as empty. */
+function valueOf(kind: FieldKind, text: string): unknown {
+  if (kind === 'list') {
+    const items = parseListLines(text)
+    return items.length ? items : undefined
+  }
+  const trimmed = text.trim()
+  if (trimmed === '') return undefined
+  return kind === 'input' ? trimmed : text
+}
+
+function useDraft(value: string): [string, (v: string) => void] {
+  const [draft, setDraft] = useState(value)
+  useEffect(() => setDraft(value), [value])
+  return [draft, setDraft]
+}
+
+function textareaClass(disabled?: boolean): string {
+  return `min-h-20 w-72 rounded-md border border-border bg-bg px-2.5 py-2 text-[13px] text-text outline-none focus:border-accent${disabled ? ' disabled:opacity-50' : ''}`
+}
+
+function StringField({
+  id,
+  label,
+  description,
+  note,
+  multiline,
+  text,
+  disabled,
+  onCommit
+}: {
+  id: string
+  label: string
+  description?: string
+  note?: string
+  multiline: boolean
+  text: string
+  disabled?: boolean
+  onCommit: (text: string) => void
+}): React.JSX.Element {
+  const [draft, setDraft] = useDraft(text)
+  const commit = (): void => {
+    if (draft !== text) onCommit(draft)
+  }
+  return (
+    <FieldRow
+      label={label}
+      description={description}
+      note={note}
+      htmlFor={id}
+      control={
+        multiline ? (
+          <textarea
+            id={id}
+            value={draft}
+            disabled={disabled}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            className={textareaClass(disabled)}
+          />
+        ) : (
+          <Input
+            id={id}
+            className="w-72"
+            value={draft}
+            disabled={disabled}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+          />
+        )
+      }
+    />
+  )
+}
+
+/** `env` gets its own field: unlike every other field, its warn note is a LIVE parse of the
+ *  current draft (rejected lines only exist before a commit — once saved, only the valid pairs
+ *  remain, so there is nothing left to report). Provenance note is shown once the draft has
+ *  nothing to reject. */
+function EnvField({
+  id,
+  label,
+  description,
+  disabled,
+  text,
+  overrideNote,
+  onCommitValue
+}: {
+  id: string
+  label: string
+  description?: string
+  disabled?: boolean
+  text: string
+  overrideNote?: string
+  onCommitValue: (value: Record<string, string> | undefined) => void
+}): React.JSX.Element {
+  const [draft, setDraft] = useDraft(text)
+  const { rejected } = parseEnvLines(draft)
+  const note = rejected.length > 0 ? `Ignored (not KEY=VALUE): ${rejected.join(', ')}` : overrideNote
+  const commit = (): void => {
+    if (draft === text) return
+    const { env } = parseEnvLines(draft)
+    onCommitValue(Object.keys(env).length ? env : undefined)
+  }
+  return (
+    <FieldRow
+      label={label}
+      description={description}
+      note={note}
+      htmlFor={id}
+      control={
+        <textarea
+          id={id}
+          value={draft}
+          disabled={disabled}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          className={textareaClass(disabled)}
+        />
+      }
+    />
+  )
+}
+
+function SwitchField({
+  label,
+  description,
+  note,
+  ariaLabel,
+  checked,
+  disabled,
+  onCommit
+}: {
+  label: string
+  description?: string
+  note?: string
+  ariaLabel: string
+  checked: boolean
+  disabled?: boolean
+  onCommit: (v: boolean) => void
+}): React.JSX.Element {
+  return (
+    <FieldRow
+      label={label}
+      description={description}
+      note={note}
+      control={
+        <Switch checked={checked} ariaLabel={ariaLabel} disabled={disabled} onChange={onCommit} />
+      }
+    />
+  )
+}
+
+/** Merges one family field into the WHOLE local settings object, preserving every other family and
+ *  `ignoreShared` untouched — `saveLocal` replaces the file, so dropping a sibling here would erase
+ *  it from disk. `undefined` clears the field; an emptied family key is dropped, and an entirely
+ *  empty result collapses to `undefined` (clears the local overlay file itself). */
+function nextLocalField(
+  current: ProjectLocalSettings | undefined,
+  family: ProjectSettingsFamily,
+  key: string,
+  value: unknown
+): ProjectLocalSettings | undefined {
+  const out: Record<string, unknown> = { ...current }
+  const familyObj: Record<string, unknown> = {
+    ...((current?.[family] as Record<string, unknown> | undefined) ?? {})
+  }
+  if (value === undefined) delete familyObj[key]
+  else familyObj[key] = value
+  if (Object.keys(familyObj).length === 0) delete out[family]
+  else out[family] = familyObj
+  return Object.keys(out).length === 0 ? undefined : (out as ProjectLocalSettings)
+}
+
+function nextLocalIgnoreShared(
+  current: ProjectLocalSettings | undefined,
+  family: ProjectSettingsFamily,
+  on: boolean
+): ProjectLocalSettings | undefined {
+  const out: Record<string, unknown> = { ...current }
+  const ignore: Record<string, unknown> = { ...(current?.ignoreShared ?? {}) }
+  if (on) ignore[family] = true
+  else delete ignore[family]
+  if (Object.keys(ignore).length === 0) delete out.ignoreShared
+  else out.ignoreShared = ignore
+  return Object.keys(out).length === 0 ? undefined : (out as ProjectLocalSettings)
+}
+
+function FamilySection({
+  projectId,
+  family,
+  sharedFamily,
+  localFamily,
+  ignoreShared,
+  resolvedFamily,
+  conflict,
+  fullLocal,
+  saveShared,
+  saveLocal
+}: {
+  projectId: string
+  family: ProjectSettingsFamily
+  sharedFamily: Record<string, unknown> | undefined
+  localFamily: Record<string, unknown> | undefined
+  ignoreShared: boolean
+  resolvedFamily: Record<string, { source: 'local' | 'shared' } | undefined>
+  conflict: boolean
+  fullLocal: ProjectLocalSettings | undefined
+  saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
+  saveLocal: (local: ProjectLocalSettings | undefined) => Promise<boolean>
+}): React.JSX.Element {
+  const config = FAMILY_CONFIG[family]
+
+  const commitShared = (key: string, value: unknown): void => {
+    void saveShared({ [family]: { [key]: value } } as ProjectSettingsDoc)
+  }
+  const commitLocal = (key: string, value: unknown): void => {
+    void saveLocal(nextLocalField(fullLocal, family, key, value))
+  }
+  const commitIgnoreShared = (on: boolean): void => {
+    void saveLocal(nextLocalIgnoreShared(fullLocal, family, on))
+  }
+
+  const renderShared = (f: FieldConfig): React.JSX.Element => {
+    const overridden = resolvedFamily[f.key]?.source === 'local'
+    const id = `project-${family}-${f.key}-${projectId}`
+    const overrideNote = overridden ? 'Overridden on this machine' : undefined
+    if (f.kind === 'switch') {
+      return (
+        <SwitchField
+          key={f.key}
+          label={f.label}
+          description={f.description}
+          note={overrideNote}
+          ariaLabel={f.label}
+          checked={sharedFamily?.[f.key] === true}
+          disabled={conflict}
+          onCommit={(on) => commitShared(f.key, on ? true : undefined)}
+        />
+      )
+    }
+    if (f.kind === 'env') {
+      return (
+        <EnvField
+          key={f.key}
+          id={id}
+          label={f.label}
+          description={f.description}
+          disabled={conflict}
+          text={formatEnvLines(sharedFamily?.[f.key] as Record<string, string> | undefined)}
+          overrideNote={overrideNote}
+          onCommitValue={(v) => commitShared(f.key, v)}
+        />
+      )
+    }
+    return (
+      <StringField
+        key={f.key}
+        id={id}
+        label={f.label}
+        description={f.description}
+        multiline={f.kind === 'textarea' || f.kind === 'list'}
+        note={overrideNote}
+        disabled={conflict}
+        text={textOf(f.kind, sharedFamily?.[f.key])}
+        onCommit={(text) => commitShared(f.key, valueOf(f.kind, text))}
+      />
+    )
+  }
+
+  const renderLocal = (f: FieldConfig): React.JSX.Element => {
+    const active = resolvedFamily[f.key]?.source === 'local'
+    const id = `project-${family}-${f.key}-local-${projectId}`
+    const activeNote = active ? 'Active' : undefined
+    if (f.kind === 'switch') {
+      return (
+        <SwitchField
+          key={f.key}
+          label={f.label}
+          description={f.description}
+          note={activeNote}
+          ariaLabel={`${f.label} (this machine)`}
+          checked={localFamily?.[f.key] === true}
+          onCommit={(on) => commitLocal(f.key, on ? true : undefined)}
+        />
+      )
+    }
+    if (f.kind === 'env') {
+      return (
+        <EnvField
+          key={f.key}
+          id={id}
+          label={f.label}
+          description={f.description}
+          text={formatEnvLines(localFamily?.[f.key] as Record<string, string> | undefined)}
+          overrideNote={activeNote}
+          onCommitValue={(v) => commitLocal(f.key, v)}
+        />
+      )
+    }
+    return (
+      <StringField
+        key={f.key}
+        id={id}
+        label={f.label}
+        description={f.description}
+        multiline={f.kind === 'textarea' || f.kind === 'list'}
+        note={activeNote}
+        text={textOf(f.kind, localFamily?.[f.key])}
+        onCommit={(text) => commitLocal(f.key, valueOf(f.kind, text))}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-3 border-t border-border pt-4">
+      <h3 className="text-[13px] font-semibold text-text">{config.title}</h3>
+      <div className="space-y-2.5">{config.fields.map(renderShared)}</div>
+      <details>
+        <summary className="cursor-pointer text-[13px] text-muted">This machine</summary>
+        <div className="mt-3 space-y-2.5">
+          <p className="text-[12px] leading-relaxed text-muted">
+            Overrides that apply only on this machine. Never written to the shared file.
+          </p>
+          {config.fields.map(renderLocal)}
+          <SwitchField
+            label={`Ignore shared ${config.title.toLowerCase()} settings`}
+            description="Never use the git-shared values for this family on this machine, even where this machine sets none of its own."
+            ariaLabel={`Ignore shared ${family} settings on this machine`}
+            checked={ignoreShared}
+            onCommit={commitIgnoreShared}
+          />
+        </div>
+      </details>
+    </div>
+  )
+}
+
+export function ProjectFamilyEditors({
+  projectId,
+  snapshot,
+  resolved,
+  conflict,
+  saveShared,
+  saveLocal
+}: {
+  projectId: string
+  snapshot: ProjectSettingsSnapshot | null | 'loading'
+  resolved: ResolvedProjectSettings
+  conflict: boolean
+  saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
+  saveLocal: (local: ProjectLocalSettings | undefined) => Promise<boolean>
+}): React.JSX.Element {
+  const shared: ProjectSettingsDoc = snapshot && snapshot !== 'loading' && snapshot.shared ? snapshot.shared : {}
+  const local: ProjectLocalSettings | undefined = snapshot && snapshot !== 'loading' ? snapshot.local : undefined
+  return (
+    <>
+      {FAMILIES.map((family) => (
+        <FamilySection
+          key={family}
+          projectId={projectId}
+          family={family}
+          sharedFamily={shared[family] as Record<string, unknown> | undefined}
+          localFamily={local?.[family] as Record<string, unknown> | undefined}
+          ignoreShared={local?.ignoreShared?.[family] === true}
+          resolvedFamily={resolved[family] as Record<string, { source: 'local' | 'shared' } | undefined>}
+          conflict={conflict}
+          fullLocal={local}
+          saveShared={saveShared}
+          saveLocal={saveLocal}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/renderer/components/settings/SettingsIcons.tsx
+++ b/src/renderer/components/settings/SettingsIcons.tsx
@@ -1,8 +1,13 @@
 import type { SettingsSectionId } from './nav'
+import { parseProjectSectionId } from './project-settings-targets'
+
+/** The closed part of `SettingsSectionId` — everything except the dynamic `project-${string}`
+ *  ids, which don't get their own icon (see the fallback in `SectionIcon`). */
+type StaticSettingsSectionId = Exclude<SettingsSectionId, `project-${string}`>
 
 /** One small line glyph per settings section, used in the sidebar nav.
  *  16×16, currentColor stroke — color is driven by the parent (active = accent). */
-const PATHS: Record<SettingsSectionId, React.JSX.Element> = {
+const PATHS: Record<StaticSettingsSectionId, React.JSX.Element> = {
   terminal: (
     <>
       <rect x="2" y="3" width="12" height="10" rx="2" />
@@ -137,7 +142,14 @@ const PATHS: Record<SettingsSectionId, React.JSX.Element> = {
   )
 }
 
+// A small folder glyph, used for project sections — those ids are dynamic (one per open
+// project), so there's no per-project entry in `PATHS`.
+const PROJECT_FALLBACK: React.JSX.Element = (
+  <path d="M2.5 4.8A1.3 1.3 0 0 1 3.8 3.5h2.6l1.3 1.5h4.5a1.3 1.3 0 0 1 1.3 1.3v5A1.3 1.3 0 0 1 12.2 12.6H3.8a1.3 1.3 0 0 1-1.3-1.3Z" />
+)
+
 export function SectionIcon({ id }: { id: SettingsSectionId }): React.JSX.Element {
+  const path = parseProjectSectionId(id) !== null ? PROJECT_FALLBACK : PATHS[id as StaticSettingsSectionId]
   return (
     <svg
       width="16"
@@ -150,7 +162,7 @@ export function SectionIcon({ id }: { id: SettingsSectionId }): React.JSX.Elemen
       strokeLinejoin="round"
       aria-hidden="true"
     >
-      {PATHS[id]}
+      {path}
     </svg>
   )
 }

--- a/src/renderer/components/settings/SettingsPage.tsx
+++ b/src/renderer/components/settings/SettingsPage.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { useEntitlement } from '../../state/entitlement'
 import { useProjects } from '../../state/projects'
 import { SettingsSearchContext } from './context'
 import { SettingsSidebar } from './SettingsSidebar'
-import { FIRST_SECTION_ID, projectsSettingsGroup, type SettingsSectionId } from './nav'
+import { projectsSettingsGroup, type SettingsSectionId } from './nav'
 import { projectSectionId } from './project-settings-targets'
+import { useSettingsTarget } from './useSettingsTarget'
 import { ProjectSettingsSection } from './sections/ProjectSettingsSection'
 import { TerminalSection } from './sections/TerminalSection'
 import { ShellSection } from './sections/ShellSection'
@@ -36,15 +37,20 @@ const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 
 export function SettingsPage({
   onClose,
-  initialSection
+  initialSection,
+  retargetNonce
 }: {
   onClose: () => void
   /** Section to open on; lets callers deep-link (e.g. "Add SSH server…" → the SSH section). */
   initialSection?: SettingsSectionId
+  /** Bumped by a caller that deep-links to a section, so a repeat of the SAME `initialSection`
+   *  still re-targets (and clears the search box). Plain opens — the gear, ⌘, , the native menu —
+   *  leave it alone: they must not throw away a query or a section the user chose in the dialog. */
+  retargetNonce?: number
 }): React.JSX.Element {
   const hydrate = useEntitlement((s) => s.hydrate)
-  const [active, setActive] = useState<SettingsSectionId>(initialSection ?? FIRST_SECTION_ID)
-  const [query, setQuery] = useState('')
+  // Which section is shown and what is typed in the search box, plus the deep-link retarget rule.
+  const { active, setActive, query, setQuery } = useSettingsTarget(initialSection, retargetNonce)
 
   // ONE list feeds both the nav rows and the panes below, so a "Projects" row can never point at a
   // section that is not rendered (or vice versa). Memoized: `projects.filter(...)` inside a zustand
@@ -61,11 +67,6 @@ export function SettingsPage({
   useEffect(() => {
     void hydrate()
   }, [hydrate])
-
-  // Re-target when a caller opens settings to a specific section.
-  useEffect(() => {
-    if (initialSection) setActive(initialSection)
-  }, [initialSection])
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/renderer/components/settings/SettingsPage.tsx
+++ b/src/renderer/components/settings/SettingsPage.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useEntitlement } from '../../state/entitlement'
+import { useProjects } from '../../state/projects'
 import { SettingsSearchContext } from './context'
 import { SettingsSidebar } from './SettingsSidebar'
-import { FIRST_SECTION_ID, type SettingsSectionId } from './nav'
+import { FIRST_SECTION_ID, projectsSettingsGroup, type SettingsSectionId } from './nav'
+import { projectSectionId } from './project-settings-targets'
+import { ProjectSettingsSection } from './sections/ProjectSettingsSection'
 import { TerminalSection } from './sections/TerminalSection'
 import { ShellSection } from './sections/ShellSection'
 import { BehaviorSection } from './sections/BehaviorSection'
@@ -43,6 +46,18 @@ export function SettingsPage({
   const [active, setActive] = useState<SettingsSectionId>(initialSection ?? FIRST_SECTION_ID)
   const [query, setQuery] = useState('')
 
+  // ONE list feeds both the nav rows and the panes below, so a "Projects" row can never point at a
+  // section that is not rendered (or vice versa). Memoized: `projects.filter(...)` inside a zustand
+  // selector would return a fresh array on every store snapshot and re-render the whole page.
+  const projects = useProjects((s) => s.projects)
+  const openProjects = useMemo(() => projects.filter((p) => !p.closed), [projects])
+  const extraGroups = useMemo(() => {
+    const group = projectsSettingsGroup(
+      openProjects.map((p) => ({ id: p.id, name: p.name, color: p.color }))
+    )
+    return group ? [group] : []
+  }, [openProjects])
+
   useEffect(() => {
     void hydrate()
   }, [hydrate])
@@ -68,6 +83,7 @@ export function SettingsPage({
         onSelect={setActive}
         onQueryChange={setQuery}
         onClose={onClose}
+        extraGroups={extraGroups}
       />
       <SettingsSearchContext.Provider value={query}>
         <main className="min-w-0 flex-1 overflow-y-auto px-12 py-10">
@@ -96,6 +112,13 @@ export function SettingsPage({
             <UpdatesSection isActive={active === 'updates'} />
             <PrivacySection isActive={active === 'privacy'} />
             <DebugSection isActive={active === 'debug'} />
+            {openProjects.map((p) => (
+              <ProjectSettingsSection
+                key={p.id}
+                projectId={p.id}
+                isActive={active === projectSectionId(p.id)}
+              />
+            ))}
           </div>
         </main>
       </SettingsSearchContext.Provider>

--- a/src/renderer/components/settings/SettingsPage.tsx
+++ b/src/renderer/components/settings/SettingsPage.tsx
@@ -49,14 +49,23 @@ export function SettingsPage({
   retargetNonce?: number
 }): React.JSX.Element {
   const hydrate = useEntitlement((s) => s.hydrate)
-  // Which section is shown and what is typed in the search box, plus the deep-link retarget rule.
-  const { active, setActive, query, setQuery } = useSettingsTarget(initialSection, retargetNonce)
 
   // ONE list feeds both the nav rows and the panes below, so a "Projects" row can never point at a
   // section that is not rendered (or vice versa). Memoized: `projects.filter(...)` inside a zustand
   // selector would return a fresh array on every store snapshot and re-render the whole page.
   const projects = useProjects((s) => s.projects)
   const openProjects = useMemo(() => projects.filter((p) => !p.closed), [projects])
+  // Same list, ids only, with a stable identity — it is an effect dependency in useSettingsTarget.
+  const openProjectIds = useMemo(() => openProjects.map((p) => p.id), [openProjects])
+
+  // Which section is shown and what is typed in the search box, plus the deep-link retarget rule
+  // and the fallback for a project section whose project has since been closed.
+  const { active, setActive, query, setQuery } = useSettingsTarget(
+    initialSection,
+    retargetNonce,
+    openProjectIds
+  )
+
   const extraGroups = useMemo(() => {
     const group = projectsSettingsGroup(
       openProjects.map((p) => ({ id: p.id, name: p.name, color: p.color }))

--- a/src/renderer/components/settings/SettingsSection.test.tsx
+++ b/src/renderer/components/settings/SettingsSection.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SettingsSearchContext } from './context'
+import { SearchableRow } from './SearchableRow'
+import { SettingsSection, sectionVisible } from './SettingsSection'
+import type { SettingsSearchEntry } from './search'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const ENTRIES: SettingsSearchEntry[] = [{ title: 'Default shell', keywords: ['bash'] }]
+
+describe('sectionVisible', () => {
+  it('shows an active section and hides an inactive one when there is no query', () => {
+    expect(sectionVisible('', true, ENTRIES)).toBe(true)
+    expect(sectionVisible('   ', true, ENTRIES)).toBe(true)
+    expect(sectionVisible('', false, ENTRIES)).toBe(false)
+  })
+
+  it('ignores forceVisible when there is no query', () => {
+    // `matchesQuery` answers true for an EMPTY query, so every caller computing forceVisible from
+    // it hands us `true` while the search box is empty. If that forced the pane open, opening
+    // settings would render every project's pane at once (and, for SSH projects, read every one).
+    expect(sectionVisible('', false, ENTRIES, true)).toBe(false)
+  })
+
+  it('shows a section whose entries match the query and hides one whose entries do not', () => {
+    expect(sectionVisible('bash', false, ENTRIES)).toBe(true)
+    expect(sectionVisible('zzz', true, ENTRIES)).toBe(false)
+  })
+
+  it('shows a section with no search entries at all for any query (legacy sections)', () => {
+    expect(sectionVisible('zzz', false, undefined)).toBe(true)
+  })
+
+  it('shows an otherwise non-matching section when forceVisible is set under a query', () => {
+    expect(sectionVisible('zzz', false, ENTRIES, true)).toBe(true)
+  })
+})
+
+describe('SettingsSection', () => {
+  let root: Root
+  let host: HTMLElement
+
+  const mount = async (node: React.JSX.Element, query: string): Promise<void> => {
+    root = createRoot(host)
+    await act(async () => {
+      root.render(<SettingsSearchContext.Provider value={query}>{node}</SettingsSearchContext.Provider>)
+    })
+  }
+
+  const section = (forceVisible?: boolean): React.JSX.Element => (
+    <SettingsSection id="demo" title="Demo" isActive={false} searchEntries={ENTRIES} forceVisible={forceVisible}>
+      <SearchableRow title="Default shell" keywords={['bash']}>
+        <p>shell row</p>
+      </SearchableRow>
+      <SearchableRow title="Something else" keywords={['other']}>
+        <p>other row</p>
+      </SearchableRow>
+    </SettingsSection>
+  )
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it('filters rows to the matching one on an ordinary query', async () => {
+    await mount(section(), 'bash')
+    expect(host.textContent).toContain('shell row')
+    expect(host.textContent).not.toContain('other row')
+  })
+
+  it('renders the WHOLE section (rows unfiltered) when forceVisible is set', async () => {
+    // forceVisible means "this query named the section itself" — navigation, not filtering, so
+    // its rows must not be individually filtered by a query that matches none of them.
+    await mount(section(true), 'zzz')
+    expect(host.textContent).toContain('shell row')
+    expect(host.textContent).toContain('other row')
+  })
+
+  it('renders nothing when neither active, matched, nor forced', async () => {
+    await mount(section(false), 'zzz')
+    expect(host.textContent).toBe('')
+  })
+})

--- a/src/renderer/components/settings/SettingsSection.tsx
+++ b/src/renderer/components/settings/SettingsSection.tsx
@@ -1,6 +1,28 @@
 import type React from 'react'
-import { useSettingsSearch } from './context'
+import { SettingsSearchContext, useSettingsSearch } from './context'
 import { matchesQuery, type SettingsSearchEntry } from './search'
+
+/**
+ * THE section-visibility predicate. Every gate in the settings dialog calls this one function:
+ * `SettingsSection` itself, and `ProjectSettingsSection`'s outer gate (which must decide the same
+ * thing one level earlier, so an invisible pane never mounts its settings-reading hook — an SSH
+ * read is a network round-trip). Two hand-written copies of this rule drifting apart shows up as a
+ * nav row pointing at a blank pane, so they share the implementation instead.
+ *
+ * `forceVisible` is honored ONLY under a non-empty query: callers compute it with `matchesQuery`,
+ * which answers `true` for an empty query, so treating it as authoritative while the search box is
+ * empty would render (and read) every project's pane the moment settings opens.
+ */
+export function sectionVisible(
+  query: string,
+  isActive: boolean,
+  searchEntries: SettingsSearchEntry[] | undefined,
+  forceVisible?: boolean
+): boolean {
+  if (query.trim() === '') return isActive
+  if (forceVisible) return true
+  return !searchEntries || searchEntries.some((e) => matchesQuery(query, e))
+}
 
 /** Section shell: header + card body. Renders only when it is the active section
  *  (no query) or when at least one of its searchEntries matches (query present). */
@@ -10,6 +32,7 @@ export function SettingsSection({
   description,
   isActive,
   searchEntries,
+  forceVisible,
   children
 }: {
   id: string
@@ -17,18 +40,18 @@ export function SettingsSection({
   description?: string
   isActive: boolean
   searchEntries?: SettingsSearchEntry[]
+  /** "This query named the SECTION, not a field in it" — set by a project pane when the query
+   *  matches the project's own name. The section then renders whole: its rows are shown
+   *  unfiltered (see the cleared search context below), because naming a section is navigation,
+   *  not filtering, and a name query matches none of the individual rows. */
+  forceVisible?: boolean
   children: React.ReactNode
 }): React.JSX.Element | null {
   const query = useSettingsSearch()
-  const hasQuery = query.trim() !== ''
-  if (hasQuery) {
-    const anyMatch = !searchEntries || searchEntries.some((e) => matchesQuery(query, e))
-    if (!anyMatch) {
-      return null
-    }
-  } else if (!isActive) {
-    return null
-  }
+  if (!sectionVisible(query, isActive, searchEntries, forceVisible)) return null
+  // Children see an EMPTY query when this section was forced open, so every `SearchableRow` (and
+  // every other query-reading descendant) renders. Identical to `query` otherwise.
+  const childQuery = forceVisible ? '' : query
   return (
     <section id={id} data-settings-section={id} className="space-y-6">
       <div className="border-b border-border pb-5">
@@ -38,7 +61,7 @@ export function SettingsSection({
         ) : null}
       </div>
       <div className="divide-y divide-border/60 rounded-2xl border border-border bg-white/[0.02] px-6 shadow-sm [&>*]:py-5">
-        {children}
+        <SettingsSearchContext.Provider value={childQuery}>{children}</SettingsSearchContext.Provider>
       </div>
     </section>
   )

--- a/src/renderer/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/components/settings/SettingsSidebar.tsx
@@ -1,26 +1,35 @@
+import { useMemo } from 'react'
 import { cn } from '@renderer/ui/cn'
 import { Input } from '@renderer/ui/Input'
-import { visibleSettingsGroups, type SettingsSectionId } from './nav'
-
-const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
-const GROUPS = visibleSettingsGroups(isMac)
+import { visibleSettingsGroups, type SettingsGroup, type SettingsSectionId } from './nav'
 import { matchesQuery } from './search'
 import { SectionIcon } from './SettingsIcons'
+
+const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 
 export function SettingsSidebar({
   activeSectionId,
   query,
   onSelect,
   onQueryChange,
-  onClose
+  onClose,
+  extraGroups
 }: {
   activeSectionId: SettingsSectionId
   query: string
   onSelect: (id: SettingsSectionId) => void
   onQueryChange: (q: string) => void
   onClose: () => void
+  /** Groups appended after the static nav — e.g. the render-time "Projects" group, which the
+   *  caller builds from live project state (kept out of the sidebar so it needs no store
+   *  subscription of its own). */
+  extraGroups?: SettingsGroup[]
 }): React.JSX.Element {
   const hasQuery = query.trim() !== ''
+  const GROUPS = useMemo(
+    () => [...visibleSettingsGroups(isMac), ...(extraGroups ?? [])],
+    [extraGroups]
+  )
   return (
     <aside className="flex w-[256px] shrink-0 flex-col border-r border-border bg-panel">
       <div

--- a/src/renderer/components/settings/nav.test.ts
+++ b/src/renderer/components/settings/nav.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { SETTINGS_GROUPS, allSectionIds, FIRST_SECTION_ID, visibleSettingsGroups } from './nav'
+import { SETTINGS_GROUPS, allSectionIds, FIRST_SECTION_ID, visibleSettingsGroups, projectsSettingsGroup } from './nav'
 
 describe('SETTINGS_GROUPS', () => {
   it('lists exactly 24 sections with no duplicates', () => {
@@ -17,5 +17,13 @@ describe('SETTINGS_GROUPS', () => {
     expect(visibleSettingsGroups(true)).toEqual(SETTINGS_GROUPS)
     // No group is left empty by the filter.
     expect(visibleSettingsGroups(false).every((g) => g.sections.length > 0)).toBe(true)
+  })
+})
+
+describe('projectsSettingsGroup', () => {
+  it('derives one row per project and returns null when empty', () => {
+    const g = projectsSettingsGroup([{ id: 'p1', name: 'Alpha', color: '#fff' }])
+    expect(g?.sections).toEqual([{ id: 'project-p1', title: 'Alpha' }])
+    expect(projectsSettingsGroup([])).toBeNull()
   })
 })

--- a/src/renderer/components/settings/nav.ts
+++ b/src/renderer/components/settings/nav.ts
@@ -1,3 +1,5 @@
+import { projectSectionId } from './project-settings-targets'
+
 export type SettingsSectionId =
   | 'terminal'
   | 'shell'
@@ -23,6 +25,13 @@ export type SettingsSectionId =
   | 'updates'
   | 'privacy'
   | 'debug'
+  | `project-${string}`
+
+export interface ProjectNavItem {
+  id: string
+  name: string
+  color: string
+}
 
 export interface SettingsSectionRef {
   id: SettingsSectionId
@@ -112,4 +121,19 @@ export function visibleSettingsGroups(isMac: boolean): SettingsGroup[] {
   return SETTINGS_GROUPS.map((g) => ({ ...g, sections: g.sections.filter((s) => !s.macOnly) })).filter(
     (g) => g.sections.length > 0
   )
+}
+
+/**
+ * Render-time only — deliberately NOT part of `SETTINGS_GROUPS`. Open projects change at
+ * runtime, so this builds a group from the current project list on every render instead of
+ * baking project ids into the static nav (which would break the `nav.test.ts` section-count
+ * pins). Returns null when there are no open projects, so callers can skip rendering the group.
+ */
+export function projectsSettingsGroup(projects: ProjectNavItem[]): SettingsGroup | null {
+  if (projects.length === 0) return null
+  return {
+    id: 'projects',
+    title: 'Projects',
+    sections: projects.map((p) => ({ id: projectSectionId(p.id), title: p.name }))
+  }
 }

--- a/src/renderer/components/settings/project-settings-env.test.ts
+++ b/src/renderer/components/settings/project-settings-env.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { formatEnvLines, formatListLines, parseEnvLines, parseListLines } from './project-settings-env'
+
+describe('parseEnvLines / formatEnvLines', () => {
+  it('parses KEY=VALUE lines, reports rejects, round-trips', () => {
+    const r = parseEnvLines('FOO=bar\nbad key=1\n\nBAZ=a=b')
+    expect(r.env).toEqual({ FOO: 'bar', BAZ: 'a=b' })
+    expect(r.rejected).toEqual(['bad key=1'])
+    expect(parseEnvLines(formatEnvLines(r.env)).env).toEqual(r.env)
+  })
+
+  it('rejects a line with no "=" and a __proto__ key, keeping the rest', () => {
+    const r = parseEnvLines('nope\n__proto__=x\nFOO=1')
+    expect(r.env).toEqual({ FOO: '1' })
+    expect(r.rejected).toEqual(['nope', '__proto__=x'])
+  })
+
+  it('rejects a key with invalid characters (mirrors the shared sanitizer)', () => {
+    const r = parseEnvLines('1BAD=x\nGOOD_1=y')
+    expect(r.env).toEqual({ GOOD_1: 'y' })
+    expect(r.rejected).toEqual(['1BAD=x'])
+  })
+
+  it('is CRLF-aware and skips blank lines', () => {
+    const r = parseEnvLines('A=1\r\n\r\nB=2\r\n')
+    expect(r.env).toEqual({ A: '1', B: '2' })
+    expect(r.rejected).toEqual([])
+  })
+
+  it('formats an env object as sorted KEY=VALUE lines, and undefined as empty', () => {
+    expect(formatEnvLines({ B: '2', A: '1' })).toBe('A=1\nB=2')
+    expect(formatEnvLines(undefined)).toBe('')
+    expect(formatEnvLines({})).toBe('')
+  })
+})
+
+describe('parseListLines / formatListLines', () => {
+  it('trims each line and drops empties', () => {
+    expect(parseListLines(' a \n\nb\r\nc \n  \n')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('formats items one per line, and undefined as empty', () => {
+    expect(formatListLines(['a', 'b'])).toBe('a\nb')
+    expect(formatListLines(undefined)).toBe('')
+    expect(formatListLines([])).toBe('')
+  })
+})

--- a/src/renderer/components/settings/project-settings-env.ts
+++ b/src/renderer/components/settings/project-settings-env.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure line-based text codecs for the `env` / `sharedPaths` textareas in the project settings
+ * family editors (Task 4). These mirror the shared sanitizer's rules for the same fields
+ * (`src/shared/project-settings.ts`: `ENV_KEY_RE`, the explicit `__proto__` rejection) but exist
+ * for a different reason: the sanitizer must never throw on hostile git-shared input, so it
+ * silently DROPS anything it does not recognize. That is wrong for an editor — a user who typed
+ * `bad key=1` needs to see that the line was ignored, not just watch it vanish on save. So this
+ * codec REPORTS every rejected line back to the caller; the UI turns that into a warn note.
+ */
+
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/** Splits on any line ending (CRLF, CR, or LF) so a file edited on Windows round-trips cleanly. */
+function splitLines(text: string): string[] {
+  return text.split(/\r\n|\r|\n/)
+}
+
+export function parseEnvLines(text: string): { env: Record<string, string>; rejected: string[] } {
+  const env: Record<string, string> = {}
+  const rejected: string[] = []
+  for (const rawLine of splitLines(text)) {
+    const line = rawLine.trim()
+    if (line === '') continue
+    const eq = line.indexOf('=')
+    if (eq <= 0) {
+      rejected.push(line)
+      continue
+    }
+    const key = line.slice(0, eq).trim()
+    const value = line.slice(eq + 1)
+    // `__proto__` matches ENV_KEY_RE lexically but must never become a real own key — same
+    // exclusion as `sanitizeEnv` in the shared module, for the same reason.
+    if (key === '__proto__' || !ENV_KEY_RE.test(key)) {
+      rejected.push(line)
+      continue
+    }
+    env[key] = value
+  }
+  return { env, rejected }
+}
+
+export function formatEnvLines(env: Record<string, string> | undefined): string {
+  if (!env) return ''
+  return Object.keys(env)
+    .sort()
+    .map((k) => `${k}=${env[k]}`)
+    .join('\n')
+}
+
+/** Trims each line and drops empties. Anything else (traversal segments, absolute paths, caps,
+ *  duplicates) is the shared sanitizer's job — this codec only turns text into candidate strings. */
+export function parseListLines(text: string): string[] {
+  return splitLines(text)
+    .map((l) => l.trim())
+    .filter((l) => l !== '')
+}
+
+export function formatListLines(items: string[] | undefined): string {
+  if (!items || items.length === 0) return ''
+  return items.join('\n')
+}

--- a/src/renderer/components/settings/project-settings-targets.test.ts
+++ b/src/renderer/components/settings/project-settings-targets.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { projectSectionId, parseProjectSectionId } from './project-settings-targets'
+
+describe('project section ids', () => {
+  it('round-trips and rejects non-project ids', () => {
+    expect(parseProjectSectionId(projectSectionId('abc-123'))).toBe('abc-123')
+    expect(parseProjectSectionId('terminal')).toBeNull()
+    expect(parseProjectSectionId('project-')).toBeNull()
+  })
+})

--- a/src/renderer/components/settings/project-settings-targets.ts
+++ b/src/renderer/components/settings/project-settings-targets.ts
@@ -1,0 +1,15 @@
+import type { SettingsSectionId } from './nav'
+
+const PROJECT_SECTION_PREFIX = 'project-'
+
+/** Builds the dynamic settings section id for a project. */
+export function projectSectionId(projectId: string): SettingsSectionId {
+  return `${PROJECT_SECTION_PREFIX}${projectId}` as SettingsSectionId
+}
+
+/** Inverse of {@link projectSectionId}. Returns null for non-project ids and for an empty project id. */
+export function parseProjectSectionId(id: string): string | null {
+  if (!id.startsWith(PROJECT_SECTION_PREFIX)) return null
+  const projectId = id.slice(PROJECT_SECTION_PREFIX.length)
+  return projectId === '' ? null : projectId
+}

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
@@ -320,6 +320,67 @@ describe('ProjectSettingsSection', () => {
     await blur(env)
     expect(writeShared).toHaveBeenCalledWith('p1', { agents: { env: { A: '1', B: '2' } } })
   })
+
+  // --- Task 5: search integration ------------------------------------------------------------
+
+  const pane = (): HTMLElement | null => host.querySelector('[data-settings-section="project-p1"]')
+
+  it('renders the WHOLE pane, rows and families included, when the query is the project name', async () => {
+    // Searching a project by NAME is navigation: it names the pane, not a field inside it, so
+    // every row renders instead of the pane collapsing to the (zero) rows that match "Alpha".
+    await mountSection(project(), { isActive: false, query: 'Alpha' })
+    expect(pane()).not.toBeNull()
+    expect(nameInput()).not.toBeNull()
+    expect(host.querySelector('#project-permission-mode-p1')).not.toBeNull()
+    expect(host.querySelector('#project-terminal-shell-p1')).not.toBeNull()
+    expect(host.querySelector('#project-setup-setupScript-p1')).not.toBeNull()
+    expect(host.querySelector('#project-worktree-basePath-local-p1')).not.toBeNull()
+  })
+
+  it('filters to the matching identity row on a field-term query', async () => {
+    await mountSection(project(), { isActive: false, query: 'approval' })
+    expect(pane()).not.toBeNull()
+    expect(host.querySelector('#project-permission-mode-p1')).not.toBeNull()
+    expect(host.querySelector('#project-name-p1')).toBeNull()
+    expect(host.querySelector('#project-terminal-shell-p1')).toBeNull()
+  })
+
+  it('filters to the matching family on a family-term query', async () => {
+    await mountSection(project(), { isActive: false, query: 'worktree' })
+    expect(pane()).not.toBeNull()
+    expect(host.querySelector('#project-worktree-basePath-p1')).not.toBeNull()
+    expect(host.querySelector('#project-terminal-shell-p1')).toBeNull()
+    expect(host.querySelector('#project-name-p1')).toBeNull()
+  })
+
+  it('renders nothing (and reads nothing) for a query matching neither the name nor any row', async () => {
+    await mountSection(project(), { isActive: false, query: 'zzzznomatch' })
+    expect(host.textContent).toBe('')
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('keeps the two visibility gates in agreement: no pane is ever mounted without being shown', async () => {
+    // The outer gate in ProjectSettingsSection duplicates SettingsSection's predicate (so an
+    // invisible SSH pane never mounts the reading hook). If the two ever disagree, one of these
+    // two symptoms appears: a read fired for a pane that renders nothing (outer open, inner shut),
+    // or a nav row pointing at a pane that renders nothing.
+    for (const [query, isActive] of [
+      ['', true],
+      ['', false],
+      ['Alpha', false],
+      ['approval', false],
+      ['worktree', false],
+      ['zzzznomatch', true]
+    ] as [string, boolean][]) {
+      read.mockClear()
+      await mountSection(project(), { isActive, query })
+      const shown = pane() !== null
+      expect({ query, mounted: read.mock.calls.length > 0 }).toEqual({ query, mounted: shown })
+      act(() => root.unmount())
+    }
+    // afterEach unmounts once more; give it a live root.
+    await mountSection()
+  })
 })
 
 describe('useProjectSettings', () => {

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
@@ -186,6 +186,77 @@ describe('ProjectSettingsSection', () => {
     expect(host.textContent).toContain('Alpha')
     expect(read).toHaveBeenCalledWith('p1')
   })
+
+  // --- Task 4: family editors --------------------------------------------------------------
+
+  const typeIntoTextarea = async (el: HTMLTextAreaElement, value: string): Promise<void> => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!
+      setter.call(el, value)
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  const click = async (el: HTMLElement): Promise<void> => {
+    await act(async () => {
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+  }
+
+  it('commits a local override row via saveLocal, carrying only that family/field', async () => {
+    await mountSection()
+    const local = host.querySelector<HTMLInputElement>('#project-terminal-shell-local-p1')!
+    await typeInto(local, '/bin/zsh')
+    await blur(local)
+    expect(updateLocal).toHaveBeenCalledWith('p1', { terminal: { shell: '/bin/zsh' } })
+  })
+
+  it('toggles a family ignoreShared Switch via saveLocal, merged with any existing local doc', async () => {
+    await mountSection()
+    const toggle = host.querySelector<HTMLButtonElement>(
+      '[aria-label="Ignore shared setup settings on this machine"]'
+    )!
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+    await click(toggle)
+    expect(updateLocal).toHaveBeenCalledWith('p1', { ignoreShared: { setup: true } })
+  })
+
+  it('flips the shared row\'s provenance note to "Overridden on this machine" when a local value wins', async () => {
+    read = vi.fn(async () => ({
+      shared: { version: 1, rev: 1, savedAt: 't', terminal: { shell: '/bin/bash' } },
+      local: { terminal: { shell: '/bin/zsh' } }
+    }))
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.projectSettings.read = read
+    await mountSection()
+    expect(host.textContent).toContain('Overridden on this machine')
+    expect(host.textContent).toContain('Active')
+    const shared = host.querySelector<HTMLInputElement>('#project-terminal-shell-p1')!
+    const local = host.querySelector<HTMLInputElement>('#project-terminal-shell-local-p1')!
+    expect(shared.value).toBe('/bin/bash')
+    expect(local.value).toBe('/bin/zsh')
+  })
+
+  it('surfaces a rejected env line in the warn note as the draft is typed', async () => {
+    await mountSection()
+    const env = host.querySelector<HTMLTextAreaElement>('#project-agents-env-p1')!
+    await typeIntoTextarea(env, 'bad key=1')
+    expect(host.textContent).toContain('bad key=1')
+    expect(host.textContent).toContain('Ignored')
+  })
+
+  it('does not disable the local editor or ignoreShared switch while the shared file is conflicted', async () => {
+    read = vi.fn(async () => ({ shared: null, local: undefined, conflict: true }) as ProjectSettingsSnapshot)
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.projectSettings.read = read
+    await mountSection()
+    const sharedShell = host.querySelector<HTMLInputElement>('#project-terminal-shell-p1')!
+    const localShell = host.querySelector<HTMLInputElement>('#project-terminal-shell-local-p1')!
+    const toggle = host.querySelector<HTMLButtonElement>(
+      '[aria-label="Ignore shared setup settings on this machine"]'
+    )!
+    expect(sharedShell.disabled).toBe(true)
+    expect(localShell.disabled).toBe(false)
+    expect(toggle.disabled).toBe(false)
+  })
 })
 
 describe('useProjectSettings', () => {

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
@@ -1,0 +1,312 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Project } from '@shared/types'
+import type { ProjectSettingsSnapshot } from '@shared/project-settings'
+import { useProjects } from '../../../state/projects'
+import { SettingsSearchContext } from '../context'
+import { ProjectSettingsSection } from './ProjectSettingsSection'
+import { useProjectSettings, type ProjectSettingsHook } from '../useProjectSettings'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function project(over: Partial<Project> = {}): Project {
+  return {
+    id: 'p1',
+    name: 'Alpha',
+    color: '#0a84ff',
+    cwd: '/repo/alpha',
+    viewport: { x: 0, y: 0, zoom: 1 },
+    nodes: [],
+    ...over
+  }
+}
+
+const EMPTY_SNAPSHOT: ProjectSettingsSnapshot = { shared: null, local: undefined }
+
+describe('ProjectSettingsSection', () => {
+  let root: Root
+  let host: HTMLElement
+  let read: ReturnType<typeof vi.fn>
+  let writeShared: ReturnType<typeof vi.fn>
+  let updateLocal: ReturnType<typeof vi.fn>
+  let save: ReturnType<typeof vi.fn>
+
+  const mount = async (node: React.JSX.Element, query = ''): Promise<void> => {
+    root = createRoot(host)
+    await act(async () => {
+      root.render(<SettingsSearchContext.Provider value={query}>{node}</SettingsSearchContext.Provider>)
+    })
+  }
+
+  const mountSection = async (
+    p: Project = project(),
+    { isActive = true, query = '' }: { isActive?: boolean; query?: string } = {}
+  ): Promise<void> => {
+    useProjects.setState({ projects: [p], activeProjectId: p.id })
+    await mount(<ProjectSettingsSection projectId={p.id} isActive={isActive} />, query)
+  }
+
+  const typeInto = async (el: HTMLInputElement, value: string): Promise<void> => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(el, value)
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  const nameInput = (): HTMLInputElement => host.querySelector<HTMLInputElement>('#project-name-p1')!
+
+  /** A real blur fires `focusout`, which is what React's `onBlur` listens for. */
+  const blur = async (el: HTMLElement): Promise<void> => {
+    await act(async () => {
+      el.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    })
+  }
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    read = vi.fn(async () => EMPTY_SNAPSHOT)
+    writeShared = vi.fn(async () => true)
+    updateLocal = vi.fn(async () => true)
+    save = vi.fn(async () => undefined)
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
+      projectSettings: { read, writeShared, updateLocal },
+      workspace: { save }
+    }
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    useProjects.setState({ projects: [], activeProjectId: '' })
+  })
+
+  it('titles the section with the project and shows its folder', async () => {
+    await mountSection()
+    expect(host.textContent).toContain('Alpha')
+    expect(host.textContent).toContain('/repo/alpha')
+    expect(nameInput().value).toBe('Alpha')
+    expect(read).toHaveBeenCalledWith('p1')
+  })
+
+  it('shows an SSH project as user@host:path', async () => {
+    await mountSection(
+      project({ ssh: { server: { host: 'box', user: 'enes' } as never, remoteCwd: '/srv/app' } })
+    )
+    expect(host.textContent).toContain('enes@box:/srv/app')
+  })
+
+  it('renames the project on BLUR only, then saves the workspace', async () => {
+    await mountSection()
+    await typeInto(nameInput(), 'Beta')
+    // Still un-renamed while typing: each save is a disk write, so the commit waits for blur.
+    expect(useProjects.getState().getProject('p1')?.name).toBe('Alpha')
+    expect(save).not.toHaveBeenCalled()
+    await blur(nameInput())
+    expect(useProjects.getState().getProject('p1')?.name).toBe('Beta')
+    expect(save).toHaveBeenCalledTimes(1)
+    expect(save.mock.calls[0][0].projects[0].name).toBe('Beta')
+  })
+
+  it('ignores a blank rename instead of writing an unnamed project', async () => {
+    await mountSection()
+    await typeInto(nameInput(), '   ')
+    await blur(nameInput())
+    expect(useProjects.getState().getProject('p1')?.name).toBe('Alpha')
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('picks a color and persists it', async () => {
+    await mountSection()
+    const swatch = host.querySelector<HTMLButtonElement>('button[data-project-color="#32d74b"]')!
+    await act(async () => {
+      swatch.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(useProjects.getState().getProject('p1')?.color).toBe('#32d74b')
+    expect(save).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets the default permission mode and clears it back to the global default', async () => {
+    await mountSection()
+    const select = host.querySelector<HTMLSelectElement>('#project-permission-mode-p1')!
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')!.set!
+      setter.call(select, 'plan')
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(useProjects.getState().getProject('p1')?.defaultPermissionMode).toBe('plan')
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')!.set!
+      setter.call(select, '')
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(useProjects.getState().getProject('p1')?.defaultPermissionMode).toBeUndefined()
+    expect(save).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows the conflict banner when the shared file is git-conflicted', async () => {
+    read = vi.fn(async () => ({ shared: null, local: undefined, conflict: true }) as ProjectSettingsSnapshot)
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.projectSettings.read = read
+    await mountSection()
+    expect(host.textContent).toContain('conflict')
+    expect(host.textContent).toContain('.nodeterm/settings.json')
+  })
+
+  it('offers no editors at all for a relay (remote) project', async () => {
+    await mountSection(project({ remote: true }))
+    expect(host.textContent).toContain('Alpha')
+    expect(host.querySelectorAll('input, select, textarea, button')).toHaveLength(0)
+    // A relay tab's project settings live on the OTHER machine — never read ours for it.
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('offers no editors for an unavailable project', async () => {
+    await mountSection(project({ unavailable: true }))
+    expect(host.querySelectorAll('input, select, textarea, button')).toHaveLength(0)
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('reads nothing for a section that is neither active nor matched by the search', async () => {
+    await mountSection(project(), { isActive: false })
+    expect(host.textContent).toBe('')
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('renders (and reads) when a search query matches the project name', async () => {
+    await mountSection(project(), { isActive: false, query: 'alph' })
+    expect(host.textContent).toContain('Alpha')
+    expect(read).toHaveBeenCalledWith('p1')
+  })
+})
+
+describe('useProjectSettings', () => {
+  let root: Root
+  let host: HTMLElement
+  let hook: ProjectSettingsHook
+  let read: ReturnType<typeof vi.fn>
+  let writeShared: ReturnType<typeof vi.fn>
+  let updateLocal: ReturnType<typeof vi.fn>
+
+  function Probe({ projectId }: { projectId: string }): React.JSX.Element {
+    hook = useProjectSettings(projectId)
+    return <div>{hook.snapshot === 'loading' ? 'loading' : JSON.stringify(hook.resolved)}</div>
+  }
+
+  const mount = async (): Promise<void> => {
+    root = createRoot(host)
+    await act(async () => {
+      root.render(<Probe projectId="p1" />)
+    })
+  }
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    read = vi.fn(async () => ({
+      shared: { version: 1, rev: 3, savedAt: 't', terminal: { shell: '/bin/bash', theme: 'dark' } },
+      local: undefined
+    }))
+    writeShared = vi.fn(async () => true)
+    updateLocal = vi.fn(async () => true)
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
+      projectSettings: { read, writeShared, updateLocal },
+      workspace: { save: vi.fn() }
+    }
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it('resolves local over shared with provenance', async () => {
+    read.mockResolvedValue({
+      shared: { version: 1, rev: 3, savedAt: 't', terminal: { shell: '/bin/bash', theme: 'dark' } },
+      local: { terminal: { theme: 'light' } }
+    })
+    await mount()
+    expect(hook.resolved.terminal.shell).toEqual({ value: '/bin/bash', source: 'shared' })
+    expect(hook.resolved.terminal.theme).toEqual({ value: 'light', source: 'local' })
+  })
+
+  it('reports empty families while the read is still in flight', async () => {
+    let release: (v: ProjectSettingsSnapshot) => void = () => {}
+    read.mockReturnValue(new Promise<ProjectSettingsSnapshot>((r) => (release = r)))
+    root = createRoot(host)
+    act(() => {
+      root.render(<Probe projectId="p1" />)
+    })
+    expect(hook.snapshot).toBe('loading')
+    expect(hook.resolved).toEqual({ setup: {}, worktree: {}, agents: {}, terminal: {} })
+    await act(async () => {
+      release(EMPTY_SNAPSHOT)
+    })
+  })
+
+  it('writes the WHOLE document (merging the edited field) and re-reads after a save', async () => {
+    await mount()
+    expect(read).toHaveBeenCalledTimes(1)
+    let ok = false
+    await act(async () => {
+      ok = await hook.saveShared({ terminal: { shell: '/bin/fish' } })
+    })
+    expect(ok).toBe(true)
+    // The sibling field survives, and version/rev/savedAt are stripped — the store owns those.
+    expect(writeShared).toHaveBeenCalledTimes(1)
+    expect(writeShared).toHaveBeenCalledWith('p1', { terminal: { shell: '/bin/fish', theme: 'dark' } })
+    expect(read).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops a field cleared to undefined, and the family with it', async () => {
+    read.mockResolvedValue({
+      shared: { version: 1, rev: 1, savedAt: 't', terminal: { shell: '/bin/bash' } },
+      local: undefined
+    })
+    await mount()
+    await act(async () => {
+      await hook.saveShared({ terminal: { shell: undefined } })
+    })
+    expect(writeShared).toHaveBeenCalledWith('p1', {})
+  })
+
+  it('does not re-read when the write is refused', async () => {
+    writeShared.mockResolvedValue(false)
+    await mount()
+    let ok = true
+    await act(async () => {
+      ok = await hook.saveShared({ terminal: { shell: '/bin/fish' } })
+    })
+    expect(ok).toBe(false)
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the local overlay through whole and re-reads', async () => {
+    await mount()
+    await act(async () => {
+      await hook.saveLocal({ terminal: { shell: '/bin/zsh' }, ignoreShared: { agents: true } })
+    })
+    expect(updateLocal).toHaveBeenCalledWith('p1', {
+      terminal: { shell: '/bin/zsh' },
+      ignoreShared: { agents: true }
+    })
+    expect(read).toHaveBeenCalledTimes(2)
+  })
+
+  it('degrades a failed read to "nothing readable" instead of throwing', async () => {
+    read.mockRejectedValue(new Error('boom'))
+    await mount()
+    expect(hook.snapshot).toBeNull()
+    expect(hook.resolved.terminal.shell).toBeUndefined()
+  })
+
+  it('re-reads on reload()', async () => {
+    await mount()
+    await act(async () => {
+      hook.reload()
+    })
+    expect(read).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Project } from '@shared/types'
 import type { ProjectSettingsSnapshot } from '@shared/project-settings'
 import { useProjects } from '../../../state/projects'
+import { registerWorkspaceDirty } from '../../../state/workspaceDirty'
 import { SettingsSearchContext } from '../context'
 import { ProjectSettingsSection } from './ProjectSettingsSection'
 import { useProjectSettings, type ProjectSettingsHook } from '../useProjectSettings'
@@ -31,7 +32,9 @@ describe('ProjectSettingsSection', () => {
   let read: ReturnType<typeof vi.fn>
   let writeShared: ReturnType<typeof vi.fn>
   let updateLocal: ReturnType<typeof vi.fn>
-  let save: ReturnType<typeof vi.fn>
+  /** Canvas's `markDirty`, registered through the same seam the app uses. */
+  let dirty: ReturnType<typeof vi.fn<() => void>>
+  let unregisterDirty: () => void
 
   const mount = async (node: React.JSX.Element, query = ''): Promise<void> => {
     root = createRoot(host)
@@ -71,16 +74,18 @@ describe('ProjectSettingsSection', () => {
     read = vi.fn(async () => EMPTY_SNAPSHOT)
     writeShared = vi.fn(async () => true)
     updateLocal = vi.fn(async () => true)
-    save = vi.fn(async () => undefined)
+    dirty = vi.fn<() => void>()
+    unregisterDirty = registerWorkspaceDirty(dirty)
     ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
       projectSettings: { read, writeShared, updateLocal },
-      workspace: { save }
+      workspace: { save: vi.fn() }
     }
   })
 
   afterEach(() => {
     act(() => root.unmount())
     host.remove()
+    unregisterDirty()
     useProjects.setState({ projects: [], activeProjectId: '' })
   })
 
@@ -99,16 +104,17 @@ describe('ProjectSettingsSection', () => {
     expect(host.textContent).toContain('enes@box:/srv/app')
   })
 
-  it('renames the project on BLUR only, then saves the workspace', async () => {
+  it('renames the project on BLUR only, then rings the workspace-save seam', async () => {
     await mountSection()
     await typeInto(nameInput(), 'Beta')
     // Still un-renamed while typing: each save is a disk write, so the commit waits for blur.
     expect(useProjects.getState().getProject('p1')?.name).toBe('Alpha')
-    expect(save).not.toHaveBeenCalled()
+    expect(dirty).not.toHaveBeenCalled()
     await blur(nameInput())
     expect(useProjects.getState().getProject('p1')?.name).toBe('Beta')
-    expect(save).toHaveBeenCalledTimes(1)
-    expect(save.mock.calls[0][0].projects[0].name).toBe('Beta')
+    // The seam (state/workspaceDirty) rings Canvas's markDirty, so the write inherits the canvas
+    // commit and the conflict gate; a raw workspace.save from here would bypass both.
+    expect(dirty).toHaveBeenCalledTimes(1)
   })
 
   it('ignores a blank rename instead of writing an unnamed project', async () => {
@@ -116,7 +122,7 @@ describe('ProjectSettingsSection', () => {
     await typeInto(nameInput(), '   ')
     await blur(nameInput())
     expect(useProjects.getState().getProject('p1')?.name).toBe('Alpha')
-    expect(save).not.toHaveBeenCalled()
+    expect(dirty).not.toHaveBeenCalled()
   })
 
   it('picks a color and persists it', async () => {
@@ -126,7 +132,7 @@ describe('ProjectSettingsSection', () => {
       swatch.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(useProjects.getState().getProject('p1')?.color).toBe('#32d74b')
-    expect(save).toHaveBeenCalledTimes(1)
+    expect(dirty).toHaveBeenCalledTimes(1)
   })
 
   it('sets the default permission mode and clears it back to the global default', async () => {
@@ -144,7 +150,7 @@ describe('ProjectSettingsSection', () => {
       select.dispatchEvent(new Event('change', { bubbles: true }))
     })
     expect(useProjects.getState().getProject('p1')?.defaultPermissionMode).toBeUndefined()
-    expect(save).toHaveBeenCalledTimes(2)
+    expect(dirty).toHaveBeenCalledTimes(2)
   })
 
   it('shows the conflict banner when the shared file is git-conflicted', async () => {
@@ -258,6 +264,34 @@ describe('useProjectSettings', () => {
     expect(writeShared).toHaveBeenCalledTimes(1)
     expect(writeShared).toHaveBeenCalledWith('p1', { terminal: { shell: '/bin/fish', theme: 'dark' } })
     expect(read).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps a save that is still being re-read as the merge base for the next one', async () => {
+    // Blur A saves the shell; blur B arrives BEFORE A's re-read lands. Merging into the pre-A
+    // document would make B's whole-document write silently delete A's shell.
+    const first: ProjectSettingsSnapshot = {
+      shared: { version: 1, rev: 1, savedAt: 't', terminal: { shell: '/bin/bash' } },
+      local: undefined
+    }
+    let gate: (v: ProjectSettingsSnapshot) => void = () => {}
+    read.mockResolvedValueOnce(first).mockReturnValue(
+      new Promise<ProjectSettingsSnapshot>((r) => (gate = r))
+    )
+    await mount()
+    await act(async () => {
+      await hook.saveShared({ terminal: { shell: '/bin/fish' } })
+    })
+    expect(hook.snapshot).toBe('loading') // the re-read is gated open
+    await act(async () => {
+      await hook.saveShared({ setup: { waitForSetup: true } })
+    })
+    expect(writeShared).toHaveBeenLastCalledWith('p1', {
+      terminal: { shell: '/bin/fish' },
+      setup: { waitForSetup: true }
+    })
+    await act(async () => {
+      gate(first)
+    })
   })
 
   it('drops a field cleared to undefined, and the family with it', async () => {

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
@@ -257,6 +257,69 @@ describe('ProjectSettingsSection', () => {
     expect(localShell.disabled).toBe(false)
     expect(toggle.disabled).toBe(false)
   })
+
+  it('disables every family editor (shared, local, and ignoreShared) while the read is in flight, and a blur landing in that window produces no write', async () => {
+    let release: (v: ProjectSettingsSnapshot) => void = () => {}
+    read = vi.fn(() => new Promise<ProjectSettingsSnapshot>((r) => (release = r)))
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.projectSettings.read = read
+    await mountSection()
+    const sharedShell = host.querySelector<HTMLInputElement>('#project-terminal-shell-p1')!
+    const localShell = host.querySelector<HTMLInputElement>('#project-terminal-shell-local-p1')!
+    const toggle = host.querySelector<HTMLButtonElement>(
+      '[aria-label="Ignore shared setup settings on this machine"]'
+    )!
+    expect(sharedShell.disabled).toBe(true)
+    expect(localShell.disabled).toBe(true)
+    expect(toggle.disabled).toBe(true)
+    // Bypass the DOM `disabled` attribute the way a stray/synthetic event could — the guard that
+    // matters is the one inside the commit handler, not just the attribute.
+    await typeInto(localShell, '/bin/zsh')
+    await blur(localShell)
+    expect(updateLocal).not.toHaveBeenCalled()
+    await act(async () => {
+      release(EMPTY_SNAPSHOT)
+    })
+    expect(sharedShell.disabled).toBe(false)
+    expect(localShell.disabled).toBe(false)
+    expect(toggle.disabled).toBe(false)
+  })
+
+  it('preserves an existing local family when a different local field is committed', async () => {
+    read = vi.fn(async () => ({ shared: null, local: { agents: { launchCmd: 'x' } } }) as ProjectSettingsSnapshot)
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.projectSettings.read = read
+    await mountSection()
+    const local = host.querySelector<HTMLInputElement>('#project-terminal-shell-local-p1')!
+    await typeInto(local, '/bin/zsh')
+    await blur(local)
+    expect(updateLocal).toHaveBeenCalledWith('p1', {
+      agents: { launchCmd: 'x' },
+      terminal: { shell: '/bin/zsh' }
+    })
+  })
+
+  it('merges a shared textarea blur into the whole shared doc, preserving other families', async () => {
+    read = vi.fn(async () => ({
+      shared: { version: 1, rev: 1, savedAt: 't', agents: { launchCmd: 'y' } },
+      local: undefined
+    }) as ProjectSettingsSnapshot)
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.projectSettings.read = read
+    await mountSection()
+    const setupScript = host.querySelector<HTMLTextAreaElement>('#project-setup-setupScript-p1')!
+    await typeIntoTextarea(setupScript, 'echo hi')
+    await blur(setupScript)
+    expect(writeShared).toHaveBeenCalledWith('p1', {
+      agents: { launchCmd: 'y' },
+      setup: { setupScript: 'echo hi' }
+    })
+  })
+
+  it('commits parsed KEY=VALUE pairs from the shared env textarea on blur', async () => {
+    await mountSection()
+    const env = host.querySelector<HTMLTextAreaElement>('#project-agents-env-p1')!
+    await typeIntoTextarea(env, 'A=1\nB=2')
+    await blur(env)
+    expect(writeShared).toHaveBeenCalledWith('p1', { agents: { env: { A: '1', B: '2' } } })
+  })
 })
 
 describe('useProjectSettings', () => {
@@ -398,6 +461,36 @@ describe('useProjectSettings', () => {
       ignoreShared: { agents: true }
     })
     expect(read).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps a local save that is still being re-read as the merge base for the next local save', async () => {
+    // Same hazard as the shared-doc race above, on the local overlay: local edit A (terminal)
+    // saves; local edit B (worktree) arrives before A's re-read lands. Merging B into the pre-A
+    // local doc would make B's whole-document write silently drop A's edit.
+    const first: ProjectSettingsSnapshot = {
+      shared: { version: 1, rev: 1, savedAt: 't', terminal: { shell: '/bin/bash' } },
+      local: { agents: { launchCmd: 'x' } }
+    }
+    let gate: (v: ProjectSettingsSnapshot) => void = () => {}
+    read.mockResolvedValueOnce(first).mockReturnValue(
+      new Promise<ProjectSettingsSnapshot>((r) => (gate = r))
+    )
+    await mount()
+    await act(async () => {
+      await hook.saveLocal((current) => ({ ...current, terminal: { shell: '/bin/zsh' } }))
+    })
+    expect(hook.snapshot).toBe('loading') // the re-read is gated open
+    await act(async () => {
+      await hook.saveLocal((current) => ({ ...current, worktree: { basePath: '/tmp/wt' } }))
+    })
+    expect(updateLocal).toHaveBeenLastCalledWith('p1', {
+      agents: { launchCmd: 'x' },
+      terminal: { shell: '/bin/zsh' },
+      worktree: { basePath: '/tmp/wt' }
+    })
+    await act(async () => {
+      gate(first)
+    })
   })
 
   it('degrades a failed read to "nothing readable" instead of throwing', async () => {

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
@@ -1,14 +1,15 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import type { Project } from '@shared/types'
 import type { ProjectSettingsSnapshot } from '@shared/project-settings'
 import { useProjects } from '../../../state/projects'
+import { useSettings } from '../../../state/settings'
 import { registerWorkspaceDirty } from '../../../state/workspaceDirty'
 import { SettingsSearchContext } from '../context'
 import { ProjectSettingsSection } from './ProjectSettingsSection'
-import { useProjectSettings, type ProjectSettingsHook } from '../useProjectSettings'
+import { mergeSharedDoc, useProjectSettings, type ProjectSettingsHook } from '../useProjectSettings'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -321,6 +322,101 @@ describe('ProjectSettingsSection', () => {
     expect(writeShared).toHaveBeenCalledWith('p1', { agents: { env: { A: '1', B: '2' } } })
   })
 
+  it('surfaces a REFUSED shared write as a warn note, re-reads the file, and clears the note on the next save that lands', async () => {
+    // A dropped `false` is silent data loss: the row snaps back to the stored value with no
+    // explanation, which is indistinguishable from the app ignoring the edit.
+    writeShared.mockResolvedValue(false)
+    await mountSection()
+    expect(read).toHaveBeenCalledTimes(1)
+    const shell = host.querySelector<HTMLInputElement>('#project-terminal-shell-p1')!
+    await typeInto(shell, '/bin/fish')
+    await blur(shell)
+    expect(writeShared).toHaveBeenCalledTimes(1)
+    expect(host.textContent).toContain('Could not save')
+    // A refusal is usually the FILE's answer (it went conflicted, or the folder went away, between
+    // our read and our write), so the pane re-reads instead of describing a file it no longer knows.
+    expect(read).toHaveBeenCalledTimes(2)
+    writeShared.mockResolvedValue(true)
+    await blur(shell)
+    expect(writeShared).toHaveBeenCalledTimes(2)
+    expect(host.textContent).not.toContain('Could not save')
+  })
+
+  it('surfaces a refused LOCAL write too, without re-reading (nothing about the shared file changed)', async () => {
+    updateLocal.mockResolvedValue(false)
+    await mountSection()
+    const local = host.querySelector<HTMLInputElement>('#project-terminal-shell-local-p1')!
+    await typeInto(local, '/bin/zsh')
+    await blur(local)
+    expect(host.textContent).toContain('Could not save this override on this machine')
+    expect(read).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the shared family rows read-only for a folderless inline project, with the reason', async () => {
+    // An inline canvas tab has no `cwd` and no `ssh`, so there is nowhere to put a
+    // `.nodeterm/settings.json`: the store refuses every shared write for it. Editors that can only
+    // ever fail must not be offered.
+    await mountSection(project({ cwd: '' }))
+    expect(host.textContent).toContain('no folder')
+    const familyControls = [
+      ...host.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>('input, textarea')
+    ].filter((el) => /^project-(setup|agents|worktree|terminal)-/.test(el.id))
+    const sharedRows = familyControls.filter((el) => !el.id.includes('-local-'))
+    expect(sharedRows.length).toBeGreaterThan(0)
+    expect(sharedRows.every((el) => el.disabled)).toBe(true)
+    // Bypassing the attribute (a synthetic event) must not write either.
+    const shell = host.querySelector<HTMLInputElement>('#project-terminal-shell-p1')!
+    await typeInto(shell, '/bin/fish')
+    await blur(shell)
+    expect(writeShared).not.toHaveBeenCalled()
+    // The identity rows still work: name/color/defaults live in project.json, not in the folder.
+    expect(nameInput().disabled).toBe(false)
+    await typeInto(nameInput(), 'Beta')
+    await blur(nameInput())
+    expect(useProjects.getState().getProject('p1')?.name).toBe('Beta')
+    // And so does the machine-local overlay, which lives in this machine's workspace index.
+    const local = host.querySelector<HTMLInputElement>('#project-terminal-shell-local-p1')!
+    expect(local.disabled).toBe(false)
+    await typeInto(local, '/bin/zsh')
+    await blur(local)
+    expect(updateLocal).toHaveBeenCalledWith('p1', { terminal: { shell: '/bin/zsh' } })
+  })
+
+  it('gives every local row an accessible name of its own, so it never duplicates its shared twin', async () => {
+    await mountSection()
+    expect(
+      host.querySelector<HTMLInputElement>('#project-terminal-shell-local-p1')!.getAttribute('aria-label')
+    ).toBe('Shell (this machine)')
+    expect(
+      host.querySelector<HTMLTextAreaElement>('#project-agents-env-local-p1')!.getAttribute('aria-label')
+    ).toBe('Environment variables (this machine)')
+    // The shared twin keeps its `<label>` as its name — the two must not read alike.
+    expect(
+      host.querySelector<HTMLInputElement>('#project-terminal-shell-p1')!.getAttribute('aria-label')
+    ).toBeNull()
+  })
+
+  it('shows an unknown default account as itself and switches to one this machine has', async () => {
+    const prior = useSettings.getState().settings
+    onTestFinished(() => useSettings.setState({ settings: prior }))
+    useSettings.setState({
+      settings: { ...prior, claudeAccounts: [{ id: 'acc-1', label: 'Work', createdAt: 0 }] }
+    })
+    await mountSection(project({ defaultAccountId: 'acc-gone' }))
+    const select = host.querySelector<HTMLSelectElement>('#project-account-p1')!
+    // A default naming an account this machine does not have (a teammate's pick, or one since
+    // removed) must READ as itself, not silently as the system account.
+    expect(host.textContent).toContain('acc-gone (not on this machine)')
+    expect(select.value).toBe('acc-gone')
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')!.set!
+      setter.call(select, 'acc-1')
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(useProjects.getState().getProject('p1')?.defaultAccountId).toBe('acc-1')
+    expect(dirty).toHaveBeenCalledTimes(1)
+  })
+
   // --- Task 5: search integration ------------------------------------------------------------
 
   const pane = (): HTMLElement | null => host.querySelector('[data-settings-section="project-p1"]')
@@ -351,6 +447,20 @@ describe('ProjectSettingsSection', () => {
     expect(host.querySelector('#project-worktree-basePath-p1')).not.toBeNull()
     expect(host.querySelector('#project-terminal-shell-p1')).toBeNull()
     expect(host.querySelector('#project-name-p1')).toBeNull()
+  })
+
+  it('does not match every family field on the non-discriminating query "project"', async () => {
+    // Every field in this pane is a project setting, so "project" told the search nothing while
+    // pulling in all four families of every open project. The identity rows still match — the
+    // "Project name" row is titled with the word.
+    // (A field whose own description genuinely says "project" — the setup scripts, the default
+    // agent — still matches, and should: that is prose about the field, not a blanket keyword.)
+    await mountSection(project(), { isActive: false, query: 'project' })
+    expect(host.querySelector('#project-name-p1')).not.toBeNull()
+    expect(host.querySelector('#project-terminal-shell-p1')).toBeNull()
+    expect(host.querySelector('#project-terminal-fontFamily-p1')).toBeNull()
+    expect(host.querySelector('#project-agents-launchCmd-p1')).toBeNull()
+    expect(host.querySelector('#project-worktree-basePath-local-p1')).toBeNull()
   })
 
   it('renders nothing (and reads nothing) for a query matching neither the name nor any row', async () => {
@@ -515,7 +625,7 @@ describe('useProjectSettings', () => {
   it('passes the local overlay through whole and re-reads', async () => {
     await mount()
     await act(async () => {
-      await hook.saveLocal({ terminal: { shell: '/bin/zsh' }, ignoreShared: { agents: true } })
+      await hook.saveLocal(() => ({ terminal: { shell: '/bin/zsh' }, ignoreShared: { agents: true } }))
     })
     expect(updateLocal).toHaveBeenCalledWith('p1', {
       terminal: { shell: '/bin/zsh' },
@@ -567,5 +677,66 @@ describe('useProjectSettings', () => {
       hook.reload()
     })
     expect(read).toHaveBeenCalledTimes(2)
+  })
+
+  it('refuses BOTH savers while the first read is still in flight, without writing anything', async () => {
+    // Defence in depth below the editors' own `ready` gate. Every write here is a WHOLE-document
+    // write; with nothing read and nothing pending, the merge base would be `{}`/`undefined`, so
+    // committing would delete whatever the files already hold.
+    let release: (v: ProjectSettingsSnapshot) => void = () => {}
+    read.mockReturnValue(new Promise<ProjectSettingsSnapshot>((r) => (release = r)))
+    root = createRoot(host)
+    act(() => {
+      root.render(<Probe projectId="p1" />)
+    })
+    expect(hook.snapshot).toBe('loading')
+    let ok = true
+    let okLocal = true
+    await act(async () => {
+      ok = await hook.saveShared({ terminal: { shell: '/bin/fish' } })
+      okLocal = await hook.saveLocal(() => ({ terminal: { shell: '/bin/zsh' } }))
+    })
+    expect(ok).toBe(false)
+    expect(okLocal).toBe(false)
+    expect(writeShared).not.toHaveBeenCalled()
+    expect(updateLocal).not.toHaveBeenCalled()
+    await act(async () => {
+      release(EMPTY_SNAPSHOT)
+    })
+  })
+
+  it('refuses BOTH savers after a FAILED read, which is equally "no document to merge into"', async () => {
+    read.mockRejectedValue(new Error('boom'))
+    await mount()
+    expect(hook.snapshot).toBeNull()
+    let ok = true
+    let okLocal = true
+    await act(async () => {
+      ok = await hook.saveShared({ terminal: { shell: '/bin/fish' } })
+      okLocal = await hook.saveLocal(() => ({ terminal: { shell: '/bin/zsh' } }))
+    })
+    expect(ok).toBe(false)
+    expect(okLocal).toBe(false)
+    expect(writeShared).not.toHaveBeenCalled()
+    expect(updateLocal).not.toHaveBeenCalled()
+  })
+})
+
+describe('mergeSharedDoc', () => {
+  it('merges field-by-field so an editor never blanks a field it does not own', () => {
+    expect(
+      mergeSharedDoc({ terminal: { shell: '/bin/bash', theme: 'dark' } }, { terminal: { theme: 'light' } })
+    ).toEqual({ terminal: { shell: '/bin/bash', theme: 'light' } })
+  })
+
+  it('clears a WHOLE family set to undefined, and drops a family its last cleared field empties', () => {
+    // The advertised family-level clear: `{ terminal: undefined }` removes the family outright,
+    // while clearing its last field removes it as a side effect — an unset setting adds no bytes
+    // to a file the whole team reads.
+    const current = { terminal: { shell: '/bin/bash' }, setup: { waitForSetup: true } }
+    expect(mergeSharedDoc(current, { terminal: undefined })).toEqual({ setup: { waitForSetup: true } })
+    expect(mergeSharedDoc(current, { terminal: { shell: undefined } })).toEqual({
+      setup: { waitForSetup: true }
+    })
   })
 })

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { Project } from '@shared/types'
+import {
+  ALL_PERMISSION_MODES,
+  PERMISSION_MODE_LABELS,
+  type AgentPermissionMode
+} from '@shared/agents/config'
+import { Input } from '@renderer/ui/Input'
+import { Select } from '@renderer/ui/Select'
+import { cn } from '@renderer/ui/cn'
+import { useProjects } from '../../../state/projects'
+import { useSettings } from '../../../state/settings'
+import { useSystemAccount } from '../../../state/systemAccount'
+import {
+  NODE_COLORS,
+  accountsForProject,
+  sshAccountsHint,
+  systemAccountDisplay
+} from '../../../state/workspace'
+import { FieldRow } from '../FieldRow'
+import { SearchableRow } from '../SearchableRow'
+import { SettingsSection } from '../SettingsSection'
+import { useSettingsSearch } from '../context'
+import { projectSectionId } from '../project-settings-targets'
+import { matchesQuery, type SettingsSearchEntry } from '../search'
+import { useProjectSettings } from '../useProjectSettings'
+
+/**
+ * Saves the whole workspace after an identity/defaults edit — the SAME route Canvas takes after
+ * `renameProject` / `setProjectColor` / `setProjectDefault*` (Canvas.tsx `persist`): the store
+ * setters are pure state, and nothing else pushes them to `.nodeterm/project.json`.
+ *
+ * Canvas's `persist` first commits its live React Flow nodes into the store; this cannot (React
+ * Flow is Canvas-owned) and must not need to — the canvas is not being edited while the Settings
+ * page is up, and its own 800ms autosave has already committed anything that was. What we write is
+ * the store's current truth for every project, exactly like every other save.
+ */
+async function persistWorkspace(): Promise<void> {
+  await window.nodeTerminal.workspace.save(useProjects.getState().toWorkspace())
+}
+
+function rowsFor(name: string): Record<string, SettingsSearchEntry> {
+  // The project's own name rides every row's keywords: searching a project by name has to surface
+  // its controls, not just the section header.
+  return {
+    name: { title: 'Project name', keywords: ['rename', 'project', 'title', name] },
+    folder: { title: 'Folder', keywords: ['cwd', 'path', 'directory', 'ssh', 'server', name] },
+    color: { title: 'Color', keywords: ['accent', 'swatch', 'tab', 'monogram', name] },
+    permission: {
+      title: 'Default permission mode',
+      keywords: ['claude', 'plan', 'accept edits', 'bypass', 'approval', name]
+    },
+    account: {
+      title: 'Default Claude account',
+      keywords: ['account', 'login', 'claude', 'system', name]
+    }
+  }
+}
+
+/** Where this project's terminals run: a local folder, or `user@host:/remote/path` for SSH. */
+function projectTarget(project: Project): string {
+  if (project.ssh) return `${project.ssh.server.user}@${project.ssh.server.host}:${project.ssh.remoteCwd}`
+  return project.cwd || 'No folder set'
+}
+
+/**
+ * One project's settings pane. Dynamic (`project-<id>`): the nav group and this list are both
+ * built from the same live project list, so a section always has a row and vice versa.
+ *
+ * The visibility gate is evaluated HERE as well as inside `SettingsSection`, deliberately: the body
+ * reads `.nodeterm/settings.json`, which for an SSH project is a network round-trip, so a pane that
+ * is neither active nor matched by the search must not mount the hook at all.
+ */
+export function ProjectSettingsSection({
+  projectId,
+  isActive
+}: {
+  projectId: string
+  isActive: boolean
+}): React.JSX.Element | null {
+  const project = useProjects((s) => s.projects.find((p) => p.id === projectId))
+  const query = useSettingsSearch()
+  const rows = useMemo(() => rowsFor(project?.name ?? ''), [project?.name])
+  const entries = useMemo(() => Object.values(rows), [rows])
+  if (!project) return null
+  const visible = query.trim() !== '' ? entries.some((e) => matchesQuery(query, e)) : isActive
+  if (!visible) return null
+  // A relay tab is a live connection to ANOTHER machine's project, and an unavailable project's
+  // files cannot be read at all. Both get an explanation and zero editors: `projectSettings.*`
+  // here would read and write THIS machine's store, so an editor would silently edit the wrong
+  // project (or nothing).
+  if (project.remote || project.unavailable) {
+    return <ExplanatoryProjectSection project={project} isActive={isActive} entries={entries} />
+  }
+  return (
+    <EditableProjectSection project={project} isActive={isActive} entries={entries} rows={rows} />
+  )
+}
+
+function ExplanatoryProjectSection({
+  project,
+  isActive,
+  entries
+}: {
+  project: Project
+  isActive: boolean
+  entries: SettingsSearchEntry[]
+}): React.JSX.Element {
+  return (
+    <SettingsSection
+      id={projectSectionId(project.id)}
+      title={project.name}
+      isActive={isActive}
+      searchEntries={entries}
+    >
+      <p className="text-[13px] leading-relaxed text-muted">
+        {project.remote
+          ? `This tab is a live connection to a project on another machine (${projectTarget(project)}). Its settings live there and are edited on that machine — nothing changed here would reach it.`
+          : `This project is unavailable: its files could not be read (folder missing, server unreachable, or the file is corrupt). Reconnect or reopen it to change its settings.`}
+      </p>
+    </SettingsSection>
+  )
+}
+
+function EditableProjectSection({
+  project,
+  isActive,
+  entries,
+  rows
+}: {
+  project: Project
+  isActive: boolean
+  entries: SettingsSearchEntry[]
+  rows: Record<string, SettingsSearchEntry>
+}): React.JSX.Element {
+  const settings = useProjectSettings(project.id)
+  const claudeAccounts = useSettings((s) => s.settings.claudeAccounts)
+  const globalMode = useSettings((s) => s.settings.claudePermissionMode)
+  const systemLabelSetting = useSettings((s) => s.settings.systemAccountLabel)
+  const systemEmail = useSystemAccount((s) => s.email)
+  const systemLabel = systemAccountDisplay(systemLabelSetting, systemEmail)
+  const accounts = accountsForProject(claudeAccounts, project)
+  const accountsHint = sshAccountsHint(project, accounts)
+
+  // Editors commit on BLUR, never per keystroke: each commit is a disk write.
+  const [nameDraft, setNameDraft] = useState(project.name)
+  useEffect(() => setNameDraft(project.name), [project.name])
+
+  const snapshot = settings.snapshot
+  // A git-conflicted settings.json is left untouched for the user to resolve, so every editor of
+  // the SHARED document is disabled while it stands (Task 4's family editors take this as their
+  // `disabled`; identity/defaults below live in project.json and are unaffected).
+  const conflict = snapshot !== 'loading' && snapshot?.conflict === true
+
+  const commitName = (): void => {
+    const next = nameDraft.trim()
+    if (!next || next === project.name) {
+      setNameDraft(project.name)
+      return
+    }
+    useProjects.getState().renameProject(project.id, next)
+    void persistWorkspace()
+  }
+
+  return (
+    <SettingsSection
+      id={projectSectionId(project.id)}
+      title={project.name}
+      description={`Settings for this project only. Name, color and defaults live in ${project.ssh ? 'the project file on the server' : '.nodeterm/project.json'}, which is shared with anyone who has the repo.`}
+      isActive={isActive}
+      searchEntries={entries}
+    >
+      {conflict ? (
+        <div
+          role="status"
+          className="rounded-xl border border-[color:var(--warn)]/40 bg-[color:var(--warn)]/10 px-4 py-3 text-[13px] leading-relaxed text-text"
+        >
+          This project&apos;s <code>.nodeterm/settings.json</code> has unresolved git conflict
+          markers. It is left exactly as it is — resolve the conflict in your editor, then reopen
+          this pane. Shared settings cannot be edited until then.
+          {/* Rendered whether or not any family editor is on screen: the pane must explain why the
+              file it is about is being ignored, even before Task 4's editors exist. */}
+        </div>
+      ) : null}
+      <SearchableRow {...rows.name}>
+        <FieldRow
+          label="Project name"
+          description="Shown on the tab and in the project switcher."
+          htmlFor={`project-name-${project.id}`}
+          control={
+            <Input
+              id={`project-name-${project.id}`}
+              className="w-72"
+              value={nameDraft}
+              aria-label="Project name"
+              onChange={(e) => setNameDraft(e.target.value)}
+              onBlur={commitName}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.currentTarget.blur()
+                if (e.key === 'Escape') setNameDraft(project.name)
+              }}
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...rows.folder}>
+        <FieldRow
+          label={project.ssh ? 'Server folder' : 'Folder'}
+          description="Where this project's terminals start. Change it from the project tab's menu."
+          control={
+            <span className="max-w-[26rem] truncate text-[13px] text-muted" title={projectTarget(project)}>
+              {projectTarget(project)}
+            </span>
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...rows.color}>
+        <FieldRow
+          label="Color"
+          description="Accent for this project's tab and monogram."
+          control={
+            <div className="flex items-center gap-1.5">
+              {NODE_COLORS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  data-project-color={c}
+                  aria-label={`Color ${c}`}
+                  aria-pressed={project.color === c}
+                  style={{ background: c }}
+                  className={cn(
+                    'size-5 rounded-full border-0 outline-none transition-transform hover:scale-110',
+                    project.color === c && 'ring-2 ring-white/80 ring-offset-2 ring-offset-transparent'
+                  )}
+                  onClick={() => {
+                    useProjects.getState().setProjectColor(project.id, c)
+                    void persistWorkspace()
+                  }}
+                />
+              ))}
+            </div>
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...rows.permission}>
+        <FieldRow
+          label="Default permission mode"
+          description="Start-up permission mode for new Claude terminal sessions in this project. Saved in the shared project file, so it travels to everyone who clones the repo."
+          htmlFor={`project-permission-mode-${project.id}`}
+          control={
+            <Select
+              id={`project-permission-mode-${project.id}`}
+              aria-label="Default permission mode"
+              value={project.defaultPermissionMode ?? ''}
+              onChange={(e) => {
+                const v = e.target.value
+                useProjects
+                  .getState()
+                  .setProjectDefaultPermissionMode(
+                    project.id,
+                    v === '' ? undefined : (v as AgentPermissionMode)
+                  )
+                void persistWorkspace()
+              }}
+            >
+              <option value="">Use global ({PERMISSION_MODE_LABELS[globalMode]})</option>
+              {ALL_PERMISSION_MODES.map((m) => (
+                <option key={m} value={m}>
+                  {PERMISSION_MODE_LABELS[m]}
+                </option>
+              ))}
+            </Select>
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...rows.account}>
+        <FieldRow
+          label="Default Claude account"
+          description="Account new Claude and chat nodes in this project use."
+          note={accountsHint ?? undefined}
+          htmlFor={`project-account-${project.id}`}
+          control={
+            <Select
+              id={`project-account-${project.id}`}
+              aria-label="Default Claude account"
+              value={project.defaultAccountId ?? ''}
+              onChange={(e) => {
+                const v = e.target.value
+                useProjects.getState().setProjectDefaultAccount(project.id, v === '' ? undefined : v)
+                void persistWorkspace()
+              }}
+            >
+              <option value="">{systemLabel}</option>
+              {accounts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.label}
+                </option>
+              ))}
+              {/* A default naming an account this machine does not have (a teammate's pick, or one
+                  since removed) must READ as itself, not silently as the system account. */}
+              {project.defaultAccountId && !accounts.some((a) => a.id === project.defaultAccountId) ? (
+                <option value={project.defaultAccountId}>
+                  {project.defaultAccountId} (not on this machine)
+                </option>
+              ) : null}
+            </Select>
+          }
+        />
+      </SearchableRow>
+      {/* Task 4 hangs the per-family editors (setup / worktree / agents / terminal) here; they take
+          `settings.resolved`, `settings.saveShared`, `settings.saveLocal`, and `conflict` as their
+          disabled flag — the hook needs no change to grow them. */}
+    </SettingsSection>
+  )
+}

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
@@ -19,6 +19,7 @@ import {
   systemAccountDisplay
 } from '../../../state/workspace'
 import { FieldRow } from '../FieldRow'
+import { ProjectFamilyEditors } from '../ProjectSettingsFamilies'
 import { SearchableRow } from '../SearchableRow'
 import { SettingsSection } from '../SettingsSection'
 import { useSettingsSearch } from '../context'
@@ -308,9 +309,14 @@ function EditableProjectSection({
           }
         />
       </SearchableRow>
-      {/* Task 4 hangs the per-family editors (setup / worktree / agents / terminal) here; they take
-          `settings.resolved`, `settings.saveShared`, `settings.saveLocal`, and `conflict` as their
-          disabled flag — the hook needs no change to grow them. */}
+      <ProjectFamilyEditors
+        projectId={project.id}
+        snapshot={snapshot}
+        resolved={settings.resolved}
+        conflict={conflict}
+        saveShared={settings.saveShared}
+        saveLocal={settings.saveLocal}
+      />
     </SettingsSection>
   )
 }

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
@@ -11,6 +11,7 @@ import { cn } from '@renderer/ui/cn'
 import { useProjects } from '../../../state/projects'
 import { useSettings } from '../../../state/settings'
 import { useSystemAccount } from '../../../state/systemAccount'
+import { markWorkspaceDirty } from '../../../state/workspaceDirty'
 import {
   NODE_COLORS,
   accountsForProject,
@@ -26,17 +27,17 @@ import { matchesQuery, type SettingsSearchEntry } from '../search'
 import { useProjectSettings } from '../useProjectSettings'
 
 /**
- * Saves the whole workspace after an identity/defaults edit — the SAME route Canvas takes after
- * `renameProject` / `setProjectColor` / `setProjectDefault*` (Canvas.tsx `persist`): the store
- * setters are pure state, and nothing else pushes them to `.nodeterm/project.json`.
+ * Persists an identity/defaults edit. The store setters (`renameProject`, `setProjectColor`,
+ * `setProjectDefault*`) are pure state — nothing else pushes them to `.nodeterm/project.json`.
  *
- * Canvas's `persist` first commits its live React Flow nodes into the store; this cannot (React
- * Flow is Canvas-owned) and must not need to — the canvas is not being edited while the Settings
- * page is up, and its own 800ms autosave has already committed anything that was. What we write is
- * the store's current truth for every project, exactly like every other save.
+ * `markWorkspaceDirty()` is the seam built for exactly this (state/workspaceDirty.ts; NodeLabels.tsx
+ * is the precedent): it rings Canvas's own `markDirty`, so the write inherits the canvas commit,
+ * the 800ms debounce, AND the conflict gate — while an external-change bar is up, autosave is
+ * suspended on purpose, and calling `workspace.save` directly from here would write straight past
+ * it. Debounced is right for these edits too: Canvas debounces node edits the same way.
  */
-async function persistWorkspace(): Promise<void> {
-  await window.nodeTerminal.workspace.save(useProjects.getState().toWorkspace())
+function persistIdentityEdit(): void {
+  markWorkspaceDirty()
 }
 
 function rowsFor(name: string): Record<string, SettingsSearchEntry> {
@@ -159,7 +160,7 @@ function EditableProjectSection({
       return
     }
     useProjects.getState().renameProject(project.id, next)
-    void persistWorkspace()
+    persistIdentityEdit()
   }
 
   return (
@@ -234,7 +235,7 @@ function EditableProjectSection({
                   )}
                   onClick={() => {
                     useProjects.getState().setProjectColor(project.id, c)
-                    void persistWorkspace()
+                    persistIdentityEdit()
                   }}
                 />
               ))}
@@ -260,7 +261,7 @@ function EditableProjectSection({
                     project.id,
                     v === '' ? undefined : (v as AgentPermissionMode)
                   )
-                void persistWorkspace()
+                persistIdentityEdit()
               }}
             >
               <option value="">Use global ({PERMISSION_MODE_LABELS[globalMode]})</option>
@@ -287,7 +288,7 @@ function EditableProjectSection({
               onChange={(e) => {
                 const v = e.target.value
                 useProjects.getState().setProjectDefaultAccount(project.id, v === '' ? undefined : v)
-                void persistWorkspace()
+                persistIdentityEdit()
               }}
             >
               <option value="">{systemLabel}</option>

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
@@ -19,9 +19,9 @@ import {
   systemAccountDisplay
 } from '../../../state/workspace'
 import { FieldRow } from '../FieldRow'
-import { ProjectFamilyEditors } from '../ProjectSettingsFamilies'
+import { FAMILY_SEARCH_ENTRIES, ProjectFamilyEditors } from '../ProjectSettingsFamilies'
 import { SearchableRow } from '../SearchableRow'
-import { SettingsSection } from '../SettingsSection'
+import { SettingsSection, sectionVisible } from '../SettingsSection'
 import { useSettingsSearch } from '../context'
 import { projectSectionId } from '../project-settings-targets'
 import { matchesQuery, type SettingsSearchEntry } from '../search'
@@ -41,23 +41,26 @@ function persistIdentityEdit(): void {
   markWorkspaceDirty()
 }
 
-function rowsFor(name: string): Record<string, SettingsSearchEntry> {
-  // The project's own name rides every row's keywords: searching a project by name has to surface
-  // its controls, not just the section header.
-  return {
-    name: { title: 'Project name', keywords: ['rename', 'project', 'title', name] },
-    folder: { title: 'Folder', keywords: ['cwd', 'path', 'directory', 'ssh', 'server', name] },
-    color: { title: 'Color', keywords: ['accent', 'swatch', 'tab', 'monogram', name] },
-    permission: {
-      title: 'Default permission mode',
-      keywords: ['claude', 'plan', 'accept edits', 'bypass', 'approval', name]
-    },
-    account: {
-      title: 'Default Claude account',
-      keywords: ['account', 'login', 'claude', 'system', name]
-    }
+/**
+ * Static search metadata for the identity/defaults rows (the ShellSection pattern). Deliberately
+ * WITHOUT the project's name: a name query is handled by `forceVisible` below, which opens the
+ * whole pane rather than filtering it down to whichever rows happened to mention the name.
+ */
+const ROWS = {
+  name: { title: 'Project name', keywords: ['rename', 'project', 'title'] },
+  folder: { title: 'Folder', keywords: ['cwd', 'path', 'directory', 'ssh', 'server'] },
+  color: { title: 'Color', keywords: ['accent', 'swatch', 'tab', 'monogram'] },
+  permission: {
+    title: 'Default permission mode',
+    keywords: ['claude', 'plan', 'accept edits', 'bypass', 'approval']
+  },
+  account: {
+    title: 'Default Claude account',
+    keywords: ['account', 'login', 'claude', 'system']
   }
-}
+} satisfies Record<string, SettingsSearchEntry>
+
+const IDENTITY_ENTRIES: SettingsSearchEntry[] = Object.values(ROWS)
 
 /** Where this project's terminals run: a local folder, or `user@host:/remote/path` for SSH. */
 function projectTarget(project: Project): string {
@@ -82,31 +85,51 @@ export function ProjectSettingsSection({
 }): React.JSX.Element | null {
   const project = useProjects((s) => s.projects.find((p) => p.id === projectId))
   const query = useSettingsSearch()
-  const rows = useMemo(() => rowsFor(project?.name ?? ''), [project?.name])
-  const entries = useMemo(() => Object.values(rows), [rows])
+  const name = project?.name ?? ''
+  // The pane's own name is a search entry in its own right (so a name query reaches the gate at
+  // all) AND the trigger for `forceVisible` (so the pane then renders whole).
+  const entries = useMemo(
+    () => [...IDENTITY_ENTRIES, ...FAMILY_SEARCH_ENTRIES, { title: name, keywords: [name] }],
+    [name]
+  )
+  const forceVisible = matchesQuery(query, { title: name })
   if (!project) return null
-  const visible = query.trim() !== '' ? entries.some((e) => matchesQuery(query, e)) : isActive
-  if (!visible) return null
+  // Same predicate `SettingsSection` uses, evaluated one level earlier — see `sectionVisible`.
+  if (!sectionVisible(query, isActive, entries, forceVisible)) return null
   // A relay tab is a live connection to ANOTHER machine's project, and an unavailable project's
   // files cannot be read at all. Both get an explanation and zero editors: `projectSettings.*`
   // here would read and write THIS machine's store, so an editor would silently edit the wrong
   // project (or nothing).
   if (project.remote || project.unavailable) {
-    return <ExplanatoryProjectSection project={project} isActive={isActive} entries={entries} />
+    return (
+      <ExplanatoryProjectSection
+        project={project}
+        isActive={isActive}
+        entries={entries}
+        forceVisible={forceVisible}
+      />
+    )
   }
   return (
-    <EditableProjectSection project={project} isActive={isActive} entries={entries} rows={rows} />
+    <EditableProjectSection
+      project={project}
+      isActive={isActive}
+      entries={entries}
+      forceVisible={forceVisible}
+    />
   )
 }
 
 function ExplanatoryProjectSection({
   project,
   isActive,
-  entries
+  entries,
+  forceVisible
 }: {
   project: Project
   isActive: boolean
   entries: SettingsSearchEntry[]
+  forceVisible: boolean
 }): React.JSX.Element {
   return (
     <SettingsSection
@@ -114,6 +137,7 @@ function ExplanatoryProjectSection({
       title={project.name}
       isActive={isActive}
       searchEntries={entries}
+      forceVisible={forceVisible}
     >
       <p className="text-[13px] leading-relaxed text-muted">
         {project.remote
@@ -128,12 +152,12 @@ function EditableProjectSection({
   project,
   isActive,
   entries,
-  rows
+  forceVisible
 }: {
   project: Project
   isActive: boolean
   entries: SettingsSearchEntry[]
-  rows: Record<string, SettingsSearchEntry>
+  forceVisible: boolean
 }): React.JSX.Element {
   const settings = useProjectSettings(project.id)
   const claudeAccounts = useSettings((s) => s.settings.claudeAccounts)
@@ -171,6 +195,7 @@ function EditableProjectSection({
       description={`Settings for this project only. Name, color and defaults live in ${project.ssh ? 'the project file on the server' : '.nodeterm/project.json'}, which is shared with anyone who has the repo.`}
       isActive={isActive}
       searchEntries={entries}
+      forceVisible={forceVisible}
     >
       {conflict ? (
         <div
@@ -184,7 +209,7 @@ function EditableProjectSection({
               file it is about is being ignored, even before Task 4's editors exist. */}
         </div>
       ) : null}
-      <SearchableRow {...rows.name}>
+      <SearchableRow {...ROWS.name}>
         <FieldRow
           label="Project name"
           description="Shown on the tab and in the project switcher."
@@ -205,7 +230,7 @@ function EditableProjectSection({
           }
         />
       </SearchableRow>
-      <SearchableRow {...rows.folder}>
+      <SearchableRow {...ROWS.folder}>
         <FieldRow
           label={project.ssh ? 'Server folder' : 'Folder'}
           description="Where this project's terminals start. Change it from the project tab's menu."
@@ -216,7 +241,7 @@ function EditableProjectSection({
           }
         />
       </SearchableRow>
-      <SearchableRow {...rows.color}>
+      <SearchableRow {...ROWS.color}>
         <FieldRow
           label="Color"
           description="Accent for this project's tab and monogram."
@@ -244,7 +269,7 @@ function EditableProjectSection({
           }
         />
       </SearchableRow>
-      <SearchableRow {...rows.permission}>
+      <SearchableRow {...ROWS.permission}>
         <FieldRow
           label="Default permission mode"
           description="Start-up permission mode for new Claude terminal sessions in this project. Saved in the shared project file, so it travels to everyone who clones the repo."
@@ -275,7 +300,7 @@ function EditableProjectSection({
           }
         />
       </SearchableRow>
-      <SearchableRow {...rows.account}>
+      <SearchableRow {...ROWS.account}>
         <FieldRow
           label="Default Claude account"
           description="Account new Claude and chat nodes in this project use."

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
@@ -339,8 +339,12 @@ function EditableProjectSection({
         snapshot={snapshot}
         resolved={settings.resolved}
         conflict={conflict}
+        // Only the shell knows WHERE this project lives; a folderless inline canvas tab has no
+        // shared settings file and never can have one — see `sharedEditable`.
+        sharedEditable={Boolean(project.cwd || project.ssh)}
         saveShared={settings.saveShared}
         saveLocal={settings.saveLocal}
+        reload={settings.reload}
       />
     </SettingsSection>
   )

--- a/src/renderer/components/settings/useProjectSettings.ts
+++ b/src/renderer/components/settings/useProjectSettings.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  resolveProjectSettings,
+  type ProjectLocalSettings,
+  type ProjectSettingsDoc,
+  type ProjectSettingsFileV1,
+  type ProjectSettingsSnapshot,
+  type ResolvedProjectSettings
+} from '@shared/project-settings'
+
+/**
+ * One project's `.nodeterm/settings.json` (the git-shared doc) plus this machine's local overlay,
+ * as the Settings panel needs them: the raw snapshot for provenance/conflict decisions, the
+ * resolved local-over-shared view for showing effective values, and two savers.
+ *
+ * `snapshot` is `'loading'` until the first read answers, then the snapshot, or `null` when the
+ * project is unknown to the store or the read failed. A failed read is never an exception here:
+ * the panel must still render its identity rows for a project whose settings file is unreadable.
+ */
+export interface ProjectSettingsHook {
+  snapshot: ProjectSettingsSnapshot | null | 'loading'
+  /** `resolveProjectSettings(local, shared)`; empty families while the first read is in flight. */
+  resolved: ResolvedProjectSettings
+  /**
+   * Commits an edit to the GIT-SHARED document. The argument is a PATCH, merged field-by-field
+   * into the document that was last read — `writeShared` is a whole-document write (it replaces
+   * the file), so an editor that owns one field must not blank its siblings. A field set to
+   * `undefined` is removed; a family left with no fields is removed with it, so an unset setting
+   * adds no bytes to a file the whole team reads.
+   *
+   * Returns the store's accept/refuse answer, and re-reads on success: the store bumped `rev` and
+   * may have sanitized what it wrote, so what the panel shows afterwards is the FILE, not our hope.
+   */
+  saveShared(doc: ProjectSettingsDoc): Promise<boolean>
+  /** This machine's overlay, written whole (`undefined` clears it). Re-reads on success. */
+  saveLocal(local: ProjectLocalSettings | undefined): Promise<boolean>
+  reload(): void
+}
+
+/** The document half of a shared file — `version`/`rev`/`savedAt` belong to the store, which
+ *  re-stamps them on every write, so they never travel back through an editor. */
+function docOf(shared: ProjectSettingsFileV1 | null | undefined): ProjectSettingsDoc {
+  if (!shared) return {}
+  const { version: _version, rev: _rev, savedAt: _savedAt, ...doc } = shared
+  return doc
+}
+
+/**
+ * Field-level merge of `patch` into `current`, dropping `undefined` (a cleared field) and any
+ * family the clearing leaves empty. Exported for the tests that pin the "an editor never blanks a
+ * field it does not own" rule.
+ */
+export function mergeSharedDoc(
+  current: ProjectSettingsDoc,
+  patch: ProjectSettingsDoc
+): ProjectSettingsDoc {
+  const out: Record<string, unknown> = { ...current }
+  for (const family of Object.keys(patch) as (keyof ProjectSettingsDoc)[]) {
+    const patchFamily = patch[family] as Record<string, unknown> | undefined
+    if (patchFamily === undefined) {
+      delete out[family]
+      continue
+    }
+    const merged: Record<string, unknown> = {
+      ...(current[family] as Record<string, unknown> | undefined),
+      ...patchFamily
+    }
+    for (const key of Object.keys(merged)) if (merged[key] === undefined) delete merged[key]
+    if (Object.keys(merged).length === 0) delete out[family]
+    else out[family] = merged
+  }
+  return out as ProjectSettingsDoc
+}
+
+const EMPTY_FAMILIES = (): ResolvedProjectSettings => resolveProjectSettings(undefined, undefined)
+
+export function useProjectSettings(projectId: string): ProjectSettingsHook {
+  const [snapshot, setSnapshot] = useState<ProjectSettingsSnapshot | null | 'loading'>('loading')
+  const [nonce, setNonce] = useState(0)
+
+  // The merge base for `saveShared` must be the LATEST snapshot, without making the saver identity
+  // change on every read (a blur handler holding last render's saver would then merge into a stale
+  // document and silently revert a sibling field).
+  const snapshotRef = useRef<ProjectSettingsSnapshot | null | 'loading'>(snapshot)
+  snapshotRef.current = snapshot
+
+  useEffect(() => {
+    let alive = true
+    setSnapshot('loading')
+    void window.nodeTerminal.projectSettings.read(projectId).then(
+      (s) => {
+        if (alive) setSnapshot(s)
+      },
+      () => {
+        if (alive) setSnapshot(null)
+      }
+    )
+    return () => {
+      alive = false
+    }
+  }, [projectId, nonce])
+
+  const reload = useCallback(() => setNonce((n) => n + 1), [])
+
+  const saveShared = useCallback(
+    async (doc: ProjectSettingsDoc): Promise<boolean> => {
+      const snap = snapshotRef.current
+      const current = snap && snap !== 'loading' ? docOf(snap.shared) : {}
+      const ok = await window.nodeTerminal.projectSettings.writeShared(
+        projectId,
+        mergeSharedDoc(current, doc)
+      )
+      if (ok) reload()
+      return ok
+    },
+    [projectId, reload]
+  )
+
+  const saveLocal = useCallback(
+    async (local: ProjectLocalSettings | undefined): Promise<boolean> => {
+      const ok = await window.nodeTerminal.projectSettings.updateLocal(projectId, local)
+      if (ok) reload()
+      return ok
+    },
+    [projectId, reload]
+  )
+
+  const resolved = useMemo(
+    () =>
+      snapshot && snapshot !== 'loading'
+        ? resolveProjectSettings(snapshot.local, docOf(snapshot.shared))
+        : EMPTY_FAMILIES(),
+    [snapshot]
+  )
+
+  return { snapshot, resolved, saveShared, saveLocal, reload }
+}

--- a/src/renderer/components/settings/useProjectSettings.ts
+++ b/src/renderer/components/settings/useProjectSettings.ts
@@ -32,8 +32,21 @@ export interface ProjectSettingsHook {
    * may have sanitized what it wrote, so what the panel shows afterwards is the FILE, not our hope.
    */
   saveShared(doc: ProjectSettingsDoc): Promise<boolean>
-  /** This machine's overlay, written whole (`undefined` clears it). Re-reads on success. */
-  saveLocal(local: ProjectLocalSettings | undefined): Promise<boolean>
+  /**
+   * Commits an edit to THIS MACHINE's local overlay — a whole-document write, exactly like
+   * `saveShared`. Takes either the next whole document directly, or an updater over the CURRENT
+   * one (preferring a still-in-flight write's result over the last-read snapshot, via the same
+   * `pendingLocalRef` guard `saveShared` uses for the shared doc) — so two local edits inside one
+   * IPC round-trip do not drop the first. Prefer the updater form for anything that merges into
+   * the existing doc; the plain-value form stays for a caller that already holds the whole next
+   * document (e.g. clearing the overlay with `undefined`). Re-reads on success.
+   */
+  saveLocal(
+    update:
+      | ProjectLocalSettings
+      | undefined
+      | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
+  ): Promise<boolean>
   reload(): void
 }
 
@@ -92,6 +105,11 @@ export function useProjectSettings(projectId: string): ProjectSettingsHook {
   // re-read is asynchronous; the user's next blur is not going to wait for it. Tagged with the
   // project id so a pane switch can never merge one project's edit into another's file.
   const pendingRef = useRef<{ projectId: string; doc: ProjectSettingsDoc } | null>(null)
+  // Same hazard, same fix, for the LOCAL overlay: `saveLocal` is also a whole-document write, so
+  // two local edits in one round-trip need their own pending base independent of the shared one.
+  const pendingLocalRef = useRef<{ projectId: string; local: ProjectLocalSettings | undefined } | null>(
+    null
+  )
 
   useEffect(() => {
     let alive = true
@@ -104,7 +122,10 @@ export function useProjectSettings(projectId: string): ProjectSettingsHook {
     const seqAtStart = writeSeqRef.current
     const settle = (next: ProjectSettingsSnapshot | null): void => {
       if (!alive) return
-      if (writeSeqRef.current === seqAtStart) pendingRef.current = null
+      if (writeSeqRef.current === seqAtStart) {
+        pendingRef.current = null
+        pendingLocalRef.current = null
+      }
       setSnapshot(next)
     }
     void window.nodeTerminal.projectSettings.read(projectId).then(settle, () => settle(null))
@@ -138,10 +159,24 @@ export function useProjectSettings(projectId: string): ProjectSettingsHook {
   )
 
   const saveLocal = useCallback(
-    async (local: ProjectLocalSettings | undefined): Promise<boolean> => {
-      const ok = await window.nodeTerminal.projectSettings.updateLocal(projectId, local)
-      if (ok) reload()
-      return ok
+    async (
+      update:
+        | ProjectLocalSettings
+        | undefined
+        | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
+    ): Promise<boolean> => {
+      const pending = pendingLocalRef.current
+      const snap = snapshotRef.current
+      const current =
+        pending?.projectId === projectId ? pending.local : snap && snap !== 'loading' ? snap.local : undefined
+      const next = typeof update === 'function' ? update(current) : update
+      const ok = await window.nodeTerminal.projectSettings.updateLocal(projectId, next)
+      if (!ok) return false
+      // Advance the merge base NOW, not when the re-read lands: the next blur may arrive first.
+      writeSeqRef.current += 1
+      pendingLocalRef.current = { projectId, local: next }
+      reload()
+      return true
     },
     [projectId, reload]
   )

--- a/src/renderer/components/settings/useProjectSettings.ts
+++ b/src/renderer/components/settings/useProjectSettings.ts
@@ -34,18 +34,16 @@ export interface ProjectSettingsHook {
   saveShared(doc: ProjectSettingsDoc): Promise<boolean>
   /**
    * Commits an edit to THIS MACHINE's local overlay — a whole-document write, exactly like
-   * `saveShared`. Takes either the next whole document directly, or an updater over the CURRENT
-   * one (preferring a still-in-flight write's result over the last-read snapshot, via the same
-   * `pendingLocalRef` guard `saveShared` uses for the shared doc) — so two local edits inside one
-   * IPC round-trip do not drop the first. Prefer the updater form for anything that merges into
-   * the existing doc; the plain-value form stays for a caller that already holds the whole next
-   * document (e.g. clearing the overlay with `undefined`). Re-reads on success.
+   * `saveShared`. Takes an UPDATER over the current document (preferring a still-in-flight write's
+   * result over the last-read snapshot, via the same `pendingLocalRef` guard `saveShared` uses for
+   * the shared doc), so two local edits inside one IPC round-trip do not drop the first. The
+   * updater form is the ONLY form: a plain next-document argument cannot see the pending base, so
+   * it would silently revert an edit whose re-read has not landed yet — the exact hazard
+   * `pendingLocalRef` exists to close. Clearing the whole overlay is `saveLocal(() => undefined)`.
+   * Re-reads on success.
    */
   saveLocal(
-    update:
-      | ProjectLocalSettings
-      | undefined
-      | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
+    update: (current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined
   ): Promise<boolean>
   reload(): void
 }
@@ -60,8 +58,9 @@ function docOf(shared: ProjectSettingsFileV1 | null | undefined): ProjectSetting
 
 /**
  * Field-level merge of `patch` into `current`, dropping `undefined` (a cleared field) and any
- * family the clearing leaves empty. Exported for the tests that pin the "an editor never blanks a
- * field it does not own" rule.
+ * family the clearing leaves empty. A whole family set to `undefined` is dropped outright.
+ * Exported for the tests that pin the "an editor never blanks a field it does not own" rule (see
+ * `mergeSharedDoc` in ProjectSettingsSection.test.tsx).
  */
 export function mergeSharedDoc(
   current: ProjectSettingsDoc,
@@ -138,14 +137,14 @@ export function useProjectSettings(projectId: string): ProjectSettingsHook {
 
   const saveShared = useCallback(
     async (doc: ProjectSettingsDoc): Promise<boolean> => {
-      const pending = pendingRef.current
+      const pending = pendingRef.current?.projectId === projectId ? pendingRef.current : null
       const snap = snapshotRef.current
-      const current =
-        pending?.projectId === projectId
-          ? pending.doc
-          : snap && snap !== 'loading'
-            ? docOf(snap.shared)
-            : {}
+      // Defence in depth under the editors' own `ready` gate: with no snapshot object AND no
+      // pending write to merge into, the merge base would be `{}` — and every write here is a
+      // WHOLE-document write, so committing it would delete whatever the file already holds. There
+      // is nothing to merge into yet, so there is nothing safe to write: refuse.
+      if (!pending && (snap === 'loading' || snap === null)) return false
+      const current = pending ? pending.doc : docOf((snap as ProjectSettingsSnapshot).shared)
       const next = mergeSharedDoc(current, doc)
       const ok = await window.nodeTerminal.projectSettings.writeShared(projectId, next)
       if (!ok) return false
@@ -160,16 +159,17 @@ export function useProjectSettings(projectId: string): ProjectSettingsHook {
 
   const saveLocal = useCallback(
     async (
-      update:
-        | ProjectLocalSettings
-        | undefined
-        | ((current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined)
+      update: (current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined
     ): Promise<boolean> => {
-      const pending = pendingLocalRef.current
+      const pending =
+        pendingLocalRef.current?.projectId === projectId ? pendingLocalRef.current : null
       const snap = snapshotRef.current
-      const current =
-        pending?.projectId === projectId ? pending.local : snap && snap !== 'loading' ? snap.local : undefined
-      const next = typeof update === 'function' ? update(current) : update
+      // Same refusal as `saveShared`, same reason: the local overlay is a whole-document write too,
+      // so an updater handed `undefined` because nothing has been READ yet (rather than because the
+      // overlay is genuinely empty) would erase this machine's overrides for every other family.
+      if (!pending && (snap === 'loading' || snap === null)) return false
+      const current = pending ? pending.local : (snap as ProjectSettingsSnapshot).local
+      const next = update(current)
       const ok = await window.nodeTerminal.projectSettings.updateLocal(projectId, next)
       if (!ok) return false
       // Advance the merge base NOW, not when the re-read lands: the next blur may arrive first.

--- a/src/renderer/components/settings/useProjectSettings.ts
+++ b/src/renderer/components/settings/useProjectSettings.ts
@@ -77,24 +77,37 @@ const EMPTY_FAMILIES = (): ResolvedProjectSettings => resolveProjectSettings(und
 export function useProjectSettings(projectId: string): ProjectSettingsHook {
   const [snapshot, setSnapshot] = useState<ProjectSettingsSnapshot | null | 'loading'>('loading')
   const [nonce, setNonce] = useState(0)
+  /** Counts successful writes, so a read can tell whether it started before or after the last one. */
+  const writeSeqRef = useRef(0)
 
-  // The merge base for `saveShared` must be the LATEST snapshot, without making the saver identity
+  // The merge base for `saveShared` must be the LATEST document, without making the saver identity
   // change on every read (a blur handler holding last render's saver would then merge into a stale
   // document and silently revert a sibling field).
   const snapshotRef = useRef<ProjectSettingsSnapshot | null | 'loading'>(snapshot)
   snapshotRef.current = snapshot
 
+  // The document we last WROTE, which outranks the snapshot until the re-read replaces it. Without
+  // it, two blurs in a row (shell, then theme) both merge into the pre-first-save document — and
+  // because every write is a WHOLE-document write, the second one silently drops the first. The
+  // re-read is asynchronous; the user's next blur is not going to wait for it. Tagged with the
+  // project id so a pane switch can never merge one project's edit into another's file.
+  const pendingRef = useRef<{ projectId: string; doc: ProjectSettingsDoc } | null>(null)
+
   useEffect(() => {
     let alive = true
     setSnapshot('loading')
-    void window.nodeTerminal.projectSettings.read(projectId).then(
-      (s) => {
-        if (alive) setSnapshot(s)
-      },
-      () => {
-        if (alive) setSnapshot(null)
-      }
-    )
+    // A read only supersedes the pending doc if no write happened while it was in flight;
+    // otherwise what we just wrote is still the newer truth. Belt-and-braces: the effect's own
+    // cancellation below already drops a read issued before the write in every path the test
+    // harness can produce — this closes the remaining window, where the write's `reload()`
+    // re-render has not been processed yet when the older read answers.
+    const seqAtStart = writeSeqRef.current
+    const settle = (next: ProjectSettingsSnapshot | null): void => {
+      if (!alive) return
+      if (writeSeqRef.current === seqAtStart) pendingRef.current = null
+      setSnapshot(next)
+    }
+    void window.nodeTerminal.projectSettings.read(projectId).then(settle, () => settle(null))
     return () => {
       alive = false
     }
@@ -104,14 +117,22 @@ export function useProjectSettings(projectId: string): ProjectSettingsHook {
 
   const saveShared = useCallback(
     async (doc: ProjectSettingsDoc): Promise<boolean> => {
+      const pending = pendingRef.current
       const snap = snapshotRef.current
-      const current = snap && snap !== 'loading' ? docOf(snap.shared) : {}
-      const ok = await window.nodeTerminal.projectSettings.writeShared(
-        projectId,
-        mergeSharedDoc(current, doc)
-      )
-      if (ok) reload()
-      return ok
+      const current =
+        pending?.projectId === projectId
+          ? pending.doc
+          : snap && snap !== 'loading'
+            ? docOf(snap.shared)
+            : {}
+      const next = mergeSharedDoc(current, doc)
+      const ok = await window.nodeTerminal.projectSettings.writeShared(projectId, next)
+      if (!ok) return false
+      // Advance the merge base NOW, not when the re-read lands: the next blur may arrive first.
+      writeSeqRef.current += 1
+      pendingRef.current = { projectId, doc: next }
+      reload()
+      return true
     },
     [projectId, reload]
   )

--- a/src/renderer/components/settings/useSettingsTarget.test.tsx
+++ b/src/renderer/components/settings/useSettingsTarget.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { FIRST_SECTION_ID, type SettingsSectionId } from './nav'
+import { useSettingsTarget, type SettingsTarget } from './useSettingsTarget'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('useSettingsTarget', () => {
+  let root: Root
+  let host: HTMLElement
+  let target: SettingsTarget
+
+  function Probe({
+    initialSection,
+    retargetNonce
+  }: {
+    initialSection?: SettingsSectionId
+    retargetNonce?: number
+  }): React.JSX.Element {
+    target = useSettingsTarget(initialSection, retargetNonce)
+    return <div>{target.active}</div>
+  }
+
+  const render = async (props: {
+    initialSection?: SettingsSectionId
+    retargetNonce?: number
+  }): Promise<void> => {
+    await act(async () => {
+      root.render(<Probe {...props} />)
+    })
+  }
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it('opens on the first section when no caller asked for one', async () => {
+    await render({})
+    expect(target.active).toBe(FIRST_SECTION_ID)
+    expect(target.query).toBe('')
+  })
+
+  it('opens on the section a deep link asked for', async () => {
+    await render({ initialSection: 'project-p1' as SettingsSectionId, retargetNonce: 1 })
+    expect(target.active).toBe('project-p1')
+  })
+
+  it('re-targets AND clears a stale query when the nonce is bumped for the SAME section', async () => {
+    await render({ initialSection: 'project-p1' as SettingsSectionId, retargetNonce: 1 })
+    await act(async () => {
+      target.setActive('ssh')
+      target.setQuery('zzzznomatch')
+    })
+    expect(target.active).toBe('ssh')
+    // Deep-linked to the same project again: only the nonce changes.
+    await render({ initialSection: 'project-p1' as SettingsSectionId, retargetNonce: 2 })
+    expect(target.active).toBe('project-p1')
+    // A filter left in the box would hide the pane the link just navigated to.
+    expect(target.query).toBe('')
+  })
+
+  it('leaves the user\'s in-dialog section and query alone when nothing re-targets', async () => {
+    await render({ initialSection: 'project-p1' as SettingsSectionId, retargetNonce: 1 })
+    await act(async () => {
+      target.setActive('ssh')
+      target.setQuery('shell')
+    })
+    // A plain re-render (parent state changed elsewhere): same section, same nonce.
+    await render({ initialSection: 'project-p1' as SettingsSectionId, retargetNonce: 1 })
+    expect(target.active).toBe('ssh')
+    expect(target.query).toBe('shell')
+  })
+
+  it('never clears the query for a plain open, which passes no section at all', async () => {
+    await render({})
+    await act(async () => {
+      target.setQuery('shell')
+    })
+    await render({ retargetNonce: undefined })
+    expect(target.query).toBe('shell')
+  })
+})

--- a/src/renderer/components/settings/useSettingsTarget.test.tsx
+++ b/src/renderer/components/settings/useSettingsTarget.test.tsx
@@ -89,3 +89,76 @@ describe('useSettingsTarget', () => {
     expect(target.query).toBe('shell')
   })
 })
+
+/**
+ * `active` outlives the dialog: Canvas keeps `settingsSection` across opens. So a project pane it
+ * points at can disappear (project closed) while the selection stays — and the panel then opens on
+ * a section nobody renders: no nav row, blank main area.
+ */
+describe('useSettingsTarget project fallback', () => {
+  let root: Root
+  let host: HTMLElement
+  let target: SettingsTarget
+
+  function Probe({
+    initialSection,
+    retargetNonce,
+    openProjectIds
+  }: {
+    initialSection?: SettingsSectionId
+    retargetNonce?: number
+    openProjectIds?: string[]
+  }): React.JSX.Element {
+    target = useSettingsTarget(initialSection, retargetNonce, openProjectIds)
+    return <div>{target.active}</div>
+  }
+
+  const render = async (props: {
+    initialSection?: SettingsSectionId
+    retargetNonce?: number
+    openProjectIds?: string[]
+  }): Promise<void> => {
+    await act(async () => {
+      root.render(<Probe {...props} />)
+    })
+  }
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it('falls back to the first section when the active project closes', async () => {
+    await render({ initialSection: 'project-p1' as SettingsSectionId, retargetNonce: 1, openProjectIds: ['p1', 'p2'] })
+    expect(target.active).toBe('project-p1')
+    // p1 closed while the dialog was shut; the selection is still pointing at its pane.
+    await render({ openProjectIds: ['p2'] })
+    expect(target.active).toBe(FIRST_SECTION_ID)
+  })
+
+  it('refuses a deep link to a project that has no pane', async () => {
+    await render({ initialSection: 'project-gone' as SettingsSectionId, retargetNonce: 1, openProjectIds: ['p1'] })
+    expect(target.active).toBe(FIRST_SECTION_ID)
+  })
+
+  it('leaves a live project section, and every non-project section, alone', async () => {
+    await render({ initialSection: 'project-p1' as SettingsSectionId, retargetNonce: 1, openProjectIds: ['p1'] })
+    expect(target.active).toBe('project-p1')
+    await act(async () => target.setActive('ssh'))
+    await render({ openProjectIds: [] })
+    expect(target.active).toBe('ssh')
+  })
+
+  it('never falls back when the caller passes no project list at all', async () => {
+    // `undefined` is "I have no list", not "no projects are open": a caller whose projects have not
+    // loaded yet must not bulldoze a legitimate deep link.
+    await render({ initialSection: 'project-p1' as SettingsSectionId, retargetNonce: 1 })
+    expect(target.active).toBe('project-p1')
+  })
+})

--- a/src/renderer/components/settings/useSettingsTarget.ts
+++ b/src/renderer/components/settings/useSettingsTarget.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { FIRST_SECTION_ID, type SettingsSectionId } from './nav'
+import { parseProjectSectionId } from './project-settings-targets'
 
 export interface SettingsTarget {
   /** Section whose pane is shown when the search box is empty. */
@@ -26,10 +27,23 @@ export interface SettingsTarget {
  *   not change, so the effect would not re-run.
  * - Plain opens (the gear, ⌘, , the native menu) pass no section and never bump the nonce, so a
  *   query or a section the user chose inside the dialog survives.
+ * - A project section that no longer exists falls back to the first section — see `openProjectIds`.
  */
 export function useSettingsTarget(
   initialSection: SettingsSectionId | undefined,
-  retargetNonce: number | undefined
+  retargetNonce: number | undefined,
+  /**
+   * Ids of the projects that currently HAVE a pane (SettingsPage's open-project list). `active`
+   * outlives the dialog — Canvas keeps it across opens — so a deep link to project X followed by
+   * closing X would otherwise leave the panel pointing at a section nobody renders: the nav row is
+   * gone and the main area is blank, with no way back but a click. Given the list, an `active` that
+   * names a project not in it falls back to the first section.
+   *
+   * Omitted (`undefined`) means "the caller has no list", not "no projects are open": the fallback
+   * is then skipped entirely, so a caller that has not loaded its projects yet cannot bulldoze a
+   * legitimate deep link. SettingsPage always passes the list.
+   */
+  openProjectIds?: string[]
 ): SettingsTarget {
   const [active, setActive] = useState<SettingsSectionId>(initialSection ?? FIRST_SECTION_ID)
   const [query, setQuery] = useState('')
@@ -39,6 +53,14 @@ export function useSettingsTarget(
     setActive(initialSection)
     setQuery('')
   }, [initialSection, retargetNonce])
+
+  useEffect(() => {
+    if (!openProjectIds) return
+    const projectId = parseProjectSectionId(active)
+    if (projectId === null) return
+    if (openProjectIds.includes(projectId)) return
+    setActive(FIRST_SECTION_ID)
+  }, [active, openProjectIds])
 
   return { active, setActive, query, setQuery }
 }

--- a/src/renderer/components/settings/useSettingsTarget.ts
+++ b/src/renderer/components/settings/useSettingsTarget.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import { FIRST_SECTION_ID, type SettingsSectionId } from './nav'
+
+export interface SettingsTarget {
+  /** Section whose pane is shown when the search box is empty. */
+  active: SettingsSectionId
+  setActive: (id: SettingsSectionId) => void
+  /** Current search query. Empty = no filtering. */
+  query: string
+  setQuery: (q: string) => void
+}
+
+/**
+ * What the settings dialog is currently pointed at, and how a caller re-points it.
+ *
+ * Its own hook (rather than two `useState`s inline in SettingsPage) because the retarget rule is
+ * the load-bearing half of the deep-link feature and SettingsPage itself is untestable in
+ * isolation — rendering it mounts ~25 section modules, every one of which reaches for the preload
+ * API on mount.
+ *
+ * The rule:
+ * - A deep link (`initialSection` + a BUMPED `retargetNonce`) selects that section AND clears the
+ *   query. Without the clear, a filter still sitting in the search box would hide the very pane
+ *   the link just navigated to — the nav row would highlight over an empty page.
+ * - The nonce is what makes a REPEAT of the same section re-target: `initialSection` alone would
+ *   not change, so the effect would not re-run.
+ * - Plain opens (the gear, ⌘, , the native menu) pass no section and never bump the nonce, so a
+ *   query or a section the user chose inside the dialog survives.
+ */
+export function useSettingsTarget(
+  initialSection: SettingsSectionId | undefined,
+  retargetNonce: number | undefined
+): SettingsTarget {
+  const [active, setActive] = useState<SettingsSectionId>(initialSection ?? FIRST_SECTION_ID)
+  const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    if (!initialSection) return
+    setActive(initialSection)
+    setQuery('')
+  }, [initialSection, retargetNonce])
+
+  return { active, setActive, query, setQuery }
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -238,6 +238,9 @@ export const IPC = {
   workspaceLoad: 'workspace:load',
   workspaceSave: 'workspace:save',
   workspaceProbeFolder: 'workspace:probe-folder',
+  projectSettingsRead: 'project-settings:read',
+  projectSettingsWriteShared: 'project-settings:write-shared',
+  projectSettingsUpdateLocal: 'project-settings:update-local',
   // main → renderer events
   workspaceMigrated: 'workspace:migrated',
   /** Payload: the `workspace.json.corrupt-<ts>` filename the unreadable index was preserved as. */

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -67,6 +67,19 @@ export type ProjectSettingsParse =
   | { status: 'invalid' }
   | { status: 'conflict' }
 
+/** What one project's settings look like right now: the git-shared document (null when there is
+ *  none, or it cannot be trusted/read) plus this machine's own overlay. `resolveProjectSettings`
+ *  turns the pair into effective values; this type only reports what each side says. Shared here
+ *  (not core) so the renderer's `ProjectSettingsApi` can name it without importing core. */
+export interface ProjectSettingsSnapshot {
+  shared: ProjectSettingsFileV1 | null
+  local: ProjectLocalSettings | undefined
+  /** The shared file exists but is git-conflict-marked, so it is left untouched for the user to
+   *  resolve. `shared` is null for a local ref; for an ssh project the last-known-good offline cache
+   *  is still served alongside the flag (it is the only readable copy of that document). */
+  conflict?: true
+}
+
 const STRING_CAP = 1024
 const BIG_STRING_CAP = 64000
 const LAUNCH_CMD_CAP = 4096

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -755,6 +755,19 @@ export interface WorkspaceApi {
   onExternalChange(cb: (project: Project) => void): () => void
 }
 
+export interface ProjectSettingsApi {
+  /** `{shared, local, conflict?}` for a known project id, or null for an unknown one. */
+  read(projectId: string): Promise<import('./project-settings').ProjectSettingsSnapshot | null>
+  /** Whole-document write of the git-shared `.nodeterm/settings.json`. See
+   *  `WorkspaceStore.writeProjectSettings` for the false-vs-true contract. */
+  writeShared(projectId: string, doc: import('./project-settings').ProjectSettingsDoc): Promise<boolean>
+  /** This machine's own overlay; `local: undefined` clears it. */
+  updateLocal(
+    projectId: string,
+    local: import('./project-settings').ProjectLocalSettings | undefined
+  ): Promise<boolean>
+}
+
 export interface DialogApi {
   /** Opens a native folder picker; returns the chosen path or null if cancelled. */
   selectFolder(): Promise<string | null>
@@ -2464,6 +2477,7 @@ export interface PresenceApi {
 export interface NodeTerminalApi {
   pty: PtyApi
   workspace: WorkspaceApi
+  projectSettings: ProjectSettingsApi
   dialog: DialogApi
   settings: SettingsApi
   speech: SpeechApi


### PR DESCRIPTION
## Summary

PR2 of the Project Settings series — **stacked on #315** (core data layer); review this one after (or together with) #315. Adds the entire user-facing surface:

- **IPC namespace** `projectSettings` (`read` / `writeShared` / `updateLocal`) registered inside `WorkspaceStore.registerIpc()`, so Electron and the Server Edition browser bridge get it from one registration. Stub leg fails closed; relay tabs never reach a write path (see below).
- **Dynamic Settings sections** — a "Projects" nav group composed at render time (the static `SETTINGS_GROUPS` and its test pins are untouched), one `project-<id>` section per open project; nav rows and panes derive from the same memoized list so they cannot disagree.
- **`useProjectSettings` hook** — whole-document writes with pending-write merge bases for both the shared doc and the machine-local overlay (two blurs inside one IPC round-trip cannot revert each other), loading-window guards at both the hook and editor layer (a blur during the initial read can never truncate the file), and failure surfacing (a refused save shows a warn note and re-reads so a freshly-appeared git conflict updates the banner).
- **Identity & defaults rows** (name, color, folder/SSH target, permission mode, managed account) persisting through the existing `markWorkspaceDirty` seam — inheriting Canvas's commit, debounce, and conflict gate rather than adding a third raw save path.
- **Four family editors** (setup/archive scripts, agent launch overrides + env, worktree defaults + shared paths, terminal overrides), each with shared editors plus a "This machine" override block, `ignoreShared` per family, and per-key provenance labels driven by the PR1 resolver. A conflicted `settings.json` disables shared editors only; projects with no folder get read-only shared rows with an explanation (their machine-local overlay still saves); **relay/remote and unavailable projects render no editors and trigger no reads** (a relay tab's API would write the guest's local store — tested that neither happens).
- **Search & deep links** — one shared `sectionVisible` predicate for both visibility gates; searching a project's *name* shows its whole pane (navigation, not row-filtering); "Project settings…" in the tab caret menu and the sidebar project context menu, with a retarget nonce that clears any stale search filter.

## Spec departures (for ratification)

Two simplifications relative to spec §3: no "remove project" row (the tab menu already owns close/remove), and provenance is rendered as note strings ("Overridden on this machine" / "Active") rather than a tri-state select with a "Use shared" ghost button — clearing the local field restores inheritance.

## Known follow-ups (deliberate)

- The query "project" still mounts every project pane (name-row title match) — the per-pane SSH read fan-out cap is a PR3 candidate at the pane gate; an overclaiming comment at `ProjectSettingsFamilies.tsx:128` will be corrected there.
- No `settings.json` external-change watcher yet (read-before-write in the store prevents damage; the panel shows stale values until reopened).
- Side-finding while mirroring persistence precedents: `setProjectCapability` (AgentsSection toggle) persists nothing today — pre-existing, reported separately.

## Test plan

- +69 tests across the branch (IPC round-trip through both shells' registration seam, nav/id round-trips, hook contracts incl. gated-read race tests, family editor behavior, folderless/remote/conflict states, search matrix pinning both gates agree, deep-link retarget + query clearing). Key invariants were mutation-checked (merge spreads, pending bases, guards).
- Full suite: 7423 passed / 12 skipped; typecheck clean on both tsconfigs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)