### PR TITLE
feat(codex): the per-node account picker and the switch menu

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -405,6 +405,10 @@ import {
   ungroupNodes,
   type CanvasNode
 } from '../state/workspace'
+import { codexAccountSelectable } from './codex-account-switch'
+import { resolveNewCodexNodeAccount } from './codex-account-ops'
+import type { CodexAccount } from '@shared/codex-account'
+import { useSystemCodexAccount } from '../state/systemCodexAccount'
 import { toKanbanSession } from './toKanbanSession'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
@@ -3548,6 +3552,18 @@ export function Canvas() {
   // the "System account" entry with it.
   useEffect(() => useSystemAccount.getState().ensure(), [])
 
+  // The connected SSH project whose host owns a remote account, or undefined when no matching
+  // project is currently connected (live ControlMaster in useSshConn). The fail-closed Codex
+  // account gates (`codexAccountSelectable`) refuse a remote account without one, so it can never
+  // run against the LOCAL login. Mirrors AccountsSection's helper of the same name.
+  const connectedProjectIdForHost = useCallback((host?: string): string | undefined => {
+    if (!host) return undefined
+    const conn = useSshConn.getState().byProject
+    return useProjects
+      .getState()
+      .projects.find((p) => p.ssh && sshHostKey(p.ssh.server) === host && conn[p.id])?.id
+  }, [])
+
   const addAgentNode = useCallback(
     (
       agentId: AgentId,
@@ -3558,13 +3574,37 @@ export function Canvas() {
     ) => {
       const project = useProjects.getState().getProject(activeProjectId)
       const cwd = cwdForNewNodeIn(groupId) ?? project?.cwd
-      // Funnel through resolveNewNodeAccount so the project default applies even without an
-      // explicit pick. The factory drops the account for non-claude agents.
-      const account = resolveNewNodeAccount(
-        accountId,
-        project,
-        useSettings.getState().settings.claudeAccounts
-      )
+      // Codex accounts (S6) resolve through their OWN fail-closed gate: an explicitly picked account
+      // that is missing/hostile/unconnected is REFUSED here rather than silently downgraded to the
+      // system login (Property 4). Claude keeps its project-default-aware resolver. The factory
+      // stamps the id only for the claude/codex builtins.
+      let account: string | undefined
+      if (agentId === 'codex') {
+        const decision = resolveNewCodexNodeAccount(
+          accountId,
+          useSettings.getState().settings.codexAccounts,
+          connectedProjectIdForHost
+        )
+        if (!decision.create) {
+          setNotice({
+            kind: 'error',
+            text:
+              decision.reason === 'no-connection'
+                ? 'That Codex account lives on a host that is not connected — connect its SSH project first.'
+                : 'That Codex account is no longer available. Nothing was created.'
+          })
+          return
+        }
+        account = decision.accountId
+      } else {
+        // Funnel through resolveNewNodeAccount so the project default applies even without an
+        // explicit pick. The factory drops the account for non-claude agents.
+        account = resolveNewNodeAccount(
+          accountId,
+          project,
+          useSettings.getState().settings.claudeAccounts
+        )
+      }
       setNodes((ns) => {
         const node = createAgentNode(
           agentId,
@@ -3580,7 +3620,15 @@ export function Canvas() {
       })
       markDirty()
     },
-    [setNodes, markDirty, activeProjectId, emptyNodePos, cwdForNewNodeIn, parentInto]
+    [
+      setNodes,
+      markDirty,
+      activeProjectId,
+      emptyNodePos,
+      cwdForNewNodeIn,
+      parentInto,
+      connectedProjectIdForHost
+    ]
   )
 
   // "Spawn a team…" (issue #78): the dialog collects the task; this opens ONE conductor node
@@ -5708,6 +5756,18 @@ export function Canvas() {
       // where this host's accounts come from — local accounts are correctly invisible here, and
       // a bare flat entry read as "multi-account is broken on SSH".
       const accountsHint = sshAccountsHint(project, accounts)
+      // Codex accounts (S6 §3.4): the accounts belonging to THIS project's machine — local accounts
+      // for a local project, this host's accounts for an SSH project — mirroring accountsForProject.
+      const codexHostKey = project?.ssh ? sshHostKey(project.ssh.server) : undefined
+      const codexAccountsHere = useSettings
+        .getState()
+        .settings.codexAccounts.filter(
+          (a) => !a.pending && (codexHostKey ? a.host === codexHostKey : !a.host)
+        )
+      const codexSystemLabel = systemAccountDisplay(
+        undefined,
+        useSystemCodexAccount.getState().email
+      )
       return [
         ...BUILTIN_AGENT_IDS.filter((aid) => !disabled.includes(aid)).map((aid): MenuItem => {
           // Claude gets an account picker submenu when ≥1 account exists; System = project
@@ -5743,6 +5803,42 @@ export function Canvas() {
               ]
             }
           }
+          // Codex gets its own account picker submenu when ≥1 managed account lives on this
+          // project's machine (S6 §3.4). Every managed row is gated through `codexAccountSelectable`
+          // — a missing/hostile/unconnected account renders DISABLED, so the fail-closed refusal is
+          // enforced before the click, and again in `addAgentNode` (the UI is not the boundary).
+          if (aid === 'codex' && codexAccountsHere.length > 0) {
+            return {
+              type: 'submenu',
+              label: `New ${AGENT_CONFIG[aid].label}`,
+              icon: <AgentIcon agentId={aid} />,
+              children: [
+                {
+                  label: codexSystemLabel,
+                  icon: <AgentIcon agentId="codex" />,
+                  onClick: () => addAgentNode('codex', at, groupId)
+                },
+                ...codexAccountsHere.map((a): MenuItem => {
+                  const sel = codexAccountSelectable(
+                    a.id,
+                    codexAccountsHere,
+                    connectedProjectIdForHost
+                  )
+                  return {
+                    label: a.label,
+                    icon: <AgentIcon agentId="codex" />,
+                    disabled: !sel.ok,
+                    hint: sel.ok
+                      ? undefined
+                      : sel.reason === 'no-connection'
+                        ? 'This account lives on a host that is not connected — connect its SSH project first.'
+                        : 'This account is no longer available.',
+                    onClick: () => addAgentNode('codex', at, groupId, a.id)
+                  }
+                })
+              ]
+            }
+          }
           return {
             label: `New ${AGENT_CONFIG[aid].label}`,
             icon: <AgentIcon agentId={aid} />,
@@ -5761,7 +5857,7 @@ export function Canvas() {
           )
       ]
     },
-    [addAgentNode]
+    [addAgentNode, connectedProjectIdForHost]
   )
 
   const groupItems = useCallback(

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -405,8 +405,8 @@ import {
   ungroupNodes,
   type CanvasNode
 } from '../state/workspace'
-import { codexAccountSelectable } from './codex-account-switch'
-import { resolveNewCodexNodeAccount } from './codex-account-ops'
+import { codexAccountSelectable, codexAccountSwitchStillEligible } from './codex-account-switch'
+import { resolveNewCodexNodeAccount, planCodexAccountSwitch } from './codex-account-ops'
 import type { CodexAccount } from '@shared/codex-account'
 import { useSystemCodexAccount } from '../state/systemCodexAccount'
 import { toKanbanSession } from './toKanbanSession'
@@ -4836,6 +4836,117 @@ export function Canvas() {
     )
   }, [setNodes, markDirty])
 
+  // S6 §3.5 — originate an owner-authorized Codex account SWITCH for a running node, then recycle
+  // its pane onto the target account. The renderer is NOT the security boundary: PR 5's three-phase
+  // handler is owner-authorized (only the WebContents that reserved may commit/finish) and refuses a
+  // missing/hostile id; here we fail closed BEFORE originating (planCodexAccountSwitch routes the
+  // target through codexAccountSelectable) and re-check `codexAccountSwitchStillEligible` before the
+  // recycle so a diverged/forked pane is never bound onto the switched account — the conversation id
+  // passed to switchThread is the node's own, so the switch RESUMES it, never forks.
+  const switchCodexAccountNode = useCallback(
+    async (nodeId: string, targetAccountId: string | undefined) => {
+      const codexApi = window.nodeTerminal.codexAccounts
+      const snapshot = (): {
+        agentId?: string
+        cwd?: string
+        accountId?: string
+        ssh?: boolean
+        sessionId?: string
+        state?: string
+      } => {
+        const n = nodesRef.current.find((x) => x.id === nodeId)
+        const st = useAgentStatus.getState().byId[nodeId]
+        return {
+          agentId: n?.data.agentId as string | undefined,
+          cwd: n?.data.cwd as string | undefined,
+          accountId: (n?.data.accountId as string | undefined) || undefined,
+          ssh: !!n?.data.ssh,
+          sessionId: restartSessionId(st?.sessionId, n?.data.agentSessionId),
+          state: st?.state
+        }
+      }
+      const decision = planCodexAccountSwitch(
+        snapshot(),
+        targetAccountId,
+        useSettings.getState().settings.codexAccounts,
+        connectedProjectIdForHost
+      )
+      if (!decision.ok) {
+        if (decision.reason === 'same-account') return // no-op: already on this account
+        setNotice({
+          kind: 'error',
+          text:
+            decision.reason === 'no-connection'
+              ? 'That Codex account lives on a host that is not connected — connect its SSH project first.'
+              : decision.reason === 'no-session'
+                ? 'This session has no resumable conversation id yet — nothing to switch.'
+                : 'That Codex account is no longer available. Nothing was changed.'
+        })
+        return
+      }
+      const { plan } = decision
+      let token: string | undefined
+      try {
+        const res = await codexApi.switchThread(
+          plan.sessionId,
+          plan.cwd,
+          plan.sourceAccountId,
+          plan.targetAccountId
+        )
+        token = res.rollbackToken
+        // A no-op or unreserved answer (no token) means main-side did not stage an exposure — done.
+        if (!token) return
+        // The fork took seconds — refuse to recycle unless the pane is STILL the exact idle
+        // conversation the user chose (Corvin's #112 recycle guard). Else roll the reservation back.
+        if (!codexAccountSwitchStillEligible(plan.expected, snapshot())) {
+          await codexApi.rollbackSwitch(token)
+          setNotice({
+            kind: 'error',
+            text: 'This session changed while the switch was preparing — nothing was changed.'
+          })
+          return
+        }
+        await codexApi.commitSwitch(token)
+        // Bind the node to the target account, THEN recycle its shell so codex relaunches under the
+        // target CODEX_HOME and `--resume <sessionId>` resumes the SAME conversation from it.
+        setNodes((ns) =>
+          ns.map((x) =>
+            x.id === nodeId && x.type === 'terminal'
+              ? { ...x, data: { ...x.data, accountId: plan.targetAccountId } }
+              : x
+          )
+        )
+        markDirty()
+        const fn = agentRestartFn(nodeId)
+        const outcome = fn ? await settleRestart(() => fn(undefined, undefined, true)) : 'not-eligible'
+        await codexApi.finishSwitch(token)
+        setNotice(
+          outcome === 'restarted'
+            ? { kind: 'info', text: 'Codex account switched — conversation resumed.' }
+            : {
+                kind: 'error',
+                text:
+                  'Codex account switched, but the pane could not be relaunched — restart the ' +
+                  'agent to resume on the new account.'
+              }
+        )
+      } catch {
+        if (token) {
+          try {
+            await codexApi.rollbackSwitch(token)
+          } catch {
+            // Best-effort rollback; the reservation also releases on its TTL / owner destruction.
+          }
+        }
+        setNotice({
+          kind: 'error',
+          text: 'The Codex account switch failed and was rolled back. Nothing was changed.'
+        })
+      }
+    },
+    [setNodes, markDirty, connectedProjectIdForHost]
+  )
+
   // Who the bulk restart would act on, right now: the ACTIVE project's canvas (nodesRef holds
   // exactly that). Read fresh at every call — agent state and session ids arrive asynchronously.
   const bulkRestartPlan = useCallback((): BulkRestartPlan => {
@@ -5701,6 +5812,57 @@ export function Canvas() {
                                 'Configure a URL and API key in Settings → Model gateway.'
                       }
                     ] as MenuItem[])
+                : []),
+              // Switch this running Codex node onto another machine-scoped account (S6 §3.5). Shown
+              // only for a Codex node with managed accounts on its machine. Each row is gated through
+              // `codexAccountSelectable`; the actual switch is owner-authorized MAIN-SIDE and resumes
+              // the SAME conversation id (`switchCodexAccountNode`) — the UI is not the boundary.
+              ...(sourceAgentId === 'codex'
+                ? (() => {
+                    const codexAll = useSettings.getState().settings.codexAccounts
+                    const hostKey = n?.data.ssh ? sshHostKey(n.data.ssh as SshServer) : undefined
+                    const onMachine = codexAll.filter(
+                      (a) => !a.pending && (hostKey ? a.host === hostKey : !a.host)
+                    )
+                    if (onMachine.length === 0) return []
+                    const currentAccountId = (n?.data.accountId as string | undefined) || undefined
+                    const systemCodexLabel = systemAccountDisplay(
+                      undefined,
+                      useSystemCodexAccount.getState().email
+                    )
+                    const row = (
+                      id: string | undefined,
+                      label: string
+                    ): MenuItem => {
+                      const isCurrent = (id || undefined) === currentAccountId
+                      const sel = codexAccountSelectable(id, onMachine, connectedProjectIdForHost)
+                      return {
+                        label: `${isCurrent ? '✓ ' : ''}${label}`,
+                        icon: <AgentIcon agentId="codex" />,
+                        disabled: !!why || isCurrent || !sel.ok,
+                        hint: isCurrent
+                          ? 'This node already runs on this account.'
+                          : !sel.ok
+                            ? sel.reason === 'no-connection'
+                              ? 'This account lives on a host that is not connected.'
+                              : 'This account is no longer available.'
+                            : (why ??
+                              'Moves this conversation to the account and resumes it there (same conversation).'),
+                        onClick: () => void switchCodexAccountNode(ids[0], id)
+                      }
+                    }
+                    return [
+                      {
+                        type: 'submenu',
+                        label: 'Switch Codex account',
+                        icon: <IconSwitch />,
+                        children: [
+                          row(undefined, systemCodexLabel),
+                          ...onMachine.map((a) => row(a.id, a.label))
+                        ]
+                      }
+                    ] as MenuItem[]
+                  })()
                 : [])
             ] as MenuItem[]
           })()
