### PR TITLE
fix(keybindings): keep Ctrl+W in focused terminals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1888,8 +1888,14 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
     fall through UNTOUCHED and `syncMenuForStandDown` disables the Close menu item on top of the
     shared list. mac's ⌘W is deliberately unaffected (not a shell key), and ⌘/Ctrl+M and ⌘/Ctrl+0
     keep firing — this is one chord whose terminal meaning outranks its app meaning, not a policy
-    change. One predicate, two consumers, pinned in `keydown-intercept.test.ts` (including a
-    source-level wiring pin, since the menu leg lives against a real Menu in index.ts).
+    change. Falling through main is not enough: xterm's custom key handler runs before the Canvas
+    dispatcher, whose main-intercepted command cases deliberately have no renderer handlers.
+    `terminalChordBubbles` must therefore refuse every `MAIN_INTERCEPTED_COMMAND_IDS` command; if
+    it returned true for `node.close`, xterm would withhold `^W` while the unclaimed event bubbled
+    to Canvas. One predicate, two main-process consumers are pinned in `keydown-intercept.test.ts`
+    (including a source-level wiring pin, since the menu leg lives against a real Menu in index.ts),
+    and `keybindingOverrides.test.ts` pins the renderer-to-xterm hand-off through
+    `terminalKeyAction`.
   - **`terminalFocused` is a MIRROR, and its fail-safe direction is `false` = not focused =
     intercepts ON.** `renderer/lib/terminalFocusMirror.ts` reports focus changes to main and is
     change-deduped (it never re-asserts), so a page that died mid-report, a reload, or a window that

--- a/src/renderer/lib/keybindingOverrides.test.ts
+++ b/src/renderer/lib/keybindingOverrides.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { DEFAULT_SETTINGS } from '@shared/types'
 import { matchesShortcut, type ShortcutKeyEvent } from '@shared/shortcut'
+import { terminalKeyAction } from '../terminal/terminal-config'
 import { useSettings } from '../state/settings'
 import {
   activeKeybindingOverrides, effectiveBindings, commandKeys, commandTooltip, chipFor,
@@ -245,6 +246,19 @@ describe('terminalChordBubbles', () => {
     expect(
       terminalChordBubbles(bubbleEv({ ctrlKey: true, shiftKey: true, key: 'F1' }), false)
     ).toBe(false)
+  })
+
+  it('keeps Ctrl+W in xterm when main stands down for a focused terminal', () => {
+    setKb({ 'node.close': ['Ctrl+W'] })
+    const event = {
+      ...bubbleEv({ ctrlKey: true, key: 'w' }),
+      type: 'keydown',
+      code: 'KeyW'
+    }
+    const bubbles = terminalChordBubbles(event, false)
+
+    expect(bubbles).toBe(false)
+    expect(terminalKeyAction(event, false, false, bubbles)).toBe('pass')
   })
 
   it('false for a chord nothing resolves', () => {

--- a/src/renderer/lib/keybindingOverrides.ts
+++ b/src/renderer/lib/keybindingOverrides.ts
@@ -7,7 +7,7 @@
  */
 import {
   getEffectiveBindings, sanitizeKeybindingOverrides, normalizeTerminalShortcutPolicy,
-  resolveCommandForKeyEvent, COMMANDS_BY_ID,
+  resolveCommandForKeyEvent, COMMANDS_BY_ID, MAIN_INTERCEPTED_COMMAND_IDS,
   type CommandId, type KeybindingOverrides, type TerminalShortcutPolicy
 } from '@shared/keybindings'
 import type { ShortcutKeyEvent } from '@shared/shortcut'
@@ -119,7 +119,10 @@ export function terminalShortcutPolicy(): TerminalShortcutPolicy {
  *  refuses non-terminal-scope commands (the chord stays with the shell), an unbound/remapped
  *  chord follows the live overrides, and `kanbanOpen` refuses canvas-scope commands so a modal
  *  terminal over the board keeps its bytes. Terminal-SCOPE commands are excluded — their local
- *  listeners own them and this helper must not reroute their chords. */
+ *  listeners own them and this helper must not reroute their chords. Main-intercepted commands
+ *  are excluded too: the window dispatcher deliberately has no handlers for them. If the main
+ *  process stands down (notably Ctrl+W in a focused Linux/Windows terminal), xterm must retain the
+ *  chord so the control byte reaches the pty. */
 export function terminalChordBubbles(e: ShortcutKeyEvent, kanbanOpen: boolean): boolean {
   const id = resolveCommandForKeyEvent(
     e,
@@ -132,7 +135,7 @@ export function terminalChordBubbles(e: ShortcutKeyEvent, kanbanOpen: boolean): 
     activeKeybindingOverrides(),
     isMacPlatform()
   )
-  if (id === null) return false
+  if (id === null || MAIN_INTERCEPTED_COMMAND_IDS.includes(id)) return false
   return COMMANDS_BY_ID.get(id)?.scope !== 'terminal'
 }
 


### PR DESCRIPTION
 Follow-up to #383 and #387.

Issue #387 correctly made both main-process owners stand down when an off-mac terminal has focus: the `before-input-event` intercept  leaves `node.close` untouched, and the native Close menu item is disabled.

Under the default app-first policy, `terminalChordBubbles` resolved Ctrl+W to  `node.close` and told xterm to skip its own keymap. Canvas deliberately has no renderer handler for main-intercepted commands, so  `^W` never reached the pty and Electron's fallback close behaviour could still show the quit dialog.

**Change**

- Keep every `MAIN_INTERCEPTED_COMMAND_IDS` chord inside xterm when it reaches the renderer. Main still owns these commands  normally; this branch only matters when main has deliberately stood down.
- Add a regression that follows the actual hand-off: focused-terminal Ctrl+W must not bubble, and `terminalKeyAction` must return  `pass` so xterm sends `^W` to the pty.
- Document the renderer leg alongside the main/menu invariant in `CLAUDE.md`.