### PR TITLE
fix(kanban): make OSC 8 + URL links clickable in the card modal

### DIFF
--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -17,7 +17,11 @@ import { useTerminalSearch } from '../../terminal/useTerminalSearch'
 import { LocalTransport } from '../../terminal/local-transport'
 import { clipboardImages, droppedPaths, pasteHasText, pastedFiles } from '../../terminal/file-drop'
 import { guardMiddleClickPaste } from '../../terminal/middle-click'
-import { createOsc8LinkHandler } from '../../terminal/file-links'
+import {
+  createOsc8LinkHandler,
+  createUrlLinkProvider,
+  installLinkClickFallback
+} from '../../terminal/file-links'
 import { parseOsc52 } from '../../terminal/osc52'
 import { activateUnicode11 } from '../../terminal/unicode-width'
 import { useCopyFeedback } from '../../terminal/useCopyFeedback'
@@ -188,6 +192,28 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
     let sessionId: string | null = null
     let dead = false
     const cleanups: Array<() => void> = []
+
+    // MIRROR TerminalNode's link wiring, minus file links. The provider handles Cmd/Ctrl+click on
+    // URL text when mouse-reporting is off (plain-shell sessions); the capture-phase fallback is
+    // what works under tmux/agent mouse-reporting — the norm, and the only path on which the OSC 8
+    // linkHandler above can ever fire in a tmux-backed session (xterm's own link activation is
+    // swallowed by the mouse report, see installLinkClickFallback). File links stay a canvas-node
+    // affordance: the modal has no project-fs/dialect routing, and resolving a path against the
+    // wrong machine is worse than not linking it — hence fileEnabled: false, not stub deps that
+    // pretend to resolve.
+    const openUrl = (uri: string): void => window.nodeTerminal.shell.openExternal(uri)
+    term.registerLinkProvider(createUrlLinkProvider(term, openUrl))
+    if (term.element) {
+      cleanups.push(
+        installLinkClickFallback(term, term.element, {
+          getCwd: () => undefined,
+          lookup: () => Promise.resolve({ exists: false, dir: false }),
+          activateFile: () => {},
+          openUrl,
+          fileEnabled: () => false
+        }).dispose
+      )
+    }
 
     // MIRROR TerminalNode "WRITE-ONLY — `parseOsc52` returns null" — the OSC 52 clipboard-write path.
     // tmux's mouse is ON, so a drag-select in copy-mode emits OSC 52 to this client; this handler

--- a/src/shared/ssh.test.ts
+++ b/src/shared/ssh.test.ts
@@ -265,6 +265,7 @@ describe('remoteTmuxConf', () => {
     // label text — a link whose URL is not also printed can then never be opened.
     expect(c).toContain('set -as terminal-features ",*:hyperlinks"')
   })
+
   it('clears the override/feature arrays a long-lived server accumulated from older versions', () => {
     // A tmux server outlives the app and keeps every entry ever sourced into it; the stale
     // smcup@/rmcup@/indn@ entries would otherwise keep breaking scrolling forever. Measured:


### PR DESCRIPTION
## Summary

Follow-up to #418. The OSC 8 `linkHandler` it set on `ModalTerminal` is unreachable on every tmux-backed session: under tmux mouse-reporting xterm's own link activation never fires — that is the exact case the canvas node covers with the capture-phase `installLinkClickFallback`, which the modal never installed. So Cmd/Ctrl+click on a link in the kanban card modal still did nothing in the normal case.

## Change

Mirror the canvas node's link wiring in `ModalTerminal`, minus file links:

- `createUrlLinkProvider` — Cmd/Ctrl+click on URL text when mouse-reporting is off (plain-shell sessions).
- `installLinkClickFallback` — the tmux/agent-TUI path, which also hit-tests OSC 8 cells first (#418's `osc8UrlAt`). Disposer rides the modal's existing `cleanups`.
- `fileEnabled: false`, deliberately: the modal has no project-fs/dialect routing, and resolving a path against the wrong machine is worse than not linking it. File links stay a canvas-node affordance.

Also adds the missing blank line between the two `remoteTmuxConf` tests from #418.

## Testing

Typecheck green; `file-links.test.ts` + `ssh.test.ts` green (the pure pieces — modifier gate, scheme allowlist, osc8 hit-test — are already covered there; this PR is wiring). Not device-verified on a Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)