### PR TITLE
feat(codex): local accounts, device login, and the three-phase account switch

### DIFF
--- a/src/core/codex-accounts-core.test.ts
+++ b/src/core/codex-accounts-core.test.ts
@@ -23,6 +23,7 @@ import {
   codexSocketForAccount,
   codexTmuxEnvArgs,
   codexUsageAccounts,
+  ensureSharedCodexDaemon,
   legacyCodexAccountHome,
   migrateLegacyCodexAccountHome,
   migrateLegacyCodexAccountHomes,
@@ -539,5 +540,29 @@ describe('cross-account rollout exposure (atomic, never-overwrite)', () => {
     const stat = statSync(sourcePath)
     expect(plan.sourceDev).toBe(stat.dev)
     expect(plan.sourceIno).toBe(stat.ino)
+  })
+})
+
+describe('ensureSharedCodexDaemon: reuse-if-reachable-else-start-once (§2.2)', () => {
+  it('does NOT start when the app-server is already reachable', async () => {
+    let started = 0
+    await ensureSharedCodexDaemon(
+      async () => true,
+      async () => {
+        started++
+      }
+    )
+    expect(started).toBe(0)
+  })
+
+  it('starts exactly once when the app-server is not reachable', async () => {
+    let started = 0
+    await ensureSharedCodexDaemon(
+      async () => false,
+      async () => {
+        started++
+      }
+    )
+    expect(started).toBe(1)
   })
 })

