### PR TITLE
fix(ssh): resolve remote tmux beyond the exec channel's PATH, degrade readably when it is missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,18 @@ interferes; status bar off, **mouse on**, 50k history, `set-clipboard on` + `ter
 sessions survive when no client is attached. `src/shared/ssh.ts`'s `remoteTmuxConf` is the same
 config for an SSH project's remote tmux.
 
+**Every REMOTE tmux invocation starts with `remoteTmuxPathPrologue()`** (`shared/ssh.ts` — PATH
+**append**: `/opt/homebrew/bin`, `/usr/local/bin`, `/opt/local/bin`, `$HOME/.local/bin`): an ssh
+exec channel gets a non-login shell, and on a macOS host Homebrew's `shellenv` lives in
+`~/.zprofile`, so a host whose own terminal runs tmux fine answered
+`zsh:1: command not found: tmux` to every command of ours (issue #449 — the same class as the
+remote claude probe's login-shell + PATH fix). Append, never prepend: a PATH that already resolves
+tmux keeps exactly that binary, so nothing re-pairs a long-lived tmux server with a different
+client build. When tmux is genuinely absent the interactive spawn (`tmuxOrExplain`,
+`control-master.ts`) prints what is missing, how to install it and what a tmux-less remote loses,
+then degrades to a plain login shell — mirroring the local plain-shell fallback; the raw
+`command not found` line must never be the user-facing error again.
+
 **tmux owns the mouse — scrolling, selection, and the alternate screen are all its job.** This is
 the native behavior, and it is deliberate:
 - **The wheel scrolls tmux's own history** (`history-limit`), not the emulator's buffer.

--- a/src/core/remote-ssh/control-master.injection.test.ts
+++ b/src/core/remote-ssh/control-master.injection.test.ts
@@ -7,6 +7,7 @@ import {
 } from './control-master'
 import { PANE_OWNER_FMT } from '../agents/pane-owner'
 import { accountTmuxEnvArgs } from '../claude-accounts-core'
+import { remoteTmuxPathPrologue } from '../../shared/ssh'
 
 /**
  * SECURITY REGRESSION TEST — remote command injection through a node id.
@@ -105,6 +106,32 @@ const PAYLOAD =
 const HOSTILE_CWD = '/srv/app;id;#'
 const HOSTILE_PROGRAM_ARGS = ['--resume', 'sess;id;#']
 
+/**
+ * The shell structure a line carries, as one comparable string. The interactive builder now
+ * DELIBERATELY emits structure of its own — the PATH-append prologue and the tmux-missing
+ * `if/else` fallback (issue #449) — so "zero unquoted metacharacters" is no longer the invariant.
+ * The invariant that survives is stronger where it matters: the structure is CONSTANT — byte-for-
+ * byte identical whatever the attacker-controlled values are. A payload that broke out of its
+ * quotes (or a replacement-pattern splice that inverted quote parity downstream) changes the
+ * structure and fails the comparison, exactly as `toEqual([])` failed before.
+ */
+const structureOf = (line: string): string => shellParse(line).unquotedMeta.join('')
+
+/** A benign twin of the pty-args call: same shape, harmless values. */
+const benignPtyStructure = (withEnv: boolean, program?: string, programArgs?: string[]): string =>
+  structureOf(
+    remoteTmuxPtyArgs(
+      conn,
+      '/s.sock',
+      'nt-n1',
+      '/home/u',
+      program,
+      programArgs,
+      withEnv ? remoteHookEnvArgs('/home/u/.nodeterm/hook-endpoint-p1.env', 'n1', '1', 'claude') : [],
+      withEnv ? '/home/u/.nodeterm/tmux.conf' : undefined
+    ).at(-1) as string
+  )
+
 describe('remoteTmuxPtyArgs: an attacker-controlled node id is DATA, never command structure', () => {
   it('the parser itself sees structure in an UNQUOTED payload (guards the assertion)', () => {
     // Without this the test could pass because the parser is blind rather than because the code
@@ -125,17 +152,22 @@ describe('remoteTmuxPtyArgs: an attacker-controlled node id is DATA, never comma
       '/home/u/.nodeterm/tmux.conf'
     )
     const cmd = args[args.length - 1]
-    const { argv, unquotedMeta } = shellParse(cmd)
-    // (a) nothing in the line is command structure any more.
-    expect(unquotedMeta).toEqual([])
+    const { argv } = shellParse(cmd)
+    // (a) the payload contributed NO command structure: the line's structure is byte-identical to
+    // a benign twin's (the constant prologue + fallback structure the builder itself emits).
+    expect(structureOf(cmd)).toBe(
+      benignPtyStructure(true, 'claude', ['--resume', 'sess-benign'])
+    )
     // (b) the payload is ONE argument, verbatim — tmux gets it as an env value, sh never sees it.
     expect(argv).toContain(`NODETERM_NODE_ID=${PAYLOAD}`)
     // (c) the region AFTER the splice is intact too: a replacement-pattern escape (`$'`) would
     // have dragged these inside the quotes and turned their `;` into command structure.
     expect(argv).toContain(HOSTILE_CWD)
     expect(argv).toContain('sess;id;#')
-    // and the command is still exactly one tmux invocation with the expected shape.
-    expect(argv.slice(0, 3)).toEqual(['tmux', '-L', 'nodeterm-rmt'])
+    // and the command still carries exactly one tmux invocation with the expected shape (the
+    // PATH prologue + tmux-missing fallback now precede it, so the head is indexOf, not slice).
+    const t = argv.lastIndexOf('tmux') // the guard's `command -v tmux` also carries the word
+    expect(argv.slice(t, t + 3)).toEqual(['tmux', '-L', 'nodeterm-rmt'])
     expect(argv.filter((a) => a === 'new-session')).toHaveLength(1)
     expect(argv).toContain('nt-n1')
   })
@@ -153,8 +185,9 @@ describe('remoteTmuxPtyArgs: an attacker-controlled node id is DATA, never comma
       remoteHookEnvArgs('/home/u/.nodeterm/hook-endpoint-p1.env', 'term-mabc-3', '1', "claude$'"),
       '/home/u/.nodeterm/tmux.conf'
     )
-    const { argv, unquotedMeta } = shellParse(args[args.length - 1])
-    expect(unquotedMeta).toEqual([])
+    const line = args[args.length - 1]
+    const { argv } = shellParse(line)
+    expect(structureOf(line)).toBe(benignPtyStructure(true))
     expect(argv).toContain("NODETERM_AGENT_ID=claude$'")
     expect(argv).toContain(HOSTILE_CWD)
   })
@@ -164,8 +197,15 @@ describe('remoteTmuxPtyArgs: an attacker-controlled node id is DATA, never comma
     const args = remoteTmuxPtyArgs(conn, '/s.sock', 'nt-n1', '/home/u', undefined, undefined, [
       ...accountTmuxEnvArgs('/home/u/.nodeterm/claude-accounts/a;id;b')
     ])
-    const { argv, unquotedMeta } = shellParse(args[args.length - 1])
-    expect(unquotedMeta).toEqual([])
+    const line = args[args.length - 1]
+    const { argv } = shellParse(line)
+    expect(structureOf(line)).toBe(
+      structureOf(
+        remoteTmuxPtyArgs(conn, '/s.sock', 'nt-n1', '/home/u', undefined, undefined, [
+          ...accountTmuxEnvArgs('/home/u/.nodeterm/claude-accounts/benign')
+        ]).at(-1) as string
+      )
+    )
     expect(argv).toContain('CLAUDE_CONFIG_DIR=/home/u/.nodeterm/claude-accounts/a;id;b')
   })
 
