### PR TITLE
fix(sidebar): match the project's own name and cwd in the sessions filter

### DIFF
--- a/src/renderer/lib/sessionList.test.ts
+++ b/src/renderer/lib/sessionList.test.ts
@@ -584,3 +584,69 @@ describe('buildStatusList', () => {
     expect(allRows.find((r) => r.id === 'a1')!.projectId).toBe('p1')
   })
 })
+
+describe('sidebar filter matches the PROJECT itself (issue #543)', () => {
+  const proj = (): ProjectInput[] => [
+    {
+      id: 'p1',
+      name: 'dot-github',
+      color: '#111',
+      cwd: '/repos/dot-github',
+      // The reported case: a project with no sessions at all could not survive ANY filter.
+      nodes: [node('g1', { kind: 'group', title: 'Frame' })]
+    },
+    {
+      id: 'p2',
+      name: 'Website',
+      color: '#222',
+      cwd: '/repos/website',
+      nodes: [
+        node('t1', { title: 'build' }),
+        node('t2', { title: 'deploy', parentId: 'gw' }),
+        node('gw', { kind: 'group', title: 'Ops' })
+      ]
+    }
+  ]
+
+  it('keeps a session-less project that the needle NAMES, and drops the others', () => {
+    const filtered = buildSessionList(proj(), null, 'p2', {}, 'dot-github')
+    expect(filtered.map((g) => g.projectId)).toEqual(['p1'])
+    // Shown whole: an empty frame stays, exactly as it does unfiltered.
+    expect(filtered[0].groups.map((b) => b.id)).toEqual(['g1'])
+  })
+
+  it('matches the project cwd too — the identity the row tooltip already shows', () => {
+    const filtered = buildSessionList(proj(), null, 'p1', {}, '/repos/website')
+    expect(filtered.map((g) => g.projectId)).toEqual(['p2'])
+  })
+
+  it('a project matched by name comes back with ALL of its sessions, not just matching ones', () => {
+    const filtered = buildSessionList(proj(), null, 'p1', {}, 'website')
+    expect(filtered.map((g) => g.projectId)).toEqual(['p2'])
+    expect(filtered[0].ungrouped.map((s) => s.id)).toEqual(['t1'])
+    expect(filtered[0].groups[0].sessions.map((s) => s.id)).toEqual(['t2'])
+  })
+
+  it('a session-level needle still narrows inside projects it does not name', () => {
+    const filtered = buildSessionList(proj(), null, 'p1', {}, 'deploy')
+    expect(filtered.map((g) => g.projectId)).toEqual(['p2'])
+    expect(filtered[0].ungrouped).toEqual([])
+    expect(filtered[0].groups[0].sessions.map((s) => s.id)).toEqual(['t2'])
+  })
+
+  it('status mode keeps every row of a project the needle names (same rule, per row)', () => {
+    const sections = buildStatusList(proj(), null, 'p1', {}, 'website')
+    const ids = sections.flatMap((s) => s.rows.map((r) => r.id))
+    expect(ids.sort()).toEqual(['t1', 't2'])
+  })
+
+  it('status mode still narrows by row for projects the needle does not name', () => {
+    const sections = buildStatusList(proj(), null, 'p1', {}, 'deploy')
+    expect(sections.flatMap((s) => s.rows.map((r) => r.id))).toEqual(['t2'])
+  })
+
+  it('an unfiltered list is untouched by the project rule', () => {
+    const unfiltered = buildSessionList(proj(), null, 'p1', {}, '')
+    expect(unfiltered.map((g) => g.projectId)).toEqual(['p1', 'p2'])
+  })
+})

--- a/src/renderer/lib/sessionList.ts
+++ b/src/renderer/lib/sessionList.ts
@@ -326,6 +326,32 @@ function matches(row: SessionRowVM, needle: string): boolean {
   return hay.includes(needle)
 }
 
