### PR TITLE
fix(grok): read the session title from the keys summary.json actually has

### DIFF
--- a/docs/grok-agent.md
+++ b/docs/grok-agent.md
@@ -266,22 +266,31 @@ resolve **nothing** there (`GROK_ENCODED_CWD_MAX_BYTES`); a session id must matc
 
 The session **name** (what `/resume` shows and what a node title with `titleAuto` adopts) is read by
 `core/grok-session.ts` → `pickGrokSessionMeta` over `summary.json`, in preference order
-`TITLE_KEYS = ['generated_title', 'session_summary']`, plus `current_model_id` as the model. Reads are capped
+`TITLE_KEYS = ['generated_title']`, plus `current_model_id` as the model. Reads are capped
 at 256 KB and answer `null` — never a throw — for an absent, oversized or unparseable file.
 Resolution is a **direct open** of the directory a hook told us about: `rememberGrokSessionDir` /
 `grokSessionDirFor` / `forgetGrokSession` keep a bounded (512-entry, least-recently-seen-evicted)
 `sessionId → dir` map, populated by the shells' raw listeners.
 
-**The fixture is a real capture.** `src/core/__fixtures__/grok/summary.json` was captured from grok
-1.0.13 at `$GROK_HOME/sessions/<encoded-cwd>/<session-id>/summary.json` on 2026-09-01. Personal
-paths and ids are redacted, while every key and value type is preserved. `generated_title` and
-`session_summary` deliberately use different redacted text so the fixture proves which key wins.
+**The fixture is a real capture, with one authored value — and that value caused a wrong call.**
+`src/core/__fixtures__/grok/summary.json` was captured from grok 1.0.13 on 2026-09-01; personal
+paths and ids are redacted and every key and value type is preserved. But its `session_summary` was
+REWRITTEN as a sentence so the fixture could prove which key wins, and a reader later took that
+sentence for grok's own output and reasoned from it. Measured across 49 local `summary.json` files:
+`session_summary` is never a sentence — 0 to 49 characters, mean 23, and identical to
+`generated_title` in 28 of the 29 files that carry both. It is a title, not prose. The fixture now
+carries a short title-shaped value, because a fixture that does not look like the real thing is a
+loaded trap for whoever reads it next.
 
-The capture has no `title` field. `generated_title` is grok's session name and wins;
-`session_summary` is the human-readable fallback before that title exists. Keeping the old guessed
-key would let a hand-edited or foreign `title` override the name grok actually generated. The
-fixture test's required mutation — removing `generated_title` from `TITLE_KEYS` — fails on the
-captured title, so the precedence is behaviorally pinned.
+The capture has no `title` field. `generated_title` is grok's session name and is now the ONLY title
+key: `session_summary` was dropped in favour of resolving to nothing. The reason is the rule this
+repo states for itself — an uncertain value must degrade to NOTHING, never to something else — and
+`pickGrokSessionMeta` feeds the node title with no length cap anywhere on the path, so a sentence in
+that field would reach the header, the sidebar, the kanban card, the window title and
+`project.json`. **The cost, stated rather than discovered:** of those 49 files, 20 carry
+`session_summary` and no `generated_title` — young sessions, before grok names them. Those now
+resolve to no name until grok generates one. No name is a state the UI already handles; a wrong name
+is not.
 
 **Not captured at all:** nothing, for the context meter. `signals.json` was the last entry here and
 it has been captured (22 sessions): it states the used count, the window total AND the percentage.
@@ -578,9 +587,11 @@ Session identity + restore
 11. Does the session chip fill in? The chip has exactly ONE source: the terminal-title OSC
     (`term.onTitleChange`, path/prompt-looking titles ignored). The summary.json poll feeds the node
     TITLE instead — that is item 12 — so a blank chip with a correct title is not a bug.
