### PR TITLE
feat(keybindings): settings UI, conflict blocking, and dictation migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1589,6 +1589,41 @@ disappearing" rather than as an occasional cull. The `vm_stat` reader is what ma
 again; the grace window was never the thing that was wrong.
 
 
+## Keybindings (registry, overrides, dispatch)
+
+Every user-facing chord is a registry command, and the whole engine is **one module**:
+`src/shared/keybindings.ts` holds the command registry, per-command validation
+(`normalizeBindingForCommand`), effective-binding resolution, conflict detection, override
+sanitization and the pure event→command resolver. **Do not split it** — main, the renderer and the
+Server Edition bridge all import it, and a second copy of any of those five is how the dispatcher,
+the Settings section and ShortcutsPanel start disagreeing about what a chord means.
+
+- **Overrides live in `settings.keybindings`** (hand-editable JSON): an absent id = the registry
+  default, `[]` = **disabled**, a list = exactly those chords. It is **sanitized at READ**
+  (`sanitizeKeybindingOverrides` → `renderer/lib/keybindingOverrides.ts`, memoized on the raw
+  object's identity), which is what makes a hand-edited file safe; the Settings section refuses a
+  bad candidate BEFORE saving (`commitCandidate`) so the user learns which chord was refused
+  instead of watching it vanish on the next launch. The write path is raw and the gates read the
+  sanitized map, so a dropped hand-edit is invisible in the UI but still on disk until a UI write
+  or Reset replaces the map.
+- **Dispatch has exactly two owners.** The renderer's is ONE window `keydown` listener in
+  `Canvas.tsx`, on the **bubble** phase — the Settings recorder's `stopPropagation` on an armed
+  capture depends on that, and moving it to capture would let a recorded chord fire the command it
+  is being bound to. The main process's is `src/main/keydown-intercept.ts`, a **closed allowlist**
+  of chords it must steal back from the application menu before the page ever sees them.
+- **Invariants**
+  - **Never read `settings.speech.shortcut`.** The dictation chord is `dictationBinding()` (the
+    first effective `speech.dictation` binding); the legacy field is a **downgrade mirror only**,
+    written by `setKeybindingOverride` so an older build still finds the user's chord.
+  - **`isHoldChord('')` is TRUE** (an all-false parse has a null key), and `''` is what a DISABLED
+    dictation binding reads as — so every caller owes an explicit `=== ''` check first. Without it
+    a disabled binding arms a modifier-less hold chord that fires on any keydown.
+  - **`MAIN_INTERCEPTED_COMMAND_IDS` must mirror the registry-backed commands `keydown-intercept.ts`
+    actually resolves** (`keydown-intercept.test.ts` pins it). The Settings UI's app-wide shadow
+    warning reads that list and cannot derive it — main is not importable from the renderer. Note
+    what the pin cannot cover: a HARDCODED intercept (the `Digit0` branch) has no command id, so it
+    swallows its chord app-wide with the recorder reporting no conflict.
+
 ## Canvas interaction & panels (`Canvas.tsx` is the hub)
 
 - **Context menus** (`components/ContextMenu.tsx`, portal, icons from `components/icons.tsx`):

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ LAN**. The same canvas also runs self-hosted in any browser (Server Edition).
 
 ### Talk to your terminal
 
-Hold `⌘⇧D` and say it. On-device **Whisper** transcribes locally — review the text,
+Hold `⌘⌥` and say it. On-device **Whisper** transcribes locally — review the text,
 then **Send** (nothing auto-submits). Your voice never leaves the machine.
 
 </td>
@@ -132,7 +132,7 @@ GitHub Copilot / opencode / Grok / custom) · 📝 **Sticky note** (link to an a
   agent sessions (`claude --resume`). The macOS app **ships its own tmux**, so this works
   with nothing installed; a tmux already on your system is always used in preference to it,
   and terminals opened before an upgrade stay as they were until you refresh the node.
-- **Talk to your terminal** — on-device Whisper dictation (⌘⇧D): speak, review, send.
+- **Talk to your terminal** — on-device Whisper dictation (hold ⌘⌥): speak, review, send.
 - **Agent superpowers** — **context links** so agent nodes read each other's transcripts
   on demand; Claude-only **branch a conversation** and **managed accounts** for several
   logged-in Claude identities side by side; agents can drive the canvas (open nodes,
@@ -233,6 +233,8 @@ npm run server:dev # build + run the browser Server Edition (needs Node 22 + tmu
 
 ## ⌨️ Keyboard shortcuts
 
+These are the defaults — every one of them is remappable in **Settings → Keyboard Shortcuts**.
+
 | Shortcut | Action |
 | --- | --- |
 | `⌘K` | Command palette |
@@ -241,7 +243,7 @@ npm run server:dev # build + run the browser Server Edition (needs Node 22 + tmu
 | `⌘W` | Close the selected node |
 | `⌘Z` / `⌘⇧Z` | Undo / Redo |
 | `⌘M` | Toggle markdown view (terminal / editor) |
-| `⌘⇧D` | Dictate into the focused terminal |
+| Hold `⌘⌥` (`Ctrl+Alt`) | Dictate into the focused terminal |
 | `⌘⇧E` | File explorer |
 | `⌘,` | Settings · `⌘/` Shortcuts |
 | `Right-click` | Actions menu (empty space or node) |

--- a/src/core/settings-store.test.ts
+++ b/src/core/settings-store.test.ts
@@ -6,7 +6,7 @@ import { IPC } from '../shared/ipc'
 import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform } from './platform-fake'
 import { SettingsStore } from './settings-store'
-import { DEFAULT_SETTINGS } from '../shared/types'
+import { DEFAULT_SETTINGS, type Settings } from '../shared/types'
 
 describe('SettingsStore nested-default merge', () => {
   let dir: string
@@ -142,6 +142,63 @@ describe('SettingsStore nested-default merge', () => {
       expect(load(42).get().terminalGpuRendering).toBe('auto')
       expect(load(null).get().terminalGpuRendering).toBe('auto')
       expect(load({ mode: 'shared' }).get().terminalGpuRendering).toBe('auto')
+    })
+  })
+
+  describe('dictation chord seed (one-shot migration)', () => {
+    // Same disk fixture as the sibling describes: write a settings.json, load it through the real
+    // store, read the merged result back.
+    const loadWith = (saved: Record<string, unknown>): Settings => {
+      writeFileSync(path.join(dir, 'settings.json'), JSON.stringify(saved), 'utf-8')
+      const store = new SettingsStore()
+      store.init()
+      return store.get()
+    }
+
+    it('a customized legacy speech.shortcut becomes the speech.dictation override', () => {
+      // The whole point of the migration: a user who had rebound dictation before the keybinding
+      // registry existed keeps their chord, because every consumer now reads the override.
+      const s = loadWith({
+        speech: { engine: 'whisper', model: '', language: 'auto', shortcut: 'Cmd+Shift+D' }
+      })
+      expect(s.keybindings?.['speech.dictation']).toEqual(['Cmd+Shift+D'])
+      // The legacy field lives on as the downgrade mirror — the seed must not consume it.
+      expect(s.speech.shortcut).toBe('Cmd+Shift+D')
+    })
+
+    it('a default shortcut seeds nothing', () => {
+      // Seeding the default would write an override that says exactly what the registry already
+      // says, and would then pin that chord forever against any future default change.
+      const s = loadWith({})
+      expect(s.keybindings?.['speech.dictation']).toBeUndefined()
+    })
+
+    it('an existing speech.dictation key wins over the legacy field — including disabled', () => {
+      // `[]` is a deliberate "dictation has no chord". Re-seeding it from the legacy field would
+      // hand the user back the shortcut they explicitly turned off, on every single load.
+      const s = loadWith({
+        speech: { engine: 'whisper', model: '', language: 'auto', shortcut: 'Cmd+Shift+D' },
+        keybindings: { 'speech.dictation': [] }
+      })
+      expect(s.keybindings?.['speech.dictation']).toEqual([])
+    })
+
+    it('seeding does not disturb other overrides', () => {
+      const s = loadWith({
+        speech: { engine: 'whisper', model: '', language: 'auto', shortcut: 'Cmd+Alt+D' },
+        keybindings: { 'canvas.undo': [] }
+      })
+      expect(s.keybindings).toEqual({ 'canvas.undo': [], 'speech.dictation': ['Cmd+Alt+D'] })
+    })
+
+    it('is idempotent — a seeded file re-loaded seeds nothing new', () => {
+      // Load 1 seeds; load 2 sees the key and leaves it alone. Without the key check the seed
+      // would keep overwriting a chord the user changed AFTER the migration, every launch.
+      const once = loadWith({
+        speech: { engine: 'whisper', model: '', language: 'auto', shortcut: 'Cmd+Shift+D' }
+      })
+      const twice = loadWith({ ...once, keybindings: { 'speech.dictation': ['Cmd+Alt+K'] } })
+      expect(twice.keybindings?.['speech.dictation']).toEqual(['Cmd+Alt+K'])
     })
   })
 })

--- a/src/core/settings-store.ts
+++ b/src/core/settings-store.ts
@@ -19,6 +19,22 @@ function mergeSettings(saved: Partial<Settings> | null | undefined): Settings {
     ...DEFAULT_SETTINGS.modelGateway,
     ...saved?.modelGateway,
   };
+  // One-shot dictation migration: a customized legacy `speech.shortcut` becomes the
+  // `speech.dictation` override that every consumer now reads (renderer lib `dictationBinding()`).
+  // Once the key exists — user-set, seeded, or explicitly disabled (`[]`) — it is the truth and
+  // this never runs again; the legacy field lives on only as a downgrade mirror (the renderer
+  // write path keeps it in sync so an older build still finds the user's chord).
+  // A shortcut EQUAL to the default seeds nothing: the override would only restate what the
+  // registry already says, and would then pin that chord against any future default change.
+  if (
+    merged.speech.shortcut !== DEFAULT_SETTINGS.speech.shortcut &&
+    !(merged.keybindings && "speech.dictation" in merged.keybindings)
+  ) {
+    merged.keybindings = {
+      ...(merged.keybindings ?? {}),
+      "speech.dictation": [merged.speech.shortcut],
+    };
+  }
   // Legacy `terminalGpuRendering` was a boolean whose default (true) was merged into every saved
   // file — so a stored `true` is indistinguishable from "never touched" and maps to the new
   // 'auto' (platform-aware) default, while a stored `false` was always an explicit escape-hatch

