### PR TITLE
Markdown UX: opt-in open-in-preview + one-shot Explorer pin hint (#495)

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -297,6 +297,12 @@ import {
   writeExplorerPinned,
   type ExplorerShowAction
 } from '../lib/explorerPin'
+import {
+  EXPLORER_PIN_HINT_TEXT,
+  readSeenExplorerPinHint,
+  shouldShowExplorerPinHint,
+  writeSeenExplorerPinHint
+} from '../lib/explorerPinHint'
 import { useProjects } from '../state/projects'
 import { useAgentStatus } from '../state/agentStatus'
 import { useBrowserLease, drivingNodeIds } from '../state/browserLease'
@@ -964,8 +970,32 @@ export function Canvas() {
     open: false
   }))
   const explorerOpen = explorerIsOpen(explorer)
+  // One-shot pin-discoverability hint (lib/explorerPinHint.ts): `explorerOpenedFileRef` remembers
+  // whether a file was opened from the drawer during the current open-spell; the state mirror ref
+  // lets showExplorer read the transition while staying dependency-free.
+  const explorerStateRef = useRef(explorer)
+  explorerStateRef.current = explorer
+  const explorerOpenedFileRef = useRef(false)
   const showExplorer = useCallback((action: ExplorerShowAction) => {
-    setExplorer((s) => ({ ...s, ...nextExplorerShow(s, action) }))
+    const cur = explorerStateRef.current
+    const next = { ...cur, ...nextExplorerShow(cur, action) }
+    const wasOpen = explorerIsOpen(cur)
+    const isOpenAfter = explorerIsOpen(next)
+    // A fresh open starts a new open-spell for the hint's "did this spell open a file" fact.
+    if (!wasOpen && isOpenAfter) explorerOpenedFileRef.current = false
+    if (
+      shouldShowExplorerPinHint({
+        wasOpen,
+        isOpenAfter,
+        pinned: cur.pinned,
+        openedFile: explorerOpenedFileRef.current,
+        seen: readSeenExplorerPinHint()
+      })
+    ) {
+      writeSeenExplorerPinHint()
+      setNotice({ kind: 'info', text: EXPLORER_PIN_HINT_TEXT })
+    }
+    setExplorer(next)
   }, [])
   const toggleExplorerPin = useCallback(() => {
     setExplorer((s) => {
@@ -11663,7 +11693,10 @@ export function Canvas() {
       {explorerOpen && (
         <ExplorerPanel
           onClose={() => showExplorer('close')}
-          onOpenFile={(path, isSsh) => openFile(path, undefined, isSsh)}
+          onOpenFile={(path, isSsh) => {
+            explorerOpenedFileRef.current = true
+            openFile(path, undefined, isSsh)
+          }}
           reveal={reveal}
           pinned={explorer.pinned}
           onTogglePin={toggleExplorerPin}

--- a/src/renderer/components/settings/sections/BehaviorSection.tsx
+++ b/src/renderer/components/settings/sections/BehaviorSection.tsx
@@ -27,6 +27,10 @@ const ROWS = {
   },
   panHover: { title: 'Pan-hover delay (ms)', keywords: ['pan', 'hover', 'delay', 'focus', 'guard'] },
   doubleClick: { title: 'Double-click to focus', keywords: ['double', 'click', 'focus'] },
+  mdPreview: {
+    title: 'Open Markdown in preview',
+    keywords: ['markdown', 'md', 'preview', 'render', 'editor', 'docs', 'readme', 'file']
+  },
   sidebarCollapse: {
     title: 'Sidebar: collapse inactive by default',
     keywords: ['sidebar', 'sessions', 'collapse', 'expand', 'project', 'switch', 'group', 'tree']
@@ -169,6 +173,19 @@ export function BehaviorSection({ isActive }: { isActive: boolean }): React.JSX.
               checked={settings.doubleClickFocus}
               onChange={(v) => update({ doubleClickFocus: v })}
               ariaLabel="Double-click to focus"
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.mdPreview}>
+        <FieldRow
+          label="Open Markdown in preview"
+          description="Markdown files open rendered instead of as editable text. The node's Preview/Edit toggle still switches either way."
+          control={
+            <Switch
+              checked={settings.openMarkdownPreview}
+              onChange={(v) => update({ openMarkdownPreview: v })}
+              ariaLabel="Open Markdown in preview"
             />
           }
         />

--- a/src/renderer/lib/explorerPinHint.test.ts
+++ b/src/renderer/lib/explorerPinHint.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXPLORER_PIN_HINT_KEY,
+  readSeenExplorerPinHint,
+  shouldShowExplorerPinHint,
+  writeSeenExplorerPinHint
+} from './explorerPinHint'
+
+const base = { wasOpen: true, isOpenAfter: false, pinned: false, openedFile: true, seen: false }
+
+describe('shouldShowExplorerPinHint', () => {
+  it('fires on the painful close: unpinned, a file was opened, first time', () => {
+    expect(shouldShowExplorerPinHint(base)).toBe(true)
+  })
+
+  it('never fires twice', () => {
+    expect(shouldShowExplorerPinHint({ ...base, seen: true })).toBe(false)
+  })
+
+  it('a pinned drawer closing (the ×) does not hint — its owner already knows the pin', () => {
+    expect(shouldShowExplorerPinHint({ ...base, pinned: true })).toBe(false)
+  })
+
+  it('a browse-and-dismiss close (no file opened) does not hint', () => {
+    expect(shouldShowExplorerPinHint({ ...base, openedFile: false })).toBe(false)
+  })
+
+  it('only a real open→closed transition qualifies', () => {
+    expect(shouldShowExplorerPinHint({ ...base, wasOpen: false })).toBe(false)
+    expect(shouldShowExplorerPinHint({ ...base, isOpenAfter: true })).toBe(false)
+  })
+})
+
+describe('seen flag storage', () => {
+  it('round-trips through the injected store', () => {
+    const store = new Map<string, string>()
+    expect(readSeenExplorerPinHint((k) => store.get(k) ?? null)).toBe(false)
+    writeSeenExplorerPinHint((k, v) => store.set(k, v))
+    expect(store.get(EXPLORER_PIN_HINT_KEY)).toBe('1')
+    expect(readSeenExplorerPinHint((k) => store.get(k) ?? null)).toBe(true)
+  })
+
+  it('an unreadable store reads as SEEN (never loop the one-shot), and writes never throw', () => {
+    expect(
+      readSeenExplorerPinHint(() => {
+        throw new Error('private mode')
+      })
+    ).toBe(true)
+    expect(() =>
+      writeSeenExplorerPinHint(() => {
+        throw new Error('quota')
+      })
+    ).not.toThrow()
+  })
+})

--- a/src/renderer/lib/explorerPinHint.ts
+++ b/src/renderer/lib/explorerPinHint.ts
@@ -1,0 +1,51 @@
+// One-shot discoverability hint for the Explorer pin (user feedback via email): people open a
+// file from the (unpinned, modal) Explorer, click into the new editor node, and the drawer
+// closes under them — not knowing the pin in its header would have kept it docked. The pin has
+// existed since lib/explorerPin.ts; this hint only makes it findable at the exact moment the
+// close bites.
+//
+// Personal, machine-local flag (same storage family as `nodeterm.seenSelectHint`): localStorage,
+// so the Server Edition keeps it per-user/browser and settings.json is untouched.
+
+export const EXPLORER_PIN_HINT_KEY = 'nodeterm.seenExplorerPinHint'
+
+export const EXPLORER_PIN_HINT_TEXT =
+  'Tip: the Explorer closes when you click away. Pin it (📌 in its header) to keep it open while you work.'
+
+/**
+ * Show the hint exactly once, and only when the close is the one that hurts: the drawer just
+ * went from open to closed, it was UNPINNED (a pinned drawer never closes on click-away, and
+ * its owner already knows the pin), and a file was opened from it during this open-spell —
+ * a browse-and-dismiss close teaches nothing about pinning.
+ */
+export function shouldShowExplorerPinHint(args: {
+  wasOpen: boolean
+  isOpenAfter: boolean
+  pinned: boolean
+  openedFile: boolean
+  seen: boolean
+}): boolean {
+  return args.wasOpen && !args.isOpenAfter && !args.pinned && args.openedFile && !args.seen
+}
+
+export function readSeenExplorerPinHint(
+  getItem: (key: string) => string | null = (key) => localStorage.getItem(key)
+): boolean {
+  try {
+    return getItem(EXPLORER_PIN_HINT_KEY) === '1'
+  } catch {
+    // Unreadable storage (private mode): claim "seen" — better to lose a nicety than to show
+    // the "one-shot" hint on every close forever.
+    return true
+  }
+}
+
+export function writeSeenExplorerPinHint(
+  setItem: (key: string, value: string) => void = (key, value) => localStorage.setItem(key, value)
+): void {
+  try {
+    setItem(EXPLORER_PIN_HINT_KEY, '1')
+  } catch {
+    /* quota / private mode: the hint is a nicety, never fail the UI */
+  }
+}

--- a/src/renderer/lib/markdownPreview.test.ts
+++ b/src/renderer/lib/markdownPreview.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { isMarkdownExt, opensInPreview } from './markdownPreview'
+
+describe('isMarkdownExt', () => {
+  it('accepts the markdown family', () => {
+    for (const ext of ['md', 'markdown', 'mdown', 'mkd']) {
+      expect(isMarkdownExt(ext)).toBe(true)
+    }
+  })
+
+  it('is case-insensitive (a file named README.MD is still markdown)', () => {
+    expect(isMarkdownExt('MD')).toBe(true)
+  })
+
+  it('rejects everything else, including the empty extension', () => {
+    for (const ext of ['ts', 'txt', 'html', 'mdx', 'json', '']) {
+      expect(isMarkdownExt(ext)).toBe(false)
+    }
+  })
+})
+
+describe('opensInPreview', () => {
+  it('requires the setting AND a markdown extension', () => {
+    expect(opensInPreview('md', true)).toBe(true)
+    expect(opensInPreview('md', false)).toBe(false)
+    expect(opensInPreview('ts', true)).toBe(false)
+  })
+
+  it('setting off is the historical behavior for every file', () => {
+    expect(opensInPreview('markdown', false)).toBe(false)
+  })
+})

--- a/src/renderer/lib/markdownPreview.ts
+++ b/src/renderer/lib/markdownPreview.ts
@@ -1,0 +1,17 @@
+// Whether an editor node should OPEN in the rendered markdown preview
+// (`settings.openMarkdownPreview`). Deliberately narrower than the Preview/Edit toggle,
+// which works on any text file: auto-preview is only for files that are actually markdown —
+// opening, say, a .ts file as a markdown render would be a confusing default for a setting
+// named after markdown.
+
+/** Extensions treated as markdown for the auto-preview decision (lowercase, no dot). */
+const MARKDOWN_EXTS = new Set(['md', 'markdown', 'mdown', 'mkd'])
+
+export function isMarkdownExt(ext: string): boolean {
+  return MARKDOWN_EXTS.has(ext.toLowerCase())
+}
+
+/** True when a freshly opened editor node should start in preview instead of the editor. */
+export function opensInPreview(ext: string, openMarkdownPreview: boolean): boolean {
+  return openMarkdownPreview && isMarkdownExt(ext)
+}

--- a/src/renderer/nodes/EditorNode.tsx
+++ b/src/renderer/nodes/EditorNode.tsx
@@ -5,6 +5,7 @@ import { monaco } from '../editor/monaco-setup'
 import { monacoTheme } from '../lib/appTheme'
 import { useAppTheme } from '../state/useAppTheme'
 import { renderMarkdown } from '../lib/markdown'
+import { opensInPreview } from '../lib/markdownPreview'
 import { useSettings } from '../state/settings'
 import { sshFs } from '../terminal/ssh-fs'
 import { useProjects } from '../state/projects'
@@ -224,6 +225,14 @@ export function EditorNode({ id, data, selected }: NodeProps<CanvasNode>) {
       savedRef.current = content
       editor.onDidChangeModelContent(() => setDirty(editor!.getValue() !== savedRef.current))
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => saveRef.current())
+      // Markdown files can open straight into the rendered preview (settings.openMarkdownPreview).
+      // Decided here rather than at useState-init because the preview needs the file content —
+      // this is exactly the state a Preview click right after load would produce, so Edit/⌘M
+      // toggle back as usual.
+      if (opensInPreview(ext, s.openMarkdownPreview)) {
+        setPreviewHtml(renderMarkdown(content))
+        setPreview(true)
+      }
     })
 
     return () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1199,6 +1199,10 @@ export interface Settings {
   /** ms to dwell over a terminal before it takes pointer focus (pan-across guard). */
   panHoverDelay: number
   doubleClickFocus: boolean
+  /** Open Markdown files (.md, .markdown, …) in rendered preview instead of the code editor.
+   *  Only picks the view an editor node OPENS in — the node's Preview/Edit toggle (and the
+   *  markdown-toggle chord) still switches either way. Default off: the historical behavior. */
+  openMarkdownPreview: boolean
   /**
    * Let a MIDDLE CLICK inside a terminal paste (Linux in practice — macOS and Windows have no
    * PRIMARY selection and no tmux middle-click habit, so the guard changes nothing visible there).
@@ -1477,6 +1481,7 @@ export const DEFAULT_SETTINGS: Settings = {
   worktreePathTemplate: DEFAULT_WORKTREE_PATH_TEMPLATE,
   panHoverDelay: 600,
   doubleClickFocus: true,
+  openMarkdownPreview: false,
   terminalMiddleClickPaste: false,
   wheelZoom: false,
   trackpadPan: true,


### PR DESCRIPTION
Closes nothing on its own — tracking discussion stays in #495 (user feedback via email).

## What

1. **`Open Markdown in preview`** (Settings → Behavior, default **off**): markdown files (`.md`, `.markdown`, `.mdown`, `.mkd`) open straight into the rendered preview instead of the Monaco editor. The Preview/Edit toggle and the markdown chord (⌘M) still switch either way — the setting only picks the view the node *opens* in. Decision logic is the pure, tested `lib/markdownPreview.ts`. With the setting off, behavior is byte-identical to before.

2. **Explorer pin discoverability**: the pin (`lib/explorerPin.ts`) already solves "opening a file closes the Explorer", but nothing ever pointed at it. A **one-shot** info notice now fires at the exact painful moment — the drawer transitions open→closed while **unpinned**, right after a file was opened from it during that open-spell. A pinned close (the ×), a browse-and-dismiss close (no file opened), and every close after the first hint never fire it. Predicate + seen-flag helpers are the pure, tested `lib/explorerPinHint.ts`; an unreadable localStorage reads as *seen*, so the "one-shot" can never loop in private-mode browsers.

## Implementation notes

- The hint rides the existing `notice` banner (`kind:'info'`, auto-dismissed by `noticeDwellMs`) — no new surface.
- `showExplorer` now reads the current pin state through a render-mirrored ref so it can observe the open→closed transition while staying dependency-free; the file-opened fact is a ref stamped by the Explorer's `onOpenFile` wrapper and reset on each fresh open.
- Auto-preview is decided *after* the file content loads (inside the existing `fs.read` continuation), producing exactly the state a Preview click right after load would — Edit/⌘M behave as usual, save/dirty untouched.

## Evaluated alternative (per #495)

Persisting each editor node's view state into node `data` was considered and set aside: it doesn't fix the complaint (every newly opened file still starts in the editor) and would write a personal view preference into the git-shared `project.json`. It can complement the setting later if wanted.

**Open question for the merge:** should the default eventually be *on*? Shipping off keeps existing installs untouched — flipping it is a product call.

## Surfaces

- **Desktop + Server Edition**: pure renderer; the setting lives in the existing settings store (works in both shells), the hint's seen-flag is localStorage → per-user/browser on SE.
- **Mobile**: N/A (no explorer / editor nodes there).

## Tests

- `lib/markdownPreview.test.ts` — extension family, case-insensitivity, setting-off = historical behavior.
- `lib/explorerPinHint.test.ts` — full predicate matrix + storage round-trip + unreadable-store fail-safe.
- `npm run typecheck` green; `explorerPin.test.ts`, `canvas-wiring.test.tsx`, `settings-store.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
