### PR TITLE
Fix shared Codex identity in local canvas/context shims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1076,6 +1076,14 @@ else, and its context links must keep classifying across restarts).
     layout by construction on all three surfaces) and then the well-known data dirs; it is monotone
     — advertised dir first, keyed by node-id filename in every candidate, and a foreign instance's
     dir yields a foreign `kid` = `legacy` = exactly what presenting nothing already gave.
+  - **Every LOCAL generated sh client recovers shared-Codex identity before its env gate.** A tool
+    shell forked by the account-scoped app-server carries `CODEX_THREAD_ID`, not the pane's
+    `NODETERM_*`. Managed hooks, local `nodeterm.sh`, and local `context.sh` therefore prepend
+    `codexThreadIdentityResolverSh(codexThreadIdentityRoot())` before testing
+    `NODETERM_NODE_ID`/`NODETERM_CANVAS_CONTROL`. Before this was shared, status hooks recovered the
+    node while both user-facing shims declared that same first-class Codex session outside
+    nodeterm. The SSH constants remain machine-neutral: the local record root is not valid on a
+    remote host and must never be baked into its copy.
   - **Every generated sh client walks the SAME endpoint failover** (`nt_candidates`/`nt_adopt`,
     `core/agents/hook-endpoint-failover-sh.ts`) — issue #445, the endpoint-level twin of #384: a
     session is pinned for life to the endpoint PATH it got at tmux creation, so an app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1083,7 +1083,39 @@ else, and its context links must keep classifying across restarts).
     `NODETERM_NODE_ID`/`NODETERM_CANVAS_CONTROL`. Before this was shared, status hooks recovered the
     node while both user-facing shims declared that same first-class Codex session outside
     nodeterm. The SSH constants remain machine-neutral: the local record root is not valid on a
-    remote host and must never be baked into its copy.
+    remote host and must never be baked into its copy — enforced by
+    `main/remote-ssh/remote-shim-neutrality.guard.test.ts`, two legs (the exported neutral bodies
+    carry no record root or prelude, and `remote-hooks.ts` cannot even NAME a parameterised
+    builder), because the failure is silent and one-sided: a remote shim carrying the prelude keeps
+    working, and the only symptom is this machine's userData layout sitting in a file on someone
+    else's server.
+  - **That prelude EXPORTS WHAT THE RECORD SAYS — it never decides.** `NODETERM_AGENT_ID` and
+    `NODETERM_CANVAS_CONTROL` were once constants there (`codex`, granted); both are
+    `buildPtyEnv`'s answers about the PANE, which labels a node with its OWN agent id
+    (`custom:<uuid>` for a custom agent whose `baseAgent` is codex, not `codex`) and gates the grant
+    on `canControlCanvas`. The constants therefore mislabelled every custom codex-based node and
+    asserted a grant that agrees with the pane only because
+    `SHARED_IDENTITY_CAPABLE ⊆ CANVAS_CONTROL_CAPABLE` — a coincidence that list's own comment
+    invites the next shared-identity agent to break, and breaking it hands a tool shell a capability
+    its pane was denied. So the record carries `agentId` + `canvasControl` INSIDE the 6-tuple HMAC,
+    and the prelude reads them; the grant is exported only when the record grants it and is left
+    UNSET otherwise (absent, never `0` — the shape both shims' `[ -z … ]` gates expect). The **pane
+    echoes its own label** on `/codex-thread/{start,bind}` (a tmux session outlives the app, so
+    after a restart nothing server-side still knows what agent a node runs), but the **grant is
+    never echoed**: the route derives it with `canControlCanvas`, so there is ONE decider and a
+    forged id cannot manufacture a grant the table refuses. The three preimage generations are
+    **selected by the record's shape, never tried in turn** — a record naming an agent must not
+    verify under a preimage that ignores one — and a pre-agent record's implied `codex` + grant is
+    keyed on the LINE being absent, never on the value being empty, so nothing that names an agent
+    falls back to the guess. The env vars were never a security boundary in any case (anyone who can
+    run the shim can `export` them by hand); the per-node token is, and
+    `docs/shared-codex-node-identity.md` states that argument in full.
+  - **A shell that forwards this identity cannot be type-checked into correctness.** A handler that
+    destructures the request without `agent`, and a record write that omits its optional trailing
+    argument, are BOTH well-typed — so the whole dimension can be plumbed through core, the route,
+    the launcher and the prelude, pass `npm run typecheck` and every unit test, and ship INERT.
+    `main/codex-identity-record-wiring.test.ts` pins it at source level, the same remedy
+    `hook-verified-parity.test.ts` uses for the same class of hole.
   - **Every generated sh client walks the SAME endpoint failover** (`nt_candidates`/`nt_adopt`,
     `core/agents/hook-endpoint-failover-sh.ts`) — issue #445, the endpoint-level twin of #384: a
     session is pinned for life to the endpoint PATH it got at tmux creation, so an app
@@ -1395,8 +1427,9 @@ else, and its context links must keep classifying across restarts).
   injects `isRemoteNode`/`readRemoteFile`/`runRemoteCommand`, bounded tail reads), its hook-fed
   path is jailed at ingest (`isSafeRemoteTranscriptPath`), and `resolveLinkTranscript` REFUSES
   the local locators for remote nodes (they'd resolve a stranger's local transcript). Server
-  Edition passes no deps → local-only (context link is NOT wired there at all — `initContextLink`
-  is never called from `src/server`). Discovery is per-agent: claude installs a
+  Edition IS wired (`src/server/context-link.ts` calls `initContextLink(ptyManager, {})`) but
+  passes no remote deps → **local-only**, which is the complete answer there: that shell runs ON the
+  host whose transcripts and tmux it reads, and SSH projects are a desktop-only concept. Discovery is per-agent: claude installs a
   `get-linked-context` skill; codex/gemini get an idempotent marker block
   (`<!-- nodeterm:get-linked-context:start/end -->`) merged into `~/.codex/AGENTS.md` /
   `~/.gemini/GEMINI.md`. On connect an idle-gated one-line note is injected into each endpoint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1088,7 +1088,14 @@ else, and its context links must keep classifying across restarts).
     carry no record root or prelude, and `remote-hooks.ts` cannot even NAME a parameterised
     builder), because the failure is silent and one-sided: a remote shim carrying the prelude keeps
     working, and the only symptom is this machine's userData layout sitting in a file on someone
-    else's server.
+    else's server. **The prelude is shared; the RECORD it reads is desktop-only.** Those writers are
+    the two hook-server handlers `src/main/index.ts` registers, and
+    `src/server/handlers/index.ts` deliberately registers neither — so on the Server Edition the
+    file is byte-identical, the signing secret is armed, and the resolver still finds nothing and
+    takes its fallback. Coherent rather than missing: that shell answers `shared: false`
+    (`UNKNOWN_CODEX_IDENTITY_CAPS`), so its Codex nodes run their own app-server and no tool shell
+    needs recovering. It turns into a real gap only when that edition grows the shared app-server,
+    and the fix is the two registrations.
   - **That prelude EXPORTS WHAT THE RECORD SAYS — it never decides.** `NODETERM_AGENT_ID` and
     `NODETERM_CANVAS_CONTROL` were once constants there (`codex`, granted); both are
     `buildPtyEnv`'s answers about the PANE, which labels a node with its OWN agent id

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,23 @@ shell is forked by the account-scoped app-server, so it has `CODEX_THREAD_ID` bu
 `NODETERM_*`. Managed hooks, local `nodeterm.sh`, and local `context.sh` must prepend
 `codexThreadIdentityResolverSh(codexThreadIdentityRoot())` before checking `NODETERM_NODE_ID` or
 `NODETERM_CANVAS_CONTROL`. Keep the SSH shim constants machine-neutral: baking the desktop/server
-record path into a remote host is both wrong and a local-layout leak.
+record path into a remote host is both wrong and a local-layout leak. A guard test enforces that
+(`remote-shim-neutrality.guard.test.ts`), because the leak is silent — the remote shim keeps
+working, and nothing goes red.
+
+**That prelude may not decide anything a pane already decided.** It exports the agent id and the
+canvas-control grant the ownership RECORD carries, never constants. They used to be hardcoded
+(`codex`, granted) and both are `buildPtyEnv`'s answers: a custom agent inheriting the codex harness
+is `custom:<uuid>`, and the grant comes from `canControlCanvas`. If you add a field the prelude
+exports, put it inside the record's HMAC and have the desktop re-derive anything that grants a
+capability — never accept the client's word for that. Withhold rather than assume: a tool shell
+missing a verb its pane has is a bug report, a tool shell holding one its pane was denied is a
+security question.
+
+**A shell that forwards data into these records cannot be type-checked into correctness.** A
+handler that destructures the request without the new field, and a call that omits an optional
+trailing argument, are both well-typed — so the feature ships inert with a green suite. Pin the
+wiring at source level (`codex-identity-record-wiring.test.ts`, `hook-verified-parity.test.ts`).
 
 **A stream error is not a throw you can catch.** When a write to `process.stdout`/`stderr` fails —
 `EPIPE` down a closed pipe, `EIO` after macOS revokes a closed terminal's tty — node reports it by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,13 @@ that file advertises presents nothing forever when the file is old or unreadable
 hook script alone could heal itself, the same node proved itself through one client and was refused
 through another for the life of the session.
 
+**Local generated sh clients recover shared-Codex identity before their env gate.** A Codex tool
+shell is forked by the account-scoped app-server, so it has `CODEX_THREAD_ID` but not the pane's
+`NODETERM_*`. Managed hooks, local `nodeterm.sh`, and local `context.sh` must prepend
+`codexThreadIdentityResolverSh(codexThreadIdentityRoot())` before checking `NODETERM_NODE_ID` or
+`NODETERM_CANVAS_CONTROL`. Keep the SSH shim constants machine-neutral: baking the desktop/server
+record path into a remote host is both wrong and a local-layout leak.
+
 **A stream error is not a throw you can catch.** When a write to `process.stdout`/`stderr` fails —
 `EPIPE` down a closed pipe, `EIO` after macOS revokes a closed terminal's tty — node reports it by
 emitting `'error'` on the stream a tick later, and the default for an unhandled `'error'` event is

--- a/docs/gemini-agent.md
+++ b/docs/gemini-agent.md
@@ -405,7 +405,7 @@ one stray keystroke.
 | In-place restart + cold-restore resume | yes | yes | N/A |
 | ⌘M transcript view (`ChatPanel`) | **not implemented for gemini** — `CHAT_CAPABLE` is claude-only; the panel parses claude's JSONL | idem | idem |
 | Find bar's transcript index | **claude only** (`readsClaudeTranscript`); the terminal-buffer search works normally | idem | N/A |
-| Context links | yes (`CONTEXT_LINK_CAPABLE`), marker block in `~/.gemini/GEMINI.md` | **not wired at all** — `initContextLink` is never called from `src/server` | N/A |
+| Context links | yes (`CONTEXT_LINK_CAPABLE`), marker block in `~/.gemini/GEMINI.md` | wired, **local-only** — `src/server/context-link.ts` calls `initContextLink(pty, {})` with no remote deps | N/A |
 | Canvas control | yes, marker block + the sh+curl shim | **not wired** — `agent:control` has no server handler; pre-existing | N/A — no canvas |
 | Managed accounts | **N/A** — accounts are a claude config-dir mechanism; `createAgentNode` never stamps an `accountId` on a non-claude node, and `CLAUDE_CONFIG_DIR` is irrelevant to `~/.gemini/settings.json` | idem | idem |
 | Working indicator | the **brand mark, breathing** — `brandPulsePlan('gemini', …)` returns the `gemini-color.svg` asset and it pulses with a bloom, on the canvas badge and in the notch strip. Before this branch gemini fell through to the plain dot, which says "something is happening" but not *who* | **N/A** for the notch (there is none); the canvas badge works | the phone has its own SwiftUI renderer |

--- a/docs/shared-codex-node-identity.md
+++ b/docs/shared-codex-node-identity.md
@@ -119,9 +119,16 @@ Ownership resolution reuses the merged fail-closed posture (`pane-ownership.ts`,
 
 ## The POSIX-sh resolver
 
-`codexThreadIdentityResolverSh(root)` is prepended to every managed hook script. A shared-app-server
-tool shell inherits `CODEX_THREAD_ID` but not the pane's `NODETERM_*` (see probe U5,
-`docs/superpowers/probes/2026-08-codex-tool-shell-env.md`), so this prelude recovers the binding:
+`codexThreadIdentityResolverSh(root)` is prepended to every managed hook script and to both LOCAL
+agent shims (`nodeterm.sh` and `context.sh`) before their early environment gates. A
+shared-app-server tool shell inherits `CODEX_THREAD_ID` but not the pane's `NODETERM_*` (see probe
+U5, `docs/superpowers/probes/2026-08-codex-tool-shell-env.md`), so this prelude recovers the binding.
+Without it, Codex hook status worked while canvas control and linked-context reads misdiagnosed the
+same first-class node as being outside nodeterm. The machine-neutral shim constants copied to SSH
+hosts deliberately omit the local record path; each local installer builds its own copy with its
+own `codexThreadIdentityRoot()`.
+
+The resolver:
 
 - reads `NODETERM_CODEX_ACCOUNT_ID` from the daemon env to pick the scope;
 - a known safe account id ⇒ reads **only** that account's record, and requires the record's

