### PR TITLE
feat(server): create folders from the web folder picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,18 @@ The codebase is split by Electron process boundary — keep code on the correct 
   browser) plus a web folder/file picker (in-app server-directory browser,
   replacing the native dialog) and WS backpressure; the renderer detects the
   bridge in `src/renderer/main.tsx` (desktop preload path is untouched).
+  The picker's **folder** mode also creates directories (`createPickerFolder`,
+  `renderer/bridge/dialog-picker.tsx`) — the native dialog it replaces has a New Folder
+  button, so without one "Open folder…" in the browser could only ever adopt a directory
+  that already existed on the server. It writes through the same `fs.mkdir`/`fs.exists`
+  the Explorer's "New Folder…" uses and validates the typed name with the same envelope,
+  `newEntryPath` (`renderer/lib/explorerCreate.ts`) — **do not add a second path
+  validator here**; `..`, absolute and empty names are refused in exactly one place. The
+  write deps are optional, so a caller with a read-only fs simply renders no button. File
+  mode has none (nobody opens a file picker to make a folder). Relay tabs get the same
+  button and it writes on the HOST, like every other `fs.*` the picker already uses. SSH
+  projects are a separate flow (`SshProjectDialog` over `sshProject.mkdir`) and already
+  had their own.
   **Phase 3b** boots the loopback **hook server** (`hookServer.start()`) + installs
   the managed hook scripts, and `wireAgentStatus` (`src/server/agent-status.ts`)
   broadcasts `agent:status` / `agent:subagent-activity` / `context:update` over the