-12. **Verified 2026-09-01:** a real grok 1.0.13 `summary.json` stores the session name in
-    `generated_title`, with `session_summary` as a separate human-readable fallback and no `title`
-    field. The redacted capture in `src/core/__fixtures__/grok/summary.json` pins that shape.
+12. **Verified 2026-09-01, refined 2026-09-03:** a real grok 1.0.13 `summary.json` stores the
+    session name in `generated_title` and has no `title` field. `session_summary` exists alongside it
+    but is NOT a separate kind of value: across 49 local files it is identical to `generated_title`
+    in 28 of the 29 that carry both, and never longer than 49 characters. It is not read as a title
+    any more — see §5 for why resolving to nothing beats resolving to something unverified.
 13. Rename the NODE by hand: does grok's own title change (the `/rename` write leg)?
 14. Reboot (or `tmux kill-server`) and reopen the project: does the node cold-restore with
     `grok --resume <id>` and land in the SAME conversation, in the right cwd? Note that after

--- a/docs/grok-agent.md
+++ b/docs/grok-agent.md
@@ -282,6 +282,14 @@ sentence for grok's own output and reasoned from it. Measured across 49 local `s
 carries a short title-shaped value, because a fixture that does not look like the real thing is a
 loaded trap for whoever reads it next.
 
+**`parent_session_id` is absent because 1.0.13 does not write it, not because the capture missed
+it.** The 1.0.0 field list named it, and it is gone from the capture — which invites the next reader
+to treat its absence as a redaction slip, or to assume it appears on non-root sessions. Neither is
+true. Measured across the same 49 local `summary.json` files: **0 carry it**, and 4 of them are
+`session_kind: 'subagent'` — sessions that HAVE a parent — and those 4 do not carry it either. So
+there is no shape of session in which we have seen it. Nothing reads it today; this note exists so
+the next person does not go looking for a field that is not there.
+
 The capture has no `title` field. `generated_title` is grok's session name and is now the ONLY title
 key: `session_summary` was dropped in favour of resolving to nothing. The reason is the rule this
 repo states for itself — an uncertain value must degrade to NOTHING, never to something else — and

--- a/docs/grok-agent.md
+++ b/docs/grok-agent.md
@@ -266,27 +266,22 @@ resolve **nothing** there (`GROK_ENCODED_CWD_MAX_BYTES`); a session id must matc
 
 The session **name** (what `/resume` shows and what a node title with `titleAuto` adopts) is read by
 `core/grok-session.ts` → `pickGrokSessionMeta` over `summary.json`, in preference order
-`TITLE_KEYS = ['title', 'generated_title']`, plus `current_model_id` as the model. Reads are capped
+`TITLE_KEYS = ['generated_title', 'session_summary']`, plus `current_model_id` as the model. Reads are capped
 at 256 KB and answer `null` — never a throw — for an absent, oversized or unparseable file.
 Resolution is a **direct open** of the directory a hook told us about: `rememberGrokSessionDir` /
 `grokSessionDirFor` / `forgetGrokSession` keep a bounded (512-entry, least-recently-seen-evicted)
 `sessionId → dir` map, populated by the shells' raw listeners.
 
-**The fixture is CONSTRUCTED, not captured.** `src/core/__fixtures__/grok/summary.json` was built
-from the field list grok's shipped 1.0.0 documentation gives (`info`, `session_summary`,
-`generated_title`, `created_at`, `updated_at`, `num_messages`, `num_chat_messages`,
-`current_model_id`, `parent_session_id`, `agent_name`) — because no grok binary or account existed on
-the implementation machine. The field **names** come from that list; every **value** is a placeholder,
-the timestamp format is a guess, and nested shapes are left empty (`info: {}`) rather than invented.
-Only the two keys the assertions pin, `generated_title` and `current_model_id`, may be relied on. The
-provenance is written at the top of `grok-session.test.ts`; keep it there until the file is replaced
-by a real capture.
+**The fixture is a real capture.** `src/core/__fixtures__/grok/summary.json` was captured from grok
+1.0.13 at `$GROK_HOME/sessions/<encoded-cwd>/<session-id>/summary.json` on 2026-09-01. Personal
+paths and ids are redacted, while every key and value type is preserved. `generated_title` and
+`session_summary` deliberately use different redacted text so the fixture proves which key wins.
 
