### PR TITLE
[codex] feat(canvas): add cross-project Wayfinder links

### DIFF
--- a/src/core/git-service.stack.test.ts
+++ b/src/core/git-service.stack.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { GitService } from './git-service'
+
+const service = new GitService()
+let repo = ''
+
+function git(...args: string[]): string {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim()
+}
+
+beforeEach(() => {
+  repo = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'nt-stack-')))
+  git('init', '-b', 'main')
+  git('config', 'user.email', 'test@nodeterm.test')
+  git('config', 'user.name', 'Nodeterm Test')
+  git('commit', '--allow-empty', '-m', 'initial')
+})
+
+afterEach(() => fs.rmSync(repo, { recursive: true, force: true }))
+
+describe('GitService stacked branches', () => {
+  it('writes and removes the git-town parent convention, but rejects self-dependency', async () => {
+    await expect(service.setBranchParent(repo, 'feature', 'feature')).resolves.toMatchObject({ ok: false })
+    await expect(service.setBranchParent(repo, 'feature', 'main')).resolves.toMatchObject({ ok: true })
+    expect(git('config', '--get', 'git-town-branch.feature.parent')).toBe('main')
+    await expect(service.unsetBranchParent(repo, 'feature')).resolves.toMatchObject({ ok: true })
+    expect(() => git('config', '--get', 'git-town-branch.feature.parent')).toThrow()
+  })
+
+  it('syncs only in the child branch owning worktree', async () => {
+    git('branch', 'child')
+    git('checkout', '-b', 'parent')
+    git('commit', '--allow-empty', '-m', 'parent change')
+    git('checkout', 'child')
+    await service.setBranchParent(repo, 'child', 'parent')
+
+    await expect(service.syncBranch(repo, 'child')).resolves.toMatchObject({ ok: true })
+    expect(git('merge-base', '--is-ancestor', 'parent', 'child')).toBe('')
+
+    git('checkout', 'main')
+    await expect(service.syncBranch(repo, 'child')).resolves.toMatchObject({
+      ok: false,
+      message: expect.stringMatching(/owning worktree/i)
+    })
+  })
+
+  it('ships only from the named parent branch owning worktree', async () => {
+    git('checkout', '-b', 'parent')
+    git('checkout', '-b', 'child')
+    git('commit', '--allow-empty', '-m', 'child change')
+    const childHead = git('rev-parse', 'child')
+
+    git('checkout', 'main')
+    await expect(service.shipBranch(repo, 'child', 'parent')).resolves.toMatchObject({
+      ok: false,
+      message: expect.stringMatching(/owning worktree/i)
+    })
+
+    git('checkout', 'parent')
+    await expect(service.shipBranch(repo, 'child', 'parent')).resolves.toMatchObject({ ok: true })
+    expect(git('rev-parse', 'parent')).toBe(childHead)
+  })
+})

--- a/src/core/git-service.ts
+++ b/src/core/git-service.ts
@@ -7,7 +7,8 @@ import { IPC } from '../shared/ipc'
 import type { GitFileChange, GitResult, GitStatus } from '../shared/types'
 import { loadGitHistoryFromExecutor } from '../shared/git-history'
 import * as worktreeOps from '../shared/worktree-ops'
-import type { WorktreeListResult } from '../shared/worktree'
+import type { WorktreeListResult, SubmoduleListResult } from '../shared/worktree'
+import { branchParentConfigKey, isValidGitRef } from '../shared/worktree'
 import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
 import { resolveGitRemote, runRemoteGit } from './remote-ssh/remote-git'
 import { platform } from './platform'
@@ -270,6 +271,7 @@ export class GitService {
     )
     platform().handle(IPC.gitRepoRoot, (cwd: string) => this.repoRoot(cwd))
     platform().handle(IPC.gitWorktreeList, (repoPath: string) => this.worktreeList(repoPath))
+    platform().handle(IPC.gitSubmoduleList, (repoPath: string) => this.submoduleList(repoPath))
     platform().handle(IPC.gitWorktreeAdd, (repoPath: string, wtPath: string, branch: string, baseRef: string, isNew: boolean) =>
       this.worktreeAdd(repoPath, wtPath, branch, baseRef, isNew)
     )
@@ -278,6 +280,17 @@ export class GitService {
     )
     platform().handle(IPC.gitWorktreeRemove, (repoPath: string, wtPath: string, deleteBranch: boolean, pruneOnly?: boolean) =>
       this.worktreeRemove(repoPath, wtPath, deleteBranch, pruneOnly)
+    )
+    platform().handle(IPC.gitSetBranchParent, (repoPath: string, child: string, parent: string) =>
+      this.setBranchParent(repoPath, child, parent)
+    )
+    platform().handle(IPC.gitUnsetBranchParent, (repoPath: string, child: string) =>
+      this.unsetBranchParent(repoPath, child)
+    )
+    platform().handle(IPC.gitSyncBranch, (cwd: string, child: string) => this.syncBranch(cwd, child))
+    platform().handle(IPC.gitProposeBranch, (cwd: string, child: string) => this.proposeBranch(cwd, child))
+    platform().handle(IPC.gitShipBranch, (cwd: string, child: string, parent: string) =>
+      this.shipBranch(cwd, child, parent)
     )
   }
 
@@ -298,6 +311,16 @@ export class GitService {
     // that came from a FAILED `git worktree list` is not "there are no worktrees", and the store on
     // the other side of this IPC would otherwise mark every bound group missing on one bad read.
     return worktreeOps.listWorktrees(git, repoPath, async (p) => fs.existsSync(p))
+  }
+  submoduleList(repoPath: string): Promise<SubmoduleListResult> {
+    // Same remote refusal as `worktreeList`: a repo on an SSH host cannot be stat'd from here, and the
+    // submodule paths are RELATIVE to a remote root — so a local `fs.existsSync` would answer about the
+    // wrong machine. Answer "the read failed" (`ok:false`), which is exactly what it is — NOT an empty
+    // list, which the auto-linker would read as "no submodules" and drop every link on one bad read.
+    if (isRemoteRepo(repoPath)) return Promise.resolve({ ok: false, entries: [] })
+    // `pathExists` is the `-` flag's fallback (see worktree-ops `listSubmodules`): a submodule git still
+    // records but whose directory is gone must read `prunable`. LOCAL-only (see the remote refusal above).
+    return worktreeOps.listSubmodules(git, repoPath, async (p) => fs.existsSync(p))
   }
   worktreeAdd(
     repoPath: string,
@@ -337,6 +360,148 @@ export class GitService {
     return worktreeOps.worktreeRemove(git, repoPath, wtPath, os.homedir(), deleteBranch, pruneOnly, async (p) =>
       fs.existsSync(p)
     )
+  }
+
+  // ── Branch-dependency / stacked-diff ops (ticket 03) ──────────────────────────────────────
+  //
+  // Plain git only — NO git-town binary. We adopt git-town's `git-town-branch.<child>.parent` config
+  // key as the topology convention (interoperable: a user who installs git-town gets the same lineage
+  // we declared, and a lineage they declared is readable by us). The rebase/PR/merge ops are plain
+  // `git`/`gh`. git-town remains an OPTIONAL power-user path, never a dependency.
+  //
+  // No `isRemoteRepo` refusal on these: `git config` and `git rebase` operate on refs already in the
+  // repo and route over the ControlMaster fine. The SSH gate lives at the verb/button layer (Canvas),
+  // which already refuses stacked-diff ops for SSH projects via `WORKTREE_SSH_NOTICE`. If a later
+  // audit wants the gate at the seam too, gate it here — but a pass-through that refuses is still a
+  // pass-through, not a reimplemented rebase.
+
+  /**
+   * Declare a branch's parent in the shared git config. Re-validates `child`/`parent` at the
+   * interpolation site (`branchParentConfigKey`): these values come from git-shared link JSON and
+   * land on a `git config` command line, so a smuggled flag or path char is rejected BEFORE any
+   * command is built (the standing rule — same as permission modes / `SAFE_SESSION_ID`). `repoPath`
+   * may be any worktree's cwd; the config is shared across worktrees.
+   */
+  async setBranchParent(repoPath: string, child: string, parent: string): Promise<GitResult> {
+    const key = branchParentConfigKey(child)
+    const p = parent.trim()
+    if (!key || !isValidGitRef(p)) return { ok: false, message: 'Invalid branch name.' }
+    if (child.trim() === p) return { ok: false, message: 'A branch cannot depend on itself.' }
+    const r = await git(repoPath, ['config', key, p])
+    return r.ok ? { ok: true, message: `Set ${child.trim()} → ${p}.` } : fail(r)
+  }
+
+  /** Drop a branch's parent config. The dependency LINK is removed separately (by the inspector). */
+  async unsetBranchParent(repoPath: string, child: string): Promise<GitResult> {
+    const key = branchParentConfigKey(child)
+    if (!key) return { ok: false, message: 'Invalid branch name.' }
+    // `--unset` exits 5 when the key is absent — that is not a failure here (the lineage is already
+    // gone, which is what the caller asked for). Treat a "key never existed" as success.
+    const r = await git(repoPath, ['config', '--unset', key])
+    if (r.ok) return { ok: true, message: `Unset parent of ${child.trim()}.` }
+    if (/exit code 5|not found/i.test(r.err)) return { ok: true, message: `Unset parent of ${child.trim()}.` }
+    return fail(r)
+  }
+
+  /**
+   * Sync one branch onto its configured parent: read the parent from config, then `git rebase
+   * <parent>` in the child's own worktree cwd (where the child is already HEAD). A clean rebase →
+   * success. A rebase that STOPS on a conflict is reported `ok:false` with a message telling the user
+   * to resolve in the terminal and `git rebase --continue` (the worktree's terminal is the natural
+   * place — it is the tmux session under the node). This is the honest behavior without git-town's
+   * conflict UI: we do not hide a conflicted state as success.
+   */
+  async syncBranch(cwd: string, child: string): Promise<GitResult> {
+    const c = child.trim()
+    if (!isValidGitRef(c)) return { ok: false, message: 'Invalid branch name.' }
+    // Read the parent from the convention config key. Missing parent → nothing to sync onto.
+    const key = branchParentConfigKey(c)
+    if (!key) return { ok: false, message: 'Invalid branch name.' }
+    const parentR = await git(cwd, ['config', '--get', key])
+    if (!parentR.ok || !parentR.out.trim()) {
+      return { ok: false, message: `No parent configured for ${c}. Declare the dependency first.` }
+    }
+    const parent = parentR.out.trim()
+    if (!isValidGitRef(parent)) return { ok: false, message: 'Invalid parent branch.' }
+    const head = await git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'])
+    if (!head.ok || head.out.trim() !== c) {
+      return { ok: false, message: `Refusing to sync ${c}: its owning worktree is not checked out here.` }
+    }
+    const r = await git(cwd, ['rebase', parent])
+    if (r.ok) return { ok: true, message: r.out || `Rebased ${c} onto ${parent}.` }
+    // A conflict leaves the repo mid-rebase. Surface it honestly and point at the terminal: the
+    // user resolves there and runs `git rebase --continue` (or `--abort`). We deliberately do NOT
+    // auto-abort — the user may want to keep partial resolution.
+    if (/conflict|could not apply|merge/i.test(r.err)) {
+      return {
+        ok: false,
+        message: `Rebase stopped on a conflict. Resolve it in this terminal, then run \`git rebase --continue\` (or \`git rebase --abort\` to give up). Parent: ${parent}.`
+      }
+    }
+    return fail(r)
+  }
+
+  /** Open a PR from `child` into its configured parent via `gh`. Auth reuses the publish path's
+   *  ghAuthed check; a not-logged-in gh is surfaced as needsAuth. */
+  async proposeBranch(cwd: string, child: string): Promise<GitResult> {
+    const c = child.trim()
+    if (!isValidGitRef(c)) return { ok: false, message: 'Invalid branch name.' }
+    if (!GH_PATH) return { ok: false, message: 'GitHub CLI (gh) not found.' }
+    const key = branchParentConfigKey(c)
+    if (!key) return { ok: false, message: 'Invalid branch name.' }
+    const parentR = await git(cwd, ['config', '--get', key])
+    const parent = parentR.out.trim()
+    if (!parentR.ok || !parent) {
+      return { ok: false, message: `No parent configured for ${c}. Declare the dependency first.` }
+    }
+    if (!isValidGitRef(parent)) return { ok: false, message: 'Invalid parent branch.' }
+    // gh needs auth. Reuse the existing token-from-git-credentials fallback so a user who can push
+    // can also propose without a separate `gh auth login`.
+    const env: NodeJS.ProcessEnv = { ...GIT_ENV }
+    if (!(await ghAuthed())) {
+      const token = await githubTokenFromGitCredentials(cwd)
+      if (!token) return { ok: false, message: 'Sign in to GitHub to propose.', needsAuth: true }
+      env.GH_TOKEN = token
+    }
+    try {
+      // --head names the source branch; --base the parent it stacks onto. The PR body notes the
+      // stack relationship so a reviewer sees the dependency without leaving the PR.
+      await run(
+        GH_PATH,
+        ['pr', 'create', '--base', parent, '--head', c, '--title', c, '--body', `Stacked on #${parent}.`],
+        { cwd, env, maxBuffer: 10 * 1024 * 1024 }
+      )
+      return { ok: true, message: `Opened PR ${c} → ${parent}.` }
+    } catch (e) {
+      const err = e as { stderr?: string; message?: string }
+      const msg = (err.stderr || err.message || 'gh failed').trim()
+      if (/\balready exists/i.test(msg)) return { ok: false, message: 'A PR already exists for this branch.' }
+      if (/\b(401|403)\b|unauthor|forbidden|auth|token|scope|HTTP 4/i.test(msg)) {
+        return { ok: false, message: msg, needsAuth: true }
+      }
+      return { ok: false, message: msg }
+    }
+  }
+
+  /**
+   * Ship one branch into its parent: fast-forward the parent to the child when clean (the simple
+   * v1 case). Run in the PARENT's worktree cwd (where parent is HEAD), after fetching the child ref.
+   * A non-fast-forward (the parent moved) is reported, NOT force-merged — rebase first (syncBranch),
+   * then ship. Multi-descendant restack (git-town's hardest part) is a deliberate follow-up.
+   */
+  async shipBranch(cwd: string, child: string, parent: string): Promise<GitResult> {
+    const c = child.trim()
+    const p = parent.trim()
+    if (!isValidGitRef(c) || !isValidGitRef(p)) return { ok: false, message: 'Invalid branch name.' }
+    const head = await git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'])
+    if (!head.ok || head.out.trim() !== p) {
+      return { ok: false, message: `Refusing to ship into ${p}: its owning worktree is not checked out here.` }
+    }
+    // `cwd` is the parent's worktree (parent is HEAD). Make the child ref reachable from here, then
+    // fast-forward. `merge --ff-only` refuses when parent is not an ancestor of child — exactly the
+    // guard we want: a stale parent means rebase first, never a surprise merge commit.
+    const r = await git(cwd, ['merge', '--ff-only', c])
+    return r.ok ? { ok: true, message: r.out || `Shipped ${c} into ${p} (fast-forward).` } : fail(r)
   }
 
   async status(cwd: string): Promise<GitStatus> {

--- a/src/core/git-service.worktree-remote.test.ts
+++ b/src/core/git-service.worktree-remote.test.ts
@@ -60,6 +60,22 @@ describe('worktree ops on a LOCAL repo (no remote claims it)', () => {
   })
 })
 
+describe('submoduleList', () => {
+  it('on a LOCAL repo reaches real git (the remote guard does not swallow the local path)', async () => {
+    const listed = await svc.submoduleList(repo)
+    // A fresh empty repo has no submodules — that is `ok: true` with no entries, NOT a failed read.
+    expect(listed).toEqual({ ok: true, entries: [] })
+  })
+
+  it('on a REMOTE repo reports a FAILED READ, not an empty list', async () => {
+    claimAsRemote(repo)
+    const listed = await svc.submoduleList(repo)
+    // Same rule as worktreeList: `{ ok: false }` so a caller cannot read an empty list as "no
+    // submodules" and drop every auto-link on one bad read. The host's submodules live on the host.
+    expect(listed).toEqual({ ok: false, entries: [] })
+  })
+})
+
 describe('worktree ops on a REMOTE repo', () => {
   it('worktreeList reports a FAILED READ, not an empty list', async () => {
     claimAsRemote(repo)

--- a/src/core/pty-manager.require-existing.test.ts
+++ b/src/core/pty-manager.require-existing.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform, type FakePlatform } from './platform-fake'
+import { IPC } from '../shared/ipc'
+import type { PtyCreateOptions, PtyCreateResult } from '../shared/types'
+
+/**
+ * `requireExisting`: a cross-project PROJECTION (`open-agent --project <B>`) is a VIEWER of B's
+ * tmux session, never its owner. Its `transport.create` carries `requireExisting: true`, and
+ * `create()` must REFUSE — return `unavailable: 'no-session'` — rather than spawn a session for a
+ * node it does not own. Spawning would steal pane ownership and run under the wrong project's
+ * resolved cwd/account, which is exactly the `requireRemote` precedent (a create that would
+ * silently land in the wrong context is refused) — only `requireExisting` is the stronger
+ * "join OR refuse": there is no valid spawn branch for it at all, so the guard sits in `create`
+ * after the join attempts are exhausted, not in `spawnNew` like `requireRemote`.
+ *
+ * This file is the sibling of `pty-require-remote.test.ts`: the same harness, the same IPC path,
+ * asserting the refusal (never spawns) and the one ordering rule — a live session is still JOINED
+ * (only a fresh spawn is refused), so a projection racing B's own spawn attaches rather than errors.
+ */
+const spawned: Array<{ file: string; args: string[] }> = []
+
+vi.mock('node-pty', () => ({
+  spawn: (file: string, args: string[]) => {
+    spawned.push({ file, args })
+    return {
+      onData: () => {},
+      onExit: () => {},
+      write: () => {},
+      resize: () => {},
+      pause: () => {},
+      resume: () => {},
+      kill: () => {},
+      pid: 4321
+    }
+  }
+}))
+
+/**
+ * A machine with pty devices to spare, always — same guard as `pty-require-remote.test.ts`. Without
+ * it the real probe runs a `readdir('/dev')` against the developer's host and the pre-flight refuses
+ * every create once that host nears its `kern.tty.ptmx_max` (511 on macOS; a dev box running this app
+ * all day genuinely reaches the 480s). Nothing here is about device pressure.
+ */
+vi.mock('./pty-devices', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./pty-devices')>()),
+  readPtyDevices: () => ({ ceiling: 511, inUse: 8 })
+}))
+
+const ALICE = 1
+const BOB = 2
+
+describe('pty create: requireExisting never spawns (only joins a live session)', () => {
+  let fake: FakePlatform
+
+  beforeEach(async () => {
+    spawned.length = 0
+    fake = fakePlatform()
+    initPlatform(fake)
+    const { PtyManager } = await import('./pty-manager')
+    new PtyManager().registerIpc()
+  })
+  afterEach(() => {
+    resetPlatformForTests()
+  })
+
+  const create = (clientId: number, options: Partial<PtyCreateOptions>) =>
+    fake.handlers[IPC.ptyCreate](clientId, {
+      cols: 80,
+      rows: 24,
+      persistKey: 'node-1',
+      ...options
+    }) as Promise<PtyCreateResult>
+
+  it('refuses (spawning nothing) when no live session exists', async () => {
+    const res = await create(ALICE, { requireExisting: true, cwd: '/srv/app' })
+
+    expect(spawned).toHaveLength(0) // ← the whole point: a projection never owns the session
+    expect(res.unavailable).toBe('no-session')
+    expect(res.sessionId).toBe('')
+    expect(res.fresh).toBe(false) // nothing was created, so nothing is "cold"
+  })
+
+  it('distinguishes no-session from the ssh refusal (a different unavailable reason)', async () => {
+    // The two `unavailable` values mean different things to the caller: 'ssh' is "the remote master
+    // is down" (reconnect), 'no-session' is "the session is simply not live yet" (wait for B to
+    // mount). A projection's plate branches on exactly this distinction.
+    const res = await create(ALICE, { requireExisting: true, cwd: '/srv/app' })
+    expect(res.unavailable).toBe('no-session')
+    expect(res.unavailable).not.toBe('ssh')
+  })
+
+  it('still JOINS a live session for that node — only a fresh spawn is refused', async () => {
+    // The session already runs (B mounted and spawned it). A second view — the projection in A — must
+    // attach to it: refusing the join would make a perfectly healthy B terminal invisible in A.
+    const first = await create(ALICE, {})
+    const joined = await create(BOB, { requireExisting: true })
+
+    expect(spawned).toHaveLength(1) // the first create spawned once; the projection joined, not spawned
+    expect(joined.unavailable).toBeUndefined()
+    expect(joined.sessionId).toBe(first.sessionId)
+  })
+
+  it('without the flag the same options DO spawn locally (what requireExisting prevents)', async () => {
+    const res = await create(ALICE, { cwd: '/srv/app' })
+
+    expect(spawned).toHaveLength(1)
+    expect(res.unavailable).toBeUndefined()
+    expect(res.sessionId).not.toBe('')
+  })
+})

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -1932,6 +1932,16 @@ export class PtyManager {
     // AFTER the in-flight barrier so a create racing the owner's own respawn joins it instead.
     const tomb = this.liveTombstone(key)
     if (tomb && tomb.by !== clientId) return { sessionId: '', fresh: false, closed: { by: tomb.by } }
+    // A projection of a FOREIGN node (ticket 05's `requireExisting`) must never SPAWN its target's
+    // session — it is a viewer, not the owner, and spawning would steal pane ownership + run under
+    // the wrong project's resolved context. By this point every legitimate join path has been
+    // exhausted: `join()` missed (no live session), the in-flight spawn it might have been racing
+    // has resolved (and its `late` re-join also missed, or there was no in-flight spawn at all),
+    // and the node was not tombstoned (a `closed` refusal already won above). So there is genuinely
+    // no session to join — refuse. The owning project's next mount spawns the session and the
+    // projection retries. See `PtyCreateOptions.requireExisting` for why this lives in `create`
+    // (not `spawnNew`) — the projection has no valid spawn branch at all.
+    if (options.requireExisting) return { sessionId: '', fresh: false, unavailable: 'no-session' }
     const spawn = this.spawnNew(clientId, options)
     this.inflight.set(key, spawn)
     // Clear on settle — INCLUDING on failure, or a single failed spawn would leave a rejected

--- a/src/core/workspace-files.test.ts
+++ b/src/core/workspace-files.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import type { CanvasNodeState, Project, Workspace } from '../shared/types'
+import type { CanvasNodeState, Link, Project, Workspace } from '../shared/types'
 import {
   toPortableNodes, resolveNodes, projectToFile, fileToProject, framingViewport,
-  sameProjectContent, splitWorkspace, serializeProjectFile
+  sameProjectContent, splitWorkspace, serializeProjectFile, migrateLinks
 } from './workspace-files'
 import { legacyFileId } from '../shared/project-id'
 import type { ProjectFileV1 } from './workspace-files'
@@ -580,5 +580,114 @@ describe('project icon: emitted only when valid, sanitized on the hostile load p
   it('a hand-edited hostile icon shape on disk is dropped on load', () => {
     const f = { ...projectToFile(project(), 1, 'now'), icon: { type: 'lucide', name: 'not-real' } } as any
     expect(fileToProject(f, { id: 'p1' }).icon).toBeUndefined()
+  })
+})
+
+describe('migrateLinks (bridges/ropes → unified Link[])', () => {
+  it('lifts bridges to kind:"context" node↔node links, preserving ids', () => {
+    const out = migrateLinks({ bridges: [{ id: 'bridge-a-b', source: 'a', target: 'b' }] })!
+    expect(out).toEqual([
+      {
+        id: 'bridge-a-b',
+        kind: 'context',
+        source: { ref: 'node', nodeId: 'a' },
+        target: { ref: 'node', nodeId: 'b' }
+      }
+    ])
+  })
+
+  it('lifts ropes to kind:"lineage" with displayOnly meta, preserving ctrl- ids', () => {
+    const out = migrateLinks({ ropes: [{ id: 'ctrl-a-b', source: 'a', target: 'b' }] })!
+    expect(out).toEqual([
+      {
+        id: 'ctrl-a-b',
+        kind: 'lineage',
+        source: { ref: 'node', nodeId: 'a' },
+        target: { ref: 'node', nodeId: 'b' },
+        meta: { displayOnly: true }
+      }
+    ])
+  })
+
+  it('merges bridges + ropes into one array (context first, then lineage)', () => {
+    const out = migrateLinks({
+      bridges: [{ id: 'bridge-a-b', source: 'a', target: 'b' }],
+      ropes: [{ id: 'ctrl-a-c', source: 'a', target: 'c' }]
+    })!
+    expect(out.map((l) => l.kind)).toEqual(['context', 'lineage'])
+    expect(out).toHaveLength(2)
+  })
+
+  it('passes an already-migrated `links` through untouched (no double-migration)', () => {
+    const links: Link[] = [
+      {
+        id: 'x',
+        kind: 'dependency',
+        source: { ref: 'branch', repoPath: '/r', branch: 'feat' },
+        target: { ref: 'branch', repoPath: '/r', branch: 'main' }
+      }
+    ]
+    // Even if legacy bridges/ropes are ALSO present, an existing `links` wins (it was written by
+    // a newer build, so the legacy fields are stale leftovers).
+    expect(migrateLinks({ links, bridges: [{ id: 'stale', source: 'a', target: 'b' }] })).toBe(links)
+  })
+
+  it('returns undefined for a link-less canvas (omitted field = byte-identical file)', () => {
+    expect(migrateLinks({})).toBeUndefined()
+    expect(migrateLinks({ bridges: [], ropes: [] })).toBeUndefined()
+  })
+})
+
+describe('projectToFile / fileToProject link migration round-trip', () => {
+  it('writes `links` only (no bridges/ropes) and reads them back', () => {
+    const p = project({
+      links: [
+        {
+          id: 'bridge-n1-n2',
+          kind: 'context',
+          source: { ref: 'node', nodeId: 'term-abc' },
+          target: { ref: 'node', nodeId: 'other' }
+        }
+      ]
+    })
+    const f = projectToFile(p, 1, '2026-01-01')
+    expect(f.links).toBeDefined()
+    expect(f.bridges).toBeUndefined()
+    expect(f.ropes).toBeUndefined()
+    // Read back: links survive (fileToProject passes `links` through migrateLinks).
+    const back = fileToProject(f, { id: 'p1' })
+    expect(back.links).toEqual(p.links)
+  })
+
+  it('reads a legacy file carrying bridges/ropes (no links) and migrates to links', () => {
+    const f: ProjectFileV1 = {
+      version: 1,
+      rev: 1,
+      savedAt: '2026-01-01',
+      name: 'foo',
+      color: '#7aa2f7',
+      nodes: [node()],
+      bridges: [{ id: 'bridge-a-b', source: 'a', target: 'b' }],
+      ropes: [{ id: 'ctrl-a-c', source: 'a', target: 'c' }]
+    }
+    const back = fileToProject(f, { id: 'p1' })
+    expect(back.links).toEqual([
+      {
+        id: 'bridge-a-b',
+        kind: 'context',
+        source: { ref: 'node', nodeId: 'a' },
+        target: { ref: 'node', nodeId: 'b' }
+      },
+      {
+        id: 'ctrl-a-c',
+        kind: 'lineage',
+        source: { ref: 'node', nodeId: 'a' },
+        target: { ref: 'node', nodeId: 'c' },
+        meta: { displayOnly: true }
+      }
+    ])
+    // Legacy fields are NOT re-attached on read (links replaces them).
+    expect(back.bridges).toBeUndefined()
+    expect(back.ropes).toBeUndefined()
   })
 })

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -7,7 +7,7 @@ import {
   stripSharedNodeExec,
   type LocalNodeExecMap
 } from '../shared/node-exec'
-import type { BridgeLink, CanvasNodeState, Project, ProjectKanban, Viewport, Workspace } from '../shared/types'
+import type { BridgeLink, CanvasNodeState, Link, Project, ProjectKanban, Viewport, Workspace } from '../shared/types'
 import { projectCapabilityFields, readProjectCapabilities } from '../shared/project-capabilities'
 import { loadedAgentBrowserPartition } from '../shared/browser-partition'
 import { sanitizeProjectIcon, type ProjectIcon } from '../shared/project-icon'
@@ -31,6 +31,47 @@ function sanitizeBrowserPartitions(nodes: CanvasNodeState[], projectId: string):
 
 export const PROJECT_DIR = '.nodeterm'
 export const PROJECT_FILE = 'project.json'
+
+/**
+ * Lift the legacy `bridges`/`ropes` arrays into the unified `Link[]` on load — a one-time,
+ * forward-compatible migration (a pre-`Link` build ignores `links`; a post-`Link` file stops
+ * emitting `bridges`/`ropes`, so a file never carries both for long).
+ *
+ *  - `bridges` → `kind:'context'`, node↔node endpoints (a sticky→terminal note link is already a
+ *    bridge in the legacy shape; `meta.note` is the renderer's concern at author time, not here).
+ *  - `ropes`  → `kind:'lineage'`, `meta:{displayOnly:true}` — the "never a context link" invariant.
+ *
+ * Existing ids (`bridge-…`/`ctrl-…`) are preserved VERBATIM so the dedup / covered-rope logic
+ * (`noteLink.hiddenLinkIds` / `linkIdsCoveredByRopes`) is undisturbed. Returns `undefined` when
+ * the result is empty so a link-less project stays byte-identical to a pre-`Link` file (the same
+ * omit-when-empty posture `kanban`/`worktree` use). Pure so it is unit-testable in isolation.
+ */
+export function migrateLinks(f: {
+  links?: Link[]
+  bridges?: BridgeLink[]
+  ropes?: BridgeLink[]
+}): Link[] | undefined {
+  if (f.links) return f.links
+  const out: Link[] = []
+  for (const b of f.bridges ?? []) {
+    out.push({
+      id: b.id,
+      kind: 'context',
+      source: { ref: 'node', nodeId: b.source },
+      target: { ref: 'node', nodeId: b.target }
+    })
+  }
+  for (const r of f.ropes ?? []) {
+    out.push({
+      id: r.id,
+      kind: 'lineage',
+      source: { ref: 'node', nodeId: r.source },
+      target: { ref: 'node', nodeId: r.target },
+      meta: { displayOnly: true }
+    })
+  }
+  return out.length ? out : undefined
+}
 
 /**
  * On-disk shape of <cwd>/.nodeterm/project.json — a GIT-SHARED document (users are asked to
@@ -79,7 +120,12 @@ export interface ProjectFileV1 {
    */
   viewport?: Viewport
   nodes: CanvasNodeState[]
+  /** The unified typed link substrate (replaces bridges/ropes). Written by new builds; see
+   *  {@link migrateLinks}. Optional and additive — a pre-`Link` build ignores it. */
+  links?: Link[]
+  /** LEGACY read-only migration source (see {@link migrateLinks}); new writes omit this. */
   bridges?: BridgeLink[]
+  /** LEGACY read-only migration source (see {@link migrateLinks}); new writes omit this. */
   ropes?: BridgeLink[]
   /**
    * LEGACY (read-only), same rule as `viewport`: a managed Claude account id names a credential
@@ -224,6 +270,9 @@ export function projectToFile(
   // entry instead (`localNodeExec` / `IndexEntryV3.localExec`). See @shared/node-exec.
   const nodes = stripSharedNodeExec(p.cwd ? toPortableNodes(p.nodes, p.cwd) : p.nodes)
   const icon = sanitizeProjectIcon(p.icon)
+  // New builds write the unified `links` only. A project still carrying legacy `bridges`/`ropes`
+  // (during the renderer repoint) is migrated here so the file is always in the new shape.
+  const links = p.links ?? migrateLinks(p)
   return {
     version: 1,
     rev,
@@ -234,8 +283,7 @@ export function projectToFile(
     viewport: framingViewport(nodes),
     nodes,
     ...(icon ? { icon } : {}),
-    ...(p.bridges ? { bridges: p.bridges } : {}),
-    ...(p.ropes ? { ropes: p.ropes } : {}),
+    ...(links ? { links } : {}),
     ...(p.defaultPermissionMode ? { defaultPermissionMode: p.defaultPermissionMode } : {}),
     // Strict-normalised (literal true only, known keys only) and omitted when off — an off
     // capability adds no bytes to the committed file. `capabilityAck` is deliberately NOT here:
@@ -289,6 +337,7 @@ export function fileToProject(
 ): Project {
   const defaultAccountId = base.defaultAccountId ?? f.defaultAccountId
   const icon = sanitizeProjectIcon(f.icon)
+  const links = migrateLinks(f)
   return {
     id: base.id,
     name: f.name,
@@ -305,8 +354,9 @@ export function fileToProject(
       applyLocalNodeExec(base.cwd ? resolveNodes(f.nodes, base.cwd) : f.nodes, base.localExec),
       base.id
     ),
-    ...(f.bridges ? { bridges: f.bridges } : {}),
-    ...(f.ropes ? { ropes: f.ropes } : {}),
+    // Migrate legacy bridges/ropes into the unified `links` on read. A file already carrying
+    // `links` passes through; a link-less project stays link-less (migrateLinks returns undefined).
+    ...(links ? { links } : {}),
     ...(defaultAccountId ? { defaultAccountId } : {}),
     ...(f.defaultPermissionMode ? { defaultPermissionMode: f.defaultPermissionMode } : {}),
     // The file is hostile input: only a literal `true` under a known key survives the read

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -6,11 +6,11 @@ import { IPC } from '../shared/ipc'
 import { platform } from './platform'
 import {
   DEFAULT_PROJECT_ID, EMPTY_WORKSPACE,
-  type BridgeLink, type CanvasNodeState, type Project, type Workspace, type WorkspaceV1
+  type CanvasNodeState, type Link, type Project, type Workspace, type WorkspaceV1
 } from '../shared/types'
 import {
-  PROJECT_DIR, PROJECT_FILE, fileToProject, projectToFile, resolveNodes, sameProjectContent,
-  serializeProjectFile, splitWorkspace, validKanban,
+  PROJECT_DIR, PROJECT_FILE, fileToProject, migrateLinks, projectToFile, resolveNodes,
+  sameProjectContent, serializeProjectFile, splitWorkspace, validKanban,
   type IndexEntryV3, type ProjectFileV1, type WorkspaceIndexV3
 } from './workspace-files'
 import { readProjectSettingsFile, writeProjectSettingsFile } from './project-settings-files'
@@ -261,8 +261,16 @@ export class WorkspaceStore {
       if (e.project) {
         // Inline projects are stored verbatim in the index (no fileToProject pass), so apply the
         // same kanban shape guard here — a v1/hand-edited board would otherwise crash the render.
+        // Likewise lift legacy bridges/ropes into `links` (migrateLinks) the way fileToProject does
+        // for ref'd projects, so an inline canvas written by a pre-`Link` build still loads edges.
         const { kanban, ...rest } = e.project
-        built.push({ entry: e, project: validKanban(kanban) ? e.project : rest })
+        const kanbanOk = validKanban(kanban)
+        const links = migrateLinks(e.project)
+        const base = kanbanOk ? e.project : rest
+        built.push({
+          entry: e,
+          project: links ? { ...base, links } : base
+        })
       } else if (e.cwd) {
         if (sideline) await sweepStaleTmp(projectFilePath(e.cwd))
         const read = await this.readProjectFile(e.cwd, sideline)
@@ -1112,13 +1120,13 @@ export class WorkspaceStore {
    * project.json, so a project whose file has never been read this run is simply absent (it
    * appears after the next load/save, which is also what re-derives the map).
    */
-  persistedCanvases(): Array<{ id: string; nodes: CanvasNodeState[]; bridges?: BridgeLink[] }> {
-    const out: Array<{ id: string; nodes: CanvasNodeState[]; bridges?: BridgeLink[] }> = []
+  persistedCanvases(): Array<{ id: string; nodes: CanvasNodeState[]; links?: Link[] }> {
+    const out: Array<{ id: string; nodes: CanvasNodeState[]; links?: Link[] }> = []
     for (const e of this.index?.entries ?? []) {
       if (e.project) {
-        out.push({ id: e.project.id, nodes: e.project.nodes, bridges: e.project.bridges })
+        out.push({ id: e.project.id, nodes: e.project.nodes, links: e.project.links })
       } else if (e.cache) {
-        out.push({ id: e.id, nodes: e.cache.nodes, bridges: e.cache.bridges })
+        out.push({ id: e.id, nodes: e.cache.nodes, links: migrateLinks(e.cache) })
       } else if (e.cwd) {
         const raw = this.lastWritten.get(projectFilePath(e.cwd))
         if (!raw) continue
@@ -1128,7 +1136,7 @@ export class WorkspaceStore {
           // a caller sees the same absolute paths the desktop's renderer would have handed it.
           // Keyed by the ENTRY id — the map's consumers look projects up by the id the renderer
           // knows, which is never the git-shared file's (it no longer has one).
-          out.push({ id: e.id, nodes: resolveNodes(f.nodes, e.cwd), bridges: f.bridges })
+          out.push({ id: e.id, nodes: resolveNodes(f.nodes, e.cwd), links: migrateLinks(f) })
         } catch {
           // Corrupt cached content: skip this entry, keep scanning the others.
         }

--- a/src/main/browser-ownership-source.test.ts
+++ b/src/main/browser-ownership-source.test.ts
@@ -6,8 +6,8 @@ import { projectToFile, fileToProject, serializeProjectFile } from '../core/work
 import type { Project } from '@shared/types'
 
 // Ownership of an agent-opened browser node is decided ONLY by the in-memory ledger a `verified`
-// open-browser filled THIS app run. It is NEVER read from `Project.ropes`, which is documented
-// display-only but IS persisted and git-shared — so a cloned project.json can ship the exact lineage
+// open-browser filled THIS app run. It is NEVER read from `Project.links`, whose `lineage` entries
+// are display-only but ARE persisted and git-shared — so a cloned project.json can ship the exact lineage
 // (`claude-1 -> browser-1`) an ownership check that trusted ropes would grant on.
 
 function projectWithHostileRope(): Project {
@@ -21,16 +21,22 @@ function projectWithHostileRope(): Project {
       { id: 'claude-1', kind: 'terminal', title: 'A', position: { x: 0, y: 0 }, agentId: 'claude' },
       { id: 'browser-1', kind: 'browser', title: 'B', position: { x: 0, y: 300 }, url: 'https://x.test/' }
     ] as unknown as Project['nodes'],
-    // The attack: a pre-declared rope that says claude-1 opened browser-1.
-    ropes: [{ id: 'r1', source: 'claude-1', target: 'browser-1' }]
+    // The attack: a pre-declared lineage link that says claude-1 opened browser-1.
+    links: [{
+      id: 'r1',
+      kind: 'lineage',
+      source: { ref: 'node', nodeId: 'claude-1' },
+      target: { ref: 'node', nodeId: 'browser-1' },
+      meta: { displayOnly: true }
+    }]
   } as Project
 }
 
-describe('ownership is never read out of Project.ropes — behavioural', () => {
+describe('ownership is never read out of Project.links — behavioural', () => {
   it('a pre-declared rope grants nothing on a freshly loaded project (empty ledger)', () => {
     const project = projectWithHostileRope()
     // The rope really is present — this is a genuine, persisted attack input, not a strawman.
-    expect(project.ropes).toEqual([{ id: 'r1', source: 'claude-1', target: 'browser-1' }])
+    expect(project.links).toHaveLength(1)
 
     // The ledger every run starts empty; nothing claimed browser-1 this run.
     const ledger = new BrowserControlLedger()
@@ -47,7 +53,7 @@ describe('ownership is never read out of Project.ropes — behavioural', () => {
     const reparsed = JSON.parse(serializeProjectFile(file))
     const reloaded = fileToProject(reparsed, { id: project.id, cwd: project.cwd })
 
-    expect(reloaded.ropes).toEqual([{ id: 'r1', source: 'claude-1', target: 'browser-1' }])
+    expect(reloaded.links).toEqual(project.links)
 
     const ledger = new BrowserControlLedger()
     expect(ledger.get('browser-1', 'claude-1')).toBe(null)
@@ -73,10 +79,10 @@ describe('ownership is never read out of Project.ropes — behavioural', () => {
  * "the rope already says who opened it" is a genuinely tempting one-liner. Same enforcement style
  * as hook-verified-parity.test.ts.
  */
-describe('ownership is never read out of Project.ropes — structural', () => {
+describe('ownership is never read out of Project.links — structural', () => {
   const root = path.resolve(__dirname, '..', '..')
 
-  /** Strip block + line comments only (NOT string literals — `project['ropes']` is a real read and
+  /** Strip block + line comments only (NOT string literals — `project['links']` is a real read and
    *  must still trip the check). The ledger's own doc comment explains why ropes is refused; that
    *  explanation lives in a comment and is correctly removed here. */
   function stripComments(src: string): string {
@@ -110,9 +116,9 @@ describe('ownership is never read out of Project.ropes — structural', () => {
     return out
   }
 
-  it('no ownership-surface source references the identifier `ropes`', () => {
+  it('no ownership-surface source reads a persisted `links` field', () => {
     for (const { name, code } of browserSurfaceSources()) {
-      expect(/\bropes\b/.test(stripComments(code)), `${name} must not read ropes`).toBe(false)
+      expect(/(?:\.links\b|\[['"]links['"]\])/.test(stripComments(code)), `${name} must not read links`).toBe(false)
     }
   })
 })

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -136,6 +136,28 @@ describe('parseControlRequest', () => {
     expect(isDestructiveVerb('close-worktree')).toBe(false)
   })
 
+  it('link-branches and sync-stack require their branch arguments; neither is confirm-gated here', () => {
+    expect(parseControlRequest('link-branches', {})).toEqual({
+      error: 'link-branches requires --base <parent branch>'
+    })
+    expect(parseControlRequest('link-branches', { base: 'feat-a' })).toEqual({
+      error: 'link-branches requires --branch <child branch>'
+    })
+    expect(parseControlRequest('link-branches', { base: 'feat-a', branch: 'feat-b' })).toEqual({
+      verb: 'link-branches',
+      args: { base: 'feat-a', branch: 'feat-b' }
+    })
+    expect(parseControlRequest('sync-stack', {})).toEqual({
+      error: 'sync-stack requires --branch <child branch>'
+    })
+    expect(parseControlRequest('sync-stack', { branch: 'feat-b' })).toEqual({
+      verb: 'sync-stack',
+      args: { branch: 'feat-b' }
+    })
+    expect(isDestructiveVerb('link-branches')).toBe(false)
+    expect(isDestructiveVerb('sync-stack')).toBe(false)
+  })
+
   it('branch requires --node, and is not destructive', () => {
     expect(parseControlRequest('branch', {})).toEqual({ error: 'branch requires --node <id>' })
     expect(parseControlRequest('branch', { node: 'n1' })).toEqual({
@@ -262,6 +284,29 @@ describe('parseControlRequest', () => {
     for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
       expect(body).toContain('`sticky --node')
       expect(body).toContain('--create')
+    }
+  })
+
+  it('both agent-facing texts document the --project flag on open-agent/open-claude (ticket 05)', () => {
+    for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
+      // --project opens the session in a DIFFERENT project the caller has already opened (review
+      // #363 superseded the earlier "projection" model: a returned id cold-opens in the other
+      // project — the session starts when the user next views it — and never switches the user's
+      // view; the caller's OWN id behaves as if the flag were omitted). The skill must tell agents
+      // the node lives in the OTHER project (owns the session) and that an unknown --project is
+      // refused, not a silent local fallback — the requireRemote precedent. An orchestrating agent
+      // that reads "unknown = local" would open in the wrong repo. `--project` rides on a
+      // continuation line under the open verbs (not the verb line itself), so the assertion checks
+      // the flag + its key facts, not a same-line regex.
+      expect(body).toContain('--project')
+      expect(body).toContain('`--project <id>`')
+      expect(body).toContain('any other id is refused')
+      // The cold-open model replaced the projection model; the old word must be gone.
+      expect(body.toLowerCase()).not.toContain('projection')
+      expect(body.toLowerCase()).toContain('refused')
+      // The open verbs themselves must still be documented (the flag hangs off them).
+      expect(body).toMatch(/open-agent/)
+      expect(body).toMatch(/open-claude/)
     }
   })
 
@@ -493,8 +538,7 @@ describe('open-project + --project docs land with the dispatch (issue #338, spec
     for (const [name, body] of bodies) {
       expect(body, name).toContain('one project per repository')
       expect(body, name).toContain('open-project --cwd <repo>')
-      // v1 has no cross-project links; the workaround is named.
-      expect(body, name).toMatch(/reader agent inside that project/)
+      expect(body, name).toMatch(/context link between sessions in different\s+projects/)
     }
   })
 })

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -109,6 +109,8 @@ export type ControlVerb =
   | 'spawn-team'
   | 'open-worktree'
   | 'close-worktree'
+  | 'link-branches'
+  | 'sync-stack'
   | 'branch'
   | 'rename'
   | 'write'
@@ -146,6 +148,8 @@ const VERBS: ControlVerb[] = [
   'spawn-team',
   'open-worktree',
   'close-worktree',
+  'link-branches',
+  'sync-stack',
   'branch',
   'rename',
   'write',
@@ -211,6 +215,9 @@ export function parseControlRequest(
   if (v === 'assign' && !args.node) return { error: 'assign requires --node <id>' }
   if (v === 'open-worktree' && !args.branch) return { error: 'open-worktree requires --branch <name>' }
   if (v === 'close-worktree' && !args.group) return { error: 'close-worktree requires --group <id>' }
+  if (v === 'link-branches' && !args.base) return { error: 'link-branches requires --base <parent branch>' }
+  if (v === 'link-branches' && !args.branch) return { error: 'link-branches requires --branch <child branch>' }
+  if (v === 'sync-stack' && !args.branch) return { error: 'sync-stack requires --branch <child branch>' }
   if (v === 'branch' && !args.node) return { error: 'branch requires --node <id>' }
   if (v === 'rename' && !args.node) return { error: 'rename requires --node <id>' }
   if (v === 'rename' && !args.title) return { error: 'rename requires --title' }
@@ -292,12 +299,18 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  start until every listed station has gone idle, and is context-linked to them so it can read',
     '  their work when it wakes — use it for "B needs what A produced" instead of polling. Only',
     `  status-reporting agent nodes (${statusAgents}, or custom agents based on them) may be waited on; a plain terminal never`,
-    '  reports finishing, so waiting on one is refused. `--project <id>` opens the node(s) in another',
-    '  project instead of yours. It accepts exactly two things — any other id is refused: your OWN',
-    '  project id, which behaves exactly as if the flag were omitted (a normal open, view switch',
-    '  included); or an id `open-project` returned to YOU in this session, which never switches the',
-    '  user\'s view. A session opened into a non-active project starts when the user next views that',
-    '  project — do not poll for it. `--group`/`--after` cannot be combined with `--project`.',
+    '  reports finishing, so waiting on one is refused.',
+    '  `--project <id>` opens the session in a DIFFERENT project you have already opened, named by',
+    '  its folder path or its project id. Passing YOUR OWN project\'s id behaves exactly as if the flag',
+    '  were omitted — the node lands on your active canvas, view switch included. Passing an id',
+    '  returned to YOU in this session, which never switches the user\'s view: the node is created',
+    '  in that other project (it owns the tmux session, runs in that project\'s cwd, inherits its',
+    '  account + permission-mode defaults), and a session opened into a non-active project',
+    '  starts when the user next views that project — do not poll for it. Resolve `<id>` to a project',
+    '  you have already opened; an unknown value is refused rather than silently opening locally, and',
+    '  any other id is refused. Prefer `--project` when the work belongs in another repo\'s canvas,',
+    '  not yours. `--group`/`--after` cannot be combined with `--project` (both name ids that live',
+    '  inside one project).',
     '- `open-project --cwd </abs/path> [--name N] [--color C]` — register (or find) the project for a',
     '  local directory; the reply carries `{ projectId, name, cwd, created }`. Idempotent: the same',
     '  cwd always returns the same project, never a duplicate. Creating/adding asks the user to',
@@ -330,6 +343,14 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  wrapped in a bound group frame (terminals inside it run in the worktree). Local projects only.',
     '- `close-worktree --group <id> [--mode unbind|remove]` — unbind keeps the directory; remove asks',
     '  the user to confirm deletion.',
+    '- `link-branches --base <parent> --branch <child>` — declare a stacked-diff dependency: the child',
+    '  branch builds on the parent. Writes the lineage to the shared git config (the git-town',
+    '  `git-town-branch.<child>.parent` convention) AND records a `dependency` link that renders as a',
+    '  dashed edge between the two worktree group frames. Local projects only. Declare it once per',
+    '  pair; the sync below uses it.',
+    '- `sync-stack --branch <child>` — rebase a child branch onto its parent (`git rebase <parent>`),',
+    '  run in the child\'s own worktree. If the rebase stops on a conflict, the reply says so and the user resolves it',
+    '  in that terminal (`git rebase --continue`). No external tool: this is plain git.',
     '- `branch --node <id>` — branch a Claude node\'s conversation (Claude nodes only).',
     '- `rename --node <id> --title "New Name"` — rename any node (terminals, groups, stickies…).',
     '- `write --node <id> --text "..."` / `close --node <id>` — type into / close a node.',
@@ -368,8 +389,8 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     'downstream one with `--after <upstream-id>` and it starts itself when the upstream goes',
     'idle (do not poll for that yourself). Then break the task into 2-5 workstreams;',
     'per stream `open-worktree --branch <slug>` then `open-agent --agent claude --group <groupId>',
-    '--prompt "<concrete task>"` (each stream on its own branch, no tree conflicts). Members land',
-    'in grid slots inside the frame automatically; align the frames themselves with',
+    '--prompt "<concrete task>"` (each stream on its own branch, no tree conflicts).',
+    'Members land in grid slots inside the frame automatically; align the frames themselves with',
     '`arrange --nodes <groupId,…> --layout row` (pass sibling GROUP ids from one container)',
     'and `rename` each by subject. When a station goes idle, READ what it did through the',
     'context link (the linked-context CLI — see the get-linked-context section in your global',
@@ -380,8 +401,8 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     'Multi-repo orchestration: one project per repository — `open-project --cwd <repo>` (the user',
     'confirms once), then `open-agent --agent claude --project <returned id> --prompt "…"` per repo,',
     'one repo at a time. Sessions in a non-active project start when the user views that project —',
-    'do not poll for them. v1 has no cross-project links: read a repo\'s results by opening a',
-    'reader agent inside that project and linking within it.'
+    'do not poll for them. Use the link picker to create a context link between sessions in different',
+    'projects; linked agents can then read each other through get-linked-context on demand.'
   ].join('\n')
 }
 
@@ -559,13 +580,16 @@ Verbs:
   plain terminal never reports finishing and the node would hang forever. Note the semantics:
   "idle" is the end of a station's TURN, not proof its whole job is done — right for a station
   given one self-contained prompt, wrong if you expect a long conversation first.
-  \`--project <id>\` opens the node(s) in another project instead of yours. It accepts exactly
-  two things — any other id is refused: your OWN project id, which behaves exactly as if the flag
-  were omitted (a normal open, view switch included); or an id \`open-project\` returned to YOU
-  in this session, which never switches the user's view. Defaults inside the target are the
-  TARGET project's (its cwd, its default account and permission mode). A session opened into a
-  non-active project starts when the user next views that project — do not poll for it; the reply
-  says so. \`--group\`/\`--after\` cannot be combined with \`--project\`.
+  \`--project <id>\` opens the session in a DIFFERENT project you have already opened, named by its
+  folder path or its project id. Passing YOUR OWN project's id behaves exactly as if the flag
+  were omitted — the node lands on your active canvas, view switch included. Passing an id
+  returned to YOU in this session, which never switches the user's view: the node is created
+  in that other project (it owns the tmux session, runs in that project's cwd, inherits its
+  account + permission-mode defaults), and a session opened into a non-active project starts when
+  the user next views that project — do not poll for it. Resolve \`<id>\` to a project you
+  have already opened; an unknown value is refused rather than silently opening locally, and
+  any other id is refused. Use this when the work belongs in another repo's canvas, not yours.
+  \`--group\`/\`--after\` cannot be combined with \`--project\` (both name ids that live inside one project).
 - \`open-project --cwd </abs/path> [--name N] [--color C]\` — register (or find) the project for a
   local directory; the reply carries \`{ projectId, name, cwd, created }\`. Idempotent: the same
   cwd always returns the same project, never a duplicate — and \`--name\`/\`--color\` apply only
@@ -620,6 +644,17 @@ Verbs:
   run in the worktree. Local projects only.
 - \`close-worktree --group <id> [--mode unbind|remove]\` — unbind (default) drops the binding
   and keeps the directory; remove asks the user to confirm deleting the worktree.
+- \`link-branches --base <parent> --branch <child>\` — declare a stacked-diff dependency: the
+  child branch is built on top of the parent. This writes the lineage to the shared git config
+  (the git-town \`git-town-branch.<child>.parent\` convention — readable by git-town if the user
+  has it, no binary required) AND records a \`dependency\` link that shows as a dashed edge
+  between the two worktree group frames. Local projects only. Declare it once per pair; it is
+  what \`sync-stack\` reads to know the parent.
+- \`sync-stack --branch <child>\` — rebase the child branch onto its parent (\`git rebase
+  <parent>\`), run in the child's own worktree (where the child is checked out). If the rebase
+  stops on a conflict, the reply says so and tells the user to resolve in that terminal and run
+  \`git rebase --continue\` (or \`--abort\`) — we do not hide a conflicted state as success, and
+  we do not auto-abort a partial resolution. Plain git, no external tool.
 - \`branch --node <id>\` — branch a Claude node's conversation: the node stays on the new
   branch and a new node opens resuming the original. Target must be a Claude agent node.
 - \`rename --node <id> --title "New Name"\` — rename any node (terminals, groups, stickies…).
@@ -731,8 +766,7 @@ piling every session onto your canvas: \`open-project --cwd <repo>\` (the user c
 idempotent thereafter), then \`open-agent --agent claude --project <returned id> --prompt
 "<task>"\` — one repo at a time. With a RETURNED id neither verb moves the user's view, and a
 session opened into a non-active project starts when the user next views that project — do not
-poll for it. v1 has no
-cross-project links: read a repo's results by opening a reader agent inside that project and
-linking within it.
+poll for it. Use the link picker to create a context link between sessions in different projects;
+linked agents can then read each other through get-linked-context on demand.
 `
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -338,12 +338,21 @@ const api: NodeTerminalApi = {
     checkoutCommit: (cwd, oid) => ipcRenderer.invoke(IPC.gitCheckoutCommit, cwd, oid),
     repoRoot: (cwd) => ipcRenderer.invoke(IPC.gitRepoRoot, cwd),
     worktreeList: (repoPath) => ipcRenderer.invoke(IPC.gitWorktreeList, repoPath),
+    submoduleList: (repoPath) => ipcRenderer.invoke(IPC.gitSubmoduleList, repoPath),
     worktreeAdd: (repoPath, wtPath, branch, baseRef, isNew) =>
       ipcRenderer.invoke(IPC.gitWorktreeAdd, repoPath, wtPath, branch, baseRef, isNew),
     worktreeMerge: (repoPath, branch, baseRef, push) =>
       ipcRenderer.invoke(IPC.gitWorktreeMerge, repoPath, branch, baseRef, push),
     worktreeRemove: (repoPath, wtPath, deleteBranch, pruneOnly) =>
       ipcRenderer.invoke(IPC.gitWorktreeRemove, repoPath, wtPath, deleteBranch, pruneOnly),
+    setBranchParent: (repoPath, child, parent) =>
+      ipcRenderer.invoke(IPC.gitSetBranchParent, repoPath, child, parent),
+    unsetBranchParent: (repoPath, child) =>
+      ipcRenderer.invoke(IPC.gitUnsetBranchParent, repoPath, child),
+    syncBranch: (cwd, child) => ipcRenderer.invoke(IPC.gitSyncBranch, cwd, child),
+    proposeBranch: (cwd, child) => ipcRenderer.invoke(IPC.gitProposeBranch, cwd, child),
+    shipBranch: (cwd, child, parent) =>
+      ipcRenderer.invoke(IPC.gitShipBranch, cwd, child, parent),
     setActiveRemote: (projectId) => ipcRenderer.invoke(IPC.gitSetActiveRemote, projectId)
   },
   clipboard: {

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -525,6 +525,8 @@ export function buildFilesApi(
     repoRoot: (cwd) => client.request(IPC.gitRepoRoot, cwd) as Promise<string | null>,
     worktreeList: (repoPath) =>
       client.request(IPC.gitWorktreeList, repoPath) as ReturnType<GitApi['worktreeList']>,
+    submoduleList: (repoPath) =>
+      client.request(IPC.gitSubmoduleList, repoPath) as ReturnType<GitApi['submoduleList']>,
     worktreeAdd: (repoPath, wtPath, branch, baseRef, isNew) =>
       client.request(
         IPC.gitWorktreeAdd,
@@ -550,6 +552,16 @@ export function buildFilesApi(
         deleteBranch,
         pruneOnly
       ) as ReturnType<GitApi['worktreeRemove']>,
+    setBranchParent: (repoPath, child, parent) =>
+      client.request(IPC.gitSetBranchParent, repoPath, child, parent) as ReturnType<GitApi['setBranchParent']>,
+    unsetBranchParent: (repoPath, child) =>
+      client.request(IPC.gitUnsetBranchParent, repoPath, child) as ReturnType<GitApi['unsetBranchParent']>,
+    syncBranch: (cwd, child) =>
+      client.request(IPC.gitSyncBranch, cwd, child) as ReturnType<GitApi['syncBranch']>,
+    proposeBranch: (cwd, child) =>
+      client.request(IPC.gitProposeBranch, cwd, child) as ReturnType<GitApi['proposeBranch']>,
+    shipBranch: (cwd, child, parent) =>
+      client.request(IPC.gitShipBranch, cwd, child, parent) as ReturnType<GitApi['shipBranch']>,
     setActiveRemote: (projectId) =>
       client.request(IPC.gitSetActiveRemote, projectId) as Promise<void>
   }

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -12,6 +12,7 @@ import {
   MiniMap,
   ReactFlow,
   SelectionMode,
+  ViewportPortal,
   useEdgesState,
   useNodesState,
   useReactFlow,
@@ -69,7 +70,8 @@ import {
   WEBGL_GESTURE_SETTLE_MS
 } from '../terminal/webgl-budget'
 import { StickyNode } from '../nodes/StickyNode'
-import { GroupNode, setWorktreeActionHandler } from '../nodes/GroupNode'
+import { GroupNode, setWorktreeActionHandler, setDrillHandler } from '../nodes/GroupNode'
+import { setTravelNodeHandler } from '../nodes/travel-handler'
 import { LazyEditorNode, LazyDiffNode } from '../nodes/lazyMonacoNodes'
 import { DinoNode } from '../nodes/DinoNode'
 import BrowserNode from '../nodes/BrowserNode'
@@ -110,7 +112,8 @@ import {
   IconTerminal,
   IconTrash,
   IconUngroup,
-  IconUnlock
+  IconUnlock,
+  IconLink
 } from '../components/icons'
 import type { SettingsSectionId } from '../components/settings/nav'
 import { projectSectionId } from '../components/settings/project-settings-targets'
@@ -152,6 +155,7 @@ import { viewportAtZoom1 } from '../lib/zoomReset'
 import { isSpaceRelease, spacePanKeydown } from '../lib/spacePan'
 import { UpdateCard } from '../components/UpdateCard'
 import { AnnouncementBanner } from '../components/AnnouncementBanner'
+import { DrillBreadcrumb } from '../components/DrillBreadcrumb'
 import { TmuxBanner } from '../components/TmuxBanner'
 import { PtyPressureBanner } from '../components/PtyPressureBanner'
 import { ShortcutCaptureBanner } from '../components/ShortcutCaptureBanner'
@@ -166,6 +170,9 @@ import { UpgradeDialog } from '../components/UpgradeDialog'
 import { RemotePicker } from '../components/RemotePicker'
 import { WorktreeDialog } from '../components/WorktreeDialog'
 import { SpawnTeamDialog } from '../components/SpawnTeamDialog'
+import { LinkTargetPicker } from '../components/links/LinkTargetPicker'
+import { LinkInspectorPanel } from '../components/links/LinkInspectorPanel'
+import { setLinkCommitHandler } from '../components/links/link-commit'
 import { conductorPrompt } from '../lib/spawnTeamPrompt'
 import { NotifyConsentDialog } from '../components/NotifyConsentDialog'
 import { SessionsSidebar } from '../components/SessionsSidebar'
@@ -275,6 +282,7 @@ import { useTeamAccessEvents } from '../state/teamAccess'
 import { useAgentNodes } from '../state/agentNodes'
 import { SubagentNode } from '../nodes/SubagentNode'
 import { LoopNode } from '../nodes/LoopNode'
+import { XProjectNode } from '../nodes/XProjectNode'
 import type { NormalizedAgentEvent } from '@shared/agents/normalize'
 import {
   computeWorktreePath,
@@ -342,8 +350,10 @@ import {
   reconnectRelayTab,
   type RelayTab,
 } from '../session/relay-tab'
-import { buildBackgroundLinkMaps, buildContextLinkNote, buildLinkMap, buildNotePushMessage, classifyLink, hiddenLinkIds, linkIdsCoveredByRopes, pairKey, planBridges, type LinkEndpoint } from '../lib/noteLink'
+import { buildBackgroundLinkMaps, buildContextLinkNote, buildLinkMap, buildNotePushMessage, classifyLink, contextLink, dependencyLink, hiddenLinkIds, lineageLink, linkIdsCoveredByRopes, mergeContextLinkMaps, nodeEndpoints, pairKey, planBridges, type LinkEndpoint } from '../lib/noteLink'
+import { offCanvasLinkColor, applyDependencyLink, newLinkId, depHostEdges, isCrossProjectDependencyLink } from '../lib/link-authoring'
 import { dependencyEdges, launchesToFire, unmetDeps, type ArmedNode } from '../lib/pendingLaunch'
+import { existingDependencyLinkKeys, planSubmoduleLinks, type SubmoduleProjectSuggestion } from '../lib/submoduleLink'
 import { freeSpot } from '../lib/placement'
 import { pushSessionRename } from '../lib/sessionRename'
 import { oneLine } from '@shared/one-line'
@@ -360,6 +370,8 @@ import type { SshServer } from '@shared/ssh'
 import { sshHostKey } from '@shared/ssh'
 import type {
   CanvasNodeState,
+  Endpoint,
+  Link,
   NodeKind,
   Project,
   ProjectKanban,
@@ -433,7 +445,10 @@ import {
   accountsForProject,
   sshAccountsHint,
   ungroupNodes,
-  type CanvasNode
+  type CanvasNode,
+  type DrillContext,
+  drillGroupChildren,
+  remergeDrilledNodes
 } from '../state/workspace'
 import { codexAccountSelectable, codexAccountSwitchStillEligible } from './codex-account-switch'
 import { resolveNewCodexNodeAccount, planCodexAccountSwitch } from './codex-account-ops'
@@ -613,6 +628,142 @@ const ropeEdge = (id: string, source: string, target: string, color: string): Ed
   markerEnd: { type: MarkerType.ArrowClosed, color, width: 14, height: 14 }
 })
 
+/** A persisted `kind:'dependency'` node↔node link rendered as an on-canvas edge — amber, dashed,
+ *  directional (child → parent). The meta-canvas submodule auto-link (ticket 09) draws these
+ *  between two `projectRef` group frames. Mirrors `ropeEdge`'s shape (flow handles, arrowhead). */
+const DEP_EDGE_COLOR = '#f59e0b'
+const depEdge = (id: string, source: string, target: string): Edge => ({
+  id,
+  source,
+  sourceHandle: 'link-out',
+  target,
+  targetHandle: 'link-in',
+  type: 'default',
+  label: 'dep',
+  labelStyle: { fill: DEP_EDGE_COLOR, fontSize: 11, fontWeight: 600 },
+  labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
+  labelBgPadding: [6, 3] as [number, number],
+  labelBgBorderRadius: 5,
+  style: { stroke: DEP_EDGE_COLOR, strokeWidth: 1.5, strokeDasharray: '5 4' },
+  markerEnd: { type: MarkerType.ArrowClosed, color: DEP_EDGE_COLOR, width: 14, height: 14 }
+})
+
+/**
+ * Split the persisted `Link[]` into the three runtime edge arrays the canvas holds:
+ *  - `context` node↔node links → `linkEdges` (context + note links, the read-back substrate).
+ *  - `lineage` node↔node links → `controlEdges` (display-only ropes), colored by the source
+ *    agent's config color (falls back to the browser blue), exactly as the old `project.ropes`
+ *    restore did.
+ * `dependency`/`xnode`/`branch` links have no on-canvas node pair and are dropped here (they are
+ * not authored on-canvas yet — ticket 06) — the same lazy-prune the old endpoint-validity filter did.
+ */
+function linksToRuntime(
+  links: readonly Link[] | undefined,
+  agentColorOf: (agentId: string) => string,
+  nodeAgentOf: (nodeId: string) => string | undefined
+): { context: Edge[]; lineage: Edge[]; dependency: Edge[] } {
+  const context: Edge[] = []
+  const lineage: Edge[] = []
+  const dependency: Edge[] = []
+  for (const l of links ?? []) {
+    const pair = nodeEndpoints(l)
+    if (!pair) continue // xnode/branch — no on-canvas node pair
+    if (l.kind === 'context') {
+      context.push({ id: pair.id, source: pair.source, target: pair.target, type: 'default' })
+    } else if (l.kind === 'lineage') {
+      const color = agentColorOf(nodeAgentOf(pair.source) ?? '') ?? '#0a84ff'
+      lineage.push(ropeEdge(pair.id, pair.source, pair.target, color))
+    } else if (l.kind === 'dependency') {
+      // A same-project node↔node dependency (the meta-canvas submodule auto-link, 09) is a real
+      // on-canvas edge. Cross-project/branch dependency links have a non-`node` endpoint and were
+      // already skipped by `nodeEndpoints` above — they stay off-canvas (inspector/xlink), untouched.
+      dependency.push(depEdge(pair.id, pair.source, pair.target))
+    }
+  }
+  return { context, lineage, dependency }
+}
+
+/** Merge the two runtime edge arrays back into the persisted `Link[]`. Context edges become
+ *  `kind:'context'` (a sticky→terminal note link is already `context` — its text lives on the
+ *  sticky node, not the link); lineage ropes become `kind:'lineage'` with `meta.displayOnly`;
+ * dependency edges become `kind:'dependency'` (the meta-canvas auto-link, 09). */
+function runtimeToLinks(
+  context: readonly Edge[],
+  lineage: readonly Edge[],
+  dependency: readonly Edge[]
+): Link[] | undefined {
+  const out: Link[] = []
+  for (const e of context) {
+    if (e.source && e.target) out.push(contextLink(e.source, e.target))
+  }
+  for (const e of lineage) {
+    if (e.source && e.target) out.push(lineageLink(e.source, e.target))
+  }
+  for (const e of dependency) {
+    if (e.source && e.target) out.push(dependencyLink(e.source, e.target))
+  }
+  return out.length ? out : undefined
+}
+
+/**
+ * Compose the persisted `Link[]` from BOTH the on-canvas runtime edge arrays (the
+ * `runtimeToLinks` projection — all node↔node `context`/`lineage`/`dependency`) AND the off-canvas
+ * links the projection cannot represent (`xnode`/`branch` and any link with a non-node endpoint).
+ * The two sets are disjoint by construction: every on-canvas edge is a node↔node pair, every
+ * off-canvas link is not, so no dedup is needed. This is what makes the load → commit round-trip
+ * LOSSLESS for off-canvas links — `runtimeToLinks` alone rebuilds a `Link[]` from only the runtime
+ * arrays and silently drops everything in `offCanvas`.
+ */
+function mergeLinks(
+  context: readonly Edge[],
+  lineage: readonly Edge[],
+  dependency: readonly Edge[],
+  offCanvas: readonly Link[]
+): Link[] | undefined {
+  const onCanvas = runtimeToLinks(context, lineage, dependency) ?? []
+  const out = offCanvas.length ? [...onCanvas, ...offCanvas] : onCanvas
+  return out.length ? out : undefined
+}
+
+/** Stable string key for an `Endpoint` — used by `linkSig` to hash the active project's links into
+ *  a primitive so `displayEdges` re-derives `xlink-` edges only when the off-canvas set changes. */
+function epKey(ep: Endpoint): string {
+  if (ep.ref === 'node') return `n:${ep.nodeId}`
+  if (ep.ref === 'xnode') return `x:${ep.projectId}:${ep.nodeId}`
+  return `b:${ep.repoPath}:${ep.branch}`
+}
+
+/** FNV-ish string hash → int32. Used only to fold link signatures into one reactive primitive. */
+function hashStr(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0
+  return h
+}
+
+/** The on-canvas node id a derived `xlink-` edge dangles from — the `node` endpoint that resolves
+ *  to a live node on the active canvas. Returns '' if neither side is a live node (the caller's
+ *  filter already guarantees one is, but TS can't track that across `.filter`). */
+function liveNodeOf(l: Link, liveIds: Set<string>): string {
+  if (l.source.ref === 'node' && liveIds.has(l.source.nodeId)) return l.source.nodeId
+  if (l.target.ref === 'node' && liveIds.has(l.target.nodeId)) return l.target.nodeId
+  return ''
+}
+
+/** Short label for a derived `xlink-` edge — names the OFF-canvas side (the on-canvas side is the
+ *  node the edge dangles from). A branch → "repo · branch"; an xnode → "Project · node" (resolved
+ *  from the projects store by the caller is overkill for a label — the branch/tag is the signal). */
+function xlinkLabel(l: Link): string {
+  const off =
+    l.source.ref !== 'node' ? l.source : l.target.ref !== 'node' ? l.target : null
+  if (!off) return l.kind === 'dependency' ? 'depends on' : l.kind === 'lineage' ? 'spawned by' : 'linked'
+  if (off.ref === 'branch') {
+    const repo = off.repoPath.split('/').filter(Boolean).pop() ?? off.repoPath
+    return `${repo} · ${off.branch}`
+  }
+  if (off.ref === 'xnode') return `→ ${off.projectId.slice(0, 6)}`
+  return l.kind
+}
+
 
 const minimapNodeColor = (n: Node): string =>
   (n.data as { color?: string })?.color ?? '#0a84ff'
@@ -741,6 +892,25 @@ export function Canvas() {
   const [controlEdges, setControlEdges] = useState<Edge[]>([])
   const controlEdgesRef = useRef<Edge[]>([])
   controlEdgesRef.current = controlEdges
+  // Same-project `node`↔`node` `dependency` links rendered as a visible amber dashed edge (the
+  // meta-canvas submodule auto-link, ticket 09). Parallel to `linkEdges` (context) / `controlEdges`
+  // (lineage): `linksToRuntime` emits these, `runtimeToLinks` round-trips them, `mergeLinks` folds
+  // them back into `Project.links`. Named `depLinkEdges` (NOT `depEdges`/`dependencyEdges` — those
+  // are the pending-launch `--after` edges from `lib/pendingLaunch`, a different concept). Off-canvas
+  // `dependency` links (xnode/branch endpoints) have `nodeEndpoints===null` so they land in
+  // `offCanvasLinksRef` and are never drawn — this array holds only the on-canvas node↔node ones.
+  const [depLinkEdges, setDepLinkEdges] = useState<Edge[]>([])
+  const depLinkEdgesRef = useRef<Edge[]>([])
+  depLinkEdgesRef.current = depLinkEdges
+  // Off-canvas links for the active project: those whose endpoints are NOT both `ref:'node'`
+  // (xnode cross-project, branch cross-repo, and `dependency`/`lineage` over non-node pairs) —
+  // i.e. exactly the links `linksToRuntime` DROPS (nodeEndpoints returns null) and so cannot
+  // survive the load → commit round-trip on their own. `runtimeToLinks` rebuilds a `Link[]` from
+  // only the two runtime edge arrays (all node↔node), so without this ref an off-canvas link
+  // written to Project.links is destroyed on the next autosave. Populate on load (the same
+  // `linksToRuntime` call site); `mergeLinks` folds it back in at commit. These links are
+  // disjoint from the on-canvas set by construction, so no dedup is needed.
+  const offCanvasLinksRef = useRef<Link[]>([])
   const [dirty, setDirty] = useState(false)
   // Bumped only when a save finished with `dirty` still set (an edit raced it). It exists purely to
   // give the debounced-autosave effect a dependency that CHANGES in that case — `dirty` stays true
@@ -1000,6 +1170,12 @@ export function Canvas() {
   // dialog opens (a branch created in a terminal since the last store refresh should still show), so
   // it is dialog-local state rather than a store fact.
   const [worktreeBranches, setWorktreeBranches] = useState<string[]>([])
+  // Off-canvas link authoring (ticket 06): the node a LinkTargetPicker / LinkInspectorPanel is open
+  // for. `linkPickerNode` opens the picker (author any-kind link off-canvas); `linkInspectorNode`
+  // opens the inspector (list/delete). Both write through `commitLinks`. The node id alone is enough
+  // — its project is resolved from the projects store at open time.
+  const [linkPickerNode, setLinkPickerNode] = useState<string | null>(null)
+  const [linkInspectorNode, setLinkInspectorNode] = useState<string | null>(null)
   // The store is filled asynchronously by the active-project effect, so the dialog subscribes
   // (rather than reading getState() once) — the repo may resolve after it's already open.
   const worktreeRepoRoot = useWorktrees((s) => s.repoRoot)
@@ -1111,6 +1287,28 @@ export function Canvas() {
    * the initial empty `useNodesState([])` can never be committed as some project's canvas.
    */
   const nodesProjectIdRef = useRef<string | null>(null)
+  /**
+   * The transient, in-memory DRILL context (ticket 07 — node-group ↔ canvas isomorphism). When set,
+   * `nodesRef`/React Flow hold the drilled SUBSET (a group's direct children promoted to root-space),
+   * not the project's full canvas. Never persisted: a drill is navigation, not a surface. On any
+   * project switch / reload it is cleared (the load effect owns the node-set). `drillChildIdsRef`
+   * records exactly which node ids constitute the drilled view, so `commitActiveToStore` can merge
+   * their edits back into the full project node array (see remergeDrilledNodes) instead of clobbering
+   * every sibling — the logged hazard.
+   */
+  const drillRef = useRef<DrillContext | null>(null)
+  const drillChildIdsRef = useRef<Set<string>>(new Set())
+  /** The parent canvas's viewport, stashed on drill entry so `exitDrill` can restore it (07). */
+  const preDrillViewportRef = useRef<Viewport | null>(null)
+  /** Bumped to force the load effect to re-run for a drill change (it keys on activeProjectId/reloadNonce). */
+  const [drillNonce, setDrillNonce] = useState(0)
+  // Unopened submodules appear as derived ghost project tiles on a meta-canvas. They never enter
+  // React Flow's node array (and therefore can never leak into project.json). Opening one registers
+  // the folder in the background, then re-runs the auto-linker to promote the ghost to a real
+  // projectRef group at the same location.
+  const [submoduleSuggestions, setSubmoduleSuggestions] = useState<SubmoduleProjectSuggestion[]>([])
+  const submoduleSuggestionsRef = useRef<SubmoduleProjectSuggestion[]>([])
+  const [submoduleRefreshNonce, setSubmoduleRefreshNonce] = useState(0)
   // focusNodeById, for callbacks declared ABOVE its definition (openFile's dedupe focuses the
   // already-open node). Assigned right after the definition, same render-mirror idiom as nodesRef.
   const focusNodeRef = useRef<(nodeId: string) => void>(() => {})
@@ -1231,6 +1429,58 @@ export function Canvas() {
   /** The active project runs on a remote host → every worktree affordance is off (see
    *  WORKTREE_SSH_HINT). Reactive, so the menus rebuild when the user switches projects. */
   const isSshProject = !!activeSshServer
+  // Signature of the active project's off-canvas links (the ones `linksToRuntime` drops and
+  // `offCanvasLinksRef` stashes). A primitive so the `displayEdges` memo re-derives the dashed
+  // `xlink-` edges only when the set actually changes — not on every canvas edit (the full
+  // `Project.links` array is rebuilt on each debounced save). Encodes count + a hash of each
+  // link's id+kind+endpoint refs.
+  const linkSig = useProjects((s) => {
+    const links = s.projects.find((p) => p.id === s.activeProjectId)?.links
+    if (!links?.length) return 0
+    let h = links.length
+    for (const l of links) {
+      h = (h * 31 + hashStr(l.id)) | 0
+      h = (h * 31 + l.kind.charCodeAt(0)) | 0
+      h = (h * 31 + hashStr(epKey(l.source))) | 0
+      h = (h * 31 + hashStr(epKey(l.target))) | 0
+    }
+    return h
+  })
+  // Signature of the active project's cross-project LINEAGE links (kind:'lineage', target
+  // ref:'xnode') — the ones a projection node derives from (ticket 05). A primitive so the
+  // `ephemeralNodes` memo re-derives the `xproj-` nodes only when that set changes, not on every
+  // canvas edit. Encodes count + a hash of each link's id + source node + target (projectId,nodeId).
+  const lineageXnodeSig = useProjects((s) => {
+    const links = s.projects.find((p) => p.id === s.activeProjectId)?.links
+    if (!links?.length) return 0
+    let h = 0
+    for (const l of links) {
+      if (l.kind !== 'lineage' || l.target.ref !== 'xnode') continue
+      h = (h * 31 + hashStr(l.id)) | 0
+      h = (h * 31 + hashStr(epKey(l.source))) | 0
+      h = (h * 31 + hashStr(epKey(l.target))) | 0
+    }
+    return h
+  })
+  // Signature of every NON-active project's nodes — so a projection re-derives when a foreign
+  // project's node list changes (B gains/loses the node a projection points at, or B's node's
+  // title/cwd/agentId fields shift). Reads the whole store but folds to one primitive, so this
+  // never re-renders the canvas per foreign edit — only the `ephemeralNodes` memo, which already
+  // depends on `nodes`. Active project is excluded (its nodes are `nodes` already).
+  const foreignNodesSig = useProjects((s) => {
+    let h = 0
+    for (const p of s.projects) {
+      if (p.id === s.activeProjectId) continue
+      h = (h * 31 + hashStr(p.id)) | 0
+      for (const n of p.nodes) {
+        h = (h * 31 + hashStr(n.id)) | 0
+        h = (h * 31 + hashStr(n.title)) | 0
+        h = (h * 31 + hashStr(n.cwd ?? '')) | 0
+        h = (h * 31 + hashStr(n.agentId ?? '')) | 0
+      }
+    }
+    return h
+  })
   nodesRef.current = nodes
   /**
    * ONE confirm dialog at a time — mirrored into a ref so the []-dep agent-control effect sees the
@@ -1289,6 +1539,7 @@ export function Canvas() {
       diff: withNodeBoundary(LazyDiffNode),
       subagent: withNodeBoundary(SubagentNode),
       loop: withNodeBoundary(LoopNode),
+      xproject: withNodeBoundary(XProjectNode),
       dino: withNodeBoundary(DinoNode),
       video: withNodeBoundary(VideoNode),
       web: withNodeBoundary(WebNode),
@@ -1417,7 +1668,10 @@ export function Canvas() {
     const claudeById = useAgentStatus.getState().byId // re-read on loopSig change (see above)
     const hasLoops = loopSig !== ''
     const hasAgents = Object.keys(agentById).length > 0
-    if (!hasLoops && !hasAgents) return NO_EPHEMERAL
+    // A cross-project lineage link (ticket 05) also derives an ephemeral projection node, so the
+    // guard must let the memo run when one exists even with no loops/subagents.
+    const hasXproj = lineageXnodeSig !== 0
+    if (!hasLoops && !hasAgents && !hasXproj) return NO_EPHEMERAL
     // Explicit width/height for an ephemeral node (so it resizes like any other node).
     // Defaults switch with expand; a user resize override wins.
     const dims = (id: string, baseW: number, expW: number, baseH: number, expH: number) => {
@@ -1530,9 +1784,71 @@ export function Canvas() {
         })
       })
     }
+    // Cross-project PROJECTIONS (ticket 05): one ephemeral `xproject` node per lineage link whose
+    // target is an `xnode` in ANOTHER project. The projection co-attaches to B's tmux session as a
+    // canvas node (XProjectNode), greyed/dotted with a B badge. Derived from the persisted lineage
+    // link (on A's `Project.links`) + B's serialized `Project.nodes` — nothing extra is persisted
+    // on A. A deleted B node or a missing B project renders nothing here (lazy-prune); the lineage
+    // link survives in the inspector for manual cleanup, exactly like 04's `available:false`.
+    if (hasXproj) {
+      const active = useProjects.getState().activeProjectId
+      const allProjects = useProjects.getState().projects
+      const links =
+        allProjects.find((p) => p.id === active)?.links?.filter(
+          (l) => l.kind === 'lineage' && l.target.ref === 'xnode' && l.source.ref === 'node'
+        ) ?? []
+      for (const l of links) {
+        // Re-narrow inside the loop: `.filter`'s predicate does not narrow the element type, so the
+        // `xnode`/`node` field accesses need their own `ref` guards.
+        if (l.source.ref !== 'node' || l.target.ref !== 'xnode') continue
+        const srcNodeId = l.source.nodeId
+        const bProjectId = l.target.projectId
+        const bNodeId = l.target.nodeId
+        const bProject = allProjects.find((p) => p.id === bProjectId)
+        const bNode = bProject?.nodes.find((n) => n.id === bNodeId)
+        // Lazy-prune: a missing B project or a deleted B node renders no projection. The link
+        // itself is NOT dropped (it lives in the inspector) — only the derived node vanishes.
+        if (!bProject || !bNode) continue
+        const source = nodes.find((n) => n.id === srcNodeId)
+        const projId = `xproj-${bProjectId}-${bNodeId}`
+        const ph = source?.measured?.height ?? (source?.height as number) ?? 400
+        eNodes.push({
+          id: projId,
+          type: 'xproject',
+          // Inherit the source agent's group so the projection sits in the same coordinate space.
+          ...(source?.parentId ? { parentId: source.parentId } : {}),
+          position: offsetFrom(
+            source ? { position: source.position } : { position: { x: 0, y: 0 } },
+            ephemeralPos[projId],
+            { x: 320, y: ph + 60 }
+          ),
+          draggable: true,
+          selectable: false, // a rubber band must not sweep a projection into a real selection
+          selected: ephSelId === projId,
+          width: 480,
+          height: 320,
+          style: { width: 480, height: 320 },
+          data: {
+            title: bNode.title || `${bProject.name} · ${bNode.id.slice(0, 6)}`,
+            color: bProject.color,
+            group: null,
+            xprojSpawn: { bProjectId, bNodeId, bNode, bProject },
+            xprojOriginName: bProject.name
+          }
+        } as unknown as CanvasNode)
+        // Dashed rope from the source agent to its projection, in B's project color.
+        eEdges.push({
+          id: `e-${projId}`,
+          source: srcNodeId,
+          sourceHandle: 'flow-out',
+          target: projId,
+          style: { stroke: bProject.color, strokeWidth: 1.5, strokeDasharray: '6 4' }
+        })
+      }
+    }
     return { ephemeralNodes: eNodes, ephemeralEdges: eEdges }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- loopSig stands in for the byId read
-  }, [agentById, loopSig, ephemeralPos, ephSizes, ephExpanded, ephSelId, nodes])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- loopSig/lineageXnodeSig/foreignNodesSig stand in for their reads
+  }, [agentById, loopSig, ephemeralPos, ephSizes, ephExpanded, ephSelId, nodes, lineageXnodeSig, foreignNodesSig])
 
   // Merge the persisted nodes with the ephemeral ones once per change (not per render),
   // so React Flow's array-identity short-circuit holds while panning/zooming.
@@ -1665,11 +1981,84 @@ export function Canvas() {
     // durable relation and stays. Built above (depEdges), keyed on the dependency signature so a
     // drag frame does not rebuild it.
     const extra =
-      ephemeralEdges.length || ropes.length || depEdges.length
-        ? [...ephemeralEdges, ...ropes, ...depEdges]
+      ephemeralEdges.length || ropes.length || depEdges.length || depLinkEdges.length
+        ? [...ephemeralEdges, ...ropes, ...depEdges, ...depLinkEdges]
         : []
-    return extra.length ? [...decorated, ...extra] : decorated
-  }, [linkEdges, ephemeralEdges, controlEdges, accent, stickySig, depEdges, drivenLeaseEntries])
+    // Off-canvas links (xnode/branch/dependency) that touch THIS canvas — i.e. whose `node`
+    // endpoint resolves to a live node id here — render as derived dashed `xlink-` edges so they
+    // are visible on-canvas, distinct from hand-drawn bridges. A cross-project link to a node that
+    // is NOT on this canvas draws nothing here (it lives in the inspector only). These are
+    // render-only: no handles a connection can originate from, so `onConnect` never starts on one,
+    // and `onEdgeDoubleClick` ignores `xlink-` ids — the inspector is the delete surface. Re-keyed
+    // on `linkSig` (the active project's link-set signature) so a commit re-derives them.
+    //
+    // EXCEPT a cross-project `dependency` link (ticket 04): A and B share no git, so it owns no
+    // stack topology and no canvas edge — resolve point 3 says it is strictly off-canvas (inspector
+    // only), never a dangling `xlink`. The `liveNodeOf` filter below would otherwise pick it up
+    // (its `source` is a live `node` in A; its `target` is an `xnode` in B). A `lineage` link with
+    // an `xnode` target is ALSO excluded: ticket 05 renders it as a foreign-node PROJECTION (an
+    // ephemeral `xproject` node + a dashed rope in the `ephemeralEdges` pass), not a dangling
+    // self-loop edge, so the two must not double-draw. The exclusion is kind+ref-specific:
+    // `dependency` (any ref) and `lineage`+`xnode` are out; every other lineage/context link still
+    // gets its `xlink-` edge.
+    const liveIds = new Set(nodes.map((n) => n.id))
+    const xlinkEdges = offCanvasLinksRef.current
+      .filter(
+        (l) =>
+          !isCrossProjectDependencyLink(l) &&
+          !(l.kind === 'lineage' && l.target.ref === 'xnode') &&
+          liveNodeOf(l, liveIds) !== ''
+      )
+      .map((l) => {
+        // The on-canvas endpoint is the `node` side; the other side has no node here, so the edge
+        // dangles from the live node toward the (off-canvas) target. Source/target are both the
+        // live node id when only one side resolves (React Flow needs real node ids to draw).
+        const liveNode = liveNodeOf(l, liveIds)
+        return {
+          id: `xlink-${l.id}`,
+          source: liveNode,
+          target: liveNode,
+          sourceHandle: 'link-out',
+          targetHandle: 'link-in',
+          type: 'default',
+          label: xlinkLabel(l),
+          labelStyle: { fill: offCanvasLinkColor(l), fontSize: 11, fontWeight: 600 },
+          labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
+          labelBgPadding: [6, 3] as [number, number],
+          labelBgBorderRadius: 5,
+          style: { stroke: offCanvasLinkColor(l), strokeWidth: 1.5, strokeDasharray: '5 4' }
+        }
+      })
+    const withXlink = xlinkEdges.length ? [...extra, ...xlinkEdges] : extra
+    // Two-host dependency edges (ticket 03): a `dependency` link whose both `branch` endpoints are
+    // hosted by worktree group nodes on THIS canvas renders as a real dashed accent edge between the
+    // two group frames (child → parent), not a dangling self-loop. Disjoint from `xlinkEdges` by
+    // construction (those need a `node` endpoint; these have two `branch` endpoints). Derived, not
+    // stored — the join key is each group node's `data.worktree.branch` against the link's branches.
+    const branchToGroupNode = new Map<string, string>()
+    for (const n of nodes) {
+      if (n.type === 'group' && n.data.worktree?.branch) {
+        // First host wins: two worktrees can't share a checked-out branch, so this is unambiguous in
+        // practice, but a stale binding could momentarily double-list — keep the first to stay stable.
+        if (!branchToGroupNode.has(n.data.worktree.branch)) branchToGroupNode.set(n.data.worktree.branch, n.id)
+      }
+    }
+    const branchDepEdges = depHostEdges(offCanvasLinksRef.current, branchToGroupNode).map((d) => ({
+      id: d.id,
+      source: d.source,
+      target: d.target,
+      type: 'default',
+      label: d.label,
+      labelStyle: { fill: '#f59e0b', fontSize: 11, fontWeight: 600 },
+      labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
+      labelBgPadding: [6, 3] as [number, number],
+      labelBgBorderRadius: 5,
+      style: { stroke: '#f59e0b', strokeWidth: 1.5, strokeDasharray: '5 4' },
+      markerEnd: { type: MarkerType.ArrowClosed, color: '#f59e0b', width: 14, height: 14 }
+    }))
+    const withDep = branchDepEdges.length ? [...withXlink, ...branchDepEdges] : withXlink
+    return withDep.length ? [...decorated, ...withDep] : decorated
+  }, [linkEdges, ephemeralEdges, controlEdges, depLinkEdges, accent, stickySig, depEdges, linkSig, nodes])
 
   // Header pin button (and ⌘⇧L): toggle the persisted pin preference. Clears the transient
   // dismiss so (re)pinning shows the docked panel; unpinning collapses it to hover-peek.
@@ -1906,7 +2295,34 @@ export function Canvas() {
       )
     }
     loadingRef.current = true
-    const flow = nodeStatesToFlow(project.nodes)
+    const fullFlow = nodeStatesToFlow(project.nodes)
+    // Drill (ticket 07): if a drill context is active for THIS project, the active node-set is the
+    // group's direct children promoted to root-space, not the full canvas. The group's own terminals
+    // stay mounted (React Flow keys nodes by id; the terminal lifecycle is keyed on
+    // [respawnNonce, offscreenEpoch], not position/parentId — so repositioning re-runs no lifecycle
+    // effect). Siblings leave the node-set and park via the existing primitive on the reverse leg.
+    const drill = drillRef.current
+    let flow: CanvasNode[]
+    if (drill && drill.projectId === project.id && drill.kind === 'group') {
+      const drilled = drillGroupChildren(fullFlow, drill.groupId)
+      flow = drilled.flow
+      drillChildIdsRef.current = drilled.childIds
+    } else if (drill?.kind === 'project-ref') {
+      // A cross-project drill (09) has NO node-set transformation: the target loads its own full
+      // canvas via the normal path. Keep the drill ALIVE while the target is active (so the breadcrumb
+      // stays and exitDrill can switch back to the source meta-canvas); only null it when a THIRD
+      // project loads — i.e. a manual tab/⌘K switch away from the target. The `project.id === targetId`
+      // guard is exactly that distinction.
+      if (project.id !== drill.targetId) {
+        drillRef.current = null
+        drillChildIdsRef.current = new Set()
+      }
+      flow = fullFlow
+    } else {
+      drillRef.current = null
+      drillChildIdsRef.current = new Set()
+      flow = fullFlow
+    }
     setNodes(flow)
     // React Flow now holds THIS project's canvas: the commit guard may pair it with the active id
     // again. Both refs are assigned HERE, synchronously, because `setNodes` only lands on the next
@@ -1924,15 +2340,21 @@ export function Canvas() {
     if (project.cwd && !project.ssh) {
       void useWorktrees.getState().refresh(project.cwd, boundGroups(flow))
     }
-    setLinkEdges((project.bridges ?? []).map((b) => ({ id: b.id, source: b.source, target: b.target })))
-    // Restore control ropes with the source agent's color (falls back to the browser blue).
-    setControlEdges(
-      (project.ropes ?? []).map((r) => {
-        const srcState = project.nodes.find((n) => n.id === r.source)
-        const color = agentConfig((srcState?.agentId as AgentId) ?? '')?.color ?? '#0a84ff'
-        return ropeEdge(r.id, r.source, r.target, color)
-      })
+    // Restore edges from the unified `links` substrate: `context` → linkEdges (context + note
+    // links, the read-back substrate), `lineage` → controlEdges (display-only ropes) colored by
+    // the source agent's config color (falls back to the browser blue), as the old `ropes` restore
+    // did. `dependency`/`xnode`/`branch` links have no on-canvas node pair and are dropped here —
+    // but they are NOT lost: they are stashed in `offCanvasLinksRef` so `mergeLinks` can fold them
+    // back into the persisted `Link[]` at commit (the round-trip is lossless for off-canvas links).
+    const restored = linksToRuntime(
+      project.links,
+      (id) => agentConfig(id)?.color ?? '#0a84ff',
+      (nodeId) => project.nodes.find((n) => n.id === nodeId)?.agentId as AgentId | undefined
     )
+    setLinkEdges(restored.context)
+    setControlEdges(restored.lineage)
+    setDepLinkEdges(restored.dependency)
+    offCanvasLinksRef.current = (project.links ?? []).filter((l) => nodeEndpoints(l) === null)
     // Reset history for the newly loaded project.
     committedRef.current = flow
     pastRef.current = []
@@ -1942,6 +2364,14 @@ export function Canvas() {
       // In-place reload (external change / SSH reconcile): keep the user's current camera —
       // the file's viewport is where another machine last saved, not where this user looks.
       preserveViewportRef.current = false
+    } else if (drill && drill.projectId === project.id && drill.kind === 'group') {
+      // Drill (07): the sub-canvas gets a DERIVED viewport — frame the drilled node-set. The parent
+      // canvas's last viewport was stashed on drill entry (preDrillViewportRef) and restored on exit.
+      // A drill has no persisted viewport of its own (and shouldn't — drilling is navigation, not a
+      // saved surface; persisting one would churn project.json per drill).
+      setTimeout(() => {
+        void fitView({ nodes: flow.map((n) => ({ id: n.id })), duration: 250, padding: 0.15 })
+      }, 0)
     } else {
       viewportRef.current = project.viewport
       setViewport(project.viewport)
@@ -1990,7 +2420,7 @@ export function Canvas() {
     }, 0)
     return () => clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeProjectId, reloadNonce, setNodes, setViewport])
+  }, [activeProjectId, reloadNonce, drillNonce, setNodes, setViewport])
 
   /**
    * Counts EDITS (not saves). `writeDisk` captures it before it builds the snapshot and clears
@@ -2067,17 +2497,339 @@ export function Canvas() {
     // The normal switch flow still commits — every caller commits BEFORE `setActive`, while the two
     // ids still agree — but an autosave timer armed under the previous project now skips instead of
     // writing its nodes under the new project's id (field bug 2026-08-10).
-    if (canCommitCanvas(nodesProjectIdRef.current, id))
+    if (canCommitCanvas(nodesProjectIdRef.current, id)) {
+      // Drill (07): while drilled, `nodesRef.current` is the SUBSET (the group's children at root-space),
+      // but `commitCanvas` wholesale-replaces the project's nodes — committing the subset would clobber
+      // every sibling. Merge the edited drilled children back into the project's FULL stored node array,
+      // re-nested under the group (positions stored parent-relative). The full array is read from the
+      // store (not nodesRef, which holds the subset); remerge needs the full CanvasNode array to resolve
+      // the group's root origin (the group is absent from the drilled view), so we re-flow the stored states.
+      const drill = drillRef.current
+      let nodesToCommit: CanvasNodeState[]
+      if (drill && drill.projectId === id && drill.kind === 'group') {
+        const stored = useProjects.getState().getProject(id)
+        const fullFlow = stored ? nodeStatesToFlow(stored.nodes) : []
+        nodesToCommit = remergeDrilledNodes(
+          stored?.nodes ?? [],
+          flowToNodeStates(nodesRef.current),
+          drill.groupId,
+          fullFlow
+        )
+      } else {
+        nodesToCommit = flowToNodeStates(nodesRef.current)
+      }
       useProjects
         .getState()
         .commitCanvas(
           id,
-          flowToNodeStates(nodesRef.current),
+          nodesToCommit,
           viewportRef.current,
-          linkEdgesRef.current.map((e) => ({ id: e.id, source: e.source, target: e.target })),
-          controlEdgesRef.current.map((e) => ({ id: e.id, source: e.source, target: e.target }))
+          mergeLinks(linkEdgesRef.current, controlEdgesRef.current, depLinkEdgesRef.current, offCanvasLinksRef.current)
         )
+    }
   }, [])
+
+  /**
+   * The single funnel for off-canvas link mutations (the picker's add, the inspector's delete).
+   * `Project.links` is the source of truth; the on-canvas edge arrays are its projection plus the
+   * hand-draw scratch space. For the ACTIVE project, this rebuilds `linkEdges`/`controlEdges` from
+   * the on-canvas subset of `next` and refreshes `offCanvasLinksRef` with the rest, so a same-
+   * project on-canvas link added off-canvas (rare, but the seam) draws immediately and a deleted
+   * one disappears in the same mutation. For a BACKGROUND project (inspector opened on a non-active
+   * node), it writes `Project.links` directly via `commitCanvas` against that project's stored
+   * nodes — never the active canvas's — so it doesn't clobber a project it isn't looking at.
+   */
+  const commitLinks = useCallback(
+    (projectId: string, next: Link[]) => {
+      if (projectId === activeProjectId) {
+        // Split `next` the same way the load effect does: node↔node context/lineage/dependency →
+        // on-canvas edges; everything else → off-canvas ref. Re-deriving from the authoritative set
+        // removes the drift hazard of mutating one store without the other.
+        const ctx: Edge[] = []
+        const lin: Edge[] = []
+        const dep: Edge[] = []
+        const offCanvas: Link[] = []
+        // Agent-color lookup for lineage ropes, mirroring `linksToRuntime`'s `nodeAgentOf`: read the
+        // CREATED agent harness id off the live node data (not `agentIdOf`, which is declared below
+        // this hook and would be a TDZ use). Falls back to the browser blue.
+        const nodeAgentOf = (nodeId: string): AgentId | undefined =>
+          createdAgentId(nodesRef.current.find((n) => n.id === nodeId)?.data) as AgentId | undefined
+        for (const l of next) {
+          const pair = nodeEndpoints(l)
+          if (!pair) {
+            offCanvas.push(l)
+          } else if (l.kind === 'context') {
+            ctx.push({ id: pair.id, source: pair.source, target: pair.target, type: 'default' })
+          } else if (l.kind === 'lineage') {
+            const color = agentConfig(nodeAgentOf(pair.source) ?? '')?.color ?? '#0a84ff'
+            lin.push(ropeEdge(pair.id, pair.source, pair.target, color))
+          } else if (l.kind === 'dependency') {
+            dep.push(depEdge(pair.id, pair.source, pair.target))
+          } else {
+            offCanvas.push(l)
+          }
+        }
+        setLinkEdges(ctx)
+        setControlEdges(lin)
+        setDepLinkEdges(dep)
+        offCanvasLinksRef.current = offCanvas
+      }
+      // Persist the full Link[] (on-canvas + off-canvas). For a background project, read its stored
+      // nodes so commitCanvas doesn't overwrite them with the active canvas's nodes.
+      const stored = useProjects.getState().getProject(projectId)
+      const nodesToCommit = projectId === activeProjectId
+        ? flowToNodeStates(nodesRef.current)
+        : (stored?.nodes ?? [])
+      useProjects.getState().commitCanvas(
+        projectId,
+        nodesToCommit,
+        projectId === activeProjectId ? viewportRef.current : (stored ? stored.viewport : { x: 0, y: 0, zoom: 1 }),
+        next.length ? next : undefined
+      )
+      markDirty()
+    },
+    [activeProjectId, setLinkEdges, setControlEdges, setDepLinkEdges, markDirty]
+  )
+
+  // Submodule auto-link (ticket 09): when the ACTIVE project is a meta-canvas — i.e. it holds group
+  // nodes carrying `data.projectRef` — resolve each referenced project's git submodules and, for
+  // every submodule whose folder is itself an OPEN project, ensure a projectRef group for it exists
+  // on the meta-canvas and draw a visible `dependency` edge between the two groups. The edge is a
+  // `node`↔`node` `dependency` link (both endpoints are real group nodes here), so `linksToRuntime`
+  // renders it amber and `runtimeToLinks` round-trips it — exactly the seam task #47 wired.
+  //
+  // Gated on the active project HAVING projectRef groups so an ordinary project never pays the git
+  // churn (repoRoot + submoduleList per referenced repo). Epoch-guarded: a project switch bumps the
+  // epoch and a stale in-flight read's result is dropped. Runs once on load + on a manual ⟳ follow-up
+  // (polling is a follow-up — each read is a `git` subprocess on the referenced project's machine).
+  // SSH projects are skipped: `git-service.submoduleList` refuses a remote repo (the cwd is on the
+  // host), and an SSH referenced project's submodules live there too — real support needs the
+  // ControlMaster, out of scope for v1.
+  const submoduleEpochRef = useRef(0)
+  useEffect(() => {
+    const project = useProjects.getState().getProject(activeProjectId)
+    if (!project) {
+      submoduleSuggestionsRef.current = []
+      setSubmoduleSuggestions([])
+      return
+    }
+    // Collect the projectRef groups on THIS canvas (live nodes), with their referenced project.
+    const refGroups = nodesRef.current
+      .filter((n) => n.type === 'group' && (n.data as unknown as { projectRef?: { projectId: string } }).projectRef)
+      .map((n) => {
+        const ref = (n.data as unknown as { projectRef: { projectId: string } }).projectRef
+        return { groupId: n.id, projectId: ref.projectId }
+      })
+    if (!refGroups.length) {
+      submoduleSuggestionsRef.current = []
+      setSubmoduleSuggestions([])
+      return // an ordinary canvas — no git churn
+    }
+    const epoch = ++submoduleEpochRef.current
+    let cancelled = false
+    void (async () => {
+      // Map every referenced project id → the group node id already on the canvas (for the link
+      // endpoints), and gather the referenced projects that actually have a local cwd to read.
+      const existingGroupForProject = new Map<string, string>()
+      for (const g of refGroups) existingGroupForProject.set(g.projectId, g.groupId)
+      const openProjects = useProjects
+        .getState()
+        .projects.filter((p) => p.cwd && !p.ssh)
+        .map((p) => ({ cwd: p.cwd!, projectId: p.id }))
+      const existingLinkKeys = existingDependencyLinkKeys(project.links)
+      const newLinks: Link[] = []
+      const groupsToCreate: { projectId: string; color?: string }[] = []
+      const suggestions: SubmoduleProjectSuggestion[] = []
+      for (const ref of refGroups) {
+        const refProject = useProjects.getState().getProject(ref.projectId)
+        if (!refProject?.cwd || refProject.ssh) continue
+        const root = await api.git.repoRoot(refProject.cwd).catch(() => null)
+        if (cancelled || epoch !== submoduleEpochRef.current || !root) continue
+        const subs = await api.git.submoduleList(root).catch(() => null)
+        if (cancelled || epoch !== submoduleEpochRef.current || !subs?.ok) continue
+        const plan = planSubmoduleLinks(
+          ref,
+          root,
+          subs.entries,
+          openProjects,
+          existingGroupForProject,
+          existingLinkKeys
+        )
+        newLinks.push(...plan.links)
+        for (const suggestion of plan.suggestions) {
+          if (!suggestions.some((s) => s.path === suggestion.path && s.sourceGroupId === suggestion.sourceGroupId)) {
+            suggestions.push(suggestion)
+          }
+        }
+        // A group to create may already have been requested by an earlier ref in this loop — dedupe.
+        for (const g of plan.groupsToCreate) {
+          if (!existingGroupForProject.has(g.projectId) && !groupsToCreate.some((x) => x.projectId === g.projectId)) {
+            groupsToCreate.push(g)
+          }
+        }
+      }
+      if (cancelled || epoch !== submoduleEpochRef.current) return
+      const previousSuggestions = submoduleSuggestionsRef.current
+      submoduleSuggestionsRef.current = suggestions
+      setSubmoduleSuggestions(suggestions)
+      // First mint any missing projectRef groups (so the links have endpoints), then upsert the
+      // dependency links. The groups are created on the live canvas via setNodes; the links are
+      // written through commitLinks so the on-canvas `depLinkEdges` + the persisted `Project.links`
+      // stay in sync. A created group lands its edge on the NEXT run (the plan defers a link whose
+      // target group doesn't exist yet — never a dangling edge).
+      if (groupsToCreate.length) {
+        const targetColors = new Map(
+          useProjects.getState().projects.map((p) => [p.id, p.color] as const)
+        )
+        setNodes((ns) => {
+          const fresh = [...ns]
+          for (const g of groupsToCreate) {
+            const target = useProjects.getState().getProject(g.projectId)
+            const suggestionIndex = previousSuggestions.findIndex((s) => s.path === target?.cwd)
+            const suggestion = suggestionIndex >= 0 ? previousSuggestions[suggestionIndex] : undefined
+            const source = suggestion ? fresh.find((n) => n.id === suggestion.sourceGroupId) : undefined
+            // Promote an opened ghost in place. A project that was already open has no ghost, so
+            // it falls back to the ordinary staggered meta-canvas grid.
+            const position = source
+              ? {
+                  x: source.position.x + (source.width ?? 520) + 80,
+                  y: source.position.y + suggestionIndex * 150
+                }
+              : {
+                  x: 200 + (fresh.length % 4) * 560,
+                  y: 200 + Math.floor(fresh.length / 4) * 420
+                }
+            const node = createGroupNode(position, undefined, fresh.length)
+            fresh.push({
+              ...node,
+              data: { ...node.data, projectRef: { projectId: g.projectId }, color: targetColors.get(g.projectId) ?? node.data.color }
+            })
+          }
+          return fresh
+        })
+        markDirty()
+        // The first pass creates the real endpoint; the next pass sees it and adds the dependency
+        // edge. Keeping those phases separate guarantees no persisted dangling edge.
+        setSubmoduleRefreshNonce((n) => n + 1)
+      }
+      if (newLinks.length) {
+        const currentLinks = useProjects.getState().getProject(activeProjectId)?.links ?? []
+        commitLinks(activeProjectId, [...currentLinks, ...newLinks])
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [activeProjectId, submoduleRefreshNonce, api, setNodes, markDirty, commitLinks])
+
+  /** The project id that holds a node (node ids are globally unique across projects). Used by the
+   *  link picker/inspector entry points to resolve a background node's project. */
+  const projectOfNode = useCallback((nodeId: string): string | null => {
+    const p = useProjects.getState().projects.find((proj) => proj.nodes.some((n) => n.id === nodeId))
+    return p?.id ?? null
+  }, [])
+
+  /** The current `Project.links` for a project — the base the picker appends a new link to before
+   *  handing the full set to `commitLinks`. */
+  const linksForProject = useCallback((projectId: string): Link[] => {
+    return useProjects.getState().getProject(projectId)?.links ?? []
+  }, [])
+
+  // Every inspector surface (terminal header, card modal, Canvas portal) writes through the same
+  // live-edge + persistence funnel. React Flow creates node components itself, so this small bridge
+  // avoids copying the reconciliation logic into each surface.
+  useEffect(() => {
+    setLinkCommitHandler(commitLinks)
+    return () => setLinkCommitHandler(null)
+  }, [commitLinks])
+
+  /**
+   * Exit a group drill (07): clear the context and re-run the load effect, which rebuilds the full
+   * canvas with the group visible as a frame again. The drilled nodes, which stayed mounted, get `parentId`/`extent`
+   * restored and re-nested; siblings, which parked, remount and adopt. Commit first so edits made
+   * inside the drill land (remerged into the full array), then restore the stashed parent viewport.
+   *
+   */
+  const exitDrill = useCallback(() => {
+    if (!drillRef.current) return
+    commitActiveToStore()
+    const drill = drillRef.current
+    drillRef.current = null
+    drillChildIdsRef.current = new Set()
+    setDrillNonce((n) => n + 1)
+    // Cross-project drill (09): switch the active project back to the SOURCE meta-canvas. The load
+    // effect then re-runs for the source (its drillRef was just nulled, so it loads its full canvas)
+    // and restores the source's own persisted viewport — the meta-canvas's camera is stashed in
+    // `preDrillViewportRef` and applied below the same way group/node drills restore theirs.
+    if (drill.kind === 'project-ref') {
+      useProjects.getState().setActive(drill.projectId)
+    }
+    // Restore the parent viewport once the full canvas has loaded. The load effect runs after this
+    // render; defer past it with a microtask + a frame so setNodes has landed and setViewport sticks.
+    if (preDrillViewportRef.current && drill.kind === 'group') {
+      const vp = preDrillViewportRef.current
+      preDrillViewportRef.current = null
+      setTimeout(() => {
+        viewportRef.current = vp
+        setViewport(vp)
+        setZoomPct(Math.round(vp.zoom * 100))
+        setGroupLabelBoost(vp.zoom)
+        setSharedGlyphCamera(vp)
+      }, 0)
+    } else if (preDrillViewportRef.current && drill.kind === 'project-ref') {
+      // The meta-canvas's stashed camera — restored once the source project's nodes have loaded back.
+      const vp = preDrillViewportRef.current
+      preDrillViewportRef.current = null
+      setTimeout(() => {
+        viewportRef.current = vp
+        setViewport(vp)
+        setZoomPct(Math.round(vp.zoom * 100))
+        setGroupLabelBoost(vp.zoom)
+        setSharedGlyphCamera(vp)
+      }, 0)
+    }
+  }, [commitActiveToStore, setViewport])
+
+  /**
+   * Drill into a node-group: switch the active node-set to the group's direct children (promoted to
+   * root-space), reusing the canvas-switcher load effect (ticket 07). The group's own terminals stay
+   * mounted (RF id-keying); only siblings leave the node-set (they park). Transient/in-memory — never
+   * persisted. Commit any live edits first (the load effect re-runs and would otherwise drop them),
+   * stash the parent viewport for `exitDrill`, then arm the drill context and bump the nonce so the
+   * load effect re-runs and builds the drilled flow.
+   */
+  const openNodeGroupAsCanvas = useCallback(
+    (groupId: string) => {
+      const id = useProjects.getState().activeProjectId
+      if (!id) return
+      // The group must exist in the live canvas.
+      const node = nodesRef.current.find((n) => n.id === groupId && n.type === 'group')
+      if (!node) return
+      // Cross-project drill (ticket 09): a `data.projectRef` group REFERENCES another project. Drilling
+      // it switches the active project to the referenced one (the existing project-switch load effect
+      // swaps the canvas), rather than promoting this group's children. The group may also hold local
+      // children on the meta-canvas — those are left alone (not a sub-canvas drill). No merge-back:
+      // commits land in the target project via its own commitCanvas path, and exitDrill switches back
+      // to THIS meta-canvas. Refuse if the referenced project is gone/unavailable/closed (the GroupNode
+      // renderer already greys it; drilling into something unopenable is a no-op, never a switch).
+      const ref = (node.data as { projectRef?: { projectId: string } }).projectRef
+      if (ref) {
+        const target = useProjects.getState().getProject(ref.projectId)
+        if (!target || target.unavailable || target.closed) return
+        commitActiveToStore()
+        preDrillViewportRef.current = getViewport()
+        drillRef.current = { kind: 'project-ref', projectId: id, targetId: target.id }
+        useProjects.getState().setActive(target.id)
+        setDrillNonce((n) => n + 1)
+        return
+      }
+      commitActiveToStore()
+      preDrillViewportRef.current = getViewport()
+      drillRef.current = { kind: 'group', groupId, projectId: id }
+      setDrillNonce((n) => n + 1)
+    },
+    [commitActiveToStore, getViewport]
+  )
 
   const writeDisk = useCallback(async () => {
     // Captured BEFORE the snapshot is built (`toWorkspace()` runs synchronously on this line), so
@@ -2681,6 +3433,19 @@ export function Canvas() {
   // Double-click a context link to remove it (ephemeral subagent/loop edges are left alone).
   const onEdgeDoubleClick = useCallback(
     (_e: React.MouseEvent, edge: Edge) => {
+      // A persisted same-project `dep-` dependency edge (ticket 09: the meta-canvas submodule
+      // auto-link, held in `depLinkEdges`) IS deletable on canvas — unlike the DERIVED `dep-` edges
+      // (ticket 03's two-host branch dependency, `dep-${linkId}`) which are render-only and owned by
+      // the inspector. Distinguish by membership: a dep edge in `depLinkEdgesRef` is persisted.
+      if (depLinkEdgesRef.current.some((b) => b.id === edge.id)) {
+        setDepLinkEdges((es) => es.filter((b) => b.id !== edge.id))
+        markDirty()
+        return
+      }
+      // Derived off-canvas edges (`xlink-`, and the two-host dependency `dep-` edges from ticket 03)
+      // are render-only — no delete here; the inspector owns them. (Ephemeral subagent/loop edges
+      // likewise fall through to the no-op return below.)
+      if (edge.id.startsWith('xlink-') || edge.id.startsWith('dep-')) return
       // Control ropes are removable the same way as context links (ephemeral edges are not).
       if (controlEdgesRef.current.some((b) => b.id === edge.id)) {
         // A rope may be the only DRAWN edge for a pair that also has a context bridge (see
@@ -2698,21 +3463,30 @@ export function Canvas() {
       setLinkEdges((es) => es.filter((b) => b.id !== edge.id))
       markDirty()
     },
-    [setLinkEdges, markDirty]
+    [setLinkEdges, setDepLinkEdges, markDirty]
   )
 
   // Route edge changes (selection) to the right store: `ctrl-` ids are control ropes (local
-  // state), everything else is a context link. Ephemeral subagent/loop edges emit no changes
-  // worth applying — applyEdgeChanges on unknown ids is a no-op either way.
+  // state), `dep-` ids that live in `depLinkEdges` are the persisted node↔node dependency edges
+  // (ticket 09), everything else is a context link. Ephemeral subagent/loop edges and the derived
+  // `dep-` host edges (ticket 03) emit no changes worth applying — applyEdgeChanges on unknown ids
+  // is a no-op either way.
   const handleEdgesChange = useCallback(
     (changes: EdgeChange[]) => {
       const rope: EdgeChange[] = []
+      const dep: EdgeChange[] = []
       const link: EdgeChange[] = []
-      for (const c of changes) ('id' in c && String(c.id).startsWith('ctrl-') ? rope : link).push(c)
+      for (const c of changes) {
+        const id = 'id' in c ? String(c.id) : ''
+        if (id.startsWith('ctrl-')) rope.push(c)
+        else if (id.startsWith('dep-') && depLinkEdgesRef.current.some((b) => b.id === id)) dep.push(c)
+        else link.push(c)
+      }
       if (rope.length) setControlEdges((es) => applyEdgeChanges(rope, es))
+      if (dep.length) setDepLinkEdges((es) => applyEdgeChanges(dep, es))
       if (link.length) onLinkEdgesChange(link)
     },
-    [onLinkEdgesChange]
+    [onLinkEdgesChange, setDepLinkEdges]
   )
 
   // Prune ropes whose endpoints were deleted (mirrors the context-link pruning below).
@@ -2725,7 +3499,15 @@ export function Canvas() {
       const valid = es.filter((e) => ids.has(e.source) && ids.has(e.target))
       return valid.length === es.length ? es : valid
     })
-  }, [nodes])
+    // Same prune for persisted `dep-` dependency edges (the meta-canvas auto-link, 09): a deleted
+    // projectRef group must drop its dependency edges, or they dangle against a missing node id.
+    if (depLinkEdgesRef.current.length) {
+      setDepLinkEdges((es) => {
+        const valid = es.filter((e) => ids.has(e.source) && ids.has(e.target))
+        return valid.length === es.length ? es : valid
+      })
+    }
+  }, [nodes, setDepLinkEdges])
 
   // Rewrite link files when a linked node's session starts/changes: main resolves
   // codex/gemini transcripts by sessionId, so a session that appears after the edge was
@@ -2735,9 +3517,10 @@ export function Canvas() {
   // loopSig).
   const linkSessionSig = useAgentStatus((s) => {
     let sig = ''
-    for (const e of linkEdges) {
-      const a = s.byId[e.source]
-      const b = s.byId[e.target]
+    for (const project of useProjects.getState().projects) for (const link of project.links ?? []) {
+      if (link.kind !== 'context' || link.source.ref === 'branch' || link.target.ref === 'branch') continue
+      const a = s.byId[link.source.nodeId]
+      const b = s.byId[link.target.nodeId]
       sig += `${a?.agentId ?? ''}:${a?.sessionId ?? ''}|${b?.agentId ?? ''}:${b?.sessionId ?? ''}|`
     }
     return sig
@@ -2767,19 +3550,19 @@ export function Canvas() {
         accountId: sticky ? undefined : ((n?.data.accountId as string) || undefined)
       }
     }
-    // Merge in the link maps of every OTHER project (from their serialized nodes + bridges):
+    // Merge in the link maps of every OTHER project (from their serialized nodes + `links`):
     // main clears all link files before writing the pushed map, so pushing only the active
     // project's map would sever the links of background projects whose agents keep running.
     const { projects, activeProjectId } = useProjects.getState()
-    const map = {
-      ...buildBackgroundLinkMaps(
+    const map = mergeContextLinkMaps(
+      buildBackgroundLinkMaps(
         projects,
         activeProjectId,
         (id) => useAgentStatus.getState().byId[id]?.sessionId,
         (id) => useAgentStatus.getState().byId[id]?.agentId
       ),
-      ...buildLinkMap(valid, infoOf)
-    }
+      buildLinkMap(valid, infoOf)
+    )
     const t = setTimeout(() => void window.nodeTerminal.contextLink.setLinks(map), 150)
     return () => clearTimeout(t)
     // linkSessionSig is read only as an effect trigger — infoOf re-reads sessionIds via getState().
@@ -2997,6 +3780,28 @@ export function Canvas() {
     [isSshProject]
   )
 
+  /**
+   * While drilled into a group (ticket 07/08), a new node is created at root-space inside the drilled
+   * canvas — it has no `parentId` yet (it gains one on exit, when the reverse leg re-nests it). So
+   * `cwdForNewNodeIn` (which walks `parentId` through `nodesRef.current`) CANNOT answer for it: the
+   * drilled group frame is absent from `nodesRef.current`, and the new node has no parent to walk.
+   * This resolver reads the worktree path straight from the durable binding via the DrillContext +
+   * the FULL project nodes (where the group still lives), applying the SAME staleness/SSH gates
+   * `cwdForNewNodeIn` uses. Returns undefined when not drilled, or when the drilled group isn't a
+   * healthy non-SSH worktree — in which case the caller falls back to `project?.cwd` as usual.
+   */
+  const drillCwdOverride = useCallback((): string | undefined => {
+    const drill = drillRef.current
+    if (!drill || drill.kind !== 'group') return undefined
+    const proj = useProjects.getState().getProject(drill.projectId)
+    const group = proj?.nodes.find((n) => n.id === drill.groupId)
+    const wt = group?.worktree
+    if (!wt) return undefined
+    const stale = useWorktrees.getState().staleGroupIds.includes(drill.groupId)
+    if (stale || isSshProject) return undefined
+    return wt.path
+  }, [isSshProject])
+
   /** The nearest ancestor frame (from `parentId` upward) that is bound to a git worktree. */
   const worktreeForGroupChain = useCallback(
     (parentId: string | undefined): { groupId: string; path: string } | undefined => {
@@ -3080,7 +3885,10 @@ export function Canvas() {
       cwdOverride?: string
     ) => {
       const project = useProjects.getState().getProject(activeProjectId)
-      const cwd = cwdOverride ?? cwdForNewNodeIn(groupId) ?? project?.cwd
+      // `drillCwdOverride` wins when no explicit override is given AND we're drilled into a worktree
+      // group (ticket 08): a root-space new node has no `parentId` for `cwdForNewNodeIn` to walk, so
+      // the worktree path is read straight from the DrillContext + the durable binding.
+      const cwd = cwdOverride ?? drillCwdOverride() ?? cwdForNewNodeIn(groupId) ?? project?.cwd
       setNodes((ns) => {
         // In an SSH project the node is stamped remote (runs over the project's master); the
         // factory takes the project's ssh and roots the terminal at its remoteCwd.
@@ -3089,7 +3897,7 @@ export function Canvas() {
       })
       markDirty()
     },
-    [setNodes, markDirty, activeProjectId, emptyNodePos, cwdForNewNodeIn, parentInto]
+    [setNodes, markDirty, activeProjectId, emptyNodePos, cwdForNewNodeIn, parentInto, drillCwdOverride]
   )
 
   /** Open a new terminal that runs a command on start (e.g. gh auth login). `cwd` lets a caller
@@ -3604,6 +4412,38 @@ export function Canvas() {
     [setNodes, markDirty, emptyNodePos, parentInto]
   )
 
+  // Meta-canvas (ticket 09): a top-level canvas whose group frames each REFERENCE another project.
+  // A meta-canvas is an ordinary `Project` (no cwd — it has no single working directory), activated
+  // like any other; the user then adds project-ref groups (below) or the submodule auto-linker
+  // populates them. Drilling a project-ref group switches the active project to the referenced one.
+  const newMetaCanvas = useCallback(() => {
+    commitActiveToStore()
+    const project = useProjects.getState().addProject('Meta canvas')
+    useProjects.getState().setActive(project.id)
+    void writeDisk()
+  }, [commitActiveToStore, writeDisk])
+
+  // Add an OPEN project to the active (meta) canvas as a `kind:'group'` node carrying
+  // `data.projectRef`. Excludes the active canvas itself (a project can't reference itself) and
+  // closed projects (drilling into a closed project is a no-op — `openNodeGroupAsCanvas` refuses).
+  // The group may also hold local children on the meta-canvas; `projectRef` is additive to the
+  // group's own label. The referenced project's color rides along so the badge dot matches its tab.
+  const addProjectToCanvas = useCallback(
+    (projectId: string) => {
+      const target = useProjects.getState().getProject(projectId)
+      if (!target || target.closed) return
+      if (projectId === activeProjectId) return // never reference itself
+      setNodes((ns) => {
+        const node = createGroupNode(emptyNodePos() ?? { x: 0, y: 0 }, undefined, ns.length)
+        // Carry the referenced project's color so the badge dot + frame match its tab.
+        const data = { ...node.data, projectRef: { projectId }, color: target.color }
+        return [...ns, { ...node, data }]
+      })
+      markDirty()
+    },
+    [setNodes, markDirty, activeProjectId, emptyNodePos]
+  )
+
   const addDino = useCallback(
     (center?: { x: number; y: number }) => {
       // Seed with the project record, maxed with any live dino nodes (pre-record projects
@@ -3729,10 +4569,14 @@ export function Canvas() {
       center?: { x: number; y: number },
       groupId?: string,
       accountId?: string,
-      initialPrompt?: string
+      initialPrompt?: string,
+      /** Force the working directory (mirrors `addTerminal`'s `cwdOverride` — e.g. a Source Control
+       *  action, or the drilled-worktree-canvas path in ticket 08 where a root-space new node has no
+       *  `parentId` for `cwdForNewNodeIn` to walk). */
+      cwdOverride?: string
     ) => {
       const project = useProjects.getState().getProject(activeProjectId)
-      const cwd = cwdForNewNodeIn(groupId) ?? project?.cwd
+      const cwd = cwdOverride ?? drillCwdOverride() ?? cwdForNewNodeIn(groupId) ?? project?.cwd
       // Codex accounts (S6) resolve through their OWN fail-closed gate: an explicitly picked account
       // that is missing/hostile/unconnected is REFUSED here rather than silently downgraded to the
       // system login (Property 4). Claude keeps its project-default-aware resolver. The factory
@@ -3789,7 +4633,8 @@ export function Canvas() {
       emptyNodePos,
       cwdForNewNodeIn,
       parentInto,
-      connectedProjectIdForHost
+      connectedProjectIdForHost,
+      drillCwdOverride
     ]
   )
 
@@ -3804,8 +4649,6 @@ export function Canvas() {
       const at = spawnTeamDialog?.at
       setSpawnTeamDialog(null)
       addAgentNode(
-        // No explicit pick here — the conductor opens on whatever this project calls its default
-        // agent (`.nodeterm/settings.json` → agents.defaultAgentId), else the global one.
         resolveNewNodeAgent(
           undefined,
           useProjects.getState().activeProjectId,
@@ -4791,7 +5634,7 @@ export function Canvas() {
   // merge / remove teardown actions (Tasks 8 & 9) slot in as new cases. `unbind` forgets the
   // binding without touching disk; `merge` merges to base; `remove` opens the safety dialog.
   const onWorktreeAction = useCallback(
-    (groupId: string, action: 'merge' | 'remove' | 'unbind' | 'rerun-setup') => {
+    (groupId: string, action: 'merge' | 'remove' | 'unbind' | 'rerun-setup' | 'sync') => {
       // A binding can only predate the SSH gate (hand-edited project file, or a project that became
       // an SSH project), but it can still exist — and merge/remove would run against the LOCAL
       // filesystem for a project whose git and terminals live on the remote host. Refuse them, out
@@ -4857,6 +5700,21 @@ export function Canvas() {
           startWorktreeSetup(groupId, wt.path)
           break
         }
+        case 'sync': {
+          const wt = nodesRef.current.find((n) => n.id === groupId)?.data.worktree
+          if (!wt) return
+          const branch = useWorktrees.getState().statusByPath[wt.path]?.branch || wt.branch
+          void api.git
+            .syncBranch(wt.path, branch)
+            .then((res) => setNotice({ kind: res.ok ? 'info' : 'error', text: res.message }))
+            .catch((error: unknown) =>
+              setNotice({
+                kind: 'error',
+                text: `The sync could not be confirmed: ${error instanceof Error ? error.message : String(error)}.`
+              })
+            )
+          break
+        }
         default:
           break
       }
@@ -4875,6 +5733,13 @@ export function Canvas() {
     setWorktreeActionHandler(onWorktreeAction)
     return () => setWorktreeActionHandler(null)
   }, [onWorktreeAction])
+
+  // Bridge the drill-into-group handler to GroupNode (ticket 07): the group's ⤢ affordance triggers
+  // openNodeGroupAsCanvas without prop drilling through React Flow.
+  useEffect(() => {
+    setDrillHandler(openNodeGroupAsCanvas)
+    return () => setDrillHandler(null)
+  }, [openNodeGroupAsCanvas])
 
   // Same reason as worktreeControlRef below: the agent-control handler needs the CURRENT
   // travelToProject (defined far below, after the project actions it composes).
@@ -6036,6 +6901,30 @@ export function Canvas() {
             gatewayModels,
             relaySession: session.source === 'relay'
           }, transferConversation)
+        : []),
+      // Off-canvas link authoring (ticket 06): the only way to add a dependency / cross-project
+      // (xnode) / cross-repo (branch) link, and the off-canvas way to list a node's links. Single
+      // node only. On the active-project sidebar row this same submenu appears via onRowContextMenu.
+      ...(ids.length === 1
+        ? ([
+            {
+              type: 'submenu' as const,
+              label: 'Links',
+              icon: <IconLink />,
+              children: [
+                {
+                  label: 'Link to…',
+                  icon: <IconLink />,
+                  onClick: () => setLinkPickerNode(ids[0])
+                },
+                {
+                  label: 'Links…',
+                  icon: <IconLink />,
+                  onClick: () => setLinkInspectorNode(ids[0])
+                }
+              ]
+            }
+          ] as MenuItem[])
         : []),
       ...(isHidden('collapse', hidden)
         ? []
@@ -7612,6 +8501,10 @@ export function Canvas() {
       // each dep after already bridging them to the opener): linkEdgesRef is a render-time ref,
       // so it cannot see edges added earlier in this same tick, and without the accumulator a
       // pair reachable twice would be added twice under two different ids.
+      // `drawn` accumulates the node PAIRS bridged across the calls ONE command makes (--after
+      // bridges each new node to each dep after already bridging them to the opener), for dedup
+      // against `existing` (a pair projection, not `Link[]`). `planBridges` returns `Link[]`; we
+      // project to pairs for the accumulator and to runtime edges for `linkEdges`.
       const drawn: { source: string; target: string }[] = []
       const bridgeTo = (
         fromId: string,
@@ -7620,8 +8513,14 @@ export function Canvas() {
       ) => {
         const plan = planBridges(fromId, targetIds, lookup, [...linkEdgesRef.current, ...drawn])
         if (plan.edges.length) {
-          drawn.push(...plan.edges)
-          setLinkEdges((es) => [...es, ...plan.edges.map((e) => ({ ...e, type: 'default' }))])
+          drawn.push(...plan.edges.map((e) => nodeEndpoints(e)!))
+          setLinkEdges((es) => [
+            ...es,
+            ...plan.edges.map((e) => {
+              const p = nodeEndpoints(e)!
+              return { id: p.id, source: p.source, target: p.target, type: 'default' as const }
+            })
+          ])
           markDirty()
         }
         return plan
@@ -7835,6 +8734,65 @@ export function Canvas() {
             // open-claude is the legacy fixed-agent form; open-agent takes any builtin or custom
             // agent id — resolveAgent is the single registry/base-harness resolver for both.
             const agentId = (verb === 'open-agent' ? args.agent : 'claude') as AgentId
+            // ── Cross-project spawn (ticket 05): `--project <cwd-or-id>` ─────────────────────
+            // The agent node is created in B's project (B owns the session/tmux, runs in B's cwd,
+            // inherits B's account/permission defaults). A keeps ONLY a `lineage` link with an
+            // `xnode` target, which the ephemeral derivation renders as a dimmed, dotted projection
+            // that co-attaches to B's session as a canvas node (XProjectNode) — interactive, not a
+            // modal. The projection never spawns B's session (`requireExisting`): it joins or waits.
+            if (args.project) {
+              const val = args.project.trim()
+              const st = useProjects.getState()
+              const b =
+                st.projects.find((p) => p.id === val) ??
+                st.projects.find((p) => p.cwd === val)
+              if (!b) {
+                reply({
+                  ok: false,
+                  error: `no project found for --project ${val}; open the folder first so it is a known project`
+                })
+                return
+              }
+              // Resolve B's defaults (B's, NOT A's): account, permission mode (B-aware, so the
+              // `auto` version gate reads B's remote probe when B is an SSH project), and cwd.
+              const bSettings = useSettings.getState().settings
+              const bAccount = resolveNewNodeAccount(undefined, b, bSettings.claudeAccounts)
+              const bPerm = projectPermissionMode(b, agentId)
+              const bCwd = args.cwd || b.cwd
+              const bSsh = nodeSshFor(b.ssh, bCwd)
+              // Create the node in B's SERIALIZED store (B's canvas isn't active, so no live
+              // setNodes). B's node position is a reasonable default; B's user reflows it. The node
+              // carries B's ssh so a remote B launches on B's host when B's canvas mounts.
+              const node = createAgentNode(
+                agentId,
+                b.nodes.length,
+                bCwd,
+                { x: 1248, y: 370 },
+                args.prompt,
+                bSsh,
+                bAccount,
+                bPerm
+              )
+              const serialized = flowToNodeStates([node])[0]
+              st.addNodeToProject(b.id, serialized)
+              // B's project.json must carry the node (a cold start of B reattaches it), and A's
+              // lineage link must persist so the projection re-derives across reloads.
+              void writeDisk()
+              // Side-effect on A: the lineage link whose `xnode` target drives the projection.
+              const lineageLink: Link = {
+                id: newLinkId(),
+                kind: 'lineage',
+                source: { ref: 'node', nodeId: sourceNodeId },
+                target: { ref: 'xnode', projectId: b.id, nodeId: node.id }
+              }
+              commitLinks(st.activeProjectId ?? '', [...linksForProject(st.activeProjectId ?? ''), lineageLink])
+              reply({
+                ok: true,
+                message: `opened ${agentId} in ${b.name}: ${node.id} (an interactive projection was added to your canvas — drive it in place; open ${b.name} to own the session)`,
+                result: { id: node.id, projectId: b.id }
+              })
+              return
+            }
             const count = Math.max(1, Math.min(5, parseInt(args.count || '1', 10) || 1))
             // --group parents the new node(s) into an existing group frame; a worktree-bound
             // group also hands its worktree path down as the cwd (same inheritance as
@@ -8357,7 +9315,7 @@ export function Canvas() {
               if (id === sourceNodeId) return linkEndpointOf(id)
               const m = members.find((x) => x.id === id)
               if (!m) return null
-              const a = m.data.agentId as AgentId | undefined
+              const a = createdAgentId(m.data)
               return { kind: m.type ?? 'terminal', contextCapable: !!a && canContextLink(a) }
             }
             const bridged = bridgeTo(sourceNodeId, memberIds, memberEndpoint).linked
@@ -8485,6 +9443,90 @@ export function Canvas() {
               return
             }
             reply({ ok: false, error: `close-worktree: unknown --mode ${mode} (unbind|remove)` })
+            return
+          }
+          case 'link-branches': {
+            // Declare a stacked-diff dependency: child builds on parent. Writes the git-town lineage
+            // config (the `git-town-branch.<child>.parent` convention, plain `git config`) AND records
+            // a `dependency` link whose two `branch` endpoints render as a dashed edge between the
+            // hosting worktree group frames. Local projects only — same SSH gate as open-worktree.
+            const projStore = useProjects.getState()
+            const project = projStore.getProject(projStore.activeProjectId ?? '')
+            if (project?.ssh) {
+              reply({ ok: false, error: WORKTREE_SSH_NOTICE })
+              return
+            }
+            const parent = sanitizeWorktreeBranch(args.base ?? '')
+            const child = sanitizeWorktreeBranch(args.branch ?? '')
+            if (!parent || !child) {
+              reply({ ok: false, error: 'link-branches: invalid branch name (use --base <parent> --branch <child>)' })
+              return
+            }
+            if (parent === child) {
+              reply({ ok: false, error: 'link-branches: a branch cannot depend on itself' })
+              return
+            }
+            const { repoRoot } = useWorktrees.getState()
+            if (!repoRoot) {
+              reply({ ok: false, error: 'link-branches: this project has no git repository (repo root unknown)' })
+              return
+            }
+            // Write the config FIRST and refuse the link if it failed: a link whose git-town lineage
+            // does not match is the drift the design says to never create.
+            const cfg = await applyDependencyLink(api.git, {
+              id: newLinkId(),
+              kind: 'dependency',
+              source: { ref: 'branch', repoPath: repoRoot, branch: child },
+              target: { ref: 'branch', repoPath: repoRoot, branch: parent }
+            }).catch((e: unknown) => ({ ok: false, message: e instanceof Error ? e.message : String(e) }))
+            if (!cfg.ok) {
+              reply({ ok: false, error: `link-branches: ${cfg.message}` })
+              return
+            }
+            const link: Link = {
+              id: newLinkId(),
+              kind: 'dependency',
+              source: { ref: 'branch', repoPath: repoRoot, branch: child },
+              target: { ref: 'branch', repoPath: repoRoot, branch: parent }
+            }
+            commitLinks(projStore.activeProjectId ?? '', [...linksForProject(projStore.activeProjectId ?? ''), link])
+            reply({ ok: true, message: `linked ${child} → ${parent} (git-town lineage set)` })
+            return
+          }
+          case 'sync-stack': {
+            // Rebase a child branch onto its configured parent, run in the child's OWN worktree cwd
+            // (where the child is already HEAD, so git-town's checkout would be a no-op — the
+            // worktree-rebase caveat). Plain `git rebase`; a conflict stops the rebase and the reply
+            // tells the user to resolve in that terminal. Local projects only.
+            const projStore = useProjects.getState()
+            const project = projStore.getProject(projStore.activeProjectId ?? '')
+            if (project?.ssh) {
+              reply({ ok: false, error: WORKTREE_SSH_NOTICE })
+              return
+            }
+            const child = sanitizeWorktreeBranch(args.branch ?? '')
+            if (!child) {
+              reply({ ok: false, error: 'sync-stack: invalid branch name (use --branch <child>)' })
+              return
+            }
+            const { repoRoot, entries } = useWorktrees.getState()
+            if (!repoRoot) {
+              reply({ ok: false, error: 'sync-stack: this project has no git repository (repo root unknown)' })
+              return
+            }
+            // Resolve the owning worktree: the entry whose checked-out branch IS the child. Running
+            // `git rebase` anywhere else would checkout the child there (yanking whatever was HEAD) —
+            // in its own worktree the child is already HEAD, so the checkout is a no-op. Mirrors
+            // worktreeMerge's listWorktrees→find.
+            const owner = entries.find((e) => e.branch === child)
+            if (!owner) {
+              reply({ ok: false, error: `sync-stack: ${child} is not checked out in any worktree — open it as a worktree first` })
+              return
+            }
+            const res = await api.git
+              .syncBranch(owner.path, child)
+              .catch((e: unknown) => ({ ok: false as const, message: e instanceof Error ? e.message : String(e) }))
+            reply(res.ok ? { ok: true, message: res.message } : { ok: false, error: res.message })
             return
           }
           case 'branch': {
@@ -9150,7 +10192,9 @@ export function Canvas() {
           : [
               // Non-active project: the shared rows read the active canvas's live nodes + per-node
               // registered closures, which don't exist here. Keep the narrow set that works for any
-              // project (Duplicate defers to the store; the rest are list-level).
+              // project (Duplicate defers to the store; the rest are list-level). "Links…" opens the
+              // off-canvas inspector for this background node (ticket 06) — it reads that project's
+              // persisted `Project.links`, so it works without the live canvas.
               {
                 label: 'Duplicate',
                 icon: <IconDuplicate />,
@@ -9158,6 +10202,11 @@ export function Canvas() {
                   useProjects.getState().duplicateNode(projectId, id)
                   void writeDisk()
                 }
+              },
+              {
+                label: 'Links…',
+                icon: <IconLink />,
+                onClick: () => setLinkInspectorNode(id)
               },
               { type: 'separator' },
               { label: 'Close', icon: <IconTrash />, danger: true, onClick: () => closeSession(projectId, id) }
@@ -9676,6 +10725,29 @@ export function Canvas() {
     return true
   }, [commitActiveToStore, writeDisk])
 
+  /** Promote a derived submodule ghost without navigating away from the meta-canvas. Unlike the
+   * human "Open folder" flow, `registerProject` is intentionally non-activating: the auto-linker
+   * needs this canvas to remain mounted so it can replace the ghost with a real projectRef group. */
+  const openSubmoduleProject = useCallback(
+    async (folder: string): Promise<void> => {
+      const metaProjectId = useProjects.getState().activeProjectId
+      if (!metaProjectId) return
+      commitActiveToStore()
+      const probed = await api.workspace.probeFolder(folder)
+      useProjects.getState().registerProject({
+        resolvedCwd: folder,
+        ...(probed ? { probed: { ...probed, closed: false } } : {})
+      })
+      await writeDisk()
+      // If the user travelled while the probe was in flight, registering is still valid but the
+      // old meta-canvas is no longer the surface to refresh. It will discover the project on return.
+      if (useProjects.getState().activeProjectId === metaProjectId) {
+        setSubmoduleRefreshNonce((n) => n + 1)
+      }
+    },
+    [api, commitActiveToStore, writeDisk]
+  )
+
   const renameProject = useCallback(
     (id: string, name: string) => {
       useProjects.getState().renameProject(id, name)
@@ -9853,6 +10925,15 @@ export function Canvas() {
   // travelToNode, not focusNodeById, so a closed project's tab is reopened first).
   useEffect(() => window.nodeTerminal.onFocusNode(travelToNode), [travelToNode])
 
+  // Bridge the node-travel handler to a cross-project projection's `↗` button (ticket 05): the
+  // projection lives on A's canvas but points at B's node, so the jump must switch to B (which
+  // owns the node) and frame it there — `travelToNode` resolves the owning project from the node
+  // id and reopens a closed tab if needed. Same indirection pattern as the focus handler above.
+  useEffect(() => {
+    setTravelNodeHandler(travelToNode)
+    return () => setTravelNodeHandler(null)
+  }, [travelToNode])
+
   // Memory pressure (core/memory-pressure.ts, pushed by the shell): run the renderer's reclaim
   // levers. Both are idempotent and cost only warmth — a reclaimed hidden context re-grants on its
   // next visibility transition, a dropped park re-mounts as an ordinary warm reattach — and the
@@ -10026,6 +11107,28 @@ export function Canvas() {
         run: () => setSpawnTeamDialog({})
       },
       { id: 'new-project', label: 'New project', icon: <IconProject />, run: () => addProject() },
+      {
+        id: 'new-meta-canvas',
+        label: 'New meta-canvas',
+        hint: 'canvas of canvases projects overview',
+        icon: <IconGroup />,
+        run: newMetaCanvas
+      },
+      // "Add project to canvas" — one command per OPEN project (excluding the active canvas itself),
+      // so the user can drop a project onto the active (meta) canvas as a draggable, drillable group.
+      ...useProjects
+        .getState()
+        .projects.filter((p) => !p.closed && p.id !== activeProjectId)
+        .map(
+          (p): Command => ({
+            id: `add-project-to-canvas-${p.id}`,
+            label: `Add “${p.name}” to canvas`,
+            hint: 'meta-canvas project reference drill',
+            section: 'Canvas',
+            icon: <IconGroup />,
+            run: () => addProjectToCanvas(p.id)
+          })
+        ),
       { id: 'clone-repo', label: 'Clone repository…', icon: <IconProject />, run: () => setCloneDialogOpen(true) },
       {
         id: 'new-remote',
@@ -10047,6 +11150,23 @@ export function Canvas() {
           ]
         : []),
       { id: 'zoom-100', label: 'Zoom to 100%', icon: <IconFit />, run: zoomTo100 },
+      // "Link to…" (ticket 06): open the off-canvas link picker for the single selected node —
+      // the only palette entry for authoring a dependency / cross-project / branch link. Hidden
+      // unless exactly one node is selected (a multi-link batch has no UI yet).
+      ...(nodesRef.current.filter((n) => n.selected).length === 1
+        ? [
+            {
+              id: 'link-to',
+              label: 'Link to…',
+              hint: 'connect node cross-project branch dependency',
+              icon: <IconLink />,
+              run: () => {
+                const t = nodesRef.current.find((n) => n.selected)
+                if (t) setLinkPickerNode(t.id)
+              }
+            } as Command
+          ]
+        : []),
       { id: 'save', label: 'Save', icon: <IconSave />, run: () => void persist() },
       // Hidden when the canvas has no restartable agent node — the row would have nothing to act
       // on. `hint` is searchable, so "new model" / "update" find it too.
@@ -10351,6 +11471,14 @@ export function Canvas() {
               </div>
             )
           })()}
+        {drillRef.current && drillRef.current.kind === 'group' && (
+            <DrillBreadcrumb
+              drill={drillRef.current}
+              onExit={exitDrill}
+              onWorktreeAction={onWorktreeAction}
+              isSshProject={isSshProject}
+            />
+          )}
       </div>
       {kanbanOpen && (
         <KanbanView
@@ -10555,6 +11683,34 @@ export function Canvas() {
               mounted in the experimental 'shared' renderer mode; nothing about it exists for the
               default modes. */}
           {glyphLayerActive && <SharedGlyphLayer />}
+          {/* Unopened git submodules on a meta-canvas are derived ghost project tiles. They live in
+              the viewport so they pan/zoom with the map, but never enter `nodes` and therefore can
+              never be selected, moved, autosaved, synced, or mistaken for a real projectRef. */}
+          {submoduleSuggestions.length > 0 && (
+            <ViewportPortal>
+              {submoduleSuggestions.map((suggestion, index) => {
+                const source = nodes.find((node) => node.id === suggestion.sourceGroupId)
+                const x = (source?.position.x ?? 200) + (source?.width ?? 520) + 80
+                const y = (source?.position.y ?? 200) + index * 150
+                const name = suggestion.relativePath.split('/').filter(Boolean).pop() ?? suggestion.relativePath
+                return (
+                  <div
+                    key={`${suggestion.sourceGroupId}:${suggestion.path}`}
+                    className="submodule-ghost nodrag nopan"
+                    style={{ transform: `translate(${x}px, ${y}px)` }}
+                    title={suggestion.path}
+                  >
+                    <span className="submodule-ghost__eyebrow">Unopened submodule</span>
+                    <strong>{name}</strong>
+                    <span className="submodule-ghost__path">{suggestion.relativePath}</span>
+                    <button type="button" onClick={() => void openSubmoduleProject(suggestion.path)}>
+                      Open folder
+                    </button>
+                  </div>
+                )
+              })}
+            </ViewportPortal>
+          )}
           <Controls showInteractive={false} position="bottom-left" onFitView={fitAll}>
             <ControlButton
               className={`canvas-lock-btn${canvasLocked ? ' locked' : ''}`}
@@ -10911,6 +12067,34 @@ export function Canvas() {
           worktreeNote={isSshProject ? WORKTREE_SSH_HINT : 'not a git repository'}
           onSubmit={spawnTeam}
           onCancel={() => setSpawnTeamDialog(null)}
+        />
+      )}
+
+      {/* Off-canvas link authoring (ticket 06). The picker/inspector are opened from the node
+          context menu's Links submenu and the sidebar non-active row. Both resolve the source
+          node's project from the store (a background node's project is not the active one) and
+          write through `commitLinks`, which persists the full `Project.links` and, for the active
+          project, re-derives the on-canvas edge arrays + off-canvas ref. */}
+      {linkPickerNode &&
+        (() => {
+          const pid = projectOfNode(linkPickerNode)
+          return pid ? (
+            <LinkTargetPicker
+              sourceNodeId={linkPickerNode}
+              sourceProjectId={pid}
+              onConfirm={(link) => {
+                if (pid) commitLinks(pid, [...linksForProject(pid), link])
+                setLinkPickerNode(null)
+              }}
+              onCancel={() => setLinkPickerNode(null)}
+            />
+          ) : null
+        })()}
+      {linkInspectorNode && (
+        <LinkInspectorPanel
+          nodeId={linkInspectorNode}
+          mount="portal"
+          onClose={() => setLinkInspectorNode(null)}
         />
       )}
 

--- a/src/renderer/components/DrillBreadcrumb.tsx
+++ b/src/renderer/components/DrillBreadcrumb.tsx
@@ -1,0 +1,150 @@
+import { useEffect } from 'react'
+import { useProjects } from '../state/projects'
+import { useWorktrees, WORKTREE_STATUS_POLL_MS } from '../state/worktrees'
+import type { DrillContext } from '../state/workspace'
+import type { WorktreeAction } from '../nodes/GroupNode'
+
+/**
+ * The drill breadcrumb (ticket 07), promoted into a component so it can SUBSCRIBE to the worktrees
+ * store (an inline IIFE in Canvas's JSX can't call hooks). For a plain group drill it shows a
+ * one-line "Drilled into {title} — Esc to return" + ← back. For a
+ * worktree-bound group drill (ticket 08) it ALSO carries the worktree's branch chip + dirty/ahead/
+ * behind + Merge/Unbind/Remove — the chrome that normally lives on the GroupNode frame, which leaves
+ * the node-set when drilled (only the group's children are shown), so the worktree's git context has
+ * to move to a canvas-level strip.
+ *
+ * The status poll reuses the SINGLE store poller invariant (no second poller, no second `git status`):
+ * a page-visibility-gated tick pokes `useWorktrees.refreshStatus(wtPath, groupId)`, exactly like
+ * GroupNode's per-frame tick minus the IntersectionObserver (the drilled canvas IS the viewport, so
+ * the observer is trivially always-intersecting — dropped). The store's throttle floor coalesces.
+ * On an SSH project the poll is OFF (worktrees unsupported in v1); the branch chip shows with no
+ * live status, matching GroupNode's contract.
+ */
+export function DrillBreadcrumb({
+  drill,
+  onExit,
+  onWorktreeAction,
+  isSshProject
+}: {
+  drill: DrillContext
+  onExit: () => void
+  onWorktreeAction: (groupId: string, action: WorktreeAction) => void
+  isSshProject: boolean
+}) {
+  // For a group drill, `proj` is the project the drilled node lives in and `title` is the
+  // node's own title. For a cross-project drill (09), `proj` is the REFERENCED (target) project —
+  // `drill.projectId` is the SOURCE meta-canvas (only `exitDrill` needs it) — and the title is the
+  // target project's name. There is no node and no worktree context for a project-ref drill.
+  const targetProjId = drill.kind === 'project-ref' ? drill.targetId : drill.projectId
+  const proj = useProjects((s) => s.projects.find((p) => p.id === targetProjId))
+  const node = drill.kind === 'group' ? proj?.nodes.find((n) => n.id === drill.groupId) : undefined
+  const title =
+    drill.kind === 'project-ref'
+      ? proj?.name ?? 'project'
+      : node?.title ?? 'group'
+
+  // Worktree context only exists for a GROUP drill whose group is worktree-bound.
+  const wt = drill.kind === 'group' ? node?.worktree : undefined
+  const groupId = drill.kind === 'group' ? drill.groupId : undefined
+  // The SSH gate matches GroupNode: a remote checkout's status can't be read by local git, so the
+  // poll is off (and `wtPath` is undefined, which short-circuits the effect below).
+  const wtPath = wt && !isSshProject ? wt.path : undefined
+  const status = useWorktrees((s) => (wt ? s.statusByPath[wt.path] : undefined))
+  const stale = useWorktrees((s) => (groupId ? s.staleGroupIds.includes(groupId) : false))
+
+  // Page-visibility-gated status tick (no IntersectionObserver — the drilled canvas fills the
+  // viewport). Same cadence + store as GroupNode; the store's throttle decides whether a read fires.
+  useEffect(() => {
+    if (!wtPath || !groupId) return
+    const poke = (): void => {
+      if (document.visibilityState === 'hidden') return
+      void useWorktrees.getState().refreshStatus(wtPath, groupId)
+    }
+    poke()
+    const t = setInterval(poke, WORKTREE_STATUS_POLL_MS)
+    document.addEventListener('visibilitychange', poke)
+    return () => {
+      clearInterval(t)
+      document.removeEventListener('visibilitychange', poke)
+    }
+  }, [wtPath, groupId])
+
+  return (
+    <div className="announce-banner announce-banner--info drill-breadcrumb">
+      <span className="announce-banner__dot" />
+      <div className="announce-banner__content">
+        <span className="announce-banner__body">
+          {drill.kind === 'project-ref' ? 'Drilled into project ' : 'Drilled into '}
+          <strong>{title}</strong>{' — '}
+          {drill.kind === 'group' ? 'press Esc to return' : 'Esc to return'}
+        </span>
+        {wt && groupId && (
+          <span className="drill-breadcrumb__wt">
+            {stale ? (
+              <span
+                className="group-node__branch group-node__branch--stale"
+                title={`Worktree directory is gone: ${wt.path}\nUnbind to detach this group from it.`}
+              >
+                ⎇ {wt.branch} · missing
+              </span>
+            ) : (
+              <span className="group-node__branch" title={wt.path}>
+                ⎇ {status?.branch || wt.branch}
+                {status && status.dirty > 0 && (
+                  <em className="group-node__wt-dirty" title={`${status.dirty} changed file(s)`}>
+                    {' '}
+                    · {status.dirty} changed
+                  </em>
+                )}
+                {status && status.ahead > 0 && (
+                  <em className="group-node__wt-ahead" title={`${status.ahead} commit(s) ahead`}>
+                    {' '}
+                    · {status.ahead}↑
+                  </em>
+                )}
+                {status && status.behind > 0 && (
+                  <em className="group-node__wt-behind" title={`${status.behind} commit(s) behind`}>
+                    {' '}
+                    · {status.behind}↓
+                  </em>
+                )}
+              </span>
+            )}
+            {!stale && (
+              <button
+                className="group-node__wt-btn"
+                title="Merge to main"
+                onClick={() => onWorktreeAction(groupId, 'merge')}
+              >
+                ⤴
+              </button>
+            )}
+            <button
+              className="group-node__wt-btn"
+              title={
+                stale
+                  ? 'Unbind (the directory is gone — also prunes the stale git registration)'
+                  : 'Unbind worktree (keeps the worktree on disk)'
+              }
+              onClick={() => onWorktreeAction(groupId, 'unbind')}
+            >
+              Unbind
+            </button>
+            {!stale && (
+              <button
+                className="group-node__wt-btn"
+                title="Remove worktree"
+                onClick={() => onWorktreeAction(groupId, 'remove')}
+              >
+                ✕
+              </button>
+            )}
+          </span>
+        )}
+      </div>
+      <button className="announce-banner__close" title="Return to canvas (Esc)" onClick={onExit}>
+        ← back
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -336,3 +336,11 @@ export const IconCanvasView = () => (
     <rect x="3.5" y="9.5" width="5.5" height="5" rx="1" />
   </svg>
 )
+
+/** Chain link — the off-canvas link authoring surface (ticket 06): picker/inspector entry points. */
+export const IconLink = () => (
+  <svg {...S}>
+    <path d="M9 12a3.5 3.5 0 0 0 5 0l2.5-2.5a3.5 3.5 0 0 0-5-5L10 6" />
+    <path d="M15 12a3.5 3.5 0 0 0-5 0L7.5 14.5a3.5 3.5 0 0 0 5 5L14 18" />
+  </svg>
+)

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
-import { IconChat, IconMic, IconSearch } from '../icons'
+import { IconChat, IconMic, IconSearch, IconLink } from '../icons'
 import { ContextMeter } from '../ContextMeter'
 import { useAgentStatus } from '../../state/agentStatus'
 import { useCardPanel } from '../../state/cardPanel'
@@ -13,6 +13,7 @@ import { CardMetaBar } from './CardMetaBar'
 import { ModalTerminal } from './ModalTerminal'
 import { BrowserSurface } from '../../nodes/BrowserSurface'
 import { BrowserDrivingIndicator } from '../../nodes/BrowserDrivingChip'
+import { LinkInspectorPanel } from '../links/LinkInspectorPanel'
 import { NoteMarkdown } from '../NoteMarkdown'
 import { relativeTime } from '../../lib/relativeTime'
 
@@ -54,6 +55,8 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
   // choice is remembered (localStorage) — once collapsed, later cards open collapsed too.
   const panelOpen = useCardPanel((s) => s.open)
   const togglePanel = useCardPanel((s) => s.toggle)
+  // Off-canvas link inspector (ticket 06): a portal over the modal, opened from the header 🔗.
+  const [linksOpen, setLinksOpen] = useState(false)
   const isTerminal = session.kind === 'terminal'
   const isBrowser = session.kind === 'browser'
 
@@ -190,6 +193,14 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
           >
             <IconChat />
           </button>
+          <button
+            className="kanban-modal__action"
+            title="Links — connect to a node, foreign canvas, or branch"
+            aria-pressed={linksOpen}
+            onClick={() => setLinksOpen((v) => !v)}
+          >
+            <IconLink />
+          </button>
           <button className="kanban-modal__action" title="Open on canvas" onClick={onOpenCanvas}>
             ↗
           </button>
@@ -289,6 +300,7 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
           {panelOpen && <BoardLogPanel card={session} />}
         </div>
       </div>
+      {linksOpen && <LinkInspectorPanel nodeId={session.id} mount="portal" onClose={() => setLinksOpen(false)} />}
     </div>,
     document.body
   )

--- a/src/renderer/components/links/LinkInspectorPanel.tsx
+++ b/src/renderer/components/links/LinkInspectorPanel.tsx
@@ -1,0 +1,203 @@
+import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useShallow } from 'zustand/react/shallow'
+import { useProjects } from '../../state/projects'
+import { useSession } from '../../session/session'
+import type { Link } from '@shared/types'
+import {
+  linksForNode,
+  describeEndpoint,
+  offCanvasLinkColor,
+  removeDependencyLinkConfig,
+  isBranchDependencyLink,
+  type ProjectLookup
+} from '../../lib/link-authoring'
+import { LinkTargetPicker } from './LinkTargetPicker'
+import { commitLinksThroughCanvas } from './link-commit'
+
+interface LinkInspectorPanelProps {
+  /** The node whose links this panel lists. */
+  nodeId: string
+  /** Flyout = a sibling-of-root panel (canvas node header button). Portal = a body portal
+   *  (card modal / sidebar). The body is identical; only the mount + scrim differ. */
+  mount: 'flyout' | 'portal'
+  /** Portal mode only: close handler (the flyout's parent owns its own open state). */
+  onClose?: () => void
+}
+
+const KIND_LABELS: Record<string, string> = {
+  context: 'context',
+  lineage: 'lineage',
+  dependency: 'dependency'
+}
+
+/**
+ * `LinkInspectorPanel` (ticket 06): lists every link a node is an endpoint of — outgoing (this node
+ * is the source) and incoming (this node is the target) — and deletes them. It is ALSO a full
+ * authoring surface: the footer's "Add link" opens `LinkTargetPicker`, so the inspector is the one
+ * place to both see and change a node's links (the card-modal requirement).
+ *
+ * Source of truth is `Project.links` (persisted); for the node's project that already carries the
+ * on-canvas `context`/`lineage` links too, so the inspector shows one combined list without needing
+ * the canvas's live edge arrays. A just-drawn on-canvas link appears here after the next debounced
+ * save (the picker/inspector write through `commitLinks` immediately, so off-canvas mutations are
+ * never stale). Unresolvable targets render as a muted "unavailable" row whose `×` is a no-confirm
+ * lazy-prune (deleting a link to a gone node is safe and tidies the project).
+ *
+ * Two mount modes share ONE body (the `.term-copy-pill`/`CardModal` "one component, two surfaces"
+ * rule): `flyout` mirrors the comments flyout (sibling-of-root, no scrim); `portal` mirrors
+ * `BoardLogPanel` in the card modal (body portal + scrim, Esc closes).
+ */
+export function LinkInspectorPanel({ nodeId, mount, onClose }: LinkInspectorPanelProps) {
+  const { api } = useSession()
+  const [adding, setAdding] = useState(false)
+
+  // The projects store, filtered to the fields the inspector reads. useShallow: the map derives a
+  // new array each call.
+  const projects = useProjects(
+    useShallow((s) =>
+      s.projects.map((p) => ({ id: p.id, name: p.name, nodes: p.nodes, links: p.links ?? [] }) as ProjectLookup & { links: Link[] })
+    )
+  )
+
+  // Which project holds this node, and its links. Node ids are globally unique across projects.
+  const { projectId, allLinks } = useMemo(() => {
+    for (const p of projects) {
+      if (p.nodes.some((n) => n.id === nodeId)) {
+        return { projectId: p.id, allLinks: p.links }
+      }
+    }
+    return { projectId: null, allLinks: [] as Link[] }
+  }, [projects, nodeId])
+
+  const { outgoing, incoming } = useMemo(() => linksForNode(allLinks, nodeId), [allLinks, nodeId])
+
+  const commit = (next: Link[]) => {
+    if (!projectId) return
+    if (commitLinksThroughCanvas(projectId, next)) return
+    // Standalone render fallback (component tests/Storybook): there is no live React Flow state to
+    // reconcile, so a direct store commit is safe and keeps the component independently usable.
+    const stored = useProjects.getState().getProject(projectId)
+    useProjects
+      .getState()
+      .commitCanvas(projectId, stored?.nodes ?? [], stored?.viewport ?? { x: 0, y: 0, zoom: 1 }, next.length ? next : undefined)
+  }
+
+  const deleteLink = (id: string) => {
+    if (!projectId) return
+    const removed = allLinks.find((l) => l.id === id)
+    const next = allLinks.filter((l) => l.id !== id)
+    commit(next)
+    // A branch-dependency link OWNS a git-town lineage config entry: dropping the link must also
+    // `git config --unset` the parent, or the config drifts from the (now gone) link set. Fire AFTER
+    // the link is removed so the UI updates immediately; a failed unset is non-fatal (the lineage is
+    // already gone from nodeterm's side — git-town just keeps a stale parent key until re-run).
+    if (removed && isBranchDependencyLink(removed)) {
+      void removeDependencyLinkConfig(api.git, removed).catch(() => {})
+    }
+  }
+
+  const body = (
+    <div className="link-inspector">
+      <div className="link-inspector__head">
+        <span className="link-inspector__title">Links</span>
+        {mount === 'portal' && (
+          <button type="button" className="link-inspector__close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        )}
+      </div>
+
+      <div className="link-inspector__body">
+        {outgoing.length === 0 && incoming.length === 0 && (
+          <p className="link-inspector__empty">No links yet. Add one to connect this node to another node, a foreign canvas, or a branch.</p>
+        )}
+        {outgoing.length > 0 && (
+          <div className="link-inspector__group">
+            <span className="link-inspector__group-label">Outgoing</span>
+            {outgoing.map((l) => (
+              <LinkRow key={l.id} link={l} projects={projects} onDelete={() => deleteLink(l.id)} />
+            ))}
+          </div>
+        )}
+        {incoming.length > 0 && (
+          <div className="link-inspector__group">
+            <span className="link-inspector__group-label">Incoming</span>
+            {incoming.map((l) => (
+              <LinkRow key={l.id} link={l} projects={projects} onDelete={() => deleteLink(l.id)} incoming />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <button type="button" className="link-inspector__add" onClick={() => setAdding(true)}>
+        + Add link
+      </button>
+
+      {adding && projectId && (
+        <LinkTargetPicker
+          sourceNodeId={nodeId}
+          sourceProjectId={projectId}
+          onConfirm={(link) => {
+            commit([...allLinks, link])
+            setAdding(false)
+          }}
+          onCancel={() => setAdding(false)}
+        />
+      )}
+    </div>
+  )
+
+  if (mount === 'flyout')
+    return (
+      <div className="term-node__links nodrag nowheel" onMouseDown={(e) => e.stopPropagation()}>
+        {body}
+      </div>
+    )
+  return createPortal(
+    <div className="confirm-overlay link-inspector-overlay" onClick={onClose}>
+      <div className="link-inspector-portal" onClick={(e) => e.stopPropagation()}>
+        {body}
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+/** One link row: colored kind chip · the OTHER endpoint's description · optional purpose · ×. */
+function LinkRow({
+  link,
+  projects,
+  onDelete,
+  incoming
+}: {
+  link: Link
+  projects: readonly ProjectLookup[]
+  onDelete: () => void
+  incoming?: boolean
+}) {
+  // The "other" endpoint is the one that is NOT this node. For an outgoing link that's the target;
+  // for incoming it's the source. (Both could be non-node — a branch/xnode — which describeEndpoint
+  // handles.)
+  const other = incoming ? link.source : link.target
+  const desc = describeEndpoint(other, projects)
+  const color = offCanvasLinkColor(link)
+  const purpose = typeof link.meta?.purpose === 'string' ? (link.meta.purpose as string) : ''
+  return (
+    <div className="link-row">
+      <span className="link-row__kind" style={{ color }}>
+        {KIND_LABELS[link.kind] ?? link.kind}
+      </span>
+      <span className="link-row__target">
+        <span className={desc.available ? '' : 'unavailable'}>
+          {incoming ? '← ' : '→ '}
+          {desc.label}
+        </span>
+        {purpose && <span className="link-row__purpose">{purpose}</span>}
+      </span>
+      <button type="button" className="link-row__delete" onClick={onDelete} aria-label="Remove link" title="Remove link">
+        ×
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/links/LinkTargetPicker.tsx
+++ b/src/renderer/components/links/LinkTargetPicker.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useShallow } from 'zustand/react/shallow'
+import { useDialogStack } from '../dialog-stack'
+import { BranchSelect } from '../BranchSelect'
+import { useProjects } from '../../state/projects'
+import { activeSessionApi } from '../../session/session'
+import type { Link, LinkKind, Endpoint } from '@shared/types'
+import {
+  resolveEndpoint,
+  describeEndpoint,
+  kindAllowed,
+  linkKindEndpointOf,
+  newLinkId,
+  offCanvasLinkColor,
+  type PickerSelection,
+  type ProjectLookup
+} from '../../lib/link-authoring'
+
+interface LinkTargetPickerProps {
+  /** The node the new link originates from (the `source` endpoint). */
+  sourceNodeId: string
+  /** That node's project — decides node vs xnode classification for a chosen target. */
+  sourceProjectId: string
+  onConfirm: (link: Link) => void
+  onCancel: () => void
+}
+
+/** The link kinds the kind dropdown offers. `note` is NOT a persisted kind (a sticky→terminal note
+ *  persists as `context`), so only the real `LinkKind`s appear. */
+const KIND_OPTIONS: LinkKind[] = ['context', 'lineage', 'dependency']
+const KIND_LABELS: Record<LinkKind, string> = {
+  context: 'context (read each other / note)',
+  lineage: 'lineage (spawned by — display only)',
+  dependency: 'dependency (waits on / blocks on)'
+}
+
+/**
+ * `LinkTargetPicker` (ticket 06): a modal to author ANY-kind link OFF-canvas — the only path for a
+ * `dependency`, a cross-project (`xnode`) target, or a cross-repo (`branch`) target. The on-canvas
+ * edge-draw (`onConnect`) stays the fast path for same-canvas `context`/note.
+ *
+ * Two tabs: **Node** lists every open, non-unavailable project's serialized nodes (the active one
+ * expanded); picking one auto-classifies `node` vs `xnode` via `resolveEndpoint` (the user never
+ * picks that distinction). **Branch** picks a repo branch from the source project's repo root.
+ * A kind dropdown is constrained by `kindAllowed` against the source + target endpoints; an optional
+ * `purpose` is the only "name" a link gets. Confirm builds a `Link` and hands it to `onConfirm`.
+ */
+export function LinkTargetPicker({ sourceNodeId, sourceProjectId, onConfirm, onCancel }: LinkTargetPickerProps) {
+  const ownsKeyboard = useDialogStack()
+  const [tab, setTab] = useState<'node' | 'branch'>('node')
+  const [nodeSel, setNodeSel] = useState<PickerSelection | null>(null)
+  const [branch, setBranch] = useState('')
+  const [branches, setBranches] = useState<string[]>([])
+  const [kind, setKind] = useState<LinkKind>('dependency')
+  const [purpose, setPurpose] = useState('')
+
+  // The projects the picker reads from — open + non-unavailable. Node titles/agent ids come from the
+  // serialized `nodes`. useShallow: the filter derives a new array each call.
+  const projects = useProjects(
+    useShallow((s) =>
+      s.projects
+        .filter((p) => !p.closed && !p.unavailable)
+        .map((p) => ({ id: p.id, name: p.name, nodes: p.nodes, ssh: !!p.ssh }) as ProjectLookup & { ssh: boolean })
+    )
+  )
+
+  const sourceProject = projects.find((p) => p.id === sourceProjectId)
+  const sourceNode = sourceProject?.nodes.find((n) => n.id === sourceNodeId)
+  const sourceEp = useMemo(() => (sourceNode ? linkKindEndpointOf(sourceNode) : null), [sourceNode])
+
+  // The branch tab's repo root is the SOURCE project's repo root (a branch endpoint is a repo ref,
+  // not a node). Fetch branches the same way WorktreeDialog does — fire-and-forget; a failed read
+  // just leaves the field free-text (BranchSelect allows custom refs).
+  useEffect(() => {
+    if (tab !== 'branch') return
+    const root = sourceProjectId ? useProjects.getState().getProject(sourceProjectId)?.cwd : null
+    if (!root) return
+    let alive = true
+    void activeSessionApi()
+      .git.status(root)
+      .then((s) => {
+        if (alive) setBranches(s.branches ?? [])
+      })
+      .catch(() => {
+        if (alive) setBranches([])
+      })
+    return () => {
+      alive = false
+    }
+  }, [tab, sourceProjectId])
+
+  // The resolved target endpoint + its capability descriptor (for the kind constraint).
+  const targetEp: Endpoint | null = useMemo(() => {
+    if (tab === 'branch') {
+      const b = branch.trim()
+      return b ? { ref: 'branch', repoPath: repoRootOf(sourceProjectId), branch: b } : null
+    }
+    return nodeSel ? resolveEndpoint(nodeSel, sourceProjectId) : null
+  }, [tab, branch, nodeSel, sourceProjectId])
+
+  const targetDescriptor = useMemo(() => {
+    if (!targetEp) return null
+    if (targetEp.ref === 'branch') return { kind: 'branch', contextCapable: false }
+    // Find the chosen node to derive its capability (a foreign node is still a real node).
+    const nodeId = targetEp.nodeId
+    const proj =
+      targetEp.ref === 'xnode' ? projects.find((p) => p.id === targetEp.projectId) : projects.find((p) => p.nodes.some((n) => n.id === nodeId))
+    const node = proj?.nodes.find((n) => n.id === nodeId)
+    return node ? linkKindEndpointOf(node) : null
+  }, [targetEp, projects])
+
+  const canConfirm =
+    !!sourceEp &&
+    !!targetEp &&
+    !!targetDescriptor &&
+    (tab === 'branch' ? !!branch.trim() : !!nodeSel) &&
+    kindAllowed(kind, sourceEp, targetDescriptor)
+
+  const submit = () => {
+    if (!canConfirm || !targetEp) return
+    const link: Link = {
+      id: newLinkId(),
+      kind,
+      source: { ref: 'node', nodeId: sourceNodeId },
+      target: targetEp,
+      ...(purpose.trim() ? { meta: { purpose: purpose.trim() } } : {})
+    }
+    onConfirm(link)
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!ownsKeyboard()) return
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      submit()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      onCancel()
+    }
+  }
+
+  const targetDesc = targetEp ? describeEndpoint(targetEp, projects) : null
+
+  return createPortal(
+    <div className="confirm-overlay" onClick={onCancel}>
+      <div className="confirm link-picker" onClick={(e) => e.stopPropagation()} onKeyDown={onKeyDown}>
+        <p className="confirm__msg">Link to… — connect this node to another node, a foreign canvas, or a repo branch.</p>
+
+        <div className="link-picker__tabs">
+          <button type="button" className={tab === 'node' ? 'link-picker__tab active' : 'link-picker__tab'} onClick={() => setTab('node')}>
+            Node
+          </button>
+          <button type="button" className={tab === 'branch' ? 'link-picker__tab active' : 'link-picker__tab'} onClick={() => setTab('branch')}>
+            Branch
+          </button>
+        </div>
+
+        {tab === 'node' ? (
+          <div className="link-picker__list">
+            {projects.map((p) => (
+              <ProjectNodeSection
+                key={p.id}
+                project={p}
+                sourceProjectId={sourceProjectId}
+                sourceNodeId={sourceNodeId}
+                selected={nodeSel?.kind === 'node' && nodeSel.projectId === p.id ? nodeSel.nodeId : null}
+                onPick={(nodeId) => setNodeSel({ kind: 'node', projectId: p.id, nodeId })}
+              />
+            ))}
+            {projects.length === 0 && <p className="link-picker__empty">No open projects to link to.</p>}
+          </div>
+        ) : (
+          <label className="link-picker__field">
+            <span className="link-picker__field-label">Branch</span>
+            <BranchSelect
+              value={branch}
+              onChange={setBranch}
+              options={branches}
+              placeholder="pick a branch…"
+              allowCustom
+              customPlaceholder="type a ref (tag / SHA / origin/x)…"
+            />
+          </label>
+        )}
+
+        <label className="link-picker__field">
+          <span className="link-picker__field-label">Kind</span>
+          <select className="link-picker__select" value={kind} onChange={(e) => setKind(e.target.value as LinkKind)}>
+            {KIND_OPTIONS.map((k) => {
+              const allowed = sourceEp && targetDescriptor ? kindAllowed(k, sourceEp, targetDescriptor) : false
+              return (
+                <option key={k} value={k} disabled={!allowed}>
+                  {KIND_LABELS[k]}
+                  {allowed ? '' : ' — not allowed for this pair'}
+                </option>
+              )
+            })}
+          </select>
+        </label>
+
+        <label className="link-picker__field">
+          <span className="link-picker__field-label">Purpose (optional)</span>
+          <input
+            className="confirm__input"
+            value={purpose}
+            placeholder="why this link exists…"
+            spellCheck={false}
+            onChange={(e) => setPurpose(e.target.value)}
+          />
+        </label>
+
+        {targetDesc && (
+          <p className={`link-picker__target${targetDesc.available ? '' : ' unavailable'}`}>
+            → {targetDesc.label}
+            {!targetDesc.available && ' (unavailable)'}
+          </p>
+        )}
+
+        <div className="confirm__actions">
+          <button type="button" className="confirm__btn" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" className="confirm__btn confirm__btn--primary" disabled={!canConfirm} onClick={submit}>
+            Link
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+/** One project's nodes as a collapsible section in the Node tab. */
+function ProjectNodeSection({
+  project,
+  sourceProjectId,
+  sourceNodeId,
+  selected,
+  onPick
+}: {
+  project: ProjectLookup
+  sourceProjectId: string
+  sourceNodeId: string
+  selected: string | null
+  onPick: (nodeId: string) => void
+}) {
+  const [open, setOpen] = useState(project.id === sourceProjectId)
+  const foreign = project.id !== sourceProjectId
+  return (
+    <div className="link-picker__project">
+      <button type="button" className="link-picker__project-head" onClick={() => setOpen((v) => !v)}>
+        <span className="link-picker__chev">{open ? '▾' : '▸'}</span>
+        <span className="link-picker__project-name">
+          {project.name}
+          {foreign && <span className="link-picker__foreign"> · cross-project</span>}
+        </span>
+      </button>
+      {open && (
+        <div className="link-picker__nodes">
+          {project.nodes.map((n) => {
+            const isSource = n.id === sourceNodeId && !foreign
+            return (
+              <button
+                type="button"
+                key={n.id}
+                className={selected === n.id ? 'link-picker__node selected' : 'link-picker__node'}
+                disabled={isSource}
+                onClick={() => onPick(n.id)}
+                title={isSource ? 'this is the source node' : n.title || n.id}
+              >
+                <span className="link-picker__node-kind">{nodeKindGlyph(n.kind)}</span>
+                <span className="link-picker__node-title">{n.title || n.id}</span>
+                {n.agentId && <span className="link-picker__node-agent">{n.agentId}</span>}
+                {foreign && <span className="link-picker__node-xnode">xnode</span>}
+              </button>
+            )
+          })}
+          {project.nodes.length === 0 && <p className="link-picker__empty">No nodes.</p>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** A one-glyph label for a node kind in the picker list. */
+function nodeKindGlyph(kind: string): string {
+  switch (kind) {
+    case 'terminal':
+      return '▣'
+    case 'sticky':
+      return '🗒'
+    case 'group':
+      return '▢'
+    case 'editor':
+      return '📄'
+    case 'diff':
+      return '⇄'
+    case 'web':
+    case 'browser':
+      return '🌐'
+    case 'video':
+      return '▶'
+    case 'dino':
+      return '🦖'
+    default:
+      return '•'
+  }
+}
+
+/** Resolve the repo root for the branch endpoint from the projects store. A branch link's
+ *  `repoPath` is the repo root (the same root WorktreeDialog / Source Control operate on). */
+function repoRootOf(projectId: string): string {
+  return useProjects.getState().getProject(projectId)?.cwd ?? ''
+}
+
+// Re-export for the inspector's kind chip so the two surfaces share one color rule.
+export { offCanvasLinkColor }

--- a/src/renderer/components/links/link-commit.test.ts
+++ b/src/renderer/components/links/link-commit.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Link } from '@shared/types'
+import { commitLinksThroughCanvas, setLinkCommitHandler } from './link-commit'
+
+const links: Link[] = [{
+  id: 'l1',
+  kind: 'context',
+  source: { ref: 'node', nodeId: 'a' },
+  target: { ref: 'node', nodeId: 'b' }
+}]
+
+afterEach(() => setLinkCommitHandler(null))
+
+describe('link commit bridge', () => {
+  it('routes every inspector mutation through Canvas while mounted', () => {
+    const commit = vi.fn()
+    setLinkCommitHandler(commit)
+    expect(commitLinksThroughCanvas('p1', links)).toBe(true)
+    expect(commit).toHaveBeenCalledWith('p1', links)
+  })
+
+  it('reports an unavailable funnel instead of pretending a write landed', () => {
+    expect(commitLinksThroughCanvas('p1', links)).toBe(false)
+  })
+})

--- a/src/renderer/components/links/link-commit.ts
+++ b/src/renderer/components/links/link-commit.ts
@@ -1,0 +1,17 @@
+import type { Link } from '@shared/types'
+
+/** Canvas owns live-edge + persisted-link reconciliation, but React Flow instantiates node
+ * components outside its prop tree. Register the one commit funnel here so header/card inspectors
+ * cannot mutate the project store behind Canvas's edge refs and lose their edit on autosave. */
+let handler: ((projectId: string, links: Link[]) => void) | null = null
+
+export function setLinkCommitHandler(next: ((projectId: string, links: Link[]) => void) | null): void {
+  handler = next
+}
+
+/** Returns false only outside a mounted Canvas (isolated component tests/story renders). */
+export function commitLinksThroughCanvas(projectId: string, links: Link[]): boolean {
+  if (!handler) return false
+  handler(projectId, links)
+  return true
+}

--- a/src/renderer/lib/link-authoring.test.ts
+++ b/src/renderer/lib/link-authoring.test.ts
@@ -1,0 +1,503 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveEndpoint,
+  describeEndpoint,
+  linksForNode,
+  kindAllowed,
+  linkKindEndpointOf,
+  newLinkId,
+  offCanvasLinkColor,
+  isBranchDependencyLink,
+  isCrossProjectDependencyLink,
+  depHostEdges,
+  applyDependencyLink,
+  removeDependencyLinkConfig,
+  type ProjectLookup
+} from './link-authoring'
+import { contextLink, dependencyLink, lineageLink, nodeEndpoints } from './noteLink'
+import type { CanvasNodeState, Link } from '@shared/types'
+
+const node = (id: string, over: Partial<CanvasNodeState> = {}): CanvasNodeState =>
+  ({
+    id,
+    kind: 'terminal',
+    position: { x: 0, y: 0 },
+    size: { width: 400, height: 240 },
+    title: id,
+    color: '#888',
+    group: null,
+    ...over
+  }) as CanvasNodeState
+
+const proj = (id: string, name: string, nodes: CanvasNodeState[], over: Partial<ProjectLookup> = {}): ProjectLookup => ({
+  id,
+  name,
+  nodes,
+  ...over
+})
+
+describe('resolveEndpoint', () => {
+  it('classifies a node in the source project as ref:node', () => {
+    expect(resolveEndpoint({ kind: 'node', projectId: 'p1', nodeId: 'a' }, 'p1')).toEqual({
+      ref: 'node',
+      nodeId: 'a'
+    })
+  })
+
+  it('classifies a node in a DIFFERENT project as ref:xnode', () => {
+    expect(resolveEndpoint({ kind: 'node', projectId: 'p2', nodeId: 'b' }, 'p1')).toEqual({
+      ref: 'xnode',
+      projectId: 'p2',
+      nodeId: 'b'
+    })
+  })
+
+  it('classifies a branch selection as ref:branch', () => {
+    expect(resolveEndpoint({ kind: 'branch', repoPath: '/repo', branch: 'main' }, 'p1')).toEqual({
+      ref: 'branch',
+      repoPath: '/repo',
+      branch: 'main'
+    })
+  })
+
+  it('branch is unaffected by the source project', () => {
+    // A branch endpoint is the same regardless of which project the link originates from.
+    expect(resolveEndpoint({ kind: 'branch', repoPath: '/r', branch: 'dev' }, 'p1')).toEqual(
+      resolveEndpoint({ kind: 'branch', repoPath: '/r', branch: 'dev' }, 'p2')
+    )
+  })
+})
+
+describe('describeEndpoint', () => {
+  const projects = [
+    proj('p1', 'Alpha', [node('a1', { title: 'api-service' })]),
+    proj('p2', 'Beta', [node('b1', { title: 'worker' })])
+  ]
+
+  it('describes a same-project node with the project name + title', () => {
+    expect(describeEndpoint({ ref: 'node', nodeId: 'a1' }, projects)).toEqual({
+      label: 'Alpha · api-service',
+      available: true
+    })
+  })
+
+  it('describes a foreign-project (xnode) target from its named project', () => {
+    expect(describeEndpoint({ ref: 'xnode', projectId: 'p2', nodeId: 'b1' }, projects)).toEqual({
+      label: 'Beta · worker',
+      available: true
+    })
+  })
+
+  it('describes a branch as repoName · branch', () => {
+    expect(describeEndpoint({ ref: 'branch', repoPath: '/repos/nodeterm', branch: 'main' }, projects)).toEqual({
+      label: 'nodeterm · main',
+      available: true
+    })
+  })
+
+  it('falls back to the node id when the title is empty', () => {
+    expect(describeEndpoint({ ref: 'node', nodeId: 'a1' }, [proj('p1', 'Alpha', [node('a1', { title: '' })])])).toEqual({
+      label: 'Alpha · a1',
+      available: true
+    })
+  })
+
+  it('reports an xnode target as unavailable when the project is missing', () => {
+    expect(describeEndpoint({ ref: 'xnode', projectId: 'gone', nodeId: 'b1' }, projects)).toEqual({
+      label: 'unavailable project',
+      available: false
+    })
+  })
+
+  it('reports an xnode target as unavailable when the project is marked unavailable', () => {
+    const withUnavail = [proj('p2', 'Beta', [node('b1')], { unavailable: true })]
+    expect(describeEndpoint({ ref: 'xnode', projectId: 'p2', nodeId: 'b1' }, withUnavail)).toEqual({
+      label: 'unavailable project',
+      available: false
+    })
+  })
+
+  it('reports an xnode target as unavailable when the node is gone from a live project', () => {
+    expect(describeEndpoint({ ref: 'xnode', projectId: 'p2', nodeId: 'ghost' }, projects)).toEqual({
+      label: 'Beta · unavailable node',
+      available: false
+    })
+  })
+
+  it('reports a node endpoint as unavailable when no project holds it', () => {
+    expect(describeEndpoint({ ref: 'node', nodeId: 'ghost' }, projects)).toEqual({
+      label: 'unavailable node',
+      available: false
+    })
+  })
+})
+
+describe('linksForNode', () => {
+  const links: Link[] = [
+    { id: 'l1', kind: 'context', source: { ref: 'node', nodeId: 'me' }, target: { ref: 'node', nodeId: 'other' } },
+    { id: 'l2', kind: 'dependency', source: { ref: 'node', nodeId: 'them' }, target: { ref: 'branch', repoPath: '/r', branch: 'main' } },
+    // 'me' is the source of a dependency to a foreign node (xnode)
+    { id: 'l3', kind: 'dependency', source: { ref: 'node', nodeId: 'me' }, target: { ref: 'xnode', projectId: 'p2', nodeId: 'b1' } },
+    // 'me' is the target of an incoming lineage from another node
+    { id: 'l4', kind: 'lineage', source: { ref: 'node', nodeId: 'parent' }, target: { ref: 'node', nodeId: 'me' } }
+  ]
+
+  it('partitions outgoing (me is source) and incoming (me is target)', () => {
+    const { outgoing, incoming } = linksForNode(links, 'me')
+    expect(outgoing.map((l) => l.id)).toEqual(['l1', 'l3'])
+    expect(incoming.map((l) => l.id)).toEqual(['l4'])
+  })
+
+  it('does not match an xnode endpoint that happens to share the node id (foreign node)', () => {
+    // A link whose xnode target nodeId is 'me' does NOT involve THIS node — 'me' here is a
+    // foreign node. Only the ref:'node' side matches.
+    const foreign: Link[] = [
+      { id: 'lx', kind: 'context', source: { ref: 'node', nodeId: 'them' }, target: { ref: 'xnode', projectId: 'p2', nodeId: 'me' } }
+    ]
+    expect(linksForNode(foreign, 'me')).toEqual({ outgoing: [], incoming: [] })
+  })
+
+  it('a branch endpoint never matches a node', () => {
+    const branchy: Link[] = [
+      { id: 'lb', kind: 'dependency', source: { ref: 'node', nodeId: 'me' }, target: { ref: 'branch', repoPath: '/r', branch: 'main' } }
+    ]
+    // 'me' is the source (outgoing); the branch target is not 'me'.
+    expect(linksForNode(branchy, 'me').outgoing.map((l) => l.id)).toEqual(['lb'])
+    expect(linksForNode(branchy, 'me').incoming).toEqual([])
+  })
+})
+
+describe('kindAllowed', () => {
+  const agent = { kind: 'terminal', contextCapable: true }
+  const plain = { kind: 'terminal', contextCapable: false }
+  const sticky = { kind: 'sticky', contextCapable: false }
+  const editor = { kind: 'editor', contextCapable: false }
+
+  it('context admits two context-capable agent terminals', () => {
+    expect(kindAllowed('context', agent, agent)).toBe(true)
+  })
+
+  it('context rejects a context-capable agent paired with a non-capable terminal', () => {
+    expect(kindAllowed('context', agent, plain)).toBe(false)
+  })
+
+  it('context admits exactly one sticky + one terminal — even an agent terminal (the sticky→terminal note persists as context)', () => {
+    expect(kindAllowed('context', sticky, plain)).toBe(true)
+    expect(kindAllowed('context', sticky, agent)).toBe(true) // agent is still a terminal
+    expect(kindAllowed('context', agent, sticky)).toBe(true) // order-independent
+  })
+
+  it('context rejects a sticky paired with a non-terminal (editor)', () => {
+    expect(kindAllowed('context', agent, editor)).toBe(false)
+    expect(kindAllowed('context', sticky, editor)).toBe(false)
+  })
+
+  it('context rejects two stickies and two non-terminal non-stickies', () => {
+    expect(kindAllowed('context', sticky, sticky)).toBe(false)
+    expect(kindAllowed('context', editor, editor)).toBe(false)
+  })
+
+  it('lineage and dependency are unconstrained (any endpoint pair)', () => {
+    expect(kindAllowed('lineage', agent, agent)).toBe(true)
+    expect(kindAllowed('lineage', sticky, editor)).toBe(true)
+    expect(kindAllowed('dependency', plain, sticky)).toBe(true)
+    expect(kindAllowed('dependency', editor, editor)).toBe(true)
+  })
+})
+
+describe('linkKindEndpointOf', () => {
+  it('marks a created context-capable agent terminal as contextCapable', () => {
+    expect(linkKindEndpointOf(node('a', { agentId: 'claude' })).contextCapable).toBe(true)
+  })
+
+  it('marks a plain terminal (no agentId) as not contextCapable', () => {
+    expect(linkKindEndpointOf(node('t')).contextCapable).toBe(false)
+  })
+
+  it('marks a sticky as not contextCapable', () => {
+    expect(linkKindEndpointOf(node('s', { kind: 'sticky' })).contextCapable).toBe(false)
+    expect(linkKindEndpointOf(node('s', { kind: 'sticky' })).kind).toBe('sticky')
+  })
+
+  it('a non-context-capable agent (copilot) is not contextCapable', () => {
+    expect(linkKindEndpointOf(node('c', { agentId: 'copilot' })).contextCapable).toBe(false)
+  })
+})
+
+describe('newLinkId', () => {
+  it('mints a link- prefixed id', () => {
+    expect(newLinkId()).toMatch(/^link-[0-9a-f-]{36}$/)
+  })
+
+  it('mints unique ids', () => {
+    expect(newLinkId()).not.toBe(newLinkId())
+  })
+})
+
+describe('offCanvasLinkColor', () => {
+  it('dependency is amber', () => {
+    expect(offCanvasLinkColor({ id: 'l', kind: 'dependency', source: { ref: 'node', nodeId: 'a' }, target: { ref: 'branch', repoPath: '/r', branch: 'main' } })).toBe('#f59e0b')
+  })
+  it('lineage is grey', () => {
+    expect(offCanvasLinkColor({ id: 'l', kind: 'lineage', source: { ref: 'node', nodeId: 'a' }, target: { ref: 'node', nodeId: 'b' } })).toBe('#8e8e93')
+  })
+  it('a context link with an xnode target is violet', () => {
+    expect(offCanvasLinkColor({ id: 'l', kind: 'context', source: { ref: 'node', nodeId: 'a' }, target: { ref: 'xnode', projectId: 'p2', nodeId: 'b' } })).toBe('#a855f7')
+  })
+  it('a branch target on a dependency falls back to blue only for non-xnode non-dependency — here dependency wins', () => {
+    // dependency is checked first, so a dependency link is amber regardless of endpoint.
+    expect(offCanvasLinkColor({ id: 'l', kind: 'dependency', source: { ref: 'node', nodeId: 'a' }, target: { ref: 'xnode', projectId: 'p2', nodeId: 'b' } })).toBe('#f59e0b')
+  })
+})
+
+/**
+ * The round-trip that ticket 06 must keep lossless. `Canvas.tsx` splits a project's `Link[]` on
+ * load into runtime edge arrays (only node↔node `context`/`lineage`) and an `offCanvasLinksRef`
+ * (everything `nodeEndpoints` returns null for), then at commit `mergeLinks` composes the two back
+ * together. This test reconstructs that exact composition against the pure primitives — pinning
+ * that a `dependency`→`branch` link and a cross-project `xnode` link (the ones this ticket
+ * introduces) survive, while a `context` node↔node link round-trips through the runtime split.
+ */
+describe('off-canvas round-trip (mergeLinks composition)', () => {
+  // The load-side split: what linksToRuntime keeps (node↔node) vs stashes as off-canvas.
+  const splitOnLoad = (links: Link[]) => ({
+    onCanvas: links.filter((l) => nodeEndpoints(l) !== null),
+    offCanvas: links.filter((l) => nodeEndpoints(l) === null)
+  })
+  // The commit-side merge: on-canvas node↔node links rebuilt via the same primitives runtimeToLinks
+  // uses, then the off-canvas set appended (disjoint by construction).
+  const mergeOnCommit = (onCanvas: Link[], offCanvas: Link[]): Link[] => [...onCanvas, ...offCanvas]
+
+  it('a dependency→branch link survives the round-trip (the clobber regression)', () => {
+    const persisted: Link[] = [
+      contextLink('a', 'b'),
+      { id: 'l-dep', kind: 'dependency', source: { ref: 'node', nodeId: 'a' }, target: { ref: 'branch', repoPath: '/r', branch: 'main' } }
+    ]
+    const { onCanvas, offCanvas } = splitOnLoad(persisted)
+    // The branch endpoint has no on-canvas node pair → stashed off-canvas, not dropped.
+    expect(onCanvas.map((l) => l.id)).toEqual(['bridge-a-b'])
+    expect(offCanvas.map((l) => l.id)).toEqual(['l-dep'])
+    const roundTripped = mergeOnCommit(onCanvas, offCanvas)
+    expect(roundTripped.map((l) => l.id).sort()).toEqual(['bridge-a-b', 'l-dep'])
+  })
+
+  it('a cross-project xnode context link survives the round-trip', () => {
+    const persisted: Link[] = [
+      { id: 'l-xnode', kind: 'context', source: { ref: 'node', nodeId: 'a' }, target: { ref: 'xnode', projectId: 'p2', nodeId: 'b' } }
+    ]
+    const { onCanvas, offCanvas } = splitOnLoad(persisted)
+    expect(onCanvas).toEqual([]) // xnode target → no on-canvas pair
+    expect(offCanvas.map((l) => l.id)).toEqual(['l-xnode'])
+    expect(mergeOnCommit(onCanvas, offCanvas).map((l) => l.id)).toEqual(['l-xnode'])
+  })
+
+  it('a lineage rope and a context note both stay on-canvas; nothing leaks to off-canvas', () => {
+    const persisted: Link[] = [contextLink('a', 'b'), lineageLink('c', 'd')]
+    const { onCanvas, offCanvas } = splitOnLoad(persisted)
+    expect(onCanvas.map((l) => l.id)).toEqual(['bridge-a-b', 'ctrl-c-d'])
+    expect(offCanvas).toEqual([])
+  })
+
+  it('an empty project round-trips to empty (not undefined-shaped drift)', () => {
+    const { onCanvas, offCanvas } = splitOnLoad([])
+    expect(mergeOnCommit(onCanvas, offCanvas)).toEqual([])
+  })
+
+  it('a node↔node dependency link stays ON-canvas (ticket 09 meta-canvas auto-link, not off-canvas)', () => {
+    // The meta-canvas submodule auto-link is a dependency between two real group nodes on the SAME
+    // project, so nodeEndpoints !== null → it is on-canvas (a visible amber edge), NOT stashed in
+    // offCanvasLinksRef. This is the gap task #47 closed: previously a node↔node dependency was
+    // neither in the runtime arrays (dropped by the load split) nor off-canvas — silently lost.
+    const persisted: Link[] = [dependencyLink('g-sub', 'g-parent')]
+    const { onCanvas, offCanvas } = splitOnLoad(persisted)
+    expect(onCanvas.map((l) => l.id)).toEqual(['dep-g-sub-g-parent'])
+    expect(offCanvas).toEqual([])
+    expect(mergeOnCommit(onCanvas, offCanvas).map((l) => l.id)).toEqual(['dep-g-sub-g-parent'])
+  })
+
+  it('a node↔node dependency coexists with a branch dependency (one on-canvas, one off)', () => {
+    const persisted: Link[] = [
+      dependencyLink('g-sub', 'g-parent'),
+      { id: 'l-dep-branch', kind: 'dependency', source: { ref: 'branch', repoPath: '/r', branch: 'feat' }, target: { ref: 'branch', repoPath: '/r', branch: 'main' } }
+    ]
+    const { onCanvas, offCanvas } = splitOnLoad(persisted)
+    expect(onCanvas.map((l) => l.id)).toEqual(['dep-g-sub-g-parent'])
+    expect(offCanvas.map((l) => l.id)).toEqual(['l-dep-branch'])
+    expect(mergeOnCommit(onCanvas, offCanvas).map((l) => l.id).sort()).toEqual(['dep-g-sub-g-parent', 'l-dep-branch'])
+  })
+})
+
+describe('isBranchDependencyLink', () => {
+  const branchLink = (id: string, child: string, parent: string): Link => ({
+    id,
+    kind: 'dependency',
+    source: { ref: 'branch', repoPath: '/r', branch: child },
+    target: { ref: 'branch', repoPath: '/r', branch: parent }
+  })
+  it('true only for a dependency with two branch endpoints', () => {
+    expect(isBranchDependencyLink(branchLink('l', 'b', 'a'))).toBe(true)
+  })
+  it('false for a node↔branch dependency (cross-project style, no config entry)', () => {
+    expect(
+      isBranchDependencyLink({
+        id: 'l',
+        kind: 'dependency',
+        source: { ref: 'node', nodeId: 'n1' },
+        target: { ref: 'branch', repoPath: '/r', branch: 'a' }
+      })
+    ).toBe(false)
+  })
+  it('false for a context/lineage link even with branch endpoints', () => {
+    expect(isBranchDependencyLink({ ...branchLink('l', 'b', 'a'), kind: 'context' })).toBe(false)
+    expect(isBranchDependencyLink({ ...branchLink('l', 'b', 'a'), kind: 'lineage' })).toBe(false)
+  })
+})
+
+describe('isCrossProjectDependencyLink', () => {
+  // Ticket 04: a `dependency` with an `xnode` endpoint is declarative-only (no git topology, no
+  // canvas edge). The gate `xlinkEdges` uses to keep it off the canvas. A `lineage`+`xnode` link
+  // is NOT this — it renders as a projection (ticket 05) — so the kind matters, not just the ref.
+  const xnodeDep = (id: string): Link => ({
+    id,
+    kind: 'dependency',
+    source: { ref: 'node', nodeId: 'a1' },
+    target: { ref: 'xnode', projectId: 'B', nodeId: 'b1' }
+  })
+  it('true for a dependency with an xnode target (the consumer→producer case)', () => {
+    expect(isCrossProjectDependencyLink(xnodeDep('l'))).toBe(true)
+  })
+  it('true when the xnode is the source instead of the target', () => {
+    expect(
+      isCrossProjectDependencyLink({
+        id: 'l',
+        kind: 'dependency',
+        source: { ref: 'xnode', projectId: 'B', nodeId: 'b1' },
+        target: { ref: 'node', nodeId: 'a1' }
+      })
+    ).toBe(true)
+  })
+  it('false for a same-repo branch↔branch dependency (that one renders a dep- edge, ticket 03)', () => {
+    expect(
+      isCrossProjectDependencyLink({
+        id: 'l',
+        kind: 'dependency',
+        source: { ref: 'branch', repoPath: '/r', branch: 'b' },
+        target: { ref: 'branch', repoPath: '/r', branch: 'a' }
+      })
+    ).toBe(false)
+  })
+  it('false for a lineage link with an xnode endpoint (that one renders a projection, ticket 05)', () => {
+    expect(isCrossProjectDependencyLink({ ...xnodeDep('l'), kind: 'lineage' })).toBe(false)
+  })
+  it('false for a context link with an xnode endpoint', () => {
+    expect(isCrossProjectDependencyLink({ ...xnodeDep('l'), kind: 'context' })).toBe(false)
+  })
+})
+
+describe('depHostEdges', () => {
+  const branchLink = (id: string, child: string, parent: string): Link => ({
+    id,
+    kind: 'dependency',
+    source: { ref: 'branch', repoPath: '/r', branch: child },
+    target: { ref: 'branch', repoPath: '/r', branch: parent }
+  })
+  it('emits a child→parent edge when both branches are hosted by group nodes', () => {
+    const hosts = new Map([
+      ['feat-b', 'gB'],
+      ['feat-a', 'gA']
+    ])
+    const edges = depHostEdges([branchLink('l1', 'feat-b', 'feat-a')], hosts)
+    expect(edges).toEqual([
+      { id: 'dep-l1', source: 'gB', target: 'gA', label: 'feat-b → feat-a', linkId: 'l1' }
+    ])
+  })
+  it('emits nothing when only one branch is hosted (link survives at repo level)', () => {
+    const hosts = new Map([['feat-b', 'gB']])
+    expect(depHostEdges([branchLink('l1', 'feat-b', 'feat-a')], hosts)).toEqual([])
+  })
+  it('emits nothing when neither branch is hosted', () => {
+    expect(depHostEdges([branchLink('l1', 'feat-b', 'feat-a')], new Map())).toEqual([])
+  })
+  it('ignores non-branch-dependency links (disjoint from the xlink path)', () => {
+    const hosts = new Map([
+      ['feat-b', 'gB'],
+      ['feat-a', 'gA']
+    ])
+    expect(depHostEdges([{ ...branchLink('l1', 'feat-b', 'feat-a'), kind: 'context' }], hosts)).toEqual([])
+  })
+  it('skips a self-edge where both branches share one host group', () => {
+    const hosts = new Map([
+      ['feat-b', 'gB'],
+      ['feat-a', 'gB']
+    ])
+    expect(depHostEdges([branchLink('l1', 'feat-b', 'feat-a')], hosts)).toEqual([])
+  })
+  it('handles a multi-level stack: b→a and c→b both render', () => {
+    const hosts = new Map([
+      ['feat-a', 'gA'],
+      ['feat-b', 'gB'],
+      ['feat-c', 'gC']
+    ])
+    const edges = depHostEdges([branchLink('l1', 'feat-b', 'feat-a'), branchLink('l2', 'feat-c', 'feat-b')], hosts)
+    expect(edges.map((e) => e.label).sort()).toEqual(['feat-b → feat-a', 'feat-c → feat-b'])
+  })
+})
+
+describe('applyDependencyLink / removeDependencyLinkConfig', () => {
+  const branchLink = (id: string, child: string, parent: string): Link => ({
+    id,
+    kind: 'dependency',
+    source: { ref: 'branch', repoPath: '/r', branch: child },
+    target: { ref: 'branch', repoPath: '/r', branch: parent }
+  })
+  const fakeGit = (log: { set: string[]; unset: string[] }) => ({
+    setBranchParent: async (repoPath: string, child: string, parent: string) => {
+      log.set.push(`${repoPath}|${child}|${parent}`)
+      return { ok: true, message: 'set' }
+    },
+    unsetBranchParent: async (repoPath: string, child: string) => {
+      log.unset.push(`${repoPath}|${child}`)
+      return { ok: true, message: 'unset' }
+    }
+  })
+  it('writes the parent config with source=child, target=parent', async () => {
+    const log = { set: [] as string[], unset: [] as string[] }
+    await applyDependencyLink(fakeGit(log), branchLink('l1', 'feat-b', 'feat-a'))
+    expect(log.set).toEqual(['/r|feat-b|feat-a'])
+  })
+  it('unsets the parent config on delete using the child (source) branch', async () => {
+    const log = { set: [] as string[], unset: [] as string[] }
+    await removeDependencyLinkConfig(fakeGit(log), branchLink('l1', 'feat-b', 'feat-a'))
+    expect(log.unset).toEqual(['/r|feat-b'])
+  })
+  it('a non-branch-dependency link touches no config (no-op, ok)', async () => {
+    const log = { set: [] as string[], unset: [] as string[] }
+    const g = fakeGit(log)
+    const nodeLink: Link = {
+      id: 'l2',
+      kind: 'dependency',
+      source: { ref: 'node', nodeId: 'n1' },
+      target: { ref: 'branch', repoPath: '/r', branch: 'a' }
+    }
+    expect((await applyDependencyLink(g, nodeLink)).ok).toBe(true)
+    expect((await removeDependencyLinkConfig(g, nodeLink)).ok).toBe(true)
+    expect(log.set).toEqual([])
+    expect(log.unset).toEqual([])
+  })
+  it('a cross-project (xnode) dependency touches no config — declarative-only (ticket 04)', async () => {
+    // No shared git → no git-town topology → nothing to write. The link is purely a persisted
+    // relationship, authored + inspected off-canvas; it renders no canvas edge either.
+    const log = { set: [] as string[], unset: [] as string[] }
+    const g = fakeGit(log)
+    const xnodeLink: Link = {
+      id: 'l3',
+      kind: 'dependency',
+      source: { ref: 'node', nodeId: 'a1' },
+      target: { ref: 'xnode', projectId: 'B', nodeId: 'b1' }
+    }
+    expect((await applyDependencyLink(g, xnodeLink)).ok).toBe(true)
+    expect((await removeDependencyLinkConfig(g, xnodeLink)).ok).toBe(true)
+    expect(log.set).toEqual([])
+    expect(log.unset).toEqual([])
+  })
+})

--- a/src/renderer/lib/link-authoring.ts
+++ b/src/renderer/lib/link-authoring.ts
@@ -1,0 +1,296 @@
+// Pure helpers for the off-canvas link authoring surface (ticket 06): classifying a picker
+// selection into an `Endpoint`, describing an endpoint for the inspector, partitioning a
+// project's links by a node, constraining which `LinkKind` a pair of endpoints may take, and
+// minting a link id. Kept free of React/store imports so the matrix is unit-testable.
+//
+// The on-canvas edge-drawing path (`onConnect` / `planBridges` in `noteLink.ts`) stays the fast
+// path for same-canvas `context` (agent↔agent AND sticky→terminal — both persist as
+// `kind:'context'`, the note carrying the sticky text in `meta.note`). These helpers serve the
+// OFF-canvas path — the only way to author `dependency`, cross-project (`xnode`), and cross-repo
+// (`branch`) links.
+import type { Endpoint, Link, LinkKind, CanvasNodeState, Project } from '@shared/types'
+import { canContextLink, createdAgentId } from '@shared/agents/config'
+
+/**
+ * The narrow git surface `applyDependencyLink`/`removeDependencyLinkConfig` need. Deliberately a
+ * structural alias (not `import { GitApi }`) so the helper stays unit-testable with a fake and so
+ * this pure-ish module does not pull the whole api type graph. Both `setBranchParent` and
+ * `unsetBranchParent` are the convention-config writers (plain `git config`, no binary).
+ */
+export interface DependencyGitSurface {
+  setBranchParent(repoPath: string, child: string, parent: string): Promise<{ ok: boolean; message: string }>
+  unsetBranchParent(repoPath: string, child: string): Promise<{ ok: boolean; message: string }>
+}
+
+/** A selection from `LinkTargetPicker` — either a node in some project, or a repo branch. */
+export type PickerSelection =
+  | { kind: 'node'; projectId: string; nodeId: string }
+  | { kind: 'branch'; repoPath: string; branch: string }
+
+/**
+ * Resolve a picker selection to an `Endpoint`, classifying node vs xnode from the chosen project
+ * relative to the SOURCE node's project — the user never picks "node vs xnode" themselves. A node
+ * chosen from the source's own project is `{ref:'node'}`; a node chosen from any OTHER project is
+ * `{ref:'xnode', projectId, nodeId}` (a foreign canvas). A branch is always `{ref:'branch'}`.
+ */
+export function resolveEndpoint(sel: PickerSelection, sourceProjectId: string): Endpoint {
+  if (sel.kind === 'branch') return { ref: 'branch', repoPath: sel.repoPath, branch: sel.branch }
+  if (sel.projectId === sourceProjectId) return { ref: 'node', nodeId: sel.nodeId }
+  return { ref: 'xnode', projectId: sel.projectId, nodeId: sel.nodeId }
+}
+
+/** The projects store shape `describeEndpoint` reads from — just the fields it needs. */
+export type ProjectLookup = Pick<Project, 'id' | 'name' | 'nodes'> & { closed?: boolean; unavailable?: boolean }
+
+/** Look up a node across the given projects by id (node ids are globally unique across projects). */
+function findNode(projects: readonly ProjectLookup[], nodeId: string): CanvasNodeState | undefined {
+  for (const p of projects) {
+    const n = p.nodes.find((x) => x.id === nodeId)
+    if (n) return n
+  }
+  return undefined
+}
+
+/**
+ * Human-readable label for an endpoint, for the inspector/picker footer. Returns the string AND a
+ * flag for whether the endpoint was resolvable (a deleted node / missing project renders as a muted
+ * "unavailable" row, which is a different fact from a resolved one). `node` resolves from ANY
+ * project's serialized nodes (the node may be in a background project); `xnode` resolves from its
+ * named foreign project; `branch` is always resolvable (it names a branch, not a node).
+ */
+export function describeEndpoint(
+  ep: Endpoint,
+  projects: readonly ProjectLookup[]
+): { label: string; available: boolean } {
+  if (ep.ref === 'branch') {
+    const repoName = ep.repoPath.split('/').filter(Boolean).pop() ?? ep.repoPath
+    return { label: `${repoName} · ${ep.branch}`, available: true }
+  }
+  if (ep.ref === 'xnode') {
+    const proj = projects.find((p) => p.id === ep.projectId)
+    if (!proj || proj.unavailable) return { label: 'unavailable project', available: false }
+    const node = proj.nodes.find((n) => n.id === ep.nodeId)
+    if (!node) return { label: `${proj.name} · unavailable node`, available: false }
+    return { label: `${proj.name} · ${node.title || node.id}`, available: true }
+  }
+  // ref: 'node' — may live in any project (the link's owner or another).
+  const node = findNode(projects, ep.nodeId)
+  if (!node) return { label: 'unavailable node', available: false }
+  const proj = projects.find((p) => p.nodes.some((n) => n.id === ep.nodeId))
+  return { label: `${proj?.name ?? 'Project'} · ${node.title || node.id}`, available: true }
+}
+
+/**
+ * Partition a project's links into those where the given node is the source (outgoing) vs the
+ * target (incoming). A link "involves" the node when an endpoint is `ref:'node'` whose `nodeId`
+ * matches — an `xnode` endpoint is a FOREIGN node and never matches this node (this node would be
+ * the `node` endpoint on the other side); a `branch` endpoint never matches a node. A link whose
+ * `node` endpoint appears on BOTH sides (self-link, not currently authorable) lands in outgoing.
+ */
+export function linksForNode(links: readonly Link[], nodeId: string): { outgoing: Link[]; incoming: Link[] } {
+  const outgoing: Link[] = []
+  const incoming: Link[] = []
+  for (const l of links) {
+    const srcIs = l.source.ref === 'node' && l.source.nodeId === nodeId
+    const tgtIs = l.target.ref === 'node' && l.target.nodeId === nodeId
+    if (srcIs) outgoing.push(l)
+    else if (tgtIs) incoming.push(l)
+  }
+  return { outgoing, incoming }
+}
+
+/** Endpoint capability descriptor for `kindAllowed` — the minimal shape `classifyLink` reasons on. */
+export interface LinkKindEndpoint {
+  /** React Flow node type / kind: 'terminal' | 'sticky' | 'editor' | … */
+  kind: string
+  /** Terminal node whose agent is CONTEXT_LINK_CAPABLE (claude/codex/gemini/opencode). */
+  contextCapable: boolean
+}
+
+/**
+ * Whether a `LinkKind` may connect two endpoints. A generalization of `classifyLink`
+ * (`noteLink.ts`) to the full persisted `LinkKind` set, for the off-canvas picker's kind dropdown.
+ * NB: `'note'` is NOT a persisted `LinkKind` — a sticky→terminal note persists as `kind:'context'`
+ * with `meta.note` (see `contextLink`). So `context` admits BOTH:
+ *  - two context-capable agent terminals (the agent↔agent read-back path), AND
+ *  - exactly one sticky + one terminal (the sticky→terminal note path).
+ *  - `lineage`   : any endpoint pair (a display-only "spawned by" edge).
+ *  - `dependency`: any endpoint pair (a branch/xnode/node dependency).
+ *
+ * `lineage`/`dependency` are unconstrained because the canvas-edge model never expressed them and
+ * there is no capability gate on "this depends on that" — a plain terminal may depend on a branch.
+ */
+export function kindAllowed(kind: LinkKind, source: LinkKindEndpoint, target: LinkKindEndpoint): boolean {
+  if (kind === 'dependency' || kind === 'lineage') return true
+  // kind === 'context': agent↔agent (both context-capable) OR sticky→terminal (exactly one sticky).
+  const stickies = (source.kind === 'sticky' ? 1 : 0) + (target.kind === 'sticky' ? 1 : 0)
+  if (stickies === 0) return source.contextCapable && target.contextCapable
+  if (stickies === 1) {
+    const other = source.kind === 'sticky' ? target : source
+    return other.kind === 'terminal'
+  }
+  return false // two stickies
+}
+
+/**
+ * Derive a `LinkKindEndpoint` from a serialized `CanvasNodeState` for the picker's kind-constraint
+ * check. Reuses `createdAgentId` (the same derivation the canvas's `linkEndpointOf` and
+ * TerminalNode's restart closure share) so a plain terminal someone typed `claude` into by hand is
+ * NOT context-capable here either — only a node CREATED as a context-link-capable agent is.
+ */
+export function linkKindEndpointOf(node: CanvasNodeState): LinkKindEndpoint {
+  const sticky = node.kind === 'sticky'
+  return {
+    kind: node.kind,
+    contextCapable: !sticky && !!createdAgentId(node) && canContextLink(createdAgentId(node)!)
+  }
+}
+
+/** A fresh link id with the `link-` prefix (distinct from `bridge-`/`ctrl-` so a derived edge id
+ *  `xlink-<linkId>` never collides with a hand-drawn bridge). */
+export function newLinkId(): string {
+  return `link-${crypto.randomUUID()}`
+}
+
+/**
+ * The derived-edge color for an off-canvas link, keyed by the target endpoint's kind. Used by both
+ * the canvas's `displayEdges` pass and the inspector's kind chip so the two surfaces agree.
+ *  - `dependency` (a branch target) → amber
+ *  - `lineage`                    → grey
+ *  - a `context` link whose target is an `xnode` (cross-project) → violet
+ *  - a `branch` endpoint          → blue
+ */
+export function offCanvasLinkColor(link: Link): string {
+  if (link.kind === 'dependency') return '#f59e0b'
+  if (link.kind === 'lineage') return '#8e8e93'
+  if (link.target.ref === 'xnode' || link.source.ref === 'xnode') return '#a855f7'
+  return '#0a84ff'
+}
+
+// ── Branch-dependency links (ticket 03) ──────────────────────────────────────────────────
+//
+// A `dependency` link whose endpoints are BOTH `{ref:'branch'}` owns a git-town lineage config
+// entry: `git config git-town-branch.<child>.parent <parent>`. The link's `source` is the CHILD
+// (the branch that builds on top) and `target` is the PARENT — matching the edge direction the
+// canvas draws (child → parent) and git-town's own `child.parent` semantics.
+//
+// Centralizing the config write here is the "duplicated rule drifts" guard: BOTH authoring
+// surfaces — the agent's `link-branches` verb (Canvas dispatch) and the UI's `LinkTargetPicker` /
+// `LinkInspectorPanel` — call these helpers, so the link set and the git config can never disagree.
+// A `context`/`lineage` link passes through untouched (it owns no config entry).
+
+/** A `Link` whose source AND target are `{ref:'branch'}` endpoints. Narrowed by
+ *  `isBranchDependencyLink` so the `repoPath`/`branch` fields are reachable without a cast. */
+export interface BranchBranchLink extends Link {
+  source: { ref: 'branch'; repoPath: string; branch: string }
+  target: { ref: 'branch'; repoPath: string; branch: string }
+}
+
+/** Is this a same-repo branch-dependency link (two `branch` endpoints)? The only kind that owns a
+ *  git-town config entry. A dependency with a `node`/`xnode` endpoint (cross-project, ticket 04)
+ *  is not a git config fact. A type guard so the `branch`/`repoPath` fields are reachable at the
+ *  call site (TS cannot narrow the `Endpoint` union through a plain `boolean`). */
+export function isBranchDependencyLink(link: Link): link is BranchBranchLink {
+  return link.kind === 'dependency' && link.source.ref === 'branch' && link.target.ref === 'branch'
+}
+
+/** Is this a cross-project dependency link — a `dependency` with at least one `xnode` endpoint
+ *  (ticket 04)? This is the **declarative-only** dependency: A and B share no git, so there is no
+ *  branch topology to stack on, no git-town config to write, and NO canvas edge (resolve point 3 —
+ *  a cross-project `dependency` edge is never drawn on either canvas; it lives in the inspector).
+ *
+ *  This is the gate the `xlinkEdges` derivation checks to keep such a link OFF the canvas: unlike a
+ *  same-repo `branch`↔`branch` dependency (which renders a `dep-` edge between hosting groups, 03)
+ *  or a same-project `node`↔`node` context link (a bridge edge), a cross-project `dependency` has
+ *  no shared coordinate space to draw in, so 06's dangling-`xlink` path must NOT pick it up. A
+ *  `lineage` link with an `xnode` endpoint (ticket 05's spawn projection) is deliberately NOT this
+ *  — that one DOES render (as a foreign-node projection), so the kind matters, not just the ref. */
+export function isCrossProjectDependencyLink(link: Link): boolean {
+  return (
+    link.kind === 'dependency' &&
+    (link.source.ref === 'xnode' || link.target.ref === 'xnode')
+  )
+}
+
+/**
+ * Write the git-town parent config for a branch-dependency link. Called at CREATE (verb + picker).
+ * Returns the git result so the caller can REFUSE to persist the link when the config write failed —
+ * a link whose git-town lineage does not match is the drift the design says to never create
+ * ("nodeterm's links ARE the git-town lineage"). The caller persists the `Link` itself (via
+ * `commitLinks`/`commitCanvas`); this helper owns ONLY the config side.
+ */
+export async function applyDependencyLink(
+  git: DependencyGitSurface,
+  link: Link
+): Promise<{ ok: boolean; message: string }> {
+  if (!isBranchDependencyLink(link)) return { ok: true, message: '' }
+  // source = child, target = parent (see the section comment).
+  return git.setBranchParent(link.source.repoPath, link.source.branch, link.target.branch)
+}
+
+/**
+ * Drop the git-town parent config when a branch-dependency link is DELETED (inspector). Called
+ * AFTER the link is removed from `Project.links` so the UI updates immediately even if the config
+ * unset is slow. A failed unset is non-fatal (returned for surfacing as a toast): git-town just
+ * keeps a stale parent until the user re-runs — it never corrupts the link set, which is now gone.
+ */
+export async function removeDependencyLinkConfig(
+  git: DependencyGitSurface,
+  link: Link
+): Promise<{ ok: boolean; message: string }> {
+  if (!isBranchDependencyLink(link)) return { ok: true, message: '' }
+  return git.unsetBranchParent(link.source.repoPath, link.source.branch)
+}
+
+/**
+ * A derived edge descriptor for the two-host dependency case: a `dependency` link whose source AND
+ * target are `branch`, and BOTH branches are hosted by worktree group nodes on the active canvas.
+ * Rendered as a dashed accent edge from the CHILD group (link.source.branch) to the PARENT group
+ * (link.target.branch), labelled `child → parent`.
+ *
+ * Pure + testable: the caller supplies a `branchToGroupNode` map (built from the live canvas nodes'
+ * `data.worktree.branch`), so this does not import React Flow. A branch hosted by NO group on this
+ * canvas produces no edge here — the link still survives in the inspector and the repo-level view
+ * (ticket 02). This path is DISJOINT from the 06 `xlink-` path by construction: `xlinkEdges` needs a
+ * `node` endpoint (a dangling self-edge off one live node), while these links have two `branch`
+ * endpoints and no `node` endpoint at all — so the two never both emit for the same link.
+ */
+export interface DepHostEdge {
+  /** `dep-<link.id>` — distinct from `xlink-<linkId>` so `onEdgeDoubleClick` can guard both. */
+  id: string
+  /** The child group node id (the branch that builds on top — link.source). */
+  source: string
+  /** The parent group node id (the branch built upon — link.target). */
+  target: string
+  /** The label pill text: `<child> → <parent>`. */
+  label: string
+  /** The link this edge derives from (for color, by the caller via `offCanvasLinkColor`). */
+  linkId: string
+}
+
+export function depHostEdges(
+  links: readonly Link[],
+  branchToGroupNode: ReadonlyMap<string, string>
+): DepHostEdge[] {
+  const out: DepHostEdge[] = []
+  for (const l of links) {
+    if (!isBranchDependencyLink(l)) continue
+    const childGroup = branchToGroupNode.get(l.source.branch)
+    const parentGroup = branchToGroupNode.get(l.target.branch)
+    // BOTH branches must be hosted by a group on this canvas; one-host / no-host renders nothing
+    // here (the link survives at the repo level).
+    if (!childGroup || !parentGroup) continue
+    // A self-edge (a branch depending on itself, or both branches hosted by one group) draws
+    // nothing useful — the link-branches verb already refuses child === parent, but a hand-edited
+    // link could still arrive; skip rather than draw a zero-length loop.
+    if (childGroup === parentGroup) continue
+    out.push({
+      id: `dep-${l.id}`,
+      source: childGroup,
+      target: parentGroup,
+      label: `${l.source.branch} → ${l.target.branch}`,
+      linkId: l.id
+    })
+  }
+  return out
+}

--- a/src/renderer/lib/noteLink.test.ts
+++ b/src/renderer/lib/noteLink.test.ts
@@ -3,6 +3,7 @@ import {
   buildBackgroundLinkMaps,
   buildContextLinkNote,
   buildLinkMap,
+  mergeContextLinkMaps,
   buildNotePushMessage,
   classifyLink,
   hiddenLinkIds,
@@ -10,10 +11,18 @@ import {
   pairKey,
   planBridges
 } from './noteLink'
-import type { CanvasNodeState } from '@shared/types'
+import type { CanvasNodeState, Link } from '@shared/types'
 
 const term = (contextCapable = false) => ({ kind: 'terminal', contextCapable })
 const sticky = () => ({ kind: 'sticky', contextCapable: false })
+
+/** Build a `kind:'context'` node↔node link — the shape `buildBackgroundLinkMaps` now consumes. */
+const ctx = (id: string, source: string, target: string): Link => ({
+  id,
+  kind: 'context',
+  source: { ref: 'node', nodeId: source },
+  target: { ref: 'node', nodeId: target }
+})
 
 describe('classifyLink', () => {
   it('two context-capable terminals form a context link', () => {
@@ -49,8 +58,18 @@ describe('planBridges', () => {
     expect(plan.linked).toEqual(['n2', 'n3'])
     expect(plan.skipped).toEqual([])
     expect(plan.edges).toEqual([
-      { id: 'bridge-n1-n2', source: 'n1', target: 'n2' },
-      { id: 'bridge-n1-n3', source: 'n1', target: 'n3' }
+      {
+        id: 'bridge-n1-n2',
+        kind: 'context',
+        source: { ref: 'node', nodeId: 'n1' },
+        target: { ref: 'node', nodeId: 'n2' }
+      },
+      {
+        id: 'bridge-n1-n3',
+        kind: 'context',
+        source: { ref: 'node', nodeId: 'n1' },
+        target: { ref: 'node', nodeId: 'n3' }
+      }
     ])
   })
 
@@ -86,7 +105,14 @@ describe('planBridges', () => {
 
   it('stores a note link sticky→terminal even when asked terminal→sticky', () => {
     const plan = planBridges('n1', ['s1'], lookup, [])
-    expect(plan.edges).toEqual([{ id: 'bridge-s1-n1', source: 's1', target: 'n1' }])
+    expect(plan.edges).toEqual([
+      {
+        id: 'bridge-s1-n1',
+        kind: 'context',
+        source: { ref: 'node', nodeId: 's1' },
+        target: { ref: 'node', nodeId: 'n1' }
+      }
+    ])
     expect(plan.linked).toEqual(['s1'])
   })
 
@@ -181,6 +207,14 @@ describe('buildLinkMap', () => {
   })
 })
 
+describe('mergeContextLinkMaps', () => {
+  it('appends links for the same node instead of overwriting them, and dedupes targets', () => {
+    const a = { id: 'a', title: 'A', cwd: '/a' }
+    const b = { id: 'b', title: 'B', cwd: '/b' }
+    expect(mergeContextLinkMaps({ n: [a] }, { n: [a, b] })).toEqual({ n: [a, b] })
+  })
+})
+
 describe('buildLinkMap agent identity', () => {
   it('carries agentId/sessionId/accountId on context entries', () => {
     const infoOf = (id: string) => ({
@@ -238,7 +272,7 @@ describe('buildBackgroundLinkMaps', () => {
     {
       id: 'p-active',
       nodes: [node({ id: 'a1', agentId: 'claude' }), node({ id: 'a2', agentId: 'codex' })],
-      bridges: [{ id: 'e0', source: 'a1', target: 'a2' }]
+      links: [ctx('e0', 'a1', 'a2')]
     },
     {
       id: 'p-bg',
@@ -247,12 +281,9 @@ describe('buildBackgroundLinkMaps', () => {
         node({ id: 'b2', title: 'Gem', cwd: '/fit', agentId: 'gemini' }),
         node({ id: 'b3', kind: 'sticky', title: 'Note', text: 'remember this' })
       ],
-      bridges: [
-        { id: 'e1', source: 'b1', target: 'b2' },
-        { id: 'e2', source: 'b3', target: 'b1' }
-      ]
+      links: [ctx('e1', 'b1', 'b2'), ctx('e2', 'b3', 'b1')]
     },
-    { id: 'p-nolinks', nodes: [node({ id: 'c1' })], bridges: [] }
+    { id: 'p-nolinks', nodes: [node({ id: 'c1' })], links: [] }
   ]
 
   it('maps every project except the active one (React Flow owns that live)', () => {
@@ -263,6 +294,45 @@ describe('buildBackgroundLinkMaps', () => {
     expect(map['b2']).toEqual([
       { id: 'b1', title: 'Fitness', cwd: '/fit', agentId: 'claude', accountId: 'acct-1' }
     ])
+  })
+  it('keeps an active project cross-project context link because React Flow never owns it', () => {
+    const crossProjects = [
+      {
+        id: 'p-active',
+        nodes: [node({ id: 'a1', title: 'Active', agentId: 'claude' })],
+        links: [{
+          id: 'cross',
+          kind: 'context' as const,
+          source: { ref: 'node' as const, nodeId: 'a1' },
+          target: { ref: 'xnode' as const, projectId: 'p-bg', nodeId: 'b1' }
+        }]
+      },
+      { id: 'p-bg', nodes: [node({ id: 'b1', title: 'Background', agentId: 'codex' })], links: [] }
+    ]
+    const map = buildBackgroundLinkMaps(crossProjects, 'p-active', () => undefined)
+    expect(map.a1).toContainEqual({ id: 'b1', title: 'Background', cwd: '', agentId: 'codex' })
+    expect(map.b1).toContainEqual({ id: 'a1', title: 'Active', cwd: '', agentId: 'claude' })
+  })
+
+  it('retains same-project and cross-project links for one background node', () => {
+    const mixedProjects = [
+      {
+        id: 'p1',
+        nodes: [node({ id: 'a' }), node({ id: 'b' })],
+        links: [
+          ctx('same', 'a', 'b'),
+          {
+            id: 'cross',
+            kind: 'context' as const,
+            source: { ref: 'node' as const, nodeId: 'a' },
+            target: { ref: 'xnode' as const, projectId: 'p2', nodeId: 'c' }
+          }
+        ]
+      },
+      { id: 'p2', nodes: [node({ id: 'c' })], links: [] }
+    ]
+    const map = buildBackgroundLinkMaps(mixedProjects, null, () => undefined)
+    expect(map.a.map((entry) => entry.id).sort()).toEqual(['b', 'c'])
   })
   it('serialized stickies map one-way with their text', () => {
     const map = buildBackgroundLinkMaps(projects, 'p-active', () => undefined)
@@ -288,7 +358,7 @@ describe('buildBackgroundLinkMaps', () => {
       {
         id: 'p-bg',
         nodes: [node({ id: 'm1', title: 'Manual', cwd: '/m' }), node({ id: 'm2', title: 'Also', cwd: '/m' })],
-        bridges: [{ id: 'e', source: 'm1', target: 'm2' }]
+        links: [ctx('e', 'm1', 'm2')]
       }
     ]
     const map = buildBackgroundLinkMaps(
@@ -309,7 +379,7 @@ describe('buildBackgroundLinkMaps', () => {
   })
   it('drops edges whose endpoints are gone from the serialized nodes', () => {
     const map = buildBackgroundLinkMaps(
-      [{ id: 'p', nodes: [node({ id: 'z1' })], bridges: [{ id: 'e', source: 'z1', target: 'gone' }] }],
+      [{ id: 'p', nodes: [node({ id: 'z1' })], links: [ctx('e', 'z1', 'gone')] }],
       null,
       () => undefined
     )

--- a/src/renderer/lib/noteLink.ts
+++ b/src/renderer/lib/noteLink.ts
@@ -2,7 +2,7 @@
 // agent nodes vs. note link between a sticky and a terminal), build the one-shot push
 // message a note link injects into an agent session, and re-export the link-map builders.
 // Kept free of React/store imports so the connection matrix is unit-testable.
-import type { BridgeLink } from '@shared/types'
+import type { Link } from '@shared/types'
 import { oneLine } from '@shared/one-line'
 
 export interface LinkEndpoint {
@@ -23,6 +23,55 @@ export function classifyLink(a: LinkEndpoint, b: LinkEndpoint): LinkKind | null 
   return other.kind === 'terminal' ? 'note' : null
 }
 
+/**
+ * Project a {@link Link} down to the `{ id, source, target }` node-id pair the renderer's edge
+ * state + the rope-cover helpers reason in. Returns `null` for a link whose endpoints are not BOTH
+ * `ref:'node'` (an `xnode` cross-project target or a `branch` dependency endpoint) — such a link
+ * has no on-canvas node pair to draw or to share a rope with. On-canvas context/lineage links are
+ * always node↔node today; the null branch is the seam tickets 03/04/05 extend through.
+ */
+export function nodeEndpoints(link: Link): { id: string; source: string; target: string } | null {
+  if (link.source.ref !== 'node' || link.target.ref !== 'node') return null
+  return { id: link.id, source: link.source.nodeId, target: link.target.nodeId }
+}
+
+/** Build a `kind:'context'` node↔node link with a stable id (the `bridge-` prefix is kept for
+ *  back-compat with any persisted id a migrated file already carries). */
+export function contextLink(source: string, target: string, note?: string): Link {
+  return {
+    id: `bridge-${source}-${target}`,
+    kind: 'context',
+    source: { ref: 'node', nodeId: source },
+    target: { ref: 'node', nodeId: target },
+    ...(note != null ? { meta: { note } } : {})
+  }
+}
+
+/** Build a `kind:'lineage'` (display-only rope) node↔node link with a `ctrl-` id. */
+export function lineageLink(source: string, target: string): Link {
+  return {
+    id: `ctrl-${source}-${target}`,
+    kind: 'lineage',
+    source: { ref: 'node', nodeId: source },
+    target: { ref: 'node', nodeId: target },
+    meta: { displayOnly: true }
+  }
+}
+
+/** Build a `kind:'dependency'` node↔node link with a `dep-` id. Used by the meta-canvas submodule
+ *  auto-link (ticket 09): a same-canvas `dependency` edge between two `projectRef` group frames.
+ *  Unlike the cross-project/branch dependency links (off-canvas, inspector-only), a node↔node
+ *  dependency is a real on-canvas edge — `linksToRuntime` renders it (amber, dashed) and
+ *  `runtimeToLinks` round-trips it, so it survives the load→commit cycle. */
+export function dependencyLink(source: string, target: string): Link {
+  return {
+    id: `dep-${source}-${target}`,
+    kind: 'dependency',
+    source: { ref: 'node', nodeId: source },
+    target: { ref: 'node', nodeId: target }
+  }
+}
+
 /** One node the plan refused to link, with the reason to report back to the caller. */
 export interface SkippedBridge {
   id: string
@@ -30,8 +79,8 @@ export interface SkippedBridge {
 }
 
 export interface BridgePlan {
-  /** Edges to append (already deduped against `existing` AND within the batch). */
-  edges: BridgeLink[]
+  /** Links to append (already deduped against `existing` AND within the batch). */
+  edges: Link[]
   linked: string[]
   skipped: SkippedBridge[]
 }
@@ -46,6 +95,9 @@ export interface BridgePlan {
  * that links nodes it created in the SAME tick cannot resolve them off the canvas yet
  * (setNodes is async), and `existing` is passed in rather than read, so a batch also dedupes
  * against itself and not just against what is already on screen.
+ *
+ * `existing` is a node-pair projection (`{source, target}[]`) of the links already on screen,
+ * not `Link[]` — dedup is endpoint-pair based and a caller holds the projection already.
  */
 export function planBridges(
   fromId: string,
@@ -53,12 +105,12 @@ export function planBridges(
   lookup: (id: string) => LinkEndpoint | null,
   existing: readonly { source: string; target: string }[]
 ): BridgePlan {
-  const edges: BridgeLink[] = []
+  const edges: Link[] = []
   const linked: string[] = []
   const skipped: SkippedBridge[] = []
   const se = lookup(fromId)
   const linkedAlready = (a: string, b: string) =>
-    [...existing, ...edges].some(
+    [...existing, ...edges.map((e) => nodeEndpoints(e)!)].some(
       (e) => (e.source === a && e.target === b) || (e.source === b && e.target === a)
     )
   for (const tid of targetIds) {
@@ -87,7 +139,7 @@ export function planBridges(
       skipped.push({ id: tid, why: 'already linked' })
       continue
     }
-    edges.push({ id: `bridge-${source}-${target}`, source, target })
+    edges.push(contextLink(source, target))
     linked.push(tid)
   }
   return { edges, linked, skipped }
@@ -191,5 +243,6 @@ export function buildContextLinkNote(
 export {
   buildLinkMap,
   buildBackgroundLinkMaps,
+  mergeContextLinkMaps,
   type LinkNodeInfo
 } from '@shared/context-link-map'

--- a/src/renderer/lib/submoduleLink.test.ts
+++ b/src/renderer/lib/submoduleLink.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { planSubmoduleLinks, existingDependencyLinkKeys, type RefGroup, type OpenProjectByCwd } from './submoduleLink'
+import type { SubmoduleEntry } from '@shared/worktree'
+
+const sub = (path: string, sha = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0'): SubmoduleEntry => ({ path, sha })
+
+describe('planSubmoduleLinks', () => {
+  const refGroup: RefGroup = { groupId: 'g-parent', projectId: 'proj-parent' }
+
+  it('draws a dependency link from the submodule group to the referencing group for an OPEN submodule', () => {
+    const openProjects: OpenProjectByCwd[] = [{ cwd: '/repo/vendor/lib', projectId: 'proj-sub' }]
+    const existingGroup = new Map([['proj-sub', 'g-sub']])
+    const plan = planSubmoduleLinks(refGroup, '/repo', [sub('vendor/lib')], openProjects, existingGroup, new Set())
+    expect(plan.links).toHaveLength(1)
+    expect(plan.links[0].kind).toBe('dependency')
+    expect(plan.links[0].source).toEqual({ ref: 'node', nodeId: 'g-sub' })
+    expect(plan.links[0].target).toEqual({ ref: 'node', nodeId: 'g-parent' })
+    expect(plan.links[0].id).toBe('dep-g-sub-g-parent')
+    expect(plan.groupsToCreate).toEqual([])
+  })
+
+  it('joins the relative submodule path against the repo root to match a cwd', () => {
+    const openProjects: OpenProjectByCwd[] = [{ cwd: '/repo/outer/inner', projectId: 'proj-inner' }]
+    const existingGroup = new Map([['proj-inner', 'g-inner']])
+    const plan = planSubmoduleLinks(refGroup, '/repo', [sub('outer/inner')], openProjects, existingGroup, new Set())
+    expect(plan.links).toHaveLength(1)
+  })
+
+  it('tolerates a trailing slash on the repo root when joining the path', () => {
+    const openProjects: OpenProjectByCwd[] = [{ cwd: '/repo/vendor/lib', projectId: 'proj-sub' }]
+    const existingGroup = new Map([['proj-sub', 'g-sub']])
+    const plan = planSubmoduleLinks(refGroup, '/repo/', [sub('vendor/lib')], openProjects, existingGroup, new Set())
+    expect(plan.links).toHaveLength(1)
+  })
+
+  it('does not suggest an uninitialized or deleted submodule checkout', () => {
+    const missing = { ...sub('vendor/lib'), prunable: true }
+    const plan = planSubmoduleLinks(refGroup, '/repo', [missing], [], new Map(), new Set())
+    expect(plan).toEqual({ links: [], groupsToCreate: [], suggestions: [] })
+  })
+
+  it('suggests an unopened submodule without creating or persisting anything', () => {
+    const plan = planSubmoduleLinks(refGroup, '/repo', [sub('vendor/lib')], [], new Map(), new Set())
+    expect(plan.links).toEqual([])
+    expect(plan.groupsToCreate).toEqual([])
+    expect(plan.suggestions).toEqual([{
+      path: '/repo/vendor/lib',
+      relativePath: 'vendor/lib',
+      sourceGroupId: 'g-parent',
+      sourceProjectId: 'proj-parent'
+    }])
+  })
+
+  it('requests a new projectRef group when the submodule project has no group yet (and adds NO link — never a dangling edge)', () => {
+    const openProjects: OpenProjectByCwd[] = [{ cwd: '/repo/vendor/lib', projectId: 'proj-sub' }]
+    // No existing group for proj-sub:
+    const plan = planSubmoduleLinks(refGroup, '/repo', [sub('vendor/lib')], openProjects, new Map(), new Set())
+    expect(plan.links).toEqual([]) // deferred to the next run once the group exists
+    expect(plan.groupsToCreate).toEqual([{ projectId: 'proj-sub', color: undefined }])
+    expect(plan.suggestions).toEqual([])
+  })
+
+  it('is idempotent: a dependency link already present is not re-added', () => {
+    const openProjects: OpenProjectByCwd[] = [{ cwd: '/repo/vendor/lib', projectId: 'proj-sub' }]
+    const existingGroup = new Map([['proj-sub', 'g-sub']])
+    const existing = new Set(['dep-g-sub-g-parent'])
+    const plan = planSubmoduleLinks(refGroup, '/repo', [sub('vendor/lib')], openProjects, existingGroup, existing)
+    expect(plan.links).toEqual([])
+  })
+
+  it('handles multiple submodules, some open and some not', () => {
+    const openProjects: OpenProjectByCwd[] = [
+      { cwd: '/repo/vendor/lib', projectId: 'proj-lib' },
+      { cwd: '/repo/vendor/other', projectId: 'proj-other' }
+    ]
+    const existingGroup = new Map([
+      ['proj-lib', 'g-lib'],
+      ['proj-other', 'g-other']
+    ])
+    const plan = planSubmoduleLinks(
+      refGroup,
+      '/repo',
+      [sub('vendor/lib'), sub('vendor/other'), sub('vendor/closed')],
+      openProjects,
+      existingGroup,
+      new Set()
+    )
+    expect(plan.links).toHaveLength(2)
+    expect(plan.links.map((l) => l.id).sort()).toEqual(['dep-g-lib-g-parent', 'dep-g-other-g-parent'])
+    expect(plan.suggestions).toEqual([{
+      path: '/repo/vendor/closed',
+      relativePath: 'vendor/closed',
+      sourceGroupId: 'g-parent',
+      sourceProjectId: 'proj-parent'
+    }])
+  })
+})
+
+describe('existingDependencyLinkKeys', () => {
+  it('collects only dependency-link ids', () => {
+    const links = [
+      { id: 'dep-a-b', kind: 'dependency', source: { ref: 'node', nodeId: 'a' }, target: { ref: 'node', nodeId: 'b' } },
+      { id: 'bridge-c-d', kind: 'context', source: { ref: 'node', nodeId: 'c' }, target: { ref: 'node', nodeId: 'd' } },
+      { id: 'ctrl-e-f', kind: 'lineage', source: { ref: 'node', nodeId: 'e' }, target: { ref: 'node', nodeId: 'f' } }
+    ] as const
+    expect(existingDependencyLinkKeys(links as never)).toEqual(new Set(['dep-a-b']))
+  })
+
+  it('returns an empty set for undefined links', () => {
+    expect(existingDependencyLinkKeys(undefined)).toEqual(new Set())
+  })
+})

--- a/src/renderer/lib/submoduleLink.ts
+++ b/src/renderer/lib/submoduleLink.ts
@@ -1,0 +1,116 @@
+// Pure helpers for the meta-canvas submodule auto-link (ticket 09). Kept free of React/store/git
+// imports so the plan is unit-testable: the effect in Canvas.tsx gathers the facts (the active
+// project's projectRef groups, each referenced project's repo root + submodule list, the open
+// projects' cwds) and hands them here; this decides what `dependency` links to upsert and what
+// projectRef groups to create. A `dependency` link between two projectRef groups on the SAME
+// meta-canvas is a `node`↔`node` edge (`dependencyLink`), so it renders as a visible amber edge.
+
+import type { Link } from '@shared/types'
+import type { SubmoduleEntry } from '@shared/worktree'
+import { dependencyLink } from './noteLink'
+
+/** A projectRef group on the active (meta) canvas, with the repo it references resolved. */
+export interface RefGroup {
+  /** The group node id on the meta-canvas. */
+  groupId: string
+  /** The referenced project's id. */
+  projectId: string
+}
+
+/** An open project keyed by its working directory (the cwd lookup, like `openFolderProject`). */
+export interface OpenProjectByCwd {
+  cwd: string
+  projectId: string
+}
+
+export interface SubmoduleLinkPlan {
+  /** `dependency` links to upsert (idempotent by id — the caller dedupes against existing). */
+  links: Link[]
+  /** Project ids that need a NEW projectRef group on the meta-canvas (no group exists for them yet).
+   *  The caller creates a `kind:'group'` node with `data.projectRef:{projectId}` for each. */
+  groupsToCreate: { projectId: string; color?: string }[]
+  /** Derived, non-persisted project tiles for submodules that are not open as projects yet. */
+  suggestions: SubmoduleProjectSuggestion[]
+}
+
+export interface SubmoduleProjectSuggestion {
+  /** Absolute folder path the Open action registers as a project. */
+  path: string
+  /** Relative path from the referencing repository, used as the concise tile label. */
+  relativePath: string
+  /** The projectRef group the suggestion is visually anchored beside. */
+  sourceGroupId: string
+  /** The project whose .gitmodules entry produced the suggestion. */
+  sourceProjectId: string
+}
+
+/**
+ * Decide the `dependency` links and new projectRef groups for one referenced project's submodules.
+ *
+ * `repoRoot` is the referenced project's git root; each submodule `path` is RELATIVE to it, so the
+ * absolute path the cwd lookup needs is `repoRoot + '/' + sub.path`. For a submodule whose absolute
+ * path matches an OPEN project: draw a `dependency` link from the submodule's projectRef group to
+ * the referencing project's group — BOTH are real group nodes on the meta-canvas, so it is a
+ * visible `node`↔`node` edge. If no projectRef group exists yet for the submodule project, request
+ * one (`groupsToCreate`); the caller creates it and the link references the new group id (which the
+ * caller knows once it mints the node).
+ *
+ * `existingGroupForProject` maps a referenced project id → the group node id already on the
+ * meta-canvas that references it (so a link is only drawn between two GROUPS, never a dangling
+ * endpoint). `existingLinkKeys` is the set of dependency-link ids already persisted, so the plan is
+ * idempotent across re-runs (re-opening the meta-canvas doesn't duplicate edges).
+ *
+ * The link direction is submodule → referencing project (child depends on parent), matching
+ * `dependencyLink`'s `dep-` id convention and the two-host branch dependency direction.
+ */
+export function planSubmoduleLinks(
+  ref: RefGroup,
+  repoRoot: string,
+  submodules: readonly SubmoduleEntry[],
+  openProjects: readonly OpenProjectByCwd[],
+  existingGroupForProject: ReadonlyMap<string, string>,
+  existingLinkKeys: ReadonlySet<string>
+): SubmoduleLinkPlan {
+  const links: Link[] = []
+  const groupsToCreate: { projectId: string; color?: string }[] = []
+  const suggestions: SubmoduleProjectSuggestion[] = []
+  const root = repoRoot.replace(/\/+$/, '')
+  for (const sub of submodules) {
+    // An uninitialized/deleted checkout has no folder a project could open. Keep the existing facts
+    // untouched and offer nothing until git reports a live working tree.
+    if (sub.prunable) continue
+    const absPath = `${root}/${sub.path.replace(/^\/+/, '')}`
+    const match = openProjects.find((p) => p.cwd === absPath)
+    if (!match) {
+      suggestions.push({
+        path: absPath,
+        relativePath: sub.path,
+        sourceGroupId: ref.groupId,
+        sourceProjectId: ref.projectId
+      })
+      continue
+    }
+    const subGroupId = existingGroupForProject.get(match.projectId)
+    if (!subGroupId) {
+      // No group on the meta-canvas references this submodule project yet — request one. The link
+      // is still added referencing `subGroupId` (unknown here), so the CALLER must mint the group
+      // FIRST and substitute its id, or skip the link until the next run. To keep the plan pure and
+      // avoid a forward reference, we DO NOT add a link with an unknown id here; the next run (after
+      // the group is created) picks it up. This means a freshly-discovered submodule project gets its
+      // group on this run and its edge on the NEXT — one extra tick, never a dangling edge.
+      groupsToCreate.push({ projectId: match.projectId })
+      continue
+    }
+    const link = dependencyLink(subGroupId, ref.groupId)
+    if (existingLinkKeys.has(link.id)) continue
+    links.push(link)
+  }
+  return { links, groupsToCreate, suggestions }
+}
+
+/** The set of dependency-link ids already on a project's `links` (for idempotent upsert). */
+export function existingDependencyLinkKeys(links: readonly Link[] | undefined): Set<string> {
+  const out = new Set<string>()
+  for (const l of links ?? []) if (l.kind === 'dependency') out.add(l.id)
+  return out
+}

--- a/src/renderer/lib/ui-visibility.test.ts
+++ b/src/renderer/lib/ui-visibility.test.ts
@@ -27,7 +27,7 @@ describe('hideable inventories', () => {
       'markdown-view', 'refresh-terminal'
     ])
     expect(HIDEABLE_HEADER_BUTTONS.map((r) => r.id)).toEqual([
-      'refresh', 'mic', 'ai-name', 'comments', 'hide-fanout', 'tidy-fanout'
+      'refresh', 'mic', 'ai-name', 'comments', 'links', 'hide-fanout', 'tidy-fanout'
     ])
   })
   it('gives every entry a user-facing label', () => {

--- a/src/renderer/lib/ui-visibility.ts
+++ b/src/renderer/lib/ui-visibility.ts
@@ -34,6 +34,7 @@ export const HIDEABLE_HEADER_BUTTONS: readonly HideableRow[] = [
   { id: 'mic', label: 'Dictate' },
   { id: 'ai-name', label: 'Name with AI' },
   { id: 'comments', label: 'Comments' },
+  { id: 'links', label: 'Links' },
   { id: 'hide-fanout', label: 'Hide subagent/loop cards' },
   { id: 'tidy-fanout', label: 'Tidy subagent cards' }
 ]

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -5,8 +5,9 @@ import { NODE_COLORS, ungroupNodes, type CanvasNode } from '../state/workspace'
 import { useProjects } from '../state/projects'
 import { useWorktrees, WORKTREE_STATUS_POLL_MS } from '../state/worktrees'
 import { useProjectSetup } from '../state/projectSetup'
+import { isBranchDependencyLink } from '../lib/link-authoring'
 
-export type WorktreeAction = 'merge' | 'remove' | 'unbind' | 'rerun-setup'
+export type WorktreeAction = 'merge' | 'remove' | 'unbind' | 'rerun-setup' | 'sync'
 
 /**
  * Worktree-action handler bridge. React Flow instantiates custom nodes itself, so we can't
@@ -22,6 +23,16 @@ export function setWorktreeActionHandler(
 }
 
 /**
+ * Drill-into-group handler bridge (ticket 07 — node-group ↔ canvas isomorphism). Same indirection as
+ * `worktreeActionHandler`: Canvas registers `openNodeGroupAsCanvas` here so the group's "open as
+ * canvas" affordance can trigger the drill without prop drilling through React Flow.
+ */
+let drillHandler: ((groupId: string) => void) | null = null
+export function setDrillHandler(fn: ((groupId: string) => void) | null): void {
+  drillHandler = fn
+}
+
+/**
  * A group frame: a dashed, rounded, translucent box that contains child nodes. A floating
  * label pill (color dot + name) sits on the top border; ungroup/× appear top-right on hover.
  * Children are real React Flow nodes parented to this one, so dragging the frame moves them
@@ -34,6 +45,18 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const frameRef = useRef<HTMLDivElement | null>(null)
 
   const wt = data.worktree
+  // Cross-project reference (ticket 09): when set, this group frame REFERENCES another project's
+  // canvas. Drilling the frame (the ⤢ button below) switches the active project to the referenced
+  // one instead of promoting this group's children. Resolved here only to render a badge (the
+  // referenced project's color dot + name) and to grey the frame when the referenced project is
+  // gone/unavailable/closed — the drill handler in Canvas refuses in that case, so the visual is
+  // the honest signal. Like `wt`, a `projectRef` group may ALSO hold local children on the
+  // meta-canvas; the badge is additive, not a replacement for the group's own label.
+  const ref = data.projectRef as { projectId: string } | undefined
+  const refProject = useProjects((s) =>
+    ref ? s.projects.find((p) => p.id === ref.projectId) : undefined
+  )
+  const refUnavailable = !!ref && (!refProject || refProject.unavailable || refProject.closed)
   // The store is the ONLY caller of the worktree/status git IPC; it throttles
   // (WORKTREE_STATUS_THROTTLE_MS) and is epoch-guarded, so asking often is free.
   const status = useWorktrees((s) => (wt ? s.statusByPath[wt.path] : undefined))
@@ -52,6 +75,18 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
   // mistaken for "nothing is happening".
   const setupPending = useProjectSetup((s) => (s.pendingByGroup[id] ?? 0) > 0)
   const setupBusy = setupPending || setupRun?.state === 'running'
+  // Does a `dependency` link name this group's branch as the CHILD (source)? That is the gate for
+  // the ↻ Sync button: a stack to rebase onto a parent exists only when the lineage is declared.
+  // Reads the active project's links (a dependency link is project-scoped). The branch git reports
+  // NOW wins over the persisted `wt.branch` (the user may have switched inside the worktree).
+  const branchNow = wt ? status?.branch || wt.branch : ''
+  const hasDepParent = useProjects((s) => {
+    if (!wt || !branchNow) return false
+    const proj = s.projects.find((p) => p.id === s.activeProjectId)
+    return !!(proj?.links ?? []).some(
+      (l) => isBranchDependencyLink(l) && l.source.branch === branchNow
+    )
+  })
 
   // On an SSH project the poll is OFF, not merely useless: `git status <path>` would be answered by
   // the LOCAL filesystem for a project whose checkout lives on the host (remote git routing is
@@ -274,6 +309,15 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
                 ⤴
               </button>
             )}
+            {!stale && hasDepParent && (
+              <button
+                className="group-node__wt-btn"
+                title="Sync: rebase this branch onto its dependency parent"
+                onClick={() => worktreeActionHandler?.(id, 'sync')}
+              >
+                ↻
+              </button>
+            )}
             <button
               className="group-node__wt-btn"
               title={
@@ -296,9 +340,43 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
             )}
           </div>
         )}
+        {ref && (
+          <div className="group-node__wt nodrag">
+            {refUnavailable ? (
+              <span
+                className="group-node__branch group-node__branch--stale"
+                title={
+                  !refProject
+                    ? `Referenced project is no longer available.\nReopen its folder to restore it (the same cwd-derived id).`
+                    : `Referenced project is ${refProject.unavailable ? 'unavailable' : 'closed'}.\nReopen it to drill into it.`
+                }
+              >
+                ↗ unavailable project
+              </span>
+            ) : (
+              <span
+                className="group-node__branch"
+                title={`Drill into project: ${refProject!.name}`}
+              >
+                <span
+                  className="group-node__dot"
+                  style={{ display: 'inline-block', background: refProject!.color ?? '#0a84ff' }}
+                />{' '}
+                ↗ {refProject!.name}
+              </span>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="group-node__actions nodrag">
+        <button
+          className="group-node__drill"
+          title="Open as canvas (drill into this group)"
+          onClick={() => drillHandler?.(id)}
+        >
+          ⤢
+        </button>
         <button className="group-node__ungroup" title="Ungroup" onClick={ungroup}>
           ungroup
         </button>

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -122,7 +122,7 @@ import {
 } from '../terminal/agent-restart'
 import { WakeInputBuffer } from '../terminal/wake-input-buffer'
 import { FindBar } from '../components/FindBar'
-import { IconSearch, IconChat, IconMic, IconReload, IconEye, IconEyeOff, IconGrid } from '../components/icons'
+import { IconSearch, IconChat, IconMic, IconReload, IconEye, IconEyeOff, IconGrid, IconLink } from '../components/icons'
 import { NodeLabels } from '../components/kanban/NodeLabels'
 import { Tooltip } from '../components/Tooltip'
 import { useTerminalSearch } from '../terminal/useTerminalSearch'
@@ -176,6 +176,7 @@ import { matchesShortcut } from '@shared/shortcut'
 import { hintLabel, isWindowsPlatform, isMacPlatform } from '@shared/platform-utils'
 import { ColumnPill } from '../components/kanban/ColumnPill'
 import { BoardLogPanel } from '../components/kanban/BoardLogPanel'
+import { LinkInspectorPanel } from '../components/links/LinkInspectorPanel'
 import { AgentMascot } from './AgentMascot'
 import { connectHostAttachment } from '../lib/sshAttachments'
 
@@ -1272,6 +1273,9 @@ export function TerminalNode({
   const claudeTranscript = readsClaudeTranscript(agentId)
   // The header 💬 now opens the board-log comments flyout (right side); ⌘M keeps the markdown/chat view.
   const [commentsOpen, setCommentsOpen] = useState(false)
+  // The header 🔗 opens the off-canvas link inspector flyout (ticket 06): list/delete a node's
+  // links + "Add link" to author a cross-project/branch/dependency link off-canvas.
+  const [linksOpen, setLinksOpen] = useState(false)
   const canRenameNode = !!agentId && canRename(agentId) // WRITE leg: push `/rename <name>` back
   // READ leg: adopt the agent's own session name into the title. A superset of canRenameNode —
   // gemini names its own sessions but has no rename command, so it polls and never pushes.
@@ -4662,6 +4666,17 @@ export function TerminalNode({
               </button>
             </Tooltip>
           )}
+        {!isHidden('links', hiddenHeaderButtons) && (
+          <Tooltip label="Links — connect to a node, foreign canvas, or branch">
+            <button
+              className="term-node__link nodrag"
+              aria-pressed={linksOpen}
+              onClick={() => setLinksOpen((v) => !v)}
+            >
+              <IconLink />
+            </button>
+          </Tooltip>
+        )}
         <button
           className="term-node__close"
           title="Close (ends the session)"
@@ -4805,6 +4820,10 @@ export function TerminalNode({
         <BoardLogPanel card={{ id }} />
       </div>
     )}
+    {/* Off-canvas link inspector flyout (ticket 06) — a sibling of the root like the comments
+        flyout, expanding to the node's right (the panel's `.term-node__links` root is
+        position:absolute relative to the node). Lists/deletes this node's links + "Add link". */}
+    {linksOpen && !collapsed && <LinkInspectorPanel nodeId={id} mount="flyout" />}
     </>
   )
 }

--- a/src/renderer/nodes/XProjectNode.tsx
+++ b/src/renderer/nodes/XProjectNode.tsx
@@ -1,0 +1,323 @@
+import { useEffect, useRef, useState } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react'
+import { quantizeCharSize } from '../terminal/char-size-quantize'
+import { reportsOwnCopy } from '@shared/agents/config'
+import type { AgentId, BuiltinAgentId } from '@shared/agents/config'
+import { useSession } from '../session/session'
+import { useSettings } from '../state/settings'
+import { LocalTransport } from '../terminal/local-transport'
+import { parseOsc52 } from '../terminal/osc52'
+import { activateUnicode11 } from '../terminal/unicode-width'
+import { useCopyFeedback } from '../terminal/useCopyFeedback'
+import {
+  attachReplay,
+  cursorPlacementSeq,
+  seedPaint,
+  stripTrailingNewline,
+  terminalKeyAction,
+  toXtermText,
+  xtermOptionsFromSettings,
+  SHIFT_ENTER_SEQ,
+  CO_ATTACH_MOUSE_SEQ
+} from '../terminal/terminal-config'
+import { resolveSshRemote, reportSshDrop } from './TerminalNode'
+import { buildSshArgs, type SshConnection } from '@shared/ssh'
+import { travelToNode } from './travel-handler'
+import { liveProjectJumpTarget } from '../lib/projectJump'
+import { NODE_MIN_SIZES } from '../lib/nodeSizing'
+import type { CanvasNode } from '../state/workspace'
+import type { CanvasNodeState, Project } from '@shared/types'
+
+/** The B-side context the projection needs to co-attach to B's session — the subset of B's node's
+ *  `data` plus B's project identity, handed down from the ephemeral derivation in Canvas. */
+export interface XProjectSpawn {
+  bProjectId: string
+  bNodeId: string
+  /** B's serialized node — the owner of the session this projection joins. */
+  bNode: CanvasNodeState
+  /** B's project, for ssh resolution + the origin badge. */
+  bProject: Project
+}
+
+/**
+ * A cross-project PROJECTION (ticket 05) — a derived, greyed/dotted canvas node that is a SECOND
+ * live client on ANOTHER project's tmux session.
+ *
+ * It is the canvas-node analogue of `ModalTerminal`: the same viewer-identity co-attach (a per-mount
+ * `viewerId` makes this an independent subscriber of B's shared session), the same seed-paint from
+ * the joiner screen, the same CO_ATTACH_MOUSE fix. What is DIFFERENT and load-bearing:
+ *
+ * - **`requireExisting: true`** — a projection is a VIEWER, never the owner. It must never spawn B's
+ *   session. The refusal lives in core's `create()` (after the in-flight barrier + tombstone, before
+ *   the spawn branch): if B's session is not live yet, the create returns `unavailable: 'no-session'`
+ *   rather than becoming the node's owner. A projection that spawned would steal pane ownership,
+ *   run under the wrong project's resolved cwd/account, and persist a session B never asked for.
+ * - **B's project context, not A's.** `cwd`/`agentId`/`accountId`/`ssh` come from B's node; ssh is
+ *   resolved against B's (possibly remote) ControlMaster via `resolveSshRemote(bProject.ssh.server,
+ *   …)`, which keys on connection scope — not on the active canvas — so a projection in A reaches
+ *   B's host. `ownerProjectId` is B (B owns the session).
+ * - **No park, no WebGL budget, no flow-control** (DOM renderer only). A projection must not be a
+ *   budget-free second GPU context on top of B's node, and it is a viewer — the shared session's
+ *   flow/pacing is driven by B's canvas client. Same stance as the modal.
+ * - **Retry on `no-session`.** B's canvas may not be mounted, so the session may not exist yet. The
+ *   projection shows a placeholder and re-tries on a bounded interval; once B mounts its node and
+ *   spawns, a retry joins it.
+ *
+ * Like `subagent`/`loop`, this node lives outside React Flow's managed `nodes` array (merged only at
+ * `<ReactFlow nodes={allNodes}>`), is never persisted (its `xproj-` id is filtered out by
+ * `isEphemeralNodeId`), and is `selectable: false` so a rubber band never sweeps it into a
+ * selection meant for real nodes.
+ */
+export function XProjectNode({ id, data, selected }: NodeProps<CanvasNode>) {
+  const { api } = useSession()
+  const hostRef = useRef<HTMLDivElement>(null)
+  const termRef = useRef<Terminal | null>(null)
+  const fitRef = useRef<FitAddon | null>(null)
+  const transportRef = useRef<LocalTransport | null>(null)
+
+  // The B-side context rides the ephemeral node's data (set by the Canvas derivation, §4). It is
+  // NOT persisted — the node itself never round-trips through flowToNodeStates — so reading it
+  // through the `[key: string]: unknown` index is fine.
+  const spawn = data.xprojSpawn as XProjectSpawn | undefined
+  const originName = (data.xprojOriginName as string) || spawn?.bProject.name || ''
+  const originColor = (data.color as string) || spawn?.bProject.color || '#8e8e93'
+
+  const copy = useCopyFeedback({
+    hostRef,
+    hasSelection: () => !!termRef.current?.hasSelection(),
+    // Same agent gate as the modal/canvas node: a claude projection stays silent because claude
+    // prints its own "copied N chars" line — a second message for one gesture is noise.
+    enabled: !reportsOwnCopy(spawn?.bNode.agentId as AgentId | undefined)
+  })
+
+  // Bump to re-run the create effect after a `no-session` retry timeout (see below).
+  const [retry, setRetry] = useState(0)
+  // The plate shown when B's session is not live / not connected. `null` once attached.
+  const [plate, setPlate] = useState<'no-session' | 'ssh' | 'closed' | null>('no-session')
+
+  useEffect(() => {
+    if (!spawn) return
+    const { bProjectId, bNodeId, bNode, bProject } = spawn
+    // A unique viewerId per mount: the core namespaces it per connection, so uniqueness only has to
+    // hold within THIS window. `xproj-<B>-<node>` makes it a distinct subscriber of B's session.
+    const viewerId = `xproj-${bProjectId}-${bNodeId}-${Math.random().toString(36).slice(2, 8)}`
+    const transport = new LocalTransport(api, viewerId)
+    const s = useSettings.getState().settings
+    const term = new Terminal(xtermOptionsFromSettings(s))
+    activateUnicode11(term)
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    termRef.current = term
+    fitRef.current = fit
+    transportRef.current = transport
+    term.open(hostRef.current!)
+    quantizeCharSize(term)
+    fit.fit()
+
+    let sessionId: string | null = null
+    let dead = false
+    const cleanups: Array<() => void> = []
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
+    // `retry` from the closure is the run index — use it to cap retries so a projection whose B
+    // never mounts stops polling after a bounded window and leaves the persistent plate.
+    const attempt = retry
+
+    // MIRROR ModalTerminal — the OSC 52 clipboard-write path (tmux's mouse is ON; a drag-select in
+    // copy-mode emits OSC 52 to this client). `parseOsc52` returns null for a `?` read query so a
+    // remote program can never read the local clipboard. Returning true swallows the sequence.
+    term.parser.registerOscHandler(52, (oscData) => {
+      const text = parseOsc52(oscData)
+      if (text !== null) {
+        window.nodeTerminal.clipboard.writeText(text)
+        copy.notifyCopy(text)
+      }
+      return true
+    })
+
+    // MIRROR ModalTerminal — copy chords (Cmd+C / Ctrl+Shift+C / Ctrl+Insert) copy the xterm
+    // selection and are always swallowed (else Ctrl+Shift+C falls through to the pty as \x03);
+    // Shift+Enter → ESC+CR so agent CLIs insert a newline; project-jump digits are swallowed when
+    // the app owns the key.
+    term.attachCustomKeyEventHandler((e) => {
+      const action = terminalKeyAction(e, term.hasSelection(), liveProjectJumpTarget(e) !== null)
+      if (action === 'pass') return true
+      e.preventDefault()
+      if (action === 'copy') window.nodeTerminal.clipboard.writeText(term.getSelection())
+      else if (action === 'shift-enter' && sessionId) transport.write(sessionId, SHIFT_ENTER_SEQ)
+      return false
+    })
+
+    void (async () => {
+      const bSsh = bProject.ssh
+      const sshRemote = bSsh ? await resolveSshRemote(bSsh.server, bNode.cwd) : undefined
+      if (dead) return
+      // B is an SSH project whose master is down: spawn NOTHING (the requireRemote precedent — a
+      // create without `sshRemote` would fall through to a LOCAL session wearing B's identity). The
+      // projection says so and queues B's project for the reconnect coordinator.
+      if (bSsh && !sshRemote) {
+        setPlate('ssh')
+        reportSshDrop(bProjectId, bNodeId)
+        return
+      }
+      // A local `ssh <host>` node runs ssh as its own pty program; an SSH-PROJECT node uses remote
+      // tmux (sshRemote). B's node carries `ssh` for the former; `bProject.ssh` implies the latter.
+      const localSsh = !!bNode.ssh && !bNode.sshRemoteTmux && !bSsh
+      const res = await transport.create({
+        cols: term.cols,
+        rows: term.rows,
+        shell: localSsh ? 'ssh' : bNode.shell,
+        shellArgs: localSsh ? buildSshArgs(bNode.ssh!) : undefined,
+        cwd: bNode.cwd,
+        persistKey: bNodeId,
+        // B owns the session — recorded main-side on a genuine fresh spawn (which `requireExisting`
+        // forbids here, but the ledger value is still correct for any co-attach accounting).
+        ownerProjectId: bProjectId,
+        agentId: bNode.agentId,
+        accountId: bNode.accountId,
+        sshRemote,
+        requireRemote: !!bSsh,
+        // The load-bearing difference: a projection JOINS or refuses, never spawns. Without this a
+        // projection of a not-yet-mounted B would become the owner of B's session.
+        requireExisting: true
+      })
+      // B's session is not live yet (B's canvas not mounted / B's node never spawned). Show the
+      // placeholder and re-try on a bounded interval — once B mounts and spawns, a retry joins it.
+      if (res.unavailable === 'no-session') {
+        setPlate('no-session')
+        // Stop re-trying after a bounded window: a projection whose B never mounts leaves the
+        // persistent plate rather than polling forever (the user opens B to start the session).
+        if (attempt < XPROJ_RETRY_MAX) {
+          retryTimer = setTimeout(() => setRetry((v) => v + 1), XPROJ_RETRY_MS)
+        }
+        return
+      }
+      // Refused core-side (B's remote master died inside the round-trip, or `ssh` is missing).
+      if (res.unavailable === 'ssh') {
+        setPlate('ssh')
+        reportSshDrop(bProjectId, bNodeId)
+        return
+      }
+      // Another client permanently deleted B's node — never resurrect it.
+      if (res.closed) {
+        setPlate('closed')
+        return
+      }
+      // Unmounted while the create was in flight: detach the viewer we may have registered.
+      if (dead) {
+        transport.kill(res.sessionId)
+        return
+      }
+      sessionId = res.sessionId
+      setPlate(null)
+      cleanups.push(transport.onData(res.sessionId, (d) => term.write(d)))
+      cleanups.push(
+        transport.onExit(res.sessionId, () =>
+          term.write('\r\n\x1b[90m[session ended]\x1b[0m\r\n')
+        )
+      )
+      if (transport.onSize)
+        cleanups.push(transport.onSize(res.sessionId, (size) => term.resize(size.cols, size.rows)))
+      term.onData((d) => sessionId && transport.write(sessionId, d))
+      // DELIBERATELY omitted vs. TerminalNode: no flow-control pause (transport.setFlow) — the pty's
+      // pacing comes from B's canvas client; the projection is a second view and never drives flow.
+
+      // A projection never owns a cold-start scrollback (`requireExisting` ⇒ no fresh spawn), so the
+      // snapshot is always null and `fresh` is false. Paint B's server-captured screen exactly as the
+      // modal co-attach does (capture-pane text → CRLFs via toXtermText, then the cursor placement).
+      const paint = seedPaint({
+        replay: attachReplay({ parked: false, fresh: res.fresh, hasInitialCommand: false }),
+        superseded: false,
+        snapshot: null,
+        screen: res.screen
+      })
+      if (paint === 'create-screen' && res.screen) {
+        term.write('\x1b[0m' + toXtermText(stripTrailingNewline(res.screen)))
+        term.write(cursorPlacementSeq(res.cursor))
+      }
+      // Co-attach joiners miss the mouse-tracking mode tmux only sends at its own attach — enable it
+      // here so the wheel scrolls tmux history (byte-identical to ModalTerminal).
+      if (res.coAttachMouse) term.write(CO_ATTACH_MOUSE_SEQ)
+
+      const ro = new ResizeObserver(() => {
+        fit.fit()
+        if (sessionId) transport.resize(sessionId, term.cols, term.rows)
+      })
+      ro.observe(hostRef.current!)
+      cleanups.push(() => ro.disconnect())
+      transport.resize(res.sessionId, term.cols, term.rows)
+      term.focus()
+    })()
+
+    return () => {
+      dead = true
+      cleanups.forEach((fn) => fn())
+      if (retryTimer) clearTimeout(retryTimer)
+      // Kill ONLY this projection's viewer — the instance appends its viewerId. B's canvas client
+      // (or parked client) is a different composite subscriber and is untouched; B's shared pty
+      // lives on until its last view goes.
+      if (sessionId) transport.kill(sessionId)
+      term.dispose()
+      termRef.current = null
+      fitRef.current = null
+      transportRef.current = null
+    }
+    // `retry` is the re-trigger; `id` pins the effect to this projection. `spawn` is captured per
+    // run (the derivation rebuilds it when B's nodes/links change). The copy object is stable per
+    // mount (useCopyFeedback memoizes its sink) so it is intentionally not a dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, spawn, retry])
+
+  const onJump = () => {
+    if (spawn) travelToNode(spawn.bNodeId)
+  }
+
+  return (
+    <div
+      className={`xproj-node${selected ? ' selected' : ''}`}
+      style={{ '--xproj-stroke': originColor } as React.CSSProperties}
+    >
+      <NodeResizer
+        isVisible={selected}
+        minWidth={NODE_MIN_SIZES.terminal.width}
+        minHeight={NODE_MIN_SIZES.terminal.height}
+        color={originColor}
+      />
+      <Handle type="target" position={Position.Top} isConnectable={false} />
+      <div className="xproj-node__header nodrag">
+        <span className="xproj-node__origin" style={{ color: originColor }}>
+          <span className="xproj-node__dot" style={{ background: originColor }} />
+          {originName}
+        </span>
+        <span className="xproj-node__title">{(data.title as string) || 'projection'}</span>
+        <button
+          className="xproj-node__jump"
+          title={`Open in ${originName}`}
+          onClick={(e) => {
+            e.stopPropagation()
+            onJump()
+          }}
+        >
+          ↗
+        </button>
+      </div>
+      <div className="xproj-node__body nodrag nowheel" ref={hostRef} />
+      {plate && (
+        <div className="xproj-node__plate">
+          {plate === 'no-session' &&
+            `${originName}'s session is not live yet — open ${originName} (or wait for it to mount) and this view connects.`}
+          {plate === 'ssh' &&
+            `Not connected to ${originName}'s host — nothing was started. Reconnect ${originName} and retry.`}
+          {plate === 'closed' && `${originName}'s session was closed by another user.`}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** How long a projection waits before re-trying a `no-session` create. B's canvas mount is the real
+ *  signal; this interval is the honest bounded fallback until B's `TerminalNode` mounts and spawns.
+ *  Bounded by `XPROJ_RETRY_MAX` attempts, after which the plate persists (open B to start it). */
+const XPROJ_RETRY_MS = 2000
+const XPROJ_RETRY_MAX = 15

--- a/src/renderer/nodes/travel-handler.ts
+++ b/src/renderer/nodes/travel-handler.ts
@@ -1,0 +1,27 @@
+/**
+ * Node-travel handler bridge (ticket 05 — cross-project projection `↗`).
+ *
+ * React Flow instantiates custom nodes itself, so Canvas can't pass `travelToNode` (the cross-
+ * project switch + focus routine a notification click uses) through props. Canvas registers it
+ * here; a projection's `↗` button calls `travelToNode(id)` to switch to the foreign project that
+ * owns the node and frames it there. Kept as a tiny bridge because React Flow instantiates custom
+ * nodes itself, so Canvas cannot pass the callback through ordinary component props.
+ *
+ * The handler is set to `null` on Canvas unmount so a stale registration from a previous mount can
+ * never travel into a canvas that no longer exists.
+ */
+let travelHandler: ((nodeId: string) => void) | null = null
+
+/** Canvas registers `travelToNode` here on mount. */
+export function setTravelNodeHandler(fn: ((nodeId: string) => void) | null): void {
+  travelHandler = fn
+}
+
+/**
+ * Switch to the project that owns `id` and focus the node there. A no-op when no handler is
+ * registered (e.g. the node is rendered outside Canvas — a test harness), so a projection's `↗`
+ * degrades to nothing rather than throwing.
+ */
+export function travelToNode(nodeId: string): void {
+  travelHandler?.(nodeId)
+}

--- a/src/renderer/state/projects.mutation.test.ts
+++ b/src/renderer/state/projects.mutation.test.ts
@@ -75,3 +75,36 @@ describe('applyNodeMutation', () => {
     expect(useProjects.getState().projects).toHaveLength(0)
   })
 })
+
+/** `addNodeToProject` — the seam canvas-control `open-agent --project <B>` (ticket 05) writes a
+ *  foreign node through: B's canvas is NOT the active one, so the node has to land in B's
+ *  serialized store directly (no live `setNodes`), and B's project.json must carry it so a cold
+ *  start of B reattaches it. A plain append (not an upsert mutation), so it has its own helper. */
+describe('addNodeToProject', () => {
+  it('appends a node to the named project only', () => {
+    const a = useProjects.getState().addProject('a')
+    const b = useProjects.getState().addProject('b')
+    useProjects.getState().commitCanvas(b.id, [node('b1')], { x: 0, y: 0, zoom: 1 })
+
+    useProjects.getState().addNodeToProject(b.id, node('b2', 200))
+
+    expect(useProjects.getState().getProject(b.id)?.nodes.map((n) => n.id)).toEqual(['b1', 'b2'])
+  })
+
+  it('leaves every other project untouched', () => {
+    const a = useProjects.getState().addProject('a')
+    const b = useProjects.getState().addProject('b')
+    useProjects.getState().commitCanvas(a.id, [node('a1')], { x: 0, y: 0, zoom: 1 })
+    useProjects.getState().commitCanvas(b.id, [node('b1')], { x: 0, y: 0, zoom: 1 })
+
+    useProjects.getState().addNodeToProject(b.id, node('b2', 50))
+
+    expect(useProjects.getState().getProject(a.id)?.nodes.map((n) => n.id)).toEqual(['a1'])
+    expect(useProjects.getState().getProject(b.id)?.nodes.map((n) => n.id)).toEqual(['b1', 'b2'])
+  })
+
+  it('is a no-op for an unknown project (never invents one)', () => {
+    useProjects.getState().addNodeToProject('nope', node('x'))
+    expect(useProjects.getState().projects).toHaveLength(0)
+  })
+})

--- a/src/renderer/state/projects.sessions.test.ts
+++ b/src/renderer/state/projects.sessions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useProjects } from './projects'
-import type { CanvasNodeState } from '@shared/types'
+import type { CanvasNodeState, Link } from '@shared/types'
 
 const mkNode = (id: string): CanvasNodeState => ({
   id,
@@ -183,22 +183,32 @@ describe('reorderNode', () => {
   })
 })
 
-describe('control ropes persistence', () => {
-  // Visual "spawned by" ropes (agent CLI → new node) persist like bridges: committed with
-  // the canvas and carried into the workspace written to disk.
-  it('commitCanvas stores ropes and toWorkspace carries them', () => {
-    useProjects
-      .getState()
-      .commitCanvas(
-        'p1',
-        [mkNode('n1')],
-        { x: 0, y: 0, zoom: 1 },
-        [{ id: 'b1', source: 'n1', target: 'n2' }],
-        [{ id: 'ctrl-n1-n2', source: 'n1', target: 'n2' }]
-      )
+describe('link substrate persistence (context + lineage)', () => {
+  // Context links (formerly `bridges`) and lineage ropes (formerly `ropes`) now persist as ONE
+  // unified `Link[]` discriminated by `kind`. Committed with the canvas and carried into the
+  // workspace written to disk.
+  it('commitCanvas stores links and toWorkspace carries them', () => {
+    const links: Link[] = [
+      {
+        id: 'bridge-n1-n2',
+        kind: 'context',
+        source: { ref: 'node', nodeId: 'n1' },
+        target: { ref: 'node', nodeId: 'n2' }
+      },
+      {
+        id: 'ctrl-n1-n2',
+        kind: 'lineage',
+        source: { ref: 'node', nodeId: 'n1' },
+        target: { ref: 'node', nodeId: 'n2' },
+        meta: { displayOnly: true }
+      }
+    ]
+    useProjects.getState().commitCanvas('p1', [mkNode('n1')], { x: 0, y: 0, zoom: 1 }, links)
     const p = useProjects.getState().projects[0]
-    expect(p.bridges).toEqual([{ id: 'b1', source: 'n1', target: 'n2' }])
-    expect(p.ropes).toEqual([{ id: 'ctrl-n1-n2', source: 'n1', target: 'n2' }])
-    expect(useProjects.getState().toWorkspace().projects[0].ropes).toHaveLength(1)
+    expect(p.links).toEqual(links)
+    // Legacy fields are dropped on write (a migrated project stops carrying them).
+    expect(p.bridges).toBeUndefined()
+    expect(p.ropes).toBeUndefined()
+    expect(useProjects.getState().toWorkspace().projects[0].links).toHaveLength(2)
   })
 })

--- a/src/renderer/state/projects.ts
+++ b/src/renderer/state/projects.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand'
 import type { AgentPermissionMode } from '@shared/agents/config'
 import type {
-  BridgeLink,
   CanvasMutation,
   CanvasNodeState,
+  Link,
   Project,
   ProjectKanban,
   Viewport,
@@ -90,14 +90,9 @@ interface ProjectsState {
   setDinoHighScore(id: string, score: number): void
   /** Replaces the project's kanban board (the UI computes the next board via lib/kanban). */
   setProjectKanban(id: string, kanban: ProjectKanban): void
-  /** Writes the serialized canvas (nodes + viewport + bridge links + control ropes) back into a project. */
-  commitCanvas(
-    id: string,
-    nodes: CanvasNodeState[],
-    viewport: Viewport,
-    bridges?: BridgeLink[],
-    ropes?: BridgeLink[]
-  ): void
+  /** Writes the serialized canvas (nodes + viewport + the unified link substrate) back into a
+   *  project. `links` merges context + lineage edges (formerly the separate `bridges`/`ropes`). */
+  commitCanvas(id: string, nodes: CanvasNodeState[], viewport: Viewport, links?: Link[]): void
   /**
    * Applies ONE peer canvas mutation to a project's serialized nodes — the path for a project
    * that is loaded but NOT active (React Flow only holds the active project's nodes). Returns
@@ -108,6 +103,13 @@ interface ProjectsState {
    * they deleted on the very next save — the data-loss shape canvas sync exists to fix.
    */
   applyNodeMutation(projectId: string, mutation: CanvasMutation): boolean
+  /**
+   * Append a fully-formed `CanvasNodeState` to a (possibly NON-active) project's serialized nodes.
+   * The seam for canvas-control `open-agent --project <B>` (ticket 05): the node is created in
+   * project B, which is not the active canvas, so it cannot go through live `setNodes` — it lands
+   * in B's `Project.nodes` and appears when B is next loaded. Other projects are untouched.
+   */
+  addNodeToProject(projectId: string, node: CanvasNodeState): void
   /** Renames a node within a project (source of truth for inactive projects). */
   renameNode(projectId: string, nodeId: string, title: string): void
   /** Recolors a node within a project. */
@@ -418,11 +420,20 @@ export const useProjects = create<ProjectsState>((set, get) => ({
     }))
   },
 
-  commitCanvas(id, nodes, viewport, bridges, ropes) {
+  commitCanvas(id, nodes, viewport, links) {
     set((s) => ({
       projects: s.projects.map((p) =>
         p.id === id
-          ? { ...p, nodes, viewport, ...(bridges ? { bridges } : {}), ...(ropes ? { ropes } : {}) }
+          ? // Drop legacy `bridges`/`ropes` on write: a project loaded by a pre-`Link` build may
+            // still carry them in memory, and the writer migrates either shape to `links` — so
+            // leaving them set would double-serialize. `links` is undefined ⇒ an empty canvas
+            // (no edges), matching the old omit-when-empty posture.
+            (({ bridges: _b, ropes: _r, ...rest }) => ({
+              ...rest,
+              nodes,
+              viewport,
+              ...(links ? { links } : {})
+            }))(p)
           : p
       )
     }))
@@ -436,6 +447,13 @@ export const useProjects = create<ProjectsState>((set, get) => ({
       )
     }))
     return true
+  },
+
+  addNodeToProject(projectId, node) {
+    if (!get().projects.some((p) => p.id === projectId)) return
+    set((s) => ({
+      projects: mapProjectNodes(s.projects, projectId, (nodes) => [...nodes, node])
+    }))
   },
 
   renameNode(projectId, nodeId, title) {

--- a/src/renderer/state/workspace.drill.test.ts
+++ b/src/renderer/state/workspace.drill.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest'
+import {
+  drillGroupChildren,
+  flowToNodeStates,
+  nodeStatesToFlow,
+  remergeDrilledNodes,
+  rootPosition
+} from './workspace'
+import type { CanvasNode } from './workspace'
+
+const term = (id: string, pos: { x: number; y: number }, parentId?: string): CanvasNode =>
+  ({
+    id,
+    type: 'terminal',
+    position: pos,
+    width: 320,
+    height: 240,
+    data: { title: id, color: '#888', group: null },
+    ...(parentId ? { parentId, extent: 'parent' as const } : {})
+  }) as unknown as CanvasNode
+
+const grp = (id: string, pos: { x: number; y: number }, parentId?: string): CanvasNode =>
+  ({
+    id,
+    type: 'group',
+    position: pos,
+    width: 400,
+    height: 300,
+    data: { title: id, color: '#fff', group: null },
+    ...(parentId ? { parentId, extent: 'parent' as const } : {})
+  }) as unknown as CanvasNode
+
+describe('rootPosition (exported for the isomorphism)', () => {
+  it('sums a node position with every ancestor frame origin', () => {
+    const nodes = [
+      grp('outer', { x: 100, y: 100 }),
+      grp('inner', { x: 50, y: 50 }, 'outer'),
+      term('leaf', { x: 10, y: 10 }, 'inner')
+    ]
+    expect(rootPosition(nodes[2], nodes)).toEqual({ x: 160, y: 160 })
+  })
+})
+
+describe('drillGroupChildren', () => {
+  it("promotes a group's direct children to root-space and strips parentId/extent", () => {
+    const nodes = [
+      grp('g', { x: 200, y: 100 }),
+      term('a', { x: 10, y: 20 }, 'g'),
+      term('b', { x: 30, y: 40 }, 'g'),
+      term('sibling', { x: 500, y: 500 }) // a sibling at top level — must NOT appear in the drilled view
+    ]
+    const { flow, childIds } = drillGroupChildren(nodes, 'g')
+
+    expect(childIds).toEqual(new Set(['a', 'b']))
+    expect(flow.map((n) => n.id).sort()).toEqual(['a', 'b'])
+    // a was at (10,20) nested under g at (200,100) → root-space (210,120)
+    const a = flow.find((n) => n.id === 'a')!
+    expect(a.position).toEqual({ x: 210, y: 120 })
+    expect(a.parentId).toBeUndefined()
+    expect(a.extent).toBeUndefined()
+    // sibling is excluded
+    expect(flow.some((n) => n.id === 'sibling')).toBe(false)
+  })
+
+  it('keeps nested groups nested — only the drilled group’s DIRECT children are promoted', () => {
+    const nodes = [
+      grp('g', { x: 100, y: 100 }),
+      grp('inner', { x: 20, y: 20 }, 'g'),
+      term('leaf', { x: 5, y: 5 }, 'inner')
+    ]
+    const { flow, childIds } = drillGroupChildren(nodes, 'g')
+    // direct child is `inner`; `leaf` is a grandchild, NOT a direct child of g
+    expect(childIds).toEqual(new Set(['inner']))
+    expect(flow.map((n) => n.id)).toEqual(['inner'])
+    // inner keeps its own parentId? No — it is promoted to the sub-canvas top level, so parentId
+    // stripped, position promoted to root-space (100+20, 100+20) = (120,120).
+    const inner = flow[0]
+    expect(inner.parentId).toBeUndefined()
+    expect(inner.position).toEqual({ x: 120, y: 120 })
+  })
+
+  it('returns an empty flow for a group with no children', () => {
+    const nodes = [grp('g', { x: 0, y: 0 }), term('x', { x: 9, y: 9 })]
+    const { flow, childIds } = drillGroupChildren(nodes, 'g')
+    expect(flow).toEqual([])
+    expect(childIds.size).toBe(0)
+  })
+})
+
+describe('remergeDrilledNodes (commit-while-drilled round-trip)', () => {
+  it('merges edited drilled children back into the full array, re-nested, and preserves siblings', () => {
+    // Full canvas: group g at (200,100) with children a (10,20) and b (30,40), plus a top-level
+    // sibling `sib` that must survive the commit untouched.
+    const fullFlow: CanvasNode[] = [
+      grp('g', { x: 200, y: 100 }),
+      term('a', { x: 10, y: 20 }, 'g'),
+      term('b', { x: 30, y: 40 }, 'g'),
+      term('sib', { x: 500, y: 500 })
+    ]
+    const fullStored = flowToNodeStates(fullFlow)
+
+    // Drill → the active node-set is the children at root-space.
+    const { flow: drilledFlow } = drillGroupChildren(fullFlow, 'g')
+    // The user edits `a` while drilled: drags it to root-space (300,150).
+    const editedDrilled = drilledFlow.map((n) =>
+      n.id === 'a' ? { ...n, position: { x: 300, y: 150 } } : n
+    )
+    const drilledStates = flowToNodeStates(editedDrilled)
+
+    const committed = remergeDrilledNodes(fullStored, drilledStates, 'g', fullFlow)
+
+    // `a` is re-nested: root (300,150) minus g origin (200,100) = (100,50), parentId restored.
+    const a = committed.find((s) => s.id === 'a')!
+    expect(a.parentId).toBe('g')
+    expect(a.position).toEqual({ x: 100, y: 50 })
+    // `b` (un-edited) re-nests back to its original nested position (30,40).
+    const b = committed.find((s) => s.id === 'b')!
+    expect(b.parentId).toBe('g')
+    expect(b.position).toEqual({ x: 30, y: 40 })
+    // `sib` and the group frame `g` are untouched.
+    const sib = committed.find((s) => s.id === 'sib')!
+    expect(sib.parentId).toBeUndefined()
+    expect(sib.position).toEqual({ x: 500, y: 500 })
+    expect(committed.some((s) => s.id === 'g')).toBe(true)
+    // No nodes lost or duplicated.
+    expect(committed.map((s) => s.id).sort()).toEqual(['a', 'b', 'g', 'sib'])
+  })
+
+  it('round-trips an un-edited drill through remerge with positions unchanged', () => {
+    const fullFlow: CanvasNode[] = [
+      grp('g', { x: 200, y: 100 }),
+      term('a', { x: 10, y: 20 }, 'g')
+    ]
+    const fullStored = flowToNodeStates(fullFlow)
+    const { flow: drilledFlow } = drillGroupChildren(fullFlow, 'g')
+    const committed = remergeDrilledNodes(fullStored, flowToNodeStates(drilledFlow), 'g', fullFlow)
+    // a promoted to (210,120) then re-nested back to (10,20).
+    expect(committed.find((s) => s.id === 'a')!.position).toEqual({ x: 10, y: 20 })
+  })
+
+  it('survives a full load round-trip through nodeStatesToFlow', () => {
+    // The persisted states must re-flow to the same nested structure after a reload.
+    const fullFlow: CanvasNode[] = [
+      grp('g', { x: 200, y: 100 }),
+      term('a', { x: 10, y: 20 }, 'g')
+    ]
+    const fullStored = flowToNodeStates(fullFlow)
+    const { flow: drilledFlow } = drillGroupChildren(fullFlow, 'g')
+    const editedDrilled = drilledFlow.map((n) =>
+      n.id === 'a' ? { ...n, position: { x: 300, y: 150 } } : n
+    )
+    const committed = remergeDrilledNodes(fullStored, flowToNodeStates(editedDrilled), 'g', fullFlow)
+    // Reload: re-flow the committed states.
+    const reloaded = nodeStatesToFlow(committed)
+    const a = reloaded.find((n) => n.id === 'a')!
+    expect(a.parentId).toBe('g')
+    expect(a.position).toEqual({ x: 100, y: 50 })
+  })
+
+  it('appends a NEW child created while drilled, re-nested under the group (08 hazard)', () => {
+    // Full canvas: group g at (200,100) with child a; sib is a top-level sibling.
+    const fullFlow: CanvasNode[] = [
+      grp('g', { x: 200, y: 100 }),
+      term('a', { x: 10, y: 20 }, 'g'),
+      term('sib', { x: 500, y: 500 })
+    ]
+    const fullStored = flowToNodeStates(fullFlow)
+    // Drill → drilled view has `a` at root-space (210,120). The user creates a NEW terminal `c`
+    // while drilled, dropping it at root-space (300,300). `c` is in the drilled view but NOT in
+    // fullStored (it didn't exist at drill entry).
+    const drilledStates = flowToNodeStates([
+      { ...fullFlow[1], parentId: undefined, extent: undefined, position: { x: 210, y: 120 } },
+      term('c', { x: 300, y: 300 })
+    ])
+
+    const committed = remergeDrilledNodes(fullStored, drilledStates, 'g', fullFlow)
+
+    // `c` is appended, re-nested: root (300,300) minus g origin (200,100) = (100,200), parentId = g.
+    const c = committed.find((s) => s.id === 'c')!
+    expect(c.parentId).toBe('g')
+    expect(c.position).toEqual({ x: 100, y: 200 })
+    // Sibling + group frame + original child all preserved.
+    expect(committed.map((s) => s.id).sort()).toEqual(['a', 'c', 'g', 'sib'])
+    // On reload, `c` re-flows nested under g (parentId → extent:'parent' on reflow).
+    const reloaded = nodeStatesToFlow(committed)
+    const cFlow = reloaded.find((n) => n.id === 'c')!
+    expect(cFlow.parentId).toBe('g')
+    expect(cFlow.extent).toBe('parent')
+  })
+
+  it('drops a child deleted while drilled from the committed array', () => {
+    const fullFlow: CanvasNode[] = [
+      grp('g', { x: 200, y: 100 }),
+      term('a', { x: 10, y: 20 }, 'g'),
+      term('b', { x: 30, y: 40 }, 'g')
+    ]
+    const fullStored = flowToNodeStates(fullFlow)
+    // Drill → delete `a` while drilled: the drilled view now has only `b`.
+    const drilledFlow: CanvasNode[] = [
+      { ...fullFlow[2], parentId: undefined, extent: undefined, position: { x: 230, y: 140 } }
+    ]
+    const committed = remergeDrilledNodes(fullStored, flowToNodeStates(drilledFlow), 'g', fullFlow)
+    // `a` is gone; `b` and `g` remain.
+    expect(committed.map((s) => s.id).sort()).toEqual(['b', 'g'])
+  })
+})

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -538,6 +538,41 @@ describe('group worktree serialization', () => {
   })
 })
 
+describe('group projectRef serialization (ticket 09 meta-canvas)', () => {
+  // A projectRef group is an ordinary `kind:'group'` node carrying `data.projectRef`. It must round-trip
+  // through flowToNodeStates/nodeStatesToFlow so a reloaded meta-canvas re-derives its reference frames —
+  // without this, `data.projectRef` is silently dropped on persist and every reference disappears on reload.
+  it('round-trips data.projectRef on a group node', () => {
+    const group = {
+      id: 'group_ref',
+      type: 'group',
+      position: { x: 0, y: 0 },
+      width: 520,
+      height: 360,
+      data: {
+        title: 'References Project A',
+        color: '#0a84ff',
+        group: null,
+        projectRef: { projectId: 'proj-a' }
+      }
+    } as unknown as CanvasNode
+
+    const states = flowToNodeStates([group])
+    expect(states[0].projectRef).toEqual(group.data.projectRef)
+
+    const back = nodeStatesToFlow(states)
+    expect(back[0].data.projectRef).toEqual(group.data.projectRef)
+  })
+
+  it('leaves projectRef undefined for an ordinary group', () => {
+    const group = {
+      id: 'group_3', type: 'group', position: { x: 0, y: 0 }, width: 1, height: 1,
+      data: { title: 'G', color: '#fff', group: null }
+    } as unknown as CanvasNode
+    expect(flowToNodeStates([group])[0].projectRef).toBeUndefined()
+  })
+})
+
 describe('resolveNewNodeAccount', () => {
   const accounts = [{ id: 'a1', label: 'work', createdAt: 0 }]
   it('prefers the explicit pick', () =>

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -1117,7 +1117,7 @@ function groupsFirst(nodes: CanvasNode[]): CanvasNode[] {
 }
 
 /** A node's position in ROOT space: its own position plus every ancestor frame's origin. */
-function rootPosition(node: CanvasNode, nodes: CanvasNode[]): { x: number; y: number } {
+export function rootPosition(node: CanvasNode, nodes: CanvasNode[]): { x: number; y: number } {
   const byId = new Map(nodes.map((candidate) => [candidate.id, candidate]))
   const seen = new Set<string>([node.id])
   let x = node.position.x
@@ -1132,6 +1132,107 @@ function rootPosition(node: CanvasNode, nodes: CanvasNode[]): { x: number; y: nu
     parentId = parent.parentId
   }
   return { x, y }
+}
+
+// ─── node-group ↔ canvas isomorphism (ticket 07) ──────────────────────────────
+//
+// A node-group and a canvas are two reversible views of the same node-set. Drilling into a group
+// promotes its DIRECT children to root-space (the sub-canvas's top level), reusing the existing
+// canvas-switcher. This is cheap because React Flow keys nodes by `id` and the terminal lifecycle
+// is keyed on `[respawnNonce, offscreenEpoch]` — NOT position/parentId — so repositioning a child
+// from nested-space to root-space re-runs no lifecycle effect: the xterm/PTY/renderer survive in
+// place. Only the group's SIBLINGS leave the node-set (they park via the existing primitive).
+//
+// `rootPosition` (above) is the same helper `ungroupNodes` uses to strip a node's parent offset.
+
+/** The transient, in-memory drill context. Never persisted — a drill is navigation, not a surface. */
+export type DrillContext =
+  | { kind: 'group'; groupId: string; projectId: string } // openNodeGroupAsCanvas: a group's children as the sub-canvas
+  | { kind: 'project-ref'; projectId: string; targetId: string } // openNodeGroupAsCanvas on a `data.projectRef` group (09): drill = switch active project to the referenced one. `projectId` is the SOURCE (meta) canvas — `exitDrill` switches back to it; `targetId` is the referenced project (so the load effect knows a target load is part of THIS drill, not a manual switch to a third project). No merge-back (commits land in the target project); no `cwdOverride` (the target loads its own full nodes).
+
+/**
+ * Build the drilled sub-canvas node-set: the group's DIRECT children promoted to ROOT space, with
+ * `parentId`/`extent` stripped (they become top-level in the sub-canvas). Nested groups stay nested
+ * — only the drilled group's direct children are promoted. The group frame itself and its siblings
+ * are absent (siblings park; the group is the thing being looked-into, not shown as a frame).
+ *
+ * Returns `{ flow, childIds }` so the caller knows exactly which node ids constitute the drilled view
+ * (used to merge edits back into the full project node array on commit — see `remergeDrilledNodes`).
+ */
+export function drillGroupChildren(
+  nodes: CanvasNode[],
+  groupId: string
+): { flow: CanvasNode[]; childIds: Set<string> } {
+  const childIds = new Set<string>()
+  const flow: CanvasNode[] = []
+  for (const node of nodes) {
+    if (node.parentId === groupId) {
+      childIds.add(node.id)
+      const root = rootPosition(node, nodes)
+      flow.push({ ...node, parentId: undefined, extent: undefined, position: root })
+    }
+  }
+  return { flow, childIds }
+}
+
+/**
+ * Commit-while-drilled: merge the EDITED drilled children back into the project's FULL node array,
+ * re-nested under the group (the inverse of `drillGroupChildren`). Drilled children were promoted to
+ * root-space for viewing; persistence stores positions NESTED (parent-relative), so the group's root
+ * origin is subtracted back. Siblings (anything not a drilled child) are kept untouched from the
+ * stored array, as is the group frame itself (it left the drilled view).
+ *
+ * `drilledStates` is `flowToNodeStates(drilledFlow)` — positions are ROOT-space (the drilled view),
+ * and `parentId` is undefined (drilling strips it). We re-nest both.
+ *
+ * This is the one place that closes the logged hazard (07): a drilled view's `nodesRef.current` is a
+ * SUBSET, but `commitCanvas` wholesale-replaces the project's nodes — so committing the subset would
+ * clobber every sibling. Merging by id against the full stored array preserves them, and re-nesting
+ * keeps the persisted positions correct regardless of when the 800ms autosave timer fires.
+ */
+export function remergeDrilledNodes(
+  fullStored: CanvasNodeState[],
+  drilledStates: CanvasNodeState[],
+  groupId: string,
+  fullNodesForRoot: CanvasNode[]
+): CanvasNodeState[] {
+  const drilledById = new Map(drilledStates.map((s) => [s.id, s]))
+  // The group's ROOT-space origin, resolved against the full node array (the group is absent from the
+  // drilled view, so it must be read from the full set — the same reason 08 reads cwd from project.nodes).
+  const group = fullNodesForRoot.find((n) => n.id === groupId)
+  const gx = group ? rootPosition(group, fullNodesForRoot).x : 0
+  const gy = group ? rootPosition(group, fullNodesForRoot).y : 0
+  // Which stored nodes were DIRECT children of the drilled group before the drill. These are the only
+  // nodes whose membership the drilled view may change: a child DELETED while drilled (present in the
+  // stored set, absent from the drilled view) must be dropped; a child NEWLY created while drilled is
+  // appended below. Siblings and the group frame are NOT direct children, so they survive untouched.
+  const wasDirectChild = new Set(
+    fullStored.filter((s) => s.parentId === groupId).map((s) => s.id)
+  )
+  // Re-nest a single drilled child: root-space position → parent-relative, parentId restored.
+  const renest = (s: CanvasNodeState): CanvasNodeState => ({
+    ...s,
+    parentId: groupId,
+    position: { x: s.position.x - gx, y: s.position.y - gy }
+  })
+  // Merge by id over the FULL stored array. A stored direct child that is GONE from the drilled view
+  // (deleted while drilled) is dropped; siblings + the group frame are untouched; remaining drilled
+  // children are re-nested.
+  const merged: CanvasNodeState[] = []
+  for (const state of fullStored) {
+    if (wasDirectChild.has(state.id) && !drilledById.has(state.id)) continue // deleted while drilled
+    const drilled = drilledById.get(state.id)
+    merged.push(drilled ? renest(drilled) : state)
+  }
+  // APPEND drilled children that are NEW (created while drilled — present in the drilled view but
+  // absent from the stored array). Without this a brand-new child would be silently dropped on commit,
+  // and for a worktree drill (08) that means its persisted cwd would never gain the `parentId = groupId`
+  // that `cwdForNewNodeIn` walks to resolve the worktree path — orphaning it from the worktree on reload.
+  const known = new Set(fullStored.map((s) => s.id))
+  for (const drilled of drilledStates) {
+    if (!known.has(drilled.id)) merged.push(renest(drilled))
+  }
+  return merged
 }
 
 function isDescendant(nodes: CanvasNode[], candidateId: string, ancestorId: string): boolean {
@@ -1534,7 +1635,8 @@ export function nodeStatesToFlow(states: CanvasNodeState[]): CanvasNode[] {
         ssh: n.ssh,
         sshRemoteTmux: n.sshRemoteTmux,
         sshFs: n.sshFs,
-        worktree: n.worktree
+        worktree: n.worktree,
+        projectRef: n.projectRef
       }
     }
   })
@@ -1597,6 +1699,7 @@ export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
         commitOid: n.data.commitOid,
         highScore: n.data.highScore,
         agentId: n.data.agentId,
+        agentBaseId: n.data.agentBaseId,
         agentModel: n.data.agentModel,
         accountId: n.data.accountId,
         agentSessionId: n.data.agentSessionId,
@@ -1604,7 +1707,8 @@ export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
         ssh: n.data.ssh,
         sshRemoteTmux: n.data.sshRemoteTmux,
         sshFs: n.data.sshFs,
-        worktree: n.data.worktree
+        worktree: n.data.worktree,
+        projectRef: n.data.projectRef as { projectId: string } | undefined
       }
     })
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5598,7 +5598,8 @@ button.group-node__setup:disabled {
 }
 
 .group-node__ungroup,
-.group-node__close {
+.group-node__close,
+.group-node__drill {
   background: var(--surface-sunken);
   border: 1px solid var(--border);
   color: var(--muted);
@@ -5614,9 +5615,94 @@ button.group-node__setup:disabled {
 }
 
 .group-node__ungroup:hover,
-.group-node__close:hover {
+.group-node__close:hover,
+.group-node__drill:hover {
   background: var(--panel-header);
   color: var(--text);
+}
+
+/* Drill breadcrumb (ticket 07): shown in the top-banners strip while a group is open as a canvas.
+   For a worktree-bound group drill (ticket 08), carries the branch chip + Merge/Unbind/Remove that
+   normally live on the GroupNode frame (which leaves the node-set when drilled). */
+.drill-breadcrumb .announce-banner__close {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 600;
+}
+.drill-breadcrumb .announce-banner__close:hover {
+  filter: brightness(1.1);
+}
+.drill-breadcrumb__wt {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 8px;
+  padding-left: 8px;
+  border-left: 1px solid var(--border);
+}
+.drill-breadcrumb__wt .group-node__branch {
+  font-size: 12px;
+  opacity: 0.9;
+}
+.drill-breadcrumb__wt .group-node__wt-btn {
+  font-size: 11px;
+  padding: 1px 6px;
+}
+
+/* Derived (never persisted) projectRef suggestion for an unopened git submodule. ViewportPortal
+   gives it canvas coordinates; the dashed/faded shell distinguishes it from a real group frame. */
+.submodule-ghost {
+  position: absolute;
+  width: 300px;
+  min-height: 116px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 16px;
+  border: 1px dashed rgba(var(--tint-rgb), 0.35);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel) 78%, transparent);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, calc(0.2 * var(--shadow-k)));
+  color: var(--text);
+  opacity: 0.78;
+  pointer-events: auto;
+}
+
+.submodule-ghost__eyebrow {
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.submodule-ghost__path {
+  max-width: 100%;
+  overflow: hidden;
+  color: rgba(var(--tint-rgb), 0.55);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.submodule-ghost button {
+  margin-top: 4px;
+  padding: 4px 10px;
+  border: 1px solid var(--accent);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.submodule-ghost button:hover {
+  background: rgba(10, 132, 255, 0.12);
 }
 
 /* Selected outline for ephemeral subagent/loop nodes. */
@@ -5921,6 +6007,126 @@ button.group-node__setup:disabled {
 
 .loop-node__empty {
   color: var(--muted);
+}
+
+/* ---- Cross-project projection (ephemeral, ticket 05) node ----
+ * A second live view of ANOTHER project's tmux session — a co-attach canvas viewer, not a modal.
+ * Deliberately DIMMED and DOTTED so it reads as a foreign projection (the session lives in project
+ * B; this is a viewer) rather than a native node the user owns. The dotted outline + left rail use
+ * B's project color (`--xproj-stroke`, set inline from `data.color`), so several projections point
+ * at visibly different projects at once. */
+.xproj-node {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border: 1.5px dashed var(--xproj-stroke, var(--muted));
+  border-top-width: 3px;
+  border-radius: 10px;
+  overflow: hidden;
+  /* Dimmed: this is a view of someone else's session, not a node the user owns. */
+  opacity: 0.72;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, calc(0.35 * var(--shadow-k)));
+}
+
+.xproj-node.selected {
+  opacity: 0.92;
+  box-shadow:
+    0 0 0 1px var(--xproj-stroke, var(--muted)),
+    0 6px 20px rgba(0, 0, 0, calc(0.35 * var(--shadow-k)));
+}
+
+.xproj-node__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--xproj-stroke, var(--muted)) 14%, transparent);
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text);
+  user-select: none;
+}
+
+/* The origin badge: B's project color dot + name, so the projection is never mistaken for a node
+ * the user owns on THIS canvas. */
+.xproj-node__origin {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-weight: 600;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 50%;
+}
+
+.xproj-node__dot {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  border-radius: 50%;
+}
+
+.xproj-node__title {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+  opacity: 0.85;
+}
+
+/* The ↗ jump button: switch to B's project and focus the node there. */
+.xproj-node__jump {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.xproj-node__jump:hover {
+  background: color-mix(in srgb, var(--xproj-stroke, var(--muted)) 18%, transparent);
+  color: var(--text);
+}
+
+.xproj-node__body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background: var(--term-bg, var(--bg));
+}
+
+/* The placeholder shown when B's session is not live / not connected / closed. Centered, muted,
+ * pointer-events none so the terminal underneath (once it attaches) stays interactive. */
+.xproj-node__plate {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  text-align: center;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  pointer-events: none;
 }
 
 /* ---- Minimap ---- */
@@ -11086,4 +11292,329 @@ button.group-node__setup:disabled {
   color: var(--warn);
   border: 1px solid var(--warn);
   background: transparent;
+}
+
+/* ── Off-canvas link authoring (ticket 06): LinkTargetPicker + LinkInspectorPanel ── */
+.link-picker {
+  width: 520px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+.link-picker__tabs {
+  display: flex;
+  gap: 4px;
+  margin: 0 0 10px;
+  border-bottom: 1px solid var(--border);
+}
+.link-picker__tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: rgba(var(--tint-rgb), 0.6);
+  font-size: 12px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+.link-picker__tab.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+.link-picker__list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 280px;
+  overflow-y: auto;
+  margin: 0 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px;
+  background: rgba(var(--tint-rgb), 0.03);
+}
+.link-picker__empty {
+  font-size: 12px;
+  color: rgba(var(--tint-rgb), 0.45);
+  padding: 8px 4px;
+}
+.link-picker__project-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: none;
+  color: rgba(var(--tint-rgb), 0.7);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 5px 4px;
+  cursor: pointer;
+  text-align: left;
+}
+.link-picker__chev {
+  width: 10px;
+  color: rgba(var(--tint-rgb), 0.4);
+}
+.link-picker__project-name {
+  flex: 1;
+}
+.link-picker__foreign {
+  color: rgba(var(--tint-rgb), 0.4);
+  font-weight: 400;
+}
+.link-picker__nodes {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 2px 0 4px 16px;
+}
+.link-picker__node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 12px;
+  padding: 5px 8px;
+  cursor: pointer;
+  text-align: left;
+}
+.link-picker__node:hover {
+  background: rgba(var(--tint-rgb), 0.06);
+}
+.link-picker__node.selected {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: var(--accent);
+}
+.link-picker__node:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.link-picker__node-kind {
+  width: 14px;
+  text-align: center;
+  color: rgba(var(--tint-rgb), 0.55);
+}
+.link-picker__node-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.link-picker__node-agent,
+.link-picker__node-xnode {
+  font-size: 10px;
+  color: rgba(var(--tint-rgb), 0.4);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 4px;
+}
+.link-picker__node-xnode {
+  color: #a855f7;
+  border-color: rgba(168, 85, 247, 0.4);
+}
+.link-picker__field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: 0 0 12px;
+}
+.link-picker__field-label {
+  font-size: 11px;
+  color: rgba(var(--tint-rgb), 0.55);
+}
+.link-picker__select {
+  background: rgba(var(--tint-rgb), 0.06);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 13px;
+  padding: 7px 8px;
+  cursor: pointer;
+}
+.link-picker__target {
+  font-size: 12px;
+  color: rgba(var(--tint-rgb), 0.7);
+  margin: 0 0 12px;
+  padding: 6px 8px;
+  background: rgba(var(--tint-rgb), 0.04);
+  border-radius: 6px;
+}
+.link-picker__target.unavailable {
+  color: rgba(var(--tint-rgb), 0.4);
+  font-style: italic;
+}
+
+/* ── LinkInspectorPanel ── */
+.link-inspector {
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+  max-height: 420px;
+  background: var(--bg, #1c1c1e);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+.link-inspector__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.link-inspector__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+.link-inspector__close {
+  background: none;
+  border: none;
+  color: rgba(var(--tint-rgb), 0.5);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.link-inspector__close:hover {
+  color: var(--text);
+}
+.link-inspector__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.link-inspector__empty {
+  font-size: 12px;
+  color: rgba(var(--tint-rgb), 0.45);
+  padding: 12px 8px;
+  line-height: 1.4;
+}
+.link-inspector__group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.link-inspector__group-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(var(--tint-rgb), 0.4);
+  padding: 2px 4px;
+}
+.link-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 6px;
+  border-radius: 6px;
+}
+.link-row:hover {
+  background: rgba(var(--tint-rgb), 0.05);
+}
+.link-row__kind {
+  font-size: 10px;
+  font-weight: 600;
+  flex-shrink: 0;
+  width: 56px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.link-row__target {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text);
+  overflow: hidden;
+}
+.link-row__target > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.link-row__target .unavailable {
+  color: rgba(var(--tint-rgb), 0.4);
+  font-style: italic;
+}
+.link-row__purpose {
+  font-size: 10px;
+  color: rgba(var(--tint-rgb), 0.45);
+}
+.link-row__delete {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: rgba(var(--tint-rgb), 0.35);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+  border-radius: 4px;
+}
+.link-row__delete:hover {
+  color: #ff453a;
+  background: rgba(255, 69, 58, 0.1);
+}
+.link-inspector__add {
+  margin: 6px;
+  padding: 7px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: 8px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.link-inspector__add:hover {
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+}
+/* Flyout mount (canvas node header button) — sibling of root, expands to the node's right. */
+.term-node__links {
+  position: absolute;
+  top: 36px;
+  right: -312px;
+  z-index: 20;
+}
+/* Portal mount (card modal / sidebar). */
+.link-inspector-overlay {
+  align-items: center;
+  justify-content: center;
+}
+.link-inspector-portal {
+  position: relative;
+}
+
+/* Links header button — mirrors .term-node__chat (the comments button). */
+.term-node__link {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  line-height: 1;
+  padding: 2px 5px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+.term-node__link:hover {
+  color: var(--text);
+  background: rgba(var(--tint-rgb), 0.1);
+}
+.term-node__link[aria-pressed='true'] {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
 }

--- a/src/renderer/styles.theme.test.ts
+++ b/src/renderer/styles.theme.test.ts
@@ -102,6 +102,7 @@ describe('every CSS variable resolves', () => {
     '--term-bg', // App.tsx, from the terminal theme
     '--peer-color', // presence chips, per peer
     '--group-label-boost', // GroupNode, zoom-compensated label size
+    '--xproj-stroke', // XProjectNode, the origin project's colour on a cross-project projection
     '--mascot-w',
     '--mascot-h',
     '--cmascot-w',

--- a/src/server/context-link.test.ts
+++ b/src/server/context-link.test.ts
@@ -11,7 +11,7 @@ import { setNodeTranscript } from '../core/context-link-core'
 import { hookServer } from '../core/agents/hook-server'
 import { initPlatform, resetPlatformForTests } from '../core/platform'
 import { fakePlatform } from '../core/platform-fake'
-import type { CanvasNodeState } from '../shared/types'
+import type { CanvasNodeState, Link } from '../shared/types'
 import type { PtyManager } from '../core/pty-manager'
 
 const dir = mkdtempSync(join(tmpdir(), 'srv-ctxlink-'))
@@ -43,7 +43,12 @@ function node(id: string, over: Partial<CanvasNodeState> = {}): CanvasNodeState 
   } as CanvasNodeState
 }
 
-const bridge = (source: string, target: string) => ({ id: `bridge-${source}-${target}`, source, target })
+const bridge = (source: string, target: string): Link => ({
+  id: `bridge-${source}-${target}`,
+  kind: 'context',
+  source: { ref: 'node', nodeId: source },
+  target: { ref: 'node', nodeId: target }
+})
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'srv-ctxlink-home-'))
@@ -67,8 +72,28 @@ describe('deriveLinkMap', () => {
         {
           id: 'p1',
           nodes: [node('term-a', { title: 'Alpha' }), node('term-b', { title: 'Beta' })],
-          bridges: [bridge('term-a', 'term-b')]
+          links: [bridge('term-a', 'term-b')]
         }
+      ]
+    })
+    expect(map['term-a']).toEqual([{ id: 'term-b', title: 'Beta', cwd: '' }])
+    expect(map['term-b']).toEqual([{ id: 'term-a', title: 'Alpha', cwd: '' }])
+  })
+
+  it('maps a cross-project context link in both directions', () => {
+    const map = deriveLinkMap({
+      canvases: () => [
+        {
+          id: 'p1',
+          nodes: [node('term-a', { title: 'Alpha' })],
+          links: [{
+            id: 'cross',
+            kind: 'context',
+            source: { ref: 'node', nodeId: 'term-a' },
+            target: { ref: 'xnode', projectId: 'p2', nodeId: 'term-b' }
+          }]
+        },
+        { id: 'p2', nodes: [node('term-b', { title: 'Beta' })], links: [] }
       ]
     })
     expect(map['term-a']).toEqual([{ id: 'term-b', title: 'Beta', cwd: '' }])
@@ -78,8 +103,8 @@ describe('deriveLinkMap', () => {
   it('covers EVERY canvas — headless, no project is the active one', () => {
     const map = deriveLinkMap({
       canvases: () => [
-        { id: 'p1', nodes: [node('a'), node('b')], bridges: [bridge('a', 'b')] },
-        { id: 'p2', nodes: [node('c'), node('d')], bridges: [bridge('c', 'd')] }
+        { id: 'p1', nodes: [node('a'), node('b')], links: [bridge('a', 'b')] },
+        { id: 'p2', nodes: [node('c'), node('d')], links: [bridge('c', 'd')] }
       ]
     })
     // The desktop skips the active project (its renderer supplies that one live). There is no
@@ -90,7 +115,7 @@ describe('deriveLinkMap', () => {
   it('drops bridges whose endpoints are no longer on the canvas', () => {
     const map = deriveLinkMap({
       canvases: () => [
-        { id: 'p1', nodes: [node('a')], bridges: [bridge('a', 'deleted')] }
+        { id: 'p1', nodes: [node('a')], links: [bridge('a', 'deleted')] }
       ]
     })
     expect(map).toEqual({})
@@ -106,7 +131,7 @@ describe('deriveLinkMap', () => {
         {
           id: 'p1',
           nodes: [node('sticky-1', { kind: 'sticky', title: 'Spec', text: 'ship it' }), node('term-a')],
-          bridges: [bridge('sticky-1', 'term-a')]
+          links: [bridge('sticky-1', 'term-a')]
         }
       ]
     })
@@ -118,7 +143,7 @@ describe('deriveLinkMap', () => {
     // A plain terminal the user started an agent CLI in by hand: project.json carries no agentId,
     // but the status mirror learned both from the hook events.
     const map = deriveLinkMap({
-      canvases: () => [{ id: 'p1', nodes: [node('a'), node('b')], bridges: [bridge('a', 'b')] }],
+      canvases: () => [{ id: 'p1', nodes: [node('a'), node('b')], links: [bridge('a', 'b')] }],
       agentSessions: () => [{ nodeId: 'b', agentId: 'codex', sessionId: 'sess-b' }]
     })
     expect(map['a']).toEqual([{ id: 'b', title: 'b', cwd: '', agentId: 'codex', sessionId: 'sess-b' }])
@@ -143,7 +168,7 @@ describe('initServerContextLink', () => {
         {
           id: 'p1',
           nodes: [node('term-a', { title: 'Alpha' }), node('term-b', { title: 'Beta' })],
-          bridges: [bridge('term-a', 'term-b')]
+          links: [bridge('term-a', 'term-b')]
         }
       ]
     })
@@ -178,15 +203,15 @@ describe('initServerContextLink', () => {
   })
 
   it('picks up a bridge drawn after boot', async () => {
-    let bridges = [] as ReturnType<typeof bridge>[]
+    let links = [] as ReturnType<typeof bridge>[]
     const { link, handler } = start({
       ptyManager: fakePty(),
-      canvases: () => [{ id: 'p1', nodes: [node('term-a'), node('term-b', { title: 'Beta' })], bridges }]
+      canvases: () => [{ id: 'p1', nodes: [node('term-a'), node('term-b', { title: 'Beta' })], links }]
     })
     await link.refresh()
     expect(await handler({ verb: 'list', nodeId: 'term-a', args: {} })).toContain('No linked nodes')
     // What a browser drawing the edge produces: a workspace save, and the onPersist refresh.
-    bridges = [bridge('term-a', 'term-b')]
+    links = [bridge('term-a', 'term-b')]
     await link.refresh()
     expect(await handler({ verb: 'list', nodeId: 'term-a', args: {} })).toContain('Beta')
     await link.stop()
@@ -199,7 +224,7 @@ describe('initServerContextLink', () => {
       {
         id: 'p1',
         nodes: [node('term-a'), node('term-b', { title: 'Beta', agentId: 'claude' as const })],
-        bridges: [bridge('term-a', 'term-b')]
+        links: [bridge('term-a', 'term-b')]
       }
     ]
     const { link, handler } = start({ ptyManager: fakePty(), canvases })
@@ -219,7 +244,7 @@ describe('initServerContextLink', () => {
     const { link } = start({
       ptyManager: fakePty(),
       canvases: () => [
-        { id: 'p1', nodes: [node('term-a'), node('term-b')], bridges: [bridge('term-a', 'term-b')] }
+        { id: 'p1', nodes: [node('term-a'), node('term-b')], links: [bridge('term-a', 'term-b')] }
       ]
     })
     // Neither the sweep nor onPersist awaits a refresh, so at close there is normally one in
@@ -238,7 +263,7 @@ describe('initServerContextLink', () => {
     const { link } = start({
       ptyManager: fakePty(),
       canvases: () => [
-        { id: 'p1', nodes: [node('term-a'), node('term-b')], bridges: [bridge('term-a', 'term-b')] }
+        { id: 'p1', nodes: [node('term-a'), node('term-b')], links: [bridge('term-a', 'term-b')] }
       ]
     })
     await link.refresh()

--- a/src/shared/canvas-publish.test.ts
+++ b/src/shared/canvas-publish.test.ts
@@ -314,10 +314,14 @@ describe('lazy snapshots', () => {
 })
 
 describe('ephemeral nodes are never published', () => {
-  it('isEphemeralNodeId matches subagent cards (by id set) and loop cards (by prefix)', () => {
+  it('isEphemeralNodeId matches subagent cards (by id set) and loop/xproj cards (by prefix)', () => {
     const eph = new Set(['sub-123'])
     expect(isEphemeralNodeId('sub-123', eph)).toBe(true)
     expect(isEphemeralNodeId('loop-n1', eph)).toBe(true)
+    // A cross-project projection (`xproj-<B>-<node>`, ticket 05) is ephemeral by prefix too — it is
+    // DERIVED from a persisted lineage link + B's nodes, so publishing it would render the card
+    // twice on a peer and persist a node that should never round-trip through flowToNodeStates.
+    expect(isEphemeralNodeId('xproj-projB-n1', eph)).toBe(true)
     expect(isEphemeralNodeId('n1', eph)).toBe(false)
   })
 
@@ -325,13 +329,48 @@ describe('ephemeral nodes are never published', () => {
     const c = collect()
     const p = createCanvasPublisher(c.send)
     const eph = new Set(['sub-123'])
-    const states = [node('n1'), node('sub-123'), node('loop-n1')]
+    const states = [node('n1'), node('sub-123'), node('loop-n1'), node('xproj-projB-n1')]
     expect(publishableStates(states, eph).map((n) => n.id)).toEqual(['n1'])
     p.publish(publishableStates(states, eph))
     expect(c.sent).toEqual([{ op: 'upsert', node: node('n1') }])
     // Moving an ephemeral card produces NO mutation at all.
-    const moved = [node('n1'), node('sub-123', 99), node('loop-n1', 99)]
+    const moved = [
+      node('n1'),
+      node('sub-123', 99),
+      node('loop-n1', 99),
+      node('xproj-projB-n1', 99)
+    ]
     p.publish(publishableStates(moved, eph))
     expect(c.sent).toHaveLength(1)
+  })
+})
+
+describe('a projectRef group publishes (ticket 09 meta-canvas)', () => {
+  // A meta-canvas group that references another project is an ordinary `kind:'group'` node carrying
+  // `data.projectRef`. It is NOT ephemeral (no sub-/loop-/xproj- prefix; it is persisted and
+  // draggable), so it MUST go on the wire to peers — otherwise a peer's meta-canvas would silently
+  // lose the reference frame. The `projectRef` field is harmless extra data that rides along.
+  const projectRefGroup = (id: string, x = 0): CanvasNodeState =>
+    ({
+      id,
+      kind: 'group',
+      title: 'References Project A',
+      color: '#0a84ff',
+      position: { x, y: 0 },
+      size: { width: 520, height: 360 },
+      projectRef: { projectId: 'proj-a' }
+    }) as CanvasNodeState
+
+  it('is not classified ephemeral', () => {
+    expect(isEphemeralNodeId('g-ref-1', new Set())).toBe(false)
+  })
+
+  it('publishableStates keeps it and it round-trips as an upsert', () => {
+    const c = collect()
+    const p = createCanvasPublisher(c.send)
+    const states = [projectRefGroup('g-ref-1')]
+    expect(publishableStates(states, new Set()).map((n) => n.id)).toEqual(['g-ref-1'])
+    p.publish(publishableStates(states, new Set()))
+    expect(c.sent).toEqual([{ op: 'upsert', node: projectRefGroup('g-ref-1') }])
   })
 })

--- a/src/shared/canvas-publish.ts
+++ b/src/shared/canvas-publish.ts
@@ -222,14 +222,16 @@ export function createCanvasPublisher(
 }
 
 /**
- * Ephemeral canvas nodes — subagent cards (ids tracked in the agentNodes store) and /loop, /schedule
- * and /cron cards (`loop-<parentId>`). They are DERIVED on every client from the already-broadcast
- * `agent:status` stream, live outside React Flow's managed `nodes` array, and are never persisted.
+ * Ephemeral canvas nodes — subagent cards (ids tracked in the agentNodes store), /loop, /schedule
+ * and /cron cards (`loop-<parentId>`), and cross-project projections (`xproj-<projectId>-<nodeId>`,
+ * ticket 05). They are DERIVED on every client from the already-broadcast `agent:status` stream
+ * (subagent/loop) or from a persisted `lineage` Link + the foreign project's serialized nodes
+ * (projection), live outside React Flow's managed `nodes` array, and are never persisted.
  * Publishing them would render each card twice on a peer. They are never published — full stop.
  * This is the one definition of "ephemeral"; Canvas's own change-list filter uses it too.
  */
 export function isEphemeralNodeId(id: string, ephemeralIds: ReadonlySet<string>): boolean {
-  return ephemeralIds.has(id) || id.startsWith('loop-')
+  return ephemeralIds.has(id) || id.startsWith('loop-') || id.startsWith('xproj-')
 }
 
 /** The node states that may go on the wire: everything except the ephemeral cards. */

--- a/src/shared/context-link-map.ts
+++ b/src/shared/context-link-map.ts
@@ -5,7 +5,25 @@
 // (Canvas.tsx). The Server Edition has no renderer holding a canvas — it derives the whole map
 // from persisted project files instead (src/server/context-link.ts). Same rules either way, so
 // they belong in one place rather than two that drift.
-import type { BridgeLink, CanvasNodeState, ContextLinkInfo, ContextLinkMap } from './types'
+import type { CanvasNodeState, ContextLinkInfo, ContextLinkMap, Link } from './types'
+
+/**
+ * The node↔node edge pairs a context-link map can read through. Both `node` and `xnode` endpoints
+ * name real nodes (node ids are workspace-global); `xnode` merely records that the other node lives
+ * in another project. Branch endpoints carry no transcript and are excluded.
+ * `kind:'context'` covers both agent↔agent context links and sticky→terminal note links (a note
+ * link persists as `context` with `meta.note`); `lineage` (display-only ropes) is excluded.
+ */
+export function contextNodeEdges(links: readonly Link[] | undefined): Array<{ source: string; target: string }> {
+  if (!links?.length) return []
+  const out: Array<{ source: string; target: string }> = []
+  for (const l of links) {
+    if (l.kind !== 'context') continue
+    if (l.source.ref === 'branch' || l.target.ref === 'branch') continue
+    out.push({ source: l.source.nodeId, target: l.target.nodeId })
+  }
+  return out
+}
 
 export interface LinkNodeInfo {
   id: string
@@ -52,8 +70,30 @@ export function buildLinkMap(
   return map
 }
 
+/** Merge independently-derived maps without letting a later project overwrite a node's earlier
+ * links. A node may participate in both a same-project link and one or more cross-project links;
+ * object spread/assign would silently keep only the last array. Duplicate target ids collapse
+ * because the read surface is node-oriented (two authored edges to the same node are one context). */
+export function mergeContextLinkMaps(...maps: readonly ContextLinkMap[]): ContextLinkMap {
+  const out: ContextLinkMap = {}
+  for (const map of maps) {
+    for (const [nodeId, entries] of Object.entries(map)) {
+      const target = (out[nodeId] ??= [])
+      const seen = new Set(target.map((entry) => entry.id))
+      for (const entry of entries) {
+        if (seen.has(entry.id)) continue
+        target.push(entry)
+        seen.add(entry.id)
+      }
+    }
+  }
+  return out
+}
+
 /**
- * Link maps built from serialized nodes + bridges, for every project EXCEPT `activeProjectId`.
+ * Link maps built from serialized nodes + links. Same-project links in `activeProjectId` are
+ * skipped because React Flow supplies their live edge set; cross-project links owned by the active
+ * project are still included because they are deliberately off-canvas and never enter React Flow.
  *
  * On the desktop the active project's map is built live from React Flow and this covers the rest,
  * because writeLinkFiles clears ALL link files before writing the pushed map — pushing only the
@@ -70,16 +110,22 @@ export function buildLinkMap(
  * running inside.
  */
 export function buildBackgroundLinkMaps(
-  projects: Array<{ id: string; nodes: CanvasNodeState[]; bridges?: BridgeLink[] }>,
+  projects: Array<{ id: string; nodes: CanvasNodeState[]; links?: Link[] }>,
   activeProjectId: string | null,
   sessionIdOf: (nodeId: string) => string | undefined,
   agentIdOf?: (nodeId: string) => string | undefined
 ): ContextLinkMap {
   const map: ContextLinkMap = {}
+  const byId = new Map<string, CanvasNodeState>()
+  for (const project of projects) {
+    for (const node of project.nodes) byId.set(node.id, node)
+  }
   for (const p of projects) {
-    if (p.id === activeProjectId || !p.bridges?.length) continue
-    const byId = new Map(p.nodes.map((n) => [n.id, n]))
-    const edges = p.bridges.filter((e) => byId.has(e.source) && byId.has(e.target))
+    if (!p.links?.length) continue
+    const links = p.id === activeProjectId
+      ? p.links.filter((link) => link.source.ref === 'xnode' || link.target.ref === 'xnode')
+      : p.links
+    const edges = contextNodeEdges(links).filter((e) => byId.has(e.source) && byId.has(e.target))
     const infoOf = (id: string): LinkNodeInfo => {
       const n = byId.get(id)!
       const sticky = n.kind === 'sticky'
@@ -95,7 +141,10 @@ export function buildBackgroundLinkMaps(
         accountId: sticky ? undefined : n.accountId
       }
     }
-    Object.assign(map, buildLinkMap(edges, infoOf))
+    const next = buildLinkMap(edges, infoOf)
+    const merged = mergeContextLinkMaps(map, next)
+    for (const key of Object.keys(map)) delete map[key]
+    Object.assign(map, merged)
   }
   return map
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -424,9 +424,19 @@ export const IPC = {
   gitCheckoutCommit: 'git:checkout-commit',
   gitRepoRoot: 'git:repo-root',
   gitWorktreeList: 'git:worktree-list',
+  gitSubmoduleList: 'git:submodule-list',
   gitWorktreeAdd: 'git:worktree-add',
   gitWorktreeMerge: 'git:worktree-merge',
   gitWorktreeRemove: 'git:worktree-remove',
+  // Branch-dependency / stacked-diff ops (ticket 03). Plain git — no external binary. The
+  // `set/unset-branch-parent` pair adopts git-town's `git-town-branch.<child>.parent` config key
+  // as the topology convention (interoperable with git-town for users who install it); the
+  // sync/propose/ship ops are plain `git rebase` / `gh pr create` / `git merge --ff-only`.
+  gitSetBranchParent: 'git:set-branch-parent',
+  gitUnsetBranchParent: 'git:unset-branch-parent',
+  gitSyncBranch: 'git:sync-branch',
+  gitProposeBranch: 'git:propose-branch',
+  gitShipBranch: 'git:ship-branch',
   gitSetActiveRemote: 'git:set-active-remote',
   shellOpenExternal: 'shell:open-external',
   commitGenerate: 'commit:generate',

--- a/src/shared/project-capabilities.ts
+++ b/src/shared/project-capabilities.ts
@@ -14,7 +14,7 @@
  *
  *  1. The switch alone grants nothing. Every capability must additionally require state this app
  *     run built and never persisted (browser control: the in-memory ownership ledger; a cloned
- *     project.json cannot pre-populate it, and `Project.ropes` — which IS persisted and git-shared —
+ *     project.json cannot pre-populate it, and `Project.links` — which IS persisted and git-shared —
  *     is deliberately never consulted for ownership).
  *  2. First use in a project the user has not personally switched on raises a one-time notice,
  *     recorded MACHINE-LOCALLY (IndexEntryV3.capabilityAck), never in project.json.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -134,6 +134,25 @@ export interface PtyCreateOptions {
    * "not connected" overlay and re-spawns when the master is back.
    */
   requireRemote?: boolean
+  /**
+   * This create must JOIN an already-live session for `persistKey` — never spawn a new one.
+   *
+   * The cross-project projection (ticket 05) is a VIEWER of another project's node, not its owner:
+   * B owns the `nt-<bNodeId>` session, and A's projection co-attaches to it. If B's session is not
+   * live yet (B's canvas never mounted, or a post-reboot cold start), the projection must refuse
+   * rather than become the spawner of B's session — a projection that spawned would steal ownership
+   * (the pane-ownership ledger would record A's project as the owner) and the node would run under
+   * A's resolved context instead of B's. The refusal (`PtyCreateResult.unavailable: 'no-session'`)
+   * is the honest answer: the projection shows a placeholder and retries once B mounts the session.
+   *
+   * Deliberately gated in `create()` AFTER the in-flight barrier (so a projection racing B's own
+   * spawn waits for it and then joins, rather than refusing a session that is coming up right now)
+   * and AFTER the tombstone check (a `closed` refusal is the more specific answer for a node B
+   * deleted). Unlike `requireRemote` — which refuses only the spawn branch and still allows a
+   * co-attach join — this refuses the WHOLE create when no live session exists, because there is no
+   * valid spawn branch for a projection at all.
+   */
+  requireExisting?: boolean
 }
 
 /** A tmux pane's cursor, as tmux reports it: 0-based column/row within the pane, plus whether the
@@ -245,8 +264,14 @@ export interface PtyCreateResult {
    * `'codex-account'` is the S6 fail-closed twin: a LOCAL Codex node that explicitly selected a
    * managed account whose home is missing refuses rather than spawning against the system login
    * (§5 property 4). Same contract — nothing spawned, the renderer shows the node's refusal.
+   *
+   * `'no-session'` — REFUSED: `requireExisting` was set and no live session for this node id exists
+   * (and none came up while waiting on an in-flight spawn). The caller is a projection of a FOREIGN
+   * node (ticket 05) that must never spawn its target's session; it shows a placeholder and retries
+   * once the owning project mounts the session. A `closed` refusal takes precedence (the node was
+   * deleted, not merely unmounted), so this is only reached when there is genuinely nothing to join.
    */
-  unavailable?: 'ssh' | 'codex-account'
+  unavailable?: 'ssh' | 'codex-account' | 'no-session'
 }
 
 /** Payload of `pty:recycled` — see IPC.ptyRecycled and `recycleAction` in the renderer. */
@@ -377,6 +402,15 @@ export interface CanvasNodeState {
   commitOid?: string
   /** group-only: when bound, the git worktree this group works in. */
   worktree?: GroupWorktree
+  /**
+   * group-only: when set, this frame REFERENCES another project's canvas. Drilling it switches the
+   * active project to the referenced one (ticket 09 — canvas-of-canvases). The group may also hold
+   * local children rendered on the source (meta) canvas. An unresolvable `projectId` renders as a
+   * greyed "unavailable project" (lazy-prune, never auto-deleted: reopening the folder restores the
+   * same cwd-derived id). Validated at use, like `worktree`: a `projectId` is a hand-editable string
+   * from git-shared JSON, never trusted by type alone.
+   */
+  projectRef?: { projectId: string }
 }
 
 /**
@@ -411,11 +445,50 @@ export interface Viewport {
   zoom: number
 }
 
-/** A persistent "bridge" link between two Claude nodes (lets their sessions message each other). */
+/** A persistent "bridge" link between two Claude nodes (lets their sessions message each other).
+ *
+ *  LEGACY read-only shape: pre-`Link` files carry `bridges`/`ropes` as arrays of this. New writes
+ *  emit the unified `Link[]` (`Project.links`) instead; `migrateLinks` (core/workspace-files.ts)
+ *  lifts these into `Link` on load. Kept declared so the migration reader is typed. */
 export interface BridgeLink {
   id: string
   source: string
   target: string
+}
+
+/**
+ * One endpoint of a typed {@link Link}. Discriminated by `ref` so consumers switch exhaustively
+ * (no id-prefix hacks — the `bridge-`/`ctrl-` prefix was the pre-`Link` discriminator and is gone).
+ *  - `node`  : a node in the SAME project that owns this link.
+ *  - `xnode` : a node in ANOTHER project (a cross-project foreign reference — names the other
+ *              project's node id, never a copy of the node; unresolved targets lazy-prune).
+ *  - `branch`: a git branch (dependency links, ticket 03).
+ */
+export type Endpoint =
+  | { ref: 'node'; nodeId: string }
+  | { ref: 'xnode'; projectId: string; nodeId: string }
+  | { ref: 'branch'; repoPath: string; branch: string }
+
+/**
+ * The persisted discriminator that replaces the "which array am I in" encoding (bridges vs ropes).
+ *  - `context`    : two CONTEXT_LINK_CAPABLE agent nodes that read each other's transcripts, OR a
+ *                   sticky→terminal note link (`meta.note` carries the sticky text). Read-back via
+ *                   the `/context-link/` route. ← migrates from `Project.bridges` (`bridge-` ids).
+ *  - `lineage`    : display-only "spawned by" edge, NEVER a context link (`meta.displayOnly: true`).
+ *                   ← migrates from `Project.ropes` (`ctrl-` ids).
+ *  - `dependency` : drives git/stack operations (ticket 03 same-repo branch endpoints, ticket 04
+ *                   cross-repo). Not authored on-canvas yet (ticket 06).
+ */
+export type LinkKind = 'context' | 'lineage' | 'dependency'
+
+/** A typed link between two {@link Endpoint}s. Replaces BOTH `Project.bridges` and `Project.ropes`. */
+export interface Link {
+  id: string
+  kind: LinkKind
+  source: Endpoint
+  target: Endpoint
+  /** 'displayOnly' (lineage ropes), 'note' (sticky→terminal text), dependency type, … */
+  meta?: Record<string, unknown>
 }
 
 /** One kanban board column. Column order = array order in ProjectKanban.columns. */
@@ -637,12 +710,20 @@ export interface Project {
   dinoHighScore?: number
   /** Kanban task board — shared via .nodeterm/project.json like nodes. */
   kanban?: ProjectKanban
-  /** Bridge links between Claude nodes (optional; absent in pre-bridge files). */
+  /**
+   * The unified, typed link substrate — replaces `bridges` + `ropes`. Every link whose `source` is
+   * a node in THIS project lives here, including links whose `target` is an `xnode` (cross-project)
+   * or a `branch` (dependency). See {@link Link} / {@link Endpoint} / {@link LinkKind}.
+   */
+  links?: Link[]
+  /** LEGACY read-only: pre-`Link` files carry `bridges`; `migrateLinks` lifts them to `links` on
+   *  load. New writes never emit this field. Absent in pre-bridge files. */
   bridges?: BridgeLink[]
   /**
-   * Visual "spawned by" ropes (control-capable agent → node it opened via the `nodeterm` CLI,
-   * or browser popup → its opener). Display-only — never context links — but persisted so the
-   * lineage survives restarts; deletable like any selected edge.
+   * LEGACY read-only: pre-`Link` files carry `ropes`; `migrateLinks` lifts them to `links` on load.
+   *  New writes never emit this field. Visual "spawned by" ropes (control-capable agent → node it
+   *  opened via the `nodeterm` CLI, or browser popup → its opener). Display-only — never context
+   *  links — but persisted so the lineage survives restarts; deletable like any selected edge.
    */
   ropes?: BridgeLink[]
   /**
@@ -1769,6 +1850,10 @@ export interface GitApi {
   /** `{ ok: false, entries: [] }` when git itself could not be read — which is NOT the same fact as
    *  "this repo has no worktrees", and no caller may treat it as one (see worktree-ops). */
   worktreeList(repoPath: string): Promise<import('./worktree').WorktreeListResult>
+  /** `git submodule status --recursive`. Same `{ ok, entries }` contract as `worktreeList`: a failed
+   *  git read is `{ ok: false, entries: [] }`, NOT "no submodules" — `ok` changes no facts (see
+   *  worktree-ops `listSubmodules`). Drives the meta-canvas submodule auto-link (ticket 09). */
+  submoduleList(repoPath: string): Promise<import('./worktree').SubmoduleListResult>
   worktreeAdd(repoPath: string, wtPath: string, branch: string, baseRef: string, isNew: boolean): Promise<GitResult>
   /** `push`: also publish `baseRef` to origin after a successful merge (only if a remote exists).
    *  Opt-in — a merge must never publish to a shared remote the user was not told about. */
@@ -1776,6 +1861,20 @@ export interface GitApi {
   /** `pruneOnly`: clean up git's registration only — never delete a directory. Used to prune a
    *  stale binding whose worktree was already deleted outside the app. */
   worktreeRemove(repoPath: string, wtPath: string, deleteBranch: boolean, pruneOnly?: boolean): Promise<GitResult>
+  /** Declare a branch's parent in the shared git config (the git-town `git-town-branch.<child>.parent`
+   *  convention — plain `git config`, no binary). `repoPath` is any worktree's cwd (config is shared). */
+  setBranchParent(repoPath: string, child: string, parent: string): Promise<GitResult>
+  /** Drop a branch's parent config (`git config --unset`). The dependency link is removed separately. */
+  unsetBranchParent(repoPath: string, child: string): Promise<GitResult>
+  /** Rebase `child` onto its configured parent, run in the child branch's own worktree cwd. Returns
+   *  `ok:false` with a "resolve conflicts" message when the rebase stops on a conflict (the user
+   *  continues/aborts in the worktree's terminal). No git-town binary. */
+  syncBranch(cwd: string, child: string): Promise<GitResult>
+  /** Open a PR from `child` into its parent (`gh pr create --base <parent> --head <child>`). */
+  proposeBranch(cwd: string, child: string): Promise<GitResult>
+  /** Fast-forward `child` into its parent when clean (a v1 simplification of full stack ship: no
+   *  multi-descendant restack). Run in the parent's worktree cwd. */
+  shipBranch(cwd: string, child: string, parent: string): Promise<GitResult>
   /** Scope remote git routing to the active project: pass its id to route git over that SSH
    *  project's master, or null for a local project so all git ops run locally. */
   setActiveRemote(projectId: string | null): Promise<void>

--- a/src/shared/worktree-ops.ts
+++ b/src/shared/worktree-ops.ts
@@ -1,9 +1,11 @@
 import {
   parseWorktreePorcelain,
+  parseSubmoduleStatus,
   isDangerousWorktreeRemovalPath,
   decideMergeStrategy,
   isValidGitRef,
-  type WorktreeListResult
+  type WorktreeListResult,
+  type SubmoduleListResult
 } from './worktree'
 
 /** One git invocation's result (mirrors git-service.ts's internal `Exec`). */
@@ -103,6 +105,40 @@ export async function listWorktrees(
     parseWorktreePorcelain(r.out).map(async (e) => ({
       ...e,
       prunable: e.prunable || !(await pathExists(e.path))
+    }))
+  )
+  return { ok: true, entries }
+}
+
+/**
+ * List a repo's submodules, with `prunable` made TRUE for any entry whose directory is not on disk.
+ *
+ * Mirrors `listWorktrees` exactly. `git submodule status --recursive` emits one line per submodule:
+ * `<flag><sha> <path> (<desc>)`, where the leading flag is ` `-` for an uninitialized (absent)
+ * submodule. We OR git's `-` flag with a live path stat — git reports a submodule the superproject
+ * records even when its directory was deleted behind git's back or never checked out, and a stale
+ * registration must read as `prunable` (so the auto-linker suggests re-opening rather than linking a
+ * ghost). Unlike `listWorktrees`, the submodule `path` is RELATIVE to the repo root, so it is joined
+ * against `repoPath` before the stat — `pathExists` answers about an ABSOLUTE path.
+ *
+ * The `{ ok, entries }` shape carries the same rule: a FAILED `git submodule status` (spawn EAGAIN, a
+ * repo with a corrupt `.gitmodules`, a not-a-repo) is `{ ok: false, entries: [] }` — NEVER collapsed
+ * to "this repo has no submodules", because a caller that reads the empty list as "no submodules" would
+ * drop every auto-link on one bad read, exactly the escalation `listWorktrees`' docstring warns about.
+ * `ok:false` changes no facts.
+ */
+export async function listSubmodules(
+  git: GitExecutor,
+  repoPath: string,
+  pathExists: PathExists = alwaysExists
+): Promise<SubmoduleListResult> {
+  if (!repoPath) return { ok: false, entries: [] }
+  const r = await git(repoPath, ['submodule', 'status', '--recursive'])
+  if (!r.ok) return { ok: false, entries: [] }
+  const entries = await Promise.all(
+    parseSubmoduleStatus(r.out).map(async (e) => ({
+      ...e,
+      prunable: e.prunable || !(await pathExists(repoPath.replace(/\/+$/, '') + '/' + e.path))
     }))
   )
   return { ok: true, entries }

--- a/src/shared/worktree-submodule.test.ts
+++ b/src/shared/worktree-submodule.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { parseSubmoduleStatus } from './worktree'
+import { listSubmodules, type GitExec } from './worktree-ops'
+
+const ok = (out = ''): GitExec => ({ ok: true, out, err: '' })
+const ko = (err = 'fail'): GitExec => ({ ok: false, out: '', err })
+
+/** Fake git executor: returns a canned result keyed by `args.join(' ')`, records every call. */
+function fakeGit(handlers: Record<string, GitExec>) {
+  const calls: string[][] = []
+  const git = async (_cwd: string, args: string[]): Promise<GitExec> => {
+    calls.push(args)
+    return handlers[args.join(' ')] ?? ok()
+  }
+  return { git, calls }
+}
+
+describe('parseSubmoduleStatus', () => {
+  it('parses a clean checked-out submodule (leading space, with description)', () => {
+    const out = ' a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 vendor/lib (1.2.3)'
+    const e = parseSubmoduleStatus(out)
+    expect(e).toHaveLength(1)
+    expect(e[0]).toEqual({ path: 'vendor/lib', sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0', prunable: false })
+  })
+
+  it('parses a submodule with no trailing description', () => {
+    const out = ' a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 vendor/lib'
+    const e = parseSubmoduleStatus(out)
+    expect(e).toHaveLength(1)
+    expect(e[0].path).toBe('vendor/lib')
+    expect(e[0].prunable).toBe(false)
+  })
+
+  it('marks a `-` (uninitialized/absent) submodule as prunable', () => {
+    const out = '-0000000000000000000000000000000000000000 vendor/missing'
+    const e = parseSubmoduleStatus(out)
+    expect(e).toHaveLength(1)
+    expect(e[0]).toEqual({ path: 'vendor/missing', sha: '0000000000000000000000000000000000000000', prunable: true })
+  })
+
+  it('does NOT mark a `+` (SHA differs) submodule as prunable — the directory exists', () => {
+    const out = '+a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 vendor/lib (1.2.3)'
+    const e = parseSubmoduleStatus(out)
+    expect(e[0].prunable).toBe(false)
+  })
+
+  it('handles a path containing spaces (no description)', () => {
+    const out = ' a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 my sub module'
+    const e = parseSubmoduleStatus(out)
+    expect(e[0].path).toBe('my sub module')
+  })
+
+  it('parses multiple lines (recursive nesting)', () => {
+    const out = [
+      ' a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 outer/sub (v1)',
+      ' b1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 outer/sub/inner'
+    ].join('\n')
+    const e = parseSubmoduleStatus(out)
+    expect(e.map((x) => x.path)).toEqual(['outer/sub', 'outer/sub/inner'])
+  })
+
+  it('skips blank lines and lines without a 40-char SHA', () => {
+    const out = '\n  not a submodule line\n a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 vendor/lib'
+    const e = parseSubmoduleStatus(out)
+    expect(e).toHaveLength(1)
+    expect(e[0].path).toBe('vendor/lib')
+  })
+})
+
+describe('listSubmodules (the ok:false rule, mirroring listWorktrees)', () => {
+  const cleanSub = ' a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 vendor/lib (v1)'
+  const absentSub = '-0000000000000000000000000000000000000000 vendor/gone'
+
+  it('says ok:false when git itself fails — an empty list is NOT proof of absence', async () => {
+    const { git } = fakeGit({ 'submodule status --recursive': ko('not a repo') })
+    expect(await listSubmodules(git, '/repo', async () => false)).toEqual({ ok: false, entries: [] })
+  })
+
+  it('says ok:true for a repo that genuinely has no submodules', async () => {
+    const { git } = fakeGit({ 'submodule status --recursive': ok('') })
+    expect(await listSubmodules(git, '/repo')).toEqual({ ok: true, entries: [] })
+  })
+
+  it('says ok:false without calling git when there is no repo path', async () => {
+    const { git, calls } = fakeGit({})
+    expect(await listSubmodules(git, '')).toEqual({ ok: false, entries: [] })
+    expect(calls.length).toBe(0)
+  })
+
+  it('ORs the `-` flag with the path stat so a directory git thinks is healthy is caught', async () => {
+    // A clean (` `) submodule whose directory was deleted behind git's back — git says healthy, the
+    // stat says gone. prunable must be true (the stat fallback, mirroring the worktree blindness).
+    const { git } = fakeGit({ 'submodule status --recursive': ok(cleanSub) })
+    const { entries } = await listSubmodules(git, '/repo', async (p) => p !== '/repo/vendor/lib')
+    expect(entries[0]).toEqual({
+      path: 'vendor/lib',
+      sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+      prunable: true
+    })
+  })
+
+  it('keeps a clean submodule with a live directory as not prunable', async () => {
+    const { git } = fakeGit({ 'submodule status --recursive': ok(cleanSub) })
+    const { entries } = await listSubmodules(git, '/repo', async () => true)
+    expect(entries[0].prunable).toBe(false)
+  })
+
+  it('joins the relative path against the repo root (trailing slash tolerated)', async () => {
+    const { git, calls } = fakeGit({ 'submodule status --recursive': ok(cleanSub) })
+    await listSubmodules(git, '/repo/', async (p) => {
+      // The stat path is the repo root (slash-stripped) joined with the relative submodule path.
+      expect(p).toBe('/repo/vendor/lib')
+      return true
+    })
+    expect(calls[0]).toEqual(['submodule', 'status', '--recursive'])
+  })
+
+  it('reports an uninitialized (`-`) submodule as prunable even when the stat says it exists', async () => {
+    // git's `-` already means absent; the OR keeps it prunable regardless of the stat.
+    const { git } = fakeGit({ 'submodule status --recursive': ok(absentSub) })
+    const { entries } = await listSubmodules(git, '/repo', async () => true)
+    expect(entries[0].prunable).toBe(true)
+  })
+})

--- a/src/shared/worktree.test.ts
+++ b/src/shared/worktree.test.ts
@@ -10,6 +10,7 @@ import {
   isDangerousWorktreeRemovalPath,
   decideMergeStrategy,
   isRemoteSessionNode,
+  branchParentConfigKey,
   isValidGitRef,
   resolveBaseRef,
   worktreeFromCreate,
@@ -66,6 +67,29 @@ describe('isValidGitRef', () => {
     expect(isValidGitRef('--force')).toBe(false)
     expect(isValidGitRef('a b')).toBe(false)
     expect(isValidGitRef('')).toBe(false)
+  })
+})
+
+describe('branchParentConfigKey', () => {
+  // The interpolation guard: a branch name from git-shared JSON lands on a `git config` command line,
+  // so a smuggled flag or path char must be rejected BEFORE the key is built (the standing rule —
+  // re-validate at the site, not by the type).
+  it('builds the git-town convention key for a valid branch', () => {
+    expect(branchParentConfigKey('feat-b')).toBe('git-town-branch.feat-b.parent')
+    expect(branchParentConfigKey('feature/x')).toBe('git-town-branch.feature/x.parent')
+  })
+  it('rejects a flag-like branch (no key built, no command possible)', () => {
+    expect(branchParentConfigKey('-x')).toBeNull()
+    expect(branchParentConfigKey('--force')).toBeNull()
+  })
+  it('rejects a branch with forbidden ref chars', () => {
+    expect(branchParentConfigKey('a b')).toBeNull()
+    expect(branchParentConfigKey('a..b')).toBeNull()
+    expect(branchParentConfigKey('')).toBeNull()
+    expect(branchParentConfigKey('   ')).toBeNull()
+  })
+  it('trims before validating', () => {
+    expect(branchParentConfigKey('  feat-b  ')).toBe('git-town-branch.feat-b.parent')
   })
 })
 

--- a/src/shared/worktree.ts
+++ b/src/shared/worktree.ts
@@ -46,6 +46,27 @@ export interface WorktreeListResult {
   entries: WorktreeEntry[]
 }
 
+/** One git submodule, as reported by `git submodule status`. `path` is RELATIVE to the repo root. */
+export interface SubmoduleEntry {
+  /** Relative path inside the repo (e.g. `vendor/lib`). */
+  path: string
+  /** Commit the superproject records for the submodule (the SHA git checks out). Empty on parse miss. */
+  sha: string
+  /**
+   * git still LISTS a submodule whose directory was deleted behind its back (or never initialized) —
+   * `git submodule status` prefixes the line with `-` exactly when the working tree is absent. Treating
+   * such an entry as alive is what makes a dead binding look healthy, so the flag has to survive the
+   * parse AND be OR-ed with a path stat (git < 2.x edge cases), mirroring `WorktreeEntry.prunable`.
+   */
+  prunable?: boolean
+}
+
+/** `git submodule status`, plus WHETHER GIT COULD BE READ AT ALL — see `worktree-ops.listSubmodules`. */
+export interface SubmoduleListResult {
+  ok: boolean
+  entries: SubmoduleEntry[]
+}
+
 /** The node fields that can say "this session does not run on this machine". */
 interface RemoteNodeLike {
   /** SSH-PROJECT terminal (`createTerminalNode(..., project.ssh)`) — the connection it runs on. */
@@ -78,6 +99,28 @@ export function isValidGitRef(name: string): boolean {
   const n = name.trim()
   if (!n || n.startsWith('-')) return false
   return !/[\s~^:?*[\\]|\.\.|^\/|\/$|@\{/.test(n)
+}
+
+/**
+ * The shared-config key git-town uses to record a branch's parent: `git-town-branch.<child>.parent`.
+ * We ADOPT this convention (plain `git config`, no git-town binary) so a topology nodeterm declares is
+ * readable by git-town, and one declared via git-town is readable by us.
+ *
+ * Pure + exported so the interpolation guard is unit-testable: a branch name that smuggles a CLI
+ * flag (`-x`) or carries path/namespace chars git forbids is REJECTED here, before it ever reaches a
+ * `git config` command line. This is the standing rule (re-validate a hand-editable value at the
+ * interpolation site, never by its type) — branch names come from git-shared JSON and land on a git
+ * command line, exactly like permission modes / `SAFE_SESSION_ID`. Returns `null` for an invalid ref
+ * so the caller can refuse without building a command. The dot-segment check keeps a `<child>` like
+ * `..` from collapsing the config section.
+ */
+export function branchParentConfigKey(child: string): string | null {
+  const n = child.trim()
+  if (!isValidGitRef(n)) return null
+  // A refname segment must not be empty or be `..` (git refines this; the regex above already
+  // rejects the leading/trailing-slash and `..` cases `isValidGitRef` covers). Belt-and-braces: a
+  // name with a literal newline is impossible after isValidGitRef but we keep the guard local.
+  return `git-town-branch.${n}.parent`
 }
 
 /** Flatten a branch name into a filesystem-safe, flag-safe slug. */
@@ -310,6 +353,45 @@ export function parseWorktreePorcelain(out: string): WorktreeEntry[] {
     }
   }
   if (cur) flush(cur)
+  return entries
+}
+
+/**
+ * Parse `git submodule status [--recursive]` into structured entries.
+ *
+ * Each line is `<flag><sha> <path> (<description>)`:
+ *  - the leading flag char is ` ` (checked out, SHA matches), `+` (SHA differs from what the
+ *    superproject records), `-` (NOT initialized — the directory is absent), or `U` (merge conflict).
+ *  - `<sha>` is the 40-char commit (or all-zeros when uninitialized).
+ *  - `<path>` is relative to the repo root (may contain spaces; the trailing ` (<desc>)` is optional
+ *    and git omits it when there is no description — so the path is everything from after the SHA to
+ *    either ` (` or end-of-line).
+ *
+ * `-` ⇒ `prunable:true`: an uninitialized submodule has no working tree, exactly the "directory gone"
+ * case `WorktreeEntry.prunable` models. `+`/`U` are NOT prunable (the directory exists; only the SHA
+ * differs). The path stat in `listSubmodules` ORs the flag with a live `fs` check so a directory git
+ * still thinks is healthy (old git, deleted-behind-its-back) is caught too.
+ */
+export function parseSubmoduleStatus(out: string): SubmoduleEntry[] {
+  const entries: SubmoduleEntry[] = []
+  for (const raw of out.split('\n')) {
+    const line = raw.trimEnd()
+    if (!line) continue
+    // The first char is the flag; the rest begins with the 40-char SHA.
+    const flag = line[0]
+    const rest = line.slice(1)
+    // SHA is the first token after the flag (git zero-pads uninitialized submodules).
+    const shaMatch = rest.match(/^\s*([0-9a-f]{40})\s+/)
+    if (!shaMatch) continue
+    const sha = shaMatch[1]
+    const afterSha = rest.slice(shaMatch[0].length)
+    // Path runs to ` (` (the optional description) or end-of-line. A path may contain spaces but not
+    // a bare ` (` — git's own format uses ` (<desc>)` only as a trailing suffix.
+    const descIdx = afterSha.indexOf(' (')
+    const path = (descIdx >= 0 ? afterSha.slice(0, descIdx) : afterSha).trim()
+    if (!path) continue
+    entries.push({ path, sha, prunable: flag === '-' })
+  }
   return entries
 }
 


### PR DESCRIPTION
## Summary

- migrate legacy bridges and ropes to a typed Link/Endpoint model with backward-compatible reads
- add cross-project link authoring, inspection, context readback, navigation, and targeted agent projections
- add group/project drill-down, worktree and branch dependencies, meta canvases, and submodule discovery
- render unopened submodules as non-persistent ghost portals, promoting them to real project references when opened

## Safety and migration notes

- New writes use `links`; existing `bridges` and `ropes` are migrated on read.
- Cross-project projections require an existing target PTY and cannot spawn or take ownership of that session.
- Link mutations share the Canvas commit path so autosave cannot overwrite inspector changes.
- Focus-node mode is intentionally excluded because it is already under review in #267.

## Verification

- `npm run typecheck`
- `npm run build`
- targeted Vitest suite: 20 files, 485 tests passed
- full Vitest run: the one Wayfinder migration expectation was fixed; 9 unrelated environment/flaky failures remain (BSD command incompatibilities, Unix socket path length, a missing xterm source file, and a session-host timing/EPIPE case)