### PR TITLE
feat(codex): the machine-grouped accounts UI, provenance pills, and the switch

### DIFF
--- a/src/main/codex-accounts.test.ts
+++ b/src/main/codex-accounts.test.ts
@@ -115,4 +115,15 @@ describe('Codex local account lifecycle (Task 5.1)', () => {
     await expect(call(IPC.codexAccountsWaitLogin, '../escape')).rejects.toThrow(/Invalid Codex account id/)
     await expect(call(IPC.codexAccountsRemove, '../escape')).rejects.toThrow(/Invalid Codex account id/)
   })
+
+  it('systemIdentity reads THIS Mac by default but fails closed for a remote projectId', async () => {
+    // No ctx ⇒ this Mac's system login (the mocked app-server reader).
+    await expect(call(IPC.codexAccountsSystemIdentity)).resolves.toEqual({ email: 'me@example.com' })
+    // A remote `{ projectId }` request cannot be resolved by this build, so it MUST resolve null —
+    // never THIS Mac's identity (§5 "system-account discovery must not fabricate an account"; a
+    // remote machine panel never borrows the local login).
+    // MUTATION PIN: change the handler to return `accountIdentity()` for a remote projectId
+    // (fail-OPEN) and this assertion reds.
+    await expect(call(IPC.codexAccountsSystemIdentity, { projectId: 'proj-1' })).resolves.toBeNull()
+  })
 })