+/**
+ * Does the PROJECT itself answer the needle (issue #543)? One level down, a canvas frame already
+ * survives the filter on its own name (`gn.title.toLowerCase().includes(needle)`), but a project
+ * only ever survived if something INSIDE it did — so typing a project's own name made it vanish,
+ * and a project with no sessions could not survive any filter at all. Same rule, one level up.
+ *
+ * `cwd` is included because it is the level's other identity: it is what the sidebar's own row
+ * tooltip shows, and it is already on the object being filtered — matching it costs nothing.
+ *
+ * When the project matches, it comes back with ALL of its sessions: the user typed the
+ * CONTAINER's name, so they asked for the container. A session-level needle still narrows within
+ * every other project, and a session title that matches also matches here.
+ */
+function projectMatches(p: Pick<ProjectInput, 'name' | 'cwd'>, needle: string): boolean {
+  if (!needle) return false
+  return `${p.name} ${p.cwd ?? ''}`.toLowerCase().includes(needle)
+}
+
+/** Project ids whose own name/cwd answers the needle — empty when nothing is being filtered. */
+function projectsMatchingNeedle(projects: ProjectInput[], needle: string): Set<string> {
+  const ids = new Set<string>()
+  if (!needle) return ids
+  for (const p of projects) if (projectMatches(p, needle)) ids.add(p.id)
+  return ids
+}
+
 export function buildSessionList(
   projects: ProjectInput[],
   liveActiveNodes: SessionNodeInput[] | null,
@@ -334,10 +360,14 @@ export function buildSessionList(
   filter: string
 ): SessionGroup[] {
   const needle = filter.trim().toLowerCase()
-  const keep = (r: SessionRowVM): boolean => !needle || matches(r, needle)
+  const nameMatched = projectsMatchingNeedle(projects, needle)
 
   const groups: SessionGroup[] = projects.map((p) => {
     const isActive = p.id === activeProjectId
+    // The project answered the needle itself → it is shown whole (frames included), exactly as
+    // if nothing were being filtered.
+    const projectMatched = nameMatched.has(p.id)
+    const keep = (r: SessionRowVM): boolean => !needle || projectMatched || matches(r, needle)
     const source = isActive && liveActiveNodes ? liveActiveNodes : p.nodes
     const groupNodes = source.filter((n) => n.kind === 'group')
     const groupById = new Map(groupNodes.map((n) => [n.id, n]))
@@ -376,9 +406,12 @@ export function buildSessionList(
         .map(buildBucket)
         .filter((bucket): bucket is GroupBucket => bucket !== null)
       // While filtering, a frame survives if it matches by NAME or still holds anything;
-      // unfiltered, empty frames stay so they remain visible drop targets.
+      // unfiltered, empty frames stay so they remain visible drop targets. A project matched by
+      // its OWN name is shown whole, so its empty frames stay too — same as unfiltered.
       const groupMatches = !!needle && gn.title.toLowerCase().includes(needle)
-      if (needle && !groupMatches && sessions.length === 0 && children.length === 0) return null
+      if (needle && !projectMatched && !groupMatches && sessions.length === 0 && children.length === 0) {
+        return null
+      }
       return { id: gn.id, title: gn.title, color: gn.color, sessions, children }
     }
     const buckets = groupNodes
@@ -405,7 +438,13 @@ export function buildSessionList(
 
   // Store order, NOT active-first: the sidebar mirrors the tab bar (both read the projects
   // array), and hoisting the active project to the top made every click reshuffle the list.
-  return needle ? groups.filter((g) => g.groups.length > 0 || g.ungrouped.length > 0) : groups
+  // A project whose own name/cwd matched survives even with nothing inside it (issue #543) —
+  // that is the case the old "something inside survived" rule could never express.
+  return needle
+    ? groups.filter(
+        (g) => nameMatched.has(g.projectId) || g.groups.length > 0 || g.ungrouped.length > 0
+      )
+    : groups
 }
 
 /** A status section in status-grouping mode: one status group and the sessions in it, flattened
@@ -436,7 +475,12 @@ export function buildStatusList(
   filter: string
 ): StatusSection[] {
   const needle = filter.trim().toLowerCase()
-  const keep = (r: SessionRowVM): boolean => !needle || matches(r, needle)
+  // Status mode drops project walls, so #543's rule is applied PER ROW instead of per group:
+  // a row belonging to a project the needle names is kept whole, exactly as project mode keeps
+  // the whole project.
+  const nameMatched = projectsMatchingNeedle(projects, needle)
+  const keep = (r: SessionRowVM, projectId: string): boolean =>
+    !needle || nameMatched.has(projectId) || matches(r, needle)
 
   // Flatten every project's terminal nodes into status-tagged rows. Canvas sub-group frames are
   // ignored here — status mode is flat by design. The project index rides alongside (not on the
@@ -476,7 +520,7 @@ export function buildStatusList(
       if (seen.has(node.id)) continue
       seen.add(node.id)
       const row = toRow(node, statusById[node.id], p)
-      if (keep(row)) tagged.push({ row, pidx })
+      if (keep(row, p.id)) tagged.push({ row, pidx })
     }
   })
   // A node in `liveActiveNodes` that isn't in any project's persisted set (brand-new, not yet
@@ -490,7 +534,7 @@ export function buildStatusList(
         if (n.kind !== 'terminal' || seen.has(n.id) || ownerById.has(n.id)) continue
         seen.add(n.id)
         const row = toRow(n, statusById[n.id], active)
-        if (keep(row)) tagged.push({ row, pidx: activePidx })
+        if (keep(row, active.id)) tagged.push({ row, pidx: activePidx })
       }
     }
   }


### PR DESCRIPTION
The sessions sidebar filter compared only against session rows, and a project survived only if something inside it survived:

```js
const hay = `${row.title} ${row.session ?? ''}`.toLowerCase()
…
return needle ? groups.filter((g) => g.groups.length > 0 || g.ungrouped.length > 0) : groups
```

So typing a project's own name made that project disappear, and a project with **no sessions** could not survive any filter at all — while one level down a canvas **frame** already survived on its own name (`gn.title.toLowerCase().includes(needle)`). Same list, two levels of grouping, opposite rules, and the level users think in was the one that did not match.

## What changed

`src/renderer/lib/sessionList.ts` only.

- `projectMatches(p, needle)` — the project's **name and `cwd`** now answer the needle. `cwd` because it is the level's other identity (it is what the sidebar row's tooltip already shows) and it is already on the object being filtered, so matching it costs nothing.
- **A matched project comes back WHOLE.** The user typed the container's name, so they asked for the container: every session inside it is kept, and its empty frames stay too — exactly as they do unfiltered. A session-level needle still narrows inside every project the needle does *not* name (a session title that matches also matches).
- **Status-grouping mode** drops project walls, so the same predicate is applied **per row** instead of per group: a row belonging to a named project is kept.

Nothing about the unfiltered list changed.

## Tests

Seven cases in `sessionList.test.ts`, including the reporter's exact case (a session-less `dot-github` project surviving its own name), cwd matching, whole-project vs. narrowed-within, both grouping modes, and that an unfiltered list is untouched. Mutation-checked: forcing `projectMatches` to `false` reds four of them.

`npm run typecheck` clean; `sessionList.test.ts` + `SessionsSidebar.wiring.test.ts` green (55 tests).

## Surfaces

Pure renderer logic shared by desktop and Server Edition — no bridge member, no IPC. Kanban: N/A (the board has its own source/label filters; there is no sessions-sidebar filter there). Mobile: N/A (no sessions sidebar).

## Device checklist

Verified by unit test on Linux; the UI itself was not exercised on a device.

1. Sidebar → type a project's name: that project appears with all of its sessions, others drop out.
2. Type a project's name that currently has **no** sessions: it stays visible (this is the reported bug).
3. Type part of a project's path: same result.
4. Type a session title: only the matching sessions show, inside their projects.
5. Switch the sidebar to **Status** grouping and repeat 1 and 4.
6. Clear the filter: the list is exactly what it was before this change.

## Out of scope (deliberately)

The reporter's "hide projects with nothing running" wish is not here — as they and the issue thread both argued, it is #442's disappearing act with a different trigger. Name search covers most of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
