### PR TITLE
feat: open/continue a project by dragging its folder onto the canvas

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -10432,39 +10432,52 @@ export function Canvas() {
     void writeDisk()
   }, [commitActiveToStore, writeDisk])
 
+  /** The dedupe/reopen/adopt/create decision for a folder path, shared by the "Open folder…"
+   *  dialog and the drag-and-drop entry point: a folder maps to one project, and this is the
+   *  ONE place that decides whether to reuse/reopen an already-registered project, adopt an
+   *  existing `.nodeterm/project.json` (git clone, synced copy, another machine's project), or
+   *  create a brand-new one. */
+  const openOrAdoptFolder = useCallback(
+    async (folder: string): Promise<void> => {
+      commitActiveToStore()
+      // A folder maps to one project: reuse the already-registered one first…
+      const existing = useProjects.getState().projects.find((p) => p.cwd === folder)
+      if (existing) {
+        useProjects.getState().openFolderProject(folder)
+        // An `unavailable` placeholder never recovers on its own: a save emits a header-only ref
+        // for it (never a file), so a deleted project.json stays deleted and every later load
+        // re-mints the placeholder. Opening the folder is the deliberate act that breaks that
+        // loop — but only on evidence, since clearing the flag lets the next save write this
+        // empty canvas. See #385.
+        const recovery = unavailableRecovery(existing, await api.workspace.projectFileState(folder))
+        if (recovery === 'clear') {
+          useProjects.getState().setProjectUnavailable(existing.id, false)
+        } else if (recovery === 'rehydrate') {
+          // `present` is a stat, not a parse: a corrupt file stats fine, and probeFolder
+          // answering null there means the placeholder is still the honest state.
+          const back = await api.workspace.probeFolder(folder)
+          if (back) useProjects.getState().replaceProject({ ...back, id: existing.id, closed: false })
+        }
+      } else {
+        // …else adopt the folder's own .nodeterm/project.json (git clone, synced copy,
+        // another machine's project) — only a virgin folder gets a brand-new project.
+        const probed = await api.workspace.probeFolder(folder)
+        if (probed) useProjects.getState().adoptProject({ ...probed, closed: false })
+        else useProjects.getState().openFolderProject(folder)
+      }
+      void writeDisk()
+    },
+    [commitActiveToStore, writeDisk]
+  )
+
   /** Returns true when a folder was picked (false on cancel), so callers like the welcome
    *  screen can keep their overlay up until the picker actually resolves. */
   const addProjectFromFolder = useCallback(async (): Promise<boolean> => {
     const folder = await window.nodeTerminal.dialog.selectFolder()
     if (!folder) return false
-    commitActiveToStore()
-    // A folder maps to one project: reuse the already-registered one first…
-    const existing = useProjects.getState().projects.find((p) => p.cwd === folder)
-    if (existing) {
-      useProjects.getState().openFolderProject(folder)
-      // An `unavailable` placeholder never recovers on its own: a save emits a header-only ref for
-      // it (never a file), so a deleted project.json stays deleted and every later load re-mints
-      // the placeholder. Opening the folder is the deliberate act that breaks that loop — but only
-      // on evidence, since clearing the flag lets the next save write this empty canvas. See #385.
-      const recovery = unavailableRecovery(existing, await api.workspace.projectFileState(folder))
-      if (recovery === 'clear') {
-        useProjects.getState().setProjectUnavailable(existing.id, false)
-      } else if (recovery === 'rehydrate') {
-        // `present` is a stat, not a parse: a corrupt file stats fine, and probeFolder answering
-        // null there means the placeholder is still the honest state.
-        const back = await api.workspace.probeFolder(folder)
-        if (back) useProjects.getState().replaceProject({ ...back, id: existing.id, closed: false })
-      }
-    } else {
-      // …else adopt the folder's own .nodeterm/project.json (git clone, synced copy,
-      // another machine's project) — only a virgin folder gets a brand-new project.
-      const probed = await api.workspace.probeFolder(folder)
-      if (probed) useProjects.getState().adoptProject({ ...probed, closed: false })
-      else useProjects.getState().openFolderProject(folder)
-    }
-    void writeDisk()
+    await openOrAdoptFolder(folder)
     return true
-  }, [commitActiveToStore, writeDisk])
+  }, [openOrAdoptFolder])
 
   const renameProject = useCallback(
     (id: string, name: string) => {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -39,8 +39,10 @@ import { selectedLocalFilePaths } from './canvas-file-copy'
 import {
   canvasImagePasteArmedAfterKey,
   canvasImportRefusal,
+  droppedDirectories,
   guardedCanvasImagePlacements,
-  isCanvasImageDropTarget
+  isCanvasImageDropTarget,
+  isFolderDropTarget
 } from './canvas-image-import'
 import {
   SharedGlyphLayer,
@@ -10477,6 +10479,42 @@ export function Canvas() {
     if (!folder) return false
     await openOrAdoptFolder(folder)
     return true
+  }, [openOrAdoptFolder])
+
+  // Drop a folder anywhere in the app (canvas background, Welcome screen, general chrome) → open
+  // or continue that project, using the exact same dedupe/reopen/adopt/create rules as the
+  // "Open folder…" dialog (openOrAdoptFolder). Registered on `window`, gated by isFolderDropTarget
+  // so terminals, editors, dialogs and form controls keep their own drop behavior untouched — a
+  // folder dropped on a terminal still pastes its path as text via terminal/file-drop.ts.
+  useEffect(() => {
+    const onDragOver = (event: DragEvent) => {
+      if (!isFolderDropTarget(event.target)) return
+      if (!Array.from(event.dataTransfer?.types ?? []).includes('Files')) return
+      event.preventDefault()
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+    }
+    const onDrop = (event: DragEvent) => {
+      if (!isFolderDropTarget(event.target)) return
+      const dirs = droppedDirectories(event.dataTransfer)
+      if (!dirs.length) return // no directories in this drop — let image-drop/terminal-drop handle it
+      event.preventDefault()
+      event.stopPropagation()
+      const paths = dirs
+        .map((f) => window.nodeTerminal.getPathForFile(f))
+        .filter((p): p is string => !!p)
+      // Sequential, not Promise.all: each folder's commitActiveToStore/writeDisk must not race
+      // the next folder's. The last resolved folder ends up active (openFolderProject's existing
+      // single-folder activation semantics).
+      void (async () => {
+        for (const folder of paths) await openOrAdoptFolder(folder)
+      })()
+    }
+    window.addEventListener('dragover', onDragOver)
+    window.addEventListener('drop', onDrop)
+    return () => {
+      window.removeEventListener('dragover', onDragOver)
+      window.removeEventListener('drop', onDrop)
+    }
   }, [openOrAdoptFolder])
 
   const renameProject = useCallback(

--- a/src/renderer/canvas/canvas-image-import.test.ts
+++ b/src/renderer/canvas/canvas-image-import.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   canvasImagePasteArmedAfterKey,
   canvasImportRefusal,
+  droppedDirectories,
   guardedCanvasImagePlacements,
   isCanvasImageDropTarget,
   isFolderDropTarget
@@ -82,6 +83,48 @@ describe('isFolderDropTarget', () => {
 
   it('rejects a null target', () => {
     expect(isFolderDropTarget(null)).toBe(false)
+  })
+})
+
+describe('droppedDirectories', () => {
+  const fakeItem = (opts: { isDirectory: boolean; file: File | null }): DataTransferItem =>
+    ({
+      kind: 'file',
+      webkitGetAsEntry: () => ({ isDirectory: opts.isDirectory }),
+      getAsFile: () => opts.file
+    }) as unknown as DataTransferItem
+
+  it('returns only directory entries, in order', () => {
+    const dirA = new File([], 'project-a')
+    const fileB = new File(['x'], 'notes.txt')
+    const dirC = new File([], 'project-c')
+    const dt = {
+      items: [
+        fakeItem({ isDirectory: true, file: dirA }),
+        fakeItem({ isDirectory: false, file: fileB }),
+        fakeItem({ isDirectory: true, file: dirC })
+      ]
+    } as unknown as DataTransfer
+    expect(droppedDirectories(dt)).toEqual([dirA, dirC])
+  })
+
+  it('tolerates a directory entry whose getAsFile() returns null', () => {
+    const dt = {
+      items: [fakeItem({ isDirectory: true, file: null })]
+    } as unknown as DataTransfer
+    expect(droppedDirectories(dt)).toEqual([])
+  })
+
+  it('returns an empty array for a null DataTransfer or no items', () => {
+    expect(droppedDirectories(null)).toEqual([])
+    expect(droppedDirectories({ items: [] } as unknown as DataTransfer)).toEqual([])
+  })
+
+  it('ignores non-file items (e.g. a text/plain drag)', () => {
+    const dt = {
+      items: [{ kind: 'string', webkitGetAsEntry: () => null, getAsFile: () => null }]
+    } as unknown as DataTransfer
+    expect(droppedDirectories(dt)).toEqual([])
   })
 })
 

--- a/src/renderer/canvas/canvas-image-import.test.ts
+++ b/src/renderer/canvas/canvas-image-import.test.ts
@@ -59,6 +59,17 @@ describe('isFolderDropTarget', () => {
     expect(isFolderDropTarget(root.querySelector('.sessions-sidebar span'))).toBe(true)
   })
 
+  it('accepts a Welcome-screen nav card even though it is a <button>', () => {
+    const root = document.createElement('div')
+    root.innerHTML = `
+      <div class="welcome__cards">
+        <button class="welcome__card"><span class="welcome__card-title">Open folder…</span></button>
+      </div>
+    `
+    expect(isFolderDropTarget(root.querySelector('.welcome__card'))).toBe(true)
+    expect(isFolderDropTarget(root.querySelector('.welcome__card-title'))).toBe(true)
+  })
+
   it('rejects terminals, editors, dialogs, form controls, and node bodies', () => {
     const root = document.createElement('div')
     root.innerHTML = `

--- a/src/renderer/canvas/canvas-image-import.test.ts
+++ b/src/renderer/canvas/canvas-image-import.test.ts
@@ -4,7 +4,8 @@ import {
   canvasImagePasteArmedAfterKey,
   canvasImportRefusal,
   guardedCanvasImagePlacements,
-  isCanvasImageDropTarget
+  isCanvasImageDropTarget,
+  isFolderDropTarget
 } from './canvas-image-import'
 
 describe('canvasImportRefusal', () => {
@@ -41,6 +42,46 @@ describe('isCanvasImageDropTarget', () => {
     const wrap = root.querySelector('.flow-wrap')!
     expect(isCanvasImageDropTarget(root.querySelector('[role="dialog"]'), wrap)).toBe(false)
     expect(isCanvasImageDropTarget(root.querySelector('.sessions-sidebar'), wrap)).toBe(false)
+  })
+})
+
+describe('isFolderDropTarget', () => {
+  it('accepts the canvas pane, the Welcome screen, and general app chrome', () => {
+    const root = document.createElement('div')
+    root.innerHTML = `
+      <div class="react-flow__pane"><span>pane</span></div>
+      <div class="welcome"><span>welcome</span></div>
+      <aside class="sessions-sidebar"><span>sidebar</span></aside>
+    `
+    expect(isFolderDropTarget(root.querySelector('.react-flow__pane span'))).toBe(true)
+    expect(isFolderDropTarget(root.querySelector('.welcome span'))).toBe(true)
+    expect(isFolderDropTarget(root.querySelector('.sessions-sidebar span'))).toBe(true)
+  })
+
+  it('rejects terminals, editors, dialogs, form controls, and node bodies', () => {
+    const root = document.createElement('div')
+    root.innerHTML = `
+      <div class="xterm"><span>term</span></div>
+      <div class="monaco-editor"><span>editor</span></div>
+      <div role="dialog"><span>dialog</span></div>
+      <input />
+      <textarea></textarea>
+      <button>btn</button>
+      <div contenteditable="true"><span>editable</span></div>
+      <div class="react-flow__node"><span>node body</span></div>
+    `
+    expect(isFolderDropTarget(root.querySelector('.xterm span'))).toBe(false)
+    expect(isFolderDropTarget(root.querySelector('.monaco-editor span'))).toBe(false)
+    expect(isFolderDropTarget(root.querySelector('[role="dialog"] span'))).toBe(false)
+    expect(isFolderDropTarget(root.querySelector('input'))).toBe(false)
+    expect(isFolderDropTarget(root.querySelector('textarea'))).toBe(false)
+    expect(isFolderDropTarget(root.querySelector('button'))).toBe(false)
+    expect(isFolderDropTarget(root.querySelector('[contenteditable] span'))).toBe(false)
+    expect(isFolderDropTarget(root.querySelector('.react-flow__node span'))).toBe(false)
+  })
+
+  it('rejects a null target', () => {
+    expect(isFolderDropTarget(null)).toBe(false)
   })
 })
 

--- a/src/renderer/canvas/canvas-image-import.ts
+++ b/src/renderer/canvas/canvas-image-import.ts
@@ -9,6 +9,21 @@ export function isCanvasImageDropTarget(target: EventTarget | null, wrap: Elemen
   )
 }
 
+/** True for anywhere a folder-drop should be handled: canvas background, the Welcome screen,
+ *  general app chrome (sidebar/dock backgrounds, tab strip empty area) — anywhere that isn't a
+ *  more specific drop target (a terminal, an editor, a dialog, a form control, or a node body).
+ *  Unlike isCanvasImageDropTarget this is NOT restricted to `.react-flow__pane`, because a
+ *  folder drop must also work with no project open yet (the Welcome screen is an overlay, not
+ *  necessarily inside the pane). */
+export function isFolderDropTarget(target: EventTarget | null): boolean {
+  const element = target instanceof Element ? target : null
+  if (!element) return false
+  return !element.closest(
+    'input, textarea, select, button, [contenteditable], [role="dialog"], ' +
+      '.monaco-editor, .xterm, .react-flow__node'
+  )
+}
+
 /**
  * Why a canvas image import cannot proceed, or null when it may. One rule, one message, so the
  * drop path and the paste path cannot disagree about either.

--- a/src/renderer/canvas/canvas-image-import.ts
+++ b/src/renderer/canvas/canvas-image-import.ts
@@ -24,6 +24,17 @@ export function isFolderDropTarget(target: EventTarget | null): boolean {
   )
 }
 
+/** Directories among a drop's items, via the synchronous webkitGetAsEntry() check — this MUST
+ *  run inside the drop handler itself, before any `await`: DataTransferItem entries are only
+ *  valid for the duration of the originating event. */
+export function droppedDirectories(dt: DataTransfer | null): File[] {
+  if (!dt) return []
+  return Array.from(dt.items)
+    .filter((it) => it.kind === 'file' && it.webkitGetAsEntry()?.isDirectory)
+    .map((it) => it.getAsFile())
+    .filter((f): f is File => !!f)
+}
+
 /**
  * Why a canvas image import cannot proceed, or null when it may. One rule, one message, so the
  * drop path and the paste path cannot disagree about either.

--- a/src/renderer/canvas/canvas-image-import.ts
+++ b/src/renderer/canvas/canvas-image-import.ts
@@ -18,6 +18,12 @@ export function isCanvasImageDropTarget(target: EventTarget | null, wrap: Elemen
 export function isFolderDropTarget(target: EventTarget | null): boolean {
   const element = target instanceof Element ? target : null
   if (!element) return false
+  // The Welcome screen's four nav cards (`.welcome__card`) are themselves <button> elements, so
+  // without this carve-out the general `button` exclusion below would silently swallow a folder
+  // dropped straight onto "Open folder…" — defeating the feature's own stated goal of working from
+  // the Welcome screen. Every OTHER button (dialogs, terminal headers, form controls, …) still
+  // falls through to the exclusion unchanged.
+  if (element.closest('.welcome__card')) return true
   return !element.closest(
     'input, textarea, select, button, [contenteditable], [role="dialog"], ' +
       '.monaco-editor, .xterm, .react-flow__node'


### PR DESCRIPTION
## Summary

Dragging one or more folders from the OS file manager (Finder/Explorer) onto the nodeterm window now opens each as a project — no need to go through the "Open folder…" dialog. It works from the canvas background, the Welcome screen (including its "Open folder…" card and the other nav cards), and general app chrome.

The drop reuses the exact same rules the "Open folder…" dialog already uses:
- A folder that maps to an already-registered project is reopened (including one that was previously closed).
- A folder carrying its own `.nodeterm/project.json` (a git clone, a synced copy, another machine's project) is adopted.
- A virgin folder becomes a brand-new project.
- Dropping several folders at once opens each as its own project, processed one at a time so they don't race each other; the last one dropped ends up active.

Dropping a folder onto a terminal node still pastes its path as text (unchanged), and dropping image files onto the canvas still creates an image node (unchanged) — the new handling only activates when the drop actually contains a directory, and otherwise gets out of the way.

Desktop only (Electron): resolving a dropped item's real filesystem path uses `webUtils.getPathForFile`, which has no meaningful equivalent for a browser-based drop in the Server Edition, so that surface is an intentional no-op there.

## How it works

- `openOrAdoptFolder(folder)` — the dedupe/reopen/adopt/create decision, extracted out of the existing folder-picker path so both entry points share one implementation.
- `isFolderDropTarget(target)` — decides whether a drop landed somewhere that should open a project (canvas, Welcome screen, general chrome) versus somewhere with its own drop behavior (a terminal, an editor, a dialog, a form control).
- `droppedDirectories(dataTransfer)` — picks out the directories among a drop's items.
- A window-level `dragover`/`drop` listener composes the three: it only intercepts the event when at least one directory is present, resolving each to an absolute path and opening/continuing the corresponding project in order.

## Test plan

- [x] Unit tests for `isFolderDropTarget` and `droppedDirectories` (accepted/rejected drop targets, directory extraction, edge cases)
- [x] `npm run typecheck` clean
- [x] Full test suite: no new failures introduced
- [ ] Manual verification in a running build: drag a virgin folder onto the canvas; close it and re-drag the same folder to confirm it reopens instead of duplicating; drag onto the Welcome screen; drag two folders at once; drag a folder onto a terminal node (should still just paste the path); drag an image file onto the canvas (should still create an image node); reorder project tabs via drag (should be unaffected)