### PR TITLE
fix(projects): let an explicit "Open folder…" recover an unavailable project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,19 @@ Persistence has two layers:
   are set aside as `project.json.corrupt-<ts>`. "Open folder…" adopts an existing
   `.nodeterm/project.json` — the probe MINTS the project id (node ids — tmux names — kept), and
   re-opening the folder is answered by the cwd lookup, not a second adoption.
+  **An `unavailable` placeholder used to be a DEAD END** (issue #385): a save deliberately emits a
+  header-only ref for it and never a file, so a `project.json` the user deleted was never
+  recreated, every later load re-minted the placeholder, and nothing cleared the flag for a LOCAL
+  project (`reopenProject` clears only `closed`; the sole `setProjectUnavailable(id,false)` caller
+  is the relay reconnect). The tab went inert (`tabClickAction` → `'ignore'`) while the sessions
+  sidebar — which has no concept of `unavailable` — still switched to it. An explicit "Open
+  folder…" now breaks the loop, but only on EVIDENCE: `WorkspaceStore.projectFileState` reports
+  `present | absent | unreadable` and **only a definite ENOENT counts as absence**, because
+  clearing the flag lets the next save write the placeholder's empty canvas over whatever is
+  there. Absent ⇒ clear; present ⇒ re-probe and rehydrate under the EXISTING entry id (a corrupt
+  file stats fine, so a null probe keeps the placeholder); unreadable ⇒ change nothing. The
+  decision is the pure `unavailableRecovery` (`renderer/lib/projectOpen.ts`), and it refuses to
+  judge a REMOTE project from a local stat.
   **The shared file carries content, not identity**: no project `id`, no `viewport`, no
   `defaultAccountId` — those are machine-local and ride the index entry (`IndexEntryV3`), beside
   `localApprovalId`/`localExec`. Two folders holding the same committed canvas (worktree, branch

--- a/src/core/workspace-project-file-state.test.ts
+++ b/src/core/workspace-project-file-state.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Issue #385 — `readProjectFile` collapses "gone", "unreadable" and "corrupt" into one `null`,
+ * which is right for its callers but wrong for recovery: clearing a project's placeholder lets the
+ * next save write its empty canvas, so acting on a failed read would overwrite the only copy.
+ * `projectFileState` is the honest question, and only a definite ENOENT counts as absence.
+ *
+ * MUTATION: make the catch return 'absent' unconditionally (i.e. treat any error as absence) →
+ * the ENOTDIR case below reddens, which is the case that stands in for a permissions/mount error.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform } from './platform-fake'
+import { WorkspaceStore } from './workspace-store'
+
+describe('projectFileState distinguishes absence from a failed read', () => {
+  let dir: string
+  let store: WorkspaceStore
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), 'nodeterm-pfs-'))
+    initPlatform(fakePlatform({ userDataDir: dir }))
+    store = new WorkspaceStore()
+  })
+  afterEach(() => {
+    resetPlatformForTests()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reports absent for a folder with no .nodeterm/project.json', async () => {
+    const folder = path.join(dir, 'plain')
+    mkdirSync(folder)
+    expect(await store.projectFileState(folder)).toBe('absent')
+  })
+
+  it('reports present once the file exists', async () => {
+    const folder = path.join(dir, 'withfile')
+    mkdirSync(path.join(folder, '.nodeterm'), { recursive: true })
+    writeFileSync(path.join(folder, '.nodeterm', 'project.json'), '{"version":1,"nodes":[]}')
+    expect(await store.projectFileState(folder)).toBe('present')
+  })
+
+  it('reports present for a CORRUPT file — a parse failure is not an absence', async () => {
+    const folder = path.join(dir, 'corrupt')
+    mkdirSync(path.join(folder, '.nodeterm'), { recursive: true })
+    writeFileSync(path.join(folder, '.nodeterm', 'project.json'), 'not json at all')
+    expect(await store.projectFileState(folder)).toBe('present')
+  })
+
+  it('reports unreadable, NOT absent, when the read fails for any other reason', async () => {
+    // `.nodeterm` is a FILE here, so stat'ing project.json under it fails ENOTDIR — a stand-in for
+    // the permissions / stalled-mount errors that must never be read as "the file is gone".
+    const folder = path.join(dir, 'blocked')
+    mkdirSync(folder)
+    writeFileSync(path.join(folder, '.nodeterm'), 'i am not a directory')
+    expect(await store.projectFileState(folder)).toBe('unreadable')
+  })
+})

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -171,6 +171,8 @@ export class WorkspaceStore {
     platform().handle(IPC.workspaceLoad, () => this.load())
     platform().handle(IPC.workspaceSave, (workspace: Workspace) => this.save(workspace))
     platform().handle(IPC.workspaceProbeFolder, (folder: string) => this.probeFolder(folder))
+    platform().handle(IPC.workspaceProjectFileState, (cwd: unknown) =>
+      typeof cwd === 'string' && cwd ? this.projectFileState(cwd) : 'unreadable')
     platform().handle(IPC.projectSettingsRead, (projectId: unknown) =>
       typeof projectId === 'string' ? this.readProjectSettings(projectId) : null)
     platform().handle(IPC.projectSettingsWriteShared, (projectId: unknown, doc: ProjectSettingsDoc) =>
@@ -942,6 +944,25 @@ export class WorkspaceStore {
     // anywhere), so its nodes come up with no custom shell and no extra ssh args — the safe
     // defaults. Only values this machine typed itself are ever restored (@shared/node-exec).
     return read ? fileToProject(read.file, { id: freshProjectId(), cwd: folder }) : null
+  }
+
+  /**
+   * Is this folder's `.nodeterm/project.json` genuinely gone, merely unreadable, or fine?
+   *
+   * `readProjectFile` collapses all three into `null`, which is right for its callers (they only
+   * need "can I use it") but wrong for recovery: clearing a project's `unavailable` placeholder
+   * lets the next save WRITE its empty canvas, so doing that on a file that is present but
+   * momentarily unreadable (permissions, a stalled mount) would overwrite the only copy. A failed
+   * read is never evidence of absence — so the errno is the answer, and anything that is not a
+   * definite ENOENT reports `unreadable`, the side that changes nothing. See issue #385.
+   */
+  async projectFileState(cwd: string): Promise<'present' | 'absent' | 'unreadable'> {
+    try {
+      await fs.stat(projectFilePath(cwd))
+      return 'present'
+    } catch (err) {
+      return (err as NodeJS.ErrnoException)?.code === 'ENOENT' ? 'absent' : 'unreadable'
+    }
   }
 
   localRefPaths(): string[] {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -139,6 +139,7 @@ const api: NodeTerminalApi = {
     load: () => ipcRenderer.invoke(IPC.workspaceLoad),
     save: (workspace: Workspace) => ipcRenderer.invoke(IPC.workspaceSave, workspace),
     probeFolder: (folder: string) => ipcRenderer.invoke(IPC.workspaceProbeFolder, folder),
+    projectFileState: (folder: string) => ipcRenderer.invoke(IPC.workspaceProjectFileState, folder),
     onMigrated: (cb: (kind: WorkspaceMigrationKind) => void) => {
       // Older mains broadcast no payload; that was the v2→v3 migration.
       const h = (_e: unknown, kind?: WorkspaceMigrationKind) => cb(kind ?? 'v2')

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -285,6 +285,12 @@ export function buildRealApi(
     // next writeDisk() overwrote the team's shared canvas. Data loss, not a degrade.
     probeFolder: (folder: string) =>
       client.request(IPC.workspaceProbeFolder, folder) as ReturnType<WorkspaceApi['probeFolder']>,
+    // REAL for the same reason: core registers IPC.workspaceProjectFileState, and a stub would
+    // have to answer 'unreadable' — which is the side that never recovers a deleted project file.
+    projectFileState: (folder: string) =>
+      client.request(IPC.workspaceProjectFileState, folder) as ReturnType<
+        WorkspaceApi['projectFileState']
+      >,
     // REAL: core broadcasts IPC.workspaceMigrated after a v2→v3 migration (workspace-store.ts).
     onMigrated: (cb) => client.subscribe(IPC.workspaceMigrated, cb as Listener),
     // REAL: core broadcasts IPC.workspaceCorruptRecovered from the load path (workspace-store.ts).

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -216,6 +216,7 @@ import {
 } from '../lib/controlRouting'
 import { applyStickyWrite, parseStickyArgs, resolveStickyRef } from '../lib/stickyWrite'
 import {
+  unavailableRecovery,
   planOpenProject,
   recordAttachConsent,
   openProjectReply,
@@ -10038,6 +10039,19 @@ export function Canvas() {
     const existing = useProjects.getState().projects.find((p) => p.cwd === folder)
     if (existing) {
       useProjects.getState().openFolderProject(folder)
+      // An `unavailable` placeholder never recovers on its own: a save emits a header-only ref for
+      // it (never a file), so a deleted project.json stays deleted and every later load re-mints
+      // the placeholder. Opening the folder is the deliberate act that breaks that loop — but only
+      // on evidence, since clearing the flag lets the next save write this empty canvas. See #385.
+      const recovery = unavailableRecovery(existing, await api.workspace.projectFileState(folder))
+      if (recovery === 'clear') {
+        useProjects.getState().setProjectUnavailable(existing.id, false)
+      } else if (recovery === 'rehydrate') {
+        // `present` is a stat, not a parse: a corrupt file stats fine, and probeFolder answering
+        // null there means the placeholder is still the honest state.
+        const back = await api.workspace.probeFolder(folder)
+        if (back) useProjects.getState().replaceProject({ ...back, id: existing.id, closed: false })
+      }
     } else {
       // …else adopt the folder's own .nodeterm/project.json (git clone, synced copy,
       // another machine's project) — only a virgin folder gets a brand-new project.

--- a/src/renderer/lib/projectOpen.ts
+++ b/src/renderer/lib/projectOpen.ts
@@ -247,3 +247,36 @@ export function nextFreePosition(
   }
   return { x: left + size.width / 2, y: bottom + 80 + size.height / 2 }
 }
+
+/**
+ * What an explicit "Open folder…" should do when it lands on a project already showing the
+ * `unavailable` placeholder (issue #385).
+ *
+ * The placeholder is minted at load time when the ref can't be read, and a save deliberately
+ * emits a header-only ref for it — never a file — so a stale placeholder can't clobber a source
+ * that might come back. Correct, but it also means a project whose file the user DELETED can
+ * never write one again: nothing clears the flag for a local project, so it stays unreadable at
+ * every later load. The tab goes inert (`tabClickAction` → 'ignore') while the sessions sidebar,
+ * which knows nothing of `unavailable`, still switches to it — the asymmetry issue #385 reports.
+ *
+ * Opening the folder is a deliberate act, so it is the right moment to break the loop — but only
+ * on evidence:
+ *   - `absent`  → the file really is gone. Clear the flag so the next save recreates it; an empty
+ *                 canvas is the truthful state, since that is what deleting the file left.
+ *   - `present` → it reads again (restored, a git checkout). Rehydrate from disk rather than
+ *                 clearing the flag, or an empty placeholder would be saved over real nodes.
+ *   - `unreadable` → we cannot tell. Change nothing; the placeholder is exactly the right answer.
+ */
+export type UnavailableRecovery = 'clear' | 'rehydrate' | 'keep'
+
+export function unavailableRecovery(
+  project: { unavailable?: boolean; ssh?: unknown },
+  fileState: 'present' | 'absent' | 'unreadable'
+): UnavailableRecovery {
+  // Remote projects are not ours to judge from a local stat — their file lives on the host, and
+  // their placeholder is cleared by the reconnect path instead.
+  if (!project.unavailable || project.ssh) return 'keep'
+  if (fileState === 'absent') return 'clear'
+  if (fileState === 'present') return 'rehydrate'
+  return 'keep'
+}

--- a/src/renderer/lib/unavailableRecovery.test.ts
+++ b/src/renderer/lib/unavailableRecovery.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue #385 — a project whose `.nodeterm/project.json` the user deleted stayed crossed out
+ * forever. The placeholder is minted at load when the ref can't be read, a save deliberately
+ * emits a header-only ref for it (never a file), and `openFolderProject` reuses the entry by cwd
+ * while `reopenProject` clears only `closed` — so nothing ever cleared `unavailable` for a local
+ * project and the state sustained itself.
+ *
+ * The decision must rest on EVIDENCE: clearing the flag lets the next save write the placeholder's
+ * empty canvas, which would destroy a file that is present but momentarily unreadable.
+ */
+import { describe, expect, it } from 'vitest'
+import { unavailableRecovery } from './projectOpen'
+
+describe('unavailableRecovery', () => {
+  const stuck = { unavailable: true }
+
+  it('clears the placeholder when the project file is genuinely gone (the #385 case)', () => {
+    expect(unavailableRecovery(stuck, 'absent')).toBe('clear')
+  })
+
+  it('rehydrates instead of clearing when the file is back — an empty canvas must not be saved over it', () => {
+    expect(unavailableRecovery(stuck, 'present')).toBe('rehydrate')
+  })
+
+  it('changes NOTHING when the read merely failed — absence is never inferred from an error', () => {
+    expect(unavailableRecovery(stuck, 'unreadable')).toBe('keep')
+  })
+
+  it('leaves a healthy project alone whatever the file says', () => {
+    expect(unavailableRecovery({}, 'absent')).toBe('keep')
+    expect(unavailableRecovery({ unavailable: false }, 'absent')).toBe('keep')
+  })
+
+  it('never judges a REMOTE project from a local stat — its file lives on the host', () => {
+    expect(unavailableRecovery({ unavailable: true, ssh: { server: {} } }, 'absent')).toBe('keep')
+  })
+})

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -269,6 +269,9 @@ export const IPC = {
   workspaceLoad: 'workspace:load',
   workspaceSave: 'workspace:save',
   workspaceProbeFolder: 'workspace:probe-folder',
+  /** Is a folder's .nodeterm/project.json present / absent / unreadable — the distinction
+   *  `probeFolder`'s null collapses. Recovery of an `unavailable` project needs it (issue #385). */
+  workspaceProjectFileState: 'workspace:project-file-state',
   projectSettingsRead: 'project-settings:read',
   projectSettingsWriteShared: 'project-settings:write-shared',
   projectSettingsUpdateLocal: 'project-settings:update-local',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -840,6 +840,9 @@ export interface WorkspaceApi {
   save(workspace: Workspace): Promise<void>
   /** Reads <folder>/.nodeterm/project.json and returns the assembled Project (cwd resolved), or null. */
   probeFolder(folder: string): Promise<Project | null>
+  /** Whether <folder>/.nodeterm/project.json is `present`, definitely `absent`, or `unreadable`
+   *  (any non-ENOENT error). Never guesses absence from a failed read — see issue #385. */
+  projectFileState(folder: string): Promise<'present' | 'absent' | 'unreadable'>
   /** Fired once after an on-disk migration: `v2` = a v2→v3 migration wrote .nodeterm/ dirs into the
    *  project folders; `exec` = the custom shell / advanced ssh args of already-open projects moved
    *  out of the shared project file into this machine's own workspace index (@shared/node-exec). */


### PR DESCRIPTION
Closes #385.

## The dead end

A project whose `.nodeterm/project.json` the user deleted stays crossed out **forever**, and nothing in the app can bring it back:

1. The ref can't be read at load → `unavailableProject()` (`workspace-store.ts:1509`) → `unavailable: true`, `nodes: []`.
2. A save deliberately emits a **header-only ref and never a file** (`workspace-files.ts:422`) — correct, since a stale placeholder must not clobber a source that might come back, but it also means the deleted file is never recreated.
3. "Open folder…" dedupes by cwd and calls `reopenProject`, which clears **`closed`** and nothing else.

So unavailable ⇒ no file written ⇒ still unreadable next load ⇒ still unavailable. It sustains itself. The only `setProjectUnavailable(id, false)` caller is the relay reconnect path, which never fires for a local project.

The reporter also noticed the odd half of it: the tab is inert by design (`tabClickAction(true, 'local')` → `'ignore'`), while `SessionsSidebar.tsx` — which has **zero** references to `unavailable` — still switches to the project.

## The fix, and why it needs evidence

Clearing the flag is not free: it lets the next save write the placeholder's empty canvas. Do that for a file that is present but momentarily unreadable (permissions, a stalled mount) and you have destroyed the only copy. `readProjectFile` collapses gone / unreadable / corrupt into a single `null`, so it cannot answer this.

New `WorkspaceStore.projectFileState` → `present | absent | unreadable`, where **only a definite ENOENT counts as absence**; every other errno reports `unreadable`, the side that changes nothing. A failed read is never evidence of absence.

An explicit "Open folder…" on an existing project then:

| file state | action |
|---|---|
| `absent` | clear the flag — the next save recreates it, and an empty canvas is the truthful state after a deletion |
| `present` | re-probe and **rehydrate under the existing entry id** — a corrupt file stats fine, so a null probe keeps the placeholder |
| `unreadable` | change nothing |

The decision is the pure, unit-tested `unavailableRecovery` (`renderer/lib/projectOpen.ts`), which also refuses to judge a **remote** project from a local stat — those belong to the reconnect path.

## Surfaces

- **Desktop** — full.
- **Server Edition** — full: core registers the handler, and the ws-bridge implementation is **real**, not a stub (a stub would have to answer `unreadable`, which is exactly the side that never recovers).
- **Mobile companion** — N/A, no project-open surface there.

## Verification

- `npm run typecheck` clean.
- 1682 tests across `core/workspace`, `renderer/lib`, `renderer/state`, `renderer/bridge`, `preload` — all pass.
- **Mutation-checked**: making the catch report `'absent'` for every error reddens the ENOTDIR case; widening the clear to `!== 'present'` reddens the unreadable case.

**Not device-verified** — proven at the store and decision level, not by clicking through a running app. Worth walking the reporter's exact sequence (delete the file → restart → Open folder) on a Mac before closing #385 out.

## Not in this PR

The tab and the sidebar still disagree about whether an unavailable project is selectable, and an inert tab with only a tooltip is what left the reporter stuck. A recovery affordance on the tab itself ("project file is missing — recreate it?") would close that loop properly; flagging rather than widening the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)