### PR TITLE
fix: restore terminal keyboard focus when the window is activated

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7282,12 +7282,20 @@ export function Canvas() {
     const onWindowFocus = () => {
       if (timer) clearTimeout(timer)
       timer = setTimeout(() => {
+        // Only the nodes we can prove belong to the canvas on screen: `nodesRef` and
+        // `activeProjectId` do not turn over in one commit, and an id we cannot place must not
+        // become a request that waits for its project to come back.
+        const activeProjectId = useProjects.getState().activeProjectId
+        const liveIds = new Set(
+          nodesProjectIdRef.current === activeProjectId ? nodesRef.current.map((n) => n.id) : []
+        )
         const target = nodeToRefocus({
           lastNodeId: useTerminalFocus.getState().lastNodeId,
           activeElement: document.activeElement as unknown as ContextElement | null,
           openDialogs: openDialogCount(),
-          boardOpen: isKanbanOpen(useProjects.getState().activeProjectId),
-          settingsOpen: settingsOpenRef.current
+          boardOpen: isKanbanOpen(activeProjectId),
+          settingsOpen: settingsOpenRef.current,
+          liveIds
         })
         if (target) {
           useTerminalFocus.getState().request(target, { ack: false })

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7259,16 +7259,24 @@ export function Canvas() {
     []
   )
 
+  // The settings page is React state, and the listener below is registered once — so it reads the
+  // flag through a ref rather than taking a dep and re-registering on every open/close.
+  const settingsOpenRef = useRef(settingsOpen)
+  settingsOpenRef.current = settingsOpen
+
   // Cmd+Tab back into the app: hand the keyboard to the terminal that last had it (issue #557).
   // Terminal focus is pointer-driven (the hover guard blurs xterm on `mouseleave`), so a pointer
   // parked on a second display leaves the app with NO terminal focused, and returning gives the
   // canvas dispatcher every keystroke, where a bare Backspace is `canvas.deleteSelection`. The
-  // refusals (a modal is open, a text surface or a terminal already holds focus) are the pure
-  // `nodeToRefocus`; this effect is the DOM read plus the request.
+  // refusals (a modal, the board or the settings page is up, a text surface or a terminal already
+  // holds focus) are the pure `nodeToRefocus`; this effect is the DOM read plus the request.
   //
   // Deferred by a macrotask rather than read inline: Chromium restores its own previously focused
   // element around window activation, and deciding before it has settled would read `<body>` and
   // steal focus from the settings field the user actually left the app from.
+  //
+  // `{ ack: false }`: coming back to the window is not evidence that the user has SEEN the node,
+  // and the ACK reaches past this machine (the notch capsule and the paired phone's Live Activity).
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | undefined
     const onWindowFocus = () => {
@@ -7277,9 +7285,13 @@ export function Canvas() {
         const target = nodeToRefocus({
           lastNodeId: useTerminalFocus.getState().lastNodeId,
           activeElement: document.activeElement as unknown as ContextElement | null,
-          openDialogs: openDialogCount()
+          openDialogs: openDialogCount(),
+          boardOpen: isKanbanOpen(useProjects.getState().activeProjectId),
+          settingsOpen: settingsOpenRef.current
         })
-        if (target) useTerminalFocus.getState().request(target)
+        if (target) {
+          useTerminalFocus.getState().request(target, { ack: false })
+        }
       }, 0)
     }
     window.addEventListener('focus', onWindowFocus)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -207,6 +207,8 @@ import {
 } from '../lib/globalKeybindings'
 import { isTerminalTarget, type ContextElement } from '../lib/keyContext'
 import { installTerminalFocusMirror } from '../lib/terminalFocusMirror'
+import { nodeToRefocus } from '../lib/focusRestore'
+import { openDialogCount } from '../components/dialog-stack'
 import {
   applyWindowTitle,
   composeWindowTitle,
@@ -7256,6 +7258,36 @@ export function Canvas() {
       }),
     []
   )
+
+  // Cmd+Tab back into the app: hand the keyboard to the terminal that last had it (issue #557).
+  // Terminal focus is pointer-driven (the hover guard blurs xterm on `mouseleave`), so a pointer
+  // parked on a second display leaves the app with NO terminal focused, and returning gives the
+  // canvas dispatcher every keystroke, where a bare Backspace is `canvas.deleteSelection`. The
+  // refusals (a modal is open, a text surface or a terminal already holds focus) are the pure
+  // `nodeToRefocus`; this effect is the DOM read plus the request.
+  //
+  // Deferred by a macrotask rather than read inline: Chromium restores its own previously focused
+  // element around window activation, and deciding before it has settled would read `<body>` and
+  // steal focus from the settings field the user actually left the app from.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const onWindowFocus = () => {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        const target = nodeToRefocus({
+          lastNodeId: useTerminalFocus.getState().lastNodeId,
+          activeElement: document.activeElement as unknown as ContextElement | null,
+          openDialogs: openDialogCount()
+        })
+        if (target) useTerminalFocus.getState().request(target)
+      }, 0)
+    }
+    window.addEventListener('focus', onWindowFocus)
+    return () => {
+      if (timer) clearTimeout(timer)
+      window.removeEventListener('focus', onWindowFocus)
+    }
+  }, [])
 
   // Active session → native window title (issue #414, opt-in `settings.windowTitleActiveSession`):
   // lets window-title-based time trackers (ActivityWatch) tell sessions apart. Two latest-wins

