### PR TITLE
fix(windows): reserve tab-bar space for macOS traffic lights only where they exist

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ installLogSink(logBuffer)
 import { writeFilesToClipboard } from './clipboard-files'
 import { pickProjectIcon } from './project-icon-upload'
 import { allowGuestNavigation } from './webview-nav'
+import { macTitleBarOptions } from './window-chrome'
 import { guestContextMenuTemplate } from './webview-context-menu'
 import { BrowserControlLedger } from './browser-control-ledger'
 import {
@@ -934,9 +935,11 @@ function createWindow(): BrowserWindow {
     // never mistaken for the real one (the dock already shows the Electron icon in dev).
     title: NT_MULTI ? 'node-terminal (test instance)' : 'node-terminal',
     icon: linuxIcon,
-    // Integrate the macOS traffic lights into our top bar (modern Mac app look).
-    titleBarStyle: 'hiddenInset',
-    trafficLightPosition: { x: 16, y: 15 },
+    // Integrate the macOS traffic lights into our top bar (modern Mac app look). Both options are
+    // macOS-only in Electron, and the renderer's tab bar reserves its 86px of left padding for
+    // exactly this window shape — so state the platform here rather than leaving it to Electron to
+    // ignore the values elsewhere (issue #564). Windows/Linux keep their native frame, unchanged.
+    ...macTitleBarOptions(process.platform),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       contextIsolation: true,

--- a/src/main/window-chrome.test.ts
+++ b/src/main/window-chrome.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { macTitleBarOptions } from './window-chrome'
+
+describe('macTitleBarOptions', () => {
+  it('hides the title bar and insets the traffic lights on macOS', () => {
+    expect(macTitleBarOptions('darwin')).toEqual({
+      titleBarStyle: 'hiddenInset',
+      trafficLightPosition: { x: 16, y: 15 }
+    })
+  })
+
+  // Issue #564: both options are macOS-only. Claiming them elsewhere is what made the renderer's
+  // 86px traffic-light reservation look justified on a window that has a native frame.
+  it('claims neither on Windows or Linux', () => {
+    expect(macTitleBarOptions('win32')).toEqual({})
+    expect(macTitleBarOptions('linux')).toEqual({})
+  })
+})

--- a/src/main/window-chrome.ts
+++ b/src/main/window-chrome.ts
@@ -1,0 +1,17 @@
+import type { BrowserWindowConstructorOptions } from 'electron'
+
+/**
+ * The window-frame options that only mean something on macOS.
+ *
+ * `titleBarStyle: 'hiddenInset'` + `trafficLightPosition` hide the title bar and draw the traffic
+ * lights inside the web contents — that is what our tab bar's left padding is reserved for. Both
+ * are macOS-only Electron options; on Windows and Linux the window keeps its native frame either
+ * way, so this changes nothing there and simply stops claiming a shape those platforms don't have
+ * (issue #564, where the renderer reserved the traffic-light space on Windows regardless).
+ */
+export function macTitleBarOptions(
+  platform: NodeJS.Platform
+): Pick<BrowserWindowConstructorOptions, 'titleBarStyle' | 'trafficLightPosition'> {
+  if (platform !== 'darwin') return {}
+  return { titleBarStyle: 'hiddenInset', trafficLightPosition: { x: 16, y: 15 } }
+}

--- a/src/renderer/boot.tsx
+++ b/src/renderer/boot.tsx
@@ -5,8 +5,15 @@ import { ensureClaudeCliCaps, ensureGrokCliCaps } from './state/permissionMode'
 import { ensureCodexIdentityCaps } from './state/codexIdentity'
 import { initAgentResolver } from './state/agent-resolver'
 import { refreshAgentEnv } from './lib/agentEnv'
+import { applyWindowChrome } from './lib/windowChrome'
 import './styles.css'
 import './tailwind.css'
+
+// Does this window draw the macOS traffic lights inside our own tab bar? Stamped on <html> before
+// the first paint so the tab bar reserves room for them only where they exist (issue #564: on
+// Windows/Linux and in a Server Edition browser tab there are none, and the reservation pushed the
+// logo in and squeezed the tabs). Runs after main.tsx's shell switch, so the browser flag is set.
+applyWindowChrome()
 
 // Register the custom-agent → baseAgent resolver so the capability predicates (hasHooks, canResume,
 // canControlCanvas, …) resolve a custom agent's inherited harness. Reads the live settings store.

--- a/src/renderer/lib/windowChrome.test.ts
+++ b/src/renderer/lib/windowChrome.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { applyWindowChrome, hasInsetTrafficLights } from './windowChrome'
+
+describe('hasInsetTrafficLights', () => {
+  it('is true only on the macOS desktop app', () => {
+    expect(hasInsetTrafficLights(true, false)).toBe(true)
+  })
+
+  // Issue #564: on Windows/Linux the controls live in a native title bar, so the tab bar's 86px
+  // reservation was pure waste — the logo pushed in, the tab strip that much narrower.
+  it('is false off macOS', () => {
+    expect(hasInsetTrafficLights(false, false)).toBe(false)
+  })
+
+  // A Server Edition browser tab has no window controls of its own on ANY OS, macOS included.
+  it('is false in a browser tab even on macOS', () => {
+    expect(hasInsetTrafficLights(true, true)).toBe(false)
+  })
+})
+
+describe('applyWindowChrome', () => {
+  it('stamps the attribute only where the traffic lights are inset', () => {
+    const root = { dataset: {} as Record<string, string | undefined> } as unknown as HTMLElement
+    applyWindowChrome(root, true)
+    expect(root.dataset.windowChrome).toBe('inset')
+    applyWindowChrome(root, false)
+    expect(root.dataset.windowChrome).toBeUndefined()
+  })
+})

--- a/src/renderer/lib/windowChrome.ts
+++ b/src/renderer/lib/windowChrome.ts
@@ -1,0 +1,35 @@
+/**
+ * Where the window's own controls are drawn — the one fact the tab bar's left padding depends on.
+ *
+ * The tab bar reserves space on the LEFT only because macOS draws the traffic lights INSIDE the
+ * web contents when Electron's `titleBarStyle: 'hiddenInset'` is used (`createWindow` sets it on
+ * darwin only). Nowhere else are they there: Windows and Linux keep a native frame with the
+ * controls in their own title bar, and a Server Edition browser tab has no window controls of its
+ * own at all. Reserving the space anyway pushed the logo ~86px in and took the same 86px off the
+ * tab strip — see issue #564.
+ *
+ * Both inputs are parameters so the decision can be tested; the defaults read the live values.
+ */
+import { isMacPlatform } from '@shared/platform-utils'
+import { isBrowserRuntime } from '../bridge/runtime'
+
+/** True only where the macOS traffic lights sit inside our own tab bar. */
+export function hasInsetTrafficLights(
+  mac: boolean = isMacPlatform(),
+  browser: boolean = isBrowserRuntime()
+): boolean {
+  return mac && !browser
+}
+
+/**
+ * Stamp the fact on the document root so CSS can scope the reservation
+ * (`:root[data-window-chrome='inset'] .tabbar`). Absent = no reservation, which is the
+ * safe default: a missing attribute costs 86px of tab width, a wrong one costs a covered logo.
+ */
+export function applyWindowChrome(
+  root: HTMLElement = document.documentElement,
+  inset: boolean = hasInsetTrafficLights()
+): void {
+  if (inset) root.dataset.windowChrome = 'inset'
+  else delete root.dataset.windowChrome
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -197,8 +197,7 @@ body,
   align-items: center;
   gap: 14px;
   height: 44px;
-  /* Leave room for the macOS traffic lights on the left. */
-  padding: 0 12px 0 86px;
+  padding: 0 12px;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
   /* Above the canvas and the menu backdrop so tabs/inputs stay interactive. */
@@ -206,6 +205,14 @@ body,
   flex-shrink: 0;
   /* The bar itself is the window drag region. */
   -webkit-app-region: drag;
+}
+
+/* Leave room for the macOS traffic lights on the left — ONLY where they are drawn inside the web
+   contents (Electron `titleBarStyle: 'hiddenInset'`, darwin desktop). The attribute is stamped by
+   `lib/windowChrome.ts` at boot; without it the reservation applied on Windows and Linux too,
+   pushing the logo in by 86px and taking the same 86px off the tab strip (issue #564). */
+:root[data-window-chrome='inset'] .tabbar {
+  padding-left: 86px;
 }
 
 /* Interactive elements inside the bar must not drag the window. */


### PR DESCRIPTION
## What was wrong

`.tabbar` reserved `padding-left: 86px` unconditionally, "to leave room for the macOS traffic
lights". Those exist inside the web contents only under Electron's macOS-only
`titleBarStyle: 'hiddenInset'`. On Windows and Linux the controls live in a native title bar, and
a Server Edition browser tab has no window controls at all — so the reservation pushed the logo in
by 86px and took the same 86px off the tab strip, on top of the tab-truncation the reporter also
hit.

## The fix

- **`src/renderer/lib/windowChrome.ts`** — `hasInsetTrafficLights()` = macOS **and** not a browser
  tab; `applyWindowChrome()` stamps `data-window-chrome="inset"` on `<html>`. Called from
  `boot.tsx`, i.e. after `main.tsx`'s shell switch has set the browser flag, before first paint.
- **`src/renderer/styles.css`** — `.tabbar` is `padding: 0 12px`; the 86px moves into
  `:root[data-window-chrome='inset'] .tabbar { padding-left: 86px }`. Absent attribute = no
  reservation, which is the safe default (a missing attribute costs tab width; a wrong one would
  cover the logo).
- **`src/main/window-chrome.ts`** — `macTitleBarOptions(platform)` supplies `titleBarStyle` /
  `trafficLightPosition` on `darwin` only, spread into `createWindow`. Both are macOS-only Electron
  options, so Windows/Linux keep the native frame they already had; this states the platform rather
  than leaving it to Electron to ignore the values.

Deliberately **not** changed: `.onb-skip { top: 40px }` (issue mentions it). The onboarding overlay
sits above the 44px tab bar on every platform — that offset is about the bar, not the traffic
lights, despite its comment. Changing it would be a cosmetic regression risk with no bug behind it.

## Tests

- `src/main/window-chrome.test.ts` — darwin gets both options, win32/linux get neither.
- `src/renderer/lib/windowChrome.test.ts` — the three-way predicate (mac desktop / off-mac /
  mac browser tab) and the attribute stamp/removal.
- `npm run typecheck` green; `vitest run src/renderer/lib src/main/keydown-intercept.test.ts`
  (100 files, 1182 tests) green.

## Device checklist — NOT verified on a device (this box is Linux)

1. **Windows 11**: the nodeterm logo sits at the left edge of the tab bar with normal padding, and
   the tab strip starts right after it (no 86px gap).
2. **Windows 11**: the window still has its native title bar and its controls still work — the
   `titleBarStyle` gating must be a no-op there.
3. **macOS**: traffic lights still sit inset in the tab bar at the same position, and the logo is
   still clear of them (i.e. the attribute is stamped and the 86px still applies).
4. **macOS**: dragging the window by the tab bar still works.
5. **Server Edition in a browser (any OS)**: no left gap before the logo.
6. **Linux desktop**: no left gap; native frame unchanged.

## Surfaces

Desktop (both halves), Server Edition (renderer only — it now correctly reserves nothing).
Mobile: N/A — no tab bar there.

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
