### PR TITLE
canvas-control: multi-line briefs (--prompt-file), --dry-run, and --base <stationId> (#520, #532, #530)

### DIFF
--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -316,6 +316,18 @@ describe('parseControlRequest', () => {
     }
   })
 
+  it('both agent-facing texts document --base accepting a station id (issue #530)', () => {
+    for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
+      // The flag surface must show the widened grammar…
+      expect(body).toContain('--base <ref|stationId>')
+      // …and both hard truths beside it: what a station id resolves to, and that the base is
+      // captured at CREATION (the deferred-resolution half of #530 is not built — an agent that
+      // reads this text and assumes lazy capture bases a wave on an empty branch).
+      expect(body.toLowerCase()).toContain('station')
+      expect(body).toMatch(/captured when the worktree is CREATED/i)
+    }
+  })
+
   it('both agent-facing texts document --dry-run, derived from DRY_RUN_VERBS (issue #532)', () => {
     for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
       expect(body).toContain('--dry-run')

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../core/agents/hook-sandbox-hint-sh'
 import { RETRYABLE } from '../core/agents/agent-message-decide'
 import { PROJECT_TARGETABLE_VERBS } from './project-grants'
+import { DRY_RUN_VERBS } from '../shared/control-verbs'
 import { STRICT_CONTROL_VERBS } from '../core/agents/node-identity-policy'
 import { BROWSER_ACTION_KEYS } from '../core/browser-verb'
 import { BROWSER_RETRYABLE, BROWSER_OUTCOME_LABEL } from '../core/browser-outcomes'
@@ -312,6 +313,19 @@ describe('parseControlRequest', () => {
       expect(body.toLowerCase()).toContain('ignore')
       // Per-role model is what lets ONE spawn-team call mix tiers; the JSON example must show it.
       expect(body).toContain('"model"')
+    }
+  })
+
+  it('both agent-facing texts document --dry-run, derived from DRY_RUN_VERBS (issue #532)', () => {
+    for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
+      expect(body).toContain('--dry-run')
+      // The verb list is RENDERED from the set (dryRunDocLines) — walk the real set so a verb
+      // added to the gate lands in the text the day it is added, and a removed one reds here.
+      for (const v of DRY_RUN_VERBS) expect(body).toContain(v)
+      // Both hard edges must be stated, or an agent discovers them by losing a call to each:
+      // unsupported verbs refuse, and --project cannot be combined.
+      expect(body.toLowerCase()).toContain('refuses `--dry-run`')
+      expect(body).toContain('cannot be combined with `--project`')
     }
   })
 

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -315,6 +315,21 @@ describe('parseControlRequest', () => {
     }
   })
 