--- a/docs/shared-codex-node-identity.md
+++ b/docs/shared-codex-node-identity.md
@@ -87,22 +87,55 @@ Each record is a flat `key=value` text file, mode `0600`, **parsed as data, neve
 accountId=<id or empty for system>
 nodeId=<owning canvas node>
 endpoint=<hook endpoint file path>
+agentId=<the node's own agent id>
+canvasControl=<1 or 0>
 signature=<base64url HMAC>
 ```
 
-### The signature binds the full 4-tuple
+### Why the record names the agent
+
+`agentId` and `canvasControl` were once **constants in the sh prelude** (`codex`, granted). Both are
+facts about the PANE that only `hookServer.buildPtyEnv` knows: it labels a node with the node's own
+agent id — which for a custom agent declaring `baseAgent: 'codex'` is `custom:<uuid>`, **not**
+`codex` — and gates the grant on `canControlCanvas`. A constant is the prelude asserting what it
+cannot know. It mislabelled every custom codex-based node, and it asserted a grant that agrees with
+the pane today only because `SHARED_IDENTITY_CAPABLE ⊆ CANVAS_CONTROL_CAPABLE` — a coincidence that
+list's own comment invites the next shared-identity agent to break, at which point the prelude would
+be handing a tool shell a capability its pane was denied.
+
+Who decides what: the **pane echoes its own label** on `/codex-thread/{start,bind}` (a tmux session
+outlives the app, so after a restart nothing server-side still remembers what agent a node runs, and
+the pane's environment is the only durable holder). The **grant is never echoed** — the route derives
+it with `canControlCanvas`, the same predicate in the same process that gated the pane, so there is
+exactly one decider and a forged agent id cannot manufacture a grant the capability table refuses.
+Echoing the label is not a capability claim in any case: reaching that route requires a token this
+instance minted for that node, so the caller *is* the node, and the record it shapes is re-exported
+only into that node's own tool shells.
+
+### The signature binds the full 6-tuple
 
 ```
