### PR TITLE
fix(core): stop building a POSIX PATH for git subprocesses on Windows

### DIFF
--- a/src/core/git-env.test.ts
+++ b/src/core/git-env.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { gitEnvFrom, GIT_POSIX_BIN_DIRS } from './git-env'
+
+describe('gitEnvFrom', () => {
+  it('darwin/linux: prepends the GUI-blind bin dirs, keeping the inherited PATH', () => {
+    const env = gitEnvFrom({ PATH: '/usr/local/sbin:/usr/bin' }, 'darwin')
+    expect(env.PATH).toBe('/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/bin')
+    expect(env.PATH!.split(':')).toContain('/usr/local/sbin')
+  })
+
+  it('posix with no inherited PATH: no trailing separator', () => {
+    expect(gitEnvFrom({}, 'linux').PATH).toBe(GIT_POSIX_BIN_DIRS.join(':'))
+  })
+
+  // Issue #583. The old construction joined the POSIX dirs with a hardcoded ':' on every platform,
+  // so Windows — which splits PATH on ';' — read the whole prefix plus the user's FIRST real entry
+  // as one directory, and that entry became unreachable for every git child process.
+  it('win32: leaves PATH exactly as inherited, so no entry fuses with a Unix prefix', () => {
+    const inherited = 'C:\\Windows\\System32;C:\\Program Files\\Git\\cmd'
+    const env = gitEnvFrom({ PATH: inherited }, 'win32')
+    expect(env.PATH).toBe(inherited)
+    expect(env.PATH!.split(';')[0]).toBe('C:\\Windows\\System32')
+    expect(env.PATH).not.toContain('/opt/homebrew/bin')
+  })
+
+  it('win32: adds no PATH key of its own when the process spells it "Path"', () => {
+    // Windows env vars are case-insensitive; a `PATH` we add beside an inherited `Path` is a
+    // second entry for the same variable.
+    const env = gitEnvFrom({ Path: 'C:\\Windows\\System32' } as NodeJS.ProcessEnv, 'win32')
+    expect(Object.keys(env)).not.toContain('PATH')
+    expect(env.Path).toBe('C:\\Windows\\System32')
+  })
+
+  it('carries GIT_TERMINAL_PROMPT=0 on every platform — it is what stops a TTY-less hang', () => {
+    for (const p of ['darwin', 'linux', 'win32']) {
+      expect(gitEnvFrom({ PATH: 'x' }, p).GIT_TERMINAL_PROMPT).toBe('0')
+    }
+  })
+
+  it('passes the rest of the environment through untouched', () => {
+    for (const p of ['darwin', 'win32']) {
+      expect(gitEnvFrom({ HOME: '/home/x', GIT_ASKPASS: 'y' }, p)).toMatchObject({
+        HOME: '/home/x',
+        GIT_ASKPASS: 'y'
+      })
+    }
+  })
+})

