### PR TITLE
feat(explorer): pin the file tree so it stays open on the canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1693,7 +1693,13 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   opens an editor node). These use `mkdir` + `exists` added to `FsApi`/`SshFsApi` across
   desktop/server/SSH (`core/fs-ops.ts`, `main/ssh-fs.ts`; relay remote-fs degrades to `false`).
   Expanded dirs **persist per project** across drawer close + app restart (`state/explorer.ts`
-  zustand store, localStorage `nodeterm.explorerExpanded`).
+  zustand store, localStorage `nodeterm.explorerExpanded`). The header pin docks it like the
+  sessions sidebar (`lib/explorerPin.ts`, `nodeterm.explorerPinned`, default off): overlay
+  click-outside closes the modal only, and a pinned overlay is `pointer-events: none` so it
+  cannot steal canvas clicks. × is a transient hide and does not clear the pin. Pinned z-index
+  is 26 so the tree stays visible on the kanban board with the controls cluster. Desktop +
+  Server Edition (personal `localStorage`). Mobile companion: N/A — no explorer there. Source
+  Control stays a modal.
 - **Source Control** (`main/git-service.ts` system `git` + `gh`, `SourceControlPanel.tsx`,
   ⎇): file-level **stage/unstage** (+/−), **discard**, click a file → **diff node**,
   **branch switch/create**, commit (message box at top) + push / sync / publish, **gh

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -241,6 +241,14 @@ const sshDisconnect = (scopeId: string): Promise<unknown> =>
   window.nodeTerminal.sshProject.disconnect(scopeId)
 import { opensInEditor } from '../lib/openTarget'
 import { newEntryPath, parentDir } from '../lib/explorerCreate'
+import {
+  explorerIsOpen,
+  nextExplorerPin,
+  nextExplorerShow,
+  readExplorerPinned,
+  writeExplorerPinned,
+  type ExplorerShowAction
+} from '../lib/explorerPin'
 import { useProjects } from '../state/projects'
 import { useAgentStatus } from '../state/agentStatus'
 import { useBrowserLease, drivingNodeIds } from '../state/browserLease'
@@ -841,7 +849,26 @@ export function Canvas() {
       .then((v) => setAppVersion(v))
       .catch(() => {})
   }, [])
-  const [explorerOpen, setExplorerOpen] = useState(false)
+  // Explorer visibility: pin is a persisted preference (default off — it is a modal today;
+  // flipping the default would dock it on every existing user's next launch). `dismissed` is
+  // the transient × hide and does NOT clear the pin, matching the sessions sidebar. `open`
+  // is the unpinned (modal) flag. See `lib/explorerPin.ts`.
+  const [explorer, setExplorer] = useState(() => ({
+    pinned: readExplorerPinned(),
+    dismissed: false,
+    open: false
+  }))
+  const explorerOpen = explorerIsOpen(explorer)
+  const showExplorer = useCallback((action: ExplorerShowAction) => {
+    setExplorer((s) => ({ ...s, ...nextExplorerShow(s, action) }))
+  }, [])
+  const toggleExplorerPin = useCallback(() => {
+    setExplorer((s) => {
+      const next = nextExplorerPin(s)
+      writeExplorerPinned(next.pinned)
+      return next
+    })
+  }, [])
   // Reveal-in-Explorer target (relative to the active project cwd). The nonce makes each reveal
   // distinct so revealing the same file twice still re-fires the Explorer effect.
   const [reveal, setReveal] = useState<{ path: string; nonce: number } | null>(null)
@@ -3274,9 +3301,9 @@ export function Canvas() {
   /** Reveal a file in the Explorer drawer: open the drawer and hand it the (relative) path.
    *  Each call bumps a nonce so revealing the same file twice still re-fires the effect. */
   const revealProjectFile = useCallback((relPath: string) => {
-    setExplorerOpen(true)
+    showExplorer('reveal')
     setReveal((r) => ({ path: relPath, nonce: (r?.nonce ?? 0) + 1 }))
-  }, [])
+  }, [showExplorer])
 
   // Cmd+click file links inside terminal output (TerminalNode dispatches these — it has no
   // direct line to the canvas). Files open as editor nodes; directories reveal in Explorer.
