### PR TITLE
feat(window): reflect the active session in the native window title (opt-in)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -193,6 +193,12 @@ import {
 import { isTerminalTarget, type ContextElement } from '../lib/keyContext'
 import { installTerminalFocusMirror } from '../lib/terminalFocusMirror'
 import {
+  applyWindowTitle,
+  composeWindowTitle,
+  installActiveNodeTracker,
+  windowBaseTitle
+} from '../lib/windowTitle'
+import {
   activeKeybindingOverrides,
   chipFor,
   commandTooltip,
@@ -6332,6 +6338,42 @@ export function Canvas() {
       }),
     []
   )
+
+  // Active session → native window title (issue #414, opt-in `settings.windowTitleActiveSession`):
+  // lets window-title-based time trackers (ActivityWatch) tell sessions apart. Two latest-wins
+  // signals feed the active node — keyboard focus landing inside a node's DOM (the tracker), and
+  // a single-node SELECTION (clicking a node header moves no focus, so focus alone would miss the
+  // most common "I'm on this node now" gesture). The write is `document.title` on both surfaces:
+  // Electron mirrors page-title changes onto the BrowserWindow, the Server Edition titles the
+  // browser tab. A node id that stops resolving (delete, project switch) degrades to the project
+  // name; disabled composes back to the boot title, captured before the first write.
+  const windowTitleEnabled = settings.windowTitleActiveSession
+  const [titleNodeId, setTitleNodeId] = useState<string | null>(null)
+  useEffect(() => {
+    if (!windowTitleEnabled) return
+    return installActiveNodeTracker({ report: setTitleNodeId })
+  }, [windowTitleEnabled])
+  useEffect(() => {
+    if (!windowTitleEnabled) return
+    const sel = nodes.filter((n) => n.selected)
+    if (sel.length === 1) setTitleNodeId(sel[0].id)
+  }, [windowTitleEnabled, nodes])
+  useEffect(() => {
+    const nodeTitle = windowTitleEnabled
+      ? nodes.find((n) => n.id === titleNodeId)?.data.title
+      : undefined
+    applyWindowTitle(
+      composeWindowTitle({
+        enabled: windowTitleEnabled,
+        baseTitle: windowBaseTitle(),
+        nodeTitle,
+        projectName: activeProjectName
+      })
+    )
+  }, [windowTitleEnabled, titleNodeId, nodes, activeProjectName])
+  // Unmount-only restore (Canvas gives way to the welcome screen when the last open project
+  // closes): without it the departing canvas's title would outlive the canvas.
+  useEffect(() => () => applyWindowTitle(windowBaseTitle()), [])
 
   // ⌘/Ctrl+0 on the DESKTOP never reaches the keydown handler above: Electron's default View menu
   // binds the accelerator to `resetZoom`, and a menu accelerator is handled before the page sees

--- a/src/renderer/components/settings/sections/AppearanceSection.tsx
+++ b/src/renderer/components/settings/sections/AppearanceSection.tsx
@@ -21,6 +21,20 @@ const ROWS = {
     keywords: ['appearance', 'theme', 'light', 'dark', 'mode', 'colour', 'color', 'chrome']
   },
   accent: { title: 'Accent', keywords: ['accent', 'color', 'theme', 'appearance'] },
+  windowTitle: {
+    title: 'Window title',
+    keywords: [
+      'window',
+      'title',
+      'session',
+      'tab',
+      'tracker',
+      'time',
+      'activitywatch',
+      'focused',
+      'native'
+    ]
+  },
   resumeCard: {
     title: 'Resume card',
     keywords: ['resume', 'where you left off', 'breadcrumb', 'card', 'popup', 'trail']
@@ -87,6 +101,7 @@ export function AppearanceSection({ isActive }: { isActive: boolean }): React.JS
   const hiddenNodeMenuItems = useSettings((s) => s.settings.hiddenNodeMenuItems)
   const hiddenHeaderButtons = useSettings((s) => s.settings.hiddenHeaderButtons)
   const showResumeCard = useSettings((s) => s.settings.showResumeCard)
+  const windowTitleActiveSession = useSettings((s) => s.settings.windowTitleActiveSession)
   const update = useSettings((s) => s.update)
   return (
     <SettingsSection
@@ -132,6 +147,24 @@ export function AppearanceSection({ isActive }: { isActive: boolean }): React.JS
             ))}
           </div>
         </div>