--- a/src/core/git-env.ts
+++ b/src/core/git-env.ts
@@ -1,0 +1,63 @@
+// The ONE environment handed to a `git` (or `gh`) subprocess.
+//
+// Two facts it exists to keep in one place:
+//
+// 1. GUI apps on macOS don't inherit the shell PATH, so a git credential helper installed by
+//    Homebrew (e.g. `gh auth git-credential`, or an osxkeychain shim) wouldn't be found by our
+//    subprocess — making push/pull fail even when the user is authed. Prepend the common bin
+//    dirs.
+//
+//    That prepend is POSIX-ONLY, and it used not to be (issue #583). The list was joined and
+//    appended with a HARDCODED ':', so on Windows — where PATH is split on ';' and every entry
+//    carries a drive-letter colon — the four Unix directories fused with the first real entry
+//    into one unusable token:
+//
+//        /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:C:\Windows\System32
+//
+//    Windows then split that on ';', got one malformed directory, and the user's first PATH entry
+//    was unreachable for every git child process — including `git-credential-manager.exe`, which
+//    fails in a way that reads as an auth problem rather than a PATH problem. There is nothing
+//    useful to prepend on Windows (these are Unix paths, and a GUI process there inherits the real
+//    PATH anyway), so the key is OMITTED entirely and `...base` carries the untouched PATH through.
+//    `path.delimiter` would only make the join produce `;`-separated Unix directories, which is a
+//    tidier way of prepending nothing.
+//
+// 2. GIT_TERMINAL_PROMPT=0 makes auth failures error out fast instead of hanging on a username
+//    prompt (there's no TTY here). That one is platform-INDEPENDENT and load-bearing, so it is
+//    outside the conditional — easy to lose inside a spread that is now platform-gated.
+//
+// Both git-service.ts and github/credentials.ts had a character-for-character copy of the PATH
+// construction. A duplicated rule drifts (CLAUDE.md), and the copy in the GitHub-credentials path
+// is precisely the credential-helper case above, so the two import this instead.
+
+/** Bin dirs a GUI-launched process on macOS/Linux routinely can't see. POSIX-only by construction. */
+export const GIT_POSIX_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin']
+
+/**
+ * Pure: base environment + platform → the environment for a git/gh subprocess.
+ *
+ * `base` and `platform` are parameters rather than reads of the ambient process so the mapping is
+ * unit-testable from any OS — the same shape as `tmuxInstall(platform, hasCommand)` and
+ * `executableCandidates(bin, platform, pathext)`.
+ */
+export function gitEnvFrom(
+  base: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform | string
+): NodeJS.ProcessEnv {
+  if (platform === 'win32') {
+    // No PATH key of our own: adding one would ALSO risk a duplicate, since Windows env vars are
+    // case-insensitive and `process.env` there usually spells it `Path`.
+    return { ...base, GIT_TERMINAL_PROMPT: '0' }
+  }
+  const prefix = GIT_POSIX_BIN_DIRS.join(':')
+  return {
+    ...base,
+    PATH: base.PATH ? `${prefix}:${base.PATH}` : prefix,
+    GIT_TERMINAL_PROMPT: '0'
+  }
+}
+
+/** The environment for a git/gh subprocess on THIS machine. */
+export function gitEnv(): NodeJS.ProcessEnv {
+  return gitEnvFrom(process.env, process.platform)
+}

--- a/src/core/git-service.ts
+++ b/src/core/git-service.ts
@@ -12,6 +12,7 @@ import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
 import { resolveGitRemote, runRemoteGit } from './remote-ssh/remote-git'
 import { platform } from './platform'
 import { findExecutableSync } from './exec-path'