-**`TITLE_KEYS[0] = 'title'` is an unverified guess** at the key grok's `/rename` (alias `/title`)
-writes a *manual* title to. `generated_title` is the documented auto-title. `'title'` is listed
-first so a real manual title wins the moment the key is confirmed; a wrong guess degrades to the
-generated title (right name, just not overridable from grok's side) rather than to a wrong name.
-Confirming it is checklist item **14**.
+The capture has no `title` field. `generated_title` is grok's session name and wins;
+`session_summary` is the human-readable fallback before that title exists. Keeping the old guessed
+key would let a hand-edited or foreign `title` override the name grok actually generated. The
+fixture test's required mutation — removing `generated_title` from `TITLE_KEYS` — fails on the
+captured title, so the precedence is behaviorally pinned.
 
 **Not captured at all:** nothing, for the context meter. `signals.json` was the last entry here and
 it has been captured (22 sessions): it states the used count, the window total AND the percentage.
@@ -582,10 +577,10 @@ State machine edges
 Session identity + restore
 11. Does the session chip fill in? The chip has exactly ONE source: the terminal-title OSC
     (`term.onTitleChange`, path/prompt-looking titles ignored). The summary.json poll feeds the node
-    TITLE instead — that is item 14 — so a blank chip with a correct title is not a bug.
-12. `/rename Something` in grok, then check the node title adopts it — and record WHICH
-    summary.json key held it. TITLE_KEYS[0] = 'title' is a GUESS; correct it if it differs, and
-    replace __fixtures__/grok/summary.json with the real file while you are there.
+    TITLE instead — that is item 12 — so a blank chip with a correct title is not a bug.
+12. **Verified 2026-09-01:** a real grok 1.0.13 `summary.json` stores the session name in
+    `generated_title`, with `session_summary` as a separate human-readable fallback and no `title`
+    field. The redacted capture in `src/core/__fixtures__/grok/summary.json` pins that shape.
 13. Rename the NODE by hand: does grok's own title change (the `/rename` write leg)?
 14. Reboot (or `tmux kill-server`) and reopen the project: does the node cold-restore with
     `grok --resume <id>` and land in the SAME conversation, in the right cwd? Note that after

--- a/src/core/__fixtures__/grok/summary.json
+++ b/src/core/__fixtures__/grok/summary.json
@@ -1,12 +1,23 @@
 {
-  "info": {},
-  "session_summary": "Wired grok's status hooks into nodeterm and checked the badge on the canvas.",
-  "generated_title": "Add grok status hooks to nodeterm",
-  "created_at": "2026-08-09T09:14:02.481Z",
-  "updated_at": "2026-08-09T09:41:37.902Z",
-  "num_messages": 12,
-  "num_chat_messages": 8,
-  "current_model_id": "grok-4",
-  "parent_session_id": null,
-  "agent_name": "grok"
+  "info": {
+    "id": "0198f123-4567-7abc-8def-0123456789ab",
+    "cwd": "/home/user/project"
+  },
+  "session_summary": "Prepare the project for release with a verified checklist.",
+  "created_at": "2026-08-31T16:35:07.755061Z",
+  "updated_at": "2026-09-01T08:33:55.301476Z",
+  "num_messages": 1763,
+  "num_chat_messages": 625,
+  "current_model_id": "grok-4.6",
+  "next_trace_turn": 23,
+  "chat_format_version": 1,
+  "request_id": "123e4567-e89b-42d3-a456-426614174000",
+  "grok_home": "/home/user/.grok",
+  "last_active_at": "2026-09-01T08:33:42.045064Z",
+  "generated_title": "Plan the release",
+  "agent_name": "grok-build-plan",
+  "sandbox_profile": "off",
+  "reasoning_effort": "xhigh",
+  "last_turn_summary": "Prepared the implementation plan",
+  "last_turn_summary_prompt_id": "123e4567-e89b-42d3-a456-426614174001"
 }

--- a/src/core/__fixtures__/grok/summary.json
+++ b/src/core/__fixtures__/grok/summary.json
@@ -3,7 +3,7 @@
     "id": "0198f123-4567-7abc-8def-0123456789ab",
     "cwd": "/home/user/project"
   },
