### PR TITLE
feat(menus): session-row ↔ canvas-node parity + Transfer-with-model nested submenu

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4930,7 +4930,15 @@ export function Canvas() {
   // agent's native transcript to a handoff file (main) and open a target node that reads it
   // and continues. The source node stays. Mirrors branchClaude's placement.
   const transferConversation = useCallback(
-    async (sourceNodeId: string, targetAgentId: AgentId, at?: { x: number; y: number }) => {
+    async (
+      sourceNodeId: string,
+      targetAgentId: AgentId,
+      at?: { x: number; y: number },
+      /** A model chosen from the Transfer submenu's nested model list. Applied to the NEW node's
+       *  launch (`--model <value>`) when the target is MODEL_SWITCH_CAPABLE; silently dropped
+       *  otherwise (the target's own default model). Persisted as `data.agentModel`. */
+      model?: string
+    ) => {
       const source = nodesRef.current.find((n) => n.id === sourceNodeId) as CanvasNode | undefined
       if (!source) return
       const sourceAgentId = source.data.agentId
@@ -4988,7 +4996,9 @@ export function Canvas() {
         source.data.accountId,
         // The mode belongs to the node being OPENED, so it is gated on the TARGET agent — a
         // handoff into grok must not inherit claude's version gate.
-        activePermissionMode(targetAgentId)
+        activePermissionMode(targetAgentId),
+        // A model picked from the Transfer submenu (only offered for switch-capable targets).
+        model
       )
       node.selected = true
       const placed = placeSpawned(node, at ?? besideNode(source))
@@ -5412,7 +5422,9 @@ export function Canvas() {
             sourceAgentId: agentIdOf(ids[0]),
             sessionId: useAgentStatus.getState().byId[ids[0]]?.sessionId,
             disabledAgents: useSettings.getState().settings.disabledAgents,
-            customAgents: useSettings.getState().settings.customAgents
+            customAgents: useSettings.getState().settings.customAgents,
+            gatewayModels,
+            relaySession: session.source === 'relay'
           }, transferConversation)
         : []),
       ...(isHidden('collapse', hidden)
@@ -8052,62 +8064,70 @@ export function Canvas() {
     (e: React.MouseEvent, projectId: string, id: string) => {
       e.preventDefault()
       e.stopPropagation()
-      setMenu({
-        x: e.clientX,
-        y: e.clientY,
-        items: [
-          { label: 'Go to', icon: <IconJump />, onClick: () => focusNodeById(id) },
-          {
-            label: 'Rename',
-            icon: <IconEditor />,
-            onClick: () => {
-              void promptDialog({ message: 'Rename session' }).then((t) => {
-                if (t && t.trim()) renameSession(projectId, id, t.trim())
-              })
-            }
-          },
-          {
-            label: 'Duplicate',
-            icon: <IconDuplicate />,
-            onClick: () => {
-              if (projectId === activeProjectId) duplicateNodes([id])
-              else {
-                useProjects.getState().duplicateNode(projectId, id)
-                void writeDisk()
-              }
-            }
-          },
-          // Transfer conversation to another agent — the SAME submenu the canvas node right-click
-          // has. Only valid for the ACTIVE project's canvas: transferConversation reads the source
-          // node out of `nodesRef.current` (the live React Flow nodes), which only holds the active
-          // project. For a non-active project the block is empty (no submenu appears), matching the
-          // Duplicate guard's active-project branch.
-          ...(projectId === activeProjectId
-            ? transferConversationItems(id, undefined, {
-                sourceAgentId: agentIdOf(id),
-                sessionId: useAgentStatus.getState().byId[id]?.sessionId,
-                disabledAgents: useSettings.getState().settings.disabledAgents,
-                customAgents: useSettings.getState().settings.customAgents
-              }, transferConversation)
-            : []),
-          {
-            label: 'Close',
-            icon: <IconTrash />,
-            danger: true,
-            onClick: () => closeSession(projectId, id)
+      // Session-list-specific rows that have no canvas analogue: Go to (focus) and Rename (the
+      // sidebar's prompt-dialog rename). These stay on top for every project.
+      const head: MenuItem[] = [
+        { label: 'Go to', icon: <IconJump />, onClick: () => focusNodeById(id) },
+        {
+          label: 'Rename',
+          icon: <IconEditor />,
+          onClick: () => {
+            void promptDialog({ message: 'Rename session' }).then((t) => {
+              if (t && t.trim()) renameSession(projectId, id, t.trim())
+            })
           }
-        ]
-      })
+        }
+      ]
+      // For the ACTIVE project, reuse the SAME single-node menu the canvas right-click builds —
+      // full parity (Color, Group, Duplicate, Branch, Collapse, Markdown view, Refresh terminal,
+      // Restart agent, Restart agent and shell, Reopen session as, Switch model, Transfer with its
+      // nested model submenus) so the two surfaces can't drift. `selectionItems` reads the live
+      // node from `nodesRef.current` (active-project only), which is exactly why this is gated.
+      // `at` is undefined: the row has no flow position, so spawned nodes (Duplicate/Branch/
+      // Transfer) place beside the source — the same as the row's existing Transfer behavior.
+      //
+      // The canvas menu ends in a destructive "Delete" (deleteNodes). The session row's analogue
+      // is non-destructive "Close" (closeSession — hides the tab, keeps the tmux session), so the
+      // trailing Delete is swapped for Close rather than offered beside it.
+      const body: MenuItem[] =
+        projectId === activeProjectId
+          ? (() => {
+              const full = selectionItems([id])
+              // Drop the canvas menu's trailing "Delete" (destructive deleteNodes) and any
+              // separator left dangling before it, then append the session row's non-destructive
+              // "Close". Found by label rather than fixed index so this stays correct if the canvas
+              // menu's tail changes — Delete is the only 'Delete'-labelled row.
+              const withoutDelete = full.filter((it) => !('label' in it && it.label === 'Delete'))
+              return [
+                ...tidySeparators(withoutDelete),
+                { type: 'separator' },
+                { label: 'Close', icon: <IconTrash />, danger: true, onClick: () => closeSession(projectId, id) }
+              ]
+            })()
+          : [
+              // Non-active project: the shared rows read the active canvas's live nodes + per-node
+              // registered closures, which don't exist here. Keep the narrow set that works for any
+              // project (Duplicate defers to the store; the rest are list-level).
+              {
+                label: 'Duplicate',
+                icon: <IconDuplicate />,
+                onClick: () => {
+                  useProjects.getState().duplicateNode(projectId, id)
+                  void writeDisk()
+                }
+              },
+              { type: 'separator' },
+              { label: 'Close', icon: <IconTrash />, danger: true, onClick: () => closeSession(projectId, id) }
+            ]
+      setMenu({ x: e.clientX, y: e.clientY, items: [...head, ...body] })
     },
     [
       activeProjectId,
       focusNodeById,
       renameSession,
-      duplicateNodes,
       closeSession,
       writeDisk,
-      agentIdOf,
-      transferConversation
+      selectionItems
     ]
   )
 

--- a/src/renderer/lib/transferItems.test.tsx
+++ b/src/renderer/lib/transferItems.test.tsx
@@ -1,12 +1,36 @@
 import { describe, it, expect } from 'vitest'
-import { transferTargets, transferConversationItems } from './transferItems'
+import { transferTargets, transferConversationItems, type TransferConversationArgs } from './transferItems'
 import type { AgentId } from '@shared/agents/config'
 import type { CustomAgent } from '@shared/types'
+import type { GatewayModel } from '@shared/agents/model-gateway'
 
 const customs: CustomAgent[] = [
   { id: 'custom:a', label: 'Agent A', launchCmd: 'a', promptInjectionMode: 'argv' },
   { id: 'custom:b', label: 'Agent B', launchCmd: 'b', promptInjectionMode: 'argv' }
 ]
+
+const claudeCustom: CustomAgent = {
+  id: 'custom:claude-proxy',
+  label: 'Claude Proxy',
+  launchCmd: 'proxy',
+  baseAgent: 'claude',
+  promptInjectionMode: 'argv'
+}
+
+const models: GatewayModel[] = [
+  { id: 'claude-sonnet-5' },
+  { id: 'claude-opus-5' }
+]
+
+/** Minimal args with sensible defaults; tests override the fields that matter. */
+const args = (over: Partial<TransferConversationArgs>): TransferConversationArgs => ({
+  sourceAgentId: 'claude' as AgentId,
+  sessionId: 'sess-1',
+  disabledAgents: [],
+  customAgents: customs,
+  gatewayModels: [],
+  ...over
+})
 
 describe('transferTargets', () => {
   it('excludes the source agent and disabled agents', () => {
@@ -43,17 +67,7 @@ describe('transferConversationItems', () => {
   const handler = () => {}
 
   it('returns the label + one item per target for a transfer-capable agent with a session', () => {
-    const items = transferConversationItems(
-      'node-1',
-      undefined,
-      {
-        sourceAgentId: 'claude' as AgentId,
-        sessionId: 'sess-1',
-        disabledAgents: [],
-        customAgents: customs
-      },
-      handler
-    )
+    const items = transferConversationItems('node-1', undefined, args({}), handler)
     expect(items.length).toBeGreaterThan(1)
     expect(items[0]).toMatchObject({ type: 'label', label: 'Transfer conversation to' })
   })
@@ -62,7 +76,7 @@ describe('transferConversationItems', () => {
     const items = transferConversationItems(
       'node-1',
       undefined,
-      { sourceAgentId: 'grok' as AgentId, sessionId: 'sess-1', disabledAgents: [], customAgents: [] },
+      args({ sourceAgentId: 'grok' as AgentId, customAgents: [] }),
       handler
     )
     expect(items).toEqual([])
@@ -72,7 +86,7 @@ describe('transferConversationItems', () => {
     const items = transferConversationItems(
       'node-1',
       undefined,
-      { sourceAgentId: 'claude' as AgentId, sessionId: undefined, disabledAgents: [], customAgents: [] },
+      args({ sessionId: undefined, customAgents: [] }),
       handler
     )
     expect(items).toEqual([])
@@ -82,9 +96,105 @@ describe('transferConversationItems', () => {
     const items = transferConversationItems(
       'node-1',
       undefined,
-      { sourceAgentId: undefined, sessionId: 'sess-1', disabledAgents: [], customAgents: [] },
+      args({ sourceAgentId: undefined, customAgents: [] }),
       handler
     )
     expect(items).toEqual([])
+  })
+
+  it('renders a switch-capable target as a nested model submenu when models are discovered', () => {
+    // claude source → codex is a switch-capable target. With discovered models, codex becomes a
+    // submenu: "Default model" + one row per model.
+    const items = transferConversationItems(
+      'node-1',
+      undefined,
+      args({ sourceAgentId: 'claude' as AgentId, customAgents: [], gatewayModels: models }),
+      handler
+    )
+    const codex = items.find(
+      (i): i is Extract<typeof i, { type: 'submenu' }> => i.type === 'submenu' && i.label === 'Codex'
+    )
+    expect(codex).toBeDefined()
+    expect(codex!.children.map((c) => ('label' in c ? c.label : ''))).toEqual([
+      'Default model',
+      'claude-sonnet-5',
+      'claude-opus-5'
+    ])
+  })
+
+  it('renders a claude-base custom agent as a nested model submenu (base-resolved capability)', () => {
+    const items = transferConversationItems(
+      'node-1',
+      undefined,
+      args({ sourceAgentId: 'codex' as AgentId, customAgents: [claudeCustom], gatewayModels: models }),
+      handler
+    )
+    const proxy = items.find(
+      (i): i is Extract<typeof i, { type: 'submenu' }> => i.type === 'submenu' && i.label === 'Claude Proxy'
+    )
+    expect(proxy).toBeDefined()
+    expect(proxy!.children.length).toBe(3) // Default + 2 models
+  })
+
+  it('renders a non-capable target (gemini) as a flat row even with models discovered', () => {
+    const items = transferConversationItems(
+      'node-1',
+      undefined,
+      args({ sourceAgentId: 'claude' as AgentId, customAgents: [], gatewayModels: models }),
+      handler
+    )
+    const gemini = items.find((i) => 'label' in i && i.label === 'Gemini')
+    expect(gemini).toBeDefined()
+    expect(gemini).not.toMatchObject({ type: 'submenu' }) // flat row, not a submenu
+  })
+
+  it('renders switch-capable targets as flat rows when no models are discovered', () => {
+    // gateway unconfigured / loading → empty gatewayModels → codex stays flat (transfer with default).
+    const items = transferConversationItems(
+      'node-1',
+      undefined,
+      args({ sourceAgentId: 'claude' as AgentId, customAgents: [], gatewayModels: [] }),
+      handler
+    )
+    const codex = items.find((i) => 'label' in i && i.label === 'Codex')
+    expect(codex).toBeDefined()
+    expect(codex).not.toMatchObject({ type: 'submenu' })
+  })
+
+  it('renders switch-capable targets as flat rows for a relay source (no local gateway)', () => {
+    const items = transferConversationItems(
+      'node-1',
+      undefined,
+      args({ sourceAgentId: 'claude' as AgentId, customAgents: [], gatewayModels: models, relaySession: true }),
+      handler
+    )
+    const codex = items.find((i) => 'label' in i && i.label === 'Codex')
+    expect(codex).toBeDefined()
+    expect(codex).not.toMatchObject({ type: 'submenu' })
+  })
+
+  it('passes the chosen model to the handler for a model-submenu row', () => {
+    const calls: Array<{ agent: AgentId; model?: string }> = []
+    const handler = (_n: string, agent: AgentId, _at: unknown, model?: string) =>
+      calls.push({ agent, model })
+    const items = transferConversationItems(
+      'node-1',
+      undefined,
+      args({ sourceAgentId: 'claude' as AgentId, customAgents: [], gatewayModels: models }),
+      handler as never
+    )
+    const codex = items.find(
+      (i): i is Extract<typeof i, { type: 'submenu' }> => i.type === 'submenu' && i.label === 'Codex'
+    )!
+    // "Default model" row → no model
+    const defaultRow = codex.children[0] as { onClick: () => void }
+    defaultRow.onClick()
+    // A model row → that model id
+    const modelRow = codex.children[1] as { onClick: () => void }
+    modelRow.onClick()
+    expect(calls).toEqual([
+      { agent: 'codex' as AgentId, model: undefined },
+      { agent: 'codex' as AgentId, model: 'claude-sonnet-5' }
+    ])
   })
 })

--- a/src/renderer/lib/transferItems.tsx
+++ b/src/renderer/lib/transferItems.tsx
@@ -5,14 +5,35 @@
  * canvas node right-click menu). The sessions-sidebar row right-click wanted the SAME submenu, so
  * the list-building is extracted here and consumed by both — one definition, two surfaces.
  *
- * `transferTargets` is pure (no React, no stores) so it unit-tests cleanly; the caller reads the
- * live settings/agent-status stores and passes the values in.
+ * Each transfer target that is **model-discovery-capable** (`canSwitchModel`, base-resolved — so a
+ * claude-base custom agent qualifies) becomes a NESTED submenu: the agent's default model, plus one
+ * row per discovered gateway model, mirroring the "Switch model" submenu's children. A non-capable
+ * target (e.g. gemini, grok) stays a flat row — it has no model grammar, so there is nothing to
+ * pick. `transferTargets` and the nesting are pure (no React, no stores) so they unit-test cleanly;
+ * the caller reads the live settings/agent-status/gateway stores and passes the values in.
  */
 import type { AgentId } from '@shared/agents/config'
-import { AGENT_CONFIG, BUILTIN_AGENT_IDS, canTransferFrom } from '@shared/agents/config'
+import {
+  AGENT_CONFIG,
+  BUILTIN_AGENT_IDS,
+  canTransferFrom,
+  MODEL_SWITCH_CAPABLE
+} from '@shared/agents/config'
+import type { GatewayModel } from '@shared/agents/model-gateway'
 import type { CustomAgent } from '@shared/types'
 import type { MenuItem } from '../components/ContextMenu'
 import { AgentIcon } from './agentIcons'
+
+/**
+ * Resolve an agent's base harness from the records passed in, WITHOUT the runtime's injected
+ * capability resolver (which reads the live settings store and so is unavailable in a pure test).
+ * A builtin is its own base; a custom agent's base is its declared `baseAgent`. `undefined` for a
+ * baseless custom or an unknown id. Mirrors `reopenVariants.baseOf`.
+ */
+function baseOf(id: AgentId, customAgents: readonly CustomAgent[]): string | undefined {
+  if ((AGENT_CONFIG as Record<string, unknown>)[id]) return id
+  return customAgents.find((c) => c.id === id)?.baseAgent
+}
 
 /** A transfer target: every enabled agent EXCEPT the source (you can't transfer a session to its
  *  own agent kind — the handoff is cross-agent). */
@@ -50,24 +71,43 @@ export interface TransferConversationArgs {
   /** Live settings lists. */
   disabledAgents: readonly AgentId[]
   customAgents: readonly CustomAgent[]
+  /** Discovered gateway models, for the nested model submenus on switch-capable targets. Empty when
+   *  the gateway is unconfigured/still loading — those targets then render as flat rows (transfer
+   *  with the agent's default model), since transfer-without-model is still useful. */
+  gatewayModels: readonly GatewayModel[]
+  /** True when the source is a relay session — its gateway lives on another machine, so the local
+   *  model list does not apply. Switch-capable targets render as flat rows (no model submenu). */
+  relaySession?: boolean
 }
 
+/** Canvas's `transferConversation(sourceNodeId, targetAgentId, at?, model?)`. */
+export type TransferConversationHandler = (
+  sourceNodeId: string,
+  targetAgentId: AgentId,
+  at?: { x: number; y: number },
+  model?: string
+) => void
+
 /**
- * Build the "Transfer conversation to" menu block (a label + one item per target), or `[]` when
+ * Build the "Transfer conversation to" menu block (a label + one entry per target), or `[]` when
  * the node can't be a transfer source (not a transfer-capable agent, or no session id yet).
+ *
+ * A switch-capable target with discovered models becomes a submenu: a "Default model" row (transfer
+ * with no `--model`) plus one row per gateway model. A non-capable target, a relay source, or a
+ * target with no discovered models yet stays a flat row — there is nothing to pick.
  *
  * @param nodeId   the source node — passed to `handler` as the first arg.
  * @param at       cursor position (passed through to the handler, which places the new node).
  * @param args     the resolved gate values (see {@link TransferConversationArgs}).
- * @param handler  Canvas's `transferConversation(sourceNodeId, targetAgentId, at?)`.
+ * @param handler  Canvas's `transferConversation`.
  */
 export function transferConversationItems(
   nodeId: string,
   at: { x: number; y: number } | undefined,
   args: TransferConversationArgs,
-  handler: (sourceNodeId: string, targetAgentId: AgentId, at?: { x: number; y: number }) => void
+  handler: TransferConversationHandler
 ): MenuItem[] {
-  const { sourceAgentId, sessionId, disabledAgents, customAgents } = args
+  const { sourceAgentId, sessionId, disabledAgents, customAgents, gatewayModels, relaySession } = args
   // Gate: single node, a transfer-capable agent, and a live session id (the handoff reads the
   // transcript by session id — no id means the conversation isn't ready to hand off yet).
   if (!sourceAgentId || !sessionId || !canTransferFrom(sourceAgentId)) return []
@@ -75,12 +115,41 @@ export function transferConversationItems(
   if (targets.length === 0) return []
   return [
     { type: 'label', label: 'Transfer conversation to' },
-    ...targets.map(
-      (tg): MenuItem => ({
+    ...targets.map((tg): MenuItem => {
+      // A model submenu only for a switch-capable target with discovered models, and never for a
+      // relay source (its gateway is on another machine). Capability is resolved from the passed-in
+      // `customAgents` (base-resolved, so a claude-base custom agent qualifies) rather than the
+      // runtime's injected resolver, so this stays pure and testable. gemini/grok and baseless
+      // customs stay flat — no model grammar. The gateway is shared across harnesses, so the full
+      // model list applies to any capable target.
+      const base = baseOf(tg.id, customAgents)
+      const capable = !!base && (MODEL_SWITCH_CAPABLE as readonly string[]).includes(base)
+      const models = capable && !relaySession ? (gatewayModels as GatewayModel[]) : []
+      if (models.length === 0) {
+        return {
+          label: tg.label,
+          icon: <AgentIcon agentId={tg.id} />,
+          onClick: () => void handler(nodeId, tg.id, at)
+        }
+      }
+      return {
+        type: 'submenu',
         label: tg.label,
         icon: <AgentIcon agentId={tg.id} />,
-        onClick: () => void handler(nodeId, tg.id, at)
-      })
-    )
+        children: [
+          // The agent's own default model — transfer with no `--model` flag.
+          {
+            label: 'Default model',
+            onClick: () => void handler(nodeId, tg.id, at)
+          },
+          ...models.map(
+            (m): MenuItem => ({
+              label: m.id,
+              onClick: () => void handler(nodeId, tg.id, at, m.id)
+            })
+          )
+        ]
+      }
+    })
   ]
 }

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -566,6 +566,27 @@ describe('accountId on Claude node factories', () => {
   })
 })
 
+describe('model on agent node factory', () => {
+  it('stamps agentModel and threads --model into the launch command for a switch-capable agent', () => {
+    const node = createAgentNode('claude', 0, undefined, undefined, undefined, undefined, undefined, undefined, 'claude-sonnet-5')
+    expect(node.data.agentModel).toBe('claude-sonnet-5')
+    expect(node.data.initialCommand).toContain('--model')
+    expect(node.data.initialCommand).toContain('claude-sonnet-5')
+  })
+  it('omits agentModel and the --model flag when no model is given', () => {
+    const node = createAgentNode('claude', 0)
+    expect(node.data.agentModel).toBeUndefined()
+    expect(node.data.initialCommand).not.toContain('--model')
+  })
+  it('drops the model (no --model) for a non-switch-capable agent', () => {
+    // gemini is not in MODEL_SWITCH_CAPABLE — withAgentModel no-ops, and agentModel is still stamped
+    // (it is harmless to persist; the point is the launch line carries no --model).
+    const node = createAgentNode('gemini', 0, undefined, undefined, undefined, undefined, undefined, undefined, 'gemini-2.5')
+    expect(node.data.agentModel).toBe('gemini-2.5')
+    expect(node.data.initialCommand).not.toContain('--model')
+  })
+})
+
 describe('accountId serialization', () => {
   it('round-trips data.accountId on a terminal node', () => {
     const node = {

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -385,7 +385,12 @@ export function createAgentNode(
   initialPrompt?: string,
   ssh?: Project['ssh'],
   accountId?: string,
-  permissionMode?: AgentPermissionMode
+  permissionMode?: AgentPermissionMode,
+  /** Per-node model override for a MODEL_SWITCH_CAPABLE agent (claude/codex/copilot, base-resolved).
+   *  Applied through the effective base harness via `withAgentModel` (a no-op for a non-capable
+   *  agent, so passing a model for one is harmless — it's simply not appended). Persisted as
+   *  `data.agentModel` so cold-restore and later restarts keep the model. */
+  model?: string
 ): CanvasNode {
   const { label, color } = resolveAgent(agentId)
   // A per-builtin launch-command override (Settings -> Agents -> Launch commands) replaces the bare
@@ -432,7 +437,11 @@ export function createAgentNode(
       // A SHARED_IDENTITY_CAPABLE agent (codex) launches through its managed launcher when this
       // machine actually has one — otherwise the bare CLI, byte-identical to before. `codexSharedIdentity`
       // folds in the SSH answer (a host has no launcher installed yet, so a remote node stays bare).
-      sharedIdentity: codexSharedIdentity(ssh)
+      sharedIdentity: codexSharedIdentity(ssh),
+      // A model picked at creation (e.g. Transfer-to-agent-with-model). `withAgentModel` appends
+      // `--model <value>` for a switch-capable agent and no-ops otherwise, so the line stays
+      // byte-identical when no model is chosen.
+      model
     },
     // The boot-time snapshot of the desktop env (empty on browser/relay by design, where the
     // missing-env warning below is the honest outcome — the same markers the preview shows).
@@ -467,6 +476,9 @@ export function createAgentNode(
       // Persisted alongside the node (unlike initialCommand, which is consumed on first open), so
       // a cold restore months later still knows which conversation this node owns.
       ...(mintedSessionId ? { agentSessionId: mintedSessionId } : {}),
+      // A model chosen at creation (Transfer-to-agent-with-model). Persisted so cold-restore and
+      // later restarts keep it; `withAgentModel` re-applies it on relaunch. Only stamped when set.
+      ...(model ? { agentModel: model } : {}),
       cwd: ssh ? ssh.remoteCwd : cwd,
       initialCommand,
       ...(ssh ? { ssh: ssh.server, sshRemoteTmux: true } : {})


### PR DESCRIPTION
Carries dkattan's #282 (reviewed and approved) over the conflicts it picked up while open. dkattan's commit is included as-is; the merge commit resolves one genuinely dangerous collision:

**Both sides added a ninth positional parameter to `createAgentNode`** — main's `projectId` (used for the per-project launch-command override) and this PR's `model`. Both are `string | undefined`, so taking either side blindly would have compiled clean and silently passed a model id where the project lookup was expected; **typecheck could not have caught it**. Resolution: `projectId` keeps position 9 (every existing call site on main already passes it there), `model` trails at 10; the transfer call site passes both, and the two model-factory tests gained the placeholder they now need.

Original review (unchanged, verified against current main): no new IPC surface, nothing on argv — the model reaches the launch line only through the existing validated + shell-quoted `withAgentModel`, gateway credentials stay on the env route. No reverts of anything merged in #244 or later.

Verified on the merged tree: typecheck clean; 3860/3861 renderer + shared tests pass (the single failure is an `@xterm/addon-webgl` version drift in the local dependency symlink, not this change — CI installs clean).

Merging this makes GitHub mark #282 as merged (its head commit is included), preserving authorship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)