-signature = base64url( HMAC-SHA256( key, threadId ␀ accountScope ␀ nodeId ␀ hookEndpoint ) )
+signature = base64url( HMAC-SHA256(
+  key, threadId ␀ accountScope ␀ nodeId ␀ hookEndpoint ␀ agentId ␀ canvasControl ) )
 ```
 
 `accountScope` is the account id, or the literal `system` for the system account (empty id
 normalised). Because the scope is inside the preimage, a record signed for account **A** verifies
 only under scope **A** — copying it byte-for-byte into account **B**'s directory fails the MAC.
-Verification is `timingSafeEqual`. Records written before this slice carry **no** `accountId=` line
-and are verified with the original 3-tuple preimage **at the system scope only** — the one
-back-compat door, and it is a system-scope door (a scope-less signature is never honoured under a
-managed account).
+`canvasControl` is inside it for the same class of reason: it names a capability the prelude exports
+into an agent's shell, so an unsigned copy would be a grant anyone able to write the file could add.
+Verification is `timingSafeEqual`.
+
+**The three preimage generations are SELECTED by the record's shape, never tried in turn.** An
+`agentId=` line ⇒ the 6-tuple and only that; no agent line but an `accountId=` line ⇒ the 4-tuple
+(an S6-era record); neither, at the system scope ⇒ the original 3-tuple. Falling through would be
+the door by which an agent id could be stripped or rewritten and the record still accepted. A
+pre-agent record is read with the implied values **`codex` + granted** — exactly what it meant when
+it was written, since it came from this same spine and codex is unconditionally canvas-control-capable
+— and that fallback is keyed on the **line being absent**, never on the value being empty, so nothing
+that names an agent can land back on the guess. `bindCodexThreadIdentity` likewise never downgrades a
+record that already names its agent, and never promotes a pre-agent record's *implication* into a
+signed claim.
 
 ## Fail-closed ambiguity (the house rule, reused)
 
@@ -139,6 +172,50 @@ The resolver:
 - it cannot verify the HMAC (no key in an agent's shell), so it re-validates every recovered field's
   charset and the account-line/scope agreement before exporting. Its behaviour is proven under real
   `/bin/sh` against a real on-disk scope tree in `codex-thread-identity-sh.test.ts`.
+
+**It exports what the record says; it does not decide.** `NODETERM_AGENT_ID` comes from the record's
+`agentId`, and `NODETERM_CANVAS_CONTROL=1` is exported **only** when the record's `canvasControl` says
+so — left UNSET otherwise, absent rather than `0`, the same shape `buildPtyEnv` produces and the shape
+both shims' `[ -z … ]` gates expect. Withholding is the honest degrade: a tool shell loses a verb its
+pane still has, whereas asserting a grant the pane was denied is the widening direction. A pre-agent
+record (no `agentId=` line) means `codex` with the grant; a record whose agent id is outside the
+accepted alphabet resolves **nothing at all** rather than falling back, because a record we did not
+write is not one to trust field by field.
+
+## The `NODETERM_*` env gate was never a security boundary
+
+Worth stating plainly, because both the prelude and the two shims *look* like access control: they
+open with `[ -z "$NODETERM_NODE_ID" ]` / `[ -z "$NODETERM_CANVAS_CONTROL" ]` and refuse to do
+anything without them. Widening what SETS those variables — which is what recovering a shared-Codex
+tool shell's identity does — therefore reads like widening what a local attacker can reach. It is
+not, and this section is the argument.
+
+Anyone who can run `nodeterm.sh` at all is already running as the user, in a shell, and can simply
+`export NODETERM_NODE_ID=… NODETERM_CANVAS_CONTROL=1` by hand. The variables are a **routing and
+no-op gate** — they tell a generated script which node it belongs to and keep it inert in the user's
+ordinary terminals — not an authorization check. Nothing server-side consults them; they never
+travel to the hook server at all.
+
+What actually authorizes is on the other side of the socket:
+
+- **Every route requires the app-wide bearer** (`X-NodeTerm-Hook-Token`, checked before any path
+  dispatch in `hook-server.ts`), which lives in the 0600 endpoint file.
+- **`/control/*` and `/context-link/*` additionally require the per-node capability**
+  (`X-NodeTerm-Node-Token`) through the single `identityGate` → `verifyNodeToken` →
+  `controlPolicy` path. The `nodeId` a caller names is a body field, and it is the token — not the
+  environment — that decides whether that caller may speak for it. `forged` is a bare 403, and the
+  strict verbs demand a `verified` verdict outright.
+- **Context link narrows again by construction**: the link document is selected by the REQUESTER's
+  node id (`linkDocs.get(req.nodeId)`), so a token-holding caller can only read the nodes in its own
+  directional link map — an env var cannot widen that set.
+- **`/codex-thread/{start,bind}`** — the routes that shape these very records — are strict: only a
+  `verified` per-node token proceeds.
+
+So the identity prelude changes *which sessions are correctly attributed to their node*, not *what
+anyone is permitted to do*. This PR does not change the threat model. The one thing that genuinely
+would is a value the prelude exports that nothing re-derives — which is exactly why
+`canvasControl` is signed and why the route computes it with `canControlCanvas` rather than
+accepting the pane's word for it.
 
 ## Supply-chain guard
 

--- a/docs/shared-codex-node-identity.md
+++ b/docs/shared-codex-node-identity.md
@@ -66,7 +66,9 @@ Every ownership record is HMAC-signed by the **one** restart-stable 32-byte node
 It is **confidential and fail-closed**: a malformed/wrong-length persisted state **throws** rather
 than minting a fresh secret — rotating the key would orphan every bound thread on the machine — and
 the single-flight cache clears on rejection so a healed machine retries. It is wired at boot in both
-`src/main/index.ts` and `src/server/index.ts` via `setCodexThreadIdentityAuthSecret(...)`.
+`src/main/index.ts` and `src/server/index.ts` via `setCodexThreadIdentityAuthSecret(...)`. Arming
+the secret is not the same as writing records: only the desktop registers the handlers that write
+any — see the resolver section below.
 
 > No `safeStorage`-only secret module is introduced. @Corvin's `codex-node-auth-secret.ts` in
 > PR #112 is `safeStorage`-ciphertext-only and throws on a headless server; the merged both-shells
@@ -160,6 +162,20 @@ Without it, Codex hook status worked while canvas control and linked-context rea
 same first-class node as being outside nodeterm. The machine-neutral shim constants copied to SSH
 hosts deliberately omit the local record path; each local installer builds its own copy with its
 own `codexThreadIdentityRoot()`.
+
+**The shim half is shared; the RECORD half is desktop-only until the Server Edition registers the
+handlers.** Both statements matter, and reading only the first overstates what that edition has.
+The prelude reaches it byte-for-byte — `context-link.ts`'s `writeCliFiles` is core, and both shells
+arm the signing secret (above) — but `src/server/handlers/index.ts` deliberately registers no
+`setCodexThreadStartHandler` / `setCodexThreadBindHandler`, and `src/main/index.ts` is the only
+non-test caller of `writeCodexThreadIdentity` / `bindCodexThreadIdentity`. **No ownership record is
+ever written on that shell**, so the resolver always finds none and takes its fallback: it exports
+nothing, and the shims stay gated exactly as they were before this prelude existed. That is
+coherent rather than merely missing — the same file answers `UNKNOWN_CODEX_IDENTITY_CAPS`
+(`shared: false`), so a Codex node there launches the bare `codex` with its own app-server, and a
+tool shell whose identity would need recovering does not exist. It becomes a real gap the day the
+Server Edition grows the shared app-server, and what closes it is those two registrations — not a
+second copy of the prelude.
 
 The resolver:
 

--- a/docs/ssh-agent-skills.md
+++ b/docs/ssh-agent-skills.md
@@ -137,10 +137,12 @@ never linked to, and cannot read *through* an edge it does not itself hold (the 
 directional). The token remains the outer boundary, exactly as for status hooks. The one value
 that reaches a remote command line — an opencode session id — is shell-quoted at that site.
 
-`docs/`-worthy consequence: `src/server` never calls `initContextLink`, so context link is absent
-on the Server Edition (it was before this change too). The route and the renderer are both in
-`src/core`, so wiring it there is now just a call plus a decision about what "remote" means when
-the server *is* the host.
+`docs/`-worthy consequence: at the time of this change `src/server` did not call
+`initContextLink`, so context link was absent on the Server Edition. **It is wired now** —
+`src/server/context-link.ts` calls `initContextLink(ptyManager, {})` and keeps the link map in step
+with the canvases on disk. It passes **no remote deps**, deliberately: that shell runs ON the host
+whose transcripts and tmux it reads, so local-only is the complete answer there and SSH projects are
+a desktop-only concept.
 
 ## Testing
 

--- a/src/core/agents/codex-thread-id-route.test.ts
+++ b/src/core/agents/codex-thread-id-route.test.ts
@@ -14,7 +14,7 @@ import { hookServer } from './hook-server'
 import { nodeAuthToken } from './node-auth-token'
 import { initPlatform, resetPlatformForTests } from '../platform'
 import { fakePlatform } from '../platform-fake'
-import { codexThreadIdentityRoot } from '../codex-identity-proxy'
+import { codexThreadIdentityRoot, type CodexThreadAgent } from '../codex-identity-proxy'
 
 const SECRET = Buffer.alloc(32, 3)
 // Another instance's secret ⇒ another instance's kid ⇒ the `legacy` failover verdict.
@@ -26,10 +26,10 @@ const NODE = 'node-thread-route'
 const UNSAFE_THREAD_IDS = ['.', '..', '../x', 'a/b', '', 'x'.repeat(129)]
 
 let dir = ''
-let bound: { nodeId: string; threadId: string }[] = []
+let bound: { nodeId: string; threadId: string; agent?: CodexThreadAgent }[] = []
 let identityEvents: { nodeId: string; mode: string; reason?: string }[] = []
 
-function bind(threadId: string): Promise<Response> {
+function bind(threadId: string, agentId?: string): Promise<Response> {
   return fetch(`http://127.0.0.1:${hookServer.getPort()}/codex-thread/bind`, {
     method: 'POST',
     headers: {
@@ -37,7 +37,9 @@ function bind(threadId: string): Promise<Response> {
       'X-Nodeterm-Node-Token': nodeAuthToken(SECRET, NODE),
       'content-type': 'application/x-www-form-urlencoded'
     },
-    body: `nodeId=${encodeURIComponent(NODE)}&threadId=${encodeURIComponent(threadId)}`
+    body:
+      `nodeId=${encodeURIComponent(NODE)}&threadId=${encodeURIComponent(threadId)}` +
+      (agentId === undefined ? '' : `&agentId=${encodeURIComponent(agentId)}`)
   })
 }
 
@@ -47,8 +49,8 @@ beforeAll(async () => {
   initPlatform(fakePlatform({ userDataDir: dir }))
   await hookServer.start()
   hookServer.setNodeAuthSecret(SECRET)
-  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId }) => {
-    bound.push({ nodeId, threadId })
+  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, agent }) => {
+    bound.push({ nodeId, threadId, agent })
   })
   hookServer.setCodexIdentityListener((e) => {
     identityEvents.push(e)
@@ -138,5 +140,45 @@ describe('/codex-thread/fallback refuses only a forged token', () => {
   it('403s OUR kid with a mac minted for another node — the one attack signal', async () => {
     expect((await fallback(nodeAuthToken(SECRET, 'some-other-node'))).status).toBe(403)
     expect(identityEvents).toEqual([])
+  })
+})
+
+// The route decides the CANVAS-CONTROL GRANT; it never accepts one.
+//
+// The agent id is echoed by the pane because the pane is the only durable holder of it — a tmux
+// session outlives the app, so a bind after a restart is the common case and nothing server-side
+// still remembers what agent a node runs. That echo is not a capability claim: reaching this route
+// takes a token this instance minted FOR THIS NODE, so the caller IS the node, and the record it
+// shapes is re-exported only into that node's own tool shells. What must not be echoed is the
+// grant, and it is not: the route runs `canControlCanvas` itself, the same predicate in the same
+// process that `buildPtyEnv` used to gate the pane, so there is exactly ONE decider.
+describe('/codex-thread/bind derives the grant from the agent id it is given', () => {
+  it('grants canvas control for codex, which is unconditionally capable', async () => {
+    expect((await bind('thread-ok', 'codex')).status).toBe(204)
+    expect(bound[0].agent).toEqual({ agentId: 'codex', canvasControl: true })
+  })
+
+  it('WITHHOLDS the grant for a custom agent that inherits nothing', async () => {
+    // The narrowing the whole change is for: a claimed id cannot manufacture a grant the capability
+    // table refuses. With no base resolver registered, `custom:abc` resolves to itself and is not in
+    // CANVAS_CONTROL_CAPABLE — so the record says so, and the prelude will export no grant.
+    expect((await bind('thread-custom', 'custom:abc')).status).toBe(204)
+    expect(bound[0].agent).toEqual({ agentId: 'custom:abc', canvasControl: false })
+  })
+
+  it('writes a PRE-AGENT record when no agent id is sent', async () => {
+    // An older launcher, or a pane whose NODETERM_AGENT_ID did not survive. `undefined` here is what
+    // makes the record carry no agent line, which reads back with the documented implied values —
+    // the behaviour that shipped before this field existed.
+    expect((await bind('thread-bare')).status).toBe(204)
+    expect(bound[0].agent).toBeUndefined()
+  })
+
+  it('treats an agent id outside the alphabet as absent, not as a reason to refuse the bind', async () => {
+    // Degrade to nothing, never to something wrong — and never to a dead node: the thread binding is
+    // what keeps the session attached to its canvas node, and losing that over a label would be a
+    // far worse failure than an unlabelled record.
+    expect((await bind('thread-bad-agent', 'bad id')).status).toBe(204)
+    expect(bound[0].agent).toBeUndefined()
   })
 })

--- a/src/core/agents/hook-server.ts
+++ b/src/core/agents/hook-server.ts
@@ -10,7 +10,7 @@ import type { CodexIdentityEvent } from '../../shared/types'
 import type { NodeTokenVerdict } from './node-auth-token'
 import { nodeTokenDir } from './node-token-files'
 import { isForeignKidToken, isSafeNodeId, verifyNodeToken } from './node-auth-token'
-import { isSafeThreadId } from '../codex-identity-proxy'
+import { isSafeCodexAgentId, isSafeThreadId, type CodexThreadAgent } from '../codex-identity-proxy'
 import { isSafeAccountId } from '../../shared/codex-account'
 import {
   controlPolicy,
@@ -285,6 +285,7 @@ class HookServer {
         cwd: string
         hookEndpoint: string
         accountId?: string
+        agent?: CodexThreadAgent
       }) => Promise<string>)
     | null = null
   private codexThreadBindHandler:
@@ -293,6 +294,7 @@ class HookServer {
         threadId: string
         hookEndpoint: string
         accountId?: string
+        agent?: CodexThreadAgent
       }) => Promise<void>)
     | null = null
   private codexIdentityListener: ((e: CodexIdentityEvent) => void) | null = null
@@ -956,6 +958,30 @@ class HookServer {
       return
     }
     const accountId = rawAccountId || undefined
+    // THE PANE'S OWN AGENT LABEL, echoed back so the ownership record can carry it.
+    //
+    // Why the client is asked at all, when `hookEndpoint` below is deliberately the server's own
+    // answer: the agent id is a fact about a tmux session that OUTLIVES this process, and the
+    // launcher POSTing here runs inside that pane with the `NODETERM_AGENT_ID` `buildPtyEnv` put
+    // there. Nothing on the server side is as durable — an in-memory map from `buildPtyEnv` is
+    // empty for every node whose pane predates this app run, which is the norm after a restart and
+    // permanent for a node in a project the user has not opened.
+    //
+    // It is not a capability claim. A caller only reaches this line by presenting a token this
+    // instance minted FOR THIS NODE (`nodeTokenVerified` above, strict), so it is the node; the
+    // record it shapes is re-exported into that same node's own tool shells and nowhere else; and
+    // the env var it sets is not what authorizes anything (see `identityGate` — the per-node token
+    // is). Lying about it buys the liar the label they already had.
+    //
+    // THE GRANT IS NOT ECHOED. It is derived here by `canControlCanvas` — the same predicate, in
+    // the same process, that `buildPtyEnv` used to gate the pane — so there is exactly ONE decider
+    // and a forged agent id cannot manufacture a grant the table would refuse. An unparseable or
+    // absent id writes a PRE-AGENT record, which reads back with the documented implied values:
+    // the behaviour that shipped before this field existed.
+    const rawAgentId = form.agentId ?? ''
+    const agent: CodexThreadAgent | undefined = isSafeCodexAgentId(rawAgentId)
+      ? { agentId: rawAgentId, canvasControl: canControlCanvas(rawAgentId) }
+      : undefined
     if (verb === 'start') {
       const cwd = form.cwd ?? ''
       if (!path.isAbsolute(cwd)) {
@@ -969,7 +995,8 @@ class HookServer {
           nodeId,
           cwd,
           hookEndpoint: this.endpointFilePath(),
-          accountId
+          accountId,
+          agent
         })
         // Same predicate the record store gates on, so a thread id the store would refuse can
         // never be handed back to a launcher that will then `resume` it.
@@ -998,7 +1025,8 @@ class HookServer {
         nodeId,
         threadId,
         hookEndpoint: this.endpointFilePath(),
-        accountId
+        accountId,
+        agent
       })
       this.codexIdentityListener?.({ nodeId, mode: 'shared' })
       res.writeHead(204)

--- a/src/core/codex-identity-proxy.test.ts
+++ b/src/core/codex-identity-proxy.test.ts
@@ -367,3 +367,189 @@ describe('account-scoped ownership', () => {
     expect(resolveCodexThreadNodeIdentity('thread-1', recordsRoot, 'acct-B')).toBe('node-2')
   })
 })
+
+// ── The agent dimension: the record names the agent, and the prelude stops guessing ───────────
+//
+// `NODETERM_AGENT_ID` and `NODETERM_CANVAS_CONTROL` used to be constants in the sh prelude
+// (`codex`, granted). Both are `buildPtyEnv`'s answers about the PANE, so the constants mislabelled
+// every custom agent inheriting the codex harness and asserted a grant the pane might not hold.
+// Now they ride the record, inside the signature.
+//
+// The invariant these tests exist for is that the three preimage generations are SELECTED by the
+// record's shape and never tried in turn: a record that names an agent must not be verifiable under
+// a preimage that ignores the agent, or the field could be stripped or rewritten at will.
+const sign6 = (
+  threadId: string,
+  scope: string,
+  nodeId: string,
+  endpoint: string,
+  agentId: string,
+  grant: boolean
+): string =>
+  b64url(
+    createHmac('sha256', FIXED_SECRET)
+      .update(`${threadId}\0${scope}\0${nodeId}\0${endpoint}\0${agentId}\0${grant ? '1' : '0'}`)
+      .digest()
+  )
+
+const recordFile = (threadId: string): string => path.join(recordsRoot, threadId)
+
+describe('agent identity in the ownership record', () => {
+  beforeEach(() => setCodexThreadIdentityAuthSecret(FIXED_SECRET))
+
+  it('round-trips the agent id and the grant', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, undefined, {
+      agentId: 'custom:abc',
+      canvasControl: false
+    })
+    const got = readCodexThreadIdentity('thread-1', recordsRoot)
+    expect(got?.agentId).toBe('custom:abc')
+    expect(got?.canvasControl).toBe(false)
+    expect(got?.agentDeclared).toBe(true)
+  })
+
+  it('reads a PRE-AGENT record as codex with the grant, and says the id was not declared', () => {
+    // The back-compat contract, and the reason it is safe: every record written before these fields
+    // existed came from this same Codex spine, and codex is unconditionally canvas-control-capable,
+    // so the implied pair reproduces exactly what the prelude used to hardcode.
+    fs.mkdirSync(recordsRoot, { recursive: true })
+    fs.writeFileSync(
+      recordFile('legacy-1'),
+      `accountId=\nnodeId=node-1\nendpoint=/data/e\nsignature=${sign4('legacy-1', 'system', 'node-1', '/data/e')}\n`
+    )
+    const got = readCodexThreadIdentity('legacy-1', recordsRoot)
+    expect(got?.nodeId).toBe('node-1')
+    expect(got?.agentId).toBe('codex')
+    expect(got?.canvasControl).toBe(true)
+    // The distinguishing bit: `codex` here is an IMPLICATION, not a claim, and callers that rewrite
+    // the record need to know the difference (see the no-downgrade test below).
+    expect(got?.agentDeclared).toBe(false)
+  })
+
+  it('refuses a record whose agent id was edited after signing', () => {
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, undefined, {
+      agentId: 'codex',
+      canvasControl: true
+    })
+    const raw = fs.readFileSync(recordFile('thread-1'), 'utf8')
+    fs.writeFileSync(recordFile('thread-1'), raw.replace('agentId=codex', 'agentId=custom:evil'))
+    expect(readCodexThreadIdentity('thread-1', recordsRoot)).toBeUndefined()
+  })
+
+  it('refuses a record whose GRANT was edited after signing', () => {
+    // The whole reason the grant is inside the signature: it is a capability the prelude exports
+    // into an agent's shell, so an unsigned copy would be a grant anyone who can write the file
+    // could add.
+    writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, undefined, {
+      agentId: 'custom:abc',
+      canvasControl: false
+    })
+    const raw = fs.readFileSync(recordFile('thread-1'), 'utf8')
+    fs.writeFileSync(recordFile('thread-1'), raw.replace('canvasControl=0', 'canvasControl=1'))
+    expect(readCodexThreadIdentity('thread-1', recordsRoot)).toBeUndefined()
+  })
+
+  it('never verifies an agent-carrying record under the pre-agent preimage', () => {
+    // THE SELECTION RULE. This record is signed with the valid 4-tuple for its node+endpoint, so a
+    // verifier that fell through generations would accept it and then read `custom:evil` — the door
+    // through which the agent id becomes forgeable. Selecting by shape closes it.
+    fs.mkdirSync(recordsRoot, { recursive: true })
+    fs.writeFileSync(
+      recordFile('thread-1'),
+      `accountId=\nnodeId=node-1\nendpoint=/data/e\nagentId=custom:evil\ncanvasControl=1\n` +
+        `signature=${sign4('thread-1', 'system', 'node-1', '/data/e')}\n`
+    )
+    expect(readCodexThreadIdentity('thread-1', recordsRoot)).toBeUndefined()
+  })
+
+  it('accepts a hand-signed 6-tuple record, so the preimage is the documented one', () => {
+    fs.mkdirSync(recordsRoot, { recursive: true })
+    fs.writeFileSync(
+      recordFile('thread-1'),
+      `accountId=\nnodeId=node-1\nendpoint=/data/e\nagentId=custom:abc\ncanvasControl=0\n` +
+        `signature=${sign6('thread-1', 'system', 'node-1', '/data/e', 'custom:abc', false)}\n`
+    )
+    expect(readCodexThreadIdentity('thread-1', recordsRoot)?.agentId).toBe('custom:abc')
+  })
+
+  it('binds the agent id under a managed account scope too', () => {
+    bindCodexThreadIdentity('thread-1', 'node-1', '/data/e', live([]), recordsRoot, 'acct-A', {
+      agentId: 'custom:abc',
+      canvasControl: true
+    })
+    expect(readCodexThreadIdentity('thread-1', recordsRoot, 'acct-A')?.agentId).toBe('custom:abc')
+    // Scope binding is unchanged: the managed record is still invisible at the system scope.
+    expect(readCodexThreadIdentity('thread-1', recordsRoot)).toBeUndefined()
+  })
+
+  it('a rebind WITHOUT an agent id keeps the one already recorded', () => {
+    // A pane whose NODETERM_AGENT_ID did not survive, or an older launcher, must not strip the line
+    // and send the prelude back to guessing `codex` — for a custom codex-based node that guess is
+    // the exact mislabel this slice removes.
+    bindCodexThreadIdentity('thread-1', 'node-1', '/data/e', live([]), recordsRoot, undefined, {
+      agentId: 'custom:abc',
+      canvasControl: false
+    })
+    bindCodexThreadIdentity('thread-1', 'node-1', '/data/e2', live([]), recordsRoot)
+    const got = readCodexThreadIdentity('thread-1', recordsRoot)
+    expect(got?.hookEndpoint).toBe('/data/e2')
+    expect(got?.agentId).toBe('custom:abc')
+    expect(got?.canvasControl).toBe(false)
+  })
+
+  it('a rebind of a PRE-AGENT record does not write the implied codex as a claim', () => {
+    // The other half of the rule. `codex` was an implication of an old record's shape; promoting it
+    // to a signed claim would make a wrong guess permanent for a custom node.
+    fs.mkdirSync(recordsRoot, { recursive: true })
+    fs.writeFileSync(
+      recordFile('legacy-1'),
+      `accountId=\nnodeId=node-1\nendpoint=/data/e\nsignature=${sign4('legacy-1', 'system', 'node-1', '/data/e')}\n`
+    )
+    bindCodexThreadIdentity('legacy-1', 'node-1', '/data/e2', live([]), recordsRoot)
+    expect(fs.readFileSync(recordFile('legacy-1'), 'utf8')).not.toContain('agentId=')
+    expect(readCodexThreadIdentity('legacy-1', recordsRoot)?.agentDeclared).toBe(false)
+  })
+
+  it('a later bind that DOES know the agent id upgrades a pre-agent record in place', () => {
+    fs.mkdirSync(recordsRoot, { recursive: true })
+    fs.writeFileSync(
+      recordFile('legacy-1'),
+      `accountId=\nnodeId=node-1\nendpoint=/data/e\nsignature=${sign4('legacy-1', 'system', 'node-1', '/data/e')}\n`
+    )
+    bindCodexThreadIdentity('legacy-1', 'node-1', '/data/e', live([]), recordsRoot, undefined, {
+      agentId: 'custom:abc',
+      canvasControl: true
+    })
+    expect(readCodexThreadIdentity('legacy-1', recordsRoot)?.agentId).toBe('custom:abc')
+  })
+
+  it('refuses an EMPTY agentId line rather than reading it as codex', () => {
+    // The fallback is keyed on the LINE BEING ABSENT, never on the value being empty. Keying it on
+    // the value would mean a record that carries an `agentId=` line can still land on the `codex`
+    // guess — the exact mislabel this slice removes, reinstated by a shape we do accept as input.
+    // This record is even signed for `codex`, so a value-keyed reader would verify it happily.
+    fs.mkdirSync(recordsRoot, { recursive: true })
+    fs.writeFileSync(
+      recordFile('thread-1'),
+      `accountId=\nnodeId=node-1\nendpoint=/data/e\nagentId=\ncanvasControl=1\n` +
+        `signature=${sign6('thread-1', 'system', 'node-1', '/data/e', 'codex', true)}\n`
+    )
+    expect(readCodexThreadIdentity('thread-1', recordsRoot)).toBeUndefined()
+  })
+
+  it('refuses to write an agent id outside the accepted alphabet', () => {
+    // Re-validated at the write as well as the read: the value ends up as an environment variable in
+    // an agent's shell, and a signature only proves we wrote the bytes, not that they are a shape we
+    // still accept.
+    for (const bad of ['', 'a b', 'a\nb', 'a/b', 'x'.repeat(129)]) {
+      expect(
+        () =>
+          writeCodexThreadIdentity('thread-1', 'node-1', '/data/e', recordsRoot, undefined, {
+            agentId: bad,
+            canvasControl: true
+          }),
+        JSON.stringify(bad)
+      ).toThrow()
+    }
+  })
+})

--- a/src/core/codex-identity-proxy.ts
+++ b/src/core/codex-identity-proxy.ts
@@ -27,6 +27,17 @@
  * rejected, so an account can never be edited to speak for another's threads. Records written
  * before this slice carry no `accountId=` line and are verified with the original 3-tuple preimage
  * at the system scope only — the one back-compat door, and it is a system-scope door.
+ *
+ * AGENT IDENTITY: a record also carries `agentId=` and `canvasControl=`, because the prelude
+ * re-exports both into a tool shell and used to HARDCODE them (`codex`, granted). Hardcoding
+ * mislabels every custom agent that inherits the codex harness (`custom:<uuid>`, not `codex`) and
+ * asserts a grant the pane may not hold — `buildPtyEnv` gates it on `canControlCanvas`, and
+ * `SHARED_IDENTITY_CAPABLE ⊆ CANVAS_CONTROL_CAPABLE` is the only reason the two agree today, a
+ * coincidence the list's own comment invites the next agent to break. The HMAC therefore binds the
+ * 6-tuple (threadId, accountScope, nodeId, hookEndpoint, agentId, canvasControl). A record with no
+ * `agentId=` line is pre-agent and is read with the implied values `codex` + granted, which is
+ * exactly what it meant when it was written; the preimages are SELECTED by shape, never tried in
+ * turn, so a record that names an agent can never be verified by one that ignores it.
  */
 import {
   chmodSync,
@@ -112,6 +123,45 @@ export function isSafeThreadId(id: string): boolean {
   )
 }
 