+      </SearchableRow>
+      <SearchableRow {...ROWS.windowTitle}>
+        <FieldRow
+          label="Show active session in window title"
+          description={
+            'Sets the native window title (and the browser tab, on the Server Edition) to the ' +
+            'focused node and project — "api server — myrepo — node-terminal" — so ' +
+            'window-title-based time trackers like ActivityWatch can tell sessions apart. ' +
+            'Off keeps the static title.'
+          }
+          control={
+            <Switch
+              checked={windowTitleActiveSession}
+              onChange={(v) => update({ windowTitleActiveSession: v })}
+              ariaLabel="Show the active session in the window title"
+            />
+          }
+        />
       </SearchableRow>
       <SearchableRow {...ROWS.resumeCard}>
         <FieldRow

--- a/src/renderer/lib/settingsReset.ts
+++ b/src/renderer/lib/settingsReset.ts
@@ -36,7 +36,8 @@ export const APPEARANCE_RESET_KEYS = [
   'accent',
   'hiddenNodeMenuItems',
   'hiddenHeaderButtons',
-  'showResumeCard'
+  'showResumeCard',
+  'windowTitleActiveSession'
 ] as const satisfies readonly (keyof Settings)[]
 
 /** The defaults for `keys`, as a patch for `useSettings.update`. */

--- a/src/renderer/lib/windowTitle.test.ts
+++ b/src/renderer/lib/windowTitle.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyWindowTitle,
+  composeWindowTitle,
+  installActiveNodeTracker,
+  nodeIdForFocusTarget,
+  resetWindowBaseTitleForTest,
+  windowBaseTitle
+} from './windowTitle'
+
+const BASE = 'node-terminal'
+
+describe('composeWindowTitle', () => {
+  it('disabled → the base title, whatever parts are around', () => {
+    expect(
+      composeWindowTitle({ enabled: false, baseTitle: BASE, nodeTitle: 'api', projectName: 'repo' })
+    ).toBe(BASE)
+  })
+
+  it('node + project + base, em-dash separated', () => {
+    expect(
+      composeWindowTitle({ enabled: true, baseTitle: BASE, nodeTitle: 'api', projectName: 'repo' })
+    ).toBe('api — repo — node-terminal')
+  })
+
+  it('no node → project + base; nothing at all → base alone', () => {
+    expect(composeWindowTitle({ enabled: true, baseTitle: BASE, projectName: 'repo' })).toBe(
+      'repo — node-terminal'
+    )
+    expect(composeWindowTitle({ enabled: true, baseTitle: BASE })).toBe(BASE)
+  })
+
+  it('whitespace-only parts drop out instead of leaving a dangling separator', () => {
+    expect(
+      composeWindowTitle({ enabled: true, baseTitle: BASE, nodeTitle: '  ', projectName: 'repo' })
+    ).toBe('repo — node-terminal')
+  })
+
+  it('a node titled exactly like its project shows once, not twice', () => {
+    expect(
+      composeWindowTitle({ enabled: true, baseTitle: BASE, nodeTitle: 'repo', projectName: 'repo' })
+    ).toBe('repo — node-terminal')
+  })
+})
+
+describe('nodeIdForFocusTarget', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function nodeWithTextarea(id: string): HTMLTextAreaElement {
+    const wrapper = document.createElement('div')
+    wrapper.className = 'react-flow__node'
+    wrapper.setAttribute('data-id', id)
+    const ta = document.createElement('textarea')
+    wrapper.appendChild(ta)
+    document.body.appendChild(wrapper)
+    return ta
+  }
+
+  it('resolves the React Flow wrapper id for focus inside a node', () => {
+    const ta = nodeWithTextarea('n1')
+    expect(nodeIdForFocusTarget(ta)).toBe('n1')
+  })
+
+  it('answers null for focus outside every node, and for non-elements', () => {
+    const stray = document.createElement('input')
+    document.body.appendChild(stray)
+    expect(nodeIdForFocusTarget(stray)).toBeNull()
+    expect(nodeIdForFocusTarget(null)).toBeNull()
+    expect(nodeIdForFocusTarget(window)).toBeNull()
+  })
+
+  it('tracker reports on focusin inside a node and stays quiet outside; teardown stops it', () => {
+    const ta = nodeWithTextarea('n2')
+    const stray = document.createElement('input')
+    document.body.appendChild(stray)
+    const report = vi.fn()
+    const stop = installActiveNodeTracker({ report })
+    ta.focus()
+    expect(report).toHaveBeenCalledWith('n2')
+    report.mockClear()
+    stray.focus()
+    expect(report).not.toHaveBeenCalled()
+    stop()
+    ta.focus()
+    expect(report).not.toHaveBeenCalled()
+  })
+})
+
+describe('base title capture + apply', () => {
+  beforeEach(() => {
+    resetWindowBaseTitleForTest()
+    document.title = BASE
+  })
+
+  it('captures the boot title once, before any write, and restores through it', () => {
+    expect(windowBaseTitle()).toBe(BASE)
+    applyWindowTitle('api — repo — node-terminal')
+    expect(document.title).toBe('api — repo — node-terminal')
+    // The capture is not re-read after writes — restoring composes back to the boot title.
+    applyWindowTitle(composeWindowTitle({ enabled: false, baseTitle: windowBaseTitle() }))
+    expect(document.title).toBe(BASE)
+  })
+})

