### PR TITLE
feat(control): open-project and project-targeted opens, live

### DIFF
--- a/src/core/workspace-files.cold-open.test.ts
+++ b/src/core/workspace-files.cold-open.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { projectToFile, fileToProject, serializeProjectFile } from './workspace-files'
+import type { CanvasNodeState, PendingLaunch, Project } from '../shared/types'
+
+/**
+ * Issue #338 Task 2.0, pin (c) — the DISK half of the cold-open round-trip. A `--project`-targeted
+ * open writes its node into the target project's serialized store with the launch command in
+ * `pendingLaunch: { after: [], command }`, then `writeDisk` persists it. The target project may
+ * not be viewed until after an app restart, when only the file's copy exists — so the armed
+ * launch has to survive `projectToFile → serialize → parse → fileToProject` or the node would
+ * silently never start. The live↔store pins (a)/(b) live in
+ * `src/renderer/state/workspace.cold-open.test.ts`.
+ */
+describe('cold-open pin (c): pendingLaunch survives the disk round-trip', () => {
+  it('projectToFile → serialize → parse → fileToProject keeps pendingLaunch', () => {
+    const pending: PendingLaunch = { after: [], command: 'claude "do the thing"' }
+    const armedState: CanvasNodeState = {
+      id: 'term-cold1',
+      kind: 'terminal',
+      position: { x: 40, y: 60 },
+      size: { width: 600, height: 400 },
+      title: 'Claude',
+      color: '#d97757',
+      group: null,
+      agentId: 'claude',
+      pendingLaunch: pending
+    }
+    const project: Project = {
+      id: 'project-a',
+      name: 'repoA',
+      color: '#888',
+      cwd: '/tmp/repoA',
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: [armedState]
+    }
+    const file = projectToFile(project, 1, new Date(0).toISOString())
+    const parsed = JSON.parse(serializeProjectFile(file))
+    const loaded = fileToProject(parsed, { id: 'project-a', cwd: '/tmp/repoA' })
+    expect(loaded.nodes[0].pendingLaunch).toEqual(pending)
+  })
+})

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -36,13 +36,11 @@ describe('parseControlRequest', () => {
     })
   })
 
-  it('open-project is NOT in DESTRUCTIVE_VERBS yet — that membership lands with PR 2', () => {
-    // Deliberate PR slicing, not an oversight: `control-destructive.test.ts` structurally
-    // requires every member's `Canvas.tsx` case to read `isDestructiveVerb(verb)`, and the
-    // dispatch case for open-project only exists in PR 2 (Task 2.2). Adding the verb to the set
-    // now would trip the set↔dispatch drift alarm with no dispatch to agree with. This test goes
-    // red the moment PR 2 adds the membership, which is the reminder to delete it.
-    expect(isDestructiveVerb('open-project')).toBe(false)
+  it('open-project IS destructive — its create/adopt/first-attach dialog is confirm-gated (PR 2)', () => {
+    // PR 1 left a tripwire here asserting the opposite; PR 2 added the early-handled dispatch
+    // block that reads `isDestructiveVerb(verb)` before its `confirmBusy()` refusal, so the
+    // membership and the dispatch now exist together (control-destructive.test.ts is the alarm).
+    expect(isDestructiveVerb('open-project')).toBe(true)
   })
 
   it('requires a target for write/close', () => {

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -8,6 +8,7 @@ import {
   CONTROL_SHIM_SCRIPT
 } from './canvas-control-core'
 import { RETRYABLE } from '../core/agents/agent-message-decide'
+import { PROJECT_TARGETABLE_VERBS } from './project-grants'
 import { STRICT_CONTROL_VERBS } from '../core/agents/node-identity-policy'
 import { BROWSER_ACTION_KEYS } from '../core/browser-verb'
 import { BROWSER_RETRYABLE, BROWSER_OUTCOME_LABEL } from '../core/browser-outcomes'
@@ -442,5 +443,58 @@ describe('the messaging verbs parse', () => {
       error: 'notify does not accept --text'
     })
     expect(isDestructiveVerb('notify')).toBe(false)
+  })
+})
+
+describe('open-project + --project docs land with the dispatch (issue #338, spec §8)', () => {
+  const bodies: [string, string][] = [
+    ['skill', buildCanvasSkillBody('/x/shim.sh')],
+    ['instructions', buildCanvasControlInstructions('/x/shim.sh')]
+  ]
+
+  it('both bodies document open-project: idempotent, confirmed (a denial is final), local-only, the returned id, no tab focus', () => {
+    for (const [name, body] of bodies) {
+      expect(body, name).toContain('open-project --cwd')
+      expect(body, name).toMatch(/[Ii]dempotent/)
+      // The confirm may be denied, and a denial is terminal — never advice to retry it.
+      expect(body, name).toMatch(/denial is final/)
+      // Local-only (B5) and no focus (B4), stated to the agent as facts.
+      expect(body, name).toMatch(/refused from an SSH project/)
+      expect(body, name).toMatch(/never\s+focuses/)
+      expect(body, name).toContain('projectId')
+    }
+  })
+
+  it('every --project-targetable verb line documents the flag — walked off the REAL set', () => {
+    // The drift alarm walks PROJECT_TARGETABLE_VERBS (src/main/project-grants.ts) rather than a
+    // re-typed list: a fourth verb joining the set without its doc line goes red here, and a doc
+    // line dropping the flag goes red too.
+    for (const [name, body] of bodies) {
+      for (const verb of PROJECT_TARGETABLE_VERBS) {
+        const line = body.split('\n').find((l) => l.includes(`\`${verb} `))
+        expect(line, `${name}: a doc line for ${verb}`).toBeTruthy()
+        expect(line, `${name}: ${verb} documents --project`).toContain('--project')
+      }
+    }
+  })
+
+  it('both bodies state the own-or-returned-id rule as fact, the cold-open contract, and the flag exclusion', () => {
+    for (const [name, body] of bodies) {
+      expect(body, name).toContain('any other id is refused')
+      // The cold-open sentence: a session opened into a non-active project starts when the user
+      // next views it — and the agent is told not to poll for that.
+      expect(body, name).toMatch(/starts when the user next views/)
+      expect(body, name).toMatch(/do not poll/)
+      expect(body, name).toMatch(/`--group`\/`--after` cannot\s+be combined with `--project`/)
+    }
+  })
+
+  it('the orchestration recipe gains the multi-repo pattern', () => {
+    for (const [name, body] of bodies) {
+      expect(body, name).toContain('one project per repository')
+      expect(body, name).toContain('open-project --cwd <repo>')
+      // v1 has no cross-project links; the workaround is named.
+      expect(body, name).toMatch(/reader agent inside that project/)
+    }
   })
 })

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -498,3 +498,39 @@ describe('open-project + --project docs land with the dispatch (issue #338, spec
     }
   })
 })
+
+describe('the --project clause tells the truth about travel (review #363 I-1 + M-3)', () => {
+  const bodies: [string, string][] = [
+    ['skill', buildCanvasSkillBody('/x/shim.sh')],
+    ['instructions', buildCanvasControlInstructions('/x/shim.sh')]
+  ]
+
+  it('no-travel is promised ONLY for a returned id; own id is documented as flag-omitted (travel included)', () => {
+    for (const [name, body] of bodies) {
+      // The clause slice: from the `--project` flag doc to the open-project entry that follows
+      // it in both bodies — anchored, so a caveat cannot drift into another paragraph (the
+      // recipe) and still count (M-3).
+      const start = body.indexOf('`--project <id>`')
+      const end = body.indexOf('open-project --cwd')
+      expect(start, `${name}: clause start`).toBeGreaterThan(-1)
+      expect(end, `${name}: clause before the open-project entry`).toBeGreaterThan(start)
+      const clause = body.slice(start, end)
+      // Own id ≡ the flag omitted, view switch included — the REAL behavior (Canvas.tsx's
+      // own-id leg falls through to the legacy path, travel included; pinned in
+      // control-open-project.source.test.ts). The doc must say the same, not more.
+      expect(clause, name).toMatch(/behaves exactly as if the flag\s+were omitted/)
+      expect(clause, name).toMatch(/view switch\s+included/)
+      // The no-travel promise exists only attached to the RETURNED id…
+      expect(clause, name).toMatch(
+        /returned to YOU\s+in this session, which never switches the\s+user'?s view/
+      )
+      // …and the old universal phrasing ("without switching the user's view", said of the whole
+      // flag) is gone from the body entirely.
+      expect(body, name).not.toMatch(/without switching/)
+      // M-3: the do-not-poll caveat and the refusal rule live in the clause ITSELF — dropping
+      // them here while the recipe's copy survives is red.
+      expect(clause, name).toMatch(/do not poll/)
+      expect(clause, name).toContain('any other id is refused')
+    }
+  })
+})

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -284,15 +284,25 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '',
     'Verbs:',
     '- `list` — current nodes (id, kind, title). Start here when you need a node id.',
-    '- `open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>]` — open N plain terminals.',
-    '- `open-claude [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>]` — open N Claude sessions.',
-    `- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>]\` — open`,
+    '- `open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>] [--project <id>]` — open N plain terminals.',
+    '- `open-claude [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]` — open N Claude sessions.',
+    `- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open`,
     '  any agent CLI. `--group` parents the node(s) into a group frame; a worktree-bound group also',
     '  hands its worktree path down as the cwd. `--after <id,id>` opens the node ARMED: it does not',
     '  start until every listed station has gone idle, and is context-linked to them so it can read',
     '  their work when it wakes — use it for "B needs what A produced" instead of polling. Only',
     `  status-reporting agent nodes (${statusAgents}, or custom agents based on them) may be waited on; a plain terminal never`,
-    '  reports finishing, so waiting on one is refused.',
+    '  reports finishing, so waiting on one is refused. `--project <id>` opens the node(s) in another',
+    '  project instead of yours: it accepts your OWN project id, or an id `open-project` returned to',
+    '  YOU in this session — any other id is refused. A session opened into a non-active project',
+    '  starts when the user next views that project — do not poll for it. `--group`/`--after` cannot',
+    '  be combined with `--project`.',
+    '- `open-project --cwd </abs/path> [--name N] [--color C]` — register (or find) the project for a',
+    '  local directory; the reply carries `{ projectId, name, cwd, created }`. Idempotent: the same',
+    '  cwd always returns the same project, never a duplicate. Creating/adding asks the user to',
+    '  confirm (your first open of an already-registered project asks once too) and may be denied —',
+    '  a denial is final, do not retry it. Local only (refused from an SSH project), and it never',
+    '  focuses the new project\'s tab. The returned id is what `--project` accepts.',
     '- `show-image <path>` / `show-video <path>` — open a media file as a node.',
     '- `show-web (--url U | --file P.html | --html "<...>")` — open a web viewer.',
     '- `open-browser --url U` — open a navigable browser node.',
@@ -364,7 +374,13 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     'context link (the linked-context CLI — see the get-linked-context section in your global',
     'agent instructions) and reconcile the streams into ONE synthesis yourself; a station you',
     'never read is one you cannot vouch for. The user merges when a stream is done;',
-    '`close-worktree --group <id>` releases a finished station.'
+    '`close-worktree --group <id>` releases a finished station.',
+    '',
+    'Multi-repo orchestration: one project per repository — `open-project --cwd <repo>` (the user',
+    'confirms once), then `open-agent --agent claude --project <returned id> --prompt "…"` per repo,',
+    'one repo at a time. Sessions in a non-active project start when the user views that project —',
+    'do not poll for them. v1 has no cross-project links: read a repo\'s results by opening a',
+    'reader agent inside that project and linking within it.'
   ].join('\n')
 }
 
@@ -529,9 +545,9 @@ value is allowed anywhere on the line, not only at the end.
 
 Verbs:
 - \`list\` — list current nodes (id, kind, title). Start here when you need a node id.
-- \`open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>]\` — open N plain terminals (default 1).
-- \`open-claude [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>]\` — open N Claude sessions (default 1).
-- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>]\` — open N sessions of any agent CLI.
+- \`open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>] [--project <id>]\` — open N plain terminals (default 1).
+- \`open-claude [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open N Claude sessions (default 1).
+- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open N sessions of any agent CLI.
   \`--group\` parents the node(s) into an existing group frame; a worktree-bound group also
   hands its worktree path down as the cwd.
   \`--after <id,id>\` opens the node **armed**: it does NOT start yet, and launches itself once
@@ -542,6 +558,20 @@ Verbs:
   plain terminal never reports finishing and the node would hang forever. Note the semantics:
   "idle" is the end of a station's TURN, not proof its whole job is done — right for a station
   given one self-contained prompt, wrong if you expect a long conversation first.
+  \`--project <id>\` opens the node(s) in ANOTHER project instead of yours, without switching the
+  user's view. It accepts exactly two things: your OWN project id, or an id \`open-project\`
+  returned to YOU in this session — any other id is refused. Defaults inside the target are the
+  TARGET project's (its cwd, its default account and permission mode). A session opened into a
+  non-active project starts when the user next views that project — do not poll for it; the reply
+  says so. \`--group\`/\`--after\` cannot be combined with \`--project\`.
+- \`open-project --cwd </abs/path> [--name N] [--color C]\` — register (or find) the project for a
+  local directory; the reply carries \`{ projectId, name, cwd, created }\`. Idempotent: the same
+  cwd always returns the same project, never a duplicate — and \`--name\`/\`--color\` apply only
+  when the project is created (an existing project's name is never changed; the reply tells you
+  its real name). Creating/adding asks the user to confirm (your first open of an
+  already-registered project asks once too) and may be denied — a denial is final, do not retry
+  it. Local only (refused from an SSH project), and it never focuses the new project's tab: use
+  the returned id with \`--project\` to open sessions there.
 - \`show-image <path>\` — open an image file as a node.
 - \`show-video <path>\` — open a video file as a player node.
 - \`show-web (--url U | --file P.html | --html "<...>")\` — open a web viewer (live URL or local HTML you wrote).
@@ -691,5 +721,15 @@ across Nodeterm sessions), be the orchestration chef — plan the kitchen, then 
    your synthesis, and say which findings you accepted and which you dismissed and why.
 7. Hand back: the user merges from the group's chip (never merge for them); release a finished
    station with \`close-worktree --group <id>\` (unbind keeps the directory).
+
+## Multi-repo orchestration (one project per repository)
+
+When the workstreams live in DIFFERENT repositories, give each repo its own project instead of
+piling every session onto your canvas: \`open-project --cwd <repo>\` (the user confirms once;
+idempotent thereafter), then \`open-agent --agent claude --project <returned id> --prompt
+"<task>"\` — one repo at a time. Neither verb moves the user's view, and a session opened into a
+non-active project starts when the user next views that project — do not poll for it. v1 has no
+cross-project links: read a repo's results by opening a reader agent inside that project and
+linking within it.
 `
 }

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -293,10 +293,11 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  their work when it wakes — use it for "B needs what A produced" instead of polling. Only',
     `  status-reporting agent nodes (${statusAgents}, or custom agents based on them) may be waited on; a plain terminal never`,
     '  reports finishing, so waiting on one is refused. `--project <id>` opens the node(s) in another',
