### PR TITLE
fix(terminal): verify both ends of the launch line, so a swallowed first character cannot submit

### DIFF
--- a/src/renderer/terminal/command-delivery.test.ts
+++ b/src/renderer/terminal/command-delivery.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DELIVERY_ATTEMPTS,
+  KILL_LINE,
   VERIFY_TIMEOUT_MS,
   cleanEcho,
   deliverCommand,
@@ -64,6 +65,15 @@ describe('echoedIntact', () => {
   it('does not match a truncated echo (flush ate the tail)', () => {
     expect(echoedIntact(CMD.slice(0, -6), CMD)).toBe(false)
   })
+  it('does not match an echo that lost its head (rc file read ate the first chars)', () => {
+    expect(echoedIntact(`% ${CMD.slice(1)}`, CMD)).toBe(false)
+  })
+  it('tolerates redraw text interleaved mid-line — the command need not be contiguous', () => {
+    // A ZLE re-wrap can splice printable prompt text into the echoed line. Both ENDS are still
+    // there, so this must verify: on the session-host leg a false negative refuses the launch.
+    const mid = Math.floor(CMD.length / 2)
+    expect(echoedIntact(`% ${CMD.slice(0, mid)}% ${CMD.slice(mid)}`, CMD)).toBe(true)
+  })
 })
 
 describe('deliverCommand', () => {
@@ -78,6 +88,19 @@ describe('deliverCommand', () => {
     f.emit('\x1b[32m% \x1b[0m' + CMD.slice(0, 40) + '\r\n')
     f.emit(CMD.slice(40))
     expect(f.writes).toEqual([CMD, '\r'])
+  })
+
+  it('does not submit a line whose head the shell never echoed (#556)', () => {
+    const f = fakeIo()
+    deliverCommand(f.io, CMD)
+    // An rc file reading the same tty during startup (oh-my-zsh's update prompt) swallows the
+    // first character, so the echo is missing its head while the TAIL is fully intact.
+    f.emit(`% ${CMD.slice(1)}`)
+    expect(f.writes).toEqual([CMD]) // no '\r': submitting here runs a mangled command
+    // The rewrite lands after the rc prompt consumed its answer, and then verifies.
+    vi.advanceTimersByTime(VERIFY_TIMEOUT_MS)
+    f.emit(`% ${CMD}`)
+    expect(f.writes).toEqual([CMD, KILL_LINE, CMD, '\r'])
   })
 
   it('kills the line and rewrites when the echo never completes, then succeeds', () => {

--- a/src/renderer/terminal/command-delivery.ts
+++ b/src/renderer/terminal/command-delivery.ts
@@ -3,16 +3,13 @@
 // rc/ZLE setup resets the tty with a FLUSH that can eat part of the queued line, and a
 // mangled line submitted anyway strands the shell at `quote>` (field report: 3 spawned
 // team agents, none started, each needed a manual `'` + Enter). So: write WITHOUT Enter,
-// wait until the shell has echoed the tail of the line back, THEN submit. A verify timeout
+// wait until the shell has echoed both ENDS of the line back, THEN submit. A verify timeout
 // kills the pending line (Ctrl-U) and rewrites; the LAST attempt submits unverified —
 // fail-open, a terminal whose echo we can't recognize must never block the launch (that
 // worst case is exactly the pre-fix behavior).
 
 export const VERIFY_TIMEOUT_MS = 2000
 export const DELIVERY_ATTEMPTS = 3
-/** Long enough to be unambiguous in the echo stream, short enough that a ZLE wrap/redraw
- *  sequence interleaved mid-line rarely lands inside the matched window. */
-export const ECHO_TAIL_CHARS = 24
 /** Ctrl-U — clear the pending input line before a rewrite. Exported because the in-place restart
  *  choreography clears the line the same way before typing its exit command (agent-restart.ts). */
 export const KILL_LINE = '\x15'
@@ -28,9 +25,33 @@ export function cleanEcho(chunk: string): string {
   return chunk.replace(ESC_SEQ, '').replace(/[\r\n]/g, '')
 }
 
-/** Has the shell echoed the full line? Tail-match: the head is polluted by the prompt. */
+/** Long enough to be unambiguous in the echo stream, short enough that a ZLE wrap/redraw
+ *  sequence interleaved mid-line rarely lands inside either matched window. */
+export const ECHO_EDGE_CHARS = 24
+
+/**
+ * Has the shell echoed the line? BOTH ENDS must appear, each as its own substring match.
+ *
+ * Tail-only (the original) was blind to a lost HEAD: an rc file that reads the same tty during
+ * startup swallows leading characters — oh-my-zsh's update prompt does exactly this — and the
+ * shell then echoes a line whose tail is fully intact, so verification passed and Enter
+ * submitted a mangled command the shell ran as garbage (#556).
+ *
+ * Requiring the WHOLE command contiguously would catch that, but it is too strict: a ZLE
+ * redraw can interleave printable prompt text inside the echoed line, so the cleaned stream
+ * need not contain the command in one piece. That matters asymmetrically — the renderer would
+ * merely stall and fail open, but the session-host leg clears the line and REFUSES the launch,
+ * turning a cosmetic false negative into a node that never starts.
+ *
+ * Two edge windows keep both properties: a truncated head or tail fails, while junk in the
+ * middle (or before the line) is tolerated. Commands shorter than 2×ECHO_EDGE_CHARS simply
+ * compare as a whole, which is the strictest form and safe at that length.
+ */
 export function echoedIntact(cleanedSoFar: string, cmd: string): boolean {
-  return cleanedSoFar.includes(cmd.slice(-ECHO_TAIL_CHARS))
+  return (
+    cleanedSoFar.includes(cmd.slice(0, ECHO_EDGE_CHARS)) &&
+    cleanedSoFar.includes(cmd.slice(-ECHO_EDGE_CHARS))
+  )
 }
 
 export interface DeliveryIo {

--- a/src/session-host/session.test.ts
+++ b/src/session-host/session.test.ts
@@ -542,3 +542,74 @@ describe('HostSession emulator output watermarks', () => {
     await expect(session.serialize()).resolves.toBe('good')
   })
 })
+
+describe('HostSession launch echo verification', () => {
+  // The launch line this leg actually carries: long enough that head and tail windows
+  // (ECHO_EDGE_CHARS = 24 each) do not overlap.
+  const COMMAND = 'claude --permission-mode auto --session-id 0f9a1c3e-5b7d-4e21-9a86-1d2c3b4a5e6f'
+
+  function deliveryProc(): { value: IPty; written: string[]; emit: (chunk: string) => void } {
+    let sink: ((d: string) => void) | undefined
+    const written: string[] = []
+    return {
+      value: {
+        pid: 42,
+        pause: vi.fn(),
+        resume: vi.fn(),
+        resize: vi.fn(),
+        write: (d: string) => {
+          written.push(d)
+        },
+        onData: (cb: (d: string) => void) => {
+          sink = cb
+          return { dispose: vi.fn() }
+        },
+        onExit: () => ({ dispose: vi.fn() })
+      } as unknown as IPty,
+      written,
+      emit: (chunk: string) => sink?.(chunk)
+    }
+  }
+
+  function deliver(session: HostSession, command: string): Promise<void> {
+    return (
+      session as unknown as { deliverVerifiedCommand(c: string): Promise<void> }
+    ).deliverVerifiedCommand(command)
+  }
+
+  it('submits when the head scrolled out of the bounded window before the tail arrived', async () => {
+    const proc = deliveryProc()
+    const session = new HostSession('echo-window', SPAWN, 100, {
+      proc: proc.value,
+      term: inertTerm()
+    })
+    const delivered = deliver(session, COMMAND)
+
+    // The shell echoes the head, then a full-line ZLE redraw pushes more than the window
+    // (max(command.length + 256, 512)) of visible characters through before the tail lands.
+    // Without a sticky head the two substrings never coexist in `echoed`, all three attempts
+    // fail, and this leg REFUSES the launch — the node never starts.
+    proc.emit(COMMAND.slice(0, 32))
+    proc.emit('x'.repeat(700))
+    proc.emit(COMMAND.slice(-32))
+
+    await expect(delivered).resolves.toBeUndefined()
+    expect(proc.written.at(-1)).toBe('\r')
+  })
+
+  it('still requires the head: a tail-only echo does not submit', async () => {
+    const proc = deliveryProc()
+    const session = new HostSession('echo-tail-only', SPAWN, 100, {
+      proc: proc.value,
+      term: inertTerm()
+    })
+    // Left pending on purpose: this asserts the NON-event, and the retry timer is unref'd.
+    void deliver(session, COMMAND).catch(() => {})
+
+    proc.emit('x'.repeat(700))
+    proc.emit(COMMAND.slice(-32))
+
+    // submit() is synchronous inside the data handler, so its absence is observable now.
+    expect(proc.written).not.toContain('\r')
+  })
+})

--- a/src/session-host/session.ts
+++ b/src/session-host/session.ts
@@ -14,8 +14,8 @@ const SHELL_QUIET_CAP_MS = 1_500
 const POST_LAUNCH_READY_CAP_MS = 5_000
 const LAUNCH_READINESS_POLL_MS = 100
 const VERIFY_TIMEOUT_MS = 2_000
+const ECHO_EDGE_CHARS = 24
 const DELIVERY_ATTEMPTS = 3
-const ECHO_TAIL_CHARS = 24
 const KILL_LINE = '\x15'
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 // eslint-disable-next-line no-control-regex
@@ -581,7 +581,15 @@ export class HostSession {
       dataSub = this.proc.onData((chunk) => {
         if (done) return
         echoed = (echoed + cleanEcho(chunk)).slice(-Math.max(command.length + 256, 512))
-        if (echoed.includes(command.slice(-ECHO_TAIL_CHARS))) submit()
+        // BOTH ends, not just the tail — see echoedIntact in the renderer's command-delivery for
+        // why a tail match let a head-truncated command through (#556), and why requiring the
+        // whole command contiguously would be too strict on this leg in particular: the retry
+        // exhaustion below REFUSES the launch rather than failing open.
+        if (
+          echoed.includes(command.slice(0, ECHO_EDGE_CHARS)) &&
+          echoed.includes(command.slice(-ECHO_EDGE_CHARS))
+        )
+          submit()
       })
       exitSub = this.proc.onExit(() =>
         finish(new Error('session-host terminal exited during launch delivery'))

--- a/src/session-host/session.ts
+++ b/src/session-host/session.ts
@@ -530,6 +530,13 @@ export class HostSession {
       let done = false
       let attempt = 0
       let echoed = ''
+      // The head is STICKY, because `echoed` below is a bounded window. A tail match is safe under
+      // that truncation by construction — the tail is what the window keeps — but a head is not:
+      // once a window's worth of bytes has arrived after it, the head is evicted and the two
+      // substrings need never coexist in the buffer even though both were genuinely echoed. This
+      // leg REFUSES on exhausted retries rather than failing open, so an evicted head would not
+      // merely retry, it would stop the node from starting.
+      let sawHead = false
       let timer: ReturnType<typeof setTimeout> | undefined
       let dataSub: { dispose(): void } | undefined
       let exitSub: { dispose(): void } | undefined
@@ -563,6 +570,7 @@ export class HostSession {
         if (done) return
         attempt++
         echoed = ''
+        sawHead = false
         timer = setTimeout(() => {
           if (done) return
           if (attempt >= DELIVERY_ATTEMPTS) {
@@ -580,16 +588,16 @@ export class HostSession {
       }
       dataSub = this.proc.onData((chunk) => {
         if (done) return
-        echoed = (echoed + cleanEcho(chunk)).slice(-Math.max(command.length + 256, 512))
         // BOTH ends, not just the tail — see echoedIntact in the renderer's command-delivery for
         // why a tail match let a head-truncated command through (#556), and why requiring the
         // whole command contiguously would be too strict on this leg in particular: the retry
         // exhaustion below REFUSES the launch rather than failing open.
-        if (
-          echoed.includes(command.slice(0, ECHO_EDGE_CHARS)) &&
-          echoed.includes(command.slice(-ECHO_EDGE_CHARS))
-        )
-          submit()
+        const merged = echoed + cleanEcho(chunk)
+        // Tested BEFORE the window is trimmed, so a head that arrived in an earlier chunk still
+        // counts once it has scrolled out. Same memory bound as before.
+        sawHead ||= merged.includes(command.slice(0, ECHO_EDGE_CHARS))
+        echoed = merged.slice(-Math.max(command.length + 256, 512))
+        if (sawHead && echoed.includes(command.slice(-ECHO_EDGE_CHARS))) submit()
       })
       exitSub = this.proc.onExit(() =>
         finish(new Error('session-host terminal exited during launch delivery'))


### PR DESCRIPTION
Closes #556.

### The reported diagnosis is not what happens

The report says nodeterm "types the startup command into the fresh PTY and hits Enter
immediately, without waiting for the shell to actually reach its prompt". That machinery does
exist — `command-delivery.ts` writes the line *without* Enter, waits for the shell to echo it,
and only then submits, with a Ctrl-U rewrite and three attempts. So the wait is there; the
verification is what lets this through.

### What actually happens

`echoedIntact` compared only the **tail**:

    return cleanedSoFar.includes(cmd.slice(-ECHO_TAIL_CHARS))   // last 24 chars

That was deliberate — the docstring says *"the head is polluted by the prompt"* — and it is
exactly blind to a lost **head**. An rc file that reads the same tty during startup swallows
the first character (oh-my-zsh's update prompt does this every 13 days by default). The shell
then echoes a line whose tail is fully intact, verification passes, Enter goes out, and the
shell runs the mangled remainder — matching the report's `laude --permission-mode auto`.

Verified in the shipped 0.3.4 bundle, not only on `main`.

### It is in two places

`src/session-host/session.ts` carries its own independent copy of the same check. Fixing only
the renderer would leave the Server Edition / SSH leg broken, so both are changed.

That leg also behaves differently in a way that shaped the fix: on retry exhaustion the
renderer submits unverified (fail-open), while the session-host clears the line and **refuses
the launch**.

### The fix

Both ends, each as its own substring match:

    return (
      cleanedSoFar.includes(cmd.slice(0, ECHO_EDGE_CHARS)) &&
      cleanedSoFar.includes(cmd.slice(-ECHO_EDGE_CHARS))
    )

A truncated head or tail fails; junk in the middle — or before the line — is tolerated.

I first tried requiring the whole command contiguously (`includes(cmd)`). That is too strict: a
ZLE redraw can splice printable prompt text into the echoed line, so the cleaned stream need
not contain the command in one piece. On the renderer that would only stall and fail open, but
on the session-host leg it would refuse the launch outright — a cosmetic false negative turned
into a node that never starts. Two edge windows keep the detection without that.

### Tests

Three added, and each was counter-proved against the variant it guards:

| change under test | result |
|---|---|
| revert to tail-only | the two #556 tests fail |
| require the whole command contiguously | the interleaving-tolerance test fails |
| head + tail (this PR) | 16/16 pass |

All 13 pre-existing delivery tests pass unchanged in every variant — the tail-only window was
not protecting a documented case.

`npm run typecheck` clean. Full suite: 9304 passed, 8 failed in 4 files — identical to the
baseline on `main` in my environment (I stashed the change and re-ran the same files to
confirm). Those 8 spawn a real `sh`/`tmux` or a socket and fail under my agent shell's sandbox,
not from this change.

### Open question for you

This doubles the number of windows that must match, so every echo-fidelity risk that already
applied to the tail now also applies to the head: a redraw splicing text inside a window, tab
or control-char expansion, or NFC/NFD differences in an edge. One mitigation is that a ZLE
re-wrap splices at the wrap column — deep into a long line — so the head window is probably
less exposed than the tail already was.

`ECHO_EDGE_CHARS` is left at the existing 24 for both ends, but that number is now doing two
jobs. A smaller head window would shrink the interleave exposure while still catching a lost
leading character; it would also raise the chance of a coincidental match against prompt text.
I did not want to pick that trade-off silently — happy to change it to whatever you measure.

### Not covered

The session-host leg has no unit coverage for launch delivery (the check is inline in a class
method driven by a real pty), so its change is verified by reading, not by a test. And the
line-based variant of the rc-file race — an rc `read` that consumes until a newline rather
than a single key — is untested; the reported shape swallows exactly one character.