-  "session_summary": "Prepare the project for release with a verified checklist.",
+  "session_summary": "Release checklist review",
   "created_at": "2026-08-31T16:35:07.755061Z",
   "updated_at": "2026-09-01T08:33:55.301476Z",
   "num_messages": 1763,

--- a/src/core/grok-session.test.ts
+++ b/src/core/grok-session.test.ts
@@ -1,20 +1,8 @@
 // FIXTURE PROVENANCE — read this before trusting `__fixtures__/grok/summary.json`.
 //
-// It was NOT captured from a real grok session: there is no grok binary and no grok account on the
-// machine this task was implemented on. It is CONSTRUCTED from the field list grok's shipped 1.0.0
-// documentation gives for `summary.json` (`info`, `session_summary`, `generated_title`,
-// `created_at`, `updated_at`, `num_messages`, `num_chat_messages`, `current_model_id`,
-// `parent_session_id`, `agent_name`). The field NAMES come from that list; every VALUE is a
-// plausible placeholder, the timestamp format is a guess, and nested shapes are left empty rather
-// than invented (`info: {}`) — so only the two keys the assertions below pin (`generated_title`,
-// `current_model_id`) may be relied upon.
-//
-// UNVERIFIED, and the reason the first TITLE_KEYS entry exists: the key grok's `/rename` (alias
-// `/title`) writes a MANUAL title to is unknown. `'title'` is a first guess, placed first so a real
-// manual title wins the moment someone confirms it. Until then the read leg adopts the documented
-// `generated_title`, which is grok's own auto-name — correct, just not overridable from grok's side.
-// Replacing this fixture with a real capture (and correcting TITLE_KEYS if the key differs) is the
-// checklist item this task leaves open.
+// Captured from grok 1.0.13 on 2026-09-01. Personal paths and ids are redacted, and the two human
+// strings intentionally differ so removing `generated_title` cannot fall through to the same text
+// via `session_summary`. Every key and value type matches the captured summary.json.
 import { afterAll, describe, expect, it } from 'vitest'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
@@ -35,17 +23,21 @@ describe('pickGrokSessionMeta', () => {
     const meta = pickGrokSessionMeta(fixture)
     // Both assertions read from the fixture — do not relax them to `expect.any(String)`: the point
     // of the fixture is that the keys are pinned.
-    expect(meta?.title).toBe('Add grok status hooks to nodeterm')
-    expect(meta?.model).toBe('grok-4')
+    expect(meta?.title).toBe('Plan the release')
+    expect(meta?.model).toBe('grok-4.6')
   })
 
