### PR TITLE
fix(sidebar): clear the sessions filter in one action

### DIFF
--- a/src/renderer/components/SessionsSidebar.tsx
+++ b/src/renderer/components/SessionsSidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   buildSessionList,
   buildStatusList,
@@ -17,6 +17,7 @@ import {
   type SessionRowVM,
   type StatusSection
 } from '../lib/sessionList'
+import { sidebarEmptyState, sidebarFilterKeyAction } from '../lib/sidebarFilter'
 import { SessionRow } from './SessionRow'
 import { ProjectGlyph } from './ProjectGlyph'
 import { ClosedHistorySection } from './ClosedHistorySection'
@@ -158,6 +159,15 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
         : [],
     [open, grouping, projects, liveActiveNodes, activeProjectId, statusById, filter]
   )
+  /**
+   * The list came back with nothing in it — in EITHER grouping mode. "Nothing here" and "nothing
+   * matched" are different facts (issue #505): the filter persists while you work, so half an hour
+   * after finding one session the sidebar was still filtered, still empty, and still saying "No
+   * sessions yet." — which reads as a broken sidebar rather than a stale filter.
+   */
+  const noRows = grouping === 'status' ? statusSections.length === 0 : groups.length === 0
+  const emptyState = sidebarEmptyState(noRows, filter, grouping)
+  const clearFilter = useCallback(() => setFilter(''), [])
 
   // Relative state ages need to advance even when no hook event arrives. Keep the clock dormant
   // unless the status view is visible; 30s catches minute boundaries without per-row timers.
@@ -515,7 +525,27 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
           placeholder="Filter sessions…"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
+          // Escape clears the filter in ONE action (issue #505) instead of select-all-delete.
+          // The refusal on an empty field lives in `sidebarFilterKeyAction`, so Escape still
+          // reaches whatever owns it next and never becomes a dead end inside this input.
+          onKeyDown={(e) => {
+            if (sidebarFilterKeyAction(e.key, filter) !== 'clear') return
+            e.preventDefault()
+            e.stopPropagation()
+            clearFilter()
+          }}
         />
+        {filter !== '' && (
+          <button
+            type="button"
+            className="sessions-sidebar__search-clear"
+            title="Clear filter (Esc)"
+            aria-label="Clear filter"
+            onClick={clearFilter}
+          >
+            ×
+          </button>
+        )}
       </div>
 
       <div
@@ -535,7 +565,17 @@ export function SessionsSidebar(props: SessionsSidebarProps): JSX.Element | null
           setDropProj(null)
         }}
       >
