### PR TITLE
fix(codex): a shared-identity node keeps a per-project unique node id

### DIFF
--- a/src/core/codex-identity-proxy.ts
+++ b/src/core/codex-identity-proxy.ts
@@ -602,7 +602,20 @@ nt_preflight() {
   # <CODEX_HOME>/packages/standalone/current/codex". Caps normally keeps that second case away from
   # here entirely, but the pane resolves CODEX_HOME from its OWN environment (§8.5) and an install
   # can be removed after boot, so the launcher still has to be able to say which it hit.
-  if ${appServerStartCommand}; then
+  #
+  # The app-server is a PERSISTENT DAEMON: the FIRST codex node to reach here starts it and every
+  # later node reuses it. Start it in a SUBSHELL with THIS node's per-pane NODETERM_* scrubbed, or
+  # the daemon — and every tool shell it later spawns for EVERY node — would inherit this one node's
+  # NODETERM_NODE_ID. The thread → node resolver (codex-thread-identity-sh.ts) only recovers the
+  # right node when a tool shell has NO NODETERM_NODE_ID; a leaked value makes its guard no-op and
+  # silently collapses every codex node's identity onto whichever node started the daemon, so
+  # Project B's codex lists Project A's links and routes to A (#350). NODETERM_CODEX_ACCOUNT_ID is
+  # the ONE var deliberately KEPT: one daemon serves one account, and the resolver reads it from the
+  # daemon's env to pick the record scope. The unset runs BEFORE the (test-injected) start command.
+  if ( unset NODETERM_NODE_ID NODETERM_HOOK_ENDPOINT NODETERM_HOOK_PORT NODETERM_HOOK_TOKEN \\
+    NODETERM_HOOK_SOCK NODETERM_AGENT_ID NODETERM_CANVAS_CONTROL NODETERM_NODE_TOKEN_DIR \\
+    NODETERM_PERM_WAIT_SECS
+    ${appServerStartCommand} ); then
     return 0
   fi
   if [ -x "\${CODEX_HOME:-$HOME/.codex}/packages/standalone/current/codex" ]; then

--- a/src/core/codex-launcher-sh.test.ts
+++ b/src/core/codex-launcher-sh.test.ts
@@ -185,6 +185,40 @@ describe('generated Codex launcher', () => {
     expect(fallbacks).toEqual([])
   })
 
+  // #350 (the confused deputy): the shared app-server is a PERSISTENT DAEMON started by the FIRST
+  // codex node to launch, and reused by every later node. If the launcher starts it while THIS
+  // node's per-pane NODETERM_NODE_ID is in the environment, the daemon — and every tool shell it
+  // later spawns for EVERY node — inherits that one node's id. The thread→node resolver only
+  // recovers the right node when the tool shell has NO NODETERM_NODE_ID (its guard is
+  // `[ -z "$NODETERM_NODE_ID" ]`), so a leaked value silently collapses every codex node's identity
+  // onto the daemon-starting node: Project B's codex then lists Project A's links and routes to A.
+  // The daemon MUST therefore be started with the per-pane vars scrubbed. NODETERM_CODEX_ACCOUNT_ID
+  // is the ONE exception — one daemon serves one account, and the resolver reads it to pick scope.
+  it('starts the shared app-server daemon WITHOUT this node\'s per-pane NODETERM_NODE_ID (#350)', async () => {
+    const envDump = path.join(dir, 'daemon-env.txt')
+    const dumpScript = path.join(dir, 'dump-daemon-env.sh')
+    fs.writeFileSync(
+      dumpScript,
+      `#!/bin/sh\n` +
+        `printf 'NID=[%s]\\nACC=[%s]\\nHOOK=[%s]\\n' ` +
+        `"\${NODETERM_NODE_ID-}" "\${NODETERM_CODEX_ACCOUNT_ID-}" "\${NODETERM_HOOK_ENDPOINT-}" ` +
+        `> ${JSON.stringify(envDump)}\n`,
+      { mode: 0o755 }
+    )
+    const script2 = path.join(dir, 'nodeterm-codex-envdump')
+    fs.writeFileSync(script2, buildCodexLauncherScript(JSON.stringify(dumpScript)), { mode: 0o755 })
+
+    await callLauncher([], { NODETERM_CODEX_ACCOUNT_ID: 'acct-A' }, script2)
+
+    const dumped = fs.readFileSync(envDump, 'utf8')
+    // The per-pane node id is scrubbed for the daemon (else its tool shells all report node-1).
+    expect(dumped).toContain('NID=[]')
+    // …and the per-pane hook endpoint too — a tool shell recovers it per-thread from the record.
+    expect(dumped).toContain('HOOK=[]')
+    // The account scope is deliberately preserved: the resolver needs it to pick the record scope.
+    expect(dumped).toContain('ACC=[acct-A]')
+  })
+
   it('keeps the caller arguments after the thread it resolved', async () => {
     await callLauncher(['--ask-for-approval', 'never', 'fix the bug'])
     expect(codexArgv()).toEqual([

--- a/src/core/codex-launcher-sh.test.ts
+++ b/src/core/codex-launcher-sh.test.ts
@@ -219,6 +219,25 @@ describe('generated Codex launcher', () => {
     expect(dumped).toContain('ACC=[acct-A]')
   })
 
+  // The #351 interplay, pinned: a failed endpoint preflight (#351's unquoted-path sourcing bug,
+  // an unreadable file, an app restart) must NEVER reach the daemon start. This is what makes #350
+  // and #351 INDEPENDENT bugs rather than a chain — the daemon-env leak above requires the shared
+  // path to have proceeded, and a #351-style failure falls back to plain codex BEFORE that line.
+  it('a failed endpoint preflight never starts the daemon (#351 cannot feed #350)', async () => {
+    const envDump = path.join(dir, 'daemon-env-endpointfail.txt')
+    const dumpScript = path.join(dir, 'dump-daemon-env-endpointfail.sh')
+    fs.writeFileSync(dumpScript, `#!/bin/sh\n: > ${JSON.stringify(envDump)}\n`, { mode: 0o755 })
+    const script2 = path.join(dir, 'nodeterm-codex-endpointfail')
+    fs.writeFileSync(script2, buildCodexLauncherScript(JSON.stringify(dumpScript)), { mode: 0o755 })
+
+    await callLauncher(['do', 'work'], { NODETERM_HOOK_ENDPOINT: '/nonexistent/hook-endpoint.env' }, script2)
+
+    // Plain codex with the args intact, and the daemon start command was never invoked.
+    expect(codexArgv()).toEqual(['do work'])
+    expect(fs.existsSync(envDump)).toBe(false)
+    expect(fallbacks.map((f) => f.reason)).toContain('hook-endpoint-unavailable')
+  })
+
   it('keeps the caller arguments after the thread it resolved', async () => {
     await callLauncher(['--ask-for-approval', 'never', 'fix the bug'])
     expect(codexArgv()).toEqual([

--- a/src/core/codex-thread-identity-sh.test.ts
+++ b/src/core/codex-thread-identity-sh.test.ts
@@ -74,6 +74,23 @@ describe('codex thread identity prelude', () => {
     )
   })
 
+  // #350, at the resolver: two projects, a codex node in each with its OWN thread. A daemon-spawned
+  // tool shell for Project B's thread — with the daemon env CLEAN (no leaked NODETERM_NODE_ID, which
+  // is what the launcher fix guarantees) — must recover B's node and NEVER A's. This is the
+  // cross-project isolation the confused-deputy broke: when the daemon leaked node-A's id the guard
+  // above no-opped and B's tool shell stayed node-A, so B listed A's links and routed to A.
+  it('cross-project isolation: a clean tool shell for project B resolves B, never A (#350)', async () => {
+    record('thread-A', `nodeId=node-A\nendpoint=${dir}/hook-endpoint.env\nsignature=x\n`)
+    record('thread-B', `nodeId=node-B\nendpoint=${dir}/hook-endpoint.env\nsignature=x\n`)
+    const resolvedB = await resolve({ CODEX_THREAD_ID: 'thread-B' })
+    expect(resolvedB).toBe(`node-B|${dir}/hook-endpoint.env|1`)
+    expect(resolvedB).not.toContain('node-A')
+    // And symmetrically, A's thread never resolves to B.
+    expect(await resolve({ CODEX_THREAD_ID: 'thread-A' })).toBe(
+      `node-A|${dir}/hook-endpoint.env|1`
+    )
+  })
+
   it('is inert for every other agent (no CODEX_THREAD_ID, no record)', async () => {
     expect(await resolve({})).toBe('||')
     expect(await resolve({ CODEX_THREAD_ID: 'unknown-thread' })).toBe('||')


### PR DESCRIPTION
## Root cause

The shared Codex app-server is a **persistent daemon** — the first codex node to launch starts it (via `codex app-server daemon start` inside the launcher's `nt_preflight`) and every later node reuses it, the #167/S6 RAM saver. But that command runs in the **node's pane**, so the daemon inherited that node's per-pane `NODETERM_NODE_ID`. Every tool shell the daemon later spawns for **every** node then inherited the **first** node's id.

The thread→node resolver (`codex-thread-identity-sh.ts`) only recovers the correct node when a tool shell has **no** `NODETERM_NODE_ID` — its outer guard is `[ -z "$NODETERM_NODE_ID" ]`. The leaked value made that guard no-op, silently collapsing every codex node's effective identity onto whichever node started the daemon.

## Cross-project routing impact (the confused deputy)

Two codex nodes in **different projects** reported the *same* `NODETERM_NODE_ID` (identical prefix **and** 8-hex suffix). Project B's codex listed Project A's context links and messages **routed to A** — even though the canvas showed separate green edges. Deleting/recreating B's node didn't help because the poisoned daemon kept running with A's env. This matches the report in #350 exactly, including the id being stable across recreate and the visual links disagreeing with routing.

It is **not** a node-id generation collision: node ids are CSPRNG (`nextId` in `workspace.ts`) and would essentially never collide. The collision is the daemon leaking one node's id into every tool shell.

## Fix

Start the daemon in a **subshell with the per-pane `NODETERM_*` scrubbed**, so its tool shells carry no `NODETERM_NODE_ID` and the resolver recovers each thread's real node from `CODEX_THREAD_ID`. `NODETERM_CODEX_ACCOUNT_ID` is **deliberately kept** — one daemon serves one account and the resolver reads it to pick the record scope — so the shared app-server / per-node thread model (#167/S6) is **untouched**. No changes to thread minting, record writing, ownership, or the resolver itself.

## Tests (both mutation-checked)

- `codex-launcher-sh.test.ts`: runs the real generated launcher under `/bin/sh` with a start command that dumps the daemon's environment; asserts `NODETERM_NODE_ID` and the hook endpoint are **empty** for the daemon while `NODETERM_CODEX_ACCOUNT_ID` is **preserved**. Red before the fix (`NID=[node-1]`), green after. Mutations killed: removing the scrub (bug returns), and also scrubbing the account (breaks scope preservation).
- `codex-thread-identity-sh.test.ts`: cross-project isolation — a **clean** daemon-spawned tool shell for Project B's thread resolves node-B and **never** node-A (and symmetrically). Vacuity-checked.

Full suite: 594 files / 8344 tests green; `tsc --noEmit` clean.

Fixes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)