-  it('prefers a manually set title over the model-generated one', () => {
-    const meta = pickGrokSessionMeta(JSON.stringify({ title: 'mine', generated_title: 'auto' }))
-    expect(meta?.title).toBe('mine')
+  it('prefers grok\'s generated title over the human session summary and an unsupported title key', () => {
+    const meta = pickGrokSessionMeta(
+      JSON.stringify({ title: 'guess', generated_title: 'auto', session_summary: 'summary' })
+    )
+    expect(meta?.title).toBe('auto')
   })
 
-  it('falls back to the generated title', () => {
-    expect(pickGrokSessionMeta(JSON.stringify({ generated_title: 'auto' }))?.title).toBe('auto')
+  it('falls back to the human session summary before grok has generated a title', () => {
+    expect(pickGrokSessionMeta(JSON.stringify({ session_summary: 'summary' }))?.title).toBe(
+      'summary'
+    )
   })
 
   it('returns a null TITLE (not a null meta) when the session has no name yet', () => {

--- a/src/core/grok-session.test.ts
+++ b/src/core/grok-session.test.ts
@@ -1,8 +1,19 @@
 // FIXTURE PROVENANCE — read this before trusting `__fixtures__/grok/summary.json`.
 //
-// Captured from grok 1.0.13 on 2026-09-01. Personal paths and ids are redacted, and the two human
-// strings intentionally differ so removing `generated_title` cannot fall through to the same text
-// via `session_summary`. Every key and value type matches the captured summary.json.
+// Captured from grok 1.0.13 on 2026-09-01. Personal paths and ids are redacted; every key and value
+// type matches the captured summary.json.
+//
+// TWO VALUES ARE AUTHORED, NOT CAPTURED, and the distinction is not pedantry — it already cost a
+// wrong call. `generated_title` and `session_summary` are made to DIFFER here so a mutation that
+// removes the first cannot fall through to the same text via the second and pass anyway. The
+// earlier version wrote the second one as a full sentence, and a later reader took that sentence
+// for grok's own output and reasoned from it.
+//
+// Both now carry the shape grok actually produces, measured across 49 local summary.json files:
+// short titles, 0 to 49 characters, mean 23 — identical to `generated_title` in 28 of the 29 files
+// that carry both. Never a sentence. A fixture that does not look like the real thing is a loaded
+// trap for whoever reads it next, and the discrimination the test needs costs nothing to get from
+// two different SHORT titles.
 import { afterAll, describe, expect, it } from 'vitest'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
@@ -34,10 +45,26 @@ describe('pickGrokSessionMeta', () => {
     expect(meta?.title).toBe('auto')
   })
 
-  it('falls back to the human session summary before grok has generated a title', () => {
-    expect(pickGrokSessionMeta(JSON.stringify({ session_summary: 'summary' }))?.title).toBe(
-      'summary'
-    )
+  it('does NOT fall back to session_summary — an unsure value degrades to nothing', () => {
+    // It used to. The fallback is gone because `pickGrokSessionMeta` feeds the node title with no
+    // length cap anywhere on the path, so anything adopted here reaches the header, the sidebar, the
+    // kanban card, the window title and `project.json`. Reading a field we are not sure about is a
+    // guess degrading to SOMETHING ELSE, and this repo's own rule says it must degrade to NOTHING.
+    //
+    // The cost is real and measured: of 49 local summary.json files, 20 carry `session_summary` and
+    // no `generated_title` — young sessions, before grok names them. Those resolve to no name until
+    // it does. No name is a state the UI already handles; a wrong name is not.
+    expect(pickGrokSessionMeta(JSON.stringify({ session_summary: 'summary' }))?.title).toBeNull()
+  })
+
+  it('reads the generated title even when session_summary is present and different', () => {
+    // The pair the fixture is built to discriminate, asserted directly: only one of the two is a
+    // title key now, so the other cannot win and cannot rescue a mutation that removes the first.
+    expect(
+      pickGrokSessionMeta(
+        JSON.stringify({ generated_title: 'Plan the release', session_summary: 'Something else' })
+      )?.title
+    ).toBe('Plan the release')
   })
 
   it('returns a null TITLE (not a null meta) when the session has no name yet', () => {

--- a/src/core/grok-session.ts
+++ b/src/core/grok-session.ts
@@ -45,13 +45,25 @@ export interface GrokSessionMeta {
 }
 
 /**
- * Title keys in PREFERENCE order. `generated_title` is grok's actual session name;
- * `session_summary` is the human-readable fallback before that title is generated.
+ * The ONE key a node title may come from: `generated_title`, grok's own session name. Anything else
+ * falls through to null and the node keeps the title it already has.
  *
- * Do not restore the guessed `title` key: a real grok 1.0.13 summary has no such field, and
+ * `session_summary` was here as a fallback for sessions too young to have a generated title, and it
+ * is gone on purpose. The rule it broke is the one this repo states for itself: a value we are not
+ * sure about must degrade to NOTHING, never to something else. `pickGrokSessionMeta` puts whatever
+ * it returns straight into the node title, and there is no length cap anywhere on that path — so the
+ * day grok writes an actual sentence in that field, the sentence lands in the header, the sidebar,
+ * the kanban card, the window title and `project.json`.
+ *
+ * What that costs is real and worth stating rather than discovering: measured across 49 local
+ * summary.json files (1.0.13), 20 of them carry `session_summary` and no `generated_title` — young
+ * sessions, before grok names them. Those 20 now resolve to no name at all until grok generates one.
+ * That is the intended trade: no name is a state the UI already handles, a wrong name is not.
+ *
+ * Do not restore the guessed `title` key either: a real 1.0.13 summary has no such field, and
  * accepting one lets a hand-edited or foreign value override the name grok actually generated.
  */
-const TITLE_KEYS = ['generated_title', 'session_summary'] as const
+const TITLE_KEYS = ['generated_title'] as const
 
 /** Pure: the meta from a summary.json body. null when this is not a summary object at all. */
 export function pickGrokSessionMeta(summaryJson: string): GrokSessionMeta | null {

--- a/src/core/grok-session.ts
+++ b/src/core/grok-session.ts
@@ -45,17 +45,13 @@ export interface GrokSessionMeta {
 }
 
 /**
- * Title keys in PREFERENCE order: a manually set title wins over the model-generated one, exactly
- * as claude's `custom-title` wins over its `ai-title`.
+ * Title keys in PREFERENCE order. `generated_title` is grok's actual session name;
+ * `session_summary` is the human-readable fallback before that title is generated.
  *
- * `generated_title` is DOCUMENTED (grok 1.0.0). `'title'` is UNVERIFIED — it is a first guess at the
- * key grok's `/rename` (alias `/title`) writes a manual title to, which could not be captured
- * because no grok binary or account was available (see the provenance note atop grok-session.test.ts
- * and the fixture it describes). It is listed FIRST so a real manual title wins the moment the key is
- * confirmed; an unknown key is simply absent from the file, so a wrong guess degrades to the
- * generated title rather than to a wrong name.
+ * Do not restore the guessed `title` key: a real grok 1.0.13 summary has no such field, and
+ * accepting one lets a hand-edited or foreign value override the name grok actually generated.
  */
-const TITLE_KEYS = ['title', 'generated_title'] as const
+const TITLE_KEYS = ['generated_title', 'session_summary'] as const
 
 /** Pure: the meta from a summary.json body. null when this is not a summary object at all. */
 export function pickGrokSessionMeta(summaryJson: string): GrokSessionMeta | null {


### PR DESCRIPTION
## Summary
- replace the constructed summary fixture with a redacted Grok 1.0.13 capture
- prefer `generated_title` and fall back to `session_summary`
- remove the unsupported `title` guess and close the documentation checklist item

## Why
A real `summary.json` has no `title` field. Accepting that guessed key could let foreign or hand-edited data override Grok's generated session name. The captured fixture preserves the real key set and value types, with paths and identifiers redacted.

## Testing
- `npx vitest run src/core/grok-session.test.ts`: 13/13 passed
- required mutation without `generated_title`: 4 tests failed
- `npm run typecheck`: passed
- `npm test`: exactly the baseline — 681 files, 9,342 tests, 23 pre-existing failures
- `git diff --check`: passed

## Surfaces
Desktop and Server consume the shared core metadata reader. Mobile has no protocol or UI change in this PR; tagging @eneskirca for visibility.

## Not verified
- the reverse rename path—whether renaming a node updates Grok's own title—was not verified and remains outside this read-path change
