### PR TITLE
fix(hooks): quote endpoint-file values so a spaced path (macOS Application Support) sources cleanly

### DIFF
--- a/src/core/agents/hook-endpoint-file-sh.test.ts
+++ b/src/core/agents/hook-endpoint-file-sh.test.ts
@@ -46,4 +46,12 @@ describe('endpoint file sources cleanly under real /bin/sh with a spaced path', 
     // (2) and the path must arrive with its space intact, byte for byte.
     expect(r.stdout).toBe(nodeTokenDir())
   })
+
+  it('the shared TS parser reads the REAL writer output identically to sh', async () => {
+    const { parseEndpointEnv } = await import('./hook-endpoint-parse')
+    const env = parseEndpointEnv(fs.readFileSync(hookServer.endpointFilePath(), 'utf8'))
+    expect(env.NODETERM_NODE_TOKEN_DIR).toBe(nodeTokenDir())
+    expect(env.NODETERM_HOOK_TOKEN).toBe(hookServer.getToken())
+    expect(Number(env.NODETERM_HOOK_PORT)).toBe(hookServer.getPort())
+  })
 })

--- a/src/core/agents/hook-endpoint-file-sh.test.ts
+++ b/src/core/agents/hook-endpoint-file-sh.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { hookServer } from './hook-server'
+import { nodeTokenDir } from './node-token-files'
+import { initPlatform, resetPlatformForTests } from '../platform'
+import { fakePlatform } from '../platform-fake'
+
+// Issue #351: on macOS the userDataDir lives under "Application Support" — a directory name WITH A
+// SPACE. The managed hook script SOURCES the endpoint file (`. "$file"`) under /bin/sh, so an
+// unquoted `NODETERM_NODE_TOKEN_DIR=/Users/x/Library/Application Support/...` made sh try to run
+// `Support/...`, exit 127, and the hook fell back to plain mode for EVERY macOS user. This test
+// proves the file sources cleanly under a REAL /bin/sh — the current-line-27 structural assertion
+// passed while real sh failed, which is exactly the class of bug this repo insists we prove against
+// a real reader.
+let spaced = ''
+beforeAll(async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-ep-sh-'))
+  // A subdir with a space in its name — the "Application Support" shape.
+  spaced = path.join(root, 'App Support', 'node-terminal')
+  fs.mkdirSync(spaced, { recursive: true })
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: spaced }))
+  await hookServer.start()
+})
+afterAll(() => {
+  hookServer.stop()
+})
+
+describe('endpoint file sources cleanly under real /bin/sh with a spaced path', () => {
+  it('preserves the exact NODETERM_NODE_TOKEN_DIR path, space intact', () => {
+    const p = hookServer.endpointFilePath()
+    // Sanity: the writer really is exercising a spaced path this run.
+    expect(nodeTokenDir()).toContain(' ')
+    expect(nodeTokenDir().startsWith(spaced)).toBe(true)
+
+    const r = spawnSync(
+      '/bin/sh',
+      ['-c', `. "$1" && printf %s "$NODETERM_NODE_TOKEN_DIR"`, 'sh', p],
+      { encoding: 'utf8' }
+    )
+    // (1) sh must source the file without error (unquoted → exit 127).
+    expect(r.status).toBe(0)
+    // (2) and the path must arrive with its space intact, byte for byte.
+    expect(r.stdout).toBe(nodeTokenDir())
+  })
+})

--- a/src/core/agents/hook-endpoint-file.test.ts
+++ b/src/core/agents/hook-endpoint-file.test.ts
@@ -24,8 +24,10 @@ describe('endpoint file v2', () => {
     const p = hookServer.endpointFilePath()
     const body = fs.readFileSync(p, 'utf8')
     expect(fs.statSync(p).mode & 0o777).toBe(0o600)
-    expect(body).toContain(`NODETERM_NODE_TOKEN_DIR=${nodeTokenDir()}\n`)
-    expect(body).toContain('NODETERM_HOOK_VERSION=2\n')
+    // Values are single-quoted (issue #351): the managed script SOURCES this file under /bin/sh,
+    // so a space or shell metachar in the path/token must be quoted to source cleanly.
+    expect(body).toContain(`NODETERM_NODE_TOKEN_DIR='${nodeTokenDir()}'\n`)
+    expect(body).toContain("NODETERM_HOOK_VERSION='2'\n")
     // The token dir is under this run's userDataDir, not a compiled-in path.
     expect(nodeTokenDir().startsWith(dir)).toBe(true)
   })

