### PR TITLE
fix(hooks): a sandboxed Codex gets an actionable error, and the hook server listens on a unix socket

### DIFF
--- a/src/core/agents/codex-thread-id-route.test.ts
+++ b/src/core/agents/codex-thread-id-route.test.ts
@@ -75,8 +75,10 @@ describe('/codex-thread/bind refuses a path-unsafe thread id', () => {
     }
     expect(bound).toEqual([])
     // Nothing anywhere: not in the store, and — the `..` row — not in the store's parent either.
+    // (`sock/` is the hook server's own unix-socket listener dir, issue #367 — always present,
+    // never a record.)
     expect(existsSync(codexThreadIdentityRoot())).toBe(false)
-    expect(readdirSync(dir)).toEqual(['hook-endpoint.env'])
+    expect(readdirSync(dir).sort()).toEqual(['hook-endpoint.env', 'sock'])
   })
 
   it('still binds a thread id the app-server would actually mint', async () => {

--- a/src/core/agents/hook-identity-enforcement.test.ts
+++ b/src/core/agents/hook-identity-enforcement.test.ts
@@ -361,7 +361,10 @@ describe('the latch is memory, not state', () => {
     const walk = (root: string): string[] =>
       readdirSync(root).flatMap((entry) => {
         const full = join(root, entry)
-        return statSync(full).isDirectory() ? walk(full) : [full]
+        const st = statSync(full)
+        // Regular files only: the hook server's own unix socket (issue #367) lives under the data
+        // dir too, and a socket is not readable state — opening it is ENXIO, not evidence.
+        return st.isDirectory() ? walk(full) : st.isFile() ? [full] : []
       })
     for (const file of walk(dir)) {
       // A persisted latch is a node that one filesystem accident can brick forever. Nothing on

--- a/src/core/agents/hook-sandbox-hint-sh.ts
+++ b/src/core/agents/hook-sandbox-hint-sh.ts
@@ -1,0 +1,60 @@
+/**
+ * The Codex-sandbox self-diagnosis both generated sh shims share (issue #367).
+ *
+ * Codex's command sandbox denies network connect() outright when its network policy is disabled —
+ * on Linux a seccomp filter EPERMs `connect()` for EVERY address family (unix sockets included,
+ * with no allowlist), and on macOS the seatbelt base profile is `(deny default)` with no
+ * network-outbound allowance. Either way curl dies with exit != 0 / HTTP 000 while the nodeterm
+ * hook server is perfectly healthy, and the shims' generic "nodeterm unreachable" message sent
+ * agents (and users) off to relink or restart a server that was never the problem.
+ *
+ * Codex exports `CODEX_SANDBOX_NETWORK_DISABLED=1` into every sandboxed command on both
+ * platforms, so the shims can tell the two failures apart at the exact moment they happen. The
+ * remedies differ by platform:
+ *  - both: retry the SAME command once with command-specific escalated permissions (the sandbox
+ *    is per-command; an escalated retry runs outside it);
+ *  - macOS only (codex >= 0.146): `network.allow_unix_sockets = ["<hook sock>"]` in
+ *    ~/.codex/config.toml permanently re-opens exactly the hook socket inside the sandbox, no
+ *    escalation needed. Linux has no such allowlist, so that line would be a false promise there
+ *    — the fragment gates it on `uname -s` = Darwin as well as on the socket being advertised.
+ *
+ * The message text lives in exported constants so the agent-facing docs (skill bodies + AGENTS.md
+ * instruction blocks) can carry the same sentences and the parity tests can hold the two ends
+ * together; the sh fragment is exercised against real /bin/sh in the shim test suites.
+ */
+
+/** Both platforms, line 1: what actually failed, and what NOT to do about it. */
+export const CODEX_SANDBOX_BLOCKED_LINE =
+  "Codex's sandbox blocked this connection to nodeterm. nodeterm itself is running — do not relink or restart it."
+
+/** Both platforms, line 2: the one action that works everywhere. */
+export const CODEX_SANDBOX_RETRY_LINE =
+  'Retry the SAME command once with command-specific escalated permissions (approve the escalation prompt for this command).'
+
+/** macOS only, wrapped around the advertised hook socket path. */
+export const CODEX_SANDBOX_MACOS_BEFORE =
+  'Permanent fix on macOS: add network.allow_unix_sockets = ['
+export const CODEX_SANDBOX_MACOS_AFTER =
+  '] to ~/.codex/config.toml — the sandbox then allows this hook socket with no escalation.'
+
+/**
+ * POSIX-sh fragment defining `nt_codex_sandbox_hint`: prints the actionable error to stderr and
+ * returns 0 when the codex sandbox is the diagnosis, returns 1 (printing nothing) otherwise —
+ * so call sites read `nt_codex_sandbox_hint || echo "<the old generic message>" >&2` and the
+ * genuine-unreachable case keeps its original text to the byte.
+ */
+export const CODEX_SANDBOX_HINT_SH = `# Codex-sandbox self-diagnosis (issue #367). Codex exports CODEX_SANDBOX_NETWORK_DISABLED=1 into
+# every sandboxed command; when it is present, a dead transport (curl exit != 0 / HTTP 000) means
+# the SANDBOX denied connect() — Linux seccomp EPERMs every address family, macOS seatbelt is
+# deny-by-default — and the generic "unreachable" message would misdirect the agent into
+# relinking/restarting a healthy server. Prints the actionable error and returns 0 only in that
+# state; callers fall back to their own generic message on 1.
+nt_codex_sandbox_hint() {
+  [ -n "$CODEX_SANDBOX_NETWORK_DISABLED" ] || return 1
+  echo "${CODEX_SANDBOX_BLOCKED_LINE}" >&2
+  echo "${CODEX_SANDBOX_RETRY_LINE}" >&2
+  if [ -n "$NODETERM_HOOK_SOCK" ] && [ "$(uname -s)" = "Darwin" ]; then
+    echo "${CODEX_SANDBOX_MACOS_BEFORE}\\"$NODETERM_HOOK_SOCK\\"${CODEX_SANDBOX_MACOS_AFTER}" >&2
+  fi
+  return 0
+}`

--- a/src/core/agents/hook-server.sock.test.ts
+++ b/src/core/agents/hook-server.sock.test.ts
@@ -1,0 +1,163 @@
+// The hook server's unix-socket listener (issue #367), exercised with the REAL curl against the
+// REAL server — the same discipline as canvas-control-shim.test.ts, because the consumers of this
+// listener are generated sh clients whose transport is exactly `curl --unix-socket`.
+//
+// What must hold: the socket answers the SAME routes through the SAME handler under the SAME auth
+// as loopback TCP (it is a second door to one room, never a side entrance around the bearer or the
+// per-node verdict); it sits at 0600 inside a 0700 dir; a stale socket file from a crash never
+// blocks the next boot; and it is advertised — posixQuoted in the endpoint file (#358) and as
+// NODETERM_HOOK_SOCK in the session env — only when it actually bound.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { hookServer } from './hook-server'
+import { nodeAuthToken } from './node-auth-token'
+import { parseEndpointEnv } from './hook-endpoint-parse'
+import { initPlatform, resetPlatformForTests } from '../platform'
+import { fakePlatform } from '../platform-fake'
+
+const run = promisify(execFile)
+
+let dir = ''
+let received: { verb: string; nodeId: string; verified: boolean }[] = []
+
+beforeAll(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-sockls-'))
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: dir }))
+  await hookServer.start()
+  hookServer.setControlHandler(async (cmd) => {
+    received.push({ verb: cmd.verb, nodeId: cmd.nodeId, verified: cmd.verified })
+    return { ok: true, message: `did ${cmd.verb}` }
+  })
+})
+
+afterAll(() => {
+  hookServer.stop()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+interface CurlReply {
+  status: string
+  body: string
+}
+
+/** POST a /control/ request with the real curl, over the socket or over loopback TCP. */
+async function post(
+  transport: { sock?: string; port?: number },
+  verb: string,
+  headers: Record<string, string>,
+  nodeId = 'node-1'
+): Promise<CurlReply> {
+  const out = path.join(dir, `curl-out-${Math.random().toString(36).slice(2)}`)
+  const args = ['-sS', '-o', out, '-w', '%{http_code}', '-X', 'POST']
+  if (transport.sock) args.push('--unix-socket', transport.sock, `http://localhost/control/${verb}`)
+  else args.push(`http://127.0.0.1:${transport.port}/control/${verb}`)
+  args.push('-H', 'Accept: text/plain')
+  for (const [k, v] of Object.entries(headers)) args.push('-H', `${k}: ${v}`)
+  args.push('--data-urlencode', `nodeId=${nodeId}`)
+  const { stdout } = await run('curl', args)
+  const body = fs.existsSync(out) ? fs.readFileSync(out, 'utf8') : ''
+  fs.rmSync(out, { force: true })
+  return { status: stdout.trim(), body }
+}
+
+describe('hook server unix-socket listener', () => {
+  it('binds hook.sock at 0600 inside a 0700 sock/ dir under the data dir', () => {
+    const sock = hookServer.getSockPath()
+    expect(sock).toBe(path.join(dir, 'sock', 'hook.sock'))
+    expect(fs.statSync(sock).mode & 0o777).toBe(0o600)
+    expect(fs.statSync(path.dirname(sock)).mode & 0o777).toBe(0o700)
+  })
+
+  it('advertises it quoted in the endpoint file (#358 parser reads it back) and in buildPtyEnv', () => {
+    const sock = hookServer.getSockPath()
+    const raw = fs.readFileSync(hookServer.endpointFilePath(), 'utf8')
+    expect(raw).toContain(`NODETERM_HOOK_SOCK='${sock}'\n`)
+    expect(parseEndpointEnv(raw).NODETERM_HOOK_SOCK).toBe(sock)
+    // ...while the TCP coordinates STAY: sessions holding a pre-socket script still connect.
+    expect(Number(parseEndpointEnv(raw).NODETERM_HOOK_PORT)).toBe(hookServer.getPort())
+    expect(hookServer.buildPtyEnv('n1', 'claude').NODETERM_HOOK_SOCK).toBe(sock)
+  })
+
+  it('answers the same route, through the same handler, on both transports', async () => {
+    received = []
+    const auth = { 'X-Nodeterm-Hook-Token': hookServer.getToken() }
+    const viaSock = await post({ sock: hookServer.getSockPath() }, 'list', auth)
+    const viaTcp = await post({ port: hookServer.getPort() }, 'list', auth)
+    expect(viaSock).toEqual({ status: '200', body: 'did list\n' })
+    expect(viaTcp).toEqual(viaSock)
+    expect(received).toEqual([
+      { verb: 'list', nodeId: 'node-1', verified: false },
+      { verb: 'list', nodeId: 'node-1', verified: false }
+    ])
+  })
+
+  // THE MUTATION GUARD the socket must carry: it is a second transport, not an auth bypass. A
+  // mutation that skips (or always-passes) the bearer check turns both cases red.
+  it('refuses a missing or wrong bearer over the socket, without reaching the handler', async () => {
+    received = []
+    const sock = hookServer.getSockPath()
+    expect((await post({ sock }, 'list', {})).status).toBe('403')
+    expect((await post({ sock }, 'list', { 'X-Nodeterm-Hook-Token': 'wrong' })).status).toBe('403')
+    expect(received).toEqual([])
+  })
+
+  it('rebinds cleanly over a stale socket file left by a crash', async () => {
+    const sock = hookServer.getSockPath()
+    hookServer.stop()
+    expect(fs.existsSync(sock)).toBe(false) // stop() unlinked its own socket
+    // A crash skips stop(): fake the leftover. Anything occupying the path blocks bind with
+    // EADDRINUSE unless the server unlinks first — the StreamLocalBindUnlink lesson.
+    fs.mkdirSync(path.dirname(sock), { recursive: true })
+    fs.writeFileSync(sock, '')
+    await hookServer.start()
+    hookServer.setControlHandler(async (cmd) => {
+      received.push({ verb: cmd.verb, nodeId: cmd.nodeId, verified: cmd.verified })
+      return { ok: true, message: `did ${cmd.verb}` }
+    })
+    expect(hookServer.getSockPath()).toBe(sock)
+    const reply = await post({ sock }, 'list', { 'X-Nodeterm-Hook-Token': hookServer.getToken() })
+    expect(reply).toEqual({ status: '200', body: 'did list\n' })
+  })
+})
+
+// The per-node identity machinery must be transport-agnostic: the verified-only verbs (sticky &
+// co.) demand a token THIS instance minted for THAT node id, on the socket exactly as on TCP.
+describe('unix-socket listener — verified-only verbs keep their gate', () => {
+  const SECRET = Buffer.alloc(32, 9)
+
+  beforeAll(() => {
+    hookServer.setNodeAuthSecret(SECRET)
+  })
+
+  afterAll(() => {
+    hookServer.clearNodeAuthSecretForTests()
+  })
+
+  it('sticky over the socket: refused without the per-node token, verified with it', async () => {
+    const sock = hookServer.getSockPath()
+    const bearer = { 'X-Nodeterm-Hook-Token': hookServer.getToken() }
+    const refused = await post({ sock }, 'sticky', bearer)
+    expect(refused.status).toBe('403')
+    expect(refused.body).toContain('Sticky write refused.')
+    received = []
+    const ok = await post({ sock }, 'sticky', {
+      ...bearer,
+      'X-Nodeterm-Node-Token': nodeAuthToken(SECRET, 'node-1')
+    })
+    expect(ok.status).toBe('200')
+    expect(received).toEqual([{ verb: 'sticky', nodeId: 'node-1', verified: true }])
+  })
+
+  it("another node's token is refused over the socket too (forged, hard 403)", async () => {
+    const reply = await post({ sock: hookServer.getSockPath() }, 'list', {
+      'X-Nodeterm-Hook-Token': hookServer.getToken(),
+      'X-Nodeterm-Node-Token': nodeAuthToken(SECRET, 'node-OTHER')
+    })
+    expect(reply.status).toBe('403')
+  })
+})

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -1,8 +1,9 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http'
 import { randomUUID, timingSafeEqual } from 'crypto'
-import { writeFileSync, mkdirSync } from 'fs'
+import { writeFileSync, mkdirSync, chmodSync, unlinkSync } from 'fs'
 import path from 'path'
 import { platform } from '../platform'
+import { hookSockPath } from './hook-sock-path'
 import { canControlCanvas, type AgentId } from '../../shared/agents/config'
 import { normalizeFor, type NormalizedAgentEvent } from '../../shared/agents/normalize'
 import type { CodexIdentityEvent } from '../../shared/types'
@@ -216,6 +217,19 @@ export function verifiedRefusalFor(verb: string): string {
 
 class HookServer {
   private server: Server | null = null
+  /**
+   * The unix-domain twin of the loopback TCP listener (issue #367). Same HTTP handler, same
+   * bearer + per-node token auth — the whole identity machinery is transport-agnostic (nothing
+   * in the handler reads `remoteAddress`), so the socket is never an auth bypass. Two reasons it
+   * exists: it lets a sandboxed macOS Codex regain hook connectivity via codex's
+   * `network.allow_unix_sockets` allowlist (the TCP loopback can never be allowlisted), and it
+   * pays down #195's debt that ANY local user could reach the TCP port at all (the socket lives
+   * in a 0700 dir at 0600). The TCP listener STAYS: existing tmux panes hold pre-socket env, and
+   * the Linux codex sandbox blocks unix sockets anyway. Best-effort: if the socket cannot bind,
+   * nothing advertises it and everything runs on TCP exactly as before.
+   */
+  private unixServer: Server | null = null
+  private sockPath = ''
   private port = 0
   private token = ''
   private listener: ((e: NormalizedAgentEvent) => void) | null = null
@@ -299,6 +313,10 @@ class HookServer {
 
   getPort(): number {
     return this.port
+  }
+  /** The unix listener's socket path, or '' when it is not live (bind failed, win32). */
+  getSockPath(): string {
+    return this.sockPath
   }
   getToken(): string {
     return this.token
@@ -475,7 +493,9 @@ class HookServer {
   async start(): Promise<void> {
     if (this.server) return
     this.token = randomUUID()
-    this.server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    // ONE handler, shared verbatim by the TCP and the unix-socket listeners: every gate (bearer,
+    // per-node verdict, verified-only verbs) runs identically on both transports.
+    const handler = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
       // Hooks fail open: any error path still ends 204 so a broken hook never blocks the agent.
       try {
         if (req.method !== 'POST') {
@@ -705,7 +725,8 @@ class HookServer {
         res.writeHead(204)
         res.end()
       }
-    })
+    }
+    this.server = createServer(handler)
     await new Promise<void>((resolve, reject) => {
       const onErr = (e: Error): void => {
         this.server?.off('listening', onOk)
@@ -716,12 +737,65 @@ class HookServer {
         this.server?.on('error', (e) => console.error('[agent-hooks] server error', e))
         const addr = this.server!.address()
         if (addr && typeof addr === 'object') this.port = addr.port
-        this.writeEndpointFile()
         resolve()
       }
       this.server!.once('error', onErr)
       this.server!.listen(0, '127.0.0.1', onOk)
     })
+    // Second leg, then ONE endpoint write that advertises whatever actually came up. A failed
+    // socket bind must not cost the TCP endpoint file (or the boot).
+    await this.startUnixListener(handler)
+    this.writeEndpointFile()
+  }
+
+  /** Bind the unix-socket twin (see `unixServer`). Never throws — a socket that cannot bind is
+   *  simply not advertised, and everything keeps running on loopback TCP. */
+  private async startUnixListener(
+    handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>
+  ): Promise<void> {
+    // Node's AF_UNIX support on Windows is not the discipline this path was built around, and no
+    // generated sh client runs there anyway.
+    if (process.platform === 'win32') return
+    const p = hookSockPath(platform().userDataDir)
+    try {
+      const dir = path.dirname(p)
+      mkdirSync(dir, { recursive: true, mode: 0o700 })
+      // mkdir's mode is ignored when the dir already exists — enforce it, because the DIRECTORY
+      // mode is what actually keeps other local users off the socket (the file chmod below only
+      // lands after listen, and the socket is world-connectable for that instant otherwise).
+      chmodSync(dir, 0o700)
+      // A stale socket file BLOCKS bind with EADDRINUSE even when nothing is listening — the
+      // StreamLocalBindUnlink lesson from the SSH reverse tunnels. Unlink-then-bind is safe here:
+      // the path is ours alone (0700 dir, digest-keyed fallback), so anything at it is our own
+      // leftover from a crash.
+      try {
+        unlinkSync(p)
+      } catch {
+        /* nothing stale to clear */
+      }
+      const srv = createServer(handler)
+      await new Promise<void>((resolve, reject) => {
+        const onErr = (e: Error): void => {
+          srv.off('listening', onOk)
+          reject(e)
+        }
+        const onOk = (): void => {
+          srv.off('error', onErr)
+          resolve()
+        }
+        srv.once('error', onErr)
+        srv.once('listening', onOk)
+        srv.listen(p)
+      })
+      chmodSync(p, 0o600)
+      srv.on('error', (e) => console.error('[agent-hooks] unix listener error', e))
+      this.unixServer = srv
+      this.sockPath = p
+    } catch (e) {
+      console.warn('[agent-hooks] unix hook socket unavailable, staying TCP-only', e)
+      this.unixServer = null
+      this.sockPath = ''
+    }
   }
 
   // Constant-time bearer-token check (avoids a timing side channel on the compare).
@@ -941,7 +1015,13 @@ class HookServer {
           // Advertised (not compiled in) so a failover that sources ANOTHER instance's endpoint
           // file also picks up THAT instance's token dir: it then finds a token that instance can
           // verify, or none — never a mismatched one.
-          `NODETERM_NODE_TOKEN_DIR=${posixQuote(nodeTokenDir())}\n`,
+          `NODETERM_NODE_TOKEN_DIR=${posixQuote(nodeTokenDir())}\n` +
+          // The unix-socket twin, only when it actually bound. Every generated client (managed
+          // hook script, both sh shims, opencode plugin, codex launcher) is already sock-first —
+          // `[ -n "$NODETERM_HOOK_SOCK" ]` — so advertising it moves local hook traffic off the
+          // TCP port; the PORT line stays above for sessions holding a pre-socket script. Quoted
+          // like every other value (#351/#358): macOS data dirs carry a space.
+          (this.sockPath ? `NODETERM_HOOK_SOCK=${posixQuote(this.sockPath)}\n` : ''),
         // 0o600: this file holds the bearer token — owner read/write only so another local user
         // can't read it and forge hook events.
         { encoding: 'utf8', mode: 0o600 }
@@ -969,6 +1049,13 @@ class HookServer {
       // means the data dir has vanished and the hook is meant to be inert anyway.
       NODETERM_HOOK_VERSION: NODETERM_HOOK_PROTOCOL_VERSION,
       NODETERM_HOOK_ENDPOINT: this.endpointFilePath(),
+      // The socket PATH is fine on the tmux -e argv where the token/port were not: it is an
+      // address, not a credential — connecting still takes the bearer from the 0600 endpoint
+      // file, and the socket itself sits in a 0700 dir. Advertised in env (not only the endpoint
+      // file) so the codex sandbox shim can name the exact path in its macOS
+      // `network.allow_unix_sockets` remedy line (issue #367) even when the endpoint file is
+      // what a sandboxed sh could not read.
+      ...(this.sockPath ? { NODETERM_HOOK_SOCK: this.sockPath } : {}),
       NODETERM_NODE_ID: nodeId,
       NODETERM_AGENT_ID: agentId,
       ...(permWaitSecs > 0 ? { NODETERM_PERM_WAIT_SECS: String(permWaitSecs) } : {}),
@@ -987,6 +1074,18 @@ class HookServer {
   stop(): void {
     this.server?.close()
     this.server = null
+    this.unixServer?.close()
+    this.unixServer = null
+    // Unlink so the NEXT bind is clean even if close() lost the race with process exit; the
+    // startup unlink above is still the backstop for a crash that skipped this entirely.
+    if (this.sockPath) {
+      try {
+        unlinkSync(this.sockPath)
+      } catch {
+        /* already gone */
+      }
+      this.sockPath = ''
+    }
     this.port = 0
     this.token = ''
   }

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -223,9 +223,11 @@ class HookServer {
    * in the handler reads `remoteAddress`), so the socket is never an auth bypass. Two reasons it
    * exists: it lets a sandboxed macOS Codex regain hook connectivity via codex's
    * `network.allow_unix_sockets` allowlist (the TCP loopback can never be allowlisted), and it
-   * pays down #195's debt that ANY local user could reach the TCP port at all (the socket lives
-   * in a 0700 dir at 0600). The TCP listener STAYS: existing tmux panes hold pre-socket env, and
-   * the Linux codex sandbox blocks unix sockets anyway. Best-effort: if the socket cannot bind,
+   * gives local traffic a filesystem-permissioned path (0700 dir, 0600 socket) that a
+   * defense-in-depth follow-up to #195 can eventually make the ONLY door. It does not close #195
+   * on its own: the TCP listener STAYS (existing tmux panes hold pre-socket env, and the Linux
+   * codex sandbox blocks unix sockets anyway), so any local user can still reach the (bearer-gated)
+   * TCP port until that port is retired. Best-effort: if the socket cannot bind,
    * nothing advertises it and everything runs on TCP exactly as before.
    */
   private unixServer: Server | null = null

--- a/src/core/agents/hook-sock-path.test.ts
+++ b/src/core/agents/hook-sock-path.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import path from 'node:path'
+import { hookSockPath, SUN_PATH_BUDGET } from './hook-sock-path'
+
+describe('hookSockPath — the SUN_LEN discipline', () => {
+  const home = '/home/u'
+
+  it('binds under the data dir with a deliberately short name when it fits', () => {
+    expect(hookSockPath('/data/nodeterm', home)).toBe('/data/nodeterm/sock/hook.sock')
+  })
+
+  it('falls back to a digest-keyed homedir path when the data dir would blow sun_path', () => {
+    const long = '/Users/a-very-long-username/Library/Application Support/' + 'x'.repeat(80)
+    const p = hookSockPath(long, home)
+    expect(p.startsWith(path.join(home, '.nodeterm', 'sock') + path.sep)).toBe(true)
+    expect(p).toMatch(/hook-[0-9a-f]{16}\.sock$/)
+    // The point of the fallback: the result itself must FIT.
+    expect(Buffer.byteLength(p, 'utf8')).toBeLessThanOrEqual(SUN_PATH_BUDGET)
+  })
+
+  it('keys the fallback to the data dir, so two instances never fight over one socket', () => {
+    const a = hookSockPath('/very/long/'.repeat(12) + 'instance-a', home)
+    const b = hookSockPath('/very/long/'.repeat(12) + 'instance-b', home)
+    expect(a).not.toBe(b)
+  })
+
+  it('the budget sits under the tightest real limit (macOS: 104 bytes including the NUL)', () => {
+    expect(SUN_PATH_BUDGET).toBeLessThanOrEqual(103)
+  })
+})

--- a/src/core/agents/hook-sock-path.ts
+++ b/src/core/agents/hook-sock-path.ts
@@ -1,0 +1,30 @@
+import { createHash } from 'crypto'
+import os from 'os'
+import path from 'path'
+
+/**
+ * Where the hook server's unix-domain listener binds (issue #367).
+ *
+ * The SUN_LEN limit is REAL and this repo has hit it twice: `sun_path` is 104 bytes on macOS
+ * (108 on Linux) INCLUDING the trailing NUL, and both the SSH ControlMaster
+ * (`core/remote-ssh/control-master.ts`) and the codex relay daemon learned that a socket under a
+ * long data dir simply fails to bind/connect. So the same discipline applies here:
+ *
+ *  - primary: `<userDataDir>/sock/hook.sock` — a deliberately SHORT filename inside a private
+ *    0700 subdirectory (the directory's mode is what actually protects the socket from other
+ *    local users; the 0600 chmod on the socket file itself is belt and braces);
+ *  - fallback, when the primary would not fit sun_path (a deep macOS "Application Support" path,
+ *    a long username): `~/.nodeterm/sock/hook-<sha256(userDataDir)[:16]>.sock` — the exact shape
+ *    `controlSocketPath` uses for the SSH masters. Home, NOT os.tmpdir(): a world-writable /tmp
+ *    lets any local user pre-create ("squat") the predictable name, and the sticky bit then stops
+ *    us from unlinking it — the homedir path has neither problem. The digest keys the file to the
+ *    data dir so two instances (two data dirs) never fight over one socket.
+ */
+export const SUN_PATH_BUDGET = 103
+
+export function hookSockPath(userDataDir: string, home: string = os.homedir()): string {
+  const primary = path.join(userDataDir, 'sock', 'hook.sock')
+  if (Buffer.byteLength(primary, 'utf8') <= SUN_PATH_BUDGET) return primary
+  const id = createHash('sha256').update(userDataDir).digest('hex').slice(0, 16)
+  return path.join(home, '.nodeterm', 'sock', `hook-${id}.sock`)
+}

--- a/src/core/context-link-core.test.ts
+++ b/src/core/context-link-core.test.ts
@@ -5,7 +5,9 @@ import {
   mergeInstructionsBlock,
   resolveLinkTranscript,
   setNodeTranscript,
-  transcriptPathOf
+  transcriptPathOf,
+  CONTEXT_SHIM_SCRIPT,
+  CONTEXT_UNREACHABLE_MSG
 } from './context-link-core'
 
 describe('buildLinkDoc', () => {
@@ -201,5 +203,11 @@ describe('buildLinkedContextInstructions', () => {
     expect(s).toContain('summary')
     expect(s).toContain('transcript')
     expect(s).toContain('terminal')
+  })
+
+  it('the shim embeds the sandbox hint, keeping the generic sentence for the non-sandbox case', () => {
+    expect(CONTEXT_SHIM_SCRIPT).toContain('nt_codex_sandbox_hint() {')
+    expect(CONTEXT_SHIM_SCRIPT).toContain('nt_codex_sandbox_hint && exit 1')
+    expect(CONTEXT_SHIM_SCRIPT).toContain(`echo "${CONTEXT_UNREACHABLE_MSG}" >&2`)
   })
 })

--- a/src/core/context-link-core.test.ts
+++ b/src/core/context-link-core.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   buildLinkDoc,
+  buildContextLinkSkillBody,
   buildLinkedContextInstructions,
   mergeInstructionsBlock,
   resolveLinkTranscript,
@@ -9,6 +10,7 @@ import {
   CONTEXT_SHIM_SCRIPT,
   CONTEXT_UNREACHABLE_MSG
 } from './context-link-core'
+import { CODEX_SANDBOX_BLOCKED_LINE } from './agents/hook-sandbox-hint-sh'
 
 describe('buildLinkDoc', () => {
   it('enriches each link with tmux name, injected transcript path, and cwd', () => {
@@ -203,6 +205,20 @@ describe('buildLinkedContextInstructions', () => {
     expect(s).toContain('summary')
     expect(s).toContain('transcript')
     expect(s).toContain('terminal')
+  })
+
+  // Issue #367 — same parity discipline as canvas-control-core.test.ts: the shim's error
+  // sentences and the docs explaining them share constants, so neither can drift alone. The
+  // runtime behaviour is proven against real /bin/sh in context-link.cli.test.ts.
+  it('both agent-facing texts carry the codex-sandbox transport guidance (issue #367)', () => {
+    for (const body of [buildContextLinkSkillBody('/x/context.sh'), buildLinkedContextInstructions('/x/context.sh')]) {
+      expect(body).toContain(CONTEXT_UNREACHABLE_MSG.replace(/\.$/, ''))
+      expect(body).toContain(CODEX_SANDBOX_BLOCKED_LINE)
+      expect(body.toLowerCase()).toContain('escalated permissions')
+      expect(body).toMatch(/never relink, reinstall or restart nodeterm/)
+      expect(body).toContain('network.allow_unix_sockets')
+      expect(body).toContain('~/.codex/config.toml')
+    }
   })
 
   it('the shim embeds the sandbox hint, keeping the generic sentence for the non-sandbox case', () => {

--- a/src/core/context-link-core.ts
+++ b/src/core/context-link-core.ts
@@ -4,7 +4,7 @@
 import type { ContextLinkInfo } from '../shared/types'
 import { sessionName } from './tmux-naming'
 import { HOOK_CURL_HEADERS_SH } from './agents/hook-curl-config-sh'
-import { CODEX_SANDBOX_HINT_SH } from './agents/hook-sandbox-hint-sh'
+import { CODEX_SANDBOX_BLOCKED_LINE, CODEX_SANDBOX_HINT_SH } from './agents/hook-sandbox-hint-sh'
 
 /** The shim's generic transport-failure sentence — exported so the agent-facing docs below can
  *  quote it verbatim and the parity test holds the two ends together. */
@@ -90,8 +90,29 @@ export function buildLinkedContextInstructions(shimPath: string): string {
     '```',
     '',
     'Only meaningful inside nodeterm (NODETERM_NODE_ID set) with a linked edge. If the CLI',
-    'says "Not a nodeterm session" or "No linked nodes", there is nothing to read — do not retry.'
+    'says "Not a nodeterm session" or "No linked nodes", there is nothing to read — do not retry.',
+    '',
+    ...codexSandboxGuidanceLines(CONTEXT_UNREACHABLE_MSG)
   ].join('\n')
+}
+
+/**
+ * The sandboxed-Codex transport guidance (issue #367), rendered into BOTH agent-facing bodies —
+ * the get-linked-context skill and the codex/gemini instructions block — quoting the shim's real
+ * error sentences so the docs and the generated script cannot drift apart (the parity test in
+ * context-link-core.test.ts walks the constants against both bodies).
+ */
+export function codexSandboxGuidanceLines(unreachableMsg: string): string[] {
+  return [
+    `Sandboxed Codex: if a call fails with "${unreachableMsg.replace(/\.$/, '')}" or with`,
+    `"${CODEX_SANDBOX_BLOCKED_LINE}",`,
+    "Codex's command sandbox is denying loopback/socket connections while nodeterm itself is",
+    'healthy. Retry the SAME command once with command-specific escalated permissions (approve the',
+    'escalation prompt) — never relink, reinstall or restart nodeterm for this error; that cannot',
+    'help. On macOS the permanent fix is adding the advertised hook socket path (the',
+    '`NODETERM_HOOK_SOCK` value) to `network.allow_unix_sockets` in ~/.codex/config.toml: hook',
+    'calls then work inside the sandbox with no escalation.'
+  ]
 }
 
 export interface LinkDocEntry {
@@ -265,5 +286,7 @@ since it was first linked).
 \`--node\` is optional when you are linked to exactly one node; otherwise pass the id or title
 from \`list\`. If the CLI says "Not a nodeterm session" or "No linked nodes", there is nothing
 to read — do not retry.
+
+${codexSandboxGuidanceLines(CONTEXT_UNREACHABLE_MSG).join('\n')}
 `
 }

--- a/src/core/context-link-core.ts
+++ b/src/core/context-link-core.ts
@@ -4,6 +4,11 @@
 import type { ContextLinkInfo } from '../shared/types'
 import { sessionName } from './tmux-naming'
 import { HOOK_CURL_HEADERS_SH } from './agents/hook-curl-config-sh'
+import { CODEX_SANDBOX_HINT_SH } from './agents/hook-sandbox-hint-sh'
+
+/** The shim's generic transport-failure sentence — exported so the agent-facing docs below can
+ *  quote it verbatim and the parity test holds the two ends together. */
+export const CONTEXT_UNREACHABLE_MSG = 'Could not read linked context (nodeterm unreachable).'
 
 // nodeId -> latest known transcript path, fed from the raw hook listener (see index.ts).
 const nodeTranscript = new Map<string, string>()
@@ -168,6 +173,8 @@ fi
 
 ${HOOK_CURL_HEADERS_SH}
 
+${CODEX_SANDBOX_HINT_SH}
+
 nt_verb="list"
 if [ $# -gt 0 ]; then nt_verb="$1"; shift; fi
 
@@ -215,7 +222,12 @@ if [ "$nt_code" = "200" ]; then
 fi
 cat "$nt_out" >&2 2>/dev/null
 rm -f "$nt_out"
-echo "Could not read linked context (nodeterm unreachable)." >&2
+# Empty / 000 = the TRANSPORT failed, not the server. Under a codex sandbox that is the sandbox's
+# own connect() denial (issue #367), and the generic sentence below would misdirect the agent.
+if [ -z "$nt_code" ] || [ "$nt_code" = "000" ]; then
+  nt_codex_sandbox_hint && exit 1
+fi
+echo "${CONTEXT_UNREACHABLE_MSG}" >&2
 exit 1
 `
 

--- a/src/core/context-link.cli.test.ts
+++ b/src/core/context-link.cli.test.ts
@@ -460,3 +460,52 @@ describe('context-link shim keeps credentials off curl\'s command line', () => {
     expect(argv).not.toContain('X-Nodeterm-Node-Token')
   })
 })
+
+// Issue #367, context-link leg. The sh fragment is the SAME one the canvas-control shim embeds
+// (hook-sandbox-hint-sh.ts) and the full platform/transport matrix lives in
+// canvas-control-shim.test.ts; what this suite pins is that the CONTEXT shim wired it into ITS
+// failure tail — with its own generic sentence kept byte-for-byte for the non-sandbox case.
+describe('codex-sandbox self-diagnosis (issue #367)', () => {
+  function deadRun(env: Record<string, string>): Promise<{ stderr: string; code?: number }> {
+    return run('/bin/sh', [shim, 'list'], {
+      env: {
+        PATH: process.env.PATH ?? '',
+        NODETERM_NODE_ID: 'node-A',
+        NODETERM_HOOK_SOCK: join(dir, 'nobody-listens.sock'),
+        NODETERM_HOOK_TOKEN: 'x',
+        ...env
+      }
+    }).then(
+      () => ({ stderr: '' }),
+      (e) => e as { stderr: string; code?: number }
+    )
+  }
+
+  it('under the sandbox, a dead transport names the sandbox + escalated retry, not "unreachable"', async () => {
+    const err = await deadRun({ CODEX_SANDBOX_NETWORK_DISABLED: '1' })
+    expect(err.code).toBe(1)
+    expect(err.stderr).toContain("Codex's sandbox blocked this connection to nodeterm")
+    expect(err.stderr).toContain('escalated permissions')
+    expect(err.stderr).not.toContain('Could not read linked context (nodeterm unreachable).')
+  })
+
+  // The mutation guard: drop the env-var branch and the case above reddens; invert it and this does.
+  it('without the env var the original genuine-unreachable sentence stands', async () => {
+    const err = await deadRun({})
+    expect(err.stderr).toContain('Could not read linked context (nodeterm unreachable).')
+    expect(err.stderr).not.toContain("Codex's sandbox")
+  })
+
+  it('a healthy endpoint is untouched by the sandbox var (failure-path only)', async () => {
+    const out = await run('/bin/sh', [shim, 'list'], {
+      env: {
+        PATH: process.env.PATH ?? '',
+        NODETERM_NODE_ID: 'node-A',
+        NODETERM_HOOK_PORT: String(hookServer.getPort()),
+        NODETERM_HOOK_TOKEN: hookServer.getToken(),
+        CODEX_SANDBOX_NETWORK_DISABLED: '1'
+      }
+    })
+    expect(out.stdout).toContain('Builder')
+  })
+})

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -5,8 +5,13 @@ import {
   mergeCanvasControlBlock,
   buildCanvasControlInstructions,
   buildCanvasSkillBody,
-  CONTROL_SHIM_SCRIPT
+  CONTROL_SHIM_SCRIPT,
+  CONTROL_UNREACHABLE_MSG
 } from './canvas-control-core'
+import {
+  CODEX_SANDBOX_BLOCKED_LINE,
+  CODEX_SANDBOX_RETRY_LINE
+} from '../core/agents/hook-sandbox-hint-sh'
 import { RETRYABLE } from '../core/agents/agent-message-decide'
 import { PROJECT_TARGETABLE_VERBS } from './project-grants'
 import { STRICT_CONTROL_VERBS } from '../core/agents/node-identity-policy'
@@ -221,6 +226,17 @@ describe('parseControlRequest', () => {
     const body = buildCanvasControlInstructions('/tmp/nodeterm.sh')
     expect(body).toContain('--flag=value')
     expect(body).toMatch(/starts? with `--`/)
+  })
+
+  it('the shim embeds the sandbox hint and its call sites in both failure tails', () => {
+    // The fragment (one definition)...
+    expect(CONTROL_SHIM_SCRIPT).toContain('nt_codex_sandbox_hint() {')
+    expect(CONTROL_SHIM_SCRIPT).toContain(CODEX_SANDBOX_BLOCKED_LINE)
+    expect(CONTROL_SHIM_SCRIPT).toContain(CODEX_SANDBOX_RETRY_LINE)
+    // ...and the fallback shape: the genuine-unreachable sentence survives to the byte.
+    expect(CONTROL_SHIM_SCRIPT).toContain(
+      `nt_codex_sandbox_hint || echo "${CONTROL_UNREACHABLE_MSG}" >&2`
+    )
   })
 
   it('send/reply require --text (Task 5.4)', () => {

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -228,6 +228,24 @@ describe('parseControlRequest', () => {
     expect(body).toMatch(/starts? with `--`/)
   })
 
+  // Issue #367: the shim's transport-failure sentences and the docs that explain them are held
+  // together by constants — re-typing either side in prose is how the guidance and the generated
+  // script drift. The runtime behaviour itself is proven against real /bin/sh in
+  // canvas-control-shim.test.ts; this pins the TEACHING of it into both agent-facing bodies.
+  it('both agent-facing texts carry the codex-sandbox transport guidance (issue #367)', () => {
+    for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
+      // Names both exact errors the agent can see: the generic sentence and the sandbox one.
+      expect(body).toContain(CONTROL_UNREACHABLE_MSG.replace(/\.$/, ''))
+      expect(body).toContain(CODEX_SANDBOX_BLOCKED_LINE)
+      // The one action that works everywhere, and the never-do.
+      expect(body.toLowerCase()).toContain('escalated permissions')
+      expect(body).toMatch(/never relink, reinstall or restart nodeterm/)
+      // The macOS permanent remedy, named exactly as codex's config reads it.
+      expect(body).toContain('network.allow_unix_sockets')
+      expect(body).toContain('~/.codex/config.toml')
+    }
+  })
+
   it('the shim embeds the sandbox hint and its call sites in both failure tails', () => {
     // The fragment (one definition)...
     expect(CONTROL_SHIM_SCRIPT).toContain('nt_codex_sandbox_hint() {')

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -2,6 +2,7 @@
 // CLI source. No electron imports, so this module + CONTROL_CLI_SCRIPT are unit-testable.
 // Electron/ipc/server wiring lives in canvas-control.ts + index.ts + hook-server.ts.
 import { HOOK_CURL_HEADERS_SH } from '../core/agents/hook-curl-config-sh'
+import { CODEX_SANDBOX_HINT_SH } from '../core/agents/hook-sandbox-hint-sh'
 import { AGENT_CONFIG, AGENT_HOOK_TARGETS, BUILTIN_AGENT_IDS } from '@shared/agents/config'
 import { RETRYABLE } from '../core/agents/agent-message-decide'
 import { FANOUT_PER_TURN, PAIR_MIN_INTERVAL_MS } from '../core/agents/agent-message-flow'
@@ -403,6 +404,10 @@ export function buildCanvasControlInstructions(shimPath: string): string {
 // remote agent nodes only after a reconnect, with no signal on the wire — the same shape as the
 // managed hook script's stale window. Verbs are therefore designed to parse identically under both
 // the old and the new loop: give every flag a value, and the two loops agree.
+/** The shim's generic transport-failure sentence — exported so the agent-facing docs can quote it
+ *  verbatim and the parity test holds the two ends together (issue #367). */
+export const CONTROL_UNREACHABLE_MSG = 'Could not reach nodeterm (control endpoint unreachable).'
+
 export const CONTROL_SHIM_SCRIPT = `#!/bin/sh
 # nodeterm canvas-control CLI (auto-generated — do not edit).
 
@@ -428,6 +433,8 @@ if [ -n "$NODETERM_NODE_TOKEN_DIR" ] && [ -n "$NODETERM_NODE_ID" ]; then
 fi
 
 ${HOOK_CURL_HEADERS_SH}
+
+${CODEX_SANDBOX_HINT_SH}
 
 nt_verb="list"
 if [ $# -gt 0 ]; then nt_verb="$1"; shift; fi
@@ -510,8 +517,10 @@ if [ "$nt_code" = "200" ]; then
 fi
 cat "$nt_out" >&2 2>/dev/null
 rm -f "$nt_out"
+# Empty / 000 = the TRANSPORT failed, not the server. Under a codex sandbox that is the sandbox's
+# own connect() denial (issue #367), and the generic sentence would misdirect the agent.
 if [ -z "$nt_code" ] || [ "$nt_code" = "000" ]; then
-  echo "Could not reach nodeterm (control endpoint unreachable)." >&2
+  nt_codex_sandbox_hint || echo "${CONTROL_UNREACHABLE_MSG}" >&2
 fi
 exit 1
 `

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -3,6 +3,7 @@
 // Electron/ipc/server wiring lives in canvas-control.ts + index.ts + hook-server.ts.
 import { HOOK_CURL_HEADERS_SH } from '../core/agents/hook-curl-config-sh'
 import { CODEX_SANDBOX_HINT_SH } from '../core/agents/hook-sandbox-hint-sh'
+import { codexSandboxGuidanceLines } from '../core/context-link-core'
 import { AGENT_CONFIG, AGENT_HOOK_TARGETS, BUILTIN_AGENT_IDS } from '@shared/agents/config'
 import { RETRYABLE } from '../core/agents/agent-message-decide'
 import { FANOUT_PER_TURN, PAIR_MIN_INTERVAL_MS } from '../core/agents/agent-message-flow'
@@ -363,6 +364,8 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '',
     ...browserGuidanceLines(),
     '',
+    ...codexSandboxGuidanceLines(CONTROL_UNREACHABLE_MSG),
+    '',
     'Orchestration ("Build with Nodeterm orchestration"): first decide what is genuinely',
     'independent — for every "and then", ask whether the next step READS the previous step\'s',
     'output. If not, they are separate stations, open them all at once; if it does, open the',
@@ -680,6 +683,8 @@ Notes:
 - \`board\` and \`assign\` act on the CURRENTLY OPEN project's board — the same one you see when you
   toggle the kanban view. They need no confirmation.
 - If the CLI says canvas control is unavailable, you are not in a controllable nodeterm session — do not retry.
+
+${codexSandboxGuidanceLines(CONTROL_UNREACHABLE_MSG).join('\n')}
 
 To orchestrate a team: decide the roles + a concrete starting prompt for each, then one
 \`spawn-team\` call (or \`open-claude\` per role followed by \`group\` + \`arrange\`).

--- a/src/main/canvas-control-shim.test.ts
+++ b/src/main/canvas-control-shim.test.ts
@@ -497,6 +497,106 @@ describe('canvas-control shim keeps credentials off curl\'s command line', () =>
   })
 })
 
+// Issue #367: Codex's command sandbox denies connect() for every address family (Linux seccomp;
+// macOS seatbelt deny-default), so curl dies with HTTP 000 while nodeterm is perfectly healthy —
+// and the old message ("control endpoint unreachable") sent agents off to relink/restart a server
+// that was never the problem. Codex exports CODEX_SANDBOX_NETWORK_DISABLED=1 into every sandboxed
+// command, so the shim can tell the two failures apart. Run against real /bin/sh with a genuinely
+// dead endpoint; `uname` is faked on PATH so the macOS-only remedy line is deterministic on any CI.
+describe('codex-sandbox self-diagnosis (issue #367)', () => {
+  let deadSock = ''
+  let unameDir = (os: 'Darwin' | 'Linux'): string => os // reassigned in beforeAll
+
+  beforeAll(() => {
+    deadSock = path.join(dir, 'nobody-listens.sock')
+    const bins: Record<string, string> = {}
+    unameDir = (osName) => {
+      if (!bins[osName]) {
+        const d = path.join(dir, `fake-uname-${osName.toLowerCase()}`)
+        fs.mkdirSync(d, { recursive: true })
+        fs.writeFileSync(path.join(d, 'uname'), `#!/bin/sh\necho ${osName}\n`, { mode: 0o755 })
+        bins[osName] = d
+      }
+      return bins[osName]
+    }
+  })
+
+  const sandboxEnv = (osName: 'Darwin' | 'Linux', extra: Record<string, string> = {}): Record<string, string> => ({
+    PATH: `${unameDir(osName)}:${process.env.PATH ?? ''}`,
+    NODETERM_HOOK_PORT: '',
+    NODETERM_HOOK_SOCK: deadSock,
+    CODEX_SANDBOX_NETWORK_DISABLED: '1',
+    ...extra
+  })
+
+  it('under the sandbox, a dead socket names the sandbox and the escalated retry — not "unreachable"', async () => {
+    await expect(callShim(['list'], sandboxEnv('Linux'))).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("Codex's sandbox blocked this connection to nodeterm")
+    })
+    await expect(callShim(['list'], sandboxEnv('Linux'))).rejects.toMatchObject({
+      stderr: expect.stringContaining('escalated permissions')
+    })
+    const err = await callShim(['list'], sandboxEnv('Linux')).catch((e) => e as { stderr: string })
+    expect(err.stderr).toContain('do not relink or restart it')
+    expect(err.stderr).not.toContain('Could not reach nodeterm')
+  })
+
+  it('on Darwin with a socket advertised, it also prints the config.toml allowlist remedy with the path', async () => {
+    const err = await callShim(['list'], sandboxEnv('Darwin')).catch((e) => e as { stderr: string })
+    expect(err.stderr).toContain(`network.allow_unix_sockets = ["${deadSock}"]`)
+    expect(err.stderr).toContain('~/.codex/config.toml')
+  })
+
+  it('on Linux the allowlist line is withheld — the Linux sandbox has no such allowlist', async () => {
+    const err = await callShim(['list'], sandboxEnv('Linux')).catch((e) => e as { stderr: string })
+    expect(err.stderr).not.toContain('network.allow_unix_sockets')
+  })
+
+  it('the same diagnosis fires on the TCP branch (a sandboxed curl to loopback dies identically)', async () => {
+    // A port with no listener: bind-then-close frees it, and nothing else grabs it mid-test.
+    const http = await import('node:http')
+    const probe = http.createServer()
+    await new Promise<void>((r) => probe.listen(0, '127.0.0.1', r))
+    const freePort = (probe.address() as { port: number }).port
+    await new Promise<void>((r) => probe.close(() => r()))
+    const err = await callShim(['list'], {
+      PATH: `${unameDir('Linux')}:${process.env.PATH ?? ''}`,
+      NODETERM_HOOK_PORT: String(freePort),
+      CODEX_SANDBOX_NETWORK_DISABLED: '1'
+    }).catch((e) => e as { stderr: string })
+    expect(err.stderr).toContain("Codex's sandbox blocked this connection to nodeterm")
+  })
+
+  // THE MUTATION GUARD for the env-var branch: without the variable, the same dead transport must
+  // keep the original sentence to the byte — dropping the branch turns the sandbox cases above
+  // red, and inverting it turns this one red.
+  it('without CODEX_SANDBOX_NETWORK_DISABLED the original genuine-unreachable message stands', async () => {
+    const err = await callShim(['list'], {
+      PATH: `${unameDir('Darwin')}:${process.env.PATH ?? ''}`,
+      NODETERM_HOOK_PORT: '',
+      NODETERM_HOOK_SOCK: deadSock
+    }).catch((e) => e as { stderr: string })
+    expect(err.stderr).toContain('Could not reach nodeterm (control endpoint unreachable).')
+    expect(err.stderr).not.toContain("Codex's sandbox")
+  })
+
+  it('never fires on a genuine HTTP error — the server answered, so the transport is fine', async () => {
+    // `boom` reaches the real hook server (which answers 400 with a body): sandbox var set, but
+    // nt_code is a real status, not 000.
+    const err = await callShim(['boom'], { CODEX_SANDBOX_NETWORK_DISABLED: '1' }).catch(
+      (e) => e as { stderr: string }
+    )
+    expect(err.stderr).toContain('that verb exploded')
+    expect(err.stderr).not.toContain("Codex's sandbox")
+  })
+
+  it('a healthy endpoint stays healthy with the sandbox var set (the hint is failure-path only)', async () => {
+    const { stdout } = await callShim(['list'], { CODEX_SANDBOX_NETWORK_DISABLED: '1' })
+    expect(stdout.trim()).toBe('did list')
+  })
+})
+
 describe('parseControlBody', () => {
   it('reads the shim dialect: nodeId plus arg.<name> fields', () => {
     expect(


### PR DESCRIPTION
Fixes #367.

## The probe (what the Codex sandbox actually does)

Measured live against codex 0.146.0 (`codex sandbox`, sandbox-state JSON) plus a static read of the seatbelt generation in openai/codex:

- **Linux: BLOCKED, unconditionally.** With network disabled, a seccomp filter EPERMs `connect()` (and accept/bind/listen/getsockname/sendto/…) for **every address family** — unix sockets included; only `socket(AF_UNIX)`/`socketpair` creation is allowed. The Linux sandbox has **no unix-socket allowlist**. `curl --unix-socket` dies with "getsockname() failed … Operation not permitted", loopback TCP with "Failed to connect … after 0 ms" — both HTTP 000.
- **macOS: BLOCKED by default, ALLOWLISTABLE.** The seatbelt base profile is `(deny default)` with no network allowance, but `seatbelt.rs` generates `network-bind`/`network-outbound` allows from `network.allow_unix_sockets` in `~/.codex/config.toml` **even when network is disabled** — so a user can permanently re-open exactly the nodeterm hook socket inside the sandbox.
- Both platforms export `CODEX_SANDBOX_NETWORK_DISABLED=1` into every sandboxed command, which is what makes self-diagnosis possible at the exact moment of failure.

So the shims' old failure text — "nodeterm unreachable" / "control endpoint unreachable" — was a misdiagnosis that sent agents (and users) off to relink/restart a perfectly healthy server.

## The three parts

**1. Self-diagnosing shim error (both platforms — the primary fix).** Both generated sh shims (canvas-control + context-link) share one fragment (`hook-sandbox-hint-sh.ts`) that fires only on a dead transport (empty/000 status) with `CODEX_SANDBOX_NETWORK_DISABLED` present: it names the sandbox as the blocker, instructs retrying the **same** command once with command-specific escalated permissions, and says plainly not to relink or restart nodeterm. On Darwin, when `NODETERM_HOOK_SOCK` is advertised, it prints the exact `network.allow_unix_sockets = ["<sock>"]` line for `~/.codex/config.toml`. Without the env var, the original messages survive to the byte; a genuine HTTP error (the server answered) never triggers it. Proven against real `/bin/sh` with `uname` faked on PATH so the Darwin-only line is deterministic on any CI.

**2. Unix-socket listener on the hook server (the macOS remedy enabler).** A second listener on `<userDataDir>/sock/hook.sock` — SUN_LEN-guarded with a `~/.nodeterm/sock/hook-<digest>.sock` fallback (the SSH ControlMaster discipline; home rather than tmpdir so the predictable name cannot be squatted by another local user). Same HTTP handler as TCP, so bearer + per-node token auth run identically on both transports; 0600 file in a 0700 dir; stale socket unlinked before bind (the StreamLocalBindUnlink lesson) and on shutdown. Advertised as `NODETERM_HOOK_SOCK` in `buildPtyEnv` and — posixQuoted per #358 — in the endpoint file, only when it actually bound. Every generated client was already sock-first, so no client change was needed beyond Part 1's error text. **TCP stays** for back-compat (existing tmux panes, and the Linux sandbox can't use the socket anyway). This is also a step toward **#195**: local traffic now has a filesystem-permissioned path (0700 dir, 0600 socket), which a defense-in-depth follow-up can make the only door. It does not close #195 on its own — the TCP listener stays for back-compat, so the (bearer-gated) port is still reachable by any local user until that port is retired (the tracked follow-up).

**3. Agent-facing guidance.** The canvas-control skill + AGENTS.md instructions and the get-linked-context skill + instructions all teach the same recovery: on either exact transport error, one escalated retry; never advise relink/restart first; on macOS the config.toml allowlist is the permanent fix. Rendered from the same constants the sh fragment embeds, with parity tests walking the constants against all four bodies.

## Verification

- `npm run typecheck` clean; full `npx vitest run`: **8824 passed, 27 skipped, 0 failed** (633 files).
- Real-sh / real-curl coverage: shim sandbox matrix (7 new cases, canvas-control) + context-link leg (3), unix-socket listener suite (7: TCP/socket parity, auth 403s, 0600/0700, stale rebind, verified-only gate over the socket), SUN_LEN path chooser (4), doc parity (4).
- **Mutations:** neuter the env-var branch → **4 tests red**; always-true bearer check (socket auth bypass) → **1 test red** (the dedicated 403 guard); drop the stale-socket unlink → **3 tests red**. All restored and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
