### PR TITLE
ci: run required checks on merge_group (prerequisite for enabling the merge queue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 # Verify typecheck, tests, and the production build on every PR and push to main.
 on:
+  # Merge-queue runs: required checks must also report on the queue's synthetic
+  # merge commits, or every queued PR times out waiting for them.
+  merge_group:
   pull_request:
     branches: [main]
   push:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,9 @@ name: Security
 #   - Dependency review: blocks a PR that adds a vulnerable or disallowed-license dep.
 # Both are free on public repos and add no secrets to the PR runner.
 on:
+  # Merge-queue runs: required checks must also report on the queue's synthetic
+  # merge commits, or every queued PR times out waiting for them.
+  merge_group:
   pull_request:
     branches: [main]
   push:


### PR DESCRIPTION
Every merge currently invalidates every other open PR (`strict` up-to-date protection) — this week that meant sequential update-branch/CI cycles babysat by watchers for 20+ merges. The proper fix is GitHub's **merge queue**; this PR is its prerequisite: required checks must also report on `merge_group` events, or queued PRs time out.

- `ci.yml` + `security.yml`: add `merge_group:` trigger.
- `Dependency review` already limits itself to `pull_request` and reports **skipped** on a merge group — branch protection treats skipped as passing, so the queue is satisfied without running a PR-only action in a context it can't handle.
- Zero behavior change until the queue is enabled in repo settings (separate, deliberate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)