### PR TITLE
OSC 8 hyperlinks: Cmd+click opens links whose URL hides behind a label

### DIFF
--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -275,6 +275,8 @@ set -as terminal-features ",*:clipboard"
 # known to speak RGB. xterm.js does, so declare it — via terminal-features like the clipboard
 # entry above, never terminal-overrides (see the MIGRATION note). Issue #78.
 set -as terminal-features ",*:RGB"
+# OSC 8 hyperlink passthrough — tmux strips the escape unless the outer terminal declares it.
+set -as terminal-features ",*:hyperlinks"
 # Mouse copy: on release tmux copies to its buffer AND (thanks to the two lines above) emits OSC 52,
 # which the client writes to the system clipboard. No pipe-to-a-local-command here, deliberately.
 bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel

--- a/src/core/tmux-conf.test.ts
+++ b/src/core/tmux-conf.test.ts
@@ -35,6 +35,12 @@ describe('tmuxConf', () => {
     expect(c).not.toMatch(/set -a[gs]? terminal-overrides/)
   })
 
+  it('declares hyperlinks via terminal-features so OSC 8 links reach the renderer', () => {
+    // tmux strips the OSC 8 escape unless the outer terminal declares support, leaving only the
+    // label text — a link whose URL is not also printed can then never be opened.
+    expect(c).toContain('set -as terminal-features ",*:hyperlinks"')
+  })
+
   it('copies mouse selections through tmux (OSC 52), with no macOS-only pbcopy pipe', () => {
     expect(c).toContain('bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel')
     expect(c).toContain('bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel')

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -17,6 +17,7 @@ import { useTerminalSearch } from '../../terminal/useTerminalSearch'
 import { LocalTransport } from '../../terminal/local-transport'
 import { clipboardImages, droppedPaths, pasteHasText, pastedFiles } from '../../terminal/file-drop'
 import { guardMiddleClickPaste } from '../../terminal/middle-click'
+import { createOsc8LinkHandler } from '../../terminal/file-links'
 import { parseOsc52 } from '../../terminal/osc52'
 import { activateUnicode11 } from '../../terminal/unicode-width'
 import { useCopyFeedback } from '../../terminal/useCopyFeedback'
@@ -161,6 +162,11 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
     // view of one session, and a card that renders it in different colours reads as a different
     // terminal. (It used to hardcode its own background, which is exactly what happened.)
     const term = new Terminal(xtermOptionsFromSettings(s))
+    // Without a handler xterm answers an OSC 8 click with a window.confirm — the one surface
+    // where this session's links would prompt instead of opening like the canvas node's.
+    term.options.linkHandler = createOsc8LinkHandler((uri) =>
+      window.nodeTerminal.shell.openExternal(uri)
+    )
     // The modal is a second view of the SAME tmux session, so it has to measure characters the way
     // the canvas node does. Two views on two width tables would disagree about where the columns
     // are — and the pty runs at the SMALLEST subscriber's grid, so the disagreement would be live.

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -27,6 +27,7 @@ import { parseOsc52 } from '../terminal/osc52'
 import { activateUnicode11 } from '../terminal/unicode-width'
 import {
   createFileLinkProvider,
+  createOsc8LinkHandler,
   createUrlLinkProvider,
   installLinkClickFallback,
   makeDirListingLookup
@@ -2460,6 +2461,11 @@ export function TerminalNode({
       // inside their activate handlers, so plain clicks stay selections.
       term.registerLinkProvider(
         createUrlLinkProvider(term, (uri) => window.nodeTerminal.shell.openExternal(uri))
+      )
+      // Not in xtermOptionsFromSettings: the handler closes over the shell bridge, which the
+      // pure options builder must not know.
+      term.options.linkHandler = createOsc8LinkHandler((uri) =>
+        window.nodeTerminal.shell.openExternal(uri)
       )
       const projectFs = (): { fs: FsApi; ssh: boolean } => {
         const st = useProjects.getState()

--- a/src/renderer/terminal/file-links.test.ts
+++ b/src/renderer/terminal/file-links.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
 import {
+  createOsc8LinkHandler,
   makeDirListingLookup,
   matchFileTokens,
   matchUrlTokens,
+  osc8UrlAt,
   paragraphContaining,
   resolveFileToken,
   type BufferView
@@ -169,5 +172,44 @@ describe('matchUrlTokens', () => {
 
   it('ignores non-http schemes and bare paths', () => {
     expect(matchUrlTokens('ftp://x.io file:///etc/hosts /usr/local plain')).toEqual([])
+  })
+})
+
+describe('createOsc8LinkHandler', () => {
+  const range = { start: { x: 1, y: 1 }, end: { x: 1, y: 1 } }
+  const click = (mod: boolean): MouseEvent => ({ metaKey: mod, ctrlKey: false }) as MouseEvent
+
+  it('opens http(s) only, and only on a modifier click', () => {
+    const opened: string[] = []
+    const h = createOsc8LinkHandler((u) => opened.push(u))
+    h.activate(click(false), 'https://example.com/a', range)
+    h.activate(click(true), 'javascript:alert(1)', range)
+    h.activate(click(true), 'file:///etc/passwd', range)
+    h.activate(click(true), 'not a url', range)
+    h.activate(click(true), 'https://example.com/a', range)
+    expect(opened).toEqual(['https://example.com/a'])
+  })
+})
+
+describe('osc8UrlAt', () => {
+  /** Just the private shape osc8UrlAt reads: a cell's extended.urlId + the osc link service. */
+  const fakeTerm = (urlId: number | undefined, uri: string | undefined): Terminal =>
+    ({
+      buffer: { active: { getLine: () => ({ getCell: () => ({ extended: { urlId } }) }) } },
+      _core: { _oscLinkService: { getLinkData: () => (uri ? { uri } : undefined) } }
+    }) as unknown as Terminal
+
+  it('resolves the URI at a linked cell and refuses a non-http scheme', () => {
+    expect(osc8UrlAt(fakeTerm(3, 'https://example.com/pr/1'), 0, 0)).toBe(
+      'https://example.com/pr/1'
+    )
+    expect(osc8UrlAt(fakeTerm(3, 'javascript:alert(1)'), 0, 0)).toBeNull()
+  })
+
+  it('returns null for an unlinked cell and when internals are absent', () => {
+    expect(osc8UrlAt(fakeTerm(undefined, 'https://x.io/a'), 0, 0)).toBeNull()
+    expect(osc8UrlAt(fakeTerm(3, undefined), 0, 0)).toBeNull()
+    const bare = { buffer: { active: { getLine: () => undefined } } } as unknown as Terminal
+    expect(osc8UrlAt(bare, 0, 0)).toBeNull()
   })
 })

--- a/src/renderer/terminal/file-links.ts
+++ b/src/renderer/terminal/file-links.ts
@@ -20,7 +20,7 @@
 //     genuinely cannot distinguish a repainted wrap from prose that exactly fills the row),
 //     gated tightly and capped at MAX_JOIN_ROWS, and the regex still has to match across the
 //     seam for a link to result.
-import type { ILink, ILinkProvider, Terminal } from '@xterm/xterm'
+import type { ILink, ILinkHandler, ILinkProvider, Terminal } from '@xterm/xterm'
 
 export interface FileToken {
   /** The raw matched span (drives the underline range), incl. any :line:col suffix. */
@@ -156,15 +156,52 @@ export function matchUrlTokens(lineText: string): UrlToken[] {
   for (const m of lineText.matchAll(URL_RE)) {
     const text = m[0].replace(TRAILING_PUNCT, '')
     if (text.length < 8) continue // "http://x" is the shortest sane URL
-    try {
-      const u = new URL(text)
-      if (u.protocol !== 'http:' && u.protocol !== 'https:') continue
-    } catch {
-      continue
-    }
+    if (!isHttpUrl(text)) continue
     out.push({ text, startIndex: m.index, url: text })
   }
   return out
+}
+
+function isHttpUrl(text: string): boolean {
+  try {
+    const u = new URL(text)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * OSC 8 hyperlinks — a visible label with the URL riding in an escape sequence (what Claude
+ * Code, gh and systemd emit), so the text-matching providers above never see the URL. xterm
+ * parses the sequence natively but activates nothing unless `options.linkHandler` is set (its
+ * built-in fallback is a window.confirm). The URI is invisible text the label hides, so a
+ * `javascript:`/`file:` link must never reach openExternal.
+ */
+export function createOsc8LinkHandler(openUrl: (url: string) => void): ILinkHandler {
+  return {
+    activate: (event: MouseEvent, text: string): void => {
+      if (!(event.metaKey || event.ctrlKey)) return
+      if (isHttpUrl(text)) openUrl(text)
+    }
+  }
+}
+
+/**
+ * The OSC 8 URI at a buffer cell, or null. Private API (`CellData.extended.urlId` +
+ * `_core._oscLinkService`), because the public buffer API exposes no hyperlink data and the
+ * tmux click fallback below has nothing else to hit-test one with.
+ */
+export function osc8UrlAt(term: Terminal, row: number, col: number): string | null {
+  const cell = term.buffer.active.getLine(row)?.getCell(col)
+  const urlId = (cell as unknown as { extended?: { urlId?: number } } | undefined)?.extended?.urlId
+  if (!urlId) return null
+  const uri = (
+    term as unknown as {
+      _core?: { _oscLinkService?: { getLinkData(id: number): { uri: string } | undefined } }
+    }
+  )._core?._oscLinkService?.getLinkData(urlId)?.uri
+  return uri && isHttpUrl(uri) ? uri : null
 }
 
 /** Absolute path for a token: absolutes pass through, relatives resolve against cwd,
@@ -487,6 +524,14 @@ export function installLinkClickFallback(
     if (term.modes.mouseTrackingMode === 'none') return
     const pos = bufferPosFromEvent(term, ev)
     if (!pos) return
+    const osc8 = osc8UrlAt(term, pos.row, pos.col)
+    if (osc8) {
+      ev.preventDefault()
+      ev.stopPropagation()
+      term.clearSelection()
+      deps.openUrl(osc8)
+      return
+    }
     const logical = paragraphContaining(bufferView(term), pos.row)
     if (!logical) return
     const idx = (pos.row - logical.startRow) * term.cols + pos.col

--- a/src/shared/ssh.test.ts
+++ b/src/shared/ssh.test.ts
@@ -259,6 +259,12 @@ describe('remoteTmuxConf', () => {
     expect(c).toContain('set -as terminal-features ",*:RGB"')
     expect(c).toContain('set-environment -g COLORTERM truecolor')
   })
+
+  it('declares hyperlinks via terminal-features so OSC 8 links reach the renderer', () => {
+    // tmux strips the OSC 8 escape unless the outer terminal declares support, leaving only the
+    // label text — a link whose URL is not also printed can then never be opened.
+    expect(c).toContain('set -as terminal-features ",*:hyperlinks"')
+  })
   it('clears the override/feature arrays a long-lived server accumulated from older versions', () => {
     // A tmux server outlives the app and keeps every entry ever sourced into it; the stale
     // smcup@/rmcup@/indn@ entries would otherwise keep breaking scrolling forever. Measured:

--- a/src/shared/ssh.ts
+++ b/src/shared/ssh.ts
@@ -300,6 +300,8 @@ set -as terminal-features ",*:clipboard"
 # known to speak RGB. The attached client is our xterm.js renderer, which does — declare it via
 # terminal-features like the clipboard entry, never terminal-overrides (see MIGRATION). Issue #78.
 set -as terminal-features ",*:RGB"
+# OSC 8 hyperlink passthrough — tmux strips the escape unless the outer terminal declares it.
+set -as terminal-features ",*:hyperlinks"
 # And advertise it to the programs INSIDE the panes: half the ecosystem checks COLORTERM before
 # emitting 24-bit SGR. Global env, copied into each session at creation — this conf is written and
 # source-filed at connect (warm server) and rides -f on cold start, so it lands before sessions do.


### PR DESCRIPTION
## Summary

Cmd/Ctrl+click now opens OSC 8 hyperlinks, the kind where only a label is printed and the URL rides in an escape sequence. This is what Claude Code emits for every markdown link, and what gh, systemd and delta emit too. Parity with Ghostty and iTerm2, which open these natively.

## Problem

An agent CLI printing `[#376]` as an OSC 8 link was a dead end in nodeterm twice over. Inside tmux (every nodeterm session), tmux strips the escape because our generated conf never declares hyperlink support for the outer terminal, so only the label text survives. And even when the escape reaches xterm.js, the renderer sets no `linkHandler`, and the existing URL/file link providers only regex the visible text, which for a labeled link does not contain the URL.

## Change

Three pieces, one per layer the link travels through:

```
tmux conf (pty-manager.ts, ssh.ts)     terminal-features ",*:hyperlinks" -> escape passes through
createOsc8LinkHandler (file-links.ts)  options.linkHandler on both terminal surfaces
├─ modifier-gated like the providers, so a plain click stays a selection
└─ http(s) only: the URI is invisible text, a javascript:/file: link never reaches openExternal
osc8UrlAt (file-links.ts)              hit-test for installLinkClickFallback
   under tmux mouse-reporting xterm's own activate never fires, so the existing
   capture-phase mouseup fallback now checks the clicked cell for an OSC 8 link first
```

`osc8UrlAt` reads `CellData.extended.urlId` plus `_core._oscLinkService`, private API, because the public buffer API exposes no hyperlink data. Same pattern as the existing `_core._renderService` uses; degrades to "no link" if internals move.

Set on both surfaces of a session: the canvas node and the kanban card modal.

## Testing

`file-links.test.ts` covers the modifier gate, the scheme allowlist and the private-API shape degrading to null; `tmux-conf.test.ts` and `ssh.test.ts` pin the new conf line next to the RGB precedent. Typecheck green, touched suites green, full suite green single-threaded (the parallel flakes are #160). Verified by hand in a packaged build on macOS: Claude Code markdown links inside tmux-backed sessions open in the default browser on Cmd+click, plain click still selects, and the live tmux server picked up the feature via `set -as` without a server restart.

Mobile note for @eneskirca: the remote tmux conf change applies to SSH sessions the iOS app attaches too, so OSC 8 escapes start reaching SwiftTerm; worth checking whether it opens them or needs its own handler.