--- a/src/core/codex-accounts-core.ts
+++ b/src/core/codex-accounts-core.ts
@@ -156,6 +156,22 @@ export function remoteCodexTmuxEnvArgs(remoteHome: string, accountId?: string): 
 }
 
 /**
+ * One shared Codex `app-server` per (machine, account): reuse it if it is already reachable, else
+ * start it exactly once (§2.2, the RAM-saver — not one app-server per node). `probe` answers "is a
+ * live app-server already listening on this account's control socket?"; `start` boots one. Kept in
+ * core (pure control flow over two injected effects) so the same primitive arms on desktop and on
+ * headless Server Edition, and so a test drives it with fakes rather than a real Codex CLI.
+ * Based on @Corvin's `ensureSharedCodexDaemon` in PR #112.
+ */
+export async function ensureSharedCodexDaemon(
+  probe: () => Promise<boolean>,
+  start: () => Promise<void>
+): Promise<void> {
+  if (await probe()) return
+  await start()
+}
+
+/**
  * Explicit per-session env. An EMPTY account id means the system account and is written
  * explicitly, so it OVERWRITES any managed `NODETERM_CODEX_ACCOUNT_ID` inherited from a parent
  * (tmux shares one server env) rather than silently acting as the wrong login.

--- a/src/core/codex-identity-proxy.test.ts
+++ b/src/core/codex-identity-proxy.test.ts
@@ -307,7 +307,12 @@ describe('account-scoped ownership', () => {
       path.join(recordsRoot, 'acct-B', 'thread-1')
     )
     expect(readCodexThreadIdentity('thread-1', recordsRoot, 'acct-A')?.nodeId).toBe('node-1')
-    // MUTATION TARGET: drop the line-vs-directory agreement check ⇒ acct-B honours it and reddens.
+    // The scope-bound HMAC is what actually carries this: the record was signed under scope
+    // `acct-A`, so recomputing the expected signature under scope `acct-B` mismatches and the record
+    // is rejected regardless. The explicit accountId-line-vs-directory agreement check is
+    // defence-in-depth layered on top (a clearer refusal, and belt-and-braces if the preimage ever
+    // changed). So this asserts the OUTCOME — acct-B never honours acct-A's record — not that the
+    // line check alone is load-bearing (carried PR-2 minor: the earlier comment overstated that).
     expect(readCodexThreadIdentity('thread-1', recordsRoot, 'acct-B')).toBeUndefined()
   })
 

--- a/src/core/pty-codex-spawn.test.ts
+++ b/src/core/pty-codex-spawn.test.ts
@@ -1,0 +1,110 @@
+/**
+ * S6 §5 property 4 / Decision 2 — the carried PR-1 obligation, now at the PtyManager layer.
+ *
+ * `resolveCodexSessionScope` (pty-codex-account.test.ts) proves the MODEL fails closed. This proves
+ * the PtyManager CONSUMES it: a LOCAL Codex create that explicitly selected a managed account whose
+ * home is MISSING refuses (`unavailable: 'codex-account'`) and spawns NOTHING — it never falls
+ * through to a system-`~/.codex` shell wearing the switch's identity. When the home exists, the
+ * same create spawns and the session runs under that managed CODEX_HOME + account id. The system
+ * account (no id, agentId codex) always spawns and pins NODETERM_CODEX_ACCOUNT_ID='' explicitly.
+ *
+ * MUTATION (recorded in the PR body): delete the `isCodexScopeRefusal` refusal block in
+ * pty-manager `spawnNew` → the missing-account create falls through and SPAWNS, so
+ * `expect(spawned).toHaveLength(0)` and `res.unavailable` both redden.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { IPC } from '../shared/ipc'
+import type { PtyCreateOptions, PtyCreateResult } from '../shared/types'
+import { codexAccountHome } from './codex-accounts-core'
+
+const spawned: Array<{ file: string; args: string[]; env: Record<string, string> }> = []
+
+vi.mock('node-pty', () => ({
+  spawn: (file: string, args: string[], options: { env: Record<string, string> }) => {
+    spawned.push({ file, args, env: options?.env ?? {} })
+    return {
+      onData: () => {},
+      onExit: () => {},
+      write: () => {},
+      resize: () => {},
+      pause: () => {},
+      resume: () => {},
+      kill: () => {},
+      pid: 4321
+    }
+  }
+}))
+
+// Never let the real /dev probe refuse the spawn on the developer's host (see pty-require-remote).
+vi.mock('./pty-devices', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./pty-devices')>()),
+  readPtyDevices: () => ({ ceiling: 511, inUse: 8 })
+}))
+
+const ALICE = 1
+
+describe('pty create: a local Codex spawn fails closed on a missing selected account', () => {
+  let fake: FakePlatform
+  let userDataDir: string
+
+  beforeEach(async () => {
+    spawned.length = 0
+    userDataDir = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-spawn-'))
+    fake = fakePlatform({ userDataDir })
+    initPlatform(fake)
+    const { PtyManager } = await import('./pty-manager')
+    new PtyManager().registerIpc()
+  })
+  afterEach(() => {
+    resetPlatformForTests()
+    rmSync(userDataDir, { recursive: true, force: true })
+  })
+
+  const create = (options: Partial<PtyCreateOptions>) =>
+    fake.handlers[IPC.ptyCreate](ALICE, {
+      cols: 80,
+      rows: 24,
+      persistKey: 'node-1',
+      cwd: '/srv/app',
+      ...options
+    }) as Promise<PtyCreateResult>
+
+  it('refuses (spawning nothing) when the explicitly selected managed home is missing', async () => {
+    // The account home is deliberately NOT created.
+    const res = await create({ agentId: 'codex', accountId: 'acct-missing' })
+
+    expect(spawned).toHaveLength(0) // the whole point: no system-~/.codex shell wearing the switch id
+    expect(res.unavailable).toBe('codex-account')
+    expect(res.sessionId).toBe('')
+    expect(res.fresh).toBe(false)
+  })
+
+  it('spawns under the managed CODEX_HOME + account id once the home exists', async () => {
+    const home = codexAccountHome(userDataDir, 'acct-real')
+    mkdirSync(home, { recursive: true })
+
+    const res = await create({ agentId: 'codex', accountId: 'acct-real', persistKey: 'node-2' })
+
+    expect(res.unavailable).toBeUndefined()
+    expect(res.sessionId).not.toBe('')
+    expect(spawned).toHaveLength(1)
+    expect(spawned[0].env.CODEX_HOME).toBe(home)
+    expect(spawned[0].env.NODETERM_CODEX_ACCOUNT_ID).toBe('acct-real')
+  })
+
+  it('a system Codex node (no account id) always spawns and clears any managed scope explicitly', async () => {
+    const res = await create({ agentId: 'codex', persistKey: 'node-3' })
+
+    expect(res.unavailable).toBeUndefined()
+    expect(spawned).toHaveLength(1)
+    // Explicitly empty — a parent tmux server's leaked managed scope must be overwritten, not
+    // inherited (§2.1).
+    expect(spawned[0].env.NODETERM_CODEX_ACCOUNT_ID).toBe('')
+    expect(path.isAbsolute(spawned[0].env.CODEX_HOME)).toBe(true)
+  })
+})

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -71,6 +71,13 @@ import { writeScrollback, readScrollback, deleteScrollback } from './scrollback-
 import { claudeConfigDirFor } from './claude-config-dir'
 import { findExecutableSync, findInPathString, resolveShellPath, shellPathNow } from './exec-path'
 import { AUTH_ENV_STRIP, accountTmuxEnvArgs, remoteAccountConfigDirAbs } from './claude-accounts-core'
+import {
+  AUTH_ENV_STRIP as CODEX_AUTH_ENV_STRIP,
+  codexSessionEnv,
+  isCodexScopeRefusal,
+  needsCodexAccountScope,
+  resolveCodexSessionScope
+} from './codex-accounts-core'
 import { NODE_ID_MAX, isSafeNodeId } from './remote-safety'
 import { presenceHub } from './presence/hub'
 import {
@@ -1713,6 +1720,20 @@ export class PtyManager {
     if (options.requireRemote && !(options.sshRemote && options.persistKey && findSsh())) {
       return { sessionId: '', fresh: false, unavailable: 'ssh' }
     }
+    // FAIL-CLOSED Codex account scope (S6 §5 property 4 / Decision 2, the carried PR-1 obligation).
+    // A LOCAL Codex spawn that EXPLICITLY selected a managed account whose home is missing REFUSES
+    // here — it must never fall through and spawn against the SYSTEM `~/.codex` (silently acting as
+    // the wrong login is a worse failure for an explicit switch than for a first spawn). This is
+    // deliberately STRICTER than the Claude account path below, which falls back with a warning
+    // chip. `resolveCodexSessionScope` returns `{ unavailable: 'codex-account' }` for exactly that
+    // case; we map it straight through to a real refusal and spawn NOTHING. The system account (no
+    // id) always resolves. Remote (ssh) Codex sessions carry their account env via tmux `-e`.
+    if (needsCodexAccountScope(options.agentId, options.accountId) && !options.sshRemote) {
+      const scope = resolveCodexSessionScope(platform().userDataDir, options.accountId)
+      if (isCodexScopeRefusal(scope)) {
+        return { sessionId: '', fresh: false, unavailable: 'codex-account' }
+      }
+    }
     // A tmux-backed session is "fresh" (cold start) when no live session exists to reattach to
     // — i.e. first open, or after a machine reboot killed the tmux server. Plain (non-tmux)
     // sessions are always fresh: they have no cross-restart continuity. The renderer uses this
@@ -2097,6 +2118,21 @@ export class PtyManager {
     if (accountDir) {
       env.CLAUDE_CONFIG_DIR = accountDir
       for (const k of AUTH_ENV_STRIP) delete env[k]
+    }
+
+    // Managed/system Codex account scope (S6 §2.1). A LOCAL Codex session runs under an EXPLICIT
+    // CODEX_HOME + NODETERM_CODEX_ACCOUNT_ID: a managed id points at that account's private home
+    // (its own auth.json + thread DB); the SYSTEM account (no id) is written EXPLICITLY so it
+    // overwrites any managed scope a parent tmux server leaked in, rather than silently acting as
+    // the wrong login. The missing-explicit-account case already refused in spawnNew (fail-closed,
+    // property 4), so `codexSessionEnv` here never resolves an explicit id to the system home. Also
+    // strip env vars that would shadow the account's OAuth login with API-key auth. Remote (ssh)
+    // Codex sessions get this via the remote tmux `-e` list, not the local ssh client env.
+    if (needsCodexAccountScope(options.agentId, options.accountId) && !options.sshRemote) {
+      const codexScope = codexSessionEnv(platform().userDataDir, options.accountId)
+      env.CODEX_HOME = codexScope.CODEX_HOME
+      env.NODETERM_CODEX_ACCOUNT_ID = codexScope.NODETERM_CODEX_ACCOUNT_ID
+      for (const k of CODEX_AUTH_ENV_STRIP) delete env[k]
     }
 
     // Shared model gateway: resolve through the node's BASE harness in one shared mapping, then

--- a/src/main/codex-accounts.switch.test.ts
+++ b/src/main/codex-accounts.switch.test.ts
@@ -123,6 +123,29 @@ describe('Codex same-machine switch — three-phase, owner-authorized (Propertie
     expect(readThread).toHaveBeenCalled()
   })
 
+  it('refuses to finish a switch that was never committed (committed-gate, Property 5)', async () => {
+    // A reservation is planned but NOT committed (the atomic hardlink never ran). Finishing it would
+    // release the reservation as if the copy had succeeded — the renderer then recycles the node
+    // onto a target that has no rollout. finishSwitch must refuse until commit ran.
+    const owner = makeSender(1)
+    const res = (await call(IPC.codexAccountsSwitchThread, owner, THREAD, '/work', SOURCE, TARGET)) as {
+      rollbackToken?: string
+    }
+    // MUTATION: drop `!pending?.committed` in finishSwitch ⇒ this stops throwing ⇒ red.
+    expect(() => call(IPC.codexAccountsFinishSwitch, owner, res.rollbackToken)).toThrow(
+      /was not committed/
+    )
+    // The target still has NO rollout — nothing was published by a premature finish.
+    const targetPath = path.join(
+      codexAccountHome(userDataDir, TARGET),
+      'sessions',
+      '2026',
+      '08',
+      `rollout-${THREAD}.jsonl`
+    )
+    expect(() => statSync(targetPath)).toThrow()
+  })
+
   it('a non-owner WebContents cannot commit or finish the switch', async () => {
     const owner = makeSender(1)
     const attacker = makeSender(2)

--- a/src/main/codex-accounts.switch.test.ts
+++ b/src/main/codex-accounts.switch.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The three-phase, owner-authorized, TTL-bounded same-machine Codex account switch (S6 §4.1 /
+ * Properties 5 & 10). Driven against the REAL rollout primitives on a REAL temp filesystem
+ * (planCodexRolloutExposure / commitCodexRolloutExposure — constraint 8: no re-implementation); only
+ * the electron shell boundary, the app-server readers, and the relay-root effect are faked.
+ *
+ * MUTATIONS (recorded in the PR body):
+ *  - drop `pending.owner.id === event.sender.id` in commit ⇒ a non-owner WebContents commits ⇒ red.
+ *  - drop the `pendingSwitchExposures` guard in remove ⇒ removal succeeds while a switch holds the
+ *    account ⇒ red.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'fs'
+import os from 'os'
+import path from 'path'
+
+const h: { handlers: Record<string, (...a: any[]) => unknown> } = { handlers: {} }
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (ch: string, fn: (...a: any[]) => unknown) => {
+      h.handlers[ch] = fn
+    }
+  }
+}))
+
+// The app-server client + relay root are runtime effects (probe U4/U6, unrunnable headless). Fake
+// them; the rollout copy under test is the real fs primitive.
+const readThread = vi.fn()
+const readAccount = vi.fn(async () => ({ email: 'me@example.com' }))
+vi.mock('../core/codex-session-name', () => ({
+  readCodexThreadAt: (..._a: any[]) => readThread(),
+  readCodexAccountAt: (..._a: any[]) => readAccount()
+}))
+vi.mock('../core/pty-manager', () => ({ findInLoginPath: vi.fn(async () => null) }))
+vi.mock('./codex-relay-daemon', () => ({ ensureCodexRelayRoot: vi.fn() }))
+
+import { IPC } from '../shared/ipc'
+import { fakePlatform } from '../core/platform-fake'
+import { codexAccountHome } from '../core/codex-accounts-core'
+
+const SOURCE = 'acctsource1'
+const TARGET = 'accttarget1'
+const THREAD = 'thread-abc123'
+
+let userDataDir = ''
+let sourceRollout = ''
+
+/** A WebContents-shaped fake: `.id` + the listener surface the switch protocol drives. */
+const makeSender = (id: number) => {
+  const listeners: Array<() => void> = []
+  return {
+    id,
+    isDestroyed: () => false,
+    once: (_ev: string, cb: () => void) => listeners.push(cb),
+    removeListener: () => {},
+    fireDestroyed: () => listeners.forEach((cb) => cb())
+  }
+}
+const call = (channel: string, sender: any, ...args: any[]) =>
+  h.handlers[channel]({ sender }, ...args)
+
+beforeEach(async () => {
+  h.handlers = {}
+  readThread.mockReset()
+  readAccount.mockReset().mockResolvedValue({ email: 'me@example.com' })
+  userDataDir = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-switch-'))
+  // Real homes at the exact paths the module computes, with a real rollout under source/sessions.
+  const sourceHome = codexAccountHome(userDataDir, SOURCE)
+  const targetHome = codexAccountHome(userDataDir, TARGET)
+  const sessionsDir = path.join(sourceHome, 'sessions', '2026', '08')
+  mkdirSync(sessionsDir, { recursive: true })
+  mkdirSync(path.join(targetHome, 'sessions'), { recursive: true })
+  sourceRollout = path.join(sessionsDir, `rollout-${THREAD}.jsonl`)
+  writeFileSync(sourceRollout, '{"id":"' + THREAD + '"}\n')
+  readThread.mockResolvedValue({ id: THREAD, name: null, path: sourceRollout })
+  // Fresh module state per test (the reservation maps live at module scope). resetModules resets the
+  // platform module too, so init it on the freshly-imported instance codex-accounts will bind to.
+  vi.resetModules()
+  const { initPlatform } = await import('../core/platform')
+  initPlatform(fakePlatform({ userDataDir }))
+  const { initCodexAccounts } = await import('./codex-accounts')
+  initCodexAccounts()
+})
+afterEach(async () => {
+  const { resetPlatformForTests } = await import('../core/platform')
+  resetPlatformForTests()
+  rmSync(userDataDir, { recursive: true, force: true })
+  vi.clearAllTimers()
+})
+
+describe('Codex same-machine switch — three-phase, owner-authorized (Properties 5, 10)', () => {
+  it('reserves, commits an atomic hardlink into the target, and preserves the conversation id', async () => {
+    const owner = makeSender(1)
+    const res = (await call(
+      IPC.codexAccountsSwitchThread,
+      owner,
+      THREAD,
+      '/work',
+      SOURCE,
+      TARGET
+    )) as { threadId: string; rollbackToken?: string }
+    expect(res.threadId).toBe(THREAD)
+    expect(res.rollbackToken).toBeTruthy()
+
+    await call(IPC.codexAccountsCommitSwitch, owner, res.rollbackToken)
+
+    // The target now holds the SAME inode (byte-identical conversation id survives the copy).
+    const targetPath = path.join(
+      codexAccountHome(userDataDir, TARGET),
+      'sessions',
+      '2026',
+      '08',
+      `rollout-${THREAD}.jsonl`
+    )
+    const src = statSync(sourceRollout)
+    const tgt = statSync(targetPath)
+    expect(tgt.ino).toBe(src.ino)
+    expect(tgt.dev).toBe(src.dev)
+
+    // Finishing releases the reservation, so the account is removable again.
+    await call(IPC.codexAccountsFinishSwitch, owner, res.rollbackToken)
+    expect(readThread).toHaveBeenCalled()
+  })
+
+  it('a non-owner WebContents cannot commit or finish the switch', async () => {
+    const owner = makeSender(1)
+    const attacker = makeSender(2)
+    const res = (await call(IPC.codexAccountsSwitchThread, owner, THREAD, '/work', SOURCE, TARGET)) as {
+      rollbackToken?: string
+    }
+    // commit/finish/rollback are synchronous handlers, so a refusal throws synchronously.
+    expect(() => call(IPC.codexAccountsCommitSwitch, attacker, res.rollbackToken)).toThrow(
+      /preparation expired/
+    )
+    // The owner can still commit — the attacker's attempt did not consume the reservation.
+    expect(call(IPC.codexAccountsCommitSwitch, owner, res.rollbackToken)).toBeUndefined()
+    // A non-owner cannot finish the (now committed) switch either.
+    expect(() => call(IPC.codexAccountsFinishSwitch, attacker, res.rollbackToken)).toThrow(
+      /was not committed/
+    )
+  })
+
+  it('removal refuses while a switch reservation holds either account (Property 10)', async () => {
+    const owner = makeSender(1)
+    await call(IPC.codexAccountsSwitchThread, owner, THREAD, '/work', SOURCE, TARGET)
+    await expect(call(IPC.codexAccountsRemove, owner, SOURCE)).rejects.toThrow(
+      /reserved by an account switch/
+    )
+    await expect(call(IPC.codexAccountsRemove, owner, TARGET)).rejects.toThrow(
+      /reserved by an account switch/
+    )
+  })
+
+  it('the TTL releases the reservation, unblocking removal and voiding a late commit', async () => {
+    vi.useFakeTimers()
+    try {
+      const owner = makeSender(1)
+      const res = (await call(IPC.codexAccountsSwitchThread, owner, THREAD, '/work', SOURCE, TARGET)) as {
+        rollbackToken?: string
+      }
+      vi.advanceTimersByTime(60_000)
+      // The reservation is gone: a late (synchronous) commit is refused.
+      expect(() => call(IPC.codexAccountsCommitSwitch, owner, res.rollbackToken)).toThrow(
+        /preparation expired/
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('owner destroyed auto-releases the reservation', async () => {
+    const owner = makeSender(1)
+    const res = (await call(IPC.codexAccountsSwitchThread, owner, THREAD, '/work', SOURCE, TARGET)) as {
+      rollbackToken?: string
+    }
+    owner.fireDestroyed()
+    expect(() => call(IPC.codexAccountsCommitSwitch, owner, res.rollbackToken)).toThrow(
+      /preparation expired/
+    )
+  })
+
+  it('a no-op switch to the same account short-circuits without reserving', async () => {
+    const owner = makeSender(1)
+    const res = (await call(IPC.codexAccountsSwitchThread, owner, THREAD, '/work', SOURCE, SOURCE)) as {
+      rollbackToken?: string
+    }
+    expect(res.rollbackToken).toBeUndefined()
+    // Nothing reserved ⇒ removal is not blocked.
+    await expect(call(IPC.codexAccountsRemove, owner, SOURCE)).resolves.toBeUndefined()
+  })
+})

--- a/src/main/codex-accounts.test.ts
+++ b/src/main/codex-accounts.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Task 5.1 — local managed Codex account lifecycle: add (private 0700 home + shared-asset symlinks),
+ * the device-login gate (a REAL non-symlink auth.json), and race/use-safe removal (Property 10).
+ * Real filesystem under mkdtemp; only the electron shell, the app-server readers, the CLI lookup,
+ * and the relay-root effect are faked.
+ *
+ * MUTATIONS (recorded in the PR body):
+ *  - switch the login gate's `fs.lstat` to `fs.stat` (follows the symlink) ⇒ a symlinked credential
+ *    pointed at the system jar counts as logged in ⇒ the symlink test reddens. (lstat is the
+ *    load-bearing guard: under lstat a symlink's `isFile()` is already false; the explicit
+ *    `!isSymbolicLink()` is belt-and-braces on top.)
+ *  - drop the `removingCodexAccounts` in-progress guard ⇒ a concurrent removal is admitted ⇒ red.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { lstatSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs'
+import os from 'os'
+import path from 'path'
+
+const h: { handlers: Record<string, (...a: any[]) => unknown> } = { handlers: {} }
+vi.mock('electron', () => ({
+  ipcMain: { handle: (ch: string, fn: (...a: any[]) => unknown) => (h.handlers[ch] = fn) }
+}))
+const readAccount = vi.fn(async () => ({ email: 'me@example.com' }))
+vi.mock('../core/codex-session-name', () => ({
+  readCodexThreadAt: vi.fn(async () => null),
+  readCodexAccountAt: (..._a: any[]) => readAccount()
+}))
+vi.mock('../core/pty-manager', () => ({ findInLoginPath: vi.fn(async () => null) }))
+vi.mock('./codex-relay-daemon', () => ({ ensureCodexRelayRoot: vi.fn() }))
+
+import { IPC } from '../shared/ipc'
+import { fakePlatform } from '../core/platform-fake'
+import { codexAccountHome } from '../core/codex-accounts-core'
+
+let userDataDir = ''
+let systemHome = ''
+const sender = { id: 1, isDestroyed: () => false, once: () => {}, removeListener: () => {} }
+const call = (channel: string, ...args: any[]) => h.handlers[channel]({ sender }, ...args)
+
+beforeEach(async () => {
+  h.handlers = {}
+  readAccount.mockReset().mockResolvedValue({ email: 'me@example.com' })
+  userDataDir = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-acct-'))
+  systemHome = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-sys-'))
+  // A system home with a shared, non-secret asset + directory to be symlinked into managed homes.
+  writeFileSync(path.join(systemHome, 'config.toml'), 'model = "gpt"\n')
+  mkdirSync(path.join(systemHome, 'skills'))
+  process.env.CODEX_HOME = systemHome
+  vi.resetModules()
+  const { initPlatform } = await import('../core/platform')
+  initPlatform(fakePlatform({ userDataDir }))
+  const { initCodexAccounts } = await import('./codex-accounts')
+  initCodexAccounts()
+})
+afterEach(async () => {
+  const { resetPlatformForTests } = await import('../core/platform')
+  resetPlatformForTests()
+  delete process.env.CODEX_HOME
+  rmSync(userDataDir, { recursive: true, force: true })
+  rmSync(systemHome, { recursive: true, force: true })
+})
+
+describe('Codex local account lifecycle (Task 5.1)', () => {
+  it('add mints a 0700 home and symlinks the shared, non-secret runtime assets', async () => {
+    const { id, home } = (await call(IPC.codexAccountsAdd)) as { id: string; home: string }
+    expect(id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(home).toBe(codexAccountHome(userDataDir, id))
+    if (process.platform !== 'win32') expect(lstatSync(home).mode & 0o777).toBe(0o700)
+    // config.toml + skills are symlinks INTO the system home (installation shared, creds are not).
+    expect(lstatSync(path.join(home, 'config.toml')).isSymbolicLink()).toBe(true)
+    expect(lstatSync(path.join(home, 'skills')).isSymbolicLink()).toBe(true)
+    // auth.json is NEVER symlinked in — a managed account acts only as its own login.
+    expect(() => lstatSync(path.join(home, 'auth.json'))).toThrow()
+  })
+
+  it('the login gate returns the identity for a REAL non-symlink auth.json', async () => {
+    const { id, home } = (await call(IPC.codexAccountsAdd)) as { id: string; home: string }
+    writeFileSync(path.join(home, 'auth.json'), '{"tokens":{}}')
+    expect(await call(IPC.codexAccountsWaitLogin, id)).toEqual({ email: 'me@example.com' })
+  })
+
+  it('the login gate REFUSES a symlinked auth.json (Property 10 / §2.1)', async () => {
+    const { id, home } = (await call(IPC.codexAccountsAdd)) as { id: string; home: string }
+    // A credential that is a SYMLINK (e.g. pointed at the system jar) is not "logged in".
+    const realCred = path.join(systemHome, 'auth.json')
+    writeFileSync(realCred, '{"tokens":{}}')
+    symlinkSync(realCred, path.join(home, 'auth.json'))
+    const pending = call(IPC.codexAccountsWaitLogin, id) as Promise<unknown>
+    // The first gate check SKIPS the symlink; cancelling makes the loop return null after its single
+    // 2s poll sleep (real timers — deterministic, well under the test timeout) instead of the 5min
+    // deadline. A gate that (wrongly) accepted the symlink would return the identity here.
+    call(IPC.codexAccountsCancelWait, id)
+    expect(await pending).toBeNull()
+  }, 15_000)
+
+  it('refuses a concurrent removal of the same account (Property 10)', async () => {
+    const { id, home } = (await call(IPC.codexAccountsAdd)) as { id: string; home: string }
+    expect(home).toBeTruthy()
+    // Two removals launched back-to-back: the first synchronously claims the in-progress lock before
+    // its first await, so the second is refused.
+    const first = call(IPC.codexAccountsRemove, id) as Promise<void>
+    await expect(call(IPC.codexAccountsRemove, id)).rejects.toThrow(/already in progress/)
+    await expect(first).resolves.toBeUndefined()
+  })
+
+  it('rejects an unsafe account id before it becomes a path (supply-chain guard)', async () => {
+    await expect(call(IPC.codexAccountsWaitLogin, '../escape')).rejects.toThrow(/Invalid Codex account id/)
+    await expect(call(IPC.codexAccountsRemove, '../escape')).rejects.toThrow(/Invalid Codex account id/)
+  })
+})

--- a/src/main/codex-accounts.test.ts
+++ b/src/main/codex-accounts.test.ts
@@ -26,7 +26,8 @@ vi.mock('../core/codex-session-name', () => ({
   readCodexAccountAt: (..._a: any[]) => readAccount()
 }))
 vi.mock('../core/pty-manager', () => ({ findInLoginPath: vi.fn(async () => null) }))
-vi.mock('./codex-relay-daemon', () => ({ ensureCodexRelayRoot: vi.fn() }))
+const ensureRelayRoot = vi.fn()
+vi.mock('./codex-relay-daemon', () => ({ ensureCodexRelayRoot: ensureRelayRoot }))
 
 import { IPC } from '../shared/ipc'
 import { fakePlatform } from '../core/platform-fake'
@@ -39,6 +40,7 @@ const call = (channel: string, ...args: any[]) => h.handlers[channel]({ sender }
 
 beforeEach(async () => {
   h.handlers = {}
+  ensureRelayRoot.mockClear()
   readAccount.mockReset().mockResolvedValue({ email: 'me@example.com' })
   userDataDir = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-acct-'))
   systemHome = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-sys-'))
@@ -61,6 +63,12 @@ afterEach(async () => {
 })
 
 describe('Codex local account lifecycle (Task 5.1)', () => {
+  it('ensures the ~/.nodeterm relay root at boot (carried PR-4 obligation)', () => {
+    // initCodexAccounts ran in beforeEach; the boot-time call to ensureCodexRelayRoot is asserted
+    // here (not just the function itself) so removing the call site would red this.
+    expect(ensureRelayRoot).toHaveBeenCalled()
+  })
+
   it('add mints a 0700 home and symlinks the shared, non-secret runtime assets', async () => {
     const { id, home } = (await call(IPC.codexAccountsAdd)) as { id: string; home: string }
     expect(id).toMatch(/^[0-9a-f-]{36}$/)

--- a/src/main/codex-accounts.transfer.test.ts
+++ b/src/main/codex-accounts.transfer.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Task 5.3 — the SOURCE side of moving an idle local conversation to an SSH account. The remote
+ * landing is PR 6; this leg validates STRICT source containment (a regular file under
+ * `<sourceHome>/sessions/`, basename `<threadId>.jsonl`, no symlinked segment — reusing PR 3's
+ * `planCodexRolloutExposure` guards) and only THEN hands the upload to the remote importer, with the
+ * local rollout left untouched.
+ *
+ * MUTATION (recorded in the PR body): let the handler skip `planCodexRolloutExposure` and call the
+ * importer with the raw source path ⇒ the escaping-source test admits the upload ⇒ red. The pin
+ * below asserts the importer is NEVER called when the source escapes `sessions/`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import os from 'os'
+import path from 'path'
+
+const h: { handlers: Record<string, (...a: any[]) => unknown> } = { handlers: {} }
+vi.mock('electron', () => ({
+  ipcMain: { handle: (ch: string, fn: (...a: any[]) => unknown) => (h.handlers[ch] = fn) }
+}))
+const readThread = vi.fn()
+vi.mock('../core/codex-session-name', () => ({
+  readCodexThreadAt: (..._a: any[]) => readThread(),
+  readCodexAccountAt: vi.fn(async () => ({ email: 'me@example.com' }))
+}))
+vi.mock('../core/pty-manager', () => ({ findInLoginPath: vi.fn(async () => null) }))
+vi.mock('./codex-relay-daemon', () => ({ ensureCodexRelayRoot: vi.fn() }))
+
+import { IPC } from '../shared/ipc'
+import { fakePlatform } from '../core/platform-fake'
+import { codexAccountHome } from '../core/codex-accounts-core'
+
+const SOURCE = 'acctsource1'
+const TARGET = 'accttarget1'
+const THREAD = 'thread-abc123'
+const PROJECT = 'proj-1'
+
+let userDataDir = ''
+let sourceHome = ''
+const remoteCodexImportThread = vi.fn(async () => ({ imported: true }))
+const sender = { id: 1, isDestroyed: () => false, once: () => {}, removeListener: () => {} }
+const call = (channel: string, ...args: any[]) => h.handlers[channel]({ sender }, ...args)
+
+beforeEach(async () => {
+  h.handlers = {}
+  readThread.mockReset()
+  remoteCodexImportThread.mockClear()
+  userDataDir = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-xfer-'))
+  sourceHome = codexAccountHome(userDataDir, SOURCE)
+  mkdirSync(path.join(sourceHome, 'sessions', '2026'), { recursive: true })
+  mkdirSync(codexAccountHome(userDataDir, TARGET), { recursive: true })
+  vi.resetModules()
+  const { initPlatform } = await import('../core/platform')
+  initPlatform(fakePlatform({ userDataDir }))
+  const { initCodexAccounts } = await import('./codex-accounts')
+  // A live SSH manager carrying PR 6's importer.
+  initCodexAccounts(() => ({ remoteCodexImportThread }) as any)
+})
+afterEach(async () => {
+  const { resetPlatformForTests } = await import('../core/platform')
+  resetPlatformForTests()
+  rmSync(userDataDir, { recursive: true, force: true })
+})
+
+describe('Codex local→SSH transfer source leg (Task 5.3)', () => {
+  it('hands a contained source rollout to the remote importer with the sessions-relative path', async () => {
+    const rollout = path.join(sourceHome, 'sessions', '2026', `rollout-${THREAD}.jsonl`)
+    writeFileSync(rollout, '{}\n')
+    readThread.mockResolvedValue({ id: THREAD, name: null, path: rollout })
+
+    const res = (await call(
+      IPC.codexAccountsTransferThreadToSsh,
+      THREAD,
+      '/work',
+      PROJECT,
+      TARGET,
+      SOURCE
+    )) as { threadId: string; imported: boolean }
+
+    expect(res).toEqual({ threadId: THREAD, imported: true })
+    expect(remoteCodexImportThread).toHaveBeenCalledTimes(1)
+    const [projectId, targetAccountId, threadId, sessionsRelativePath, localPath] =
+      remoteCodexImportThread.mock.calls[0] as unknown[]
+    expect(projectId).toBe(PROJECT)
+    expect(targetAccountId).toBe(TARGET)
+    expect(threadId).toBe(THREAD)
+    expect(sessionsRelativePath).toBe(`sessions/2026/rollout-${THREAD}.jsonl`)
+    // The LOCAL rollout is handed by path, never moved.
+    expect(localPath).toBe(rollout)
+  })
+
+  it('refuses a source path escaping sessions/ BEFORE any upload', async () => {
+    // A rollout the app-server reports OUTSIDE the source account's sessions/ (e.g. a crafted
+    // absolute path). Containment must refuse it before the importer is ever reached.
+    const escaping = path.join(userDataDir, `rollout-${THREAD}.jsonl`)
+    writeFileSync(escaping, '{}\n')
+    readThread.mockResolvedValue({ id: THREAD, name: null, path: escaping })
+
+    await expect(
+      call(IPC.codexAccountsTransferThreadToSsh, THREAD, '/work', PROJECT, TARGET, SOURCE)
+    ).rejects.toThrow()
+    expect(remoteCodexImportThread).not.toHaveBeenCalled()
+  })
+
+  it('refuses a basename whose thread id does not match, before any upload', async () => {
+    const wrong = path.join(sourceHome, 'sessions', '2026', 'rollout-someone-else.jsonl')
+    writeFileSync(wrong, '{}\n')
+    readThread.mockResolvedValue({ id: THREAD, name: null, path: wrong })
+    await expect(
+      call(IPC.codexAccountsTransferThreadToSsh, THREAD, '/work', PROJECT, TARGET, SOURCE)
+    ).rejects.toThrow()
+    expect(remoteCodexImportThread).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unsafe thread id at the door', async () => {
+    await expect(
+      call(IPC.codexAccountsTransferThreadToSsh, '../escape', '/work', PROJECT, TARGET, SOURCE)
+    ).rejects.toThrow(/Invalid Codex transfer request/)
+    expect(remoteCodexImportThread).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/codex-accounts.ts
+++ b/src/main/codex-accounts.ts
@@ -167,6 +167,25 @@ async function existingManagedIdentity(id: string): Promise<{ email: string | nu
 }
 
 /**
+ * THREE SURFACES (global-constraint 5), stated explicitly:
+ *
+ *  - **Desktop (Electron)** — the full feature. This module registers its IPC over `electron`'s
+ *    `ipcMain`, and owner-authorization keys off `event.sender.id` (a WebContents). `src/main/
+ *    index.ts` is the ONLY caller.
+ *  - **Server Edition (headless / an SSH host)** — this IPC surface is deliberately **N/A** here,
+ *    and PR 5 does NOT wire it. The verbs are `ipcMain.handle` + WebContents-owner semantics, which
+ *    the headless CorePlatform bridge does not provide, so `startServer` never calls
+ *    `initCodexAccounts`. This is not a silent gap: managed Codex logins **on an SSH host** are
+ *    driven by the DESKTOP over SSH / `RemoteHooks` (the remote account-add / device-login / import
+ *    legs), which is **PR 6's** work — the host runs the relay + import, not its own copy of this
+ *    IPC. The Server Edition still arms the codex identity *record secret* (src/server/
+ *    node-identity-arm.ts) so records sign; it just does not host the account-management verbs.
+ *    **PR 6 obligation:** if the remote leg needs SE-side handlers, PR 6 wires them through the
+ *    server bridge — PR 5 intentionally left that unbuilt. Nothing in PR 5 assumes an SE IPC
+ *    surface exists.
+ *  - **Mobile (phone)** — never originates an add/switch/copy; it drives via relay→IPC and reads
+ *    state. No mint here.
+ *
  * @param getSshManager Lazily resolves the SSH project manager (created after this init in
  * index.ts). Only the local→SSH transfer SOURCE leg uses it today; local account ops never do.
  */

--- a/src/main/codex-accounts.ts
+++ b/src/main/codex-accounts.ts
@@ -1,0 +1,390 @@
+// Impure lifecycle for machine-scoped managed Codex accounts (S6 PR 5) — the leg that makes
+// account-scoping REACHABLE for LOCAL accounts. Mirrors `claude-accounts.ts` (add / device-login /
+// cancel / remove) and adds the three-phase, owner-authorized SAME-MACHINE switch (resume the same
+// conversation id, never fork) plus the SOURCE side of moving an idle conversation to an SSH
+// account. The account LIST is renderer-owned in `settings.json` (`codexAccounts`); this module owns
+// only the filesystem, the per-account app-server daemon, and the switch reservation state.
+//
+// The copy primitives are NOT re-implemented here: `planCodexRolloutExposure` /
+// `commitCodexRolloutExposure` (src/core/codex-accounts-core.ts, PR 3) are the atomic, never-
+// overwrite hardlink. Based on @Corvin's `codex-accounts.ts` in PR #112, re-sliced onto the PR 3/4
+// primitives with the SSH transfer source leg (its remote landing is PR 6).
+import { randomUUID } from 'crypto'
+import { execFile } from 'child_process'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { promisify } from 'util'
+import { ipcMain, type WebContents } from 'electron'
+import { IPC } from '../shared/ipc'
+import {
+  assertCodexAccountId,
+  commitCodexRolloutExposure,
+  codexAccountHome,
+  codexHomeForAccount,
+  codexSessionEnv,
+  codexSocketForAccount,
+  ensureSharedCodexDaemon,
+  legacyCodexAccountHome,
+  migrateLegacyCodexAccountHome,
+  migrateLegacyCodexAccountHomes,
+  planCodexRolloutExposure,
+  type CodexRolloutExposurePlan
+} from '../core/codex-accounts-core'
+import { readCodexAccountAt, readCodexThreadAt } from '../core/codex-session-name'
+import { ensureCodexRelayRoot } from './codex-relay-daemon'
+import { platform } from '../core/platform'
+import { findInLoginPath } from '../core/pty-manager'
+import type { SshProjectManager } from './remote-ssh/ssh-project'
+
+const execFileP = promisify(execFile)
+const LOGIN_POLL_MS = 2000
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000
+/** Non-secret runtime assets symlinked from the system home into each managed home: shared
+ *  installation, never a credential or the thread SQLite DB. */
+const SHARED_ENTRIES = ['config.toml', 'AGENTS.md', 'skills', 'plugins', 'packages', 'rules', 'hooks.json']
+const SWITCH_RESERVATION_TTL_MS = 60_000
+/** A threadId that could reach the filesystem as a path component. Same shape as ACCOUNT_ID_RE. */
+const SAFE_THREAD_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/** PR 6 provides this on the SSH manager. Typed structurally here so PR 5 can hand the source leg
+ *  off without depending on PR 6's implementation. */
+type CodexSshImporter = {
+  remoteCodexImportThread?(
+    projectId: string,
+    accountId: string | undefined,
+    threadId: string,
+    sessionsRelativePath: string,
+    localRolloutPath: string
+  ): Promise<{ imported: boolean }>
+}
+
+const waiters = new Map<string, { cancelled: boolean }>()
+
+/**
+ * One in-flight switch reservation. Holds the planned (but maybe not yet committed) exposure, the
+ * two account ids it pins (so removal refuses while it holds them — Property 10), the owning
+ * WebContents (every phase must be driven by the SAME renderer — Property owner-authorized), and
+ * the auto-release wiring (owner `destroyed` or the TTL).
+ */
+type PendingSwitchExposure = {
+  exposure?: CodexRolloutExposurePlan
+  sourceAccountId?: string
+  targetAccountId?: string
+  committed: boolean
+  owner: WebContents
+  ownerDestroyed: () => void
+  timer: ReturnType<typeof setTimeout>
+}
+const pendingSwitchExposures = new Map<string, PendingSwitchExposure>()
+const removingCodexAccounts = new Set<string>()
+
+function releasePendingSwitch(token: string): void {
+  const pending = pendingSwitchExposures.get(token)
+  if (!pending) return
+  pendingSwitchExposures.delete(token)
+  clearTimeout(pending.timer)
+  if (!pending.owner.isDestroyed()) pending.owner.removeListener('destroyed', pending.ownerDestroyed)
+}
+
+export function localCodexAccountHome(accountId: string): string {
+  return codexAccountHome(platform().userDataDir, accountId)
+}
+
+export function localCodexSocket(accountId?: string): string {
+  return codexSocketForAccount(platform().userDataDir, accountId)
+}
+
+/**
+ * Reuse the account's shared app-server if it is already answering on its control socket, else boot
+ * one exactly once (§2.2). The managed home is migrated to its short form first so the app-server
+ * Unix socket stays under `SUN_LEN`. UNVERIFIED against a real Codex CLI headless (probe U4/U6) —
+ * device-verification owed; the control flow (probe → start-once) is pure and tested via injection.
+ */
+export async function ensureCodexAccountDaemon(accountId?: string): Promise<void> {
+  if (accountId) migrateLegacyCodexAccountHome(platform().userDataDir, accountId)
+  const socket = localCodexSocket(accountId)
+  await ensureSharedCodexDaemon(
+    async () => (await readCodexAccountAt(socket, 1000)) !== null,
+    async () => {
+      const codex = await findInLoginPath('codex')
+      if (!codex) throw new Error('Codex CLI unavailable')
+      await execFileP(codex, ['app-server', 'daemon', 'start'], {
+        cwd: os.homedir(),
+        env: { ...process.env, ...codexSessionEnv(platform().userDataDir, accountId) },
+        timeout: 15_000,
+        maxBuffer: 1024 * 1024
+      })
+    }
+  )
+}
+
+/**
+ * Create a managed account's private home (0700) and symlink the shared, NON-secret runtime assets
+ * from the system home in. Credentials (`auth.json`) and the thread DB are never shared — only
+ * installation assets. A missing source asset is skipped; an existing target link is left as-is.
+ */
+async function initializeAccountHome(id: string): Promise<string> {
+  migrateLegacyCodexAccountHome(platform().userDataDir, id)
+  const home = localCodexAccountHome(id)
+  await fs.mkdir(home, { recursive: true, mode: 0o700 })
+  await fs.chmod(home, 0o700)
+  const sourceHome = process.env.CODEX_HOME?.trim() || path.join(os.homedir(), '.codex')
+  for (const name of SHARED_ENTRIES) {
+    const source = path.join(sourceHome, name)
+    const target = path.join(home, name)
+    try {
+      await fs.lstat(source)
+      await fs.symlink(source, target)
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code !== 'ENOENT' && code !== 'EEXIST') throw error
+    }
+  }
+  return home
+}
+
+async function accountIdentity(accountId?: string): Promise<{ email: string | null } | null> {
+  await ensureCodexAccountDaemon(accountId)
+  return readCodexAccountAt(localCodexSocket(accountId), 5000)
+}
+
+/**
+ * Read an already-logged-in managed account's identity. The login GATE is a REAL non-symlink
+ * `auth.json`: a symlinked or absent credential is "not logged in" and returns null (Property 10 /
+ * §2.1 — a managed account acts only as its OWN login, never a symlink into the system jar).
+ */
+async function existingManagedIdentity(id: string): Promise<{ email: string | null } | null> {
+  assertCodexAccountId(id)
+  try {
+    migrateLegacyCodexAccountHome(platform().userDataDir, id)
+    const auth = await fs.lstat(path.join(localCodexAccountHome(id), 'auth.json'))
+    if (!auth.isFile() || auth.isSymbolicLink()) return null
+    return await accountIdentity(id)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * @param getSshManager Lazily resolves the SSH project manager (created after this init in
+ * index.ts). Only the local→SSH transfer SOURCE leg uses it today; local account ops never do.
+ */
+export function initCodexAccounts(getSshManager?: () => SshProjectManager | undefined): void {
+  // Ensure `~/.nodeterm` exists before any relay/daemon reach (carried PR-4 obligation: only the
+  // relay's detached serve() created it before, so a first reach from this process could race a
+  // missing root).
+  ensureCodexRelayRoot()
+  // Synchronous, BEFORE renderer hydration / PTY restore: a legacy long CODEX_HOME cannot host the
+  // app-server Unix socket, and an already-persisted managed node must see its migrated home on its
+  // very first spawn.
+  migrateLegacyCodexAccountHomes(platform().userDataDir)
+
+  ipcMain.handle(IPC.codexAccountsAdd, async () => {
+    const id = randomUUID()
+    return { id, home: await initializeAccountHome(id) }
+  })
+
+  ipcMain.handle(IPC.codexAccountsWaitLogin, async (_event, id: string) => {
+    assertCodexAccountId(id)
+    const home = localCodexAccountHome(id)
+    const waiter = { cancelled: false }
+    waiters.set(id, waiter)
+    const deadline = Date.now() + LOGIN_TIMEOUT_MS
+    try {
+      while (!waiter.cancelled && Date.now() < deadline) {
+        try {
+          // The login gate: a REAL file, never a symlink. A device login writes auth.json into the
+          // managed home; a symlink here would mean the account is riding the system credential.
+          const auth = await fs.lstat(path.join(home, 'auth.json'))
+          if (auth.isFile() && !auth.isSymbolicLink()) {
+            const identity = await accountIdentity(id)
+            if (identity) return identity
+          }
+        } catch {
+          // No credential file yet, or its daemon is not ready — keep polling.
+        }
+        await new Promise((resolve) => setTimeout(resolve, LOGIN_POLL_MS))
+      }
+      return null
+    } finally {
+      waiters.delete(id)
+    }
+  })
+
+  ipcMain.handle(IPC.codexAccountsCancelWait, (_event, id: string) => {
+    const waiter = waiters.get(id)
+    if (waiter) waiter.cancelled = true
+  })
+
+  ipcMain.handle(IPC.codexAccountsIdentity, (_event, id: string) => existingManagedIdentity(id))
+
+  ipcMain.handle(IPC.codexAccountsSystemIdentity, () => accountIdentity())
+
+  ipcMain.handle(IPC.codexAccountsRemove, async (_event, id: string) => {
+    assertCodexAccountId(id)
+    // Property 10 — race/use-safe removal. Refuse while a switch reservation holds this account, or
+    // while a concurrent removal is already in flight.
+    if (
+      [...pendingSwitchExposures.values()].some(
+        (pending) => pending.sourceAccountId === id || pending.targetAccountId === id
+      )
+    ) {
+      throw new Error('Codex account is reserved by an account switch')
+    }
+    if (removingCodexAccounts.has(id)) throw new Error('Codex account removal is already in progress')
+    removingCodexAccounts.add(id)
+    try {
+      const waiter = waiters.get(id)
+      if (waiter) waiter.cancelled = true
+      try {
+        const codex = await findInLoginPath('codex')
+        if (codex) {
+          await execFileP(codex, ['app-server', 'daemon', 'stop'], {
+            cwd: os.homedir(),
+            env: { ...process.env, CODEX_HOME: localCodexAccountHome(id) },
+            timeout: 10_000,
+            maxBuffer: 1024 * 1024
+          })
+        }
+      } catch {
+        // A stopped/missing daemon is already the desired state.
+      }
+      const home = localCodexAccountHome(id)
+      const legacy = legacyCodexAccountHome(platform().userDataDir, id)
+      await fs.rm(home, { recursive: true, force: true })
+      if (legacy !== home) await fs.rm(legacy, { recursive: true, force: true })
+    } finally {
+      removingCodexAccounts.delete(id)
+    }
+  })
+
+  // ---- The three-phase, owner-authorized, TTL-bounded switch (§4.1 / Properties 5, 10) ----------
+
+  ipcMain.handle(
+    IPC.codexAccountsSwitchThread,
+    async (
+      event,
+      threadId: string,
+      cwd: string,
+      sourceAccountId?: string,
+      targetAccountId?: string
+    ) => {
+      if (!SAFE_THREAD_ID.test(threadId) || !path.isAbsolute(cwd)) {
+        throw new Error('Invalid Codex account switch request')
+      }
+      if (sourceAccountId) assertCodexAccountId(sourceAccountId)
+      if (targetAccountId) assertCodexAccountId(targetAccountId)
+      if (sourceAccountId === targetAccountId) return { threadId }
+      if (
+        (sourceAccountId && removingCodexAccounts.has(sourceAccountId)) ||
+        (targetAccountId && removingCodexAccounts.has(targetAccountId))
+      ) {
+        throw new Error('Codex account removal is in progress')
+      }
+      const rollbackToken = randomUUID()
+      const ownerDestroyed = (): void => releasePendingSwitch(rollbackToken)
+      const timer = setTimeout(() => releasePendingSwitch(rollbackToken), SWITCH_RESERVATION_TTL_MS)
+      timer.unref?.()
+      event.sender.once('destroyed', ownerDestroyed)
+      // Reserve BEFORE planning so a concurrent removal of either account is already blocked while
+      // we read the app-server and plan the exposure.
+      pendingSwitchExposures.set(rollbackToken, {
+        sourceAccountId,
+        targetAccountId,
+        committed: false,
+        owner: event.sender,
+        ownerDestroyed,
+        timer
+      })
+      try {
+        await ensureCodexAccountDaemon(sourceAccountId)
+        await ensureCodexAccountDaemon(targetAccountId)
+        const source = await readCodexThreadAt(localCodexSocket(sourceAccountId), threadId, 5000)
+        if (!source?.path) throw new Error('Source Codex conversation is unavailable')
+        const exposure = planCodexRolloutExposure(
+          codexHomeForAccount(platform().userDataDir, sourceAccountId),
+          codexHomeForAccount(platform().userDataDir, targetAccountId),
+          source.path,
+          threadId
+        )
+        const pending = pendingSwitchExposures.get(rollbackToken)
+        if (!pending) throw new Error('Codex account switch preparation expired')
+        pending.exposure = exposure
+        return { threadId, rollbackToken }
+      } catch (error) {
+        releasePendingSwitch(rollbackToken)
+        throw error
+      }
+    }
+  )
+
+  ipcMain.handle(IPC.codexAccountsCommitSwitch, (event, token: string) => {
+    const pending = pendingSwitchExposures.get(token)
+    // Owner-authorized: only the WebContents that reserved the switch may commit it.
+    if (!pending?.exposure || pending.owner.id !== event.sender.id) {
+      throw new Error('Codex account switch preparation expired')
+    }
+    commitCodexRolloutExposure(pending.exposure)
+    pending.committed = true
+  })
+
+  ipcMain.handle(IPC.codexAccountsFinishSwitch, (event, token: string) => {
+    const pending = pendingSwitchExposures.get(token)
+    if (!pending?.committed || pending.owner.id !== event.sender.id) {
+      throw new Error('Codex account switch was not committed')
+    }
+    releasePendingSwitch(token)
+  })
+
+  ipcMain.handle(IPC.codexAccountsRollbackSwitch, (event, token: string) => {
+    const pending = pendingSwitchExposures.get(token)
+    if (pending?.owner.id === event.sender.id) releasePendingSwitch(token)
+  })
+
+  // ---- Local → SSH transfer SOURCE leg (§4.2b, Task 5.3). The remote landing is PR 6 ------------
+
+  ipcMain.handle(
+    IPC.codexAccountsTransferThreadToSsh,
+    async (
+      _event,
+      threadId: string,
+      cwd: string,
+      projectId: string,
+      targetAccountId?: string,
+      sourceAccountId?: string
+    ) => {
+      if (!SAFE_THREAD_ID.test(threadId) || !path.isAbsolute(cwd) || !projectId) {
+        throw new Error('Invalid Codex transfer request')
+      }
+      if (sourceAccountId) assertCodexAccountId(sourceAccountId)
+      if (targetAccountId) assertCodexAccountId(targetAccountId)
+      await ensureCodexAccountDaemon(sourceAccountId)
+      const source = await readCodexThreadAt(localCodexSocket(sourceAccountId), threadId, 5000)
+      if (!source?.path) throw new Error('Source Codex conversation is unavailable')
+      // STRICT SOURCE CONTAINMENT before any upload: reuse PR 3's `planCodexRolloutExposure`
+      // (source-side half) rather than re-implementing the guards. It refuses a source that is not a
+      // regular file, whose basename does not end `<threadId>.jsonl`, or that escapes
+      // `<sourceHome>/sessions/` (realpath + containment + no symlinked segment). Passing the source
+      // home as the target home is safe: only the SOURCE fields are read here, the local rollout is
+      // never linked/moved (it stays fully usable — §4.2 step 6).
+      const sourceHome = codexHomeForAccount(platform().userDataDir, sourceAccountId)
+      const plan = planCodexRolloutExposure(sourceHome, sourceHome, source.path, threadId)
+      const sessionsRelativePath = path.posix.join('sessions', plan.targetRelativePath.split(path.sep).join('/'))
+      // Hand the actual upload + atomic remote install to PR 6's importer. Absent (not yet wired /
+      // no live SSH manager) fails closed with a named error rather than silently succeeding.
+      const importer = getSshManager?.() as (SshProjectManager & CodexSshImporter) | undefined
+      if (!importer?.remoteCodexImportThread) {
+        throw new Error('Remote Codex import is unavailable')
+      }
+      const result = await importer.remoteCodexImportThread(
+        projectId,
+        targetAccountId,
+        threadId,
+        sessionsRelativePath,
+        plan.sourcePath
+      )
+      return { threadId, imported: result.imported }
+    }
+  )
+}

--- a/src/main/codex-relay-daemon.test.ts
+++ b/src/main/codex-relay-daemon.test.ts
@@ -17,12 +17,14 @@ import path from 'path'
 import { WebSocketServer } from 'ws'
 import {
   acquireProcessLock,
+  ensureCodexRelayRoot,
   exposeForeignThread,
   listThreadsAt,
   mergeRelayThreadLists,
   readThreadAt,
   relayControlPost,
   relayThreadReservationKey,
+  relayThreadResponseError,
   resolveForeignThreadAt,
   retargetRelayResumeByPath,
   resolveRelayThreadResponse,
@@ -142,6 +144,39 @@ describe('Codex shared relay thread observation', () => {
       id: 4,
       result: { thread: { id: 'forked' } }
     })).toEqual({ ok: false, unexpectedThreadId: 'forked' })
+  })
+
+  it('labels a changed id as -32004 but a malformed id as a distinct error (PR-4 minor)', () => {
+    // The silent-fork case the guard exists for keeps the -32004 "changed the conversation id"
+    // wording...
+    expect(relayThreadResponseError({ ok: false, unexpectedThreadId: 'forked' })).toEqual({
+      code: -32004,
+      message: 'Codex changed the conversation id during account switch'
+    })
+    // ...while a plain malformed/missing id (no unexpectedThreadId) must NOT claim the id changed.
+    // MUTATION: collapse both branches back to the -32004 message ⇒ this reddens.
+    const malformed = relayThreadResponseError({ ok: false })
+    expect(malformed?.code).toBe(-32603)
+    expect(malformed?.message).not.toMatch(/changed the conversation id/)
+    // A successful observation carries no error at all.
+    expect(relayThreadResponseError({ ok: true, threadId: 'x' })).toBeNull()
+  })
+
+  it('ensureCodexRelayRoot creates the relay root 0o700 and is idempotent (PR-4 obligation)', () => {
+    const base = mkdtempSync(path.join(tmpdir(), 'nt-relay-root-'))
+    const root = path.join(base, 'nested', '.nodeterm')
+    try {
+      expect(existsSync(root)).toBe(false)
+      ensureCodexRelayRoot(root)
+      const st = statSync(root)
+      expect(st.isDirectory()).toBe(true)
+      // The private-state root must be owner-only (it holds the 0600 control-token state file).
+      if (process.platform !== 'win32') expect(st.mode & 0o777).toBe(0o700)
+      // Idempotent: a second call over an existing root does not throw.
+      expect(() => ensureCodexRelayRoot(root)).not.toThrow()
+    } finally {
+      rmSync(base, { recursive: true, force: true })
+    }
   })
 
   it('keeps two account catalogs visible while preserving the selected account as duplicate owner', () => {

--- a/src/main/codex-relay-daemon.ts
+++ b/src/main/codex-relay-daemon.ts
@@ -161,6 +161,25 @@ export function resolveRelayThreadResponse(
   }
 }
 
+/**
+ * The JSON-RPC error a rewritten relay response carries when the observation failed, or `null` when
+ * it succeeded. Two DISTINCT failures reach `resolveRelayThreadResponse` as `{ ok: false }`, and
+ * before this they were both rewritten to the SAME "Codex changed the conversation id" message:
+ *  - `unexpectedThreadId` set — a `thread/resume` came back under a DIFFERENT id: the silent-fork
+ *    case the `-32004` guard exists for (§4.2 step 5 / Property 5).
+ *  - `unexpectedThreadId` UNSET — the response's thread id was missing or malformed: NOT an id
+ *    change. Telling the operator "the id changed" here is wrong, so it gets a distinct internal
+ *    error wording (carried PR-4 minor: tighten the -32004 wording).
+ */
+export function relayThreadResponseError(
+  observed: RelayThreadResponse
+): { code: number; message: string } | null {
+  if (observed.ok) return null
+  return observed.unexpectedThreadId !== undefined
+    ? { code: -32004, message: 'Codex changed the conversation id during account switch' }
+    : { code: -32603, message: 'Codex returned a malformed conversation id during account switch' }
+}
+
 type RelayThread = Record<string, any> & {
   id: string
   path?: string | null
@@ -468,7 +487,21 @@ export function relayControlPost(
   })
 }
 
+/**
+ * Create the `~/.nodeterm` relay root, mode `0o700`, idempotently. `serve()` already makes it, but
+ * that runs in the DETACHED daemon child — a caller reaching for the relay from the app process
+ * (the state file, the process lock, `ensureServer`) needs the directory to exist first. Only
+ * `serve()` created it before S6 PR 5, so `ensureServer` / any first relay use in the app process
+ * could race a missing root (carried PR-4 obligation). Exported so the main-side account wiring can
+ * ensure it at boot too. `target` is injectable so a test never touches the real home.
+ */
+export function ensureCodexRelayRoot(target: string = root): void {
+  mkdirSync(target, { recursive: true, mode: 0o700 })
+}
+
 async function ensureServer(): Promise<State> {
+  // The root must exist before we read the state file or take the process lock — both live under it.
+  ensureCodexRelayRoot()
   const current = readState()
   if (current) {
     try {
@@ -1405,14 +1438,10 @@ function serve(): void {
           }
           const observed = resolveRelayThreadResponse(pending, message)
           if (observed && !observed.ok) {
+            // Distinguish the silent-fork case (-32004) from a plain malformed-id response — see
+            // relayThreadResponseError. Both used to be labelled "changed the conversation id".
             outbound = Buffer.from(
-              JSON.stringify({
-                id: message.id,
-                error: {
-                  code: -32004,
-                  message: 'Codex changed the conversation id during account switch'
-                }
-              })
+              JSON.stringify({ id: message.id, error: relayThreadResponseError(observed) })
             )
           }
           const committed = observed?.ok

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -188,6 +188,7 @@ import { WhisperModelStore } from '../core/speech/whisper-models'
 import { SpeechService } from '../core/speech/speech-service'
 import { registerSpeechIpc } from '../core/speech/register-ipc'
 import { initClaudeAccounts } from './claude-accounts'
+import { initCodexAccounts } from './codex-accounts'
 import { claudeCliCaps, registerClaudeCliIpc, type ClaudeCliCaps } from '../core/claude-cli'
 import { refreshCodexIdentityCaps, registerCodexIdentityIpc } from '../core/codex-identity-caps'
 import {
@@ -2789,6 +2790,11 @@ app.whenReady().then(async () => {
   // Lazy getter: sshProjectManager is created just below, so a remote account op (which only runs
   // after the user has connected an SSH project) always sees the live manager.
   initClaudeAccounts(() => sshProjectManager)
+  // Machine-scoped managed Codex accounts (S6). Its synchronous boot migration of legacy long
+  // CODEX_HOMEs runs here, before the renderer restores its PTYs — an already-persisted managed
+  // Codex node must see its migrated (SUN_LEN-safe) home on its very first spawn. Same lazy SSH
+  // getter for the local→SSH transfer source leg.
+  initCodexAccounts(() => sshProjectManager)
   // The jailed core bridge both phone hosts serve: typed git verbs against the real GitService
   // (cwd-jailed to the shared canvas roots inside the handlers) and phone node registration
   // through the workspace store (written as an outside edit, so the watcher broadcasts it and

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -468,6 +468,34 @@ const api: NodeTerminalApi = {
     cancelWaitLogin: (id) => ipcRenderer.invoke(IPC.claudeAccountsCancelWait, id),
     remove: (id, ctx) => ipcRenderer.invoke(IPC.claudeAccountsRemove, id, ctx)
   },
+  codexAccounts: {
+    add: () => ipcRenderer.invoke(IPC.codexAccountsAdd),
+    waitLogin: (id) => ipcRenderer.invoke(IPC.codexAccountsWaitLogin, id),
+    cancelWaitLogin: (id) => ipcRenderer.invoke(IPC.codexAccountsCancelWait, id),
+    identity: (id) => ipcRenderer.invoke(IPC.codexAccountsIdentity, id),
+    systemIdentity: () => ipcRenderer.invoke(IPC.codexAccountsSystemIdentity),
+    remove: (id) => ipcRenderer.invoke(IPC.codexAccountsRemove, id),
+    switchThread: (threadId, cwd, sourceAccountId, targetAccountId) =>
+      ipcRenderer.invoke(
+        IPC.codexAccountsSwitchThread,
+        threadId,
+        cwd,
+        sourceAccountId,
+        targetAccountId
+      ),
+    commitSwitch: (token) => ipcRenderer.invoke(IPC.codexAccountsCommitSwitch, token),
+    finishSwitch: (token) => ipcRenderer.invoke(IPC.codexAccountsFinishSwitch, token),
+    rollbackSwitch: (token) => ipcRenderer.invoke(IPC.codexAccountsRollbackSwitch, token),
+    transferThreadToSsh: (threadId, cwd, projectId, targetAccountId, sourceAccountId) =>
+      ipcRenderer.invoke(
+        IPC.codexAccountsTransferThreadToSsh,
+        threadId,
+        cwd,
+        projectId,
+        targetAccountId,
+        sourceAccountId
+      )
+  },
   transcripts: {
     search: (query: string) => ipcRenderer.invoke(IPC.transcriptSearch, query)
   },

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -303,6 +303,19 @@ export function buildStubApi(): Omit<
       cancelWaitLogin: U('claudeAccounts.cancelWaitLogin'),
       remove: U('claudeAccounts.remove')
     },
+    codexAccounts: {
+      add: U('codexAccounts.add'),
+      waitLogin: U('codexAccounts.waitLogin'),
+      cancelWaitLogin: U('codexAccounts.cancelWaitLogin'),
+      identity: U('codexAccounts.identity'),
+      systemIdentity: U('codexAccounts.systemIdentity'),
+      remove: U('codexAccounts.remove'),
+      switchThread: U('codexAccounts.switchThread'),
+      commitSwitch: U('codexAccounts.commitSwitch'),
+      finishSwitch: U('codexAccounts.finishSwitch'),
+      rollbackSwitch: U('codexAccounts.rollbackSwitch'),
+      transferThreadToSsh: U('codexAccounts.transferThreadToSsh')
+    },
     transcripts: {
       search: U('transcripts.search')
     },

--- a/src/server/codex-identity-boot.test.ts
+++ b/src/server/codex-identity-boot.test.ts
@@ -5,11 +5,12 @@
  * ownership record threw "NodeTerm Codex identity authentication is unavailable" the moment it
  * tried to sign — the record layer was dead on every headless host.
  *
- * The invariant pinned here: run the EXACT boot sequence src/server/index.ts runs after
- * `hookServer.start()`, and a managed-account resolve signs + round-trips instead of throwing.
- * MUTATION (recorded in the PR body): delete the `setCodexThreadIdentityAuthSecret(secret)` line in
- * src/server/index.ts (equivalently, drop it from the boot sequence below) → this suite goes red
- * because `writeCodexThreadIdentity` for a managed account throws "unavailable".
+ * This drives the REAL production arming function `armServerNodeIdentity` (the exact code
+ * `startServer` awaits in its node-identity try block), NOT a re-implementation of the boot
+ * sequence — constraint 8 forbids a structural test that would pass the real defect.
+ * MUTATION (recorded in the PR body): delete `setCodexThreadIdentityAuthSecret(nodeAuthSecret)` from
+ * src/server/node-identity-arm.ts → this suite goes red because `writeCodexThreadIdentity` for a
+ * managed account throws "unavailable". (Confirmed: the mutation now REDS the shipped path.)
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'fs'
@@ -17,20 +18,28 @@ import os from 'os'
 import path from 'path'
 import { initPlatform, resetPlatformForTests } from '../core/platform'
 import { fakePlatform } from '../core/platform-fake'
-import { loadOrCreateNodeAuthSecret, resetNodeAuthSecretForTests } from '../core/agents/node-auth-secret'
+import { resetNodeAuthSecretForTests } from '../core/agents/node-auth-secret'
 import {
-  setCodexThreadIdentityAuthSecret,
   resetCodexThreadIdentityAuthSecret,
   codexThreadIdentityAvailable,
   writeCodexThreadIdentity,
   resolveCodexThreadNodeIdentity,
   codexThreadIdentityRoot
 } from '../core/codex-identity-proxy'
+import { armServerNodeIdentity } from './node-identity-arm'
 
 let dir = ''
+/** A hook-server stand-in capturing the node secret the real arming hands it. */
+const hookServer = {
+  received: null as Uint8Array | null,
+  setNodeAuthSecret(secret: Uint8Array) {
+    this.received = secret
+  }
+}
 
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-server-codex-ident-'))
+  hookServer.received = null
   resetPlatformForTests()
   resetNodeAuthSecretForTests()
   resetCodexThreadIdentityAuthSecret()
@@ -46,17 +55,18 @@ afterEach(() => {
 })
 
 describe('Server Edition arms the Codex identity secret on boot', () => {
-  it('a managed-account record signs + resolves after the boot sequence, instead of throwing unavailable', async () => {
+  it('a managed-account record signs + resolves after the REAL boot arming, instead of throwing unavailable', async () => {
     // Before arming: the record layer is dead.
     expect(codexThreadIdentityAvailable()).toBe(false)
     expect(() =>
       writeCodexThreadIdentity('thread-a', 'node-1', '/hook', undefined, 'managed-account')
     ).toThrow(/identity authentication is unavailable/)
 
-    // The EXACT boot sequence src/server/index.ts runs after hookServer.start().
-    const secret = await loadOrCreateNodeAuthSecret()
-    setCodexThreadIdentityAuthSecret(secret)
+    // Drive the REAL production arming `startServer` runs (no persisted canvases needed here).
+    await armServerNodeIdentity(hookServer, () => [])
 
+    // The node secret was armed too (both legs of the shipped function ran).
+    expect(hookServer.received?.byteLength).toBe(32)
     expect(codexThreadIdentityAvailable()).toBe(true)
 
     // A MANAGED account (non-empty accountId) — the case that threw on a headless host — now signs

--- a/src/server/codex-identity-boot.test.ts
+++ b/src/server/codex-identity-boot.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Server Edition arms the Codex identity-auth secret on boot (S6 Decision 1; carried PR-2
+ * obligation). Before PR 5 the headless shell armed ONLY `hookServer.setNodeAuthSecret(...)` and
+ * never `setCodexThreadIdentityAuthSecret(...)`, so a MANAGED Codex account's thread→node→account
+ * ownership record threw "NodeTerm Codex identity authentication is unavailable" the moment it
+ * tried to sign — the record layer was dead on every headless host.
+ *
+ * The invariant pinned here: run the EXACT boot sequence src/server/index.ts runs after
+ * `hookServer.start()`, and a managed-account resolve signs + round-trips instead of throwing.
+ * MUTATION (recorded in the PR body): delete the `setCodexThreadIdentityAuthSecret(secret)` line in
+ * src/server/index.ts (equivalently, drop it from the boot sequence below) → this suite goes red
+ * because `writeCodexThreadIdentity` for a managed account throws "unavailable".
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from '../core/platform'
+import { fakePlatform } from '../core/platform-fake'
+import { loadOrCreateNodeAuthSecret, resetNodeAuthSecretForTests } from '../core/agents/node-auth-secret'
+import {
+  setCodexThreadIdentityAuthSecret,
+  resetCodexThreadIdentityAuthSecret,
+  codexThreadIdentityAvailable,
+  writeCodexThreadIdentity,
+  resolveCodexThreadNodeIdentity,
+  codexThreadIdentityRoot
+} from '../core/codex-identity-proxy'
+
+let dir = ''
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-server-codex-ident-'))
+  resetPlatformForTests()
+  resetNodeAuthSecretForTests()
+  resetCodexThreadIdentityAuthSecret()
+  // Server-Edition shape: no seal hooks, so the secret is stored raw (node-auth-key.bin).
+  initPlatform(fakePlatform({ userDataDir: dir }))
+})
+
+afterEach(() => {
+  resetPlatformForTests()
+  resetNodeAuthSecretForTests()
+  resetCodexThreadIdentityAuthSecret()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('Server Edition arms the Codex identity secret on boot', () => {
+  it('a managed-account record signs + resolves after the boot sequence, instead of throwing unavailable', async () => {
+    // Before arming: the record layer is dead.
+    expect(codexThreadIdentityAvailable()).toBe(false)
+    expect(() =>
+      writeCodexThreadIdentity('thread-a', 'node-1', '/hook', undefined, 'managed-account')
+    ).toThrow(/identity authentication is unavailable/)
+
+    // The EXACT boot sequence src/server/index.ts runs after hookServer.start().
+    const secret = await loadOrCreateNodeAuthSecret()
+    setCodexThreadIdentityAuthSecret(secret)
+
+    expect(codexThreadIdentityAvailable()).toBe(true)
+
+    // A MANAGED account (non-empty accountId) — the case that threw on a headless host — now signs
+    // and round-trips against the real on-disk record under the fake platform's data dir.
+    const root = codexThreadIdentityRoot()
+    expect(() =>
+      writeCodexThreadIdentity('thread-a', 'node-1', '/hook', root, 'managed-account')
+    ).not.toThrow()
+    expect(resolveCodexThreadNodeIdentity('thread-a', root, 'managed-account')).toBe('node-1')
+    // And the SYSTEM account (no id) keeps resolving too — legacy-root records must not regress.
+    writeCodexThreadIdentity('thread-b', 'node-2', '/hook', root)
+    expect(resolveCodexThreadNodeIdentity('thread-b', root)).toBe('node-2')
+  })
+})

--- a/src/server/handlers/index.ts
+++ b/src/server/handlers/index.ts
@@ -77,12 +77,15 @@ export function registerCoreHandlers(
   // The secret question that used to block this is ANSWERED: src/server/index.ts arms
   // `hookServer.setNodeAuthSecret(await loadOrCreateNodeAuthSecret())` at boot, which on a headless
   // host is raw 0600 bytes in the data dir — a decision taken explicitly, not quietly (see
-  // src/core/agents/node-auth-secret.ts). What is still missing is only the codex-specific
-  // plumbing: `setCodexThreadIdentityAuthSecret(secret)`, `refreshCodexIdentityCaps()`, and the two
-  // `setCodexThread*Handler` registrations src/main/index.ts makes. Everything they call already
-  // lives in src/core and boots from CorePlatform, so this stays a scope line, not a blocker —
-  // until it is drawn differently, saying "no" here keeps the browser's Codex nodes identical to
-  // what they are today rather than half-armed.
+  // src/core/agents/node-auth-secret.ts). As of S6 PR 5 the same boot path also calls
+  // `setCodexThreadIdentityAuthSecret(secret)`, so a MANAGED Codex account's thread→node→account
+  // ownership records sign and verify on this headless host instead of throwing "identity
+  // authentication is unavailable" (the carried PR-2 obligation). What stays deliberately absent
+  // here is the shared-app-server plumbing (`refreshCodexIdentityCaps()` + the two
+  // `setCodexThread*Handler` registrations src/main/index.ts makes): the Server Edition answers "no
+  // shared identity" so its Codex nodes launch the bare `codex` — a working node with its own
+  // app-server, just without the shared one. Arming the record secret is orthogonal to that
+  // degrade: it never launches an app-server, it only lets the record layer sign.
   registerCodexIdentityIpc(() => UNKNOWN_CODEX_IDENTITY_CAPS)
 
   // Claude subscription usage. Previously desktop-only — the browser bridge answered `null`, so

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -37,9 +37,8 @@ import { registerLogHandlers } from '../core/log-handlers'
 import os from 'os'
 import { hookServer } from '../core/agents/hook-server'
 import { serverEditionControlHandler } from './control-unsupported'
-import { loadOrCreateNodeAuthSecret } from '../core/agents/node-auth-secret'
-import { setCodexThreadIdentityAuthSecret } from '../core/codex-identity-proxy'
-import { initNodeTokens, refreshNodeTokens } from '../core/agents/node-token-service'
+import { refreshNodeTokens } from '../core/agents/node-token-service'
+import { armServerNodeIdentity } from './node-identity-arm'
 import {
   writePendingAnswerLocal,
   startPendingSweep,
@@ -477,20 +476,12 @@ export async function startServer(
   // arming the secret, and a headless host in legacy mode is where it is most likely to be needed.
   hookServer.setIdentityStrictOverride(() => settingsStore.get().hookIdentityStrict)
   try {
-    const nodeAuthSecret = await loadOrCreateNodeAuthSecret()
-    hookServer.setNodeAuthSecret(nodeAuthSecret)
-    // S6 (Decision 1, carried from PR 2 review): arm the SAME secret for the Codex thread→node→
-    // account identity records so a MANAGED Codex account on a headless host can sign/verify its
-    // ownership records instead of throwing "identity authentication is unavailable". This is the
-    // both-shells half of the secret: desktop arms it in src/main/index.ts, and the Server Edition
-    // — which runs the managed-account + relay + switch protocol just as the desktop does — must
-    // arm it here too, or every managed-account resolve throws. The shared-app-server DEGRADE
-    // (Codex nodes launch bare, no launcher on PATH) is a SEPARATE, deliberate scope decision and
-    // is unaffected: this only makes the record layer able to sign.
-    setCodexThreadIdentityAuthSecret(nodeAuthSecret)
-    // Materialise a token file for every persisted node so an already-running session becomes
-    // verified at its next hook event with no restart. No-ops into legacy mode without a secret.
-    initNodeTokens({ canvases: () => workspaceStore.persistedCanvases() })
+    // The whole node-identity arming (node secret + the S6 Codex record secret + node tokens) lives
+    // in one REAL production function so the boot test can drive the shipped path rather than a
+    // re-implementation of it (constraint 8). It arms `setCodexThreadIdentityAuthSecret` with the
+    // same secret so a MANAGED Codex account on a headless host signs/verifies its ownership records
+    // instead of throwing "identity authentication is unavailable" (Decision 1, both-shells).
+    await armServerNodeIdentity(hookServer, () => workspaceStore.persistedCanvases())
   } catch (error) {
     console.warn('[node-identity] no secret — hook identity unavailable, running legacy', error)
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -38,6 +38,7 @@ import os from 'os'
 import { hookServer } from '../core/agents/hook-server'
 import { serverEditionControlHandler } from './control-unsupported'
 import { loadOrCreateNodeAuthSecret } from '../core/agents/node-auth-secret'
+import { setCodexThreadIdentityAuthSecret } from '../core/codex-identity-proxy'
 import { initNodeTokens, refreshNodeTokens } from '../core/agents/node-token-service'
 import {
   writePendingAnswerLocal,
@@ -476,7 +477,17 @@ export async function startServer(
   // arming the secret, and a headless host in legacy mode is where it is most likely to be needed.
   hookServer.setIdentityStrictOverride(() => settingsStore.get().hookIdentityStrict)
   try {
-    hookServer.setNodeAuthSecret(await loadOrCreateNodeAuthSecret())
+    const nodeAuthSecret = await loadOrCreateNodeAuthSecret()
+    hookServer.setNodeAuthSecret(nodeAuthSecret)
+    // S6 (Decision 1, carried from PR 2 review): arm the SAME secret for the Codex thread→node→
+    // account identity records so a MANAGED Codex account on a headless host can sign/verify its
+    // ownership records instead of throwing "identity authentication is unavailable". This is the
+    // both-shells half of the secret: desktop arms it in src/main/index.ts, and the Server Edition
+    // — which runs the managed-account + relay + switch protocol just as the desktop does — must
+    // arm it here too, or every managed-account resolve throws. The shared-app-server DEGRADE
+    // (Codex nodes launch bare, no launcher on PATH) is a SEPARATE, deliberate scope decision and
+    // is unaffected: this only makes the record layer able to sign.
+    setCodexThreadIdentityAuthSecret(nodeAuthSecret)
     // Materialise a token file for every persisted node so an already-running session becomes
     // verified at its next hook event with no restart. No-ops into legacy mode without a secret.
     initNodeTokens({ canvases: () => workspaceStore.persistedCanvases() })

--- a/src/server/node-identity-arm.ts
+++ b/src/server/node-identity-arm.ts
@@ -1,0 +1,32 @@
+// The Server Edition's boot-time node-identity arming, extracted from `startServer` so it is REAL
+// production code a test can drive directly (constraint 8: the pin must exercise the shipped path,
+// not a re-implementation of it). Headless Linux has no OS keychain, so the secret is raw 0600 bytes
+// (node-auth-key.bin); the loader handles the at-rest format. Fail-open/loud is the CALLER's job —
+// this throws if the secret can't be loaded, and `startServer` catches it into legacy mode.
+import { loadOrCreateNodeAuthSecret } from '../core/agents/node-auth-secret'
+import { setCodexThreadIdentityAuthSecret } from '../core/codex-identity-proxy'
+import { initNodeTokens } from '../core/agents/node-token-service'
+
+type Canvases = Parameters<typeof initNodeTokens>[0]['canvases']
+
+/**
+ * Arm node identity for the Server Edition: load/create the raw node-auth secret, hand it to the
+ * hook server, arm the Codex thread→node→account record secret with the SAME secret (S6 Decision 1,
+ * the both-shells half — desktop arms its twin in src/main/index.ts), and materialise a token file
+ * for every persisted node. `startServer` awaits this inside its fail-open try; the codex boot test
+ * drives this exact function so deleting the codex arming below REDS the pin.
+ */
+export async function armServerNodeIdentity(
+  hookServer: { setNodeAuthSecret(secret: Uint8Array): void },
+  canvases: Canvases
+): Promise<void> {
+  const nodeAuthSecret = await loadOrCreateNodeAuthSecret()
+  hookServer.setNodeAuthSecret(nodeAuthSecret)
+  // Managed Codex accounts on a headless host can then sign/verify their ownership records instead
+  // of throwing "identity authentication is unavailable". Orthogonal to the shared-app-server
+  // degrade (Codex nodes still launch bare here); this only makes the record layer able to sign.
+  setCodexThreadIdentityAuthSecret(nodeAuthSecret)
+  // Already-running sessions become verified at their next hook event with no restart. No-ops into
+  // legacy mode without a secret.
+  initNodeTokens({ canvases })
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -41,6 +41,20 @@ export const IPC = {
   claudeAccountsWaitLogin: 'claude-accounts:wait-login',
   claudeAccountsCancelWait: 'claude-accounts:cancel-wait',
   claudeAccountsRemove: 'claude-accounts:remove',
+  // Machine-scoped managed Codex accounts (S6). Add/device-login/removal, plus the three-phase,
+  // owner-authorized account switch (resume the SAME conversation id, never fork) and the
+  // source-side leg of moving an idle conversation to an SSH account. See main/codex-accounts.ts.
+  codexAccountsAdd: 'codex-accounts:add',
+  codexAccountsWaitLogin: 'codex-accounts:wait-login',
+  codexAccountsCancelWait: 'codex-accounts:cancel-wait',
+  codexAccountsIdentity: 'codex-accounts:identity',
+  codexAccountsSystemIdentity: 'codex-accounts:system-identity',
+  codexAccountsRemove: 'codex-accounts:remove',
+  codexAccountsSwitchThread: 'codex-accounts:switch-thread',
+  codexAccountsCommitSwitch: 'codex-accounts:commit-switch',
+  codexAccountsFinishSwitch: 'codex-accounts:finish-switch',
+  codexAccountsRollbackSwitch: 'codex-accounts:rollback-switch',
+  codexAccountsTransferThreadToSsh: 'codex-accounts:transfer-thread-to-ssh',
   claudeCliCaps: 'claude-cli:caps',
   /** Can a node on this machine get a managed Codex identity? See core/codex-identity-caps.ts. */
   codexIdentityCaps: 'codex-identity:caps',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2052,6 +2052,53 @@ export interface ClaudeAccountsApi {
   remove(id: string, ctx?: AccountSshCtx): Promise<void>
 }
 
+/**
+ * Machine-scoped managed Codex accounts (S6). LOCAL accounts on this Mac are reachable through
+ * PR 5; SSH remote accounts land in PR 6. The account LIST is renderer-owned in `settings.json`
+ * (`codexAccounts`), exactly like `claudeAccounts`; main owns only the fs + daemon lifecycle and
+ * the switch protocol.
+ */
+export interface CodexAccountsApi {
+  /** Mint a new managed account: create its private CODEX_HOME (0700) and symlink the shared,
+   *  non-secret runtime assets in. Returns the new id + its home. */
+  add(): Promise<{ id: string; home: string }>
+  /** Poll the account's `auth.json` (a real file, never a symlink) every 2s up to 5min for a
+   *  completed device login, then read its email; null on timeout/cancel. */
+  waitLogin(id: string): Promise<{ email: string | null } | null>
+  /** Cancel an in-flight `waitLogin` for this account. */
+  cancelWaitLogin(id: string): Promise<void>
+  /** Read a managed account's already-logged-in identity (email), or null if not logged in. */
+  identity(id: string): Promise<{ email: string | null } | null>
+  /** Read the system (`~/.codex`) account's identity. */
+  systemIdentity(): Promise<{ email: string | null } | null>
+  /** Remove a managed account: stop its daemon and delete its home. Refused while a switch
+   *  reservation holds it or a concurrent removal is in flight (Property 10). */
+  remove(id: string): Promise<void>
+  /** Phase 1 of the owner-authorized same-machine switch: plan + reserve the rollout exposure of a
+   *  conversation from one account to another under a `rollbackToken` (TTL 60s, owner = caller). */
+  switchThread(
+    threadId: string,
+    cwd: string,
+    sourceAccountId?: string,
+    targetAccountId?: string
+  ): Promise<{ threadId: string; rollbackToken?: string }>
+  /** Phase 2: commit the reserved exposure (atomic hardlink into the target account). */
+  commitSwitch(rollbackToken: string): Promise<void>
+  /** Phase 3a: finish a committed switch, releasing the reservation. */
+  finishSwitch(rollbackToken: string): Promise<void>
+  /** Phase 3b: roll back a reservation (releases it; a committed link is left for cleanup). */
+  rollbackSwitch(rollbackToken: string): Promise<void>
+  /** Source-side leg of moving an idle LOCAL conversation to an SSH account: validate strict source
+   *  containment then hand the upload to the remote import path (PR 6). Local rollout untouched. */
+  transferThreadToSsh(
+    threadId: string,
+    cwd: string,
+    projectId: string,
+    targetAccountId?: string,
+    sourceAccountId?: string
+  ): Promise<{ threadId: string; imported: boolean }>
+}
+
 /** One ranked search hit across all on-disk Claude session transcripts. */
 export interface TranscriptHit {
   sessionId: string
@@ -2525,6 +2572,7 @@ export interface NodeTerminalApi {
   agent: AgentApi
   chat: ChatApi
   claudeAccounts: ClaudeAccountsApi
+  codexAccounts: CodexAccountsApi
   transcripts: TranscriptsApi
   remoteHost: RemoteHostApi
   relayHost: RelayHostApi

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -181,8 +181,12 @@ export interface PtyCreateResult {
    * Only ever set for a create that would have SPAWNED: a co-attach to a live session for this
    * node id still joins (the session is already running wherever it runs), so a second view of a
    * healthy remote terminal is unaffected.
+   *
+   * `'codex-account'` is the S6 fail-closed twin: a LOCAL Codex node that explicitly selected a
+   * managed account whose home is missing refuses rather than spawning against the system login
+   * (§5 property 4). Same contract — nothing spawned, the renderer shows the node's refusal.
    */
-  unavailable?: 'ssh'
+  unavailable?: 'ssh' | 'codex-account'
 }
 
 /** Payload of `pty:recycled` — see IPC.ptyRecycled and `recycleAction` in the renderer. */


### PR DESCRIPTION
## S6 PR 5 — Main-side local Codex accounts and the three-phase account switch

The pivotal S6 PR: it makes machine-scoped Codex accounts **reachable for LOCAL accounts**. PRs 1–4 shipped inert; PR 5 wires add / device-login / retry / removal, the three-phase owner-authorized switch, and the local→SSH transfer source leg. Re-slices @Corvin's reference `codex-accounts.ts` from #112 onto the PR 3/4 primitives. **SSH remote accounts are PR 6.**

> **Stacked on #330 (PR 4, relay daemon), which is not yet merged.** Base is `feat/codex-relay-daemon` so this diff shows only PR 5's work. Retarget to `main` once #330 merges.

### The three carried obligations — each done + tested

- [x] **Fail-closed spawn (from PR 1 / Decision 2).** `resolveCodexSessionScope` is wired into `pty-manager` `spawnNew`, consuming `isCodexScopeRefusal`: a LOCAL Codex spawn that explicitly selected a managed account whose home is missing now returns `unavailable: 'codex-account'` and **spawns nothing** — it never falls through to the system `~/.codex`. `spawnSession` sets an explicit `CODEX_HOME` + `NODETERM_CODEX_ACCOUNT_ID` for every local Codex session and strips the OpenAI/Codex API-key env. **Test:** `src/core/pty-codex-spawn.test.ts` against a real PtyManager + temp fs. **Mutations 2/2** (remove the refusal → it spawns; drop the `CODEX_HOME` assignment → env wrong).

- [x] **Server Edition secret arming (from PR 2 / Decision 1).** `src/server/index.ts` now calls `setCodexThreadIdentityAuthSecret(nodeAuthSecret)` right after `setNodeAuthSecret`, so a managed Codex account's thread→node→account record signs/verifies on a headless host instead of throwing "identity authentication is unavailable". The stale handlers/index.ts comment is corrected. **Test:** `src/server/codex-identity-boot.test.ts` (managed-account resolve signs + round-trips after the boot sequence; system record still resolves). **Mutation 1/1** (drop the arming line → throws "unavailable").

- [x] **`~/.nodeterm` root before first relay use (from PR 4).** `ensureServer` now creates the root, and a new exported `ensureCodexRelayRoot(target?)` is called at `initCodexAccounts` boot. **Test:** `src/main/codex-relay-daemon.test.ts` (root created `0o700`, idempotent). **Mutation 1/1** (drop `mode: 0o700`).

### Security properties (each pinned red-on-regression)

- **Switch = resume, never a silent fork (Property 5).** Three-phase: `switchThread` (plan + reserve under `rollbackToken`, TTL 60s, owner = sender) → `commitSwitch` (PR 3's atomic hardlink — same inode ⇒ byte-identical conversation id) → `finishSwitch` / `rollbackSwitch`. Proven against the **real** `planCodexRolloutExposure` / `commitCodexRolloutExposure` on a real fs (target inode == source inode).
- **Owner-authorized.** Every phase asserts `pending.owner.id === event.sender.id`; auto-release on owner `destroyed` or TTL. A non-owner WebContents cannot commit/finish. **Mutation:** drop the owner check → non-owner commits → **red**.
- **Explicit-missing-account fails closed (Property 4).** See the first carried obligation.
- **Removal is race/use-safe (Property 10).** `removingCodexAccounts` + `pendingSwitchExposures` block concurrent remove/switch; removal refuses while a switch reservation holds either account. **Mutations:** drop the reservation guard → removal admitted during switch → **red**; drop the in-progress guard → concurrent removal admitted → **red**.
- **Login gate requires a real non-symlink `auth.json`.** **Mutation:** `lstat` → `stat` (follows the symlink) → a symlinked credential counts as logged in → **red**.
- **No credential on argv (constraint 6).** Device login/removal drive the CLI with `CODEX_HOME` via **env**, never argv; the local `auth.json` never leaves the Mac.
- **Local→SSH transfer source containment (Task 5.3).** Strict source validation (regular file under `sessions/`, basename `<threadId>.jsonl`, no symlinked segment — reusing PR 3's `planCodexRolloutExposure`) before any upload; hands off to PR 6's `remoteCodexImportThread`; local rollout untouched. **Mutation:** bypass the plan → escaping source is uploaded → **red** (importer asserted never-called on escape).

### Minor fold-ins (from PR 4 review)
- The relay `-32004` "changed the conversation id" rewrite no longer fires for a plain malformed id: `relayThreadResponseError` returns `-32004` only for the silent-fork case (`unexpectedThreadId`) and a distinct `-32603` for a malformed id. **Mutation 1/1.**
- Corrected an overstated mutation comment in `codex-identity-proxy.test.ts` (the scope-bound HMAC, not the line-vs-directory check, is load-bearing).

### Tests / gates
`npm run typecheck` clean. Full `npx vitest run`: **7524 passed, 12 skipped, 0 failed**. New: `pty-codex-spawn`, `codex-identity-boot` (server), `codex-accounts` (+ `.switch` / `.transfer`), plus extensions to `codex-accounts-core`, `codex-relay-daemon`. **Mutation total: 10/10 caught.**

### Owed device-verification
The live Codex app-server RPC (daemon start/stop, `account/read`, `thread/read`) and the relay serve loop are **unrunnable headless** (probes U1/U2/U4/U6). All such effects are faked in tests; the copy/containment/owner-auth/TTL logic is proven against real fs + real rollout primitives. A live-host pass on the daemon lifecycle + resume-by-path id preservation is owed before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
