### PR TITLE
fix(terminal): make project-jump Cmd+1..9 bubble to dispatcher

### DIFF
--- a/src/renderer/terminal/terminal-config.test.ts
+++ b/src/renderer/terminal/terminal-config.test.ts
@@ -550,9 +550,10 @@ describe('terminalKeyAction', () => {
     expect(
       terminalKeyAction(ev({ key: 'Enter', code: 'Enter', shiftKey: true }), false, false, true)
     ).toBe('shift-enter')
-    // project-jump swallow wins over bubble
+    // project-jump bubbles to the dispatcher (which performs the switch) — it must
+    // still beat a registry bubble's reason but reach the window as a bubble, not a swallow
     expect(terminalKeyAction(ev({ key: '1', code: 'Digit1', metaKey: true }), false, true, true)).toBe(
-      'swallow'
+      'bubble'
     )
     // keyup never bubbles — the dispatcher only acts on keydown
     expect(
@@ -571,9 +572,11 @@ describe('terminalKeyAction', () => {
 
   // The jump-to-project chord: WHICH events are the chord is decided once, in lib/projectJump.ts
   // (and tested there — layout, AltGr, keyup, digit range). This module only obeys the answer.
-  it('swallows the jump-to-project chord so the PTY never sees the control byte', () => {
+  // It bubbles (not swallow) so the window dispatcher can perform the switch while still
+  // preventing the PTY control byte — see terminal-config.ts.
+  it('bubbles the jump-to-project chord so the PTY never sees the control byte', () => {
     expect(terminalKeyAction(ev({ key: '1', code: 'Digit1', ctrlKey: true }), false, true)).toBe(
-      'swallow'
+      'bubble'
     )
   })
 

--- a/src/renderer/terminal/terminal-config.ts
+++ b/src/renderer/terminal/terminal-config.ts
@@ -779,12 +779,15 @@ export type TerminalKeyAction = CopyKeyAction | 'shift-enter' | 'bubble'
  * `ownsProjectJump` is the Cmd/Ctrl+1-9 "jump to the Nth project" decision, made by the caller
  * (`liveProjectJumpTarget` in `lib/projectJump.ts`) and passed in — this module deliberately does
  * NOT re-derive it. There is exactly one matcher for that chord, because it has to agree with the
- * Canvas handler that performs the switch. When it is true the key must be swallowed HERE: xterm's
- * own handler runs first (via `attachCustomKeyEventHandler`), and by the time Canvas's bubble-phase
- * listener calls `preventDefault()` the control byte has already gone to the pty (on Linux/Windows
- * Ctrl+2..Ctrl+8 are `^@ ^[ ^\ ^] ^^ ^_`).
+ * Canvas handler that performs the switch. When it is true we return `'bubble'`: xterm's own
+ * handler runs first (via `attachCustomKeyEventHandler`), so we must suppress xterm's control-byte
+ * write (on Linux/Windows Ctrl+2..Ctrl+8 are `^@ ^[ ^\ ^] ^^ ^_`) without calling
+ * `preventDefault()` — a swallowed event is marked `defaultPrevented` and the window's bubble-phase
+ * dispatcher bails, which is why the jump stopped working from a focused terminal. `'bubble'`
+ * returns `false` from the xterm handler (skips the keymap) while the untouched event still bubbles
+ * to `Canvas.projectJumpGesture` which performs the actual switch.
  *
- * It defaults to `false` = never swallow = the byte-identical pre-feature behavior, which is also
+ * It defaults to `false` = never intercept = the byte-identical pre-feature behavior, which is also
  * what the Server Edition wants: browsers reserve the chord, so nothing there can act on it.
  */
 export function terminalKeyAction(
@@ -802,7 +805,13 @@ export function terminalKeyAction(
     !e.altKey
   )
     return 'shift-enter'
-  if (ownsProjectJump) return 'swallow'
+  // `ownsProjectJump` is a bubble, not a swallow: it must reach the window dispatcher
+  // that performs the actual project switch (see `lib/projectJump.ts` + Canvas
+  // `projectJumpGesture`), while still preventing xterm's control-byte write (Ctrl+2..8 are
+  // ^@ ^[ etc.). Swallowing with preventDefault would mark the event handled and the
+  // dispatcher bails on defaultPrevented — which is why Cmd+1 from a focused terminal
+  // (canvas or kanban modal) stopped switching.
+  if (ownsProjectJump) return 'bubble'
   const base = copyKeyAction(e, hasSelection)
   if (base !== 'pass') return base
   // `registryOwns` — decided by the caller via `terminalChordBubbles`, the same live-registry


### PR DESCRIPTION
Extracted from #588 per review — standalone regression fix.

The Cmd/Ctrl+1..9 project-jump chord must prevent xterm's control-byte write (Linux/Windows Ctrl+2..8 are `^@ ^[ ^\ ^] ^^ ^_`) without calling `preventDefault`. A swallowed event is marked `defaultPrevented` and the window's bubble-phase dispatcher (`Canvas.projectJumpGesture`) bails, which is why the jump stopped working from a focused terminal/modal.

- `terminalKeyAction` now returns `'bubble'` for `ownsProjectJump` (returns `false` from xterm's handler, skips keymap, event still bubbles)
- JSDoc rewritten to match
- Tests updated to expect `bubble`

This was buried in #588's 819-line feature PR; extracting lets it land fast independent of the swimlane product decision.

Ref: https://github.com/eneskirca/nodeterm/pull/588#issuecomment-5498602893 point 3, and https://github.com/eneskirca/nodeterm/pull/588#issuecomment-5500480388