### PR TITLE
feat(keybindings): a bindable command per agent and per node type

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -5815,6 +5815,29 @@ export function Canvas() {
           )
         )
         return true
+      },
+      // Per-agent creates: the chord names the agent, so these bypass resolveNewNodeAgent (which
+      // answers "what does this project default to?") and open exactly what the row says.
+      'node.newAgent.claude': () => { addAgentNode('claude'); return true },
+      'node.newAgent.codex': () => { addAgentNode('codex'); return true },
+      'node.newAgent.gemini': () => { addAgentNode('gemini'); return true },
+      'node.newAgent.opencode': () => { addAgentNode('opencode'); return true },
+      'node.newAgent.grok': () => { addAgentNode('grok'); return true },
+      'node.newAgent.copilot': () => { addAgentNode('copilot'); return true },
+      'node.newSticky': () => { addSticky(); return true },
+      'node.newBrowser': () => { addBrowser(); return true },
+      // Opening the URL prompt IS claiming the chord — a cancelled prompt creates nothing, but the
+      // keystroke was consumed by us and must not fall through to the platform.
+      'node.newWebView': () => { void addWebView(); return true },
+      'node.newDino': () => { addDino(); return true },
+      'node.newFile': () => {
+        // Same gate the pane menu / ⌘K use for their "New file…" row: the file is created UNDER
+        // the project folder, so a cwd-less (inline) project has nowhere to put it. Refuse rather
+        // than open a prompt that could only fail — and refusing lets the chord fall through.
+        const project = useProjects.getState().getProject(activeProjectId ?? '')
+        if (!(project?.ssh?.remoteCwd ?? project?.cwd)) return false
+        void newProjectFile()
+        return true
       }
       // node.close / node.toggleMarkdown: main-process intercepted on desktop; deliberately
       // no renderer handler (the browser owns ⌘W in the Server Edition — see bridge/stubs.ts).

--- a/src/renderer/canvas/keybindings-handler-parity.test.ts
+++ b/src/renderer/canvas/keybindings-handler-parity.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Source-level parity: every `node.new*` command in the registry has a handler in Canvas.tsx.
+ *
+ * `CommandHandlers` is a `Partial<Record<CommandId, …>>` (deliberately — most registry commands
+ * are owned by local listeners or by the main process, not by the canvas dispatcher), so the
+ * compiler can never tell you a create command shipped with no handler. It would simply be a
+ * remappable row in Settings whose chord does nothing, with the user's own binding as the only
+ * evidence. Same discipline as `hook-verified-parity.test.ts`: read the source, assert the key.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { COMMAND_DEFINITIONS } from '@shared/keybindings'
+
+const canvasSource = readFileSync(join(__dirname, 'Canvas.tsx'), 'utf8')
+
+describe('Canvas keybinding handler parity', () => {
+  const createIds = COMMAND_DEFINITIONS.map((d) => d.id).filter((id) => id.startsWith('node.new'))
+
+  it('finds the create commands to check (guards against an empty sweep)', () => {
+    expect(createIds.length).toBeGreaterThanOrEqual(13)
+  })
+
+  // `includes` + a message rather than `toContain`: a miss on a 12k-line file would otherwise
+  // print the whole source as the diff and bury the one fact the failure carries.
+  it.each(createIds)('%s has a handler entry in Canvas.tsx', (id) => {
+    expect(
+      canvasSource.includes(`'${id}':`),
+      `Canvas.tsx has no '${id}' handler — the handlers map is Partial, so nothing else catches this`
+    ).toBe(true)
+  })
+})

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -14,6 +14,12 @@ import { ShortcutsSection, commitCandidate } from './ShortcutsSection'
 // so pin macOS here — `isMacPlatform()` is read at call time, never captured at module load.
 Object.defineProperty(window.navigator, 'platform', { value: 'MacIntel', configurable: true })
 
+/** How many commands ship with NO chord on the pinned (mac) platform. COMPUTED, because the
+ *  registry is a growing POOL: every unbound command added later would otherwise red these
+ *  counts with a number that says nothing about the behavior under test. Overrides are absent in
+ *  the cases below (or sanitized away), so the effective binding IS the mac default. */
+const UNASSIGNED = COMMAND_DEFINITIONS.filter((d) => d.defaultBindings.darwin.length === 0).length
+
 const setKb = (kb: unknown): void =>
   useSettings.setState({ settings: { ...DEFAULT_SETTINGS, keybindings: kb as never } })
 
@@ -200,7 +206,7 @@ describe('ShortcutsSection rows', () => {
     expect(statusLabels()).toEqual([
       `All ${COMMAND_DEFINITIONS.length}`,
       'Modified 0',
-      'Unassigned 2',
+      `Unassigned ${UNASSIGNED}`,
       'Disabled 0'
     ])
   })
@@ -343,8 +349,8 @@ describe('the filter rail', () => {
     expect(statusLabels()).toEqual([
       `All ${COMMAND_DEFINITIONS.length}`,
       'Modified 0',
-      // fitAll + groupSelection ship with no default chord.
-      'Unassigned 2',
+      // fitAll + groupSelection + the PR-7 create pool ship with no default chord.
+      `Unassigned ${UNASSIGNED}`,
       'Disabled 0'
     ])
   })
