### PR TITLE
feat(codex): the shared relay daemon — catalog merge, expose/verify, conversation-id guard

### DIFF
--- a/docs/superpowers/probes/2026-08-codex-relay-daemon.md
+++ b/docs/superpowers/probes/2026-08-codex-relay-daemon.md
@@ -1,0 +1,99 @@
+# Probe — the shared Codex relay daemon (S6 PR 4: U1, U2, U4, U6)
+
+**Design claims under test:** the four `[UNVERIFIED]` assumptions the shared relay daemon
+(`src/main/codex-relay-daemon.ts`) and the cross-machine rollout copy rest on (S6-spec §7). Run
+first, before the daemon was built on them; recorded here and in the daemon's header comment.
+
+## Environment
+
+- **Codex CLI 0.146.0** (`/usr/bin/codex`, npm-managed). Linux, headless. System `~/.codex` is logged
+  in (`~/.codex/auth.json`, `0600`) and holds real rollouts under `~/.codex/sessions/YYYY/MM/DD/`.
+- **No running app-server and no curl-managed standalone install** on this host:
+  `~/.codex/app-server-control/` has only a `app-server-startup.lock`, no `.sock`; there is no
+  `~/.codex/packages/standalone/current/codex`. This is the documented U4 caveat and it bounds what
+  U1/U2 could be measured directly (see below) — the same limitation the U5 probe hit.
+- Node 22.22.2. The relay's own runnable behaviour is exercised by
+  `src/main/codex-relay-daemon.test.ts` (30 tests) against real fs / real unix-socket fake
+  app-servers.
+
+## U4 — Codex app-server subcommands and flags exist as used — **PARTIAL / VERIFIED**
+
+Measured against the real CLI:
+
+- `codex app-server daemon` exposes `start | restart | stop | version | bootstrap |
+  enable-remote-control | disable-remote-control`. `CODEX_HOME` is honoured: `daemon start` created
+  `<CODEX_HOME>/app-server-daemon/{app-server.pid.lock,daemon.lock}`, and `daemon version` returned
+  JSON reporting `socketPath = <CODEX_HOME>/app-server-control/app-server-control.sock` (confirming
+  the socket layout the daemon assumes: `dirname(dirname(socket)) === CODEX_HOME`, sibling
+  `sessions/` — U7 corollary, confirmed against the real `~/.codex` tree).
+- **The `SUN_LEN` constraint is REAL.** With a long scratch `CODEX_HOME`, `daemon version` failed to
+  connect: `path must be shorter than SUN_LEN`. This is exactly why the managed home digest is short
+  (S6-spec §2.1) — measured, not assumed.
+- `--remote <ADDR>` and `--remote-auth-token-env <ENV_VAR>` exist on the global command and on
+  `resume`/`fork`. The remote bearer token is named by **env var**, never passed on argv (GC 6).
+- Rollout filenames are `rollout-<timestamp>-<UUID>.jsonl` where the UUID is the thread id
+  (`session_meta.session_id`), so PR 3's `planCodexRolloutExposure` filename check
+  (`basename.endsWith("<threadId>.jsonl")`) holds against real rollouts.
+
+**Not runnable headless:** `daemon start` actually binding a live socket, and the
+`account/read`→`{email}` / `thread/read`→`{path,cwd}` RPC shapes, require the curl-managed standalone
+install absent here (`daemon start` errored: *"managed standalone Codex install not found at
+…/packages/standalone/current/codex"*). The relay speaks those shapes to **fake** app-servers in the
+suite; a live-shape check is **owed device-verification** on a box with the standalone install.
+
+**Verdict: NOT BLOCKED** — the subcommand/flag surface the daemon depends on exists as used; the RPC
+payload shapes are the only unmeasured part and are covered by the design's fail-closed verify step.
+
+## U1 — a RUNNING app-server surfaces a freshly hardlinked rollout without a reindex — **UNVERIFIED (headless), NOT BLOCKING**
+
+Could not be measured: no running app-server and no standalone install to start one, so whether
+`thread/read` (and the merged `thread/list` picker) surfaces a just-hardlinked
+`sessions/…/rollout-…jsonl` without rebuilding an index is unproven here.
+
+**Why it does not block, and how the design self-protects:** the cross-machine copy does **not** trust
+the optimistic answer. `exposeForeignThread` links the rollout via PR 3's primitive and then RE-READS
+the **target** socket (`thread-check` = `thread/read`); it returns `exposed` only if the far side
+reports that exact id with an absolute path/cwd, and otherwise **rolls the published link back and
+refuses** (proven by *"rolls the published link back when the target app-server cannot discover the
+copy"*). So if U1 is false in practice, the copy degrades to a *refused* copy — never a silent switch
+onto a host that cannot see the conversation. If a device check finds a reindex IS required, the fix
+is local: trigger it before the verify read; the fail-closed contract is unchanged. **Owed
+device-verification** with the standalone install + auth.
+
+## U2 — the conversation id survives copy + account switch — **UNVERIFIED (headless), NOT BLOCKING**
+
+Could not be measured: needs auth, a second managed login, and a running daemon to actually
+`resume <id>` a copied rollout under a different account and observe the returned `thread.id`.
+
+**Why it does not block:** the copy is a **hardlink of the exact source inode**, so the on-disk
+conversation id is byte-identical; the relay resumes **by rollout path** with `params.history`
+deleted (Codex resume precedence history > path > id, `retargetRelayResumeByPath`). If Codex
+nonetheless forks the id under the new login, `resolveRelayThreadResponse` flags `unexpectedThreadId`
+and the reply is rewritten to error `-32004 "Codex changed the conversation id during account
+switch"` (proven by *"rejects a path-resume response that changes the conversation id"*). A false U2
+therefore surfaces as a refused switch, never a silent fork. **Owed device-verification.**
+
+## U6 — relay self-spawn — **LOCAL LEG VERIFIED (runnable); REMOTE LEG owed**
+
+The daemon self-execs `spawn(process.execPath, [__filename, 'serve'], { env: {
+ELECTRON_RUN_AS_NODE: '1', … } })` and dispatches on `process.argv[2]`
+(`serve|register|account-read|thread-check|expose-thread`).
+
+- **Runnable, verified:** the suite bundles the TS daemon to CJS (esbuild) and runs it under plain
+  `node`: `register` self-spawns `serve`, which binds a loopback-TCP control port, writes its `0600`
+  state file, and answers a real `/register` round-trip returning `ws://127.0.0.1:<port>` + a route
+  key (*"sources the node token from env, never argv, and mints a header-only control token"*). In
+  Electron main `process.execPath` is the Electron binary and `ELECTRON_RUN_AS_NODE=1` runs it as
+  Node — the standard NodeTerm self-spawn idiom.
+- **Owed device-verification:** the REMOTE leg — the uploaded `~/.nodeterm/bin/codex-relay.js` run
+  via the `nodeterm-codex` launcher over the host's own Node, answering
+  `register`/`thread-check`/`expose-thread` — needs a live SSH host and is not exercised here.
+
+**Verdict: NOT BLOCKED.**
+
+## Note observed while probing (not a probe target)
+
+`ensureServer` acquires its control lock *inside* `~/.nodeterm` but does not itself create that root
+(only `serve()` does), so the very first `register` on a machine whose `~/.nodeterm` does not yet
+exist cannot self-spawn the server. In production `~/.nodeterm` already exists (node-auth secret,
+mappings, …); flagged for PR 5's live wiring to ensure the root is created before first relay use.

--- a/src/core/codex-session-name.test.ts
+++ b/src/core/codex-session-name.test.ts
@@ -10,10 +10,17 @@ import os from 'node:os'
 import http from 'node:http'
 import path from 'node:path'
 import { WebSocketServer, type WebSocket } from 'ws'
+import { createHash } from 'node:crypto'
 import {
   codexThreadExistsAt,
   codexUnixWebSocketUrl,
+  forgetCodexSessionNames,
+  readCodexAccountAt,
+  readCodexSessionName,
   readCodexSessionNameAt,
+  readCodexThreadAt,
+  relayedCodexSessionName,
+  rememberCodexSessionName,
   waitForCodexAppServer
 } from './codex-session-name'
 
@@ -158,5 +165,133 @@ describe('codexUnixWebSocketUrl', () => {
     expect(() => codexUnixWebSocketUrl('relative/app-server.sock')).toThrow()
     expect(() => codexUnixWebSocketUrl('/tmp/with space/app.sock')).toThrow()
     expect(() => codexUnixWebSocketUrl('/tmp/a?b/app.sock')).toThrow()
+  })
+})
+
+describe('relayedCodexSessionName (the on-disk relay fallback)', () => {
+  it('reads, trims and caps the name the relay stored under the socket-scoped path', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-relay-name-'))
+    const socketPath = '/home/x/.codex/app-server-control/app-server-control.sock'
+    const scope = createHash('sha256').update(socketPath).digest('hex').slice(0, 16)
+    const nameDir = path.join(home, '.nodeterm', 'codex-thread-names', scope)
+    fs.mkdirSync(nameDir, { recursive: true })
+    fs.writeFileSync(path.join(nameDir, 'thread-1'), `  ${'z'.repeat(600)}  `)
+    const value = relayedCodexSessionName(socketPath, 'thread-1', home)
+    expect(value).toBe('z'.repeat(500))
+    expect(relayedCodexSessionName(socketPath, 'thread-missing', home)).toBeNull()
+    expect(relayedCodexSessionName(socketPath, '../escape', home)).toBeNull()
+    fs.rmSync(home, { recursive: true, force: true })
+  })
+})
+
+describe('readCodexSessionName relay fallback wiring', () => {
+  it('falls back to the relayed name when the app-server reports none, and a real name wins', async () => {
+    const savedHome = process.env.HOME
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-name-wire-'))
+    process.env.HOME = home
+    forgetCodexSessionNames()
+    try {
+      const scope = createHash('sha256').update(sock).digest('hex').slice(0, 16)
+      const nameDir = path.join(home, '.nodeterm', 'codex-thread-names', scope)
+      fs.mkdirSync(nameDir, { recursive: true })
+      fs.writeFileSync(path.join(nameDir, 'thread-nameless'), 'Relayed title')
+      // The server has this thread but with a null name → the relay copy fills in.
+      expect(await readCodexSessionName('thread-nameless', sock)).toBe('Relayed title')
+      forgetCodexSessionNames()
+      // A real server name always wins over the relay copy.
+      fs.writeFileSync(path.join(nameDir, 'thread-known'), 'Stale relayed title')
+      expect(await readCodexSessionName('thread-known', sock)).toBe('Named by codex')
+    } finally {
+      forgetCodexSessionNames()
+      if (savedHome === undefined) delete process.env.HOME
+      else process.env.HOME = savedHome
+      fs.rmSync(home, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('rememberCodexSessionName', () => {
+  it('seeds the cache so the next read serves it without a socket, and rejects a bad id', async () => {
+    forgetCodexSessionNames()
+    try {
+      // A dead socket would answer null; the seeded value is served instead.
+      const dead = path.join(dir, 'dead-remember.sock')
+      rememberCodexSessionName('thread-seeded', 'Seeded title', dead)
+      expect(await readCodexSessionName('thread-seeded', dead)).toBe('Seeded title')
+      rememberCodexSessionName('../bad', 'ignored', dead)
+      expect(relayedCodexSessionName(dead, '../bad')).toBeNull()
+    } finally {
+      forgetCodexSessionNames()
+    }
+  })
+})
+
+describe('readCodexThreadAt / readCodexAccountAt', () => {
+  let d = ''
+  let s = ''
+  let srv: http.Server
+  let w: WebSocketServer
+
+  beforeAll(async () => {
+    d = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-cx2-'))
+    s = path.join(d, 'as.sock')
+    srv = http.createServer()
+    w = new WebSocketServer({ server: srv })
+    w.on('connection', (ws) => {
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString()) as Record<string, any>
+        if (msg.method === 'initialize') return ws.send(JSON.stringify({ id: msg.id, result: {} }))
+        if (msg.method === 'thread/read') {
+          const id = msg.params?.threadId as string
+          if (id === 'thread-a')
+            return ws.send(
+              JSON.stringify({
+                id: msg.id,
+                result: { thread: { id, name: 'A', path: '/abs/rollout-thread-a.jsonl' } }
+              })
+            )
+          if (id === 'thread-b')
+            return ws.send(
+              JSON.stringify({ id: msg.id, result: { thread: { id, name: null, path: 'relative' } } })
+            )
+          if (id === 'thread-forked')
+            // The server answers with a DIFFERENT id — must be refused.
+            return ws.send(
+              JSON.stringify({ id: msg.id, result: { thread: { id: 'other', path: '/abs/x.jsonl' } } })
+            )
+          return ws.send(JSON.stringify({ id: msg.id, error: { message: 'no rollout found' } }))
+        }
+        if (msg.method === 'account/read')
+          return ws.send(
+            JSON.stringify({ id: msg.id, result: { account: { email: '  dev@example.com  ' } } })
+          )
+      })
+    })
+    await new Promise<void>((resolve) => srv.listen(s, resolve))
+  })
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => w.close(() => resolve()))
+    await new Promise<void>((resolve) => srv.close(() => resolve()))
+    fs.rmSync(d, { recursive: true, force: true })
+  })
+
+  it('reads id, name and absolute path; drops a non-absolute path to null', async () => {
+    expect(await readCodexThreadAt(s, 'thread-a')).toEqual({
+      id: 'thread-a',
+      name: 'A',
+      path: '/abs/rollout-thread-a.jsonl'
+    })
+    expect(await readCodexThreadAt(s, 'thread-b')).toEqual({ id: 'thread-b', name: null, path: null })
+  })
+
+  it('refuses a response whose thread id does not match the one asked for', async () => {
+    expect(await readCodexThreadAt(s, 'thread-forked')).toBeNull()
+    expect(await readCodexThreadAt(s, 'thread-unknown')).toBeNull()
+    expect(await readCodexThreadAt(s, '../../etc/passwd')).toBeNull()
+  })
+
+  it('reads and trims the account email', async () => {
+    expect(await readCodexAccountAt(s)).toEqual({ email: 'dev@example.com' })
   })
 })

--- a/src/core/codex-session-name.ts
+++ b/src/core/codex-session-name.ts
@@ -13,6 +13,8 @@
  * cannot read means the node keeps its own title, and a thread we cannot start means the launcher
  * falls back to plain codex.
  */
+import { createHash } from 'crypto'
+import { readFileSync } from 'fs'
 import { homedir } from 'os'
 import path from 'path'
 import { WebSocket } from 'ws'
