### PR TITLE
feat(kanban): resizable + maximizable card modal that remembers its size

### DIFF
--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -5,6 +5,14 @@ import { IconChat, IconMic, IconSearch } from '../icons'
 import { ContextMeter } from '../ContextMeter'
 import { useAgentStatus } from '../../state/agentStatus'
 import { useCardPanel } from '../../state/cardPanel'
+import {
+  useCardModalSize,
+  resolveModalSize,
+  maxModalSize,
+  clampAxis,
+  CARD_MODAL_MIN_W,
+  CARD_MODAL_MIN_H
+} from '../../state/cardModalSize'
 import { useSession } from '../../session/session'
 import type { ProjectKanban } from '@shared/types'
 import type { KanbanSession } from './KanbanView'
@@ -56,6 +64,80 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
   const togglePanel = useCardPanel((s) => s.toggle)
   const isTerminal = session.kind === 'terminal'
   const isBrowser = session.kind === 'browser'
+
+  // ── Resizable / maximizable sheet (issue #389) ──────────────────────────────────────────────
+  // The sheet stays CENTRED; resize is symmetric about the centre, so every edge/corner handle
+  // tracks the cursor 1:1 with `Δsize = 2·Δcursor` and we never manage a left/top. Size (and the
+  // maximized flag) is remembered per machine in localStorage — see cardModalSize.ts.
+  const savedWidth = useCardModalSize((s) => s.width)
+  const savedHeight = useCardModalSize((s) => s.height)
+  const maximized = useCardModalSize((s) => s.maximized)
+  const rememberSize = useCardModalSize((s) => s.remember)
+  const setMaximized = useCardModalSize((s) => s.setMaximized)
+  const [viewport, setViewport] = useState(() => ({
+    w: typeof window === 'undefined' ? 1280 : window.innerWidth,
+    h: typeof window === 'undefined' ? 800 : window.innerHeight
+  }))
+  const [size, setSize] = useState(() =>
+    resolveModalSize({ width: savedWidth, height: savedHeight, maximized }, viewport.w, viewport.h)
+  )
+  const resizingRef = useRef(false)
+
+  useEffect(() => {
+    const onResize = () => setViewport({ w: window.innerWidth, h: window.innerHeight })
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  // Recompute the rendered size whenever the remembered size, the maximized flag, or the viewport
+  // changes — but never while a drag is mid-flight (that owns `size` directly).
+  useEffect(() => {
+    if (resizingRef.current) return
+    setSize(resolveModalSize({ width: savedWidth, height: savedHeight, maximized }, viewport.w, viewport.h))
+  }, [savedWidth, savedHeight, maximized, viewport.w, viewport.h])
+
+  const startResize = (dir: string) => (e: React.PointerEvent) => {
+    if (maximized) return
+    e.preventDefault()
+    e.stopPropagation()
+    const handle = e.currentTarget as HTMLElement
+    handle.setPointerCapture(e.pointerId)
+    resizingRef.current = true
+    const startX = e.clientX
+    const startY = e.clientY
+    const startW = size.width
+    const startH = size.height
+    // Cache the ceiling once; capture keeps events flowing even over the terminal/browser webview.
+    const max = maxModalSize(window.innerWidth, window.innerHeight)
+    let latest = { width: startW, height: startH }
+    const onMove = (ev: PointerEvent) => {
+      const dx = ev.clientX - startX
+      const dy = ev.clientY - startY
+      let w = startW
+      let h = startH
+      if (dir.includes('e')) w = startW + 2 * dx
+      if (dir.includes('w')) w = startW - 2 * dx
+      if (dir.includes('s')) h = startH + 2 * dy
+      if (dir.includes('n')) h = startH - 2 * dy
+      latest = {
+        width: clampAxis(w, CARD_MODAL_MIN_W, max.width),
+        height: clampAxis(h, CARD_MODAL_MIN_H, max.height)
+      }
+      setSize(latest)
+    }
+    const onUp = () => {
+      handle.removeEventListener('pointermove', onMove)
+      handle.removeEventListener('pointerup', onUp)
+      handle.removeEventListener('pointercancel', onUp)
+      resizingRef.current = false
+      rememberSize(latest.width, latest.height) // persist the size the drag settled on
+    }
+    handle.addEventListener('pointermove', onMove)
+    handle.addEventListener('pointerup', onUp)
+    handle.addEventListener('pointercancel', onUp)
+  }
+
+  const RESIZE_DIRS = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw']
 
   const nameWithAi = async () => {
     setNaming(true)
@@ -118,8 +200,29 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
   return createPortal(
     <div className="kanban-modal-scrim" onMouseDown={onClose}>
       {/* stopPropagation: clicks inside the sheet must not reach the scrim-close */}
-      <div className="kanban-modal" onMouseDown={(e) => e.stopPropagation()}>
-        <div className="kanban-modal__header">
+      <div
+        className="kanban-modal"
+        style={{ width: size.width, height: size.height }}
+        data-maximized={maximized || undefined}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {!maximized &&
+          RESIZE_DIRS.map((d) => (
+            <div
+              key={d}
+              className={`kanban-modal__resize kanban-modal__resize--${d}`}
+              onPointerDown={startResize(d)}
+            />
+          ))}
+        <div
+          className="kanban-modal__header"
+          onDoubleClick={(e) => {
+            // Double-click the header BACKGROUND toggles maximize — not the title (rename) or actions.
+            const t = e.target as HTMLElement
+            if (t.closest('button') || t.closest('input') || t.closest('.kanban-modal__title')) return
+            setMaximized(!maximized)
+          }}
+        >
           <span className="kanban-card__nodedot" style={{ background: session.color }} />
           {editingTitle ? (
             <input
@@ -189,6 +292,14 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
             onClick={togglePanel}
           >
             <IconChat />
+          </button>
+          <button
+            className="kanban-modal__action"
+            title={maximized ? 'Restore size' : 'Maximize'}
+            aria-pressed={maximized}
+            onClick={() => setMaximized(!maximized)}
+          >
+            {maximized ? '❐' : '⤢'}
           </button>
           <button className="kanban-modal__action" title="Open on canvas" onClick={onOpenCanvas}>
             ↗

--- a/src/renderer/state/cardModalSize.test.ts
+++ b/src/renderer/state/cardModalSize.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  parseCardModalSize,
+  resolveModalSize,
+  defaultModalSize,
+  maxModalSize,
+  clampAxis,
+  CARD_MODAL_MIN_W,
+  CARD_MODAL_MIN_H,
+  CARD_MODAL_PREF_W,
+  CARD_MODAL_PREF_H,
+  CARD_MODAL_MARGIN_X,
+  CARD_MODAL_MARGIN_Y,
+  useCardModalSize,
+  CARD_MODAL_SIZE_KEY
+} from './cardModalSize'
+
+describe('clampAxis', () => {
+  it('clamps into range', () => {
+    expect(clampAxis(500, 480, 900)).toBe(500)
+    expect(clampAxis(100, 480, 900)).toBe(480)
+    expect(clampAxis(2000, 480, 900)).toBe(900)
+  })
+  it('lets the max (fit-the-viewport) win when the viewport is smaller than the minimum', () => {
+    expect(clampAxis(700, 480, 300)).toBe(300)
+  })
+})
+
+describe('defaultModalSize', () => {
+  it('uses the preferred size on a large viewport', () => {
+    expect(defaultModalSize(2560, 1440)).toEqual({ width: CARD_MODAL_PREF_W, height: CARD_MODAL_PREF_H })
+  })
+  it('scales down to fit a small viewport (the core of the bug — no fixed box)', () => {
+    const vw = 1000, vh = 700
+    expect(defaultModalSize(vw, vh)).toEqual({ width: vw - CARD_MODAL_MARGIN_X, height: vh - CARD_MODAL_MARGIN_Y })
+  })
+})
+
+describe('resolveModalSize', () => {
+  const big = { vw: 2560, vh: 1440 }
+
+  it('returns the scaling default when nothing is remembered', () => {
+    expect(resolveModalSize({ width: null, height: null, maximized: false }, big.vw, big.vh))
+      .toEqual(defaultModalSize(big.vw, big.vh))
+  })
+
+  it('honours an explicit remembered size', () => {
+    expect(resolveModalSize({ width: 900, height: 620, maximized: false }, big.vw, big.vh))
+      .toEqual({ width: 900, height: 620 })
+  })
+
+  it('clamps a remembered size that no longer fits the viewport', () => {
+    // Saved on a big screen, reopened on a small one.
+    const r = resolveModalSize({ width: 2000, height: 1200, maximized: false }, 1200, 800)
+    expect(r).toEqual(maxModalSize(1200, 800))
+  })
+
+  it('never shrinks below the minimum', () => {
+    expect(resolveModalSize({ width: 50, height: 50, maximized: false }, big.vw, big.vh))
+      .toEqual({ width: CARD_MODAL_MIN_W, height: CARD_MODAL_MIN_H })
+  })
+
+  it('maximized fills the viewport regardless of the remembered size', () => {
+    expect(resolveModalSize({ width: 700, height: 500, maximized: true }, big.vw, big.vh))
+      .toEqual(maxModalSize(big.vw, big.vh))
+  })
+})
+
+describe('parseCardModalSize', () => {
+  it('treats missing / garbage as no memory', () => {
+    expect(parseCardModalSize(null)).toEqual({ width: null, height: null, maximized: false })
+    expect(parseCardModalSize('not json')).toEqual({ width: null, height: null, maximized: false })
+  })
+  it('rejects non-positive dimensions but keeps the flag', () => {
+    expect(parseCardModalSize(JSON.stringify({ width: 0, height: -5, maximized: true })))
+      .toEqual({ width: null, height: null, maximized: true })
+  })
+  it('round-trips a real size', () => {
+    expect(parseCardModalSize(JSON.stringify({ width: 900, height: 620, maximized: false })))
+      .toEqual({ width: 900, height: 620, maximized: false })
+  })
+})
+
+describe('useCardModalSize store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCardModalSize.setState({ width: null, height: null, maximized: false })
+  })
+  it('remember() persists the size and clears maximized', () => {
+    useCardModalSize.setState({ maximized: true })
+    useCardModalSize.getState().remember(910, 640)
+    expect(useCardModalSize.getState()).toMatchObject({ width: 910, height: 640, maximized: false })
+    expect(parseCardModalSize(localStorage.getItem(CARD_MODAL_SIZE_KEY))).toEqual({ width: 910, height: 640, maximized: false })
+  })
+  it('setMaximized() persists the flag and keeps the last size', () => {
+    useCardModalSize.getState().remember(910, 640)
+    useCardModalSize.getState().setMaximized(true)
+    expect(parseCardModalSize(localStorage.getItem(CARD_MODAL_SIZE_KEY))).toEqual({ width: 910, height: 640, maximized: true })
+  })
+})

--- a/src/renderer/state/cardModalSize.ts
+++ b/src/renderer/state/cardModalSize.ts
@@ -1,0 +1,110 @@
+import { create } from 'zustand'
+
+// Remembered size of the kanban card modal — PERSONAL, per machine (localStorage), never in the
+// git-shared .nodeterm/project.json (same rule as the view mode and the comments panel). The modal
+// stays centred; resize is symmetric about the centre, which is what lets every edge/corner handle
+// track the cursor 1:1 with `Δsize = 2·Δcursor` and needs no left/top bookkeeping.
+//
+// Issue #389: the modal was a fixed min(1040,…)×min(680,…) box — too small on a large display and
+// not resizable. We remember an explicit width/height (and a maximized flag) instead.
+
+export const CARD_MODAL_SIZE_KEY = 'nodeterm.cardModalSize'
+
+/** Smallest usable modal — below this the header actions and the two panes stop fitting. */
+export const CARD_MODAL_MIN_W = 480
+export const CARD_MODAL_MIN_H = 340
+/** Breathing room kept to the viewport edge (total across both sides of each axis). */
+export const CARD_MODAL_MARGIN_X = 48
+export const CARD_MODAL_MARGIN_Y = 64
+/** Default when nothing is remembered — bigger than the old cap, and it scales with the window. */
+export const CARD_MODAL_PREF_W = 1400
+export const CARD_MODAL_PREF_H = 940
+
+export interface CardModalSize {
+  width: number | null
+  height: number | null
+  maximized: boolean
+}
+
+/** value clamped into [min, max]; when the viewport is so small that max < min, max (fit the
+ *  viewport) wins over min. */
+export function clampAxis(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/** The largest the modal may be in a given viewport (also the maximized size). */
+export function maxModalSize(vw: number, vh: number): { width: number; height: number } {
+  return {
+    width: Math.max(CARD_MODAL_MIN_W, vw - CARD_MODAL_MARGIN_X),
+    height: Math.max(CARD_MODAL_MIN_H, vh - CARD_MODAL_MARGIN_Y)
+  }
+}
+
+/** The default (unremembered) size: the preferred size, but never larger than the viewport allows. */
+export function defaultModalSize(vw: number, vh: number): { width: number; height: number } {
+  const max = maxModalSize(vw, vh)
+  return {
+    width: Math.min(CARD_MODAL_PREF_W, max.width),
+    height: Math.min(CARD_MODAL_PREF_H, max.height)
+  }
+}
+
+/** The size to actually render, given what's remembered and the current viewport. Maximized fills
+ *  the viewport; an explicit remembered size is clamped into range; otherwise the scaling default. */
+export function resolveModalSize(
+  saved: CardModalSize,
+  vw: number,
+  vh: number
+): { width: number; height: number } {
+  const max = maxModalSize(vw, vh)
+  if (saved.maximized) return max
+  if (saved.width != null && saved.height != null) {
+    return {
+      width: clampAxis(saved.width, CARD_MODAL_MIN_W, max.width),
+      height: clampAxis(saved.height, CARD_MODAL_MIN_H, max.height)
+    }
+  }
+  return defaultModalSize(vw, vh)
+}
+
+/** Parse the persisted blob; anything missing/unparseable means "no memory" (use the default). */
+export function parseCardModalSize(raw: string | null): CardModalSize {
+  if (!raw) return { width: null, height: null, maximized: false }
+  try {
+    const v = JSON.parse(raw) as Partial<CardModalSize>
+    const width = typeof v.width === 'number' && v.width > 0 ? v.width : null
+    const height = typeof v.height === 'number' && v.height > 0 ? v.height : null
+    return { width, height, maximized: v.maximized === true }
+  } catch {
+    return { width: null, height: null, maximized: false }
+  }
+}
+
+function save(size: CardModalSize): void {
+  try {
+    localStorage.setItem(CARD_MODAL_SIZE_KEY, JSON.stringify(size))
+  } catch {
+    /* quota/private-mode: a remembered size is a nicety, never fail the UI */
+  }
+}
+
+interface CardModalSizeState extends CardModalSize {
+  /** Record a user-chosen size (a resize drag ended). Clears maximized — a manual resize exits it. */
+  remember(width: number, height: number): void
+  setMaximized(maximized: boolean): void
+}
+
+export const useCardModalSize = create<CardModalSizeState>((set, get) => ({
+  // localStorage guard: this module is also imported by node-environment vitest suites.
+  ...parseCardModalSize(typeof localStorage === 'undefined' ? null : localStorage.getItem(CARD_MODAL_SIZE_KEY)),
+  remember: (width, height) => {
+    const next = { width, height, maximized: false }
+    if (typeof localStorage !== 'undefined') save(next)
+    set(next)
+  },
+  setMaximized: (maximized) => {
+    const next = { width: get().width, height: get().height, maximized }
+    if (typeof localStorage !== 'undefined') save(next)
+    set({ maximized })
+  }
+}))

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8890,8 +8890,11 @@ button.group-node__setup:disabled {
 }
 .kanban-modal {
   animation: kanban-pop 0.16s ease-out;
-  width: min(1040px, calc(100vw - 96px));
-  height: min(680px, calc(100vh - 120px));
+  /* width/height are inline (remembered per machine — see cardModalSize.ts). These are the safety
+     ceiling so the sheet can never exceed the viewport, even for the frame before the clamp runs. */
+  max-width: calc(100vw - 24px);
+  max-height: calc(100vh - 24px);
+  position: relative;
   display: flex;
   flex-direction: column;
   background: var(--surface-sunken);
@@ -8900,6 +8903,29 @@ button.group-node__setup:disabled {
   box-shadow: 0 24px 80px rgba(0, 0, 0, calc(0.6 * var(--shadow-k)));
   overflow: hidden;
 }
+/* Resize handles (issue #389): thin strips just inside each edge, larger squares at the corners.
+   Inset (not outset) so the sheet's overflow:hidden / border-radius doesn't clip them. */
+.kanban-modal__resize {
+  position: absolute;
+  z-index: 6;
+  touch-action: none;
+}
+.kanban-modal__resize--n { top: 0; left: 0; right: 0; height: 6px; cursor: ns-resize; }
+.kanban-modal__resize--s { bottom: 0; left: 0; right: 0; height: 6px; cursor: ns-resize; }
+.kanban-modal__resize--w { left: 0; top: 0; bottom: 0; width: 6px; cursor: ew-resize; }
+.kanban-modal__resize--e { right: 0; top: 0; bottom: 0; width: 6px; cursor: ew-resize; }
+.kanban-modal__resize--ne,
+.kanban-modal__resize--nw,
+.kanban-modal__resize--se,
+.kanban-modal__resize--sw {
+  width: 14px;
+  height: 14px;
+  z-index: 7; /* corners beat the edge strips they overlap */
+}
+.kanban-modal__resize--ne { top: 0; right: 0; cursor: nesw-resize; }
+.kanban-modal__resize--nw { top: 0; left: 0; cursor: nwse-resize; }
+.kanban-modal__resize--se { bottom: 0; right: 0; cursor: nwse-resize; }
+.kanban-modal__resize--sw { bottom: 0; left: 0; cursor: nesw-resize; }
 .kanban-modal__header {
   flex: 0 0 auto;
   display: flex;


### PR DESCRIPTION
Closes #389.

## Problem

The kanban card modal was a fixed `min(1040px,…) × min(680px,…)` box — no resize handles, no maximize, double-clicking the header did nothing, and it didn't grow with the app window. On a large display the terminal (the actual work) used ~a third of the screen while diffs, test output and agent logs wrapped into a narrow column.

## What this adds — the issue's four asks

1. **Resize from any edge or corner.** The sheet stays centred and resizes *symmetrically*, so `Δsize = 2·Δcursor` makes every one of the 8 handles track the cursor 1:1 with **no left/top bookkeeping**. Pointer capture keeps the drag alive even over the terminal / browser `<webview>`.
2. **Maximize** — a `⤢` header button *and* double-clicking the header background fill the available space; toggling restores the previous size. (Double-click ignores the title, inputs and action buttons.)
3. **Remembered** — the size and the maximized flag persist per machine in `localStorage` (never the git-shared `project.json`, same rule as the view mode).
4. **Bigger default that scales with the window** — `min(1400, vw−48) × min(940, vh−64)` instead of the old fixed cap; clamps down on smaller screens and on window resize.

## Design

Size logic is a pure, unit-tested module (`src/renderer/state/cardModalSize.ts`): `defaultModalSize` / `maxModalSize` / `clampAxis` / `resolveModalSize` / `parse` + the persisted store. The component holds the live size, recomputes it from `{saved, viewport, maximized}` (except mid-drag), and persists on drag-end.

## Testing

- New `cardModalSize.test.ts` — 14 cases incl. **reopen-on-a-smaller-screen clamping**, never-below-minimum, maximized-fills-viewport, and store persistence.
- Existing `CardModal.test.tsx` still green; `styles.theme` guard green; `typecheck` + `build` clean.
- **Not browser-verified** — the Playwright MCP was unavailable this session, so the drag/maximize interaction is owed a visual pass on Mac. Logic and geometry are covered by the unit tests and code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
