### PR TITLE
feat(codex): the account signing secret and the account-scoped identity proxy

### DIFF
--- a/docs/shared-codex-node-identity.md
+++ b/docs/shared-codex-node-identity.md
@@ -1,0 +1,102 @@
+# Shared Codex node identity — the account-scoped ownership spine
+
+A Codex canvas node talks to **one shared `codex app-server`** and owns **one thread** inside it.
+The node↔thread mapping is what survives resumes, in-pane restarts, and app restarts. S6 adds the
+**account** dimension: the same machine can hold the system login (`~/.codex`) alongside several
+managed logins, and a thread's ownership record must name **which account** it belongs to, not just
+which node — so one account can never be made to speak for another's threads.
+
+This document covers the ownership spine shipped in S6 PR 2. The account **model** and on-disk home
+layout are PR 1 (`codex-accounts-core.ts`); the spawn wiring, relay, and switch/transfer protocol
+are later PRs. This slice **ships inert** — nothing sets `NODETERM_CODEX_ACCOUNT_ID` on a pane yet —
+but it is fully tested against real primitives (real `/bin/sh`, real fs, real HMAC).
+
+## The signing secret (both shells — Decision 1)
+
+Every ownership record is HMAC-signed by the **one** restart-stable 32-byte node-auth secret
+(`src/core/agents/node-auth-secret.ts`, `loadOrCreateNodeAuthSecret`). That secret already arms on
+**both** shells and this proxy reuses it as-is:
+
+- **Desktop:** sealed at rest via `safeStorage` → `node-auth-key.json` (ciphertext only, mode
+  `0600`; no raw-secret fallback ever written).
+- **Server Edition (no keychain):** 32 raw bytes at `node-auth-key.bin`, mode `0600`.
+
+It is **confidential and fail-closed**: a malformed/wrong-length persisted state **throws** rather
+than minting a fresh secret — rotating the key would orphan every bound thread on the machine — and
+the single-flight cache clears on rejection so a healed machine retries. It is wired at boot in both
+`src/main/index.ts` and `src/server/index.ts` via `setCodexThreadIdentityAuthSecret(...)`.
+
+> No `safeStorage`-only secret module is introduced. @Corvin's `codex-node-auth-secret.ts` in
+> PR #112 is `safeStorage`-ciphertext-only and throws on a headless server; the merged both-shells
+> channel above is the correct mirror, and duplicating it as a keychain-only file would regress the
+> Server Edition. This is the ratified Decision 1.
+
+## The ownership records
+
+`~/.nodeterm/codex-thread-nodes/` (under `CorePlatform.userDataDir`, **not** `~`):
+
+- **System account** → the bare-root file `<root>/<threadId>` — the exact S4 layout, so a machine
+  with no managed accounts is byte-for-byte unchanged and its legacy records keep resolving.
+- **Managed account** → `<root>/<accountId>/<threadId>`.
+
+Each record is a flat `key=value` text file, mode `0600`, **parsed as data, never sourced**:
+
+```
+accountId=<id or empty for system>
+nodeId=<owning canvas node>
+endpoint=<hook endpoint file path>
+signature=<base64url HMAC>
+```
+
+### The signature binds the full 4-tuple
+
+```
+signature = base64url( HMAC-SHA256( key, threadId ␀ accountScope ␀ nodeId ␀ hookEndpoint ) )
+```
+
+`accountScope` is the account id, or the literal `system` for the system account (empty id
+normalised). Because the scope is inside the preimage, a record signed for account **A** verifies
+only under scope **A** — copying it byte-for-byte into account **B**'s directory fails the MAC.
+Verification is `timingSafeEqual`. Records written before this slice carry **no** `accountId=` line
+and are verified with the original 3-tuple preimage **at the system scope only** — the one
+back-compat door, and it is a system-scope door (a scope-less signature is never honoured under a
+managed account).
+
+## Fail-closed ambiguity (the house rule, reused)
+
+Ownership resolution reuses the merged fail-closed posture (`pane-ownership.ts`,
+`node-identity-policy.ts`): **an owner that cannot be proven is denied.**
+
+- `resolveCodexThreadNodeIdentity(threadId)` with no account hint (the shared tool shell that knows
+  only a bare thread id) scans **every** scope and returns an owner **only when `owners.size === 1`**.
+  The same thread id owned by two different accounts resolves to **nothing**.
+- `resolveCodexThreadNodeIdentity(threadId, root, accountId)` with an explicit account resolves
+  within that one scope.
+- `codexThreadIdentityHasLiveConflict(...)` reports a conflict only when **two different live
+  nodes** own the thread across scopes.
+
+## The POSIX-sh resolver
+
+`codexThreadIdentityResolverSh(root)` is prepended to every managed hook script. A shared-app-server
+tool shell inherits `CODEX_THREAD_ID` but not the pane's `NODETERM_*` (see probe U5,
+`docs/superpowers/probes/2026-08-codex-tool-shell-env.md`), so this prelude recovers the binding:
+
+- reads `NODETERM_CODEX_ACCOUNT_ID` from the daemon env to pick the scope;
+- a known safe account id ⇒ reads **only** that account's record, and requires the record's
+  `accountId=` line to **agree with the daemon scope**;
+- an **empty** account id ⇒ scans every scope (bare-root system + each managed subdir) and binds
+  **only when exactly one candidate matches** (`nt_codex_matches -eq 1`) — two accounts holding the
+  same thread id change nothing;
+- it cannot verify the HMAC (no key in an agent's shell), so it re-validates every recovered field's
+  charset and the account-line/scope agreement before exporting. Its behaviour is proven under real
+  `/bin/sh` against a real on-disk scope tree in `codex-thread-identity-sh.test.ts`.
+
+## Supply-chain guard
+
+Account ids arrive from hand-editable `settings.json` / `project.json`. Every id passes
+`ACCOUNT_ID_RE` (`^[A-Za-z0-9][A-Za-z0-9._-]*$`, must start alphanumeric) — via `accountScope()` in
+the proxy, the launcher's own sh check, and the hook-server route — **before** it becomes a
+directory scope, so `.`/`..`/leading-separator/`a/b`/absolute ids are refused at the door. The
+launcher threads the account id through the `/codex-thread/{start,bind}` POST **body**, never on
+argv (Constraint 6); a bad id falls back to plain `codex` rather than binding under a hostile scope,
+and the server refuses it at `400` before the start handler can create an orphan thread.

--- a/docs/superpowers/probes/2026-08-codex-tool-shell-env.md
+++ b/docs/superpowers/probes/2026-08-codex-tool-shell-env.md
@@ -1,0 +1,55 @@
+# Probe — a shared Codex `app-server` tool shell keeps `CODEX_THREAD_ID`, drops `NODETERM_*`
+
+**Design claim under test:** S6 `[UNVERIFIED] U5` — the premise of the entire sh resolver
+(`codex-thread-identity-sh.ts` / `CODEX_THREAD_IDENTITY_RESOLVER`). A tool/hook shell spawned by the
+**shared** Codex `app-server` inherits `CODEX_THREAD_ID` (so the owning NodeTerm node can be
+recovered from a bare thread id) but **not** the per-pane `NODETERM_*` env (so the resolver has real
+work to do). If `NODETERM_NODE_ID` survived into that shell, the resolver would be dead code and the
+account-scoped scan added in S6 PR 2 would be unnecessary complexity — stop and report.
+
+## Environment
+
+- **Codex CLI 0.146.0** (`/usr/bin/codex`, `@openai/codex@0.146.0`, npm-managed —
+  `CODEX_MANAGED_BY_NPM=1`). Linux, headless, logged in (`~/.codex/auth.json`).
+- This host actively runs NodeTerm Codex nodes; the deployed S4 resolver lives at
+  `~/.nodeterm/agent-hooks/codex.sh` and is the production consumer of this premise.
+- Measurement: a throwaway `CODEX_HOME` under the scratchpad, driven by `codex exec` with
+  `NODETERM_NODE_ID` / `NODETERM_CODEX_ACCOUNT_ID` / `NODETERM_HOOK_ENDPOINT` set in the launching
+  env, running a tool command that dumps `env | grep -E '^(CODEX_|NODETERM_)'`.
+
+## Measured result
+
+**U5 holds.** Split into its two halves:
+
+1. **`CODEX_THREAD_ID` is present in the tool shell — measured directly.** Every tool command
+   Codex 0.146.0 executed carried a fresh `CODEX_THREAD_ID` (two runs, two distinct thread ids —
+   `01a01ab8-…` then `01a01ab9-…`), injected by Codex regardless of the launching env. Confirmed.
+
+2. **`NODETERM_*` are dropped by the SHARED app-server — confirmed by topology + the deployed S4
+   resolver.** The persistent daemon (`codex app-server daemon start`, which honours `CODEX_HOME`)
+   forks its tool shells as children of the **daemon** process, not of the connecting per-node TUI
+   client, so they inherit the daemon's env — and NodeTerm starts the shared daemon once, without
+   the per-pane `NODETERM_*`. The merged, **deployed** S4 resolver on this host guards on exactly
+   this (`[ -z "$NODETERM_NODE_ID" ] && [ -n "$CODEX_THREAD_ID" ]`) and works in production (Codex
+   node badges move) — which is only possible if `NODETERM_NODE_ID` is absent in those shells.
+
+### Caveat measured (and why it is harmless)
+
+`codex exec` (and any client that spawns its **own** in-process app-server rather than connecting to
+the shared daemon) forks the tool shell as a descendant of the launching process, so there
+`NODETERM_*` **do leak** through — the probe saw `NODETERM_NODE_ID=probe-node-xyz` and
+`NODETERM_CODEX_ACCOUNT_ID=probe-acct-123` survive into that shell. This is the non-shared topology
+and is harmless: the resolver's outer guard `[ -z "$NODETERM_NODE_ID" ]` makes it a no-op whenever
+those are already set, so a leaked (and possibly stale) account id can never drive a mis-scoped
+bind. The account-scoped scan added in PR 2 only ever runs when `NODETERM_NODE_ID` is empty — i.e.
+the genuine shared-daemon tool shell.
+
+### What could NOT be measured directly, and why it does not block
+
+The persistent daemon's tool shell could not be exercised in isolation on this host: `codex
+app-server daemon start` refuses without the curl-managed standalone install
+(`<CODEX_HOME>/packages/standalone/current/codex`), which the npm-managed CLI here does not ship
+(and no running daemon exists at `~/.codex/app-server-control/`). That is the U4 install caveat, not
+a failure of the U5 premise — the premise is corroborated by (2) above.
+
+**Verdict: NOT BLOCKED.** Build the account-scoped resolver on this premise.

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -10,6 +10,7 @@ import type { NodeTokenVerdict } from './node-auth-token'
 import { nodeTokenDir } from './node-token-files'
 import { isForeignKidToken, isSafeNodeId, verifyNodeToken } from './node-auth-token'
 import { isSafeThreadId } from '../codex-identity-proxy'
+import { isSafeAccountId } from '../../shared/codex-account'
 import {
   controlPolicy,
   CONTEXT_LINK_POLICY_VERB,
@@ -245,10 +246,20 @@ class HookServer {
    * `nodeTokenVerified`.
    */
   private codexThreadStartHandler:
-    | ((req: { nodeId: string; cwd: string; hookEndpoint: string }) => Promise<string>)
+    | ((req: {
+        nodeId: string
+        cwd: string
+        hookEndpoint: string
+        accountId?: string
+      }) => Promise<string>)
     | null = null
   private codexThreadBindHandler:
-    | ((req: { nodeId: string; threadId: string; hookEndpoint: string }) => Promise<void>)
+    | ((req: {
+        nodeId: string
+        threadId: string
+        hookEndpoint: string
+        accountId?: string
+      }) => Promise<void>)
     | null = null
   private codexIdentityListener: ((e: CodexIdentityEvent) => void) | null = null
   private endpointPath = ''
@@ -828,6 +839,17 @@ class HookServer {
       res.end()
       return
     }
+    // The account scope for this thread's ownership record (S6). Absent ⇒ system account. A
+    // non-empty id that is not a safe account id is refused BEFORE it reaches the record store,
+    // where it would become a directory component (Supply-chain guard, Constraint 7). Both routes
+    // share the same normalisation so a managed thread is never mis-filed under `system`.
+    const rawAccountId = form.accountId ?? ''
+    if (rawAccountId !== '' && !isSafeAccountId(rawAccountId)) {
+      res.writeHead(400)
+      res.end()
+      return
+    }
+    const accountId = rawAccountId || undefined
     if (verb === 'start') {
       const cwd = form.cwd ?? ''
       if (!path.isAbsolute(cwd)) {
@@ -840,7 +862,8 @@ class HookServer {
         const threadId = await this.codexThreadStartHandler({
           nodeId,
           cwd,
-          hookEndpoint: this.endpointFilePath()
+          hookEndpoint: this.endpointFilePath(),
+          accountId
         })
         // Same predicate the record store gates on, so a thread id the store would refuse can
         // never be handed back to a launcher that will then `resume` it.
@@ -868,7 +891,8 @@ class HookServer {
       await this.codexThreadBindHandler({
         nodeId,
         threadId,
-        hookEndpoint: this.endpointFilePath()
+        hookEndpoint: this.endpointFilePath(),
+        accountId
       })
       this.codexIdentityListener?.({ nodeId, mode: 'shared' })
       res.writeHead(204)

--- a/src/core/agents/hooks/managed-script.test.ts
+++ b/src/core/agents/hooks/managed-script.test.ts
@@ -156,8 +156,9 @@ describe('buildManagedScript', () => {
     // under /bin/sh in core/codex-thread-identity-sh.test.ts.)
     it('is present in every agent script when an identity root is known', () => {
       for (const agent of ['claude', 'codex', 'gemini', 'grok', 'opencode']) {
+        // The account-scoped resolver bakes the (quoted) record root in and scans scopes below it.
         expect(buildManagedScript(agent, '/data/codex-thread-nodes')).toContain(
-          "nt_codex_map='/data/codex-thread-nodes'/\"$CODEX_THREAD_ID\""
+          "nt_codex_root='/data/codex-thread-nodes'"
         )
       }
     })

--- a/src/core/agents/node-auth-secret.test.ts
+++ b/src/core/agents/node-auth-secret.test.ts
@@ -68,6 +68,12 @@ describe('node-auth secret behind CorePlatform', () => {
     const atRest = fs.readFileSync(file, 'utf8')
     // The raw secret's base64 must not appear on disk — only the sealed form.
     expect(atRest.includes(first.toString('base64'))).toBe(false)
+    // And no SIBLING file may carry it either: the sealed json is the only thing written, so a
+    // plaintext fallback (the mutation Property 6 forbids) has nowhere to hide. Scan every file.
+    expect(fs.readdirSync(dir)).toEqual(['node-auth-key.json'])
+    for (const name of fs.readdirSync(dir)) {
+      expect(fs.readFileSync(path.join(dir, name), 'utf8').includes(first.toString('base64'))).toBe(false)
+    }
     const parsed = JSON.parse(atRest)
     expect(parsed.version).toBe(1)
     expect(typeof parsed.secretKeyEnc).toBe('string')
@@ -105,6 +111,19 @@ describe('node-auth secret behind CorePlatform', () => {
     fs.writeFileSync(path.join(dir, 'node-auth-key.bin'), Buffer.alloc(10), { mode: 0o600 })
     initPlatform(fakePlatform({ userDataDir: dir }))
     await expect(loadOrCreateNodeAuthSecret()).rejects.toThrow(/invalid|malformed/i)
+  })
+
+  it('Desktop: fails closed on a malformed sealed key instead of rotating ownership', async () => {
+    // A present-but-corrupt node-auth-key.json must THROW, never silently mint a fresh secret: the
+    // same key signs the codex thread→node ownership records, so rotating it would orphan every
+    // bound thread on the machine (Property 6). The corrupt file is left exactly as found.
+    const file = path.join(dir, 'node-auth-key.json')
+    fs.writeFileSync(file, '{ this is not json', { mode: 0o600 })
+    initPlatform(fakePlatform({ userDataDir: dir, sealSecret: xor, unsealSecret: xor }))
+    await expect(loadOrCreateNodeAuthSecret()).rejects.toThrow(/malformed|invalid/i)
+    // Not rotated: the bytes on disk are untouched, and no raw .bin fallback was written.
+    expect(fs.readFileSync(file, 'utf8')).toBe('{ this is not json')
+    expect(fs.existsSync(path.join(dir, 'node-auth-key.bin'))).toBe(false)
   })
 
   it('reject-then-retry: a rejected load clears the single-flight cache so a later healthy call succeeds', async () => {

--- a/src/core/codex-identity-proxy.test.ts
+++ b/src/core/codex-identity-proxy.test.ts
@@ -4,18 +4,24 @@ import os from 'node:os'
 import path from 'node:path'
 import { randomBytes } from 'node:crypto'
 import {
+  accountScope,
   bindCodexThreadIdentity,
   codexLauncherDir,
+  codexThreadIdentityHasLiveConflict,
   forgetCodexThreadIdentitiesForNode,
   codexThreadIdentityRoot,
+  identityCandidates,
   installCodexLauncher,
   isSafeThreadId,
   readCodexThreadIdentity,
+  readIdentityCandidate,
   resetCodexThreadIdentityAuthSecret,
   resolveCodexThreadNodeIdentity,
   setCodexThreadIdentityAuthSecret,
+  SYSTEM_ACCOUNT_SCOPE,
   writeCodexThreadIdentity
 } from './codex-identity-proxy'
+import { createHmac } from 'node:crypto'
 import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform } from './platform-fake'
 
@@ -200,5 +206,159 @@ describe('forgetting a permanently deleted node', () => {
     // A node deletion must never fail on this: no directory at all is simply nothing to forget.
     fs.rmSync(recordsRoot, { recursive: true, force: true })
     expect(() => forgetCodexThreadIdentitiesForNode('node-1', recordsRoot)).not.toThrow()
+  })
+
+  it('forgets a node across managed account scopes, not just the bare system root', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot) // system
+    writeCodexThreadIdentity('thread-2', 'node-1', '/data/e', recordsRoot, 'acct-A')
+    writeCodexThreadIdentity('thread-3', 'node-2', '/data/e', recordsRoot, 'acct-A')
+    forgetCodexThreadIdentitiesForNode('node-1', recordsRoot)
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBeUndefined()
+    expect(readCodexThreadIdentity('thread-2', recordsRoot, 'acct-A')).toBeUndefined()
+    // Another node's managed record in the same scope is left alone.
+    expect(readCodexThreadIdentity('thread-3', recordsRoot, 'acct-A')?.nodeId).toBe('node-2')
+  })
+})
+
+// ── S6 PR 2: the account-scoped ownership spine (Properties 3, 7, 8) ──────────────────────────
+//
+// A FIXED secret is used here rather than the per-test random one, so the tests can forge both a
+// legacy 3-tuple record (Constraint 12 back-compat) and a hand-signed managed record.
+const FIXED_SECRET = Buffer.alloc(32, 7)
+const b64url = (b: Buffer): string => b.toString('base64url')
+const sign4 = (threadId: string, scope: string, nodeId: string, endpoint: string): string =>
+  b64url(createHmac('sha256', FIXED_SECRET).update(`${threadId}\0${scope}\0${nodeId}\0${endpoint}`).digest())
+const sign3 = (threadId: string, nodeId: string, endpoint: string): string =>
+  b64url(createHmac('sha256', FIXED_SECRET).update(`${threadId}\0${nodeId}\0${endpoint}`).digest())
+
+describe('account-scoped ownership', () => {
+  beforeEach(() => setCodexThreadIdentityAuthSecret(FIXED_SECRET))
+
+  it('accountScope normalises the system account and refuses an id that escapes the directory', () => {
+    // Property 8: the account id is a directory scope, so `..`/`a/b`/absolute/`system` are refused.
+    expect(accountScope(undefined)).toBe(SYSTEM_ACCOUNT_SCOPE)
+    expect(accountScope('')).toBe(SYSTEM_ACCOUNT_SCOPE)
+    expect(accountScope('acct-A')).toBe('acct-A')
+    for (const bad of ['..', '../x', 'a/b', '/abs', '.', 'system', ' sp']) {
+      expect(() => accountScope(bad), bad).toThrow()
+    }
+  })
+
+  it('refuses to write a record under an account scope that could escape the mapping directory', () => {
+    // Property 8: `..` as a scope resolves to the record dir's PARENT. Refused, and nothing written.
+    expect(() => writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, '..')).toThrow()
+    expect(() => writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, 'a/b')).toThrow()
+    expect(fs.existsSync(recordsRoot)).toBe(false)
+    expect(fs.readdirSync(dir)).toEqual([])
+  })
+
+  it('round-trips a managed record under its scope directory, isolated from the system record', () => {
+    writeCodexThreadIdentity('thread-1', 'node-sys', '/data/e', recordsRoot) // system, bare root
+    writeCodexThreadIdentity('thread-1', 'node-mgd', '/data/e', recordsRoot, 'acct-A')
+    expect(fs.existsSync(path.join(recordsRoot, 'thread-1'))).toBe(true)
+    expect(fs.existsSync(path.join(recordsRoot, 'acct-A', 'thread-1'))).toBe(true)
+    expect(readCodexThreadIdentity('thread-1', recordsRoot)?.nodeId).toBe('node-sys')
+    expect(readCodexThreadIdentity('thread-1', recordsRoot, 'acct-A')?.nodeId).toBe('node-mgd')
+  })
+
+  it('fails closed for the same thread id owned by different accounts (Property 3)', () => {
+    // Two accounts each own thread-1, naming DIFFERENT nodes. An unscoped resolve (the shared tool
+    // shell that only knows the bare thread id) must return NOTHING — ambiguity is refusal.
+    writeCodexThreadIdentity('thread-1', 'node-A', '/data/e', recordsRoot, 'acct-A')
+    writeCodexThreadIdentity('thread-1', 'node-B', '/data/e', recordsRoot, 'acct-B')
+    expect(identityCandidates('thread-1', recordsRoot)).toHaveLength(2)
+    // MUTATION TARGET: return the first owner instead of requiring owners.size === 1 ⇒ this reddens.
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBeUndefined()
+    // But a resolve SCOPED to one account still answers unambiguously.
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot, 'acct-A')).toBe('node-A')
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot, 'acct-B')).toBe('node-B')
+  })
+
+  it('resolves the single owner when the same thread id names the SAME node in two scopes', () => {
+    // Same owner in two places is not a conflict — owners.size === 1.
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot)
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, 'acct-A')
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot)).toBe('node-1')
+  })
+
+  it('reports a live conflict only when two DIFFERENT live nodes own the thread', () => {
+    writeCodexThreadIdentity('thread-1', 'node-A', '/data/e', recordsRoot, 'acct-A')
+    writeCodexThreadIdentity('thread-1', 'node-B', '/data/e', recordsRoot, 'acct-B')
+    expect(codexThreadIdentityHasLiveConflict('thread-1', live(['node-A', 'node-B']), recordsRoot)).toBe(true)
+    // Only one of them live ⇒ no conflict; the other is a stale record free to be reclaimed.
+    expect(codexThreadIdentityHasLiveConflict('thread-1', live(['node-A']), recordsRoot)).toBe(false)
+  })
+
+  it('rejects a managed record whose owner was edited without the signing key (Property 7)', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, 'acct-A')
+    const file = path.join(recordsRoot, 'acct-A', 'thread-1')
+    fs.writeFileSync(file, fs.readFileSync(file, 'utf8').replace('node-1', 'node-evil'))
+    // MUTATION TARGET: skip recordSignatureValid ⇒ this returns node-evil and reddens.
+    expect(readCodexThreadIdentity('thread-1', recordsRoot, 'acct-A')).toBeUndefined()
+  })
+
+  it('rejects a record whose accountId line disagrees with its directory scope (Property 7)', () => {
+    // A perfectly valid record for acct-A, physically moved into acct-B's directory. Its account
+    // line still says acct-A, so it must not be honoured as acct-B's — nor re-verify under acct-B.
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, 'acct-A')
+    fs.mkdirSync(path.join(recordsRoot, 'acct-B'), { recursive: true })
+    fs.copyFileSync(
+      path.join(recordsRoot, 'acct-A', 'thread-1'),
+      path.join(recordsRoot, 'acct-B', 'thread-1')
+    )
+    expect(readCodexThreadIdentity('thread-1', recordsRoot, 'acct-A')?.nodeId).toBe('node-1')
+    // MUTATION TARGET: drop the line-vs-directory agreement check ⇒ acct-B honours it and reddens.
+    expect(readCodexThreadIdentity('thread-1', recordsRoot, 'acct-B')).toBeUndefined()
+  })
+
+  it('hand-forged managed record with a correct 4-tuple signature is honoured', () => {
+    // Proves the 4-tuple preimage is exactly (threadId ␀ scope ␀ nodeId ␀ endpoint) — the mutation
+    // check for the ambiguity/HMAC tests rests on being able to mint a genuinely valid record.
+    fs.mkdirSync(path.join(recordsRoot, 'acct-A'), { recursive: true })
+    fs.writeFileSync(
+      path.join(recordsRoot, 'acct-A', 'thread-9'),
+      `accountId=acct-A\nnodeId=node-9\nendpoint=/data/e\nsignature=${sign4('thread-9', 'acct-A', 'node-9', '/data/e')}\n`
+    )
+    expect(readIdentityCandidate('thread-9', 'acct-A', recordsRoot)?.nodeId).toBe('node-9')
+    // The same bytes with a scope-mismatched signature (signed as system) do NOT verify at acct-A.
+    fs.writeFileSync(
+      path.join(recordsRoot, 'acct-A', 'thread-9'),
+      `accountId=acct-A\nnodeId=node-9\nendpoint=/data/e\nsignature=${sign4('thread-9', 'system', 'node-9', '/data/e')}\n`
+    )
+    expect(readIdentityCandidate('thread-9', 'acct-A', recordsRoot)).toBeUndefined()
+  })
+
+  it('keeps resolving a legacy 3-tuple system record with no accountId line (Constraint 12)', () => {
+    // A record written by pre-S6 S4 code: bare root, no accountId line, 3-tuple signature. A
+    // system-only user must keep resolving after the account scoping lands.
+    fs.mkdirSync(recordsRoot, { recursive: true })
+    fs.writeFileSync(
+      path.join(recordsRoot, 'legacy-thread'),
+      `nodeId=node-legacy\nendpoint=/data/e\nsignature=${sign3('legacy-thread', 'node-legacy', '/data/e')}\n`
+    )
+    expect(readCodexThreadIdentity('legacy-thread', recordsRoot)?.nodeId).toBe('node-legacy')
+    expect(resolveCodexThreadNodeIdentity('legacy-thread', recordsRoot)).toBe('node-legacy')
+  })
+
+  it('never accepts the legacy 3-tuple fallback for a managed scope', () => {
+    // The back-compat door is system-only: a 3-tuple signature under a managed subdir is refused,
+    // so the account dimension cannot be stripped by omitting the account line in acct-A's dir.
+    fs.mkdirSync(path.join(recordsRoot, 'acct-A'), { recursive: true })
+    fs.writeFileSync(
+      path.join(recordsRoot, 'acct-A', 'thread-1'),
+      `nodeId=node-1\nendpoint=/data/e\nsignature=${sign3('thread-1', 'node-1', '/data/e')}\n`
+    )
+    expect(readIdentityCandidate('thread-1', 'acct-A', recordsRoot)).toBeUndefined()
+  })
+
+  it('bind refuses to steal a managed thread from a live node in the SAME scope', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, 'acct-A')
+    expect(() =>
+      bindCodexThreadIdentity('thread-1', 'node-2', '/data/e', live(['node-1']), recordsRoot, 'acct-A')
+    ).toThrow()
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot, 'acct-A')).toBe('node-1')
+    // A different account's identically-named thread is a different owner, freely bindable.
+    bindCodexThreadIdentity('thread-1', 'node-2', '/data/e', live(['node-1']), recordsRoot, 'acct-B')
+    expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot, 'acct-B')).toBe('node-2')
   })
 })

--- a/src/core/codex-identity-proxy.ts
+++ b/src/core/codex-identity-proxy.ts
@@ -18,9 +18,15 @@
  * (`src/core/agents/node-auth-secret.ts` — sealed via safeStorage on the desktop, raw 0600 bytes on
  * the Server Edition). Unsigned/mis-signed records are ignored, not repaired.
  *
- * ACCOUNT SCOPING is deliberately absent here: managed Codex accounts are a later slice. The
- * storage shape is one file per thread id; scoping adds a directory level above it without
- * changing anything this file promises.
+ * ACCOUNT SCOPING (S6): managed Codex accounts add a directory level above the thread id. A
+ * SYSTEM record still lives at the bare root (`<root>/<threadId>`), so a machine with no managed
+ * accounts keeps the exact S4 layout and its legacy records keep resolving (Constraint 12). A
+ * MANAGED record lives under `<root>/<accountId>/<threadId>`. The HMAC now binds the full 4-tuple
+ * (threadId, accountScope, nodeId, hookEndpoint) — an empty account id is normalised to the scope
+ * string `system`, and a record whose `accountId=` line disagrees with the directory it sits in is
+ * rejected, so an account can never be edited to speak for another's threads. Records written
+ * before this slice carry no `accountId=` line and are verified with the original 3-tuple preimage
+ * at the system scope only — the one back-compat door, and it is a system-scope door.
  */
 import {
   chmodSync,
@@ -34,6 +40,35 @@ import {
 import path from 'path'
 import { createHmac, timingSafeEqual } from 'crypto'
 import { platform } from './platform'
+import { ACCOUNT_ID_RE, isSafeAccountId } from '../shared/codex-account'
+
+/**
+ * The scope string for the SYSTEM account (`~/.codex`, no managed id). Empty/undefined account ids
+ * normalise to this both in the HMAC preimage and — for the directory — to the bare record root.
+ */
+export const SYSTEM_ACCOUNT_SCOPE = 'system'
+
+/**
+ * The one shape of a safe managed account id, re-exported from the shared seam so there is a single
+ * definition of the alphabet the path builders and this proxy both trust. Must start alphanumeric,
+ * which blocks `.`/`..`/leading-separator ids at the door before an id becomes a directory scope.
+ */
+export const SAFE_ACCOUNT_ID = ACCOUNT_ID_RE
+
+/**
+ * The scope string for an account id: `system` for empty/undefined, else the validated id itself.
+ * THROWS on an id that could escape the mapping directory (`..`, `a/b`, `/abs`, whitespace) — the
+ * supply-chain guard, since account ids arrive from hand-editable `settings.json` / `project.json`.
+ * A literal id of `system` is refused so the reserved bare-root scope can never be impersonated by
+ * a managed subdirectory.
+ */
+export function accountScope(accountId?: string): string {
+  if (!accountId) return SYSTEM_ACCOUNT_SCOPE
+  if (accountId === SYSTEM_ACCOUNT_SCOPE || !isSafeAccountId(accountId)) {
+    throw new Error('Invalid NodeTerm Codex account scope')
+  }
+  return accountId
+}
 
 /**
  * How long the SERVER gives itself to mint a thread (`startCodexThreadAt`'s default).
@@ -103,105 +138,270 @@ export function codexThreadIdentityRoot(): string {
   return path.join(platform().userDataDir, 'codex-thread-nodes')
 }
 
-function identitySignature(threadId: string, nodeId: string, hookEndpoint: string): string {
+/**
+ * The current 4-tuple preimage: HMAC-SHA256(threadId ␀ accountScope ␀ nodeId ␀ hookEndpoint). The
+ * account scope binds the record to ONE account; without it a record for account A could be moved,
+ * byte-for-byte, into account B's directory and still verify.
+ */
+function identitySignature(
+  threadId: string,
+  scope: string,
+  nodeId: string,
+  hookEndpoint: string
+): string {
+  if (!identityAuthSecret) throw new Error('NodeTerm Codex identity authentication is unavailable')
+  return createHmac('sha256', identityAuthSecret)
+    .update(`${threadId}\0${scope}\0${nodeId}\0${hookEndpoint}`)
+    .digest('base64url')
+}
+
+/**
+ * The pre-S6 3-tuple preimage (no account dimension). Accepted ONLY for a system-scope record that
+ * carries no `accountId=` line — i.e. one written before this slice. Every record this slice writes
+ * (system included) carries the account line and the 4-tuple, so the legacy door is system-only and
+ * closes itself the first time a machine rewrites the record.
+ */
+function legacyIdentitySignature(threadId: string, nodeId: string, hookEndpoint: string): string {
   if (!identityAuthSecret) throw new Error('NodeTerm Codex identity authentication is unavailable')
   return createHmac('sha256', identityAuthSecret)
     .update(`${threadId}\0${nodeId}\0${hookEndpoint}`)
     .digest('base64url')
 }
 
-function signatureMatches(threadId: string, identity: CodexThreadIdentity): boolean {
-  if (!identity.signature || !identityAuthSecret) return false
+function signatureEquals(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented)
+  const b = Buffer.from(expected)
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+/**
+ * Verify a parsed record sitting in the `dirScope` directory (Property 7). Two checks, in order:
+ *  1. the record's own `accountId=` line must AGREE with the directory it was found in, and
+ *  2. the HMAC must match — the 4-tuple for any record with an account line, with a system-only
+ *     3-tuple fallback for a legacy record that has no line at all.
+ *
+ * Check (1) (line-vs-directory) is defence in depth, kept legible rather than removed. What carries
+ * Property 7 is the SCOPE-bound HMAC in check (2): a record signed for `acct-A` verifies only with
+ * the preimage scope `acct-A`, so re-filing it under `acct-B` fails the MAC regardless of the line
+ * check. The legacy 3-tuple fallback is the ONE back-compat door and is restricted to the SYSTEM
+ * scope, so a scope-less signature can never be honoured under a managed account. (The mutations
+ * that redden these tests are the HMAC one and the `scope === SYSTEM_ACCOUNT_SCOPE` fallback guard;
+ * check (1) is redundant with the scope-bound HMAC and is documented as such.)
+ */
+function recordSignatureValid(threadId: string, dirScope: string, record: ParsedRecord): boolean {
+  if (!record.signature || !identityAuthSecret) return false
+  const scope = dirScope || SYSTEM_ACCOUNT_SCOPE
+  if (record.accountLinePresent) {
+    const lineScope = record.accountId || SYSTEM_ACCOUNT_SCOPE
+    if (lineScope !== scope) return false
+  }
   let expected = ''
   try {
-    expected = identitySignature(threadId, identity.nodeId, identity.hookEndpoint)
+    expected = identitySignature(threadId, scope, record.nodeId, record.hookEndpoint)
   } catch {
     return false
   }
-  const actual = Buffer.from(identity.signature)
-  const wanted = Buffer.from(expected)
-  return actual.length === wanted.length && timingSafeEqual(actual, wanted)
+  if (signatureEquals(record.signature, expected)) return true
+  if (!record.accountLinePresent && scope === SYSTEM_ACCOUNT_SCOPE) {
+    try {
+      return signatureEquals(
+        record.signature,
+        legacyIdentitySignature(threadId, record.nodeId, record.hookEndpoint)
+      )
+    } catch {
+      return false
+    }
+  }
+  return false
 }
 
 export interface CodexThreadIdentity {
+  /** '' for the system account; a managed account id otherwise. */
+  accountId: string
   nodeId: string
   hookEndpoint: string
   signature: string
+}
+
+interface ParsedRecord extends CodexThreadIdentity {
+  accountLinePresent: boolean
 }
 
 export function validCodexIdentity(nodeId: string, hookEndpoint: string): boolean {
   return SAFE_NODE_ID.test(nodeId) && SAFE_ENDPOINT.test(hookEndpoint)
 }
 
-function identityFile(threadId: string, root = codexThreadIdentityRoot()): string {
-  if (!isSafeThreadId(threadId)) throw new Error('Invalid NodeTerm Codex thread identity')
-  return path.join(root, threadId)
+/** The absolute path of a record for a thread under a scope (`system` ⇒ bare root). */
+function recordFilePath(root: string, scope: string, threadId: string): string {
+  return scope && scope !== SYSTEM_ACCOUNT_SCOPE
+    ? path.join(root, scope, threadId)
+    : path.join(root, threadId)
 }
 
-function parseCodexThreadIdentity(raw: string): CodexThreadIdentity {
+function identityFile(threadId: string, scope: string, root = codexThreadIdentityRoot()): string {
+  if (!isSafeThreadId(threadId)) throw new Error('Invalid NodeTerm Codex thread identity')
+  return recordFilePath(root, scope, threadId)
+}
+
+function parseCodexThreadIdentity(raw: string): ParsedRecord {
   const values: Record<string, string> = {}
   for (const line of raw.split('\n')) {
     const separator = line.indexOf('=')
     if (separator < 1) continue
-    values[line.slice(0, separator)] = line.slice(separator + 1)
+    const key = line.slice(0, separator)
+    // First occurrence wins, matching the `head -n 1` the sh prelude uses: a second `accountId=`
+    // line cannot be smuggled in to disagree with the first.
+    if (!(key in values)) values[key] = line.slice(separator + 1)
   }
   return {
+    accountId: values.accountId ?? '',
     nodeId: values.nodeId ?? '',
     hookEndpoint: values.endpoint ?? '',
-    signature: values.signature ?? ''
+    signature: values.signature ?? '',
+    accountLinePresent: 'accountId' in values
   }
 }
 
-/** The record for a thread, or undefined when it is absent, malformed or badly signed. */
-export function readCodexThreadIdentity(
+/**
+ * Read and verify the record for a thread AT A SPECIFIC SCOPE (`system` = bare root). Returns
+ * undefined when it is absent, malformed, badly signed, or its account line disagrees with the
+ * directory. The scope itself is validated so a hostile scan entry can never escape the root.
+ */
+export function readIdentityCandidate(
   threadId: string,
+  scope: string,
   root = codexThreadIdentityRoot()
 ): CodexThreadIdentity | undefined {
   if (!isSafeThreadId(threadId)) return undefined
+  const norm = scope || SYSTEM_ACCOUNT_SCOPE
+  if (norm !== SYSTEM_ACCOUNT_SCOPE && !isSafeAccountId(norm)) return undefined
   let raw: string
   try {
-    raw = readFileSync(path.join(root, threadId), 'utf8')
+    raw = readFileSync(recordFilePath(root, norm, threadId), 'utf8')
   } catch {
     return undefined
   }
-  const identity = parseCodexThreadIdentity(raw)
-  if (!validCodexIdentity(identity.nodeId, identity.hookEndpoint)) return undefined
-  if (!signatureMatches(threadId, identity)) return undefined
-  return identity
+  const record = parseCodexThreadIdentity(raw)
+  if (!validCodexIdentity(record.nodeId, record.hookEndpoint)) return undefined
+  if (!recordSignatureValid(threadId, norm, record)) return undefined
+  return {
+    accountId: record.accountId,
+    nodeId: record.nodeId,
+    hookEndpoint: record.hookEndpoint,
+    signature: record.signature
+  }
+}
+
+/**
+ * Every verified record for a thread, across every scope present on disk: the bare-root system
+ * record plus one per managed-account subdirectory. Unsafe scope names are skipped, never read.
+ */
+export function identityCandidates(
+  threadId: string,
+  root = codexThreadIdentityRoot()
+): Array<{ scope: string; identity: CodexThreadIdentity }> {
+  const out: Array<{ scope: string; identity: CodexThreadIdentity }> = []
+  const system = readIdentityCandidate(threadId, SYSTEM_ACCOUNT_SCOPE, root)
+  if (system) out.push({ scope: SYSTEM_ACCOUNT_SCOPE, identity: system })
+  let entries: Array<{ name: string; isDirectory(): boolean }>
+  try {
+    entries = readdirSync(root, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    if (entry.name === SYSTEM_ACCOUNT_SCOPE || !isSafeAccountId(entry.name)) continue
+    const identity = readIdentityCandidate(threadId, entry.name, root)
+    if (identity) out.push({ scope: entry.name, identity })
+  }
+  return out
+}
+
+/** The record for a thread at a scope (`accountId` empty/undefined ⇒ system), or undefined. */
+export function readCodexThreadIdentity(
+  threadId: string,
+  root = codexThreadIdentityRoot(),
+  accountId?: string
+): CodexThreadIdentity | undefined {
+  let scope: string
+  try {
+    scope = accountScope(accountId)
+  } catch {
+    return undefined
+  }
+  return readIdentityCandidate(threadId, scope, root)
 }
 
 /**
  * Recover a thread's owning node after the app restarts. tmux sessions outlive the app, so a
  * running Codex client can outlive every in-memory map we hold; the file is the only thing that
  * still knows which node it belongs to.
+ *
+ * With `accountId` given the answer is that one scope's record. WITHOUT it — the shared-app-server
+ * tool shell that only knows a bare thread id — every scope is scanned and an owner is returned
+ * ONLY when it is unambiguous (`owners.size === 1`). The same thread id owned by two accounts is
+ * NOT resolved: ambiguous ownership fails closed (Property 3), the same posture as an unproven pane
+ * claim in `pane-ownership.ts`.
  */
 export function resolveCodexThreadNodeIdentity(
   threadId: string,
-  root = codexThreadIdentityRoot()
+  root = codexThreadIdentityRoot(),
+  accountId?: string
 ): string | undefined {
-  return readCodexThreadIdentity(threadId, root)?.nodeId
+  if (accountId !== undefined) {
+    return readCodexThreadIdentity(threadId, root, accountId)?.nodeId
+  }
+  const candidates = identityCandidates(threadId, root)
+  const owners = new Set(candidates.map((c) => c.identity.nodeId))
+  return owners.size === 1 ? candidates[0].identity.nodeId : undefined
 }
 
-/** Write (or replace) the record for `threadId`, atomically. */
+/**
+ * Whether a thread id is owned by MORE THAN ONE currently-live node across scopes — a genuine
+ * ownership conflict the caller must refuse rather than pick a winner for. A single live owner (or
+ * none) is not a conflict. Fail-closed twin of the single-live-owner rule in `bindCodexThreadIdentity`.
+ */
+export function codexThreadIdentityHasLiveConflict(
+  threadId: string,
+  isNodeLive: (nodeId: string) => boolean,
+  root = codexThreadIdentityRoot()
+): boolean {
+  const liveOwners = new Set(
+    identityCandidates(threadId, root)
+      .map((c) => c.identity.nodeId)
+      .filter(isNodeLive)
+  )
+  return liveOwners.size > 1
+}
+
+/** Write (or replace) the record for `threadId` under its account scope, atomically. */
 export function writeCodexThreadIdentity(
   threadId: string,
   nodeId: string,
   hookEndpoint: string,
-  root = codexThreadIdentityRoot()
+  root = codexThreadIdentityRoot(),
+  accountId?: string
 ): void {
   if (!isSafeThreadId(threadId) || !validCodexIdentity(nodeId, hookEndpoint)) {
     throw new Error('Invalid NodeTerm Codex thread identity')
   }
-  const signature = identitySignature(threadId, nodeId, hookEndpoint)
-  const file = identityFile(threadId, root)
-  const tmp = path.join(root, `.${threadId}.${process.pid}.${Date.now()}`)
-  mkdirSync(root, { recursive: true, mode: 0o700 })
+  const scope = accountScope(accountId) // throws on an id that could escape the mapping directory
+  const signature = identitySignature(threadId, scope, nodeId, hookEndpoint)
+  const file = identityFile(threadId, scope, root)
+  const dir = path.dirname(file)
+  const tmp = path.join(dir, `.${threadId}.${process.pid}.${Date.now()}`)
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
   let renamed = false
   try {
-    writeFileSync(tmp, `nodeId=${nodeId}\nendpoint=${hookEndpoint}\nsignature=${signature}\n`, {
-      encoding: 'utf8',
-      mode: 0o600
-    })
+    writeFileSync(
+      tmp,
+      `accountId=${accountId ?? ''}\nnodeId=${nodeId}\nendpoint=${hookEndpoint}\nsignature=${signature}\n`,
+      {
+        encoding: 'utf8',
+        mode: 0o600
+      }
+    )
     renameSync(tmp, file)
     renamed = true
   } finally {
@@ -226,17 +426,19 @@ export function bindCodexThreadIdentity(
   nodeId: string,
   hookEndpoint: string,
   isNodeLive: (nodeId: string) => boolean,
-  root = codexThreadIdentityRoot()
+  root = codexThreadIdentityRoot(),
+  accountId?: string
 ): void {
   if (!isSafeThreadId(threadId) || !validCodexIdentity(nodeId, hookEndpoint)) {
     throw new Error('Invalid NodeTerm Codex thread identity')
   }
-  const existing = readCodexThreadIdentity(threadId, root)
+  accountScope(accountId) // reject an escaping account id before any read or write
+  const existing = readCodexThreadIdentity(threadId, root, accountId)
   if (existing && existing.nodeId !== nodeId && isNodeLive(existing.nodeId)) {
     throw new Error('Codex thread is already bound to another live node')
   }
   if (existing && existing.nodeId === nodeId && existing.hookEndpoint === hookEndpoint) return
-  writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, root)
+  writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, root, accountId)
 }
 
 /**
@@ -255,21 +457,38 @@ export function forgetCodexThreadIdentitiesForNode(
   root = codexThreadIdentityRoot()
 ): void {
   if (!SAFE_NODE_ID.test(nodeId)) return
-  let entries: string[]
+  const forgetInScope = (scope: string, dir: string): void => {
+    let entries: Array<{ name: string; isFile(): boolean }>
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.isFile()) continue // a managed-scope SUBDIRECTORY at the root is not a thread id
+      const threadId = entry.name
+      if (!isSafeThreadId(threadId)) continue
+      // Reads through the signature check, so a record we do not trust is also one we do not delete.
+      if (readIdentityCandidate(threadId, scope, root)?.nodeId !== nodeId) continue
+      try {
+        unlinkSync(path.join(dir, threadId))
+      } catch {
+        /* nothing to forget */
+      }
+    }
+  }
+  // System records live at the bare root; managed records one directory down, per account scope.
+  forgetInScope(SYSTEM_ACCOUNT_SCOPE, root)
+  let scopes: Array<{ name: string; isDirectory(): boolean }>
   try {
-    entries = readdirSync(root)
+    scopes = readdirSync(root, { withFileTypes: true })
   } catch {
     return
   }
-  for (const threadId of entries) {
-    if (!isSafeThreadId(threadId)) continue
-    // Reads through the signature check, so a record we do not trust is also one we do not delete.
-    if (readCodexThreadIdentity(threadId, root)?.nodeId !== nodeId) continue
-    try {
-      unlinkSync(path.join(root, threadId))
-    } catch {
-      /* nothing to forget */
-    }
+  for (const entry of scopes) {
+    if (!entry.isDirectory()) continue
+    if (entry.name === SYSTEM_ACCOUNT_SCOPE || !isSafeAccountId(entry.name)) continue
+    forgetInScope(entry.name, path.join(root, entry.name))
   }
 }
 
@@ -364,6 +583,15 @@ nt_preflight() {
   if [ "\${1-}" = resume ]; then
     case "\${2-}" in ''|*[!A-Za-z0-9._-]*) nt_fail thread-id-unavailable; return ;; esac
   fi
+  # The account scope (S6). Empty ⇒ the system account. A non-empty id is validated to the SAME
+  # shape the record store's accountScope() enforces — must START alphanumeric (so '.'/'..'/leading
+  # separators can never become a directory scope) — BEFORE it rides a POST body onward. A bad id
+  # falls back to plain codex rather than binding a thread under an attacker-shaped scope; the id
+  # travels in the request body, never on argv (Constraint 6).
+  case "\${NODETERM_CODEX_ACCOUNT_ID-}" in
+    '') ;;
+    [!A-Za-z0-9]*|*[!A-Za-z0-9._-]*) nt_fail codex-account-invalid; return ;;
+  esac
   # The authoritative check runs FIRST and unchanged; the stat below only decides WHICH reason to
   # report. Ordering it the other way would let a codex that no longer needs the standalone runtime
   # fall back on a stat we had no business trusting more than the command itself.
@@ -422,6 +650,7 @@ if [ "\${1-}" = resume ]; then
   # Claim the caller-supplied thread for THIS node before Codex opens it. A refusal means another
   # live node owns it; two clients on one thread is worse than one plain session, so we fall back.
   if nt_post 20 --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "threadId=\${2-}" \\
+      --data-urlencode "accountId=\${NODETERM_CODEX_ACCOUNT_ID-}" \\
       "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/bind" >/dev/null; then
     exec codex --remote unix:// "$@"
   fi
@@ -430,6 +659,7 @@ if [ "\${1-}" = resume ]; then
 fi
 
 nt_thread=$(nt_post ${CODEX_THREAD_START_CLIENT_MAX_S} --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "cwd=$PWD" \\
+  --data-urlencode "accountId=\${NODETERM_CODEX_ACCOUNT_ID-}" \\
   "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/start") || nt_thread=''
 nt_thread=$(printf %s "$nt_thread" | tr -d '\\r\\n')
 case "$nt_thread" in

--- a/src/core/codex-launcher-sh.test.ts
+++ b/src/core/codex-launcher-sh.test.ts
@@ -8,6 +8,7 @@
 // remote-claude-usage.test.ts.
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { execFile } from 'node:child_process'
+import { request as httpRequest } from 'node:http'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -35,8 +36,8 @@ let dir = ''
 let launcher = ''
 let binDir = ''
 let argvLog = ''
-let started: Array<{ nodeId: string; cwd: string }> = []
-let bound: Array<{ nodeId: string; threadId: string }> = []
+let started: Array<{ nodeId: string; cwd: string; accountId?: string }> = []
+let bound: Array<{ nodeId: string; threadId: string; accountId?: string }> = []
 let fallbacks: Array<{ nodeId: string; reason?: string }> = []
 let startAnswer: (() => string) | null = null
 let startDelayMs = 0
@@ -64,14 +65,14 @@ beforeAll(async () => {
   fs.writeFileSync(launcher, buildCodexLauncherScript('true'), { mode: 0o755 })
   await hookServer.start()
   hookServer.setNodeAuthSecret(SECRET)
-  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd }) => {
-    started.push({ nodeId, cwd })
+  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd, accountId }) => {
+    started.push({ nodeId, cwd, accountId })
     if (startDelayMs) await new Promise((r) => setTimeout(r, startDelayMs))
     if (!startAnswer) throw new Error('start refused')
     return startAnswer()
   })
-  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId }) => {
-    bound.push({ nodeId, threadId })
+  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, accountId }) => {
+    bound.push({ nodeId, threadId, accountId })
     if (!bindAnswer) throw new Error('bind refused')
     bindAnswer()
   })
@@ -138,6 +139,40 @@ function codexArgv(): string[] {
   return fs.readFileSync(argvLog, 'utf8').split('\n').slice(0, -1)
 }
 
+/**
+ * POST a codex-thread request DIRECTLY, bypassing the launcher's own account-id validation, to
+ * exercise the SERVER's gate. Both bearer headers are presented so the request is authenticated and
+ * only the account-id check can reject it.
+ */
+function postCodexThread(
+  verb: 'start' | 'bind',
+  fields: Record<string, string>
+): Promise<number> {
+  const body = new URLSearchParams(fields).toString()
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        host: '127.0.0.1',
+        port: hookServer.getPort(),
+        method: 'POST',
+        path: `/codex-thread/${verb}`,
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'content-length': Buffer.byteLength(body),
+          'x-nodeterm-hook-token': hookServer.getToken(),
+          'x-nodeterm-node-token': nodeAuthToken(SECRET, 'node-1')
+        }
+      },
+      (res) => {
+        res.resume()
+        res.on('end', () => resolve(res.statusCode ?? 0))
+      }
+    )
+    req.on('error', reject)
+    req.end(body)
+  })
+}
+
 describe('generated Codex launcher', () => {
   it('is valid POSIX sh', async () => {
     await expect(run('/bin/sh', ['-n', launcher])).resolves.toBeTruthy()
@@ -162,6 +197,53 @@ describe('generated Codex launcher', () => {
     expect(bound).toEqual([{ nodeId: 'node-1', threadId: 'thread-xyz' }])
     expect(started).toEqual([])
     expect(codexArgv()).toEqual(['--remote unix:// resume thread-xyz'])
+  })
+
+  // S6: the account scope travels in the POST body, never on argv (Constraint 6), so the record is
+  // filed under the right account. An empty id (the system account) reaches the handler as undefined.
+  it('threads the managed account id through start (in the body, not on argv)', async () => {
+    await callLauncher([], { NODETERM_CODEX_ACCOUNT_ID: 'acct-A' })
+    expect(started).toEqual([{ nodeId: 'node-1', cwd: fs.realpathSync(dir), accountId: 'acct-A' }])
+    // The account id is NOT on the codex command line.
+    expect(codexArgv().join(' ')).not.toContain('acct-A')
+  })
+
+  it('threads the managed account id through a resume bind too', async () => {
+    await callLauncher(['resume', 'thread-xyz'], { NODETERM_CODEX_ACCOUNT_ID: 'acct-A' })
+    expect(bound).toEqual([{ nodeId: 'node-1', threadId: 'thread-xyz', accountId: 'acct-A' }])
+    expect(codexArgv().join(' ')).not.toContain('acct-A')
+  })
+
+  it('an account id that could escape the mapping directory → plain codex, never an unbound bind', async () => {
+    await callLauncher(['do', 'work'], { NODETERM_CODEX_ACCOUNT_ID: '../evil' })
+    // No thread was started or bound under the hostile scope; codex ran plain with the args intact.
+    expect(started).toEqual([])
+    expect(bound).toEqual([])
+    expect(codexArgv()).toEqual(['do work'])
+    expect(fallbacks.map((f) => f.reason)).toContain('codex-account-invalid')
+  })
+
+  // The SERVER's own gate, independent of the launcher: a hostile account id posted directly is
+  // refused at 400 BEFORE the start handler runs — so `startCodexThread` never creates a thread the
+  // record write would then orphan. (Mutation: drop the isSafeAccountId gate ⇒ 200 + a started row.)
+  it('the server refuses a hostile account id at 400 before starting a thread', async () => {
+    const status = await postCodexThread('start', {
+      nodeId: 'node-1',
+      cwd: fs.realpathSync(dir),
+      accountId: '../evil'
+    })
+    expect(status).toBe(400)
+    expect(started).toEqual([]) // the handler never ran ⇒ no orphaned thread
+  })
+
+  it('the server accepts a safe managed account id on a direct post', async () => {
+    const status = await postCodexThread('start', {
+      nodeId: 'node-1',
+      cwd: fs.realpathSync(dir),
+      accountId: 'acct-A'
+    })
+    expect(status).toBe(200)
+    expect(started).toEqual([{ nodeId: 'node-1', cwd: fs.realpathSync(dir), accountId: 'acct-A' }])
   })
 })
 

--- a/src/core/codex-thread-identity-sh.test.ts
+++ b/src/core/codex-thread-identity-sh.test.ts
@@ -2,7 +2,7 @@
 // quoting slip here does not break "codex identity recovery" — it breaks every agent's hooks on
 // every machine. It is also the one place where a data file's contents become environment
 // variables, which is why the negative cases below matter as much as the positive one.
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
 import { execFile } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -34,6 +34,18 @@ afterAll(() => fs.rmSync(dir, { recursive: true, force: true }))
 
 function record(threadId: string, body: string): void {
   fs.writeFileSync(path.join(root, threadId), body)
+}
+
+/** Write a managed-scope record under `<root>/<accountId>/<threadId>`. */
+function scopedRecord(accountId: string, threadId: string, body: string): void {
+  fs.mkdirSync(path.join(root, accountId), { recursive: true })
+  fs.writeFileSync(path.join(root, accountId, threadId), body)
+}
+
+/** A well-formed record body for a scope (empty account = system, no accountId line = legacy). */
+function body(nodeId: string, accountId?: string): string {
+  const acct = accountId === undefined ? '' : `accountId=${accountId}\n`
+  return `${acct}nodeId=${nodeId}\nendpoint=${dir}/hook-endpoint.env\nsignature=x\n`
 }
 
 async function resolve(env: Record<string, string>): Promise<string> {
@@ -78,5 +90,73 @@ describe('codex thread identity prelude', () => {
     expect(await resolve({ CODEX_THREAD_ID: 'thread-bad-ep' })).toBe('||')
     record('thread-bad-ep2', 'nodeId=node-7\nendpoint=/etc/$(id)\n')
     expect(await resolve({ CODEX_THREAD_ID: 'thread-bad-ep2' })).toBe('||')
+  })
+})
+
+// ── S6 PR 2: the account-scoped sh resolver, proven under real /bin/sh (Property 8, Constraint 8) ──
+describe('codex thread identity prelude — account scoping', () => {
+  // The subdir layout differs per test; clear the record store before each so scopes never bleed.
+  beforeEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+    fs.mkdirSync(root, { recursive: true })
+  })
+
+  it('binds the one matching managed scope when the daemon carries that account id', async () => {
+    scopedRecord('acct-A', 'thr-1', body('node-A', 'acct-A'))
+    expect(
+      await resolve({ CODEX_THREAD_ID: 'thr-1', NODETERM_CODEX_ACCOUNT_ID: 'acct-A' })
+    ).toBe(`node-A|${dir}/hook-endpoint.env|1`)
+  })
+
+  it('binds the single candidate across scopes when no account id is present (system record)', async () => {
+    record('thr-1', body('node-sys')) // bare-root legacy/system record, no account line
+    expect(await resolve({ CODEX_THREAD_ID: 'thr-1' })).toBe(`node-sys|${dir}/hook-endpoint.env|1`)
+  })
+
+  it('binds the single candidate across scopes when no account id is present (one managed record)', async () => {
+    scopedRecord('acct-A', 'thr-1', body('node-A', 'acct-A'))
+    expect(await resolve({ CODEX_THREAD_ID: 'thr-1' })).toBe(`node-A|${dir}/hook-endpoint.env|1`)
+  })
+
+  it('fails closed: two scopes hold the same thread id and no account env clears the map', async () => {
+    scopedRecord('acct-A', 'thr-1', body('node-A', 'acct-A'))
+    scopedRecord('acct-B', 'thr-1', body('node-B', 'acct-B'))
+    // MUTATION TARGET: bind on the first match (drop `-eq 1`) ⇒ this exports node-A and reddens.
+    expect(await resolve({ CODEX_THREAD_ID: 'thr-1' })).toBe('||')
+  })
+
+  it('fails closed: a system record and a managed record collide with no account env', async () => {
+    record('thr-1', body('node-sys'))
+    scopedRecord('acct-A', 'thr-1', body('node-A', 'acct-A'))
+    expect(await resolve({ CODEX_THREAD_ID: 'thr-1' })).toBe('||')
+  })
+
+  it('clears the map when the record account line disagrees with its directory scope', async () => {
+    // A record physically under acct-B but whose own line still claims acct-A: not honoured as B.
+    scopedRecord('acct-B', 'thr-1', body('node-A', 'acct-A'))
+    expect(
+      await resolve({ CODEX_THREAD_ID: 'thr-1', NODETERM_CODEX_ACCOUNT_ID: 'acct-B' })
+    ).toBe('||')
+    // And the unscoped scan skips it too (the scope check fails), so nothing binds.
+    expect(await resolve({ CODEX_THREAD_ID: 'thr-1' })).toBe('||')
+  })
+
+  it('reads only the named account, not a same-thread record in another scope', async () => {
+    scopedRecord('acct-A', 'thr-1', body('node-A', 'acct-A'))
+    scopedRecord('acct-B', 'thr-1', body('node-B', 'acct-B'))
+    // With the account id pinned, the scan never touches the other account — no ambiguity, binds B.
+    expect(
+      await resolve({ CODEX_THREAD_ID: 'thr-1', NODETERM_CODEX_ACCOUNT_ID: 'acct-B' })
+    ).toBe(`node-B|${dir}/hook-endpoint.env|1`)
+  })
+
+  it('resolves nothing for a daemon account id that could escape the mapping directory', async () => {
+    scopedRecord('acct-A', 'thr-1', body('node-A', 'acct-A'))
+    expect(
+      await resolve({ CODEX_THREAD_ID: 'thr-1', NODETERM_CODEX_ACCOUNT_ID: '../acct-A' })
+    ).toBe('||')
+    expect(
+      await resolve({ CODEX_THREAD_ID: 'thr-1', NODETERM_CODEX_ACCOUNT_ID: 'system' })
+    ).toBe('||')
   })
 })

--- a/src/core/codex-thread-identity-sh.ts
+++ b/src/core/codex-thread-identity-sh.ts
@@ -12,10 +12,20 @@
  * `codex-identity-proxy.ts`; this prelude cannot verify that signature (no key in an agent's
  * shell), which is why the charset re-validation below is not redundant.
  *
- * Inert for every other agent: without `CODEX_THREAD_ID` the whole block is skipped, and the
- * generated script is otherwise byte-identical to what it was. That is intentional — the prelude
- * is prepended once in `buildManagedScript`, so it lands in claude/gemini/codex/grok/opencode
- * scripts alike rather than in a codex-only fork of the builder.
+ * ACCOUNT SCOPING (S6): a SYSTEM record lives at the bare root (`<root>/<threadId>`) and a MANAGED
+ * record under `<root>/<accountId>/<threadId>`. This prelude reads `NODETERM_CODEX_ACCOUNT_ID` from
+ * the daemon's env to pick the scope:
+ *   - a known, safe account id ⇒ read ONLY that account's record, and require the record's
+ *     `accountId=` line to agree with the daemon scope;
+ *   - an EMPTY account id (the classic shared tool shell that knows only a bare thread id) ⇒ scan
+ *     EVERY scope (bare-root system + each managed subdir) and bind ONLY when exactly one candidate
+ *     matches (`nt_codex_matches -eq 1`). Two accounts holding the same thread id ⇒ ambiguous ⇒
+ *     change nothing (Property 3 / Constraint 8, the same fail-closed posture as the TypeScript
+ *     `resolveCodexThreadNodeIdentity`).
+ *
+ * Inert for every other agent: without `CODEX_THREAD_ID` the whole block is skipped. A machine with
+ * no managed accounts has no subdirs, so the scan reduces to the one bare-root read S4 did — the
+ * legacy layout keeps resolving byte-for-byte (Constraint 12).
  *
  * Deliberately free of Node/Electron imports beyond the path it is given: the generated-script
  * cores are shared by the desktop and the Server Edition.
@@ -23,36 +33,78 @@
 import { posixQuote } from '../shared/ssh'
 
 /**
+ * PROBE U5 (Codex 0.146.0, 2026-08-19 — docs/superpowers/probes/2026-08-codex-tool-shell-env.md):
+ * a shared `app-server`-spawned tool shell carries `CODEX_THREAD_ID` (measured — a fresh id per
+ * thread) and NOT the per-pane `NODETERM_*` (the tool shell forks from the shared daemon, not the
+ * connecting client; corroborated by the deployed S4 resolver that depends on exactly this). The
+ * premise HOLDS, so the account-scoped scan below is warranted. Caveat: an in-process app-server
+ * (`codex exec`) leaks `NODETERM_*`, but the outer `[ -z "$NODETERM_NODE_ID" ]` guard no-ops there.
+ *
  * @param identityRoot absolute path of the thread → node record directory
  *   (`codexThreadIdentityRoot()`, i.e. under `CorePlatform.userDataDir` — NOT `~`).
  */
 export function codexThreadIdentityResolverSh(identityRoot: string): string {
   return `# A shared-app-server Codex tool shell inherits CODEX_THREAD_ID, not the TUI client's
-# NODETERM_* env. Recover this thread's exact node binding, or change nothing at all.
+# NODETERM_* env. Recover this thread's exact node binding (account-scoped), or change nothing.
 if [ -z "\${NODETERM_NODE_ID-}" ] && [ -n "\${CODEX_THREAD_ID-}" ]; then
   case "$CODEX_THREAD_ID" in
     # '.' and '..' MATCH the charset and are path segments: "$identityRoot"/.. is the record dir's
     # PARENT. Refused by name here for the same reason isSafeThreadId refuses them in TypeScript.
     ''|.|..|*[!A-Za-z0-9._-]*) ;;
     *)