@@ -355,7 +361,7 @@ describe('the filter rail', () => {
     expect(statusLabels()).toEqual([
       `All ${COMMAND_DEFINITIONS.length}`,
       'Modified 1',
-      'Unassigned 2',
+      `Unassigned ${UNASSIGNED}`,
       'Disabled 0'
     ])
   })
@@ -379,7 +385,7 @@ describe('the filter rail', () => {
     expect(statusLabels()).toEqual([
       `All ${COMMAND_DEFINITIONS.length}`,
       'Modified 1',
-      'Unassigned 2',
+      `Unassigned ${UNASSIGNED}`,
       'Disabled 1'
     ])
 

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -14,6 +14,8 @@ import {
   MAIN_INTERCEPTED_COMMAND_IDS,
   findMainInterceptShadowing
 } from './keybindings'
+import type { CommandId } from './keybindings'
+import { AGENT_CONFIG, BUILTIN_AGENT_IDS } from './agents/config'
 import { parseShortcut } from './shortcut'
 import type { ShortcutKeyEvent } from './shortcut'
 
@@ -93,6 +95,29 @@ describe('registry invariants', () => {
         darwin: ['Cmd+T'], other: ['Cmd+T'] },
       { id: 'node.newAgent', title: 'New agent node', group: 'Nodes', scope: 'canvas',
         darwin: ['Cmd+Shift+C'], other: ['Cmd+Shift+C'] },
+      // The per-agent + per-node-kind creates: pool only, no default chord on either platform.
+      { id: 'node.newAgent.claude', title: 'New Claude Code node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newAgent.codex', title: 'New Codex node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newAgent.gemini', title: 'New Gemini node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newAgent.opencode', title: 'New opencode node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newAgent.grok', title: 'New Grok node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newAgent.copilot', title: 'New GitHub Copilot node', group: 'Nodes',
+        scope: 'canvas', darwin: [], other: [] },
+      { id: 'node.newSticky', title: 'New sticky note', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newBrowser', title: 'New browser node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newWebView', title: 'New web view node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newDino', title: 'New dino node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newFile', title: 'New file…', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
       { id: 'node.close', title: 'Close node / window', group: 'Nodes', scope: 'app',
         darwin: ['Cmd+W'], other: ['Cmd+W'], allowInTerminal: true, allowWhileTyping: true },
       { id: 'node.toggleMarkdown', title: 'Toggle markdown view', group: 'Nodes', scope: 'app',
@@ -112,6 +137,48 @@ describe('registry invariants', () => {
   it('isCommandId accepts known ids and rejects unknowns', () => {
     expect(isCommandId('node.newTerminal')).toBe(true)
     expect(isCommandId('node.selfDestruct')).toBe(false)
+  })
+
+  // Parity with the agent registry, both directions. The union is spelled statically (so the
+  // CommandId type stays literal), which means nothing but this test notices when builtin agent
+  // #7 lands: it reds here until `node.newAgent.<id>` exists, and it reds again if a command
+  // outlives the agent it creates.
+  it('has one create command per builtin agent, titled from AGENT_CONFIG', () => {
+    const perAgent = COMMAND_DEFINITIONS.map((d) => d.id).filter((id) =>
+      id.startsWith('node.newAgent.')
+    )
+    expect([...perAgent].sort()).toEqual(
+      BUILTIN_AGENT_IDS.map((a) => `node.newAgent.${a}`).sort()
+    )
+    for (const agentId of BUILTIN_AGENT_IDS) {
+      const d = COMMANDS_BY_ID.get(`node.newAgent.${agentId}` as CommandId)
+      expect(d?.title).toBe(`New ${AGENT_CONFIG[agentId].label} node`)
+      expect(d?.group).toBe('Nodes')
+      expect(d?.scope).toBe('canvas')
+    }
+  })
+
+  // Every command this PR added ships with NO default chord — the pool grows, the out-of-box
+  // key map does not. A default sneaking in here would shadow an existing binding or steal a
+  // key from the terminal for a user who never asked for the command.
+  it('ships the new create commands unbound on both platforms', () => {
+    const added: readonly string[] = [
+      ...BUILTIN_AGENT_IDS.map((a) => `node.newAgent.${a}`),
+      'node.newSticky',
+      'node.newBrowser',
+      'node.newWebView',
+      'node.newDino',
+      'node.newFile'
+    ]
+    expect(added).toHaveLength(11)
+    for (const id of added) {
+      const d = COMMANDS_BY_ID.get(id as CommandId)
+      expect(d, id).toBeDefined()
+      expect(d!.defaultBindings.darwin, id).toEqual([])
+      expect(d!.defaultBindings.other, id).toEqual([])
+      expect(getEffectiveBindings(id as CommandId, {}, true), id).toEqual([])
+      expect(getEffectiveBindings(id as CommandId, {}, false), id).toEqual([])
+    }
   })
 })
 

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -6,6 +6,7 @@
  * canonical binding strings are shortcut.ts strings (`Cmd` = abstract primary modifier,
  * `Ctrl` = literal Control, modifier-only chords = hold-to-talk).
  */
+import { AGENT_CONFIG } from './agents/config'
 import {
   parseShortcut,
   serializeShortcut,
@@ -53,6 +54,20 @@ export type CommandId =
   | 'canvas.groupSelection'
   | 'node.newTerminal'
   | 'node.newAgent'
+  // Per-builtin-agent creates. The six ids are spelled STATICALLY (never derived from
+  // BUILTIN_AGENT_IDS) so this union stays literal — `isCommandId`, the overrides map and the
+  // handler table all depend on that.
+  | 'node.newAgent.claude'
+  | 'node.newAgent.codex'
+  | 'node.newAgent.gemini'
+  | 'node.newAgent.opencode'
+  | 'node.newAgent.grok'
+  | 'node.newAgent.copilot'
+  | 'node.newSticky'
+  | 'node.newBrowser'
+  | 'node.newWebView'
+  | 'node.newDino'
+  | 'node.newFile'
   | 'node.close'
   | 'node.toggleMarkdown'
   | 'terminal.find'
@@ -108,6 +123,32 @@ export const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     // Non-mac note: Ctrl+Shift+C is a common terminal-copy convention; kept for parity
     // with current behavior, revisit with telemetry.
     defaultBindings: both('Cmd+Shift+C') },
+  // Every command below ships UNBOUND on purpose: they expand the remappable POOL, and a chord
+  // nobody asked for would either shadow an existing default or steal a key from the terminal.
+  // The user assigns them in Settings → Keyboard Shortcuts; titles come from AGENT_CONFIG so a
+  // relabelled agent cannot drift from its row.
+  { id: 'node.newAgent.claude', title: `New ${AGENT_CONFIG.claude.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newAgent.codex', title: `New ${AGENT_CONFIG.codex.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newAgent.gemini', title: `New ${AGENT_CONFIG.gemini.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newAgent.opencode', title: `New ${AGENT_CONFIG.opencode.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newAgent.grok', title: `New ${AGENT_CONFIG.grok.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newAgent.copilot', title: `New ${AGENT_CONFIG.copilot.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newSticky', title: 'New sticky note', group: 'Nodes', scope: 'canvas',
+    defaultBindings: both() },
+  { id: 'node.newBrowser', title: 'New browser node', group: 'Nodes', scope: 'canvas',
+    defaultBindings: both() },
+  { id: 'node.newWebView', title: 'New web view node', group: 'Nodes', scope: 'canvas',
+    defaultBindings: both() },
+  { id: 'node.newDino', title: 'New dino node', group: 'Nodes', scope: 'canvas',
+    defaultBindings: both() },
+  { id: 'node.newFile', title: 'New file…', group: 'Nodes', scope: 'canvas',
+    defaultBindings: both() },
   // Main-process intercepted today (unconditional): keep firing everywhere.
   { id: 'node.close', title: 'Close node / window', group: 'Nodes', scope: 'app',
     defaultBindings: both('Cmd+W'), allowInTerminal: true, allowWhileTyping: true },


### PR DESCRIPTION
## What changed

The command pool grows by **11 bindable create commands** — one per builtin agent and one per argument-free node kind — so a direct shortcut can open exactly the node you want instead of going through the dock/menu:

- **Per agent** (titles from `AGENT_CONFIG` labels): `node.newAgent.claude`, `.codex`, `.gemini`, `.opencode`, `.grok`, `.copilot`. The existing `node.newAgent` (⌘⇧C) is untouched and still opens the project/global **default** agent.
- **Per node kind**: `node.newSticky`, `node.newBrowser`, `node.newWebView` (opens the URL prompt), `node.newDino`, `node.newFile` (opens the New-file flow; on a project with no folder the chord deliberately falls through — same condition under which the pane menu hides the row).

All 11 ship **unbound by default**: zero upgrade-time conflicts, zero main-intercept/menu interaction, and the Settings section's **Unassigned** filter is exactly where they surface — record whichever you actually use. The section needed no changes: rows, groups and status counts all derive from `COMMAND_DEFINITIONS`.

## Drift protection

- A registry test derives the expected `node.newAgent.<id>` set from the builtin agent ids — adding a 7th builtin agent reds it until its command exists.
- A new source-level parity test (`keybindings-handler-parity.test.ts`, the `hook-verified-parity` discipline) asserts every `node.new*` command has a handler key in Canvas — the handlers map is `Partial`, so the compiler cannot catch a definition shipped without a handler (written RED-first: 11 failures before the handlers landed).
- The `'Unassigned 2'` literals in the section tests became one computed constant, so the next pool expansion doesn't red them.

## Out of scope, deliberately

- **Custom agents**: the registry is a static id union; `node.newAgent` already honors a custom default agent (per project or globally), which covers the common case.
- **Editor/video/diff nodes**: they need a file path — `node.newFile` covers the editor entry point.
- **Group frames**: meaningless without a selection; `canvas.groupSelection` already exists.
- The ⌘/ cheat-sheet panel deliberately does not list unbound commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
