### PR TITLE
Usage popover: Switch account action (system-scoped `claude /login`) — closes #420

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -431,6 +431,7 @@ import {
   fitGroupToChildren,
   createAccountLoginNode,
   createCodexAccountLoginNode,
+  createSystemLoginNode,
   isAccountLoginNode,
   systemAccountDisplay,
   createAgentNode,
@@ -3824,6 +3825,29 @@ export function Canvas() {
     window.addEventListener('nodeterm:add-codex-account-login', onAddCodexAccountLogin)
     return () =>
       window.removeEventListener('nodeterm:add-codex-account-login', onAddCodexAccountLogin)
+  }, [setNodes, markDirty, viewCenter])
+
+  // Issue #420 — the usage popover's "Switch account" dispatches 'nodeterm:switch-system-account'
+  // to open a terminal running `claude /login` under the SYSTEM env (no accountId — see
+  // createSystemLoginNode for why that is its own factory, not a reuse of the managed one).
+  // Local by construction: the popover only offers the action on a local scope, and this listener
+  // never resolves an ssh binding — so even a stray dispatch spawns the login on THIS machine,
+  // the only machine whose ~/.claude the action claims to switch.
+  useEffect(() => {
+    const onSwitchSystemAccount = (): void => {
+      setNodes((ns) => [
+        ...ns.map((n) => ({ ...n, selected: false })),
+        { ...createSystemLoginNode(ns.length, viewCenter()), selected: true }
+      ])
+      markDirty()
+      // The popover is reachable from over the kanban board too (`overBoard`) — leave the board
+      // so the user actually sees the login node they must interact with. Same rationale as the
+      // Settings-overlay close in the add-account listeners above.
+      const pid = useProjects.getState().activeProjectId
+      if (pid && isKanbanOpen(pid)) useViewMode.getState().toggle(pid)
+    }
+    window.addEventListener('nodeterm:switch-system-account', onSwitchSystemAccount)
+    return () => window.removeEventListener('nodeterm:switch-system-account', onSwitchSystemAccount)
   }, [setNodes, markDirty, viewCenter])
 
   // Resolve the system account's email once, so context menus (built via getState) can label