@@ -5721,6 +5883,8 @@ export function Canvas() {
     toggleMarkdown,
     reloadTerminals,
     restartAgentNode,
+    switchCodexAccountNode,
+    connectedProjectIdForHost,
     deleteNodes,
     gatewayModels,
     gatewayStatus,

--- a/src/renderer/canvas/codex-account-ops.test.ts
+++ b/src/renderer/canvas/codex-account-ops.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { CodexAccount } from '@shared/codex-account'
-import { resolveNewCodexNodeAccount } from './codex-account-ops'
+import { resolveNewCodexNodeAccount, planCodexAccountSwitch } from './codex-account-ops'
 
 const local: CodexAccount = { id: 'account-a', label: 'Work' }
 const remote: CodexAccount = { id: 'account-r', label: 'Box', host: 'u@box' }
@@ -48,6 +48,76 @@ describe('resolveNewCodexNodeAccount (fail-closed New Codex picker — §3.4 / P
   it('REFUSES a remote account whose host is not connected — never binds it locally', () => {
     expect(resolveNewCodexNodeAccount('account-r', accounts, noConnection)).toEqual({
       create: false,
+      reason: 'no-connection'
+    })
+  })
+})
+
+describe('planCodexAccountSwitch (fail-closed switch origination — §3.5)', () => {
+  const codexNode = {
+    agentId: 'codex',
+    cwd: '/repo',
+    accountId: 'account-a',
+    ssh: false,
+    sessionId: 'thread-a'
+  }
+
+  it('plans a switch to a present account, preserving the conversation id', () => {
+    const d = planCodexAccountSwitch(codexNode, 'account-r', accounts, connected)
+    expect(d.ok).toBe(true)
+    if (!d.ok) return
+    expect(d.plan.sourceAccountId).toBe('account-a')
+    expect(d.plan.targetAccountId).toBe('account-r')
+    // MUTATION PIN: the switch must resume the SAME conversation id, never fork. If the plan carried
+    // any id other than the node's own `sessionId` here (or in `expected.sessionId`), a UI switch
+    // could recycle a diverged pane. Both must equal 'thread-a'. Must stay red on any divergence.
+    expect(d.plan.sessionId).toBe('thread-a')
+    expect(d.plan.expected.sessionId).toBe('thread-a')
+    // The eligibility snapshot pins the SOURCE account (the pane still runs it pre-recycle).
+    expect(d.plan.expected.accountId).toBe('account-a')
+    expect(d.plan.expected.agentId).toBe('codex')
+  })
+
+  it('plans a switch to the system account (target undefined) from a managed one', () => {
+    const d = planCodexAccountSwitch(codexNode, undefined, accounts, connected)
+    expect(d).toMatchObject({ ok: true, plan: { targetAccountId: undefined } })
+  })
+
+  it('refuses a non-Codex node', () => {
+    expect(planCodexAccountSwitch({ ...codexNode, agentId: 'claude' }, 'account-r', accounts, connected)).toEqual({
+      ok: false,
+      reason: 'not-codex'
+    })
+  })
+
+  it('refuses a node with no resumable conversation id', () => {
+    expect(planCodexAccountSwitch({ ...codexNode, sessionId: undefined }, 'account-r', accounts, connected)).toEqual({
+      ok: false,
+      reason: 'no-session'
+    })
+  })
+
+  it('refuses a no-op switch to the account the node already runs', () => {
+    // MUTATION PIN: drop the `source === target` short-circuit → a same-account switch would be
+    // ORIGINATED (reserving + recycling for nothing). Must stay red.
+    expect(planCodexAccountSwitch(codexNode, 'account-a', accounts, connected)).toEqual({
+      ok: false,
+      reason: 'same-account'
+    })
+  })
+
+  it('REFUSES a MISSING target account — no silent substitution', () => {
+    // MUTATION PIN: if a refused target fell through to `{ ok: true }`, the UI would originate a
+    // switch that main-side then binds/refuses. The renderer must fail closed first. Must stay red.
+    expect(planCodexAccountSwitch(codexNode, 'account-gone', accounts, connected)).toEqual({
+      ok: false,
+      reason: 'unavailable'
+    })
+  })
+
+  it('REFUSES a remote target whose host is not connected', () => {
+    expect(planCodexAccountSwitch(codexNode, 'account-r', accounts, noConnection)).toEqual({
+      ok: false,
       reason: 'no-connection'
     })
   })

--- a/src/renderer/canvas/codex-account-ops.test.ts
+++ b/src/renderer/canvas/codex-account-ops.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { CodexAccount } from '@shared/codex-account'
+import { resolveNewCodexNodeAccount } from './codex-account-ops'
+
+const local: CodexAccount = { id: 'account-a', label: 'Work' }
+const remote: CodexAccount = { id: 'account-r', label: 'Box', host: 'u@box' }
+const accounts = [local, remote]
+const connected = (host: string): string | undefined => (host === 'u@box' ? 'proj-1' : undefined)
+const noConnection = (): undefined => undefined
+
+describe('resolveNewCodexNodeAccount (fail-closed New Codex picker — §3.4 / Property 4)', () => {
+  it('creates on the system account when nothing is picked', () => {
+    expect(resolveNewCodexNodeAccount(undefined, accounts, noConnection)).toEqual({
+      create: true,
+      accountId: undefined
+    })
+    expect(resolveNewCodexNodeAccount('', accounts, noConnection)).toEqual({
+      create: true,
+      accountId: undefined
+    })
+  })
+
+  it('creates on a present local managed account', () => {
+    expect(resolveNewCodexNodeAccount('account-a', accounts, noConnection)).toEqual({
+      create: true,
+      accountId: 'account-a'
+    })
+  })
+
+  it('REFUSES an explicitly picked MISSING account — no silent substitution to system', () => {
+    // MUTATION PIN: if a refused selection fell back to `{ create: true, accountId: undefined }`
+    // (the system login) instead of refusing, this goes green — a missing pick would silently bind
+    // the system account. Must stay red.
+    expect(resolveNewCodexNodeAccount('account-gone', accounts, connected)).toEqual({
+      create: false,
+      reason: 'unavailable'
+    })
+  })
+
+  it('REFUSES a hostile (path-escaping) id even when a matching row is present', () => {
+    const hostile: CodexAccount = { id: '../escape', label: 'evil' }
+    expect(resolveNewCodexNodeAccount('../escape', [...accounts, hostile], connected)).toEqual({
+      create: false,
+      reason: 'unavailable'
+    })
+  })
+
+  it('REFUSES a remote account whose host is not connected — never binds it locally', () => {
+    expect(resolveNewCodexNodeAccount('account-r', accounts, noConnection)).toEqual({
+      create: false,
+      reason: 'no-connection'
+    })
+  })
+})

--- a/src/renderer/canvas/codex-account-ops.ts
+++ b/src/renderer/canvas/codex-account-ops.ts
@@ -1,0 +1,37 @@
+// S6 PR 8.5 — the two USER-FACING trigger surfaces for machine-scoped Codex accounts, wired on top
+// of PR 8's fail-closed guards (`codex-account-switch.ts`). NOTHING here is the security boundary:
+// owner-authorization and the atomic exposure live MAIN-SIDE (PR 5's three-phase switch), and the
+// account-validity gate is `codexAccountSelectable`. These pure decisions are the renderer's own
+// fail-closed refusals so the two UI surfaces can never ORIGINATE an unauthorized or fail-open op:
+//   1. `resolveNewCodexNodeAccount` — the "New Codex node" account picker (§3.4). An explicitly
+//      picked account that is MISSING / hostile / unconnected is REFUSED, never silently swapped for
+//      the system login.
+
+import type { CodexAccount } from '@shared/codex-account'
+import { codexAccountSelectable } from './codex-account-switch'
+
+/** The picker's verdict for a NEW Codex node. `create: false` carries the same fail-closed reason
+ *  `codexAccountSelectable` produced — the node is NOT created, and never with another account. */
+export type CodexCreateDecision =
+  | { create: true; accountId: string | undefined }
+  | { create: false; reason: 'unavailable' | 'no-connection' }
+
+/**
+ * Fail-closed account resolution for a NEW Codex node (surface §3.4). An empty/undefined selection
+ * is the SYSTEM account (`~/.codex`), always creatable. Any explicit id is routed through
+ * `codexAccountSelectable`; a missing, hostile, or (remote) unconnected pick is REFUSED — the caller
+ * must NOT fall back to the system login or any other account (Property 4, Decision 2).
+ */
+export function resolveNewCodexNodeAccount(
+  explicit: string | undefined,
+  accounts: readonly CodexAccount[],
+  connectedProjectIdForHost: (host: string) => string | undefined
+): CodexCreateDecision {
+  // The system account (no id) always lives on this machine — nothing to miss, nothing to connect.
+  if (!explicit) return { create: true, accountId: undefined }
+  const selectable = codexAccountSelectable(explicit, accounts, connectedProjectIdForHost)
+  // A refused selection is NEVER downgraded to the system account — that silent substitution is the
+  // exact fail-open Property 4 forbids. Refuse the creation and let the UI say why.
+  if (!selectable.ok) return { create: false, reason: selectable.reason }
+  return { create: true, accountId: explicit }
+}

--- a/src/renderer/canvas/codex-account-ops.ts
+++ b/src/renderer/canvas/codex-account-ops.ts
@@ -6,9 +6,14 @@
 //   1. `resolveNewCodexNodeAccount` — the "New Codex node" account picker (§3.4). An explicitly
 //      picked account that is MISSING / hostile / unconnected is REFUSED, never silently swapped for
 //      the system login.
+//   2. `planCodexAccountSwitch` — the running-node account-SWITCH menu (§3.5). Refuses a non-Codex
+//      node, a node with no resumable conversation id, a no-op same-account switch, and (through
+//      `codexAccountSelectable`) a missing/hostile/unconnected target. The `expected` snapshot it
+//      returns is exactly what `codexAccountSwitchStillEligible` re-checks before the pane is
+//      recycled, so a UI-originated switch always resumes the SAME conversation id — never a fork.
 
 import type { CodexAccount } from '@shared/codex-account'
-import { codexAccountSelectable } from './codex-account-switch'
+import { codexAccountSelectable, type CodexAccountSwitchState } from './codex-account-switch'
 
 /** The picker's verdict for a NEW Codex node. `create: false` carries the same fail-closed reason
  *  `codexAccountSelectable` produced — the node is NOT created, and never with another account. */
@@ -34,4 +39,65 @@ export function resolveNewCodexNodeAccount(
   // exact fail-open Property 4 forbids. Refuse the creation and let the UI say why.
   if (!selectable.ok) return { create: false, reason: selectable.reason }
   return { create: true, accountId: explicit }
+}
+
+/** What the imperative orchestrator needs to drive PR 5's three-phase switch for a node. */
+export interface CodexSwitchPlan {
+  /** The node's current account (undefined = system) — the switch source. */
+  sourceAccountId: string | undefined
+  /** The chosen account (undefined = system) — the switch target. */
+  targetAccountId: string | undefined
+  /** The node's conversation id. Passed verbatim to `switchThread`; the switch resumes THIS id. */
+  sessionId: string
+  cwd: string
+  /** Snapshot re-checked by `codexAccountSwitchStillEligible` before the pane is recycled. Its
+   *  `sessionId` is the node's current id, so a diverged/forked pane is refused recycling. */
+  expected: Required<Pick<CodexAccountSwitchState, 'agentId' | 'cwd' | 'sessionId'>> &
+    Pick<CodexAccountSwitchState, 'accountId' | 'ssh'>
+}
+
+export type CodexSwitchDecision =
+  | { ok: true; plan: CodexSwitchPlan }
+  | { ok: false; reason: 'not-codex' | 'no-session' | 'same-account' | 'unavailable' | 'no-connection' }
+
+/**
+ * Decide whether a UI-originated account SWITCH may be ORIGINATED for a node (surface §3.5).
+ * Fail-closed — proceeds only on `{ ok: true }`:
+ *   - the node must be a Codex node (`agentId === 'codex'`);
+ *   - it must have a resumable conversation id (`sessionId`) and an absolute-ish cwd;
+ *   - the target must differ from the source (a no-op switch is refused, not run);
+ *   - the target must pass `codexAccountSelectable` (missing/hostile/unconnected ⇒ refused).
+ * The returned `plan.expected.sessionId` and `plan.sessionId` are BOTH the node's current id, so the
+ * orchestration can never fork the conversation onto the switched account.
+ */
+export function planCodexAccountSwitch(
+  node: { agentId?: string; cwd?: string; accountId?: string; ssh?: boolean; sessionId?: string },
+  targetAccountId: string | undefined,
+  accounts: readonly CodexAccount[],
+  connectedProjectIdForHost: (host: string) => string | undefined
+): CodexSwitchDecision {
+  if (node.agentId !== 'codex') return { ok: false, reason: 'not-codex' }
+  if (!node.sessionId || !node.cwd) return { ok: false, reason: 'no-session' }
+  const source = node.accountId || undefined
+  const target = targetAccountId || undefined
+  // A switch to the account the node already runs is a no-op — refuse rather than reserve/recycle.
+  if (source === target) return { ok: false, reason: 'same-account' }
+  const selectable = codexAccountSelectable(target, accounts, connectedProjectIdForHost)
+  if (!selectable.ok) return { ok: false, reason: selectable.reason }
+  return {
+    ok: true,
+    plan: {
+      sourceAccountId: source,
+      targetAccountId: target,
+      sessionId: node.sessionId,
+      cwd: node.cwd,
+      expected: {
+        agentId: 'codex',
+        cwd: node.cwd,
+        sessionId: node.sessionId,
+        accountId: source,
+        ssh: !!node.ssh
+      }
+    }
+  }
 }

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -556,8 +556,13 @@ describe('accountId on Claude node factories', () => {
     const node = createAgentNode('claude', 0, undefined, undefined, undefined, undefined, 'a1')
     expect(node.data.accountId).toBe('a1')
   })
-  it('does not stamp accountId onto a non-Claude agent node', () => {
+  it('stamps accountId onto a Codex agent node (S6 per-node account picker)', () => {
     const node = createAgentNode('codex', 0, undefined, undefined, undefined, undefined, 'a1')
+    expect(node.data.accountId).toBe('a1')
+  })
+  it('does not stamp accountId onto a non-account agent node', () => {
+    // Accounts bind to the Claude/Codex builtins only — another agent never carries one.
+    const node = createAgentNode('gemini', 0, undefined, undefined, undefined, undefined, 'a1')
     expect(node.data.accountId).toBeUndefined()
   })
   it('omits accountId when none is given', () => {

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -471,9 +471,12 @@ export function createAgentNode(
       group: null,
       tags: [],
       agentId,
-      // Accounts are inherently Claude-only — never stamp one onto another agent's node. A custom
-      // agent inheriting claude is still its own agent; account binding stays claude-the-builtin.
-      ...(accountId && agentId === 'claude' ? { accountId } : {}),
+      // Managed accounts bind to the builtin Claude and Codex agents (S6) — never to another
+      // builtin, and never to a custom agent even when it inherits one of those bases. A custom
+      // agent inheriting claude/codex is still its own agent; account binding stays with the
+      // builtin the account picker offered it for. The Codex spawn side honours `data.accountId`
+      // (resolveCodexSessionScope), the same field Claude uses.
+      ...(accountId && (agentId === 'claude' || agentId === 'codex') ? { accountId } : {}),
       // Persisted alongside the node (unlike initialCommand, which is consumed on first open), so
       // a cold restore months later still knows which conversation this node owns.
       ...(mintedSessionId ? { agentSessionId: mintedSessionId } : {}),


### PR DESCRIPTION
## What

Completes **S6 (machine-scoped Codex accounts, slice of #112)** by wiring the two user-facing TRIGGER surfaces that PR 8 deliberately deferred. The full backend (account model, identity proxy, three-phase owner-authorized switch, per-account usage) and the Settings display UI already merged; this makes S6 **operable** — a user can now *select* a Codex account for a new node and *switch* a running node's account.

Each surface routes through a PR 8 pinned guard, but the UI is **not** the security boundary — origination is owner-authorized MAIN-SIDE.

### Surface §3.4 — New-Codex-node account picker (`feat: the per-node account picker`)
- `createAgentNode` now stamps `data.accountId` for the `codex` builtin too (the field the spawn side already honours via `resolveCodexSessionScope`).
- The "New Codex" menu gains an account-picker submenu (accounts on the node's machine + system).
- Routes every pick through **`codexAccountSelectable`**. `resolveNewCodexNodeAccount` fails CLOSED: a missing / hostile / unconnected pick is REFUSED and the node is not created — never silently substituted with the system login (Property 4). Enforced in `addAgentNode`, not just the disabled menu rows.

### Surface §3.5 — Account-switch menu (`feat: the account-switch menu`)
- "Switch Codex account" submenu on a Codex node drives `switchThread → commitSwitch → finishSwitch` (`rollbackSwitch` on any failure).
- Routes through **`codexAccountSwitchStillEligible`**: between reserving and recycling the pane it re-checks the snapshot, so a pane whose thread/account/cwd drifted while the fork prepared is never recycled.
- The conversation id handed to `switchThread` is the node's own `agentSessionId`, so a UI-originated switch **resumes** it, never forks. After commit the node is rebound to the target account and its shell recycled → codex relaunches under the target `CODEX_HOME` and `--resume <sid>` continues the thread there.

## Security pins (mutation-checked)
- **Owner-auth (main-side, PR 5 — not modified):** a non-owner WebContents cannot commit/finish a switch — mutation dropping the `owner.id === sender.id` gate → **1 red** (`codex-accounts.switch.test.ts`).
- **Fail-closed selection:** missing account refused, no substitution to system — **3 red** (create) / **2 red** (switch target); hostile path-escaping id refused; remote-with-no-connection refused.
- **Same conversation id, never a fork:** a UI-originated switch carries the node's own id — mutation forking `expected.sessionId` → **1 red**.
- **No-op refused:** same-account switch short-circuits — mutation → **1 red**.

`assertCodexAccountId` / `isSafeAccountId` still gate every id; no credential on argv; merged S6 backend untouched.

## Tests
`npm run typecheck` clean; full `npx vitest run` = **7677 passed, 12 skipped, 0 failed**. New pure-logic suite `codex-account-ops.test.ts` (mutation-pinned) plus updated `workspace.test.ts` (codex node now stamps `accountId`).

## Notes
- CodeQL hygiene: diff is renderer logic + IPC calls only — no fs reads, no file→network.
- Device verification (real codex daemon + live SSH remote account) is owed — the pane-recycle leg is only exercised against the app at runtime.

Based on @Corvin's machine-scoped Codex accounts (#112). S6 of #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
