### PR TITLE
fix(test): make the suite green on a Windows clone — .gitattributes + CRLF-agnostic reads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# Line endings, decided here instead of by each contributor's git config.
+#
+# Without this file `text` and `eol` are unspecified, and Git for Windows defaults to
+# `core.autocrlf=true` — so every Windows clone gets CRLF working files while CI and every other
+# platform see LF. Any test that reads a checked-in file and reasons about `\n` then fails on a
+# checkout with zero local changes, which is the first thing a Windows contributor sees and reads
+# as "my environment is broken" (issue #578).
+#
+# `text=auto eol=lf`: git normalizes to LF in the repository, and checks out LF everywhere.
+* text=auto eol=lf
+
+# Binary assets: never touched, never diffed as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.icns binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.mp4 binary
+*.mov binary
+*.zip binary
+*.gz binary
+*.pdf binary
+
+# Windows-only entry points must keep CRLF: cmd.exe is tolerant of LF in most places but not all,
+# and these are the files a Windows contributor runs before anything else works.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,18 @@ means — and what you may assume when writing a feature — is three tiers, not
   never assume `/` or a unix socket. When a test can only run on one platform, gate it with
   `it.skipIf(process.platform === 'win32')` (or the inverse) and say why — never let it fail the
   cross-platform CI. The `windows-latest` CI job runs the platform-dependent suites on real Windows.
