### PR TITLE
feat(project-settings): consume worktree defaults + materialize sharedPaths

### DIFF
--- a/src/core/worktree-shared-paths-handlers.test.ts
+++ b/src/core/worktree-shared-paths-handlers.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import {
+  registerWorktreeSharedPathsHandlers,
+  type WorktreeSharedPathsDeps
+} from './worktree-shared-paths-handlers'
+import { IPC } from '../shared/ipc'
+import type { SharedPathResult } from './worktree-shared-paths'
+import type { ProjectSettingsSnapshot } from '../shared/project-settings'
+import type { WorktreeListResult } from '../shared/worktree'
+
+const materialize = (f: FakePlatform, projectId: unknown, worktreePath: unknown) =>
+  f.handlers[IPC.worktreeMaterializeShared](projectId, worktreePath) as Promise<SharedPathResult[]>
+
+// A snapshot whose SHARED doc lists the given sharedPaths — the list the handler must read ITSELF
+// by projectId (never a value the renderer passed in).
+const snapshotWithSharedPaths = (sharedPaths: string[]): ProjectSettingsSnapshot => ({
+  shared: { version: 1, rev: 1, savedAt: '', worktree: { sharedPaths } },
+  local: undefined
+})
+
+describe('registerWorktreeSharedPathsHandlers', () => {
+  let base: string
+  let repoRoot: string
+  let worktreeRoot: string
+  beforeEach(() => {
+    base = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-wt-shared-'))
+    repoRoot = path.join(base, 'repo')
+    worktreeRoot = path.join(base, 'repo.worktrees', 'feature')
+    fs.mkdirSync(repoRoot, { recursive: true })
+    fs.mkdirSync(worktreeRoot, { recursive: true })
+    // A git-ignored dir that the worktree does NOT have yet — the thing sharedPaths links back.
+    fs.mkdirSync(path.join(repoRoot, 'node_modules'), { recursive: true })
+    fs.writeFileSync(path.join(repoRoot, 'node_modules', 'marker.txt'), 'x')
+  })
+  afterEach(() => {
+    fs.rmSync(base, { recursive: true, force: true })
+  })
+
+  const depsFor = (over: Partial<WorktreeSharedPathsDeps> = {}): WorktreeSharedPathsDeps => ({
+    readSettings: async () => snapshotWithSharedPaths(['node_modules']),
+    targetInfo: () => ({ cwd: repoRoot, name: 'demo' }),
+    worktreeList: async (): Promise<WorktreeListResult> => ({
+      ok: true,
+      entries: [
+        { path: repoRoot, branch: 'main', head: null, isBare: false },
+        { path: worktreeRoot, branch: 'feature', head: null, isBare: false }
+      ]
+    }),
+    ...over
+  })
+
+  it('materializes the sharedPaths list it reads by projectId — the renderer never passes one', async () => {
+    const f = fakePlatform()
+    // The wire passes ONLY (projectId, worktreePath); the list comes from readSettings.
+    registerWorktreeSharedPathsHandlers(f, depsFor())
+    const res = await materialize(f, 'p1', worktreeRoot)
+    expect(res).toEqual([{ path: 'node_modules', status: 'linked' }])
+    // The symlink actually points back at the repo copy.
+    const linked = path.join(worktreeRoot, 'node_modules', 'marker.txt')
+    expect(fs.readFileSync(linked, 'utf-8')).toBe('x')
+  })
+
+  it('refuses a worktreePath that is not one of the project’s worktrees → []', async () => {
+    const f = fakePlatform()
+    registerWorktreeSharedPathsHandlers(f, depsFor())
+    const strayer = path.join(os.tmpdir(), 'nt-not-a-worktree')
+    fs.mkdirSync(strayer, { recursive: true })
+    const res = await materialize(f, 'p1', strayer)
+    expect(res).toEqual([])
+    // And nothing was linked into the stray dir.
+    expect(fs.existsSync(path.join(strayer, 'node_modules'))).toBe(false)
+    fs.rmSync(strayer, { recursive: true, force: true })
+  })
+
+  it('an SSH project → [] (materialization is local-only this PR)', async () => {
+    const f = fakePlatform()
+    registerWorktreeSharedPathsHandlers(
+      f,
+      depsFor({
+        targetInfo: () => ({
+          ssh: { host: 'h', user: 'u', remoteCwd: '/srv/app' } as never,
+          name: 'demo'
+        })
+      })
+    )
+    const res = await materialize(f, 'p1', worktreeRoot)
+    expect(res).toEqual([])
+  })
+
+  it('an unknown project (no target info) → []', async () => {
+    const f = fakePlatform()
+    registerWorktreeSharedPathsHandlers(f, depsFor({ targetInfo: () => null }))
+    const res = await materialize(f, 'p1', worktreeRoot)
+    expect(res).toEqual([])
+  })
+
+  it('a non-string projectId or worktreePath → []', async () => {
+    const f = fakePlatform()
+    registerWorktreeSharedPathsHandlers(f, depsFor())
+    expect(await materialize(f, 42, worktreeRoot)).toEqual([])
+    expect(await materialize(f, 'p1', undefined)).toEqual([])
+  })
+
+  it('no sharedPaths configured → [] (nothing to link)', async () => {
+    const f = fakePlatform()
+    registerWorktreeSharedPathsHandlers(
+      f,
+      depsFor({ readSettings: async () => snapshotWithSharedPaths([]) })
+    )
+    const res = await materialize(f, 'p1', worktreeRoot)
+    expect(res).toEqual([])
+  })
+})

--- a/src/core/worktree-shared-paths-handlers.ts
+++ b/src/core/worktree-shared-paths-handlers.ts
@@ -1,0 +1,66 @@
+import { IPC } from '../shared/ipc'
+import { resolveProjectSettings, type ProjectSettingsSnapshot } from '../shared/project-settings'
+import type { WorktreeListResult } from '../shared/worktree'
+import type { CorePlatform } from './platform'
+import { resolveProjectSetupTarget, type ProjectSetupTargetInfo } from './project-setup-runner-local'
+import { materializeSharedPaths, type SharedPathResult } from './worktree-shared-paths'
+
+/**
+ * RPC surface for `worktree:materialize-shared`, registered once per shell (Electron main + Server
+ * Edition) through CorePlatform — the `project-setup-handlers.ts` / `project-launch-info-handlers.ts`
+ * sibling-registrar shape.
+ *
+ * The wire carries ONLY `(projectId, worktreePath)`. It NEVER carries the `sharedPaths` list: a
+ * renderer-supplied list of relative paths is untrusted input (it could name anything, and would
+ * also let a compromised renderer materialize links a project never opted into). The handler reads
+ * the list ITSELF, by projectId, out of the project's resolved settings
+ * (`readSettings` → `resolveProjectSettings` → `worktree.sharedPaths`).
+ *
+ * The trust boundary is the SAME one the setup runner uses (`resolveProjectSetupTarget`): rootPath
+ * (= the project's `cwd`) is derived from THIS process's own workspace index by projectId, never the
+ * caller, and `worktreePath` is independently validated to be either that rootPath or one of the
+ * project's ACTUAL git worktrees — else the call is refused with `[]`. An SSH project is refused the
+ * same way (materialization is local-only this PR; `resolveProjectSetupTarget` already rejects an
+ * ssh target that carries a worktreePath, and we re-check `target.ssh` here as defense in depth).
+ * Every refusal — unknown project, bad worktreePath, ssh, non-string args, no configured
+ * sharedPaths — answers `[]`, the same shape a real "nothing was linked" answer uses, so a caller
+ * needs no extra branch.
+ */
+export interface WorktreeSharedPathsDeps {
+  /** This shell's own settings resolution (e.g. `WorkspaceStore.readProjectSettings`). */
+  readSettings(projectId: string): Promise<ProjectSettingsSnapshot | null>
+  /** This shell's own workspace index lookup (e.g. `WorkspaceStore.projectTargetInfo`). */
+  targetInfo(projectId: string): ProjectSetupTargetInfo | null
+  /** `git worktree list` for a repo root (e.g. `GitService#worktreeList` bound to the caller). */
+  worktreeList(repoPath: string): Promise<WorktreeListResult>
+}
+
+export function registerWorktreeSharedPathsHandlers(
+  platform: CorePlatform,
+  deps: WorktreeSharedPathsDeps
+): void {
+  platform.handle(
+    IPC.worktreeMaterializeShared,
+    async (projectId: unknown, worktreePath: unknown): Promise<SharedPathResult[]> => {
+      if (typeof projectId !== 'string' || !projectId) return []
+      if (typeof worktreePath !== 'string' || !worktreePath) return []
+
+      // Same derivation + validation the setup runner performs: rootPath/ssh come from THIS
+      // process's index by projectId, and `worktreePath` must be the project's rootPath or one of
+      // its actual worktrees. A null target = unknown project / no local folder / refused ssh path.
+      const info = deps.targetInfo(projectId)
+      const target = await resolveProjectSetupTarget(projectId, worktreePath, info, deps.worktreeList)
+      if (!target || target.ssh || !target.worktreePath) return []
+
+      // Read the sharedPaths list ITSELF by projectId — never a value off the wire.
+      const snap = await deps.readSettings(projectId)
+      const resolved = resolveProjectSettings(snap?.local, snap?.shared ?? undefined)
+      const sharedPaths = resolved.worktree.sharedPaths?.value ?? []
+      if (sharedPaths.length === 0) return []
+
+      // repoRoot = the project's own cwd (target.rootPath); target.worktreePath is the validated,
+      // absolute worktree directory. materializeSharedPaths never throws.
+      return materializeSharedPaths(target.rootPath, target.worktreePath, sharedPaths)
+    }
+  )
+}

