### PR TITLE
fix(hooks): normalize path separators when matching managed hook commands on Windows

### DIFF
--- a/src/core/agents/hooks/install-helper.test.ts
+++ b/src/core/agents/hooks/install-helper.test.ts
@@ -64,6 +64,27 @@ describe('mergeManagedHook', () => {
     )
     expect(out.hooks!.Stop).toEqual([{ hooks: [{ type: 'command', command: cmd }] }])
   })
+  it('is idempotent on Windows — drops prior managed entry when path uses backslashes', () => {
+    const winCmd = buildManagedHookCommand('C:\\Users\\dev\\.nodeterm\\agent-hooks\\claude.sh')
+    const once = mergeManagedHook({}, winCmd, ['Stop'])
+    const twice = mergeManagedHook(once, winCmd, ['Stop'])
+    expect(twice.hooks!.Stop).toEqual([{ hooks: [{ type: 'command', command: winCmd }] }])
+  })
+
+  it('collapses accumulated duplicate Windows managed entries down to one', () => {
+    const winCmd = buildManagedHookCommand('C:\\Users\\dev\\.nodeterm\\agent-hooks\\claude.sh')
+    const accumulated = {
+      hooks: {
+        Stop: [
+          { hooks: [{ type: 'command', command: winCmd }] },
+          { hooks: [{ type: 'command', command: winCmd }] },
+          { hooks: [{ type: 'command', command: winCmd }] }
+        ]
+      }
+    }
+    const out = mergeManagedHook(accumulated, winCmd, ['Stop'])
+    expect(out.hooks!.Stop).toEqual([{ hooks: [{ type: 'command', command: winCmd }] }])
+  })
 })
 
 describe('mergeManagedHook — repair sweep', () => {
@@ -81,6 +102,17 @@ describe('mergeManagedHook — repair sweep', () => {
     }
     const out = mergeManagedHook(before, cmd, ['Stop'])
     expect(out.hooks!.Stop).toEqual([{ hooks: [{ type: 'command', command: cmd }] }])
+    expect(out.hooks!.SubagentStop).toBeUndefined()
+  })
+
+  it('drops stale managed entries with Windows backslash paths from unmanaged events', () => {
+    const staleWin = buildManagedHookCommand('C:\\Users\\dev\\.nodeterm\\agent-hooks\\claude.sh')
+    const before = {
+      hooks: {
+        SubagentStop: [{ hooks: [{ type: 'command', command: staleWin }] }]
+      }
+    }
+    const out = mergeManagedHook(before, cmd, ['Stop'])
     expect(out.hooks!.SubagentStop).toBeUndefined()
   })
 
@@ -111,3 +143,46 @@ describe('mergeManagedHook — matcher support is opt-in per event', () => {
     expect(out.hooks!.PreToolUse[0]).toEqual({ matcher: '.*', hooks: [{ type: 'command', command: 'CMD' }] })
   })
 })
+
+describe('removeHooksFrom', () => {
+  it('removes managed hook entries with Windows backslash paths while preserving other hooks', async () => {
+    const { removeHooksFrom } = await import('./install-helper')
+    const { mkdtempSync, readFileSync, writeFileSync, rmSync } = await import('fs')
+    const { tmpdir } = await import('os')
+    const path = await import('path')
+
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'nt-remove-hooks-'))
+    const cfgPath = path.join(tempDir, 'settings.json')
+    const winCmd = buildManagedHookCommand('C:\\Users\\dev\\.nodeterm\\agent-hooks\\claude.sh')
+    const foreignHook = { type: 'command', command: '/bin/sh /custom/my-hook.sh' }
+
+    try {
+      writeFileSync(
+        cfgPath,
+        JSON.stringify({
+          hooks: {
+            Stop: [
+              { hooks: [{ type: 'command', command: winCmd }] },
+              { hooks: [foreignHook] }
+            ],
+            SessionStart: [{ hooks: [{ type: 'command', command: winCmd }] }]
+          }
+        }),
+        'utf8'
+      )
+
+      removeHooksFrom({
+        configPath: cfgPath,
+        events: ['Stop', 'SessionStart'],
+        scriptFileName: 'claude.sh'
+      })
+
+      const updated = JSON.parse(readFileSync(cfgPath, 'utf8'))
+      expect(updated.hooks.Stop).toEqual([{ hooks: [foreignHook] }])
+      expect(updated.hooks.SessionStart).toBeUndefined()
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})
+

--- a/src/core/agents/hooks/install-helper.ts
+++ b/src/core/agents/hooks/install-helper.ts
@@ -96,7 +96,7 @@ const matcherOf = (e: ManagedHookEvent): string | undefined => (typeof e === 'st
 /** A managed entry: matches OUR script under `agent-hooks/` or the legacy `claude-signals` marker. */
 function isManaged(d: HookDef, marker: string): boolean {
   return !!d.hooks?.some(
-    (h) => h.command.includes(marker) || h.command.includes('claude-signals')
+    (h) => h.command.replaceAll('\\', '/').includes(marker) || h.command.includes('claude-signals')
   )
 }
 
@@ -189,7 +189,9 @@ export function removeHooksFrom(opts: RemoveHooksOptions): void {
   for (const e of events) {
     const ev = eventNameOf(e)
     if (!config.hooks[ev]) continue
-    config.hooks[ev] = config.hooks[ev].filter((d) => !d.hooks?.some((h) => h.command.includes(marker)))
+    config.hooks[ev] = config.hooks[ev].filter(
+      (d) => !d.hooks?.some((h) => h.command.replaceAll('\\', '/').includes(marker))
+    )
     if (config.hooks[ev].length === 0) delete config.hooks[ev]
   }
   try {


### PR DESCRIPTION
## Problem
On Windows, `buildManagedHookCommand()` generates hook commands containing native backslash paths (`agent-hooks\claude.sh`), while `managedMarkerFor()` produces forward-slash normalized markers (`agent-hooks/claude.sh`).

Because `isManaged()` and `removeHooksFrom()` performed substring checks without normalizing `h.command`, the match returned `false`. This caused `mergeManagedHook()` to treat prior entries as foreign, appending duplicate hook definitions to `~/.claude/settings.json` on every app start.

## Solution
Normalize backslashes to forward slashes (`replaceAll('\\', '/')`) before checking `includes(marker)` in both `isManaged()` and `removeHooksFrom()`.

## Verification
- Added test in `install-helper.test.ts` verifying idempotency when merging Windows backslash hook commands.
- Added test verifying that existing accumulated duplicates are collapsed down to a single entry upon merge.
- Added tests verifying repair sweeps and `removeHooksFrom()` properly prune Windows backslash entries.
- Verified all 16 tests in `install-helper.test.ts` and `npm run typecheck` pass.

Fixes #558