-      nt_codex_map=${posixQuote(identityRoot)}/"$CODEX_THREAD_ID"
-      if [ -r "$nt_codex_map" ]; then
-        nt_codex_node=$(sed -n 's/^nodeId=//p' "$nt_codex_map" | head -n 1)
-        nt_codex_endpoint=$(sed -n 's/^endpoint=//p' "$nt_codex_map" | head -n 1)
-        case "$nt_codex_node" in ''|*[!A-Za-z0-9._-]*) nt_codex_node='' ;; esac
-        case "$nt_codex_endpoint" in /*) ;; *) nt_codex_endpoint='' ;; esac
-        if [ -n "$nt_codex_endpoint" ] &&
-           [ "$(printf %s "$nt_codex_endpoint" | tr -cd 'A-Za-z0-9._/ -')" != "$nt_codex_endpoint" ]
-        then
-          nt_codex_endpoint=''
-        fi
-        if [ -n "$nt_codex_node" ] && [ -n "$nt_codex_endpoint" ]; then
-          NODETERM_NODE_ID="$nt_codex_node"
-          NODETERM_HOOK_ENDPOINT="$nt_codex_endpoint"
-          NODETERM_AGENT_ID=codex
-          NODETERM_CANVAS_CONTROL=1
-          export NODETERM_NODE_ID NODETERM_HOOK_ENDPOINT NODETERM_AGENT_ID NODETERM_CANVAS_CONTROL
-        fi
+      nt_codex_root=${posixQuote(identityRoot)}
+      nt_codex_matches=0
+      nt_codex_node=''
+      nt_codex_endpoint=''
+      # Validate one candidate record file for an expected scope, parsed as DATA. On success it
+      # records the node/endpoint and counts the match. $1=file, $2=expected scope ('' = system).
+      nt_codex_try() {
+        [ -r "$1" ] || return 0
+        nt_a=$(sed -n 's/^accountId=//p' "$1" | head -n 1)
+        # The record's own account line must AGREE with the directory it was found in. A system
+        # record's line is empty or the reserved word 'system'; a managed record's line is its id.
+        case "$2" in
+          '') case "$nt_a" in ''|system) ;; *) return 0 ;; esac ;;
+          *) [ "$nt_a" = "$2" ] || return 0 ;;
+        esac
+        nt_n=$(sed -n 's/^nodeId=//p' "$1" | head -n 1)
+        nt_e=$(sed -n 's/^endpoint=//p' "$1" | head -n 1)
+        case "$nt_n" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
+        case "$nt_e" in /*) ;; *) return 0 ;; esac
+        [ "$(printf %s "$nt_e" | tr -cd 'A-Za-z0-9._/ -')" = "$nt_e" ] || return 0
+        nt_codex_node=$nt_n
+        nt_codex_endpoint=$nt_e
+        nt_codex_matches=$((nt_codex_matches + 1))
+      }
+      case "\${NODETERM_CODEX_ACCOUNT_ID-}" in
+        '')
+          # Unknown account: scan every scope, bind only if exactly one candidate matches.
+          nt_codex_try "$nt_codex_root/$CODEX_THREAD_ID" ''
+          for nt_codex_dir in "$nt_codex_root"/*/; do
+            [ -d "$nt_codex_dir" ] || continue
+            nt_codex_scope=\${nt_codex_dir%/}
+            nt_codex_scope=\${nt_codex_scope##*/}
+            case "$nt_codex_scope" in
+              ''|.|..|system|*[!A-Za-z0-9._-]*) continue ;;
+            esac
+            nt_codex_try "$nt_codex_dir$CODEX_THREAD_ID" "$nt_codex_scope"
+          done
+          ;;
+        # A daemon scope that could escape the mapping directory, or the reserved system word used
+        # as a managed id: resolve nothing.
+        .|..|system|*[!A-Za-z0-9._-]*) ;;
+        *)
+          nt_codex_try "$nt_codex_root/\${NODETERM_CODEX_ACCOUNT_ID}/$CODEX_THREAD_ID" \\
+            "$NODETERM_CODEX_ACCOUNT_ID"
+          ;;
+      esac
+      if [ "$nt_codex_matches" -eq 1 ] && [ -n "$nt_codex_node" ] && [ -n "$nt_codex_endpoint" ]
+      then
+        NODETERM_NODE_ID="$nt_codex_node"
+        NODETERM_HOOK_ENDPOINT="$nt_codex_endpoint"
+        NODETERM_AGENT_ID=codex
+        NODETERM_CANVAS_CONTROL=1
+        export NODETERM_NODE_ID NODETERM_HOOK_ENDPOINT NODETERM_AGENT_ID NODETERM_CANVAS_CONTROL
       fi
       ;;
   esac

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1307,12 +1307,12 @@ app.whenReady().then(async () => {
   // workspace that no longer holds it) is free to be re-claimed; one whose owner is still there is
   // not, and the launcher then falls back rather than putting two clients on one conversation.
   const codexNodeIsLive = (nodeId: string): boolean => !!workspaceStore.getNode(nodeId)
-  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd, hookEndpoint }) => {
+  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd, hookEndpoint, accountId }) => {
     const threadId = await startCodexThread(cwd)
-    writeCodexThreadIdentity(threadId, nodeId, hookEndpoint)
+    writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, undefined, accountId)
     return threadId
   })