+import { gitEnv } from './git-env'
 import {
   isValidCloneUrl,
   expandCloneUrl,
@@ -49,16 +50,11 @@ function ghPath(): string | null {
   return found
 }
 
-// GUI apps on macOS don't inherit the shell PATH, so a git credential helper installed by
-// Homebrew (e.g. `gh auth git-credential`, or osxkeychain shims) wouldn't be found by our
-// `git` subprocess — making push/pull fail even when the user is authed. Prepend the common
-// bin dirs. GIT_TERMINAL_PROMPT=0 makes auth failures error out fast instead of hanging on a
-// username prompt (there's no TTY here).
-const GIT_ENV: NodeJS.ProcessEnv = {
-  ...process.env,
-  PATH: `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${process.env.PATH ? `:${process.env.PATH}` : ''}`,
-  GIT_TERMINAL_PROMPT: '0'
-}
+// The environment every `git`/`gh` subprocess gets: the GUI-blind POSIX bin dirs prepended (macOS
+// credential helpers), and GIT_TERMINAL_PROMPT=0 so auth failures error out fast instead of hanging
+// on a prompt with no TTY. Both halves — and the reason the prepend must not happen on Windows
+// (issue #583) — live in git-env.ts, which github/credentials.ts imports as well.
+const GIT_ENV: NodeJS.ProcessEnv = gitEnv()
 
 // Single-flight registry for the one clone the app runs at a time. Module-scoped so a
 // macOS window re-creation can't orphan it.

--- a/src/core/github/credentials.ts
+++ b/src/core/github/credentials.ts
@@ -6,6 +6,7 @@ import type {
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { SecretStore } from '../secret-store'
+import { gitEnv } from '../git-env'
 
 export type CommandResult = { ok: boolean; stdout: string; stderr: string }
 export type CommandRunner = (command: string, args: string[]) => Promise<CommandResult>
@@ -18,10 +19,10 @@ export const runGitHubCliCommand: CommandRunner = async (command, args) => {
     const result = await execute(command, args, {
       timeout: 15_000,
       maxBuffer: 1024 * 1024,
-      env: {
-        ...process.env,
-        PATH: `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${process.env.PATH ? `:${process.env.PATH}` : ''}`
-      }
+      // Shared with git-service so the two can never disagree about what a git/gh child gets. It
+      // used to be a character-for-character copy whose hardcoded ':' corrupted PATH on Windows
+      // (issue #583) — in the credential path, which is the one that hurts most there.
+      env: gitEnv()
     })
     return { ok: true, stdout: result.stdout, stderr: result.stderr }
   } catch (error) {

--- a/src/core/tmux-hint.test.ts
+++ b/src/core/tmux-hint.test.ts
@@ -55,6 +55,28 @@ describe('findCommand', () => {
   it('tolerates a missing PATH', () => {
     expect(findCommand('brew', {}, (p) => p === '/usr/local/bin/brew')).toBe(true)
   })
+
+  // Issue #565: the split was a hardcoded ':', so on Windows every entry came apart at its drive
+  // letter. Latent (tmuxInstall answers null for win32 before this callback runs), but wrong.
+  it('win32: splits PATH on ";" and keeps drive-lettered entries whole', () => {
+    const seen: string[] = []
+    const exists = (p: string) => (seen.push(p), false)
+    findCommand('git', { PATH: 'C:\\Program Files\\Git\\cmd;C:\\Windows\\System32' }, exists, 'win32')
+    expect(seen).toEqual(['C:\\Program Files\\Git\\cmd\\git', 'C:\\Windows\\System32\\git'])
+    // The old ':' split produced these fragments; neither is a directory.
+    expect(seen.some((p) => p.startsWith('C/') || p.startsWith('C\\g'))).toBe(false)
+  })
+
+  it('win32: never stats the POSIX common bin dirs — not one of them can exist there', () => {
+    const seen: string[] = []
+    findCommand('brew', {}, (p) => (seen.push(p), false), 'win32')
+    expect(seen).toEqual([])
+  })
+
+  it('posix: an explicit platform behaves like the default', () => {
+    expect(findCommand('brew', { PATH: '/usr/bin' }, (p) => p === '/usr/bin/brew', 'darwin')).toBe(true)
+    expect(findCommand('brew', {}, (p) => p === '/opt/homebrew/bin/brew', 'linux')).toBe(true)
+  })
 })
 
 describe('tmuxCandidatePaths / findFixedTmux', () => {

--- a/src/core/tmux-hint.ts
+++ b/src/core/tmux-hint.ts
@@ -51,7 +51,8 @@ export function tmuxInstall(
 }
 
 /** Dirs GUI apps routinely miss (they don't inherit the shell PATH) — same reasoning as
- *  findTmux in pty-manager. Checked after the process PATH. */
+ *  findTmux in pty-manager. Checked after the process PATH. POSIX-only: not one of them can exist
+ *  on Windows, so stat'ing all seven per lookup there is pure waste (issue #565). */
 const COMMON_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin', '/opt/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']
 
 /**
@@ -148,14 +149,33 @@ export function bundledTmuxPath(opts: {
   return null
 }
 
-/** Is `name` on the process PATH or in the common bin dirs? `exists` is injected (fs.existsSync
- *  in production) so the lookup stays pure and testable. */
+/**
+ * Is `name` on the process PATH or in the common bin dirs? `exists` is injected (fs.existsSync
+ * in production) so the lookup stays pure and testable, and `platform` is a parameter for the same
+ * reason — the same shape as `tmuxInstall(platform, hasCommand)` above.
+ *
+ * The PATH split used to be a hardcoded ':' (issue #565). On Windows that is not the separator and
+ * every entry carries a drive-letter colon, so `C:\Program Files\Git\cmd` came apart into the
+ * fragments `C` and `\Program Files\Git\cmd` — neither of which is a directory. Latent rather
+ * than observed: the only caller hands this to `tmuxInstall`, which returns null for win32 before
+ * the callback is ever invoked. It is fixed because the rule is already the codebase's
+ * (`exec-path.ts` uses `path.delimiter`) and these were the sites that predate it — not because
+ * something on Windows reaches it today. NOTE for anyone who later makes one: a bare `name` never
+ * resolves on Windows either (`gh` is `gh.exe`); that is `executableCandidates` in exec-path.ts,
+ * and this probe deliberately does not grow a second copy of it.
+ */
 export function findCommand(
   name: string,
   env: Record<string, string | undefined>,
-  exists: (path: string) => boolean
+  exists: (path: string) => boolean,
+  platform: NodeJS.Platform | string = process.platform
 ): boolean {
-  const dirs = [...(env.PATH ? env.PATH.split(':') : []), ...COMMON_BIN_DIRS]
-  return dirs.some((d) => d && exists(`${d}/${name}`))
+  // Not `path.delimiter`: that reports the HOST's separator, and `platform` here is a parameter
+  // precisely so the mapping can be exercised from any OS.
+  const win = platform === 'win32'
+  const sep = win ? '\\' : '/'
+  const entries = env.PATH ? env.PATH.split(win ? ';' : ':') : []
+  const dirs = [...entries, ...(win ? [] : COMMON_BIN_DIRS)]
+  return dirs.some((d) => d && exists(`${d}${sep}${name}`))
 }
 


### PR DESCRIPTION
Two sites built a POSIX PATH for a git/gh subprocess with a hardcoded `:`, and one probe split PATH the same way. Fixed as one rule, as requested on both issues.

## #583 — `GIT_ENV` corrupts PATH on Windows

`src/core/git-service.ts` prepended four Unix bin dirs joined and appended with `:`. Windows splits PATH on `;` and every entry carries a drive-letter colon, so the prefix fused with the user's first real entry into a single unusable token:

```
/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:C:\Windows\System32
```

That first entry was then unreachable for every git child process — `git-credential-manager.exe` included, which fails in a way that reads as an auth problem rather than a PATH problem.

**There were two copies.** `src/core/github/credentials.ts:23` had the same construction character-for-character, in the GitHub-credentials path — the exact case the issue's impact list is about. A fix scoped to `git-service.ts` would have left it, and the two would then differ, which is the drift CLAUDE.md warns about. Both now import one `gitEnv()` from the new `src/core/git-env.ts`.

On win32 the PATH key is **omitted entirely** rather than joined with `path.delimiter`: these are Unix directories, so a `;`-joined version would be a tidier way of prepending nothing, and `...process.env` already carries the real PATH through. It also avoids a second hazard — Windows env vars are case-insensitive and `process.env` there usually spells it `Path`, so a `PATH` key of ours would be a duplicate entry for the same variable. `GIT_TERMINAL_PROMPT: '0'` stays **outside** the conditional on every platform, per the review note on the issue: it is what stops a TTY-less subprocess hanging on a credential prompt, and it is easy to lose inside a spread that is now platform-gated.

`gh auth status` / `gh auth token` are the only commands `runGitHubCliCommand` accepts, both non-interactive, so inheriting `GIT_TERMINAL_PROMPT=0` there is a strict improvement rather than a behaviour change.

## #565 — `findCommand` splits PATH on `:`

`src/core/tmux-hint.ts:158` split on a hardcoded `:` and always walked seven POSIX `COMMON_BIN_DIRS`. Now the split follows the platform and the common dirs are skipped on win32, where not one of them can exist.

This one is **latent, not observed**, exactly as the reporter corrected himself: `findCommand`'s only caller hands it to `tmuxInstall`, which returns `null` for win32 before the callback is ever invoked. It is fixed because `exec-path.ts` already had the rule and these two sites predate it — not because something on Windows reaches it today. `platform` is a parameter (defaulting to `process.platform`), the same shape as `tmuxInstall(platform, hasCommand)`, so it is exercisable from any OS; `path.delimiter` would report the host's separator and defeat that.

The existing `PATH: '/usr/bin:/bin'` assertion keeps passing — on POSIX the behaviour is byte-identical.

## Tests

`src/core/git-env.test.ts` (new, 6 cases) pins the platform split, the untouched Windows PATH, the no-duplicate-`PATH`-beside-`Path` rule, and `GIT_TERMINAL_PROMPT` on all three platforms. `src/core/tmux-hint.test.ts` gains three cases: drive-lettered entries stay whole, no POSIX dirs are stat'd on win32, and an explicit POSIX platform matches the default.

`npm run typecheck` clean; `git-env`, `tmux-hint`, `git-service`, `github/*`, `no-electron` and `fs-atomic.guard` suites green (24 + 141 tests).

## Device verification — NOT done

Both changes are reasoned and unit-tested on Linux; **neither has been run on Windows.** For a reviewer with a Windows machine:

- [ ] Source Control panel opens and `git status` / stage / commit work.
- [ ] A push or fetch over HTTPS resolves the credential helper (`git-credential-manager.exe`) instead of failing as an auth error.
- [ ] The GitHub sign-in banner reflects real `gh auth status` (this is the half that also needed #573's PATHEXT work — the two are the same user-visible symptom, so test them together, not independently).
- [ ] macOS regression: a Homebrew-installed credential helper is still found from a Dock-launched app.

Fixes #583
Fixes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
