### PR TITLE
Add an uninstall script for a clean trial/removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,20 @@ detects your platform. Everything is also listed at
 - **iOS** — **nodeterm mobile** on the
   [App Store](https://apps.apple.com/app/nodeterm/id6790581233).
 
+**Trying it out?** Removal is one script — it stops every process nodeterm started, reverts
+the status-hook/skill entries it merged into your agent CLIs' config (your own hooks and
+credentials are never touched), and deletes all of nodeterm's own state. Run it with
+`--dry-run` first to see the full list of what it found:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/eneskirca/nodeterm/main/scripts/uninstall.sh | bash -s -- --dry-run
+curl -fsSL https://raw.githubusercontent.com/eneskirca/nodeterm/main/scripts/uninstall.sh | bash -s -- --yes
+```
+
+The full inventory of what nodeterm writes where (and what the script keeps, like the
+`.nodeterm/` canvas folders inside your own repos) is documented in
+[docs/uninstall.md](docs/uninstall.md).
+
 ## 🛠 Build from source
 
 Requires Node.js 20+ on macOS or Linux (tmux recommended — it's what makes sessions

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,0 +1,114 @@
+# Uninstalling nodeterm — the full inventory, and the portable-install question
+
+Issue #347 asked for a clean trial: install, evaluate, remove without residue.
+`scripts/uninstall.sh` is that removal. This document is the inventory behind it — every
+place the app writes at runtime, keyed to the code that writes it — plus a feasibility note
+on the alternative the issue proposed (a fully portable install).
+
+Run it safely first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/eneskirca/nodeterm/main/scripts/uninstall.sh | bash -s -- --dry-run
+```
+
+`--dry-run` prints everything the script found on your machine (processes, tmux sessions,
+files, config entries inside other tools' files) and changes nothing. Re-run with `--yes`
+to apply. Interactive runs (downloaded script, no pipe) confirm before touching anything.
+
+## What nodeterm writes, and who removes it
+
+### 1. nodeterm's own state — deleted wholesale
+
+| Location | What it holds | Written by |
+| --- | --- | --- |
+| `~/Library/Application Support/nodeterm` (macOS) / `~/.config/nodeterm` (Linux) | The Electron user-data dir: `workspace.json`, `settings.json`, generated `tmux.conf`, `terminal-scrollback/`, `hook-endpoint.env`, `context-links/`, `canvas-control/`, `claude-accounts/<id>/` (managed-account config dirs), `speech-models/`, media caches, secret stores, `device-id`, browser storage | everything behind `CorePlatform.userDataDir` |
+| `~/.nodeterm` | Machine-stable state shared by every instance: `agent-hooks/*.sh` (the managed hook scripts), `ssh-cm/*.sock` (SSH ControlMaster sockets), `acks/`, `pending/`, `push-grants/`, `cx/`, `codex-thread-names/`, the app-private ssh-agent | `install-helper.ts`, `control-master.ts`, `pairing-service.ts`, … |
+| `~/Library/Caches/nodeterm*`, `~/Library/Caches/com.nodeterm.app*`, `~/Library/Application Support/Caches/nodeterm-updater`, `~/Library/Preferences/com.nodeterm.app.plist`, `~/Library/Saved Application State/…`, `~/Library/HTTPStorages/com.nodeterm.app`, `~/Library/Logs/nodeterm` | Chromium/electron-updater caches, macOS window state | Electron / macOS |
+| Keychain entry `nodeterm Safe Storage` (macOS) | The key Electron `safeStorage` encrypts local secrets with | Electron |
+| `/Applications/nodeterm.app` (or the Homebrew cask) | The app itself | `install.sh` / brew |
+| `~/.nodeterm-server-app`, `~/.nodeterm-server`, systemd units `nodeterm-server.service` + `nodeterm-server-update.{service,timer}` (system or `--user`) | Server Edition checkout, private Node runtime, data dir, service + daily auto-update timer | `install-server.sh` |
+
+### 2. Integration merged into OTHER tools' config — reverted surgically
+
+nodeterm integrates with agent CLIs you already have by merging entries into their config.
+Every merge is marker-identified, so removal never touches your own hooks, credentials, or
+settings:
+
+| File | What nodeterm added | How it's removed |
+| --- | --- | --- |
+| `~/.claude/settings.json`, `~/.gemini/settings.json` | Status-hook entries whose command references `~/.nodeterm/agent-hooks/` (legacy marker: `claude-signals`) | JSON filter keyed on those markers; other hooks and keys preserved |
+| `~/.codex/hooks.json` + `~/.codex/config.toml` | Hook entries + the matching `[hooks.state."…"]` trust blocks | Our entries removed; trust blocks for surviving user hooks re-keyed to their shifted indexes (the hash covers content, not position) |
+| `~/.claude/skills/manage-nodeterm-canvas/`, `~/.claude/skills/get-linked-context/` | nodeterm-owned skill dirs | Deleted |
+| `~/.grok/hooks/nodeterm-status.json`, `~/.copilot/hooks/nodeterm-status.json` | nodeterm-owned hook files (those CLIs merge whole directories) | Deleted |
+| `~/.config/opencode/plugins/nodeterm-status.js` | nodeterm-owned plugin (first-line marker checked before deletion) | Deleted |
+| `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, `~/.copilot/copilot-instructions.md`, `~/.config/opencode/AGENTS.md` | `<!-- nodeterm:manage-canvas -->` / `<!-- nodeterm:get-linked-context -->` marker blocks | Block stripped; file deleted only if nothing but our blocks remains |
+
+Two deliberate exceptions:
+
+- **`"tui": "fullscreen"` in `~/.claude/settings.json` is left alone.** nodeterm writes it
+  only when absent, so an existing value can be the user's own — removal can't tell the two
+  apart, and the setting is harmless outside nodeterm.
+- **If no JS runtime (`node`) is found, the JSON/TOML entries are left in place with a
+  warning.** They are self-neutralizing: the installed hook command is
+  `if [ -r <script> ]; then sh <script>; else cat >/dev/null; fi`, so once
+  `~/.nodeterm/agent-hooks/` is deleted every entry is a silent no-op (this guard exists
+  precisely so an uninstalled nodeterm can never block a Claude session — see
+  `install-helper.ts`).
+
+### 3. Processes — stopped cleanly, in order
+
+1. Server Edition systemd units are disabled and their unit files removed.
+2. The desktop app is asked to quit (AppleScript on macOS, SIGTERM elsewhere), with a
+   10-second grace before a hard kill.
+3. The tmux servers on nodeterm's private sockets (`node-terminal`, and `nodeterm-rmt` if
+   another machine SSH'd in) are killed — **the script lists every live session first and
+   warns that processes inside them end.** Your own tmux (default socket) is untouched.
+4. Lingering SSH ControlMasters are closed via `ssh -O exit` on each
+   `~/.nodeterm/ssh-cm/*.sock`.
+
+### 4. What is deliberately KEPT
+
+- **`<project>/.nodeterm/` inside your repos** (`project.json`, `board-log.jsonl`,
+  `images/`). These are your canvas layouts — git-shareable by design, possibly committed,
+  possibly another collaborator's. The script enumerates them from the workspace index
+  *before* deleting it and prints the list with a manual `rm -rf` hint instead of deleting.
+- **Remote SSH hosts.** A connected SSH project installs the same hook scripts/skills under
+  the *host's* `~/.nodeterm` and agent dirs, and its sessions live on the host's
+  `nodeterm-rmt` tmux socket. The script prints per-host cleanup instructions; it does not
+  reach over the network.
+- **The agent CLIs and tmux themselves** — nodeterm never owned them.
+
+## Portable install — feasibility note
+
+The issue's preferred shape was "everything in one folder; removal = delete the folder".
+How close can nodeterm get?
+
+**The easy 80%: redirecting user data.** Electron supports
+`app.setPath('userData', …)` before `ready`. A `portable` marker file next to the app (or a
+`NODETERM_PORTABLE_DATA=<dir>` env var) checked at boot in `src/main/index.ts` would move
+the entire user-data table above into the chosen folder, and `TMUX_TMPDIR` can move the
+tmux sockets there too. That's a small, low-risk change and worth doing.
+
+**The structural 20%: integration cannot be portable.** The issue also asks to *keep* the
+ability to connect to existing claude/codex/opencode installs — and that connection *is*
+writes into those tools' own config dirs (`~/.claude`, `~/.codex`, …): they only read hooks,
+skills and instruction files from their own locations, which nodeterm does not control.
+Likewise `~/.nodeterm/agent-hooks` is deliberately machine-stable rather than
+per-install: when the hook script path lived inside each instance's data dir, a second
+install (dev build, Server Edition, E2E run) re-pointed the shared `settings.json` at *its*
+copy, and when that dir vanished, hooks silently died for every session on the box (field
+report — see the note in `install-helper.ts`). A "portable" mode that moved it back into
+the app folder would reintroduce exactly that failure.
+
+So the honest design is:
+
+- **Portable data dir** (feasible follow-up): keeps canvases, settings, scrollback, caches,
+  accounts in one deletable folder. Escape-hatch env var + marker file, ~30 lines.
+- **Uninstall script** (this change): required regardless, because agent integration and
+  the machine-stable hook path can never live inside the portable folder without breaking
+  the integration the issue wants to keep. Every write outside the folder is env-gated
+  (inert in sessions nodeterm didn't spawn) and marker-reversible.
+
+Windows note: the desktop build ships as an NSIS installer with its own uninstaller
+(Add/Remove Programs); after running it, delete `%APPDATA%\nodeterm` and
+`%USERPROFILE%\.nodeterm`. The POSIX script does not run there.

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+# nodeterm uninstaller — removes the app and every trace it leaves on this machine.
+#
+#   curl -fsSL https://nodeterm.dev/uninstall.sh | bash -s -- --dry-run   # list what would happen
+#   curl -fsSL https://nodeterm.dev/uninstall.sh | bash -s -- --yes       # actually uninstall
+#   bash scripts/uninstall.sh                                             # interactive (asks first)
+# (a piped bash has no interactive stdin, so the piped form requires an explicit --yes)
+#
+# What it does, in order:
+#   1. PLAN: inspects the machine and prints everything it found (processes, tmux sessions,
+#      files, config entries in other tools' files). --dry-run stops here.
+#   2. Stops processes cleanly: the desktop app, the Server Edition systemd units, the tmux
+#      servers on nodeterm's private sockets (node-terminal / nodeterm-rmt), lingering SSH
+#      ControlMasters.
+#   3. Reverts the integration nodeterm merged into OTHER tools' config — idempotently, using
+#      the same markers the installer wrote, never touching entries that aren't ours:
+#        ~/.claude/settings.json      managed hook entries (marker: agent-hooks / claude-signals)
+#        ~/.claude/skills/…           the two nodeterm-owned skill dirs
+#        ~/.gemini/settings.json      managed hook entries
+#        ~/.gemini/GEMINI.md          <!-- nodeterm:… --> marker blocks
+#        ~/.codex/hooks.json          managed hook entries + config.toml trust entries
+#        ~/.codex/AGENTS.md           marker blocks
+#        ~/.copilot/hooks/nodeterm-status.json (owned file) + copilot-instructions.md blocks
+#        ~/.grok/hooks/nodeterm-status.json    (owned file)
+#        ~/.config/opencode/plugins/nodeterm-status.js (owned, marker-checked) + AGENTS.md blocks
+#      Your agents' credentials, sessions and own settings are never touched.
+#   4. Deletes nodeterm's own state: ~/.nodeterm, the Electron user-data dir, caches, prefs,
+#      logs, the Keychain entry, /Applications/nodeterm.app (or the brew cask), and the Server
+#      Edition checkout + data dir if present.
+#   5. Reports what it deliberately does NOT delete: the per-project `.nodeterm/` folders inside
+#      your repos (they are your canvas layouts, and may be committed/shared), and anything on
+#      remote SSH hosts.
+#
+# Notes:
+#   - JSON/TOML surgery needs a JS runtime (node). Without one those entries are left in place
+#     with a warning — they are harmless: the installed hook command is self-guarded and becomes
+#     a silent no-op once the script it points to is deleted.
+#   - macOS and Linux. On Windows use the NSIS uninstaller (Add/Remove Programs), then delete
+#     %APPDATA%\nodeterm and %USERPROFILE%\.nodeterm.
+set -u
+
+DRY_RUN=0
+ASSUME_YES=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --yes|-y)  ASSUME_YES=1 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//' | sed -n '2,40p'; exit 0 ;;
+    *) printf 'Unknown option: %s (try --help)\n' "$arg" >&2; exit 2 ;;
+  esac
+done
+
+OS="$(uname -s)"
+info()  { printf '\033[36m→\033[0m %s\n' "$1"; }
+ok()    { printf '\033[32m✓\033[0m %s\n' "$1"; }
+warn()  { printf '\033[33m⚠\033[0m %s\n' "$1" >&2; }
+plan()  { printf '  \033[33m•\033[0m %s\n' "$1"; }
+note()  { printf '  \033[2m%s\033[0m\n' "$1"; }
+
+HOME="${HOME:-$(cd ~ && pwd)}"
+
+# ---- locations (must mirror what the app writes; see docs/uninstall.md) ----------------------
+if [ "$OS" = "Darwin" ]; then
+  USER_DATA="$HOME/Library/Application Support/nodeterm"
+else
+  USER_DATA="${XDG_CONFIG_HOME:-$HOME/.config}/nodeterm"
+fi
+NT_HOME="$HOME/.nodeterm"                       # agent-hooks, ssh-cm sockets, acks, push-grants…
+SERVER_APP="${NODETERM_APP_DIR:-$HOME/.nodeterm-server-app}"
+SERVER_DATA="${NODETERM_DATA_DIR:-$HOME/.nodeterm-server}"
+APP_BUNDLE="/Applications/nodeterm.app"
+GROK_HOME="${GROK_HOME:-$HOME/.grok}"
+COPILOT_HOME="${COPILOT_HOME:-$HOME/.copilot}"
+if [ -n "${XDG_CONFIG_HOME:-}" ] && [ "${XDG_CONFIG_HOME#\/}" != "$XDG_CONFIG_HOME" ]; then
+  OPENCODE_DIR="$XDG_CONFIG_HOME/opencode"
+else
+  OPENCODE_DIR="$HOME/.config/opencode"
+fi
+
+# Markers the installers wrote — the uninstall keys off the SAME strings (see
+# src/core/agents/hooks/install-helper.ts and src/main/canvas-control-core.ts).
+HOOK_MARKERS='agent-hooks|claude-signals'
+CC_START='<!-- nodeterm:manage-canvas:start -->'
+CC_END='<!-- nodeterm:manage-canvas:end -->'
+CL_START='<!-- nodeterm:get-linked-context:start -->'
+CL_END='<!-- nodeterm:get-linked-context:end -->'
+OPENCODE_PLUGIN_MARKER='nodeterm managed plugin'
+
+# ---- JS runtime for JSON/TOML surgery --------------------------------------------------------
+NODE_BIN=""
+if command -v node >/dev/null 2>&1; then
+  NODE_BIN="$(command -v node)"
+elif [ -x "$SERVER_APP/runtime/node/bin/node" ]; then
+  NODE_BIN="$SERVER_APP/runtime/node/bin/node"
+fi
+
+# jsedit <mode> <args…> — runs the embedded helper. Modes:
+#   clean-hooks <settings.json>          remove managed entries (claude / gemini shape), print count
+#   clean-codex <codexHome>              remove managed entries + drop/re-key trust entries
+#   list-projects <workspace.json>       print each local project cwd (one per line)
+jsedit() {
+  [ -n "$NODE_BIN" ] || return 3
+  "$NODE_BIN" - "$@" <<'JSEOF'
+const fs = require('fs')
+const path = require('path')
+const [mode, target] = process.argv.slice(2)
+const MARKER = /agent-hooks|claude-signals/
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')) } catch { return null }
+}
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v)
+
+// Remove managed entries from a claude/gemini-shaped settings.json:
+// hooks[event] = [{ matcher?, hooks: [{ type, command }] }]. Returns removed count (dry=true
+// leaves the file untouched).
+function cleanHooks(file, dry) {
+  const s = readJson(file)
+  if (!s || !isObj(s.hooks)) return 0
+  let removed = 0
+  for (const ev of Object.keys(s.hooks)) {
+    const defs = s.hooks[ev]
+    if (!Array.isArray(defs)) continue
+    const kept = []
+    for (const def of defs) {
+      if (isObj(def) && Array.isArray(def.hooks)) {
+        const keptHooks = def.hooks.filter(
+          (h) => !(isObj(h) && typeof h.command === 'string' && MARKER.test(h.command))
+        )
+        removed += def.hooks.length - keptHooks.length
+        def.hooks = keptHooks
+        if (keptHooks.length === 0) continue // the def existed only to carry our hook
+      }
+      kept.push(def)
+    }
+    if (kept.length === 0) delete s.hooks[ev]
+    else s.hooks[ev] = kept
+  }
+  if (Object.keys(s.hooks).length === 0) delete s.hooks
+  if (removed > 0 && !dry) fs.writeFileSync(file, JSON.stringify(s, null, 2) + '\n')
+  return removed
+}
+
+// Codex: hooks.json carries our entries; config.toml gates each hook behind a
+// [hooks.state."<realpath(hooks.json)>:<event_label>:<group>:<handler>"] trust block. Removing
+// our entries shifts the indexes of any LATER user entries in the same event array, so their
+// trust keys are re-keyed to the new indexes (trusted_hash covers content, not position).
+function cleanCodex(codexHome, dry) {
+  const hooksPath = path.join(codexHome, 'hooks.json')
+  const tomlPath = path.join(codexHome, 'config.toml')
+  const cfg = readJson(hooksPath)
+  const out = { removedHooks: 0, removedTrust: 0, rekeyedTrust: 0 }
+  if (!cfg || !isObj(cfg.hooks)) return out
+
+  const LABEL = {
+    SessionStart: 'session_start', UserPromptSubmit: 'user_prompt_submit',
+    PreToolUse: 'pre_tool_use', PermissionRequest: 'permission_request',
+    PostToolUse: 'post_tool_use', Stop: 'stop', PreCompact: 'pre_compact',
+    PostCompact: 'post_compact'
+  }
+  const drop = new Set()   // "label:g:h" of our handlers
+  const remap = new Map()  // "label:oldG:oldH" -> [newG, newH] for surviving handlers
+  for (const ev of Object.keys(cfg.hooks)) {
+    const label = LABEL[ev]
+    const defs = cfg.hooks[ev]
+    if (!label || !Array.isArray(defs)) continue
+    let newG = 0
+    const keptDefs = []
+    defs.forEach((def, g) => {
+      const handlers = isObj(def) && Array.isArray(def.hooks) ? def.hooks : null
+      // A def with no handler array carries no trust entries — keep it, position advances.
+      if (!handlers) { keptDefs.push(def); newG++; return }
+      let newH = 0
+      const keptHandlers = []
+      handlers.forEach((h, hIdx) => {
+        const ours = isObj(h) && typeof h.command === 'string' && MARKER.test(h.command)
+        if (ours) { drop.add(`${label}:${g}:${hIdx}`); out.removedHooks++; return }
+        remap.set(`${label}:${g}:${hIdx}`, [newG, newH])
+        keptHandlers.push(h); newH++
+      })
+      if (keptHandlers.length === 0 && handlers.length > 0) return // def was entirely ours
+      def.hooks = keptHandlers
+      keptDefs.push(def); newG++
+    })
+    if (keptDefs.length === 0) delete cfg.hooks[ev]
+    else cfg.hooks[ev] = keptDefs
+  }
+  if (out.removedHooks === 0) return out
+
+  // Rewrite config.toml trust blocks that reference this hooks.json.
+  let canonical = hooksPath
+  try { canonical = fs.realpathSync.native(hooksPath) } catch {}
+  let toml = null
+  try { toml = fs.readFileSync(tomlPath, 'utf8') } catch {}
+  if (toml !== null) {
+    const lines = toml.split(/\r?\n/)
+    const header = /^[ \t]*\[hooks\.state\."((?:[^"\\]|\\.)*)"\][ \t]*(?:#[^\r\n]*)?$/
+    const outLines = []
+    let skip = false
+    for (let i = 0; i < lines.length; i++) {
+      const m = header.exec(lines[i])
+      if (!m) {
+        if (skip && /^[ \t]*\[/.test(lines[i])) skip = false
+        if (!skip) outLines.push(lines[i])
+        continue
+      }
+      skip = false
+      const key = m[1].replace(/\\(["\\])/g, '$1')
+      // key = <sourcePath>:<label>:<g>:<h>; sourcePath may itself contain ':'
+      const parts = key.split(':')
+      const [h, g, label] = [parts.pop(), parts.pop(), parts.pop()]
+      const src = parts.join(':')
+      const matches = src === canonical || src === hooksPath
+      const tail = `${label}:${g}:${h}`
+      if (matches && drop.has(tail)) { skip = true; out.removedTrust++; continue }
+      if (matches && remap.has(tail)) {
+        const [ng, nh] = remap.get(tail)
+        const newKey = `${src}:${label}:${ng}:${nh}`.replace(/([\\"])/g, '\\$1')
+        outLines.push(lines[i].replace(header, `[hooks.state."${newKey}"]`))
+        out.rekeyedTrust++
+        continue
+      }
+      outLines.push(lines[i])
+    }
+    if (!dry && (out.removedTrust > 0 || out.rekeyedTrust > 0)) {
+      fs.writeFileSync(tomlPath, outLines.join('\n'))
+    }
+  }
+
+  if (!dry) {
+    const onlyHooksKey = Object.keys(cfg).every((k) => k === 'hooks')
+    if (Object.keys(cfg.hooks).length === 0 && onlyHooksKey) fs.unlinkSync(hooksPath)
+    else fs.writeFileSync(hooksPath, JSON.stringify(cfg, null, 2) + '\n')
+  }
+  return out
+}
+
+function listProjects(file) {
+  const ws = readJson(file)
+  if (!ws) return []
+  const cwds = new Set()
+  const walk = (v) => {
+    if (Array.isArray(v)) { v.forEach(walk); return }
+    if (!isObj(v)) return
+    if (typeof v.cwd === 'string' && v.cwd.startsWith('/')) cwds.add(v.cwd)
+    Object.values(v).forEach(walk)
+  }
+  walk(ws)
+  return [...cwds]
+}
+
+if (mode === 'clean-hooks') {
+  process.stdout.write(String(cleanHooks(target, false)))
+} else if (mode === 'clean-codex') {
+  const r = cleanCodex(target, false)
+  process.stdout.write(`${r.removedHooks} ${r.removedTrust} ${r.rekeyedTrust}`)
+} else if (mode === 'list-projects') {
+  process.stdout.write(listProjects(target).join('\n'))
+} else {
+  process.exit(2)
+}
+JSEOF
+}
+
+# strip_blocks <file> — remove every nodeterm marker block; delete the file if only whitespace
+# remains (the installer created it in that case).
+strip_blocks() {
+  local f="$1" tmp
+  [ -f "$f" ] || return 0
+  tmp="$(mktemp)"
+  awk -v s1="$CC_START" -v e1="$CC_END" -v s2="$CL_START" -v e2="$CL_END" '
+    index($0, s1) || index($0, s2) { skip = 1 }
+    !skip { print }
+    index($0, e1) || index($0, e2) { skip = 0 }
+  ' "$f" > "$tmp"
+  if ! cmp -s "$f" "$tmp"; then
+    if [ -z "$(tr -d '[:space:]' < "$tmp")" ]; then
+      rm -f "$f"
+      ok "Removed $f (contained only nodeterm blocks)"
+    else
+      cat "$tmp" > "$f"
+      ok "Removed nodeterm blocks from $f"
+    fi
+  fi
+  rm -f "$tmp"
+}
+
+has_blocks() {
+  [ -f "$1" ] || return 1
+  grep -qF "$CC_START" "$1" 2>/dev/null || grep -qF "$CL_START" "$1" 2>/dev/null
+}
+
+# ================================ 1. PLAN =====================================================
+echo
+info "nodeterm uninstall — scanning this machine ($OS)…"
+echo
+
+FOUND_ANY=0
+
+# -- processes / services
+APP_PGREP="$APP_BUNDLE/Contents/MacOS"
+[ "$OS" != "Darwin" ] && APP_PGREP='/opt/nodeterm/nodeterm|nodeterm.*\.AppImage'
+if pgrep -f "$APP_PGREP" >/dev/null 2>&1; then
+  plan "Quit the running nodeterm app"; FOUND_ANY=1
+fi
+SYSTEMD_SCOPE=""
+if command -v systemctl >/dev/null 2>&1; then
+  if systemctl --user cat nodeterm-server.service >/dev/null 2>&1; then SYSTEMD_SCOPE="user"
+  elif systemctl cat nodeterm-server.service >/dev/null 2>&1; then SYSTEMD_SCOPE="system"; fi
+  if [ -n "$SYSTEMD_SCOPE" ]; then
+    plan "Stop + remove the Server Edition systemd units (nodeterm-server, nodeterm-server-update) [$SYSTEMD_SCOPE]"
+    FOUND_ANY=1
+  fi
+fi
+for sock in node-terminal nodeterm-rmt; do
+  if command -v tmux >/dev/null 2>&1 && tmux -L "$sock" list-sessions >/dev/null 2>&1; then
+    n="$(tmux -L "$sock" list-sessions 2>/dev/null | wc -l | tr -d ' ')"
+    plan "Kill the tmux server on socket '$sock' ($n session(s) — running processes in them will end):"
+    tmux -L "$sock" list-sessions -F '      #{session_name}  (#{session_windows} win, created #{t:session_created})' 2>/dev/null || true
+    FOUND_ANY=1
+  fi
+done
+if ls "$NT_HOME"/ssh-cm/*.sock >/dev/null 2>&1; then
+  plan "Close SSH ControlMaster connections ($(ls "$NT_HOME"/ssh-cm/*.sock 2>/dev/null | wc -l | tr -d ' ') socket(s) in ~/.nodeterm/ssh-cm)"
+  FOUND_ANY=1
+fi
+
+# -- integration in other tools' config
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+GEMINI_SETTINGS="$HOME/.gemini/settings.json"
+for f in "$CLAUDE_SETTINGS" "$GEMINI_SETTINGS"; do
+  if [ -f "$f" ] && grep -Eq "$HOOK_MARKERS" "$f" 2>/dev/null; then
+    plan "Remove nodeterm hook entries from $f (other hooks kept)"; FOUND_ANY=1
+  fi
+done
+if [ -f "$HOME/.codex/hooks.json" ] && grep -Eq "$HOOK_MARKERS" "$HOME/.codex/hooks.json" 2>/dev/null; then
+  plan "Remove nodeterm hook entries from ~/.codex/hooks.json + matching trust entries in ~/.codex/config.toml"
+  FOUND_ANY=1
+fi
+for d in "$HOME/.claude/skills/manage-nodeterm-canvas" "$HOME/.claude/skills/get-linked-context"; do
+  [ -d "$d" ] && { plan "Delete skill dir $d"; FOUND_ANY=1; }
+done
+for f in "$GROK_HOME/hooks/nodeterm-status.json" "$COPILOT_HOME/hooks/nodeterm-status.json"; do
+  [ -f "$f" ] && { plan "Delete $f"; FOUND_ANY=1; }
+done
+OPENCODE_PLUGIN="$OPENCODE_DIR/plugins/nodeterm-status.js"
+if [ -f "$OPENCODE_PLUGIN" ] && head -1 "$OPENCODE_PLUGIN" | grep -qF "$OPENCODE_PLUGIN_MARKER"; then
+  plan "Delete $OPENCODE_PLUGIN"; FOUND_ANY=1
+fi
+for f in "$HOME/.codex/AGENTS.md" "$HOME/.gemini/GEMINI.md" "$COPILOT_HOME/copilot-instructions.md" "$OPENCODE_DIR/AGENTS.md"; do
+  has_blocks "$f" && { plan "Remove nodeterm marker blocks from $f"; FOUND_ANY=1; }
+done
+
+# -- nodeterm-owned files and directories
+DIRS_TO_REMOVE=()
+add_dir() { [ -e "$1" ] && { DIRS_TO_REMOVE+=("$1"); plan "Delete $1"; FOUND_ANY=1; }; }
+add_dir "$NT_HOME"
+add_dir "$USER_DATA"
+if [ "$OS" = "Darwin" ]; then
+  add_dir "$HOME/Library/Caches/nodeterm"
+  add_dir "$HOME/Library/Caches/com.nodeterm.app"
+  add_dir "$HOME/Library/Caches/com.nodeterm.app.ShipIt"
+  add_dir "$HOME/Library/Application Support/Caches/nodeterm-updater"
+  add_dir "$HOME/Library/Preferences/com.nodeterm.app.plist"
+  add_dir "$HOME/Library/Saved Application State/com.nodeterm.app.savedState"
+  add_dir "$HOME/Library/HTTPStorages/com.nodeterm.app"
+  add_dir "$HOME/Library/Logs/nodeterm"
+else
+  add_dir "${XDG_CACHE_HOME:-$HOME/.cache}/nodeterm"
+fi
+add_dir "$SERVER_APP"
+add_dir "$SERVER_DATA"
+
+BREW_CASK=0
+if [ "$OS" = "Darwin" ]; then
+  if command -v brew >/dev/null 2>&1 && brew list --cask nodeterm >/dev/null 2>&1; then
+    BREW_CASK=1
+    plan "Uninstall the Homebrew cask 'nodeterm' (removes $APP_BUNDLE)"; FOUND_ANY=1
+  elif [ -d "$APP_BUNDLE" ]; then
+    plan "Delete $APP_BUNDLE"; FOUND_ANY=1
+  fi
+  if security find-generic-password -s "nodeterm Safe Storage" >/dev/null 2>&1; then
+    plan "Delete the 'nodeterm Safe Storage' Keychain entry"; FOUND_ANY=1
+  fi
+fi
+
+# -- per-project data: enumerate BEFORE the workspace index is deleted; never auto-deleted.
+PROJECT_DIRS=""
+for ws in "$USER_DATA/workspace.json" "$SERVER_DATA/workspace.json"; do
+  [ -f "$ws" ] || continue
+  cwds="$(jsedit list-projects "$ws" 2>/dev/null || true)"
+  while IFS= read -r cwd; do
+    [ -n "$cwd" ] && [ -d "$cwd/.nodeterm" ] && PROJECT_DIRS="$PROJECT_DIRS$cwd/.nodeterm
+"
+  done <<EOF
+$cwds
+EOF
+done
+PROJECT_DIRS="$(printf '%s' "$PROJECT_DIRS" | sort -u)"
+
+if [ "$FOUND_ANY" = 0 ]; then
+  ok "Nothing to do — no nodeterm traces found on this machine."
+  exit 0
+fi
+
+if [ -z "$NODE_BIN" ]; then
+  echo
+  warn "No JS runtime (node) found: hook entries inside ~/.claude/settings.json, ~/.gemini/settings.json and ~/.codex will be LEFT IN PLACE."
+  warn "They are harmless no-ops once the hook scripts are deleted (the command is self-guarded), but for a fully clean file install node and re-run."
+fi
+
+if [ "$DRY_RUN" = 1 ]; then
+  echo
+  if [ -n "$PROJECT_DIRS" ]; then
+    info "Would be KEPT (your project data — delete manually if you want):"
+    printf '%s\n' "$PROJECT_DIRS" | sed 's/^/      /'
+  fi
+  info "Dry run — nothing was changed."
+  exit 0
+fi
+
+echo
+if [ "$ASSUME_YES" != 1 ]; then
+  if [ ! -t 0 ]; then
+    warn "Not running interactively. Re-run with --yes to proceed (or --dry-run to inspect)."
+    exit 2
+  fi
+  printf 'Proceed with the actions above? Terminal sessions and their processes will be terminated. [y/N] '
+  read -r answer
+  case "$answer" in y|Y|yes|YES) ;; *) info "Aborted — nothing was changed."; exit 0 ;; esac
+fi
+
+# ================================ 2. STOP PROCESSES ===========================================
+echo
+if [ -n "$SYSTEMD_SCOPE" ]; then
+  if [ "$SYSTEMD_SCOPE" = "user" ]; then SCTL="systemctl --user"; UNIT_DIR="$HOME/.config/systemd/user"
+  else SCTL="systemctl"; UNIT_DIR="/etc/systemd/system"; fi
+  $SCTL disable --now nodeterm-server-update.timer >/dev/null 2>&1 || true
+  $SCTL disable --now nodeterm-server.service >/dev/null 2>&1 || true
+  rm -f "$UNIT_DIR/nodeterm-server.service" "$UNIT_DIR/nodeterm-server-update.service" \
+        "$UNIT_DIR/nodeterm-server-update.timer" 2>/dev/null || true
+  $SCTL daemon-reload >/dev/null 2>&1 || true
+  ok "Server Edition services stopped and removed"
+fi
+
+if pgrep -f "$APP_PGREP" >/dev/null 2>&1; then
+  [ "$OS" = "Darwin" ] && osascript -e 'quit app "nodeterm"' >/dev/null 2>&1
+  [ "$OS" != "Darwin" ] && pkill -TERM -f "$APP_PGREP" 2>/dev/null
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    pgrep -f "$APP_PGREP" >/dev/null 2>&1 || break
+    sleep 1
+  done
+  pkill -f "$APP_PGREP" 2>/dev/null || true
+  ok "nodeterm app quit"
+fi
+
+for sock in node-terminal nodeterm-rmt; do
+  if command -v tmux >/dev/null 2>&1 && tmux -L "$sock" list-sessions >/dev/null 2>&1; then
+    tmux -L "$sock" kill-server 2>/dev/null || true
+    ok "tmux server on '$sock' stopped"
+  fi
+done
+
+for cm in "$NT_HOME"/ssh-cm/*.sock; do
+  [ -e "$cm" ] || continue
+  ssh -o ControlPath="$cm" -O exit nodeterm-cm 2>/dev/null || true
+done
+pkill -f "ssh-agent.*\.nodeterm" 2>/dev/null || true
+
+# ================================ 3. REVERT AGENT INTEGRATION =================================
+for f in "$CLAUDE_SETTINGS" "$GEMINI_SETTINGS"; do
+  if [ -f "$f" ] && grep -Eq "$HOOK_MARKERS" "$f" 2>/dev/null; then
+    if n="$(jsedit clean-hooks "$f")" && [ "${n:-0}" -gt 0 ] 2>/dev/null; then
+      ok "Removed $n nodeterm hook entr(ies) from $f"
+    else
+      warn "Could not clean $f — left as is (entries are inert without the hook script)"
+    fi
+  fi
+done
+if [ -f "$HOME/.codex/hooks.json" ] && grep -Eq "$HOOK_MARKERS" "$HOME/.codex/hooks.json" 2>/dev/null; then
+  if r="$(jsedit clean-codex "$HOME/.codex")"; then
+    set -- $r
+    ok "Codex: removed ${1:-0} hook entr(ies), ${2:-0} trust entr(ies) (re-keyed ${3:-0}) in ~/.codex"
+  else
+    warn "Could not clean ~/.codex — left as is (entries are inert without the hook script)"
+  fi
+fi
+rm -rf "$HOME/.claude/skills/manage-nodeterm-canvas" "$HOME/.claude/skills/get-linked-context" 2>/dev/null || true
+rm -f "$GROK_HOME/hooks/nodeterm-status.json" "$COPILOT_HOME/hooks/nodeterm-status.json" 2>/dev/null || true
+if [ -f "$OPENCODE_PLUGIN" ] && head -1 "$OPENCODE_PLUGIN" | grep -qF "$OPENCODE_PLUGIN_MARKER"; then
+  rm -f "$OPENCODE_PLUGIN"
+fi
+for f in "$HOME/.codex/AGENTS.md" "$HOME/.gemini/GEMINI.md" "$COPILOT_HOME/copilot-instructions.md" "$OPENCODE_DIR/AGENTS.md"; do
+  strip_blocks "$f"
+done
+
+# ================================ 4. DELETE NODETERM'S OWN STATE ==============================
+for d in ${DIRS_TO_REMOVE[@]+"${DIRS_TO_REMOVE[@]}"}; do
+  rm -rf "$d" && ok "Deleted $d"
+done
+if [ "$OS" = "Darwin" ]; then
+  if [ "$BREW_CASK" = 1 ]; then
+    brew uninstall --cask nodeterm >/dev/null 2>&1 && ok "Homebrew cask uninstalled" \
+      || warn "brew uninstall --cask nodeterm failed — run it manually"
+  elif [ -d "$APP_BUNDLE" ]; then
+    rm -rf "$APP_BUNDLE" && ok "Deleted $APP_BUNDLE" \
+      || warn "Could not delete $APP_BUNDLE — drag it to the Trash"
+  fi
+  security delete-generic-password -s "nodeterm Safe Storage" >/dev/null 2>&1 || true
+  defaults delete com.nodeterm.app >/dev/null 2>&1 || true
+fi
+
+# ================================ 5. WHAT REMAINS =============================================
+echo
+ok "nodeterm has been removed from this machine."
+if [ -n "$PROJECT_DIRS" ]; then
+  echo
+  info "Kept (your project data — canvas layouts inside your repos; delete if you don't want them):"
+  printf '%s\n' "$PROJECT_DIRS" | sed 's/^/      /'
+  note "Each is a '.nodeterm' folder in a project you opened; safe to delete with rm -rf."
+fi
+echo
+note "Not covered by this script:"
+note "  • Remote SSH hosts you connected projects to may hold: ~/.nodeterm, hook/skill installs"
+note "    under the host's agent dirs, and tmux sessions on the 'nodeterm-rmt' socket."
+note "    On each host: tmux -L nodeterm-rmt kill-server; rm -rf ~/.nodeterm  (then re-run this"
+note "    script's agent-integration steps there if you used agents on that host)."
+note "  • The tmux/agent CLIs themselves (claude, codex, …) — nodeterm never owned them."
+if [ "$OS" != "Darwin" ]; then
+  if command -v dpkg >/dev/null 2>&1 && dpkg -s nodeterm >/dev/null 2>&1; then
+    note "  • The .deb package needs root to remove: sudo apt remove nodeterm"
+  fi
+  note "  • If you used the AppImage, delete the nodeterm-*.AppImage file you downloaded."
+fi


### PR DESCRIPTION
Closes #347.

## What

**`scripts/uninstall.sh`** — a single self-contained, curl-able script that removes every trace nodeterm leaves on a machine, in order:

1. **Plan first.** It inspects the machine and prints everything it found — running processes, live tmux sessions (named, with a warning that killing them ends the processes inside), files, and the config entries inside other tools' files. `--dry-run` stops here; interactive runs confirm before changing anything; piped runs require an explicit `--yes`.
2. **Stops processes cleanly**: the desktop app (AppleScript quit / SIGTERM with a grace period), the Server Edition systemd units + auto-update timer, the tmux servers on nodeterm's private sockets (`node-terminal` / `nodeterm-rmt` — the user's own default-socket tmux is untouched), and lingering SSH ControlMasters (`ssh -O exit` per `~/.nodeterm/ssh-cm/*.sock`).
3. **Reverts agent-CLI integration surgically**, keyed on the same markers the installers wrote, so the user's own hooks/credentials/settings are never touched:
   - `~/.claude/settings.json` / `~/.gemini/settings.json`: managed hook entries (marker: `agent-hooks` / legacy `claude-signals`) filtered out, everything else preserved.
   - `~/.codex/hooks.json` + `config.toml`: our entries removed **and** the matching `[hooks.state."…"]` trust blocks dropped; trust blocks of surviving user hooks whose indexes shifted are re-keyed (the trusted_hash covers content, not position), so user hooks keep firing.
   - Owned files deleted outright: the two `~/.claude/skills/` dirs, `~/.grok/hooks/nodeterm-status.json`, `~/.copilot/hooks/nodeterm-status.json`, the opencode plugin (first-line marker checked first).
   - `<!-- nodeterm:… -->` marker blocks stripped from `AGENTS.md` / `GEMINI.md` / `copilot-instructions.md`; the file is deleted only if nothing but our blocks remains.
4. **Deletes nodeterm's own state**: `~/.nodeterm`, the user-data dir, macOS caches/prefs/saved-state/logs, the `nodeterm Safe Storage` Keychain entry, `/Applications/nodeterm.app` (via `brew uninstall --cask` when installed that way), and the Server Edition checkout + data dir.
5. **Reports what it deliberately keeps**: the per-project `.nodeterm/` folders inside the user's repos (enumerated from the workspace index *before* it is deleted, printed with a manual hint — they may be committed/shared), plus per-host instructions for remote SSH hosts it cannot reach.

**`docs/uninstall.md`** — the full inventory of what nodeterm writes where (keyed to the code that writes it) and a feasibility note on the portable-install alternative the issue proposed: redirecting the Electron userData dir (+ `TMUX_TMPDIR`) into one folder is a cheap follow-up, but the agent integration is structurally non-portable — connecting to existing claude/codex installs *is* writes into their config dirs, and `~/.nodeterm/agent-hooks` is machine-stable on purpose (the per-instance path caused the silent hooks-dead-for-every-session field bug documented in `install-helper.ts`). So the uninstall script is needed regardless of a portable mode.

README gets a short "Trying it out?" section pointing at both.

## Notes

- JSON/TOML surgery runs on an embedded Node helper (`node` from PATH, falling back to the Server Edition's provisioned runtime). Without any JS runtime the entries are left with a warning — they are already self-neutralizing: the installed hook command is guarded (`if [ -r <script> ] … else cat >/dev/null`), so deleting `~/.nodeterm/agent-hooks` turns every entry into a silent no-op.
- `"tui": "fullscreen"` in `~/.claude/settings.json` is intentionally left: it is written only-if-absent, so an existing value may be the user's own and removal cannot tell.
- Tested against a fixture home with shimmed `tmux`/`systemctl`/`pgrep`/`ssh` (this box hosts live sessions): dry-run listing, full apply, marker-block stripping incl. block-only file deletion, codex trust re-keying, user-hook preservation, idempotent re-run ("Nothing to do"), and the non-interactive guard all verified. Not yet run on a real Mac — the macOS-only legs (osascript quit, Keychain, brew cask, Library paths) are best-effort `|| true` and worth one device pass.
- Deploy follow-up (outside this repo): serve the script at `https://nodeterm.dev/uninstall.sh` next to `install.sh` so the README one-liner can use the short URL too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)