### PR TITLE
Add middle-click to end a sidebar session, rename Close to End session

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -9907,21 +9907,22 @@ export function Canvas() {
       // Transfer) place beside the source — the same as the row's existing Transfer behavior.
       //
       // The canvas menu ends in a destructive "Delete" (deleteNodes). The session row's analogue
-      // is non-destructive "Close" (closeSession — hides the tab, keeps the tmux session), so the
-      // trailing Delete is swapped for Close rather than offered beside it.
+      // is "End session" (closeSession — stops the tmux session and removes the node too, just
+      // confirmed via its own dialog rather than the canvas's shared confirm), so the trailing
+      // Delete is swapped for End session rather than offered beside it.
       const body: MenuItem[] =
         projectId === activeProjectId
           ? (() => {
               const full = selectionItems([id])
               // Drop the canvas menu's trailing "Delete" (destructive deleteNodes) and any
-              // separator left dangling before it, then append the session row's non-destructive
-              // "Close". Found by label rather than fixed index so this stays correct if the canvas
+              // separator left dangling before it, then append the session row's "End session".
+              // Found by label rather than fixed index so this stays correct if the canvas
               // menu's tail changes — Delete is the only 'Delete'-labelled row.
               const withoutDelete = full.filter((it) => !('label' in it && it.label === 'Delete'))
               return [
                 ...tidySeparators(withoutDelete),
                 { type: 'separator' },
-                { label: 'Close', icon: <IconTrash />, danger: true, onClick: () => closeSession(projectId, id) }
+                { label: 'End session', icon: <IconTrash />, danger: true, onClick: () => closeSession(projectId, id) }
               ]
             })()
           : [
@@ -9937,7 +9938,7 @@ export function Canvas() {
                 }
               },
               { type: 'separator' },
-              { label: 'Close', icon: <IconTrash />, danger: true, onClick: () => closeSession(projectId, id) }
+              { label: 'End session', icon: <IconTrash />, danger: true, onClick: () => closeSession(projectId, id) }
             ]
       setMenu({ x: e.clientX, y: e.clientY, items: [...head, ...body] })
     },

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -63,6 +63,16 @@ export function SessionRow({
       draggable={!editing}
       onClick={onClick}
       onContextMenu={onContextMenu}
+      onMouseDown={(e) => {
+        // Middle-click closes the session, same as the × button — but goes through
+        // onClose's confirm dialog rather than skipping it (killing a real tmux
+        // session isn't the same low-stakes action as closing a browser tab).
+        if (e.button === 1) {
+          e.preventDefault()
+          e.stopPropagation()
+          onClose()
+        }
+      }}
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = 'move'
         // Some browsers require data to be set for a drag to start.
@@ -153,7 +163,7 @@ export function SessionRow({
           </button>
           <button
             className="ss-row__close"
-            title="Close session"
+            title="End session"
             onClick={(e) => {
               e.stopPropagation()
               onClose()


### PR DESCRIPTION
## Summary
- Sidebar session row's × button and right-click menu both said "Close" but already went through `closeSession`'s confirm dialog ("End this session? This stops its tmux session and removes the node from its canvas.") — renamed both to "End session" so the label matches the actual (destructive) behavior.
- Added a middle-click handler on the session row that calls the same `closeSession(projectId, id)` path (× button, right-click menu, and middle-click are now three entry points into one confirmed action — no new confirmation logic needed).

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/renderer/components/SessionRow.test.*`
- [x] `npx vitest run src/renderer/canvas/canvas-wiring.test.tsx src/renderer/nodes/status-lifecycle.test.ts src/renderer/lib/projectCloseSessions.test.ts`
- [x] Manual: middle-click a sidebar session row → confirm dialog appears → confirming ends the session