+/**
+ * The agent identity a record may carry, and the canvas-control grant that goes with it.
+ *
+ * WHY THE RECORD CARRIES THIS AT ALL: the sh prelude re-exports a tool shell's `NODETERM_*`, and it
+ * used to HARDCODE `NODETERM_AGENT_ID=codex` and `NODETERM_CANVAS_CONTROL=1`. Both are facts about
+ * the PANE that only `hookServer.buildPtyEnv` knows — it sets `NODETERM_AGENT_ID` to the node's own
+ * agent id (which is `custom:<uuid>` for a custom agent declaring `baseAgent: 'codex'`, not
+ * `codex`) and gates the grant on `canControlCanvas`. A constant in the prelude is the prelude
+ * asserting what it cannot know: it mislabels every custom codex-based agent, and it hands out a
+ * grant the pane may not hold. Recording them is what lets the prelude EXPORT WHAT THE RECORD SAYS.
+ *
+ * The grant is not merely derived from the agent id here because the prelude is POSIX sh and cannot
+ * evaluate `canControlCanvas` — the membership list plus the custom-agent base resolver live in
+ * TypeScript. So the decision is made once, on the desktop, by the same predicate `buildPtyEnv`
+ * uses, and travels as a boolean.
+ *
+ * BOTH FIELDS ARE INSIDE THE SIGNATURE. They name a capability the prelude then exports into an
+ * agent's environment, which is exactly the class of field `identitySignature` exists to protect —
+ * an unsigned `canvasControl=1` line would be a grant anyone who can write the file could add.
+ */
+export interface CodexThreadAgent {
+  /** The node's own agent id — `codex`, or a `custom:<uuid>` inheriting it. */
+  agentId: string
+  /** Whether `canControlCanvas` granted this node canvas control at spawn. */
+  canvasControl: boolean
+}
+
+/**
+ * Agent ids are `codex` or `custom:<uuid>`, so the alphabet needs `:` on top of the node-id one.
+ * Bounded and re-validated for the same reason every other recovered field is: the value becomes an
+ * environment variable in an agent's shell, and the file it comes from is data we parse, not code.
+ */
+const AGENT_ID_CHARSET = /^[A-Za-z0-9._:-]+$/
+const MAX_AGENT_ID = 128
+
+export function isSafeCodexAgentId(id: string): boolean {
+  return typeof id === 'string' && id.length > 0 && id.length <= MAX_AGENT_ID && AGENT_ID_CHARSET.test(id)
+}
+
 let identityAuthSecret: Buffer | null = null
 
 /** Injected by the shell once, from the same keychain-backed secret the hook server signs with. */
