### PR TITLE
fix(keybindings): off-mac Ctrl+W reaches the shell while a terminal has focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1684,6 +1684,14 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
     suspends the same items, so ⌘M / ⌘⇧B / ⌘, / off-mac Ctrl+W reach the recorder instead of the
     menu item that owns them; `menuStandsDown(false, …)` is `policyStandsDown(…)` by construction.
     The two INTERCEPT thunks stay independent parameters — only the menu ORs them.
+    **The CLOSE leg has one extra, policy-independent stand-down** (issue #383, off-mac only):
+    `closeStandsDownInTerminal(isMac, terminalFocused)` — off-mac `node.close`'s default chord is
+    Ctrl+W, readline's kill-word, so while a terminal has focus the close intercept lets the chord
+    fall through UNTOUCHED and `syncMenuForStandDown` disables the Close menu item on top of the
+    shared list. mac's ⌘W is deliberately unaffected (not a shell key), and ⌘/Ctrl+M and ⌘/Ctrl+0
+    keep firing — this is one chord whose terminal meaning outranks its app meaning, not a policy
+    change. One predicate, two consumers, pinned in `keydown-intercept.test.ts` (including a
+    source-level wiring pin, since the menu leg lives against a real Menu in index.ts).
   - **`terminalFocused` is a MIRROR, and its fail-safe direction is `false` = not focused =
     intercepts ON.** `renderer/lib/terminalFocusMirror.ts` reports focus changes to main and is
     change-deduped (it never re-asserts), so a page that died mid-report, a reload, or a window that
@@ -2019,7 +2027,10 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   named in `menuItemIdsToSuspend` — Minimize (`MENU_ITEM_ID_MINIMIZE`), **Toggle Kanban Board
   (`MENU_ITEM_ID_KANBAN`, ⌘⇧B)** and **Settings (`MENU_ITEM_ID_SETTINGS`, ⌘,)** on every platform,
   plus Close (`MENU_ITEM_ID_CLOSE`) on Windows/Linux — because a disabled item suppresses its
-  accelerator and only then do those chords fall through to the terminal, or to the recorder. The
+  accelerator and only then do those chords fall through to the terminal, or to the recorder.
+  Off-mac the Close item is ALSO disabled whenever a terminal has focus, policy or no policy
+  (`closeStandsDownInTerminal`, issue #383): its role owns the Ctrl+W accelerator, and that
+  keystroke in a shell is readline's kill-word. The
   recorder leg is why ⌘M is bindable at all, and it fixed a live misfire: ⌘⇧B pressed into an armed
   recorder used to open the kanban board behind the Settings dialog, and ⌘, to re-open Settings.
   Kanban and Settings are

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -116,6 +116,7 @@ import {
   MENU_ITEM_ID_KANBAN,
   MENU_ITEM_ID_MINIMIZE,
   MENU_ITEM_ID_SETTINGS,
+  closeStandsDownInTerminal,
   installKeydownIntercepts,
   menuItemIdsToSuspend,
   menuStandsDown,
@@ -893,6 +894,15 @@ function syncMenuForStandDown(): void {
     const item = menu.getMenuItemById(id)
     if (item) item.enabled = enabled
   }
+  // The CLOSE item's extra, policy-independent stand-down (issue #383): off-mac its role owns the
+  // Ctrl+W accelerator above the page, and while a terminal has focus that keystroke is readline's
+  // kill-word. Applied ON TOP of the shared suspension — the item must never be MORE enabled than
+  // the shared rule says. Mac has no close item in the template, so the lookup is null there and
+  // this is a no-op by construction.
+  if (closeStandsDownInTerminal(interceptIsMac, terminalFocused)) {
+    const close = menu.getMenuItemById(MENU_ITEM_ID_CLOSE)
+    if (close) close.enabled = false
+  }
 }
 
 function createWindow(): BrowserWindow {
@@ -1049,7 +1059,9 @@ function createWindow(): BrowserWindow {
     currentInterceptBindings,
     interceptIsMac,
     () => shortcutRecording,
-    () => policyStandsDown(currentInterceptPolicy(), terminalFocused)
+    () => policyStandsDown(currentInterceptPolicy(), terminalFocused),
+    // The close leg's own, policy-independent stand-down (issue #383) — see the predicate's doc.
+    () => closeStandsDownInTerminal(interceptIsMac, terminalFocused)
   )
 
   // The THIRD way the page that armed a recorder (or reported terminal focus) can go away: a

--- a/src/main/keydown-intercept.test.ts
+++ b/src/main/keydown-intercept.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import path from 'path'
 import { describe, expect, it } from 'vitest'
 import { IPC } from '../shared/ipc'
 import { MAIN_INTERCEPTED_COMMAND_IDS } from '../shared/keybindings'
@@ -15,7 +17,8 @@ import {
   resolveInterceptBindings,
   type KeydownInterceptBindings,
   type KeydownInterceptInput,
-  type KeydownInterceptTarget
+  type KeydownInterceptTarget,
+  closeStandsDownInTerminal
 } from './keydown-intercept'
 
 /**
@@ -84,7 +87,8 @@ function install(
   getBindings: () => KeydownInterceptBindings,
   isMac: boolean,
   isRecording: () => boolean,
-  isStoodDown: () => boolean
+  isStoodDown: () => boolean,
+  isCloseSuspended?: () => boolean
 ): { fire: (over?: Partial<KeydownInterceptInput>) => void; prevented: string[]; sent: string[] } {
   let handler:
     | ((event: { preventDefault(): void }, input: KeydownInterceptInput) => void)
@@ -101,7 +105,7 @@ function install(
       }
     }
   }
-  installKeydownIntercepts(win, getBindings, isMac, isRecording, isStoodDown)
+  installKeydownIntercepts(win, getBindings, isMac, isRecording, isStoodDown, isCloseSuspended)
   if (!handler) throw new Error('installKeydownIntercepts registered no before-input-event listener')
   const fire = (over: Partial<KeydownInterceptInput> = {}): void => {
     const i = input(over)
@@ -617,5 +621,63 @@ describe('menuStandsDown', () => {
         expect(menuStandsDown(true, policy, focused)).toBe(true)
       }
     }
+  })
+})
+
+/**
+ * Issue #383: off-mac, `node.close`'s default chord is Ctrl+W — readline's kill-word in every
+ * shell — so while a terminal has FOCUS the close leg stands down REGARDLESS of the policy, and
+ * the keystroke falls through untouched to the page → xterm → the pty. mac's ⌘W is not a shell
+ * key and is deliberately unaffected.
+ */
+describe('the close leg stands down inside a terminal, off-mac only (#383)', () => {
+  it('closeStandsDownInTerminal truth table', () => {
+    expect(closeStandsDownInTerminal(false, true)).toBe(true) // off-mac + terminal focused
+    expect(closeStandsDownInTerminal(false, false)).toBe(false) // off-mac, no terminal
+    expect(closeStandsDownInTerminal(true, true)).toBe(false) // mac untouched
+    expect(closeStandsDownInTerminal(true, false)).toBe(false)
+  })
+
+  it('a suspended close chord falls through UNTOUCHED; the other intercepts keep firing', () => {
+    let terminalFocused = true
+    const offMacDefaults = resolveInterceptBindings({}, false)
+    const seam = install(
+      () => offMacDefaults,
+      false,
+      () => false,
+      () => false, // app-first: the policy leg does NOT stand down — this is the narrow close rule
+      () => closeStandsDownInTerminal(false, terminalFocused)
+    )
+    seam.fire({ control: true, key: 'w', code: 'KeyW' })
+    // No preventDefault and no send: the chord must reach the pty as readline's kill-word.
+    expect(seam.prevented).toEqual([])
+    expect(seam.sent).toEqual([])
+    // The OTHER claimed chords are untouched by the close-only rule.
+    seam.fire({ control: true, key: 'm', code: 'KeyM' })
+    expect(seam.sent).toEqual([IPC.appToggleMarkdown])
+    // Focus leaves the terminal → close works again.
+    terminalFocused = false
+    seam.fire({ control: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([IPC.appToggleMarkdown, IPC.appCloseNode])
+  })
+
+  it('the default 6th parameter is "never suspended" — pre-#383 callers are byte-identical', () => {
+    const offMacDefaults = resolveInterceptBindings({}, false)
+    const seam = install(() => offMacDefaults, false, () => false, () => false)
+    seam.fire({ control: true, key: 'w', code: 'KeyW' })
+    expect(seam.sent).toEqual([IPC.appCloseNode])
+  })
+
+  it('index.ts wires the predicate into BOTH consumers (intercept thunk + close menu item)', () => {
+    // The menu leg cannot be pressed from here (it lives against a real Menu in index.ts), so the
+    // wiring is pinned at source level — the same discipline as hook-verified-parity.
+    const src = fs.readFileSync(path.join(__dirname, 'index.ts'), 'utf8')
+    expect(src).toContain('() => closeStandsDownInTerminal(interceptIsMac, terminalFocused)')
+    const menuSync = src.slice(
+      src.indexOf('function syncMenuForStandDown'),
+      src.indexOf('function createWindow')
+    )
+    expect(menuSync).toContain('closeStandsDownInTerminal(interceptIsMac, terminalFocused)')
+    expect(menuSync).toContain('MENU_ITEM_ID_CLOSE')
   })
 })

--- a/src/main/keydown-intercept.ts
+++ b/src/main/keydown-intercept.ts
@@ -225,6 +225,26 @@ export function policyStandsDown(
 }
 
 /**
+ * PURE. The CLOSE leg's extra stand-down, applied REGARDLESS of the policy (issue #383): off-mac,
+ * `node.close`'s default chord is Ctrl+W — which is readline's kill-word in every shell — so a
+ * keystroke typed into a FOCUSED terminal must reach the pty, not close the node/window out from
+ * under the user (with no reopen affordance once the last window goes). The narrow shape is the
+ * point:
+ * - **mac is untouched**: ⌘W is not a shell key, and closing the focused terminal's node with it
+ *   is the behavior mac users expect.
+ * - **Only the close leg**: ⌘/Ctrl+M and ⌘/Ctrl+0 stay claimed under app-first exactly as before —
+ *   this is not a policy change, it is one chord whose terminal meaning outranks its app meaning.
+ * - **Only while a terminal has focus** (the same fail-safe mirror the policy leg reads: a dead
+ *   report resolves to "not focused" = close works).
+ * Closing while typing off-mac: click the node's ×, or focus away first. Both the intercept branch
+ * and the Window ▸ Close menu item (whose role owns the Ctrl+W accelerator above the page) consult
+ * THIS predicate — one definition, two consumers, per the house rule.
+ */
+export function closeStandsDownInTerminal(isMac: boolean, terminalFocused: boolean): boolean {
+  return !isMac && terminalFocused
+}
+
+/**
  * PURE. The MENU leg's composed stand-down state: `index.ts`'s `syncMenuForStandDown` disables
  * `menuItemIdsToSuspend` for exactly as long as this is true.
  *
@@ -404,12 +424,20 @@ export function installKeydownIntercepts(
   getBindings: () => KeydownInterceptBindings,
   isMac: boolean,
   isRecording: () => boolean,
-  isStoodDown: () => boolean
+  isStoodDown: () => boolean,
+  // The close leg's OWN stand-down (`closeStandsDownInTerminal` — off-mac + terminal focused,
+  // policy-independent). Defaults to "never" so every pre-#383 caller and test is byte-identical.
+  isCloseSuspended: () => boolean = () => false
 ): void {
   win.webContents.on('before-input-event', (event, input) => {
     if (isRecording() || isStoodDown()) return
     const decision = keydownIntercept(input, getBindings(), isMac)
     if (!decision) return
+    // Checked AFTER resolution and only for close: the chord must fall through UNTOUCHED (no
+    // preventDefault) so it reaches the page → xterm → the pty as readline's kill-word. The menu
+    // leg is suspended in the same states (syncMenuForStandDown), so nothing above the page takes
+    // it either.
+    if (decision.action === 'close-node' && isCloseSuspended()) return
     event.preventDefault()
     if (decision.action) win.webContents.send(keydownInterceptChannel(decision.action))
   })


### PR DESCRIPTION
Addresses the Windows/Linux half of #383 (confirmed by a Linux user there; the macOS report is still under diagnosis with the reporter — our code provably does not route Ctrl+W to close on darwin, so this PR deliberately does not auto-close the issue).

## The bug

Off-mac, `node.close`'s default chord is **Ctrl+W** — readline's kill-word in every shell. Two owners above the page claimed it even while the user was typing into a focused terminal: the Window ▸ Close menu role (its accelerator) and the main-process intercept. Result: delete-a-word closed the node, or with nothing selected the whole window, with no reopen affordance.

## The fix

One new pure predicate, `closeStandsDownInTerminal(isMac, terminalFocused)` — off-mac + terminal focused, **policy-independent** — consulted by both consumers:

- the **intercept** lets a resolved `close-node` decision fall through **untouched** (no `preventDefault`), so the keystroke reaches the page → xterm → the pty as kill-word;
- **`syncMenuForStandDown`** disables the Close menu item on top of the shared suspension list (a disabled item suppresses its accelerator).

Deliberately narrow: mac's ⌘W is not a shell key and is unaffected; ⌘/Ctrl+M and ⌘/Ctrl+0 keep firing under app-first; focus leaving the terminal restores Close immediately (same fail-safe mirror as the policy leg — a dead report resolves to "close works"). Closing while typing off-mac: the node's ×, or focus away first.

Pinned in `keydown-intercept.test.ts`: the truth table, the fall-through seam behavior (no prevent, no send; other intercepts unaffected; restores on focus loss), the byte-identical default for pre-existing callers, and a source-level pin that index.ts wires the predicate into BOTH consumers. CLAUDE.md's stand-down and window-chrome bullets updated. 8914 tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)