--- a/src/renderer/bridge/dialog-picker.dom.test.tsx
+++ b/src/renderer/bridge/dialog-picker.dom.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+//
+// The web picker's "New folder" flow, end to end through the real `openDirectoryPicker` promise
+// (which is what `ws-bridge` / `relay-api` call). What is pinned here is the FLOW — create, step
+// in, Open — plus the two ways the button must be absent and the two ways a refusal must be
+// visible. The path rules themselves live in `dialog-picker.test.ts`.
+import { act } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { DirEntry } from '../../shared/types'
+import { openDirectoryPicker, type PickerMkdirDeps } from './dialog-picker'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+/** A tiny in-memory server fs: `dirs` is the set of absolute directories that exist. */
+function fakeFs(dirs: string[] = ['/home']): {
+  list: (p: string) => Promise<DirEntry[]>
+  write: PickerMkdirDeps
+  made: string[]
+} {
+  const set = new Set(dirs)
+  const made: string[] = []
+  return {
+    list: async (p) => {
+      const base = p.length > 1 ? p.replace(/\/+$/, '') : p
+      return [...set]
+        .filter((d) => d !== base && d.slice(0, base === '/' ? 1 : base.length + 1) === (base === '/' ? '/' : `${base}/`))
+        .filter((d) => !d.slice(base === '/' ? 1 : base.length + 1).includes('/'))
+        .map((d) => ({ name: d.slice(d.lastIndexOf('/') + 1), dir: true }))
+    },
+    write: {
+      exists: async (p) => set.has(p),
+      mkdir: async (p) => {
+        made.push(p)
+        set.add(p)
+        return true
+      }
+    },
+    made
+  }
+}
+
+const $ = <T extends Element>(sel: string): T | null => document.body.querySelector<T>(sel)
+const click = async (el: Element | null): Promise<void> => {
+  await act(async () => {
+    el?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+const type = async (el: HTMLInputElement, value: string): Promise<void> => {
+  await act(async () => {
+    // React tracks the value on the DOM node; bypass its dedupe so `onChange` fires.
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+    setter?.call(el, value)
+    el.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+/** Flush the picker's initial async listing (it lands after the first paint). */
+const settle = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+// The picker root is a module singleton (one container appended to <body>, reused for every
+// call — exactly as in the app), so tests must NOT wipe <body>: a fresh `openDirectoryPicker`
+// re-renders into it and unmounts whatever the previous test left open.
+
+describe('web folder picker — New folder', () => {
+  it('creates the folder, steps into it, and "Use this folder" returns it', async () => {
+    const fs = fakeFs(['/home'])
+    let resolved: string | null | undefined
+    await act(async () => {
+      void openDirectoryPicker({
+        mode: 'folder',
+        startDir: '/home',
+        list: fs.list,
+        write: fs.write
+      }).then((r) => {
+        resolved = r
+      })
+    })
+    await settle()
+
+    await click($('.dir-picker__new'))
+    const input = $<HTMLInputElement>('.dir-picker__input')
+    expect(input).not.toBeNull()
+    await type(input as HTMLInputElement, 'newproj')
+    await click($('.dir-picker__create .confirm__btn.primary'))
+    await settle()
+
+    expect(fs.made).toEqual(['/home/newproj'])
+    // Stepped INTO it: the path line is the new folder, and the create form is gone.
+    expect($('.dir-picker__path')?.textContent).toBe('/home/newproj')
+    expect($('.dir-picker__input')).toBeNull()
+
+    await click($('.confirm__actions .confirm__btn.primary'))
+    expect(resolved).toBe('/home/newproj')
+  })
+
+  it('shows a readable error and keeps the form open when the name is taken', async () => {
+    const fs = fakeFs(['/home', '/home/taken'])
+    await act(async () => {
+      void openDirectoryPicker({ mode: 'folder', startDir: '/home', list: fs.list, write: fs.write })
+    })
+    await settle()
+
+    await click($('.dir-picker__new'))
+    await type($<HTMLInputElement>('.dir-picker__input') as HTMLInputElement, 'taken')
+    await click($('.dir-picker__create .confirm__btn.primary'))
+    await settle()
+
+    expect($('.dir-picker__error')?.textContent).toBe('Already exists: /home/taken')
+    expect($('.dir-picker__input')).not.toBeNull() // still editable, nothing silently dropped
+    expect(fs.made).toEqual([])
+    expect($('.dir-picker__path')?.textContent).toBe('/home') // did not navigate
+  })
+
+  it('surfaces a rejected mkdir instead of doing nothing', async () => {
+    const fs = fakeFs(['/home'])
+    const write: PickerMkdirDeps = { exists: fs.write.exists, mkdir: vi.fn(async () => false) }
+    await act(async () => {
+      void openDirectoryPicker({ mode: 'folder', startDir: '/home', list: fs.list, write })
+    })
+    await settle()
+
+    await click($('.dir-picker__new'))
+    await type($<HTMLInputElement>('.dir-picker__input') as HTMLInputElement, 'nope')
+    await click($('.dir-picker__create .confirm__btn.primary'))
+    await settle()
+
+    expect($('.dir-picker__error')?.textContent).toBe('Could not create /home/nope')
+  })
+
+  it('Escape backs out of the create form before it closes the picker', async () => {
+    const fs = fakeFs(['/home'])
+    let resolved: string | null | undefined
+    let settled = false
+    await act(async () => {
+      void openDirectoryPicker({
+        mode: 'folder',
+        startDir: '/home',
+        list: fs.list,
+        write: fs.write
+      }).then((r) => {
+        resolved = r
+        settled = true
+      })
+    })
+    await settle()
+
+    await click($('.dir-picker__new'))
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect($('.dir-picker__input')).toBeNull()
+    expect(settled).toBe(false) // the picker itself is still open
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(settled).toBe(true)
+    expect(resolved).toBeNull()
+  })
+
+  it('offers no button in file mode, or when the caller passes no write deps', async () => {
+    const fs = fakeFs(['/home'])
+    await act(async () => {
+      void openDirectoryPicker({ mode: 'file', startDir: '/home', list: fs.list, write: fs.write })
+    })
+    await settle()
+    expect($('.dir-picker__new')).toBeNull()
+
+    // Re-rendering the shared root replaces the file-mode picker with this one.
+    await act(async () => {
+      void openDirectoryPicker({ mode: 'folder', startDir: '/home', list: fs.list })
+    })
+    await settle()
+    expect($('.dir-picker__new')).toBeNull()
+  })
+})

--- a/src/renderer/bridge/dialog-picker.test.ts
+++ b/src/renderer/bridge/dialog-picker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { nextEntries } from './dialog-picker'
+import { createPickerFolder, nextEntries, type PickerMkdirDeps } from './dialog-picker'
 import type { DirEntry } from '../../shared/types'
 
 // The real `DirEntry` (src/shared/types.ts) is `{ name, dir, ignored? }` — it uses `dir`
@@ -45,5 +45,85 @@ describe('dialog-picker navigation helper', () => {
   it('normalizes a trailing slash when computing the parent', async () => {
     const view = await nextEntries('/home/u/', 'folder', vi.fn(async () => []))
     expect(view.parent).toBe('/home')
+  })
+})
+
+// ── "New folder" (folder mode only; Server Edition + relay tabs) ─────────────────────────────
+// `createPickerFolder` is the whole create step. It reuses the Explorer's `newEntryPath`
+// envelope rather than validating paths a second time, so the cases below are the picker's
+// contract with that envelope, not a re-test of it.
+describe('createPickerFolder', () => {
+  const deps = (over: Partial<PickerMkdirDeps> = {}): PickerMkdirDeps => ({
+    exists: vi.fn(async () => false),
+    mkdir: vi.fn(async () => true),
+    ...over
+  })
+
+  it('creates the folder under the current dir and reports its absolute path', async () => {
+    const d = deps()
+    await expect(createPickerFolder('/home/u', 'proj', d)).resolves.toEqual({
+      ok: true,
+      path: '/home/u/proj'
+    })
+    expect(d.mkdir).toHaveBeenCalledWith('/home/u/proj')
+  })
+
+  it('joins correctly at the filesystem root', async () => {
+    const d = deps()
+    await expect(createPickerFolder('/', 'srv', d)).resolves.toEqual({ ok: true, path: '/srv' })
+  })
+
+  it('normalizes a trailing slash on the current dir', async () => {
+    const d = deps()
+    await expect(createPickerFolder('/home/u/', 'proj', d)).resolves.toEqual({
+      ok: true,
+      path: '/home/u/proj'
+    })
+  })
+
+  // The jail: whatever the picker can navigate to, it can create in — and nothing else. `..`,
+  // an absolute name and an empty one are refused by `newEntryPath` BEFORE any fs call.
+  it.each([
+    ['..', '/home/u'],
+    ['../evil', '/home/u'],
+    ['a/../../evil', '/home/u'],
+    ['/etc/passwd', '/home/u'],
+    ['', '/home/u'],
+    ['   ', '/home/u']
+  ])('refuses %s without touching the filesystem', async (name, dir) => {
+    const d = deps()
+    const res = await createPickerFolder(dir, name, d)
+    expect(res.ok).toBe(false)
+    expect(res.ok === false && res.error).toMatch(/^Invalid name:/)
+    expect(d.mkdir).not.toHaveBeenCalled()
+    expect(d.exists).not.toHaveBeenCalled()
+  })
+
+  it('never overwrites: an existing path is refused by name, with no mkdir', async () => {
+    const d = deps({ exists: vi.fn(async () => true) })
+    const res = await createPickerFolder('/home/u', 'proj', d)
+    expect(res).toEqual({ ok: false, error: 'Already exists: /home/u/proj' })
+    expect(d.mkdir).not.toHaveBeenCalled()
+  })
+
+  // A refused mkdir (no write permission on the parent) must READ as a refusal — the silent
+  // no-op is what makes a server picker feel broken.
+  it('surfaces a failed mkdir as a readable error naming the path', async () => {
+    const d = deps({ mkdir: vi.fn(async () => false) })
+    await expect(createPickerFolder('/srv', 'x', d)).resolves.toEqual({
+      ok: false,
+      error: 'Could not create /srv/x'
+    })
+  })
+
+  // mkdir is `mkdir -p`, so a nested name is a legitimate way to make a whole path at once;
+  // the deepest dir is what the picker then navigates into.
+  it('allows a nested name and reports the deepest path', async () => {
+    const d = deps()
+    await expect(createPickerFolder('/home/u', 'a/b', d)).resolves.toEqual({
+      ok: true,
+      path: '/home/u/a/b'
+    })
+    expect(d.mkdir).toHaveBeenCalledWith('/home/u/a/b')
   })
 })

--- a/src/renderer/bridge/dialog-picker.tsx
+++ b/src/renderer/bridge/dialog-picker.tsx
@@ -5,12 +5,21 @@
 // (Task 4) and let the user drill into directories, then either "Use this folder" (folder mode)
 // or click a file (file mode). The chosen ABSOLUTE path becomes a project cwd / opened file.
 //
-// `nextEntries` is the pure navigation core (unit-tested without the DOM). The modal, the
-// `openDirectoryPicker` promise wrapper, and `mountPickerRoot` wire it into `ws-bridge`.
+// `nextEntries` is the pure navigation core and `createPickerFolder` the pure create step (both
+// unit-tested without the DOM). The modal, the `openDirectoryPicker` promise wrapper, and
+// `mountPickerRoot` wire them into `ws-bridge` / `relay-api`.
+//
+// FOLDER CREATION (folder mode only): the browser has no native "New Folder" button, so
+// "Open folder…" in the Server Edition could only ever adopt a directory that already existed on
+// the server. The button here closes that. It writes through the SAME `fs.mkdir`/`fs.exists` the
+// Explorer's "New Folder…" uses (core/fs-ops.ts, wired on all three surfaces) and validates the
+// typed name with the SAME envelope, `newEntryPath` — no second copy of path validation lives
+// here, so `..`, absolute and empty names are refused exactly as they are in the Explorer.
 
 import { useCallback, useEffect, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { DirEntry } from '../../shared/types'
+import { newEntryPath } from '../lib/explorerCreate'
 
 export type PickerMode = 'folder' | 'file'
 
@@ -18,6 +27,37 @@ export type PickerMode = 'folder' | 'file'
 export type PickerRow = DirEntry & { path: string }
 
 type ListFn = (dirPath: string) => Promise<DirEntry[]>
+
+/**
+ * The write half of the picker's filesystem access. OPTIONAL at every call site: a caller with a
+ * read-only fs simply omits it and the "New folder" affordance is not rendered — a hidden button
+ * rather than one that can only fail.
+ */
+export interface PickerMkdirDeps {
+  mkdir: (dirPath: string) => Promise<boolean>
+  exists: (p: string) => Promise<boolean>
+}
+
+/** Outcome of the create step: the new absolute path, or a message to show inside the picker. */
+export type CreateFolderResult = { ok: true; path: string } | { ok: false; error: string }
+
+/**
+ * Pure create step: validate the typed name against `newEntryPath` (the Explorer's envelope —
+ * refuses empty / absolute / trailing-slash / `..` traversal), refuse an existing path, then
+ * `mkdir -p`. EVERY failure carries a message; nothing here is a silent no-op. Messages mirror the
+ * Explorer's word-for-word so the two create flows read as one feature.
+ */
+export async function createPickerFolder(
+  dir: string,
+  name: string,
+  deps: PickerMkdirDeps
+): Promise<CreateFolderResult> {
+  const dest = newEntryPath(dir, name)
+  if (!dest) return { ok: false, error: `Invalid name: “${name.trim()}”` }
+  if (await deps.exists(dest)) return { ok: false, error: `Already exists: ${dest}` }
+  if (!(await deps.mkdir(dest))) return { ok: false, error: `Could not create ${dest}` }
+  return { ok: true, path: dest }
+}
 
 /** Strip a trailing slash from a path (but keep the root `/` as-is). */
 function stripTrailingSlash(dir: string): string {
@@ -57,20 +97,46 @@ interface PickerProps {
   mode: PickerMode
   startDir: string
   list: ListFn
+  /** Absent ⇒ no "New folder" affordance (see `PickerMkdirDeps`). */
+  write?: PickerMkdirDeps
   onDone: (result: string | null) => void
 }
 
-function DirectoryPicker({ mode, startDir, list, onDone }: PickerProps): React.ReactElement {
+function DirectoryPicker({
+  mode,
+  startDir,
+  list,
+  write,
+  onDone
+}: PickerProps): React.ReactElement {
   const [dir, setDir] = useState(startDir)
   const [rows, setRows] = useState<PickerRow[]>([])
   const [parent, setParent] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  // Create-folder form: `creating` opens the inline name row, `createErr` is the readable
+  // refusal shown under it (permission denied, a name already taken, a rejected name).
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [createErr, setCreateErr] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  // Only folder mode can create: the file picker exists to open an existing file, and a folder
+  // button there would be an affordance for a thing nobody came to do.
+  const canCreate = mode === 'folder' && !!write
+
+  const closeCreate = useCallback(() => {
+    setCreating(false)
+    setNewName('')
+    setCreateErr(null)
+  }, [])
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
     setError(null)
+    // A navigation abandons the form: a refusal naming the OLD directory must not survive into
+    // the new one.
+    closeCreate()
     nextEntries(dir, mode, list)
       .then((view) => {
         if (cancelled) return
@@ -86,18 +152,44 @@ function DirectoryPicker({ mode, startDir, list, onDone }: PickerProps): React.R
     return () => {
       cancelled = true
     }
-  }, [dir, mode, list])
+  }, [dir, mode, list, closeCreate])
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        onDone(null)
-      }
+      if (e.key !== 'Escape') return
+      e.preventDefault()
+      // Escape backs out of the create form first; only a picker with no form open closes.
+      if (creating) closeCreate()
+      else onDone(null)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [onDone])
+  }, [onDone, creating, closeCreate])
+
+  /**
+   * Create the typed folder under the current dir and NAVIGATE INTO IT, so the list refreshes and
+   * "Use this folder" already points at what was just made (create → step in → Open). A refusal
+   * stays in the form with its message; the user's typed name is kept so it can be edited.
+   */
+  const submitCreate = useCallback(async () => {
+    if (!write || busy) return
+    setBusy(true)
+    setCreateErr(null)
+    try {
+      const res = await createPickerFolder(dir, newName, write)
+      if (!res.ok) {
+        setCreateErr(res.error)
+        return
+      }
+      setCreating(false)
+      setNewName('')
+      setDir(res.path)
+    } catch {
+      setCreateErr('Could not create the folder')
+    } finally {
+      setBusy(false)
+    }
+  }, [write, busy, dir, newName])
 
   const openRow = useCallback(
     (row: PickerRow) => {
@@ -127,7 +219,51 @@ function DirectoryPicker({ mode, startDir, list, onDone }: PickerProps): React.R
           <span className="dir-picker__path" title={dir}>
             {dir}
           </span>
+          {canCreate && !creating && (
+            <button
+              className="dir-picker__new"
+              onClick={() => {
+                setCreateErr(null)
+                setNewName('')
+                setCreating(true)
+              }}
+              title="Create a folder here"
+            >
+              ＋ New folder
+            </button>
+          )}
         </div>
+
+        {canCreate && creating && (
+          <div className="dir-picker__create">
+            <input
+              autoFocus
+              className="dir-picker__input"
+              value={newName}
+              placeholder="Folder name"
+              aria-label="New folder name"
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  void submitCreate()
+                }
+                // Escape is handled by the window listener above (it backs out of this form).
+              }}
+            />
+            <button
+              className="confirm__btn primary"
+              disabled={busy || !newName.trim()}
+              onClick={() => void submitCreate()}
+            >
+              Create
+            </button>
+            <button className="confirm__btn" onClick={closeCreate}>
+              Cancel
+            </button>
+          </div>
+        )}
+        {createErr && <div className="dir-picker__error">{createErr}</div>}
 
         <div className="dir-picker__list">
           {loading && <div className="dir-picker__empty">Loading…</div>}
@@ -182,11 +318,14 @@ export function mountPickerRoot(): void {
  * Open the in-app server-directory browser and resolve with the chosen ABSOLUTE path
  * (folder mode → the current dir; file mode → the clicked file) or `null` on cancel/close.
  * Never rejects — cancel resolves `null`, mirroring the native dialog's contract.
+ *
+ * `write` enables the "New folder" button in folder mode; omit it for a read-only picker.
  */
 export function openDirectoryPicker(opts: {
   mode: PickerMode
   startDir: string
   list: ListFn
+  write?: PickerMkdirDeps
 }): Promise<string | null> {
   if (!pickerRoot) mountPickerRoot()
   return new Promise<string | null>((resolve) => {
@@ -195,7 +334,13 @@ export function openDirectoryPicker(opts: {
       resolve(result)
     }
     pickerRoot?.render(
-      <DirectoryPicker mode={opts.mode} startDir={opts.startDir} list={opts.list} onDone={finish} />
+      <DirectoryPicker
+        mode={opts.mode}
+        startDir={opts.startDir}
+        list={opts.list}
+        write={opts.write}
+        onDone={finish}
+      />
     )
   })
 }

--- a/src/renderer/bridge/relay-api.ts
+++ b/src/renderer/bridge/relay-api.ts
@@ -131,8 +131,12 @@ export function buildRelayApi(connectionId: string, transport?: FrameTransport):
     dialog: (() => {
       mountPickerRoot()
       const startDir = '/' // navigable up/down from the host root; no cross-call memory in v1
+      // "New folder" writes through the HOST's `fs.mkdir`/`fs.exists` (same core handlers, reached
+      // over the relay), so the folder is created on the machine whose path the picker returns.
+      const write = { mkdir: files.fs.mkdir, exists: files.fs.exists }
       return {
-        selectFolder: () => openDirectoryPicker({ mode: 'folder', startDir, list: files.fs.list }),
+        selectFolder: () =>
+          openDirectoryPicker({ mode: 'folder', startDir, list: files.fs.list, write }),
         selectFile: () => openDirectoryPicker({ mode: 'file', startDir, list: files.fs.list })
       }
     })(),

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -1061,8 +1061,18 @@ export async function installWsBridge(): Promise<boolean> {
     dialog: (() => {
       mountPickerRoot()
       const startDir = '/' // navigable up/down from root; the picker remembers nothing across calls in v1
+      // `write` is what gives folder mode its "New folder" button — the native dialog has one and
+      // the browser has no dialog at all, so without it a server folder had to exist already
+      // before it could be opened as a project. Same `fs.mkdir`/`fs.exists` the Explorer writes
+      // through, and therefore the same reach as everything else this picker already lists.
+      // Lambdas, not `api.fs.mkdir` directly: this IIFE runs while `api` is still being built.
+      const write = {
+        mkdir: (p: string) => api.fs.mkdir(p),
+        exists: (p: string) => api.fs.exists(p)
+      }
       return {
-        selectFolder: () => openDirectoryPicker({ mode: 'folder', startDir, list: api.fs.list }),
+        selectFolder: () =>
+          openDirectoryPicker({ mode: 'folder', startDir, list: api.fs.list, write }),
         selectFile: () => openDirectoryPicker({ mode: 'file', startDir, list: api.fs.list })
       }
     })()

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5203,6 +5203,65 @@ body,
   font-family: monospace;
 }
 
+.dir-picker__new {
+  flex: none;
+  padding: 0 10px;
+  height: 28px;
+  background: var(--panel-header);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.dir-picker__new:hover {
+  background: rgba(var(--tint-rgb), 0.1);
+}
+
+.dir-picker__create {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dir-picker__input {
+  flex: 1;
+  min-width: 0;
+  height: 28px;
+  padding: 0 9px;
+  background: rgba(var(--tint-rgb), 0.06);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.dir-picker__input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* Match the inline Create/Cancel buttons to the name input's height. */
+.dir-picker__create .confirm__btn {
+  flex: none;
+  height: 28px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+
+.dir-picker__create .confirm__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.dir-picker__error {
+  font-size: 12px;
+  color: var(--danger);
+  word-break: break-all;
+}
+
 .dir-picker__list {
   height: 300px;
   overflow-y: auto;


### PR DESCRIPTION
The Server Edition replaces the native folder dialog with an in-app server-directory browser (`renderer/bridge/dialog-picker.tsx`, Phase 3a). The native dialog it stands in for has a **New Folder** button; the picker had none — so "Open folder…" in the browser could only ever adopt a directory that **already existed** on the server. A new project folder had to be created from a terminal first.

## What changed

Folder mode now carries a **＋ New folder** button with an inline name row.

- **It reuses the existing plumbing, both halves.** The write is the same `fs.mkdir` / `fs.exists` the Explorer's "New Folder…" uses (`core/fs-ops.ts`, already wired on desktop / server / SSH), and the name is validated with the same envelope — `newEntryPath` (`renderer/lib/explorerCreate.ts`). **No second path validator was written**: `..`, absolute and empty names are refused in exactly one place, so the picker can create only where it can navigate.
- **Create → step in → Open.** On success it navigates INTO the new folder, which refreshes the list and points "Use this folder" at it — one click from created to opened.
- **No silent no-ops.** Every refusal is readable inside the picker and names the path: `Already exists: …`, `Could not create …` (permission denied), `Invalid name: …` — the Explorer's wording, so the two create flows read as one feature. The form stays open with the typed name so it can be edited.
- **Escape backs out of the form first**, and only closes the picker when no form is open.
- The write deps are **optional** at the call site: a caller with a read-only fs renders no button rather than one that can only fail. File mode has none — nobody opens a file picker to make a folder.

CSS follows the picker's existing visual language (`.dir-picker__up` for the button, the list's border/radius tokens for the input, `--danger` for the error line).

## Surfaces

- **Desktop** — unaffected. It uses the native dialog, which has its own New Folder button.
- **Server Edition** — the fix. Reaches `dialog.selectFolder()`'s three consumers: "Open folder…", "Change project folder", and the clone-destination picker.
- **Relay tabs** — same picker, same button. `fs:mkdir` is not in `isHostOnlyChannel`, so it creates on the **host** whose path the picker returns — the machine every other `fs.*` in this picker already reads from. Verified statically, not on a device.
- **SSH projects** — untouched, and verified: folder selection there is a separate flow (`SshProjectDialog` over `sshProject.listDir` / `sshProject.mkdir`) that already had its own `＋ New folder`, including the navigate-into-it step this change mirrors. `ExplorerPanel`'s "Download to…" is the one other `selectFolder` consumer and is gated to `route === 'scp'` (desktop + SSH), so it never reaches the web picker.
- **Mobile** — N/A (no picker).

## Tests

- `dialog-picker.test.ts` — `createPickerFolder`: root join, trailing-slash normalization, the four refusal shapes (`..`, `../evil`, `a/../../evil`, absolute, empty, whitespace) asserted to touch the filesystem **not at all**, never-overwrite, a rejected `mkdir`, and a nested `mkdir -p` name.
- `dialog-picker.dom.test.tsx` (new, jsdom) — drives the real `openDirectoryPicker` promise: the create → step in → Open flow, both error states staying visible with the form open, Escape precedence, and the two no-button cases.
- `npm run typecheck` clean; `src/renderer/bridge/`, `explorerCreate` and `src/server/handlers/` suites green (96 tests).

Not device-verified in a real browser session — worth one pass on the Server Edition (create a folder, open it as a project) and one on a relay tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcL5p4wQb8ZPwZE5mwHxLt