--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -556,6 +556,33 @@ export function UsageIndicator({
           {dedupeProviderRows(visibleProviders).map((p) => (
             <ProviderBlock key={providerRowKey(p)} u={p} mode={percentMode} />
           ))}
+          {/* Issue #420 — "Switch account" where the limit is displayed: opens a terminal
+              running the SYSTEM-scoped `claude /login` (createSystemLoginNode), so picking the
+              other org is one click from the panel that said you need to. Nothing changes until
+              the user completes the login IN that terminal — the CLI's own org picker + OAuth —
+              which is why there is no confirm dialog in front of it: the terminal is the
+              confirmation surface, and the tooltip names what completing it changes. LOCAL scope
+              only: on an SSH project a system login would rewrite the HOST's ~/.claude, and
+              saying "switch account" while meaning another machine's identity is the kind of
+              ambiguity this popover exists to avoid. Hidden with the Claude provider — a switch
+              button for numbers the user chose not to see would be an orphan. */}
+          {scope.kind === 'local' && !hidden.has('claude') && (
+            <button
+              type="button"
+              className="usage-popover__switch"
+              title={
+                'Opens a terminal running `claude /login` for the system account (~/.claude). ' +
+                'Completing it switches the org/account all system sessions use — running ' +
+                'sessions carry on under the new one. Managed accounts keep their own logins.'
+              }
+              onClick={() => {
+                setOpen(false)
+                window.dispatchEvent(new CustomEvent('nodeterm:switch-system-account'))
+              }}
+            >
+              ⇄ Switch account…
+            </button>
+          )}
         </div>
       )}
       {/* The SSH pill is visually identical to the local one — same labels, same bar — so the

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -8,6 +8,8 @@ import {
   createCodexAccountLoginNode,
   createAgentNode,
   createDinoNode,
+  createSystemLoginNode,
+  isAccountLoginNode,
   fitGroupToChildren,
   flowToNodeStates,
   groupSelectedNodes,
@@ -721,6 +723,36 @@ describe('createCodexAccountLoginNode', () => {
     // With an agentId of 'codex' this would be an agent node and take the agent paths; the login
     // terminal is scoped purely because its account id is a managed CODEX one (see #345/#346).
     expect(createCodexAccountLoginNode('acct-2', 0).data.agentId).toBeUndefined()
+  })
+})
+
+describe('createSystemLoginNode (issue #420)', () => {
+  it('produces a SYSTEM-scoped login terminal: no accountId, no agentId, its own title', () => {
+    const node = createSystemLoginNode(0)
+    expect(node.type).toBe('terminal')
+    expect(node.data.title).toBe('Switch Claude account')
+    // No accountId = the plain-terminal spawn env, so `claude /login` writes ~/.claude — the
+    // whole point of the switch. Agent-less like the managed login nodes.
+    expect(node.data.accountId).toBeUndefined()
+    expect(node.data.agentId).toBeUndefined()
+    expect(node.data.initialCommand).toBe('claude /login')
+  })
+
+  it('is never swept by account removal, and a serialized copy sheds the login signature', () => {
+    const node = createSystemLoginNode(0)
+    // Live (pre-first-open) data matches isAccountLoginNode via initialCommand — harmless,
+    // because both destroy paths (Canvas + AccountsSection) additionally require accountId
+    // equality with the removed account, and this node has none.
+    expect(isAccountLoginNode(node.data)).toBe(true)
+    expect(node.data.accountId).toBeUndefined()
+    // The durable half: initialCommand never survives a serialize, and the title is NOT the
+    // managed factory's 'Claude login' — so a persisted copy fails isAccountLoginNode outright.
+    // That is also the anti-respawn guarantee: a restarted app rehydrates this node with no
+    // command at all, so `claude /login` can only ever run the once the user clicked for.
+    const persisted = flowToNodeStates([node])[0]
+    expect((persisted as { initialCommand?: string }).initialCommand).toBeUndefined()
+    const back = nodeStatesToFlow([persisted])[0]
+    expect(isAccountLoginNode(back.data)).toBe(false)
   })
 })
 

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -740,6 +740,36 @@ export function createCodexAccountLoginNode(
 }
 
 /**
+ * Terminal node that SWITCHES the system (~/.claude) Claude identity — the usage popover's
+ * "Switch account" action (issue #420). Runs `claude /login` with NO `accountId`, so the spawn
+ * env is bit-for-bit the plain-terminal one and the OAuth writes the system `~/.claude` —
+ * which is the point: every system-scope session follows the new org, exactly as a hand-typed
+ * `claude /login` would make them. Deliberately a SEPARATE factory from
+ * `createAccountLoginNode`: that one REQUIRES an accountId because config-dir scoping is its
+ * purpose, and its 'Claude login' title is the durable signature `isAccountLoginNode` keys on
+ * to destroy login nodes together with their removed account — a sweep this node must never be
+ * caught by (both destroy paths also gate on accountId equality, and this node has none).
+ *
+ * The docblock hazard on `isAccountLoginNode` — a respawned `claude /login` overwriting the
+ * system identity — is only a hazard when it happens UNASKED. Here the overwrite is the feature,
+ * and "once" is structural rather than promised: `initialCommand` is consumed on first mount and
+ * never serialized (`flowToNodeStates` drops it), so after an app restart or a machine reboot
+ * this node is an inert plain terminal, not a login prompt nobody requested.
+ *
+ * Local only, on purpose: on an SSH project a system login would rewrite THAT host's ~/.claude,
+ * so the popover does not offer the action there (see UsageIndicator).
+ */
+export function createSystemLoginNode(index: number, center?: { x: number; y: number }): CanvasNode {
+  const node = createTerminalNode(index, undefined, center)
+  node.data = {
+    ...node.data,
+    title: 'Switch Claude account',
+    initialCommand: 'claude /login'
+  }
+  return node
+}
+
+/**
  * True when node data is (or started as) an account-login terminal (`claude /login`).
  * `initialCommand` is one-shot and never persisted, so the factory title is the only durable
  * signature — serialized copies match on title alone. Used to DESTROY the login node together

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6401,6 +6401,28 @@ button.group-node__setup:disabled {
   background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
+/* Popover-footer action (issue #420): opens the system-scoped `claude /login` terminal. A quiet
+   full-width row, styled with the same tint/accent tokens as `.usage-account__use` so it reads
+   in both themes. */
+.usage-popover__switch {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 5px 8px;
+  border: none;
+  border-radius: 6px;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  text-align: left;
+  color: rgba(var(--tint-rgb), 0.55);
+  background: rgba(var(--tint-rgb), 0.06);
+  cursor: pointer;
+}
+.usage-popover__switch:hover {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
 /* ---- Session-memory panel (opened by the system-resource pill) ----
    Same surface, border and shadow as `.usage-popover` above — the two panels open from adjacent
    pills in the same corner, so anything that made them read as different kinds of thing would be


### PR DESCRIPTION
Closes #420.

## What

A **Switch account…** button at the bottom of the usage popover (local scope only) that opens a terminal node running the **system-scoped** `claude /login` — so when the popover is showing you one org is spent and the other has room, picking the other org is one click from where that decision is made.

## Design decisions (mapping to the issue's "worth your judgement" list)

**A separate factory.** `createSystemLoginNode` (`renderer/state/workspace.ts`) is deliberately not a reuse of `createAccountLoginNode`: that factory *requires* an `accountId` because config-dir scoping is its purpose, and its `'Claude login'` title is the durable signature `isAccountLoginNode` keys on to destroy login nodes together with their removed account. The system node carries **no `accountId`** and its own title (`'Switch Claude account'`), so:
- Both destroy sweeps (Canvas + AccountsSection) gate on `accountId` equality with the removed account — this node has none, so account removal can never sweep it up.
- The **cold-restart respawn hazard** the `isAccountLoginNode` docblock warns about does not apply structurally: `initialCommand` is one-shot (consumed on first mount) and never serialized (`flowToNodeStates` drops it), so an app restart or machine reboot rehydrates this node as an inert plain terminal — `claude /login` can only ever run the once the user clicked for. Pinned by a round-trip test: a serialized copy sheds the login signature entirely (`isAccountLoginNode` → `false`).

**Overwriting `~/.claude` is the feature, and the confirmation is the terminal itself.** There is no confirm dialog in front of the button: clicking it changes nothing — the identity only switches when the user completes the login *in* the spawned terminal, through the CLI's own org picker + OAuth, which is a stronger confirmation than a dialog would be. The button's tooltip names exactly what completing it changes ("switches the org/account all system sessions use — running sessions carry on under the new one; managed accounts keep their own logins").

**SSH projects: not offered, on purpose.** The button renders only on a **local** scope (`scope.kind === 'local'`). On an SSH project a system login would rewrite the *host's* `~/.claude`, and a button saying "switch account" while meaning another machine's identity is the ambiguity the scoped popover exists to avoid. The Canvas listener is also local by construction (it never resolves an ssh binding), so even a stray dispatch spawns the login on this machine — the only machine whose identity the action claims to switch. A host-side switch can be a follow-up if there's demand, with the host named in the copy.

**Which sessions follow.** Nodes pinned to a managed account are excluded by the existing mechanism, not by new code: their `CLAUDE_CONFIG_DIR` is baked into the tmux session at spawn, so they never see the system dir. System-scope sessions share `~/.claude` and follow the new identity the way they do after a hand-typed `claude /login` (the issue's "not verified" point — see below).

**Wiring.** The popover dispatches `nodeterm:switch-system-account`; Canvas listens and spawns the node selected at view center (the pairing is enforced by `nodeterm-events.test.ts`, so neither end can ship alone — the #346 lesson). If the kanban board is up, Canvas switches back to the canvas view so the login node the user must interact with is actually visible (same rationale as the Settings-overlay close in the add-account flow). Hidden together with the Claude provider (Settings → Usage): a switch button for numbers the user chose not to see would be an orphan.

## Three surfaces

- **Desktop**: full feature.
- **Server Edition**: works as-is with **no bridge change** — this is a pure renderer feature (a CustomEvent + an existing node factory + the existing pty create path); it adds no `window.nodeTerminal` member, so there is nothing to stub or implement in `src/renderer/bridge`. The spawned `claude /login` runs on the server host, which is exactly the machine the local scope's numbers describe — so the semantics are right by construction.
- **Mobile companion**: N/A — no canvas or usage popover there; nothing to degrade.

## Not implemented (deliberate, per the issue)

- **Surfacing at the limit moment** (a nudge when a window hits 100%): left out of v1 to keep this a one-affordance change; the popover the user opens when a limit bites now carries the action, which is the core ask. Can layer on `primaryLimit` severity later.
- **Verification that running sessions re-read `~/.claude` on their next turn** is the issue's own open question and is a CLI behavior, not something this codebase controls; the feature reproduces exactly what a hand-typed `claude /login` does, no more.

## Tests

- `createSystemLoginNode` shape (terminal, own title, no `accountId`, no `agentId`, `claude /login`).
- Removal-sweep + anti-respawn pin: live data matches `isAccountLoginNode` only via the one-shot `initialCommand` (harmless — both destroy paths also require an `accountId` match); the serialized round-trip drops the command and fails `isAccountLoginNode`.
- `nodeterm-events.test.ts` (existing) enforces the dispatch/listener pairing.
- Full suite: 9068 passed; the only red is `node-pty-patch.test.ts`, the documented unpatched-`node_modules` environment signal (shared checkout), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)