### PR TITLE
fix(settings): strip native button chrome from the shortcut row icon controls

### DIFF
--- a/src/renderer/components/settings/ShortcutRecorderButton.tsx
+++ b/src/renderer/components/settings/ShortcutRecorderButton.tsx
@@ -137,7 +137,9 @@ export function ShortcutRecorderButton({
   const className = capturing
     ? 'min-w-[140px] rounded-md border border-accent bg-[color:var(--accent)]/10 px-3 py-1 text-[12px] text-text ring-1 ring-[color:var(--accent)]/40'
     : appearance === 'icon'
-      ? 'flex size-6 items-center justify-center rounded-md text-muted hover:bg-fill-weak hover:text-text focus-visible:text-text'
+      ? // No Tailwind preflight in this repo: `border-0 bg-transparent p-0` must be explicit or
+        // the browser's native button chrome (border + fill + padding) renders around the glyph.
+        'flex size-6 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-muted hover:bg-fill-weak hover:text-text focus-visible:text-text'
       : 'min-w-[120px] cursor-pointer rounded-md border border-border bg-panel-header px-3 py-1.5 text-[13px] font-medium text-text outline-none hover:bg-[rgba(255,255,255,0.06)]'
   const isIdleIcon = appearance === 'icon' && !capturing
   return (

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -219,6 +219,26 @@ describe('ShortcutsSection rows', () => {
     expect(armed.getAttribute('aria-label')).toBe('Record Command palette')
   })
 
+  // The repo ships no Tailwind preflight, so a bare <button> keeps the browser's native chrome
+  // (border + fill + padding) — which turned every icon control into a chunky empty keycap on
+  // the first real render. The reset classes are load-bearing, not cosmetic.
+  it('strips native button chrome from every icon control', () => {
+    render()
+    // Reset only exists on an overridden row — create one first.
+    click(button('canvas.undo', 'Disable Undo')!)
+    const controls = [
+      button('app.commandPalette', 'Record Command palette')!,
+      button('app.commandPalette', 'Add a shortcut to Command palette')!,
+      button('app.commandPalette', 'Disable Command palette')!,
+      button('canvas.undo', 'Reset Undo')!
+    ]
+    for (const el of controls) {
+      expect(el.className).toContain('border-0')
+      expect(el.className).toContain('bg-transparent')
+      expect(el.className).toContain('p-0')
+    }
+  })
+
   // Record and Add sit side by side in the same hover-revealed cluster with no text, so two
   // identical keycaps would leave the pair unreadable — the icon is the whole label.
   it('gives Add a different glyph than Record', () => {

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -127,9 +127,11 @@ const RAIL_ROW: SettingsSearchEntry = {
   keywords: ['filter', 'search', 'modified', 'unassigned', 'disabled']
 }
 
-/** The row's per-command controls: 16px glyph in a 24px hit target, color from the parent. */
+/** The row's per-command controls: 16px glyph in a 24px hit target, color from the parent.
+ *  The repo ships no Tailwind preflight, so `border-0 bg-transparent p-0` must be explicit —
+ *  without them the browser's native button chrome (border + fill + padding) renders. */
 const ICON_BUTTON =
-  'flex size-6 items-center justify-center rounded-md text-muted hover:bg-fill-weak hover:text-text focus-visible:text-text'
+  'flex size-6 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-muted hover:bg-fill-weak hover:text-text focus-visible:text-text'
 /** Shared pill geometry — the accent/neutral fill is appended per badge. */
 const BADGE = 'rounded-full px-2 py-0.5 text-[11px] font-medium'
 


### PR DESCRIPTION
## What happened

On the first real (non-jsdom) render of the redesigned Keyboard Shortcuts section (#344), the hover-revealed icon controls — Record / Add / Disable / Reset — drew as chunky bordered keycaps with the 16px glyph barely visible inside:

The repo deliberately ships **no Tailwind preflight**, so a bare `<button>` keeps the browser's native chrome (border + fill + padding). The per-chip `×` in the same file already carried `border-0 bg-transparent`; the shared `ICON_BUTTON` constant and the recorder's icon-idle shell did not.

## The fix

- `border-0 bg-transparent p-0 cursor-pointer` added to `ICON_BUTTON` (ShortcutsSection) and the recorder's icon-idle className (ShortcutRecorderButton), with a comment stating why the reset is load-bearing.
- A test walks all four icon controls and pins the reset classes, so a future class-string edit can't silently reintroduce the native chrome.

Armed pill and the `button` appearance are untouched — both author their own border/background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)