### PR TITLE
fix(canvas): keep subagent cards across a parent unmount (project switch)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4336,9 +4336,11 @@ export function Canvas() {
           disposeTerminalOnUnmount(sessionForProject(useProjects.getState().activeProjectId ?? '').id, n.id)
         if (n.type === 'terminal') transport.destroy(n.id)
         // Permanent deletion → drop the node's persisted agent status (sessionId/session/
-        // unread/loop). Node unmount no longer does this, so deletion must. The loop card's
-        // UI overrides live in agentNodes and are skipped by unmount's clearForParent.
+        // unread/loop) AND its subagent fan-out. Node unmount does neither (issue #402: an
+        // unmount is a project switch, not an end — a mid-run card cleared there never came
+        // back), so deletion must do both.
         useAgentStatus.getState().remove(n.id)
+        useAgentNodes.getState().clearForParent(n.id)
         useAgentNodes.getState().clearLoop(n.id)
         // The open-project attach-consent mirror dies with its caller (review #363 M-1) —
         // symmetric with main's grant ledger, which clears on the same teardown (ptyDestroy).
@@ -9264,6 +9266,9 @@ export function Canvas() {
             disposeTerminalOnUnmount(sessionForProject(projectId).id, id) // node may be parked from the project switch
             transport.destroy(id)
             useAgentStatus.getState().remove(id)
+            // Unmount no longer clears the fan-out (issue #402), so this cross-project delete
+            // must — the node unmounted at the project switch with its cards kept in the store.
+            useAgentNodes.getState().clearForParent(id)
             // Same teardown symmetry as deleteNodes (review #363 M-1): the attach-consent
             // mirror dies with the node.
             clearAttachConsent(id)
@@ -9331,8 +9336,10 @@ export function Canvas() {
           remoteKill?.()
           // Nothing else to clean up: with no node anywhere, there is no canvas entry to remove and
           // no parked terminal to dispose. Persisted agent status is dropped anyway, since a
-          // session id can outlive the node it belonged to.
+          // session id can outlive the node it belonged to — and so is any subagent fan-out the
+          // store still holds for the id (kept across unmounts since issue #402).
           useAgentStatus.getState().remove(nodeId)
+          useAgentNodes.getState().clearForParent(nodeId)
           setConfirm(null)
         }
       })