-  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, hookEndpoint }) => {
+  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, hookEndpoint, accountId }) => {
     // Ask the app-server whether this conversation exists BEFORE recording that a node owns it.
     // The id reaching us is whatever the node persisted — it can be stale, or from a session that
     // ran under plain codex and the shared server has never heard of. Binding it anyway writes a
@@ -1321,7 +1321,7 @@ app.whenReady().then(async () => {
     if (!(await codexThreadExists(threadId))) {
       throw new Error('Codex thread is unknown to the shared app-server')
     }
-    bindCodexThreadIdentity(threadId, nodeId, hookEndpoint, codexNodeIsLive)
+    bindCodexThreadIdentity(threadId, nodeId, hookEndpoint, codexNodeIsLive, undefined, accountId)
   })
   // SSH_ASKPASS relay (ssh-project.ts): lets the ControlMaster, which has no tty, route a
   // passphrase-protected identity file's prompt back through the app instead of failing auth.


### PR DESCRIPTION
S6 PR 2 of external PR #112 (**@Corvin / proteus-dev**) — the **ownership spine**: the signing
secret that authenticates thread↔node↔account mappings, and the account-scoped identity proxy. Ships
inert (nothing sets `NODETERM_CODEX_ACCOUNT_ID` on a pane until later PRs), but fully tested against
real primitives (real `/bin/sh`, real fs, real HMAC).

## Probe U5 (run first) — the premise holds

**Measured under real Codex 0.146.0:** a shared `app-server`-spawned tool shell carries
`CODEX_THREAD_ID` (a fresh id per thread — measured directly, twice) and **not** the per-pane
`NODETERM_*`. The tool shell forks from the shared daemon, not the connecting client; corroborated
by the merged S4 resolver deployed on this host, which depends on exactly this and works in
production. Caveat measured: an in-process app-server (`codex exec`) leaks `NODETERM_*`, but the
resolver's outer `[ -z "$NODETERM_NODE_ID" ]` guard no-ops there, so it cannot mis-scope a bind.
**NOT BLOCKED.** Full write-up: `docs/superpowers/probes/2026-08-codex-tool-shell-env.md`.

## Decision 1 — the secret arms on BOTH shells (not safeStorage-only)

@Corvin's `codex-node-auth-secret.ts` is safeStorage-ciphertext-only and throws on the headless
Server Edition. This PR does **not** introduce it. The records are signed by the already-merged
both-shells `node-auth-secret.ts` (`loadOrCreateNodeAuthSecret`) — sealed on the desktop
(`node-auth-key.json`), raw `0600` on the server (`node-auth-key.bin`), already wired at boot in
`src/main/index.ts` and `src/server/index.ts`. Confidential and fail-closed: malformed persisted
state **throws rather than rotating** the key (rotating would orphan every bound thread). The one
missing Property-6 test (desktop malformed sealed key → fail closed, no rotation, no plaintext
fallback) is added.

## Security spine (each with a red-on-regression test + mutation)

- **Property 7 — signed mappings are authenticated.** HMAC binds the 4-tuple
  `threadId ␀ accountScope ␀ nodeId ␀ hookEndpoint` (empty id → `system`, `timingSafeEqual`). A
  record signed for account A verifies only under scope A — re-filing it into B fails the MAC. A
  pre-S6 record with no `accountId=` line is honoured with the original 3-tuple **only at the system
  scope** (the single back-compat door). A record whose account line disagrees with its directory is
  rejected.
- **Property 3 — ambiguous ownership fails closed.** `resolveCodexThreadNodeIdentity` returns an
  owner only when `owners.size === 1` across scopes; the same thread id owned by two accounts
  resolves to nothing. The sh resolver binds only when `nt_codex_matches -eq 1`.
- **Property 8 — ids/scopes cannot escape the filesystem.** `accountScope()` reuses the shared
  `isSafeAccountId` regex (`^[A-Za-z0-9][A-Za-z0-9._-]*$`) and refuses `.`/`..`/`a/b`/absolute/
  `system`; enforced in the proxy, the launcher's sh, and the hook route.
- **Launcher fails closed.** The account id travels in the `/codex-thread/{start,bind}` POST **body**,
  never on argv (Constraint 6); an invalid id falls back to plain `codex`; the server refuses a
  hostile id at **400 before** `startCodexThread` can create an orphan thread.

## Layout & back-compat

System records stay at the bare root `<root>/<threadId>` (the exact S4 layout); managed records go
under `<root>/<accountId>/<threadId>`. A machine with **no** managed accounts is byte-for-byte
unchanged and its legacy records keep resolving (Constraint 12). The sh resolver runs under real
`/bin/sh` against a real on-disk scope tree — never a TS re-parse. The rollout quarantine/restore
trio is deliberately deferred to PR 3 (it is the cross-machine copy mechanism, not this PR's
ownership-authentication spine).

## Mutation checks (introduced / caught)

| Assertion | Mutation | Result |
| --- | --- | --- |
| Property 3 (proxy) | admit `owners.size > 1` (return first owner) | 1/1 red |
| Property 3 (sh) | bind on first match (`-eq 1` → `-ge 1`) | 1/1 red |
| Property 6 (secret) | add a plaintext fallback on the sealed path | 1/1 red |
| Property 7 (HMAC) | `recordSignatureValid` always true | 1/1 red (2 tests) |
| Property 7 (legacy door) | broaden the 3-tuple fallback to any scope | 1/1 red |
| Property 7 (sh) | drop the account-line vs directory-scope check | 1/1 red |
| Property 8 (proxy) | drop the `accountScope` escape throw | 1/1 red |
| Task 2.4 (launcher) | drop the account-id validation in preflight | 1/1 red |
| Task 2.4 (server gate) | drop the hook-route `isSafeAccountId` gate | 1/1 red |

## Gates

`npm run typecheck` clean. Full `npx vitest run`: **7454 passed, 0 failed, 12 skipped** (538 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