@@ -233,9 +273,14 @@ describe('remoteForegroundArgvArgs: a tty the remote host reported is DATA, neve
   })
 
   it('the tmux half sends the format to the REMOTE tmux verbatim, on the remote socket', () => {
-    const { argv, unquotedMeta } = shellParse(
-      remotePaneOwnerArgs(conn, '/s.sock', 'nt-n1').at(-1) as string
-    )
+    const line = remotePaneOwnerArgs(conn, '/s.sock', 'nt-n1').at(-1) as string
+    // The constant PATH prologue (issue #449) is the ONLY structure the line may carry: it is
+    // authored here (never attacker data), quote-free (cannot flip parity of what follows), and
+    // the remainder after it must still parse structure-free.
+    const prologue = remoteTmuxPathPrologue()
+    expect(line.startsWith(prologue)).toBe(true)
+    expect(prologue).not.toContain("'")
+    const { argv, unquotedMeta } = shellParse(line.slice(prologue.length))
     expect(unquotedMeta).toEqual([])
     expect(argv.slice(0, 3)).toEqual(['tmux', '-L', 'nodeterm-rmt'])
     // The CONSTANT, not a copy of it. A literal here was a second spelling of the format that

--- a/src/core/remote-ssh/control-master.realsh.test.ts
+++ b/src/core/remote-ssh/control-master.realsh.test.ts
@@ -191,3 +191,54 @@ describe('REAL sh: the four vectors that survived the first fix', () => {
     expect(argv).toContain('sess;id;#')
   })
 })
