### PR TITLE
fix(hooks): give codex a Windows entry point — cmd.exe cannot run an sh one-liner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1211,7 +1211,24 @@ else, and its context links must keep classifying across restarts).
   *healed*, not preserved, on both the local and the SSH path). The per-event **`matcher`** the grok
   installer needs is why events are typed `ManagedHookEvent` (`string | {event, matcher}`): grok's
   tool matcher is a REGEX and must be `.*` — a bare `*` is invalid and silently stops tool events
-  firing. Plain-string events keep their byte-identical output for every other agent. **Both
+  firing. Plain-string events keep their byte-identical output for every other agent.
+  **Codex is the one agent whose hook command is NOT a POSIX one-liner on Windows** (issue #567):
+  it builds the command as `cmd.exe /C <string>` (`codex-rs/hooks/src/engine/command_runner.rs`,
+  rust-v0.151.0) unless the session has a shell configured, which a default Windows install has
+  not — so `if [ -x '…' ]; then …; fi` answered `-x was unexpected at this time.` and **exit 1 on
+  every event**, for the life of the node. Claude is fine there only because Claude Code runs its
+  hooks through Git Bash. The fix is a batch entry point (`codex-hook.cmd`,
+  `codex-windows-wrapper.ts`) written beside `codex.sh` and named by `buildManagedCommand`'s win32
+  branch; it **locates a POSIX shell and runs the same script** — deliberately not a second
+  implementation of the hook protocol, which would be two copies of the POST/failover/token/
+  permission-poll to drift. Three rules it must keep: pass stdin through, DRAIN stdin on every bail
+  (codex writes the payload there; #186/#187), and exit 0 when there is no shell or no script.
+  Two traps around it: `buildManagedCommand`'s `platform` is the platform of the machine that will
+  RUN codex, so `RemoteHooks.installCodexRemote` passes POSIX explicitly (a Windows desktop must not
+  put a `.cmd` command on a Linux host); and `isManagedCommand` matches **both** leaves
+  (`codex.sh` AND `codex-hook.cmd`) on every platform — matching only the local one would leave a
+  pre-fix entry unrecognized, so the fresh one is appended beside it, which is #558 on a second
+  file. Matching both is what REPAIRS an existing Windows install at the next launch. **Both
   sides of the managed-entry match go through `normalizeHookCommand`** — the marker used to be
   folded to `/` while the stored command was compared raw, so on Windows nodeterm never recognized
   its OWN entry and appended a fresh set every launch (#558: nine copies of nine events, nine

--- a/src/core/agents/hooks/codex-windows-wrapper.ts
+++ b/src/core/agents/hooks/codex-windows-wrapper.ts
@@ -1,0 +1,95 @@
+// The Windows entry point for the codex managed hook.
+//
+// WHY THIS EXISTS. Every managed hook command in this repo is a POSIX `sh` one-liner, and for
+// claude that is fine on Windows because Claude Code runs its hooks through Git Bash. Codex does
+// not: `codex-rs/hooks/src/engine/command_runner.rs` (rust-v0.151.0) builds the hook command as
+//
+//     #[cfg(windows)]  ("COMSPEC", "cmd.exe", "/C")
+//
+// and only substitutes a different shell when the session has one configured — which a default
+// Windows install does not. So the string we write is handed to `cmd.exe /C`, which cannot parse
+// `if [ -x '...' ]; then ...; fi`:
+//
+//     -x was unexpected at this time.       exit=1
+//
+// That is exit 1 on EVERY event, for the whole life of a codex node: no status badge, no
+// PermissionRequest forwarding, no Stop to clear RUNNING, and a visible "hook exited with code 1"
+// line each time (issue #567). `/bin/sh` would not have rescued a cmd-parsable variant either —
+// Git Bash's shell is at `C:\Program Files\Git\bin\sh.exe` and is not on PATH.
+//
+// WHAT THIS IS NOT. It is deliberately **not** a second implementation of the hook protocol. The
+// managed script (`managed-script.ts`) stays the one POSIX source of truth for POSTing the payload,
+// the endpoint failover, the node token and the permission-answer poll; a `.cmd`/PowerShell port of
+// all that is two copies of one protocol, which is the drift this codebase pays for repeatedly.
+// This file only finds a POSIX shell and hands it the script.
+//
+// THREE THINGS THE WRAPPER OWES, and each is a real failure if dropped:
+//   1. **Pass stdin through untouched.** Codex writes the hook payload to the child's stdin; the
+//      script reads it. `cmd.exe` does not buffer or consume it, so the plain call inherits it.
+//   2. **Drain stdin on every bail.** A wrapper that exits without reading can EPIPE the writer
+//      mid-payload — the exact reason the claude/gemini command carries `else cat >/dev/null 2>&1`
+//      (#186/#187), and the one thing the codex POSIX command was missing.
+//   3. **Exit 0 when there is no shell and no script.** "nodeterm is not installed here" must look
+//      like nothing happening, not like a broken hook — same contract the POSIX `else` branch has.
+//
+// The shell search order is Git for Windows' real layouts first (both `bin` and `usr\bin`, 64-bit
+// and 32-bit program dirs, and the per-user install under LOCALAPPDATA, which is what `winget
+// install Git.Git` produces without admin), then whatever `sh.exe` is on PATH. PATH is last on
+// purpose: it is the least predictable, and a WSL `sh` shim there cannot run a Windows-path script.
+
+/** Where the wrapper looks for a POSIX shell, in order. cmd.exe expands these itself. */
+export const WINDOWS_SH_CANDIDATES = [
+  '%ProgramFiles%\\Git\\bin\\sh.exe',
+  '%ProgramFiles%\\Git\\usr\\bin\\sh.exe',
+  '%ProgramFiles(x86)%\\Git\\bin\\sh.exe',
+  '%ProgramFiles(x86)%\\Git\\usr\\bin\\sh.exe',
+  '%LOCALAPPDATA%\\Programs\\Git\\bin\\sh.exe',
+  '%LOCALAPPDATA%\\Programs\\Git\\usr\\bin\\sh.exe'
+] as const
+
+/** The wrapper's file name, beside the managed script it runs. */
+export const CODEX_WINDOWS_WRAPPER_FILE = 'codex-hook.cmd'
+
+/**
+ * The batch wrapper's content.
+ *
+ * `%~dp0` is the wrapper's own directory (with a trailing backslash), so the wrapper carries NO
+ * absolute path of its own — it finds `codex.sh` beside itself. That matters because
+ * `managedHookScriptPath`'s whole point is one stable machine-wide location, and baking the path
+ * in would give us a second copy of it to keep in sync.
+ *
+ * The script path is handed to sh with forward slashes (`%VAR:\=/%`): MSYS converts a
+ * `C:\...`-shaped argument in most cases, but `C:/...` needs no conversion at all and cannot be
+ * mistaken for an option or an escape.
+ *
+ * CRLF: batch files are line-oriented and cmd.exe is not reliably tolerant of LF, so this is
+ * written with CRLF regardless of the host that generated it (an SSH host never runs it — see
+ * `buildManagedCommand`'s platform parameter).
+ */
+export function buildCodexWindowsWrapper(): string {
+  const probe = WINDOWS_SH_CANDIDATES.map(
+    (p) => `if not defined NT_SH if exist "${p}" set "NT_SH=${p}"`
+  )
+  const lines = [
+    '@echo off',
+    'rem Managed by nodeterm (agent-hooks). Regenerated on every app launch; edits are lost.',
+    'setlocal EnableExtensions',
+    'set "NT_SCRIPT=%~dp0codex.sh"',
+    'if not exist "%NT_SCRIPT%" goto :nt_drain',
+    'set "NT_SH="',
+    ...probe,
+    // PATH last: least predictable, and a WSL shim there cannot run a Windows-path script.
+    'if not defined NT_SH for %%I in (sh.exe) do if not defined NT_SH set "NT_SH=%%~$PATH:I"',
+    'if not defined NT_SH goto :nt_drain',
+    'set "NT_ARG=%NT_SCRIPT:\\=/%"',
+    '"%NT_SH%" "%NT_ARG%"',
+    'exit /b %ERRORLEVEL%',
+    ':nt_drain',
+    'rem No shell or no script: consume the payload codex wrote to our stdin, then succeed.',
+    'rem Bailing without reading can EPIPE the writer mid-payload (#186/#187).',
+    'findstr /r ".*" >nul 2>&1',
+    'exit /b 0',
+    ''
+  ]
+  return lines.join('\r\n')
+}

--- a/src/core/agents/hooks/codex.test.ts
+++ b/src/core/agents/hooks/codex.test.ts
@@ -193,7 +193,7 @@ describe('buildCodexHooksAndTrust', () => {
     const stale = {
       hooks: [
         {
-          type: 'command',
+          type: 'command' as const,
           command:
             "if [ -x 'C:\\Users\\u\\.nodeterm\\agent-hooks\\codex.sh' ]; then /bin/sh 'C:\\Users\\u\\.nodeterm\\agent-hooks\\codex.sh'; fi"
         }
@@ -214,7 +214,7 @@ describe('buildCodexHooksAndTrust', () => {
   // copied between machines) is repaired the same way rather than accumulating both.
   it('replaces a stray Windows entry on a POSIX install', () => {
     const stale = {
-      hooks: [{ type: 'command', command: '"/home/u/.nodeterm/agent-hooks/codex-hook.cmd"' }]
+      hooks: [{ type: 'command' as const, command: '"/home/u/.nodeterm/agent-hooks/codex-hook.cmd"' }]
     }
     const command = buildManagedCommand('/home/u/.nodeterm/agent-hooks/codex.sh', 'linux')
     const built = buildCodexHooksAndTrust({ hooks: { Stop: [stale] } }, command, '/h/hooks.json')!

--- a/src/core/agents/hooks/codex.test.ts
+++ b/src/core/agents/hooks/codex.test.ts
@@ -1,15 +1,88 @@
 import { describe, expect, it } from 'vitest'
 import { buildCodexHooksAndTrust, buildManagedCommand, CODEX_EVENTS } from './codex'
 import { computeTrustedHash } from './codex-trust'
+import { buildCodexWindowsWrapper, WINDOWS_SH_CANDIDATES } from './codex-windows-wrapper'
 
-// The command form a codex hook carries: `if [ -x '<script>' ]; then /bin/sh '<script>'; fi`.
-// The trust hash is computed over THIS exact byte string, so the hooks.json command and the
-// config.toml trust entry must always come from the same builder.
+// The command form a codex hook carries. The trust hash is computed over THIS exact byte string, so
+// the hooks.json command and the config.toml trust entry must always come from the same builder.
 describe('buildManagedCommand', () => {
-  it('wraps the script path in the [ -x ] guard with POSIX single-quoting', () => {
-    expect(buildManagedCommand('/a/b/codex.sh')).toBe(
-      "if [ -x '/a/b/codex.sh' ]; then /bin/sh '/a/b/codex.sh'; fi"
+  it('POSIX: wraps the script path in the [ -x ] guard with POSIX single-quoting', () => {
+    expect(buildManagedCommand('/a/b/codex.sh', 'linux')).toBe(
+      "if [ -x '/a/b/codex.sh' ]; then /bin/sh '/a/b/codex.sh'; else cat >/dev/null 2>&1 || :; fi"
     )
+  })
+
+  it('POSIX: drains stdin when it bails — codex writes the payload there (#186/#187)', () => {
+    // Without this, a bail that never reads can EPIPE the writer mid-payload. It is the same
+    // `else` branch install-helper's command has always carried; codex's was the one without it.
+    expect(buildManagedCommand('/a/b/codex.sh', 'darwin')).toContain('else cat >/dev/null 2>&1')
+  })
+
+  // Issue #567: codex runs a hook command through `cmd.exe /C` on Windows
+  // (codex-rs/hooks/src/engine/command_runner.rs, rust-v0.151.0), which answers
+  // "-x was unexpected at this time." and exit 1 to an `sh` one-liner — on EVERY event, for the
+  // life of the node.
+  it('win32: points cmd.exe at the batch wrapper beside the script, not at an sh one-liner', () => {
+    expect(buildManagedCommand('C:\\Users\\u\\.nodeterm\\agent-hooks\\codex.sh', 'win32')).toBe(
+      '"C:\\Users\\u\\.nodeterm\\agent-hooks\\codex-hook.cmd"'
+    )
+    expect(buildManagedCommand('C:\\a\\codex.sh', 'win32')).not.toContain('[ -x')
+    expect(buildManagedCommand('C:\\a\\codex.sh', 'win32')).not.toContain('/bin/sh')
+  })
+
+  it('win32: the path stays one quoted token — a user profile routinely has a space in it', () => {
+    expect(buildManagedCommand('C:\\Users\\First Last\\agent-hooks\\codex.sh', 'win32')).toBe(
+      '"C:\\Users\\First Last\\agent-hooks\\codex-hook.cmd"'
+    )
+  })
+
+  // The platform is the machine that will RUN codex. RemoteHooks writes this into an SSH host's
+  // hooks.json, and that host is POSIX whatever the desktop is — so a Windows desktop must not put
+  // a `.cmd` command on a Linux server.
+  it('the platform argument decides, not the host generating the string', () => {
+    expect(buildManagedCommand('/home/u/.nodeterm/agent-hooks/codex.sh', 'linux')).toContain(
+      '/bin/sh'
+    )
+  })
+})
+
+describe('buildCodexWindowsWrapper', () => {
+  const wrapper = buildCodexWindowsWrapper()
+
+  it('runs the SAME codex.sh, found beside itself — no second copy of the protocol', () => {
+    // The wrapper only locates a shell. Everything about the hook protocol (the POST, the endpoint
+    // failover, the node token, the permission-answer poll) stays in the one POSIX script.
+    expect(wrapper).toContain('set "NT_SCRIPT=%~dp0codex.sh"')
+    expect(wrapper).not.toContain('curl')
+  })
+
+  it('searches Git for Windows layouts before PATH', () => {
+    for (const candidate of WINDOWS_SH_CANDIDATES) expect(wrapper).toContain(candidate)
+    const lastCandidate = Math.max(...WINDOWS_SH_CANDIDATES.map((c) => wrapper.indexOf(c)))
+    expect(wrapper.indexOf('%%~$PATH:I')).toBeGreaterThan(lastCandidate)
+  })
+
+  it('hands sh a forward-slash path, which needs no MSYS conversion', () => {
+    expect(wrapper).toContain('set "NT_ARG=%NT_SCRIPT:\\=/%"')
+    expect(wrapper).toContain('"%NT_SH%" "%NT_ARG%"')
+  })
+
+  it('drains stdin and exits 0 on every bail — no shell, no script', () => {
+    // "nodeterm is not installed here" must look like nothing happening, not a broken hook; and a
+    // bail that never reads codex's payload can EPIPE the writer.
+    expect(wrapper).toContain('if not exist "%NT_SCRIPT%" goto :nt_drain')
+    expect(wrapper).toContain('if not defined NT_SH goto :nt_drain')
+    expect(wrapper.slice(wrapper.indexOf(':nt_drain'))).toContain('findstr /r ".*" >nul 2>&1')
+    expect(wrapper.trimEnd().endsWith('exit /b 0')).toBe(true)
+  })
+
+  it('propagates the script exit code on the happy path', () => {
+    expect(wrapper).toContain('exit /b %ERRORLEVEL%')
+  })
+
+  it('is CRLF — cmd.exe is not reliably tolerant of LF in a batch file', () => {
+    expect(wrapper).toContain('\r\n')
+    expect(wrapper.replace(/\r\n/g, '')).not.toContain('\n')
   })
 })
 
@@ -86,7 +159,13 @@ describe('buildCodexHooksAndTrust', () => {
   // hooks fire correctly (codex-cli 0.114.0). Locking them guards the exact JSON canonicalization
   // codex hashes against — any drift here silently breaks every codex status badge.
   it('matches the byte-exact trust hashes codex accepts in the field', () => {
-    const command = buildManagedCommand('/root/.nodeterm-server/agent-hooks/codex.sh')
+    // The command is a FROZEN LITERAL, not `buildManagedCommand(...)`. These hashes are evidence
+    // about codex's CANONICALIZATION, captured from a live config.toml — regenerating them from
+    // whatever the builder currently emits would silently destroy the only external check we have
+    // on it. Change the command string here only if you have re-captured the hashes from a host
+    // where the hooks demonstrably fire.
+    const command =
+      "if [ -x '/root/.nodeterm-server/agent-hooks/codex.sh' ]; then /bin/sh '/root/.nodeterm-server/agent-hooks/codex.sh'; fi"
     const built = buildCodexHooksAndTrust({}, command, '/root/.codex/hooks.json')!
     const byLabel = Object.fromEntries(built.trustEntries.map((e) => [e.eventLabel, computeTrustedHash(e)]))
     expect(byLabel).toMatchObject({
@@ -103,6 +182,43 @@ describe('buildCodexHooksAndTrust', () => {
       subagent_start: 'sha256:9034d6329983b581fc9f996344766d6129321c5c33369a79c9971aa8879d3d5f',
       subagent_stop: 'sha256:88c207ae65d9d016967fce19b01735b5700f827cbfdb48692e42305f7427f0b6'
     })
+  })
+
+  // Issue #567 repair. A Windows machine already carries the unrunnable POSIX command in its
+  // hooks.json. If the managed-entry matcher only recognized the leaf THIS platform writes, that
+  // entry would survive the strip and the fresh `.cmd` entry would be APPENDED beside it — #558's
+  // duplicate-per-launch, on the same file. Both leaves are matched, always, so the next app launch
+  // collapses the file to exactly one runnable entry.
+  it('replaces a pre-fix POSIX entry with the Windows one instead of appending beside it', () => {
+    const stale = {
+      hooks: [
+        {
+          type: 'command',
+          command:
+            "if [ -x 'C:\\Users\\u\\.nodeterm\\agent-hooks\\codex.sh' ]; then /bin/sh 'C:\\Users\\u\\.nodeterm\\agent-hooks\\codex.sh'; fi"
+        }
+      ]
+    }
+    const command = buildManagedCommand('C:\\Users\\u\\.nodeterm\\agent-hooks\\codex.sh', 'win32')
+    const built = buildCodexHooksAndTrust(
+      { hooks: { Stop: [stale], SessionStart: [stale] } },
+      command,
+      'C:\\Users\\u\\.codex\\hooks.json'
+    )!
+    for (const ev of ['Stop', 'SessionStart']) {
+      expect(built.config.hooks![ev]).toEqual([{ hooks: [{ type: 'command', command }] }])
+    }
+  })
+
+  // The mirror of the above: a POSIX host that somehow carries a `.cmd` entry (a settings file
+  // copied between machines) is repaired the same way rather than accumulating both.
+  it('replaces a stray Windows entry on a POSIX install', () => {
+    const stale = {
+      hooks: [{ type: 'command', command: '"/home/u/.nodeterm/agent-hooks/codex-hook.cmd"' }]
+    }
+    const command = buildManagedCommand('/home/u/.nodeterm/agent-hooks/codex.sh', 'linux')
+    const built = buildCodexHooksAndTrust({ hooks: { Stop: [stale] } }, command, '/h/hooks.json')!
+    expect(built.config.hooks!.Stop).toEqual([{ hooks: [{ type: 'command', command }] }])
   })
 
   it('subscribes the subagent pair (spawn_agent fan-out) with snake_case labels', () => {

--- a/src/core/agents/hooks/codex.ts
+++ b/src/core/agents/hooks/codex.ts
@@ -28,6 +28,7 @@ import { randomUUID } from 'crypto'
 import { renameAtomicSync } from '../../fs-atomic'
 import { buildManagedScript } from './managed-script'
 import { normalizeHookCommand } from './install-helper'
+import { buildCodexWindowsWrapper, CODEX_WINDOWS_WRAPPER_FILE } from './codex-windows-wrapper'
 import {
   computeTrustedHash,
   getCodexCanonicalTrustPath,
@@ -105,7 +106,18 @@ function isManagedCommand(command: string | undefined): boolean {
   // Separator folding comes from install-helper so the two installers can never disagree about
   // what makes an entry ours — the drift that made the JSON-settings agents duplicate on Windows
   // (#558). Only the normalizer is shared; codex's merge stays its own (the trust hash).
-  return normalizeHookCommand(command).includes(`agent-hooks/${SCRIPT_FILE_NAME}`)
+  //
+  // BOTH leaves, always, on every platform. The Windows command names `codex-hook.cmd` while every
+  // pre-#567 Windows install (and every POSIX one) names `codex.sh`, so matching only the leaf THIS
+  // platform writes would fail to recognize an entry we ourselves put there — and `mergeManagedHook`
+  // logic here would keep it and append a second one, which is #558 all over again. Matching both is
+  // also what REPAIRS a Windows hooks.json that already carries the unrunnable POSIX command: it is
+  // stripped before the fresh one is pushed, so the next app launch heals the file.
+  const c = normalizeHookCommand(command)
+  return (
+    c.includes(`agent-hooks/${SCRIPT_FILE_NAME}`) ||
+    c.includes(`agent-hooks/${CODEX_WINDOWS_WRAPPER_FILE}`)
+  )
 }
 
 function definitionHasManagedCommand(def: HookDefinition): boolean {
@@ -128,15 +140,35 @@ function removeManagedFromDefinitions(defs: HookDefinition[]): HookDefinition[] 
   })
 }
 
-// Why: form the POSIX command the SAME way for hooks.json AND the trust entry —
-// the trust hash is computed over this exact byte string, so any divergence
-// makes Codex reject the hook. The POSIX wrapper's
-// `[ -x ... ]` guard makes a missing/non-executable script a silent no-op so a
-// broken install never poisons the session with exit-127 noise.
-export function buildManagedCommand(script: string): string {
+/**
+ * The hook command, formed the SAME way for hooks.json AND the trust entry — the trust hash is
+ * computed over this exact byte string, so any divergence makes Codex reject the hook. The POSIX
+ * form's `[ -x ... ]` guard makes a missing/non-executable script a silent no-op, so a broken
+ * install never poisons the session with exit-127 noise.
+ *
+ * `platform` is the platform of the machine that will RUN codex, not the one generating the string,
+ * and it is a parameter for exactly that reason: `RemoteHooks.installCodexRemote` writes this into
+ * an SSH host's `~/.codex/hooks.json`, and that host is POSIX whatever the desktop is. A default of
+ * `process.platform` would make a Windows desktop install a `.cmd` command on a Linux server.
+ */
+export function buildManagedCommand(
+  script: string,
+  platform: NodeJS.Platform | string = process.platform
+): string {
+  if (platform === 'win32') {
+    // Codex hands this to `cmd.exe /C`, which cannot parse an `sh` one-liner (issue #567). Point it
+    // at the batch wrapper written beside the script; the wrapper finds a POSIX shell and runs the
+    // very same `codex.sh`. Quoted as one token: cmd strips a single surrounding pair, and the path
+    // routinely contains spaces (`C:\Users\First Last\...`).
+    const dir = script.slice(0, Math.max(script.lastIndexOf('\\'), script.lastIndexOf('/')) + 1)
+    return `"${dir}${CODEX_WINDOWS_WRAPPER_FILE}"`
+  }
   // POSIX single-quote escape so $, `, ", \ in the path are taken literally.
   const quoted = `'${script.replaceAll("'", "'\\''")}'`
-  return `if [ -x ${quoted} ]; then /bin/sh ${quoted}; fi`
+  // The `else` branch DRAINS stdin. Codex writes the hook payload there, so a bail that never reads
+  // it can EPIPE the writer mid-payload — the same reason install-helper's command carries it
+  // (#186/#187). This was the one managed command missing it.
+  return `if [ -x ${quoted} ]; then /bin/sh ${quoted}; else cat >/dev/null 2>&1 || :; fi`
 }
 
 // Pure core of the codex install: given the CURRENT parsed hooks.json (or {} for
@@ -258,10 +290,35 @@ function writeManagedScript(file: string): void {
   }
 }
 
+/** The batch entry point beside the script — Windows only; nothing else ever reads it. */
+function writeWindowsWrapper(script: string): void {
+  const dir = path.dirname(script)
+  const file = path.join(dir, CODEX_WINDOWS_WRAPPER_FILE)
+  mkdirSync(dir, { recursive: true })
+  const tmp = path.join(dir, `.${Date.now()}-${randomUUID()}.tmp`)
+  let renamed = false
+  try {
+    writeFileSync(tmp, buildCodexWindowsWrapper(), 'utf8')
+    renameAtomicSync(tmp, file)
+    renamed = true
+  } finally {
+    if (!renamed && existsSync(tmp)) {
+      try {
+        unlinkSync(tmp)
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+}
+
 export function installCodexHooks(): void {
   const script = scriptPath()
   try {
     writeManagedScript(script)
+    // Order matters: the wrapper must exist before hooks.json points codex at it, or the first
+    // events after an install land on a missing file.
+    if (process.platform === 'win32') writeWindowsWrapper(script)
   } catch (e) {
     console.warn('[agent-hooks] codex script write failed', e)
     return

--- a/src/main/remote-ssh/remote-hooks.ts
+++ b/src/main/remote-ssh/remote-hooks.ts
@@ -382,7 +382,9 @@ export class RemoteHooks {
         ),
         buildManagedScript('codex', REMOTE_IDENTITY_ROOT)
       )
-      const command = buildCodexManagedCommand(script)
+      // POSIX explicitly: the platform argument is the HOST's, never this desktop's. A Windows
+      // desktop writes a `.cmd` command locally (issue #567) and must not put one on a Linux server.
+      const command = buildCodexManagedCommand(script, 'linux')
       const codexHome = `${home}/.codex`
       const hooksFile = `${codexHome}/hooks.json`
       const configToml = `${codexHome}/config.toml`


### PR DESCRIPTION
On Windows a Codex node reports nothing at all, and says so on screen once per event. Every feature built on agent status — the RUNNING / NEEDS YOU badge, completion notifications, the context meter, subagent cards, the phone's session list — is silently absent for Codex there.

## Root cause (confirmed on `main` after #606/#609)

Codex builds its hook command as `cmd.exe /C <string>` unless the session has a shell configured (`codex-rs/hooks/src/engine/command_runner.rs`, rust-v0.151.0), and a default Windows install has none. Handed our POSIX one-liner it answers `-x was unexpected at this time.` and exit 1 — which is exactly the code the session reports, on every event, for the life of the node. Claude is unaffected there only because Claude Code runs its hooks through Git Bash.

`#606` (managed-hook dedup) and `#609` (curl payload path) both landed and neither touches this: `buildManagedCommand` in `src/core/agents/hooks/codex.ts` is still the unconditional `if [ -x '…' ]; then /bin/sh '…'; fi`.

## The fix: a batch entry point, NOT a second implementation

The maintainer comment on the issue framed the choice as (1) port the protocol to `.cmd`/PowerShell, or (2) invoke the one script through a shell we control. This is (2), and it is deliberately the cheap version: `codex-hook.cmd` is written beside `codex.sh` and only **finds a POSIX shell and runs that same script**. The POST, the endpoint failover, the node token and the permission-answer poll stay in the one POSIX source of truth — a `.cmd` port of all that would be two copies of one protocol, which is the drift CLAUDE.md warns about by name.

Shell search order: Git for Windows' real layouts first (`bin` and `usr\bin`, 64-bit and 32-bit program dirs, and the per-user `LOCALAPPDATA\Programs\Git` that `winget install Git.Git` produces without admin), then `sh.exe` on PATH. PATH is last because it is the least predictable and a WSL `sh` shim there cannot run a Windows-path script. The script path is handed over with forward slashes, which needs no MSYS conversion.

Three things the wrapper owes, all named in the issue and all pinned by tests:

1. **stdin passes through** — codex writes the payload there and cmd neither buffers nor consumes it.
2. **stdin is DRAINED on every bail** — a bail that never reads can EPIPE the writer mid-payload (#186/#187).
3. **exit 0 when there is no shell and no script** — "nodeterm is not installed here" must look like nothing happening, which is the contract the POSIX `else` branch already had.

## Two rules a reviewer should check hardest

**The platform argument is the machine that will RUN codex.** `buildManagedCommand(script, platform)` defaults to `process.platform`, but `RemoteHooks.installCodexRemote` now passes POSIX **explicitly** — it writes into an SSH host's `~/.codex/hooks.json`, and that host is POSIX whatever the desktop is. Without it a Windows desktop would install a `.cmd` command on a Linux server.

**`isManagedCommand` matches BOTH leaves on every platform.** Every existing Windows install already carries the unrunnable POSIX command. If the matcher only recognized the leaf this platform writes, that entry would survive the strip and the fresh `.cmd` entry would be appended beside it — #558's duplicate-per-launch, on a second file. Matching both is also what **repairs** an existing Windows `hooks.json`: `installCodexHooks` runs at every app launch, strips every managed entry, and pushes exactly one. Both directions are tested (a stale POSIX entry on Windows, a stray `.cmd` entry on POSIX).

## One POSIX-side change, called out separately

The POSIX command gains the `else cat >/dev/null 2>&1 || :` drain — it was the only managed command missing it, which the issue notes. That changes its bytes, so the **golden trust-hash test is re-anchored to a frozen literal** of the historical command instead of calling the live builder. Those six hashes were read from a real `config.toml` on a host where the hooks fire; regenerating them from whatever the builder currently emits would silently destroy the only external check on codex's canonicalization. The trust entries are rewritten from the current command at every launch, so the hash change self-heals.

## Tests

`codex.test.ts` grows 10 cases (POSIX form + drain, the win32 command, a profile path with a space, the platform-argument rule, and the two repair directions) plus a `buildCodexWindowsWrapper` block (same script, search order, forward-slash arg, drain-and-exit-0 on both bails, exit-code propagation, CRLF). Both new guards were mutation-tested: dropping the dual-leaf match reds 3 tests, disabling the win32 branch reds 2.

`npm run typecheck` clean; `src/core/agents` + `src/main/remote-ssh` + `no-electron` + `fs-atomic.guard` green (56 files, 955 tests).

## Device verification — NOT done

**Nothing here has run on Windows.** The batch file is reasoned from cmd semantics and pinned by string assertions, which cannot execute it. For a reviewer with a Windows machine:

- [ ] After one app launch, `%USERPROFILE%\.nodeterm\agent-hooks\` holds both `codex.sh` and `codex-hook.cmd`, and `%USERPROFILE%\.codex\hooks.json` names the `.cmd` — **once** per event, not twice.
- [ ] A Codex node reports status: RUNNING appears, Stop clears it, and no "hook exited with code 1" line appears on any event.
- [ ] `PermissionRequest` reaches the canvas (and the phone) and an answer is delivered back.
- [ ] Git installed **per-user** (`%LOCALAPPDATA%\Programs\Git`) is found, not just the Program Files install.
- [ ] A profile path containing a space (`C:\Users\First Last`) works.
- [ ] Git **not** installed at all: hooks are silent, exit 0, no error lines, and the session behaves exactly like one with nodeterm absent.
- [ ] An install that predates this PR collapses to a single runnable entry after one launch (the repair path).
- [ ] macOS/Linux regression: a Codex node still reports status after the drain change (the trust hash changes, so the first launch rewrites `config.toml`).
- [ ] SSH: a Linux host connected from a **Windows** desktop still gets the POSIX command in its `hooks.json`.

Fixes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
