### PR TITLE
fix(github): resolve gh executable path in runGitHubCliCommand

### DIFF
--- a/src/core/gh-path.test.ts
+++ b/src/core/gh-path.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ghPath, _resetGhPathForTest } from './gh-path'
+import * as execPath from './exec-path'
+
+describe('ghPath', () => {
+  beforeEach(() => {
+    _resetGhPathForTest()
+    vi.restoreAllMocks()
+  })
+
+  it('memoizes on hit so repeated calls do not re-probe', () => {
+    const spy = vi.spyOn(execPath, 'findExecutableSync').mockReturnValue('/usr/local/bin/gh')
+
+    expect(ghPath()).toBe('/usr/local/bin/gh')
+    expect(ghPath()).toBe('/usr/local/bin/gh')
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not memoize on miss so a newly installed gh is picked up', () => {
+    const spy = vi.spyOn(execPath, 'findExecutableSync')
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce('/opt/homebrew/bin/gh')
+
+    expect(ghPath()).toBeNull()
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    expect(ghPath()).toBe('/opt/homebrew/bin/gh')
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    // Now cached because it was a hit
+    expect(ghPath()).toBe('/opt/homebrew/bin/gh')
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('probes with common bin dirs fallbacks', () => {
+    const spy = vi.spyOn(execPath, 'findExecutableSync').mockReturnValue('/usr/bin/gh')
+
+    expect(ghPath()).toBe('/usr/bin/gh')
+    expect(spy).toHaveBeenCalledWith('gh', [
+      '/opt/homebrew/bin/gh',
+      '/usr/local/bin/gh',
+      '/usr/bin/gh'
+    ])
+  })
+})

--- a/src/core/gh-path.ts
+++ b/src/core/gh-path.ts
@@ -1,0 +1,34 @@
+import { findExecutableSync } from './exec-path'
+
+const COMMON_GH_BIN_DIRS = [
+  '/opt/homebrew/bin/gh',
+  '/usr/local/bin/gh',
+  '/usr/bin/gh'
+]
+
+/**
+ * Resolves the path to the `gh` executable.
+ *
+ * Windows resolves a bare command against PATHEXT (`gh.EXE`, typically under
+ * `C:\Program Files\GitHub CLI\`).
+ * On macOS, GUI apps don't inherit the shell PATH, so the shared resolver checks
+ * the login-shell PATH first, followed by well-known POSIX locations.
+ *
+ * MEMOIZED-ON-HIT rather than computed at import: a miss is re-probed so a gh
+ * installed while the app is running is picked up, and the async login-shell PATH
+ * probe that lands after module load is no longer raced.
+ */
+let cachedGh: string | null | undefined
+
+export function ghPath(): string | null {
+  if (cachedGh) return cachedGh
+  const found = findExecutableSync('gh', COMMON_GH_BIN_DIRS)
+  // Only a HIT is cached. Caching a miss here would freeze the answer for the process lifetime.
+  if (found) cachedGh = found
+  return found
+}
+
+/** Reset the cached path (for testing). */
+export function _resetGhPathForTest(): void {
+  cachedGh = undefined
+}

--- a/src/core/git-service.ts
+++ b/src/core/git-service.ts
@@ -11,7 +11,7 @@ import type { WorktreeListResult } from '../shared/worktree'
 import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
 import { resolveGitRemote, runRemoteGit } from './remote-ssh/remote-git'
 import { platform } from './platform'
-import { findExecutableSync } from './exec-path'
+import { ghPath } from './gh-path'
 import { gitEnv } from './git-env'
 import {
   isValidCloneUrl,
@@ -22,33 +22,6 @@ import {
 } from '../shared/clone-url'
 
 const run = promisify(execFile)
-
-/**
- * Absolute path to the GitHub CLI, or null when it isn't installed.
- *
- * Was a module-level const over three hardcoded POSIX paths, which never consulted PATH at all.
- * That answered null for EVERY Windows install — `gh` there is `gh.exe`, usually under
- * `C:\Program Files\GitHub CLI\` — so `ghAvailable` was permanently false and every GitHub
- * action reported "GitHub CLI (gh) not found." on a machine where gh was installed and authed.
- *
- * Now it goes through the shared resolver (login-shell PATH first, then the well-known locations),
- * and it is MEMOIZED-ON-HIT rather than computed at import: a miss is re-probed, so a gh installed
- * while the app is running is picked up, and the async login-shell PATH probe that lands after
- * module load is no longer raced.
- */
-let cachedGh: string | null | undefined
-function ghPath(): string | null {
-  if (cachedGh) return cachedGh
-  const found = findExecutableSync('gh', [
-    '/opt/homebrew/bin/gh',
-    '/usr/local/bin/gh',
-    '/usr/bin/gh'
-  ])
-  // Only a HIT is cached. Caching a miss here would freeze the answer for the process lifetime,
-  // which is what the old module-level const effectively did.
-  if (found) cachedGh = found
-  return found
-}
 
 // The environment every `git`/`gh` subprocess gets: the GUI-blind POSIX bin dirs prepended (macOS
 // credential helpers), and GIT_TERMINAL_PROMPT=0 so auth failures error out fast instead of hanging

--- a/src/core/github/credentials.test.ts
+++ b/src/core/github/credentials.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import * as ghPathModule from '../gh-path'
 import {
   CREDENTIAL_CACHE_MS,
   GitHubCredentialResolver,
+  runGitHubCliCommand,
   type CommandRunner,
   type GitHubSecretStore
 } from './credentials'
@@ -165,5 +167,24 @@ describe('GitHubCredentialResolver', () => {
     const { resolver, calls } = fixture({ gh: 'invalid', storedToken: null })
     await resolver.resolve('gh')
     expect(calls).toEqual(['auth status --hostname github.com'])
+  })
+})
+
+describe('runGitHubCliCommand', () => {
+  it('rejects unsupported commands without executing', async () => {
+    const result = await runGitHubCliCommand('not-gh', ['status'])
+    expect(result).toEqual({
+      ok: false,
+      stdout: '',
+      stderr: 'unsupported command'
+    })
+  })
+
+  it('queries ghPath when executing gh', async () => {
+    const spy = vi.spyOn(ghPathModule, 'ghPath').mockReturnValue('/mock/bin/gh')
+    const result = await runGitHubCliCommand('gh', ['status'])
+    expect(spy).toHaveBeenCalled()
+    expect(result.ok).toBe(false)
+    spy.mockRestore()
   })
 })

--- a/src/core/github/credentials.ts
+++ b/src/core/github/credentials.ts
@@ -7,6 +7,7 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { SecretStore } from '../secret-store'
 import { gitEnv } from '../git-env'
+import { ghPath } from '../gh-path'
 
 export type CommandResult = { ok: boolean; stdout: string; stderr: string }
 export type CommandRunner = (command: string, args: string[]) => Promise<CommandResult>
@@ -16,7 +17,8 @@ const execute = promisify(execFile)
 export const runGitHubCliCommand: CommandRunner = async (command, args) => {
   if (command !== 'gh') return { ok: false, stdout: '', stderr: 'unsupported command' }
   try {
-    const result = await execute(command, args, {
+    const gh = ghPath() ?? 'gh'
+    const result = await execute(gh, args, {
       timeout: 15_000,
       maxBuffer: 1024 * 1024,
       // Shared with git-service so the two can never disagree about what a git/gh child gets. It


### PR DESCRIPTION
Unifies `gh` executable resolution across `git-service.ts` and `github/credentials.ts` by extracting `ghPath()` into a standalone `src/core/gh-path.ts` module.

### Rationale

1. **Single unified resolver for both `gh` call sites**: `git-service.ts` resolved through `ghPath()` while `credentials.ts` invoked literal `'gh'`. Routing both through `ghPath()` prevents drift between git operations and credential checks.
2. **Coverage beyond `gitEnv()`'s fixed directories**: `ghPath()` delegates to `findExecutableSync`, which consults the cached login-shell `PATH` first. This allows resolving `gh` installed under `~/.local/bin`, `mise`, `asdf`, or `scoop`, which `gitEnv()`'s four hardcoded POSIX directories cannot reach.
3. **Clean architectural separation**: Extracting `ghPath()` into `src/core/gh-path.ts` avoids importing `git-service.ts` into `credentials.ts`, keeping the credential module decoupled from `GitService` and its IPC/spawn surface.

### Changes
- Extracted `ghPath()` and `_resetGhPathForTest()` into `src/core/gh-path.ts`.
- Replaced local `ghPath()` in `src/core/git-service.ts` with import from `./gh-path`.
- Updated `runGitHubCliCommand` in `src/core/github/credentials.ts` to execute `ghPath() ?? 'gh'`.
- Added unit tests in `src/core/gh-path.test.ts` and updated `src/core/github/credentials.test.ts`.
