### PR TITLE
chore(release): v0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-terminal",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "engines": {
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },


### PR DESCRIPTION
Version bump 0.3.3 → 0.3.4 for the v0.3.4 release. Includes the EPIPE fix (#524), monaco 0.56 (#525), the kanban disabled-agents filter (#499) and the rest of the wave since v0.3.3. The v0.3.4 tag will be pushed once this lands on main, triggering the mac sign+notarize / linux release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2MZ1AbJACyDKsuWU1VsTJ