### PR TITLE
fix(macos): drop allow-dyld-environment-variables from production entitlements

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -8,8 +8,6 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
   </dict>

--- a/src/main/entitlements.test.ts
+++ b/src/main/entitlements.test.ts
@@ -21,50 +21,89 @@ import path from 'path'
  * `safeStorage` (Keychain-backed) for GitHub / model-gateway secrets, the
  * node-auth root secret, and remote host identity material.
  *
- * `com.apple.security.cs.allow-dyld-environment-variables` is REMOVED because no
- * code in this app reads DYLD_* in the main process — the only reference is in
- * `src/core/claude-accounts-core.ts`, which STRIPS DYLD_* out of spawned child
- * agent processes (the opposite direction). Removing it closes the demonstrated
- * injection vector at zero functional cost.
+ * WHY REMOVING THE DYLD ENTITLEMENT IS SAFE, measured twice:
+ *  1. Nothing in this repo reads `DYLD_*`. The only references are in
+ *     `src/core/claude-accounts-core.ts` (and its tests), which STRIP `DYLD_*`
+ *     OUT of spawned child agent processes — the opposite direction.
+ *  2. It is not an Electron requirement. electron-builder's own default template
+ *     (`node_modules/app-builder-lib/templates/entitlements.mac.plist`) grants
+ *     exactly `allow-jit`, `allow-unsigned-executable-memory` and
+ *     `disable-library-validation` — `allow-dyld-environment-variables` is NOT in
+ *     it. It was an addition on top of the default, so removing it returns us to
+ *     the stock Electron packaging posture rather than departing from it.
  *
- * This test reads the plist rather than measuring a signed binary, so it runs on
- * the ubuntu CI runner (`npm test`) on every PR/push — the release-CI assertion
- * the report asked for.
+ * The same measurement is why `disable-library-validation` STAYS: it IS in
+ * electron-builder's default set (their template cites electron-builder#3940),
+ * because Electron apps need it to load native modules such as node-pty and
+ * smart-whisper. Dropping it can only be validated by launching a SIGNED build on
+ * a real Mac, and the reporter's own controls showed it does not enable the
+ * attack on its own.
+ *
+ * SHAPE OF THE GUARD: an ALLOWLIST, not a snapshot. It fails when an entitlement
+ * nobody reviewed is ADDED, and stays green when one is removed — so tightening
+ * the entitlements later (e.g. dropping `disable-library-validation` after device
+ * verification) never has to fight this test. It reads the plist rather than a
+ * signed binary, so it runs on the ubuntu CI runner via `npm test` on every
+ * PR/push — the release-CI assertion the report asked for.
  */
 const ENTITLEMENTS = path.resolve(__dirname, '../../build/entitlements.mac.plist')
 
