### PR TITLE
Landing page: note Windows support is coming

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -40,7 +40,7 @@
 
     <main>
       <section class="hero">
-        <span class="badge">macOS · Apple Silicon &amp; Intel · Free</span>
+        <span class="badge">macOS · Apple Silicon &amp; Intel · Windows soon · Free</span>
         <h1>Your terminals on an<br /><span class="grad">infinite canvas.</span></h1>
         <p class="lede">
           Multiple real terminals as draggable nodes on a single pan/zoom canvas — a spatial
@@ -63,6 +63,7 @@
           <a id="dl-intel" href="https://github.com/eneskirca/nodeterm/releases">Intel</a>
           <span id="ver-meta">— free for personal use · macOS 12+</span>
         </p>
+        <p class="cta-meta">Windows support is on the way — the same terminals, canvas, and agents, coming soon.</p>
 
         <div class="window">
           <img src="assets/hero.svg" alt="nodeterm canvas with terminal, Claude Code, sticky note, and editor nodes" />


### PR DESCRIPTION
Adds an honest "Windows soon" cue to the landing page now that the Windows-support extraction (#300, #302, #303, #305) has merged.

**Deliberately NOT a download button.** There is no signed Windows installer or Windows release pipeline yet — packaging is groundwork. A "Download for Windows" link would hand the visitor nothing, so this is a "coming soon" note instead:
- Hero badge: `… · Windows soon · Free`
- A one-line note under the download CTA: "Windows support is on the way — the same terminals, canvas, and agents, coming soon."

Flip this to a real download once there's a signed `nodeterm-Setup-*.exe` on the release feed. Framing (soon vs available) is easy to change if you'd prefer different wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)