+- **Line endings are decided by `.gitattributes` (`* text=auto eol=lf`), not by each contributor's
+  git config.** Without it `text`/`eol` are unspecified and Git for Windows' default
+  `core.autocrlf=true` gives every Windows clone CRLF working files — so a test that reads a
+  checked-in file and slices on a `\n`-bearing literal (`CSS.indexOf('}\n}')`,
+  `indexOf('\n}\n')`, `indexOf('\n}')`) matched nothing and failed on a checkout with ZERO local
+  changes (issue #578). Two suites did; one reported 25 theme tokens missing that were all present,
+  which reads like a regression rather than a broken slice. Attributes only apply on re-checkout
+  (`git add --renormalize .` for a tree cloned earlier), so the readers ALSO normalize —
+  `readFileSync(f, 'utf8').replace(/\r\n/g, '\n')` — and `src/shared/line-endings.guard.test.ts`
+  fails on any such read that does not. `*.bat`/`*.cmd`/`*.ps1` are the deliberate exception and
+  keep CRLF: cmd.exe is not reliably tolerant of LF, and those are the files a Windows contributor
+  runs before anything else works.
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,6 +310,16 @@ Where a behaviour can only be verified on hardware we do not have in CI (a Mac, 
 GPU), say so explicitly rather than implying coverage. Several docs carry numbered device
 checklists for exactly this.
 
+**A test that reads a checked-in file must not care how git checked it out.** `.gitattributes`
+declares `* text=auto eol=lf`, so every working tree is LF — but attributes only take effect on a
+re-checkout, so if you cloned before it landed, run `git add --renormalize .` (or re-clone) and your
+tree catches up. Windows is where this bites: Git for Windows defaults to `core.autocrlf=true`, so
+without the attributes file a fresh clone had CRLF working files and `CSS.indexOf('}\n}')` matched
+nothing — two suites failed on a checkout with zero local changes, and one of them reported 25 theme
+tokens missing that were all present. Normalize at the read
+(`readFileSync(f, 'utf8').replace(/\r\n/g, '\n')`); `src/shared/line-endings.guard.test.ts` fails on
+a read that slices a `\n`-bearing literal without it.
+
 ## Pull requests
 
 - Branch from `main`. CI runs `quality`, `CodeQL` and `Dependency review`; all three are required.

--- a/src/renderer/lib/brandPulse.test.tsx
+++ b/src/renderer/lib/brandPulse.test.tsx
@@ -138,8 +138,14 @@ describe('BrandPulse', () => {
 describe('the pulse classes exist in both stylesheets', () => {
   // The class names are strings on one side and selectors on the other, so a rename can only be
   // half-done. Nothing else would notice: a missing selector loses the animation silently.
-  const CANVAS_CSS = readFileSync(join(__dirname, '..', 'styles.css'), 'utf8')
-  const HUD_CSS = readFileSync(join(__dirname, '..', 'hud', 'hud.css'), 'utf8')
+  // `.replace(/\r\n/g, '\n')` on every read below: a test that reads a checked-in file must not
+  // care how git checked it out. Git for Windows defaults to `core.autocrlf=true`, so a Windows
+  // clone has CRLF working files, and a slice on a literal containing `\n` (`indexOf('}\n}')`,
+  // `indexOf('\n}\n')`) then matches nothing and the assertion fails on a checkout with zero local
+  // changes (issue #578). `.gitattributes` is the durable half of the fix; this is the half that
+  // survives a working tree that was checked out before it landed.
+  const CANVAS_CSS = readFileSync(join(__dirname, '..', 'styles.css'), 'utf8').replace(/\r\n/g, '\n')
+  const HUD_CSS = readFileSync(join(__dirname, '..', 'hud', 'hud.css'), 'utf8').replace(/\r\n/g, '\n')
 
   it('the canvas badge class is styled and animated', () => {
     expect(CANVAS_CSS).toContain(`.${BRAND_PULSE_CLASS} {`)

--- a/src/renderer/styles.handles.test.ts
+++ b/src/renderer/styles.handles.test.ts
@@ -13,7 +13,13 @@ import { join } from 'node:path'
  * on the line above — restating the full translate chain is then that rule's own job.
  */
 
-const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
+// `.replace(/\r\n/g, '\n')` on every read below: a test that reads a checked-in file must not
+// care how git checked it out. Git for Windows defaults to `core.autocrlf=true`, so a Windows
+// clone has CRLF working files, and a slice on a literal containing `\n` (`indexOf('}\n}')`,
+// `indexOf('\n}\n')`) then matches nothing and the assertion fails on a checkout with zero local
+// changes (issue #578). `.gitattributes` is the durable half of the fix; this is the half that
+// survives a working tree that was checked out before it landed.
+const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8').replace(/\r\n/g, '\n')
 
 describe('React Flow handle rules never declare transform', () => {
   it('finds no transform inside a handle-targeting rule block', () => {

--- a/src/renderer/styles.kanban.test.ts
+++ b/src/renderer/styles.kanban.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
-const VIEW = readFileSync(join(__dirname, 'components/kanban/KanbanView.tsx'), 'utf8')
+// `.replace(/\r\n/g, '\n')` on every read below: a test that reads a checked-in file must not
+// care how git checked it out. Git for Windows defaults to `core.autocrlf=true`, so a Windows
+// clone has CRLF working files, and a slice on a literal containing `\n` (`indexOf('}\n}')`,
+// `indexOf('\n}\n')`) then matches nothing and the assertion fails on a checkout with zero local
+// changes (issue #578). `.gitattributes` is the durable half of the fix; this is the half that
+// survives a working tree that was checked out before it landed.
+const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8').replace(/\r\n/g, '\n')
+const VIEW = readFileSync(join(__dirname, 'components/kanban/KanbanView.tsx'), 'utf8').replace(/\r\n/g, '\n')
 
 describe('Kanban column row layout', () => {
   it('stretches empty columns to the height of the tallest column without filling the viewport', () => {

--- a/src/renderer/styles.pills.test.ts
+++ b/src/renderer/styles.pills.test.ts
@@ -15,7 +15,13 @@ import { join } from 'node:path'
  * a rule whose selector names exactly one pill.
  */
 
-const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
+// `.replace(/\r\n/g, '\n')` on every read below: a test that reads a checked-in file must not
+// care how git checked it out. Git for Windows defaults to `core.autocrlf=true`, so a Windows
+// clone has CRLF working files, and a slice on a literal containing `\n` (`indexOf('}\n}')`,
+// `indexOf('\n}\n')`) then matches nothing and the assertion fails on a checkout with zero local
+// changes (issue #578). `.gitattributes` is the durable half of the fix; this is the half that
+// survives a working tree that was checked out before it landed.
+const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8').replace(/\r\n/g, '\n')
 
 /**
  * The declaration body of the rule whose selector list is EXACTLY `selectors`.

--- a/src/renderer/styles.theme.test.ts
+++ b/src/renderer/styles.theme.test.ts
@@ -11,7 +11,13 @@ import { join } from 'node:path'
  * is the entire canvas and appeared exactly once. A test doesn't get bored at entry 26.
  */
 
-const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
+// `.replace(/\r\n/g, '\n')` on every read below: a test that reads a checked-in file must not
+// care how git checked it out. Git for Windows defaults to `core.autocrlf=true`, so a Windows
+// clone has CRLF working files, and a slice on a literal containing `\n` (`indexOf('}\n}')`,
+// `indexOf('\n}\n')`) then matches nothing and the assertion fails on a checkout with zero local
+// changes (issue #578). `.gitattributes` is the durable half of the fix; this is the half that
+// survives a working tree that was checked out before it landed.
+const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8').replace(/\r\n/g, '\n')
 
 /**
  * Where the light block actually starts. This MUST be anchored to the selector at the start of a

--- a/src/renderer/styles.worktree.test.ts
+++ b/src/renderer/styles.worktree.test.ts
@@ -2,8 +2,14 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
-const DIALOG = readFileSync(join(__dirname, 'components', 'WorktreeDialog.tsx'), 'utf8')
+// `.replace(/\r\n/g, '\n')` on every read below: a test that reads a checked-in file must not
+// care how git checked it out. Git for Windows defaults to `core.autocrlf=true`, so a Windows
+// clone has CRLF working files, and a slice on a literal containing `\n` (`indexOf('}\n}')`,
+// `indexOf('\n}\n')`) then matches nothing and the assertion fails on a checkout with zero local
+// changes (issue #578). `.gitattributes` is the durable half of the fix; this is the half that
+// survives a working tree that was checked out before it landed.
+const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8').replace(/\r\n/g, '\n')
+const DIALOG = readFileSync(join(__dirname, 'components', 'WorktreeDialog.tsx'), 'utf8').replace(/\r\n/g, '\n')
 
 describe('New Worktree existing-worktree list', () => {
   it('keeps large repositories inside a viewport-bounded scrolling list', () => {

--- a/src/renderer/terminal/offscreen-policy.test.ts
+++ b/src/renderer/terminal/offscreen-policy.test.ts
@@ -191,7 +191,9 @@ describe('shouldDeferReleaseForLiveWork — the fourth kill lever behind issue #
    * invariants no call can express — and it fails the moment someone threads a clock through.
    */
   it('is UNCAPPED: no clock reaches the predicate, so no caller can grow a cap', () => {
-    const src = fs.readFileSync(path.resolve(__dirname, 'offscreen-policy.ts'), 'utf8')
+    // Normalized at the read: `indexOf('\n}')` below cannot match CRLF bytes, and a Windows
+    // clone has them (issue #578).
+    const src = fs.readFileSync(path.resolve(__dirname, 'offscreen-policy.ts'), 'utf8').replace(/\r\n/g, '\n')
     const start = src.indexOf('export function shouldDeferReleaseForLiveWork')
     expect(start, 'the predicate must still exist').toBeGreaterThan(-1)
     const body = src.slice(start, src.indexOf('\n}', start))
@@ -200,7 +202,7 @@ describe('shouldDeferReleaseForLiveWork — the fourth kill lever behind issue #
     expect(body).toMatch(/shouldDeferReleaseForLiveWork\(\s*i: LiveWorkInput\s*\)/)
     expect(body).not.toMatch(/elapsed|Ms\b|Date\.now|cap|minutes/i)
     // …and the shared input type itself carries no clock either (the other end of the same claim).
-    const live = fs.readFileSync(path.resolve(__dirname, 'live-work.ts'), 'utf8')
+    const live = fs.readFileSync(path.resolve(__dirname, 'live-work.ts'), 'utf8').replace(/\r\n/g, '\n')
     const iface = live.slice(live.indexOf('export interface LiveWorkInput'))
     expect(iface.slice(0, iface.indexOf('\n}'))).not.toMatch(/elapsed|Date\.now|cap|minutes/i)
   })

--- a/src/shared/line-endings.guard.test.ts
+++ b/src/shared/line-endings.guard.test.ts
@@ -1,0 +1,80 @@
+// A test that reads a checked-in file must not care how git checked it out.
+//
+// Issue #578: with no `.gitattributes`, `text`/`eol` are unspecified, and Git for Windows defaults
+// to `core.autocrlf=true` — so every Windows clone gets CRLF working files. A test that then slices
+// on a literal containing `\n` (`CSS.indexOf('}\n}')`, `CSS.indexOf('\n}\n')`) matches nothing, the
+// slice degenerates, and the assertion fails on a checkout with ZERO local changes. Two suites did
+// exactly that, and the second one (`styles.theme.test.ts`) reported 25 colour tokens missing that
+// were all present — a failure that reads like a real regression rather than a broken slice.
+//
+// Two halves, and this guard pins both:
+//   1. `.gitattributes` normalizes the working tree on every platform. Durable, and it closes the
+//      class rather than the instance.
+//   2. The readers normalize anyway — which is what protects a working tree that was checked out
+//      BEFORE the attributes file landed (they only take effect on re-checkout or
+//      `git add --renormalize .`).
+//
+// Deliberately narrow: it only asks about test files that BOTH read a file and slice on a
+// `\n`-bearing literal. A broad "every readFileSync must normalize" rule would fire on the many
+// guard tests that read source and only ever use `includes`/regex, where the bytes do not matter.
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const REPO_ROOT = join(__dirname, '..', '..')
+const SRC = join(REPO_ROOT, 'src')
+
+function testFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) testFiles(full, out)
+    else if (/\.test\.tsx?$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * A search for a literal that contains an escaped newline AND something else — the shape that
+ * breaks. `split('\n')` and a bare `indexOf('\n')` are deliberately excluded: they survive CRLF
+ * (a stray `\r` is trimmed, or lands one character before a boundary the caller re-derives), and
+ * including them would fire on a dozen guard tests that only ever line-split source.
+ */
+const NEWLINE_SLICE = /\b(indexOf|lastIndexOf)\(\s*(['"])(?=[^'"]*\\n)(?=[^'"]*[^'"\\n])[^'"]{2,}?\2/
+/**
+ * A read of a file that comes out of the git CHECKOUT — its path is built from `__dirname` or the
+ * repo root. A test that reads a temp file it just WROTE (a fake curl's argv log) is unaffected by
+ * how git checks anything out, so those are not the subject.
+ */
+const READ_CALL = /readFileSync\([^)]*(?:__dirname|repoRoot|REPO_ROOT)[^)]*\)/g
+const NORMALIZED = /\.replace\(\/\\r\\n\/g,\s*'\\n'\)/
+
+describe('line endings', () => {
+  it('.gitattributes normalizes the working tree to LF on every platform', () => {
+    const file = join(REPO_ROOT, '.gitattributes')
+    expect(existsSync(file), '.gitattributes is missing — Windows clones will be CRLF').toBe(true)
+    const text = readFileSync(file, 'utf8')
+    expect(text).toMatch(/^\*\s+text=auto\s+eol=lf\s*$/m)
+    // Windows entry points are the deliberate exception: cmd.exe is not reliably tolerant of LF,
+    // and these are the files a Windows contributor runs before anything else works.
+    expect(text).toMatch(/^\*\.bat\s+text\s+eol=crlf\s*$/m)
+  })
+
+  it('a test that slices on a \\n literal normalizes what it read', () => {
+    const offenders: string[] = []
+    for (const file of testFiles(SRC)) {
+      if (file === __filename) continue // this file quotes the broken shapes in prose
+      const source = readFileSync(file, 'utf8')
+      if (!NEWLINE_SLICE.test(source)) continue
+      for (const call of source.match(READ_CALL) ?? []) {
+        const after = source.slice(source.indexOf(call) + call.length, source.indexOf(call) + call.length + 40)
+        if (!NORMALIZED.test(after)) offenders.push(`${file.slice(REPO_ROOT.length + 1)}: ${call}`)
+      }
+    }
+    expect(
+      offenders,
+      "these reads slice on a '\\n' literal but keep the bytes as checked out — append " +
+        ".replace(/\\r\\n/g, '\\n') (issue #578)"
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
A fresh clone on Windows has a red suite before you change anything. Both halves of the fix, as agreed on the issue.

## The class

With no `.gitattributes`, `text` and `eol` are unspecified, and Git for Windows defaults to `core.autocrlf=true` — so every Windows clone gets CRLF working files while CI and every other platform see LF. A test that reads a checked-in file and slices on a literal containing `\n` then matches nothing, the slice degenerates, and the assertion fails on a checkout with **zero local changes**. That is a worse signal than a missing feature: it teaches a new contributor to distrust the suite, on the exact command `CONTRIBUTING.md` names as the gate.

## Three failing sites, not one

The report named `brandPulse.test.tsx` (`indexOf('}\n}')`), and the review comment added `styles.theme.test.ts` (`indexOf('\n}\n')`). The new guard found a third the scan on `src/renderer/lib` + `src/renderer/state` could not reach:

| site | shape | verdict |
|---|---|---|
| `renderer/lib/brandPulse.test.tsx` | `indexOf('}\n}')` | **failed** |
| `renderer/styles.theme.test.ts` | `indexOf('\n}\n')` | **failed** |
| `renderer/terminal/offscreen-policy.test.ts` | `indexOf('\n}')` ×2 | **failed** |

The `styles.theme.test.ts` one is the alarming failure — it reports 25 colour tokens missing that are all present, which reads like a real theme regression rather than a broken slice.

The remaining `styles.*.test.ts` reads are normalized too. They survive CRLF today by luck (they split on `\n` and trim), not by design, and the point of normalizing at the read is that nobody has to re-derive which shapes are lucky.

## The fix

1. **`.gitattributes`** — `* text=auto eol=lf`, so checked-in text is LF in the working tree on every platform. `*.bat` / `*.cmd` / `*.ps1` are the deliberate exception and keep CRLF: cmd.exe is not reliably tolerant of LF, and those are the files a Windows contributor runs before anything else works. Binary asset extensions are marked so they are never touched or diffed as text.
2. **The readers normalize anyway** — `.replace(/\r\n/g, '\n')` at each read, which is the cheapest form and covers every existing literal in the file. This is not belt-and-braces: attributes only take effect on a **re-checkout**, so a tree cloned before this lands stays CRLF until `git add --renormalize .` or a fresh clone. `CONTRIBUTING.md` says so, in the Testing section.
3. **`src/shared/line-endings.guard.test.ts`** pins both halves. It fails on any future read of a **checked-out** file (path built from `__dirname` / the repo root) that slices a `\n`-bearing literal without normalizing — deliberately narrow, so it does not fire on the many guard tests that read source and only ever use `includes`/regex, nor on tests that read a temp file they just wrote.

## Verification

The reporter's repro, runnable on Linux without a Windows machine:

```
sed -i 's/$/\r/' src/renderer/styles.css src/renderer/hud/hud.css \
                 src/renderer/terminal/offscreen-policy.ts src/renderer/terminal/live-work.ts
npx vitest run src/renderer/lib/brandPulse.test.tsx src/renderer/styles.*.test.ts \
               src/renderer/terminal/offscreen-policy.test.ts
```

Before: 3 files failed. After: **7 files / 59 tests passed.** `npm run typecheck` clean; `src/shared` (64 files, 1055 tests) green.

## Device verification — NOT done

The mechanism is reproduced and fixed on Linux; **no run on a real Windows clone.** For a reviewer with a Windows machine:

- [ ] Fresh `git clone` with default Git for Windows settings, `npm install --ignore-scripts`, `npx vitest run src/renderer` — green, including `brandPulse` and `styles.theme`.
- [ ] `git check-attr text eol -- src/renderer/styles.css` reports `text: auto` / `eol: lf`, and the checked-out file has LF bytes.
- [ ] `bootstrap-windows.bat` still runs (it is the one file deliberately kept CRLF).
- [ ] An existing Windows clone: `git add --renormalize .` reports no content changes beyond line endings.

Fixes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
