### PR TITLE
feat(settings): explanatory hover tooltips on the shortcut row icon controls

### DIFF
--- a/src/renderer/components/settings/ShortcutRecorderButton.tsx
+++ b/src/renderer/components/settings/ShortcutRecorderButton.tsx
@@ -41,6 +41,7 @@ import { COMMANDS_BY_ID, normalizeBindingForCommand, type CommandId } from '@sha
 import { isMacPlatform } from '@shared/platform-utils'
 import { recordingKeydown, recordingKeyup, type RecordingState } from './shortcutRecording'
 import { IconRecordKey } from './ShortcutRowIcons'
+import { Tooltip } from '../Tooltip'
 
 const isMac = isMacPlatform()
 
@@ -50,13 +51,18 @@ export function ShortcutRecorderButton({
   onCommit,
   appearance = 'button',
   label,
-  idleIcon
+  idleIcon,
+  tooltip
 }: {
   commandId: CommandId
   idleLabel: string
   onCommit: (combo: string) => void
   appearance?: 'button' | 'icon'
   label?: string
+  /** Hover-tooltip text for the IDLE `appearance="icon"` button (the app's custom Tooltip, not
+   *  the OS-delayed native one). The icon is the whole visible label, so this is where "replace"
+   *  vs "add another" gets said. Omitted ⇒ the accessible label. */
+  tooltip?: string
   /** The glyph the IDLE `appearance="icon"` button shows — presentational only, and it changes
    *  nothing else about the recorder. It exists because a row can carry two recorders (Record and
    *  Add) side by side in one label-less cluster, where the icon IS the label and two identical
@@ -141,8 +147,7 @@ export function ShortcutRecorderButton({
         // the browser's native button chrome (border + fill + padding) renders around the glyph.
         'flex size-6 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-muted hover:bg-fill-weak hover:text-text focus-visible:text-text'
       : 'min-w-[120px] cursor-pointer rounded-md border border-border bg-panel-header px-3 py-1.5 text-[13px] font-medium text-text outline-none hover:bg-[rgba(255,255,255,0.06)]'
-  const isIdleIcon = appearance === 'icon' && !capturing
-  return (
+  const btn = (
     <button
       type="button"
       // Observability only — no dispatcher reads it (see the header). Keeps the armed state
@@ -157,10 +162,9 @@ export function ShortcutRecorderButton({
       // and it must survive arming. Dropping it on capture (as this did) left a screen-reader
       // user with a button whose name flipped to the hint text mid-interaction, i.e. no way to
       // tell which command is being recorded for. The 'button' appearance keeps its own text and
-      // is deliberately untouched. `title` stays idle-only: the armed pill already says
-      // "Press keys…" on screen, and a hover tooltip over a live capture is noise.
+      // is deliberately untouched. There is no native `title`: the icon appearance carries the
+      // app's custom Tooltip below instead, and two tooltips for one hover is noise.
       aria-label={appearance === 'icon' ? effectiveLabel : undefined}
-      title={isIdleIcon ? effectiveLabel : undefined}
     >
       {capturing ? (
         <>
@@ -173,5 +177,14 @@ export function ShortcutRecorderButton({
         idleLabel
       )}
     </button>
+  )
+  // Only the icon appearance gets the custom tooltip — the 'button' appearance has visible text,
+  // and wrapping it would change its markup. `appearance` is fixed per instance, so the wrapper
+  // never appears/disappears mid-capture (that would remount the armed button and kill capture).
+  if (appearance !== 'icon') return btn
+  return (
+    <Tooltip label={capturing ? 'Press the new shortcut · Esc cancels' : (tooltip ?? effectiveLabel)}>
+      {btn}
+    </Tooltip>
   )
 }

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -239,6 +239,34 @@ describe('ShortcutsSection rows', () => {
     }
   })
 
+  // The icon glyphs cannot say that Record REPLACES while Add appends — the hover tooltip is
+  // where that difference is spelled out. It is the app's custom Tooltip (350ms), not the native
+  // `title` (whose ~1.5s OS delay read as "no tooltip at all" on device).
+  it('explains the icon controls with the custom tooltip, not a native title', () => {
+    vi.useFakeTimers()
+    try {
+      render()
+      click(button('canvas.undo', 'Disable Undo')!)
+      const controls = [
+        button('app.commandPalette', 'Record Command palette')!,
+        button('app.commandPalette', 'Add a shortcut to Command palette')!,
+        button('app.commandPalette', 'Disable Command palette')!,
+        button('canvas.undo', 'Reset Undo')!
+      ]
+      for (const el of controls) expect(el.getAttribute('title')).toBeNull()
+      const add = controls[1]
+      act(() => {
+        add.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+      })
+      act(() => {
+        vi.advanceTimersByTime(400)
+      })
+      expect(document.body.textContent).toContain('Add another shortcut')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   // Record and Add sit side by side in the same hover-revealed cluster with no text, so two
   // identical keycaps would leave the pair unreadable — the icon is the whole label.
   it('gives Add a different glyph than Record', () => {

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -62,6 +62,7 @@ import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
 import { ShortcutRecorderButton } from '../ShortcutRecorderButton'
 import { IconDisableSlash, IconPlusSmall, IconResetArrow } from '../ShortcutRowIcons'
+import { Tooltip } from '../../Tooltip'
 import { Input } from '@renderer/ui/Input'
 import { SegmentedPill } from '@renderer/ui/SegmentedPill'
 import { useSettingsSearch } from '../context'
@@ -527,11 +528,15 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
             {/* Hidden until the row is hovered so a 21-row list reads as chords, not as a wall of
                 buttons — `focus-within` is the keyboard user's door to the same controls. */}
             <div className="flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/row:opacity-100">
+              {/* Tooltips say what the glyphs cannot: Record REPLACES the current shortcut,
+                  Add records ANOTHER one beside it. Native `title` is not used here — it takes
+                  the OS's ~1.5s delay and reads as no tooltip at all. */}
               <ShortcutRecorderButton
                 commandId={def.id}
                 appearance="icon"
                 idleLabel={bound ? 'Record' : 'Record shortcut'}
                 label={bound ? `Record ${def.title}` : `Record shortcut for ${def.title}`}
+                tooltip={bound ? 'Replace shortcut' : 'Record a shortcut'}
                 onCommit={(combo) => apply(def.id, combo, 'replace')}
               />
               {bound && !single ? (
@@ -540,6 +545,7 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
                   appearance="icon"
                   idleLabel="Add"
                   label={`Add a shortcut to ${def.title}`}
+                  tooltip="Add another shortcut"
                   // Record sits immediately to its left in the same label-less cluster; the
                   // glyph is the only thing telling the two apart.
                   idleIcon={<IconPlusSmall />}
@@ -547,26 +553,28 @@ export function ShortcutsSection({ isActive }: { isActive: boolean }): React.JSX
                 />
               ) : null}
               {bound ? (
-                <button
-                  type="button"
-                  className={ICON_BUTTON}
-                  aria-label={`Disable ${def.title}`}
-                  title={`Disable ${def.title}`}
-                  onClick={() => write(def.id, [])}
-                >
-                  <IconDisableSlash />
-                </button>
+                <Tooltip label="Disable shortcut">
+                  <button
+                    type="button"
+                    className={ICON_BUTTON}
+                    aria-label={`Disable ${def.title}`}
+                    onClick={() => write(def.id, [])}
+                  >
+                    <IconDisableSlash />
+                  </button>
+                </Tooltip>
               ) : null}
               {status.modified ? (
-                <button
-                  type="button"
-                  className={ICON_BUTTON}
-                  aria-label={`Reset ${def.title}`}
-                  title={`Reset ${def.title}`}
-                  onClick={() => write(def.id, null)}
-                >
-                  <IconResetArrow />
-                </button>
+                <Tooltip label="Reset to default">
+                  <button
+                    type="button"
+                    className={ICON_BUTTON}
+                    aria-label={`Reset ${def.title}`}
+                    onClick={() => write(def.id, null)}
+                  >
+                    <IconResetArrow />
+                  </button>
+                </Tooltip>
               ) : null}
             </div>
           </div>


### PR DESCRIPTION
## Why

Device feedback on #344/#355: the three hover-revealed icon controls read as unlabeled mystery buttons — the glyphs cannot express that **Record replaces** the current shortcut while **Add records another one beside it**, and the native `title` they carried takes the OS's ~1.5s hover delay, which in practice reads as *no tooltip at all*.

## What changed

- The four icon controls now use the app's existing custom `Tooltip` (350ms, styled, same as Dock/TabBar): **Record** → "Replace shortcut" ("Record a shortcut" when unbound), **Add** → "Add another shortcut", **Disable** → "Disable shortcut", **Reset** → "Reset to default". While a recorder is armed its tooltip switches to "Press the new shortcut · Esc cancels".
- Native `title` attributes are removed from these controls so one hover never produces two tooltips.
- `ShortcutRecorderButton` gained a presentational `tooltip` prop; the wrapper applies only to the icon appearance and is decided per instance, so it can never remount a mid-capture button. Capture logic, handlers and `aria-label`s are untouched.
- Test: pins no-native-title on all four controls and drives the custom tooltip via fake timers (hover → "Add another shortcut" in the portal).

8344 tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)