### PR TITLE
feat: reopen last closed project/node with Cmd+Shift+T

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -346,6 +346,8 @@ import { buildBackgroundLinkMaps, buildContextLinkNote, buildLinkMap, buildNoteP
 import { dependencyEdges, launchesToFire, unmetDeps, type ArmedNode } from '../lib/pendingLaunch'
 import { freeSpot } from '../lib/placement'
 import { pushSessionRename } from '../lib/sessionRename'
+import { useReopenHistory } from '../state/reopenHistory'
+import { snapshotNode, recreateNodeFromSnapshot } from '../lib/reopenNode'
 import { oneLine } from '@shared/one-line'
 import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
 import { useSettings } from '../state/settings'
@@ -4201,8 +4203,22 @@ export function Canvas() {
 
   // ---- multi-node actions (context menu) ----
   const deleteNodes = useCallback(
-    (ids: string[]) => {
+    (ids: string[], opts?: { record?: boolean }) => {
       const set = new Set(ids)
+      if (opts?.record !== false) {
+        const snapshots = nodesRef.current
+          .filter((n) => set.has(n.id))
+          .map((n) => snapshotNode(n, nodesRef.current))
+          .filter((s): s is NonNullable<typeof s> => s !== null)
+        if (snapshots.length) {
+          useReopenHistory.getState().push({
+            kind: 'nodes',
+            projectId: useProjects.getState().activeProjectId ?? '',
+            closedAt: Date.now(),
+            nodes: snapshots
+          })
+        }
+      }
       nodesRef.current.forEach((n) => {
         if (!set.has(n.id)) return
         // Permanent delete: the upcoming unmount must dispose the xterm, not park it (the
@@ -4312,7 +4328,7 @@ export function Canvas() {
       const loginIds = nodesRef.current
         .filter((n) => n.data.accountId === accountId && isAccountLoginNode(n.data))
         .map((n) => n.id)
-      if (loginIds.length) deleteNodes(loginIds)
+      if (loginIds.length) deleteNodes(loginIds, { record: false })
       setNodes((ns) =>
         ns.some((n) => n.data.accountId === accountId)
           ? ns.map((n) =>
@@ -5681,6 +5697,66 @@ export function Canvas() {
     [commitActiveToStore, writeDisk]
   )
 
+  /** `app.reopenLastClosed` (Cmd+Shift+T): pops the shared close-history stack and reopens a
+   *  project tab or recreates a deleted node batch — whichever was closed more recently.
+   *  Skips stale entries (already reopened another way, or the project was permanently
+   *  deleted since) and keeps walking back until it finds a usable one or the stack empties. */
+  const reopenLastClosedCommand = useCallback((): boolean => {
+    for (;;) {
+      const entry = useReopenHistory.getState().popNext()
+      if (!entry) return false
+
+      if (entry.kind === 'project') {
+        const project = useProjects.getState().projects.find((p) => p.id === entry.projectId)
+        if (project?.closed) {
+          useProjects.getState().reopenProject(entry.projectId)
+          return true
+        }
+        continue
+      }
+
+      const project = useProjects.getState().projects.find((p) => p.id === entry.projectId)
+      if (!project) continue
+
+      const isActive = project.id === useProjects.getState().activeProjectId
+      const accounts = useSettings.getState().settings.claudeAccounts
+      const liveIds = new Set(
+        (isActive ? nodesRef.current : project.nodes).map((n) => n.id)
+      )
+      const created = entry.nodes
+        .map((snap) =>
+          recreateNodeFromSnapshot(snap, {
+            liveNodeIds: liveIds,
+            project,
+            resolveAccountId: (id) => resolveNewNodeAccount(id, project, accounts),
+            permissionModeFor: (agentId) => activePermissionMode(agentId)
+          })
+        )
+        .filter((n): n is CanvasNode => n !== null)
+      // A snapshot that recreated to nothing (e.g. a kind this feature doesn't cover, or an
+      // editor whose filePath is somehow missing) leaves this entry with nothing to do — treat
+      // it as stale rather than switching/reopening a project for an empty result.
+      if (!created.length) continue
+
+      if (isActive) {
+        setNodes((ns) => [...ns, ...created])
+        markDirty()
+      } else {
+        // Not on screen: write straight into the project's SERIALIZED nodes (the store, not
+        // React Flow) — the same mechanism canvas-control uses to create a node in a
+        // non-active project (Canvas.tsx:6499, :6540). The switch/reopen below then loads
+        // them through the ordinary active-project effect; there is no live array to race.
+        for (const node of created) {
+          useProjects.getState().applyNodeMutation(project.id, { op: 'upsert', node: flowToNodeStates([node])[0] })
+        }
+        void writeDisk()
+        if (project.closed) useProjects.getState().reopenProject(project.id)
+        else switchProject(project.id)
+      }
+      return true
+    }
+  }, [switchProject, setNodes, markDirty, writeDisk])
+
   // ---- global shortcuts ----
   // The three trailing gestures below are registry-LESS chords (design D2: declared gestures,
   // deliberately not remappable in this PR). The dispatcher hands them the RAW event with no
@@ -5796,6 +5872,7 @@ export function Canvas() {
       'panel.explorer': () => { showExplorer('toggle'); return true },
       'panel.sourceControl': () => { setScOpen((v) => !v); return true },
       'panel.sessions': () => { toggleSessionsPin(); return true },
+      'app.reopenLastClosed': reopenLastClosedCommand,
       'canvas.undo': () => { undo(); return true },
       'canvas.redo': () => { redo(); return true },
       'canvas.fitAll': () => { fitAll(); return true },
@@ -9736,6 +9813,7 @@ export function Canvas() {
     (id: string) => {
       const store = useProjects.getState()
       if (id === store.activeProjectId) commitActiveToStore()
+      useReopenHistory.getState().push({ kind: 'project', projectId: id, closedAt: Date.now() })
       disposeRelayTabForProject(id)
       store.closeProject(id)
       void writeDisk()

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -348,6 +348,7 @@ import { freeSpot } from '../lib/placement'
 import { pushSessionRename } from '../lib/sessionRename'
 import { useReopenHistory } from '../state/reopenHistory'
 import { snapshotNode, recreateNodeFromSnapshot } from '../lib/reopenNode'
+import { planReopen } from '../lib/reopenPlan'
 import { oneLine } from '@shared/one-line'
 import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
 import { useSettings } from '../state/settings'
@@ -5700,62 +5701,77 @@ export function Canvas() {
   /** `app.reopenLastClosed` (Cmd+Shift+T): pops the shared close-history stack and reopens a
    *  project tab or recreates a deleted node batch — whichever was closed more recently.
    *  Skips stale entries (already reopened another way, or the project was permanently
-   *  deleted since) and keeps walking back until it finds a usable one or the stack empties. */
+   *  deleted since) and keeps walking back until it finds a usable one or the stack empties.
+   *  The DECISION (which branch, staleness, active-vs-stored) is the pure `planReopen`
+   *  (`lib/reopenPlan.ts`, unit-tested there); this loop only pops the real stack and executes
+   *  whichever `ReopenPlan` comes back — the side-effecting parts that need live Canvas state. */
   const reopenLastClosedCommand = useCallback((): boolean => {
     for (;;) {
       const entry = useReopenHistory.getState().popNext()
       if (!entry) return false
 
-      if (entry.kind === 'project') {
-        const project = useProjects.getState().projects.find((p) => p.id === entry.projectId)
-        if (project?.closed) {
-          useProjects.getState().reopenProject(entry.projectId)
-          return true
-        }
-        continue
-      }
-
-      const project = useProjects.getState().projects.find((p) => p.id === entry.projectId)
-      if (!project) continue
-
-      const isActive = project.id === useProjects.getState().activeProjectId
+      const { projects, activeProjectId } = useProjects.getState()
+      const project = projects.find((p) => p.id === entry.projectId)
       const accounts = useSettings.getState().settings.claudeAccounts
-      const liveIds = new Set(
-        (isActive ? nodesRef.current : project.nodes).map((n) => n.id)
-      )
-      const created = entry.nodes
-        .map((snap) =>
+      const plan = planReopen(
+        entry,
+        projects,
+        activeProjectId,
+        new Set(nodesRef.current.map((n) => n.id)),
+        (snap, liveIds) =>
           recreateNodeFromSnapshot(snap, {
             liveNodeIds: liveIds,
             project,
             resolveAccountId: (id) => resolveNewNodeAccount(id, project, accounts),
-            permissionModeFor: (agentId) => activePermissionMode(agentId)
+            // The TARGET project's own permission mode, not the caller's active one — a node
+            // restored into project B must start under B's override, never A's.
+            permissionModeFor: (agentId) => projectPermissionMode(project, agentId)
           })
-        )
-        .filter((n): n is CanvasNode => n !== null)
-      // A snapshot that recreated to nothing (e.g. a kind this feature doesn't cover, or an
-      // editor whose filePath is somehow missing) leaves this entry with nothing to do — treat
-      // it as stale rather than switching/reopening a project for an empty result.
-      if (!created.length) continue
+      )
 
-      if (isActive) {
-        setNodes((ns) => [...ns, ...created])
-        markDirty()
-      } else {
-        // Not on screen: write straight into the project's SERIALIZED nodes (the store, not
-        // React Flow) — the same mechanism canvas-control uses to create a node in a
-        // non-active project (Canvas.tsx:6499, :6540). The switch/reopen below then loads
-        // them through the ordinary active-project effect; there is no live array to race.
-        for (const node of created) {
-          useProjects.getState().applyNodeMutation(project.id, { op: 'upsert', node: flowToNodeStates([node])[0] })
-        }
-        void writeDisk()
-        if (project.closed) useProjects.getState().reopenProject(project.id)
-        else switchProject(project.id)
+      switch (plan.action) {
+        case 'skip':
+          continue
+        case 'reopenProject':
+          // A project switch — commit the live canvas back to the store first, or whatever the
+          // user was looking at is silently lost (the same invariant every other project switch/
+          // add/delete in this file honors via commitActiveToStore()).
+          commitActiveToStore()
+          useProjects.getState().reopenProject(plan.projectId)
+          setWelcomeOpen(false)
+          void writeDisk()
+          return true
+        case 'insertActive':
+          setNodes((ns) => [...ns, ...plan.nodes])
+          markDirty()
+          return true
+        case 'insertStored':
+          // Not on screen: write straight into the project's SERIALIZED nodes (the store, not
+          // React Flow) — the same mechanism canvas-control uses to create a node in a
+          // non-active project (Canvas.tsx:6499, :6540). armForColdOpen is required here: a bare
+          // `flowToNodeStates` drops `initialCommand` (never serialized on purpose), so an agent
+          // node restored this way would never launch its command on the eventual cold open.
+          for (const node of plan.nodes) {
+            useProjects
+              .getState()
+              .applyNodeMutation(plan.projectId, {
+                op: 'upsert',
+                node: flowToNodeStates([armForColdOpen(node)])[0]
+              })
+          }
+          void writeDisk()
+          if (plan.reopenProjectAfter) {
+            commitActiveToStore()
+            useProjects.getState().reopenProject(plan.projectId)
+            setWelcomeOpen(false)
+            void writeDisk()
+          } else {
+            switchProject(plan.projectId)
+          }
+          return true
       }
-      return true
     }
-  }, [switchProject, setNodes, markDirty, writeDisk])
+  }, [switchProject, setNodes, markDirty, writeDisk, commitActiveToStore])
 
   // ---- global shortcuts ----
   // The three trailing gestures below are registry-LESS chords (design D2: declared gestures,

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -126,3 +126,26 @@ describe('the end-session confirm describes both things it does', () => {
     }
   })
 })
+
+describe('reopen-last-closed records and dispatches through the shared history stack', () => {
+  it('records a project close before hiding it', () => {
+    expect(CANVAS_SRC).toContain('useReopenHistory.getState().push({ kind: \'project\'')
+  })
+
+  it('records a node-delete batch, opting the account-removal cleanup out', () => {
+    expect(CANVAS_SRC).toContain("kind: 'nodes'")
+    expect(CANVAS_SRC).toContain('deleteNodes(loginIds, { record: false })')
+  })
+
+  it('registers the command in the dispatch map', () => {
+    expect(CANVAS_SRC).toContain("'app.reopenLastClosed': reopenLastClosedCommand")
+  })
+
+  it('never live-inserts into a non-active project — routes through applyNodeMutation instead', () => {
+    // The bug this pins: a synchronous setNodes() right after switchProject()/reopenProject()
+    // races the active-project load effect and silently loses the recreated nodes.
+    expect(CANVAS_SRC).toContain(
+      "useProjects.getState().applyNodeMutation(project.id, { op: 'upsert', node: flowToNodeStates([node])[0] })"
+    )
+  })
+})

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -144,8 +144,36 @@ describe('reopen-last-closed records and dispatches through the shared history s
   it('never live-inserts into a non-active project — routes through applyNodeMutation instead', () => {
     // The bug this pins: a synchronous setNodes() right after switchProject()/reopenProject()
     // races the active-project load effect and silently loses the recreated nodes.
-    expect(CANVAS_SRC).toContain(
-      "useProjects.getState().applyNodeMutation(project.id, { op: 'upsert', node: flowToNodeStates([node])[0] })"
-    )
+    expect(CANVAS_SRC).toContain('.applyNodeMutation(plan.projectId, {')
+  })
+
+  it('arms a cold-open command before writing a restored node into a non-active project', () => {
+    // The bug this pins: flowToNodeStates alone drops initialCommand, so an agent node restored
+    // into a project that isn't on screen would never launch its command on the eventual cold
+    // open — armForColdOpen is what carries it through serialization.
+    expect(CANVAS_SRC).toContain('node: flowToNodeStates([armForColdOpen(node)])[0]')
+  })
+
+  it('commits the live canvas to the store before every reopenProject call — never a bare switch', () => {
+    // The bug this pins: useProjects.getState().reopenProject(...) is a project SWITCH, and every
+    // switch/add/delete elsewhere in this file calls commitActiveToStore() first so the live
+    // canvas isn't silently lost. Both reopen-a-project call sites inside reopenLastClosedCommand
+    // must do the same, rather than referencing the later `reopenProject` wrapper (a TDZ hazard
+    // from this callback's declaration point).
+    const calls = CANVAS_SRC.match(/useProjects\.getState\(\)\.reopenProject\(/g) ?? []
+    const guarded = CANVAS_SRC.match(/commitActiveToStore\(\)\n\s+useProjects\.getState\(\)\.reopenProject\(/g) ?? []
+    expect(calls.length).toBeGreaterThanOrEqual(2)
+    expect(guarded.length).toBe(calls.length)
+  })
+
+  it('resolves permission mode against the TARGET project being restored into, not the caller\'s active one', () => {
+    expect(CANVAS_SRC).toContain('permissionModeFor: (agentId) => projectPermissionMode(project, agentId)')
+  })
+
+  it('extracts the reopen decision into the pure, tested planReopen', () => {
+    expect(CANVAS_SRC).toContain('const plan = planReopen(')
+    expect(CANVAS_SRC).toContain("case 'insertActive':")
+    expect(CANVAS_SRC).toContain("case 'insertStored':")
+    expect(CANVAS_SRC).toContain("case 'reopenProject':")
   })
 })

--- a/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.test.tsx
@@ -157,14 +157,17 @@ describe('ShortcutsSection rows', () => {
   // body is `divide-y [&>*]:py-5`, so an empty wrapper is a visible empty block, not nothing.
   it('drops a whole group when neither its header nor any of its rows match', () => {
     render('close')
-    expect([...host.querySelectorAll('h3')].map((h) => h.textContent)).toEqual(['Nodes'])
-    expect(ids()).toEqual(['node.close'])
-    // Exactly the policy row (its description names Close) and the ONE group wrapper holding the
-    // heading + its row — no empty siblings. The rail is a searchable row of its own and 'close'
-    // does not match it, so it is gone too.
+    // `app.reopenLastClosed`'s title "Reopen last closed" also matches 'close', so its group
+    // (General) now survives the filter too — General's group order precedes Nodes in the
+    // registry, matching the h3 order.
+    expect([...host.querySelectorAll('h3')].map((h) => h.textContent)).toEqual(['General', 'Nodes'])
+    expect(ids()).toEqual(['app.reopenLastClosed', 'node.close'])
+    // Exactly the policy row (its description names Close) and the TWO group wrappers (General,
+    // holding `app.reopenLastClosed`; Nodes, holding `node.close`) — no empty siblings. The rail
+    // is a searchable row of its own and 'close' does not match it, so it is gone too.
     expect(pill()).toBeTruthy()
     expect(statusPill()).toBeNull()
-    expect(body().children).toHaveLength(2)
+    expect(body().children).toHaveLength(3)
     expect([...body().children].every((c) => (c.textContent ?? '').trim() !== '')).toBe(true)
   })
 

--- a/src/renderer/lib/keybindingOverrides.test.ts
+++ b/src/renderer/lib/keybindingOverrides.test.ts
@@ -22,9 +22,9 @@ describe('activeKeybindingOverrides', () => {
   })
   it('sanitizes and memoizes by reference, warning once per change', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    setKb({ 'node.newTerminal': ['Cmd+Shift+T'], 'bogus.command': ['Cmd+X'] })
+    setKb({ 'node.newTerminal': ['Cmd+Shift+Y'], 'bogus.command': ['Cmd+X'] })
     const first = activeKeybindingOverrides()
-    expect(first).toEqual({ 'node.newTerminal': ['Cmd+Shift+T'] })
+    expect(first).toEqual({ 'node.newTerminal': ['Cmd+Shift+Y'] })
     expect(activeKeybindingOverrides()).toBe(first)
     expect(warn).toHaveBeenCalledTimes(1)
     warn.mockRestore()

--- a/src/renderer/lib/reopenNode.test.ts
+++ b/src/renderer/lib/reopenNode.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { snapshotNode, recreateNodeFromSnapshot, type ReopenNodeSnapshot } from './reopenNode'
+
+// createAgentNode reads settings/CLI-caps singletons — none of that matters for these tests,
+// so stub the pieces snapshotNode/recreateNodeFromSnapshot actually touch.
+vi.mock('@renderer/state/settings', () => ({
+  useSettings: { getState: () => ({ settings: { customAgents: [], defaultNodeWidth: undefined, defaultNodeHeight: undefined, agentLaunchCommands: {} } }) }
+}))
+vi.mock('@renderer/state/permissionMode', () => ({ claudeCliCapsNow: () => ({ sessionIdFlag: false }) }))
+vi.mock('@renderer/state/codexIdentity', () => ({ codexSharedIdentity: () => undefined }))
+
+const baseCtx = () => ({
+  liveNodeIds: new Set<string>(),
+  project: undefined,
+  resolveAccountId: (id: string | undefined) => id,
+  permissionModeFor: () => undefined
+})
+
+describe('snapshotNode', () => {
+  it('captures a leaf node, resolving absolute position through its parent chain', () => {
+    const all = [
+      { id: 'group-1', position: { x: 100, y: 200 }, parentId: undefined },
+      { id: 'sticky-1', position: { x: 10, y: 20 }, parentId: 'group-1' }
+    ]
+    const node = {
+      type: 'sticky' as const,
+      position: { x: 10, y: 20 },
+      parentId: 'group-1',
+      extent: 'parent' as const,
+      width: 240,
+      height: 200,
+      data: { title: 'Note', color: '#ffd60a', group: null, text: 'hi' }
+    }
+    const snap = snapshotNode(node, all)
+    expect(snap).toEqual({
+      type: 'sticky',
+      position: { x: 10, y: 20 },
+      absolutePosition: { x: 110, y: 220 },
+      parentId: 'group-1',
+      extent: 'parent',
+      size: { width: 240, height: 200 },
+      data: node.data
+    })
+  })
+
+  it('returns null for group/subagent/loop nodes', () => {
+    for (const type of ['group', 'subagent', 'loop'] as const) {
+      const node = { type, position: { x: 0, y: 0 }, data: { title: 'x', color: '#fff', group: null } }
+      expect(snapshotNode(node, [])).toBeNull()
+    }
+  })
+
+  it('returns null for an account-login node', () => {
+    const node = {
+      type: 'terminal' as const,
+      position: { x: 0, y: 0 },
+      data: { title: 'Claude login', color: '#fff', group: null, initialCommand: 'claude /login' }
+    }
+    expect(snapshotNode(node, [])).toBeNull()
+  })
+})
+
+describe('recreateNodeFromSnapshot', () => {
+  const snap = (over: Partial<ReopenNodeSnapshot>): ReopenNodeSnapshot => ({
+    type: 'sticky',
+    position: { x: 10, y: 20 },
+    absolutePosition: { x: 10, y: 20 },
+    data: { title: 'Note', color: '#ffd60a', group: null, text: 'hi' },
+    ...over
+  })
+
+  it('recreates a sticky at its absolute position when the parent is gone', () => {
+    const node = recreateNodeFromSnapshot(snap({ parentId: 'dead-group' }), baseCtx())
+    expect(node).not.toBeNull()
+    expect(node!.type).toBe('sticky')
+    expect(node!.position).toEqual({ x: 10, y: 20 })
+    expect(node!.parentId).toBeUndefined()
+    expect(node!.data.text).toBe('hi')
+    expect(node!.data.title).toBe('Note')
+  })
+
+  it('reattaches to the parent group when it still exists, using the RELATIVE position', () => {
+    const ctx = { ...baseCtx(), liveNodeIds: new Set(['group-1']) }
+    const node = recreateNodeFromSnapshot(
+      snap({ parentId: 'group-1', extent: 'parent', position: { x: 5, y: 5 }, absolutePosition: { x: 105, y: 205 } }),
+      ctx
+    )
+    expect(node!.parentId).toBe('group-1')
+    expect(node!.extent).toBe('parent')
+    expect(node!.position).toEqual({ x: 5, y: 5 })
+  })
+
+  it('carries over size when the snapshot has one', () => {
+    const node = recreateNodeFromSnapshot(snap({ size: { width: 900, height: 500 } }), baseCtx())
+    expect(node!.width).toBe(900)
+    expect(node!.height).toBe(500)
+  })
+
+  it('recreates an editor node from filePath, carrying the custom title', () => {
+    const node = recreateNodeFromSnapshot(
+      snap({
+        type: 'editor',
+        data: { title: 'My renamed editor', color: '#6ac4dc', group: null, filePath: '/tmp/a.ts' }
+      }),
+      baseCtx()
+    )
+    expect(node!.type).toBe('editor')
+    expect(node!.data.filePath).toBe('/tmp/a.ts')
+    expect(node!.data.title).toBe('My renamed editor')
+  })
+
+  it('returns null for an editor snapshot missing filePath (never a silently blank node)', () => {
+    const node = recreateNodeFromSnapshot(
+      snap({ type: 'editor', data: { title: 'x', color: '#fff', group: null } }),
+      baseCtx()
+    )
+    expect(node).toBeNull()
+  })
+
+  it('recreates a dino node carrying its high score', () => {
+    const node = recreateNodeFromSnapshot(
+      snap({ type: 'dino', data: { title: 'Dino', color: '#a2a2a2', group: null, highScore: 42 } }),
+      baseCtx()
+    )
+    expect(node!.data.highScore).toBe(42)
+  })
+})

--- a/src/renderer/lib/reopenNode.ts
+++ b/src/renderer/lib/reopenNode.ts
@@ -1,6 +1,192 @@
+import type { NodeKind, Project } from '@shared/types'
+import type { AgentId, AgentPermissionMode } from '@shared/agents/config'
+import {
+  type CanvasNode,
+  type NodeData,
+  createTerminalNode,
+  createAgentNode,
+  createEditorNode,
+  createVideoNode,
+  createWebNode,
+  createBrowserNode,
+  createDiffNode,
+  createStickyNode,
+  createDinoNode,
+  isAccountLoginNode
+} from '@renderer/state/workspace'
+import { absolutePosition, type FocusableNode } from './nodeFocus'
+
+export type RestorableNodeKind = Exclude<NodeKind, 'group' | 'subagent' | 'loop'>
+
 export interface ReopenNodeSnapshot {
-  type: string
+  type: RestorableNodeKind
+  /** Raw position as stored on the node — relative to `parentId` when one is set. */
   position: { x: number; y: number }
+  /** Precomputed via `absolutePosition` at snapshot time, for when the parent is gone by
+   *  restore time (its own raw position would then be meaningless on its own). */
   absolutePosition: { x: number; y: number }
-  data: Record<string, unknown>
+  parentId?: string
+  extent?: 'parent'
+  size?: { width: number; height: number }
+  data: NodeData
+}
+
+type SnapshotSource = {
+  type?: string
+  position: { x: number; y: number }
+  parentId?: string
+  /** @xyflow/react's `Node.extent` is `'parent' | CoordinateExtent | undefined` — only the
+   *  `'parent'` literal matters here, so this stays loosely typed rather than importing that
+   *  union just to narrow it. */
+  extent?: unknown
+  width?: number | null
+  height?: number | null
+  data: NodeData
+}
+
+const UNRESTORABLE: ReadonlySet<string> = new Set(['group', 'subagent', 'loop'])
+
+/** Captures a node right before deletion. `all` must be the FULL live tree (before any
+ *  mutation), so the parent chain is still walkable. Returns null for kinds this feature
+ *  doesn't cover: group/subagent/loop nodes, and the account-login node (deleting it is a
+ *  distinct "remove this account's node" action, not a close a user wants back). */
+export function snapshotNode(
+  node: SnapshotSource,
+  all: readonly FocusableNode[]
+): ReopenNodeSnapshot | null {
+  const type = node.type ?? 'terminal'
+  if (UNRESTORABLE.has(type)) return null
+  if (isAccountLoginNode(node.data)) return null
+  const size =
+    typeof node.width === 'number' && typeof node.height === 'number'
+      ? { width: node.width, height: node.height }
+      : undefined
+  return {
+    type: type as RestorableNodeKind,
+    position: node.position,
+    absolutePosition: absolutePosition({ id: '__snapshot__', position: node.position, parentId: node.parentId }, all),
+    ...(node.parentId ? { parentId: node.parentId } : {}),
+    ...(node.extent === 'parent' ? { extent: 'parent' as const } : {}),
+    ...(size ? { size } : {}),
+    data: node.data
+  }
+}
+
+export interface RecreateContext {
+  /** ids present in the tree right now — decides whether the original parent group is still
+   *  around to reattach to. Groups are never recreated by this feature, so this only ever
+   *  needs to reflect nodes that were never deleted. */
+  liveNodeIds: ReadonlySet<string>
+  project: { ssh?: Project['ssh'] } | undefined
+  /** Validates/redirects an account id against the accounts that exist right now (a removed
+   *  account must not be stamped onto a new node). */
+  resolveAccountId: (accountId: string | undefined) => string | undefined
+  permissionModeFor: (agentId: AgentId) => AgentPermissionMode | undefined
+}
+
+const COSMETIC_KEYS = [
+  'title', 'titleAuto', 'color', 'group', 'tags', 'collapsed', 'expandedHeight', 'shell', 'agentModel'
+] as const
+
+function withCosmetics(node: CanvasNode, data: NodeData): CanvasNode {
+  const cosmetics: Partial<NodeData> = {}
+  for (const key of COSMETIC_KEYS) {
+    const value = data[key]
+    if (value !== undefined) (cosmetics as Record<string, unknown>)[key] = value
+  }
+  return { ...node, data: { ...node.data, ...cosmetics } }
+}
+
+function buildBase(snapshot: ReopenNodeSnapshot, ctx: RecreateContext): CanvasNode | null {
+  const d = snapshot.data
+  switch (snapshot.type) {
+    case 'terminal': {
+      if (d.sshRemoteTmux && d.ssh) {
+        // `remoteCwd` is non-optional on `Project['ssh']` — a remote node always had a cwd, but
+        // fall back to '' (server default `~`) rather than asserting the type away.
+        const sshBinding: Project['ssh'] = { server: d.ssh, remoteCwd: d.cwd ?? '' }
+        return d.agentId
+          ? createAgentNode(
+              d.agentId,
+              0,
+              d.cwd,
+              undefined,
+              undefined,
+              sshBinding,
+              ctx.resolveAccountId(d.accountId),
+              ctx.permissionModeFor(d.agentId)
+            )
+          : createTerminalNode(0, d.cwd, undefined, undefined, sshBinding)
+      }
+      if (d.ssh) {
+        // Standalone "SSH terminal" node (local `ssh …`, not a remote-tmux project node).
+        // Deliberately NOT routed through `createSshTerminalNode(server, …)`: that factory
+        // RECOMPUTES `execTrusted: server.extraArgs ? true : undefined` from whatever server
+        // object it's handed, which would mint trust=true for `extraArgs` of unknown
+        // provenance (e.g. hydrated some other way). `d.ssh` is the LIVE node's own data
+        // object, captured at snapshot time — its `execTrusted` already reflects genuine
+        // local provenance (see `SshConnection.execTrusted`'s doc in shared/ssh.ts), so it is
+        // copied verbatim, never re-derived. Build off `createTerminalNode` for id/size/position
+        // scaffolding, then stamp `data.ssh` directly (no `sshRemoteTmux` — that flag means the
+        // OTHER, remote-tmux-project case above).
+        const scaffold = createTerminalNode(0)
+        return { ...scaffold, data: { ...scaffold.data, ssh: d.ssh } }
+      }
+      if (d.agentId) {
+        return createAgentNode(
+          d.agentId,
+          0,
+          d.cwd,
+          undefined,
+          undefined,
+          ctx.project?.ssh,
+          ctx.resolveAccountId(d.accountId),
+          ctx.permissionModeFor(d.agentId)
+        )
+      }
+      return createTerminalNode(0, d.cwd, undefined, undefined, ctx.project?.ssh)
+    }
+    case 'sticky': {
+      const node = createStickyNode(0)
+      return { ...node, data: { ...node.data, text: d.text ?? '' } }
+    }
+    case 'editor':
+      return d.filePath ? createEditorNode(0, d.filePath, undefined, d.sshFs) : null
+    case 'video':
+      return d.filePath ? createVideoNode(0, d.filePath, undefined, d.sshFs) : null
+    case 'diff':
+      return d.cwd && d.filePath ? createDiffNode(0, d.cwd, d.filePath, !!d.diffStaged, undefined, d.commitOid) : null
+    case 'web':
+      return createWebNode(0, { url: d.url, filePath: d.filePath })
+    case 'browser':
+      return createBrowserNode(0, d.url ?? '', undefined, d.partition)
+    case 'dino':
+      return createDinoNode(0, undefined, d.highScore ?? 0)
+    default:
+      return null
+  }
+}
+
+/** Rebuilds a fresh node from a snapshot: same kind, position, parent group (if it still
+ *  exists), and cosmetic metadata — but a NEW id/session, assembled through the same factories
+ *  "New terminal/agent/…" uses, so e.g. an agent node's launch command is computed correctly
+ *  for the CURRENT permission mode rather than replaying a stale one. Returns null for a kind
+ *  this feature doesn't cover, or when required data (e.g. an editor's filePath) is missing —
+ *  never a silently wrong node. */
+export function recreateNodeFromSnapshot(snapshot: ReopenNodeSnapshot, ctx: RecreateContext): CanvasNode | null {
+  const base = buildBase(snapshot, ctx)
+  if (!base) return null
+  const node = withCosmetics(base, snapshot.data)
+  const reattach = !!snapshot.parentId && ctx.liveNodeIds.has(snapshot.parentId)
+  node.position = reattach ? snapshot.position : snapshot.absolutePosition
+  node.parentId = reattach ? snapshot.parentId : undefined
+  // `snapshot.extent` is loosely typed (see SnapshotSource) — narrow back to the one literal
+  // this codebase ever sets on a child node.
+  node.extent = reattach && snapshot.extent === 'parent' ? 'parent' : undefined
+  if (snapshot.size) {
+    node.width = snapshot.size.width
+    node.height = snapshot.size.height
+    node.style = { ...node.style, width: snapshot.size.width, height: snapshot.size.height }
+  }
+  return node
 }

--- a/src/renderer/lib/reopenNode.ts
+++ b/src/renderer/lib/reopenNode.ts
@@ -1,0 +1,6 @@
+export interface ReopenNodeSnapshot {
+  type: string
+  position: { x: number; y: number }
+  absolutePosition: { x: number; y: number }
+  data: Record<string, unknown>
+}

--- a/src/renderer/lib/reopenPlan.test.ts
+++ b/src/renderer/lib/reopenPlan.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { planReopen, type PlanReopenProject } from './reopenPlan'
+import { useReopenHistory } from '@renderer/state/reopenHistory'
+import type { ReopenNodeSnapshot } from './reopenNode'
+import type { CanvasNode } from '@renderer/state/workspace'
+
+const snap = (over: Partial<ReopenNodeSnapshot> = {}): ReopenNodeSnapshot => ({
+  type: 'sticky',
+  position: { x: 0, y: 0 },
+  absolutePosition: { x: 0, y: 0 },
+  data: { title: 'Note', color: '#ffd60a', group: null },
+  ...over
+})
+
+const node = (id: string): CanvasNode =>
+  ({ id, type: 'sticky', position: { x: 0, y: 0 }, data: { title: 'Note', color: '#ffd60a', group: null } }) as CanvasNode
+
+/** A `recreate` stand-in that always succeeds, tagging each output node with a counter so a
+ *  multi-node batch is distinguishable in assertions. */
+function alwaysRecreates(): (s: ReopenNodeSnapshot) => CanvasNode | null {
+  let n = 0
+  return () => node(`recreated-${n++}`)
+}
+
+const neverRecreates = () => null
+
+beforeEach(() => {
+  useReopenHistory.setState({ stack: [] })
+})
+
+describe('planReopen', () => {
+  it('reopens a still-closed project', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: true, nodes: [] }]
+    const plan = planReopen(
+      { kind: 'project', projectId: 'p1', closedAt: 1 },
+      projects,
+      'p2',
+      new Set(),
+      neverRecreates
+    )
+    expect(plan).toEqual({ action: 'reopenProject', projectId: 'p1' })
+  })
+
+  it('skips a project entry whose project was already reopened another way (no longer closed)', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: false, nodes: [] }]
+    const plan = planReopen(
+      { kind: 'project', projectId: 'p1', closedAt: 1 },
+      projects,
+      'p2',
+      new Set(),
+      neverRecreates
+    )
+    expect(plan).toEqual({ action: 'skip' })
+  })
+
+  it('skips a project entry whose project was permanently deleted since', () => {
+    const plan = planReopen({ kind: 'project', projectId: 'gone', closedAt: 1 }, [], 'p2', new Set(), neverRecreates)
+    expect(plan).toEqual({ action: 'skip' })
+  })
+
+  it('skips a nodes entry whose project was permanently deleted since', () => {
+    const plan = planReopen(
+      { kind: 'nodes', projectId: 'gone', closedAt: 1, nodes: [snap()] },
+      [],
+      'p2',
+      new Set(),
+      alwaysRecreates()
+    )
+    expect(plan).toEqual({ action: 'skip' })
+  })
+
+  it('skips a nodes entry that recreates to nothing, rather than switching for an empty result', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: false, nodes: [] }]
+    const plan = planReopen(
+      { kind: 'nodes', projectId: 'p1', closedAt: 1, nodes: [snap(), snap()] },
+      projects,
+      'p1',
+      new Set(),
+      neverRecreates
+    )
+    expect(plan).toEqual({ action: 'skip' })
+  })
+
+  it('inserts live when the target project is the active one', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: false, nodes: [] }]
+    const plan = planReopen(
+      { kind: 'nodes', projectId: 'p1', closedAt: 1, nodes: [snap(), snap()] },
+      projects,
+      'p1',
+      new Set(['live-1']),
+      alwaysRecreates()
+    )
+    expect(plan.action).toBe('insertActive')
+    if (plan.action !== 'insertActive') throw new Error('unreachable')
+    // A multi-node batch restores as ONE unit, not split across separate plans.
+    expect(plan.nodes.map((n) => n.id)).toEqual(['recreated-0', 'recreated-1'])
+  })
+
+  it('a batch that partially recreates still restores as one unit with only the survivors', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: false, nodes: [] }]
+    let call = 0
+    const recreate = () => (call++ === 0 ? null : node('survivor'))
+    const plan = planReopen(
+      { kind: 'nodes', projectId: 'p1', closedAt: 1, nodes: [snap(), snap()] },
+      projects,
+      'p1',
+      new Set(),
+      recreate
+    )
+    expect(plan.action).toBe('insertActive')
+    if (plan.action !== 'insertActive') throw new Error('unreachable')
+    expect(plan.nodes).toHaveLength(1)
+    expect(plan.nodes[0].id).toBe('survivor')
+  })
+
+  it('routes a non-active OPEN project through insertStored with reopenProjectAfter false (plain switch)', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: false, nodes: [{ id: 'existing' }] }]
+    const plan = planReopen(
+      { kind: 'nodes', projectId: 'p1', closedAt: 1, nodes: [snap()] },
+      projects,
+      'p-active-elsewhere',
+      new Set(['ignored-because-not-active']),
+      alwaysRecreates()
+    )
+    expect(plan).toMatchObject({ action: 'insertStored', projectId: 'p1', reopenProjectAfter: false })
+  })
+
+  it('routes a non-active CLOSED project through insertStored with reopenProjectAfter true', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: true, nodes: [] }]
+    const plan = planReopen(
+      { kind: 'nodes', projectId: 'p1', closedAt: 1, nodes: [snap()] },
+      projects,
+      'p-active-elsewhere',
+      new Set(),
+      alwaysRecreates()
+    )
+    expect(plan).toMatchObject({ action: 'insertStored', projectId: 'p1', reopenProjectAfter: true })
+  })
+
+  it('uses the STORED project nodes (not the live set) as liveNodeIds for a non-active target', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: false, nodes: [{ id: 'stored-parent' }] }]
+    let seenLiveIds: ReadonlySet<string> | null = null
+    const plan = planReopen(
+      { kind: 'nodes', projectId: 'p1', closedAt: 1, nodes: [snap({ parentId: 'stored-parent' })] },
+      projects,
+      'p-active-elsewhere',
+      new Set(['live-only-id']), // must NOT be what the recreate call sees
+      (s, liveIds) => {
+        seenLiveIds = liveIds
+        return node('n')
+      }
+    )
+    expect(plan.action).toBe('insertStored')
+    expect(seenLiveIds).toEqual(new Set(['stored-parent']))
+  })
+
+  it('uses the ACTIVE live node ids (not the stored copy) for the active target', () => {
+    const projects: PlanReopenProject[] = [{ id: 'p1', closed: false, nodes: [{ id: 'stale-stored-id' }] }]
+    let seenLiveIds: ReadonlySet<string> | null = null
+    planReopen(
+      { kind: 'nodes', projectId: 'p1', closedAt: 1, nodes: [snap()] },
+      projects,
+      'p1',
+      new Set(['live-parent']),
+      (s, liveIds) => {
+        seenLiveIds = liveIds
+        return node('n')
+      }
+    )
+    expect(seenLiveIds).toEqual(new Set(['live-parent']))
+  })
+
+  // Spec scenario (a): repeated presses walk back through history in true chronological order,
+  // across interleaved entry kinds — driven through the REAL stack (Task 1's useReopenHistory),
+  // not a fake, so this exercises the actual pop order the command relies on.
+  it('walks back through interleaved project/nodes history in true chronological order, skipping stale entries', () => {
+    const projects: PlanReopenProject[] = [
+      { id: 'proj-old', closed: true, nodes: [] }, // still closed: reopenable
+      { id: 'proj-mid', closed: false, nodes: [] }, // reopened another way since: stale
+      { id: 'proj-new', closed: false, nodes: [] } // holds the recreatable node batch
+    ]
+    useReopenHistory.getState().push({ kind: 'project', projectId: 'proj-old', closedAt: 1 })
+    useReopenHistory.getState().push({ kind: 'project', projectId: 'proj-mid', closedAt: 2 })
+    useReopenHistory.getState().push({ kind: 'nodes', projectId: 'proj-new', closedAt: 3, nodes: [snap()] })
+
+    const plans: ReturnType<typeof planReopen>[] = []
+    let popped = useReopenHistory.getState().popNext()
+    while (popped) {
+      plans.push(planReopen(popped, projects, 'proj-new', new Set(['live-1']), alwaysRecreates()))
+      popped = useReopenHistory.getState().popNext()
+    }
+
+    // Most-recently-closed first: the nodes batch, then proj-mid (stale — skip), then proj-old.
+    expect(plans[0].action).toBe('insertActive')
+    expect(plans[1]).toEqual({ action: 'skip' })
+    expect(plans[2]).toEqual({ action: 'reopenProject', projectId: 'proj-old' })
+    expect(plans).toHaveLength(3)
+  })
+})

