### PR TITLE
Ship Windows as an unsigned beta on every version tag (#454)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,11 +179,80 @@ jobs:
             dist/*.deb
             dist/latest-linux.yml
 
-  # Flips the release to a published "latest" only when BOTH platform jobs uploaded their
-  # assets. Until then it stays a prerelease, so /releases/latest (the site + both update
+  # Windows build: UNSIGNED BETA (#454), on a plain GitHub runner. Publishes the NSIS
+  # installer + zip as assets on the same tag's GitHub Release — and NOTHING to the update
+  # feed: `dist:win` stamps the package `nodeTermUpdates=disabled` (see src/main/updater.ts),
+  # so the shipped app's updater is cleanly off — no latest.yml is uploaded anywhere, no 404
+  # polling in the field. Auto-update arrives with code signing; an unsigned auto-update is a
+  # trust downgrade. Users update by downloading the next installer.
+  #
+  # BEST-EFFORT by design: the `publish` promote gate below deliberately does NOT wait on
+  # this job, so a Windows failure never strands the mac+linux release as a prerelease. A
+  # failed run is rerun and uploads into the (possibly already published) release. Uploads
+  # use `gh release upload --clobber` (never softprops) so a late finish can't flip an
+  # already-promoted release back to prerelease by re-writing its fields.
+  release-win:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # postinstall patches node-pty and rebuilds node-pty + smart-whisper against Electron's
+      # ABI — the same install win-package-smoke.yml and the quality-windows CI job prove green.
+      - name: Install dependencies
+        run: npm ci
+
+      # make-icon + electron-vite build + electron-builder --win --x64 --publish never.
+      # Unsigned: no signing secrets exist for Windows yet; SmartScreen will warn.
+      - name: Build Windows packages (NSIS installer + zip, unsigned)
+        run: npm run dist:win
+
+      # The artifact names are the contract (same check as win-package-smoke.yml): a silent
+      # target/artifactName regression must fail here, before the upload step lies about it.
+      - name: Verify expected artifacts
+        shell: bash
+        run: |
+          ls -la dist
+          version=$(node -p "require('./package.json').version")
+          test -f "dist/nodeterm-Setup-${version}.exe" || { echo "::error::NSIS installer missing"; exit 1; }
+          ls dist/nodeterm-*-win.zip >/dev/null 2>&1 || { echo "::error::win zip missing"; exit 1; }
+
+      # Deliberately narrow globs: only the installer + zip. No *.yml (that would be the
+      # update-feed leg this job must not have) and no *.blockmap (differential updates are
+      # part of the same auto-update story that waits on signing).
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          # Another platform job may already have created the release for this tag; tolerate
+          # the race. Created as PRERELEASE for the same reason the mac job does it — a
+          # half-built release must never become "latest"; the `publish` job flips it.
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create "$tag" --repo "$GITHUB_REPOSITORY" --title "$tag" --verify-tag --prerelease --notes "" || true
+          n=1
+          until gh release upload "$tag" dist/nodeterm-Setup-*.exe dist/nodeterm-*-win.zip --clobber --repo "$GITHUB_REPOSITORY"; do
+            if [ "$n" -ge 5 ]; then
+              echo "::error::asset upload failed after $n attempts"
+              exit 1
+            fi
+            echo "::warning::asset upload attempt $n failed (transient network?); retrying in 30s…"
+            n=$((n + 1))
+            sleep 30
+          done
+
+  # Flips the release to a published "latest" only when BOTH the mac and linux jobs uploaded
+  # their assets. Until then it stays a prerelease, so /releases/latest (the site + both update
   # feeds) keeps serving the previous complete release — a mac-runner sleep or an upload
   # failure can no longer put a partial release in front of users. If one platform job
   # fails, fix/rerun it; this job then runs on the rerun and publishes.
+  # release-win is deliberately NOT in `needs`: the Windows asset is an unsigned beta with no
+  # update feed behind it, and its failure must never hold the mac+linux release hostage.
   publish:
     runs-on: ubuntu-latest
     needs: [release-mac, release-linux]

--- a/.github/workflows/win-package-smoke.yml
+++ b/.github/workflows/win-package-smoke.yml
@@ -7,8 +7,10 @@ name: Windows package smoke
 #
 # BUILD ONLY — this workflow must NEVER publish. `dist:win` passes `--publish never`, nothing
 # here uploads to the update feed or creates a release, and the produced installer is unsigned.
-# Windows is not a shippable target until the session-host phase merges; release wiring (signing,
-# latest.yml on nodeterm.dev/updates, a release.yml job) is a deliberate follow-up.
+# The session-host phase (#305) has merged and release.yml's `release-win` job now ships this
+# same build as an UNSIGNED BETA on every version tag (#454). Still deliberate follow-ups:
+# code signing, and — gated on it — the auto-update leg (latest.yml on nodeterm.dev/updates);
+# an unsigned auto-update is a trust downgrade, so the beta ships with its updater disabled.
 on:
   workflow_dispatch:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2236,20 +2236,30 @@ the same script hand-packs `build/icon.icns` (size-checked frames — issue #369
 zip, `--publish never`). Production release signing/notarization and the update-feed hosting are
 handled outside this repo.
 
-**Windows packaging is GROUNDWORK, not a shippable app** (extracted from external PR #276; a
-Windows build is unusable until the session-host phase merges). Deliberate decisions: the target
+**Windows ships as an UNSIGNED BETA** (extracted from external PR #276; the session-host phase
+#305 merged 2026-08-20, and the decision to release without signing is #454 — CI-green, but no
+real-device daily-use verification yet, and that is a stated risk, not an oversight). Deliberate
+decisions: the target
 is **NSIS via electron-builder** — the fork switched to Squirrel.Windows
 (`electron-builder-squirrel-windows` + an 800-line `windows-installer.mjs` wrapper + its own
 update feed), but our pipeline is electron-builder end-to-end and NSIS is built in, needs no
 extra dependency, and is what electron-updater's generic provider expects on Windows — so
 Squirrel was not adopted. Builds are **unsigned** (no Windows cert; electron-builder skips
-signing when no cert env is present). `bootstrap-windows.bat` (repo root) takes a fresh Windows
+signing when no cert env is present; SmartScreen warns on install). Release wiring is
+`release.yml`'s `release-win` job: on every version tag it uploads the NSIS installer + zip as
+GitHub Release assets — **best-effort by design** (the `publish` promote gate does not wait on
+it, so a Windows failure never strands the mac+linux release) and with **no update-feed leg**:
+`dist:win` stamps `nodeTermUpdates=disabled`, so the shipped app's updater is cleanly off (no
+latest.yml anywhere, no 404 polling; users update by downloading the next installer). Do not
+add `*.yml`/`*.blockmap` to that job's upload globs — that IS the auto-update leg, and it waits
+on signing. `bootstrap-windows.bat` (repo root) takes a fresh Windows
 machine to a built checkout: it verifies Node ≥ 20 / VS Build Tools C++ / Python 3 with exact
 winget hints (it never installs machine-wide tools itself, and refuses to run elevated) and runs
 `npm ci`. `.github/workflows/win-package-smoke.yml` is a **workflow_dispatch-only** packaging
-smoke on windows-latest — build only, never publishes. **Follow-ups, in order:** Windows
-auto-update wiring (electron-updater NSIS leg + `latest.yml` on the nodeterm.dev feed — blocked
-on signing: an unsigned auto-update is a downgrade in trust), a release.yml Windows job, and the
+smoke on windows-latest — build only, never publishes. **Follow-ups, in order:** code signing,
+then Windows auto-update wiring (electron-updater NSIS leg + `latest.yml` on the nodeterm.dev
+feed — blocked
+on signing: an unsigned auto-update is a downgrade in trust), and the
 fork's PE-identity polish (electron-builder leaves `OriginalFilename` empty; the fork's
 `resedit`-based afterSign hook fixes it — cosmetic for NSIS, load-bearing only for Squirrel).
 


### PR DESCRIPTION
## What

Adds a `release-win` job to `release.yml`: on every `v*` tag it builds the same unsigned NSIS installer + zip that `win-package-smoke.yml` already proves green on `windows-latest`, verifies the artifact names, and uploads them as assets on the tag's GitHub Release. Also retires the stale "Windows is not a shippable target until the session-host phase merges" comment in the smoke workflow (#305 merged 20 Aug) and updates CLAUDE.md's Windows packaging section to describe the new state.

## Deliberate boundaries

- **Best-effort:** the `publish` promote gate does **not** wait on `release-win` — a Windows failure must never strand the mac+linux release as a prerelease. Uploads use `gh release upload --clobber` (not softprops), so a Windows job that finishes after promotion cannot flip the release back to prerelease by rewriting its fields.
- **No update feed:** only the `.exe` and win `.zip` are uploaded — no `latest.yml`, no blockmaps. `dist:win` already stamps `nodeTermUpdates=disabled`, so the shipped app's updater is cleanly off (no 404 polling in the field; a manual check answers "up to date"). The auto-update leg waits on code signing — an unsigned auto-update is a trust downgrade.
- **Unsigned, known risk:** SmartScreen will warn on install. CI proves the suite + packaging, not daily use on a real machine; shipping as a labeled beta and collecting field reports is the accepted trade (decision context in #454).

## Verification

- Both workflow files parse (yaml.safe_load; jobs: release-mac / release-linux / release-win / publish).
- The build + artifact-name check is byte-for-byte the smoke workflow's, which has run green on windows-latest.
- No change to the mac/linux jobs or the promote gate's `needs`.

Closes nothing — #454 stays open as the tracking issue for signing + auto-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)