--- a/src/renderer/lib/focusRestore.test.ts
+++ b/src/renderer/lib/focusRestore.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { nodeToRefocus, type FocusRestoreState } from './focusRestore'
+import { XTERM_INPUT_CLASS } from './keyContext'
+
+const el = (tagName: string, cls: string[] = [], contentEditable = false) => ({
+  tagName,
+  isContentEditable: contentEditable,
+  classList: { contains: (name: string) => cls.includes(name) }
+})
+
+const state = (over: Partial<FocusRestoreState> = {}): FocusRestoreState => ({
+  lastNodeId: 'term-1',
+  activeElement: el('BODY'),
+  openDialogs: 0,
+  ...over
+})
+
+describe('nodeToRefocus', () => {
+  it('restores the last focused terminal when nothing else owns the keyboard', () => {
+    expect(nodeToRefocus(state())).toBe('term-1')
+  })
+
+  it('restores when focus sits on a non-typing element (a button, the canvas pane)', () => {
+    expect(nodeToRefocus(state({ activeElement: el('BUTTON') }))).toBe('term-1')
+  })
+
+  it('refuses without a remembered terminal', () => {
+    expect(nodeToRefocus(state({ lastNodeId: null }))).toBeNull()
+  })
+
+  it('refuses while a modal is open', () => {
+    expect(nodeToRefocus(state({ openDialogs: 1 }))).toBeNull()
+  })
+
+  it('refuses when a terminal already has focus', () => {
+    const term = el('TEXTAREA', [XTERM_INPUT_CLASS])
+    expect(nodeToRefocus(state({ activeElement: term }))).toBeNull()
+  })
+
+  it('refuses when a text field or editor has focus', () => {
+    expect(nodeToRefocus(state({ activeElement: el('INPUT') }))).toBeNull()
+    expect(nodeToRefocus(state({ activeElement: el('TEXTAREA') }))).toBeNull()
+    expect(nodeToRefocus(state({ activeElement: el('DIV', [], true) }))).toBeNull()
+  })
+
+  it('restores when nothing at all is focused', () => {
+    expect(nodeToRefocus(state({ activeElement: null }))).toBe('term-1')
+  })
+})

--- a/src/renderer/lib/focusRestore.test.ts
+++ b/src/renderer/lib/focusRestore.test.ts
@@ -14,6 +14,7 @@ const state = (over: Partial<FocusRestoreState> = {}): FocusRestoreState => ({
   openDialogs: 0,
   boardOpen: false,
   settingsOpen: false,
+  liveIds: new Set(['term-1']),
   ...over
 })
 
@@ -59,5 +60,23 @@ describe('nodeToRefocus', () => {
 
   it('restores when nothing at all is focused', () => {
     expect(nodeToRefocus(state({ activeElement: null }))).toBe('term-1')
+  })
+
+  it('refuses a remembered node that belongs to another project', () => {
+    // `lastNodeId` survives a project switch on purpose, and a request for an unmounted node is
+    // not dropped: it stays latent and fires when that node next mounts. Leaving project A with a
+    // terminal focused, switching to B and Cmd+Tabbing back would otherwise park a request that
+    // takes the keyboard on the next switch back to A, minutes after the activation.
+    expect(nodeToRefocus(state({ liveIds: new Set(['other-1', 'other-2']) }))).toBeNull()
+  })
+
+  it('refuses when the live nodes cannot be resolved at all', () => {
+    // Empty means "we do not know which project's nodes we are holding", not "the canvas is
+    // empty": the node array and the active project id do not turn over in one commit.
+    expect(nodeToRefocus(state({ liveIds: new Set() }))).toBeNull()
+  })
+
+  it('restores a node that is on the canvas alongside others', () => {
+    expect(nodeToRefocus(state({ liveIds: new Set(['other-1', 'term-1']) }))).toBe('term-1')
   })
 })

