### PR TITLE
fix(canvas): write the NUL sentinel as an escape, not a literal byte

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -2218,11 +2218,11 @@ export function Canvas() {
   // projects array is rebuilt on every node serialization, the id set is not. Closed-but-kept
   // projects keep their entries on purpose: closing detaches like a project switch, and the
   // memory saver reaps their pages on its own clock.
-  const projectIdsSig = useProjects((s) => s.projects.map((p) => p.id).join(' '))
+  const projectIdsSig = useProjects((s) => s.projects.map((p) => p.id).join('\0'))
   useEffect(() => {
     useWebviewKeepAlive
       .getState()
-      .prune(new Set(projectIdsSig === '' ? [] : projectIdsSig.split(' ')))
+      .prune(new Set(projectIdsSig === '' ? [] : projectIdsSig.split('\0')))
   }, [projectIdsSig])
 
   /**


### PR DESCRIPTION
Two raw 0x00 bytes were embedded in Canvas.tsx string literals (the project-ids signature separator from the webview keep-alive change, #437). Semantically identical to `'\0'`, but a literal NUL makes git/grep treat the file as binary and silently skip it — the exact hazard fixed once before in 4c0e8c3. This rewrites the two literals as escapes; behavior is byte-for-byte identical at runtime, and the file is plain UTF-8 again.

Found during the external-PR review sweep (reported as a shared note on main, not caused by any open PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)