### PR TITLE
feat(browser): say why a page did not load, and show that one is loading

### DIFF
--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -259,7 +259,7 @@ export function BrowserSurface({
     // A navigation with an initiator: whatever it navigates to is not a restore echo.
     restoringNavRef.current = null
     locationRef.current = safe
-    if (safe === src) ref.current?.reload()
+    if (safe === src) reloadWebview(ref.current, false)
     else setSrc(safe)
   }
 
@@ -274,8 +274,8 @@ export function BrowserSurface({
         </button>
         <button
           className="browser-node__btn"
-          onClick={() => (loading ? ref.current?.stop() : ref.current?.reload())}
-          title={loading ? 'Stop' : 'Reload'}
+          onClick={(e) => (loading ? ref.current?.stop() : reloadWebview(ref.current, e.shiftKey))}
+          title={loading ? 'Stop' : 'Reload (Shift to bypass the cache)'}
         >
           {loading ? '✕' : '⟳'}
         </button>

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -4,6 +4,10 @@ import { BrowserStartPage } from './BrowserStartPage'
 import { useBrowserHistory } from '../state/browserHistory'
 import { useDiscardWhenHidden, webviewAudible } from './useDiscardWhenHidden'
 import { DiscardedPlate } from './DiscardedPlate'
+import { reloadWebview, type ReloadableWebview } from './webviewReload'
+import { describeLoadFailure, isReportableFailure, type WebviewLoadFailure } from './webviewError'
+import { WebviewErrorPlate } from './WebviewErrorPlate'
+import { WebviewLoadingBar } from './WebviewLoadingBar'
 
 // Minimal typing for the Electron <webview> element methods/events we use.
 type WebviewEl = HTMLElement & {
@@ -70,7 +74,11 @@ export function BrowserSurface({
   const [loading, setLoading] = useState(false)
   const [canBack, setCanBack] = useState(false)
   const [canFwd, setCanFwd] = useState(false)
-  const [failed, setFailed] = useState('')
+  /** A complaint about what was TYPED in the address bar, not about a page. Rendered as a strip
+   *  under the toolbar, so it never covers a page that is still perfectly readable. */
+  const [notice, setNotice] = useState('')
+  /** A main-frame load failure, which DOES cover the guest — see {@link WebviewErrorPlate}. */
+  const [failure, setFailure] = useState<WebviewLoadFailure | null>(null)
   // Memory saver (see `useDiscardWhenHidden`): the page is released while hidden and rebuilt on
   // reveal. `loadingRef` mirrors the `loading` state because the hook reads it at fire time, from
   // a callback that must not force the observer to be re-created.
@@ -92,6 +100,10 @@ export function BrowserSurface({
     const onStart = (): void => {
       loadingRef.current = true
       setLoading(true)
+      // The one unambiguous "we are trying again" signal, and the ONLY place the plate clears.
+      // `did-navigate` is not usable for it: Chromium navigates to its own error page under the
+      // very URL that just failed, so clearing there would wipe the plate the instant it appears.
+      setFailure(null)
     }
     const onStop = (): void => {
       loadingRef.current = false
@@ -115,7 +127,7 @@ export function BrowserSurface({
       restoringNavRef.current = null
       setAddress(u)
       locationRef.current = u
-      setFailed('')
+      setNotice('')
       if (echo) return
       // A genuine navigation re-opens the title gate below: the first title of the NEW page always
       // records, however it compares to the old page's.
@@ -140,11 +152,16 @@ export function BrowserSurface({
       if (lastUrlRef.current) useBrowserHistory.getState().record(lastUrlRef.current, title)
     }
     const onFail = (e: Event): void => {
-      const ev = e as unknown as { isMainFrame: boolean; errorCode: number; errorDescription: string }
-      if (ev.isMainFrame && ev.errorCode !== -3) {
+      const ev = e as unknown as {
+        isMainFrame: boolean
+        errorCode: number
+        errorDescription: string
+        validatedURL?: string
+      }
+      if (isReportableFailure(ev.isMainFrame, ev.errorCode)) {
         // A restore that never landed has no echo to swallow — disarm, or the next navigation pays.
         restoringNavRef.current = null
-        setFailed(ev.errorDescription || 'Failed to load')
+        setFailure(describeLoadFailure(ev.errorCode, ev.errorDescription, ev.validatedURL || locationRef.current))
       }
     }
     wv.addEventListener('did-start-loading', onStart)
@@ -196,9 +213,10 @@ export function BrowserSurface({
     onDiscard: () => {
       setDiscarded(true)
       setSrc('')
-      // A failure banner belongs to the page we just released; the restore re-navigates and will
-      // raise its own if the load fails again.
-      setFailed('')
+      // A failure belongs to the page we just released; the restore re-navigates and will raise
+      // its own if the load fails again.
+      setFailure(null)
+      setNotice('')
       onGuestDiscarded?.()
     },
     onRestore: () => {
@@ -233,11 +251,11 @@ export function BrowserSurface({
   const go = (): void => {
     const safe = searchOrUrl(address)
     if (!safe) {
-      setFailed('Enter a URL or search term')
+      setNotice('Enter a URL or search term')
       return
     }
     setAddress(safe)
-    setFailed('')
+    setNotice('')
     // A navigation with an initiator: whatever it navigates to is not a restore echo.
     restoringNavRef.current = null
     locationRef.current = safe
@@ -293,12 +311,16 @@ export function BrowserSurface({
               setSrc(u)
               setAddress(u)
               locationRef.current = u
-              setFailed('')
+              setNotice('')
             }}
           />
         )}
         {discarded && <DiscardedPlate />}
-        {failed && <div className="browser-node__error">{failed}</div>}
+        {failure && !discarded && (
+          <WebviewErrorPlate failure={failure} onRetry={() => reloadWebview(ref.current, false)} />
+        )}
+        {loading && <WebviewLoadingBar />}
+        {notice && <div className="browser-node__error">{notice}</div>}
       </div>
     </div>
   )

--- a/src/renderer/nodes/BrowserSurface.tsx
+++ b/src/renderer/nodes/BrowserSurface.tsx
@@ -217,6 +217,9 @@ export function BrowserSurface({
       // its own if the load fails again.
       setFailure(null)
       setNotice('')
+      // The guest is gone, so no did-stop-loading is coming to end a navigation left in flight.
+      loadingRef.current = false
+      setLoading(false)
       onGuestDiscarded?.()
     },
     onRestore: () => {

--- a/src/renderer/nodes/WebNode.tsx
+++ b/src/renderer/nodes/WebNode.tsx
@@ -5,6 +5,10 @@ import type { CanvasNode } from '../state/workspace'
 import { httpUrl } from './webUrl'
 import { useDiscardWhenHidden, webviewAudible, type AudibleWebview } from './useDiscardWhenHidden'
 import { DiscardedPlate } from './DiscardedPlate'
+import { reloadWebview, type ReloadableWebview } from './webviewReload'
+import { describeLoadFailure, isReportableFailure, type WebviewLoadFailure } from './webviewError'
+import { WebviewErrorPlate } from './WebviewErrorPlate'
+import { WebviewLoadingBar } from './WebviewLoadingBar'
 import { useWebviewKeepAlive } from '../state/webviewKeepAlive'
 
 /**
@@ -16,13 +20,17 @@ import { useWebviewKeepAlive } from '../state/webviewKeepAlive'
 export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const { deleteElements } = useReactFlow()
   const [src, setSrc] = useState('')
+  /** We never got as far as handing the guest a source: an unusable scheme, or a media grant that
+   *  was refused. Distinct from `failure`, which is a page that was attempted and did not load. */
   const [error, setError] = useState('')
+  const [failure, setFailure] = useState<WebviewLoadFailure | null>(null)
+  const [loading, setLoading] = useState(false)
   const url = (data.url as string) ?? ''
   const filePath = (data.filePath as string) ?? ''
   const title = (data.title as string) || url || filePath.split('/').pop() || 'web'
   const rootRef = useRef<HTMLDivElement | null>(null)
   /** The guest, for the audible check only — a local html page can hold a playing <video>. */
-  const wvRef = useRef<AudibleWebview | null>(null)
+  const wvRef = useRef<(AudibleWebview & ReloadableWebview) | null>(null)
   // Memory saver — the same shared hook {@link BrowserSurface} uses: hidden long enough, the
   // <webview> is unmounted (its Chromium process exits) and rebuilt on reveal. `revive` is what
   // re-runs the source effect below, so the `nt-media://` grant is re-issued for a local file
@@ -78,6 +86,45 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
     }
   }, [url, filePath, revive])
 
+  // One definition of "there is a guest right now", read by both the reload button and the body:
+  // the button must appear exactly when there is something to reload, and a second copy of the
+  // condition is what would let those two drift.
+  const live = !!src && !discarded && !restoring
+
+  // The guest's own load lifecycle. Without it a node whose page refuses the connection sits on
+  // Chromium's error page behind our chrome, saying nothing the node can act on. `live` is the dep
+  // because that is exactly when the element mounts and unmounts; a src change reuses it.
+  useEffect(() => {
+    const wv = wvRef.current as unknown as (EventTarget & { addEventListener: HTMLElement['addEventListener'] }) | null
+    if (!wv || !live) return
+    const onStart = (): void => {
+      setLoading(true)
+      // A new attempt is the only thing that clears the plate — see BrowserSurface's `onStart`.
+      setFailure(null)
+    }
+    const onStop = (): void => setLoading(false)
+    const onFail = (e: Event): void => {
+      const ev = e as unknown as {
+        isMainFrame: boolean
+        errorCode: number
+        errorDescription: string
+        validatedURL?: string
+      }
+      if (isReportableFailure(ev.isMainFrame, ev.errorCode)) {
+        setFailure(describeLoadFailure(ev.errorCode, ev.errorDescription, ev.validatedURL || srcRef.current))
+      }
+    }
+    wv.addEventListener('did-start-loading', onStart)
+    wv.addEventListener('did-stop-loading', onStop)
+    wv.addEventListener('did-fail-load', onFail)
+    return () => {
+      wv.removeEventListener('did-start-loading', onStart)
+      wv.removeEventListener('did-stop-loading', onStop)
+      wv.removeEventListener('did-fail-load', onFail)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [live])
+
   useDiscardWhenHidden(rootRef, {
     isLoading: () => grantingRef.current,
     isAudible: () => webviewAudible(wvRef.current),
@@ -86,6 +133,9 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
       setDiscarded(true)
       setSrc('')
       srcRef.current = ''
+      // The failure belonged to the page we just released; the restore raises its own if it fails.
+      setFailure(null)
+      setLoading(false)
       // A background keep-alive GHOST (data.ghost — lib/webviewKeepAlive.ts) whose guest is gone
       // is a husk holding a pool slot: end its entry, which unmounts this whole node. An active
       // node keeps the plate-and-restore behavior unchanged.
@@ -97,6 +147,7 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
       // round-trip to main, and without this the node flashes "No source" for the whole of it.
       setRestoring(true)
       setError('')
+      setFailure(null)
       setRevive((n) => n + 1)
     }
   })
@@ -147,15 +198,21 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
         <div className="editor-node__image nodrag nowheel">
           {discarded || restoring ? (
             <DiscardedPlate restoring={restoring} />
-          ) : src ? (
-            // eslint-disable-next-line react/no-unknown-property
-            <webview
-              ref={(el) => {
-                wvRef.current = el as unknown as AudibleWebview | null
-              }}
-              src={src}
-              style={{ width: '100%', height: '100%' }}
-            />
+          ) : live ? (
+            <>
+              {/* eslint-disable-next-line react/no-unknown-property */}
+              <webview
+                ref={(el) => {
+                  wvRef.current = el as unknown as (AudibleWebview & ReloadableWebview) | null
+                }}
+                src={src}
+                style={{ width: '100%', height: '100%' }}
+              />
+              {failure && (
+                <WebviewErrorPlate failure={failure} onRetry={() => reloadWebview(wvRef.current, false)} />
+              )}
+              {loading && <WebviewLoadingBar />}
+            </>
           ) : (
             <span className="editor-node__loading">{error || 'No source'}</span>
           )}

--- a/src/renderer/nodes/WebNode.tsx
+++ b/src/renderer/nodes/WebNode.tsx
@@ -173,6 +173,15 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
           {title}
         </span>
         <span className="term-node__spacer" />
+        {live && (
+          <button
+            className="term-node__close"
+            title="Reload (Shift to bypass the cache)"
+            onClick={(e) => reloadWebview(wvRef.current, e.shiftKey)}
+          >
+            ⟳
+          </button>
+        )}
         {url && (
           <button
             className="term-node__close"

--- a/src/renderer/nodes/WebNode.tsx
+++ b/src/renderer/nodes/WebNode.tsx
@@ -39,10 +39,13 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const [restoring, setRestoring] = useState(false)
   const [revive, setRevive] = useState(0)
   const srcRef = useRef('')
-  /** "Loading" here is the media grant being in flight — the only await between mount and a
-   *  usable src (a live URL is resolved synchronously). Discarding mid-grant would drop the
-   *  answer to a request already made. */
+  /** The media grant being in flight — the only await between mount and a usable src (a live URL
+   *  is resolved synchronously). Discarding mid-grant would drop the answer to a request already
+   *  made. */
   const grantingRef = useRef(false)
+  /** The guest's own navigation, mirrored for the same fire-time read: the hook asks from a
+   *  callback that must not force the observer to be re-created. */
+  const loadingRef = useRef(false)
 
   useEffect(() => {
     let alive = true
@@ -98,11 +101,15 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
     const wv = wvRef.current as unknown as (EventTarget & { addEventListener: HTMLElement['addEventListener'] }) | null
     if (!wv || !live) return
     const onStart = (): void => {
+      loadingRef.current = true
       setLoading(true)
       // A new attempt is the only thing that clears the plate — see BrowserSurface's `onStart`.
       setFailure(null)
     }
-    const onStop = (): void => setLoading(false)
+    const onStop = (): void => {
+      loadingRef.current = false
+      setLoading(false)
+    }
     const onFail = (e: Event): void => {
       const ev = e as unknown as {
         isMainFrame: boolean
@@ -126,7 +133,7 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
   }, [live])
 
   useDiscardWhenHidden(rootRef, {
-    isLoading: () => grantingRef.current,
+    isLoading: () => grantingRef.current || loadingRef.current,
     isAudible: () => webviewAudible(wvRef.current),
     hasContent: () => !!srcRef.current,
     onDiscard: () => {
@@ -135,6 +142,7 @@ export default function WebNode({ id, data, selected }: NodeProps<CanvasNode>) {
       srcRef.current = ''
       // The failure belonged to the page we just released; the restore raises its own if it fails.
       setFailure(null)
+      loadingRef.current = false
       setLoading(false)
       // A background keep-alive GHOST (data.ghost — lib/webviewKeepAlive.ts) whose guest is gone
       // is a husk holding a pool slot: end its entry, which unmounts this whole node. An active

--- a/src/renderer/nodes/WebviewErrorPlate.tsx
+++ b/src/renderer/nodes/WebviewErrorPlate.tsx
@@ -1,0 +1,32 @@
+import type { WebviewLoadFailure } from './webviewError'
+
+/**
+ * What stands in for a page that failed to load, over the guest rather than beside it: Chromium
+ * paints its own error page inside the `<webview>`, and leaving that visible puts another
+ * product's chrome in the middle of a node with no way back.
+ *
+ * One component so the canvas web node and the browser surface cannot drift into two wordings for
+ * the same failure. The wording itself lives in {@link describeLoadFailure}.
+ */
+export function WebviewErrorPlate({
+  failure,
+  onRetry
+}: {
+  failure: WebviewLoadFailure
+  onRetry?: () => void
+}): React.JSX.Element {
+  return (
+    <div className="browser-node__failed" role="alert">
+      <span className="browser-node__failed-msg">{failure.message}</span>
+      {failure.url && <span className="browser-node__failed-url">{failure.url}</span>}
+      {failure.hint && <span className="browser-node__failed-hint">{failure.hint}</span>}
+      {/* Chromium's own symbol: the one part of this plate that is searchable and quotable. */}
+      <span className="browser-node__failed-code">{failure.raw}</span>
+      {failure.retryable && onRetry && (
+        <button className="browser-node__failed-retry" onClick={onRetry}>
+          Try again
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/nodes/WebviewLoadingBar.tsx
+++ b/src/renderer/nodes/WebviewLoadingBar.tsx
@@ -1,0 +1,11 @@
+/**
+ * The indeterminate bar across the top of a `<webview>` while a navigation is in flight.
+ *
+ * Indeterminate rather than a progress percentage: a guest reports `did-start-loading` and
+ * `did-stop-loading` and nothing in between, so any number here would be invented.
+ *
+ * One component for both surfaces, for the same reason as {@link DiscardedPlate}.
+ */
+export function WebviewLoadingBar(): React.JSX.Element {
+  return <div className="webview-progress" role="progressbar" aria-label="Loading" aria-busy="true" />
+}

--- a/src/renderer/nodes/webview-error-parity.test.ts
+++ b/src/renderer/nodes/webview-error-parity.test.ts
@@ -1,0 +1,43 @@
+// Two surfaces host a <webview> — the canvas WebNode and the BrowserSurface shared by the browser
+// node and the kanban card modal. A failed page must read the same on both, and a page that failed
+// must be COVERED rather than left showing Chromium's own error page, so both go through the one
+// module and the one plate. The tempting simplification is a per-surface string, which is how the
+// two ended up describing (and, in WebNode's case, not describing) the same failure differently.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const read = (file: string): string => readFileSync(path.join(__dirname, file), 'utf8')
+
+const SURFACES = ['WebNode.tsx', 'BrowserSurface.tsx']
+
+describe('every webview surface reports load failures the same way', () => {
+  it.each(SURFACES)('%s describes a failure through the shared module', (file) => {
+    const src = read(file)
+    expect(src).toContain("from './webviewError'")
+    expect(src).toContain('describeLoadFailure(')
+    expect(src).toContain('<WebviewErrorPlate')
+  })
+
+  it.each(SURFACES)('%s filters the event through isReportableFailure', (file) => {
+    const src = read(file)
+    expect(src).toContain('isReportableFailure(')
+    // Not the inlined predicate this replaced: a bare `!== -3` loses the name of what it skips.
+    expect(src).not.toMatch(/errorCode\s*!==\s*-3/)
+  })
+
+  it.each(SURFACES)('%s shows the shared bar while a navigation is in flight', (file) => {
+    expect(read(file)).toContain('<WebviewLoadingBar')
+  })
+
+  it.each(SURFACES)('%s clears the plate on did-start-loading, never on did-navigate', (file) => {
+    // Chromium navigates to its own error page under the URL that just failed, so clearing the
+    // plate from `did-navigate` would wipe it the instant it appears.
+    const src = read(file)
+    const start = src.indexOf('const onStart')
+    expect(start).toBeGreaterThan(-1)
+    expect(src.slice(start, start + 400)).toContain('setFailure(null)')
+    const nav = src.indexOf('const onNav = ')
+    if (nav > -1) expect(src.slice(nav, src.indexOf('const onNavInPage'))).not.toContain('setFailure(')
+  })
+})

--- a/src/renderer/nodes/webview-error-parity.test.ts
+++ b/src/renderer/nodes/webview-error-parity.test.ts
@@ -30,14 +30,28 @@ describe('every webview surface reports load failures the same way', () => {
     expect(read(file)).toContain('<WebviewLoadingBar')
   })
 
-  it.each(SURFACES)('%s clears the plate on did-start-loading, never on did-navigate', (file) => {
-    // Chromium navigates to its own error page under the URL that just failed, so clearing the
-    // plate from `did-navigate` would wipe it the instant it appears.
+  it.each(SURFACES)('%s clears the plate on did-start-loading', (file) => {
+    // Chromium navigates to its own error page under the URL that just failed, so a new load
+    // starting is the only signal that means "we are trying again".
     const src = read(file)
     const start = src.indexOf('const onStart')
     expect(start).toBeGreaterThan(-1)
     expect(src.slice(start, start + 400)).toContain('setFailure(null)')
+  })
+
+  // The surfaces genuinely differ here, so each is asserted rather than probed: a handle looked up
+  // and not found would take the guard with it and leave the suite green.
+  it('BrowserSurface.tsx never clears the plate from did-navigate', () => {
+    // Clearing there would wipe the plate the instant Chromium's error page navigated under it.
+    const src = read('BrowserSurface.tsx')
     const nav = src.indexOf('const onNav = ')
-    if (nav > -1) expect(src.slice(nav, src.indexOf('const onNavInPage'))).not.toContain('setFailure(')
+    const end = src.indexOf('const onNavInPage')
+    expect(nav).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(nav)
+    expect(src.slice(nav, end)).not.toContain('setFailure(')
+  })
+
+  it('WebNode.tsx has no did-navigate handler the plate could be cleared from', () => {
+    expect(read('WebNode.tsx')).not.toContain('did-navigate')
   })
 })

--- a/src/renderer/nodes/webview-reload-parity.test.ts
+++ b/src/renderer/nodes/webview-reload-parity.test.ts
@@ -1,0 +1,25 @@
+// Two surfaces reload a guest — the canvas WebNode's header button and the BrowserSurface toolbar
+// shared by the browser node and the kanban card modal. Both must go through `reloadWebview`, which
+// is where the two rules live: Shift bypasses the cache and never silently falls back to a cached
+// re-fetch, and a guest that has not attached yet throws instead of reloading. Calling the element's
+// own methods works in the happy path and loses both, which is exactly the "simplification" a later
+// refactor reaches for — so it is pinned at source level.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const read = (file: string): string => readFileSync(path.join(__dirname, file), 'utf8')
+
+const SURFACES = ['WebNode.tsx', 'BrowserSurface.tsx']
+
+describe('every reload path goes through reloadWebview', () => {
+  it.each(SURFACES)('%s reloads through the helper, carrying the Shift modifier', (file) => {
+    const src = read(file)
+    expect(src).toContain("from './webviewReload'")
+    expect(src).toMatch(/reloadWebview\([^)]*e\.shiftKey\)/)
+  })
+
+  it.each(SURFACES)('%s never calls the guest reload methods directly', (file) => {
+    expect(read(file)).not.toMatch(/\.current\??\.reload(IgnoringCache)?\s*\(/)
+  })
+})

--- a/src/renderer/nodes/webviewError.test.ts
+++ b/src/renderer/nodes/webviewError.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { describeLoadFailure, isReportableFailure, ERR_ABORTED } from './webviewError'
+
+describe('isReportableFailure', () => {
+  it('reports a main-frame failure', () => {
+    expect(isReportableFailure(true, -102)).toBe(true)
+  })
+
+  it('ignores a subframe failure', () => {
+    // Covering a working page because an ad or an iframe died hides the content the user came for.
+    expect(isReportableFailure(false, -102)).toBe(false)
+  })
+
+  it('ignores an aborted navigation', () => {
+    expect(isReportableFailure(true, ERR_ABORTED)).toBe(false)
+  })
+})
+
+describe('describeLoadFailure', () => {
+  it('explains a refused connection, which is the one a dev server produces', () => {
+    const f = describeLoadFailure(-102, 'ERR_CONNECTION_REFUSED', 'http://localhost:3000/')
+    expect(f.message).toBe('Nothing is listening at that address.')
+    expect(f.hint).toContain('dev server')
+    expect(f.url).toBe('http://localhost:3000/')
+    expect(f.retryable).toBe(true)
+  })
+
+  it("carries Chromium's own symbol even when the code is known", () => {
+    // It is the only part of the plate that is searchable and quotable in a bug report.
+    expect(describeLoadFailure(-105, 'ERR_NAME_NOT_RESOLVED', 'https://nope.invalid/').raw).toBe(
+      'ERR_NAME_NOT_RESOLVED'
+    )
+  })
+
+  it('degrades an unknown code to the generic sentence rather than inventing one', () => {
+    const f = describeLoadFailure(-99999, 'ERR_SOMETHING_NEW', 'https://example.com/')
+    expect(f.message).toBe('The page could not be loaded.')
+    expect(f.hint).toBe('')
+    expect(f.raw).toBe('ERR_SOMETHING_NEW')
+    expect(f.retryable).toBe(true)
+  })
+
+  it('names the code when the event carried no description', () => {
+    expect(describeLoadFailure(-7, '   ', '').raw).toBe('Error -7')
+  })
+
+  it('offers no retry when the address itself is the problem', () => {
+    // Re-running the identical navigation cannot succeed; the fix is to type something else.
+    expect(describeLoadFailure(-300, 'ERR_INVALID_URL', 'ht!tp://x').retryable).toBe(false)
+    expect(describeLoadFailure(-302, 'ERR_UNKNOWN_URL_SCHEME', 'wat://x').retryable).toBe(false)
+  })
+
+  it('offers a retry for a certificate failure, which the user can fix and re-attempt', () => {
+    expect(describeLoadFailure(-202, 'ERR_CERT_AUTHORITY_INVALID', 'https://local.test/').retryable).toBe(true)
+  })
+
+  it('tolerates a missing url', () => {
+    expect(describeLoadFailure(-106, 'ERR_INTERNET_DISCONNECTED', '').url).toBe('')
+  })
+
+  it('never returns an undefined hint', () => {
+    for (const code of [-2, -6, -7, -100, -101, -104, -106, -109, -118, -200, -201, -310, -324, -501]) {
+      expect(typeof describeLoadFailure(code, 'ERR', '').hint).toBe('string')
+    }
+  })
+})

--- a/src/renderer/nodes/webviewError.ts
+++ b/src/renderer/nodes/webviewError.ts
@@ -1,0 +1,94 @@
+/**
+ * What a `did-fail-load` from a `<webview>` guest means, in words a user can act on.
+ *
+ * Chromium renders its own error page inside the guest for a failed main-frame navigation. That
+ * page is another product's chrome sitting in the middle of ours, it names the failure only as an
+ * `ERR_` symbol, and it offers no way back into the node. So the surfaces cover it with their own
+ * plate, and this module is the one place that decides what the plate says.
+ *
+ * Shared by the canvas `WebNode` and the `BrowserSurface` (browser node + kanban card modal), so
+ * one failure cannot be described two ways depending on which view the user is looking at.
+ */
+
+/** `ERR_ABORTED`: a navigation something replaced or canceled, which is not a failure to report. */
+export const ERR_ABORTED = -3
+
+/** A main-frame load failure, ready to render. */
+export interface WebviewLoadFailure {
+  /** Chromium's net error code (negative; see `net_error_list.h`). */
+  code: number
+  /** Chromium's own symbol for it, e.g. `ERR_CONNECTION_REFUSED`. Shown so a bug report can carry it. */
+  raw: string
+  /** The URL the navigation was aiming at; empty when the event carried none. */
+  url: string
+  /** One sentence naming what went wrong. */
+  message: string
+  /** A second line naming what to check, or empty when there is nothing useful to add. */
+  hint: string
+  /** Whether re-running this exact navigation could plausibly succeed. */
+  retryable: boolean
+}
+
+interface Explanation {
+  message: string
+  hint?: string
+  /** Omitted means true: most failures are worth another attempt. */
+  retryable?: boolean
+}
+
+/**
+ * The codes a user of this app actually meets. Anything outside the table degrades to the generic
+ * sentence plus Chromium's own symbol, which is honest: a wrong explanation is worse than none.
+ */
+const BY_CODE: Record<number, Explanation> = {
+  [-2]: { message: 'The page could not be loaded.' },
+  [-6]: { message: 'That file is not there.', hint: 'It may have been moved or deleted.' },
+  [-7]: { message: 'The server took too long to answer.', hint: 'It may be overloaded, or a firewall may be dropping the connection.' },
+  [-20]: { message: 'Something on this machine blocked the request.', hint: 'A content blocker, an extension or a proxy.' },
+  [-21]: { message: 'The network changed while the page was loading.' },
+  [-100]: { message: 'The server closed the connection.' },
+  [-101]: { message: 'The server reset the connection.' },
+  [-102]: { message: 'Nothing is listening at that address.', hint: 'If this is a dev server, it may not be running yet.' },
+  [-104]: { message: 'The connection could not be made.' },
+  [-105]: { message: 'That host name could not be resolved.', hint: 'Check the spelling, and whether this machine is online.' },
+  [-106]: { message: 'This machine is offline.' },
+  [-109]: { message: 'That address could not be reached.' },
+  [-118]: { message: 'The connection timed out.', hint: 'The host may be unreachable from this network.' },
+  [-137]: { message: 'That host name could not be resolved.', hint: 'Check the spelling, and whether this machine is online.' },
+  [-200]: { message: 'The certificate does not match this address.' },
+  [-201]: { message: 'The certificate has expired, or is not valid yet.' },
+  [-202]: { message: 'The certificate is not from a trusted authority.', hint: 'Usual for a self-signed certificate on a local server.' },
+  [-300]: { message: 'That is not a valid address.', retryable: false },
+  [-301]: { message: 'That address uses a scheme this view does not open.', retryable: false },
+  [-302]: { message: 'That address uses a scheme this view does not open.', retryable: false },
+  [-310]: { message: 'The server redirected too many times.' },
+  [-324]: { message: 'The server answered with nothing.' },
+  [-501]: { message: 'The secure connection could not be established.' }
+}
+
+/**
+ * Whether a `did-fail-load` is worth showing at all.
+ *
+ * A subframe failure leaves a working page on screen, and covering it with a plate would hide the
+ * content the user came for over an ad that did not load. `ERR_ABORTED` is what a navigation the
+ * user or the app replaced looks like, and what a download reports.
+ */
+export function isReportableFailure(isMainFrame: boolean, code: number): boolean {
+  return isMainFrame && code !== ERR_ABORTED
+}
+
+/**
+ * Turn the event's fields into something renderable. `description` is Chromium's own symbol and is
+ * carried through even when the code is known, because it is what a search or a bug report needs.
+ */
+export function describeLoadFailure(code: number, description: string, url: string): WebviewLoadFailure {
+  const known = BY_CODE[code]
+  return {
+    code,
+    raw: description.trim() || `Error ${code}`,
+    url: url.trim(),
+    message: known?.message ?? 'The page could not be loaded.',
+    hint: known?.hint ?? '',
+    retryable: known?.retryable ?? true
+  }
+}

--- a/src/renderer/nodes/webviewReload.test.ts
+++ b/src/renderer/nodes/webviewReload.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { reloadWebview } from './webviewReload'
+
+const guest = () => ({ reload: vi.fn(), reloadIgnoringCache: vi.fn() })
+
+describe('reloadWebview', () => {
+  it('a plain click reloads', () => {
+    const el = guest()
+    reloadWebview(el, false)
+    expect(el.reload).toHaveBeenCalledOnce()
+    expect(el.reloadIgnoringCache).not.toHaveBeenCalled()
+  })
+
+  it('Shift+click bypasses the cache', () => {
+    const el = guest()
+    reloadWebview(el, true)
+    expect(el.reloadIgnoringCache).toHaveBeenCalledOnce()
+    expect(el.reload).not.toHaveBeenCalled()
+  })
+
+  it('a forced reload never falls back to the cached one', () => {
+    const el = { reload: vi.fn() }
+    reloadWebview(el, true)
+    expect(el.reload).not.toHaveBeenCalled()
+  })
+
+  it('does nothing without a guest', () => {
+    expect(() => reloadWebview(null, false)).not.toThrow()
+    expect(() => reloadWebview(undefined, true)).not.toThrow()
+  })
+
+  it('swallows the throw from a guest that has not attached yet', () => {
+    const notAttached = {
+      reload: () => {
+        throw new Error('The WebView must be attached to the DOM')
+      },
+      reloadIgnoringCache: () => {
+        throw new Error('The WebView must be attached to the DOM')
+      }
+    }
+    expect(() => reloadWebview(notAttached, false)).not.toThrow()
+    expect(() => reloadWebview(notAttached, true)).not.toThrow()
+  })
+})

--- a/src/renderer/nodes/webviewReload.ts
+++ b/src/renderer/nodes/webviewReload.ts
@@ -1,0 +1,25 @@
+/** The slice of Electron's `WebviewTag` a reload needs. */
+export type ReloadableWebview = {
+  reload(): void
+  reloadIgnoringCache(): void
+}
+
+/**
+ * Reload the guest; `force` (Shift+click) bypasses the HTTP cache.
+ *
+ * A forced reload never falls back to a plain one. The gesture means "I do not trust what is on
+ * screen", and a silent downgrade to a cached re-fetch is indistinguishable from a page that
+ * genuinely did not change — so on a guest that can only `reload()` we do nothing instead.
+ *
+ * Both methods throw before the guest attaches, exactly like `isCurrentlyAudible` (see
+ * `webviewAudible`). A guest that does not exist yet has nothing to reload, so swallowing that is
+ * the correct answer rather than merely a safe one.
+ */
+export function reloadWebview(el: Partial<ReloadableWebview> | null | undefined, force: boolean): void {
+  try {
+    if (force) el?.reloadIgnoringCache?.()
+    else el?.reload?.()
+  } catch {
+    // Not attached yet.
+  }
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7766,6 +7766,94 @@ button.group-node__setup:disabled {
   color: var(--muted);
   font-size: 12px;
 }
+/* A main-frame load failure, OVER the guest rather than beside it: Chromium paints its own error
+   page inside the <webview>, which is another product's chrome in the middle of a node and offers
+   no way back. Shared by the web node and the browser surface (WebviewErrorPlate). */
+.browser-node__failed {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 16px;
+  text-align: center;
+  background: var(--bg);
+}
+.browser-node__failed-msg {
+  color: var(--text);
+  font-size: 13px;
+}
+.browser-node__failed-url,
+.browser-node__failed-hint {
+  color: var(--muted);
+  font-size: 11px;
+  max-width: 100%;
+}
+.browser-node__failed-url {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.browser-node__failed-code {
+  color: var(--muted);
+  opacity: 0.6;
+  font-size: 10px;
+  letter-spacing: 0.02em;
+}
+.browser-node__failed-retry {
+  margin-top: 4px;
+  background: rgba(var(--tint-rgb), 0.08);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 12px;
+}
+.browser-node__failed-retry:hover {
+  background: rgba(var(--tint-rgb), 0.14);
+}
+
+/* Navigation in flight. Indeterminate on purpose: a guest reports only start and stop, so any
+   percentage here would be invented. */
+.webview-progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  overflow: hidden;
+  background: rgba(var(--tint-rgb), 0.1);
+  pointer-events: none;
+}
+.webview-progress::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 35%;
+  background: var(--accent);
+  animation: webview-progress-slide 1.1s ease-in-out infinite;
+}
+@keyframes webview-progress-slide {
+  from {
+    left: -35%;
+  }
+  to {
+    left: 100%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .webview-progress::after {
+    animation: none;
+    left: 0;
+    width: 100%;
+    opacity: 0.5;
+  }
+}
+
 .browser-node__error {
   position: absolute;
   left: 0;


### PR DESCRIPTION
A `<webview>` node that failed to load told you nothing useful, and the two surfaces that host one
disagreed about what "nothing useful" looked like.

Chromium paints its own error page inside the guest for a failed main-frame navigation. So a web
node pointed at a dev server that is not running sat on another product's chrome, in the middle of
the canvas, with no way back. The browser surface did slightly better: a red strip along the bottom
carrying the raw `ERR_CONNECTION_REFUSED`, over that same page. The web node had no `did-fail-load`
listener at all.

Neither surface showed that a navigation was in flight either, beyond the browser toolbar's reload
button turning into a stop.

## What it does

Both surfaces now cover the guest with one plate (`WebviewErrorPlate`) that names the failure in a
sentence, shows the URL it was aiming at, adds a line about what to check where there is one, keeps
Chromium's own symbol, and offers Try again. The symbol stays because it is the one part of the
plate that is searchable and quotable in a bug report.

The wording lives in one module, `webviewError.ts`:

| Code | Says | Adds |
| --- | --- | --- |
| `ERR_CONNECTION_REFUSED` | Nothing is listening at that address. | If this is a dev server, it may not be running yet. |
| `ERR_NAME_NOT_RESOLVED` | That host name could not be resolved. | Check the spelling, and whether this machine is online. |
| `ERR_CERT_AUTHORITY_INVALID` | The certificate is not from a trusted authority. | Usual for a self-signed certificate on a local server. |
| anything not in the table | The page could not be loaded. | nothing |

Two rules that table exists to enforce. An unknown code degrades to the generic sentence plus the
symbol rather than to an invented explanation, because a confident wrong cause is worse than none.
And Try again is withheld only where the address itself is the problem (`ERR_INVALID_URL`,
`ERR_UNKNOWN_URL_SCHEME`), since re-running that exact navigation cannot succeed; a certificate or
a refused connection keeps the button, because the user is the one who knows whether they just
fixed the server.

A subframe failure is ignored: covering a working page because an ad did not load hides the content
the reader came for. `ERR_ABORTED` is ignored too, which is what a navigation the app replaced, and
a download, both look like. Both live in `isReportableFailure`, so the rule is named rather than
inlined as `!== -3`.

Loading is an indeterminate bar across the top of the view. Indeterminate on purpose: a guest
reports `did-start-loading` and `did-stop-loading` and nothing between, so any percentage would be
invented. It honors `prefers-reduced-motion`.

## The trap

**The plate clears on `did-start-loading` and nowhere else.** Chromium navigates to its own error
page under the URL that just failed, so clearing from `did-navigate` wipes the plate the instant it
appears. A new load starting is the one signal that means "we are trying again", and it is
order-independent, which no comparison against the failed URL would be. `webview-error-parity.test.ts`
pins it at source level for both surfaces, because the tempting simplification is exactly the one
that breaks it.

## One more split

The browser surface's `failed` state also held "Enter a URL or search term". That is a complaint
about what was typed in the address bar, not about a page, and it was rendered in the same red
strip. It keeps the strip as `notice`, so it can never cover a page that is perfectly readable,
while a real load failure gets the plate.

## On `webviewReload`

Try again is a reload, so the helper lands here with its first consumer rather than as its own
change. It carries two rules worth having in one place: Shift bypasses the cache and never silently
falls back to a cached re-fetch (the gesture means "I do not trust what is on screen", and a
downgrade is indistinguishable from a page that genuinely did not change), and both methods throw
before the guest attaches, which is correct to swallow because a guest that does not exist has
nothing to reload.

The second commit then makes it the *only* reload path. Two others in the same file still reached
past it, the toolbar button and pressing Enter on the URL already loaded, so the rules applied to
the plate's button and not to the one directly beside it. Routing them through it also gives the
toolbar the Shift bypass it never had, and `webview-reload-parity.test.ts` pins both surfaces at
source level: a direct `.reload()` works in the happy path while losing both rules, which is exactly
the simplification a later refactor reaches for.

The web node had no reload at all, on the one node kind whose whole content is a page someone else
is serving. A page that failed could only be retried from the plate, and a stale one not at all. It
gets the same button, in the glyph idiom of the two beside it, shown exactly when there is a guest.

## Surfaces

- **Desktop:** the feature. The kanban card modal gets it for free, since it hosts the same
  `BrowserSurface`.
- **Server Edition:** N/A by construction. There is no `<webview>` in a browser, so there is
  nothing to degrade.
- **Mobile companion:** N/A. No canvas, no browser nodes.

## Testing

28 unit tests plus `npm run typecheck`, all renderer-side and pure.

- `webviewError.test.ts` (11): the named codes, the unknown-code degrade, the missing-description
  fallback, the two non-retryable codes, subframe and aborted filtering.
- `webview-error-parity.test.ts` (8, four rules over both surfaces): both describe through the
  shared module, both filter through `isReportableFailure` and no longer inline `!== -3`, both
  render the shared bar, and both clear the plate from `onStart` and never from `onNav`.
- `webviewReload.test.ts` (5): the two reload modes, no fallback on a forced reload, no guest, and
  the not-yet-attached throw.
- `webview-reload-parity.test.ts` (4, two rules over both surfaces): every reload goes through the
  helper carrying the Shift modifier, and neither surface calls the guest's methods directly.

<img width="776" height="573" alt="image" src="https://github.com/user-attachments/assets/1eb31465-7a71-4a1e-b0b7-1f35e13df2bf" />

<img width="871" height="616" alt="image" src="https://github.com/user-attachments/assets/366df32a-efbb-4d23-9e02-ad2a0ecaab9f" />