### PR TITLE
docs(canvas-control): say that --prompt arrives on one line

### DIFF
--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -292,6 +292,19 @@ describe('parseControlRequest', () => {
     expect(isDestructiveVerb('sticky')).toBe(false)
   })
 
+  it('both agent-facing texts warn that --prompt is one line and must not start with a slash', () => {
+    for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
+      // `assembleLaunchCommand` collapses every whitespace run in the prompt, because the prompt
+      // rides argv on a line that is typed into the pane. An agent that does not know this writes
+      // a numbered brief and gets one paragraph.
+      expect(body.toLowerCase()).toContain('one line')
+      // The failure that costs a whole station: flattened, a leading slash command swallows the
+      // task as its argument, and the node then reads as idle to `--after`. Silence here is what
+      // let that ship.
+      expect(body).toMatch(/start a prompt with `\/`|begin a prompt with `\/`/i)
+    }
+  })
+
   it('both agent-facing texts document --model on the open verbs and per-role model on spawn-team', () => {
     for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
       // The flag is the only cost lever an orchestrator has: without it every station it opens

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -303,6 +303,13 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  included); or an id `open-project` returned to YOU in this session, which never switches the',
     '  user\'s view. A session opened into a non-active project starts when the user next views that',
     '  project — do not poll for it. `--group`/`--after` cannot be combined with `--project`.',
+    '  `--prompt` arrives on ONE LINE: every run of whitespace in it, newlines included, is',
+    '  collapsed to a single space before the session starts. Write the task as continuous prose',
+    '  and use sentences where you would have used bullets — a numbered list arrives as one',
+    '  paragraph. Never begin a prompt with `/`: once flattened, the agent reads the whole prompt',
+    '  as arguments to that slash command, your task is never seen, and the node then sits idle',
+    '  looking healthy. To pick a model use `--model`, not a leading `/model`. To send a long or',
+    '  structured brief, open the node and follow up with `send --node <id> --text "..."`.',
     '  `--model <id>` picks the model the session launches with, instead of inheriting the',
     '  default. Use it to keep a cheap station cheap: a node whose whole job is editing a README',
     '  does not need the model you give the node rewriting a test suite. Honoured by claude, codex',
@@ -670,6 +677,19 @@ Verbs:
   TARGET project's (its cwd, its default account and permission mode). A session opened into a
   non-active project starts when the user next views that project — do not poll for it; the reply
   says so. \`--group\`/\`--after\` cannot be combined with \`--project\`.
+  \`--prompt\` arrives on ONE LINE. Every run of whitespace in it — newlines included — is
+  collapsed to a single space before the session starts, because the prompt is passed as an
+  argument on the agent CLI's launch command line and that line is typed into the pane. So write
+  the task as continuous prose: a numbered list or a markdown heading arrives as one paragraph,
+  and indentation is lost. Two consequences worth planning around:
+  - **Never start a prompt with \`/\`.** Flattened, \`/model sonnet\` followed by your task reads
+    to the agent as one slash command whose argument is the entire rest of the prompt. The
+    command fails, your task is never seen, and the node then sits at an idle prompt looking
+    perfectly healthy — including to \`--after\`, which will arm everything behind it. Use
+    \`--model\` for the model; there is no supported way to run a slash command at launch.
+  - **For a long or structured brief, split it.** Open the node with a short \`--prompt\` (or
+    none), then deliver the body with \`send --node <id> --text "..."\`, which preserves the text
+    as written.
   \`--model <id>\` decides which model the session LAUNCHES with, instead of inheriting the
   project default. This is the lever for cost: a station whose job is editing a README does not
   need the model you give the station rewriting a 1000-line test suite, and without this flag

--- a/src/shared/agents/launch.ts
+++ b/src/shared/agents/launch.ts
@@ -154,6 +154,14 @@ export function assembleLaunchCommand(
   const { fragment: argsFragment, missing: m2 } = expandedArgs(inputs.customAgent?.args ?? '', env)
   const baseCmd = argsFragment ? `${program} ${argsFragment}` : program
 
+  // The prompt becomes a POSITIONAL ARGUMENT on a command line that is then typed into the pane
+  // (`writeWhenShellReady` -> `deliverCommand`, which echo-verifies the line before submitting it).
+  // A newline inside it would submit the half-typed line and fail that verification, so every run
+  // of whitespace is collapsed to a single space. Load-bearing for this delivery path, not tidying:
+  // preserving structure means delivering the prompt as a MESSAGE after launch (sendText, which
+  // frames multi-line text through tmux `paste-buffer -p`) rather than as argv. Callers that let a
+  // user or an agent supply the prompt must say the text arrives on one line -- see
+  // `buildCanvasSkillBody` / `buildCanvasControlInstructions`.
   const promptArg = inputs.initialPrompt
     ? shellSingleQuote(inputs.initialPrompt.replace(/\s+/g, ' ').trim())
     : null


### PR DESCRIPTION
`assembleLaunchCommand` collapses every whitespace run in the prompt:

```ts
shellSingleQuote(inputs.initialPrompt.replace(/\s+/g, ' ').trim())
```

That is load-bearing, not tidying: the prompt is a positional argument on the agent CLI's launch command line, and that line is *typed into the pane* by `writeWhenShellReady` → `deliverCommand`, which echo-verifies it before submitting. A newline would submit the half-typed line and fail verification.

Neither agent-facing body mentions it. Grepping `canvas-control-core.ts` for `newline` or `single line` returns nothing.

## The failure this cost

The expensive case is a prompt beginning with `/`. Flattened, a leading `/model sonnet` followed by the task reads to the agent as one slash command whose argument is the entire rest of the prompt:

```
> /model sonnet Do not use any tools. Reply with exactly two lines: MODEL: <the
exact model id you are running as> SAW: <yes if a slash command named /model ...
  |- API error: 400
     {"error":{"message":"model: String should have at most 256 characters"}}
```

The command fails, the task is never seen, and the node then sits at an idle prompt looking healthy — **including to `--after`**, which arms every station behind it against an upstream that produced nothing. In a dependency chain one such prompt can start the rest of the pipeline on bad ground.

## What this changes

Documentation only, no behaviour change.

- Both bodies state that `--prompt` arrives on one line and that structure is lost.
- Both name the leading-slash trap and its `--after` consequence explicitly.
- Both point at the two supported alternatives: `--model` for a model, and `send --node <id> --text` for a long or structured brief.
- The collapse is commented at its source, so the next reader knows why it cannot simply be deleted.
- A doc test pins both claims.

## Two things deliberately left out, for you to call

1. **Refusing a prompt that starts with `/`** in `parseControlRequest`. Cheap to add and arguably better than documenting a trap — but it is a behaviour change to a verb agents already call, so I would rather you decide than have it arrive inside a docs PR.
2. **Preserving newlines properly.** Given the above this means not putting the prompt in argv at all: launch the CLI bare, then deliver the body through `sendText`, which already frames multi-line text via tmux `paste-buffer -p`. That changes how every agent node starts and wants its own issue.

## Testing

`canvas-control-core.test.ts` and the `shared/agents` suites pass (316 tests). Same two pre-existing environmental failures as on `main` (`node-pty-patch`, `remote-atomic-write`), verified by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhoRtz59pbXu7XpXfTrH9R
