### PR TITLE
feat(keybindings): dictation conflict bucket + recording menu stand-down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1623,6 +1623,14 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
     warning reads that list and cannot derive it — main is not importable from the renderer. Note
     what the pin cannot cover: a HARDCODED intercept (the `Digit0` branch) has no command id, so it
     swallows its chord app-wide with the recorder reporting no conflict.
+  - **Dictation has its own conflict bucket** (`conflictBucket` — `speech.dictation` is never in
+    `global`), because it never competes at dispatch: the resolver skips it and its own keyed
+    listener claims the chord FIRST **in plain app focus only**, which is precedence, not ambiguity.
+    Overlap policy is deliberately asymmetric — the LOAD path PERMITS a shared chord (legacy
+    settings.json files contain them and `sanitizeKeybindingOverrides` would otherwise strip the
+    user's own binding with the migrated one), while the Settings UI REFUSES to create one
+    (`commitCandidate`'s two dictation gates, both keyed-only — a modifier-only hold chord renders
+    as `…:(hold)` and can never match a keyed identity).
   - **The terminal-first stand-down is `policyStandsDown(policy, terminalFocused)`, and both halves
     are refusals.** `settings.terminalShortcutPolicy` (`app-first` default, Settings → Keyboard
     Shortcuts, read everywhere through `normalizeTerminalShortcutPolicy` because it is
@@ -1632,7 +1640,11 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
     `menuItemIdsToSuspend` — Minimize, Toggle Kanban Board (⌘⇧B) and Settings (⌘,) everywhere, plus
     Close off-mac, with **Reload deliberately excluded** (see **Window chrome**): not calling
     `preventDefault` alone would hand ⌘M straight to `{role:'minimize'}`, which is strictly worse
-    than having no policy.
+    than having no policy. **The MENU's state is the composed
+    `menuStandsDown(shortcutRecording, policy, terminalFocused)`** — an armed shortcut recorder
+    suspends the same items, so ⌘M / ⌘⇧B / ⌘, / off-mac Ctrl+W reach the recorder instead of the
+    menu item that owns them; `menuStandsDown(false, …)` is `policyStandsDown(…)` by construction.
+    The two INTERCEPT thunks stay independent parameters — only the menu ORs them.
   - **`terminalFocused` is a MIRROR, and its fail-safe direction is `false` = not focused =
     intercepts ON.** `renderer/lib/terminalFocusMirror.ts` reports focus changes to main and is
     change-deduped (it never re-asserts), so a page that died mid-report, a reload, or a window that
@@ -1927,19 +1939,26 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   submenu's standard `{role:'cut'|'copy'|'paste'|'selectAll'|…}` items behave differently — Chromium
   routes them into the focused element, so ⌘C in a terminal or a text field does the ordinary thing
   and does not need stealing. Ask which kind an item is before reasoning from this bullet.
-  That difference is also why the **terminal-first stand-down has a menu leg**: while a terminal
-  owns the keys under `terminal-first`, `syncMenuForStandDown` disables the command-style items
+  That difference is also why the **stand-down has a menu leg**: while a terminal
+  owns the keys under `terminal-first` **or while a shortcut recorder is armed**
+  (`menuStandsDown(shortcutRecording, policy, terminalFocused)`), `syncMenuForStandDown` disables
+  the command-style items
   named in `menuItemIdsToSuspend` — Minimize (`MENU_ITEM_ID_MINIMIZE`), **Toggle Kanban Board
   (`MENU_ITEM_ID_KANBAN`, ⌘⇧B)** and **Settings (`MENU_ITEM_ID_SETTINGS`, ⌘,)** on every platform,
   plus Close (`MENU_ITEM_ID_CLOSE`) on Windows/Linux — because a disabled item suppresses its
-  accelerator and only then do those chords fall through to the terminal. Kanban and Settings are
+  accelerator and only then do those chords fall through to the terminal, or to the recorder. The
+  recorder leg is why ⌘M is bindable at all, and it fixed a live misfire: ⌘⇧B pressed into an armed
+  recorder used to open the kanban board behind the Settings dialog, and ⌘, to re-open Settings.
+  Kanban and Settings are
   the ones a reader gets wrong: they are **not** intercepted chords at all but ordinary registry
   commands (`view.kanbanToggle` / `app.settings`), so the renderer's dispatcher could never stand
   them down itself — under app-first the menu takes them before the keydown exists, which is also
   why their capture NOTICE is raised at the IPC receivers in `Canvas.tsx` rather than by the
   dispatcher. **Reload (⌘R / ⌘⇧R) is the named exception and stays live while stood down**: it is
   the crash-recovery lever (a wedged renderer is exactly when it is needed) and a main-frame
-  navigation is one of the three sites that reset `terminalFocused` / `shortcutRecording`.
+  navigation is one of the three sites that reset `terminalFocused` / `shortcutRecording`. It is
+  therefore also the one chord a shortcut recorder can never capture, which is what the Keyboard
+  Shortcuts section's description now says.
   `keydown-intercept.test.ts` pins both the stolen chords and the suspended item ids (including
   that the list does not silently grow) — `getMenuItemById` answers `null` for a typo and the
   fail-safe is to do nothing, which is indistinguishable from the feature working.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1956,9 +1956,16 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   why their capture NOTICE is raised at the IPC receivers in `Canvas.tsx` rather than by the
   dispatcher. **Reload (⌘R / ⌘⇧R) is the named exception and stays live while stood down**: it is
   the crash-recovery lever (a wedged renderer is exactly when it is needed) and a main-frame
-  navigation is one of the three sites that reset `terminalFocused` / `shortcutRecording`. It is
-  therefore also the one chord a shortcut recorder can never capture, which is what the Keyboard
-  Shortcuts section's description now says.
+  navigation is one of the three sites that reset `terminalFocused` / `shortcutRecording`. **Of the
+  items main suspends, Reload is therefore the deliberate exception** — the one it holds back from a
+  shortcut recorder — which is what the Keyboard Shortcuts section's description now says.
+  **KNOWN GAP, pre-existing and accepted:** the suspend list only ever covered the command-style
+  items the terminal-first policy needed, so the always-on app roles — `quit` (⌘Q), `hide` /
+  `hideOthers` (⌘H / ⌘⌥H), `toggleDevTools`, `togglefullscreen` — still act while a recorder is
+  armed (⌘Q pressed into one QUITS the app). They are deliberately NOT added: ONE list drives both
+  stand-downs, and making ⌘Q/⌘H unreachable for a terminal-first user is the worse trade — quit and
+  hide must never be policy-gated. Splitting the list per stand-down is the change that would close
+  it, and it has not been made.
   `keydown-intercept.test.ts` pins both the stolen chords and the suspended item ids (including
   that the list does not silently grow) — `getMenuItemById` answers `null` for a typo and the
   fail-safe is to do nothing, which is indistinguishable from the feature working.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,11 +100,14 @@ three times.
 screen. A previous design moved that into the emulator and failed structurally; `CLAUDE.md` explains
 why in detail.
 
-**A new keyboard chord has to survive the shells, not just the renderer.** Electron's default
-application menu is live (we never replace it) and owns ⌘0, ⌘M, ⌘W, ⌘Q, ⌘R and friends — a menu
-accelerator is handled before the page, so your `keydown` branch simply never runs. Steal it back in
-`main/index.ts`'s `before-input-event` and forward it, like the three already there. Browsers own a
-different set. And any chord that reaches the canvas needs the two refusals every canvas shortcut
+**A new keyboard chord has to survive the shells, not just the renderer.** The application menu is
+ours (`buildAppMenu` in `main/index.ts`), but its command-style accelerators — ⌘Q, ⌘M, ⌘W, ⌘0, ⌘⇧B,
+⌘, — are still handled above the page, so your `keydown` branch simply never runs: steal the chord
+back in `main/keydown-intercept.ts`'s `before-input-event` allowlist and forward it, like the three
+already there. Two legs stand the menu down instead of stealing — the terminal-first policy and an
+armed shortcut recorder (`menuStandsDown` → `menuItemIdsToSuspend`, since a disabled item suppresses
+its accelerator) — and Reload (⌘R / ⌘⇧R) is the named exception that always stays with the app,
+because it is the crash-recovery lever. Browsers own a different set. And any chord that reaches the canvas needs the two refusals every canvas shortcut
 here has: not while the kanban board covers it, not while the user is typing.
 
 **Comments explain WHY, and name the failure they prevent.** The codebase is deliberately dense with

--- a/src/core/settings-store.test.ts
+++ b/src/core/settings-store.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, promises as fs, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
 import { IPC } from '../shared/ipc'
+import { sanitizeKeybindingOverrides } from '../shared/keybindings'
 import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform } from './platform-fake'
 import { SettingsStore } from './settings-store'
@@ -199,6 +200,16 @@ describe('SettingsStore nested-default merge', () => {
       })
       const twice = loadWith({ ...once, keybindings: { 'speech.dictation': ['Cmd+Alt+K'] } })
       expect(twice.keybindings?.['speech.dictation']).toEqual(['Cmd+Alt+K'])
+    })
+
+    it('a legacy chord colliding with another command now survives load end-to-end', () => {
+      // The PR3-era hole, measured then: Cmd+K was seeded and then stripped by the sanitizer.
+      const s = loadWith({ speech: { engine: 'whisper', model: '', language: 'auto', shortcut: 'Cmd+K' } })
+      expect(s.keybindings?.['speech.dictation']).toEqual(['Cmd+K'])
+      // The read path is the renderer's sanitizer; assert its verdict here too so the
+      // end-to-end claim is one test, not an inference across two files.
+      expect(sanitizeKeybindingOverrides(s.keybindings, true).overrides['speech.dictation'])
+        .toEqual(['Cmd+K'])
     })
   })
 })