--- a/src/renderer/lib/reopenPlan.ts
+++ b/src/renderer/lib/reopenPlan.ts
@@ -1,0 +1,70 @@
+import type { ReopenEntry } from '@renderer/state/reopenHistory'
+import type { ReopenNodeSnapshot } from './reopenNode'
+import type { CanvasNode } from '@renderer/state/workspace'
+
+/** What `app.reopenLastClosed` (Cmd+Shift+T) should do for ONE popped history entry. Pure
+ *  decision only — no store writes, no `setNodes`, no navigation. `Canvas.tsx` executes
+ *  whichever variant comes back; `'skip'` means the entry was stale (already reopened another
+ *  way, its project was permanently deleted, or every node it held recreated to nothing) and the
+ *  caller should keep popping. */
+export type ReopenPlan =
+  | { action: 'reopenProject'; projectId: string }
+  | { action: 'insertActive'; nodes: CanvasNode[] }
+  | { action: 'insertStored'; projectId: string; reopenProjectAfter: boolean; nodes: CanvasNode[] }
+  | { action: 'skip' }
+
+/** The subset of `Project` this decision needs — kept minimal so tests can pass plain fixtures
+ *  instead of a full `Project`. */
+export interface PlanReopenProject {
+  id: string
+  closed?: boolean
+  nodes: readonly { id: string }[]
+}
+
+/**
+ * Decides what reopening `entry` should do, given the CURRENT project list and active project —
+ * both may have changed since the entry was recorded, which is exactly why an entry can be
+ * stale. `activeLiveNodeIds` is the live React Flow node id set (`nodesRef.current` on the
+ * canvas) — it's only consulted when `entry`'s project turns out to be the active one; a
+ * non-active project's own `nodes` (its serialized snapshot) stands in otherwise, since there is
+ * no live array for it. `recreate` is `recreateNodeFromSnapshot` pre-bound with everything except
+ * the live-id set (account resolution, permission mode, the TARGET project) — kept as an
+ * injected function so this stays pure and the account/permission-mode plumbing doesn't leak
+ * into the decision logic under test.
+ */
+export function planReopen(
+  entry: ReopenEntry,
+  projects: readonly PlanReopenProject[],
+  activeProjectId: string | undefined,
+  activeLiveNodeIds: ReadonlySet<string>,
+  recreate: (snapshot: ReopenNodeSnapshot, liveNodeIds: ReadonlySet<string>) => CanvasNode | null
+): ReopenPlan {
+  if (entry.kind === 'project') {
+    const project = projects.find((p) => p.id === entry.projectId)
+    // Only stale if it isn't sitting closed right now — already reopened another way, or gone.
+    return project?.closed ? { action: 'reopenProject', projectId: entry.projectId } : { action: 'skip' }
+  }
+
+  const project = projects.find((p) => p.id === entry.projectId)
+  if (!project) return { action: 'skip' } // permanently deleted since the entry was recorded
+
+  const isActive = project.id === activeProjectId
+  const liveIds = isActive ? activeLiveNodeIds : new Set(project.nodes.map((n) => n.id))
+  const created = entry.nodes
+    .map((snap) => recreate(snap, liveIds))
+    .filter((n): n is CanvasNode => n !== null)
+  // A snapshot that recreated to nothing (a kind this feature doesn't cover, or e.g. an editor
+  // whose filePath is somehow missing) leaves the whole batch with nothing to insert — treat as
+  // stale rather than switching/reopening a project for an empty result. A multi-node batch that
+  // DID partially recreate still restores as ONE unit (whatever survived), never split across plans.
+  if (!created.length) return { action: 'skip' }
+
+  return isActive
+    ? { action: 'insertActive', nodes: created }
+    : {
+        action: 'insertStored',
+        projectId: project.id,
+        reopenProjectAfter: !!project.closed,
+        nodes: created
+      }
+}