+
+/**
+ * Issue #449 — `zsh:1: command not found: tmux` on an SSH host whose exec-channel PATH misses the
+ * tmux install dir (Homebrew on macOS being the field report). Two behaviors, both executed under
+ * a real /bin/sh because both are generated shell:
+ *  - the PATH append finds a tmux that only lives in one of the known dirs;
+ *  - a host with NO tmux prints a readable explanation and degrades to a plain login shell,
+ *    instead of dying with the shell's one-line error.
+ */
+describe('REAL sh: remote tmux PATH resolution + graceful degrade (issue #449)', () => {
+  const runRaw = (cmd: string, env: Record<string, string>): string => {
+    try {
+      return execFileSync('/bin/sh', ['-c', cmd], { env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    } catch (e) {
+      return String((e as { stdout?: string }).stdout ?? '')
+    }
+  }
+
+  // PATH must hold NO tmux at all for these — the dev/CI box's own /usr/bin/tmux would win the
+  // `command -v` and run for real ("open terminal failed"). An empty dir is the only safe PATH;
+  // everything the guard needs (command, printf, cd, exec) is an sh builtin.
+  const emptyPath = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'ntsh-nopath-'))
+
+  it('finds a tmux that lives only in an appended dir ($HOME/.local/bin)', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ntsh-home-'))
+    const local = path.join(home, '.local', 'bin')
+    fs.mkdirSync(local, { recursive: true })
+    fs.copyFileSync(path.join(binDir, 'tmux'), path.join(local, 'tmux'))
+    fs.chmodSync(path.join(local, 'tmux'), 0o755)
+    const cmd = remoteTmuxPtyArgs(conn, '/s.sock', 'nt-n1', '/home/u').slice(-1)[0]
+    // PATH deliberately has NO tmux — only the $HOME/.local/bin append can resolve it.
+    const out = runRaw(cmd, { PATH: emptyPath(), HOME: home })
+    const argv = out.split('\0').slice(0, -1)
+    expect(argv.slice(0, 2)).toEqual(['-L', 'nodeterm-rmt'])
+    expect(argv).toContain('new-session')
+  })
+
+  it('a host with NO tmux prints the explanation and execs a plain login shell', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ntsh-home-'))
+    const shell = path.join(home, 'shell-stub')
+    fs.writeFileSync(shell, `#!/bin/sh\nprintf 'SHELL_STUB %s\\n' "$@"\n`, { mode: 0o755 })
+    const cmd = remoteTmuxPtyArgs(conn, '/s.sock', 'nt-n1', '/home/u').slice(-1)[0]
+    const out = runRaw(cmd, { PATH: emptyPath(), HOME: home, SHELL: shell })
+    // The message names the fact and the fix — never the raw `command not found: tmux` line.
+    expect(out).toContain('nodeterm: tmux was not found on this host.')
+    expect(out).toContain('Install tmux on the host')
+    expect(out).toContain('will NOT persist')
+    // …and the pane still gets a usable login shell instead of closing.
+    expect(out).toContain('SHELL_STUB -l')
+  })
+})

--- a/src/core/remote-ssh/control-master.test.ts
+++ b/src/core/remote-ssh/control-master.test.ts
@@ -32,6 +32,10 @@ import {
   scpDownArgs,
   remoteScpPath
 } from './control-master'
+import { remoteTmuxPathPrologue } from '../../shared/ssh'
+
+/** The PATH-append prologue every remote tmux line now starts with (issue #449). */
+const TP = remoteTmuxPathPrologue()
 
 const conn = { host: 'h.example.com', user: 'deploy', port: 2222, identityFile: '/k/id' }
 
@@ -174,7 +178,7 @@ describe('remoteTmuxHasSessionArgs', () => {
     expect(remoteTmuxHasSessionArgs(conn, '/s.sock', 'nt-x')).toEqual([
       ...childPrefix,
       'deploy@h.example.com',
-      `tmux -L ${RMT_TMUX_SOCKET} has-session -t nt-x`
+      `${TP}tmux -L ${RMT_TMUX_SOCKET} has-session -t nt-x`
     ])
   })
 })
@@ -189,7 +193,7 @@ describe('remoteTmuxPasteArgs', () => {
     expect(remoteTmuxPasteArgs(conn, '/s.sock', 'nt-x', BUF, true)).toEqual([
       ...childPrefix,
       'deploy@h.example.com',
-      `${TMUX} load-buffer -b ${BUF} - ';' ` +
+      `${TP}${TMUX} load-buffer -b ${BUF} - ';' ` +
         `if-shell -F -t nt-x '#{pane_in_mode}' 'send-keys -t nt-x -X cancel' ';' ` +
         `paste-buffer -d -p -r -b ${BUF} -t nt-x ';' send-keys -t nt-x Enter`
     ])
@@ -250,7 +254,7 @@ describe('remoteTmuxEnterArgs', () => {
     expect(remoteTmuxEnterArgs(conn, '/s.sock', 'nt-x')).toEqual([
       ...childPrefix,
       'deploy@h.example.com',
-      `tmux -L ${RMT_TMUX_SOCKET} send-keys -t nt-x Enter`
+      `${TP}tmux -L ${RMT_TMUX_SOCKET} send-keys -t nt-x Enter`
     ])
   })
 })
