### PR TITLE
Canvas: maximize toggle follow-ups — right-side button + Cmd+Shift+Enter shortcut

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -234,6 +234,7 @@ import {
   viewportForRect,
   type FocusableNode
 } from '../lib/nodeFocus'
+import { maximizeTargetRect } from '../lib/nodeMaximize'
 import {
   recordBreadcrumb,
   stepBreadcrumb,
@@ -453,6 +454,8 @@ import {
   accountsForProject,
   sshAccountsHint,
   ungroupNodes,
+  maximizeNodeToRect,
+  restoreMaximizedNode,
   type CanvasNode
 } from '../state/workspace'
 import { codexAccountSelectable, codexAccountSwitchStillEligible } from './codex-account-switch'
@@ -6128,6 +6131,37 @@ export function Canvas() {
     [viewCenter]
   )
 
+  /**
+   * The header maximize toggle's chord (issue #399). Same origin rule as `moveNodeFocus`: the
+   * node the keyboard is actually IN (hover-dwell focuses a terminal without selecting it), else
+   * the single selected node — a multi-selection is ambiguous, so it declines and the chord
+   * falls through. Declines (false) rather than half-acts everywhere the button would not show:
+   * group frames, collapsed nodes, an unmeasured container.
+   */
+  const toggleMaximizeCommand = useCallback((): boolean => {
+    const nodes = nodesRef.current
+    const focusedId = document.activeElement
+      ?.closest(`.${FLOW_NODE_CLASS}`)
+      ?.getAttribute('data-id')
+    const selected = nodes.filter((n) => n.selected)
+    const target =
+      (focusedId ? nodes.find((n) => n.id === focusedId) : undefined) ??
+      (selected.length === 1 ? selected[0] : undefined)
+    if (!target || target.type === 'group') return false
+    if (target.data.premaxRect) {
+      setNodes((ns) => restoreMaximizedNode(ns, target.id))
+      markDirty()
+      return true
+    }
+    if (target.data.collapsed) return false
+    const wrap = flowWrapRef.current?.getBoundingClientRect()
+    const rect = wrap ? maximizeTargetRect(getViewport(), wrap.width, wrap.height) : null
+    if (!rect) return false
+    setNodes((ns) => maximizeNodeToRect(ns, target.id, rect))
+    markDirty()
+    return true
+  }, [setNodes, markDirty, getViewport])
+
   // ONE window keydown for every registry command + the legacy gestures. The deps live in a
   // ref refreshed each render so the listener is registered once; handlers return whether
   // they claimed the chord (an unavailable surface falls through to the platform).
@@ -6207,7 +6241,8 @@ export function Canvas() {
       'node.focusLeft': () => moveNodeFocus('left'),
       'node.focusRight': () => moveNodeFocus('right'),
       'node.focusUp': () => moveNodeFocus('up'),
-      'node.focusDown': () => moveNodeFocus('down')
+      'node.focusDown': () => moveNodeFocus('down'),
+      'node.maximize': toggleMaximizeCommand
       // node.close / node.toggleMarkdown: main-process intercepted on desktop; deliberately
       // no renderer handler (the browser owns ⌘W in the Server Edition — see bridge/stubs.ts).
       // terminal.* / scm.commit / speech.dictation: owned by their local listeners.

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -336,3 +336,24 @@ export const IconCanvasView = () => (
     <rect x="3.5" y="9.5" width="5.5" height="5" rx="1" />
   </svg>
 )
+
+/** Fullscreen expand — outward diagonal arrows: the maximize toggle's "will fill the viewport"
+ *  state (issue #399). Pairs with IconRestoreSize; the two states must not share a glyph. */
+export const IconMaximize = () => (
+  <svg {...S}>
+    <path d="M14 4h6v6" />
+    <path d="M20 4l-6 6" />
+    <path d="M10 20H4v-6" />
+    <path d="M4 20l6-6" />
+  </svg>
+)
+
+/** Fullscreen restore — the same arrows pointing back inward: the maximize toggle's second click. */
+export const IconRestoreSize = () => (
+  <svg {...S}>
+    <path d="M20 10h-6V4" />
+    <path d="M20 4l-6 6" />
+    <path d="M4 14h6v6" />
+    <path d="M4 20l6-6" />
+  </svg>
+)

--- a/src/renderer/nodes/DiffNode.tsx
+++ b/src/renderer/nodes/DiffNode.tsx
@@ -140,12 +140,12 @@ export function DiffNode({ id, data, selected }: NodeProps<CanvasNode>) {
       <NodeResizer minWidth={NODE_MIN_SIZES.diff.width} minHeight={NODE_MIN_SIZES.diff.height} isVisible={selected} color={data.color} />
 
       <div className="term-node__header">
-        <MaximizeButton id={id} maximized={!!data.premaxRect} />
         <span className="term-node__title-text" title={`${rel} — ${commitOid ? commitOid.slice(0, 7) : staged ? 'staged' : 'working'}`}>
           {rel.split('/').pop()}
           <span className="diff-node__tag">{commitOid ? commitOid.slice(0, 7) : staged ? 'staged' : 'changes'}</span>
         </span>
         <span className="term-node__spacer" />
+        <MaximizeButton id={id} maximized={!!data.premaxRect} />
         <button
           className="term-node__close"
           title="Close"

--- a/src/renderer/nodes/EditorNode.tsx
+++ b/src/renderer/nodes/EditorNode.tsx
@@ -263,7 +263,6 @@ export function EditorNode({ id, data, selected }: NodeProps<CanvasNode>) {
       />
 
       <div className="term-node__header">
-        <MaximizeButton id={id} maximized={!!data.premaxRect} />
         <span className="term-node__title-text" title={filePath}>
           {fileName}
           {!isImage && !isPdf && dirty ? ' ●' : ''}
@@ -290,6 +289,7 @@ export function EditorNode({ id, data, selected }: NodeProps<CanvasNode>) {
             </button>
           </>
         )}
+        <MaximizeButton id={id} maximized={!!data.premaxRect} />
         <button
           className="term-node__close"
           title="Close"

--- a/src/renderer/nodes/MaximizeButton.tsx
+++ b/src/renderer/nodes/MaximizeButton.tsx
@@ -1,12 +1,13 @@
-// The macOS-style green maximize toggle in a node's header (issue #399). One click resizes the
-// NODE to fill the visible canvas — a real resize through the normal resize path, so a terminal
-// reflows and gains rows (the camera never moves; canvas zoom is a CSS transform and magnifying
-// an 80×24 shows no extra line). The second click restores the exact previous rect. Shared by the
-// terminal, editor and diff nodes; the transforms live in state/workspace.ts so grouped nodes
-// re-fit their ancestor frames in the same tick.
+// The maximize toggle in a node header's right-hand button group (issue #399). One click resizes
+// the NODE to fill the visible canvas — a real resize through the normal resize path, so a
+// terminal reflows and gains rows (the camera never moves; canvas zoom is a CSS transform and
+// magnifying an 80×24 shows no extra line). The second click restores the exact previous rect.
+// Shared by the terminal, editor and diff nodes; the transforms live in state/workspace.ts so
+// grouped nodes re-fit their ancestor frames in the same tick.
 
 import { useReactFlow, useStoreApi } from '@xyflow/react'
 import { Tooltip } from '../components/Tooltip'
+import { IconMaximize, IconRestoreSize } from '../components/icons'
 import { markWorkspaceDirty } from '../state/workspaceDirty'
 import { maximizeNodeToRect, restoreMaximizedNode, type CanvasNode } from '../state/workspace'
 import { maximizeTargetRect } from '../lib/nodeMaximize'
@@ -41,20 +42,7 @@ export function MaximizeButton({ id, maximized }: { id: string; maximized: boole
           toggle()
         }}
       >
-        {/* macOS traffic-light arrows: outward when it will maximize, inward when it will restore. */}
-        <svg viewBox="0 0 12 12" aria-hidden="true">
-          {maximized ? (
-            <>
-              <path d="M 5.2 1.6 L 5.2 6.8 L 0 6.8 Z" />
-              <path d="M 6.8 10.4 L 6.8 5.2 L 12 5.2 Z" />
-            </>
-          ) : (
-            <>
-              <path d="M 1.6 6.8 L 1.6 1.6 L 6.8 1.6 Z" />
-              <path d="M 10.4 5.2 L 10.4 10.4 L 5.2 10.4 Z" />
-            </>
-          )}
-        </svg>
+        {maximized ? <IconRestoreSize /> : <IconMaximize />}
       </button>
     </Tooltip>
   )

--- a/src/renderer/nodes/MaximizeButton.tsx
+++ b/src/renderer/nodes/MaximizeButton.tsx
@@ -8,6 +8,7 @@
 import { useReactFlow, useStoreApi } from '@xyflow/react'
 import { Tooltip } from '../components/Tooltip'
 import { IconMaximize, IconRestoreSize } from '../components/icons'
+import { commandTooltip } from '../lib/keybindingOverrides'
 import { markWorkspaceDirty } from '../state/workspaceDirty'
 import { maximizeNodeToRect, restoreMaximizedNode, type CanvasNode } from '../state/workspace'
 import { maximizeTargetRect } from '../lib/nodeMaximize'
@@ -31,7 +32,10 @@ export function MaximizeButton({ id, maximized }: { id: string; maximized: boole
 
   return (
     <Tooltip
-      label={maximized ? 'Restore previous size and position' : 'Maximize — fill the visible canvas'}
+      label={commandTooltip(
+        maximized ? 'Restore previous size and position' : 'Maximize — fill the visible canvas',
+        'node.maximize'
+      )}
     >
       <button
         className="term-node__maximize nodrag"

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -4438,9 +4438,6 @@ export function TerminalNode({
             ))}
           </div>
         )}
-        {!collapsed && !isHidden('maximize', hiddenHeaderButtons) && (
-          <MaximizeButton id={id} maximized={!!data.premaxRect} />
-        )}
         {editingTitle ? (
           <input
             className="term-node__title nodrag"
@@ -4744,6 +4741,9 @@ export function TerminalNode({
               </button>
             </Tooltip>
           )}
+        {!collapsed && !isHidden('maximize', hiddenHeaderButtons) && (
+          <MaximizeButton id={id} maximized={!!data.premaxRect} />
+        )}
         <button
           className="term-node__close"
           title="Close (ends the session)"

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1255,35 +1255,24 @@ body,
   flex-shrink: 0;
 }
 
-/* Maximize toggle (issue #399): the macOS green traffic light, next to the color dot. The arrow
-   glyphs appear on header hover — same behavior as the real thing. */
+/* Maximize toggle (issue #399): a regular right-group header icon button, next to the close ×.
+   Same recipe as .term-node__refresh — the toggle is ordinary chrome, not a traffic light. */
 .term-node__maximize {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  background: transparent;
   border: none;
-  padding: 0;
-  background: #28c840;
+  color: var(--muted);
   cursor: pointer;
+  line-height: 1;
+  padding: 2px 5px;
+  border-radius: 4px;
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-}
-
-.term-node__maximize svg {
-  width: 8px;
-  height: 8px;
-  fill: rgba(0, 0, 0, 0.55);
-  opacity: 0;
-}
-
-.term-node__header:hover .term-node__maximize svg {
-  opacity: 1;
 }
 
 .term-node__maximize:hover {
-  background: #2fd948;
+  background: rgba(10, 132, 255, 0.18);
+  color: var(--accent-text);
 }
 
 .term-node__title {

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -141,6 +141,8 @@ describe('registry invariants', () => {
         darwin: ['Cmd+ArrowUp'], other: ['Ctrl+Shift+ArrowUp'], allowInTerminal: true },
       { id: 'node.focusDown', title: 'Focus node below', group: 'Nodes', scope: 'canvas',
         darwin: ['Cmd+ArrowDown'], other: ['Ctrl+Shift+ArrowDown'], allowInTerminal: true },
+      { id: 'node.maximize', title: 'Maximize / restore node', group: 'Nodes', scope: 'canvas',
+        darwin: ['Cmd+Shift+Enter'], other: ['Cmd+Shift+Enter'], allowInTerminal: true },
       { id: 'node.close', title: 'Close node / window', group: 'Nodes', scope: 'app',
         darwin: ['Cmd+W'], other: ['Cmd+W'], allowInTerminal: true, allowWhileTyping: true },
       { id: 'node.toggleMarkdown', title: 'Toggle markdown view', group: 'Nodes', scope: 'app',

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -76,6 +76,7 @@ export type CommandId =
   | 'node.focusRight'
   | 'node.focusUp'
   | 'node.focusDown'
+  | 'node.maximize'
   | 'node.close'
   | 'node.toggleMarkdown'
   | 'terminal.find'
@@ -199,6 +200,13 @@ export const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
   { id: 'node.focusDown', title: 'Focus node below', group: 'Nodes', scope: 'canvas',
     defaultBindings: { darwin: ['Cmd+ArrowDown'], other: ['Ctrl+Shift+ArrowDown'] },
     allowInTerminal: true },
+  // The header maximize toggle's chord (issue #399): fill the viewport with the node under the
+  // keyboard (else the single selected node), or restore it. allowInTerminal for focus-mode's
+  // reason — the hand that wants more rows is already typing in the terminal being enlarged.
+  // ⌘⇧Enter is iTerm2's maximize-pane chord — the same gesture terminal users already know —
+  // and collides with nothing here (scm.commit's ⌘Enter is a different chord, scm scope).
+  { id: 'node.maximize', title: 'Maximize / restore node', group: 'Nodes', scope: 'canvas',
+    defaultBindings: both('Cmd+Shift+Enter'), allowInTerminal: true },
   // Main-process intercepted today (unconditional): keep firing everywhere.
   { id: 'node.close', title: 'Close node / window', group: 'Nodes', scope: 'app',
     defaultBindings: both('Cmd+W'), allowInTerminal: true, allowWhileTyping: true },


### PR DESCRIPTION
Follow-up to #400, which was merged while these two commits were landing on the branch — they were pushed minutes after the merge, so main currently has the first iteration only (the macOS-style green traffic-light button, no shortcut).

- **Move the maximize toggle into the right-hand header group** (`c6e100d7`): the green dot next to the color control read as a second color swatch. It is now an ordinary right-group icon button beside the close × (terminal, editor and diff nodes alike), with fullscreen expand/restore arrow glyphs (`IconMaximize` / `IconRestoreSize`) in the shared icon style.
- **`node.maximize` keybinding** (`6ba8af90`): default **⌘⇧Enter** (iTerm2's maximize-pane chord; collides with nothing in the registry). Acts on the node under the keyboard, else the single selected node; `allowInTerminal` like the directional-focus commands, routed out of xterm by the registry-driven `terminalChordBubbles` — no extra wiring. Declines (falls through) on group frames, collapsed nodes, multi-selections and an unmeasured container. The button tooltip shows the live chord via `commandTooltip`.

Registry whole-table pin and keydown-intercept tests updated; full suite green except the pre-existing `node-pty-patch.test.ts` environment marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)