--- a/src/core/settings-store.ts
+++ b/src/core/settings-store.ts
@@ -26,12 +26,15 @@ function mergeSettings(saved: Partial<Settings> | null | undefined): Settings {
   // write path keeps it in sync so an older build still finds the user's chord).
   // A shortcut EQUAL to the default seeds nothing: the override would only restate what the
   // registry already says, and would then pin that chord against any future default change.
-  // **Seeding here is not the same as surviving.** The value written below is a plain override,
-  // so the READ path's sanitizer (`sanitizeKeybindingOverrides`) can still STRIP it: if the
-  // legacy chord collides with another command's effective binding in the same conflict bucket,
-  // every OVERRIDDEN participant of that conflict is deleted — the seed goes, dictation silently
-  // falls back to the registry default chord, and the user's own colliding override is dropped
-  // with it. The only signal is a console warning; nothing surfaces in the UI.
+  // **The seeded value survives the read path.** `speech.dictation` has its OWN conflict bucket
+  // (`conflictBucket` in shared/keybindings.ts), so it can never be a participant in a
+  // cross-command collision, and the READ path's sanitizer (`sanitizeKeybindingOverrides`) has
+  // nothing to strip — neither the seed nor the user's own override on the same chord. (It used
+  // not to: both were deleted on load, and dictation silently fell back to the registry default.)
+  // What a shared chord costs is PRECEDENCE, not the binding: dictation's own keyed listener
+  // claims it first in plain app focus, and the other command still gets it everywhere dictation
+  // does not listen — terminal focus, say. That is exactly the pre-migration behavior of a legacy
+  // `speech.shortcut` that happened to match an app chord, which is what this seed must preserve.
   if (
     merged.speech.shortcut !== DEFAULT_SETTINGS.speech.shortcut &&
     !(merged.keybindings && "speech.dictation" in merged.keybindings)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -95,6 +95,7 @@ import {
   MENU_ITEM_ID_SETTINGS,
   installKeydownIntercepts,
   menuItemIdsToSuspend,
+  menuStandsDown,
   navigationClearsRecording,
   policyStandsDown,
   resolveInterceptBindings,
@@ -630,9 +631,11 @@ function buildAppMenu(win: BrowserWindow): void {
         { label: 'View', submenu: viewSubmenu },
         {
           label: 'Window',
-          // `id` on minimize: `syncMenuForStandDown` disables it while the intercepts are stood
-          // down, so ⌘M falls through to the terminal instead of minimizing the window. mac has no
-          // `{role:'close'}` here at all — which is why the intercept is ⌘W's only handler on mac.
+          // `id` on minimize: `syncMenuForStandDown` disables it while EITHER stand-down is in
+          // effect — a terminal focused under terminal-first, or an armed shortcut recorder — so
+          // ⌘M falls through to the terminal, or to the recorder, instead of minimizing the
+          // window. mac has no `{role:'close'}` here at all — which is why the intercept is ⌘W's
+          // only handler on mac.
           submenu: [
             { role: 'minimize', id: MENU_ITEM_ID_MINIMIZE },
             { role: 'zoom' },
@@ -679,7 +682,16 @@ function buildAppMenu(win: BrowserWindow): void {
 }
 
 /**
- * Enable/disable the menu items whose ACCELERATORS would otherwise beat the intercept stand-down.
+ * Enable/disable the menu items whose ACCELERATORS would otherwise beat a stand-down.
+ *
+ * **Two stand-downs share this leg**, composed by `menuStandsDown(shortcutRecording, policy,
+ * terminalFocused)`: the terminal-first policy (below) and an armed Settings shortcut RECORDER.
+ * The recorder needs it for the same structural reason and a different destination — a menu
+ * accelerator is handled above the page, so while it was armed ⌘M minimized the window, ⌘⇧B opened
+ * the kanban board behind the dialog and ⌘, re-opened Settings, none of them recordable. With the
+ * items suspended those chords reach the recorder. **Reload is still not among them** (see below),
+ * so ⌘R / ⌘⇧R remain unrecordable by design. The two INTERCEPT thunks stay independent parameters
+ * on `installKeydownIntercepts`; only this single `enabled` boolean ORs them.
  *
  * `installKeydownIntercepts` standing down means only that main stops calling `preventDefault` —
  * the key then reaches the page, and if the page ignores it, the MENU, which is handled above the
@@ -697,33 +709,38 @@ function buildAppMenu(win: BrowserWindow): void {
  * never sees them and could not stand them down itself. **Reload (⌘R / ⌘⇧R) is the named
  * exception** and stays live while stood down; see `menuItemIdsToSuspend`'s comment for why.
  *
- * Called from every place the stood-down answer can change — the `ui:terminal-focus` receiver, the
- * policy recompute in `settingsStore.onChange`, `clearRendererKeyState`, and the end of
- * `buildAppMenu` (a rebuild resets `enabled`). NEVER per keystroke: this is a menu mutation, and
- * `before-input-event` is the one path in the app where work is measured in keystrokes.
+ * Called from every place the composed answer can change — the `ui:terminal-focus` receiver, the
+ * `ui:shortcut-recording` receiver (the recorder arms and disarms once per chord the user records),
+ * the policy recompute in `settingsStore.onChange`, `clearRendererKeyState` (which clears BOTH
+ * bits), and the end of `buildAppMenu` (a rebuild resets `enabled`). NEVER per keystroke: this is a
+ * menu mutation, and `before-input-event` is the one path in the app where work is measured in
+ * keystrokes.
  *
  * FAIL-SAFE: a missing menu, or an item id that no longer resolves, does nothing at all. That
  * leaves the pre-feature behaviour (menu enabled, intercepts deciding), which is the direction
  * where the app still works — the cost is that a silent id drift is invisible, which is why both
  * sides of the lookup use the same exported constants rather than string literals.
  *
- * KNOWN COST, deliberate: while a terminal is focused under terminal-first, every suspended item —
- * Window ▸ Minimize, View ▸ Toggle Kanban Board, Settings, and off-mac Window ▸ Close — is greyed
- * out to the MOUSE as well. They re-enable the moment focus leaves the terminal (and the
+ * KNOWN COST, deliberate: while either stand-down holds, every suspended item — Window ▸ Minimize,
+ * View ▸ Toggle Kanban Board, Settings, and off-mac Window ▸ Close — is greyed out to the MOUSE as
+ * well. They re-enable the moment focus leaves the terminal, or the recorder disarms (and the
  * traffic-light button is unaffected), so this is a visible but self-healing trade. The alternative
  * — rebuilding the whole menu without those accelerators on every focus change — costs a menu
- * rebuild per click between the canvas and a terminal, and closes any menu the user has open.
+ * rebuild per click between the canvas and a terminal, and closes any menu the user has open. For
+ * the recorder the trade is smaller still: the greyed items sit behind a modal dialog the user
+ * opened to record a chord, and the alternative was four chords they could not bind at all.
  *
  * UNTESTED, and here is why: this is Electron menu mutation reached through the module-level
  * `Menu` singleton inside `src/main/index.ts`, which no test imports (the same gap the intercept
  * WIRING has — see `keydown-intercept.ts`'s header on why the decision lives in a pure module).
- * The two testable parts were extracted: `policyStandsDown` (the state) and `menuItemIdsToSuspend`
- * (the list, including the mac/non-mac asymmetry), both pinned in `keydown-intercept.test.ts`.
+ * The testable parts were extracted: `menuStandsDown` (the composed state) over `policyStandsDown`
+ * (the policy half) and `menuItemIdsToSuspend` (the list, including the mac/non-mac asymmetry), all
+ * pinned in `keydown-intercept.test.ts`.
  */
 function syncMenuForStandDown(): void {
   const menu = Menu.getApplicationMenu()
   if (!menu) return
-  const enabled = !policyStandsDown(currentInterceptPolicy(), terminalFocused)
+  const enabled = !menuStandsDown(shortcutRecording, currentInterceptPolicy(), terminalFocused)
   for (const id of menuItemIdsToSuspend(interceptIsMac)) {
     const item = menu.getMenuItemById(id)
     if (item) item.enabled = enabled
@@ -1115,6 +1132,13 @@ app.whenReady().then(async () => {
   ipcMain.on(IPC.uiShortcutRecording, (event, active: boolean) => {
     if (getMainWindow()?.webContents.id !== event.sender.id) return
     shortcutRecording = active === true
+    // The menu leg follows recording too (`menuStandsDown`), so an arm/disarm owes a sync — that is
+    // what lets ⌘M, ⌘⇧B, ⌘, and off-mac Ctrl+W reach the recorder instead of the menu item that
+    // owns them. A recorder arms and disarms once per chord the user records, which is the right
+    // cadence for a menu mutation; NEVER per keystroke (same rule as the focus mirror below). It
+    // must be INSIDE the guard for the same reason as there: a rejected sender must not move the
+    // menu either.
+    syncMenuForStandDown()
   })
 
   // The terminal-focus mirror, under the SAME sender guard and for a sharper version of the same

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -332,7 +332,9 @@ settingsStore.onChange((s) => {
 // 1. `shortcutRecording` — Settings' shortcut recorder is armed: stand every intercept down so the
 //    chord the user presses reaches the recorder. Without it, recording ⌘W CLOSES THE SELECTED
 //    NODES — a claimed chord never reaches the page, so the recorder's own preventDefault cannot
-//    save it.
+//    save it. It ALSO drives the menu leg (`menuStandsDown` → `syncMenuForStandDown`, called from
+//    this bit's IPC receiver), which is what lets a menu-owned chord — ⌘M, ⌘⇧B, ⌘,, off-mac
+//    Ctrl+W — reach the recorder instead of the item that owns it.
 // 2. `terminalFocused` — an xterm holds keyboard focus, which under the `terminal-first` policy
 //    means the intercepts stand down so the terminal gets the chord. `before-input-event` fires
 //    before any renderer handler could answer, so the answer has to be sitting here in advance;

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -9,6 +9,7 @@ import {
   installKeydownIntercepts,
   keydownIntercept,
   menuItemIdsToSuspend,
+  menuStandsDown,
   navigationClearsRecording,
   policyStandsDown,
   resolveInterceptBindings,
@@ -573,6 +574,48 @@ describe('policyStandsDown', () => {
   it('the reset value (not focused) means intercepts stay on under either policy', () => {
     for (const policy of ['app-first', 'terminal-first'] as const) {
       expect(policyStandsDown(policy, false)).toBe(false)
+    }
+  })
+})
+
+/**
+ * The MENU leg's composed state — what `index.ts`'s `syncMenuForStandDown` asks. The INTERCEPT
+ * thunks stay two independent parameters (the describe above pins that); only the menu ORs them,
+ * because a menu item is enabled or it is not and both reasons want the same items suspended.
+ *
+ * Why recording joined at all: a menu accelerator is handled above the page, so while a recorder
+ * was armed ⌘M minimized the window, ⌘⇧B opened the kanban board and ⌘, opened Settings instead of
+ * being recorded. Suspending the items is what lets the chord reach the recorder.
+ */
+describe('menuStandsDown', () => {
+  it('recording alone suspends the menu leg, under either policy', () => {
+    expect(menuStandsDown(true, 'app-first', false)).toBe(true)
+    expect(menuStandsDown(true, 'terminal-first', false)).toBe(true)
+  })
+  it('without recording it is exactly the policy stand-down', () => {
+    expect(menuStandsDown(false, 'terminal-first', true)).toBe(true)
+    expect(menuStandsDown(false, 'terminal-first', false)).toBe(false)
+    expect(menuStandsDown(false, 'app-first', true)).toBe(false)
+  })
+
+  // The behaviour contract of this change, stated as a test: with no recorder armed the menu leg
+  // is BYTE-IDENTICAL to what it was before recording was composed in, so a user who never opens
+  // the Settings recorder sees exactly the previous app.
+  it('is exactly policyStandsDown over the whole non-recording matrix', () => {
+    for (const policy of ['app-first', 'terminal-first'] as const) {
+      for (const focused of [true, false]) {
+        expect(menuStandsDown(false, policy, focused)).toBe(policyStandsDown(policy, focused))
+      }
+    }
+  })
+
+  // Recording is the ALWAYS suspension (see `installKeydownIntercepts`): it does not consult the
+  // mirror, so a recorder armed with no terminal focused still gets its chords.
+  it('recording ignores the focus mirror entirely', () => {
+    for (const policy of ['app-first', 'terminal-first'] as const) {
+      for (const focused of [true, false]) {
+        expect(menuStandsDown(true, policy, focused)).toBe(true)
+      }
     }
   })
 })

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -277,9 +277,13 @@ export const MENU_ITEM_ID_SETTINGS = 'app-settings'
  * earlier argument here was that a recorder greying out Minimize was a worse trade than an
  * unrecordable ⌘M; that trade REVERSED once the menu leg existed for the policy anyway. The cost is
  * now a momentary grey-out while a modal recorder is armed — self-healing the instant it disarms —
- * and the benefit is four chords that could not be bound at all: ⌘M everywhere, off-mac Ctrl+W, and
- * ⌘⇧B / ⌘, which did not merely fail to record but FIRED — pressing ⌘⇧B into the recorder opened
- * the kanban board behind the Settings dialog, and ⌘, re-opened Settings.
+ * and the benefit is that four chords now REACH the recorder instead of acting on the app: ⌘M
+ * everywhere, off-mac Ctrl+W, and ⌘⇧B / ⌘, which did not merely fail to record but FIRED —
+ * pressing ⌘⇧B into the recorder opened the kanban board behind the Settings dialog, and ⌘,
+ * re-opened Settings. **Reaching the recorder is all this buys, and it is the unconditional part.**
+ * Whether the chord can then be BOUND is a separate question, answered by the pre-save gates in
+ * `ShortcutsSection.commitCandidate`: while its owning command still holds it, it is refused there
+ * like any other taken chord — the user has to Disable or remap that command first.
  *
  * **KNOWN GAP for the recording half, pre-existing and accepted.** This list was written for the
  * POLICY stand-down, so it covers only the command-style items that policy needed. The always-on

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -281,6 +281,14 @@ export const MENU_ITEM_ID_SETTINGS = 'app-settings'
  * ⌘⇧B / ⌘, which did not merely fail to record but FIRED — pressing ⌘⇧B into the recorder opened
  * the kanban board behind the Settings dialog, and ⌘, re-opened Settings.
  *
+ * **KNOWN GAP for the recording half, pre-existing and accepted.** This list was written for the
+ * POLICY stand-down, so it covers only the command-style items that policy needed. The always-on
+ * app roles — `{role:'quit'}` (⌘Q), `{role:'hide'}`/`hideOthers`, `toggleDevTools`,
+ * `togglefullscreen` — are NOT here, so those chords still ACT while a recorder is armed (⌘Q quits
+ * the app). Adding them is refused rather than overlooked: ONE list drives both stand-downs, so
+ * they would also go dead for a terminal-first user with a terminal focused, and quit/hide must
+ * never be policy-gated. Closing it properly means splitting the list per stand-down.
+ *
  * mac carries no CLOSE id: the mac template has no `{role:'close'}` at all (Window ▸ Minimize /
  * Zoom / Front), which is exactly why `keydownIntercept` is ⌘W's only handler there. Kanban and
  * Settings are on BOTH platforms — one `viewSubmenu` array and one `settingsItem` object are shared

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -225,6 +225,26 @@ export function policyStandsDown(
 }
 
 /**
+ * PURE. The MENU leg's composed stand-down state: `index.ts`'s `syncMenuForStandDown` disables
+ * `menuItemIdsToSuspend` for exactly as long as this is true.
+ *
+ * **The menu ORs the two suspensions; the INTERCEPTS do not.** `installKeydownIntercepts` keeps
+ * `isRecording` and `isStoodDown` as separate parameters on purpose (unrelated reasons, unrelated
+ * schedules — see its doc), and that stays. But a menu item is enabled or it is not: both reasons
+ * want the same items suspended, and one boolean is the honest shape for a single `enabled` write.
+ *
+ * `menuStandsDown(false, …)` is `policyStandsDown(…)` by construction, which is the byte-identical
+ * guarantee for every user who never arms the Settings recorder.
+ */
+export function menuStandsDown(
+  recording: boolean,
+  policy: TerminalShortcutPolicy,
+  terminalFocused: boolean
+): boolean {
+  return recording || policyStandsDown(policy, terminalFocused)
+}
+
+/**
  * Menu item ids `buildAppMenu` stamps on the items whose ACCELERATORS survive an intercept
  * stand-down. Exported constants used by both sides — the template that sets them and the sync that
  * looks them up — because `getMenuItemById` answers `null` for a typo and the fail-safe there is to
@@ -252,10 +272,14 @@ export const MENU_ITEM_ID_SETTINGS = 'app-settings'
  * nothing matches) → xterm → the PTY. That is what completes "under terminal-first everything
  * reaches the shell", ⌘M included.
  *
- * **This is NOT the recording stand-down's story** — keep the two apart. Recording is a transient,
- * user-initiated arming of a dialog, and its ⌘M limitation (documented on `installKeydownIntercepts`)
- * stands: nothing here re-enables recording those chords, because a recorder that silently disabled
- * Minimize for the duration of a keypress is a different and worse trade.
+ * **The list serves BOTH stand-downs** — the policy one above and an armed shortcut recorder
+ * (`menuStandsDown` composes them; `syncMenuForStandDown` disables these items for either). The
+ * earlier argument here was that a recorder greying out Minimize was a worse trade than an
+ * unrecordable ⌘M; that trade REVERSED once the menu leg existed for the policy anyway. The cost is
+ * now a momentary grey-out while a modal recorder is armed — self-healing the instant it disarms —
+ * and the benefit is four chords that could not be bound at all: ⌘M everywhere, off-mac Ctrl+W, and
+ * ⌘⇧B / ⌘, which did not merely fail to record but FIRED — pressing ⌘⇧B into the recorder opened
+ * the kanban board behind the Settings dialog, and ⌘, re-opened Settings.
  *
  * mac carries no CLOSE id: the mac template has no `{role:'close'}` at all (Window ▸ Minimize /
  * Zoom / Front), which is exactly why `keydownIntercept` is ⌘W's only handler there. Kanban and
@@ -321,18 +345,17 @@ export interface KeydownInterceptTarget {
  * not forwarding would still hand the recorder nothing — and forwarding is the live bug, since ⌘W
  * pressed into the recorder deletes the canvas's selected nodes.
  *
- * **What this stand-down does NOT buy, and cannot.** It only stops US from taking the key; it has
- * no say over the application MENU, whose accelerators are handled above the page either way. So
- * every menu accelerator is unrecordable while this stands down — including **⌘M**, which
- * `{role:'minimize'}` owns on every platform, **⌘⇧B** and **⌘,** (View ▸ Toggle Kanban Board and
- * Settings, also every platform), and **Ctrl+W** on Windows/Linux, where the Window submenu has a
- * `{role:'close'}`. Pressing one of those into an armed recorder minimizes/closes the window, opens
- * the board or opens Settings instead of recording. Concretely, the stand-down fully delivers
- * **⌘0** everywhere and
- * **⌘W on macOS** (neither is in the menu), and cannot deliver ⌘M anywhere. Fixing that means
- * suspending the MENU while recording (`Menu.setApplicationMenu(null)` around the armed window, or
- * per-item `enabled:false`) — a change to `buildAppMenu`, not to this module. Known limitation;
- * see the PR body.
+ * **What this stand-down buys on its own, and what the MENU leg adds.** This half only stops US
+ * from taking the key; it has no say over the application MENU, whose accelerators are handled
+ * above the page either way — so by itself it delivers **⌘0** everywhere and **⌘W on macOS**
+ * (neither is in the menu) and nothing else. **The menu now follows recording too**:
+ * `index.ts`'s `syncMenuForStandDown` asks `menuStandsDown(recording, policy, terminalFocused)`
+ * and disables every item in `menuItemIdsToSuspend` while a recorder is armed, so the suspended
+ * items' chords — **⌘M** (`{role:'minimize'}`, every platform), **⌘⇧B** and **⌘,** (View ▸ Toggle
+ * Kanban Board and Settings, every platform) and **Ctrl+W** on Windows/Linux — reach the recorder
+ * instead of minimizing the window, opening the board or opening Settings. **RELOAD (⌘R / ⌘⇧R)
+ * stays unrecordable by design**: it is the app's crash-recovery lever and is deliberately absent
+ * from that list (see `menuItemIdsToSuspend`).
  *
  * `isStoodDown` is the SECOND suspension and the same shape again, but a different fact:
  * `policyStandsDown(policy, terminalFocused)` — the user chose `terminal-first` AND an xterm
@@ -343,18 +366,19 @@ export interface KeydownInterceptTarget {
  * assert. Both are checked BEFORE `preventDefault` for the same reason: a claimed chord never
  * reaches the page at all, and the page is exactly who terminal-first stands down FOR.
  *
- * **The policy stand-down DOES get the menu leg the recording one does not** — the two cases are
- * different and the paragraph above stays true for recording. `index.ts`'s `syncMenuForStandDown`
- * disables every item in `menuItemIdsToSuspend` below — `{role:'minimize'}`, Toggle Kanban Board
- * and Settings on all platforms, plus off-mac `{role:'close'}`, with RELOAD deliberately left out —
- * for exactly as long as `isStoodDown` is true. It has to: not calling
- * `preventDefault` hands the key to the page and, failing that, to the menu, so without the menu
- * leg a terminal-first user's ⌘M would minimize the window and their Ctrl+W — readline's kill-word
- * — would CLOSE it on Windows/Linux, which is strictly worse than not having the policy. With the
- * items disabled the chord completes the trip it was promised: page → the renderer's dispatcher
- * (terminal context, terminal-first, nothing matches) → xterm → the PTY. Recording keeps the
- * limitation because a recorder that greyed out Minimize for the duration of a keypress is a worse
- * trade than an unrecordable ⌘M.
+ * **The menu leg is SHARED by the two suspensions, on the same item list.** `index.ts`'s
+ * `syncMenuForStandDown` disables every item in `menuItemIdsToSuspend` below —
+ * `{role:'minimize'}`, Toggle Kanban Board and Settings on all platforms, plus off-mac
+ * `{role:'close'}`, with RELOAD deliberately left out — for exactly as long as
+ * `menuStandsDown(recording, policy, terminalFocused)` is true. The policy half has to have it:
+ * not calling `preventDefault` hands the key to the page and, failing that, to the menu, so
+ * without the menu leg a terminal-first user's ⌘M would minimize the window and their Ctrl+W —
+ * readline's kill-word — would CLOSE it on Windows/Linux, which is strictly worse than not having
+ * the policy. With the items disabled the chord completes the trip it was promised: page → the
+ * renderer's dispatcher (terminal context, terminal-first, nothing matches) → xterm → the PTY.
+ * The recording half rides the same list for a different destination: page → the armed recorder.
+ * That the ITEM list is shared does not merge the two INTERCEPT thunks — they stay independent
+ * parameters below, and only the menu's single `enabled` boolean composes them.
  *
  * **The stand-down leg cannot be more reliable than the mirror behind it**, and the mirror is a
  * renderer reporting over fire-and-forget IPC. Every uncertainty therefore resolves to NOT stood

--- a/src/renderer/components/settings/ShortcutRecorderButton.tsx
+++ b/src/renderer/components/settings/ShortcutRecorderButton.tsx
@@ -21,10 +21,20 @@
  * because the send would be harmless. One global bit, many instances: an unconditional release
  * would let a sibling unmounting for unrelated reasons clear the armed recorder's bit.
  *
- * **A menu accelerator is still out of reach.** The main-process stand-down only stops nodeterm's
- * own `before-input-event` intercepts; the application menu's accelerators are handled above the
- * page regardless. So ⌘M (Window ▸ Minimize, every platform) and Ctrl+W (Windows/Linux) cannot be
- * recorded here — see the limitation note in `src/main/keydown-intercept.ts`.
+ * **A menu accelerator needs a THIRD mechanism, and it now has one.** The main-process bit above
+ * only stops nodeterm's own `before-input-event` intercepts; the application menu's accelerators
+ * are handled above the page regardless. So main also DISABLES the command-style menu items in
+ * `menuItemIdsToSuspend` while this bit is set (`menuStandsDown` → `syncMenuForStandDown` in
+ * `src/main/index.ts`) — a disabled item suppresses its accelerator, which is what lets ⌘M
+ * (Window ▸ Minimize), ⌘⇧B (Toggle Kanban Board), ⌘, (Settings) and, off-mac, Ctrl+W (Window ▸
+ * Close) reach this component instead of acting. Pressing ⌘⇧B or ⌘, into an armed recorder used to
+ * FIRE — opening the board behind the Settings dialog, or re-opening Settings.
+ *
+ * **What stays out of reach**, deliberately: **Reload** (⌘R / ⌘⇧R) is excluded from that list as
+ * the crash-recovery lever, so it can never be recorded. And the list only covers the items the
+ * policy stand-down needed — the always-on app roles (`quit` ⌘Q, `hide`/`hideOthers`,
+ * `toggleDevTools`, `togglefullscreen`) are NOT suspended, so those chords still act while a
+ * recorder is armed. See `menuItemIdsToSuspend` in `src/main/keydown-intercept.ts`.
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { COMMANDS_BY_ID, normalizeBindingForCommand, type CommandId } from '@shared/keybindings'

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -291,4 +291,34 @@ describe('commitCandidate', () => {
     expect(commitCandidate('canvas.fitAll', 'Cmd+Alt+F', 'add')).toEqual({ ok: true })
     expect(kb()['canvas.fitAll']).toEqual(['Cmd+Alt+G', 'Cmd+Alt+F'])
   })
+
+  // Dictation is its own conflict bucket (Task 1), so NEITHER of the three gates above can see an
+  // overlap with it — the detector is silent by design and the load path deliberately permits one.
+  // These two gates are what makes `conflictBucket`'s "the Settings UI REFUSES to create one" true.
+  it("refuses binding another command onto Dictate's keyed chord, naming Dictate", () => {
+    setKb({ 'speech.dictation': ['Cmd+Alt+D'] })
+    const r = commitCandidate('canvas.fitAll', 'Cmd+Alt+D', 'replace')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('Dictate')
+    expect(kb()['canvas.fitAll']).toBeUndefined()
+  })
+
+  it('refuses a keyed Dictate chord that another command already holds', () => {
+    const r = commitCandidate('speech.dictation', 'Cmd+K', 'replace')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('Command palette')
+    expect(kb()['speech.dictation']).toBeUndefined()
+  })
+
+  // Both gates are keyed-only for free: a hold chord's identity ends in `:(hold)`, which no keyed
+  // identity can equal — so neither direction needs an explicit hold guard.
+  it('a HOLD dictation chord never trips the overlap gates', () => {
+    const r = commitCandidate('speech.dictation', 'Cmd+Ctrl', 'replace')
+    expect(r.ok).toBe(true)
+  })
+
+  it('the default hold chord does not block other commands (keyed-only gate)', () => {
+    const r = commitCandidate('canvas.fitAll', 'Cmd+Alt+F9', 'replace')
+    expect(r.ok).toBe(true)
+  })
 })

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -295,7 +295,12 @@ describe('commitCandidate', () => {
   // Dictation is its own conflict bucket (Task 1), so NEITHER of the three gates above can see an
   // overlap with it — the detector is silent by design and the load path deliberately permits one.
   // These two gates are what makes `conflictBucket`'s "the Settings UI REFUSES to create one" true.
-  it("refuses binding another command onto Dictate's keyed chord, naming Dictate", () => {
+  //
+  // They are SCOPED, and the four tests below are the discriminating matrix: the keyed gesture is
+  // offered only in plain app focus (`globalKeybindings.ts` — `!ctx.typing && !ctx.terminal &&
+  // !ctx.kanbanOpen`), so an 'app'/'canvas'-scope command really does lose the chord most of the
+  // time, while a 'terminal'/'scm'-scope one NEVER competes with it and must stay bindable.
+  it("refuses a canvas-scope command on Dictate's keyed chord, naming Dictate", () => {
     setKb({ 'speech.dictation': ['Cmd+Alt+D'] })
     const r = commitCandidate('canvas.fitAll', 'Cmd+Alt+D', 'replace')
     expect(r.ok).toBe(false)
@@ -303,21 +308,52 @@ describe('commitCandidate', () => {
     expect(kb()['canvas.fitAll']).toBeUndefined()
   })
 
-  it('refuses a keyed Dictate chord that another command already holds', () => {
+  it("refuses an app-scope command on Dictate's keyed chord, naming Dictate", () => {
+    setKb({ 'speech.dictation': ['Cmd+Alt+D'] })
+    const r = commitCandidate('panel.explorer', 'Cmd+Alt+D', 'replace')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('Dictate')
+    expect(kb()['panel.explorer']).toBeUndefined()
+  })
+
+  // The other half of the pair, and the one that reds if gate 1 loses its scope check: Find in
+  // terminal fires only in terminal focus, where the gesture is not offered at all — so this
+  // binding was legal before the branch, works at dispatch, and must stay accepted.
+  it("allows a terminal-scope command on Dictate's keyed chord", () => {
+    setKb({ 'speech.dictation': ['Cmd+Alt+D'] })
+    expect(commitCandidate('terminal.find', 'Cmd+Alt+D', 'replace')).toEqual({ ok: true })
+    expect(kb()['terminal.find']).toEqual(['Cmd+Alt+D'])
+  })
+
+  it('refuses a keyed Dictate chord that a global-bucket command already holds', () => {
     const r = commitCandidate('speech.dictation', 'Cmd+K', 'replace')
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.error).toContain('Command palette')
     expect(kb()['speech.dictation']).toBeUndefined()
   })
 
-  // Both gates are keyed-only for free: a hold chord's identity ends in `:(hold)`, which no keyed
-  // identity can equal — so neither direction needs an explicit hold guard.
-  it('a HOLD dictation chord never trips the overlap gates', () => {
+  // Gate 2's mirror of the same rule, and it reds if the loop stops skipping the two focused
+  // scopes: Find in terminal holds Cmd+F and Commit holds Cmd+Enter, neither of which the keyed
+  // gesture could ever take from them.
+  it('allows a keyed Dictate chord that only a focused-surface command holds', () => {
+    expect(commitCandidate('speech.dictation', 'Cmd+F', 'replace')).toEqual({ ok: true })
+    expect(kb()['speech.dictation']).toEqual(['Cmd+F'])
+    expect(commitCandidate('speech.dictation', 'Cmd+Enter', 'replace')).toEqual({ ok: true })
+    expect(kb()['speech.dictation']).toEqual(['Cmd+Enter'])
+  })
+
+  // DOCUMENTATION OF A PROPERTY, not a guard test — stated honestly because both stay GREEN if the
+  // dictation gates are deleted outright. Nothing can make them red by deletion: a hold chord's
+  // identity ends in `:(hold)` and no keyed identity can equal it, so correct code has no path to
+  // a refusal here. What the second one does discriminate is a mutation of `bindingIdentity`
+  // itself — drop the key segment and the default `Cmd+Alt` hold chord starts swallowing every
+  // Cmd+Alt+<key> candidate.
+  it('documents that a HOLD dictation chord cannot trip the overlap gates', () => {
     const r = commitCandidate('speech.dictation', 'Cmd+Ctrl', 'replace')
     expect(r.ok).toBe(true)
   })
 
-  it('the default hold chord does not block other commands (keyed-only gate)', () => {
+  it('documents that the default hold chord blocks no keyed candidate', () => {
     const r = commitCandidate('canvas.fitAll', 'Cmd+Alt+F9', 'replace')
     expect(r.ok).toBe(true)
   })

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -13,7 +13,9 @@
  *   3. `findMainInterceptShadowing` — a CROSS-bucket hit the conflict check cannot see.
  *   4. REVERSE shadowing — the same collision seen from the non-intercepted side.
  *   5. The two DICTATION overlap gates — the one overlap `conflictBucket` deliberately does not
- *      report, refused here in both directions (see the block itself for why).
+ *      report, refused here in both directions, but only for `app`/`canvas`-scope commands: the
+ *      keyed gesture has a focus gate, so a terminal- or scm-scope command never competes with it
+ *      (see the block itself for why).
  * (2) returns early, so a candidate that trips both detectors (a main-intercepted command taking
  * a chord another GLOBAL command already holds — `node.close` ← `Cmd+K`) produces exactly ONE
  * message. The shadow message is reserved for what only it can see: `node.close` ← `Cmd+F`, where
@@ -131,6 +133,9 @@ export function commitCandidate(
   const existing = effectiveBindings(id)
   const nextList = mode === 'add' ? [...existing.filter((b) => b !== combo), combo] : [combo]
   const chord = formatShortcut(combo, isMac)
+  // The candidate's platform identity, computed ONCE: the reverse-shadow block and both dictation
+  // gates all ask the same question of it, and three copies of one call is three chances to drift.
+  const identity = bindingIdentity(combo, isMac)
 
   const conflicts = findKeybindingConflicts({ ...current, [id]: nextList }, isMac).filter((c) =>
     c.commandIds.includes(id)
@@ -159,9 +164,8 @@ export function commitCandidate(
   // every check and produced a permanently dead shortcut with no warning — main swallows the chord
   // in `before-input-event` and the terminal surface is never offered it.
   if (!MAIN_INTERCEPTED_COMMAND_IDS.includes(id)) {
-    const target = bindingIdentity(combo, isMac)
     for (const cid of MAIN_INTERCEPTED_COMMAND_IDS) {
-      const hit = effectiveBindings(cid).some((b) => bindingIdentity(b, isMac) === target)
+      const hit = effectiveBindings(cid).some((b) => bindingIdentity(b, isMac) === identity)
       if (!hit) continue
       const title = COMMANDS_BY_ID.get(cid)?.title ?? cid
       const own = COMMANDS_BY_ID.get(id)?.title ?? id
@@ -183,13 +187,20 @@ export function commitCandidate(
   // Both gates are keyed-only WITHOUT an explicit hold guard: `bindingIdentity` renders a
   // modifier-only chord as `…:(hold)`, which no keyed identity can ever equal — so the default
   // `Cmd+Alt` hold chord blocks nothing, and a hold candidate trips nothing.
+  //
+  // Both are also SCOPED to `app`/`canvas`, because the gesture has a FOCUS GATE: the keyed
+  // dictation listener runs only in plain app focus (`dispatchGlobalKeydown` in
+  // `renderer/lib/globalKeybindings.ts` — `!ctx.typing && !ctx.terminal && !ctx.kanbanOpen`). A
+  // `terminal`- or `scm`-scope command dispatches ONLY where that gate is already shut, so it
+  // never competes with dictation for its chord; refusing the overlap would forbid a binding that
+  // was legal before this branch and still works at dispatch (⌘⌥D on Find in terminal, say).
   const dictationId: CommandId = 'speech.dictation'
   const dictationTitle = COMMANDS_BY_ID.get(dictationId)?.title ?? dictationId
-  const identity = bindingIdentity(combo, isMac)
-  if (id !== dictationId) {
+  const candidateScope = COMMANDS_BY_ID.get(id)?.scope
+  if (id !== dictationId && (candidateScope === 'app' || candidateScope === 'canvas')) {
     // "rarely", not "never": dictation's keyed listener only claims the chord where it listens.
-    // In terminal or typing focus the gesture is not offered and this command CAN still fire —
-    // the message must not overclaim a chord that is merely usually lost.
+    // An app-scope command flagged `allowInTerminal` still fires in terminal focus under
+    // app-first — the message must not overclaim a chord that is merely usually lost.
     const taken = effectiveBindings(dictationId).some((b) => bindingIdentity(b, isMac) === identity)
     if (taken) {
       const own = COMMANDS_BY_ID.get(id)?.title ?? id
@@ -198,9 +209,12 @@ export function commitCandidate(
         error: `${chord} is used by ${dictationTitle}, which claims it first; it would rarely reach ${own}.`
       }
     }
-  } else {
+  } else if (id === dictationId) {
     for (const def of COMMAND_DEFINITIONS) {
       if (def.id === dictationId) continue
+      // The same focus gate, read from the other side: a focused-surface command cannot be hidden
+      // by a gesture that is never offered on that surface.
+      if (def.scope === 'terminal' || def.scope === 'scm') continue
       const hit = effectiveBindings(def.id).some((b) => bindingIdentity(b, isMac) === identity)
       if (!hit) continue
       return {
@@ -286,7 +300,10 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
       // items in `menuItemIdsToSuspend` (Minimize, Toggle Kanban Board, Settings, off-mac Close),
       // so those chords reach the recorder — but RELOAD is deliberately never suspended, because it
       // is the crash-recovery lever. See `src/main/keydown-intercept.ts`.
-      description="Remap any command. Overrides are stored in settings.json under `keybindings`; Disable turns a command's shortcut off, Reset restores its default. Reload (⌘R / ⌘⇧R) cannot be recorded — it always stays with the app."
+      // The residual clause is the KNOWN GAP `menuItemIdsToSuspend` documents: one list drives
+      // both stand-downs, so the always-on app roles are deliberately left unsuspended and still
+      // act while recording. The ruling stands; the user is simply told.
+      description="Remap any command. Overrides are stored in settings.json under `keybindings`; Disable turns a command's shortcut off, Reset restores its default. Reload (⌘R / ⌘⇧R) cannot be recorded — it always stays with the app; the system-level chords the menu keeps — ⌘Q (Quit), ⌘H (Hide) and the developer roles — also act while recording, so don't try to bind them."
       isActive={isActive}
       searchEntries={entries}
     >

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -281,11 +281,12 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
     <SettingsSection
       id="shortcuts"
       title="Keyboard Shortcuts"
-      // The limitation is the application MENU's, not macOS's: its accelerators are handled above
-      // the page on every platform, so the main-process stand-down cannot deliver them to the
-      // recorder. Minimize is in the menu everywhere; Close only on Windows/Linux (the mac
-      // template has no {role:'close'}) — see `src/main/keydown-intercept.ts`.
-      description="Remap any command. Overrides are stored in settings.json under `keybindings`; Disable turns a command's shortcut off, Reset restores its default. The application menu owns Minimize (⌘M / Ctrl+M) and, on Windows/Linux, Close (Ctrl+W); those chords cannot be recorded here."
+      // The one remaining limitation is the application MENU's, not macOS's: its accelerators are
+      // handled above the page on every platform. While a recorder is armed main now suspends the
+      // items in `menuItemIdsToSuspend` (Minimize, Toggle Kanban Board, Settings, off-mac Close),
+      // so those chords reach the recorder — but RELOAD is deliberately never suspended, because it
+      // is the crash-recovery lever. See `src/main/keydown-intercept.ts`.
+      description="Remap any command. Overrides are stored in settings.json under `keybindings`; Disable turns a command's shortcut off, Reset restores its default. Reload (⌘R / ⌘⇧R) cannot be recorded — it always stays with the app."
       isActive={isActive}
       searchEntries={entries}
     >

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -6,11 +6,14 @@
  * Design D3 is "same detector, different surfacing": `sanitizeKeybindingOverrides` applies what
  * survives on LOAD, while this section refuses a bad candidate BEFORE anything is written, so the
  * user learns which chord was refused and why instead of watching a saved shortcut disappear on
- * the next launch. Three checks, in this order, and the order is the whole dedupe:
+ * the next launch. The checks run in this order, and the order is the whole dedupe:
  *   1. `normalizeBindingForCommand` — already inside `ShortcutRecorderButton`, so an invalid chord
  *      never reaches `onCommit` (its own hint is shown in the recorder button itself).
  *   2. `findKeybindingConflicts` over the candidate map — a same-bucket collision.
  *   3. `findMainInterceptShadowing` — a CROSS-bucket hit the conflict check cannot see.
+ *   4. REVERSE shadowing — the same collision seen from the non-intercepted side.
+ *   5. The two DICTATION overlap gates — the one overlap `conflictBucket` deliberately does not
+ *      report, refused here in both directions (see the block itself for why).
  * (2) returns early, so a candidate that trips both detectors (a main-intercepted command taking
  * a chord another GLOBAL command already holds — `node.close` ← `Cmd+K`) produces exactly ONE
  * message. The shadow message is reserved for what only it can see: `node.close` ← `Cmd+F`, where
@@ -58,7 +61,7 @@ const NOTES: Partial<Record<CommandId, string>> = {
   // Reused verbatim from the old SpeechSection row: the mode is derived from the chord's SHAPE,
   // which is not guessable from a chip.
   'speech.dictation':
-    'With a key = toggle (press to start, press again to stop and insert); modifiers only = hold to talk (hold to record, release to stop and insert). The Dock mic uses the same shortcut.',
+    'With a key = toggle (press to start, press again to stop and insert); modifiers only = hold to talk (hold to record, release to stop and insert). The Dock mic uses the same shortcut. A keyed dictation chord is claimed before any other shortcut while the canvas has focus.',
   'canvas.deleteSelection': 'Bare keys are allowed here; the typing guard keeps Backspace safe.',
   'terminal.copySelection': 'Applies to a selection xterm owns — a tmux drag copies through OSC 52.'
 }
@@ -165,6 +168,44 @@ export function commitCandidate(
       return {
         ok: false,
         error: `${chord} is intercepted app-wide for ${title}; it would never reach ${own}.`
+      }
+    }
+  }
+
+  // DICTATION OVERLAP, both directions. `speech.dictation` is its own conflict bucket (see
+  // `conflictBucket` in @shared/keybindings), so gate (2) above is silent about it BY DESIGN —
+  // dictation never competes at dispatch, it PRE-EMPTS: the resolver skips it and its own keyed
+  // listener claims the chord first while the canvas has focus. That is precedence, not ambiguity,
+  // which is why the LOAD path permits an overlap (legacy files contain them, and dropping a user's
+  // chord is the failure that bucket closes) while a chord a user picks HERE is refused instead:
+  // an interactive pick deserves to be told about the precedence, not to discover it later.
+  //
+  // Both gates are keyed-only WITHOUT an explicit hold guard: `bindingIdentity` renders a
+  // modifier-only chord as `…:(hold)`, which no keyed identity can ever equal — so the default
+  // `Cmd+Alt` hold chord blocks nothing, and a hold candidate trips nothing.
+  const dictationId: CommandId = 'speech.dictation'
+  const dictationTitle = COMMANDS_BY_ID.get(dictationId)?.title ?? dictationId
+  const identity = bindingIdentity(combo, isMac)
+  if (id !== dictationId) {
+    // "rarely", not "never": dictation's keyed listener only claims the chord where it listens.
+    // In terminal or typing focus the gesture is not offered and this command CAN still fire —
+    // the message must not overclaim a chord that is merely usually lost.
+    const taken = effectiveBindings(dictationId).some((b) => bindingIdentity(b, isMac) === identity)
+    if (taken) {
+      const own = COMMANDS_BY_ID.get(id)?.title ?? id
+      return {
+        ok: false,
+        error: `${chord} is used by ${dictationTitle}, which claims it first; it would rarely reach ${own}.`
+      }
+    }
+  } else {
+    for (const def of COMMAND_DEFINITIONS) {
+      if (def.id === dictationId) continue
+      const hit = effectiveBindings(def.id).some((b) => bindingIdentity(b, isMac) === identity)
+      if (!hit) continue
+      return {
+        ok: false,
+        error: `${chord} is already used by ${def.title}; ${dictationTitle} would claim it first and hide it.`
       }
     }
   }

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -500,6 +500,8 @@ describe('dictation conflict bucket', () => {
     })
     expect(r.warnings).toEqual([])
   })
+  // Dictation is now OUTSIDE `includeDefaults`' reach: a future default colliding with its
+  // `Cmd+Alt` would not be caught here.
   it('the shipped defaults stay conflict-free under full scrutiny (unchanged invariant)', () => {
     expect(findKeybindingConflicts({}, true, { includeDefaults: true })).toEqual([])
     expect(findKeybindingConflicts({}, false, { includeDefaults: true })).toEqual([])

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeBindingForCommand,
   getEffectiveBindings,
   bindingIdentity,
+  conflictBucket,
   findKeybindingConflicts,
   sanitizeKeybindingOverrides,
   resolveCommandForKeyEvent,
@@ -193,6 +194,25 @@ describe('bindingIdentity', () => {
   it('still separates a modifier from a bare key, and a hold chord from a keyed one', () => {
     expect(bindingIdentity('Cmd+Delete', true)).not.toBe(bindingIdentity('Delete', true))
     expect(bindingIdentity('Cmd+Alt', true)).not.toBe(bindingIdentity('Cmd+Alt+D', true))
+  })
+})
+
+describe('conflictBucket', () => {
+  // The whole mapping, asserted over the REGISTRY rather than a hand-picked example per bucket:
+  // 'app' and 'canvas' share the global keyspace, 'terminal' and 'scm' are their own, and
+  // `speech.dictation` is the one command whose bucket comes from its id instead of its scope.
+  // Kills two mutants a per-bucket sample can miss: a scope-mapping typo (folding 'scm' — or a
+  // scope added later — into 'global', or dropping 'canvas' out of it), and the removal of the
+  // dictation branch, which would send Dictate back into 'global' and re-report the collision
+  // the bucket exists to stop.
+  it('maps every command to its scope bucket, dictation excepted', () => {
+    for (const def of COMMAND_DEFINITIONS) {
+      if (def.id === 'speech.dictation') continue
+      expect(conflictBucket(def)).toBe(
+        def.scope === 'app' || def.scope === 'canvas' ? 'global' : def.scope
+      )
+    }
+    expect(conflictBucket(COMMANDS_BY_ID.get('speech.dictation')!)).toBe('dictation')
   })
 })
 

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -480,3 +480,28 @@ describe('resolver under terminal-first', () => {
       .toBe('app.commandPalette')
   })
 })
+
+describe('dictation conflict bucket', () => {
+  it("a dictation override sharing another command's chord is NOT a conflict", () => {
+    expect(findKeybindingConflicts({ 'speech.dictation': ['Cmd+K'] }, true)).toEqual([])
+  })
+  it('sanitize keeps a colliding dictation override — the migration survival case', () => {
+    const r = sanitizeKeybindingOverrides({ 'speech.dictation': ['Cmd+K'] }, true)
+    expect(r).toEqual({ overrides: { 'speech.dictation': ['Cmd+K'] }, warnings: [] })
+  })
+  it("sanitize keeps BOTH sides when a user override shares dictation's chord", () => {
+    const r = sanitizeKeybindingOverrides(
+      { 'speech.dictation': ['Cmd+J'], 'app.commandPalette': ['Cmd+J'] },
+      true
+    )
+    expect(r.overrides).toEqual({
+      'speech.dictation': ['Cmd+J'],
+      'app.commandPalette': ['Cmd+J']
+    })
+    expect(r.warnings).toEqual([])
+  })
+  it('the shipped defaults stay conflict-free under full scrutiny (unchanged invariant)', () => {
+    expect(findKeybindingConflicts({}, true, { includeDefaults: true })).toEqual([])
+    expect(findKeybindingConflicts({}, false, { includeDefaults: true })).toEqual([])
+  })
+})

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -239,8 +239,13 @@ export function bindingIdentity(binding: string, isMac: boolean): string {
  *
  *  **Overlap policy is deliberately asymmetric.** The LOAD path PERMITS a shared chord — legacy
  *  settings.json files already contain them and silently dropping a user's chord is the failure
- *  this closes. The Settings UI REFUSES to create one, because a user picking a chord interactively
- *  should be told about the precedence rather than discover it later. */
+ *  this closes. The Settings UI REFUSES to create one (`commitCandidate`'s two dictation gates),
+ *  because a user picking a chord interactively should be told about the precedence rather than
+ *  discover it later. One case the permissive load path cannot rescue: a keyed dictation override
+ *  on a MAIN-INTERCEPTED chord (⌘W / ⌘M) wins NOWHERE — main steals those in `before-input-event`
+ *  before the page exists, so such a hand-edit survives sanitization as a permanently dead chord.
+ *  The UI can never create it (`commitCandidate`'s reverse-shadow gate refuses it one step earlier
+ *  than the dictation gates). */
 export function conflictBucket(
   def: Pick<CommandDefinition, 'id' | 'scope'>
 ): 'global' | 'terminal' | 'scm' | 'dictation' {

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -328,9 +328,9 @@ export function findMainInterceptShadowing(
  *  Loops until conflict-free so one bad edit cannot leave ambiguous dispatch. This is the
  *  SETTINGS-LOAD path: it applies what survives and warns about what it dropped. It is not the
  *  pre-save gate — its warnings are unstructured strings, which cannot tell a UI which field to
- *  block on. The future Settings UI blocks pre-save by calling `normalizeBindingForCommand` and
- *  `findKeybindingConflicts` directly, per candidate binding: same detector, different surfacing
- *  (design.md D3). */
+ *  block on. The Settings UI blocks pre-save in `ShortcutsSection.commitCandidate`, which runs
+ *  `normalizeBindingForCommand` (inside its recorder) and `findKeybindingConflicts` directly, per
+ *  candidate binding: same detector, different surfacing (design.md D3). */
 export function sanitizeKeybindingOverrides(
   raw: unknown,
   isMac: boolean

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -220,9 +220,32 @@ export function bindingIdentity(binding: string, isMac: boolean): string {
 
 /** Commands sharing a bucket compete for the same keys. 'app' and 'canvas' share one global
  *  keyspace (both dispatch from the window listener; canvas commands are merely inert while
- *  the board is open); terminal and scm are their own focused surfaces. */
-export function conflictBucket(scope: CommandScope): 'global' | 'terminal' | 'scm' {
-  return scope === 'app' || scope === 'canvas' ? 'global' : scope
+ *  the board is open); terminal and scm are their own focused surfaces.
+ *
+ *  **`speech.dictation` is its own fourth bucket, and the reason is dispatch, not scope.** It
+ *  never competes for a chord: the resolver SKIPS it outright (see the `def.id ===
+ *  'speech.dictation'` guard in `resolveCommandForKeyEvent`), and its keyed gesture runs from a
+ *  dedicated listener that claims the chord FIRST in plain app focus. So a chord shared with
+ *  another command is a matter of PRECEDENCE — dictation wins where it listens, the other command
+ *  wins everywhere else (terminal focus, say) — never ambiguity, which is the only thing the
+ *  conflict detector exists to find. Folding it into 'global' therefore reported a collision that
+ *  dispatch cannot produce.
+ *
+ *  What the bucket BUYS is survival on the read path: `sanitizeKeybindingOverrides` deletes every
+ *  overridden participant of a reported conflict, so a migrated legacy chord that happened to match
+ *  another command's binding (the `speech.shortcut` → `speech.dictation` seed in
+ *  `core/settings-store.ts`) was seeded on load and stripped moments later, taking the user's own
+ *  colliding override with it. With its own bucket the seed survives.
+ *
+ *  **Overlap policy is deliberately asymmetric.** The LOAD path PERMITS a shared chord — legacy
+ *  settings.json files already contain them and silently dropping a user's chord is the failure
+ *  this closes. The Settings UI REFUSES to create one, because a user picking a chord interactively
+ *  should be told about the precedence rather than discover it later. */
+export function conflictBucket(
+  def: Pick<CommandDefinition, 'id' | 'scope'>
+): 'global' | 'terminal' | 'scm' | 'dictation' {
+  if (def.id === 'speech.dictation') return 'dictation'
+  return def.scope === 'app' || def.scope === 'canvas' ? 'global' : def.scope
 }
 
 export interface KeybindingConflict {
@@ -244,7 +267,7 @@ export function findKeybindingConflicts(
   const byBucketAndIdentity = new Map<string, { binding: string; ids: Set<CommandId> }>()
   for (const def of COMMAND_DEFINITIONS) {
     for (const binding of getEffectiveBindings(def.id, overrides, isMac)) {
-      const key = `${conflictBucket(def.scope)} ${bindingIdentity(binding, isMac)}`
+      const key = `${conflictBucket(def)} ${bindingIdentity(binding, isMac)}`
       const entry = byBucketAndIdentity.get(key) ?? {
         // Canonicalized, so a hand-edited `cmd+k` override is reported as `Cmd+K`.
         binding: serializeShortcut(parseShortcut(binding)),


### PR DESCRIPTION
Closes the two follow-ups filed by the remappable-shortcuts series (#311/#316/#322/#329).

### Dictation gets its own conflict bucket

The measured migration hole from #322: a legacy custom dictation chord that collided with another command's binding in the same bucket (e.g. `Cmd+K`) was seeded and then STRIPPED by the read-path sanitizer — dictation silently reverted to the default, and a colliding hand-set override could be dropped with it. Now `speech.dictation` lives in its own conflict bucket:

- A legacy `speech.shortcut: "Cmd+K"` settings.json migrates intact, end-to-end (pinned by a test that runs the real seed AND the real sanitizer).
- The load path stays permissive (legacy files must survive); the Settings UI refuses creating NEW overlaps in both directions with named errors — but only where dictation genuinely competes: the keyed gesture claims chords in plain app focus only, so binding a terminal- or scm-scope command onto dictation's chord remains legal and works.
- Dispatch is unchanged: a shared keyed chord goes to dictation first on the canvas (the pre-migration behavior), to the other command elsewhere.

### The menu stands down while a recorder is armed

Recording ⌘M minimized the window; ⌘⇧B opened the kanban board and ⌘, opened Settings mid-recording (a misfire since the settings UI shipped); Ctrl+W on Windows/Linux closed the window. Now the same menu items the terminal-first policy suspends (`menuStandsDown = recording || policyStandsDown(...)`) are disabled while a recorder is armed — those chords reach the recorder. Reload (⌘R/⌘⇧R) stays the deliberate exception (crash-recovery lever). What the change buys is delivery to the recorder: binding a chord to another command is still refused while its current owner holds it.

**Known gap (documented, ruled not-suspended):** system-level roles the menu keeps — ⌘Q Quit, ⌘H Hide, dev/fullscreen — still act while recording; suspending them would also remove them under terminal-first, which is the wrong trade for Quit/Hide. The Shortcuts section's copy warns about it.

Non-recording, non-dictation behavior is byte-identical (pinned: `menuStandsDown(false, …)` equals the policy stand-down over the whole matrix; `conflictBucket` unchanged for all 20 other commands by an enumerated test).

Docs aligned in the same commits (CLAUDE.md invariants incl. the dictation bucket; CONTRIBUTING.md's stale default-menu claim corrected). Mac verification owed: arm a recorder and press ⌘M/⌘⇧B/⌘, (Ctrl+W on Win/Linux) — each should show in the recorder; a legacy `Cmd+K` dictation settings.json should survive a full launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)