### PR TITLE
fix(agents): never append a permission flag the launch command already carries

### DIFF
--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -330,6 +330,7 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
             'Launch an agent with your own command — e.g. a wrapper script that switches accounts or sets env vars. ' +
             'Used everywhere the agent is launched (new sessions, resumes, restarts), with flags like --resume appended after it, ' +
             'so the command must pass its arguments through — a shell script should end with `exec claude "$@"`. ' +
+            'A flag your command already spells is left alone: write the permission mode here and it wins over the start-up mode below. ' +
             'Leave empty for the default. SSH projects run the same command on the remote host.'
           }
           control={null}

--- a/src/shared/agents/approval-mode.test.ts
+++ b/src/shared/agents/approval-mode.test.ts
@@ -210,6 +210,69 @@ describe('UI copy derived from the mapping', () => {
  * one that matters — a plain-object lookup table answers `'constructor' in table` with true and
  * hands back a Function, which would have been stringified onto a command line.
  */
+/**
+ * Issue #601 — a launch-command override that already spells the approval flag.
+ *
+ * `settings.agentLaunchCommands` replaces the program part with the user's own wrapper, and the
+ * wrapper is entitled to carry the flag itself. Appending regardless produced
+ * `claude --permission-mode bypassPermissions --permission-mode auto`: a duplicate the settings
+ * field still displayed as exactly what was typed, so whichever occurrence the CLI honoured, the
+ * user could not tell which one was in force from the UI.
+ */
+describe('withPermissionMode — a flag the command already carries (issue #601)', () => {
+  it('does not append a second --permission-mode', () => {
+    expect(withPermissionMode('claude --permission-mode bypassPermissions', 'claude', 'auto')).toBe(
+      'claude --permission-mode bypassPermissions'
+    )
+  })
+
+  it('reads the `--flag=value` spelling too', () => {
+    expect(withPermissionMode('claude --permission-mode=plan', 'claude', 'auto')).toBe(
+      'claude --permission-mode=plan'
+    )
+  })
+
+  it('still appends when the override spells a DIFFERENT flag', () => {
+    // The reporter's own benign case: the two flags are about different things, so nodeterm keeps
+    // ownership of the one the user said nothing about.
+    expect(withPermissionMode('claude --allow-dangerously-skip-permissions', 'claude', 'auto')).toBe(
+      'claude --allow-dangerously-skip-permissions --permission-mode auto'
+    )
+  })
+
+  it('answers per agent — a gemini wrapper carrying claude’s spelling is not a match', () => {
+    // The dialects differ (`--approval-mode` vs `--permission-mode`), so the suppression has to be
+    // keyed on the flag THIS agent would actually emit, not on a fixed string.
+    expect(withPermissionMode('gemini --approval-mode yolo', 'gemini', 'plan')).toBe(
+      'gemini --approval-mode yolo'
+    )
+    expect(withPermissionMode('gemini --permission-mode plan', 'gemini', 'plan')).toBe(
+      'gemini --permission-mode plan --approval-mode plan'
+    )
+  })
+
+  it('does not match the flag NAMED inside a quoted argument', () => {
+    // Why this is tokenized rather than a substring search: a wrapper may talk ABOUT the flag, and
+    // suppressing nodeterm's real flag over a sentence would silently change the mode every node
+    // launches in.
+    expect(
+      withPermissionMode(
+        "claude --append-system-prompt 'never suggest --permission-mode'",
+        'claude',
+        'auto'
+      )
+    ).toBe("claude --append-system-prompt 'never suggest --permission-mode' --permission-mode auto")
+  })
+
+  it('leaves every non-override command byte-identical', () => {
+    // The regression guard for everyone who has not set an override: nodeterm builds those lines
+    // and never puts the flag in twice, so the new branch is unreachable for them.
+    expect(withPermissionMode('claude', 'claude', 'auto')).toBe('claude --permission-mode auto')
+    expect(withPermissionMode('codex', 'codex', 'manual')).toBe('codex --ask-for-approval untrusted')
+    expect(withPermissionMode('claude', 'claude', 'manual')).toBe('claude')
+  })
+})
+
 describe('approvalFlags — a forged mode yields the bare command', () => {
   const FORGED = ['yolo', 'on-request', 'constructor', '__proto__', 'toString', '', undefined, null]
   it('emits no flag for any agent', () => {

--- a/src/shared/agents/approval-mode.ts
+++ b/src/shared/agents/approval-mode.ts
@@ -23,6 +23,7 @@ import {
   type AgentPermissionMode,
   type BuiltinAgentId
 } from './config'
+import { argvHasFlag } from '../shell-quote'
 
 /** One agent's approval dialect: the flag it spells, and the values it accepts. ONE fact per agent —
  *  a flag and a table maintained separately is how a third agent added to the table silently emits
@@ -130,10 +131,33 @@ export function approvalFlags(agentId: AgentId, mode: AgentPermissionMode): stri
  * WHERE the flag lands is decided one layer up, by `createAgentNode`: with no `argvPromptSeparator`
  * (claude, gemini, codex) it goes LAST, keeping those command lines byte-identical; with one
  * (grok's `--`) it must go BEFORE the separator, because `--` is end-of-options.
+ *
+ * **A flag the command already carries is left alone (issue #601).** `cmd` is not always ours:
+ * `settings.agentLaunchCommands` lets the user replace the program part with a wrapper, and a
+ * wrapper may spell the approval flag itself. Appending regardless produced
+ * `claude --permission-mode bypassPermissions --permission-mode auto` — a duplicate the settings
+ * field still displayed as exactly what the user typed, so whichever occurrence the CLI honoured,
+ * they had no way to tell which one was in force.
+ *
+ * The contract this settles is "program only, minus what you spelled yourself", not "the override
+ * owns the whole command". The whole-command reading cannot work: the settings copy already
+ * promises that `--resume` and friends are appended, and a wrapper has no way to know the session id
+ * a cold restore is resuming — so nodeterm has to keep appending. What it must not do is append a
+ * SECOND opinion about a flag the user has already stated one about; theirs is the more specific and
+ * the more explicit, and it wins.
+ *
+ * Deliberately not extended to `withAgentModel`: a model switch is a per-node action the user just
+ * took, and letting a global launch-command override veto it would silently strand that node on the
+ * wrapper's model. Different specificity, opposite answer.
+ *
+ * A command with no override cannot reach the suppression — nodeterm builds it and never puts the
+ * flag in twice — so every existing launch line is byte-identical.
  */
 export function withPermissionMode(cmd: string, id: AgentId, mode: AgentPermissionMode): string {
   const flags = approvalFlags(id, mode)
-  return flags.length ? `${cmd} ${flags.join(' ')}` : cmd
+  if (!flags.length) return cmd
+  if (argvHasFlag(cmd, flags[0])) return cmd
+  return `${cmd} ${flags.join(' ')}`
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/src/shared/agents/launch.test.ts
+++ b/src/shared/agents/launch.test.ts
@@ -370,6 +370,51 @@ describe('assembleLaunchCommand — promptFile (issue #520)', () => {
   })
 })
 
+/**
+ * Issue #601, at the layer the reporter actually read it off — the assembled command line, the one
+ * that shows up in the process table. `withPermissionMode` has its own unit tests; these two pin
+ * that the composition does not put the flag back.
+ */
+describe('assembleLaunchCommand / assembleResumeCommand — override already carries the flag (#601)', () => {
+  it('does not duplicate --permission-mode on a fresh launch', () => {
+    expect(
+      assembleLaunchCommand(
+        {
+          agentId: 'claude',
+          launchCmdOverride: 'claude --permission-mode bypassPermissions',
+          permissionMode: 'auto'
+        },
+        ENV
+      ).command
+    ).toBe('claude --permission-mode bypassPermissions')
+  })
+
+  it('does not duplicate it on the resume path either', () => {
+    // The cold-restore / restart leg. It resumes through the same wrapper, so it inherits the same
+    // duplicate if this is fixed in only one assembler.
+    expect(
+      assembleResumeCommand(
+        {
+          agentId: 'claude',
+          launchCmdOverride: 'claude --permission-mode=plan',
+          sessionId: 'abc-123',
+          permissionMode: 'auto'
+        },
+        ENV
+      ).command
+    ).toBe('claude --permission-mode=plan --resume abc-123')
+  })
+
+  it('still appends to an override that says nothing about permissions', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'claude', launchCmdOverride: 'my-wrapper', permissionMode: 'auto' },
+        ENV
+      ).command
+    ).toBe('my-wrapper --permission-mode auto')
+  })
+})
+
 describe('promptFilePathError', () => {
   it('accepts an absolute POSIX path', () => {
     expect(promptFilePathError('/tmp/brief.md')).toBeNull()

--- a/src/shared/shell-quote.test.ts
+++ b/src/shared/shell-quote.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shellSingleQuote, shellSplit } from './shell-quote'
+import { argvHasFlag, shellSingleQuote, shellSplit } from './shell-quote'
 
 describe('shellSingleQuote', () => {
   it('wraps a plain string in single quotes', () => {
@@ -29,5 +29,28 @@ describe('shellSplit', () => {
   })
   it('does NOT perform shell variable expansion ($VAR stays literal)', () => {
     expect(shellSplit('$HOME/x')).toEqual(['$HOME/x'])
+  })
+})
+
+describe('argvHasFlag', () => {
+  it('finds both spellings of an option', () => {
+    expect(argvHasFlag('claude --permission-mode plan', '--permission-mode')).toBe(true)
+    expect(argvHasFlag('claude --permission-mode=plan', '--permission-mode')).toBe(true)
+  })
+  it('is false when the flag is absent', () => {
+    expect(argvHasFlag('claude --resume abc', '--permission-mode')).toBe(false)
+    expect(argvHasFlag('', '--permission-mode')).toBe(false)
+  })
+  it('does not match a PREFIX of a longer option', () => {
+    // `--permission-mode-file` is a different flag; matching it would suppress the real one.
+    expect(argvHasFlag('claude --permission-mode-file /x', '--permission-mode')).toBe(false)
+  })
+  it('does not match the flag inside a quoted argument', () => {
+    expect(argvHasFlag("claude -p 'use --permission-mode'", '--permission-mode')).toBe(false)
+    expect(argvHasFlag('claude -p "use --permission-mode"', '--permission-mode')).toBe(false)
+  })
+  it('stops at a bare `--` — past end-of-options a word is data, not an option', () => {
+    expect(argvHasFlag('grok -- --permission-mode', '--permission-mode')).toBe(false)
+    expect(argvHasFlag('grok --permission-mode plan -- prompt', '--permission-mode')).toBe(true)
   })
 })

--- a/src/shared/shell-quote.ts
+++ b/src/shared/shell-quote.ts
@@ -35,6 +35,32 @@ export function shellQuoteIfNeeded(s: string): string {
  * (see launch.ts), so a resolved value containing spaces or metacharacters stays one argument by
  * construction — the token boundary is fixed before any environment value enters the string.
  */
+/**
+ * Does this command line already carry `flag` as an OPTION of its own?
+ *
+ * Issue #601: nodeterm appends its managed flags to a launch command it did not necessarily write —
+ * `settings.agentLaunchCommands` lets the user replace the program part with a wrapper, and a
+ * wrapper is entitled to spell an option nodeterm also spells. Appending blindly produced
+ * `claude --permission-mode bypassPermissions --permission-mode auto`: a duplicate the field still
+ * displayed as what the user typed, so whichever occurrence the CLI honoured, they had no way to
+ * tell which.
+ *
+ * Both spellings count (`--flag value` and `--flag=value`), and the answer is computed from TOKENS
+ * rather than from a substring search, which is the whole reason this lives beside `shellSplit`: an
+ * override like `claude --append-system-prompt 'mind --permission-mode'` mentions the flag inside a
+ * quoted argument, and a substring match there would suppress nodeterm's real flag over a sentence.
+ *
+ * Scanning stops at a bare `--`, because everything after end-of-options is a positional argument —
+ * a word there is the CLI's data, not an option it will act on.
+ */
+export function argvHasFlag(cmd: string, flag: string): boolean {
+  for (const token of shellSplit(cmd)) {
+    if (token === '--') return false
+    if (token === flag || token.startsWith(`${flag}=`)) return true
+  }
+  return false
+}
+
 export function shellSplit(input: string): string[] {
   const tokens: string[] = []
   let buf = ''


### PR DESCRIPTION
## The answer to the question

**Program only — minus what you spelled yourself.** Neither of the two readings in the issue survives on its own, so this takes the narrow third one.

*Whole command* cannot work. The settings copy already promises that `--resume` is appended after the override, and a wrapper has no way to know the session id a cold restore is resuming — if the override owned the entire line, a restarted node could never resume. So nodeterm has to keep appending.

*Program only, as it stands* is also wrong, and for the reason you gave: what it produces is not a decision, it is a **duplicate the UI still renders as what you typed**. Whichever occurrence the CLI honours, the user cannot tell which one is in force. That is the bug — not the outcome, the unknowability.

So the flag nodeterm appends is one **it owns only where the user has said nothing**. Their literal flag is the more specific and the more explicit statement, and it wins; everything they did not spell stays nodeterm's. Your `--allow-dangerously-skip-permissions` case keeps behaving exactly as it does today.

## The fix

`withPermissionMode` now checks the command it was handed:

```ts
const flags = approvalFlags(id, mode)
if (!flags.length) return cmd
if (argvHasFlag(cmd, flags[0])) return cmd
return `${cmd} ${flags.join(' ')}`
```

`argvHasFlag` lives beside `shellSplit` in `src/shared/shell-quote.ts` and answers from **tokens**, not from a substring search. That is load-bearing: an override like `claude --append-system-prompt 'never suggest --permission-mode'` mentions the flag inside a quoted argument, and a substring match there would suppress nodeterm's real flag and silently change the mode **every** node launches in — a worse failure than the one being fixed. Both spellings count (`--flag value`, `--flag=value`), a prefix does not (`--permission-mode-file` is a different flag), and scanning stops at a bare `--`, past which a word is the CLI's data rather than an option.

It keys on the flag **this agent** would emit, so a gemini wrapper carrying claude's `--permission-mode` still gets its own `--approval-mode` appended — the dialects are genuinely different flags.

## Deliberately not extended to `--model`

`withAgentModel` has the identical shape and is left alone. A model switch is a per-node action the user just took; a launch-command override is global config. Letting the global config veto the explicit per-node action would strand that node on the wrapper's model with no message. Same mechanism, opposite specificity, opposite answer — worth stating because the next reader will notice the asymmetry.

`--resume` is likewise untouched: an override carrying a session id would be broken already (every node would share it), and the settings copy asks the wrapper to pass arguments through.

## Visibility

The Settings → Agents description gains one sentence, so the contract is readable where it is configured:

> A flag your command already spells is left alone: write the permission mode here and it wins over the start-up mode below.

## Byte-identical for everyone else

A command with no override cannot reach the new branch — nodeterm builds those lines and never puts the flag in twice. Pinned by a test that asserts the bare, the `manual` (no flag) and the codex `untrusted` lines are unchanged.

## Verification

- New tests in `approval-mode.test.ts` (6), `launch.test.ts` (3, at the assembled-command layer the process table shows — both the fresh-launch and the **resume** assembler, since fixing one and not the other is the obvious half-fix), `shell-quote.test.ts` (5).
- Mutation-tested: deleting the guard line turns 5 of them red.
- `npm run typecheck` clean on both projects; `src/shared`, `src/renderer/state` and the settings suites green.

Not device-verified: which occurrence Claude Code actually honours in a duplicate was never established (the issue does not claim it either), and this change means the duplicate is no longer produced, so the question stops mattering.

### Device checklist

1. Set the Claude launch command to `claude --permission-mode bypassPermissions` with the start-up mode on Auto, open a node, and check `ps`: exactly one `--permission-mode`, and it is `bypassPermissions`.
2. Set it to `claude --allow-dangerously-skip-permissions` — the line still gains `--permission-mode auto`, as it does today.
3. Restart the same node ("Restart agent (resume)") and confirm the resume line carries no duplicate either.
4. Clear the field and confirm the command line is byte-identical to a build before this change.

Fixes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
