### PR TITLE
feat(control): the open-project grant ledger and targeting gate (inert)

### DIFF
--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -175,11 +175,22 @@ export interface HookEventMeta {
  * protect — the routes are new — which is the one place in the whole control surface where
  * fail-closed from day one costs nobody anything.
  *
+ * `open-project` (issue #338) is here for the same class of reason as `sticky`: the main-side
+ * grant ledger (src/main/project-grants.ts) mints per-caller targeting rights off a successful
+ * `open-project`, and a grant recorded for an unverifiable caller would authorize whoever can
+ * name that caller's node id. NEW verb, so fail-closed from day one strands nobody.
+ *
  * Consulted in the `/control/` route BEFORE `identityGate`'s decision is, so no future change to
  * the policy table can widen it; `messaging-verified-only.test.ts` drives the route on both sides
  * of every hatch and is the test that fails if either half of this comment stops being true.
  */
-export const requiresVerified: ReadonlySet<string> = new Set(['send', 'reply', 'notify', 'sticky'])
+export const requiresVerified: ReadonlySet<string> = new Set([
+  'send',
+  'reply',
+  'notify',
+  'sticky',
+  'open-project'
+])
 
 /**
  * The refusal for a messaging verb: one sentence, no diagnosis, no hint about tokens or restarts —
@@ -192,9 +203,15 @@ export const MESSAGING_CONTROL_REFUSAL = 'Agent messaging refused.'
  *  because "agent messaging refused" answering a note write is a diagnosis-delaying lie. */
 export const STICKY_CONTROL_REFUSAL = 'Sticky write refused.'
 
+/** Same posture again for `open-project` (issue #338): one sentence naming what was refused, no
+ *  diagnosis, no token or restart advice — a designed refusal, not a rollout accident. */
+export const OPEN_PROJECT_CONTROL_REFUSAL = 'Project open refused.'
+
 /** The verified-only refusal, worded for the verb that was refused. */
 export function verifiedRefusalFor(verb: string): string {
-  return verb === 'sticky' ? STICKY_CONTROL_REFUSAL : MESSAGING_CONTROL_REFUSAL
+  if (verb === 'sticky') return STICKY_CONTROL_REFUSAL
+  if (verb === 'open-project') return OPEN_PROJECT_CONTROL_REFUSAL
+  return MESSAGING_CONTROL_REFUSAL
 }
 
 class HookServer {

--- a/src/core/agents/messaging-verified-only.test.ts
+++ b/src/core/agents/messaging-verified-only.test.ts
@@ -112,7 +112,7 @@ describe('send/reply require `verified` — and controlPolicy is NOT the decider
     // from day one — there is no upgrade population to protect.
     hookServer.clearNodeAuthSecretForTests()
     try {
-      for (const verb of ['send', 'reply'] as const) {
+      for (const verb of ['send', 'reply', 'open-project'] as const) {
         const res = await post(verb, 'n-src')
         expect(res.status, verb).toBe(403)
       }
@@ -137,14 +137,31 @@ describe('where the verbs sit in the routing tables', () => {
     }
   })
 
-  it('the verified-only set is exactly the messaging verbs plus sticky', () => {
+  it('the verified-only set is exactly the messaging verbs plus sticky plus open-project', () => {
     // Pins that nothing ELSE ever drifts in: adding a SHIPPED verb here would strand its legacy
     // population with no hatch, which is the one thing this set must never be casually grown by.
     // `notify` (folded in from #98, Task 5.2) is a messaging verb like the other two — it writes
     // into another agent's pane — so it takes the same gate. `sticky` (issue #144) is here
     // because its "↻ <agent> · when" stamp replaces the confirm dialog, and a byline any
     // bearer-holder could forge would be worse than no byline; it shipped verified-only from
-    // day one, so no legacy population is stranded.
-    expect([...requiresVerified].sort()).toEqual(['notify', 'reply', 'send', 'sticky'])
+    // day one, so no legacy population is stranded. `open-project` (issue #338) is here because
+    // the grant ledger binds targeting rights to the verified caller identity — a grant minted
+    // for a forgeable caller would authorize whoever forged it; new verb, so fail-closed from
+    // day one strands nobody.
+    expect([...requiresVerified].sort()).toEqual([
+      'notify',
+      'open-project',
+      'reply',
+      'send',
+      'sticky'
+    ])
+  })
+
+  it('the open-project refusal is its own flat sentence, not the messaging one', () => {
+    // "Agent messaging refused." answering a project open would be a diagnosis-delaying lie —
+    // the same argument that gave sticky its own sentence. Same posture: one sentence, no
+    // token/restart advice.
+    expect(verifiedRefusalFor('open-project')).toBe('Project open refused.')
+    expect(verifiedRefusalFor('open-project')).not.toBe(MESSAGING_CONTROL_REFUSAL)
   })
 })

--- a/src/core/workspace-store.test.ts
+++ b/src/core/workspace-store.test.ts
@@ -1764,3 +1764,36 @@ describe('the shared project file carries content, not machine identity', () => 
     expect(await fs.readFile(path.join(otherRoot, '.nodeterm/project.json'), 'utf-8')).toBe(bytes)
   })
 })
+
+describe('projectMetaFor (issue #338 PR 1) — target exists / is SSH, from the store alone', () => {
+  // The --project targeting gate (src/main/project-grants.ts) learns "does this project exist,
+  // and is it SSH" from main's OWN store — never from anything the caller sent. Same three
+  // entry kinds as persistedCanvases: inline (e.project), ssh (e.ssh), local ref (e.cwd).
+  it('answers for all three entry kinds and undefined for an unknown id', async () => {
+    const store = new WorkspaceStore()
+    const local = project({ id: 'p-local', cwd: projRoot })
+    const inline = project({ id: 'p-inline', cwd: undefined })
+    const ssh = project({
+      id: 'p-ssh',
+      cwd: undefined,
+      ssh: { server: { host: 'h', user: 'u' }, remoteCwd: '/srv/app' }
+    })
+    await store.save(ws([local, inline, ssh]))
+
+    expect(store.projectMetaFor('p-local')).toEqual({ ssh: false })
+    expect(store.projectMetaFor('p-inline')).toEqual({ ssh: false })
+    expect(store.projectMetaFor('p-ssh')).toEqual({ ssh: true })
+    // Fail closed: an id the store does not know (deleted, invented, another machine's) has no
+    // meta at all — the gate refuses on undefined.
+    expect(store.projectMetaFor('p-gone')).toBeUndefined()
+    expect(store.projectMetaFor('')).toBeUndefined()
+  })
+
+  it('a deleted project stops answering after the save that removed it', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ id: 'p-a', cwd: projRoot }), project({ id: 'p-b', cwd: undefined })]))
+    expect(store.projectMetaFor('p-b')).toEqual({ ssh: false })
+    await store.save(ws([project({ id: 'p-a', cwd: projRoot })]))
+    expect(store.projectMetaFor('p-b')).toBeUndefined()
+  })
+})

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -1145,6 +1145,26 @@ export class WorkspaceStore {
   }
 
   /**
+   * Does this project exist on THIS machine, and is it SSH? The `--project` targeting gate
+   * (issue #338, src/main/project-grants.ts) asks main's own store — never the request — before
+   * any targeted open is forwarded. Same three-entry-kind scan and same id semantics as
+   * `persistedCanvases` (inline keyed by `e.project.id`, ssh/local refs by `e.id`), because the
+   * projectId a grant names there must resolve to the same project here. `undefined` = unknown
+   * to this store (deleted, invented, another machine's) — the gate fails closed on it.
+   */
+  projectMetaFor(projectId: string): { ssh: boolean } | undefined {
+    if (!projectId) return undefined
+    for (const e of this.index?.entries ?? []) {
+      if (e.project) {
+        if (e.project.id === projectId) return { ssh: !!e.project.ssh }
+        continue
+      }
+      if (e.id === projectId) return { ssh: !!e.ssh }
+    }
+    return undefined
+  }
+
+  /**
    * The capability view of one project, for `projectCapabilityGrantedFor`: the STRICT capability
    * flags from the shared file (`readProjectCapabilities` — literal `true`, known keys only) plus
    * this machine's recorded answers from the INDEX ENTRY. Same three-entry-kind scan and same id

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -26,6 +26,25 @@ describe('parseControlRequest', () => {
     expect(parseControlRequest('nuke', {})).toEqual({ error: 'Unknown verb: nuke' })
   })
 
+  it('open-project requires --cwd (issue #338, PR 1)', () => {
+    expect(parseControlRequest('open-project', {})).toEqual({
+      error: 'open-project requires --cwd <abs-path>'
+    })
+    expect(parseControlRequest('open-project', { cwd: '/tmp/repo' })).toEqual({
+      verb: 'open-project',
+      args: { cwd: '/tmp/repo' }
+    })
+  })
+
+  it('open-project is NOT in DESTRUCTIVE_VERBS yet — that membership lands with PR 2', () => {
+    // Deliberate PR slicing, not an oversight: `control-destructive.test.ts` structurally
+    // requires every member's `Canvas.tsx` case to read `isDestructiveVerb(verb)`, and the
+    // dispatch case for open-project only exists in PR 2 (Task 2.2). Adding the verb to the set
+    // now would trip the set↔dispatch drift alarm with no dispatch to agree with. This test goes
+    // red the moment PR 2 adds the membership, which is the reminder to delete it.
+    expect(isDestructiveVerb('open-project')).toBe(false)
+  })
+
   it('requires a target for write/close', () => {
     expect(parseControlRequest('close', {})).toEqual({ error: 'close requires --node <id>' })
     expect(parseControlRequest('write', { node: 'n1' })).toEqual({ error: 'write requires --text' })

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -120,6 +120,7 @@ export type ControlVerb =
   | 'notify'
   | 'sticky'
   | 'browser'
+  | 'open-project'
 
 export interface ControlCommand {
   verb: ControlVerb
@@ -155,7 +156,12 @@ const VERBS: ControlVerb[] = [
   'reply',
   'notify',
   'sticky',
-  'browser'
+  'browser',
+  // Issue #338 PR 1: registered in the model (parse + gates + the grant ledger run in main), but
+  // INERT until PR 2 adds the renderer dispatch case — today the renderer's `default:` answers
+  // `unknown verb: open-project`. Deliberately undocumented in the skill/instructions bodies until
+  // PR 2 makes it do something (spec §8: docs land in the same PR that makes the verb reachable).
+  'open-project'
 ]
 
 /**
@@ -226,6 +232,11 @@ export function parseControlRequest(
   // enforced in hook-server before it ever reaches a handler) and refused by name on the Server
   // Edition (control-unsupported-on-this-edition), where there is no webview to drive.
   if (v === 'browser' && !args.node) return { error: 'browser: --node <id> is required' }
+  // `open-project` requires a cwd; everything else about the argument (absolute, exists, is a
+  // directory, resolved once) is validated in MAIN by `validateOpenProjectCwd`
+  // (src/main/project-grants.ts) — the caller's path is hostile input and this presence check is
+  // only the polite half.
+  if (v === 'open-project' && !args.cwd) return { error: 'open-project requires --cwd <abs-path>' }
   return { verb: v, args }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,18 @@ import { writeFilesToClipboard } from './clipboard-files'
 import { pickProjectIcon } from './project-icon-upload'
 import { allowGuestNavigation } from './webview-nav'
 import { BrowserControlLedger } from './browser-control-ledger'
+import {
+  grant as grantProjectTo,
+  isGranted as projectGrantedTo,
+  atCap as projectGrantsAtCap,
+  clearCaller as clearProjectGrants,
+  gateProjectTarget,
+  validateOpenProjectCwd,
+  PROJECT_TARGETABLE_VERBS,
+  OPEN_PROJECT_LOCAL_ONLY,
+  OPEN_PROJECT_GRANT_CAP,
+  OPEN_PROJECT_CALLER_UNRESOLVED
+} from './project-grants'
 import { BrowserLeaseManager, BrowserSession } from './browser-lease'
 import { CdpEventBus, type Sendable } from './browser-actions'
 import { RefTable } from './browser-refs'
@@ -91,7 +103,7 @@ import {
 import { generateCommitMessage, generateGroupName, generateTerminalName } from '../core/commit-message'
 import { initUpdater } from './updater'
 import { fetchCheck } from '../core/check'
-import { hookServer } from '../core/agents/hook-server'
+import { hookServer, OPEN_PROJECT_CONTROL_REFUSAL } from '../core/agents/hook-server'
 import { askpassServer, ensureAskpassScript } from './remote-ssh/ssh-askpass'
 import { appSshAgent } from './remote-ssh/ssh-agent'
 import {
@@ -2916,6 +2928,12 @@ app.whenReady().then(async () => {
   corePlatform.on(IPC.ptyRecycle, (nodeId: string) =>
     pushBrowserLeases(revokeBrowserByOwner(nodeId, browserRevocation))
   )
+  // The caller's PROJECT GRANTS die with its node too (issue #338, spec P3) — same teardown
+  // anchor, same reasoning as the browser leases above: a grant is consent given to a running
+  // session, and a recycle mints a fresh identity that must re-earn its targeting rights via
+  // open-project. App restart clears the whole in-memory ledger by construction.
+  corePlatform.on(IPC.ptyDestroy, (nodeId: string) => clearProjectGrants(nodeId))
+  corePlatform.on(IPC.ptyRecycle, (nodeId: string) => clearProjectGrants(nodeId))
   // App quit: detach every debugger lease. A second `before-quit` listener alongside the module-
   // level flush one (both fire); scoped here so it can reach `browserRevocation`. No push — the
   // window is going away. LIFECYCLE, so no tombstone (the in-memory ledger is gone on quit anyway).
@@ -3028,11 +3046,52 @@ app.whenReady().then(async () => {
       ? { ok: true, message: result.message }
       : { ok: false, error: result.message, message: result.message }
   }
+  // The caller's OWNING project, by node membership in main's own persisted store — the same
+  // source `resolveDeliveryScope` trusts. `undefined` = not in any saved project (a brand-new
+  // node inside the save debounce, or an id main never saved): the project gates fail closed.
+  const projectIdOfNode = (id: string): string | undefined =>
+    workspaceStore.persistedCanvases().find((c) => c.nodes.some((n) => n.id === id))?.id
   hookServer.setControlHandler(async ({ verb, nodeId, args, verified }) => {
     // `browser` is answered in MAIN and never forwarded to the renderer's agent-control dispatch:
     // the debugger handle and the CDP allowlist are main-side, and the renderer is the more
     // attackable half. Every other verb still round-trips to the renderer below.
     if (verb === 'browser') return handleBrowserVerb(nodeId, args, verified)
+    // ── `open-project` + `--project` targeting, gated in MAIN before anything is forwarded
+    // (issue #338 PR 1). The renderer never sees an invalid cwd or an unauthorized `--project`.
+    // The verb itself is verified-only at the hook-server route (requiresVerified) — by the time
+    // an open-project reaches this wrapper, `verified` is true; the gates below are main's own
+    // belt plus everything identity cannot answer (SSH caller, cwd validity, the grant cap).
+    if (verb === 'open-project') {
+      const refuse = (error: string) => ({ ok: false, error, message: error })
+      if (!verified) return refuse(OPEN_PROJECT_CONTROL_REFUSAL)
+      const callerProjectId = projectIdOfNode(nodeId)
+      if (!callerProjectId) return refuse(OPEN_PROJECT_CALLER_UNRESOLVED)
+      if (workspaceStore.projectMetaFor(callerProjectId)?.ssh) {
+        // B5: local-only v1 — an SSH-project agent's --cwd would be a host path.
+        return refuse(OPEN_PROJECT_LOCAL_ONLY)
+      }
+      // Refuse the cap BEFORE the renderer would show a dialog (PR 2): a grant that cannot be
+      // recorded must not be consented to first.
+      if (projectGrantsAtCap(nodeId)) return refuse(OPEN_PROJECT_GRANT_CAP)
+      const cwd = validateOpenProjectCwd(args.cwd ?? '', (p) => statSync(p))
+      if ('error' in cwd) return refuse(cwd.error)
+      // The RESOLVED path — never the raw argument — is what the renderer (PR 2's dialog, the
+      // dedupe, the store) sees. Single resolution, in main, right here.
+      args = { ...args, cwd: cwd.resolved }
+    } else if (PROJECT_TARGETABLE_VERBS.has(verb) && args.project !== undefined) {
+      // Open verbs carrying `--project`: own-or-granted only (spec §3, P2), decided against
+      // main's own store + ledger. Anything else is refused without forwarding.
+      const meta = workspaceStore.projectMetaFor(args.project)
+      const gate = gateProjectTarget({
+        verified,
+        verb,
+        targetProjectId: args.project,
+        callerProjectId: projectIdOfNode(nodeId),
+        targetIsSsh: meta?.ssh,
+        granted: projectGrantedTo(nodeId, args.project)
+      })
+      if (gate !== 'allow') return { ok: false, error: gate.refuse, message: gate.refuse }
+    }
     const target = getMainWindow()
     if (!target) return { ok: false, error: 'window unavailable' }
     const requestId = randomUUID()
@@ -3069,6 +3128,18 @@ app.whenReady().then(async () => {
         // A claim carries no live lease (a verb sets that in PR 7), so this does not light the chip;
         // it keeps the renderer's view consistent from the moment ownership exists.
         pushBrowserLeases()
+      }
+    }
+    // Record a project grant the moment an open-project succeeds — the open-browser ledger
+    // pattern above, same conditions: ONLY when the caller's identity verdict for THIS request
+    // was `verified` (main's own verdict, never anything off the wire) AND the renderer's reply
+    // carries a non-empty projectId. Inert until PR 2: today the renderer's `default:` case
+    // answers `unknown verb: open-project` with ok: false, so nothing is ever recorded — but the
+    // record path ships fail-closed and finished, not stubbed.
+    if (verb === 'open-project' && verified && result.ok) {
+      const opened = result.result as { projectId?: unknown } | undefined
+      if (typeof opened?.projectId === 'string' && opened.projectId) {
+        grantProjectTo(nodeId, opened.projectId)
       }
     }
     return result

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,16 +18,14 @@ import { pickProjectIcon } from './project-icon-upload'
 import { allowGuestNavigation } from './webview-nav'
 import { BrowserControlLedger } from './browser-control-ledger'
 import {
-  grant as grantProjectTo,
+  recordOpenProjectGrant,
   isGranted as projectGrantedTo,
   atCap as projectGrantsAtCap,
   clearCaller as clearProjectGrants,
   gateProjectTarget,
-  validateOpenProjectCwd,
+  gateOpenProject,
   PROJECT_TARGETABLE_VERBS,
-  OPEN_PROJECT_LOCAL_ONLY,
-  OPEN_PROJECT_GRANT_CAP,
-  OPEN_PROJECT_CALLER_UNRESOLVED
+  OPEN_PROJECT_GRANT_CAP
 } from './project-grants'
 import { BrowserLeaseManager, BrowserSession } from './browser-lease'
 import { CdpEventBus, type Sendable } from './browser-actions'
@@ -3064,20 +3062,24 @@ app.whenReady().then(async () => {
     if (verb === 'open-project') {
       const refuse = (error: string) => ({ ok: false, error, message: error })
       if (!verified) return refuse(OPEN_PROJECT_CONTROL_REFUSAL)
+      // The rules themselves are the PURE gateOpenProject (project-grants.ts) — caller-unresolved
+      // fail-closed, SSH-caller local-only, cap-before-consent, cwd resolved once — proven
+      // red-capable branch by branch in project-grants.test.ts. This wrapper only feeds it main's
+      // own stores and returns its refusals unforwarded.
       const callerProjectId = projectIdOfNode(nodeId)
-      if (!callerProjectId) return refuse(OPEN_PROJECT_CALLER_UNRESOLVED)
-      if (workspaceStore.projectMetaFor(callerProjectId)?.ssh) {
-        // B5: local-only v1 — an SSH-project agent's --cwd would be a host path.
-        return refuse(OPEN_PROJECT_LOCAL_ONLY)
-      }
-      // Refuse the cap BEFORE the renderer would show a dialog (PR 2): a grant that cannot be
-      // recorded must not be consented to first.
-      if (projectGrantsAtCap(nodeId)) return refuse(OPEN_PROJECT_GRANT_CAP)
-      const cwd = validateOpenProjectCwd(args.cwd ?? '', (p) => statSync(p))
-      if ('error' in cwd) return refuse(cwd.error)
+      const gate = gateOpenProject({
+        callerProjectId,
+        callerIsSsh: callerProjectId
+          ? workspaceStore.projectMetaFor(callerProjectId)?.ssh
+          : undefined,
+        atCap: projectGrantsAtCap(nodeId),
+        rawCwd: args.cwd ?? '',
+        statFn: (p) => statSync(p)
+      })
+      if ('refuse' in gate) return refuse(gate.refuse)
       // The RESOLVED path — never the raw argument — is what the renderer (PR 2's dialog, the
       // dedupe, the store) sees. Single resolution, in main, right here.
-      args = { ...args, cwd: cwd.resolved }
+      args = { ...args, cwd: gate.resolvedCwd }
     } else if (PROJECT_TARGETABLE_VERBS.has(verb) && args.project !== undefined) {
       // Open verbs carrying `--project`: own-or-granted only (spec §3, P2), decided against
       // main's own store + ledger. Anything else is refused without forwarding.
@@ -3136,10 +3138,20 @@ app.whenReady().then(async () => {
     // carries a non-empty projectId. Inert until PR 2: today the renderer's `default:` case
     // answers `unknown verb: open-project` with ok: false, so nothing is ever recorded — but the
     // record path ships fail-closed and finished, not stubbed.
-    if (verb === 'open-project' && verified && result.ok) {
-      const opened = result.result as { projectId?: unknown } | undefined
-      if (typeof opened?.projectId === 'string' && opened.projectId) {
-        grantProjectTo(nodeId, opened.projectId)
+    if (verb === 'open-project') {
+      // The whole decision (verified && ok && string projectId → grant; cap race detection) is
+      // the PURE recordOpenProjectGrant — proven branch by branch in project-grants.test.ts.
+      // 'cap' = the pre-forward atCap() check passed but a concurrent open-project from the same
+      // caller filled the last slot while this one was in flight (PR #362 review, M1): the
+      // caller must NOT hear ok while holding no targeting right, so the named refusal replaces
+      // the success reply. Nothing is lost — open-project is idempotent (B1), so a re-run once
+      // grants have cleared returns the same project id and records the grant.
+      if (recordOpenProjectGrant(nodeId, result, verified) === 'cap') {
+        console.warn(
+          `[project-grants] grant cap raced for caller ${nodeId}: open-project succeeded but ` +
+            'the grant was not recorded; replying open-project-grant-cap'
+        )
+        return { ok: false, error: OPEN_PROJECT_GRANT_CAP, message: OPEN_PROJECT_GRANT_CAP }
       }
     }
     return result

--- a/src/main/project-grants.test.ts
+++ b/src/main/project-grants.test.ts
@@ -204,3 +204,50 @@ describe('validateOpenProjectCwd (P7) — resolved once, statted once, fails clo
     })
   })
 })
+
+describe('main wiring (structural) — the wrapper records, consumes and clears correctly', () => {
+  // Structural in the control-destructive.test.ts sense and for the same reason: the wiring lives
+  // inside index.ts's setControlHandler wrapper and whenReady closure, which have no unit seam,
+  // and the property pinned — WHEN a grant is recorded and WHEN it dies — is a property of the
+  // source. The behavioural halves (the ledger, the gate, the cwd rules) are proven above against
+  // the real functions.
+  const src = fs.readFileSync(path.join(__dirname, 'index.ts'), 'utf8')
+
+  it('records a grant ONLY under verified && result.ok with a string projectId (the open-browser pattern)', () => {
+    const at = src.indexOf("verb === 'open-project' && verified && result.ok")
+    expect(at).toBeGreaterThan(-1)
+    const block = src.slice(at, at + 400)
+    expect(block).toContain("typeof opened?.projectId === 'string'")
+    expect(block).toContain('grantProjectTo(nodeId, opened.projectId)')
+    // No other call site mints a grant: the record path is the wrapper's, once.
+    expect(src.match(/grantProjectTo\(/g)?.length).toBe(1)
+  })
+
+  it('consumes the ledger per-CALLER and gates before forwarding to the renderer', () => {
+    // The gate reads isGranted(nodeId, …) — the verified caller of THIS request — never a global
+    // or target-derived key, and it runs inside the wrapper before webContents.send.
+    expect(src).toMatch(/granted: projectGrantedTo\(nodeId, args\.project\)/)
+    const gateAt = src.indexOf('gateProjectTarget({')
+    const forwardAt = src.indexOf('target.webContents.send(IPC.agentControl', gateAt)
+    expect(gateAt).toBeGreaterThan(-1)
+    expect(forwardAt).toBeGreaterThan(gateAt)
+    // The target's SSH/existence meta comes from main's own store, never the request.
+    expect(src).toMatch(/workspaceStore\.projectMetaFor\(args\.project\)/)
+  })
+
+  it('clears a caller on BOTH pty teardown paths (destroy + recycle) — spec P3', () => {
+    expect(src).toMatch(
+      /corePlatform\.on\(IPC\.ptyDestroy, \(nodeId: string\) => clearProjectGrants\(nodeId\)\)/
+    )
+    expect(src).toMatch(
+      /corePlatform\.on\(IPC\.ptyRecycle, \(nodeId: string\) => clearProjectGrants\(nodeId\)\)/
+    )
+  })
+
+  it('open-project resolves + replaces the cwd in MAIN before forwarding (P7)', () => {
+    const at = src.indexOf('validateOpenProjectCwd(args.cwd')
+    expect(at).toBeGreaterThan(-1)
+    // The resolved form replaces the raw argument in the forwarded args.
+    expect(src.slice(at, at + 400)).toContain('args = { ...args, cwd: cwd.resolved }')
+  })
+})

--- a/src/main/project-grants.test.ts
+++ b/src/main/project-grants.test.ts
@@ -20,12 +20,17 @@ import {
   clearCaller,
   clearAll,
   gateProjectTarget,
+  gateOpenProject,
+  recordOpenProjectGrant,
   validateOpenProjectCwd,
   PROJECT_TARGETABLE_VERBS,
   PROJECT_TARGETING_REFUSAL,
   PROJECT_TARGET_REFUSED,
   PROJECT_TARGET_SSH_UNSUPPORTED,
-  OPEN_PROJECT_CWD_INVALID
+  OPEN_PROJECT_CWD_INVALID,
+  OPEN_PROJECT_LOCAL_ONLY,
+  OPEN_PROJECT_CALLER_UNRESOLVED,
+  OPEN_PROJECT_GRANT_CAP
 } from './project-grants'
 
 beforeEach(() => clearAll())
@@ -139,11 +144,41 @@ describe('gateProjectTarget (spec §3/§5) — every branch, fail closed', () =>
     ).toBe('allow')
   })
 
-  it('refuses an SSH target that is not the caller own project — even a (impossible) granted one', () => {
-    // Grants are only ever minted by local open-project, so a granted SSH id cannot exist; the
-    // SSH check running BEFORE the granted check is the belt for that invariant.
+  it('allows OWN even when the meta lookup misses — own-before-unknown (review M2)', () => {
+    // callerProjectId and the target meta derive from the same index scan, but if a rename
+    // mid-debounce ever staggered the two read paths, a legitimate `--project <own-id>` must not
+    // be spuriously refused as unknown. Still fail-closed: the id IS the caller's own project by
+    // main's own caller resolution.
+    expect(
+      gateProjectTarget({ ...base, targetProjectId: 'proj-own', targetIsSsh: undefined })
+    ).toBe('allow')
+  })
+
+  it('refuses every stranger id with byte-identical text — no existence OR kind oracle (review I3)', () => {
+    // unknown, real-local-ungranted and real-SSH-ungranted must be indistinguishable to a caller
+    // with no relationship to the id. Byte-for-byte, not toEqual: the property is that the WIRE
+    // BYTES leak nothing.
+    const refuseOf = (r: ReturnType<typeof gateProjectTarget>): string =>
+      r === 'allow' ? '' : r.refuse
+    const unknown = refuseOf(gateProjectTarget({ ...base, targetIsSsh: undefined }))
+    const localUngranted = refuseOf(gateProjectTarget({ ...base, targetIsSsh: false }))
+    const sshUngranted = refuseOf(gateProjectTarget({ ...base, targetIsSsh: true }))
+    expect(unknown).toBe(PROJECT_TARGET_REFUSED)
+    expect(Buffer.from(localUngranted).equals(Buffer.from(unknown))).toBe(true)
+    expect(Buffer.from(sshUngranted).equals(Buffer.from(unknown))).toBe(true)
+  })
+
+  it('the SSH belt refuses a granted SSH id — and only a grant holder ever sees that wording', () => {
+    // Grants are only ever minted by local open-project, so a granted SSH id cannot exist; if
+    // that invariant ever breaks, the target is refused, not opened. The kind-naming wording is
+    // harmless here — a grant holder was handed the id by open-project — and is reachable ONLY
+    // through the granted branch (the stranger case above gets PROJECT_TARGET_REFUSED).
     const r = gateProjectTarget({ ...base, targetIsSsh: true, granted: true })
     expect(r).toEqual({ refuse: PROJECT_TARGET_SSH_UNSUPPORTED })
+    // A granted id whose project has since vanished still fails closed as a stranger.
+    expect(gateProjectTarget({ ...base, targetIsSsh: undefined, granted: true })).toEqual({
+      refuse: PROJECT_TARGET_REFUSED
+    })
   })
 
   it('allows a granted target and refuses an ungranted one with the named sentence', () => {
@@ -205,6 +240,98 @@ describe('validateOpenProjectCwd (P7) — resolved once, statted once, fails clo
   })
 })
 
+describe('gateOpenProject — every pre-forward branch, behaviorally red-capable (review I1/I2)', () => {
+  const dirStat = { isDirectory: () => true }
+  const base = {
+    callerProjectId: 'proj-own' as string | undefined,
+    callerIsSsh: false as boolean | undefined,
+    atCap: false,
+    rawCwd: '/tmp/repo',
+    statFn: () => dirStat
+  }
+
+  it('refuses an unresolvable caller with the transient named error, before anything else', () => {
+    // A node inside the save debounce is not in any persisted project yet: fail closed (GC 10),
+    // worded transient because it genuinely is. No stat runs — the request goes nowhere.
+    let stats = 0
+    const r = gateOpenProject({
+      ...base,
+      callerProjectId: undefined,
+      // Even a hostile combination (SSH + cap) must not change which refusal fires first.
+      callerIsSsh: true,
+      atCap: true,
+      statFn: () => ((stats++, dirStat))
+    })
+    expect(r).toEqual({ refuse: OPEN_PROJECT_CALLER_UNRESOLVED })
+    expect(stats).toBe(0)
+  })
+
+  it('refuses an SSH-project caller with open-project-local-only (B5)', () => {
+    expect(gateOpenProject({ ...base, callerIsSsh: true })).toEqual({
+      refuse: OPEN_PROJECT_LOCAL_ONLY
+    })
+  })
+
+  it('refuses at the grant cap BEFORE the cwd is ever touched (no consent could follow)', () => {
+    let stats = 0
+    const r = gateOpenProject({ ...base, atCap: true, statFn: () => ((stats++, dirStat)) })
+    expect(r).toEqual({ refuse: OPEN_PROJECT_GRANT_CAP })
+    expect(stats).toBe(0)
+  })
+
+  it('composes with the real ledger cap and the real cwd rules', () => {
+    for (let i = 0; i < GRANT_CAP; i++) grant('caller-a', `proj-${i}`)
+    expect(gateOpenProject({ ...base, atCap: atCap('caller-a') })).toEqual({
+      refuse: OPEN_PROJECT_GRANT_CAP
+    })
+    expect(gateOpenProject({ ...base, atCap: atCap('caller-b'), rawCwd: 'not/absolute' })).toEqual(
+      { refuse: OPEN_PROJECT_CWD_INVALID }
+    )
+  })
+
+  it('passes a clean request through with the RESOLVED cwd (P7)', () => {
+    const statted: string[] = []
+    const r = gateOpenProject({
+      ...base,
+      rawCwd: '/tmp/a/../repo/',
+      statFn: (p) => ((statted.push(p), dirStat))
+    })
+    expect(r).toEqual({ resolvedCwd: path.resolve('/tmp/a/../repo/') })
+    expect(statted).toEqual([path.resolve('/tmp/a/../repo/')])
+  })
+})
+
+describe('recordOpenProjectGrant — the record decision, behaviorally (P2 record-side + review M1)', () => {
+  const okReply = { ok: true, result: { projectId: 'proj-new' } }
+
+  it('records ONLY under verified && ok && non-empty string projectId — the open-browser pattern', () => {
+    // The four fail-closed legs first: none of these may mint anything.
+    expect(recordOpenProjectGrant('caller-a', okReply, false)).toBe('not-applicable')
+    expect(recordOpenProjectGrant('caller-a', { ok: false, result: { projectId: 'proj-new' } }, true)).toBe('not-applicable')
+    expect(recordOpenProjectGrant('caller-a', { ok: true, result: {} }, true)).toBe('not-applicable')
+    expect(recordOpenProjectGrant('caller-a', { ok: true, result: { projectId: '' } }, true)).toBe('not-applicable')
+    expect(recordOpenProjectGrant('caller-a', { ok: true, result: { projectId: 42 } }, true)).toBe('not-applicable')
+    expect(isGranted('caller-a', 'proj-new')).toBe(false)
+    // The one leg that mints — and only for THIS caller.
+    expect(recordOpenProjectGrant('caller-a', okReply, true)).toBe('recorded')
+    expect(isGranted('caller-a', 'proj-new')).toBe(true)
+    expect(isGranted('caller-b', 'proj-new')).toBe(false)
+  })
+
+  it("answers 'cap' when a concurrent open-project filled the last slot — nothing recorded", () => {
+    // The M1 race: both requests passed the pre-forward atCap() check; the loser's grant() call
+    // is the first place the collision is visible, and the wrapper turns 'cap' into the named
+    // refusal instead of relaying ok (a caller must never hear ok while holding no right).
+    for (let i = 0; i < GRANT_CAP; i++) grant('caller-a', `proj-${i}`)
+    expect(recordOpenProjectGrant('caller-a', okReply, true)).toBe('cap')
+    expect(isGranted('caller-a', 'proj-new')).toBe(false)
+    // An id already granted re-records fine at the cap (idempotent, no new slot).
+    expect(
+      recordOpenProjectGrant('caller-a', { ok: true, result: { projectId: 'proj-0' } }, true)
+    ).toBe('recorded')
+  })
+})
+
 describe('main wiring (structural) — the wrapper records, consumes and clears correctly', () => {
   // Structural in the control-destructive.test.ts sense and for the same reason: the wiring lives
   // inside index.ts's setControlHandler wrapper and whenReady closure, which have no unit seam,
@@ -213,14 +340,36 @@ describe('main wiring (structural) — the wrapper records, consumes and clears 
   // the real functions.
   const src = fs.readFileSync(path.join(__dirname, 'index.ts'), 'utf8')
 
-  it('records a grant ONLY under verified && result.ok with a string projectId (the open-browser pattern)', () => {
-    const at = src.indexOf("verb === 'open-project' && verified && result.ok")
-    expect(at).toBeGreaterThan(-1)
-    const block = src.slice(at, at + 400)
-    expect(block).toContain("typeof opened?.projectId === 'string'")
-    expect(block).toContain('grantProjectTo(nodeId, opened.projectId)')
-    // No other call site mints a grant: the record path is the wrapper's, once.
-    expect(src.match(/grantProjectTo\(/g)?.length).toBe(1)
+  it('the record path is the pure recordOpenProjectGrant, called once, with the cap race surfaced', () => {
+    // The record RULES (verified && ok && string projectId; per-caller; 'cap' on the race) are
+    // proven behaviorally above against the real function. Here: the wrapper routes the reply
+    // through that function exactly once, with main's own verdict, and a 'cap' answer replaces
+    // the success reply with the named refusal (review M1 — no ok without a recorded right).
+    expect(src.match(/recordOpenProjectGrant\(/g)?.length).toBe(1)
+    expect(src).toMatch(
+      /if \(recordOpenProjectGrant\(nodeId, result, verified\) === 'cap'\) \{/
+    )
+    const at = src.indexOf("recordOpenProjectGrant(nodeId, result, verified) === 'cap'")
+    const block = src.slice(at, src.indexOf('return result', at))
+    expect(block).toContain('error: OPEN_PROJECT_GRANT_CAP')
+    // No raw grant() call sneaks around the pure decision anywhere in main's entry.
+    expect(src).not.toMatch(/\bgrantProjectTo\(|[^A-Za-z]grant\(nodeId/)
+  })
+
+  it('every open-project is routed through the pure gateOpenProject before forwarding (I1/I2)', () => {
+    // The branches themselves (caller-unresolved, SSH caller, cap, cwd) are proven behaviorally
+    // above; this pins that the wrapper cannot bypass them — the gate call sits inside the
+    // open-project arm, its refusal returns unforwarded, and its resolved cwd is what forwards.
+    const arm = src.indexOf("if (verb === 'open-project') {")
+    expect(arm).toBeGreaterThan(-1)
+    const block = src.slice(arm, src.indexOf('} else if (PROJECT_TARGETABLE_VERBS', arm))
+    expect(block).toContain('gateOpenProject({')
+    expect(block).toContain("if ('refuse' in gate) return refuse(gate.refuse)")
+    expect(block).toContain('args = { ...args, cwd: gate.resolvedCwd }')
+    // Its inputs come from main's own stores, never the request.
+    expect(block).toMatch(/callerProjectId: projectIdOfNode\(nodeId\)|callerProjectId,/)
+    expect(block).toContain('workspaceStore.projectMetaFor(callerProjectId)?.ssh')
+    expect(block).toContain('atCap: projectGrantsAtCap(nodeId)')
   })
 
   it('consumes the ledger per-CALLER and gates before forwarding to the renderer', () => {
@@ -245,9 +394,10 @@ describe('main wiring (structural) — the wrapper records, consumes and clears 
   })
 
   it('open-project resolves + replaces the cwd in MAIN before forwarding (P7)', () => {
-    const at = src.indexOf('validateOpenProjectCwd(args.cwd')
+    // The resolution itself lives in gateOpenProject → validateOpenProjectCwd (proven above);
+    // here: the raw caller cwd enters the gate and only the gate's resolved form is forwarded.
+    const at = src.indexOf('rawCwd: args.cwd')
     expect(at).toBeGreaterThan(-1)
-    // The resolved form replaces the raw argument in the forwarded args.
-    expect(src.slice(at, at + 400)).toContain('args = { ...args, cwd: cwd.resolved }')
+    expect(src.slice(at, at + 400)).toContain('args = { ...args, cwd: gate.resolvedCwd }')
   })
 })

--- a/src/main/project-grants.test.ts
+++ b/src/main/project-grants.test.ts
@@ -1,0 +1,206 @@
+/**
+ * The session-scoped project-grant ledger + targeting gate (issue #338 PR 1, spec P2/P3 + §3/§5).
+ *
+ * The properties pinned here are the security spine of project targeting:
+ *  - a grant is PER-CALLER (P2): caller B presenting an id granted to caller A is refused;
+ *  - a grant is SESSION-SCOPED (P3): cleared per-caller on teardown, never persisted — the module
+ *    is pure in-memory state with no fs and no electron import (asserted structurally below);
+ *  - the gate FAILS CLOSED: unverified, unknown target, SSH target, ungranted target all refuse
+ *    with a named error;
+ *  - cwd validation resolves ONCE and stats ONCE (P7, CodeQL single-fd posture).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  GRANT_CAP,
+  grant,
+  isGranted,
+  atCap,
+  clearCaller,
+  clearAll,
+  gateProjectTarget,
+  validateOpenProjectCwd,
+  PROJECT_TARGETABLE_VERBS,
+  PROJECT_TARGETING_REFUSAL,
+  PROJECT_TARGET_REFUSED,
+  PROJECT_TARGET_SSH_UNSUPPORTED,
+  OPEN_PROJECT_CWD_INVALID
+} from './project-grants'
+
+beforeEach(() => clearAll())
+
+describe('the grant ledger is per-caller (P2)', () => {
+  it('a grant authorizes the granted caller and nobody else', () => {
+    expect(grant('caller-a', 'proj-1')).toBe('ok')
+    expect(isGranted('caller-a', 'proj-1')).toBe(true)
+    // THE pin: caller B using an id granted to caller A is refused. A globally-keyed ledger
+    // passes every single-caller test and fails exactly this one.
+    expect(isGranted('caller-b', 'proj-1')).toBe(false)
+    expect(isGranted('caller-a', 'proj-2')).toBe(false)
+  })
+
+  it('granting the same id twice is idempotent and costs one cap slot', () => {
+    expect(grant('caller-a', 'proj-1')).toBe('ok')
+    expect(grant('caller-a', 'proj-1')).toBe('ok')
+    for (let i = 1; i < GRANT_CAP; i++) expect(grant('caller-a', `proj-extra-${i}`)).toBe('ok')
+    // proj-1 counted once, so exactly GRANT_CAP distinct ids fit.
+    expect(atCap('caller-a')).toBe(true)
+  })
+})
+
+describe('the grant ledger is session-scoped (P3)', () => {
+  it('clearCaller revokes that caller and only that caller', () => {
+    grant('caller-a', 'proj-1')
+    grant('caller-b', 'proj-2')
+    clearCaller('caller-a')
+    expect(isGranted('caller-a', 'proj-1')).toBe(false)
+    expect(isGranted('caller-b', 'proj-2')).toBe(true)
+  })
+
+  it('clearAll empties the ledger (the app-restart lifetime, exercised by beforeEach)', () => {
+    grant('caller-a', 'proj-1')
+    clearAll()
+    expect(isGranted('caller-a', 'proj-1')).toBe(false)
+  })
+
+  it('the module is pure: no fs, no electron, no persistence path to write through', () => {
+    // Structural, in the no-electron.test.ts style: the P3 claim "never persisted" is a property
+    // of the SOURCE — an in-memory Map with no import that could reach a disk or the shell.
+    const src = fs.readFileSync(path.join(__dirname, 'project-grants.ts'), 'utf8')
+    expect(src).not.toMatch(/from ['"]electron(\/[^'"]*)?['"]|require\(['"]electron/)
+    expect(src).not.toMatch(/from ['"](node:)?fs['"]|require\(['"](node:)?fs['"]\)/)
+    expect(src).not.toMatch(/from ['"](node:)?child_process['"]/)
+  })
+})
+
+describe('the per-caller cap (open-project-grant-cap)', () => {
+  it('admits exactly GRANT_CAP grants and refuses the 65th', () => {
+    for (let i = 0; i < GRANT_CAP; i++) {
+      expect(grant('caller-a', `proj-${i}`)).toBe('ok')
+      expect(atCap('caller-a')).toBe(i === GRANT_CAP - 1)
+    }
+    expect(grant('caller-a', 'proj-one-too-many')).toBe('cap')
+    // Refused means refused: the over-cap id was NOT recorded (no silent eviction either — the
+    // first 64 all survive).
+    expect(isGranted('caller-a', 'proj-one-too-many')).toBe(false)
+    expect(isGranted('caller-a', 'proj-0')).toBe(true)
+    expect(isGranted('caller-a', `proj-${GRANT_CAP - 1}`)).toBe(true)
+    // The cap is per caller, not global.
+    expect(atCap('caller-b')).toBe(false)
+    expect(grant('caller-b', 'proj-0')).toBe('ok')
+  })
+})
+
+describe('gateProjectTarget (spec §3/§5) — every branch, fail closed', () => {
+  const base = {
+    verified: true,
+    verb: 'open-claude',
+    targetProjectId: 'proj-t' as string | undefined,
+    callerProjectId: 'proj-own' as string | undefined,
+    targetIsSsh: false as boolean | undefined,
+    granted: false
+  }
+
+  it('is a no-op for a verb that is not a project-targetable open', () => {
+    expect(PROJECT_TARGETABLE_VERBS.has('open-claude')).toBe(true)
+    expect(PROJECT_TARGETABLE_VERBS.has('open-terminal')).toBe(true)
+    expect(PROJECT_TARGETABLE_VERBS.has('open-agent')).toBe(true)
+    expect(PROJECT_TARGETABLE_VERBS.has('show-image')).toBe(false)
+    expect(gateProjectTarget({ ...base, verb: 'list' })).toBe('allow')
+  })
+
+  it('is a no-op when no --project is present', () => {
+    expect(gateProjectTarget({ ...base, targetProjectId: undefined })).toBe('allow')
+  })
+
+  it('refuses an unverified caller with the flat sentence, before anything else', () => {
+    // Even the caller's OWN project: --project requires verified === true (P1's arg half), and
+    // the sentence carries no token/restart advice (a designed refusal, not an outage).
+    const r = gateProjectTarget({ ...base, verified: false, targetProjectId: 'proj-own' })
+    expect(r).toEqual({ refuse: PROJECT_TARGETING_REFUSAL })
+    for (const hint of ['token', 'restart', 'identity']) {
+      expect(PROJECT_TARGETING_REFUSAL.toLowerCase()).not.toContain(hint)
+    }
+  })
+
+  it('refuses an unknown/deleted target id — fail closed, same sentence as ungranted', () => {
+    // targetIsSsh === undefined is "main's own store does not know this project". The refusal
+    // reuses PROJECT_TARGET_REFUSED so a probing caller cannot distinguish "does not exist"
+    // from "exists but not granted" (no project-existence oracle).
+    const r = gateProjectTarget({ ...base, targetIsSsh: undefined, granted: true })
+    expect(r).toEqual({ refuse: PROJECT_TARGET_REFUSED })
+  })
+
+  it('allows the caller its own project, SSH-own included (the legacy live path)', () => {
+    expect(gateProjectTarget({ ...base, targetProjectId: 'proj-own' })).toBe('allow')
+    expect(
+      gateProjectTarget({ ...base, targetProjectId: 'proj-own', targetIsSsh: true })
+    ).toBe('allow')
+  })
+
+  it('refuses an SSH target that is not the caller own project — even a (impossible) granted one', () => {
+    // Grants are only ever minted by local open-project, so a granted SSH id cannot exist; the
+    // SSH check running BEFORE the granted check is the belt for that invariant.
+    const r = gateProjectTarget({ ...base, targetIsSsh: true, granted: true })
+    expect(r).toEqual({ refuse: PROJECT_TARGET_SSH_UNSUPPORTED })
+  })
+
+  it('allows a granted target and refuses an ungranted one with the named sentence', () => {
+    expect(gateProjectTarget({ ...base, granted: true })).toBe('allow')
+    expect(gateProjectTarget({ ...base, granted: false })).toEqual({
+      refuse: PROJECT_TARGET_REFUSED
+    })
+    expect(PROJECT_TARGET_REFUSED).toBe(
+      'project-target-refused: you may only target your own project or a project id ' +
+        'open-project returned to you in this session'
+    )
+  })
+
+  it('composes with the real ledger: granted for A, still refused for B (P2 end-to-end)', () => {
+    grant('caller-a', 'proj-t')
+    const forCaller = (caller: string) =>
+      gateProjectTarget({ ...base, granted: isGranted(caller, 'proj-t') })
+    expect(forCaller('caller-a')).toBe('allow')
+    expect(forCaller('caller-b')).toEqual({ refuse: PROJECT_TARGET_REFUSED })
+  })
+})
+
+describe('validateOpenProjectCwd (P7) — resolved once, statted once, fails closed', () => {
+  const dirStat = { isDirectory: () => true }
+  const fileStat = { isDirectory: () => false }
+
+  it('refuses a relative path before touching the filesystem at all', () => {
+    let stats = 0
+    const r = validateOpenProjectCwd('repo/sub', () => ((stats++, dirStat)))
+    expect(r).toEqual({ error: OPEN_PROJECT_CWD_INVALID })
+    expect(stats).toBe(0)
+    expect(validateOpenProjectCwd('', () => dirStat)).toEqual({ error: OPEN_PROJECT_CWD_INVALID })
+    expect(validateOpenProjectCwd('./x', () => dirStat)).toEqual({
+      error: OPEN_PROJECT_CWD_INVALID
+    })
+  })
+
+  it('resolves traversal and stats the RESOLVED path, exactly once', () => {
+    const statted: string[] = []
+    const r = validateOpenProjectCwd('/tmp/a/../b/./c/', (p) => {
+      statted.push(p)
+      return dirStat
+    })
+    // The resolved form — never the raw argument — is what every later step (dedupe, the PR 2
+    // dialog, storage) sees.
+    expect(r).toEqual({ resolved: path.resolve('/tmp/a/../b/./c/') })
+    expect(statted).toEqual([path.resolve('/tmp/a/../b/./c/')])
+  })
+
+  it('refuses a nonexistent path (stat throws) and a non-directory, with the named error', () => {
+    expect(
+      validateOpenProjectCwd('/no/such/dir', () => {
+        throw new Error('ENOENT')
+      })
+    ).toEqual({ error: OPEN_PROJECT_CWD_INVALID })
+    expect(validateOpenProjectCwd('/tmp/some.file', () => fileStat)).toEqual({
+      error: OPEN_PROJECT_CWD_INVALID
+    })
+  })
+})

--- a/src/main/project-grants.ts
+++ b/src/main/project-grants.ts
@@ -1,0 +1,164 @@
+/**
+ * The session-scoped project-grant ledger + the `--project` targeting gate (issue #338, spec §3).
+ *
+ * WHO MAY TARGET WHAT: a control caller may aim an open verb (`open-terminal`/`open-claude`/
+ * `open-agent`) at (a) its OWN project, or (b) a project id that `open-project` RETURNED TO THAT
+ * SAME CALLER in this app run. Nothing else — arbitrary cross-project targeting is deliberately
+ * not v1 (confused-deputy-adjacent; a future version needs the target project's own capability
+ * consent via the #213 mechanism, which would be a third disjunct in `gateProjectTarget`, not a
+ * redesign).
+ *
+ * IN MEMORY, IN MAIN, NEVER PERSISTED — the browser-ownership-ledger posture
+ * (browser-control-ledger.ts), for the same reason: a grant is a record of consent given to a
+ * RUNNING session, not a durable claim. An app restart clears every grant; a caller's node
+ * teardown (pty destroy/recycle, wired in index.ts) clears that caller's. Recording happens ONLY
+ * in main's control-handler wrapper on `result.ok && verified` — main's own identity verdict for
+ * that request, never anything off the wire or out of project.json.
+ *
+ * PURE on purpose: no electron, no fs, no child_process (project-grants.test.ts asserts this
+ * structurally). It unit-tests like agent-message-scope.ts and cannot persist anything even by
+ * accident.
+ */
+import path from 'node:path'
+
+/** At most this many granted project ids per caller. Beyond it `open-project` REFUSES
+ *  (`open-project-grant-cap`) rather than evicting silently — an evicted grant would revoke a
+ *  targeting right the human consented to without anyone being told. */
+export const GRANT_CAP = 64
+
+/** callerNodeId -> the project ids open-project returned to that caller this app run. */
+const grants = new Map<string, Set<string>>()
+
+/** Record that `open-project` returned `projectId` to `callerNodeId`. `'cap'` = refused (the set
+ *  is full and `projectId` is not already in it); nothing is recorded and nothing is evicted. */
+export function grant(callerNodeId: string, projectId: string): 'ok' | 'cap' {
+  const set = grants.get(callerNodeId) ?? new Set<string>()
+  if (!set.has(projectId) && set.size >= GRANT_CAP) return 'cap'
+  set.add(projectId)
+  grants.set(callerNodeId, set)
+  return 'ok'
+}
+
+/** Was `projectId` granted to `callerNodeId` — THIS caller, not any caller (spec P2)? */
+export function isGranted(callerNodeId: string, projectId: string): boolean {
+  return grants.get(callerNodeId)?.has(projectId) ?? false
+}
+
+/** Is this caller's grant set full? Consulted BEFORE forwarding an `open-project`, so the refusal
+ *  arrives before a dialog is ever shown rather than after the human already consented. */
+export function atCap(callerNodeId: string): boolean {
+  return (grants.get(callerNodeId)?.size ?? 0) >= GRANT_CAP
+}
+
+/** Caller-node teardown (pty destroy/recycle): that caller's grants die with its identity. */
+export function clearCaller(callerNodeId: string): void {
+  grants.delete(callerNodeId)
+}
+
+/** Everything gone — the app-restart lifetime, and the test seam. */
+export function clearAll(): void {
+  grants.clear()
+}
+
+/** The open verbs that accept `--project` (spec §2.2). Only these three — `--project` on any
+ *  other verb is dead weight the gate deliberately ignores (spec §7.5). */
+export const PROJECT_TARGETABLE_VERBS: ReadonlySet<string> = new Set([
+  'open-terminal',
+  'open-claude',
+  'open-agent'
+])
+
+/** The flat refusal an UNVERIFIED caller's `--project` gets — one sentence, no diagnosis, no
+ *  token/restart advice, same posture as the hook server's verified-only refusals. */
+export const PROJECT_TARGETING_REFUSAL = 'Project targeting refused.'
+
+/** The named refusal for an id that is neither the caller's own project nor granted. Also the
+ *  answer for an id main's store does not know: refusing unknown ids with the SAME sentence keeps
+ *  this from becoming a project-existence oracle. */
+export const PROJECT_TARGET_REFUSED =
+  'project-target-refused: you may only target your own project or a project id open-project ' +
+  'returned to you in this session'
+
+/** Targeting an SSH project (other than the caller's own, which takes the legacy live path) is
+ *  not v1 (spec B5/§6): the nodes would need host-side materialization this feature defers. */
+export const PROJECT_TARGET_SSH_UNSUPPORTED =
+  'project-target-ssh-unsupported: opening sessions into an SSH project is not supported — do not retry'
+
+/** `open-project` from an agent whose own project is SSH: the --cwd would be a host path (B5). */
+export const OPEN_PROJECT_LOCAL_ONLY =
+  'open-project-local-only: open-project is not available from an SSH project — do not retry'
+
+/** The caller's grant set is full (see GRANT_CAP). */
+export const OPEN_PROJECT_GRANT_CAP =
+  'open-project-grant-cap: this session already holds the maximum number of project grants'
+
+/** The wrapper could not resolve the caller's own project from main's persisted store (a node
+ *  saved seconds ago may still be inside the save debounce). Fail closed, but say it is
+ *  transient — this is the one refusal here that a short wait can clear. */
+export const OPEN_PROJECT_CALLER_UNRESOLVED =
+  'open-project-caller-unresolved: the calling node is not in any saved project yet — wait a few seconds and retry once'
+
+/** `--cwd` failed validation: not absolute, not existing, or not a directory. */
+export const OPEN_PROJECT_CWD_INVALID =
+  'open-project-cwd-invalid: --cwd must be an absolute path to an existing directory'
+
+export type ProjectTargetGate = 'allow' | { refuse: string }
+
+/**
+ * The `--project` targeting gate (spec §3 "consumed" + §5 P1/P2/P8), run in main's control-handler
+ * wrapper BEFORE anything is forwarded to the renderer — the renderer never sees an unauthorized
+ * `--project`. Every input is main's own data: `verified` is the hook server's identity verdict
+ * for THIS request, `callerProjectId` comes from node membership in `persistedCanvases()`,
+ * `targetIsSsh` from `projectMetaFor` (undefined = the store does not know the target), and
+ * `granted` from this module's ledger. Nothing is read off the request except the target id
+ * being judged.
+ *
+ * Branch order is load-bearing: unknown-target refuses before the own-project allow (a project
+ * main cannot resolve is not provably anyone's own), and the SSH refusal runs before the granted
+ * allow (grants are only minted by local open-project, so a granted SSH id cannot exist — this is
+ * the belt for that invariant).
+ */
+export function gateProjectTarget(input: {
+  verified: boolean
+  verb: string
+  targetProjectId: string | undefined
+  callerProjectId: string | undefined
+  targetIsSsh: boolean | undefined
+  granted: boolean
+}): ProjectTargetGate {
+  const { verified, verb, targetProjectId, callerProjectId, targetIsSsh, granted } = input
+  if (!PROJECT_TARGETABLE_VERBS.has(verb)) return 'allow'
+  if (targetProjectId === undefined) return 'allow'
+  if (verified !== true) return { refuse: PROJECT_TARGETING_REFUSAL }
+  if (targetIsSsh === undefined) return { refuse: PROJECT_TARGET_REFUSED }
+  if (callerProjectId !== undefined && targetProjectId === callerProjectId) return 'allow'
+  if (targetIsSsh) return { refuse: PROJECT_TARGET_SSH_UNSUPPORTED }
+  if (granted) return 'allow'
+  return { refuse: PROJECT_TARGET_REFUSED }
+}
+
+/**
+ * Validate + normalize an `open-project --cwd` argument (spec §2.1 step 1, P7). The caller's path
+ * is hostile input: it must be absolute, is resolved ONCE (`path.resolve` collapses `..`/`.`),
+ * and the RESOLVED form is statted ONCE (single fd — no TOCTOU re-walk; `statFn` follows
+ * symlinks, so the directory check is on the real target). The resolved path — never the raw
+ * argument — is what every later step sees: the PR 2 confirm dialog shows it, the dedupe compares
+ * it, the store records it.
+ *
+ * `statFn` is injected (main passes `fs.statSync`) so the rules stay pure and unit-testable.
+ */
+export function validateOpenProjectCwd(
+  raw: string,
+  statFn: (p: string) => { isDirectory(): boolean }
+): { resolved: string } | { error: string } {
+  if (typeof raw !== 'string' || raw.length === 0 || !path.isAbsolute(raw)) {
+    return { error: OPEN_PROJECT_CWD_INVALID }
+  }
+  const resolved = path.resolve(raw)
+  try {
+    if (!statFn(resolved).isDirectory()) return { error: OPEN_PROJECT_CWD_INVALID }
+  } catch {
+    return { error: OPEN_PROJECT_CWD_INVALID }
+  }
+  return { resolved }
+}

