### PR TITLE
feat(canvas-control): a help verb, answered by the shim itself

### DIFF
--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -288,6 +288,7 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '',
     'Verbs:',
     '- `list` — current nodes (id, kind, title). Start here when you need a node id.',
+    '- `help` — print the verb list. Answered by the shim itself, so it works even if the app is down.',
     '- `open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>] [--project <id>]` — open N plain terminals.',
     '- `open-claude [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]` — open N Claude sessions.',
     `- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open`,
@@ -413,6 +414,16 @@ export function buildCanvasControlInstructions(shimPath: string): string {
  *  verbatim and the parity test holds the two ends together (issue #367). */
 export const CONTROL_UNREACHABLE_MSG = 'Could not reach nodeterm (control endpoint unreachable).'
 
+/** The verb list `help` prints, DERIVED from the registry rather than re-typed — a verb added to
+ *  `VERBS` is discoverable from the CLI the day it lands, which is the whole point of the verb.
+ *  Names only, deliberately: flags live in the skill body, and a second copy of them here would be
+ *  a second thing to keep in sync. */
+export const helpVerbList = (): string => VERBS.join(' ')
+
+/** The registry, exposed for the `help` test so it asserts against the source of truth rather than
+ *  a copy of the list it is checking. Not for production use — read `VERBS` directly. */
+export const VERBS_FOR_TEST: readonly ControlVerb[] = VERBS
+
 export const CONTROL_SHIM_SCRIPT = `#!/bin/sh
 # nodeterm canvas-control CLI (auto-generated — do not edit).
 
@@ -444,6 +455,23 @@ ${CODEX_SANDBOX_HINT_SH}
 
 nt_verb="list"
 if [ $# -gt 0 ]; then nt_verb="$1"; shift; fi
+
+# \`help\` is answered HERE, not by the server: a bare invocation defaults to \`list\`, so the verb
+# set was undiscoverable from the CLI itself — the one place an agent looks when its skill text is
+# not to hand. Local and free, so it also answers when the app is down.
+if [ "$nt_verb" = "help" ] || [ "$nt_verb" = "--help" ] || [ "$nt_verb" = "-h" ]; then
+  echo "nodeterm canvas control — usage: sh <this script> <verb> [--flag value]"
+  echo
+  echo "Verbs:"
+  echo "  ${helpVerbList()}"
+  echo
+  # Single quotes: a backtick inside a double-quoted echo is command substitution, and the first
+  # word of the verb list is \`list\` — which sh then tried to RUN.
+  echo 'Run with no verb to list the current nodes (same as \`list\`).'
+  echo "Flags take a value: --flag value, or --flag=value when the value starts with '--'."
+  echo "Per-verb flags are documented in the manage-nodeterm-canvas skill / instructions block."
+  exit 0
+fi
 
 # Translate \`--flag value\` pairs — plus the one bare positional the show-image/show-video and
 # write/close/rename/branch/send/reply/sticky forms accept — into curl --data-urlencode arguments. The positional
@@ -612,6 +640,8 @@ value is allowed anywhere on the line, not only at the end.
 
 Verbs:
 - \`list\` — list current nodes (id, kind, title). Start here when you need a node id.
+- \`help\` — print the verb list. The shim answers this itself, without reaching the app, so it
+  is also what to run when you are unsure whether the control endpoint is alive.
 - \`open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>] [--project <id>]\` — open N plain terminals (default 1).
 - \`open-claude [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open N Claude sessions (default 1).
 - \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--group <id>] [--after <id,id>] [--project <id>]\` — open N sessions of any agent CLI.

--- a/src/main/control-shim-help.test.ts
+++ b/src/main/control-shim-help.test.ts
@@ -1,0 +1,55 @@
+// `help` is answered by the shim itself, so it is tested the same way the flag loop is: the REAL
+// script under REAL `sh`, with a `curl` that fails the run if it is called at all. A local answer
+// that quietly round-trips would still pass a test that only inspected stdout.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { CONTROL_SHIM_SCRIPT, VERBS_FOR_TEST } from './canvas-control-core'
+
+let dir = ''
+
+const run = (args: string[]): string =>
+  execFileSync('sh', [path.join(dir, 'shim.sh'), ...args], {
+    env: {
+      PATH: `${path.join(dir, 'bin')}:${process.env.PATH ?? ''}`,
+      NODETERM_CANVAS_CONTROL: '1',
+      NODETERM_HOOK_PORT: '1',
+      NODETERM_NODE_ID: 'n1',
+      HOME: dir
+    },
+    encoding: 'utf8'
+  })
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ctlhelp-'))
+  fs.mkdirSync(path.join(dir, 'bin'))
+  fs.writeFileSync(path.join(dir, 'shim.sh'), CONTROL_SHIM_SCRIPT, { mode: 0o755 })
+  // Any invocation is a failure: help must cost no network, so it also works while the app is down.
+  fs.writeFileSync(path.join(dir, 'bin', 'curl'), '#!/bin/sh\nexit 77\n', { mode: 0o755 })
+})
+
+afterAll(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+describe('the control shim answers help locally', () => {
+  it.each(['help', '--help', '-h'])('%s prints usage without calling curl', (flag) => {
+    const out = run([flag])
+    expect(out).toContain('usage:')
+    expect(out).toContain('Verbs:')
+  })
+
+  it('lists every registered verb — the list is derived, not re-typed', () => {
+    // The reason `help` exists is that the verb set was undiscoverable from the CLI. A hand-copied
+    // list would go stale on the first verb added and put us back where we started, so this asserts
+    // against the registry itself.
+    const out = run(['help'])
+    for (const verb of VERBS_FOR_TEST) expect(out).toContain(verb)
+  })
+
+  it('points at the skill for per-verb flags rather than restating them', () => {
+    // Flags are documented once, in the generated bodies. A second copy inside the shim is a second
+    // thing to keep in sync, and the shim is the copy that goes stale on an SSH host until reconnect.
+    expect(run(['help'])).toContain('manage-nodeterm-canvas')
+  })
+})


### PR DESCRIPTION
The shim defaults a bare invocation to `list` (`nt_verb="list"`), so running it with no arguments returns the node list and no hint that anything else exists. There is no way to discover the verb set from the CLI at all — the only source is the skill text, which is exactly what an agent reaches for the CLI to check when it is unsure.

## Changes

- `help` / `--help` / `-h` print usage and the verb list.
- Answered **locally**, before any network work, so it also works when the app is down or the endpoint has gone stale.
- The list is derived from the `VERBS` registry rather than re-typed, so a verb added tomorrow is discoverable the day it lands.
- Per-verb flags are deliberately **not** restated. They are documented once in the generated bodies, and a second copy inside the shim would be the copy that goes stale: an already-connected SSH project keeps the shim it was handed until reconnect.
- The bare-invocation default is untouched, so nothing relying on it changes.

## One shell trap worth flagging

The first draft wrote the pointer line as `echo "… (same as \`list\`)."`. Inside double quotes that backtick is command substitution, and the first word of the verb list is `list` — so `sh` tried to run it. Caught only because the test executes the script; a TypeScript model of the shim would have passed. Single quotes now.

## Testing

New `control-shim-help.test.ts` runs the real script under real `sh` with a `curl` that exits non-zero if it is called at all, so a local answer that quietly round-tripped would fail rather than pass on stdout alone. It asserts against `VERBS` itself rather than a copy of the list under test.

`src/main` suite: 1266 passing. Same two pre-existing environmental failures as on `main` (`node-pty-patch.test.ts`, documented as red on an unpatched `node_modules`; `remote-atomic-write.test.ts`), verified by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhoRtz59pbXu7XpXfTrH9R