@@ -480,8 +482,192 @@ export function startCodexThread(cwd: string): Promise<string> {
 }
 
 /**
+ * The relay's on-disk fallback for a session name the shared app-server no longer reports.
+ *
+ * A native in-TUI `/resume` can fork a cloud conversation into a local app-server thread whose
+ * `Thread.name` is `null`; the persistent relay observed the source id at bind time and copied its
+ * `session_index` title to `~/.nodeterm/codex-thread-names/<sha256(socket)[..16]>/<threadId>` (the
+ * exact path the relay daemon's `nameFile` writes — one definition, kept in step). Read as DATA and
+ * capped; a later real `Thread.name` from the server always wins. Fails to `null`.
+ */
+export function relayedCodexSessionName(
+  socketPath: string,
+  threadId: string,
+  home = homedir()
+): string | null {
+  if (!isSafeThreadId(threadId)) return null
+  try {
+    const scope = createHash('sha256').update(socketPath).digest('hex').slice(0, 16)
+    const value = readFileSync(
+      path.join(home, '.nodeterm', 'codex-thread-names', scope, threadId),
+      'utf8'
+    ).trim()
+    return value ? value.slice(0, 500) : null
+  } catch {
+    return null
+  }
+}
+
+/** Seed the in-process name cache from a name observed elsewhere (e.g. a relay bind), so the next
+ * sweep serves it without a socket round-trip. A blank name caches an explicit `null`. */
+export function rememberCodexSessionName(
+  threadId: string,
+  name: unknown,
+  socketPath = defaultCodexAppServerSocket()
+): void {
+  if (!isSafeThreadId(threadId)) return
+  const value = typeof name === 'string' && name.trim() ? name.trim() : null
+  names.set(`${socketPath}\0${threadId}`, { name: value, at: Date.now() })
+}
+
+/** Read a thread's full identity from an app-server socket: its id (must come back UNCHANGED), name,
+ * and absolute rollout path. Used by the cross-account switch to locate a foreign rollout. Fails to
+ * `null` rather than throwing into a poll loop. */
+export function readCodexThreadAt(
+  socketPath: string,
+  threadId: string,
+  timeoutMs = REQUEST_TIMEOUT_MS
+): Promise<{ id: string; name: string | null; path: string | null } | null> {
+  if (!isSafeThreadId(threadId)) return Promise.resolve(null)
+  return new Promise((resolve) => {
+    let settled = false
+    let ws: WebSocket
+    const finish = (value: { id: string; name: string | null; path: string | null } | null): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {
+        /* the connection may never have opened */
+      }
+      resolve(value)
+    }
+    const timer = setTimeout(() => finish(null), timeoutMs)
+    timer.unref?.()
+    try {
+      ws = connectCodexAppServer(socketPath)
+    } catch {
+      clearTimeout(timer)
+      resolve(null)
+      return
+    }
+    ws.once('open', () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'initialize',
+          params: { clientInfo: { name: 'nodeterm', version: '1' } }
+        })
+      )
+    })
+    ws.on('message', (raw) => {
+      let message: Record<string, any>
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.id === 1) {
+        if (message.error) return finish(null)
+        ws.send(JSON.stringify({ method: 'initialized' }))
+        ws.send(
+          JSON.stringify({ id: 2, method: 'thread/read', params: { threadId, includeTurns: false } })
+        )
+      } else if (message.id === 2) {
+        const thread = message.result?.thread
+        if (message.error || typeof thread?.id !== 'string' || thread.id !== threadId) {
+          finish(null)
+          return
+        }
+        finish({
+          id: thread.id,
+          name: typeof thread.name === 'string' && thread.name.trim() ? thread.name.trim() : null,
+          path: typeof thread.path === 'string' && path.isAbsolute(thread.path) ? thread.path : null
+        })
+      }
+    })
+    ws.once('error', () => finish(null))
+    ws.once('close', () => finish(null))
+  })
+}
+
+/** Read the logged-in account's email from an app-server socket (`account/read`). Fails to `null`. */
+export function readCodexAccountAt(
+  socketPath: string,
+  timeoutMs = REQUEST_TIMEOUT_MS
+): Promise<{ email: string | null } | null> {
+  return new Promise((resolve) => {
+    let settled = false
+    let ws: WebSocket
+    const finish = (value: { email: string | null } | null): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {
+        /* the connection may never have opened */
+      }
+      resolve(value)
+    }
+    const timer = setTimeout(() => finish(null), timeoutMs)
+    timer.unref?.()
+    try {
+      ws = connectCodexAppServer(socketPath)
+    } catch {
+      clearTimeout(timer)
+      resolve(null)
+      return
+    }
+    ws.once('open', () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'initialize',
+          params: { clientInfo: { name: 'nodeterm', version: '1' } }
+        })
+      )
+    })
+    ws.on('message', (raw) => {
+      let message: Record<string, any>
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.id === 1) {
+        if (message.error) return finish(null)
+        ws.send(JSON.stringify({ method: 'initialized' }))
+        ws.send(JSON.stringify({ id: 2, method: 'account/read', params: {} }))
+      } else if (message.id === 2) {
+        const account = message.result?.account
+        const email =
+          typeof account?.email === 'string' && account.email.trim()
+            ? account.email.trim()
+            : typeof message.result?.email === 'string' && message.result.email.trim()
+              ? message.result.email.trim()
+              : null
+        finish(message.error ? null : { email })
+      }
+    })
+    ws.once('error', () => finish(null))
+    ws.once('close', () => finish(null))
+  })
+}
+
+/** Drop the memoized/coalesced name state — for tests and for a relay/account-set change. */
+export function forgetCodexSessionNames(): void {
+  names.clear()
+  inflight.clear()
+}
+
+/**
  * The READ leg for `TITLE_READ_CAPABLE`. Memoized for `CACHE_MS` and coalesced, because the
  * session-name sweep asks once a minute PER NODE and every ask is a socket connect.
+ *
+ * When the shared app-server reports no name, fall back to the relay's on-disk copy
+ * (`relayedCodexSessionName`) so a conversation forked in the TUI still shows its title.
  */
 export function readCodexSessionName(
   threadId: string,
@@ -494,7 +680,8 @@ export function readCodexSessionName(
   const running = inflight.get(key)
   if (running) return running
   const request = readCodexSessionNameAt(socketPath, threadId).then(
-    (name) => {
+    (serverName) => {
+      const name = serverName ?? relayedCodexSessionName(socketPath, threadId)
       names.set(key, { name, at: Date.now() })
       inflight.delete(key)
       return name

--- a/src/main/codex-relay-daemon.test.ts
+++ b/src/main/codex-relay-daemon.test.ts
@@ -1,0 +1,847 @@
+import { describe, expect, it } from 'vitest'
+import { createServer } from 'http'
+import { spawnSync } from 'child_process'
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync
+} from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { WebSocketServer } from 'ws'
+import {
+  acquireProcessLock,
+  exposeForeignThread,
+  listThreadsAt,
+  mergeRelayThreadLists,
+  readThreadAt,
+  relayControlPost,
+  relayThreadReservationKey,
+  resolveForeignThreadAt,
+  retargetRelayResumeByPath,
+  resolveRelayThreadResponse,
+  trackRelayThreadRequest,
+  tryReserveRelayThread,
+  type RelayThreadRequest
+} from './codex-relay-daemon'
+
+async function fakeCodexServer(
+  socketPath: string,
+  onRequest: (message: any) => any
+): Promise<() => Promise<void>> {
+  const server = createServer()
+  const wss = new WebSocketServer({ noServer: true })
+  server.on('upgrade', (request, socket, head) => {
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      ws.on('message', (raw) => {
+        const response = onRequest(JSON.parse(raw.toString()))
+        if (response) ws.send(JSON.stringify(response))
+      })
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve))
+  return async () => {
+    for (const client of wss.clients) client.close()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
+describe('Codex shared relay thread observation', () => {
+  it('binds the exact native thread/start response without a seed resume or fork', () => {
+    const pending = new Map<string, RelayThreadRequest>()
+    trackRelayThreadRequest(pending, { id: 6, method: 'thread/start', params: { cwd: '/tmp' } })
+    expect(resolveRelayThreadResponse(pending, {
+      id: 6,
+      result: { thread: { id: 'new-thread', name: 'Fresh' } }
+    })).toEqual({ ok: true, threadId: 'new-thread', source: undefined, name: 'Fresh' })
+  })
+
+  it('keeps equal JSON-RPC ids isolated between two parallel node connections', () => {
+    const a = new Map<string, RelayThreadRequest>()
+    const b = new Map<string, RelayThreadRequest>()
+    trackRelayThreadRequest(a, {
+      id: 7,
+      method: 'thread/resume',
+      params: { threadId: 'source-a' }
+    })
+    trackRelayThreadRequest(b, {
+      id: 7,
+      method: 'thread/resume',
+      params: { threadId: 'source-b' }
+    })
+
+    expect(
+      resolveRelayThreadResponse(a, {
+        id: 7,
+        result: { thread: { id: 'source-a' } }
+      })
+    ).toEqual({
+      ok: true,
+      threadId: 'source-a',
+      source: 'source-a',
+      name: undefined
+    })
+    expect(
+      resolveRelayThreadResponse(b, {
+        id: 7,
+        result: { thread: { id: 'source-b', name: 'B' } }
+      })
+    ).toEqual({
+      ok: true,
+      threadId: 'source-b',
+      source: 'source-b',
+      name: 'B'
+    })
+  })
+
+  it('ignores unrelated methods and fails closed on malformed thread ids', () => {
+    const pending = new Map<string, RelayThreadRequest>()
+    trackRelayThreadRequest(pending, {
+      id: 1,
+      method: 'turn/start',
+      params: { threadId: 'source' }
+    })
+    expect(pending.size).toBe(0)
+    trackRelayThreadRequest(pending, {
+      id: 2,
+      method: 'thread/resume',
+      params: { threadId: 'source' }
+    })
+    expect(
+      resolveRelayThreadResponse(pending, {
+        id: 2,
+        result: { thread: { id: '../wrong' } }
+      })
+    ).toEqual({ ok: false })
+    expect(pending.size).toBe(0)
+  })
+
+  it('normalizes a blank app-server name so the session-index fallback remains reachable', () => {
+    const pending = new Map<string, RelayThreadRequest>()
+    trackRelayThreadRequest(pending, { id: 3, method: 'thread/resume', params: { threadId: 'source' } })
+    expect(resolveRelayThreadResponse(pending, {
+      id: 3,
+      result: { thread: { id: 'source', name: '   ' } }
+    })).toEqual({ ok: true, threadId: 'source', source: 'source', name: undefined })
+  })
+
+  it('rejects a path-resume response that changes the conversation id', () => {
+    const pending = new Map<string, RelayThreadRequest>()
+    trackRelayThreadRequest(pending, {
+      id: 4,
+      method: 'thread/resume',
+      params: { threadId: 'source' }
+    })
+    expect(resolveRelayThreadResponse(pending, {
+      id: 4,
+      result: { thread: { id: 'forked' } }
+    })).toEqual({ ok: false, unexpectedThreadId: 'forked' })
+  })
+
+  it('keeps two account catalogs visible while preserving the selected account as duplicate owner', () => {
+    const current = '/tmp/current/app-server-control.sock'
+    const foreign = '/tmp/foreign/app-server-control.sock'
+    const merged = mergeRelayThreadLists([
+      {
+        socketPath: foreign,
+        threads: [
+          { id: 'foreign-1', path: '/foreign/rollout.jsonl', cwd: '/repo', name: 'Foreign', updatedAt: 30 },
+          { id: 'same', path: '/foreign/same.jsonl', cwd: '/repo', updatedAt: 40 }
+        ]
+      },
+      {
+        socketPath: current,
+        threads: [
+          { id: 'current-1', path: '/current/rollout.jsonl', cwd: '/repo', updatedAt: 20 },
+          { id: 'same', path: '/current/same.jsonl', cwd: '/repo', updatedAt: 10 }
+        ]
+      }
+    ], current, { limit: 10, sortKey: 'updated_at', sortDirection: 'desc' })
+
+    expect(merged.result.data.map((thread) => thread.id)).toEqual(['foreign-1', 'current-1', 'same'])
+    expect(merged.result.data.find((thread) => thread.id === 'same')?.path).toBe('/current/same.jsonl')
+    expect(merged.foreignThreads.get('foreign-1')).toEqual({
+      socketPath: foreign,
+      path: '/foreign/rollout.jsonl',
+      cwd: '/repo',
+      name: 'Foreign'
+    })
+    expect(merged.foreignThreads.has('same')).toBe(false)
+  })
+
+  it('paginates the merged catalog and never advertises an unimportable foreign thread', () => {
+    const current = '/tmp/current/app-server-control.sock'
+    const foreign = '/tmp/foreign/app-server-control.sock'
+    const sources = [{
+      socketPath: foreign,
+      threads: [
+        { id: 'newest', path: '/foreign/newest.jsonl', cwd: '/repo', createdAt: 3 },
+        { id: 'missing-path', path: null, cwd: '/repo', createdAt: 4 },
+        { id: 'oldest', path: '/foreign/oldest.jsonl', cwd: '/repo', createdAt: 1 }
+      ]
+    }, {
+      socketPath: current,
+      threads: [{ id: 'middle', path: '/current/middle.jsonl', cwd: '/repo', createdAt: 2 }]
+    }]
+    const first = mergeRelayThreadLists(sources, current, {
+      limit: 2,
+      sortKey: 'created_at',
+      sortDirection: 'desc'
+    })
+    expect(first.result.data.map((thread) => thread.id)).toEqual(['newest', 'middle'])
+    expect(first.result.nextCursor).toMatch(/^nodeterm:/)
+    sources[1].threads.push({ id: 'inserted', path: '/current/inserted.jsonl', cwd: '/repo', createdAt: 4 })
+    const second = mergeRelayThreadLists(sources, current, {
+      limit: 2,
+      cursor: first.result.nextCursor,
+      sortKey: 'created_at',
+      sortDirection: 'desc'
+    })
+    expect(second.result.data.map((thread) => thread.id)).toEqual(['oldest'])
+    expect(second.result.backwardsCursor).toBeNull()
+    expect(second.result.nextCursor).toBeNull()
+  })
+
+  it('fails closed when the same id belongs to two foreign account stores', () => {
+    const current = '/tmp/current/app-server-control.sock'
+    const merged = mergeRelayThreadLists([
+      { socketPath: current, threads: [] },
+      {
+        socketPath: '/tmp/a/app-server-control.sock',
+        threads: [{ id: 'collision', path: '/a/rollout.jsonl', cwd: '/repo', createdAt: 2 }]
+      },
+      {
+        socketPath: '/tmp/b/app-server-control.sock',
+        threads: [{ id: 'collision', path: '/b/rollout.jsonl', cwd: '/repo', createdAt: 2 }]
+      }
+    ], current, {})
+    expect(merged.result.data).toEqual([])
+    expect(merged.foreignThreads.size).toBe(0)
+  })
+
+  it('keeps one hardlinked rollout visible once when two foreign accounts expose it', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-picker-hardlink-'))
+    const rolloutA = path.join(dir, 'a.jsonl')
+    const rolloutB = path.join(dir, 'b.jsonl')
+    writeFileSync(rolloutA, 'one inode')
+    linkSync(rolloutA, rolloutB)
+    const current = path.join(dir, 'current.sock')
+    const merged = mergeRelayThreadLists([
+      { socketPath: current, threads: [] },
+      { socketPath: path.join(dir, 'a.sock'), threads: [{ id: 'shared', path: rolloutA, cwd: '/repo' }] },
+      { socketPath: path.join(dir, 'b.sock'), threads: [{ id: 'shared', path: rolloutB, cwd: '/repo' }] }
+    ], current, {})
+    expect(merged.result.data.map((thread) => thread.id)).toEqual(['shared'])
+    expect(merged.foreignThreads.get('shared')?.path).toBe(rolloutA)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('carries a foreign title through the path-resumed response', () => {
+    const pending = new Map<string, RelayThreadRequest>()
+    trackRelayThreadRequest(pending, {
+      id: 8,
+      method: 'thread/resume',
+      params: { threadId: 'foreign-id' }
+    }, 'Foreign title')
+    expect(resolveRelayThreadResponse(pending, {
+      id: 8,
+      result: { thread: { id: 'foreign-id', name: null } }
+    })).toEqual({
+      ok: true,
+      threadId: 'foreign-id',
+      source: 'foreign-id',
+      name: 'Foreign title'
+    })
+  })
+
+  it('resumes the verified foreign path without changing the conversation id', () => {
+    expect(retargetRelayResumeByPath({
+      id: 9,
+      method: 'thread/resume',
+      params: {
+        threadId: 'foreign-id',
+        path: '/foreign/rollout.jsonl',
+        history: [{ role: 'user' }],
+        cwd: '/repo'
+      }
+    }, 'foreign-id', '/verified/rollout.jsonl', '/repo')).toEqual({
+      id: 9,
+      method: 'thread/resume',
+      params: { threadId: 'foreign-id', path: '/verified/rollout.jsonl', cwd: '/repo' }
+    })
+  })
+
+  it('uses one global reservation for a thread across every source and target account', () => {
+    const key = relayThreadReservationKey('thread-1')
+    expect(relayThreadReservationKey('thread-1')).toBe(key)
+    expect(relayThreadReservationKey('thread-2')).not.toBe(key)
+  })
+
+  it('lists and freshly verifies a paginated foreign fixture before path resume', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-accounts-'))
+    const sourceSocket = path.join(dir, 'source.sock')
+    const sourceRequests: any[] = []
+    const stopSource = await fakeCodexServer(sourceSocket, (message) => {
+      sourceRequests.push(message)
+      if (message.id === 1) return { id: 1, result: {} }
+      if (message.id === 2 && message.method === 'thread/read') return {
+        id: 2,
+        result: {
+          thread: { id: 'foreign-a', path: '/fixtures/a-fresh.jsonl', cwd: '/repo', name: 'Fresh' }
+        }
+      }
+      if (message.id === 2) return {
+        id: 2,
+        result: {
+          data: [{ id: 'foreign-a', path: '/fixtures/a.jsonl', cwd: '/repo', updatedAt: 2 }],
+          nextCursor: 'page-2'
+        }
+      }
+      if (message.id === 3) return {
+        id: 3,
+        result: {
+          data: [{ id: 'foreign-b', path: '/fixtures/b.jsonl', cwd: '/repo', updatedAt: 1 }],
+          nextCursor: null
+        }
+      }
+    })
+    try {
+      await expect(listThreadsAt(sourceSocket, { cwd: '/repo' })).resolves.toHaveLength(2)
+      await expect(readThreadAt(sourceSocket, 'foreign-a')).resolves.toMatchObject({
+        id: 'foreign-a',
+        path: '/fixtures/a-fresh.jsonl'
+      })
+      expect(sourceRequests.filter((message) => message.method === 'thread/list').map((message) =>
+        message.params.cursor
+      )).toEqual([null, 'page-2'])
+    } finally {
+      await stopSource()
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves a direct resume to exactly one foreign account without picker state', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-direct-resume-'))
+    const currentSocket = path.join(dir, 'current.sock')
+    const foreignSocket = path.join(dir, 'foreign.sock')
+    const foreignRollout = path.join(dir, 'foreign-thread-a.jsonl')
+    writeFileSync(foreignRollout, 'fixture')
+    const stopCurrent = await fakeCodexServer(currentSocket, (message) => {
+      if (message.id === 1) return { id: 1, result: {} }
+      if (message.method === 'thread/read') return {
+        id: message.id,
+        error: { code: -32600, message: 'thread not loaded: thread-a' }
+      }
+    })
+    const stopForeign = await fakeCodexServer(foreignSocket, (message) => {
+      if (message.id === 1) return { id: 1, result: {} }
+      if (message.method === 'thread/read') return {
+        id: message.id,
+        result: {
+          thread: {
+            id: 'thread-a',
+            path: foreignRollout,
+            cwd: '/repo',
+            name: 'Existing conversation'
+          }
+        }
+      }
+    })
+    try {
+      await expect(resolveForeignThreadAt(
+        currentSocket,
+        [currentSocket, foreignSocket],
+        'thread-a'
+      )).resolves.toEqual({
+        kind: 'foreign',
+        thread: {
+          socketPath: foreignSocket,
+          path: foreignRollout,
+          cwd: '/repo',
+          name: 'Existing conversation'
+        }
+      })
+    } finally {
+      await Promise.all([stopCurrent(), stopForeign()])
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('distinguishes a native thread from an unavailable id', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-native-resume-'))
+    const currentSocket = path.join(dir, 'current.sock')
+    const stop = await fakeCodexServer(currentSocket, (message) => {
+      if (message.id === 1) return { id: 1, result: {} }
+      if (message.method === 'thread/read' && message.params.threadId === 'native-id') return {
+        id: message.id,
+        result: {
+          thread: { id: 'native-id', path: '/current/native.jsonl', cwd: '/repo' }
+        }
+      }
+      if (message.method === 'thread/read') return {
+        id: message.id,
+        error: { code: -32600, message: `no rollout found for thread id ${message.params.threadId}` }
+      }
+    })
+    try {
+      await expect(resolveForeignThreadAt(
+        currentSocket,
+        [currentSocket],
+        'native-id'
+      )).resolves.toEqual({ kind: 'native' })
+      await expect(resolveForeignThreadAt(
+        currentSocket,
+        [currentSocket],
+        'missing-id'
+      )).resolves.toEqual({ kind: 'unavailable' })
+    } finally {
+      await stop()
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps direct resume fail-closed when two foreign accounts expose the same id', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-ambiguous-resume-'))
+    const currentSocket = path.join(dir, 'current.sock')
+    const foreignA = path.join(dir, 'foreign-a.sock')
+    const foreignB = path.join(dir, 'foreign-b.sock')
+    const rolloutA = path.join(dir, 'foreign-a.jsonl')
+    const rolloutB = path.join(dir, 'foreign-b.jsonl')
+    writeFileSync(rolloutA, 'a')
+    writeFileSync(rolloutB, 'b')
+    const server = (socketPath: string, rolloutPath?: string) => fakeCodexServer(socketPath, (message) => {
+      if (message.id === 1) return { id: 1, result: {} }
+      if (message.method === 'thread/read' && rolloutPath) return {
+        id: message.id,
+        result: { thread: { id: 'same-id', path: rolloutPath, cwd: '/repo' } }
+      }
+      if (message.method === 'thread/read') return {
+        id: message.id,
+        error: { code: -32600, message: `no rollout found for thread id ${message.params.threadId}` }
+      }
+    })
+    const stops = await Promise.all([
+      server(currentSocket),
+      server(foreignA, rolloutA),
+      server(foreignB, rolloutB)
+    ])
+    try {
+      await expect(resolveForeignThreadAt(
+        currentSocket,
+        [currentSocket, foreignA, foreignB],
+        'same-id'
+      )).resolves.toEqual({ kind: 'ambiguous' })
+    } finally {
+      await Promise.all(stops.map((stop) => stop()))
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('deduplicates the same account-neutral rollout exposed by two foreign accounts', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-shared-resume-'))
+    const currentSocket = path.join(dir, 'current.sock')
+    const foreignA = path.join(dir, 'foreign-a.sock')
+    const foreignB = path.join(dir, 'foreign-b.sock')
+    const rollout = path.join(dir, 'shared.jsonl')
+    const aliasA = path.join(dir, 'a.jsonl')
+    const aliasB = path.join(dir, 'b.jsonl')
+    writeFileSync(rollout, 'shared')
+    symlinkSync(rollout, aliasA)
+    symlinkSync(rollout, aliasB)
+    const server = (socketPath: string, rolloutPath?: string) => fakeCodexServer(socketPath, (message) => {
+      if (message.id === 1) return { id: 1, result: {} }
+      if (message.method === 'thread/read' && rolloutPath) return {
+        id: message.id,
+        result: { thread: { id: 'same-id', path: rolloutPath, cwd: '/repo' } }
+      }
+      if (message.method === 'thread/read') return {
+        id: message.id,
+        error: { code: -32600, message: `no rollout found for thread id ${message.params.threadId}` }
+      }
+    })
+    const stops = await Promise.all([
+      server(currentSocket),
+      server(foreignA, aliasA),
+      server(foreignB, aliasB)
+    ])
+    try {
+      await expect(resolveForeignThreadAt(
+        currentSocket,
+        [currentSocket, foreignA, foreignB],
+        'same-id'
+      )).resolves.toMatchObject({ kind: 'foreign', thread: { path: aliasA } })
+    } finally {
+      await Promise.all(stops.map((stop) => stop()))
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed when one foreign account matches but another account is unavailable', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-partial-catalog-'))
+    const currentSocket = path.join(dir, 'current.sock')
+    const foreignSocket = path.join(dir, 'foreign.sock')
+    const unavailableSocket = path.join(dir, 'unavailable.sock')
+    const stopCurrent = await fakeCodexServer(currentSocket, (message) => {
+      if (message.id === 1) return { id: 1, result: {} }
+      if (message.method === 'thread/read') return {
+        id: message.id,
+        error: { code: -32600, message: 'no rollout found for thread id same-id' }
+      }
+    })
+    const stopForeign = await fakeCodexServer(foreignSocket, (message) => {
+      if (message.id === 1) return { id: 1, result: {} }
+      if (message.method === 'thread/read') return {
+        id: message.id,
+        result: { thread: { id: 'same-id', path: '/foreign/thread.jsonl', cwd: '/repo' } }
+      }
+    })
+    try {
+      await expect(resolveForeignThreadAt(
+        currentSocket,
+        [currentSocket, foreignSocket, unavailableSocket],
+        'same-id'
+      )).resolves.toEqual({ kind: 'unavailable' })
+    } finally {
+      await Promise.all([stopCurrent(), stopForeign()])
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reclaims a dead lock but never steals one owned by a live process', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-lock-'))
+    const lock = path.join(dir, 'relay.lock')
+    writeFileSync(lock, '99999999\n')
+    expect(acquireProcessLock(lock)).toBe(true)
+    expect(readFileSync(path.join(lock, 'owner'), 'utf8').trim()).toBe(String(process.pid))
+    expect(acquireProcessLock(lock)).toBe(false)
+  })
+
+  it('never steals a freshly created directory lock before its owner pid is written', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nodeterm-relay-lock-race-'))
+    const lock = path.join(dir, 'relay.lock')
+    mkdirSync(lock)
+    expect(acquireProcessLock(lock)).toBe(false)
+  })
+
+  it('times out a stale control port that accepts but never answers', async () => {
+    const server = createServer(() => {})
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (!address || typeof address === 'string') throw new Error('missing test port')
+    const started = Date.now()
+    await expect(relayControlPost(address.port, 'token', '/ping', {})).rejects.toThrow('timed out')
+    expect(Date.now() - started).toBeLessThan(2_000)
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+})
+
+describe('Codex relay per-thread reservation (Property 3 / Property 10)', () => {
+  // Mutation: make tryReserveRelayThread always return true (drop the reservation) and this test
+  // goes red — a second connection in the same synchronous turn would be allowed to open the same
+  // rollout in parallel. It is the "set synchronously before any await" guard.
+  it('grants a thread reservation once and refuses a same-turn contender for the same thread', () => {
+    const reservations = new Map<string, symbol>()
+    const requestReservations = new Map<string, string>()
+    const key = relayThreadReservationKey('thread-x')
+    const ownerA = Symbol('node-a')
+    const ownerB = Symbol('node-b')
+    expect(tryReserveRelayThread(reservations, requestReservations, key, '1', ownerA)).toBe(true)
+    // Same thread, different request/connection, before A released: refused.
+    expect(tryReserveRelayThread(reservations, requestReservations, key, '2', ownerB)).toBe(false)
+    // The first claim is the one recorded — never overwritten by the contender.
+    expect(reservations.get(key)).toBe(ownerA)
+    // A different thread is independently grantable.
+    expect(
+      tryReserveRelayThread(
+        reservations,
+        requestReservations,
+        relayThreadReservationKey('thread-y'),
+        '3',
+        ownerB
+      )
+    ).toBe(true)
+  })
+
+  it('refuses a duplicate request id even for a fresh thread key', () => {
+    const reservations = new Map<string, symbol>()
+    const requestReservations = new Map<string, string>()
+    const owner = Symbol('node')
+    expect(
+      tryReserveRelayThread(reservations, requestReservations, relayThreadReservationKey('a'), '1', owner)
+    ).toBe(true)
+    expect(
+      tryReserveRelayThread(reservations, requestReservations, relayThreadReservationKey('b'), '1', owner)
+    ).toBe(false)
+  })
+
+  it('refuses an empty request id or reservation key', () => {
+    const owner = Symbol('node')
+    expect(tryReserveRelayThread(new Map(), new Map(), 'k', '', owner)).toBe(false)
+    expect(tryReserveRelayThread(new Map(), new Map(), '', '1', owner)).toBe(false)
+  })
+})
+
+/** A fake account app-server bound to a unix socket under `<home>/app-server-control/`. `threadRead`
+ * returns the thread record for a matching id or `null` to answer "no rollout found". Answers
+ * `account/read`/`account` liveness minimally. */
+async function fakeAccountServer(
+  socketPath: string,
+  threadRead: (threadId: string) => { id: string; path: string; cwd: string } | null
+): Promise<() => Promise<void>> {
+  const server = createServer()
+  const wss = new WebSocketServer({ noServer: true })
+  server.on('upgrade', (request, socket, head) => {
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      ws.on('message', (raw) => {
+        const message = JSON.parse(raw.toString())
+        if (message.method === 'initialize') {
+          ws.send(JSON.stringify({ id: message.id, result: {} }))
+          return
+        }
+        if (message.method === 'thread/read') {
+          const thread = threadRead(message.params.threadId)
+          ws.send(
+            JSON.stringify(
+              thread
+                ? { id: message.id, result: { thread } }
+                : {
+                    id: message.id,
+                    error: {
+                      code: -32600,
+                      message: `no rollout found for thread id ${message.params.threadId}`
+                    }
+                  }
+            )
+          )
+        }
+      })
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve))
+  return async () => {
+    for (const client of wss.clients) client.close()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
+describe('exposeForeignThread — PR 3 primitive + verify-then-recycle (§4.2a, Properties 2 & 5)', () => {
+  // Every case runs against a REAL filesystem (mkdtemp) and REAL fake app-servers on unix sockets;
+  // the copy is PR 3's primitive, never a re-implemented linkSync (GC 8).
+  const setup = () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'nt-exp-'))
+    const threadId = 'thread01a'
+    const sourceHome = path.join(root, 'src')
+    const targetHome = path.join(root, 'tgt')
+    const sourceSocket = path.join(sourceHome, 'app-server-control', 's.sock')
+    const targetSocket = path.join(targetHome, 'app-server-control', 's.sock')
+    mkdirSync(path.dirname(sourceSocket), { recursive: true })
+    mkdirSync(path.dirname(targetSocket), { recursive: true })
+    mkdirSync(path.join(sourceHome, 'sessions'), { recursive: true })
+    mkdirSync(path.join(targetHome, 'sessions'), { recursive: true })
+    const sourceRollout = path.join(sourceHome, 'sessions', `rollout-${threadId}.jsonl`)
+    const targetRollout = path.join(targetHome, 'sessions', `rollout-${threadId}.jsonl`)
+    writeFileSync(sourceRollout, 'source rollout bytes')
+    return { root, threadId, sourceSocket, targetSocket, sourceRollout, targetRollout }
+  }
+
+  it('hardlinks the foreign rollout via the primitive and only reports exposed once discoverable', async () => {
+    const { root, threadId, sourceSocket, targetSocket, sourceRollout, targetRollout } = setup()
+    const stopSource = await fakeAccountServer(sourceSocket, (id) =>
+      id === threadId ? { id, path: sourceRollout, cwd: '/repo' } : null
+    )
+    // The target answers "found" ONLY when the copy is actually on disk — a real "discover before
+    // recycle" gate, i.e. the running-app-server surfacing of a fresh hardlink (probe U1).
+    const stopTarget = await fakeAccountServer(targetSocket, (id) =>
+      id === threadId && existsSync(targetRollout)
+        ? { id, path: targetRollout, cwd: '/repo' }
+        : null
+    )
+    try {
+      await expect(
+        exposeForeignThread(targetSocket, threadId, [targetSocket, sourceSocket])
+      ).resolves.toEqual({ kind: 'exposed' })
+      // Same inode ⇒ identical conversation id; source left intact (hardlink, never moved).
+      expect(existsSync(sourceRollout)).toBe(true)
+      expect(statSync(targetRollout).ino).toBe(statSync(sourceRollout).ino)
+    } finally {
+      await Promise.all([stopSource(), stopTarget()])
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rolls the published link back when the target app-server cannot discover the copy', async () => {
+    const { root, threadId, sourceSocket, targetSocket, sourceRollout, targetRollout } = setup()
+    const stopSource = await fakeAccountServer(sourceSocket, (id) =>
+      id === threadId ? { id, path: sourceRollout, cwd: '/repo' } : null
+    )
+    // Target NEVER discovers it — the U1-false case. The copy must be rolled back and the switch
+    // refused, never silently recycled.
+    const stopTarget = await fakeAccountServer(targetSocket, () => null)
+    try {
+      await expect(
+        exposeForeignThread(targetSocket, threadId, [targetSocket, sourceSocket])
+      ).rejects.toThrow('not discoverable')
+      expect(existsSync(targetRollout)).toBe(false) // rolled back
+      expect(existsSync(sourceRollout)).toBe(true) // source untouched
+    } finally {
+      await Promise.all([stopSource(), stopTarget()])
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('never overwrites a different rollout already occupying the target path', async () => {
+    const { root, threadId, sourceSocket, targetSocket, sourceRollout, targetRollout } = setup()
+    // A DIFFERENT, unrelated rollout (distinct inode) already sits where the copy would land.
+    writeFileSync(targetRollout, 'a different conversation')
+    const differentIno = statSync(targetRollout).ino
+    const stopSource = await fakeAccountServer(sourceSocket, (id) =>
+      id === threadId ? { id, path: sourceRollout, cwd: '/repo' } : null
+    )
+    const stopTarget = await fakeAccountServer(targetSocket, () => null)
+    try {
+      await expect(
+        exposeForeignThread(targetSocket, threadId, [targetSocket, sourceSocket])
+      ).rejects.toThrow('different rollout')
+      // The pre-existing target is byte- and inode-preserved: never overwritten, never rolled back.
+      expect(statSync(targetRollout).ino).toBe(differentIno)
+      expect(readFileSync(targetRollout, 'utf8')).toBe('a different conversation')
+    } finally {
+      await Promise.all([stopSource(), stopTarget()])
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('early-returns native without copying when the target account already owns the thread', async () => {
+    const { root, threadId, sourceSocket, targetSocket, sourceRollout, targetRollout } = setup()
+    const stopSource = await fakeAccountServer(sourceSocket, (id) =>
+      id === threadId ? { id, path: sourceRollout, cwd: '/repo' } : null
+    )
+    const stopTarget = await fakeAccountServer(targetSocket, (id) =>
+      id === threadId ? { id, path: '/tgt/native.jsonl', cwd: '/repo' } : null
+    )
+    try {
+      await expect(
+        exposeForeignThread(targetSocket, threadId, [targetSocket, sourceSocket])
+      ).resolves.toEqual({ kind: 'native' })
+      expect(existsSync(targetRollout)).toBe(false) // nothing copied
+    } finally {
+      await Promise.all([stopSource(), stopTarget()])
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses (does not copy) when the source id is ambiguous across two foreign accounts', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'nt-exp-amb-'))
+    const threadId = 'thread01a'
+    const targetSocket = path.join(root, 'tgt', 'app-server-control', 's.sock')
+    const aSocket = path.join(root, 'a', 'app-server-control', 's.sock')
+    const bSocket = path.join(root, 'b', 'app-server-control', 's.sock')
+    for (const s of [targetSocket, aSocket, bSocket]) mkdirSync(path.dirname(s), { recursive: true })
+    const rolloutA = path.join(root, 'a.jsonl')
+    const rolloutB = path.join(root, 'b.jsonl')
+    writeFileSync(rolloutA, 'a')
+    writeFileSync(rolloutB, 'b')
+    const stopTarget = await fakeAccountServer(targetSocket, () => null)
+    const stopA = await fakeAccountServer(aSocket, (id) =>
+      id === threadId ? { id, path: rolloutA, cwd: '/repo' } : null
+    )
+    const stopB = await fakeAccountServer(bSocket, (id) =>
+      id === threadId ? { id, path: rolloutB, cwd: '/repo' } : null
+    )
+    try {
+      await expect(
+        exposeForeignThread(targetSocket, threadId, [targetSocket, aSocket, bSocket])
+      ).rejects.toThrow('unavailable or ambiguous')
+    } finally {
+      await Promise.all([stopTarget(), stopA(), stopB()])
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('relay self-spawn + token transport (probe U6, GC 6 argv-spy)', () => {
+  // Bundle the TS daemon to CJS and drive its CLI dispatch under plain `node` — the runnable half of
+  // U6 (`process.argv[2]` switch; self-spawned `serve`; a real `/register` round-trip). The node
+  // capability token travels ONLY in env `NODETERM_CODEX_NODE_TOKEN`, never on argv; the control
+  // token lives only in the 0600 state file and is sent as an `Authorization: Bearer` header — this
+  // test proves registration SUCCEEDS with the token in env and FAILS without it, though the argv is
+  // byte-identical either way (the argv-spy: capability is env-borne, not command-line-borne).
+  const bundle = (): string => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const esbuild = require('esbuild')
+    // Emit inside the repo tree so the externalized `ws` (and friends) resolve through the project's
+    // node_modules when the bundle runs under plain node.
+    const out = path.join(__dirname, `.relay-bundle-${process.pid}-${Date.now()}.cjs`)
+    esbuild.buildSync({
+      entryPoints: [path.join(__dirname, 'codex-relay-daemon.ts')],
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      packages: 'external',
+      outfile: out
+    })
+    return out
+  }
+
+  it('sources the node token from env, never argv, and mints a header-only control token', () => {
+    const out = bundle()
+    const home = mkdtempSync(path.join(tmpdir(), 'nt-relay-home-'))
+    // The relay assumes its `~/.nodeterm` root exists (the app creates it at startup); the control
+    // lock lives directly under it. Create it so the first register can self-spawn the server.
+    mkdirSync(path.join(home, '.nodeterm'), { recursive: true })
+    const token = 'A'.repeat(43) // matches SAFE_NODE_TOKEN /^[A-Za-z0-9_-]{43}$/
+    const argv = [
+      out,
+      'register',
+      'node-1',
+      '', // system account
+      path.join(home, 'up.sock'),
+      path.join(home, 'hook.env')
+    ]
+    try {
+      // No token on argv, none in env: registration is refused at the argv validation gate.
+      const missing = spawnSync(process.execPath, argv, {
+        env: { ...process.env, HOME: home, NODETERM_CODEX_NODE_TOKEN: '' },
+        encoding: 'utf8',
+        timeout: 15_000
+      })
+      expect(missing.status).not.toBe(0)
+      expect(missing.stderr).toContain('invalid relay registration')
+
+      // Same argv, token now in env: registration succeeds. The token is NEVER a command-line arg.
+      expect(argv).not.toContain(token)
+      const ok = spawnSync(process.execPath, argv, {
+        env: { ...process.env, HOME: home, NODETERM_CODEX_NODE_TOKEN: token },
+        encoding: 'utf8',
+        timeout: 15_000
+      })
+      expect(ok.status).toBe(0)
+      expect(ok.stdout).toMatch(/^ws:\/\/127\.0\.0\.1:\d+\n[0-9a-f-]{36}\n$/)
+      // The node token is not echoed back into the relay's stdout.
+      expect(ok.stdout).not.toContain(token)
+
+      // The control token lives only in the 0600 state file, and it is not the node token.
+      const statePath = path.join(home, '.nodeterm', 'codex-relay-v6.json')
+      const state = JSON.parse(readFileSync(statePath, 'utf8')) as { token: string; pid: number }
+      expect((statSync(statePath).mode & 0o777).toString(8)).toBe('600')
+      expect(state.token).not.toBe(token)
+      expect(readFileSync(statePath, 'utf8')).not.toContain(token)
+
+      // Tear down the detached serve child the round-trip spawned.
+      try {
+        process.kill(state.pid)
+      } catch {
+        /* already gone */
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+      rmSync(out, { force: true })
+    }
+  }, 30_000)
+})

--- a/src/main/codex-relay-daemon.test.ts
+++ b/src/main/codex-relay-daemon.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { createServer } from 'http'
 import { spawnSync } from 'child_process'
 import {
+  closeSync,
   existsSync,
+  fstatSync,
   linkSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   rmSync,
   statSync,
@@ -709,8 +712,15 @@ describe('exposeForeignThread — PR 3 primitive + verify-then-recycle (§4.2a, 
         exposeForeignThread(targetSocket, threadId, [targetSocket, sourceSocket])
       ).rejects.toThrow('different rollout')
       // The pre-existing target is byte- and inode-preserved: never overwritten, never rolled back.
-      expect(statSync(targetRollout).ino).toBe(differentIno)
-      expect(readFileSync(targetRollout, 'utf8')).toBe('a different conversation')
+      // One descriptor proves the inode AND the contents belong to the same file — no stat-then-read
+      // race on the target path.
+      const fd = openSync(targetRollout, 'r')
+      try {
+        expect(fstatSync(fd).ino).toBe(differentIno)
+        expect(readFileSync(fd, 'utf8')).toBe('a different conversation')
+      } finally {
+        closeSync(fd)
+      }
     } finally {
       await Promise.all([stopSource(), stopTarget()])
       rmSync(root, { recursive: true, force: true })
@@ -826,12 +836,23 @@ describe('relay self-spawn + token transport (probe U6, GC 6 argv-spy)', () => {
       // The node token is not echoed back into the relay's stdout.
       expect(ok.stdout).not.toContain(token)
 
-      // The control token lives only in the 0600 state file, and it is not the node token.
+      // The control token lives only in the 0600 state file, and it is not the node token. One
+      // descriptor proves the mode AND the contents belong to the same inode — no stat-then-read
+      // race on the state path.
       const statePath = path.join(home, '.nodeterm', 'codex-relay-v6.json')
-      const state = JSON.parse(readFileSync(statePath, 'utf8')) as { token: string; pid: number }
-      expect((statSync(statePath).mode & 0o777).toString(8)).toBe('600')
+      const stateFd = openSync(statePath, 'r')
+      let raw: string
+      let mode: number
+      try {
+        mode = fstatSync(stateFd).mode & 0o777
+        raw = readFileSync(stateFd, 'utf8')
+      } finally {
+        closeSync(stateFd)
+      }
+      const state = JSON.parse(raw) as { token: string; pid: number }
+      expect(mode.toString(8)).toBe('600')
       expect(state.token).not.toBe(token)
-      expect(readFileSync(statePath, 'utf8')).not.toContain(token)
+      expect(raw).not.toContain(token)
 
       // Tear down the detached serve child the round-trip spawned.
       try {

--- a/src/main/codex-relay-daemon.test.ts
+++ b/src/main/codex-relay-daemon.test.ts
@@ -702,26 +702,24 @@ describe('exposeForeignThread — PR 3 primitive + verify-then-recycle (§4.2a, 
     const { root, threadId, sourceSocket, targetSocket, sourceRollout, targetRollout } = setup()
     // A DIFFERENT, unrelated rollout (distinct inode) already sits where the copy would land.
     writeFileSync(targetRollout, 'a different conversation')
-    const differentIno = statSync(targetRollout).ino
     const stopSource = await fakeAccountServer(sourceSocket, (id) =>
       id === threadId ? { id, path: sourceRollout, cwd: '/repo' } : null
     )
     const stopTarget = await fakeAccountServer(targetSocket, () => null)
+    // Hold ONE descriptor open across the whole operation. never-overwrite means the target inode is
+    // never replaced, so the same open file object before and after the expose proves the target
+    // survived untouched — a stronger claim than re-opening the path, and no stat-then-read race.
+    const heldFd = openSync(targetRollout, 'r')
+    const differentIno = fstatSync(heldFd).ino
     try {
       await expect(
         exposeForeignThread(targetSocket, threadId, [targetSocket, sourceSocket])
       ).rejects.toThrow('different rollout')
-      // The pre-existing target is byte- and inode-preserved: never overwritten, never rolled back.
-      // One descriptor proves the inode AND the contents belong to the same file — no stat-then-read
-      // race on the target path.
-      const fd = openSync(targetRollout, 'r')
-      try {
-        expect(fstatSync(fd).ino).toBe(differentIno)
-        expect(readFileSync(fd, 'utf8')).toBe('a different conversation')
-      } finally {
-        closeSync(fd)
-      }
+      // Same held fd: inode unchanged and contents intact ⇒ never overwritten, never rolled back.
+      expect(fstatSync(heldFd).ino).toBe(differentIno)
+      expect(readFileSync(heldFd, 'utf8')).toBe('a different conversation')
     } finally {
+      closeSync(heldFd)
       await Promise.all([stopSource(), stopTarget()])
       rmSync(root, { recursive: true, force: true })
     }

--- a/src/main/codex-relay-daemon.ts
+++ b/src/main/codex-relay-daemon.ts
@@ -1,0 +1,1607 @@
+/* A single tiny, detached WebSocket relay shared by every local Codex node. It keeps the TUI
+ * connected across Electron restarts while observing thread/resume on that node's own connection.
+ * The authenticated Codex app-server remains shared per account; this is only a routing shim.
+ *
+ * Adapted from @Corvin's `src/main/codex-relay-daemon.ts` in external PR #112 (S6 PR 4 slice). The
+ * one deliberate divergence from the reference: cross-account rollout exposure does NOT re-implement
+ * `linkSync` here — it calls PR 3's atomic, never-overwrite primitive
+ * (`planCodexRolloutExposure`/`commitCodexRolloutExposure` in `src/core/codex-accounts-core.ts`) and
+ * then VERIFIES the target app-server can discover the copy before the caller recycles the node,
+ * rolling the published link back if it cannot (§4.2 step 4 / §6). Ships inert: no node connects
+ * until PR 5/6 wire it live.
+ *
+ * ── Task 4.0 probe results (Codex CLI 0.146.0, `/usr/bin/codex`, npm-managed; recorded in full in
+ *    docs/superpowers/probes/2026-08-codex-relay-daemon.md) ──
+ *  U4  PARTIAL/VERIFIED. `codex app-server daemon start|stop|version` honours `CODEX_HOME` (creates
+ *      `<CODEX_HOME>/app-server-daemon/`; `version` JSON reports
+ *      `socketPath=<CODEX_HOME>/app-server-control/app-server-control.sock`). The `SUN_LEN` limit is
+ *      REAL — a long `CODEX_HOME` makes the socket connect fail "path must be shorter than SUN_LEN",
+ *      which is exactly why the managed home digest is short. `--remote <ADDR>` and
+ *      `--remote-auth-token-env <ENV_VAR>` exist on the global/`resume`/`fork` commands (token by env
+ *      var name, never on argv — GC 6). NOT runnable headless: `daemon start` binding a live socket,
+ *      and the `account/read`→{email} / `thread/read`→{path,cwd} RPC shapes, need the curl-managed
+ *      standalone install (`<CODEX_HOME>/packages/standalone/current/codex`) absent here — owed
+ *      device-verification.
+ *  U1  UNVERIFIED headless (no standalone daemon). Does a RUNNING app-server surface a freshly
+ *      hardlinked rollout on `thread/read` WITHOUT a reindex? Cannot measure without the managed
+ *      install. The design does NOT rest on the optimistic answer: `exposeForeignThread` re-reads the
+ *      TARGET socket after linking (`thread-check`) and rolls the link back if the far side does not
+ *      report the thread — so a false U1 degrades to a refused copy, never a silent one. Owed
+ *      device-verification; not blocking.
+ *  U2  UNVERIFIED headless (needs auth + a second login + a running daemon). Does the conversation id
+ *      survive copy+switch? Safety net if not: hardlinked inode + resume-by-path (history deleted,
+ *      precedence history > path > id) and the `-32004` guard — `resolveRelayThreadResponse` flags a
+ *      changed id and the reply is rewritten to `-32004`, refusing the silent fork. Owed
+ *      device-verification; not blocking.
+ *  U6  Local self-spawn VERIFIED runnable: the `process.argv[2]` dispatch (serve/register/
+ *      account-read/thread-check/expose-thread) runs under plain `node` (proven by a child-process
+ *      test that self-spawns `serve` and completes a `/register` round-trip). In Electron main
+ *      `process.execPath` is the Electron binary; `ELECTRON_RUN_AS_NODE=1` runs it as Node. The
+ *      remote leg (uploaded `codex-relay.js` via `nodeterm-codex`) needs a live SSH host — owed. */
+import { createHash, randomUUID, timingSafeEqual } from 'crypto'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync
+} from 'fs'
+import { createServer, request } from 'http'
+import { homedir } from 'os'
+import path from 'path'
+import { spawn } from 'child_process'
+import { WebSocket, WebSocketServer } from 'ws'
+import {
+  commitCodexRolloutExposure,
+  isSafeAccountId,
+  planCodexRolloutExposure
+} from '../core/codex-accounts-core'
+
+// Protocol v6 adds a node-scoped capability to every Electron identity request. It also merges
+// account-isolated catalogs and resumes a selected foreign rollout by path in
+// the chosen account. Codex preserves the rollout's thread id; switching login never forks history.
+// Keep earlier versions on their own state files so already-connected nodes may drain safely.
+const VERSION = '6'
+const SAFE = /^[A-Za-z0-9._-]+$/
+const SAFE_NODE_TOKEN = /^[A-Za-z0-9_-]{43}$/
+const SAFE_ENDPOINT = /^\/[A-Za-z0-9._/ -]+$/
+const INVALID_OWNER = '__invalid__'
+const root = path.join(homedir(), '.nodeterm')
+const statePath = path.join(root, `codex-relay-v${VERSION}.json`)
+
+type State = { version: string; pid: number; port: number; token: string }
+type Route = {
+  nodeId: string
+  nodeToken: string
+  accountId?: string
+  socketPath: string
+  hookEndpoint: string
+}
+export type RelayForeignThread = {
+  socketPath: string
+  path: string
+  cwd: string
+  name?: string
+}
+export type RelayThreadLocation =
+  | { kind: 'native' }
+  | { kind: 'foreign'; thread: RelayForeignThread }
+  | { kind: 'ambiguous' }
+  | { kind: 'unavailable' }
+type RegisteredRoute = {
+  route: Route
+  timer: NodeJS.Timeout
+  active: number
+}
+
+export type RelayThreadRequest = {
+  method: string
+  source?: string
+  sourceName?: string
+}
+export type RelayThreadResponse =
+  | { ok: true; threadId: string; source?: string; name?: string }
+  | { ok: false; unexpectedThreadId?: string }
+
+/** Per-connection JSON-RPC tracking. Equal request ids in parallel node connections remain
+ * isolated because every connection supplies its own map. */
+export function trackRelayThreadRequest(
+  pending: Map<string, RelayThreadRequest>,
+  message: unknown,
+  sourceName?: string
+): void {
+  const m = message as {
+    id?: unknown
+    method?: unknown
+    params?: { threadId?: unknown }
+  }
+  if (
+    m?.id === undefined ||
+    typeof m.method !== 'string' ||
+    !/^thread\/(?:resume|start|fork)$/.test(m.method)
+  )
+    return
+  pending.set(String(m.id), {
+    method: m.method,
+    source: typeof m.params?.threadId === 'string' ? m.params.threadId : undefined,
+    sourceName
+  })
+}
+
+export function resolveRelayThreadResponse(
+  pending: Map<string, RelayThreadRequest>,
+  message: unknown
+): RelayThreadResponse | undefined {
+  const m = message as {
+    id?: unknown
+    error?: unknown
+    result?: { thread?: { id?: unknown; name?: unknown } }
+  }
+  if (m?.id === undefined) return undefined
+  const tracked = pending.get(String(m.id))
+  if (!tracked) return undefined
+  pending.delete(String(m.id))
+  if (m.error) return undefined
+  const threadId = m.result?.thread?.id
+  if (typeof threadId !== 'string' || !SAFE.test(threadId)) return { ok: false }
+  if (tracked.method === 'thread/resume' && tracked.source && threadId !== tracked.source) {
+    return { ok: false, unexpectedThreadId: threadId }
+  }
+  const rawName = typeof m.result?.thread?.name === 'string' ? m.result.thread.name.trim() : ''
+  return {
+    ok: true,
+    threadId,
+    source: tracked.source,
+    name: rawName || tracked.sourceName
+  }
+}
+
+type RelayThread = Record<string, any> & {
+  id: string
+  path?: string | null
+  cwd: string
+  name?: string | null
+  createdAt?: number
+  updatedAt?: number
+  recencyAt?: number | null
+}
+
+export type RelayThreadReadOutcome =
+  { kind: 'found'; thread: RelayThread } | { kind: 'absent' } | { kind: 'unavailable' }
+
+type RelayThreadSource = { socketPath: string; threads: RelayThread[] }
+
+type RelayCursor = {
+  key: string
+  direction: 1 | -1
+  value: number
+  id: string
+}
+
+function rolloutIdentity(rolloutPath: unknown): string | null {
+  if (typeof rolloutPath !== 'string' || !path.isAbsolute(rolloutPath)) return null
+  try {
+    const stat = statSync(rolloutPath)
+    return stat.isFile() ? `${stat.dev}:${stat.ino}` : null
+  } catch {
+    return null
+  }
+}
+
+function decodeRelayCursor(cursor: unknown): RelayCursor | null {
+  if (typeof cursor !== 'string' || !cursor.startsWith('nodeterm:')) return null
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor.slice(9), 'base64url').toString()) as RelayCursor
+    return typeof parsed.key === 'string' &&
+      (parsed.direction === 1 || parsed.direction === -1) &&
+      Number.isFinite(parsed.value) &&
+      typeof parsed.id === 'string' &&
+      SAFE.test(parsed.id)
+      ? parsed
+      : null
+  } catch {
+    return null
+  }
+}
+
+function encodeRelayCursor(cursor: RelayCursor): string {
+  return `nodeterm:${Buffer.from(JSON.stringify(cursor)).toString('base64url')}`
+}
+
+/** Merge already server-filtered account pages without ever sharing their state databases. The
+ * selected account wins an equal thread id. Foreign entries without an absolute rollout path are
+ * omitted because they cannot be safely resumed in the selected account. */
+export function mergeRelayThreadLists(
+  sources: RelayThreadSource[],
+  currentSocketPath: string,
+  params: Record<string, any>
+): {
+  result: {
+    data: RelayThread[]
+    nextCursor: string | null
+    backwardsCursor: string | null
+  }
+  foreignThreads: Map<string, RelayForeignThread>
+} {
+  const ordered = [...sources].sort((a, b) =>
+    a.socketPath === currentSocketPath ? -1 : b.socketPath === currentSocketPath ? 1 : 0
+  )
+  const byId = new Map<string, { thread: RelayThread; socketPath: string } | null>()
+  for (const source of ordered) {
+    for (const thread of source.threads) {
+      if (!thread || typeof thread.id !== 'string' || !SAFE.test(thread.id)) continue
+      if (
+        source.socketPath !== currentSocketPath &&
+        (typeof thread.path !== 'string' || !path.isAbsolute(thread.path))
+      )
+        continue
+      const existing = byId.get(thread.id)
+      if (source.socketPath === currentSocketPath) {
+        byId.set(thread.id, { thread, socketPath: source.socketPath })
+        continue
+      }
+      if (existing === null || (existing && existing.socketPath !== currentSocketPath)) {
+        const sameRollout =
+          existing &&
+          rolloutIdentity(existing.thread.path) !== null &&
+          rolloutIdentity(existing.thread.path) === rolloutIdentity(thread.path)
+        // Hardlinks in multiple account homes are one conversation. Different/unreadable inodes
+        // remain ambiguous; never pick one by catalog order.
+        if (!sameRollout) byId.set(thread.id, null)
+        continue
+      }
+      if (existing) continue
+      byId.set(thread.id, { thread, socketPath: source.socketPath })
+    }
+  }
+  const sortKey =
+    params.sortKey === 'updated_at'
+      ? 'updatedAt'
+      : params.sortKey === 'recency_at'
+        ? 'recencyAt'
+        : 'createdAt'
+  const direction = params.sortDirection === 'asc' ? 1 : -1
+  const valueOf = (thread: RelayThread): number =>
+    Number(thread[sortKey] ?? thread.updatedAt ?? thread.createdAt ?? 0)
+  const compare = (a: { thread: RelayThread }, b: { thread: RelayThread }): number => {
+    const av = valueOf(a.thread)
+    const bv = valueOf(b.thread)
+    return av === bv ? a.thread.id.localeCompare(b.thread.id) : (av - bv) * direction
+  }
+  const all = [...byId.values()]
+    .filter((entry): entry is { thread: RelayThread; socketPath: string } => entry !== null)
+    .sort(compare)
+  const cursor = decodeRelayCursor(params.cursor)
+  let offset = 0
+  if (cursor && cursor.key === sortKey && cursor.direction === direction) {
+    offset = all.findIndex(
+      (entry) =>
+        compare(entry, {
+          thread: { id: cursor.id, cwd: '', [sortKey]: cursor.value }
+        }) > 0
+    )
+    if (offset < 0) offset = all.length
+  }
+  const requestedLimit = Number(params.limit)
+  const limit =
+    Number.isSafeInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 1000) : 50
+  const page = all.slice(offset, offset + limit)
+  const foreignThreads = new Map<string, RelayForeignThread>()
+  for (const { thread, socketPath } of page) {
+    if (socketPath === currentSocketPath || typeof thread.path !== 'string') continue
+    foreignThreads.set(thread.id, {
+      socketPath,
+      path: thread.path,
+      cwd: thread.cwd,
+      name: typeof thread.name === 'string' && thread.name.trim() ? thread.name.trim() : undefined
+    })
+  }
+  const next = offset + page.length
+  const last = page.at(-1)?.thread
+  return {
+    result: {
+      data: page.map((entry) => entry.thread),
+      nextCursor:
+        next < all.length && last
+          ? encodeRelayCursor({
+              key: sortKey,
+              direction,
+              value: valueOf(last),
+              id: last.id
+            })
+          : null,
+      backwardsCursor: null
+    },
+    foreignThreads
+  }
+}
+
+export function retargetRelayResumeByPath(
+  message: Record<string, any>,
+  threadId: string,
+  sourcePath: string,
+  cwd: string
+): Record<string, any> {
+  const params = { ...(message.params ?? {}), threadId, path: sourcePath, cwd }
+  // Resume precedence is history > path > id. Remove picker-supplied history so Codex loads the
+  // verified rollout path and preserves its existing thread identity under the selected login.
+  delete params.history
+  return { ...message, params }
+}
+
+export function relayThreadReservationKey(threadId: string): string {
+  return `thread\0${threadId}`
+}
+
+/**
+ * Claim a per-thread reservation SYNCHRONOUSLY — before any `await` — so two connections arriving
+ * in the same event-loop turn can never both pass and open the same rollout in parallel (Property
+ * 3 / Property 10). Returns false (already reserved) or true (this owner now holds it); on success
+ * both maps are mutated in the same synchronous step, which is the whole point: the window between
+ * "check" and "set" must not contain an await. `owner` is a per-connection `Symbol` so a release
+ * only ever removes a reservation this exact connection still owns.
+ */
+export function tryReserveRelayThread(
+  reservations: Map<string, symbol>,
+  requestReservations: Map<string, string>,
+  reservationKey: string,
+  requestId: string,
+  owner: symbol
+): boolean {
+  if (!requestId || !reservationKey) return false
+  if (requestReservations.has(requestId) || reservations.has(reservationKey)) return false
+  reservations.set(reservationKey, owner)
+  requestReservations.set(requestId, reservationKey)
+  return true
+}
+
+function readState(): State | null {
+  try {
+    const x = JSON.parse(readFileSync(statePath, 'utf8')) as State
+    return x.version === VERSION && x.port > 0 && !!x.token ? x : null
+  } catch {
+    return null
+  }
+}
+
+export function acquireProcessLock(lock: string): boolean {
+  const attempt = (): boolean => {
+    try {
+      // mkdir is the ownership operation. Unlike create-then-write of a file, contenders can never
+      // observe a newly-created empty lock and delete it before this process writes its pid.
+      mkdirSync(lock, { mode: 0o700 })
+      writeFileSync(path.join(lock, 'owner'), `${process.pid}\n`, {
+        mode: 0o600
+      })
+      return true
+    } catch {
+      return false
+    }
+  }
+  if (attempt()) return true
+  let owner = 0
+  let directory = false
+  try {
+    directory = statSync(lock).isDirectory()
+    owner = Number(readFileSync(directory ? path.join(lock, 'owner') : lock, 'utf8').trim())
+  } catch {}
+  if (owner > 0) {
+    try {
+      process.kill(owner, 0)
+      return false
+    } catch {}
+  }
+  if (directory && owner <= 0) {
+    // A missing owner is the tiny post-mkdir/pre-write window of a live contender. Only reclaim it
+    // after it has remained incomplete long enough that the creator demonstrably died.
+    try {
+      if (Date.now() - statSync(lock).mtimeMs < 10_000) return false
+    } catch {
+      return false
+    }
+  }
+  try {
+    if (directory) rmSync(lock, { recursive: true, force: true })
+    else unlinkSync(lock)
+  } catch {
+    return false
+  }
+  return attempt()
+}
+
+function releaseProcessLock(lock: string): void {
+  try {
+    const owner = Number(readFileSync(path.join(lock, 'owner'), 'utf8').trim())
+    if (owner === process.pid) rmSync(lock, { recursive: true, force: true })
+  } catch {}
+}
+
+function authOk(raw: string | undefined, token: string): boolean {
+  if (!raw?.startsWith('Bearer ')) return false
+  const a = Buffer.from(raw.slice(7))
+  const b = Buffer.from(token)
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+function bearerToken(raw: string | undefined): string {
+  return raw?.startsWith('Bearer ') ? raw.slice(7) : ''
+}
+
+export function relayControlPost(
+  port: number,
+  token: string,
+  pathname: string,
+  body: unknown
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body)
+    const req = request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: pathname,
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(data)
+        }
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c) => chunks.push(Buffer.from(c)))
+        res.on('end', () =>
+          res.statusCode === 200
+            ? resolve(Buffer.concat(chunks).toString())
+            : reject(new Error('relay request failed'))
+        )
+      }
+    )
+    req.on('error', reject)
+    req.setTimeout(1_000, () => req.destroy(new Error('relay request timed out')))
+    req.end(data)
+  })
+}
+
+async function ensureServer(): Promise<State> {
+  const current = readState()
+  if (current) {
+    try {
+      await relayControlPost(current.port, current.token, '/ping', {})
+      return current
+    } catch {
+      /* stale */
+    }
+  }
+  const lock = `${statePath}.lock`
+  const ownsLock = acquireProcessLock(lock)
+  if (ownsLock) {
+    const child = spawn(process.execPath, [__filename, 'serve'], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
+    })
+    child.unref()
+  }
+  try {
+    for (let i = 0; i < 50; i++) {
+      await new Promise((r) => setTimeout(r, 50))
+      const state = readState()
+      if (state) {
+        try {
+          await relayControlPost(state.port, state.token, '/ping', {})
+          return state
+        } catch {}
+      }
+    }
+    throw new Error('NodeTerm Codex relay unavailable')
+  } finally {
+    if (ownsLock) {
+      releaseProcessLock(lock)
+    }
+  }
+}
+
+function scope(accountId?: string): string {
+  return accountId || 'system'
+}
+function identityFile(threadId: string, accountId?: string): string {
+  return path.join(root, 'codex-thread-nodes', scope(accountId), threadId)
+}
+function nameFile(socketPath: string, threadId: string): string {
+  const socketScope = createHash('sha256').update(socketPath).digest('hex').slice(0, 16)
+  return path.join(root, 'codex-thread-names', socketScope, threadId)
+}
+function parseOwner(file: string, expectedScope?: string): string {
+  try {
+    const raw = readFileSync(file, 'utf8')
+    const accountId = /^accountId=(.*)$/m.exec(raw)?.[1]
+    const nodeId = /^nodeId=(.*)$/m.exec(raw)?.[1] ?? ''
+    const endpoint = /^endpoint=(.*)$/m.exec(raw)?.[1] ?? ''
+    if (
+      (expectedScope ? accountId !== expectedScope : !!accountId) ||
+      !SAFE.test(nodeId) ||
+      !SAFE_ENDPOINT.test(endpoint)
+    )
+      return INVALID_OWNER
+    return nodeId
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT' ? '' : INVALID_OWNER
+  }
+}
+function conflictingOwner(threadId: string): string {
+  if (!SAFE.test(threadId)) return ''
+  const mappings = path.join(root, 'codex-thread-nodes')
+  const owners = new Set<string>()
+  const legacyOwner = parseOwner(path.join(mappings, threadId))
+  if (legacyOwner) owners.add(legacyOwner)
+  try {
+    for (const entry of readdirSync(mappings, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !SAFE.test(entry.name)) continue
+      const owner = parseOwner(path.join(mappings, entry.name, threadId), entry.name)
+      if (owner) owners.add(owner)
+    }
+  } catch {
+    owners.add(INVALID_OWNER)
+  }
+  if (owners.size === 0) return ''
+  if (owners.size === 1) return owners.values().next().value ?? ''
+  return '__ambiguous__'
+}
+function persistName(route: Route, threadId: string, name?: string): void {
+  if (!name?.trim()) return
+  const nf = nameFile(route.socketPath, threadId)
+  mkdirSync(path.dirname(nf), { recursive: true, mode: 0o700 })
+  writeFileSync(nf, name.trim().slice(0, 500), { mode: 0o600 })
+}
+
+async function bind(route: Route, threadId: string, name?: string): Promise<boolean> {
+  if (!SAFE.test(threadId) || !SAFE.test(route.nodeId)) return false
+  const file = identityFile(threadId, route.accountId)
+  const existingOwner = parseOwner(file, scope(route.accountId))
+  // Without Electron's live workspace we cannot distinguish a stale owner from a live one. Never
+  // steal another node's thread in the detached fallback; the authenticated main handler may
+  // rebind it after checking liveness.
+  if (existingOwner && existingOwner !== route.nodeId) {
+    persistName(route, threadId, name)
+    // The reservation remains held until Electron has atomically checked liveness and committed
+    // the replacement mapping. Without that acknowledgement, report failure to the TUI.
+    return notifyElectron(route, threadId, name)
+  }
+  mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+  const tmp = `${file}.${process.pid}.tmp`
+  const quarantined: Array<{ source: string; quarantine: string }> = []
+  const mappings = path.join(root, 'codex-thread-nodes')
+  try {
+    writeFileSync(
+      tmp,
+      `accountId=${scope(route.accountId)}\nnodeId=${route.nodeId}\nendpoint=${route.hookEndpoint}\n`,
+      {
+        mode: 0o600
+      }
+    )
+    for (const dir of readdirSync(mappings, { withFileTypes: true })) {
+      const files: Array<{ file: string; scope?: string }> =
+        dir.isDirectory() && SAFE.test(dir.name)
+          ? readdirSync(path.join(mappings, dir.name)).map((n) => ({
+              file: path.join(mappings, dir.name, n),
+              scope: dir.name
+            }))
+          : dir.isFile()
+            ? [{ file: path.join(mappings, dir.name) }]
+            : []
+      for (const other of files) {
+        if (
+          other.file !== file &&
+          other.file !== tmp &&
+          (parseOwner(other.file, other.scope) === route.nodeId ||
+            path.basename(other.file) === threadId)
+        ) {
+          const quarantine = `${other.file}.transfer-${process.pid}-${Date.now()}-${quarantined.length}`
+          renameSync(other.file, quarantine)
+          quarantined.push({ source: other.file, quarantine })
+        }
+      }
+    }
+    renameSync(tmp, file)
+  } catch {
+    for (const item of quarantined.reverse()) {
+      try {
+        renameSync(item.quarantine, item.source)
+      } catch {}
+    }
+    try {
+      unlinkSync(tmp)
+    } catch {}
+    return false
+  }
+  for (const item of quarantined) {
+    try {
+      unlinkSync(item.quarantine)
+    } catch {}
+  }
+  try {
+    persistName(route, threadId, name)
+  } catch {}
+  // Local atomic mapping is already the ownership commit. Await Electron for immediate title/status
+  // refresh, but an app restart must not invalidate the durable mapping the relay just wrote.
+  await notifyElectron(route, threadId, name)
+  return true
+}
+
+function indexedName(socketPath: string, threadId?: string): string | undefined {
+  if (!threadId || !SAFE.test(threadId)) return undefined
+  const home = path.dirname(path.dirname(socketPath))
+  try {
+    let found: string | undefined
+    for (const line of readFileSync(path.join(home, 'session_index.jsonl'), 'utf8').split('\n')) {
+      if (!line.includes(threadId)) continue
+      const x = JSON.parse(line) as { id?: string; thread_name?: string }
+      if (x.id === threadId && x.thread_name?.trim()) found = x.thread_name.trim()
+    }
+    return found
+  } catch {
+    return undefined
+  }
+}
+
+function hookEndpointOptions(
+  env: Record<string, string>,
+  pathname: string
+): { socketPath: string; path: string } | { hostname: string; port: number; path: string } | null {
+  if (env.NODETERM_HOOK_SOCK?.startsWith('/')) {
+    return { socketPath: env.NODETERM_HOOK_SOCK, path: pathname }
+  }
+  const port = Number(env.NODETERM_HOOK_PORT)
+  return port > 0 ? { hostname: '127.0.0.1', port, path: pathname } : null
+}
+
+function hookRequest(
+  route: Route,
+  pathname: string,
+  fields: Record<string, string>
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let env: Record<string, string>
+    try {
+      env = Object.fromEntries(
+        readFileSync(route.hookEndpoint, 'utf8')
+          .split('\n')
+          .filter(Boolean)
+          .map((l) => {
+            const i = l.indexOf('=')
+            return i > 0 ? [l.slice(0, i), l.slice(i + 1)] : ['', '']
+          })
+      )
+    } catch (error) {
+      reject(error)
+      return
+    }
+    const token = env.NODETERM_HOOK_TOKEN
+    const endpoint = hookEndpointOptions(env, pathname)
+    if (!endpoint || !token || !SAFE_NODE_TOKEN.test(route.nodeToken)) {
+      reject(new Error('NodeTerm hook endpoint unavailable'))
+      return
+    }
+    const body = new URLSearchParams(fields).toString()
+    const req = request(
+      {
+        ...endpoint,
+        method: 'POST',
+        headers: {
+          'x-nodeterm-hook-token': token,
+          'x-nodeterm-node-token': route.nodeToken,
+          'content-type': 'application/x-www-form-urlencoded',
+          'content-length': Buffer.byteLength(body)
+        }
+      },
+      (res) => {
+        res.resume()
+        res.on('end', () => resolve(res.statusCode ?? 0))
+      }
+    )
+    req.on('error', reject)
+    req.setTimeout(3_000, () => req.destroy(new Error('NodeTerm hook request timed out')))
+    req.end(body)
+  })
+}
+
+function hookJsonRequest<T>(route: Route, pathname: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let env: Record<string, string>
+    try {
+      env = Object.fromEntries(
+        readFileSync(route.hookEndpoint, 'utf8')
+          .split('\n')
+          .filter(Boolean)
+          .map((line) => {
+            const separator = line.indexOf('=')
+            return separator > 0 ? [line.slice(0, separator), line.slice(separator + 1)] : ['', '']
+          })
+      )
+    } catch (error) {
+      reject(error)
+      return
+    }
+    const token = env.NODETERM_HOOK_TOKEN
+    const endpoint = hookEndpointOptions(env, pathname)
+    if (!endpoint || !token || !SAFE_NODE_TOKEN.test(route.nodeToken)) {
+      reject(new Error('NodeTerm hook endpoint unavailable'))
+      return
+    }
+    const req = request(
+      {
+        ...endpoint,
+        method: 'POST',
+        headers: {
+          'x-nodeterm-hook-token': token,
+          'x-nodeterm-node-token': route.nodeToken,
+          'x-nodeterm-node-id': route.nodeId,
+          'content-length': '0'
+        }
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            reject(new Error('NodeTerm hook request failed'))
+            return
+          }
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString()) as T)
+          } catch {
+            reject(new Error('NodeTerm hook returned invalid JSON'))
+          }
+        })
+      }
+    )
+    req.on('error', reject)
+    req.setTimeout(10_000, () => req.destroy(new Error('NodeTerm hook request timed out')))
+    req.end()
+  })
+}
+
+export function listThreadsAt(
+  socketPath: string,
+  requestedParams: Record<string, any>,
+  timeoutMs = 10_000
+): Promise<RelayThread[]> {
+  return new Promise((resolve, reject) => {
+    let ws: WebSocket
+    let settled = false
+    let requestId = 2
+    const threads: RelayThread[] = []
+    const seenCursors = new Set<string>()
+    const finish = (error?: Error): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {}
+      if (error) reject(error)
+      else resolve(threads)
+    }
+    const timer = setTimeout(() => finish(new Error('Codex thread catalog timed out')), timeoutMs)
+    timer.unref?.()
+    try {
+      ws = new WebSocket(`ws+unix://${socketPath}:/rpc`, {
+        perMessageDeflate: false
+      })
+    } catch {
+      clearTimeout(timer)
+      reject(new Error('Codex app-server is unavailable'))
+      return
+    }
+    const requestPage = (cursor?: string): void => {
+      const params = {
+        ...requestedParams,
+        cursor: cursor ?? null,
+        limit: 1000
+      }
+      ws.send(JSON.stringify({ id: requestId, method: 'thread/list', params }))
+    }
+    ws.once('open', () =>
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'initialize',
+          params: {
+            clientInfo: { name: 'nodeterm-relay', version: VERSION },
+            capabilities: { experimentalApi: true }
+          }
+        })
+      )
+    )
+    ws.on('message', (raw) => {
+      let message: Record<string, any>
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.id === 1) {
+        if (message.error) return finish(new Error('Codex app-server initialization failed'))
+        ws.send(JSON.stringify({ method: 'initialized' }))
+        requestPage()
+        return
+      }
+      if (message.id !== requestId) return
+      if (message.error || !Array.isArray(message.result?.data)) {
+        finish(new Error('Codex thread catalog failed'))
+        return
+      }
+      threads.push(...message.result.data)
+      const cursor = message.result.nextCursor
+      if (
+        typeof cursor !== 'string' ||
+        !cursor ||
+        seenCursors.has(cursor) ||
+        threads.length >= 10_000
+      ) {
+        finish()
+        return
+      }
+      seenCursors.add(cursor)
+      requestId += 1
+      requestPage(cursor)
+    })
+    ws.once('error', () => finish(new Error('Codex app-server is unavailable')))
+    ws.once('close', () => finish(new Error('Codex app-server closed during thread listing')))
+  })
+}
+
+function isExplicitThreadAbsent(error: unknown, threadId: string): boolean {
+  if (!error || typeof error !== 'object') return false
+  const { code, message } = error as { code?: unknown; message?: unknown }
+  if (code !== -32600 || typeof message !== 'string') return false
+  return (
+    message === `thread not loaded: ${threadId}` ||
+    message === `no rollout found for thread id ${threadId}`
+  )
+}
+
+export function readThreadOutcomeAt(
+  socketPath: string,
+  threadId: string,
+  timeoutMs = 5_000
+): Promise<RelayThreadReadOutcome> {
+  if (!path.isAbsolute(socketPath) || !SAFE.test(threadId)) {
+    return Promise.resolve({ kind: 'unavailable' })
+  }
+  return new Promise((resolve) => {
+    let ws: WebSocket
+    let settled = false
+    const finish = (outcome: RelayThreadReadOutcome): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {}
+      resolve(outcome)
+    }
+    const timer = setTimeout(() => finish({ kind: 'unavailable' }), timeoutMs)
+    timer.unref?.()
+    try {
+      ws = new WebSocket(`ws+unix://${socketPath}:/rpc`, {
+        perMessageDeflate: false
+      })
+    } catch {
+      clearTimeout(timer)
+      resolve({ kind: 'unavailable' })
+      return
+    }
+    ws.once('open', () =>
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'initialize',
+          params: { clientInfo: { name: 'nodeterm-relay', version: VERSION } }
+        })
+      )
+    )
+    ws.on('message', (raw) => {
+      let message: Record<string, any>
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.id === 1) {
+        if (message.error) return finish({ kind: 'unavailable' })
+        ws.send(JSON.stringify({ method: 'initialized' }))
+        ws.send(
+          JSON.stringify({
+            id: 2,
+            method: 'thread/read',
+            params: { threadId, includeTurns: false }
+          })
+        )
+      } else if (message.id === 2) {
+        if (message.error) {
+          finish(
+            isExplicitThreadAbsent(message.error, threadId)
+              ? { kind: 'absent' }
+              : { kind: 'unavailable' }
+          )
+          return
+        }
+        const thread = message.result?.thread as RelayThread | undefined
+        if (
+          !thread ||
+          thread.id !== threadId ||
+          typeof thread.path !== 'string' ||
+          !path.isAbsolute(thread.path) ||
+          typeof thread.cwd !== 'string' ||
+          !path.isAbsolute(thread.cwd)
+        ) {
+          finish({ kind: 'unavailable' })
+          return
+        }
+        finish({ kind: 'found', thread })
+      }
+    })
+    ws.once('error', () => finish({ kind: 'unavailable' }))
+    ws.once('close', () => finish({ kind: 'unavailable' }))
+  })
+}
+
+export async function readThreadAt(
+  socketPath: string,
+  threadId: string,
+  timeoutMs = 5_000
+): Promise<RelayThread> {
+  const outcome = await readThreadOutcomeAt(socketPath, threadId, timeoutMs)
+  if (outcome.kind !== 'found') throw new Error('Codex source thread is unavailable')
+  return outcome.thread
+}
+
+async function readAccountAt(
+  socketPath: string,
+  timeoutMs = 5_000
+): Promise<{ email: string | null }> {
+  if (!path.isAbsolute(socketPath)) throw new Error('Invalid Codex socket')
+  return new Promise((resolve, reject) => {
+    let ws: WebSocket
+    let settled = false
+    const finish = (value?: { email: string | null }, error?: Error): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {}
+      if (error) reject(error)
+      else resolve(value ?? { email: null })
+    }
+    const timer = setTimeout(
+      () => finish(undefined, new Error('Codex account read timed out')),
+      timeoutMs
+    )
+    timer.unref?.()
+    ws = new WebSocket(`ws+unix://${socketPath}:/rpc`, {
+      perMessageDeflate: false
+    })
+    ws.once('open', () =>
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'initialize',
+          params: { clientInfo: { name: 'nodeterm-relay', version: VERSION } }
+        })
+      )
+    )
+    ws.on('message', (raw) => {
+      let message: Record<string, any>
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.id === 1) {
+        if (message.error)
+          return finish(undefined, new Error('Codex app-server initialization failed'))
+        ws.send(JSON.stringify({ method: 'initialized' }))
+        ws.send(JSON.stringify({ id: 2, method: 'account/read', params: {} }))
+      } else if (message.id === 2) {
+        if (message.error) return finish(undefined, new Error('Codex account read failed'))
+        const email =
+          typeof message.result?.account?.email === 'string'
+            ? message.result.account.email
+            : typeof message.result?.email === 'string'
+              ? message.result.email
+              : null
+        finish({ email })
+      }
+    })
+    ws.once('error', () => finish(undefined, new Error('Codex app-server is unavailable')))
+    ws.once('close', () =>
+      finish(undefined, new Error('Codex app-server closed during account read'))
+    )
+  })
+}
+
+/** Resolve a direct `resume <id>` that did not pass through the merged picker. The selected
+ * account wins when it already knows the id. Otherwise exactly one foreign account must expose a
+ * valid rollout path; duplicate ids across foreign accounts deliberately remain unresolved. */
+export async function resolveForeignThreadAt(
+  currentSocketPath: string,
+  catalogSocketPaths: string[],
+  threadId: string
+): Promise<RelayThreadLocation> {
+  if (!path.isAbsolute(currentSocketPath) || !SAFE.test(threadId)) return { kind: 'unavailable' }
+  const current = await readThreadOutcomeAt(currentSocketPath, threadId)
+  if (current.kind === 'found') return { kind: 'native' }
+  if (current.kind === 'unavailable') return { kind: 'unavailable' }
+  const sockets = [...new Set(catalogSocketPaths)].filter(
+    (socketPath) => socketPath !== currentSocketPath && path.isAbsolute(socketPath)
+  )
+  const outcomes = await Promise.all(
+    sockets.map(async (socketPath) => {
+      const outcome = await readThreadOutcomeAt(socketPath, threadId)
+      if (outcome.kind !== 'found') return outcome
+      const thread = outcome.thread
+      const name =
+        typeof thread.name === 'string' && thread.name.trim() ? thread.name.trim() : undefined
+      return {
+        kind: 'found' as const,
+        thread: {
+          socketPath,
+          path: thread.path as string,
+          cwd: thread.cwd,
+          ...(name ? { name } : {})
+        }
+      }
+    })
+  )
+  if (outcomes.some((outcome) => outcome.kind === 'unavailable')) return { kind: 'unavailable' }
+  const matches = outcomes
+    .filter(
+      (outcome): outcome is { kind: 'found'; thread: RelayForeignThread } =>
+        outcome.kind === 'found'
+    )
+    .map((outcome) => outcome.thread)
+  if (matches.length === 0) return { kind: 'unavailable' }
+  const canonical = new Map<string, RelayForeignThread>()
+  for (const match of matches) {
+    const rollout = rolloutIdentity(match.path)
+    if (!rollout) return { kind: 'unavailable' }
+    canonical.set(rollout, canonical.get(rollout) ?? match)
+  }
+  if (canonical.size === 1) return { kind: 'foreign', thread: [...canonical.values()][0] }
+  return { kind: 'ambiguous' }
+}
+
+async function authorizeResume(route: Route, threadId: string): Promise<boolean> {
+  const owner = conflictingOwner(threadId)
+  if (owner === '' || owner === route.nodeId) return true
+  try {
+    return (
+      (await hookRequest(route, '/codex-thread/authorize', {
+        nodeId: route.nodeId,
+        threadId,
+        accountId: route.accountId ?? ''
+      })) === 204
+    )
+  } catch {
+    return false
+  }
+}
+
+async function notifyElectron(route: Route, threadId: string, name?: string): Promise<boolean> {
+  try {
+    return (
+      (await hookRequest(route, '/codex-thread/observed', {
+        nodeId: route.nodeId,
+        threadId,
+        accountId: route.accountId ?? '',
+        name: name ?? ''
+      })) === 204
+    )
+  } catch {
+    return false
+  }
+}
+
+function serve(): void {
+  mkdirSync(root, { recursive: true, mode: 0o700 })
+  const lock = `${statePath}.serve-lock`
+  if (!acquireProcessLock(lock)) return
+  const current = readState()
+  if (current) {
+    try {
+      process.kill(current.pid, 0)
+      releaseProcessLock(lock)
+      return
+    } catch {}
+  }
+  const token = randomUUID()
+  const routes = new Map<string, RegisteredRoute>()
+  const reservations = new Map<string, symbol>()
+  const wss = new WebSocketServer({ noServer: true })
+  const server = createServer((req, res) => {
+    if (!authOk(req.headers.authorization, token) || req.method !== 'POST') {
+      res.writeHead(403).end()
+      return
+    }
+    if (req.url === '/ping') {
+      res.writeHead(200).end('ok')
+      return
+    }
+    if (req.url !== '/register') {
+      res.writeHead(404).end()
+      return
+    }
+    const chunks: Buffer[] = []
+    req.on('data', (c) => chunks.push(Buffer.from(c)))
+    req.on('end', () => {
+      try {
+        const route = JSON.parse(Buffer.concat(chunks).toString()) as Route
+        // Account id becomes a directory/scope/mapping-file component, so it passes the shared
+        // supply-chain predicate (must start alnum — blocks `.`/`..`/leading separator), not just
+        // the looser wire charset (GC 7).
+        if (
+          !SAFE.test(route.nodeId) ||
+          !SAFE_NODE_TOKEN.test(route.nodeToken) ||
+          (route.accountId && !isSafeAccountId(route.accountId)) ||
+          !path.isAbsolute(route.socketPath) ||
+          !path.isAbsolute(route.hookEndpoint)
+        )
+          throw new Error()
+        const key = randomUUID()
+        const timer = setTimeout(() => routes.delete(key), 60_000)
+        timer.unref?.()
+        routes.set(key, { route, timer, active: 0 })
+        res.writeHead(200, { 'content-type': 'text/plain' })
+        res.end(key)
+      } catch {
+        res.writeHead(400).end()
+      }
+    })
+  })
+  server.on('upgrade', (req, socket, head) => {
+    // Codex 0.147 deliberately accepts only `ws://host:port` as --remote; URL paths are rejected
+    // before a connection is attempted. Use the already-required per-connection Bearer token as
+    // the one-shot route capability while every node still shares this single listener.
+    const routeKey = bearerToken(req.headers.authorization)
+    const registered = routeKey && routes.get(routeKey)
+    if (!registered || !authOk(req.headers.authorization, routeKey)) {
+      socket.destroy()
+      return
+    }
+    const route = registered.route
+    clearTimeout(registered.timer)
+    // Codex TUI opens more than one WebSocket for one invocation (session picker/bootstrap and
+    // the main session). The random capability remains scoped to this exact node route while any
+    // connection is live, then expires shortly after the final disconnect to allow reconnects.
+    registered.active += 1
+    wss.handleUpgrade(req, socket, head, (down) => {
+      const up = new WebSocket(`ws+unix://${route.socketPath}:/rpc`, {
+        perMessageDeflate: false
+      })
+      const queued: Array<{ data: Buffer; binary: boolean }> = []
+      const pending = new Map<string, RelayThreadRequest>()
+      const reservationOwner = Symbol(route.nodeId)
+      const requestReservations = new Map<string, string>()
+      down.on('message', async (data, binary) => {
+        let buf = Buffer.from(data as any)
+        let message: any
+        let foreignName: string | undefined
+        try {
+          message = JSON.parse(buf.toString())
+          if (message.method === 'thread/list' && message.id !== undefined) {
+            try {
+              const catalog = await hookJsonRequest<{
+                accounts: Array<{ accountId?: string; socketPath: string }>
+              }>(route, '/codex-thread/catalog')
+              const socketPaths = [
+                ...new Set([
+                  route.socketPath,
+                  ...catalog.accounts
+                    .map((account) => account.socketPath)
+                    .filter((socketPath) => path.isAbsolute(socketPath))
+                ])
+              ]
+              if (socketPaths.length > 1) {
+                const params =
+                  message.params && typeof message.params === 'object' ? message.params : {}
+                const sourceParams = { ...params }
+                delete sourceParams.cursor
+                const sources = (
+                  await Promise.all(
+                    socketPaths.map(async (socketPath) => {
+                      try {
+                        return {
+                          socketPath,
+                          threads: await listThreadsAt(socketPath, sourceParams)
+                        }
+                      } catch {
+                        return null
+                      }
+                    })
+                  )
+                ).filter((source): source is RelayThreadSource => source !== null)
+                if (sources.some((source) => source.socketPath === route.socketPath)) {
+                  const merged = mergeRelayThreadLists(sources, route.socketPath, params)
+                  if (down.readyState === WebSocket.OPEN) {
+                    down.send(JSON.stringify({ id: message.id, result: merged.result }))
+                  }
+                  return
+                }
+              }
+            } catch {
+              // Electron may be restarting. Fall through to the selected account's native list.
+            }
+          }
+          if (message.method === 'thread/resume') {
+            const selectedThreadId = message.params?.threadId
+            const requestId = message.id === undefined ? '' : String(message.id)
+            const reservationKey =
+              typeof selectedThreadId === 'string' && SAFE.test(selectedThreadId)
+                ? relayThreadReservationKey(selectedThreadId)
+                : ''
+            // Global by thread id and synchronous before catalog/read awaits: neither another
+            // account nor a native/foreign routing difference may open the rollout concurrently.
+            if (
+              !tryReserveRelayThread(
+                reservations,
+                requestReservations,
+                reservationKey,
+                requestId,
+                reservationOwner
+              )
+            ) {
+              if (message.id !== undefined && down.readyState === WebSocket.OPEN) {
+                down.send(
+                  JSON.stringify({
+                    id: message.id,
+                    error: {
+                      code: -32001,
+                      message: 'Codex thread is already open in another NodeTerm node'
+                    }
+                  })
+                )
+              }
+              return
+            }
+            try {
+              let location: RelayThreadLocation
+              try {
+                await readThreadAt(route.socketPath, selectedThreadId)
+                location = { kind: 'native' }
+              } catch {
+                const catalog = await hookJsonRequest<{
+                  accounts: Array<{ accountId?: string; socketPath: string }>
+                }>(route, '/codex-thread/catalog')
+                location = await resolveForeignThreadAt(
+                  route.socketPath,
+                  catalog.accounts.map((account) => account.socketPath),
+                  selectedThreadId
+                )
+              }
+              if (
+                reservations.get(reservationKey) !== reservationOwner ||
+                down.readyState !== WebSocket.OPEN
+              )
+                return
+              if (location.kind === 'ambiguous' || location.kind === 'unavailable')
+                throw new Error()
+              if (location.kind === 'foreign') {
+                const foreign = location.thread
+                const cwd =
+                  typeof message.params?.cwd === 'string' && path.isAbsolute(message.params.cwd)
+                    ? message.params.cwd
+                    : foreign.cwd
+                foreignName = foreign.name ?? indexedName(foreign.socketPath, selectedThreadId)
+                message = retargetRelayResumeByPath(message, selectedThreadId, foreign.path, cwd)
+                buf = Buffer.from(JSON.stringify(message))
+              }
+            } catch {
+              if (reservations.get(reservationKey) === reservationOwner)
+                reservations.delete(reservationKey)
+              requestReservations.delete(requestId)
+              if (message.id !== undefined && down.readyState === WebSocket.OPEN) {
+                down.send(
+                  JSON.stringify({
+                    id: message.id,
+                    error: {
+                      code: -32003,
+                      message: 'NodeTerm could not uniquely resolve this Codex session'
+                    }
+                  })
+                )
+              }
+              return
+            }
+          }
+          if (message.method === 'thread/resume' || message.method === 'thread/fork') {
+            const threadId = message.params?.threadId
+            const requestId = message.id === undefined ? '' : String(message.id)
+            const heldReservationKey = requestReservations.get(requestId)
+            const reservationKey =
+              heldReservationKey ??
+              (typeof threadId === 'string' ? `${route.socketPath}\0fork\0${threadId}` : '')
+            // Set synchronously BEFORE authorizeResume's first await. Two connections arriving in
+            // the same event-loop turn therefore cannot both pass and reach the shared app-server.
+            if (
+              !requestId ||
+              !reservationKey ||
+              (!heldReservationKey && reservations.has(reservationKey))
+            ) {
+              if (message.id !== undefined && down.readyState === WebSocket.OPEN) {
+                down.send(
+                  JSON.stringify({
+                    id: message.id,
+                    error: {
+                      code: -32001,
+                      message: 'Codex thread is already open in another NodeTerm node'
+                    }
+                  })
+                )
+              }
+              return
+            }
+            if (!heldReservationKey) {
+              reservations.set(reservationKey, reservationOwner)
+              requestReservations.set(requestId, reservationKey)
+            }
+            const authorized = await authorizeResume(route, threadId)
+            // Close may have run while authorization was pending. It released this reservation;
+            // never resurrect it or forward a queued resume after its owning connection is gone.
+            if (
+              reservations.get(reservationKey) !== reservationOwner ||
+              down.readyState !== WebSocket.OPEN
+            ) {
+              return
+            }
+            if (!authorized) {
+              if (reservations.get(reservationKey) === reservationOwner)
+                reservations.delete(reservationKey)
+              requestReservations.delete(requestId)
+              if (down.readyState === WebSocket.OPEN) {
+                down.send(
+                  JSON.stringify({
+                    id: message.id,
+                    error: {
+                      code: -32001,
+                      message: 'Codex thread is already open in another NodeTerm node'
+                    }
+                  })
+                )
+              }
+              return
+            }
+          }
+          trackRelayThreadRequest(pending, message, foreignName)
+        } catch {}
+        if (up.readyState === WebSocket.OPEN) up.send(buf, { binary })
+        else queued.push({ data: buf, binary })
+      })
+      up.on('open', () => {
+        if (down.readyState !== WebSocket.OPEN) {
+          queued.length = 0
+          up.close()
+          return
+        }
+        for (const q of queued.splice(0)) up.send(q.data, { binary: q.binary })
+      })
+      up.on('message', async (data, binary) => {
+        const buf = Buffer.from(data as any)
+        let outbound = buf
+        let reservationKey: string | undefined
+        let responseId = ''
+        try {
+          const message = JSON.parse(buf.toString())
+          if (message?.id !== undefined) {
+            responseId = String(message.id)
+            reservationKey = requestReservations.get(responseId)
+          }
+          const observed = resolveRelayThreadResponse(pending, message)
+          if (observed && !observed.ok) {
+            outbound = Buffer.from(
+              JSON.stringify({
+                id: message.id,
+                error: {
+                  code: -32004,
+                  message: 'Codex changed the conversation id during account switch'
+                }
+              })
+            )
+          }
+          const committed = observed?.ok
+            ? await bind(
+                route,
+                observed.threadId,
+                observed.name ?? indexedName(route.socketPath, observed.source)
+              ).catch(() => false)
+            : true
+          if (observed?.ok && !committed) {
+            outbound = Buffer.from(
+              JSON.stringify({
+                id: message.id,
+                error: {
+                  code: -32002,
+                  message: 'NodeTerm could not commit Codex thread ownership'
+                }
+              })
+            )
+          }
+        } catch {}
+        if (reservationKey) {
+          requestReservations.delete(responseId)
+          if (reservations.get(reservationKey) === reservationOwner)
+            reservations.delete(reservationKey)
+        }
+        if (down.readyState === WebSocket.OPEN) down.send(outbound, { binary })
+      })
+      let closed = false
+      const close = () => {
+        if (closed) return
+        closed = true
+        for (const key of requestReservations.values())
+          if (reservations.get(key) === reservationOwner) reservations.delete(key)
+        requestReservations.clear()
+        queued.length = 0
+        try {
+          down.close()
+        } catch {}
+        try {
+          up.close()
+        } catch {}
+        registered.active = Math.max(0, registered.active - 1)
+        if (registered.active === 0) {
+          registered.timer = setTimeout(() => {
+            if (routes.get(routeKey) === registered && registered.active === 0)
+              routes.delete(routeKey)
+          }, 5 * 60_000)
+          registered.timer.unref?.()
+        }
+      }
+      down.on('close', close)
+      down.on('error', close)
+      up.on('close', close)
+      up.on('error', close)
+    })
+  })
+  const releaseLock = (): void => {
+    releaseProcessLock(lock)
+  }
+  const onListenError = (): void => releaseLock()
+  server.once('error', onListenError)
+  server.listen(0, '127.0.0.1', () => {
+    server.off('error', onListenError)
+    const addr = server.address()
+    if (!addr || typeof addr === 'string') process.exit(1)
+    const tmp = `${statePath}.${process.pid}.tmp`
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        version: VERSION,
+        pid: process.pid,
+        port: addr.port,
+        token
+      }),
+      { mode: 0o600 }
+    )
+    renameSync(tmp, statePath)
+    releaseLock()
+  })
+}
+
+async function register(): Promise<void> {
+  const [nodeId, accountRaw, socketPath, hookEndpoint] = process.argv.slice(3)
+  const nodeToken = process.env.NODETERM_CODEX_NODE_TOKEN ?? ''
+  const accountId = accountRaw || undefined
+  if (
+    !SAFE.test(nodeId) ||
+    !SAFE_NODE_TOKEN.test(nodeToken) ||
+    (accountId && !isSafeAccountId(accountId)) ||
+    !path.isAbsolute(socketPath) ||
+    !path.isAbsolute(hookEndpoint)
+  )
+    throw new Error('invalid relay registration')
+  const state = await ensureServer()
+  const key = await relayControlPost(state.port, state.token, '/register', {
+    nodeId,
+    nodeToken,
+    accountId,
+    socketPath,
+    hookEndpoint
+  })
+  process.stdout.write(`ws://127.0.0.1:${state.port}\n${key}\n`)
+}
+
+export type ExposeThreadOutcome = { kind: 'native' } | { kind: 'exposed' }
+
+/**
+ * Copy a foreign idle conversation's rollout into the TARGET account and prove the far side can
+ * discover it — the "verify then recycle" leg of the cross-machine copy (§4.2a / §6). The node is
+ * recycled onto the target account ONLY when this resolves `exposed`.
+ *
+ * The copy itself is NOT re-implemented here: it is PR 3's atomic, never-overwrite hardlink
+ * primitive. `planCodexRolloutExposure` re-confirms the source stays inside its own account
+ * `sessions/` and is a regular file; `commitCodexRolloutExposure` links the exact source inode into
+ * `<targetHome>/sessions/<same relative path>` (same conversation id), fails closed on a target that
+ * already holds a DIFFERENT rollout for the thread, and never writes through a symlinked segment.
+ *
+ * Then — because a running app-server surfacing the fresh hardlink without a reindex is UNVERIFIED
+ * (probe U1) — re-read the TARGET socket: `thread/read` must report this exact id with an absolute
+ * path/cwd. If it does not, roll the published link back (only while it still names our source
+ * inode, so a concurrent legitimate entry is never deleted) and refuse. A pre-existing idempotent
+ * link is never rolled back, because this call did not publish it. The source rollout is a hardlink
+ * and is left fully intact throughout.
+ */
+export async function exposeForeignThread(
+  targetSocket: string,
+  threadId: string,
+  catalogSockets: string[]
+): Promise<ExposeThreadOutcome> {
+  if (
+    !path.isAbsolute(targetSocket) ||
+    !SAFE.test(threadId) ||
+    catalogSockets.length === 0 ||
+    catalogSockets.some((socket) => !path.isAbsolute(socket))
+  ) {
+    throw new Error('invalid Codex exposure request')
+  }
+  const resolved = await resolveForeignThreadAt(targetSocket, catalogSockets, threadId)
+  if (resolved.kind === 'native') return { kind: 'native' }
+  if (resolved.kind !== 'foreign') throw new Error('Codex session id is unavailable or ambiguous')
+  const sourceHome = path.dirname(path.dirname(resolved.thread.socketPath))
+  const targetHome = path.dirname(path.dirname(targetSocket))
+  const plan = planCodexRolloutExposure(sourceHome, targetHome, resolved.thread.path, threadId)
+  // Remember whether the target already held the rollout: only a link THIS call publishes may be
+  // rolled back on a discovery failure.
+  const preExisted = existsSync(plan.targetPath)
+  commitCodexRolloutExposure(plan)
+  const outcome = await readThreadOutcomeAt(targetSocket, threadId)
+  if (outcome.kind === 'found') return { kind: 'exposed' }
+  if (!preExisted) rollbackExposedLink(plan)
+  throw new Error('Copied Codex rollout was not discoverable on the target account')
+}
+
+/** Undo a link this exposure published — but only while the target still names the exact source
+ * inode we linked, so a legitimate entry a concurrent process raced into the pathname is untouched
+ * (mirrors PR 3's `publishedTargetStillOurs` discipline). */
+function rollbackExposedLink(plan: {
+  targetPath: string
+  sourceDev: number
+  sourceIno: number
+}): void {
+  try {
+    const entry = lstatSync(plan.targetPath)
+    if (entry.dev === plan.sourceDev && entry.ino === plan.sourceIno) unlinkSync(plan.targetPath)
+  } catch {
+    /* nothing to roll back */
+  }
+}
+
+async function exposeThread(): Promise<void> {
+  const [targetSocket, threadId, ...catalogSockets] = process.argv.slice(3)
+  await exposeForeignThread(targetSocket ?? '', threadId ?? '', catalogSockets)
+}
+
+if (process.argv[2] === 'serve') serve()
+else if (process.argv[2] === 'register')
+  void register().catch((error) => {
+    console.error(error instanceof Error ? error.message : 'NodeTerm Codex relay unavailable')
+    process.exit(69)
+  })
+else if (process.argv[2] === 'account-read')
+  void readAccountAt(process.argv[3] ?? '')
+    .then((account) => {
+      process.stdout.write(`${JSON.stringify(account)}\n`)
+    })
+    .catch(() => process.exit(69))
+else if (process.argv[2] === 'thread-check')
+  void readThreadAt(process.argv[3] ?? '', process.argv[4] ?? '')
+    .then(() => process.exit(0))
+    .catch(() => process.exit(69))
+else if (process.argv[2] === 'expose-thread') void exposeThread().catch(() => process.exit(69))