--- a/src/core/worktree-shared-paths.test.ts
+++ b/src/core/worktree-shared-paths.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { materializeSharedPaths } from './worktree-shared-paths'
+
+let base: string
+let repoRoot: string
+let worktreeRoot: string
+
+beforeEach(async () => {
+  base = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-wsp-'))
+  repoRoot = path.join(base, 'repo')
+  worktreeRoot = path.join(base, 'wt')
+  await fs.mkdir(repoRoot, { recursive: true })
+  await fs.mkdir(worktreeRoot, { recursive: true })
+})
+afterEach(async () => {
+  await fs.rm(base, { recursive: true, force: true })
+})
+
+function statusOf(results: { path: string; status: string }[], p: string): string | undefined {
+  return results.find((r) => r.path === p)?.status
+}
+
+describe('materializeSharedPaths', () => {
+  it('symlinks a file and a directory, readable through the link', async () => {
+    await fs.writeFile(path.join(repoRoot, '.env'), 'SECRET=1', 'utf-8')
+    await fs.mkdir(path.join(repoRoot, 'node_modules', 'pkg'), { recursive: true })
+    await fs.writeFile(path.join(repoRoot, 'node_modules', 'pkg', 'index.js'), 'module.exports=1', 'utf-8')
+
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['.env', 'node_modules'])
+
+    expect(statusOf(res, '.env')).toBe('linked')
+    expect(statusOf(res, 'node_modules')).toBe('linked')
+
+    // Read through the links.
+    expect(await fs.readFile(path.join(worktreeRoot, '.env'), 'utf-8')).toBe('SECRET=1')
+    expect(await fs.readFile(path.join(worktreeRoot, 'node_modules', 'pkg', 'index.js'), 'utf-8')).toBe(
+      'module.exports=1'
+    )
+
+    // The link actually points at the source.
+    const link = await fs.readlink(path.join(worktreeRoot, '.env'))
+    expect(path.resolve(worktreeRoot, link)).toBe(path.join(repoRoot, '.env'))
+  })
+
+  it('skips a missing source (fresh clone, deps not installed)', async () => {
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['node_modules'])
+    expect(statusOf(res, 'node_modules')).toBe('skipped-missing-source')
+    // No stray link created.
+    await expect(fs.lstat(path.join(worktreeRoot, 'node_modules'))).rejects.toBeTruthy()
+  })
+
+  it('never overwrites an existing target (even a broken symlink)', async () => {
+    await fs.writeFile(path.join(repoRoot, '.env'), 'FROM_REPO', 'utf-8')
+    // Pre-existing real file in the worktree.
+    await fs.writeFile(path.join(worktreeRoot, '.env'), 'ALREADY_HERE', 'utf-8')
+    // Pre-existing broken symlink.
+    await fs.mkdir(path.join(repoRoot, 'dir'), { recursive: true })
+    await fs.symlink(path.join(base, 'does-not-exist'), path.join(worktreeRoot, 'dir'))
+
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['.env', 'dir'])
+
+    expect(statusOf(res, '.env')).toBe('skipped-exists')
+    expect(statusOf(res, 'dir')).toBe('skipped-exists')
+    // The real file is untouched.
+    expect(await fs.readFile(path.join(worktreeRoot, '.env'), 'utf-8')).toBe('ALREADY_HERE')
+    // The broken symlink is left exactly as it was.
+    expect(await fs.readlink(path.join(worktreeRoot, 'dir'))).toBe(path.join(base, 'does-not-exist'))
+  })
+
+  it('rejects absolute and traversal entries as unsafe', async () => {
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['/etc/passwd', '../escape', 'a/../../x'])
+    expect(statusOf(res, '/etc/passwd')).toBe('skipped-unsafe')
+    expect(statusOf(res, '../escape')).toBe('skipped-unsafe')
+    expect(statusOf(res, 'a/../../x')).toBe('skipped-unsafe')
+  })
+
+  it('reserves .git and anything under it', async () => {
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['.git', '.git/hooks', '.GIT'])
+    expect(statusOf(res, '.git')).toBe('skipped-reserved')
+    expect(statusOf(res, '.git/hooks')).toBe('skipped-reserved')
+    expect(statusOf(res, '.GIT')).toBe('skipped-reserved')
+  })
+
+  it('creates intermediate parent dirs for a nested target', async () => {
+    await fs.mkdir(path.join(repoRoot, 'a', 'b'), { recursive: true })
+    await fs.writeFile(path.join(repoRoot, 'a', 'b', 'c.txt'), 'nested', 'utf-8')
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['a/b/c.txt'])
+    expect(statusOf(res, 'a/b/c.txt')).toBe('linked')
+    expect(await fs.readFile(path.join(worktreeRoot, 'a', 'b', 'c.txt'), 'utf-8')).toBe('nested')
+  })
+
+  it('returns a result per entry and never throws, even for a nonexistent worktree root', async () => {
+    await fs.writeFile(path.join(repoRoot, '.env'), 'x', 'utf-8')
+    const res = await materializeSharedPaths(repoRoot, path.join(base, 'missing-wt', 'deep'), ['.env'])
+    // Either linked (mkdir -p created the tree) — but never a throw and always one result.
+    expect(res).toHaveLength(1)
+    expect(res[0].path).toBe('.env')
+  })
+
+  it('returns an empty list for no shared paths', async () => {
+    expect(await materializeSharedPaths(repoRoot, worktreeRoot, [])).toEqual([])
+  })
+})

--- a/src/core/worktree-shared-paths.test.ts
+++ b/src/core/worktree-shared-paths.test.ts
@@ -103,4 +103,51 @@ describe('materializeSharedPaths', () => {
   it('returns an empty list for no shared paths', async () => {
     expect(await materializeSharedPaths(repoRoot, worktreeRoot, [])).toEqual([])
   })
+
+  // Security: `git worktree add` checks out attacker-controllable TRACKED symlinks, so the lexical
+  // within-root guard is insufficient — a link can be planted OUTSIDE the worktree/repo THROUGH an
+  // intermediate symlink. The realpath-of-deepest-existing-ancestor checks are the authoritative
+  // containment guards.
+  it('refuses a target that escapes the worktree through an intermediate symlink (plant primitive)', async () => {
+    // A real source so we get past the missing-source check and reach the target guard.
+    await fs.mkdir(path.join(repoRoot, 'cfg'), { recursive: true })
+    await fs.writeFile(path.join(repoRoot, 'cfg', 'x'), 'PAYLOAD', 'utf-8')
+    // The checked-out worktree contains `cfg` as a symlink pointing OUTSIDE the worktree root.
+    const outside = path.join(base, 'outside')
+    await fs.mkdir(outside, { recursive: true })
+    await fs.symlink(outside, path.join(worktreeRoot, 'cfg'))
+
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['cfg/x'])
+
+    expect(statusOf(res, 'cfg/x')).toBe('skipped-unsafe')
+    // Nothing was planted at the escape location.
+    await expect(fs.lstat(path.join(outside, 'x'))).rejects.toBeTruthy()
+  })
+
+  it('refuses a source that escapes the repo through an intermediate symlink', async () => {
+    // Outside-the-repo content the hostile symlink points at.
+    const outside = path.join(base, 'outside-repo')
+    await fs.mkdir(outside, { recursive: true })
+    await fs.writeFile(path.join(outside, 'secret'), 'LEAKED', 'utf-8')
+    // A tracked symlink inside the repo that escapes it.
+    await fs.symlink(outside, path.join(repoRoot, 'evil'))
+
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['evil/secret'])
+
+    expect(statusOf(res, 'evil/secret')).toBe('skipped-unsafe')
+    // Materialization surfaced nothing from outside the repo.
+    await expect(fs.lstat(path.join(worktreeRoot, 'evil', 'secret'))).rejects.toBeTruthy()
+  })
+
+  it('still links a legitimate in-repo symlink source (realpath stays under the repo root)', async () => {
+    await fs.mkdir(path.join(repoRoot, 'real'), { recursive: true })
+    await fs.writeFile(path.join(repoRoot, 'real', 'f'), 'INREPO', 'utf-8')
+    // A relative, in-repo symlink — resolves back under the repo, so it is allowed.
+    await fs.symlink('./real', path.join(repoRoot, 'link'))
+
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['link/f'])
+
+    expect(statusOf(res, 'link/f')).toBe('linked')
+    expect(await fs.readFile(path.join(worktreeRoot, 'link', 'f'), 'utf-8')).toBe('INREPO')
+  })
 })

