### PR TITLE
docs(codex): S6 machine-scoped accounts — docs and the acceptance gate

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -529,6 +529,27 @@ than a generic failure, see above), full **two-master flow-control coordination*
 a single actuator with the renderer), and the web folder picker's **hardcoded start
 directory**.
 
+### Managed Codex accounts (S6)
+
+The Server Edition **arms the Codex record-signing secret** but does **not** host the
+account-management IPC — that surface is desktop-driven over SSH.
+
+- **Arms the record secret (Decision 1).** At boot `armServerNodeIdentity`
+  (`src/server/node-identity-arm.ts`) loads the raw node-auth secret and calls
+  `setCodexThreadIdentityAuthSecret(...)` with it, so a managed Codex account's thread→node→account
+  ownership records can **sign and verify on a headless host**. Headless Linux has no OS keychain, so
+  the secret is 32 **raw bytes** at `node-auth-key.bin`, mode `0600` — the same both-shells channel the
+  desktop seals via `safeStorage`. This only makes the record layer *able to sign*; it is orthogonal to
+  the shared-app-server degrade (Codex nodes still launch bare here, exactly as before).
+- **Does NOT host the account-management verbs.** `initCodexAccounts` registers its IPC over Electron's
+  `ipcMain` with WebContents-owner authorization, which the headless bridge does not provide, so
+  `startServer` never calls it. This is **not** a silent gap: managed Codex logins **on an SSH host**
+  are driven by the **desktop** over SSH (the remote account-add / device-login / import legs + the
+  relay) — the host runs the relay + import, not its own copy of the account IPC.
+- **Fail-closed, both ways.** With no secret armed (unwritable key file), the record layer throws
+  rather than writing anything unsigned, and Codex nodes keep working bare. A machine with **no** managed
+  accounts is byte-for-byte the pre-S6 layout (a bare-root record per thread).
+
 ## Manual browser smoke checklist
 
 Run against a real browser (this is the human-verified path; the automated harness

--- a/docs/codex-accounts-acceptance.md
+++ b/docs/codex-accounts-acceptance.md
@@ -1,0 +1,83 @@
+# S6 acceptance gate — machine-scoped managed Codex accounts
+
+**S6 is not "done" until this gate is green.** The feature closes external PR #112 (@Corvin). Every
+mechanism (PRs 1–8.5) is merged and unit-tested against real primitives, and the composition is walked
+once end-to-end in `src/main/codex-accounts-e2e.test.ts`. But several legs **cannot run in headless
+CI** — a live `codex app-server`, a second logged-in ChatGPT account, a real SSH host with a
+curl-managed standalone Codex install, and the renderer's imperative pane-recycle sequencing. Those
+are the checklist below. **The code fails CLOSED on each**, so a false assumption is a *refused* op and
+a *rolled-back* copy, never a silent corruption — but "fails closed" is not "verified", and nobody may
+call S6 verified until a human runs these on a real Mac + real host.
+
+## What CI already proves (no device needed)
+
+`npx vitest run src/main/codex-accounts-e2e.test.ts` — the one long composition test. Against REAL
+primitives (real fs, real `/bin/sh`, real HMAC, the real main-side switch handler; only the live
+app-server JSON-RPC is faked, and the rollout path it returns is a real on-disk file):
+
+- a managed account home resolves its spawn scope; an explicitly selected **missing** account
+  **refuses** to spawn (no system fallback);
+- a signed ownership record is recovered under real `/bin/sh` by the resolver prelude;
+- the three-phase main-side switch **hardlinks the rollout inode** into the target (same conversation
+  id, never a fork) and the local copy remains;
+- the local→SSH transfer source leg hands off the containment-validated path and keeps the local copy;
+  an absent importer **fails closed**;
+- the same thread id in two scopes resolves to **no owner** in the proxy, the sh resolver, and the
+  relay catalog;
+- a different existing rollout at the target is **never overwritten** (the local twin of remote
+  `exit 17`);
+- usage stays **per-account** (each row stamped with its own id, `unavailable` included), never mixed;
+- the Server Edition arms the record secret **raw** (`node-auth-key.bin`, `0600`), no keychain
+  plaintext; with no secret armed a record write throws rather than writing unsigned;
+- **no credential rides any argv** (tmux env, the generated launcher, the auth-env strip).
+
+Mutation report (GC 9): 5 source mutations introduced, 5 caught (5/5) — M1 spawn-scope fallback, M2
+ambiguity gate, M3 rollout never-overwrite, M4 usage attribution, M5 sh `matches -eq 1` gate.
+
+## Owed device verifications — a human MUST run these before S6 is called done
+
+Everything below needs **a real Mac desktop + a real SSH host** with a curl-managed **standalone**
+Codex install + a **logged-in 2nd managed account**. Headless CI cannot run them.
+
+- [ ] **U1 — a running app-server discovers a hardlinked rollout without a reindex.** Load-bearing for
+      the copy. Code mitigation: verify-then-recycle ⇒ a false U1 is a refused copy + rollback, never
+      silent. VERIFY: expose a thread to a 2nd account and confirm the **live daemon** finds it *before*
+      the node recycles.
+- [ ] **U2 — the conversation id survives copy + switch under a 2nd login.** Hardlinked inode +
+      resume-by-path + the `-32004` guard. VERIFY: switch a **running** node's account and confirm the
+      **same** conversation resumes — not a fork.
+- [ ] **U4 — live RPC payload shapes.** `account/read` → `{email}`, `thread/read` → `{path, cwd}`,
+      confirmed against Codex 0.146.0 via `app-server --listen`; the **curl-standalone `daemon start`**
+      path is still owed. VERIFY the shapes against the daemon the app actually starts.
+- [ ] **Full desktop → host flow over real WAN.** Add account, remote **device-login**, **import** a
+      conversation to an SSH account, then **recycle** the node onto the host. Owed on Mac + real host.
+- [ ] **The imperative pane-recycle glue** (commit → rebind → restartShell → finish) + a **live SSH
+      remote-account switch.** The pure logic + the main-side switch are unit-tested; the imperative
+      renderer sequencing is only exercised against the running app.
+- [ ] **Remote-host account LIFECYCLE UI** (add / login / remove **on** an SSH host). The local picker +
+      switch are wired (PR 8.5); the remote-host lifecycle surface is **display + group only**,
+      fail-closed, owed to the host-relay follow-up. VERIFY it stays display-only and refuses to mint.
+
+## Happy-path acceptance walk (the one a human runs end to end)
+
+On a real Mac with a real SSH host and a 2nd ChatGPT login available:
+
+1. **Add account** — Settings → add a managed Codex account, complete the device login; the row shows
+   its captured email and stops being `pending`.
+2. **New node under it** — stamp a fresh Codex node and pick the managed account in the per-node picker;
+   confirm the node runs against that account's isolated home (its own `auth.json`, not the system one).
+3. **Switch** — switch the running node to another account; confirm the **same conversation resumes**
+   (U2), not a new thread, and that the source account's copy is still usable (the hardlink).
+4. **Copy to SSH** — transfer the (idle) conversation to a remote account on the SSH host; confirm the
+   id survives, the far side **discovers** it (U1), the **local copy remains**, and a pre-existing
+   remote rollout is **never overwritten**.
+5. **Recycle** — recycle the node onto the host; confirm it resumes the imported conversation.
+
+Failure expectations to spot-check while walking it: a selected-but-missing account **refuses** (no
+fallback); the same thread id claimed by two accounts resolves to **no owner**; removing an account
+while a switch holds it is **refused**; the phone can **read** account state but never originate an
+add/switch/copy.
+
+---
+
+Credit: @Corvin (external PR #112). S6 = PRs 1–9 (this gate is PR 9 of 9).

--- a/docs/node-identity.md
+++ b/docs/node-identity.md
@@ -408,6 +408,40 @@ and the other node reads it. The materialiser refuses tokens for the **whole col
 sweeps anything an earlier pass wrote for them; those nodes fall back to `legacy`, the designed
 fail-open state.
 
+## Account scoping (S6): the same secret signs Codex account-scoped records
+
+The restart-stable node-auth secret above does a second job: it signs the Codex thread→node→**account**
+ownership records (`src/core/codex-identity-proxy.ts`). S6 gives a machine the system Codex login
+(`~/.codex`) alongside managed logins, and a record now binds the full 4-tuple
+`(threadId, accountScope, nodeId, hookEndpoint)` so one account can never be made to speak for
+another's threads. The full model is [Shared Codex node identity](shared-codex-node-identity.md); the
+parts that touch this secret and the invariants here:
+
+- **The codex identity secret is armed on both shells.** Desktop and Server Edition both call
+  `setCodexThreadIdentityAuthSecret(loadOrCreateNodeAuthSecret())` at boot — the desktop in
+  `src/main/index.ts`, the Server Edition in `src/server/node-identity-arm.ts` — so **managed records
+  sign on a headless host too** (raw `0600` `node-auth-key.bin`, no keychain). This is the both-shells
+  half of Decision 1; a keychain-only secret would regress Server Edition. With **no** secret armed, a
+  record write **throws** rather than writing an unsigned record (fail-closed) — nothing is minted.
+- **The switch is owner-authorized, main-side.** Moving a running node's conversation to another
+  account is a three-phase, TTL-bounded protocol keyed off `event.sender.id` — only the WebContents
+  that reserved the switch may commit or finish it. It resumes the **same conversation id** (an atomic
+  hardlink of the rollout inode), never a fork. The phone **never originates** an add/switch/copy.
+- **Ambiguity fails closed, like the latch.** The same thread id owned by two account scopes resolves
+  to **no owner** unless `owners.size === 1` — the same house rule as the pane-ownership and
+  invented-`kid` refusals: an owner that cannot be *proven* is denied, never picked by order.
+- **Ids are path segments, still.** A managed account id is a directory scope
+  (`<codexThreadIdentityRoot>/<accountId>/<threadId>`), so it passes `isSafeAccountId` (must start
+  alphanumeric — blocks `.`/`..`/leading-separator) before it becomes a path, exactly as `isSafeNodeId`
+  / `isSafeThreadId` do. The account id travels in the launcher's POST **body**, never on an argv
+  (invariant 1 — no credential *or* scope-shaping input on a command line).
+
+Two S6 surfaces remain **owed device verifications** rather than shipped-and-verified: the imperative
+pane-recycle glue behind a live switch, and the remote-host account **lifecycle** UI (add/login/remove
+*on* an SSH host — the local picker + switch are wired, the remote lifecycle surface is display-only,
+fail-closed). Both, plus the live-daemon and real-WAN legs, are in
+[the acceptance gate](codex-accounts-acceptance.md).
+
 ## Invariants a future change must not break
 
 1. **No credential on any argv or command line — local or SSH.** Not tmux `-e`, not `curl -H`, not a

--- a/docs/shared-codex-node-identity.md
+++ b/docs/shared-codex-node-identity.md
@@ -6,10 +6,52 @@ The node↔thread mapping is what survives resumes, in-pane restarts, and app re
 managed logins, and a thread's ownership record must name **which account** it belongs to, not just
 which node — so one account can never be made to speak for another's threads.
 
-This document covers the ownership spine shipped in S6 PR 2. The account **model** and on-disk home
-layout are PR 1 (`codex-accounts-core.ts`); the spawn wiring, relay, and switch/transfer protocol
-are later PRs. This slice **ships inert** — nothing sets `NODETERM_CODEX_ACCOUNT_ID` on a pane yet —
-but it is fully tested against real primitives (real `/bin/sh`, real fs, real HMAC).
+This document covers the whole S6 feature — the account × machine model, the on-disk layout, the
+switch and cross-machine protocols, the fail-closed properties, and the same-filesystem (U3) /
+discovery (U1) constraints the probes settled. S6 shipped across nine PRs (the account model, the
+identity proxy documented here, the rollout primitive, the relay daemon, local accounts + the switch,
+SSH remote accounts, per-account usage, the Settings UI, and the per-node account picker); this
+feature is **fully operable** — a Codex node carries an account scope, the picker stamps it, and the
+switch/transfer verbs run. Every layer is tested against real primitives (real `/bin/sh`, real fs,
+real HMAC, the real main-side switch handler); the composition is walked once end-to-end in
+`src/main/codex-accounts-e2e.test.ts` (Task 9.2), and the human/device verifications that headless CI
+cannot run are enumerated in [the acceptance gate](codex-accounts-acceptance.md).
+
+Based on @Corvin's S6 design in external PR #112.
+
+## The account × machine model
+
+An account is **system** or **managed**, and it lives on **one machine**:
+
+- **System account** — the login at `$CODEX_HOME` (or `~/.codex`). No id. Always resolves. A machine
+  with no managed accounts behaves exactly as it did before S6 (Constraint 12).
+- **Managed account** — a second (or third…) logged-in Codex identity, addressed by a validated id.
+  Its home is private (`0700`) and isolated; only NON-secret installation assets (`config.toml`,
+  `AGENTS.md`, `skills`, …) are symlinked in from the system home — never `auth.json`, never the
+  thread DB, so a managed account acts only as **its own** login.
+- **Remote account** — the same, but its home lives on an SSH host (`host` set). The desktop drives
+  its lifecycle over SSH; the host runs the relay + import, not its own account-management IPC.
+
+`id` empty/undefined at any call site means the system account. Ids arrive from hand-editable,
+git-shared `settings.json` / `project.json`, so every id passes `isSafeAccountId`
+(`^[A-Za-z0-9][A-Za-z0-9._-]*$`, must start alphanumeric) **before** it becomes a path component.
+
+## On-disk home layout
+
+| What | Where |
+| --- | --- |
+| System home | `$CODEX_HOME` or `~/.codex` |
+| Managed home (local) | `~/.nodeterm/cx/<sha256(userDataDir ␀ accountId)[0..16]>`, mode `0700` |
+| Managed home (remote) | `<remoteHome>/.nodeterm/cx/<sha256(accountId)[0..16]>` |
+| App-server control socket | `<home>/app-server-control/app-server-control.sock` |
+| Ownership records | `<userDataDir>/codex-thread-nodes/` (system: bare root; managed: `<accountId>/`) |
+
+The digest is deliberately **short**: the app-server control Unix socket lives two levels below the
+home and must stay under macOS `SUN_LEN`, which an Electron userData path plus a UUID already
+overshoots. `userDataDir` is folded into the LOCAL digest so separate NodeTerm profiles never
+collide; a remote host has one home root, so the remote digest is over `accountId` only. A
+pre-migration long home (`<userData>/codex-accounts/<id>`) is moved to its short home at boot,
+fail-closed (no-op if absent, if the target exists, or on an invalid id).
 
 ## The signing secret (both shells — Decision 1)
 
@@ -100,3 +142,90 @@ directory scope, so `.`/`..`/leading-separator/`a/b`/absolute ids are refused at
 launcher threads the account id through the `/codex-thread/{start,bind}` POST **body**, never on
 argv (Constraint 6); a bad id falls back to plain `codex` rather than binding under a hostile scope,
 and the server refuses it at `400` before the start handler can create an orphan thread.
+
+## Spawn scope resolution (fail-closed)
+
+`resolveCodexSessionScope(userDataDir, accountId, homeExists)` decides the `CODEX_HOME` +
+`NODETERM_CODEX_ACCOUNT_ID` a Codex spawn runs under:
+
+- **No id** → the system home. Always resolves, and it is written **explicitly** so it overwrites any
+  managed scope inherited from a parent (tmux shares one server env) rather than silently acting as
+  the wrong login.
+- **An explicitly selected managed account whose home is missing** → **refuses**
+  (`{ unavailable: 'codex-account' }`). It never falls back to the system home. This is deliberately
+  **stricter** than the Claude sibling's first-spawn fallback: silently acting as the wrong login is a
+  worse failure for an explicit switch than a refused spawn. The `pty-manager` maps `unavailable`
+  straight through to the renderer.
+
+The OAuth-shadowing env vars (`OPENAI_API_KEY`, `CODEX_API_KEY` — `AUTH_ENV_STRIP`) are removed from
+the session env at spawn so a managed account always acts as its own `auth.json` login. That strip
+touches only the **env**; no credential is ever placed on an argv (Constraint 6).
+
+## The same-machine switch (three-phase, owner-authorized)
+
+Moving a running node's conversation to another account **resumes the same conversation id, never
+forks it**. The switch is a three-phase, TTL-bounded, owner-authorized protocol driven by the
+renderer (`src/main/codex-accounts.ts`):
+
+1. **plan** (`switch-thread`) — reserve both account ids (so a concurrent removal is blocked —
+   Property 10), read the source rollout path off its app-server, and `planCodexRolloutExposure`
+   (validate only, mutate nothing). Returns a `rollbackToken`.
+2. **commit** (`commit-switch`) — `commitCodexRolloutExposure`: **atomically hardlink** the source
+   rollout inode into the target account's `sessions/<same relative path>`. Same inode ⇒
+   byte-identical conversation id. Only the **owning WebContents** may commit.
+3. **finish** (`finish-switch`) — release the reservation. Refuses until commit actually ran, so a
+   premature finish can never make the renderer recycle a node onto a target that has no rollout.
+
+`rollback-switch`, the reservation TTL, and the owner being `destroyed` all release a reservation
+without committing. The exposure is an **atomic, never-overwrite hardlink**: `link(2)` is
+no-overwrite, an `EEXIST` collision is tolerated **only** when the existing target is already the same
+inode (an idempotent re-expose), and the copy refuses to write **through** a symlinked directory
+segment. The source `dev`/`ino` is re-verified before and after the link, so a mid-flight source swap
+fails closed.
+
+## The cross-machine transfer (local → SSH)
+
+`transfer-thread-to-ssh` moves an **idle** local conversation to a remote account. The SOURCE leg
+reuses `planCodexRolloutExposure`'s guards (regular file under `<home>/sessions/`, basename
+`<threadId>.jsonl`, no symlinked segment) and then hands the upload + atomic remote install to the
+SSH importer. Properties: the conversation id survives; the far side must **discover** the hardlinked
+rollout before the node is recycled (verify-then-recycle — a false discovery is a **refused copy +
+rollback**, never a silent one); the **local copy remains** (it is a hardlink, never moved); and an
+existing remote rollout is **never overwritten** (`link` / `mv` fail closed on `EEXIST` / `exit 17`).
+An absent importer (no live SSH manager) **fails closed** with a named error, never a silent success.
+
+## Per-account usage (no mixing)
+
+Usage is one **system row** plus one row **per managed account**, each keyed by its own `accountId`
+and built independently — there is no reduce/merge step, so one account's numbers can never be
+attributed to another. Every `fetchCodexUsage` return path (including `unavailable`) is stamped with
+the account's identity, so an empty or failed read fails closed to **that** account, never to a
+fabricated one; the system row stays explicitly un-owned (`accountId: undefined`). A throwing account
+source yields **system-only**, never a made-up account. A cache fingerprint over the account set
+busts stale numbers when an account is added, removed, or relabelled.
+
+## Fail-closed properties (the house rules)
+
+| Situation | Verdict |
+| --- | --- |
+| Explicitly selected account, home missing | Refuse the spawn — no system fallback |
+| Same thread id owned by two account scopes, no hint | No owner (proxy, sh resolver, relay catalog all fail closed) |
+| Rollout collision at target, different inode | Never overwrite (throws / `exit 17`) |
+| Cross-mount rollout link | Named `EXDEV` error — no silent byte-copy fallback (U3) |
+| Far side cannot discover the imported rollout | Roll back the import |
+| Record signed for account A, filed under B | MAC fails — rejected |
+| No signing secret armed | Record write throws; nothing unsigned is written |
+| Usage source throws | System-only; never a fabricated account |
+| Account id from `settings.json` that could escape the root | Refused at the door by `isSafeAccountId` |
+
+## U1 / U3 — the two constraints the probes settled
+
+- **U3 — same filesystem.** A same-machine switch links a rollout inode between two LOCAL homes, both
+  under `$HOME` (`~/.codex` and `~/.nodeterm/cx`), measured same-device on the build host (ext4).
+  `link(2)` throws `EXDEV` across mounts, and a `$HOME` subtree **can** be bind-mounted onto another
+  volume, so v1 does **not** silently fall back to a byte copy — `commit` surfaces a named `EXDEV`
+  error. A cross-mount copy fallback is explicitly out of scope for S6 v1.
+- **U1 — live discovery.** The cross-machine copy rests on a running `app-server` discovering a
+  hardlinked rollout **without a reindex**. Mitigated in code by verify-then-recycle (a false U1 is a
+  refused copy + rollback, never silent), but the live-daemon confirmation is a **device
+  verification**, owed on a real host — see the acceptance gate.

--- a/src/main/codex-accounts-e2e.test.ts
+++ b/src/main/codex-accounts-e2e.test.ts
@@ -1,0 +1,396 @@
+/**
+ * S6 ACCEPTANCE GATE — the one long end-to-end composition test (PR 9, Task 9.2a).
+ *
+ * The individual PRs (1–8.5) each pin their own slice in isolation. This file does the OTHER job the
+ * gate needs: it walks the whole operable chain ONCE, against the REAL merged primitives, to prove
+ * the pieces COMPOSE — a managed account home on a real fs, the fail-closed spawn-scope resolver, the
+ * real HMAC-signed ownership record read back by the real POSIX-sh resolver under real `/bin/sh`, the
+ * real main-side three-phase switch handler linking a real rollout inode, the relay catalog's
+ * fail-closed ambiguity, per-account usage attribution, and the invariant that no credential ever
+ * rides an argv. It is NOT a re-implementation of any of them (Global Constraint 8): every leg calls
+ * the shipped export.
+ *
+ * WHAT THIS TEST DELIBERATELY DOES NOT DO — the legs that cannot run headless are documented as OWED
+ * in docs/codex-accounts-acceptance.md rather than faked here:
+ *   - the live `codex app-server` JSON-RPC (U4): `readCodexThreadAt`/`readCodexAccountAt` are the ONE
+ *     boundary faked (as the per-PR suites do) — they stand in for a running daemon that this CI has
+ *     no standalone Codex install to start. The rollout COPY they hand off to is the real fs primitive.
+ *   - the real SSH WAN transfer landing (U1, PR 6): the remote importer is a spy; the far-side
+ *     discover / rollback / `exit 17` are host behaviors, owed on a real host. The LOCAL never-overwrite
+ *     twin (a different inode already at the target) IS exercised here on a real fs.
+ *   - the imperative pane-recycle glue (commit→rebind→restartShell→finish): only the pure/main-side
+ *     legs run here; the renderer sequencing is owed against the running app.
+ *
+ * MUTATION REPORT (Global Constraint 9) — recorded in the PR body. For each claim below, the named
+ * source mutation was introduced and this file reddened, then reverted:
+ *   M1 resolveCodexSessionScope: return the system env instead of `{unavailable}` when a selected
+ *      home is missing ⇒ "an explicitly selected missing account refuses to spawn" greens wrongly ⇒ red.
+ *   M2 resolveCodexThreadNodeIdentity: return `candidates[0]` instead of gating on `owners.size===1`
+ *      ⇒ "the same thread id in two scopes resolves to no owner" ⇒ red.
+ *   M3 commitCodexRolloutExposure: accept an EEXIST collision without the dev/ino check ⇒ "an existing
+ *      different rollout is never overwritten" ⇒ red.
+ *   M4 fetchCodexUsage: stop stamping `accountId` on the `unavailable` return ⇒ "usage stays
+ *      per-account, never fabricated/mixed" ⇒ red.
+ *   M5 codexThreadIdentityResolverSh: drop the `nt_codex_matches -eq 1` gate ⇒ the ambiguous-scan leg
+ *      exports a node under `/bin/sh` ⇒ red.
+ *
+ * Based on @Corvin's S6 design in external PR #112 (github.com/eneskirca/nodeterm #112).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'child_process'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'fs'
+import os from 'os'
+import path from 'path'
+
+// The electron shell boundary — the switch/transfer handlers register over ipcMain.handle.
+const h: { handlers: Record<string, (...a: any[]) => unknown> } = { handlers: {} }
+vi.mock('electron', () => ({
+  ipcMain: { handle: (ch: string, fn: (...a: any[]) => unknown) => (h.handlers[ch] = fn) }
+}))
+
+// The ONE faked boundary: the live app-server JSON-RPC (probe U4, unrunnable headless). The rollout
+// path it returns is a REAL file on disk that the real copy primitive then hardlinks.
+const readThread = vi.fn()
+const readAccount = vi.fn(async () => ({ email: 'me@example.com' }))
+vi.mock('../core/codex-session-name', () => ({
+  readCodexThreadAt: (..._a: any[]) => readThread(),
+  readCodexAccountAt: (..._a: any[]) => readAccount()
+}))
+// No real `codex` binary is discovered, so no app-server subprocess is ever spawned in this run —
+// which is also what lets the "no credential on any argv" leg assert against a clean spawn ledger.
+vi.mock('../core/pty-manager', () => ({ findInLoginPath: vi.fn(async () => null) }))
+// Keep every OTHER relay-daemon export real (mergeRelayThreadLists is exercised below); only stub the
+// boot effect that would touch the real home dir.
+vi.mock('./codex-relay-daemon', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('./codex-relay-daemon')
+  return { ...actual, ensureCodexRelayRoot: vi.fn() }
+})
+
+const remoteCodexImportThread = vi.fn(async () => ({ imported: true }))
+
+/** A WebContents-shaped fake carrying the `.id` + listener surface the switch protocol drives. */
+const makeSender = (id: number) => ({
+  id,
+  isDestroyed: () => false,
+  once: () => {},
+  removeListener: () => {}
+})
+const call = (channel: string, sender: any, ...args: any[]) =>
+  h.handlers[channel]({ sender }, ...args)
+
+const THREAD = 'thread-e2e-abc123'
+const LOCAL = 'acctlocal1'
+
+// Post-reset module instances, imported fresh per test so the whole graph is one consistent build.
+let proxy: typeof import('../core/codex-identity-proxy')
+let coreMod: typeof import('../core/codex-accounts-core')
+let shMod: typeof import('../core/codex-thread-identity-sh')
+let usageMod: typeof import('../core/usage/codex-usage')
+let relayMod: typeof import('./codex-relay-daemon')
+let IPC: typeof import('../shared/ipc').IPC
+
+let userDataDir = ''
+let systemHome = ''
+let prevCodexHome: string | undefined
+const createdHomes: string[] = []
+
+beforeEach(async () => {
+  h.handlers = {}
+  readThread.mockReset()
+  readAccount.mockReset().mockResolvedValue({ email: 'me@example.com' })
+  remoteCodexImportThread.mockClear()
+
+  userDataDir = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-codex-e2e-'))
+  // The system (CODEX_HOME) home MUST sit on the same filesystem as the managed short-home root
+  // (`~/.nodeterm/cx`), because the switch links a real inode between them — a cross-mount placement
+  // would (correctly) hit the shipped EXDEV fail-closed guard, which is not what this leg exercises.
+  const ntRoot = path.join(os.homedir(), '.nodeterm')
+  mkdirSync(ntRoot, { recursive: true })
+  systemHome = mkdtempSync(path.join(ntRoot, 'e2e-sys-'))
+  createdHomes.push(systemHome)
+  prevCodexHome = process.env.CODEX_HOME
+  process.env.CODEX_HOME = systemHome
+
+  vi.resetModules()
+  const platformMod = await import('../core/platform')
+  const { fakePlatform } = await import('../core/platform-fake')
+  platformMod.initPlatform(fakePlatform({ userDataDir }))
+
+  proxy = await import('../core/codex-identity-proxy')
+  coreMod = await import('../core/codex-accounts-core')
+  shMod = await import('../core/codex-thread-identity-sh')
+  usageMod = await import('../core/usage/codex-usage')
+  relayMod = await import('./codex-relay-daemon')
+  ;({ IPC } = await import('../shared/ipc'))
+
+  // Arm the record-signing secret on THIS module graph (deterministic bytes for the record legs).
+  proxy.setCodexThreadIdentityAuthSecret(new Uint8Array(32).fill(7))
+
+  const accounts = await import('./codex-accounts')
+  accounts.initCodexAccounts(() => ({ remoteCodexImportThread }) as any)
+})
+
+afterEach(async () => {
+  const { resetPlatformForTests } = await import('../core/platform')
+  resetPlatformForTests()
+  proxy.resetCodexThreadIdentityAuthSecret()
+  rmSync(userDataDir, { recursive: true, force: true })
+  rmSync(systemHome, { recursive: true, force: true })
+  for (const home of createdHomes.splice(0)) rmSync(home, { recursive: true, force: true })
+  if (prevCodexHome === undefined) delete process.env.CODEX_HOME
+  else process.env.CODEX_HOME = prevCodexHome
+  vi.clearAllTimers()
+})
+
+/** Create a managed account's real home (the exact path the module computes) and remember it for
+ *  cleanup — the short home lives under `~/.nodeterm/cx`, not under the temp userDataDir. */
+function makeManagedHome(id: string): string {
+  const home = coreMod.codexAccountHome(userDataDir, id)
+  mkdirSync(path.join(home, 'sessions'), { recursive: true })
+  createdHomes.push(home)
+  return home
+}
+
+describe('S6 acceptance gate — the merged machine-scoped-Codex-account chain composes', () => {
+  it('walks the whole operable chain against real primitives', async () => {
+    // ---- LEG A: a managed account home on real fs; the spawn scope resolves fail-closed ----------
+    const localHome = makeManagedHome(LOCAL)
+    // System account (no id) always resolves to ~/.codex-equivalent ($CODEX_HOME here).
+    const systemScope = coreMod.resolveCodexSessionScope(userDataDir, undefined)
+    expect(coreMod.isCodexScopeRefusal(systemScope)).toBe(false)
+    expect((systemScope as { CODEX_HOME: string }).CODEX_HOME).toBe(systemHome)
+    // The managed account resolves to its own isolated home (real existsSync against the real dir).
+    const localScope = coreMod.resolveCodexSessionScope(userDataDir, LOCAL)
+    expect(localScope).toEqual({ CODEX_HOME: localHome, NODETERM_CODEX_ACCOUNT_ID: LOCAL })
+
+    // ---- LEG B: stamp a Codex node's ownership record, recover it under REAL /bin/sh -------------
+    const recordRoot = path.join(userDataDir, 'codex-thread-nodes')
+    const endpoint = path.join(userDataDir, 'hook-endpoint')
+    proxy.writeCodexThreadIdentity(THREAD, 'node-1', endpoint, recordRoot, LOCAL)
+    const boundNode = runResolver(shMod.codexThreadIdentityResolverSh(recordRoot), {
+      CODEX_THREAD_ID: THREAD,
+      NODETERM_CODEX_ACCOUNT_ID: LOCAL
+    })
+    expect(boundNode).toBe('node-1') // the real sh recovered the exact node binding from the record
+
+    // ---- LEG C: the real main-side three-phase switch links a real rollout inode -----------------
+    // A real rollout under the managed home; the faked daemon returns its REAL path.
+    const sessionsDir = path.join(localHome, 'sessions', '2026', '08')
+    mkdirSync(sessionsDir, { recursive: true })
+    const rollout = path.join(sessionsDir, `rollout-${THREAD}.jsonl`)
+    writeFileSync(rollout, `{"id":"${THREAD}"}\n`)
+    readThread.mockResolvedValue({ id: THREAD, name: null, path: rollout })
+
+    const owner = makeSender(1)
+    // Switch the managed account's conversation onto the SYSTEM account (targetAccountId undefined).
+    const res = (await call(
+      IPC.codexAccountsSwitchThread,
+      owner,
+      THREAD,
+      '/work',
+      LOCAL,
+      undefined
+    )) as { threadId: string; rollbackToken?: string }
+    expect(res.threadId).toBe(THREAD) // the conversation id is carried unchanged, never forked
+    expect(res.rollbackToken).toBeTruthy()
+    await call(IPC.codexAccountsCommitSwitch, owner, res.rollbackToken)
+    const targetPath = path.join(systemHome, 'sessions', '2026', '08', `rollout-${THREAD}.jsonl`)
+    const src = statSync(rollout)
+    const tgt = statSync(targetPath)
+    expect(tgt.ino).toBe(src.ino) // same inode ⇒ byte-identical conversation id survives the switch
+    expect(tgt.dev).toBe(src.dev)
+    await call(IPC.codexAccountsFinishSwitch, owner, res.rollbackToken)
+    // The source (local) copy is a hardlink and is never moved: it remains fully usable.
+    expect(existsSync(rollout)).toBe(true)
+
+    // ---- LEG D: the local→SSH transfer SOURCE leg keeps the local copy and hands off the upload --
+    const xfer = (await call(
+      IPC.codexAccountsTransferThreadToSsh,
+      owner,
+      THREAD,
+      '/work',
+      'proj-1',
+      undefined,
+      LOCAL
+    )) as { threadId: string; imported: boolean }
+    expect(xfer.imported).toBe(true)
+    expect(remoteCodexImportThread).toHaveBeenCalledTimes(1)
+    // The importer is handed the containment-validated relative path + the REAL local rollout, which
+    // is never moved (the far-side landing / discover / rollback are PR 6, owed on a real host).
+    const [, , , sessionsRelativePath, localRolloutPath] = remoteCodexImportThread.mock
+      .calls[0] as unknown[]
+    expect(sessionsRelativePath).toBe(`sessions/2026/08/rollout-${THREAD}.jsonl`)
+    expect(localRolloutPath).toBe(rollout)
+    expect(existsSync(rollout)).toBe(true)
+
+    // ---- LEG E: per-account usage attribution — never mixed, never fabricated --------------------
+    // Neutralise PATH so the app-server tier's `spawn('codex')` fails fast with ENOENT instead of
+    // finding a real binary; no auth.json ⇒ the backend tier declines without a network call.
+    const prevPath = process.env.PATH
+    process.env.PATH = ''
+    try {
+      const rowA = await usageMod.fetchCodexUsage(localHome, {
+        id: LOCAL,
+        label: 'Work',
+        email: 'work@example.com'
+      })
+      const rowSystem = await usageMod.fetchCodexUsage(systemHome)
+      expect(rowA.accountId).toBe(LOCAL) // the managed row is stamped with its OWN id
+      expect(rowA.account).toBe('work@example.com')
+      expect(rowSystem.accountId).toBeUndefined() // the un-owned system row stays explicitly un-owned
+      expect(rowSystem.account).toBeNull()
+    } finally {
+      process.env.PATH = prevPath
+    }
+
+    // ---- LEG F: no credential rides any argv, anywhere in the run --------------------------------
+    // The tmux env args (the only place the account scope reaches a shell) carry ONLY CODEX_HOME +
+    // NODETERM_CODEX_ACCOUNT_ID — no token, no secret.
+    const tmuxArgs = coreMod.codexTmuxEnvArgs(userDataDir, LOCAL).join(' ')
+    expect(tmuxArgs).not.toMatch(/TOKEN|SECRET|auth[_-]?json|Bearer/i)
+    // The generated launcher threads credentials by stdin (`curl --config -`) and the account id via
+    // the POST body — never on argv.
+    const launcher = proxy.buildCodexLauncherScript()
+    expect(launcher).toContain('--config -')
+    expect(launcher).not.toMatch(/-H ["']?X-NodeTerm/) // no header credential on a curl argv
+    expect(launcher).toContain('accountId=') // scope travels in the POST body
+    // The OAuth-shadowing env vars are stripped at spawn, never placed on a command line.
+    expect(coreMod.stripCodexAuthEnv({ OPENAI_API_KEY: 'x', CODEX_API_KEY: 'y', PATH: '/b' })).toEqual(
+      { PATH: '/b' }
+    )
+  })
+
+  // ---- LEG (fail-closed) 1: an explicitly selected MISSING account refuses to spawn — no fallback -
+  it('an explicitly selected account whose home is missing refuses to spawn (no system fallback)', () => {
+    // M1: return the system env here instead of the refusal ⇒ this greens wrongly.
+    const scope = coreMod.resolveCodexSessionScope(userDataDir, 'neverloggedin1')
+    expect(coreMod.isCodexScopeRefusal(scope)).toBe(true)
+    expect(scope).toEqual({ unavailable: 'codex-account' })
+    // The system account, by contrast, always resolves — the strictness is for an EXPLICIT id only.
+    expect(coreMod.isCodexScopeRefusal(coreMod.resolveCodexSessionScope(userDataDir, undefined))).toBe(
+      false
+    )
+  })
+
+  // ---- LEG (fail-closed) 2: the same thread id in two scopes resolves to NO owner ----------------
+  it('ambiguous ownership fails closed in the proxy, the sh resolver, and the relay catalog', () => {
+    const recordRoot = path.join(userDataDir, 'codex-thread-nodes')
+    const endpoint = path.join(userDataDir, 'hook-endpoint')
+    // The SAME thread id, two accounts, two different owning nodes.
+    proxy.writeCodexThreadIdentity(THREAD, 'node-sys', endpoint, recordRoot) // system scope
+    proxy.writeCodexThreadIdentity(THREAD, 'node-mgd', endpoint, recordRoot, LOCAL) // managed scope
+
+    // (a) the proxy — no account hint ⇒ owners.size !== 1 ⇒ undefined (M2 reds this).
+    expect(proxy.resolveCodexThreadNodeIdentity(THREAD, recordRoot)).toBeUndefined()
+    // …but WITH an explicit scope, direct resume resolves within that one account.
+    expect(proxy.resolveCodexThreadNodeIdentity(THREAD, recordRoot, LOCAL)).toBe('node-mgd')
+    expect(proxy.resolveCodexThreadNodeIdentity(THREAD, recordRoot, undefined /* n/a */)).toBeUndefined()
+
+    // (b) the real POSIX-sh resolver with an EMPTY scope scans every account and binds nothing when
+    // the match count is not exactly one (M5 reds this).
+    const boundAmbiguous = runResolver(shMod.codexThreadIdentityResolverSh(recordRoot), {
+      CODEX_THREAD_ID: THREAD,
+      NODETERM_CODEX_ACCOUNT_ID: ''
+    })
+    expect(boundAmbiguous).toBe('')
+
+    // (c) the relay catalog — two foreign accounts advertising the same id with different (unreadable)
+    // inodes stay ambiguous; the id is dropped rather than resumed under a guessed owner.
+    const merged = relayMod.mergeRelayThreadLists(
+      [
+        { socketPath: '/a.sock', threads: [{ id: THREAD, cwd: '/w', path: '/homeA/r.jsonl' } as any] },
+        { socketPath: '/b.sock', threads: [{ id: THREAD, cwd: '/w', path: '/homeB/r.jsonl' } as any] }
+      ],
+      '/current.sock',
+      {}
+    )
+    expect(merged.result.data.some((t) => t.id === THREAD)).toBe(false)
+    expect(merged.foreignThreads.has(THREAD)).toBe(false)
+  })
+
+  // ---- LEG (fail-closed) 3: an existing DIFFERENT rollout is never overwritten (the exit-17 twin) -
+  it('the rollout copy never overwrites a different existing target (local twin of remote exit 17)', () => {
+    const sourceHome = makeManagedHome('acctsrc2')
+    const targetHome = makeManagedHome('accttgt2')
+    const srcSessions = path.join(sourceHome, 'sessions', '2026', '08')
+    const tgtSessions = path.join(targetHome, 'sessions', '2026', '08')
+    mkdirSync(srcSessions, { recursive: true })
+    mkdirSync(tgtSessions, { recursive: true })
+    const srcRollout = path.join(srcSessions, `rollout-${THREAD}.jsonl`)
+    const tgtRollout = path.join(tgtSessions, `rollout-${THREAD}.jsonl`)
+    writeFileSync(srcRollout, `{"id":"${THREAD}"}\n`)
+    // A DIFFERENT conversation already occupies the target path (a different inode).
+    writeFileSync(tgtRollout, `{"id":"other"}\n`)
+
+    const plan = coreMod.planCodexRolloutExposure(sourceHome, targetHome, srcRollout, THREAD)
+    // M3: tolerate the EEXIST collision without the dev/ino match ⇒ this stops throwing ⇒ red.
+    expect(() => coreMod.commitCodexRolloutExposure(plan)).toThrow(/already has a different rollout/)
+    // The target's foreign content is left byte-for-byte intact — never clobbered.
+    expect(statSync(tgtRollout).ino).not.toBe(statSync(srcRollout).ino)
+  })
+
+  // ---- LEG (fail-closed) 4: the transfer source leg fails CLOSED when no importer is wired --------
+  it('the local→SSH transfer refuses (named) when no remote importer is available', async () => {
+    const { initCodexAccounts } = await import('./codex-accounts')
+    // Re-init with NO ssh manager (getSshManager returns undefined) — the remote leg is unavailable.
+    initCodexAccounts(() => undefined)
+    const localHome = makeManagedHome(LOCAL)
+    const sessionsDir = path.join(localHome, 'sessions', '2026', '08')
+    mkdirSync(sessionsDir, { recursive: true })
+    const rollout = path.join(sessionsDir, `rollout-${THREAD}.jsonl`)
+    writeFileSync(rollout, `{"id":"${THREAD}"}\n`)
+    readThread.mockResolvedValue({ id: THREAD, name: null, path: rollout })
+    await expect(
+      call(IPC.codexAccountsTransferThreadToSsh, makeSender(1), THREAD, '/work', 'proj-1', undefined, LOCAL)
+    ).rejects.toThrow(/Remote Codex import is unavailable/)
+  })
+
+  // ---- LEG (both shells): the record-signing secret arms on the Server Edition shell -------------
+  it('the Server Edition arms the codex record secret raw (0600 .bin), no keychain plaintext', async () => {
+    const { resetNodeAuthSecretForTests } = await import('../core/agents/node-auth-secret')
+    resetNodeAuthSecretForTests()
+    proxy.resetCodexThreadIdentityAuthSecret()
+    expect(proxy.codexThreadIdentityAvailable()).toBe(false)
+    const { armServerNodeIdentity } = await import('../server/node-identity-arm')
+    const hookServer = { setNodeAuthSecret: vi.fn() }
+    await armServerNodeIdentity(hookServer, () => [])
+    // The headless shell has no OS keychain: the secret is the raw 0600 `.bin`, never a sealed `.json`.
+    const entries = readdirSync(userDataDir)
+    expect(entries).toContain('node-auth-key.bin')
+    expect(entries).not.toContain('node-auth-key.json')
+    expect(statSync(path.join(userDataDir, 'node-auth-key.bin')).mode & 0o777).toBe(0o600)
+    // …and the Codex record layer is now armed to sign on this shell (records verify instead of throwing).
+    expect(hookServer.setNodeAuthSecret).toHaveBeenCalledOnce()
+    expect(proxy.codexThreadIdentityAvailable()).toBe(true)
+    resetNodeAuthSecretForTests()
+  })
+
+  // ---- LEG (fail-closed): with NO secret armed, writing an ownership record throws (no record) ----
+  it('an unavailable signing secret fails a record write closed rather than writing unsigned', () => {
+    proxy.resetCodexThreadIdentityAuthSecret()
+    const recordRoot = path.join(userDataDir, 'codex-thread-nodes')
+    expect(() =>
+      proxy.writeCodexThreadIdentity(THREAD, 'node-1', path.join(userDataDir, 'ep'), recordRoot, LOCAL)
+    ).toThrow(/authentication is unavailable/)
+    expect(existsSync(path.join(recordRoot, LOCAL, THREAD))).toBe(false)
+  })
+})
+
+/** Run the generated POSIX-sh resolver prelude under REAL `/bin/sh` and echo the node id it exports
+ *  (empty when it binds nothing). The record dir is baked into the script; only CODEX_THREAD_ID and
+ *  NODETERM_CODEX_ACCOUNT_ID vary per call. */
+function runResolver(prelude: string, env: Record<string, string>): string {
+  const script = `${prelude}\nprintf '%s' "\${NODETERM_NODE_ID-}"`
+  return execFileSync('/bin/sh', ['-c', script], {
+    env: { PATH: process.env.PATH ?? '', ...env },
+    encoding: 'utf8'
+  }).trim()
+}


### PR DESCRIPTION
Closes **S6** — machine-scoped managed Codex accounts — the **final PR (9 of 9)** of external PR #112 (@Corvin). All of S6's mechanism is merged (PRs 1–8.5: account model, identity proxy, rollout primitive, relay daemon, local accounts + the 3-phase switch, SSH remote accounts, per-account usage, Settings UI, per-node account picker). PR 9 documents the shipped feature and records the acceptance gate + the owed device verifications, so nobody can call S6 "verified" until they run on a real Mac + real SSH host.

## Task 9.1 — docs (accurate to what shipped)
- **`docs/shared-codex-node-identity.md`** — finalized: dropped the "ships inert / PR 2 slice" framing; now covers the whole feature (account × machine model, on-disk home layout, spawn-scope resolution, the three-phase owner-authorized switch, the cross-machine transfer, per-account usage, the fail-closed properties table, and the U1/U3 constraints the probes settled).
- **`docs/node-identity.md`** — added the account-scoping note: the codex identity secret is armed on **both** shells (managed records sign on a headless host too), the switch is owner-authorized main-side, ambiguity fails closed (`owners.size === 1`), account ids are validated path segments, and the two owed remote surfaces are named.
- **`docs/SERVER.md`** — the Server Edition **arms the codex record secret** (raw `0600` `node-auth-key.bin`, Decision 1) but does **not** host the account-management IPC — that surface is desktop-driven over SSH.

## Task 9.2 — the acceptance gate
- **`src/main/codex-accounts-e2e.test.ts`** — one long e2e that walks the whole operable chain **once** against REAL primitives (real fs, real `/bin/sh`, real HMAC, the real main-side switch handler; only the live app-server JSON-RPC is faked, and the rollout path it returns is a real on-disk file). Proves the merged pieces **compose**: managed-account home + fail-closed spawn scope; a signed record recovered under real `/bin/sh`; the switch hardlinking the rollout inode (same conversation id, never a fork); the local→SSH transfer source leg (local copy remains; absent importer fails closed); ambiguity → **no owner** in the proxy, the sh resolver, and the relay catalog; never-overwrite (the local `exit 17` twin); per-account usage attribution; the SE arming the record secret raw; and **no credential on any argv**.
- **`docs/codex-accounts-acceptance.md`** — the checklist a human/device must run before S6 is done.

### Mutation report (Global Constraint 9) — 5 introduced / **5 caught**
| # | Mutation | Reddens |
|---|---|---|
| M1 | `resolveCodexSessionScope` returns the system env instead of `{unavailable}` when a selected home is missing | "an explicitly selected missing account refuses to spawn" |
| M2 | `resolveCodexThreadNodeIdentity` returns `candidates[0]` instead of gating on `owners.size === 1` | "the same thread id in two scopes resolves to no owner" |
| M3 | `commitCodexRolloutExposure` accepts an `EEXIST` collision without the dev/ino check | "an existing different rollout is never overwritten" |
| M4 | `fetchCodexUsage` stops stamping `accountId` on the `unavailable` return | "usage stays per-account, never fabricated/mixed" |
| M5 | `codexThreadIdentityResolverSh` drops the `nt_codex_matches -eq 1` gate | the ambiguous-scan leg exports a node under `/bin/sh` |

## Acceptance-gate OWED device verifications (6)
Headless CI cannot run these; the code fails **closed** on each. A human must run them on a real Mac + real SSH host with a curl-managed standalone Codex install + a logged-in 2nd managed account:
1. **U1** — a running app-server discovers a hardlinked rollout without a reindex (verify before the node recycles).
2. **U2** — the conversation id survives copy + switch under a 2nd login (same conversation resumes, not a fork).
3. **U4** — live RPC payload shapes against the **curl-standalone `daemon start`** path (`account/read`→{email}, `thread/read`→{path,cwd}).
4. **Full desktop → host flow over real WAN** — add account, remote device-login, import a conversation to an SSH account, recycle the node onto the host.
5. **The imperative pane-recycle glue** (commit→rebind→restartShell→finish) + a live SSH remote-account switch.
6. **Remote-host account LIFECYCLE UI** (add/login/remove on an SSH host) — display+group only, fail-closed, owed to the host-relay follow-up.

Plus the happy-path walk: **add account → new node under it → switch → copy to SSH → recycle**.

## Gates
- `npm run typecheck` ✅
- `npx vitest run src/main/codex-accounts-e2e.test.ts` ✅ (7 passed)
- full `npx vitest run` ✅ — 572 files passed, 0 failed (7981 tests, 12 skipped)

No S6 behavior changed — docs + one composition test only. Credit **@Corvin** (#112). **This CLOSES S6 (PR 9 of 9).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)