--- a/src/main/codex-relay-daemon.ts
+++ b/src/main/codex-relay-daemon.ts
@@ -40,9 +40,12 @@
  *      remote leg (uploaded `codex-relay.js` via `nodeterm-codex`) needs a live SSH host — owed. */
 import { createHash, randomUUID, timingSafeEqual } from 'crypto'
 import {
+  closeSync,
   existsSync,
+  fstatSync,
   lstatSync,
   mkdirSync,
+  openSync,
   readFileSync,
   readdirSync,
   renameSync,
@@ -384,12 +387,45 @@ export function acquireProcessLock(lock: string): boolean {
     }
   }
   if (attempt()) return true
+  // Read the lock's type, mtime and (legacy-file) owner from ONE descriptor, and the directory
+  // owner file from ONE open+read — never a `statSync(path)` followed by a `readFileSync(path)` on
+  // the same path (that check-then-use is a real fs race; here the fd IS the check-and-use, one
+  // inode). Same liveness semantics as before: a live pid holds the lock; a missing owner inside a
+  // fresh directory is the post-mkdir/pre-write window and is left alone for a grace period.
   let owner = 0
   let directory = false
+  let lockMtimeMs = 0
+  let fd: number | undefined
   try {
-    directory = statSync(lock).isDirectory()
-    owner = Number(readFileSync(directory ? path.join(lock, 'owner') : lock, 'utf8').trim())
-  } catch {}
+    fd = openSync(lock, 'r')
+    const stat = fstatSync(fd)
+    directory = stat.isDirectory()
+    lockMtimeMs = stat.mtimeMs
+    if (!directory) owner = Number(readFileSync(fd, 'utf8').trim())
+  } catch {
+    /* the lock vanished after our attempt failed — nothing to reclaim */
+  } finally {
+    if (fd !== undefined)
+      try {
+        closeSync(fd)
+      } catch {}
+  }
+  if (directory) {
+    // The owner file is a child of the lock directory; read it in a single open+read (no prior
+    // stat), so a missing owner surfaces as an open error, not a separate existence check.
+    let ownerFd: number | undefined
+    try {
+      ownerFd = openSync(path.join(lock, 'owner'), 'r')
+      owner = Number(readFileSync(ownerFd, 'utf8').trim())
+    } catch {
+      /* no owner file yet: the tiny post-mkdir/pre-write window */
+    } finally {
+      if (ownerFd !== undefined)
+        try {
+          closeSync(ownerFd)
+        } catch {}
+    }
+  }
   if (owner > 0) {
     try {
       process.kill(owner, 0)
@@ -398,12 +434,9 @@ export function acquireProcessLock(lock: string): boolean {
   }
   if (directory && owner <= 0) {
     // A missing owner is the tiny post-mkdir/pre-write window of a live contender. Only reclaim it
-    // after it has remained incomplete long enough that the creator demonstrably died.
-    try {
-      if (Date.now() - statSync(lock).mtimeMs < 10_000) return false
-    } catch {
-      return false
-    }
+    // after it has remained incomplete long enough that the creator demonstrably died. `lockMtimeMs`
+    // came from the same `fstatSync` above — no extra stat, no new race.
+    if (Date.now() - lockMtimeMs < 10_000) return false
   }
   try {
     if (directory) rmSync(lock, { recursive: true, force: true })
@@ -440,6 +473,12 @@ export function relayControlPost(
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const data = JSON.stringify(body)
+    // LOOPBACK-ONLY IPC, not an external request. The hostname is the hardcoded literal `127.0.0.1`
+    // (never a variable, never a remote host); the only recipient is THIS machine's own relay daemon
+    // on an ephemeral loopback port, gated by the per-process control token read from the relay's own
+    // `0600` state file and compared with `timingSafeEqual` on the far side. No file content is
+    // exfiltrated off-box: the "file data" a taint tracker sees is that local capability token
+    // travelling to the local socket that minted it. See docs/superpowers/probes for the transport.
     const req = request(
       {
         hostname: '127.0.0.1',


### PR DESCRIPTION
S6 PR 4 of external PR #112 ("Machine-scoped Codex accounts", @Corvin). Builds the shared relay daemon that multiplexes per-account Codex app-servers, merges the thread catalog across accounts, exposes/verifies cross-account rollouts, and guards the conversation id. Consumes PR 2's ownership proxy and **PR 3's atomic rollout primitive**. **Ships INERT** — no node connects until PR 5/6 wire it live.

## Probe results (Task 4.0, run first — Codex CLI 0.146.0, headless)
- **U4 — PARTIAL/VERIFIED.** `codex app-server daemon start|stop|version` honours `CODEX_HOME`; `version` JSON reports the socket at `<CODEX_HOME>/app-server-control/app-server-control.sock`. The **`SUN_LEN` socket-path limit is real** (a long `CODEX_HOME` fails to connect) — the measured justification for the short home digest. `--remote <ADDR>` + `--remote-auth-token-env <ENV_VAR>` exist (token by env, not argv). The `account/read`/`thread/read` RPC shapes need the curl-managed standalone install (absent here) → owed device-verify.
- **U1 — UNVERIFIED headless, NOT BLOCKING.** No running app-server / standalone install to test whether a fresh hardlink is surfaced without a reindex. The design does not rest on the optimistic answer: `exposeForeignThread` re-reads the target socket after linking and **rolls the link back + refuses** if the far side can't discover it — a false U1 degrades to a refused copy, never a silent switch.
- **U2 — UNVERIFIED headless, NOT BLOCKING.** Needs auth + a second login + a running daemon. Safety net: hardlinked inode + resume-by-path (history deleted) + the `-32004` guard when Codex changes the id.
- **U6 — LOCAL LEG VERIFIED (runnable).** A child-process test bundles the daemon to CJS and runs it under plain `node`: `register` self-spawns `serve`, binds the control port, writes its `0600` state, and answers a real `/register` round-trip. Remote leg (uploaded `codex-relay.js` via `nodeterm-codex`) needs a live SSH host → owed.

Full detail: `docs/superpowers/probes/2026-08-codex-relay-daemon.md`.

## Security properties (each red-on-regression, mutation-checked — 9 introduced / 9 caught)
- **Property 3 (fail closed on ambiguity):** `mergeRelayThreadLists` drops an id whose duplicates don't share a rollout inode; `resolveForeignThreadAt` requires `canonical.size === 1`. *Mutations: admit `canonical.size > 1` → red; drop the inode-ambiguity check → red.*
- **Property 5 (conversation-id guard):** `resolveRelayThreadResponse` flags `unexpectedThreadId`; reply rewritten to `-32004`; resume-by-path deletes `history`. *Mutation: swallow the flag and return success → red.*
- **Expose/verify uses PR 3's primitive** (`plan`/`commitCodexRolloutExposure`) — never a re-implemented `linkSync` — and verifies discoverability before recycle, rolling back if not. *Mutation: skip the verify → red.*
- **No credential on argv (GC 6):** node token via env, control token via the `0600` state file as a `Bearer` header, hook token from a file. *Argv-spy child-process test: registration succeeds with the token in env and fails without it, argv byte-identical.*
- **Locks:** `mkdir`-as-ownership; stale-reclaim only after `kill(pid,0)` + 10s grace; never steals a freshly created dir lock. *Mutations: drop the live-owner check → red; drop the fresh-lock grace → red.*
- **Reservation mutex** (`tryReserveRelayThread`) set synchronously before any await. *Mutation: always grant → red.*
- **Session-name relay fallback** (Task 4.4). *Mutations: drop the fallback → red; drop `readCodexThreadAt`'s id-match guard → red.*

## Divergences from the reference (stated)
1. Rollout copy calls **PR 3's** atomic never-overwrite primitive + a verify-then-recycle rollback, instead of @Corvin's inline `linkSync`.
2. The now-redundant socket-wait/`codexThreadExists` helpers in `codex-session-name.ts` are **kept**, not removed: their callers are live on `origin/main` and this PR ships inert — their removal belongs with PR 5's live wiring.
3. Account ids validated with the shared supply-chain predicate (`isSafeAccountId`, GC 7) at the register boundary.

## Tests
`npm run typecheck` clean. Full `npx vitest run`: **7501 passed, 12 skipped, 0 failed** (539 files). New: 30 daemon tests (`src/main/codex-relay-daemon.test.ts`) against real fs + real unix-socket fake app-servers; 17 in `codex-session-name.test.ts`.

## Owed device-verification
U1/U2 live-RPC shapes and the U6 remote leg need a host with the curl-managed standalone Codex install + auth + a second login. `ensureServer` does not create `~/.nodeterm` itself — PR 5's wiring must ensure the root exists before first relay use.

Credit: @Corvin (external PR #112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