--- a/src/core/settings-store.ts
+++ b/src/core/settings-store.ts
@@ -26,6 +26,12 @@ function mergeSettings(saved: Partial<Settings> | null | undefined): Settings {
   // write path keeps it in sync so an older build still finds the user's chord).
   // A shortcut EQUAL to the default seeds nothing: the override would only restate what the
   // registry already says, and would then pin that chord against any future default change.
+  // **Seeding here is not the same as surviving.** The value written below is a plain override,
+  // so the READ path's sanitizer (`sanitizeKeybindingOverrides`) can still STRIP it: if the
+  // legacy chord collides with another command's effective binding in the same conflict bucket,
+  // every OVERRIDDEN participant of that conflict is deleted — the seed goes, dictation silently
+  // falls back to the registry default chord, and the user's own colliding override is dropped
+  // with it. The only signal is a console warning; nothing surfaces in the UI.
   if (
     merged.speech.shortcut !== DEFAULT_SETTINGS.speech.shortcut &&
     !(merged.keybindings && "speech.dictation" in merged.keybindings)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -292,6 +292,18 @@ const currentInterceptBindings = (): KeydownInterceptBindings =>
 settingsStore.onChange((s) => {
   interceptBindings = resolveInterceptBindings(s.keybindings, interceptIsMac)
 })
+// Settings' shortcut recorder is armed: stand every intercept down so the chord the user presses
+// reaches the recorder. Without it, recording ⌘W CLOSES THE SELECTED NODES — a claimed chord never
+// reaches the page, so the recorder's own preventDefault cannot save it.
+// A module-level `let` read through a closure, exactly like `interceptBindings` above: the window
+// is created later and can be recreated (macOS dock reopen), so nothing may capture a value.
+// FAIL-SAFE DIRECTION: every uncertainty resolves to `false` (intercepts on). A renderer that
+// crashes or a window that closes while armed clears it — see `createWindow` — because the
+// alternative is ⌘W/⌘M/⌘0 dead app-wide with no component left alive to release the bit.
+let shortcutRecording = false
+const clearShortcutRecording = (): void => {
+  shortcutRecording = false
+}
 const sshStore = new SshStore()
 const ptyManager = new PtyManager()
 // Dictation: local whisper.cpp models live under userData, one dir per install (same convention
@@ -622,6 +634,11 @@ function createWindow(): BrowserWindow {
     // client to co-attach to that node would inherit a frozen terminal. The tmux sessions
     // themselves keep running, exactly as they do on quit (killAll).
     ptyManager.dropClient(presenceId)
+    // The window that armed the recorder is gone, so nothing can ever disarm it. Leaving the bit
+    // set would suppress ⌘W/⌘M/⌘0 for the NEXT window too (the flag outlives the window; a dock
+    // reopen builds a fresh one). Same shape as the dropClient above: state this window owned,
+    // released where its departure is observed.
+    clearShortcutRecording()
   })
   // A crashed/killed renderer is the same story, minus the window: drop its subscriptions so the
   // reloaded renderer reattaches to live sessions instead of inheriting the dead one's state.
@@ -632,6 +649,9 @@ function createWindow(): BrowserWindow {
   const crashReload = createCrashReloadPolicy()
   win.webContents.on('render-process-gone', (_event, details) => {
     ptyManager.dropClient(presenceId)
+    // A dead renderer sends no disarm. The reloaded page mounts no recorder, so without this the
+    // user would come back to an app where ⌘W does nothing at all.
+    clearShortcutRecording()
     if (quitting || win.isDestroyed()) return
     const action = crashReload(details.reason, Date.now())
     if (action === 'reload') {
@@ -686,7 +706,7 @@ function createWindow(): BrowserWindow {
   // resetZoom) and forward each to the renderer instead. The decision — and, importantly, what it
   // must REFUSE — is in `keydown-intercept.ts`, where it can be pressed by a test. The first two
   // are the user's effective `node.toggleMarkdown` / `node.close` bindings (⌘0 is not remappable).
-  installKeydownIntercepts(win, currentInterceptBindings, interceptIsMac)
+  installKeydownIntercepts(win, currentInterceptBindings, interceptIsMac, () => shortcutRecording)
 
   // Open external links in the system browser — only safe schemes (no file://, no custom
   // protocol handlers). Reachable from remotely-fetched announcement URLs and rendered
@@ -911,6 +931,16 @@ app.whenReady().then(async () => {
   )
 
   ipcMain.on(IPC.appCloseWindow, () => BrowserWindow.getFocusedWindow()?.close())
+
+  // Settings' shortcut recorder arming/disarming. Guarded on the sender being the live main window
+  // (the same `getMainWindow()?.webContents.id !== event.sender.id` test `registerElectronGitHubControl`
+  // uses): a <webview> guest — a browser node showing an arbitrary page — is a webContents in this
+  // process too, and this bit disables the app's own keyboard shortcuts. Resolved at call time, not
+  // captured, because the window can be closed and recreated on macOS.
+  ipcMain.on(IPC.uiShortcutRecording, (event, active: boolean) => {
+    if (getMainWindow()?.webContents.id !== event.sender.id) return
+    shortcutRecording = active === true
+  })
 
   // Bring the window forward after a file is dropped into a terminal. On macOS a drag-drop from
   // another app does NOT activate the destination app, so without this the drag-source keeps OS

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -90,6 +90,7 @@ import {
 import { setMainWindow, getMainWindow, sendToMain, closeAction, createCrashReloadPolicy } from './main-window'
 import {
   installKeydownIntercepts,
+  navigationClearsRecording,
   resolveInterceptBindings,
   type KeydownInterceptBindings
 } from './keydown-intercept'
@@ -297,9 +298,12 @@ settingsStore.onChange((s) => {
 // reaches the page, so the recorder's own preventDefault cannot save it.
 // A module-level `let` read through a closure, exactly like `interceptBindings` above: the window
 // is created later and can be recreated (macOS dock reopen), so nothing may capture a value.
-// FAIL-SAFE DIRECTION: every uncertainty resolves to `false` (intercepts on). A renderer that
-// crashes or a window that closes while armed clears it — see `createWindow` — because the
-// alternative is ⌘W/⌘M/⌘0 dead app-wide with no component left alive to release the bit.
+// FAIL-SAFE DIRECTION: every uncertainty resolves to `false` (intercepts on). The alternative is
+// ⌘W/⌘M/⌘0 dead app-wide with no component left alive to release the bit, so EVERY way the page
+// that armed it can stop existing owes a clear — `createWindow` wires three (window `closed`,
+// `render-process-gone`, and a main-frame navigation, i.e. ⌘R). That is three known paths, not a
+// proof of exhaustiveness: a fourth would show up as "⌘W stopped working after I did X", so add
+// its reset beside the others rather than assuming this list is closed.
 let shortcutRecording = false
 const clearShortcutRecording = (): void => {
   shortcutRecording = false
@@ -707,6 +711,16 @@ function createWindow(): BrowserWindow {
   // must REFUSE — is in `keydown-intercept.ts`, where it can be pressed by a test. The first two
   // are the user's effective `node.toggleMarkdown` / `node.close` bindings (⌘0 is not remappable).
   installKeydownIntercepts(win, currentInterceptBindings, interceptIsMac, () => shortcutRecording)
+
+  // The THIRD way the page that armed a recorder can go away: a reload. The View menu above
+  // restores `{role:'reload'}` / `{role:'forceReload'}`, and ⌘R/⌘⇧R are accelerators — handled
+  // above the page, so the recorder cannot preventDefault its way out of one, and a same-process
+  // reload fires neither `closed` nor `render-process-gone`. `navigationClearsRecording` is the
+  // (tested) filter: a same-document navigation is the SAME page with the recorder still armed,
+  // and a subframe is not this page at all.
+  win.webContents.on('did-start-navigation', (details) => {
+    if (navigationClearsRecording(details)) clearShortcutRecording()
+  })
 
   // Open external links in the system browser — only safe schemes (no file://, no custom
   // protocol handlers). Reachable from remotely-fetched announcement URLs and rendered

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { IPC } from '../shared/ipc'
+import { MAIN_INTERCEPTED_COMMAND_IDS } from '../shared/keybindings'
 import {
   installKeydownIntercepts,
   keydownIntercept,
@@ -57,10 +58,28 @@ function press(
 ): { prevented: boolean; sent: string[] } {
   const isMac = opts.isMac ?? true
   const bindings = opts.bindings ?? (isMac ? DEFAULTS : DEFAULTS_PC)
+  // Not recording: the ordinary state of the app, and the baseline every case below asserts
+  // against. The armed state has its own describe block at the bottom of this file.
+  const seam = install(() => bindings, isMac, () => false)
+  seam.fire(over)
+  return { prevented: seam.prevented.length > 0, sent: seam.sent }
+}
+
+/**
+ * ONE installation whose listener can be fired repeatedly — the shape a live window has, and the
+ * only way to press the same key on both sides of a state change (the recording bit flipping under
+ * a running window is exactly what `press`, which installs per call, cannot show).
+ */
+function install(
+  getBindings: () => KeydownInterceptBindings,
+  isMac: boolean,
+  isRecording: () => boolean
+): { fire: (over?: Partial<KeydownInterceptInput>) => void; prevented: string[]; sent: string[] } {
   let handler:
     | ((event: { preventDefault(): void }, input: KeydownInterceptInput) => void)
     | null = null
   const sent: string[] = []
+  const prevented: string[] = []
   const win: KeydownInterceptTarget = {
     webContents: {
       on: (_event, listener) => {
@@ -71,14 +90,16 @@ function press(
       }
     }
   }
-  installKeydownIntercepts(win, () => bindings, isMac)
+  installKeydownIntercepts(win, getBindings, isMac, isRecording)
   if (!handler) throw new Error('installKeydownIntercepts registered no before-input-event listener')
-  let prevented = false
-  ;(handler as (e: { preventDefault(): void }, i: KeydownInterceptInput) => void)(
-    { preventDefault: () => (prevented = true) },
-    input(over)
-  )
-  return { prevented, sent }
+  const fire = (over: Partial<KeydownInterceptInput> = {}): void => {
+    const i = input(over)
+    ;(handler as (e: { preventDefault(): void }, i: KeydownInterceptInput) => void)(
+      { preventDefault: () => prevented.push(i.code) },
+      i
+    )
+  }
+  return { fire, prevented, sent }
 }
 
 /** Nothing happened at all: the page gets the key, and so does the menu if the page ignores it. */
@@ -299,5 +320,53 @@ describe('binding-driven intercept', () => {
       { prevented: true, sent: [IPC.appCloseNode] }
     )
     expect(press({ meta: true, key: 'w', code: 'KeyW' }, { bindings: remapped })).toEqual(UNTOUCHED)
+  })
+
+  // LIST DRIFT. `MAIN_INTERCEPTED_COMMAND_IDS` is what the Settings UI checks a candidate binding
+  // against for the app-wide shadow warning (`findMainInterceptShadowing`), and nothing else ties
+  // it to the commands THIS module actually resolves. A third intercept added here without the id
+  // added there would be swallowed app-wide with the recorder cheerfully reporting no conflict.
+  it('MAIN_INTERCEPTED_COMMAND_IDS is exactly the set this module resolves', () => {
+    expect(Object.keys(DEFAULTS)).toHaveLength(MAIN_INTERCEPTED_COMMAND_IDS.length)
+    // Unbinding a listed command must visibly change what this module resolves — i.e. it is read
+    // here, not merely claimed.
+    for (const id of MAIN_INTERCEPTED_COMMAND_IDS) {
+      expect(resolveInterceptBindings({ [id]: [] }, true), id).not.toEqual(DEFAULTS)
+    }
+  })
+})
+
+/**
+ * THE bug this suppression exists to close: the Settings shortcut recorder asks the user to PRESS
+ * the chord they want to bind, and pressing ⌘W there used to reach `app:close-node` — deleting the
+ * selected nodes instead of recording a keystroke. A claimed chord never reaches the page at all,
+ * so the recorder's own `preventDefault`/`stopPropagation` cannot help: main has to stand down.
+ */
+describe('an armed shortcut recorder suspends every interception', () => {
+  it('suppresses while armed and resumes on disarm', () => {
+    let recording = true
+    const seam = install(() => DEFAULTS, true, () => recording)
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    seam.fire({ meta: true, key: 'm', code: 'KeyM' })
+    seam.fire({ meta: true, code: 'Digit0' })
+    // Not swallowed either: `preventDefault` would take the key from the recorder as well as the
+    // menu, so the suppression must return BEFORE it, not merely skip the send.
+    expect(seam.prevented).toEqual([])
+    expect(seam.sent).toEqual([])
+    recording = false
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([IPC.appCloseNode])
+    expect(seam.prevented).toEqual(['KeyW'])
+  })
+
+  it('is read per event, not captured at install time', () => {
+    // The bit lives in a module-level `let` in index.ts that the renderer flips over IPC long
+    // after the window was created; a captured boolean would make the whole feature inert.
+    let recording = false
+    const seam = install(() => DEFAULTS, true, () => recording)
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    recording = true
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([IPC.appCloseNode])
   })
 })

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -4,6 +4,7 @@ import { MAIN_INTERCEPTED_COMMAND_IDS } from '../shared/keybindings'
 import {
   installKeydownIntercepts,
   keydownIntercept,
+  navigationClearsRecording,
   resolveInterceptBindings,
   type KeydownInterceptBindings,
   type KeydownInterceptInput,
@@ -357,6 +358,39 @@ describe('an armed shortcut recorder suspends every interception', () => {
     seam.fire({ meta: true, key: 'w', code: 'KeyW' })
     expect(seam.sent).toEqual([IPC.appCloseNode])
     expect(seam.prevented).toEqual(['KeyW'])
+  })
+
+  // THE HOLE REVIEW FOUND. The app's own View menu restores `{role:'reload'}` /
+  // `{role:'forceReload'}`, and ⌘R/⌘⇧R are ACCELERATORS — they fire above the page, so the
+  // recorder's preventDefault cannot stop them. A same-process reload fires no React unmount, no
+  // window `closed` and no `render-process-gone`, so every release path this feature had missed
+  // it and the bit stayed true forever: ⌘W/⌘M/⌘0 dead app-wide with nothing left to clear them.
+  // This mirrors index.ts's wiring exactly — the listener runs the same predicate.
+  it('a reload while armed restores interception; an in-page navigation does not', () => {
+    let recording = true
+    const seam = install(() => DEFAULTS, true, () => recording)
+    const onNavigation = (d: { isMainFrame: boolean; isSameDocument: boolean }): void => {
+      if (navigationClearsRecording(d)) recording = false
+    }
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([])
+    // pushState / a fragment jump is not a page change: the recorder is still mounted and armed,
+    // so disarming here would suppress the recorder instead of the intercept.
+    onNavigation({ isMainFrame: true, isSameDocument: true })
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([])
+    onNavigation({ isMainFrame: true, isSameDocument: false }) // ⌘R
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([IPC.appCloseNode])
+  })
+
+  it('only a real main-frame document navigation clears the bit', () => {
+    expect(navigationClearsRecording({ isMainFrame: true, isSameDocument: false })).toBe(true)
+    expect(navigationClearsRecording({ isMainFrame: true, isSameDocument: true })).toBe(false)
+    // A subframe navigating is not this page going away — an iframe/ad reloading itself must not
+    // silently re-arm the app's shortcuts under a recorder that is still listening.
+    expect(navigationClearsRecording({ isMainFrame: false, isSameDocument: false })).toBe(false)
+    expect(navigationClearsRecording({ isMainFrame: false, isSameDocument: true })).toBe(false)
   })
 
   it('is read per event, not captured at install time', () => {

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -28,7 +28,10 @@ import { matchesShortcut } from '../shared/shortcut'
  * **This module stays the closed list of main-intercepted chords.** ⌘M and ⌘W are now resolved
  * from the keybinding registry (`node.toggleMarkdown` / `node.close`), so the USER decides which
  * chord they are — but nothing else is intercepted here, because everything else reaches the
- * renderer's dispatcher on its own.
+ * renderer's dispatcher on its own. That closed list is ALSO written down in
+ * `shared/keybindings.ts` as `MAIN_INTERCEPTED_COMMAND_IDS` (the Settings UI's app-wide shadow
+ * warning reads it, and cannot derive it from here — main is not importable from the renderer);
+ * a third intercept added here owes that list an entry, which `keydown-intercept.test.ts` pins.
  *
  * Desktop-only by construction (it exists to fight a native menu), so it stays in `src/main` next
  * to `main-window.ts` rather than moving to `src/core` — the Server Edition's browser shell has no
@@ -181,13 +184,22 @@ export interface KeydownInterceptTarget {
  * `getBindings` is read per event rather than captured: settings change while the window lives, and
  * it returns a cached object (`index.ts` recomputes it on `settingsStore.onChange`, not here — a
  * sanitize per keystroke would be real work on the input path).
+ *
+ * `isRecording` is the same shape and for the same reason — the renderer flips it over IPC while
+ * this window is alive. **It is checked BEFORE `preventDefault`, not before the send**: a claimed
+ * chord never reaches the page at all, so while the Settings shortcut recorder is armed the only
+ * way it can SEE ⌘W is for this listener to leave the key completely alone. Swallowing but not
+ * forwarding would still hand the recorder nothing — and forwarding is the live bug, since ⌘W
+ * pressed into the recorder deletes the canvas's selected nodes.
  */
 export function installKeydownIntercepts(
   win: KeydownInterceptTarget,
   getBindings: () => KeydownInterceptBindings,
-  isMac: boolean
+  isMac: boolean,
+  isRecording: () => boolean
 ): void {
   win.webContents.on('before-input-event', (event, input) => {
+    if (isRecording()) return
     const decision = keydownIntercept(input, getBindings(), isMac)
     if (!decision) return
     event.preventDefault()

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -7,15 +7,22 @@ import { matchesShortcut } from '../shared/shortcut'
  * pair whose renderer half is `src/renderer/lib/zoomShortcut.ts` (same shape: a key-state-only
  * input, an action-or-null out, and the refusals as the point of the module).
  *
- * **Why the main process gets a say at all.** We never call `Menu.setApplicationMenu`, so Electron
- * installs its DEFAULT application menu, and that menu already claims all three of these chords:
+ * **Why the main process gets a say at all.** A menu accelerator is handled *before* the page sees
+ * the key, so a renderer-side listener for one would simply never run on the desktop.
+ * `before-input-event`'s `preventDefault` suppresses the menu item AND the page event, which is why
+ * each claimed chord has to forward its intent to the renderer over IPC itself rather than letting
+ * the key through. The three chords, and who claims them TODAY:
  *
- *   ⌘M → Window ▸ Minimize     ⌘W → Window ▸ Close     ⌘0 → View ▸ Actual Size (`resetZoom`)
+ *   ⌘M → Window ▸ Minimize — a live accelerator on **every** platform (`{role:'minimize'}`).
+ *   ⌘W → Window ▸ Close — a live accelerator on **Windows/Linux only**; the mac template has no
+ *         `{role:'close'}`, so on macOS this module is now ⌘W's only handler.
+ *   ⌘0 → not in any menu at all any more; this module is its only handler, which is exactly why
+ *         the View menu's Fit View item deliberately carries NO accelerator.
  *
- * A menu accelerator is handled *before* the page sees the key, so a renderer-side listener for any
- * of them would simply never run on the desktop. `before-input-event`'s `preventDefault` suppresses
- * the menu item AND the page event, which is why each claimed chord has to forward its intent to
- * the renderer over IPC itself rather than letting the key through.
+ * (This paragraph used to say "we never call `Menu.setApplicationMenu`, so Electron installs its
+ * DEFAULT menu". That has been false since `buildAppMenu` landed in `index.ts`. The menu is OURS
+ * now, so the list above is a fact about `buildAppMenu` — check it there, not against Electron's
+ * defaults, and update this comment when you edit that template.)
  *
  * **Why it is pure and lives here rather than in the callback.** Deleting a branch from an inline
  * callback breaks nothing and throws nothing — the shortcut just quietly starts minimizing the
@@ -28,10 +35,14 @@ import { matchesShortcut } from '../shared/shortcut'
  * **This module stays the closed list of main-intercepted chords.** ⌘M and ⌘W are now resolved
  * from the keybinding registry (`node.toggleMarkdown` / `node.close`), so the USER decides which
  * chord they are — but nothing else is intercepted here, because everything else reaches the
- * renderer's dispatcher on its own. That closed list is ALSO written down in
+ * renderer's dispatcher on its own. The **remappable** half of that list is ALSO written down in
  * `shared/keybindings.ts` as `MAIN_INTERCEPTED_COMMAND_IDS` (the Settings UI's app-wide shadow
  * warning reads it, and cannot derive it from here — main is not importable from the renderer);
- * a third intercept added here owes that list an entry, which `keydown-intercept.test.ts` pins.
+ * a third REGISTRY-BACKED intercept added here owes that list an entry, which
+ * `keydown-intercept.test.ts` pins. Note what that pin does NOT cover: a hardcoded ⌘0-shaped
+ * intercept has no command id, so it cannot appear in the list and the invariant test cannot see
+ * it — it would swallow its chord app-wide with the Settings recorder reporting no conflict. If
+ * you add one, the Settings UI needs a separate way to know about it.
  *
  * Desktop-only by construction (it exists to fight a native menu), so it stays in `src/main` next
  * to `main-window.ts` rather than moving to `src/core` — the Server Edition's browser shell has no
@@ -157,6 +168,33 @@ export function keydownIntercept(
   return null
 }
 
+/**
+ * PURE. Does this `did-start-navigation` mean the page that armed a shortcut recorder is going
+ * away, so the recording bit must be cleared?
+ *
+ * **Why the bit needs a navigation leg at all.** The recording bit is GLOBAL and lives in the main
+ * process, so every way the renderer can stop existing owes it a release. Window `closed` and
+ * `render-process-gone` cover two of them. The third is a **reload** — and the app's own View menu
+ * restores `{role:'reload'}` / `{role:'forceReload'}`, whose ⌘R/⌘⇧R are ACCELERATORS: they are
+ * handled above the page, so the recorder's `preventDefault` cannot stop a user from pressing one
+ * while armed. That reload fires no React unmount, no `closed` and no `render-process-gone`; the
+ * new page mounts no recorder, and the bit would stay true forever — ⌘W/⌘M/⌘0 dead app-wide with
+ * nothing left alive to clear them.
+ *
+ * The two filters are both refusals, and both matter:
+ * - `isSameDocument` (Electron's newer name for the old `isInPlace`) is a `pushState`, a
+ *   `replaceState` or a fragment jump — the SAME page, with the recorder still mounted and still
+ *   armed. Clearing there would re-arm the intercepts under a live recorder, i.e. re-open the very
+ *   bug this feature closes.
+ * - A subframe navigating is not this page going away either.
+ */
+export function navigationClearsRecording(details: {
+  isMainFrame: boolean
+  isSameDocument: boolean
+}): boolean {
+  return details.isMainFrame && !details.isSameDocument
+}
+
 /** The renderer channel a claimed action is forwarded on. */
 export function keydownInterceptChannel(action: KeydownInterceptAction): string {
   if (action === 'toggle-markdown') return IPC.appToggleMarkdown
@@ -186,11 +224,22 @@ export interface KeydownInterceptTarget {
  * sanitize per keystroke would be real work on the input path).
  *
  * `isRecording` is the same shape and for the same reason — the renderer flips it over IPC while
- * this window is alive. **It is checked BEFORE `preventDefault`, not before the send**: a claimed
- * chord never reaches the page at all, so while the Settings shortcut recorder is armed the only
- * way it can SEE ⌘W is for this listener to leave the key completely alone. Swallowing but not
- * forwarding would still hand the recorder nothing — and forwarding is the live bug, since ⌘W
+ * this window is alive. **It is checked BEFORE `preventDefault`, not before the send**: a chord
+ * THIS MODULE claims never reaches the page at all, so while the Settings shortcut recorder is
+ * armed, leaving the key completely alone is the only way the recorder can see it. Swallowing but
+ * not forwarding would still hand the recorder nothing — and forwarding is the live bug, since ⌘W
  * pressed into the recorder deletes the canvas's selected nodes.
+ *
+ * **What this stand-down does NOT buy, and cannot.** It only stops US from taking the key; it has
+ * no say over the application MENU, whose accelerators are handled above the page either way. So
+ * every menu accelerator is unrecordable while this stands down — including **⌘M**, which
+ * `{role:'minimize'}` owns on every platform, and **Ctrl+W** on Windows/Linux, where the Window
+ * submenu has a `{role:'close'}`. Pressing one of those into an armed recorder minimizes/closes the
+ * window instead of recording. Concretely, the stand-down fully delivers **⌘0** everywhere and
+ * **⌘W on macOS** (neither is in the menu), and cannot deliver ⌘M anywhere. Fixing that means
+ * suspending the MENU while recording (`Menu.setApplicationMenu(null)` around the armed window, or
+ * per-item `enabled:false`) — a change to `buildAppMenu`, not to this module. Known limitation;
+ * see the PR body.
  */
 export function installKeydownIntercepts(
   win: KeydownInterceptTarget,

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -88,6 +88,16 @@ describe('preload sshProject passphrase wiring', () => {
     expect(h.invoke).toHaveBeenCalledWith(IPC.sessionMemory, { projectId: 'p2', remote: false })
   })
 
+  // The recorder's release leg is a `false`, and main reads it as `active === true`. A preload
+  // that dropped the argument, or sent on the wrong channel, would leave ⌘W/⌘M/⌘0 suppressed
+  // app-wide after Settings closed — with every other test in the tree still green.
+  it('shortcuts.setRecording sends both edges on its own channel', () => {
+    api.shortcuts.setRecording(true)
+    expect(h.send).toHaveBeenCalledWith(IPC.uiShortcutRecording, true)
+    api.shortcuts.setRecording(false)
+    expect(h.send).toHaveBeenCalledWith(IPC.uiShortcutRecording, false)
+  })
+
   it('onPassphraseDismiss subscribes the dismiss channel and forwards the requestId', () => {
     const got: { requestId: string }[] = []
     const off = api.sshProject.onPassphraseDismiss((e) => got.push(e))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -593,6 +593,11 @@ const api: NodeTerminalApi = {
   },
   // Per-node subscriptions (each terminal/editor listens) — multiplexed so they don't pile up
   // ipcRenderer listeners and trip the MaxListeners warning.
+  shortcuts: {
+    // Fire-and-forget: nothing waits on the answer, and a dropped disarm is covered by main's own
+    // window/renderer-death resets (index.ts `clearShortcutRecording`).
+    setRecording: (active: boolean) => ipcRenderer.send(IPC.uiShortcutRecording, active)
+  },
   onMarkdownToggle: subscribe(IPC.appToggleMarkdown),
   onCloseNode: subscribe(IPC.appCloseNode),
   onZoomActualSize: subscribe(IPC.appZoomActualSize),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -594,8 +594,10 @@ const api: NodeTerminalApi = {
   // Per-node subscriptions (each terminal/editor listens) — multiplexed so they don't pile up
   // ipcRenderer listeners and trip the MaxListeners warning.
   shortcuts: {
-    // Fire-and-forget: nothing waits on the answer, and a dropped disarm is covered by main's own
-    // window/renderer-death resets (index.ts `clearShortcutRecording`).
+    // Fire-and-forget: nothing waits on the answer. Main clears the bit itself on the three ways
+    // this page can stop existing — window closed, renderer died, main-frame navigation (⌘R) —
+    // but those are a backstop for a page that VANISHED, not a general safety net: an ordinary
+    // disarm that never sends leaves the shortcuts suppressed until one of them happens.
     setRecording: (active: boolean) => ipcRenderer.send(IPC.uiShortcutRecording, active)
   },
   onMarkdownToggle: subscribe(IPC.appToggleMarkdown),

--- a/src/renderer/bridge/stubs.test.ts
+++ b/src/renderer/bridge/stubs.test.ts
@@ -98,6 +98,10 @@ describe('bridge stubs', () => {
       s.setBadgeCount(3)
       s.contextLink.setLinks({} as never)
       s.sendAgentControlResult({} as never)
+      // The shortcut recorder calls this on every arm AND on unmount; a throw here would leave
+      // Settings unusable in the browser, where there is no main-process intercept to suspend.
+      s.shortcuts.setRecording(true)
+      s.shortcuts.setRecording(false)
     }).not.toThrow()
   })
 })

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -353,6 +353,13 @@ export function buildStubApi(): Omit<
       listDevices: U('pairing.listDevices'),
       revokeDevice: U('pairing.revokeDevice')
     },
+    shortcuts: {
+      // Deliberate no-op (not a gap): the recording bit exists to stand the DESKTOP's
+      // `before-input-event` intercepts down, and a browser tab has no application menu to steal
+      // ⌘W/⌘M/⌘0 back from — nothing intercepts here, so there is nothing to suspend. The
+      // recorder's own preventDefault/stopPropagation is the whole path in this shell.
+      setRecording: noop
+    },
     onMarkdownToggle: noopUnsub,
     onCloseNode: noopUnsub,
     // Deliberate no-op (not a gap): a browser tab has no application menu to steal ⌘0, so the

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -9089,7 +9089,7 @@ export function Canvas() {
       cmds.push({
         id: 'toggle-kanban',
         label: kb ? 'Canvas view' : 'Kanban view',
-        hint: '⌘⇧B',
+        hint: chipFor('view.kanbanToggle') || undefined,
         section: 'View',
         icon: kb ? <IconCanvasView /> : <IconKanban />,
         run: () => useViewMode.getState().toggle(kanbanId)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -179,7 +179,12 @@ import {
   type GlobalKeydownDeps
 } from '../lib/globalKeybindings'
 import type { ContextElement } from '../lib/keyContext'
-import { activeKeybindingOverrides, chipFor, commandTooltip } from '../lib/keybindingOverrides'
+import {
+  activeKeybindingOverrides,
+  chipFor,
+  commandTooltip,
+  dictationBinding
+} from '../lib/keybindingOverrides'
 import { UsageIndicator } from '../components/UsageIndicator'
 import { SystemResourcePill } from '../components/SystemResourcePill'
 import { PresenceLayer } from '../components/PresenceLayer'
@@ -3615,6 +3620,10 @@ export function Canvas() {
     setRemotePicker(screenPos)
   }, [])
 
+  // The selector re-runs on every settings change and returns a STRING, so zustand's default
+  // equality keeps this from re-rendering the canvas unless the chord itself moved.
+  const dictationChord = useSettings(() => dictationBinding())
+
   // v3 hold-to-talk: active only while the configured dictation shortcut is a modifier-only
   // chord (isHoldChord — the new default, "Cmd+Alt"). Walkie-talkie semantics: the chord held
   // down starts recording immediately (armed on the keydown that completes the exact modifier
@@ -3631,8 +3640,15 @@ export function Canvas() {
   // already-armed chord are inert by construction: once armed, a repeat keydown of the same
   // modifier still satisfies chordHeld, so the "misfire" branch's condition is false and it's a
   // no-op. Window blur (app switch) cancels outright.
+  //
+  // The chord comes from the keybinding registry (`dictationBinding()` — the first effective
+  // `speech.dictation` binding), not from settings.speech.shortcut, so a remap in
+  // settings.json's `keybindings` block reaches hold mode too. The `=== ''` test in front of
+  // every isHoldChord call is LOAD-BEARING: `''` means the user DISABLED dictation, and
+  // `isHoldChord('')` is TRUE (an all-false parse has a null key), so without it a disabled
+  // binding would arm a modifier-less hold chord that fires on any keydown.
   useEffect(() => {
-    if (!isHoldChord(settings.speech.shortcut)) return
+    if (dictationChord === '' || !isHoldChord(dictationChord)) return
 
     let armed = false
     let heldSince = 0
@@ -3651,8 +3667,8 @@ export function Canvas() {
 
     const onKeyDown = (e: KeyboardEvent): void => {
       if (isKanbanOpen(useProjects.getState().activeProjectId)) return
-      const combo = useSettings.getState().settings.speech.shortcut
-      if (!isHoldChord(combo)) return
+      const combo = dictationBinding()
+      if (combo === '' || !isHoldChord(combo)) return
 
       if (!armed) {
         // Arm only on the keydown that completes the exact chord — not on every keydown while
@@ -3686,7 +3702,16 @@ export function Canvas() {
 
     const onKeyUp = (e: KeyboardEvent): void => {
       if (!armed) return
-      const combo = useSettings.getState().settings.speech.shortcut
+      const combo = dictationBinding()
+      // The binding moved mid-hold (disabled, or remapped to a keyed chord): this gesture has
+      // no owner any more, so cancel — the same thing the cleanup below does once the change
+      // reaches React a tick later. Without this the `''` case would READ AS STILL HELD
+      // (`chordHeld(e, '', isMac)` is true exactly when no modifier is down) and the recording
+      // would never stop.
+      if (combo === '' || !isHoldChord(combo)) {
+        cancel()
+        return
+      }
       // Still fully down (an unrelated key was released) — keep recording.
       if (chordHeld(e, combo, isMac)) return
       const heldMs = Date.now() - heldSince
@@ -3714,7 +3739,7 @@ export function Canvas() {
         setDictationOpen(false)
       }
     }
-  }, [settings.speech.shortcut])
+  }, [dictationChord])
 
   // "Connect to a host" from the Settings section / tab-menu dialog: they collect the pairing offer
   // and dispatch it here (a window event, so they need no Canvas reference), and this runs the SAME
@@ -5230,13 +5255,16 @@ export function Canvas() {
       // terminal.* / scm.commit / speech.dictation: owned by their local listeners.
     },
     gestures: {
-      // A KEYED dictation shortcut (e.g. "Cmd+Alt+D") toggles dictation. A modifier-only
-      // shortcut (the new default, "Cmd+Alt") is hold-to-talk instead — matchesShortcut always
-      // returns false for that shape (its `key` is null), so this gesture is naturally a no-op
-      // for it; see the dedicated hold-mode effect above, which is what fires in that case.
+      // A KEYED dictation shortcut (e.g. "Cmd+Alt+D") toggles dictation. The chord is the
+      // registry's first effective `speech.dictation` binding (`dictationBinding()`), so a
+      // remap lands here without touching this file. A modifier-only shortcut (the default,
+      // "Cmd+Alt") is hold-to-talk instead — matchesShortcut always returns false for that
+      // shape (its `key` is null), so this gesture is naturally a no-op for it; see the
+      // dedicated hold-mode effect above, which is what fires in that case. The DISABLED case
+      // (`''`) needs no guard for the same reason: an empty parse also has a null key.
       // The dispatcher only offers it in plain app focus (not typing / terminal / kanban).
       keyedDictation: (e) => {
-        if (!matchesShortcut(e, useSettings.getState().settings.speech.shortcut, isMac)) return false
+        if (!matchesShortcut(e, dictationBinding(), isMac)) return false
         e.preventDefault()
         toggleDictation()
         return true

--- a/src/renderer/components/Dock.tsx
+++ b/src/renderer/components/Dock.tsx
@@ -3,7 +3,7 @@ import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type AgentId, type BuiltinAgentId } fr
 import type { CustomAgent } from '@shared/types'
 import { formatShortcut, isHoldChord } from '@shared/shortcut'
 import { hasSpeechModel } from '@shared/speech'
-import { commandTooltip } from '../lib/keybindingOverrides'
+import { commandTooltip, dictationBinding } from '../lib/keybindingOverrides'
 import { AgentIcon } from '../lib/agentIcons'
 import { useSettings } from '../state/settings'
 import { useProjects } from '../state/projects'
@@ -77,7 +77,10 @@ export function Dock({
   // ≥1 inheriting custom agent (one with a `baseAgent` matching it); otherwise it stays a flat
   // button, byte-identical to before this nesting existed.
   const [openSub, setOpenSub] = useState<BuiltinAgentId | null>(null)
-  const dictationShortcut = useSettings((s) => s.settings.speech.shortcut)
+  // The registry's first effective `speech.dictation` binding, `''` when the user unbound it.
+  // The selector returns a STRING, so zustand's default equality keeps an unrelated settings
+  // write from re-rendering the dock.
+  const dictationShortcut = useSettings(() => dictationBinding())
   const speechEngine = useSettings((s) => s.settings.speech.engine)
   const speechModel = useSettings((s) => s.settings.speech.model)
   // Whisper with the explicit None selection = dictation off (issue #143). The mic stays visible
@@ -302,9 +305,13 @@ export function Dock({
           title={
             dictationOff
               ? 'Dictation off — choose a model in Settings → Speech'
-              : isHoldChord(dictationShortcut)
-                ? `Dictate (hold ${formatShortcut(dictationShortcut, isMac)})`
-                : `Dictate (${formatShortcut(dictationShortcut, isMac)})`
+              : // The user unbound the shortcut: the mic button still dictates, so the tooltip
+                // keeps the label and drops the chord rather than promising a key that is gone.
+                dictationShortcut === ''
+                ? 'Dictate'
+                : isHoldChord(dictationShortcut)
+                  ? `Dictate (hold ${formatShortcut(dictationShortcut, isMac)})`
+                  : `Dictate (${formatShortcut(dictationShortcut, isMac)})`
           }
           onClick={onDictate}
         >

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { isHoldChord, shortcutKeyParts } from '@shared/shortcut'
 import type { CommandId } from '@shared/keybindings'
 import { isBrowserRuntime } from '../bridge/runtime'
-import { commandKeys } from '../lib/keybindingOverrides'
+import { commandKeys, dictationBinding } from '../lib/keybindingOverrides'
 import { useSettings } from '../state/settings'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
@@ -25,14 +25,26 @@ interface Row {
  *  what makes the panel and the key agree — `terminal.find` included, whose match in
  *  TerminalNode now reads `effectiveBindings('terminal.find')` instead of a hardcoded
  *  Cmd/Ctrl+F. Gesture/mouse rows stay literal: they are not commands and the registry knows
- *  nothing about them. "Dictate" also stays literal — its chord still lives in
- *  `settings.speech.shortcut` (the registry's `speech.dictation` row is display-only for now),
- *  and a modifier-only chord is hold-to-talk, which the label spells out. */
-function buildSections(dictationKeys: string[], dictationLabel: string): { title: string; rows: Row[] }[] {
+ *  nothing about them. "Dictate" is a registry row too now — its chord comes from
+ *  `dictationBinding()` (the first effective `speech.dictation` binding), with the legacy
+ *  `settings.speech.shortcut` field kept only as a downgrade mirror — so it follows a remap and
+ *  DROPS off the panel when the user unbinds it, exactly like every `cmd()` row above. It keeps
+ *  its own builder because it is the one row whose LABEL depends on the chord's shape: a
+ *  modifier-only chord is hold-to-talk, which "Dictate (hold)" spells out. */
+function buildSections(dictationChord: string): { title: string; rows: Row[] }[] {
   const cmd = (id: CommandId, label: string): Row[] => {
     const keys = commandKeys(id)
     return keys.length ? [{ keys, label }] : []
   }
+  const dictate = (): Row[] =>
+    dictationChord === ''
+      ? []
+      : [
+          {
+            keys: shortcutKeyParts(dictationChord, isMac),
+            label: isHoldChord(dictationChord) ? 'Dictate (hold)' : 'Dictate'
+          }
+        ]
   return [
     {
       title: 'General',
@@ -47,7 +59,7 @@ function buildSections(dictationKeys: string[], dictationLabel: string): { title
         // Desktop only: browsers own Cmd/Ctrl+1-9 for tab switching and a page cannot take it
         // back, so listing it in the Server Edition would promise a shortcut that never fires.
         ...(isBrowserRuntime() ? [] : [{ keys: ['⌘', '1-9'], label: 'Jump to project' }]),
-        { keys: dictationKeys, label: dictationLabel },
+        ...dictate(),
         ...cmd('canvas.undo', 'Undo'),
         ...cmd('canvas.redo', 'Redo')
       ]
@@ -96,11 +108,9 @@ function buildSections(dictationKeys: string[], dictationLabel: string): { title
 
 /** Keyboard shortcuts reference; shown on first launch and via ⌘/ or the ? button. */
 export function ShortcutsPanel({ onClose }: ShortcutsPanelProps) {
-  const speechShortcut = useSettings((s) => s.settings.speech.shortcut)
-  const SECTIONS = buildSections(
-    shortcutKeyParts(speechShortcut, isMac),
-    isHoldChord(speechShortcut) ? 'Dictate (hold)' : 'Dictate'
-  )
+  // A string selector, so an unrelated settings write cannot re-render the panel.
+  const dictationChord = useSettings(() => dictationBinding())
+  const SECTIONS = buildSections(dictationChord)
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -53,7 +53,9 @@ function buildSections(dictationChord: string): { title: string; rows: Row[] }[]
         ...cmd('app.settings', 'Settings'),
         ...cmd('app.shortcutsPanel', 'This shortcuts panel'),
         ...cmd('panel.explorer', 'Explorer'),
-        ...cmd('panel.sourceControl', 'Source Control'),
+        // `panel.sourceControl` used to be listed here AND in the Source Control section below —
+        // one command, two rows, both showing the same chord. The section row ("Open Source
+        // Control") is the one that belongs, so the General duplicate is gone.
         ...cmd('view.kanbanToggle', 'Kanban board'),
         ...cmd('panel.sessions', 'Pin the sessions sidebar'),
         // Desktop only: browsers own Cmd/Ctrl+1-9 for tab switching and a page cannot take it
@@ -110,6 +112,12 @@ function buildSections(dictationChord: string): { title: string; rows: Row[] }[]
 export function ShortcutsPanel({ onClose }: ShortcutsPanelProps) {
   // A string selector, so an unrelated settings write cannot re-render the panel.
   const dictationChord = useSettings(() => dictationBinding())
+  // Every OTHER row reads the registry through a plain `commandKeys()` call, which is not a
+  // subscription — so a panel left open while a chord is remapped (Settings in another window,
+  // or an outside edit to settings.json the store watcher picks up) kept showing the old key
+  // unless the remap happened to be dictation's. Subscribing to the overrides object itself is
+  // what makes the whole panel re-render; the value is unused on purpose.
+  useSettings((s) => s.settings.keybindings)
   const SECTIONS = buildSections(dictationChord)
 
   useEffect(() => {

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -11,6 +11,7 @@ import { useSystemAccount } from '../state/systemAccount'
 import { sessionCount, sessionForProject, useProjectSession } from '../session/session'
 import { tabClickAction } from '../session/relay-tab'
 import { useMenuFlip } from '../ui/useMenuFlip'
+import { commandTooltip } from '../lib/keybindingOverrides'
 import { IconCanvasView, IconKanban } from './icons'
 import {
   ALL_PERMISSION_MODES,
@@ -335,9 +336,16 @@ export function TabBar({
                 )}
 
                 {active && editingId !== p.id && (
+                  // The title was a hardcoded `(⌘⇧B)` — mac glyphs shown to Linux/Windows users
+                  // (a pre-existing bug: it was never even hintLabel-wrapped), and stale after a
+                  // remap. `commandTooltip` fixes both and drops the chord entirely when the
+                  // command is unbound.
                   <button
                     className="tab__board-toggle"
-                    title={kanbanActive ? 'Canvas view (⌘⇧B)' : 'Kanban view (⌘⇧B)'}
+                    title={commandTooltip(
+                      kanbanActive ? 'Canvas view' : 'Kanban view',
+                      'view.kanbanToggle'
+                    )}
                     onClick={(e) => {
                       e.stopPropagation() // a tab click switches projects, this only flips the view
                       useViewMode.getState().toggle(p.id)

--- a/src/renderer/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/components/onboarding/OnboardingFlow.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import type { SpeechModelInfo } from '@shared/types'
+import { DEFAULT_SETTINGS, type SpeechModelInfo } from '@shared/types'
 import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type BuiltinAgentId } from '@shared/agents/config'
 import { isHoldChord, shortcutKeyParts } from '@shared/shortcut'
 import { hasSpeechModel, SPEECH_MODEL_NONE } from '@shared/speech'
 import { keyLabel } from '@shared/platform-utils'
+import { dictationBinding } from '../../lib/keybindingOverrides'
 import { IOS_APP_STORE_URL } from '../../lib/links'
 import { useSettings } from '../../state/settings'
 import { useEntitlement } from '../../state/entitlement'
@@ -159,8 +160,14 @@ export function OnboardingFlow({ onClose }: { onClose: () => void }) {
     ? (settings.defaultAgent as BuiltinAgentId)
     : 'claude'
   const agent = AGENT_CONFIG[agentId]
-  const dictKeys = shortcutKeyParts(settings.speech.shortcut, isMac)
-  const dictHold = isHoldChord(settings.speech.shortcut)
+  // The registry's dictation chord. `''` (the user unbound it) falls back to the DEFAULT chord
+  // with the copy unchanged: the tour TEACHES the feature, and a fresh install — the only place
+  // this flow runs on its own — cannot have it disabled. Telling a first-run user "dictation is
+  // off" on a screen whose whole job is to introduce dictation would be a worse lie than the
+  // chord being stale for the one user who re-opened the tour after unbinding it.
+  const dictationChord = useSettings(() => dictationBinding()) || DEFAULT_SETTINGS.speech.shortcut
+  const dictKeys = shortcutKeyParts(dictationChord, isMac)
+  const dictHold = isHoldChord(dictationChord)
 
   const stepId: StepId = STEPS[step] ?? 'cover'
   const next = () => setStep((s) => Math.min(s + 1, STEP_COUNT - 1))

--- a/src/renderer/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/components/onboarding/OnboardingFlow.tsx
@@ -2,10 +2,15 @@ import { useCallback, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { DEFAULT_SETTINGS, type SpeechModelInfo } from '@shared/types'
 import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type BuiltinAgentId } from '@shared/agents/config'
-import { isHoldChord, shortcutKeyParts } from '@shared/shortcut'
+import { isHoldChord, matchesShortcut, shortcutKeyParts } from '@shared/shortcut'
 import { hasSpeechModel, SPEECH_MODEL_NONE } from '@shared/speech'
 import { keyLabel } from '@shared/platform-utils'
-import { dictationBinding } from '../../lib/keybindingOverrides'
+import {
+  chipFor,
+  commandKeys,
+  dictationBinding,
+  effectiveBindings
+} from '../../lib/keybindingOverrides'
 import { IOS_APP_STORE_URL } from '../../lib/links'
 import { useSettings } from '../../state/settings'
 import { useEntitlement } from '../../state/entitlement'
@@ -114,14 +119,20 @@ export function OnboardingFlow({ onClose }: { onClose: () => void }) {
     }
   }
 
-  // ---- kanban try-it: catch a real ⌘⇧B while the step is up (capture phase, so the
-  // canvas's own toggle handler never fires under the tour) ----
+  // ---- kanban try-it: catch the REAL kanban-toggle chord while the step is up (capture phase,
+  // so the canvas's own toggle handler never fires under the tour). Matched through the registry
+  // rather than by hand, so a remapped chord is what the tour accepts — and so the acceptance is
+  // exactly as strict as dispatch. The old test was LAX in two directions: `metaKey || ctrlKey`
+  // accepted Ctrl+Shift+B on a mac (where the command is ⌘⇧B) and Cmd+Shift+B on Linux, and it
+  // ignored `altKey` entirely, so ⌘⌥⇧B — a different chord — also lit the checkmark. Narrowing
+  // it means the tour can only be satisfied by the key that actually toggles the board. ----
   const [kanbanTried, setKanbanTried] = useState(false)
   const [kanbanPulse, setKanbanPulse] = useState(0)
   useEffect(() => {
     if (STEPS[step] !== 'kanban') return
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'b') {
+      // Read at event time, not at effect setup: a remap mid-tour takes effect immediately.
+      if (effectiveBindings('view.kanbanToggle').some((s) => matchesShortcut(e, s, isMac))) {
         e.preventDefault()
         e.stopPropagation()
         setKanbanTried(true)
@@ -168,6 +179,11 @@ export function OnboardingFlow({ onClose }: { onClose: () => void }) {
   const dictationChord = useSettings(() => dictationBinding()) || DEFAULT_SETTINGS.speech.shortcut
   const dictKeys = shortcutKeyParts(dictationChord, isMac)
   const dictHold = isHoldChord(dictationChord)
+  // Both read through the SAME `settings` subscription above (`useSettings((s) => s.settings)`
+  // re-renders this component on every settings write, a remap included), so these plain calls
+  // are live. `''` / `[]` mean the command is unbound — each site below says what it does then.
+  const newAgentChip = chipFor('node.newAgent')
+  const kanbanKeys = commandKeys('view.kanbanToggle')
 
   const stepId: StepId = STEPS[step] ?? 'cover'
   const next = () => setStep((s) => Math.min(s + 1, STEP_COUNT - 1))
@@ -242,7 +258,11 @@ export function OnboardingFlow({ onClose }: { onClose: () => void }) {
                   its own persistent tmux session.
                 </p>
                 <div className="onb-label">
-                  Default agent (what {isMac ? '⌘⇧C' : 'Ctrl+Shift+C'} opens)
+                  {/* Follows a remap of `node.newAgent`. When the user unbound it there is no
+                      key to name, so the label drops the parenthetical instead of promising a
+                      chord that no longer fires — the setting itself still matters (the pane
+                      menu, the dock and ⌘K all open the default agent). */}
+                  {newAgentChip ? `Default agent (what ${newAgentChip} opens)` : 'Default agent'}
                 </div>
                 <div className="onb-agent-grid">
                   {BUILTIN_AGENT_IDS.map((id) => (
@@ -329,22 +349,30 @@ export function OnboardingFlow({ onClose }: { onClose: () => void }) {
                   Every project is a canvas — and also a kanban board. Cards are your live
                   sessions: drag them across columns, open them, comment on them.
                 </p>
-                <div className={`onb-tryit ${kanbanTried ? 'is-done' : ''}`}>
-                  {kanbanTried ? (
-                    <>
-                      <OnbCheck /> That's the toggle — it works in any project.
-                    </>
-                  ) : (
-                    <>
-                      Try it now — press{' '}
-                      {['⌘', '⇧', 'B'].map((k, i) => (
-                        <kbd key={i} className="kbd">
-                          {keyLabel(k, isMac)}
-                        </kbd>
-                      ))}
-                    </>
-                  )}
-                </div>
+                {/* No chord to press when the user unbound the toggle, so the try-it PROMPT is
+                    dropped — the scene, the copy and the default-view choice all stay. (Kept
+                    while `kanbanTried` so an unbind mid-tour doesn't retract a checkmark the
+                    user already earned; nothing can set it once unbound.) The chips are
+                    `commandKeys`, which already renders platform-correct parts — no keyLabel
+                    rewrite on top. */}
+                {(kanbanKeys.length > 0 || kanbanTried) && (
+                  <div className={`onb-tryit ${kanbanTried ? 'is-done' : ''}`}>
+                    {kanbanTried ? (
+                      <>
+                        <OnbCheck /> That's the toggle — it works in any project.
+                      </>
+                    ) : (
+                      <>
+                        Try it now — press{' '}
+                        {kanbanKeys.map((k, i) => (
+                          <kbd key={i} className="kbd">
+                            {k}
+                          </kbd>
+                        ))}
+                      </>
+                    )}
+                  </div>
+                )}
                 <div className="onb-defaultview">
                   <span className="onb-defaultview__label">Open new projects as</span>
                   <div className="onb-seg" role="group" aria-label="Default view">

--- a/src/renderer/components/settings/SettingsIcons.tsx
+++ b/src/renderer/components/settings/SettingsIcons.tsx
@@ -42,6 +42,13 @@ const PATHS: Record<SettingsSectionId, React.JSX.Element> = {
       <path d="M4 8.2a4 4 0 0 0 8 0M8 12.2v1.6M6.2 13.8h3.6" />
     </>
   ),
+  // A keyboard: the outline, two key rows, and a wide space bar.
+  shortcuts: (
+    <>
+      <rect x="1.5" y="4" width="13" height="8" rx="1.8" />
+      <path d="M4 6.5h.01M6.5 6.5h.01M9 6.5h.01M11.5 6.5h.01M4 9.6h8" />
+    </>
+  ),
   agents: (
     <path d="M8 2.3 9.4 5.9 13 7.3 9.4 8.7 8 12.3 6.6 8.7 3 7.3 6.6 5.9z" />
   ),

--- a/src/renderer/components/settings/SettingsPage.tsx
+++ b/src/renderer/components/settings/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { AppearanceSection } from './sections/AppearanceSection'
 import { NotchSection } from './sections/NotchSection'
 import { PhoneSection } from './sections/PhoneSection'
 import { SpeechSection } from './sections/SpeechSection'
+import { ShortcutsSection } from './sections/ShortcutsSection'
 import { AgentsSection } from './sections/AgentsSection'
 import { UsageSection } from './sections/UsageSection'
 import { AccountsSection } from './sections/AccountsSection'
@@ -79,6 +80,7 @@ export function SettingsPage({
             {isMac && <NotchSection isActive={active === 'notch'} />}
             <PhoneSection isActive={active === 'phone'} />
             <SpeechSection isActive={active === 'speech'} onNavigate={setActive} />
+            <ShortcutsSection isActive={active === 'shortcuts'} />
             <AgentsSection isActive={active === 'agents'} />
             <UsageSection isActive={active === 'usage'} />
             <AccountsSection isActive={active === 'accounts'} />

--- a/src/renderer/components/settings/ShortcutRecorderButton.tsx
+++ b/src/renderer/components/settings/ShortcutRecorderButton.tsx
@@ -16,9 +16,15 @@
  * fire `blur` on a focused element that is REMOVED from the DOM, so closing Settings while the
  * recorder is armed can skip `onBlur` entirely — leaving the bit set with no component left to
  * clear it, suppressing ⌘W/⌘M/⌘0 app-wide until the next arm/disarm cycle. `release` (below) is
- * the teardown both `stop()` and the unmount cleanup run; it touches refs only, so it is stable
- * and safe to run when the recorder was never armed (`setRecording(false)` on a shell that was
- * never told `true` is a plain no-op).
+ * the teardown both `stop()` and the unmount cleanup run; it touches refs only, so it is stable.
+ * It is safe to run from an instance that was never armed because it CHECKS (`armedRef`) — not
+ * because the send would be harmless. One global bit, many instances: an unconditional release
+ * would let a sibling unmounting for unrelated reasons clear the armed recorder's bit.
+ *
+ * **A menu accelerator is still out of reach.** The main-process stand-down only stops nodeterm's
+ * own `before-input-event` intercepts; the application menu's accelerators are handled above the
+ * page regardless. So ⌘M (Window ▸ Minimize, every platform) and Ctrl+W (Windows/Linux) cannot be
+ * recorded here — see the limitation note in `src/main/keydown-intercept.ts`.
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { COMMANDS_BY_ID, normalizeBindingForCommand, type CommandId } from '@shared/keybindings'
@@ -39,13 +45,26 @@ export function ShortcutRecorderButton({
   const [capturing, setCapturing] = useState(false)
   const [hint, setHint] = useState('')
   const stateRef = useRef<RecordingState>({ mods: null })
+  // Did THIS instance arm the (global) main-process bit? See `release`.
+  const armedRef = useRef(false)
   const def = COMMANDS_BY_ID.get(commandId)!
   const opts = { isMac, allowHold: def.allowHoldChord === true }
 
   // Refs only ⇒ stable with no deps, so the mount-time cleanup below cannot capture stale state,
-  // and idempotent ⇒ running it on an unmount that was never armed is a no-op.
+  // and idempotent ⇒ running it twice, or on an unmount that was never armed, does nothing.
+  //
+  // **`armedRef` is what makes it safe to run from every instance.** The main-process bit is ONE
+  // global boolean while this component is rendered once per command, so a sibling unmounting for
+  // reasons that have nothing to do with recording must not speak for the armed one. That is not
+  // hypothetical in this page: settings rows are wrapped in `SearchableRow`, which returns `null`
+  // for every row the filter box does not match — so typing there unmounts a batch of recorders at
+  // once. An unconditional `setRecording(false)` in that cleanup would clear the ARMED recorder's
+  // bit from under it, re-arming ⌘W/⌘M mid-capture: the original bug, reached by a different door.
+  // Only the instance that sent `true` may send `false`.
   const release = useCallback((): void => {
     stateRef.current = { mods: null }
+    if (!armedRef.current) return
+    armedRef.current = false
     window.nodeTerminal.shortcuts.setRecording(false)
   }, [])
   // The unmount leg — the one that matters most (Settings closed mid-recording fires no blur).
@@ -60,6 +79,7 @@ export function ShortcutRecorderButton({
     stateRef.current = { mods: null }
     setCapturing(true)
     setHint('')
+    armedRef.current = true
     window.nodeTerminal.shortcuts.setRecording(true)
   }
   const commit = (combo: string): void => {

--- a/src/renderer/components/settings/ShortcutRecorderButton.tsx
+++ b/src/renderer/components/settings/ShortcutRecorderButton.tsx
@@ -6,10 +6,17 @@
  * (so ⌘W/⌘M/⌘0 interception cannot swallow the capture) is Task 5's: `window.nodeTerminal
  * .shortcuts` does not exist on `NodeTerminalApi` yet, and that type lives in
  * `src/shared/types.ts` — a file this task does not own. An optional-chained call does NOT
- * typecheck against a member the interface never declares, so the two calls are marked below
- * rather than shipped broken.
+ * typecheck against a member the interface never declares, so the three call sites are marked
+ * below rather than shipped broken.
+ *
+ * **That bit is GLOBAL, so it owes an unmount release.** Chromium does not reliably fire `blur`
+ * on a focused element that is REMOVED from the DOM, so closing Settings while the recorder is
+ * armed can skip `onBlur` entirely — leaving the main-process bit set with no component left to
+ * clear it, suppressing ⌘W/⌘M/⌘0 app-wide until the next arm/disarm cycle. `release` (below) is
+ * the teardown both `stop()` and the unmount cleanup run; it touches refs only, so it is stable
+ * and safe to run when the recorder was never armed.
  */
-import { useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { COMMANDS_BY_ID, normalizeBindingForCommand, type CommandId } from '@shared/keybindings'
 import { isMacPlatform } from '@shared/platform-utils'
 import { recordingKeydown, recordingKeyup, type RecordingState } from './shortcutRecording'
@@ -31,11 +38,19 @@ export function ShortcutRecorderButton({
   const def = COMMANDS_BY_ID.get(commandId)!
   const opts = { isMac, allowHold: def.allowHoldChord === true }
 
+  // Refs only ⇒ stable with no deps, so the mount-time cleanup below cannot capture stale state,
+  // and idempotent ⇒ running it on an unmount that was never armed is a no-op.
+  const release = useCallback((): void => {
+    stateRef.current = { mods: null }
+    // Task 5 wires the main-process recording bit here: setRecording(false)
+  }, [])
+  // Task 5: setRecording(false) must also be called from this unmount cleanup — see the header.
+  useEffect(() => release, [release])
+
   const stop = (): void => {
     setCapturing(false)
     setHint('')
-    stateRef.current = { mods: null }
-    // Task 5 wires the main-process recording bit here: setRecording(false)
+    release()
   }
   const start = (): void => {
     stateRef.current = { mods: null }

--- a/src/renderer/components/settings/ShortcutRecorderButton.tsx
+++ b/src/renderer/components/settings/ShortcutRecorderButton.tsx
@@ -1,20 +1,24 @@
 /**
  * Generalized shortcut recorder: click to arm, press a chord. Keyed chords commit on keydown;
  * for allowHoldChord commands a modifier-only chord commits on full release (hold-to-talk).
- * While armed it sets data-shortcut-recording (the window dispatcher bails on it via
- * defaultPrevented — every key here is preventDefault'ed). The main-process recording bit
- * (so ⌘W/⌘M/⌘0 interception cannot swallow the capture) is Task 5's: `window.nodeTerminal
- * .shortcuts` does not exist on `NodeTerminalApi` yet, and that type lives in
- * `src/shared/types.ts` — a file this task does not own. An optional-chained call does NOT
- * typecheck against a member the interface never declares, so the three call sites are marked
- * below rather than shipped broken.
  *
- * **That bit is GLOBAL, so it owes an unmount release.** Chromium does not reliably fire `blur`
- * on a focused element that is REMOVED from the DOM, so closing Settings while the recorder is
- * armed can skip `onBlur` entirely — leaving the main-process bit set with no component left to
+ * **Two separate mechanisms hold the keys off, one per process.** In the RENDERER it is this
+ * component's own `preventDefault` + `stopPropagation` on every key it sees — the window
+ * dispatcher bails on `defaultPrevented`, so nothing else in the page acts on the chord. The
+ * `data-shortcut-recording` attribute is NOT part of that path: nothing reads it, and it is kept
+ * only as the DOM-visible signal that the recorder is armed (tests, debugging, styling hooks). In
+ * MAIN it is `shortcuts.setRecording`, because a chord the window intercepts in
+ * `before-input-event` (⌘W, ⌘M, ⌘0) never reaches the page at all — no amount of renderer-side
+ * preventing can catch a key the page was never given. Recording ⌘W without it DELETES THE
+ * SELECTED NODES.
+ *
+ * **The main-process bit is GLOBAL, so it owes an unmount release.** Chromium does not reliably
+ * fire `blur` on a focused element that is REMOVED from the DOM, so closing Settings while the
+ * recorder is armed can skip `onBlur` entirely — leaving the bit set with no component left to
  * clear it, suppressing ⌘W/⌘M/⌘0 app-wide until the next arm/disarm cycle. `release` (below) is
  * the teardown both `stop()` and the unmount cleanup run; it touches refs only, so it is stable
- * and safe to run when the recorder was never armed.
+ * and safe to run when the recorder was never armed (`setRecording(false)` on a shell that was
+ * never told `true` is a plain no-op).
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { COMMANDS_BY_ID, normalizeBindingForCommand, type CommandId } from '@shared/keybindings'
@@ -42,9 +46,9 @@ export function ShortcutRecorderButton({
   // and idempotent ⇒ running it on an unmount that was never armed is a no-op.
   const release = useCallback((): void => {
     stateRef.current = { mods: null }
-    // Task 5 wires the main-process recording bit here: setRecording(false)
+    window.nodeTerminal.shortcuts.setRecording(false)
   }, [])
-  // Task 5: setRecording(false) must also be called from this unmount cleanup — see the header.
+  // The unmount leg — the one that matters most (Settings closed mid-recording fires no blur).
   useEffect(() => release, [release])
 
   const stop = (): void => {
@@ -56,7 +60,7 @@ export function ShortcutRecorderButton({
     stateRef.current = { mods: null }
     setCapturing(true)
     setHint('')
-    // Task 5 wires the main-process recording bit here: setRecording(true)
+    window.nodeTerminal.shortcuts.setRecording(true)
   }
   const commit = (combo: string): void => {
     const r = normalizeBindingForCommand(def, combo, isMac)
@@ -87,6 +91,8 @@ export function ShortcutRecorderButton({
   return (
     <button
       type="button"
+      // Observability only — no dispatcher reads it (see the header). Keeps the armed state
+      // visible to tests and to anyone inspecting the DOM.
       data-shortcut-recording={capturing || undefined}
       className="min-w-[120px] cursor-pointer rounded-md border border-border bg-panel-header px-3 py-1.5 text-[13px] font-medium text-text outline-none hover:bg-[rgba(255,255,255,0.06)]"
       onClick={start}

--- a/src/renderer/components/settings/ShortcutRecorderButton.tsx
+++ b/src/renderer/components/settings/ShortcutRecorderButton.tsx
@@ -1,0 +1,85 @@
+/**
+ * Generalized shortcut recorder: click to arm, press a chord. Keyed chords commit on keydown;
+ * for allowHoldChord commands a modifier-only chord commits on full release (hold-to-talk).
+ * While armed it sets data-shortcut-recording (the window dispatcher bails on it via
+ * defaultPrevented — every key here is preventDefault'ed). The main-process recording bit
+ * (so ⌘W/⌘M/⌘0 interception cannot swallow the capture) is Task 5's: `window.nodeTerminal
+ * .shortcuts` does not exist on `NodeTerminalApi` yet, and that type lives in
+ * `src/shared/types.ts` — a file this task does not own. An optional-chained call does NOT
+ * typecheck against a member the interface never declares, so the two calls are marked below
+ * rather than shipped broken.
+ */
+import { useRef, useState } from 'react'
+import { COMMANDS_BY_ID, normalizeBindingForCommand, type CommandId } from '@shared/keybindings'
+import { isMacPlatform } from '@shared/platform-utils'
+import { recordingKeydown, recordingKeyup, type RecordingState } from './shortcutRecording'
+
+const isMac = isMacPlatform()
+
+export function ShortcutRecorderButton({
+  commandId,
+  idleLabel,
+  onCommit
+}: {
+  commandId: CommandId
+  idleLabel: string
+  onCommit: (combo: string) => void
+}): React.JSX.Element {
+  const [capturing, setCapturing] = useState(false)
+  const [hint, setHint] = useState('')
+  const stateRef = useRef<RecordingState>({ mods: null })
+  const def = COMMANDS_BY_ID.get(commandId)!
+  const opts = { isMac, allowHold: def.allowHoldChord === true }
+
+  const stop = (): void => {
+    setCapturing(false)
+    setHint('')
+    stateRef.current = { mods: null }
+    // Task 5 wires the main-process recording bit here: setRecording(false)
+  }
+  const start = (): void => {
+    stateRef.current = { mods: null }
+    setCapturing(true)
+    setHint('')
+    // Task 5 wires the main-process recording bit here: setRecording(true)
+  }
+  const commit = (combo: string): void => {
+    const r = normalizeBindingForCommand(def, combo, isMac)
+    if (!r.ok) {
+      setHint(r.error)
+      return
+    }
+    onCommit(r.value)
+    stop()
+  }
+  const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (!capturing) return
+    e.preventDefault()
+    e.stopPropagation()
+    const action = recordingKeydown(stateRef.current, e, opts)
+    if (action.kind === 'cancel') stop()
+    else if (action.kind === 'commit') commit(action.combo)
+    else if (action.kind === 'pending') {
+      stateRef.current = action.state
+      setHint(action.hint)
+    }
+  }
+  const onKeyUp = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (!capturing) return
+    const action = recordingKeyup(stateRef.current, e, opts)
+    if (action.kind === 'commit') commit(action.combo)
+  }
+  return (
+    <button
+      type="button"
+      data-shortcut-recording={capturing || undefined}
+      className="min-w-[120px] cursor-pointer rounded-md border border-border bg-panel-header px-3 py-1.5 text-[13px] font-medium text-text outline-none hover:bg-[rgba(255,255,255,0.06)]"
+      onClick={start}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      onBlur={stop}
+    >
+      {capturing ? hint || 'Press keys…' : idleLabel}
+    </button>
+  )
+}

--- a/src/renderer/components/settings/nav.test.ts
+++ b/src/renderer/components/settings/nav.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { SETTINGS_GROUPS, allSectionIds, FIRST_SECTION_ID, visibleSettingsGroups } from './nav'
 
 describe('SETTINGS_GROUPS', () => {
-  it('lists exactly 24 sections with no duplicates', () => {
+  it('lists exactly 25 sections with no duplicates', () => {
     const ids = allSectionIds()
-    expect(ids).toHaveLength(24)
-    expect(new Set(ids).size).toBe(24)
+    expect(ids).toHaveLength(25)
+    expect(new Set(ids).size).toBe(25)
   })
   it('starts at a section that exists in the groups', () => {
     expect(allSectionIds()).toContain(FIRST_SECTION_ID)
@@ -13,7 +13,7 @@ describe('SETTINGS_GROUPS', () => {
   it('hides mac-only sections off macOS, keeps them on', () => {
     const off = visibleSettingsGroups(false).flatMap((g) => g.sections.map((s) => s.id))
     expect(off).not.toContain('notch')
-    expect(off).toHaveLength(23)
+    expect(off).toHaveLength(24)
     expect(visibleSettingsGroups(true)).toEqual(SETTINGS_GROUPS)
     // No group is left empty by the filter.
     expect(visibleSettingsGroups(false).every((g) => g.sections.length > 0)).toBe(true)

--- a/src/renderer/components/settings/nav.ts
+++ b/src/renderer/components/settings/nav.ts
@@ -6,6 +6,7 @@ export type SettingsSectionId =
   | 'notch'
   | 'phone'
   | 'speech'
+  | 'shortcuts'
   | 'agents'
   | 'usage'
   | 'accounts'
@@ -70,7 +71,8 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
       { id: 'appearance', title: 'Appearance' },
       { id: 'notch', title: 'Notch', macOnly: true },
       { id: 'notifications', title: 'Notifications' },
-      { id: 'speech', title: 'Speech' }
+      { id: 'speech', title: 'Speech' },
+      { id: 'shortcuts', title: 'Keyboard Shortcuts' }
     ]
   },
   {

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { COMMAND_DEFINITIONS } from '@shared/keybindings'
 import { DEFAULT_SETTINGS } from '@shared/types'
 import { useSettings } from '../../../state/settings'
+import { SettingsSearchContext } from '../context'
 import { ShortcutsSection, commitCandidate } from './ShortcutsSection'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -22,12 +23,21 @@ const kb = (): Record<string, readonly string[]> =>
 let host: HTMLDivElement
 let root: Root | null = null
 
-function render(): void {
+function render(query = ''): void {
   host = document.createElement('div')
   document.body.appendChild(host)
   root = createRoot(host)
-  act(() => root!.render(<ShortcutsSection isActive={true} />))
+  act(() =>
+    root!.render(
+      <SettingsSearchContext.Provider value={query}>
+        <ShortcutsSection isActive={true} />
+      </SettingsSearchContext.Provider>
+    )
+  )
 }
+
+/** The section shell's card body — `divide-y [&>*]:py-5`, so every direct child DRAWS. */
+const body = (): Element => host.querySelector<HTMLElement>('#shortcuts')!.lastElementChild!
 
 const row = (id: string): HTMLElement => host.querySelector<HTMLElement>(`[data-command="${id}"]`)!
 const button = (id: string, label: string): HTMLButtonElement | null =>
@@ -100,6 +110,49 @@ describe('ShortcutsSection rows', () => {
     ])
   })
 
+  // A filtered query must not leave the group's padded, divider-separated strip behind: the shell
+  // body is `divide-y [&>*]:py-5`, so an empty wrapper is a visible empty block, not nothing.
+  it('drops a whole group when neither its header nor any of its rows match', () => {
+    render('close')
+    expect([...host.querySelectorAll('h3')].map((h) => h.textContent)).toEqual(['Nodes'])
+    expect([...host.querySelectorAll('[data-command]')].map((el) =>
+      el.getAttribute('data-command')
+    )).toEqual(['node.close'])
+    // Exactly the heading and the one row — no empty siblings.
+    expect(body().children).toHaveLength(2)
+    expect([...body().children].every((c) => (c.textContent ?? '').trim() !== '')).toBe(true)
+  })
+
+  // A row can match on its own note, which the group's keywords do not carry — the heading must
+  // follow the rows, never filter itself independently and strand one.
+  it('keeps the heading over a row that matched on its note', () => {
+    render('tmux')
+    expect([...host.querySelectorAll('h3')].map((h) => h.textContent)).toEqual(['Terminal'])
+    expect([...host.querySelectorAll('[data-command]')].map((el) =>
+      el.getAttribute('data-command')
+    )).toEqual(['terminal.copySelection'])
+  })
+
+  it('renders every group and row unfiltered, each as its own divided block', () => {
+    render()
+    expect(host.querySelectorAll('h3')).toHaveLength(6)
+    expect(body().children).toHaveLength(6 + COMMAND_DEFINITIONS.length)
+  })
+
+  // The dictation row must not promise a second chord: every consumer reads
+  // `dictationBinding()` = the FIRST effective binding, so an added one could never fire.
+  it('offers Add for an ordinary command but never for Dictate', () => {
+    setKb({ 'speech.dictation': ['Cmd+Alt', 'Cmd+Alt+D'] })
+    render()
+    expect(recorder('app.commandPalette', 'Add')).toBeTruthy()
+    expect(recorder('speech.dictation', 'Add')).toBeUndefined()
+    // …and the chips show only the chord that is actually live.
+    expect([...row('speech.dictation').querySelectorAll('kbd')].map((k) => k.textContent)).toEqual([
+      '⌘',
+      '⌥'
+    ])
+  })
+
   // Ruling 1(a): the disabled-dictation render case. `[]` is the load-bearing "off" value —
   // `dictationBinding()` returns '' for it, and this row must SAY so rather than looking unbound.
   it('renders the dictation row as disabled when its override is []', () => {
@@ -136,6 +189,21 @@ describe('commitCandidate', () => {
     expect(r.ok).toBe(false)
     expect(r.ok === false && r.error).toContain('Command palette')
     expect(r.ok === false && r.error).not.toContain('swallowed app-wide')
+  })
+
+  // REVERSE shadowing: neither existing gate can see it — the shadow check answers only for an
+  // intercepted id, and the two commands are in different buckets so nothing conflicts.
+  it('refuses a chord the main process intercepts for another command', () => {
+    const r = commitCandidate('terminal.find', 'Cmd+W', 'replace')
+    expect(r.ok).toBe(false)
+    expect(r.ok === false && r.error).toContain('Close node / window')
+    expect(r.ok === false && r.error).toContain('Find in terminal')
+    expect('terminal.find' in kb()).toBe(false)
+  })
+
+  it('still accepts a chord no intercepted command holds', () => {
+    expect(commitCandidate('terminal.find', 'Cmd+Alt+F', 'replace')).toEqual({ ok: true })
+    expect(kb()['terminal.find']).toEqual(['Cmd+Alt+F'])
   })
 
   it('accepts a free chord, replacing or adding to the list', () => {

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -23,10 +23,9 @@ const kb = (): Record<string, readonly string[]> =>
 let host: HTMLDivElement
 let root: Root | null = null
 
-function render(query = ''): void {
-  host = document.createElement('div')
-  document.body.appendChild(host)
-  root = createRoot(host)
+/** Re-render into the SAME root, so component identity survives a query change — which is the
+ *  whole point of the armed-recorder test below. */
+function rerender(query: string): void {
   act(() =>
     root!.render(
       <SettingsSearchContext.Provider value={query}>
@@ -35,6 +34,17 @@ function render(query = ''): void {
     )
   )
 }
+
+function render(query = ''): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  rerender(query)
+}
+
+const setRecording = (): ReturnType<typeof vi.fn> =>
+  (window as unknown as { nodeTerminal: { shortcuts: { setRecording: ReturnType<typeof vi.fn> } } })
+    .nodeTerminal.shortcuts.setRecording
 
 /** The section shell's card body — `divide-y [&>*]:py-5`, so every direct child DRAWS. */
 const body = (): Element => host.querySelector<HTMLElement>('#shortcuts')!.lastElementChild!
@@ -162,6 +172,37 @@ describe('ShortcutsSection rows', () => {
     expect(dictate.querySelectorAll('kbd')).toHaveLength(0)
     expect(dictate.textContent).toContain('Disabled')
     expect(dictate.textContent).toContain('hold to talk')
+  })
+
+  // `ShortcutRecorderButton.release` is guarded by `armedRef`, and this section is where that
+  // guard is actually reachable: every row is a `SearchableRow`, which returns `null` for a row
+  // the query does not match, so typing in the settings search box unmounts a BATCH of recorders
+  // at once. The main-process recording bit is ONE global boolean — an unconditional
+  // `setRecording(false)` in that cleanup would clear the ARMED recorder's bit from under it and
+  // re-arm the ⌘W/⌘M intercepts mid-capture.
+  it('keeps the global recording bit while non-armed sibling recorders unmount', () => {
+    render()
+    click(recorder('terminal.copySelection', 'Record')!)
+    expect(setRecording()).toHaveBeenCalledWith(true)
+
+    // 'tmux' matches only Copy terminal selection (via its note) — every other row unmounts, and
+    // the armed one keeps its identity (stable group/row keys), so it is still armed.
+    rerender('tmux')
+    expect([...host.querySelectorAll('[data-command]')].map((el) =>
+      el.getAttribute('data-command')
+    )).toEqual(['terminal.copySelection'])
+    expect(
+      recorder('terminal.copySelection', 'Press keys…')?.getAttribute('data-shortcut-recording')
+    ).toBe('true')
+    expect(setRecording()).not.toHaveBeenCalledWith(false)
+
+    // …and the armed instance still owes the release on its own unmount (Settings closed
+    // mid-recording fires no blur), exactly once.
+    const r = root!
+    root = null
+    act(() => r.unmount())
+    host.remove()
+    expect(setRecording().mock.calls.filter((c) => c[0] === false)).toHaveLength(1)
   })
 })
 

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { COMMAND_DEFINITIONS } from '@shared/keybindings'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import { useSettings } from '../../../state/settings'
+import { ShortcutsSection, commitCandidate } from './ShortcutsSection'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// jsdom reports a non-mac platform; the chips and the refusal messages are platform-formatted,
+// so pin macOS here — `isMacPlatform()` is read at call time, never captured at module load.
+Object.defineProperty(window.navigator, 'platform', { value: 'MacIntel', configurable: true })
+
+const setKb = (kb: unknown): void =>
+  useSettings.setState({ settings: { ...DEFAULT_SETTINGS, keybindings: kb as never } })
+
+const kb = (): Record<string, readonly string[]> =>
+  (useSettings.getState().settings.keybindings ?? {}) as Record<string, readonly string[]>
+
+let host: HTMLDivElement
+let root: Root | null = null
+
+function render(): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => root!.render(<ShortcutsSection isActive={true} />))
+}
+
+const row = (id: string): HTMLElement => host.querySelector<HTMLElement>(`[data-command="${id}"]`)!
+const button = (id: string, label: string): HTMLButtonElement | null =>
+  row(id).querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
+/** The recorder button carries no per-command aria-label (it is a shared component), so it is
+ *  found by its idle text within the row. */
+const recorder = (id: string, text: string): HTMLButtonElement | undefined =>
+  [...row(id).querySelectorAll('button')].find((b) => b.textContent === text)
+const click = (el: HTMLElement): void => {
+  act(() => el.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+}
+
+beforeEach(() => {
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+    settings: { save: vi.fn() },
+    shortcuts: { setRecording: vi.fn() }
+  }
+  setKb(undefined)
+})
+
+afterEach(() => {
+  if (!root) return
+  const r = root
+  root = null
+  act(() => r.unmount())
+  host.remove()
+})
+
+describe('ShortcutsSection rows', () => {
+  it('renders one row per command, in registry order, with its chips', () => {
+    render()
+    const ids = [...host.querySelectorAll('[data-command]')].map((el) =>
+      el.getAttribute('data-command')
+    )
+    expect(ids).toEqual(COMMAND_DEFINITIONS.map((d) => d.id))
+    const palette = row('app.commandPalette')
+    expect(palette.textContent).toContain('Command palette')
+    expect([...palette.querySelectorAll('kbd')].map((k) => k.textContent)).toEqual(['⌘', 'K'])
+  })
+
+  it('shows an em-dash placeholder and a record button for an unbound command', () => {
+    render()
+    const fitAll = row('canvas.fitAll')
+    expect(fitAll.querySelectorAll('kbd')).toHaveLength(0)
+    expect(fitAll.textContent).toContain('—')
+    expect(recorder('canvas.fitAll', 'Record shortcut')).toBeTruthy()
+    // Nothing to add to, disable, or reset yet.
+    expect(recorder('canvas.fitAll', 'Add')).toBeUndefined()
+    expect(button('canvas.fitAll', 'Disable Fit all nodes in view')).toBeNull()
+    expect(button('canvas.fitAll', 'Reset Fit all nodes in view')).toBeNull()
+  })
+
+  it('Disable writes an empty list through the override write path', () => {
+    render()
+    click(button('app.commandPalette', 'Disable Command palette')!)
+    expect(kb()['app.commandPalette']).toEqual([])
+    expect(row('app.commandPalette').textContent).toContain('Disabled')
+  })
+
+  it('Reset appears only with an override, and deletes the key', () => {
+    render()
+    expect(button('canvas.undo', 'Reset Undo')).toBeNull()
+    click(button('canvas.undo', 'Disable Undo')!)
+    expect(kb()['canvas.undo']).toEqual([])
+    click(button('canvas.undo', 'Reset Undo')!)
+    expect('canvas.undo' in kb()).toBe(false)
+    expect([...row('canvas.undo').querySelectorAll('kbd')].map((k) => k.textContent)).toEqual([
+      '⌘',
+      'Z'
+    ])
+  })
+
+  // Ruling 1(a): the disabled-dictation render case. `[]` is the load-bearing "off" value —
+  // `dictationBinding()` returns '' for it, and this row must SAY so rather than looking unbound.
+  it('renders the dictation row as disabled when its override is []', () => {
+    setKb({ 'speech.dictation': [] })
+    render()
+    const dictate = row('speech.dictation')
+    expect(dictate.querySelectorAll('kbd')).toHaveLength(0)
+    expect(dictate.textContent).toContain('Disabled')
+    expect(dictate.textContent).toContain('hold to talk')
+  })
+})
+
+describe('commitCandidate', () => {
+  it('refuses a conflicting candidate, naming the other command, and writes nothing', () => {
+    setKb({ 'canvas.fitAll': [] })
+    const r = commitCandidate('canvas.fitAll', 'Cmd+K', 'replace')
+    expect(r.ok).toBe(false)
+    expect(r.ok === false && r.error).toContain('Command palette')
+    expect(kb()['canvas.fitAll']).toEqual([])
+  })
+
+  it('refuses a candidate that would be swallowed app-wide before another surface', () => {
+    const r = commitCandidate('node.close', 'Cmd+F', 'replace')
+    expect(r.ok).toBe(false)
+    expect(r.ok === false && r.error).toContain('swallowed app-wide')
+    expect(r.ok === false && r.error).toContain('Find in terminal')
+    expect('node.close' in kb()).toBe(false)
+  })
+
+  // Ruling 2: the two detectors can both see a same-bucket collision for a main-intercepted
+  // command. One candidate, ONE message — the conflict message, not both.
+  it('reports a same-bucket collision on an intercepted command exactly once', () => {
+    const r = commitCandidate('node.close', 'Cmd+K', 'replace')
+    expect(r.ok).toBe(false)
+    expect(r.ok === false && r.error).toContain('Command palette')
+    expect(r.ok === false && r.error).not.toContain('swallowed app-wide')
+  })
+
+  it('accepts a free chord, replacing or adding to the list', () => {
+    expect(commitCandidate('canvas.fitAll', 'Cmd+Alt+F', 'replace')).toEqual({ ok: true })
+    expect(kb()['canvas.fitAll']).toEqual(['Cmd+Alt+F'])
+    expect(commitCandidate('canvas.fitAll', 'Cmd+Alt+G', 'add')).toEqual({ ok: true })
+    expect(kb()['canvas.fitAll']).toEqual(['Cmd+Alt+F', 'Cmd+Alt+G'])
+    // Re-adding an existing chord is idempotent, not a self-conflict.
+    expect(commitCandidate('canvas.fitAll', 'Cmd+Alt+F', 'add')).toEqual({ ok: true })
+    expect(kb()['canvas.fitAll']).toEqual(['Cmd+Alt+G', 'Cmd+Alt+F'])
+  })
+})

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -1,0 +1,248 @@
+/**
+ * The Keyboard Shortcuts settings section: one row per registry command, with its live chips,
+ * a recorder, and Add / Disable / Reset.
+ *
+ * **The pre-save gate is `commitCandidate`, and it is where the refusal messages are decided.**
+ * Design D3 is "same detector, different surfacing": `sanitizeKeybindingOverrides` applies what
+ * survives on LOAD, while this section refuses a bad candidate BEFORE anything is written, so the
+ * user learns which chord was refused and why instead of watching a saved shortcut disappear on
+ * the next launch. Three checks, in this order, and the order is the whole dedupe:
+ *   1. `normalizeBindingForCommand` — already inside `ShortcutRecorderButton`, so an invalid chord
+ *      never reaches `onCommit` (its own hint is shown in the recorder button itself).
+ *   2. `findKeybindingConflicts` over the candidate map — a same-bucket collision.
+ *   3. `findMainInterceptShadowing` — a CROSS-bucket hit the conflict check cannot see.
+ * (2) returns early, so a candidate that trips both detectors (a main-intercepted command taking
+ * a chord another GLOBAL command already holds — `node.close` ← `Cmd+K`) produces exactly ONE
+ * message. The shadow message is reserved for what only it can see: `node.close` ← `Cmd+F`, where
+ * the two commands live in different buckets and nothing collides, yet main swallows the key
+ * before the terminal surface is ever offered it.
+ *
+ * Writes go through `setKeybindingOverride` (the single write path — it also mirrors
+ * `speech.dictation` into the legacy `settings.speech.shortcut` field for one release).
+ */
+import { useMemo, useState } from 'react'
+import {
+  COMMANDS_BY_ID,
+  COMMAND_DEFINITIONS,
+  findKeybindingConflicts,
+  findMainInterceptShadowing,
+  type CommandDefinition,
+  type CommandGroup,
+  type CommandId
+} from '@shared/keybindings'
+import { formatShortcut } from '@shared/shortcut'
+import { isMacPlatform, keyLabel } from '@shared/platform-utils'
+import {
+  activeKeybindingOverrides,
+  commandKeysFor,
+  effectiveBindings,
+  setKeybindingOverride
+} from '../../../lib/keybindingOverrides'
+import { useSettings } from '../../../state/settings'
+import { SettingsSection } from '../SettingsSection'
+import { SearchableRow } from '../SearchableRow'
+import { FieldRow } from '../FieldRow'
+import { ShortcutRecorderButton } from '../ShortcutRecorderButton'
+import { Button } from '@renderer/ui/Button'
+import type { SettingsSearchEntry } from '../search'
+
+/** Per-command help text. Only commands whose BEHAVIOR needs explaining get one — a row that
+ *  merely repeats its own title is noise in a 20-row list. */
+const NOTES: Partial<Record<CommandId, string>> = {
+  // Reused verbatim from the old SpeechSection row: the mode is derived from the chord's SHAPE,
+  // which is not guessable from a chip.
+  'speech.dictation':
+    'With a key = toggle (press to start, press again to stop and insert); modifiers only = hold to talk (hold to record, release to stop and insert). The Dock mic uses the same shortcut.',
+  'canvas.deleteSelection': 'Bare keys are allowed here; the typing guard keeps Backspace safe.',
+  'terminal.copySelection': 'Applies to a selection xterm owns — a tmux drag copies through OSC 52.'
+}
+
+function rowEntry(def: CommandDefinition): SettingsSearchEntry {
+  return {
+    title: def.title,
+    description: NOTES[def.id],
+    keywords: ['shortcut', 'keybinding', 'hotkey', 'key', def.group, def.id]
+  }
+}
+
+function groupEntry(group: CommandGroup, defs: CommandDefinition[]): SettingsSearchEntry {
+  // The header must survive any query that keeps one of its rows, so its keywords are the union
+  // of what those rows match on — otherwise a filtered list shows rows under the wrong heading.
+  return {
+    title: group,
+    keywords: ['shortcut', 'keybinding', 'hotkey', ...defs.flatMap((d) => [d.title, d.id])]
+  }
+}
+
+/**
+ * The testable core the row controls delegate to: gate a candidate binding, then write it.
+ * `mode` is `'replace'` (the recorder's primary action) or `'add'` (a second chord for the same
+ * command). Re-adding a chord the command already holds is idempotent rather than a
+ * self-conflict — it is filtered out of the list before being appended.
+ *
+ * Assumes `combo` is already canonical: `ShortcutRecorderButton` runs
+ * `normalizeBindingForCommand` and never emits an invalid chord.
+ */
+export function commitCandidate(
+  id: CommandId,
+  combo: string,
+  mode: 'replace' | 'add'
+): { ok: true } | { ok: false; error: string } {
+  const isMac = isMacPlatform()
+  const current = activeKeybindingOverrides()
+  const existing = effectiveBindings(id)
+  const nextList = mode === 'add' ? [...existing.filter((b) => b !== combo), combo] : [combo]
+  const chord = formatShortcut(combo, isMac)
+
+  const conflicts = findKeybindingConflicts({ ...current, [id]: nextList }, isMac).filter((c) =>
+    c.commandIds.includes(id)
+  )
+  if (conflicts.length) {
+    const titles = [
+      ...new Set(
+        conflicts
+          .flatMap((c) => c.commandIds)
+          .filter((cid) => cid !== id)
+          .map((cid) => COMMANDS_BY_ID.get(cid)?.title ?? cid)
+      )
+    ]
+    return { ok: false, error: `${chord} is already used by ${titles.join(', ')}.` }
+  }
+
+  const shadowed = findMainInterceptShadowing(id, combo, current, isMac)
+  if (shadowed.length) {
+    const titles = shadowed.map((cid) => COMMANDS_BY_ID.get(cid)?.title ?? cid).join(', ')
+    return { ok: false, error: `${chord} would be swallowed app-wide before ${titles} could see it.` }
+  }
+
+  setKeybindingOverride(id, nextList)
+  return { ok: true }
+}
+
+function Chips({ id }: { id: CommandId }): React.JSX.Element {
+  const keys = commandKeysFor(id)
+  if (keys.length === 0) return <></>
+  return (
+    <span className="flex items-center gap-2">
+      {keys.map((parts, i) => (
+        <span key={i} className="flex items-center gap-1">
+          {i > 0 ? <span className="text-[11px] text-muted">or</span> : null}
+          {parts.map((p, j) => (
+            <kbd key={j} className="kbd">
+              {keyLabel(p)}
+            </kbd>
+          ))}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX.Element {
+  // Any remap re-renders every row: chips, and the Add/Disable/Reset visibility, are all derived
+  // from the override map.
+  const overrides = useSettings((s) => s.settings.keybindings)
+  const [errors, setErrors] = useState<Partial<Record<CommandId, string>>>({})
+
+  const groups = useMemo(() => {
+    const byGroup = new Map<CommandGroup, CommandDefinition[]>()
+    for (const def of COMMAND_DEFINITIONS) {
+      byGroup.set(def.group, [...(byGroup.get(def.group) ?? []), def])
+    }
+    return [...byGroup.entries()]
+  }, [])
+
+  const entries = useMemo(
+    () => [
+      ...groups.map(([group, defs]) => groupEntry(group, defs)),
+      ...COMMAND_DEFINITIONS.map(rowEntry)
+    ],
+    [groups]
+  )
+
+  const apply = (id: CommandId, combo: string, mode: 'replace' | 'add'): void => {
+    const r = commitCandidate(id, combo, mode)
+    setErrors((prev) => ({ ...prev, [id]: r.ok ? undefined : r.error }))
+  }
+  const write = (id: CommandId, bindings: readonly string[] | null): void => {
+    setKeybindingOverride(id, bindings)
+    setErrors((prev) => ({ ...prev, [id]: undefined }))
+  }
+
+  return (
+    <SettingsSection
+      id="shortcuts"
+      title="Keyboard Shortcuts"
+      description="Remap any command. Overrides are stored in settings.json under `keybindings`; Disable turns a command's shortcut off, Reset restores its default. macOS owns ⌘M for Window ▸ Minimize, so that one chord cannot be recorded here."
+      isActive={isActive}
+      searchEntries={entries}
+    >
+      {groups.map(([group, defs]) => (
+        <div key={group} className="space-y-4">
+          <SearchableRow {...groupEntry(group, defs)}>
+            <h3 className="text-[13px] font-semibold uppercase tracking-wide text-muted">
+              {group}
+            </h3>
+          </SearchableRow>
+          {defs.map((def) => {
+            const override = overrides?.[def.id]
+            const disabled = Array.isArray(override) && override.length === 0
+            const bound = commandKeysFor(def.id).length > 0
+            return (
+              <SearchableRow key={def.id} {...rowEntry(def)}>
+                <div data-command={def.id}>
+                  <FieldRow
+                    label={def.title}
+                    description={NOTES[def.id]}
+                    note={errors[def.id]}
+                    control={
+                      <div className="flex items-center gap-2">
+                        {bound ? (
+                          <Chips id={def.id} />
+                        ) : (
+                          <span className="text-[13px] text-muted">
+                            {disabled ? 'Disabled' : '—'}
+                          </span>
+                        )}
+                        <ShortcutRecorderButton
+                          commandId={def.id}
+                          idleLabel={bound ? 'Record' : 'Record shortcut'}
+                          onCommit={(combo) => apply(def.id, combo, 'replace')}
+                        />
+                        {bound ? (
+                          <ShortcutRecorderButton
+                            commandId={def.id}
+                            idleLabel="Add"
+                            onCommit={(combo) => apply(def.id, combo, 'add')}
+                          />
+                        ) : null}
+                        {bound ? (
+                          <Button
+                            variant="ghost"
+                            aria-label={`Disable ${def.title}`}
+                            onClick={() => write(def.id, [])}
+                          >
+                            Disable
+                          </Button>
+                        ) : null}
+                        {override !== undefined ? (
+                          <Button
+                            variant="ghost"
+                            aria-label={`Reset ${def.title}`}
+                            onClick={() => write(def.id, null)}
+                          >
+                            Reset
+                          </Button>
+                        ) : null}
+                      </div>
+                    }
+                  />
+                </div>
+              </SearchableRow>
+            )
+          })}
+        </div>
+      ))}
+    </SettingsSection>
+  )
+}

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -20,12 +20,14 @@
  * Writes go through `setKeybindingOverride` (the single write path — it also mirrors
  * `speech.dictation` into the legacy `settings.speech.shortcut` field for one release).
  */
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import {
+  bindingIdentity,
   COMMANDS_BY_ID,
   COMMAND_DEFINITIONS,
   findKeybindingConflicts,
   findMainInterceptShadowing,
+  MAIN_INTERCEPTED_COMMAND_IDS,
   type CommandDefinition,
   type CommandGroup,
   type CommandId
@@ -44,7 +46,8 @@ import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
 import { ShortcutRecorderButton } from '../ShortcutRecorderButton'
 import { Button } from '@renderer/ui/Button'
-import type { SettingsSearchEntry } from '../search'
+import { useSettingsSearch } from '../context'
+import { matchesQuery, type SettingsSearchEntry } from '../search'
 
 /** Per-command help text. Only commands whose BEHAVIOR needs explaining get one — a row that
  *  merely repeats its own title is noise in a 20-row list. */
@@ -65,6 +68,12 @@ function rowEntry(def: CommandDefinition): SettingsSearchEntry {
   }
 }
 
+/** Commands whose consumers read the FIRST effective binding only, so a second chord would be
+ *  dead on arrival. `speech.dictation` is the case: every dictation surface (the hold listener,
+ *  the keyed gesture, the Dock mic, SpeechSection's note) goes through `dictationBinding()`, which
+ *  is `effectiveBindings('speech.dictation')[0]`. Their rows get no Add and show one chip. */
+const SINGLE_BINDING_COMMANDS: ReadonlySet<CommandId> = new Set<CommandId>(['speech.dictation'])
+
 function groupEntry(group: CommandGroup, defs: CommandDefinition[]): SettingsSearchEntry {
   // The header must survive any query that keeps one of its rows, so its keywords are the union
   // of what those rows match on — otherwise a filtered list shows rows under the wrong heading.
@@ -72,6 +81,17 @@ function groupEntry(group: CommandGroup, defs: CommandDefinition[]): SettingsSea
     title: group,
     keywords: ['shortcut', 'keybinding', 'hotkey', ...defs.flatMap((d) => [d.title, d.id])]
   }
+}
+
+/** Does this group have anything to show under the current query? It decides BOTH the heading and
+ *  the group's presence, which is why the heading is not a `SearchableRow` of its own: a row can
+ *  match on its per-command note (`NOTES`) — query "tmux" hits Copy terminal selection — and a
+ *  heading filtered independently would then leave that row standing under no heading at all. */
+function groupVisible(query: string, group: CommandGroup, defs: CommandDefinition[]): boolean {
+  if (query.trim() === '') return true
+  return (
+    matchesQuery(query, groupEntry(group, defs)) || defs.some((d) => matchesQuery(query, rowEntry(d)))
+  )
 }
 
 /**
@@ -115,12 +135,34 @@ export function commitCandidate(
     return { ok: false, error: `${chord} would be swallowed app-wide before ${titles} could see it.` }
   }
 
+  // REVERSE shadowing — the same collision seen from the other side, and neither gate above can
+  // see it. `findMainInterceptShadowing` answers only for an INTERCEPTED id, and a bucket conflict
+  // needs both commands in one bucket; binding `terminal.find` to `Cmd+W` is neither, so it passed
+  // every check and produced a permanently dead shortcut with no warning — main swallows the chord
+  // in `before-input-event` and the terminal surface is never offered it.
+  if (!MAIN_INTERCEPTED_COMMAND_IDS.includes(id)) {
+    const target = bindingIdentity(combo, isMac)
+    for (const cid of MAIN_INTERCEPTED_COMMAND_IDS) {
+      const hit = effectiveBindings(cid).some((b) => bindingIdentity(b, isMac) === target)
+      if (!hit) continue
+      const title = COMMANDS_BY_ID.get(cid)?.title ?? cid
+      const own = COMMANDS_BY_ID.get(id)?.title ?? id
+      return {
+        ok: false,
+        error: `${chord} is intercepted app-wide for ${title}; it would never reach ${own}.`
+      }
+    }
+  }
+
   setKeybindingOverride(id, nextList)
   return { ok: true }
 }
 
-function Chips({ id }: { id: CommandId }): React.JSX.Element {
-  const keys = commandKeysFor(id)
+/** `limit` exists for `speech.dictation`: its consumers read `dictationBinding()` — the FIRST
+ *  effective binding — so showing a second chip would promise a chord that can never fire. */
+function Chips({ id, limit }: { id: CommandId; limit?: number }): React.JSX.Element {
+  const all = commandKeysFor(id)
+  const keys = limit === undefined ? all : all.slice(0, limit)
   if (keys.length === 0) return <></>
   return (
     <span className="flex items-center gap-2">
@@ -142,6 +184,7 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
   // Any remap re-renders every row: chips, and the Add/Disable/Reset visibility, are all derived
   // from the override map.
   const overrides = useSettings((s) => s.settings.keybindings)
+  const query = useSettingsSearch()
   const [errors, setErrors] = useState<Partial<Record<CommandId, string>>>({})
 
   const groups = useMemo(() => {
@@ -177,72 +220,77 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
       isActive={isActive}
       searchEntries={entries}
     >
-      {groups.map(([group, defs]) => (
-        <div key={group} className="space-y-4">
-          <SearchableRow {...groupEntry(group, defs)}>
+      {groups.map(([group, defs]) => {
+        // A group whose header AND every row are filtered out must not render at all. The shell's
+        // body is `divide-y [&>*]:py-5`, so an empty wrapper is not invisible — it draws a padded
+        // strip with a divider, and a narrow query left five of those above the one real hit.
+        if (!groupVisible(query, group, defs)) return null
+        return (
+          <Fragment key={group}>
             <h3 className="text-[13px] font-semibold uppercase tracking-wide text-muted">
               {group}
             </h3>
-          </SearchableRow>
-          {defs.map((def) => {
-            const override = overrides?.[def.id]
-            const disabled = Array.isArray(override) && override.length === 0
-            const bound = commandKeysFor(def.id).length > 0
-            return (
-              <SearchableRow key={def.id} {...rowEntry(def)}>
-                <div data-command={def.id}>
-                  <FieldRow
-                    label={def.title}
-                    description={NOTES[def.id]}
-                    note={errors[def.id]}
-                    control={
-                      <div className="flex items-center gap-2">
-                        {bound ? (
-                          <Chips id={def.id} />
-                        ) : (
-                          <span className="text-[13px] text-muted">
-                            {disabled ? 'Disabled' : '—'}
-                          </span>
-                        )}
-                        <ShortcutRecorderButton
-                          commandId={def.id}
-                          idleLabel={bound ? 'Record' : 'Record shortcut'}
-                          onCommit={(combo) => apply(def.id, combo, 'replace')}
-                        />
-                        {bound ? (
+            {defs.map((def) => {
+              const override = overrides?.[def.id]
+              const disabled = Array.isArray(override) && override.length === 0
+              const single = SINGLE_BINDING_COMMANDS.has(def.id)
+              const bound = commandKeysFor(def.id).length > 0
+              return (
+                <SearchableRow key={def.id} {...rowEntry(def)}>
+                  <div data-command={def.id}>
+                    <FieldRow
+                      label={def.title}
+                      description={NOTES[def.id]}
+                      note={errors[def.id]}
+                      control={
+                        <div className="flex items-center gap-2">
+                          {bound ? (
+                            <Chips id={def.id} limit={single ? 1 : undefined} />
+                          ) : (
+                            <span className="text-[13px] text-muted">
+                              {disabled ? 'Disabled' : '—'}
+                            </span>
+                          )}
                           <ShortcutRecorderButton
                             commandId={def.id}
-                            idleLabel="Add"
-                            onCommit={(combo) => apply(def.id, combo, 'add')}
+                            idleLabel={bound ? 'Record' : 'Record shortcut'}
+                            onCommit={(combo) => apply(def.id, combo, 'replace')}
                           />
-                        ) : null}
-                        {bound ? (
-                          <Button
-                            variant="ghost"
-                            aria-label={`Disable ${def.title}`}
-                            onClick={() => write(def.id, [])}
-                          >
-                            Disable
-                          </Button>
-                        ) : null}
-                        {override !== undefined ? (
-                          <Button
-                            variant="ghost"
-                            aria-label={`Reset ${def.title}`}
-                            onClick={() => write(def.id, null)}
-                          >
-                            Reset
-                          </Button>
-                        ) : null}
-                      </div>
-                    }
-                  />
-                </div>
-              </SearchableRow>
-            )
-          })}
-        </div>
-      ))}
+                          {bound && !single ? (
+                            <ShortcutRecorderButton
+                              commandId={def.id}
+                              idleLabel="Add"
+                              onCommit={(combo) => apply(def.id, combo, 'add')}
+                            />
+                          ) : null}
+                          {bound ? (
+                            <Button
+                              variant="ghost"
+                              aria-label={`Disable ${def.title}`}
+                              onClick={() => write(def.id, [])}
+                            >
+                              Disable
+                            </Button>
+                          ) : null}
+                          {override !== undefined ? (
+                            <Button
+                              variant="ghost"
+                              aria-label={`Reset ${def.title}`}
+                              onClick={() => write(def.id, null)}
+                            >
+                              Reset
+                            </Button>
+                          ) : null}
+                        </div>
+                      }
+                    />
+                  </div>
+                </SearchableRow>
+              )
+            })}
+          </Fragment>
+        )
+      })}
     </SettingsSection>
   )
 }

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -216,7 +216,11 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
     <SettingsSection
       id="shortcuts"
       title="Keyboard Shortcuts"
-      description="Remap any command. Overrides are stored in settings.json under `keybindings`; Disable turns a command's shortcut off, Reset restores its default. macOS owns ⌘M for Window ▸ Minimize, so that one chord cannot be recorded here."
+      // The limitation is the application MENU's, not macOS's: its accelerators are handled above
+      // the page on every platform, so the main-process stand-down cannot deliver them to the
+      // recorder. Minimize is in the menu everywhere; Close only on Windows/Linux (the mac
+      // template has no {role:'close'}) — see `src/main/keydown-intercept.ts`.
+      description="Remap any command. Overrides are stored in settings.json under `keybindings`; Disable turns a command's shortcut off, Reset restores its default. The application menu owns Minimize (⌘M / Ctrl+M) and, on Windows/Linux, Close (Ctrl+W); those chords cannot be recorded here."
       isActive={isActive}
       searchEntries={entries}
     >

--- a/src/renderer/components/settings/sections/SpeechSection.tsx
+++ b/src/renderer/components/settings/sections/SpeechSection.tsx
@@ -1,16 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { SpeechModelInfo } from '@shared/types'
 import { hasSpeechModel, modelAfterDelete, modelAfterDownload, SPEECH_MODEL_NONE } from '@shared/speech'
-import { DEFAULT_SETTINGS } from '@shared/types'
-import {
-  buildModifierChord,
-  captureToShortcut,
-  formatShortcut,
-  isHoldChord,
-  isModifierEventKey,
-  type ChordModifiers,
-  type ShortcutKeyEvent
-} from '@shared/shortcut'
+import { formatShortcut, isHoldChord } from '@shared/shortcut'
+import { dictationBinding } from '../../../lib/keybindingOverrides'
 import { useSettings } from '../../../state/settings'
 import { useEntitlement } from '../../../state/entitlement'
 import { SettingsSection } from '../SettingsSection'
@@ -22,7 +14,6 @@ import { Button } from '@renderer/ui/Button'
 import type { SettingsSectionId } from '../nav'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
-const DEFAULT_SHORTCUT = DEFAULT_SETTINGS.speech.shortcut
 
 const ROWS = {
   engine: {
@@ -68,114 +59,6 @@ const ROWS = {
 }
 const ENTRIES = Object.values(ROWS)
 
-/**
- * Focus -> "Press keys…" -> capture -> saves the canonical combo. Two shapes commit
- * differently (v3):
- *  - A real key (Cmd/Ctrl + a non-modifier key) commits IMMEDIATELY on keydown, same as before
- *    — toggle mode.
- *  - Modifier keys only (Cmd/Ctrl [+ Alt] [+ Shift], no other key yet) commit on KEYUP, once
- *    every key has been released — hold-to-talk mode. Each modifier keydown along the way
- *    remembers the strongest state seen (`modsRef`) and previews it, since the keyup event
- *    itself no longer carries that state once everything's up (see `buildModifierChord`'s doc).
- * Esc cancels; blur cancels; a separate Reset button restores the default (`Cmd+Alt`, itself a
- * hold-to-talk chord). Pure combo logic lives in `@shared/shortcut`.
- */
-function ShortcutCaptureField({
-  value,
-  onChange
-}: {
-  value: string
-  onChange: (combo: string) => void
-}): React.JSX.Element {
-  const [capturing, setCapturing] = useState(false)
-  const [hint, setHint] = useState('')
-  const modsRef = useRef<ChordModifiers | null>(null)
-
-  const stopCapturing = (): void => {
-    setCapturing(false)
-    setHint('')
-    modsRef.current = null
-  }
-
-  const startCapturing = (): void => {
-    modsRef.current = null
-    setCapturing(true)
-    setHint('')
-  }
-
-  const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
-    if (!capturing) return
-    e.preventDefault()
-    if (e.key === 'Escape') {
-      stopCapturing()
-      return
-    }
-
-    if (isModifierEventKey(e.key)) {
-      // Only modifier keys pressed so far — remember the strongest state for a possible keyUp
-      // commit (hold-to-talk) and preview it; still lets the user continue on to press a real
-      // key instead (toggle mode) below.
-      const primaryPressed = isMac ? e.metaKey : e.ctrlKey
-      if (!primaryPressed) {
-        setHint(isMac ? `Hold ⌘…` : `Hold Ctrl…`)
-        return
-      }
-      const mods: ChordModifiers = { cmd: true, alt: e.altKey, shift: e.shiftKey }
-      modsRef.current = mods
-      const preview = buildModifierChord(mods)
-      setHint(preview ? `Release now for hold-to-talk (${formatShortcut(preview, isMac)}) — or press a key for toggle` : '')
-      return
-    }
-
-    const evt: ShortcutKeyEvent = {
-      metaKey: e.metaKey,
-      ctrlKey: e.ctrlKey,
-      shiftKey: e.shiftKey,
-      altKey: e.altKey,
-      key: e.key
-    }
-    const combo = captureToShortcut(evt, isMac)
-    if (!combo) {
-      setHint(isMac ? `Hold ⌘ and press a key` : `Hold Ctrl and press a key`)
-      return
-    }
-    onChange(combo)
-    stopCapturing()
-  }
-
-  const onKeyUp = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
-    if (!capturing || !modsRef.current) return
-    const anyModDown = (isMac ? e.metaKey : e.ctrlKey) || e.altKey || e.shiftKey
-    if (anyModDown) return // not fully released yet — keep waiting
-    const combo = buildModifierChord(modsRef.current)
-    if (!combo) return
-    onChange(combo)
-    stopCapturing()
-  }
-
-  return (
-    <div className="flex items-center gap-2">
-      <button
-        type="button"
-        className="min-w-[140px] cursor-pointer rounded-md border border-border bg-panel-header px-3 py-1.5 text-[13px] font-medium text-text outline-none hover:bg-[rgba(255,255,255,0.06)]"
-        onClick={startCapturing}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onBlur={stopCapturing}
-      >
-        {capturing ? hint || 'Press keys…' : formatShortcut(value, isMac)}
-      </button>
-      <Button
-        variant="ghost"
-        disabled={value === DEFAULT_SHORTCUT}
-        onClick={() => onChange(DEFAULT_SHORTCUT)}
-      >
-        Reset
-      </Button>
-    </div>
-  )
-}
-
 const LANGUAGES: { value: string; label: string }[] = [
   { value: 'auto', label: 'Auto-detect' },
   { value: 'en', label: 'English' },
@@ -211,6 +94,10 @@ export function SpeechSection({
 }): React.JSX.Element {
   const settings = useSettings((s) => s.settings)
   const update = useSettings((s) => s.update)
+  // The chord's single source is the registry override (`speech.shortcut` is only the legacy
+  // downgrade mirror), and a string selector keeps an unrelated settings write from re-rendering
+  // this section. `''` = the user disabled dictation's shortcut.
+  const dictationChord = useSettings(() => dictationBinding())
   const isPremium = useEntitlement((s) => s.isPremium)
 
   const [models, setModels] = useState<SpeechModelInfo[]>([])
@@ -260,9 +147,6 @@ export function SpeechSection({
   }
   const setLanguage = (language: string): void => {
     update({ speech: { ...settings.speech, language } })
-  }
-  const setShortcut = (shortcut: string): void => {
-    update({ speech: { ...settings.speech, shortcut } })
   }
 
   const selectModel = (m: SpeechModelInfo): void => {
@@ -354,13 +238,19 @@ export function SpeechSection({
       <SearchableRow {...ROWS.shortcut}>
         <FieldRow
           label="Shortcut"
-          description="Press a combo — with a key = toggle (press to start, press again to stop and insert); modifiers only = hold to talk (hold to record, release to stop and insert). The Dock mic uses the same shortcut."
+          description="Dictation's shortcut is managed with every other keyboard shortcut."
           note={
-            isHoldChord(settings.speech.shortcut)
-              ? `Currently hold-to-talk: hold ${formatShortcut(settings.speech.shortcut, isMac)}.`
-              : `Currently toggle: press ${formatShortcut(settings.speech.shortcut, isMac)}.`
+            dictationChord === ''
+              ? 'Currently disabled.'
+              : isHoldChord(dictationChord)
+                ? `Currently hold-to-talk: hold ${formatShortcut(dictationChord, isMac)}.`
+                : `Currently toggle: press ${formatShortcut(dictationChord, isMac)}.`
           }
-          control={<ShortcutCaptureField value={settings.speech.shortcut} onChange={setShortcut} />}
+          control={
+            <Button variant="ghost" onClick={() => onNavigate('shortcuts')}>
+              Open Keyboard Shortcuts
+            </Button>
+          }
         />
       </SearchableRow>
 

--- a/src/renderer/components/settings/shortcutRecording.test.ts
+++ b/src/renderer/components/settings/shortcutRecording.test.ts
@@ -50,6 +50,16 @@ describe('recordingKeydown', () => {
       expect(r.hint).toContain('Super')
     }
   })
+  // Deliberate divergence from the legacy SpeechSection field, which left modsRef untouched here:
+  // arm Cmd+Alt, release ⌘ while keeping ⌥, add ⇧ — the baseline still committed Cmd+Alt on the
+  // eventual full release, a chord the finished gesture (⌥⇧) could never fire under exact
+  // matching. Losing the primary modifier must DISARM.
+  it('a modifier-only keydown without the primary disarms an armed hold chord', () => {
+    const armed = { mods: { cmd: true, ctrl: false, alt: true, shift: false } }
+    const r = recordingKeydown(armed, e({ altKey: true, shiftKey: true, key: 'Shift' }), HOLD)
+    expect(r.kind).toBe('pending')
+    if (r.kind === 'pending') expect(r.state.mods).toBeNull()
+  })
   it('modifier-only keydown without allowHold just previews the requirement', () => {
     const r = recordingKeydown({ mods: null }, e({ metaKey: true, key: 'Meta' }), KEYED)
     expect(r.kind).toBe('pending')

--- a/src/renderer/components/settings/shortcutRecording.test.ts
+++ b/src/renderer/components/settings/shortcutRecording.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { recordingKeydown, recordingKeyup } from './shortcutRecording'
+
+const e = (
+  over: Partial<{ metaKey: boolean; ctrlKey: boolean; shiftKey: boolean; altKey: boolean; key: string }>
+) => ({
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  key: '',
+  ...over
+})
+const HOLD = { isMac: true, allowHold: true }
+const KEYED = { isMac: true, allowHold: false }
+
+describe('recordingKeydown', () => {
+  it('a keyed chord commits immediately', () => {
+    expect(recordingKeydown({ mods: null }, e({ metaKey: true, key: 'd' }), KEYED)).toEqual({
+      kind: 'commit',
+      combo: 'Cmd+D'
+    })
+  })
+  it('mac Ctrl rides along in a keyed capture (the PR1 gap, closed)', () => {
+    expect(
+      recordingKeydown({ mods: null }, e({ metaKey: true, ctrlKey: true, key: 'd' }), KEYED)
+    ).toEqual({ kind: 'commit', combo: 'Cmd+Ctrl+D' })
+  })
+  it('Escape cancels', () => {
+    expect(recordingKeydown({ mods: null }, e({ key: 'Escape' }), KEYED)).toEqual({ kind: 'cancel' })
+  })
+  it('modifier-only keydown is pending: remembered for a hold commit when allowed', () => {
+    const r = recordingKeydown({ mods: null }, e({ metaKey: true, altKey: true, key: 'Alt' }), HOLD)
+    expect(r.kind).toBe('pending')
+    if (r.kind === 'pending') expect(r.state.mods).toEqual({ cmd: true, ctrl: false, alt: true, shift: false })
+  })
+  it('mac Ctrl is collected into a hold chord (the PR1 gap, closed)', () => {
+    const r = recordingKeydown({ mods: null }, e({ metaKey: true, ctrlKey: true, key: 'Control' }), HOLD)
+    if (r.kind === 'pending') expect(r.state.mods?.ctrl).toBe(true)
+    expect(r.kind).toBe('pending')
+  })
+  it('non-mac held Super is refused with a hint', () => {
+    const r = recordingKeydown({ mods: null }, e({ metaKey: true, ctrlKey: true, key: 'Control' }), {
+      isMac: false,
+      allowHold: true
+    })
+    expect(r.kind).toBe('pending')
+    if (r.kind === 'pending') {
+      expect(r.state.mods).toBeNull()
+      expect(r.hint).toContain('Super')
+    }
+  })
+  it('modifier-only keydown without allowHold just previews the requirement', () => {
+    const r = recordingKeydown({ mods: null }, e({ metaKey: true, key: 'Meta' }), KEYED)
+    expect(r.kind).toBe('pending')
+    if (r.kind === 'pending') expect(r.state.mods).toBeNull()
+  })
+})
+
+describe('recordingKeyup', () => {
+  it('full release commits the remembered hold chord', () => {
+    const armed = { mods: { cmd: true, ctrl: false, alt: true, shift: false } }
+    expect(recordingKeyup(armed, e({}), HOLD)).toEqual({ kind: 'commit', combo: 'Cmd+Alt' })
+  })
+  it('partial release keeps waiting; no remembered mods ignores', () => {
+    const armed = { mods: { cmd: true, ctrl: false, alt: true, shift: false } }
+    expect(recordingKeyup(armed, e({ metaKey: true }), HOLD)).toEqual({ kind: 'ignored' })
+    expect(recordingKeyup({ mods: null }, e({}), HOLD)).toEqual({ kind: 'ignored' })
+  })
+  // WATCH-2: the legacy SpeechSection `anyModDown` omitted ctrlKey, so a mac hold chord recorded
+  // with Ctrl held committed while Ctrl was still down — mis-capturing the gesture. The full
+  // release condition must read ALL FOUR modifier flags.
+  it('a keyup with only Ctrl still held is ignored (the anyModDown gap, closed)', () => {
+    const armed = { mods: { cmd: true, ctrl: true, alt: false, shift: false } }
+    expect(recordingKeyup(armed, e({ ctrlKey: true }), HOLD)).toEqual({ kind: 'ignored' })
+    expect(recordingKeyup(armed, e({}), HOLD)).toEqual({ kind: 'commit', combo: 'Cmd+Ctrl' })
+  })
+})

--- a/src/renderer/components/settings/shortcutRecording.ts
+++ b/src/renderer/components/settings/shortcutRecording.ts
@@ -1,0 +1,131 @@
+/**
+ * The pure capture state machine behind the Settings shortcut recorder. Generalizes the legacy
+ * SpeechSection `ShortcutCaptureField` (one hard-wired dictation chord) into a decision function
+ * any command row can drive, and closes the two gaps that field shipped with.
+ *
+ * Two commit shapes, exactly as the v3 chord grammar defines them:
+ *  - A KEYED chord (primary modifier + a non-modifier key) commits IMMEDIATELY on keydown.
+ *  - A HOLD chord (modifier keys only — permitted only when `allowHold`, i.e. the command's
+ *    `allowHoldChord`) commits on KEYUP once every key is released. The keyup event no longer
+ *    carries the modifier state that was held, so each modifier keydown along the way remembers
+ *    it in `RecordingState.mods` (see `buildModifierChord`'s doc in @shared/shortcut).
+ * Escape cancels. The caller cancels on blur.
+ *
+ * The gaps this closes, both instances of "a capture must describe the WHOLE gesture" (matching is
+ * exact on all four modifier flags, so a chord that omits a modifier the user was holding can
+ * never fire again):
+ *  1. **mac Ctrl is collected**, in BOTH paths — the keyed path via `captureToShortcut`, the hold
+ *     path via `ChordModifiers.ctrl` here. The legacy field built `{cmd, alt, shift}` and dropped
+ *     a held ⌃ on the floor.
+ *  2. **Full release reads ALL FOUR flags.** The legacy `anyModDown` was
+ *     `(isMac ? metaKey : ctrlKey) || altKey || shiftKey` — no `ctrlKey`, so a mac chord recorded
+ *     with Ctrl held committed while Ctrl was still down, recording a chord the user never
+ *     finished making.
+ * A non-mac held Meta (Super/Win) is REFUSED rather than recorded as a bare `Cmd+…`: that gesture
+ * has no spelling in this grammar (same rule `captureToShortcut` already applies to keyed
+ * captures, here extended to the hold path).
+ *
+ * Pure: no DOM, no React, no clock. The component owns `RecordingState` in a ref and the caller
+ * validates the committed combo through `normalizeBindingForCommand` — this module decides only
+ * what the gesture MEANT, never whether the command accepts it.
+ */
+import {
+  buildModifierChord,
+  captureToShortcut,
+  formatShortcut,
+  isModifierEventKey,
+  type ChordModifiers,
+  type ShortcutKeyEvent
+} from '@shared/shortcut'
+
+/** What the recorder remembers between events: the strongest modifier-only state seen so far,
+ *  or `null` while no hold chord is armed. */
+export interface RecordingState {
+  mods: ChordModifiers | null
+}
+
+export type RecordingAction =
+  /** A complete gesture. The combo is canonical but NOT yet validated for the command. */
+  | { kind: 'commit'; combo: string }
+  /** Escape — stop recording, change nothing. */
+  | { kind: 'cancel' }
+  /** Still recording: adopt `state` and show `hint`. */
+  | { kind: 'pending'; state: RecordingState; hint: string }
+  /** Nothing to do (and nothing to show) — leave the recorder exactly as it was. */
+  | { kind: 'ignored' }
+
+export interface RecordingOptions {
+  isMac: boolean
+  /** The command's `allowHoldChord`. When false, a modifier-only gesture can never commit — it
+   *  only previews the requirement, and the user must go on to press a real key. */
+  allowHold: boolean
+}
+
+/** Non-mac Meta (Super/Win): unspellable in this grammar, in both the keyed and hold paths. */
+const SUPER_UNSUPPORTED = 'The Super key is not supported.'
+
+const holdPrimaryHint = (isMac: boolean): string => (isMac ? 'Hold ⌘…' : 'Hold Ctrl…')
+const keyedPrimaryHint = (isMac: boolean): string =>
+  isMac ? 'Hold ⌘ and press a key' : 'Hold Ctrl and press a key'
+
+/** Decide what a keydown during recording means. `state` is the recorder's current state; the
+ *  returned `pending` state replaces it (a `commit`/`cancel`/`ignored` leaves it to the caller,
+ *  which stops recording on the first two). */
+export function recordingKeydown(
+  state: RecordingState,
+  e: ShortcutKeyEvent & { key: string },
+  opts: RecordingOptions
+): RecordingAction {
+  const { isMac, allowHold } = opts
+  if (e.key === 'Escape') return { kind: 'cancel' }
+
+  if (isModifierEventKey(e.key)) {
+    // Only modifier keys are down so far. When the command permits a hold chord this is a
+    // candidate commit-on-release; otherwise it is purely a preview of what is still missing.
+    if (!allowHold) return { kind: 'pending', state: { mods: null }, hint: keyedPrimaryHint(isMac) }
+    if (!isMac && e.metaKey) return { kind: 'pending', state: { mods: null }, hint: SUPER_UNSUPPORTED }
+    const primaryPressed = isMac ? e.metaKey : e.ctrlKey
+    if (!primaryPressed) {
+      return { kind: 'pending', state: { mods: null }, hint: holdPrimaryHint(isMac) }
+    }
+    // A literal ⌃ beside the primary is part of the gesture on mac; off-mac `Cmd` already IS
+    // ctrlKey, so recording both would be the chord keybindings.ts validation forbids.
+    const mods: ChordModifiers = {
+      cmd: true,
+      ctrl: isMac && e.ctrlKey,
+      alt: e.altKey,
+      shift: e.shiftKey
+    }
+    const preview = buildModifierChord(mods)
+    return {
+      kind: 'pending',
+      state: { mods },
+      hint: preview ? `Release for ${formatShortcut(preview, isMac)} — or press a key` : ''
+    }
+  }
+
+  const combo = captureToShortcut(e, isMac)
+  if (combo) return { kind: 'commit', combo }
+  // Refused: either the primary modifier is missing, or (off-mac) Super is held. Keep whatever
+  // hold chord was armed — the user may still complete it by releasing everything.
+  return {
+    kind: 'pending',
+    state,
+    hint: !isMac && e.metaKey ? SUPER_UNSUPPORTED : keyedPrimaryHint(isMac)
+  }
+}
+
+/** Decide what a keyup during recording means: a hold chord commits once EVERY modifier is up. */
+export function recordingKeyup(
+  state: RecordingState,
+  e: ShortcutKeyEvent,
+  opts: RecordingOptions
+): RecordingAction {
+  if (!opts.allowHold || !state.mods) return { kind: 'ignored' }
+  // All four flags. `ctrlKey` is the one the legacy field forgot — see the module doc. The keyup
+  // event's own flags already exclude the key just released, so "no flag set" means fully up.
+  if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return { kind: 'ignored' }
+  const combo = buildModifierChord(state.mods)
+  if (!combo) return { kind: 'ignored' }
+  return { kind: 'commit', combo }
+}

--- a/src/renderer/components/settings/shortcutRecording.ts
+++ b/src/renderer/components/settings/shortcutRecording.ts
@@ -3,6 +3,9 @@
  * SpeechSection `ShortcutCaptureField` (one hard-wired dictation chord) into a decision function
  * any command row can drive, and closes the two gaps that field shipped with.
  *
+ * `ShortcutCaptureField` and its `anyModDown` helper were both REMOVED in this series — they are
+ * named below only to record which bug each gap was; there is nothing left in the tree to grep.
+ *
  * Two commit shapes, exactly as the v3 chord grammar defines them:
  *  - A KEYED chord (primary modifier + a non-modifier key) commits IMMEDIATELY on keydown.
  *  - A HOLD chord (modifier keys only — permitted only when `allowHold`, i.e. the command's

--- a/src/renderer/components/settings/shortcutRecording.ts
+++ b/src/renderer/components/settings/shortcutRecording.ts
@@ -25,6 +25,18 @@
  * has no spelling in this grammar (same rule `captureToShortcut` already applies to keyed
  * captures, here extended to the hold path).
  *
+ * **Deliberate divergence from the legacy field — losing the primary modifier DISARMS.** When a
+ * modifier-only keydown arrives with the primary modifier NOT pressed, the legacy field showed the
+ * `Hold ⌘…` hint and returned, leaving `modsRef` holding whatever it had armed earlier. That let a
+ * gesture commit a chord the user was no longer making: arm `Cmd+Alt`, release ⌘ while keeping ⌥,
+ * add ⇧ — the ⇧ keydown left `{cmd:true, alt:true}` armed, and the eventual full release committed
+ * `Cmd+Alt` even though the user finished on ⌥⇧. Under exact matching that stored chord then never
+ * fires from the gesture that recorded it. Here the same event clears `mods`, so a hold chord is
+ * only ever committed from a state where the primary was observed down alongside it; the user
+ * simply presses the chord again. (`recordingKeydown` still preserves an armed chord across a
+ * REFUSED KEYED press — see the `captureToShortcut` fall-through below — because that path cannot
+ * lose the primary without a modifier keyup/keydown passing through here first.)
+ *
  * Pure: no DOM, no React, no clock. The component owns `RecordingState` in a ref and the caller
  * validates the committed combo through `normalizeBindingForCommand` — this module decides only
  * what the gesture MEANT, never whether the command accepts it.

--- a/src/renderer/lib/keybindingOverrides.test.ts
+++ b/src/renderer/lib/keybindingOverrides.test.ts
@@ -3,7 +3,8 @@ import { DEFAULT_SETTINGS } from '@shared/types'
 import { matchesShortcut, type ShortcutKeyEvent } from '@shared/shortcut'
 import { useSettings } from '../state/settings'
 import {
-  activeKeybindingOverrides, effectiveBindings, commandKeys, commandTooltip, chipFor
+  activeKeybindingOverrides, effectiveBindings, commandKeys, commandTooltip, chipFor,
+  setKeybindingOverride, commandKeysFor, dictationBinding
 } from './keybindingOverrides'
 
 const setKb = (kb: unknown) =>
@@ -103,5 +104,38 @@ describe('chipFor', () => {
   })
   it('is empty for an unbound command, so callers can fall back', () => {
     expect(chipFor('canvas.fitAll', true)).toBe('')
+  })
+})
+
+describe('setKeybindingOverride', () => {
+  it('set, disable, and reset shape the map correctly', () => {
+    setKeybindingOverride('node.newTerminal', ['Cmd+Shift+T'])
+    expect(useSettings.getState().settings.keybindings).toEqual({
+      'node.newTerminal': ['Cmd+Shift+T']
+    })
+    setKeybindingOverride('canvas.undo', [])
+    expect(useSettings.getState().settings.keybindings?.['canvas.undo']).toEqual([])
+    setKeybindingOverride('node.newTerminal', null)
+    expect('node.newTerminal' in (useSettings.getState().settings.keybindings ?? {})).toBe(false)
+  })
+  it('mirrors speech.dictation into speech.shortcut, and reset restores the default mirror', () => {
+    setKeybindingOverride('speech.dictation', ['Cmd+Alt+D'])
+    expect(useSettings.getState().settings.speech.shortcut).toBe('Cmd+Alt+D')
+    setKeybindingOverride('speech.dictation', null)
+    expect(useSettings.getState().settings.speech.shortcut).toBe(DEFAULT_SETTINGS.speech.shortcut)
+  })
+})
+
+describe('commandKeysFor / dictationBinding', () => {
+  it('lists every effective binding', () => {
+    expect(commandKeysFor('canvas.deleteSelection', true)).toEqual([['Delete'], ['Backspace']])
+    expect(commandKeysFor('canvas.fitAll', true)).toEqual([])
+  })
+  it('dictationBinding follows the override and reports disabled as empty', () => {
+    expect(dictationBinding()).toBe('Cmd+Alt')
+    setKeybindingOverride('speech.dictation', ['Cmd+Alt+D'])
+    expect(dictationBinding()).toBe('Cmd+Alt+D')
+    setKeybindingOverride('speech.dictation', [])
+    expect(dictationBinding()).toBe('')
   })
 })

--- a/src/renderer/lib/keybindingOverrides.ts
+++ b/src/renderer/lib/keybindingOverrides.ts
@@ -62,7 +62,14 @@ export function chipFor(id: CommandId, isMac: boolean = isMacPlatform()): string
  *  `speech.shortcut` field for one release, so a downgraded build keeps the user's chord.
  *  On DISABLE (`[]`) `bindings?.[0]` is `undefined`, so the mirror falls back to the DEFAULT
  *  chord rather than an empty string: a downgraded build then gets default dictation instead
- *  of a broken value it cannot parse. */
+ *  of a broken value it cannot parse.
+ *
+ *  **Raw in, sanitized out — the two maps are not the same map.** This writes into the RAW
+ *  `settings.keybindings` object, while every UI gate (the chips, Disable/Reset visibility,
+ *  `commitCandidate`'s conflict check) reads the SANITIZED one. So a hand-edited entry the
+ *  sanitizer drops — an unknown id, an invalid chord, a conflict participant — is invisible to
+ *  the gate yet still sitting on disk, and it stays there until a UI write for that command, or
+ *  a Reset, replaces the map. */
 export function setKeybindingOverride(id: CommandId, bindings: readonly string[] | null): void {
   const state = useSettings.getState()
   const next: KeybindingOverrides = { ...(state.settings.keybindings ?? {}) }

--- a/src/renderer/lib/keybindingOverrides.ts
+++ b/src/renderer/lib/keybindingOverrides.ts
@@ -11,6 +11,7 @@ import {
 } from '@shared/keybindings'
 import { shortcutKeyParts } from '@shared/shortcut'
 import { isMacPlatform } from '@shared/platform-utils'
+import { DEFAULT_SETTINGS } from '@shared/types'
 import { useSettings } from '../state/settings'
 
 const UNSET = Symbol('unset')
@@ -52,4 +53,42 @@ export function commandTooltip(text: string, id: CommandId, isMac: boolean = isM
 export function chipFor(id: CommandId, isMac: boolean = isMacPlatform()): string {
   const parts = commandKeys(id, isMac)
   return isMac ? parts.join('') : parts.join('+')
+}
+
+/** The single WRITE path for overrides. `null` = reset (delete the key, defaults return);
+ *  `[]` = disabled. Values are stored as given — callers pass canonical strings from
+ *  `normalizeBindingForCommand`; the read path's sanitizer remains the safety net for
+ *  hand-edited files. `speech.dictation` also mirrors its first binding into the legacy
+ *  `speech.shortcut` field for one release, so a downgraded build keeps the user's chord.
+ *  On DISABLE (`[]`) `bindings?.[0]` is `undefined`, so the mirror falls back to the DEFAULT
+ *  chord rather than an empty string: a downgraded build then gets default dictation instead
+ *  of a broken value it cannot parse. */
+export function setKeybindingOverride(id: CommandId, bindings: readonly string[] | null): void {
+  const state = useSettings.getState()
+  const next: KeybindingOverrides = { ...(state.settings.keybindings ?? {}) }
+  if (bindings === null) delete next[id]
+  else next[id] = [...bindings]
+  if (id === 'speech.dictation') {
+    const mirror = bindings?.[0] ?? DEFAULT_SETTINGS.speech.shortcut
+    state.update({
+      keybindings: next,
+      speech: { ...state.settings.speech, shortcut: mirror }
+    })
+    return
+  }
+  state.update({ keybindings: next })
+}
+
+/** Display parts for EVERY effective binding (the panel shows the first; the Settings section
+ *  shows them all). [] when unbound/disabled. */
+export function commandKeysFor(id: CommandId, isMac: boolean = isMacPlatform()): string[][] {
+  return getEffectiveBindings(id, activeKeybindingOverrides(), isMac).map((b) =>
+    shortcutKeyParts(b, isMac)
+  )
+}
+
+/** The dictation chord's single source: the first effective `speech.dictation` binding.
+ *  `''` = the user disabled it (dictation shortcut off; the mic button still works). */
+export function dictationBinding(): string {
+  return effectiveBindings('speech.dictation')[0] ?? ''
 }

--- a/src/renderer/state/settings.ts
+++ b/src/renderer/state/settings.ts
@@ -17,6 +17,9 @@ const SAVE_COALESCE_MS = 300
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 let pendingSave: Settings | null = null
 function scheduleSave(next: Settings): void {
+  // Same guard as the beforeunload flush below: this module is transitively imported by
+  // node-environment unit tests, where `window` doesn't exist and the timer would throw.
+  if (typeof window === 'undefined') return
   pendingSave = next
   if (saveTimer) return
   saveTimer = setTimeout(() => {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -69,6 +69,12 @@ export const IPC = {
    *  Electron's default View menu binds that accelerator to `resetZoom`, which resets the WINDOW's
    *  page zoom rather than the canvas's. */
   appZoomActualSize: 'app:zoom-actual-size',
+  /** Renderer → main: the Settings shortcut recorder is armed (`true`) or disarmed (`false`).
+   *  While armed the main window's `before-input-event` intercepts above stand down entirely, so
+   *  the chord the user is recording — ⌘W and ⌘M among them — reaches the recorder instead of
+   *  closing their selected nodes. Fire-and-forget `send`; desktop-only (a browser tab has no
+   *  application menu to steal a chord back from, so the Server Edition stubs it). */
+  uiShortcutRecording: 'ui:shortcut-recording',
   appCloseWindow: 'app:close-window',
   /** Main → renderer: the native application menu's "Settings…" item (⌘,) was clicked. The
    *  renderer opens the settings page — same path as the in-canvas gear button / Cmd+, keydown. */

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -8,7 +8,9 @@ import {
   bindingIdentity,
   findKeybindingConflicts,
   sanitizeKeybindingOverrides,
-  resolveCommandForKeyEvent
+  resolveCommandForKeyEvent,
+  MAIN_INTERCEPTED_COMMAND_IDS,
+  findMainInterceptShadowing
 } from './keybindings'
 import { parseShortcut } from './shortcut'
 import type { ShortcutKeyEvent } from './shortcut'
@@ -408,5 +410,32 @@ describe('resolveCommandForKeyEvent', () => {
     // Deliberately unsanitized colliding override — the resolver must order the tie deterministically.
     const o = { 'canvas.redo': ['Cmd+Z'] }
     expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'z' }), ctx(), o, true)).toBe('canvas.undo')
+  })
+})
+
+describe('findMainInterceptShadowing', () => {
+  it('flags a main-intercepted remap that shadows another bucket', () => {
+    expect(findMainInterceptShadowing('node.close', 'Cmd+F', {}, true)).toEqual(['terminal.find'])
+    expect(findMainInterceptShadowing('node.close', 'Cmd+Enter', {}, true)).toEqual(['scm.commit'])
+  })
+  it('same-bucket collisions are the sanitizer/conflict path, still reported here', () => {
+    expect(findMainInterceptShadowing('node.toggleMarkdown', 'Cmd+K', {}, true)).toEqual([
+      'app.commandPalette'
+    ])
+  })
+  it('empty for a clean chord, for non-intercepted commands, and never self-reports', () => {
+    expect(findMainInterceptShadowing('node.close', 'Cmd+Alt+F9', {}, true)).toEqual([])
+    expect(findMainInterceptShadowing('canvas.undo', 'Cmd+F', {}, true)).toEqual([])
+    expect(findMainInterceptShadowing('node.close', 'Cmd+W', {}, true)).toEqual([])
+  })
+  it('respects overrides and cross-spelling identities', () => {
+    const o = { 'terminal.find': ['Cmd+Alt+F9'] }
+    expect(findMainInterceptShadowing('node.close', 'Cmd+F', o, true)).toEqual([])
+    expect(findMainInterceptShadowing('node.close', 'Ctrl+K', {}, false)).toEqual([
+      'app.commandPalette'
+    ])
+  })
+  it('names exactly the two main-intercepted commands', () => {
+    expect(MAIN_INTERCEPTED_COMMAND_IDS).toEqual(['node.close', 'node.toggleMarkdown'])
   })
 })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -386,7 +386,8 @@ export function resolveCommandForKeyEvent(
     // the window listener — resolving them here would fire Commit with no composer focused.
     if (def.scope === 'scm') continue
     // speech.dictation dispatches from its own dedicated listeners (the keyed gesture and the
-    // hold-mode effect, both reading settings.speech.shortcut), never from the registry — its
+    // hold-mode effect, both reading `dictationBinding()` — the registry override; the legacy
+    // settings.speech.shortcut field is only its downgrade mirror), never from here — its
     // row here is display-only, for ShortcutsPanel and the Settings section. A hand-edited KEYED
     // override would otherwise RESOLVE, find no handler, and spend the chord: the dispatcher's
     // claim protocol stops a resolved command from reaching the trailing gestures, so

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -260,6 +260,38 @@ export function findKeybindingConflicts(
   return conflicts
 }
 
+/** Commands the MAIN process intercepts via before-input-event. A remap of one of these is
+ *  swallowed app-wide before any renderer surface sees the key, so the Settings UI must check
+ *  its candidate against EVERY command — the per-bucket conflict detector cannot see this. */
+export const MAIN_INTERCEPTED_COMMAND_IDS: readonly CommandId[] = [
+  'node.close',
+  'node.toggleMarkdown'
+]
+
+/** Cross-bucket shadowing check for a candidate binding of a main-intercepted command:
+ *  every OTHER command whose effective bindings share the candidate's platform identity.
+ *  Empty for non-intercepted commands (their collisions are the ordinary bucket check). */
+export function findMainInterceptShadowing(
+  id: CommandId,
+  candidate: string,
+  overrides: KeybindingOverrides,
+  isMac: boolean
+): CommandId[] {
+  if (!MAIN_INTERCEPTED_COMMAND_IDS.includes(id)) return []
+  const target = bindingIdentity(candidate, isMac)
+  const hits: CommandId[] = []
+  for (const def of COMMAND_DEFINITIONS) {
+    if (def.id === id) continue
+    for (const binding of getEffectiveBindings(def.id, overrides, isMac)) {
+      if (bindingIdentity(binding, isMac) === target) {
+        hits.push(def.id)
+        break
+      }
+    }
+  }
+  return hits
+}
+
 /** Validate a raw `settings.keybindings` value (hand-editable JSON) into a safe override map.
  *  Loops until conflict-free so one bad edit cannot leave ambiguous dispatch. This is the
  *  SETTINGS-LOAD path: it applies what survives and warns about what it dropped. It is not the

--- a/src/shared/shortcut.test.ts
+++ b/src/shared/shortcut.test.ts
@@ -262,6 +262,15 @@ describe('isHoldChord', () => {
     expect(isHoldChord('Cmd+Alt+D')).toBe(false)
     expect(isHoldChord('Cmd+D')).toBe(false)
   })
+
+  // DOCUMENTATION OF A HAZARD, not a desirable property: `''` parses to a chord with no key, so
+  // it reads as a HOLD chord. `dictationBinding()` returns `''` for a DISABLED dictation shortcut
+  // (override `[]`), so any caller that asks `isHoldChord(chord)` without first testing for the
+  // empty string classifies "off" as "hold-to-talk" — which is why SpeechSection's note checks
+  // `chord === ''` FIRST, and why the hold listener must not arm on it.
+  it('is TRUE for the empty string — every caller owes it an explicit empty check', () => {
+    expect(isHoldChord('')).toBe(true)
+  })
 })
 
 describe('isModifierEventKey', () => {
@@ -439,6 +448,13 @@ describe('strict modifier matching', () => {
   it('chordHeld applies the same strictness', () => {
     const e = { metaKey: true, ctrlKey: true, shiftKey: false, altKey: true, key: 'Control' }
     expect(chordHeld(e, 'Cmd+Alt', true)).toBe(false)
+  })
+  // The other half of the `''` guard (see isHoldChord above): the KEYED path is safe on its own —
+  // an empty chord parses to `key: null`, which no event key equals — so a disabled dictation
+  // shortcut can never be pressed into existence, however the modifiers happen to be held.
+  it('never matches the empty string, whatever is held', () => {
+    const e = { metaKey: true, ctrlKey: false, shiftKey: false, altKey: true, key: 'd' }
+    expect(matchesShortcut(e, '', true)).toBe(false)
   })
 })
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2467,6 +2467,19 @@ export interface PresenceApi {
   onPeer(listener: (diff: PeerDiff) => void): () => void
 }
 
+/** Keyboard-shortcut plumbing the RENDERER cannot do for itself. */
+export interface ShortcutsApi {
+  /** Tell the shell that a shortcut recorder is armed (`true`) or released (`false`), so the
+   *  desktop's `before-input-event` intercepts stand down and the chord being recorded — ⌘W and
+   *  ⌘M among them — reaches the recorder instead of closing the user's selected nodes. A claimed
+   *  chord never reaches the page, so the recorder's own preventDefault cannot substitute for
+   *  this. Fire-and-forget. **The `false` leg is not optional**: the bit is global, so a recorder
+   *  that arms and never releases leaves those chords dead app-wide. Server Edition: a documented
+   *  no-op (a browser tab has no application menu to steal a chord back from, so nothing
+   *  intercepts). */
+  setRecording(active: boolean): void
+}
+
 export interface NodeTerminalApi {
   pty: PtyApi
   workspace: WorkspaceApi
@@ -2508,6 +2521,7 @@ export interface NodeTerminalApi {
   handoff: HandoffApi
   pairing: PairingApi
   presence: PresenceApi
+  shortcuts: ShortcutsApi
   /** Fires when the user presses Cmd/Ctrl+M (toggle markdown view). Returns unsubscribe. */
   onMarkdownToggle(listener: () => void): () => void
   /** Fires when the user presses Cmd/Ctrl+W (close selected node). Returns unsubscribe. */


### PR DESCRIPTION
Part 3 of the remappable-shortcuts series (#311 registry, #316 dispatch): the user-facing Settings → Keyboard Shortcuts section, plus the dictation chord's migration onto the registry.

- **Keyboard Shortcuts section** (Settings → Interface): every registry command grouped as in the registry, with Record / Add / Disable / Reset. Recording captures hold chords for dictation, collects the non-primary modifier (mac ⌘⌃ chords now round-trip — closing a gap parked since #311), and refuses the non-mac Super key with a hint. A candidate is blocked inline when it conflicts in its own bucket, when a main-intercepted command would swallow it app-wide, or — the reverse — when it would sit under a chord the main process already intercepts. One error per candidate.
- **Recording suppression**: while a recorder is armed, the main process stands down (⌘W/⌘0 flow to the recorder instead of closing nodes/zooming). The bit clears on window close, renderer death, and real navigations (a ⌘R reload can no longer strand it), and only the instance that armed it may release it.
- **Dictation migration**: the chord now lives in `settings.keybindings["speech.dictation"]`. A customized legacy `speech.shortcut` is seeded once on load (idempotent; an explicit `[]` — the new "shortcut off" capability — is respected); the legacy field remains as a one-release downgrade mirror. All consumers (hold effect, keyed gesture, Dock tooltip, panels, onboarding) read the registry value; the Speech section's capture field became a link to the new section.
- **Display**: TabBar kanban tooltip (which showed raw mac glyphs off-mac — fixed), the palette hint, and the onboarding chords follow remaps; the onboarding kanban try-it now accepts exactly the effective binding (its old lax matcher also accepted Ctrl+Shift+B on mac and ⌘⌥⇧B); ShortcutsPanel drops the duplicate Source Control row and re-renders live on a remap.
- Docs: README shortcut table notes remappability and fixes a stale Dictate chord; CLAUDE.md gains the subsystem's invariants.

### Known limitations (documented, not silent)

- **Seed vs. sanitizer:** a legacy dictation chord that collides with another command's binding in the same conflict bucket (e.g. `Cmd+K`) is seeded and then stripped by the read-path sanitizer — dictation reverts to the default with only a console warning, and a colliding hand-set override can be dropped with it. Follow-up filed: give `speech.dictation` its own conflict bucket (it never competes at dispatch — the resolver skips it).
- **The application menu owns Minimize (⌘M / Ctrl+M) and, on Windows/Linux, Close (Ctrl+W)** — those chords cannot be recorded; the fix site is `buildAppMenu` (suspend/rebuild while recording), left as a follow-up.
- Hand-edited `settings.json` entries bypass the UI's blocking (they are sanitized at read instead) — one detector, two surfacings, by design.
- Settings nav grows 24 → 25 sections (the only test-expectation change).

Remaining for later parts: terminal-first policy + capture toast (design D7), per-chip binding removal UX, Server Edition chord-reservation parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)