--- a/src/renderer/state/reopenHistory.test.ts
+++ b/src/renderer/state/reopenHistory.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { pushEntry, popEntry, HISTORY_CAP, type ReopenEntry } from './reopenHistory'
+
+const proj = (id: string, closedAt: number): ReopenEntry => ({ kind: 'project', projectId: id, closedAt })
+
+describe('pushEntry', () => {
+  it('appends to the end (most recent last)', () => {
+    const out = pushEntry([proj('a', 1)], proj('b', 2), 10)
+    expect(out.map((e) => (e as { projectId: string }).projectId)).toEqual(['a', 'b'])
+  })
+
+  it('caps the stack, dropping the OLDEST entries', () => {
+    const stack = [proj('a', 1), proj('b', 2)]
+    const out = pushEntry(stack, proj('c', 3), 2)
+    expect(out.map((e) => (e as { projectId: string }).projectId)).toEqual(['b', 'c'])
+  })
+
+  it('HISTORY_CAP is 10', () => {
+    expect(HISTORY_CAP).toBe(10)
+  })
+})
+
+describe('popEntry', () => {
+  it('removes and returns the LAST (most recent) entry', () => {
+    const stack = [proj('a', 1), proj('b', 2)]
+    const { entry, rest } = popEntry(stack)
+    expect(entry).toEqual(proj('b', 2))
+    expect(rest).toEqual([proj('a', 1)])
+  })
+
+  it('returns undefined entry and an empty rest for an empty stack', () => {
+    const { entry, rest } = popEntry([])
+    expect(entry).toBeUndefined()
+    expect(rest).toEqual([])
+  })
+})

