### PR TITLE
fix(welcome): order "Recently closed" by recency, and filter it past six rows

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -420,7 +420,11 @@ import { freeSpot } from '../lib/placement'
 import { pushSessionRename, sessionNameUnchanged } from '../lib/sessionRename'
 import { useReopenHistory, type ReopenEntry } from '../state/reopenHistory'
 import { snapshotNode, recreateNodeFromSnapshot } from '../lib/reopenNode'
-import { buildClosedSessionEntries, stateToReopenSnapshot } from '../lib/closedHistory'
+import {
+  buildClosedSessionEntries,
+  recentlyClosedProjects,
+  stateToReopenSnapshot
+} from '../lib/closedHistory'
 import { uuid } from '../lib/uuid'
 import { planReopen, type ReopenPlan } from '../lib/reopenPlan'
 import { oneLine } from '@shared/one-line'
@@ -1434,11 +1438,11 @@ export function Canvas() {
   const hasProjects = useProjects((s) => s.projects.some((p) => !p.closed))
   // Exclude UNAVAILABLE closed projects (folder missing): reopenProject would activate them
   // unconditionally → a silent-discard empty canvas (the same case the palette guard blocks).
-  // useShallow: the filter derives a NEW array each call — without it, every useProjects write
+  // Ordered newest-CLOSED first, so the "Recently closed" heading is true (issue #506) — this
+  // used to be tab order, which put the project shut ten minutes ago wherever its tab sat.
+  // useShallow: the selector derives a NEW array each call — without it, every useProjects write
   // (each kanban board commit, each debounced canvas save) re-rendered the entire Canvas.
-  const closedProjects = useProjects(
-    useShallow((s) => s.projects.filter((p) => p.closed && !p.unavailable))
-  )
+  const closedProjects = useProjects(useShallow((s) => recentlyClosedProjects(s.projects)))
   // The active project's SSH server (if it's an SSH project) — drives the connection banner.
   const activeSshServer = useProjects(
     (s) => s.projects.find((p) => p.id === s.activeProjectId)?.ssh?.server

--- a/src/renderer/components/WelcomeScreen.test.tsx
+++ b/src/renderer/components/WelcomeScreen.test.tsx
@@ -62,3 +62,80 @@ describe('WelcomeScreen — Recently closed session badges (issue #442)', () => 
     expect(onReopen).not.toHaveBeenCalled()
   })
 })
+
+describe('WelcomeScreen — Recently closed filter (issue #506)', () => {
+  let root: Root
+  let host: HTMLElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  const render = async (el: React.ReactElement): Promise<void> => {
+    await act(async () => root.render(el))
+  }
+
+  const many = Array.from({ length: 7 }, (_, i) => ({
+    id: `p${i}`,
+    name: i === 3 ? 'dot-github' : `Project ${i}`,
+    cwd: `/repos/p${i}`
+  }))
+
+  const base = {
+    onNewProject: noop,
+    onOpenFolder: noop,
+    onCloneRepo: noop,
+    onConnectSsh: noop
+  }
+
+  const type = async (input: HTMLInputElement, value: string): Promise<void> => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(input, value)
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  it('stays out of the way below the visible-row cap', async () => {
+    await render(<WelcomeScreen {...base} closedProjects={many.slice(0, 6)} />)
+    expect(host.querySelector('.welcome__recent-filter')).toBeNull()
+  })
+
+  it('appears once the list is longer than the cap, and narrows by name', async () => {
+    await render(<WelcomeScreen {...base} closedProjects={many} />)
+    const input = host.querySelector('.welcome__recent-filter') as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(host.querySelectorAll('.welcome__recent-item')).toHaveLength(7)
+
+    await type(input, 'dot-git')
+    const rows = host.querySelectorAll('.welcome__recent-name')
+    expect(Array.from(rows).map((r) => r.textContent)).toEqual(['dot-github'])
+  })
+
+  it('narrows by folder too — the row already renders it as the title', async () => {
+    await render(<WelcomeScreen {...base} closedProjects={many} />)
+    const input = host.querySelector('.welcome__recent-filter') as HTMLInputElement
+    await type(input, '/repos/p5')
+    expect(host.querySelectorAll('.welcome__recent-item')).toHaveLength(1)
+  })
+
+  it('says nothing matched instead of rendering an empty list', async () => {
+    await render(<WelcomeScreen {...base} closedProjects={many} />)
+    const input = host.querySelector('.welcome__recent-filter') as HTMLInputElement
+    await type(input, 'zzzz')
+    expect(host.querySelectorAll('.welcome__recent-item')).toHaveLength(0)
+    expect(host.querySelector('.welcome__recent-empty')!.textContent).toContain('zzzz')
+  })
+
+  it('the section itself stays hidden when there are no closed projects at all', async () => {
+    await render(<WelcomeScreen {...base} closedProjects={[]} />)
+    expect(host.querySelector('.welcome__recent')).toBeNull()
+  })
+})