--- a/src/main/codex-accounts.ts
+++ b/src/main/codex-accounts.ts
@@ -238,7 +238,15 @@ export function initCodexAccounts(getSshManager?: () => SshProjectManager | unde
 
   ipcMain.handle(IPC.codexAccountsIdentity, (_event, id: string) => existingManagedIdentity(id))
 
-  ipcMain.handle(IPC.codexAccountsSystemIdentity, () => accountIdentity())
+  // No ctx ⇒ this Mac's system identity. A `{ projectId }` ctx asks for a remote HOST's system
+  // identity, which this build does not yet resolve — fail closed to `null` rather than returning
+  // THIS Mac's login, so a remote machine panel never fabricates/borrows a local identity
+  // (§5 "system-account discovery must not fabricate an account"). Remote resolution is a follow-up.
+  ipcMain.handle(
+    IPC.codexAccountsSystemIdentity,
+    (_event, ctx?: { projectId?: string }) =>
+      ctx?.projectId ? Promise.resolve(null) : accountIdentity()
+  )
 
   ipcMain.handle(IPC.codexAccountsRemove, async (_event, id: string) => {
     assertCodexAccountId(id)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -473,7 +473,7 @@ const api: NodeTerminalApi = {
     waitLogin: (id) => ipcRenderer.invoke(IPC.codexAccountsWaitLogin, id),
     cancelWaitLogin: (id) => ipcRenderer.invoke(IPC.codexAccountsCancelWait, id),
     identity: (id) => ipcRenderer.invoke(IPC.codexAccountsIdentity, id),
-    systemIdentity: () => ipcRenderer.invoke(IPC.codexAccountsSystemIdentity),
+    systemIdentity: (ctx) => ipcRenderer.invoke(IPC.codexAccountsSystemIdentity, ctx),
     remove: (id) => ipcRenderer.invoke(IPC.codexAccountsRemove, id),
     switchThread: (threadId, cwd, sourceAccountId, targetAccountId) =>
       ipcRenderer.invoke(

--- a/src/renderer/canvas/codex-account-switch.test.ts
+++ b/src/renderer/canvas/codex-account-switch.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { CodexAccount } from '@shared/codex-account'
+import { codexAccountSelectable, codexAccountSwitchStillEligible } from './codex-account-switch'
+
+const expected = {
+  accountId: 'account-a',
+  agentId: 'codex',
+  cwd: '/repo',
+  sessionId: 'thread-a',
+  ssh: false
+}
+
+describe('codexAccountSwitchStillEligible', () => {
+  it('accepts only the unchanged idle source conversation', () => {
+    expect(codexAccountSwitchStillEligible(expected, { ...expected, state: 'done' })).toBe(true)
+  })
+
+  it('accepts an unchanged remote source without pretending it is local', () => {
+    const remote = { ...expected, ssh: true }
+    expect(codexAccountSwitchStillEligible(remote, { ...remote, state: 'done' })).toBe(true)
+  })
+
+  it.each([
+    { name: 'still working', current: { ...expected, state: 'working' } },
+    // MUTATION PIN: drop the `sessionId` equality from the eligibility check → this case
+    // (a diverged thread) goes green, i.e. a forked pane would be recycled. Must stay red.
+    { name: 'sessionId diverged', current: { ...expected, sessionId: 'thread-new', state: 'done' } },
+    { name: 'accountId changed', current: { ...expected, accountId: 'account-b', state: 'done' } },
+    { name: 'cwd moved', current: { ...expected, cwd: '/other', state: 'done' } },
+    { name: 'ssh flag flipped', current: { ...expected, ssh: true, state: 'done' } }
+  ])('rejects state drift before recycle: $name', ({ current }) => {
+    expect(codexAccountSwitchStillEligible(expected, current)).toBe(false)
+  })
+})
+
+describe('codexAccountSelectable (fail-closed selection — Property 4)', () => {
+  const local: CodexAccount = { id: 'account-a', label: 'Work' }
+  const remote: CodexAccount = { id: 'account-r', label: 'Box', host: 'u@box' }
+  const accounts = [local, remote]
+  const connected = (host: string) => (host === 'u@box' ? 'proj-1' : undefined)
+  const noConnection = () => undefined
+
+  it('allows the system account (no id) on this Mac', () => {
+    expect(codexAccountSelectable(undefined, accounts, noConnection)).toEqual({ ok: true })
+    expect(codexAccountSelectable('', accounts, noConnection)).toEqual({ ok: true })
+  })
+
+  it('allows a present local managed account', () => {
+    expect(codexAccountSelectable('account-a', accounts, noConnection)).toEqual({ ok: true })
+  })
+
+  it('refuses an explicitly selected MISSING account instead of falling back', () => {
+    // The user picked an id that is no longer in the settings list — refuse, never resolve it to
+    // the system login or any other account.
+    expect(codexAccountSelectable('account-gone', accounts, connected)).toEqual({
+      ok: false,
+      reason: 'unavailable'
+    })
+  })
+
+  it('refuses a hostile account id even when a matching row is PRESENT in settings', () => {
+    // settings.json is attacker-controlled (Constraint 7): a hostile row can carry an escaping id.
+    // MUTATION PIN: drop the isSafeAccountId guard → this row is FOUND (local, no host) and returns
+    // { ok: true }, i.e. a path-escaping id becomes a launch target. Must stay red.
+    const hostile: CodexAccount = { id: '../escape', label: 'evil' }
+    expect(codexAccountSelectable('../escape', [...accounts, hostile], connected)).toEqual({
+      ok: false,
+      reason: 'unavailable'
+    })
+  })
+
+  it('refuses a remote account with no live connection — never runs it locally', () => {
+    // MUTATION PIN: drop the `account.host && !connection` gate → this goes { ok: true } and the
+    // remote switch would run against the LOCAL login. Must stay red.
+    expect(codexAccountSelectable('account-r', accounts, noConnection)).toEqual({
+      ok: false,
+      reason: 'no-connection'
+    })
+  })
+
+  it('allows a remote account once its host is connected', () => {
+    expect(codexAccountSelectable('account-r', accounts, connected)).toEqual({ ok: true })
+  })
+})

--- a/src/renderer/canvas/codex-account-switch.ts
+++ b/src/renderer/canvas/codex-account-switch.ts
@@ -7,6 +7,21 @@
 //   2. `codexAccountSelectable` — an explicitly selected account that is MISSING, unsafe, or a
 //      remote account with no live connection is REFUSED; the UI never silently falls back to
 //      another login (§5 Property 4 / Decision 2).
+//
+// READERS / follow-up wiring:
+//   - `codexAccountSelectable` is consumed today by the Accounts settings UI
+//     (`AccountsSection.tsx`), which drives each Codex row's operable/warning state through it — one
+//     definition of "operable" for the surface PR 8 builds. It is ALSO the gate the "New Codex
+//     node" account picker must route every pick through once that picker exists. That picker is a
+//     FOLLOW-UP (surface §3.4): the base node factory deliberately refuses a non-Claude accountId
+//     (`createAgentNode` in `state/workspace.ts` stamps `accountId` only when `agentId==='claude'`)
+//     and `addAgentNode` validates against `claudeAccounts`, so wiring a Codex picker first needs
+//     the factory/creation path to carry codex account ids. The pty spawn side already honours one
+//     (`pty-manager.ts` applies `codexSessionEnv` and fails closed on a missing home).
+//   - `codexAccountSwitchStillEligible` is the recycle gate the account-SWITCH menu (surface §3.5)
+//     must consult before reusing the source pane. That menu is a FOLLOW-UP: the renderer switch
+//     bridge (`codexAccounts.switchThread` et al.) is still a stub, so no switch is originated in
+//     the renderer yet. When the switch menu lands it MUST gate recycle on this function.
 
 import type { CodexAccount } from '@shared/codex-account'
 import { isSafeAccountId } from '@shared/codex-account'

--- a/src/renderer/canvas/codex-account-switch.ts
+++ b/src/renderer/canvas/codex-account-switch.ts
@@ -1,0 +1,89 @@
+// S6 PR 8 — the renderer-side gates for the Codex account switch/create UI. The actual
+// authorization is main-side (PR 5's three-phase, owner-authorized switch); NOTHING here is the
+// security boundary. These are the renderer's own fail-closed refusals so the UI can never
+// ORIGINATE an unauthorized or fail-open switch:
+//   1. `codexAccountSwitchStillEligible` — the source pane may be recycled only if it is still the
+//      exact idle conversation the user chose when the fork began (Corvin's #112 guard).
+//   2. `codexAccountSelectable` — an explicitly selected account that is MISSING, unsafe, or a
+//      remote account with no live connection is REFUSED; the UI never silently falls back to
+//      another login (§5 Property 4 / Decision 2).
+
+import type { CodexAccount } from '@shared/codex-account'
+import { isSafeAccountId } from '@shared/codex-account'
+import { restartEligibility } from '../terminal/agent-restart'
+
+export interface CodexAccountSwitchState {
+  accountId?: string
+  agentId?: string
+  cwd?: string
+  sessionId?: string
+  ssh?: boolean
+  state?: string
+}
+
+/**
+ * The account fork can take seconds. Nothing may recycle the source pane unless it is still the
+ * exact idle conversation that the user chose when the fork began. The `sessionId` equality is the
+ * "resume the same conversation id, never fork" enforcement — a pane whose thread has diverged is
+ * never recycled onto the switched account.
+ */
+export function codexAccountSwitchStillEligible(
+  expected: Required<Pick<CodexAccountSwitchState, 'agentId' | 'cwd' | 'sessionId'>> &
+    Pick<CodexAccountSwitchState, 'accountId' | 'ssh'>,
+  current: CodexAccountSwitchState
+): boolean {
+  return (
+    current.agentId === expected.agentId &&
+    current.agentId === 'codex' &&
+    !!current.ssh === !!expected.ssh &&
+    current.cwd === expected.cwd &&
+    current.accountId === expected.accountId &&
+    current.sessionId === expected.sessionId &&
+    restartEligibility('codex', current.state, current.sessionId).ok
+  )
+}
+
+/**
+ * Why a chosen Codex account cannot be launched/switched to right now. Fail-closed verdicts only —
+ * the absence of a reason (`{ ok: true }`) is the sole path that proceeds.
+ */
+export type CodexAccountSelectability =
+  | { ok: true }
+  | {
+      /** `unavailable` — the id names no known/safe account (a missing or hostile selection).
+       *  `no-connection` — a remote account whose host is not currently connected. */
+      ok: false
+      reason: 'unavailable' | 'no-connection'
+    }
+
+/**
+ * Fail-closed gate for the create/switch menus (§5 Property 4). `selectedId` empty/undefined = the
+ * SYSTEM account on this Mac (always selectable). Any managed id must:
+ *   - pass `isSafeAccountId` — a hostile settings/relay id never becomes a launch target;
+ *   - name an account still present in `accounts` — an explicitly selected MISSING account is
+ *     refused, never silently resolved to the system or another login;
+ *   - for a remote account, have a live connection — `connectedProjectIdForHost(host)` must return
+ *     a project id, else the switch is refused rather than run against the local login.
+ *
+ * The UI must proceed ONLY on `{ ok: true }`; every other verdict shows the account as unavailable
+ * and does nothing.
+ */
+export function codexAccountSelectable(
+  selectedId: string | undefined,
+  accounts: readonly CodexAccount[],
+  connectedProjectIdForHost: (host: string) => string | undefined
+): CodexAccountSelectability {
+  // The system account (no id) always lives on this Mac — nothing to connect to, nothing to miss.
+  if (!selectedId) return { ok: true }
+  // Supply-chain: an id that could escape the filesystem is never a valid selection.
+  if (!isSafeAccountId(selectedId)) return { ok: false, reason: 'unavailable' }
+  const account = accounts.find((candidate) => candidate.id === selectedId)
+  // Explicitly selected but absent from the known set ⇒ refuse (never fall back to another login).
+  if (!account) return { ok: false, reason: 'unavailable' }
+  // A remote account is only operable while its host is connected; without a live connection the
+  // op would run against the LOCAL login — the exact fail-open Property 4 forbids.
+  if (account.host && !connectedProjectIdForHost(account.host)) {
+    return { ok: false, reason: 'no-connection' }
+  }
+  return { ok: true }
+}

--- a/src/renderer/components/AccountIdentityPills.test.tsx
+++ b/src/renderer/components/AccountIdentityPills.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { AccountIdentityPills } from './AccountIdentityPills'
+
+describe('AccountIdentityPills', () => {
+  it('renders identity and provenance from the same presentation object', () => {
+    const html = renderToStaticMarkup(
+      <AccountIdentityPills
+        account={{
+          identity: 'Work',
+          provenance: 'SSH · Ubuntu WSL',
+          tooltip: 'Work (me@example.com) · SSH corvin@devbox'
+        }}
+        selected
+      />
+    )
+    expect(html).toContain('Work')
+    expect(html).toContain('SSH · Ubuntu WSL')
+    expect(html).toContain('Selected')
+    // The credential-storage kind must never reach the DOM.
+    expect(html).not.toContain('system')
+    expect(html).not.toContain('managed')
+  })
+
+  it('omits the selected check unless the account is chosen', () => {
+    const html = renderToStaticMarkup(
+      <AccountIdentityPills
+        account={{ identity: 'Home', provenance: 'Local', tooltip: 'Home · This Mac' }}
+      />
+    )
+    expect(html).not.toContain('Selected')
+  })
+})

--- a/src/renderer/components/AccountIdentityPills.tsx
+++ b/src/renderer/components/AccountIdentityPills.tsx
@@ -1,0 +1,38 @@
+// S6 PR 8 — the identity + provenance pills rendered on every Codex account surface (settings,
+// node chrome, create/switch menus). Based on @Corvin's #112 (`AccountIdentityPills.tsx`).
+
+import type { AccountPresentation } from '../lib/accountPresentation'
+
+/**
+ * Renders a presented account as an identity pill + a Local/SSH provenance pill, with an optional
+ * "selected" check. The whole cluster shares one native tooltip (the presentation's `tooltip`), so
+ * the same account reads identically wherever it appears.
+ */
+export function AccountIdentityPills({
+  account,
+  selected = false,
+  warning = false,
+  className = ''
+}: {
+  account: AccountPresentation
+  selected?: boolean
+  warning?: boolean
+  className?: string
+}): React.JSX.Element {
+  return (
+    <span
+      className={`account-identity-pills${warning ? ' account-identity-pills--warning' : ''}${
+        className ? ` ${className}` : ''
+      }`}
+      title={account.tooltip}
+    >
+      <span className="account-identity-pill">{account.identity}</span>
+      <span className="account-provenance-pill">{account.provenance}</span>
+      {selected ? (
+        <span className="account-identity-check" aria-label="Selected">
+          ✓
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -4,7 +4,14 @@ import { AGENT_CONFIG } from '@shared/agents/config'
 import { useSettings } from '../state/settings'
 import { useProjects } from '../state/projects'
 import { useSshConn } from '../state/sshConn'
-import { accountRowAction, scopeFromKey, scopeUsage, usageScopeKey } from '../lib/usageScope'
+import {
+  accountRowAction,
+  dedupeProviderRows,
+  providerRowKey,
+  scopeFromKey,
+  scopeUsage,
+  usageScopeKey
+} from '../lib/usageScope'
 import {
   barFillPercent,
   formatResetCountdown,
@@ -543,8 +550,11 @@ export function UsageIndicator({
               No usage from this host yet — it is read once the project connects.
             </div>
           )}
-          {visibleProviders.map((p) => (
-            <ProviderBlock key={p.provider} u={p} mode={percentMode} />
+          {/* U8 (owed from PR 7): Codex emits one row per account, all `provider: 'codex'`.
+              Key on provider+accountId so each account renders distinctly, and reduce true
+              duplicates (two settings entries → the same underlying account) to one row. */}
+          {dedupeProviderRows(visibleProviders).map((p) => (
+            <ProviderBlock key={providerRowKey(p)} u={p} mode={percentMode} />
           ))}
         </div>
       )}

--- a/src/renderer/components/settings/sections/AccountsSection.tsx
+++ b/src/renderer/components/settings/sections/AccountsSection.tsx
@@ -1,11 +1,25 @@
 import { useEffect, useState } from 'react'
 import type { ClaudeAccount } from '@shared/types'
+import type { CodexAccount } from '@shared/codex-account'
 import { sshHostKey } from '@shared/ssh'
 import { useSettings } from '../../../state/settings'
 import { useSystemAccount } from '../../../state/systemAccount'
+import { useSystemCodexAccount } from '../../../state/systemCodexAccount'
 import { isAccountLoginNode } from '../../../state/workspace'
 import { useProjects } from '../../../state/projects'
 import { useSshConn } from '../../../state/sshConn'
+import { useSshServers } from '../../../state/sshServers'
+import {
+  applyResolvedCodexAccounts,
+  discoverResolvedCodexAccounts
+} from '../../../state/codexAccountReconcile'
+import {
+  codexRemoteTargets,
+  groupCodexAccountsByMachine,
+  strayCodexAccounts
+} from '../../../lib/codexMachineGroups'
+import { presentAccount } from '../../../lib/accountPresentation'
+import { AccountIdentityPills } from '../../AccountIdentityPills'
 import { ConfirmDialog } from '../../ConfirmDialog'
 import { SettingsSection } from '../SettingsSection'
 import { SearchableRow } from '../SearchableRow'
@@ -16,9 +30,49 @@ const ROWS = {
   accounts: {
     title: 'Claude accounts',
     keywords: ['account', 'claude', 'login', 'isolated', 'multi', 'email']
+  },
+  codex: {
+    title: 'Codex accounts',
+    keywords: ['account', 'codex', 'openai', 'login', 'isolated', 'multi', 'email', 'machine', 'ssh']
   }
 }
 const ENTRIES = Object.values(ROWS)
+
+/** One machine's card in the accounts UI: a connectivity dot, the machine label, a Local/SSH pill,
+ *  and (for a remote machine) its `user@host` subtitle. Children are the provider account rows. */
+function MachinePanel({
+  label,
+  remote,
+  hostKey,
+  connected,
+  children
+}: {
+  label: string
+  remote: boolean
+  hostKey?: string
+  connected?: boolean
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="space-y-3 rounded-md border border-border p-3">
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-block h-2 w-2 rounded-full ${
+            !remote || connected ? 'bg-[color:var(--ok,#30d158)]' : 'bg-[color:var(--muted-2)]'
+          }`}
+          aria-hidden
+          title={!remote ? 'This machine' : connected ? 'Connected' : 'Not connected'}
+        />
+        <span className="text-[13px] font-medium text-text">{label}</span>
+        <span className="rounded-full bg-fill-weak px-2 py-0.5 text-[11px] font-medium text-muted">
+          {remote ? 'SSH' : 'Local'}
+        </span>
+        {remote && hostKey ? <span className="text-[12px] text-muted">{hostKey}</span> : null}
+      </div>
+      {children}
+    </div>
+  )
+}
 
 /** `addingOn` sentinel for the local button — a host key can never be this. */
 const LOCAL_TARGET = ''
@@ -38,6 +92,12 @@ function AddingLabel({ where }: { where: string }): React.JSX.Element {
 function applyAccounts(fn: (accs: ClaudeAccount[]) => ClaudeAccount[]): void {
   const s = useSettings.getState()
   s.update({ claudeAccounts: fn(s.settings.claudeAccounts) })
+}
+
+/** The same fresh-read/transform for the Codex account list. */
+function applyCodexAccounts(fn: (accs: CodexAccount[]) => CodexAccount[]): void {
+  const s = useSettings.getState()
+  s.update({ codexAccounts: fn(s.settings.codexAccounts) })
 }
 
 /** Counts nodes bound to an account across every project's SERIALIZED nodes. The active
@@ -93,6 +153,178 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
   const connectedProjectIdForHost = (host?: string): string | undefined => {
     const id = projectIdForHost(host)
     return id && sshByProject[id] ? id : undefined
+  }
+
+  // ── Codex accounts (machine-grouped) ─────────────────────────────────────────────────────────
+  const codexAccounts = useSettings((s) => s.settings.codexAccounts)
+  const sshServers = useSshServers((s) => s.servers)
+  const systemCodexEmail = useSystemCodexAccount((s) => s.email)
+  const remoteSystemCodexEmails = useSystemCodexAccount((s) => s.remoteEmails)
+  useEffect(() => useSystemCodexAccount.getState().ensure(), [])
+  useEffect(() => {
+    void useSshServers.getState().hydrate?.()
+  }, [])
+  const [pendingRemoveCodex, setPendingRemoveCodex] = useState<CodexAccount | null>(null)
+  const [addingCodex, setAddingCodex] = useState(false)
+
+  // The reachable machines: this Mac first, then every saved SSH server unioned with the active
+  // project's own server (deduped by host key). Accounts partition onto them by `host`.
+  const remoteTargets = codexRemoteTargets(sshServers, activeProject?.ssh?.server)
+  const codexGroups = groupCodexAccountsByMachine(codexAccounts, remoteTargets)
+  const codexStrays = strayCodexAccounts(codexAccounts, remoteTargets)
+
+  // Discover the system Codex identity of every CONNECTED remote target, once per host. A host with
+  // no live connection is skipped (and never fabricated — its panel simply shows no system email).
+  useEffect(() => {
+    if (!isActive) return
+    for (const [host] of remoteTargets) {
+      const projectId = connectedProjectIdForHost(host)
+      if (projectId) useSystemCodexAccount.getState().ensureRemote(host, projectId)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isActive, remoteTargets.map(([h]) => h).join('|'), sshByProject])
+
+  // Reconcile LOCAL pending Codex accounts against their now-authenticated homes. Remote accounts
+  // are intentionally NOT probed here: `codexAccounts.identity` reads the LOCAL managed home, so
+  // resolving a remote account against it would read the wrong machine. Their reconcile arrives
+  // with the host relay (a follow-up); until then a remote row stays pending, not misattributed.
+  useEffect(() => {
+    if (!isActive) return
+    let cancelled = false
+    let timer: number | undefined
+    const reconcile = async (): Promise<void> => {
+      const localPending = useSettings
+        .getState()
+        .settings.codexAccounts.filter((account) => account.pending && !account.host)
+      if (localPending.length === 0) return
+      const resolved = await discoverResolvedCodexAccounts(localPending, (id) =>
+        window.nodeTerminal.codexAccounts.identity(id)
+      )
+      if (cancelled) return
+      if (resolved.length > 0) {
+        applyCodexAccounts((accs) => applyResolvedCodexAccounts(accs, resolved))
+      }
+      const stillPending = useSettings
+        .getState()
+        .settings.codexAccounts.some((account) => account.pending && !account.host)
+      if (!cancelled && stillPending) timer = window.setTimeout(() => void reconcile(), 2000)
+    }
+    void reconcile()
+    return () => {
+      cancelled = true
+      if (timer) window.clearTimeout(timer)
+    }
+  }, [isActive, codexAccounts])
+
+  const setCodexLabel = (id: string, label: string): void =>
+    applyCodexAccounts((accs) => accs.map((a) => (a.id === id ? { ...a, label } : a)))
+
+  // Add a LOCAL managed Codex account and open its device-login node. Remote Codex account creation
+  // is fail-closed here: the base `codexAccounts.add()` mints on THIS Mac, so offering it under a
+  // remote machine would silently create a local account — the remote leg lands with the host relay.
+  const onAddCodexAccount = async (): Promise<void> => {
+    if (addingCodex) return
+    setAddingCodex(true)
+    try {
+      const added = await window.nodeTerminal.codexAccounts.add()
+      const account: CodexAccount = { id: added.id, label: 'New Codex account', pending: true }
+      applyCodexAccounts((accs) => [...accs, account])
+      window.dispatchEvent(
+        new CustomEvent('nodeterm:add-codex-account-login', { detail: { accountId: added.id } })
+      )
+      const captured = await window.nodeTerminal.codexAccounts.waitLogin(added.id)
+      if (captured) {
+        applyCodexAccounts((accs) =>
+          applyResolvedCodexAccounts(accs, [{ id: added.id, email: captured.email }])
+        )
+      }
+    } finally {
+      setAddingCodex(false)
+    }
+  }
+
+  const confirmRemoveCodex = async (account: CodexAccount): Promise<void> => {
+    setPendingRemoveCodex(null)
+    if (account.pending) await window.nodeTerminal.codexAccounts.cancelWaitLogin(account.id)
+    // A remote account's home lives on its host; the base remove() acts locally only, so a remote
+    // account is dropped from settings without a local fs op it does not own (fail-closed — it never
+    // deletes the wrong machine's home).
+    if (!account.host) await window.nodeTerminal.codexAccounts.remove(account.id)
+    applyCodexAccounts((accs) => accs.filter((a) => a.id !== account.id))
+    useProjects.setState((s) => ({
+      projects: s.projects.map((p) => ({
+        ...p,
+        nodes: p.nodes.map((n) => (n.accountId === account.id ? { ...n, accountId: undefined } : n))
+      }))
+    }))
+  }
+
+  // The presented account for a row, resolving the friendly machine label from saved servers.
+  const presentCodex = (account: CodexAccount) => {
+    const server = account.host
+      ? sshServers.find((entry) => sshHostKey(entry) === account.host)
+      : undefined
+    return presentAccount({
+      label: account.label,
+      email: account.email,
+      host: account.host,
+      machineLabel: server?.label
+    })
+  }
+
+  /** A machine's managed-account rows + the system row header. `remoteHost` set ⇒ that host. */
+  const codexRowsFor = (
+    accounts: readonly CodexAccount[],
+    remoteHost?: string
+  ): React.JSX.Element => {
+    const systemEmail = remoteHost ? (remoteSystemCodexEmails[remoteHost] ?? null) : systemCodexEmail
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3 rounded-md border border-border/60 p-2">
+          <AccountIdentityPills
+            account={presentAccount({
+              label: null,
+              email: systemEmail,
+              host: remoteHost,
+              machineLabel: remoteHost
+                ? sshServers.find((s) => sshHostKey(s) === remoteHost)?.label
+                : undefined
+            })}
+          />
+        </div>
+        {accounts.map((account) => {
+          const blockedRemote = !!account.host && !connectedProjectIdForHost(account.host)
+          return (
+            <div
+              key={account.id}
+              className="flex items-center justify-between gap-3 rounded-md border border-border/60 p-2"
+            >
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <Input
+                  className="w-48"
+                  placeholder="Codex account label"
+                  value={account.label}
+                  onChange={(e) => setCodexLabel(account.id, e.target.value)}
+                />
+                <AccountIdentityPills account={presentCodex(account)} warning={blockedRemote} />
+                {account.pending ? (
+                  <span className="rounded-full bg-[color:var(--warn)]/15 px-2 py-0.5 text-[11px] font-medium text-[color:var(--warn)]">
+                    pending
+                  </span>
+                ) : null}
+              </div>
+              <Button
+                variant="ghost"
+                aria-label="Remove Codex account"
+                onClick={() => setPendingRemoveCodex(account)}
+              >
+                ×
+              </Button>
+            </div>
+          )
+        })}
+      </div>
+    )
   }
 
   // Open a login terminal for an account and wait (up to ~5 min) for the CLI to write its
@@ -383,12 +615,76 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
         </div>
       </SearchableRow>
 
+      {/* Codex accounts, grouped by machine. Each managed Codex login has its own CODEX_HOME and
+          credentials; a node keeps its account for life. Machine provenance (Local / SSH · host)
+          is shown as a pill; the credential-storage kind is deliberately not surfaced. */}
+      <SearchableRow {...ROWS.codex}>
+        <div className="space-y-4">
+          {codexGroups.map((group) => (
+            <MachinePanel
+              key={group.host || 'local'}
+              label={group.remote ? (group.server?.label ?? group.host) : 'This Mac'}
+              remote={group.remote}
+              hostKey={group.host || undefined}
+              connected={group.remote ? !!connectedProjectIdForHost(group.host) : true}
+            >
+              {codexRowsFor(group.accounts, group.remote ? group.host : undefined)}
+              {!group.remote ? (
+                <div className="space-y-2">
+                  <Button variant="primary" disabled={addingCodex} onClick={() => void onAddCodexAccount()}>
+                    {addingCodex ? (
+                      <span className="inline-flex items-center gap-2">
+                        <span className="ui-spinner" aria-hidden />
+                        Setting up on this Mac…
+                      </span>
+                    ) : (
+                      'Add Codex account'
+                    )}
+                  </Button>
+                </div>
+              ) : (
+                <p className="text-[12px] leading-relaxed text-muted">
+                  Codex accounts on this machine are managed from its own NodeTerm. Accounts already
+                  created here are shown above.
+                </p>
+              )}
+            </MachinePanel>
+          ))}
+
+          {codexStrays.length > 0 ? (
+            <div className="space-y-2 rounded-md border border-[color:var(--warn)]/40 p-3">
+              <p className="text-[12px] font-medium text-[color:var(--warn)]">
+                Accounts on machines you no longer have saved
+              </p>
+              {codexRowsFor(codexStrays)}
+            </div>
+          ) : null}
+
+          <p className="text-[12px] leading-relaxed text-muted">
+            Codex accounts are isolated logins, grouped by the machine their credentials live on.
+            New Codex nodes pick an account from the add menus; each node keeps its account for life.
+          </p>
+        </div>
+      </SearchableRow>
+
       {pendingRemove ? (
         <ConfirmDialog
           message={removeMessage(pendingRemove)}
           confirmLabel="Remove"
           onConfirm={() => void confirmRemove(pendingRemove)}
           onCancel={() => setPendingRemove(null)}
+        />
+      ) : null}
+      {pendingRemoveCodex ? (
+        <ConfirmDialog
+          message={`Remove Codex account "${pendingRemoveCodex.label}"?${
+            pendingRemoveCodex.host
+              ? ' It is dropped from this NodeTerm; its credentials on the host are untouched.'
+              : ' Its logged-in credentials and its Codex home will be deleted.'
+          }`}
+          confirmLabel="Remove"
+          onConfirm={() => void confirmRemoveCodex(pendingRemoveCodex)}
+          onCancel={() => setPendingRemoveCodex(null)}
         />
       ) : null}
     </SettingsSection>

--- a/src/renderer/components/settings/sections/AccountsSection.tsx
+++ b/src/renderer/components/settings/sections/AccountsSection.tsx
@@ -19,6 +19,7 @@ import {
   strayCodexAccounts
 } from '../../../lib/codexMachineGroups'
 import { presentAccount } from '../../../lib/accountPresentation'
+import { codexAccountSelectable } from '../../../canvas/codex-account-switch'
 import { AccountIdentityPills } from '../../AccountIdentityPills'
 import { ConfirmDialog } from '../../ConfirmDialog'
 import { SettingsSection } from '../SettingsSection'
@@ -293,11 +294,23 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
           />
         </div>
         {accounts.map((account) => {
-          const blockedRemote = !!account.host && !connectedProjectIdForHost(account.host)
+          // The SAME fail-closed gate the create/switch UI uses (§5 Property 4): an account that is
+          // unsafe, missing, or a remote account with no live connection is not operable. Driving
+          // the row's warning state through it (rather than an ad-hoc host check) makes
+          // `codexAccountSelectable` a real reader and keeps one definition of "operable".
+          const selectable = codexAccountSelectable(account.id, codexAccounts, (host) =>
+            connectedProjectIdForHost(host)
+          )
+          const blockedReason = selectable.ok
+            ? undefined
+            : selectable.reason === 'no-connection'
+              ? `Connect to ${account.host} to use this account`
+              : 'This account is unavailable'
           return (
             <div
               key={account.id}
               className="flex items-center justify-between gap-3 rounded-md border border-border/60 p-2"
+              title={blockedReason}
             >
               <div className="flex min-w-0 flex-1 items-center gap-2">
                 <Input
@@ -306,7 +319,7 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
                   value={account.label}
                   onChange={(e) => setCodexLabel(account.id, e.target.value)}
                 />
-                <AccountIdentityPills account={presentCodex(account)} warning={blockedRemote} />
+                <AccountIdentityPills account={presentCodex(account)} warning={!selectable.ok} />
                 {account.pending ? (
                   <span className="rounded-full bg-[color:var(--warn)]/15 px-2 py-0.5 text-[11px] font-medium text-[color:var(--warn)]">
                     pending

--- a/src/renderer/components/settings/sections/SshSection.tsx
+++ b/src/renderer/components/settings/sections/SshSection.tsx
@@ -108,7 +108,7 @@ export function SshSection({ isActive }: { isActive: boolean }): React.JSX.Eleme
     <SettingsSection
       id="ssh"
       title="Remote (SSH)"
-      description="Saved SSH servers appear under “New remote”, and can host nodes on a local canvas. Opening remote terminals over SSH is free."
+      description="Saved SSH servers appear under “New remote”, and can host nodes on a local canvas. Each also becomes a machine in Accounts, where its own isolated Codex logins live. Opening remote terminals over SSH is free."
       isActive={isActive}
       searchEntries={ENTRIES}
     >

--- a/src/renderer/lib/accountPresentation.test.ts
+++ b/src/renderer/lib/accountPresentation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { presentAccount } from './accountPresentation'
+
+describe('presentAccount', () => {
+  it('uses a chosen name before the email and identifies a local login', () => {
+    expect(presentAccount({ label: 'Work', email: 'me@example.com' })).toEqual({
+      identity: 'Work',
+      provenance: 'Local',
+      tooltip: 'Work (me@example.com) · This Mac'
+    })
+  })
+
+  it('falls back to email and never exposes system or managed storage terminology', () => {
+    expect(
+      presentAccount({
+        label: 'System Codex account',
+        email: 'me@example.com'
+      })
+    ).toEqual({
+      identity: 'me@example.com',
+      provenance: 'Local',
+      tooltip: 'me@example.com · This Mac'
+    })
+    // A row still carrying the generated placeholder collapses to "Default account".
+    expect(presentAccount({ label: 'New Codex account' }).identity).toBe('Default account')
+    // The provenance/tooltip must never leak the credential-storage kind.
+    const t = presentAccount({ label: 'New Codex account' }).tooltip
+    expect(t).not.toMatch(/managed|system/i)
+  })
+
+  it('uses one SSH provenance format with the friendly machine name', () => {
+    expect(
+      presentAccount({
+        email: 'remote@example.com',
+        host: 'corvin@devbox',
+        machineLabel: 'Ubuntu WSL'
+      })
+    ).toEqual({
+      identity: 'remote@example.com',
+      provenance: 'SSH · Ubuntu WSL',
+      tooltip: 'remote@example.com · SSH corvin@devbox'
+    })
+  })
+
+  it('falls back to the raw host when no friendly machine label is saved', () => {
+    // The `host ?` branch is provenance's load-bearing local/SSH split — with the machineLabel
+    // absent the raw `user@host` must still read as SSH, never as Local.
+    expect(presentAccount({ email: 'r@x', host: 'me@box' }).provenance).toBe('SSH · me@box')
+  })
+})

--- a/src/renderer/lib/accountPresentation.ts
+++ b/src/renderer/lib/accountPresentation.ts
@@ -1,0 +1,66 @@
+// S6 PR 8 — the single account-display contract shared by settings, node chrome, and account
+// menus. Based on @Corvin's #112 (`src/renderer/lib/accountPresentation.ts`).
+//
+// This module is renderer-pure: it imports nothing from `src/core`, so presenting an account
+// never drags the impure core path machinery into the bundle.
+
+export interface AccountPresentation {
+  /** Human identity: a chosen account name, otherwise the login email. */
+  identity: string
+  /** Short origin pill rendered beside the identity on every account surface. */
+  provenance: string
+  /** Full, stable explanation for native tooltips. */
+  tooltip: string
+}
+
+/**
+ * Auto-generated placeholder labels that must NOT be shown as a chosen identity — a row still
+ * carrying one of these has never been named by the user, so we fall through to the email (or
+ * "Default account"). Kept lowercase; matched case-insensitively.
+ */
+const GENERATED_LABELS = new Set([
+  'new account',
+  'new codex account',
+  'system account',
+  'system codex account'
+])
+
+function chosenLabel(label: string | null | undefined): string | undefined {
+  const value = label?.trim()
+  if (!value || GENERATED_LABELS.has(value.toLowerCase())) return undefined
+  return value
+}
+
+/**
+ * Single account-display contract shared by settings, node chrome, and account menus.
+ *
+ * The *credential storage kind* (system vs managed directory) is deliberately NOT user-facing:
+ * users select a person/login and the machine it lives on, not an implementation directory. The
+ * only origin fact surfaced is machine provenance — `Local` or `SSH · <machineLabel>`.
+ */
+export function presentAccount({
+  label,
+  email,
+  host,
+  machineLabel
+}: {
+  label?: string | null
+  email?: string | null
+  /** Canonical SSH address (`user@host`). Omit for an account on this Mac. */
+  host?: string | null
+  /** Friendly saved SSH-machine name. */
+  machineLabel?: string | null
+}): AccountPresentation {
+  const displayLabel = chosenLabel(label)
+  const cleanEmail = email?.trim() || undefined
+  const identity = displayLabel || cleanEmail || 'Default account'
+  const provenance = host ? `SSH · ${machineLabel?.trim() || host}` : 'Local'
+  const originDetail = host ? `SSH ${host}` : 'This Mac'
+  const identityDetail =
+    cleanEmail && cleanEmail !== identity ? `${identity} (${cleanEmail})` : identity
+  return {
+    identity,
+    provenance,
+    tooltip: `${identityDetail} · ${originDetail}`
+  }
+}

--- a/src/renderer/lib/codexMachineGroups.test.ts
+++ b/src/renderer/lib/codexMachineGroups.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { SshServer } from '@shared/ssh'
+import type { CodexAccount } from '@shared/codex-account'
+import {
+  codexRemoteTargets,
+  groupCodexAccountsByMachine,
+  strayCodexAccounts
+} from './codexMachineGroups'
+
+const server = (id: string, user: string, host: string, label: string): SshServer => ({
+  id,
+  user,
+  host,
+  label
+})
+
+describe('codexRemoteTargets', () => {
+  it('dedupes by host key and prefers the saved server over the active project connection', () => {
+    const saved = [server('s1', 'me', 'box', 'Ubuntu WSL')]
+    const active = server('p1', 'me', 'box', 'raw') // same host key me@box
+    const targets = codexRemoteTargets(saved, active)
+    expect(targets).toHaveLength(1)
+    expect(targets[0][0]).toBe('me@box')
+    expect(targets[0][1].label).toBe('Ubuntu WSL') // first (saved) wins
+  })
+
+  it('adds the active project server when it is a new host', () => {
+    const targets = codexRemoteTargets([server('s1', 'me', 'box', 'Box')], server('p1', 'me', 'two', 'Two'))
+    expect(targets.map(([host]) => host)).toEqual(['me@box', 'me@two'])
+  })
+
+  it('is empty with no servers', () => {
+    expect(codexRemoteTargets([], null)).toEqual([])
+  })
+})
+
+describe('groupCodexAccountsByMachine', () => {
+  const accounts: CodexAccount[] = [
+    { id: 'local-1', label: 'Home' },
+    { id: 'box-1', label: 'Work', host: 'me@box' },
+    { id: 'local-2', label: 'Side' },
+    { id: 'two-1', label: 'Other', host: 'me@two' }
+  ]
+  const targets = codexRemoteTargets(
+    [server('s1', 'me', 'box', 'Box'), server('s2', 'me', 'two', 'Two')],
+    null
+  )
+
+  it('puts This Mac first with exactly the host-less accounts', () => {
+    const groups = groupCodexAccountsByMachine(accounts, targets)
+    expect(groups[0]).toMatchObject({ host: '', remote: false })
+    expect(groups[0].accounts.map((a) => a.id)).toEqual(['local-1', 'local-2'])
+  })
+
+  it('emits one panel per configured host with its own accounts', () => {
+    const groups = groupCodexAccountsByMachine(accounts, targets)
+    expect(groups).toHaveLength(3) // This Mac + 2 hosts
+    expect(groups[1]).toMatchObject({ host: 'me@box', remote: true })
+    expect(groups[1].accounts.map((a) => a.id)).toEqual(['box-1'])
+    expect(groups[2].accounts.map((a) => a.id)).toEqual(['two-1'])
+  })
+
+  it('leaves a machine panel empty rather than borrowing another machine account', () => {
+    const groups = groupCodexAccountsByMachine([{ id: 'box-1', label: 'W', host: 'me@box' }], targets)
+    expect(groups.find((g) => g.host === 'me@two')?.accounts).toEqual([])
+  })
+})
+
+describe('strayCodexAccounts', () => {
+  it('surfaces a remote account whose host is not a configured target', () => {
+    const accounts: CodexAccount[] = [
+      { id: 'ok', label: 'W', host: 'me@box' },
+      { id: 'stray', label: 'Old', host: 'me@gone' }
+    ]
+    const targets = codexRemoteTargets([server('s1', 'me', 'box', 'Box')], null)
+    expect(strayCodexAccounts(accounts, targets).map((a) => a.id)).toEqual(['stray'])
+  })
+
+  it('never counts a local account as a stray', () => {
+    expect(strayCodexAccounts([{ id: 'l', label: 'H' }], [])).toEqual([])
+  })
+})

--- a/src/renderer/lib/codexMachineGroups.ts
+++ b/src/renderer/lib/codexMachineGroups.ts
@@ -1,0 +1,82 @@
+// S6 PR 8 — the pure machine-grouping the Accounts settings renders. Extracted from @Corvin's
+// #112 inline `AccountsSection` logic so the "one panel per host, accounts under the right machine"
+// invariant is unit-tested apart from the JSX.
+//
+// Renderer-pure: no `src/core`, no IPC. It only rearranges the flat `settings.codexAccounts` array
+// (partitioned by `host`) alongside the deduped set of reachable SSH machines.
+
+import type { SshConnection } from '@shared/ssh'
+import { sshHostKey } from '@shared/ssh'
+import type { CodexAccount } from '@shared/codex-account'
+
+/** The server behind a machine panel. A saved `SshServer` or the active project's own
+ *  `SshConnection` both satisfy this — only the host/user (for the key) and an optional label are
+ *  read. */
+export type MachineServer = SshConnection
+
+/** A reachable remote machine for the accounts UI: its host key + the server behind it. */
+export type CodexRemoteTarget = readonly [host: string, server: MachineServer]
+
+/**
+ * The remote machines to show a panel for, deduped by `sshHostKey`. Unions the saved SSH servers
+ * with the active project's own SSH server (so an ad-hoc `New remote` project still gets a machine
+ * panel even before it is saved). First occurrence of a host key wins, so a saved server's friendly
+ * label is preferred over the raw active-project connection.
+ */
+export function codexRemoteTargets(
+  sshServers: readonly MachineServer[],
+  activeProjectServer?: MachineServer | null
+): CodexRemoteTarget[] {
+  const byHost = new Map<string, MachineServer>()
+  for (const server of [...sshServers, ...(activeProjectServer ? [activeProjectServer] : [])]) {
+    const host = sshHostKey(server)
+    if (!byHost.has(host)) byHost.set(host, server)
+  }
+  return [...byHost.entries()]
+}
+
+/** One machine's panel: the machine, its SSH server (absent for this Mac), and its accounts. */
+export interface CodexMachineGroup {
+  /** Stable key: `''` for this Mac, else the host key. */
+  host: string
+  /** True for a remote (SSH) machine. */
+  remote: boolean
+  /** The saved SSH server, when remote. */
+  server?: MachineServer
+  /** Managed accounts that live on this machine, in settings order. */
+  accounts: CodexAccount[]
+}
+
+/**
+ * Group the flat account list into ordered machine panels: **this Mac first** (accounts with no
+ * `host`), then one panel per remote target in target order. An account lands under exactly the
+ * machine whose host key it carries; a remote account whose host is no longer a configured target
+ * is dropped from the panels (it is surfaced as a stray in the JSX, not fabricated into a machine).
+ */
+export function groupCodexAccountsByMachine(
+  accounts: readonly CodexAccount[],
+  remoteTargets: readonly CodexRemoteTarget[]
+): CodexMachineGroup[] {
+  const local: CodexMachineGroup = {
+    host: '',
+    remote: false,
+    accounts: accounts.filter((account) => !account.host)
+  }
+  const remotes = remoteTargets.map(([host, server]) => ({
+    host,
+    remote: true,
+    server,
+    accounts: accounts.filter((account) => account.host === host)
+  }))
+  return [local, ...remotes]
+}
+
+/** Managed accounts whose `host` matches no configured target — shown as strays, never fabricated
+ *  into a machine panel of their own. */
+export function strayCodexAccounts(
+  accounts: readonly CodexAccount[],
+  remoteTargets: readonly CodexRemoteTarget[]
+): CodexAccount[] {
+  const known = new Set(remoteTargets.map(([host]) => host))
+  return accounts.filter((account) => account.host && !known.has(account.host))
+}

--- a/src/renderer/lib/usageScope.test.ts
+++ b/src/renderer/lib/usageScope.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
   accountRowAction,
+  dedupeProviderRows,
+  providerRowKey,
   scopeFromKey,
   scopeUsage,
   usageScopeFor,
@@ -202,5 +204,47 @@ describe('accountRowAction', () => {
 
   it('with no managed accounts the System row is default and nothing is offered', () => {
     expect(accountRowAction(null, [], undefined)).toBe('default')
+  })
+})
+
+describe('providerRowKey / dedupeProviderRows (U8 — per-account Codex rows)', () => {
+  const codex = (over: Partial<ProviderUsage> = {}): ProviderUsage => ({
+    provider: 'codex',
+    limits: [limit()],
+    account: null,
+    updatedAt: 0,
+    status: 'ok',
+    ...over
+  })
+
+  it('keys each Codex account distinctly and the system row as system', () => {
+    expect(providerRowKey(codex())).toBe('codex:system')
+    expect(providerRowKey(codex({ accountId: 'acc-1' }))).toBe('codex:acc-1')
+    expect(providerRowKey(codex({ accountId: 'acc-2' }))).toBe('codex:acc-2')
+  })
+
+  it('keeps distinct per-account rows instead of colliding them onto one key', () => {
+    const rows = [
+      codex({ account: 'sys@x' }),
+      codex({ accountId: 'acc-1', account: 'a@x' }),
+      codex({ accountId: 'acc-2', account: 'b@x' })
+    ]
+    const out = dedupeProviderRows(rows)
+    expect(out).toHaveLength(3)
+    expect(out.map(providerRowKey)).toEqual(['codex:system', 'codex:acc-1', 'codex:acc-2'])
+  })
+
+  it('collapses two rows with the same account key, keeping the informative one', () => {
+    const empty = codex({ accountId: 'acc-1', limits: [], status: 'fetching' })
+    const full = codex({ accountId: 'acc-1', account: 'a@x' })
+    const out = dedupeProviderRows([empty, full])
+    expect(out).toHaveLength(1)
+    expect(out[0].status).toBe('ok')
+    expect(out[0].limits).toHaveLength(1)
+  })
+
+  it('does not merge across different providers that happen to share a system slot', () => {
+    const out = dedupeProviderRows([codex(), { ...codex(), provider: 'gemini' }])
+    expect(out.map(providerRowKey)).toEqual(['codex:system', 'gemini:system'])
   })
 })

--- a/src/renderer/lib/usageScope.ts
+++ b/src/renderer/lib/usageScope.ts
@@ -140,3 +140,43 @@ export function scopeUsage(input: ScopeInput): ScopedUsage {
     pillLimits: leading?.usage.limits ?? []
   }
 }
+
+/**
+ * The React key for a provider usage row. `runProviders` emits ONE row per Codex account (the
+ * system fetcher with no `accountId`, plus one per managed account), all carrying
+ * `provider: 'codex'` — so keying on `provider` alone collides every Codex account onto one key
+ * (U8, owed from PR 7). Keying on `provider` + `accountId` keeps each account's row distinct.
+ */
+export function providerRowKey(row: Pick<ProviderUsage, 'provider' | 'accountId'>): string {
+  return `${row.provider}:${row.accountId ?? 'system'}`
+}
+
+/**
+ * Collapse provider usage rows that share a `provider`+`accountId` key (U8 keyed reduce). Two
+ * settings entries that resolve to the same underlying account would otherwise print twice; a
+ * genuine per-account row keeps its own key and survives. Insertion order is preserved, and the
+ * MORE INFORMATIVE duplicate wins — a row with limits, or a non-`fetching` status, beats an empty
+ * placeholder — so a resolved reading is never dropped in favour of an in-flight one.
+ */
+export function dedupeProviderRows(rows: readonly ProviderUsage[]): ProviderUsage[] {
+  const order: string[] = []
+  const byKey = new Map<string, ProviderUsage>()
+  for (const row of rows) {
+    const key = providerRowKey(row)
+    const existing = byKey.get(key)
+    if (!existing) {
+      order.push(key)
+      byKey.set(key, row)
+      continue
+    }
+    if (moreInformative(row, existing)) byKey.set(key, row)
+  }
+  return order.map((key) => byKey.get(key)!)
+}
+
+/** True when `candidate` carries strictly more usable information than `current`. */
+function moreInformative(candidate: ProviderUsage, current: ProviderUsage): boolean {
+  const rank = (r: ProviderUsage): number =>
+    r.limits.length > 0 ? 2 : r.status === 'fetching' ? 0 : 1
+  return rank(candidate) > rank(current)
+}

--- a/src/renderer/state/codexAccountReconcile.test.ts
+++ b/src/renderer/state/codexAccountReconcile.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { CodexAccount } from '@shared/codex-account'
+import {
+  applyResolvedCodexAccounts,
+  discoverResolvedCodexAccounts,
+  type ResolvedCodexAccount
+} from './codexAccountReconcile'
+
+const pending = (id: string, over: Partial<CodexAccount> = {}): CodexAccount => ({
+  id,
+  label: 'New Codex account',
+  pending: true,
+  ...over
+})
+
+describe('discoverResolvedCodexAccounts', () => {
+  it('discovers only authenticated pending accounts', async () => {
+    const accounts: CodexAccount[] = [
+      pending('a'), // authenticated
+      pending('b'), // still logging in (identity null)
+      { id: 'c', label: 'Settled', email: 'c@x', pending: false } // not pending → never probed
+    ]
+    const identity = vi.fn(async (id: string) =>
+      id === 'a' ? { email: 'a@x' } : null
+    )
+    const resolved = await discoverResolvedCodexAccounts(accounts, identity)
+    expect(resolved).toEqual<ResolvedCodexAccount[]>([{ id: 'a', email: 'a@x' }])
+    // The settled account 'c' is never read — probing a non-pending account is the mutation.
+    expect(identity).not.toHaveBeenCalledWith('c')
+  })
+
+  it('drops an account whose identity read throws (fail-closed, no fabrication)', async () => {
+    const identity = vi.fn(async () => {
+      throw new Error('unreachable host')
+    })
+    expect(await discoverResolvedCodexAccounts([pending('a')], identity)).toEqual([])
+  })
+})
+
+describe('applyResolvedCodexAccounts', () => {
+  it('promotes a generated label to the email and clears pending', () => {
+    const out = applyResolvedCodexAccounts([pending('a')], [{ id: 'a', email: 'a@x' }])
+    expect(out).toEqual([{ id: 'a', label: 'a@x', email: 'a@x', pending: false }])
+  })
+
+  it('keeps a user-chosen label but still captures the email', () => {
+    const out = applyResolvedCodexAccounts(
+      [pending('a', { label: 'Work' })],
+      [{ id: 'a', email: 'a@x' }]
+    )
+    expect(out[0]).toMatchObject({ label: 'Work', email: 'a@x', pending: false })
+  })
+
+  it('merges against fresh state without reviving removed or already-changed accounts', () => {
+    // Fresh list: 'a' was already settled by a concurrent edit; 'removed' is gone entirely.
+    const fresh: CodexAccount[] = [{ id: 'a', label: 'Renamed', email: 'a@x', pending: false }]
+    const resolved: ResolvedCodexAccount[] = [
+      { id: 'a', email: 'stale@x' }, // must NOT clobber the already-changed row
+      { id: 'removed', email: 'ghost@x' } // must NOT be revived into the list
+    ]
+    const out = applyResolvedCodexAccounts(fresh, resolved)
+    expect(out).toEqual(fresh) // untouched
+    expect(out.some((account) => account.id === 'removed')).toBe(false)
+  })
+})

--- a/src/renderer/state/codexAccountReconcile.ts
+++ b/src/renderer/state/codexAccountReconcile.ts
@@ -1,0 +1,65 @@
+// S6 PR 8 — reconcile pending Codex accounts against the app-servers' live identity, without
+// trusting attacker-controlled settings fields. Based on @Corvin's #112
+// (`src/renderer/state/codexAccountReconcile.ts`).
+//
+// `discover` reads only the identity the account home actually holds (an authenticated `auth.json`
+// yielded an email); `apply` merges that against a FRESH accounts list so a login that resolves
+// late can never revive an account the user removed, nor clobber one that already changed. Nothing
+// here fabricates an account: an unauthenticated / unreadable home drops out of the resolved set.
+
+import type { CodexAccount } from '@shared/codex-account'
+
+export interface ResolvedCodexAccount {
+  id: string
+  email: string | null
+}
+
+/**
+ * Read the live identity of every PENDING account (only pending ones are still waiting on a
+ * login). A home that has not authenticated — `identity` resolves null or throws — is omitted, so
+ * the resolved set is exactly the accounts that genuinely logged in. `identity` is the caller's
+ * bound reader (local `codexAccounts.identity`, or the host reader behind a live connection).
+ */
+export async function discoverResolvedCodexAccounts(
+  accounts: readonly CodexAccount[],
+  identity: (id: string) => Promise<{ email: string | null } | null>
+): Promise<ResolvedCodexAccount[]> {
+  const resolved = await Promise.all(
+    accounts
+      .filter((account) => account.pending)
+      .map(async (account) => ({
+        id: account.id,
+        identity: await identity(account.id).catch(() => null)
+      }))
+  )
+  return resolved.flatMap(({ id, identity: value }) =>
+    value ? [{ id, email: value.email }] : []
+  )
+}
+
+/**
+ * Merge resolved identities onto the CURRENT accounts list. Fail-closed against staleness:
+ * - only an account still present in `accounts` is touched (a removed id is never re-added — the
+ *   result is `accounts.map(...)`, which can only transform existing rows, never append);
+ * - only an account still `pending` is promoted (`!account.pending` short-circuits, so a row that
+ *   already changed under a concurrent edit is left exactly as the user left it);
+ * - a generated "New Codex account" label is promoted to the captured email; a user-chosen label
+ *   is preserved.
+ */
+export function applyResolvedCodexAccounts(
+  accounts: readonly CodexAccount[],
+  resolved: readonly ResolvedCodexAccount[]
+): CodexAccount[] {
+  const byId = new Map(resolved.map((account) => [account.id, account]))
+  return accounts.map((account) => {
+    const identity = byId.get(account.id)
+    if (!identity || !account.pending) return account
+    return {
+      ...account,
+      label:
+        account.label === 'New Codex account' && identity.email ? identity.email : account.label,
+      email: identity.email ?? undefined,
+      pending: false
+    }
+  })
+}

--- a/src/renderer/state/systemCodexAccount.test.ts
+++ b/src/renderer/state/systemCodexAccount.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const systemIdentity = vi.fn()
+
+/** Fresh store per test — the once-guard is module state, so we re-import after resetModules. */
+async function freshStore() {
+  vi.resetModules()
+  vi.stubGlobal('window', {
+    nodeTerminal: { codexAccounts: { systemIdentity } }
+  })
+  return (await import('./systemCodexAccount')).useSystemCodexAccount
+}
+
+beforeEach(() => {
+  systemIdentity.mockReset()
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useSystemCodexAccount.ensure', () => {
+  it('reads the local system identity exactly once per session', async () => {
+    systemIdentity.mockResolvedValue({ email: 'me@mac' })
+    const store = await freshStore()
+    store.getState().ensure()
+    store.getState().ensure()
+    await vi.waitFor(() => expect(store.getState().email).toBe('me@mac'))
+    // Once-guard: the second ensure() must not fire a second read.
+    expect(systemIdentity).toHaveBeenCalledTimes(1)
+    expect(systemIdentity).toHaveBeenCalledWith()
+  })
+
+  it('fails closed to null when the read rejects (no fabrication)', async () => {
+    systemIdentity.mockRejectedValue(new Error('no login'))
+    const store = await freshStore()
+    store.getState().ensure()
+    await vi.waitFor(() => expect(store.getState().loaded).toBe(true))
+    expect(store.getState().email).toBeNull()
+  })
+})
+
+describe('useSystemCodexAccount.ensureRemote', () => {
+  it('probes each host once and asks with that host connection', async () => {
+    systemIdentity.mockResolvedValue({ email: 'me@box' })
+    const store = await freshStore()
+    store.getState().ensureRemote('u@box', 'proj-1')
+    store.getState().ensureRemote('u@box', 'proj-1') // in-flight guard
+    await vi.waitFor(() => expect(store.getState().remoteEmails['u@box']).toBe('me@box'))
+    store.getState().ensureRemote('u@box', 'proj-1') // already-resolved guard
+    expect(systemIdentity).toHaveBeenCalledTimes(1)
+    expect(systemIdentity).toHaveBeenCalledWith({ projectId: 'proj-1' })
+  })
+
+  it('records a resolved-but-null host and never re-probes it', async () => {
+    systemIdentity.mockResolvedValue({ email: null })
+    const store = await freshStore()
+    store.getState().ensureRemote('u@box', 'proj-1')
+    await vi.waitFor(() => expect(Object.hasOwn(store.getState().remoteEmails, 'u@box')).toBe(true))
+    expect(store.getState().remoteEmails['u@box']).toBeNull()
+    store.getState().ensureRemote('u@box', 'proj-1')
+    expect(systemIdentity).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps different hosts in separate slots', async () => {
+    systemIdentity.mockImplementation(async (ctx: { projectId: string }) =>
+      ctx.projectId === 'p-a' ? { email: 'a@box' } : { email: 'b@box' }
+    )
+    const store = await freshStore()
+    store.getState().ensureRemote('a@box', 'p-a')
+    store.getState().ensureRemote('b@box', 'p-b')
+    await vi.waitFor(() => {
+      expect(store.getState().remoteEmails['a@box']).toBe('a@box')
+      expect(store.getState().remoteEmails['b@box']).toBe('b@box')
+    })
+    expect(systemIdentity).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/state/systemCodexAccount.ts
+++ b/src/renderer/state/systemCodexAccount.ts
@@ -1,0 +1,62 @@
+// S6 PR 8 — the discovered identity of the SYSTEM Codex account (`~/.codex`), per machine.
+// Based on @Corvin's #112 (`src/renderer/state/systemCodexAccount.ts`).
+//
+// The system account is implicit (no CodexAccount record), so its email is resolved lazily and
+// once per machine: `ensure()` for this Mac, `ensureRemote(host, projectId)` for a connected SSH
+// host. Every read is fail-closed — no login / unreachable host / read error resolves to `null`,
+// NEVER a fabricated identity (a machine panel with no discoverable system login shows no email
+// rather than borrowing another machine's).
+
+import { create } from 'zustand'
+
+interface SystemCodexAccountState {
+  /** This Mac's system Codex login email, or null (unknown / not logged in). */
+  email: string | null
+  /** Once-guard: the local read fires a single time per app session. */
+  loaded: boolean
+  /** Per-host system login email; a key present with value null means "read, not logged in". */
+  remoteEmails: Record<string, string | null>
+  /** Per-host in-flight guard so a host is probed once even while its read is pending. */
+  remoteLoading: Record<string, boolean>
+  ensure(): void
+  ensureRemote(host: string, projectId: string): void
+}
+
+export const useSystemCodexAccount = create<SystemCodexAccountState>((set, get) => ({
+  email: null,
+  loaded: false,
+  remoteEmails: {},
+  remoteLoading: {},
+  ensure() {
+    if (get().loaded) return
+    set({ loaded: true })
+    void window.nodeTerminal.codexAccounts
+      .systemIdentity()
+      .then((identity) => set({ email: identity?.email ?? null }))
+      .catch(() => {})
+  },
+  ensureRemote(host, projectId) {
+    // Once per host: skip if a read is in flight OR already completed (even to a null email — a
+    // resolved "not logged in" must not re-trigger a probe every render).
+    if (get().remoteLoading[host] || Object.hasOwn(get().remoteEmails, host)) return
+    set((state) => ({
+      remoteLoading: { ...state.remoteLoading, [host]: true }
+    }))
+    void window.nodeTerminal.codexAccounts
+      .systemIdentity({ projectId })
+      .then((identity) =>
+        set((state) => ({
+          remoteEmails: {
+            ...state.remoteEmails,
+            [host]: identity?.email ?? null
+          },
+          remoteLoading: { ...state.remoteLoading, [host]: false }
+        }))
+      )
+      .catch(() =>
+        set((state) => ({
+          remoteLoading: { ...state.remoteLoading, [host]: false }
+        }))
+      )
+  }
+}))

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -10940,3 +10940,51 @@ body,
 * {
   scrollbar-width: thin;
 }
+
+/* S6 — account identity + provenance pills (AccountIdentityPills). One cluster wherever a Codex
+   account is shown (settings, node chrome, create/switch menus) so an account reads identically
+   everywhere. Theme-aware via --tint-rgb / semantic tokens; no new colour language. */
+.account-identity-pills {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  vertical-align: middle;
+}
+.account-identity-pill {
+  max-width: 22ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  background: rgba(var(--tint-rgb), 0.08);
+}
+.account-provenance-pill {
+  flex: none;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  background: rgba(var(--tint-rgb), 0.05);
+  border: 1px solid var(--border);
+}
+.account-identity-check {
+  flex: none;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--accent);
+}
+/* A managed home that is missing / an account that cannot be operated: the same cluster, warned.
+   Recolour text + outline with the warn token; no tinted fill (there is no --warn-rgb to build
+   a translucent background from, and the theme guard forbids referencing an undefined variable). */
+.account-identity-pills--warning .account-identity-pill,
+.account-identity-pills--warning .account-provenance-pill {
+  color: var(--warn);
+  border: 1px solid var(--warn);
+  background: transparent;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2096,8 +2096,10 @@ export interface CodexAccountsApi {
   cancelWaitLogin(id: string): Promise<void>
   /** Read a managed account's already-logged-in identity (email), or null if not logged in. */
   identity(id: string): Promise<{ email: string | null } | null>
-  /** Read the system (`~/.codex`) account's identity. */
-  systemIdentity(): Promise<{ email: string | null } | null>
+  /** Read a machine's system (`~/.codex`) account identity. No arg ⇒ this Mac. `{ projectId }` ⇒
+   *  the connected SSH host behind that project; a host whose system identity cannot be resolved
+   *  resolves `null` (fail-closed — a remote machine panel never borrows this Mac's login). */
+  systemIdentity(ctx?: { projectId?: string }): Promise<{ email: string | null } | null>
   /** Remove a managed account: stop its daemon and delete its home. Refused while a switch
    *  reservation holds it or a concurrent removal is in flight (Property 10). */
   remove(id: string): Promise<void>


### PR DESCRIPTION
S6 PR 8 of #112 (@Corvin) — the USER-FACING layer where machine-scoped Codex accounts become visible and operable. Depends on PRs 1–7 (all present in the base). Renderer-focused; `src/core` untouched.

## What lands
- **8.1 — presentation + pills.** `presentAccount` → `{identity, provenance, tooltip}` (generated placeholder labels collapse to email / "Default account"; provenance = `Local` | `SSH · <machineLabel>`; the credential-storage kind is never surfaced). `AccountIdentityPills` renders identity + provenance pills + an optional selected check, one cluster for every Codex surface, with theme-aware CSS on the existing tint tokens.
- **8.2 — machine grouping.** `codexMachineGroups` partitions `settings.codexAccounts` by `host` and dedupes remote targets by `sshHostKey` (saved servers ∪ the active project's own server). `AccountsSection` renders a `MachinePanel` per machine — **This Mac first**, then each remote target — each carrying its system row + managed accounts + provenance pills, with reconcile-on-activation and fail-closed remote gating. `systemIdentity` widened to accept `{ projectId }`; a host it cannot resolve returns `null` (**fail-closed, no fabrication**) pending the remote relay leg.
- **8.3 — reconcile + system discovery.** `codexAccountReconcile` discovers only authenticated **pending** accounts and merges against a **fresh** list — never reviving a removed account nor clobbering an already-changed one. `systemCodexAccount` resolves the implicit `~/.codex` login once per machine (`ensure` / `ensureRemote`), every read failing closed to `null`.
- **8.4 — the switch UI + fail-closed selection (Property 4).** `codexAccountSwitchStillEligible` recycles the source pane only if it is still the exact idle conversation (agentId/ssh/cwd/accountId and **sessionId** unchanged + `restartEligibility` ok — the sessionId equality is the "resume, never fork" enforcement). `codexAccountSelectable` is the create/switch gate: a hostile/unsafe id, an explicitly selected **MISSING** account, or a remote account with **no live connection** is REFUSED — the UI never silently falls back to another login. The real authorization stays main-side (PR 5); these are the renderer's own refusals so the UI can never *originate* a fail-open switch.
- **U8 (owed from PR 7).** `UsageIndicator` keyed the codex popover blocks by `provider` ('codex'), colliding N accounts on one React key. `providerRowKey` keys on `provider`+`accountId` and `dedupeProviderRows` reduces true duplicates to one row (keeping the informative one). Per-account Codex usage now renders distinctly. Closes PR 7's U8.

## The security-relevant pin (Property 4)
A pane whose `sessionId` diverged is not recycled; an explicitly selected missing/unreachable account is refused, never run against another login. Both are pinned red-on-regression. **Mutation: dropping the `sessionId` equality → red; dropping the remote no-connection gate → red.**

## Tests / gates
`npm run typecheck` clean. Full `npx vitest run`: **553 files passed, 1 skipped, 0 failed** (7663 tests). New suites: `accountPresentation`, `AccountIdentityPills`, `codexAccountReconcile`, `systemCodexAccount`, `codex-account-switch`, `codexMachineGroups`, `usageScope` (U8).

## Mutation numbers (introduced/caught)
- `codex-account-switch.test.ts` — **4/4** (drop sessionId equality; drop remote no-connection gate; missing-account returns ok; drop `isSafeAccountId` on a *present* hostile row).
- `codexAccountReconcile.test.ts` — **2/2** (drop pending filter in discover; drop `!pending` guard in apply).
- `systemCodexAccount.test.ts` — **2/2** (drop the once-guard; drop the already-resolved guard).
- `accountPresentation.test.ts` — **2/2** (drop generated-label rejection; force provenance to Local).
- `codexMachineGroups.test.ts` — **2/2** (local partition takes all accounts; drop remote-target dedupe).
- `usageScope.test.ts` (U8) — **1/1** (key by provider only). **Total 13/13.**

## Scope notes
- Remote Codex account *lifecycle* (add/login/remove) is displayed and grouped but gated fail-closed: the base IPC (`add`/`waitLogin`/`remove`) has no host ctx, so operating "on host X" would silently act on **this Mac** — the exact fail-open Property 4 forbids. Local Codex accounts are fully operable; the remote leg lands with the host relay (a follow-up).
- The existing Claude accounts block is left intact; Codex gets the machine-grouped treatment as an added section, to avoid regressing the shipped Claude flow.

Credit: @Corvin (#112) for the presentation model, machine grouping, reconcile, and switch-eligibility shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