--- a/src/core/agents/hook-endpoint-parse.test.ts
+++ b/src/core/agents/hook-endpoint-parse.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { parseEndpointEnv } from './hook-endpoint-parse'
+import { posixQuote } from '../../shared/ssh'
+
+describe('parseEndpointEnv', () => {
+  it('unquotes the exact posixQuote form both writers emit (spaced macOS path, #351)', () => {
+    const dir = '/Users/work/Library/Application Support/node-terminal/node-tokens'
+    // Built with the SAME posixQuote the writers use — not a hand-approximated fixture.
+    const body =
+      `NODETERM_HOOK_PORT=${posixQuote('54321')}\n` +
+      `NODETERM_HOOK_TOKEN=${posixQuote('08011abf-af79')}\n` +
+      `NODETERM_HOOK_VERSION=${posixQuote('2')}\n` +
+      `NODETERM_NODE_TOKEN_DIR=${posixQuote(dir)}\n`
+    expect(parseEndpointEnv(body)).toEqual({
+      NODETERM_HOOK_PORT: '54321',
+      NODETERM_HOOK_TOKEN: '08011abf-af79',
+      NODETERM_HOOK_VERSION: '2',
+      NODETERM_NODE_TOKEN_DIR: dir
+    })
+  })
+
+  it('still parses a LEGACY unquoted file verbatim (pre-fix build; stale files are a real state)', () => {
+    const body =
+      'NODETERM_HOOK_SOCK=/home/u/.nodeterm/hook-p1.sock\n' +
+      'NODETERM_HOOK_TOKEN=tok\n' +
+      'NODETERM_NODE_TOKEN_DIR=/home/u/.nodeterm/node-tokens\n'
+    expect(parseEndpointEnv(body)).toEqual({
+      NODETERM_HOOK_SOCK: '/home/u/.nodeterm/hook-p1.sock',
+      NODETERM_HOOK_TOKEN: 'tok',
+      NODETERM_NODE_TOKEN_DIR: '/home/u/.nodeterm/node-tokens'
+    })
+  })
+
+  it("round-trips an embedded single quote (posixQuote's '\\'' escape)", () => {
+    const value = "it's a 'weird' $token; `x`"
+    expect(parseEndpointEnv(`K=${posixQuote(value)}\n`).K).toBe(value)
+    // Quote at the very edge of the value.
+    expect(parseEndpointEnv(`K=${posixQuote("'")}\n`).K).toBe("'")
+    expect(parseEndpointEnv(`K=${posixQuote("a'")}\n`).K).toBe("a'")
+  })
+
+  it('keeps values containing "=" whole (first-= split) and skips malformed lines', () => {
+    const env = parseEndpointEnv(`A=${posixQuote('x=y')}\nB=x=y\n\nnot a line\n=nope\n`)
+    expect(env).toEqual({ A: 'x=y', B: 'x=y' })
+  })
+
+  it('is self-contained, so the opencode plugin can embed it via toString()', () => {
+    const src = parseEndpointEnv.toString()
+    // Must not close over anything or use template literals — the plugin inlines this source.
+    expect(src).not.toContain('`')
+    expect(src).not.toContain('${')
+    // eslint-disable-next-line no-eval
+    const embedded = (0, eval)(`(${src})`) as typeof parseEndpointEnv
+    expect(embedded(`K=${posixQuote('a b')}\n`).K).toBe('a b')
+  })
+})

