### PR TITLE
feat(canvas-control): --model on the open verbs, per-role model in spawn-team

### DIFF
--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -292,6 +292,20 @@ describe('parseControlRequest', () => {
     expect(isDestructiveVerb('sticky')).toBe(false)
   })
 
+  it('both agent-facing texts document --model on the open verbs and per-role model on spawn-team', () => {
+    for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
+      // The flag is the only cost lever an orchestrator has: without it every station it opens
+      // inherits one default model. A body that stops naming it leaves that lever undiscoverable,
+      // which is the state this test was written to end.
+      expect(body).toContain('--model')
+      // Both silent no-ops must be stated, or an agent reads a missing flag as a failed call:
+      // a non-switch-capable agent ignores it, and an unknown id fails in-session, not at open.
+      expect(body.toLowerCase()).toContain('ignore')
+      // Per-role model is what lets ONE spawn-team call mix tiers; the JSON example must show it.
+      expect(body).toContain('"model"')
+    }
+  })
+
   it('both agent-facing texts document the sticky verb', () => {
     for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
       expect(body).toContain('`sticky --node')

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -289,8 +289,8 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     'Verbs:',
     '- `list` — current nodes (id, kind, title). Start here when you need a node id.',
     '- `open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>] [--project <id>]` — open N plain terminals.',
-    '- `open-claude [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]` — open N Claude sessions.',
-    `- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open`,
+    '- `open-claude [--count N] [--cwd P] [--prompt T] [--model M] [--group <id>] [--after <id,id>] [--project <id>]` — open N Claude sessions.',
+    `- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open`,
     '  any agent CLI. `--group` parents the node(s) into a group frame; a worktree-bound group also',
     '  hands its worktree path down as the cwd. `--after <id,id>` opens the node ARMED: it does not',
     '  start until every listed station has gone idle, and is context-linked to them so it can read',
@@ -302,6 +302,12 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  included); or an id `open-project` returned to YOU in this session, which never switches the',
     '  user\'s view. A session opened into a non-active project starts when the user next views that',
     '  project — do not poll for it. `--group`/`--after` cannot be combined with `--project`.',
+    '  `--model <id>` picks the model the session launches with, instead of inheriting the',
+    '  default. Use it to keep a cheap station cheap: a node whose whole job is editing a README',
+    '  does not need the model you give the node rewriting a test suite. Honoured by claude, codex',
+    '  and copilot (and custom agents based on them); any other agent ignores it and launches',
+    '  exactly as it would without the flag. The id is passed to the CLI as-is, so a name that',
+    '  agent does not recognise fails inside the session, not at open time — name a model you know.',
     '- `open-project --cwd </abs/path> [--name N] [--color C]` — register (or find) the project for a',
     '  local directory; the reply carries `{ projectId, name, cwd, created }`. Idempotent: the same',
     '  cwd always returns the same project, never a duplicate. Creating/adding asks the user to',
@@ -328,8 +334,10 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  review panel over that node\'s work: one reviewer per lens, each armed behind the target and linked',
     '  to it, plus a judge armed behind the panel that merges the findings into one verdict. Reviewers are',
     '  told not to change files. Prefer this over asking one agent to double-check itself.',
-    '- `spawn-team --label L --team \'[{"title":"UI","prompt":"...","agent":"claude"}]\'` — one agent per',
+    '- `spawn-team --label L --team \'[{"title":"UI","prompt":"...","agent":"claude","model":"..."}]\'` — one agent per',
     '  role (max 8), arranged in a grid, wrapped in a labeled group, each connected + context-linked to you.',
+    '  `model` is per role, so one team can mix tiers — give an expensive model to the role that needs it',
+    '  and a cheap one to the rest. Same rule as `--model` below.',
     '- `open-worktree --branch <name> [--base <ref>] [--path P] [--group <id>]` — create a git worktree',
     '  wrapped in a bound group frame (terminals inside it run in the worktree). Local projects only.',
     '- `close-worktree --group <id> [--mode unbind|remove]` — unbind keeps the directory; remove asks',
@@ -613,8 +621,8 @@ value is allowed anywhere on the line, not only at the end.
 Verbs:
 - \`list\` — list current nodes (id, kind, title). Start here when you need a node id.
 - \`open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>] [--project <id>]\` — open N plain terminals (default 1).
-- \`open-claude [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open N Claude sessions (default 1).
-- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open N sessions of any agent CLI.
+- \`open-claude [--count N] [--cwd P] [--prompt T] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open N Claude sessions (default 1).
+- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open N sessions of any agent CLI.
   \`--group\` parents the node(s) into an existing group frame; a worktree-bound group also
   hands its worktree path down as the cwd.
   \`--after <id,id>\` opens the node **armed**: it does NOT start yet, and launches itself once
@@ -632,6 +640,14 @@ Verbs:
   TARGET project's (its cwd, its default account and permission mode). A session opened into a
   non-active project starts when the user next views that project — do not poll for it; the reply
   says so. \`--group\`/\`--after\` cannot be combined with \`--project\`.
+  \`--model <id>\` decides which model the session LAUNCHES with, instead of inheriting the
+  project default. This is the lever for cost: a station whose job is editing a README does not
+  need the model you give the station rewriting a 1000-line test suite, and without this flag
+  every station you open runs on the same one. Honoured by claude, codex and copilot (and custom
+  agents declaring one of those as their base); every other agent IGNORES it and launches exactly
+  as it would have — the flag is never an error, so a mixed fan-out needs no special-casing. The
+  id goes to the CLI verbatim: an unknown name fails inside the session on its first turn, not at
+  open time, so name a model you know that CLI accepts rather than guessing.
 - \`open-project --cwd </abs/path> [--name N] [--color C]\` — register (or find) the project for a
   local directory; the reply carries \`{ projectId, name, cwd, created }\`. Idempotent: the same
   cwd always returns the same project, never a duplicate — and \`--name\`/\`--color\` apply only
@@ -677,9 +693,11 @@ Verbs:
   they share one checkout, and finding is a separate job from fixing. Use this instead of asking
   one agent "are you sure?": several INDEPENDENT looks from different angles catch what one pass,
   or several identical passes, cannot.
-- \`spawn-team --label "Frontend Team" --team '[{"title":"UI","prompt":"...","agent":"claude"}]'\` —
+- \`spawn-team --label "Frontend Team" --team '[{"title":"UI","prompt":"...","agent":"claude","model":"..."}]'\` —
   open one agent per role (each prompt starts that member working), arrange them in a grid,
   wrap them in a labeled group, and connect + context-link each to you. Max 8 roles per call.
+  \`model\` is optional and per role — the same selector \`--model\` applies, so a single team can
+  run its heavy role on a large model and the rest on a cheap one.
 - \`open-worktree --branch <name> [--base <ref>] [--path P] [--group <id>]\` — create a git
   worktree (new branch off base, default: the repo's default branch) and wrap it in a bound
   group frame (or bind it to an existing empty group). Terminals created inside the group

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -8633,7 +8633,11 @@ export function Canvas() {
                   activePermissionMode(agentId),
                   // Same project the account funnel above resolves from: the canvas the verb runs
                   // on, whose `.nodeterm/settings.json` launch command applies to what it opens.
-                  projStore.activeProjectId
+                  projStore.activeProjectId,
+                  // `--model` is a pass-through: `withAgentModel` re-validates the value at the
+                  // interpolation site and emits nothing for an agent outside MODEL_SWITCH_CAPABLE,
+                  // so an unsupported agent's command line stays byte-identical.
+                  args.model
                 ),
                 after ?? [],
                 undefined,
@@ -9057,12 +9061,15 @@ export function Canvas() {
             return
           }
           case 'spawn-team': {
-            let roles: { title?: string; prompt?: string; agent?: string }[]
+            let roles: { title?: string; prompt?: string; agent?: string; model?: string }[]
             try {
               const parsed = JSON.parse(args.team ?? '')
               roles = Array.isArray(parsed) ? parsed : []
             } catch {
-              reply({ ok: false, error: 'spawn-team: --team must be a JSON array of {title?, prompt, agent?}' })
+              reply({
+                ok: false,
+                error: 'spawn-team: --team must be a JSON array of {title?, prompt, agent?, model?}'
+              })
               return
             }
             roles = roles.filter((r) => r && typeof r.prompt === 'string' && r.prompt.trim()).slice(0, 8)
@@ -9093,7 +9100,10 @@ export function Canvas() {
                 sshFor(srcCwd),
                 teamAccount,
                 activePermissionMode(memberAgent),
-                teamStore.activeProjectId
+                teamStore.activeProjectId,
+                // Per-role model, so one team can mix tiers in a single call. A role naming a
+                // model its agent cannot switch simply launches bare (withAgentModel no-ops).
+                typeof r.model === 'string' ? r.model : undefined
               )
               return r.title ? { ...node, data: { ...node.data, title: r.title, titleAuto: false } } : node
             })


### PR DESCRIPTION
An orchestrator asked to keep costs reasonable has no lever today. Every station it opens inherits the project default, so a node whose whole job is editing a README runs on the same model as the node rewriting a 1100-line test suite.

The plumbing already exists end to end — only the control verbs stop short of using it:

- `createAgentNode` takes a `model` parameter and persists it as `data.agentModel`, so cold restore and in-place restart keep it.
- `withAgentModel` appends a safely quoted `--model` for a `MODEL_SWITCH_CAPABLE` agent and no-ops otherwise.
- The `open-claude` / `open-agent` case calls `createAgentNode` with nine arguments; `spawn-team` does the same per role.

## What this adds

- `--model <id>` on `open-claude` and `open-agent`.
- An optional `model` key per role in the `spawn-team` JSON, so one call can mix tiers.
- Both generated agent-facing bodies document the flag, plus a doc test that reddens if either stops naming it.

Pass-through by design: `normalizedAgentModel` already re-validates the value at the interpolation site (length, control characters, capability), so a hostile `--model` off the wire cannot reach a command line, and an agent outside `MODEL_SWITCH_CAPABLE` produces a byte-identical launch line.

## The two silent no-ops, and why they are documented rather than fixed

- An agent that cannot switch models ignores the flag. Making that an error would mean a mixed fan-out had to special-case which roles may carry a model, so the docs state it instead.
- An unknown model id fails inside the session on its first turn, not at open time. Refusing at open would mean consulting the gateway's discovery list (`agent:discover-models`) inside the verb — a design call about whether the verb blocks on a network round trip. **Happy to do that as a follow-up if you want it; I did not want to decide it inside a pass-through PR.**

## Testing

- `canvas-control-core.test.ts` — 47 passing, including the new doc pin.
- `npx tsc --noEmit -p tsconfig.node.json` and `-p tsconfig.web.json` clean for the touched files.
- Two suites fail on my checkout before and after this branch: `node-pty-patch.test.ts` (documented as red on an unpatched `node_modules`) and `remote-atomic-write.test.ts`. Verified pre-existing by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhoRtz59pbXu7XpXfTrH9R
