### PR TITLE
feat(canvas): per-node toggle to hide subagent/loop fan-out cards, plus tidy

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -1315,7 +1315,7 @@ export function Canvas() {
       // lives here, in the render layer, and nowhere else.
       if (!st.loop || st.loop.dismissed) continue
       const parent = nodes.find((n) => n.id === pid)
-      if (!parent) continue
+      if (!parent || parent.data.hideFanout) continue
       const ph = parent.measured?.height ?? (parent.height as number) ?? 400
       const accent = agentConfig((parent.data.agentId as string) ?? 'claude')?.color ?? '#d97757'
       const lid = `loop-${pid}`
@@ -1364,7 +1364,7 @@ export function Canvas() {
     }
     for (const [pid, childIds] of Object.entries(byParent)) {
       const parent = nodes.find((n) => n.id === pid)
-      if (!parent) continue
+      if (!parent || parent.data.hideFanout) continue
       const ph = parent.measured?.height ?? (parent.height as number) ?? 400
       const accent = agentConfig((parent.data.agentId as string) ?? 'claude')?.color ?? '#d97757'
       const COLS = 4

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -176,6 +176,20 @@ export const IconBranch = () => (
   </svg>
 )
 
+export const IconEye = () => (
+  <svg {...S}>
+    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+)
+
+export const IconEyeOff = () => (
+  <svg {...S}>
+    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 7 11 7a13.16 13.16 0 0 1-1.67 2.68M6.61 6.61A13.53 13.53 0 0 0 1 11s4 7 11 7a9.26 9.26 0 0 0 5.39-1.61M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+    <path d="M1 1l22 22" />
+  </svg>
+)
+
 export const IconEditor = () => (
   <svg {...S}>
     <path d="M9 8l-4 4 4 4M15 8l4 4-4 4" />

--- a/src/renderer/lib/ui-visibility.test.ts
+++ b/src/renderer/lib/ui-visibility.test.ts
@@ -26,7 +26,9 @@ describe('hideable inventories', () => {
       'group', 'remove-from-group', 'colors', 'duplicate', 'collapse',
       'markdown-view', 'refresh-terminal'
     ])
-    expect(HIDEABLE_HEADER_BUTTONS.map((r) => r.id)).toEqual(['refresh', 'mic', 'ai-name', 'comments'])
+    expect(HIDEABLE_HEADER_BUTTONS.map((r) => r.id)).toEqual([
+      'refresh', 'mic', 'ai-name', 'comments', 'hide-fanout', 'tidy-fanout'
+    ])
   })
   it('gives every entry a user-facing label', () => {
     for (const { label } of [...HIDEABLE_MENU_ITEMS, ...HIDEABLE_HEADER_BUTTONS])

--- a/src/renderer/lib/ui-visibility.ts
+++ b/src/renderer/lib/ui-visibility.ts
@@ -33,7 +33,9 @@ export const HIDEABLE_HEADER_BUTTONS: readonly HideableRow[] = [
   { id: 'refresh', label: 'Refresh' },
   { id: 'mic', label: 'Dictate' },
   { id: 'ai-name', label: 'Name with AI' },
-  { id: 'comments', label: 'Comments' }
+  { id: 'comments', label: 'Comments' },
+  { id: 'hide-fanout', label: 'Hide subagent/loop cards' },
+  { id: 'tidy-fanout', label: 'Tidy subagent cards' }
 ]
 
 /** Every id the user may hide — the guard that makes everything else unhideable. */

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -119,7 +119,7 @@ import {
 } from '../terminal/agent-restart'
 import { WakeInputBuffer } from '../terminal/wake-input-buffer'
 import { FindBar } from '../components/FindBar'
-import { IconSearch, IconChat, IconMic, IconReload } from '../components/icons'
+import { IconSearch, IconChat, IconMic, IconReload, IconEye, IconEyeOff, IconGrid } from '../components/icons'
 import { NodeLabels } from '../components/kanban/NodeLabels'
 import { Tooltip } from '../components/Tooltip'
 import { useTerminalSearch } from '../terminal/useTerminalSearch'
@@ -148,6 +148,7 @@ import { accountChipLabel, agentLaunchOverride, COLLAPSED_HEIGHT, NODE_COLORS, t
 import {
   hasHooks,
   canRecur,
+  canSubagent,
   canContextLink,
   hasUsage,
   canChat,
@@ -1290,6 +1291,12 @@ export function TerminalNode({
     !remoteSession &&
     (data.cwd as string | undefined) !== parentWtPath
   const status = useAgentStatus((s) => s.byId[id])
+  // Fan-out (subagent/loop card) visibility + tidy — any agent capable of either kind of card.
+  const fanoutCapable = !!agentId && (canSubagent(agentId) || canRecur(agentId))
+  const hideFanout = !!data.hideFanout
+  const fanoutCount = useAgentNodes(
+    (s) => Object.values(s.byId).filter((v) => v.parentNodeId === id).length
+  )
   // Transient, per-launch: what this node's Codex launcher reported it actually got. Undefined for
   // every non-codex node and for a codex node whose launcher never spoke.
   const codexIdentity = useCodexIdentity((s) => s.byId[id])
@@ -4512,6 +4519,38 @@ export function TerminalNode({
             </button>
           </Tooltip>
         )}
+        {fanoutCapable && !isHidden('hide-fanout', hiddenHeaderButtons) && (
+          <Tooltip label={hideFanout ? 'Show subagent/loop cards' : 'Hide subagent/loop cards'}>
+            <button
+              className="term-node__hide-fanout nodrag"
+              title={hideFanout ? 'Show subagent/loop cards' : 'Hide subagent/loop cards'}
+              aria-pressed={hideFanout}
+              onClick={(e) => {
+                e.stopPropagation()
+                updateNodeData(id, { hideFanout: !hideFanout })
+              }}
+            >
+              {hideFanout ? <IconEyeOff /> : <IconEye />}
+            </button>
+          </Tooltip>
+        )}
+        {fanoutCapable &&
+          !hideFanout &&
+          fanoutCount >= 2 &&
+          !isHidden('tidy-fanout', hiddenHeaderButtons) && (
+            <Tooltip label="Tidy subagent cards into a grid">
+              <button
+                className="term-node__tidy-fanout nodrag"
+                title="Tidy subagent cards into a grid"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  useAgentNodes.getState().tidyFanout(id)
+                }}
+              >
+                <IconGrid />
+              </button>
+            </Tooltip>
+          )}
         <button
           className="term-node__close"
           title="Close (ends the session)"

--- a/src/renderer/state/agentNodes.test.ts
+++ b/src/renderer/state/agentNodes.test.ts
@@ -18,6 +18,34 @@ describe('loop node overrides vs per-turn fan-out', () => {
     expect(useAgentNodes.getState().positions['loop-n1']).toEqual({ x: 5, y: 6 })
   })
 
+  it('tidyFanout drops only the given parent\'s subagent overrides, keeping the loop card and other parents', () => {
+    const s = useAgentNodes.getState()
+    s.start('tu1', { parentNodeId: 'n1' })
+    s.start('tu2', { parentNodeId: 'n1' })
+    s.start('tu3', { parentNodeId: 'n2' })
+    s.setPosition('tu1', { x: 1, y: 2 })
+    s.setSize('tu2', { width: 400, height: 300 })
+    s.toggleExpanded('tu2')
+    s.setPosition('tu3', { x: 9, y: 9 })
+    s.setPosition('loop-n1', { x: 5, y: 6 })
+    s.tidyFanout('n1')
+    const st = useAgentNodes.getState()
+    expect(st.positions['tu1']).toBeUndefined()
+    expect(st.sizes['tu2']).toBeUndefined()
+    expect(st.expanded['tu2']).toBeUndefined()
+    expect(st.positions['tu3']).toEqual({ x: 9, y: 9 })
+    expect(st.positions['loop-n1']).toEqual({ x: 5, y: 6 })
+    // The cards themselves survive — only their placement overrides are dropped.
+    expect(st.byId['tu1']).toBeDefined()
+    expect(st.byId['tu2']).toBeDefined()
+  })
+
+  it('tidyFanout is a no-op for a parent with no subagents', () => {
+    const before = useAgentNodes.getState()
+    useAgentNodes.getState().tidyFanout('nobody')
+    expect(useAgentNodes.getState()).toBe(before)
+  })
+
   it('clearLoop drops only the loop card overrides', () => {
     const s = useAgentNodes.getState()
     s.start('tu1', { parentNodeId: 'n1' })

--- a/src/renderer/state/agentNodes.ts
+++ b/src/renderer/state/agentNodes.ts
@@ -70,6 +70,15 @@ interface AgentNodesState {
   /** Remove all subagents spawned by a given parent node (turn/session ended, or node closed). */
   clearForParent(parentNodeId: string): void
   /**
+   * Drop every dragged position/size/expanded override for a parent's subagent cards, snapping
+   * them back to the default packed grid (`offsetFrom`'s fallback in Canvas) at base dims — an
+   * expanded card kept at its larger size would still overlap its grid neighbors. Loop cards are
+   * excluded — there is only ever one per parent, so there is nothing to pack. If this is ever
+   * extended to loop cards, route through `saveLoopOverrides` too, or a cleared `loop-*` entry
+   * would resurrect from its localStorage mirror on reload.
+   */
+  tidyFanout(parentNodeId: string): void
+  /**
    * Drop the loop card's UI overrides (position/size/expanded) for a parent. Separate from
    * clearForParent on purpose: a loop/cron card outlives turns, so the per-turn fan-out
    * clear must not reset where the user dragged it — this runs only when the loop ends.
@@ -192,6 +201,21 @@ export const useAgentNodes = create<AgentNodesState>((set) => ({
       // come back pre-selected.
       const selectedId = s.selectedId && ids.includes(s.selectedId) ? null : s.selectedId
       return { byId, activityById, positions, sizes, expanded, selectedId }
+    }),
+
+  tidyFanout: (parentNodeId) =>
+    set((s) => {
+      const ids = Object.keys(s.byId).filter((id) => s.byId[id].parentNodeId === parentNodeId)
+      if (!ids.length) return s
+      const positions = { ...s.positions }
+      const sizes = { ...s.sizes }
+      const expanded = { ...s.expanded }
+      for (const id of ids) {
+        delete positions[id]
+        delete sizes[id]
+        delete expanded[id]
+      }
+      return { positions, sizes, expanded }
     }),
 
   clearLoop: (parentNodeId) =>

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -57,6 +57,8 @@ export interface NodeData {
   group: string | null
   tags?: string[]
   collapsed?: boolean
+  /** Agent nodes only: when true, this node's subagent/loop fan-out cards are hidden. */
+  hideFanout?: boolean
   /** Expanded height to restore when un-collapsing (kept out of the persisted size). */
   expandedHeight?: number
   /** One-shot command run once when the terminal first opens (not persisted). */
@@ -1316,6 +1318,7 @@ export function nodeStatesToFlow(states: CanvasNodeState[]): CanvasNode[] {
         group: n.group,
         tags: n.tags,
         collapsed,
+        hideFanout: n.hideFanout,
         expandedHeight: n.size.height,
         shell: n.shell,
         cwd: n.cwd,
@@ -1385,6 +1388,7 @@ export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
         group: n.data.group,
         tags: n.data.tags,
         collapsed: n.data.collapsed,
+        hideFanout: n.data.hideFanout,
         parentId: n.parentId,
         shell: n.data.shell,
         cwd: n.data.cwd,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1739,6 +1739,30 @@ body,
   color: var(--accent-text);
 }
 
+.term-node__hide-fanout,
+.term-node__tidy-fanout {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  line-height: 1;
+  padding: 2px 5px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.term-node__hide-fanout:hover,
+.term-node__tidy-fanout:hover {
+  background: rgba(10, 132, 255, 0.18);
+  color: var(--accent-text);
+}
+
+.term-node__hide-fanout[aria-pressed='true'] {
+  color: var(--accent-text);
+}
+
 .term-node__find {
   display: flex;
   flex-direction: column;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -235,6 +235,8 @@ export interface CanvasNodeState {
   tags?: string[]
   /** When true the node body is hidden (header-only). */
   collapsed?: boolean
+  /** Agent nodes only: when true, this node's subagent/loop fan-out cards are hidden. */
+  hideFanout?: boolean
   /** Parent group node id, if this node belongs to a group frame. */
   parentId?: string
   // terminal-only


### PR DESCRIPTION
## Summary
- Persisted `data.hideFanout` flag on agent nodes (`CanvasNodeState`/`NodeData`), threaded through both serializers.
- New header eye toggle on subagent/loop-capable agent nodes hides that node's ephemeral fan-out cards + edges. Render-only: subagent/loop tracking, `agentStatus.loop`, and the hibernation guard's evidence keep working underneath.
- New header "tidy" button (shown when a node has 2+ subagent cards) resets dragged position/size/expanded overrides back to the default packed grid. Loop cards excluded — one per parent, nothing to pack.
- Both buttons registered as user-hideable in Settings → Appearance (`HIDEABLE_HEADER_BUTTONS`).

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/state/agentNodes.test.ts src/renderer/lib/ui-visibility.test.ts` (new/updated tests pass)
- [x] Full `npx vitest run` — 32 pre-existing failures, none touching changed files (node-pty rebuild patch, real-tmux socket path length, board-log broadcast — all environment-dependent, unrelated)