### PR TITLE
UI polish: icons, spacing and tooltips across the canvas chrome

### DIFF
--- a/src/renderer/bridge/dialog-picker.tsx
+++ b/src/renderer/bridge/dialog-picker.tsx
@@ -17,6 +17,7 @@
 // here, so `..`, absolute and empty names are refused exactly as they are in the Explorer.
 
 import { useCallback, useEffect, useState } from 'react'
+import { IconArrowUp } from '../components/icons'
 import { createRoot, type Root } from 'react-dom/client'
 import type { DirEntry } from '../../shared/types'
 import { newEntryPath } from '../lib/explorerCreate'
@@ -214,7 +215,7 @@ function DirectoryPicker({
             disabled={parent === null}
             title="Up one level"
           >
-            ↑
+            <IconArrowUp />
           </button>
           <span className="dir-picker__path" title={dir}>
             {dir}

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -741,6 +741,11 @@ const offsetFrom = (
 }
 
 
+/** Zoom-step tween. One constant because the same step sits on two surfaces, the dock and the
+ *  bottom-left controls, and a user who reaches for whichever is nearer must not get two
+ *  different gestures. */
+const ZOOM_STEP_DURATION_MS = 150
+
 // A canvas-control request whose source node lives in another project switches that project in
 // first, and the active-project effect hydrates React Flow ASYNCHRONOUSLY — so the handler waits
 // for the node to appear instead of reading an empty canvas one tick too early. Bounded well under
@@ -13378,16 +13383,15 @@ export function Canvas() {
               default modes. */}
           {glyphLayerActive && <SharedGlyphLayer />}
           {/* The library's own zoom/fit glyphs are swapped for the shared icon set so this cluster
-              matches every other floating control; the actions behind them are unchanged, and
-              zoom stays instant here (the dock's buttons are the animated pair). */}
+              matches every other floating control; the actions behind them are unchanged. */}
           <Controls showZoom={false} showFitView={false} showInteractive={false} position="bottom-left">
             <Tooltip label="Zoom in" placement="top">
-              <ControlButton aria-label="Zoom in" onClick={() => zoomIn()}>
+              <ControlButton aria-label="Zoom in" onClick={() => zoomIn({ duration: ZOOM_STEP_DURATION_MS })}>
                 <IconPlus />
               </ControlButton>
             </Tooltip>
             <Tooltip label="Zoom out" placement="top">
-              <ControlButton aria-label="Zoom out" onClick={() => zoomOut()}>
+              <ControlButton aria-label="Zoom out" onClick={() => zoomOut({ duration: ZOOM_STEP_DURATION_MS })}>
                 <IconMinus />
               </ControlButton>
             </Tooltip>
@@ -13988,8 +13992,8 @@ export function Canvas() {
         onAddWorktree={() => openWorktreeDialog(null)}
         onSave={persist}
         onFitView={fitAll}
-        onZoomIn={() => zoomIn({ duration: 150 })}
-        onZoomOut={() => zoomOut({ duration: 150 })}
+        onZoomIn={() => zoomIn({ duration: ZOOM_STEP_DURATION_MS })}
+        onZoomOut={() => zoomOut({ duration: ZOOM_STEP_DURATION_MS })}
         onZoomTo={zoomToPct}
         onDictate={toggleDictation}
         dictateActive={dictationOpen}

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -91,9 +91,13 @@ import { Dock } from '../components/Dock'
 import { TabBar } from '../components/TabBar'
 import { ContextMenu, type MenuItem } from '../components/ContextMenu'
 import { CommandPalette, type Command } from '../components/CommandPalette'
+import { Tooltip } from '../components/Tooltip'
 import {
-  IconCollapse,
   IconBranch,
+  IconCanvasView,
+  IconClose,
+  IconCollapse,
+  IconDino,
   IconDuplicate,
   IconEditor,
   IconExplorer,
@@ -101,22 +105,23 @@ import {
   IconGear,
   IconGrid,
   IconGroup,
-  IconDino,
   IconJump,
   IconKanban,
-  IconCanvasView,
   IconLock,
   IconMarkdown,
-  IconReload,
-  IconSmiley,
-  IconPower,
+  IconMinus,
   IconNote,
   IconPhone,
+  IconPlus,
+  IconPower,
   IconProject,
+  IconReload,
   IconRemote,
   IconSave,
+  IconSearch,
   IconSelectAll,
   IconSessions,
+  IconSmiley,
   IconSwitch,
   IconTerminal,
   IconTrash,
@@ -946,9 +951,9 @@ export function Canvas() {
     return () => clearTimeout(t)
   }, [notice])
   const [zoomPct, setZoomPct] = useState(100)
-  // Canvas lock (bottom-left Controls): freezes the viewport against GESTURES — pan (drag +
+  // Canvas lock (bottom-left Controls): freezes the viewport against GESTURES: pan (drag +
   // scroll), zoom (pinch / Cmd+wheel / double-click), node dragging and edge connecting.
-  // Deliberate button clicks (Controls +/−/fit, dock zoom, ⌘K fit) still work, matching React
+  // Deliberate button clicks (Controls +/-/fit, dock zoom, ⌘K fit) still work, matching React
   // Flow's own lock convention. Transient by design: a lock that survives restart reads as
   // "the app is frozen" to whoever opens it next.
   const [canvasLocked, setCanvasLocked] = useState(false)
@@ -13011,7 +13016,7 @@ export function Canvas() {
               title="Dismiss"
               onClick={() => setMigrationNote(null)}
             >
-              ✕
+              <IconClose />
             </button>
           </div>
         )}
@@ -13026,7 +13031,7 @@ export function Canvas() {
               title="Dismiss"
               onClick={() => setSyncNote(null)}
             >
-              ✕
+              <IconClose />
             </button>
           </div>
         )}
@@ -13041,7 +13046,7 @@ export function Canvas() {
               title="Dismiss"
               onClick={() => setCopyError(null)}
             >
-              ✕
+              <IconClose />
             </button>
           </div>
         )}
@@ -13060,7 +13065,7 @@ export function Canvas() {
               title="Dismiss"
               onClick={() => setNotice(null)}
             >
-              ✕
+              <IconClose />
             </button>
           </div>
         )}
@@ -13202,7 +13207,7 @@ export function Canvas() {
           title="Command palette"
           onClick={() => setPaletteOpen(true)}
         >
-          <span className="cluster-search__icon">⌕</span>
+          <IconSearch />
           {paletteChip && <span className="kbd">{paletteChip}</span>}
         </button>
         <button title={commandTooltip('Explorer', 'panel.explorer')} onClick={() => showExplorer('toggle')}>
@@ -13368,14 +13373,37 @@ export function Canvas() {
               mounted in the experimental 'shared' renderer mode; nothing about it exists for the
               default modes. */}
           {glyphLayerActive && <SharedGlyphLayer />}
-          <Controls showInteractive={false} position="bottom-left" onFitView={fitAll}>
-            <ControlButton
-              className={`canvas-lock-btn${canvasLocked ? ' locked' : ''}`}
-              title={canvasLocked ? 'Unlock view (pan/zoom)' : 'Lock view (pan/zoom) — nodes stay movable'}
-              onClick={() => setCanvasLocked((v) => !v)}
+          {/* The library's own zoom/fit glyphs are swapped for the shared icon set so this cluster
+              matches every other floating control; the actions behind them are unchanged, and
+              zoom stays instant here (the dock's buttons are the animated pair). */}
+          <Controls showZoom={false} showFitView={false} showInteractive={false} position="bottom-left">
+            <Tooltip label="Zoom in" placement="top">
+              <ControlButton aria-label="Zoom in" onClick={() => zoomIn()}>
+                <IconPlus />
+              </ControlButton>
+            </Tooltip>
+            <Tooltip label="Zoom out" placement="top">
+              <ControlButton aria-label="Zoom out" onClick={() => zoomOut()}>
+                <IconMinus />
+              </ControlButton>
+            </Tooltip>
+            <Tooltip label="Fit view" placement="top">
+              <ControlButton aria-label="Fit view" onClick={fitAll}>
+                <IconFit />
+              </ControlButton>
+            </Tooltip>
+            <Tooltip
+              label={canvasLocked ? 'Unlock view (pan/zoom)' : 'Lock view (pan/zoom); nodes stay movable'}
+              placement="top"
             >
-              {canvasLocked ? <IconLock /> : <IconUnlock />}
-            </ControlButton>
+              <ControlButton
+                className={`canvas-lock-btn${canvasLocked ? ' locked' : ''}`}
+                aria-label={canvasLocked ? 'Unlock view' : 'Lock view'}
+                onClick={() => setCanvasLocked((v) => !v)}
+              >
+                {canvasLocked ? <IconLock /> : <IconUnlock />}
+              </ControlButton>
+            </Tooltip>
           </Controls>
           {/* Peer cursors live INSIDE <ReactFlow>: PresenceLayer uses ViewportPortal +
               useReactFlow, which throw outside the provider — and cursors are flow coordinates. */}

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -13383,26 +13383,28 @@ export function Canvas() {
               default modes. */}
           {glyphLayerActive && <SharedGlyphLayer />}
           {/* The library's own zoom/fit glyphs are swapped for the shared icon set so this cluster
-              matches every other floating control; the actions behind them are unchanged. */}
+              matches every other floating control; the actions behind them are unchanged. The
+              tooltips open to the RIGHT rather than upward like the dock's: this is a vertical
+              stack, so an upward bubble covers the button above the one being pointed at. */}
           <Controls showZoom={false} showFitView={false} showInteractive={false} position="bottom-left">
-            <Tooltip label="Zoom in" placement="top">
+            <Tooltip label="Zoom in" placement="right">
               <ControlButton aria-label="Zoom in" onClick={() => zoomIn({ duration: ZOOM_STEP_DURATION_MS })}>
                 <IconPlus />
               </ControlButton>
             </Tooltip>
-            <Tooltip label="Zoom out" placement="top">
+            <Tooltip label="Zoom out" placement="right">
               <ControlButton aria-label="Zoom out" onClick={() => zoomOut({ duration: ZOOM_STEP_DURATION_MS })}>
                 <IconMinus />
               </ControlButton>
             </Tooltip>
-            <Tooltip label="Fit view" placement="top">
+            <Tooltip label="Fit view" placement="right">
               <ControlButton aria-label="Fit view" onClick={fitAll}>
                 <IconFit />
               </ControlButton>
             </Tooltip>
             <Tooltip
               label={canvasLocked ? 'Unlock view (pan/zoom)' : 'Lock view (pan/zoom); nodes stay movable'}