@@ -139,11 +189,35 @@ export function codexThreadIdentityRoot(): string {
 }
 
 /**
- * The current 4-tuple preimage: HMAC-SHA256(threadId ␀ accountScope ␀ nodeId ␀ hookEndpoint). The
- * account scope binds the record to ONE account; without it a record for account A could be moved,
- * byte-for-byte, into account B's directory and still verify.
+ * The current 6-tuple preimage:
+ * HMAC-SHA256(threadId ␀ accountScope ␀ nodeId ␀ hookEndpoint ␀ agentId ␀ canvasControl).
+ *
+ * The account scope binds the record to ONE account; without it a record for account A could be
+ * moved, byte-for-byte, into account B's directory and still verify. The agent id and the grant
+ * joined the preimage for the same reason they joined the record: the prelude exports both, so an
+ * unsigned copy of either would be a capability anyone able to write the file could edit.
  */
 function identitySignature(
+  threadId: string,
+  scope: string,
+  nodeId: string,
+  hookEndpoint: string,
+  agent: CodexThreadAgent
+): string {
+  if (!identityAuthSecret) throw new Error('NodeTerm Codex identity authentication is unavailable')
+  return createHmac('sha256', identityAuthSecret)
+    .update(
+      `${threadId}\0${scope}\0${nodeId}\0${hookEndpoint}\0${agent.agentId}\0${agent.canvasControl ? '1' : '0'}`
+    )
+    .digest('base64url')
+}
+
+/**
+ * The pre-agent 4-tuple preimage (no agent dimension). Accepted ONLY for a record that carries no
+ * `agentId=` line — one written before this slice. See `recordSignatureValid` for why the two
+ * preimages are mutually exclusive rather than tried in turn.
+ */
+function accountScopedIdentitySignature(
   threadId: string,
   scope: string,
   nodeId: string,
@@ -187,6 +261,18 @@ function signatureEquals(presented: string, expected: string): boolean {
  * scope, so a scope-less signature can never be honoured under a managed account. (The mutations
  * that redden these tests are the HMAC one and the `scope === SYSTEM_ACCOUNT_SCOPE` fallback guard;
  * check (1) is redundant with the scope-bound HMAC and is documented as such.)
+ *
+ * THREE PREIMAGE GENERATIONS, SELECTED — NOT TRIED IN TURN. Which one applies is decided by which
+ * LINES the record carries, and exactly one branch runs:
+ *   - an `agentId=` line ⇒ the current 6-tuple, and ONLY that;
+ *   - no agent line but an `accountId=` line ⇒ the 4-tuple (an S6-era record);
+ *   - neither, at the system scope ⇒ the 3-tuple (a pre-S6 record).
+ * Selecting rather than falling through is the load-bearing part. A record that DOES name an agent
+ * must never verify under a preimage that ignores the agent: that is the door through which an
+ * `agentId=custom:…` line could be stripped or rewritten and the record still accepted, putting the
+ * prelude back to guessing `codex` — the precise defect this generation exists to close. A caller
+ * that wants the old behaviour must present an old-SHAPED record, and an old-shaped record gets the
+ * documented implied values (see `parseCodexThreadIdentity`), never a mix of the two.
  */
 function recordSignatureValid(threadId: string, dirScope: string, record: ParsedRecord): boolean {
   if (!record.signature || !identityAuthSecret) return false
@@ -195,32 +281,46 @@ function recordSignatureValid(threadId: string, dirScope: string, record: Parsed
     const lineScope = record.accountId || SYSTEM_ACCOUNT_SCOPE
     if (lineScope !== scope) return false
   }
-  let expected = ''
   try {
-    expected = identitySignature(threadId, scope, record.nodeId, record.hookEndpoint)
-  } catch {
-    return false
-  }
-  if (signatureEquals(record.signature, expected)) return true
-  if (!record.accountLinePresent && scope === SYSTEM_ACCOUNT_SCOPE) {
-    try {
+    if (record.agentDeclared) {
       return signatureEquals(
+        record.signature,
+        identitySignature(threadId, scope, record.nodeId, record.hookEndpoint, {
+          agentId: record.agentId,
+          canvasControl: record.canvasControl
+        })
+      )
+    }
+    if (record.accountLinePresent) {
+      return signatureEquals(
+        record.signature,
+        accountScopedIdentitySignature(threadId, scope, record.nodeId, record.hookEndpoint)
+      )
+    }
+    return (
+      scope === SYSTEM_ACCOUNT_SCOPE &&
+      signatureEquals(
         record.signature,
         legacyIdentitySignature(threadId, record.nodeId, record.hookEndpoint)
       )
-    } catch {
-      return false
-    }
+    )
+  } catch {
+    return false
   }
-  return false
 }
 
-export interface CodexThreadIdentity {
+export interface CodexThreadIdentity extends CodexThreadAgent {
   /** '' for the system account; a managed account id otherwise. */
   accountId: string
   nodeId: string
   hookEndpoint: string
   signature: string
+  /**
+   * Whether the record NAMED its agent, as opposed to implying `codex` by being pre-agent. Callers
+   * that rewrite a record need the difference: re-writing an implication as a signed claim is how a
+   * custom codex-based node's guess would become permanent (see `bindCodexThreadIdentity`).
+   */
+  agentDeclared: boolean
 }
 
 interface ParsedRecord extends CodexThreadIdentity {
@@ -253,11 +353,24 @@ function parseCodexThreadIdentity(raw: string): ParsedRecord {
     // line cannot be smuggled in to disagree with the first.
     if (!(key in values)) values[key] = line.slice(separator + 1)
   }
+  // THE IMPLIED VALUES OF A PRE-AGENT RECORD, and why they are safe. Every record written before
+  // this slice was written by this same Codex identity spine, so its node ran the codex CLI —
+  // `codex` is the right agent id for it, and `codex` is unconditionally in
+  // `CANVAS_CONTROL_CAPABLE`, so its implied grant reproduces today's behaviour exactly. This is
+  // therefore a faithful reading of an old record, not a guess about a new one.
+  //
+  // The fallback is keyed on the LINE BEING ABSENT (`'agentId' in values`), never on the value
+  // being empty or unparseable. A record that names an agent is read as naming that agent; there is
+  // no input that carries an agent id and still lands on `codex`.
+  const agentLinePresent = 'agentId' in values
   return {
     accountId: values.accountId ?? '',
     nodeId: values.nodeId ?? '',
     hookEndpoint: values.endpoint ?? '',
     signature: values.signature ?? '',
+    agentId: agentLinePresent ? (values.agentId ?? '') : 'codex',
+    canvasControl: agentLinePresent ? values.canvasControl === '1' : true,
+    agentDeclared: agentLinePresent,
     accountLinePresent: 'accountId' in values
   }
 }
@@ -283,12 +396,19 @@ export function readIdentityCandidate(
   }
   const record = parseCodexThreadIdentity(raw)
   if (!validCodexIdentity(record.nodeId, record.hookEndpoint)) return undefined
+  // An agent id that reached the record is re-validated before the signature check, exactly as the
+  // node id and endpoint are: the value becomes an environment variable in an agent's shell, and a
+  // valid signature only proves WE wrote the bytes, not that they are still a shape we accept.
+  if (record.agentDeclared && !isSafeCodexAgentId(record.agentId)) return undefined
   if (!recordSignatureValid(threadId, norm, record)) return undefined
   return {
     accountId: record.accountId,
     nodeId: record.nodeId,
     hookEndpoint: record.hookEndpoint,
-    signature: record.signature
+    signature: record.signature,
+    agentId: record.agentId,
+    canvasControl: record.canvasControl,
+    agentDeclared: record.agentDeclared
   }
 }
 
@@ -375,19 +495,36 @@ export function codexThreadIdentityHasLiveConflict(
   return liveOwners.size > 1
 }
 
-/** Write (or replace) the record for `threadId` under its account scope, atomically. */
+/**
+ * Write (or replace) the record for `threadId` under its account scope, atomically.
+ *
+ * `agent` is what the prelude will export as this thread's `NODETERM_AGENT_ID` /
+ * `NODETERM_CANVAS_CONTROL`. Omitting it writes a PRE-AGENT record — the old shape, read back with
+ * the documented implied values (`codex`, grant on). That is the honest degrade for a caller that
+ * genuinely does not know the node's agent id, and it reproduces the behaviour this slice replaced;
+ * it is not a default to reach for when the id IS available.
+ */
 export function writeCodexThreadIdentity(
   threadId: string,
   nodeId: string,
   hookEndpoint: string,
   root = codexThreadIdentityRoot(),
-  accountId?: string
+  accountId?: string,
+  agent?: CodexThreadAgent
 ): void {
   if (!isSafeThreadId(threadId) || !validCodexIdentity(nodeId, hookEndpoint)) {
     throw new Error('Invalid NodeTerm Codex thread identity')
   }
+  if (agent && !isSafeCodexAgentId(agent.agentId)) {
+    throw new Error('Invalid NodeTerm Codex thread identity')
+  }
   const scope = accountScope(accountId) // throws on an id that could escape the mapping directory
-  const signature = identitySignature(threadId, scope, nodeId, hookEndpoint)
+  const signature = agent
+    ? identitySignature(threadId, scope, nodeId, hookEndpoint, agent)
+    : accountScopedIdentitySignature(threadId, scope, nodeId, hookEndpoint)
+  const agentLines = agent
+    ? `agentId=${agent.agentId}\ncanvasControl=${agent.canvasControl ? '1' : '0'}\n`
+    : ''
   const file = identityFile(threadId, scope, root)
   const dir = path.dirname(file)
   const tmp = path.join(dir, `.${threadId}.${process.pid}.${Date.now()}`)
@@ -396,7 +533,7 @@ export function writeCodexThreadIdentity(
   try {
     writeFileSync(
       tmp,
-      `accountId=${accountId ?? ''}\nnodeId=${nodeId}\nendpoint=${hookEndpoint}\nsignature=${signature}\n`,
+      `accountId=${accountId ?? ''}\nnodeId=${nodeId}\nendpoint=${hookEndpoint}\n${agentLines}signature=${signature}\n`,
       {
         encoding: 'utf8',
         mode: 0o600
@@ -427,7 +564,8 @@ export function bindCodexThreadIdentity(
   hookEndpoint: string,
   isNodeLive: (nodeId: string) => boolean,
   root = codexThreadIdentityRoot(),
-  accountId?: string
+  accountId?: string,
+  agent?: CodexThreadAgent
 ): void {
   if (!isSafeThreadId(threadId) || !validCodexIdentity(nodeId, hookEndpoint)) {
     throw new Error('Invalid NodeTerm Codex thread identity')
@@ -437,8 +575,31 @@ export function bindCodexThreadIdentity(
   if (existing && existing.nodeId !== nodeId && isNodeLive(existing.nodeId)) {
     throw new Error('Codex thread is already bound to another live node')
   }
-  if (existing && existing.nodeId === nodeId && existing.hookEndpoint === hookEndpoint) return
-  writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, root, accountId)
+  // NEVER DOWNGRADE A RECORD THAT ALREADY NAMES ITS AGENT. A rebind arriving without an agent id
+  // (an older client, or a pane whose NODETERM_AGENT_ID did not survive) must not strip the line
+  // and send the prelude back to guessing `codex` — the same rule `recordSignatureValid` enforces
+  // at the signature, applied at the write. What we already know is kept; only what we are told
+  // replaces it. `agentDeclared` and not a truthy `agentId` is the test, because a PRE-AGENT record
+  // reads back as `codex` by implication and re-writing that implication as a signed claim is
+  // exactly the mislabel — for a custom codex-based node it would make the guess permanent.
+  const carried =
+    agent ??
+    (existing?.agentDeclared
+      ? { agentId: existing.agentId, canvasControl: existing.canvasControl }
+      : undefined)
+  // A rebind that would change nothing writes nothing. The agent identity is part of "nothing" now,
+  // so a caller that learns the id later still upgrades a pre-agent record in place.
+  if (
+    existing &&
+    existing.nodeId === nodeId &&
+    existing.hookEndpoint === hookEndpoint &&
+    existing.agentDeclared === !!carried &&
+    (!carried ||
+      (existing.agentId === carried.agentId && existing.canvasControl === carried.canvasControl))
+  ) {
+    return
+  }
+  writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, root, accountId, carried)
 }
 
 /**
@@ -664,6 +825,7 @@ if [ "\${1-}" = resume ]; then
   # live node owns it; two clients on one thread is worse than one plain session, so we fall back.
   if nt_post 20 --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "threadId=\${2-}" \\
       --data-urlencode "accountId=\${NODETERM_CODEX_ACCOUNT_ID-}" \\
+      --data-urlencode "agentId=\${NODETERM_AGENT_ID-}" \\
       "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/bind" >/dev/null; then
     exec codex --remote unix:// "$@"
   fi
@@ -671,8 +833,14 @@ if [ "\${1-}" = resume ]; then
   exec codex "$@"
 fi
 
+# THIS PANE'S OWN LABEL travels with both calls, and the pane is the only durable holder of it:
+# tmux sessions outlive the app, so a bind arriving after a restart is the common case and nothing
+# server-side still remembers what agent this node runs. The server re-derives the canvas-control
+# grant from it rather than trusting a claim (see handleCodexThread); an absent or unparseable
+# value writes a pre-agent record and the prelude falls back to codex, i.e. the old behaviour.
 nt_thread=$(nt_post ${CODEX_THREAD_START_CLIENT_MAX_S} --data-urlencode "nodeId=$NODETERM_NODE_ID" --data-urlencode "cwd=$PWD" \\
   --data-urlencode "accountId=\${NODETERM_CODEX_ACCOUNT_ID-}" \\
+  --data-urlencode "agentId=\${NODETERM_AGENT_ID-}" \\
   "http://localhost:\${NODETERM_HOOK_PORT-0}/codex-thread/start") || nt_thread=''
 nt_thread=$(printf %s "$nt_thread" | tr -d '\\r\\n')
 case "$nt_thread" in

--- a/src/core/codex-launcher-sh.test.ts
+++ b/src/core/codex-launcher-sh.test.ts
@@ -36,8 +36,8 @@ let dir = ''
 let launcher = ''
 let binDir = ''
 let argvLog = ''
-let started: Array<{ nodeId: string; cwd: string; accountId?: string }> = []
-let bound: Array<{ nodeId: string; threadId: string; accountId?: string }> = []
+let started: Array<{ nodeId: string; cwd: string; accountId?: string; agentId?: string }> = []
+let bound: Array<{ nodeId: string; threadId: string; accountId?: string; agentId?: string }> = []
 let fallbacks: Array<{ nodeId: string; reason?: string }> = []
 let startAnswer: (() => string) | null = null
 let startDelayMs = 0
@@ -65,14 +65,14 @@ beforeAll(async () => {
   fs.writeFileSync(launcher, buildCodexLauncherScript('true'), { mode: 0o755 })
   await hookServer.start()
   hookServer.setNodeAuthSecret(SECRET)
-  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd, accountId }) => {
-    started.push({ nodeId, cwd, accountId })
+  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd, accountId, agent }) => {
+    started.push({ nodeId, cwd, accountId, agentId: agent?.agentId })
     if (startDelayMs) await new Promise((r) => setTimeout(r, startDelayMs))
     if (!startAnswer) throw new Error('start refused')
     return startAnswer()
   })
-  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, accountId }) => {
-    bound.push({ nodeId, threadId, accountId })
+  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, accountId, agent }) => {
+    bound.push({ nodeId, threadId, accountId, agentId: agent?.agentId })
     if (!bindAnswer) throw new Error('bind refused')
     bindAnswer()
   })
@@ -555,5 +555,38 @@ describe('per-node capability (the authorization the shared bearer cannot give)'
     expect(bound).toEqual([])
     expect(codexArgv()).toEqual(['resume thread-xyz'])
     expect(fallbacks).toEqual([{ nodeId: 'node-1', reason: 'thread-bind-refused' }])
+  })
+})
+
+// THIS PANE'S AGENT LABEL travels in the POST body on both calls.
+//
+// The pane is the only durable holder of it: a tmux session outlives the app, so a bind arriving
+// after a restart is the common case and nothing server-side still remembers what agent a node
+// runs. The server re-derives the canvas-control grant from the id rather than trusting a claim
+// (see codex-thread-id-route.test.ts), so what travels here is a label, not a capability — and
+// like the account id it must stay in the BODY, never on argv, where a shared host's `ps` reads it.
+describe('the pane agent id reaches the record', () => {
+  it('threads NODETERM_AGENT_ID through start', async () => {
+    await callLauncher([], { NODETERM_AGENT_ID: 'custom:abc' })
+    expect(started).toEqual([
+      { nodeId: 'node-1', cwd: fs.realpathSync(dir), agentId: 'custom:abc' }
+    ])
+    expect(codexArgv().join(' ')).not.toContain('custom:abc')
+  })
+
+  it('threads it through a resume bind too', async () => {
+    await callLauncher(['resume', 'thread-xyz'], { NODETERM_AGENT_ID: 'custom:abc' })
+    expect(bound).toEqual([
+      { nodeId: 'node-1', threadId: 'thread-xyz', agentId: 'custom:abc' }
+    ])
+    expect(codexArgv().join(' ')).not.toContain('custom:abc')
+  })
+
+  it('starts a thread with no label when the pane carries none, rather than failing', async () => {
+    // `${NODETERM_AGENT_ID-}` under `set -u` and an unset var: the launch must still work. A node
+    // whose label is missing gets a pre-agent record, which is the pre-feature behaviour.
+    await callLauncher([], { NODETERM_AGENT_ID: '' })
+    expect(started).toEqual([{ nodeId: 'node-1', cwd: fs.realpathSync(dir) }])
+    expect(fallbacks).toEqual([])
   })
 })

--- a/src/core/codex-thread-identity-sh.test.ts
+++ b/src/core/codex-thread-identity-sh.test.ts
@@ -177,3 +177,86 @@ describe('codex thread identity prelude — account scoping', () => {
     ).toBe('||')
   })
 })
+
+// ── The prelude EXPORTS WHAT THE RECORD SAYS ─────────────────────────────────────────────────
+//
+// `NODETERM_AGENT_ID=codex` and `NODETERM_CANVAS_CONTROL=1` used to be constants here. Both are
+// `buildPtyEnv`'s answers about the pane — it labels a node with its OWN agent id (`custom:<uuid>`
+// for a custom agent inheriting the codex harness) and gates the grant on `canControlCanvas` — so
+// the constants mislabelled every such node and asserted a grant the pane might not hold.
+//
+// A SECOND script, deliberately, rather than widening the printf above: every expectation in this
+// file is a pin on behaviour that must not change for a pre-agent record, and rewriting them all to
+// carry a new field would destroy that evidence.
+let agentScript = ''
+
+beforeAll(() => {
+  agentScript = path.join(dir, 'prelude-agent.sh')
+  fs.writeFileSync(
+    agentScript,
+    `#!/bin/sh\n${codexThreadIdentityResolverSh(root)}\n` +
+      `printf '%s|%s|%s\\n' "\${NODETERM_NODE_ID-}" "\${NODETERM_AGENT_ID-}" "\${NODETERM_CANVAS_CONTROL-}"\n`,
+    { mode: 0o755 }
+  )
+})
+
+/** node|agentId|canvasControl, so the exported label and grant can both be asserted. */
+async function resolveAgent(env: Record<string, string>): Promise<string> {
+  const { stdout } = await run('/bin/sh', [agentScript], {
+    env: { PATH: process.env.PATH ?? '', HOME: dir, ...env }
+  })
+  return stdout.trim()
+}
+
+/** A record body that NAMES its agent and grant, as every record written now does. */
+function agentBody(nodeId: string, agentId: string, grant: boolean): string {
+  return (
+    `accountId=\nnodeId=${nodeId}\nendpoint=${dir}/hook-endpoint.env\n` +
+    `agentId=${agentId}\ncanvasControl=${grant ? '1' : '0'}\nsignature=x\n`
+  )
+}
+
+describe('codex thread identity prelude — the exported agent label and grant', () => {
+  it('exports the recorded agent id, not the constant codex', async () => {
+    record('thr-a', agentBody('node-7', 'custom:abc', true))
+    expect(await resolveAgent({ CODEX_THREAD_ID: 'thr-a' })).toBe('node-7|custom:abc|1')
+  })
+
+  it('leaves the grant UNSET when the record withholds it', async () => {
+    // Absent, never '0' — both shims gate on `[ -z "$NODETERM_CANVAS_CONTROL" ]`, and this is the
+    // shape `buildPtyEnv` produces for an agent `canControlCanvas` refuses.
+    record('thr-b', agentBody('node-7', 'custom:abc', false))
+    expect(await resolveAgent({ CODEX_THREAD_ID: 'thr-b' })).toBe('node-7|custom:abc|')
+  })
+
+  it('falls back to codex WITH the grant for a pre-agent record', async () => {
+    // The back-compat contract, exercised end to end: a record written before these fields existed
+    // came from this same Codex spine, and codex is unconditionally canvas-control-capable.
+    record('thr-c', body('node-7'))
+    expect(await resolveAgent({ CODEX_THREAD_ID: 'thr-c' })).toBe('node-7|codex|1')
+  })
+
+  it('resolves NOTHING when the recorded agent id is outside the alphabet', async () => {
+    // Re-validated here because this prelude cannot check the signature (no key in an agent's
+    // shell), and the value becomes an environment variable. A bad shape resolves nothing at all
+    // rather than falling back to codex — the record is not one we wrote, so none of it is trusted.
+    record('thr-d', agentBody('node-7', 'bad id', true))
+    expect(await resolveAgent({ CODEX_THREAD_ID: 'thr-d' })).toBe('||')
+  })
+
+  it('carries the agent label through a managed account scope', async () => {
+    scopedRecord(
+      'acct-A',
+      'thr-e',
+      `accountId=acct-A\nnodeId=node-A\nendpoint=${dir}/hook-endpoint.env\n` +
+        `agentId=custom:abc\ncanvasControl=0\nsignature=x\n`
+    )
+    expect(
+      await resolveAgent({ CODEX_THREAD_ID: 'thr-e', NODETERM_CODEX_ACCOUNT_ID: 'acct-A' })
+    ).toBe('node-A|custom:abc|')
+  })
+
+  it('is valid POSIX sh', async () => {
+    await expect(run('/bin/sh', ['-n', agentScript])).resolves.toBeTruthy()
+  })
+})

--- a/src/core/codex-thread-identity-sh.ts
+++ b/src/core/codex-thread-identity-sh.ts
@@ -23,6 +23,18 @@
  *     change nothing (Property 3 / Constraint 8, the same fail-closed posture as the TypeScript
  *     `resolveCodexThreadNodeIdentity`).
  *
+ * WHAT IT EXPORTS IS WHAT THE RECORD SAYS — it does not decide. `NODETERM_AGENT_ID` and
+ * `NODETERM_CANVAS_CONTROL` used to be constants here (`codex`, granted), and both are facts only
+ * `hookServer.buildPtyEnv` knows: it labels the node with its OWN agent id, which for a custom
+ * agent inheriting the codex harness is `custom:<uuid>`, and it gates the grant on
+ * `canControlCanvas`. Asserting them here mislabelled every such node, and asserted a grant that
+ * agrees with the pane today only because `SHARED_IDENTITY_CAPABLE ⊆ CANVAS_CONTROL_CAPABLE` — a
+ * coincidence that list's own comment invites the next shared-identity agent to break. So the pair
+ * is recorded at bind time and read back here. A PRE-AGENT record (written before those fields
+ * existed) carries neither and means `codex` with the grant, which is precisely what it meant when
+ * it was written; a record that names an agent is exported as it stands, grant included, and never
+ * falls back to the guess.
+ *
  * Inert for every other agent: without `CODEX_THREAD_ID` the whole block is skipped. A machine with
  * no managed accounts has no subdirs, so the scan reduces to the one bare-root read S4 did — the
  * legacy layout keeps resolving byte-for-byte (Constraint 12).
@@ -56,8 +68,11 @@ if [ -z "\${NODETERM_NODE_ID-}" ] && [ -n "\${CODEX_THREAD_ID-}" ]; then
       nt_codex_matches=0
       nt_codex_node=''
       nt_codex_endpoint=''
+      nt_codex_agent=''
+      nt_codex_grant=''
       # Validate one candidate record file for an expected scope, parsed as DATA. On success it
-      # records the node/endpoint and counts the match. $1=file, $2=expected scope ('' = system).
+      # records the node/endpoint/agent/grant and counts the match. $1=file, $2=expected scope
+      # ('' = system).
       nt_codex_try() {
         [ -r "$1" ] || return 0
         nt_a=$(sed -n 's/^accountId=//p' "$1" | head -n 1)
@@ -69,11 +84,36 @@ if [ -z "\${NODETERM_NODE_ID-}" ] && [ -n "\${CODEX_THREAD_ID-}" ]; then
         esac
         nt_n=$(sed -n 's/^nodeId=//p' "$1" | head -n 1)
         nt_e=$(sed -n 's/^endpoint=//p' "$1" | head -n 1)
+        nt_g=$(sed -n 's/^agentId=//p' "$1" | head -n 1)
+        nt_c=$(sed -n 's/^canvasControl=//p' "$1" | head -n 1)
         case "$nt_n" in ''|*[!A-Za-z0-9._-]*) return 0 ;; esac
         case "$nt_e" in /*) ;; *) return 0 ;; esac
+        # SPACES ARE ADMITTED DELIBERATELY, and this line is the reason to say so. The endpoint is
+        # this app's own data-dir path, which on macOS is "~/Library/Application Support/…" — a
+        # filter without the space would reject every macOS record and silently disable the whole
+        # recovery there. What the value is used FOR is what makes that safe: both shims DOT-SOURCE
+        # it with the dot command (canvas-control-core.ts / context-link-core.ts) and the
+        # socket it names then reaches curl --unix-socket "$NODETERM_HOOK_SOCK" — every expansion
+        # inside double quotes, so a space cannot split into extra arguments. The charset is what
+        # keeps quoting and command substitution out; the leading slash above keeps it absolute.
         [ "$(printf %s "$nt_e" | tr -cd 'A-Za-z0-9._/ -')" = "$nt_e" ] || return 0
+        # A PRE-AGENT record (no agentId line, or an empty one) means codex with canvas control:
+        # every record written before the agent fields existed was written by this same Codex
+        # spine, and codex is unconditionally canvas-control-capable, so the implied pair
+        # reproduces what this prelude hardcoded. A record that DOES name an agent is exported as
+        # it stands and never falls back to the guess — including its grant, which is then the
+        # canControlCanvas answer the pane itself got, not an assumption made here.
+        case "$nt_g" in
+          '')
+            nt_g=codex
+            nt_c=1
+            ;;
+          *[!A-Za-z0-9._:-]*) return 0 ;;
+        esac
         nt_codex_node=$nt_n
         nt_codex_endpoint=$nt_e
+        nt_codex_agent=$nt_g
+        nt_codex_grant=$nt_c
         nt_codex_matches=$((nt_codex_matches + 1))
       }
       case "\${NODETERM_CODEX_ACCOUNT_ID-}" in
@@ -102,9 +142,17 @@ if [ -z "\${NODETERM_NODE_ID-}" ] && [ -n "\${CODEX_THREAD_ID-}" ]; then
       then
         NODETERM_NODE_ID="$nt_codex_node"
         NODETERM_HOOK_ENDPOINT="$nt_codex_endpoint"
-        NODETERM_AGENT_ID=codex
-        NODETERM_CANVAS_CONTROL=1
-        export NODETERM_NODE_ID NODETERM_HOOK_ENDPOINT NODETERM_AGENT_ID NODETERM_CANVAS_CONTROL
+        NODETERM_AGENT_ID="$nt_codex_agent"
+        export NODETERM_NODE_ID NODETERM_HOOK_ENDPOINT NODETERM_AGENT_ID
+        # The grant is EXPORTED ONLY WHEN THE RECORD CARRIES IT, and is left UNSET otherwise —
+        # absent, never '0', the same shape buildPtyEnv produces, because both shims gate on
+        # \`[ -z "$NODETERM_CANVAS_CONTROL" ]\`. Withholding is the honest degrade: the tool shell
+        # loses a verb its pane still has, whereas asserting a grant the pane was denied is the
+        # widening this file must never do.
+        if [ "$nt_codex_grant" = 1 ]; then
+          NODETERM_CANVAS_CONTROL=1
+          export NODETERM_CANVAS_CONTROL
+        fi
       fi
       ;;
   esac

--- a/src/core/context-link-core.ts
+++ b/src/core/context-link-core.ts
@@ -7,6 +7,7 @@ import { HOOK_CURL_HEADERS_SH } from './agents/hook-curl-config-sh'
 import { CODEX_SANDBOX_BLOCKED_LINE, CODEX_SANDBOX_HINT_SH } from './agents/hook-sandbox-hint-sh'
 import { HOOK_ENDPOINT_FALLBACK_SH, STALE_ENDPOINT_HINT } from './agents/hook-endpoint-failover-sh'
 import { NODE_TOKEN_READ_SH } from './agents/node-token-sh'
+import { codexThreadIdentityResolverSh } from './codex-thread-identity-sh'
 
 /** The shim's generic transport-failure sentence — exported so the agent-facing docs below can
  *  quote it verbatim and the parity test holds the two ends together. */
@@ -171,8 +172,7 @@ export function buildLinkDoc(
 // desktop (context-link-render.ts) behind the hook server's /context-link/ route, and this shim is
 // the thin client that reaches it — over the reverse tunnel's unix socket for a remote node, over
 // loopback for a local one. Same script either way; sh + curl only.
-export const CONTEXT_SHIM_SCRIPT = `#!/bin/sh
-# nodeterm context-link CLI (auto-generated — do not edit).
+const CONTEXT_SHIM_BODY = `# nodeterm context-link CLI (auto-generated — do not edit).
 
 if [ -z "$NODETERM_NODE_ID" ]; then
   echo "Not a nodeterm session (NODETERM_NODE_ID unset) — nothing to read."
@@ -303,6 +303,21 @@ if [ -z "$nt_code" ] || [ "$nt_code" = "000" ]; then
 fi
 exit 1
 `
+
+/**
+ * Build the local context-link shim with the same shared-Codex identity recovery used by managed
+ * hooks and canvas control. The resolver has to precede the NODETERM_NODE_ID early return or a
+ * legitimate app-server tool shell is misdiagnosed as being outside nodeterm.
+ *
+ * Omit `identityRoot` for the machine-neutral script copied to SSH hosts.
+ */
+export function buildContextShimScript(identityRoot?: string): string {
+  const identityPrelude = identityRoot ? `${codexThreadIdentityResolverSh(identityRoot)}\n` : ''
+  return `#!/bin/sh\n${identityPrelude}${CONTEXT_SHIM_BODY}`
+}
+
+/** Machine-neutral variant used by SSH installation and legacy tests. */
+export const CONTEXT_SHIM_SCRIPT = buildContextShimScript()
 
 /** The get-linked-context SKILL.md body, pointing at the shim at `shimPath`. Parameterized
  *  because the same skill is installed twice with different paths: into the desktop's config

--- a/src/core/context-link.ts
+++ b/src/core/context-link.ts
@@ -5,7 +5,9 @@
 // document per node (linked nodes' titles, transcript paths learned from hooks, cwds, tmux
 // session names) and answers reads over the hook server's /context-link/ route. A POSIX-sh shim
 // (context.sh) is the client; a globally-installed Claude skill (plus instruction blocks for the
-// agents that have no skill system) tells the agent how + when to call it.
+// agents that have no skill system) tells the agent how + when to call it. The local shim is built
+// with the shared-Codex thread resolver before its node-id gate; the SSH installer keeps the
+// machine-neutral body because this machine's ownership-record path is meaningless on the host.
 //
 // The reading and parsing happen HERE, on the desktop, not in the CLI. That is what lets an SSH
 // project's remote agent use the feature at all: its transcripts live on the host, reachable over
@@ -21,7 +23,7 @@ import type { ContextLinkMap } from '../shared/types'
 import { type PtyManager } from './pty-manager'
 import { TMUX_SOCKET } from './tmux-naming'
 import {
-  CONTEXT_SHIM_SCRIPT,
+  buildContextShimScript,
   buildContextLinkSkillBody,
   buildLinkDoc,
   buildLinkedContextInstructions,
@@ -31,6 +33,7 @@ import {
   type LinkDoc,
   type LinkDocEntry
 } from './context-link-core'
+import { codexThreadIdentityRoot } from './codex-identity-proxy'
 import {
   CONTEXT_LINK_VERBS,
   renderContextLink,
@@ -58,7 +61,7 @@ function skillPath(): string {
 function writeCliFiles(): void {
   const d = contextLinkDir()
   fs.mkdirSync(d, { recursive: true })
-  fs.writeFileSync(cliShimPath(), CONTEXT_SHIM_SCRIPT)
+  fs.writeFileSync(cliShimPath(), buildContextShimScript(codexThreadIdentityRoot()))
   try {
     fs.chmodSync(cliShimPath(), 0o755)
   } catch {

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -11,6 +11,7 @@ import { RETRYABLE } from '../core/agents/agent-message-decide'
 import { FANOUT_PER_TURN, PAIR_MIN_INTERVAL_MS } from '../core/agents/agent-message-flow'
 import { BROWSER_RETRYABLE, BROWSER_OUTCOME_LABEL } from '../core/browser-outcomes'
 import { BROWSER_KEYS, BROWSER_TIMEOUT_DEFAULT_MS, BROWSER_TIMEOUT_MAX_MS } from '../core/browser-verb'
+import { codexThreadIdentityResolverSh } from '../core/codex-thread-identity-sh'
 
 /**
  * The messaging verbs' retry guidance, RENDERED from `RETRYABLE` — the table is the source, and
@@ -441,8 +442,7 @@ export const helpVerbList = (): string => VERBS.join(' ')
  *  a copy of the list it is checking. Not for production use — read `VERBS` directly. */
 export const VERBS_FOR_TEST: readonly ControlVerb[] = VERBS
 
-export const CONTROL_SHIM_SCRIPT = `#!/bin/sh
-# nodeterm canvas-control CLI (auto-generated — do not edit).
+const CONTROL_SHIM_BODY = `# nodeterm canvas-control CLI (auto-generated — do not edit).
 
 if [ -z "$NODETERM_CANVAS_CONTROL" ]; then
   echo "Canvas control is not available in this session (not a nodeterm agent node)." >&2
@@ -626,6 +626,23 @@ if [ -z "$nt_code" ] || [ "$nt_code" = "000" ]; then
 fi
 exit 1
 `
+
+/**
+ * Build the local canvas-control shim. A Codex tool shell is forked by the account-scoped shared
+ * app-server, not by its pane, so it carries CODEX_THREAD_ID but none of the NODETERM_* identity
+ * variables. The signed thread-ownership record is the only safe way to recover that identity,
+ * and the resolver must run before the shim's early NODETERM_CANVAS_CONTROL gate.
+ *
+ * `identityRoot` stays optional because the same machine-neutral script is copied to SSH hosts;
+ * the desktop's local ownership-record path must never be baked into a remote client.
+ */
+export function buildControlShimScript(identityRoot?: string): string {
+  const identityPrelude = identityRoot ? `${codexThreadIdentityResolverSh(identityRoot)}\n` : ''
+  return `#!/bin/sh\n${identityPrelude}${CONTROL_SHIM_BODY}`
+}
+
+/** Machine-neutral variant used by SSH installation and legacy tests. */
+export const CONTROL_SHIM_SCRIPT = buildControlShimScript()
 
 /** The manage-nodeterm-canvas SKILL.md body, pointing at the shim at `shimPath`.
  *  Parameterized because the same skill is installed twice with different paths: into the

--- a/src/main/canvas-control.ts
+++ b/src/main/canvas-control.ts
@@ -3,19 +3,20 @@
 // /control/* routes; a Claude skill / codex-gemini instruction blocks tell the agent how +
 // when to call it. The CLI no-ops unless NODETERM_CANVAS_CONTROL is set.
 //
-// The SSH counterpart of this file is RemoteHooks.installCanvasControl, which writes the very
-// same shim + skill onto the remote host — the shim carries no machine-specific paths, so one
-// script serves both sides.
+// The SSH counterpart is RemoteHooks.installCanvasControl. Both use the same machine-neutral
+// body, but the LOCAL installer prepends the shared-Codex thread resolver with this machine's
+// ownership-record path; a desktop path must never be baked into the remote copy.
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { app } from 'electron'
 import {
-  CONTROL_SHIM_SCRIPT,
+  buildControlShimScript,
   buildCanvasControlInstructions,
   buildCanvasSkillBody,
   mergeCanvasControlBlock
 } from './canvas-control-core'
+import { codexThreadIdentityRoot } from '../core/codex-identity-proxy'
 import { opencodeConfigDir } from '../core/agents/hooks/opencode'
 import { copilotHomeDir } from '../core/agents/hooks/copilot'
 
@@ -35,7 +36,7 @@ function skillBody(): string {
 function writeCliFiles(): void {
   const d = dir()
   fs.mkdirSync(d, { recursive: true })
-  fs.writeFileSync(shimPath(), CONTROL_SHIM_SCRIPT)
+  fs.writeFileSync(shimPath(), buildControlShimScript(codexThreadIdentityRoot()))
   try {
     fs.chmodSync(shimPath(), 0o755)
   } catch {

--- a/src/main/codex-identity-record-wiring.test.ts
+++ b/src/main/codex-identity-record-wiring.test.ts
@@ -1,0 +1,60 @@
+// The shell must FORWARD the agent identity into the ownership record, and no type can make it.
+//
+// `hookServer.setCodexThread{Start,Bind}Handler` take a request object. A handler that destructures
+// `{ nodeId, cwd, hookEndpoint, accountId }` and drops `agent` is perfectly well-typed — an object
+// destructure is allowed to ignore properties — and so is a call to `writeCodexThreadIdentity`
+// that omits its optional trailing argument. So the whole agent dimension can be plumbed through
+// core, the route, the launcher and the sh prelude, pass `npm run typecheck`, pass every unit test,
+// and still be INERT in the shipped desktop app: every record written would carry no agent line,
+// every one would read back as the implied `codex` with the grant, and the mislabel this exists to
+// remove would survive untouched with a green suite. That happened once while writing this change.
+//
+// It is the same class of hole `hook-verified-parity.test.ts` was written for — "the boundary tests
+// cannot tell you a field is MISSING" — and the same remedy: pin it at SOURCE level.
+//
+// Only `src/main` registers these handlers today. If the Server Edition ever grows a shared-Codex
+// leg it must be added to `SHELLS` below, or it inherits exactly this silence.
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const SHELLS = [{ name: 'desktop', file: join(__dirname, 'index.ts') }] as const
+
+/**
+ * The text of one handler registration: from its `setCodexThread…Handler(` to the closing `})` that
+ * ends the call. Found by brace-free scanning for the terminator at the registration's own
+ * indentation, which is enough here and keeps the guard free of a TS parser.
+ */
+function handlerBody(source: string, setter: string): string {
+  const start = source.indexOf(`hookServer.${setter}(`)
+  expect(start, `${setter} is not registered — this guard is looking at the wrong file`).toBeGreaterThan(-1)
+  const end = source.indexOf('\n  })', start)
+  expect(end, `${setter} has no recognisable end`).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('the desktop shell forwards Codex agent identity into the ownership record', () => {
+  for (const shell of SHELLS) {
+    const source = readFileSync(shell.file, 'utf8')
+
+    for (const [setter, writer] of [
+      ['setCodexThreadStartHandler', 'writeCodexThreadIdentity'],
+      ['setCodexThreadBindHandler', 'bindCodexThreadIdentity']
+    ] as const) {
+      const body = handlerBody(source, setter)
+
+      it(`${shell.name}: ${setter} destructures the agent off the request`, () => {
+        // Without this the field is silently dropped at the very first line of the handler.
+        expect(body).toMatch(/\{[^}]*\bagent\b[^}]*\}/)
+      })
+
+      it(`${shell.name}: ${setter} passes it to ${writer}`, () => {
+        const call = body.slice(body.indexOf(writer))
+        expect(call, `${writer} is not called in ${setter}`).not.toBe('')
+        // The argument list must actually name it. A record written without it is a PRE-AGENT
+        // record: legal, readable, and wrong for every node whose agent is not plain codex.
+        expect(call).toMatch(/\bagent\b/)
+      })
+    }
+  }
+})

--- a/src/main/codex-shim-identity.integration.test.ts
+++ b/src/main/codex-shim-identity.integration.test.ts
@@ -1,0 +1,82 @@
+// A shared Codex app-server forks tool shells without the pane's NODETERM_* environment. These
+// tests run both generated local shims under real /bin/sh with only CODEX_THREAD_ID, proving that
+// the signed ownership-record prelude executes before either shim's "not a nodeterm node" gate.
+import { afterEach, describe, expect, it } from 'vitest'
+import { execFile } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+import { buildContextShimScript } from '../core/context-link-core'
+import { buildControlShimScript } from './canvas-control-core'
+
+const run = promisify(execFile)
+const cleanup: string[] = []
+
+afterEach(() => {
+  for (const dir of cleanup.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('local Codex tool-shell identity recovery', () => {
+  for (const [name, build] of [
+    ['canvas control', buildControlShimScript],
+    ['linked context', buildContextShimScript]
+  ] as const) {
+    it(`${name} resolves CODEX_THREAD_ID before its NODETERM_* gate`, async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'nodeterm-codex-local-shim-'))
+      cleanup.push(dir)
+      const root = join(dir, 'codex-thread-nodes')
+      const built = build(root)
+
+      const bin = join(dir, 'bin')
+      const endpoint = join(dir, 'hook-endpoint.env')
+      const tokens = join(dir, 'node-tokens')
+      const capture = join(dir, 'curl-args')
+      const script = join(dir, 'shim.sh')
+      mkdirSync(root)
+      mkdirSync(bin)
+      mkdirSync(tokens)
+      writeFileSync(
+        join(root, 'thread-1'),
+        `accountId=\nnodeId=node-1\nendpoint=${endpoint}\nsignature=test-fixture\n`,
+        { mode: 0o600 }
+      )
+      writeFileSync(
+        endpoint,
+        `NODETERM_HOOK_PORT=54321\nNODETERM_HOOK_TOKEN=test-hook\n` +
+          `NODETERM_HOOK_VERSION=2\nNODETERM_NODE_TOKEN_DIR=${tokens}\n`,
+        { mode: 0o600 }
+      )
+      writeFileSync(join(tokens, 'node-1'), 'test-node-token\n', { mode: 0o600 })
+      writeFileSync(script, built, { mode: 0o755 })
+      writeFileSync(
+        join(bin, 'curl'),
+        `#!/bin/sh
+nt_out=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; nt_out="$1" ;;
+    --data-urlencode) shift; printf '%s\n' "$1" >> "$NT_CAPTURE" ;;
+  esac
+  shift
+done
+[ -n "$nt_out" ] && printf 'ok\n' > "$nt_out"
+printf '200'
+`,
+        { mode: 0o755 }
+      )
+
+      const result = await run('/bin/sh', [script, 'list'], {
+        env: {
+          PATH: `${bin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+          CODEX_THREAD_ID: 'thread-1',
+          NT_CAPTURE: capture
+        }
+      })
+
+      expect(result.stdout.trim()).toBe('ok')
+      expect(readFileSync(capture, 'utf8').split('\n')).toContain('nodeId=node-1')
+    })
+  }
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1703,12 +1703,16 @@ app.whenReady().then(async () => {
   // workspace that no longer holds it) is free to be re-claimed; one whose owner is still there is
   // not, and the launcher then falls back rather than putting two clients on one conversation.
   const codexNodeIsLive = (nodeId: string): boolean => !!workspaceStore.getNode(nodeId)
-  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd, hookEndpoint, accountId }) => {
+  // `agent` is the pane's own label plus the grant the route derived from it; passing it is what
+  // makes the record name its agent instead of leaving the sh prelude to guess `codex`. Omitting it
+  // compiles perfectly — the destructure would just ignore the field — so the feature would ship
+  // INERT on this shell with a green typecheck. `codex-identity-record-wiring.test.ts` pins it.
+  hookServer.setCodexThreadStartHandler(async ({ nodeId, cwd, hookEndpoint, accountId, agent }) => {
     const threadId = await startCodexThread(cwd)
-    writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, undefined, accountId)
+    writeCodexThreadIdentity(threadId, nodeId, hookEndpoint, undefined, accountId, agent)
     return threadId
   })
-  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, hookEndpoint, accountId }) => {
+  hookServer.setCodexThreadBindHandler(async ({ nodeId, threadId, hookEndpoint, accountId, agent }) => {
     // Ask the app-server whether this conversation exists BEFORE recording that a node owns it.
     // The id reaching us is whatever the node persisted — it can be stale, or from a session that
     // ran under plain codex and the shared server has never heard of. Binding it anyway writes a
@@ -1717,7 +1721,15 @@ app.whenReady().then(async () => {
     if (!(await codexThreadExists(threadId))) {
       throw new Error('Codex thread is unknown to the shared app-server')
     }
-    bindCodexThreadIdentity(threadId, nodeId, hookEndpoint, codexNodeIsLive, undefined, accountId)
+    bindCodexThreadIdentity(
+      threadId,
+      nodeId,
+      hookEndpoint,
+      codexNodeIsLive,
+      undefined,
+      accountId,
+      agent
+    )
   })
   // SSH_ASKPASS relay (ssh-project.ts): lets the ControlMaster, which has no tty, route a
   // passphrase-protected identity file's prompt back through the app instead of failing auth.

--- a/src/main/remote-ssh/remote-shim-neutrality.guard.test.ts
+++ b/src/main/remote-ssh/remote-shim-neutrality.guard.test.ts
@@ -1,0 +1,107 @@
+// The shim scripts copied onto an SSH host must stay MACHINE-NEUTRAL: no path that only means
+// something on the desktop/server that generated them.
+//
+// Since the local shims gained the shared-Codex identity prelude, the two builders take an
+// `identityRoot` — this machine's `<userDataDir>/codex-thread-nodes`. The LOCAL installers pass it;
+// the SSH installer must not, because a record root under one machine's user-data dir is not a
+// path on somebody else's server. The rule is stated in three places (CLAUDE.md, CONTRIBUTING.md,
+// docs/shared-codex-node-identity.md) and was enforced by none of them.
+//
+// WHY IT NEEDS A GUARD RATHER THAN A REVIEWER: the failure is SILENT AND ONE-SIDED. A remote shim
+// carrying the prelude still works — the outer `[ -n "$CODEX_THREAD_ID" ]` guard is false in a
+// remote pane, and even if it were true the baked root does not exist there, so every candidate
+// read fails and the block changes nothing. Nothing breaks, no test goes red, no user reports a
+// bug. The only symptom is that this machine's user-data layout is now sitting in a file on
+// someone else's server, written there by us, and refreshed on every connect.
+//
+// Two legs, because they catch the mistake at different moments:
+//   1. the VALUE — the neutral exports the SSH installer writes carry nothing machine-specific;
+//   2. the IMPORT — `remote-hooks.ts` cannot even reach a builder that would produce one.
+// Leg 2 is the one that survives a refactor: a future author who reaches for the parameterised
+// builder "so the remote shim gets the fix too" is stopped at the import, before there is a value
+// to assert about.
+//
+// Every assertion has a POSITIVE CONTROL beside it. A guard whose subject has been renamed or
+// removed matches nothing and reports clean — the same failure mode `fs-atomic.guard.test.ts`
+// opens with — and a silent pass here would restore exactly the blindness this file exists to end.
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { CONTROL_SHIM_SCRIPT, buildControlShimScript } from '../canvas-control-core'
+import { CONTEXT_SHIM_SCRIPT, buildContextShimScript } from '../../core/context-link-core'
+
+/** A root no real machine would produce, so a hit is unambiguously the one we baked in. */
+const SENTINEL_ROOT = '/nodeterm-guard-sentinel/codex-thread-nodes'
+
+const REMOTE_HOOKS = join(__dirname, 'remote-hooks.ts')
+
+/**
+ * Identifiers `remote-hooks.ts` must never name. Each one is a way to obtain a shim body carrying
+ * a local path, or the local path itself.
+ */
+const BANNED_IN_REMOTE_HOOKS = [
+  'buildControlShimScript',
+  'buildContextShimScript',
+  'codexThreadIdentityResolverSh',
+  'codexThreadIdentityRoot'
+] as const
+
+/**
+ * Identifiers `remote-hooks.ts` must still name — the neutral exports it writes to the host. If
+ * these disappear the file has been restructured and leg 2's scan is no longer looking at the
+ * thing it was written to look at, so it must go red rather than pass over an empty subject.
+ */
+const REQUIRED_IN_REMOTE_HOOKS = ['CONTROL_SHIM_SCRIPT', 'CONTEXT_SHIM_SCRIPT'] as const
+
+/**
+ * Strip comments before scanning, so this file's own rule can be EXPLAINED at the call site in
+ * `remote-hooks.ts` without the explanation tripping the scan. Only comments are removed; a string
+ * literal naming a banned identifier is still a hit, which is the conservative direction.
+ */
+function code(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+}
+
+describe('SSH-installed shims stay machine-neutral', () => {
+  describe('leg 1 — the exported neutral bodies carry no local path', () => {
+    for (const [name, neutral, build] of [
+      ['canvas control', CONTROL_SHIM_SCRIPT, buildControlShimScript],
+      ['linked context', CONTEXT_SHIM_SCRIPT, buildContextShimScript]
+    ] as const) {
+      it(`${name}: the builder DOES bake a root when given one (positive control)`, () => {
+        // Without this, the two assertions below would also pass if the prelude had been dropped
+        // from the local shims altogether — a regression, reported as compliance.
+        const local = build(SENTINEL_ROOT)
+        expect(local).toContain(SENTINEL_ROOT)
+        expect(local).toContain('CODEX_THREAD_ID')
+      })
+
+      it(`${name}: the neutral export names no record root`, () => {
+        expect(neutral).not.toContain('codex-thread-nodes')
+      })
+
+      it(`${name}: the neutral export carries no identity prelude at all`, () => {
+        // Broader than the path check on purpose. The path is what leaks today; the prelude is the
+        // only thing that can carry one, so refusing the whole block refuses the next spelling of
+        // the leak too (a root read from an env var, a relative path, a default argument).
+        expect(neutral).not.toContain('CODEX_THREAD_ID')
+        expect(build()).toBe(neutral)
+      })
+    }
+  })
+
+  describe('leg 2 — remote-hooks.ts cannot reach a parameterised builder', () => {
+    const source = code(readFileSync(REMOTE_HOOKS, 'utf8'))
+
+    it('is reading the real remote installer (positive control)', () => {
+      for (const required of REQUIRED_IN_REMOTE_HOOKS) expect(source).toContain(required)
+    })
+
+    for (const banned of BANNED_IN_REMOTE_HOOKS) {
+      it(`never names ${banned}`, () => {
+        expect(source).not.toContain(banned)
+      })
+    }
+  })
+})

--- a/src/server/context-link.test.ts
+++ b/src/server/context-link.test.ts
@@ -3,7 +3,14 @@
 // parsing, the local/remote split) are core's and are covered by src/core/context-link.handler.test.ts —
 // what is tested here is the wiring that was missing server-side.
 import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest'
-import { existsSync, mkdtempSync, promises as fsPromises, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdtempSync,
+  promises as fsPromises,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { deriveLinkMap, initServerContextLink } from './context-link'
@@ -150,6 +157,9 @@ describe('initServerContextLink', () => {
     // Without this registration the hook server answers every read with
     // "Context link is unavailable in this session." — the whole desktop-only symptom.
     expect(registered).toBe(true)
+    const shimBody = readFileSync(join(dir, 'context-links', 'context.sh'), 'utf8')
+    expect(shimBody).toContain('CODEX_THREAD_ID')
+    expect(shimBody).toContain(join(dir, 'codex-thread-nodes'))
     await link.refresh()
     const out = await handler({ verb: 'list', nodeId: 'term-a', args: {} })
     expect(out).toContain('Beta')


### PR DESCRIPTION
## Why

A Codex tool shell spawned by the shared app-server carries `CODEX_THREAD_ID`, but not the pane `NODETERM_*` variables. The managed status hook already recovers the signed thread-to-node binding. The local canvas-control and linked-context shims checked their environment first, so the same real Codex node was incorrectly reported as outside nodeterm.

This is the focused, current-main extraction of the identity repair discovered while exercising #537; it does not pull in the Server Edition feature branch.

## What changed

- Build each local `nodeterm.sh` and `context.sh` with `codexThreadIdentityResolverSh(codexThreadIdentityRoot())` before its environment gate.
- Keep the exported machine-neutral variants unchanged for SSH installation, so no local record path leaks to a remote host.
- Add a real `/bin/sh` integration regression covering both shims with only `CODEX_THREAD_ID` present.
- Document the invariant in `CONTRIBUTING.md`, `CLAUDE.md`, and the shared-Codex identity guide.

## Verification

- `npx vitest run src/main/codex-shim-identity.integration.test.ts src/main/canvas-control-core.test.ts src/core/context-link-core.test.ts src/server/context-link.test.ts` — 87 passed.
- `npm run typecheck` — passed.
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build` — passed.
- Mutation check: removing the canvas resolver made the new real-shell test fail with the original "not a nodeterm agent node" symptom; restoring it returned 2/2 green.
- Full local suite: 9,314 passed, 27 skipped, with three pre-existing host/environment failures in untouched surfaces (`tmux-paste.realtmux`, bogus-SSH timeout, headless listener probe). Each reproduced in isolation; none of their source or test files differ from `origin/main`.