--- a/src/core/agents/hook-endpoint-parse.ts
+++ b/src/core/agents/hook-endpoint-parse.ts
@@ -1,0 +1,37 @@
+/**
+ * TS-side parser for the endpoint env file (`hook-endpoint.env` / `hook-endpoint-<project>.env`).
+ *
+ * Since #351 both writers `posixQuote` every value so the file sources cleanly under /bin/sh when
+ * a path carries a space (macOS "Application Support") or a token carries a shell metachar. Shell
+ * consumers get the unquoting for free from `. "$file"`; every TypeScript consumer must unquote
+ * through THIS function instead of splitting on `=` naively — a naive read keeps the literal
+ * quote characters, which breaks the constant-time bearer check (opencode plugin) and turns
+ * `Number("'54321'")` into NaN (codex relay daemon).
+ *
+ * Accepts BOTH forms per line, so one parser covers the whole fleet:
+ *  - quoted (post-#351): `KEY='value'`, with embedded single quotes escaped exactly as
+ *    `posixQuote` emits them (`'` → `'\''`);
+ *  - legacy unquoted (pre-fix builds): `KEY=value` verbatim. tmux sessions outlive the app, so a
+ *    stale endpoint file written by an old build is a real, documented state — it must keep
+ *    parsing.
+ *
+ * SELF-CONTAINED ON PURPOSE — no imports, no closure over module state. The opencode plugin is
+ * generated JS source that runs standalone under Bun/node (it cannot import from this app), so
+ * `buildOpencodePlugin()` embeds this very function via `parseEndpointEnv.toString()`. Keep it
+ * dependency-free (and free of template literals / `${`) or the embedded copy breaks.
+ */
+export function parseEndpointEnv(text: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const line of text.split('\n')) {
+    const i = line.indexOf('=')
+    if (i <= 0) continue
+    let v = line.slice(i + 1)
+    if (v.length >= 2 && v.charAt(0) === "'" && v.charAt(v.length - 1) === "'") {
+      // posixQuote form: strip the outer quotes, then collapse each embedded-quote escape
+      // ('\'' — close quote, escaped quote, reopen quote) back to a literal quote.
+      v = v.slice(1, -1).split("'\\''").join("'")
+    }
+    env[line.slice(0, i)] = v
+  }
+  return env
+}

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -22,6 +22,7 @@ import {
   STRICT_CONTROL_VERBS,
   type IdentityDecision
 } from './node-identity-policy'
+import { posixQuote } from '../../shared/ssh'
 
 // v2 advertises NODETERM_NODE_TOKEN_DIR so clients read their per-node capability from a file
 // rather than receiving it in argv. Nothing consumes the posted version server-side, so the bump