--- a/src/renderer/state/reopenHistory.ts
+++ b/src/renderer/state/reopenHistory.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand'
+import type { ReopenNodeSnapshot } from '@renderer/lib/reopenNode'
+
+/** A single "close" event this session recorded — a project tab close, or a batch of node
+ *  deletions from one Delete/×/Cmd+W action. In-memory only: unlike closed-project state
+ *  (`project.closed`), which persists, this history resets on app restart — the same
+ *  convention a browser's own "reopen closed tab" uses. */
+export type ReopenEntry =
+  | { kind: 'project'; projectId: string; closedAt: number }
+  | { kind: 'nodes'; projectId: string; closedAt: number; nodes: ReopenNodeSnapshot[] }
+
+export const HISTORY_CAP = 10
+
+/** Appends `entry` (most recent last) and drops the oldest entries past `cap`. */
+export function pushEntry(stack: ReopenEntry[], entry: ReopenEntry, cap: number): ReopenEntry[] {
+  return [...stack, entry].slice(-cap)
+}
+
+/** Removes and returns the most recently pushed entry, or `undefined` for an empty stack. */
+export function popEntry(stack: ReopenEntry[]): { entry: ReopenEntry | undefined; rest: ReopenEntry[] } {
+  if (!stack.length) return { entry: undefined, rest: stack }
+  return { entry: stack[stack.length - 1], rest: stack.slice(0, -1) }
+}
+
+interface ReopenHistoryState {
+  stack: ReopenEntry[]
+  push: (entry: ReopenEntry) => void
+  /** Pops and returns the most recent entry. Callers that find it stale (project already
+   *  reopened another way, or permanently deleted) call this again to keep walking back. */
+  popNext: () => ReopenEntry | undefined
+}
+
+export const useReopenHistory = create<ReopenHistoryState>((set, get) => ({
+  stack: [],
+  push: (entry) => set((s) => ({ stack: pushEntry(s.stack, entry, HISTORY_CAP) })),
+  popNext: () => {
+    const { entry, rest } = popEntry(get().stack)
+    if (entry) set({ stack: rest })
+    return entry
+  }
+}))

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -49,6 +49,13 @@ describe('registry invariants', () => {
     expect(COMMANDS_BY_ID.get('canvas.fitAll')?.defaultBindings.darwin).toEqual([])
   })
 