-        {groups.length === 0 && grouping !== 'status' && (
+        {emptyState === 'no-matches' && (
+          // A filtered list that came back empty says so — and offers the one action that undoes
+          // it, in both grouping modes (status mode had no empty state at all).
+          <div className="sessions-sidebar__empty">
+            <div>No sessions match “{filter.trim()}”.</div>
+            <button type="button" className="sessions-sidebar__empty-clear" onClick={clearFilter}>
+              Clear filter
+            </button>
+          </div>
+        )}
+        {emptyState === 'no-sessions' && (
           <div className="sessions-sidebar__empty">No sessions yet.</div>
         )}
         {grouping === 'status' ? (

--- a/src/renderer/lib/sidebarFilter.test.ts
+++ b/src/renderer/lib/sidebarFilter.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { sidebarEmptyState, sidebarFilterKeyAction } from './sidebarFilter'
+
+describe('sidebarFilterKeyAction — Escape clears the filter (issue #505)', () => {
+  it('clears in one action while the field holds text', () => {
+    expect(sidebarFilterKeyAction('Escape', 'api')).toBe('clear')
+  })
+
+  it('leaves Escape alone on an empty field, so the key is never a dead end here', () => {
+    expect(sidebarFilterKeyAction('Escape', '')).toBe('ignore')
+  })
+
+  it('ignores every other key', () => {
+    expect(sidebarFilterKeyAction('Enter', 'api')).toBe('ignore')
+    expect(sidebarFilterKeyAction('a', 'api')).toBe('ignore')
+    expect(sidebarFilterKeyAction('Backspace', 'api')).toBe('ignore')
+  })
+})
+
+describe('sidebarEmptyState — "nothing matched" is not "nothing here"', () => {
+  it('says nothing while the list has rows', () => {
+    expect(sidebarEmptyState(false, '', 'project')).toBe('none')
+    expect(sidebarEmptyState(false, 'api', 'project')).toBe('none')
+    expect(sidebarEmptyState(false, 'api', 'status')).toBe('none')
+  })
+
+  it('reports no-matches in BOTH grouping modes when a filter is active', () => {
+    expect(sidebarEmptyState(true, 'api', 'project')).toBe('no-matches')
+    // Status mode renders only non-empty sections, so this used to be a blank panel with no
+    // sentence at all — the case that read as "no sessions".
+    expect(sidebarEmptyState(true, 'api', 'status')).toBe('no-matches')
+  })
+
+  it('treats a whitespace-only filter as no filter (it matches everything)', () => {
+    expect(sidebarEmptyState(true, '   ', 'project')).toBe('no-sessions')
+  })
+
+  it('keeps the unfiltered empty state exactly where it was: project mode only', () => {
+    expect(sidebarEmptyState(true, '', 'project')).toBe('no-sessions')
+    expect(sidebarEmptyState(true, '', 'status')).toBe('none')
+  })
+})

--- a/src/renderer/lib/sidebarFilter.ts
+++ b/src/renderer/lib/sidebarFilter.ts
@@ -1,0 +1,43 @@
+import type { SidebarGrouping } from './sessionList'
+
+/**
+ * Pure decisions behind the sessions sidebar's filter field (issue #505). The field was quick to
+ * type into and slow to get out of: no clear button, no `type="search"` ✕, and Escape did nothing
+ * — so going back to the full list meant select-all-delete. The filter also persists while you
+ * work, so a list filtered half an hour ago was still filtered, still empty, and still saying
+ * "No sessions yet.", which reads as a broken sidebar rather than a stale filter.
+ */
+
+/** What a keydown inside the filter field means. */
+export type SidebarFilterKeyAction = 'clear' | 'ignore'
+
+/**
+ * Escape clears the filter in ONE action — but ONLY while there is text to clear. On an empty
+ * field it is `ignore`, so the key is left alone and still reaches whatever owns it next (the
+ * dialog stack, the drawer); a field that swallowed Escape unconditionally would be a dead end
+ * for the one key users reach for to back out of things.
+ */
+export function sidebarFilterKeyAction(key: string, filter: string): SidebarFilterKeyAction {
+  return key === 'Escape' && filter !== '' ? 'clear' : 'ignore'
+}
+
+/** Which sentence (if any) an empty sessions list should show. */
+export type SidebarEmptyState = 'none' | 'no-sessions' | 'no-matches'
+
+/**
+ * "Nothing here" and "nothing matched" are different facts, and only the second one has an undo.
+ *
+ * `no-matches` is reported in BOTH grouping modes: status mode renders only non-empty sections,
+ * so a filter that matched nothing there used to produce a completely blank panel with no
+ * sentence at all. `no-sessions` stays project-mode-only, exactly as before — status mode has
+ * never had an unfiltered empty state and this is not the change that adds one.
+ */
+export function sidebarEmptyState(
+  noRows: boolean,
+  filter: string,
+  grouping: SidebarGrouping
+): SidebarEmptyState {
+  if (!noRows) return 'none'
+  if (filter.trim() !== '') return 'no-matches'
+  return grouping === 'status' ? 'none' : 'no-sessions'
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7292,10 +7292,44 @@ button.group-node__setup:disabled {
 .sessions-sidebar__head-actions button { width: 24px; height: 24px; display: inline-flex; align-items: center; justify-content: center; background: transparent; border: none; color: var(--text); cursor: pointer; border-radius: 6px; }
 .sessions-sidebar__head-actions button:hover { background: var(--panel-header); }
 .sessions-sidebar__head-actions button.is-on { color: var(--accent); }
-.sessions-sidebar__search { margin: 8px 10px 4px; }
-.sessions-sidebar__search input { width: 100%; box-sizing: border-box; font-size: 12px; padding: 5px 8px; background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 7px; }
+.sessions-sidebar__search { margin: 8px 10px 4px; position: relative; }
+/* Right padding leaves room for the clear button, which overlays the field's trailing edge. */
+.sessions-sidebar__search input { width: 100%; box-sizing: border-box; font-size: 12px; padding: 5px 24px 5px 8px; background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 7px; }
+/* Issue #505: one action back to the full list. Quiet until hovered — it is an escape hatch,
+   not a control competing with the field. */
+.sessions-sidebar__search-clear {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+.sessions-sidebar__search-clear:hover { color: var(--text); background: var(--panel-header); }
 .sessions-sidebar__body { overflow-y: auto; padding: 4px 6px 8px; }
 .sessions-sidebar__empty { padding: 18px 12px; text-align: center; font-size: 12px; color: var(--muted); }
+.sessions-sidebar__empty-clear {
+  margin-top: 8px;
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font-size: 11px;
+  cursor: pointer;
+}
+.sessions-sidebar__empty-clear:hover { border-color: var(--accent); color: var(--accent); }
 
 /* "Recently closed" — merged closed-projects/closed-sessions history at the bottom of the
    sidebar. Same head layout as .sessions-sidebar__head, just smaller/muted (it is a secondary


### PR DESCRIPTION
The sessions sidebar's filter is a plain `<input>` with a placeholder and an `onChange` — no clear button, no `type="search"` (so no native ✕ on WebKit), and Escape does nothing while it has focus. Getting back to the full list means select-all-delete or holding backspace.

It bites more than it sounds like because the filter persists while you work: filter to find one session, switch to it, and half an hour later the sidebar is still filtered — sometimes with a count of 0 and an empty panel that reads as "no sessions" rather than "no matches".

## What changed

- **Escape clears the field** — but only while it HOLDS text. On an empty field the key is left alone, so it still reaches whatever owns it next (the dialog stack, the drawer) and this input never becomes a dead end for the one key people reach for to back out of things.
- **A ✕ button** appears in the field while it holds text (title `Clear filter (Esc)`).
- **An empty list under an active filter says so**: `No sessions match “x”.` with a **Clear filter** button — in BOTH grouping modes. Status mode renders only non-empty sections, so a filter that matched nothing there produced a completely blank panel with no sentence at all. The unfiltered `No sessions yet.` stays exactly where it was: project mode only. This PR is not the one that gives status mode an unfiltered empty state.

The issue said any of the three escapes would do and expressed no preference; all three are cheap and they compose, so all three are here.

## Tests

Both decisions are pure functions in the new `renderer/lib/sidebarFilter.ts` — `sidebarFilterKeyAction` and `sidebarEmptyState` — with unit tests covering the empty-field Escape refusal, the whitespace-only filter, and that the unfiltered empty state did not move. `npm run typecheck` clean; `sidebarFilter.test.ts` + `SessionsSidebar.wiring.test.ts` green.

## Surfaces

Pure renderer — desktop and Server Edition both get it, no bridge member, no IPC. Kanban: N/A (the board's own source/label filters are a different control; there is no sessions-filter field there or in the card modal). Mobile: N/A (no sessions sidebar).

## Device checklist

Verified by unit test on Linux; the UI was not exercised on a device.

1. Sidebar → type in the filter: a ✕ appears at the field's trailing edge; click it → full list back, ✕ gone.
2. Type a filter, press **Esc** with the field focused → cleared; the sidebar/drawer does not also close.
3. Press **Esc** in the empty filter field → nothing is swallowed (whatever Escape normally does still happens).
4. Type a filter that matches nothing → "No sessions match “…”." plus a Clear filter button; click it.
5. Switch grouping to **Status** and repeat 4 (this is the case that used to be a blank panel).
6. With no projects/sessions and an empty filter → still "No sessions yet." in Project mode, still nothing in Status mode.
7. Light and dark: the ✕ and the Clear filter button read correctly in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