@@ -911,14 +912,19 @@ class HookServer {
       mkdirSync(path.dirname(p), { recursive: true })
       writeFileSync(
         p,
-        `NODETERM_HOOK_PORT=${this.port}\n` +
-          `NODETERM_HOOK_TOKEN=${this.token}\n` +
-          `NODETERM_HOOK_VERSION=${NODETERM_HOOK_PROTOCOL_VERSION}\n` +
+        // Every value is `posixQuote`d: the managed script SOURCES this file (`. "$file"`) under
+        // /bin/sh, so an unquoted space or shell metachar in a path or token would break the source
+        // (issue #351: macOS userDataDir lives under "Application Support" — the space made sh try
+        // to run the tail of the path, exit 127, and the hook fell back to plain mode for EVERY
+        // macOS user). Quoting all four keeps the file a valid POSIX assignment list regardless.
+        `NODETERM_HOOK_PORT=${posixQuote(String(this.port))}\n` +
+          `NODETERM_HOOK_TOKEN=${posixQuote(this.token)}\n` +
+          `NODETERM_HOOK_VERSION=${posixQuote(NODETERM_HOOK_PROTOCOL_VERSION)}\n` +
           // Where clients read their PER-NODE capability from, keyed by $NODETERM_NODE_ID.
           // Advertised (not compiled in) so a failover that sources ANOTHER instance's endpoint
           // file also picks up THAT instance's token dir: it then finds a token that instance can
           // verify, or none — never a mismatched one.
-          `NODETERM_NODE_TOKEN_DIR=${nodeTokenDir()}\n`,
+          `NODETERM_NODE_TOKEN_DIR=${posixQuote(nodeTokenDir())}\n`,
         // 0o600: this file holds the bearer token — owner read/write only so another local user
         // can't read it and forge hook events.
         { encoding: 'utf8', mode: 0o600 }

--- a/src/core/agents/hooks/opencode-live-endpoint.test.ts
+++ b/src/core/agents/hooks/opencode-live-endpoint.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { buildOpencodePlugin } from './opencode'
+import { hookServer } from '../hook-server'
+import { initPlatform, resetPlatformForTests } from '../../platform'
+import { fakePlatform } from '../../platform-fake'
+import type { NormalizedAgentEvent } from '../../../shared/agents/normalize'
+
+// Issue #351 follow-up: the plugin's `live()` re-parses the REAL endpoint file that
+// `writeEndpointFile()` writes — every fixture in opencode.test.ts hand-writes that file, so a
+// writer-format change (the #351 quoting) could break the parse without any test noticing. This
+// test closes that gap end-to-end: real writer → real plugin parse → real hook server bearer
+// check. If the plugin's parser ever keeps the quotes (or otherwise mangles the token), the POST
+// is 401'd and the listener below never fires.
+let tmp = ''
+beforeAll(async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-oc-live-'))
+  // Spaced userDataDir — the "Application Support" shape the quoting exists for.
+  tmp = path.join(root, 'App Support', 'node-terminal')
+  fs.mkdirSync(tmp, { recursive: true })
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: tmp }))
+  await hookServer.start()
+})
+afterAll(() => {
+  hookServer.stop()
+  vi.unstubAllEnvs()
+})
+
+describe('opencode plugin against the real endpoint-file writer', () => {
+  it('parses the quoted endpoint file and its token passes the real bearer check', async () => {
+    const events: NormalizedAgentEvent[] = []
+    hookServer.setListener((e) => events.push(e))
+    vi.stubEnv('NODETERM_NODE_ID', 'node-oc-live')
+    vi.stubEnv('NODETERM_HOOK_ENDPOINT', hookServer.endpointFilePath())
+    // No env fallbacks: port/token MUST come out of the file, exactly as a tmux restart handoff.
+    vi.stubEnv('NODETERM_HOOK_PORT', '')
+    vi.stubEnv('NODETERM_HOOK_TOKEN', '')
+    vi.stubEnv('NODETERM_HOOK_SOCK', '')
+
+    const file = path.join(tmp, 'plugin-live.mjs')
+    fs.writeFileSync(file, buildOpencodePlugin())
+    const mod = await import(/* @vite-ignore */ `file://${file}`)
+    const hooks = await mod.NodetermStatus()
+    await hooks.event({ event: { type: 'session.idle', properties: { sessionID: 'ses_live' } } })
+
+    // The listener fires only for an ACCEPTED post — a quote-mangled token is 401'd before it.
+    await vi.waitFor(() => expect(events.length).toBeGreaterThan(0))
+    expect(events[0].nodeId).toBe('node-oc-live')
+  })
+})

--- a/src/core/agents/hooks/opencode.ts
+++ b/src/core/agents/hooks/opencode.ts
@@ -7,6 +7,7 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { parseEndpointEnv } from '../hook-endpoint-parse'
 
 export const PLUGIN_MARKER = '// nodeterm managed plugin — do not edit (reinstalled at app launch)'
 
