### PR TITLE
feat(codex): per-account usage aggregation, fail-closed

### DIFF
--- a/src/core/usage/codex-usage.test.ts
+++ b/src/core/usage/codex-usage.test.ts
@@ -1,9 +1,23 @@
-import { describe, it, expect } from 'vitest'
-import { mapCodexWindow, mapCodexLimits, readCodexAuth, codexHome } from './codex-usage'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  mapCodexWindow,
+  mapCodexLimits,
+  readCodexAuth,
+  codexHome,
+  fetchCodexUsage
+} from './codex-usage'
 import { primaryLimit, limitShortLabel } from '../../shared/usage-limits'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+
+// The app-server tier spawns the real `codex` binary; force it to decline instantly so the
+// identity-stamping tests below are hermetic (they exercise the backend + unavailable paths only).
+vi.mock('child_process', () => ({
+  spawn: () => {
+    throw new Error('app-server disabled in test')
+  }
+}))
 
 /**
  * The ChatGPT backend's `wham/usage` rate_limit block, matching Codex's own
@@ -144,6 +158,60 @@ describe('readCodexAuth', () => {
     await expect(readCodexAuth(dir)).resolves.toEqual({ accessToken: null, accountId: null })
     fs.writeFileSync(path.join(dir, 'auth.json'), 'not json')
     await expect(readCodexAuth(dir)).resolves.toEqual({ accessToken: null, accountId: null })
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+describe('fetchCodexUsage account identity', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function authHome(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-id-'))
+    fs.writeFileSync(
+      path.join(dir, 'auth.json'),
+      JSON.stringify({ tokens: { access_token: 'tok', account_id: 'chatgpt-xyz' } })
+    )
+    return dir
+  }
+
+  it('stamps the account identity on the backend (ok) row', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ plan_type: 'pro', rate_limit: BACKEND_RATE_LIMIT })
+      }))
+    )
+    const dir = authHome()
+    const row = await fetchCodexUsage(dir, { id: 'acc-1', label: 'Work', email: 'work@example.com' })
+    expect(row.status).toBe('ok')
+    // The row read from THIS account's home is attributed to THIS account, never left un-owned.
+    expect(row.accountId).toBe('acc-1')
+    expect(row.account).toBe('work@example.com')
+    expect(row.limits.length).toBeGreaterThan(0)
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('stamps the account identity even on the unavailable row (no auth, both tiers decline)', async () => {
+    // No auth.json ⇒ the backend tier returns null without a request; the app-server tier is
+    // stubbed to throw ⇒ 'unavailable'. The empty row must still fail closed to THIS account.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-noauth-'))
+    const row = await fetchCodexUsage(dir, { id: 'acc-2', label: 'Personal', email: 'me@example.com' })
+    expect(row.status).toBe('unavailable')
+    expect(row.limits).toEqual([])
+    expect(row.accountId).toBe('acc-2')
+    expect(row.account).toBe('me@example.com')
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('leaves the system row un-owned when no identity is given', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-sys-'))
+    const row = await fetchCodexUsage(dir)
+    expect(row.status).toBe('unavailable')
+    expect(row.accountId).toBeUndefined()
+    expect(row.account).toBeNull()
     fs.rmSync(dir, { recursive: true, force: true })
   })
 })

--- a/src/core/usage/codex-usage.ts
+++ b/src/core/usage/codex-usage.ts
@@ -106,8 +106,13 @@ export function mapCodexLimits(rateLimit: unknown): UsageLimit[] {
   ].filter((l): l is UsageLimit => l !== null)
 }
 
-function snapshot(limits: UsageLimit[], status: ProviderUsage['status']): ProviderUsage {
-  return { provider: 'codex', limits, account: null, updatedAt: Date.now(), status }
+function snapshot(
+  limits: UsageLimit[],
+  status: ProviderUsage['status'],
+  account: string | null = null,
+  accountId?: string
+): ProviderUsage {
+  return { provider: 'codex', limits, account, accountId, updatedAt: Date.now(), status }
 }
 
 /** Tier 1: the endpoint the Codex CLI itself reads. */