--- a/src/renderer/lib/windowTitle.ts
+++ b/src/renderer/lib/windowTitle.ts
@@ -1,0 +1,98 @@
+/**
+ * Reflect the active session in the native window title (issue #414).
+ *
+ * Window-title-based time trackers (ActivityWatch is the reporter's) read whatever title the OS
+ * shows for the focused window — that is how they tell "which iTerm2 tab / VS Code file" apart.
+ * nodeterm keeps everything inside ONE OS window, so those tools only ever saw the static app
+ * title. With `settings.windowTitleActiveSession` on, the title becomes
+ * `<node title> — <project name> — <base title>` for whichever node was last active.
+ *
+ * The write is `document.title`, deliberately, on both surfaces: Electron mirrors page-title
+ * changes onto the BrowserWindow (nothing in `src/main` intercepts `page-title-updated`), and in
+ * the Server Edition the same write titles the browser tab. No IPC, no bridge member to stub.
+ *
+ * "Active node" is fed by two signals, latest-wins, both wired in Canvas:
+ *  - focus: `installActiveNodeTracker` reports the canvas node whose DOM subtree gained keyboard
+ *    focus (an xterm textarea, a sticky's editor, Monaco). Focus landing OUTSIDE any node (tab
+ *    bar, Settings, palette) deliberately reports nothing — for a time tracker, "the session I
+ *    was last in" is the honest answer while the user pokes at chrome around it.
+ *  - selection: Canvas reports a single-node selection (clicking a node header moves no focus).
+ *
+ * A node id that stops resolving (deleted node, project switch) degrades to the project name, and
+ * the OFF state — or nothing to show — restores the exact title the page booted with, captured
+ * before the first write ever happens, so the feature disabled is byte-identical to before it
+ * existed (including the NT_MULTI "(test instance)" label in dev sandboxes).
+ */
+
+/** Title separator — the em-dash convention window titles already use (VS Code, iTerm2). */
+const SEP = ' — '
+
+export interface WindowTitleParts {
+  enabled: boolean
+  /** What the title falls back to (and suffixes) — the page's boot title. */
+  baseTitle: string
+  nodeTitle?: string | null
+  projectName?: string | null
+}
+
+/** Compose the full window title. Pure — the applier owns the DOM. Empty/whitespace parts drop
+ *  out, and a node titled exactly like its project is shown once, not twice. */
+export function composeWindowTitle({
+  enabled,
+  baseTitle,
+  nodeTitle,
+  projectName
+}: WindowTitleParts): string {
+  if (!enabled) return baseTitle
+  const parts: string[] = []
+  for (const raw of [nodeTitle, projectName]) {
+    const p = raw?.trim()
+    if (p && !parts.includes(p)) parts.push(p)
+  }
+  if (parts.length === 0) return baseTitle
+  return [...parts, baseTitle].join(SEP)
+}
+
+/** The canvas node id owning `el`, via React Flow's node wrapper (`.react-flow__node[data-id]`),
+ *  or null when focus landed outside every node. */
+export function nodeIdForFocusTarget(el: unknown): string | null {
+  if (!(el instanceof Element)) return null
+  const wrapper = el.closest('.react-flow__node[data-id]')
+  return wrapper?.getAttribute('data-id') ?? null
+}
+
+export interface ActiveNodeTrackerOptions {
+  /** Called with the node id whenever keyboard focus lands inside a canvas node. Never called
+   *  for focus outside the canvas — the last active node deliberately stands. */
+  report: (nodeId: string) => void
+}
+
+/** Start reporting focus-derived active nodes. Returns the teardown. */
+export function installActiveNodeTracker(opts: ActiveNodeTrackerOptions): () => void {
+  const onFocusIn = (e: FocusEvent): void => {
+    const id = nodeIdForFocusTarget(e.target)
+    if (id) opts.report(id)
+  }
+  window.addEventListener('focusin', onFocusIn)
+  return () => window.removeEventListener('focusin', onFocusIn)
+}
+
+/** The page's boot title, captured once BEFORE the first write — the restore target for the OFF
+ *  state. Lazy (not at import) so a test's jsdom title churn cannot poison it. */
+let baseTitle: string | null = null
+
+export function windowBaseTitle(): string {
+  if (baseTitle === null) baseTitle = document.title
+  return baseTitle
+}
+
+/** Test-only: forget the captured base title so each test's jsdom starts clean. */
+export function resetWindowBaseTitleForTest(): void {
+  baseTitle = null
+}
+
+/** Write the title if it changed. Change-deduped: Electron forwards every page-title update over
+ *  IPC to the BrowserWindow, so re-assigning the same string per render is pure noise. */
+export function applyWindowTitle(next: string): void {
+  if (document.title !== next) document.title = next
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1116,6 +1116,14 @@ export interface Settings {
    *  takes it from the terminal colour theme, so picking a light terminal theme doesn't leave a
    *  black window framing it; `dark`/`light` pin it. See renderer/lib/appTheme.ts. */
   appTheme: 'auto' | 'dark' | 'light'
+  /** Reflect the active session in the NATIVE window title ("<node> — <project> — node-terminal"),
+   *  so window-title-based time trackers (ActivityWatch et al.) can tell sessions apart — the same
+   *  thing iTerm2 / Windows Terminal do per tab (issue #414). Opt-in and OFF by default: the title
+   *  is OS-visible surface area (window switchers, screen sharing), so an update must not start
+   *  broadcasting session names for users who never asked. Renderer-only (`document.title` —
+   *  Electron mirrors page-title changes onto the BrowserWindow, and the Server Edition gets the
+   *  browser tab title through the identical write), so there is no bridge member to stub. */
+  windowTitleActiveSession: boolean
   /** Terminal colour scheme — an id from `renderer/terminal/themes.ts`. Resolution is tolerant
    *  (settings.json is hand-editable): an unknown id falls back to the default theme, whose
    *  colours reproduce the pre-feature hardcoded `#1e1e1e`/`#e6e6e6` exactly. */
@@ -1426,6 +1434,7 @@ export const DEFAULT_SETTINGS: Settings = {
   // Follows the terminal theme, whose own default is dark — so an install that never touches
   // either setting keeps the dark chrome it has always had.
   appTheme: 'auto',
+  windowTitleActiveSession: false,
   terminalTheme: 'nodeterm-dark',
   fontWeight: 400,
   fontWeightBold: 700,


### PR DESCRIPTION
Closes #414.

ActivityWatch-style time trackers read whatever title the OS reports for the focused window; nodeterm's single static title (`node-terminal`) made every session look the same to them. This adds the opt-in setting the issue asks for.

## What it does

- **New setting** `windowTitleActiveSession` (Settings → Appearance → "Show active session in window title", **off by default** — the title is OS-visible surface area, so an update must not start broadcasting session names for users who never asked).
- When on, the native window title becomes **`<node title> — <project name> — node-terminal`** for the last active node (falling back to `<project> — node-terminal` when no node is known, and to the plain boot title when there is nothing to show). Empty parts drop out and a node titled exactly like its project shows once.
- "Active node" is fed by two latest-wins signals: **keyboard focus** landing inside a node's DOM subtree (xterm textarea, sticky editor, Monaco — resolved through React Flow's `.react-flow__node[data-id]` wrapper), and a **single-node selection** (clicking a node header moves no focus, so focus alone would miss the most common gesture). Focus landing outside every node (tab bar, Settings, palette) deliberately keeps the last session — for a time tracker that is the honest answer while the user pokes at chrome.
- A node id that stops resolving (delete, project switch) degrades to the project name. Turning the setting off — and Canvas unmounting to the welcome screen — restores the exact boot title, captured before the first write (which also preserves the `NT_MULTI` "(test instance)" label in dev sandboxes).

## Three surfaces

- **Desktop**: the write is `document.title`; nothing in `src/main` intercepts `page-title-updated`, so Electron mirrors it onto the BrowserWindow — verified there is no competing `win.setTitle` after boot.
- **Server Edition**: the identical write titles the **browser tab**, which is what browser-side trackers read. No bridge member, no IPC, nothing to stub.
- **Mobile**: N/A — no OS window of ours to title.

## Implementation notes

- All logic lives in the framework-free `renderer/lib/windowTitle.ts` (pure `composeWindowTitle`, the `focusin` tracker, change-deduped `applyWindowTitle` — every page-title update is an IPC hop to main, so re-assigning the same string per render would be pure noise). Canvas only wires the two signals and the compose effect, next to the existing terminal-focus mirror.
- Setting rides the normal shallow merge over `DEFAULT_SETTINGS`; added to `APPEARANCE_RESET_KEYS` so the section reset covers it.
- Tests: `windowTitle.test.ts` (jsdom) — compose matrix, wrapper-id resolution, tracker report/teardown, boot-title capture + restore.

Happy to hear from @kalus-msic whether the composed format works for the Redmine pipeline (the node title comes first so truncated titles stay distinguishable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)