@@ -52,6 +53,12 @@ export function buildOpencodePlugin(): string {
 import fs from 'node:fs'
 import http from 'node:http'
 
+// The SAME quote-aware parser every TS consumer of the endpoint file uses, embedded verbatim
+// (this plugin runs standalone under Bun/node — it cannot import from the app). Values are
+// posixQuote'd since #351; a quote-blind read would present a token wrapped in literal quotes,
+// which the hook server's constant-time bearer check rejects on every POST.
+const parseEndpointEnv = ${parseEndpointEnv.toString()}
+
 export const NodetermStatus = async () => {
   const nodeId = process.env.NODETERM_NODE_ID
   if (!nodeId) return {}
@@ -66,14 +73,13 @@ export const NodetermStatus = async () => {
     try {
       const file = process.env.NODETERM_HOOK_ENDPOINT
       if (file) {
-        for (const line of fs.readFileSync(file, 'utf8').split('\\n')) {
-          const m = line.match(/^NODETERM_HOOK_(PORT|SOCK|TOKEN|VERSION)=(.*)$/)
-          if (m) conf[m[1].toLowerCase()] = m[2]
-          // The v2 endpoint line: where this instance keeps per-node tokens. It has its own
-          // prefix, so it needs its own match rather than a widened NODETERM_HOOK_ group.
-          const d = line.match(/^NODETERM_NODE_TOKEN_DIR=(.*)$/)
-          if (d) conf.tokenDir = d[1]
-        }
+        const env = parseEndpointEnv(fs.readFileSync(file, 'utf8'))
+        if ('NODETERM_HOOK_PORT' in env) conf.port = env.NODETERM_HOOK_PORT
+        if ('NODETERM_HOOK_SOCK' in env) conf.sock = env.NODETERM_HOOK_SOCK
+        if ('NODETERM_HOOK_TOKEN' in env) conf.token = env.NODETERM_HOOK_TOKEN
+        if ('NODETERM_HOOK_VERSION' in env) conf.version = env.NODETERM_HOOK_VERSION
+        // The v2 endpoint line: where this instance keeps per-node tokens.
+        if ('NODETERM_NODE_TOKEN_DIR' in env) conf.tokenDir = env.NODETERM_NODE_TOKEN_DIR
       }
     } catch {}
     return conf

--- a/src/core/remote-ssh/control-master.test.ts
+++ b/src/core/remote-ssh/control-master.test.ts
@@ -390,11 +390,21 @@ describe('hook forwarding', () => {
     ])
     expect(remoteHookEnvArgs('/ep', 'n1', '1')).not.toContain('NODETERM_CANVAS_CONTROL=1')
   })
-  it('remoteEndpointFileContents writes SOCK/TOKEN/VERSION and the remote token dir', () => {
+  it('remoteEndpointFileContents writes SOCK/TOKEN/VERSION and the remote token dir, each quoted', () => {
     expect(remoteEndpointFileContents('/r.sock', 'tok', '2', '/home/u/.nodeterm/node-tokens')).toBe(
-      'NODETERM_HOOK_SOCK=/r.sock\nNODETERM_HOOK_TOKEN=tok\nNODETERM_HOOK_VERSION=2\n' +
-        'NODETERM_NODE_TOKEN_DIR=/home/u/.nodeterm/node-tokens\n'
+      "NODETERM_HOOK_SOCK='/r.sock'\nNODETERM_HOOK_TOKEN='tok'\nNODETERM_HOOK_VERSION='2'\n" +
+        "NODETERM_NODE_TOKEN_DIR='/home/u/.nodeterm/node-tokens'\n"
     )
+  })
+  it('remoteEndpointFileContents quotes a spaced remote path so /bin/sh sources it cleanly', () => {
+    const body = remoteEndpointFileContents(
+      '/home/u/App Support/hook.sock',
+      'tok',
+      '2',
+      '/home/u/App Support/node-tokens'
+    )
+    expect(body).toContain("NODETERM_HOOK_SOCK='/home/u/App Support/hook.sock'\n")
+    expect(body).toContain("NODETERM_NODE_TOKEN_DIR='/home/u/App Support/node-tokens'\n")
   })
 })
 

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -684,13 +684,17 @@ export function remoteEndpointFileContents(
   version: string,
   tokenDir: string
 ): string {
+  // Every value is `posixQuote`d for the same reason as the local writer (issue #351): the managed
+  // script SOURCES this file under /bin/sh, so an unquoted space or shell metachar in the socket
+  // path, token, or token dir would break the source. Remote paths rarely carry spaces, but the
+  // token can hold any byte, and the guarantee should not depend on the host's home layout.
   return (
-    `NODETERM_HOOK_SOCK=${sock}\n` +
-    `NODETERM_HOOK_TOKEN=${token}\n` +
-    `NODETERM_HOOK_VERSION=${version}\n` +
+    `NODETERM_HOOK_SOCK=${posixQuote(sock)}\n` +
+    `NODETERM_HOOK_TOKEN=${posixQuote(token)}\n` +
+    `NODETERM_HOOK_VERSION=${posixQuote(version)}\n` +
     // The REMOTE token dir ($HOME/.nodeterm/node-tokens on the host), not ours. The host stores
     // per-node tokens only; it never holds a secret and can never mint.
-    `NODETERM_NODE_TOKEN_DIR=${tokenDir}\n`
+    `NODETERM_NODE_TOKEN_DIR=${posixQuote(tokenDir)}\n`
   )
 }
 

--- a/src/main/codex-relay-daemon.test.ts
+++ b/src/main/codex-relay-daemon.test.ts
@@ -27,6 +27,8 @@ import {
   readThreadAt,
   relayControlPost,
   relayThreadReservationKey,
+  hookEndpointOptions,
+  readHookEndpointEnv,
   relayThreadResponseError,
   resolveForeignThreadAt,
   retargetRelayResumeByPath,
@@ -35,6 +37,7 @@ import {
   tryReserveRelayThread,
   type RelayThreadRequest
 } from './codex-relay-daemon'
+import { posixQuote } from '../shared/ssh'
 
 async function fakeCodexServer(
   socketPath: string,
@@ -898,4 +901,78 @@ describe('relay self-spawn + token transport (probe U6, GC 6 argv-spy)', () => {
       rmSync(out, { force: true })
     }
   }, 30_000)
+})
+
+// The endpoint file's values are posixQuote'd since #351 (a spaced macOS path must source
+// cleanly under /bin/sh). The daemon's TS-side reader must UNQUOTE them, or
+// `Number("'54321'")` is NaN and `"'/sock'".startsWith('/')` is false — hookEndpointOptions
+// then returns null and every authorize/observed/catalog call dies "endpoint unavailable".
+describe('readHookEndpointEnv + hookEndpointOptions', () => {
+  const writeEndpoint = (dir: string, lines: string) => {
+    const f = path.join(dir, 'hook-endpoint.env')
+    writeFileSync(f, lines)
+    return f
+  }
+
+  it('parses the QUOTED (post-#351) file: TCP port', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nt-relay-ep-'))
+    try {
+      const f = writeEndpoint(
+        dir,
+        `NODETERM_HOOK_PORT=${posixQuote('54321')}\n` +
+          `NODETERM_HOOK_TOKEN=${posixQuote('tok-abc')}\n` +
+          `NODETERM_HOOK_VERSION=${posixQuote('2')}\n` +
+          `NODETERM_NODE_TOKEN_DIR=${posixQuote('/Users/x/Library/Application Support/node-terminal/node-tokens')}\n`
+      )
+      const env = readHookEndpointEnv(f)
+      expect(env.NODETERM_HOOK_TOKEN).toBe('tok-abc')
+      expect(env.NODETERM_NODE_TOKEN_DIR).toBe(
+        '/Users/x/Library/Application Support/node-terminal/node-tokens'
+      )
+      expect(hookEndpointOptions(env, '/codex-thread/authorize')).toEqual({
+        hostname: '127.0.0.1',
+        port: 54321,
+        path: '/codex-thread/authorize'
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('parses the QUOTED (post-#351) file: unix socket with a spaced path', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nt-relay-ep-'))
+    try {
+      const f = writeEndpoint(
+        dir,
+        `NODETERM_HOOK_SOCK=${posixQuote('/home/u/App Support/hook.sock')}\n` +
+          `NODETERM_HOOK_TOKEN=${posixQuote('tok-abc')}\n`
+      )
+      const env = readHookEndpointEnv(f)
+      expect(hookEndpointOptions(env, '/codex-thread/observed')).toEqual({
+        socketPath: '/home/u/App Support/hook.sock',
+        path: '/codex-thread/observed'
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('still parses a LEGACY unquoted file (pre-fix build; tmux sessions outlive the app)', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nt-relay-ep-'))
+    try {
+      const f = writeEndpoint(
+        dir,
+        'NODETERM_HOOK_PORT=54321\nNODETERM_HOOK_TOKEN=tok-abc\nNODETERM_NODE_TOKEN_DIR=/home/u/.nodeterm/node-tokens\n'
+      )
+      const env = readHookEndpointEnv(f)
+      expect(env.NODETERM_HOOK_TOKEN).toBe('tok-abc')
+      expect(hookEndpointOptions(env, '/x')).toEqual({
+        hostname: '127.0.0.1',
+        port: 54321,
+        path: '/x'
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/main/codex-relay-daemon.ts
+++ b/src/main/codex-relay-daemon.ts
@@ -64,6 +64,7 @@ import {
   isSafeAccountId,
   planCodexRolloutExposure
 } from '../core/codex-accounts-core'
+import { parseEndpointEnv } from '../core/agents/hook-endpoint-parse'
 
 // Protocol v6 adds a node-scoped capability to every Electron identity request. It also merges
 // account-isolated catalogs and resumes a selected foreign rollout by path in
@@ -722,7 +723,18 @@ function indexedName(socketPath: string, threadId?: string): string | undefined 
   }
 }
 
-function hookEndpointOptions(
+/**
+ * Read + parse the local endpoint env file for `hookRequest`/`hookJsonRequest`. Values are
+ * `posixQuote`d since #351, so this must go through the shared quote-aware parser — a naive
+ * first-`=` split keeps the quotes, making the port NaN and the sock non-absolute, and every
+ * authorize/observed/catalog call then dies "endpoint unavailable". Exported for tests.
+ */
+export function readHookEndpointEnv(file: string): Record<string, string> {
+  return parseEndpointEnv(readFileSync(file, 'utf8'))
+}
+
+/** Exported for tests. */
+export function hookEndpointOptions(
   env: Record<string, string>,
   pathname: string
 ): { socketPath: string; path: string } | { hostname: string; port: number; path: string } | null {
@@ -741,15 +753,7 @@ function hookRequest(
   return new Promise((resolve, reject) => {
     let env: Record<string, string>
     try {
-      env = Object.fromEntries(
-        readFileSync(route.hookEndpoint, 'utf8')
-          .split('\n')
-          .filter(Boolean)
-          .map((l) => {
-            const i = l.indexOf('=')
-            return i > 0 ? [l.slice(0, i), l.slice(i + 1)] : ['', '']
-          })
-      )
+      env = readHookEndpointEnv(route.hookEndpoint)
     } catch (error) {
       reject(error)
       return
@@ -787,15 +791,7 @@ function hookJsonRequest<T>(route: Route, pathname: string): Promise<T> {
   return new Promise((resolve, reject) => {
     let env: Record<string, string>
     try {
-      env = Object.fromEntries(
-        readFileSync(route.hookEndpoint, 'utf8')
-          .split('\n')
-          .filter(Boolean)
-          .map((line) => {
-            const separator = line.indexOf('=')
-            return separator > 0 ? [line.slice(0, separator), line.slice(separator + 1)] : ['', '']
-          })
-      )
+      env = readHookEndpointEnv(route.hookEndpoint)
     } catch (error) {
       reject(error)
       return

--- a/src/main/remote-ssh/remote-hooks.test.ts
+++ b/src/main/remote-ssh/remote-hooks.test.ts
@@ -56,8 +56,9 @@ describe('RemoteHooks.setup', () => {
     expect(
       calls.some(
         (c) =>
-          (c.stdin ?? '').includes('NODETERM_HOOK_TOKEN=tok') &&
-          (c.stdin ?? '').includes('NODETERM_HOOK_SOCK=/home/u/.nodeterm/hook-p1.sock')
+          // Values are single-quoted (issue #351) so a spaced remote path sources cleanly.
+          (c.stdin ?? '').includes("NODETERM_HOOK_TOKEN='tok'") &&
+          (c.stdin ?? '').includes("NODETERM_HOOK_SOCK='/home/u/.nodeterm/hook-p1.sock'")
       )
     ).toBe(true)
     // managed script written to the absolute path + config merged with the guarded command.


### PR DESCRIPTION
## The bug

The managed hook script **sources** the generated endpoint env file (`. "$file"`) under `/bin/sh` to read the live port/token/token-dir. Both endpoint writers emitted every value **unquoted**, so a space (or any shell metachar) in a path broke the source.

On macOS the userDataDir lives under **"Application Support"** — a directory name with a space. So:

```
NODETERM_NODE_TOKEN_DIR=/Users/work/Library/Application Support/node-terminal/node-tokens
```

made `sh` try to execute `Support/...` → **exit 127** → the hook fell back to plain mode: *"nodeterm's hook server was unreachable"*, context-link reads failed, and the codex hook died.

## Impact

This broke context links + the codex hook for **every macOS user** (the data dir is always under "Application Support"). Shipped in v0.3.2, still present on `main`. This is our own #195 per-node-identity code.

## The fix

`posixQuote` every value in **both** endpoint writers:

- `src/core/agents/hook-server.ts` — `writeEndpointFile()` (local TCP transport)
- `src/core/remote-ssh/control-master.ts` — `remoteEndpointFileContents()` (server-edition unix-socket transport, `NODETERM_HOOK_SOCK=…`)

Quoting all values (not just the paths) is the safe, consistent choice — the token can carry any byte too. 0600 mode and the failover-endpoint semantics are unchanged.

## Shared quote-aware parser for the TS-side readers

Adversarial review found **two TypeScript consumers** that re-parse this file and would have broken universally once the values were quoted:

- **opencode plugin** `live()` — its regex captured the value *including* the quotes, so the token failed the hook server's constant-time bearer check on every POST;
- **codex relay daemon** `hookRequest`/`hookJsonRequest` — naive first-`=` split: `Number("'54321'")` → NaN, `"'/sock'".startsWith('/')` → false, `hookEndpointOptions` → null, every authorize/observed/catalog call rejected.

Both now go through one shared `parseEndpointEnv` (`src/core/agents/hook-endpoint-parse.ts`): splits on the first `=`, unquotes the exact `posixQuote` form (including the `'\''` embedded-quote escape), and passes **legacy unquoted lines through verbatim** — so a stale endpoint file written by a pre-fix build still parses (tmux sessions outlive the app). The relay daemon imports it; the opencode plugin (generated standalone JS) embeds the very same function via `toString()`, so there is a single source of truth. A grep census confirmed no third TS reader — every other consumer sources the file under sh, which the quoting is for.

## Tests — prove against a real reader

The prior assertion pinned the **unquoted** form — a structural check that passed while real `sh` failed, which is precisely this bug. It now expects the quoted form.

- `hook-endpoint-file-sh.test.ts`: writes the endpoint file with the token dir under a path **with a space**, then runs `/bin/sh -c '. <file> && printf %s "$NODETERM_NODE_TOKEN_DIR"'` and asserts exit `0` + the exact path, space intact. On the unquoted writer it reds with **exit 127** (verified by mutation, both writers).
- `opencode-live-endpoint.test.ts` (red-first): REAL writer → REAL plugin → REAL hook server; the POST must pass the bearer check. Failed before the parser, passes after.
- `codex-relay-daemon.test.ts` (red-first): quoted TCP + quoted spaced-socket + legacy-unquoted parses through `readHookEndpointEnv`/`hookEndpointOptions`.
- `hook-endpoint-parse.test.ts`: writer-form, legacy-form, embedded-single-quote round-trips, and the self-containment the plugin embedding relies on.
- Mutation: making the parser keep the quotes reds both consumers' tests — including the plugin's **embedded** copy.

Full `vitest run` green (597 files / 8354 tests) + typecheck clean.

Fixes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)