### PR TITLE
Default 'Open Markdown in preview' to ON (follow-up to #496, per #495)

### DIFF
--- a/src/core/settings-store.test.ts
+++ b/src/core/settings-store.test.ts
@@ -60,6 +60,26 @@ describe('SettingsStore nested-default merge', () => {
     expect(store.get().ptyShadowClients).toBe(false)
   })
 
+  it('turns markdown auto-preview ON for a settings.json that predates the key', () => {
+    // Every pre-v0.3.3 install upgrades with no `openMarkdownPreview` in its file: the shallow
+    // merge is what delivers the flipped default (#495) to exactly that population.
+    writeFileSync(path.join(dir, 'settings.json'), JSON.stringify({ fontSize: 15 }), 'utf-8')
+    const store = new SettingsStore()
+    store.init()
+    expect(store.get().openMarkdownPreview).toBe(true)
+  })
+
+  it('keeps an explicit openMarkdownPreview:false — an opt-out survives the default flip', () => {
+    writeFileSync(
+      path.join(dir, 'settings.json'),
+      JSON.stringify({ openMarkdownPreview: false }),
+      'utf-8'
+    )
+    const store = new SettingsStore()
+    store.init()
+    expect(store.get().openMarkdownPreview).toBe(false)
+  })
+
   it('leaves an already-modern speech object alone', () => {
     writeFileSync(
       path.join(dir, 'settings.json'),

--- a/src/core/settings-store.test.ts
+++ b/src/core/settings-store.test.ts
@@ -62,17 +62,33 @@ describe('SettingsStore nested-default merge', () => {
 
   it('turns markdown auto-preview ON for a settings.json that predates the key', () => {
     // Every pre-v0.3.3 install upgrades with no `openMarkdownPreview` in its file: the shallow
-    // merge is what delivers the flipped default (#495) to exactly that population.
+    // merge plus the one-shot migration deliver the flipped default (#495) to that population.
     writeFileSync(path.join(dir, 'settings.json'), JSON.stringify({ fontSize: 15 }), 'utf-8')
     const store = new SettingsStore()
     store.init()
     expect(store.get().openMarkdownPreview).toBe(true)
+    expect(store.get().openMarkdownPreviewMigrated).toBe(true)
   })
 
-  it('keeps an explicit openMarkdownPreview:false — an opt-out survives the default flip', () => {
+  it('migrates a v0.3.3-materialized openMarkdownPreview:false to ON, exactly once', () => {
+    // v0.3.3 (the sole release that defaulted off) materialized `false` into every file it
+    // saved, indistinguishable from an explicit opt-out — the maintainer call on #495 is that
+    // everyone sees ON at least once, so the un-stamped file is force-flipped and stamped.
     writeFileSync(
       path.join(dir, 'settings.json'),
       JSON.stringify({ openMarkdownPreview: false }),
+      'utf-8'
+    )
+    const store = new SettingsStore()
+    store.init()
+    expect(store.get().openMarkdownPreview).toBe(true)
+    expect(store.get().openMarkdownPreviewMigrated).toBe(true)
+  })
+
+  it('keeps a post-migration opt-out — a stamped openMarkdownPreview:false is permanent', () => {
+    writeFileSync(
+      path.join(dir, 'settings.json'),
+      JSON.stringify({ openMarkdownPreview: false, openMarkdownPreviewMigrated: true }),
       'utf-8'
     )
     const store = new SettingsStore()

--- a/src/core/settings-store.ts
+++ b/src/core/settings-store.ts
@@ -45,6 +45,18 @@ function mergeSettings(saved: Partial<Settings> | null | undefined): Settings {
       "speech.dictation": [merged.speech.shortcut],
     };
   }
+  // One-shot markdown-preview default flip (#495, maintainer decision): every file written
+  // before the flip gets `openMarkdownPreview: true` exactly once — INCLUDING one saved by
+  // v0.3.3, the sole release that defaulted off, whose full-snapshot saves materialized `false`
+  // for users who never touched the toggle (indistinguishable from an explicit off, so the
+  // absent-key merge alone could not reach them). The stamped `openMarkdownPreviewMigrated`
+  // is what makes it one-shot: once present, the stored value is the user's own and an opt-out
+  // is permanent. Same shape as the dictation seed above — keyed on the marker's absence in
+  // the SAVED file, never on the merged value.
+  if (!saved?.openMarkdownPreviewMigrated) {
+    merged.openMarkdownPreview = true;
+    merged.openMarkdownPreviewMigrated = true;
+  }
   // Legacy `terminalGpuRendering` was a boolean whose default (true) was merged into every saved
   // file — so a stored `true` is indistinguishable from "never touched" and maps to the new
   // 'auto' (platform-aware) default, while a stored `false` was always an explicit escape-hatch

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1215,13 +1215,18 @@ export interface Settings {
   /** Open Markdown files (.md, .markdown, …) in rendered preview instead of the code editor.
    *  Only picks the view an editor node OPENS in — the node's Preview/Edit toggle (and the
    *  markdown-toggle chord) still switches either way. Default ON since the release after
-   *  v0.3.3 (maintainer decision on issue #495; docs open as docs). An absent key picks up the
-   *  new default via the shallow merge; an explicit `false` is respected. Caveat, same shape as
-   *  `terminalGpuRendering`'s boolean history: `saveNow` materializes EVERY key, so a file
-   *  saved by v0.3.3 itself (the one release that defaulted off) carries `false`
-   *  indistinguishable from a user's explicit off — those installs keep off, which is the safe
-   *  direction (never overwrite what may be an explicit choice). */
+   *  v0.3.3 (maintainer decision on issue #495; a preview is one ⌘M from the editor, so the
+   *  rendered view is the better first sight for docs). A one-shot load migration keyed on
+   *  `openMarkdownPreviewMigrated` (see mergeSettings) forces this ON once for every existing
+   *  file — including one saved by v0.3.3, the one release that defaulted off and whose
+   *  full-snapshot saves materialized `false` for users who never touched the toggle. After
+   *  the migration the user's own opt-out is permanent. */
   openMarkdownPreview: boolean
+  /** One-shot marker for the openMarkdownPreview default flip (#495). Absent = the file
+   *  predates the flip → the load migration sets `openMarkdownPreview: true` and stamps this
+   *  true; present = the migration already ran (or the install was born after it) and the
+   *  stored `openMarkdownPreview` value is the user's own, never touched again. */
+  openMarkdownPreviewMigrated: boolean
   /**
    * Let a MIDDLE CLICK inside a terminal paste (Linux in practice — macOS and Windows have no
    * PRIMARY selection and no tmux middle-click habit, so the guard changes nothing visible there).
@@ -1501,6 +1506,7 @@ export const DEFAULT_SETTINGS: Settings = {
   panHoverDelay: 600,
   doubleClickFocus: true,
   openMarkdownPreview: true,
+  openMarkdownPreviewMigrated: true,
   terminalMiddleClickPaste: false,
   wheelZoom: false,
   trackpadPan: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1214,7 +1214,13 @@ export interface Settings {
   doubleClickFocus: boolean
   /** Open Markdown files (.md, .markdown, …) in rendered preview instead of the code editor.
    *  Only picks the view an editor node OPENS in — the node's Preview/Edit toggle (and the
-   *  markdown-toggle chord) still switches either way. Default off: the historical behavior. */
+   *  markdown-toggle chord) still switches either way. Default ON since the release after
+   *  v0.3.3 (maintainer decision on issue #495; docs open as docs). An absent key picks up the
+   *  new default via the shallow merge; an explicit `false` is respected. Caveat, same shape as
+   *  `terminalGpuRendering`'s boolean history: `saveNow` materializes EVERY key, so a file
+   *  saved by v0.3.3 itself (the one release that defaulted off) carries `false`
+   *  indistinguishable from a user's explicit off — those installs keep off, which is the safe
+   *  direction (never overwrite what may be an explicit choice). */
   openMarkdownPreview: boolean
   /**
    * Let a MIDDLE CLICK inside a terminal paste (Linux in practice — macOS and Windows have no
@@ -1494,7 +1500,7 @@ export const DEFAULT_SETTINGS: Settings = {
   worktreePathTemplate: DEFAULT_WORKTREE_PATH_TEMPLATE,
   panHoverDelay: 600,
   doubleClickFocus: true,
-  openMarkdownPreview: false,
+  openMarkdownPreview: true,
   terminalMiddleClickPaste: false,
   wheelZoom: false,
   trackpadPan: true,


### PR DESCRIPTION
Follow-up to #496 — default **ON** per maintainer decision on #495, now with a **one-shot force-ON migration** so every install sees the new default at least once.

## What

1. `DEFAULT_SETTINGS.openMarkdownPreview` flips `false` → `true`: markdown files open rendered by default. The Behavior toggle, the node's Preview/Edit button and ⌘M are unchanged — the editor is one ⌘M away, which is the rationale for defaulting to the rendered view.
2. **One-shot migration** (`mergeSettings`, so it runs in both shells): if the saved file lacks the new `openMarkdownPreviewMigrated` stamp, `openMarkdownPreview` is force-set to `true` and the stamp is written. Same shape as the existing dictation-shortcut seed — keyed on the **saved** file, never on the merged value.

## Why a migration (and why this one)

- The absent-key merge alone delivers ON to every pre-v0.3.3 file (the key didn't exist), but **misses the v0.3.3 population**: that release defaulted off and `saveNow` persists full materialized snapshots, so any settings save on v0.3.3 wrote `openMarkdownPreview: false` even for users who never touched the toggle — indistinguishable from an explicit opt-out.
- Maintainer call: everyone gets ON once (preview is not sticky pain — ⌘M switches instantly). The stamp is what keeps it one-shot: **after the migration, a user's own opt-out is permanent** — the migration never runs again and never overwrites a stamped `false`.

Net: historical `false`s are cleared exactly once; forward-looking opt-outs are respected. There is no remaining "residual OFF" population.

## Tests

Three new/updated `settings-store.test.ts` cases pin the matrix (beside the existing absent/explicit pairs):
- file predating the key → ON + stamped
- un-stamped `false` (the v0.3.3 materialization) → ON + stamped
- stamped `false` (a real post-flip opt-out) → stays `false`

`npm run typecheck` green; `settings-store.test.ts` + `markdownPreview.test.ts` green.

## Docs / release notes

Field + stamp doc comments in `shared/types.ts` describe the flip and the migration. No `CHANGELOG` in-repo; suggested release-note line: *"Markdown files now open in rendered preview by default (Settings → Behavior → 'Open Markdown in preview' to turn off — your choice sticks)."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