@@ -225,21 +230,35 @@ async function fetchViaAppServer(home: string): Promise<ProviderUsage | null> {
  *
  * Never rejects: an unreachable backend and a missing CLI are both "we don't know", and the
  * caller renders that as no data rather than an error the user can't act on.
+ *
+ * `identity` scopes the row to one managed account (S6 §4.3): its `id` is stamped as `accountId`
+ * on EVERY return path — including `unavailable` — so a row read from account A's home is always
+ * attributed to A and can never be mixed with, or mistaken for, another account or the un-owned
+ * system row. Absent ⇒ the system account: `account: null`, `accountId: undefined` (un-owned stays
+ * explicitly un-owned). The id is never used to build a path here — the caller already resolved
+ * `home` from it through the validated account-home builders — so no id validation is duplicated.
  */
-export async function fetchCodexUsage(home = codexHome()): Promise<ProviderUsage> {
+export async function fetchCodexUsage(
+  home = codexHome(),
+  identity?: { id?: string; label?: string | null; email?: string | null }
+): Promise<ProviderUsage> {
+  const account = identity?.email || identity?.label || null
+  const accountId = identity?.id
   try {
     const viaBackend = await fetchViaBackend(home)
-    if (viaBackend) return viaBackend
+    if (viaBackend) return { ...viaBackend, account, accountId }
   } catch {
     // fall through to the app-server tier
   }
   try {
     const viaAppServer = await fetchViaAppServer(home)
-    if (viaAppServer) return viaAppServer
+    if (viaAppServer) return { ...viaAppServer, account, accountId }
   } catch {
     // fall through to 'unavailable'
   }
   // Not signed in, no CLI, or both transports declined — nothing to show, same as Claude on
-  // API-key billing. 'unavailable' hides the provider rather than showing a broken row.
-  return snapshot([], 'unavailable')
+  // API-key billing. 'unavailable' hides the provider rather than showing a broken row. Still
+  // stamped with this account's identity so an empty read fails closed to THIS account, never to
+  // a fabricated one or another account's numbers.
+  return snapshot([], 'unavailable', account, accountId)
 }

--- a/src/core/usage/usage-service.codex-accounts.test.ts
+++ b/src/core/usage/usage-service.codex-accounts.test.ts
@@ -1,0 +1,172 @@
+// Per-account Codex usage aggregation (S6 §4.3, Property 9): each managed account's usage is
+// fetched against its OWN home and stamped with its OWN accountId, and the rows are NEVER merged
+// or de-duplicated in the service — so one account's numbers can never collapse into, or be
+// attributed to, another. Ambiguity / a read error fails closed to an EMPTY row for that account,
+// never a fabricated account and never another account's numbers.
+//
+// fetchCodexUsage is mocked so these tests exercise the SERVICE's fan-out, keying and cache
+// fingerprint — not the HTTP/app-server transports (those are covered in codex-usage.test.ts).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IPC } from '../../shared/ipc'
+import type { ProviderUsage } from '../../shared/types'
+import { initPlatform, resetPlatformForTests } from '../platform'
+import { fakePlatform, type FakePlatform } from '../platform-fake'
+
+const { fetchCodexUsage } = vi.hoisted(() => ({
+  fetchCodexUsage: vi.fn(
+    async (
+      home?: string,
+      identity?: { id?: string; label?: string | null; email?: string | null }
+    ): Promise<ProviderUsage> => ({
+      provider: 'codex',
+      accountId: identity?.id,
+      account: identity?.email ?? identity?.label ?? null,
+      limits: [],
+      updatedAt: Date.now(),
+      status: 'ok'
+    })
+  )
+}))
+
+vi.mock('./codex-usage', () => ({ fetchCodexUsage }))
+vi.mock('./gemini-usage', () => ({ fetchGeminiUsage: async () => unavailableRow('gemini') }))
+vi.mock('./grok-usage', () => ({ fetchGrokUsage: async () => unavailableRow('grok') }))
+vi.mock('./kimi-usage', () => ({ fetchKimiUsage: async () => unavailableRow('kimi') }))
+vi.mock('./minimax-usage', () => ({ fetchMinimaxUsage: async () => unavailableRow('minimax') }))
+vi.mock('./opencode-usage', () => ({ fetchOpencodeUsage: async () => unavailableRow('opencode') }))
+
+import { startUsageService, type UsageService } from './usage-service'
+
+function unavailableRow(provider: string): ProviderUsage {
+  return { provider, account: null, limits: [], updatedAt: 0, status: 'unavailable' }
+}
+
+function codexRows(rows: ProviderUsage[]): ProviderUsage[] {
+  return rows.filter((row) => row.provider === 'codex')
+}
+
+let platform: FakePlatform
+let service: UsageService | undefined
+
+beforeEach(() => {
+  resetPlatformForTests()
+  platform = fakePlatform()
+  initPlatform(platform)
+  fetchCodexUsage.mockClear()
+})
+
+afterEach(() => {
+  service?.dispose()
+  service = undefined
+  resetPlatformForTests()
+})
+
+describe('Codex multi-account usage', () => {
+  it('returns the system identity and two managed account rows independently', async () => {
+    const accounts = [
+      { id: 'a', home: '/isolated/a', label: 'Work', email: 'work@example.com' },
+      { id: 'b', home: '/isolated/b', label: 'Personal', email: 'me@example.com' }
+    ]
+    service = startUsageService({ shouldPoll: () => false, codexAccounts: () => accounts })
+
+    const rows = (await platform.handlers[IPC.usageProviders]()) as ProviderUsage[]
+    // System row first (un-owned ⇒ accountId undefined), then one row per account keyed by its
+    // own id — three DISTINCT rows, never merged into one.
+    expect(codexRows(rows).map((row) => row.accountId)).toEqual([undefined, 'a', 'b'])
+    // Each managed account is read against its OWN home + identity — never the system home.
+    expect(fetchCodexUsage).toHaveBeenNthCalledWith(1)
+    expect(fetchCodexUsage).toHaveBeenNthCalledWith(2, '/isolated/a', accounts[0])
+    expect(fetchCodexUsage).toHaveBeenNthCalledWith(3, '/isolated/b', accounts[1])
+  })
+
+  it('invalidates the provider cache when an account is added', async () => {
+    let accounts = [{ id: 'a', home: '/isolated/a', label: 'Work' }]
+    service = startUsageService({ shouldPoll: () => false, codexAccounts: () => accounts })
+
+    await platform.handlers[IPC.usageProviders]()
+    // First sweep: system + account a.
+    expect(fetchCodexUsage).toHaveBeenCalledTimes(2)
+
+    // Adding an account changes the fingerprint, which must bust the debounce cache — otherwise
+    // the popover would keep serving the two-row snapshot and the new account would never appear.
+    accounts = [...accounts, { id: 'b', home: '/isolated/b', label: 'Personal' }]
+    const rows = (await platform.handlers[IPC.usageProviders]()) as ProviderUsage[]
+    expect(codexRows(rows).map((row) => row.accountId)).toEqual([undefined, 'a', 'b'])
+    // 2 (first sweep) + 3 (second sweep after the bust) = 5. A stale cache would leave this at 2.
+    expect(fetchCodexUsage).toHaveBeenCalledTimes(5)
+  })
+
+  it('serves the cache within the debounce while the account set is unchanged', async () => {
+    const accounts = [{ id: 'a', home: '/isolated/a', label: 'Work' }]
+    service = startUsageService({ shouldPoll: () => false, codexAccounts: () => accounts })
+
+    await platform.handlers[IPC.usageProviders]()
+    await platform.handlers[IPC.usageProviders]()
+    // Same fingerprint ⇒ the second call is served from cache, not a re-fetch (2 + 2 would mean
+    // the fingerprint check wrongly busts an unchanged set).
+    expect(fetchCodexUsage).toHaveBeenCalledTimes(2)
+  })
+
+  it('a throwing codexAccounts() yields system-only, never a fabricated account', async () => {
+    service = startUsageService({
+      shouldPoll: () => false,
+      codexAccounts: () => {
+        throw new Error('settings read blew up')
+      }
+    })
+
+    const rows = (await platform.handlers[IPC.usageProviders]()) as ProviderUsage[]
+    // Fail closed: only the un-owned system row, no guessed / invented account.
+    expect(codexRows(rows).map((row) => row.accountId)).toEqual([undefined])
+    expect(fetchCodexUsage).toHaveBeenCalledTimes(1)
+    expect(fetchCodexUsage).toHaveBeenNthCalledWith(1)
+  })
+
+  it('a read error for one account stays empty for THAT account — never another account’s numbers', async () => {
+    const accounts = [
+      { id: 'a', home: '/isolated/a', label: 'Work' },
+      { id: 'b', home: '/isolated/b', label: 'Personal' }
+    ]
+    // Account a's read throws; account b returns real limits. The failure must fail closed to an
+    // EMPTY row keyed to a — never adopt b's numbers and never drop a's id (which would fold it
+    // into the un-owned system row).
+    fetchCodexUsage.mockImplementation(async (home?: string, identity?: { id?: string }) => {
+      if (identity?.id === 'a') throw new Error('auth.json unreadable')
+      if (identity?.id === 'b') {
+        return {
+          provider: 'codex',
+          accountId: 'b',
+          account: null,
+          limits: [
+            {
+              kind: 'session',
+              group: 'session',
+              usedPercent: 42,
+              severity: null,
+              resetsAt: null,
+              windowMinutes: 300,
+              scopeLabel: null,
+              isActive: false
+            }
+          ],
+          updatedAt: Date.now(),
+          status: 'ok' as const
+        }
+      }
+      return unavailableRow('codex')
+    })
+    service = startUsageService({ shouldPoll: () => false, codexAccounts: () => accounts })
+
+    const rows = codexRows((await platform.handlers[IPC.usageProviders]()) as ProviderUsage[])
+    const rowA = rows.find((r) => r.accountId === 'a')
+    const rowB = rows.find((r) => r.accountId === 'b')
+
+    expect(rowA).toBeDefined()
+    expect(rowA?.status).toBe('error')
+    expect(rowA?.limits).toEqual([]) // empty, NOT b's [42%] window
+    expect(rowB?.status).toBe('ok')
+    expect(rowB?.limits).toHaveLength(1)
+    // The failing account never collapsed into the un-owned system row.
+    expect(rows.filter((r) => r.accountId === undefined)).toHaveLength(1)
+  })
+})

--- a/src/core/usage/usage-service.ts
+++ b/src/core/usage/usage-service.ts
@@ -60,7 +60,9 @@ interface OAuthCreds {
  * Adding a provider is one entry here plus its fetcher — no changes to the service or the UI.
  */
 const OTHER_PROVIDERS: { id: string; fetch: () => Promise<ProviderUsage> }[] = [
-  { id: 'codex', fetch: fetchCodexUsage },
+  // Codex is NOT here — it is account-scoped (one system row + one row per managed account,
+  // built dynamically in runProviders so each row is keyed by its own accountId and can never
+  // collapse into another). See the Codex block in runProviders and S6 §4.3 (no mixing).
   { id: 'gemini', fetch: fetchGeminiUsage },
   { id: 'grok', fetch: fetchGrokUsage },
   { id: 'kimi', fetch: fetchKimiUsage },
@@ -203,6 +205,15 @@ export interface UsageServiceOptions {
    */
   localAccounts?: () => string[]
   /**
+   * Local managed Codex accounts (settings' non-`host`, non-`pending` codex accounts), each with
+   * the isolated home its `auth.json` lives in. Every one is fetched SEPARATELY and rendered by
+   * account — there is no reduce/merge step, so one account's usage can never be attributed to
+   * another (S6 §4.3, Property 9). The shell owns this because settings live in the shell. Must
+   * never throw — a throwing provider fails closed to system-only, never a fabricated account.
+   * Absent ⇒ the system Codex account only (the merged S4 flat-identity behavior is untouched).
+   */
+  codexAccounts?: () => Array<{ id: string; home: string; label: string; email?: string | null }>
+  /**
    * Fired after any account's cache is (re)populated — the mirror wires this to a flush so the
    * phone-facing `usage` block refreshes when a poll lands. Best-effort; must never throw.
    */
@@ -302,17 +313,62 @@ export function startUsageService(opts: UsageServiceOptions = {}): UsageService 
   let providersAt = 0
   let providersCache: ProviderUsage[] = []
   let providersInFlight: Promise<ProviderUsage[]> | null = null
+  // The account set the current cache was built from. When it changes (an account added, removed,
+  // or relabelled) the cache is busted so a snapshot from a DIFFERENT account set is never served —
+  // switching accounts can't show stale numbers (S6 §4.3, cache fingerprint).
+  let codexAccountsFingerprint = ''
+
+  // A throwing provider must never break the sweep — fail closed to the empty set (system-only),
+  // never a fabricated account (S6 §4.3).
+  const readCodexAccounts = (): ReturnType<NonNullable<UsageServiceOptions['codexAccounts']>> => {
+    try {
+      return opts.codexAccounts?.() ?? []
+    } catch {
+      return []
+    }
+  }
+
+  // `id\0home\0label\0email` per account, NUL-joined — every field that changes what a row reports
+  // participates, so a relabel or a home move busts the cache too, not just add/remove.
+  const fingerprintCodexAccounts = (
+    accounts: ReturnType<NonNullable<UsageServiceOptions['codexAccounts']>>
+  ): string =>
+    accounts.map((a) => `${a.id}\0${a.home}\0${a.label}\0${a.email ?? ''}`).join('\x01')
 
   const runProviders = async (): Promise<ProviderUsage[]> => {
     if (providersInFlight) return providersInFlight
+    // Codex is account-scoped: one system fetcher (no identity ⇒ accountId undefined, the un-owned
+    // row stays un-owned) plus one fetcher per managed account against ITS OWN home + identity.
+    // No reduce/dedupe merge step — each row is keyed by its own accountId and can never collapse
+    // into another (Property 9). The account id is carried on the descriptor so even a THROWN fetch
+    // stays attributed to its own account (fail closed), never masquerading as the system row.
+    const codexAccounts = readCodexAccounts()
+    codexAccountsFingerprint = fingerprintCodexAccounts(codexAccounts)
+    type ProviderFetcher = {
+      id: string
+      accountId?: string
+      fetch: () => Promise<ProviderUsage>
+    }
+    const codexProviders: ProviderFetcher[] = [
+      { id: 'codex', fetch: () => fetchCodexUsage() },
+      ...codexAccounts.map((account) => ({
+        id: 'codex',
+        accountId: account.id,
+        fetch: () => fetchCodexUsage(account.home, account)
+      }))
+    ]
+    const allProviders: ProviderFetcher[] = [...codexProviders, ...OTHER_PROVIDERS]
     // One slow provider must not withhold the others — settle each independently.
     providersInFlight = Promise.all(
-      OTHER_PROVIDERS.map((p) =>
+      allProviders.map((p) =>
         p.fetch().catch(
           (): ProviderUsage => ({
             provider: p.id,
             limits: [],
             account: null,
+            // Keep the failing row attributed to its own account (undefined for the un-owned
+            // rows) so an error fails closed to THIS account, never another's or a fabricated one.
+            accountId: p.accountId,
             updatedAt: Date.now(),
             status: 'error'
           })
@@ -347,6 +403,10 @@ export function startUsageService(opts: UsageServiceOptions = {}): UsageService 
   })
 
   platform().handle(IPC.usageProviders, (force?: boolean) => {
+    // Bust the debounce when the Codex account set has changed since the cache was built, so a
+    // snapshot from a different account set (stale numbers after an add/remove/switch) is never
+    // served (S6 §4.3). runProviders re-stamps the fingerprint from the fresh set.
+    if (fingerprintCodexAccounts(readCodexAccounts()) !== codexAccountsFingerprint) providersAt = 0
     if (!force && providersAt && Date.now() - providersAt < REFETCH_DEBOUNCE_MS) {
       return providersCache
     }

--- a/src/main/claude-usage.ts
+++ b/src/main/claude-usage.ts
@@ -17,6 +17,9 @@ export { resolveClaudeAccessToken } from '../core/usage/usage-service'
  *  SSH projects, so it passes none and `usage:remote` answers empty). */
 export interface InitClaudeUsageOpts {
   localAccounts?: () => string[]
+  /** Local managed Codex accounts (id + isolated home) to aggregate usage for, one row each and
+   *  never merged. See UsageServiceOptions.codexAccounts. */
+  codexAccounts?: () => Array<{ id: string; home: string; label: string; email?: string | null }>
   onCacheUpdate?: () => void
   remote?: RemoteUsageDeps
   /** "A phone may be reading the agent-status mirror" (paired / has a push grant). When true the
@@ -36,6 +39,7 @@ export function initClaudeUsage(win: BrowserWindow, opts: InitClaudeUsageOpts = 
     shouldPoll: () => win.isFocused(),
     mirrorMayBeRead: opts.mirrorMayBeRead,
     localAccounts: opts.localAccounts,
+    codexAccounts: opts.codexAccounts,
     onCacheUpdate: opts.onCacheUpdate,
     remote: opts.remote
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -208,6 +208,8 @@ import {
   writeCodexThreadIdentity
 } from '../core/codex-identity-proxy'
 import { codexThreadExists, startCodexThread } from '../core/codex-session-name'
+import { codexUsageAccounts } from '../core/codex-accounts-core'
+import { codexHomeFor } from '../core/codex-config-dir'
 import { loadOrCreateNodeAuthSecret } from '../core/agents/node-auth-secret'
 import { initNodeTokens, refreshNodeTokens } from '../core/agents/node-token-service'
 import { claudeConfigDirFor } from '../core/claude-config-dir'
@@ -3024,8 +3026,22 @@ app.whenReady().then(async () => {
   // drop it (filterMirrorForNodes) — a host answers only for its own local credentials.
   const localClaudeAccountIds = (): string[] =>
     (settingsStore.get().claudeAccounts ?? []).filter((a) => !a.host && !a.pending).map((a) => a.id)
+  // Local managed Codex accounts, each paired with the isolated home its auth.json lives in, for
+  // the per-account usage fan-out (S6 §4.3). Remote (`host`) accounts have no local home; pending
+  // ones have no auth yet — both are excluded, exactly like the Claude list above.
+  const localCodexAccounts = (): Array<{
+    id: string
+    home: string
+    label: string
+    email?: string | null
+  }> =>
+    codexUsageAccounts(
+      (settingsStore.get().codexAccounts ?? []).filter((a) => !a.host && !a.pending),
+      codexHomeFor
+    )
   const usageService = initClaudeUsage(win, {
     localAccounts: localClaudeAccountIds,
+    codexAccounts: localCodexAccounts,
     onCacheUpdate: () => {
       void flushAgentStatusMirror()
     },

--- a/src/server/handlers/index.ts
+++ b/src/server/handlers/index.ts
@@ -10,6 +10,8 @@ import { claudeCliCaps, registerClaudeCliIpc } from '../../core/claude-cli'
 import { registerCodexIdentityIpc } from '../../core/codex-identity-caps'
 import { UNKNOWN_CODEX_IDENTITY_CAPS } from '@shared/types'
 import { startUsageService } from '../../core/usage/usage-service'
+import { codexUsageAccounts } from '../../core/codex-accounts-core'
+import { codexHomeFor } from '../../core/codex-config-dir'
 import {
   setMirrorUsageProvider,
   buildMirrorUsage,
@@ -98,8 +100,22 @@ export function registerCoreHandlers(
   // poll all local managed accounts, and re-flush the mirror on every cache update.
   const localClaudeAccountIds = (): string[] =>
     (deps.getSettings().claudeAccounts ?? []).filter((a) => !a.host && !a.pending).map((a) => a.id)
+  // Local managed Codex accounts + their isolated homes, for the per-account usage fan-out
+  // (S6 §4.3). Managed Codex accounts run on the headless host too, so the Server Edition serves
+  // them the same way desktop does — a src/core change ships on both shells by construction.
+  const localCodexAccounts = (): Array<{
+    id: string
+    home: string
+    label: string
+    email?: string | null
+  }> =>
+    codexUsageAccounts(
+      (deps.getSettings().codexAccounts ?? []).filter((a) => !a.host && !a.pending),
+      codexHomeFor
+    )
   const usageService = startUsageService({
     localAccounts: localClaudeAccountIds,
+    codexAccounts: localCodexAccounts,
     onCacheUpdate: () => {
       void flushAgentStatusMirror()
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1788,6 +1788,13 @@ export interface ProviderUsage {
   limits: UsageLimit[]
   /** Signed-in identity, when the provider exposes one cheaply (email / account label). */
   account: string | null
+  /**
+   * The managed account this row's numbers belong to, when the provider is account-scoped (Codex
+   * manages N homes on one machine). `undefined` is the un-owned system row — an account that
+   * cannot be proven un-owned is never labelled un-owned. Rows are keyed by this so one account's
+   * usage can never collapse into or be attributed to another (S6 §4.3, no mixing / fail-closed).
+   */
+  accountId?: string
   updatedAt: number
   /**
    * 'unavailable' = not signed in / no subscription to report → hide this provider entirely.


### PR DESCRIPTION
**S6 PR 7 of #112 (@Corvin)** — machine-scoped Codex accounts. Makes Codex USAGE per-account: each managed/system account's token usage is aggregated separately and NEVER mixed. Depends only on PR 1 (merged). Files: delta on `src/core/usage/codex-usage.ts` + `usage-service.ts`, new `usage-service.codex-accounts.test.ts`, plus the two shells' wiring and the `ProviderUsage.accountId` field.

## Task 7.0 — U8 PROBE RESULT: the renderer does NOT dedupe usage rows by accountId
Measured against `src/renderer/`:
- `enabledProviders` (`src/shared/usage-limits.ts`) is a pure `filter(status==='ok' && limits.length>0)` — no reduce.
- `scopeUsage` (`src/renderer/lib/usageScope.ts`) passes `providers` straight through (`[...providers]`).
- The popover renders `visibleProviders.map(p => <ProviderBlock key={p.provider} .../>)` and the pill renders `enabled.map(p => …key={p.provider}…)` — **keyed by provider id (`'codex'`) only**, not `accountId`.

So once `runProviders` emits N codex rows (system + accounts), they reach the UI as **separate, key-colliding blocks** — the renderer neither merges nor de-duplicates them. Per the plan, the keyed reduce is **deferred to PR 8**; PR 7's service **deliberately emits un-merged rows** (that is precisely the no-mixing guarantee). Recorded, no contradiction to fold in.

## Property 9 — usage never mixes accounts (the security/correctness property)
- Per-account rows are keyed by `accountId`; `runProviders` builds **one system fetcher** (`fetchCodexUsage()` ⇒ `accountId: undefined`, un-owned stays un-owned) **+ one fetcher per account** against its own home + identity. **No reduce/dedupe merge step.**
- `fetchCodexUsage(home, identity?)` stamps `account`/`accountId` on **all three** return paths (backend ok, app-server ok, `unavailable`) — a read error → **empty for THAT account**, never a fabricated account and never another account's numbers.
- The per-account descriptor carries its `accountId` into the error fallback, so even a thrown fetch stays attributed to its own account (never masquerading as the un-owned system row).
- `readCodexAccounts()` swallows a throwing provider → empty set (system-only), never a guess.
- A `codexAccountsFingerprint` (`id\0home\0label\0email`) busts the provider cache when the set changes → switching accounts never shows stale numbers.

Reuses PR 1's account-home builders (no id validation duplicated — the id is never a path here). A system-only install (no managed accounts) is byte-for-byte unchanged (S4 flat identity untouched).

### Fail-closed / no-mixing tests — mutation-verified **8/8 caught** (introduced/caught)
`usage-service.codex-accounts.test.ts` (5) + `codex-usage.test.ts` (3 new):
1. merge rows by provider id (dedupe cache) → 3 tests red — **1/1**
2. read managed accounts from the system home → 3 tests red — **1/1**
3. drop the fingerprint cache-bust → "invalidates cache when account added" red — **1/1**
4. `readCodexAccounts` fails open (rethrows) → "throwing → system-only" red — **1/1**
5. return a fabricated account on error → "throwing → system-only" red — **1/1**
6. error-fallback row drops its `accountId` → "read error stays empty for THAT account" red — **1/1**
7. `unavailable` path drops the identity stamp → "stamps identity on unavailable row" red — **1/1**
8. backend ok path drops the identity stamp → "stamps identity on ok row" red — **1/1**

Also covered: cache is served (not re-fetched) while the set is unchanged; the system row stays un-owned when no identity is given.

## Surfaces
- **Desktop (Electron)** + **Server Edition**: both wire the local (non-`host`, non-`pending`) Codex accounts identically via `codexUsageAccounts` + `codexHomeFor` — a `src/core` change ships on both shells by construction. Managed Codex accounts run headless too, so the Server Edition serves them the same way.
- **Mobile**: unchanged — read-only, originates nothing; the codex rows flow through the existing `usage:providers` RPC.

## Reconciliation note (constraint 1 — anchors drift)
The brief asked to "delete the rebase-artifact `mirrorMayBeRead`". On current `origin/main` that is **not** a rebase artifact — it is a shipped, documented feature (commit `612f6fec`, "keep the phone's usage mirror fresh on a backgrounded desktop") with its own `usage-service.poll-gate.test.ts` and shell wiring. Deleting it would break the build and drop a live feature, so it was **kept** and the codex scoping folded around it.

## Gates
`npm run typecheck` clean. Full `npx vitest run`: **547 files, 7622 passed, 12 skipped, 0 failing** (the usual environmental flakes passed this run). CodeQL hygiene: changes are read-only file parsing (no new fs reads, no stat-then-read, no file-data→network flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)