### PR TITLE
feat(terminal): crisp text when zoomed in — hand the canvas back to the DOM renderer past 175%

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -64,6 +64,7 @@ import {
 import { terminalKey } from '../terminal/terminal-config'
 import {
   setWebglGesture,
+  setWebglZoom,
   releaseAllHiddenGrants,
   WEBGL_GESTURE_SETTLE_MS
 } from '../terminal/webgl-budget'
@@ -1852,6 +1853,10 @@ export function Canvas() {
       setViewport(project.viewport)
       setZoomPct(Math.round(project.viewport.zoom * 100))
       setGroupLabelBoost(project.viewport.zoom)
+      // A project can load already zoomed IN past the crisp threshold (saved viewport) — seed the
+      // gate before the mount-time IntersectionObserver reports make every node request a context
+      // it would only have to give back.
+      setWebglZoom(project.viewport.zoom)
       // Seed the shared glyph camera from the same viewport: `onMove` only fires once the user
       // actually pans, so without this a project that loads scrolled away would draw its grids
       // against the previous project's camera until the first gesture.
@@ -6072,6 +6077,10 @@ export function Canvas() {
           zoomRafRef.current = null
           setZoomPct(Math.round(viewportRef.current.zoom * 100))
           setGroupLabelBoost(viewportRef.current.zoom)
+          // Feed the crisp gate (GPU text is a magnified bitmap past ~175%; the DOM renderer
+          // re-rasters and stays sharp). Idempotent + hysteresis inside, and the swaps it queues
+          // only run once the gesture settles — per-frame cost here is a float compare.
+          setWebglZoom(viewportRef.current.zoom)
         })
       }
     },

