### PR TITLE
refactor(kanban): make card sources a registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2125,7 +2125,23 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   issues (`GitHubIssueCardView` via `state/githubIssues.ts`, opened through
   `GitHubIssueSummaryModal`, a column move that closes/reopens the issue confirms first). A
   **source filter** (`KanbanSourceFilter`: All / GitHub / Sessions) and a transient per-board
-  **label filter** narrow what shows. **Labels** are a per-project palette (`ProjectKanban` labels,
+  **label filter** narrow what shows.
+  **Where a card comes from is a registry, not a branch per call site** (`renderer/lib/kanbanSources.ts`,
+  2026-08-30 — the same membership-plus-one-leaf discipline `AGENT_CONFIG` uses): each entry declares
+  its filter `label`, its `placement` (`assignment` = the board's own persisted assignments,
+  reorderable within a column; `provider` = the provider reports the column, the board persists
+  nothing and a move is the provider's write), its in-column `lane` order and whether it is
+  `configured` for a given board. Two orders live there deliberately: **declaration order is the
+  source filter's button order** (All · GitHub · Sessions), **`lane` is the in-column stacking order**
+  (sessions above issues) — they genuinely differ, and pinning both is what stops either being
+  re-spelled elsewhere. `KanbanColumn` therefore takes ONE `lanes` prop (`{sourceId, cards, footer?,
+  count}`) instead of a `cards` + eight `github*` props, places them via `byLane` and names no source;
+  the board builds each source's leaf, and the drag union branches on `placement` (`isProviderDrag`)
+  rather than on the string `'github'`. A lane's `count` is passed rather than derived from
+  `cards.length` because a provider reports a server-side total larger than the page fetched so far.
+  What deliberately did NOT move into the registry: the virtual **Ungrouped** column (board
+  semantics, not a source's concern) and `validKanban`, which stays the single shape gate on every
+  load path — a registry entry must never grow its own parallel validation. **Labels** are a per-project palette (`ProjectKanban` labels,
   edited inline via the Notion-style `LabelPicker`: create/assign/rename/recolor/delete through the
   pure `lib/kanban.ts` transforms) plus each GitHub issue's own labels, both filterable. The canvas stays MOUNTED under the opaque overlay (agent-status
   listeners live in Canvas.tsx; `display:none` would 0×0-resize every terminal into a tmux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,14 @@ The **canvas and the kanban board are two views of the same nodes.** When you ad
 canvas node — a header action, a badge, a menu item — ask whether the board's card and card modal
 need it too, and wire it in the same change.
 
+A board card's **source** is a registry entry, not a branch you add at a call site
+(`renderer/lib/kanbanSources.ts`). Declare the source once — filter label, `placement`
+(`assignment` = the board's own persisted assignments, `provider` = the provider owns the column),
+in-column `lane` order, whether it is `configured` for a board — and give it its one leaf (a card
+component and the list path feeding it). Columns take lanes and name no source; the drag path
+branches on `placement`. If you find yourself writing `=== 'github'` outside the registry, the
+registry is missing a field.
+
 ## House rules
 
 - **Anything path-shaped: Windows is a delivery target.** Most of this was written on

--- a/src/renderer/components/kanban/KanbanColumn.test.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it, vi } from 'vitest'
+import { KanbanColumn, type KanbanLane } from './KanbanColumn'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const lanes: KanbanLane[] = [
+  { sourceId: 'github', count: 7, cards: <article key="i" className="gh">issue</article>,
+    footer: <button key="more">Show more issues</button> },
+  { sourceId: 'sessions', count: 2, cards: <article key="s" className="sess">session</article> }
+]
+
+const render = (extra: Partial<Parameters<typeof KanbanColumn>[0]> = {}): HTMLElement => {
+  const host = document.createElement('div')
+  act(() => createRoot(host).render(
+    <KanbanColumn
+      column={null}
+      lanes={lanes}
+      createOptions={[]}
+      onCreate={vi.fn()}
+      onDragEnd={vi.fn()}
+      onDropOnColumn={vi.fn()}
+      {...extra}
+    />
+  ))
+  return host
+}
+
+describe('KanbanColumn lanes', () => {
+  it('places lanes in registry order, not the order it was handed them', () => {
+    const host = render()
+    const cards = [...host.querySelectorAll('.kanban-col__cards article')].map((el) => el.className)
+    expect(cards).toEqual(['sess', 'gh'])
+  })
+
+  it('renders a lane footer under that lane', () => {
+    const host = render()
+    expect(host.querySelector('.kanban-col__cards button')?.textContent).toBe('Show more issues')
+  })
+
+  it('counts every lane, including totals larger than the cards fetched', () => {
+    expect(render().querySelector('.kanban-col__count')?.textContent).toBe('9')
+  })
+})

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -1,61 +1,47 @@
-import { memo, useCallback, useLayoutEffect, useRef, useState } from 'react'
+import { Fragment, memo, useLayoutEffect, useRef, useState } from 'react'
 import type { KanbanColumn as KanbanColumnT } from '@shared/types'
 import { NODE_COLORS } from '../../state/workspace'
-import { SessionCard } from './SessionCard'
-import type { KanbanCardMeta, KanbanLabel } from '@shared/types'
-import type { KanbanCreateChoice, KanbanCreateOption, KanbanSession } from './KanbanView'
-import type { GitHubIssueCardView } from '@shared/github-issues'
-import { GitHubIssueCard } from './GitHubIssueCard'
+import type { KanbanCreateChoice, KanbanCreateOption } from './KanbanView'
+import { byLane, type KanbanSourceId } from '../../lib/kanbanSources'
+
+/** One source's contribution to one column. The board builds the cards (each source renders its
+ *  own leaf); the column only places the lanes, so it knows nothing about where a card came from
+ *  beyond the registry's stacking order. */
+export interface KanbanLane {
+  sourceId: KanbanSourceId
+  /** This lane's cards, already keyed by the board. */
+  cards: React.ReactNode
+  /** Trailing affordance under the lane's cards (e.g. GitHub's "Show more issues"). */
+  footer?: React.ReactNode
+  /** What this lane adds to the column's header count. Not `cards.length`: a provider-placed
+   *  source reports a server-side total that can exceed the page it has fetched. */
+  count: number
+}
 
 interface KanbanColumnProps {
   /** null = the virtual Ungrouped column: fixed label, no rename/recolor/delete, header not draggable. */
   column: KanbanColumnT | null
-  cards: KanbanSession[]
-  githubCards?: GitHubIssueCardView[]
-  githubColumns?: KanbanColumnT[]
-  githubMoving?: Record<number, true>
-  githubReadOnly?: boolean
-  githubStatus?: Record<number, string>
-  displayCount?: number
-  // Column-scoped callbacks carry the column id (and card-scoped ones the node id) so KanbanView
-  // can hand every column the SAME function references — that identity stability is what lets
-  // memo() skip columns/cards untouched by a render.
+  /** The column's card lanes, one per visible source; placed in registry lane order. */
+  lanes: KanbanLane[]
+  // Column-scoped callbacks carry the column id so KanbanView can hand every column the SAME
+  // function references — that identity stability is what lets memo() skip untouched columns.
   onRename?: (columnId: string, title: string) => void
   onRecolor?: (columnId: string, color: string) => void
   onDelete?: (columnId: string) => void
-  /** Open a card's modal (↗ / double-click on the card). */
-  onOpenCard: (nodeId: string) => void
-  /** Card metadata lookup (assignees/due) for the chips on each card. */
-  metaOf: (nodeId: string) => KanbanCardMeta | undefined
-  /** Resolved board labels for a card (the colored label chips). */
-  labelsOf: (nodeId: string) => KanbanLabel[]
   /** "+ New" menu entries (agents, terminal, sticky) and what to do when one is picked
    *  (columnId null = Ungrouped: no assignment). */
   createOptions: KanbanCreateOption[]
   onCreate: (choice: KanbanCreateChoice, columnId: string | null) => void
   // Drag plumbing — the single drag source of truth lives in KanbanView.
-  onCardDragStart: (nodeId: string) => void
   onColumnDragStart?: (columnId: string) => void
   onDragEnd: () => void
   /** Drop on the column body: a card lands at the END of this column; a column lands BEFORE it. */
   onDropOnColumn: (columnId: string | null) => void
-  onDropAtCard: (columnId: string | null, nodeId: string, side: 'before' | 'after') => void
-  /** Right-click on a card — bubbles the cursor position + node id up to the board menu. */
-  onCardContext: (nodeId: string, x: number, y: number) => void
-  onOpenGitHub?: (issue: GitHubIssueCardView) => void
-  onMoveGitHub?: (issue: GitHubIssueCardView, columnId: string | null) => void
-  onGitHubDragStart?: (issue: GitHubIssueCardView) => void
-  onLoadMoreGitHub?: (columnId: string | null) => void
-  hasMoreGitHub?: boolean
 }
 
 export const KanbanColumn = memo(function KanbanColumn({
-  column, cards, githubCards = [], githubColumns = [], githubMoving = {}, displayCount, metaOf, labelsOf,
-  githubReadOnly = false, githubStatus = {},
-  onRename, onRecolor, onDelete, onOpenCard, onCardContext, onOpenGitHub, onMoveGitHub,
-  onGitHubDragStart, onLoadMoreGitHub, hasMoreGitHub,
-  createOptions, onCreate, onCardDragStart, onColumnDragStart, onDragEnd, onDropOnColumn,
-  onDropAtCard
+  column, lanes, onRename, onRecolor, onDelete,
+  createOptions, onCreate, onColumnDragStart, onDragEnd, onDropOnColumn
 }: KanbanColumnProps) {
   const [editingTitle, setEditingTitle] = useState(false)
   const [title, setTitle] = useState(column?.title ?? '')
@@ -85,11 +71,8 @@ export const KanbanColumn = memo(function KanbanColumn({
   }, [newMenuOpen])
 
   const colId = column?.id ?? null
-  // Binds this column's id onto the shared card-drop handler; stable while the parent's is.
-  const dropAtCard = useCallback(
-    (nodeId: string, side: 'before' | 'after') => onDropAtCard(colId, nodeId, side),
-    [onDropAtCard, colId]
-  )
+  const orderedLanes = byLane(lanes)
+  const count = lanes.reduce((total, lane) => total + lane.count, 0)
 
   const commitTitle = () => {
     const t = title.trim()
@@ -153,7 +136,7 @@ export const KanbanColumn = memo(function KanbanColumn({
             {column ? column.title : 'Ungrouped'}
           </span>
         )}
-        <span className="kanban-col__count">{displayCount ?? cards.length + githubCards.length}</span>
+        <span className="kanban-col__count">{count}</span>
         {column && (
           <button
             className="kanban-col__close"
@@ -180,38 +163,12 @@ export const KanbanColumn = memo(function KanbanColumn({
         </div>
       )}
       <div className="kanban-col__cards">
-        {cards.map((s) => (
-          <SessionCard
-            key={s.id}
-            session={s}
-            meta={metaOf(s.id)}
-            labels={labelsOf(s.id)}
-            onOpen={onOpenCard}
-            onContext={onCardContext}
-            onDragStart={onCardDragStart}
-            onDragEnd={onDragEnd}
-            onDropAt={dropAtCard}
-          />
+        {orderedLanes.map((lane) => (
+          <Fragment key={lane.sourceId}>
+            {lane.cards}
+            {lane.footer}
+          </Fragment>
         ))}
-        {githubCards.map((issue) => (
-          <GitHubIssueCard
-            key={`github:${issue.id}`}
-            issue={issue}
-            columns={githubColumns}
-            moving={!!githubMoving[issue.number]}
-            readOnly={githubReadOnly}
-            status={githubStatus[issue.number]}
-            onOpen={(item) => onOpenGitHub?.(item)}
-            onMove={(item, target) => onMoveGitHub?.(item, target)}
-            onDragStart={(item) => onGitHubDragStart?.(item)}
-            onDragEnd={onDragEnd}
-          />
-        ))}
-        {hasMoreGitHub && (
-          <button className="kanban-github-more" onClick={() => onLoadMoreGitHub?.(colId)}>
-            Show more issues
-          </button>
-        )}
       </div>
       <div className="kanban-col__footer">
         {newMenuOpen && (

--- a/src/renderer/components/kanban/KanbanSourceFilter.tsx
+++ b/src/renderer/components/kanban/KanbanSourceFilter.tsx
@@ -1,4 +1,8 @@
-export type KanbanSource = 'all' | 'github' | 'sessions'
+import { KANBAN_SOURCES, type KanbanSourceFilter as KanbanSourceFilterValue } from '../../lib/kanbanSources'
+
+/** The filter's value: every source, or one of them. Named for its call sites, which read it as
+ *  "which source is the board showing". */
+export type KanbanSource = KanbanSourceFilterValue
 
 export function KanbanSourceFilter({
   value,
@@ -7,17 +11,22 @@ export function KanbanSourceFilter({
   value: KanbanSource
   onChange: (value: KanbanSource) => void
 }): React.JSX.Element {
+  // 'all' plus the registry, in declaration order — adding a source adds a button here.
+  const options: { id: KanbanSource; label: string }[] = [
+    { id: 'all', label: 'All' },
+    ...KANBAN_SOURCES.map((source) => ({ id: source.id as KanbanSource, label: source.label }))
+  ]
   return (
     <div className="kanban-source-filter" role="group" aria-label="Card source">
-      {(['all', 'github', 'sessions'] as const).map((source) => (
+      {options.map((option) => (
         <button
-          key={source}
+          key={option.id}
           type="button"
-          className={value === source ? 'kanban-source-filter__button is-active' : 'kanban-source-filter__button'}
-          aria-pressed={value === source}
-          onClick={() => onChange(source)}
+          className={value === option.id ? 'kanban-source-filter__button is-active' : 'kanban-source-filter__button'}
+          aria-pressed={value === option.id}
+          onClick={() => onChange(option.id)}
         >
-          {source === 'all' ? 'All' : source === 'github' ? 'GitHub' : 'Sessions'}
+          {option.label}
         </button>
       ))}
     </div>

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -11,7 +11,10 @@ import {
 } from '../../lib/kanban'
 import { labelSwatch } from '../../lib/kanbanLabelColors'
 import { CardModal } from './CardModal'
-import { KanbanColumn } from './KanbanColumn'
+import { KanbanColumn, type KanbanLane } from './KanbanColumn'
+import { SessionCard } from './SessionCard'
+import { GitHubIssueCard } from './GitHubIssueCard'
+import { kanbanSource, sourceVisible } from '../../lib/kanbanSources'
 import type { ModalSpawn } from './ModalTerminal'
 import { ContextMenu, type MenuItem } from '../ContextMenu'
 import { IconAgent, IconExternal, IconNote, IconSwitch, IconTerminal, IconTrash, IconWeb } from '../icons'
@@ -88,9 +91,18 @@ export interface KanbanViewProps {
 }
 
 type Drag =
-  | { kind: 'card' | 'column'; id: string }
-  | { kind: 'github'; issue: GitHubIssueCardView }
+  | { kind: 'column'; id: string }
+  | { kind: 'card'; sourceId: 'sessions'; id: string }
+  | { kind: 'card'; sourceId: 'github'; issue: GitHubIssueCardView }
   | null
+
+type CardDrag = Extract<Drag, { kind: 'card' }>
+
+/** A dragged card whose column the PROVIDER owns: dropping it is the provider's write (which may
+ *  confirm or refuse), never a board assignment. The branch is the registry's `placement`, not
+ *  the source's name — the union only supplies the narrowing. */
+const isProviderDrag = (drag: CardDrag): drag is Extract<CardDrag, { sourceId: 'github' }> =>
+  kanbanSource(drag.sourceId).placement === 'provider'
 
 /** Shared empty results — stable identities so memoized cards/columns see "no change". */
 const NO_LABELS: KanbanLabel[] = []
@@ -288,11 +300,11 @@ export const KanbanView = memo(function KanbanView({
     (columnId: string | null) => {
       const drag = takeDrag()
       if (!drag) return
-      if (drag.kind === 'github') {
-        requestGitHubMove(drag.issue, columnId)
-      } else if (drag.kind === 'card') commit(assignNode(board, drag.id, columnId, null))
-      else if (columnId !== null) commit(moveColumn(board, drag.id, columnId))
-      // a column dropped on Ungrouped is a no-op — Ungrouped is always first
+      if (drag.kind === 'column') {
+        if (columnId !== null) commit(moveColumn(board, drag.id, columnId))
+        // a column dropped on Ungrouped is a no-op — Ungrouped is always first
+      } else if (isProviderDrag(drag)) requestGitHubMove(drag.issue, columnId)
+      else commit(assignNode(board, drag.id, columnId, null))
     },
     [board, commit, requestGitHubMove]
   )
@@ -301,12 +313,12 @@ export const KanbanView = memo(function KanbanView({
     (columnId: string | null, targetNodeId: string, side: 'before' | 'after') => {
       const drag = takeDrag()
       if (!drag) return
-      if (drag.kind === 'github') {
-        requestGitHubMove(drag.issue, columnId)
-        return
-      }
       if (drag.kind === 'column') {
         if (columnId !== null) commit(moveColumn(board, drag.id, columnId))
+        return
+      }
+      if (isProviderDrag(drag)) {
+        requestGitHubMove(drag.issue, columnId)
         return
       }
       // "after this card" = "before the NEXT card in the column" (null = end of column).
@@ -340,10 +352,10 @@ export const KanbanView = memo(function KanbanView({
   // Stable column/card plumbing — every handler the memoized columns receive is identity-stable
   // across renders (the column binds its own id; cards bind theirs).
   const handleCardDragStart = useCallback((id: string) => {
-    dragRef.current = { kind: 'card', id }
+    dragRef.current = { kind: 'card', sourceId: 'sessions', id }
   }, [])
   const handleGitHubDragStart = useCallback((issue: GitHubIssueCardView) => {
-    dragRef.current = { kind: 'github', issue }
+    dragRef.current = { kind: 'card', sourceId: 'github', issue }
   }, [])
   const handleColumnDragStart = useCallback((columnId: string) => {
     dragRef.current = { kind: 'column', id: columnId }
@@ -370,8 +382,85 @@ export const KanbanView = memo(function KanbanView({
   const handleMoveGitHub = requestGitHubMove
   const githubPage = useCallback((columnId: string | null) =>
     github?.pages[columnId ?? 'ungrouped'], [github])
-  const sessionVisible = source !== 'github'
-  const githubVisible = source !== 'sessions' && !!board.github
+
+  // One bound card-drop handler per column, cached by column id: SessionCard is memoized on its
+  // props, so a fresh closure per render would defeat it. (The column used to bind this itself,
+  // back when it knew which of its cards were sessions.)
+  const dropAtCardFor = useMemo(() => {
+    const cache = new Map<string, (nodeId: string, side: 'before' | 'after') => void>()
+    return (columnId: string | null) => {
+      const key = columnId ?? '\u0000ungrouped'
+      let bound = cache.get(key)
+      if (!bound) {
+        bound = (nodeId, side) => dropAtCard(columnId, nodeId, side)
+        cache.set(key, bound)
+      }
+      return bound
+    }
+  }, [dropAtCard])
+
+  // A column's lanes: one per source that is both configured for this board and visible under
+  // the current filter. Each source builds its own leaf here; the column only places them (in
+  // registry lane order) and sums their counts. A new source is one more branch in this list.
+  const lanesFor = (columnId: string | null): KanbanLane[] => {
+    const lanes: KanbanLane[] = []
+    if (sourceVisible(source, 'sessions')) {
+      const cards = columnId === null
+        ? columnCards.ungrouped
+        : columnCards.byColumn.get(columnId) ?? NO_CARDS
+      const onDropAt = dropAtCardFor(columnId)
+      lanes.push({
+        sourceId: 'sessions',
+        count: cards.length,
+        cards: cards.map((s) => (
+          <SessionCard
+            key={s.id}
+            session={s}
+            meta={metaOf(s.id)}
+            labels={labelsOf(s.id)}
+            onOpen={setModalNodeId}
+            onContext={handleCardContext}
+            onDragStart={handleCardDragStart}
+            onDragEnd={handleDragEnd}
+            onDropAt={onDropAt}
+          />
+        ))
+      })
+    }
+    if (sourceVisible(source, 'github') && kanbanSource('github').configured(board)) {
+      const page = githubPage(columnId)
+      lanes.push({
+        sourceId: 'github',
+        // The provider's own total for the column, which can exceed the page fetched so far.
+        count: (columnId === null ? page?.counts.ungrouped : page?.counts[columnId]) ?? 0,
+        cards: (page?.items ?? []).map((issue) => (
+          <GitHubIssueCard
+            key={`github:${issue.id}`}
+            issue={issue}
+            columns={board.columns}
+            moving={!!github?.moving[issue.number]}
+            readOnly={githubReadOnly}
+            status={github?.issueStatus[issue.number]}
+            onOpen={setModalIssue}
+            onMove={handleMoveGitHub}
+            onDragStart={handleGitHubDragStart}
+            onDragEnd={handleDragEnd}
+          />
+        )),
+        footer: page?.nextCursor
+          ? (
+            <button
+              className="kanban-github-more"
+              onClick={() => void loadMoreGitHub(api.githubIssues, projectId, columnId)}
+            >
+              Show more issues
+            </button>
+          )
+          : undefined
+      })
+    }
+    return lanes
+  }
 
   // Right-click menu for a card: open on canvas, move to another column, delete.
   const cardMenuItems = (nodeId: string): MenuItem[] => {
@@ -476,61 +565,25 @@ export const KanbanView = memo(function KanbanView({
         <div className="kanban-board__columns">
           <KanbanColumn
             column={null}
-            cards={sessionVisible ? columnCards.ungrouped : NO_CARDS}
-            githubCards={githubVisible ? githubPage(null)?.items ?? [] : []}
-            githubColumns={board.columns}
-            githubMoving={github?.moving}
-            githubReadOnly={githubReadOnly}
-            githubStatus={github?.issueStatus}
-            displayCount={(sessionVisible ? columnCards.ungrouped.length : 0) +
-              (githubVisible ? githubPage(null)?.counts.ungrouped ?? 0 : 0)}
-            metaOf={metaOf}
-            labelsOf={labelsOf}
-            onOpenCard={setModalNodeId}
+            lanes={lanesFor(null)}
             createOptions={createOptions}
             onCreate={onCreateNode}
-            onCardDragStart={handleCardDragStart}
             onDragEnd={handleDragEnd}
             onDropOnColumn={dropOnColumn}
-            onDropAtCard={dropAtCard}
-            onCardContext={handleCardContext}
-            onOpenGitHub={setModalIssue}
-            onMoveGitHub={handleMoveGitHub}
-            onGitHubDragStart={handleGitHubDragStart}
-            hasMoreGitHub={githubVisible && !!githubPage(null)?.nextCursor}
-            onLoadMoreGitHub={() => void loadMoreGitHub(api.githubIssues, projectId, null)}
           />
           {board.columns.map((col) => (
             <KanbanColumn
               key={col.id}
               column={col}
-              cards={sessionVisible ? columnCards.byColumn.get(col.id) ?? NO_CARDS : NO_CARDS}
-              githubCards={githubVisible ? githubPage(col.id)?.items ?? [] : []}
-              githubColumns={board.columns}
-              githubMoving={github?.moving}
-              githubReadOnly={githubReadOnly}
-              githubStatus={github?.issueStatus}
-              displayCount={(sessionVisible ? columnCards.byColumn.get(col.id)?.length ?? 0 : 0) +
-                (githubVisible ? githubPage(col.id)?.counts[col.id] ?? 0 : 0)}
-              metaOf={metaOf}
-              labelsOf={labelsOf}
+              lanes={lanesFor(col.id)}
               onRename={handleRenameColumn}
               onRecolor={handleRecolorColumn}
               onDelete={handleDeleteColumn}
-              onOpenCard={setModalNodeId}
               createOptions={createOptions}
               onCreate={onCreateNode}
-              onCardDragStart={handleCardDragStart}
               onColumnDragStart={handleColumnDragStart}
               onDragEnd={handleDragEnd}
               onDropOnColumn={dropOnColumn}
-              onDropAtCard={dropAtCard}
-              onCardContext={handleCardContext}
-              onOpenGitHub={setModalIssue}
-              onMoveGitHub={handleMoveGitHub}
-              onGitHubDragStart={handleGitHubDragStart}
-              hasMoreGitHub={githubVisible && !!githubPage(col.id)?.nextCursor}
-              onLoadMoreGitHub={() => void loadMoreGitHub(api.githubIssues, projectId, col.id)}
             />
           ))}
           <button

--- a/src/renderer/lib/kanbanSources.test.ts
+++ b/src/renderer/lib/kanbanSources.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectKanban } from '@shared/types'
+import { KANBAN_SOURCES, byLane, kanbanSource, sourceVisible } from './kanbanSources'
+
+const board = (github?: ProjectKanban['github']): ProjectKanban =>
+  ({ columns: [], assignments: [], github }) as ProjectKanban
+
+describe('kanban source registry', () => {
+  it('declares each source once, with a unique lane', () => {
+    const ids = KANBAN_SOURCES.map((s) => s.id)
+    const lanes = KANBAN_SOURCES.map((s) => s.lane)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(new Set(lanes).size).toBe(lanes.length)
+  })
+
+  it('stacks sessions above provider-placed cards in a column', () => {
+    const ordered = byLane([{ sourceId: 'github' as const }, { sourceId: 'sessions' as const }])
+    expect(ordered.map((lane) => lane.sourceId)).toEqual(['sessions', 'github'])
+  })
+
+  it('keeps the board out of a provider-placed card’s column', () => {
+    expect(kanbanSource('github').placement).toBe('provider')
+    expect(kanbanSource('sessions').placement).toBe('assignment')
+  })
+
+  it('offers GitHub only on a board configured for it; sessions always', () => {
+    expect(kanbanSource('github').configured(board())).toBe(false)
+    expect(kanbanSource('github').configured(board({ repository: 'owner/repo', columnMappings: [] }))).toBe(true)
+    expect(kanbanSource('sessions').configured(board())).toBe(true)
+  })
+
+  it('shows one source under its own filter, every source under "all"', () => {
+    expect(sourceVisible('all', 'github')).toBe(true)
+    expect(sourceVisible('all', 'sessions')).toBe(true)
+    expect(sourceVisible('sessions', 'github')).toBe(false)
+    expect(sourceVisible('github', 'sessions')).toBe(false)
+    expect(sourceVisible('github', 'github')).toBe(true)
+  })
+
+  it('rejects an unknown source id rather than answering for it', () => {
+    expect(() => kanbanSource('nope' as never)).toThrow()
+  })
+})

--- a/src/renderer/lib/kanbanSources.ts
+++ b/src/renderer/lib/kanbanSources.ts
@@ -1,0 +1,65 @@
+import type { ProjectKanban } from '@shared/types'
+
+/** Where a board card can come from. Sources are a membership list plus one concrete leaf each
+ *  (the card component and the list path that feeds it) — the same discipline `AGENT_CONFIG`
+ *  uses for agents, so no consumer spells a source id to decide how a card behaves. */
+export type KanbanSourceId = 'github' | 'sessions'
+
+/** The board's source filter: everything, or exactly one source. */
+export type KanbanSourceFilter = 'all' | KanbanSourceId
+
+export interface KanbanSourceDef {
+  id: KanbanSourceId
+  /** Button label in the source filter. */
+  label: string
+  /** Where a card's column comes from.
+   *  `assignment` — the board's own `assignments` list, persisted in `.nodeterm/project.json`
+   *  and reorderable within a column.
+   *  `provider` — the provider reports the column; the board persists nothing for the card and
+   *  a move is the provider's write, not a board edit. */
+  placement: 'assignment' | 'provider'
+  /** In-column stacking order, low first. */
+  lane: number
+  /** Whether this source can contribute cards to a given board at all. */
+  configured: (board: ProjectKanban) => boolean
+}
+
+/** Declaration order IS the source filter's button order; `lane` is the in-column stacking
+ *  order. The two genuinely differ on the board today (the filter reads All · GitHub · Sessions
+ *  while a column stacks its sessions above its issues), and pinning both here is what keeps
+ *  either of them from being re-spelled at a call site. */
+export const KANBAN_SOURCES: readonly KanbanSourceDef[] = [
+  {
+    id: 'github',
+    label: 'GitHub',
+    placement: 'provider',
+    lane: 1,
+    configured: (board) => !!board.github
+  },
+  {
+    id: 'sessions',
+    label: 'Sessions',
+    placement: 'assignment',
+    lane: 0,
+    configured: () => true
+  }
+]
+
+const BY_ID = new Map(KANBAN_SOURCES.map((source) => [source.id, source]))
+
+export function kanbanSource(id: KanbanSourceId): KanbanSourceDef {
+  const source = BY_ID.get(id)
+  if (!source) throw new Error(`unknown kanban source: ${id}`)
+  return source
+}
+
+/** Does the current filter show this source's cards? */
+export function sourceVisible(filter: KanbanSourceFilter, id: KanbanSourceId): boolean {
+  return filter === 'all' || filter === id
+}
+
+/** Sorts lanes into their in-column stacking order. Callers hand lanes over in whatever order
+ *  they built them; the registry decides what a column shows first. */
+export function byLane<T extends { sourceId: KanbanSourceId }>(lanes: T[]): T[] {
+  return [...lanes].sort((a, b) => kanbanSource(a.sourceId).lane - kanbanSource(b.sourceId).lane)
+}


### PR DESCRIPTION
Phase 1 of the #462 plan: internal plumbing only, no behaviour change and no new UI. PR cards land on top of this in the next PR.

**Review decision:** does `lib/kanbanSources.ts` declare the right things about a card source, and does the board still behave identically? The existing kanban tests are unchanged, which is the mechanical half of that answer.

## What changed

`KanbanColumn` stitched two mechanisms together: session cards arrived as `cards` and were placed by the board's own assignments, GitHub cards arrived as eight `github*` props and were placed by the provider. The drag union branched on `kind: 'github'` by hand, and the source filter was three hardcoded strings. PR cards on top of that would have been a third copy of the path.

New `src/renderer/lib/kanbanSources.ts` declares each source once - the same membership-plus-one-leaf shape `AGENT_CONFIG` uses:

- `label` - its button in the source filter
- `placement` - `assignment` (the board's persisted assignments, reorderable in a column) or `provider` (the provider reports the column; a move is its write, not a board edit)
- `lane` - in-column stacking order
- `configured(board)` - whether the source can contribute cards to this board at all

Consumers stop spelling source names:

- `KanbanSourceFilter` renders `all` plus the registry.
- `KanbanColumn` takes one `lanes` prop (`{sourceId, cards, footer?, count}`), places them via `byLane`, and knows nothing about where a card came from - eight props and two hardcoded render blocks gone.
- `KanbanView` builds each source's leaf, and the drop path branches on `placement` via `isProviderDrag` rather than on the string `github`.

Two details worth a reviewer's eye:

- **Two orders are declared deliberately.** Declaration order is the filter's button order (All / GitHub / Sessions); `lane` is the in-column stacking order (sessions above issues). They genuinely differ on the board today, so pinning both is what stops either being re-spelled at a call site.
- **A lane's `count` is passed, not derived from its cards.** A provider reports a column total that can exceed the page fetched so far, which is what the old `displayCount` prop carried.

Out of the registry on purpose, per the scope agreed in #462: the virtual **Ungrouped** column stays board semantics, and `validKanban` stays the single shape gate on every load path - no entry grows its own validation.

## Verification

<details>
<summary>Tests, typecheck, surfaces</summary>

- **Existing kanban tests pass unchanged** - no test file was edited. Kanban suites: 67 passed.
- New tests: `kanbanSources.test.ts` (registry shape, lane order, placement, filter visibility, unknown id) and `KanbanColumn.test.tsx` (lanes placed in registry order regardless of the order handed in, lane footer placement, count sums every lane).
- `npm run typecheck` clean.
- Full suite: 9041 passed, 29 failed - the identical failing set on a clean checkout of `main` here (unpatched `node-pty` in `node_modules`, real-tmux/ssh/session-host suites). None are kanban.
- Surfaces: Desktop and Server Edition share this renderer code, and both are unaffected by construction (pure renderer refactor, no bridge member touched). Mobile: N/A - no board there.

</details>

## Follow-ups (unchanged from the #462 plan)

2. PR cards, read-only - one registry entry plus one list path.
3. Explicit attachment plus the canvas chip.
4. create-from-nodeterm.

Draft while you take a first look at the registry entry's shape - happy to resize it before it carries a second source.