--- a/src/renderer/lib/focusRestore.test.ts
+++ b/src/renderer/lib/focusRestore.test.ts
@@ -12,6 +12,8 @@ const state = (over: Partial<FocusRestoreState> = {}): FocusRestoreState => ({
   lastNodeId: 'term-1',
   activeElement: el('BODY'),
   openDialogs: 0,
+  boardOpen: false,
+  settingsOpen: false,
   ...over
 })
 
@@ -30,6 +32,18 @@ describe('nodeToRefocus', () => {
 
   it('refuses while a modal is open', () => {
     expect(nodeToRefocus(state({ openDialogs: 1 }))).toBeNull()
+  })
+
+  it('refuses while the kanban board is up', () => {
+    // The board is an opaque overlay over a still-mounted canvas and registers no dialog, so the
+    // restore would aim the keyboard at a terminal the user cannot see.
+    expect(nodeToRefocus(state({ boardOpen: true }))).toBeNull()
+  })
+
+  it('refuses while the settings page is up', () => {
+    // Same shape as the board: a full-page surface outside the dialog stack, and its fields are
+    // only covered by the typing refusal once one of them actually has focus.
+    expect(nodeToRefocus(state({ settingsOpen: true }))).toBeNull()
   })
 
   it('refuses when a terminal already has focus', () => {

--- a/src/renderer/lib/focusRestore.ts
+++ b/src/renderer/lib/focusRestore.ts
@@ -1,0 +1,44 @@
+/**
+ * Which terminal (if any) should take the keyboard back when the window is activated again.
+ *
+ * Issue #557. Terminal focus in this app is pointer-driven: `TerminalNode`'s hover guard focuses
+ * xterm on a dwell or a click and BLURS it again on `mouseleave`. On a multi-monitor desk the
+ * pointer routinely leaves the node on its way to another display, so by the time the user
+ * Cmd+Tabs away the terminal has already lost focus, and coming back there is no pointer event
+ * left to hand it over. `document.activeElement` is `<body>`, the guard is armed again, and the
+ * next keystroke goes to the global dispatcher, where a bare Backspace is `canvas.deleteSelection`
+ * and opens the delete-node confirm over a terminal the user believed they were typing into.
+ *
+ * The decision is pure so the interesting refusals are testable without a window that can be
+ * activated: this runs on window activation, where reading the DOM by hand proves very little.
+ */
+import { isTerminalTarget, isTypingTarget, type ContextElement } from './keyContext'
+
+export interface FocusRestoreState {
+  /** The last terminal that held the keyboard (`useTerminalFocus.lastNodeId`). */
+  lastNodeId: string | null
+  /** Who holds focus at the moment the window came back. */
+  activeElement: ContextElement | null
+  /** How many modals are open (`openDialogCount()`). */
+  openDialogs: number
+}
+
+/**
+ * The node to hand the keyboard to, or `null` to leave focus exactly where the browser put it.
+ *
+ * Every refusal is "something else is already owning, or about to own, the keyboard":
+ * - **A modal is open**: a confirm, the card modal (whose own terminal focuses itself), a prompt.
+ *   Stealing focus out from under one is worse than the bug this fixes, and `openDialogCount`
+ *   already answers it for every modal in the app (they all register in the dialog stack).
+ * - **A typing surface has focus**: a settings field, a sticky's textarea, Monaco. Chromium
+ *   restores the previously focused element on activation, so this is the ordinary case of the
+ *   user having left the app from a text field; it is not ours to override.
+ * - **A terminal already has focus**: the pointer never left, so nothing was lost. Restoring
+ *   would be a no-op at best and could move focus to a DIFFERENT node at worst.
+ */
+export function nodeToRefocus(state: FocusRestoreState): string | null {
+  const { lastNodeId, activeElement, openDialogs } = state
+  if (!lastNodeId || openDialogs > 0) return null
+  if (isTerminalTarget(activeElement) || isTypingTarget(activeElement)) return null
+  return lastNodeId
+}

--- a/src/renderer/lib/focusRestore.ts
+++ b/src/renderer/lib/focusRestore.ts
@@ -30,6 +30,13 @@ export interface FocusRestoreState {
   boardOpen: boolean
   /** The settings page is up. Also outside the dialog stack, for the same reason as `boardOpen`. */
   settingsOpen: boolean
+  /**
+   * The nodes of the project currently on screen, by id.
+   *
+   * Empty means "we cannot tell which project's nodes we are holding", which refuses rather than
+   * guesses: `nodesRef` is only trustworthy while its epoch tag still matches the active project.
+   */
+  liveIds: ReadonlySet<string>
 }
 
 /**
@@ -49,10 +56,19 @@ export interface FocusRestoreState {
  *   user having left the app from a text field; it is not ours to override.
  * - **A terminal already has focus**: the pointer never left, so nothing was lost. Restoring
  *   would be a no-op at best and could move focus to a DIFFERENT node at worst.
+ * - **The remembered node is not on the canvas we are looking at**: `lastNodeId` deliberately
+ *   survives a project switch, and a request for an unmounted node is not dropped, it stays
+ *   LATENT until that node mounts (`TerminalNode`'s `lastFocusReqRef` starts at 0, and only the
+ *   consumer clears the store). So restoring a node that belongs to another project queues a
+ *   focus that fires minutes later, the next time the user switches back to it. Refusing here is
+ *   what keeps the restore bound to the canvas the activation actually returned to.
  */
 export function nodeToRefocus(state: FocusRestoreState): string | null {
-  const { lastNodeId, activeElement, openDialogs, boardOpen, settingsOpen } = state
+  const { lastNodeId, activeElement, openDialogs, boardOpen, settingsOpen, liveIds } = state
   if (!lastNodeId || openDialogs > 0) {
+    return null
+  }
+  if (!liveIds.has(lastNodeId)) {
     return null
   }
   if (boardOpen || settingsOpen) {

--- a/src/renderer/lib/focusRestore.ts
+++ b/src/renderer/lib/focusRestore.ts
@@ -21,6 +21,15 @@ export interface FocusRestoreState {
   activeElement: ContextElement | null
   /** How many modals are open (`openDialogCount()`). */
   openDialogs: number
+  /**
+   * The kanban board is up for the active project (`isKanbanOpen`).
+   *
+   * The board is NOT in the dialog stack, so `openDialogs` cannot see it. A full-page surface
+   * that covers the canvas without registering there owes a field of its own here.
+   */
+  boardOpen: boolean
+  /** The settings page is up. Also outside the dialog stack, for the same reason as `boardOpen`. */
+  settingsOpen: boolean
 }
 
 /**
@@ -30,6 +39,11 @@ export interface FocusRestoreState {
  * - **A modal is open**: a confirm, the card modal (whose own terminal focuses itself), a prompt.
  *   Stealing focus out from under one is worse than the bug this fixes, and `openDialogCount`
  *   already answers it for every modal in the app (they all register in the dialog stack).
+ * - **A full-page surface is up**: the kanban board and the settings page both paint an OPAQUE
+ *   layer over a still-mounted canvas, and neither registers in the dialog stack. Restoring under
+ *   one aims the keyboard at a terminal the user cannot see, which is the same hazard the modal
+ *   refusal exists for and worse than the bug: they are looking at the board and typing into a
+ *   pane somewhere behind it.
  * - **A typing surface has focus**: a settings field, a sticky's textarea, Monaco. Chromium
  *   restores the previously focused element on activation, so this is the ordinary case of the
  *   user having left the app from a text field; it is not ours to override.
@@ -37,8 +51,15 @@ export interface FocusRestoreState {
  *   would be a no-op at best and could move focus to a DIFFERENT node at worst.
  */
 export function nodeToRefocus(state: FocusRestoreState): string | null {
-  const { lastNodeId, activeElement, openDialogs } = state
-  if (!lastNodeId || openDialogs > 0) return null
-  if (isTerminalTarget(activeElement) || isTypingTarget(activeElement)) return null
+  const { lastNodeId, activeElement, openDialogs, boardOpen, settingsOpen } = state
+  if (!lastNodeId || openDialogs > 0) {
+    return null
+  }
+  if (boardOpen || settingsOpen) {
+    return null
+  }
+  if (isTerminalTarget(activeElement) || isTypingTarget(activeElement)) {
+    return null
+  }
   return lastNodeId
 }

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -4342,6 +4342,7 @@ export function TerminalNode({
     if (dwellRef.current) clearTimeout(dwellRef.current)
     setArmed(false)
     termRef.current?.focus()
+    useTerminalFocus.getState().remember(id)
     useAgentStatus.getState().setActive(id, true)
     useAgentStatus.getState().clearUnread(id)
     presence.reportFocus(id)
@@ -4374,6 +4375,7 @@ export function TerminalNode({
       }
       setArmed(false)
       termRef.current?.focus()
+      useTerminalFocus.getState().remember(id)
       useAgentStatus.getState().setActive(id, true)
       useAgentStatus.getState().clearUnread(id)
       // "I am working in this node" — the same signal the agent-status active flag uses, i.e. the
@@ -4494,6 +4496,7 @@ export function TerminalNode({
     // A paste came from THIS window, which already has it.
     if (opts.raiseWindow) window.nodeTerminal.focusWindow()
     term.focus()
+    useTerminalFocus.getState().remember(id)
     term.paste(paths.join(' ') + ' ')
     useAgentStatus.getState().setActive(id, true)
     presence.reportFocus(id)

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -4337,14 +4337,20 @@ export function TerminalNode({
    * Take the keyboard: leave the guard, focus xterm, and report the node active.
    *
    * Split out of `onBodyEnter` so a deliberate CLICK can run it with no delay — see `onGuardUp`.
+   *
+   * `ack` (default true) also marks the node's finish read. Every gesture that reaches here aims
+   * at THIS node — a dwell, a click, a sidebar or notification jump — so the read is real. The one
+   * caller that passes false is the window-activation restore, which nobody aimed at anything.
    */
-  const enterNow = () => {
+  const enterNow = (opts?: { ack?: boolean }) => {
     if (dwellRef.current) clearTimeout(dwellRef.current)
     setArmed(false)
     termRef.current?.focus()
     useTerminalFocus.getState().remember(id)
     useAgentStatus.getState().setActive(id, true)
-    useAgentStatus.getState().clearUnread(id)
+    if (opts?.ack !== false) {
+      useAgentStatus.getState().clearUnread(id)
+    }
     presence.reportFocus(id)
   }
 
@@ -4359,8 +4365,9 @@ export function TerminalNode({
   useEffect(() => {
     if (focusReq === 0 || focusReq === lastFocusReqRef.current) return
     lastFocusReqRef.current = focusReq
+    const { ack } = useTerminalFocus.getState()
     useTerminalFocus.setState({ nodeId: null })
-    enterNow()
+    enterNow({ ack })
     // enterNow closes over live refs/setters; re-running on its identity would fire spuriously.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusReq])

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -4334,21 +4334,29 @@ export function TerminalNode({
 
   // ---- hover guard: dwell before entering the terminal ----
   /**
-   * Take the keyboard: leave the guard, focus xterm, and report the node active.
+   * Take the keyboard: focus xterm, leave the guard, and report the node active.
    *
    * Split out of `onBodyEnter` so a deliberate CLICK can run it with no delay — see `onGuardUp`.
    *
-   * `ack` (default true) also marks the node's finish read. Every gesture that reaches here aims
-   * at THIS node — a dwell, a click, a sidebar or notification jump — so the read is real. The one
-   * caller that passes false is the window-activation restore, which nobody aimed at anything.
+   * `ack` (default true) says a human AIMED at this node, and two things follow from it. It marks
+   * the node's finish read, which reaches past this machine (`clearUnread` → `ackDone` → the notch
+   * capsule and the paired phone). And it drops the hover guard, which is a POINTER contract: the
+   * guard makes a quick scroll pan the canvas until the dwell has elapsed, so a restore nobody
+   * pointed at must leave it armed, or the next pointer entry silently skips its dwell and the
+   * first wheel scrolls tmux instead. Keyboard focus does not need the guard down: it is an
+   * overlay, and a programmatic `focus()` is not hit-tested.
+   *
+   * Every gesture that reaches here aims at THIS node: a dwell, a click, a sidebar or notification
+   * jump. The one caller that passes false is the window-activation restore.
    */
   const enterNow = (opts?: { ack?: boolean }) => {
+    const aimed = opts?.ack !== false
     if (dwellRef.current) clearTimeout(dwellRef.current)
-    setArmed(false)
+    if (aimed) setArmed(false)
     termRef.current?.focus()
     useTerminalFocus.getState().remember(id)
     useAgentStatus.getState().setActive(id, true)
-    if (opts?.ack !== false) {
+    if (aimed) {
       useAgentStatus.getState().clearUnread(id)
     }
     presence.reportFocus(id)

--- a/src/renderer/state/terminalFocus.test.ts
+++ b/src/renderer/state/terminalFocus.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { useTerminalFocus } from './terminalFocus'
 
-afterEach(() => useTerminalFocus.setState({ nodeId: null, nonce: 0 }))
+afterEach(() => useTerminalFocus.setState({ nodeId: null, nonce: 0, lastNodeId: null }))
 
 describe('useTerminalFocus', () => {
   it('records the requested node and bumps the nonce each time', () => {
@@ -24,5 +24,14 @@ describe('useTerminalFocus', () => {
     useTerminalFocus.setState({ nodeId: null })
     expect(useTerminalFocus.getState().nodeId).toBeNull()
     // The nonce is untouched, so no node's `s.nodeId === id ? s.nonce : 0` selector fires again.
+  })
+
+  it('remembers the last focused terminal and keeps it across a one-shot request', () => {
+    useTerminalFocus.getState().remember('node-a')
+    expect(useTerminalFocus.getState().lastNodeId).toBe('node-a')
+    useTerminalFocus.getState().request('node-a')
+    useTerminalFocus.setState({ nodeId: null })
+    // The consume clears the REQUEST, never the memory the window-activation restore reads.
+    expect(useTerminalFocus.getState().lastNodeId).toBe('node-a')
   })
 })

--- a/src/renderer/state/terminalFocus.test.ts
+++ b/src/renderer/state/terminalFocus.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { useTerminalFocus } from './terminalFocus'
 
-afterEach(() => useTerminalFocus.setState({ nodeId: null, nonce: 0, lastNodeId: null }))
+afterEach(() => useTerminalFocus.setState({ nodeId: null, nonce: 0, ack: true, lastNodeId: null }))
 
 describe('useTerminalFocus', () => {
   it('records the requested node and bumps the nonce each time', () => {
@@ -33,5 +33,16 @@ describe('useTerminalFocus', () => {
     useTerminalFocus.setState({ nodeId: null })
     // The consume clears the REQUEST, never the memory the window-activation restore reads.
     expect(useTerminalFocus.getState().lastNodeId).toBe('node-a')
+  })
+
+  it('acks by default and only skips the ack when the caller asks', () => {
+    useTerminalFocus.getState().request('node-a')
+    expect(useTerminalFocus.getState().ack).toBe(true)
+    useTerminalFocus.getState().request('node-a', { ack: false })
+    expect(useTerminalFocus.getState().ack).toBe(false)
+    // A later request that says nothing acks again, so one silent restore cannot mute the next
+    // deliberate jump to the same node.
+    useTerminalFocus.getState().request('node-a')
+    expect(useTerminalFocus.getState().ack).toBe(true)
   })
 })

--- a/src/renderer/state/terminalFocus.ts
+++ b/src/renderer/state/terminalFocus.ts
@@ -35,11 +35,17 @@ export const useTerminalFocus = create<{
    * that is gone or unmounted simply misses the request, the same fail-open as `request`.
    *
    * It therefore also survives a PROJECT SWITCH, so the remembered node can belong to another
-   * project. That fails open today because the request is consumed by a mounted `TerminalNode`
-   * and the node of an inactive project is unmounted. Load-bearing: a change that starts routing
-   * a focus request across projects (switching to the node's project first, as `focusNodeById`
-   * does) has to clear or qualify this, or a window activation would yank the user out of the
-   * project they are looking at.
+   * project. That does NOT fail open: a request for an unmounted node stays LATENT rather than
+   * being dropped. `nodeId` is cleared only by the consumer, and `TerminalNode`'s `lastFocusReqRef`
+   * starts at 0, so the node consumes the request the moment it mounts. The cross-project
+   * `pendingFocusRef` path in `Canvas` relies on exactly that, requesting right after a project
+   * loads and before the node exists.
+   *
+   * So the restore, not this field, is where the staleness is refused: `nodeToRefocus` takes the
+   * live nodes of the project on screen and returns null for an id that is not among them. Without
+   * it, leaving project A with a terminal focused, switching to B and Cmd+Tabbing back would park a
+   * request that fires on the next switch to A, handing a node the keyboard minutes after the
+   * activation nobody aimed at it.
    */
   lastNodeId: string | null
   /**

--- a/src/renderer/state/terminalFocus.ts
+++ b/src/renderer/state/terminalFocus.ts
@@ -18,6 +18,13 @@ export const useTerminalFocus = create<{
   /** Bumped on every request so re-requesting the same node still fires a subscriber effect. */
   nonce: number
   /**
+   * Whether consuming the pending request should also ACK the node's finish. See `request`.
+   *
+   * Carried on the request rather than decided by the consumer, because only the CALLER knows
+   * whether a human aimed at this node.
+   */
+  ack: boolean
+  /**
    * The last terminal that actually took the keyboard, kept AFTER it lost focus again.
    *
    * This is the memory the window-activation restore reads (`lib/focusRestore.ts`). It must
@@ -26,16 +33,32 @@ export const useTerminalFocus = create<{
    * out and back, where no pointer event is left to hand the keyboard over again. Clearing it on
    * blur would forget exactly the terminal we want back. It is never cleared explicitly: a node
    * that is gone or unmounted simply misses the request, the same fail-open as `request`.
+   *
+   * It therefore also survives a PROJECT SWITCH, so the remembered node can belong to another
+   * project. That fails open today because the request is consumed by a mounted `TerminalNode`
+   * and the node of an inactive project is unmounted. Load-bearing: a change that starts routing
+   * a focus request across projects (switching to the node's project first, as `focusNodeById`
+   * does) has to clear or qualify this, or a window activation would yank the user out of the
+   * project they are looking at.
    */
   lastNodeId: string | null
-  /** Ask a node's terminal to take the keyboard now. */
-  request(nodeId: string): void
+  /**
+   * Ask a node's terminal to take the keyboard now.
+   *
+   * `ack` (default true) also marks the node's finish read, everywhere: `clearUnread` calls
+   * `ackDone`, which resolves the notch capsule's blob and the paired phone's DONE Live Activity
+   * and Inbox card. That is right for a request a human aimed at a node (a sidebar click, a
+   * notification tap, ⌘K) and wrong for one the app raised on its own, so the window-activation
+   * restore passes `{ ack: false }`.
+   */
+  request(nodeId: string, opts?: { ack?: boolean }): void
   /** Record that this node's terminal has the keyboard (called where it takes focus). */
   remember(nodeId: string): void
 }>((set) => ({
   nodeId: null,
   nonce: 0,
+  ack: true,
   lastNodeId: null,
-  request: (nodeId) => set((s) => ({ nodeId, nonce: s.nonce + 1 })),
+  request: (nodeId, opts) => set((s) => ({ nodeId, nonce: s.nonce + 1, ack: opts?.ack !== false })),
   remember: (nodeId) => set({ lastNodeId: nodeId })
 }))

--- a/src/renderer/state/terminalFocus.ts
+++ b/src/renderer/state/terminalFocus.ts
@@ -17,10 +17,25 @@ export const useTerminalFocus = create<{
   nodeId: string | null
   /** Bumped on every request so re-requesting the same node still fires a subscriber effect. */
   nonce: number
+  /**
+   * The last terminal that actually took the keyboard, kept AFTER it lost focus again.
+   *
+   * This is the memory the window-activation restore reads (`lib/focusRestore.ts`). It must
+   * deliberately survive a blur: the case it exists for is a pointer that left the node (a second
+   * display, issue #557), which blurs the terminal through `onBodyLeave`, followed by a Cmd+Tab
+   * out and back, where no pointer event is left to hand the keyboard over again. Clearing it on
+   * blur would forget exactly the terminal we want back. It is never cleared explicitly: a node
+   * that is gone or unmounted simply misses the request, the same fail-open as `request`.
+   */
+  lastNodeId: string | null
   /** Ask a node's terminal to take the keyboard now. */
   request(nodeId: string): void
+  /** Record that this node's terminal has the keyboard (called where it takes focus). */
+  remember(nodeId: string): void
 }>((set) => ({
   nodeId: null,
   nonce: 0,
-  request: (nodeId) => set((s) => ({ nodeId, nonce: s.nonce + 1 }))
+  lastNodeId: null,
+  request: (nodeId) => set((s) => ({ nodeId, nonce: s.nonce + 1 })),
+  remember: (nodeId) => set({ lastNodeId: nodeId })
 }))


### PR DESCRIPTION
Fixes #557.

## The bug

Terminal focus in this app is pointer-driven. `TerminalNode`'s hover guard focuses xterm on a dwell or a click (`onBodyEnter` / `onGuardUp`) and **blurs it again on `mouseleave`** (`onBodyLeave`). That is deliberate, because the guard exists so a pointer merely passing over a terminal does not steal the keyboard, but it means focus has no owner once the pointer is elsewhere.

On a multi-monitor desk the pointer routinely leaves the node on its way to another display, so by the time the user Cmd+Tabs away **the terminal has already lost focus**. Coming back, there is no pointer event left to hand it over: `document.activeElement` is `<body>`, the guard is armed again, and the next keystroke reaches the global dispatcher instead. There `canvas.deleteSelection` has a bare `Backspace` default (`shared/keybindings.ts`), so pressing Backspace to delete a character opens the **delete-node confirm** over a terminal the user believed they were typing into.

That is exactly the sequence the reporter describes, and it explains why hovering cannot rescue it: the pointer is on another screen.

## The fix

`useTerminalFocus` gains a `lastNodeId` memory, recorded on the three paths where a terminal actually takes the keyboard (`enterNow`, the dwell `enter`, `insertFiles`). It **deliberately survives a blur**, since the blur is the case being repaired and clearing it there would forget precisely the terminal we want back. Nothing clears it explicitly: a node that is gone or unmounted simply misses the request, the same fail-open the existing one-shot `request` already has.

On window activation the canvas asks for that node through the request `TerminalNode` already consumes, so the restore reuses the click path (`enterNow`) rather than adding a second way to focus a terminal.

## Refusals

The decision is the pure `nodeToRefocus` (`renderer/lib/focusRestore.ts`), so the interesting cases are testable without a window that can be activated. It hands back `null`, leaving focus exactly where the browser put it, when:

- **a modal is open** (`openDialogCount() > 0`). Every modal registers in the dialog stack, the kanban `CardModal` included, whose own `ModalTerminal` focuses itself. Stealing focus out from under one is worse than the bug.
- **a typing surface has focus** (input, textarea, contentEditable, Monaco). Chromium restores the previously focused element on activation, so this is the ordinary case of the user having left the app from a text field.
- **a terminal already has focus**, meaning the pointer never left and nothing was lost.

The DOM read is deferred by a macrotask rather than taken inline: Chromium restores its own focused element around window activation, and deciding before that has settled would read `<body>` and steal focus from the settings field the user actually left the app from.

## What this deliberately does not change

The `Backspace` default on `canvas.deleteSelection` stays. It already goes through a confirm dialog, and dropping it would change behavior for every user who never hit this; the reporter's own workaround (unbinding it in Settings > Keyboard Shortcuts) remains available for anyone who prefers `Delete` / `Fn+Backspace` only.

## Surfaces

- **Desktop**: the target.
- **Server Edition**: works as-is. Pure renderer code, no new `window.nodeTerminal` member, no bridge change.
- **Mobile companion**: N/A, no canvas and no pointer-driven focus guard.

## Testing

- New `renderer/lib/focusRestore.test.ts` (7 cases: restore, and each refusal).
- `renderer/state/terminalFocus.test.ts` gains a case pinning that consuming the one-shot request does **not** clear the memory the restore reads.
- `npm run typecheck` clean; full suite 9299 passed. The 18 remaining failures are pre-existing and environment-bound (verified against a stashed tree): BSD `chmod --`, an over-long unix socket path in `$TMPDIR`, real-tmux/real-sh suites, `localStorage` in the node env, and one flaky `fs.watch` timing test.

Manually verified on macOS with the reported sequence: type in a terminal, move the pointer off the node, Cmd+Tab out and back, press Backspace, and it now lands in the terminal. Also checked that an open dialog, a focused text field and an open card modal all keep their focus.
