### PR TITLE
fix(git): stop Source Control panel from opening untracked directories as file diffs

### DIFF
--- a/src/core/git-service.ts
+++ b/src/core/git-service.ts
@@ -380,7 +380,10 @@ export class GitService {
         git(cwd, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}']),
         git(cwd, ['diff', '--cached', '--numstat']),
         git(cwd, ['diff', '--numstat']),
-        git(cwd, ['status', '--porcelain'])
+        // -uall forces git to list every untracked file individually instead of collapsing an
+        // entirely-untracked directory into one `?? dir/` entry (issue: SC panel showed a folder
+        // row that, when clicked, opened a diff node against a directory). Still respects .gitignore.
+        git(cwd, ['status', '--porcelain', '-uall'])
       ])
     const gh = ghAuthedSwr()
 
@@ -419,6 +422,9 @@ export class GitService {
       let p = raw.slice(3)
       if (p.includes(' -> ')) p = p.split(' -> ')[1] // rename: use new path
       const unquoted = p.replace(/^"|"$/g, '')
+      // Defense in depth against -uall: a directory-shaped entry (trailing '/') can never be
+      // opened as a file diff, so drop it here rather than let it reach the diff-node click path.
+      if (unquoted.endsWith('/')) continue
 
       if (x === '?' && y === '?') {
         changes.push({ path: unquoted, status: 'U', added: 0, deleted: 0 })

--- a/src/core/git-service.untracked-dir.test.ts
+++ b/src/core/git-service.untracked-dir.test.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from 'node:child_process'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { GitService } from './git-service'
+
+let directory = ''
+
+afterEach(async () => {
+  if (directory) await fs.rm(directory, { recursive: true, force: true })
+})
+
+describe('GitService.status untracked directories', () => {
+  it('lists individual untracked files instead of collapsing the directory into one entry', async () => {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'nodeterm-untracked-dir-'))
+    execFileSync('git', ['init', '-q'], { cwd: directory })
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: directory })
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: directory })
+
+    // A brand-new, entirely untracked subdirectory with two files: git's default
+    // `--untracked-files=normal` collapses this into a single `?? newdir/` porcelain line.
+    await fs.mkdir(path.join(directory, 'newdir'))
+    await fs.writeFile(path.join(directory, 'newdir', 'a.txt'), 'a')
+    await fs.writeFile(path.join(directory, 'newdir', 'b.txt'), 'b')
+
+    const service = new GitService()
+    const status = await service.status(directory)
+
+    const paths = status.changes.map((c) => c.path).sort()
+    expect(paths).toEqual(['newdir/a.txt', 'newdir/b.txt'])
+    // No entry should ever be directory-shaped — nothing here can be opened as a file diff.
+    expect(status.changes.some((c) => c.path.endsWith('/'))).toBe(false)
+    expect(status.staged.some((c) => c.path.endsWith('/'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- `git status --porcelain` collapses an entirely-untracked directory into a single `?? dir/` entry by default; that path flowed unchanged into the Source Control panel's diff-node click handler, which then tried to diff a directory as if it were a file.
- Pass `-uall` so untracked files are listed individually (still respects `.gitignore`).
- Defensive skip of any leftover directory-shaped (trailing `/`) porcelain entry in the parse loop.

## Test plan
- [x] New regression test `src/core/git-service.untracked-dir.test.ts` (real temp git repo, real `git` commands) asserting individual untracked files are listed instead of the collapsed directory
- [x] Full `git-service` test suite passes (11/11)
- [x] `npm run typecheck` clean