--- a/src/renderer/terminal/webgl-budget.test.ts
+++ b/src/renderer/terminal/webgl-budget.test.ts
@@ -8,7 +8,10 @@ import {
   setWebglBudget,
   setWebglEnabled,
   setWebglGesture,
+  setWebglZoom,
   WEBGL_ACQUIRE_DEBOUNCE_MS,
+  WEBGL_CRISP_ABOVE_ZOOM,
+  WEBGL_GPU_RESUME_BELOW_ZOOM,
   WEBGL_DRAIN_MS,
   WEBGL_SWAPS_PER_DRAIN,
   WEBGL_BUDGET,
@@ -351,6 +354,89 @@ describe('webgl-budget coordinator', () => {
     expect(getWebglBudget()).toBe(20)
     __resetWebglBudgetForTests()
     expect(getWebglBudget()).toBe(WEBGL_BUDGET)
+  })
+
+  describe('crisp gate (GPU text is a magnified bitmap when zoomed in)', () => {
+    /** Zoom past the threshold and let the rest-time drain run. */
+    const zoomTo = (zoom: number): void => {
+      setWebglZoom(zoom)
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 10)
+    }
+
+    it('crossing above the threshold gives every context back — including VISIBLE holders', () => {
+      const a = fakeClient('a')
+      const b = fakeClient('b')
+      grant(a)
+      grant(b)
+      expect(a.rec.held && b.rec.held).toBe(true)
+      zoomTo(WEBGL_CRISP_ABOVE_ZOOM + 0.01)
+      // The visible-holder exemption every other release path honours is deliberately waived
+      // here: the terminal the user zoomed into is exactly the one that must go crisp.
+      expect(a.rec.held).toBe(false)
+      expect(b.rec.held).toBe(false)
+    })
+
+    it('blocks grants while zoomed in, and re-grants visible clients on the way back', () => {
+      const a = fakeClient('a')
+      zoomTo(WEBGL_CRISP_ABOVE_ZOOM + 0.01)
+      grant(a)
+      expect(a.rec.acquires).toBe(0)
+      zoomTo(WEBGL_GPU_RESUME_BELOW_ZOOM - 0.01)
+      expect(a.rec.held).toBe(true)
+    })
+
+    it('hysteresis: hovering between the two thresholds never churns a context', () => {
+      const a = fakeClient('a')
+      grant(a)
+      zoomTo(WEBGL_CRISP_ABOVE_ZOOM + 0.01)
+      expect(a.rec.releases).toBe(1)
+      // Back into the band, but not under the resume threshold: still crisp, no re-grant…
+      zoomTo(WEBGL_CRISP_ABOVE_ZOOM - 0.05)
+      expect(a.rec.acquires).toBe(1)
+      // …and back up again costs nothing either.
+      zoomTo(WEBGL_CRISP_ABOVE_ZOOM + 0.05)
+      expect(a.rec.releases).toBe(1)
+    })
+
+    it('swaps NOTHING mid-gesture, then trickles once the canvas is at rest', () => {
+      const clients = ['a', 'b', 'c'].map((id) => fakeClient(id))
+      clients.forEach(grant)
+      setWebglGesture(true)
+      setWebglZoom(WEBGL_CRISP_ABOVE_ZOOM + 0.01)
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(clients.every((c) => c.rec.held)).toBe(true) // a zoom gesture is still running
+      setWebglGesture(false)
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(clients.every((c) => !c.rec.held)).toBe(true)
+    })
+
+    it('a dip below the threshold before the drain runs keeps the context warm', () => {
+      const a = fakeClient('a')
+      grant(a)
+      setWebglGesture(true) // parks the release
+      setWebglZoom(WEBGL_CRISP_ABOVE_ZOOM + 0.01)
+      setWebglZoom(WEBGL_GPU_RESUME_BELOW_ZOOM - 0.01) // zoomed back out before rest
+      setWebglGesture(false)
+      vi.advanceTimersByTime(WEBGL_DRAIN_MS * 5)
+      expect(a.rec.releases).toBe(0)
+      expect(a.rec.acquires).toBe(1)
+    })
+
+    it('the way back respects the master switch: disabled stays DOM-only', () => {
+      const a = fakeClient('a')
+      grant(a)
+      zoomTo(WEBGL_CRISP_ABOVE_ZOOM + 0.01)
+      setWebglEnabled(false)
+      zoomTo(WEBGL_GPU_RESUME_BELOW_ZOOM - 0.01)
+      expect(a.rec.acquires).toBe(1)
+    })
+
+    it('ignores non-finite zoom values', () => {
+      const a = fakeClient('a')
+      grant(a)
+      zoomTo(Number.NaN)
+      expect(a.rec.held).toBe(true)
+    })
   })
 
   describe('gesture latch (no swaps mid-gesture, staggered drain at rest)', () => {

--- a/src/renderer/terminal/webgl-budget.ts
+++ b/src/renderer/terminal/webgl-budget.ts
@@ -107,6 +107,81 @@ export function getWebglBudget(): number {
 }
 
 /**
+ * THE CRISP GATE — above this canvas zoom the coordinator holds NO contexts, and every terminal
+ * paints through xterm's DOM renderer instead.
+ *
+ * A GPU terminal is a BITMAP: the addon rasterizes into a canvas sized from the element's LAYOUT
+ * box in device pixels, and React Flow's `transform: scale()` then magnifies that bitmap. xterm
+ * never learns about the zoom — its sizing observer reads `devicePixelContentBoxSize`, which
+ * ignores transforms — so zooming in makes GPU text softer and dimmer, while the DOM renderer's
+ * text is re-rastered by the browser at the composited scale and gets SHARPER. Measured on one
+ * node with identical content (share of ink pixels sitting mid-ramp between background and peak;
+ * higher = blurrier):
+ *
+ *              100%     200%    peak glyph luminance at 200%
+ *   webgl      55.7% →  62.7%   226 → 194
+ *   dom        60.3% →  36.8%   226 → 226
+ *
+ * Raising the terminal's effective device-pixel ratio with the zoom was tried first and does not
+ * work from outside the addon: three variants (dpr override; + pinning the backing store; +
+ * re-running the renderer resize) all left the terminal drawing almost nothing, because the
+ * renderer assumes throughout that its canvas is at true device resolution. Swapping renderers is
+ * what remains, and it is affordable exactly where it is needed: at this zoom only one or two
+ * terminals fit on screen, so the swap is a couple of nodes, not a canvas-wide rebalance.
+ *
+ * This is deliberately the INVERSE of the zoom gate removed in the budget-only lifecycle change,
+ * and it is not that gate returning: that one suspended the GPU when zoomed OUT past 40% on a
+ * compositor theory that was later refuted, and it cost half-second stalls on a band users cross
+ * constantly. This one triggers only when someone zooms IN past 175% — a deliberate "let me read
+ * this" gesture — and the release it performs is the cheap direction (teardown, no shader compile
+ * or atlas build).
+ */
+export const WEBGL_CRISP_ABOVE_ZOOM = 1.75
+/** Resume threshold, BELOW the crisp threshold on purpose (hysteresis): a pinch hovering at one
+ *  boundary must not thrash swap cycles — renderer churn is its own hazard. */
+export const WEBGL_GPU_RESUME_BELOW_ZOOM = 1.6
+
+/** True while the canvas is zoomed past the crisp threshold — grants are blocked. */
+let zoomCrisp = false
+
+/**
+ * Report the canvas zoom (React Flow viewport scale). Cheap and idempotent — call it from the
+ * zoom/pan handler; state only changes when a hysteresis boundary is crossed. Crossing UP marks
+ * every held context release-OWED and drains; crossing DOWN forgives owed releases still held
+ * (kept warm through a brief overshoot) and queues budget-gated grants for visible clients. Both
+ * directions go through `owed`/`drain`, so nothing swaps mid-gesture and a multi-node crossing
+ * trickles.
+ */
+export function setWebglZoom(zoom: number): void {
+  if (!Number.isFinite(zoom)) return
+  const next = zoomCrisp ? zoom > WEBGL_GPU_RESUME_BELOW_ZOOM : zoom > WEBGL_CRISP_ABOVE_ZOOM
+  if (next === zoomCrisp) return
+  zoomCrisp = next
+  if (zoomCrisp) {
+    for (const c of clients.values()) {
+      cancelAcquire(c)
+      if (c.granted) {
+        c.releaseOwed = true
+        owed.add(c)
+      }
+    }
+    drain()
+    return
+  }
+  if (!enabled) return
+  for (const c of clients.values()) {
+    // Zoomed back in under the threshold before the drain got to this client: keep the context,
+    // releasing and re-granting it back to back is the churn this design forbids.
+    if (c.granted && c.releaseOwed) c.releaseOwed = false
+    if (c.visible && !c.granted) {
+      c.releaseOwed = false
+      owed.add(c)
+    }
+  }
+  drain()
+}
+
+/**
  * THE GESTURE LATCH — the load-bearing rule of this coordinator: renderer swaps NEVER run
  * while the user is panning/zooming.
  *
@@ -166,7 +241,7 @@ function drain(): void {
       c.releaseOwed = false
       // Only release if the reason still holds — a client that came back (visible again, zoom
       // resumed) keeps its warm context instead of paying a release+re-grant round trip.
-      if (c.granted && (!c.visible || !enabled)) {
+      if (c.granted && (zoomCrisp || !c.visible || !enabled)) {
         reclaim(c)
         ops++
       }
@@ -355,6 +430,8 @@ function tryGrant(c: Client): void {
   if (!clients.has(c.id) || !c.visible || c.granted) return
   // Master switch off → never grant; every terminal stays on the DOM renderer.
   if (!enabled) return
+  // Zoomed in past the crisp threshold → never grant (see setWebglZoom).
+  if (zoomCrisp) return
   // Mid-gesture → park the attempt; the rest-time drain re-runs it (see the gesture latch).
   if (gestureActive) {
     c.releaseOwed = false
@@ -491,6 +568,7 @@ export function __resetWebglBudgetForTests(): void {
   visibilityClock = 0
   budget = WEBGL_BUDGET
   enabled = true
+  zoomCrisp = false
   gestureActive = false
   owed.clear()
   if (drainTimer) {


### PR DESCRIPTION
## The report

> "it's pretty blurry if i zoom into it and scaling" — in `auto` mode.

## Why it happens

A GPU terminal is a **bitmap**. The addon rasterizes into a canvas sized from the element's *layout* box in device pixels, and React Flow's `transform: scale()` then magnifies that bitmap. xterm never learns about the zoom — its sizing observer reads `devicePixelContentBoxSize`, which ignores transforms. The DOM renderer draws real text, which the browser re-rasters at the composited scale, so it goes the other way.

Measured on one node with identical content (share of ink pixels sitting mid-ramp between background and peak — higher = blurrier):

| renderer | 100% | 200% | peak glyph luminance @200% |
| --- | --- | --- | --- |
| webgl | 55.7% | **62.7%** | 226 → **194** |
| shared | 71.9% | 65.2% | 230 → **151** |
| dom | 60.3% | **36.8%** | 226 → 226 |

**The obvious fix does not work.** Raising the terminal's effective device-pixel ratio with the zoom was tried first, in three variants — dpr override; + pinning the backing store; + re-running the renderer resize — and each left the terminal drawing almost nothing (peak 194 → **45**), because the renderer assumes throughout that its canvas is at true device resolution. Making that path work means maintaining a patched copy of the addon's sizing logic, not a guarded poke.

## The change

Past **175%** the coordinator holds no contexts and terminals paint through xterm's DOM renderer; below **160%** (hysteresis) the GPU comes back. Both directions ride the existing `owed`/drain queue, so nothing swaps mid-gesture and a multi-node crossing trickles.

This is deliberately the *inverse* of the zoom gate removed in #179, and it is not that gate returning: that one suspended the GPU when zoomed **out** past 40% on a compositor theory later refuted in #173, and it cost half-second stalls on a band users cross constantly. This one fires only when someone zooms **in** past 175% — a deliberate "let me read this" gesture — where one or two terminals fit on screen, and the release it performs is the cheap direction (teardown; no shader compile, no atlas build).

## Verification

| Check | Result |
| --- | --- |
| typecheck + full suite | green (8350 passed on the merged base) |
| new coordinator cases | 7: release incl. **visible** holders, grants blocked while zoomed, hysteresis, mid-gesture deferral, a dip before the drain keeping the context warm, master switch, non-finite input |
| mutation check | deleting the grant block fails exactly the grant test; collapsing the two thresholds fails exactly the hysteresis test |
| E2E on the built app | 100% stays `webgl` @55.7% softness; 200% becomes `dom` @36.8%, peak luminance back to 226 |

## Known coverage limit (it decides the constant)

The canvas caps at `maxZoom={2}`, so **175% covers a single reachable step**. Measured softness at the intermediate steps is *worse* than at 200% — 120%: 71.4%, 144%: 72.4%, 173%: 70.9% (non-integer scale factors resample worst). If the field wants those crisp too, `WEBGL_CRISP_ABOVE_ZOOM` moves to ~1.2 and nothing else changes. Shipping at 175% first, by request, to look at the mechanism on a device before widening the band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)