--- a/src/renderer/components/WelcomeScreen.tsx
+++ b/src/renderer/components/WelcomeScreen.tsx
@@ -1,6 +1,14 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ProjectIcon } from '@shared/project-icon'
+import { filterClosedProjects } from '../lib/closedHistory'
 import { ProjectGlyph } from './ProjectGlyph'
+
+/**
+ * Rows before the "Recently closed" filter box appears (issue #506). `.welcome__recent-list` is
+ * capped at 220px ≈ six rows, so this is the point where the list starts scrolling — below it a
+ * filter would only be clutter for someone with three projects.
+ */
+const RECENT_FILTER_THRESHOLD = 6
 
 interface WelcomeScreenProps {
   onNewProject: () => void
@@ -46,6 +54,12 @@ export function WelcomeScreen({
   onClose,
   overBoard
 }: WelcomeScreenProps) {
+  const [query, setQuery] = useState('')
+  const visibleClosed = useMemo(
+    () => filterClosedProjects(closedProjects, query),
+    [closedProjects, query]
+  )
+
   useEffect(() => {
     if (!onClose) return
     const onKey = (e: KeyboardEvent) => {
@@ -141,8 +155,29 @@ export function WelcomeScreen({
       {closedProjects.length > 0 && (
         <div className="welcome__recent">
           <div className="welcome__recent-title">Recently closed</div>
+          {/* Shown only past the visible-row cap: with three closed projects a filter box is
+              in the way, and past six the list is already scrolling. */}
+          {closedProjects.length > RECENT_FILTER_THRESHOLD && (
+            <input
+              className="welcome__recent-filter"
+              placeholder="Filter by name or folder…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                // Esc clears the box before it reaches the screen's own close handler; on an
+                // empty box it falls through and still closes the screen.
+                if (e.key !== 'Escape' || query === '') return
+                e.preventDefault()
+                e.stopPropagation()
+                setQuery('')
+              }}
+            />
+          )}
           <div className="welcome__recent-list">
-            {closedProjects.map((p) => (
+            {visibleClosed.length === 0 && (
+              <div className="welcome__recent-empty">No closed projects match “{query.trim()}”.</div>
+            )}
+            {visibleClosed.map((p) => (
               <div
                 key={p.id}
                 className="welcome__recent-item"

--- a/src/renderer/lib/closedHistory.test.ts
+++ b/src/renderer/lib/closedHistory.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { buildClosedSessionEntries, stateToReopenSnapshot, mergeClosedHistory } from './closedHistory'
+import {
+  buildClosedSessionEntries,
+  filterClosedProjects,
+  mergeClosedHistory,
+  recentlyClosedProjects,
+  stateToReopenSnapshot
+} from './closedHistory'
 import type { CanvasNode } from '@renderer/state/workspace'
 import type { ClosedSessionEntry, Project } from '@shared/types'
 
@@ -134,5 +140,59 @@ describe('mergeClosedHistory', () => {
   it('excludes an unavailable closed project', () => {
     const rows = mergeClosedHistory([proj({ id: 'a', closed: true, unavailable: true, closedAt: 5 })])
     expect(rows).toHaveLength(0)
+  })
+})
+
+describe('recentlyClosedProjects — the heading promises recency (issue #506)', () => {
+  type Probe = { id: string; name: string; closed?: boolean; unavailable?: boolean; closedAt?: number }
+  const p = (id: string, over: Partial<Probe> = {}): Probe => ({ id, name: id, ...over })
+
+  it('orders newest-closed first, NOT tab order', () => {
+    // Tab order here is old, new, mid — the project shut most recently must lead regardless.
+    const rows = recentlyClosedProjects([
+      p('old', { closed: true, closedAt: 10 }),
+      p('new', { closed: true, closedAt: 300 }),
+      p('mid', { closed: true, closedAt: 100 })
+    ])
+    expect(rows.map((r) => r.id)).toEqual(['new', 'mid', 'old'])
+  })
+
+  it('drops open and unavailable projects', () => {
+    const rows = recentlyClosedProjects([
+      p('open'),
+      p('gone', { closed: true, unavailable: true, closedAt: 999 }),
+      p('kept', { closed: true, closedAt: 1 })
+    ])
+    expect(rows.map((r) => r.id)).toEqual(['kept'])
+  })
+
+  it('sorts a project closed before the field existed last, never as NaN', () => {
+    const rows = recentlyClosedProjects([p('legacy', { closed: true }), p('known', { closed: true, closedAt: 5 })])
+    expect(rows.map((r) => r.id)).toEqual(['known', 'legacy'])
+  })
+})
+
+describe('filterClosedProjects', () => {
+  const rows = [
+    { id: 'a', name: 'Website', cwd: '/repos/site' },
+    { id: 'b', name: 'API', cwd: '/repos/api-server' }
+  ]
+
+  it('matches the project name', () => {
+    expect(filterClosedProjects(rows, 'web').map((r) => r.id)).toEqual(['a'])
+  })
+
+  it('matches the folder, which is what the row already shows as its title', () => {
+    expect(filterClosedProjects(rows, 'api-server').map((r) => r.id)).toEqual(['b'])
+  })
+
+  it('is case-insensitive and returns everything for an empty or blank query', () => {
+    expect(filterClosedProjects(rows, 'WEBSITE').map((r) => r.id)).toEqual(['a'])
+    expect(filterClosedProjects(rows, '')).toHaveLength(2)
+    expect(filterClosedProjects(rows, '   ')).toHaveLength(2)
+  })
+
+  it('returns nothing when nothing matches (the caller says so, it does not fall back)', () => {
+    expect(filterClosedProjects(rows, 'zzz')).toHaveLength(0)
   })
 })

--- a/src/renderer/lib/closedHistory.ts
+++ b/src/renderer/lib/closedHistory.ts
@@ -104,6 +104,42 @@ export type ClosedHistoryRow =
  * no known `closedAt` (pre-existing data from before that field existed) sorts last via the `-1`
  * sentinel — never `NaN` from subtracting `undefined`.
  */
+/**
+ * The start screen's "Recently closed" list: closed, AVAILABLE projects, newest-closed first
+ * (issue #506).
+ *
+ * The heading promises recency and the list did not deliver it — it was
+ * `projects.filter(p => p.closed && !p.unavailable)`, i.e. TAB order, so the project shut ten
+ * minutes ago sat wherever its tab happened to be. With the list capped to about six visible
+ * rows, that turned scanning into hunting.
+ *
+ * `unavailable` is excluded for the same reason the Canvas selector always excluded it: reopening
+ * a ref whose folder is missing activates an empty placeholder. Sort rule and `-1` sentinel are
+ * `mergeClosedHistory`'s, deliberately — the two lists describe the same event and must not order
+ * it differently; `closedAt` is absent only on projects closed before that field existed, and
+ * those sort last rather than becoming `NaN`.
+ */
+export function recentlyClosedProjects<
+  T extends { closed?: boolean; unavailable?: boolean; closedAt?: number }
+>(projects: readonly T[]): T[] {
+  return projects
+    .filter((p) => p.closed && !p.unavailable)
+    .sort((a, b) => (b.closedAt ?? -1) - (a.closedAt ?? -1))
+}
+
+/**
+ * Narrows the "Recently closed" list by name or folder — both already rendered on the row, and
+ * `cwd` is the row's `title`. Empty/whitespace query = everything, unchanged.
+ */
+export function filterClosedProjects<T extends { name: string; cwd?: string }>(
+  rows: readonly T[],
+  query: string
+): T[] {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return rows as T[]
+  return rows.filter((r) => `${r.name} ${r.cwd ?? ''}`.toLowerCase().includes(needle))
+}
+
 export function mergeClosedHistory(projects: readonly Project[]): ClosedHistoryRow[] {
   const rows: ClosedHistoryRow[] = []
   for (const p of projects) {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2918,12 +2918,33 @@ body,
   padding-left: 2px;
 }
 
+/* Issue #506: shown only past RECENT_FILTER_THRESHOLD rows, where the list is already
+   scrolling. Same shape as the sessions sidebar's own "Filter sessions…" box — this is the
+   same idea applied to the other list, so it should not look like a different control. */
+.welcome__recent-filter {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 6px;
+  font-size: 12px;
+  padding: 5px 8px;
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+}
+
 .welcome__recent-list {
   display: flex;
   flex-direction: column;
   gap: 4px;
   max-height: 220px;
   overflow-y: auto;
+}
+
+.welcome__recent-empty {
+  padding: 10px 10px;
+  font-size: 12px;
+  color: var(--muted);
 }
 
 .welcome__recent-item {


### PR DESCRIPTION
Following up on #442 / #458. The start screen's "Recently closed" list has two rough edges, and the reporter named the cause correctly: the ordering is the bug, the scrolling is the symptom.

**The heading promises recency and the list did not deliver it.** `closedProjects` was `projects.filter(p => p.closed && !p.unavailable)` — **tab order** — so the project shut ten minutes ago sat wherever its tab happened to be. With `.welcome__recent-list` capped at `max-height: 220px` (about six rows), that turned scanning into hunting: scrolling did not help, because the order carried no meaning.

## What changed

**Ordering (the fix).** `recentlyClosedProjects` (in `lib/closedHistory.ts`) filters and sorts newest-closed first, reusing the rule *and* the `-1` sentinel that `mergeClosedHistory` already applies to the sessions sidebar's own closed history. The two lists describe the same event and must not order it differently. `closedAt` already existed on `Project` and is already written by `closeProject`; it is absent only on projects closed before that field existed, and those sort last rather than becoming `NaN`.

**Filter (kept small).** A box over the list matching **name and folder** — both already rendered, and the folder is the row's own `title`. Shown only past **six** rows, the point where the list starts scrolling: below that it would be clutter for someone with three projects. An empty result says `No closed projects match “…”.` rather than rendering a blank list, and Esc clears the box before it reaches the screen's own close handler (on an empty box it falls through and still closes the screen).

`max-height: 220px` is left alone — with a true order and a filter, six visible rows is a scan, not a hunt.

## Tests

- `closedHistory.test.ts`: ordering (newest-first over a deliberately non-tab order), open/unavailable exclusion, the no-`closedAt` sentinel, and the name/folder/case/blank/no-match filter cases.
- `WelcomeScreen.test.tsx`: the box is absent at six rows and present at seven, narrows by name and by folder, shows the no-match sentence, and the section itself still hides entirely with no closed projects.

`npm run typecheck` clean; `closedHistory` + `WelcomeScreen` + `reopenPlan` suites green (38 tests).

## Surfaces

Pure renderer (`WelcomeScreen` + a Canvas selector) — desktop and Server Edition both get it, no bridge member, no IPC. Kanban: N/A (the start screen is not a board surface). Mobile: N/A (no start screen with a closed-projects list).

## Device checklist

Verified by unit test on Linux; the UI was not exercised on a device.

1. Close three projects in a deliberately different order from their tabs, open the start screen → the most recently closed is first.
2. Reopen one, close another → the list reorders to match.
3. With **six or fewer** closed projects: no filter box.
4. With **seven or more**: filter box appears; type a project name, then a path fragment.
5. Type something that matches nothing → the "no match" sentence, not a blank list.
6. Press Esc with text in the box → box clears and the screen stays open. Press Esc again → the screen closes as before.
7. A project closed by an older build (no `closedAt`) still appears, at the bottom.
8. The live-session badge (#442) and the × delete still work on the reordered rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