-              placement="top"
+              placement="right"
             >
               <ControlButton
                 className={`canvas-lock-btn${canvasLocked ? ' locked' : ''}`}

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -13014,6 +13014,7 @@ export function Canvas() {
             <button
               className="announce-banner__close"
               title="Dismiss"
+              aria-label="Dismiss"
               onClick={() => setMigrationNote(null)}
             >
               <IconClose />
@@ -13029,6 +13030,7 @@ export function Canvas() {
             <button
               className="announce-banner__close"
               title="Dismiss"
+              aria-label="Dismiss"
               onClick={() => setSyncNote(null)}
             >
               <IconClose />
@@ -13044,6 +13046,7 @@ export function Canvas() {
             <button
               className="announce-banner__close"
               title="Dismiss"
+              aria-label="Dismiss"
               onClick={() => setCopyError(null)}
             >
               <IconClose />
@@ -13063,6 +13066,7 @@ export function Canvas() {
             <button
               className="announce-banner__close"
               title="Dismiss"
+              aria-label="Dismiss"
               onClick={() => setNotice(null)}
             >
               <IconClose />

--- a/src/renderer/canvas/canvas-image-import.ts
+++ b/src/renderer/canvas/canvas-image-import.ts
@@ -5,7 +5,7 @@ export function isCanvasImageDropTarget(target: EventTarget | null, wrap: Elemen
     element &&
     wrap.contains(element) &&
     element.closest('.react-flow__pane') &&
-    !element.closest('.react-flow__node, .react-flow__controls, .react-flow__minimap')
+    !element.closest('.react-flow__node, .react-flow__minimap')
   )
 }
 

--- a/src/renderer/components/AccountIdentityPills.tsx
+++ b/src/renderer/components/AccountIdentityPills.tsx
@@ -2,6 +2,7 @@
 // node chrome, create/switch menus). Based on @Corvin's #112 (`AccountIdentityPills.tsx`).
 
 import type { AccountPresentation } from '../lib/accountPresentation'
+import { IconCheck } from './icons'
 
 /**
  * Renders a presented account as an identity pill + a Local/SSH provenance pill, with an optional
@@ -30,7 +31,7 @@ export function AccountIdentityPills({
       <span className="account-provenance-pill">{account.provenance}</span>
       {selected ? (
         <span className="account-identity-check" aria-label="Selected">
-          ✓
+          <IconCheck />
         </span>
       ) : null}
     </span>

--- a/src/renderer/components/AnnouncementBanner.tsx
+++ b/src/renderer/components/AnnouncementBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IconClose } from './icons'
 import type { Announcement } from '@shared/types'
 
 // Polls the remote announcements feed (via the main process) and shows the newest
@@ -72,7 +73,7 @@ export function AnnouncementBanner(): JSX.Element | null {
         </button>
       )}
       <button className="announce-banner__close" title="Dismiss" onClick={dismiss}>
-        ✕
+        <IconClose />
       </button>
     </div>
   )

--- a/src/renderer/components/AnnouncementBanner.tsx
+++ b/src/renderer/components/AnnouncementBanner.tsx
@@ -72,7 +72,7 @@ export function AnnouncementBanner(): JSX.Element | null {
           Learn more
         </button>
       )}
-      <button className="announce-banner__close" title="Dismiss" onClick={dismiss}>
+      <button className="announce-banner__close" title="Dismiss" aria-label="Dismiss" onClick={dismiss}>
         <IconClose />
       </button>
     </div>

--- a/src/renderer/components/DictationOverlay.tsx
+++ b/src/renderer/components/DictationOverlay.tsx
@@ -285,7 +285,7 @@ export function DictationOverlay({ target, stopSignal, onClose, onOpenLicense }:
           See nodeterm Pro
         </button>
       )}
-      <button type="button" className="dictation__close" title="Dismiss" onClick={handleClose}>
+      <button type="button" className="dictation__close" title="Dismiss" aria-label="Dismiss" onClick={handleClose}>
         <IconClose />
       </button>
     </div>
@@ -299,7 +299,7 @@ export function DictationOverlay({ target, stopSignal, onClose, onOpenLicense }:
             ? 'Dictation is off — choose a Whisper model in Settings → Speech.'
             : 'Select a terminal node first.'}
         </span>
-        <button type="button" className="dictation__close" title="Dismiss" onClick={handleClose}>
+        <button type="button" className="dictation__close" title="Dismiss" aria-label="Dismiss" onClick={handleClose}>
           <IconClose />
         </button>
       </div>,

--- a/src/renderer/components/DictationOverlay.tsx
+++ b/src/renderer/components/DictationOverlay.tsx
@@ -13,6 +13,7 @@
 //
 // No target selected at press time never records at all — see the warning-pill render branch.
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { IconClose } from './icons'
 import { createPortal } from 'react-dom'
 import { equalizerBars } from '../lib/dictation-equalizer'
 import { PcmCapture } from '../lib/pcm-capture'
@@ -285,7 +286,7 @@ export function DictationOverlay({ target, stopSignal, onClose, onOpenLicense }:
         </button>
       )}
       <button type="button" className="dictation__close" title="Dismiss" onClick={handleClose}>
-        ×
+        <IconClose />
       </button>
     </div>
   )
@@ -299,7 +300,7 @@ export function DictationOverlay({ target, stopSignal, onClose, onOpenLicense }:
             : 'Select a terminal node first.'}
         </span>
         <button type="button" className="dictation__close" title="Dismiss" onClick={handleClose}>
-          ×
+          <IconClose />
         </button>
       </div>,
       document.body

--- a/src/renderer/components/Dock.tsx
+++ b/src/renderer/components/Dock.tsx
@@ -390,7 +390,7 @@ export function Dock({
         <span className="dock-sep" />
 
         <Tooltip label="Zoom out" placement="top">
-          <button className="dock-btn dock-zoom-btn" aria-label="Zoom out" onClick={onZoomOut}>
+          <button className="dock-btn" aria-label="Zoom out" onClick={onZoomOut}>
             <MinusIcon />
           </button>
         </Tooltip>
@@ -432,7 +432,7 @@ export function Dock({
           </Tooltip>
         </div>
         <Tooltip label="Zoom in" placement="top">
-          <button className="dock-btn dock-zoom-btn" aria-label="Zoom in" onClick={onZoomIn}>
+          <button className="dock-btn" aria-label="Zoom in" onClick={onZoomIn}>
             <PlusSmallIcon />
           </button>
         </Tooltip>
@@ -454,14 +454,14 @@ function PlusIcon() {
 function UndoIcon() {
   return (
     <svg {...S}>
-      <path d="M9 7L4 12l5 5M4 12h11a5 5 0 0 1 0 10h-2" />
+      <path d="M9 14L4 9l5-5M4 9h10.5a5.5 5.5 0 0 1 0 11H10" />
     </svg>
   )
 }
 function RedoIcon() {
   return (
     <svg {...S}>
-      <path d="M15 7l5 5-5 5M20 12H9a5 5 0 0 0 0 10h2" />
+      <path d="M15 14l5-5-5-5M20 9H9.5a5.5 5.5 0 0 0 0 11H14" />
     </svg>
   )
 }
@@ -481,7 +481,7 @@ function ArrowRightIcon() {
 }
 function PlusSmallIcon() {
   return (
-    <svg {...S} width={15} height={15}>
+    <svg {...S}>
       <path d="M12 5v14M5 12h14" />
     </svg>
   )
@@ -495,7 +495,7 @@ function CheckIcon() {
 }
 function MinusIcon() {
   return (
-    <svg {...S} width={15} height={15}>
+    <svg {...S}>
       <path d="M5 12h14" />
     </svg>
   )

--- a/src/renderer/components/Dock.tsx
+++ b/src/renderer/components/Dock.tsx
@@ -10,6 +10,7 @@ import { useProjects } from '../state/projects'
 import { accountsForProject, sshAccountsHint } from '../state/workspace'
 import { CONTENT_ADD_ITEMS, contentAddItemsToDockRows, type AddHandlers } from '../lib/addMenuSpec'
 import { ZOOM_PRESETS, activeZoomPreset } from '../lib/zoomPresets'
+import { Tooltip } from './Tooltip'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 
@@ -309,54 +310,62 @@ export function Dock({
           </div>
         )}
 
-        <button
-          className={`dock-btn dock-add${menuOpen ? ' active' : ''}`}
-          title="Add node"
-          onClick={() => {
-            setZoomMenuOpen(false)
-            setMenuOpen((v) => !v)
-          }}
-        >
-          <PlusIcon />
-        </button>
+        <Tooltip label="Add node" placement="top">
+          <button
+            className={`dock-btn dock-add${menuOpen ? ' active' : ''}`}
+            aria-label="Add node"
+            onClick={() => {
+              setZoomMenuOpen(false)
+              setMenuOpen((v) => !v)
+            }}
+          >
+            <PlusIcon />
+          </button>
+        </Tooltip>
 
         <span className="dock-sep" />
 
-        <button className="dock-btn" title={commandTooltip('Undo', 'canvas.undo')} disabled={!canUndo} onClick={onUndo}>
-          <UndoIcon />
-        </button>
-        <button className="dock-btn" title={commandTooltip('Redo', 'canvas.redo')} disabled={!canRedo} onClick={onRedo}>
-          <RedoIcon />
-        </button>
-        <button
-          className="dock-btn"
-          title={commandTooltip('Go back', 'canvas.goBack')}
-          disabled={!canGoBack}
-          onClick={onGoBack}
-        >
-          <ArrowLeftIcon />
-        </button>
-        <button
-          className="dock-btn"
-          title={commandTooltip('Go forward', 'canvas.goForward')}
-          disabled={!canGoForward}
-          onClick={onGoForward}
-        >
-          <ArrowRightIcon />
-        </button>
+        <Tooltip label={commandTooltip('Undo', 'canvas.undo')} placement="top">
+          <button className="dock-btn" aria-label="Undo" disabled={!canUndo} onClick={onUndo}>
+            <UndoIcon />
+          </button>
+        </Tooltip>
+        <Tooltip label={commandTooltip('Redo', 'canvas.redo')} placement="top">
+          <button className="dock-btn" aria-label="Redo" disabled={!canRedo} onClick={onRedo}>
+            <RedoIcon />
+          </button>
+        </Tooltip>
+        <Tooltip label={commandTooltip('Go back', 'canvas.goBack')} placement="top">
+          <button className="dock-btn" aria-label="Go back" disabled={!canGoBack} onClick={onGoBack}>
+            <ArrowLeftIcon />
+          </button>
+        </Tooltip>
+        <Tooltip label={commandTooltip('Go forward', 'canvas.goForward')} placement="top">
+          <button
+            className="dock-btn"
+            aria-label="Go forward"
+            disabled={!canGoForward}
+            onClick={onGoForward}
+          >
+            <ArrowRightIcon />
+          </button>
+        </Tooltip>
 
         <span className="dock-sep" />
 
-        <button className="dock-btn" title="Save" onClick={onSave}>
-          <SaveIcon />
-          <span className={`dock-dirty${dirty ? ' dirty' : ''}`} />
-        </button>
-        <button className="dock-btn" title="Fit view" onClick={onFitView}>
-          <FrameIcon />
-        </button>
-        <button
-          className={`dock-btn${dictateActive ? ' active' : ''}`}
-          title={
+        <Tooltip label={dirty ? 'Save (unsaved changes)' : 'Save'} placement="top">
+          <button className="dock-btn" aria-label="Save" onClick={onSave}>
+            <SaveIcon />
+            <span className={`dock-dirty${dirty ? ' dirty' : ''}`} />
+          </button>
+        </Tooltip>
+        <Tooltip label="Fit view" placement="top">
+          <button className="dock-btn" aria-label="Fit view" onClick={onFitView}>
+            <FrameIcon />
+          </button>
+        </Tooltip>
+        <Tooltip
+          label={
             dictationOff
               ? 'Dictation off — choose a model in Settings → Speech'
               : // The user unbound the shortcut: the mic button still dictates, so the tooltip
@@ -367,16 +376,24 @@ export function Dock({
                   ? `Dictate (hold ${formatShortcut(dictationShortcut, isMac)})`
                   : `Dictate (${formatShortcut(dictationShortcut, isMac)})`
           }
-          onClick={onDictate}
+          placement="top"
         >
-          <MicIcon />
-        </button>
+          <button
+            className={`dock-btn${dictateActive ? ' active' : ''}`}
+            aria-label="Dictate"
+            onClick={onDictate}
+          >
+            <MicIcon />
+          </button>
+        </Tooltip>
 
         <span className="dock-sep" />
 
-        <button className="dock-btn dock-zoom-btn" title="Zoom out" onClick={onZoomOut}>
-          <MinusIcon />
-        </button>
+        <Tooltip label="Zoom out" placement="top">
+          <button className="dock-btn dock-zoom-btn" aria-label="Zoom out" onClick={onZoomOut}>
+            <MinusIcon />
+          </button>
+        </Tooltip>
         <div className="dock-zoom-wrap">
           {zoomMenuOpen && (
             <div className="dock-menu dock-zoom-menu">
@@ -399,22 +416,26 @@ export function Dock({
               </button>
             </div>
           )}
-          <button
-            className={`dock-zoom${zoomMenuOpen ? ' active' : ''}`}
-            title="Zoom presets"
-            aria-haspopup="menu"
-            aria-expanded={zoomMenuOpen}
-            onClick={() => {
-              setMenuOpen(false)
-              setZoomMenuOpen((v) => !v)
-            }}
-          >
-            {zoomPct}%
-          </button>
+          <Tooltip label="Zoom presets" placement="top">
+            <button
+              className={`dock-zoom${zoomMenuOpen ? ' active' : ''}`}
+              aria-label="Zoom presets"
+              aria-haspopup="menu"
+              aria-expanded={zoomMenuOpen}
+              onClick={() => {
+                setMenuOpen(false)
+                setZoomMenuOpen((v) => !v)
+              }}
+            >
+              {zoomPct}%
+            </button>
+          </Tooltip>
         </div>
-        <button className="dock-btn dock-zoom-btn" title="Zoom in" onClick={onZoomIn}>
-          <PlusSmallIcon />
-        </button>
+        <Tooltip label="Zoom in" placement="top">
+          <button className="dock-btn dock-zoom-btn" aria-label="Zoom in" onClick={onZoomIn}>
+            <PlusSmallIcon />
+          </button>
+        </Tooltip>
       </div>
     </>
   )

--- a/src/renderer/components/ExplorerPanel.tsx
+++ b/src/renderer/components/ExplorerPanel.tsx
@@ -11,7 +11,7 @@ import { ancestorDirs, createTargetDir, newEntryPath, parentDir } from '../lib/e
 import { canRevealLocally, downloadRoute, triggerBrowserDownload } from '../lib/download'
 import { explorerOverlayClickCloses } from '../lib/explorerPin'
 import { isBrowserRuntime } from '../bridge/runtime'
-import { IconPin } from './icons'
+import { IconClose, IconPin, IconReload } from './icons'
 
 export interface ExplorerPanelProps {
   onClose: () => void
@@ -473,7 +473,7 @@ export function ExplorerPanel({
           <h2>{project?.name || 'Explorer'}</h2>
           <div className="ex-head-actions">
             <button type="button" title="Refresh" aria-label="Refresh" onClick={() => setVersion((v) => v + 1)}>
-              ↻
+              <IconReload />
             </button>
             {onTogglePin && (
               <button
@@ -488,7 +488,7 @@ export function ExplorerPanel({
               </button>
             )}
             <button type="button" className="drawer__close" title="Close" aria-label="Close" onClick={onClose}>
-              ×
+              <IconClose />
             </button>
           </div>
         </div>
@@ -547,11 +547,11 @@ export function ExplorerPanel({
                   </button>
                 )}
                 <button
-                  className="ex-dls__act"
+                  className="ex-dls__act ex-dls__dismiss"
                   aria-label="Dismiss"
                   onClick={() => setDownloads((list) => list.filter((x) => x.id !== d.id))}
                 >
-                  ×
+                  <IconClose />
                 </button>
               </div>
             ))}

--- a/src/renderer/components/FindBar.tsx
+++ b/src/renderer/components/FindBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { IconClose } from './icons'
+import { IconArrowDown, IconArrowUp, IconClose } from './icons'
 
 /** Identical shape to SearchSnippet in useTerminalSearch.ts (imported by the consumer). */
 export interface FindBarSnippet {
@@ -64,7 +64,7 @@ export function FindBar({
           onClick={onPrev}
           disabled={!matchCount}
         >
-          ↑
+          <IconArrowUp />
         </button>
         <button
           type="button"
@@ -74,7 +74,7 @@ export function FindBar({
           onClick={onNext}
           disabled={!matchCount}
         >
-          ↓
+          <IconArrowDown />
         </button>
         <button
           type="button"

--- a/src/renderer/components/FindBar.tsx
+++ b/src/renderer/components/FindBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { IconClose } from './icons'
 
 /** Identical shape to SearchSnippet in useTerminalSearch.ts (imported by the consumer). */
 export interface FindBarSnippet {
@@ -82,7 +83,7 @@ export function FindBar({
           aria-label="Close search"
           onClick={onClose}
         >
-          ✕
+          <IconClose />
         </button>
       </div>
       {current && (

--- a/src/renderer/components/LogPanel.tsx
+++ b/src/renderer/components/LogPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { IconClose } from './icons'
 import { createPortal } from 'react-dom'
 import type { LogRecord } from '@shared/types'
 
@@ -128,7 +129,7 @@ export function LogPanel({ onClose }: LogPanelProps) {
             Clear
           </button>
           <button className="drawer__close" onClick={onClose}>
-            ×
+            <IconClose />
           </button>
         </div>
         <div

--- a/src/renderer/components/LogPanel.tsx
+++ b/src/renderer/components/LogPanel.tsx
@@ -128,7 +128,7 @@ export function LogPanel({ onClose }: LogPanelProps) {
           <button className="logpanel__act" title="Empty the ring" onClick={clear}>
             Clear
           </button>
-          <button className="drawer__close" onClick={onClose}>
+          <button className="drawer__close" aria-label="Close" onClick={onClose}>
             <IconClose />
           </button>
         </div>

--- a/src/renderer/components/PtyPressureBanner.tsx
+++ b/src/renderer/components/PtyPressureBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IconClose } from './icons'
 import type { PtyPressure } from '@shared/types'
 import { isMacPlatform } from '../../shared/platform-utils'
 
@@ -129,7 +130,7 @@ export function PtyPressureBanner({
         title="Dismiss"
         onClick={() => setDismissed({ level: reading.level, seq: state!.seq })}
       >
-        ✕
+        <IconClose />
       </button>
     </div>
   )

--- a/src/renderer/components/PtyPressureBanner.tsx
+++ b/src/renderer/components/PtyPressureBanner.tsx
@@ -128,6 +128,7 @@ export function PtyPressureBanner({
       <button
         className="announce-banner__close"
         title="Dismiss"
+        aria-label="Dismiss"
         onClick={() => setDismissed({ level: reading.level, seq: state!.seq })}
       >
         <IconClose />

--- a/src/renderer/components/RemoteAccessDialog.tsx
+++ b/src/renderer/components/RemoteAccessDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IconClose } from './icons'
 import { createPortal } from 'react-dom'
 import { useDialogStack } from './dialog-stack'
 import { useEntitlement } from '../state/entitlement'
@@ -91,7 +92,7 @@ export function RemoteAccessDialog({ onClose }: { onClose: () => void }): React.
         <div className="remote-dialog__head">
           <h3>Remote access</h3>
           <button className="remote-dialog__x" onClick={onClose} title="Close">
-            ×
+            <IconClose />
           </button>
         </div>
         <p className="remote-dialog__desc">

--- a/src/renderer/components/ResumeCard.tsx
+++ b/src/renderer/components/ResumeCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { IconClose } from './icons'
 import type { NavStop, Project } from '@shared/types'
 import { relativeTime } from '../lib/relativeTime'
 
@@ -62,7 +63,7 @@ export function ResumeCard({ project, nodes, onOpen }: ResumeCardProps): JSX.Ele
           aria-label="Dismiss"
           onClick={() => setDismissed(true)}
         >
-          ✕
+          <IconClose />
         </button>
       </div>
       <div className="resume-card__rows">

--- a/src/renderer/components/SessionMemoryPanel.test.tsx
+++ b/src/renderer/components/SessionMemoryPanel.test.tsx
@@ -410,6 +410,34 @@ describe('SessionMemoryPanel', () => {
       expect(pauseOf(0)!.title).toBe('Open this session on its canvas')
     })
 
+    it('draws the shared power icon, and the shared spinner while the pause is in flight', async () => {
+      // The panel's pause is the SAME action as the node menu's "Pause session", which draws
+      // `IconPower` — one action seen in two places must not speak in two voices.
+      let settle = (): void => {}
+      onPauseSession.mockImplementation(
+        () =>
+          new Promise<void>((res) => {
+            settle = () => res()
+          })
+      )
+      pauseOffer = () => ({ show: true, disabled: false, hint: 'Pause session' })
+      mount()
+      const btn = pauseOf(0)!
+      expect(btn.querySelector('svg')).not.toBeNull()
+      expect(btn.querySelector('.ui-spinner')).toBeNull()
+
+      act(() => btn.click())
+      expect(btn.querySelector('.ui-spinner')).not.toBeNull()
+      expect(btn.querySelector('svg')).toBeNull()
+
+      // Settle inside `act` so the icon is back before the test ends — a promise still pending at
+      // teardown resolves into an unmounted tree.
+      await act(async () => {
+        settle()
+      })
+      expect(pauseOf(0)!.querySelector('svg')).not.toBeNull()
+    })
+
     it('asks per row, so one row may offer a pause while another does not', () => {
       pauseOffer = (id) =>
         id === ROWS[0].nodeId

--- a/src/renderer/components/SessionMemoryPanel.tsx
+++ b/src/renderer/components/SessionMemoryPanel.tsx
@@ -10,7 +10,7 @@
 //   3. Every row is rendered. A cap would have to announce itself.
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { IconClose, IconReload } from './icons'
+import { IconClose, IconPower, IconReload } from './icons'
 import type { AgentState } from '@shared/agents/normalize'
 import { formatBytes } from '@shared/fsLimits'
 import { useAgentStatus } from '../state/agentStatus'
@@ -199,7 +199,11 @@ export function SessionMemoryPanel({
                       .finally(() => setPausing(null))
                   }}
                 >
-                  {pausing === v.row.nodeId ? '…' : '⏻'}
+                  {pausing === v.row.nodeId ? (
+                    <span className="ui-spinner" aria-hidden />
+                  ) : (
+                    <IconPower />
+                  )}
                 </button>
               )
             })()}

--- a/src/renderer/components/SessionMemoryPanel.tsx
+++ b/src/renderer/components/SessionMemoryPanel.tsx
@@ -10,6 +10,7 @@
 //   3. Every row is rendered. A cap would have to announce itself.
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { IconReload } from './icons'
 import type { AgentState } from '@shared/agents/normalize'
 import { formatBytes } from '@shared/fsLimits'
 import { useAgentStatus } from '../state/agentStatus'
@@ -262,7 +263,7 @@ export function SessionMemoryPanel({
             disabled={loading}
             onClick={sweep}
           >
-            ⟳
+            <IconReload />
           </button>
         )}
       </div>

--- a/src/renderer/components/SessionMemoryPanel.tsx
+++ b/src/renderer/components/SessionMemoryPanel.tsx
@@ -10,7 +10,7 @@
 //   3. Every row is rendered. A cap would have to announce itself.
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { IconReload } from './icons'
+import { IconClose, IconReload } from './icons'
 import type { AgentState } from '@shared/agents/normalize'
 import { formatBytes } from '@shared/fsLimits'
 import { useAgentStatus } from '../state/agentStatus'
@@ -209,7 +209,7 @@ export function SessionMemoryPanel({
               aria-label={`End ${v.title}`}
               onClick={() => onKillSession(v.row.nodeId, v.orphan)}
             >
-              ×
+              <IconClose />
             </button>
             {v.row.childCount > 0 && (
               // "child processes", NOT "MCP servers": `pane_pid` is the pane's SHELL, so the count

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { AccountChip, useAccountChip } from './AccountChip'
-import { IconBellFilled, IconCircleCheck } from './icons'
+import { IconBellFilled, IconCircleCheck, IconClose } from './icons'
 import { NodeIconView } from './NodeIcon'
 import { ProjectGlyph } from './ProjectGlyph'
 import type { SessionRowVM } from '../lib/sessionList'
@@ -180,7 +180,7 @@ export function SessionRow({
               onClose()
             }}
           >
-            ×
+            <IconClose />
           </button>
         </div>
         {(row.projectName || row.cwd || row.sshHost || stateAgeLabel) && (

--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -21,7 +21,7 @@ import { sidebarEmptyState, sidebarFilterKeyAction } from '../lib/sidebarFilter'
 import { SessionRow } from './SessionRow'
 import { ProjectGlyph } from './ProjectGlyph'
 import { ClosedHistorySection } from './ClosedHistorySection'
-import { IconBellFilled, IconCircleCheck, IconPin } from './icons'
+import { IconBellFilled, IconCircleCheck, IconClose, IconPin } from './icons'
 import { useProjects } from '../state/projects'
 import { useSettings } from '../state/settings'
 import { useAgentStatus } from '../state/agentStatus'
@@ -496,7 +496,7 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
             <IconPin />
           </button>
           <button title="Close" onClick={props.onClose}>
-            ×
+            <IconClose />
           </button>
         </div>
       </div>

--- a/src/renderer/components/ShortcutCaptureBanner.test.tsx
+++ b/src/renderer/components/ShortcutCaptureBanner.test.tsx
@@ -68,6 +68,9 @@ const body = (): string | undefined =>
   host.querySelector<HTMLElement>('.announce-banner__body')?.textContent ?? undefined
 const btn = (label: string): HTMLButtonElement =>
   [...host.querySelectorAll('button')].find((b) => b.textContent === label) as HTMLButtonElement
+/** The dismiss button carries an icon, not a label, so it is addressed by its title. */
+const btnByTitle = (title: string): HTMLButtonElement =>
+  host.querySelector(`button[title="${title}"]`) as HTMLButtonElement
 const click = (el: HTMLElement): void => {
   act(() => el.dispatchEvent(new MouseEvent('click', { bubbles: true })))
 }
@@ -153,10 +156,10 @@ describe('ShortcutCaptureBanner', () => {
     expect(banner()).toBeNull()
   })
 
-  it('the ✕ dismisses without opening Settings', () => {
+  it('the dismiss button dismisses without opening Settings', () => {
     render()
     capture('app.commandPalette')
-    click(btn('✕'))
+    click(btnByTitle('Dismiss'))
     expect(banner()).toBeNull()
     expect(onOpenShortcuts).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/ShortcutCaptureBanner.tsx
+++ b/src/renderer/components/ShortcutCaptureBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IconClose } from './icons'
 import type { CommandId } from '@shared/keybindings'
 import { shortcutCaptureCopy } from './shortcutCaptureCopy'
 
@@ -65,7 +66,7 @@ export function ShortcutCaptureBanner({
         Open Shortcuts
       </button>
       <button className="announce-banner__close" title="Dismiss" onClick={() => setCurrent(null)}>
-        ✕
+        <IconClose />
       </button>
     </div>
   )

--- a/src/renderer/components/ShortcutCaptureBanner.tsx
+++ b/src/renderer/components/ShortcutCaptureBanner.tsx
@@ -65,7 +65,7 @@ export function ShortcutCaptureBanner({
       >
         Open Shortcuts
       </button>
-      <button className="announce-banner__close" title="Dismiss" onClick={() => setCurrent(null)}>
+      <button className="announce-banner__close" title="Dismiss" aria-label="Dismiss" onClick={() => setCurrent(null)}>
         <IconClose />
       </button>
     </div>

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -44,6 +44,7 @@ import { isMacPlatform, keyLabel } from '@shared/platform-utils'
 import { isBrowserRuntime } from '../bridge/runtime'
 import { effectiveBindings } from '../lib/keybindingOverrides'
 import { useSettings } from '../state/settings'
+import { IconClose } from './icons'
 
 export interface ShortcutsPanelProps {
   onClose: () => void
@@ -222,7 +223,7 @@ export function ShortcutsPanel({ onClose, onCustomize }: ShortcutsPanelProps) {
         <div className="shortcuts__head">
           <h2>Keyboard shortcuts</h2>
           <button className="drawer__close" onClick={onClose}>
-            ×
+            <IconClose />
           </button>
         </div>
         <div className="shortcuts__body">

--- a/src/renderer/components/ShortcutsPanel.tsx
+++ b/src/renderer/components/ShortcutsPanel.tsx
@@ -222,7 +222,7 @@ export function ShortcutsPanel({ onClose, onCustomize }: ShortcutsPanelProps) {
       <div className="shortcuts" onClick={(e) => e.stopPropagation()}>
         <div className="shortcuts__head">
           <h2>Keyboard shortcuts</h2>
-          <button className="drawer__close" onClick={onClose}>
+          <button className="drawer__close" aria-label="Close" onClick={onClose}>
             <IconClose />
           </button>
         </div>

--- a/src/renderer/components/SourceControlPanel.tsx
+++ b/src/renderer/components/SourceControlPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { IconClose, IconMore, IconSparkle, IconUndo } from './icons'
 import { createPortal } from 'react-dom'
 import type { FsApi, GitFileChange, GitResult, GitStatus } from '@shared/types'
 import { gitignoreAdd } from '@shared/gitignore'
@@ -305,7 +306,7 @@ export function SourceControlPanel({
           <span className="scm-row-actions">
             {!staged && (
               <button className="scm-iconbtn" title="Discard changes" onClick={() => discard(f)}>
-                ↩
+                <IconUndo />
               </button>
             )}
             <button
@@ -420,7 +421,7 @@ export function SourceControlPanel({
         <div className="drawer__head">
           <h2>Source Control</h2>
           <button className="drawer__close" onClick={onClose}>
-            ×
+            <IconClose />
           </button>
         </div>
 
@@ -480,7 +481,7 @@ export function SourceControlPanel({
                   setMoreMenu({ x: r.right - 200, y: r.bottom + 4 })
                 }}
               >
-                ⋯
+                <IconMore />
               </button>
             </div>
 
@@ -500,7 +501,7 @@ export function SourceControlPanel({
                       useScmDraft.getState().clearError(draftKey)
                     }}
                   >
-                    ×
+                    <IconClose />
                   </button>
                 </div>
               )}
@@ -537,7 +538,7 @@ export function SourceControlPanel({
                     aria-label="Generate commit message"
                     onClick={generate}
                   >
-                    ✦
+                    <IconSparkle />
                   </button>
                 </div>
                 <button

--- a/src/renderer/components/SourceControlPanel.tsx
+++ b/src/renderer/components/SourceControlPanel.tsx
@@ -420,7 +420,7 @@ export function SourceControlPanel({
       <aside className="drawer scm" onClick={(e) => e.stopPropagation()}>
         <div className="drawer__head">
           <h2>Source Control</h2>
-          <button className="drawer__close" onClick={onClose}>
+          <button className="drawer__close" aria-label="Close" onClick={onClose}>
             <IconClose />
           </button>
         </div>

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -12,7 +12,7 @@ import { sessionCount, sessionForProject, useProjectSession } from '../session/s
 import { tabClickAction } from '../session/relay-tab'
 import { useMenuFlip } from '../ui/useMenuFlip'
 import { commandTooltip } from '../lib/keybindingOverrides'
-import { IconCanvasView, IconKanban } from './icons'
+import { IconCanvasView, IconChevronDown, IconKanban, IconPlus } from './icons'
 import { ProjectGlyph } from './ProjectGlyph'
 import {
   ALL_PERMISSION_MODES,
@@ -410,7 +410,7 @@ export function TabBar({
                       else openMenu(p.id, e.currentTarget)
                     }}
                   >
-                    ⌄
+                    <IconChevronDown />
                   </button>
                 )}
               </div>
@@ -424,7 +424,7 @@ export function TabBar({
             aria-label="New project"
             onClick={onOpenWelcome}
           >
-            +
+            <IconPlus />
           </button>
         </div>
       </div>

--- a/src/renderer/components/TmuxBanner.tsx
+++ b/src/renderer/components/TmuxBanner.tsx
@@ -111,7 +111,7 @@ export function TmuxBanner({ onInstall }: { onInstall: (command: string) => void
           {phase === 'failed' ? 'Retry' : (status.installLabel ?? 'Install tmux')}
         </button>
       )}
-      <button className="announce-banner__close" title="Dismiss" onClick={() => setDismissed(true)}>
+      <button className="announce-banner__close" title="Dismiss" aria-label="Dismiss" onClick={() => setDismissed(true)}>
         <IconClose />
       </button>
     </div>

--- a/src/renderer/components/TmuxBanner.tsx
+++ b/src/renderer/components/TmuxBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconClose } from './icons'
 import type { TmuxStatus } from '@shared/types'
 import { localSession } from '../session/localSession'
 
@@ -111,7 +112,7 @@ export function TmuxBanner({ onInstall }: { onInstall: (command: string) => void
         </button>
       )}
       <button className="announce-banner__close" title="Dismiss" onClick={() => setDismissed(true)}>
-        ✕
+        <IconClose />
       </button>
     </div>
   )

--- a/src/renderer/components/Tooltip.test.ts
+++ b/src/renderer/components/Tooltip.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { tooltipAnchor, tooltipClass, type TooltipPlacement } from './Tooltip'
+
+/**
+ * The anchor and the `.tooltip--*` transform are two halves of one position: the anchor says which
+ * point the bubble is pinned to, the CSS says which corner of the bubble lands on it. Change one
+ * without the other and the bubble drifts by its own width or height, which renders fine and looks
+ * merely misaligned. These pin which edge each placement reads, so that pairing stays deliberate.
+ */
+
+const RECT = { top: 100, right: 50, left: 20, width: 30, height: 30 }
+
+describe('tooltipAnchor', () => {
+  it('pins a horizontal center above the trigger for top', () => {
+    expect(tooltipAnchor(RECT, 'top')).toEqual({ x: 35, y: 94 })
+  })
+
+  it('pins a horizontal center below the trigger for bottom', () => {
+    expect(tooltipAnchor(RECT, 'bottom')).toEqual({ x: 35, y: 136 })
+  })
+
+  it('pins the left edge beside the trigger, vertically centered, for right', () => {
+    expect(tooltipAnchor(RECT, 'right')).toEqual({ x: 56, y: 115 })
+  })
+
+  it('offsets away from the trigger on the axis it opens along, and only that axis', () => {
+    expect(tooltipAnchor(RECT, 'top').x).toBe(tooltipAnchor(RECT, 'bottom').x)
+    expect(tooltipAnchor(RECT, 'right').y).toBe(RECT.top + RECT.height / 2)
+  })
+})
+
+describe('tooltipClass', () => {
+  it('leaves bottom on the base rule, since that is what the base rule already does', () => {
+    expect(tooltipClass('bottom')).toBe('tooltip')
+  })
+
+  it('adds one modifier per other placement', () => {
+    const placements: TooltipPlacement[] = ['top', 'right']
+    for (const placement of placements) {
+      expect(tooltipClass(placement)).toBe(`tooltip tooltip--${placement}`)
+    }
+  })
+})

--- a/src/renderer/components/Tooltip.tsx
+++ b/src/renderer/components/Tooltip.tsx
@@ -5,10 +5,13 @@ interface TooltipProps {
   label: string
   children: ReactNode
   delay?: number
+  /** Which side of the trigger the bubble opens on. Chrome that hugs the bottom of the window (the
+   *  dock) must open upward: below it, the bubble lands off-screen. */
+  placement?: 'top' | 'bottom'
 }
 
 /** A custom styled tooltip (portal, fixed-positioned) shown on hover after a short delay. */
-export function Tooltip({ label, children, delay = 350 }: TooltipProps) {
+export function Tooltip({ label, children, delay = 350, placement = 'bottom' }: TooltipProps) {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -17,7 +20,10 @@ export function Tooltip({ label, children, delay = 350 }: TooltipProps) {
     if (timer.current) clearTimeout(timer.current)
     timer.current = setTimeout(() => {
       const r = el.getBoundingClientRect()
-      setPos({ x: r.left + r.width / 2, y: r.bottom + 6 })
+      setPos({
+        x: r.left + r.width / 2,
+        y: placement === 'top' ? r.top - 6 : r.bottom + 6
+      })
     }, delay)
   }
 
@@ -31,7 +37,10 @@ export function Tooltip({ label, children, delay = 350 }: TooltipProps) {
       {children}
       {pos &&
         createPortal(
-          <div className="tooltip" style={{ left: pos.x, top: pos.y }}>
+          <div
+            className={`tooltip${placement === 'top' ? ' tooltip--top' : ''}`}
+            style={{ left: pos.x, top: pos.y }}
+          >
             {label}
           </div>,
           document.body

--- a/src/renderer/components/Tooltip.tsx
+++ b/src/renderer/components/Tooltip.tsx
@@ -4,11 +4,51 @@ import { createPortal } from 'react-dom'
 /** How close the bubble may come to the window edge before it is slid back inward. */
 const EDGE_MARGIN = 8
 
+/** Gap between the trigger's edge and the bubble, on whichever axis the placement opens along. */
+const TOOLTIP_OFFSET = 6
+
+/** Which side of the trigger the bubble opens on. Chrome that hugs the bottom of the window (the
+ *  dock) must open upward: below it, the bubble lands off-screen. Chrome stacked vertically against
+ *  the left edge (the canvas controls) opens sideways, where an upward bubble would cover the
+ *  button above the one being pointed at. */
+export type TooltipPlacement = 'top' | 'bottom' | 'right'
+
 interface TooltipOptions {
   delay?: number
-  /** Which side of the trigger the bubble opens on. Chrome that hugs the bottom of the window (the
-   *  dock) must open upward: below it, the bubble lands off-screen. */
-  placement?: 'top' | 'bottom'
+  placement?: TooltipPlacement
+}
+
+/**
+ * The point the bubble is pinned to, in viewport coordinates. It is only half the position: the
+ * matching `.tooltip--*` rule supplies the transform that pulls the bubble off that point, so the
+ * two must agree. `top`/`bottom` pin a horizontal CENTER and shift the bubble up or down; `right`
+ * pins its LEFT edge and centers it vertically instead.
+ */
+export function tooltipAnchor(
+  rect: { top: number; right: number; left: number; width: number; height: number },
+  placement: TooltipPlacement
+): { x: number; y: number } {
+  if (placement === 'right') {
+    return { x: rect.right + TOOLTIP_OFFSET, y: rect.top + rect.height / 2 }
+  }
+  return {
+    x: rect.left + rect.width / 2,
+    y: placement === 'top' ? rect.top - TOOLTIP_OFFSET : rect.top + rect.height + TOOLTIP_OFFSET
+  }
+}
+
+/** `bottom` is what the base rule already does, so it takes no modifier. */
+export function tooltipClass(placement: TooltipPlacement): string {
+  return placement === 'bottom' ? 'tooltip' : `tooltip tooltip--${placement}`
+}
+
+/**
+ * How much of the bubble sits on either side of `left`, which is what the edge clamp has to know:
+ * a centered placement spends half its width each way, `right` spends all of it trailing.
+ */
+function horizontalExtent(width: number, placement: TooltipPlacement): { leading: number; trailing: number } {
+  const leading = placement === 'right' ? 0 : width / 2
+  return { leading, trailing: width - leading }
 }
 
 interface TooltipProps extends TooltipOptions {
@@ -44,21 +84,20 @@ export function useTooltip(label: string, { delay = 350, placement = 'bottom' }:
   useLayoutEffect(() => {
     const el = bubbleRef.current
     if (!anchor || !el) return
-    const half = el.offsetWidth / 2
-    const min = EDGE_MARGIN + half
-    const max = window.innerWidth - EDGE_MARGIN - half
+    const { leading, trailing } = horizontalExtent(el.offsetWidth, placement)
+    const min = EDGE_MARGIN + leading
+    const max = window.innerWidth - EDGE_MARGIN - trailing
     const next = min > max ? window.innerWidth / 2 : Math.min(Math.max(anchor.x, min), max)
     if (next !== left) setLeft(next)
-  }, [anchor, left])
+  }, [anchor, left, placement])
 
   const show = (e: React.MouseEvent): void => {
     const el = e.currentTarget as HTMLElement
     if (timer.current) clearTimeout(timer.current)
     timer.current = setTimeout(() => {
-      const r = el.getBoundingClientRect()
-      const x = r.left + r.width / 2
-      setLeft(x)
-      setAnchor({ x, y: placement === 'top' ? r.top - 6 : r.bottom + 6 })
+      const next = tooltipAnchor(el.getBoundingClientRect(), placement)
+      setLeft(next.x)
+      setAnchor(next)
     }, delay)
   }
 
@@ -74,7 +113,7 @@ export function useTooltip(label: string, { delay = 350, placement = 'bottom' }:
       createPortal(
         <div
           ref={bubbleRef}
-          className={`tooltip${placement === 'top' ? ' tooltip--top' : ''}`}
+          className={tooltipClass(placement)}
           style={{ left, top: anchor.y }}
         >
           {label}

--- a/src/renderer/components/Tooltip.tsx
+++ b/src/renderer/components/Tooltip.tsx
@@ -1,50 +1,97 @@
-import { useRef, useState, type ReactNode } from 'react'
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 
-interface TooltipProps {
-  label: string
-  children: ReactNode
+/** How close the bubble may come to the window edge before it is slid back inward. */
+const EDGE_MARGIN = 8
+
+interface TooltipOptions {
   delay?: number
   /** Which side of the trigger the bubble opens on. Chrome that hugs the bottom of the window (the
    *  dock) must open upward: below it, the bubble lands off-screen. */
   placement?: 'top' | 'bottom'
 }
 
-/** A custom styled tooltip (portal, fixed-positioned) shown on hover after a short delay. */
-export function Tooltip({ label, children, delay = 350, placement = 'bottom' }: TooltipProps) {
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+interface TooltipProps extends TooltipOptions {
+  label: string
+  children: ReactNode
+}
 
-  const show = (e: React.MouseEvent) => {
+interface TooltipTrigger {
+  /** Spread onto the trigger element. */
+  triggerProps: {
+    onMouseEnter: (e: React.MouseEvent) => void
+    onMouseLeave: () => void
+    onMouseDown: () => void
+  }
+  /** Render anywhere in the tree: the bubble portals to `document.body` regardless. */
+  bubble: ReactNode
+}
+
+/**
+ * The tooltip without its wrapper element, for a trigger that cannot take one: a React Flow
+ * `Handle` positions itself with `translate(±50%, ±50%)` against the node, so a wrapper risks
+ * moving it. The props compose rather than replace, since `Handle` destructures `onMouseDown` and
+ * calls it from its own pointer-down handler.
+ */
+export function useTooltip(label: string, { delay = 350, placement = 'bottom' }: TooltipOptions = {}): TooltipTrigger {
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null)
+  const [left, setLeft] = useState(0)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const bubbleRef = useRef<HTMLDivElement>(null)
+
+  // A centered bubble runs off-screen for a long label near the window edge (a link handle carries
+  // a whole sentence). `nowrap` makes the width independent of `left`, so this settles in one pass.
+  useLayoutEffect(() => {
+    const el = bubbleRef.current
+    if (!anchor || !el) return
+    const half = el.offsetWidth / 2
+    const min = EDGE_MARGIN + half
+    const max = window.innerWidth - EDGE_MARGIN - half
+    const next = min > max ? window.innerWidth / 2 : Math.min(Math.max(anchor.x, min), max)
+    if (next !== left) setLeft(next)
+  }, [anchor, left])
+
+  const show = (e: React.MouseEvent): void => {
     const el = e.currentTarget as HTMLElement
     if (timer.current) clearTimeout(timer.current)
     timer.current = setTimeout(() => {
       const r = el.getBoundingClientRect()
-      setPos({
-        x: r.left + r.width / 2,
-        y: placement === 'top' ? r.top - 6 : r.bottom + 6
-      })
+      const x = r.left + r.width / 2
+      setLeft(x)
+      setAnchor({ x, y: placement === 'top' ? r.top - 6 : r.bottom + 6 })
     }, delay)
   }
 
-  const hide = () => {
+  const hide = (): void => {
     if (timer.current) clearTimeout(timer.current)
-    setPos(null)
+    setAnchor(null)
   }
 
+  return {
+    triggerProps: { onMouseEnter: show, onMouseLeave: hide, onMouseDown: hide },
+    bubble:
+      anchor &&
+      createPortal(
+        <div
+          ref={bubbleRef}
+          className={`tooltip${placement === 'top' ? ' tooltip--top' : ''}`}
+          style={{ left, top: anchor.y }}
+        >
+          {label}
+        </div>,
+        document.body
+      )
+  }
+}
+
+/** A custom styled tooltip (portal, fixed-positioned) shown on hover after a short delay. */
+export function Tooltip({ label, children, delay, placement }: TooltipProps) {
+  const { triggerProps, bubble } = useTooltip(label, { delay, placement })
+
   return (
-    <span className="tooltip-trigger nodrag" onMouseEnter={show} onMouseLeave={hide} onMouseDown={hide}>
+    <span className="tooltip-trigger nodrag" {...triggerProps}>
       {children}
-      {pos &&
-        createPortal(
-          <div
-            className={`tooltip${placement === 'top' ? ' tooltip--top' : ''}`}
-            style={{ left: pos.x, top: pos.y }}
-          >
-            {label}
-          </div>,
-          document.body
-        )}
+      {bubble}
     </span>
   )
 }

--- a/src/renderer/components/UpdateCard.tsx
+++ b/src/renderer/components/UpdateCard.tsx
@@ -162,7 +162,7 @@ export function UpdateCard(): JSX.Element | null {
           </button>
         )}
         {canDismiss && (
-          <button className="update-card__icon" title="Dismiss" onClick={dismiss}>
+          <button className="update-card__icon" title="Dismiss" aria-label="Dismiss" onClick={dismiss}>
             <IconClose />
           </button>
         )}

--- a/src/renderer/components/UpdateCard.tsx
+++ b/src/renderer/components/UpdateCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconClose } from './icons'
 import type { UpdateProgress } from '@shared/types'
 
 // The full updater lifecycle as one status union, driving a fixed bottom-right card.
@@ -162,7 +163,7 @@ export function UpdateCard(): JSX.Element | null {
         )}
         {canDismiss && (
           <button className="update-card__icon" title="Dismiss" onClick={dismiss}>
-            ✕
+            <IconClose />
           </button>
         )}
       </div>

--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { IconReload } from './icons'
 import type { ClaudeUsage, ProviderUsage, RemoteAccountUsage, UsageLimit } from '@shared/types'
 import { AGENT_CONFIG } from '@shared/agents/config'
 import { useSettings } from '../state/settings'
@@ -611,7 +612,7 @@ export function UsageIndicator({
         disabled={refreshing}
         title="Refresh usage"
       >
-        ⟳
+        <IconReload />
       </button>
     </div>
   )

--- a/src/renderer/components/WelcomeScreen.tsx
+++ b/src/renderer/components/WelcomeScreen.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { IconClose } from './icons'
 import type { ProjectIcon } from '@shared/project-icon'
 import { filterClosedProjects } from '../lib/closedHistory'
 import { ProjectGlyph } from './ProjectGlyph'
@@ -83,15 +84,20 @@ export function WelcomeScreen({
             position: 'absolute',
             top: 16,
             right: 20,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 26,
+            height: 26,
+            padding: 0,
             background: 'transparent',
             border: 'none',
             color: 'rgba(235,235,245,0.6)',
-            fontSize: 26,
             lineHeight: 1,
             cursor: 'pointer'
           }}
         >
-          ×
+          <IconClose />
         </button>
       )}
       <div className="welcome__brand">
@@ -219,7 +225,7 @@ export function WelcomeScreen({
                       onDeleteClosed(p.id)
                     }}
                   >
-                    ×
+                    <IconClose />
                   </button>
                 )}
               </div>

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -64,6 +64,12 @@ export const IconPlus = () => (
   </svg>
 )
 
+export const IconMinus = () => (
+  <svg {...S}>
+    <path d="M5 12h14" />
+  </svg>
+)
+
 export const IconSelectAll = () => (
   <svg {...S}>
     <path d="M4 8V6a2 2 0 0 1 2-2h2M16 4h2a2 2 0 0 1 2 2v2M20 16v2a2 2 0 0 1-2 2h-2M8 20H6a2 2 0 0 1-2-2v-2" />
@@ -273,10 +279,10 @@ export const IconMic = () => (
 
 export const IconSessions = () => (
   <svg {...S}>
-    <rect x="3" y="4" width="18" height="5" rx="1.5" />
-    <rect x="3" y="11" width="18" height="5" rx="1.5" />
-    <line x1="6" y1="6.5" x2="6" y2="6.5" />
-    <line x1="6" y1="13.5" x2="6" y2="13.5" />
+    <rect x="3" y="4" width="18" height="6" rx="2" />
+    <rect x="3" y="14" width="18" height="6" rx="2" />
+    <circle cx="6.5" cy="7" r="0.9" fill="currentColor" stroke="none" />
+    <circle cx="6.5" cy="17" r="0.9" fill="currentColor" stroke="none" />
   </svg>
 )
 
@@ -294,23 +300,19 @@ export const IconCircleCheck = () => (
   </svg>
 )
 
-/* Filled padlocks (like the bell below): they live in the React Flow controls, whose
-   default icons are filled glyphs capped at 12px — a stroked lock collapses there. */
+/* Stroked padlocks: the canvas lock moved out of the React Flow controls (whose filled 12px
+   glyph set is why these used to be filled) into the dock, where every icon is an outline. */
 export const IconLock = () => (
-  <svg width={16} height={16} viewBox="0 0 24 24" fill="currentColor" stroke="none">
-    <path
-      fillRule="evenodd"
-      d="M6 10V7a6 6 0 0 1 12 0v3h.5A2.5 2.5 0 0 1 21 12.5v7A2.5 2.5 0 0 1 18.5 22h-13A2.5 2.5 0 0 1 3 19.5v-7A2.5 2.5 0 0 1 5.5 10H6zm2.4 0h7.2V7a3.6 3.6 0 0 0-7.2 0v3zM12 14.2a1.8 1.8 0 0 0-.9 3.36V19a.9.9 0 0 0 1.8 0v-1.44a1.8 1.8 0 0 0-.9-3.36z"
-    />
+  <svg {...S}>
+    <rect x="4.5" y="10.5" width="15" height="10.5" rx="2.5" />
+    <path d="M8 10.5V7a4 4 0 0 1 8 0v3.5" />
   </svg>
 )
 
 export const IconUnlock = () => (
-  <svg width={16} height={16} viewBox="0 0 24 24" fill="currentColor" stroke="none">
-    <path
-      fillRule="evenodd"
-      d="M6 10V7a6 6 0 0 1 11.7-1.9l-2.3.8A3.6 3.6 0 0 0 8.4 7v3h10.1A2.5 2.5 0 0 1 21 12.5v7A2.5 2.5 0 0 1 18.5 22h-13A2.5 2.5 0 0 1 3 19.5v-7A2.5 2.5 0 0 1 5.5 10H6zM12 14.2a1.8 1.8 0 0 0-.9 3.36V19a.9.9 0 0 0 1.8 0v-1.44a1.8 1.8 0 0 0-.9-3.36z"
-    />
+  <svg {...S}>
+    <rect x="4.5" y="10.5" width="15" height="10.5" rx="2.5" />
+    <path d="M8 10.5V7a4 4 0 0 1 7.7-1.5" />
   </svg>
 )
 
@@ -337,6 +339,24 @@ export const IconKanban = () => (
     <rect x="1.5" y="2.5" width="3.6" height="11" rx="1" />
     <rect x="6.2" y="2.5" width="3.6" height="7.5" rx="1" />
     <rect x="10.9" y="2.5" width="3.6" height="5" rx="1" />
+  </svg>
+)
+
+export const IconChevronDown = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M4 6.5L8 10.5l4-4" />
+  </svg>
+)
+
+export const IconChevronRight = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M6.5 4l4 4-4 4" />
+  </svg>
+)
+
+export const IconClose = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+    <path d="M4 4l8 8M12 4l-8 8" />
   </svg>
 )
 

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -263,6 +263,15 @@ export const IconExternal = () => (
   </svg>
 )
 
+/** Box with an arrow leaving it: hand this off to another app (the system browser). Distinct from
+ *  IconExternal above, whose two corner brackets read as expand/fullscreen. */
+export const IconOpenExternal = () => (
+  <svg {...S}>
+    <path d="M18 13v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h5" />
+    <path d="M14 4h6v6M20 4l-8 8" />
+  </svg>
+)
+
 export const IconAgent = () => (
   <svg {...S}>
     <path d="M12 3l1.8 4.2L18 9l-4.2 1.8L12 15l-1.8-4.2L6 9l4.2-1.8z" />
@@ -342,21 +351,96 @@ export const IconKanban = () => (
   </svg>
 )
 
+/** Four-point sparkle: the "name this with AI" action. Replaces a literal ✦, which sat on a text
+ *  baseline among the header's SVGs and could not be centered with them. */
+export const IconSparkle = () => (
+  <svg {...S}>
+    <path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z" />
+    <path d="M18.5 15.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7z" />
+  </svg>
+)
+
+/** Arrow entering a folder: move this node's session into the worktree bound to its group. */
+export const IconMoveTo = () => (
+  <svg {...S}>
+    <path d="M4 7a2 2 0 0 1 2-2h3.5l1.5 2H18a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z" />
+    <path d="M9 13h6M12.5 10.5l2.5 2.5-2.5 2.5" />
+  </svg>
+)
+
+/** Solid play triangle: run a queued launch now, replay a loop iteration. Filled on purpose, the
+ *  way a transport control is drawn; an outlined triangle reads as a shape, not as "go". */
+export const IconPlay = () => (
+  <svg {...S} fill="currentColor" stroke="none">
+    <path d="M8 5.5v13l11-6.5z" />
+  </svg>
+)
+
+export const IconArrowUp = () => (
+  <svg {...S}>
+    <path d="M12 19V5M6 11l6-6 6 6" />
+  </svg>
+)
+
+export const IconArrowDown = () => (
+  <svg {...S}>
+    <path d="M12 5v14M6 13l6 6 6-6" />
+  </svg>
+)
+
+export const IconArrowLeft = () => (
+  <svg {...S}>
+    <path d="M19 12H5M11 6l-6 6 6 6" />
+  </svg>
+)
+
+export const IconArrowRight = () => (
+  <svg {...S}>
+    <path d="M5 12h14M13 6l6 6-6 6" />
+  </svg>
+)
+
+/** Undo curve: discard a file's changes. Same shape as the dock's undo, which is the same idea. */
+export const IconUndo = () => (
+  <svg {...S}>
+    <path d="M9 14L4 9l5-5M4 9h10.5a5.5 5.5 0 0 1 0 11H10" />
+  </svg>
+)
+
+/** Horizontal ellipsis: opens an overflow menu. */
+export const IconMore = () => (
+  <svg {...S} fill="currentColor" stroke="none">
+    <circle cx="5.5" cy="12" r="1.6" />
+    <circle cx="12" cy="12" r="1.6" />
+    <circle cx="18.5" cy="12" r="1.6" />
+  </svg>
+)
+
+/** Bare checkmark. IconCircleCheck is the badged variant and means something else: a completed
+ *  thing, not a selected one. */
+export const IconCheck = () => (
+  <svg {...S}>
+    <path d="M5 12.5l4.5 4.5L19 7" />
+  </svg>
+)
+
+/* On the shared 24 viewBox like every icon above, not a 16 one: two viewBoxes in one row cannot be
+   made to match by setting equal pixel sizes, because the shapes fill their boxes differently. */
 export const IconChevronDown = () => (
-  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M4 6.5L8 10.5l4-4" />
+  <svg {...S}>
+    <path d="M6 9.5l6 6 6-6" />
   </svg>
 )
 
 export const IconChevronRight = () => (
-  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M6.5 4l4 4-4 4" />
+  <svg {...S}>
+    <path d="M9.5 6l6 6-6 6" />
   </svg>
 )
 
 export const IconClose = () => (
-  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
-    <path d="M4 4l8 8M12 4l-8 8" />
+  <svg {...S}>
+    <path d="M6 6l12 12M18 6L6 18" />
   </svg>
 )
 

--- a/src/renderer/components/kanban/CardMetaBar.tsx
+++ b/src/renderer/components/kanban/CardMetaBar.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { IconClose } from '../icons'
 import type { BoardLogAuthor, KanbanPriority, ProjectKanban } from '@shared/types'
 import { cardMeta, labelsForCard, setCardDue, setCardPriority, toggleAssignee } from '../../lib/kanban'
 import { LabelChips } from './LabelChips'
@@ -143,7 +144,7 @@ export function CardMetaBar({ nodeId, board, onChange }: CardMetaBarProps) {
               title="Clear due date"
               onClick={() => onChange(setCardDue(board, nodeId, null))}
             >
-              ✕
+              <IconClose />
             </button>
           )}
         </div>

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -1,7 +1,16 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isTopDialog, nextDialogId, popDialog, pushDialog } from '../dialog-stack'
-import { IconChat, IconMic, IconSearch, IconSmiley } from '../icons'
+import {
+  IconChat,
+  IconClose,
+  IconExternal,
+  IconMaximize,
+  IconMic,
+  IconRestoreSize,
+  IconSearch,
+  IconSmiley
+} from '../icons'
 import { NodeIconView } from '../NodeIcon'
 import { nodeIconDialog } from '../NodeIconPicker'
 import { applyIconChoice } from '../../lib/nodeIconChoice'
@@ -359,13 +368,13 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
             aria-pressed={maximized}
             onClick={() => setMaximized(!maximized)}
           >
-            {maximized ? '❐' : '⤢'}
+            {maximized ? <IconRestoreSize /> : <IconMaximize />}
           </button>
           <button className="kanban-modal__action" title="Open on canvas" onClick={onOpenCanvas}>
-            ↗
+            <IconExternal />
           </button>
           <button className="kanban-modal__action" title="Close" onClick={onClose}>
-            ✕
+            <IconClose />
           </button>
         </div>
         <CardMetaBar nodeId={session.id} board={board} onChange={onChangeBoard} />

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -1,5 +1,6 @@
 import { Fragment, memo, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { IconClose } from '../icons'
 import type { KanbanColumn as KanbanColumnT } from '@shared/types'
 import { NODE_COLORS } from '../../state/workspace'
 import type { KanbanCreateChoice, KanbanCreateOption } from './KanbanView'
@@ -167,7 +168,7 @@ export const KanbanColumn = memo(function KanbanColumn({
             title="Delete column (cards return to Ungrouped)"
             onClick={() => onDelete?.(column.id)}
           >
-            ✕
+            <IconClose />
           </button>
         )}
       </div>

--- a/src/renderer/components/kanban/LabelPicker.tsx
+++ b/src/renderer/components/kanban/LabelPicker.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
+import { IconClose, IconMore } from '../icons'
 import type { KanbanLabelColor, ProjectKanban } from '@shared/types'
 import {
   autoLabelColor,
@@ -111,7 +112,7 @@ export function LabelPicker({
             <span key={l.id} className="kanban-label-chip" style={{ background: s.bg, color: s.fg }}>
               {l.name || 'Label'}
               <button className="kanban-label-chip__x" title="Remove" onClick={() => toggle(l.id)}>
-                ×
+                <IconClose />
               </button>
             </span>
           )
@@ -147,7 +148,7 @@ export function LabelPicker({
                 title="Edit label"
                 onClick={() => setEditing(l.id)}
               >
-                ⋯
+                <IconMore />
               </button>
             </div>
           )

--- a/src/renderer/components/settings/ProjectIconPicker.tsx
+++ b/src/renderer/components/settings/ProjectIconPicker.tsx
@@ -259,7 +259,7 @@ export function ProjectIconPicker({
             <div className="flex flex-col gap-2">
               <button
                 type="button"
-                className="flex w-full items-center justify-center gap-2 rounded-lg bg-[color:var(--accent)] px-3 py-2 text-[13px] font-medium text-white transition-opacity hover:opacity-90"
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-transparent bg-[color:var(--accent)] px-3 py-2 text-[13px] font-medium text-white transition-opacity hover:opacity-90"
                 onClick={() => void onUseGithubAvatar()}
               >
                 <Github className="size-4" />

--- a/src/renderer/components/settings/sections/AccountsSection.tsx
+++ b/src/renderer/components/settings/sections/AccountsSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IconClose } from '../../icons'
 import type { ClaudeAccount } from '@shared/types'
 import type { CodexAccount } from '@shared/codex-account'
 import { E_UNSUPPORTED } from '@shared/rpc'
@@ -473,7 +474,7 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
                 aria-label="Remove Codex account"
                 onClick={() => setPendingRemoveCodex(account)}
               >
-                ×
+                <IconClose />
               </Button>
             </div>
           )
@@ -780,7 +781,7 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
                     aria-label={account.configDir ? 'Unlink account' : 'Remove account'}
                     onClick={() => setPendingRemove(account)}
                   >
-                    ×
+                    <IconClose />
                   </Button>
                 </div>
               </div>

--- a/src/renderer/components/settings/sections/ShortcutsSection.tsx
+++ b/src/renderer/components/settings/sections/ShortcutsSection.tsx
@@ -34,6 +34,7 @@
  * `speech.dictation` into the legacy `settings.speech.shortcut` field for one release).
  */
 import { useMemo, useState } from 'react'
+import { IconClose } from '../../icons'
 import {
   bindingIdentity,
   COMMANDS_BY_ID,
@@ -321,7 +322,7 @@ function Chips({
               onClick={() => onRemove(i)}
               className="cursor-pointer border-0 bg-transparent px-0.5 text-[12px] leading-none text-muted opacity-0 group-hover/row:opacity-60 hover:!opacity-100 focus-visible:opacity-100"
             >
-              ×
+              <IconClose />
             </button>
           ) : null}
         </span>

--- a/src/renderer/nodes/BrowserNode.tsx
+++ b/src/renderer/nodes/BrowserNode.tsx
@@ -1,4 +1,5 @@
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
+import { Tooltip } from '../components/Tooltip'
 import { IconClose } from '../components/icons'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
@@ -50,9 +51,11 @@ export default function BrowserNode({ id, data, selected }: NodeProps<CanvasNode
             drives a lease, in every case today). */}
         <BrowserDrivingIndicator nodeId={id} />
         <span className="term-node__spacer" />
-        <button className="term-node__close" title="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
-          <IconClose />
-        </button>
+        <Tooltip label="Close">
+          <button className="term-node__close" aria-label="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
+            <IconClose />
+          </button>
+        </Tooltip>
       </div>
 
       <div className="editor-node__body">

--- a/src/renderer/nodes/BrowserNode.tsx
+++ b/src/renderer/nodes/BrowserNode.tsx
@@ -1,4 +1,5 @@
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
+import { IconClose } from '../components/icons'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
 import { BrowserSurface } from './BrowserSurface'
@@ -50,7 +51,7 @@ export default function BrowserNode({ id, data, selected }: NodeProps<CanvasNode
         <BrowserDrivingIndicator nodeId={id} />
         <span className="term-node__spacer" />
         <button className="term-node__close" title="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
-          ×
+          <IconClose />
         </button>
       </div>
 

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconArrowLeft, IconArrowRight } from '../components/icons'
 import { searchOrUrl } from './browserUrl'
 import { BrowserStartPage } from './BrowserStartPage'
 import { useBrowserHistory } from '../state/browserHistory'
@@ -270,10 +271,10 @@ export function BrowserSurface({
     <div className="browser-surface" ref={rootRef}>
       <div className="browser-node__toolbar nodrag">
         <button className="browser-node__btn" disabled={!canBack} onClick={() => ref.current?.goBack()} title="Back">
-          ◀
+          <IconArrowLeft />
         </button>
         <button className="browser-node__btn" disabled={!canFwd} onClick={() => ref.current?.goForward()} title="Forward">
-          ▶
+          <IconArrowRight />
         </button>
         <button
           className="browser-node__btn"

--- a/src/renderer/nodes/DiffNode.tsx
+++ b/src/renderer/nodes/DiffNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Tooltip } from '../components/Tooltip'
 import { IconClose } from '../components/icons'
 import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
@@ -147,13 +148,11 @@ export function DiffNode({ id, data, selected }: NodeProps<CanvasNode>) {
         </span>
         <span className="term-node__spacer" />
         <MaximizeButton id={id} maximized={!!data.premaxRect} />
-        <button
-          className="term-node__close"
-          title="Close"
-          onClick={() => deleteElements({ nodes: [{ id }] })}
-        >
-          <IconClose />
-        </button>
+        <Tooltip label="Close">
+          <button className="term-node__close" aria-label="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
+            <IconClose />
+          </button>
+        </Tooltip>
       </div>
 
       {fileMissing ? (

--- a/src/renderer/nodes/DiffNode.tsx
+++ b/src/renderer/nodes/DiffNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconClose } from '../components/icons'
 import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import { monaco } from '../editor/monaco-setup'
@@ -151,7 +152,7 @@ export function DiffNode({ id, data, selected }: NodeProps<CanvasNode>) {
           title="Close"
           onClick={() => deleteElements({ nodes: [{ id }] })}
         >
-          ×
+          <IconClose />
         </button>
       </div>
 

--- a/src/renderer/nodes/DinoNode.tsx
+++ b/src/renderer/nodes/DinoNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Tooltip } from '../components/Tooltip'
 import { IconClose } from '../components/icons'
 import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
@@ -113,13 +114,11 @@ export function DinoNode({ id, data, selected }: NodeProps<CanvasNode>) {
             ▷ {peer.name} is playing
           </span>
         )}
-        <button
-          className="term-node__close"
-          title="Close"
-          onClick={() => deleteElements({ nodes: [{ id }] })}
-        >
-          <IconClose />
-        </button>
+        <Tooltip label="Close">
+          <button className="term-node__close" aria-label="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
+            <IconClose />
+          </button>
+        </Tooltip>
       </div>
 
       <div ref={hostRef} className="dino-node__body nodrag nowheel" tabIndex={0} />

--- a/src/renderer/nodes/DinoNode.tsx
+++ b/src/renderer/nodes/DinoNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconClose } from '../components/icons'
 import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import { useShallow } from 'zustand/react/shallow'
@@ -117,7 +118,7 @@ export function DinoNode({ id, data, selected }: NodeProps<CanvasNode>) {
           title="Close"
           onClick={() => deleteElements({ nodes: [{ id }] })}
         >
-          ×
+          <IconClose />
         </button>
       </div>
 

--- a/src/renderer/nodes/EditorNode.tsx
+++ b/src/renderer/nodes/EditorNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconClose } from '../components/icons'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import { monaco } from '../editor/monaco-setup'
@@ -304,7 +305,7 @@ export function EditorNode({ id, data, selected }: NodeProps<CanvasNode>) {
           title="Close"
           onClick={() => deleteElements({ nodes: [{ id }] })}
         >
-          ×
+          <IconClose />
         </button>
       </div>
 

--- a/src/renderer/nodes/EditorNode.tsx
+++ b/src/renderer/nodes/EditorNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Tooltip } from '../components/Tooltip'
 import { IconClose } from '../components/icons'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
@@ -282,31 +283,32 @@ export function EditorNode({ id, data, selected }: NodeProps<CanvasNode>) {
           imageDims && <span className="editor-node__dims">{imageDims}</span>
         ) : isPdf ? null : (
           <>
-            <button
-              className="editor-node__toggle"
-              title={commandTooltip('Toggle markdown preview', 'node.toggleMarkdown')}
-              onClick={togglePreview}
-            >
-              {preview ? 'Edit' : 'Preview'}
-            </button>
-            <button
-              className="editor-node__save"
-              disabled={!dirty}
-              title={hintLabel('Save (⌘S)')}
-              onClick={save}
-            >
-              Save
-            </button>
+            <Tooltip label={commandTooltip('Toggle markdown preview', 'node.toggleMarkdown')}>
+              <button
+                className="editor-node__toggle"
+                aria-label="Toggle markdown preview"
+                onClick={togglePreview}
+              >
+                {preview ? 'Edit' : 'Preview'}
+              </button>
+            </Tooltip>
+            <Tooltip label={hintLabel('Save (⌘S)')}>
+              <button className="editor-node__save" disabled={!dirty} onClick={save}>
+                Save
+              </button>
+            </Tooltip>
           </>
         )}
         <MaximizeButton id={id} maximized={!!data.premaxRect} />
-        <button
-          className="term-node__close"
-          title="Close"
-          onClick={() => deleteElements({ nodes: [{ id }] })}
-        >
-          <IconClose />
-        </button>
+        <Tooltip label="Close">
+          <button
+            className="term-node__close"
+            aria-label="Close"
+            onClick={() => deleteElements({ nodes: [{ id }] })}
+          >
+            <IconClose />
+          </button>
+        </Tooltip>
       </div>
 
       <div className="editor-node__body">

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Tooltip } from '../components/Tooltip'
 import { IconClose, IconUngroup } from '../components/icons'
 import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
@@ -165,12 +166,14 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
       />
 
       <div className="group-node__label">
-        <button
-          className="group-node__dot nodrag"
-          style={{ background: data.color }}
-          title="Color"
-          onClick={() => setShowColors((v) => !v)}
-        />
+        <Tooltip label="Color">
+          <button
+            className="group-node__dot nodrag"
+            style={{ background: data.color }}
+            aria-label="Color"
+            onClick={() => setShowColors((v) => !v)}
+          />
+        </Tooltip>
         {showColors && (
           <div className="color-popover">
             {NODE_COLORS.map((c) => (
@@ -238,6 +241,9 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
               // PROJECT lane, so it can never re-attach a worktree group's run — clicking it would
               // leave this chip failed and its nodes armed forever. Re-running here re-attaches the
               // group's lane, and a `done` from the new run releases them.
+              // Keeps a native `title` while the frame's action buttons moved to Tooltip: the
+              // bubble is `white-space: nowrap`, so these four explanatory lines would render as
+              // one bar running off the window.
               (setupRun.kind === 'setup' && setupRun.state === 'failed' ? (
                 <button
                   className={`group-node__setup group-node__setup--${setupBusy ? 'running' : 'failed'} nodrag`}
@@ -267,47 +273,55 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
                 </span>
               ))}
             {!stale && (
-              <button
-                className="group-node__wt-btn"
-                title="Merge to main"
-                onClick={() => worktreeActionHandler?.(id, 'merge')}
-              >
-                ⤴
-              </button>
+              <Tooltip label="Merge to main">
+                <button
+                  className="group-node__wt-btn"
+                  aria-label="Merge to main"
+                  onClick={() => worktreeActionHandler?.(id, 'merge')}
+                >
+                  ⤴
+                </button>
+              </Tooltip>
             )}
-            <button
-              className="group-node__wt-btn"
-              title={
+            <Tooltip
+              label={
                 stale
                   ? 'Unbind (the directory is gone — also prunes the stale git registration)'
                   : 'Unbind worktree (keeps the worktree on disk)'
               }
-              onClick={() => worktreeActionHandler?.(id, 'unbind')}
             >
-              Unbind
-            </button>
-            {!stale && (
               <button
                 className="group-node__wt-btn"
-                title="Remove worktree"
-                onClick={() => worktreeActionHandler?.(id, 'remove')}
+                onClick={() => worktreeActionHandler?.(id, 'unbind')}
               >
-                <IconClose />
+                Unbind
               </button>
+            </Tooltip>
+            {!stale && (
+              <Tooltip label="Remove worktree">
+                <button
+                  className="group-node__wt-btn"
+                  aria-label="Remove worktree"
+                  onClick={() => worktreeActionHandler?.(id, 'remove')}
+                >
+                  <IconClose />
+                </button>
+              </Tooltip>
             )}
           </div>
         )}
       </div>
 
       <div className="group-node__actions nodrag">
-        <button
-          className="group-node__ungroup"
-          title="Ungroup (keeps nodes)"
-          aria-label="Ungroup (keeps nodes)"
-          onClick={ungroup}
-        >
-          <IconUngroup />
-        </button>
+        <Tooltip label="Ungroup (keeps nodes)">
+          <button
+            className="group-node__ungroup"
+            aria-label="Ungroup (keeps nodes)"
+            onClick={ungroup}
+          >
+            <IconUngroup />
+          </button>
+        </Tooltip>
       </div>
     </div>
   )

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { IconClose } from '../components/icons'
+import { IconClose, IconUngroup } from '../components/icons'
 import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import { NODE_COLORS, ungroupNodes, type CanvasNode } from '../state/workspace'
@@ -300,12 +300,18 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
       </div>
 
       <div className="group-node__actions nodrag">
-        <button className="group-node__ungroup" title="Ungroup" onClick={ungroup}>
-          ungroup
+        <button
+          className="group-node__ungroup"
+          title="Ungroup"
+          aria-label="Ungroup"
+          onClick={ungroup}
+        >
+          <IconUngroup />
         </button>
         <button
           className="group-node__close"
           title="Remove group (keeps nodes)"
+          aria-label="Remove group"
           onClick={ungroup}
         >
           <IconClose />

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -24,7 +24,7 @@ export function setWorktreeActionHandler(
 
 /**
  * A group frame: a dashed, rounded, translucent box that contains child nodes. A floating
- * label pill (color dot + name) sits on the top border; ungroup/× appear top-right on hover.
+ * label pill (color dot + name) sits on the top border; Ungroup appears top-right on hover.
  * Children are real React Flow nodes parented to this one, so dragging the frame moves them
  * together. The frame renders behind its children (it appears first in the array).
  */
@@ -302,19 +302,11 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
       <div className="group-node__actions nodrag">
         <button
           className="group-node__ungroup"
-          title="Ungroup"
-          aria-label="Ungroup"
+          title="Ungroup (keeps nodes)"
+          aria-label="Ungroup (keeps nodes)"
           onClick={ungroup}
         >
           <IconUngroup />
-        </button>
-        <button
-          className="group-node__close"
-          title="Remove group (keeps nodes)"
-          aria-label="Remove group"
-          onClick={ungroup}
-        >
-          <IconClose />
         </button>
       </div>
     </div>

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconClose } from '../components/icons'
 import { NodeResizer, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import { NODE_COLORS, ungroupNodes, type CanvasNode } from '../state/workspace'
@@ -291,7 +292,7 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
                 title="Remove worktree"
                 onClick={() => worktreeActionHandler?.(id, 'remove')}
               >
-                ✕
+                <IconClose />
               </button>
             )}
           </div>
@@ -307,7 +308,7 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
           title="Remove group (keeps nodes)"
           onClick={ungroup}
         >
-          ×
+          <IconClose />
         </button>
       </div>
     </div>

--- a/src/renderer/nodes/LoopNode.tsx
+++ b/src/renderer/nodes/LoopNode.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { IconChevronDown, IconChevronRight, IconClose } from '../components/icons'
+import { IconChevronDown, IconChevronRight, IconClose, IconPlay } from '../components/icons'
 import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
@@ -73,7 +73,7 @@ export function LoopNode({ id, data, selected }: NodeProps<CanvasNode>) {
         {schedule && <span className="loop-node__sched">{schedule}</span>}
         {task && (
           <button className="loop-node__play" title="Run now (manual trigger)" onClick={trigger}>
-            ▶
+            <IconPlay />
           </button>
         )}
         <button

--- a/src/renderer/nodes/LoopNode.tsx
+++ b/src/renderer/nodes/LoopNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { IconChevronDown, IconChevronRight, IconClose } from '../components/icons'
 import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
@@ -64,7 +65,7 @@ export function LoopNode({ id, data, selected }: NodeProps<CanvasNode>) {
             toggle()
           }}
         >
-          {expanded ? '▾' : '▸'}
+          {expanded ? <IconChevronDown /> : <IconChevronRight />}
         </button>
         <span className="loop-node__dot" />
         <span className="loop-node__type">{label}</span>
@@ -80,7 +81,7 @@ export function LoopNode({ id, data, selected }: NodeProps<CanvasNode>) {
           title="Dismiss card (does not remove the job)"
           onClick={dismiss}
         >
-          ×
+          <IconClose />
         </button>
       </div>
       {(task || schedule) && !expanded && <div className="loop-node__task">{task || schedule}</div>}

--- a/src/renderer/nodes/StickyNode.tsx
+++ b/src/renderer/nodes/StickyNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Tooltip } from '../components/Tooltip'
 import { IconChevronDown, IconChevronRight, IconClose } from '../components/icons'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
@@ -89,15 +90,23 @@ export function StickyNode({ id, data, selected }: NodeProps<CanvasNode>) {
       />
 
       <div className="sticky-node__header" style={{ background: `${data.color}33` }}>
-        <button className="term-node__collapse" title={collapsed ? 'Expand' : 'Collapse'} onClick={toggleCollapse}>
-          {collapsed ? <IconChevronRight /> : <IconChevronDown />}
-        </button>
-        <button
-          className="term-node__color"
-          style={{ background: data.color }}
-          title="Color"
-          onClick={() => setShowColors((v) => !v)}
-        />
+        <Tooltip label={collapsed ? 'Expand' : 'Collapse'}>
+          <button
+            className="term-node__collapse"
+            aria-label={collapsed ? 'Expand' : 'Collapse'}
+            onClick={toggleCollapse}
+          >
+            {collapsed ? <IconChevronRight /> : <IconChevronDown />}
+          </button>
+        </Tooltip>
+        <Tooltip label="Color">
+          <button
+            className="term-node__color"
+            style={{ background: data.color }}
+            aria-label="Color"
+            onClick={() => setShowColors((v) => !v)}
+          />
+        </Tooltip>
         {showColors && (
           <div className="color-popover">
             {NODE_COLORS.map((c) => (
@@ -150,13 +159,15 @@ export function StickyNode({ id, data, selected }: NodeProps<CanvasNode>) {
             up by. That grab area is what the permanent full-width input used to swallow. Absent
             while editing, since the input takes the `flex: 1` role itself. */}
         {!editingTitle && <span className="term-node__spacer" />}
-        <button
-          className="term-node__close"
-          title="Close"
-          onClick={() => deleteElements({ nodes: [{ id }] })}
-        >
-          <IconClose />
-        </button>
+        <Tooltip label="Close">
+          <button
+            className="term-node__close"
+            aria-label="Close"
+            onClick={() => deleteElements({ nodes: [{ id }] })}
+          >
+            <IconClose />
+          </button>
+        </Tooltip>
       </div>
 
       {editingText ? (

--- a/src/renderer/nodes/StickyNode.tsx
+++ b/src/renderer/nodes/StickyNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IconChevronDown, IconChevronRight, IconClose } from '../components/icons'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import { COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from '../state/workspace'
@@ -89,7 +90,7 @@ export function StickyNode({ id, data, selected }: NodeProps<CanvasNode>) {
 
       <div className="sticky-node__header" style={{ background: `${data.color}33` }}>
         <button className="term-node__collapse" title={collapsed ? 'Expand' : 'Collapse'} onClick={toggleCollapse}>
-          {collapsed ? '▸' : '▾'}
+          {collapsed ? <IconChevronRight /> : <IconChevronDown />}
         </button>
         <button
           className="term-node__color"
@@ -154,7 +155,7 @@ export function StickyNode({ id, data, selected }: NodeProps<CanvasNode>) {
           title="Close"
           onClick={() => deleteElements({ nodes: [{ id }] })}
         >
-          ×
+          <IconClose />
         </button>
       </div>
 

--- a/src/renderer/nodes/SubagentNode.tsx
+++ b/src/renderer/nodes/SubagentNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconChevronDown, IconChevronRight } from '../components/icons'
 import { Handle, NodeResizer, Position, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
@@ -71,7 +72,7 @@ export function SubagentNode({ id, data, selected }: NodeProps<CanvasNode>) {
             toggle()
           }}
         >
-          {expanded ? '▾' : '▸'}
+          {expanded ? <IconChevronDown /> : <IconChevronRight />}
         </button>
         <span className="subagent-node__dot" />
         <span className="subagent-node__type">{(data.subagentType as string) || 'subagent'}</span>

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -5217,7 +5217,12 @@ export function TerminalNode({
         )}
         {!isHidden('ai-name', hiddenHeaderButtons) && (
           <Tooltip label="Name with AI (from terminal output)">
-            <button className="term-node__ai nodrag" disabled={naming} onClick={nameWithAi}>
+            <button
+              className="term-node__ai nodrag"
+              aria-label="Name with AI"
+              disabled={naming}
+              onClick={nameWithAi}
+            >
               {naming ? <span className="ui-spinner" /> : <IconSparkle />}
             </button>
           </Tooltip>

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -135,7 +135,18 @@ import {
 import { shouldAutoWake, shouldColdResume } from '../terminal/hibernation-policy'
 import { WakeInputBuffer } from '../terminal/wake-input-buffer'
 import { FindBar } from '../components/FindBar'
-import { IconSearch, IconChat, IconMic, IconReload, IconEye, IconEyeOff, IconGrid } from '../components/icons'
+import {
+  IconSearch,
+  IconChat,
+  IconMic,
+  IconReload,
+  IconEye,
+  IconEyeOff,
+  IconGrid,
+  IconChevronDown,
+  IconChevronRight,
+  IconClose
+} from '../components/icons'
 import { NodeLabels } from '../components/kanban/NodeLabels'
 import { Tooltip } from '../components/Tooltip'
 import { useTerminalSearch } from '../terminal/useTerminalSearch'
@@ -4854,7 +4865,7 @@ export function TerminalNode({
 
       <div className="term-node__header">
         <button className="term-node__collapse" title={collapsed ? 'Expand' : 'Collapse'} onClick={toggleCollapse}>
-          {collapsed ? '▸' : '▾'}
+          {collapsed ? <IconChevronRight /> : <IconChevronDown />}
         </button>
         <button
           className="term-node__color"
@@ -5268,7 +5279,7 @@ export function TerminalNode({
             deleteElements({ nodes: [{ id }] })
           }}
         >
-          ×
+          <IconClose />
         </button>
       </div>
 
@@ -5390,7 +5401,7 @@ export function TerminalNode({
               title="Dismiss"
               aria-label="Dismiss"
             >
-              ×
+              <IconClose />
             </button>
           </div>
         )}

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -135,18 +135,7 @@ import {
 import { shouldAutoWake, shouldColdResume } from '../terminal/hibernation-policy'
 import { WakeInputBuffer } from '../terminal/wake-input-buffer'
 import { FindBar } from '../components/FindBar'
-import {
-  IconSearch,
-  IconChat,
-  IconMic,
-  IconReload,
-  IconEye,
-  IconEyeOff,
-  IconGrid,
-  IconChevronDown,
-  IconChevronRight,
-  IconClose
-} from '../components/icons'
+import { IconChat, IconChevronDown, IconChevronRight, IconClose, IconEye, IconEyeOff, IconGrid, IconMic, IconMoveTo, IconPlay, IconReload, IconSearch, IconSparkle } from '../components/icons'
 import { NodeLabels } from '../components/kanban/NodeLabels'
 import { Tooltip } from '../components/Tooltip'
 import { useTerminalSearch } from '../terminal/useTerminalSearch'
@@ -4864,15 +4853,23 @@ export function TerminalNode({
       />
 
       <div className="term-node__header">
-        <button className="term-node__collapse" title={collapsed ? 'Expand' : 'Collapse'} onClick={toggleCollapse}>
-          {collapsed ? <IconChevronRight /> : <IconChevronDown />}
-        </button>
-        <button
-          className="term-node__color"
-          style={{ background: data.color }}
-          title="Color"
-          onClick={() => setShowColors((v) => !v)}
-        />
+        <Tooltip label={collapsed ? 'Expand' : 'Collapse'}>
+          <button
+            className="term-node__collapse"
+            aria-label={collapsed ? 'Expand' : 'Collapse'}
+            onClick={toggleCollapse}
+          >
+            {collapsed ? <IconChevronRight /> : <IconChevronDown />}
+          </button>
+        </Tooltip>
+        <Tooltip label="Color">
+          <button
+            className="term-node__color"
+            style={{ background: data.color }}
+            aria-label="Color"
+            onClick={() => setShowColors((v) => !v)}
+          />
+        </Tooltip>
         {showColors && (
           <div className="color-popover">
             {NODE_COLORS.map((c) => (
@@ -5089,7 +5086,7 @@ export function TerminalNode({
                 })
               }}
             >
-              ▶
+              <IconPlay />
             </button>
           </span>
         )}
@@ -5166,7 +5163,7 @@ export function TerminalNode({
               className="term-node__move-worktree nodrag"
               onClick={() => moveIntoWorktreeHandler?.(id)}
             >
-              ↪
+              <IconMoveTo />
             </button>
           </Tooltip>
         )}
@@ -5221,7 +5218,7 @@ export function TerminalNode({
         {!isHidden('ai-name', hiddenHeaderButtons) && (
           <Tooltip label="Name with AI (from terminal output)">
             <button className="term-node__ai nodrag" disabled={naming} onClick={nameWithAi}>
-              {naming ? '…' : '✦'}
+              {naming ? <span className="ui-spinner" /> : <IconSparkle />}
             </button>
           </Tooltip>
         )}
@@ -5240,7 +5237,7 @@ export function TerminalNode({
           <Tooltip label={hideFanout ? 'Show cards & connections' : 'Hide cards & connections'}>
             <button
               className="term-node__hide-fanout nodrag"
-              title={hideFanout ? 'Show cards & connections' : 'Hide cards & connections'}
+              aria-label={hideFanout ? 'Show cards & connections' : 'Hide cards & connections'}
               aria-pressed={hideFanout}
               onClick={(e) => {
                 e.stopPropagation()
@@ -5258,7 +5255,7 @@ export function TerminalNode({
             <Tooltip label="Tidy subagent cards into a grid">
               <button
                 className="term-node__tidy-fanout nodrag"
-                title="Tidy subagent cards into a grid"
+                aria-label="Tidy subagent cards into a grid"
                 onClick={(e) => {
                   e.stopPropagation()
                   useAgentNodes.getState().tidyFanout(id)
@@ -5271,16 +5268,18 @@ export function TerminalNode({
         {!collapsed && !isHidden('maximize', hiddenHeaderButtons) && (
           <MaximizeButton id={id} maximized={!!data.premaxRect} />
         )}
-        <button
-          className="term-node__close"
-          title="Close (ends the session)"
-          onClick={() => {
-            transport.destroy(id)
-            deleteElements({ nodes: [{ id }] })
-          }}
-        >
-          <IconClose />
-        </button>
+        <Tooltip label="Close (ends the session)">
+          <button
+            className="term-node__close"
+            aria-label="Close"
+            onClick={() => {
+              transport.destroy(id)
+              deleteElements({ nodes: [{ id }] })
+            }}
+          >
+            <IconClose />
+          </button>
+        </Tooltip>
       </div>
 
       {searchOpen && !collapsed && (

--- a/src/renderer/nodes/VideoNode.tsx
+++ b/src/renderer/nodes/VideoNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IconClose } from '../components/icons'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
@@ -90,7 +91,7 @@ export default function VideoNode({ id, data, selected }: NodeProps<CanvasNode>)
           title="Close"
           onClick={() => deleteElements({ nodes: [{ id }] })}
         >
-          ×
+          <IconClose />
         </button>
       </div>
 

--- a/src/renderer/nodes/VideoNode.tsx
+++ b/src/renderer/nodes/VideoNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Tooltip } from '../components/Tooltip'
 import { IconClose } from '../components/icons'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
@@ -86,13 +87,11 @@ export default function VideoNode({ id, data, selected }: NodeProps<CanvasNode>)
           {fileName}
         </span>
         <span className="term-node__spacer" />
-        <button
-          className="term-node__close"
-          title="Close"
-          onClick={() => deleteElements({ nodes: [{ id }] })}
-        >
-          <IconClose />
-        </button>
+        <Tooltip label="Close">
+          <button className="term-node__close" aria-label="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
+            <IconClose />
+          </button>
+        </Tooltip>
       </div>
 
       <div className="editor-node__body">

--- a/src/renderer/nodes/WebNode.tsx
+++ b/src/renderer/nodes/WebNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { IconClose } from '../components/icons'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
@@ -207,7 +208,7 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
           title="Close"
           onClick={() => deleteElements({ nodes: [{ id }] })}
         >
-          ×
+          <IconClose />
         </button>
       </div>
 

--- a/src/renderer/nodes/WebNode.tsx
+++ b/src/renderer/nodes/WebNode.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { IconClose } from '../components/icons'
+import { Tooltip } from '../components/Tooltip'
+import { IconClose, IconOpenExternal } from '../components/icons'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
@@ -192,24 +193,28 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
           </button>
         )}
         {url && (
+          <Tooltip label="Open in browser">
+            <button
+              className="term-node__external"
+              aria-label="Open in browser"
+              onClick={() => {
+                const safe = httpUrl(url)
+                if (safe) window.nodeTerminal.shell.openExternal(safe)
+              }}
+            >
+              <IconOpenExternal />
+            </button>
+          </Tooltip>
+        )}
+        <Tooltip label="Close">
           <button
             className="term-node__close"
-            title="Open in browser"
-            onClick={() => {
-              const safe = httpUrl(url)
-              if (safe) window.nodeTerminal.shell.openExternal(safe)
-            }}
+            aria-label="Close"
+            onClick={() => deleteElements({ nodes: [{ id }] })}
           >
-            ↗
+            <IconClose />
           </button>
-        )}
-        <button
-          className="term-node__close"
-          title="Close"
-          onClick={() => deleteElements({ nodes: [{ id }] })}
-        >
-          <IconClose />
-        </button>
+        </Tooltip>
       </div>
 
       <div className="editor-node__body">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1829,6 +1829,12 @@ body,
   transform: translate(-50%, -100%);
 }
 
+/* Opens sideways: the anchor x is the trigger's RIGHT edge and is already the bubble's left edge,
+   so the base rule's horizontal pull is dropped and the centering moves to the other axis. */
+.tooltip--right {
+  transform: translateY(-50%);
+}
+
 
 
 /* Icon sizing for the boxes that are smaller than the shared 16px glyph. The icon set is one

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -619,11 +619,6 @@ body,
   margin: 0 4px;
 }
 
-.dock-zoom-btn {
-  width: 30px;
-  height: 30px;
-}
-
 .dock-zoom-wrap {
   position: relative;
   display: inline-flex;
@@ -1360,21 +1355,7 @@ body,
   flex-shrink: 0;
 }
 
-/* Maximize toggle (issue #399): a regular right-group header icon button, next to the close ×.
-   Same recipe as .term-node__refresh — the toggle is ordinary chrome, not a traffic light. */
-.term-node__maximize {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  line-height: 1;
-  border-radius: 4px;
-}
 
-.term-node__maximize:hover {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
-}
 
 .term-node__title {
   flex: 1;
@@ -1843,107 +1824,51 @@ body,
   transform: translate(-50%, -100%);
 }
 
-.term-node__ai {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  font-size: 13px;
-  line-height: 1;
-  border-radius: 4px;
+
+
+/* Icon sizing for the boxes that are smaller than the shared 16px glyph. The icon set is one
+   family on one viewBox (see icons.tsx); where a button is tight, the BUTTON scales it down
+   rather than the icon carrying a second size of its own. */
+.tab__caret svg,
+.sessmem-row__kill svg,
+.welcome__recent-del svg {
+  width: 14px;
+  height: 14px;
 }
 
-.term-node__ai:hover:not(:disabled) {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
+.loop-node__expand svg,
+.subagent-node__expand svg,
+.ex-dls__dismiss svg,
+.term-node__stalecwd-dismiss svg,
+.node-tag button svg {
+  width: 12px;
+  height: 12px;
 }
 
-.term-node__ai:disabled {
-  opacity: 0.6;
-  cursor: default;
+/* Boxes smaller than the shared 16px glyph, scaled by the BUTTON (see icons.tsx: one family,
+   one viewBox). */
+.scm-iconbtn svg,
+.ss-row__close svg,
+.account-identity-check svg,
+.kanban-modal__action svg {
+  width: 13px;
+  height: 13px;
 }
 
-.term-node__move-worktree {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  font-size: 13px;
-  line-height: 1;
-  border-radius: 4px;
-}
-
-.term-node__move-worktree:hover {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
-}
-
-.term-node__search {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  line-height: 1;
-  border-radius: 4px;
-}
-
-.term-node__search:hover {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
-}
-
-.term-node__refresh {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  line-height: 1;
-  border-radius: 4px;
-}
-
-.term-node__refresh:hover {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
-}
-
-.term-node__mic {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  line-height: 1;
-  border-radius: 4px;
-}
-
-.term-node__mic:hover {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
-}
-
-.term-node__chat {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  line-height: 1;
-  border-radius: 4px;
-}
-
-.term-node__chat:hover {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
-}
-
-/* Every icon-only button in the terminal header shares ONE box: a 22px square with the icon
-   centered on both axes. They used to differ per button (padding 2px 4/5/6px on a text baseline),
-   which is what made the row read as misaligned. Buttons carrying TEXT (approve, queued-run, the
-   status pills, the title) deliberately keep their own shape. */
+/* ---- Node header actions ----
+   ONE recipe for every icon-only button in a node header (terminal, editor, diff, video, web,
+   browser, sticky, dino). Each of these used to carry its own copy of the same six declarations
+   plus a hand-typed hover colour; the copies had already drifted (collapse hovered grey where its
+   neighbours hovered blue, and the close button's red was not the --danger hue).
+   Buttons carrying TEXT (approve, queued-run, Save/Preview, the status pills, the title) keep
+   their own shape: a word needs room a 22px square does not have. */
 .term-node__collapse,
 .term-node__ai,
 .term-node__chat,
 .term-node__mic,
 .term-node__search,
 .term-node__refresh,
+.term-node__external,
 .term-node__maximize,
 .term-node__close,
 .term-node__move-worktree,
@@ -1952,31 +1877,59 @@ body,
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   width: 22px;
   height: 22px;
   padding: 0;
-  flex-shrink: 0;
-}
-
-.term-node__hide-fanout,
-.term-node__tidy-fanout {
   background: transparent;
   border: none;
-  color: var(--muted);
-  cursor: pointer;
-  line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
+  color: var(--muted);
+  line-height: 1;
+  cursor: pointer;
 }
 
+/* A neutral wash, not the accent: a header full of blue-on-hover buttons competes with the
+   status badges and the project colour, which are the things in that row that carry meaning.
+   Only the destructive action below answers in colour. */
+.term-node__collapse:hover,
+.term-node__ai:hover:not(:disabled),
+.term-node__chat:hover,
+.term-node__mic:hover,
+.term-node__search:hover,
+.term-node__refresh:hover,
+.term-node__external:hover,
+.term-node__maximize:hover,
+.term-node__move-worktree:hover,
 .term-node__hide-fanout:hover,
 .term-node__tidy-fanout:hover {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
+  background: rgba(var(--tint-rgb), 0.1);
+  color: var(--text);
 }
+
+/* Closing a node ends its session, so it is the one header action that answers in --danger. */
+.term-node__close:hover {
+  background: color-mix(in srgb, var(--danger) 20%, transparent);
+  color: var(--danger);
+}
+
+.term-node__ai:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 .term-node__hide-fanout[aria-pressed='true'] {
   color: var(--accent-text);
@@ -2037,8 +1990,8 @@ body,
 }
 
 .term-node__find-btn:hover:not(:disabled) {
-  background: rgba(10, 132, 255, 0.18);
-  color: var(--accent-text);
+  background: rgba(var(--tint-rgb), 0.1);
+  color: var(--text);
 }
 
 .term-node__find-btn:disabled {
@@ -2078,19 +2031,7 @@ body,
   color: var(--accent-text);
 }
 
-.term-node__close {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  line-height: 1;
-  border-radius: 4px;
-}
 
-.term-node__close:hover {
-  background: rgba(247, 118, 142, 0.2);
-  color: var(--danger);
-}
 
 .term-node__body {
   position: relative;
@@ -2750,19 +2691,7 @@ body,
   display: none;
 }
 
-.term-node__collapse {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  line-height: 1;
-  border-radius: 4px;
-}
 
-.term-node__collapse:hover {
-  background: rgba(var(--tint-rgb), 0.08);
-  color: var(--text);
-}
 
 /* ---- Node tags ---- */
 .node-tags {
@@ -7487,7 +7416,14 @@ button.group-node__setup:disabled {
 .ss-row:hover .ss-row__ai { opacity: 0.6; }
 .ss-row__ai:hover { opacity: 1 !important; color: var(--accent); }
 .ss-row__ai:disabled { opacity: 0.6; cursor: default; color: var(--accent); }
-.ss-row__close { opacity: 0; border: none; background: transparent; color: var(--text); cursor: pointer; font-size: 14px; line-height: 1; padding: 0 2px; flex: 0 0 auto; }
+.ss-row__close { opacity: 0; border: none; background: transparent; color: var(--text); cursor: pointer; font-size: 14px; line-height: 1; padding: 0 2px; flex: 0 0 auto; 
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+}
 .ss-row:hover .ss-row__close { opacity: 0.6; }
 .ss-row__close:hover { opacity: 1 !important; color: var(--danger); }
 
@@ -7909,8 +7845,13 @@ button.group-node__setup:disabled {
   border: none;
   color: var(--text, #ddd);
   cursor: pointer;
-  padding: 2px 6px;
   border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
 }
 .browser-node__btn:disabled {
   opacity: 0.35;
@@ -9940,12 +9881,16 @@ button.group-node__setup:disabled {
   margin-right: auto;
 }
 .kanban-modal__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
   background: rgba(var(--tint-rgb), 0.06);
   border: none;
   border-radius: 6px;
   color: rgba(var(--tint-rgb), 0.7);
-  font-size: 13px;
-  padding: 4px 10px;
   cursor: pointer;
 }
 .kanban-modal__action:hover {
@@ -10353,9 +10298,13 @@ button.group-node__setup:disabled {
   border: none;
   color: rgba(var(--tint-rgb), 0.55);
   cursor: pointer;
-  padding: 4px 8px;
   border-radius: 5px;
-  font-size: 15px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
 }
 .label-picker__more:hover {
   background: rgba(var(--tint-rgb), 0.1);
@@ -12247,9 +12196,14 @@ body.focus-mode .dock:hover {
 }
 .account-identity-check {
   flex: none;
-  font-size: 12px;
   line-height: 1;
   color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
 }
 /* A managed home that is missing / an account that cannot be operated: the same cluster, warned.
    Recolour text + outline with the warn token; no tinted fill (there is no --warn-rgb to build

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -63,8 +63,15 @@
      without touching 54 rules. Scrims are excluded: darkening IS a scrim's job. */
   --shadow-k: 1;
 
+  /* One distance between every floating overlay and the edge it hugs (the dock's, historically):
+     the dock, the pill cluster, the minimap, the sidebars and the top-right cluster each used to
+     carry their own 14 to 22px, which read as a ragged margin. Top-anchored chrome adds the tab bar's
+     44px on top of it. */
+  --float-gap: 22px;
+  --tabbar-h: 44px;
+
   /* Canvas chrome that lives on React Flow props rather than in a rule. */
-  --canvas-dot: #4a4a4a;
+  --canvas-dot: #303030;
   --minimap-mask: rgba(10, 12, 18, 0.6);
   --git-graph-ref: var(--accent);
   --git-graph-remote-ref: #bf5af2;
@@ -163,7 +170,7 @@
 
   /* Dots must read as a grid, not as noise: the dark-mode grey is far too heavy on a pale field,
      and a neutral one would be the only cold thing on screen. */
-  --canvas-dot: #d8cdba;
+  --canvas-dot: #eae3d6;
   --minimap-mask: rgba(251, 248, 243, 0.6);
 }
 
@@ -196,7 +203,7 @@ body,
   display: flex;
   align-items: center;
   gap: 14px;
-  height: 44px;
+  height: var(--tabbar-h);
   padding: 0 12px;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
@@ -404,11 +411,13 @@ body,
 }
 
 .tab__caret {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
   border: none;
   color: currentColor;
   cursor: pointer;
-  font-size: 12px;
   line-height: 1;
   padding: 2px 2px;
   border-radius: 4px;
@@ -437,7 +446,6 @@ body,
   border: none;
   border-radius: 14px;
   color: var(--muted);
-  font-size: 17px;
   cursor: pointer;
 }
 
@@ -547,14 +555,14 @@ body,
 
 .dock {
   position: absolute;
-  bottom: 22px;
+  bottom: var(--float-gap);
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 7px 10px;
+  padding: 7px;
   background: rgba(var(--menu-rgb), 0.92);
   backdrop-filter: blur(10px);
   border: 1px solid var(--border);
@@ -590,12 +598,12 @@ body,
   color: #fff;
 }
 
-.dock-add:hover {
-  background: var(--accent-hover);
+.dock-btn.dock-add:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 85%, black);
 }
 
-.dock-add.active {
-  background: #0060df;
+.dock-btn.dock-add.active:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 72%, black);
   color: #fff;
 }
 
@@ -804,7 +812,7 @@ body,
 /* ---- Dictation overlay: bottom-center floating card above the Dock ---- */
 .dictation {
   position: fixed;
-  bottom: 88px;
+  bottom: calc(var(--float-gap) + 52px + var(--float-gap));
   left: 50%;
   transform: translateX(-50%);
   z-index: 60; /* above the kanban board (25) and the card modal scrim (55) — the mic works there too */
@@ -1337,7 +1345,7 @@ body,
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 8px;
+  padding: 6px;
   background: var(--panel-header);
   cursor: grab;
   user-select: none;
@@ -1360,11 +1368,7 @@ body,
   color: var(--muted);
   cursor: pointer;
   line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
 }
 
 .term-node__maximize:hover {
@@ -1834,6 +1838,11 @@ body,
   white-space: nowrap;
 }
 
+/* Opens upward: the anchor y is the trigger's TOP edge, so the bubble is pulled fully above it. */
+.tooltip--top {
+  transform: translate(-50%, -100%);
+}
+
 .term-node__ai {
   background: transparent;
   border: none;
@@ -1841,9 +1850,7 @@ body,
   cursor: pointer;
   font-size: 13px;
   line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
-  flex-shrink: 0;
 }
 
 .term-node__ai:hover:not(:disabled) {
@@ -1863,9 +1870,7 @@ body,
   cursor: pointer;
   font-size: 13px;
   line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
-  flex-shrink: 0;
 }
 
 .term-node__move-worktree:hover {
@@ -1879,11 +1884,7 @@ body,
   color: var(--muted);
   cursor: pointer;
   line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
 }
 
 .term-node__search:hover {
@@ -1897,11 +1898,7 @@ body,
   color: var(--muted);
   cursor: pointer;
   line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
 }
 
 .term-node__refresh:hover {
@@ -1915,11 +1912,7 @@ body,
   color: var(--muted);
   cursor: pointer;
   line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
 }
 
 .term-node__mic:hover {
@@ -1933,16 +1926,36 @@ body,
   color: var(--muted);
   cursor: pointer;
   line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
 }
 
 .term-node__chat:hover {
   background: rgba(10, 132, 255, 0.18);
   color: var(--accent-text);
+}
+
+/* Every icon-only button in the terminal header shares ONE box: a 22px square with the icon
+   centered on both axes. They used to differ per button (padding 2px 4/5/6px on a text baseline),
+   which is what made the row read as misaligned. Buttons carrying TEXT (approve, queued-run, the
+   status pills, the title) deliberately keep their own shape. */
+.term-node__collapse,
+.term-node__ai,
+.term-node__chat,
+.term-node__mic,
+.term-node__search,
+.term-node__refresh,
+.term-node__maximize,
+.term-node__close,
+.term-node__move-worktree,
+.term-node__hide-fanout,
+.term-node__tidy-fanout {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  flex-shrink: 0;
 }
 
 .term-node__hide-fanout,
@@ -2014,9 +2027,13 @@ body,
   cursor: pointer;
   font-size: 12px;
   line-height: 1;
-  padding: 2px 5px;
   border-radius: 4px;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
 }
 
 .term-node__find-btn:hover:not(:disabled) {
@@ -2066,9 +2083,7 @@ body,
   border: none;
   color: var(--muted);
   cursor: pointer;
-  font-size: 16px;
   line-height: 1;
-  padding: 2px 6px;
   border-radius: 4px;
 }
 
@@ -2417,15 +2432,18 @@ body,
 .term-node__stalecwd-restart:hover {
   background: rgba(255, 255, 255, 0.2);
 }
-.term-node__stalecwd-dismiss {
-  padding: 0 4px;
-  border: none;
+.term-node__stalecwd-dismiss {  border: none;
   background: none;
   color: inherit;
-  font-size: 14px;
   line-height: 1;
   cursor: pointer;
   opacity: 0.7;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
 }
 .term-node__stalecwd-dismiss:hover {
   opacity: 1;
@@ -2737,11 +2755,8 @@ body,
   border: none;
   color: var(--muted);
   cursor: pointer;
-  font-size: 11px;
   line-height: 1;
-  padding: 2px 4px;
   border-radius: 4px;
-  flex-shrink: 0;
 }
 
 .term-node__collapse:hover {
@@ -2779,7 +2794,9 @@ body,
   cursor: pointer;
   font-size: 12px;
   line-height: 1;
-  padding: 0 1px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .node-tag button:hover {
@@ -2870,9 +2887,14 @@ body,
   background: transparent;
   border: none;
   color: rgba(var(--tint-rgb), 0.55);
-  font-size: 18px;
   line-height: 1;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
 }
 .remote-dialog__x:hover {
   color: var(--text-strong);
@@ -3395,7 +3417,7 @@ body,
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 5px 8px;
+  padding: 5px;
   cursor: grab;
   user-select: none;
 }
@@ -3495,8 +3517,8 @@ body,
 /* ---- Top-right controls cluster ---- */
 .controls-cluster {
   position: absolute;
-  top: 54px;
-  right: 14px;
+  top: calc(var(--tabbar-h) + var(--float-gap));
+  right: var(--float-gap);
   z-index: 26; /* above the kanban overlay (25) — the view toggle must stay reachable on the board */
   display: flex;
   align-items: center; /* center the presence facepile (26px) against the 34px toolbar buttons */
@@ -3526,7 +3548,7 @@ body,
 /* Stack of notification strips (update + announcements), just below the tab bar. */
 .top-banners {
   position: absolute;
-  top: 46px;
+  top: calc(var(--tabbar-h) + var(--float-gap));
   left: 50%;
   transform: translateX(-50%);
   z-index: 27; /* above the kanban overlay (25) and the cluster (26), below the tab bar (30) */
@@ -3902,13 +3924,8 @@ body,
 /* Search button shows the ⌘K shortcut so its purpose is obvious */
 .cluster-search {
   width: auto !important;
-  gap: 7px;
+  gap: 10px;
   padding: 0 10px;
-}
-
-.cluster-search__icon {
-  font-size: 15px;
-  color: var(--muted);
 }
 
 .kbd {
@@ -3966,7 +3983,7 @@ body,
 
 /* Pinned explorer: no scrim, clicks pass through to the canvas. The drawer is a floating
    card on the right — same shape as the sessions sidebar on the left — so the controls
-   cluster (top: 54px, right: 14px, 34px tall) stays reachable. z 26 sits with that cluster
+   cluster (one --float-gap below the tab bar, 34px tall) stays reachable. z 26 sits with that cluster
    above the kanban board (25) and below the tab bar (30) / dialogs (55+). pointer-events
    on the overlay is load-bearing: a transparent overlay that still captures would freeze
    the canvas even with the click-to-close handler removed. */
@@ -3978,9 +3995,10 @@ body,
 .drawer-overlay--pinned .drawer--pinned {
   pointer-events: auto;
   position: absolute;
-  top: 96px; /* 54 (cluster) + 34 (buttons) + 8 (gap) — must sit BELOW the cluster */
-  right: 14px;
-  bottom: 14px;
+  /* Below the cluster: its own top + its 34px height + a gap. Same stack as .resume-card. */
+  top: calc(var(--tabbar-h) + var(--float-gap) + 34px + 12px);
+  right: var(--float-gap);
+  bottom: var(--float-gap);
   height: auto;
   max-height: none;
   width: 320px;
@@ -4007,9 +4025,14 @@ body,
   background: transparent;
   border: none;
   color: var(--muted);
-  font-size: 20px;
   line-height: 1;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
 }
 
 .drawer__close:hover {
@@ -4589,6 +4612,12 @@ body,
   font-size: 16px;
   line-height: 1;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
 }
 
 .ex-head-actions button:hover {
@@ -4763,9 +4792,20 @@ body,
   background: transparent;
   border: none;
   color: var(--accent);
-  font-size: 12px;
   cursor: pointer;
+  font-size: 12px;
   padding: 0 2px;
+}
+
+/* The dismiss half of the download row: `.ex-dls__act` is shared with the text "Reveal" button,
+   so the icon box lives here rather than on the shared class. */
+.ex-dls__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
 }
 
 /* The `+ .ex-dls__act` sibling is the dismiss ×: only the FIRST action pushes right. */
@@ -5297,6 +5337,9 @@ body,
   color: var(--text);
   font-size: 14px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .dir-picker__up:hover:not(:disabled) {
@@ -5959,9 +6002,13 @@ button.group-node__setup:disabled {
   border: 1px solid var(--border);
   color: var(--muted);
   border-radius: 7px;
-  font-size: 13px;
-  padding: 2px 8px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
 }
 
 .group-node__wt-btn:hover {
@@ -5993,9 +6040,13 @@ button.group-node__setup:disabled {
   border: 1px solid var(--border);
   color: var(--muted);
   border-radius: 7px;
-  font-size: 11px;
-  padding: 3px 8px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
 }
 
 .group-node__close {
@@ -6313,8 +6364,64 @@ button.group-node__setup:disabled {
   color: var(--muted);
 }
 
+/* ---- Canvas controls (bottom-left) ----
+   Same plate and --float-gap offset as the other floating chrome; the library's own glyphs are
+   replaced in Canvas.tsx, so these rules only size and color our 16px icons. */
+.react-flow__controls {
+  margin: var(--float-gap) !important;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, calc(0.4 * var(--shadow-k)));
+}
+
+/* Each button wraps in a Tooltip span, which must not break the library's vertical stack. */
+.react-flow__controls .tooltip-trigger {
+  display: block;
+}
+
+.react-flow__controls-button {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--menu-rgb), 0.85);
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.react-flow__controls .tooltip-trigger:last-child .react-flow__controls-button {
+  border-bottom: none;
+}
+
+.react-flow__controls-button svg {
+  width: 15px;
+  height: 15px;
+  max-width: none;
+  max-height: none;
+  fill: none;
+  stroke: currentColor;
+}
+
+.react-flow__controls-button:hover {
+  background: var(--panel-header);
+}
+
+/* Canvas lock toggle. The padlock strokes with currentColor, so the locked state tints via
+   `color`. */
+.react-flow__controls-button.canvas-lock-btn.locked {
+  color: var(--accent);
+  background: rgba(10, 132, 255, 0.14);
+}
+
 /* ---- Minimap ---- */
 .minimap {
+  /* React Flow places its panels with a 15px margin; the app's overlays all sit one --float-gap
+     from their edge, and the minimap and the controls are the two the library positions. */
+  margin: var(--float-gap) !important;
   background: rgba(var(--menu-rgb), 0.85) !important;
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -6376,31 +6483,6 @@ button.group-node__setup:disabled {
   }
 }
 
-/* React Flow controls dark theme */
-.react-flow__controls {
-  border-radius: 10px;
-  overflow: hidden;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, calc(0.4 * var(--shadow-k)));
-}
-
-.react-flow__controls-button {
-  background: var(--panel);
-  border-bottom: 1px solid var(--border);
-  color: var(--text);
-  fill: var(--text);
-}
-
-.react-flow__controls-button:hover {
-  background: var(--panel-header);
-}
-
-/* Canvas lock toggle (in the bottom-left Controls). The padlock fills with
-   currentColor, so the locked state tints via `color`. */
-.react-flow__controls-button.canvas-lock-btn.locked {
-  color: var(--accent);
-  background: rgba(10, 132, 255, 0.14);
-}
-
 /* ---- Bottom-left pill cluster (usage + system resources) ----
    ONE flex row, because neither pill can hard-code an offset for the other: the usage pill's width
    changes with every number it prints, and it is absent altogether for a user with no agent
@@ -6411,23 +6493,23 @@ button.group-node__setup:disabled {
    z-index, transform, filter or opacity here — any of them would trap both pills below the sidebar. */
 .canvas-pills {
   position: absolute;
-  left: 60px; /* clear the React Flow Controls column */
-  bottom: 18px;
+  left: var(--float-gap);
+  bottom: var(--float-gap);
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
 /* ---- Resume-where-you-left-off card (breadcrumb trail, once per project activation) ---- */
-/* Anchored in .flow-wrap under the controls cluster (top: 54px, 34px tall) rather than beside it,
-   so the two never overlap; the left side is the sessions sidebar's (top: 54px, left: 14px).
+/* Anchored in .flow-wrap under the controls cluster (one --float-gap below the tab bar, 34px tall)
+   rather than beside it, so the two never overlap; the left side is the sessions sidebar's.
    z-index 11 sits above the canvas and BELOW the sidebar (12) — a card the user has not dismissed
    must never cover a panel they deliberately opened — and below the kanban overlay (25), where the
    canvas and everything on it is correctly hidden. */
 .resume-card {
   position: absolute;
-  top: 100px;
-  right: 14px;
+  top: calc(var(--tabbar-h) + var(--float-gap) + 34px + 12px);
+  right: var(--float-gap);
   z-index: 11;
   width: 260px;
   max-width: calc(100vw - 28px);
@@ -6674,12 +6756,18 @@ button.group-node__setup:disabled {
   background: rgba(var(--card-rgb), 0.92);
   border: 1px solid rgba(var(--tint-rgb), 0.08);
   color: rgba(var(--tint-rgb), 0.7);
-  font-size: 13px;
   cursor: pointer;
 }
 .usage-refresh:hover { color: var(--text-strong); }
 .usage-refresh:disabled { opacity: 0.4; cursor: default; }
-.usage-refresh.spin { animation: usage-spin 0.9s linear infinite; }
+/* Smaller than the shared 16px icon: these two live in a dense pill row and replaced a 13px
+   glyph, so the row's height must not change. */
+.usage-refresh svg,
+.sessmem-panel__refresh svg {
+  width: 14px;
+  height: 14px;
+}
+.usage-refresh.spin svg { animation: usage-spin 0.9s linear infinite; }
 @keyframes usage-spin { to { transform: rotate(360deg); } }
 
 .usage-popover {
@@ -6975,6 +7063,9 @@ button.group-node__setup:disabled {
   font-size: 14px;
   line-height: 1;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .sessmem-row__kill:hover { color: var(--danger); background: rgba(var(--tint-rgb), 0.08); }
 /* The pane's descendants — the agent CLI itself included, since pane_pid is the pane's shell. */
@@ -7013,13 +7104,12 @@ button.group-node__setup:disabled {
   border-radius: 11px;
   background: transparent;
   color: rgba(var(--tint-rgb), 0.7);
-  font-size: 13px;
   cursor: pointer;
 }
 .sessmem-panel__refresh:hover { color: var(--text-strong); background: rgba(var(--tint-rgb), 0.08); }
 .sessmem-panel__refresh:disabled { opacity: 0.4; cursor: default; }
 /* Same spin as the usage panel's refresh. */
-.sessmem-panel__refresh.spin { animation: usage-spin 0.9s linear infinite; }
+.sessmem-panel__refresh.spin svg { animation: usage-spin 0.9s linear infinite; }
 
 /* ---- Claude context-window meter (per-node header pill + popover) ---- */
 .ctx-meter {
@@ -7404,11 +7494,11 @@ button.group-node__setup:disabled {
 /* Sessions sidebar — shell */
 .sessions-sidebar {
   position: absolute;
-  top: 54px;
-  left: 14px;
+  top: calc(var(--tabbar-h) + var(--float-gap));
+  left: var(--float-gap);
   z-index: 12;
   width: 300px;
-  max-height: calc(100vh - 96px);
+  max-height: calc(100vh - var(--tabbar-h) - 26px - 2 * var(--float-gap));
   display: flex;
   flex-direction: column;
   background: rgba(var(--card-rgb), 0.96);
@@ -7756,7 +7846,7 @@ button.group-node__setup:disabled {
 .ss-meta__project { color: var(--muted); font-size: 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .ss-meta__project + .ss-meta__cwd::before { content: '· '; }
 
-.sessions-icon-cluster { position: absolute; top: 54px; left: 14px; z-index: 11; }
+.sessions-icon-cluster { position: absolute; top: calc(var(--tabbar-h) + var(--float-gap)); left: var(--float-gap); z-index: 11; }
 .sessions-icon-cluster button { width: 34px; height: 34px; display: inline-flex; align-items: center; justify-content: center; background: rgba(var(--menu-rgb), 0.92); border: 1px solid var(--border); border-radius: 9px; color: var(--text); cursor: pointer; box-shadow: 0 6px 20px rgba(0, 0, 0, calc(0.3 * var(--shadow-k))); }
 .sessions-icon-cluster button:hover { background: var(--panel-header); }
 
@@ -7778,7 +7868,7 @@ button.group-node__setup:disabled {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 6px;
+  padding: 4px;
   background: var(--surface-overlay);
 }
 .dino-node__body {
@@ -7811,7 +7901,7 @@ button.group-node__setup:disabled {
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 6px;
+  padding: 4px;
   border-bottom: 1px solid var(--border, #333);
 }
 .browser-node__btn {
@@ -8658,8 +8748,8 @@ button.group-node__setup:disabled {
 /* ---- first-connect name/color prompt ---- */
 .presence-prompt {
   position: absolute;
-  top: 46px;
-  right: 12px;
+  top: calc(var(--tabbar-h) + var(--float-gap));
+  right: var(--float-gap);
   z-index: 14;
   width: 260px;
   padding: 12px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -70,6 +70,11 @@
   --float-gap: 22px;
   --tabbar-h: 44px;
 
+  /* Outer width of the bottom-left controls column: one button plus the column's 1px border on
+     each side. The pill cluster clears the column by reading this, so resizing the buttons cannot
+     silently drop the pills back on top of them. */
+  --controls-w: 30px;
+
   /* Canvas chrome that lives on React Flow props rather than in a rule. */
   --canvas-dot: #303030;
   --minimap-mask: rgba(10, 12, 18, 0.6);
@@ -5978,9 +5983,10 @@ button.group-node__setup:disabled {
   padding: 0;
 }
 
-.group-node__close {
-  padding: 3px 8px;
-  line-height: 1;
+.group-node__ungroup svg,
+.group-node__close svg {
+  width: 14px;
+  height: 14px;
 }
 
 .group-node__ungroup:hover,
@@ -6295,9 +6301,14 @@ button.group-node__setup:disabled {
 
 /* ---- Canvas controls (bottom-left) ----
    Same plate and --float-gap offset as the other floating chrome; the library's own glyphs are
-   replaced in Canvas.tsx, so these rules only size and color our 16px icons. */
+   replaced in Canvas.tsx, so these rules only size and color our 16px icons.
+   The plate, the blur and the border sit on the COLUMN, matching .dock: with a background on each
+   button instead, the four read as four stacked chips and the border around them had nothing to
+   enclose. */
 .react-flow__controls {
   margin: var(--float-gap) !important;
+  background: rgba(var(--menu-rgb), 0.92);
+  backdrop-filter: blur(10px);
   border: 1px solid var(--border);
   border-radius: 10px;
   overflow: hidden;
@@ -6310,20 +6321,23 @@ button.group-node__setup:disabled {
 }
 
 .react-flow__controls-button {
-  width: 28px;
-  height: 28px;
+  width: calc(var(--controls-w) - 2px);
+  height: calc(var(--controls-w) - 2px);
   padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(var(--menu-rgb), 0.85);
+  background: transparent;
   border: none;
-  border-bottom: 1px solid var(--border);
   color: var(--text);
 }
 
-.react-flow__controls .tooltip-trigger:last-child .react-flow__controls-button {
-  border-bottom: none;
+/* ONE separator, where there used to be a rule under every button. Zoom in, zoom out and fit view
+   are all camera moves; the lock is a mode toggle, and it is the only one that changes what the
+   other three are allowed to do. The lock already carries its own class, so this needs no
+   nth-child over the Tooltip spans that wrap each button. */
+.react-flow__controls-button.canvas-lock-btn {
+  border-top: 1px solid var(--border);
 }
 
 .react-flow__controls-button svg {
@@ -6419,10 +6433,12 @@ button.group-node__setup:disabled {
    Deliberately carries NO z-index: an absolutely positioned box with `z-index: auto` establishes no
    stacking context, so each pill's own z-index (5 / 13 / 26 / 60) keeps competing with the sessions
    sidebar and the kanban overlay exactly as it did when each was anchored on its own. Do not add
-   z-index, transform, filter or opacity here — any of them would trap both pills below the sidebar. */
+   z-index, transform, filter or opacity here — any of them would trap both pills below the sidebar.
+   The left offset clears the controls column, which shares this corner: --controls-w plus the 12px
+   the other chrome already uses between two adjacent clusters (see .resume-card). */
 .canvas-pills {
   position: absolute;
-  left: var(--float-gap);
+  left: calc(var(--float-gap) + var(--controls-w) + 12px);
   bottom: var(--float-gap);
   display: flex;
   align-items: center;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6997,9 +6997,11 @@ button.group-node__setup:disabled {
   border-radius: 10px;
   background: transparent;
   color: rgba(var(--tint-rgb), 0.45);
-  font-size: 11px;
   line-height: 1;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .sessmem-row__pause:hover:not(:disabled) {
   color: var(--accent);
@@ -7017,7 +7019,6 @@ button.group-node__setup:disabled {
   border-radius: 10px;
   background: transparent;
   color: rgba(var(--tint-rgb), 0.45);
-  font-size: 14px;
   line-height: 1;
   cursor: pointer;
   display: inline-flex;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5835,6 +5835,15 @@ body,
   display: none;
 }
 
+/* A tooltip wraps its trigger in a span, so inside the pill, the worktree chip and the actions row
+   the WRAPPER is the flex item, not the button. Without this the fixed-size buttons would shrink
+   under the 180px name input instead of holding their 11px / 22px boxes. */
+.group-node__label > .tooltip-trigger,
+.group-node__wt > .tooltip-trigger,
+.group-node__actions > .tooltip-trigger {
+  flex: none;
+}
+
 .group-node__dot {
   width: 11px;
   height: 11px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5950,7 +5950,8 @@ button.group-node__setup:disabled {
   color: var(--text);
 }
 
-/* ungroup / × — top-right, revealed on hover or when selected. */
+/* Ungroup, top-right, revealed on hover or when selected. One action, so no gap: the frame's
+   × called the same handler under a second name and was removed. */
 .group-node__actions {
   position: absolute;
   top: 0;
@@ -5958,7 +5959,6 @@ button.group-node__setup:disabled {
   transform: translateY(-50%);
   display: flex;
   align-items: center;
-  gap: 5px;
   opacity: 0;
   transition: opacity 0.12s;
 }
@@ -5968,8 +5968,7 @@ button.group-node__setup:disabled {
   opacity: 1;
 }
 
-.group-node__ungroup,
-.group-node__close {
+.group-node__ungroup {
   background: var(--surface-sunken);
   border: 1px solid var(--border);
   color: var(--muted);
@@ -5983,14 +5982,12 @@ button.group-node__setup:disabled {
   padding: 0;
 }
 
-.group-node__ungroup svg,
-.group-node__close svg {
+.group-node__ungroup svg {
   width: 14px;
   height: 14px;
 }
 
-.group-node__ungroup:hover,
-.group-node__close:hover {
+.group-node__ungroup:hover {
   background: var(--panel-header);
   color: var(--text);
 }

--- a/src/renderer/ui/Button.tsx
+++ b/src/renderer/ui/Button.tsx
@@ -12,10 +12,18 @@ export function Button({
     <button
       type="button"
       className={cn(
-        'inline-flex cursor-pointer items-center justify-center rounded-md px-3 py-1.5 text-[13px] font-medium outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-50',
-        variant === 'primary' && 'bg-accent text-white hover:bg-accent-hover',
-        variant === 'ghost' && 'bg-transparent text-muted hover:text-text',
-        variant === 'default' && 'border border-border bg-panel-header text-text hover:bg-[rgba(255,255,255,0.06)]',
+        // The base declares the border WIDTH only and every variant names its own colour, because
+        // two border-colour utilities on one element are decided by their order in Tailwind's
+        // output rather than by the order they are listed here. Tailwind's preflight is
+        // deliberately not loaded (see tailwind.css), so a variant that declares no border at all
+        // keeps the browser's own: primary rendered with a light UA ring around the accent fill,
+        // and sat 2px taller than the bordered `default` beside it.
+        'inline-flex cursor-pointer items-center justify-center rounded-md border px-3 py-1.5 text-[13px] font-medium outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+        variant === 'primary' && 'border-transparent bg-accent text-white hover:bg-accent-hover',
+        variant === 'ghost' && 'border-transparent bg-transparent text-muted hover:text-text',
+        // `bg-fill-weak` rather than a literal white overlay: that token exists so a hover does
+        // not turn into a white smear the moment the surface under it is the light theme.
+        variant === 'default' && 'border-border bg-panel-header text-text hover:bg-fill-weak',
         className
       )}
       {...rest}


### PR DESCRIPTION
UI polish across the canvas chrome: icons, spacing and tooltips.

## What changed

**Icons.** Text glyphs used as icons are replaced with SVGs from the shared icon set, so every button centers its icon on both axes instead of sitting on a text baseline. Close buttons used two different glyphs across the app and are now one icon everywhere. `IconSessions` contained two zero-length `<line>` elements that only rendered because of round caps; redrawn.

**Spacing.** New `--float-gap` (22px, the dock's distance) and `--tabbar-h` tokens, and every overlay that floats over the canvas is anchored on them: the dock, the pill cluster, the minimap, the controls, both sidebars, the top-right cluster, the banners, the resume card, the pinned explorer and the dictation pill each carried their own 14 to 22px before.

**Tooltips.** Custom tooltips on every dock and controls button. The dock's open upward, since it hugs the bottom edge; the controls' open to the right, since an upward bubble on a vertical stack covers the button above the one being pointed at. This also brings the `Tooltip` refactor (positioning into a `useTooltip` hook, plus viewport clamping) into this branch ahead of its handle consumers, so the new placement extends the shared component rather than colliding with a rewrite of it. `GroupNode` was the last node file still on native `title` rather than the shared `Tooltip`; its five interactive controls now use it, with `aria-label` on the icon-only ones, while the informational spans and the one button whose label is four lines long keep `title` - the tooltip bubble is `nowrap`.

**One recipe for node header actions.** Ten drifted copies of the icon-button recipe collapse into one, with color reserved for the destructive action.

**Fixes with a specific cause.** The refresh spinner rotated the *button*, not the glyph inside it, so it wobbled around a center the glyph did not share; it now rotates the icon. `.dock-btn:hover:not(:disabled)` out-specificed `.dock-add:hover`, so the add button lost its accent on hover. Tailwind preflight put a ring around the primary button.

**Accessibility.** Icon-only dismiss buttons carried their accessible name via `title` only, which is a tooltip first and a name by fallback. They now carry an explicit `aria-label`.

## Behavior changes

This is not a pure no-op pass. Four things behave differently:

- **The bottom-left Controls are restyled**, not removed. An earlier revision of this PR deleted the widget (zoom and fit already live in the dock, so only the lock added value). That is dropped per @eneskirca: with ~5k users on the current layout, removing a visible muscle-memory surface is not a risk worth taking in a polish pass. The widget keeps its position, its four actions and the lock where they were. The plate, blur and border now sit on the column rather than on each button, so the four read as one enclosure instead of four stacked chips; the rule under every button becomes one separator between the camera moves and the lock; and a `--controls-w` token sizes the buttons *and* offsets the pill cluster that shares that corner, so changing the button size cannot silently drop the pills back on top of them. `fit-view.ts` still reserves the controls rect in `CANVAS_CHROME_SELECTOR`, so `fitAll` lands where it always did.
- **The zoom step is animated in both places.** The controls stepped instantly while the dock tweened, which is one action feeling like two depending on which button you reach for. Both now read `ZOOM_STEP_DURATION_MS`.
- **`.dock-zoom-btn`'s 30px override is gone**, so the two dock zoom-step buttons are the same 38px as every other dock button. That is the point of having one recipe.
- **The group frame's two actions become one.** `ungroup` and the `x` beside it called the same handler under different tooltips, which the icon change made obvious; the `x` is dropped and the survivor reads "Ungroup (keeps nodes)". Deleting a frame with its children is still the context menu's Delete, and a bound frame still releases its worktree binding through `unbind` first.

## Split out of this PR

The **WebNode reload button** (`webviewReload.ts` + its tests) is a feature, not polish, and is not in this branch any more. It goes up as its own small PR once this one lands, as agreed on the review.

## Rebase

Rebased onto current `main`. #544's dock zoom presets and #451/#452's wheel-zoom handling landed after this branch and both survive untouched: `zoomPresets.ts`, `zoomShortcut.ts`, `zoom-limits.ts` and `wheel-zoom.ts` are byte-identical to `main`, and the preset menu keeps its logic, its `onZoomTo`, its `activeZoomPreset` and its mutual exclusion with the add menu. Only its presentation moved to `Tooltip` + `aria-label`.

## Verification

`npm run typecheck` is green. The renderer suite passes apart from pre-existing failures that reproduce identically on unmodified `main` in the same checkout (they read files out of `node_modules` or need a `localStorage` the env lacks).