--- a/src/main/project-grants.ts
+++ b/src/main/project-grants.ts
@@ -73,14 +73,22 @@ export const PROJECT_TARGETABLE_VERBS: ReadonlySet<string> = new Set([
 export const PROJECT_TARGETING_REFUSAL = 'Project targeting refused.'
 
 /** The named refusal for an id that is neither the caller's own project nor granted. Also the
- *  answer for an id main's store does not know: refusing unknown ids with the SAME sentence keeps
- *  this from becoming a project-existence oracle. */
+ *  answer for an id main's store does not know, AND for an ungranted id that happens to name an
+ *  SSH project: every id the caller has no relationship to refuses with these SAME BYTES, so the
+ *  gate is neither a project-existence oracle nor a project-KIND oracle (PR #362 review, I3 —
+ *  the earlier distinct SSH wording let a verified caller learn "this id is a real SSH project"
+ *  with no grant). */
 export const PROJECT_TARGET_REFUSED =
   'project-target-refused: you may only target your own project or a project id open-project ' +
   'returned to you in this session'
 
-/** Targeting an SSH project (other than the caller's own, which takes the legacy live path) is
- *  not v1 (spec B5/§6): the nodes would need host-side materialization this feature defers. */
+/** Targeting an SSH project is not v1 (spec B5/§6): the nodes would need host-side
+ *  materialization this feature defers. Shown ONLY to a caller that already holds a GRANT for
+ *  the id (where disclosing the project's kind is harmless — the caller was handed the id by
+ *  open-project). A caller with no relationship to an SSH id gets PROJECT_TARGET_REFUSED like
+ *  every other stranger, see above. Today this constant is pure belt: grants are only minted by
+ *  local open-project, so a granted SSH id cannot exist — but if that invariant ever breaks,
+ *  the target must still be refused, not opened. */
 export const PROJECT_TARGET_SSH_UNSUPPORTED =
   'project-target-ssh-unsupported: opening sessions into an SSH project is not supported — do not retry'
 
@@ -113,10 +121,19 @@ export type ProjectTargetGate = 'allow' | { refuse: string }
  * `granted` from this module's ledger. Nothing is read off the request except the target id
  * being judged.
  *
- * Branch order is load-bearing: unknown-target refuses before the own-project allow (a project
- * main cannot resolve is not provably anyone's own), and the SSH refusal runs before the granted
- * allow (grants are only minted by local open-project, so a granted SSH id cannot exist — this is
- * the belt for that invariant).
+ * Branch order is load-bearing:
+ *  - the OWN-project allow runs before the unknown-target refusal (PR #362 review, M2): both
+ *    `callerProjectId` and the target meta derive from the same index scan, but if a rename
+ *    mid-debounce ever let `persistedCanvases` resolve the caller one tick before
+ *    `projectMetaFor` finds the entry, the caller's legitimate `--project <own-id>` must not be
+ *    spuriously refused as unknown. Allowing OWN on the caller-resolution alone is still
+ *    fail-closed — the id equals the caller's own project in main's own store;
+ *  - every id the caller has NO relationship to (unknown, local-ungranted, SSH-ungranted)
+ *    refuses with the byte-identical PROJECT_TARGET_REFUSED (review I3 — no kind oracle);
+ *  - the SSH refusal sits INSIDE the granted allow as pure belt: a granted SSH id cannot exist
+ *    (grants are only minted by local open-project), but if that invariant ever breaks the
+ *    target is refused, not opened — and only there is the kind-naming wording harmless, because
+ *    a grant holder was handed the id by open-project.
  */
 export function gateProjectTarget(input: {
   verified: boolean
@@ -130,11 +147,65 @@ export function gateProjectTarget(input: {
   if (!PROJECT_TARGETABLE_VERBS.has(verb)) return 'allow'
   if (targetProjectId === undefined) return 'allow'
   if (verified !== true) return { refuse: PROJECT_TARGETING_REFUSAL }
-  if (targetIsSsh === undefined) return { refuse: PROJECT_TARGET_REFUSED }
   if (callerProjectId !== undefined && targetProjectId === callerProjectId) return 'allow'
-  if (targetIsSsh) return { refuse: PROJECT_TARGET_SSH_UNSUPPORTED }
-  if (granted) return 'allow'
+  if (granted && targetIsSsh !== undefined) {
+    if (targetIsSsh) return { refuse: PROJECT_TARGET_SSH_UNSUPPORTED }
+    return 'allow'
+  }
   return { refuse: PROJECT_TARGET_REFUSED }
+}
+
+/**
+ * The whole record-side decision for a finished `open-project` request (spec §3 "recorded", made
+ * pure in the PR #362 fix round so the cap race — review M1 — is behaviorally testable).
+ * `'recorded'` = the grant now exists; `'not-applicable'` = the reply mints nothing (not ok, not
+ * verified, or no usable projectId — all fail closed); `'cap'` = the reply LOOKED grantable but a
+ * concurrent open-project from the same caller filled the last slot while this one was in flight
+ * (the pre-forward `atCap` check passed for both). On `'cap'` the wrapper must NOT relay the
+ * success reply — the caller would hear ok while holding no targeting right — it answers
+ * OPEN_PROJECT_GRANT_CAP instead; nothing is lost, because open-project is idempotent (B1) and a
+ * re-run after grants clear returns the same id and records the grant.
+ */
+export function recordOpenProjectGrant(
+  callerNodeId: string,
+  reply: { ok: boolean; result?: unknown },
+  verified: boolean
+): 'recorded' | 'not-applicable' | 'cap' {
+  if (verified !== true || reply.ok !== true) return 'not-applicable'
+  const projectId = (reply.result as { projectId?: unknown } | undefined)?.projectId
+  if (typeof projectId !== 'string' || !projectId) return 'not-applicable'
+  return grant(callerNodeId, projectId) === 'cap' ? 'cap' : 'recorded'
+}
+
+/**
+ * The whole main-side pre-forward gate for an `open-project` request (issue #338 Task 1.4, made
+ * pure in the PR #362 fix round — review I1/I2 proved the SSH-caller and unresolved-caller
+ * branches had no red-capable coverage while they lived inline in index.ts's wrapper). The
+ * wrapper resolves the inputs from main's own stores (caller project by node membership in
+ * `persistedCanvases`, SSH-ness via `projectMetaFor`, the cap from this module's ledger) and
+ * routes EVERY open-project through here; a `refuse` answer is returned to the caller without
+ * anything being forwarded to the renderer, so no dialog can be shown (PR 2) and no grant can be
+ * minted for a request that failed these rules.
+ *
+ * Branch order: caller-unresolved (fail closed per GC 10 — a node inside the save debounce, the
+ * one transient refusal here) → SSH caller (B5 local-only) → cap (refused BEFORE any consent
+ * could be collected) → cwd validation (P7, resolved once). Identity is NOT re-checked here: the
+ * hook-server's `requiresVerified` refuses an unverified open-project before any handler, and
+ * the wrapper keeps its own belt in front of this call.
+ */
+export function gateOpenProject(input: {
+  callerProjectId: string | undefined
+  callerIsSsh: boolean | undefined
+  atCap: boolean
+  rawCwd: string
+  statFn: (p: string) => { isDirectory(): boolean }
+}): { resolvedCwd: string } | { refuse: string } {
+  if (input.callerProjectId === undefined) return { refuse: OPEN_PROJECT_CALLER_UNRESOLVED }
+  if (input.callerIsSsh) return { refuse: OPEN_PROJECT_LOCAL_ONLY }
+  if (input.atCap) return { refuse: OPEN_PROJECT_GRANT_CAP }
+  const cwd = validateOpenProjectCwd(input.rawCwd, input.statFn)
+  if ('error' in cwd) return { refuse: cwd.error }
+  return { resolvedCwd: cwd.resolved }
 }
 
 /**

--- a/src/server/control-unsupported.test.ts
+++ b/src/server/control-unsupported.test.ts
@@ -99,6 +99,25 @@ describe('the Server Edition refuses canvas control by name', () => {
     expect(text).toContain('do not retry')
   })
 
+  it('`open-project` is unreachable on this edition — the P8 pin for issue #338', async () => {
+    // No server code changed for #338 and none may need to: the SE registers this handler for
+    // ALL verbs, so open-project (and any --project-carrying open) answers the same permanent
+    // named refusal. Pinned by name so the contract cannot drift silently.
+    expect(await serverEditionControlHandler({ verb: 'open-project' })).toEqual({
+      ok: false,
+      error: CONTROL_UNSUPPORTED_ERROR,
+      message: controlUnsupportedMessage('open-project')
+    })
+    // And on the wire: open-project is verified-only at the route (requiresVerified runs before
+    // the handler on every edition), so a token is presented — the edition answer is what a
+    // caller that got PAST identity hears.
+    const res = await control('open-project', 'n-op', 'text/plain', nodeAuthToken(SECRET, 'n-op'))
+    expect(res.status).toBe(400)
+    const text = await res.text()
+    expect(text).toContain(CONTROL_UNSUPPORTED_ERROR)
+    expect(text).toContain('do not retry')
+  })
+
   it('an unverified `send` is refused on IDENTITY first, and that refusal does not invite a retry either', async () => {
     const res = await control('send', 'n-msg2')
     expect(res.status).toBe(403)


### PR DESCRIPTION
PR 1 of 2 for issue #338 (`open-project --cwd` + project-targeted opens). This half ships the grant ledger, the targeting gate and the verb model — **inert**: there is no renderer dispatch yet, so a live `open-project` parses, passes the gates, and is answered by the renderer's `default:` case with `unknown verb: open-project` (`ok: false`, so no grant is ever minted). PR 2 wires the dispatch, the confirm dialogs, the store-path opens and the agent-facing docs, and closes #338.

## Tasks → commits

| Task | Commit | What |
|---|---|---|
| 1.1 verb model + parse | `a223ac3e` | `'open-project'` in `ControlVerb` + `VERBS`; `parseControlRequest` requires `--cwd` |
| 1.2 verified-only (P1) | `100f8353` | `requiresVerified` + `'Project open refused.'` in `verifiedRefusalFor`; wire tests on the real `/control/` route |
| 1.3 grant ledger (P2/P3) | `6e01845b` | `src/main/project-grants.ts`: pure `Map<caller, Set<projectId>>`, cap 64, `grant`/`isGranted`/`atCap`/`clearCaller`/`clearAll` |
| 1.4 targeting gate + cwd (P7/P8-ssh) | `6e01845b` + `7e6a18f5` | `gateProjectTarget` + `validateOpenProjectCwd` (pure) and the `setControlHandler` wrapper wiring; `workspace-store.projectMetaFor` |
| V-2 teardown anchor | `7e6a18f5` | Resolved: `corePlatform.on(IPC.ptyDestroy/ptyRecycle)` — the same anchor the browser leases die on. **Both** legs clear the caller's grants (a recycle mints a fresh identity that must re-earn its rights); app restart clears the in-memory ledger by construction. |
| 1.5 Server Edition pin (P8) | `c6db741f` | `serverEditionControlHandler({ verb: 'open-project' })` answers `control-unsupported-on-this-edition`; direct call + a wire leg past identity. No server code changes. |

## Security properties shipped here

- **P1 verified-only.** `open-project` joins `requiresVerified`, decided on the VERDICT before any handler — unreachable by `hookIdentityStrict: false` and the dated window (the #212 send/reply pattern). Legacy/forged/foreign-kid callers get 403 + the flat sentence `Project open refused.` (no token/restart advice). The `--project` arg half: `gateProjectTarget` refuses `verified !== true` with `Project targeting refused.` before anything is forwarded.
- **P2 per-caller grants.** Caller B presenting an id granted to caller A is refused — pinned against the real ledger + gate composition.
- **P3 session-scoped.** In-memory only; the module is pure (no `fs`, no electron, no `child_process` — asserted structurally); cleared per-caller on `ptyDestroy`/`ptyRecycle`, wholesale on restart. Recording happens ONLY in the wrapper on `result.ok && verified && non-empty string projectId` (the open-browser ledger pattern at the same call site).
- **Targeting gate fails closed.** Unknown/deleted target ids refuse with the SAME sentence as ungranted ids (`project-target-refused: …`), so the gate is not a project-existence oracle. SSH targets (other than the caller's own) refuse `project-target-ssh-unsupported` — and that check runs BEFORE the granted allow, as the belt for "a granted id can never be SSH". Target existence/SSH-ness comes from `projectMetaFor` (main's own store), never from the request.
- **cwd validation (P7).** Absolute required, `path.resolve` once, ONE stat on the resolved path (single-fd, no TOCTOU re-walk; the path never leaves the process). The resolved form replaces the raw argument in the forwarded args — PR 2's dialog, dedupe and storage all see it. SSH-project callers get `open-project-local-only`; an unresolvable caller fails closed with `open-project-caller-unresolved` (transient: a just-created node inside the save debounce).
- **Cap.** 64 grants/caller; the 65th refuses `open-project-grant-cap` (no silent eviction), checked BEFORE forwarding so no dialog can be consented to and then dropped.
- **P8 Server Edition.** Pinned unreachable by name.

## Mutation checks (introduced/caught: 9/9)

| # | Mutation | Result |
|---|---|---|
| 1 | verified-only decided on `decision === 'refuse'` instead of `verdict !== 'verified'` | red (2 tests) |
| 2 | `isGranted` keyed globally instead of per-caller | red (2 tests) |
| 3 | `clearCaller` made a no-op | red (1 test) |
| 4 | gate: `verified` check dropped | red (1 test) |
| 5 | gate: unknown target allowed | red (1 test) |
| 6 | cap removed | red (1 test) |
| 7 | granted checked before the SSH refusal | red (1 test) |
| 8 | wrapper records a grant without `verified` | red (1 test) |
| 9 | `ptyRecycle` teardown leg dropped | red (1 test) |

## Deliberate deferrals (per the plan)

- **`DESTRUCTIVE_VERBS` membership moves to PR 2 (Task 2.2):** `control-destructive.test.ts` structurally requires every member's `Canvas.tsx` case to read `isDestructiveVerb(verb)`, and that case only exists in PR 2 — adding the membership now trips the set↔dispatch drift alarm with no dispatch to agree with. A tripwire test (`open-project is NOT in DESTRUCTIVE_VERBS yet`) goes red the moment PR 2 adds it.
- **No skill/instructions text:** spec §8 — docs land in the PR that makes the verb reachable. The parity test walks a named verb list, so it stays green without a half-documented stub.

## Verification

`npm run typecheck` green; per-task suites green (`canvas-control-core` 39, `messaging-verified-only` 6, `project-grants` 21, `workspace-store` 92, `control-unsupported` 11); full `npx vitest run`: **598 files passed | 1 skipped, 8393 tests passed | 12 skipped**.

Refs #338 (PR 2 closes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
