### PR TITLE
fix(canvas-control): distinguish an unanswered confirm dialog from a denial

### DIFF
--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -292,6 +292,15 @@ describe('parseControlRequest', () => {
     expect(isDestructiveVerb('sticky')).toBe(false)
   })
 
+  it('both agent-facing texts separate a denial from an unanswered dialog', () => {
+    for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
+      // The two answers carry opposite guidance — a denial is final, a timeout is retryable — and
+      // a body that names only "may be denied" leaves a caller reading its own timeout as refusal.
+      expect(body).toContain('denied by user')
+      expect(body).toContain('no answer within 120s')
+    }
+  })
+
   it('both agent-facing texts document --model on the open verbs and per-role model on spawn-team', () => {
     for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
       // The flag is the only cost lever an orchestrator has: without it every station it opens

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -346,7 +346,9 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '- `branch --node <id>` — branch a Claude node\'s conversation (Claude nodes only).',
     '- `rename --node <id> --title "New Name"` — rename any node (terminals, groups, stickies…).',
     '- `write --node <id> --text "..."` / `close --node <id>` — type into / close a node.',
-    '  Both ask the user to confirm a dialog and may be denied.',
+    '  Both ask the user to confirm a dialog and may be denied. Read WHICH answer came back:',
+    '  `denied by user` is a decision and is FINAL — never re-ask — while `no answer within 120s`',
+    '  means nobody reached the dialog, which is worth one retry when the user is back.',
     '- `send --node <id> --text "..."` / `reply --node <id> --text "..."` — deliver a message into',
     '  another AGENT node in this project (no confirm dialog: verified-only, gated by the project\'s',
     '  agent-messaging switch — off by default — and rate-limited). A busy target is not interrupted',
@@ -782,6 +784,9 @@ ${browserGuidanceLines().join('\n')}
 
 Notes:
 - \`write\` and \`close\` require the user to approve a confirmation dialog; they may be denied.
+  Two different replies, two different follow-ups: \`denied by user\` is a decision and is FINAL —
+  never re-ask — whereas \`no answer within 120s\` means the dialog was simply not reached in
+  time, which is worth one retry when the user is back at the machine.
 - \`board\` and \`assign\` act on the CURRENTLY OPEN project's board — the same one you see when you
   toggle the kanban view. They need no confirmation.
 - If the CLI says canvas control is unavailable, you are not in a controllable nodeterm session — do not retry.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2805,7 +2805,9 @@ app.whenReady().then(async () => {
   corePlatform.on(IPC.ptyRecycle, (nodeId: string) => releaseNodeTails(nodeId))
   // Agent canvas control: the spawned agent's `nodeterm` CLI POSTs a verb to the hook server,
   // which we forward to the renderer and await a reply. A pending-request map (keyed by a random
-  // requestId) bridges the two async hops; both the reply and the 120s timeout clear the entry.
+  // requestId) bridges the two async hops; both the reply and the timeout below clear the entry.
+  // The window is generous because a confirm-gated verb waits on a human, not on the renderer.
+  const CONTROL_REQUEST_TIMEOUT_MS = 120_000
   const pendingControl = new Map<
     string,
     {
@@ -3135,8 +3137,15 @@ app.whenReady().then(async () => {
     const result = await new Promise<{ ok: boolean; message?: string; result?: unknown; error?: string }>((resolve) => {
       const timer = setTimeout(() => {
         pendingControl.delete(requestId)
-        resolve({ ok: false, error: 'timed out (no response / not confirmed)' })
-      }, 120_000)
+        // Name the timeout and say it is retryable. A DENIAL is a different answer with different
+        // guidance (`denied by user`, final, never retried), and the old wording — "no response /
+        // not confirmed" — read as though it covered both, so a caller that had merely waited out
+        // an unanswered dialog treated it as a refusal and gave up.
+        resolve({
+          ok: false,
+          error: `no answer within ${CONTROL_REQUEST_TIMEOUT_MS / 1000}s — the confirmation dialog may still be open; safe to retry`
+        })
+      }, CONTROL_REQUEST_TIMEOUT_MS)
       pendingControl.set(requestId, { resolve, timer })
       target.webContents.send(IPC.agentControl, { requestId, sourceNodeId: nodeId, verb, args })
     })


### PR DESCRIPTION
A confirm-gated verb (`write`, `close`, `open-project`, `close-worktree --mode remove`) has two ways to come back unsuccessful, and they carry opposite guidance:

- `denied by user` — a decision. The skill text says a denial is final and must not be retried.
- The 120s timeout — nobody reached the dialog. Plainly worth retrying.

The timeout said `timed out (no response / not confirmed)`, which reads as though it covered both. A caller that had merely waited out an unanswered dialog treated it as a refusal and gave up — which is how I read it during a seven-station run, and why I originally filed this as "a timeout and a denial are indistinguishable to the caller". They are in fact distinct; only the wording was.

## Changes

- The timeout names its window and says it is retryable: `no answer within 120s — the confirmation dialog may still be open; safe to retry`.
- `120_000` becomes `CONTROL_REQUEST_TIMEOUT_MS`, so the number in the message cannot drift from the number in the `setTimeout`.
- Both agent-facing bodies now state the two replies and the follow-up each one warrants. Previously they said only "may be denied", which gave a caller nothing to distinguish its own timeout from.

## Testing

`canvas-control-core.test.ts` — 47 passing, including a new pin that both bodies name both replies. `npx tsc --noEmit -p tsconfig.node.json` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhoRtz59pbXu7XpXfTrH9R