-    '  project instead of yours: it accepts your OWN project id, or an id `open-project` returned to',
-    '  YOU in this session — any other id is refused. A session opened into a non-active project',
-    '  starts when the user next views that project — do not poll for it. `--group`/`--after` cannot',
-    '  be combined with `--project`.',
+    '  project instead of yours. It accepts exactly two things — any other id is refused: your OWN',
+    '  project id, which behaves exactly as if the flag were omitted (a normal open, view switch',
+    '  included); or an id `open-project` returned to YOU in this session, which never switches the',
+    '  user\'s view. A session opened into a non-active project starts when the user next views that',
+    '  project — do not poll for it. `--group`/`--after` cannot be combined with `--project`.',
     '- `open-project --cwd </abs/path> [--name N] [--color C]` — register (or find) the project for a',
     '  local directory; the reply carries `{ projectId, name, cwd, created }`. Idempotent: the same',
     '  cwd always returns the same project, never a duplicate. Creating/adding asks the user to',
@@ -558,9 +559,10 @@ Verbs:
   plain terminal never reports finishing and the node would hang forever. Note the semantics:
   "idle" is the end of a station's TURN, not proof its whole job is done — right for a station
   given one self-contained prompt, wrong if you expect a long conversation first.
-  \`--project <id>\` opens the node(s) in ANOTHER project instead of yours, without switching the
-  user's view. It accepts exactly two things: your OWN project id, or an id \`open-project\`
-  returned to YOU in this session — any other id is refused. Defaults inside the target are the
+  \`--project <id>\` opens the node(s) in another project instead of yours. It accepts exactly
+  two things — any other id is refused: your OWN project id, which behaves exactly as if the flag
+  were omitted (a normal open, view switch included); or an id \`open-project\` returned to YOU
+  in this session, which never switches the user's view. Defaults inside the target are the
   TARGET project's (its cwd, its default account and permission mode). A session opened into a
   non-active project starts when the user next views that project — do not poll for it; the reply
   says so. \`--group\`/\`--after\` cannot be combined with \`--project\`.
@@ -727,8 +729,9 @@ across Nodeterm sessions), be the orchestration chef — plan the kitchen, then 
 When the workstreams live in DIFFERENT repositories, give each repo its own project instead of
 piling every session onto your canvas: \`open-project --cwd <repo>\` (the user confirms once;
 idempotent thereafter), then \`open-agent --agent claude --project <returned id> --prompt
-"<task>"\` — one repo at a time. Neither verb moves the user's view, and a session opened into a
-non-active project starts when the user next views that project — do not poll for it. v1 has no
+"<task>"\` — one repo at a time. With a RETURNED id neither verb moves the user's view, and a
+session opened into a non-active project starts when the user next views that project — do not
+poll for it. v1 has no
 cross-project links: read a repo's results by opening a reader agent inside that project and
 linking within it.
 `

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -212,7 +212,8 @@ import {
   recordAttachConsent,
   openProjectReply,
   findProjectByCwd,
-  nextFreePosition
+  nextFreePosition,
+  armForColdOpen
 } from '../lib/projectOpen'
 import {
   FIT_NODE_OPTIONS,
@@ -346,7 +347,7 @@ import { pushSessionRename } from '../lib/sessionRename'
 import { oneLine } from '@shared/one-line'
 import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
 import { useSettings } from '../state/settings'
-import { activePermissionMode } from '../state/permissionMode'
+import { activePermissionMode, projectPermissionMode } from '../state/permissionMode'
 import { useContextWindow } from '../state/contextWindow'
 import { useSessionNaming } from '../state/sessionNaming'
 import { useSshServers } from '../state/sshServers'
@@ -7248,6 +7249,155 @@ export function Canvas() {
           onCancel: () => reply({ ok: false, error: 'denied by user' })
         })
         return
