### PR TITLE
fix(canvas): make snap-to-grid actually snap, on resize and on placement

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -644,14 +644,25 @@ const NO_EPHEMERAL: { ephemeralNodes: CanvasNode[]; ephemeralEdges: Edge[] } = {
  * inherits the agent's `parentId`), which is the whole point of storing an offset — grouping or
  * ungrouping the agent flips that space between absolute and group-relative, and a stored
  * position would then teleport the card by the group's own x/y.
+ *
+ * `snap` (0 = off) rounds the LAID-OUT default onto the grid: React Flow's `snapToGrid` only
+ * constrains a drag, so a fan-out card landed off-grid and only jumped into place once the user
+ * nudged it. A DRAGGED offset is left alone — it was already snapped at drag time if the mode was
+ * on, and re-rounding it here would move cards the user placed by hand while it was off.
  */
 const offsetFrom = (
   parent: { position: { x: number; y: number } },
   stored: { x: number; y: number } | undefined,
-  fallback: { x: number; y: number }
+  fallback: { x: number; y: number },
+  snap = 0
 ): { x: number; y: number } => {
   const off = stored ?? fallback
-  return { x: parent.position.x + off.x, y: parent.position.y + off.y }
+  const x = parent.position.x + off.x
+  const y = parent.position.y + off.y
+  if (stored || !snap) {
+    return { x, y }
+  }
+  return { x: Math.round(x / snap) * snap, y: Math.round(y / snap) * snap }
 }
 
 // Delivering an armed node's held launch (canvas-control `--after`) can lose the race against
@@ -1606,6 +1617,8 @@ export function Canvas() {
   // Selection state for ephemeral nodes (they live outside React Flow's managed nodes), owned by
   // the agent-nodes store so the cards themselves can set it — see `selectable: false` below.
   const ephSelId = useAgentNodes((s) => s.selectedId)
+  // Grid the laid-out fan-out cards round onto (0 = snap off) — see offsetFrom.
+  const ephSnap = settings.snapToGrid ? settings.gridSize || GRID : 0
   const { ephemeralNodes, ephemeralEdges } = useMemo(() => {
     // Common case: no /loop running and no subagents → return a stable empty result so
     // this memo (which depends on `nodes`, i.e. recomputes every drag frame) stays cheap
@@ -1644,7 +1657,7 @@ export function Canvas() {
         // with the group). Deliberately no extent:'parent' — the fan-out may hang below the
         // frame border without being clamped into it.
         ...(parent.parentId ? { parentId: parent.parentId } : {}),
-        position: offsetFrom(parent, ephemeralPos[lid], { x: -250, y: ph + 60 }),
+        position: offsetFrom(parent, ephemeralPos[lid], { x: -250, y: ph + 60 }, ephSnap),
         draggable: true,
         // NOT selectable: React Flow's rubber band would otherwise sweep a whole fan-out of cards
         // into the selection alongside the real nodes, and every selection action (Group,
@@ -1694,10 +1707,15 @@ export function Canvas() {
           type: 'subagent',
           // Same coordinate-space rule as the loop card above: inherit the agent's group.
           ...(parent.parentId ? { parentId: parent.parentId } : {}),
-          position: offsetFrom(parent, ephemeralPos[cid], {
-            x: (i % COLS) * COL_W,
-            y: ph + 60 + Math.floor(i / COLS) * ROW_H
-          }),
+          position: offsetFrom(
+            parent,
+            ephemeralPos[cid],
+            {
+              x: (i % COLS) * COL_W,
+              y: ph + 60 + Math.floor(i / COLS) * ROW_H
+            },
+            ephSnap
+          ),
           draggable: true,
           selectable: false, // see the loop card above
           selected: ephSelId === cid,
@@ -1728,7 +1746,7 @@ export function Canvas() {
     }
     return { ephemeralNodes: eNodes, ephemeralEdges: eEdges }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- loopSig stands in for the byId read
-  }, [agentById, loopSig, ephemeralPos, ephSizes, ephExpanded, ephSelId, nodes])
+  }, [agentById, loopSig, ephemeralPos, ephSizes, ephExpanded, ephSelId, ephSnap, nodes])
 
   // Merge the persisted nodes with the ephemeral ones and the webview keep-alive pool once per
   // change (not per render), so React Flow's array-identity short-circuit holds while

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -155,6 +155,7 @@ import { reopenVariants } from '../lib/reopenVariants'
 import { modelsForAgent } from '@shared/agents/model-gateway'
 import { useModelGateway } from '../state/modelGateway'
 import { viewportAtZoom } from '../lib/zoomReset'
+import { containerOrigin, snapPointInRootSpace } from '../lib/gridSnap'
 import { zoomFromPct } from '../lib/zoomPresets'
 import { CANVAS_MAX_ZOOM, CANVAS_MIN_ZOOM } from './zoom-limits'
 import { isSpaceRelease, spacePanKeydown } from '../lib/spacePan'
@@ -645,24 +646,27 @@ const NO_EPHEMERAL: { ephemeralNodes: CanvasNode[]; ephemeralEdges: Edge[] } = {
  * ungrouping the agent flips that space between absolute and group-relative, and a stored
  * position would then teleport the card by the group's own x/y.
  *
- * `snap` (0 = off) rounds the LAID-OUT default onto the grid: React Flow's `snapToGrid` only
+ * `snap` (absent = off) rounds the LAID-OUT default onto the grid: React Flow's `snapToGrid` only
  * constrains a drag, so a fan-out card landed off-grid and only jumped into place once the user
  * nudged it. A DRAGGED offset is left alone — it was already snapped at drag time if the mode was
  * on, and re-rounding it here would move cards the user placed by hand while it was off.
+ *
+ * The snap carries its container's root-space `origin` because the composed position above is
+ * container-relative, and React Flow's own drag snap works in root space — see
+ * `snapPointInRootSpace`.
  */
 const offsetFrom = (
   parent: { position: { x: number; y: number } },
   stored: { x: number; y: number } | undefined,
   fallback: { x: number; y: number },
-  snap = 0
+  snap?: { grid: number; origin: { x: number; y: number } }
 ): { x: number; y: number } => {
   const off = stored ?? fallback
-  const x = parent.position.x + off.x
-  const y = parent.position.y + off.y
+  const position = { x: parent.position.x + off.x, y: parent.position.y + off.y }
   if (stored || !snap) {
-    return { x, y }
+    return position
   }
-  return { x: Math.round(x / snap) * snap, y: Math.round(y / snap) * snap }
+  return snapPointInRootSpace(position, snap.origin, snap.grid)
 }
 
 // Delivering an armed node's held launch (canvas-control `--after`) can lose the race against
@@ -1617,7 +1621,9 @@ export function Canvas() {
   // Selection state for ephemeral nodes (they live outside React Flow's managed nodes), owned by
   // the agent-nodes store so the cards themselves can set it — see `selectable: false` below.
   const ephSelId = useAgentNodes((s) => s.selectedId)
-  // Grid the laid-out fan-out cards round onto (0 = snap off) — see offsetFrom.
+  // Grid the laid-out fan-out cards round onto (0 = snap off) — see offsetFrom. A hand-edited
+  // `gridSize: 0` reads as "use the default" here, exactly as it does everywhere else on this
+  // canvas, rather than as a second way to switch snapping off.
   const ephSnap = settings.snapToGrid ? settings.gridSize || GRID : 0
   const { ephemeralNodes, ephemeralEdges } = useMemo(() => {
     // Common case: no /loop running and no subagents → return a stable empty result so
@@ -1648,6 +1654,9 @@ export function Canvas() {
       if (!parent || parent.data.hideFanout) continue
       const ph = parent.measured?.height ?? (parent.height as number) ?? 400
       const accent = agentConfig((parent.data.agentId as string) ?? 'claude')?.color ?? '#d97757'
+      const snap = ephSnap
+        ? { grid: ephSnap, origin: containerOrigin(parent.parentId, nodes) }
+        : undefined
       const lid = `loop-${pid}`
       eNodes.push({
         id: lid,
@@ -1657,7 +1666,7 @@ export function Canvas() {
         // with the group). Deliberately no extent:'parent' — the fan-out may hang below the
         // frame border without being clamped into it.
         ...(parent.parentId ? { parentId: parent.parentId } : {}),
-        position: offsetFrom(parent, ephemeralPos[lid], { x: -250, y: ph + 60 }, ephSnap),
+        position: offsetFrom(parent, ephemeralPos[lid], { x: -250, y: ph + 60 }, snap),
         draggable: true,
         // NOT selectable: React Flow's rubber band would otherwise sweep a whole fan-out of cards
         // into the selection alongside the real nodes, and every selection action (Group,
@@ -1697,6 +1706,9 @@ export function Canvas() {
       if (!parent || parent.data.hideFanout) continue
       const ph = parent.measured?.height ?? (parent.height as number) ?? 400
       const accent = agentConfig((parent.data.agentId as string) ?? 'claude')?.color ?? '#d97757'
+      const snap = ephSnap
+        ? { grid: ephSnap, origin: containerOrigin(parent.parentId, nodes) }
+        : undefined
       const COLS = 4
       const COL_W = 240
       const ROW_H = 140
@@ -1714,7 +1726,7 @@ export function Canvas() {
               x: (i % COLS) * COL_W,
               y: ph + 60 + Math.floor(i / COLS) * ROW_H
             },
-            ephSnap
+            snap
           ),
           draggable: true,
           selectable: false, // see the loop card above

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -433,6 +433,7 @@ import type { KanbanCreateChoice, KanbanSession } from '../components/kanban/Kan
 import { assignNode, assignedTo, defaultKanban, labelsForCard, migrateProjectTags, resolveColumnRef, unassigned } from '../lib/kanban'
 import { registerWorkspaceDirty } from '../state/workspaceDirty'
 import { snapNodeToGrid } from '../lib/nodeSizing'
+import { snapResizeChanges } from '../lib/resizeSnap'
 import { canClearDirty, canCommitCanvas, canCreateOnCanvas } from '../state/persistGuards'
 import { isHidden } from '../lib/ui-visibility'
 import { boardLogEvents } from '../lib/boardLogDiff'
@@ -2945,8 +2946,14 @@ export function Canvas() {
         }
         return true
       })
-      onNodesChange(managed)
-      if (managed.some((c) => c.type !== 'select')) markDirty()
+      // Re-snap what the resizer proposes before it is applied, so a resize tracks the grid
+      // during the drag instead of correcting itself on release (see lib/resizeSnap.ts).
+      const settings = useSettings.getState().settings
+      const snapped = settings.snapToGrid
+        ? snapResizeChanges(managed, nodesRef.current, settings.gridSize || GRID)
+        : managed
+      onNodesChange(snapped)
+      if (snapped.some((c) => c.type !== 'select')) markDirty()
     },
     [onNodesChange, markDirty, ephParentPosition]
   )

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -2948,9 +2948,9 @@ export function Canvas() {
       })
       // Re-snap what the resizer proposes before it is applied, so a resize tracks the grid
       // during the drag instead of correcting itself on release (see lib/resizeSnap.ts).
-      const settings = useSettings.getState().settings
-      const snapped = settings.snapToGrid
-        ? snapResizeChanges(managed, nodesRef.current, settings.gridSize || GRID)
+      const snapSettings = useSettings.getState().settings
+      const snapped = snapSettings.snapToGrid
+        ? snapResizeChanges(managed, nodesRef.current, snapSettings.gridSize || GRID)
         : managed
       onNodesChange(snapped)
       if (snapped.some((c) => c.type !== 'select')) markDirty()

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -516,6 +516,17 @@ const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 
 const GRID = 24
 
+/**
+ * The grid a structural edit should snap to right now, 0 when snapping is off. Read through
+ * `getState()` rather than the component's `settings`, so a callback that is not re-created per
+ * settings change cannot act on a stale value. `gridSize: 0` reads as "use the default", exactly
+ * as it does everywhere else on this canvas.
+ */
+function snapGridNow(): number {
+  const settings = useSettings.getState().settings
+  return settings.snapToGrid ? settings.gridSize || GRID : 0
+}
+
 /** The empty opaque set (glyphgrid), shared so the render-time compute allocates nothing on the
  *  overwhelmingly common "nothing overlaps / layer off" path. */
 const EMPTY_OPAQUE: string[] = []
@@ -4975,7 +4986,7 @@ export function Canvas() {
   const groupSelection = useCallback(
     (ids: string[]) => {
       const groupCount = nodesRef.current.filter((n) => n.type === 'group').length
-      setNodes((ns) => groupSelectedNodes(ns as CanvasNode[], ids, groupCount))
+      setNodes((ns) => groupSelectedNodes(ns as CanvasNode[], ids, groupCount, snapGridNow()))
       markDirty()
     },
     [setNodes, markDirty]
@@ -4985,7 +4996,7 @@ export function Canvas() {
   // always makes a new one). Only subtree roots move — see addSelectionToGroup.
   const addToExistingGroup = useCallback(
     (ids: string[], groupId: string) => {
-      setNodes((nodes) => addSelectionToGroup(nodes as CanvasNode[], ids, groupId))
+      setNodes((nodes) => addSelectionToGroup(nodes as CanvasNode[], ids, groupId, snapGridNow()))
       markDirty()
     },
     [setNodes, markDirty]
@@ -9385,7 +9396,7 @@ export function Canvas() {
               return
             }
             const groupCount = live.filter((nd) => nd.type === 'group').length
-            let grouped = groupSelectedNodes(live, resolvable, groupCount)
+            let grouped = groupSelectedNodes(live, resolvable, groupCount, snapGridNow())
             // The new frame is no longer guaranteed to be first (it is emitted in tree order),
             // and a refused set returns the array unchanged — find it by id instead.
             const oldIds = new Set(live.map((node) => node.id))
@@ -9460,7 +9471,7 @@ export function Canvas() {
               if (was?.parentId) affected.add(was.parentId)
             }
             for (const g of affected) {
-              if (next.some((n) => n.parentId === g)) next = fitGroupToChildren(next, g)
+              if (next.some((n) => n.parentId === g)) next = fitGroupToChildren(next, g, snapGridNow())
             }
             setNodes(next)
             markDirty()
@@ -9498,7 +9509,7 @@ export function Canvas() {
               : alignNodes(live, ids, edge!)
             // Tidying a frame's children usually leaves the frame oversized (it was sized to their
             // old scattered spots) — shrink it to hug the new layout. Top-level sets have no frame.
-            if (container) next = fitGroupToChildren(next, container)
+            if (container) next = fitGroupToChildren(next, container, snapGridNow())
             setNodes(next)
             markDirty()
             const how = verb === 'arrange' ? `as ${layout}` : `to ${edge}`
@@ -9638,7 +9649,7 @@ export function Canvas() {
             const existingGroupIds = new Set(
               next.filter((node) => node.type === 'group').map((node) => node.id)
             )
-            next = groupSelectedNodes(next, panelIds, vGroupCount)
+            next = groupSelectedNodes(next, panelIds, vGroupCount, snapGridNow())
             const vGroup = next.find(
               (node) => node.type === 'group' && !existingGroupIds.has(node.id)
             )!
@@ -9766,7 +9777,7 @@ export function Canvas() {
             const existingGroupIds = new Set(
               next.filter((node) => node.type === 'group').map((node) => node.id)
             )
-            next = groupSelectedNodes(next, memberIds, groupCount)
+            next = groupSelectedNodes(next, memberIds, groupCount, snapGridNow())
             const teamGroup = next.find(
               (node) => node.type === 'group' && !existingGroupIds.has(node.id)
             )!

--- a/src/renderer/lib/gridSnap.test.ts
+++ b/src/renderer/lib/gridSnap.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import type { CanvasNode } from '../state/workspace'
+import { containerOrigin, snapPointInRootSpace, snapRectInRootSpace } from './gridSnap'
+
+const G = 20
+
+const node = (
+  id: string,
+  type: string,
+  pos: { x: number; y: number },
+  parentId?: string
+): CanvasNode =>
+  ({
+    id,
+    type,
+    position: pos,
+    width: 320,
+    height: 240,
+    data: { title: id, color: '#888', group: null },
+    ...(parentId ? { parentId, extent: 'parent' as const } : {})
+  }) as unknown as CanvasNode
+
+// `groupSelectedNodes` creates a frame at (minX - 28, minY - 62), so an off-grid frame origin is
+// the normal case rather than an edge case.
+const FRAME = { x: -28, y: -62 }
+
+// `%` keeps the sign of its left operand, so a negative grid multiple yields -0 and `toBe(0)`
+// fails on a value that is on the grid.
+const onGrid = (value: number): boolean => Math.abs(value % G) === 0
+
+describe('containerOrigin', () => {
+  it('is the root for a top-level object', () => {
+    expect(containerOrigin(undefined, [])).toEqual({ x: 0, y: 0 })
+  })
+
+  it('is the frame own root position', () => {
+    const nodes = [node('g1', 'group', FRAME)]
+    expect(containerOrigin('g1', nodes)).toEqual(FRAME)
+  })
+
+  it('sums every ancestor frame in a nested tree', () => {
+    const nodes = [node('g1', 'group', { x: 100, y: 50 }), node('g2', 'group', { x: 7, y: 3 }, 'g1')]
+    expect(containerOrigin('g2', nodes)).toEqual({ x: 107, y: 53 })
+  })
+
+  it('falls back to the root for a dangling parentId', () => {
+    expect(containerOrigin('gone', [node('g1', 'group', FRAME)])).toEqual({ x: 0, y: 0 })
+  })
+})
+
+describe('snapPointInRootSpace', () => {
+  it('snaps a top-level point onto the canvas grid', () => {
+    expect(snapPointInRootSpace({ x: 113, y: 47 }, { x: 0, y: 0 }, G)).toEqual({ x: 120, y: 40 })
+  })
+
+  it('lands a card inside an off-grid frame on the CANVAS grid, not the frame grid', () => {
+    // The card's stored position is frame-relative; only origin + position is on the canvas.
+    const out = snapPointInRootSpace({ x: 113, y: 47 }, FRAME, G)
+    expect(out.x + FRAME.x).toBe(80)
+    expect(out.y + FRAME.y).toBe(-20)
+    expect(onGrid(out.x + FRAME.x)).toBe(true)
+    expect(onGrid(out.y + FRAME.y)).toBe(true)
+  })
+
+  it('is what React Flow drag snap would produce, so the first drag does not move the card', () => {
+    const position = { x: 113, y: 47 }
+    const snapped = snapPointInRootSpace(position, FRAME, G)
+    // XYDrag: snap in flow coordinates, then subtract the parent origin.
+    const dragged = {
+      x: Math.round((snapped.x + FRAME.x) / G) * G - FRAME.x,
+      y: Math.round((snapped.y + FRAME.y) / G) * G - FRAME.y
+    }
+    expect(dragged).toEqual(snapped)
+  })
+
+  it('rounding frame-relative instead would put the card on a different grid', () => {
+    // The bug this helper exists for: the old math rounded the composed frame-relative value.
+    const frameRelative = { x: Math.round(113 / G) * G, y: Math.round(47 / G) * G }
+    expect(snapPointInRootSpace({ x: 113, y: 47 }, FRAME, G)).not.toEqual(frameRelative)
+  })
+
+  it('normalizes -0 so it never reaches project.json', () => {
+    const out = snapPointInRootSpace({ x: -2, y: -3 }, { x: 0, y: 0 }, G)
+    expect(Object.is(out.x, -0)).toBe(false)
+    expect(Object.is(out.y, -0)).toBe(false)
+  })
+
+  it('is a no-op when snapping is off', () => {
+    const point = { x: 113, y: 47 }
+    expect(snapPointInRootSpace(point, FRAME, 0)).toBe(point)
+  })
+})
+
+describe('snapRectInRootSpace', () => {
+  it('snaps every edge of a top-level rect onto the grid', () => {
+    const out = snapRectInRootSpace(
+      { x: 113, y: 47, width: 331, height: 205 },
+      { x: 0, y: 0 },
+      G,
+      'terminal'
+    )
+    expect(onGrid(out.x)).toBe(true)
+    expect(onGrid(out.y)).toBe(true)
+    expect(onGrid(out.x + out.width)).toBe(true)
+    expect(onGrid(out.y + out.height)).toBe(true)
+  })
+
+  it('puts a child rect edges on the CANVAS grid, not the frame grid', () => {
+    const out = snapRectInRootSpace({ x: 113, y: 47, width: 331, height: 205 }, FRAME, G, 'terminal')
+    expect(onGrid(out.x + FRAME.x)).toBe(true)
+    expect(onGrid(out.y + FRAME.y)).toBe(true)
+    expect(onGrid(out.x + FRAME.x + out.width)).toBe(true)
+    expect(onGrid(out.y + FRAME.y + out.height)).toBe(true)
+  })
+
+  it('is a no-op when snapping is off', () => {
+    const rect = { x: 113, y: 47, width: 331, height: 205 }
+    expect(snapRectInRootSpace(rect, FRAME, 0, 'terminal')).toBe(rect)
+  })
+})

--- a/src/renderer/lib/gridSnap.ts
+++ b/src/renderer/lib/gridSnap.ts
@@ -1,6 +1,4 @@
 import type { NodeKind } from '@shared/types'
-import type { CanvasNode } from '../state/workspace'
-import { rootPosition } from '../state/workspace'
 import { snapNodeToGrid, type Rect } from './nodeSizing'
 
 export interface Point {
@@ -8,19 +6,9 @@ export interface Point {
   y: number
 }
 
-const ROOT_ORIGIN: Point = { x: 0, y: 0 }
-
-/**
- * Root-space origin of the container `parentId` names: (0, 0) for a top-level object, else the
- * frame's own root position. A missing frame resolves to the root rather than throwing, matching
- * how the rest of the canvas treats a dangling parentId.
- */
-export function containerOrigin(parentId: string | undefined, nodes: CanvasNode[]): Point {
-  if (!parentId) return ROOT_ORIGIN
-  const frame = nodes.find((node) => node.id === parentId)
-  if (!frame) return ROOT_ORIGIN
-  return rootPosition(frame, nodes)
-}
+// One home, in the module that owns `rootPosition`; re-exported so this stays the import site
+// every snap caller already uses.
+export { containerOrigin } from '../state/workspace'
 
 /**
  * Snap a CONTAINER-relative point onto the canvas grid.
@@ -28,9 +16,12 @@ export function containerOrigin(parentId: string | undefined, nodes: CanvasNode[
  * React Flow snaps a drag in flow (root) coordinates and only converts to parent-relative
  * afterwards: `XYDrag` runs `snapPosition(nextPosition, snapGrid)` and `calculateNodePosition`
  * subtracts the parent origin after that. Rounding a parent-relative value directly instead puts
- * the object on the FRAME's grid, and `groupSelectedNodes` creates frames at
- * `(minX - 28, minY - 62)`, so an off-grid frame origin is the normal case — the two grids then
- * differ by the frame's own fractional offset and the first drag moves the object again.
+ * the object on the FRAME's grid, and the two grids then differ by the frame's own fractional
+ * offset, so the first drag moves the object again.
+ *
+ * `groupSelectedNodes` now places a frame on the grid when snapping is on, but this stays
+ * load-bearing: a frame created with snapping off, or moved while it was off, keeps a fractional
+ * origin for the rest of its life.
  */
 export function snapPointInRootSpace(point: Point, origin: Point, grid: number): Point {
   if (grid <= 0) return point

--- a/src/renderer/lib/gridSnap.ts
+++ b/src/renderer/lib/gridSnap.ts
@@ -1,0 +1,63 @@
+import type { NodeKind } from '@shared/types'
+import type { CanvasNode } from '../state/workspace'
+import { rootPosition } from '../state/workspace'
+import { snapNodeToGrid, type Rect } from './nodeSizing'
+
+export interface Point {
+  x: number
+  y: number
+}
+
+const ROOT_ORIGIN: Point = { x: 0, y: 0 }
+
+/**
+ * Root-space origin of the container `parentId` names: (0, 0) for a top-level object, else the
+ * frame's own root position. A missing frame resolves to the root rather than throwing, matching
+ * how the rest of the canvas treats a dangling parentId.
+ */
+export function containerOrigin(parentId: string | undefined, nodes: CanvasNode[]): Point {
+  if (!parentId) return ROOT_ORIGIN
+  const frame = nodes.find((node) => node.id === parentId)
+  if (!frame) return ROOT_ORIGIN
+  return rootPosition(frame, nodes)
+}
+
+/**
+ * Snap a CONTAINER-relative point onto the canvas grid.
+ *
+ * React Flow snaps a drag in flow (root) coordinates and only converts to parent-relative
+ * afterwards: `XYDrag` runs `snapPosition(nextPosition, snapGrid)` and `calculateNodePosition`
+ * subtracts the parent origin after that. Rounding a parent-relative value directly instead puts
+ * the object on the FRAME's grid, and `groupSelectedNodes` creates frames at
+ * `(minX - 28, minY - 62)`, so an off-grid frame origin is the normal case — the two grids then
+ * differ by the frame's own fractional offset and the first drag moves the object again.
+ */
+export function snapPointInRootSpace(point: Point, origin: Point, grid: number): Point {
+  if (grid <= 0) return point
+  const x = Math.round((point.x + origin.x) / grid) * grid - origin.x
+  const y = Math.round((point.y + origin.y) / grid) * grid - origin.y
+  // `+ 0` normalizes the -0 that rounding a small negative coordinate produces, which would
+  // otherwise ride into node positions and out to project.json.
+  return { x: x + 0, y: y + 0 }
+}
+
+/**
+ * Snap a CONTAINER-relative rect onto the canvas grid, in root space for the reason above, then
+ * hand it back in the caller's coordinate space. Sizes are grid deltas, so only the origin has to
+ * cross spaces.
+ */
+export function snapRectInRootSpace(rect: Rect, origin: Point, grid: number, kind: NodeKind): Rect {
+  if (grid <= 0) return rect
+  const snapped = snapNodeToGrid(grid, kind, {
+    x: rect.x + origin.x,
+    y: rect.y + origin.y,
+    width: rect.width,
+    height: rect.height
+  })
+  return {
+    x: snapped.x - origin.x + 0,
+    y: snapped.y - origin.y + 0,
+    width: snapped.width,
+    height: snapped.height
+  }
+}

--- a/src/renderer/lib/nodeSizing.test.ts
+++ b/src/renderer/lib/nodeSizing.test.ts
@@ -51,6 +51,23 @@ describe('snapNodeToGrid', () => {
     expect(r.height).toBe(216)
   })
 
+  // What the resize wiring needs: React Flow adds a grid-multiple DELTA to whatever width the
+  // node started at, so an off-grid node can never reach a multiple by resizing. One snap has to
+  // land it there from any start, or the correction only moves the problem.
+  it('lands any off-grid box on grid multiples in one step', () => {
+    for (let width = 263; width < 420; width += 7) {
+      const r = snapNodeToGrid(20, 'terminal', { x: 13, y: 7, width, height: width - 90 })
+
+      expect([r.x % 20, r.y % 20, r.width % 20, r.height % 20]).toEqual([0, 0, 0, 0])
+    }
+  })
+
+  it('is idempotent, so the next resize starts from a clean base', () => {
+    const once = snapNodeToGrid(20, 'terminal', { x: 13, y: 7, width: 331, height: 199 })
+
+    expect(snapNodeToGrid(20, 'terminal', once)).toEqual(once)
+  })
+
   it('every kind has a positive min-size entry', () => {
     const kinds: NodeKind[] = [
       'terminal', 'sticky', 'group', 'editor', 'diff',

--- a/src/renderer/lib/nodeSizing.test.ts
+++ b/src/renderer/lib/nodeSizing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { NODE_MIN_SIZES, snapNodeToGrid } from './nodeSizing'
+import { NODE_MIN_SIZES, expandRectToGrid, snapNodeToGrid } from './nodeSizing'
 import type { NodeKind } from '@shared/types'
 
 const G = 24
@@ -78,5 +78,48 @@ describe('snapNodeToGrid', () => {
       expect(NODE_MIN_SIZES[k].width).toBeGreaterThan(0)
       expect(NODE_MIN_SIZES[k].height).toBeGreaterThan(0)
     }
+  })
+})
+
+describe('expandRectToGrid', () => {
+  it('grows the rect outward: left/top floor, right/bottom ceil', () => {
+    // x=10 -> 0 (not the nearer 24), right=210 -> 216, so the rect only ever gains area.
+    const r = expandRectToGrid(G, 'sticky', { x: 10, y: 10, width: 200, height: 200 })
+    expect(r).toEqual({ x: 0, y: 0, width: 216, height: 216 })
+  })
+
+  it('never pulls an edge inward, where nearest-rounding would', () => {
+    // x=20 is nearer to 24 than to 0, so snapNodeToGrid moves the left edge RIGHT by 4,
+    // eating 4px of whatever clearance the caller put there.
+    const rect = { x: 20, y: 20, width: 400, height: 400 }
+    expect(snapNodeToGrid(G, 'group', rect).x).toBe(24)
+    const grown = expandRectToGrid(G, 'group', rect)
+    expect(grown.x).toBe(0)
+    expect(grown.y).toBeLessThanOrEqual(rect.y)
+    expect(grown.x + grown.width).toBeGreaterThanOrEqual(rect.x + rect.width)
+    expect(grown.y + grown.height).toBeGreaterThanOrEqual(rect.y + rect.height)
+  })
+
+  it('lands every corner on a grid intersection, negative origins included', () => {
+    const r = expandRectToGrid(G, 'sticky', { x: -13, y: -47, width: 190, height: 205 })
+    // Math.abs: a negative multiple modulo the grid is -0, which toBe distinguishes from 0.
+    expect(Math.abs(r.x % G)).toBe(0)
+    expect(Math.abs(r.y % G)).toBe(0)
+    expect(Math.abs((r.x + r.width) % G)).toBe(0)
+    expect(Math.abs((r.y + r.height) % G)).toBe(0)
+  })
+
+  it('raises a small rect to the kind grid-aligned minimum, extending right/bottom only', () => {
+    const r = expandRectToGrid(G, 'group', { x: 0, y: 0, width: 10, height: 10 })
+    expect(r.x).toBe(0)
+    expect(r.y).toBe(0)
+    expect(r.width).toBeGreaterThanOrEqual(NODE_MIN_SIZES.group.width)
+    expect(r.height).toBeGreaterThanOrEqual(NODE_MIN_SIZES.group.height)
+  })
+
+  it('normalizes -0 so it cannot ride into a persisted position', () => {
+    const r = expandRectToGrid(G, 'sticky', { x: -0, y: -0, width: 240, height: 240 })
+    expect(Object.is(r.x, -0)).toBe(false)
+    expect(Object.is(r.y, -0)).toBe(false)
   })
 })

--- a/src/renderer/lib/nodeSizing.ts
+++ b/src/renderer/lib/nodeSizing.ts
@@ -52,3 +52,25 @@ export function snapNodeToGrid(g: number, kind: NodeKind, r: Rect): Rect {
   if (height < minH) height = minH
   return { x, y, width, height }
 }
+
+/**
+ * Snap a rectangle onto the grid by growing it: left/top round DOWN, right/bottom round UP, so
+ * every edge lands on a grid line and the rect never loses area. `snapNodeToGrid` rounds each
+ * edge to the nearest line instead, which is right for a resize (the user is aiming an edge) and
+ * wrong for a frame that has to keep a minimum clearance around what it wraps — nearest-rounding
+ * pulls an edge inward by up to half a grid and eats the padding.
+ */
+export function expandRectToGrid(g: number, kind: NodeKind, r: Rect): Rect {
+  // `+ 0` normalizes the -0 that flooring a small negative coordinate produces, which would
+  // otherwise ride into node positions and out to project.json.
+  const x = Math.floor(r.x / g) * g + 0
+  const y = Math.floor(r.y / g) * g + 0
+  let width = Math.ceil((r.x + r.width) / g) * g - x
+  let height = Math.ceil((r.y + r.height) / g) * g - y
+  const min = NODE_MIN_SIZES[kind] ?? { width: 0, height: 0 }
+  const minW = Math.ceil(min.width / g) * g
+  const minH = Math.ceil(min.height / g) * g
+  if (width < minW) width = minW
+  if (height < minH) height = minH
+  return { x, y, width, height }
+}

--- a/src/renderer/lib/resizeSnap.test.ts
+++ b/src/renderer/lib/resizeSnap.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import type { NodeChange } from '@xyflow/react'
+import type { CanvasNode } from '../state/workspace'
+import { snapResizeChanges } from './resizeSnap'
+
+const G = 20
+
+/** A terminal node sitting off-grid, which is the only case the whole module exists for. */
+function node(over: Partial<CanvasNode> = {}): CanvasNode {
+  return {
+    id: 'n1',
+    type: 'terminal',
+    position: { x: 13, y: 7 },
+    data: {},
+    measured: { width: 613, height: 371 },
+    ...over
+  } as CanvasNode
+}
+
+const resize = (width: number, height: number, resizing = true): NodeChange<CanvasNode> =>
+  ({ id: 'n1', type: 'dimensions', resizing, dimensions: { width, height } }) as NodeChange<CanvasNode>
+
+const dims = (changes: NodeChange<CanvasNode>[]): { width: number; height: number } | undefined =>
+  changes.flatMap((c) => (c.type === 'dimensions' && c.dimensions ? [c.dimensions] : []))[0]
+
+const pos = (changes: NodeChange<CanvasNode>[]): { x: number; y: number } | undefined =>
+  changes.flatMap((c) => (c.type === 'position' && c.position ? [c.position] : []))[0]
+
+describe('snapResizeChanges', () => {
+  it('lands an in-flight resize on grid multiples, not on start + a multiple', () => {
+    // What React Flow proposes: 613 + 20, off-grid like the 613 it started from. Snapped, the
+    // node runs from x 20 to a right edge on 640, so 620 wide.
+    const out = snapResizeChanges([resize(633, 391)], [node()], G)
+
+    expect(dims(out)).toEqual({ width: 620, height: 400 })
+  })
+
+  it('does the same on the final change, so releasing does not undo the drag', () => {
+    const out = snapResizeChanges([resize(633, 391, false)], [node()], G)
+
+    expect(dims(out)).toEqual({ width: 620, height: 400 })
+  })
+
+  it('adds a position change when snapping moves the anchored edge', () => {
+    // A right/bottom-handle drag sends no position change of its own.
+    const out = snapResizeChanges([resize(633, 391)], [node()], G)
+
+    expect(pos(out)).toEqual({ x: 20, y: 0 })
+  })
+
+  it('adds none when the node already sits on the grid', () => {
+    const out = snapResizeChanges([resize(633, 391)], [node({ position: { x: 40, y: 60 } })], G)
+
+    expect(pos(out)).toBeUndefined()
+  })
+
+  it('rewrites a left-handle drag in place rather than appending a second position', () => {
+    const changes: NodeChange<CanvasNode>[] = [
+      { id: 'n1', type: 'position', position: { x: -7, y: 7 } } as NodeChange<CanvasNode>,
+      resize(633, 391)
+    ]
+    const out = snapResizeChanges(changes, [node()], G)
+
+    expect(out.filter((c) => c.type === 'position')).toHaveLength(1)
+    expect(pos(out)).toEqual({ x: 0, y: 0 })
+  })
+
+  it('leaves a MEASUREMENT change alone: only the resizer sets `resizing`', () => {
+    // Forcing the ResizeObserver's reading onto the grid would fight the DOM on every node.
+    const measured: NodeChange<CanvasNode>[] = [
+      { id: 'n1', type: 'dimensions', dimensions: { width: 613, height: 371 } } as NodeChange<CanvasNode>
+    ]
+
+    expect(snapResizeChanges(measured, [node()], G)).toEqual(measured)
+  })
+
+  it('passes a batch with no resize through untouched', () => {
+    const changes: NodeChange<CanvasNode>[] = [
+      { id: 'n1', type: 'select', selected: true } as NodeChange<CanvasNode>
+    ]
+
+    expect(snapResizeChanges(changes, [node()], G)).toBe(changes)
+  })
+
+  it('keeps a collapsed node at its bar height', () => {
+    const collapsed = node({
+      data: { title: 'n', color: '#0a84ff', group: null, collapsed: true },
+      measured: { width: 613, height: 34 }
+    })
+    const out = snapResizeChanges([resize(633, 34)], [collapsed], G)
+
+    expect(dims(out)?.height).toBe(34)
+    expect(dims(out)?.width).toBe(620)
+  })
+
+  it('leaves a change for a node it cannot find alone', () => {
+    const changes = [resize(633, 391)]
+
+    expect(snapResizeChanges(changes, [], G)).toEqual(changes)
+  })
+})

--- a/src/renderer/lib/resizeSnap.test.ts
+++ b/src/renderer/lib/resizeSnap.test.ts
@@ -99,3 +99,88 @@ describe('snapResizeChanges', () => {
     expect(snapResizeChanges(changes, [], G)).toEqual(changes)
   })
 })
+
+/**
+ * A group frame plus one child, the case React Flow compensates for itself: on a top/left drag
+ * `XYResizer` shifts every child by the origin delta IT chose, so rewriting the frame underneath
+ * those changes moves the children with it.
+ */
+const frame = (over: Partial<CanvasNode> = {}): CanvasNode =>
+  ({
+    id: 'g1',
+    type: 'group',
+    position: { x: 13, y: 7 },
+    data: {},
+    measured: { width: 613, height: 371 },
+    ...over
+  }) as CanvasNode
+
+const child = (over: Partial<CanvasNode> = {}): CanvasNode =>
+  ({
+    id: 'c1',
+    type: 'terminal',
+    parentId: 'g1',
+    extent: 'parent',
+    position: { x: 100, y: 100 },
+    data: {},
+    measured: { width: 320, height: 240 },
+    ...over
+  }) as CanvasNode
+
+const positionOf = (
+  changes: NodeChange<CanvasNode>[],
+  id: string
+): { x: number; y: number } | undefined =>
+  changes.flatMap((c) => (c.type === 'position' && c.id === id && c.position ? [c.position] : []))[0]
+
+const resizeOf = (id: string, width: number, height: number): NodeChange<CanvasNode> =>
+  ({ id, type: 'dimensions', resizing: true, dimensions: { width, height } }) as NodeChange<CanvasNode>
+
+const moveOf = (id: string, x: number, y: number): NodeChange<CanvasNode> =>
+  ({ id, type: 'position', position: { x, y } }) as NodeChange<CanvasNode>
+
+describe('snapResizeChanges with a group frame', () => {
+  it('keeps a child in place on a top-left drag', () => {
+    // React Flow proposes the frame at -7 and compensates the child to 120, which restores the
+    // child's original root x of 113. Snapping the frame to 0 without touching the child would
+    // leave it at 120 instead.
+    const changes = [moveOf('g1', -7, -13), resizeOf('g1', 633, 391), moveOf('c1', 120, 120)]
+    const out = snapResizeChanges(changes, [frame(), child()], G)
+
+    const framePos = positionOf(out, 'g1')!
+    const childPos = positionOf(out, 'c1')!
+    expect(framePos).toEqual({ x: 0, y: -20 })
+    expect({ x: framePos.x + childPos.x, y: framePos.y + childPos.y }).toEqual({ x: 113, y: 107 })
+  })
+
+  it('keeps a child in place when snapping moves an edge React Flow never moved', () => {
+    // A bottom-right drag emits no frame position change and no child changes at all, but the
+    // snap still pulls the frame origin from 13 to 20, so the child owes the same compensation.
+    const out = snapResizeChanges([resizeOf('g1', 633, 391)], [frame(), child()], G)
+
+    const framePos = positionOf(out, 'g1')!
+    const childPos = positionOf(out, 'c1')!
+    expect({ x: framePos.x + childPos.x, y: framePos.y + childPos.y }).toEqual({ x: 113, y: 107 })
+  })
+
+  it('emits no child change when the snap leaves the frame origin where it was', () => {
+    const on = frame({ position: { x: 40, y: 60 } })
+    const out = snapResizeChanges([resizeOf('g1', 633, 391)], [on, child()], G)
+
+    expect(positionOf(out, 'c1')).toBeUndefined()
+  })
+
+  it('snaps a nested frame against the CANVAS grid, not its own parent grid', () => {
+    const outer = frame({
+      id: 'g0',
+      position: { x: -28, y: -62 },
+      measured: { width: 900, height: 700 }
+    })
+    const inner = frame({ parentId: 'g0', extent: 'parent', position: { x: 41, y: 69 } })
+    const out = snapResizeChanges([resizeOf('g1', 633, 391)], [outer, inner], G)
+
+    const framePos = positionOf(out, 'g1') ?? inner.position
+    expect(Math.abs((framePos.x + outer.position.x) % G)).toBe(0)
+    expect(Math.abs((framePos.y + outer.position.y) % G)).toBe(0)
+  })
+})

--- a/src/renderer/lib/resizeSnap.ts
+++ b/src/renderer/lib/resizeSnap.ts
@@ -1,7 +1,7 @@
 import type { NodeChange } from '@xyflow/react'
 import type { NodeKind } from '@shared/types'
 import type { CanvasNode } from '../state/workspace'
-import { snapNodeToGrid } from './nodeSizing'
+import { containerOrigin, snapRectInRootSpace } from './gridSnap'
 
 /**
  * React Flow snaps the resize DELTA, never the resulting edges. From `getDimensionsAfterResize`
@@ -17,6 +17,10 @@ import { snapNodeToGrid } from './nodeSizing'
  * A right/bottom-handle drag sends no position change, so one is ADDED when snapping moves the
  * anchored edge. Without it the node keeps an off-grid x while its width is measured from a
  * snapped one, and the right edge lands between grid lines again.
+ *
+ * Two coordinate rules make this agree with React Flow's own drag snap and with group frames:
+ * the box is snapped in ROOT space (`snapRectInRootSpace`), and a frame's children are shifted
+ * by whatever the snap moved the frame's origin (`childShifts`).
  */
 export function snapResizeChanges(
   changes: NodeChange<CanvasNode>[],
@@ -28,9 +32,14 @@ export function snapResizeChanges(
   )
   if (!resizing.size || grid <= 0) return changes
 
+  const byId = new Map(nodes.map((node) => [node.id, node]))
   const boxes = new Map<string, { x: number; y: number; width: number; height: number }>()
+  // How far the snap moved each resized node's origin away from what React Flow proposed. Its
+  // children are positioned against that origin, so they owe the opposite shift.
+  const shifts = new Map<string, { x: number; y: number }>()
+
   for (const id of resizing) {
-    const node = nodes.find((n) => n.id === id)
+    const node = byId.get(id)
     if (!node) continue
     const moved = changes.find((c) => c.type === 'position' && c.id === id && c.position)
     const sized = changes.find((c) => c.type === 'dimensions' && c.id === id && c.dimensions)
@@ -38,43 +47,72 @@ export function snapResizeChanges(
     const dimensions = sized?.type === 'dimensions' ? sized.dimensions : undefined
     const width = dimensions?.width ?? node.measured?.width ?? (node.width as number) ?? 0
     const height = dimensions?.height ?? node.measured?.height ?? (node.height as number) ?? 0
-    const snapped = snapNodeToGrid(grid, (node.type ?? 'terminal') as NodeKind, {
-      x: position.x,
-      y: position.y,
-      width,
-      height
-    })
-    // A collapsed node keeps its collapsed bar height, exactly as align-to-grid leaves it.
-    // `+ 0` normalizes the -0 that rounding a small negative coordinate produces, which would
-    // otherwise ride into node positions on every resize near the origin.
+    const snapped = snapRectInRootSpace(
+      { x: position.x, y: position.y, width, height },
+      containerOrigin(node.parentId, nodes),
+      grid,
+      (node.type ?? 'terminal') as NodeKind
+    )
     boxes.set(id, {
-      x: snapped.x + 0,
-      y: snapped.y + 0,
+      x: snapped.x,
+      y: snapped.y,
       width: snapped.width,
+      // A collapsed node keeps its collapsed bar height, exactly as align-to-grid leaves it.
       height: node.data?.collapsed ? height : snapped.height
     })
+    shifts.set(id, { x: snapped.x - position.x, y: snapped.y - position.y })
+  }
+
+  const childShifts = new Map<string, { x: number; y: number }>()
+  for (const [id, shift] of shifts) {
+    if (shift.x === 0 && shift.y === 0) continue
+    for (const node of nodes) {
+      if (node.parentId === id) {
+        childShifts.set(node.id, { x: -shift.x, y: -shift.y })
+      }
+    }
   }
 
   const positioned = new Set(
     changes.flatMap((c) => (c.type === 'position' && boxes.has(c.id) ? [c.id] : []))
   )
+  const shifted = new Set<string>()
   const applied = changes.map((change) => {
     const box = 'id' in change ? boxes.get(change.id) : undefined
-    if (!box) return change
-    if (change.type === 'position' && change.position) {
-      return { ...change, position: { x: box.x, y: box.y } }
+    if (box) {
+      if (change.type === 'position' && change.position) {
+        return { ...change, position: { x: box.x, y: box.y } }
+      }
+      if (change.type === 'dimensions' && change.dimensions) {
+        return { ...change, dimensions: { width: box.width, height: box.height } }
+      }
+      return change
     }
-    if (change.type === 'dimensions' && change.dimensions) {
-      return { ...change, dimensions: { width: box.width, height: box.height } }
+    const shift = 'id' in change ? childShifts.get(change.id) : undefined
+    if (shift && change.type === 'position' && change.position) {
+      shifted.add(change.id)
+      return { ...change, position: { x: change.position.x + shift.x, y: change.position.y + shift.y } }
     }
     return change
   })
 
   for (const [id, box] of boxes) {
     if (positioned.has(id)) continue
-    const node = nodes.find((n) => n.id === id)
+    const node = byId.get(id)
     if (!node || (node.position.x === box.x && node.position.y === box.y)) continue
     applied.push({ id, type: 'position', position: { x: box.x, y: box.y } })
+  }
+  // A right/bottom drag compensates no child of its own, because React Flow never moved the
+  // frame's origin there - the snap did.
+  for (const [id, shift] of childShifts) {
+    if (shifted.has(id)) continue
+    const node = byId.get(id)
+    if (!node) continue
+    applied.push({
+      id,
+      type: 'position',
+      position: { x: node.position.x + shift.x, y: node.position.y + shift.y }
+    })
   }
   return applied
 }

--- a/src/renderer/lib/resizeSnap.ts
+++ b/src/renderer/lib/resizeSnap.ts
@@ -1,0 +1,80 @@
+import type { NodeChange } from '@xyflow/react'
+import type { NodeKind } from '@shared/types'
+import type { CanvasNode } from '../state/workspace'
+import { snapNodeToGrid } from './nodeSizing'
+
+/**
+ * React Flow snaps the resize DELTA, never the resulting edges. From `getDimensionsAfterResize`
+ * (@xyflow/system): `newWidth = startWidth + distX`, where both pointer reads are snapped so
+ * `distX` is a grid multiple. Added to an off-grid start width, the result is off-grid forever:
+ * the size the user aims for is unreachable however carefully they drag.
+ *
+ * So the resizer's changes are re-snapped BEFORE they are applied, which is what makes the node
+ * track the grid during the drag rather than jump when it ends. `resizing` is the marker: only
+ * the resizer sets it, while the ResizeObserver's measurement changes carry no such field and
+ * must pass through untouched, or every node's measured size would be forced onto the grid.
+ *
+ * A right/bottom-handle drag sends no position change, so one is ADDED when snapping moves the
+ * anchored edge. Without it the node keeps an off-grid x while its width is measured from a
+ * snapped one, and the right edge lands between grid lines again.
+ */
+export function snapResizeChanges(
+  changes: NodeChange<CanvasNode>[],
+  nodes: CanvasNode[],
+  grid: number
+): NodeChange<CanvasNode>[] {
+  const resizing = new Set(
+    changes.flatMap((c) => (c.type === 'dimensions' && typeof c.resizing === 'boolean' ? [c.id] : []))
+  )
+  if (!resizing.size || grid <= 0) return changes
+
+  const boxes = new Map<string, { x: number; y: number; width: number; height: number }>()
+  for (const id of resizing) {
+    const node = nodes.find((n) => n.id === id)
+    if (!node) continue
+    const moved = changes.find((c) => c.type === 'position' && c.id === id && c.position)
+    const sized = changes.find((c) => c.type === 'dimensions' && c.id === id && c.dimensions)
+    const position = (moved?.type === 'position' && moved.position) || node.position
+    const dimensions = sized?.type === 'dimensions' ? sized.dimensions : undefined
+    const width = dimensions?.width ?? node.measured?.width ?? (node.width as number) ?? 0
+    const height = dimensions?.height ?? node.measured?.height ?? (node.height as number) ?? 0
+    const snapped = snapNodeToGrid(grid, (node.type ?? 'terminal') as NodeKind, {
+      x: position.x,
+      y: position.y,
+      width,
+      height
+    })
+    // A collapsed node keeps its collapsed bar height, exactly as align-to-grid leaves it.
+    // `+ 0` normalizes the -0 that rounding a small negative coordinate produces, which would
+    // otherwise ride into node positions on every resize near the origin.
+    boxes.set(id, {
+      x: snapped.x + 0,
+      y: snapped.y + 0,
+      width: snapped.width,
+      height: node.data?.collapsed ? height : snapped.height
+    })
+  }
+
+  const positioned = new Set(
+    changes.flatMap((c) => (c.type === 'position' && boxes.has(c.id) ? [c.id] : []))
+  )
+  const applied = changes.map((change) => {
+    const box = 'id' in change ? boxes.get(change.id) : undefined
+    if (!box) return change
+    if (change.type === 'position' && change.position) {
+      return { ...change, position: { x: box.x, y: box.y } }
+    }
+    if (change.type === 'dimensions' && change.dimensions) {
+      return { ...change, dimensions: { width: box.width, height: box.height } }
+    }
+    return change
+  })
+
+  for (const [id, box] of boxes) {
+    if (positioned.has(id)) continue
+    const node = nodes.find((n) => n.id === id)
+    if (!node || (node.position.x === box.x && node.position.y === box.y)) continue
+    applied.push({ id, type: 'position', position: { x: box.x, y: box.y } })
+  }
+  return applied
+}

--- a/src/renderer/state/workspace.placement.test.ts
+++ b/src/renderer/state/workspace.placement.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import { useSettings } from './settings'
+import { createStickyNode, createTerminalNode } from './workspace'
+
+const GRID = 20
+
+function settings(over: Partial<typeof DEFAULT_SETTINGS>): void {
+  useSettings.setState({ settings: { ...DEFAULT_SETTINGS, ...over } })
+}
+
+afterEach(() => settings({}))
+
+describe('new node placement with snap-to-grid', () => {
+  // The cursor is the off-grid source: placeAt centres the node on it, so the position is half a
+  // width off whatever the pointer happened to hit.
+  const cursor = { x: 517, y: 293 }
+
+  it('lands the whole box on the grid, position and size', () => {
+    settings({ snapToGrid: true, gridSize: GRID, defaultNodeWidth: 613, defaultNodeHeight: 371 })
+    const node = createTerminalNode(0, undefined, cursor)
+
+    expect([node.position.x % GRID, node.position.y % GRID]).toEqual([0, 0])
+    expect([(node.width as number) % GRID, (node.height as number) % GRID]).toEqual([0, 0])
+  })
+
+  it('keeps style in step with width/height, which is what React Flow paints', () => {
+    settings({ snapToGrid: true, gridSize: GRID, defaultNodeWidth: 613, defaultNodeHeight: 371 })
+    const node = createTerminalNode(0, undefined, cursor)
+
+    expect(node.style).toEqual({ width: node.width, height: node.height })
+  })
+
+  it('snaps a node placed WITHOUT a cursor too (dock, palette, kanban)', () => {
+    settings({ snapToGrid: true, gridSize: 16 })
+    const node = createStickyNode(3)
+
+    expect([node.position.x % 16, node.position.y % 16]).toEqual([0, 0])
+  })
+
+  it('never lands a position on -0, which would ride into project.json', () => {
+    settings({ snapToGrid: true, gridSize: GRID })
+    const node = createStickyNode(0, { x: 4, y: 4 })
+
+    expect(Object.is(node.position.x, -0)).toBe(false)
+    expect(Object.is(node.position.y, -0)).toBe(false)
+  })
+
+  it('leaves everything alone with snapping off: the same box as before this existed', () => {
+    settings({ snapToGrid: false, gridSize: GRID, defaultNodeWidth: 613, defaultNodeHeight: 371 })
+    const node = createTerminalNode(0, undefined, cursor)
+
+    expect(node.position).toEqual({ x: cursor.x - 613 / 2, y: cursor.y - 371 / 2 })
+    expect([node.width, node.height]).toEqual([613, 371])
+  })
+
+  it('never snaps a node below the minimum its resizer would allow', () => {
+    settings({ snapToGrid: true, gridSize: 200 })
+    const node = createStickyNode(0, cursor)
+
+    expect(node.width as number).toBeGreaterThanOrEqual(160)
+    expect(node.height as number).toBeGreaterThanOrEqual(120)
+  })
+})

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -363,6 +363,93 @@ describe('groupSelectedNodes', () => {
   })
 })
 
+describe('groupSelectedNodes with snapping on', () => {
+  const GRID = 20
+  const GROUP_PAD = 28
+  const GROUP_HEADER = 34
+
+  it('places the frame on the grid, all four edges', () => {
+    const nodes = [term('t1', { x: 100, y: 100 }), term('t2', { x: 500, y: 300 })]
+    const group = groupSelectedNodes(nodes, ['t1', 't2'], 0, GRID)[0]
+    expect(group.position.x % GRID).toBe(0)
+    expect(group.position.y % GRID).toBe(0)
+    expect((group.position.x + (group.width as number)) % GRID).toBe(0)
+    expect((group.position.y + (group.height as number)) % GRID).toBe(0)
+  })
+
+  it('keeps at least the unsnapped clearance on every side', () => {
+    // Snapping may only push the frame outward. The members span (100,100)-(820,540).
+    const nodes = [term('t1', { x: 100, y: 100 }), term('t2', { x: 500, y: 300 })]
+    const group = groupSelectedNodes(nodes, ['t1', 't2'], 0, GRID)[0]
+    const pad = Math.max(GROUP_PAD, GRID)
+    expect(group.position.x).toBeLessThanOrEqual(100 - pad)
+    expect(group.position.y).toBeLessThanOrEqual(100 - pad - GROUP_HEADER)
+    expect(group.position.x + (group.width as number)).toBeGreaterThanOrEqual(820 + pad)
+    expect(group.position.y + (group.height as number)).toBeGreaterThanOrEqual(540 + pad)
+  })
+
+  it('honours a grid coarser than the fixed padding', () => {
+    const coarse = 64
+    const nodes = [term('t1', { x: 200, y: 200 })]
+    const group = groupSelectedNodes(nodes, ['t1'], 0, coarse)[0]
+    expect(group.position.x).toBeLessThanOrEqual(200 - coarse)
+    expect(group.position.x % coarse).toBe(0)
+  })
+
+  it('leaves every member where it was on canvas', () => {
+    const nodes = [term('t1', { x: 100, y: 100 }), term('t2', { x: 500, y: 300 })]
+    const out = groupSelectedNodes(nodes, ['t1', 't2'], 0, GRID)
+    const group = out[0]
+    for (const [id, pos] of [['t1', { x: 100, y: 100 }], ['t2', { x: 500, y: 300 }]] as const) {
+      const child = out.find((n) => n.id === id)!
+      expect(group.position.x + child.position.x).toBe(pos.x)
+      expect(group.position.y + child.position.y).toBe(pos.y)
+    }
+  })
+
+  it('snaps a nested frame onto the CANVAS grid, not its parent frame grid', () => {
+    // An off-grid frame origin is the normal case, so a parent-relative snap would land the
+    // wrapper on a grid offset by (-28, -62) from the one React Flow drags against.
+    const nodes = [
+      grp('outer', { x: -28, y: -62 }),
+      term('a', { x: 100, y: 100 }, 'outer'),
+      term('b', { x: 400, y: 260 }, 'outer')
+    ]
+    const out = groupSelectedNodes(nodes, ['a', 'b'], 1, GRID)
+    const outer = out.find((n) => n.id === 'outer')!
+    const wrapper = out.find((n) => !nodes.some((old) => old.id === n.id))!
+    expect(wrapper.parentId).toBe('outer')
+    // Math.abs: a negative multiple modulo the grid is -0, which toBe distinguishes from 0.
+    expect(Math.abs((outer.position.x + wrapper.position.x) % GRID)).toBe(0)
+    expect(Math.abs((outer.position.y + wrapper.position.y) % GRID)).toBe(0)
+  })
+
+  it('is byte-identical to the unsnapped box when snapping is off', () => {
+    const nodes = [term('t1', { x: 103, y: 107 }), term('t2', { x: 511, y: 313 })]
+    const group = groupSelectedNodes(nodes, ['t1', 't2'], 0, 0)[0]
+    expect(group.position).toEqual({ x: 103 - GROUP_PAD, y: 107 - GROUP_PAD - GROUP_HEADER })
+    expect(group.width).toBe(511 + 320 - 103 + GROUP_PAD * 2)
+    expect(group.height).toBe(313 + 240 - 107 + GROUP_PAD * 2 + GROUP_HEADER)
+    expect(groupSelectedNodes(nodes, ['t1', 't2'], 0)[0].position).toEqual(group.position)
+  })
+
+  it('keeps a re-fit frame on the grid, so a later fit cannot undo the placement', () => {
+    const nodes = [
+      grp('g1', { x: 100, y: 100 }),
+      term('a', { x: 23, y: 41 }, 'g1'),
+      term('b', { x: 61, y: 19 }, 'g1')
+    ]
+    const out = fitGroupToChildren(nodes, 'g1', GRID)
+    const g = out.find((n) => n.id === 'g1')!
+    expect(g.position.x % GRID).toBe(0)
+    expect(g.position.y % GRID).toBe(0)
+    // Children still sit where they were on canvas.
+    const a = out.find((n) => n.id === 'a')!
+    expect(g.position.x + a.position.x).toBe(123)
+    expect(g.position.y + a.position.y).toBe(141)
+  })
+})
+
 describe('ungroupNodes', () => {
   it('removes the frame and restores children to absolute positions', () => {
     const nodes = [grp('g1', { x: 50, y: 50 }), term('t1', { x: 10, y: 10 }, 'g1')]

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -1259,7 +1259,7 @@ function groupsFirst(nodes: CanvasNode[]): CanvasNode[] {
 }
 
 /** A node's position in ROOT space: its own position plus every ancestor frame's origin. */
-function rootPosition(node: CanvasNode, nodes: CanvasNode[]): { x: number; y: number } {
+export function rootPosition(node: CanvasNode, nodes: CanvasNode[]): { x: number; y: number } {
   const byId = new Map(nodes.map((candidate) => [candidate.id, candidate]))
   const seen = new Set<string>([node.id])
   let x = node.position.x

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -8,12 +8,14 @@ import type {
   Project,
   Settings
 } from '@shared/types'
+import { DEFAULT_SETTINGS } from '@shared/types'
 import type { AgentId, AgentPermissionMode, BuiltinAgentId } from '@shared/agents/config'
 import { agentConfig, supportsSessionIdFlag } from '@shared/agents/config'
 import { assembleLaunchCommand } from '@shared/agents/launch'
 import { agentAccountColor } from '@shared/agents/account-color'
 import { agentEnvSnapshot } from '../lib/agentEnv'
 import { uuid } from '@renderer/lib/uuid'
+import { snapNodeToGrid } from '../lib/nodeSizing'
 import { claudeCliCapsNow } from './permissionMode'
 import { projectLaunchInfoNow } from './projectLaunchInfo'
 import { isAgentEnabled, launchableDefaultAgent } from './agentAvailability'
@@ -223,6 +225,36 @@ function placeAt(center: { x: number; y: number } | undefined, index: number, w:
 }
 
 /**
+ * Where a new node starts and how big it is, on the grid when snapping is on.
+ *
+ * Neither input is grid-aligned to begin with: `placeAt` centers the node on the cursor, half a
+ * width off whatever the pointer hit, and a terminal's size comes from a hand-editable setting.
+ * So every new node landed off-grid, and because React Flow resizes by adding a grid MULTIPLE to
+ * the start size (see lib/resizeSnap.ts), it could never be resized onto the grid either.
+ */
+function placeNode(
+  kind: NodeKind,
+  center: { x: number; y: number } | undefined,
+  index: number,
+  w: number,
+  h: number
+): Pick<CanvasNode, 'position' | 'width' | 'height' | 'style'> {
+  const { snapToGrid, gridSize } = useSettings.getState().settings
+  const at = placeAt(center, index, w, h)
+  const grid = snapToGrid ? gridSize || DEFAULT_SETTINGS.gridSize : 0
+  const box = grid
+    ? snapNodeToGrid(grid, kind, { x: at.x, y: at.y, width: w, height: h })
+    : { ...at, width: w, height: h }
+  return {
+    // `+ 0` normalizes the -0 that rounding a small negative coordinate produces.
+    position: { x: box.x + 0, y: box.y + 0 },
+    width: box.width,
+    height: box.height,
+    style: { width: box.width, height: box.height }
+  }
+}
+
+/**
  * Default size for NEW terminal/agent nodes: the user's setting (Settings → Canvas), clamped
  * to sane canvas bounds — settings.json is hand-editable, and a 0×0 or NaN node would be
  * unclickable/ungrabbable forever. Falls back to the historical 600×400.
@@ -273,10 +305,7 @@ export function createTerminalNode(
   return {
     id: nextId('term'),
     type: 'terminal',
-    position: placeAt(center, index, size.width, size.height),
-    width: size.width,
-    height: size.height,
-    style: { width: size.width, height: size.height },
+    ...placeNode('terminal', center, index, size.width, size.height),
     data: {
       title: `Terminal ${index + 1}`,
       color: NODE_COLORS[index % NODE_COLORS.length],
@@ -302,10 +331,7 @@ export function createSshTerminalNode(
   return {
     id: nextId('ssh'),
     type: 'terminal',
-    position: placeAt(center, index, size.width, size.height),
-    width: size.width,
-    height: size.height,
-    style: { width: size.width, height: size.height },
+    ...placeNode('terminal', center, index, size.width, size.height),
     data: {
       title: server.label,
       color: NODE_COLORS[index % NODE_COLORS.length],
@@ -687,10 +713,7 @@ export function createAgentNode(
   return {
     id: nextId('term'),
     type: 'terminal',
-    position: placeAt(center, index, size.width, size.height),
-    width: size.width,
-    height: size.height,
-    style: { width: size.width, height: size.height },
+    ...placeNode('terminal', center, index, size.width, size.height),
     data: {
       title: label,
       // Adopt the agent's own session name into the title until the user renames it by hand.
@@ -883,10 +906,7 @@ export function createEditorNode(
   return {
     id: nextId('editor'),
     type: 'editor',
-    position: placeAt(center, index, EDITOR_SIZE.width, EDITOR_SIZE.height),
-    width: EDITOR_SIZE.width,
-    height: EDITOR_SIZE.height,
-    style: { width: EDITOR_SIZE.width, height: EDITOR_SIZE.height },
+    ...placeNode('editor', center, index, EDITOR_SIZE.width, EDITOR_SIZE.height),
     data: {
       title: filePath.split('/').pop() || 'untitled',
       color: '#6ac4dc',
@@ -918,10 +938,7 @@ export function createVideoNode(
   return {
     id: nextId('video'),
     type: 'video',
-    position: placeAt(center, index, VIDEO_SIZE.width, VIDEO_SIZE.height),
-    width: VIDEO_SIZE.width,
-    height: VIDEO_SIZE.height,
-    style: { width: VIDEO_SIZE.width, height: VIDEO_SIZE.height },
+    ...placeNode('video', center, index, VIDEO_SIZE.width, VIDEO_SIZE.height),
     data: {
       title: filePath.split('/').pop() || 'video',
       color: '#bf5af2',
@@ -944,10 +961,7 @@ export function createWebNode(
   return {
     id: nextId('web'),
     type: 'web',
-    position: placeAt(center, index, WEB_SIZE.width, WEB_SIZE.height),
-    width: WEB_SIZE.width,
-    height: WEB_SIZE.height,
-    style: { width: WEB_SIZE.width, height: WEB_SIZE.height },
+    ...placeNode('web', center, index, WEB_SIZE.width, WEB_SIZE.height),
     data: {
       title,
       color: '#6ac4dc',
@@ -977,10 +991,7 @@ export function createBrowserNode(
   return {
     id: nextId('browser'),
     type: 'browser',
-    position: placeAt(center, index, BROWSER_SIZE.width, BROWSER_SIZE.height),
-    width: BROWSER_SIZE.width,
-    height: BROWSER_SIZE.height,
-    style: { width: BROWSER_SIZE.width, height: BROWSER_SIZE.height },
+    ...placeNode('browser', center, index, BROWSER_SIZE.width, BROWSER_SIZE.height),
     data: {
       title,
       color: '#0a84ff',
@@ -1003,10 +1014,7 @@ export function createDiffNode(
   return {
     id: nextId('diff'),
     type: 'diff',
-    position: placeAt(center, index, DIFF_SIZE.width, DIFF_SIZE.height),
-    width: DIFF_SIZE.width,
-    height: DIFF_SIZE.height,
-    style: { width: DIFF_SIZE.width, height: DIFF_SIZE.height },
+    ...placeNode('diff', center, index, DIFF_SIZE.width, DIFF_SIZE.height),
     data: {
       title: `${relPath.split('/').pop() || relPath} (${commitOid ? commitOid.slice(0, 7) : 'diff'})`,
       color: '#e0af68',
@@ -1024,10 +1032,7 @@ export function createStickyNode(index: number, center?: { x: number; y: number 
   return {
     id: nextId('sticky'),
     type: 'sticky',
-    position: placeAt(center, index, STICKY_SIZE.width, STICKY_SIZE.height),
-    width: STICKY_SIZE.width,
-    height: STICKY_SIZE.height,
-    style: { width: STICKY_SIZE.width, height: STICKY_SIZE.height },
+    ...placeNode('sticky', center, index, STICKY_SIZE.width, STICKY_SIZE.height),
     data: {
       title: 'Note',
       color: '#ffd60a',
@@ -1067,10 +1072,7 @@ export function createDinoNode(
   return {
     id: nextId('dino'),
     type: 'dino',
-    position: placeAt(center, index, DINO_SIZE.width, DINO_SIZE.height),
-    width: DINO_SIZE.width,
-    height: DINO_SIZE.height,
-    style: { width: DINO_SIZE.width, height: DINO_SIZE.height },
+    ...placeNode('dino', center, index, DINO_SIZE.width, DINO_SIZE.height),
     data: {
       title: 'Dino',
       color: '#a2a2a2',

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -15,7 +15,7 @@ import { assembleLaunchCommand } from '@shared/agents/launch'
 import { agentAccountColor } from '@shared/agents/account-color'
 import { agentEnvSnapshot } from '../lib/agentEnv'
 import { uuid } from '@renderer/lib/uuid'
-import { snapNodeToGrid } from '../lib/nodeSizing'
+import { expandRectToGrid, snapNodeToGrid, type Rect } from '../lib/nodeSizing'
 import { claudeCliCapsNow } from './permissionMode'
 import { projectLaunchInfoNow } from './projectLaunchInfo'
 import { isAgentEnabled, launchableDefaultAgent } from './agentAvailability'
@@ -1131,6 +1131,48 @@ const GROUP_HEADER = 34
 const nodeW = (n: CanvasNode) => n.measured?.width ?? (n.width as number) ?? 0
 const nodeH = (n: CanvasNode) => n.measured?.height ?? (n.height as number) ?? 0
 
+/**
+ * Geometry for a frame that has to wrap `bounds`, with its label header above. `bounds` and the
+ * result are both in the space of the frame's own container, which is where `parentId` points.
+ *
+ * With `grid` on, the frame is placed on the grid AT CREATION instead of being left off-grid for
+ * every later resize to compensate: the padding is raised to at least one cell and the box then
+ * grows OUTWARD to the surrounding grid lines, so all four edges land on the grid and the
+ * clearance around the children can only increase. Snapping runs in ROOT space, because React
+ * Flow snaps a drag there too — rounding this container-relative box directly would put a nested
+ * frame on its parent's grid, which is the defect the rest of this change removes.
+ *
+ * `grid <= 0` (snapping off) reproduces the original fixed-padding box exactly.
+ */
+function groupBox(
+  nodes: CanvasNode[],
+  parentId: string | undefined,
+  bounds: { minX: number; minY: number; maxX: number; maxY: number },
+  grid: number
+): Rect {
+  const pad = grid > 0 ? Math.max(GROUP_PAD, grid) : GROUP_PAD
+  const rect: Rect = {
+    x: bounds.minX - pad,
+    y: bounds.minY - pad - GROUP_HEADER,
+    width: bounds.maxX - bounds.minX + pad * 2,
+    height: bounds.maxY - bounds.minY + pad * 2 + GROUP_HEADER
+  }
+  if (grid <= 0) return rect
+  const origin = containerOrigin(parentId, nodes)
+  const snapped = expandRectToGrid(grid, 'group', {
+    x: rect.x + origin.x,
+    y: rect.y + origin.y,
+    width: rect.width,
+    height: rect.height
+  })
+  return {
+    x: snapped.x - origin.x + 0,
+    y: snapped.y - origin.y + 0,
+    width: snapped.width,
+    height: snapped.height
+  }
+}
+
 export type ArrangeLayout = 'grid' | 'row' | 'column'
 
 /**
@@ -1278,6 +1320,24 @@ export function rootPosition(node: CanvasNode, nodes: CanvasNode[]): { x: number
   return { x, y }
 }
 
+/**
+ * Root-space origin of the container `parentId` names: (0, 0) for a top-level object, else the
+ * frame's own root position. A missing frame resolves to the root rather than throwing, matching
+ * how the rest of the canvas treats a dangling parentId.
+ *
+ * Lives here rather than in `lib/gridSnap` (which re-exports it) because it is `rootPosition`
+ * with one branch in front, and two homes for that would drift.
+ */
+export function containerOrigin(
+  parentId: string | undefined,
+  nodes: CanvasNode[]
+): { x: number; y: number } {
+  if (!parentId) return { x: 0, y: 0 }
+  const frame = nodes.find((node) => node.id === parentId)
+  if (!frame) return { x: 0, y: 0 }
+  return rootPosition(frame, nodes)
+}
+
 function isDescendant(nodes: CanvasNode[], candidateId: string, ancestorId: string): boolean {
   const byId = new Map(nodes.map((node) => [node.id, node]))
   const seen = new Set<string>()
@@ -1318,13 +1378,17 @@ export function selectedRootIds(nodes: CanvasNode[], ids: string[]): string[] {
  * that gained a child bigger than itself must be re-fitted BEFORE its own parent is, or the
  * parent is fitted around a size that is about to change.
  */
-function fitAncestorChain(nodes: CanvasNode[], groupId: string | undefined): CanvasNode[] {
+function fitAncestorChain(
+  nodes: CanvasNode[],
+  groupId: string | undefined,
+  grid = 0
+): CanvasNode[] {
   let next = nodes
   const seen = new Set<string>()
   let currentId = groupId
   while (currentId && !seen.has(currentId)) {
     seen.add(currentId)
-    next = fitGroupToChildren(next, currentId)
+    next = fitGroupToChildren(next, currentId, grid)
     currentId = next.find((n) => n.id === currentId)?.parentId
   }
   return next
@@ -1478,15 +1542,18 @@ export function restoreMaximizedNode(nodes: CanvasNode[], nodeId: string): Canva
  * descendant would be torn out of the ancestor being wrapped).
  *
  * When the members live inside a parent frame, that parent (and its own ancestors) are re-fitted
- * around the new wrapper. Without this the wrapper is created at `(minX - 28, minY - 62)` — often
- * NEGATIVE — inside a parent that is by construction too small to hold it, and `extent: 'parent'`
+ * around the new wrapper. Without this the wrapper is created at a negative offset from its
+ * members inside a parent that is by construction too small to hold it, and `extent: 'parent'`
  * makes React Flow clamp it to `parentSize - wrapperSize`, i.e. hundreds of px off, dragging the
  * whole wrapped subtree with it. Same trap `addGrouped` documents in Canvas.
+ *
+ * `grid` (0 = snapping off) puts the frame on the grid immediately — see `groupBox`.
  */
 export function groupSelectedNodes(
   nodes: CanvasNode[],
   ids: string[],
-  groupIndex: number
+  groupIndex: number,
+  grid = 0
 ): CanvasNode[] {
   const set = new Set(ids)
   const members = nodes.filter((n) => set.has(n.id))
@@ -1506,14 +1573,13 @@ export function groupSelectedNodes(
   const maxX = Math.max(...members.map((n) => n.position.x + nodeW(n)))
   const maxY = Math.max(...members.map((n) => n.position.y + nodeH(n)))
 
-  const gx = minX - GROUP_PAD
-  const gy = minY - GROUP_PAD - GROUP_HEADER
+  const parentId = members[0].parentId
+  const box = groupBox(nodes, parentId, { minX, minY, maxX, maxY }, grid)
   const group = createGroupNode(
-    { x: gx, y: gy },
-    { width: maxX - minX + GROUP_PAD * 2, height: maxY - minY + GROUP_PAD * 2 + GROUP_HEADER },
+    { x: box.x, y: box.y },
+    { width: box.width, height: box.height },
     groupIndex
   )
-  const parentId = members[0].parentId
   if (parentId) {
     group.parentId = parentId
     group.extent = 'parent'
@@ -1525,12 +1591,12 @@ export function groupSelectedNodes(
           ...n,
           parentId: group.id,
           extent: 'parent' as const,
-          position: { x: n.position.x - gx, y: n.position.y - gy },
+          position: { x: n.position.x - box.x, y: n.position.y - box.y },
           selected: false
         }
       : n
   )
-  return fitAncestorChain(groupsFirst([group, ...updated]), parentId)
+  return fitAncestorChain(groupsFirst([group, ...updated]), parentId, grid)
 }
 
 /** Returns a copy of a node with a fresh id, offset position, and top-level placement. */
@@ -1555,7 +1621,11 @@ export function duplicateNode(node: CanvasNode, offset = 28): CanvasNode {
  * to sit when they were grouped, so a tidy inner layout still leaves an oversized box. No-op for a
  * missing/non-group id or a frame with no children. Pure.
  */
-export function fitGroupToChildren(nodes: CanvasNode[], groupId: string): CanvasNode[] {
+export function fitGroupToChildren(
+  nodes: CanvasNode[],
+  groupId: string,
+  grid = 0
+): CanvasNode[] {
   const group = nodes.find((n) => n.id === groupId)
   if (!group || group.type !== 'group') return nodes
   const children = nodes.filter((n) => n.parentId === groupId)
@@ -1567,10 +1637,10 @@ export function fitGroupToChildren(nodes: CanvasNode[], groupId: string): Canvas
   const minY = Math.min(...children.map(absY))
   const maxX = Math.max(...children.map((c) => absX(c) + nodeW(c)))
   const maxY = Math.max(...children.map((c) => absY(c) + nodeH(c)))
-  const gx = minX - GROUP_PAD
-  const gy = minY - GROUP_PAD - GROUP_HEADER
-  const width = maxX - minX + GROUP_PAD * 2
-  const height = maxY - minY + GROUP_PAD * 2 + GROUP_HEADER
+  // Same box as a fresh grouping, so a re-fit cannot pull a frame off the grid that
+  // `groupSelectedNodes` just put on it.
+  const box = groupBox(nodes, group.parentId, { minX, minY, maxX, maxY }, grid)
+  const { x: gx, y: gy, width, height } = box
   return nodes.map((n) => {
     if (n.id === groupId) {
       return { ...n, position: { x: gx, y: gy }, width, height, style: { ...n.style, width, height } }
@@ -1654,7 +1724,8 @@ export function reparentNode(
 export function addSelectionToGroup(
   nodes: CanvasNode[],
   selectedIds: string[],
-  groupId: string
+  groupId: string,
+  grid = 0
 ): CanvasNode[] {
   if (!nodes.some((node) => node.id === groupId && node.type === 'group')) return nodes
   const selected = new Set(selectedIds)
@@ -1672,7 +1743,7 @@ export function addSelectionToGroup(
   })
   let next = nodes
   for (const root of roots) next = reparentNode(next, root.id, groupId)
-  return next === nodes ? nodes : fitAncestorChain(next, groupId)
+  return next === nodes ? nodes : fitAncestorChain(next, groupId, grid)
 }
 
 /**


### PR DESCRIPTION
With snap-to-grid on, a node could never be brought onto the grid: not by resizing it, and not by creating it there. Two causes, one rule.

## Resizing adds to the grid instead of snapping to it

React Flow snaps the resize DELTA, never the resulting edges. From `getDimensionsAfterResize` (`@xyflow/system`):

```js
let distX = Math.floor(isHorizontal ? xSnapped - startValues.pointerX : 0)
const newWidth = startWidth + (affectsX ? -distX : distX)
```

Both pointer reads are snapped, so `distX` is always a grid multiple, and it is **added** to whatever width the node started at. A node that starts at 613 with a grid of 20 can only ever reach 613 + n·20. The size the user is aiming for is unreachable, however carefully they drag.

`lib/resizeSnap.ts` re-snaps the resizer's changes *before* they are applied, so the node tracks the grid during the drag rather than correcting itself on release.

Two details worth reviewing:

- **`resizing` is the marker.** Only the resizer sets it; the `ResizeObserver`'s measurement changes carry no such field and pass through untouched. Forcing those onto the grid would fight the DOM about what every node actually measures.
- **A right/bottom-handle drag sends no position change**, so one is added when snapping moves the anchored edge. Without it the node keeps an off-grid `x` while its width is measured from a snapped one, and the right edge lands between grid lines again.

## New nodes were born off-grid

`placeAt` centres a node on the cursor, so its position is half a width off whatever the pointer hit, and a terminal's size comes from `settings.defaultNodeWidth`/`Height`, which are hand-editable and clamped but never rounded. That is where the resize problem came from in the first place.

`placeNode` snaps the whole box through the same `snapNodeToGrid` that the resizer and align-to-grid use, so all three land a node in the same place rather than each having its own rule. It replaces the `position`/`width`/`height`/`style` block that all ten node factories repeated verbatim, which is what kept the rule from having a single home.

## Scope

Everything is gated on `settings.snapToGrid`. With it off, nothing in either path runs: resizing and placement are byte-identical to before. `alignToGrid` is untouched.

**Surfaces:** desktop and Server Edition share the renderer, so both get it; mobile has no canvas.

## Tests

- `resizeSnap.test.ts` (9): in-flight and final changes snap, a measurement change is left alone, the appended position change appears only when the anchored edge actually moves, a left-handle drag is rewritten in place rather than gaining a second position, collapsed nodes keep their bar height.
- `workspace.placement.test.ts` (6): position and size both land on multiples, with and without a cursor, `style` stays in step with `width`/`height`, minimums are respected at a large grid, and snapping off reproduces the old box exactly.
- `nodeSizing.test.ts` (+2): one snap lands any off-grid box on multiples, and is idempotent.

Two of these came from a wrong assumption of mine that the tests caught: at x 13 with a proposed width of 633 the right edge is at 646, so it snaps to 640 and the **width becomes 620**, not 640. Rounding a small negative coordinate also produces `-0`, which would have ridden into node positions on every resize near the origin; both paths normalize it.