### PR TITLE
feat(keybindings): terminal-first policy and capture notice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1623,6 +1623,22 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
     warning reads that list and cannot derive it — main is not importable from the renderer. Note
     what the pin cannot cover: a HARDCODED intercept (the `Digit0` branch) has no command id, so it
     swallows its chord app-wide with the recorder reporting no conflict.
+  - **The terminal-first stand-down is `policyStandsDown(policy, terminalFocused)`, and both halves
+    are refusals.** `settings.terminalShortcutPolicy` (`app-first` default, Settings → Keyboard
+    Shortcuts, read everywhere through `normalizeTerminalShortcutPolicy` because it is
+    hand-editable) never stands anything down under `app-first`, whatever the mirror reports — that
+    is the byte-identical guarantee for a user who never touched it. Under `terminal-first` with a
+    focused terminal, main stops claiming its chords AND disables the menu's Minimize/Close items
+    (see **Window chrome**): not calling `preventDefault` alone would hand ⌘M straight to
+    `{role:'minimize'}`, which is strictly worse than having no policy.
+  - **`terminalFocused` is a MIRROR, and its fail-safe direction is `false` = not focused =
+    intercepts ON.** `renderer/lib/terminalFocusMirror.ts` reports focus changes to main and is
+    change-deduped (it never re-asserts), so a page that died mid-report, a reload, or a window that
+    never had one all resolve to intercepts on — never to "off with nothing alive to turn them back
+    on". Consequence: clear the bit ONLY where the renderer's DOCUMENT is ending (window `closed`,
+    `render-process-gone`, main-frame navigation). Clearing it under a live page that is still
+    focused on its terminal strands mirror and main out of sync with no event that can reconcile
+    them, and the policy is dead until the user clicks away and back.
 
 ## Canvas interaction & panels (`Canvas.tsx` is the hub)
 
@@ -1897,12 +1913,20 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
 - **Welcome** (`WelcomeScreen.tsx`): shown when no projects exist.
 - **Window chrome**: macOS integrated title bar (`titleBarStyle: 'hiddenInset'`); the tab
   bar (`TabBar.tsx`) is the drag region with the `nodeterm` logo + a rounded pill of project
-  tabs. Cmd+M is intercepted in `main/index.ts` `before-input-event` (else macOS minimizes)
-  and forwarded to the renderer via `app:toggle-markdown`; Cmd+W (`app:close-node`) and Cmd+0
-  (`app:zoom-actual-size`) are taken back from the same default menu the same way. We never call
-  `Menu.setApplicationMenu`, so Electron's DEFAULT menu is live and owns every accelerator in it —
-  a chord that collides with one never reaches the renderer at all
-  (`main/menu-accelerator-intercepts.test.ts` pins the three we steal).
+  tabs. Cmd+M is intercepted in `main/keydown-intercept.ts` (`before-input-event`, installed from
+  `main/index.ts` — else macOS minimizes) and forwarded to the renderer via `app:toggle-markdown`;
+  Cmd+W (`app:close-node`) and Cmd+0 (`app:zoom-actual-size`) are taken back the same way. **The
+  application menu is OURS**: `buildAppMenu` (`main/index.ts`) calls `Menu.setApplicationMenu` and
+  re-runs on every settings change. (This bullet used to claim we never call it — false since that
+  function landed; check the template, not Electron's defaults.) Menu accelerators are handled
+  ABOVE the page on every platform, so a chord one of them owns never reaches the renderer at all —
+  which is why those three are stolen in `before-input-event`, and why the **terminal-first
+  stand-down has a menu leg**: while a terminal owns the keys under `terminal-first`,
+  `syncMenuForStandDown` disables the menu's Minimize (`MENU_ITEM_ID_MINIMIZE`, every platform)
+  and, on Windows/Linux, Close (`MENU_ITEM_ID_CLOSE`), because a disabled item suppresses its
+  accelerator and only then do ⌘M / Ctrl+W fall through to the terminal. `keydown-intercept.test.ts`
+  pins both the stolen chords and those item ids — `getMenuItemById` answers `null` for a typo and
+  the fail-safe is to do nothing, which is indistinguishable from the feature working.
 - **Theme**: macOS dark palette as CSS tokens in `styles.css` `:root` (`--accent` = systemBlue,
   label/separator opacities, SF font stack). Canvas background is black with dot grid.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1628,9 +1628,11 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
     Shortcuts, read everywhere through `normalizeTerminalShortcutPolicy` because it is
     hand-editable) never stands anything down under `app-first`, whatever the mirror reports — that
     is the byte-identical guarantee for a user who never touched it. Under `terminal-first` with a
-    focused terminal, main stops claiming its chords AND disables the menu's Minimize/Close items
-    (see **Window chrome**): not calling `preventDefault` alone would hand ⌘M straight to
-    `{role:'minimize'}`, which is strictly worse than having no policy.
+    focused terminal, main stops claiming its chords AND disables the command-style menu items in
+    `menuItemIdsToSuspend` — Minimize, Toggle Kanban Board (⌘⇧B) and Settings (⌘,) everywhere, plus
+    Close off-mac, with **Reload deliberately excluded** (see **Window chrome**): not calling
+    `preventDefault` alone would hand ⌘M straight to `{role:'minimize'}`, which is strictly worse
+    than having no policy.
   - **`terminalFocused` is a MIRROR, and its fail-safe direction is `false` = not focused =
     intercepts ON.** `renderer/lib/terminalFocusMirror.ts` reports focus changes to main and is
     change-deduped (it never re-asserts), so a page that died mid-report, a reload, or a window that
