### PR TITLE
fix(usage): cap the account popover and scroll its account list

### DIFF
--- a/src/renderer/components/UsageIndicator.tsx
+++ b/src/renderer/components/UsageIndicator.tsx
@@ -489,73 +489,80 @@ export function UsageIndicator({
               <span className="usage-popover__ago">Updated {formatTimeAgo(updatedAt)}</span>
             )}
           </div>
-          {/* The local Claude section belongs to a LOCAL project only. On an SSH project the
-              remote blocks below carry the same limits, and rendering both would print the
-              host's numbers twice under two different headings. */}
-          {scope.kind === 'local' &&
-            (scoped.accounts.length > 0 && claudeUsage ? (
-              <>
-                <AccountUsageBlock
-                  mode={percentMode}
-                  label={systemAccountDisplay(systemLabelSetting, claudeUsage.email)}
-                  // Avoid printing the email twice when it's already the display label.
-                  email={systemLabelSetting.trim() ? (claudeUsage.email ?? undefined) : undefined}
-                  u={claudeUsage}
-                  {...rowMark(null)}
-                />
-                {scoped.accounts.map((a) => (
+          {/* Issue #503: the account blocks SCROLL, the heading and the footer action do not.
+              Each account is a tall block (name + Session/Weekly/Opus meters), so past about
+              four accounts the popover grew off the top of the window — the first account's
+              header and meter were clipped with no way to reach them. Same rule as the session
+              memory panel's row list: every row is rendered, the list scrolls. */}
+          <div className="usage-popover__body">
+            {/* The local Claude section belongs to a LOCAL project only. On an SSH project the
+                remote blocks below carry the same limits, and rendering both would print the
+                host's numbers twice under two different headings. */}
+            {scope.kind === 'local' &&
+              (scoped.accounts.length > 0 && claudeUsage ? (
+                <>
                   <AccountUsageBlock
-                    key={a.id}
                     mode={percentMode}
-                    label={a.label}
-                    email={a.email}
-                    u={acctUsage[a.id] ?? null}
-                    {...rowMark(a.id)}
+                    label={systemAccountDisplay(systemLabelSetting, claudeUsage.email)}
+                    // Avoid printing the email twice when it's already the display label.
+                    email={systemLabelSetting.trim() ? (claudeUsage.email ?? undefined) : undefined}
+                    u={claudeUsage}
+                    {...rowMark(null)}
                   />
-                ))}
-              </>
-            ) : (
-              <>
-                {/* Claude's rows are bare when it is the only provider; once others share the
-                    panel they need a heading of their own to stay attributable. */}
-                {enabled.length > 0 && limits.length > 0 && (
-                  <div className="usage-account__label">Claude</div>
-                )}
-                {limits.map((l) => (
-                  <LimitRow key={limitKey(l)} limit={l} mode={percentMode} />
-                ))}
-                {!hasData && <div className="usage-popover__empty">No usage data.</div>}
-                {claudeUsage?.email && (
-                  <div className="usage-account">
-                    <div className="usage-account__label">Claude Account</div>
-                    <div className="usage-account__email">{claudeUsage.email}</div>
-                  </div>
-                )}
-              </>
+                  {scoped.accounts.map((a) => (
+                    <AccountUsageBlock
+                      key={a.id}
+                      mode={percentMode}
+                      label={a.label}
+                      email={a.email}
+                      u={acctUsage[a.id] ?? null}
+                      {...rowMark(a.id)}
+                    />
+                  ))}
+                </>
+              ) : (
+                <>
+                  {/* Claude's rows are bare when it is the only provider; once others share the
+                      panel they need a heading of their own to stay attributable. */}
+                  {enabled.length > 0 && limits.length > 0 && (
+                    <div className="usage-account__label">Claude</div>
+                  )}
+                  {limits.map((l) => (
+                    <LimitRow key={limitKey(l)} limit={l} mode={percentMode} />
+                  ))}
+                  {!hasData && <div className="usage-popover__empty">No usage data.</div>}
+                  {claudeUsage?.email && (
+                    <div className="usage-account">
+                      <div className="usage-account__label">Claude Account</div>
+                      <div className="usage-account__email">{claudeUsage.email}</div>
+                    </div>
+                  )}
+                </>
+              ))}
+            {/* On an SSH project these are the whole panel; the host badge is what says the numbers
+                were read somewhere other than this machine. */}
+            {/* The same offer on an SSH project's rows — scoped as ever: only the host's system
+                identity and THIS host's managed accounts are actionable (accountRowAction). */}
+            {visibleRemote.map((r) => (
+              <RemoteUsageBlock
+                key={`${r.hostKey}#${r.accountId ?? ''}`}
+                row={r}
+                mode={percentMode}
+                {...rowMark(r.accountId)}
+              />
             ))}
-          {/* On an SSH project these are the whole panel; the host badge is what says the numbers
-              were read somewhere other than this machine. */}
-          {/* The same offer on an SSH project's rows — scoped as ever: only the host's system
-              identity and THIS host's managed accounts are actionable (accountRowAction). */}
-          {visibleRemote.map((r) => (
-            <RemoteUsageBlock
-              key={`${r.hostKey}#${r.accountId ?? ''}`}
-              row={r}
-              mode={percentMode}
-              {...rowMark(r.accountId)}
-            />
-          ))}
-          {scope.kind === 'ssh' && visibleRemote.length === 0 && (
-            <div className="usage-popover__empty">
-              No usage from this host yet — it is read once the project connects.
-            </div>
-          )}
-          {/* U8 (owed from PR 7): Codex emits one row per account, all `provider: 'codex'`.
-              Key on provider+accountId so each account renders distinctly, and reduce true
-              duplicates (two settings entries → the same underlying account) to one row. */}
-          {dedupeProviderRows(visibleProviders).map((p) => (
-            <ProviderBlock key={providerRowKey(p)} u={p} mode={percentMode} />
-          ))}
+            {scope.kind === 'ssh' && visibleRemote.length === 0 && (
+              <div className="usage-popover__empty">
+                No usage from this host yet — it is read once the project connects.
+              </div>
+            )}
+            {/* U8 (owed from PR 7): Codex emits one row per account, all `provider: 'codex'`.
+                Key on provider+accountId so each account renders distinctly, and reduce true
+                duplicates (two settings entries → the same underlying account) to one row. */}
+            {dedupeProviderRows(visibleProviders).map((p) => (
+              <ProviderBlock key={providerRowKey(p)} u={p} mode={percentMode} />
+            ))}
+          </div>
           {/* Issue #420 — "Switch account" where the limit is displayed: opens a terminal
               running the SYSTEM-scoped `claude /login` (createSystemLoginNode), so picking the
               other org is one click from the panel that said you need to. Nothing changes until

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6575,8 +6575,25 @@ button.group-node__setup:disabled {
   border: 1px solid rgba(var(--tint-rgb), 0.1);
   box-shadow: 0 12px 40px rgba(0, 0, 0, calc(0.5 * var(--shadow-k)));
   color: var(--text-strong);
+  /* Issue #503: each account is a tall block (label + Session/Weekly/Opus meters), so past
+     about four accounts the panel grew off the TOP of the window — the first account's header
+     and meter were clipped with no way to reach them. Capped to the space between the pill
+     (bottom: 34px) and the tab bar (44px at z 30, which paints over this panel in canvas mode),
+     with the blocks scrolling inside __body while the heading and footer action stay put. */
+  max-height: calc(100vh - 86px);
+  display: flex;
+  flex-direction: column;
 }
-.usage-popover__head { margin-bottom: 12px; }
+.usage-popover__body {
+  /* Every account is rendered — the list SCROLLS rather than truncating. A cap would have to
+     say so, and there is no honest way to say "and 3 accounts you cannot see". */
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  /* Without this a flex child refuses to shrink below its content height and the max-height
+     above would do nothing. */
+  min-height: 0;
+}
+.usage-popover__head { margin-bottom: 12px; flex: none; }
 .usage-popover__title { display: block; font-size: 15px; font-weight: 600; }
 .usage-popover__ago { font-size: 12px; color: rgba(var(--tint-rgb), 0.5); }
 .usage-popover__empty { font-size: 13px; color: rgba(var(--tint-rgb), 0.5); }
@@ -6659,6 +6676,8 @@ button.group-node__setup:disabled {
 .usage-popover__switch {
   display: block;
   width: 100%;
+  /* Stays put below the scrolling account list (issue #503). */
+  flex: none;
   margin-top: 10px;
   padding: 5px 8px;
   border: none;

--- a/src/renderer/styles.usage-popover.test.ts
+++ b/src/renderer/styles.usage-popover.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Guard on the account usage popover's overflow behaviour (issue #503).
+ *
+ * The panel had no `max-height` and no scroll, so once about four accounts were present it grew
+ * taller than the window: the FIRST account's header and Session meter were clipped off the top
+ * with no way to reach them, and the last was squeezed against the status bar. Removing the
+ * account was the only workaround.
+ *
+ * The fix is structural, not cosmetic, and every part of it is load-bearing:
+ *  - the popover is capped and is a flex COLUMN, so the heading and the footer action stay put;
+ *  - `__body` is the scroll container, and needs `min-height: 0` or a flex child refuses to
+ *    shrink below its content height and the cap does nothing;
+ *  - the "Switch account…" button lives OUTSIDE `__body`, or it scrolls away with the accounts.
+ *
+ * None of that renders in CI, and all of it is one "simplification" away from being undone.
+ */
+
+const CSS = readFileSync(join(__dirname, 'styles.css'), 'utf8')
+const TSX = readFileSync(join(__dirname, 'components/UsageIndicator.tsx'), 'utf8')
+
+/** The declaration body of the rule whose selector list is EXACTLY `selector`. */
+function ruleBody(selector: string): string {
+  for (const chunk of CSS.split('}')) {
+    const brace = chunk.indexOf('{')
+    if (brace < 0) continue
+    const head = chunk
+      .slice(0, brace)
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split(',')
+      .map((sel) => sel.trim())
+      .filter(Boolean)
+      .join(',')
+    // Comments are stripped from the body too: they legitimately NAME the properties they
+    // explain, and a `not.toMatch` would then answer about the prose instead of the rule.
+    if (head === selector) return chunk.slice(brace + 1).replace(/\/\*[\s\S]*?\*\//g, '')
+  }
+  throw new Error(`no rule for selector "${selector}"`)
+}
+
+describe('.usage-popover is bounded and scrolls (issue #503)', () => {
+  it('caps its height so it can never grow past the window', () => {
+    const body = ruleBody('.usage-popover')
+    expect(body).toMatch(/max-height:\s*calc\(100vh/)
+  })
+
+  it('is a flex column, so the heading and footer can be held out of the scroll', () => {
+    const body = ruleBody('.usage-popover')
+    expect(body).toMatch(/display:\s*flex/)
+    expect(body).toMatch(/flex-direction:\s*column/)
+  })
+
+  it('scrolls the account list rather than truncating it', () => {
+    const body = ruleBody('.usage-popover__body')
+    expect(body).toMatch(/overflow-y:\s*auto/)
+    // Without min-height: 0 a flex child will not shrink below its content, and the cap above
+    // becomes decorative.
+    expect(body).toMatch(/min-height:\s*0/)
+    // A max-height here would be a silent truncation — the panel must show every account.
+    expect(body).not.toMatch(/max-height/)
+  })
+
+  it('holds the heading and the switch-account action out of the scrolling area', () => {
+    expect(ruleBody('.usage-popover__head')).toMatch(/flex:\s*none/)
+    expect(ruleBody('.usage-popover__switch')).toMatch(/flex:\s*none/)
+  })
+})
+
+describe('UsageIndicator wraps only the account blocks in the scroll container', () => {
+  it('opens __body after the head and closes it before the switch-account button', () => {
+    const head = TSX.indexOf('className="usage-popover__head"')
+    const bodyOpen = TSX.indexOf('className="usage-popover__body"')
+    const switchBtn = TSX.indexOf('className="usage-popover__switch"')
+    expect(head).toBeGreaterThan(-1)
+    expect(bodyOpen).toBeGreaterThan(head)
+    expect(switchBtn).toBeGreaterThan(bodyOpen)
+    // The wrapper is closed before the footer button — otherwise "Switch account…" scrolls away
+    // with the accounts it is meant to sit under.
+    const closeBeforeSwitch = TSX.lastIndexOf('</div>', switchBtn)
+    expect(closeBeforeSwitch).toBeGreaterThan(bodyOpen)
+  })
+})


### PR DESCRIPTION
The account usage popover had **no `max-height` and no scroll**. Each account renders as a tall vertical block (label + Session / Weekly / Opus meters) stacked in a single column, so once about four accounts are present the panel grows taller than the window: the **first** account's header and Session meter are clipped off the top with no way to reach them, and the last is squeezed against the status bar. Removing an account was the only way to see the ones above it.

## What changed

Option 1 from the issue, done so the panel's fixed parts stay fixed:

- `.usage-popover` becomes a **flex column** capped with `max-height: calc(100vh - 86px)` — the space between the pill (`bottom: 34px`) and the tab bar (44px at z 30, which paints over this panel in canvas mode, so claiming that space would be a lie).
- The account blocks move into a scrolling `.usage-popover__body` (`overflow-y: auto`, `overscroll-behavior: contain`, `min-height: 0`).
- The heading and the **"Switch account…"** action are held out of the scroll (`flex: none`) — a footer that scrolls away with the accounts it sits under is a different bug.

**Every account is still rendered**; the list scrolls rather than truncating. That is the rule the session-memory panel's row list already follows, for the same reason: there is no honest way to say "and 3 accounts you cannot see".

The grid and collapsible-row options from the issue are not here. They are layout redesigns, and the clipping is closed by the cap alone; a 280px panel does not have room for two columns without a width change that affects every other reader of this component.

## Tests

`styles.usage-popover.test.ts` guards the parts that do not render in CI and are one "simplification" away from being undone: the cap, the flex column, the scroll container's `min-height: 0` (without it a flex child never shrinks below its content and the cap is decorative), that `__body` carries no `max-height` of its own (that would be a silent truncation), and that the footer button sits **outside** the scroll wrapper. `npm run typecheck` clean.

## Surfaces

Pure renderer CSS + one wrapper element — desktop and Server Edition both get it. Kanban: covered, the popover is the same element there (`--board` z-index only). Mobile: N/A (no usage popover).

## Device checklist

Not verified on a device — this is a layout change and the screenshot case needs four or more accounts.

1. With 4+ Claude accounts (Settings → Accounts), open the usage popover → nothing is clipped at the top; the account list scrolls.
2. Scroll inside it → the "✦ Usage / Updated …" heading and the "⇄ Switch account…" button stay in place.
3. Shrink the window vertically → the panel shrinks with it and never reaches the tab bar.
4. With 1–2 accounts → the panel is exactly the size it always was (no scrollbar, no cap reached).
5. On an **SSH** project (remote account rows) and with non-Claude providers (Codex etc.) → same behaviour.
6. Open it while the **kanban board** is up → still above the board, still scrolls.
7. Scroll to the bottom of the list and keep scrolling → the canvas behind does not pan (`overscroll-behavior: contain`).
8. Light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
