### PR TITLE
Attach a node to a GitHub issue or pull request (#462 phase 3a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2402,6 +2402,30 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   connection drop replays its outstanding onChanged unsubscribes). Deliberate v1 gaps: column-level
   events are stored but no card feed shows them; canvas-born nodes get no card-created; no
   card-deleted type.
+  **Explicit node ↔ issue/PR links (issue #462 phase 3):** a node carries `CanvasNodeState.github`
+  (`GitHubLink[]` — kind + number + a title SNAPSHOT; the repository is the project's and is never
+  stored per link, the github.com URL is derived by `githubLinkUrl`). It is git-shared CONTENT, so
+  `sanitizeNodeGitHubLinks` (@shared/github-link) runs on EVERY crossing in BOTH directions
+  (`projectToFile`, `fileToProject`, `sanitizeLoadedClosedSessions`, `sanitizeInboundNode`) — the
+  same rule and the same reason as `sanitizeNodeTriggers`. **A link exists only because the user
+  made it**: nothing is inferred from output, transcripts or a branch name, and a bad guess is only
+  ever a suggestion the user can dismiss. Core serves two new reads that BOTH shells register
+  (`core/github/handlers.ts`): `lookup` resolves one number cache-first and falls back to
+  `client.getIssueOrPull` — a SIBLING of `getIssue`, whose pull-request refusal is load-bearing for
+  `moveIssue` and stays — reporting every refusal as a VALUE (`GitHubLookupResult`), because
+  Electron `invoke` and the ws-bridge's `RpcErr` both flatten a typed code and the picker must
+  render `not-approved` as a disabled row; and `search`, a METHOD rather than a `columnId` sentinel
+  on `query` (a sentinel would collide with a real column id, leak into `counts` keys and the relay
+  jail, and force every `query` caller to handle a third state), whose absent `kind` means BOTH
+  kinds — the opposite of `query`, where absent means issues so a pre-pull-request caller gets the
+  page it always got. `query` and `search` share the column-blind `candidates`. The renderer keeps
+  ONE write funnel (`setNodeGitHubLinks` in Canvas: node write + `markDirty` + the board-log
+  `github-attached` / `github-detached` event, which `boardLogDiff` cannot emit because it diffs
+  the KANBAN only), reached from every surface through the module bridge
+  `canvas/githubLinkActions.ts` — the same indirection `setWorktreeActionHandler` uses. Canvas
+  chips hold NO host subscription (the board's is ref-counted), so freshness is bounded by
+  `state/githubLinks.ts`'s 5-minute lookup TTL plus whatever the last board load seeded; its
+  per-project `gate` is what stops a dozen chips re-asking an unanswerable question.
   Per-column "+ New session" menus create agents/terminal/sticky nodes assigned to the column
   (assignment written UN-pruned — the fresh node isn't in the derived list yet). The column
   half-pill itself: (`components/kanban/ColumnPill.tsx`, `columnForNode` in lib/kanban; rendered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,12 @@ lane unaffected.
   see. Keep a remote temp's own leaf bounded: extending an already-valid maximum-length target leaf
   with a UUID suffix turns an atomic write into a guaranteed `ENAMETOOLONG` failure.
 
+- **A new `githubIssues:*` channel must land in the relay-host jail switch in the same commit.**
+  `githubIssuesProject` (`src/main/remote/relay-host.ts`) is what keeps a relay guest inside the one
+  shared project; a channel it does not name is dispatched for ANY project id the guest asks about.
+  Add the case beside the others and extend the `relay-host.test.ts` cross-project suite in the same
+  change — the handler must never be reached, not merely answer nothing.
+
 - **Never write to a child's stdin without an `'error'` listener on that stream.** A pipe write's
   failure is not a throw at the call site: when the child exits before draining stdin (a CLI handed
   a flag it doesn't know, an unreachable ssh host), Node re-emits the EPIPE as an async `'error'`

--- a/PLAN-462-phase3.md
+++ b/PLAN-462-phase3.md
@@ -1,0 +1,336 @@
+# Issue #462 phase 3: explicit GitHub attachment + canvas chip + worktree PR suggestion
+
+## Context
+
+Phases 1 (source registry, PR #513) and 2 (read-only PR cards, PR #584) are merged. Phase 3 is the
+first phase that creates a session ↔ PR/issue RELATIONSHIP. Maintainer rules (issue thread):
+
+- A relationship exists ONLY when the user made it explicitly (or nodeterm itself performed the
+  create/modify op, which is phase 4). Nothing is ever inferred from terminal output or transcripts.
+- Worktree frames: **suggest, never adopt.** A frame whose branch has an open PR offers
+  "PR #n open, attach?"; one click makes an ordinary explicit link. A bad guess costs a dismissed
+  prompt, not a wrong chip.
+- Canvas presence via the existing card ↔ node linkage, not a new node kind.
+- Polling with ETags, never webhooks. Each phase independently shippable + revertible.
+
+Decisions taken with the user (do not reopen):
+- Storage = **node data** `CanvasNodeState.github?: GitHubLink[]` (git-shared content in
+  `.nodeterm/project.json`, rides the relay canvas mirror free, works on group frames).
+- **Many** links per node. Chip shows first + `+n`.
+- Reverse indicator on GitHub cards and an agent-facing canvas-control `attach` verb: **out of
+  scope** (state in PR body; verb can land later on the same write funnel).
+- Mobile: N/A. `core/agent-status-mirror.ts` carries no node data; iOS board mirrors kanban
+  assignments only. FYI-mention @eneskirca in the PR.
+
+Ship as **two PRs** (via fork `Temikus/nodeterm`, per memory): 3a data + core lookup/search +
+picker + chips; 3b `pullsForBranch` + worktree suggestion. 3a is complete on its own (frames get
+manual attach via their menu).
+
+Phase-2 tail items still open on `main` (maintainer asked; user offered a separate PR): `readOnly`
+declared but unconsumed, `issue-limit` slice dilutes issues with PRs (`service.ts:775`). Not part of
+this plan; fix in their own PR if asked.
+
+## Existing facts the plan rests on
+
+- `pull.head` is declared (`shared/github-issues.ts:74`) and cache-validated (`core/github/cache.ts:44-51`)
+  but never populated; no `/pulls` call exists. PR #584 body: "phase 3 asks about one branch, which
+  `/pulls?head=owner:branch` answers in one request".
+- `client.getIssue` (`core/github/client.ts:247`) THROWS `invalid-request` on a PR. `moveIssue`
+  relies on that guard. Do not loosen; add a sibling.
+- `service.query` (`core/github/service.ts:299`) filters ONE cached snapshot by
+  `columnId === request.columnId`, so a picker cannot ask "all columns" today.
+- `sanitizeNodeTriggers` (`core/workspace-files.ts:45`) is the both-directions sanitizer precedent;
+  `sanitizeInboundNode` (`shared/node-exec.ts:103`) is the relay inbound hook.
+- Serializers enumerate keys explicitly: `nodeStatesToFlow` (`renderer/state/workspace.ts:1744`,
+  data literal ~:1788) and `flowToNodeStates` (:1828, ~:1862). Round-trip test precedent
+  `workspace.trigger.test.ts`.
+- `registerGitHubIntegration` (`core/github/integration.ts:69`) registers handlers for BOTH shells
+  (`src/main/index.ts:1563`, `src/server/index.ts:328`); ws-bridge `buildGitHubApi`
+  (`renderer/bridge/ws-bridge.ts:405`); relay jail switch `githubIssuesProject`
+  (`main/remote/relay-host.ts:199`, test at `relay-host.test.ts:411+`); relay guest forwards the whole
+  `githubIssues` namespace (`renderer/bridge/relay-api.ts:90`).
+- Chip/menu precedents: `span.node-account-chip` and `span.term-node__status--x` before
+  `.term-node__spacer` (`nodes/TerminalNode.tsx:4741-4920`); `HIDEABLE_MENU_ITEMS`
+  (`renderer/lib/ui-visibility.ts:22`); `selectionItems` (`canvas/Canvas.tsx:7131`), `groupItems`
+  (:7702), sidebar menu reuses `selectionItems` (:10713); `setWorktreeActionHandler` module bridge
+  (`nodes/GroupNode.tsx:18-22`); searchable menu idiom `components/BranchSelect.tsx` /
+  `settings/SpeechLanguageSelect.tsx` (`.tab-backdrop` + `.tab-menu` + pinned filter, `useMenuFlip`).
+- Kanban: `toKanbanSession` (`canvas/toKanbanSession.ts`), `KanbanSession` (`kanban/KanbanView.tsx:37`),
+  `SessionCard.tsx` `.kanban-card__metarow`, `CardModal.tsx` `.kanban-modal__column` (:257),
+  `CardMetaBar.tsx` `.kanban-meta__group` sections, `GitHubIssueSummaryModal` (kind-aware,
+  `readOnly`, footer Open on GitHub), `pullCardState` (`lib/githubPull.ts`).
+- Board log: `BoardLogEvent.type` union (`shared/types.ts:556`, payload only `from/to/title`);
+  `boardLogDiff.ts` diffs KANBAN only, so node-data changes emit at the write site (precedent:
+  `createNodeInColumn`'s `card-created`); `eventBody` (`kanban/BoardLogPanel.tsx:19`) degrades unknown
+  types.
+- `docs/github-issues-kanban.md` is stale after phase 2 (":47 Pull requests are excluded.",
+  ":53 All, GitHub, or Sessions").
+
+---
+
+## PR 3a: attach a node to a GitHub issue / PR
+
+### 1. Data model + sanitizer
+
+`src/shared/github-issues.ts`:
+```ts
+export type GitHubLinkKind = 'issue' | 'pull'
+export interface GitHubLink { kind: GitHubLinkKind; number: number; title?: string }  // title = display snapshot only
+export const GITHUB_LINK_TITLE_MAX = 200
+export const GITHUB_LINKS_PER_NODE_MAX = 20
+```
+`src/shared/types.ts` `CanvasNodeState`: `github?: GitHubLink[]` after `worktree?` (:394). Repository
+is implicit (`kanban.github.repository`); `htmlUrl` is DERIVED, never stored.
+
+New `src/shared/github-link.ts` (pure):
+- `sanitizeGitHubLinks(value: unknown): GitHubLink[] | undefined`: non-array ⇒ undefined; entry must
+  be a plain object; `kind` ∈ set else dropped; `number` safe int > 0 else dropped; `title` kept only
+  if string, trimmed, non-empty, ≤ 200 (else title dropped, link kept); dedupe by `kind#number`
+  first-wins; cap 20; rebuild objects with only the three keys; empty ⇒ undefined.
+- `sanitizeNodeGitHubLinks(nodes)`: mirror of `sanitizeNodeTriggers`, no kind gate.
+- `githubLinkUrl(repository, link)`: `https://github.com/<repo>/<issues|pull>/<n>`; `''` when repo falsy.
+
+Call sites: `projectToFile` and `fileToProject` (`core/workspace-files.ts:257/:370`, wrap the
+existing trigger sanitizer), `sanitizeInboundNode` (`shared/node-exec.ts:103`).
+
+Serializers `renderer/state/workspace.ts`: `NodeData.github?`, `nodeStatesToFlow` data literal
+`github: n.github`, `flowToNodeStates` `github: n.data.github`.
+
+### 2. Core API: `lookup` + `search` (one definition in `src/core`, both shells)
+
+`src/shared/github-issues.ts`:
+```ts
+export interface GitHubLookupRequest { projectId: string; number: number }
+export type GitHubLookupResult =
+  | { ok: true; item: GitHubIssueCardView; source: 'cache' | 'api' }
+  | { ok: false; reason: 'not-found' | 'not-approved' | 'not-authenticated' | 'configuration-changed' | 'invalid-request' | 'failed'; message?: string }
+export interface GitHubSearchRequest { projectId: string; search: string; kind?: 'issue' | 'pull'; limit: number }
+export interface GitHubSearchResult { items: GitHubIssueCardView[]; partial: boolean }
+```
+`GitHubIssuesApi` gains `lookup(req)`, `search(req)`. Errors as VALUES for `lookup` (Electron
+`invoke` and `RpcErr` both lose the typed code; UI must render `not-approved` as a disabled row).
+`search` keeps `query`'s throw semantics (never hits the network).
+
+`core/github/client.ts`: add `getIssueOrPull(repository, number): Promise<GitHubIssue>` to the class
+and to `GitHubIssuesClientLike` (`service.ts:39`). Same URL as `getIssue`, same decode, but PR items
+return with `pull` set via `pullFrom`. 404 ⇒ `GitHubClientError('not-found')` (check what `request()`
+does with 404 today and map).
+
+`core/github/service.ts`:
+- Refactor `query`: extract snapshot → mapped → text/label filter into
+  `private candidates(context, state, {kind?, search?, labelFilter?})` WITHOUT the columnId gate.
+  `query` applies columnId + sort + paging + avatars as before. Existing service tests must pass
+  unchanged (byte-identical output).
+- `search(req)`: validate `limit` 1..50, `search.length ≤ 200` (`invalid-query`); `kind` absent ⇒
+  BOTH kinds (differs from `query`; JSDoc says why); exact-number match (`/^#?(\d+)$/`) first, then
+  `updatedAt desc, number desc`; no avatars; `partial = !state.snapshot && !!state.partialIssues`.
+  **New method, not a `columnId` sentinel**: a sentinel would collide with a real column id, leak into
+  `counts` keys and the relay jail, and force every `query` caller to handle a third state.
+- `lookup(req)`: `positiveInteger` else `invalid-request`; `cacheContext` + `cachedState` with
+  `GitHubHostError` mapped to `reason`; snapshot hit by number ⇒ `{ok:true, source:'cache', item:
+  {...issue, ...mapping(issue, config)}}`; else `contextForProject` (auth) + `coordinator.runRead` +
+  `getIssueOrPull`, epoch/generation checked like `moveIssue` (:385). Never writes into the snapshot
+  (poll owns watermark + eviction). 60 s negative memo per `(repositoryKey, number)`.
+
+Wiring, same order every time: `shared/ipc.ts` (`githubIssuesLookup: 'githubIssues:lookup'`,
+`githubIssuesSearch: 'githubIssues:search'`) → `core/github/handlers.ts` (interface + `platform.handle`,
+object-arg style) → `preload/index.ts` → `renderer/bridge/ws-bridge.ts buildGitHubApi` →
+`main/remote/relay-host.ts githubIssuesProject` object-arg case group (**same commit as the channel**,
+else a guest reaches a non-shared project) → `relay-host.test.ts:411` suite. `relay-api.ts` needs
+nothing; `stubs.ts` lists the namespace as real, confirm nothing enumerates keys by hand.
+
+### 3. Renderer helpers + store
+
+`renderer/lib/githubLinks.ts` (pure): `linkKey`, `hasLink`, `addLink` (dedupe, cap, same ref on
+no-op), `removeLink` (undefined when empty), `linkChipLabel` (`#123` / `#123 +2`), `linkTooltip`,
+`linkState(link, card?)` → `open|closed|draft|merged|unknown` (pulls via `pullCardState`),
+`parseLinkInput(text, repository)` (`#123`, `123`, `https://github.com/<repo>/issues|pull/123`;
+other repo ⇒ null; `#0` ⇒ null), `linkToBoardTitle`.
+
+`renderer/state/githubLinks.ts` (new zustand store; separate from `githubIssues.ts` whose per-project
+record is replaced wholesale on `connect`):
+- `cards[projectId][linkKey] = {card, at}`, `pending`, `missing` (60 s negative cache),
+  `gate[projectId]` (`not-approved`/`not-authenticated` stops a dozen chips re-asking; retry 60 s).
+- `ensureCard(api, projectId, link)`: no-op if cached < 5 min / pending / negative-cached / gated.
+- `seedFromPages(projectId, pages)`: called from `githubIssues.reload` after `pageColumns` (free warm-up).
+- `invalidate(projectId, numbers?)`: from `githubIssues.connect`'s `onChanged` handler.
+- Canvas chips have no host subscription (board's is ref-counted); freshness = last lookup ≤ 5 min or
+  last board open. Acceptable for a status dot; document.
+
+### 4. UI
+
+**Write funnel** (Canvas): `setNodeGitHubLinks(nodeId, next, event?)` = `setNodes` map + `markDirty()`
++ `useBoardLog.getState().append(api, projectId, {kind:'event', nodeId, event})`. Exposed to nodes
+via a module-level bridge `renderer/canvas/githubLinkActions.ts` (`setGitHubLinkHandler`,
+`attachGitHubLink`, `detachGitHubLink`, `openGitHubLinkPicker`, `openGitHubLinkDetails`), registered
+in the same effect as `setWorktreeActionHandler`. Canvas-level state renders the picker and a
+read-only `GitHubIssueSummaryModal` (kind-aware; `readOnly`, moves stay a board affair).
+`repository = parseGitHubRepository(kanban?.github?.repository)`; `githubConfigured = !!repository`.
+
+**`components/github/GitHubLinkPicker.tsx`**: searchable `.tab-menu` idiom. Props `{projectId,
+repository, existing, initialQuery?, kindFilter?, preset?: GitHubBranchPull[], anchor, onPick, onClose}`.
+Debounced 150 ms: `parseLinkInput` hit ⇒ `lookup`; else `search({search, kind, limit: 20})`; empty ⇒
+20 most recent, both kinds. Row: state dot, `#n`, title, PR badge; already-attached rows disabled.
+States: not-approved / not-authenticated ⇒ one disabled row with reason; `partial` footer;
+`not-found` row. Enter picks first, Esc closes. `useSession()` for `api` (relay/server aware).
+
+**`components/github/GitHubLinkChip.tsx`** `{nodeId, links, variant: 'node'|'card'|'modal'|'group'}`:
+`span.github-link-chip.nodrag` + `i.github-link-chip__dot--{state}` (first link) + `linkChipLabel`;
+`title` tooltip; `useEffect` ⇒ `ensureCard` each link; nothing when empty or unconfigured. Click /
+right-click (stopPropagation) ⇒ `ContextMenu`: per link `Open #n details` / `Open #n on GitHub`
+(`api.shell.openExternal(githubLinkUrl(...))`) / `Detach #n` (flat ≤ 3 links, submenu per link
+beyond), then `Attach another…`. Mount points: `TerminalNode` after the SSH chip, before
+`.term-node__spacer`; `StickyNode` and `BrowserNode` header rows (cheap, same one-liner). CSS beside
+`.node-account-chip`; `.term-node--collapsed .github-link-chip { max-width }` + ellipsis. Chip is
+inside the node root, so the `SharedGlyphLayer` sibling-rect gap does not apply.
+
+**Menus**: `ui-visibility.ts` `HIDEABLE_MENU_ITEMS` += `github-attach`. `selectionItems`: single
+node of kind terminal/sticky/browser AND `githubConfigured` AND not hidden ⇒ `Attach GitHub issue /
+PR…` (opens picker); existing links ⇒ `Detach` submenu. Hidden entirely (not disabled) when
+unconfigured. Sidebar menu inherits. `groupItems`: same attach row after "Bind to worktree…";
+`GroupNode` renders `GitHubLinkChip variant="group"` in its label bar.
+
+**Kanban** (same nodes, so both views agree for free): `KanbanSession.github?` via
+`toKanbanSession` for all three kinds; `KanbanViewProps` += `onChangeNodeLinks(nodeId, next, event?)`
++ `githubRepository?`; `SessionCard` chip first in `.kanban-card__metarow` and card right-click
+"Attach…"; `CardModal` chip after `.kanban-modal__column`; `CardMetaBar` fifth group "GitHub" (only
+when repository set): one row per link with `×` detach, `Attach…` button opening the SAME picker.
+
+**Board log**: `BoardLogEvent.type` += `'github-attached' | 'github-detached'` (`title` = `#n Title`,
+`to` = kind); `eventBody` renders "attached PR #n Title" / "detached …". `boardLogDiff.ts` untouched.
+
+### 5. Docs (same PR, house rule)
+- `docs/github-issues-kanban.md`: fix phase-2 staleness (:47, :53) and add "Linking sessions to
+  issues and pull requests" (explicit-only rule, chip, kanban group, no reverse indicator yet).
+- `CLAUDE.md` Kanban bullet: `CanvasNodeState.github`, sanitize-both-ways rule, why `search` is a
+  method not a sentinel, `getIssue` PR guard kept + `getIssueOrPull` opt-in.
+- `CONTRIBUTING.md` house rules: a new `githubIssues:*` channel must land in the relay-host jail
+  switch in the same commit.
+
+### 6. Tests (3a)
+| File | Pins |
+|---|---|
+| `src/shared/github-link.test.ts` | every sanitizer rule; `githubLinkUrl` both kinds |
+| `src/core/workspace-files.github-links.test.ts` | round-trip both directions; hostile file normalized on read AND write |
+| `src/renderer/state/workspace.github-links.test.ts` | flow serializers round-trip on terminal/sticky/browser/group |
+| `src/shared/node-exec.test.ts` (extend) | `sanitizeInboundNode` caps `github` |
+| `src/core/github/client.test.ts` (extend) | `getIssueOrPull` returns PR with `pull`; `getIssue` still rejects it; 404 ⇒ `not-found` |
+| `src/core/github/service.test.ts` (extend) | `lookup` cache-first (no client call), API fallback, typed errors not throws; `search` ignores columns, both kinds default, exact-number first, limit bounds; `query` byte-identical after refactor |
+| `src/core/github/handlers.test.ts` (extend) | new channels dispatch |
+| `src/main/remote/relay-host.test.ts` (extend) | `lookup`/`search` on `proj-2` ⇒ forbidden, handler never reached |
+| `src/renderer/lib/githubLinks.test.ts` | add/remove/label/parse/linkState |
+| `src/renderer/state/githubLinks.test.ts` | coalescing, negative cache, gate, invalidate |
+| `src/renderer/components/github/GitHubLinkChip.test.tsx` (jsdom) | label `#12 +1`, dot from cached card, menu items, Detach calls handler, nothing without repository |
+| `src/renderer/components/github/GitHubLinkPicker.test.tsx` (jsdom) | `#12` ⇒ lookup not search; foreign URL ⇒ no call; not-approved disabled row; attached row disabled; Enter picks first |
+| `src/renderer/components/kanban/CardMetaBar.test.tsx` (new) | group hidden without repo; lists links; × emits `github-detached` |
+| `BoardLogPanel` test (extend) | `eventBody` both types |
+| `src/renderer/canvas/toKanbanSession.test.ts` (extend) | `github` copied for all kinds |
+
+### 7. Commit order (3a)
+1. shared types + `github-link.ts` + tests
+2. workspace-files both directions + `sanitizeInboundNode` + tests
+3. workspace serializers + round-trip test
+4. core `getIssueOrPull`, `candidates` refactor, `lookup`, `search`; ipc/handlers/preload/ws-bridge/relay jail + tests
+5. `lib/githubLinks.ts`, `state/githubLinks.ts`, seed from `githubIssues.reload`
+6. picker, chip, Canvas funnel + modals, menus, kanban surfaces, board-log types + `eventBody`, CSS
+7. docs
+
+---
+
+## PR 3b: worktree frames suggest their open PR (suggest, never adopt)
+
+### 1. Core `pullsForBranch`
+
+`shared/github-issues.ts`:
+```ts
+export interface GitHubBranchPull { number: number; title: string; draft: boolean; head: string; updatedAt: string; htmlUrl: string; state: 'open' }
+export type GitHubPullsForBranchResult =
+  | { ok: true; pulls: GitHubBranchPull[]; fetchedAt: number; fromCache: boolean }
+  | { ok: false; reason: 'not-approved' | 'not-authenticated' | 'configuration-changed' | 'invalid-request' | 'rate-limited' | 'failed'; message?: string }
+```
+`GitHubIssuesApi.pullsForBranch({projectId, branch, force?})`.
+
+`client.ts` `listPullsByHead(repository, head, {perPage})`: `safeRepository`; `head` matches
+`/^[^\s:]+:[^\s]+$/`, ≤ 300; `GET /repos/{repo}/pulls?head=<owner>:<branch>&state=open&per_page=10`.
+**No `since`, no etag** (endpoint ignores `since`; TTL cache replaces the etag). Decode number, title
+(≤ 1000), draft, `head.ref`, `updated_at`, `html_url` (https github.com only); > 100 items ⇒
+`malformed-response`.
+
+`service.ts` `pullsForBranch`: validate branch (non-empty, ≤ 255, no whitespace/`:`); approval +
+auth gates mapped to `reason` as in `lookup`; owner = `context.repository.split('/')[0]` (host-resolved,
+never renderer-supplied); in-memory cache keyed `${repository}\0${branch}`, `BRANCH_PULLS_TTL_MS =
+5 min`, max 200 entries LRU, in-flight coalescing, `force` skips TTL but still coalesces; fetch via
+`coordinator.runRead`; return the lean `GitHubBranchPull[]` (the live card comes through `lookup`
+once attached). `pull.head` is populated ONLY where `lookup` enriches a snapshot item from this
+cache (one place; poll snapshot stays unpolluted). Invalidate on `clearCache` and in
+`onCredentialBoundaryChange` (`integration.ts:54`).
+
+Wiring: same chain + relay jail + tests as 3a.
+
+### 2. Renderer
+`state/githubLinks.ts` += `pullSuggestions[`${projectId}:${groupId}`] = {branch, pulls, at,
+error?}`, `fetchPullsForBranch(api, projectId, groupId, branch, {force?})`, `dismissed: Set<string>`
+(`${projectId}:${groupId}:${number}`) hydrated from localStorage `nodeterm.prSuggestDismissed`
+(JSON array, cap 500). `lib/githubLinks.ts` += `suggestionFor(links, pulls, dismissed)` (open PRs
+minus already-linked `pull` numbers minus dismissed, `updatedAt desc`).
+
+### 3. GroupNode
+- Effect keyed `[wtPath, branch, githubConfigured]`: `wtPath` is already `undefined` on SSH projects
+  (`GroupNode.tsx:63`), so SSH frames fetch nothing. Fires when the frame is on screen + page visible
+  (reuse the existing visibility/IntersectionObserver gating in the status-poll effect, expose the
+  on-screen edge via a ref) on mount and on branch change (`status?.branch || wt.branch`). **Never a
+  timer.** Skipped when unconfigured or `gate` set.
+- Render `candidates.length ≥ 1` as `div.group-node__pr-suggest.nodrag`: label "PR #123 open" /
+  "PR #123 draft" (`> 1` ⇒ "N open PRs"), `button.group-node__wt-btn` **Attach** ⇒
+  `attachGitHubLink(id, {kind:'pull', number, title})` (ordinary explicit link + board-log event; for
+  N > 1 opens the picker with `preset: candidates`), `×` ⇒ `dismiss(...)`.
+- `ok:false` renders nothing on the frame; `not-approved` sets `gate`.
+- `groupItems` (worktree, non-SSH): `Check for pull request` ⇒ `fetchPullsForBranch(..., {force:true})`.
+- Two frames on one branch share the service cache; dismissal is per group id (intentional, note in docs).
+
+### 4. Tests (3b)
+| File | Pins |
+|---|---|
+| `client.test.ts` (extend) | URL `/repos/o/r/pulls?head=o%3Abranch&state=open&per_page=10`, no `since`, no `if-none-match`, head validation, malformed item |
+| `service.test.ts` (extend) | TTL with fake `now`; two concurrent ⇒ one client call; owner from host repo; `force` bypasses TTL; `clearCache` + credential change drop cache; `rate-limited` mapping; `lookup` enriches `head` |
+| `handlers.test.ts`, `relay-host.test.ts` (extend) | channel dispatch; jail |
+| `lib/githubLinks.test.ts` (extend) | `suggestionFor` |
+| `state/githubLinks.test.ts` (extend) | dismiss persists + survives fresh store |
+| `src/renderer/nodes/GroupNode.github.test.tsx` (jsdom) | fetch once on mount-visible, again on branch change, fake timers +10 min ⇒ still 1 call; suggestion row renders; **no** node write without a click; Attach ⇒ handler `{kind:'pull', number}`; dismissed hidden after remount; already-linked hidden; SSH ⇒ 0 fetches; unconfigured ⇒ 0 fetches |
+
+### 5. Docs
+`docs/github-issues-kanban.md` suggestion section (suggest-never-adopt, dismissal is machine-local,
+per-frame); CLAUDE.md Worktrees + Kanban bullets; PR body mentions the rate budget (≤ 1 request per
+visible frame per 5 min).
+
+---
+
+## Risks / open points
+- `query` → `candidates` refactor must keep order, `counts`, `partial` identical; run
+  `service.test.ts` before writing `search`.
+- Chip width in collapsed terminal nodes (header already holds title/session/account/SSH chips).
+  Verify visually on a narrow node.
+- Canvas chip freshness without a host subscription is bounded at 5 min; a later phase can
+  `acquireHostSubscription` while any chip is visible.
+- Relay guest attaching: node-data write rides the canvas mirror; confirm `useBoardLog.append` for
+  `kind:'event'` is relay-routed like comments.
+- Title snapshot in project.json goes stale after a GitHub rename; chip prefers the live card and
+  only falls back. No refresh-on-save.
+- `stubs.ts` github namespace: confirm nothing builds the API by hand-enumerated keys.
+
+## Verification
+1. `npm run typecheck` and `npm test` green (all new tests above; existing kanban/github tests
+   unchanged).
+2. Desktop, project with `kanban.github.repository` approved: right-click terminal node → Attach →
+   type `#<n>` and a title fragment → pick → chip `#n` with correct state dot; chip menu Open details
+   (modal, read-only) / Open on GitHub / Detach; board card + card modal show the same chip; CardMetaBar
+   group lists + detaches; board log shows attached/detached rows; `.nodeterm/project.json` carries
+   `github: [{kind, number, title}]`; hand-edit it to `kind:'commit'`, 500 entries, `number:-1` →
+   reload drops/normalizes, no crash.
+3. Unconfigured project: no Attach row anywhere, no chip.
+4. 3b: bind a worktree frame on a branch with an open PR → frame shows "PR #n open · Attach · ×";
+   nothing attaches until Attach is clicked; × hides it across restart; Attach makes the chip;
+   network tab shows one `/pulls?head=` request per branch per 5 min, none on a timer; SSH project
+   frame shows nothing.
+5. Server Edition (`npm run server:dev`): attach flow works in the browser; relay guest: `lookup` on a
+   non-shared project id is refused (unit test) and the shared project works.

--- a/docs/github-issues-kanban.md
+++ b/docs/github-issues-kanban.md
@@ -44,17 +44,29 @@ Each configured column has one exact issue label. Matching is case insensitive, 
 - Closing and reopening ask for confirmation first. Both notify everyone watching the issue and neither can be undone from the board. Moves that only rewrite labels apply immediately, and a card dropped back where it already sits writes nothing.
 - A move never rewrites the GitHub close reason. Re-closing an issue that is already closed leaves a `not planned` close as it is.
 - Unrelated labels are preserved.
-- Pull requests are excluded.
+- Pull requests appear as their own read-only lane. They carry no Move control and never drag: the board writes nothing to a pull request.
 
 Every card has a Move issue selector, so movement does not depend on drag and drop. Stale writes are not repeated. nodeterm refreshes the current issue and asks for a new action.
 
 ## Source filter and paging
 
-Use All, GitHub, or Sessions in the board header to choose which card sources are visible. The selection is temporary and does not change the project configuration.
+Use All, Issues, Pull requests, or Sessions in the board header to choose which card sources are visible. The selection is temporary and does not change the project configuration.
 
 The label filter groups session labels and GitHub labels separately. GitHub selections are sent to the host with a `github:` namespace, while session selections remain local to the board.
 
 Issues are loaded in pages of up to 50 per column. Use Show more issues at the end of a column for the next page.
+
+## Linking sessions to issues and pull requests
+
+A session, note, browser node, or group frame can be attached to one or more issues or pull requests. **A link only ever exists because you made it.** Nothing is inferred from terminal output, a transcript, or a branch name.
+
+Attach from the node's right-click menu, a board card's right-click menu, or the GitHub row of the card modal's metadata strip. Type `#123`, part of a title, or a github.com link for this project's repository; a link for another repository is refused, because a link's repository is always the project's.
+
+The node then wears a `#123` chip (with `+n` when it carries several) on the canvas, on its board card, and in the card modal. Its dot shows the item's state — open, closed, draft, merged — and clicking the chip opens the details, the item on GitHub, or a detach. Attaching and detaching are recorded in the board log.
+
+Links are stored on the node in `.nodeterm/project.json`, so they travel with the repository like the rest of the canvas, and are normalized as untrusted input on every read and write. There is no reverse indicator on the GitHub card yet: an issue does not know which sessions point at it.
+
+Canvas chips hold no host subscription. A chip's state is refreshed when it is first painted and then at most every 5 minutes, plus whenever the board is opened.
 
 ## Refresh and cache
 

--- a/src/core/github/client.test.ts
+++ b/src/core/github/client.test.ts
@@ -102,6 +102,33 @@ describe('GitHubIssuesClient', () => {
       .rejects.toMatchObject({ code: 'invalid-request' })
   })
 
+  it('getIssueOrPull admits a pull request, with its pull metadata decoded', async () => {
+    const client = new GitHubIssuesClient({
+      token: 'secret',
+      fetch: async () => response(issue(7, {
+        pull_request: { url: 'x', merged_at: null }, draft: true
+      }))
+    })
+    const item = await client.getIssueOrPull('nodeterm/nodeterm', 7)
+    expect(item.number).toBe(7)
+    expect(item.pull).toEqual({ draft: true, mergedAt: null })
+  })
+
+  it('getIssueOrPull reports a number that exists in neither space as not-found', async () => {
+    const client = new GitHubIssuesClient({
+      token: 'secret',
+      fetch: async () => response({ message: 'Not Found' }, { status: 404 })
+    })
+    await expect(client.getIssueOrPull('nodeterm/nodeterm', 9_999))
+      .rejects.toMatchObject({ code: 'not-found', status: 404 })
+  })
+
+  it('getIssueOrPull refuses a number that cannot be one', async () => {
+    const client = new GitHubIssuesClient({ token: 'secret', fetch: async () => response({}) })
+    await expect(client.getIssueOrPull('nodeterm/nodeterm', 0))
+      .rejects.toMatchObject({ code: 'invalid-request' })
+  })
+
   it('distinguishes permissions from primary and secondary rate limits', async () => {
     const forbidden = new GitHubIssuesClient({
       token: 'secret', fetch: async () => response({ message: 'forbidden' }, { status: 403 })

--- a/src/core/github/client.ts
+++ b/src/core/github/client.ts
@@ -19,7 +19,7 @@ const MAX_ERROR_METADATA_BYTES = 4 * 1024
 export class GitHubClientError extends Error {
   constructor(
     readonly code: 'invalid-request' | 'malformed-response' | 'response-too-large' |
-      'request-failed' | 'rate-limited' | 'insufficient-permission',
+      'request-failed' | 'rate-limited' | 'insufficient-permission' | 'not-found',
     readonly status?: number,
     readonly retryAt?: number
   ) {
@@ -249,6 +249,27 @@ export class GitHubIssuesClient {
     if (!positiveInteger(issueNumber, Number.MAX_SAFE_INTEGER)) throw new GitHubClientError('invalid-request')
     const value = await this.json(await this.request(`/repos/${repository}/issues/${issueNumber}`, { method: 'GET' }))
     if (object(value)?.pull_request !== undefined) throw new GitHubClientError('invalid-request')
+    const decoded = issueFrom(value)
+    if (!decoded) throw new GitHubClientError('malformed-response')
+    return decoded
+  }
+
+  /** The sibling of `getIssue` for a caller that WANTS either kind (a node's explicit link is to
+   *  whatever the user picked). `getIssue`'s pull-request refusal is deliberate and stays — the
+   *  write paths rely on it — so admitting one is opt-in, per call site. A number that exists in
+   *  neither space is `not-found`, which the caller renders rather than treating as a failure. */
+  async getIssueOrPull(repository: string, number: number): Promise<GitHubIssue> {
+    safeRepository(repository)
+    if (!positiveInteger(number, Number.MAX_SAFE_INTEGER)) throw new GitHubClientError('invalid-request')
+    let value: unknown
+    try {
+      value = await this.json(await this.request(`/repos/${repository}/issues/${number}`, { method: 'GET' }))
+    } catch (error) {
+      if (error instanceof GitHubClientError && error.code === 'request-failed' && error.status === 404) {
+        throw new GitHubClientError('not-found', 404)
+      }
+      throw error
+    }
     const decoded = issueFrom(value)
     if (!decoded) throw new GitHubClientError('malformed-response')
     return decoded

--- a/src/core/github/handlers.test.ts
+++ b/src/core/github/handlers.test.ts
@@ -11,6 +11,12 @@ describe('registerGitHubIssueHandlers', () => {
       subscribe: async (...args: unknown[]) => { calls.push(['subscribe', ...args]); return page },
       unsubscribe: (...args: unknown[]) => { calls.push(['unsubscribe', ...args]) },
       query: async (...args: unknown[]) => { calls.push(['query', ...args]); return page },
+      lookup: async (...args: unknown[]) => {
+        calls.push(['lookup', ...args]); return { ok: false as const, reason: 'not-found' as const }
+      },
+      search: async (...args: unknown[]) => {
+        calls.push(['search', ...args]); return { items: [], partial: false }
+      },
       refresh: async (...args: unknown[]) => { calls.push(['refresh', ...args]) },
       moveIssue: async (...args: unknown[]) => {
         calls.push(['move', ...args]); return { status: 'configuration-changed' as const }
@@ -26,10 +32,14 @@ describe('registerGitHubIssueHandlers', () => {
     await platform.handlers[IPC.githubIssuesSubscribe](7, { projectId: 'p1' })
     platform.senderListeners[IPC.githubIssuesUnsubscribe](7, 'p1')
     await platform.handlers[IPC.githubIssuesQuery]({ projectId: 'p1', columnId: null, pageSize: 50 })
+    await platform.handlers[IPC.githubIssuesLookup]({ projectId: 'p1', number: 12 })
+    await platform.handlers[IPC.githubIssuesSearch]({ projectId: 'p1', search: 'x', limit: 20 })
     expect(calls).toEqual([
       ['subscribe', 7, { projectId: 'p1' }],
       ['unsubscribe', 7, 'p1'],
-      ['query', { projectId: 'p1', columnId: null, pageSize: 50 }]
+      ['query', { projectId: 'p1', columnId: null, pageSize: 50 }],
+      ['lookup', { projectId: 'p1', number: 12 }],
+      ['search', { projectId: 'p1', search: 'x', limit: 20 }]
     ])
     expect(Object.keys(platform.handlers).some((channel) => channel.startsWith('githubControl:'))).toBe(false)
   })

--- a/src/core/github/handlers.ts
+++ b/src/core/github/handlers.ts
@@ -4,13 +4,19 @@ import type {
   CreateMappedLabelsResult,
   GitHubIssuePage,
   GitHubIssueQuery,
-  GitHubMutationResult
+  GitHubLookupRequest,
+  GitHubLookupResult,
+  GitHubMutationResult,
+  GitHubSearchRequest,
+  GitHubSearchResult
 } from '../../shared/github-issues'
 
 export interface GitHubIssueHandlerService {
   subscribe(uiId: number, request: { projectId: string }): Promise<GitHubIssuePage>
   unsubscribe(uiId: number, projectId: string): void
   query(request: GitHubIssueQuery): Promise<GitHubIssuePage>
+  lookup(request: GitHubLookupRequest): Promise<GitHubLookupResult>
+  search(request: GitHubSearchRequest): Promise<GitHubSearchResult>
   refresh(request: { projectId: string; full?: boolean }): Promise<void>
   moveIssue(request: {
     projectId: string
@@ -31,6 +37,8 @@ export function registerGitHubIssueHandlers(
   platform.onWithSender(IPC.githubIssuesUnsubscribe, (uiId, projectId: string) =>
     service.unsubscribe(uiId, projectId))
   platform.handle(IPC.githubIssuesQuery, (request: GitHubIssueQuery) => service.query(request))
+  platform.handle(IPC.githubIssuesLookup, (request: GitHubLookupRequest) => service.lookup(request))
+  platform.handle(IPC.githubIssuesSearch, (request: GitHubSearchRequest) => service.search(request))
   platform.handle(IPC.githubIssuesRefresh, (projectId: string, full?: boolean) =>
     service.refresh({ projectId, full }))
   platform.handle(IPC.githubIssuesMove, (request) => service.moveIssue(request))

--- a/src/core/github/host.test.ts
+++ b/src/core/github/host.test.ts
@@ -89,6 +89,7 @@ function fixture() {
   const client = {
     listIssues: vi.fn(),
     getIssue: vi.fn(),
+    getIssueOrPull: vi.fn(),
     updateIssue: vi.fn(),
     listRepositoryLabels: vi.fn(),
     createLabel: vi.fn()

--- a/src/core/github/service.test.ts
+++ b/src/core/github/service.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { GitHubIssueCache } from './cache'
+import { GitHubClientError } from './client'
 import {
   evictPullsToFit,
   FULL_REFRESH_MIN_INTERVAL_MS,
@@ -11,6 +12,7 @@ import {
   type GitHubIssueServiceContext,
   type GitHubIssuesClientLike
 } from './service'
+import { GitHubHostError } from './host'
 import { GitHubRequestCoordinator } from './request-coordinator'
 import type {
   GitHubIssue,
@@ -65,6 +67,15 @@ class FixtureClient implements GitHubIssuesClientLike {
 
   async getIssue(_repository: string, number: number) {
     return structuredClone(this.issues.get(number)!)
+  }
+
+  lookups: number[] = []
+
+  async getIssueOrPull(_repository: string, number: number) {
+    this.lookups.push(number)
+    const item = this.issues.get(number)
+    if (!item) throw new GitHubClientError('not-found', 404)
+    return structuredClone(item)
   }
 
   async updateIssue(
@@ -934,5 +945,113 @@ describe('GitHubIssueService', () => {
       expectedUpdatedAt: '2026-08-09T10:05Z'
     })).toEqual({ status: 'invalid-target' })
     expect(client.updates).toEqual([])
+  })
+})
+
+describe('GitHubIssueService lookup / search (node links)', () => {
+  const seeded = async (client: FixtureClient, over: Partial<GitHubIssueServiceContext> = {}) => {
+    const cache = new GitHubIssueCache(userDataDir)
+    await cache.bind('local-1', 'project-1', 'o/r', 'user-1')
+    await cache.saveComplete('user-1', 'o/r', {
+      issues: [...client.issues.values()],
+      etags: {},
+      lastSuccessfulRefreshAt: 1,
+      lastFullReconciliationAt: 1
+    })
+    return new GitHubIssueService({
+      cache,
+      coordinator: new GitHubRequestCoordinator(),
+      contextForProject: async () => context(client, over)
+    })
+  }
+
+  it('answers from the cached snapshot without calling the client', async () => {
+    const client = new FixtureClient([issue(4)])
+    const service = await seeded(client)
+    const result = await service.lookup({ projectId: 'project-1', number: 4 })
+    expect(result).toMatchObject({ ok: true, source: 'cache' })
+    expect(result.ok && result.item.number).toBe(4)
+    expect(result.ok && result.item.columnId).toBe(null)
+    expect(client.lookups).toEqual([])
+  })
+
+  it('falls back to the API for a number the snapshot does not carry', async () => {
+    const client = new FixtureClient([issue(4)])
+    const service = await seeded(client)
+    client.issues.set(9, issue(9, { pull: { draft: true, mergedAt: null } }))
+    const result = await service.lookup({ projectId: 'project-1', number: 9 })
+    expect(result).toMatchObject({ ok: true, source: 'api' })
+    expect(result.ok && result.item.pull).toEqual({ draft: true, mergedAt: null })
+    expect(client.lookups).toEqual([9])
+  })
+
+  it('never writes an API answer into the snapshot', async () => {
+    const client = new FixtureClient([issue(4)])
+    const service = await seeded(client)
+    client.issues.set(9, issue(9))
+    await service.lookup({ projectId: 'project-1', number: 9 })
+    const page = await service.query({ projectId: 'project-1', columnId: null, pageSize: 50 })
+    expect(page.items.map((item) => item.number)).toEqual([4])
+  })
+
+  it('reports a miss as a value, and remembers it for the negative window', async () => {
+    const client = new FixtureClient([issue(4)])
+    const service = await seeded(client)
+    expect(await service.lookup({ projectId: 'project-1', number: 77 }))
+      .toEqual({ ok: false, reason: 'not-found' })
+    await service.lookup({ projectId: 'project-1', number: 77 })
+    expect(client.lookups).toEqual([77])
+  })
+
+  it('reports a host refusal as a typed value rather than throwing', async () => {
+    const service = new GitHubIssueService({
+      cache: new GitHubIssueCache(userDataDir),
+      coordinator: new GitHubRequestCoordinator(),
+      contextForProject: async () => { throw new GitHubHostError('not-approved') }
+    })
+    expect(await service.lookup({ projectId: 'project-1', number: 4 }))
+      .toEqual({ ok: false, reason: 'not-approved' })
+    expect(await service.lookup({ projectId: 'project-1', number: 0 }))
+      .toEqual({ ok: false, reason: 'invalid-request' })
+  })
+
+  it('searches across every column and both kinds by default', async () => {
+    const client = new FixtureClient([
+      issue(1, { labels: [{ id: 1, name: 'status:todo', color: 'ffffff' }] }),
+      issue(2, { state: 'closed' }),
+      issue(3, { pull: { draft: false, mergedAt: null } })
+    ])
+    const service = await seeded(client)
+    const all = await service.search({ projectId: 'project-1', search: 'Issue', limit: 20 })
+    expect(all.items.map((item) => item.number).sort()).toEqual([1, 2, 3])
+    const pulls = await service.search({
+      projectId: 'project-1', search: 'Issue', limit: 20, kind: 'pull'
+    })
+    expect(pulls.items.map((item) => item.number)).toEqual([3])
+  })
+
+  it('puts an exact number match first', async () => {
+    const client = new FixtureClient([
+      issue(12, { updatedAt: '2026-08-01T10:00:00Z' }),
+      issue(120, { updatedAt: '2026-08-09T10:00:00Z', title: 'Contains 12 in the title' })
+    ])
+    const service = await seeded(client)
+    const byHash = await service.search({ projectId: 'project-1', search: '#12', limit: 20 })
+    expect(byHash.items.map((item) => item.number)).toEqual([12, 120])
+    const bare = await service.search({ projectId: 'project-1', search: '12', limit: 20 })
+    expect(bare.items[0].number).toBe(12)
+  })
+
+  it('bounds the limit and the query length', async () => {
+    const client = new FixtureClient([issue(1)])
+    const service = await seeded(client)
+    await expect(service.search({ projectId: 'project-1', search: '', limit: 0 }))
+      .rejects.toThrow('invalid-query')
+    await expect(service.search({ projectId: 'project-1', search: '', limit: 51 }))
+      .rejects.toThrow('invalid-query')
+    await expect(service.search({ projectId: 'project-1', search: 'x'.repeat(201), limit: 20 }))
+      .rejects.toThrow('invalid-query')
+    expect((await service.search({ projectId: 'project-1', search: '', limit: 1 })).items)
+      .toHaveLength(1)
   })
 })

--- a/src/core/github/service.ts
+++ b/src/core/github/service.ts
@@ -4,7 +4,11 @@ import type {
   GitHubIssueCardView,
   GitHubIssuePage,
   GitHubIssueQuery,
+  GitHubLookupRequest,
+  GitHubLookupResult,
   GitHubMutationResult,
+  GitHubSearchRequest,
+  GitHubSearchResult,
   GitHubRepositoryLabel,
   IssuePageResult,
   LabelPageResult,
@@ -13,6 +17,8 @@ import type {
   UpdateIssueInput
 } from '../../shared/github-issues'
 import type { GitHubAvatarFetcher } from './avatar-fetcher'
+import { GitHubClientError } from './client'
+import { GitHubHostError } from './host'
 import {
   GitHubCacheError,
   type GitHubCompleteSnapshot,
@@ -24,6 +30,12 @@ const MAX_ISSUES = 10_000
 const MAX_CACHE_BYTES = 64 * 1024 * 1024
 const FULL_REFRESH_AGE = 24 * 60 * 60_000
 const POLL_MS = 60_000
+
+/** How long a `lookup` remembers that a number resolves to nothing, and how many such memories it
+ *  keeps before dropping the lot. Short, because an issue can be created at that number a second
+ *  later and the chip must then find it. */
+const LOOKUP_MISS_TTL_MS = 60_000
+const LOOKUP_MISS_MAX = 500
 
 /** Floor between two caller-driven refreshes of one project, and the longer floor for a FULL
  *  reconciliation. `refresh` is reachable from the renderer AND — for a shared project — from a
@@ -38,6 +50,7 @@ export const FULL_REFRESH_MIN_INTERVAL_MS = 120_000
 export interface GitHubIssuesClientLike {
   listIssues(repository: string, options: ListIssueOptions): Promise<IssuePageResult>
   getIssue(repository: string, issueNumber: number): Promise<GitHubIssue>
+  getIssueOrPull(repository: string, number: number): Promise<GitHubIssue>
   updateIssue(repository: string, issueNumber: number, input: UpdateIssueInput): Promise<GitHubIssue>
   listRepositoryLabels(
     repository: string,
@@ -158,6 +171,18 @@ export function evictPullsToFit(
   return { items: [...issues, ...pulls.slice(0, low)], pullsTruncated: true }
 }
 
+/** A host-side refusal, as the value `lookup` reports. Only the three the UI can act on are
+ *  named; everything else (a bad repository, a project that vanished) is a plain failure. */
+function hostReason(error: GitHubHostError): 'not-approved' | 'not-authenticated' | 'configuration-changed' | 'failed' {
+  switch (error.code) {
+    case 'not-approved': return 'not-approved'
+    case 'not-authenticated':
+    case 'invalid-token': return 'not-authenticated'
+    case 'configuration-changed': return 'configuration-changed'
+    default: return 'failed'
+  }
+}
+
 function mutationChain<T>(
   chains: Map<string, Promise<void>>,
   key: string,
@@ -182,6 +207,7 @@ export class GitHubIssueService {
   private readonly repositoryControls = new Map<string, RepositoryControl>()
   private readonly statePreparations = new Map<string, Set<Promise<RepositoryState>>>()
   private readonly refreshFloors = new Map<string, { any: number; full: number }>()
+  private readonly lookupMisses = new Map<string, number>()
   private operationSequence = 0
   private readonly now: () => number
   private readonly schedule: NonNullable<ServiceOptions['setInterval']>
@@ -306,16 +332,11 @@ export class GitHubIssueService {
     // what keeps the issue lane's items and counts exactly what they were before pull requests
     // were harvested. An absent kind means issues.
     const wantPull = request.kind === 'pull'
-    const source = (state.snapshot?.issues ?? state.partialIssues ?? [])
-      .filter((item) => !!item.pull === wantPull)
-    const mapped = source.map((issue): GitHubIssueCardView => ({ ...issue, ...mapping(issue, context.config) }))
-    const search = request.search?.trim().toLocaleLowerCase('en-US') ?? ''
-    const filters = new Set((request.labelFilter ?? []).map((item) =>
-      foldLabel(item.replace(/^github:/, ''))))
-    const filtered = mapped.filter((item) => !search || item.title.toLocaleLowerCase('en-US').includes(search) ||
-        String(item.number).includes(search))
-      .filter((item) => filters.size === 0 || item.labels.some((label) =>
-        filters.has(foldLabel(label.name))))
+    const filtered = this.candidates(context, state, {
+      kind: wantPull ? 'pull' : 'issue',
+      search: request.search,
+      labelFilter: request.labelFilter
+    })
     const visible = filtered.filter((item) => item.columnId === request.columnId)
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt) || b.number - a.number)
     const offset = request.cursor ? Number(request.cursor) : 0
@@ -350,6 +371,122 @@ export class GitHubIssueService {
         lastFullReconciliationAt: state.snapshot.lastFullReconciliationAt
       } : {})
     }
+  }
+
+  /** The cached items of one project, mapped to cards and narrowed by kind, free text and labels
+   *  — everything `query` does EXCEPT the column gate, because a picker asks about the whole
+   *  repository and a column is a board concept. */
+  private candidates(
+    context: GitHubIssueProjectContext,
+    state: RepositoryState,
+    options: { kind: 'issue' | 'pull' | 'both'; search?: string; labelFilter?: string[] }
+  ): GitHubIssueCardView[] {
+    const source = (state.snapshot?.issues ?? state.partialIssues ?? [])
+      .filter((item) => options.kind === 'both' || !!item.pull === (options.kind === 'pull'))
+    const mapped = source.map((issue): GitHubIssueCardView => ({ ...issue, ...mapping(issue, context.config) }))
+    const search = options.search?.trim().toLocaleLowerCase('en-US') ?? ''
+    const filters = new Set((options.labelFilter ?? []).map((item) =>
+      foldLabel(item.replace(/^github:/, ''))))
+    return mapped
+      .filter((item) => !search || item.title.toLocaleLowerCase('en-US').includes(search) ||
+        String(item.number).includes(search))
+      .filter((item) => filters.size === 0 || item.labels.some((label) =>
+        filters.has(foldLabel(label.name))))
+  }
+
+  /**
+   * Free-text / by-number search across every column, for the attach picker (issue #462).
+   *
+   * A separate method rather than a `columnId` sentinel on `query`: a sentinel would collide with
+   * a real column id, leak into the `counts` keys and the relay jail's shape, and force every
+   * existing `query` caller to handle a third state. It reads the SAME cached snapshot and never
+   * touches the network, so it keeps `query`'s throw-on-bad-input semantics.
+   *
+   * An absent `kind` means BOTH kinds — the opposite of `query`, where absent means issues so a
+   * caller predating pull requests gets the page it always got. A picker attaching a link has no
+   * such history and asking for one kind only would hide half the repository.
+   */
+  async search(request: GitHubSearchRequest): Promise<GitHubSearchResult> {
+    if (!Number.isSafeInteger(request.limit) || request.limit < 1 || request.limit > 50 ||
+        typeof request.search !== 'string' || request.search.length > 200 ||
+        (request.kind !== undefined && request.kind !== 'issue' && request.kind !== 'pull')) {
+      throw new Error('invalid-query')
+    }
+    const context = await this.cacheContext(request.projectId)
+    const { state } = await this.cachedState(context)
+    // `#12` is how a number is written everywhere in the GitHub UI, but no title or number
+    // contains the hash — matching it literally would answer an empty picker for the most
+    // obvious query there is.
+    const digits = request.search.trim().match(/^#?(\d+)$/)?.[1]
+    const items = this.candidates(context, state, {
+      kind: request.kind ?? 'both',
+      search: digits ?? request.search
+    })
+    // A search that IS a number wants that item, whatever its update stamp: it must not sit under
+    // twenty freshly-touched issues whose titles happen to contain those digits.
+    const exact = Number(digits ?? NaN)
+    items.sort((a, b) =>
+      Number(b.number === exact) - Number(a.number === exact) ||
+      b.updatedAt.localeCompare(a.updatedAt) || b.number - a.number)
+    return {
+      items: items.slice(0, request.limit),
+      partial: !state.snapshot && !!state.partialIssues
+    }
+  }
+
+  /**
+   * Resolve one issue OR pull request by number for an attached link.
+   *
+   * Errors are VALUES, not throws: both transports between here and the chip (Electron `invoke`
+   * and the ws-bridge's `RpcErr`) flatten a typed error into a message, and the UI has to render
+   * `not-approved` as a disabled row rather than as a failure. The snapshot is never written —
+   * the poll owns the watermark and the eviction order — so an API answer here is display-only.
+   */
+  async lookup(request: GitHubLookupRequest): Promise<GitHubLookupResult> {
+    if (!Number.isSafeInteger(request.number) || request.number <= 0) {
+      return { ok: false, reason: 'invalid-request' }
+    }
+    try {
+      const context = await this.cacheContext(request.projectId)
+      const { state } = await this.cachedState(context)
+      const cached = (state.snapshot?.issues ?? state.partialIssues ?? [])
+        .find((item) => item.number === request.number)
+      if (cached) {
+        return { ok: true, source: 'cache', item: { ...cached, ...mapping(cached, context.config) } }
+      }
+      const memoKey = `${context.repository}\0${request.number}`
+      const memo = this.lookupMisses.get(memoKey)
+      if (memo !== undefined && memo > this.now()) return { ok: false, reason: 'not-found' }
+      const captured = await this.options.contextForProject(request.projectId)
+      const capturedEpoch = epoch(captured)
+      const item = await this.readWithEpoch(captured, () =>
+        captured.client.getIssueOrPull(captured.repository, request.number))
+      if (capturedEpoch !== epoch(await this.options.contextForProject(request.projectId))) {
+        return { ok: false, reason: 'configuration-changed' }
+      }
+      return { ok: true, source: 'api', item: { ...item, ...mapping(item, captured.config) } }
+    } catch (error) {
+      if (error instanceof ConfigurationChangedError) return { ok: false, reason: 'configuration-changed' }
+      if (error instanceof GitHubHostError) return { ok: false, reason: hostReason(error) }
+      if (error instanceof GitHubClientError && error.code === 'not-found') {
+        // Remembered briefly so a canvas full of chips pointing at a deleted issue does not
+        // re-ask the API once per chip per mount.
+        this.rememberLookupMiss(request.projectId, request.number)
+        return { ok: false, reason: 'not-found' }
+      }
+      return {
+        ok: false,
+        reason: 'failed',
+        ...(error instanceof Error ? { message: error.message } : {})
+      }
+    }
+  }
+
+  private rememberLookupMiss(projectId: string, number: number): void {
+    void this.cacheContext(projectId).then((context) => {
+      if (this.lookupMisses.size > LOOKUP_MISS_MAX) this.lookupMisses.clear()
+      this.lookupMisses.set(`${context.repository}\0${number}`, this.now() + LOOKUP_MISS_TTL_MS)
+    }).catch(() => undefined)
   }
 
   moveIssue(request: {

--- a/src/core/workspace-files.github-links.test.ts
+++ b/src/core/workspace-files.github-links.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubLink } from '../shared/github-issues'
+import type { CanvasNodeState, Project } from '../shared/types'
+import { fileToProject, projectToFile } from './workspace-files'
+
+const links: GitHubLink[] = [
+  { kind: 'issue', number: 462, title: 'GitHub issues on the board' },
+  { kind: 'pull', number: 584 }
+]
+
+const node = (extra?: Partial<CanvasNodeState>): CanvasNodeState => ({
+  id: 'term-a-1',
+  kind: 'terminal',
+  position: { x: 10, y: 20 },
+  size: { width: 300, height: 170 },
+  title: 'Work',
+  color: '#888',
+  group: null,
+  github: links,
+  ...extra
+})
+
+const project = (nodes: CanvasNodeState[]): Project => ({
+  id: 'project-1',
+  name: 'Test',
+  color: '#fff',
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes
+})
+
+describe('github links at the project-file boundary', () => {
+  it('round-trips links through projectToFile → fileToProject', () => {
+    const file = projectToFile(project([node()]), 1, '2026-09-02T00:00:00Z')
+    expect(file.nodes[0].github).toEqual(links)
+    const back = fileToProject(file, { id: 'project-1' })
+    expect(back.nodes[0].github).toEqual(links)
+  })
+
+  it('round-trips links on a group frame', () => {
+    const frame = node({ id: 'group-a-1', kind: 'group', github: [{ kind: 'pull', number: 7 }] })
+    const back = fileToProject(projectToFile(project([frame]), 1, 'ts'), { id: 'project-1' })
+    expect(back.nodes[0].github).toEqual([{ kind: 'pull', number: 7 }])
+  })
+
+  it('normalizes a hostile file on READ — bad kinds, numbers, titles and overflow', () => {
+    const file = projectToFile(project([node()]), 1, 'ts')
+    const hostile = {
+      ...file,
+      nodes: [{
+        ...file.nodes[0],
+        github: [
+          { kind: 'commit', number: 1 },
+          { kind: 'issue', number: -1 },
+          { kind: 'issue', number: 5, title: 'x'.repeat(500), extra: 'smuggled' },
+          ...Array.from({ length: 40 }, (_, index) => ({ kind: 'pull', number: index + 100 }))
+        ]
+      }]
+    }
+    const back = fileToProject(hostile, { id: 'project-1' })
+    expect(back.nodes[0].github).toHaveLength(20)
+    expect(back.nodes[0].github?.[0]).toEqual({ kind: 'issue', number: 5 })
+    expect(JSON.stringify(back.nodes[0].github)).not.toContain('smuggled')
+  })
+
+  it('never writes a malformed array into the shared file', () => {
+    const bad = node({ github: [{ kind: 'commit', number: 1 }] as never })
+    const file = projectToFile(project([bad]), 1, 'ts')
+    expect(file.nodes[0].github).toBeUndefined()
+  })
+
+  it('leaves a link-less node byte-identical', () => {
+    const plain = node()
+    delete plain.github
+    const file = projectToFile(project([plain]), 1, 'ts')
+    expect('github' in file.nodes[0]).toBe(false)
+  })
+})

--- a/src/core/workspace-files.github-links.test.ts
+++ b/src/core/workspace-files.github-links.test.ts
@@ -53,7 +53,7 @@ describe('github links at the project-file boundary', () => {
           { kind: 'issue', number: -1 },
           { kind: 'issue', number: 5, title: 'x'.repeat(500), extra: 'smuggled' },
           ...Array.from({ length: 40 }, (_, index) => ({ kind: 'pull', number: index + 100 }))
-        ]
+        ] as never
       }]
     }
     const back = fileToProject(hostile, { id: 'project-1' })

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -14,6 +14,7 @@ import { projectCapabilityFields, readProjectCapabilities } from '../shared/proj
 import { loadedAgentBrowserPartition } from '../shared/browser-partition'
 import { sanitizeProjectIcon, type ProjectIcon } from '../shared/project-icon'
 import { sanitizeTriggerSpec } from '../shared/trigger'
+import { sanitizeNodeGitHubLinks } from '../shared/github-link'
 
 /**
  * Drop a browser node's persisted `partition` unless it is exactly the jar THIS project (its
@@ -266,9 +267,9 @@ export function projectToFile(
   // Trigger specs are additionally normalized on the way OUT too, so a malformed spec that
   // reached the live nodes some other way (a peer mutation, a hand edit) is never written into
   // the shared file as if it were ours.
-  const nodes = sanitizeNodeTriggers(
+  const nodes = sanitizeNodeGitHubLinks(sanitizeNodeTriggers(
     stripSharedNodeExec(p.cwd ? toPortableNodes(p.nodes, p.cwd) : p.nodes)
-  )
+  ))
   const icon = sanitizeProjectIcon(p.icon)
   return {
     version: 1,
@@ -356,7 +357,7 @@ export function sanitizeLoadedClosedSessions(x: unknown): ClosedSessionEntry[] |
   if (!validClosedSessions(x)) return undefined
   const capped = x.slice(0, CLOSED_SESSIONS_CAP)
   if (!capped.length) return undefined
-  return capped.map((e) => ({ ...e, node: sanitizeNodeTriggers([e.node])[0] }))
+  return capped.map((e) => ({ ...e, node: sanitizeNodeGitHubLinks(sanitizeNodeTriggers([e.node]))[0] }))
 }
 
 /**
@@ -413,12 +414,12 @@ export function fileToProject(
     // `partition` survives only when it is exactly the one THIS project (base.id, machine-local)
     // would mint — a foreign/cloned/unsafe one drops to un-owned default session. See
     // loadedAgentBrowserPartition; without it a cloned project.json forges another project's jar.
-    nodes: sanitizeNodeTriggers(
+    nodes: sanitizeNodeGitHubLinks(sanitizeNodeTriggers(
       sanitizeBrowserPartitions(
         applyLocalNodeExec(base.cwd ? resolveNodes(f.nodes, base.cwd) : f.nodes, base.localExec),
         base.id
       )
-    ),
+    )),
     ...(f.bridges ? { bridges: f.bridges } : {}),
     ...(f.ropes ? { ropes: f.ropes } : {}),
     ...(defaultAccountId ? { defaultAccountId } : {}),

--- a/src/main/remote/relay-host.test.ts
+++ b/src/main/remote/relay-host.test.ts
@@ -414,6 +414,8 @@ describe('relay host — GitHub issue RPCs are scoped to the shared project', ()
     const methods: Array<[string, unknown[]]> = [
       [IPC.githubIssuesSubscribe, [{ projectId: 'proj-2' }]],
       [IPC.githubIssuesQuery, [{ projectId: 'proj-2', columnId: null, pageSize: 50 }]],
+      [IPC.githubIssuesLookup, [{ projectId: 'proj-2', number: 7 }]],
+      [IPC.githubIssuesSearch, [{ projectId: 'proj-2', search: 'x', limit: 20 }]],
       [IPC.githubIssuesRefresh, ['proj-2', true]],
       [IPC.githubIssuesMove, [{ projectId: 'proj-2', issueNumber: 7, toColumnId: null,
         expectedUpdatedAt: '2026-08-09T00:00:00Z' }]],

--- a/src/main/remote/relay-host.ts
+++ b/src/main/remote/relay-host.ts
@@ -203,6 +203,8 @@ export function connectRelayHost(opts: ConnectRelayHostOptions): RelayHostSessio
     switch (method) {
       case IPC.githubIssuesSubscribe:
       case IPC.githubIssuesQuery:
+      case IPC.githubIssuesLookup:
+      case IPC.githubIssuesSearch:
       case IPC.githubIssuesMove:
         return {
           githubIssues: true,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -213,6 +213,8 @@ const api: NodeTerminalApi = {
       ipcRenderer.send(IPC.githubIssuesUnsubscribe, projectId)
     },
     query: (request) => ipcRenderer.invoke(IPC.githubIssuesQuery, request),
+    lookup: (request) => ipcRenderer.invoke(IPC.githubIssuesLookup, request),
+    search: (request) => ipcRenderer.invoke(IPC.githubIssuesSearch, request),
     refresh: (projectId, full) => ipcRenderer.invoke(IPC.githubIssuesRefresh, projectId, full),
     moveIssue: (request) => ipcRenderer.invoke(IPC.githubIssuesMove, request),
     createMissingLabels: (projectId) => ipcRenderer.invoke(IPC.githubIssuesCreateLabels, projectId),

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -415,6 +415,10 @@ export function buildGitHubApi(
     },
     query: (request) =>
       client.request(IPC.githubIssuesQuery, request) as ReturnType<GitHubIssuesApi['query']>,
+    lookup: (request) =>
+      client.request(IPC.githubIssuesLookup, request) as ReturnType<GitHubIssuesApi['lookup']>,
+    search: (request) =>
+      client.request(IPC.githubIssuesSearch, request) as ReturnType<GitHubIssuesApi['search']>,
     refresh: (projectId, full) =>
       client.request(IPC.githubIssuesRefresh, projectId, full) as Promise<void>,
     moveIssue: (request) =>

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -429,7 +429,9 @@ import { useSystemAccount } from '../state/systemAccount'
 import { useEntitlement } from '../state/entitlement'
 import type { SshServer } from '@shared/ssh'
 import { sshHostKey } from '@shared/ssh'
+import type { GitHubIssueCardView, GitHubLink } from '@shared/github-issues'
 import type {
+  BoardLogEvent,
   CanvasNodeState,
   NodeKind,
   Project,
@@ -446,6 +448,18 @@ import { canClearDirty, canCommitCanvas, canCreateOnCanvas } from '../state/pers
 import { isHidden } from '../lib/ui-visibility'
 import { boardLogEvents } from '../lib/boardLogDiff'
 import { useBoardLog } from '../state/boardLog'
+import { useGitHubLinks } from '../state/githubLinks'
+import { setGitHubLinkHandler } from './githubLinkActions'
+import { GitHubLinkPicker } from '../components/github/GitHubLinkPicker'
+import { GitHubIssueSummaryModal } from '../components/kanban/GitHubIssueSummaryModal'
+import {
+  addLink,
+  hasLink,
+  linkKey,
+  linkRepository,
+  linkToBoardTitle,
+  removeLink
+} from '../lib/githubLinks'
 import { isKanbanOpen, useViewMode, viewFor } from '../state/viewMode'
 import { useFocusNode, FOCUS_SURFACE_ID } from '../state/focusNode'
 import { focusTargetId } from '../lib/focusTarget'
@@ -2414,6 +2428,95 @@ export function Canvas() {
     },
     [markDirty, api, seedBoard]
   )
+
+  const githubRepository = useMemo(() => linkRepository(projectKanban), [projectKanban])
+  const [githubPicker, setGithubPicker] = useState<{
+    nodeId: string
+    anchor: { x: number; y: number }
+    preset?: GitHubIssueCardView[]
+    kindFilter?: 'issue' | 'pull'
+  } | null>(null)
+  const [githubDetails, setGithubDetails] = useState<GitHubLink | null>(null)
+  const [githubDetailsCard, setGithubDetailsCard] = useState<GitHubIssueCardView | null>(null)
+
+  /**
+   * The ONE write path for a node's GitHub links: the node write, the dirty mark and the
+   * board-log event happen together, whichever surface asked (canvas chip, node menu, group
+   * frame, board card, card metadata strip). `boardLogDiff` cannot see this — it diffs the
+   * KANBAN only — so the event is emitted here, exactly as `createNodeInColumn` emits its own.
+   */
+  const setNodeGitHubLinks = useCallback(
+    (nodeId: string, next: GitHubLink[] | undefined, event?: BoardLogEvent) => {
+      setNodes((ns) => ns.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, github: next } } : n)))
+      markDirty()
+      const projectId = useProjects.getState().activeProjectId
+      if (event && projectId) {
+        useBoardLog.getState().append(api, projectId, { kind: 'event', nodeId, event })
+      }
+    },
+    [setNodes, markDirty, api]
+  )
+
+  const attachNodeLink = useCallback(
+    (nodeId: string, link: GitHubLink) => {
+      const current = nodesRef.current.find((n) => n.id === nodeId)?.data.github as
+        | GitHubLink[]
+        | undefined
+      const next = addLink(current, link)
+      // `addLink` answers with the same array for a duplicate or a full node: no write, and no
+      // board-log line claiming something was attached.
+      if (next === current) return
+      setNodeGitHubLinks(nodeId, next, {
+        type: 'github-attached',
+        to: link.kind,
+        title: linkToBoardTitle(link)
+      })
+    },
+    [setNodeGitHubLinks]
+  )
+
+  const detachNodeLink = useCallback(
+    (nodeId: string, link: Pick<GitHubLink, 'kind' | 'number'>) => {
+      const current = nodesRef.current.find((n) => n.id === nodeId)?.data.github as
+        | GitHubLink[]
+        | undefined
+      if (!hasLink(current, link)) return
+      const removed = current?.find((entry) => entry.kind === link.kind && entry.number === link.number)
+      setNodeGitHubLinks(nodeId, removeLink(current, link), {
+        type: 'github-detached',
+        to: link.kind,
+        title: linkToBoardTitle(removed ?? { ...link })
+      })
+    },
+    [setNodeGitHubLinks]
+  )
+
+  // Bridge the link actions to the nodes React Flow instantiates itself, beside the worktree one.
+  useEffect(() => {
+    setGitHubLinkHandler({
+      attach: attachNodeLink,
+      detach: detachNodeLink,
+      openPicker: (nodeId, anchor) => setGithubPicker({ nodeId, anchor }),
+      openDetails: (link) => setGithubDetails(link)
+    })
+    return () => setGitHubLinkHandler(null)
+  }, [attachNodeLink, detachNodeLink])
+
+  // The details modal renders a CARD, and a chip only knows a link. Resolve it through the same
+  // cache the chips use so the modal never opens on a placeholder.
+  useEffect(() => {
+    if (!githubDetails) { setGithubDetailsCard(null); return }
+    const projectId = useProjects.getState().activeProjectId
+    if (!projectId) return
+    let live = true
+    const settle = (): void => {
+      const card = useGitHubLinks.getState().cards[projectId]?.[linkKey(githubDetails)]?.card
+      if (live && card) setGithubDetailsCard(card)
+    }
+    settle()
+    void useGitHubLinks.getState().ensureCard(api.githubIssues, projectId, githubDetails).then(settle)
+    return () => { live = false }
+  }, [githubDetails, api])
 
   // The node states that go on the wire: React Flow's managed nodes minus the ephemeral cards
   // (subagent / loop), which every client derives for itself from the agent:status stream.
@@ -7538,10 +7641,43 @@ export function Canvas() {
             ] as MenuItem[]
           })()
         : []),
+      // Attach a GitHub issue / PR (issue #462). Hidden ENTIRELY without a repository — an
+      // unconfigured project shows no GitHub surface at all, so there is nothing to explain — and
+      // single-target only: one link belongs to one session, and a multi-select attach would be a
+      // bulk claim nobody asked for.
+      ...(ids.length === 1 && githubRepository && !isHidden('github-attach', hidden) && (() => {
+        const n = nodesRef.current.find((nd) => nd.id === ids[0])
+        return n?.type === 'terminal' || n?.type === 'sticky' || n?.type === 'browser'
+      })()
+        ? ([
+            { type: 'separator' },
+            {
+              label: 'Attach GitHub issue / PR…',
+              onClick: () => setGithubPicker({ nodeId: ids[0], anchor: at ?? { x: 200, y: 200 } })
+            },
+            ...((): MenuItem[] => {
+              const links = (nodesRef.current.find((nd) => nd.id === ids[0])?.data.github ??
+                []) as GitHubLink[]
+              return links.length
+                ? [{
+                    type: 'submenu',
+                    label: 'Detach GitHub link',
+                    children: links.map((link): MenuItem => ({
+                      label: linkToBoardTitle(link),
+                      danger: true,
+                      onClick: () => detachNodeLink(ids[0], link)
+                    }))
+                  }]
+                : []
+            })()
+          ] as MenuItem[])
+        : []),
       { type: 'separator' },
       { label: 'Delete', icon: <IconTrash />, danger: true, onClick: () => deleteNodes(ids) }
     ])
   }, [
+    githubRepository,
+    detachNodeLink,
     groupSelection,
     addToExistingGroup,
     removeFromGroup,
@@ -7764,6 +7900,16 @@ export function Canvas() {
                 onClick: () => openWorktreeDialog(groupId)
               } as MenuItem
             ]),
+        ...(githubRepository &&
+        !isHidden('github-attach', useSettings.getState().settings.hiddenNodeMenuItems)
+          ? [
+              {
+                label: 'Attach GitHub issue / PR…',
+                onClick: () =>
+                  setGithubPicker({ nodeId: groupId, anchor: at ?? { x: 200, y: 200 } })
+              } as MenuItem
+            ]
+          : []),
         { label: 'Ungroup', icon: <IconUngroup />, onClick: () => ungroup(groupId) },
         {
           label: 'Delete (keeps nodes)',
@@ -7774,6 +7920,7 @@ export function Canvas() {
       ])
     },
     [
+      githubRepository,
       setNodesColor,
       ungroup,
       groupHasWorktree,
@@ -12162,6 +12309,41 @@ export function Canvas() {
           onDeleteNode={deleteNodeFromKanban}
           onModalNodeChange={setKanbanModalNode}
           onBrowserNav={browserNavFromKanban}
+          onChangeNodeLinks={setNodeGitHubLinks}
+          onAttachNodeLink={attachNodeLink}
+          onDetachNodeLink={detachNodeLink}
+          githubRepository={githubRepository}
+        />
+      )}
+      {githubPicker && githubRepository && activeProjectId && (
+        <GitHubLinkPicker
+          projectId={activeProjectId}
+          repository={githubRepository}
+          existing={
+            (nodesRef.current.find((n) => n.id === githubPicker.nodeId)?.data.github ??
+              []) as GitHubLink[]
+          }
+          anchor={githubPicker.anchor}
+          {...(githubPicker.preset ? { preset: githubPicker.preset } : {})}
+          {...(githubPicker.kindFilter ? { kindFilter: githubPicker.kindFilter } : {})}
+          onPick={(link) => {
+            attachNodeLink(githubPicker.nodeId, link)
+            setGithubPicker(null)
+          }}
+          onClose={() => setGithubPicker(null)}
+        />
+      )}
+      {githubDetails && githubDetailsCard && (
+        // Read-only: moving a card between columns is a board affair, and this modal is reached
+        // from a node's chip, which has no column of its own to move.
+        <GitHubIssueSummaryModal
+          issue={githubDetailsCard}
+          columns={(projectKanban ?? seedBoard).columns}
+          moving={false}
+          readOnly
+          kind={githubDetails.kind}
+          onMove={() => undefined}
+          onClose={() => setGithubDetails(null)}
         />
       )}
       <UpdateCard />

--- a/src/renderer/canvas/githubLinkActions.ts
+++ b/src/renderer/canvas/githubLinkActions.ts
@@ -1,0 +1,39 @@
+import type { GitHubLink } from '@shared/github-issues'
+
+/**
+ * Canvas ↔ node bridge for the GitHub link actions, the same indirection `setWorktreeActionHandler`
+ * uses: React Flow instantiates custom nodes itself, so a Canvas callback cannot reach them as a
+ * prop. Canvas registers the handler in the same effect; a node (or a board surface) calls the
+ * verbs below. Every write goes through Canvas so the node write, `markDirty` and the board-log
+ * event stay one funnel.
+ */
+export interface GitHubLinkHandler {
+  attach(nodeId: string, link: GitHubLink): void
+  detach(nodeId: string, link: Pick<GitHubLink, 'kind' | 'number'>): void
+  /** Open the picker anchored at a point, adding to `nodeId`. */
+  openPicker(nodeId: string, anchor: { x: number; y: number }): void
+  /** Open the read-only summary for one link. */
+  openDetails(link: GitHubLink): void
+}
+
+let handler: GitHubLinkHandler | null = null
+
+export function setGitHubLinkHandler(next: GitHubLinkHandler | null): void {
+  handler = next
+}
+
+export function attachGitHubLink(nodeId: string, link: GitHubLink): void {
+  handler?.attach(nodeId, link)
+}
+
+export function detachGitHubLink(nodeId: string, link: Pick<GitHubLink, 'kind' | 'number'>): void {
+  handler?.detach(nodeId, link)
+}
+
+export function openGitHubLinkPicker(nodeId: string, anchor: { x: number; y: number }): void {
+  handler?.openPicker(nodeId, anchor)
+}
+
+export function openGitHubLinkDetails(link: GitHubLink): void {
+  handler?.openDetails(link)
+}

--- a/src/renderer/canvas/toKanbanSession.test.ts
+++ b/src/renderer/canvas/toKanbanSession.test.ts
@@ -36,3 +36,21 @@ describe('toKanbanSession (sticky, markdown label)', () => {
     expect(toKanbanSession(sticky('## Plan \nbody'))?.title).toBe('Plan')
   })
 })
+
+describe('toKanbanSession (github links)', () => {
+  const node = (type: string): CanvasNode =>
+    ({
+      id: 'n1',
+      type,
+      position: { x: 0, y: 0 },
+      data: { text: 'note', github: [{ kind: 'issue', number: 12, title: 'Board' }] }
+    }) as unknown as CanvasNode
+
+  for (const type of ['terminal', 'sticky', 'browser']) {
+    it(`copies the links onto a ${type} card`, () => {
+      expect(toKanbanSession(node(type))?.github).toEqual([
+        { kind: 'issue', number: 12, title: 'Board' }
+      ])
+    })
+  }
+})

--- a/src/renderer/canvas/toKanbanSession.ts
+++ b/src/renderer/canvas/toKanbanSession.ts
@@ -1,3 +1,4 @@
+import type { GitHubLink } from '@shared/github-issues'
 import type { SshConnection } from '@shared/ssh'
 import { NODE_COLORS, type CanvasNode } from '../state/workspace'
 import type { KanbanSession } from '../components/kanban/KanbanView'
@@ -13,6 +14,7 @@ export function toKanbanSession(n: CanvasNode): KanbanSession | null {
       title: (n.data.title as string) || 'Browser',
       color: (n.data.color as string) ?? NODE_COLORS[0],
       kind: 'browser',
+      github: n.data.github as GitHubLink[] | undefined,
       url: n.data.url as string | undefined,
       partition: n.data.partition as string | undefined,
       spawn: {}
@@ -30,6 +32,7 @@ export function toKanbanSession(n: CanvasNode): KanbanSession | null {
       title: text.trim().split('\n')[0].replace(/^#{1,6}\s+/, '').trim().slice(0, 80) || 'Note',
       color: (n.data.color as string) ?? NODE_COLORS[2],
       kind: 'sticky',
+      github: n.data.github as GitHubLink[] | undefined,
       text,
       textUpdatedAt: n.data.textUpdatedAt as number | undefined,
       textUpdatedBy: n.data.textUpdatedBy as string | undefined,
@@ -43,6 +46,7 @@ export function toKanbanSession(n: CanvasNode): KanbanSession | null {
     title: (n.data.title as string) ?? '',
     color: (n.data.color as string) ?? NODE_COLORS[0],
     kind: 'terminal',
+    github: n.data.github as GitHubLink[] | undefined,
     agentId: n.data.agentId as string | undefined,
     // What the card modal's co-attach terminal needs to join THIS node's session the same way the
     // canvas TerminalNode does.

--- a/src/renderer/components/github/GitHubLinkChip.test.tsx
+++ b/src/renderer/components/github/GitHubLinkChip.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitHubIssueCardView } from '@shared/github-issues'
+import { useProjects } from '../../state/projects'
+import { useGitHubLinks } from '../../state/githubLinks'
+import { setGitHubLinkHandler } from '../../canvas/githubLinkActions'
+import { GitHubLinkChip } from './GitHubLinkChip'
+
+const openExternal = vi.fn()
+vi.mock('../../session/session', () => ({
+  useSession: () => ({
+    api: {
+      shell: { openExternal: (url: string) => openExternal(url) },
+      githubIssues: { lookup: vi.fn(async () => ({ ok: false, reason: 'not-found' })) }
+    }
+  })
+}))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+// jsdom has no ResizeObserver; the menu's edge-flip hook observes itself.
+globalThis.ResizeObserver = class {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+} as unknown as typeof ResizeObserver
+
+const card = (number: number, over: Partial<GitHubIssueCardView> = {}): GitHubIssueCardView => ({
+  id: number,
+  number,
+  title: `Item ${number}`,
+  body: '',
+  state: 'open',
+  stateReason: null,
+  htmlUrl: `https://github.com/o/r/issues/${number}`,
+  apiUrl: `https://api.github.com/repos/o/r/issues/${number}`,
+  labels: [],
+  assignees: [],
+  createdAt: '2026-08-01T10:00:00Z',
+  updatedAt: '2026-08-09T10:00:00Z',
+  locked: false,
+  columnId: null,
+  conflict: null,
+  ...over
+})
+
+const withRepository = (repository?: string): void => {
+  useProjects.setState({
+    activeProjectId: 'p1',
+    projects: [{
+      id: 'p1',
+      name: 'P',
+      color: '#fff',
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: [],
+      ...(repository ? { kanban: { columns: [], assignments: [], github: { repository, columnMappings: [] } } } : {})
+    }]
+  } as never)
+}
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  useGitHubLinks.setState({ cards: {}, pending: {}, missing: {}, gate: {} })
+  withRepository('o/r')
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  setGitHubLinkHandler(null)
+  vi.clearAllMocks()
+})
+
+const render = (links: Parameters<typeof GitHubLinkChip>[0]['links']): void => {
+  act(() => root.render(<GitHubLinkChip nodeId="n1" links={links} variant="node" />))
+}
+
+describe('GitHubLinkChip', () => {
+  it('labels the first link and counts the rest', () => {
+    render([{ kind: 'issue', number: 12 }, { kind: 'pull', number: 3 }])
+    expect(host.querySelector('.github-link-chip')?.textContent).toBe('#12 +1')
+  })
+
+  it('paints the dot from the cached card', () => {
+    useGitHubLinks.setState({ cards: { p1: { 'issue#12': { card: card(12, { state: 'closed' }), at: Date.now() } } } })
+    render([{ kind: 'issue', number: 12 }])
+    expect(host.querySelector('.github-link-chip__dot')?.className).toContain('--closed')
+  })
+
+  it('renders nothing without links, and nothing without a repository', () => {
+    render([])
+    expect(host.querySelector('.github-link-chip')).toBeNull()
+    withRepository(undefined)
+    render([{ kind: 'issue', number: 12 }])
+    expect(host.querySelector('.github-link-chip')).toBeNull()
+  })
+
+  it('opens a menu whose actions reach the canvas handler', () => {
+    const detach = vi.fn()
+    const openPicker = vi.fn()
+    setGitHubLinkHandler({ attach: vi.fn(), detach, openPicker, openDetails: vi.fn() })
+    render([{ kind: 'pull', number: 3, title: 'Ship' }])
+    act(() => {
+      host.querySelector('.github-link-chip')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    const labels = [...document.querySelectorAll('.ctx-menu button')].map((b) => b.textContent)
+    expect(labels).toEqual(expect.arrayContaining([
+      'Open #3 details', 'Open #3 on GitHub', 'Detach #3', 'Attach another…'
+    ]))
+
+    const detachRow = [...document.querySelectorAll('.ctx-menu button')]
+      .find((b) => b.textContent === 'Detach #3')!
+    act(() => detachRow.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(detach).toHaveBeenCalledWith('n1', { kind: 'pull', number: 3, title: 'Ship' })
+  })
+
+  it('opens the item on github.com through the shell, at its own kind’s path', () => {
+    setGitHubLinkHandler({ attach: vi.fn(), detach: vi.fn(), openPicker: vi.fn(), openDetails: vi.fn() })
+    render([{ kind: 'pull', number: 3 }])
+    act(() => {
+      host.querySelector('.github-link-chip')!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    const row = [...document.querySelectorAll('.ctx-menu button')]
+      .find((b) => b.textContent === 'Open #3 on GitHub')!
+    act(() => row.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(openExternal).toHaveBeenCalledWith('https://github.com/o/r/pull/3')
+  })
+})

--- a/src/renderer/components/github/GitHubLinkChip.tsx
+++ b/src/renderer/components/github/GitHubLinkChip.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState, type MouseEvent } from 'react'
+import type { GitHubLink } from '@shared/github-issues'
+import { githubLinkUrl } from '@shared/github-link'
+import { useSession } from '../../session/session'
+import { useProjects } from '../../state/projects'
+import { useGitHubLinks } from '../../state/githubLinks'
+import {
+  linkChipLabel,
+  linkKey,
+  linkRepository,
+  linkState,
+  linkToBoardTitle,
+  linkTooltip
+} from '../../lib/githubLinks'
+import {
+  detachGitHubLink,
+  openGitHubLinkDetails,
+  openGitHubLinkPicker
+} from '../../canvas/githubLinkActions'
+import { ContextMenu, type MenuItem } from '../ContextMenu'
+
+/** Beyond this many links the per-link rows move into one submenu each: a flat menu of twenty
+ *  detach rows is not a menu. */
+const FLAT_MENU_MAX = 3
+
+interface Props {
+  nodeId: string
+  links: GitHubLink[]
+  /** Where the chip is rendered — styling only; every variant carries the same actions. */
+  variant: 'node' | 'card' | 'modal' | 'group'
+}
+
+/**
+ * The `#12 +2` chip a linked node wears on the canvas and on its board card.
+ *
+ * It resolves each link's card itself (`ensureCard`), because the chip has no host subscription:
+ * a canvas full of chips must not each hold one. Renders nothing when the node has no links or
+ * the project has no repository — an unconfigured project shows no GitHub surface at all.
+ */
+export function GitHubLinkChip({ nodeId, links, variant }: Props) {
+  const repository = useProjects((s) =>
+    linkRepository(s.projects.find((p) => p.id === s.activeProjectId)?.kanban))
+  // The body is a separate component so the session is only required by a chip that renders:
+  // every node mounts one of these, and a link-less node must not depend on a session provider.
+  if (!links.length || !repository) return null
+  return <ChipBody nodeId={nodeId} links={links} variant={variant} repository={repository} />
+}
+
+function ChipBody({ nodeId, links, variant, repository }: Props & { repository: string }) {
+  const { api } = useSession()
+  const projectId = useProjects((s) => s.activeProjectId)
+  const cards = useGitHubLinks((s) => s.cards[projectId])
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null)
+
+  useEffect(() => {
+    for (const link of links) void useGitHubLinks.getState().ensureCard(api.githubIssues, projectId, link)
+  }, [api, projectId, links])
+
+  const cardFor = (link: GitHubLink) => cards?.[linkKey(link)]?.card
+  const first = links[0]
+  const open = (event: MouseEvent): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    setMenu({ x: event.clientX, y: event.clientY })
+  }
+
+  const linkRows = (link: GitHubLink): MenuItem[] => [
+    { label: `Open #${link.number} details`, onClick: () => openGitHubLinkDetails(link) },
+    {
+      label: `Open #${link.number} on GitHub`,
+      onClick: () => api.shell.openExternal(githubLinkUrl(repository, link))
+    },
+    {
+      label: `Detach #${link.number}`,
+      danger: true,
+      onClick: () => detachGitHubLink(nodeId, link)
+    }
+  ]
+
+  const items: MenuItem[] = [
+    ...(links.length <= FLAT_MENU_MAX
+      ? links.flatMap((link, index): MenuItem[] => [
+          ...(index ? [{ type: 'separator' } as MenuItem] : []),
+          { type: 'label', label: linkToBoardTitle(link, cardFor(link)) },
+          ...linkRows(link)
+        ])
+      : links.map((link): MenuItem => ({
+          type: 'submenu',
+          label: linkToBoardTitle(link, cardFor(link)),
+          children: linkRows(link)
+        }))),
+    { type: 'separator' },
+    {
+      label: 'Attach another…',
+      onClick: () => menu && openGitHubLinkPicker(nodeId, menu)
+    }
+  ]
+
+  return (
+    <>
+      <span
+        className={`github-link-chip github-link-chip--${variant} nodrag`}
+        title={linkTooltip(links, Object.fromEntries(
+          links.map((link) => [linkKey(link), cardFor(link)])
+        ))}
+        onClick={open}
+        onContextMenu={open}
+      >
+        <i className={`github-link-chip__dot github-link-chip__dot--${linkState(first, cardFor(first))}`} />
+        {linkChipLabel(links)}
+      </span>
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          items={items}
+          zIndex={variant === 'modal' ? 60 : undefined}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/renderer/components/github/GitHubLinkPicker.test.tsx
+++ b/src/renderer/components/github/GitHubLinkPicker.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitHubIssueCardView } from '@shared/github-issues'
+import { GitHubLinkPicker } from './GitHubLinkPicker'
+
+const lookup = vi.fn()
+const search = vi.fn()
+vi.mock('../../session/session', () => ({
+  useSession: () => ({ api: { githubIssues: { lookup, search } } })
+}))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const card = (number: number, over: Partial<GitHubIssueCardView> = {}): GitHubIssueCardView => ({
+  id: number,
+  number,
+  title: `Item ${number}`,
+  body: '',
+  state: 'open',
+  stateReason: null,
+  htmlUrl: `https://github.com/o/r/issues/${number}`,
+  apiUrl: `https://api.github.com/repos/o/r/issues/${number}`,
+  labels: [],
+  assignees: [],
+  createdAt: '2026-08-01T10:00:00Z',
+  updatedAt: '2026-08-09T10:00:00Z',
+  locked: false,
+  columnId: null,
+  conflict: null,
+  ...over
+})
+
+let host: HTMLDivElement
+let root: Root
+const onPick = vi.fn()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  lookup.mockReset()
+  search.mockReset()
+  onPick.mockReset()
+  search.mockResolvedValue({ items: [], partial: false })
+  lookup.mockResolvedValue({ ok: false, reason: 'not-found' })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.useRealTimers()
+})
+
+const render = (props: Partial<Parameters<typeof GitHubLinkPicker>[0]> = {}): void => {
+  act(() => root.render(
+    <GitHubLinkPicker
+      projectId="p1"
+      repository="o/r"
+      existing={[]}
+      anchor={{ x: 10, y: 10 }}
+      onPick={onPick}
+      onClose={vi.fn()}
+      {...props}
+    />
+  ))
+}
+
+/** Let the 150 ms debounce fire and the resolved promise land. */
+const settle = async (): Promise<void> => {
+  await act(async () => { await vi.advanceTimersByTimeAsync(200) })
+}
+
+const type = async (value: string): Promise<void> => {
+  const input = document.querySelector('.github-link-picker__filter') as HTMLInputElement
+  act(() => {
+    // React tracks the previous value on the node itself; assigning `.value` directly makes it
+    // think nothing changed, so the native setter has to be used.
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!
+      .set!.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  await settle()
+}
+
+describe('GitHubLinkPicker', () => {
+  it('sends a number to lookup, not to search', async () => {
+    lookup.mockResolvedValue({ ok: true, source: 'cache', item: card(12) })
+    render()
+    await settle()
+    search.mockClear()
+    await type('#12')
+    expect(lookup).toHaveBeenCalledWith({ projectId: 'p1', number: 12 })
+    expect(search).not.toHaveBeenCalled()
+    expect(document.querySelector('.github-link-picker__title')?.textContent).toBe('Item 12')
+  })
+
+  it('sends free text to search, which never hits the network', async () => {
+    search.mockResolvedValue({ items: [card(4)], partial: false })
+    render()
+    await type('board')
+    expect(search).toHaveBeenLastCalledWith({ projectId: 'p1', search: 'board', limit: 20 })
+    expect(lookup).not.toHaveBeenCalled()
+  })
+
+  it('treats a URL for another repository as free text, so no number is resolved', async () => {
+    render()
+    await type('https://github.com/other/repo/issues/12')
+    expect(lookup).not.toHaveBeenCalled()
+    expect(search).toHaveBeenCalled()
+  })
+
+  it('renders a refusal as one disabled row instead of an empty list', async () => {
+    lookup.mockResolvedValue({ ok: false, reason: 'not-approved' })
+    render()
+    await type('12')
+    const note = document.querySelector('.github-link-picker__note') as HTMLButtonElement
+    expect(note.disabled).toBe(true)
+    expect(note.textContent).toContain('not approved')
+  })
+
+  it('disables a row for a link the node already carries', async () => {
+    search.mockResolvedValue({ items: [card(4)], partial: false })
+    render({ existing: [{ kind: 'issue', number: 4 }] })
+    await type('item')
+    const row = [...document.querySelectorAll('.github-link-picker__list button')]
+      .find((b) => b.textContent?.includes('#4')) as HTMLButtonElement
+    expect(row.disabled).toBe(true)
+    act(() => row.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onPick).not.toHaveBeenCalled()
+  })
+
+  it('Enter picks the first row that is not already attached, with the item’s own kind', async () => {
+    search.mockResolvedValue({
+      items: [card(4), card(5, { pull: { draft: false, mergedAt: null } })],
+      partial: false
+    })
+    render({ existing: [{ kind: 'issue', number: 4 }] })
+    await type('item')
+    const input = document.querySelector('.github-link-picker__filter') as HTMLInputElement
+    act(() => input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })))
+    expect(onPick).toHaveBeenCalledWith({ kind: 'pull', number: 5, title: 'Item 5' })
+  })
+
+  it('offers the preset candidates before anything is typed', () => {
+    render({ preset: [card(9)] })
+    expect(document.querySelector('.github-link-picker__title')?.textContent).toBe('Item 9')
+  })
+})

--- a/src/renderer/components/github/GitHubLinkPicker.tsx
+++ b/src/renderer/components/github/GitHubLinkPicker.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { GitHubIssueCardView, GitHubLink } from '@shared/github-issues'
+import { useSession } from '../../session/session'
+import { hasLink, linkState, parseLinkInput } from '../../lib/githubLinks'
+
+const DEBOUNCE_MS = 150
+const RESULT_LIMIT = 20
+
+/** What the list is currently showing. `refused` carries a reason the user can act on rather
+ *  than an empty list, which reads as "this repository has nothing in it". */
+type Results =
+  | { kind: 'items'; items: GitHubIssueCardView[]; partial: boolean }
+  | { kind: 'refused'; message: string }
+  | { kind: 'not-found'; number: number }
+
+interface Props {
+  projectId: string
+  repository: string
+  /** Links the node already carries — their rows are shown, disabled. */
+  existing: GitHubLink[]
+  initialQuery?: string
+  kindFilter?: 'issue' | 'pull'
+  /** Candidates to offer before anything is typed (the worktree frame's open pull requests). */
+  preset?: GitHubIssueCardView[]
+  anchor: { x: number; y: number }
+  onPick: (link: GitHubLink) => void
+  onClose: () => void
+}
+
+const REFUSALS: Record<string, string> = {
+  'not-approved': 'GitHub is not approved for this project — approve it in Settings → GitHub.',
+  'not-authenticated': 'Not signed in to GitHub — sign in in Settings → GitHub.',
+  'configuration-changed': 'The project’s GitHub configuration changed — try again.',
+  'invalid-request': 'That is not an issue or pull request number.'
+}
+
+/**
+ * Search-and-pick list for attaching a GitHub issue or pull request to a node.
+ *
+ * A query that IS a number or a github.com URL goes to `lookup` (which can reach the API for an
+ * item the cached snapshot never held); anything else goes to `search`, which only ever reads the
+ * cache. A URL for another repository resolves to nothing at all — the link's repository is the
+ * project's, so attaching by that number would silently point at the wrong item.
+ */
+export function GitHubLinkPicker({
+  projectId,
+  repository,
+  existing,
+  initialQuery,
+  kindFilter,
+  preset,
+  anchor,
+  onPick,
+  onClose
+}: Props) {
+  const { api } = useSession()
+  const [query, setQuery] = useState(initialQuery ?? '')
+  const [results, setResults] = useState<Results>({
+    kind: 'items',
+    items: preset ?? [],
+    partial: false
+  })
+  const [busy, setBusy] = useState(false)
+  const generation = useRef(0)
+
+  useEffect(() => {
+    const run = generation.current + 1
+    generation.current = run
+    const parsed = parseLinkInput(query, repository)
+    const timer = setTimeout(() => {
+      setBusy(true)
+      const work = parsed
+        ? api.githubIssues.lookup({ projectId, number: parsed.number }).then((result): Results => {
+            if (result.ok) return { kind: 'items', items: [result.item], partial: false }
+            if (result.reason === 'not-found') return { kind: 'not-found', number: parsed.number }
+            return { kind: 'refused', message: REFUSALS[result.reason] ?? 'GitHub is unavailable.' }
+          })
+        : api.githubIssues.search({
+            projectId,
+            search: query.trim(),
+            limit: RESULT_LIMIT,
+            ...(kindFilter ? { kind: kindFilter } : {})
+          }).then((result): Results => ({
+            kind: 'items', items: result.items, partial: result.partial
+          }))
+      void work
+        .catch((): Results => ({ kind: 'refused', message: 'GitHub is unavailable.' }))
+        .then((next) => {
+          if (generation.current !== run) return
+          setBusy(false)
+          setResults(next)
+        })
+    }, DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [api, projectId, repository, query, kindFilter])
+
+  const rows = useMemo(
+    () => (results.kind === 'items' ? results.items : []),
+    [results]
+  )
+
+  const pick = (item: GitHubIssueCardView): void => {
+    const link: GitHubLink = {
+      kind: item.pull ? 'pull' : 'issue',
+      number: item.number,
+      ...(item.title ? { title: item.title.slice(0, 200) } : {})
+    }
+    if (hasLink(existing, link)) return
+    onPick(link)
+  }
+
+  const firstFree = rows.find((item) =>
+    !hasLink(existing, { kind: item.pull ? 'pull' : 'issue', number: item.number }))
+
+  return createPortal(
+    <>
+      <div className="tab-backdrop" style={{ zIndex: 78 }} onClick={onClose} />
+      <div
+        className="tab-menu github-link-picker"
+        style={{ top: anchor.y, left: anchor.x, zIndex: 80 }}
+      >
+        <input
+          className="tab__edit github-link-picker__filter"
+          placeholder="#123, a title, or a github.com link"
+          value={query}
+          spellCheck={false}
+          autoFocus
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') { event.preventDefault(); onClose() }
+            if (event.key === 'Enter' && firstFree) { event.preventDefault(); pick(firstFree) }
+          }}
+        />
+        <div className="github-link-picker__list">
+          {results.kind === 'refused' && (
+            <button type="button" disabled className="github-link-picker__note">
+              {results.message}
+            </button>
+          )}
+          {results.kind === 'not-found' && (
+            <button type="button" disabled className="github-link-picker__note">
+              #{results.number} is not in {repository}.
+            </button>
+          )}
+          {results.kind === 'items' && !rows.length && !busy && (
+            <button type="button" disabled className="github-link-picker__note">
+              Nothing matches.
+            </button>
+          )}
+          {rows.map((item) => {
+            const link = { kind: (item.pull ? 'pull' : 'issue') as GitHubLink['kind'], number: item.number }
+            const attached = hasLink(existing, link)
+            return (
+              <button
+                type="button"
+                key={`${link.kind}#${item.number}`}
+                disabled={attached}
+                title={attached ? 'Already attached to this node' : item.title}
+                onClick={() => pick(item)}
+              >
+                <i className={`github-link-chip__dot github-link-chip__dot--${linkState(link, item)}`} />
+                <span className="github-link-picker__num">#{item.number}</span>
+                <span className="github-link-picker__title">{item.title}</span>
+                {item.pull && <span className="github-link-picker__badge">PR</span>}
+              </button>
+            )
+          })}
+        </div>
+        {results.kind === 'items' && results.partial && (
+          <div className="github-link-picker__foot">
+            Only part of the repository is cached — refresh the board for the rest.
+          </div>
+        )}
+      </div>
+    </>,
+    document.body
+  )
+}

--- a/src/renderer/components/kanban/BoardLogPanel.tsx
+++ b/src/renderer/components/kanban/BoardLogPanel.tsx
@@ -42,6 +42,10 @@ export function eventBody(e: BoardLogEvent): string {
       return `removed the priority`
     case 'agent-message':
       return `sent a message to ${e.to ?? 'another node'} (${e.title ?? 'unknown outcome'})`
+    case 'github-attached':
+      return `attached ${e.to === 'pull' ? 'PR' : 'issue'} ${e.title ?? ''}`.trimEnd()
+    case 'github-detached':
+      return `detached ${e.to === 'pull' ? 'PR' : 'issue'} ${e.title ?? ''}`.trimEnd()
     case 'agent-read-cookies':
       // A loud, human-visible line for a cookie read (the whole point of the trace). `from` names the
       // agent, `to` the domain it read; `title` names the browser node it drove.

--- a/src/renderer/components/kanban/CardMetaBar.test.tsx
+++ b/src/renderer/components/kanban/CardMetaBar.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProjectKanban } from '@shared/types'
+import { CardMetaBar } from './CardMetaBar'
+
+vi.mock('./LabelPicker', () => ({ LabelPicker: () => null }))
+vi.mock('../../state/presence', () => ({
+  loadIdentity: () => ({ name: 'me', color: '#fff' }),
+  selectFaces: () => [],
+  usePresence: () => []
+}))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const board: ProjectKanban = { columns: [], assignments: [] }
+
+let host: HTMLDivElement
+let root: Root
+const onChangeLinks = vi.fn()
+const onAttachLink = vi.fn()
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  onChangeLinks.mockReset()
+  onAttachLink.mockReset()
+  ;(window as unknown as { nodeTerminal: unknown }).nodeTerminal = {
+    shell: { openExternal: vi.fn() }
+  }
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+const render = (props: Partial<Parameters<typeof CardMetaBar>[0]> = {}): void => {
+  act(() => root.render(
+    <CardMetaBar
+      nodeId="n1"
+      board={board}
+      onChange={vi.fn()}
+      links={[]}
+      onChangeLinks={onChangeLinks}
+      onAttachLink={onAttachLink}
+      {...props}
+    />
+  ))
+}
+
+const groups = (): string[] =>
+  [...host.querySelectorAll('.kanban-meta__label')].map((el) => el.textContent ?? '')
+
+describe('CardMetaBar GitHub group', () => {
+  it('is absent when the project has no repository', () => {
+    render({ links: [{ kind: 'issue', number: 12 }] })
+    expect(groups()).not.toContain('GitHub')
+  })
+
+  it('lists every link once a repository is configured', () => {
+    render({
+      githubRepository: 'o/r',
+      links: [{ kind: 'issue', number: 12, title: 'Board' }, { kind: 'pull', number: 3 }]
+    })
+    expect(groups()).toContain('GitHub')
+    expect([...host.querySelectorAll('.kanban-meta__ghlink a')].map((a) => a.textContent))
+      .toEqual(['#12 Board', '#3'])
+  })
+
+  it('detaches through the write funnel, with the event that names it', () => {
+    render({ githubRepository: 'o/r', links: [{ kind: 'pull', number: 3, title: 'Ship' }] })
+    const remove = host.querySelector('.kanban-meta__ghlink .kanban-meta__clear')!
+    act(() => remove.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onChangeLinks).toHaveBeenCalledWith(undefined, {
+      type: 'github-detached', to: 'pull', title: '#3 Ship'
+    })
+  })
+
+  it('asks the board to open the picker, anchored at the button', () => {
+    render({ githubRepository: 'o/r', links: [] })
+    const add = [...host.querySelectorAll('.kanban-avatar--add')].at(-1)!
+    act(() => add.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onAttachLink).toHaveBeenCalledWith(expect.objectContaining({ x: expect.any(Number) }))
+  })
+})

--- a/src/renderer/components/kanban/CardMetaBar.tsx
+++ b/src/renderer/components/kanban/CardMetaBar.tsx
@@ -1,5 +1,8 @@
 import { useMemo, useState } from 'react'
-import type { BoardLogAuthor, KanbanPriority, ProjectKanban } from '@shared/types'
+import type { BoardLogAuthor, BoardLogEvent, KanbanPriority, ProjectKanban } from '@shared/types'
+import type { GitHubLink } from '@shared/github-issues'
+import { githubLinkUrl } from '@shared/github-link'
+import { linkToBoardTitle, removeLink } from '../../lib/githubLinks'
 import { cardMeta, labelsForCard, setCardDue, setCardPriority, toggleAssignee } from '../../lib/kanban'
 import { LabelChips } from './LabelChips'
 import { LabelPicker } from './LabelPicker'
@@ -28,12 +31,20 @@ interface CardMetaBarProps {
   nodeId: string
   board: ProjectKanban
   onChange: (next: ProjectKanban) => void
+  /** This node's GitHub links, and the write-back for the × on each row. */
+  links: GitHubLink[]
+  onChangeLinks: (next: GitHubLink[] | undefined, event?: BoardLogEvent) => void
+  /** Opens the board's attach picker anchored at the button. Absent repository = no group at all. */
+  onAttachLink: (anchor: { x: number; y: number }) => void
+  githubRepository?: string
 }
 
 /** Trello-style Members / Due date strip under the modal header. The assignable pool is
  *  everyone the session can NAME: me (presence identity), live presence peers, and every
  *  author already seen in the board log — no separate membership system. */
-export function CardMetaBar({ nodeId, board, onChange }: CardMetaBarProps) {
+export function CardMetaBar({
+  nodeId, board, onChange, links, onChangeLinks, onAttachLink, githubRepository
+}: CardMetaBarProps) {
   const [pickerOpen, setPickerOpen] = useState(false)
   const [labelsOpen, setLabelsOpen] = useState(false)
   const meta = cardMeta(board, nodeId)
@@ -148,6 +159,49 @@ export function CardMetaBar({ nodeId, board, onChange }: CardMetaBarProps) {
           )}
         </div>
       </div>
+      {githubRepository && (
+        <div className="kanban-meta__group">
+          <span className="kanban-meta__label">GitHub</span>
+          <div className="kanban-meta__row">
+            {links.map((link) => (
+              <span key={`${link.kind}#${link.number}`} className="kanban-meta__ghlink">
+                <a
+                  href={githubLinkUrl(githubRepository, link)}
+                  onClick={(event) => {
+                    event.preventDefault()
+                    window.nodeTerminal.shell.openExternal(githubLinkUrl(githubRepository, link))
+                  }}
+                >
+                  {linkToBoardTitle(link)}
+                </a>
+                <button
+                  className="kanban-meta__clear"
+                  title={`Detach #${link.number}`}
+                  onClick={() =>
+                    onChangeLinks(removeLink(links, link), {
+                      type: 'github-detached',
+                      to: link.kind,
+                      title: linkToBoardTitle(link)
+                    })
+                  }
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+            <button
+              className="kanban-avatar kanban-avatar--add"
+              title="Attach an issue or pull request"
+              onClick={(event) => {
+                const rect = event.currentTarget.getBoundingClientRect()
+                onAttachLink({ x: rect.left, y: rect.bottom + 4 })
+              }}
+            >
+              +
+            </button>
+          </div>
+        </div>
+      )}
       <div className="kanban-meta__group">
         <span className="kanban-meta__label">Priority</span>
         <div className="kanban-meta__row">

--- a/src/renderer/components/kanban/CardModal.test.tsx
+++ b/src/renderer/components/kanban/CardModal.test.tsx
@@ -93,6 +93,8 @@ describe('CardModal', () => {
           onRename={vi.fn()}
           onEditSticky={onEditSticky}
           onBrowserNav={vi.fn()}
+          onChangeNodeLinks={vi.fn()}
+          onAttachLink={vi.fn()}
         />
       )
     )
@@ -173,6 +175,8 @@ describe('CardModal', () => {
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
           onBrowserNav={vi.fn()}
+          onChangeNodeLinks={vi.fn()}
+          onAttachLink={vi.fn()}
         />
       )
     )
@@ -215,6 +219,8 @@ describe('CardModal', () => {
           onRename={onRename}
           onEditSticky={vi.fn()}
           onBrowserNav={vi.fn()}
+          onChangeNodeLinks={vi.fn()}
+          onAttachLink={vi.fn()}
         />
       )
     )
@@ -290,6 +296,8 @@ describe('CardModal', () => {
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
           onBrowserNav={vi.fn()}
+          onChangeNodeLinks={vi.fn()}
+          onAttachLink={vi.fn()}
         />
       )
     )
@@ -343,6 +351,8 @@ describe('CardModal', () => {
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
           onBrowserNav={vi.fn()}
+          onChangeNodeLinks={vi.fn()}
+          onAttachLink={vi.fn()}
         />
       )
     )
@@ -384,6 +394,8 @@ describe('CardModal', () => {
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
           onBrowserNav={vi.fn()}
+          onChangeNodeLinks={vi.fn()}
+          onAttachLink={vi.fn()}
         />
       )
     )
@@ -437,6 +449,8 @@ describe('CardModal', () => {
           onRename={vi.fn()}
           onEditSticky={vi.fn()}
           onBrowserNav={vi.fn()}
+          onChangeNodeLinks={vi.fn()}
+          onAttachLink={vi.fn()}
         />
       )
     )

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -19,10 +19,12 @@ import { useSession } from '../../session/session'
 // retries. Importing one function out of the canvas node module is safe: TerminalNode.tsx already
 // imports from `components/kanban/*`, and none of those re-import CardModal.
 import { wakeHibernatedNode } from '../../nodes/TerminalNode'
-import type { ProjectKanban } from '@shared/types'
+import type { BoardLogEvent, ProjectKanban } from '@shared/types'
+import type { GitHubLink } from '@shared/github-issues'
 import type { KanbanSession } from './KanbanView'
 import { BoardLogPanel } from './BoardLogPanel'
 import { CardMetaBar } from './CardMetaBar'
+import { GitHubLinkChip } from '../github/GitHubLinkChip'
 import { ModalTerminal } from './ModalTerminal'
 import { BrowserSurface } from '../../nodes/BrowserSurface'
 import { BrowserDrivingIndicator } from '../../nodes/BrowserDrivingChip'
@@ -45,12 +47,18 @@ interface CardModalProps {
   onEditSticky: (text: string) => void
   /** Browser navigation write-through (only called for kind 'browser'). */
   onBrowserNav: (patch: { url?: string; title?: string }) => void
+  /** The project's repository, or undefined when GitHub is not configured. */
+  githubRepository?: string
+  /** Replace this node's GitHub links (the metadata strip's × routes here). */
+  onChangeNodeLinks: (nodeId: string, next: GitHubLink[] | undefined, event?: BoardLogEvent) => void
+  /** Ask the board to open the attach picker anchored at this point. */
+  onAttachLink: (anchor: { x: number; y: number }) => void
 }
 
 /** Trello-style card popup over the board. Scrim click / Esc close it; the board (and the
  *  canvas under it) stay mounted. Terminal cards carry the node header's actions too:
  *  search / dictate / AI-name / markdown view (the node itself is hidden under the board). */
-export function CardModal({ session, columnTitle, board, onChangeBoard, onClose, onOpenCanvas, onRename, onEditSticky, onBrowserNav }: CardModalProps) {
+export function CardModal({ session, columnTitle, board, onChangeBoard, onClose, onOpenCanvas, onRename, onEditSticky, onBrowserNav, githubRepository, onChangeNodeLinks, onAttachLink }: CardModalProps) {
   const { api } = useSession()
   const idRef = useRef<string>()
   if (!idRef.current) idRef.current = nextDialogId()
@@ -255,6 +263,9 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
             </span>
           )}
           <span className="kanban-modal__column">{columnTitle ?? 'Ungrouped'}</span>
+          {!!session.github?.length && (
+            <GitHubLinkChip nodeId={session.id} links={session.github} variant="modal" />
+          )}
           {/* The driving chip, so a user watching a browser card THROUGH the modal is not
               driving-blind. The lease is keyed by node id (not by webview object), so this shows
               when the node is being driven even though the drive lands on the CANVAS webview, not
@@ -328,7 +339,15 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
             ✕
           </button>
         </div>
-        <CardMetaBar nodeId={session.id} board={board} onChange={onChangeBoard} />
+        <CardMetaBar
+          nodeId={session.id}
+          board={board}
+          onChange={onChangeBoard}
+          links={session.github ?? []}
+          {...(githubRepository ? { githubRepository } : {})}
+          onChangeLinks={(next, event) => onChangeNodeLinks(session.id, next, event)}
+          onAttachLink={onAttachLink}
+        />
         <div className="kanban-modal__body">
           {/* Body is a flex row: the card's own pane (2/3) + the board-log panel (1/3, all kinds). */}
           <div className="kanban-modal__main">

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { KanbanLabel, ProjectKanban } from '@shared/types'
+import type { BoardLogEvent, KanbanLabel, ProjectKanban } from '@shared/types'
 import { AGENT_CONFIG, BUILTIN_AGENT_IDS, type AgentId } from '@shared/agents/config'
 import { useViewMode } from '../../state/viewMode'
 import { useProjects } from '../../state/projects'
@@ -19,12 +19,13 @@ import { kanbanSource, sourceVisible } from '../../lib/kanbanSources'
 import type { ModalSpawn } from './ModalTerminal'
 import { ContextMenu, type MenuItem } from '../ContextMenu'
 import { IconAgent, IconExternal, IconNote, IconSwitch, IconTerminal, IconTrash, IconWeb } from '../icons'
-import type { GitHubIssueCardView } from '@shared/github-issues'
+import type { GitHubIssueCardView, GitHubLink } from '@shared/github-issues'
 import { useGitHubIssues } from '../../state/githubIssues'
 import { useAgentStatus } from '../../state/agentStatus'
 import { useSession } from '../../session/session'
 import { KanbanSourceFilter, type KanbanSource } from './KanbanSourceFilter'
 import { GitHubIssueSummaryModal } from './GitHubIssueSummaryModal'
+import { GitHubLinkPicker } from '../github/GitHubLinkPicker'
 import { ConfirmDialog } from '../ConfirmDialog'
 import {
   githubMoveConfirmation,
@@ -39,6 +40,9 @@ export interface KanbanSession {
   title: string
   color: string
   kind: 'terminal' | 'sticky' | 'browser'
+  /** The issues / pull requests explicitly attached to the node — the same array the canvas chip
+   *  reads, so the two views can never disagree about what a session is working on. */
+  github?: GitHubLink[]
   agentId?: string
   /** Sticky note body — shown in the expanded detail row. */
   text?: string
@@ -89,6 +93,14 @@ export interface KanbanViewProps {
   onModalNodeChange: (nodeId: string | null) => void
   /** Persist a browser card's navigation (url/title) from the modal webview to the node. */
   onBrowserNav: (nodeId: string, patch: { url?: string; title?: string }) => void
+  /** Replace a node's GitHub links wholesale (the metadata strip's × routes here). */
+  onChangeNodeLinks: (nodeId: string, next: GitHubLink[] | undefined, event?: BoardLogEvent) => void
+  /** Attach / detach one link through the canvas funnel, so the board-log event is emitted once. */
+  onAttachNodeLink: (nodeId: string, link: GitHubLink) => void
+  onDetachNodeLink: (nodeId: string, link: Pick<GitHubLink, 'kind' | 'number'>) => void
+  /** The project's repository, or undefined when GitHub is not configured — the board's whole
+   *  "show a GitHub surface at all?" answer. */
+  githubRepository?: string
 }
 
 type Drag =
@@ -117,8 +129,10 @@ const NO_CARDS: KanbanSession[] = []
  *  renders stop at this boundary. */
 export const KanbanView = memo(function KanbanView({
   board, sessions, onChange, onOpenNode, onCreateNode, onRenameNode, onEditSticky, onDeleteNode,
-  onModalNodeChange, onBrowserNav
+  onModalNodeChange, onBrowserNav, onChangeNodeLinks, onAttachNodeLink, onDetachNodeLink,
+  githubRepository
 }: KanbanViewProps) {
+  const [linkPicker, setLinkPicker] = useState<{ x: number; y: number; nodeId: string } | null>(null)
   const { api } = useSession()
   const dragRef = useRef<Drag>(null)
   // One card modal at a time; a deleted node closes it via the byId.has render guard.
@@ -523,6 +537,15 @@ export const KanbanView = memo(function KanbanView({
       ...(moveTargets.length
         ? ([{ type: 'submenu', label: 'Move to', icon: <IconSwitch />, children: moveTargets }] as MenuItem[])
         : []),
+      ...(githubRepository
+        ? ([
+            { type: 'separator' },
+            {
+              label: 'Attach GitHub issue / PR…',
+              onClick: () => setLinkPicker({ ...(cardMenu ?? { x: 200, y: 200 }), nodeId })
+            }
+          ] as MenuItem[])
+        : []),
       { type: 'separator' },
       { label: 'Delete', icon: <IconTrash />, danger: true, onClick: () => onDeleteNode(nodeId) }
     ]
@@ -663,6 +686,22 @@ export const KanbanView = memo(function KanbanView({
           onRename={(t) => onRenameNode(modalNodeId, t)}
           onEditSticky={(t) => onEditSticky(modalNodeId, t)}
           onBrowserNav={(patch) => onBrowserNav(modalNodeId, patch)}
+          githubRepository={githubRepository}
+          onChangeNodeLinks={onChangeNodeLinks}
+          onAttachLink={(anchor) => setLinkPicker({ ...anchor, nodeId: modalNodeId })}
+        />
+      )}
+      {linkPicker && githubRepository && projectId && (
+        <GitHubLinkPicker
+          projectId={projectId}
+          repository={githubRepository}
+          existing={byId.get(linkPicker.nodeId)?.github ?? []}
+          anchor={{ x: linkPicker.x, y: linkPicker.y }}
+          onPick={(link) => {
+            onAttachNodeLink(linkPicker.nodeId, link)
+            setLinkPicker(null)
+          }}
+          onClose={() => setLinkPicker(null)}
         />
       )}
       {modalIssue && (

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -2,6 +2,7 @@ import { memo, useState } from 'react'
 import type { KanbanCardMeta, KanbanLabel, KanbanPriority } from '@shared/types'
 import { useAgentStatus } from '../../state/agentStatus'
 import { ContextMeter } from '../ContextMeter'
+import { GitHubLinkChip } from '../github/GitHubLinkChip'
 import { LabelChips } from './LabelChips'
 import type { KanbanSession } from './KanbanView'
 
@@ -128,9 +129,13 @@ export const SessionCard = memo(function SessionCard({
         )}
         {status?.unread && <span className="kanban-card__unread" />}
       </div>
-      {(labels.length > 0 || assignees.length > 0 || due !== undefined || priority !== undefined) && (
+      {(session.github?.length || labels.length > 0 || assignees.length > 0 ||
+        due !== undefined || priority !== undefined) && (
         <div className="kanban-card__metarow">
           {/* Labels share the priority/due/avatars row (left); the meta chips hug the right. */}
+          {!!session.github?.length && (
+            <GitHubLinkChip nodeId={session.id} links={session.github} variant="card" />
+          )}
           <LabelChips labels={labels} size="sm" className="kanban-card__metalabels" />
           <div className="kanban-card__metaright">
             {priority !== undefined && PRIO_COLOR[priority] && (

--- a/src/renderer/components/kanban/board-log-panel.test.tsx
+++ b/src/renderer/components/kanban/board-log-panel.test.tsx
@@ -21,6 +21,13 @@ describe('eventBody — the activity sentence', () => {
     )
   })
 
+  it('names the kind and the item for an attach / detach', () => {
+    expect(eventBody({ type: 'github-attached', to: 'pull', title: '#584 Pull cards' }))
+      .toBe('attached PR #584 Pull cards')
+    expect(eventBody({ type: 'github-detached', to: 'issue', title: '#462 Board' }))
+      .toBe('detached issue #462 Board')
+  })
+
   it('an unknown future type falls back neutrally', () => {
     expect(eventBody({ type: 'something-new' as BoardLogEvent['type'] })).toBe('updated this card')
   })

--- a/src/renderer/lib/githubLinks.test.ts
+++ b/src/renderer/lib/githubLinks.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubIssueCardView, GitHubLink } from '@shared/github-issues'
+import {
+  addLink,
+  hasLink,
+  linkChipLabel,
+  linkKey,
+  linkState,
+  linkToBoardTitle,
+  linkTooltip,
+  parseLinkInput,
+  removeLink
+} from './githubLinks'
+
+const card = (over: Partial<GitHubIssueCardView> = {}): GitHubIssueCardView => ({
+  id: 1,
+  number: 12,
+  title: 'Board',
+  body: '',
+  state: 'open',
+  stateReason: null,
+  htmlUrl: 'https://github.com/o/r/issues/12',
+  apiUrl: 'https://api.github.com/repos/o/r/issues/12',
+  labels: [],
+  assignees: [],
+  createdAt: '2026-08-01T10:00:00Z',
+  updatedAt: '2026-08-09T10:00:00Z',
+  locked: false,
+  columnId: null,
+  conflict: null,
+  ...over
+})
+
+describe('add / remove', () => {
+  const issue: GitHubLink = { kind: 'issue', number: 12 }
+
+  it('keeps issue #7 and pull #7 apart', () => {
+    expect(linkKey({ kind: 'issue', number: 7 })).not.toBe(linkKey({ kind: 'pull', number: 7 }))
+    const links = addLink([{ kind: 'issue', number: 7 }], { kind: 'pull', number: 7 })
+    expect(links).toHaveLength(2)
+  })
+
+  it('returns the same array for a duplicate, so the caller can skip the write', () => {
+    const links = [issue]
+    expect(addLink(links, { ...issue, title: 'again' })).toBe(links)
+    expect(hasLink(links, issue)).toBe(true)
+  })
+
+  it('refuses to grow past the per-node cap', () => {
+    const full = Array.from({ length: 20 }, (_, index): GitHubLink => ({ kind: 'issue', number: index + 1 }))
+    expect(addLink(full, { kind: 'issue', number: 99 })).toBe(full)
+  })
+
+  it('removes to undefined rather than an empty array', () => {
+    expect(removeLink([issue], issue)).toBeUndefined()
+    expect(removeLink([issue, { kind: 'pull', number: 3 }], issue)).toEqual([{ kind: 'pull', number: 3 }])
+    expect(removeLink(undefined, issue)).toBeUndefined()
+  })
+})
+
+describe('labels', () => {
+  it('shows the first link and how many more', () => {
+    expect(linkChipLabel([])).toBe('')
+    expect(linkChipLabel([{ kind: 'issue', number: 12 }])).toBe('#12')
+    expect(linkChipLabel([
+      { kind: 'issue', number: 12 }, { kind: 'pull', number: 3 }, { kind: 'pull', number: 4 }
+    ])).toBe('#12 +2')
+  })
+
+  it('prefers the live card title over the snapshot, and survives having neither', () => {
+    expect(linkToBoardTitle({ kind: 'issue', number: 12, title: 'stale' }, card({ title: 'live' })))
+      .toBe('#12 live')
+    expect(linkToBoardTitle({ kind: 'issue', number: 12, title: 'stale' })).toBe('#12 stale')
+    expect(linkToBoardTitle({ kind: 'issue', number: 12 })).toBe('#12')
+  })
+
+  it('tooltips one line per link', () => {
+    expect(linkTooltip(
+      [{ kind: 'issue', number: 12 }, { kind: 'pull', number: 3, title: 'Ship' }],
+      { 'issue#12': card({ title: 'live' }) }
+    )).toBe('#12 live\n#3 Ship')
+  })
+})
+
+describe('linkState', () => {
+  it('is unknown until a card is resolved', () => {
+    expect(linkState({ kind: 'issue', number: 12 })).toBe('unknown')
+  })
+
+  it('reads an issue from its state and a pull request through the pull rules', () => {
+    expect(linkState({ kind: 'issue', number: 12 }, card())).toBe('open')
+    expect(linkState({ kind: 'issue', number: 12 }, card({ state: 'closed' }))).toBe('closed')
+    const pull = { kind: 'pull', number: 12 } as const
+    expect(linkState(pull, card({ pull: { draft: true, mergedAt: null } }))).toBe('draft')
+    expect(linkState(pull, card({ state: 'closed', pull: { draft: false, mergedAt: '2026-08-09T00:00:00Z' } })))
+      .toBe('merged')
+    expect(linkState(pull, card({ state: 'closed', pull: { draft: false, mergedAt: null } }))).toBe('closed')
+  })
+})
+
+describe('parseLinkInput', () => {
+  it('reads a bare number and a hashed one, without claiming a kind', () => {
+    expect(parseLinkInput('123', 'o/r')).toEqual({ number: 123 })
+    expect(parseLinkInput(' #123 ', 'o/r')).toEqual({ number: 123 })
+  })
+
+  it('reads a github.com URL for THIS repository, with its kind', () => {
+    expect(parseLinkInput('https://github.com/o/r/issues/12', 'o/r')).toEqual({ number: 12, kind: 'issue' })
+    expect(parseLinkInput('https://github.com/O/R/pull/12#issuecomment-1', 'o/r'))
+      .toEqual({ number: 12, kind: 'pull' })
+  })
+
+  it('refuses another repository, a non-link, and #0', () => {
+    expect(parseLinkInput('https://github.com/other/repo/issues/12', 'o/r')).toBeNull()
+    expect(parseLinkInput('https://github.com/o/r/issues/12', undefined)).toBeNull()
+    expect(parseLinkInput('#0', 'o/r')).toBeNull()
+    expect(parseLinkInput('fix the board', 'o/r')).toBeNull()
+    expect(parseLinkInput('', 'o/r')).toBeNull()
+  })
+})

--- a/src/renderer/lib/githubLinks.ts
+++ b/src/renderer/lib/githubLinks.ts
@@ -4,6 +4,7 @@ import {
   type GitHubLink,
   type GitHubLinkKind
 } from '@shared/github-issues'
+import type { ProjectKanban } from '@shared/types'
 import { pullCardState } from './githubPull'
 
 /** What a linked item currently is. `unknown` is its own answer: no card has been resolved yet,
@@ -94,4 +95,20 @@ export function parseLinkInput(text: string, repository: string | undefined): Pa
   const number = Number(digits[1])
   if (!Number.isSafeInteger(number) || number <= 0) return null
   return { number }
+}
+
+const REPOSITORY = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9_.-]+$/
+
+/**
+ * The repository every link on this board resolves against, or `undefined` when the project has
+ * none — which is also the whole "is GitHub configured here?" answer for the attach affordances.
+ *
+ * Deliberately NOT `core/github/config`'s `parseGitHubRepository`: that module imports
+ * `node:crypto` and cannot run in the renderer, and it also ACCEPTS a git URL. The stored value
+ * has already been normalised to `owner/repo` by the settings write path, so this is a shape
+ * check on a value we own, not a second parser.
+ */
+export function linkRepository(kanban: ProjectKanban | undefined): string | undefined {
+  const value = kanban?.github?.repository?.trim()
+  return value && REPOSITORY.test(value) ? value : undefined
 }

--- a/src/renderer/lib/githubLinks.ts
+++ b/src/renderer/lib/githubLinks.ts
@@ -1,0 +1,97 @@
+import {
+  GITHUB_LINKS_PER_NODE_MAX,
+  type GitHubIssueCardView,
+  type GitHubLink,
+  type GitHubLinkKind
+} from '@shared/github-issues'
+import { pullCardState } from './githubPull'
+
+/** What a linked item currently is. `unknown` is its own answer: no card has been resolved yet,
+ *  which is not the same as an item nobody can find. */
+export type GitHubLinkState = 'open' | 'closed' | 'draft' | 'merged' | 'unknown'
+
+/** Identity of a link within a node. Issue #7 and pull #7 are different items — GitHub's two
+ *  spaces share one number sequence — so the kind is part of the key. */
+export function linkKey(link: Pick<GitHubLink, 'kind' | 'number'>): string {
+  return `${link.kind}#${link.number}`
+}
+
+export function hasLink(links: GitHubLink[] | undefined, link: Pick<GitHubLink, 'kind' | 'number'>): boolean {
+  return !!links?.some((entry) => entry.kind === link.kind && entry.number === link.number)
+}
+
+/** Append a link. Returns the SAME array when it changes nothing, so a caller can skip the write
+ *  (and the board-log event) on a duplicate or a full node. */
+export function addLink(links: GitHubLink[] | undefined, link: GitHubLink): GitHubLink[] {
+  const current = links ?? []
+  if (hasLink(current, link) || current.length >= GITHUB_LINKS_PER_NODE_MAX) return current
+  return [...current, link]
+}
+
+/** Remove a link. `undefined` when nothing is left — the field is absent rather than `[]`, which
+ *  is what keeps a link-less node byte-identical in the shared project file. */
+export function removeLink(
+  links: GitHubLink[] | undefined,
+  link: Pick<GitHubLink, 'kind' | 'number'>
+): GitHubLink[] | undefined {
+  const next = (links ?? []).filter((entry) => !(entry.kind === link.kind && entry.number === link.number))
+  return next.length ? next : undefined
+}
+
+export function linkState(link: GitHubLink, card?: GitHubIssueCardView): GitHubLinkState {
+  if (!card) return 'unknown'
+  if (link.kind === 'pull' || card.pull) return pullCardState(card)
+  return card.state === 'closed' ? 'closed' : 'open'
+}
+
+/** The chip's own text: the first link, plus how many more the node carries. */
+export function linkChipLabel(links: GitHubLink[]): string {
+  if (!links.length) return ''
+  const first = `#${links[0].number}`
+  return links.length > 1 ? `${first} +${links.length - 1}` : first
+}
+
+/** One line per link, live title preferred over the snapshot taken when it was attached. */
+export function linkTooltip(
+  links: GitHubLink[],
+  cards?: Record<string, GitHubIssueCardView | undefined>
+): string {
+  return links.map((link) => linkToBoardTitle(link, cards?.[linkKey(link)])).join('\n')
+}
+
+/** `#12 Title` — the label used in menus, the board-log event and the tooltip. */
+export function linkToBoardTitle(link: GitHubLink, card?: GitHubIssueCardView): string {
+  const title = card?.title ?? link.title ?? ''
+  return title ? `#${link.number} ${title}` : `#${link.number}`
+}
+
+/** What the picker's input box resolved to. The kind is absent for a bare number: only a lookup
+ *  can say which of GitHub's two spaces owns it. */
+export interface ParsedLinkInput {
+  number: number
+  kind?: GitHubLinkKind
+}
+
+const URL_PATTERN = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/(issues|pull)\/(\d+)(?:[/?#].*)?$/
+
+/**
+ * Read `#123`, `123` or a github.com issue/PR URL. A URL for ANOTHER repository is `null`, not a
+ * bare number: the link's repository is the project's, so accepting it would silently attach the
+ * same number in the wrong repo.
+ */
+export function parseLinkInput(text: string, repository: string | undefined): ParsedLinkInput | null {
+  const value = text.trim()
+  if (!value) return null
+  const url = value.match(URL_PATTERN)
+  if (url) {
+    if (!repository || url[1].toLocaleLowerCase('en-US') !== repository.toLocaleLowerCase('en-US')) return null
+    const number = Number(url[3])
+    if (!Number.isSafeInteger(number) || number <= 0) return null
+    return { number, kind: url[2] === 'pull' ? 'pull' : 'issue' }
+  }
+  const digits = value.match(/^#?(\d+)$/)
+  if (!digits) return null
+  const number = Number(digits[1])
+  if (!Number.isSafeInteger(number) || number <= 0) return null
+  return { number }
+}

--- a/src/renderer/lib/ui-visibility.test.ts
+++ b/src/renderer/lib/ui-visibility.test.ts
@@ -24,7 +24,7 @@ describe('hideable inventories', () => {
   it('list the agreed ids and nothing destructive', () => {
     expect(HIDEABLE_MENU_ITEMS.map((r) => r.id)).toEqual([
       'group', 'remove-from-group', 'colors', 'duplicate', 'snap-zone', 'collapse',
-      'markdown-view', 'refresh-terminal'
+      'markdown-view', 'refresh-terminal', 'github-attach'
     ])
     expect(HIDEABLE_HEADER_BUTTONS.map((r) => r.id)).toEqual([
       'maximize', 'refresh', 'mic', 'ai-name', 'comments', 'hide-fanout', 'tidy-fanout'

--- a/src/renderer/lib/ui-visibility.ts
+++ b/src/renderer/lib/ui-visibility.ts
@@ -26,7 +26,8 @@ export const HIDEABLE_MENU_ITEMS: readonly HideableRow[] = [
   { id: 'snap-zone', label: 'Snap to zone' },
   { id: 'collapse', label: 'Collapse / Expand' },
   { id: 'markdown-view', label: 'Markdown view' },
-  { id: 'refresh-terminal', label: 'Refresh terminal' }
+  { id: 'refresh-terminal', label: 'Refresh terminal' },
+  { id: 'github-attach', label: 'Attach GitHub issue / PR' }
 ]
 
 /** Hideable terminal node header buttons, in header order. */

--- a/src/renderer/nodes/BrowserNode.tsx
+++ b/src/renderer/nodes/BrowserNode.tsx
@@ -1,3 +1,5 @@
+import type { GitHubLink } from '@shared/github-issues'
+import { GitHubLinkChip } from '../components/github/GitHubLinkChip'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
@@ -48,6 +50,7 @@ export default function BrowserNode({ id, data, selected }: NodeProps<CanvasNode
             with the one obvious Stop. Renders nothing otherwise (and, until PR 7 ships the verb that
             drives a lease, in every case today). */}
         <BrowserDrivingIndicator nodeId={id} />
+        <GitHubLinkChip nodeId={id} links={(data.github as GitHubLink[] | undefined) ?? []} variant="node" />
         <span className="term-node__spacer" />
         <button className="term-node__close" title="Close" onClick={() => deleteElements({ nodes: [{ id }] })}>
           ×

--- a/src/renderer/nodes/GroupNode.tsx
+++ b/src/renderer/nodes/GroupNode.tsx
@@ -5,6 +5,7 @@ import { NODE_COLORS, ungroupNodes, type CanvasNode } from '../state/workspace'
 import { useProjects } from '../state/projects'
 import { useWorktrees, WORKTREE_STATUS_POLL_MS } from '../state/worktrees'
 import { useProjectSetup } from '../state/projectSetup'
+import { GitHubLinkChip } from '../components/github/GitHubLinkChip'
 
 export type WorktreeAction = 'merge' | 'remove' | 'unbind' | 'rerun-setup'
 
@@ -190,6 +191,7 @@ export function GroupNode({ id, data, selected }: NodeProps<CanvasNode>) {
           spellCheck={false}
           onChange={(e) => updateNodeData(id, { title: e.target.value })}
         />
+        <GitHubLinkChip nodeId={id} links={data.github ?? []} variant="group" />
         {wt && (
           <div className="group-node__wt nodrag">
             {stale ? (

--- a/src/renderer/nodes/StickyNode.tsx
+++ b/src/renderer/nodes/StickyNode.tsx
@@ -1,3 +1,5 @@
+import type { GitHubLink } from '@shared/github-issues'
+import { GitHubLinkChip } from '../components/github/GitHubLinkChip'
 import { useEffect, useState } from 'react'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
@@ -148,6 +150,7 @@ export function StickyNode({ id, data, selected }: NodeProps<CanvasNode>) {
             it is deliberately NOT `nodrag`, so this is the bare strip of header the note is picked
             up by. That grab area is what the permanent full-width input used to swallow. Absent
             while editing, since the input takes the `flex: 1` role itself. */}
+        <GitHubLinkChip nodeId={id} links={(data.github as GitHubLink[] | undefined) ?? []} variant="node" />
         {!editingTitle && <span className="term-node__spacer" />}
         <button
           className="term-node__close"

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -134,6 +134,8 @@ import { Tooltip } from '../components/Tooltip'
 import { useTerminalSearch } from '../terminal/useTerminalSearch'
 import { useCopyFeedback } from '../terminal/useCopyFeedback'
 import { ContextMeter } from '../components/ContextMeter'
+import type { GitHubLink } from '@shared/github-issues'
+import { GitHubLinkChip } from '../components/github/GitHubLinkChip'
 import { isZoomModifierHeld } from '../lib/zoomModifier'
 import { isHidden } from '../lib/ui-visibility'
 import { readsClaudeTranscript } from '../lib/transcriptGates'
@@ -4775,6 +4777,7 @@ export function TerminalNode({
             SSH {(data.ssh as SshConnection).user}@{(data.ssh as SshConnection).host}
           </span>
         ) : null}
+        <GitHubLinkChip nodeId={id} links={(data.github as GitHubLink[] | undefined) ?? []} variant="node" />
         {showUsage && <ContextMeter sessionId={status?.sessionId ?? null} />}
         {/* Who else is in this node. Subscribes to presence itself — see PresenceChips. */}
         <PresenceChips nodeId={id} />

--- a/src/renderer/nodes/browser-partition-parity.test.tsx
+++ b/src/renderer/nodes/browser-partition-parity.test.tsx
@@ -80,6 +80,8 @@ function partitionFromModal(sessionPartition: string | undefined): string | null
         onRename={vi.fn()}
         onEditSticky={vi.fn()}
         onBrowserNav={vi.fn()}
+          onChangeNodeLinks={vi.fn()}
+          onAttachLink={vi.fn()}
       />
     )
   )

--- a/src/renderer/state/githubIssues.test.ts
+++ b/src/renderer/state/githubIssues.test.ts
@@ -28,6 +28,8 @@ function api(): GitHubIssuesApi {
     query: vi.fn(async (request) => request.kind === 'pull'
       ? pullPage(request.columnId === 'todo' ? 200 : 300, request.columnId)
       : page(request.columnId === 'todo' ? 2 : 3, request.columnId)),
+    lookup: vi.fn(async () => ({ ok: false as const, reason: 'not-found' as const })),
+    search: vi.fn(async () => ({ items: [], partial: false })),
     refresh: vi.fn(async () => {}),
     moveIssue: vi.fn(async () => ({ status: 'configuration-changed' as const })),
     createMissingLabels: vi.fn(async () => ({ status: 'confirmed' as const, created: [], remaining: [] })),

--- a/src/renderer/state/githubIssues.ts
+++ b/src/renderer/state/githubIssues.ts
@@ -5,6 +5,7 @@ import type {
   GitHubIssuesApi,
   GitHubMutationResult
 } from '@shared/github-issues'
+import { useGitHubLinks } from './githubLinks'
 
 export interface GitHubProjectPages {
   pages: Record<string, GitHubIssuePage>
@@ -57,6 +58,14 @@ async function pageColumns(
   ] as const))
   return Object.fromEntries(pages)
 }
+/** Every card the board just paged is a card a node chip may be about to ask for one at a time. */
+function seedLinkCards(
+  projectId: string,
+  ...pages: Record<string, GitHubIssuePage>[]
+): void {
+  useGitHubLinks.getState().seedFromPages(projectId, pages.flatMap((record) => Object.values(record)))
+}
+
 let nextConnectionGeneration = 0
 
 type HostSubscription = {
@@ -133,8 +142,12 @@ export const useGitHubIssues = create<GitHubIssuesState>((set, get) => ({
     }))
     let live = true
     let releaseHost: (() => void) | undefined
-    const changed = api.onChanged(projectId, () => {
-      if (live && ownsConnection()) void get().reload(api, projectId)
+    const changed = api.onChanged(projectId, (changedIssueNumbers) => {
+      if (!live || !ownsConnection()) return
+      useGitHubLinks.getState().invalidate(
+        projectId, changedIssueNumbers.length ? changedIssueNumbers : undefined
+      )
+      void get().reload(api, projectId)
     })
     const teardown = (): void => {
       if (!live) return
@@ -162,6 +175,7 @@ export const useGitHubIssues = create<GitHubIssuesState>((set, get) => ({
         pageColumns(api, projectId, [null, ...columns], labelFilter, 'issue'),
         pageColumns(api, projectId, [null, ...columns], labelFilter, 'pull')
       ])
+      seedLinkCards(projectId, columnPages, columnPullPages)
       set((state) => state.projects[projectId]?.generation === generation &&
         state.projects[projectId]?.loadGeneration === loadGeneration ? ({
         projects: {
@@ -221,6 +235,7 @@ export const useGitHubIssues = create<GitHubIssuesState>((set, get) => ({
         pageColumns(api, projectId, [null, ...current.columns], current.labelFilter, 'issue'),
         pageColumns(api, projectId, [null, ...current.columns], current.labelFilter, 'pull')
       ])
+      seedLinkCards(projectId, pages, pullPages)
       set((state) => {
         const existing = state.projects[projectId]
         if (existing?.generation !== generation || existing.loadGeneration !== loadGeneration) return state

--- a/src/renderer/state/githubLinks.test.ts
+++ b/src/renderer/state/githubLinks.test.ts
@@ -33,7 +33,7 @@ function api(lookup: (number: number) => Promise<GitHubLookupResult>): {
   return {
     calls,
     api: {
-      lookup: async ({ number }) => { calls.push(number); return lookup(number) }
+      lookup: async ({ number }: { number: number }) => { calls.push(number); return lookup(number) }
     } as unknown as GitHubIssuesApi
   }
 }

--- a/src/renderer/state/githubLinks.test.ts
+++ b/src/renderer/state/githubLinks.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  GitHubIssueCardView,
+  GitHubIssuesApi,
+  GitHubLookupResult
+} from '@shared/github-issues'
+import { LINK_CARD_TTL_MS, LINK_RETRY_MS, linkCard, useGitHubLinks } from './githubLinks'
+
+const card = (number: number, over: Partial<GitHubIssueCardView> = {}): GitHubIssueCardView => ({
+  id: number,
+  number,
+  title: `Item ${number}`,
+  body: '',
+  state: 'open',
+  stateReason: null,
+  htmlUrl: `https://github.com/o/r/issues/${number}`,
+  apiUrl: `https://api.github.com/repos/o/r/issues/${number}`,
+  labels: [],
+  assignees: [],
+  createdAt: '2026-08-01T10:00:00Z',
+  updatedAt: '2026-08-09T10:00:00Z',
+  locked: false,
+  columnId: null,
+  conflict: null,
+  ...over
+})
+
+function api(lookup: (number: number) => Promise<GitHubLookupResult>): {
+  api: GitHubIssuesApi
+  calls: number[]
+} {
+  const calls: number[] = []
+  return {
+    calls,
+    api: {
+      lookup: async ({ number }) => { calls.push(number); return lookup(number) }
+    } as unknown as GitHubIssuesApi
+  }
+}
+
+beforeEach(() => {
+  vi.useRealTimers()
+  useGitHubLinks.setState({ cards: {}, pending: {}, missing: {}, gate: {} })
+})
+
+describe('ensureCard', () => {
+  it('resolves once and then serves the cache for the whole freshness window', async () => {
+    const { api: client, calls } = api(async (number) => ({ ok: true, source: 'api', item: card(number) }))
+    const link = { kind: 'issue' as const, number: 12 }
+    await useGitHubLinks.getState().ensureCard(client, 'p1', link)
+    await useGitHubLinks.getState().ensureCard(client, 'p1', link)
+    expect(calls).toEqual([12])
+    expect(linkCard('p1', link)?.title).toBe('Item 12')
+  })
+
+  it('coalesces concurrent asks for the same link', async () => {
+    let release!: (value: GitHubLookupResult) => void
+    const { api: client, calls } = api(() => new Promise<GitHubLookupResult>((resolve) => { release = resolve }))
+    const link = { kind: 'issue' as const, number: 12 }
+    const first = useGitHubLinks.getState().ensureCard(client, 'p1', link)
+    const second = useGitHubLinks.getState().ensureCard(client, 'p1', link)
+    release({ ok: true, source: 'api', item: card(12) })
+    await Promise.all([first, second])
+    expect(calls).toEqual([12])
+  })
+
+  it('caches the answer under the kind the ITEM reports, not the kind that was asked for', async () => {
+    const { api: client } = api(async (number) => ({
+      ok: true, source: 'api', item: card(number, { pull: { draft: false, mergedAt: null } })
+    }))
+    await useGitHubLinks.getState().ensureCard(client, 'p1', { kind: 'issue', number: 12 })
+    expect(linkCard('p1', { kind: 'pull', number: 12 })?.number).toBe(12)
+    expect(linkCard('p1', { kind: 'issue', number: 12 })).toBeUndefined()
+  })
+
+  it('remembers a miss for the retry window instead of re-asking per chip', async () => {
+    const { api: client, calls } = api(async () => ({ ok: false, reason: 'not-found' }))
+    const link = { kind: 'issue' as const, number: 77 }
+    await useGitHubLinks.getState().ensureCard(client, 'p1', link)
+    await useGitHubLinks.getState().ensureCard(client, 'p1', link)
+    expect(calls).toEqual([77])
+    expect(useGitHubLinks.getState().missing.p1['issue#77']).toBeGreaterThan(0)
+  })
+
+  it('a project-wide refusal gates every other link, and lapses after the retry window', async () => {
+    const { api: client, calls } = api(async () => ({ ok: false, reason: 'not-approved' }))
+    await useGitHubLinks.getState().ensureCard(client, 'p1', { kind: 'issue', number: 1 })
+    await useGitHubLinks.getState().ensureCard(client, 'p1', { kind: 'issue', number: 2 })
+    expect(calls).toEqual([1])
+    expect(useGitHubLinks.getState().gate.p1.reason).toBe('not-approved')
+
+    useGitHubLinks.setState((s) => ({
+      gate: { ...s.gate, p1: { reason: 'not-approved', at: Date.now() - LINK_RETRY_MS - 1 } }
+    }))
+    await useGitHubLinks.getState().ensureCard(client, 'p1', { kind: 'issue', number: 2 })
+    expect(calls).toEqual([1, 2])
+  })
+
+  it('re-asks a stale card once the freshness window has passed', async () => {
+    const { api: client, calls } = api(async (number) => ({ ok: true, source: 'api', item: card(number) }))
+    const link = { kind: 'issue' as const, number: 12 }
+    await useGitHubLinks.getState().ensureCard(client, 'p1', link)
+    useGitHubLinks.setState((s) => ({
+      cards: { ...s.cards, p1: { 'issue#12': { card: card(12), at: Date.now() - LINK_CARD_TTL_MS - 1 } } }
+    }))
+    await useGitHubLinks.getState().ensureCard(client, 'p1', link)
+    expect(calls).toEqual([12, 12])
+  })
+
+  it('leaves nothing pending when the lookup itself rejects', async () => {
+    const { api: client } = api(async () => { throw new Error('offline') })
+    await useGitHubLinks.getState().ensureCard(client, 'p1', { kind: 'issue', number: 12 })
+    expect(useGitHubLinks.getState().pending.p1['issue#12']).toBeUndefined()
+  })
+})
+
+describe('seedFromPages / invalidate', () => {
+  it('warms cards from a board load', () => {
+    useGitHubLinks.getState().seedFromPages('p1', [
+      { items: [card(1), card(2, { pull: { draft: false, mergedAt: null } })], counts: {}, partial: false, readOnly: false }
+    ])
+    expect(linkCard('p1', { kind: 'issue', number: 1 })?.number).toBe(1)
+    expect(linkCard('p1', { kind: 'pull', number: 2 })?.number).toBe(2)
+  })
+
+  it('drops only the numbers a delta named, and everything when it names none', () => {
+    useGitHubLinks.getState().seedFromPages('p1', [
+      { items: [card(1), card(2)], counts: {}, partial: false, readOnly: false }
+    ])
+    useGitHubLinks.getState().invalidate('p1', [1])
+    expect(linkCard('p1', { kind: 'issue', number: 1 })).toBeUndefined()
+    expect(linkCard('p1', { kind: 'issue', number: 2 })?.number).toBe(2)
+
+    useGitHubLinks.setState((s) => ({ gate: { ...s.gate, p1: { reason: 'not-approved', at: Date.now() } } }))
+    useGitHubLinks.getState().invalidate('p1')
+    expect(linkCard('p1', { kind: 'issue', number: 2 })).toBeUndefined()
+    expect(useGitHubLinks.getState().gate.p1).toBeUndefined()
+  })
+})

--- a/src/renderer/state/githubLinks.ts
+++ b/src/renderer/state/githubLinks.ts
@@ -1,0 +1,140 @@
+import { create } from 'zustand'
+import type {
+  GitHubIssueCardView,
+  GitHubIssuePage,
+  GitHubIssuesApi,
+  GitHubLink
+} from '@shared/github-issues'
+import { linkKey } from '../lib/githubLinks'
+
+/** How long a resolved card is considered fresh enough for a chip's status dot. A canvas chip has
+ *  no host subscription (the board's is ref-counted and lives with the board), so this bound IS
+ *  the freshness guarantee: last lookup within the window, or the last board open. */
+export const LINK_CARD_TTL_MS = 5 * 60_000
+/** A number that resolves to nothing, and a project whose GitHub is refused, are both re-asked
+ *  after this — long enough that a canvas full of chips does not hammer the host. */
+export const LINK_RETRY_MS = 60_000
+
+/** A refusal that applies to the whole project, not to one number: one gate stops a dozen chips
+ *  asking the same unanswerable question. */
+export type LinkGate = 'not-approved' | 'not-authenticated'
+
+interface CardEntry {
+  card: GitHubIssueCardView
+  at: number
+}
+
+interface GitHubLinksState {
+  cards: Record<string, Record<string, CardEntry>>
+  pending: Record<string, Record<string, true>>
+  missing: Record<string, Record<string, number>>
+  gate: Record<string, { reason: LinkGate; at: number }>
+  ensureCard(api: GitHubIssuesApi, projectId: string, link: GitHubLink): Promise<void>
+  seedFromPages(projectId: string, pages: GitHubIssuePage[]): void
+  invalidate(projectId: string, numbers?: number[]): void
+}
+
+const now = (): number => Date.now()
+
+export const useGitHubLinks = create<GitHubLinksState>((set, get) => ({
+  cards: {},
+  pending: {},
+  missing: {},
+  gate: {},
+
+  async ensureCard(api, projectId, link) {
+    const key = linkKey(link)
+    const state = get()
+    const gate = state.gate[projectId]
+    if (gate && now() - gate.at < LINK_RETRY_MS) return
+    if (state.pending[projectId]?.[key]) return
+    const cached = state.cards[projectId]?.[key]
+    if (cached && now() - cached.at < LINK_CARD_TTL_MS) return
+    const missedAt = state.missing[projectId]?.[key]
+    if (missedAt !== undefined && now() - missedAt < LINK_RETRY_MS) return
+    set((s) => ({
+      pending: { ...s.pending, [projectId]: { ...s.pending[projectId], [key]: true } }
+    }))
+    try {
+      const result = await api.lookup({ projectId, number: link.number })
+      set((s) => {
+        const pending = { ...s.pending[projectId] }
+        delete pending[key]
+        const next: Partial<GitHubLinksState> = {
+          pending: { ...s.pending, [projectId]: pending }
+        }
+        if (result.ok) {
+          // The lookup is BY NUMBER, so the answer may be the other kind: keying it by the item's
+          // own kind is what stops a pull request being cached as the issue chip's card.
+          const answerKey = linkKey({ kind: result.item.pull ? 'pull' : 'issue', number: result.item.number })
+          next.cards = {
+            ...s.cards,
+            [projectId]: { ...s.cards[projectId], [answerKey]: { card: result.item, at: now() } }
+          }
+        } else if (result.reason === 'not-approved' || result.reason === 'not-authenticated') {
+          next.gate = { ...s.gate, [projectId]: { reason: result.reason, at: now() } }
+        } else if (result.reason === 'not-found') {
+          next.missing = {
+            ...s.missing,
+            [projectId]: { ...s.missing[projectId], [key]: now() }
+          }
+        }
+        return next as GitHubLinksState
+      })
+    } catch {
+      set((s) => {
+        const pending = { ...s.pending[projectId] }
+        delete pending[key]
+        return { pending: { ...s.pending, [projectId]: pending } }
+      })
+    }
+  },
+
+  /** Warm every chip from a board load: the pages the board just paged are the same items a chip
+   *  would ask for one at a time. Free — nothing is fetched here. */
+  seedFromPages(projectId, pages) {
+    const at = now()
+    const entries: Record<string, CardEntry> = {}
+    for (const page of pages) {
+      for (const item of page.items) {
+        entries[linkKey({ kind: item.pull ? 'pull' : 'issue', number: item.number })] = { card: item, at }
+      }
+    }
+    if (!Object.keys(entries).length) return
+    set((s) => ({
+      cards: { ...s.cards, [projectId]: { ...s.cards[projectId], ...entries } }
+    }))
+  },
+
+  /** Drop what a host delta invalidated. No numbers = the whole project (a cache clear, a
+   *  configuration change), including the gate — the refusal may be what just changed. */
+  invalidate(projectId, numbers) {
+    set((s) => {
+      if (!numbers) {
+        const cards = { ...s.cards }
+        const missing = { ...s.missing }
+        const gate = { ...s.gate }
+        delete cards[projectId]
+        delete missing[projectId]
+        delete gate[projectId]
+        return { cards, missing, gate }
+      }
+      const wanted = new Set(numbers)
+      const drop = (record: Record<string, unknown> | undefined): Record<string, never> =>
+        Object.fromEntries(Object.entries(record ?? {})
+          .filter(([key]) => !wanted.has(Number(key.split('#')[1])))) as Record<string, never>
+      return {
+        cards: { ...s.cards, [projectId]: drop(s.cards[projectId]) as Record<string, CardEntry> },
+        missing: { ...s.missing, [projectId]: drop(s.missing[projectId]) as Record<string, number> }
+      }
+    })
+  }
+}))
+
+/** The card a chip should paint with, or undefined while none is known. */
+export function linkCard(
+  projectId: string,
+  link: Pick<GitHubLink, 'kind' | 'number'>
+): GitHubIssueCardView | undefined {
+  return useGitHubLinks.getState().cards[projectId]?.[linkKey(link)]?.card
+}

--- a/src/renderer/state/workspace.github-links.test.ts
+++ b/src/renderer/state/workspace.github-links.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubLink } from '@shared/github-issues'
+import type { CanvasNodeState, NodeKind } from '@shared/types'
+import { flowToNodeStates, nodeStatesToFlow } from './workspace'
+
+const links: GitHubLink[] = [
+  { kind: 'issue', number: 462, title: 'Board' },
+  { kind: 'pull', number: 584 }
+]
+
+const state = (kind: NodeKind): CanvasNodeState => ({
+  id: `${kind}-a-1`,
+  kind,
+  position: { x: 5, y: 6 },
+  size: { width: 300, height: 170 },
+  title: 'Work',
+  color: '#888',
+  group: null,
+  github: links
+})
+
+describe('github link serialization', () => {
+  for (const kind of ['terminal', 'sticky', 'browser', 'group'] as NodeKind[]) {
+    it(`round-trips links on a ${kind} node`, () => {
+      const [flow] = nodeStatesToFlow([state(kind)])
+      expect(flow.data.github).toEqual(links)
+      const [back] = flowToNodeStates([flow])
+      expect(back.kind).toBe(kind)
+      expect(back.github).toEqual(links)
+    })
+  }
+
+  it('leaves a node without links undefined in both directions', () => {
+    const plain = state('terminal')
+    delete plain.github
+    const [flow] = nodeStatesToFlow([plain])
+    expect(flow.data.github).toBeUndefined()
+    expect(flowToNodeStates([flow])[0].github).toBeUndefined()
+  })
+})

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -173,6 +173,11 @@ export interface NodeData {
    * the machine-local arm store's question, never this field's. See @shared/trigger.
    */
   trigger?: import('@shared/trigger').TriggerSpec
+  /**
+   * The GitHub issues / pull requests the user explicitly attached to this node (issue #462).
+   * Persisted git-shared content; the repository is the project's, never stored per link.
+   */
+  github?: import('@shared/github-issues').GitHubLink[]
   [key: string]: unknown
 }
 
@@ -1818,7 +1823,8 @@ export function nodeStatesToFlow(states: CanvasNodeState[]): CanvasNode[] {
         sshRemoteTmux: n.sshRemoteTmux,
         sshFs: n.sshFs,
         worktree: n.worktree,
-        trigger: n.trigger
+        trigger: n.trigger,
+        github: n.github
       }
     }
   })
@@ -1892,6 +1898,7 @@ export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
         sshFs: n.data.sshFs,
         worktree: n.data.worktree,
         trigger: n.data.trigger,
+        github: n.data.github,
         premaxRect: n.data.premaxRect
       }
     })

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1433,6 +1433,110 @@ body,
   background: rgba(255, 159, 10, 0.16);
 }
 
+/* Explicit GitHub link chip (issue #462) — the node's own claim on an issue / PR. Same size and
+   idiom as the account chip beside it; the dot carries the item's state. */
+.github-link-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: 8px;
+  max-width: 130px;
+  padding: 1px 8px;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+}
+
+.term-node--collapsed .github-link-chip {
+  max-width: 64px;
+}
+
+.github-link-chip--card,
+.github-link-chip--modal {
+  margin-left: 0;
+}
+
+.github-link-chip__dot {
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.github-link-chip__dot--open { background: var(--success); }
+.github-link-chip__dot--draft { background: var(--muted); }
+.github-link-chip__dot--merged { background: #bf5af2; }
+.github-link-chip__dot--closed { background: var(--danger, #ff453a); }
+.github-link-chip__dot--unknown { background: rgba(255, 255, 255, 0.25); }
+
+.github-link-picker {
+  width: 340px;
+  max-height: 360px;
+  display: flex;
+  flex-direction: column;
+}
+
+.github-link-picker__filter {
+  margin: 4px;
+}
+
+.github-link-picker__list {
+  overflow-y: auto;
+}
+
+.github-link-picker__list button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}
+
+.github-link-picker__num {
+  flex-shrink: 0;
+  color: var(--muted);
+}
+
+.github-link-picker__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-link-picker__badge {
+  margin-left: auto;
+  padding: 0 5px;
+  font-size: 9.5px;
+  font-weight: 700;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+}
+
+.github-link-picker__note,
+.github-link-picker__foot {
+  padding: 6px 8px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.kanban-meta__ghlink {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.kanban-meta__ghlink a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
 /* Claude Code status: RUNNING badge while working, unread dot when finished. */
 .term-node__status {
   display: inline-flex;

--- a/src/shared/github-issues.ts
+++ b/src/shared/github-issues.ts
@@ -175,6 +175,36 @@ export interface GitHubIssueQuery {
   labelFilter?: string[]
 }
 
+export interface GitHubLookupRequest {
+  projectId: string
+  number: number
+}
+
+/** Why `lookup` answers with a value instead of throwing: both transports between core and the
+ *  chip flatten a typed error into a message, and the UI must render `not-approved` as a disabled
+ *  row rather than as a failure. */
+export type GitHubLookupResult =
+  | { ok: true; item: GitHubIssueCardView; source: 'cache' | 'api' }
+  | {
+      ok: false
+      reason: 'not-found' | 'not-approved' | 'not-authenticated' | 'configuration-changed' |
+        'invalid-request' | 'failed'
+      message?: string
+    }
+
+export interface GitHubSearchRequest {
+  projectId: string
+  search: string
+  /** Absent = BOTH kinds, unlike `GitHubIssueQuery.kind`. */
+  kind?: 'issue' | 'pull'
+  limit: number
+}
+
+export interface GitHubSearchResult {
+  items: GitHubIssueCardView[]
+  partial: boolean
+}
+
 export interface GitHubIssuePage {
   items: GitHubIssueCardView[]
   counts: Record<string, number>
@@ -218,6 +248,10 @@ export interface GitHubIssuesApi {
   subscribe(projectId: string): Promise<GitHubIssuePage>
   unsubscribe(projectId: string): Promise<void>
   query(request: GitHubIssueQuery): Promise<GitHubIssuePage>
+  /** Resolve one attached link by number. Never throws for a refusal — see `GitHubLookupResult`. */
+  lookup(request: GitHubLookupRequest): Promise<GitHubLookupResult>
+  /** Search the cached snapshot across every column, for the attach picker. Never hits the network. */
+  search(request: GitHubSearchRequest): Promise<GitHubSearchResult>
   refresh(projectId: string, full?: boolean): Promise<void>
   moveIssue(request: {
     projectId: string

--- a/src/shared/github-issues.ts
+++ b/src/shared/github-issues.ts
@@ -143,6 +143,26 @@ export interface GitHubIssueCardView extends GitHubIssue {
   avatarDataUrls?: Record<string, string>
 }
 
+/** A node's explicit link to a GitHub issue or pull request.
+ *
+ *  The relationship exists ONLY because the user made it (issue #462): nothing is inferred from
+ *  terminal output, transcripts or a branch name. Repository is implicit — the project's
+ *  `kanban.github.repository` — so a link that travels in a git-shared `.nodeterm/project.json`
+ *  resolves against THAT project's repository, never a stale slug. The github.com URL is derived
+ *  (`githubLinkUrl`), never stored. */
+export type GitHubLinkKind = 'issue' | 'pull'
+
+export interface GitHubLink {
+  kind: GitHubLinkKind
+  number: number
+  /** Display snapshot taken when the link was made. Goes stale after a rename on GitHub, so every
+   *  reader prefers the live card and falls back to this only while none is cached. */
+  title?: string
+}
+
+export const GITHUB_LINK_TITLE_MAX = 200
+export const GITHUB_LINKS_PER_NODE_MAX = 20
+
 export interface GitHubIssueQuery {
   projectId: string
   /** Which kind of item to page. Absent = `'issue'`, so a caller that predates pull requests

--- a/src/shared/github-link.test.ts
+++ b/src/shared/github-link.test.ts
@@ -13,6 +13,7 @@ const node = (github: unknown): CanvasNodeState => ({
   size: { width: 10, height: 10 },
   title: 't',
   color: '#fff',
+  group: null,
   github: github as CanvasNodeState['github']
 })
 

--- a/src/shared/github-link.test.ts
+++ b/src/shared/github-link.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import type { CanvasNodeState } from './types'
+import {
+  githubLinkUrl,
+  sanitizeGitHubLinks,
+  sanitizeNodeGitHubLinks
+} from './github-link'
+
+const node = (github: unknown): CanvasNodeState => ({
+  id: 'n1',
+  kind: 'terminal',
+  position: { x: 0, y: 0 },
+  size: { width: 10, height: 10 },
+  title: 't',
+  color: '#fff',
+  github: github as CanvasNodeState['github']
+})
+
+describe('sanitizeGitHubLinks', () => {
+  it('keeps well-formed entries and rebuilds them with only the three known keys', () => {
+    expect(sanitizeGitHubLinks([
+      { kind: 'issue', number: 12, title: 'Fix it', extra: 'smuggled' },
+      { kind: 'pull', number: 3 }
+    ])).toEqual([
+      { kind: 'issue', number: 12, title: 'Fix it' },
+      { kind: 'pull', number: 3 }
+    ])
+  })
+
+  it('drops a non-array, and an array with nothing valid in it', () => {
+    expect(sanitizeGitHubLinks(undefined)).toBeUndefined()
+    expect(sanitizeGitHubLinks({ kind: 'issue', number: 1 })).toBeUndefined()
+    expect(sanitizeGitHubLinks([])).toBeUndefined()
+    expect(sanitizeGitHubLinks([{ kind: 'commit', number: 1 }])).toBeUndefined()
+  })
+
+  it('drops entries with an unknown kind or an unusable number', () => {
+    expect(sanitizeGitHubLinks([
+      { kind: 'commit', number: 1 },
+      { kind: 'issue', number: -1 },
+      { kind: 'issue', number: 0 },
+      { kind: 'issue', number: 1.5 },
+      { kind: 'issue', number: '2' },
+      null,
+      ['issue', 3],
+      { kind: 'issue', number: 4 }
+    ])).toEqual([{ kind: 'issue', number: 4 }])
+  })
+
+  it('drops only the title when it is unusable, never the link', () => {
+    const long = 'x'.repeat(201)
+    expect(sanitizeGitHubLinks([
+      { kind: 'issue', number: 1, title: 7 },
+      { kind: 'issue', number: 2, title: '   ' },
+      { kind: 'issue', number: 3, title: long },
+      { kind: 'issue', number: 4, title: '  padded  ' }
+    ])).toEqual([
+      { kind: 'issue', number: 1 },
+      { kind: 'issue', number: 2 },
+      { kind: 'issue', number: 3 },
+      { kind: 'issue', number: 4, title: 'padded' }
+    ])
+  })
+
+  it('dedupes by kind and number, first wins, and keeps issue #7 apart from pull #7', () => {
+    expect(sanitizeGitHubLinks([
+      { kind: 'issue', number: 7, title: 'first' },
+      { kind: 'issue', number: 7, title: 'second' },
+      { kind: 'pull', number: 7 }
+    ])).toEqual([
+      { kind: 'issue', number: 7, title: 'first' },
+      { kind: 'pull', number: 7 }
+    ])
+  })
+
+  it('caps at 20 entries', () => {
+    const many = Array.from({ length: 50 }, (_, index) => ({ kind: 'issue', number: index + 1 }))
+    expect(sanitizeGitHubLinks(many)).toHaveLength(20)
+    expect(sanitizeGitHubLinks(many)?.at(-1)).toEqual({ kind: 'issue', number: 20 })
+  })
+})
+
+describe('sanitizeNodeGitHubLinks', () => {
+  it('leaves a node without links untouched by identity', () => {
+    const clean: CanvasNodeState = { ...node(undefined) }
+    delete clean.github
+    expect(sanitizeNodeGitHubLinks([clean])[0]).toBe(clean)
+  })
+
+  it('removes the key entirely when nothing survives', () => {
+    const [out] = sanitizeNodeGitHubLinks([node([{ kind: 'commit', number: 1 }])])
+    expect('github' in out).toBe(false)
+  })
+
+  it('normalizes links on a group frame too — there is no kind gate', () => {
+    const frame = { ...node([{ kind: 'pull', number: 9, title: 'Ship' }]), kind: 'group' as const }
+    expect(sanitizeNodeGitHubLinks([frame])[0].github).toEqual([
+      { kind: 'pull', number: 9, title: 'Ship' }
+    ])
+  })
+})
+
+describe('githubLinkUrl', () => {
+  it('routes issues and pull requests to their own path segment', () => {
+    expect(githubLinkUrl('o/r', { kind: 'issue', number: 12 }))
+      .toBe('https://github.com/o/r/issues/12')
+    expect(githubLinkUrl('o/r', { kind: 'pull', number: 12 }))
+      .toBe('https://github.com/o/r/pull/12')
+  })
+
+  it('is empty without a repository', () => {
+    expect(githubLinkUrl(undefined, { kind: 'issue', number: 1 })).toBe('')
+    expect(githubLinkUrl('', { kind: 'issue', number: 1 })).toBe('')
+  })
+})

--- a/src/shared/github-link.ts
+++ b/src/shared/github-link.ts
@@ -1,0 +1,68 @@
+import {
+  GITHUB_LINK_TITLE_MAX,
+  GITHUB_LINKS_PER_NODE_MAX,
+  type GitHubLink,
+  type GitHubLinkKind
+} from './github-issues'
+import type { CanvasNodeState } from './types'
+
+const KINDS = new Set<string>(['issue', 'pull'])
+
+function plainObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+/**
+ * Normalize the `github` array of a node crossing the shared-file boundary, in BOTH directions
+ * (`sanitizeNodeTriggers` is the precedent). `.nodeterm/project.json` is git-shared and
+ * hand-editable, so every field is hostile input: a bad entry is dropped, a bad title drops while
+ * the link survives, and the whole array degrades to `undefined` rather than throwing anywhere
+ * downstream. The rebuilt objects carry only the three known keys, so a smuggled extra key cannot
+ * ride into the live nodes or back out to disk.
+ */
+export function sanitizeGitHubLinks(value: unknown): GitHubLink[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const out: GitHubLink[] = []
+  const seen = new Set<string>()
+  for (const candidate of value) {
+    if (out.length >= GITHUB_LINKS_PER_NODE_MAX) break
+    const entry = plainObject(candidate)
+    if (!entry) continue
+    const kind = entry.kind
+    if (typeof kind !== 'string' || !KINDS.has(kind)) continue
+    const number = entry.number
+    if (typeof number !== 'number' || !Number.isSafeInteger(number) || number <= 0) continue
+    const key = `${kind}#${number}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    const rawTitle = entry.title
+    const title = typeof rawTitle === 'string' ? rawTitle.trim() : ''
+    out.push({
+      kind: kind as GitHubLinkKind,
+      number,
+      ...(title && title.length <= GITHUB_LINK_TITLE_MAX ? { title } : {})
+    })
+  }
+  return out.length ? out : undefined
+}
+
+/** `sanitizeGitHubLinks` over a whole node array. Unlike triggers there is no kind gate: any node
+ *  kind may carry links (a group frame does, which is what phase 3b's suggestion attaches to). */
+export function sanitizeNodeGitHubLinks(nodes: CanvasNodeState[]): CanvasNodeState[] {
+  return nodes.map((n) => {
+    if (n.github === undefined) return n
+    const safe = sanitizeGitHubLinks(n.github)
+    if (safe) return { ...n, github: safe }
+    const { github: _dropped, ...rest } = n
+    return rest
+  })
+}
+
+/** The link's page on github.com. Empty string when the project has no repository — the caller
+ *  must not offer "Open on GitHub" without one. */
+export function githubLinkUrl(repository: string | undefined, link: GitHubLink): string {
+  if (!repository) return ''
+  return `https://github.com/${repository}/${link.kind === 'pull' ? 'pull' : 'issues'}/${link.number}`
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -352,6 +352,8 @@ export const IPC = {
   githubIssuesSubscribe: 'githubIssues:subscribe',
   githubIssuesUnsubscribe: 'githubIssues:unsubscribe',
   githubIssuesQuery: 'githubIssues:query',
+  githubIssuesLookup: 'githubIssues:lookup',
+  githubIssuesSearch: 'githubIssues:search',
   githubIssuesRefresh: 'githubIssues:refresh',
   githubIssuesMove: 'githubIssues:move',
   githubIssuesCreateLabels: 'githubIssues:create-labels',

--- a/src/shared/node-exec.test.ts
+++ b/src/shared/node-exec.test.ts
@@ -140,6 +140,19 @@ describe('sanitizeInboundNode / sanitizeInboundMutation (canvas-sync peers)', ()
     expect(clean.title).toBe('theirs')
   })
 
+  it('normalizes a peer node\'s github links instead of laundering them into our nodes', () => {
+    const peer = node({
+      github: [
+        { kind: 'issue', number: 12, title: 'ok' },
+        { kind: 'commit', number: 1 },
+        ...Array.from({ length: 40 }, (_, index) => ({ kind: 'pull', number: index + 100 }))
+      ] as never
+    })
+    const clean = sanitizeInboundNode(peer)
+    expect(clean.github).toHaveLength(20)
+    expect(clean.github?.[0]).toEqual({ kind: 'issue', number: 12, title: 'ok' })
+  })
+
   it('a peer cannot forge the provenance marker itself', () => {
     const peer = node({
       ssh: { host: 'h', user: 'u', extraArgs: '-o ProxyCommand=evil', execTrusted: true }

--- a/src/shared/node-exec.ts
+++ b/src/shared/node-exec.ts
@@ -26,6 +26,7 @@
  * a program string carrying shell metacharacters is never handed to tmux.
  */
 
+import { sanitizeNodeGitHubLinks } from './github-link'
 import { sshExtraArgsEnableLocalExec } from './ssh'
 import type { CanvasNodeState } from './types'
 
@@ -101,7 +102,10 @@ export function stripSharedNodeExec(nodes: CanvasNodeState[]): CanvasNodeState[]
  * is merely being mirrored. So they are dropped at ingest, on every surface.
  */
 export function sanitizeInboundNode(node: CanvasNodeState): CanvasNodeState {
-  return stripNodeExec(node)
+  // `github` is shared content a peer legitimately mutates, so it is normalized rather than
+  // dropped — a wire frame is as hostile as the file, and an unbounded array would ride into our
+  // nodes and back out to disk.
+  return sanitizeNodeGitHubLinks([stripNodeExec(node)])[0]
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -584,6 +584,12 @@ export interface BoardLogEvent {
      *  agent node so it files under that agent's card. Written BEFORE the read (fail-closed): a cookie
      *  read that happened but was not recorded is the one outcome this trace exists to prevent. */
     | 'agent-read-cookies'
+    /** A GitHub issue / pull request was explicitly attached to (or detached from) a node
+     *  (issue #462). `to` is the link's kind, `title` its `#n Title` at the time. Written at the
+     *  write site, like `card-created`: `boardLogDiff` diffs the kanban only and cannot see a
+     *  node-data change. */
+    | 'github-attached'
+    | 'github-detached'
   from?: string
   to?: string
   /** Column title for column-added/deleted; card title for card-created; outcome for agent-message. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -393,6 +393,14 @@ export interface CanvasNodeState {
   /** group-only: when bound, the git worktree this group works in. */
   worktree?: GroupWorktree
   /**
+   * The GitHub issues / pull requests the user explicitly attached to this node (issue #462).
+   * Git-shared CONTENT — the team shares which session works on which issue — and therefore
+   * hostile input on every load path (`sanitizeNodeGitHubLinks` in @shared/github-link, applied in
+   * BOTH directions). The repository is implicit (`kanban.github.repository`), so nothing here
+   * pins a slug; a link is never inferred, only made by a click.
+   */
+  github?: import('./github-issues').GitHubLink[]
+  /**
    * trigger-only: the schedule + payload + target this node represents (issue #493). Git-shared
    * CONTENT — deliberately, the team shares the definition — which is exactly why it is treated
    * as hostile on every load path (`sanitizeNodeTriggers` in core/workspace-files) and why the


### PR DESCRIPTION
Phase 3a of #462: a node can be attached to a GitHub issue or pull request, explicitly.

**The rule this is built on:** a link exists only because the user made it. Nothing is inferred from terminal output, a transcript, or a branch name — so there is no path here that can put a wrong chip on someone's canvas.

### What to review

- **Storage is node data.** `CanvasNodeState.github?: GitHubLink[]` (kind + number + a title *snapshot*). The repository is the project's and is never stored per link, so the same committed `project.json` resolves correctly in any clone. It is git-shared content, so `sanitizeNodeGitHubLinks` runs on every crossing in **both** directions, exactly like `sanitizeNodeTriggers` — plus at the canvas-sync inbound hook.
- **`lookup` reports refusals as VALUES, not throws.** Electron `invoke` and the ws-bridge's `RpcErr` both flatten a typed code, and the picker has to render `not-approved` as a disabled row rather than as a failure.
- **`search` is a method, not a `columnId` sentinel on `query`.** A sentinel would collide with a real column id, leak into the `counts` keys and the relay jail's shape, and force every existing `query` caller to handle a third state. `query` and `search` share the new column-blind `candidates`, so `query`'s output is unchanged — its existing tests pass untouched.
- **`getIssue` still refuses a pull request.** `moveIssue` relies on that guard; `getIssueOrPull` is an opt-in sibling for the one caller that wants either kind.
- **One write funnel.** `setNodeGitHubLinks` in Canvas does the node write, the dirty mark and the board-log event together; every surface (node menu, group frame, board card, card modal, metadata strip) reaches it through a module bridge, the same indirection `setWorktreeActionHandler` uses.

Canvas chips deliberately hold no host subscription — freshness is the 5-minute lookup TTL plus whatever the last board open seeded. Documented; a later phase can hold one while a chip is visible.

Surfaces: Desktop and Server Edition both work (the handlers are registered by `registerGitHubIntegration`, which both shells boot). Relay guests are jailed to the shared project in the same commit as the channels. **Mobile: N/A** — the agent-status mirror carries no node data. cc @eneskirca for the mobile call.

<details>
<summary>Tests</summary>

New: `shared/github-link.test.ts`, `core/workspace-files.github-links.test.ts`, `renderer/state/workspace.github-links.test.ts`, `renderer/lib/githubLinks.test.ts`, `renderer/state/githubLinks.test.ts`, `GitHubLinkChip.test.tsx`, `GitHubLinkPicker.test.tsx`, `CardMetaBar.test.tsx`.

Extended: `node-exec`, `client`, `service`, `handlers`, `relay-host`, `toKanbanSession`, `board-log-panel`, `ui-visibility`.

`npm run typecheck` clean. The suite is green except 21 files that already fail on `main` in this checkout (missing optional deps and real-tmux/session-host fixtures) — same set before and after.
</details>

<details>
<summary>Not in this PR</summary>

A reverse indicator on the GitHub card, and an agent-facing canvas-control `attach` verb — both land on this same write funnel later. Device verification of the approved-repository flow is still owed.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkkmZHECPi93T4VXkodTMh