@@ -1918,15 +1920,29 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   Cmd+W (`app:close-node`) and Cmd+0 (`app:zoom-actual-size`) are taken back the same way. **The
   application menu is OURS**: `buildAppMenu` (`main/index.ts`) calls `Menu.setApplicationMenu` and
   re-runs on every settings change. (This bullet used to claim we never call it — false since that
-  function landed; check the template, not Electron's defaults.) Menu accelerators are handled
-  ABOVE the page on every platform, so a chord one of them owns never reaches the renderer at all —
-  which is why those three are stolen in `before-input-event`, and why the **terminal-first
-  stand-down has a menu leg**: while a terminal owns the keys under `terminal-first`,
-  `syncMenuForStandDown` disables the menu's Minimize (`MENU_ITEM_ID_MINIMIZE`, every platform)
-  and, on Windows/Linux, Close (`MENU_ITEM_ID_CLOSE`), because a disabled item suppresses its
-  accelerator and only then do ⌘M / Ctrl+W fall through to the terminal. `keydown-intercept.test.ts`
-  pins both the stolen chords and those item ids — `getMenuItemById` answers `null` for a typo and
-  the fail-safe is to do nothing, which is indistinguishable from the feature working.
+  function landed; check the template, not Electron's defaults.) **COMMAND-style accelerators are
+  handled ABOVE the page on every platform** — Minimize, Close, Toggle Kanban Board, Settings,
+  Reload — so a chord one of those owns never reaches the renderer, which is why those three are
+  stolen in `before-input-event`. **This is not a blanket claim about the whole menu:** the Edit
+  submenu's standard `{role:'cut'|'copy'|'paste'|'selectAll'|…}` items behave differently — Chromium
+  routes them into the focused element, so ⌘C in a terminal or a text field does the ordinary thing
+  and does not need stealing. Ask which kind an item is before reasoning from this bullet.
+  That difference is also why the **terminal-first stand-down has a menu leg**: while a terminal
+  owns the keys under `terminal-first`, `syncMenuForStandDown` disables the command-style items
+  named in `menuItemIdsToSuspend` — Minimize (`MENU_ITEM_ID_MINIMIZE`), **Toggle Kanban Board
+  (`MENU_ITEM_ID_KANBAN`, ⌘⇧B)** and **Settings (`MENU_ITEM_ID_SETTINGS`, ⌘,)** on every platform,
+  plus Close (`MENU_ITEM_ID_CLOSE`) on Windows/Linux — because a disabled item suppresses its
+  accelerator and only then do those chords fall through to the terminal. Kanban and Settings are
+  the ones a reader gets wrong: they are **not** intercepted chords at all but ordinary registry
+  commands (`view.kanbanToggle` / `app.settings`), so the renderer's dispatcher could never stand
+  them down itself — under app-first the menu takes them before the keydown exists, which is also
+  why their capture NOTICE is raised at the IPC receivers in `Canvas.tsx` rather than by the
+  dispatcher. **Reload (⌘R / ⌘⇧R) is the named exception and stays live while stood down**: it is
+  the crash-recovery lever (a wedged renderer is exactly when it is needed) and a main-frame
+  navigation is one of the three sites that reset `terminalFocused` / `shortcutRecording`.
+  `keydown-intercept.test.ts` pins both the stolen chords and the suspended item ids (including
+  that the list does not silently grow) — `getMenuItemById` answers `null` for a typo and the
+  fail-safe is to do nothing, which is indistinguishable from the feature working.
 - **Theme**: macOS dark palette as CSS tokens in `styles.css` `:root` (`--accent` = systemBlue,
   label/separator opacities, SF font stack). Canvas background is black with dot grid.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -89,7 +89,10 @@ import {
 } from '../core/agents/pending-approvals'
 import { setMainWindow, getMainWindow, sendToMain, closeAction, createCrashReloadPolicy } from './main-window'
 import {
+  MENU_ITEM_ID_CLOSE,
+  MENU_ITEM_ID_MINIMIZE,
   installKeydownIntercepts,
+  menuItemIdsToSuspend,
   navigationClearsRecording,
   policyStandsDown,
   resolveInterceptBindings,
@@ -307,6 +310,11 @@ const currentInterceptPolicy = (): TerminalShortcutPolicy =>
 settingsStore.onChange((s) => {
   interceptBindings = resolveInterceptBindings(s.keybindings, interceptIsMac)
   interceptPolicy = normalizeTerminalShortcutPolicy(s.terminalShortcutPolicy)
+  // A policy flip changes the stood-down answer with no focus event behind it, so the menu leg
+  // owes a sync here too. (`buildAppMenu` re-runs on this same hook and syncs at its end, so this
+  // is belt-and-braces for the ordering between the two `onChange` subscribers — cheap, and not
+  // something to leave to subscriber registration order.)
+  syncMenuForStandDown()
 })
 // TWO bits the RENDERER owns and main only mirrors. Both are module-level `let`s read through a
 // closure, exactly like `interceptBindings` above: the window is created later and can be recreated
@@ -331,11 +339,24 @@ settingsStore.onChange((s) => {
 // The two bits are cleared TOGETHER, by one function called at all three sites, because they die
 // for the same reason (the page is gone) and a reset that remembered only one of them would be
 // invisible until a user hit the policy path.
+//
+// ONE RULE FOR A FOURTH RESET, and it is specific to `terminalFocused`: only clear it where the
+// renderer's DOCUMENT is ending. The mirror is change-deduped and never re-asserts — it holds its
+// own `last` and reports only on a change — so clearing main's bit under a page that is still
+// alive and still focused on its terminal strands the two out of sync (`last === true` there,
+// `false` here) with no event that will ever reconcile them, and the policy is dead until the user
+// happens to click away and back. The three below are safe precisely because each one means that
+// page, and its mirror, are gone. `shortcutRecording` has no such constraint (the recorder
+// re-arms), so do not reason about the two bits interchangeably.
 let shortcutRecording = false
 let terminalFocused = false
 const clearRendererKeyState = (): void => {
   shortcutRecording = false
   terminalFocused = false
+  // The menu leg follows the same state, so it must follow it here too — otherwise a crash or a
+  // reload while stood down would leave Window ▸ Minimize disabled with nothing left to re-enable
+  // it, i.e. ⌘M dead app-wide. Safe before any window exists: it no-ops without a menu.
+  syncMenuForStandDown()
 }
 const sshStore = new SshStore()
 const ptyManager = new PtyManager()
@@ -584,7 +605,15 @@ function buildAppMenu(win: BrowserWindow): void {
         { label: 'View', submenu: viewSubmenu },
         {
           label: 'Window',
-          submenu: [{ role: 'minimize' }, { role: 'zoom' }, { type: 'separator' }, { role: 'front' }]
+          // `id` on minimize: `syncMenuForStandDown` disables it while the intercepts are stood
+          // down, so ⌘M falls through to the terminal instead of minimizing the window. mac has no
+          // `{role:'close'}` here at all — which is why the intercept is ⌘W's only handler on mac.
+          submenu: [
+            { role: 'minimize', id: MENU_ITEM_ID_MINIMIZE },
+            { role: 'zoom' },
+            { type: 'separator' },
+            { role: 'front' }
+          ]
         }
       ]
     : [
@@ -604,9 +633,69 @@ function buildAppMenu(win: BrowserWindow): void {
         },
         { label: 'View', submenu: viewSubmenu },
         { label: 'Settings', submenu: [settingsItem] },
-        { label: 'Window', submenu: [{ role: 'minimize' }, { role: 'close' }] }
+        // Both ids matter off-mac: `{role:'close'}` owns Ctrl+W here, which is readline's kill-word
+        // in a terminal — a stand-down that left it enabled would CLOSE the window on a keystroke
+        // a terminal-first user meant for their shell.
+        {
+          label: 'Window',
+          submenu: [
+            { role: 'minimize', id: MENU_ITEM_ID_MINIMIZE },
+            { role: 'close', id: MENU_ITEM_ID_CLOSE }
+          ]
+        }
       ]
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+  // A REBUILD resets every item to `enabled: true`, and this function runs on every settings
+  // change — so without this line, a terminal-first user with a terminal focused would have ⌘M
+  // silently start minimizing again the moment they toggled any unrelated setting. The sync is
+  // idempotent and cheap; it belongs at the end of every path that installs a menu, not only at
+  // the paths where the stand-down state changes.
+  syncMenuForStandDown()
+}
+
+/**
+ * Enable/disable the menu items whose ACCELERATORS would otherwise beat the intercept stand-down.
+ *
+ * `installKeydownIntercepts` standing down means only that main stops calling `preventDefault` —
+ * the key then reaches the page, and if the page ignores it, the MENU, which is handled above the
+ * page either way. So under `terminal-first` with a terminal focused, ⌘M would still hit
+ * `{role:'minimize'}` and (Windows/Linux) Ctrl+W would still hit `{role:'close'}` — the latter
+ * closing the window on what a terminal user means as readline's kill-word, i.e. strictly worse
+ * than not having the policy at all. Disabling the item suppresses its accelerator, so the chord
+ * falls through: page → the renderer's dispatcher (terminal context under terminal-first, where
+ * nothing matches) → xterm → the PTY. That is what makes "everything reaches the shell" true for
+ * ⌘M and Ctrl+W too, not just for ⌘0 and mac's ⌘W.
+ *
+ * Called from every place the stood-down answer can change — the `ui:terminal-focus` receiver, the
+ * policy recompute in `settingsStore.onChange`, `clearRendererKeyState`, and the end of
+ * `buildAppMenu` (a rebuild resets `enabled`). NEVER per keystroke: this is a menu mutation, and
+ * `before-input-event` is the one path in the app where work is measured in keystrokes.
+ *
+ * FAIL-SAFE: a missing menu, or an item id that no longer resolves, does nothing at all. That
+ * leaves the pre-feature behaviour (menu enabled, intercepts deciding), which is the direction
+ * where the app still works — the cost is that a silent id drift is invisible, which is why both
+ * sides of the lookup use the same exported constants rather than string literals.
+ *
+ * KNOWN COST, deliberate: while a terminal is focused under terminal-first, Window ▸ Minimize is
+ * greyed out to the MOUSE as well. It re-enables the moment focus leaves the terminal (and the
+ * traffic-light button is unaffected), so this is a visible but self-healing trade. The alternative
+ * — rebuilding the whole menu without those accelerators on every focus change — costs a menu
+ * rebuild per click between the canvas and a terminal, and closes any menu the user has open.
+ *
+ * UNTESTED, and here is why: this is Electron menu mutation reached through the module-level
+ * `Menu` singleton inside `src/main/index.ts`, which no test imports (the same gap the intercept
+ * WIRING has — see `keydown-intercept.ts`'s header on why the decision lives in a pure module).
+ * The two testable parts were extracted: `policyStandsDown` (the state) and `menuItemIdsToSuspend`
+ * (the list, including the mac/non-mac asymmetry), both pinned in `keydown-intercept.test.ts`.
+ */
+function syncMenuForStandDown(): void {
+  const menu = Menu.getApplicationMenu()
+  if (!menu) return
+  const enabled = !policyStandsDown(currentInterceptPolicy(), terminalFocused)
+  for (const id of menuItemIdsToSuspend(interceptIsMac)) {
+    const item = menu.getMenuItemById(id)
+    if (item) item.enabled = enabled
+  }
 }
 
 function createWindow(): BrowserWindow {
@@ -1004,6 +1093,10 @@ app.whenReady().then(async () => {
   ipcMain.on(IPC.uiTerminalFocus, (event, focused: boolean) => {
     if (getMainWindow()?.webContents.id !== event.sender.id) return
     terminalFocused = focused === true
+    // The mirror is change-deduped, so this fires only on a real focus transition — the right
+    // cadence for a menu mutation, and the reason the sync is here rather than on the keystroke
+    // path. It must be INSIDE the guard: a rejected sender must not move the menu either.
+    syncMenuForStandDown()
   })
 
   // Bring the window forward after a file is dropped into a terminal. On macOS a drag-drop from

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -90,7 +90,9 @@ import {
 import { setMainWindow, getMainWindow, sendToMain, closeAction, createCrashReloadPolicy } from './main-window'
 import {
   MENU_ITEM_ID_CLOSE,
+  MENU_ITEM_ID_KANBAN,
   MENU_ITEM_ID_MINIMIZE,
+  MENU_ITEM_ID_SETTINGS,
   installKeydownIntercepts,
   menuItemIdsToSuspend,
   navigationClearsRecording,
@@ -304,6 +306,11 @@ const currentInterceptBindings = (): KeydownInterceptBindings =>
 // `onChange`, never per keystroke. Normalized through the shared helper so an unknown value from a
 // hand-edited settings.json reads as the default `app-first` — i.e. as "keep intercepting", which
 // is the direction that leaves the app working.
+// FIRST-READ STALENESS IS BENIGN, and the ordering is what makes it so: `settingsStore.init()` runs
+// in `whenReady` well before `createWindow` → `buildAppMenu`, whose trailing `syncMenuForStandDown`
+// is the earliest possible read of this memo — so the value it latches is already the user's saved
+// policy, never DEFAULT_SETTINGS, and every later change arrives on `onChange`. The memo can
+// therefore only ever hold what settings.json says.
 let interceptPolicy: TerminalShortcutPolicy | null = null
 const currentInterceptPolicy = (): TerminalShortcutPolicy =>
   (interceptPolicy ??= normalizeTerminalShortcutPolicy(settingsStore.get().terminalShortcutPolicy))
@@ -529,7 +536,13 @@ function buildAppMenu(win: BrowserWindow): void {
   const send = (channel: string): void => {
     if (!win.isDestroyed()) win.webContents.send(channel)
   }
+  // ONE object, placed into BOTH templates below (mac's app menu, off-mac's own `Settings` menu),
+  // so `MENU_ITEM_ID_SETTINGS` resolves on every platform — which is why `menuItemIdsToSuspend`
+  // lists it unconditionally. ⌘, is an ordinary registry command (`app.settings`), not an
+  // intercepted chord: the menu just takes it above the page, and disabling this item under the
+  // stand-down is the only way it can reach a focused terminal.
   const settingsItem: Electron.MenuItemConstructorOptions = {
+    id: MENU_ITEM_ID_SETTINGS,
     label: isMac ? 'Settings…' : 'Settings',
     accelerator: 'CmdOrCtrl+,',
     click: () => send(IPC.appOpenSettings)
@@ -543,6 +556,12 @@ function buildAppMenu(win: BrowserWindow): void {
     // so a reload only re-hydrates the canvas from the workspace store — it never drops a session
     // (same path the crash-reload policy uses). No interceptor claims ⌘R, so the accelerator is
     // honest (unlike ⌘0, which `installKeydownIntercepts` owns for zoom-to-100%).
+    //
+    // These two carry NO id and are the NAMED EXCEPTION to the stand-down (see
+    // `menuItemIdsToSuspend`): ⌘R / ⌘⇧R keep working over a focused terminal under terminal-first,
+    // because a renderer wedged badly enough to stop dispatching keys is exactly when the user
+    // needs the lever — and the reload is also what resets `terminalFocused` / `shortcutRecording`
+    // in main. Do not "complete" the suspend list with them.
     { role: 'reload' },
     { role: 'forceReload' },
     { role: 'toggleDevTools' },
@@ -562,6 +581,11 @@ function buildAppMenu(win: BrowserWindow): void {
       click: () => send(IPC.appFitView)
     },
     {
+      // `viewSubmenu` goes into BOTH templates, so this id resolves on every platform (the same
+      // reason `menuItemIdsToSuspend` lists it unconditionally). ⌘⇧B is a registry command
+      // (`view.kanbanToggle`) the menu happens to own above the page; suspending the item is what
+      // lets a terminal-first user's ⌘⇧B reach the shell like every other chord.
+      id: MENU_ITEM_ID_KANBAN,
       label: 'Toggle Kanban Board',
       accelerator: 'CmdOrCtrl+Shift+B',
       click: () => send(IPC.appToggleKanban)
@@ -666,6 +690,12 @@ function buildAppMenu(win: BrowserWindow): void {
  * nothing matches) → xterm → the PTY. That is what makes "everything reaches the shell" true for
  * ⌘M and Ctrl+W too, not just for ⌘0 and mac's ⌘W.
  *
+ * The list is `menuItemIdsToSuspend` and it also carries **Toggle Kanban Board (⌘⇧B)** and
+ * **Settings (⌘,)** on every platform. Those two are not intercepted chords at all — they are
+ * ordinary registry commands the menu simply takes above the page, which is why the dispatcher
+ * never sees them and could not stand them down itself. **Reload (⌘R / ⌘⇧R) is the named
+ * exception** and stays live while stood down; see `menuItemIdsToSuspend`'s comment for why.
+ *
  * Called from every place the stood-down answer can change — the `ui:terminal-focus` receiver, the
  * policy recompute in `settingsStore.onChange`, `clearRendererKeyState`, and the end of
  * `buildAppMenu` (a rebuild resets `enabled`). NEVER per keystroke: this is a menu mutation, and
@@ -676,8 +706,9 @@ function buildAppMenu(win: BrowserWindow): void {
  * where the app still works — the cost is that a silent id drift is invisible, which is why both
  * sides of the lookup use the same exported constants rather than string literals.
  *
- * KNOWN COST, deliberate: while a terminal is focused under terminal-first, Window ▸ Minimize is
- * greyed out to the MOUSE as well. It re-enables the moment focus leaves the terminal (and the
+ * KNOWN COST, deliberate: while a terminal is focused under terminal-first, every suspended item —
+ * Window ▸ Minimize, View ▸ Toggle Kanban Board, Settings, and off-mac Window ▸ Close — is greyed
+ * out to the MOUSE as well. They re-enable the moment focus leaves the terminal (and the
  * traffic-light button is unaffected), so this is a visible but self-healing trade. The alternative
  * — rebuilding the whole menu without those accelerators on every focus change — costs a menu
  * rebuild per click between the canvas and a terminal, and closes any menu the user has open.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -91,9 +91,14 @@ import { setMainWindow, getMainWindow, sendToMain, closeAction, createCrashReloa
 import {
   installKeydownIntercepts,
   navigationClearsRecording,
+  policyStandsDown,
   resolveInterceptBindings,
   type KeydownInterceptBindings
 } from './keydown-intercept'
+import {
+  normalizeTerminalShortcutPolicy,
+  type TerminalShortcutPolicy
+} from '../shared/keybindings'
 import {
   initNotchHud,
   applyNotchHudSettings,
@@ -290,23 +295,47 @@ const interceptIsMac = process.platform === 'darwin'
 let interceptBindings: KeydownInterceptBindings | null = null
 const currentInterceptBindings = (): KeydownInterceptBindings =>
   (interceptBindings ??= resolveInterceptBindings(settingsStore.get().keybindings, interceptIsMac))
+// The user's terminal-shortcut policy, memoized on exactly the same terms and for exactly the same
+// reason as `interceptBindings` above: lazily on first keystroke (module load is before
+// `settingsStore.init()`, where every stored value still reads as DEFAULT_SETTINGS), recomputed on
+// `onChange`, never per keystroke. Normalized through the shared helper so an unknown value from a
+// hand-edited settings.json reads as the default `app-first` — i.e. as "keep intercepting", which
+// is the direction that leaves the app working.
+let interceptPolicy: TerminalShortcutPolicy | null = null
+const currentInterceptPolicy = (): TerminalShortcutPolicy =>
+  (interceptPolicy ??= normalizeTerminalShortcutPolicy(settingsStore.get().terminalShortcutPolicy))
 settingsStore.onChange((s) => {
   interceptBindings = resolveInterceptBindings(s.keybindings, interceptIsMac)
+  interceptPolicy = normalizeTerminalShortcutPolicy(s.terminalShortcutPolicy)
 })
-// Settings' shortcut recorder is armed: stand every intercept down so the chord the user presses
-// reaches the recorder. Without it, recording ⌘W CLOSES THE SELECTED NODES — a claimed chord never
-// reaches the page, so the recorder's own preventDefault cannot save it.
-// A module-level `let` read through a closure, exactly like `interceptBindings` above: the window
-// is created later and can be recreated (macOS dock reopen), so nothing may capture a value.
-// FAIL-SAFE DIRECTION: every uncertainty resolves to `false` (intercepts on). The alternative is
-// ⌘W/⌘M/⌘0 dead app-wide with no component left alive to release the bit, so EVERY way the page
-// that armed it can stop existing owes a clear — `createWindow` wires three (window `closed`,
-// `render-process-gone`, and a main-frame navigation, i.e. ⌘R). That is three known paths, not a
-// proof of exhaustiveness: a fourth would show up as "⌘W stopped working after I did X", so add
-// its reset beside the others rather than assuming this list is closed.
+// TWO bits the RENDERER owns and main only mirrors. Both are module-level `let`s read through a
+// closure, exactly like `interceptBindings` above: the window is created later and can be recreated
+// (macOS dock reopen), so nothing may capture a value.
+//
+// 1. `shortcutRecording` — Settings' shortcut recorder is armed: stand every intercept down so the
+//    chord the user presses reaches the recorder. Without it, recording ⌘W CLOSES THE SELECTED
+//    NODES — a claimed chord never reaches the page, so the recorder's own preventDefault cannot
+//    save it.
+// 2. `terminalFocused` — an xterm holds keyboard focus, which under the `terminal-first` policy
+//    means the intercepts stand down so the terminal gets the chord. `before-input-event` fires
+//    before any renderer handler could answer, so the answer has to be sitting here in advance;
+//    `renderer/lib/terminalFocusMirror.ts` keeps it current and change-deduped.
+//
+// FAIL-SAFE DIRECTION, and it is the same one for both: every uncertainty resolves to `false`
+// (intercepts ON — the app as it behaved before either feature). The alternative is ⌘W/⌘M/⌘0
+// silently handed back to the application MENU app-wide, with no component left alive to release
+// the bit. So EVERY way the page that set one can stop existing owes a clear, and `createWindow`
+// wires three — window `closed`, `render-process-gone`, and a main-frame navigation (⌘R). That is
+// three known paths, not a proof of exhaustiveness: a fourth would show up as "⌘W stopped working
+// after I did X", so add its reset beside the others rather than assuming this list is closed.
+// The two bits are cleared TOGETHER, by one function called at all three sites, because they die
+// for the same reason (the page is gone) and a reset that remembered only one of them would be
+// invisible until a user hit the policy path.
 let shortcutRecording = false
-const clearShortcutRecording = (): void => {
+let terminalFocused = false
+const clearRendererKeyState = (): void => {
   shortcutRecording = false
+  terminalFocused = false
 }
 const sshStore = new SshStore()
 const ptyManager = new PtyManager()
@@ -638,11 +667,11 @@ function createWindow(): BrowserWindow {
     // client to co-attach to that node would inherit a frozen terminal. The tmux sessions
     // themselves keep running, exactly as they do on quit (killAll).
     ptyManager.dropClient(presenceId)
-    // The window that armed the recorder is gone, so nothing can ever disarm it. Leaving the bit
-    // set would suppress ⌘W/⌘M/⌘0 for the NEXT window too (the flag outlives the window; a dock
-    // reopen builds a fresh one). Same shape as the dropClient above: state this window owned,
-    // released where its departure is observed.
-    clearShortcutRecording()
+    // The window that armed the recorder — or reported a focused terminal — is gone, so nothing
+    // can ever release either bit. Leaving one set would suppress ⌘W/⌘M/⌘0 for the NEXT window too
+    // (the flags outlive the window; a dock reopen builds a fresh one). Same shape as the
+    // dropClient above: state this window owned, released where its departure is observed.
+    clearRendererKeyState()
   })
   // A crashed/killed renderer is the same story, minus the window: drop its subscriptions so the
   // reloaded renderer reattaches to live sessions instead of inheriting the dead one's state.
@@ -653,9 +682,10 @@ function createWindow(): BrowserWindow {
   const crashReload = createCrashReloadPolicy()
   win.webContents.on('render-process-gone', (_event, details) => {
     ptyManager.dropClient(presenceId)
-    // A dead renderer sends no disarm. The reloaded page mounts no recorder, so without this the
-    // user would come back to an app where ⌘W does nothing at all.
-    clearShortcutRecording()
+    // A dead renderer sends no disarm and no focus-lost report. The reloaded page mounts no
+    // recorder and no terminal, so without this the user would come back to an app where ⌘W does
+    // nothing at all (recording) or minimizes the window (stood down).
+    clearRendererKeyState()
     if (quitting || win.isDestroyed()) return
     const action = crashReload(details.reason, Date.now())
     if (action === 'reload') {
@@ -710,16 +740,26 @@ function createWindow(): BrowserWindow {
   // resetZoom) and forward each to the renderer instead. The decision — and, importantly, what it
   // must REFUSE — is in `keydown-intercept.ts`, where it can be pressed by a test. The first two
   // are the user's effective `node.toggleMarkdown` / `node.close` bindings (⌘0 is not remappable).
-  installKeydownIntercepts(win, currentInterceptBindings, interceptIsMac, () => shortcutRecording)
+  // The two suspensions are separate thunks on purpose (see `installKeydownIntercepts`): the
+  // recorder suspends ALWAYS, the policy only while the mirror says a terminal has focus. Both are
+  // read per keystroke — the settings memo and the mirror both change under a live window.
+  installKeydownIntercepts(
+    win,
+    currentInterceptBindings,
+    interceptIsMac,
+    () => shortcutRecording,
+    () => policyStandsDown(currentInterceptPolicy(), terminalFocused)
+  )
 
-  // The THIRD way the page that armed a recorder can go away: a reload. The View menu above
-  // restores `{role:'reload'}` / `{role:'forceReload'}`, and ⌘R/⌘⇧R are accelerators — handled
-  // above the page, so the recorder cannot preventDefault its way out of one, and a same-process
-  // reload fires neither `closed` nor `render-process-gone`. `navigationClearsRecording` is the
-  // (tested) filter: a same-document navigation is the SAME page with the recorder still armed,
-  // and a subframe is not this page at all.
+  // The THIRD way the page that armed a recorder (or reported terminal focus) can go away: a
+  // reload. The View menu above restores `{role:'reload'}` / `{role:'forceReload'}`, and ⌘R/⌘⇧R are
+  // accelerators — handled above the page, so the recorder cannot preventDefault its way out of
+  // one, and a same-process reload fires neither `closed` nor `render-process-gone`.
+  // `navigationClearsRecording` is the (tested) filter: a same-document navigation is the SAME page
+  // with the recorder still armed and the terminal still focused, and a subframe is not this page
+  // at all.
   win.webContents.on('did-start-navigation', (details) => {
-    if (navigationClearsRecording(details)) clearShortcutRecording()
+    if (navigationClearsRecording(details)) clearRendererKeyState()
   })
 
   // Open external links in the system browser — only safe schemes (no file://, no custom
@@ -954,6 +994,16 @@ app.whenReady().then(async () => {
   ipcMain.on(IPC.uiShortcutRecording, (event, active: boolean) => {
     if (getMainWindow()?.webContents.id !== event.sender.id) return
     shortcutRecording = active === true
+  })
+
+  // The terminal-focus mirror, under the SAME sender guard and for a sharper version of the same
+  // reason: a <webview> guest is a webContents in this process, and this bit decides whether the
+  // window claims ⌘W/⌘M/⌘0 at all — an arbitrary page in a browser node could otherwise hand
+  // itself the window's shortcuts by claiming a terminal is focused. `focused === true` so a
+  // malformed payload reads as NOT focused, the fail-safe direction (intercepts on).
+  ipcMain.on(IPC.uiTerminalFocus, (event, focused: boolean) => {
+    if (getMainWindow()?.webContents.id !== event.sender.id) return
+    terminalFocused = focused === true
   })
 
   // Bring the window forward after a file is dropped into a terminal. On macOS a drag-drop from

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -3,7 +3,9 @@ import { IPC } from '../shared/ipc'
 import { MAIN_INTERCEPTED_COMMAND_IDS } from '../shared/keybindings'
 import {
   MENU_ITEM_ID_CLOSE,
+  MENU_ITEM_ID_KANBAN,
   MENU_ITEM_ID_MINIMIZE,
+  MENU_ITEM_ID_SETTINGS,
   installKeydownIntercepts,
   keydownIntercept,
   menuItemIdsToSuspend,
@@ -491,12 +493,45 @@ describe('terminal-first stands every interception down while a terminal is focu
  * menu items for exactly as long as the intercepts are stood down, and this list is which ones.
  */
 describe('menuItemIdsToSuspend', () => {
-  it('is minimize everywhere and, off-mac, close as well', () => {
+  it('suspends minimize, kanban and settings everywhere, and close only off-mac', () => {
     // The mac template has no `{role:'close'}` at all (Window ▸ Minimize / Zoom / Front), which is
     // exactly why `keydownIntercept` is ⌘W's only handler there. Listing a close id on mac would
     // be a no-op today and a silent lie the day someone adds the role.
-    expect(menuItemIdsToSuspend(true)).toEqual([MENU_ITEM_ID_MINIMIZE])
-    expect(menuItemIdsToSuspend(false)).toEqual([MENU_ITEM_ID_MINIMIZE, MENU_ITEM_ID_CLOSE])
+    //
+    // Kanban and Settings, by contrast, ARE on both templates — `buildAppMenu` builds one
+    // `viewSubmenu` array and one `settingsItem` object and puts each into the mac and the
+    // Windows/Linux template — so an asymmetry for them would be the lie instead.
+    expect(menuItemIdsToSuspend(true)).toEqual([
+      MENU_ITEM_ID_MINIMIZE,
+      MENU_ITEM_ID_KANBAN,
+      MENU_ITEM_ID_SETTINGS
+    ])
+    expect(menuItemIdsToSuspend(false)).toEqual([
+      MENU_ITEM_ID_MINIMIZE,
+      MENU_ITEM_ID_KANBAN,
+      MENU_ITEM_ID_SETTINGS,
+      MENU_ITEM_ID_CLOSE
+    ])
+  })
+
+  // ⌘⇧B and ⌘, are ordinary registry commands, not intercepted chords — the menu simply takes them
+  // above the page, so under terminal-first they were the two chords that did NOT reach the shell.
+  // Membership is the whole fix, which is why it is pinned per-id rather than only by the arrays.
+  it('carries the two menu-owned registry chords on both platforms', () => {
+    for (const isMac of [true, false]) {
+      expect(menuItemIdsToSuspend(isMac)).toContain(MENU_ITEM_ID_KANBAN)
+      expect(menuItemIdsToSuspend(isMac)).toContain(MENU_ITEM_ID_SETTINGS)
+    }
+  })
+
+  // The named exception. `{role:'reload'}` / `{role:'forceReload'}` keep their accelerators while
+  // stood down ON PURPOSE: a wedged renderer is exactly when ⌘R is needed, and a main-frame
+  // navigation is one of the three sites that reset `terminalFocused` / `shortcutRecording`. There
+  // is no id to assert the absence of, so this pins the LENGTH — a fourth/fifth entry appearing
+  // here (a reload id being the likely one) reds this test and sends the author to the comment.
+  it('does not grow silently — reload is deliberately not suspended', () => {
+    expect(menuItemIdsToSuspend(true)).toHaveLength(3)
+    expect(menuItemIdsToSuspend(false)).toHaveLength(4)
   })
 
   // The ids are the ONLY link between `buildAppMenu`'s template and the sync that disables the
@@ -504,9 +539,14 @@ describe('menuItemIdsToSuspend', () => {
   // which looks exactly like the feature working. Both sides import these constants, so the typo
   // class cannot happen; this pins that they are distinct and non-empty.
   it('the ids are distinct and non-empty', () => {
-    expect(MENU_ITEM_ID_MINIMIZE).toBeTruthy()
-    expect(MENU_ITEM_ID_CLOSE).toBeTruthy()
-    expect(MENU_ITEM_ID_MINIMIZE).not.toBe(MENU_ITEM_ID_CLOSE)
+    const ids = [
+      MENU_ITEM_ID_MINIMIZE,
+      MENU_ITEM_ID_CLOSE,
+      MENU_ITEM_ID_KANBAN,
+      MENU_ITEM_ID_SETTINGS
+    ]
+    for (const id of ids) expect(id).toBeTruthy()
+    expect(new Set(ids).size).toBe(ids.length)
   })
 })
 

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -5,6 +5,7 @@ import {
   installKeydownIntercepts,
   keydownIntercept,
   navigationClearsRecording,
+  policyStandsDown,
   resolveInterceptBindings,
   type KeydownInterceptBindings,
   type KeydownInterceptInput,
@@ -59,9 +60,11 @@ function press(
 ): { prevented: boolean; sent: string[] } {
   const isMac = opts.isMac ?? true
   const bindings = opts.bindings ?? (isMac ? DEFAULTS : DEFAULTS_PC)
-  // Not recording: the ordinary state of the app, and the baseline every case below asserts
-  // against. The armed state has its own describe block at the bottom of this file.
-  const seam = install(() => bindings, isMac, () => false)
+  // Neither recording nor stood down: the ordinary state of the app, and the baseline every case
+  // below asserts against. Each suspended state has its own describe block at the bottom of this
+  // file. Both thunks are spelled out rather than defaulted, so a THIRD suspension added to
+  // `installKeydownIntercepts` cannot silently inherit "off" here.
+  const seam = install(() => bindings, isMac, () => false, () => false)
   seam.fire(over)
   return { prevented: seam.prevented.length > 0, sent: seam.sent }
 }
@@ -74,7 +77,8 @@ function press(
 function install(
   getBindings: () => KeydownInterceptBindings,
   isMac: boolean,
-  isRecording: () => boolean
+  isRecording: () => boolean,
+  isStoodDown: () => boolean
 ): { fire: (over?: Partial<KeydownInterceptInput>) => void; prevented: string[]; sent: string[] } {
   let handler:
     | ((event: { preventDefault(): void }, input: KeydownInterceptInput) => void)
@@ -91,7 +95,7 @@ function install(
       }
     }
   }
-  installKeydownIntercepts(win, getBindings, isMac, isRecording)
+  installKeydownIntercepts(win, getBindings, isMac, isRecording, isStoodDown)
   if (!handler) throw new Error('installKeydownIntercepts registered no before-input-event listener')
   const fire = (over: Partial<KeydownInterceptInput> = {}): void => {
     const i = input(over)
@@ -346,7 +350,7 @@ describe('binding-driven intercept', () => {
 describe('an armed shortcut recorder suspends every interception', () => {
   it('suppresses while armed and resumes on disarm', () => {
     let recording = true
-    const seam = install(() => DEFAULTS, true, () => recording)
+    const seam = install(() => DEFAULTS, true, () => recording, () => false)
     seam.fire({ meta: true, key: 'w', code: 'KeyW' })
     seam.fire({ meta: true, key: 'm', code: 'KeyM' })
     seam.fire({ meta: true, code: 'Digit0' })
@@ -368,7 +372,7 @@ describe('an armed shortcut recorder suspends every interception', () => {
   // This mirrors index.ts's wiring exactly — the listener runs the same predicate.
   it('a reload while armed restores interception; an in-page navigation does not', () => {
     let recording = true
-    const seam = install(() => DEFAULTS, true, () => recording)
+    const seam = install(() => DEFAULTS, true, () => recording, () => false)
     const onNavigation = (d: { isMainFrame: boolean; isSameDocument: boolean }): void => {
       if (navigationClearsRecording(d)) recording = false
     }
@@ -397,10 +401,107 @@ describe('an armed shortcut recorder suspends every interception', () => {
     // The bit lives in a module-level `let` in index.ts that the renderer flips over IPC long
     // after the window was created; a captured boolean would make the whole feature inert.
     let recording = false
-    const seam = install(() => DEFAULTS, true, () => recording)
+    const seam = install(() => DEFAULTS, true, () => recording, () => false)
     seam.fire({ meta: true, key: 'w', code: 'KeyW' })
     recording = true
     seam.fire({ meta: true, key: 'w', code: 'KeyW' })
     expect(seam.sent).toEqual([IPC.appCloseNode])
+  })
+})
+
+/**
+ * The SECOND suspension, and a different fact from the first. `terminal-first` is the user saying
+ * "while I am typing in a terminal, the terminal gets the chord" — so main must stop claiming keys
+ * it would otherwise steal from the page, for exactly as long as an xterm holds keyboard focus.
+ *
+ * It is a separate thunk rather than an `||` folded into `isRecording` because the two suspend for
+ * unrelated reasons and on unrelated schedules: recording is a Settings dialog being armed and
+ * suspends ALWAYS, the policy one is a live focus mirror and suspends only while the mirror says a
+ * terminal is focused. One boolean would make "recording still works when the policy is off" — the
+ * first case below — untestable, and would hide a future bug where one reason silently ate the
+ * other.
+ */
+describe('terminal-first stands every interception down while a terminal is focused', () => {
+  it('suppresses all three chords while stood down, and resumes when it flips back', () => {
+    let stoodDown = true
+    const seam = install(() => DEFAULTS, true, () => false, () => stoodDown)
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    seam.fire({ meta: true, key: 'm', code: 'KeyM' })
+    seam.fire({ meta: true, code: 'Digit0' })
+    // ⌘0 is in the list on purpose: it is the one chord with no registry command behind it, so a
+    // stand-down written against `getBindings` alone would leave it claimed — and the canvas would
+    // still snap to 100% under a user who asked their terminal to own the key.
+    // Not swallowed either: `preventDefault` takes the key from the PAGE as well as the menu, and
+    // the page is who the terminal-first policy is standing down FOR, so the suppression must
+    // return before it rather than merely skip the send.
+    expect(seam.prevented).toEqual([])
+    expect(seam.sent).toEqual([])
+    // Focus leaves the terminal (or the user switches back to app-first): every chord is ours again.
+    stoodDown = false
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    seam.fire({ meta: true, key: 'm', code: 'KeyM' })
+    seam.fire({ meta: true, code: 'Digit0' })
+    expect(seam.sent).toEqual([IPC.appCloseNode, IPC.appToggleMarkdown, IPC.appZoomActualSize])
+    expect(seam.prevented).toEqual(['KeyW', 'KeyM', 'Digit0'])
+  })
+
+  it('the two suspensions are independent — either one alone suppresses', () => {
+    let recording = false
+    let stoodDown = false
+    const seam = install(() => DEFAULTS, true, () => recording, () => stoodDown)
+    // Recording alone, with the policy off: the Settings recorder must keep working for a user who
+    // never chose terminal-first (i.e. everybody, by default).
+    recording = true
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([])
+    // Stood down alone, with no recorder armed: the policy suspension does not depend on the other.
+    recording = false
+    stoodDown = true
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([])
+    // Neither: back to the ordinary app.
+    stoodDown = false
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([IPC.appCloseNode])
+  })
+
+  it('is read per event, not captured at install time', () => {
+    // Same reason as the recording bit's twin test: the focus mirror flips a module-level `let` in
+    // index.ts over IPC while the window lives. A captured boolean would make the policy inert for
+    // whichever value happened to be true at `createWindow` time — i.e. always inert, since the
+    // window is built before any renderer has reported focus.
+    let stoodDown = false
+    const seam = install(() => DEFAULTS, true, () => false, () => stoodDown)
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    stoodDown = true
+    seam.fire({ meta: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([IPC.appCloseNode])
+  })
+})
+
+/**
+ * The composition index.ts hands to the 5th parameter, as a pure function so it can be pressed.
+ * The BYTE-IDENTICAL claim of this whole change lives here: on the shipped default (`app-first`)
+ * it is false whatever the mirror says, so nothing about the intercepts changes for a user who
+ * never touched the setting — including one whose renderer is reporting terminal focus all day.
+ */
+describe('policyStandsDown', () => {
+  it('stands down only under terminal-first, and only while a terminal is focused', () => {
+    expect(policyStandsDown('terminal-first', true)).toBe(true)
+    expect(policyStandsDown('terminal-first', false)).toBe(false)
+  })
+
+  it('app-first never stands down, focused or not', () => {
+    expect(policyStandsDown('app-first', true)).toBe(false)
+    expect(policyStandsDown('app-first', false)).toBe(false)
+  })
+
+  // The fail-safe direction, stated as a test: main starts at `terminalFocused = false` and every
+  // reset returns it there, so a mirror that never reported — or a page that died mid-report —
+  // leaves the intercepts ON (the pre-feature behaviour), never off.
+  it('the reset value (not focused) means intercepts stay on under either policy', () => {
+    for (const policy of ['app-first', 'terminal-first'] as const) {
+      expect(policyStandsDown(policy, false)).toBe(false)
+    }
   })
 })

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { IPC } from '../shared/ipc'
 import { MAIN_INTERCEPTED_COMMAND_IDS } from '../shared/keybindings'
 import {
+  MENU_ITEM_ID_CLOSE,
+  MENU_ITEM_ID_MINIMIZE,
   installKeydownIntercepts,
   keydownIntercept,
+  menuItemIdsToSuspend,
   navigationClearsRecording,
   policyStandsDown,
   resolveInterceptBindings,
@@ -476,6 +479,34 @@ describe('terminal-first stands every interception down while a terminal is focu
     stoodDown = true
     seam.fire({ meta: true, key: 'w', code: 'KeyW' })
     expect(seam.sent).toEqual([IPC.appCloseNode])
+  })
+})
+
+/**
+ * Standing the INTERCEPTS down is only half of "the terminal gets the chord". The other half is the
+ * application MENU, which is handled above the page either way — so a stand-down that only stopped
+ * `preventDefault` would hand ⌘M to `{role:'minimize'}` and, on Windows/Linux, Ctrl+W to
+ * `{role:'close'}`. For a terminal-first user that is strictly WORSE than not having the policy:
+ * a Linux user's readline kill-word would close their window. `index.ts` therefore disables those
+ * menu items for exactly as long as the intercepts are stood down, and this list is which ones.
+ */
+describe('menuItemIdsToSuspend', () => {
+  it('is minimize everywhere and, off-mac, close as well', () => {
+    // The mac template has no `{role:'close'}` at all (Window ▸ Minimize / Zoom / Front), which is
+    // exactly why `keydownIntercept` is ⌘W's only handler there. Listing a close id on mac would
+    // be a no-op today and a silent lie the day someone adds the role.
+    expect(menuItemIdsToSuspend(true)).toEqual([MENU_ITEM_ID_MINIMIZE])
+    expect(menuItemIdsToSuspend(false)).toEqual([MENU_ITEM_ID_MINIMIZE, MENU_ITEM_ID_CLOSE])
+  })
+
+  // The ids are the ONLY link between `buildAppMenu`'s template and the sync that disables the
+  // items — `getMenuItemById` answers `null` for a typo, and the fail-safe there is to do nothing,
+  // which looks exactly like the feature working. Both sides import these constants, so the typo
+  // class cannot happen; this pins that they are distinct and non-empty.
+  it('the ids are distinct and non-empty', () => {
+    expect(MENU_ITEM_ID_MINIMIZE).toBeTruthy()
+    expect(MENU_ITEM_ID_CLOSE).toBeTruthy()
+    expect(MENU_ITEM_ID_MINIMIZE).not.toBe(MENU_ITEM_ID_CLOSE)
   })
 })
 

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -225,13 +225,18 @@ export function policyStandsDown(
 }
 
 /**
- * Menu item ids `buildAppMenu` stamps on the two roles whose ACCELERATORS survive an intercept
+ * Menu item ids `buildAppMenu` stamps on the items whose ACCELERATORS survive an intercept
  * stand-down. Exported constants used by both sides — the template that sets them and the sync that
  * looks them up — because `getMenuItemById` answers `null` for a typo and the fail-safe there is to
  * do nothing, which is indistinguishable from the feature working.
  */
 export const MENU_ITEM_ID_MINIMIZE = 'window-minimize'
 export const MENU_ITEM_ID_CLOSE = 'window-close'
+/** View ▸ Toggle Kanban Board (⌘⇧B). In `viewSubmenu`, which BOTH templates include. */
+export const MENU_ITEM_ID_KANBAN = 'view-kanban-toggle'
+/** The Settings item (⌘,) — mac's app menu, off-mac's own `Settings` menu; ONE `settingsItem`
+ *  object shared by both templates, so the id exists on every platform. */
+export const MENU_ITEM_ID_SETTINGS = 'app-settings'
 
 /**
  * PURE. Which menu items must be disabled while the intercepts are stood down.
@@ -252,13 +257,33 @@ export const MENU_ITEM_ID_CLOSE = 'window-close'
  * stands: nothing here re-enables recording those chords, because a recorder that silently disabled
  * Minimize for the duration of a keypress is a different and worse trade.
  *
- * mac carries only minimize: the mac template has no `{role:'close'}` at all (Window ▸ Minimize /
- * Zoom / Front), which is exactly why `keydownIntercept` is ⌘W's only handler there.
+ * mac carries no CLOSE id: the mac template has no `{role:'close'}` at all (Window ▸ Minimize /
+ * Zoom / Front), which is exactly why `keydownIntercept` is ⌘W's only handler there. Kanban and
+ * Settings are on BOTH platforms — one `viewSubmenu` array and one `settingsItem` object are shared
+ * by the two templates — so they are suspended on both.
+ *
+ * **What suspending kanban/settings actually buys, since neither is an intercepted chord.** ⌘⇧B and
+ * ⌘, are ordinary REGISTRY commands (`view.kanbanToggle` / `app.settings`); the renderer's
+ * dispatcher would resolve them if it ever saw the keydown, but under app-first the MENU takes them
+ * above the page and the dispatcher never runs. Disabling the items removes that theft, so under
+ * terminal-first with a terminal focused the chord reaches the page → the resolver, which REFUSES
+ * it (a terminal context under terminal-first matches only commands flagged `allowInTerminal`, and
+ * that flag is app-first-only) → xterm → the PTY. Without these two ids, terminal-first would
+ * deliver every chord to the shell EXCEPT the two the menu happened to own, which is the same
+ * inconsistency the minimize/close leg exists to remove.
+ *
+ * **RELOAD (⌘R / ⌘⇧R) is deliberately NOT here — named exception, do not "complete" the list.**
+ * `{role:'reload'}` / `{role:'forceReload'}` are the app's crash-recovery lever: a renderer wedged
+ * badly enough to stop dispatching keys is exactly when the user needs them, and a policy that
+ * suspended them would take the lever away precisely in the state that calls for it. The recovery
+ * also depends on the reload actually happening in MAIN — a main-frame navigation is one of the
+ * three sites that reset `terminalFocused`/`shortcutRecording` (see `navigationClearsRecording`),
+ * so suspending reload would strand the very bits a stuck page leaves set. The cost is honest and
+ * small: a terminal-first user's ⌘R reloads the window instead of reaching the shell.
  */
 export function menuItemIdsToSuspend(isMac: boolean): string[] {
-  return isMac
-    ? [MENU_ITEM_ID_MINIMIZE]
-    : [MENU_ITEM_ID_MINIMIZE, MENU_ITEM_ID_CLOSE]
+  const shared = [MENU_ITEM_ID_MINIMIZE, MENU_ITEM_ID_KANBAN, MENU_ITEM_ID_SETTINGS]
+  return isMac ? shared : [...shared, MENU_ITEM_ID_CLOSE]
 }
 
 /** The renderer channel a claimed action is forwarded on. */
@@ -299,9 +324,11 @@ export interface KeydownInterceptTarget {
  * **What this stand-down does NOT buy, and cannot.** It only stops US from taking the key; it has
  * no say over the application MENU, whose accelerators are handled above the page either way. So
  * every menu accelerator is unrecordable while this stands down — including **⌘M**, which
- * `{role:'minimize'}` owns on every platform, and **Ctrl+W** on Windows/Linux, where the Window
- * submenu has a `{role:'close'}`. Pressing one of those into an armed recorder minimizes/closes the
- * window instead of recording. Concretely, the stand-down fully delivers **⌘0** everywhere and
+ * `{role:'minimize'}` owns on every platform, **⌘⇧B** and **⌘,** (View ▸ Toggle Kanban Board and
+ * Settings, also every platform), and **Ctrl+W** on Windows/Linux, where the Window submenu has a
+ * `{role:'close'}`. Pressing one of those into an armed recorder minimizes/closes the window, opens
+ * the board or opens Settings instead of recording. Concretely, the stand-down fully delivers
+ * **⌘0** everywhere and
  * **⌘W on macOS** (neither is in the menu), and cannot deliver ⌘M anywhere. Fixing that means
  * suspending the MENU while recording (`Menu.setApplicationMenu(null)` around the armed window, or
  * per-item `enabled:false`) — a change to `buildAppMenu`, not to this module. Known limitation;
@@ -318,8 +345,9 @@ export interface KeydownInterceptTarget {
  *
  * **The policy stand-down DOES get the menu leg the recording one does not** — the two cases are
  * different and the paragraph above stays true for recording. `index.ts`'s `syncMenuForStandDown`
- * disables `{role:'minimize'}` (and, off-mac, `{role:'close'}`) for exactly as long as
- * `isStoodDown` is true, via the ids in `menuItemIdsToSuspend` below. It has to: not calling
+ * disables every item in `menuItemIdsToSuspend` below — `{role:'minimize'}`, Toggle Kanban Board
+ * and Settings on all platforms, plus off-mac `{role:'close'}`, with RELOAD deliberately left out —
+ * for exactly as long as `isStoodDown` is true. It has to: not calling
  * `preventDefault` hands the key to the page and, failing that, to the menu, so without the menu
  * leg a terminal-first user's ⌘M would minimize the window and their Ctrl+W — readline's kill-word
  * — would CLOSE it on Windows/Linux, which is strictly worse than not having the policy. With the

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -224,6 +224,43 @@ export function policyStandsDown(
   return policy === 'terminal-first' && terminalFocused
 }
 
+/**
+ * Menu item ids `buildAppMenu` stamps on the two roles whose ACCELERATORS survive an intercept
+ * stand-down. Exported constants used by both sides — the template that sets them and the sync that
+ * looks them up — because `getMenuItemById` answers `null` for a typo and the fail-safe there is to
+ * do nothing, which is indistinguishable from the feature working.
+ */
+export const MENU_ITEM_ID_MINIMIZE = 'window-minimize'
+export const MENU_ITEM_ID_CLOSE = 'window-close'
+
+/**
+ * PURE. Which menu items must be disabled while the intercepts are stood down.
+ *
+ * **Why the stand-down needs a menu leg at all.** `preventDefault` is the only lever this module
+ * has, and NOT calling it hands the key to the page *and*, if the page ignores it, to the menu —
+ * whose accelerators are handled above the page either way. So a stand-down that stopped at the
+ * intercept would deliver ⌘0 and (on macOS) ⌘W to the terminal, and hand ⌘M to
+ * `{role:'minimize'}` and, on Windows/Linux, Ctrl+W to `{role:'close'}`. For a terminal-first user
+ * that is strictly WORSE than not having the policy: Ctrl+W is readline's kill-word, and a Linux
+ * user pressing it would close their window. Disabling the item suppresses its accelerator, so the
+ * chord falls through to the page → the renderer's dispatcher (terminal context, terminal-first:
+ * nothing matches) → xterm → the PTY. That is what completes "under terminal-first everything
+ * reaches the shell", ⌘M included.
+ *
+ * **This is NOT the recording stand-down's story** — keep the two apart. Recording is a transient,
+ * user-initiated arming of a dialog, and its ⌘M limitation (documented on `installKeydownIntercepts`)
+ * stands: nothing here re-enables recording those chords, because a recorder that silently disabled
+ * Minimize for the duration of a keypress is a different and worse trade.
+ *
+ * mac carries only minimize: the mac template has no `{role:'close'}` at all (Window ▸ Minimize /
+ * Zoom / Front), which is exactly why `keydownIntercept` is ⌘W's only handler there.
+ */
+export function menuItemIdsToSuspend(isMac: boolean): string[] {
+  return isMac
+    ? [MENU_ITEM_ID_MINIMIZE]
+    : [MENU_ITEM_ID_MINIMIZE, MENU_ITEM_ID_CLOSE]
+}
+
 /** The renderer channel a claimed action is forwarded on. */
 export function keydownInterceptChannel(action: KeydownInterceptAction): string {
   if (action === 'toggle-markdown') return IPC.appToggleMarkdown
@@ -278,6 +315,18 @@ export interface KeydownInterceptTarget {
  * recorder still works for an app-first user" — the overwhelmingly common case — impossible to
  * assert. Both are checked BEFORE `preventDefault` for the same reason: a claimed chord never
  * reaches the page at all, and the page is exactly who terminal-first stands down FOR.
+ *
+ * **The policy stand-down DOES get the menu leg the recording one does not** — the two cases are
+ * different and the paragraph above stays true for recording. `index.ts`'s `syncMenuForStandDown`
+ * disables `{role:'minimize'}` (and, off-mac, `{role:'close'}`) for exactly as long as
+ * `isStoodDown` is true, via the ids in `menuItemIdsToSuspend` below. It has to: not calling
+ * `preventDefault` hands the key to the page and, failing that, to the menu, so without the menu
+ * leg a terminal-first user's ⌘M would minimize the window and their Ctrl+W — readline's kill-word
+ * — would CLOSE it on Windows/Linux, which is strictly worse than not having the policy. With the
+ * items disabled the chord completes the trip it was promised: page → the renderer's dispatcher
+ * (terminal context, terminal-first, nothing matches) → xterm → the PTY. Recording keeps the
+ * limitation because a recorder that greyed out Minimize for the duration of a keypress is a worse
+ * trade than an unrecordable ⌘M.
  *
  * **The stand-down leg cannot be more reliable than the mirror behind it**, and the mirror is a
  * renderer reporting over fire-and-forget IPC. Every uncertainty therefore resolves to NOT stood

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -1,5 +1,9 @@
 import { IPC } from '../shared/ipc'
-import { getEffectiveBindings, sanitizeKeybindingOverrides } from '../shared/keybindings'
+import {
+  getEffectiveBindings,
+  sanitizeKeybindingOverrides,
+  type TerminalShortcutPolicy
+} from '../shared/keybindings'
 import { matchesShortcut } from '../shared/shortcut'
 
 /**
@@ -195,6 +199,31 @@ export function navigationClearsRecording(details: {
   return details.isMainFrame && !details.isSameDocument
 }
 
+/**
+ * PURE. Does the user's `terminalShortcutPolicy` mean this window must stop claiming chords right
+ * now? The composition `index.ts` hands to `installKeydownIntercepts`' 5th parameter, exported so
+ * it can be pressed instead of living untested inside a closure in a 5000-line file.
+ *
+ * **Both halves are refusals and both matter.** `app-first` is the shipped default, so it must be
+ * false whatever the mirror reports — that is the byte-identical guarantee of this feature: a user
+ * who never touched the setting sees exactly the pre-feature intercepts, even though their
+ * renderer is reporting terminal focus all day. And `terminalFocused` is a MIRROR of the
+ * renderer's `document.activeElement`, which is why `false` is its reset value everywhere: a page
+ * that died mid-report, a window that never had one, a reload — all resolve to "intercepts on",
+ * never to "intercepts off with nothing alive to turn them back on".
+ *
+ * Why the policy is read here rather than the intercepts simply being uninstalled under
+ * `terminal-first`: the policy is a live setting and the focus changes per keystroke, so there is
+ * nothing static to install against — and an app-first user's window must not be a different
+ * window from a terminal-first user's.
+ */
+export function policyStandsDown(
+  policy: TerminalShortcutPolicy,
+  terminalFocused: boolean
+): boolean {
+  return policy === 'terminal-first' && terminalFocused
+}
+
 /** The renderer channel a claimed action is forwarded on. */
 export function keydownInterceptChannel(action: KeydownInterceptAction): string {
   if (action === 'toggle-markdown') return IPC.appToggleMarkdown
@@ -240,15 +269,32 @@ export interface KeydownInterceptTarget {
  * suspending the MENU while recording (`Menu.setApplicationMenu(null)` around the armed window, or
  * per-item `enabled:false`) — a change to `buildAppMenu`, not to this module. Known limitation;
  * see the PR body.
+ *
+ * `isStoodDown` is the SECOND suspension and the same shape again, but a different fact:
+ * `policyStandsDown(policy, terminalFocused)` — the user chose `terminal-first` AND an xterm
+ * currently holds keyboard focus in the renderer. It is a separate parameter rather than an `||`
+ * folded into `isRecording` because the two suspend for unrelated reasons on unrelated schedules
+ * (a Settings dialog being armed vs. a live focus mirror), and one boolean would make "the
+ * recorder still works for an app-first user" — the overwhelmingly common case — impossible to
+ * assert. Both are checked BEFORE `preventDefault` for the same reason: a claimed chord never
+ * reaches the page at all, and the page is exactly who terminal-first stands down FOR.
+ *
+ * **The stand-down leg cannot be more reliable than the mirror behind it**, and the mirror is a
+ * renderer reporting over fire-and-forget IPC. Every uncertainty therefore resolves to NOT stood
+ * down (intercepts on = the pre-feature app): `index.ts` starts `terminalFocused` false and every
+ * way the page can stop existing resets it there. Getting that direction backwards would leave ⌘W
+ * and ⌘M with the application MENU — closing and minimizing the window — with no live component
+ * able to correct it.
  */
 export function installKeydownIntercepts(
   win: KeydownInterceptTarget,
   getBindings: () => KeydownInterceptBindings,
   isMac: boolean,
-  isRecording: () => boolean
+  isRecording: () => boolean,
+  isStoodDown: () => boolean
 ): void {
   win.webContents.on('before-input-event', (event, input) => {
-    if (isRecording()) return
+    if (isRecording() || isStoodDown()) return
     const decision = keydownIntercept(input, getBindings(), isMac)
     if (!decision) return
     event.preventDefault()

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -98,6 +98,24 @@ describe('preload sshProject passphrase wiring', () => {
     expect(h.send).toHaveBeenCalledWith(IPC.uiShortcutRecording, false)
   })
 
+  // Same story for the focus mirror, and its OWN channel matters: main keeps the two bits apart
+  // (one suspends always, the other only under `terminal-first`), so a preload that folded the
+  // mirror onto the recording channel would disable ⌘W/⌘M/⌘0 for every user the moment they
+  // clicked into a terminal — with the whole suite still green.
+  it('shortcuts.setTerminalFocused sends both edges on its own channel', () => {
+    const before = h.send.mock.calls.length
+    api.shortcuts.setTerminalFocused(true)
+    api.shortcuts.setTerminalFocused(false)
+    // The whole call list, not two `toHaveBeenCalledWith`s: what must be true is that the mirror
+    // touched the terminal-focus channel and NOTHING else — folding it onto `ui:shortcut-recording`
+    // would disable ⌘W/⌘M/⌘0 for every user the moment they clicked into a terminal, and a
+    // per-call assertion would stay green through exactly that.
+    expect(h.send.mock.calls.slice(before)).toEqual([
+      [IPC.uiTerminalFocus, true],
+      [IPC.uiTerminalFocus, false]
+    ])
+  })
+
   it('onPassphraseDismiss subscribes the dismiss channel and forwards the requestId', () => {
     const got: { requestId: string }[] = []
     const off = api.sshProject.onPassphraseDismiss((e) => got.push(e))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -598,7 +598,11 @@ const api: NodeTerminalApi = {
     // this page can stop existing — window closed, renderer died, main-frame navigation (⌘R) —
     // but those are a backstop for a page that VANISHED, not a general safety net: an ordinary
     // disarm that never sends leaves the shortcuts suppressed until one of them happens.
-    setRecording: (active: boolean) => ipcRenderer.send(IPC.uiShortcutRecording, active)
+    setRecording: (active: boolean) => ipcRenderer.send(IPC.uiShortcutRecording, active),
+    // The terminal-focus mirror, same fire-and-forget shape and the same fail-safe reading on the
+    // far side: main starts at "not focused" and the three page-death resets return it there, so a
+    // report that never arrives costs the terminal-first policy, not the app's shortcuts.
+    setTerminalFocused: (focused: boolean) => ipcRenderer.send(IPC.uiTerminalFocus, focused)
   },
   onMarkdownToggle: subscribe(IPC.appToggleMarkdown),
   onCloseNode: subscribe(IPC.appCloseNode),

--- a/src/renderer/bridge/stubs.test.ts
+++ b/src/renderer/bridge/stubs.test.ts
@@ -102,6 +102,11 @@ describe('bridge stubs', () => {
       // Settings unusable in the browser, where there is no main-process intercept to suspend.
       s.shortcuts.setRecording(true)
       s.shortcuts.setRecording(false)
+      // The focus mirror fires on every click into and out of a terminal, so a throw here would
+      // break the browser canvas on the first keystroke — and the browser has no main-process
+      // intercept for it to suspend in the first place.
+      s.shortcuts.setTerminalFocused(true)
+      s.shortcuts.setTerminalFocused(false)
     }).not.toThrow()
   })
 })

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -358,7 +358,12 @@ export function buildStubApi(): Omit<
       // `before-input-event` intercepts down, and a browser tab has no application menu to steal
       // ⌘W/⌘M/⌘0 back from — nothing intercepts here, so there is nothing to suspend. The
       // recorder's own preventDefault/stopPropagation is the whole path in this shell.
-      setRecording: noop
+      setRecording: noop,
+      // Deliberate no-op for the same reason, one step further: the mirror exists so the DESKTOP's
+      // intercepts can stand down under `terminal-first`, and there are no intercepts here to
+      // stand down. The policy itself still works in the browser — it is enforced by the
+      // renderer's own dispatcher (`keyDispatchContextFor`), which reads focus directly.
+      setTerminalFocused: noop
     },
     onMarkdownToggle: noopUnsub,
     onCloseNode: noopUnsub,

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -183,7 +183,8 @@ import {
   activeKeybindingOverrides,
   chipFor,
   commandTooltip,
-  dictationBinding
+  dictationBinding,
+  terminalShortcutPolicy
 } from '../lib/keybindingOverrides'
 import { UsageIndicator } from '../components/UsageIndicator'
 import { SystemResourcePill } from '../components/SystemResourcePill'
@@ -5226,6 +5227,9 @@ export function Canvas() {
     kanbanOpen: () => isKanbanOpen(useProjects.getState().activeProjectId),
     overrides: activeKeybindingOverrides,
     isMac,
+    // Read per keystroke (the deps object is rebuilt each render anyway, but the thunk is what
+    // the contract asks for): a policy change takes effect immediately, with no re-registration.
+    terminalFirst: () => terminalShortcutPolicy() === 'terminal-first',
     handlers: {
       'app.commandPalette': () => { setPaletteOpen((v) => !v); return true },
       'app.settings': () => { setSettingsSection(undefined); setSettingsOpen(true); return true },

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -152,6 +152,7 @@ import { UpdateCard } from '../components/UpdateCard'
 import { AnnouncementBanner } from '../components/AnnouncementBanner'
 import { TmuxBanner } from '../components/TmuxBanner'
 import { PtyPressureBanner } from '../components/PtyPressureBanner'
+import { ShortcutCaptureBanner } from '../components/ShortcutCaptureBanner'
 import { ConflictBar } from '../components/ConflictBar'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { CapabilityNotice } from '../components/CapabilityNotice'
@@ -178,12 +179,13 @@ import {
   type GlobalKeyEvent,
   type GlobalKeydownDeps
 } from '../lib/globalKeybindings'
-import type { ContextElement } from '../lib/keyContext'
+import { isTerminalTarget, type ContextElement } from '../lib/keyContext'
 import {
   activeKeybindingOverrides,
   chipFor,
   commandTooltip,
   dictationBinding,
+  noteTerminalCapture,
   terminalShortcutPolicy
 } from '../lib/keybindingOverrides'
 import { UsageIndicator } from '../components/UsageIndicator'
@@ -3993,11 +3995,31 @@ export function Canvas() {
   // node's × button. With nothing selected it falls back to closing the window.
   useEffect(() => {
     return window.nodeTerminal.onCloseNode(() => {
+      // The two main-intercepted chords never reach the window dispatcher, so their capture
+      // notice has to be raised HERE, at the IPC receiver — asking the live focus, because the
+      // IPC carries no context. Notice only: nothing is consumed, and the close below runs
+      // exactly as it did before (`noteTerminalCapture` is silent under terminal-first, on a
+      // repeat, and outside a focused terminal).
+      if (isTerminalTarget(document.activeElement as unknown as ContextElement | null)) {
+        noteTerminalCapture('node.close')
+      }
       const ids = nodesRef.current.filter((n) => n.selected).map((n) => n.id)
       if (ids.length) deleteNodes(ids)
       else window.nodeTerminal.closeWindow()
     })
   }, [deleteNodes])
+
+  // The second main-intercepted chord (⌘/Ctrl+M). Canvas does NOT own the markdown toggle —
+  // TerminalNode and EditorNode each subscribe for themselves — so this listener exists ONLY to
+  // raise the same notice, and must stay side-effect-free: it consumes nothing, prevents nothing,
+  // and the nodes' own subscriptions are untouched by it.
+  useEffect(() => {
+    return window.nodeTerminal.onMarkdownToggle(() => {
+      if (isTerminalTarget(document.activeElement as unknown as ContextElement | null)) {
+        noteTerminalCapture('node.toggleMarkdown')
+      }
+    })
+  }, [])
 
   // Native View menu → renderer. The menu item click sends IPC; these listeners fire the canvas
   // action. Snap-to-Grid flips the setting (the `autoAlignGrid` effect above runs the arrange on
@@ -5230,6 +5252,10 @@ export function Canvas() {
     // Read per keystroke (the deps object is rebuilt each render anyway, but the thunk is what
     // the contract asks for): a policy change takes effect immediately, with no re-registration.
     terminalFirst: () => terminalShortcutPolicy() === 'terminal-first',
+    // The notice half. `noteTerminalCapture` re-asks the policy and the once-per-command ledger
+    // itself, so this is a plain pass-through — the dispatcher decides that a capture HAPPENED,
+    // the lib decides whether it is worth saying.
+    onTerminalCapture: noteTerminalCapture,
     handlers: {
       'app.commandPalette': () => { setPaletteOpen((v) => !v); return true },
       'app.settings': () => { setSettingsSection(undefined); setSettingsOpen(true); return true },
@@ -9170,6 +9196,14 @@ export function Canvas() {
         {/* This MACHINE is running out of pty devices — subscribes for itself; a failed
             "Fix automatically…" lands in the same notice strip as every other async op. */}
         <PtyPressureBanner onError={(text) => setNotice({ kind: 'error', text })} />
+        {/* App-first just took a chord from a focused terminal, once per command ever —
+            subscribes for itself; only the route into Settings is Canvas's to give. */}
+        <ShortcutCaptureBanner
+          onOpenShortcuts={() => {
+            setSettingsSection('shortcuts')
+            setSettingsOpen(true)
+          }}
+        />
         {migrationNote && (
           <div className="announce-banner announce-banner--info">
             <span className="announce-banner__dot" />

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -180,6 +180,7 @@ import {
   type GlobalKeydownDeps
 } from '../lib/globalKeybindings'
 import { isTerminalTarget, type ContextElement } from '../lib/keyContext'
+import { installTerminalFocusMirror } from '../lib/terminalFocusMirror'
 import {
   activeKeybindingOverrides,
   chipFor,
@@ -5314,6 +5315,25 @@ export function Canvas() {
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [])
+
+  // Mirror "an xterm has keyboard focus" to main, so the DESKTOP's `before-input-event` intercepts
+  // can stand down under the `terminal-first` policy: that intercept fires before any renderer
+  // handler could tell it, so the answer has to already be in main. The mirror is deliberately NOT
+  // gated on the policy — main composes `policy === 'terminal-first' && terminalFocused`, so a user
+  // who flips the setting with a terminal already focused gets the new behaviour on their very next
+  // keystroke, rather than after the next focus change. Under the shipped `app-first` default main's
+  // half is false regardless, so nothing about this app's shortcuts changes.
+  // The logic (change-dedup, the microtask-settled read, the window-blur leg and the re-check that
+  // catches a focused terminal being torn out of the DOM by a park / offscreen release / delete)
+  // lives in `lib/terminalFocusMirror.ts`, where it is pressed against a real DOM. Server Edition:
+  // the bridge stubs `setTerminalFocused` — there is no main-process intercept there to suspend.
+  useEffect(
+    () =>
+      installTerminalFocusMirror({
+        report: (focused) => window.nodeTerminal.shortcuts.setTerminalFocused(focused)
+      }),
+    []
+  )
 
   // ⌘/Ctrl+0 on the DESKTOP never reaches the keydown handler above: Electron's default View menu
   // binds the accelerator to `resetZoom`, and a menu accelerator is handled before the page sees

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4001,12 +4001,17 @@ export function Canvas() {
       // IPC carries no context. Notice only: nothing is consumed, and the close below runs
       // exactly as it did before (`noteTerminalCapture` is silent under terminal-first, on a
       // repeat, and outside a focused terminal).
-      if (isTerminalTarget(document.activeElement as unknown as ContextElement | null)) {
-        noteTerminalCapture('node.close')
-      }
       const ids = nodesRef.current.filter((n) => n.selected).map((n) => n.id)
-      if (ids.length) deleteNodes(ids)
-      else window.nodeTerminal.closeWindow()
+      // The notice sits INSIDE the branch that actually captured the key. With nothing selected
+      // ⌘W closes the WINDOW, and a notice raised there would burn this command's once-ever slot
+      // on a banner nobody can read — the window is going away in the same tick — leaving the user
+      // permanently unable to be told why ⌘W stops reaching their shell.
+      if (ids.length) {
+        if (isTerminalTarget(document.activeElement as unknown as ContextElement | null)) {
+          noteTerminalCapture('node.close')
+        }
+        deleteNodes(ids)
+      } else window.nodeTerminal.closeWindow()
     })
   }, [deleteNodes])
 
@@ -4033,8 +4038,18 @@ export function Canvas() {
   useEffect(() => {
     return window.nodeTerminal.onFitView(() => fitAll())
   }, [fitAll])
+  // ⌘⇧B and ⌘, are the other two chords the dispatcher can never notice — not because main steals
+  // them (it does not; they are ordinary registry commands) but because the MENU owns their
+  // accelerators above the page under app-first, so the window keydown listener never runs and its
+  // notice half never fires. Like the two receivers above, the notice is raised HERE and asks the
+  // live focus, since the IPC carries no context. Notice ONLY: nothing is consumed, the toggle and
+  // the settings open run exactly as before, and `noteTerminalCapture` is silent under
+  // terminal-first, on a repeat, and outside a focused terminal.
   useEffect(() => {
     return window.nodeTerminal.onToggleKanban(() => {
+      if (isTerminalTarget(document.activeElement as unknown as ContextElement | null)) {
+        noteTerminalCapture('view.kanbanToggle')
+      }
       const id = useProjects.getState().activeProjectId
       if (id) useViewMode.getState().toggle(id)
     })
@@ -4043,6 +4058,9 @@ export function Canvas() {
   // Cmd+, keydown handler alone would leave the menu item inert — main forwards it as IPC.
   useEffect(() => {
     return window.nodeTerminal.onOpenSettings(() => {
+      if (isTerminalTarget(document.activeElement as unknown as ContextElement | null)) {
+        noteTerminalCapture('app.settings')
+      }
       setSettingsSection(undefined)
       setSettingsOpen(true)
     })

--- a/src/renderer/components/ShortcutCaptureBanner.test.tsx
+++ b/src/renderer/components/ShortcutCaptureBanner.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CommandId } from '@shared/keybindings'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import { useSettings } from '../state/settings'
+import { ShortcutCaptureBanner } from './ShortcutCaptureBanner'
+
+/**
+ * The banner is the only surface that ever SHOWS a capture notice, and until now nothing pressed
+ * it — `keybindingOverrides.test.ts` runs in the node environment and can assert only the settings
+ * half (the once-ever ledger, the terminal-first silence). Everything below is the other half: the
+ * `window` event → visible strip → dismissal path, which is where a queue-less design, a restarted
+ * clock and two `null` copy cases all live.
+ *
+ * FAKE TIMERS, and the coupling documented in `terminalFocusMirror.test.ts` applies here too:
+ * `vi.useFakeTimers()` does NOT fake microtasks in this repo's configuration, so React's own
+ * flushing still happens naturally inside `act` — advance the CLOCK with
+ * `vi.advanceTimersByTime` and let `act` settle the render. Never try to "advance" a microtask.
+ * The 12s auto-dismiss is a `setTimeout` in an effect, so every advance has to be wrapped in
+ * `act` or the resulting `setCurrent(null)` never reaches the DOM being asserted on.
+ */
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// jsdom reports a non-mac platform, and the body quotes a PLATFORM-FORMATTED chord ('⌘K' vs
+// 'Ctrl+K'). Pin macOS so the assertions name one spelling — `isMacPlatform()` is read at call
+// time, never captured at module load.
+Object.defineProperty(window.navigator, 'platform', { value: 'MacIntel', configurable: true })
+
+/** Must be a FRESH `keybindings` object every time: `activeKeybindingOverrides` memoizes on that
+ *  object's identity, so mutating one in place would serve the previous sanitize. */
+const setKb = (kb: Record<string, readonly string[]> | undefined): void =>
+  useSettings.setState({ settings: { ...DEFAULT_SETTINGS, keybindings: kb as never } })
+
+const onOpenShortcuts = vi.fn()
+let host: HTMLDivElement
+let root: Root | null = null
+
+function render(): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => root!.render(<ShortcutCaptureBanner onOpenShortcuts={onOpenShortcuts} />))
+}
+
+/** What `noteTerminalCapture` dispatches. Raised directly here: the DECISION to raise it is
+ *  already pinned in `keybindingOverrides.test.ts`, and this file is about what happens after. */
+function capture(commandId: string): void {
+  act(() =>
+    window.dispatchEvent(
+      new CustomEvent('nodeterm:shortcut-captured', { detail: { commandId: commandId as CommandId } })
+    )
+  )
+}
+
+const tick = (ms: number): void => {
+  act(() => {
+    vi.advanceTimersByTime(ms)
+  })
+}
+
+const banner = (): HTMLElement | null => host.querySelector<HTMLElement>('.announce-banner')
+const title = (): string | undefined =>
+  host.querySelector<HTMLElement>('.announce-banner__title')?.textContent ?? undefined
+const body = (): string | undefined =>
+  host.querySelector<HTMLElement>('.announce-banner__body')?.textContent ?? undefined
+const btn = (label: string): HTMLButtonElement =>
+  [...host.querySelectorAll('button')].find((b) => b.textContent === label) as HTMLButtonElement
+const click = (el: HTMLElement): void => {
+  act(() => el.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  onOpenShortcuts.mockClear()
+  setKb(undefined)
+})
+
+afterEach(() => {
+  if (root) {
+    const r = root
+    root = null
+    act(() => r.unmount())
+    host.remove()
+  }
+  vi.useRealTimers()
+})
+
+describe('ShortcutCaptureBanner', () => {
+  it('renders nothing until a capture arrives', () => {
+    render()
+    expect(banner()).toBeNull()
+  })
+
+  it('a bound command renders its title and a body quoting the chord in force', () => {
+    render()
+    capture('app.commandPalette')
+    expect(banner()).not.toBeNull()
+    expect(title()).toBe('Command palette')
+    // The chord is read through `chipFor`, so this is the EFFECTIVE binding, not the registry
+    // default — the remap case below is the same assertion with an override in place.
+    expect(body()).toContain('⌘K')
+    expect(body()).toContain('Command palette')
+    expect(body()).toContain('terminal-first')
+  })
+
+  it('quotes the user’s own chord after a remap, never the registry default', () => {
+    setKb({ 'app.commandPalette': ['Cmd+Alt+P'] })
+    render()
+    capture('app.commandPalette')
+    expect(body()).toContain('⌘⌥P')
+    expect(body()).not.toContain('⌘K')
+  })
+
+  it('a second capture REPLACES the first and restarts the 12s clock', () => {
+    render()
+    capture('app.commandPalette')
+    tick(8_000)
+    expect(title()).toBe('Command palette')
+
+    capture('app.settings')
+    // Replaced, not queued: the first notice is gone the instant the second arrives.
+    expect(title()).toBe('Open settings')
+    expect(body()).toContain('⌘,')
+
+    // 8s past the FIRST capture's deadline (16s in) — a clock that had been inherited rather than
+    // restarted would have dismissed the strip here.
+    tick(8_000)
+    expect(title()).toBe('Open settings')
+    // …and the second one's own 12s still lands.
+    tick(4_000)
+    expect(banner()).toBeNull()
+  })
+
+  it('auto-dismisses at 12s, and not a tick before', () => {
+    render()
+    capture('app.commandPalette')
+    tick(11_999)
+    expect(banner()).not.toBeNull()
+    tick(1)
+    expect(banner()).toBeNull()
+  })
+
+  it('Open Shortcuts calls the prop AND clears the strip', () => {
+    render()
+    capture('app.commandPalette')
+    click(btn('Open Shortcuts'))
+    expect(onOpenShortcuts).toHaveBeenCalledTimes(1)
+    // Both halves matter: opening the settings page behind a strip that stays up would leave the
+    // user reading a notice about the very screen they are now looking at.
+    expect(banner()).toBeNull()
+  })
+
+  it('the ✕ dismisses without opening Settings', () => {
+    render()
+    capture('app.commandPalette')
+    click(btn('✕'))
+    expect(banner()).toBeNull()
+    expect(onOpenShortcuts).not.toHaveBeenCalled()
+  })
+
+  it('an id the registry does not know renders nothing', () => {
+    render()
+    // The id arrives inside a `CustomEvent.detail` off `window`, so its `CommandId` type is a
+    // compile-time claim and nothing more — a stale or forged one must be silence, not a hole.
+    capture('app.notACommand')
+    expect(banner()).toBeNull()
+  })
+
+  it('a DISABLED (unbound) command renders nothing — the sentence is built around its chord', () => {
+    setKb({ 'app.commandPalette': [] })
+    render()
+    capture('app.commandPalette')
+    expect(banner()).toBeNull()
+  })
+
+  it('a malformed event with no commandId renders nothing', () => {
+    render()
+    act(() => window.dispatchEvent(new CustomEvent('nodeterm:shortcut-captured')))
+    expect(banner()).toBeNull()
+  })
+
+  it('stops listening once unmounted', () => {
+    render()
+    const r = root!
+    root = null
+    act(() => r.unmount())
+    // No throw, no state update on a dead root — the subscription is torn down in the effect's
+    // cleanup, and a leaked one would surface here as a React warning about an unmounted update.
+    capture('app.commandPalette')
+    expect(host.querySelector('.announce-banner')).toBeNull()
+    host.remove()
+  })
+})

--- a/src/renderer/components/ShortcutCaptureBanner.tsx
+++ b/src/renderer/components/ShortcutCaptureBanner.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import type { CommandId } from '@shared/keybindings'
+import { shortcutCaptureCopy } from './shortcutCaptureCopy'
+
+// The one time the app explains itself: a chord the user pressed inside a focused terminal ran an
+// APP command instead of reaching the shell. `noteTerminalCapture` decides WHEN that is worth
+// saying (app-first only, once per command, ever, persisted in settings) — this strip only says it.
+//
+// Its own component, subscribing for itself, for the same reason PtyPressureBanner and TmuxBanner
+// are: Canvas.tsx is a hot file every other branch touches, and a banner is not canvas logic. The
+// one thing it cannot own is opening Settings (the page's state lives in Canvas), so that arrives
+// as a prop.
+
+/** Informational, not a warning: it names something that already happened correctly and offers a
+ *  setting. Longer than a toast because there are two sentences to read, far shorter than the
+ *  pty-pressure strips, which stay until the machine's state changes. */
+const CAPTURE_NOTICE_MS = 12_000
+
+export function ShortcutCaptureBanner({
+  onOpenShortcuts
+}: {
+  /** Open Settings on the Keyboard Shortcuts section — where both exits the copy names live. */
+  onOpenShortcuts: () => void
+}): JSX.Element | null {
+  // Queue-less on purpose: a second capture REPLACES the first. These fire once per command ever,
+  // so a queue would only exist to replay a notice the user has already been shown the shape of.
+  const [current, setCurrent] = useState<{ id: CommandId } | null>(null)
+
+  useEffect(() => {
+    const onCaptured = (e: Event): void => {
+      const id = (e as CustomEvent<{ commandId: CommandId }>).detail?.commandId
+      if (id) setCurrent({ id })
+    }
+    window.addEventListener('nodeterm:shortcut-captured', onCaptured)
+    return () => window.removeEventListener('nodeterm:shortcut-captured', onCaptured)
+  }, [])
+
+  // A fresh object per capture, so a second one restarts the clock rather than inheriting the
+  // remainder of the first one's.
+  useEffect(() => {
+    if (!current) return
+    const t = setTimeout(() => setCurrent(null), CAPTURE_NOTICE_MS)
+    return () => clearTimeout(t)
+  }, [current])
+
+  // Resolved at RENDER, not at capture: an id we cannot name — or one whose chord is gone by now —
+  // shows nothing at all rather than a sentence with a hole in it.
+  const copy = current ? shortcutCaptureCopy(current.id) : null
+  if (!copy) return null
+
+  return (
+    <div className="announce-banner announce-banner--info">
+      <span className="announce-banner__dot" />
+      <div className="announce-banner__content">
+        <span className="announce-banner__title">{copy.title}</span>
+        <span className="announce-banner__body">{copy.body}</span>
+      </div>
+      <button
+        className="announce-banner__btn"
+        onClick={() => {
+          setCurrent(null)
+          onOpenShortcuts()
+        }}
+      >
+        Open Shortcuts
+      </button>
+      <button className="announce-banner__close" title="Dismiss" onClick={() => setCurrent(null)}>
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -7,6 +7,7 @@ import { reportsOwnCopy } from '@shared/agents/config'
 import type { AgentId } from '@shared/agents/config'
 import { readsClaudeTranscript } from '../../lib/transcriptGates'
 import { liveProjectJumpTarget } from '../../lib/projectJump'
+import { terminalShortcutPolicy } from '../../lib/keybindingOverrides'
 import { FindBar } from '../FindBar'
 import { useAgentStatus } from '../../state/agentStatus'
 import { useProjects } from '../../state/projects'
@@ -192,9 +193,12 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
     // Ctrl+Shift+C would fall through to the pty as \x03/SIGINT); plain Ctrl+C is left alone.
     // MIRROR TerminalNode: Cmd/Ctrl+1-9 (jump to the Nth project) is swallowed here, before xterm
     // turns Ctrl+2..Ctrl+8 into control bytes — but only when the app owns the key (desktop shell,
-    // digit addressing an open project), which `liveProjectJumpTarget` decides for both surfaces.
+    // digit addressing an open project, AND app-first: under terminal-first the digit belongs to
+    // the PTY), which `liveProjectJumpTarget` + the policy decide for both surfaces.
     term.attachCustomKeyEventHandler((e) => {
-      const action = terminalKeyAction(e, term.hasSelection(), liveProjectJumpTarget(e) !== null)
+      const ownsProjectJump =
+        terminalShortcutPolicy() !== 'terminal-first' && liveProjectJumpTarget(e) !== null
+      const action = terminalKeyAction(e, term.hasSelection(), ownsProjectJump)
       if (action === 'pass') return true
       e.preventDefault()
       if (action === 'copy') window.nodeTerminal.clipboard.writeText(term.getSelection())

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -50,6 +50,12 @@ const setRecording = (): ReturnType<typeof vi.fn> =>
 const body = (): Element => host.querySelector<HTMLElement>('#shortcuts')!.lastElementChild!
 
 const row = (id: string): HTMLElement => host.querySelector<HTMLElement>(`[data-command="${id}"]`)!
+/** The policy row's SegmentedPill, found by the `ariaLabel` it is given (it carries no command id
+ *  — it is a setting, not a registry command). */
+const pill = (): HTMLElement | null =>
+  host.querySelector<HTMLElement>('[role="radiogroup"][aria-label="While a terminal has focus"]')
+const pillOption = (label: string): HTMLButtonElement =>
+  [...pill()!.querySelectorAll('button')].find((b) => b.textContent === label)!
 const button = (id: string, label: string): HTMLButtonElement | null =>
   row(id).querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
 /** The recorder button carries no per-command aria-label (it is a shared component), so it is
@@ -128,8 +134,10 @@ describe('ShortcutsSection rows', () => {
     expect([...host.querySelectorAll('[data-command]')].map((el) =>
       el.getAttribute('data-command')
     )).toEqual(['node.close'])
-    // Exactly the heading and the one row — no empty siblings.
-    expect(body().children).toHaveLength(2)
+    // Exactly the policy row (its description names Close), the heading and the one command row —
+    // no empty siblings.
+    expect(pill()).toBeTruthy()
+    expect(body().children).toHaveLength(3)
     expect([...body().children].every((c) => (c.textContent ?? '').trim() !== '')).toBe(true)
   })
 
@@ -146,7 +154,8 @@ describe('ShortcutsSection rows', () => {
   it('renders every group and row unfiltered, each as its own divided block', () => {
     render()
     expect(host.querySelectorAll('h3')).toHaveLength(6)
-    expect(body().children).toHaveLength(6 + COMMAND_DEFINITIONS.length)
+    // + 1 for the terminal-policy row, which sits above the groups as its own block.
+    expect(body().children).toHaveLength(1 + 6 + COMMAND_DEFINITIONS.length)
   })
 
   // The dictation row must not promise a second chord: every consumer reads
@@ -203,6 +212,32 @@ describe('ShortcutsSection rows', () => {
     act(() => r.unmount())
     host.remove()
     expect(setRecording().mock.calls.filter((c) => c[0] === false)).toHaveLength(1)
+  })
+})
+
+describe('terminal shortcut policy row', () => {
+  // `app-first` is the shipped default and the byte-identical-behavior guarantee of the whole
+  // policy: a user who never opens this row must see the pre-feature app.
+  it('shows app-first checked by default', () => {
+    render()
+    expect(pillOption('App shortcuts first').getAttribute('aria-checked')).toBe('true')
+    expect(pillOption('Terminal first').getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('writes the setting when Terminal first is picked', () => {
+    render()
+    click(pillOption('Terminal first'))
+    expect(useSettings.getState().settings.terminalShortcutPolicy).toBe('terminal-first')
+    expect(pillOption('Terminal first').getAttribute('aria-checked')).toBe('true')
+  })
+
+  // The row is its OWN searchable unit, not part of a group Fragment: a query that matches only
+  // its keywords must keep it and drop every command group, heading included.
+  it('survives a query that drops every command group', () => {
+    render('tui')
+    expect(pill()).toBeTruthy()
+    expect(host.querySelectorAll('h3')).toHaveLength(0)
+    expect(host.querySelectorAll('[data-command]')).toHaveLength(0)
   })
 })
 

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -68,7 +68,7 @@ const NOTES: Partial<Record<CommandId, string>> = {
  *  knows about commands) decide whether a *setting* is on screen. */
 const POLICY_LABEL = 'While a terminal has focus'
 const POLICY_DESCRIPTION =
-  "App shortcuts first (the default): shared shortcuts like ⌘K keep working over a focused terminal, and the first time one is captured that way the terminal says so — once per chord, ever. Terminal first: every chord but the terminal's own reaches the shell or TUI, including Close (⌘W / Ctrl+W), Minimize (⌘M / Ctrl+M), actual size (⌘0) and the ⌘1–9 project jumps — the application menu's Minimize and Close entries grey out while a terminal is focused, so those chords can reach it."
+  "App shortcuts first (the default): shared shortcuts like ⌘K keep working over a focused terminal, and the first time one is captured that way the terminal says so — once per chord, ever. Terminal first: every chord but the terminal's own reaches the shell or TUI, including Close (⌘W / Ctrl+W), Minimize (⌘M / Ctrl+M), actual size (⌘0), the kanban board (⌘⇧B), Settings (⌘,) and the ⌘1–9 project jumps — the matching application-menu entries grey out while a terminal is focused, so those chords can reach it. Reload (⌘R / ⌘⇧R) is the one exception and always stays with the app, so a stuck window can still be recovered."
 const POLICY_ROW: SettingsSearchEntry = {
   title: POLICY_LABEL,
   description: POLICY_DESCRIPTION,

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -28,9 +28,11 @@ import {
   findKeybindingConflicts,
   findMainInterceptShadowing,
   MAIN_INTERCEPTED_COMMAND_IDS,
+  normalizeTerminalShortcutPolicy,
   type CommandDefinition,
   type CommandGroup,
-  type CommandId
+  type CommandId,
+  type TerminalShortcutPolicy
 } from '@shared/keybindings'
 import { formatShortcut } from '@shared/shortcut'
 import { isMacPlatform, keyLabel } from '@shared/platform-utils'
@@ -46,6 +48,7 @@ import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
 import { ShortcutRecorderButton } from '../ShortcutRecorderButton'
 import { Button } from '@renderer/ui/Button'
+import { SegmentedPill } from '@renderer/ui/SegmentedPill'
 import { useSettingsSearch } from '../context'
 import { matchesQuery, type SettingsSearchEntry } from '../search'
 
@@ -58,6 +61,18 @@ const NOTES: Partial<Record<CommandId, string>> = {
     'With a key = toggle (press to start, press again to stop and insert); modifiers only = hold to talk (hold to record, release to stop and insert). The Dock mic uses the same shortcut.',
   'canvas.deleteSelection': 'Bare keys are allowed here; the typing guard keeps Backspace safe.',
   'terminal.copySelection': 'Applies to a selection xterm owns — a tmux drag copies through OSC 52.'
+}
+
+/** The policy row is NOT a registry command, so it carries its own search entry and its own
+ *  `SearchableRow` — putting it inside a group Fragment would make `groupVisible` (which only
+ *  knows about commands) decide whether a *setting* is on screen. */
+const POLICY_LABEL = 'While a terminal has focus'
+const POLICY_DESCRIPTION =
+  "App shortcuts first (the default): shared shortcuts like ⌘K keep working over a focused terminal, and the first time one is captured that way the terminal says so — once per chord, ever. Terminal first: every chord but the terminal's own reaches the shell or TUI, including Close (⌘W / Ctrl+W), Minimize (⌘M / Ctrl+M), actual size (⌘0) and the ⌘1–9 project jumps — the application menu's Minimize and Close entries grey out while a terminal is focused, so those chords can reach it."
+const POLICY_ROW: SettingsSearchEntry = {
+  title: POLICY_LABEL,
+  description: POLICY_DESCRIPTION,
+  keywords: ['shortcut', 'terminal', 'tui', 'shell', 'policy', 'first', 'capture', 'minimize']
 }
 
 function rowEntry(def: CommandDefinition): SettingsSearchEntry {
@@ -184,6 +199,14 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
   // Any remap re-renders every row: chips, and the Add/Disable/Reset visibility, are all derived
   // from the override map.
   const overrides = useSettings((s) => s.settings.keybindings)
+  // Read through the normalizer, never as the raw field: settings.json is hand-editable, so the
+  // compile-time type is not a runtime guarantee and an unknown value must render as `app-first`
+  // — the same degrade `terminalShortcutPolicy()` applies at dispatch, so the pill cannot show a
+  // policy the dispatcher is not using.
+  const policy = normalizeTerminalShortcutPolicy(
+    useSettings((s) => s.settings.terminalShortcutPolicy)
+  )
+  const update = useSettings((s) => s.update)
   const query = useSettingsSearch()
   const [errors, setErrors] = useState<Partial<Record<CommandId, string>>>({})
 
@@ -197,6 +220,7 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
 
   const entries = useMemo(
     () => [
+      POLICY_ROW,
       ...groups.map(([group, defs]) => groupEntry(group, defs)),
       ...COMMAND_DEFINITIONS.map(rowEntry)
     ],
@@ -224,6 +248,26 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
       isActive={isActive}
       searchEntries={entries}
     >
+      <SearchableRow {...POLICY_ROW}>
+        <div data-setting="terminal-shortcut-policy">
+          <FieldRow
+            label={POLICY_LABEL}
+            description={POLICY_DESCRIPTION}
+            control={
+              <SegmentedPill<TerminalShortcutPolicy>
+                value={policy}
+                ariaLabel={POLICY_LABEL}
+                options={[
+                  { value: 'app-first', label: 'App shortcuts first' },
+                  { value: 'terminal-first', label: 'Terminal first' }
+                ]}
+                onChange={(v) => update({ terminalShortcutPolicy: v })}
+              />
+            }
+          />
+        </div>
+      </SearchableRow>
+
       {groups.map(([group, defs]) => {
         // A group whose header AND every row are filtered out must not render at all. The shell's
         // body is `divide-y [&>*]:py-5`, so an empty wrapper is not invisible — it draws a padded

--- a/src/renderer/components/shortcutCaptureCopy.test.ts
+++ b/src/renderer/components/shortcutCaptureCopy.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import type { CommandId } from '@shared/keybindings'
+import { useSettings } from '../state/settings'
+import { shortcutCaptureCopy } from './shortcutCaptureCopy'
+
+const setKb = (kb: unknown) =>
+  useSettings.setState({ settings: { ...DEFAULT_SETTINGS, keybindings: kb as never } })
+
+beforeEach(() => setKb(undefined))
+
+describe('shortcutCaptureCopy', () => {
+  it('names the command and the chord that took the key', () => {
+    const copy = shortcutCaptureCopy('app.commandPalette', true)
+    expect(copy?.title).toBe('Command palette')
+    expect(copy?.body).toContain('⌘K')
+    expect(copy?.body).toContain('Command palette')
+    // The two ways out are what the banner is FOR — a notice that only reports is noise.
+    expect(copy?.body.toLowerCase()).toContain('terminal-first')
+  })
+
+  it('spells the chord the way the platform does', () => {
+    expect(shortcutCaptureCopy('app.commandPalette', false)?.body).toContain('Ctrl+K')
+  })
+
+  it('follows a remap, so the notice quotes the chord the user actually pressed', () => {
+    setKb({ 'app.commandPalette': ['Cmd+Shift+P'] })
+    expect(shortcutCaptureCopy('app.commandPalette', true)?.body).toContain('⌘⇧P')
+  })
+
+  // Both halves of "say nothing": there is no chord to quote, so a banner could only claim a
+  // key was taken without naming one.
+  it('is null for an unbound command', () => {
+    expect(shortcutCaptureCopy('canvas.fitAll', true)).toBeNull()
+  })
+
+  it('is null for a DISABLED command', () => {
+    setKb({ 'app.commandPalette': [] })
+    expect(shortcutCaptureCopy('app.commandPalette', true)).toBeNull()
+  })
+
+  // The event's detail crosses a `window` boundary, so the id is not a compile-time fact.
+  it('is null for an id the registry does not know', () => {
+    expect(shortcutCaptureCopy('bogus.command' as CommandId, true)).toBeNull()
+  })
+})

--- a/src/renderer/components/shortcutCaptureCopy.ts
+++ b/src/renderer/components/shortcutCaptureCopy.ts
@@ -1,0 +1,41 @@
+/**
+ * What the capture notice SAYS, kept pure so it can be tested without a DOM and so the banner
+ * stays a subscription plus markup.
+ *
+ * Two things this returns `null` for, and they mean the same thing to the caller — **show
+ * nothing**:
+ *   - an id the registry does not know. The id arrives inside a `CustomEvent.detail` off
+ *     `window`, so its `CommandId` type is a compile-time claim, not a runtime fact.
+ *   - a command with no effective chord (unbound, or the user disabled it). The whole sentence is
+ *     built around the chord that took the key; with none to quote the notice could only assert
+ *     that *something* was captured, which is worse than silence.
+ *
+ * The chord is read through `chipFor`, so the notice quotes the binding IN FORCE — a remapped
+ * command names the user's own chord, never the registry default they no longer use.
+ */
+import { COMMANDS_BY_ID, type CommandId } from '@shared/keybindings'
+import { isMacPlatform } from '@shared/platform-utils'
+import { chipFor } from '../lib/keybindingOverrides'
+
+export interface ShortcutCaptureCopy {
+  title: string
+  body: string
+}
+
+export function shortcutCaptureCopy(
+  id: CommandId,
+  isMac: boolean = isMacPlatform()
+): ShortcutCaptureCopy | null {
+  const def = COMMANDS_BY_ID.get(id)
+  if (!def) return null
+  const chip = chipFor(id, isMac)
+  if (!chip) return null
+  return {
+    title: def.title,
+    // Names both exits the user has — remap this one chord, or hand every chord to the terminal.
+    // A notice that only reports what happened teaches the user to dismiss notices.
+    body:
+      `${chip} ran “${def.title}” instead of reaching your terminal. You can remap it, ` +
+      'or switch to terminal-first so terminals keep every chord.'
+  }
+}

--- a/src/renderer/lib/globalKeybindings.test.ts
+++ b/src/renderer/lib/globalKeybindings.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
+import type { CommandId } from '@shared/keybindings'
 import { dispatchGlobalKeydown, type GlobalKeydownDeps, type GlobalKeyEvent } from './globalKeybindings'
-import { XTERM_INPUT_CLASS } from './keyContext'
+import { XTERM_INPUT_CLASS, type ContextElement } from './keyContext'
 
 const ev = (over: Partial<GlobalKeyEvent>): GlobalKeyEvent => ({
   metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, key: '',
@@ -9,13 +10,22 @@ const ev = (over: Partial<GlobalKeyEvent>): GlobalKeyEvent => ({
   ...over
 })
 const noGesture = () => false
+const noGestures = {
+  keyedDictation: noGesture, zoom: noGesture, projectJump: noGesture, copy: noGesture
+}
+/** xterm's hidden helper textarea — what `activeElement` reports whenever a terminal owns
+ *  the keyboard, i.e. the only element shape that makes `ctx.terminal` true. */
+const xtermEl = (): ContextElement => ({
+  tagName: 'TEXTAREA', classList: { contains: (n: string) => n === XTERM_INPUT_CLASS }
+})
 const deps = (over: Partial<GlobalKeydownDeps> = {}): GlobalKeydownDeps => ({
   activeElement: () => null,
   kanbanOpen: () => false,
   overrides: () => ({}),
   isMac: true,
+  terminalFirst: () => false,
   handlers: {},
-  gestures: { keyedDictation: noGesture, zoom: noGesture, projectJump: noGesture, copy: noGesture },
+  gestures: { ...noGestures },
   ...over
 })
 
@@ -51,10 +61,7 @@ describe('dispatchGlobalKeydown', () => {
     expect(term).not.toHaveBeenCalled()
     const typing = deps({ gestures: g, activeElement: () => ({ tagName: 'INPUT' }) })
     expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 't' }), typing)).toBe(false)
-    const terminal = deps({
-      gestures: g,
-      activeElement: () => ({ tagName: 'TEXTAREA', classList: { contains: (n: string) => n === XTERM_INPUT_CLASS } })
-    })
+    const terminal = deps({ gestures: g, activeElement: xtermEl })
     dispatchGlobalKeydown(ev({ metaKey: true, key: 't' }), terminal)
     expect(dictation).toHaveBeenCalledTimes(1)
   })
@@ -133,5 +140,56 @@ describe('dispatchGlobalKeydown', () => {
     })
     expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 'k' }), d)).toBe(true)
     expect(fit).toHaveBeenCalled()
+  })
+  it('terminal-first: trailing gestures are not offered while a terminal has focus', () => {
+    // The registry half of terminal-first lives in the resolver; the gestures never went
+    // through it, so without this gate Cmd+0 would still zoom the canvas out from under a
+    // user who reserved every chord for the shell.
+    const zoom = vi.fn(() => true)
+    const d = deps({
+      terminalFirst: () => true,
+      activeElement: xtermEl,
+      gestures: { ...noGestures, zoom }
+    })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: '0' }), d)).toBe(false)
+    expect(zoom).not.toHaveBeenCalled()
+  })
+  it('app-first: a terminal-context claim reports a capture exactly at claim time', () => {
+    const captured: string[] = []
+    const d = deps({
+      activeElement: xtermEl,
+      handlers: { 'app.commandPalette': () => true },
+      onTerminalCapture: (id) => captured.push(id)
+    })
+    dispatchGlobalKeydown(ev({ metaKey: true, key: 'k' }), d)
+    expect(captured).toEqual(['app.commandPalette'])
+  })
+  it('no capture report outside terminal focus, on decline, or under terminal-first', () => {
+    const captured: string[] = []
+    const base = { onTerminalCapture: (id: CommandId) => captured.push(id) }
+    // Plain app focus: nothing was taken from a terminal.
+    dispatchGlobalKeydown(ev({ metaKey: true, key: 'k' }),
+      deps({ ...base, handlers: { 'app.commandPalette': () => true } }))
+    // Declined: the chord fell through to the PTY, so nothing was captured.
+    dispatchGlobalKeydown(ev({ metaKey: true, key: 'k' }),
+      deps({ ...base, activeElement: xtermEl, handlers: { 'app.commandPalette': () => false } }))
+    // A TERMINAL-scope claim under terminal-first is the terminal's own key — legitimate
+    // ownership, not a capture.
+    dispatchGlobalKeydown(ev({ metaKey: true, key: 'f' }),
+      deps({ ...base, activeElement: xtermEl, terminalFirst: () => true,
+             handlers: { 'terminal.find': () => true } }))
+    expect(captured).toEqual([])
+  })
+  it('a terminal-scope claim under APP-first is ownership too, not a capture', () => {
+    // The scope check is the load-bearing half: gating only on `!terminalFirst` would report
+    // Cmd+F ("Find in terminal") as a chord app-first stole from the terminal.
+    const captured: string[] = []
+    const d = deps({
+      activeElement: xtermEl,
+      handlers: { 'terminal.find': () => true },
+      onTerminalCapture: (id: CommandId) => captured.push(id)
+    })
+    expect(dispatchGlobalKeydown(ev({ metaKey: true, key: 'f' }), d)).toBe(true)
+    expect(captured).toEqual([])
   })
 })

--- a/src/renderer/lib/globalKeybindings.ts
+++ b/src/renderer/lib/globalKeybindings.ts
@@ -65,7 +65,8 @@ export interface GlobalKeydownDeps {
 export function dispatchGlobalKeydown(e: GlobalKeyEvent, deps: GlobalKeydownDeps): boolean {
   // A child handler (find bar, dialogs, terminal) that already claimed the key wins outright.
   if (e.defaultPrevented) return false
-  const ctx = keyDispatchContextFor(deps.activeElement(), deps.kanbanOpen())
+  // Task 2 threads the real policy (a deps thunk); app-first until then, which is today's behavior.
+  const ctx = keyDispatchContextFor(deps.activeElement(), deps.kanbanOpen(), false)
   // Keyed dictation predates the registry and may deliberately collide with a default; it
   // keeps first claim, but only in plain app focus (its old guard blocked inputs AND xterm).
   if (!ctx.typing && !ctx.terminal && !ctx.kanbanOpen && deps.gestures.keyedDictation(e)) return true

--- a/src/renderer/lib/globalKeybindings.ts
+++ b/src/renderer/lib/globalKeybindings.ts
@@ -26,8 +26,17 @@
  *    registry and is offered to zoom → projectJump → copy. Those gestures receive the RAW event
  *    with no context, so **each trailing gesture closure owes its own focus/typing guard**; keyed
  *    dictation is the only gesture this module guards.
+ *
+ * 3. **The terminal-shortcut policy is applied in TWO places, because the gestures bypass the
+ *    resolver.** `resolveCommandForKeyEvent` honors `ctx.terminalFirst` for registry commands;
+ *    the trailing gestures never go through it, so this module gates them separately. A future
+ *    gesture appended to that chain inherits the gate for free — one added ABOVE the registry
+ *    (as keyed dictation is) does not, and owes its own.
  */
-import { resolveCommandForKeyEvent, type CommandId, type KeybindingOverrides } from '@shared/keybindings'
+import {
+  resolveCommandForKeyEvent, COMMANDS_BY_ID,
+  type CommandId, type KeybindingOverrides
+} from '@shared/keybindings'
 import { keyDispatchContextFor, type ContextElement } from './keyContext'
 
 /** Structural key event so node-env tests need no DOM (a real KeyboardEvent satisfies it). */
@@ -49,7 +58,15 @@ export interface GlobalKeydownDeps {
   kanbanOpen: () => boolean
   overrides: () => KeybindingOverrides
   isMac: boolean
+  /** The user's `terminalShortcutPolicy`, read live: true = 'terminal-first'. A thunk, not a
+   *  value, so a policy change takes effect on the next keystroke without re-registering the
+   *  window listener. */
+  terminalFirst: () => boolean
   handlers: CommandHandlers
+  /** Called when a registry handler CLAIMS a chord that a focused terminal would otherwise
+   *  have received — i.e. app-first took it. Terminal-scope claims and terminal-first are not
+   *  captures (see the call site). Optional: a caller that shows no notice omits it. */
+  onTerminalCapture?: (id: CommandId) => void
   /** Registry-less chords, tried in this exact order (matches today's if-chain order):
    *  keyed dictation BEFORE the registry (a custom keyed chord may collide with a default
    *  and must keep winning), zoom/projectJump/copy AFTER a registry miss. Each returns true
@@ -65,8 +82,7 @@ export interface GlobalKeydownDeps {
 export function dispatchGlobalKeydown(e: GlobalKeyEvent, deps: GlobalKeydownDeps): boolean {
   // A child handler (find bar, dialogs, terminal) that already claimed the key wins outright.
   if (e.defaultPrevented) return false
-  // Task 2 threads the real policy (a deps thunk); app-first until then, which is today's behavior.
-  const ctx = keyDispatchContextFor(deps.activeElement(), deps.kanbanOpen(), false)
+  const ctx = keyDispatchContextFor(deps.activeElement(), deps.kanbanOpen(), deps.terminalFirst())
   // Keyed dictation predates the registry and may deliberately collide with a default; it
   // keeps first claim, but only in plain app focus (its old guard blocked inputs AND xterm).
   if (!ctx.typing && !ctx.terminal && !ctx.kanbanOpen && deps.gestures.keyedDictation(e)) return true
@@ -75,12 +91,28 @@ export function dispatchGlobalKeydown(e: GlobalKeyEvent, deps: GlobalKeydownDeps
     const handler = deps.handlers[id]
     if (handler && handler()) {
       e.preventDefault()
+      // App-first just took this chord from a focused terminal: the once-per-command notice.
+      // The scope check is the load-bearing one — a terminal-scope claim (find, copy) is the
+      // terminal's OWN key, not a capture, and gating on the policy alone would report ⌘F as
+      // stolen. `!ctx.terminalFirst` is deliberate redundancy: the RESOLVER already refuses
+      // every non-terminal-scope command under terminal-first, so no test can distinguish it
+      // today (measured — removing it leaves the suite green). It STATES the condition here so
+      // the notice stays honest if that resolver rule is ever loosened, the same way the
+      // resolver's own isHoldChord skip states a contract it does not currently need.
+      if (ctx.terminal && !ctx.terminalFirst && COMMANDS_BY_ID.get(id)?.scope !== 'terminal') {
+        deps.onTerminalCapture?.(id)
+      }
       return true
     }
     // Resolved but unhandled/declined: fall through to the platform, never to a gesture that
     // could reinterpret the same chord.
     return false
   }
+  // terminal-first: the trailing gestures are APP gestures (zoom, project jump, copy) and the
+  // resolver never saw them, so the policy has to be applied here too — otherwise Cmd+0 still
+  // zooms out from under a user who reserved every chord for the shell. Each gesture keeps its
+  // own guards for the app-first case; this is an additional gate, not a replacement.
+  if (ctx.terminal && ctx.terminalFirst) return false
   if (deps.gestures.zoom(e)) return true
   if (deps.gestures.projectJump(e)) return true
   if (deps.gestures.copy(e)) return true

--- a/src/renderer/lib/keyContext.test.ts
+++ b/src/renderer/lib/keyContext.test.ts
@@ -41,15 +41,29 @@ describe('isTypingTarget', () => {
 
 describe('keyDispatchContextFor', () => {
   it('typing and terminal are disjoint by construction', () => {
-    expect(keyDispatchContextFor(el('TEXTAREA', { classes: [XTERM_INPUT_CLASS] }), false)).toEqual({
+    expect(
+      keyDispatchContextFor(el('TEXTAREA', { classes: [XTERM_INPUT_CLASS] }), false, false)
+    ).toEqual({
       typing: false,
       terminal: true,
-      kanbanOpen: false
+      kanbanOpen: false,
+      terminalFirst: false
     })
-    expect(keyDispatchContextFor(el('INPUT'), true)).toEqual({
+    expect(keyDispatchContextFor(el('INPUT'), true, false)).toEqual({
       typing: true,
       terminal: false,
-      kanbanOpen: true
+      kanbanOpen: true,
+      terminalFirst: false
+    })
+  })
+  it('carries the terminal-first policy through as given', () => {
+    expect(
+      keyDispatchContextFor(el('TEXTAREA', { classes: [XTERM_INPUT_CLASS] }), false, true)
+    ).toEqual({
+      typing: false,
+      terminal: true,
+      kanbanOpen: false,
+      terminalFirst: true
     })
   })
 })

--- a/src/renderer/lib/keyContext.ts
+++ b/src/renderer/lib/keyContext.ts
@@ -39,9 +39,12 @@ export function isTypingTarget(el: ContextElement | null): boolean {
   return el.isContentEditable === true
 }
 
+/** `terminalFirst` is REQUIRED, not defaulted: it is a user policy, and a default here would let
+ *  a call site silently answer "app-first" for a user who chose otherwise. Every caller decides. */
 export function keyDispatchContextFor(
   el: ContextElement | null,
-  kanbanOpen: boolean
+  kanbanOpen: boolean,
+  terminalFirst: boolean
 ): KeyDispatchContext {
-  return { typing: isTypingTarget(el), terminal: isTerminalTarget(el), kanbanOpen }
+  return { typing: isTypingTarget(el), terminal: isTerminalTarget(el), kanbanOpen, terminalFirst }
 }

--- a/src/renderer/lib/keybindingOverrides.test.ts
+++ b/src/renderer/lib/keybindingOverrides.test.ts
@@ -4,7 +4,8 @@ import { matchesShortcut, type ShortcutKeyEvent } from '@shared/shortcut'
 import { useSettings } from '../state/settings'
 import {
   activeKeybindingOverrides, effectiveBindings, commandKeys, commandTooltip, chipFor,
-  setKeybindingOverride, commandKeysFor, dictationBinding
+  setKeybindingOverride, commandKeysFor, dictationBinding,
+  terminalShortcutPolicy, noteTerminalCapture
 } from './keybindingOverrides'
 
 const setKb = (kb: unknown) =>
@@ -123,6 +124,59 @@ describe('setKeybindingOverride', () => {
     expect(useSettings.getState().settings.speech.shortcut).toBe('Cmd+Alt+D')
     setKeybindingOverride('speech.dictation', null)
     expect(useSettings.getState().settings.speech.shortcut).toBe(DEFAULT_SETTINGS.speech.shortcut)
+  })
+})
+
+// NODE ENV, deliberately: this file runs without jsdom (see the note on noteTerminalCapture),
+// so only the SETTINGS side is asserted here. The 'nodeterm:shortcut-captured' event is
+// window-guarded and its dispatch is covered by the banner's jsdom test.
+describe('terminalShortcutPolicy / noteTerminalCapture', () => {
+  const seen = () => useSettings.getState().settings.seenShortcutCaptureNotices
+  const setSettings = (patch: Record<string, unknown>) =>
+    useSettings.setState({ settings: { ...DEFAULT_SETTINGS, ...patch } as never })
+
+  it('normalizes the setting', () => {
+    expect(terminalShortcutPolicy()).toBe('app-first')
+    setSettings({ terminalShortcutPolicy: 'terminal-first' })
+    expect(terminalShortcutPolicy()).toBe('terminal-first')
+  })
+  it('a hand-edited garbage policy reads as app-first, not as the raw value', () => {
+    // settings.json is hand-editable, so the compile-time type is not a runtime guarantee —
+    // and the unknown value must degrade to today's behavior, never to terminal-first.
+    setSettings({ terminalShortcutPolicy: 'shell-first' })
+    expect(terminalShortcutPolicy()).toBe('app-first')
+  })
+  it('notes a capture once, persists the id, and is silent under terminal-first', () => {
+    noteTerminalCapture('app.commandPalette')
+    noteTerminalCapture('app.commandPalette')
+    expect(seen()).toEqual(['app.commandPalette'])
+    setSettings({
+      terminalShortcutPolicy: 'terminal-first',
+      seenShortcutCaptureNotices: ['app.commandPalette']
+    })
+    noteTerminalCapture('canvas.undo')
+    expect(seen()).toEqual(['app.commandPalette'])
+  })
+  it('appends to the ids already seen rather than replacing them', () => {
+    setSettings({ seenShortcutCaptureNotices: ['app.settings'] })
+    noteTerminalCapture('app.commandPalette')
+    expect(seen()).toEqual(['app.settings', 'app.commandPalette'])
+  })
+  it('a hand-edited seenShortcutCaptureNotices of the wrong shape reads as empty', () => {
+    // `.includes` on a string would answer TRUE for any substring of it, silently swallowing
+    // the first notice; on a non-array it would throw inside a keydown handler.
+    setSettings({ seenShortcutCaptureNotices: 'garbage' })
+    noteTerminalCapture('app.commandPalette')
+    expect(seen()).toEqual(['app.commandPalette'])
+  })
+  it('drops non-string entries from a hand-edited list instead of carrying them forward', () => {
+    setSettings({ seenShortcutCaptureNotices: ['app.settings', 7, null] })
+    noteTerminalCapture('app.commandPalette')
+    expect(seen()).toEqual(['app.settings', 'app.commandPalette'])
+  })
+  it('does not throw with no window (the guard node-env dispatch depends on)', () => {
+    expect(typeof window).toBe('undefined')
+    expect(() => noteTerminalCapture('app.commandPalette')).not.toThrow()
   })
 })
 

--- a/src/renderer/lib/keybindingOverrides.test.ts
+++ b/src/renderer/lib/keybindingOverrides.test.ts
@@ -127,9 +127,16 @@ describe('setKeybindingOverride', () => {
   })
 })
 
-// NODE ENV, deliberately: this file runs without jsdom (see the note on noteTerminalCapture),
-// so only the SETTINGS side is asserted here. The 'nodeterm:shortcut-captured' event is
-// window-guarded and its dispatch is covered by the banner's jsdom test.
+// NODE ENV, deliberately: this file runs without jsdom (see the note on noteTerminalCapture), so
+// only the SETTINGS side is asserted here — WHETHER a notice is raised (the policy gate, the
+// once-ever ledger), never what it looks like.
+//
+// The other side is `components/ShortcutCaptureBanner.test.tsx` (jsdom): it dispatches
+// 'nodeterm:shortcut-captured' ITSELF and asserts what the banner does with it — copy, replacement,
+// the 12s clock, dismissal, and the two silent cases (unknown id, unbound command). Be precise
+// about the seam: nothing presses `noteTerminalCapture`'s own `window.dispatchEvent` line, which is
+// `typeof window` guarded and cannot run here. The two files meet at the event NAME and its
+// `detail.commandId` shape, and that agreement is by convention, not by a test.
 describe('terminalShortcutPolicy / noteTerminalCapture', () => {
   const seen = () => useSettings.getState().settings.seenShortcutCaptureNotices
   const setSettings = (patch: Record<string, unknown>) =>

--- a/src/renderer/lib/keybindingOverrides.ts
+++ b/src/renderer/lib/keybindingOverrides.ts
@@ -6,8 +6,8 @@
  * ShortcutsPanel, and tooltips cannot disagree.
  */
 import {
-  getEffectiveBindings, sanitizeKeybindingOverrides,
-  type CommandId, type KeybindingOverrides
+  getEffectiveBindings, sanitizeKeybindingOverrides, normalizeTerminalShortcutPolicy,
+  type CommandId, type KeybindingOverrides, type TerminalShortcutPolicy
 } from '@shared/keybindings'
 import { shortcutKeyParts } from '@shared/shortcut'
 import { isMacPlatform } from '@shared/platform-utils'
@@ -98,4 +98,35 @@ export function commandKeysFor(id: CommandId, isMac: boolean = isMacPlatform()):
  *  `''` = the user disabled it (dictation shortcut off; the mic button still works). */
 export function dictationBinding(): string {
   return effectiveBindings('speech.dictation')[0] ?? ''
+}
+
+/** Who wins while an xterm has focus. Read through the normalizer, NOT as the raw field: the
+ *  setting is hand-editable JSON, so its compile-time type is not a runtime guarantee, and an
+ *  unknown value must degrade to `app-first` (today's behavior) rather than reach dispatch. */
+export function terminalShortcutPolicy(): TerminalShortcutPolicy {
+  return normalizeTerminalShortcutPolicy(useSettings.getState().settings.terminalShortcutPolicy)
+}
+
+/** Once per command, ever (persisted in settings so Server Edition shares it): record that
+ *  app-first captured this command's chord from a focused terminal, and tell the banner.
+ *  Silent under terminal-first — nothing is being taken from the terminal there.
+ *
+ *  `seenShortcutCaptureNotices` is hand-editable too, so its SHAPE is guarded before use: a
+ *  string would make `.includes` answer true for any substring (swallowing the first notice),
+ *  and a number/object would throw inside a keydown handler. Anything that is not an array of
+ *  strings is treated as empty and REPLACED by a clean array on the next write.
+ *
+ *  The event is window-guarded because this module is imported by node-environment unit
+ *  tests (the same guard `state/settings.ts` carries for its save timer); the settings write
+ *  is the durable half and happens either way. */
+export function noteTerminalCapture(id: CommandId): void {
+  if (terminalShortcutPolicy() !== 'app-first') return
+  const state = useSettings.getState()
+  const raw = state.settings.seenShortcutCaptureNotices
+  const seen = Array.isArray(raw) ? raw.filter((x): x is string => typeof x === 'string') : []
+  if (seen.includes(id)) return
+  state.update({ seenShortcutCaptureNotices: [...seen, id] })
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('nodeterm:shortcut-captured', { detail: { commandId: id } }))
+  }
 }

--- a/src/renderer/lib/terminalFocusMirror.test.ts
+++ b/src/renderer/lib/terminalFocusMirror.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { XTERM_INPUT_CLASS } from './keyContext'
+import { TERMINAL_FOCUS_RECHECK_MS, installTerminalFocusMirror } from './terminalFocusMirror'
+
+/**
+ * REAL DOM (jsdom), because every question this module answers is a question about focus event
+ * ORDER and about what `document.activeElement` says at each point — and a hand-rolled fake would
+ * simply encode whatever the author assumed. The three facts below were MEASURED against jsdom
+ * before this module was written, and each one decides a line of it:
+ *
+ *   1. `focusout` fires with `document.activeElement` already reset to `<body>` — the incoming
+ *      element is not focused yet. So an immediate read during focusout answers "no terminal" for
+ *      EVERY focus move, including terminal → terminal.
+ *   2. A microtask scheduled from that same `focusout` reads the SETTLED element. So deferring the
+ *      read collapses a terminal → terminal hop into no change at all.
+ *   3. Removing the focused element from the document fires NO focusout whatsoever; activeElement
+ *      silently becomes `<body>`. That is the stuck-state path this app actually walks — a parked,
+ *      released or deleted terminal node tears its xterm out of the DOM — and it is why the
+ *      mirror carries a re-check that does not depend on an event arriving.
+ */
+
+const report = vi.fn<(focused: boolean) => void>()
+let stop: (() => void) | null = null
+
+function terminalTextarea(): HTMLTextAreaElement {
+  const ta = document.createElement('textarea')
+  ta.className = XTERM_INPUT_CLASS
+  document.body.append(ta)
+  return ta
+}
+
+function ordinaryInput(): HTMLInputElement {
+  const el = document.createElement('input')
+  document.body.append(el)
+  return el
+}
+
+/** Let the mirror's deferred read run. */
+const settle = (): Promise<void> => Promise.resolve()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  report.mockClear()
+  document.body.innerHTML = ''
+})
+
+afterEach(() => {
+  stop?.()
+  stop = null
+  vi.useRealTimers()
+})
+
+describe('installTerminalFocusMirror', () => {
+  it('reports true when an xterm textarea takes focus, and false when it loses it', async () => {
+    const term = terminalTextarea()
+    const input = ordinaryInput()
+    stop = installTerminalFocusMirror({ report })
+    expect(report).toHaveBeenCalledWith(false) // the initial read: nothing focused yet
+
+    report.mockClear()
+    term.focus()
+    await settle()
+    expect(report.mock.calls).toEqual([[true]])
+
+    report.mockClear()
+    input.focus()
+    await settle()
+    expect(report.mock.calls).toEqual([[false]])
+  })
+
+  it('is change-deduped: focus moving between two terminals reports nothing at all', async () => {
+    const a = terminalTextarea()
+    const b = terminalTextarea()
+    stop = installTerminalFocusMirror({ report })
+    a.focus()
+    await settle()
+    report.mockClear()
+
+    // The measured trap: `focusout` fires with activeElement === <body>, so an IMMEDIATE read here
+    // would report false-then-true on every hop between terminals — a window, however brief, in
+    // which main re-arms the intercepts under a terminal that never lost focus. Two chords land in
+    // that window in practice (⌘W closing a node mid-edit is the one users would file).
+    b.focus()
+    await settle()
+    expect(report).not.toHaveBeenCalled()
+  })
+
+  it('reports the CURRENT state once at install, before any event fires', async () => {
+    terminalTextarea().focus()
+    stop = installTerminalFocusMirror({ report })
+    // Focus predates the mirror (the canvas mounts after a reload with a terminal already focused).
+    // Without this initial read main would sit on its `false` until the user clicked away and back.
+    expect(report.mock.calls).toEqual([[true]])
+  })
+
+  it('reports false when the window loses focus, and re-reports on regain', async () => {
+    const term = terminalTextarea()
+    stop = installTerminalFocusMirror({ report })
+    term.focus()
+    await settle()
+    report.mockClear()
+
+    // A window blur leaves `document.activeElement` on the terminal, so the ordinary read would
+    // keep saying true. The fail-safe direction is "not focused" — main's intercepts belong to the
+    // window that has the keyboard.
+    window.dispatchEvent(new Event('blur'))
+    expect(report.mock.calls).toEqual([[false]])
+
+    // ...and coming back must re-engage. Without this leg the mirror would be stuck FALSE for a
+    // terminal that still holds focus — the intercepts would keep claiming ⌘W under a user who
+    // asked their terminal to have it, with no event left to correct it.
+    report.mockClear()
+    window.dispatchEvent(new Event('focus'))
+    await settle()
+    expect(report.mock.calls).toEqual([[true]])
+  })
+
+  it('the re-check does not undo a window blur', async () => {
+    const term = terminalTextarea()
+    stop = installTerminalFocusMirror({ report })
+    term.focus()
+    await settle()
+    window.dispatchEvent(new Event('blur'))
+    report.mockClear()
+
+    // `document.activeElement` is STILL the terminal while the window sits in the background, so a
+    // re-check that only asked the DOM would report `true` again two seconds later and make the
+    // blur leg decoration. Whether this window has the keyboard is a separate fact and is tracked
+    // as one.
+    vi.advanceTimersByTime(TERMINAL_FOCUS_RECHECK_MS * 3)
+    expect(report).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event('focus'))
+    await settle()
+    expect(report.mock.calls).toEqual([[true]])
+  })
+
+  it('recovers when the focused terminal is removed from the DOM without any focus event', async () => {
+    const term = terminalTextarea()
+    stop = installTerminalFocusMirror({ report })
+    term.focus()
+    await settle()
+    report.mockClear()
+
+    // Park / offscreen release / node delete all rip the xterm out from under a focus that may
+    // still be on it. jsdom fires NOTHING here (measured), and the browsers disagree about whether
+    // they fire `blur` — so the mirror may not lean on an event. Left uncorrected this is the worst
+    // failure this feature has: main believes a terminal is focused forever, stands its intercepts
+    // down forever, and ⌘W/⌘M go to the application MENU — closing and minimizing the window.
+    term.remove()
+    expect(report).not.toHaveBeenCalled() // nothing observed it yet — that is the whole problem
+
+    vi.advanceTimersByTime(TERMINAL_FOCUS_RECHECK_MS)
+    expect(report.mock.calls).toEqual([[false]])
+  })
+
+  it('the re-check is silent while nothing changed', async () => {
+    terminalTextarea().focus()
+    stop = installTerminalFocusMirror({ report })
+    await settle()
+    report.mockClear()
+    vi.advanceTimersByTime(TERMINAL_FOCUS_RECHECK_MS * 5)
+    // Change-deduped, so the safety net costs zero IPC in the steady state — which is what makes
+    // a timer an acceptable price for closing the case above.
+    expect(report).not.toHaveBeenCalled()
+  })
+
+  it('stops completely on teardown — no listeners, no timer', async () => {
+    const term = terminalTextarea()
+    stop = installTerminalFocusMirror({ report })
+    stop()
+    stop = null
+    report.mockClear()
+
+    term.focus()
+    await settle()
+    window.dispatchEvent(new Event('blur'))
+    window.dispatchEvent(new Event('focus'))
+    vi.advanceTimersByTime(TERMINAL_FOCUS_RECHECK_MS * 3)
+    // A leaked listener on a remounted canvas would double-report, and a leaked interval would
+    // keep a torn-down page's answer flowing to main after the mirror was supposed to be gone.
+    expect(report).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/terminalFocusMirror.test.ts
+++ b/src/renderer/lib/terminalFocusMirror.test.ts
@@ -166,11 +166,20 @@ describe('installTerminalFocusMirror', () => {
     expect(report).not.toHaveBeenCalled()
   })
 
-  it('stops completely on teardown — no listeners, no timer', async () => {
+  it('releases the bit on teardown, then stops completely — no listeners, no timer', async () => {
     const term = terminalTextarea()
+    term.focus()
     stop = installTerminalFocusMirror({ report })
+    await settle()
+    report.mockClear()
+
+    // Teardown reports `false` on its way out rather than leaving main holding a `true` nobody
+    // owns any more. Main's three page-death resets cover the page VANISHING; this covers the
+    // ordinary case where the page lives and only this mirror stops. A remount re-reports from
+    // scratch (`last` starts null), so nothing is lost by releasing here.
     stop()
     stop = null
+    expect(report.mock.calls).toEqual([[false]])
     report.mockClear()
 
     term.focus()

--- a/src/renderer/lib/terminalFocusMirror.ts
+++ b/src/renderer/lib/terminalFocusMirror.ts
@@ -123,6 +123,11 @@ export function installTerminalFocusMirror(opts: TerminalFocusMirrorOptions): ()
   push(focusedNow())
 
   return () => {
+    // Release the bit on the way out rather than leaving main holding a `true` that nobody owns
+    // any more. Main's resets cover the page VANISHING; this covers the ordinary case where the
+    // page lives and only this mirror stops. Before `stopped`, or `push` would refuse it. A
+    // remount re-reports from scratch (`last` starts null), so nothing is lost.
+    push(false)
     stopped = true
     window.removeEventListener('focusin', onFocusIn)
     window.removeEventListener('focusout', onFocusOut)

--- a/src/renderer/lib/terminalFocusMirror.ts
+++ b/src/renderer/lib/terminalFocusMirror.ts
@@ -1,0 +1,133 @@
+/**
+ * Mirror "an xterm currently has keyboard focus" from the renderer to the main process, so the
+ * window's `before-input-event` intercepts can stand down under the `terminal-first` shortcut
+ * policy (`src/main/keydown-intercept.ts`).
+ *
+ * **Why main cannot answer this itself.** `before-input-event` fires BEFORE the page sees the key,
+ * so by the time any renderer handler could look at `document.activeElement` main has already
+ * decided whether to `preventDefault`. The answer has to be standing there in advance, which makes
+ * it a mirror — a fact main holds a possibly-stale copy of — and every design choice below is
+ * about that staleness.
+ *
+ * **Fail-safe direction: NOT focused.** A missing, stale or never-sent mirror must read as "no
+ * terminal is focused", i.e. the intercepts stay ON and the app behaves exactly as it did before
+ * this feature. The opposite direction is the expensive one: main would stand down forever, ⌘W and
+ * ⌘M would go to the application MENU (close window / minimize), and no live component would be
+ * left to correct it. Main enforces its half (a `false` initial value plus a reset on every way
+ * the page can stop existing); this module enforces the renderer's half by never leaving a `true`
+ * standing on an event that may not arrive.
+ *
+ * Extracted from `Canvas.tsx` rather than written inline as an effect **because the interesting
+ * cases are the ones no manual test walks**: focus hopping between two terminals, a window blur,
+ * and a focused terminal being torn out of the DOM by a park / offscreen release / node delete.
+ * `terminalFocusMirror.test.ts` presses all three against a real (jsdom) DOM.
+ */
+import { isTerminalTarget, type ContextElement } from './keyContext'
+
+/**
+ * How often the mirror re-reads focus with no event to prompt it. This exists for ONE measured
+ * case: removing the focused element from the document fires **no** focus event at all (jsdom
+ * fires nothing; browsers disagree about whether they fire `blur`), and this app removes focused
+ * xterm textareas routinely — terminal park, the offscreen release, and node deletion all do it.
+ * Without a re-check that case leaves the mirror stuck on `true` permanently.
+ *
+ * The read is `document.activeElement` plus one `classList.contains`, and the report is
+ * change-deduped, so the steady-state cost of this net is a property read per interval and zero
+ * IPC. 2s is picked so a stuck `true` self-heals well inside the time it takes a user to notice a
+ * terminal vanished and reach for a chord.
+ */
+export const TERMINAL_FOCUS_RECHECK_MS = 2000
+
+export interface TerminalFocusMirrorOptions {
+  /** Where the answer goes. Called ONLY when the answer changed — main holds a boolean, so
+   *  re-sending the same value is pure IPC noise on a canvas that changes focus constantly. */
+  report: (focused: boolean) => void
+  /** Overridable purely for tests; see the deferred read in `schedule` below. */
+  recheckMs?: number
+}
+
+/**
+ * Start mirroring. Returns the teardown — it removes every listener AND clears the re-check timer;
+ * a leaked one of either would keep reporting from a canvas that has been replaced.
+ */
+export function installTerminalFocusMirror(opts: TerminalFocusMirrorOptions): () => void {
+  const { report, recheckMs = TERMINAL_FOCUS_RECHECK_MS } = opts
+  let last: boolean | null = null
+  let stopped = false
+  /**
+   * Does this WINDOW have the keyboard? Tracked as its own flag because `document.activeElement`
+   * does not answer it — an element keeps being the active element while the whole window sits in
+   * the background, so without this the re-check below would quietly re-report `true` two seconds
+   * after the blur leg pushed `false`, and the blur leg would be decoration.
+   *
+   * Seeded `true` rather than from `document.hasFocus()`: that answers differently across
+   * environments (jsdom says `false` for a perfectly ordinary document — measured), and of the two
+   * ways to be wrong at mount only one is expensive. A wrong `true` costs nothing — an unfocused
+   * window receives no `before-input-event` at all, and the `focus` leg re-reads the moment it does
+   * — whereas a wrong `false` would leave the policy silently dead over a terminal that is focused
+   * and fires no further focus event.
+   */
+  let windowFocused = true
+
+  const focusedNow = (): boolean =>
+    windowFocused && isTerminalTarget(document.activeElement as unknown as ContextElement | null)
+
+  /** Report `focused` if it differs from what main was last told. */
+  const push = (focused: boolean): void => {
+    if (stopped || focused === last) return
+    last = focused
+    report(focused)
+  }
+
+  /**
+   * Read `document.activeElement` **in a microtask**, not inline.
+   *
+   * MEASURED (jsdom, and the same order the HTML spec prescribes): `focusout` is dispatched with
+   * `activeElement` already reset to `<body>` — the incoming element is not focused yet — and the
+   * matching `focusin` follows afterwards. An inline read therefore answers "no terminal" for
+   * every single focus move, including terminal → terminal, so main would re-arm its intercepts
+   * for the gap between the two events. A microtask scheduled from `focusout` reads the SETTLED
+   * element (measured), which collapses a terminal → terminal hop into no report at all and still
+   * answers `<body>` when focus genuinely went nowhere.
+   */
+  const readSoon = (): void => {
+    queueMicrotask(() => push(focusedNow()))
+  }
+
+  const onFocusIn = (): void => readSoon()
+  const onFocusOut = (): void => readSoon()
+  /** The window lost the keyboard. `document.activeElement` stays on the terminal, so the answer
+   *  has to come from `windowFocused` — and it must be recorded there, not just pushed, or the
+   *  re-check would undo it on its next tick. */
+  const onWindowBlur = (): void => {
+    windowFocused = false
+    push(focusedNow())
+  }
+  /** ...and the matching re-engage. Regaining window focus does not reliably fire `focusin` on the
+   *  element that still holds focus, so without this leg the mirror would sit stuck at `false`
+   *  over a focused terminal — the safe direction, but a policy that silently stopped working. */
+  const onWindowFocus = (): void => {
+    windowFocused = true
+    readSoon()
+  }
+
+  window.addEventListener('focusin', onFocusIn)
+  window.addEventListener('focusout', onFocusOut)
+  window.addEventListener('blur', onWindowBlur)
+  window.addEventListener('focus', onWindowFocus)
+  const timer = setInterval(() => push(focusedNow()), recheckMs)
+
+  // The state BEFORE any event: the canvas mounts after a reload with focus already somewhere, and
+  // main is sitting on its `false` until told otherwise. Synchronous on purpose — this is the one
+  // read with no focus transition to settle.
+  push(focusedNow())
+
+  return () => {
+    stopped = true
+    window.removeEventListener('focusin', onFocusIn)
+    window.removeEventListener('focusout', onFocusOut)
+    window.removeEventListener('blur', onWindowBlur)
+    window.removeEventListener('focus', onWindowFocus)
+    clearInterval(timer)
+  }
+}

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -166,7 +166,7 @@ import { agentEnvSnapshot } from '@renderer/lib/agentEnv'
 import { normalizedAgentModel } from '@shared/agents/model-gateway'
 import { ensureActivePermissionMode } from '../state/permissionMode'
 import { buildSshArgs, sshConnectionIdForProject, sshHostKey, type SshConnection } from '@shared/ssh'
-import { chipFor, effectiveBindings } from '../lib/keybindingOverrides'
+import { chipFor, effectiveBindings, terminalShortcutPolicy } from '../lib/keybindingOverrides'
 import { matchesShortcut } from '@shared/shortcut'
 import { isMacPlatform } from '@shared/platform-utils'
 import { ColumnPill } from '../components/kanban/ColumnPill'
@@ -2370,9 +2370,14 @@ export function TerminalNode({
     // ESC+CR (`SHIFT_ENTER_SEQ`) — agent CLIs read that as "insert newline" (see terminal-config.ts).
     // Cmd/Ctrl+1-9 (jump to the Nth project) must be swallowed before xterm turns Ctrl+2..Ctrl+8
     // into control bytes — but ONLY when the app owns the key: desktop shell, digit addressing an
-    // open project. `liveProjectJumpTarget` is the same decision Canvas's handler makes.
+    // open project, AND app-first. Under terminal-first the user reserved every chord for the
+    // shell, so the digit must reach the PTY: this handler runs inside xterm, ahead of the window
+    // dispatcher that honors the policy for every other chord, so it owes the check itself.
+    // `liveProjectJumpTarget` is the same decision Canvas's handler makes.
     term.attachCustomKeyEventHandler((e) => {
-      const action = terminalKeyAction(e, term.hasSelection(), liveProjectJumpTarget(e) !== null)
+      const ownsProjectJump =
+        terminalShortcutPolicy() !== 'terminal-first' && liveProjectJumpTarget(e) !== null
+      const action = terminalKeyAction(e, term.hasSelection(), ownsProjectJump)
       if (action === 'pass') return true
       e.preventDefault()
       if (action === 'copy') window.nodeTerminal.clipboard.writeText(term.getSelection())

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -75,6 +75,15 @@ export const IPC = {
    *  closing their selected nodes. Fire-and-forget `send`; desktop-only (a browser tab has no
    *  application menu to steal a chord back from, so the Server Edition stubs it). */
   uiShortcutRecording: 'ui:shortcut-recording',
+  /** Renderer → main: an xterm does (`true`) / does not (`false`) currently hold keyboard focus.
+   *  A MIRROR, not a request: under the `terminal-first` shortcut policy the intercepts above must
+   *  stand down while the user is typing in a terminal, and `before-input-event` fires before any
+   *  renderer handler could tell main so — the answer has to already be there. Change-deduped by
+   *  the sender, fire-and-forget `send`, and read fail-safe: main starts at `false` and every way
+   *  the page can stop existing resets it there, so a stale mirror means intercepts ON (the
+   *  pre-policy app), never a window whose ⌘W has silently gone back to the application menu.
+   *  Desktop-only, for the same reason as the recording bit — the Server Edition stubs it. */
+  uiTerminalFocus: 'ui:terminal-focus',
   appCloseWindow: 'app:close-window',
   /** Main → renderer: the native application menu's "Settings…" item (⌘,) was clicked. The
    *  renderer opens the settings page — same path as the in-canvas gear button / Cmd+, keydown. */

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -9,6 +9,7 @@ import {
   findKeybindingConflicts,
   sanitizeKeybindingOverrides,
   resolveCommandForKeyEvent,
+  normalizeTerminalShortcutPolicy,
   MAIN_INTERCEPTED_COMMAND_IDS,
   findMainInterceptShadowing
 } from './keybindings'
@@ -318,8 +319,12 @@ describe('sanitizeKeybindingOverrides', () => {
 const ev = (over: Partial<ShortcutKeyEvent>): ShortcutKeyEvent => ({
   metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, key: '', ...over
 })
-const ctx = (over: Partial<{ typing: boolean; terminal: boolean; kanbanOpen: boolean }> = {}) => ({
-  typing: false, terminal: false, kanbanOpen: false, ...over
+const ctx = (
+  over: Partial<{
+    typing: boolean; terminal: boolean; kanbanOpen: boolean; terminalFirst: boolean
+  }> = {}
+) => ({
+  typing: false, terminal: false, kanbanOpen: false, terminalFirst: false, ...over
 })
 
 describe('resolveCommandForKeyEvent', () => {
@@ -439,5 +444,39 @@ describe('findMainInterceptShadowing', () => {
   })
   it('names exactly the two main-intercepted commands', () => {
     expect(MAIN_INTERCEPTED_COMMAND_IDS).toEqual(['node.close', 'node.toggleMarkdown'])
+  })
+})
+
+describe('normalizeTerminalShortcutPolicy', () => {
+  it('defaults everything but the literal terminal-first to app-first', () => {
+    expect(normalizeTerminalShortcutPolicy('terminal-first')).toBe('terminal-first')
+    expect(normalizeTerminalShortcutPolicy('app-first')).toBe('app-first')
+    expect(normalizeTerminalShortcutPolicy(undefined)).toBe('app-first')
+    expect(normalizeTerminalShortcutPolicy('shell-first')).toBe('app-first')
+  })
+})
+
+describe('resolver under terminal-first', () => {
+  const term = (terminalFirst: boolean) => ({
+    typing: false, terminal: true, kanbanOpen: false, terminalFirst
+  })
+  it('app-first keeps today: allowInTerminal app commands fire over a terminal', () => {
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'k' }), term(false), {}, true))
+      .toBe('app.commandPalette')
+  })
+  it('terminal-first blocks allowInTerminal app commands', () => {
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'k' }), term(true), {}, true))
+      .toBeNull()
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, shiftKey: true, key: 'b' }), term(true), {}, true))
+      .toBeNull()
+  })
+  it('terminal-first keeps terminal-scope commands alive', () => {
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'f' }), term(true), {}, true))
+      .toBe('terminal.find')
+  })
+  it('terminalFirst is inert outside terminal focus', () => {
+    const app = { typing: false, terminal: false, kanbanOpen: false, terminalFirst: true }
+    expect(resolveCommandForKeyEvent(ev({ metaKey: true, key: 'k' }), app, {}, true))
+      .toBe('app.commandPalette')
   })
 })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -363,6 +363,18 @@ export function sanitizeKeybindingOverrides(
   return { overrides, warnings }
 }
 
+/** Who wins while an xterm has focus. 'app-first' (default): allowInTerminal app commands still
+ *  fire (today's behavior). 'terminal-first': ONLY scope:'terminal' commands fire; everything
+ *  else — allowInTerminal app commands, the main-intercepted ⌘W/⌘M, the registry-less gestures —
+ *  reaches the PTY. NOTE: the naive reading "terminal-first = the existing allowInTerminal gate"
+ *  is vacuous here — that gate IS app-first; this flag tightens past it. */
+export type TerminalShortcutPolicy = 'app-first' | 'terminal-first'
+
+/** Unknown/legacy values read as app-first (the safe, current-behavior direction). */
+export function normalizeTerminalShortcutPolicy(v: unknown): TerminalShortcutPolicy {
+  return v === 'terminal-first' ? 'terminal-first' : 'app-first'
+}
+
 /** `typing` and `terminal` are expected to be DISJOINT — xterm's hidden textarea is a terminal,
  *  not a typing surface, so a caller classifying focus must not report both. If one does anyway,
  *  `typing` wins (it is checked first) and every terminal-scope command becomes unreachable. */
@@ -373,6 +385,9 @@ export interface KeyDispatchContext {
   terminal: boolean
   /** The kanban board is open for the active project. */
   kanbanOpen: boolean
+  /** terminal-first policy is active: while `terminal` is true, only scope:'terminal' commands
+   *  may resolve (allowInTerminal is an app-first concept). Inert when `terminal` is false. */
+  terminalFirst: boolean
 }
 
 /** Pure dispatch core: the first registry command (source order) whose effective bindings
@@ -398,7 +413,9 @@ export function resolveCommandForKeyEvent(
     // `{"speech.dictation": ["Cmd+0"]}` would silently kill zoom-to-100%.
     if (def.id === 'speech.dictation') continue
     if (ctx.typing && !def.allowWhileTyping) continue
-    if (ctx.terminal && !(def.scope === 'terminal' || def.allowInTerminal)) continue
+    if (ctx.terminal) {
+      if (def.scope !== 'terminal' && (ctx.terminalFirst || !def.allowInTerminal)) continue
+    }
     if (!ctx.terminal && def.scope === 'terminal') continue
     if (ctx.kanbanOpen && def.scope === 'canvas') continue
     for (const binding of getEffectiveBindings(def.id, overrides, isMac)) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2496,6 +2496,15 @@ export interface ShortcutsApi {
    *  no-op (a browser tab has no application menu to steal a chord back from, so nothing
    *  intercepts). */
   setRecording(active: boolean): void
+  /** Mirror whether an xterm currently holds keyboard focus, so the desktop's intercepts can stand
+   *  down under the `terminal-first` shortcut policy — `before-input-event` fires before any
+   *  renderer handler could answer, so main needs the answer in advance. Sent on CHANGE only.
+   *  Fire-and-forget, and **not optional**: the mirror is the only thing that makes the policy
+   *  reach the three main-intercepted chords. Read fail-safe on the far side (a missing or stale
+   *  mirror = not focused = intercepts on), so the failure mode of never sending is the app
+   *  behaving as it did before the policy existed. Server Edition: a documented no-op, like
+   *  `setRecording` — a browser tab has no application menu to steal a chord back from. */
+  setTerminalFocused(focused: boolean): void
 }
 
 export interface NodeTerminalApi {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,7 +2,7 @@
 
 import { DEFAULT_WORKTREE_PATH_TEMPLATE } from './worktree'
 import type { CloneProgress } from './clone-url'
-import type { KeybindingOverrides } from './keybindings'
+import type { KeybindingOverrides, TerminalShortcutPolicy } from './keybindings'
 import type { NormalizedAgentEvent } from './agents/normalize'
 import type { AgentId, AgentPermissionMode, BuiltinAgentId, PromptInjectionMode } from './agents/config'
 import type { AgentMessageDeliverRequest, AgentMessageReply } from './agents/agent-messaging'
@@ -1206,9 +1206,17 @@ export interface Settings {
    *  entries are dropped with a console warning at read time (sanitizeKeybindingOverrides).
    *  Optional and deliberately not in DEFAULT_SETTINGS: absent simply means "no overrides". */
   keybindings?: KeybindingOverrides
+  /** Who wins while a terminal has keyboard focus: 'app-first' (default) lets allowInTerminal
+   *  app commands fire over an xterm; 'terminal-first' reserves every chord but the terminal's
+   *  own (find, copy) for the shell/TUI — including ⌘W/⌘M and the zoom/project-jump gestures. */
+  terminalShortcutPolicy: TerminalShortcutPolicy
+  /** Command ids whose "this chord was captured from your terminal" notice has been shown
+   *  (app-first only, once per command). Optional and absent from DEFAULT_SETTINGS: absent
+   *  means none seen. Lives in settings, not localStorage, so Server Edition shares it. */
+  seenShortcutCaptureNotices?: string[]
   /** Per-node hook identity enforcement (src/core/agents/node-identity-policy.ts).
    *
-   *  One of the two optional keys in this interface, and deliberately so: it is a TRI-state, and the two
+   *  One of the three optional keys in this interface, and deliberately so: it is a TRI-state, and the two
    *  non-default states are opposite escape hatches. Absent (the default — it is not in
    *  DEFAULT_SETTINGS) follows `NODE_IDENTITY_STRICT_AFTER`, so the rollout has one schedule for
    *  everybody. `true` opts in to strict enforcement before that date. `false` keeps the warning
@@ -1264,6 +1272,9 @@ export const DEFAULT_SETTINGS: Settings = {
   commitAgent: 'claude',
   commitAgentCommand: '',
   commitExtraPrompt: '',
+  // 'app-first' reproduces today's dispatch bit-for-bit: allowInTerminal app commands keep
+  // firing over a focused xterm. Opting into 'terminal-first' is the user's call, never ours.
+  terminalShortcutPolicy: 'app-first',
   seenShortcuts: false,
   seenOnboarding: false,
   notifyOnClaudeDone: true,


### PR DESCRIPTION
Part 4 of the remappable-shortcuts series (#311 registry, #316 dispatch, #322 settings UI): who wins the keyboard while a terminal has focus.

- **`terminalShortcutPolicy` setting** (Shortcuts section, segmented control). Default **app-first** = today's behavior, bit-for-bit. Opt-in **terminal-first**: while an xterm has focus, only the terminal's own commands (find, copy) fire — everything else reaches the shell/TUI: the shared app chords (⌘K, panels, kanban), ⌘W/⌘M, ⌘0, ⌘1-9 (the terminals' own digit-swallow is now policy-aware too), and the ⌘C copy gesture. Hold-to-talk dictation is deliberately exempt (modifier-only chords type nothing into a TUI). **Named exception: reload (⌘R/⌘⇧R) stays with the app** — it is the crash-recovery lever.
- **How the main process learns**: a renderer→main terminal-focus mirror (change-deduped; window focus/blur legs; a 2-second re-check because removing a focused element fires no focus event at all — park/offscreen-release/node-delete would otherwise strand the stand-down; fail-safe direction throughout: a stale mirror reads as NOT focused, i.e. intercepts stay on; the same three resets as the recorder bit).
- **The application menu stands down too**: while terminal-first + terminal focused, the menu's Minimize, Close (Windows/Linux), Toggle Kanban Board and Settings items are disabled so their accelerators (⌘M, Ctrl+W, ⌘⇧B, ⌘,) genuinely reach the PTY instead of minimizing/closing the window — those items grey out to the mouse for that moment, by design, and re-enable the instant focus leaves the terminal.
- **Capture notice (app-first only)**: the first time each command's chord is taken from a focused terminal, a dismissible banner names it ("⌘K ran Command palette instead of reaching your terminal") with an Open Shortcuts action. Once per command, remembered in settings (shared with Server Edition). The menu-owned pair (⌘⇧B, ⌘,) get their notices at the IPC receivers since the menu wins before the page sees the key.

### Notes and limits (documented, not silent)

- Worst case after tearing out a focused terminal (delete/park), the stand-down can persist up to ~2s; the re-check closes it. The mirror also runs (inert, deduped-to-zero IPC) in the Server Edition, where there is nothing to stand down.
- The CLAUDE.md claim about menu accelerators is scoped to command-style roles; Chromium's standard edit roles behave differently — one Mac measurement item is on the verification matrix (⌘⇧B with a terminal focused under terminal-first).
- Under app-first nothing changed — verified down to the resolver gate's truth table and the menu sync's `policyStandsDown('app-first', …) === false` pin.

Remaining for later: per-chip binding removal UX; the two filed follow-ups from #322 (dictation conflict bucket; menu suspension while RECORDING ⌘M).

🤖 Generated with [Claude Code](https://claude.com/claude-code)