+  it('reopen-last-closed defaults to Cmd+Shift+T and works in a terminal', () => {
+    const def = COMMANDS_BY_ID.get('app.reopenLastClosed')
+    expect(def?.defaultBindings.darwin).toEqual(['Cmd+Shift+T'])
+    expect(def?.defaultBindings.other).toEqual(['Cmd+Shift+T'])
+    expect(def?.allowInTerminal).toBe(true)
+  })
+
   it('pins the WHOLE table — every row PR 2 will dispatch on, in source order', () => {
     // Source order is contractual (first match wins in the resolver), so the array order is
     // asserted too. A dropped flag — allowInTerminal above all — reds this test.
@@ -79,6 +86,8 @@ describe('registry invariants', () => {
         scope: 'app', darwin: ['Cmd+Shift+G'], other: ['Cmd+Shift+G'], allowInTerminal: true },
       { id: 'panel.sessions', title: 'Pin sessions sidebar', group: 'General', scope: 'app',
         darwin: ['Cmd+Shift+L'], other: ['Cmd+Shift+L'], allowInTerminal: true },
+      { id: 'app.reopenLastClosed', title: 'Reopen last closed', group: 'General', scope: 'app',
+        darwin: ['Cmd+Shift+T'], other: ['Cmd+Shift+T'], allowInTerminal: true },
       { id: 'canvas.undo', title: 'Undo', group: 'Canvas', scope: 'canvas',
         darwin: ['Cmd+Z'], other: ['Cmd+Z'] },
       { id: 'canvas.redo', title: 'Redo', group: 'Canvas', scope: 'canvas',
@@ -331,12 +340,12 @@ describe('findKeybindingConflicts', () => {
 
 describe('sanitizeKeybindingOverrides', () => {
   it('passes through a clean override map', () => {
-    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['Cmd+Shift+T'] }, true)
-    expect(r).toEqual({ overrides: { 'node.newTerminal': ['Cmd+Shift+T'] }, warnings: [] })
+    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['Cmd+Shift+Y'] }, true)
+    expect(r).toEqual({ overrides: { 'node.newTerminal': ['Cmd+Shift+Y'] }, warnings: [] })
   })
   it('canonicalizes spellings', () => {
-    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['shift+cmd+t'] }, true)
-    expect(r.overrides).toEqual({ 'node.newTerminal': ['Cmd+Shift+T'] })
+    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['shift+cmd+y'] }, true)
+    expect(r.overrides).toEqual({ 'node.newTerminal': ['Cmd+Shift+Y'] })
   })
   it('drops unknown ids with a warning, keeps the rest', () => {
     const r = sanitizeKeybindingOverrides(
@@ -346,8 +355,8 @@ describe('sanitizeKeybindingOverrides', () => {
     expect(r.warnings.some((w) => w.includes('node.selfDestruct'))).toBe(true)
   })
   it('drops an invalid binding string but keeps valid siblings', () => {
-    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['Cmd+Shift+T', 'T'] }, true)
-    expect(r.overrides).toEqual({ 'node.newTerminal': ['Cmd+Shift+T'] })
+    const r = sanitizeKeybindingOverrides({ 'node.newTerminal': ['Cmd+Shift+Y', 'T'] }, true)
+    expect(r.overrides).toEqual({ 'node.newTerminal': ['Cmd+Shift+Y'] })
     expect(r.warnings.length).toBe(1)
   })
   it('a non-empty list that is entirely invalid falls back to defaults, not disabled', () => {

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -46,6 +46,7 @@ export type CommandId =
   | 'panel.explorer'
   | 'panel.sourceControl'
   | 'panel.sessions'
+  | 'app.reopenLastClosed'
   | 'canvas.undo'
   | 'canvas.redo'
   | 'canvas.deleteSelection'
@@ -98,6 +99,8 @@ export const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     defaultBindings: both('Cmd+Shift+G'), allowInTerminal: true },
   { id: 'panel.sessions', title: 'Pin sessions sidebar', group: 'General', scope: 'app',
     defaultBindings: both('Cmd+Shift+L'), allowInTerminal: true },
+  { id: 'app.reopenLastClosed', title: 'Reopen last closed', group: 'General', scope: 'app',
+    defaultBindings: both('Cmd+Shift+T'), allowInTerminal: true },
 
   // Canvas — inert while the kanban board is open (scope 'canvas'), blocked while typing.
   { id: 'canvas.undo', title: 'Undo', group: 'Canvas', scope: 'canvas',


### PR DESCRIPTION
## Summary

- Adds `Cmd+Shift+T` (`app.reopenLastClosed`) to reopen the most recently closed project tab, or recreate the most recently deleted node batch (terminal, agent, sticky, editor, video, diff, web, browser, dino) — whichever happened more recently. Repeated presses walk further back through a single chronological history stack shared by both kinds of "close" events.
- History is in-memory only per app run (capped at 10 entries), never persisted — matches a browser's own "reopen closed tab" convention.
- A recreated node is always a fresh node/session (new id), rebuilt through the app's existing `create*Node` factories rather than resurrecting the killed tmux session — so an agent node gets a correctly assembled launch command and permission mode, an SSH node's trust provenance is preserved verbatim (never re-derived), etc.
- The reopen decision logic (which branch to take, staleness checks, active-vs-non-active-project routing) is extracted into a pure, unit-tested `planReopen` function rather than living untestable inside `Canvas.tsx`.

Known limitation: `Cmd/Ctrl+Shift+T` is a browser-reserved chord (Chrome's own "reopen closed tab"), so it does not reach the page in Server Edition — this PR documents that as Desktop-only rather than claiming full coverage.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds
- [x] New unit tests: `reopenHistory.test.ts`, `reopenNode.test.ts`, `reopenPlan.test.ts` (covers recency interleaving across entry kinds, stale-entry skip, batch restore, cross-project routing)
- [x] `keybindings.test.ts`, `keybindingOverrides.test.ts`, `canvas-wiring.test.tsx`, `ShortcutsSection.test.tsx` all green
- [x] Full suite run; all failures traced to pre-existing, environment-dependent real-tmux/pty/session-host integration tests unrelated to this change (none touch `reopen*`, `Canvas.tsx`, or `keybindings.*`)