### PR TITLE
feat(settings): opt-in toggle for the resume card (default off)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1765,7 +1765,10 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   deliberate `goToNode` landing records a `NavStop` ({nodeId, at, note}) for the ACTIVE project, and
   **Cmd+[ / Cmd+]** (`canvas.goBack` / `canvas.goForward`, bound in `shared/keybindings.ts`) plus the
   two Dock buttons walk that trail; on a project activation a once-per-app-run **`ResumeCard`** offers
-  the last few distinct stops ("resume where you left off"). Load-bearing facts:
+  the last few distinct stops ("resume where you left off") — **opt-in via
+  `settings.showResumeCard` (Settings → Appearance, default OFF)**: while disabled the
+  once-per-app-run slot is not spent, so enabling it later still shows the card on the next
+  activation; the chords/Dock buttons work regardless. Load-bearing facts:
   - **The trail is MACHINE-LOCAL and rides `IndexEntryV3.breadcrumbs`, never `.nodeterm/project.json`** —
     the same tier as `viewport` / `defaultAccountId` / `capabilityAck`, for the same reason: a repo must
     not carry one person's camera history to everyone who clones it. `fileToProject` therefore ignores a

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -2026,14 +2026,22 @@ export function Canvas() {
       if (useSettings.getState().settings.phoneAccessEnabled) {
         window.nodeTerminal.remoteHost.sendCanvasState({ nodes: flowToNodeStates(nodesRef.current) })
       }
-      // Offer the resume card once per project per app run. "Once" is only spent on a card that
-      // could actually render: a project whose breadcrumbs ALL point at nodes deleted since must
-      // not burn its one-shot slot on an empty card the user never saw — and neither must a
-      // project that activates ON the kanban board, where the card (z 11) sits invisible under
-      // the opaque overlay (z 25). Same failure mode, same rule.
+      // Offer the resume card once per project per app run — and only when the user opted in
+      // (settings.showResumeCard, default off): while disabled the one-shot slot is NOT spent,
+      // so flipping the switch on later still shows the card on the next activation. "Once" is
+      // only spent on a card that could actually render: a project whose breadcrumbs ALL point
+      // at nodes deleted since must not burn its one-shot slot on an empty card the user never
+      // saw — and neither must a project that activates ON the kanban board, where the card
+      // (z 11) sits invisible under the opaque overlay (z 25). Same failure mode, same rule.
       const liveIds = new Set(flow.map((n) => n.id))
       const hasLiveStop = (project.breadcrumbs ?? []).some((b) => liveIds.has(b.nodeId))
-      if (!resumeCardShown.has(project.id) && hasLiveStop && !isKanbanOpen(project.id)) {
+      const resumeCardEnabled = useSettings.getState().settings.showResumeCard
+      if (
+        resumeCardEnabled &&
+        !resumeCardShown.has(project.id) &&
+        hasLiveStop &&
+        !isKanbanOpen(project.id)
+      ) {
         resumeCardShown.add(project.id)
         setResumeProject(project)
       } else {

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -155,10 +155,15 @@ describe('breadcrumb wiring the CLAUDE.md bullet calls load-bearing', () => {
     expect(CANVAS_SRC.match(/isMeasured\(internal\)/g) ?? []).toHaveLength(1)
   })
 
-  it('the resume card slot is spent only on a card that can render', () => {
-    // Once per app run, only with a live stop, and never under the opaque kanban overlay.
+  it('the resume card slot is spent only on a card that can render, and only when opted in', () => {
+    // Gated on settings.showResumeCard (default off) FIRST — a disabled card must not spend the
+    // one-shot slot — then once per app run, only with a live stop, and never under the opaque
+    // kanban overlay.
     expect(CANVAS_SRC).toContain(
-      '!resumeCardShown.has(project.id) && hasLiveStop && !isKanbanOpen(project.id)'
+      'resumeCardEnabled &&\n        !resumeCardShown.has(project.id) &&\n        hasLiveStop &&\n        !isKanbanOpen(project.id)'
+    )
+    expect(CANVAS_SRC).toContain(
+      'const resumeCardEnabled = useSettings.getState().settings.showResumeCard'
     )
   })
 })

--- a/src/renderer/components/settings/sections/AppearanceSection.tsx
+++ b/src/renderer/components/settings/sections/AppearanceSection.tsx
@@ -21,6 +21,10 @@ const ROWS = {
     keywords: ['appearance', 'theme', 'light', 'dark', 'mode', 'colour', 'color', 'chrome']
   },
   accent: { title: 'Accent', keywords: ['accent', 'color', 'theme', 'appearance'] },
+  resumeCard: {
+    title: 'Resume card',
+    keywords: ['resume', 'where you left off', 'breadcrumb', 'card', 'popup', 'trail']
+  },
   menuItems: {
     title: 'Node menu items',
     keywords: ['menu', 'context', 'right click', 'items', 'hide']
@@ -82,6 +86,7 @@ export function AppearanceSection({ isActive }: { isActive: boolean }): React.JS
   const accent = useSettings((s) => s.settings.accent)
   const hiddenNodeMenuItems = useSettings((s) => s.settings.hiddenNodeMenuItems)
   const hiddenHeaderButtons = useSettings((s) => s.settings.hiddenHeaderButtons)
+  const showResumeCard = useSettings((s) => s.settings.showResumeCard)
   const update = useSettings((s) => s.update)
   return (
     <SettingsSection
@@ -127,6 +132,19 @@ export function AppearanceSection({ isActive }: { isActive: boolean }): React.JS
             ))}
           </div>
         </div>
+      </SearchableRow>
+      <SearchableRow {...ROWS.resumeCard}>
+        <FieldRow
+          label="Resume card"
+          description='Offer a "Resume where you left off" card when a project is activated, listing your last few node landings. Cmd+[ / Cmd+] and the Dock arrows walk the same trail either way.'
+          control={
+            <Switch
+              checked={showResumeCard}
+              onChange={(v) => update({ showResumeCard: v })}
+              ariaLabel="Show the resume card on project activation"
+            />
+          }
+        />
       </SearchableRow>
       {/* One wrapper element per row: the section body puts a divider and its own padding around
           every direct child, so a heading + caption + list must arrive as a single node. */}

--- a/src/renderer/lib/settingsReset.ts
+++ b/src/renderer/lib/settingsReset.ts
@@ -35,7 +35,8 @@ export const APPEARANCE_RESET_KEYS = [
   'appTheme',
   'accent',
   'hiddenNodeMenuItems',
-  'hiddenHeaderButtons'
+  'hiddenHeaderButtons',
+  'showResumeCard'
 ] as const satisfies readonly (keyof Settings)[]
 
 /** The defaults for `keys`, as a patch for `useSettings.update`. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1298,6 +1298,10 @@ export interface Settings {
   /** Ids of terminal node header buttons the user has hidden; empty = everything visible. Gated by
    *  HIDEABLE_HEADER_BUTTONS the same way. */
   hiddenHeaderButtons: string[]
+  /** Whether project activation offers the "Resume where you left off" card (breadcrumb trail's
+   *  once-per-app-run popup). OFF by default — it interrupts every project switch, so it is
+   *  opt-in. Cmd+[ / Cmd+] and the Dock buttons walk the trail regardless of this. */
+  showResumeCard: boolean
   /** Whether usage percentages render as consumed ("32% used"), remaining ("68% left"), or raw
    *  token counts ("48k/200k tokens" — context-window surfaces only; provider quota surfaces
    *  have no token counts and fall back to 'used' display). 'remaining' is the historical
@@ -1470,6 +1474,9 @@ export const DEFAULT_SETTINGS: Settings = {
   // Nothing hidden out of the box, so existing users see the menu and header they already know.
   hiddenNodeMenuItems: [],
   hiddenHeaderButtons: [],
+  // Opt-in: the resume card pops over the canvas on every qualifying project activation, which
+  // reads as noise to users who navigate by the trail chords/Dock buttons instead.
+  showResumeCard: false,
   usagePercentMode: 'remaining',
   defaultAgent: 'claude',
   // Sessions start in auto mode out of the box. Existing users pick this up on hydrate


### PR DESCRIPTION
## Why

The "Resume where you left off" card (#366) pops over the canvas on every qualifying project activation and had no off switch. Per user feedback it reads as noise — especially for people who navigate by the trail chords / Dock buttons.

## What

- New `settings.showResumeCard` (Settings → Appearance), **default OFF** — the card becomes opt-in.
- The Canvas activation offer checks the setting **before** spending the once-per-app-run slot, so enabling the switch later still shows the card on the very next activation (a disabled card never burns its slot).
- Cmd+[ / Cmd+] and the Dock arrows keep walking the breadcrumb trail regardless — only the popup is gated.
- The key joins `APPEARANCE_RESET_KEYS`; the Appearance row is searchable ("resume", "breadcrumb", "popup").
- `canvas-wiring.test.tsx` pin updated to the gated condition (and pins that the gate reads the settings store).
- CLAUDE.md breadcrumb bullet documents the toggle.

## Surfaces

Desktop + Server Edition share the renderer/settings store, so both get it as-is. Mobile N/A (no canvas).

## Verification

- `npm run typecheck` clean.
- `canvas-wiring` + `settingsReset` + `breadcrumbs` + full settings component suites: 368 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)