### PR TITLE
fix(hud): detect the notch by ratio, not an absolute px inset

### DIFF
--- a/docs/notch-hud.md
+++ b/docs/notch-hud.md
@@ -15,16 +15,26 @@ alwaysOnTop:true, focusable:false, skipTaskbar:true}` + `setAlwaysOnTop(true,'sc
 {forward:true})`. Its own renderer entry `hud.html` (add to electron.vite.config.ts
 `renderer.input`) sharing the existing preload plus a small HUD-specific API.
 
-- **Geometry** from `screen.getPrimaryDisplay()`: the window spans the full top edge (`bounds`,
-  `y = bounds.y`), sized to the EXPANDED box (`HUD_WINDOW_HEIGHT`); we never resize the frame. Main
-  sends the renderer everything it needs to draw the capsule: `bar` (= `workArea.y - bounds.y`,
-  floor `NOTCH_BAR_FLOOR` 24 — the fused top zone height), `width`, `notchWidth` (`settings.notchWidth`
-  clamped to `NOTCH_WIDTH_MIN/MAX` 100–320, falling back to `NOTCH_WIDTH` **168** — Electron exposes
-  no `auxiliaryTopLeftArea`, so assume a centered notch of this width; 200 left a visible gap),
-  `notchCenterX` (= `bounds.width/2`), and `hasNotch` (`inset > 0 && inset >= NOTCH_MIN_BAR`
-  32 — a notched Mac's menu bar is ~37 px vs ~24 on a notchless display; when false the renderer
-  draws a standalone floating pill instead of fusing). Re-asserted on `screen`
-  `display-metrics-changed` + `display-added/removed`.
+- **Geometry** is the pure `hudGeometry` (`notch-hud-geometry.ts`, unit-tested); the controller
+  only feeds it `screen.getPrimaryDisplay()`. The window spans the full top edge (`bounds`,
+  `y = bounds.y`), sized to `bar + HUD_WINDOW_HEIGHT` so the EXPANDED box clears the top strip in
+  either layout; we never resize the frame. Main sends the renderer everything it needs to draw the
+  capsule: `bar` (= `workArea.y - bounds.y`, floor `NOTCH_BAR_FLOOR` 24 — the fused top zone
+  height), `width`, `notchWidth` (`settings.notchWidth` clamped to `NOTCH_WIDTH_MIN/MAX` 100–320,
+  falling back to `NOTCH_WIDTH` **168** — Electron exposes no `auxiliaryTopLeftArea`, so assume a
+  centered notch of this width; 200 left a visible gap), `notchCenterX` (= `bounds.width/2`), and
+  `hasNotch`. Re-asserted on `screen` `display-metrics-changed` + `display-added/removed`.
+
+  **`hasNotch` is a RATIO, never an absolute px count** (`display.internal && inset / bounds.height
+  >= NOTCH_BAR_RATIO` 0.03). macOS reserves a menu bar exactly as tall as the notch, so on a
+  notched panel that strip is a fixed SHARE of the display and survives every scaling mode — a 15"
+  Air reports 37/1112 at its default and 31/932 at 1440x932, both 0.0333. A notchless panel's menu
+  bar is a fixed 24 pt, so its share instead falls as the resolution rises (24/1080 = 0.0222). The
+  predecessor was an absolute `inset >= 32`, which the 0.0333 share only clears while the display
+  is tall enough: the HUD detected the notch at the default scaling and nowhere else, and drew its
+  notchless pill straight into the notch (issue #508). `display.internal` is the second half —
+  notches exist only on built-in panels, so it stops an external at a low resolution from clearing
+  the ratio on its own.
 - **Click-through with a hotspot**: window stays mouse-ignoring; the renderer reports pointer
   enter/leave of the indicator rect over IPC → main toggles `setIgnoreMouseEvents(false/true,
   {forward:true})`. Click in the hotspot → expand; click outside the expanded panel → collapse
@@ -145,14 +155,23 @@ the transparent rest of the window stays click-through. Hidden entirely when idl
   (`dismissedAt`), so a session hung in `working` (agent died mid-turn) stays hidden while any
   genuine state change brings the row back. HUD-local only — the node/terminal is untouched.
 - **Notchless fallback** (`hasNotch === false`, e.g. an external monitor or a display with no menu
-  bar): the `.notchless` root class draws the capsule as a **standalone floating pill** — a small
-  `--pill-top-gap` above it and all-corner `--pill-radius`, since there is no notch to fuse with.
-  Collapsed height = `--pill-height`; the mascots center in the pill (no `--bar` padding to clear).
+  bar): the `.notchless` root class draws the capsule as a **standalone floating pill** — all-corner
+  `--pill-radius`, since there is no notch to fuse with. Collapsed height = `--pill-height`; the
+  mascots center in the pill (no `--bar` padding to clear).
 
-**Tunables** (main constants in `notch-hud.ts`; CSS vars in `hud.css :root`, defaults in parens —
-tune on a Mac): `NOTCH_WIDTH` (168) / `--notch-width` (the CSS fallback is 200; main pushes the real
-value on the first geometry push), `NOTCH_WIDTH_MIN/MAX` (100/320, the settings clamp),
-`NOTCH_MIN_BAR` (32, notch-detection threshold), `NOTCH_BAR_FLOOR` (24), `HUD_WINDOW_HEIGHT` (460),
+  **The pill hangs BELOW the top strip** (`top: calc(var(--bar) + var(--pill-top-gap))`), and that
+  is load-bearing rather than cosmetic. The window's top edge is the display's, so the first
+  `--bar` px are the menu-bar / notch strip; a pill placed there is centred on exactly the
+  coordinates a notch occupies, which made every notch MISdetection invisible instead of merely
+  wrong — the visible half of issue #508. Clearing the strip means the fallback layout stays safe
+  even when the detector is not, and on a genuine notchless display the pill no longer paints over
+  the menu bar it used to overlap.
+
+**Tunables** (main constants in `notch-hud.ts` and `notch-hud-geometry.ts`; CSS vars in
+`hud.css :root`, defaults in parens — tune on a Mac): `NOTCH_WIDTH` (168) / `--notch-width` (main
+pushes the real value on the first geometry push), `NOTCH_WIDTH_MIN/MAX` (100/320, the settings
+clamp), `NOTCH_BAR_RATIO` (0.03, notch-detection threshold as a fraction of display height),
+`NOTCH_BAR_FLOOR` (24), `HUD_WINDOW_HEIGHT` (460, added ON TOP of `bar`),
 `--capsule-drop` (0 — the bulge was dropped; kept only for the expand math),
 `--capsule-radius` (16), `--panel-width` (400), `--panel-max-h` (420), `--capsule-dur` (0.22s)/`--capsule-ease`,
 and the notchless `--pill-top-gap` (6) / `--pill-radius` (18) / `--pill-height` (30).

--- a/src/main/notch-hud-geometry.test.ts
+++ b/src/main/notch-hud-geometry.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { hudGeometry, NOTCH_BAR_FLOOR, HUD_WINDOW_HEIGHT, type HudGeometryInput } from './notch-hud-geometry'
+
+/** A display, described the way Electron reports one: full bounds plus a menu-bar-shortened workArea. */
+function display(width: number, height: number, menuBar: number, internal: boolean): HudGeometryInput {
+  return {
+    bounds: { x: 0, y: 0, width, height },
+    workArea: { x: 0, y: menuBar, width, height: height - menuBar },
+    internal,
+    notchWidth: 168
+  }
+}
+
+describe('hudGeometry — notch detection across scaling modes (issue #508)', () => {
+  // The regression: every one of these is the SAME notched panel, and the absolute-32px predecessor
+  // answered true only for the first. The reporter's setting is 1440x932.
+  it.each([
+    ['15" Air, default 1710x1112', 1710, 1112, 37],
+    ['15" Air, scaled 1440x932', 1440, 932, 31],
+    ['15" Air, scaled 1280x829', 1280, 829, 28],
+    ['14" MBP, default 1512x982', 1512, 982, 37],
+    ['16" MBP, default 1728x1117', 1728, 1117, 37]
+  ])('detects the notch on %s', (_label, w, h, bar) => {
+    expect(hudGeometry(display(w, h, bar, true)).hasNotch).toBe(true)
+  })
+
+  it.each([
+    ['1080p external', 1920, 1080, 24],
+    ['1440p external', 2560, 1440, 24],
+    ['scaled 4K external', 3008, 1692, 24],
+    ['pre-notch 13" MacBook internal', 1440, 900, 24],
+    ['pre-notch MacBook, scaled up', 1680, 1050, 24]
+  ])('reports notchless on %s', (_label, w, h, bar) => {
+    expect(hudGeometry(display(w, h, bar, false)).hasNotch).toBe(false)
+  })
+
+  it('never reports a notch on an external display, whatever its menu bar measures', () => {
+    // An external at an unusually low resolution clears the ratio on its own; `internal` is what
+    // stops it. Notches do not exist on external panels.
+    expect(hudGeometry(display(1024, 640, 24, false)).hasNotch).toBe(false)
+  })
+
+  it('reports notchless when the menu bar is hidden entirely', () => {
+    expect(hudGeometry(display(1710, 1112, 0, true)).hasNotch).toBe(false)
+  })
+})
+
+describe('hudGeometry — window placement', () => {
+  it('spans the display full width from its very top edge, not the work area', () => {
+    const g = hudGeometry({ ...display(1710, 1112, 37, true), bounds: { x: -1710, y: -100, width: 1710, height: 1112 } })
+    expect({ x: g.x, y: g.y, width: g.width }).toEqual({ x: -1710, y: -100, width: 1710 })
+  })
+
+  it('reserves the top strip ON TOP of the expanded box, so neither layout clips', () => {
+    // Both layouts start below the strip: the fused capsule pads it, the pill clears it.
+    expect(hudGeometry(display(1710, 1112, 37, true)).height).toBe(37 + HUD_WINDOW_HEIGHT)
+  })
+
+  it('never exceeds the display height', () => {
+    expect(hudGeometry(display(1024, 300, 24, false)).height).toBe(300)
+  })
+
+  it('floors a short menu bar so the mascots always have room', () => {
+    expect(hudGeometry(display(1920, 1080, 12, false)).bar).toBe(NOTCH_BAR_FLOOR)
+  })
+
+  it('centres the notch anchor on the display', () => {
+    expect(hudGeometry(display(1711, 1112, 37, true)).notchCenterX).toBe(856)
+  })
+
+  it('passes the sanitized notch width through untouched', () => {
+    expect(hudGeometry({ ...display(1710, 1112, 37, true), notchWidth: 220 }).notchWidth).toBe(220)
+  })
+})

--- a/src/main/notch-hud-geometry.ts
+++ b/src/main/notch-hud-geometry.ts
@@ -1,0 +1,87 @@
+// Pure, Electron-free geometry for the macOS Notch HUD (docs/notch-hud.md).
+//
+// Split out of notch-hud.ts so vitest can cover notch DETECTION without an Electron runtime: the
+// controller reads `screen.getPrimaryDisplay()` and hands the plain numbers here. Everything the
+// HUD window and its renderer position themselves by is decided in this one function.
+
+/** A rectangle in Electron's logical (point) coordinate space. */
+export interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface HudGeometryInput {
+  /** display.bounds — the full display, menu bar included. */
+  bounds: Rect
+  /** display.workArea — excludes the menu bar / notch strip. */
+  workArea: Rect
+  /** display.internal — a notch only ever exists on a built-in panel. */
+  internal: boolean
+  /** Already-sanitized settings.notchWidth. */
+  notchWidth: number
+}
+
+export interface HudGeometry {
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Height of the fused top strip (menu bar / notch), floored so the mascots always fit. */
+  bar: number
+  notchWidth: number
+  notchCenterX: number
+  hasNotch: boolean
+}
+
+/** Minimum strip height when there is no physical notch (menu-bar height floor). */
+export const NOTCH_BAR_FLOOR = 24
+
+/**
+ * Notch detection threshold, as a FRACTION of the display's logical height — deliberately not an
+ * absolute px count.
+ *
+ * macOS reserves a menu bar exactly as tall as the notch on a notched panel, so that strip is a
+ * fixed share of the panel and survives every scaling mode: a 15" Air reports 37/1112 at its
+ * default and 31/932 at 1440x932 — both 0.0333. A notchless panel's menu bar is a fixed 24 pt, so
+ * its share instead FALLS as the resolution rises: 24/1080 = 0.0222, 24/900 = 0.0267.
+ *
+ * The predecessor of this constant was an absolute 32 px, which the 0.0333 share only clears while
+ * the display is tall enough — i.e. at the default scaling and nowhere else (issue #508).
+ *
+ * Residual, and why it is survivable: a notchless BUILT-IN panel driven at an unusually low scaled
+ * resolution (24/640 = 0.0375) still reads as notched. That misdetection now costs a capsule fused
+ * to a notch that is not there, never a pill hidden behind one — the notchless layout no longer
+ * occupies the top strip at all (see `.notchless .hud-capsule` in hud.css).
+ */
+export const NOTCH_BAR_RATIO = 0.03
+
+/** Total window height ABOVE the top strip — sized to the EXPANDED box (we never resize the frame;
+ *  the renderer scales a CSS transform). The strip itself is added on top, because both layouts
+ *  start below it: the fused capsule reserves it as padding, the floating pill clears it. */
+export const HUD_WINDOW_HEIGHT = 460
+
+/**
+ * Decide where the HUD window sits and which of the two layouts its renderer should draw.
+ *
+ * The window always spans the display's full width at its very top edge (`bounds`, not `workArea`
+ * — painting OVER the menu bar is the point, see `enableLargerThanScreen` in notch-hud.ts).
+ */
+export function hudGeometry(input: HudGeometryInput): HudGeometry {
+  const b = input.bounds
+  const inset = input.workArea.y - b.y
+  const bar = Math.max(NOTCH_BAR_FLOOR, inset)
+  // A physical notch requires a built-in panel whose reserved strip is a notch-sized SHARE of it.
+  const hasNotch = input.internal && inset > 0 && b.height > 0 && inset / b.height >= NOTCH_BAR_RATIO
+  return {
+    x: b.x,
+    y: b.y,
+    width: b.width,
+    height: Math.min(bar + HUD_WINDOW_HEIGHT, b.height),
+    bar,
+    notchWidth: input.notchWidth,
+    notchCenterX: Math.round(b.width / 2),
+    hasNotch
+  }
+}

--- a/src/main/notch-hud.ts
+++ b/src/main/notch-hud.ts
@@ -22,9 +22,8 @@ import {
 } from '../core/agent-status-mirror'
 import type { NormalizedAgentEvent } from '../shared/agents/normalize'
 import { createHudModel, type HudModel } from './notch-hud-model'
+import { hudGeometry, type HudGeometry } from './notch-hud-geometry'
 
-/** Minimum strip height when there is no physical notch (menu-bar height floor). */
-const NOTCH_BAR_FLOOR = 24
 /**
  * Assumed physical notch WIDTH (px). Electron exposes no `auxiliaryTopLeftArea`, so we assume a
  * centered notch of this width, and the capsule butts against its LEFT edge. Field-tuned to 168 px
@@ -35,15 +34,6 @@ const NOTCH_WIDTH = 168
 /** Bounds for the user-tunable notch width (settings.notchWidth). */
 export const NOTCH_WIDTH_MIN = 100
 export const NOTCH_WIDTH_MAX = 320
-/**
- * A top inset (`workArea.y - bounds.y`) at least this tall (px) means a PHYSICAL notch is present:
- * a notched Mac's menu bar is ~37 px, a notchless display's is ~24–25 px. Below this we treat the
- * display as notchless and draw a standalone floating pill instead of fusing to a notch. TUNABLE.
- */
-const NOTCH_MIN_BAR = 32
-/** Total window height — sized to the EXPANDED box (we never resize the frame; the renderer scales
- *  a CSS transform). Capped to the display height. */
-const HUD_WINDOW_HEIGHT = 460
 /** Debounce for coalescing feed changes into one push to the HUD renderer. */
 const PUSH_DEBOUNCE_MS = 150
 /** Low-frequency sweep so stale (gone + idle > 6h) nodes drop even with no live events. */
@@ -248,37 +238,15 @@ class NotchHudController {
     this.schedulePush()
   }
 
-  private geometry(): {
-    x: number
-    y: number
-    width: number
-    height: number
-    bar: number
-    notchWidth: number
-    notchCenterX: number
-    hasNotch: boolean
-  } {
+  private geometry(): HudGeometry {
     const d = screen.getPrimaryDisplay()
-    const b = d.bounds
-    const wa = d.workArea
-    // The notch bar height is the strip between the display top and the usable work area
-    // (menu-bar / notch). Floor at 24 so we always have room for the mascots.
-    const inset = wa.y - b.y
-    const bar = Math.max(NOTCH_BAR_FLOOR, inset)
-    const height = Math.min(HUD_WINDOW_HEIGHT, b.height)
-    // A physical notch is present only when the display actually has a menu bar (inset > 0) AND that
-    // inset is as tall as a notched Mac's menu bar. Otherwise the renderer draws a floating pill.
-    const hasNotch = inset > 0 && inset >= NOTCH_MIN_BAR
-    return {
-      x: b.x,
-      y: b.y,
-      width: b.width,
-      height,
-      bar,
-      notchWidth: sanitizeNotchWidth(this.tunables.notchWidth),
-      notchCenterX: Math.round(b.width / 2),
-      hasNotch
-    }
+    return hudGeometry({
+      bounds: d.bounds,
+      workArea: d.workArea,
+      // `internal` is what keeps an external monitor at a low resolution from reading as notched.
+      internal: d.internal === true,
+      notchWidth: sanitizeNotchWidth(this.tunables.notchWidth)
+    })
   }
 
   private reposition(): void {

--- a/src/renderer/hud/hud.css
+++ b/src/renderer/hud/hud.css
@@ -12,7 +12,7 @@
      SAME surface downward into the session panel. `--bar`, `--notch-width` and `--notch-center-x`
      are pushed from main (notch-hud.ts geometry); the rest are visual tunables. */
   --bar: 32px; /* menu-bar / notch strip height (from main) — the fused top zone */
-  --notch-width: 200px; /* physical notch width (from main) = the capsule's collapsed width */
+  --notch-width: 168px; /* physical notch width (from main) = the capsule's collapsed width */
   --notch-center-x: 50%; /* notch horizontal center in px (from main) — the capsule anchor */
   /* Unused while collapsed (the capsule never exceeds --bar); kept for the expand math only. */
   --capsule-drop: 0px;
@@ -23,7 +23,7 @@
   --capsule-ease: cubic-bezier(0.22, 1, 0.36, 1); /* spring-ish grow */
   --capsule-dur: 0.22s;
   /* Notchless fallback (no physical notch): a standalone floating pill. */
-  --pill-top-gap: 6px; /* gap above the floating pill */
+  --pill-top-gap: 6px; /* gap between the menu-bar strip and the floating pill */
   --pill-radius: 18px; /* all-corner radius of the floating pill */
   --pill-height: 30px; /* collapsed floating-pill height */
 }
@@ -99,13 +99,21 @@ body {
   border-radius: 0 0 var(--capsule-radius) var(--capsule-radius);
 }
 
-/* Notchless display: a standalone floating pill (no notch to fuse with) — a small top gap and
-   all-corner radius so it reads as its own Dynamic-Island-like element, not a black bar at y=0. */
+/* Notchless display: a standalone floating pill (no notch to fuse with) — all-corner radius so it
+   reads as its own Dynamic-Island-like element, not a black bar at y=0.
+
+   LOAD-BEARING: the pill hangs BELOW `--bar`, never inside it. The window's top edge is the
+   display's, so the top `--bar` px are the menu-bar / notch strip; a pill placed there is centred
+   on exactly the coordinates a notch occupies. That made every notch MISdetection invisible rather
+   than merely wrong — issue #508, where scaled resolutions pushed the detector below its threshold
+   and the pill landed behind the notch. Clearing the strip means the fallback layout is safe even
+   when the detector is not, and on a genuine notchless display the pill no longer paints over the
+   menu bar it used to overlap. */
 .notchless .hud-capsule {
   /* No notch to butt against — centre the pill instead of hanging it off the notch's left edge. */
   left: var(--notch-center-x, 50%);
   transform: translateX(-50%);
-  top: var(--pill-top-gap);
+  top: calc(var(--bar) + var(--pill-top-gap));
   max-height: var(--pill-height);
   border-radius: var(--pill-radius);
 }


### PR DESCRIPTION
Fixes #508.

## The decision

Two changes, and the second matters more than the first.

`hasNotch` compared the display's reserved top strip against a fixed **32 px**. That strip is reported in *logical points*, so it shrinks with the display scaling - which meant the HUD only detected the notch at one resolution, and hid itself behind it at every other. It now compares a **ratio**, and the notchless fallback layout **no longer occupies the notch strip at all**, so a future detection miss is cosmetic rather than invisible.

## What was wrong

`notch-hud.ts` decided which of its two layouts to draw like this:

```ts
const inset = workArea.y - bounds.y          // logical px
const hasNotch = inset > 0 && inset >= NOTCH_MIN_BAR   // 32
```

The threshold was calibrated against one measurement: a notched Mac's menu bar reads ~37 px, a notchless display's ~24 px, so 32 sits between them. That holds at the default scaling and nowhere else. On the reporter's 15" MacBook Air:

| Scaling | Reserved strip | `inset >= 32` |
| --- | --- | --- |
| 1710 × 1112 (default) | 37 px | ✅ |
| 1440 × 932 (reported) | 31 px | ❌ |

Below the threshold the renderer takes the `.notchless` branch, whose job is to draw a standalone floating pill on a display that has no notch to fuse with:

```css
.notchless .hud-capsule {
  left: var(--notch-center-x, 50%);   /* the display's horizontal centre */
  transform: translateX(-50%);
  top: var(--pill-top-gap);           /* 6px from the top of the display */
}
```

Centre of the display, 6 px down. On a notched Mac those are the coordinates of the notch. The detector failed and the fallback layout put the HUD in the one place it could not be seen.

## The fix

**1. Detect by ratio, and require an internal panel.**

macOS reserves a menu bar exactly as tall as the notch, so on a notched panel that strip is a fixed *share* of the display and survives every scaling mode. A notchless panel's menu bar is instead a fixed 24 pt, so its share *falls* as the resolution rises:

| Display | Strip / height | |
| --- | --- | --- |
| 15" Air, 1710 × 1112 | 37/1112 = **0.0333** | notched |
| 15" Air, 1440 × 932 | 31/932 = **0.0333** | notched |
| 14" MBP, 1512 × 982 | 37/982 = **0.0377** | notched |
| 1080p external | 24/1080 = 0.0222 | notchless |
| pre-notch 13" MacBook | 24/900 = 0.0267 | notchless |

`NOTCH_BAR_RATIO` is 0.03, which sits between the two families with margin on both sides. `display.internal` is the second half of the predicate: notches exist only on built-in panels, so an external monitor driven at an unusually low resolution can't clear the ratio on its own.

**2. Move the notchless pill below the top strip.**

```css
top: calc(var(--bar) + var(--pill-top-gap));
```

This is the part I'd argue is load-bearing. The detector is a heuristic - Electron exposes neither `safeAreaInsets` nor `auxiliaryTopLeftArea`, so there is no authoritative answer to ask for - and a heuristic's *failure mode* is a design decision. While the fallback rendered inside the notch strip, every misdetection was silent. Below it, the worst case is a pill hanging a few pixels lower than it needs to.

It also fixes a smaller pre-existing problem: on a genuinely notchless display the pill spanned y 6-36 px at screen-saver window level, painting over the menu bar rather than sitting under it.

The window frame grows to `bar + HUD_WINDOW_HEIGHT` to keep the expanded panel from clipping now that both layouts start below the strip. The frame is transparent and click-through, so this costs nothing visually.

**3. Make the geometry testable.**

`geometry()` was a private method that read `screen.getPrimaryDisplay()` inline, so nothing about the detection could be covered. It's now the pure `hudGeometry()` in `notch-hud-geometry.ts`; the controller just feeds it the display's numbers. The regression cases are pinned per scaling mode, so the next time this constant is tuned on a Mac the other resolutions are still checked.

## Notes

- The residual: a *notchless built-in* panel driven at an unusually low scaled resolution (24/640 = 0.0375) still reads as notched. That's a capsule fused to a notch that isn't there - visible and wrong, never hidden. The pre-notch Macs this could affect are also the ones least likely to be running at 1024 × 640.
- I deliberately did not take the issue's "make the HUD position user-adjustable in Settings" suggestion as the primary fix. It's a reasonable feature on its own merits, but as a remedy here it asks the user to hand-compensate for a number we can compute correctly, and it wouldn't help anyone who never finds the setting.

## Testing

- `src/main/notch-hud-geometry.test.ts` - 18 cases: the five notched configurations that the absolute-px rule got wrong, five notchless ones, the external-at-low-resolution guard, and the window placement/floor/anchor maths.
- Full suite: 9132 passed, same 30 pre-existing environment-dependent failures as on `main` (`realtmux`/`realsh`/`realtty`, `session-host` missing an optional dep, `node-pty-patch` against an unpatched `node_modules`). No change in the failure set.
- `npm run typecheck` clean.

**Not yet verified on a device.** I don't have a notched Mac to hand, so the ratio figures come from published logical resolutions and the reporter's own measurements rather than from a live `screen.getPrimaryDisplay()` reading. Worth a check at default and one scaled resolution, plus an external monitor, before merge.

## Surfaces

Desktop macOS only - the HUD is gated on `process.platform === 'darwin'` and doesn't exist on the Server Edition or the mobile companion.