@@ -5236,7 +5263,7 @@ export function Canvas() {
         useViewMode.getState().toggle(id)
         return true
       },
-      'panel.explorer': () => { setExplorerOpen((v) => !v); return true },
+      'panel.explorer': () => { showExplorer('toggle'); return true },
       'panel.sourceControl': () => { setScOpen((v) => !v); return true },
       'panel.sessions': () => { toggleSessionsPin(); return true },
       'canvas.undo': () => { undo(); return true },
@@ -9358,7 +9385,7 @@ export function Canvas() {
           <span className="cluster-search__icon">⌕</span>
           {paletteChip && <span className="kbd">{paletteChip}</span>}
         </button>
-        <button title={commandTooltip('Explorer', 'panel.explorer')} onClick={() => setExplorerOpen(true)}>
+        <button title={commandTooltip('Explorer', 'panel.explorer')} onClick={() => showExplorer('toggle')}>
           <IconExplorer />
         </button>
         <button title={commandTooltip('Source Control', 'panel.sourceControl')} onClick={() => setScOpen(true)}>
@@ -9722,9 +9749,11 @@ export function Canvas() {
 
       {explorerOpen && (
         <ExplorerPanel
-          onClose={() => setExplorerOpen(false)}
+          onClose={() => showExplorer('close')}
           onOpenFile={(path, isSsh) => openFile(path, undefined, isSsh)}
           reveal={reveal}
+          pinned={explorer.pinned}
+          onTogglePin={toggleExplorerPin}
         />
       )}
 

--- a/src/renderer/components/ExplorerPanel.tsx
+++ b/src/renderer/components/ExplorerPanel.tsx
@@ -9,7 +9,9 @@ import { useSession } from '../session/session'
 import { promptDialog } from './promptDialog'
 import { ancestorDirs, createTargetDir, newEntryPath, parentDir } from '../lib/explorerCreate'
 import { canRevealLocally, downloadRoute, triggerBrowserDownload } from '../lib/download'
+import { explorerOverlayClickCloses } from '../lib/explorerPin'
 import { isBrowserRuntime } from '../bridge/runtime'
+import { IconPin } from './icons'
 
 export interface ExplorerPanelProps {
   onClose: () => void
@@ -19,6 +21,12 @@ export interface ExplorerPanelProps {
   /** File to reveal (expand ancestors + select + scroll). `path` is relative to the active project
    *  cwd; `nonce` increments per request so revealing the same file twice still re-fires. */
   reveal?: { path: string; nonce: number } | null
+  /**
+   * Docked: no scrim close, pointer-events pass through to the canvas. Default false so an
+   * omitted prop stays the historical overlay. Toggle lives here; persistence lives in Canvas.
+   */
+  pinned?: boolean
+  onTogglePin?: () => void
 }
 
 type ContextFn = (x: number, y: number, path: string, isDir: boolean, ignored?: boolean) => void
@@ -219,7 +227,13 @@ function TreeEntry({
  * NOTE (relay): a relay session's Explorer is still rooted at the local project's `cwd` — the host's
  * root cwd isn't known client-side. A relay tab reaches the host fs through its bridged session api
  * (the same seam TerminalNode/EditorNode use), not a separate per-connection fs client. */
-export function ExplorerPanel({ onClose, onOpenFile, reveal }: ExplorerPanelProps) {
+export function ExplorerPanel({
+  onClose,
+  onOpenFile,
+  reveal,
+  pinned = false,
+  onTogglePin
+}: ExplorerPanelProps) {
   const project = useProjects((s) => s.projects.find((p) => p.id === s.activeProjectId))
   // SSH projects browse the REMOTE filesystem: root at the project's `remoteCwd` and list over the
   // ControlMaster via `sshFs`. Local (and relay) projects keep the local fs rooted at `cwd`.
@@ -444,15 +458,36 @@ export function ExplorerPanel({ onClose, onOpenFile, reveal }: ExplorerPanelProp
   )
 
   return createPortal(
-    <div className="drawer-overlay" onClick={onClose}>
-      <aside className="drawer" onClick={(e) => e.stopPropagation()}>
+    <div
+      className={pinned ? 'drawer-overlay drawer-overlay--pinned' : 'drawer-overlay'}
+      // Pinned: no handler, so a CSS miss still cannot dismiss the docked tree. The overlay
+      // also has pointer-events:none (styles.css) — without that it would steal canvas clicks
+      // even with a no-op handler. Both halves are load-bearing.
+      onClick={explorerOverlayClickCloses(pinned) ? onClose : undefined}
+    >
+      <aside
+        className={pinned ? 'drawer drawer--pinned' : 'drawer'}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="drawer__head">
           <h2>{project?.name || 'Explorer'}</h2>
           <div className="ex-head-actions">
-            <button title="Refresh" onClick={() => setVersion((v) => v + 1)}>
+            <button type="button" title="Refresh" aria-label="Refresh" onClick={() => setVersion((v) => v + 1)}>
               ↻
             </button>
-            <button className="drawer__close" onClick={onClose}>
+            {onTogglePin && (
+              <button
+                type="button"
+                className={pinned ? 'is-on' : ''}
+                title={pinned ? 'Unpin' : 'Pin'}
+                aria-label={pinned ? 'Unpin' : 'Pin'}
+                aria-pressed={pinned}
+                onClick={onTogglePin}
+              >
+                <IconPin />
+              </button>
+            )}
+            <button type="button" className="drawer__close" title="Close" aria-label="Close" onClick={onClose}>
               ×
             </button>
           </div>
@@ -528,8 +563,10 @@ export function ExplorerPanel({ onClose, onOpenFile, reveal }: ExplorerPanelProp
         createPortal(
           <>
             {/* stopPropagation everywhere (same as ContextMenu): this portal's React parent is the
-                drawer OVERLAY (not the aside), so a bubbled click lands on the overlay's
-                onClick={onClose} and closes the whole Explorer along with the menu. */}
+                drawer OVERLAY (not the aside), so a bubbled click on the unpinned modal lands on
+                the overlay's onClick={onClose} and closes the whole Explorer along with the menu.
+                A pinned overlay has no close handler, but the stop is still what keeps the
+                click off the canvas. */}
             <div
               className="tab-backdrop"
               style={{ zIndex: 78 }}

--- a/src/renderer/lib/explorerPin.test.ts
+++ b/src/renderer/lib/explorerPin.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXPLORER_PINNED_KEY,
+  explorerIsOpen,
+  explorerOverlayClickCloses,
+  nextExplorerPin,
+  nextExplorerShow,
+  parseExplorerPinned,
+  readExplorerPinned,
+  writeExplorerPinned,
+  type ExplorerPinState
+} from './explorerPin'
+
+const hidden: ExplorerPinState = { pinned: false, dismissed: false, open: false }
+const modal: ExplorerPinState = { pinned: false, dismissed: false, open: true }
+const docked: ExplorerPinState = { pinned: true, dismissed: false, open: true }
+const dockedHidden: ExplorerPinState = { pinned: true, dismissed: true, open: false }
+/** Launch after a previous pin: shown, but `open` was never set this session. */
+const launchPinned: ExplorerPinState = { pinned: true, dismissed: false, open: false }
+
+describe('parseExplorerPinned', () => {
+  it('is off by default — missing must not dock the drawer on existing users', () => {
+    expect(parseExplorerPinned(null)).toBe(false)
+    expect(parseExplorerPinned('')).toBe(false)
+    expect(parseExplorerPinned('0')).toBe(false)
+    expect(parseExplorerPinned('true')).toBe(false)
+    expect(parseExplorerPinned('1')).toBe(true)
+  })
+})
+
+describe('readExplorerPinned / writeExplorerPinned', () => {
+  it('reads the namespaced key and writes 1/0', () => {
+    const store: Record<string, string> = {}
+    expect(readExplorerPinned((k) => store[k] ?? null)).toBe(false)
+    writeExplorerPinned(true, (k, v) => {
+      store[k] = v
+    })
+    expect(store[EXPLORER_PINNED_KEY]).toBe('1')
+    expect(readExplorerPinned((k) => store[k] ?? null)).toBe(true)
+    writeExplorerPinned(false, (k, v) => {
+      store[k] = v
+    })
+    expect(store[EXPLORER_PINNED_KEY]).toBe('0')
+    expect(readExplorerPinned((k) => store[k] ?? null)).toBe(false)
+  })
+
+  it('degrades to unpinned when storage throws', () => {
+    expect(
+      readExplorerPinned(() => {
+        throw new Error('blocked')
+      })
+    ).toBe(false)
+    expect(() =>
+      writeExplorerPinned(true, () => {
+        throw new Error('quota')
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('explorerIsOpen', () => {
+  it('uses `open` when unpinned and `!dismissed` when pinned', () => {
+    expect(explorerIsOpen(hidden)).toBe(false)
+    expect(explorerIsOpen(modal)).toBe(true)
+    expect(explorerIsOpen(docked)).toBe(true)
+    expect(explorerIsOpen(dockedHidden)).toBe(false)
+    expect(explorerIsOpen(launchPinned)).toBe(true)
+  })
+
+  it('does not treat dismissed as closed when unpinned — dismissed is a pin-only hide', () => {
+    // An unpinned modal with a leftover dismissed flag (stale after unpin) still follows `open`.
+    expect(explorerIsOpen({ pinned: false, dismissed: true, open: true })).toBe(true)
+    expect(explorerIsOpen({ pinned: false, dismissed: true, open: false })).toBe(false)
+  })
+})
+
+describe('explorerOverlayClickCloses', () => {
+  it('closes the modal scrim, never a pinned drawer', () => {
+    expect(explorerOverlayClickCloses(false)).toBe(true)
+    expect(explorerOverlayClickCloses(true)).toBe(false)
+  })
+})
+
+describe('nextExplorerShow', () => {
+  it('open/reveal shows without clearing a pin', () => {
+    expect(nextExplorerShow(hidden, 'open')).toEqual({ dismissed: false, open: true })
+    expect(nextExplorerShow(dockedHidden, 'reveal')).toEqual({ dismissed: false, open: true })
+    expect(nextExplorerShow(dockedHidden, 'open')).toEqual({ dismissed: false, open: true })
+  })
+
+  it('close hides without touching the pin (caller keeps `pinned`)', () => {
+    expect(nextExplorerShow(modal, 'close')).toEqual({ dismissed: true, open: false })
+    expect(nextExplorerShow(docked, 'close')).toEqual({ dismissed: true, open: false })
+  })
+
+  it('toggle flips visibility', () => {
+    expect(nextExplorerShow(hidden, 'toggle')).toEqual({ dismissed: false, open: true })
+    expect(nextExplorerShow(modal, 'toggle')).toEqual({ dismissed: true, open: false })
+    expect(nextExplorerShow(docked, 'toggle')).toEqual({ dismissed: true, open: false })
+    expect(nextExplorerShow(dockedHidden, 'toggle')).toEqual({ dismissed: false, open: true })
+    expect(nextExplorerShow(launchPinned, 'toggle')).toEqual({ dismissed: true, open: false })
+  })
+})
+
+describe('nextExplorerPin', () => {
+  it('pinning a modal (or a closed panel) docks and shows it', () => {
+    expect(nextExplorerPin(modal)).toEqual({ pinned: true, dismissed: false, open: true })
+    expect(nextExplorerPin(hidden)).toEqual({ pinned: true, dismissed: false, open: true })
+  })
+
+  it('unpinning a visible drawer keeps it as the modal, including the launch-pinned case', () => {
+    // If this just flipped `pinned` and left `open` false, the drawer would vanish.
+    expect(nextExplorerPin(launchPinned)).toEqual({ pinned: false, dismissed: false, open: true })
+    expect(nextExplorerPin(docked)).toEqual({ pinned: false, dismissed: false, open: true })
+  })
+
+  it('unpinning a dismissed drawer stays hidden', () => {
+    expect(nextExplorerPin(dockedHidden)).toEqual({ pinned: false, dismissed: false, open: false })
+  })
+})

--- a/src/renderer/lib/explorerPin.ts
+++ b/src/renderer/lib/explorerPin.ts
@@ -1,0 +1,85 @@
+// Personal pin for the Explorer drawer. Same storage family as the sessions sidebar
+// (`nodeterm.sessionsPinned`) and the tree's expanded dirs (`nodeterm.explorerExpanded`):
+// this machine only, never settings.json / project.json.
+//
+// Default OFF. Sessions defaulted on because it launched as a docked panel; Explorer is a
+// modal overlay today, and flipping the default would dock it on every existing user's next
+// launch. The pin is opt-in: once set, the next launch reopens the drawer already docked.
+//
+// Three flags, same shape as the sessions sidebar:
+//   pinned    — persisted preference
+//   dismissed — transient "hide for now" (the ×). Does NOT clear the pin.
+//   open      — unpinned (modal) visibility
+//
+// There is no hover-peek: unpinning a visible drawer keeps it as the modal so the tree the
+// user was looking at does not vanish. Overlay click-outside closes only the modal; a pinned
+// drawer that still sat under a full-screen overlay would STEAL canvas clicks even if the
+// handler no-op'd — so the overlay must also stop capturing pointer events (CSS).
+
+export const EXPLORER_PINNED_KEY = 'nodeterm.explorerPinned'
+
+export interface ExplorerPinState {
+  pinned: boolean
+  dismissed: boolean
+  open: boolean
+}
+
+/** `'1'` is pinned; missing, `'0'`, or any other value is unpinned. */
+export function parseExplorerPinned(raw: string | null): boolean {
+  return raw === '1'
+}
+
+export function readExplorerPinned(
+  getItem: (key: string) => string | null = (key) => localStorage.getItem(key)
+): boolean {
+  try {
+    return parseExplorerPinned(getItem(EXPLORER_PINNED_KEY))
+  } catch {
+    return false
+  }
+}
+
+export function writeExplorerPinned(
+  pinned: boolean,
+  setItem: (key: string, value: string) => void = (key, value) => localStorage.setItem(key, value)
+): void {
+  try {
+    setItem(EXPLORER_PINNED_KEY, pinned ? '1' : '0')
+  } catch {
+    /* private-mode / quota: pin is a nicety, never fail the UI */
+  }
+}
+
+/** Pin docks it; dismissed is a transient hide. Unpinned uses `open` as the modal flag. */
+export function explorerIsOpen(state: ExplorerPinState): boolean {
+  return state.pinned ? !state.dismissed : state.open
+}
+
+/** Click-outside on the scrim closes the modal only. A pinned drawer has no scrim close. */
+export function explorerOverlayClickCloses(pinned: boolean): boolean {
+  return !pinned
+}
+
+export type ExplorerShowAction = 'open' | 'toggle' | 'close' | 'reveal'
+
+export function nextExplorerShow(
+  state: ExplorerPinState,
+  action: ExplorerShowAction
+): Pick<ExplorerPinState, 'dismissed' | 'open'> {
+  if (action === 'close') return { dismissed: true, open: false }
+  if (action === 'toggle' && explorerIsOpen(state)) return { dismissed: true, open: false }
+  // open / reveal / toggle-from-hidden: show, keep the pin
+  return { dismissed: false, open: true }
+}
+
+/**
+ * Flip the pin. (Re)pinning always shows the docked panel. Unpinning a visible drawer
+ * becomes the modal (`open: true`) even if `open` was still false — that is the
+ * launch-pinned case: `pinned && !dismissed` showed it without ever setting `open`.
+ */
+export function nextExplorerPin(state: ExplorerPinState): ExplorerPinState {
+  if (!state.pinned) {
+    return { pinned: true, dismissed: false, open: true }
+  }
+  return { pinned: false, dismissed: false, open: explorerIsOpen(state) }
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3591,6 +3591,7 @@ body,
 /* Overlays/menus that can overlap the macOS title-bar strip must opt out of window-drag,
    otherwise clicks on their top controls (×, ↻, …) drag the window instead. */
 .drawer-overlay,
+.drawer--pinned,
 .palette-overlay,
 .sc-overlay,
 .confirm-overlay,
@@ -3617,6 +3618,32 @@ body,
 
 .drawer.scm {
   width: 460px;
+}
+
+/* Pinned explorer: no scrim, clicks pass through to the canvas. The drawer is a floating
+   card on the right — same shape as the sessions sidebar on the left — so the controls
+   cluster (top: 54px, right: 14px, 34px tall) stays reachable. z 26 sits with that cluster
+   above the kanban board (25) and below the tab bar (30) / dialogs (55+). pointer-events
+   on the overlay is load-bearing: a transparent overlay that still captures would freeze
+   the canvas even with the click-to-close handler removed. */
+.drawer-overlay--pinned {
+  background: transparent;
+  pointer-events: none;
+  z-index: 26;
+}
+.drawer-overlay--pinned .drawer--pinned {
+  pointer-events: auto;
+  position: absolute;
+  top: 96px; /* 54 (cluster) + 34 (buttons) + 8 (gap) — must sit BELOW the cluster */
+  right: 14px;
+  bottom: 14px;
+  height: auto;
+  max-height: none;
+  width: 320px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, calc(0.45 * var(--shadow-k)));
 }
 
 .drawer__head {
@@ -4222,6 +4249,14 @@ body,
 
 .ex-head-actions button:hover {
   color: var(--text);
+}
+
+.ex-head-actions button.is-on {
+  color: var(--accent);
+}
+
+.ex-head-actions button svg {
+  display: block;
 }
 
 .ex-body {


### PR DESCRIPTION
## What

Explorer can be pinned so it stays open while you work on the canvas.

It was a click-outside overlay, so opening a file or touching the canvas dismissed the tree ([#297](https://github.com/eneskirca/nodeterm/issues/297)). The header pin docks it like the sessions sidebar: no scrim, pointer-events pass through to the canvas, × hides without clearing the pin, and the preference persists in `localStorage` (`nodeterm.explorerPinned`).

Default **off**. Explorer is a modal today, and flipping the default would dock it on every existing user's next launch. Unpinning a visible drawer keeps it as the modal so the tree does not vanish (there is no hover-peek). Source Control is unchanged.

## Why the overlay change is two halves

A pinned drawer that still sat under a full-screen overlay would **steal canvas clicks** even if the click handler no-op'd. So:

1. Overlay click-outside closes the **modal only** (`explorerOverlayClickCloses`).
2. A pinned overlay is `pointer-events: none`; only the drawer captures events.

Both are load-bearing. The docked card sits below the controls cluster (`top: 96px`) so Settings / SCM / Explorer stay reachable, at z 26 so it remains visible on the kanban board.

## Surfaces

- **Desktop** — full.
- **Server Edition** — full (renderer `localStorage`; no new IPC).
- **Mobile companion** — N/A. There is no explorer there. Flagging for @eneskirca rather than assuming.

Kanban: the pinned tree is a panel, not a node action, so there is nothing to mirror on cards. It stays visible on the board with the controls cluster.

## Testing

`npm test -- src/renderer/lib/explorerPin.test.ts` — 12/12 pass. The four load-bearing guards were mutation-tested (default-on parse, overlay always closes, unpin dropping a launch-pinned drawer, dismissed pin still showing) and each turned a test red.

`npm run typecheck` passed.

**Not verified:** clicking through it in a running app.

Full `npm test` on this machine still has pre-existing failures in `pty-shadow` / `pty-background-write` / `pty-idle-reap` (tmux control-client / unix socket path) and a few jsdom `localStorage` store loads. None of those files are in this change; they fail the same way on a clean tree here.

Closes #297.