+      }
+
+      // ── `--project` targeted opens (issue #338 Task 2.3) — the three open verbs, early ──────
+      // Main's gateProjectTarget already enforced own-or-granted BEFORE forwarding (spec §3):
+      // the renderer never sees an unauthorized target — the checks below are belt, not the
+      // boundary. This block routes an AUTHORIZED target to the right DATA OWNER without
+      // travelling (B4): the live canvas owns the ACTIVE project (a store write there would be
+      // clobbered by the next commitCanvas), the projects store owns every other. A target equal
+      // to the caller's OWN project falls through to the legacy path unchanged — exactly as if
+      // the flag were omitted (B3a), travel included.
+      if (
+        (verb === 'open-terminal' || verb === 'open-claude' || verb === 'open-agent') &&
+        args.project !== undefined
+      ) {
+        const targetId = args.project
+        // v1 excludes the flags that name ids inside another project (spec §2.2): validating a
+        // group frame or a dependency station across a project boundary is exactly the surface
+        // v1 leaves out. Uniformly refused — own-project callers just omit --project.
+        if (args.group || args.after) {
+          reply({
+            ok: false,
+            error:
+              'project-target-flag-unsupported: --group/--after cannot be combined with --project'
+          })
+          return
+        }
+        const tgStore = useProjects.getState()
+        const tgLiveSrc = nodesRef.current.find((n) => n.id === sourceNodeId)
+        const tgStoredSrc = tgStore.projects
+          .flatMap((p) => p.nodes.map((n) => ({ node: n, projectId: p.id })))
+          .find((x) => x.node.id === sourceNodeId)
+        const callerProjectId = tgLiveSrc ? tgStore.activeProjectId : tgStoredSrc?.projectId
+        if (targetId !== callerProjectId) {
+          if (!tgLiveSrc && !tgStoredSrc) {
+            reply({ ok: false, error: 'source node is not in any open project' })
+            return
+          }
+          if (!sourceIsControlCapable(tgLiveSrc?.data.agentId ?? tgStoredSrc?.node.agentId)) {
+            reply({ ok: false, error: 'source node is not a control-capable agent' })
+            return
+          }
+          // Belt only — main already refused every stranger id with one byte-identical sentence
+          // (no existence oracle). This fires for a target main authorized that this renderer's
+          // store cannot see yet (mid-hydration), so it is worded transient.
+          const target = tgStore.getProject(targetId)
+          if (!target) {
+            reply({
+              ok: false,
+              error: 'project-target-refused: the target project is not available here — try again'
+            })
+            return
+          }
+          // Belt for the SSH invariant: a granted SSH id cannot exist (grants are minted only by
+          // local open-project) and main refuses ungranted ones — but if that ever breaks, the
+          // target is refused, not opened. A relay tab is another machine's project entirely.
+          if (target.ssh || target.remote) {
+            reply({
+              ok: false,
+              error:
+                'project-target-ssh-unsupported: opening sessions into an SSH project is not supported — do not retry'
+            })
+            return
+          }
+          const tgAgentId = (verb === 'open-agent' ? args.agent : 'claude') as AgentId
+          const tgIsTerminal = verb === 'open-terminal'
+          const tgCount = Math.max(
+            1,
+            Math.min(tgIsTerminal ? 8 : 5, parseInt(args.count || '1', 10) || 1)
+          )
+          // Defaults come from the TARGET, never the caller (spec §2.2): cwd falls back to the
+          // target project's root; the account funnel runs with the TARGET project (an account
+          // must not silently cross a project boundary, so the source node's account is NOT
+          // consulted); permission mode and launch-command overrides are the target's too.
+          const tgCwd = args.cwd || target.cwd
+          const tgAccount = tgIsTerminal
+            ? undefined
+            : resolveNewNodeAccount(undefined, target, useSettings.getState().settings.claudeAccounts)
+          const tgMode = tgIsTerminal ? undefined : projectPermissionMode(target, tgAgentId)
+          const tgActive = target.id === tgStore.activeProjectId
+          // Placement: below the lowest existing node in the TARGET (placeBelow(src) is
+          // meaningless in a project that does not contain the source). The live canvas is the
+          // truthful node set for the active project, the serialized store for any other.
+          const tgPlacedNodes = tgActive ? nodesRef.current : target.nodes
+          const tgMade: CanvasNode[] = []
+          let tgBase = { x: 0, y: 0 }
+          const tgIndexBase = tgActive ? nodesRef.current.length : target.nodes.length
+          for (let i = 0; i < tgCount; i++) {
+            const node = tgIsTerminal
+              ? createTerminalNode(tgIndexBase + i, tgCwd, { x: 0, y: 0 }, args.cmd)
+              : createAgentNode(
+                  tgAgentId,
+                  tgIndexBase + i,
+                  tgCwd,
+                  { x: 0, y: 0 },
+                  args.prompt,
+                  undefined,
+                  tgAccount,
+                  tgMode,
+                  // The TARGET project: its `.nodeterm/settings.json` launch override applies to
+                  // what runs in it, not the caller's.
+                  target.id
+                )
+            const w = (node.width as number) ?? 640
+            const h = (node.height as number) ?? 440
+            if (i === 0) tgBase = nextFreePosition(tgPlacedNodes, { width: w, height: h })
+            node.position = { x: tgBase.x + i * (w + 60) - w / 2, y: tgBase.y - h / 2 }
+            tgMade.push(node)
+          }
+          const tgIds = tgMade.map((n) => n.id)
+          const tgWhat = tgIsTerminal ? 'terminal' : tgAgentId
+          // No ropes and no context-links in either branch: both are per-project arrays, and an
+          // edge to a node in another project has no representation (v1 — #284's linking half).
+          // The skill text names the workaround (open a reader agent inside the target project).
+          if (tgActive) {
+            // The human is looking at the target (the caller is a background orchestrator):
+            // live-canvas insertion, normal initialCommand — the session starts immediately.
+            setNodes((ns) => [...ns, ...tgMade])
+            markDirty()
+            reply({
+              ok: true,
+              message: `opened ${tgCount} ${tgWhat} session(s) in "${target.name}" (${tgIds.join(', ')})`,
+              result: { ids: tgIds, id: tgIds[0], projectId: target.id }
+            })
+            return
+          }
+          // The normal orchestration case: the target is NOT active, so its serialized store is
+          // the source of truth. The launch command MOVES into pendingLaunch (armForColdOpen —
+          // initialCommand is deliberately never serialized) and the node is upserted through
+          // the same store path sticky uses, then persisted. Cold-open contract: the session
+          // starts when that project's canvas is next shown (mount spawns the PTY, the
+          // armed-launch effect delivers with its retry loop — Task 2.0's measured round-trip).
+          for (const node of tgMade) {
+            tgStore.applyNodeMutation(target.id, {
+              op: 'upsert',
+              node: flowToNodeStates([armForColdOpen(node)])[0]
+            })
+          }
+          void writeDisk()
+          reply({
+            ok: true,
+            message:
+              `opened ${tgCount} ${tgWhat} session(s) in "${target.name}" (${tgIds.join(', ')}) — ` +
+              'starts when that project is next viewed',
+            result: { ids: tgIds, id: tgIds[0], projectId: target.id }
+          })
+          return
+        }
+        // targetId === the caller's own project: fall through to the legacy path unchanged
+        // (B3a — behaves exactly as if --project were omitted).
       }
       // ── end of the early-handled (store-answered) verbs ─────────────────────────────────────
 

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -213,7 +213,9 @@ import {
   openProjectReply,
   findProjectByCwd,
   nextFreePosition,
-  armForColdOpen
+  armForColdOpen,
+  projectTargetFlagRefusal,
+  clearAttachConsent
 } from '../lib/projectOpen'
 import {
   FIT_NODE_OPTIONS,
@@ -4213,6 +4215,10 @@ export function Canvas() {
         // UI overrides live in agentNodes and are skipped by unmount's clearForParent.
         useAgentStatus.getState().remove(n.id)
         useAgentNodes.getState().clearLoop(n.id)
+        // The open-project attach-consent mirror dies with its caller (review #363 M-1) —
+        // symmetric with main's grant ledger, which clears on the same teardown (ptyDestroy).
+        // A node id revived later faces a fresh dialog, exactly as it faces a fresh grant.
+        clearAttachConsent(n.id)
       })
       setNodes((ns) => {
         // Free children of any deleted group back to absolute positions.
@@ -7264,15 +7270,13 @@ export function Canvas() {
         args.project !== undefined
       ) {
         const targetId = args.project
-        // v1 excludes the flags that name ids inside another project (spec §2.2): validating a
-        // group frame or a dependency station across a project boundary is exactly the surface
-        // v1 leaves out. Uniformly refused — own-project callers just omit --project.
-        if (args.group || args.after) {
-          reply({
-            ok: false,
-            error:
-              'project-target-flag-unsupported: --group/--after cannot be combined with --project'
-          })
+        // v1 excludes the flags that name ids inside another project (spec §2.2). The decision is
+        // the PURE projectTargetFlagRefusal — red-capable in projectOpen.test.ts (review #363
+        // I-2); this site only relays its answer. Uniformly refused — own-project callers just
+        // omit --project.
+        const tgFlagRefusal = projectTargetFlagRefusal(args)
+        if (tgFlagRefusal) {
+          reply({ ok: false, error: tgFlagRefusal })
           return
         }
         const tgStore = useProjects.getState()
@@ -8828,6 +8832,9 @@ export function Canvas() {
             disposeTerminalOnUnmount(sessionForProject(projectId).id, id) // node may be parked from the project switch
             transport.destroy(id)
             useAgentStatus.getState().remove(id)
+            // Same teardown symmetry as deleteNodes (review #363 M-1): the attach-consent
+            // mirror dies with the node.
+            clearAttachConsent(id)
             useProjects.getState().removeNode(projectId, id)
             void writeDisk()
           }

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -208,6 +208,13 @@ import {
 } from '../lib/controlRouting'
 import { applyStickyWrite, parseStickyArgs, resolveStickyRef } from '../lib/stickyWrite'
 import {
+  planOpenProject,
+  recordAttachConsent,
+  openProjectReply,
+  findProjectByCwd,
+  nextFreePosition
+} from '../lib/projectOpen'
+import {
   FIT_NODE_OPTIONS,
   absolutePosition,
   isMeasured,
@@ -7156,6 +7163,93 @@ export function Canvas() {
         reply(delivered ?? { ok: false, error: 'delivery produced no reply' })
         return
       }
+
+      // ── `open-project` (issue #338 Task 2.2) — handled BEFORE the source-routing machinery ──
+      // A STORE_ANSWERED_VERBS member for the G5 reason (controlRouting.ts): routing is by
+      // SOURCE, and travelling would yank the human's view to the CALLER's project on every
+      // registration. Main already gated this request (gateOpenProject): the caller is verified,
+      // local, under the grant cap, and `args.cwd` is the RESOLVED path (P7) — the raw argument
+      // never reaches this process, so the dialog below can only ever show the resolved form
+      // (P5). The renderer's job: validate the source live-or-stored, decide the consent branch
+      // (planOpenProject — every grant passes a human decision exactly once, spec Q1), raise the
+      // dialog, apply the NON-ACTIVATING registerProject (P6 — no setActive/travel in any
+      // branch), and reply exactly once on confirm AND cancel (GC 12). The grant itself is
+      // recorded MAIN-side when this reply lands ok && verified (recordOpenProjectGrant) —
+      // nothing in this block authorizes anything.
+      if (verb === 'open-project') {
+        const resolvedCwd = args.cwd ?? ''
+        if (!resolvedCwd) {
+          reply({ ok: false, error: 'open-project requires --cwd' })
+          return
+        }
+        const opLive = nodesRef.current.find((n) => n.id === sourceNodeId)
+        const opStored = useProjects
+          .getState()
+          .projects.flatMap((p) => p.nodes)
+          .find((n) => n.id === sourceNodeId)
+        if (!opLive && !opStored) {
+          reply({ ok: false, error: 'source node is not in any open project' })
+          return
+        }
+        if (!sourceIsControlCapable(opLive?.data.agentId ?? opStored?.agentId)) {
+          reply({ ok: false, error: 'source node is not a control-capable agent' })
+          return
+        }
+        const opTitle =
+          oneLine((opLive?.data.title as string) ?? opStored?.title ?? '') || sourceNodeId
+        // Apply one consent decision: register (create/adopt/idempotent hit) without activating,
+        // persist, remember the (caller, project) pair for dialog dedupe — authorization stays
+        // main-side — and reply with the id the caller can feed `--project`.
+        const opFinish = (adoptProbed?: Project) => {
+          const r = useProjects.getState().registerProject({
+            resolvedCwd,
+            name: args.name,
+            color: args.color,
+            ...(adoptProbed ? { probed: adoptProbed } : {})
+          })
+          recordAttachConsent(sourceNodeId, r.project.id)
+          void writeDisk()
+          reply({ ok: true, ...openProjectReply(r.project, r.created, r.adopted) })
+        }
+        // The probe only matters when no project owns this cwd yet (adopt-vs-create copy) — an
+        // idempotent hit must not pay a folder read.
+        const opProjects = useProjects.getState().projects
+        const opProbed = findProjectByCwd(opProjects, resolvedCwd)
+          ? null
+          : await api.workspace.probeFolder(resolvedCwd).catch(() => null)
+        const opPlan = planOpenProject({
+          projects: opProjects,
+          callerNodeId: sourceNodeId,
+          srcTitle: opTitle,
+          resolvedCwd,
+          probedName: opProbed?.name,
+          requestedName: args.name
+        })
+        if (opPlan.kind === 'silent') {
+          // This caller already passed a human decision for this project (Q1): idempotent, quiet.
+          opFinish()
+          return
+        }
+        // One confirm dialog at a time — the write/close rule, read off the shared set.
+        if (isDestructiveVerb(verb) && confirmBusy()) {
+          reply({ ok: false, error: 'a confirmation is already pending — try again' })
+          return
+        }
+        setConfirm({
+          message: opPlan.message,
+          confirmLabel: opPlan.confirmLabel,
+          requestedBy: opTitle,
+          onConfirm: () => {
+            setConfirm(null)
+            opFinish(
+              opPlan.confirmKind === 'adopt' && opProbed ? { ...opProbed, closed: false } : undefined
+            )
+          },
+          onCancel: () => reply({ ok: false, error: 'denied by user' })
+        })
+        return
+      }
+      // ── end of the early-handled (store-answered) verbs ─────────────────────────────────────
 
       // Which canvas answers? React Flow holds only the ACTIVE project's nodes, but every OTHER
       // project's tmux sessions keep running and are re-adopted on the next app start — so after a

--- a/src/renderer/canvas/control-destructive.test.ts
+++ b/src/renderer/canvas/control-destructive.test.ts
@@ -33,21 +33,43 @@ function caseBody(verb: string): string {
   return end === -1 ? rest : rest.slice(0, end)
 }
 
+/**
+ * The body of an EARLY-HANDLED verb's block — `open-project` is dispatched before the
+ * source-routing machinery (a STORE_ANSWERED_VERBS member, spec §2.3), so it has no `case` label.
+ * Delimited by its `if (verb === '<verb>')` guard and the next section-comment rule (`// ──`),
+ * the same way the switch slice above is delimited by the next case label.
+ */
+function earlyBody(verb: string): string {
+  const start = src.indexOf(`if (verb === '${verb}')`)
+  if (start === -1) return ''
+  const rest = src.slice(start)
+  const end = rest.indexOf('// ──', 10)
+  return end === -1 ? rest : rest.slice(0, end)
+}
+
+/** A verb's dispatch body wherever it lives: its switch case, or its early-handled block. */
+function dispatchBody(verb: string): string {
+  return caseBody(verb) || earlyBody(verb)
+}
+
 describe('the confirm-gated set and the dispatch that reads it stay in agreement', () => {
   it('the dispatch imports the set rather than restating it', () => {
     expect(src).toMatch(/import \{[^}]*isDestructiveVerb[^}]*\} from '@shared\/control-verbs'/)
   })
 
-  for (const verb of ['write', 'close'] as const) {
+  for (const verb of ['write', 'close', 'open-project'] as const) {
     it(`${verb} reaches its confirm through isDestructiveVerb`, () => {
       expect(isDestructiveVerb(verb)).toBe(true)
-      const body = caseBody(verb)
+      const body = dispatchBody(verb)
       expect(body).not.toBe('')
       // The guard CALL, not a hardcoded truth: adding a verb to the set must change behaviour.
       expect(body).toMatch(/isDestructiveVerb\(verb\) && confirmBusy\(\)/)
       // …and no leftover bare gate beside it, which would make the set decorative again.
       expect(body).not.toMatch(/\bif \(confirmBusy\(\)\)/)
       expect(body).toContain('setConfirm({')
+      // Denial is honored on every confirm this set gates (spec P4): the cancel leg replies the
+      // shared refusal instead of hanging the CLI to its 120s timeout.
+      expect(body).toContain("'denied by user'")
     })
   }
 
@@ -61,6 +83,10 @@ describe('the confirm-gated set and the dispatch that reads it stay in agreement
     // is confirm-gated"; it is "no other case claims to be gated by this set".
     const labels = [...src.matchAll(/\n {10}case '([a-z-]+)': \{/g)].map((m) => m[1])
     const gated = labels.filter((v) => /isDestructiveVerb\(verb\)/.test(caseBody(v)))
+    // The early-handled block (`open-project`) is counted the same way, off its own slice.
+    for (const early of ['open-project']) {
+      if (/isDestructiveVerb\(verb\)/.test(earlyBody(early))) gated.push(early)
+    }
     expect(new Set(gated)).toEqual(new Set(DESTRUCTIVE_VERBS))
   })
 })

--- a/src/renderer/canvas/control-open-project.source.test.ts
+++ b/src/renderer/canvas/control-open-project.source.test.ts
@@ -72,3 +72,79 @@ describe('the open-project dispatch block (source pins)', () => {
     expect(finish).toContain('writeDisk()')
   })
 })
+
+/** The `--project` targeted-opens block (Task 2.3): from its section rule to the end-of-early
+ *  marker. */
+function targetedOpensBody(): string {
+  const start = src.indexOf('// ── `--project` targeted opens')
+  expect(start).toBeGreaterThan(-1)
+  const rest = src.slice(start)
+  const end = rest.indexOf('// ── end of the early-handled')
+  expect(end).toBeGreaterThan(-1)
+  return rest.slice(0, end)
+}
+
+describe('the --project targeted-opens block (source pins)', () => {
+  it('sits BEFORE the source-routing machinery, like open-project', () => {
+    const block = src.indexOf('// ── `--project` targeted opens')
+    const routing = src.indexOf('routeControlSource(projects, activeId, sourceNodeId)')
+    expect(block).toBeGreaterThan(-1)
+    expect(block).toBeLessThan(routing)
+  })
+
+  it('never activates or travels (B4)', () => {
+    const body = targetedOpensBody()
+    expect(body).not.toContain('setActive')
+    expect(body).not.toContain('travelToProject')
+  })
+
+  it('the gate order is refusal-before-write: every refusal precedes every store/canvas write', () => {
+    // A refused target must write NOTHING. The flag refusal, the source checks, the
+    // unknown-target belt and the SSH belt all return before the first applyNodeMutation or
+    // setNodes — moving a write above any of them is the gate-before-write mutation.
+    const body = targetedOpensBody()
+    const firstWrite = Math.min(
+      ...['applyNodeMutation', 'setNodes'].map((s) => {
+        const i = body.indexOf(s)
+        return i === -1 ? body.length : i
+      })
+    )
+    for (const refusal of [
+      'project-target-flag-unsupported',
+      'project-target-refused',
+      'project-target-ssh-unsupported',
+      'source node is not a control-capable agent'
+    ]) {
+      const at = body.indexOf(refusal)
+      expect(at, refusal).toBeGreaterThan(-1)
+      expect(at, `${refusal} after a write`).toBeLessThan(firstWrite)
+    }
+  })
+
+  it('the store path arms through armForColdOpen — the launch survives serialization', () => {
+    // flowToNodeStates drops initialCommand by design; upserting a node without moving its
+    // command into pendingLaunch is the silent-never-starts mutation (Task 2.0's pins prove the
+    // round-trip; this pins that the store path actually uses the mover).
+    const body = targetedOpensBody()
+    expect(body).toMatch(/flowToNodeStates\(\[armForColdOpen\(node\)\]\)\[0\]/)
+  })
+
+  it('the store path persists (writeDisk) and states the cold-open contract in the reply', () => {
+    const body = targetedOpensBody()
+    expect(body).toContain('writeDisk()')
+    expect(body).toContain('starts when that project is next viewed')
+  })
+
+  it('the caller’s OWN project id falls through to the legacy path (B3a) — no return on that leg', () => {
+    const body = targetedOpensBody()
+    expect(body).toContain('if (targetId !== callerProjectId)')
+    expect(body).toContain('fall through to the legacy path unchanged')
+  })
+
+  it('draws no ropes and no context-links in either branch (v1 — #284’s half)', () => {
+    const body = targetedOpensBody()
+    expect(body).not.toContain('addAndConnect')
+    expect(body).not.toContain('bridgeTo')
+    expect(body).not.toContain('connect(')
+  })
+})

--- a/src/renderer/canvas/control-open-project.source.test.ts
+++ b/src/renderer/canvas/control-open-project.source.test.ts
@@ -110,7 +110,10 @@ describe('the --project targeted-opens block (source pins)', () => {
       })
     )
     for (const refusal of [
-      'project-target-flag-unsupported',
+      // The flag exclusion is decided by the pure projectTargetFlagRefusal (its logic is
+      // red-capable in projectOpen.test.ts — review #363 I-2); here we pin its CALL SITE's
+      // position, like the inline refusals below.
+      'projectTargetFlagRefusal(args)',
       'project-target-refused',
       'project-target-ssh-unsupported',
       'source node is not a control-capable agent'
@@ -119,6 +122,16 @@ describe('the --project targeted-opens block (source pins)', () => {
       expect(at, refusal).toBeGreaterThan(-1)
       expect(at, `${refusal} after a write`).toBeLessThan(firstWrite)
     }
+  })
+
+  it('the flag-exclusion guard FIRES on a truthy refusal — polarity pinned (review #363 I-2)', () => {
+    // The helper's decision logic is behaviorally tested; what only the source can show is that
+    // the dispatch honors the answer with the right polarity. `if (!tgFlagRefusal)` — the
+    // guard-inversion mutation that survived the original suite — no longer matches this.
+    const body = targetedOpensBody()
+    expect(body).toMatch(
+      /const tgFlagRefusal = projectTargetFlagRefusal\(args\)\s+if \(tgFlagRefusal\) \{\s+reply\(\{ ok: false, error: tgFlagRefusal \}\)\s+return/
+    )
   })
 
   it('the store path arms through armForColdOpen — the launch survives serialization', () => {

--- a/src/renderer/canvas/control-open-project.source.test.ts
+++ b/src/renderer/canvas/control-open-project.source.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * STRUCTURAL pins for the `open-project` early-handled dispatch block (issue #338 Task 2.2) —
+ * the same class of test as `control-destructive.test.ts`, and for the same reason: the block
+ * lives inside a 7000-line React component's IPC listener with no unit seam, and the properties
+ * pinned here are properties of the SOURCE (what the block calls and what it never calls). Every
+ * behavioural half is separately proven against real primitives: the consent decision in
+ * `projectOpen.test.ts` (planOpenProject on the real ledger), the store action in
+ * `projects.register.test.ts` (registerProject never activates), the grant in main's
+ * `project-grants.test.ts`.
+ */
+const src = readFileSync(new URL('./Canvas.tsx', import.meta.url), 'utf8')
+
+/** The early-handled open-project block: from its `if (verb === ...)` guard to the next
+ *  section-rule comment (`// ──`) — the same delimiting `control-destructive.test.ts` uses. */
+function openProjectBody(): string {
+  const start = src.indexOf(`if (verb === 'open-project')`)
+  expect(start).toBeGreaterThan(-1)
+  const rest = src.slice(start)
+  const end = rest.indexOf('// ──', 10)
+  return end === -1 ? rest : rest.slice(0, end)
+}
+
+describe('the open-project dispatch block (source pins)', () => {
+  it('sits BEFORE the source-routing machinery — ahead of the routeControlSource lookup', () => {
+    // The store-answered declaration (controlRouting.ts) and this early-exit are the same
+    // decision stated once each (spec §2.3): the block must run before the dispatch ever
+    // consults routeControlSource, or a background caller's open-project would travel the
+    // human's view to the CALLER's project (G5).
+    const block = src.indexOf(`if (verb === 'open-project')`)
+    const routing = src.indexOf('routeControlSource(projects, activeId, sourceNodeId)')
+    expect(block).toBeGreaterThan(-1)
+    expect(routing).toBeGreaterThan(-1)
+    expect(block).toBeLessThan(routing)
+  })
+
+  it('never activates or travels (spec P6): no setActive, no travelToProject in any branch', () => {
+    const body = openProjectBody()
+    expect(body).not.toContain('setActive')
+    expect(body).not.toContain('travelToProject')
+    expect(body).not.toContain('reopenProject')
+    expect(body).not.toContain('openFolderProject')
+    expect(body).not.toContain('adoptProject')
+  })
+
+  it('every store change goes through the non-activating registerProject, and only in opFinish', () => {
+    const body = openProjectBody()
+    // registerProject is reached exactly once, inside the single opFinish closure both the
+    // silent hit and the confirmed dialog call — so a denial (onCancel) structurally cannot
+    // create anything: the only creation site is behind opFinish.
+    expect(body.match(/registerProject\(/g)?.length).toBe(1)
+    expect(body).toContain('const opFinish')
+    // The cancel leg replies the shared denial and calls nothing else.
+    expect(body).toMatch(/onCancel: \(\) => reply\(\{ ok: false, error: 'denied by user' \}\)/)
+  })
+
+  it('the dialog shows the plan message (built from the RESOLVED cwd, P5), not a re-derived path', () => {
+    const body = openProjectBody()
+    expect(body).toContain('message: opPlan.message')
+    // The block never re-resolves or re-derives the path: args.cwd (main's resolved form) is
+    // read once into resolvedCwd and that identifier is what the plan and the store see.
+    expect(body).toContain('const resolvedCwd = args.cwd')
+  })
+
+  it('persists after registering (writeDisk inside opFinish)', () => {
+    const body = openProjectBody()
+    const finishStart = body.indexOf('const opFinish')
+    const finishEnd = body.indexOf('// The probe only matters')
+    const finish = body.slice(finishStart, finishEnd)
+    expect(finish).toContain('writeDisk()')
+  })
+})

--- a/src/renderer/lib/controlRouting.test.ts
+++ b/src/renderer/lib/controlRouting.test.ts
@@ -90,6 +90,16 @@ describe('needsLiveCanvas', () => {
     // projects store (`applyNodeMutation`), not the live canvas.
     expect(needsLiveCanvas('sticky')).toBe(false)
   })
+
+  it('is false for open-project — registering a project must never travel the camera (issue #338)', () => {
+    // The G5 argument one more time: routing is by SOURCE, and open-project's headline caller is
+    // a background orchestrator registering repos one after another — travelling would yank the
+    // human's view to the CALLER's project on every call. The verb acts on the projects STORE
+    // (registerProject, non-activating by construction), so no live canvas is needed at either
+    // end; this membership and Canvas.tsx's early-exit dispatch are the same decision stated once
+    // each (spec §2.3, P6).
+    expect(needsLiveCanvas('open-project')).toBe(false)
+  })
 })
 
 describe('sourceIsControlCapable', () => {

--- a/src/renderer/lib/controlRouting.ts
+++ b/src/renderer/lib/controlRouting.ts
@@ -101,7 +101,24 @@ export function routeControlSource(
  * project's serialized nodes (`applyNodeMutation`, the same path peer mutations take) when that
  * project is not the active one; the live canvas handles it when it is.
  */
-const STORE_ANSWERED_VERBS: ReadonlySet<string> = new Set(['list', 'send', 'reply', 'sticky'])
+/*
+ * `open-project` (issue #338) is store-answered for the G5 reason in its sharpest form: its
+ * headline caller is a background orchestrator registering one repo after another, and routing is
+ * by SOURCE — a live requirement would yank the human's view to the CALLER's project on every
+ * registration (and clear its unread badge via `setActive` on the way). The verb acts on the
+ * projects STORE through the non-activating `registerProject`, and its consent dialog is
+ * app-global (`ConfirmState` overlays the window), so no live canvas is needed at either end.
+ * Canvas.tsx handles it BEFORE the source-routing machinery — this declaration and that
+ * early-exit are the same decision stated once each (spec §2.3, P6), pinned by
+ * `controlRouting.test.ts`.
+ */
+const STORE_ANSWERED_VERBS: ReadonlySet<string> = new Set([
+  'list',
+  'send',
+  'reply',
+  'sticky',
+  'open-project'
+])
 
 /**
  * Does this verb have to run against the LIVE canvas? Everything that creates, moves, writes to or

--- a/src/renderer/lib/projectOpen.test.ts
+++ b/src/renderer/lib/projectOpen.test.ts
@@ -8,6 +8,8 @@ import {
   openProjectReply,
   nextFreePosition,
   armForColdOpen,
+  projectTargetFlagRefusal,
+  clearAttachConsent,
   type PlacedNode
 } from './projectOpen'
 
@@ -212,5 +214,73 @@ describe('armForColdOpen — the launch moves (never copies) into pendingLaunch 
   it('a node with no command is returned unchanged (a plain terminal just opens)', () => {
     const node = like(undefined)
     expect(armForColdOpen(node)).toBe(node)
+  })
+})
+
+describe('projectTargetFlagRefusal — the v1 flag exclusion fires (review I-2)', () => {
+  const REFUSAL =
+    'project-target-flag-unsupported: --group/--after cannot be combined with --project'
+
+  it('refuses --group, --after, and both — with the exact named reply', () => {
+    expect(projectTargetFlagRefusal({ group: 'g1' })).toBe(REFUSAL)
+    expect(projectTargetFlagRefusal({ after: 'n1,n2' })).toBe(REFUSAL)
+    expect(projectTargetFlagRefusal({ group: 'g1', after: 'n1' })).toBe(REFUSAL)
+  })
+
+  it('passes a request carrying neither flag', () => {
+    expect(projectTargetFlagRefusal({})).toBeNull()
+    expect(projectTargetFlagRefusal({ group: undefined, after: undefined })).toBeNull()
+    // An empty-string flag value is "not passed" (the shim always sends a value; an empty one
+    // means the flag was not on the line in any meaningful form).
+    expect(projectTargetFlagRefusal({ group: '', after: '' })).toBeNull()
+  })
+})
+
+describe('clearAttachConsent — the mirror dies with its caller (review M-1)', () => {
+  it('a cleared caller confirms again; other callers are untouched', () => {
+    recordAttachConsent('term-caller', 'project-a')
+    recordAttachConsent('term-other', 'project-a')
+    clearAttachConsent('term-caller')
+    expect(attachConsentRecorded('term-caller', 'project-a')).toBe(false)
+    expect(attachConsentRecorded('term-other', 'project-a')).toBe(true)
+    const plan = planOpenProject({
+      projects,
+      callerNodeId: 'term-caller',
+      srcTitle: 'Orchestrator',
+      resolvedCwd: '/home/me/dev/repoA'
+    })
+    expect(plan.kind).toBe('confirm')
+  })
+})
+
+describe('dialog copy flattens hostile names to one line (review M-2)', () => {
+  it('a multi-line --name cannot inject lines into the create dialog', () => {
+    const plan = planOpenProject({
+      projects: [],
+      callerNodeId: 'c',
+      srcTitle: 'A',
+      resolvedCwd: '/x/fresh',
+      requestedName: 'Nice\nAgent "root" wants to delete everything. Allow?'
+    })
+    expect(plan.kind).toBe('confirm')
+    if (plan.kind !== 'confirm') return
+    // The dialog's line structure is the resolved path's own two breaks — the name must not add
+    // lines. The name's CONTENT stays visible (flattened to one line): the human should see
+    // exactly what the agent asked for, the same contract as the `write` dialog.
+    expect(plan.message.split('\n').length).toBe(3)
+    expect(plan.message).toContain('Nice Agent')
+  })
+
+  it('a multi-line probed project name cannot inject lines into the adopt dialog', () => {
+    const plan = planOpenProject({
+      projects: [],
+      callerNodeId: 'c',
+      srcTitle: 'A',
+      resolvedCwd: '/x/cloned',
+      probedName: 'evil\nname'
+    })
+    expect(plan.kind).toBe('confirm')
+    if (plan.kind !== 'confirm') return
+    expect(plan.message.split('\n').length).toBe(3)
   })
 })

--- a/src/renderer/lib/projectOpen.test.ts
+++ b/src/renderer/lib/projectOpen.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  planOpenProject,
+  recordAttachConsent,
+  attachConsentRecorded,
+  clearAttachConsentForTests,
+  findProjectByCwd,
+  openProjectReply,
+  nextFreePosition,
+  type PlacedNode
+} from './projectOpen'
+
+/**
+ * Issue #338 Task 2.2/2.3 — the pure halves of the `open-project` dispatch and the
+ * `--project`-targeted placement. Canvas.tsx only wires these (the dialog, the store calls, the
+ * reply); everything decidable without React is decided here so it is red-capable:
+ *
+ * - EVERY grant passes a human decision exactly once (spec Q1, adopted): a caller's FIRST
+ *   open-project against an EXISTING project confirms too — the confirm-bypass mutation
+ *   ("silent idempotent hit") turns this suite red.
+ * - The dialog copy always contains the RESOLVED path (spec P5).
+ * - The consent mirror is per-caller and session-scoped (dialog dedupe only — authorization is
+ *   main's grant ledger, never this map).
+ */
+
+beforeEach(() => clearAttachConsentForTests())
+
+const projects = [
+  { id: 'project-a', name: 'repoA', cwd: '/home/me/dev/repoA' },
+  { id: 'project-b', name: 'repoB', cwd: '/home/me/dev/repoB' }
+]
+
+describe('planOpenProject — the consent decision (spec §2.1, Q1)', () => {
+  it('FIRST attach to an existing project confirms — an idempotent hit is not silent', () => {
+    const plan = planOpenProject({
+      projects,
+      callerNodeId: 'term-caller',
+      srcTitle: 'Orchestrator',
+      resolvedCwd: '/home/me/dev/repoA'
+    })
+    expect(plan.kind).toBe('confirm')
+    if (plan.kind !== 'confirm') return
+    expect(plan.confirmKind).toBe('attach')
+    expect(plan.project?.id).toBe('project-a')
+    // Lighter copy than create (Q1): names the project and the asking agent.
+    expect(plan.message).toContain('Orchestrator')
+    expect(plan.message).toContain('repoA')
+  })
+
+  it('after the consent is recorded, the SAME caller hits silently — once per caller+project', () => {
+    recordAttachConsent('term-caller', 'project-a')
+    const plan = planOpenProject({
+      projects,
+      callerNodeId: 'term-caller',
+      srcTitle: 'Orchestrator',
+      resolvedCwd: '/home/me/dev/repoA'
+    })
+    expect(plan.kind).toBe('silent')
+    if (plan.kind !== 'silent') return
+    expect(plan.project.id).toBe('project-a')
+  })
+
+  it('consent is PER-CALLER: another caller presenting the same cwd still confirms', () => {
+    recordAttachConsent('term-caller', 'project-a')
+    const plan = planOpenProject({
+      projects,
+      callerNodeId: 'term-other',
+      srcTitle: 'Other',
+      resolvedCwd: '/home/me/dev/repoA'
+    })
+    expect(plan.kind).toBe('confirm')
+    expect(attachConsentRecorded('term-other', 'project-a')).toBe(false)
+  })
+
+  it('no hit + a probed .nodeterm project → adopt-confirm showing the RESOLVED path (P5)', () => {
+    const plan = planOpenProject({
+      projects,
+      callerNodeId: 'term-caller',
+      srcTitle: 'Orchestrator',
+      resolvedCwd: '/home/me/dev/cloned',
+      probedName: 'cloned-app'
+    })
+    expect(plan.kind).toBe('confirm')
+    if (plan.kind !== 'confirm') return
+    expect(plan.confirmKind).toBe('adopt')
+    expect(plan.message).toContain('/home/me/dev/cloned')
+    expect(plan.message).toContain('existing project')
+  })
+
+  it('no hit, no probe → create-confirm showing the RESOLVED path and the name', () => {
+    const plan = planOpenProject({
+      projects,
+      callerNodeId: 'term-caller',
+      srcTitle: 'Orchestrator',
+      resolvedCwd: '/home/me/dev/fresh',
+      requestedName: 'Fresh One'
+    })
+    expect(plan.kind).toBe('confirm')
+    if (plan.kind !== 'confirm') return
+    expect(plan.confirmKind).toBe('create')
+    expect(plan.message).toContain('/home/me/dev/fresh')
+    expect(plan.message).toContain('Fresh One')
+  })
+
+  it('the create name defaults to the folder basename', () => {
+    const plan = planOpenProject({
+      projects: [],
+      callerNodeId: 'c',
+      srcTitle: 'A',
+      resolvedCwd: '/x/some-repo'
+    })
+    expect(plan.kind).toBe('confirm')
+    if (plan.kind !== 'confirm') return
+    expect(plan.message).toContain('some-repo')
+  })
+})
+
+describe('findProjectByCwd — the dedupe rule', () => {
+  it('matches exactly, with the trailing slash normalized away', () => {
+    expect(findProjectByCwd(projects, '/home/me/dev/repoA')?.id).toBe('project-a')
+    expect(findProjectByCwd(projects, '/home/me/dev/repoA/')?.id).toBe('project-a')
+    expect(findProjectByCwd(projects, '/home/me/dev/repoA-2')).toBeUndefined()
+  })
+})
+
+describe('openProjectReply — the reply shape', () => {
+  it('carries { projectId, name, cwd, created } and names the id in the message', () => {
+    const r = openProjectReply({ id: 'project-a', name: 'repoA', cwd: '/x' }, false, false)
+    expect(r.result).toEqual({ projectId: 'project-a', name: 'repoA', cwd: '/x', created: false })
+    expect(r.message).toContain('project-a')
+    expect(r.message).toContain('opened')
+  })
+
+  it('created and adopted both answer created: true (a new workspace entry either way)', () => {
+    expect(openProjectReply({ id: 'p', name: 'n', cwd: '/x' }, true, false).result.created).toBe(true)
+    const adopted = openProjectReply({ id: 'p', name: 'n', cwd: '/x' }, false, true)
+    expect(adopted.result.created).toBe(true)
+    expect(adopted.message).toContain('added')
+  })
+})
+
+describe('nextFreePosition — placement into a project the caller is not on (spec §2.2)', () => {
+  const rect = (center: { x: number; y: number }, w: number, h: number) => ({
+    left: center.x - w / 2,
+    top: center.y - h / 2,
+    right: center.x + w / 2,
+    bottom: center.y + h / 2
+  })
+  const overlaps = (
+    a: { left: number; top: number; right: number; bottom: number },
+    b: { left: number; top: number; right: number; bottom: number }
+  ) => a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom
+
+  it('never overlaps any existing store node', () => {
+    const nodes: PlacedNode[] = [
+      { id: 'a', position: { x: 0, y: 0 }, size: { width: 600, height: 400 } },
+      { id: 'b', position: { x: 700, y: 120 }, size: { width: 240, height: 200 } },
+      { id: 'c', position: { x: -300, y: 900 }, size: { width: 860, height: 500 } }
+    ]
+    const size = { width: 640, height: 440 }
+    const center = nextFreePosition(nodes, size)
+    const mine = rect(center, size.width, size.height)
+    for (const n of nodes) {
+      const theirs = {
+        left: n.position.x,
+        top: n.position.y,
+        right: n.position.x + (n.size?.width ?? 0),
+        bottom: n.position.y + (n.size?.height ?? 0)
+      }
+      expect(overlaps(mine, theirs)).toBe(false)
+    }
+  })
+
+  it('resolves a group child to ROOT space before comparing (a nested node cannot be landed on)', () => {
+    const nodes: PlacedNode[] = [
+      { id: 'g', position: { x: 100, y: 100 }, size: { width: 800, height: 700 } },
+      // Child at group-relative (20, 500): its root bottom is 100+500+400 = 1000, far below the
+      // frame's own bottom (800) — placing "below the lowest" must use the child's ROOT rect.
+      { id: 'child', parentId: 'g', position: { x: 20, y: 500 }, size: { width: 600, height: 400 } }
+    ]
+    const size = { width: 640, height: 440 }
+    const center = nextFreePosition(nodes, size)
+    expect(center.y - size.height / 2).toBeGreaterThanOrEqual(1000)
+  })
+
+  it('an empty project gets a sane default near the origin', () => {
+    const c = nextFreePosition([], { width: 640, height: 440 })
+    expect(c.x).toBeGreaterThan(0)
+    expect(c.y).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/lib/projectOpen.test.ts
+++ b/src/renderer/lib/projectOpen.test.ts
@@ -7,6 +7,7 @@ import {
   findProjectByCwd,
   openProjectReply,
   nextFreePosition,
+  armForColdOpen,
   type PlacedNode
 } from './projectOpen'
 
@@ -187,5 +188,29 @@ describe('nextFreePosition — placement into a project the caller is not on (sp
     const c = nextFreePosition([], { width: 640, height: 440 })
     expect(c.x).toBeGreaterThan(0)
     expect(c.y).toBeGreaterThan(0)
+  })
+})
+
+describe('armForColdOpen — the launch moves (never copies) into pendingLaunch (spec §2.2)', () => {
+  const like = (
+    initialCommand?: string
+  ): { id: string; data: { initialCommand?: string; pendingLaunch?: unknown; title: string } } => ({
+    id: 'term-x',
+    data: { initialCommand, title: 'T' }
+  })
+
+  it('moves initialCommand into pendingLaunch { after: [], command }', () => {
+    const armed = armForColdOpen(like('claude "go"'))
+    expect(armed.data.pendingLaunch).toEqual({ after: [], command: 'claude "go"' })
+    // MOVED, not copied: initialCommand is deliberately never serialized (workspace.ts), so a
+    // copy left behind is dead weight and a command left ONLY there is silently dropped — the
+    // node would never start. The serialization round-trip pin lives in
+    // workspace.cold-open.test.ts; this is the construction-site half.
+    expect(armed.data.initialCommand).toBeUndefined()
+  })
+
+  it('a node with no command is returned unchanged (a plain terminal just opens)', () => {
+    const node = like(undefined)
+    expect(armForColdOpen(node)).toBe(node)
   })
 })

--- a/src/renderer/lib/projectOpen.ts
+++ b/src/renderer/lib/projectOpen.ts
@@ -1,0 +1,201 @@
+// Pure halves of the `open-project` control verb and the `--project`-targeted opens
+// (issue #338, spec §2.1/§2.2). Canvas.tsx's dispatch only wires these — the dialog, the store
+// calls and the reply — so every decision that does not need React is unit-testable here, the
+// same reasoning as controlRouting.ts / pendingLaunch.ts.
+
+/** The little these helpers need to know about a project. */
+export interface ProjectForOpen {
+  id: string
+  name: string
+  cwd?: string
+}
+
+/**
+ * The dedupe rule (spec B1): the exact-string match `openFolderProject` uses, with the trailing
+ * slash normalized away so `/a/b/` and `/a/b` cannot mint two tabs for one directory. `--cwd`
+ * arrives here ALREADY resolved by main (`path.resolve`, spec P7) — this is cosmetic-slash
+ * defense, never a second resolution.
+ */
+export function normalizeProjectCwd(resolvedCwd: string): string {
+  return resolvedCwd.length > 1 ? resolvedCwd.replace(/\/+$/, '') : resolvedCwd
+}
+
+export function findProjectByCwd<T extends { cwd?: string }>(
+  projects: readonly T[],
+  resolvedCwd: string
+): T | undefined {
+  const cwd = normalizeProjectCwd(resolvedCwd)
+  return projects.find((p) => p.cwd === cwd)
+}
+
+/**
+ * The renderer-session attach-consent mirror (spec §4.2 Q1, adopted): which (caller, project)
+ * pairs have already passed a human decision — creating, adopting, or the lighter first-attach
+ * "Allow?" — so an idempotent re-open by the SAME caller does not re-raise the dialog, while a
+ * DIFFERENT caller naming the same cwd still asks. DIALOG DEDUPE ONLY: authorization is main's
+ * grant ledger (src/main/project-grants.ts), keyed to main's own verified identity verdict; this
+ * map decides nothing but whether a dialog is shown. In-memory, per app run — the same lifetime
+ * as the grants it mirrors.
+ */
+const attachAsked = new Map<string, Set<string>>()
+
+export function attachConsentRecorded(callerNodeId: string, projectId: string): boolean {
+  return attachAsked.get(callerNodeId)?.has(projectId) ?? false
+}
+
+export function recordAttachConsent(callerNodeId: string, projectId: string): void {
+  const set = attachAsked.get(callerNodeId) ?? new Set<string>()
+  set.add(projectId)
+  attachAsked.set(callerNodeId, set)
+}
+
+export function clearAttachConsentForTests(): void {
+  attachAsked.clear()
+}
+
+export type OpenProjectPlan =
+  | { kind: 'silent'; project: ProjectForOpen }
+  | {
+      kind: 'confirm'
+      confirmKind: 'attach' | 'adopt' | 'create'
+      message: string
+      confirmLabel: string
+      /** Set for `attach` — the existing project the caller is asking into. */
+      project?: ProjectForOpen
+    }
+
+/**
+ * The whole consent decision for one `open-project` request (spec §2.1 steps 2–4 + Q1). Pure:
+ * the caller has already resolved the cwd (main), looked for a probe result (only needed when no
+ * cwd hit exists), and passes everything in. Every dialog message shows the RESOLVED path (P5) —
+ * the raw argument never reaches the renderer at all (main rewrites args.cwd).
+ *
+ * Q1 (adopted): an idempotent hit is silent ONLY for a caller that already passed a human
+ * decision for this project. The first attach confirms with lighter copy, so every grant main
+ * records traces back to exactly one human decision — a silent hit would let a verified caller
+ * reach BY CWD the very targeting rights B3 forbids reaching by id.
+ */
+export function planOpenProject(input: {
+  projects: readonly ProjectForOpen[]
+  callerNodeId: string
+  srcTitle: string
+  resolvedCwd: string
+  /** The probed .nodeterm project's name, when `probeFolder` answered (adopt path). */
+  probedName?: string
+  requestedName?: string
+}): OpenProjectPlan {
+  const { projects, callerNodeId, srcTitle, resolvedCwd, probedName, requestedName } = input
+  const existing = findProjectByCwd(projects, resolvedCwd)
+  if (existing) {
+    if (attachConsentRecorded(callerNodeId, existing.id)) return { kind: 'silent', project: existing }
+    return {
+      kind: 'confirm',
+      confirmKind: 'attach',
+      message: `Agent "${srcTitle}" wants to open sessions in project "${existing.name}". Allow?`,
+      confirmLabel: 'Allow',
+      project: existing
+    }
+  }
+  if (probedName !== undefined) {
+    return {
+      kind: 'confirm',
+      confirmKind: 'adopt',
+      message:
+        `Agent "${srcTitle}" wants to add the existing project at\n${resolvedCwd}\n` +
+        `to your workspace ("${probedName}"). Add it?`,
+      confirmLabel: 'Add project'
+    }
+  }
+  const name =
+    (requestedName ?? '').trim() ||
+    (normalizeProjectCwd(resolvedCwd).split('/').filter(Boolean).pop() || 'Project')
+  return {
+    kind: 'confirm',
+    confirmKind: 'create',
+    message:
+      `Agent "${srcTitle}" wants to create a project for\n${resolvedCwd}\n` +
+      `(name "${name}"). Create it?`,
+    confirmLabel: 'Create project'
+  }
+}
+
+/**
+ * The success reply (spec §2.1): `result` carries `{ projectId, name, cwd, created }` — the id is
+ * what the caller feeds `--project`, and `created` is true for anything that added a new
+ * workspace entry (create AND adopt; an idempotent hit answers false). The message carries the
+ * project's REAL name, so an agent whose `--name` was ignored on a hit learns what it is.
+ */
+export function openProjectReply(
+  project: ProjectForOpen,
+  created: boolean,
+  adopted: boolean
+): {
+  message: string
+  result: { projectId: string; name: string; cwd: string; created: boolean }
+} {
+  const verb = created ? 'created' : adopted ? 'added' : 'opened'
+  const cwd = project.cwd ?? ''
+  return {
+    message: `${verb} project "${project.name}" (${project.id}) for ${cwd}`,
+    result: { projectId: project.id, name: project.name, cwd, created: created || adopted }
+  }
+}
+
+/** A node as either the serialized store or the live canvas holds it — enough for placement. */
+export interface PlacedNode {
+  id?: string
+  parentId?: string
+  position: { x: number; y: number }
+  size?: { width: number; height: number }
+  width?: number | null
+  height?: number | null
+}
+
+const placedW = (n: PlacedNode): number => n.size?.width ?? (n.width as number) ?? 0
+const placedH = (n: PlacedNode): number => n.size?.height ?? (n.height as number) ?? 0
+
+/** A node's position in ROOT space: its own plus every ancestor frame's origin (a group child's
+ *  stored position is frame-relative). Cycle-guarded like every other parent walk. */
+function rootPosition(n: PlacedNode, byId: Map<string, PlacedNode>): { x: number; y: number } {
+  let x = n.position.x
+  let y = n.position.y
+  const seen = new Set<string>(n.id ? [n.id] : [])
+  let parentId = n.parentId
+  while (parentId && !seen.has(parentId)) {
+    seen.add(parentId)
+    const parent = byId.get(parentId)
+    if (!parent) break
+    x += parent.position.x
+    y += parent.position.y
+    parentId = parent.parentId
+  }
+  return { x, y }
+}
+
+/**
+ * Where a node opened INTO another project lands (spec §2.2): centered below the lowest existing
+ * node, because `placeBelow(src)` is meaningless in a project that does not contain the source.
+ * Returns a CENTER point (the factories' `center` parameter — `placeAt` converts to top-left).
+ * Guaranteed non-overlapping: everything else ends above the returned rect's top edge. Positions
+ * are resolved to root space first, so a group child poking below its frame still counts.
+ */
+export function nextFreePosition(
+  nodes: readonly PlacedNode[],
+  size: { width: number; height: number } = { width: 640, height: 440 }
+): { x: number; y: number } {
+  if (!nodes.length) return { x: 40 + size.width / 2, y: 40 + size.height / 2 }
+  const byId = new Map<string, PlacedNode>()
+  for (const n of nodes) if (n.id) byId.set(n.id, n)
+  let left = Infinity
+  let bottom = -Infinity
+  for (const n of nodes) {
+    const at = rootPosition(n, byId)
+    if (Number.isFinite(at.x)) left = Math.min(left, at.x)
+    const b = at.y + placedH(n)
+    if (Number.isFinite(b)) bottom = Math.max(bottom, b)
+  }
+  if (!Number.isFinite(left) || !Number.isFinite(bottom)) {
+    return { x: 40 + size.width / 2, y: 40 + size.height / 2 }
+  }
+  return { x: left + size.width / 2, y: bottom + 80 + size.height / 2 }
+}

--- a/src/renderer/lib/projectOpen.ts
+++ b/src/renderer/lib/projectOpen.ts
@@ -2,6 +2,7 @@
 // (issue #338, spec §2.1/§2.2). Canvas.tsx's dispatch only wires these — the dialog, the store
 // calls and the reply — so every decision that does not need React is unit-testable here, the
 // same reasoning as controlRouting.ts / pendingLaunch.ts.
+import { oneLine } from '@shared/one-line'
 
 /** The little these helpers need to know about a project. */
 export interface ProjectForOpen {
@@ -49,8 +50,29 @@ export function recordAttachConsent(callerNodeId: string, projectId: string): vo
   attachAsked.set(callerNodeId, set)
 }
 
+/** Caller-node teardown: the mirror dies with the node it asked for — the same lifetime as
+ *  main's grant ledger (`clearCaller` on pty destroy/recycle), so a node id revived after a
+ *  deletion faces a fresh dialog, exactly as it faces a fresh grant (review #363 M-1). */
+export function clearAttachConsent(callerNodeId: string): void {
+  attachAsked.delete(callerNodeId)
+}
+
 export function clearAttachConsentForTests(): void {
   attachAsked.clear()
+}
+
+/**
+ * The v1 flag exclusion for `--project` (spec §2.2): `--group` and `--after` both name ids that
+ * live INSIDE a project, and validating them across a project boundary is exactly the surface v1
+ * excludes. Returns the named refusal, or null when neither flag is present. Pure so the guard
+ * is red-capable (review #363 I-2) — the dispatch only relays the answer; an empty-string value
+ * counts as "not passed" (the shim always sends a value for a bare flag).
+ */
+export function projectTargetFlagRefusal(args: { group?: string; after?: string }): string | null {
+  if (args.group || args.after) {
+    return 'project-target-flag-unsupported: --group/--after cannot be combined with --project'
+  }
+  return null
 }
 
 export type OpenProjectPlan =
@@ -91,7 +113,12 @@ export function planOpenProject(input: {
     return {
       kind: 'confirm',
       confirmKind: 'attach',
-      message: `Agent "${srcTitle}" wants to open sessions in project "${existing.name}". Allow?`,
+      // `oneLine` on every interpolated name (review #363 M-2): a project/probe/--name string is
+      // caller- or repo-supplied, and a newline in it would let it inject lines into the consent
+      // dialog. The resolved path's own line breaks are the dialog's structure; nothing else adds
+      // lines. (The stored name stays the raw create-only string, like the human addProject path
+      // — this flattening is dialog copy only.)
+      message: `Agent "${srcTitle}" wants to open sessions in project "${oneLine(existing.name)}". Allow?`,
       confirmLabel: 'Allow',
       project: existing
     }
@@ -102,13 +129,14 @@ export function planOpenProject(input: {
       confirmKind: 'adopt',
       message:
         `Agent "${srcTitle}" wants to add the existing project at\n${resolvedCwd}\n` +
-        `to your workspace ("${probedName}"). Add it?`,
+        `to your workspace ("${oneLine(probedName)}"). Add it?`,
       confirmLabel: 'Add project'
     }
   }
-  const name =
+  const name = oneLine(
     (requestedName ?? '').trim() ||
-    (normalizeProjectCwd(resolvedCwd).split('/').filter(Boolean).pop() || 'Project')
+      (normalizeProjectCwd(resolvedCwd).split('/').filter(Boolean).pop() || 'Project')
+  )
   return {
     kind: 'confirm',
     confirmKind: 'create',

--- a/src/renderer/lib/projectOpen.ts
+++ b/src/renderer/lib/projectOpen.ts
@@ -141,6 +141,26 @@ export function openProjectReply(
   }
 }
 
+/**
+ * Re-arm a freshly-built node for a COLD open (spec §2.2): its composed launch command is MOVED —
+ * never copied — from `initialCommand` into `pendingLaunch: { after: [], command }`.
+ * `initialCommand` is deliberately never serialized (workspace.ts), while `pendingLaunch` is: a
+ * command left in `initialCommand` on the store path would be silently dropped by serialization
+ * and the node would never start; a copy left behind would double-deliver if that ever changed.
+ * An empty `after` is vacuously ready (`launchesToFire`), so the armed-launch effect fires it on
+ * the target project's first view — the cold-open contract.
+ */
+export function armForColdOpen<
+  T extends { data: { initialCommand?: string; pendingLaunch?: unknown } }
+>(node: T): T {
+  const command = node.data.initialCommand
+  if (!command) return node
+  return {
+    ...node,
+    data: { ...node.data, initialCommand: undefined, pendingLaunch: { after: [], command } }
+  }
+}
+
 /** A node as either the serialized store or the live canvas holds it — enough for placement. */
 export interface PlacedNode {
   id?: string

--- a/src/renderer/state/permissionMode.ts
+++ b/src/renderer/state/permissionMode.ts
@@ -95,9 +95,20 @@ function autoSupportedFor(project: Project | undefined): boolean {
  * (createProject) — importing the projects store from workspace.ts would close that cycle.
  */
 export function activePermissionMode(agentId: AgentId = 'claude'): AgentPermissionMode {
-  const { settings } = useSettings.getState()
   const { getProject, activeProjectId } = useProjects.getState()
-  const project = getProject(activeProjectId)
+  return projectPermissionMode(getProject(activeProjectId), agentId)
+}
+
+/**
+ * The same resolution for an EXPLICIT project — the `--project`-targeted opens (issue #338) need
+ * the TARGET project's override + gate, not the active one's: a node opened into another project
+ * must start with that project's permission mode (spec §2.2 defaults), never the caller's.
+ */
+export function projectPermissionMode(
+  project: Project | undefined,
+  agentId: AgentId = 'claude'
+): AgentPermissionMode {
+  const { settings } = useSettings.getState()
   const mode = resolvePermissionMode(project, settings)
   // The version gate is CLAUDE-specific BY CONSTRUCTION: it exists because Claude Code < 2.1.71
   // exits 1 on `--permission-mode auto`, and it is fed by a `claude --version` probe (local, or the

--- a/src/renderer/state/projects.register.test.ts
+++ b/src/renderer/state/projects.register.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useProjects } from './projects'
+import type { Project } from '@shared/types'
+
+/**
+ * Issue #338 Task 2.1 — `registerProject`, the NON-ACTIVATING create/find used by the
+ * `open-project` control verb (spec §2.1 steps 2–4).
+ *
+ * The one property every test here re-asserts is spec P6: `registerProject` NEVER writes
+ * `activeProjectId`. The human paths (`openFolderProject`/`adoptProject`/`reopenProject`) all
+ * activate — deliberately untouched (Decision 4) — so the agent verb needs its own store action,
+ * and the mutation this suite is checked against is exactly "reuse the activating path".
+ */
+
+beforeEach(() => {
+  useProjects.getState().hydrate({ version: 2, activeProjectId: '', projects: [] })
+})
+
+const probed = (id: string): Project => ({
+  id,
+  name: 'shared-app',
+  color: '#7aa2f7',
+  cwd: '/Users/me/dev/shared-app',
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: [
+    {
+      id: 'term-a',
+      kind: 'terminal' as const,
+      position: { x: 0, y: 0 },
+      size: { width: 1, height: 1 },
+      title: 'a',
+      color: '#fff',
+      group: null
+    }
+  ]
+})
+
+describe('registerProject — idempotent hit (spec B1)', () => {
+  it('returns the same project twice without duplicating, and never activates', () => {
+    const active = useProjects.getState().addProject('elsewhere', '/tmp/elsewhere')
+    useProjects.getState().setActive(active.id)
+
+    const first = useProjects.getState().registerProject({ resolvedCwd: '/Users/me/dev/my-app' })
+    expect(first.created).toBe(true)
+    expect(first.adopted).toBe(false)
+    const second = useProjects.getState().registerProject({ resolvedCwd: '/Users/me/dev/my-app' })
+    expect(second.created).toBe(false)
+    expect(second.adopted).toBe(false)
+    expect(second.project.id).toBe(first.project.id)
+    expect(useProjects.getState().projects.filter((p) => p.cwd === '/Users/me/dev/my-app')).toHaveLength(1)
+    // P6 — the visible tab never moved.
+    expect(useProjects.getState().activeProjectId).toBe(active.id)
+  })
+
+  it('dedupes on the trailing-slash-normalized cwd', () => {
+    const first = useProjects.getState().registerProject({ resolvedCwd: '/Users/me/dev/my-app' })
+    const second = useProjects.getState().registerProject({ resolvedCwd: '/Users/me/dev/my-app/' })
+    expect(second.created).toBe(false)
+    expect(second.project.id).toBe(first.project.id)
+  })
+
+  it('un-closes a closed project WITHOUT activating it', () => {
+    const active = useProjects.getState().addProject('elsewhere', '/tmp/elsewhere')
+    useProjects.getState().setActive(active.id)
+    const closedOne = useProjects.getState().addProject('my-app', '/Users/me/dev/my-app')
+    useProjects.getState().closeProject(closedOne.id)
+
+    const hit = useProjects.getState().registerProject({ resolvedCwd: '/Users/me/dev/my-app' })
+    expect(hit.created).toBe(false)
+    expect(hit.project.id).toBe(closedOne.id)
+    const s = useProjects.getState()
+    // The tab is back (closed cleared)…
+    expect(s.projects.find((p) => p.id === closedOne.id)?.closed).toBeFalsy()
+    // …but the view did not travel (P6): reopenProject would have activated it.
+    expect(s.activeProjectId).toBe(active.id)
+  })
+
+  it('an idempotent hit never mutates the existing name or color on the agent’s say-so', () => {
+    const first = useProjects.getState().registerProject({ resolvedCwd: '/x/app', name: 'Real Name', color: '#123456' })
+    const hit = useProjects
+      .getState()
+      .registerProject({ resolvedCwd: '/x/app', name: 'Impostor', color: '#ff0000' })
+    expect(hit.created).toBe(false)
+    expect(hit.project.name).toBe('Real Name')
+    expect(hit.project.color).toBe('#123456')
+    expect(first.project.id).toBe(hit.project.id)
+  })
+})
+
+describe('registerProject — create (spec §2.1 step 4)', () => {
+  it('creates with the given name and color, defaulting the name to the folder basename', () => {
+    const named = useProjects.getState().registerProject({ resolvedCwd: '/a/b', name: 'Named', color: '#abcdef' })
+    expect(named.created).toBe(true)
+    expect(named.project.name).toBe('Named')
+    expect(named.project.color).toBe('#abcdef')
+    expect(named.project.cwd).toBe('/a/b')
+
+    const unnamed = useProjects.getState().registerProject({ resolvedCwd: '/a/some-repo' })
+    expect(unnamed.project.name).toBe('some-repo')
+  })
+
+  it('never activates the created project — activeProjectId is untouched in every branch', () => {
+    const active = useProjects.getState().addProject('elsewhere', '/tmp/elsewhere')
+    useProjects.getState().setActive(active.id)
+    useProjects.getState().registerProject({ resolvedCwd: '/a/b' })
+    expect(useProjects.getState().activeProjectId).toBe(active.id)
+  })
+})
+
+describe('registerProject — adopt (spec §2.1 step 3)', () => {
+  it('adopts a probed project keeping its minted id, without activating', () => {
+    const active = useProjects.getState().addProject('elsewhere', '/tmp/elsewhere')
+    useProjects.getState().setActive(active.id)
+
+    const r = useProjects
+      .getState()
+      .registerProject({ resolvedCwd: '/Users/me/dev/shared-app', probed: probed('project-minted') })
+    expect(r.adopted).toBe(true)
+    expect(r.created).toBe(false)
+    expect(r.project.id).toBe('project-minted')
+    expect(r.project.nodes).toHaveLength(1)
+    expect(useProjects.getState().activeProjectId).toBe(active.id)
+  })
+
+  it('defends against an id collision exactly as adoptProject does (derived id, nodes kept)', () => {
+    const taken = useProjects.getState().addProject('other', '/tmp/other')
+    const r = useProjects
+      .getState()
+      .registerProject({ resolvedCwd: '/Users/me/dev/shared-app', probed: probed(taken.id) })
+    expect(r.adopted).toBe(true)
+    expect(r.project.id).not.toBe(taken.id)
+    expect(r.project.nodes.map((n) => n.id)).toEqual(['term-a'])
+    // Both projects present, ids unique.
+    const ids = useProjects.getState().projects.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/src/renderer/state/projects.ts
+++ b/src/renderer/state/projects.ts
@@ -140,6 +140,30 @@ interface ProjectsState {
   /** Restores a closed project and makes it active. No-op if the id is unknown. */
   reopenProject(id: string): void
 
+  /**
+   * Registers (or finds) the project for a local directory WITHOUT activating it — the store half
+   * of the `open-project` control verb (issue #338, spec §2.1 steps 2–4). The human paths
+   * (`openFolderProject`/`adoptProject`/`reopenProject`) all set `activeProjectId`; an agent verb
+   * must not travel the user's view (spec P6), so this action NEVER writes it, in any branch.
+   *
+   * `resolvedCwd` is main's already-validated, `path.resolve`d form (spec P7) — this action only
+   * re-applies the trailing-slash normalization so the exact-string dedupe cannot be split by a
+   * cosmetic slash. Branches, in order:
+   *  - idempotent hit (B1): a project with this cwd is returned as-is; a `closed` one is
+   *    un-closed (its tab reappears) without activation. `name`/`color` are NOT applied — an
+   *    existing project's identity is never mutated on an agent's say-so.
+   *  - adopt: `probed` (the folder's own .nodeterm/project.json, from `probeFolder`) is added,
+   *    defending against an id collision exactly as `adoptProject` does (derived id, nodes kept).
+   *  - create: the same `createProject` factory `addProject` uses; `name` defaults to the folder
+   *    basename, `color` applies on create only.
+   */
+  registerProject(input: {
+    resolvedCwd: string
+    name?: string
+    color?: string
+    probed?: Project
+  }): { project: Project; created: boolean; adopted: boolean }
+
   toWorkspace(): Workspace
 }
 
@@ -555,6 +579,49 @@ export const useProjects = create<ProjectsState>((set, get) => ({
         activeProjectId: id
       }
     })
+  },
+
+  registerProject({ resolvedCwd, name, color, probed }) {
+    // The same exact-match rule as `openFolderProject` (a folder maps to one project), with the
+    // trailing slash stripped so `/a/b/` and `/a/b` cannot mint two tabs for one directory.
+    // Root stays '/': stripping it to '' would match every cwd-less project.
+    const cwd = resolvedCwd.length > 1 ? resolvedCwd.replace(/\/+$/, '') : resolvedCwd
+    const existing = get().projects.find((p) => p.cwd === cwd)
+    if (existing) {
+      if (existing.closed) {
+        // Un-close WITHOUT activation — reopenProject also activates, which is the exact
+        // mutation the register tests are checked against (spec P6).
+        set((s) => ({
+          projects: s.projects.map((p) => (p.id === existing.id ? { ...p, closed: false } : p))
+        }))
+      }
+      return {
+        project: get().projects.find((p) => p.id === existing.id) ?? existing,
+        created: false,
+        adopted: false
+      }
+    }
+    if (probed) {
+      // adoptProject's collision defense verbatim (deterministic in (id, folder)) — but appended
+      // WITHOUT the `activeProjectId` write that makes adoptProject a human path.
+      const taken = get().projects.some((p) => p.id === probed.id)
+      const adopted = taken
+        ? {
+            ...probed,
+            id: derivedProjectId(probed.id, collisionSeed(probed), (c) =>
+              get().projects.some((p) => p.id === c))
+          }
+        : probed
+      set((s) => ({ projects: [...s.projects, adopted] }))
+      return { project: adopted, created: false, adopted: true }
+    }
+    const fallbackName = cwd.split('/').filter(Boolean).pop() || 'Project'
+    const project = {
+      ...createProject(get().projects.length, name ?? fallbackName, cwd),
+      ...(color ? { color } : {})
+    }
+    set((s) => ({ projects: [...s.projects, project] }))
+    return { project, created: true, adopted: false }
   },
 
   toWorkspace() {

--- a/src/renderer/state/workspace.cold-open.test.ts
+++ b/src/renderer/state/workspace.cold-open.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { flowToNodeStates, nodeStatesToFlow } from './workspace'
+import { launchesToFire, type ArmedNode } from '../lib/pendingLaunch'
+import type { CanvasNodeState, PendingLaunch } from '@shared/types'
+
+/**
+ * Issue #338 Task 2.0 — the COLD-OPEN round-trip pins.
+ *
+ * A `--project`-targeted open into a NON-ACTIVE project writes the node into that project's
+ * serialized store with its composed launch command moved from `initialCommand` (deliberately
+ * never serialized) into `pendingLaunch: { after: [], command }` (deliberately serialized). The
+ * whole cold-open contract — "the session starts when that project's canvas is next shown" —
+ * rests on three facts, pinned here so a serialization change cannot silently strand every node
+ * opened this way:
+ *
+ *  (a) `pendingLaunch` survives `flowToNodeStates → nodeStatesToFlow` (the live↔store shape),
+ *      while `initialCommand` does not — which is WHY the command must be moved, not copied;
+ *  (b) `launchesToFire` reports a node with an empty `after` as ready (vacuously satisfied), so
+ *      the armed-launch effect fires it on the project's first view without any dep reporting;
+ *  (c) `pendingLaunch` survives the DISK round-trip — pinned in
+ *      `src/core/workspace-files.cold-open.test.ts` (the renderer cannot import src/core), because
+ *      the store write is followed by `writeDisk` and the project may not be viewed until after an
+ *      app restart, when only the file's copy exists.
+ *
+ * The manual half of Task 2.0 (a fresh tmux pane accepting the retried delivery on a cold PTY
+ * spawn) is a running-app measurement recorded in the PR body, not a unit test.
+ */
+
+const pending: PendingLaunch = { after: [], command: 'claude "do the thing"' }
+
+const armedState: CanvasNodeState = {
+  id: 'term-cold1',
+  kind: 'terminal',
+  position: { x: 40, y: 60 },
+  size: { width: 600, height: 400 },
+  title: 'Claude',
+  color: '#d97757',
+  group: null,
+  agentId: 'claude',
+  pendingLaunch: pending
+}
+
+describe('cold-open pin (a): pendingLaunch survives the store↔live round-trip', () => {
+  it('nodeStatesToFlow → flowToNodeStates keeps pendingLaunch byte-for-byte', () => {
+    const roundTripped = flowToNodeStates(nodeStatesToFlow([armedState]))[0]
+    expect(roundTripped.pendingLaunch).toEqual(pending)
+  })
+
+  it('initialCommand does NOT survive serialization — moving (not copying) it is load-bearing', () => {
+    // A live node built by the factories carries initialCommand; flowToNodeStates has no field
+    // for it. If the store path kept the command there, the node would round-trip commandless
+    // and never start. This is the mutation the Task 2.3 tests guard against.
+    const live = nodeStatesToFlow([armedState])[0]
+    live.data.initialCommand = 'claude "do the thing"'
+    const state = flowToNodeStates([live])[0]
+    expect(state).not.toHaveProperty('initialCommand')
+    expect((state as Record<string, unknown>).initialCommand).toBeUndefined()
+  })
+})
+
+describe('cold-open pin (b): an empty `after` is vacuously ready', () => {
+  it('launchesToFire reports the node ready with no agent status at all', () => {
+    const node: ArmedNode = { id: 'term-cold1', data: { pendingLaunch: pending } }
+    // No status entries, live set contains only the node itself — exactly the first render of a
+    // freshly viewed project: nothing has reported anything yet.
+    const ready = launchesToFire([node], {}, new Set(['term-cold1']))
+    expect(ready).toEqual([{ id: 'term-cold1', command: pending.command }])
+  })
+
+  it('an armed node with an unmet dep is NOT fired (the empty-after case is special)', () => {
+    const node: ArmedNode = {
+      id: 'term-cold1',
+      data: { pendingLaunch: { after: ['dep-1'], command: pending.command } }
+    }
+    const ready = launchesToFire([node], {}, new Set(['term-cold1', 'dep-1']))
+    expect(ready).toEqual([])
+  })
+})

--- a/src/renderer/state/workspace.cold-open.test.ts
+++ b/src/renderer/state/workspace.cold-open.test.ts
@@ -54,7 +54,7 @@ describe('cold-open pin (a): pendingLaunch survives the store↔live round-trip'
     live.data.initialCommand = 'claude "do the thing"'
     const state = flowToNodeStates([live])[0]
     expect(state).not.toHaveProperty('initialCommand')
-    expect((state as Record<string, unknown>).initialCommand).toBeUndefined()
+    expect((state as unknown as Record<string, unknown>).initialCommand).toBeUndefined()
   })
 })
 

--- a/src/shared/control-verbs.ts
+++ b/src/shared/control-verbs.ts
@@ -35,7 +35,10 @@
 // exactly what the renderer cannot see, and the renderer's dispatch receives a raw `verb: string`
 // off IPC anyway. `canvas-control-core.ts` re-exports this so main-side callers are unchanged.
 
-export const DESTRUCTIVE_VERBS: ReadonlySet<string> = new Set(['write', 'close'])
+// `open-project` (issue #338): create/adopt/first-attach all raise a human confirm (spec B2 +
+// Q1), and its early-handled block in Canvas.tsx reads `isDestructiveVerb(verb)` before its
+// `confirmBusy()` refusal exactly as write/close's cases do — the drift alarm covers all three.
+export const DESTRUCTIVE_VERBS: ReadonlySet<string> = new Set(['write', 'close', 'open-project'])
 
 /**
  * Does this verb's dispatch case take its `confirmBusy()` refusal from the shared set?

--- a/test/acceptance/open-project-chain.test.ts
+++ b/test/acceptance/open-project-chain.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { useProjects } from '../../src/renderer/state/projects'
+import {
+  planOpenProject,
+  recordAttachConsent,
+  clearAttachConsentForTests,
+  openProjectReply,
+  nextFreePosition,
+  armForColdOpen
+} from '../../src/renderer/lib/projectOpen'
+import { flowToNodeStates, nodeStatesToFlow, createProject } from '../../src/renderer/state/workspace'
+import {
+  clearAll as clearAllGrants,
+  clearCaller,
+  isGranted,
+  recordOpenProjectGrant,
+  gateProjectTarget,
+  gateOpenProject,
+  PROJECT_TARGET_REFUSED
+} from '../../src/main/project-grants'
+
+/**
+ * Issue #338 Task 2.5 — THE CHAIN, once, against real primitives on both sides of the boundary:
+ * the renderer's real projects store + the real pure planners, and main's real grant
+ * ledger/gates. Production layering forbids these imports inside src/ (renderer never imports
+ * main), so the chain lives here — the same reason test/server boots cross-layer.
+ *
+ * What one verified orchestrator actually experiences:
+ *   open-project (human confirms) → id returned, tab NOT activated → grant recorded main-side →
+ *   targeted open into the non-active project (store write, pendingLaunch survives the round
+ *   trip) → a second open-project on the same cwd is idempotent and silent for the SAME caller →
+ *   ANOTHER caller presenting the stolen id is refused → the caller's node teardown clears the
+ *   grant → the denial leg registers nothing and grants nothing.
+ *
+ * The running-app leg (real dialog, real cold PTY spawn, real tmux delivery) is Task 2.0's
+ * measured probe + the scripted manual run recorded in the PR body.
+ */
+
+const CALLER_A = 'term-orchestratorA'
+const CALLER_B = 'term-strangerB'
+
+let repoA = ''
+
+beforeEach(() => {
+  clearAllGrants()
+  clearAttachConsentForTests()
+  repoA = fs.mkdtempSync(path.join(os.tmpdir(), 'i338-chain-')) + '/repoA'
+  fs.mkdirSync(repoA)
+  useProjects.getState().hydrate({
+    version: 2,
+    activeProjectId: '',
+    projects: []
+  })
+  // The workspace the human is looking at: the orchestrator's own project, active.
+  const own = useProjects.getState().addProject('control-room', '/tmp/control-room')
+  useProjects.getState().setActive(own.id)
+})
+
+/** Main's pre-forward gate with a real stat on the real directory (spec P7). */
+const gateCwd = (raw: string) =>
+  gateOpenProject({
+    callerProjectId: useProjects.getState().activeProjectId,
+    callerIsSsh: false,
+    atCap: false,
+    rawCwd: raw,
+    statFn: (p) => fs.statSync(p)
+  })
+
+describe('the open-project → targeted-open chain', () => {
+  it('runs end to end with exactly one human decision per caller+project', () => {
+    const store = useProjects.getState()
+    const activeBefore = store.activeProjectId
+
+    // 1. Main resolves + validates the hostile --cwd once; the renderer only ever sees the
+    //    resolved form (P5/P7) — here proven with a real un-normalized path.
+    const gate = gateCwd(repoA + '/./')
+    expect('resolvedCwd' in gate && gate.resolvedCwd).toBe(repoA)
+    const resolvedCwd = (gate as { resolvedCwd: string }).resolvedCwd
+
+    // 2. First contact: the plan demands a CONFIRM (create) — never a silent create.
+    const plan1 = planOpenProject({
+      projects: useProjects.getState().projects,
+      callerNodeId: CALLER_A,
+      srcTitle: 'Orchestrator',
+      resolvedCwd
+    })
+    expect(plan1.kind).toBe('confirm')
+    if (plan1.kind !== 'confirm') return
+    expect(plan1.confirmKind).toBe('create')
+    expect(plan1.message).toContain(resolvedCwd)
+
+    // 3. The human confirms → the NON-ACTIVATING registration; the reply carries the id.
+    const r1 = useProjects.getState().registerProject({ resolvedCwd })
+    recordAttachConsent(CALLER_A, r1.project.id)
+    expect(r1.created).toBe(true)
+    const reply1 = openProjectReply(r1.project, r1.created, r1.adopted)
+    expect(reply1.result.projectId).toBe(r1.project.id)
+    // B4/P6: the visible tab did not move.
+    expect(useProjects.getState().activeProjectId).toBe(activeBefore)
+
+    // 4. Main records the grant off the ok reply and ITS OWN verified verdict.
+    expect(recordOpenProjectGrant(CALLER_A, { ok: true, result: reply1.result }, true)).toBe(
+      'recorded'
+    )
+    expect(isGranted(CALLER_A, r1.project.id)).toBe(true)
+
+    // 5. Targeted open into the (non-active) project: the real gate allows the grant holder…
+    const gateA = gateProjectTarget({
+      verified: true,
+      verb: 'open-agent',
+      targetProjectId: r1.project.id,
+      callerProjectId: activeBefore,
+      targetIsSsh: false,
+      granted: isGranted(CALLER_A, r1.project.id)
+    })
+    expect(gateA).toBe('allow')
+
+    // …and the store write lands an ARMED node that survives the round trip (Task 2.0's pins,
+    // exercised through the real store this time).
+    const center = nextFreePosition(r1.project.nodes)
+    const live = nodeStatesToFlow([
+      {
+        id: 'term-target1',
+        kind: 'terminal',
+        position: { x: center.x - 300, y: center.y - 200 },
+        size: { width: 600, height: 400 },
+        title: 'Claude',
+        color: '#d97757',
+        group: null,
+        agentId: 'claude'
+      }
+    ])[0]
+    live.data.initialCommand = 'claude "work in repoA"'
+    const armedState = flowToNodeStates([armForColdOpen(live)])[0]
+    expect(
+      useProjects.getState().applyNodeMutation(r1.project.id, { op: 'upsert', node: armedState })
+    ).toBe(true)
+    const stored = useProjects
+      .getState()
+      .getProject(r1.project.id)
+      ?.nodes.find((n) => n.id === 'term-target1')
+    expect(stored?.pendingLaunch).toEqual({ after: [], command: 'claude "work in repoA"' })
+    // Still no travel.
+    expect(useProjects.getState().activeProjectId).toBe(activeBefore)
+
+    // 6. SECOND open-project, same cwd, same caller: idempotent AND silent — no second confirm,
+    //    no duplicate project.
+    const plan2 = planOpenProject({
+      projects: useProjects.getState().projects,
+      callerNodeId: CALLER_A,
+      srcTitle: 'Orchestrator',
+      resolvedCwd
+    })
+    expect(plan2.kind).toBe('silent')
+    const r2 = useProjects.getState().registerProject({ resolvedCwd })
+    expect(r2.created).toBe(false)
+    expect(r2.project.id).toBe(r1.project.id)
+    expect(useProjects.getState().projects.filter((p) => p.cwd === repoA)).toHaveLength(1)
+
+    // 7. ANOTHER caller presenting the id it was never granted: refused, byte-identically to
+    //    every other stranger (P2 — the grant is per-caller).
+    const gateB = gateProjectTarget({
+      verified: true,
+      verb: 'open-agent',
+      targetProjectId: r1.project.id,
+      callerProjectId: activeBefore,
+      targetIsSsh: false,
+      granted: isGranted(CALLER_B, r1.project.id)
+    })
+    expect(gateB).toEqual({ refuse: PROJECT_TARGET_REFUSED })
+    // …and its dialog is not skipped either: caller B's plan confirms (per-caller consent).
+    const planB = planOpenProject({
+      projects: useProjects.getState().projects,
+      callerNodeId: CALLER_B,
+      srcTitle: 'Stranger',
+      resolvedCwd
+    })
+    expect(planB.kind).toBe('confirm')
+
+    // 8. The caller's node is torn down (pty destroy/recycle in main): the grant dies with it —
+    //    the next targeted open refuses (P3, session-scoped).
+    clearCaller(CALLER_A)
+    const gateAfterTeardown = gateProjectTarget({
+      verified: true,
+      verb: 'open-agent',
+      targetProjectId: r1.project.id,
+      callerProjectId: activeBefore,
+      targetIsSsh: false,
+      granted: isGranted(CALLER_A, r1.project.id)
+    })
+    expect(gateAfterTeardown).toEqual({ refuse: PROJECT_TARGET_REFUSED })
+  })
+
+  it('the denial leg: cancel registers nothing and grants nothing', () => {
+    const before = useProjects.getState().projects.length
+    const plan = planOpenProject({
+      projects: useProjects.getState().projects,
+      callerNodeId: CALLER_A,
+      srcTitle: 'Orchestrator',
+      resolvedCwd: repoA
+    })
+    expect(plan.kind).toBe('confirm')
+    // The human cancels: the dispatch replies { ok: false, error: 'denied by user' } WITHOUT
+    // calling registerProject (the only creation site is behind opFinish —
+    // control-open-project.source.test.ts pins that structurally). Main's record path then sees
+    // a not-ok reply and mints nothing:
+    expect(
+      recordOpenProjectGrant(CALLER_A, { ok: false, result: undefined }, true)
+    ).toBe('not-applicable')
+    expect(isGranted(CALLER_A, 'anything')).toBe(false)
+    expect(useProjects.getState().projects.length).toBe(before)
+  })
+
+  it('a cold-opened node placed by nextFreePosition never lands on an existing node', () => {
+    // The placement contract on the REAL store shapes: seed a store project with nodes, place,
+    // assert no rect intersection (the pure suite proves the geometry; this proves the shapes).
+    const seeded = createProject(9, 'seeded', '/tmp/seeded')
+    const nodes = [
+      { ...seedNode('a', 0, 0, 600, 400) },
+      { ...seedNode('b', 700, 300, 240, 200) }
+    ]
+    const withNodes = { ...seeded, nodes }
+    const size = { width: 640, height: 440 }
+    const c = nextFreePosition(withNodes.nodes, size)
+    for (const n of nodes) {
+      const disjoint =
+        c.x + size.width / 2 <= n.position.x ||
+        n.position.x + n.size.width <= c.x - size.width / 2 ||
+        c.y + size.height / 2 <= n.position.y ||
+        n.position.y + n.size.height <= c.y - size.height / 2
+      expect(disjoint).toBe(true)
+    }
+  })
+})
+
+function seedNode(id: string, x: number, y: number, w: number, h: number) {
+  return {
+    id,
+    kind: 'terminal' as const,
+    position: { x, y },
+    size: { width: w, height: h },
+    title: id,
+    color: '#fff',
+    group: null
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
       'src/server/**/*.test.ts',
       'test/server/**/*.test.ts',
       'test/remote/**/*.test.ts',
+      // Cross-layer acceptance chains (e.g. renderer store + main's pure gates in one flow):
+      // production layering forbids these imports inside src/, so the chain lives here, like
+      // test/server's cross-layer boots.
+      'test/acceptance/**/*.test.ts',
       // Opt-in end-to-end tests against a real sshd in Docker. They self-skip unless
       // NODETERM_SSH_DOCKER is set, so a machine without Docker still runs a green suite.
       'test/ssh-docker/**/*.test.ts'


### PR DESCRIPTION
PR 2 of 2 for #338 (PR 1 = #362, merged): the renderer dispatch that makes `open-project --cwd` and `--project` targeting **live**. Fixes #338.

## Tasks → commits

| Task | Commit | What |
| --- | --- | --- |
| 2.0 probe | `cd5057d4` | Cold-open round-trip pins: `pendingLaunch{after:[],command}` survives live↔store AND disk round-trips while `initialCommand` is dropped by design; `launchesToFire` reports empty-`after` vacuously ready. Manual leg below. |
| 2.1 | `423f934f` | `registerProject` — non-activating create/find/adopt/un-close on the trailing-slash-normalized resolved cwd; never writes `activeProjectId` in any branch. |
| 2.2 | `dd0c3bfe` | `open-project` dispatch: early (before source routing), `STORE_ANSWERED_VERBS` + `DESTRUCTIVE_VERBS` membership (PR 1's tripwire deleted as designed), pure `planOpenProject` consent decision (Q1 adopted: FIRST attach per caller+project confirms, with lighter copy), dialog shows main's RESOLVED path, reply `{projectId,name,cwd,created}` exactly once on confirm AND cancel. Grant recorded main-side on ok && verified (PR 1's wrapper, now fed by a real reply — verified end-to-end in the live run below). |
| 2.3 | `4e15fdb6` | `--project` targeted opens: active target → live `setNodes` insertion (starts immediately); non-active target → `armForColdOpen` (launch MOVES into `pendingLaunch`) + `applyNodeMutation` + `writeDisk`, reply names the cold-open contract. Target-derived defaults (cwd, account funnel, `projectPermissionMode`, launch override). `--group`/`--after` + `--project` → `project-target-flag-unsupported`; own id falls through unchanged; unknown/SSH targets refused as belt; gate-before-write pinned; no cross-project ropes/links (v1). Placement via pure `nextFreePosition`. |
| 2.4 | `77894e87` | Agent-facing docs in the SAME PR: both bodies document `open-project` (idempotent, denial is final, local-only, returns the id, never focuses) + the `--project` clause (own-or-returned-id as fact, cold-open "do not poll", flag exclusion) + the multi-repo recipe. Parity tests walk the REAL `PROJECT_TARGETABLE_VERBS` set. |
| 2.5 | `c84afaf6` | Acceptance chain on real primitives (`test/acceptance/`): gate→confirm→register→grant→target→round-trip→idempotent-silent→stranger-refused→teardown-revoked→denial-registers-nothing. |

## Task 2.0 probe result — CONFIRMS the design (no retry-budget fix needed)

Ran against the real app (xvfb + CDP + real tmux, Linux):
- A node written into a NON-ACTIVE project's store with `pendingLaunch{after:[],command}` spawned its PTY on first view; the launch-effect retry loop landed the command in the fresh tmux pane **1.13 s** after the tab click (5×400 ms budget; no `[pending-launch] gave up`). `pendingLaunch` was cleared from disk by the debounced save.
- In the acceptance run the same leg measured **0.63 s** click-to-command-executed.

## Scripted manual acceptance (real app, real verified caller)

Two plain terminal nodes as callers (per-node tokens minted; commands typed into their panes over tmux; dialogs clicked over CDP):
1. `open-project --cwd …/repoC/../repoC/` → dialog shows the **resolved** path → Create → `created project "repoC" (project-…)`; tab bar gains repoC, **active tab unchanged**.
2. `open-terminal --project <id> --cmd …` (target non-active) → reply `— starts when that project is next viewed`; repoC's `project.json` holds the node with `pendingLaunch` and portable cwd.
3. Second `open-project` same cwd, same caller → same id, **no dialog** (idempotent + Q1 once-per-caller).
4. Second caller presents the id → `project-target-refused: …` (PR 1's exact sentence).
5. Viewing repoC → cold session starts, command executes (0.63 s).
6. Denial: second caller's create canceled → `denied by user`, nothing created on disk, no tab.
7. Q1 first-attach: second caller's `open-project` on existing repoC → "wants to open sessions in project "repoC". Allow?" → Allow → its targeted open then succeeds via the **live-insertion** branch (target was active) and runs immediately.
8. `--project` + `--group` → `project-target-flag-unsupported`.

## Mutation checks — 15 introduced / 15 caught

| # | Mutation (introduced, red verified, reverted) | Caught by |
| --- | --- | --- |
| 1 | `flowToNodeStates` drops `pendingLaunch` | cold-open pin (a) |
| 2 | `launchesToFire` skips empty-`after` | cold-open pin (b) |
| 3 | `registerProject` un-close leg uses activating `reopenProject` | projects.register (P6) |
| 4 | confirm-bypass: first attach silently hits | projectOpen (Q1) |
| 5 | create dialog drops the resolved path | projectOpen (P5) |
| 6 | dispatch activates the registered project | source pin (P6) |
| 7 | cancel leg also registers | source pin (P4) |
| 8 | store path skips `armForColdOpen` | source pin |
| 9 | `armForColdOpen` copies instead of moving | projectOpen |
| 10 | SSH-belt refusal moved after the store write | source pin (gate-before-write) |
| 11 | `nextFreePosition` ignores the parent chain | projectOpen |
| 12 | skill line drops `--project` | doc parity |
| 13 | cold-open sentence dropped from instructions | doc parity |
| 14 | `registerProject` dedupe dropped | acceptance chain (B1) |
| 15 | grants keyed globally, not per-caller | acceptance chain (P2) |

## Verification

`npm run typecheck` green after every task; named suites green per task (TDD — each new suite shown red first); full `npx vitest run`: **604 files / 8451 tests passed** (12 skipped), +48 tests over PR 1's baseline, no regressions. Surfaces: Desktop = the feature; Server Edition = still refused by the existing named handler (pinned in PR 1); mobile never originates — effects ride existing sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