--- a/src/core/worktree-shared-paths.test.ts
+++ b/src/core/worktree-shared-paths.test.ts
@@ -139,6 +139,23 @@ describe('materializeSharedPaths', () => {
     await expect(fs.lstat(path.join(worktreeRoot, 'evil', 'secret'))).rejects.toBeTruthy()
   })
 
+  it('does not mkdir -p through an intermediate symlink outside the worktree (empty-dir plant)', async () => {
+    // A real deep source so we get past the missing-source check and reach the parent-creation step.
+    await fs.mkdir(path.join(repoRoot, 'cfg', 'deep'), { recursive: true })
+    await fs.writeFile(path.join(repoRoot, 'cfg', 'deep', 'x'), 'PAYLOAD', 'utf-8')
+    // The checked-out worktree has `cfg` as a symlink OUTSIDE the worktree; `mkdir -p <wt>/cfg/deep`
+    // would follow it and create `<outside>/deep` before any post-mkdir guard.
+    const outside = path.join(base, 'outside-mkdir')
+    await fs.mkdir(outside, { recursive: true })
+    await fs.symlink(outside, path.join(worktreeRoot, 'cfg'))
+
+    const res = await materializeSharedPaths(repoRoot, worktreeRoot, ['cfg/deep/x'])
+
+    expect(statusOf(res, 'cfg/deep/x')).toBe('skipped-unsafe')
+    // The mkdir must NOT have run through the symlink.
+    await expect(fs.lstat(path.join(outside, 'deep'))).rejects.toBeTruthy()
+  })
+
   it('still links a legitimate in-repo symlink source (realpath stays under the repo root)', async () => {
     await fs.mkdir(path.join(repoRoot, 'real'), { recursive: true })
     await fs.writeFile(path.join(repoRoot, 'real', 'f'), 'INREPO', 'utf-8')

--- a/src/core/worktree-shared-paths.ts
+++ b/src/core/worktree-shared-paths.ts
@@ -1,0 +1,138 @@
+// Materialize a project's `sharedPaths` from the repo root into a freshly-created git worktree.
+//
+// A git worktree gets its own working copy but shares the common `.git`. Anything git-ignored —
+// `node_modules`, `.env`, local build caches — is NOT copied and would otherwise be missing in the
+// worktree. `sharedPaths` lists the relative paths a project wants to appear in every worktree; we
+// materialize each one as a symlink back to the repo-root copy.
+//
+// v1 is symlink-only (never copy/clone). Tradeoff, intended: a symlinked `node_modules` is the SAME
+// tree as the repo's — no extra disk, no second `npm install`, but an edit or `npm install` inside
+// the worktree writes through to the repo's copy. For dependency dirs that is the desired sharing;
+// a future opt-in could copy instead for isolation.
+//
+// Every entry is handled fail-safe: this function NEVER throws. Each entry yields one result so the
+// caller can report exactly what happened (linked / why skipped / errored).
+//
+// The symlink call is kept LOCAL here (node:fs.symlink) rather than added to fs-ops.ts: the fs-ops
+// helpers all collapse failure to a boolean, but we must distinguish an EPERM (Windows file symlink
+// without Developer Mode) from other errors and surface a typed per-entry result — a boolean helper
+// would throw that information away. So the raw call lives in this module, wrapped per entry.
+
+import { promises as fs } from 'fs'
+import path from 'path'
+import { isInsideDir } from '../shared/worktree'
+
+export interface SharedPathResult {
+  path: string
+  status:
+    | 'linked'
+    | 'skipped-missing-source'
+    | 'skipped-exists'
+    | 'skipped-reserved'
+    | 'skipped-unsafe'
+    | 'error'
+  /** Present only for `error` (or a noteworthy skip): a short human-readable reason. */
+  note?: string
+}
+
+// Mirror of the sanitizer's relative-safety checks in src/shared/project-settings.ts
+// (`hasTraversalSegment` + the absolute / Windows-drive rejection). Values are already sanitized at
+// write time, but we RE-validate here at fs time as defense in depth — the on-disk settings file
+// could have been hand-edited or arrived over the relay unsanitized.
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/
+function hasTraversalSegment(p: string): boolean {
+  return p.split(/[/\\]/).includes('..')
+}
+function isRelativeSafe(entry: string): boolean {
+  if (entry.length === 0) return false
+  if (entry.startsWith('/') || entry.startsWith('\\')) return false
+  if (WINDOWS_DRIVE_RE.test(entry)) return false
+  if (hasTraversalSegment(entry)) return false
+  return true
+}
+
+// First path segment, case-folded — so `.git`, `.GIT`, `.git/hooks` all trip the reserved guard.
+function firstSegment(entry: string): string {
+  return entry.split(/[/\\]/)[0].toLowerCase()
+}
+
+/** True when the path exists as a link/file/dir — LSTAT, so a broken symlink counts as present. */
+async function lexists(p: string): Promise<boolean> {
+  try {
+    await fs.lstat(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Symlink each relative `sharedPath` from `repoRoot` into `worktreeRoot`. Pure fs, never throws;
+ * returns a per-entry result list (one `SharedPathResult` per input, order preserved).
+ */
+export async function materializeSharedPaths(
+  repoRoot: string,
+  worktreeRoot: string,
+  sharedPaths: string[]
+): Promise<SharedPathResult[]> {
+  const repoAbs = path.resolve(repoRoot)
+  const wtAbs = path.resolve(worktreeRoot)
+  const results: SharedPathResult[] = []
+
+  for (const entry of sharedPaths) {
+    results.push(await materializeOne(repoAbs, wtAbs, entry))
+  }
+  return results
+}
+
+async function materializeOne(
+  repoAbs: string,
+  wtAbs: string,
+  entry: string
+): Promise<SharedPathResult> {
+  try {
+    // (1) Re-validate relative-safe: absolute, `..` segment, or Windows drive → unsafe.
+    if (!isRelativeSafe(entry)) return { path: entry, status: 'skipped-unsafe' }
+
+    // (2) Reserved guard: the worktree already shares the common `.git` (git writes its own `.git`
+    // FILE pointing at the gitdir). Never symlink over it or anything beneath it.
+    if (firstSegment(entry) === '.git') return { path: entry, status: 'skipped-reserved' }
+
+    const source = path.resolve(repoAbs, entry)
+    const target = path.resolve(wtAbs, entry)
+
+    // (3) Within-root assertion (defense in depth on top of the relative-safety check above).
+    if (!isInsideDir(source, repoAbs) || !isInsideDir(target, wtAbs)) {
+      return { path: entry, status: 'skipped-unsafe' }
+    }
+
+    // (4) Source missing → not an error: a fresh clone whose `node_modules` isn't installed yet.
+    if (!(await lexists(source))) return { path: entry, status: 'skipped-missing-source' }
+
+    // (5) Target exists (lstat, even a broken symlink) → never overwrite. This also protects the
+    // worktree's own `.git` file and anything git already wrote into the tree.
+    if (await lexists(target)) return { path: entry, status: 'skipped-exists' }
+
+    // (6) Create the target's parent tree, then link. On Windows the symlink type matters (a file
+    // link and a dir link are distinct); infer it from the source. On POSIX the type is ignored.
+    await fs.mkdir(path.dirname(target), { recursive: true })
+    let type: 'dir' | 'file' = 'file'
+    try {
+      if ((await fs.stat(source)).isDirectory()) type = 'dir'
+    } catch {
+      // Source vanished between checks — fall back to a file link; symlink() below will error out
+      // cleanly if that too fails, and we return an `error` result rather than throwing.
+    }
+    await fs.symlink(source, target, type)
+    return { path: entry, status: 'linked' }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    // EPERM on Windows = symlink creation needs Developer Mode / elevated rights. Surface it as an
+    // error with a note instead of throwing out of the whole batch.
+    const note =
+      code === 'EPERM'
+        ? 'symlink not permitted (on Windows, enable Developer Mode)'
+        : (err as Error).message
+    return { path: entry, status: 'error', note }
+  }
+}

--- a/src/core/worktree-shared-paths.ts
+++ b/src/core/worktree-shared-paths.ts
@@ -20,20 +20,12 @@
 
 import { promises as fs } from 'fs'
 import path from 'path'
-import { isInsideDir } from '../shared/worktree'
+import { isInsideDir, type SharedPathResult } from '../shared/worktree'
 
-export interface SharedPathResult {
-  path: string
-  status:
-    | 'linked'
-    | 'skipped-missing-source'
-    | 'skipped-exists'
-    | 'skipped-reserved'
-    | 'skipped-unsafe'
-    | 'error'
-  /** Present only for `error` (or a noteworthy skip): a short human-readable reason. */
-  note?: string
-}
+// The type lives in `shared/worktree.ts` so the renderer's `WorktreeApi` can name it without a
+// wrong-direction import into core; re-exported here so this module's own callers/tests keep
+// importing it from where it originated.
+export type { SharedPathResult }
 
 // Mirror of the sanitizer's relative-safety checks in src/shared/project-settings.ts
 // (`hasTraversalSegment` + the absolute / Windows-drive rejection). Values are already sanitized at

--- a/src/core/worktree-shared-paths.ts
+++ b/src/core/worktree-shared-paths.ts
@@ -68,6 +68,22 @@ async function realpathOrNull(p: string): Promise<string | null> {
   }
 }
 
+/** Realpath of the DEEPEST EXISTING ancestor of `p` (p itself if it exists, else walk up until a
+ *  component exists), or `null` on failure. Used to contain a path we are about to CREATE: the leaf
+ *  and some parents may not exist yet, but the first existing component realpath-resolves any
+ *  intermediate symlink — so we can prove where a `mkdir -p` would actually land BEFORE running it. */
+async function realpathDeepestExisting(p: string): Promise<string | null> {
+  let cur = p
+  // Walk up until an existing component is found. `path.dirname` is idempotent at the root, so the
+  // `parent === cur` check terminates the loop rather than spinning on `/` (which always exists).
+  for (;;) {
+    if (await lexists(cur)) return realpathOrNull(cur)
+    const parent = path.dirname(cur)
+    if (parent === cur) return null
+    cur = parent
+  }
+}
+
 /**
  * Symlink each relative `sharedPath` from `repoRoot` into `worktreeRoot`. Pure fs, never throws;
  * returns a per-entry result list (one `SharedPathResult` per input, order preserved).
@@ -132,6 +148,20 @@ async function materializeOne(
 
     // (6) Create the target's parent tree, then link. On Windows the symlink type matters (a file
     // link and a dir link are distinct); infer it from the source. On POSIX the type is ignored.
+    const realWtAbs = await realpathOrNull(wtAbs)
+
+    // (6a) PRE-mkdir containment. `mkdir -p` itself FOLLOWS intermediate symlinks, so for a deeper
+    // entry like `cfg/deep/x` where the checked-out tree has `cfg -> /outside`, the mkdir would
+    // create `/outside/deep` OUTSIDE the worktree root before the post-mkdir guard (6b) could reject
+    // it (an empty-directory-creation primitive from a hostile repo). The containment check must
+    // therefore run BEFORE the mkdir, not only after it: resolve the realpath of the deepest EXISTING
+    // ancestor of the parent-to-create (which realpath-resolves any such intermediate symlink) and
+    // assert it stays under the worktree root. Fail closed on realpath failure.
+    const realDeepest = await realpathDeepestExisting(path.dirname(target))
+    if (!realWtAbs || !isInsideDir(realDeepest ?? undefined, realWtAbs)) {
+      return { path: entry, status: 'skipped-unsafe' }
+    }
+
     await fs.mkdir(path.dirname(target), { recursive: true })
 
     // (6b) TARGET realpath containment — the authoritative guard against the symlink-plant escape.
@@ -140,7 +170,6 @@ async function materializeOne(
     // then write THROUGH it and plant a link OUTSIDE the worktree root. The target's parent exists
     // post-mkdir, so realpath resolves any such intermediate symlink; assert the REAL parent stays
     // inside the worktree. A realpath failure → fail closed as skipped-unsafe.
-    const realWtAbs = await realpathOrNull(wtAbs)
     const realParent = await realpathOrNull(path.dirname(target))
     if (!realWtAbs || !isInsideDir(realParent ?? undefined, realWtAbs)) {
       return { path: entry, status: 'skipped-unsafe' }

--- a/src/core/worktree-shared-paths.ts
+++ b/src/core/worktree-shared-paths.ts
@@ -58,6 +58,16 @@ async function lexists(p: string): Promise<boolean> {
   }
 }
 
+/** Realpath fully resolved, or `null` if it cannot be resolved (broken link / ENOENT race). Callers
+ *  treat `null` as "fail closed" — an unresolvable path cannot be proven contained, so it is unsafe. */
+async function realpathOrNull(p: string): Promise<string | null> {
+  try {
+    return await fs.realpath(p)
+  } catch {
+    return null
+  }
+}
+
 /**
  * Symlink each relative `sharedPath` from `repoRoot` into `worktreeRoot`. Pure fs, never throws;
  * returns a per-entry result list (one `SharedPathResult` per input, order preserved).
@@ -101,6 +111,21 @@ async function materializeOne(
     // (4) Source missing → not an error: a fresh clone whose `node_modules` isn't installed yet.
     if (!(await lexists(source))) return { path: entry, status: 'skipped-missing-source' }
 
+    // (4b) SOURCE realpath containment. The lexical check in (3) is path-string only, but the source
+    // may resolve THROUGH a symlink the repo committed — `git worktree add` checks out attacker-
+    // controllable tracked symlinks, so a lexical path check is insufficient. Realpath of the source
+    // (it exists per (4)) is the authoritative containment check: a repo-internal symlink escaping
+    // the repo must not let materialization surface content from OUTSIDE the repo. A legitimate
+    // in-repo symlink (e.g. a relative link to another repo dir) resolves back under repoAbs and is
+    // allowed. A realpath failure (broken link / ENOENT race) → fail closed as skipped-unsafe.
+    // The root itself is realpath'd too, so a symlinked prefix (e.g. macOS `/tmp -> /private/tmp`)
+    // in the root path doesn't spuriously make a legitimately-contained source look outside it.
+    const realRepoAbs = await realpathOrNull(repoAbs)
+    const realSource = await realpathOrNull(source)
+    if (!realRepoAbs || !isInsideDir(realSource ?? undefined, realRepoAbs)) {
+      return { path: entry, status: 'skipped-unsafe' }
+    }
+
     // (5) Target exists (lstat, even a broken symlink) → never overwrite. This also protects the
     // worktree's own `.git` file and anything git already wrote into the tree.
     if (await lexists(target)) return { path: entry, status: 'skipped-exists' }
@@ -108,6 +133,19 @@ async function materializeOne(
     // (6) Create the target's parent tree, then link. On Windows the symlink type matters (a file
     // link and a dir link are distinct); infer it from the source. On POSIX the type is ignored.
     await fs.mkdir(path.dirname(target), { recursive: true })
+
+    // (6b) TARGET realpath containment — the authoritative guard against the symlink-plant escape.
+    // The lexical check in (3) resolves `<wt>/cfg/x` as a string, but `git worktree add` may have
+    // checked out an intermediate tracked symlink (e.g. `<wt>/cfg -> /outside`); `fs.symlink` would
+    // then write THROUGH it and plant a link OUTSIDE the worktree root. The target's parent exists
+    // post-mkdir, so realpath resolves any such intermediate symlink; assert the REAL parent stays
+    // inside the worktree. A realpath failure → fail closed as skipped-unsafe.
+    const realWtAbs = await realpathOrNull(wtAbs)
+    const realParent = await realpathOrNull(path.dirname(target))
+    if (!realWtAbs || !isInsideDir(realParent ?? undefined, realWtAbs)) {
+      return { path: entry, status: 'skipped-unsafe' }
+    }
+
     let type: 'dir' | 'file' = 'file'
     try {
       if ((await fs.stat(source)).isDirectory()) type = 'dir'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -71,6 +71,7 @@ import {
   type ProjectSetupHandlerDeps
 } from '../core/project-setup-handlers'
 import { registerProjectLaunchInfoHandlers } from '../core/project-launch-info-handlers'
+import { registerWorktreeSharedPathsHandlers } from '../core/worktree-shared-paths-handlers'
 import { makeProjectSpawnOverrides } from '../core/project-spawn-overrides'
 import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
 import { makeSshSetupRunner } from './remote-ssh/ssh-setup-runner'
@@ -385,6 +386,16 @@ const projectSetupDeps: ProjectSetupHandlerDeps = {
   worktreeList: (repoPath) => gitService.worktreeList(repoPath)
 }
 registerProjectSetupHandlers(corePlatform, projectSetupService, projectSetupDeps)
+// `worktree:materialize-shared` — same sibling-registrar shape and the SAME trust boundary as the
+// setup runner (rootPath/ssh derived from THIS process's index by projectId, `worktreePath`
+// re-validated against the project's actual git worktrees); the sharedPaths LIST is read here by
+// projectId, never taken off the wire. Reuses the very `projectTargetInfo`/`worktreeList` the setup
+// deps already carry, plus the store's own settings resolution.
+registerWorktreeSharedPathsHandlers(corePlatform, {
+  readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
+  targetInfo: projectSetupDeps.projectTargetInfo,
+  worktreeList: projectSetupDeps.worktreeList
+})
 // `project-settings:launch-info` — a sibling registrar (not a widening of
 // WorkspaceStore.registerIpc()) sharing the trust store constructed above.
 registerProjectLaunchInfoHandlers(corePlatform, workspaceStore, projectTrustStore)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -185,6 +185,13 @@ const api: NodeTerminalApi = {
       }
     }
   },
+  worktree: {
+    // Wire carries exactly `(projectId, worktreePath)` — never the sharedPaths list: main reads it
+    // itself by projectId and validates the path against the project's own git worktrees
+    // (worktree-shared-paths-handlers.ts).
+    materializeShared: (projectId: string, worktreePath: string) =>
+      ipcRenderer.invoke(IPC.worktreeMaterializeShared, projectId, worktreePath)
+  },
   dialog: {
     selectFolder: () => ipcRenderer.invoke(IPC.dialogSelectFolder),
     selectFile: () => ipcRenderer.invoke(IPC.dialogSelectFile)

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -320,6 +320,12 @@ export function buildStubApi(): Omit<
       onConsentDismiss: noopUnsub,
       onEvent: noopUnsub
     },
+    worktree: {
+      // Real over the bridge (`buildRealApi`'s `worktree`); this fallback only matters if some
+      // future assembly spreads the stub alone. Fails closed with the SAME empty-result shape a
+      // real "nothing was linked" answer uses, so a caller needs no extra branch.
+      materializeShared: () => Promise.resolve([])
+    },
     chat: {
       readTranscript: U('chat.readTranscript')
     },

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -211,7 +211,14 @@ export function buildRealApi(
   client: RpcClient
 ): Pick<
   NodeTerminalApi,
-  'pty' | 'workspace' | 'projectSettings' | 'projectSetup' | 'settings' | 'agent' | 'userDataDir'
+  | 'pty'
+  | 'workspace'
+  | 'projectSettings'
+  | 'projectSetup'
+  | 'worktree'
+  | 'settings'
+  | 'agent'
+  | 'userDataDir'
 > {
   const pty: PtyApi = {
     create: (options: PtyCreateOptions) =>
@@ -343,6 +350,15 @@ export function buildRealApi(
     }
   }
 
+  // REAL: registerWorktreeSharedPathsHandlers (core), same construction point as main/server. Wire
+  // carries exactly `(projectId, worktreePath)`; the server reads the sharedPaths list itself.
+  const worktree: NodeTerminalApi['worktree'] = {
+    materializeShared: (projectId, worktreePath) =>
+      client.request(IPC.worktreeMaterializeShared, projectId, worktreePath) as ReturnType<
+        NodeTerminalApi['worktree']['materializeShared']
+      >
+  }
+
   const settings: SettingsApi = {
     load: () => client.request(IPC.settingsLoad) as Promise<Settings>,
     save: (s: Settings) => client.request(IPC.settingsSave, s) as Promise<void>
@@ -377,7 +393,7 @@ export function buildRealApi(
   // `/worktrees/…` at the filesystem root (the server usually runs as root, and git would create it).
   const userDataDir = (): Promise<string> => client.request(IPC.appUserDataDir) as Promise<string>
 
-  return { pty, workspace, projectSettings, projectSetup, settings, agent, userDataDir }
+  return { pty, workspace, projectSettings, projectSetup, worktree, settings, agent, userDataDir }
 }
 
 export function buildGitHubApi(

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -245,6 +245,8 @@ import {
   computeWorktreePath,
   resolveWorktreePath,
   displacedByWorktree,
+  effectiveWorktreeBaseRef,
+  effectiveWorktreeTemplate,
   isRemoteSessionNode,
   resolveBaseRef,
   sanitizeWorktreeBranch,
@@ -268,7 +270,11 @@ import {
 } from '../terminal/file-drop'
 import { useWorktrees } from '../state/worktrees'
 import { setupAckDecision, setupGateDone, useProjectSetup } from '../state/projectSetup'
-import { ensureProjectLaunchInfo, invalidateProjectLaunchInfo } from '../state/projectLaunchInfo'
+import {
+  ensureProjectLaunchInfo,
+  invalidateProjectLaunchInfo,
+  projectLaunchInfoNow
+} from '../state/projectLaunchInfo'
 import { activeSessionApi } from '../session/session'
 import {
   agentConfig,
@@ -1177,6 +1183,15 @@ export function Canvas() {
   }, [getViewport, setViewport])
 
   const activeProjectId = useProjects((s) => s.activeProjectId)
+  // Project-level worktree defaults (basePath/baseRef) for the active project, read from the warmed
+  // launch-info cache. Fed to the "New worktree" dialog defaults below; the open-worktree verb reads
+  // its own project's entry separately. Absent (project never warmed, or it sets neither) → the
+  // `effectiveWorktree*` resolvers fall back to entries/global, i.e. today's exact behavior.
+  const activeWorktreePw = projectLaunchInfoNow(activeProjectId ?? '')?.resolved.worktree
+  const activeWorktreeDefaults = {
+    basePath: activeWorktreePw?.basePath?.value,
+    baseRef: activeWorktreePw?.baseRef?.value
+  }
   // Bumped by `requestReload()`; a dependency of the project-load effect so an in-place reload of
   // the ALREADY-active project actually re-runs it (see reloadActiveProject).
   const reloadNonce = useProjects((s) => s.reloadNonce)
@@ -7733,14 +7748,22 @@ export function Canvas() {
               }
               bindGroupId = g.id
             }
-            const baseRef = args.base?.trim() || resolveBaseRef(entries)
+            // Project-level worktree defaults (basePath/baseRef) from the warmed launch-info cache,
+            // same as the "New worktree" dialog. Fail-open: no cached entry → `effectiveWorktree*`
+            // reduce to entries/global exactly as before. An explicit `--base` still wins.
+            const pw = projectLaunchInfoNow(project?.id ?? '')?.resolved.worktree
+            const projectDefaults = { basePath: pw?.basePath?.value, baseRef: pw?.baseRef?.value }
+            const baseRef = args.base?.trim() || effectiveWorktreeBaseRef(projectDefaults, entries)
             // Resolve from this session's repo root, so a relay tab still produces a path on the
             // same host/filesystem where the `api.git` operation below runs.
             const wtPath = await resolveWorktreePath({
               explicitPath: args.path,
               repoRoot,
               branch,
-              template: useSettings.getState().settings.worktreePathTemplate
+              template: effectiveWorktreeTemplate(
+                projectDefaults,
+                useSettings.getState().settings.worktreePathTemplate
+              )
             })
             if (!wtPath) {
               reply({ ok: false, error: 'open-worktree: could not derive a worktree path — pass --path' })
@@ -10178,13 +10201,13 @@ export function Canvas() {
           intent={worktreeDialog.groupId ? 'bind' : 'create'}
           repoPath={worktreeRepoRoot ?? ''}
           existing={worktreeOrphans.filter((e) => !boundWorktreePaths.has(normWorktreePath(e.path)))}
-          defaultBaseRef={resolveBaseRef(worktreeEntries)}
+          defaultBaseRef={effectiveWorktreeBaseRef(activeWorktreeDefaults, worktreeEntries)}
           branches={worktreeBranches}
           defaultPath={(repoPath, branch) =>
             computeWorktreePath(
               repoPath,
               branch,
-              settings.worktreePathTemplate
+              effectiveWorktreeTemplate(activeWorktreeDefaults, settings.worktreePathTemplate)
             )
           }
           busy={worktreeBusy}

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4432,7 +4432,18 @@ export function Canvas() {
       // A fresh checkout is the moment the project's `setup` script exists for: this is the single
       // shared post-create point (the dialog AND agent-control's open-worktree land here), so the
       // trigger lives here rather than being repeated — and never diverging — at each caller.
-      startWorktreeSetup(groupId, wt.path)
+      //
+      // Materialize the project's `sharedPaths` (symlink node_modules/etc back to the repo root)
+      // BEFORE the setup script runs, so a setup `npm install` sees those links. Fire-and-forget re
+      // the bind (it never blocks the frame), but ORDERED before `startWorktreeSetup` — main reads
+      // the sharedPaths list itself by projectId and validates `wt.path`, so a `[]`/reject is safe.
+      void (async () => {
+        const projectId = useProjects.getState().activeProjectId
+        if (projectId) {
+          await window.nodeTerminal.worktree.materializeShared(projectId, wt.path).catch(() => {})
+        }
+        startWorktreeSetup(groupId, wt.path)
+      })()
       // The bound group's id (fresh one when created here) — nodesRef lags setNodes, so
       // callers that need the id (agent-control's open-worktree reply) take it from here.
       return groupId

--- a/src/renderer/components/settings/ProjectSettingsFamilies.tsx
+++ b/src/renderer/components/settings/ProjectSettingsFamilies.tsx
@@ -104,7 +104,16 @@ const FAMILY_CONFIG: Record<ProjectSettingsFamily, FamilyConfig> = {
   worktree: {
     title: 'Worktree',
     fields: [
-      { key: 'basePath', label: 'Base path', kind: 'input' },
+      {
+        key: 'basePath',
+        label: 'Base path',
+        // NB: no literal "project" in this searchable copy — see `fieldEntry` / the "project" query
+        // guard in ProjectSettingsSection.test.tsx. "Local checkouts only" carries the same meaning
+        // as the SSH-inert note without the trap word.
+        description:
+          'Directory new worktrees are created under; overrides the global template. Local checkouts only.',
+        kind: 'input'
+      },
       {
         key: 'baseRef',
         label: 'Base ref',
@@ -113,8 +122,11 @@ const FAMILY_CONFIG: Record<ProjectSettingsFamily, FamilyConfig> = {
       },
       {
         key: 'sharedPaths',
+        // Honest now that the linker exists (core/worktree-shared-paths.ts): it does not error on a
+        // missing source or a target that already exists — it SKIPS them (SharedPathResult).
         label: 'Shared paths',
-        description: 'One relative path per line, symlinked into every worktree.',
+        description:
+          'Relative paths symlinked into each new worktree — e.g. .env, node_modules. Skipped when the source is missing or the target already exists.',
         kind: 'list'
       }
     ]
@@ -476,6 +488,16 @@ const RUN_LABEL: Record<ProjectSetupKind, string> = { setup: 'Run setup', archiv
 export const LAUNCH_CMD_UNPAIRED_NOTE =
   'Launch command applies only when a Default agent id is set above.'
 
+/**
+ * The whole worktree family is INERT on an SSH project: `git worktree` runs against the local
+ * filesystem, and an SSH project has no local checkout to create worktrees in (both creation sites —
+ * the "New worktree" dialog and the `open-worktree` verb — refuse SSH outright). Shown on every
+ * worktree row so a value typed there does not look as if it will ever take effect. Unlike the
+ * searchable field copy this note may say "project" — it is a `note`, not part of any search entry.
+ */
+export const WORKTREE_SSH_INERT_NOTE =
+  'Worktree settings apply to local projects; this is an SSH project.'
+
 /** How a finished run reads in the badge. */
 function exitNote(state: 'done' | 'failed' | 'cancelled', exitCode: number | undefined): string {
   if (state === 'cancelled') return 'Cancelled'
@@ -629,6 +651,7 @@ function FamilySection({
   ready,
   sharedEditable,
   canRun,
+  ssh,
   saveShared,
   saveLocal,
   reload
@@ -654,6 +677,9 @@ function FamilySection({
    *  shared-editing gate entirely (a machine-local script on a folderless project still cannot
    *  run). */
   canRun: boolean
+  /** SSH project → the whole `worktree` family is inert (no local checkout). Drives the per-row
+   *  caveat below; ignored by every other family. */
+  ssh: boolean
   saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
   saveLocal: (
     update: (current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined
@@ -723,15 +749,21 @@ function FamilySection({
     family === 'agents' &&
     resolvedFamily.launchCmd !== undefined &&
     resolvedFamily.defaultAgentId === undefined
+  // The whole worktree family cannot take effect on an SSH project (no local checkout) — every row
+  // of it carries the caveat, not just one.
+  const worktreeInert = family === 'worktree' && ssh
   /** The caveat WINS over the provenance note ("Active" / "Overridden on this machine"): where the
    *  value comes from hardly matters while nothing consumes it. */
-  const unpairedNote = (f: FieldConfig): string | undefined =>
-    launchCmdUnpaired && f.key === 'launchCmd' ? LAUNCH_CMD_UNPAIRED_NOTE : undefined
+  const caveatNote = (f: FieldConfig): string | undefined => {
+    if (worktreeInert) return WORKTREE_SSH_INERT_NOTE
+    if (launchCmdUnpaired && f.key === 'launchCmd') return LAUNCH_CMD_UNPAIRED_NOTE
+    return undefined
+  }
 
   const renderShared = (f: FieldConfig): React.JSX.Element => {
     const overridden = resolvedFamily[f.key]?.source === 'local'
     const id = `project-${family}-${f.key}-${projectId}`
-    const overrideNote = unpairedNote(f) ?? (overridden ? 'Overridden on this machine' : undefined)
+    const overrideNote = caveatNote(f) ?? (overridden ? 'Overridden on this machine' : undefined)
     if (f.kind === 'switch') {
       return (
         <SwitchField
@@ -792,7 +824,7 @@ function FamilySection({
   const renderLocal = (f: FieldConfig): React.JSX.Element => {
     const active = resolvedFamily[f.key]?.source === 'local'
     const id = `project-${family}-${f.key}-local-${projectId}`
-    const activeNote = unpairedNote(f) ?? (active ? 'Active' : undefined)
+    const activeNote = caveatNote(f) ?? (active ? 'Active' : undefined)
     if (f.kind === 'switch') {
       return (
         <SwitchField
@@ -905,6 +937,7 @@ export function ProjectFamilyEditors({
   conflict,
   sharedEditable,
   canRun,
+  ssh = false,
   saveShared,
   saveLocal,
   reload
@@ -926,6 +959,9 @@ export function ProjectFamilyEditors({
   /** See `FamilySection`'s `canRun`: where a PROCESS may be spawned, which is a different question
    *  from where the shared file may be written. */
   canRun: boolean
+  /** SSH project → the worktree family is inert (local-only feature). Defaults false; forwarded to
+   *  each `FamilySection` for its per-row caveat. */
+  ssh?: boolean
   saveShared: (doc: ProjectSettingsDoc) => Promise<boolean>
   saveLocal: (
     update: (current: ProjectLocalSettings | undefined) => ProjectLocalSettings | undefined
@@ -959,6 +995,7 @@ export function ProjectFamilyEditors({
           ready={ready}
           sharedEditable={sharedEditable}
           canRun={canRun}
+          ssh={ssh}
           saveShared={saveShared}
           saveLocal={saveLocal}
           reload={reload}

--- a/src/renderer/components/settings/project-settings-worktree-panel.test.tsx
+++ b/src/renderer/components/settings/project-settings-worktree-panel.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+//
+// Settings → Project → Worktree: honest field copy + the "inert on SSH" caveat.
+//
+// Worktrees are LOCAL-only (`git worktree` runs against the project's own filesystem), so on an SSH
+// project none of these settings can take effect. An inert setting that looks editable is a lie the
+// panel has to correct on the row itself — same mechanism as the Agents family's unpaired launchCmd
+// note. The base-path / shared-paths descriptions are also asserted here: they must describe what
+// the code actually does, and must avoid the literal substring "project" (the searchable copy would
+// otherwise make the non-discriminating query "project" match the whole pane).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { ResolvedProjectSettings } from '@shared/project-settings'
+import { WORKTREE_SSH_INERT_NOTE, ProjectFamilyEditors } from './ProjectSettingsFamilies'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+let host: HTMLElement
+
+const EMPTY_RESOLVED: ResolvedProjectSettings = { setup: {}, worktree: {}, agents: {}, terminal: {} }
+
+function mount({ ssh = false }: { ssh?: boolean } = {}): void {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() =>
+    root.render(
+      <ProjectFamilyEditors
+        projectId="p1"
+        snapshot={{ shared: null, local: undefined }}
+        resolved={EMPTY_RESOLVED}
+        conflict={false}
+        sharedEditable
+        canRun
+        ssh={ssh}
+        saveShared={async () => true}
+        saveLocal={async () => true}
+        reload={() => {}}
+      />
+    )
+  )
+}
+
+/** Every field row whose visible label is `label` (the shared row and its "this machine" twin). */
+function rows(label: string): HTMLElement[] {
+  return [...host.querySelectorAll('label')]
+    .filter((el) => el.textContent === label)
+    .map((el) => el.parentElement as HTMLElement)
+}
+
+const noteCount = (): number => (host.textContent ?? '').split(WORKTREE_SSH_INERT_NOTE).length - 1
+
+beforeEach(() => {
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {}
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+describe('Worktree family — honest field copy', () => {
+  it('describes shared paths by what the linker actually does', () => {
+    mount()
+    const sharedPaths = rows('Shared paths')[0]
+    expect(sharedPaths.textContent).toContain('symlinked into each new worktree')
+    // The honest caveats: missing source / pre-existing target are SKIPPED, not errors.
+    expect(sharedPaths.textContent).toContain('Skipped when the source is missing')
+    expect(sharedPaths.textContent).toContain('the target already exists')
+  })
+
+  it('gives the base path a description saying it overrides the global template', () => {
+    mount()
+    const basePath = rows('Base path')[0]
+    expect(basePath.textContent).toContain('new worktrees are created under')
+    expect(basePath.textContent).toContain('overrides the global template')
+  })
+
+  it('keeps its searchable copy free of the literal "project" substring', () => {
+    // The non-discriminating query "project" must not match every worktree field (it would mount
+    // every open project's pane). Descriptions are searchable, so they carry no "project".
+    mount()
+    for (const label of ['Base path', 'Base ref', 'Shared paths']) {
+      const desc = rows(label)[0].querySelector('p')?.textContent ?? ''
+      expect(desc.toLowerCase()).not.toContain('project')
+    }
+  })
+})
+
+describe('Worktree family — the SSH-inert caveat', () => {
+  it('warns on EVERY worktree row (shared + this machine) for an SSH project', () => {
+    mount({ ssh: true })
+    for (const label of ['Base path', 'Base ref', 'Shared paths']) {
+      const labelRows = rows(label)
+      expect(labelRows).toHaveLength(2) // shared + "this machine"
+      for (const row of labelRows) expect(row.textContent).toContain(WORKTREE_SSH_INERT_NOTE)
+    }
+    // Six worktree rows, and only those.
+    expect(noteCount()).toBe(6)
+  })
+
+  it('says nothing for a local project', () => {
+    mount({ ssh: false })
+    expect(noteCount()).toBe(0)
+  })
+
+  it('does not leak the worktree caveat onto other families', () => {
+    mount({ ssh: true })
+    for (const row of rows('Shell')) {
+      expect(row.textContent).not.toContain(WORKTREE_SSH_INERT_NOTE)
+    }
+  })
+})

--- a/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
+++ b/src/renderer/components/settings/sections/ProjectSettingsSection.tsx
@@ -345,6 +345,9 @@ function EditableProjectSection({
         // Same predicate today, deliberately a separate prop: this one gates SPAWNING a setup
         // script, not writing the shared file — see `FamilySection`'s `canRun`.
         canRun={Boolean(project.cwd || project.ssh)}
+        // An SSH project has no local checkout, so the worktree family is inert — the panel says so
+        // on each of its rows (both creation sites already refuse SSH).
+        ssh={Boolean(project.ssh)}
         saveShared={settings.saveShared}
         saveLocal={settings.saveLocal}
         reload={settings.reload}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -39,6 +39,7 @@ import {
   type ProjectSetupHandlerDeps
 } from '../core/project-setup-handlers'
 import { registerProjectLaunchInfoHandlers } from '../core/project-launch-info-handlers'
+import { registerWorktreeSharedPathsHandlers } from '../core/worktree-shared-paths-handlers'
 import { makeProjectSpawnOverrides } from '../core/project-spawn-overrides'
 import { makeLocalSetupRunner } from '../core/project-setup-runner-local'
 import { LogBuffer } from '../core/log-buffer'
@@ -294,6 +295,14 @@ export async function startServer(
     worktreeList: (repoPath) => gitService.worktreeList(repoPath)
   }
   registerProjectSetupHandlers(platform, projectSetupService, projectSetupDeps)
+  // `worktree:materialize-shared` — same sibling registrar and trust boundary as main/index.ts,
+  // over this process's own stores. The Server Edition has no SSH projects, so an ssh-shaped target
+  // never arises; the path validation and by-projectId list read are identical.
+  registerWorktreeSharedPathsHandlers(platform, {
+    readSettings: (projectId) => workspaceStore.readProjectSettings(projectId),
+    targetInfo: projectSetupDeps.projectTargetInfo,
+    worktreeList: projectSetupDeps.worktreeList
+  })
   // `project-settings:launch-info` — same sibling registrar as main/index.ts, sharing this
   // process's own trust store.
   registerProjectLaunchInfoHandlers(platform, workspaceStore, projectTrustStore)

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -276,6 +276,13 @@ export const IPC = {
   projectSetupEvent: (projectId: string) => `project-setup:event:${projectId}`,
   projectSetupSubscribe: 'project-setup:subscribe',
   projectSetupUnsubscribe: 'project-setup:unsubscribe',
+  /** Renderer → core: symlink a project's `sharedPaths` from its repo root into a freshly-created
+   *  git worktree. Args carry ONLY `(projectId, worktreePath)` — NEVER the path list, which the
+   *  handler reads itself by projectId (the list is untrusted from a renderer). The handler
+   *  validates `worktreePath` is that project's rootPath or one of its actual git worktrees, and
+   *  refuses an SSH project (local-only this PR); an unknown/invalid input answers `[]`. Resolves
+   *  `SharedPathResult[]`. See core/worktree-shared-paths-handlers.ts. */
+  worktreeMaterializeShared: 'worktree:materialize-shared',
   // main → renderer events
   workspaceMigrated: 'workspace:migrated',
   /** Payload: the `workspace.json.corrupt-<ts>` filename the unreadable index was preserved as. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -821,6 +821,23 @@ export interface ProjectSetupApi {
   onEvent(projectId: string, cb: (ev: import('./project-settings').ProjectSetupEvent) => void): () => void
 }
 
+export interface WorktreeApi {
+  /**
+   * Symlink a project's configured `sharedPaths` (git-ignored dirs like `node_modules`) from its
+   * repo root into a freshly-created git worktree, so a setup `npm install` there sees the links.
+   *
+   * The renderer passes ONLY `(projectId, worktreePath)` — never the path list: main reads the list
+   * itself out of the project's settings by `projectId`, derives the repo root from its own
+   * workspace index, and validates `worktreePath` is that project's rootPath or one of its actual
+   * git worktrees. An unknown project, an unvalidated path, or an SSH project (local-only this PR)
+   * all resolve `[]`. Never rejects — a per-entry `SharedPathResult[]` reports what happened.
+   */
+  materializeShared(
+    projectId: string,
+    worktreePath: string
+  ): Promise<import('./worktree').SharedPathResult[]>
+}
+
 export interface DialogApi {
   /** Opens a native folder picker; returns the chosen path or null if cancelled. */
   selectFolder(): Promise<string | null>
@@ -2532,6 +2549,7 @@ export interface NodeTerminalApi {
   workspace: WorkspaceApi
   projectSettings: ProjectSettingsApi
   projectSetup: ProjectSetupApi
+  worktree: WorktreeApi
   dialog: DialogApi
   settings: SettingsApi
   speech: SpeechApi

--- a/src/shared/worktree.test.ts
+++ b/src/shared/worktree.test.ts
@@ -15,8 +15,12 @@ import {
   worktreeFromCreate,
   worktreeFromEntry,
   worktreeRemoveMessage,
+  effectiveWorktreeBaseRef,
+  effectiveWorktreeTemplate,
   DEFAULT_BASE_REF,
-  type WorktreeEntry
+  DEFAULT_WORKTREE_PATH_TEMPLATE,
+  type WorktreeEntry,
+  type ProjectWorktreeDefaults
 } from './worktree'
 import { filterWorktrees } from './worktree'
 
@@ -442,5 +446,69 @@ describe('filterWorktrees', () => {
   it('returns every entry for a blank query and none for a miss', () => {
     expect(filterWorktrees(entries, '  ')).toBe(entries)
     expect(filterWorktrees(entries, 'not-here')).toEqual([])
+  })
+})
+
+// Pure worktree-creation resolver: what baseRef and path TEMPLATE a new worktree should default to,
+// given a project's own settings. Neither function does IO or validates a path — computeWorktreePath
+// (the caller) already refuses a shallow-rooted result, so a hostile basePath is left to fall back
+// exactly as it does today; see the `computeWorktreePath` case below.
+describe('effectiveWorktreeBaseRef', () => {
+  const entries = [entry('/repo', 'trunk'), entry('/wt/x', 'feature/x')]
+
+  it('a project baseRef wins over the repo-derived default', () => {
+    const project: ProjectWorktreeDefaults = { baseRef: 'release' }
+    expect(effectiveWorktreeBaseRef(project, entries)).toBe('release')
+  })
+
+  it('falls back to resolveBaseRef(entries) when the project has no baseRef', () => {
+    expect(effectiveWorktreeBaseRef(undefined, entries)).toBe('trunk')
+    expect(effectiveWorktreeBaseRef({}, entries)).toBe('trunk')
+  })
+
+  it('treats a whitespace-only project baseRef as unset', () => {
+    expect(effectiveWorktreeBaseRef({ baseRef: '   ' }, entries)).toBe('trunk')
+  })
+
+  it('falls all the way to DEFAULT_BASE_REF when neither the project nor the repo says', () => {
+    expect(effectiveWorktreeBaseRef(undefined, [])).toBe(DEFAULT_BASE_REF)
+  })
+})
+
+describe('effectiveWorktreeTemplate', () => {
+  it('a set project basePath becomes `<basePath>/${branch}`', () => {
+    expect(effectiveWorktreeTemplate({ basePath: '/srv/worktrees' }, undefined)).toBe(
+      '/srv/worktrees/${branch}'
+    )
+  })
+
+  it('joins with exactly one slash even when basePath has a trailing slash', () => {
+    expect(effectiveWorktreeTemplate({ basePath: '/srv/worktrees/' }, undefined)).toBe(
+      '/srv/worktrees/${branch}'
+    )
+  })
+
+  it('a whitespace-only basePath is ignored, falling through to the global template', () => {
+    expect(effectiveWorktreeTemplate({ basePath: '   ' }, './worktrees')).toBe('./worktrees')
+  })
+
+  it('falls back to the trimmed global template when there is no project basePath', () => {
+    expect(effectiveWorktreeTemplate(undefined, '  ./worktrees  ')).toBe('./worktrees')
+    expect(effectiveWorktreeTemplate({}, './worktrees')).toBe('./worktrees')
+  })
+
+  it('falls back to DEFAULT_WORKTREE_PATH_TEMPLATE when neither project basePath nor global template is set', () => {
+    expect(effectiveWorktreeTemplate(undefined, undefined)).toBe(DEFAULT_WORKTREE_PATH_TEMPLATE)
+    expect(effectiveWorktreeTemplate({}, '   ')).toBe(DEFAULT_WORKTREE_PATH_TEMPLATE)
+  })
+
+  // The function itself does no path resolution or validation — it only builds a template string.
+  // A hostile basePath like '/' must still end up refused, but that refusal happens DOWNSTREAM in
+  // computeWorktreePath (via resolvePathFromRepo's shallow-root guard), not here. Prove the chain
+  // actually holds by feeding the synthesized template through computeWorktreePath.
+  it('a rooted basePath produces a template that computeWorktreePath later refuses', () => {
+    const template = effectiveWorktreeTemplate({ basePath: '/' }, undefined)
+    expect(template).toBe('/${branch}')
+    expect(computeWorktreePath('/src/repo', 'topic/a', template)).toBe('')
   })
 })

--- a/src/shared/worktree.ts
+++ b/src/shared/worktree.ts
@@ -188,6 +188,43 @@ export function resolveBaseRef(entries: WorktreeEntry[]): string {
   return entries[0]?.branch?.trim() || DEFAULT_BASE_REF
 }
 
+/** The worktree-related fields a project can override — see `effectiveWorktreeBaseRef` /
+ *  `effectiveWorktreeTemplate`. Both optional: an unset or whitespace-only value defers below it. */
+export interface ProjectWorktreeDefaults {
+  basePath?: string
+  baseRef?: string
+}
+
+/**
+ * The baseRef a NEW worktree should default to: a project override wins, else the repo's own
+ * default branch (`resolveBaseRef`, which falls back to `DEFAULT_BASE_REF`). Pure — no IO.
+ */
+export function effectiveWorktreeBaseRef(
+  project: ProjectWorktreeDefaults | undefined,
+  entries: WorktreeEntry[]
+): string {
+  return project?.baseRef?.trim() || resolveBaseRef(entries)
+}
+
+/**
+ * The path TEMPLATE a new worktree's location should expand from — fed straight into
+ * `computeWorktreePath`. A project `basePath` becomes `<basePath>/${branch}` (exactly one slash
+ * between the two); otherwise the given global template, or `DEFAULT_WORKTREE_PATH_TEMPLATE`.
+ *
+ * Deliberately does NOT resolve or validate `basePath` — `computeWorktreePath`'s
+ * `resolvePathFromRepo` already refuses a template that resolves to (or under) the filesystem root,
+ * so a hostile `basePath` such as `'/'` synthesizes `/${branch}`, which that downstream guard
+ * refuses (returns `''`), and creation falls back exactly as it does today. Pure — no IO.
+ */
+export function effectiveWorktreeTemplate(
+  project: ProjectWorktreeDefaults | undefined,
+  globalTemplate: string | undefined
+): string {
+  const basePath = project?.basePath?.trim()
+  if (basePath) return `${basePath.replace(/\/+$/, '')}/\${branch}`
+  return globalTemplate?.trim() || DEFAULT_WORKTREE_PATH_TEMPLATE
+}
+
 /**
  * Binding for a worktree THIS APP just created — `createdByApp: true` grants Remove the right
  * to delete the directory. Only call this after `git worktree add` succeeded.

--- a/src/shared/worktree.ts
+++ b/src/shared/worktree.ts
@@ -11,6 +11,22 @@ export interface GroupWorktree {
   createdByApp: boolean
 }
 
+/** One entry's outcome from materializing a project's `sharedPaths` into a worktree
+ *  (core/worktree-shared-paths.ts). Lives here in `shared` so the renderer's `WorktreeApi` type can
+ *  name it without importing core; core's module re-exports it for its own callers/tests. */
+export interface SharedPathResult {
+  path: string
+  status:
+    | 'linked'
+    | 'skipped-missing-source'
+    | 'skipped-exists'
+    | 'skipped-reserved'
+    | 'skipped-unsafe'
+    | 'error'
+  /** Present only for `error` (or a noteworthy skip): a short human-readable reason. */
+  note?: string
+}
+
 export interface WorktreeEntry {
   path: string
   branch: string | null


### PR DESCRIPTION
## Summary

PR5 — the **final phase** of the Project Settings series. **Stacked on #332** (consumption), which stacks #323 → #317 → #315. It makes the worktree family's promises real.

- **baseRef / basePath consumption** — a pure resolver (`effectiveWorktreeBaseRef`: project override → git main-checkout branch → `main`; `effectiveWorktreeTemplate`: a set `basePath` becomes a `<basePath>/${branch}` template fed through the existing `computeWorktreePath` path-safety, so a hostile `basePath` is refused downstream exactly as today). Consumed at both creation sites (the new-worktree dialog and the `open-worktree` agent verb) via `projectLaunchInfoNow` — the value already rides PR4's launch-info snapshot, so no IPC change. **Fail-open, verified byte-identical:** a project with no override creates worktrees exactly as before.
- **sharedPaths materialization** — net-new `materializeSharedPaths` symlinks each relative path from the checkout into every new worktree (`.env`, `node_modules`), per-entry fail-safe (`skipped-unsafe`/`reserved`/`missing-source`/`exists`, never overwrites, never throws), wired through a `worktree:materialize-shared` IPC that **reads the path list itself main-side by projectId** (never a renderer-supplied list) and validates the worktree path against the project's actual worktrees — run **before** the setup script so a setup `npm install` sees the links.
- **Security — realpath containment.** `git worktree add` checks out attacker-controllable tracked symlinks, so a lexical within-root check is insufficient: an intermediate symlink (`wt/cfg → /outside`) would let a shared `sharedPaths: ['cfg/x']` plant a link — or `mkdir` an empty dir — outside the worktree. Both the symlink target/source and the `mkdir` are now contained by realpath-of-deepest-existing-ancestor checks that fail closed; the worktree family stays ungated because these guards (not consent) are what make it safe. Both primitives were proven exploitable pre-fix and are closed with tests asserting nothing lands outside the root.
- **Honest panel copy** — the sharedPaths description now matches the real skip semantics, `basePath` gains a description, and every worktree row carries an SSH-inert caveat note on SSH projects.

## Scope ruling: SSH worktree *creation* parity is a flagged follow-up (needs your sign-off)

The series listed "SSH worktree parity" for PR5, but remote worktree **creation** is unreachable today, refused at 4+ layers because a local `fs.existsSync` cannot stat a remote host — lifting it means owning the destructive `worktreeGone` false-positive the git-service tripwire warns about. That is a separable, risk-bearing subsystem change, not settings consumption, and I would not lift a deliberate safety gate unattended. PR5 keeps the worktree family **editable-but-inert** on SSH projects with honest per-row copy (and the materialize handler returns `[]` for SSH as defense-in-depth). Remote worktree creation + remote sharedPaths is the follow-up, gated on your decision about the destructive-delete risk.

## Test plan

- +34 tests (pure resolver incl. the rooted-basePath refusal proven through `computeWorktreePath`; materialization's every skip reason + never-overwrite against a broken symlink + both realpath-escape PoCs asserting the outside path is absent; the by-projectId handler trust boundary; the SSH-inert panel note).
- Full suite: 7761 passed / 12 skipped; typecheck clean on both configs.

## Series complete

With this, the five-PR Project Settings series is up for review: **#315 core → #317 panel → #323 trust/setup → #332 consumption → #333 worktree.** See the individual PR bodies for the spec deviations awaiting ratification and the accumulated observability-wave follow-ups. Mac + live-SSH device verification owed across the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)