-const HOWTO =
-  'A macOS main-process entitlement that permits pre-main code injection into the ' +
-  'signed, notarized production process must not ship. See the Fortress MSSP report ' +
-  '(2026-08-23) and the reasoning in this test file.'
+/**
+ * Every entitlement the production build is allowed to request, each with the
+ * reason it survived review. electron-builder's default three, plus the
+ * microphone (the dictation feature; paired with NSMicrophoneUsageDescription in
+ * the package.json `build.mac.extendInfo`).
+ */
+const REVIEWED_ENTITLEMENTS: Readonly<Record<string, string>> = {
+  'com.apple.security.cs.allow-jit': "electron-builder default — V8's JIT",
+  'com.apple.security.cs.allow-unsigned-executable-memory': 'electron-builder default',
+  'com.apple.security.cs.disable-library-validation':
+    'electron-builder default (electron-builder#3940) — loads node-pty / smart-whisper',
+  'com.apple.security.device.audio-input': 'dictation (speech-to-text) captures the microphone'
+}
+
+/**
+ * Entitlements that must never come back, with what they cost. Kept separate from
+ * the allowlist so the failure message names the vulnerability rather than just
+ * saying "unreviewed key".
+ */
+const FORBIDDEN_ENTITLEMENTS: Readonly<Record<string, string>> = {
+  'com.apple.security.cs.allow-dyld-environment-variables':
+    'permits DYLD_INSERT_LIBRARIES pre-main dylib injection into the signed, notarized ' +
+    'process, which then holds nodeterm code identity against Keychain-backed safeStorage ' +
+    '(Fortress MSSP report, 2026-08-23). Nothing in this app reads DYLD_*, and it is not ' +
+    "in electron-builder's default template."
+}
+
+/** Keys requested by the plist, in file order. */
+function entitlementKeys(plist: string): string[] {
+  return [...plist.matchAll(/<key>([^<]+)<\/key>/g)].map((m) => m[1].trim())
+}
 
 describe('macOS production entitlements', () => {
   const exists = fs.existsSync(ENTITLEMENTS)
   const plist = exists ? fs.readFileSync(ENTITLEMENTS, 'utf8') : ''
+  const keys = entitlementKeys(plist)
 
-  it('build/entitlements.mac.plist exists', () => {
+  it('build/entitlements.mac.plist exists and requests something', () => {
     expect(exists, `Missing ${ENTITLEMENTS}`).toBe(true)
+    expect(keys.length).toBeGreaterThan(0)
   })
 
-  it('does NOT grant allow-dyld-environment-variables (the pre-main dylib injection vector)', () => {
+  it('requests no entitlement that permits pre-main code injection', () => {
+    for (const [key, why] of Object.entries(FORBIDDEN_ENTITLEMENTS)) {
+      expect(keys, `${key} is back in the production entitlements: ${why}`).not.toContain(key)
+    }
+  })
+
+  it('requests only reviewed entitlements', () => {
+    const unreviewed = keys.filter((k) => !(k in REVIEWED_ENTITLEMENTS))
     expect(
-      plist.includes('com.apple.security.cs.allow-dyld-environment-variables'),
-      `allow-dyld-environment-variables is back in the production entitlements. ${HOWTO}`
-    ).toBe(false)
-  })
-
-  /**
-   * `disable-library-validation` is the OTHER half of the pair the report flagged.
-   * It is deliberately STILL PRESENT for now: removing it can prevent the app from
-   * loading its own native modules (node-pty, smart-whisper) unless every one is
-   * signed with the same Team ID, which can only be confirmed by building and
-   * launching a signed build on a real Mac. This assertion is intentionally NOT a
-   * `.toBe(false)` — it documents the known-remaining state so a reviewer who
-   * removes it later (after device verification) is prompted to update this test
-   * instead of being surprised. Follow-up: drop the entitlement, then flip this to
-   * assert its absence.
-   */
-  it('still grants disable-library-validation (pending on-device verification of native module signing)', () => {
-    expect(plist.includes('com.apple.security.cs.disable-library-validation')).toBe(true)
+      unreviewed,
+      'Unreviewed macOS entitlement(s) in the production build. A hardened-runtime exception ' +
+        'weakens the signed process — add it to REVIEWED_ENTITLEMENTS with the reason only ' +
+        'after deciding it is genuinely required, and check it is not one Electron already ' +
+        'works without.'
+    ).toEqual([])
   })
 })

--- a/src/main/entitlements.test.ts
+++ b/src/main/entitlements.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Release guard for the macOS hardened-runtime entitlements the production main
+ * executable is signed with (build/entitlements.mac.plist, wired via the
+ * package.json `build.mac.entitlements` + `entitlementsInherit` keys).
+ *
+ * WHY THIS EXISTS: a private report (Fortress MSSP, 2026-08-23) confirmed that on
+ * an arm64 host a same-user, post-compromise attacker could launch the exact
+ * shipped, Developer-ID-signed, notarized nodeterm executable with
+ * `DYLD_INSERT_LIBRARIES` pointing at a foreign ad-hoc-signed dylib, and its
+ * constructor ran INSIDE the vendor-signed process before application main. The
+ * enabling condition was the entitlement PAIR
+ * `com.apple.security.cs.allow-dyld-environment-variables` +
+ * `com.apple.security.cs.disable-library-validation`; matched controls confirmed
+ * neither alone reproduced it. Foreign pre-main code running with nodeterm's own
+ * code identity matters here specifically because macOS Keychain ACLs gate
+ * access by the requesting binary's identity, and the app uses Electron
+ * `safeStorage` (Keychain-backed) for GitHub / model-gateway secrets, the
+ * node-auth root secret, and remote host identity material.
+ *
+ * `com.apple.security.cs.allow-dyld-environment-variables` is REMOVED because no
+ * code in this app reads DYLD_* in the main process — the only reference is in
+ * `src/core/claude-accounts-core.ts`, which STRIPS DYLD_* out of spawned child
+ * agent processes (the opposite direction). Removing it closes the demonstrated
+ * injection vector at zero functional cost.
+ *
+ * This test reads the plist rather than measuring a signed binary, so it runs on
+ * the ubuntu CI runner (`npm test`) on every PR/push — the release-CI assertion
+ * the report asked for.
+ */
+const ENTITLEMENTS = path.resolve(__dirname, '../../build/entitlements.mac.plist')
+
+const HOWTO =
+  'A macOS main-process entitlement that permits pre-main code injection into the ' +
+  'signed, notarized production process must not ship. See the Fortress MSSP report ' +
+  '(2026-08-23) and the reasoning in this test file.'
+
+describe('macOS production entitlements', () => {
+  const exists = fs.existsSync(ENTITLEMENTS)
+  const plist = exists ? fs.readFileSync(ENTITLEMENTS, 'utf8') : ''
+
+  it('build/entitlements.mac.plist exists', () => {
+    expect(exists, `Missing ${ENTITLEMENTS}`).toBe(true)
+  })
+
+  it('does NOT grant allow-dyld-environment-variables (the pre-main dylib injection vector)', () => {
+    expect(
+      plist.includes('com.apple.security.cs.allow-dyld-environment-variables'),
+      `allow-dyld-environment-variables is back in the production entitlements. ${HOWTO}`
+    ).toBe(false)
+  })
+
+  /**
+   * `disable-library-validation` is the OTHER half of the pair the report flagged.
+   * It is deliberately STILL PRESENT for now: removing it can prevent the app from
+   * loading its own native modules (node-pty, smart-whisper) unless every one is
+   * signed with the same Team ID, which can only be confirmed by building and
+   * launching a signed build on a real Mac. This assertion is intentionally NOT a
+   * `.toBe(false)` — it documents the known-remaining state so a reviewer who
+   * removes it later (after device verification) is prompted to update this test
+   * instead of being surprised. Follow-up: drop the entitlement, then flip this to
+   * assert its absence.
+   */
+  it('still grants disable-library-validation (pending on-device verification of native module signing)', () => {
+    expect(plist.includes('com.apple.security.cs.disable-library-validation')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Removes `com.apple.security.cs.allow-dyld-environment-variables` from the macOS production entitlements (`build/entitlements.mac.plist`) and adds a CI guard that keeps unreviewed hardened-runtime exceptions out.

## Why

A private security report (Fortress MSSP, 2026-08-23) confirmed that on arm64, a **same-user, post-compromise** attacker could launch the shipped, Developer-ID-signed, notarized nodeterm executable with `DYLD_INSERT_LIBRARIES` pointing at a foreign ad-hoc-signed dylib, and its constructor executed **inside the vendor-signed process before application main**. Matched controls confirmed the enabling condition was the entitlement pair `allow-dyld-environment-variables` + `disable-library-validation` — neither alone reproduced it.

This has app-specific impact because nodeterm uses Keychain-backed Electron `safeStorage` for GitHub / model-gateway secrets, the node-auth root secret, and remote host identity material. macOS Keychain ACLs gate access by the **requesting binary's code identity**, so foreign pre-main code running with nodeterm's identity is a real marginal risk beyond a plain same-user compromise.

Scope, as stated by the reporter: local, post-compromise hardening weakness. No remote exploitation, no credential read, no TCC/Gatekeeper bypass, no root — and no CVSS assigned.

## This is a packaging choice, not an Electron requirement

The decisive measurement: electron-builder's own default template (`node_modules/app-builder-lib/templates/entitlements.mac.plist`) grants exactly

```
com.apple.security.cs.allow-jit
com.apple.security.cs.allow-unsigned-executable-memory
com.apple.security.cs.disable-library-validation
```

`allow-dyld-environment-variables` is **not** in it — it was an addition on top of the default. So removing it **returns us to the stock Electron packaging posture** rather than departing from it. Independently, nothing in this repo reads `DYLD_*`: the only references (`src/core/claude-accounts-core.ts` and its tests) *strip* `DYLD_*` out of spawned child agent processes, the opposite direction.

After this change the plist is electron-builder's default set plus `com.apple.security.device.audio-input` (dictation; paired with the existing `NSMicrophoneUsageDescription`).

## Deliberately left for a follow-up

`disable-library-validation` — the other half of the pair — is **kept**, and the same measurement is why: it *is* in electron-builder's default set, cited there to electron-builder#3940, because Electron apps need it to load native modules (`node-pty`, `smart-whisper`). Dropping it can only be validated by launching a **signed** build on a real Mac. The reporter's own controls showed it does not enable the attack on its own, so keeping it does not leave the reported issue open.

## The guard

`src/main/entitlements.test.ts` reads the plist (so it runs on the ubuntu CI runner via `npm test`, on every PR/push — the release-CI assertion the report asked for) and is deliberately an **allowlist, not a snapshot**:

- a forbidden entitlement coming back fails with a message naming the vulnerability;
- any entitlement outside the reviewed set fails, each reviewed entry carrying its reason;
- **removing** an entitlement keeps it green, so tightening later (e.g. dropping `disable-library-validation` after device verification) never has to fight this test.

Mutation-checked all three ways.

## Test

```
npx vitest run src/main/entitlements.test.ts   # 3 passed
```

Not device-verified: that a signed build launches without the entitlement can only be confirmed on a Mac. Risk is low — the entitlement only *permits* honoring env vars we never set — but it is the kind of thing that surfaces at launch, not in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