+  it('both agent-facing texts document --prompt-file and the one-line --prompt fact (issue #520)', () => {
+    for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
+      // `assembleLaunchCommand` collapses every whitespace run in a --prompt literal (it rides
+      // argv on a line typed into the pane). An agent that does not know this writes a numbered
+      // brief and gets one paragraph — and the fix, --prompt-file, is useless undocumented.
+      expect(body.toUpperCase()).toContain('ONE LINE')
+      expect(body).toContain('--prompt-file')
+      // The per-role escape on spawn-team must be named too, or teams stay prose-only.
+      expect(body).toContain('promptFile')
+      // The failure that costs a whole station: flattened, a leading slash command swallows the
+      // task as its argument, and the node then reads as idle to `--after`.
+      expect(body.toLowerCase()).toMatch(/begin a prompt with `\/`|start a prompt with `\/`/)
+    }
+  })
+
   it('both agent-facing texts document the sticky verb', () => {
     for (const body of [buildCanvasSkillBody('/x/shim.sh'), buildCanvasControlInstructions('/tmp/nodeterm.sh')]) {
       expect(body).toContain('`sticky --node')

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -185,6 +185,23 @@ const VERBS: ControlVerb[] = [
  * dispatch stop agreeing.
  */
 export { isDestructiveVerb, DESTRUCTIVE_VERBS } from '../shared/control-verbs'
+// Imported (not only re-exported) because the agent-facing bodies RENDER the dry-run verb list
+// from the set — the same derive-don't-retype rule as `messagingGuidanceLines`, so the docs can
+// never name a verb the gate does not honour.
+import { DRY_RUN_VERBS } from '../shared/control-verbs'
+
+/** The `--dry-run` paragraph both agent-facing bodies share, rendered from `DRY_RUN_VERBS`. */
+function dryRunDocLines(): string[] {
+  return [
+    `Add \`--dry-run\` to a spawn verb (${[...DRY_RUN_VERBS].join(', ')}) to validate the call`,
+    'WITHOUT opening anything: it runs the same validation as a real call — ids resolved against',
+    'the live canvas, the team JSON parsed role by role, the worktree path computed — and replies',
+    'with what WOULD happen, or the exact refusal. Use it to vet a `spawn-team` payload, a',
+    '`--group`/`--after` id or a `--prompt-file` path before fanning out: these verbs are cheap to',
+    'call and expensive to undo, and the dry run moves the mistake to the cheap side. Every other',
+    'verb refuses `--dry-run` (nothing is done), and it cannot be combined with `--project`.'
+  ]
+}
 
 /** Validate a raw (verb, args) pair into a ControlCommand, or return an { error }. */
 export function parseControlRequest(
@@ -285,6 +302,8 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     'Flags take a value: `--flag value`, or `--flag=value`. Use the `=` form when the value itself',
     'starts with `--` (`--cmd=--version`); written as two tokens, a leading `--` is read as the next',
     'flag. A flag with no value is allowed anywhere on the line.',
+    '',
+    ...dryRunDocLines(),
     '',
     'Verbs:',
     '- `list` — current nodes (id, kind, title). Start here when you need a node id.',
@@ -656,6 +675,8 @@ Flags take a value: \`--flag value\`, or \`--flag=value\`. Use the \`=\` form wh
 starts with \`--\` (\`--cmd=--version\`); written as two tokens, a leading \`--\` is read as the
 next flag, so \`--text --oops\` sends an empty \`--text\` plus a stray \`--oops\`. A flag with no
 value is allowed anywhere on the line, not only at the end.
+
+${dryRunDocLines().join('\n')}
 
 Verbs:
 - \`list\` — list current nodes (id, kind, title). Start here when you need a node id.

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -290,8 +290,8 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '- `list` — current nodes (id, kind, title). Start here when you need a node id.',
     '- `help` — print the verb list. Answered by the shim itself, so it works even if the app is down.',
     '- `open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>] [--project <id>]` — open N plain terminals.',
-    '- `open-claude [--count N] [--cwd P] [--prompt T] [--model M] [--group <id>] [--after <id,id>] [--project <id>]` — open N Claude sessions.',
-    `- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open`,
+    '- `open-claude [--count N] [--cwd P] [--prompt T | --prompt-file F] [--model M] [--group <id>] [--after <id,id>] [--project <id>]` — open N Claude sessions.',
+    `- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T | --prompt-file F] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open`,
     '  any agent CLI. `--group` parents the node(s) into a group frame; a worktree-bound group also',
     '  hands its worktree path down as the cwd. `--after <id,id>` opens the node ARMED: it does not',
     '  start until every listed station has gone idle, and is context-linked to them so it can read',
@@ -303,6 +303,14 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  included); or an id `open-project` returned to YOU in this session, which never switches the',
     '  user\'s view. A session opened into a non-active project starts when the user next views that',
     '  project — do not poll for it. `--group`/`--after` cannot be combined with `--project`.',
+    '  `--prompt` arrives on ONE LINE: every whitespace run in it, newlines included, is collapsed',
+    '  to a single space (the prompt rides the launch command line typed into the pane). For a',
+    '  structured or multi-line brief use `--prompt-file <abs path>` instead: write the brief to a',
+    '  file, pass the absolute path, and the session starts with the file\'s exact contents —',
+    '  newlines, numbered lists and headings preserved. The file is read when the session LAUNCHES',
+    '  (later than the call for an `--after`-armed node), so leave it in place until the station has',
+    '  started. Never begin a prompt with `/`: the agent reads the whole text as that slash',
+    '  command\'s arguments and your task is never seen — use `--model` to pick a model.',
     '  `--model <id>` picks the model the session launches with, instead of inheriting the',
     '  default. Use it to keep a cheap station cheap: a node whose whole job is editing a README',
     '  does not need the model you give the node rewriting a test suite. Honoured by claude, codex',
@@ -338,7 +346,8 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '- `spawn-team --label L --team \'[{"title":"UI","prompt":"...","agent":"claude","model":"..."}]\'` — one agent per',
     '  role (max 8), arranged in a grid, wrapped in a labeled group, each connected + context-linked to you.',
     '  `model` is per role, so one team can mix tiers — give an expensive model to the role that needs it',
-    '  and a cheap one to the rest. Same rule as `--model` below.',
+    '  and a cheap one to the rest. Same rule as `--model` below. A role may carry `promptFile`',
+    '  (absolute path) instead of `prompt` — same multi-line-brief semantics as `--prompt-file`.',
     '- `open-worktree --branch <name> [--base <ref>] [--path P] [--group <id>]` — create a git worktree',
     '  wrapped in a bound group frame (terminals inside it run in the worktree). Local projects only.',
     '- `close-worktree --group <id> [--mode unbind|remove]` — unbind keeps the directory; remove asks',
@@ -653,8 +662,8 @@ Verbs:
 - \`help\` — print the verb list. The shim answers this itself, without reaching the app, so it
   is also what to run when you are unsure whether the control endpoint is alive.
 - \`open-terminal [--count N] [--cwd P] [--cmd C] [--group <id>] [--after <id,id>] [--project <id>]\` — open N plain terminals (default 1).
-- \`open-claude [--count N] [--cwd P] [--prompt T] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open N Claude sessions (default 1).
-- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open N sessions of any agent CLI.
+- \`open-claude [--count N] [--cwd P] [--prompt T | --prompt-file F] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open N Claude sessions (default 1).
+- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T | --prompt-file F] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open N sessions of any agent CLI.
   \`--group\` parents the node(s) into an existing group frame; a worktree-bound group also
   hands its worktree path down as the cwd.
   \`--after <id,id>\` opens the node **armed**: it does NOT start yet, and launches itself once
@@ -672,6 +681,20 @@ Verbs:
   TARGET project's (its cwd, its default account and permission mode). A session opened into a
   non-active project starts when the user next views that project — do not poll for it; the reply
   says so. \`--group\`/\`--after\` cannot be combined with \`--project\`.
+  \`--prompt\` arrives on ONE LINE. Every run of whitespace in it — newlines included — is
+  collapsed to a single space, because the prompt is passed as an argument on the agent CLI's
+  launch command line and that line is typed into the pane. Two consequences:
+  - **A structured brief goes through \`--prompt-file <abs path>\`.** Write the brief (numbered
+    acceptance criteria, file lists, guard clauses — anything multi-line) to a file, pass the
+    absolute path, and the session starts with the file's exact contents: the launch line stays
+    one line and the pane's shell reads the file at execution. The file is read when the session
+    LAUNCHES — for an \`--after\`-armed node that is later than your call — so leave it in place
+    until the station has started. On an SSH project the path is on the host (where you run).
+    Pass either \`--prompt\` or \`--prompt-file\`, not both.
+  - **Never start a prompt with \`/\`.** The agent reads the whole prompt as arguments to that
+    slash command, your task is never seen, and the node then sits at an idle prompt looking
+    healthy — including to \`--after\`, which will arm everything behind it. Use \`--model\` for
+    the model; there is no supported way to run a slash command at launch.
   \`--model <id>\` decides which model the session LAUNCHES with, instead of inheriting the
   project default. This is the lever for cost: a station whose job is editing a README does not
   need the model you give the station rewriting a 1000-line test suite, and without this flag
@@ -729,7 +752,9 @@ Verbs:
   open one agent per role (each prompt starts that member working), arrange them in a grid,
   wrap them in a labeled group, and connect + context-link each to you. Max 8 roles per call.
   \`model\` is optional and per role — the same selector \`--model\` applies, so a single team can
-  run its heavy role on a large model and the rest on a cheap one.
+  run its heavy role on a large model and the rest on a cheap one. A role may carry
+  \`promptFile\` (absolute path) instead of \`prompt\` — the \`--prompt-file\` semantics per role,
+  for members whose brief is structured or multi-line.
 - \`open-worktree --branch <name> [--base <ref>] [--path P] [--group <id>]\` — create a git
   worktree (new branch off base, default: the repo's default branch) and wrap it in a bound
   group frame (or bind it to an existing empty group). Terminals created inside the group

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -367,8 +367,13 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  `model` is per role, so one team can mix tiers — give an expensive model to the role that needs it',
     '  and a cheap one to the rest. Same rule as `--model` below. A role may carry `promptFile`',
     '  (absolute path) instead of `prompt` — same multi-line-brief semantics as `--prompt-file`.',
-    '- `open-worktree --branch <name> [--base <ref>] [--path P] [--group <id>]` — create a git worktree',
-    '  wrapped in a bound group frame (terminals inside it run in the worktree). Local projects only.',
+    '- `open-worktree --branch <name> [--base <ref|stationId>] [--path P] [--group <id>]` — create a git',
+    '  worktree wrapped in a bound group frame (terminals inside it run in the worktree). `--base`',
+    '  takes a git ref, or the id of a STATION — a node or group inside a worktree-bound frame — and',
+    '  then resolves to that station\'s branch, so wave two branches off wave one by identity instead',
+    '  of restating the branch name. The base is captured when the worktree is CREATED: to build on',
+    '  a station\'s finished work, create the downstream worktree after that station has committed',
+    '  (or have the downstream agent merge the branch first). Local projects only.',
     '- `close-worktree --group <id> [--mode unbind|remove]` — unbind keeps the directory; remove asks',
     '  the user to confirm deletion.',
     '- `branch --node <id>` — branch a Claude node\'s conversation (Claude nodes only).',
@@ -776,10 +781,20 @@ Verbs:
   run its heavy role on a large model and the rest on a cheap one. A role may carry
   \`promptFile\` (absolute path) instead of \`prompt\` — the \`--prompt-file\` semantics per role,
   for members whose brief is structured or multi-line.
-- \`open-worktree --branch <name> [--base <ref>] [--path P] [--group <id>]\` — create a git
+- \`open-worktree --branch <name> [--base <ref|stationId>] [--path P] [--group <id>]\` — create a git
   worktree (new branch off base, default: the repo's default branch) and wrap it in a bound
   group frame (or bind it to an existing empty group). Terminals created inside the group
   run in the worktree. Local projects only.
+  \`--base\` also takes the id of a STATION — a node or group inside a worktree-bound frame —
+  and resolves to that station's branch, so "branch off what that station is working on" is
+  said by identity: \`open-worktree --branch wave2 --base <wave1 node or group id>\`. The reply
+  names the branch the id resolved to. Refused explicitly: an id outside any worktree frame, a
+  base that resolves to the branch being created, and a value that is neither a node id nor a
+  valid git ref. NOTE the timing: the base is captured when the worktree is CREATED, so a
+  downstream worktree made at fan-out time starts from the upstream branch AS IT IS THEN
+  (usually empty) — create it after the upstream station has committed (arm the downstream
+  agent with \`--after\` and open its worktree when it fires), or have the downstream agent
+  \`git merge\` the upstream branch as its first step.
 - \`close-worktree --group <id> [--mode unbind|remove]\` — unbind (default) drops the binding
   and keeps the directory; remove asks the user to confirm deleting the worktree.
 - \`branch --node <id>\` — branch a Claude node's conversation: the node stays on the new

--- a/src/main/canvas-control-shim.test.ts
+++ b/src/main/canvas-control-shim.test.ts
@@ -679,6 +679,14 @@ describe('parseControlBody', () => {
   it('degrades to an empty command on garbage rather than throwing', () => {
     expect(parseControlBody('not json', 'application/json')).toEqual({ nodeId: '', args: {} })
   })
+
+  it("reads the shim's valueless --dry-run as an empty-string arg (issue #532)", () => {
+    // The sh loop translates a valueless `--dry-run` to `arg.dry-run=`; the server must land it
+    // as `args['dry-run'] === ''`, which `dryRunRequested` reads as ON.
+    expect(
+      parseControlBody('nodeId=n1&arg.dry-run=&arg.team=%5B%5D', 'application/x-www-form-urlencoded')
+    ).toEqual({ nodeId: 'n1', args: { 'dry-run': '', team: '[]' } })
+  })
 })
 
 describe('sticky through the shim (verified-only verb)', () => {

--- a/src/main/control-shim-parse.test.ts
+++ b/src/main/control-shim-parse.test.ts
@@ -82,6 +82,14 @@ describe('the control shim translates flags', () => {
     expect(run(['rename', '--node', 'n1', '--title='])).toEqual(['arg.node=n1', 'arg.title='])
   })
 
+  // Hyphenated flag names ride through as-is — the loop strips only the leading `--`, so
+  // `--prompt-file` lands as `arg.prompt-file` and the server reads args['prompt-file'].
+  it('a hyphenated flag name (--prompt-file) keeps its hyphen in the arg key', () => {
+    expect(run(['open-claude', '--prompt-file', '/tmp/brief.md'])).toEqual([
+      'arg.prompt-file=/tmp/brief.md'
+    ])
+  })
+
   // The peek tests for `--`, not for `-`: a single-dash token is a VALUE. `--scroll -600` must
   // keep working, or the fix trades one silent misparse for another.
   it('a negative number is still consumed as a value', () => {

--- a/src/main/control-shim-parse.test.ts
+++ b/src/main/control-shim-parse.test.ts
@@ -82,6 +82,15 @@ describe('the control shim translates flags', () => {
     expect(run(['rename', '--node', 'n1', '--title='])).toEqual(['arg.node=n1', 'arg.title='])
   })
 
+  // `--dry-run` is valueless and usually mid-line (issue #532): the peek must leave the next
+  // `--flag` alone and translate it to an explicit empty `arg.dry-run=`.
+  it('--dry-run rides as a valueless flag anywhere on the line', () => {
+    expect(run(['spawn-team', '--dry-run', '--team', '[]'])).toEqual([
+      'arg.dry-run=',
+      'arg.team=[]'
+    ])
+  })
+
   // Hyphenated flag names ride through as-is — the loop strips only the leading `--`, so
   // `--prompt-file` lands as `arg.prompt-file` and the server reads args['prompt-file'].
   it('a hyphenated flag name (--prompt-file) keeps its hyphen in the arg key', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -216,6 +216,7 @@ import { buildHandoff, type HandoffRemote } from './handoff'
 import { initContextLink, setNodeTranscript } from '../core/context-link'
 import { transcriptPathOf } from '../core/context-link-core'
 import { initCanvasControl, installCanvasSkillInto } from './canvas-control'
+import { DRY_RUN_VERBS, dryRunRequested, dryRunRefusal } from '../shared/control-verbs'
 import { initTranscriptIndex, searchTranscripts } from '../core/transcript-index'
 import { initTelemetry } from './telemetry'
 import { initClaudeUsage } from './claude-usage'
@@ -3102,6 +3103,15 @@ app.whenReady().then(async () => {
   const projectIdOfNode = (id: string): string | undefined =>
     workspaceStore.persistedCanvases().find((c) => c.nodes.some((n) => n.id === id))?.id
   hookServer.setControlHandler(async ({ verb, nodeId, args, verified }) => {
+    // `--dry-run` (issue #532) is honoured by the spawn verbs only, and this gate runs FIRST —
+    // before the browser intercept, the open-project gates and the renderer forward — because a
+    // verb that cannot dry-run must REFUSE rather than silently perform: a `close --dry-run`
+    // that closes is worse than no flag at all. Supported verbs pass through with the flag
+    // intact; their renderer dispatch case stops before the mutation.
+    if (dryRunRequested(args) && !DRY_RUN_VERBS.has(verb)) {
+      const msg = dryRunRefusal(verb)
+      return { ok: false, error: msg, message: msg }
+    }
     // `browser` is answered in MAIN and never forwarded to the renderer's agent-control dispatch:
     // the debugger handle and the CDP allowlist are main-side, and the renderer is the more
     // attackable half. Every other verb still round-trips to the renderer below.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -366,6 +366,7 @@ import {
   type AgentPermissionMode
 } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
+import { promptFilePathError } from '@shared/agents/launch'
 import { relativeTime } from '../lib/relativeTime'
 import { AgentIcon } from '../lib/agentIcons'
 import { branchClaudeSession } from '../lib/claudeBranch'
@@ -8641,6 +8642,32 @@ export function Canvas() {
             )
             const after = resolveAfter()
             if (after === null) return // bad --after, already replied
+            // `--prompt-file` (issue #520): a multi-line brief travels as a FILE the new node's
+            // shell reads at launch (`"$(cat …)"` in the assembler), because `--prompt` rides a
+            // command line typed into the pane and is collapsed to one line. Validated here — the
+            // path shape by the pure rule, existence against the filesystem the node will read it
+            // from (the HOST's on an SSH project). A missing file would launch the agent with an
+            // EMPTY prompt (the substitution expands to nothing), which is the silent failure the
+            // check exists to catch; a check that itself errors fails OPEN, since the pane shows
+            // cat's own error where a wrongly-refused open shows nothing.
+            const promptFile = (args['prompt-file'] ?? '').trim() || undefined
+            if (promptFile && args.prompt) {
+              reply({ ok: false, error: `${verb}: pass either --prompt or --prompt-file, not both` })
+              return
+            }
+            if (promptFile) {
+              const pfErr = promptFilePathError(promptFile)
+              if (pfErr) {
+                reply({ ok: false, error: `${verb}: --prompt-file ${pfErr}` })
+                return
+              }
+              const pfFs = ctlSsh && ctlProject ? sshFs(ctlProject.id) : api.fs
+              const pfExists = await pfFs.exists(promptFile).catch(() => true)
+              if (!pfExists) {
+                reply({ ok: false, error: `${verb}: --prompt-file not found: ${promptFile}` })
+                return
+              }
+            }
             const agentCwd = args.cwd || groupCwd || srcCwd
             const make = (i: number): CanvasNode =>
               armAfter(
@@ -8659,7 +8686,8 @@ export function Canvas() {
                   // `--model` is a pass-through: `withAgentModel` re-validates the value at the
                   // interpolation site and emits nothing for an agent outside MODEL_SWITCH_CAPABLE,
                   // so an unsupported agent's command line stays byte-identical.
-                  args.model
+                  args.model,
+                  promptFile
                 ),
                 after ?? [],
                 undefined,
@@ -9083,21 +9111,58 @@ export function Canvas() {
             return
           }
           case 'spawn-team': {
-            let roles: { title?: string; prompt?: string; agent?: string; model?: string }[]
+            let roles: {
+              title?: string
+              prompt?: string
+              promptFile?: string
+              agent?: string
+              model?: string
+            }[]
             try {
               const parsed = JSON.parse(args.team ?? '')
               roles = Array.isArray(parsed) ? parsed : []
             } catch {
               reply({
                 ok: false,
-                error: 'spawn-team: --team must be a JSON array of {title?, prompt, agent?, model?}'
+                error:
+                  'spawn-team: --team must be a JSON array of {title?, prompt|promptFile, agent?, model?}'
               })
               return
             }
-            roles = roles.filter((r) => r && typeof r.prompt === 'string' && r.prompt.trim()).slice(0, 8)
+            roles = roles
+              .filter(
+                (r) =>
+                  r &&
+                  ((typeof r.prompt === 'string' && r.prompt.trim()) ||
+                    (typeof r.promptFile === 'string' && r.promptFile.trim()))
+              )
+              .slice(0, 8)
             if (roles.length === 0) {
-              reply({ ok: false, error: 'spawn-team: --team needs at least one role with a prompt' })
+              reply({
+                ok: false,
+                error: 'spawn-team: --team needs at least one role with a prompt (or promptFile)'
+              })
               return
+            }
+            // Per-role `promptFile` — the same contract as `--prompt-file` on the open verbs
+            // (issue #520): path shape by the pure rule, existence against the filesystem the new
+            // node reads it from, missing file refused (an empty `$(cat …)` would silently start
+            // the member with no task), a check that errors fails open.
+            for (const [ri, r] of roles.entries()) {
+              const rf = typeof r.promptFile === 'string' ? r.promptFile.trim() : ''
+              if (!rf) continue
+              const roleName = r.title?.trim() ? `"${r.title.trim()}"` : `#${ri + 1}`
+              const rfErr = promptFilePathError(rf)
+              if (rfErr) {
+                reply({ ok: false, error: `spawn-team: role ${roleName} promptFile ${rfErr}` })
+                return
+              }
+              const rfFs = ctlSsh && ctlProject ? sshFs(ctlProject.id) : api.fs
+              const rfExists = await rfFs.exists(rf).catch(() => true)
+              if (!rfExists) {
+                reply({ ok: false, error: `spawn-team: role ${roleName} promptFile not found: ${rf}` })
+                return
+              }
             }
             const live = nodesRef.current as CanvasNode[]
             // Same account funnel as open-claude/open-agent above; per-role the factory
@@ -9125,7 +9190,11 @@ export function Canvas() {
                 teamStore.activeProjectId,
                 // Per-role model, so one team can mix tiers in a single call. A role naming a
                 // model its agent cannot switch simply launches bare (withAgentModel no-ops).
-                typeof r.model === 'string' ? r.model : undefined
+                typeof r.model === 'string' ? r.model : undefined,
+                // Per-role promptFile (validated above); wins over `prompt` in the assembler.
+                typeof r.promptFile === 'string' && r.promptFile.trim()
+                  ? r.promptFile.trim()
+                  : undefined
               )
               return r.title ? { ...node, data: { ...node.data, title: r.title, titleAuto: false } } : node
             })

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -367,6 +367,7 @@ import {
 } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
 import { promptFilePathError } from '@shared/agents/launch'