@@ -10298,7 +10305,7 @@ export function Canvas() {
       const store = useProjects.getState()
       if (id === store.activeProjectId) commitActiveToStore()
       // End the tmux sessions of every terminal in the deleted project, and drop their
-      // persisted agent status (node unmount no longer removes it).
+      // persisted agent status and subagent fan-out (node unmount removes neither — issue #402).
       const project = store.getProject(id)
       project?.nodes.forEach((n) => {
         if ((n.kind ?? 'terminal') === 'terminal') {
@@ -10306,6 +10313,7 @@ export function Canvas() {
           transport.destroy(n.id)
         }
         useAgentStatus.getState().remove(n.id)
+        useAgentNodes.getState().clearForParent(n.id)
       })
       // SSH project: the per-node `transport.destroy` above only ends the REMOTE session for
       // the (mounted) ACTIVE project's nodes — a non-active project has no live local sessions,

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -3881,19 +3881,18 @@ export function TerminalNode({
     // honestly keyed on what its closure captures.
   }, [termKey])
 
-  /**
-   * Remove transient subagent render overrides when this React node leaves the active canvas.
-   * Live agent status deliberately survives the unmount: selecting a session in another project
-   * swaps the whole active canvas, but the session we left is still alive and must remain Running
-   * or Waiting in the cross-project sidebar. Real node deletion removes the status explicitly in
-   * `Canvas.deleteNodes`; a later hook/session event owns every other state transition.
-   */
-  useEffect(
-    () => () => {
-      useAgentNodes.getState().clearForParent(id)
-    },
-    [id]
-  )
+  // There is deliberately NO unmount-scoped store cleanup here (issue #402). Live agent status
+  // survives the unmount — selecting a session in another project swaps the whole active canvas,
+  // but the session we left is still alive and must remain Running or Waiting in the cross-project
+  // sidebar. The subagent fan-out survives for the same reason: an unmount says the COMPONENT went
+  // away, not that the work did, and a still-running subagent's card cleared here could never come
+  // back (`start` only fires from live hook events, and a subagent already past its PreToolUse
+  // emits no second one — the card was gone for the rest of its run). Canvas's ephemeral-node memo
+  // skips cards whose parent is not on the active canvas, so a kept entry renders nothing while
+  // away and simply reappears on switch-back. Clearing is owned by the signals that actually mean
+  // "this fan-out is over": a genuine new turn / `sessionPhase === 'end'` in Canvas's status
+  // listener, and every permanent-removal path (`deleteNodes`, cross-project `closeSession`,
+  // `deleteProject`), which must call `clearForParent` explicitly now that unmount does not.
 
   // glyphgrid origin sync. React Flow rewrites these two props per frame while the node is
   // dragged; `setOrigin` is change-gated inside the engine, and a drag is exactly the gesture the

--- a/src/renderer/nodes/status-lifecycle.test.ts
+++ b/src/renderer/nodes/status-lifecycle.test.ts
@@ -6,13 +6,18 @@ import { useAgentNodes } from '../state/agentNodes'
 
 // The behaviour under test: leaving a project unmounts its TerminalNodes, and that unmount must
 // NOT clear their live agent status — the sidebar spans projects, so a live `working`/`waiting`
-// state has to survive a project switch. Only an explicit delete (Canvas.deleteNodes /
-// closeSession → useAgentStatus.remove) or a real hook transition may change it.
+// state has to survive a project switch. Since issue #402 the same rule covers the subagent
+// fan-out: an unmount says the component went away, not that the work did, and a still-running
+// subagent's card cleared on unmount could never come back (`start` only fires from live hook
+// events, and a subagent already past its PreToolUse emits no second one). Clearing is owned by
+// the lifecycle events (new turn / session end in Canvas's status listener) and by the explicit
+// permanent-removal paths (deleteNodes / cross-project closeSession / deleteProject).
 //
 // TerminalNode itself is impractical to mount in jsdom (xterm, a live PTY, dozens of stores), so
-// the two store CONTRACTS the fix depends on are exercised directly — behavioural coverage of the
-// mechanism, not a re-grep of the source. The source guard below is kept as a cheap secondary
-// tripwire for the exact line that was removed.
+// the store CONTRACTS the fix depends on are exercised directly — behavioural coverage of the
+// mechanism, not a re-grep of the source. The source guards below are kept as cheap secondary
+// tripwires for the exact lines that were removed, and for the deletion paths that now owe the
+// clear the unmount no longer performs.
 
 describe('agent status survives an unmount that is not a deletion', () => {
   afterEach(() => {
@@ -33,25 +38,48 @@ describe('agent status survives an unmount that is not a deletion', () => {
     expect(useAgentStatus.getState().byId['node-x']).toBeUndefined()
   })
 
-  it("clearForParent drops a node's subagent cards without touching sibling parents", () => {
+  it('a running subagent card outlives its parent — only clearForParent drops it, per parent', () => {
     useAgentNodes.getState().start('tool-a1', { parentNodeId: 'parent-a', label: 'sub' })
     useAgentNodes.getState().start('tool-b1', { parentNodeId: 'parent-b', label: 'sub' })
     expect(useAgentNodes.getState().byId['tool-a1']?.parentNodeId).toBe('parent-a')
 
-    // The unmount clears only the leaving node's fan-out (this is the one thing the unmount DOES do).
+    // A project switch (unmount) calls nothing on this store, so the card is still here — this is
+    // what lets it reappear on switch-back while the subagent is mid-run (issue #402).
+    expect(useAgentNodes.getState().byId['tool-a1']?.state).toBe('working')
+
+    // The sanctioned clear (new turn / session end / permanent deletion) drops only that parent's
+    // fan-out; a sibling parent's cards are untouched.
     useAgentNodes.getState().clearForParent('parent-a')
     expect(useAgentNodes.getState().byId['tool-a1']).toBeUndefined()
-    // A sibling parent's cards are untouched.
     expect(useAgentNodes.getState().byId['tool-b1']?.parentNodeId).toBe('parent-b')
+  })
+
+  it('finish() lands on a card kept across an unmount, so the background end is not lost', () => {
+    // The synthetic subagent-end (the <task-notification> sniffed by the context tails) arrives
+    // through Canvas's always-mounted listener even while the parent's project is inactive. With
+    // the entry kept, that finish must mark the card done rather than no-op on a missing id.
+    useAgentNodes.getState().start('tool-a1', { parentNodeId: 'parent-a', label: 'sub' })
+    useAgentNodes.getState().finish('tool-a1', { tokens: 105_200 })
+    expect(useAgentNodes.getState().byId['tool-a1']?.state).toBe('done')
+    expect(useAgentNodes.getState().byId['tool-a1']?.tokens).toBe(105_200)
   })
 })
 
 describe('TerminalNode unmount source guard (secondary tripwire)', () => {
-  it('has no unmount-scoped status clear, and still clears its subagent fan-out', () => {
-    // Proves the removed line stays removed; it cannot prove behaviour (a different spelling would
+  it('has no unmount-scoped status or fan-out clear', () => {
+    // Proves the removed lines stay removed; it cannot prove behaviour (a different spelling would
     // pass), which is why the store-contract tests above exist.
     const source = readFileSync(join(__dirname, 'TerminalNode.tsx'), 'utf8')
     expect(source).not.toContain('useAgentStatus.getState().setState(id, undefined)')
-    expect(source).toContain('useAgentNodes.getState().clearForParent(id)')
+    expect(source).not.toContain('useAgentNodes.getState().clearForParent(id)')
+  })
+
+  it('the permanent-removal paths in Canvas clear the fan-out the unmount no longer does', () => {
+    // deleteNodes, the cross-project closeSession branch, the orphan-session kill and
+    // deleteProject each owe an explicit clearForParent now — four call sites beyond the two
+    // lifecycle ones (newTurn / sessionPhase end) in the status listener.
+    const source = readFileSync(join(__dirname, '..', 'canvas', 'Canvas.tsx'), 'utf8')
+    const calls = source.match(/useAgentNodes\.getState\(\)\.clearForParent\(/g) ?? []
+    expect(calls.length).toBeGreaterThanOrEqual(4)
   })
 })


### PR DESCRIPTION
Fixes #402.

## Problem

A `TerminalNode` unmount cleared its entire subagent fan-out (`useAgentNodes.clearForParent`), so switching projects while a subagent was still running dropped its card **permanently**: `start()` only fires from live hook events, a subagent already past its `PreToolUse` emits no second one, and nothing rehydrates `byId`. The agent kept working — 4 minutes in, 105k tokens in the reporter's case — with nothing on the canvas to show it. Long-running subagents, exactly the ones a card is for, were the ones lost. The issue's root-cause analysis was correct on every point.

## Fix

Drop the unmount-scoped `clearForParent` and let the signals that actually mean "this fan-out is over" own the clearing:

- The two **lifecycle events** already in Canvas's status listener (genuine `newTurn`, `sessionPhase === 'end'`) — unchanged.
- The four **permanent-removal paths**, which now call `clearForParent` explicitly since unmount no longer does: `deleteNodes` (node ×, context-menu Delete, canvas-control `close`), the cross-project `closeSession` branch, the orphan-session kill, and `deleteProject`.

## Why keeping the entries across an unmount is safe

- Canvas's ephemeral-node memo already skips cards whose parent is not on the active canvas (`if (!parent) continue`), so a kept entry renders nothing while away and reappears — rope included — on switch-back.
- The synthetic subagent-end (the `<task-notification>` sniffed by the context tails) arrives through Canvas's always-mounted listener; with the entry kept, `finish()` now marks the card **done** while its project is inactive instead of no-oping on a missing id. Previously that end event was silently lost.
- Bonus: the Eco hibernation guard ("any card that has not finished pins its parent") reads this same store — a project switch used to wipe its evidence, so a session with a live backgrounded subagent could be hibernated. That guard now survives switches.
- `byId` stays in-memory-only (never persisted), so nothing outlives an app restart — same as before.

## Tests

`status-lifecycle.test.ts` updated: the store contracts now pin that a running card survives (only `clearForParent` drops it, per parent) and that `finish()` lands on a kept entry; the source tripwire flips to assert **no** unmount-scoped fan-out clear in `TerminalNode` and that Canvas carries the four explicit removal-path calls. Full renderer suite: 253 files / 3334 tests green; `tsc -p tsconfig.web.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)