@@ -258,11 +262,11 @@ describe('remoteTmuxEnterArgs', () => {
 describe('remoteCapturePaneArgs', () => {
   it('captures the whole scrollback (-S -) when full', () => {
     const args = remoteCapturePaneArgs(conn, '/s.sock', 'nt-x', true)
-    expect(args[args.length - 1]).toBe(`tmux -L ${RMT_TMUX_SOCKET} capture-pane -p -e -t nt-x -S -`)
+    expect(args[args.length - 1]).toBe(`${TP}tmux -L ${RMT_TMUX_SOCKET} capture-pane -p -e -t nt-x -S -`)
   })
   it('captures the recent ~200 lines (-S -200) when not full', () => {
     const args = remoteCapturePaneArgs(conn, '/s.sock', 'nt-x', false)
-    expect(args[args.length - 1]).toBe(`tmux -L ${RMT_TMUX_SOCKET} capture-pane -p -e -t nt-x -S -200`)
+    expect(args[args.length - 1]).toBe(`${TP}tmux -L ${RMT_TMUX_SOCKET} capture-pane -p -e -t nt-x -S -200`)
   })
 })
 
@@ -270,7 +274,7 @@ describe('remotePaneCommandArgs', () => {
   it('asks the remote tmux for the pane_current_command of the session', () => {
     const args = remotePaneCommandArgs(conn, '/s.sock', 'nt-x')
     expect(args[args.length - 1]).toBe(
-      `tmux -L ${RMT_TMUX_SOCKET} display-message -p -t nt-x '#{pane_current_command}'`
+      `${TP}tmux -L ${RMT_TMUX_SOCKET} display-message -p -t nt-x '#{pane_current_command}'`
     )
   })
 })
@@ -279,7 +283,7 @@ describe('remote foreground process termination', () => {
   it('reads pane pid + command through the existing ControlMaster', () => {
     const args = remotePaneProcessArgs(conn, '/s.sock', 'nt-x')
     expect(args[args.length - 1]).toBe(
-      `tmux -L ${RMT_TMUX_SOCKET} display-message -p -t nt-x '#{pane_pid}|#{pane_current_command}'`
+      `${TP}tmux -L ${RMT_TMUX_SOCKET} display-message -p -t nt-x '#{pane_pid}|#{pane_current_command}'`
     )
   })
 
@@ -565,10 +569,10 @@ describe('killing a session by name (both sockets, exact target)', () => {
 
   it('keeps the remote default on the ssh socket, and overrides it explicitly', () => {
     expect(remoteTmuxKillArgs(conn, '/s.sock', 'nt-x').at(-1)).toBe(
-      `tmux -L ${RMT_TMUX_SOCKET} kill-session -t =nt-x`
+      `${TP}tmux -L ${RMT_TMUX_SOCKET} kill-session -t =nt-x`
     )
     expect(remoteTmuxKillArgs(conn, '/s.sock', 'nt-x', 'node-terminal').at(-1)).toBe(
-      'tmux -L node-terminal kill-session -t =nt-x'
+      `${TP}tmux -L node-terminal kill-session -t =nt-x`
     )
   })
 
@@ -576,8 +580,8 @@ describe('killing a session by name (both sockets, exact target)', () => {
     const runs = remoteTmuxKillEverySocketArgs(conn, '/s.sock', 'nt-x')
     expect(runs).toHaveLength(2)
     expect(runs.map((r) => r.at(-1)).sort()).toEqual([
-      'tmux -L node-terminal kill-session -t =nt-x',
-      `tmux -L ${RMT_TMUX_SOCKET} kill-session -t =nt-x`
+      `${TP}tmux -L node-terminal kill-session -t =nt-x`,
+      `${TP}tmux -L ${RMT_TMUX_SOCKET} kill-session -t =nt-x`
     ])
     // Each is a complete child-ssh argv, not a bare command.
     for (const r of runs) expect(r.slice(0, childPrefix.length)).toEqual(childPrefix)
@@ -608,13 +612,13 @@ describe('remoteFramedDelivery', () => {
     expect(plan.args).toEqual([
       ...childPrefix,
       'deploy@h.example.com',
-      `${TMUX} load-buffer -b ${buf} - ';' ` +
+      `${TP}${TMUX} load-buffer -b ${buf} - ';' ` +
         `if-shell -F -t nt-x '#{pane_in_mode}' 'send-keys -t nt-x -X cancel' ';' ` +
         `paste-buffer -d -r -b ${buf} -t nt-x`
     ])
     expect(line).not.toContain('-p -r')
     expect(line).not.toContain('Enter')
-    expect(plan.cleanup?.slice(-1)[0]).toBe(`${TMUX} delete-buffer -b ${buf}`)
+    expect(plan.cleanup?.slice(-1)[0]).toBe(`${TP}${TMUX} delete-buffer -b ${buf}`)
   })
 
   it('refuses a payload that is not a well-formed, pre-sanitized frame', () => {

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -3,7 +3,13 @@
 import os from 'os'
 import path from 'path'
 import { createHash } from 'crypto'
-import { posixQuote, quoteRemotePath, remoteTmuxCommand, type SshConnection } from '../../shared/ssh'
+import {
+  posixQuote,
+  quoteRemotePath,
+  remoteTmuxCommand,
+  remoteTmuxPathPrologue,
+  type SshConnection
+} from '../../shared/ssh'
 import {
   TMUX_SOCKET,
   assertFramedPayload,
@@ -19,6 +25,17 @@ import { PANE_OWNER_FMT, foregroundArgvArgs } from '../agents/pane-owner'
 
 /** Dedicated remote tmux socket so an SSH project never collides with the user's own tmux. */
 export const RMT_TMUX_SOCKET = 'nodeterm-rmt'
+
+/**
+ * Every remote command that invokes `tmux` goes through this: the PATH-append prologue
+ * (`remoteTmuxPathPrologue`, issue #449) plus the command. Without it a bare `tmux` dies with
+ * `command not found` on any host whose ssh exec-channel PATH misses the install dir — most
+ * visibly macOS with Homebrew's tmux in `/opt/homebrew/bin`. The prologue is one assignment, so
+ * the command's own exit code (what `probeSaysAbsent` and every caller reads) is unchanged.
+ */
+function tmuxCmd(body: string): string {
+  return `${remoteTmuxPathPrologue()}${body}`
+}
 
 /**
  * Per-project ControlMaster socket path. Deliberately SHORT and space-free. The macOS userData dir
@@ -211,7 +228,7 @@ export function exitMasterArgs(conn: SshConnection, controlPath: string): string
   return ['-O', 'exit', '-o', `ControlPath=${controlPath}`, ...portArgs(conn), target(conn)]
 }
 export function remoteTmuxHasSessionArgs(conn: SshConnection, controlPath: string, sessionId: string): string[] {
-  return childArgs(conn, controlPath, `tmux -L ${RMT_TMUX_SOCKET} has-session -t ${sessionId}`)
+  return childArgs(conn, controlPath, tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} has-session -t ${sessionId}`))
 }
 /**
  * Every nodeterm tmux session on the host, by name.
@@ -227,7 +244,7 @@ export function remoteListSessionsArgs(conn: SshConnection, controlPath: string)
   return childArgs(
     conn,
     controlPath,
-    `tmux -L ${RMT_TMUX_SOCKET} list-sessions -F '#{session_name}'`
+    tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} list-sessions -F '#{session_name}'`)
   )
 }
 
@@ -286,7 +303,7 @@ export function remoteTmuxPasteArgs(
     `if-shell -F -t ${sessionId} '#{pane_in_mode}' 'send-keys -t ${sessionId} -X cancel' ';' ` +
     `paste-buffer -d -p -r -b ${buffer} -t ${sessionId}`
   if (enter) cmd += ` ';' send-keys -t ${sessionId} Enter`
-  return childArgs(conn, controlPath, cmd)
+  return childArgs(conn, controlPath, tmuxCmd(cmd))
 }
 
 /**
@@ -307,7 +324,7 @@ export function remoteTmuxFramedPasteArgs(
     `${tmux} load-buffer -b ${buffer} - ';' ` +
     `if-shell -F -t ${sessionId} '#{pane_in_mode}' 'send-keys -t ${sessionId} -X cancel' ';' ` +
     `paste-buffer -d -r -b ${buffer} -t ${sessionId}`
-  return childArgs(conn, controlPath, cmd)
+  return childArgs(conn, controlPath, tmuxCmd(cmd))
 }
 
 /**
@@ -354,7 +371,7 @@ export function remoteTmuxEnterArgs(
   sessionId: string
 ): string[] {
   assertPasteTarget(sessionId)
-  return childArgs(conn, controlPath, `tmux -L ${RMT_TMUX_SOCKET} send-keys -t ${sessionId} Enter`)
+  return childArgs(conn, controlPath, tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} send-keys -t ${sessionId} Enter`))
 }
 
 /** `delete-buffer` on the REMOTE server — the sweep for a remote paste that never ran. */
@@ -364,7 +381,7 @@ export function remoteDeleteBufferArgs(
   buffer: string
 ): string[] {
   assertPasteBuffer(buffer)
-  return childArgs(conn, controlPath, `tmux -L ${RMT_TMUX_SOCKET} delete-buffer -b ${buffer}`)
+  return childArgs(conn, controlPath, tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} delete-buffer -b ${buffer}`))
 }
 
 /**
@@ -468,7 +485,7 @@ export function remoteTmuxKillArgs(
   sessionId: string,
   socket: string = RMT_TMUX_SOCKET
 ): string[] {
-  return childArgs(conn, controlPath, `tmux -L ${socket} kill-session -t ${exactTarget(sessionId)}`)
+  return childArgs(conn, controlPath, tmuxCmd(`tmux -L ${socket} kill-session -t ${exactTarget(sessionId)}`))
 }
 
 /**
@@ -492,7 +509,7 @@ export function remoteCapturePaneArgs(conn: SshConnection, controlPath: string, 
   return childArgs(
     conn,
     controlPath,
-    `tmux -L ${RMT_TMUX_SOCKET} capture-pane -p -e -t ${sessionId} -S ${full ? '-' : '-200'}`
+    tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} capture-pane -p -e -t ${sessionId} -S ${full ? '-' : '-200'}`)
   )
 }
 /**
@@ -505,7 +522,7 @@ export function remotePaneCommandArgs(conn: SshConnection, controlPath: string, 
   return childArgs(
     conn,
     controlPath,
-    `tmux -L ${RMT_TMUX_SOCKET} display-message -p -t ${sessionId} '#{pane_current_command}'`
+    tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} display-message -p -t ${sessionId} '#{pane_current_command}'`)
   )
 }
 
@@ -518,7 +535,7 @@ export function remotePaneProcessArgs(
   return childArgs(
     conn,
     controlPath,
-    `tmux -L ${RMT_TMUX_SOCKET} display-message -p -t ${sessionId} '#{pane_pid}|#{pane_current_command}'`
+    tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} display-message -p -t ${sessionId} '#{pane_pid}|#{pane_current_command}'`)
   )
 }
 
@@ -553,7 +570,7 @@ export function remotePaneOwnerArgs(conn: SshConnection, controlPath: string, se
   return childArgs(
     conn,
     controlPath,
-    `tmux -L ${RMT_TMUX_SOCKET} display-message -p -t ${sessionId} '${PANE_OWNER_FMT}'`
+    tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} display-message -p -t ${sessionId} '${PANE_OWNER_FMT}'`)
   )
 }
 
@@ -594,11 +611,11 @@ export function remotePaneCursorArgs(
   return childArgs(
     conn,
     controlPath,
-    `tmux -L ${RMT_TMUX_SOCKET} display-message -p -t ${sessionId} '#{cursor_x} #{cursor_y} #{cursor_flag}'`
+    tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} display-message -p -t ${sessionId} '#{cursor_x} #{cursor_y} #{cursor_flag}'`)
   )
 }
 export function tmuxProbeArgs(conn: SshConnection, controlPath: string): string[] {
-  return childArgs(conn, controlPath, 'command -v tmux')
+  return childArgs(conn, controlPath, tmuxCmd('command -v tmux'))
 }
 export function listDirArgs(conn: SshConnection, controlPath: string, path: string): string[] {
   return childArgs(conn, controlPath, `ls -1Ap ${quoteRemotePath(path)}`)
@@ -760,8 +777,42 @@ export function remoteTmuxPtyArgs(
     // was remote code execution EVEN WITH the posixQuote above. A function replacement is never
     // pattern-expanded, so the quoted bytes land verbatim. See control-master.injection.test.ts.
     cmd = cmd.replace('new-session -A ', () => `new-session -A ${extraEnv.map(posixQuote).join(' ')} `)
+  cmd = tmuxOrExplain(cmd, remoteCwd)
   if (sessionEnv) cmd = `${remoteSessionEnvPrologue(sessionEnv, confPath)}${cmd}`
-  return ['-t', ...childArgs(conn, controlPath, cmd)]
+  // The PATH prologue goes at the very FRONT of the composed line: the session-env prologue's own
+  // tmux calls (start-server / show-options) and the `command -v tmux` guard must resolve the
+  // binary the same way new-session does.
+  return ['-t', ...childArgs(conn, controlPath, tmuxCmd(cmd))]
+}
+
+/** What a tmux-less remote loses, told to the user IN the pane. English + apostrophe-free: each
+ *  line is embedded as one single-quoted printf argument in the remote shell line. */
+const REMOTE_TMUX_MISSING_LINES = [
+  'nodeterm: tmux was not found on this host.',
+  'nodeterm runs remote terminals inside tmux so they survive disconnects, app restarts and project switches.',
+  'Install tmux on the host (brew install tmux / apt install tmux / dnf install tmux) and reopen this terminal.',
+  'Starting a plain shell instead - it will NOT persist when this terminal closes.'
+]
+
+/**
+ * Wrap the interactive remote tmux command so a host WITHOUT tmux gets a readable explanation and
+ * a usable plain login shell, instead of the raw `zsh:1: command not found: tmux` that closed the
+ * pane immediately (issue #449). Runs after the PATH widening, so it only fires when tmux is
+ * genuinely absent from PATH + every known install dir. The fallback shell is the honest local
+ * analogue: `PtyManager` falls back to a plain shell when the LOCAL tmux is unavailable too.
+ * `cd` first (best-effort) so the shell at least opens in the node's cwd; `${SHELL:-sh}` because
+ * an exec channel without SHELL set should still produce a prompt rather than exec ''.
+ */
+function tmuxOrExplain(tmuxCommand: string, remoteCwd: string): string {
+  const msg = REMOTE_TMUX_MISSING_LINES.map(posixQuote).join(' ')
+  // The `;` separators are SPACE-PADDED on purpose: the tmux command ends in a single-quoted
+  // token, and `'…';` glues the separator onto that token in the injection tests' shell parser
+  // (a real sh splits them, but the padded form is equally valid and keeps the parse exact).
+  return (
+    `if command -v tmux >/dev/null 2>&1 ; then ${tmuxCommand} ; else ` +
+    `printf '%s\\n' '' ${msg} '' ; cd ${quoteRemotePath(remoteCwd)} 2>/dev/null ; ` +
+    `exec "\${SHELL:-sh}" -l ; fi`
+  )
 }
 
 /** Credentials for a remote session, delivered WITHOUT argv: a 0600 file (staged over the

--- a/src/core/session-memory-remote.ts
+++ b/src/core/session-memory-remote.ts
@@ -17,6 +17,7 @@ import {
   type SessionMemoryReport
 } from './session-memory'
 import { TMUX_SOCKET } from './tmux-naming'
+import { REMOTE_TMUX_PATH_DIRS } from '../shared/ssh'
 import { RMT_TMUX_SOCKET } from './remote-ssh/control-master'
 
 const MEM = '##MEM'
@@ -62,6 +63,10 @@ export function remoteSessionMemoryCommand(): string {
       `echo "${SOCKRC} $?"`
     ].join('\n')
   return [
+    // tmux may live off the exec channel's PATH (Homebrew on macOS — issue #449, same append as
+    // remoteTmuxPathPrologue). Without this every socket answers 127 and the sweep reports
+    // ok:false ("Could not measure") on a host whose sessions are perfectly readable.
+    `PATH="$PATH:${REMOTE_TMUX_PATH_DIRS}"`,
     `echo '${MEM}'`,
     `cat /proc/meminfo 2>/dev/null | grep -E '^(MemAvailable|MemTotal):' 2>/dev/null || true`,
     `echo '${PANES}'`,

--- a/src/main/remote-ssh/ssh-project.killSessions.test.ts
+++ b/src/main/remote-ssh/ssh-project.killSessions.test.ts
@@ -11,6 +11,10 @@ vi.mock('electron', () => ({
 }))
 
 import { SshProjectManager } from './ssh-project'
+import { remoteTmuxPathPrologue } from '../../shared/ssh'
+
+/** The PATH-append prologue every remote tmux line now starts with (issue #449). */
+const TP = remoteTmuxPathPrologue()
 
 const conn = { host: 'h.example.com', user: 'deploy', port: 22 }
 
@@ -44,8 +48,8 @@ describe('SshProjectManager.killSessions', () => {
     const { mgr, runs } = managerWithConn()
     await mgr.killSessions('p1', ['abc'], { everySocket: true })
     expect(commands(runs)).toEqual([
-      'tmux -L node-terminal kill-session -t =nt-abc',
-      'tmux -L nodeterm-rmt kill-session -t =nt-abc'
+      `${TP}tmux -L node-terminal kill-session -t =nt-abc`,
+      `${TP}tmux -L nodeterm-rmt kill-session -t =nt-abc`
     ])
   })
 
@@ -54,13 +58,13 @@ describe('SshProjectManager.killSessions', () => {
     // that host belongs to a nodeterm running ON it, so a delete must not speculate there.
     const { mgr, runs } = managerWithConn()
     await mgr.killSessions('p1', ['abc'])
-    expect(commands(runs)).toEqual(['tmux -L nodeterm-rmt kill-session -t =nt-abc'])
+    expect(commands(runs)).toEqual([`${TP}tmux -L nodeterm-rmt kill-session -t =nt-abc`])
   })
 
   it('demands a literal true — the flag comes off the wire', async () => {
     const { mgr, runs } = managerWithConn()
     await mgr.killSessions('p1', ['abc'], { everySocket: 'yes' as unknown as boolean })
-    expect(commands(runs)).toEqual(['tmux -L nodeterm-rmt kill-session -t =nt-abc'])
+    expect(commands(runs)).toEqual([`${TP}tmux -L nodeterm-rmt kill-session -t =nt-abc`])
   })
 
   it('is best-effort: a socket that refuses does not spare the others', async () => {
@@ -75,10 +79,10 @@ describe('SshProjectManager.killSessions', () => {
     const { mgr, runs } = managerWithConn()
     await mgr.killSessions('p1', ['a', 'b'], { everySocket: true })
     expect(commands(runs)).toEqual([
-      'tmux -L node-terminal kill-session -t =nt-a',
-      'tmux -L node-terminal kill-session -t =nt-b',
-      'tmux -L nodeterm-rmt kill-session -t =nt-a',
-      'tmux -L nodeterm-rmt kill-session -t =nt-b'
+      `${TP}tmux -L node-terminal kill-session -t =nt-a`,
+      `${TP}tmux -L node-terminal kill-session -t =nt-b`,
+      `${TP}tmux -L nodeterm-rmt kill-session -t =nt-a`,
+      `${TP}tmux -L nodeterm-rmt kill-session -t =nt-b`
     ])
   })
 

--- a/src/main/remote-ssh/ssh-project.ts
+++ b/src/main/remote-ssh/ssh-project.ts
@@ -5,7 +5,15 @@ import { spawn, execFile, execFileSync } from 'child_process'
 import { app, ipcMain } from 'electron'
 import { IPC } from '../../shared/ipc'
 import { getMainWindow, sendToMain } from '../main-window'
-import { parseLsDirs, posixQuote, quoteRemotePath, remoteTmuxConf, sshHostKey, type SshConnection } from '../../shared/ssh'
+import {
+  parseLsDirs,
+  posixQuote,
+  quoteRemotePath,
+  remoteTmuxConf,
+  remoteTmuxPathPrologue,
+  sshHostKey,
+  type SshConnection
+} from '../../shared/ssh'
 import type { DownloadResult, SshPassphraseRequest, SshProjectStatusEvent } from '../../shared/types'
 import { candidateName, safeDownloadBasename } from '../../core/download-name'
 import { removeAtomic, renameAtomic } from '../../core/fs-atomic'
@@ -718,7 +726,7 @@ export class SshProjectManager {
             )
             if (w.code === 0) {
               // source-file is best-effort (pushes options into a warm server); ignore its result.
-              await this.r.run(childArgs(conn, controlPath, `tmux -L ${RMT_TMUX_SOCKET} source-file ${posixQuote(confPath)}`))
+              await this.r.run(childArgs(conn, controlPath, `${remoteTmuxPathPrologue()}tmux -L ${RMT_TMUX_SOCKET} source-file ${posixQuote(confPath)}`))
               tmuxConfPath = confPath
             }
           } catch {

--- a/src/shared/ssh.ts
+++ b/src/shared/ssh.ts
@@ -275,6 +275,34 @@ export function quoteRemotePath(p: string): string {
   return posixQuote(p)
 }
 
+/**
+ * Directories where tmux commonly lives but that an ssh EXEC channel's PATH misses. An exec
+ * channel gets a non-login, non-interactive shell — the same trap the remote claude probe hit
+ * (`core/remote-ssh/claude-version-probe.ts`): on a macOS host Homebrew's `shellenv` lives in
+ * `~/.zprofile`, which only LOGIN shells source, so `tmux` resolves fine in the user's own
+ * terminal and every remote command of ours died with `zsh:1: command not found: tmux`
+ * (issue #449). Known absolute locations beat inherited-PATH luck — `findTmux()`'s rule, applied
+ * to the machine we cannot install anything on.
+ *
+ *  - `/opt/homebrew/bin` — Homebrew on Apple Silicon (the issue's report).
+ *  - `/usr/local/bin` — Homebrew on Intel macs; classic hand-installs on Linux/BSD.
+ *  - `/opt/local/bin` — MacPorts.
+ *  - `$HOME/.local/bin` — per-user installs (expanded by the REMOTE shell; the prologue keeps it
+ *    inside double quotes).
+ */
+export const REMOTE_TMUX_PATH_DIRS = '/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:$HOME/.local/bin'
+
+/**
+ * Shell prologue (note the trailing `; `) prepended to every remote command that invokes `tmux`.
+ * APPENDED to PATH, never prepended: a host whose exec-channel PATH already resolves tmux keeps
+ * using exactly that binary — the same "system first" rule as the local `findTmux()`, and the only
+ * ordering that cannot re-pair a long-lived tmux server with a different client build. The `$PATH`
+ * / `$HOME` references expand on the REMOTE side (the whole line travels as one ssh argument).
+ */
+export function remoteTmuxPathPrologue(): string {
+  return `PATH="$PATH:${REMOTE_TMUX_PATH_DIRS}"; `
+}
+
 /** Remote variant of pty-manager's tmuxConf — same behavior, same reasoning (see `tmuxConf` for
  *  the long version). Mouse ON: tmux owns scrolling and selection, the pane is on the alternate
  *  screen, and NOTHING is hydrated on reattach (tmux redraws and its own history is scrollable).


### PR DESCRIPTION
Fixes #449.

## The bug

An ssh **exec channel** runs a non-login, non-interactive shell. On a macOS host, Homebrew's `shellenv` lives in `~/.zprofile`, which only login shells source — so `/opt/homebrew/bin` is not on that shell's PATH, and every remote command nodeterm builds (`tmux -L nodeterm-rmt new-session …`, `has-session`, pastes, kills, capture reads) died with:

```
zsh:1: command not found: tmux
```

even though the user's own terminal on the same host runs tmux fine. This is the same class of failure the remote `claude --version` probe already fixed with a login shell + PATH prepend (see the probe story in CLAUDE.md's SSH section).

## The fix

**1. `remoteTmuxPathPrologue()`** (`shared/ssh.ts`) — one PATH **append** prepended to every remote command that invokes tmux:

```sh
PATH="$PATH:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:$HOME/.local/bin";
```

Append, never prepend: a host whose exec-channel PATH already resolves tmux keeps using exactly that binary (the local `findTmux()` "system first" rule), so nothing can re-pair a long-lived tmux server with a different client build. The prologue is a plain assignment, so every command's exit code — what `probeSaysAbsent` and the session-memory no-server classifier read — is unchanged.

Applied at one seam per file: `tmuxCmd()` in `control-master.ts` (all remote tmux builders), the `source-file` push in `ssh-project.ts`, and the session-memory sweep script (`session-memory-remote.ts` — a brew-tmux host previously answered 127 on every socket and the panel reported "Could not measure").

**2. A readable degrade when tmux is genuinely absent** — the interactive spawn wraps the tmux command in `tmuxOrExplain`: if tmux resolves nowhere (PATH + all appended dirs), the pane prints

> nodeterm: tmux was not found on this host.
> nodeterm runs remote terminals inside tmux so they survive disconnects, app restarts and project switches.
> Install tmux on the host (brew install tmux / apt install tmux / dnf install tmux) and reopen this terminal.
> Starting a plain shell instead - it will NOT persist when this terminal closes.

and then `exec`s a plain **login** shell in the node's cwd — mirroring the local plain-shell fallback, instead of closing the pane on a bare shell error. Warm/cold detection is unaffected: the `has-session` probe's 127 is already "not evidence of absence" → warm attach → nothing is typed into the fallback shell.

## Tests

- `control-master.realsh.test.ts`: two new tests execute the generated line under a real `/bin/sh` — tmux resolvable **only** through the appended `$HOME/.local/bin`, and the no-tmux path (message + `SHELL -l` exec, via a recording SHELL stub). PATH for these is an empty dir, because the CI box's own `/usr/bin/tmux` would otherwise win the `command -v`.
- `control-master.injection.test.ts`: the builder now deliberately emits shell structure (prologue + if/else fallback), so "zero unquoted metacharacters" is no longer the invariant. The replacement is stronger where it matters: the line's structure must be **byte-identical across hostile and benign inputs** — a payload that escapes its quotes (or a replacement-pattern splice that inverts quote parity downstream) still fails, exactly as `toEqual([])` did. All existing payload/canary tests still run unchanged under real sh.
- Pinned-string updates in `control-master.test.ts` / `ssh-project.killSessions.test.ts`.
- Full suite: 9170 passed; the only red is `node-pty-patch.test.ts` ×3, which fails identically on an untouched checkout on this machine (unpatched `node_modules` — the test's documented "run `npm run rebuild`" case), unrelated to this change.

## Surfaces

- **Desktop**: full fix (SSH projects are desktop-only today).
- **Server Edition**: no SSH ControlMaster there; the shared builders are the same code, nothing else to do.
- **Mobile**: N/A — the phone attaches through the desktop/host transport, which now resolves tmux correctly.

Also noted in CLAUDE.md next to the tmux-continuity section, beside the claude-probe precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)