+import { parseTeamSpec } from '../lib/teamSpec'
 import { relativeTime } from '../lib/relativeTime'
 import { AgentIcon } from '../lib/agentIcons'
 import { branchClaudeSession } from '../lib/claudeBranch'
@@ -436,7 +437,7 @@ import { chordHeld, isHoldChord, isModifierEventKey, matchesShortcut } from '@sh
 // The dispatch below is the CONSUMER of the confirm-gated set. Before this import the set named
 // write/close as "the confirm-gated pair" from inside `src/main` — which this project cannot see —
 // while the gating lived in two hand-written blocks here, so the set decided nothing.
-import { isDestructiveVerb } from '@shared/control-verbs'
+import { isDestructiveVerb, dryRunRequested } from '@shared/control-verbs'
 import { canvasSyncTarget } from './collab-sync'
 import {
   applyCanvasMutation,
@@ -7912,6 +7913,12 @@ export function Canvas() {
     return api.onAgentControl(async ({ requestId, sourceNodeId, verb, args }) => {
       const reply = (r: { ok: boolean; message?: string; result?: unknown; error?: string }) =>
         api.sendAgentControlResult({ requestId, ...r })
+      // `--dry-run` (issue #532): validate + report, mutate nothing. Only DRY_RUN_VERBS reach
+      // this process with the flag set — main's setControlHandler refuses it for every other
+      // verb before forwarding — so the per-case branches below are the whole renderer story:
+      // each runs the SAME validation as a real call and stops just before the mutation.
+      const dryRun = dryRunRequested(args)
+      const DRY_RUN_PREFIX = 'DRY RUN — nothing was opened or changed.'
 
       // ── Agent messaging (`send`/`reply`) — handled BEFORE the source-routing machinery ──────
       // These are STORE_ANSWERED_VERBS (lib/controlRouting): routing by source must never travel
@@ -8080,6 +8087,13 @@ export function Canvas() {
         (verb === 'open-terminal' || verb === 'open-claude' || verb === 'open-agent') &&
         args.project !== undefined
       ) {
+        // `--dry-run` validates against the LIVE canvas; a `--project` open lands in another
+        // project's serialized store through a different code path, and a "validate only" copy of
+        // that path is exactly the rot #532 warns about. Refused, not silently run.
+        if (dryRun) {
+          reply({ ok: false, error: `${verb}: --dry-run cannot be combined with --project` })
+          return
+        }
         const targetId = args.project
         // v1 excludes the flags that name ids inside another project (spec §2.2). The decision is
         // the PURE projectTargetFlagRefusal — red-capable in projectOpen.test.ts (review #363
@@ -8593,6 +8607,27 @@ export function Canvas() {
             const after = resolveAfter()
             if (after === null) return // bad --after, already replied
             const termCwd = args.cwd || groupCwd || srcCwd
+            if (dryRun) {
+              reply({
+                ok: true,
+                message: [
+                  DRY_RUN_PREFIX,
+                  `open-terminal would open ${count} terminal(s)` +
+                    (intoGroupId ? ` in group ${intoGroupId}` : '') +
+                    (termCwd ? `, cwd ${termCwd}` : '') +
+                    (args.cmd ? `, running: ${args.cmd}` : ''),
+                  ...(after?.length ? [`armed to wait for: ${after.join(', ')}`] : [])
+                ].join('\n'),
+                result: {
+                  dryRun: true,
+                  count,
+                  group: intoGroupId ?? null,
+                  cwd: termCwd ?? null,
+                  after: after ?? []
+                }
+              })
+              return
+            }
             const make = (i: number): CanvasNode =>
               armAfter(
                 createTerminalNode(
@@ -8669,6 +8704,47 @@ export function Canvas() {
               }
             }
             const agentCwd = args.cwd || groupCwd || srcCwd
+            if (dryRun) {
+              // The dry run is deliberately STRICTER than the real open here: an unknown agent id
+              // today opens a node whose launch command is the typo, failing only inside its pane
+              // — precisely the "validated by running it" cost #532 names. Catch it when asked.
+              const dryKnownAgent =
+                !!agentConfig(agentId) ||
+                useSettings.getState().settings.customAgents.some((c) => c.id === agentId)
+              if (!dryKnownAgent) {
+                reply({
+                  ok: false,
+                  error: `${verb}: unknown agent "${agentId}" — pass a builtin id or a custom agent id from Settings`
+                })
+                return
+              }
+              reply({
+                ok: true,
+                message: [
+                  DRY_RUN_PREFIX,
+                  `${verb} would open ${count} ${agentId} session(s)` +
+                    (intoGroupId ? ` in group ${intoGroupId}` : '') +
+                    (agentCwd ? `, cwd ${agentCwd}` : '') +
+                    (args.model ? `, model ${args.model}` : '') +
+                    (promptFile
+                      ? `, prompt from file ${promptFile}`
+                      : args.prompt
+                        ? `, prompt: "${args.prompt.slice(0, 80)}${args.prompt.length > 80 ? '…' : ''}"`
+                        : ''),
+                  ...(after?.length ? [`armed to wait for: ${after.join(', ')}`] : []),
+                  'Each session would be connected + context-linked to you.'
+                ].join('\n'),
+                result: {
+                  dryRun: true,
+                  agent: agentId,
+                  count,
+                  group: intoGroupId ?? null,
+                  cwd: agentCwd ?? null,
+                  after: after ?? []
+                }
+              })
+              return
+            }
             const make = (i: number): CanvasNode =>
               armAfter(
                 createAgentNode(
@@ -9111,58 +9187,53 @@ export function Canvas() {
             return
           }
           case 'spawn-team': {
-            let roles: {
-              title?: string
-              prompt?: string
-              promptFile?: string
-              agent?: string
-              model?: string
-            }[]
-            try {
-              const parsed = JSON.parse(args.team ?? '')
-              roles = Array.isArray(parsed) ? parsed : []
-            } catch {
-              reply({
-                ok: false,
-                error:
-                  'spawn-team: --team must be a JSON array of {title?, prompt|promptFile, agent?, model?}'
-              })
+            // Parse + validate through the ONE pure parser (lib/teamSpec.ts) the dry run shares —
+            // named refusals for bad JSON, a role missing its prompt, a ninth role, an unknown
+            // agent id — instead of the old silent filter-and-slice, where a role without a
+            // prompt simply vanished and a typo'd agent opened a broken node (issue #532).
+            const teamKnownAgents = new Set<string>([
+              ...BUILTIN_AGENT_IDS,
+              ...useSettings.getState().settings.customAgents.map((c) => c.id)
+            ])
+            const teamSpec = parseTeamSpec(args.team ?? '', teamKnownAgents)
+            if (!teamSpec.ok) {
+              reply({ ok: false, error: `spawn-team: ${teamSpec.error}` })
               return
             }
-            roles = roles
-              .filter(
-                (r) =>
-                  r &&
-                  ((typeof r.prompt === 'string' && r.prompt.trim()) ||
-                    (typeof r.promptFile === 'string' && r.promptFile.trim()))
-              )
-              .slice(0, 8)
-            if (roles.length === 0) {
-              reply({
-                ok: false,
-                error: 'spawn-team: --team needs at least one role with a prompt (or promptFile)'
-              })
-              return
-            }
-            // Per-role `promptFile` — the same contract as `--prompt-file` on the open verbs
-            // (issue #520): path shape by the pure rule, existence against the filesystem the new
-            // node reads it from, missing file refused (an empty `$(cat …)` would silently start
-            // the member with no task), a check that errors fails open.
+            const roles = teamSpec.roles
+            // Per-role `promptFile` existence — the same contract as `--prompt-file` on the open
+            // verbs (issue #520): checked against the filesystem the new node reads it from,
+            // missing refused (an empty `$(cat …)` would silently start the member with no task),
+            // a check that errors fails open. Path SHAPE is the parser's job.
             for (const [ri, r] of roles.entries()) {
-              const rf = typeof r.promptFile === 'string' ? r.promptFile.trim() : ''
-              if (!rf) continue
-              const roleName = r.title?.trim() ? `"${r.title.trim()}"` : `#${ri + 1}`
-              const rfErr = promptFilePathError(rf)
-              if (rfErr) {
-                reply({ ok: false, error: `spawn-team: role ${roleName} promptFile ${rfErr}` })
-                return
-              }
+              if (!r.promptFile) continue
+              const rName = r.title ? `"${r.title}"` : `#${ri + 1}`
               const rfFs = ctlSsh && ctlProject ? sshFs(ctlProject.id) : api.fs
-              const rfExists = await rfFs.exists(rf).catch(() => true)
+              const rfExists = await rfFs.exists(r.promptFile).catch(() => true)
               if (!rfExists) {
-                reply({ ok: false, error: `spawn-team: role ${roleName} promptFile not found: ${rf}` })
+                reply({
+                  ok: false,
+                  error: `spawn-team: role ${rName} promptFile not found: ${r.promptFile}`
+                })
                 return
               }
+            }
+            if (dryRun) {
+              reply({
+                ok: true,
+                message: [
+                  DRY_RUN_PREFIX,
+                  `spawn-team would open ${roles.length} member(s) in a new group "${args.label || 'Team'}", each connected + context-linked to you:`,
+                  ...roles.map((r, i) => {
+                    const brief = r.promptFile
+                      ? `prompt from file ${r.promptFile}`
+                      : `prompt: "${(r.prompt ?? '').slice(0, 80)}${(r.prompt ?? '').length > 80 ? '…' : ''}"`
+                    return `  ${i + 1}. ${r.title ?? r.agent} — agent ${r.agent}${r.model ? `, model ${r.model}` : ''} — ${brief}`
+                  })
+                ].join('\n'),
+                result: { dryRun: true, label: args.label || 'Team', roles }
+              })
+              return
             }
             const live = nodesRef.current as CanvasNode[]
             // Same account funnel as open-claude/open-agent above; per-role the factory
@@ -9177,7 +9248,8 @@ export function Canvas() {
             const members = roles.map((r, i) => {
               // Roles may name different agents, so the mode is resolved PER member: claude's
               // `auto` version gate must not decide what a grok teammate launches with.
-              const memberAgent = (r.agent ?? 'claude') as AgentId
+              // (`agent` is parser-defaulted to 'claude' and validated against the known set.)
+              const memberAgent = r.agent as AgentId
               const node = createAgentNode(
                 memberAgent,
                 live.length + i,
@@ -9190,11 +9262,10 @@ export function Canvas() {
                 teamStore.activeProjectId,
                 // Per-role model, so one team can mix tiers in a single call. A role naming a
                 // model its agent cannot switch simply launches bare (withAgentModel no-ops).
-                typeof r.model === 'string' ? r.model : undefined,
-                // Per-role promptFile (validated above); wins over `prompt` in the assembler.
-                typeof r.promptFile === 'string' && r.promptFile.trim()
-                  ? r.promptFile.trim()
-                  : undefined
+                r.model,
+                // Per-role promptFile (parser-validated + existence-checked above); wins over
+                // `prompt` in the assembler.
+                r.promptFile
               )
               return r.title ? { ...node, data: { ...node.data, title: r.title, titleAuto: false } } : node
             })
@@ -9285,6 +9356,25 @@ export function Canvas() {
             })
             if (!wtPath) {
               reply({ ok: false, error: 'open-worktree: could not derive a worktree path — pass --path' })
+              return
+            }
+            if (dryRun) {
+              reply({
+                ok: true,
+                message: [
+                  DRY_RUN_PREFIX,
+                  `open-worktree would create branch "${branch}" off ${baseRef || 'the repo default branch'} at ${wtPath}, ` +
+                    `bound to ${bindGroupId ? `group ${bindGroupId}` : 'a new group frame'}.`,
+                  'The base ref is not verified against git in a dry run — a bad ref still fails at create time.'
+                ].join('\n'),
+                result: {
+                  dryRun: true,
+                  branch,
+                  baseRef: baseRef || null,
+                  path: wtPath,
+                  group: bindGroupId
+                }
+              })
               return
             }
             const res = await api.git

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -329,6 +329,7 @@ import {
   worktreeFromCreate,
   worktreeFromEntry,
   worktreeRemoveMessage,
+  resolveWorktreeBase,
   type GroupWorktree,
   type WorktreeCreateValue,
   type WorktreeEntry
@@ -9342,7 +9343,35 @@ export function Canvas() {
             // reduce to entries/global exactly as before. An explicit `--base` still wins.
             const pw = projectLaunchInfoNow(project?.id ?? '')?.resolved.worktree
             const projectDefaults = { basePath: pw?.basePath?.value, baseRef: pw?.baseRef?.value }
-            const baseRef = args.base?.trim() || effectiveWorktreeBaseRef(projectDefaults, entries)
+            // `--base` takes a git ref OR a station id (issue #530): an id naming a node/group on
+            // the canvas resolves through its worktree-bound group to that station's BRANCH, so
+            // "branch off what that station is working on" is expressed by identity. The pure
+            // resolver owes the explicit refusals (unbound node, self-base, neither-node-nor-ref).
+            const baseRes = resolveWorktreeBase(
+              args.base,
+              branch,
+              nodesRef.current.map((nd) => ({
+                id: nd.id,
+                parentId: nd.parentId,
+                worktree: nd.data.worktree as GroupWorktree | undefined
+              }))
+            )
+            if (baseRes.kind === 'error') {
+              reply({ ok: false, error: `open-worktree: ${baseRes.error}` })
+              return
+            }
+            const baseRef =
+              baseRes.kind === 'default'
+                ? effectiveWorktreeBaseRef(projectDefaults, entries)
+                : baseRes.ref
+            // Said back in every reply so the resolution is transparent — the caller passed an id
+            // and must see which branch it bought.
+            const baseNote =
+              baseRes.kind === 'station'
+                ? ` (resolved from station ${baseRes.stationId}${
+                    baseRes.groupId !== baseRes.stationId ? ` in group ${baseRes.groupId}` : ''
+                  })`
+                : ''
             // Resolve from this session's repo root, so a relay tab still produces a path on the
             // same host/filesystem where the `api.git` operation below runs.
             const wtPath = await resolveWorktreePath({
@@ -9363,14 +9392,21 @@ export function Canvas() {
                 ok: true,
                 message: [
                   DRY_RUN_PREFIX,
-                  `open-worktree would create branch "${branch}" off ${baseRef || 'the repo default branch'} at ${wtPath}, ` +
+                  `open-worktree would create branch "${branch}" off ${baseRef || 'the repo default branch'}${baseNote} at ${wtPath}, ` +
                     `bound to ${bindGroupId ? `group ${bindGroupId}` : 'a new group frame'}.`,
-                  'The base ref is not verified against git in a dry run — a bad ref still fails at create time.'
+                  // A station's branch comes from a live binding; a plain ref is only vetted by
+                  // git at create time — say which assurance the caller is getting.
+                  ...(baseRes.kind === 'station'
+                    ? []
+                    : [
+                        'The base ref is not verified against git in a dry run — a bad ref still fails at create time.'
+                      ])
                 ].join('\n'),
                 result: {
                   dryRun: true,
                   branch,
                   baseRef: baseRef || null,
+                  ...(baseRes.kind === 'station' ? { baseStation: baseRes.stationId } : {}),
                   path: wtPath,
                   group: bindGroupId
                 }
@@ -9402,8 +9438,14 @@ export function Canvas() {
             )
             reply({
               ok: true,
-              message: `opened worktree ${branch} at ${wtPath} in group ${groupId}`,
-              result: { groupId, branch, path: wtPath, baseRef }
+              message: `opened worktree ${branch} (off ${baseRef || 'the repo default branch'}${baseNote}) at ${wtPath} in group ${groupId}`,
+              result: {
+                groupId,
+                branch,
+                path: wtPath,
+                baseRef,
+                ...(baseRes.kind === 'station' ? { baseStation: baseRes.stationId } : {})
+              }
             })
             return
           }

--- a/src/renderer/lib/teamSpec.test.ts
+++ b/src/renderer/lib/teamSpec.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { parseTeamSpec, TEAM_MAX_ROLES } from './teamSpec'
+
+const KNOWN = new Set(['claude', 'codex', 'gemini', 'custom:mine'])
+
+const err = (raw: string): string => {
+  const r = parseTeamSpec(raw, KNOWN)
+  if (r.ok) throw new Error('expected a refusal')
+  return r.error
+}
+
+describe('parseTeamSpec — the happy path', () => {
+  it('parses roles, defaulting agent to claude and trimming fields', () => {
+    const r = parseTeamSpec(
+      '[{"title":" UI ","prompt":"build it","model":" sonnet "},{"prompt":"test it","agent":"codex"}]',
+      KNOWN
+    )
+    expect(r).toEqual({
+      ok: true,
+      roles: [
+        { title: 'UI', prompt: 'build it', agent: 'claude', model: 'sonnet' },
+        { prompt: 'test it', agent: 'codex' }
+      ]
+    })
+  })
+  it('accepts promptFile in place of prompt', () => {
+    const r = parseTeamSpec('[{"title":"UI","promptFile":"/tmp/brief.md"}]', KNOWN)
+    expect(r).toEqual({
+      ok: true,
+      roles: [{ title: 'UI', promptFile: '/tmp/brief.md', agent: 'claude' }]
+    })
+  })
+  it('accepts a custom agent id when it is in the known set', () => {
+    const r = parseTeamSpec('[{"prompt":"x","agent":"custom:mine"}]', KNOWN)
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe('parseTeamSpec — every mistake is a NAMED refusal (issue #532)', () => {
+  it('empty payload', () => {
+    expect(err('')).toMatch(/--team is empty/)
+  })
+  it('invalid JSON names the parse error and shows the expected shape', () => {
+    const e = err('[{"title":"UI"')
+    expect(e).toMatch(/not valid JSON/)
+    expect(e).toContain('promptFile')
+  })
+  it('a bare object is refused as not-an-array', () => {
+    expect(err('{"prompt":"x"}')).toMatch(/ARRAY/)
+  })
+  it('an empty array is refused', () => {
+    expect(err('[]')).toMatch(/at least one role/)
+  })
+  it(`a ${TEAM_MAX_ROLES + 1}th role is refused, not silently sliced off`, () => {
+    const roles = JSON.stringify(
+      Array.from({ length: TEAM_MAX_ROLES + 1 }, (_, i) => ({ prompt: `t${i}` }))
+    )
+    expect(err(roles)).toMatch(new RegExp(`${TEAM_MAX_ROLES + 1} roles — max ${TEAM_MAX_ROLES}`))
+  })
+  it('a role missing its prompt is refused BY NAME, not silently dropped', () => {
+    // The old inline parse filtered this role out: the team opened short and nobody said which
+    // role vanished. Now the reply names it.
+    expect(err('[{"prompt":"a"},{"title":"Docs"}]')).toContain('"Docs"')
+    expect(err('[{"prompt":"a"},{}]')).toContain('#2')
+  })
+  it('a role with both prompt and promptFile is refused', () => {
+    expect(err('[{"title":"UI","prompt":"a","promptFile":"/x"}]')).toMatch(/not both/)
+  })
+  it('a non-string field is refused by field name', () => {
+    expect(err('[{"prompt":42}]')).toContain('"prompt" must be a string')
+    expect(err('[{"prompt":"a","model":7}]')).toContain('"model" must be a string')
+  })
+  it('a relative promptFile is refused (same rule as --prompt-file)', () => {
+    expect(err('[{"title":"UI","promptFile":"brief.md"}]')).toMatch(/absolute/)
+  })
+  it('an unknown agent id is refused with the known list', () => {
+    const e = err('[{"prompt":"x","agent":"claudee"}]')
+    expect(e).toContain('unknown agent "claudee"')
+    expect(e).toContain('codex')
+  })
+  it('a non-object role is refused by position', () => {
+    expect(err('["just a string"]')).toContain('#1')
+  })
+})

--- a/src/renderer/lib/teamSpec.ts
+++ b/src/renderer/lib/teamSpec.ts
@@ -1,0 +1,109 @@
+// Pure parser for `spawn-team --team <json>` (issue #532). One parser, two consumers — the REAL
+// spawn path and `--dry-run` — so the dry run can never validate a different grammar than the run
+// it stands in for (the rot the issue warns about: a hand-maintained "validate only" copy drifts).
+//
+// It exists because the old inline parse made every mistake SILENT: a role missing a `prompt` was
+// filtered out (the team opened short, nobody said which role vanished), a ninth role was sliced
+// off, a typo'd `agent` id opened a broken node that failed only inside its pane. Each of those is
+// now a named refusal — the caller learns which role and which field, before anything opens.
+import { promptFilePathError } from '@shared/agents/launch'
+
+export const TEAM_MAX_ROLES = 8
+
+export interface TeamRole {
+  title?: string
+  prompt?: string
+  promptFile?: string
+  /** Defaulted to 'claude' when the role names none — the historical behavior, made explicit. */
+  agent: string
+  model?: string
+}
+
+export type TeamSpecResult = { ok: true; roles: TeamRole[] } | { ok: false; error: string }
+
+const SHAPE = '{title?, prompt|promptFile, agent?, model?}'
+
+/** A role's name for an error message: its title when it has one, else its 1-based position. */
+function roleName(r: { title?: unknown }, i: number): string {
+  return typeof r.title === 'string' && r.title.trim() ? `"${r.title.trim()}"` : `#${i + 1}`
+}
+
+/**
+ * Parse + validate a `--team` payload. `knownAgentIds` is the full agent inventory (builtins +
+ * the user's custom agents): a role naming anything else is refused HERE, at parse time, instead
+ * of opening a node whose launch command is a typo — the exact "validated by running it" cost
+ * issue #532 names. Error messages are bare (no `spawn-team:` prefix — the caller adds it).
+ */
+export function parseTeamSpec(raw: string, knownAgentIds: ReadonlySet<string>): TeamSpecResult {
+  const trimmed = (raw ?? '').trim()
+  if (!trimmed) {
+    return { ok: false, error: `--team is empty — pass a JSON array of ${SHAPE} role objects` }
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch (e) {
+    const why = e instanceof Error ? e.message : String(e)
+    return {
+      ok: false,
+      error:
+        `--team is not valid JSON (${why}). Expected a JSON array of ${SHAPE} role objects — ` +
+        `quote the whole value in the shell: --team '[{"title":"UI","prompt":"..."}]'`
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return { ok: false, error: `--team must be a JSON ARRAY of ${SHAPE} role objects, not a ${typeof parsed === 'object' ? 'single object' : typeof parsed}` }
+  }
+  if (parsed.length === 0) {
+    return { ok: false, error: '--team needs at least one role with a prompt (or promptFile)' }
+  }
+  if (parsed.length > TEAM_MAX_ROLES) {
+    return {
+      ok: false,
+      error: `--team has ${parsed.length} roles — max ${TEAM_MAX_ROLES} per call; split into two calls`
+    }
+  }
+  const roles: TeamRole[] = []
+  for (const [i, r] of parsed.entries()) {
+    if (typeof r !== 'object' || r === null || Array.isArray(r)) {
+      return { ok: false, error: `role #${i + 1} is not an object (${SHAPE})` }
+    }
+    const role = r as Record<string, unknown>
+    const name = roleName(role, i)
+    for (const field of ['title', 'prompt', 'promptFile', 'agent', 'model'] as const) {
+      if (role[field] !== undefined && typeof role[field] !== 'string') {
+        return { ok: false, error: `role ${name}: "${field}" must be a string` }
+      }
+    }
+    const prompt = typeof role.prompt === 'string' ? role.prompt.trim() : ''
+    const promptFile = typeof role.promptFile === 'string' ? role.promptFile.trim() : ''
+    if (prompt && promptFile) {
+      return { ok: false, error: `role ${name}: pass either "prompt" or "promptFile", not both` }
+    }
+    if (!prompt && !promptFile) {
+      return {
+        ok: false,
+        error: `role ${name} is missing a non-empty "prompt" (or "promptFile") — every member needs a starting task`
+      }
+    }
+    if (promptFile) {
+      const pfErr = promptFilePathError(promptFile)
+      if (pfErr) return { ok: false, error: `role ${name}: promptFile ${pfErr}` }
+    }
+    const agent = typeof role.agent === 'string' && role.agent.trim() ? role.agent.trim() : 'claude'
+    if (!knownAgentIds.has(agent)) {
+      return {
+        ok: false,
+        error: `role ${name}: unknown agent "${agent}" — known agents: ${[...knownAgentIds].join(', ')}`
+      }
+    }
+    roles.push({
+      ...(typeof role.title === 'string' && role.title.trim() ? { title: role.title.trim() } : {}),
+      ...(prompt ? { prompt } : {}),
+      ...(promptFile ? { promptFile } : {}),
+      agent,
+      ...(typeof role.model === 'string' && role.model.trim() ? { model: role.model.trim() } : {})
+    })
+  }
+  return { ok: true, roles }
+}

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -588,7 +588,13 @@ export function createAgentNode(
    *  agent, so passing a model for one is harmless — it's simply not appended). Persisted as
    *  `data.agentModel` so cold-restore and later restarts keep the model. Trails `projectId`: every
    *  existing caller passes that ninth argument, so the model is the one that had to move. */
-  model?: string
+  model?: string,
+  /** Absolute path to a file holding the first prompt (canvas-control `--prompt-file`). Wins over
+   *  `initialPrompt`; composed by the assembler as a `"$(cat …)"` substitution so a multi-line
+   *  brief survives the single-line typed delivery. Validated by the caller
+   *  (`promptFilePathError` + an existence check) — the factory trusts it. Trailing/optional so
+   *  every existing caller is unchanged. */
+  promptFile?: string
 ): CanvasNode {
   const { label, color } = resolveAgent(agentId)
   // The launch-command override (this project's `.nodeterm/settings.json` first, then Settings →
@@ -625,6 +631,7 @@ export function createAgentNode(
       agentId,
       customAgent,
       initialPrompt,
+      promptFile,
       permissionMode,
       sessionId: mintedSessionId,
       sessionIdFlagSupported,

--- a/src/shared/agents/launch.test.ts
+++ b/src/shared/agents/launch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { assembleLaunchCommand, assembleResumeCommand } from './launch'
+import { assembleLaunchCommand, assembleResumeCommand, promptFilePathError } from './launch'
 import { setCustomAgentBaseResolver } from './config'
 import type { CustomAgent } from '../types'
 
@@ -282,5 +282,77 @@ describe('quoting by construction — env values can never become shell syntax o
     )
     expect(command).toBe("claude-wopr '--model' '--verbose'")
     expect(missingEnv).toEqual(['GONE'])
+  })
+})
+
+describe('assembleLaunchCommand — promptFile (issue #520)', () => {
+  // The whole point: the TYPED line stays single-line while the pane's shell expands the file at
+  // execution, so a multi-line brief reaches the CLI with its structure intact.
+  it('claude composes the prompt as a "$(cat …)" substitution with the PATH single-quoted', () => {
+    expect(
+      assembleLaunchCommand({ agentId: 'claude', promptFile: '/tmp/brief.md' }, ENV).command
+    ).toBe('claude "$(cat \'/tmp/brief.md\')"')
+  })
+  it('flags still land after the prompt for claude', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'claude', promptFile: '/tmp/brief.md', permissionMode: 'auto' },
+        ENV
+      ).command
+    ).toBe('claude "$(cat \'/tmp/brief.md\')" --permission-mode auto')
+  })
+  it('grok keeps its flags BEFORE the -- separator, substitution after it', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'grok', promptFile: '/tmp/brief.md', permissionMode: 'plan' },
+        ENV
+      ).command
+    ).toBe('grok --permission-mode plan -- "$(cat \'/tmp/brief.md\')"')
+  })
+  it('a flag-prompt agent passes the substitution through its prompt flag', () => {
+    expect(assembleLaunchCommand({ agentId: 'opencode', promptFile: '/tmp/b.md' }, ENV).command).toBe(
+      'opencode --prompt "$(cat \'/tmp/b.md\')"'
+    )
+  })
+  it('promptFile wins over initialPrompt', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'claude', initialPrompt: 'ignored', promptFile: '/tmp/brief.md' },
+        ENV
+      ).command
+    ).toBe('claude "$(cat \'/tmp/brief.md\')"')
+  })
+  it('a path with a quote in it cannot break out of the quoting', () => {
+    // shellSingleQuote's '\'' dance — the path stays ONE argument to cat and nothing in it
+    // reaches the shell as syntax.
+    const cmd = assembleLaunchCommand(
+      { agentId: 'claude', promptFile: "/tmp/my brief's.md" },
+      ENV
+    ).command
+    expect(cmd.startsWith('claude "$(cat ')).toBe(true)
+    expect(cmd).toContain("'/tmp/my brief'\\''s.md'")
+  })
+  it('the --prompt literal is still collapsed to one line (unchanged behavior)', () => {
+    expect(
+      assembleLaunchCommand({ agentId: 'claude', initialPrompt: 'a\nb\n\n  c' }, ENV).command
+    ).toBe("claude 'a b c'")
+  })
+})
+
+describe('promptFilePathError', () => {
+  it('accepts an absolute POSIX path', () => {
+    expect(promptFilePathError('/tmp/brief.md')).toBeNull()
+  })
+  it('accepts a Windows drive path', () => {
+    expect(promptFilePathError('C:\\briefs\\x.md')).toBeNull()
+  })
+  it('refuses a relative path', () => {
+    expect(promptFilePathError('brief.md')).toMatch(/absolute/)
+  })
+  it('refuses an empty path', () => {
+    expect(promptFilePathError('  ')).toMatch(/needs a path/)
+  })
+  it('refuses a newline in the path — it would break the single-line typed delivery', () => {
+    expect(promptFilePathError('/tmp/a\nb')).toMatch(/newlines/)
   })
 })

--- a/src/shared/agents/launch.ts
+++ b/src/shared/agents/launch.ts
@@ -39,8 +39,17 @@ export interface LaunchInputs {
    *  Trusted verbatim, exactly like a custom agent's `launchCmd`: it is the local user's own
    *  settings and is typed into their own pane. */
   launchCmdOverride?: string
-  /** First-launch prompt. Empty/undefined = start the agent with no prompt. */
+  /** First-launch prompt. Empty/undefined = start the agent with no prompt. Collapsed to ONE
+   *  line (every whitespace run → a single space): the prompt rides argv on a command line typed
+   *  into the pane, and a newline would submit the half-typed line. Multi-line briefs go through
+   *  `promptFile` instead. */
   initialPrompt?: string
+  /** Absolute path to a file holding the first-launch prompt (canvas-control `--prompt-file`).
+   *  Wins over `initialPrompt`. Composed as `"$(cat '<path>')"` so the TYPED line stays one line
+   *  while the pane's shell expands the file — newlines and all — into a single argv element at
+   *  execution. Requires a POSIX-style shell in the new node; validate with
+   *  `promptFilePathError` before passing. */
+  promptFile?: string
   /** Permission mode to start in. `undefined` = no flag (the agent's own default). */
   permissionMode?: AgentPermissionMode
   /** Per-node model override, applied through the effective base harness. */
@@ -126,6 +135,26 @@ function expandedProgram(
 }
 
 /**
+ * Validate a `--prompt-file` path BEFORE it is composed into the launch line. Returns a short
+ * error fragment, or null when the path is usable. The rules exist because the path is
+ * interpolated into a command that is typed into the pane as ONE line: a newline in the path
+ * would break the single-line delivery the whole mechanism exists to preserve, and a relative
+ * path is ambiguous between the calling agent's cwd and the new node's cwd — requiring an
+ * absolute path removes the guess. (Quoting itself is `shellSingleQuote`'s job — a space or a
+ * quote in the path is fine.)
+ */
+export function promptFilePathError(p: string): string | null {
+  const t = p.trim()
+  if (!t) return 'needs a path'
+  // eslint-disable-next-line no-control-regex
+  if (/[\r\n\x00]/.test(t)) return 'must not contain newlines or control characters'
+  if (!(t.startsWith('/') || /^[A-Za-z]:[\\/]/.test(t))) {
+    return `must be an absolute path (got "${t}")`
+  }
+  return null
+}
+
+/**
  * Assemble the FIRST-LAUNCH command: `<launchCmd> <args> [sep] [prompt] [permission flag]
  * [session-id flag]`. The prompt and flags land per the resolved prompt convention (separator
  * agents put flags before `--`; positional agents put them last), exactly as the historical
@@ -154,9 +183,22 @@ export function assembleLaunchCommand(
   const { fragment: argsFragment, missing: m2 } = expandedArgs(inputs.customAgent?.args ?? '', env)
   const baseCmd = argsFragment ? `${program} ${argsFragment}` : program
 
-  const promptArg = inputs.initialPrompt
-    ? shellSingleQuote(inputs.initialPrompt.replace(/\s+/g, ' ').trim())
-    : null
+  // The prompt becomes an ARGUMENT on a command line that is then typed into the pane
+  // (`writeWhenShellReady` → `deliverCommand`, which echo-verifies the line before submitting).
+  // A raw newline inside it would submit the half-typed line and fail that verification, so:
+  // - `initialPrompt` (a literal) has every whitespace run collapsed to a single space —
+  //   load-bearing for the delivery path, not tidying (issue #520 / PR #516's finding).
+  // - `promptFile` keeps structure WITHOUT putting it on the typed line: the argument is a
+  //   `"$(cat '<path>')"` command substitution, so the pane's shell reads the file at execution
+  //   and hands the CLI its exact contents as ONE argv element. The double quotes make the
+  //   substitution a single word and keep its RESULT data — file content is never re-parsed as
+  //   shell syntax. On an SSH project the path (and the `cat`) are on the host, which is exactly
+  //   where the node runs. Only the PATH is interpolated, and it is single-quoted.
+  const promptArg = inputs.promptFile
+    ? `"$(cat ${shellSingleQuote(inputs.promptFile.trim())})"`
+    : inputs.initialPrompt
+      ? shellSingleQuote(inputs.initialPrompt.replace(/\s+/g, ' ').trim())
+      : null
   const sep = eff.argvPromptSeparator
   const promptFlag =
     eff.promptInjectionMode === 'flag-prompt'

--- a/src/shared/control-verbs.test.ts
+++ b/src/shared/control-verbs.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { DRY_RUN_VERBS, dryRunRequested, dryRunRefusal } from './control-verbs'
+
+describe('dryRunRequested', () => {
+  it('absent means no dry run', () => {
+    expect(dryRunRequested({})).toBe(false)
+    expect(dryRunRequested({ count: '2' })).toBe(false)
+  })
+  it("the shim's valueless flag (empty string) means ON", () => {
+    // `sh nodeterm.sh spawn-team --dry-run --team …` translates to `arg.dry-run=` — an empty
+    // string. Reading that as off would run the real mutation under a flag that asked it not to.
+    expect(dryRunRequested({ 'dry-run': '' })).toBe(true)
+  })
+  it('explicit truthy spellings are ON', () => {
+    for (const v of ['true', 'yes', '1']) expect(dryRunRequested({ 'dry-run': v })).toBe(true)
+  })
+  it('explicit off-values are OFF', () => {
+    for (const v of ['false', 'no', '0', 'FALSE', ' No ']) {
+      expect(dryRunRequested({ 'dry-run': v })).toBe(false)
+    }
+  })
+  it('an unrecognized value fails toward DRY (the safe direction)', () => {
+    expect(dryRunRequested({ 'dry-run': 'maybe' })).toBe(true)
+  })
+})
+
+describe('DRY_RUN_VERBS', () => {
+  it('covers exactly the spawn verbs', () => {
+    expect([...DRY_RUN_VERBS].sort()).toEqual(
+      ['open-agent', 'open-claude', 'open-terminal', 'open-worktree', 'spawn-team'].sort()
+    )
+  })
+  it('never contains a destructive or read verb', () => {
+    for (const v of ['write', 'close', 'open-project', 'list', 'board', 'browser']) {
+      expect(DRY_RUN_VERBS.has(v)).toBe(false)
+    }
+  })
+})
+
+describe('dryRunRefusal', () => {
+  it('names the verb and derives the supported list from the set', () => {
+    const msg = dryRunRefusal('close')
+    expect(msg).toContain('close')
+    for (const v of DRY_RUN_VERBS) expect(msg).toContain(v)
+    expect(msg).toContain('Nothing was done')
+  })
+})

--- a/src/shared/control-verbs.ts
+++ b/src/shared/control-verbs.ts
@@ -53,3 +53,46 @@ export const DESTRUCTIVE_VERBS: ReadonlySet<string> = new Set(['write', 'close',
 export function isDestructiveVerb(verb: string): boolean {
   return DESTRUCTIVE_VERBS.has(verb)
 }
+
+/**
+ * Verbs that honour `--dry-run` (issue #532): validate the call — the SAME validation a real call
+ * runs, ids resolved against the live canvas — and report what would happen, changing nothing.
+ *
+ * Deliberately only the SPAWN verbs. The asymmetry the issue names is that these are easy to call
+ * and expensive to undo (a mis-spawned team is N nodes to clean up by hand; a bad `--after` id
+ * arms a station against nothing); `list`/`board` are already reads, and the mutating verbs
+ * outside this set are either cheap to reverse (`rename`, `assign`) or human-confirmed
+ * (`write`/`close`). A verb OUTSIDE this set must REFUSE `--dry-run`, never silently perform —
+ * a `close --dry-run` that closes is strictly worse than no flag at all. That refusal is decided
+ * in MAIN's control handler (src/main/index.ts, setControlHandler's first gate), which every
+ * control dispatch passes through, `browser` and `open-project` included.
+ *
+ * Same `string` typing rationale as DESTRUCTIVE_VERBS above: both sides read this set, and the
+ * renderer's dispatch receives a raw `verb: string` off IPC.
+ */
+export const DRY_RUN_VERBS: ReadonlySet<string> = new Set([
+  'open-terminal',
+  'open-claude',
+  'open-agent',
+  'spawn-team',
+  'open-worktree'
+])
+
+/**
+ * Did the caller ask for a dry run? Presence-based, because the sh shim translates a valueless
+ * `--dry-run` to `arg.dry-run=` (empty string) — so `''` MUST read as on. The explicit
+ * off-values exist for the `--dry-run=false` a caller writes to be safe; anything else present
+ * is on (guessing "off" for an unrecognized value would run the real mutation under a flag that
+ * asked it not to — the unsafe direction).
+ */
+export function dryRunRequested(args: Record<string, string | undefined>): boolean {
+  const v = args['dry-run']
+  if (v === undefined) return false
+  return !/^(false|no|0)$/i.test(v.trim())
+}
+
+/** The refusal for `--dry-run` on a verb outside DRY_RUN_VERBS — derived from the set so the
+ *  sentence can never name a verb the gate does not honour. */
+export function dryRunRefusal(verb: string): string {
+  return `--dry-run is not supported for ${verb} — it applies to: ${[...DRY_RUN_VERBS].join(', ')}. Nothing was done.`
+}

--- a/src/shared/worktree.test.ts
+++ b/src/shared/worktree.test.ts
@@ -12,6 +12,8 @@ import {
   isRemoteSessionNode,
   isValidGitRef,
   resolveBaseRef,
+  resolveWorktreeBase,
+  type WorktreeBaseNode,
   worktreeFromCreate,
   worktreeFromEntry,
   worktreeRemoveMessage,
@@ -510,5 +512,88 @@ describe('effectiveWorktreeTemplate', () => {
     const template = effectiveWorktreeTemplate({ basePath: '/' }, undefined)
     expect(template).toBe('/${branch}')
     expect(computeWorktreePath('/src/repo', 'topic/a', template)).toBe('')
+  })
+})
+
+describe('resolveWorktreeBase (issue #530 — --base <ref|stationId>)', () => {
+  // A wave-one worktree frame (g1, branch wave1) holding an agent node (a1), a nested inner
+  // frame (g1a) holding a2; a loose node (n0); an unbound frame (g2) with a member (b1).
+  const NODES: WorktreeBaseNode[] = [
+    { id: 'g1', worktree: { branch: 'wave1' } },
+    { id: 'a1', parentId: 'g1' },
+    { id: 'g1a', parentId: 'g1' },
+    { id: 'a2', parentId: 'g1a' },
+    { id: 'n0' },
+    { id: 'g2' },
+    { id: 'b1', parentId: 'g2' }
+  ]
+
+  it('no --base means the default', () => {
+    expect(resolveWorktreeBase(undefined, 'wave2', NODES)).toEqual({ kind: 'default' })
+    expect(resolveWorktreeBase('  ', 'wave2', NODES)).toEqual({ kind: 'default' })
+  })
+  it('a member node resolves through its bound group to the branch', () => {
+    expect(resolveWorktreeBase('a1', 'wave2', NODES)).toEqual({
+      kind: 'station',
+      ref: 'wave1',
+      stationId: 'a1',
+      groupId: 'g1'
+    })
+  })
+  it('a node in a NESTED frame climbs to the nearest bound ancestor', () => {
+    expect(resolveWorktreeBase('a2', 'wave2', NODES)).toEqual({
+      kind: 'station',
+      ref: 'wave1',
+      stationId: 'a2',
+      groupId: 'g1'
+    })
+  })
+  it('the bound group id itself is a station', () => {
+    expect(resolveWorktreeBase('g1', 'wave2', NODES)).toEqual({
+      kind: 'station',
+      ref: 'wave1',
+      stationId: 'g1',
+      groupId: 'g1'
+    })
+  })
+  it('a node outside any worktree frame is an explicit refusal — never reinterpreted as a ref', () => {
+    for (const id of ['n0', 'b1', 'g2']) {
+      const r = resolveWorktreeBase(id, 'wave2', NODES)
+      expect(r.kind).toBe('error')
+      if (r.kind === 'error') expect(r.error).toContain('not inside a worktree-bound frame')
+    }
+  })
+  it('a station whose branch IS the new branch is refused (self-base)', () => {
+    const r = resolveWorktreeBase('a1', 'wave1', NODES)
+    expect(r.kind).toBe('error')
+    if (r.kind === 'error') expect(r.error).toContain('based on itself')
+  })
+  it('a plain ref self-base is refused too', () => {
+    const r = resolveWorktreeBase('wave2', 'wave2', NODES)
+    expect(r.kind).toBe('error')
+    if (r.kind === 'error') expect(r.error).toContain('based on itself')
+  })
+  it('a value naming no node passes through as a validated git ref', () => {
+    expect(resolveWorktreeBase('main', 'wave2', NODES)).toEqual({ kind: 'ref', ref: 'main' })
+    expect(resolveWorktreeBase('origin/main', 'wave2', NODES)).toEqual({
+      kind: 'ref',
+      ref: 'origin/main'
+    })
+  })
+  it('a value that is neither a node nor a valid ref is refused', () => {
+    for (const bad of ['-rf', 'a..b', 'has space']) {
+      const r = resolveWorktreeBase(bad, 'wave2', NODES)
+      expect(r.kind).toBe('error')
+      if (r.kind === 'error') expect(r.error).toContain('neither')
+    }
+  })
+  it('a forged parentId cycle terminates as a refusal instead of hanging', () => {
+    // project.json is hand-editable and git-shared; the walk is visited-set guarded.
+    const cyc: WorktreeBaseNode[] = [
+      { id: 'x', parentId: 'y' },
+      { id: 'y', parentId: 'x' }
+    ]
+    const r = resolveWorktreeBase('x', 'wave2', cyc)
+    expect(r.kind).toBe('error')
   })
 })

--- a/src/shared/worktree.ts
+++ b/src/shared/worktree.ts
@@ -80,6 +80,89 @@ export function isValidGitRef(name: string): boolean {
   return !/[\s~^:?*[\\]|\.\.|^\/|\/$|@\{/.test(n)
 }
 
+/** The node shape `resolveWorktreeBase` walks — id, containment, and (for groups) the binding. */
+export interface WorktreeBaseNode {
+  id: string
+  parentId?: string
+  /** The group's binding, when this node is a worktree-bound group frame. */
+  worktree?: Pick<GroupWorktree, 'branch'>
+}
+
+export type WorktreeBaseResolution =
+  /** No `--base` given — the caller falls back to its default base. */
+  | { kind: 'default' }
+  /** A plain git ref, validated by `isValidGitRef`. */
+  | { kind: 'ref'; ref: string }
+  /** A STATION: the id named a node/group on the canvas, and the base is the branch of the
+   *  worktree-bound group that contains it (or is it). */
+  | { kind: 'station'; ref: string; stationId: string; groupId: string }
+  | { kind: 'error'; error: string }
+
+/**
+ * Resolve `open-worktree --base <value>` (issue #530): the value may be a git ref, OR the id of a
+ * station — a node or group frame inside a worktree-bound group — in which case the base is that
+ * station's branch, resolved through the binding. This lets an orchestrator say "branch off what
+ * that station is working on" by IDENTITY, instead of restating the branch name (and getting it
+ * wrong) in every downstream call.
+ *
+ * Precedence: an id that names an EXISTING node is always read as a station — a node that is not
+ * inside a worktree frame is an explicit refusal, never silently reinterpreted as a git ref (an
+ * id that matched a node was clearly meant as one; falling through would base the worktree on a
+ * ref that happens to parse). A value naming no node must be a valid git ref. Refusals are
+ * explicit for: a station with no binding, a base that resolves to the branch being created
+ * (a worktree cannot be based on itself), and a value that is neither a node nor a valid ref.
+ *
+ * Note the timing this deliberately does NOT change: the base is captured when the worktree is
+ * CREATED, exactly like a plain ref — deferred (create-at-fire) worktrees are a separate design
+ * (the rest of issue #530). The docs tell the orchestrator to create a downstream worktree after
+ * the upstream station has committed.
+ */
+export function resolveWorktreeBase(
+  baseArg: string | undefined,
+  newBranch: string,
+  nodes: WorktreeBaseNode[]
+): WorktreeBaseResolution {
+  const raw = (baseArg ?? '').trim()
+  if (!raw) return { kind: 'default' }
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const station = byId.get(raw)
+  if (station) {
+    // Climb from the station to the nearest worktree-bound group (the station may BE the group).
+    // Visited-set guarded: parentId chains come from a hand-editable, git-shared project.json,
+    // and a forged cycle must not hang the verb.
+    const seen = new Set<string>()
+    let cur: WorktreeBaseNode | undefined = station
+    while (cur && !seen.has(cur.id)) {
+      seen.add(cur.id)
+      const branch = cur.worktree?.branch
+      if (branch) {
+        if (branch === newBranch) {
+          return {
+            kind: 'error',
+            error: `--base ${raw} resolves to branch "${branch}", which is the branch being created — a worktree cannot be based on itself`
+          }
+        }
+        return { kind: 'station', ref: branch, stationId: raw, groupId: cur.id }
+      }
+      cur = cur.parentId ? byId.get(cur.parentId) : undefined
+    }
+    return {
+      kind: 'error',
+      error: `--base ${raw} names a node that is not inside a worktree-bound frame — pass a git ref, or a station (node or group id) inside a worktree frame`
+    }
+  }
+  if (!isValidGitRef(raw)) {
+    return {
+      kind: 'error',
+      error: `--base "${raw}" is neither an existing node/group id nor a valid git ref`
+    }
+  }
+  if (raw === newBranch) {
+    return { kind: 'error', error: `--base "${raw}" is the branch being created — a worktree cannot be based on itself` }
+  }
+  return { kind: 'ref', ref: raw }
+}
+
 /** Flatten a branch name into a filesystem-safe, flag-safe slug. */
 export function sanitizeWorktreeBranch(input: string): string {
   return input


### PR DESCRIPTION
Three small, sharp gaps from @Temikus's orchestration feedback series, all on the same canvas-control verb surface, one commit each. Closes #520, closes #532; ships the expressivity half of #530 (that issue stays open for the deferred-creation design — see my comment there).

## 1. `--prompt-file` — a multi-line brief for a station (#520)

`--prompt` rides argv on a launch line that is typed into the pane and echo-verified, so `assembleLaunchCommand` collapses every whitespace run — a structured brief arrived as one paragraph, and orchestration contracts degraded into run-on prose.

Rather than moving the prompt off the launch line entirely (the issue's sketch — it changes how *every* agent node starts, cold-restore and hibernation wake included, and needs a new "CLI is accepting input" readiness signal), this keeps the delivery path byte-identical and moves only the *content*:

- `open-claude` / `open-agent` take `--prompt-file <abs path>` (and a `spawn-team` role may carry `promptFile`).
- The assembler composes the prompt as `"$(cat '<path>')"`: the **typed line stays one line** — echo verification untouched — and the pane's shell expands the file at execution into a single argv element, newlines and structure intact. Only the path is interpolated (single-quoted); the file content is a substitution *result*, never re-parsed as shell syntax. It also sidesteps our own argv limits — the brief never rides tmux/ssh argv at all (the CLI still receives it as one exec arg, so ~100 KB is the practical ceiling on Linux).
- On an SSH project the path and the `cat` are both on the host, which is exactly where the node runs.
- Validation at the verb: absolute path only, no control characters, `--prompt` XOR `--prompt-file`, and an existence check against the filesystem the node will read from — a missing file would otherwise silently start the agent with an *empty* prompt. Check errors fail open (the pane shows `cat`'s own error).
- Caveat stated in the docs: the file is read at *launch* (later than the call for an `--after`-armed node — keep it in place), and the expansion needs a POSIX-style shell in the new node.

This overlaps #516 (docs-only, still open): both agent-facing bodies here document the one-line `--prompt` fact and the leading-`/` trap in the same breath as the fix, so if this lands first #516 becomes mostly redundant — your call on ordering.

## 2. `--dry-run` — validate a spawn call without performing it (#532)

The fan-out verbs were easy to call and expensive to undo: a `spawn-team` payload could only be validated by opening nodes; a wrong `--after` id was discovered after arming.

- `DRY_RUN_VERBS` (`shared/control-verbs.ts`): `open-terminal`, `open-claude`, `open-agent`, `spawn-team`, `open-worktree` honour `--dry-run`. This is the issue's "round-trip to the renderer" option, but **without a second validation path to rot**: each dispatch case runs its *real* validators (`--group`/`--after` resolved against the live canvas, team JSON parsed, prompt-file existence, worktree path computed) and stops just before the mutation.
- Every other verb **refuses** the flag — a `close --dry-run` that closes would be worse than no flag. The refusal is main's `setControlHandler`'s *first* gate (covers `browser` and `open-project` too) and its sentence derives from the set. `--dry-run` + `--project` is refused (that open lands in another project's store through a different path; a validate-only copy of it is exactly the rot risk).
- A valueless `--dry-run` arrives from the sh shim as an empty string and reads as ON; an unrecognized value fails toward DRY (the safe direction).
- The dry run is deliberately *stricter* in one place: an unknown `--agent` id is caught at dry-run time (the real open still builds the node whose pane then shows the typo — unchanged).
- `spawn-team`'s parser moved to the pure `lib/teamSpec.ts` with **named refusals** — this changes real-path behavior in the refusal direction: a role missing its prompt used to be silently filtered (the team just opened short), a 9th role silently sliced, an unknown agent id opened a broken node. All three now refuse with the role named.

Tested in both parsers per house rules: the shim's valueless-flag translation under real `sh` (`control-shim-parse.test.ts`) and `parseControlBody` (`canvas-control-shim.test.ts`), plus `teamSpec.test.ts` and `control-verbs.test.ts`.

## 3. `open-worktree --base <ref|stationId>` (#530)

`--base` only took a git ref, so "wave two branches off what the wave-one station is producing" lived in prose (`git merge …` at the top of every downstream prompt).

- `resolveWorktreeBase` (`shared/worktree.ts`, pure + tested): a `--base` value naming an existing node or group resolves through its worktree-bound group frame (nested frames climb to the nearest bound ancestor) to that station's **branch** — the dependency is stated once, by identity. Every reply, dry run included, names the branch the id resolved to.
- Explicit refusals, never a guess: an id naming a node *outside* any worktree frame is refused rather than reinterpreted as a ref; self-base (the resolved branch == the branch being created) is refused; a value that is neither a node id nor a valid git ref is refused (`isValidGitRef` also closes leading-dash flag smuggling); a forged `parentId` cycle in the git-shared project.json terminates as a refusal.
- **Deliberately not built here: lazy resolution.** The issue's deferred-creation half (a pending frame with no worktree behind it, refuse-at-fire, persistence + a post-restart escape hatch) is a real design with its own states and is left open for you to rule on — see my reply on #530. Until then the docs state the capture timing outright and give the working pattern: arm the downstream agent with `--after` and create its worktree when the upstream has committed, or have it merge first.

## Cross-cutting

- All agent-facing text updated in the same PR (`buildCanvasSkillBody` + `buildCanvasControlInstructions`), pinned in `canvas-control-core.test.ts` per the #269 stale-doc rule; the dry-run verb list *renders from* `DRY_RUN_VERBS` so it cannot drift.
- New verbs/flags parse identically under the old and new shim loops (every flag has a value, or is valueless-safe) — no dependence on a shim rewrite reaching SSH hosts.
- Surfaces: desktop only in practice (canvas-control is not wired on the Server Edition; mobile N/A). SSH projects covered as noted per feature.
- Full suite: 9348 passed; the two failures are node_modules-freshness pins (`@xterm`/`@xyflow` dists not installed in my worktree), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
