### PR TITLE
fix(canvas): self-heal the trackpad gesture ledger when macOS drops a gestureScrollEnd

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -988,17 +988,32 @@ function createWindow(): BrowserWindow {
   // Trackpad-vs-mouse ground truth for the canvas wheel router: macOS wraps trackpad scrolls and
   // pinches in gesture begin/end events a wheel mouse never emits, visible only here in main.
   // The ledger reduces the raw stream (which includes every ~120Hz pointer packet — observe() is
-  // one Set lookup on the hot path) to edge transitions, so the renderer hears a few messages per
-  // physical gesture. Attached unconditionally: on non-mac these events simply never fire, and
-  // the renderer's router ignores the flag off macOS anyway. See main/trackpad-gesture.ts and
-  // canvas/wheel-gesture.ts for the two halves of the contract.
-  const trackpadLedger = new TrackpadGestureLedger()
-  win.webContents.on('input-event', (_event, input) => {
-    const active = trackpadLedger.observe(input.type)
-    if (active !== null && !win.isDestroyed()) {
-      win.webContents.send(IPC.canvasTrackpadGesture, active)
+  // one prefix test on the hot path) to edge transitions, so the renderer hears a few messages per
+  // physical gesture. See main/trackpad-gesture.ts and canvas/wheel-gesture.ts for the two halves
+  // of the contract.
+  //
+  // Attached on macOS ONLY (issue #535). It used to be unconditional on the grounds that these
+  // events never fire elsewhere — but Chromium synthesizes gesture scroll events for TOUCHSCREEN
+  // scrolling on Windows and Linux too, so a touch-enabled non-mac machine paid per-gesture IPC
+  // for a flag the renderer's router discards off macOS. Gating the attach makes the "desktop
+  // macOS only" contract true by construction rather than by the consumer's good manners.
+  if (process.platform === 'darwin') {
+    const trackpadLedger = new TrackpadGestureLedger()
+    const sendGesture = (active: boolean): void => {
+      if (!win.isDestroyed()) win.webContents.send(IPC.canvasTrackpadGesture, active)
     }
-  })
+    win.webContents.on('input-event', (_event, input) => {
+      const active = trackpadLedger.observe(input.type)
+      if (active !== null) sendGesture(active)
+    })
+    // A gesture cannot survive a focus loss, and an End that never arrives (⌘Tab / hide / minimize
+    // mid-scroll) would otherwise leave the ledger stuck open for the life of the window — with
+    // wheel zoom silently dead until restart. `reset()` reports whether anything was actually
+    // open, so an ordinary blur between gestures sends nothing.
+    win.on('blur', () => {
+      if (trackpadLedger.reset()) sendGesture(false)
+    })
+  }
   const crashReload = createCrashReloadPolicy()
   win.webContents.on('render-process-gone', (_event, details) => {
     ptyManager.dropClient(presenceId)

--- a/src/main/trackpad-gesture.test.ts
+++ b/src/main/trackpad-gesture.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { TrackpadGestureLedger } from './trackpad-gesture'
+import { GESTURE_STALE_MS, TrackpadGestureLedger } from './trackpad-gesture'
 
 describe('TrackpadGestureLedger', () => {
   it('reports a transition on the first begin and the matching end', () => {
@@ -49,5 +51,79 @@ describe('TrackpadGestureLedger', () => {
     expect(ledger.observe('mouseWheel')).toBe(null)
     expect(ledger.observe('gestureScrollBegin')).toBe(true)
     expect(ledger.observe('gestureScrollEnd')).toBe(false)
+  })
+
+  // Issue #535: a dropped End used to stick the depth at >= 1 for the life of the window, so no
+  // edge transition was ever emitted again and the renderer held gestureActive = true forever —
+  // wheel zoom silently dead until restart.
+  describe('a dropped gestureScrollEnd', () => {
+    it('swallows every later transition without a heal (the regression this guards)', () => {
+      const ledger = new TrackpadGestureLedger()
+      expect(ledger.observe('gestureScrollBegin', 0)).toBe(true)
+      // ... the End never arrives (window blurred / display slept mid-gesture).
+      // A later gesture, close enough in time that the staleness guard does not fire:
+      expect(ledger.observe('gestureScrollBegin', 100)).toBe(null)
+      expect(ledger.observe('gestureScrollEnd', 200)).toBe(null)
+      // Still open — this is the phantom the two guards below exist to clear.
+      expect(ledger.reset()).toBe(true)
+    })
+
+    it('heals on reset(), which reports whether an IPC message is owed', () => {
+      const ledger = new TrackpadGestureLedger()
+      expect(ledger.observe('gestureScrollBegin', 0)).toBe(true)
+      expect(ledger.reset()).toBe(true)
+      // A second reset with nothing open owes nothing — an ordinary blur must send no IPC.
+      expect(ledger.reset()).toBe(false)
+      // And the next real gesture reports both edges again.
+      expect(ledger.observe('gestureScrollBegin', 10)).toBe(true)
+      expect(ledger.observe('gestureScrollEnd', 20)).toBe(false)
+    })
+
+    it('heals on the next Begin once the open gesture has gone stale', () => {
+      const ledger = new TrackpadGestureLedger()
+      expect(ledger.observe('gestureScrollBegin', 0)).toBe(true)
+      const next = GESTURE_STALE_MS
+      expect(ledger.observe('gestureScrollBegin', next)).toBe(true)
+      expect(ledger.observe('gestureScrollEnd', next + 10)).toBe(false)
+    })
+
+    it('does not fire the staleness guard on a live gesture kept open by update packets', () => {
+      // A slow pan: gesture packets keep arriving, so the nested pinch below must still nest.
+      const ledger = new TrackpadGestureLedger()
+      expect(ledger.observe('gestureScrollBegin', 0)).toBe(true)
+      for (let t = 500; t <= GESTURE_STALE_MS * 3; t += 500) {
+        expect(ledger.observe('gestureScrollUpdate', t)).toBe(null)
+      }
+      const t = GESTURE_STALE_MS * 3 + 100
+      expect(ledger.observe('gesturePinchBegin', t)).toBe(null)
+      expect(ledger.observe('gesturePinchEnd', t + 10)).toBe(null)
+      expect(ledger.observe('gestureScrollEnd', t + 20)).toBe(false)
+    })
+
+    it('never heals on a bare mouseWheel — a live pan is made of those', () => {
+      const ledger = new TrackpadGestureLedger()
+      expect(ledger.observe('gestureScrollBegin', 0)).toBe(true)
+      expect(ledger.observe('mouseWheel', GESTURE_STALE_MS * 10)).toBe(null)
+      // Still open: the End is what closes it, never a wheel packet.
+      expect(ledger.observe('gestureScrollEnd', GESTURE_STALE_MS * 10 + 1)).toBe(false)
+    })
+  })
+})
+
+describe('main-process wiring (source-level pin)', () => {
+  const SRC = readFileSync(join(__dirname, 'index.ts'), 'utf8')
+
+  it('attaches the input-event listener on macOS only', () => {
+    // Chromium synthesizes gesture scroll events for touchscreen scrolling on Windows/Linux too,
+    // so an unconditional attach bills a touch-enabled non-mac machine for IPC nobody reads.
+    const at = SRC.indexOf("win.webContents.on('input-event'")
+    expect(at).toBeGreaterThan(0)
+    const guard = SRC.lastIndexOf("if (process.platform === 'darwin') {", at)
+    expect(guard).toBeGreaterThan(0)
+  })
+
+  it('resets the ledger on window blur and tells the renderer', () => {
+    expect(SRC).toContain("win.on('blur', () => {")
+    expect(SRC).toContain('if (trackpadLedger.reset()) sendGesture(false)')
   })
 })

--- a/src/main/trackpad-gesture.ts
+++ b/src/main/trackpad-gesture.ts
@@ -20,26 +20,84 @@
  * and a few more sit in the gap before the momentum phase's begin. The renderer's router absorbs
  * both with the same linger window it already used for heuristic stickiness — see
  * `MacWheelGestureRouter.noteGesture`.
+ *
+ * Self-healing (issue #535). A pure depth counter is only correct while every Begin is eventually
+ * paired with an End. If macOS ever drops the End for an open gesture — ⌘Tab / hide / minimize
+ * mid-scroll, a display sleep or GPU reset — the depth sticks at ≥ 1 for the life of the window:
+ * every later gesture then nests inside the phantom one, so NO edge transition is ever emitted
+ * again, the renderer holds `gestureActive = true` forever, and wheel zoom is silently dead until
+ * the app restarts. A stray End cannot rescue it either (strays are only observed at depth 0).
+ * Two guards close that, both cheap and both refusals rather than guesses:
+ *
+ *  1. `reset()` — the shell calls it on window blur (see main/index.ts). A trackpad gesture cannot
+ *     meaningfully span a focus loss, so this can never misclassify anything the user still cares
+ *     about; the worst case after a blur is the already-documented touch→momentum-gap linger.
+ *  2. A staleness check at BEGIN — a real open gesture interleaves gesture packets continuously,
+ *     so depth > 0 with no gesture packet for `GESTURE_STALE_MS` is a phantom and is cleared
+ *     before the new Begin is counted. This is what heals a drop that came with no blur at all
+ *     (display sleep), on the user's very next trackpad gesture.
+ *
+ * Deliberately NOT done: healing on a bare `mouseWheel` packet. It would fix the reported symptom
+ * one gesture sooner, but a wheel packet is also what a REAL trackpad scroll is made of, so a
+ * mis-timed heal would report a close in the middle of a live pan — and the renderer answers a
+ * close by zooming. A wrong zoom mid-pan is worse than one extra gesture of latency, and which
+ * gesture packets macOS interleaves during a slow scroll has not been measured.
  */
 
 const GESTURE_BEGIN = new Set(['gestureScrollBegin', 'gesturePinchBegin'])
 const GESTURE_END = new Set(['gestureScrollEnd', 'gesturePinchEnd'])
 
+/** Every Chromium input-event type that belongs to a trackpad gesture shares this prefix
+ *  (`gestureScrollUpdate`, `gesturePinchUpdate`, `gestureFlingStart`, …). Matching the family by
+ *  prefix rather than by an explicit list keeps the staleness clock fed by whatever packets the
+ *  running Chromium actually interleaves — an under-listed set would make a live gesture look
+ *  stale, which is the one direction that misbehaves. */
+const GESTURE_PREFIX = 'gesture'
+
+/**
+ * How long an open gesture may go with no gesture packet at all before the NEXT Begin treats it as
+ * a phantom left by a dropped End. Real gestures interleave packets at ~120 Hz, so two seconds is
+ * three orders of magnitude of headroom; the cost of being wrong in the other direction is only
+ * that the heal waits for one more gesture.
+ */
+export const GESTURE_STALE_MS = 2000
+
 export class TrackpadGestureLedger {
   private depth = 0
+  /** When a gesture packet of any kind was last seen. Only read while `depth > 0`. */
+  private lastGestureAt = 0
 
   /** Feed one raw input-event type; returns the new active state on a transition, null when
-   *  nothing changed (the overwhelmingly common case — this runs on every input event). */
-  observe(type: string): boolean | null {
+   *  nothing changed (the overwhelmingly common case — this runs on every input event). `now` is
+   *  injected so the staleness guard stays deterministically testable. */
+  observe(type: string, now: number = Date.now()): boolean | null {
+    if (!type.startsWith(GESTURE_PREFIX)) return null
     if (GESTURE_BEGIN.has(type)) {
+      // A phantom left by a dropped End would swallow this transition (depth 1 → 2) and every one
+      // after it. Clear it first, so this Begin is the outermost one it actually is.
+      if (this.depth > 0 && now - this.lastGestureAt >= GESTURE_STALE_MS) this.depth = 0
+      this.lastGestureAt = now
       this.depth += 1
       return this.depth === 1 ? true : null
     }
     if (GESTURE_END.has(type)) {
+      this.lastGestureAt = now
       if (this.depth === 0) return null
       this.depth -= 1
       return this.depth === 0 ? false : null
     }
+    // Update/fling packets: no transition, but they are the proof that the open gesture is live.
+    this.lastGestureAt = now
     return null
+  }
+
+  /**
+   * Force the ledger closed. Returns whether anything was open — i.e. whether the caller still
+   * owes the renderer a `false`, so a no-op blur sends no IPC at all.
+   */
+  reset(): boolean {
+    if (this.depth === 0) return false
+    this.depth = 0
+    return true
   }
 }


### PR DESCRIPTION
Fixes #535

## The bug

`TrackpadGestureLedger` (`src/main/trackpad-gesture.ts`) is a pure depth counter over `gestureScrollBegin/End` + `gesturePinchBegin/End`. It is only correct while every Begin is eventually paired with an End. If macOS ever drops the End for an open gesture, the depth sticks at ≥ 1 for the life of the window:

1. Every later real gesture nests inside the phantom one (Begin → depth 2, End → depth 1), so **no edge transition is ever emitted again** — the ledger only reports on 0↔1 crossings.
2. The renderer's `MacWheelGestureRouter` therefore holds `gestureActive = true` forever, and in reporting mode that routes **every** plain wheel packet to pan.
3. Wheel zoom is silently dead until the app restarts. A stray End cannot rescue it: strays are only observed at depth 0.

## The fix

Two guards, both refusals rather than guesses:

- **`reset(): boolean`**, called by the shell on `win.on('blur')`. A trackpad gesture cannot meaningfully span a focus loss, so this can never misclassify anything the user still cares about; the worst case after a blur is the already-documented touch→momentum-gap linger. The return value says whether anything was actually open, so an ordinary blur between gestures sends **no IPC at all**.
- **A staleness check at Begin** (`GESTURE_STALE_MS` = 2 s). A real open gesture interleaves gesture packets continuously (~120 Hz), so `depth > 0` with no gesture packet for two seconds is a phantom, and it is cleared before the new Begin is counted. This is what heals a drop that arrived with **no blur at all** (display sleep, GPU reset), on the user's very next trackpad gesture. `now` is injected, so it is deterministically testable.

`observe()` also short-circuits on the `gesture` prefix now, which makes the hot path (every ~120 Hz pointer packet) one prefix test instead of two Set lookups.

### Deliberately not done

**Healing on a bare `mouseWheel` packet.** It would clear the phantom one gesture sooner — but a wheel packet is also what a *real* trackpad scroll is made of, so a mis-timed heal reports a close in the middle of a live pan, and the renderer answers a close by **zooming**. A wrong zoom mid-pan is worse than one gesture of latency, and exactly which gesture packets macOS interleaves during a slow scroll has not been measured here. The reasoning is written into the ledger's doc block so the next reader does not have to re-derive it.

## Riding along

The second finding from the same #452 review thread: the `input-event` listener is now attached on **macOS only**. Chromium synthesizes gesture scroll events for touchscreen scrolling on Windows and Linux too, so a touch-enabled non-mac machine was paying per-gesture IPC for a flag the renderer's router discards off macOS. Gating the attach makes the "desktop macOS only" contract true by construction rather than by the consumer's good manners.

## Tests

`src/main/trackpad-gesture.test.ts` (13 passing):

- the regression itself — a dropped End swallows every later transition;
- `reset()` heals it, and reports whether an IPC message is owed (so a no-op blur is silent);
- the staleness guard heals on the next Begin;
- it does **not** fire on a live gesture kept open by update packets (a nested pinch still nests after 6 s of scrolling);
- it never fires on a bare `mouseWheel`.

Plus a source-level pin on the wiring (`win.webContents.on('input-event')` is inside the `darwin` guard; blur calls `reset()` and sends `false`), in the house style of `keydown-intercept.test.ts` / `canvas-wiring.test.tsx`.

`npm run typecheck` clean; `trackpad-gesture`, `wheel-gesture` and `keydown-intercept` suites green.

## Surfaces

- **Desktop (macOS)** — the fix. **Desktop (Windows/Linux)** — the listener is no longer attached; `gestureReporting` was already ignored by the router there.
- **Server Edition** — unreachable: no raw input stream, so the browser tab stays on the delta-shape heuristics. Untouched.
- **Mobile companion** — N/A (no canvas wheel routing).

## Device checklist — NOT device-verified

This box is Linux, so the guards are pinned by logic tests only, and **which trigger actually drops the End on macOS remains unmeasured**. On a Mac with a trackpad *and* a precise-pixel mouse (MX Master / Magic Mouse), with `trackpadPan` on:

1. Two-finger scroll, then ⌘Tab away mid-gesture and back. Wheel-mouse scroll must still **zoom**.
2. Same, but minimize (⌘M) / hide (⌘H) mid-gesture. Wheel zoom must still work.
3. Sleep the display mid-two-finger-scroll, wake, then wheel-scroll: the first wheel packets may pan (no blur fired), and the **next trackpad gesture** must restore zoom (staleness heal).
4. Ordinary use, no dropped End: trackpad still pans, mouse still zooms, a pinch inside a scroll still does not report a false close, and a slow 5+ second pan never flips to zoom mid-gesture.
5. Blur/focus the window repeatedly with no gesture in flight — no gesture IPC should be sent (`reset()` returning `false`).
6. Windows/Linux desktop with a touchscreen: canvas scrolling behaves as before (the router ignored the flag there already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
