### PR TITLE
feat: configure terminal word separators

### DIFF
--- a/src/renderer/components/settings/sections/TerminalSection.tsx
+++ b/src/renderer/components/settings/sections/TerminalSection.tsx
@@ -9,6 +9,7 @@ import { SectionReset } from '../SectionReset'
 import { Switch } from '@renderer/ui/Switch'
 import { Select } from '@renderer/ui/Select'
 import { NumberField } from '@renderer/ui/NumberField'
+import { Input } from '@renderer/ui/Input'
 import { SegmentedPill } from '@renderer/ui/SegmentedPill'
 import { TERMINAL_RESET_KEYS } from '@renderer/lib/settingsReset'
 import {
@@ -61,6 +62,10 @@ const ROWS = {
   middleClickPaste: {
     title: 'Middle-click paste',
     keywords: ['middle', 'click', 'mouse', 'paste', 'primary', 'selection', 'x11', 'linux', 'wheel']
+  },
+  wordSeparator: {
+    title: 'Word selection',
+    keywords: ['word', 'separator', 'selection', 'double click', 'identifier', 'hyphen']
   },
   boldBright: {
     title: 'Bold text uses bright colours',
@@ -316,6 +321,21 @@ export function TerminalSection({ isActive }: { isActive: boolean }): React.JSX.
             }
           />
         </div>
+      </SearchableRow>
+
+      <SearchableRow {...ROWS.wordSeparator}>
+        <FieldRow
+          label="Word separators"
+          description="Characters that end a word when you double-click terminal text. Remove a character to keep it inside selections; for example, leave hyphen out to select a full issue ID."
+          control={
+            <Input
+              className="w-48 font-mono"
+              value={settings.terminalWordSeparator}
+              onChange={(e) => update({ terminalWordSeparator: e.target.value })}
+              aria-label="Terminal word separators"
+            />
+          }
+        />
       </SearchableRow>
 
       <SearchableRow {...ROWS.boldBright}>

--- a/src/renderer/lib/settingsReset.ts
+++ b/src/renderer/lib/settingsReset.ts
@@ -14,6 +14,7 @@ import { DEFAULT_SETTINGS, type Settings } from '@shared/types'
 export const TERMINAL_RESET_KEYS = [
   'fontFamily',
   'fontSize',
+  'terminalWordSeparator',
   'fontWeight',
   'fontWeightBold',
   'drawBoldTextInBrightColors',

--- a/src/renderer/terminal/terminal-config.test.ts
+++ b/src/renderer/terminal/terminal-config.test.ts
@@ -747,6 +747,7 @@ describe('repaintResync', () => {
 const visual = (p: Partial<XtermVisualSettings> = {}): XtermVisualSettings => ({
   fontFamily: 'Menlo',
   fontSize: 13,
+  terminalWordSeparator: " ()[]{}',\"",
   fontWeight: 400,
   fontWeightBold: 700,
   drawBoldTextInBrightColors: true,
@@ -790,6 +791,7 @@ describe('xtermOptionsFromSettings', () => {
       visual({
         fontFamily: 'JetBrains Mono',
         fontSize: 15,
+        terminalWordSeparator: ' ',
         cursorBlink: false,
         cursorStyle: 'bar',
         cursorInactiveStyle: 'none',
@@ -799,6 +801,7 @@ describe('xtermOptionsFromSettings', () => {
     )
     expect(o.fontFamily).toBe('JetBrains Mono')
     expect(o.fontSize).toBe(15)
+    expect(o.wordSeparator).toBe(' ')
     expect(o.cursorBlink).toBe(false)
     expect(o.cursorStyle).toBe('bar')
     expect(o.cursorInactiveStyle).toBe('none')
@@ -862,6 +865,14 @@ describe('applyLiveOptions', () => {
     expect(r.themeChanged).toBe(false)
     expect(term.options.fontSize).toBe(16)
     expect(term.writes).toEqual(['fontSize'])
+  })
+
+  it('applies a word-separator change without refitting the terminal', () => {
+    const term = fakeTerm(visual())
+    const r = applyLiveOptions(term, visual({ terminalWordSeparator: ' ' }))
+    expect(r).toEqual({ metricsChanged: false, themeChanged: false })
+    expect(term.options.wordSeparator).toBe(' ')
+    expect(term.writes).toEqual(['wordSeparator'])
   })
 
   it.each([

--- a/src/renderer/terminal/terminal-config.ts
+++ b/src/renderer/terminal/terminal-config.ts
@@ -220,6 +220,7 @@ export type XtermVisualSettings = Pick<
   Settings,
   | 'fontFamily'
   | 'fontSize'
+  | 'terminalWordSeparator'
   | 'fontWeight'
   | 'fontWeightBold'
   | 'drawBoldTextInBrightColors'
@@ -238,6 +239,7 @@ export type XtermVisualSettings = Pick<
 export const XTERM_VISUAL_KEYS = [
   'fontFamily',
   'fontSize',
+  'terminalWordSeparator',
   'fontWeight',
   'fontWeightBold',
   'drawBoldTextInBrightColors',
@@ -307,6 +309,7 @@ export function mergeProjectVisuals(
 export interface XtermVisualOptions {
   fontFamily: string
   fontSize: number
+  wordSeparator: string
   // xterm widens these to `FontWeight` ('normal' | 'bold' | '100'… | number). We only ever WRITE
   // numbers, but the type has to match what `term.options` exposes or the live target can't be
   // compared against a real terminal.
@@ -336,6 +339,7 @@ export function xtermOptionsFromSettings(
   return {
     fontFamily: s.fontFamily,
     fontSize: s.fontSize,
+    wordSeparator: s.terminalWordSeparator,
     fontWeight: terminalFontWeight(s.fontWeight, 400),
     fontWeightBold: terminalFontWeight(s.fontWeightBold, 700),
     drawBoldTextInBrightColors: s.drawBoldTextInBrightColors,
@@ -408,6 +412,7 @@ export function applyLiveOptions(
 
   if (o.fontFamily !== next.fontFamily) o.fontFamily = next.fontFamily
   if (o.fontSize !== next.fontSize) o.fontSize = next.fontSize
+  if (o.wordSeparator !== next.wordSeparator) o.wordSeparator = next.wordSeparator
   if (o.lineHeight !== next.lineHeight) o.lineHeight = next.lineHeight
   if (o.letterSpacing !== next.letterSpacing) o.letterSpacing = next.letterSpacing
   if (o.fontWeight !== next.fontWeight) o.fontWeight = next.fontWeight

--- a/src/shared/default-settings.test.ts
+++ b/src/shared/default-settings.test.ts
@@ -24,4 +24,8 @@ describe('DEFAULT_SETTINGS', () => {
   it('uses the shared worktree path template default', () => {
     expect(DEFAULT_SETTINGS.worktreePathTemplate).toBe(DEFAULT_WORKTREE_PATH_TEMPLATE)
   })
+
+  it('keeps common identifier and path characters inside terminal word selections', () => {
+    expect(DEFAULT_SETTINGS.terminalWordSeparator).not.toMatch(/[-_/.]/)
+  })
 })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1111,6 +1111,8 @@ export type TerminalCursorInactiveStyle = TerminalCursorStyle | 'outline' | 'non
 export interface Settings {
   fontSize: number
   fontFamily: string
+  /** Characters that end a word during xterm double-click selection. */
+  terminalWordSeparator: string
   cursorBlink: boolean
   /** Appearance of the APP chrome (tab bar, panels, node headers, menus). `auto` (the default)
    *  takes it from the terminal colour theme, so picking a light terminal theme doesn't leave a
@@ -1427,6 +1429,8 @@ export interface Settings {
 export const DEFAULT_SETTINGS: Settings = {
   fontSize: 13,
   fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+  // Keep hyphens, underscores, slashes and dots inside words so identifiers and paths select whole.
+  terminalWordSeparator: " ()[]{}',\"",
   cursorBlink: true,
   // Every appearance default below reproduces the pre-feature look bit-for-bit: the default theme
   // carries the old hardcoded background/foreground, and block/outline/1/0 are xterm's own


### PR DESCRIPTION
Closes #349

## Summary
- expose xterm's word separator setting in Terminal settings
- use a default that keeps `-`, `_`, `/`, and `.` inside double-click selections
- apply updates live and include the setting in section reset
- add mapping, live-update, and default-regression coverage

The shared renderer path covers desktop and Server Edition. Mobile does not instantiate xterm, so there is no mobile surface for this setting.

## Verification
- `npx vitest run src/renderer/terminal/terminal-config.test.ts src/shared/default-settings.test.ts` (125 passed)
- `git diff --check`
- `npm run typecheck` attempted; blocked by the partial Windows dependency install missing declarations for existing `@xyflow/system` imports

Manual UI verification was not performed in this Windows workspace.