### PR TITLE
fix(windows): make the pairing SSH-server prompt platform-correct

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ installLogSink(logBuffer)
 import { writeFilesToClipboard } from './clipboard-files'
 import { pickProjectIcon } from './project-icon-upload'
 import { allowGuestNavigation } from './webview-nav'
+import { hostOsFromPlatform, sshServerCopy } from '../shared/ssh-server'
 import { guestContextMenuTemplate } from './webview-context-menu'
 import { BrowserControlLedger } from './browser-control-ledger'
 import {
@@ -1509,15 +1510,14 @@ app.whenReady().then(async () => {
   ipcMain.handle(IPC.pairingStop, () => pairingService.stop())
   ipcMain.handle(IPC.pairingProbeSsh, () => pairingService.probeSsh())
   // Same pattern as appOpenNotificationSettings: a main-side constant deep link, NOT routed
-  // through shellOpenExternal's http(s)-only allowlist (which silently drops x-apple.* URLs —
+  // through shellOpenExternal's http(s)-only allowlist (which silently drops non-http URLs —
   // the "Open System Settings" button did nothing when it sent the URL from the renderer).
-  // The `Services_RemoteLogin` query selected the service in the pre-Ventura prefpane and is
-  // harmless on newer macOS, which opens the Sharing pane either way.
+  // The URL comes from `sshServerCopy`, the SAME table the renderer prints its copy from, so the
+  // button can never appear on a platform this handler opens nothing for (issue #572: on Windows
+  // it offered a macOS `x-apple.systempreferences:` link that is inert there).
   ipcMain.handle(IPC.pairingOpenRemoteLoginSettings, () => {
-    if (process.platform !== 'darwin') return
-    void shell.openExternal(
-      'x-apple.systempreferences:com.apple.preferences.sharing?Services_RemoteLogin'
-    )
+    const url = sshServerCopy(hostOsFromPlatform(process.platform)).settingsUrl
+    if (url) void shell.openExternal(url)
   })
   ipcMain.handle(IPC.pairingListDevices, () => pairingService.listDevices())
   ipcMain.handle(IPC.pairingRevokeDevice, (_e, id: string) => pairingService.revokeDevice(id))

--- a/src/renderer/components/PhonePairPopover.tsx
+++ b/src/renderer/components/PhonePairPopover.tsx
@@ -4,8 +4,10 @@ import { Switch } from '@renderer/ui/Switch'
 import { useSettings } from '@renderer/state/settings'
 import { usePhonePairing } from './settings/usePhonePairing'
 import { IOS_APP_STORE_URL } from '@renderer/lib/links'
+import { hostOsFromNavigator, sshServerCopy } from '@shared/ssh-server'
 
-const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
+/** Same table the Phone settings section prints from — see @shared/ssh-server. */
+const sshServer = sshServerCopy(hostOsFromNavigator())
 
 /**
  * Quick phone pairing, anchored under the top-right phone button: opens straight into a live QR
@@ -69,8 +71,8 @@ export function PhonePairPopover({
             // No QR while Remote Login is off — pairing against an unreachable sshd installs a
             // key the phone can never use. The live probe flips sshOpen and the QR appears.
             <div className="phone-pair__warn">
-              <strong>Remote Login</strong> is off — the pairing QR appears the moment it is on
-              {isMac ? (
+              <strong>{sshServer.name}</strong> is off — the pairing QR appears the moment it is on
+              {sshServer.settingsLabel ? (
                 <>
                   {' '}
                   (
@@ -78,13 +80,14 @@ export function PhonePairPopover({
                     className="phone-pair__link"
                     onClick={() => void window.nodeTerminal.pairing.openRemoteLoginSettings()}
                   >
-                    System Settings
+                    {sshServer.settingsLabel}
                   </button>
                   &nbsp;— watching).
                 </>
               ) : (
                 '.'
               )}
+              <div className="phone-pair__hint">{sshServer.how}</div>
             </div>
           ) : (
             <>
@@ -101,7 +104,9 @@ export function PhonePairPopover({
                   toggle below first to also connect from anywhere — the QR refreshes by itself.
                 </div>
               ) : null}
-              {sshHealed ? <div className="phone-pair__ok">✓ Remote Login is on.</div> : null}
+              {sshHealed ? (
+                <div className="phone-pair__ok">✓ {sshServer.name} is on.</div>
+              ) : null}
             </>
           )
         ) : phase === 'paired' ? (

--- a/src/renderer/components/settings/sections/PhoneSection.tsx
+++ b/src/renderer/components/settings/sections/PhoneSection.tsx
@@ -8,6 +8,7 @@ import { Switch } from '@renderer/ui/Switch'
 import { useSettings } from '@renderer/state/settings'
 import { usePhonePairing } from '../usePhonePairing'
 import { IOS_APP_STORE_URL } from '@renderer/lib/links'
+import { hostOsFromNavigator, sshServerCopy } from '@shared/ssh-server'
 
 const ROWS = {
   remote: {
@@ -35,8 +36,9 @@ function formatPairedAt(ms: number): string {
   })
 }
 
-/** The pairing host is this machine, so the renderer's own UA answers "is this a Mac?". */
-const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
+/** The pairing host is this machine, so the renderer's own UA answers which OS it runs on —
+ *  and that decides what the SSH server is called and whether a settings deep link exists. */
+const sshServer = sshServerCopy(hostOsFromNavigator())
 
 export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Element {
   const [devices, setDevices] = useState<PairedDevice[]>([])
@@ -205,15 +207,16 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
                 // The live probe (usePhonePairing) flips sshOpen and the QR appears by itself.
                 <div className="space-y-2">
                   <p className="text-sm" style={{ color: '#ff9f0a' }}>
-                    <strong>Remote Login</strong> is off, so your phone wouldn&apos;t be able to
-                    connect after pairing. Turn it on — the QR appears here the moment it is
-                    {isMac ? ' (watching, no need to restart pairing).' : '.'}
+                    <strong>{sshServer.name}</strong> is off, so your phone wouldn&apos;t be able
+                    to connect after pairing. Turn it on — the QR appears here the moment it is
+                    (watching, no need to restart pairing).
                   </p>
-                  {isMac ? (
+                  <p className="text-xs text-muted">{sshServer.how}</p>
+                  {sshServer.settingsLabel ? (
                     <Button
                       onClick={() => void window.nodeTerminal.pairing.openRemoteLoginSettings()}
                     >
-                      Open System Settings
+                      {sshServer.settingsLabel}
                     </Button>
                   ) : null}
                 </div>
@@ -242,7 +245,7 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
                   ) : null}
                   {sshHealed ? (
                     <p className="text-sm" style={{ color: '#30d158' }}>
-                      ✓ Remote Login is on — scan away.
+                      ✓ {sshServer.name} is on — scan away.
                     </p>
                   ) : null}
                 </>

--- a/src/shared/ssh-server.test.ts
+++ b/src/shared/ssh-server.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { hostOsFromPlatform, sshServerCopy, type HostOs } from './ssh-server'
+
+describe('hostOsFromPlatform', () => {
+  it('maps the two platforms with their own name for sshd, everything else to the generic case', () => {
+    expect(hostOsFromPlatform('darwin')).toBe('mac')
+    expect(hostOsFromPlatform('win32')).toBe('windows')
+    expect(hostOsFromPlatform('linux')).toBe('other')
+    expect(hostOsFromPlatform('freebsd')).toBe('other')
+  })
+})
+
+describe('sshServerCopy', () => {
+  const all: HostOs[] = ['mac', 'windows', 'other']
+
+  it('names the service the OS actually has', () => {
+    expect(sshServerCopy('mac').name).toBe('Remote Login')
+    // Issue #572: on Windows the warning said "Remote Login", a setting that does not exist there,
+    // so the instruction could not be followed as written.
+    expect(sshServerCopy('windows').name).toBe('OpenSSH Server')
+    expect(sshServerCopy('other').name).not.toMatch(/Remote Login|OpenSSH Server/)
+  })
+
+  it('tells a Windows user BOTH steps — it is an optional feature, not a toggle', () => {
+    const how = sshServerCopy('windows').how
+    expect(how).toMatch(/Optional features/)
+    expect(how).toMatch(/sshd|SSH Server/)
+  })
+
+  it('offers a deep link only where main can open one, and never a foreign scheme', () => {
+    expect(sshServerCopy('mac').settingsUrl).toMatch(/^x-apple\.systempreferences:/)
+    expect(sshServerCopy('windows').settingsUrl).toMatch(/^ms-settings:/)
+    // No URL for the generic case: a button that opens nothing is what this issue was about.
+    expect(sshServerCopy('other').settingsUrl).toBeUndefined()
+  })
+
+  it('keeps label and URL together — the UI shows the button on the label', () => {
+    for (const os of all) {
+      const copy = sshServerCopy(os)
+      expect(Boolean(copy.settingsLabel)).toBe(Boolean(copy.settingsUrl))
+      expect(copy.name.length).toBeGreaterThan(0)
+      expect(copy.how.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/shared/ssh-server.ts
+++ b/src/shared/ssh-server.ts
@@ -1,0 +1,74 @@
+/**
+ * What THIS machine calls its SSH server, and how the user turns it on.
+ *
+ * Phone pairing installs the phone's key into `~/.ssh/authorized_keys` and the phone then connects
+ * over SSH, so the QR is withheld until something answers on `127.0.0.1:22` — a pairing completed
+ * against a dead sshd installs a key that can never be used. That gate is fine; the WORDS around
+ * it were macOS-only ("Remote Login", a `x-apple.systempreferences:` deep link), which on Windows
+ * named a setting the OS does not have and a button that opened nothing (issue #572).
+ *
+ * One definition, two consumers: the renderer prints the copy (deriving the OS from its own UA —
+ * the pairing host is this machine) and the main process opens `settingsUrl`. Keeping the URL here
+ * rather than beside the handler is what stops the button from appearing on a platform main cannot
+ * open anything for.
+ */
+
+export type HostOs = 'mac' | 'windows' | 'other'
+
+export interface SshServerCopy {
+  /** The service's name on this OS, used as the SUBJECT of a sentence ("<name> is off, so …"). */
+  name: string
+  /** Where to turn it on, in that OS's own words. */
+  how: string
+  /** Label for the deep-link button — present only when `settingsUrl` is. */
+  settingsLabel?: string
+  /** A settings deep link the MAIN process may open. Absent = no button. */
+  settingsUrl?: string
+}
+
+/** `process.platform` (or any platform string) → the three cases the copy distinguishes. */
+export function hostOsFromPlatform(platform: string): HostOs {
+  if (platform === 'darwin') return 'mac'
+  if (platform === 'win32') return 'windows'
+  return 'other'
+}
+
+/**
+ * The renderer's own OS, from the same `navigator` sniff the shortcut labels use.
+ *
+ * Correct for pairing because the pairing host IS this machine — the service is desktop-only
+ * (`ipcMain.handle`, an `E_UNSUPPORTED` stub in the browser bridge), so there is no case where
+ * this renderer prints the copy for a machine other than the one running sshd.
+ */
+export function hostOsFromNavigator(): HostOs {
+  if (typeof navigator === 'undefined') return 'other'
+  const ua = navigator.platform || navigator.userAgent
+  if (/Mac/i.test(ua)) return 'mac'
+  if (/Win/i.test(ua)) return 'windows'
+  return 'other'
+}
+
+export function sshServerCopy(os: HostOs): SshServerCopy {
+  if (os === 'mac')
+    return {
+      name: 'Remote Login',
+      how: 'System Settings → General → Sharing → Remote Login.',
+      settingsLabel: 'Open System Settings',
+      // The `Services_RemoteLogin` query selected the service in the pre-Ventura prefpane and is
+      // harmless on newer macOS, which opens the Sharing pane either way.
+      settingsUrl: 'x-apple.systempreferences:com.apple.preferences.sharing?Services_RemoteLogin'
+    }
+  if (os === 'windows')
+    return {
+      // OpenSSH Server is an OPTIONAL FEATURE on Windows and is off on a stock machine — so this
+      // is usually "install it", not "flip a switch", and the copy has to say both steps.
+      name: 'OpenSSH Server',
+      how: 'Settings → System → Optional features → Add an optional feature → OpenSSH Server, then start the “OpenSSH SSH Server” service (Services, or `Start-Service sshd`).',
+      settingsLabel: 'Open Optional features',
+      settingsUrl: 'ms-settings:optionalfeatures'
+    }
+  return {
+    name: 'The SSH server',
+    how: 'Install and start an SSH server (e.g. `sudo apt install openssh-server && sudo systemctl enable --now ssh`).'
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2883,12 +2883,13 @@ export interface PairingApi {
   stop(): Promise<void>
   /** Fires once when pairing finishes (ok=true paired, ok=false timeout). Returns unsubscribe. */
   onDone(cb: (result: { ok: boolean; relay?: 'ok' | 'off' | 'failed' | 'dev' }) => void): () => void
-  /** Live re-probe of 127.0.0.1:22, so the Remote Login warning can clear the moment the user
-   *  flips the toggle in System Settings (polled by the UI only while the warning is showing). */
+  /** Live re-probe of 127.0.0.1:22, so the "SSH server is off" warning can clear the moment the
+   *  user turns it on (polled by the UI only while the warning is showing). */
   probeSsh(): Promise<boolean>
-  /** Open System Settings → General → Sharing (Remote Login). The deep link is a main-side
-   *  constant — x-apple.* schemes never pass shellOpenExternal's http(s) allowlist. macOS-only;
-   *  a no-op elsewhere. */
+  /** Open this OS's settings page for its SSH server — Sharing → Remote Login on macOS, Optional
+   *  features on Windows (`sshServerCopy().settingsUrl`, the same table the warning's copy comes
+   *  from). The deep link is a main-side constant: neither scheme passes shellOpenExternal's
+   *  http(s) allowlist. A no-op where that table offers no URL, and the UI shows no button there. */
   openRemoteLoginSettings(): Promise<void>
   /** List paired devices from ~/.nodeterm/agent.json (never includes the token). */
   listDevices(): Promise<PairedDevice[]>


### PR DESCRIPTION
## What was wrong

The QR gate itself is sound and stays: pairing installs the phone's key into `~/.ssh/authorized_keys`
and the phone then connects over SSH, so completing a pairing against a dead sshd installs a key that
can never be used. **The words around the gate were macOS-only**, which is what made pairing
*unreachable* on Windows rather than merely blocked:

- the warning named **Remote Login**, the macOS name for a setting Windows does not have;
- the button beside it opened `x-apple.systempreferences:…`, inert there (and it was already
  `isMac`-gated in the settings section, so on Windows there was no affordance at all);
- nothing named the thing a Windows user actually has to do — OpenSSH Server is an **optional
  feature**, off on a stock machine, so it is "install it *and* start the service", not a toggle.

## The fix (the issue's own short-term suggestion)

`src/shared/ssh-server.ts` — one table for what this machine calls its SSH server, how to turn it on,
and whether a settings deep link exists:

| OS | name | how | deep link |
|---|---|---|---|
| macOS | Remote Login | System Settings → General → Sharing → Remote Login | `x-apple.systempreferences:…` (unchanged) |
| Windows | OpenSSH Server | Settings → System → Optional features → Add an optional feature → OpenSSH Server, then start the “OpenSSH SSH Server” service (`Start-Service sshd`) | `ms-settings:optionalfeatures` |
| other | The SSH server | install/start openssh-server | **none** — and therefore no button |

Both pairing surfaces print from it — **Settings → Phone** *and* the quick-pair popover (the popover
had the same macOS-only copy; a fix in one place only would have left the other lying) — and the main
handler opens `settingsUrl` from the same table. That is why the URL lives in `@shared` rather than
beside the handler: a button can never appear on a platform main opens nothing for.

Also: the "(watching, no need to restart pairing)" parenthetical is no longer `isMac`-gated. The
re-probe poll in `usePhonePairing` was never platform-specific — the warning clears by itself
everywhere, and saying so only on a Mac understated what the other platforms already do.

## Deliberately NOT in this PR

- **The second blocker the issue flags** — Windows OpenSSH enforces ACLs, and for accounts in the
  Administrators group it reads `%PROGRAMDATA%\ssh\administrators_authorized_keys` rather than the
  user's file. `appendAuthorizedKey`'s `mkdir({mode:0o700})` / `chmod(0o600)` do not express that.
  Node does not throw for those on Windows, so nothing crashes — the key may simply be ignored by
  sshd. Fixing it blind, from a Linux box, on a path that hands out shell access, is not something
  to guess at: it needs a Windows machine that has got past blocker 1. Flagged, not touched.
- **Questioning the sshd dependency on Windows** (the issue's longer-term point) — a design change,
  not a fix.
- **"Reach this Mac from anywhere"** and the rest of the `This Mac` copy — issue #563.

## Tests

`src/shared/ssh-server.test.ts` — platform mapping; each OS names the service it actually has;
Windows copy carries both steps; a deep link only where one exists and never a foreign scheme;
label-and-URL are present together (that pair is what the UI's button condition rests on).
`npm run typecheck` green; `vitest run src/shared src/main/pairing-service.test.ts` (64 files,
1052 tests) green.

## Device checklist — NOT verified on a device (this box is Linux; no Windows/macOS here)

1. **Windows, OpenSSH Server not installed**: Settings → Phone → Start pairing shows
   "**OpenSSH Server** is off…" plus the Optional-features path and the service step.
2. **Windows**: the **Open Optional features** button really opens Settings → System → Optional
   features (`ms-settings:optionalfeatures`). If it does not, the button should be dropped for
   Windows rather than left opening nothing — that was the original complaint.
3. **Windows**: after installing OpenSSH Server and `Start-Service sshd`, the warning clears by
   itself within ~2 s and the QR appears with no restart of pairing.
4. **Windows, past the gate**: does the pairing actually complete and does the phone connect? This
   is where the ACL / `administrators_authorized_keys` blocker above is expected to surface —
   please report what happens.
5. **macOS**: the section and the quick-pair popover read exactly as before ("Remote Login", "Open
   System Settings"), and the button still opens Sharing.
6. **Linux**: names the SSH server generically, shows the install hint, and shows **no** button.
7. The same three checks in the **quick-pair popover** (top-right phone button), which shares the
   copy.

## Surfaces

Desktop only — the pairing service is `ipcMain`-registered and the browser bridge stubs the whole
`pairing` namespace, so nothing changes for Server Edition. Mobile: N/A (the phone scans the QR;
this is about the host's own copy).

Fixes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
