### PR TITLE
feat(relay): node.wake / node.refresh / node.rename host verbs for the phone session list

### DIFF
--- a/src/core/project-node-append.ts
+++ b/src/core/project-node-append.ts
@@ -37,7 +37,10 @@ export interface RemoteNodeInput {
  *  same boring alphabet; an empty tail (`term-abc-`) is still refused. */
 const SAFE_NODE_ID = /^term-[a-z0-9]+-[a-z0-9]{1,16}$/
 
-const TITLE_MAX = 120
+/** One title ceiling for every host-side write of a client-supplied node title — the registrar's
+ *  append below AND the relay `node.rename` verb (host-service) clamp to the same number, so a
+ *  rename can never persist a title the registration path would have refused. */
+export const TITLE_MAX = 120
 
 /**
  * A `data.ssh` block usable as a donor: the two fields the pty manager needs to dial the host.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3447,6 +3447,26 @@ app.whenReady().then(async () => {
         }
       }
     })(),
+    // Renderer-nudge node actions for the phone's session-LIST long-press menu (`node.wake` /
+    // `node.refresh` / `node.rename`). Each returns whether it reached a LIVE window — the verb
+    // answers ok only on delivery, never on outcome (nudge contract: the renderer re-reads its
+    // own state and no-ops for a node it cannot resolve). `wake` reuses the exact `agent:wake`
+    // channel the attach path fires, so the renderer needs no new wiring for it; `rename` rides
+    // `agent:rename-node` into the renderer's `renameSession` funnel (titleAuto:false + `/rename`
+    // push) — deliberately NOT canvas:mutate's raw title write, which the session-name poll would
+    // overwrite on the next tick.
+    nodeActions: (() => {
+      const deliver = (channel: string, payload: unknown): boolean => {
+        if (win.isDestroyed()) return false
+        win.webContents.send(channel, payload)
+        return true
+      }
+      return {
+        wake: (nodeId: string) => deliver(IPC.agentWake, nodeId),
+        refresh: (nodeId: string) => deliver(IPC.agentRefreshNode, nodeId),
+        rename: (nodeId: string, title: string) => deliver(IPC.agentRenameNode, { nodeId, title })
+      }
+    })(),
     // Jail roots beyond the active canvas: the phone browses EVERY project (projects.list), so
     // its fs/git access spans every local project root — not just the tab the desktop happens
     // to have focused (that gap read as "cwd is outside the shared project roots" on the phone).

--- a/src/main/remote/host-node-actions.test.ts
+++ b/src/main/remote/host-node-actions.test.ts
@@ -1,0 +1,164 @@
+// The phone session-list long-press verbs (`node.wake` / `node.refresh` / `node.rename`) —
+// renderer nudges in the `agent:wake` shape. What these tests pin:
+//   - Absent injection ⇒ every verb answers an honest "not served" (a pre-feature host).
+//   - The client-sent node id is validated (non-string / empty / over REF_MAX_LEN / control
+//     chars ⇒ refused, callback never invoked) — these verbs deliberately take a client id
+//     (they fire from the LIST, where no stream exists), so the validation is the envelope.
+//   - A rename title is sanitized HERE, before it rides toward a `/rename` command line:
+//     control chars (ESC/CSI, \r\n) stripped, whitespace collapsed, TITLE_MAX clamp, and an
+//     empty-after-sanitize title refused.
+//   - The answer means "delivered to a live desktop window": a false callback (window gone)
+//     answers ok:false, never a silent success.
+import { describe, expect, it, vi } from 'vitest'
+import { REF_MAX_LEN } from '../../shared/presence'
+import { TITLE_MAX } from '../../core/project-node-append'
+import {
+  createHostHandlers,
+  type HostFsOps,
+  type HostNodeActions,
+  type HostPtyManager,
+  type HostRelaySocket
+} from './host-service'
+
+function makeFakes(actions?: Partial<HostNodeActions> & { delivered?: boolean }) {
+  const responses: Array<{ id: string; ok: boolean; body: unknown }> = []
+  const socket: HostRelaySocket = {
+    respond: (id, ok, body) => responses.push({ id, ok, body }),
+    sendFrame: () => true
+  }
+  const fs: HostFsOps = {
+    listDir: async () => [],
+    readText: async () => '',
+    readBinary: async () => '',
+    writeText: async () => true
+  }
+  const delivered = actions?.delivered ?? true
+  const nodeActions: HostNodeActions = {
+    wake: vi.fn(() => delivered),
+    refresh: vi.fn(() => delivered),
+    rename: vi.fn(() => delivered),
+    ...actions
+  }
+  const handlers = createHostHandlers(
+    {} as HostPtyManager,
+    socket,
+    fs,
+    () => [],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    nodeActions
+  )
+  return { handlers, responses, nodeActions }
+}
+
+function makeUnserved() {
+  const responses: Array<{ id: string; ok: boolean; body: unknown }> = []
+  const socket: HostRelaySocket = {
+    respond: (id, ok, body) => responses.push({ id, ok, body }),
+    sendFrame: () => true
+  }
+  const fs: HostFsOps = {
+    listDir: async () => [],
+    readText: async () => '',
+    readBinary: async () => '',
+    writeText: async () => true
+  }
+  const handlers = createHostHandlers({} as HostPtyManager, socket, fs, () => [])
+  return { handlers, responses }
+}
+
+describe('node.* verbs refuse honestly when not injected (pre-feature host)', () => {
+  it.each(['node.wake', 'node.refresh', 'node.rename'])('%s answers not served', (method) => {
+    const { handlers, responses } = makeUnserved()
+    handlers.onRpc({ id: '1', method, params: { nodeId: 'term-a-1', title: 'x' } })
+    expect(responses).toEqual([
+      { id: '1', ok: false, body: { message: `${method} is not served on this host.` } }
+    ])
+  })
+})
+
+describe('node id validation (client-sent id — the whole envelope for these verbs)', () => {
+  it.each([
+    ['missing', {}],
+    ['non-string', { nodeId: 42 }],
+    ['empty', { nodeId: '' }],
+    ['over REF_MAX_LEN', { nodeId: 'a'.repeat(REF_MAX_LEN + 1) }],
+    ['control chars', { nodeId: 'term-a\x1b[2J-1' }],
+    ['newline', { nodeId: 'term-a\n-1' }]
+  ])('refuses a %s node id and never invokes the callback', (_label, params) => {
+    const { handlers, responses, nodeActions } = makeFakes()
+    handlers.onRpc({ id: '1', method: 'node.wake', params })
+    expect(responses).toEqual([{ id: '1', ok: false, body: { message: 'Invalid node id.' } }])
+    expect(nodeActions.wake).not.toHaveBeenCalled()
+  })
+
+  it('accepts an ordinary desktop node id and answers ok on delivery', () => {
+    const { handlers, responses, nodeActions } = makeFakes()
+    handlers.onRpc({ id: '1', method: 'node.wake', params: { nodeId: 'term-lz0abc-x1' } })
+    expect(nodeActions.wake).toHaveBeenCalledWith('term-lz0abc-x1')
+    expect(responses).toEqual([{ id: '1', ok: true, body: {} }])
+  })
+})
+
+describe('node.refresh', () => {
+  it('routes to the refresh callback', () => {
+    const { handlers, responses, nodeActions } = makeFakes()
+    handlers.onRpc({ id: '1', method: 'node.refresh', params: { nodeId: 'term-a-1' } })
+    expect(nodeActions.refresh).toHaveBeenCalledWith('term-a-1')
+    expect(nodeActions.wake).not.toHaveBeenCalled()
+    expect(responses[0]?.ok).toBe(true)
+  })
+})
+
+describe('node.rename title sanitation (before anything rides toward /rename)', () => {
+  it('strips ESC/CSI and newlines, collapses whitespace', () => {
+    const { handlers, nodeActions } = makeFakes()
+    handlers.onRpc({
+      id: '1',
+      method: 'node.rename',
+      params: { nodeId: 'term-a-1', title: 'fix\x1b[201~ the\r\nbug  now' }
+    })
+    // ESC stripped (its CSI tail "[201~" survives as plain text — the ESC is what made it
+    // structure), \r\n → single space, runs collapsed.
+    expect(nodeActions.rename).toHaveBeenCalledWith('term-a-1', 'fix [201~ the bug now')
+  })
+
+  it('clamps to TITLE_MAX (the registrar ceiling)', () => {
+    const { handlers, nodeActions } = makeFakes()
+    handlers.onRpc({
+      id: '1',
+      method: 'node.rename',
+      params: { nodeId: 'term-a-1', title: 'x'.repeat(TITLE_MAX + 50) }
+    })
+    expect(nodeActions.rename).toHaveBeenCalledWith('term-a-1', 'x'.repeat(TITLE_MAX))
+  })
+
+  it.each([
+    ['missing', undefined],
+    ['non-string', 7],
+    ['empty', ''],
+    ['whitespace-only', '   '],
+    ['control-only', '\x1b\x1b\r\n']
+  ])('refuses a %s title without invoking the callback', (_label, title) => {
+    const { handlers, responses, nodeActions } = makeFakes()
+    handlers.onRpc({ id: '1', method: 'node.rename', params: { nodeId: 'term-a-1', title } })
+    expect(responses).toEqual([
+      { id: '1', ok: false, body: { message: 'node.rename requires a non-empty title.' } }
+    ])
+    expect(nodeActions.rename).not.toHaveBeenCalled()
+  })
+})
+
+describe('delivery is the answer, never assumed', () => {
+  it('answers ok:false when the desktop window is gone', () => {
+    const { handlers, responses } = makeFakes({ delivered: false })
+    handlers.onRpc({ id: '1', method: 'node.refresh', params: { nodeId: 'term-a-1' } })
+    expect(responses).toEqual([
+      { id: '1', ok: false, body: { message: 'The desktop window is not available.' } }
+    ])
+  })
+})

--- a/src/main/remote/host-service.ts
+++ b/src/main/remote/host-service.ts
@@ -32,7 +32,7 @@ import type { CanvasMutation, CanvasState, DirEntry, PtyCreateOptions } from '..
 import type { AgentId } from '../../shared/agents/config'
 import { PtyManager, type DetachedSinks } from '../../core/pty-manager'
 import * as fsOps from '../../core/fs-ops'
-import type { RemoteNodeInput } from '../../core/project-node-append'
+import { TITLE_MAX, type RemoteNodeInput } from '../../core/project-node-append'
 import { getStoredEntitlement, isPremium } from '../../core/license'
 import { publicKeyToB64, type KeyPair } from './e2ee'
 import { loadOrCreateHostKeyPair, HostKeyLockedError } from './host-identity'
@@ -128,6 +128,25 @@ export interface HostGitOps {
   history(cwd: string): Promise<unknown>
 }
 
+/**
+ * Renderer-nudge node actions the phone's session-LIST long-press menu invokes (`node.wake` /
+ * `node.refresh` / `node.rename`). Each forwards to the host renderer and returns whether it was
+ * DELIVERED to a live window — never whether the action "worked": all three are nudges in the
+ * `agent:wake` shape (the renderer re-reads its own state and no-ops for a node it cannot
+ * resolve), which is exactly why they may take a client-sent node id where the session-scoped
+ * RPCs must not — the worst a hostile id buys is a no-op nudge, and `pty.attach` already accepts
+ * a client-chosen node id for a far stronger capability. Absent ⇒ the verbs answer an honest
+ * "not served" (a pre-feature host, and every pre-feature test fake).
+ */
+export interface HostNodeActions {
+  /** Ask the renderer to wake a hibernated node (same `agent:wake` channel the attach path uses). */
+  wake(nodeId: string): boolean
+  /** Ask the renderer to reload the node's terminal view in place (`respawnNonce` bump). */
+  refresh(nodeId: string): boolean
+  /** Rename a node through the renderer's `renameSession` funnel (title pre-sanitized here). */
+  rename(nodeId: string, title: string): boolean
+}
+
 interface Stream {
   sessionId: string
   /** The node id (tmux persistKey) this stream attached to. The ONLY tmux target a client can
@@ -206,7 +225,10 @@ export function createHostHandlers(
   // balanced per stream (kill, destroy, PTY exit, closeAll, an attach superseded mid-flight).
   // The desktop uses it to (a) wake a hibernated node someone just opened on their phone and
   // (b) keep Eco from hibernating a session a phone is actively watching. Absent ⇒ no tracking.
-  remoteViewer?: { attached(nodeId: string): void; detached(nodeId: string): void }
+  remoteViewer?: { attached(nodeId: string): void; detached(nodeId: string): void },
+  // Renderer-nudge node actions for the phone's session-list long-press menu (`node.wake` /
+  // `node.refresh` / `node.rename`). Absent ⇒ the verbs answer an honest "not served".
+  nodeActions?: HostNodeActions
 ): HostHandlers {
   // streamId -> Stream. PTY callbacks close over their own `streamId` directly, so no
   // reverse (sessionId -> streamId) index is needed.
@@ -564,6 +586,58 @@ export function createHostHandlers(
       )
   }
 
+  /**
+   * `node.wake` / `node.refresh` / `node.rename {nodeId, title?}` — the session-list long-press
+   * actions. Unlike the session-scoped RPCs these take a client-sent `nodeId`, deliberately:
+   * they fire from the LIST, where no stream exists, and each is a renderer NUDGE that no-ops
+   * for a node the canvas cannot resolve (the same trust envelope as `pty.attach`'s
+   * client-chosen node id, for a much weaker capability). Validation still applies — the id is
+   * length-capped and control-char-refused, and a rename title is sanitized here (control chars
+   * out, `TITLE_MAX` clamp) BEFORE it rides toward a `/rename` command line. The answer means
+   * "delivered to a live desktop window", never "the action happened" — that contract is in the
+   * verb docs the iOS client mirrors.
+   */
+  function handleNodeAction(req: RpcRequest): void {
+    if (!nodeActions) {
+      socket.respond(req.id, false, { message: `${req.method} is not served on this host.` })
+      return
+    }
+    const p = asRecord(req.params)
+    const nodeId = str(p.nodeId)
+    // eslint-disable-next-line no-control-regex -- refusing control chars is the point
+    if (!nodeId || nodeId.length > REF_MAX_LEN || /[\x00-\x1f\x7f-\x9f]/.test(nodeId)) {
+      socket.respond(req.id, false, { message: 'Invalid node id.' })
+      return
+    }
+    let delivered = false
+    if (req.method === 'node.rename') {
+      // Strip C0/C1 control chars (ESC/CSI included — the paste-injection rule: a payload must
+      // not be able to become structure) and collapse the leftovers; clamp to the registrar's
+      // TITLE_MAX so a rename can never persist a title registration would have refused.
+      const raw = str(p.title) ?? ''
+      const title = raw
+        // eslint-disable-next-line no-control-regex -- stripping control chars is the point
+        .replace(/[\x00-\x1f\x7f-\x9f]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, TITLE_MAX)
+      if (!title) {
+        socket.respond(req.id, false, { message: 'node.rename requires a non-empty title.' })
+        return
+      }
+      delivered = nodeActions.rename(nodeId, title)
+    } else {
+      delivered = req.method === 'node.wake' ? nodeActions.wake(nodeId) : nodeActions.refresh(nodeId)
+    }
+    if (!delivered) {
+      // The desktop window is gone (quitting / crashed) — an honest refusal, not a silent "ok"
+      // over a nudge that reached nothing.
+      socket.respond(req.id, false, { message: 'The desktop window is not available.' })
+      return
+    }
+    socket.respond(req.id, true, {})
+  }
+
   return {
     onRpc(req) {
       switch (req.method) {
@@ -603,6 +677,11 @@ export function createHostHandlers(
           break
         case 'projects.registerNode':
           handleRegisterNode(req)
+          break
+        case 'node.wake':
+        case 'node.refresh':
+        case 'node.rename':
+          handleNodeAction(req)
           break
         case 'projects.list':
           // Read-only enumeration of the host's projects/sessions/agent-status (no client params —
@@ -842,6 +921,9 @@ export interface HostSessionOptions {
   /** Relay-viewer presence per node (attach/detach, balanced per stream) — see createHostHandlers.
    *  Optional: absent ⇒ no tracking. */
   remoteViewer?: { attached(nodeId: string): void; detached(nodeId: string): void }
+  /** Renderer-nudge node actions (`node.wake` / `node.refresh` / `node.rename`) for the phone's
+   *  session-list long-press menu. Optional: absent ⇒ the verbs answer an honest "not served". */
+  nodeActions?: HostNodeActions
   /** Extra fs/git jail roots beyond the shared canvas's node cwds — production passes the
    *  workspace's local project cwds: the phone browses EVERY project over `projects.list`, so a
    *  canvas-only jail denied whichever project the desktop didn't happen to have focused. */
@@ -964,7 +1046,8 @@ export function connectHostSession(opts: HostSessionOptions): HostSession {
     opts.git,
     opts.registerNode,
     opts.destroyNode,
-    opts.remoteViewer
+    opts.remoteViewer,
+    opts.nodeActions
   )
   canvasSync = createHostCanvasSync(socket, opts.applyMutation)
   unsubCanvas = opts.subscribeCanvas(() => scheduleBroadcast())
@@ -990,6 +1073,9 @@ export interface HostBridgeDeps {
   /** Relay-viewer presence per node — wakes a hibernated node a phone just opened and shields a
    *  phone-watched session from Eco (see main/index.ts's counter). */
   remoteViewer?: { attached(nodeId: string): void; detached(nodeId: string): void }
+  /** Renderer-nudge node actions for the phone's session-list long-press menu (`node.wake` /
+   *  `node.refresh` / `node.rename`) — see main/index.ts's deliverers. */
+  nodeActions?: HostNodeActions
   /** Workspace-level jail roots (local project cwds) merged with the canvas node cwds. */
   workspaceRoots?: () => string[]
 }
@@ -1062,6 +1148,7 @@ export function initRemoteHost(
       registerNode: bridge.registerNode,
       destroyNode: bridge.destroyNode,
       remoteViewer: bridge.remoteViewer,
+      nodeActions: bridge.nodeActions,
       extraRoots: bridge.workspaceRoots,
       // Typing attribution: this session's input frames are this phone's keystrokes.
       getClientId: () => phone.id(),

--- a/src/main/remote/standing-host.ts
+++ b/src/main/remote/standing-host.ts
@@ -337,6 +337,7 @@ export function initStandingHost(
         registerNode: bridge.registerNode,
         destroyNode: bridge.destroyNode,
         remoteViewer: bridge.remoteViewer,
+        nodeActions: bridge.nodeActions,
         extraRoots: bridge.workspaceRoots,
         // Typing attribution: this pooled session's input frames are ITS phone's keystrokes.
         getClientId: () => pooled.presence.id(),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -768,6 +768,16 @@ const api: NodeTerminalApi = {
     ipcRenderer.on(IPC.agentRemoteViewers, handler)
     return () => ipcRenderer.removeListener(IPC.agentRemoteViewers, handler)
   },
+  onAgentRefreshNode: (listener) => {
+    const handler = (_e: unknown, nodeId: string) => listener(nodeId)
+    ipcRenderer.on(IPC.agentRefreshNode, handler)
+    return () => ipcRenderer.removeListener(IPC.agentRefreshNode, handler)
+  },
+  onAgentRenameNode: (listener) => {
+    const handler = (_e: unknown, payload: { nodeId: string; title: string }) => listener(payload)
+    ipcRenderer.on(IPC.agentRenameNode, handler)
+    return () => ipcRenderer.removeListener(IPC.agentRenameNode, handler)
+  },
   onSubagentActivity: (listener) => {
     const handler = (_e: unknown, payload: Parameters<typeof listener>[0]) => listener(payload)
     ipcRenderer.on(IPC.agentSubagentActivity, handler)

--- a/src/renderer/bridge/stubs.ts
+++ b/src/renderer/bridge/stubs.ts
@@ -125,6 +125,8 @@ export function buildStubApi(): Omit<
   | 'reportHibernated'
   | 'onAgentWake'
   | 'onRemoteViewers'
+  | 'onAgentRefreshNode'
+  | 'onAgentRenameNode'
   // Real over the bridge (IPC.appUserDataDir): the worktree dialog's default path is derived from
   // it, and a '' stub would propose `/worktrees/…` at the filesystem root.
   | 'userDataDir'
@@ -527,6 +529,8 @@ export function buildStubApi(): Omit<
   | 'reportHibernated'
   | 'onAgentWake'
   | 'onRemoteViewers'
+  | 'onAgentRefreshNode'
+  | 'onAgentRenameNode'
     | 'userDataDir'
     | 'presence'
     | 'speech'

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -638,6 +638,8 @@ export function buildAgentApi(
   | 'reportHibernated'
   | 'onAgentWake'
   | 'onRemoteViewers'
+  | 'onAgentRefreshNode'
+  | 'onAgentRenameNode'
 > {
   return {
     onAgentStatus: (listener) => client.subscribe(IPC.agentStatus, listener as Listener),
@@ -651,6 +653,8 @@ export function buildAgentApi(
     // relay, so there is nothing to subscribe to and nothing silently degrades.
     onAgentWake: () => () => undefined,
     onRemoteViewers: () => () => undefined,
+    onAgentRefreshNode: () => () => undefined,
+    onAgentRenameNode: () => () => undefined,
     // Host swept a phone read-ack → drop this browser canvas's unread flag (external clear, no re-ack).
     onUnreadClear: (listener) => client.subscribe(IPC.agentUnreadClear, listener as Listener),
     onSubagentActivity: (listener) =>

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -10421,6 +10421,35 @@ export function Canvas() {
     [renameSession, activeProjectId]
   )
 
+  // Phone-originated node actions over the relay (the iOS session-list long-press menu). Both are
+  // nudges in the `agent:wake` shape — main already validated/sanitized the payload, and this side
+  // still re-resolves everything and no-ops for a node it cannot find. `refresh` bumps
+  // `respawnNonce` on a mounted terminal of the ACTIVE project (an inactive project's node has no
+  // live view to refresh — honest no-op). `rename` routes through `renameSession`, the same funnel
+  // as the node header: title + titleAuto:false + `/rename` into a rename-capable agent's live
+  // session — the reason this is not a canvas:mutate title write, which would do none of that and
+  // be overwritten by the next session-name poll. The owning project is resolved here because the
+  // phone knows only the node id; a node in NO project is dropped.
+  useEffect(() => {
+    const unsubRefresh = window.nodeTerminal.onAgentRefreshNode?.((nodeId) => {
+      if (typeof nodeId === 'string' && nodeId) reloadTerminals([nodeId])
+    })
+    const unsubRename = window.nodeTerminal.onAgentRenameNode?.((payload) => {
+      const nodeId = typeof payload?.nodeId === 'string' ? payload.nodeId : ''
+      const title = typeof payload?.title === 'string' ? payload.title.trim() : ''
+      if (!nodeId || !title) return
+      const projectId = nodesRef.current.some((n) => n.id === nodeId)
+        ? activeProjectId
+        : useProjects.getState().projects.find((p) => p.nodes.some((n) => n.id === nodeId))?.id
+      if (!projectId) return
+      renameSession(projectId, nodeId, title)
+    })
+    return () => {
+      unsubRefresh?.()
+      unsubRename?.()
+    }
+  }, [reloadTerminals, renameSession, activeProjectId])
+
   // Write-through a sticky node's body text from the kanban card modal (the canvas sticky
   // reads the same data.text path).
   const editStickyText = useCallback(

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -155,6 +155,19 @@ export const IPC = {
    *  no-ops for a non-hibernated or unmounted node — same contract as `wakeHibernatedNode`. Arg:
    *  `nodeId: string`. */
   agentWake: 'agent:wake',
+  /** main → renderer: ask the renderer to reload a terminal node's view in place NOW (bump its
+   *  `respawnNonce` — fresh PTY attach to the SAME tmux session, nothing running is interrupted).
+   *  Fired by the phone relay host's `node.refresh` verb (the session-list long-press menu's
+   *  "Refresh on desktop"). Same nudge contract as `agent:wake`: the renderer no-ops for an
+   *  unknown, non-terminal or unmounted (inactive project) node. Arg: `nodeId: string`. */
+  agentRefreshNode: 'agent:refresh-node',
+  /** main → renderer: rename a node on behalf of a phone (the relay host's `node.rename` verb).
+   *  Routed through the renderer's `renameSession` funnel — the same one the node header uses —
+   *  so `titleAuto` flips off and a rename-capable agent gets `/rename` pushed into its live
+   *  session; a raw `data.title` write (canvas:mutate) would do neither and be overwritten by the
+   *  next session-name poll. The title is sanitized host-side before this fires (control chars
+   *  stripped, length-clamped). Arg: `{ nodeId: string, title: string }`. */
+  agentRenameNode: 'agent:rename-node',
   /** main → renderer: the CURRENT set of node ids with a live relay viewer attached (a phone
    *  watching the session). Arg: `string[]` — the full set each change, so a dropped event cannot
    *  strand a stale entry. Feeds `isNodeWatched`: a session someone is watching from a phone must

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3065,6 +3065,17 @@ export interface NodeTerminalApi {
    *  full set each change, never a delta. Feeds `isNodeWatched` so Eco cannot hibernate a session
    *  someone is watching from a phone. Desktop-only signal, like `onAgentWake`. */
   onRemoteViewers(listener: (nodeIds: string[]) => void): () => void
+  /** Fires when the core asks this renderer to reload a terminal node's view in place (bump its
+   *  `respawnNonce` — fresh attach to the SAME tmux session) — the phone relay host's
+   *  `node.refresh` verb. A nudge with the `onAgentWake` contract: no-op for an unknown,
+   *  non-terminal or unmounted node. Desktop-only signal (the relay host lives in the desktop
+   *  main process); the ws-bridge subscribes to nothing and returns a no-op unsubscribe. */
+  onAgentRefreshNode(listener: (nodeId: string) => void): () => void
+  /** Fires when the core asks this renderer to rename a node on a phone's behalf (the relay
+   *  host's `node.rename` verb, title already sanitized host-side). The renderer routes it
+   *  through the same `renameSession` funnel as the node header. Desktop-only signal, like
+   *  `onAgentRefreshNode`. */
+  onAgentRenameNode(listener: (payload: { nodeId: string; title: string }) => void): () => void
   /** Fires with live subagent transcript chunks while a subagent runs. Returns unsubscribe. */
   onSubagentActivity(listener: (e: SubagentActivity) => void): () => void
   /** Fires when an agent's `nodeterm` CLI requests a canvas action. Returns unsubscribe. */


### PR DESCRIPTION
## What

Three small host verbs on the phone relay dialect (`host-service.ts`), consumed by the iOS session-list long-press menu (eneskirca/nodeterm-ios#19). All three are renderer **nudges in the `agent:wake` shape** — the host forwards to the desktop renderer, which re-checks its own state and no-ops for a node it cannot resolve:

- **`node.wake {nodeId}`** → the existing `IPC.agentWake` channel (the exact nudge a `pty.attach` already fires), so the renderer needed no new wiring — this lets the phone wake a SLEEPING (Eco-hibernated) node without opening it.
- **`node.refresh {nodeId}`** → new `agent:refresh-node` → `Canvas.reloadTerminals` (`respawnNonce` bump — fresh attach to the SAME tmux session; the desktop's own "Refresh terminal", nothing running is interrupted).
- **`node.rename {nodeId, title}`** → new `agent:rename-node` → Canvas resolves the owning project and routes through **`renameSession`**, the same funnel as the node header: title + `titleAuto:false` + `/rename` pushed into a rename-capable agent's live session. Deliberately NOT `canvas:mutate`'s raw title write, which does none of that and is overwritten by the next session-name poll.

## Envelope / security

- Unlike the session-scoped RPCs these take a **client-sent `nodeId`**, because they fire from the LIST where no stream exists. That is the same trust shape as `pty.attach`'s client-chosen node id, for a much weaker capability — a hostile id buys a no-op nudge. Validation still applies: length-capped at `REF_MAX_LEN`, control chars refused.
- A rename title is sanitized **host-side, before anything rides toward a `/rename` command line**: C0/C1 controls (ESC/CSI, `\r\n`) stripped per the paste-injection rule, whitespace collapsed, clamped to the registrar's `TITLE_MAX` (now exported from `project-node-append.ts` so the two ceilings cannot drift), empty-after-sanitize refused.
- The answer means **"delivered to a live desktop window"**, never "the action happened": absent injection answers an honest `"<verb> is not served on this host."` (pre-feature hosts and every pre-feature test fake), a destroyed window answers `ok:false`, and the approval gate in `connectHostSession` fronts everything as usual.
- Both phone hosts (interactive `initRemoteHost` + standing pool) thread the same `HostBridgeDeps.nodeActions`.

## Surfaces

- **Desktop**: full (above).
- **Server Edition**: N/A by construction — the phone relay host lives in desktop main. The two new `window.nodeTerminal` members are documented no-op subscriptions in the ws-bridge, exactly like `onAgentWake` / `onRemoteViewers`.
- **Mobile**: consuming UI ships in eneskirca/nodeterm-ios#19 (@eneskirca).

## Tests

`src/main/remote/host-node-actions.test.ts` pins: the not-served refusal per verb, node-id validation (missing / non-string / over-cap / control chars, callback never invoked), title sanitation (ESC stripped, CRLF collapsed, `TITLE_MAX` clamp, empty refused), and delivery-as-the-answer (window gone ⇒ `ok:false`). Ran the full suite: the only failures are two pre-existing installed-dist pin tests (`keyContext` xterm class / `directionalFocus` xyflow class) that read this checkout's `node_modules` and are untouched by this branch — CI runs against a clean install.

## Feasibility notes for the remaining iOS menu candidates (not in this PR)

- **Pause/Resume (#514)**: `paused` lives only in the renderer's localStorage and is absent from the agent-status mirror, so the phone can neither see nor toggle it. Would need a `paused` field on `MirrorEntry`/`MirrorFile.nodes`, an `agent:paused` mirror channel (twin of `agent:hibernated`), and a `node.pause`/`node.resume` verb pair routed to `pauseAgentNode` — say the word and it's a follow-up.
- **Labels**: kanban labels are renderer-pure (`lib/kanban.ts` + `workspace.save()`); a phone label toggle needs a real host handler over `project.kanban` — the largest of the set.
- **End session from the list**: refused on purpose — `pty.destroy` is stream-scoped ("a client can only destroy a session it has actually attached to") and a nodeId-addressed destructive verb would break that envelope.

## Device checklist

1. Phone (nodeterm-ios#19) + this desktop: long-press Wake on a SLEEPING session → CLI resumes on the desktop; chip clears on the next mirror poll.
2. Rename from the phone → node header renames, `titleAuto` off (the session-name poll stops overwriting), `/rename` visible in a claude pane; works for a node in a NON-active project too.
3. Refresh from the phone → the desktop terminal repaints in place; a running agent is untouched.
4. Old phone app against this desktop: byte-identical behavior (verbs only answer when asked).
5. New phone against an OLD desktop: each action surfaces the "update nodeterm on the computer" hint (Unknown method rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL