### PR TITLE
fix(windows): stop calling the local machine a Mac

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2861,6 +2861,18 @@ the overlap tests exercise the resulting race.
 
 
 - Code comments, UI strings, and identifiers are all in **English**. Match this when editing.
+- **The local machine is not a Mac.** Every user-visible string naming it goes through
+  `renderer/lib/machineName.ts` (`thisMachine()` / `thisMachineCap()` / `machineNoun()` →
+  "this Mac" / "this PC" / "this computer"). A **browser tab always gets the neutral word**: the
+  license, seats and sessions it describes belong to the SERVER, and the viewer's `navigator` says
+  nothing about that machine's OS — a confident wrong noun is worse than a plain one. Issue #563
+  found ~30 such strings, and the damage was not in Accounts but in the copy people must TRUST:
+  "This Mac is not authorized on this license" and "a teammate on a seat can run commands on this
+  Mac". `machineName.guard.test.ts` scans non-comment lines in `src/renderer` + `src/shared` and
+  fails on a new one, with a named-and-reasoned exemption list (the ptmx-limit banner, whose
+  `kern.tty.ptmx_max` really is macOS; the onboarding notch step, which only exists there).
+  `@shared` code cannot ask the renderer, so it takes the machine word as a PARAMETER defaulting
+  to the neutral one (`describeGrant(peer, machine)`) rather than hard-coding a brand.
 - Path aliases: `@shared/*`, `@renderer/*` (see the tsconfig files / vite config).
 - **Subagent model:** when dispatching subagents (implementers, reviewers, etc. — e.g. in
   the subagent-driven-development workflow), use the latest model, **Opus 5**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,16 @@ lane unaffected.
 
 ## House rules
 
+- **Never call the user's machine a Mac in user-visible copy.** Use `thisMachine()` /
+  `thisMachineCap()` / `machineNoun()` from `src/renderer/lib/machineName.ts` — "this Mac" on
+  macOS, "this PC" on Windows, "this computer" elsewhere and in any Server Edition browser tab
+  (where the machine being described is the SERVER, whose OS the viewer cannot know). Issue #563:
+  ~30 strings said "this Mac", including *"This Mac is not authorized on this license"* and *"a
+  teammate on a seat can run commands on this Mac"* — the one sentence a user has to trust before
+  handing out shell access. `machineName.guard.test.ts` scans non-comment lines and will fail your
+  PR; copy that really is macOS-specific (the ptmx-limit banner, the notch step) is exempt by name
+  with its reason. Comments are not scanned.
+
 - **Anything path-shaped: Windows is a delivery target.** Most of this was written on
   macOS/Linux, so the recurring defect is code that is genuinely correct on POSIX —
   `split('/')`, `startsWith('/')` as an is-absolute test, a bare `fs.rename`. Use

--- a/src/renderer/components/PhonePairPopover.tsx
+++ b/src/renderer/components/PhonePairPopover.tsx
@@ -4,13 +4,14 @@ import { Switch } from '@renderer/ui/Switch'
 import { useSettings } from '@renderer/state/settings'
 import { usePhonePairing } from './settings/usePhonePairing'
 import { IOS_APP_STORE_URL } from '@renderer/lib/links'
+import { thisMachine } from '@renderer/lib/machineName'
 
 const isMac = /Mac/i.test(navigator.platform || navigator.userAgent)
 
 /**
  * Quick phone pairing, anchored under the top-right phone button: opens straight into a live QR
  * (no "Start pairing" click — that's the whole point of the shortcut), with the standing
- * "Reach this Mac from anywhere" toggle below and a link into the full Phone settings.
+ * "Reach this <machine> from anywhere" toggle below and a link into the full Phone settings.
  * Closing the popover stops an unfinished pairing (the shared hook's unmount rule).
  */
 export function PhonePairPopover({
@@ -97,8 +98,8 @@ export function PhonePairPopover({
                 </div>
               ) : !phoneAccessEnabled ? (
                 <div className="phone-pair__warn">
-                  LAN-only code: the phone will reach this Mac only on this network. Flip the
-                  toggle below first to also connect from anywhere — the QR refreshes by itself.
+                  LAN-only code: the phone will reach {thisMachine()} only on this network. Flip
+                  the toggle below first to also connect from anywhere — the QR refreshes by itself.
                 </div>
               ) : null}
               {sshHealed ? <div className="phone-pair__ok">✓ Remote Login is on.</div> : null}
@@ -138,13 +139,13 @@ export function PhonePairPopover({
 
         <div className="phone-pair__row">
           <div className="phone-pair__row-text">
-            <div className="phone-pair__row-title">Reach this Mac from anywhere</div>
+            <div className="phone-pair__row-title">Reach {thisMachine()} from anywhere</div>
             <div className="phone-pair__row-sub">E2E encrypted over the relay — not just your LAN.</div>
           </div>
           <Switch
             checked={phoneAccessEnabled}
             onChange={togglePhoneAccess}
-            ariaLabel="Reach this Mac from anywhere"
+            ariaLabel={`Reach ${thisMachine()} from anywhere`}
           />
         </div>
 

--- a/src/renderer/components/RemoteAccessDialog.tsx
+++ b/src/renderer/components/RemoteAccessDialog.tsx
@@ -4,6 +4,7 @@ import { useDialogStack } from './dialog-stack'
 import { useEntitlement } from '../state/entitlement'
 import { useProjects } from '../state/projects'
 import { hostShareOptions } from '../lib/relayHostShare'
+import { thisMachine } from '../lib/machineName'
 import { Button } from '@renderer/ui/Button'
 import { CopyButton } from '@renderer/ui/CopyButton'
 import { Input } from '@renderer/ui/Input'
@@ -104,7 +105,8 @@ export function RemoteAccessDialog({ onClose }: { onClose: () => void }): React.
             <div className="remote-dialog__block">
               <p className="remote-dialog__hint">
                 Sharing <strong>{sharedName || 'this project'}</strong> — the joiner will see this
-                project and can run commands on this Mac. Share this pairing code (single use):
+                project and can run commands on {thisMachine()}. Share this pairing code (single
+                use):
               </p>
               <Input
                 className="w-full"
@@ -137,7 +139,7 @@ export function RemoteAccessDialog({ onClose }: { onClose: () => void }): React.
               ) : (
                 <p className="remote-dialog__hint">
                   Sharing <strong>{sharedName || 'this project'}</strong> — the joiner sees this
-                  project and can run commands on this Mac.
+                  project and can run commands on {thisMachine()}.
                 </p>
               )}
               <Button disabled={hostBusy} onClick={() => void startHosting()}>

--- a/src/renderer/components/UpgradeDialog.tsx
+++ b/src/renderer/components/UpgradeDialog.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom'
 import { useEntitlement } from '../state/entitlement'
 import { useUpgradeGate } from '../state/upgradeGate'
+import { thisMachine } from '../lib/machineName'
 
 /**
  * Pro upgrade prompt shown when a free user triggers a gated feature. Closes automatically
@@ -17,8 +18,8 @@ export function UpgradeDialog() {
         <p className="confirm__msg">{feature} is a Pro feature</p>
         <p className="confirm__msg">
           Pro unlocks unlimited remote access from your phone (free plan: 5 connections/month),
-          3 team seats to share this Mac, and nodeterm mobile Pro. Complete your purchase in the
-          browser — Pro unlocks here automatically.
+          3 team seats to share {thisMachine()}, and nodeterm mobile Pro. Complete your purchase
+          in the browser — Pro unlocks here automatically.
         </p>
         <div className="confirm__actions">
           <button className="confirm__btn" onClick={hide}>

--- a/src/renderer/components/settings/sections/AccountsSection.tsx
+++ b/src/renderer/components/settings/sections/AccountsSection.tsx
@@ -28,6 +28,7 @@ import { SearchableRow } from '../SearchableRow'
 import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
 import { cn } from '@renderer/ui/cn'
+import { thisMachine, thisMachineCap } from '../../../lib/machineName'
 
 const ROWS = {
   accounts: {
@@ -235,7 +236,7 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
   const [addingCodex, setAddingCodex] = useState(false)
   const [codexAddError, setCodexAddError] = useState<string | null>(null)
 
-  // The reachable machines: this Mac first, then every saved SSH server unioned with the active
+  // The reachable machines: this machine first, then every saved SSH server unioned with the active
   // project's own server (deduped by host key). Accounts partition onto them by `host`.
   const remoteTargets = codexRemoteTargets(sshServers, activeProject?.ssh?.server)
   const codexGroups = groupCodexAccountsByMachine(codexAccounts, remoteTargets)
@@ -661,8 +662,8 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
           )}
 
           {activeHostKey ? (
-            // Inside an SSH project: choose where the new account lives. "On this Mac" is a normal
-            // local account; "On <host>" creates it on the remote host (usable only there).
+            // Inside an SSH project: choose where the new account lives. "On this machine" is a
+            // normal local account; "On <host>" creates it on the remote host (usable only there).
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-2">
                 <Button
@@ -671,9 +672,9 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
                   onClick={() => void onAddAccount()}
                 >
                   {addingOn === LOCAL_TARGET ? (
-                    <AddingLabel where="this Mac" />
+                    <AddingLabel where={thisMachine()} />
                   ) : (
-                    'Add account — On this Mac'
+                    `Add account — On ${thisMachine()}`
                   )}
                 </Button>
                 <Button
@@ -707,7 +708,7 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
                 disabled={addingOn !== null}
                 onClick={() => void onAddAccount()}
               >
-                {addingOn === LOCAL_TARGET ? <AddingLabel where="this Mac" /> : 'Add account'}
+                {addingOn === LOCAL_TARGET ? <AddingLabel where={thisMachine()} /> : 'Add account'}
               </Button>
               {addingOn !== null ? (
                 <p className="text-[12px] leading-relaxed text-muted">
@@ -735,7 +736,7 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
           {codexGroups.map((group) => (
             <MachinePanel
               key={group.host || 'local'}
-              label={group.remote ? (group.server?.label ?? group.host) : 'This Mac'}
+              label={group.remote ? (group.server?.label ?? group.host) : thisMachineCap()}
               remote={group.remote}
               hostKey={group.host || undefined}
               connected={group.remote ? !!connectedProjectIdForHost(group.host) : true}
@@ -747,7 +748,7 @@ export function AccountsSection({ isActive }: { isActive: boolean }): React.JSX.
                     {addingCodex ? (
                       <span className="inline-flex items-center gap-2">
                         <span className="ui-spinner" aria-hidden />
-                        Setting up on this Mac…
+                        Setting up on {thisMachine()}…
                       </span>
                     ) : (
                       'Add Codex account'

--- a/src/renderer/components/settings/sections/LicenseSection.test.tsx
+++ b/src/renderer/components/settings/sections/LicenseSection.test.tsx
@@ -174,7 +174,7 @@ describe('LicenseSection — confirming the destructive actions', () => {
     const dialog = screenText()
     expect(dialog).toMatch(/paired phone/)
     expect(dialog).toMatch(/once every 30 days/)
-    expect(dialog).toMatch(/this Mac keeps it/)
+    expect(dialog).toMatch(/this computer keeps it/)
 
     await act(async () => confirmDialog('Cancel'))
     expect(releaseOthers).not.toHaveBeenCalled()

--- a/src/renderer/components/settings/sections/LicenseSection.tsx
+++ b/src/renderer/components/settings/sections/LicenseSection.tsx
@@ -6,6 +6,7 @@ import { FieldRow } from '../FieldRow'
 import { ConfirmDialog } from '../../ConfirmDialog'
 import { ProCompare } from './ProCompare'
 import { Button } from '@renderer/ui/Button'
+import { machineNoun, otherMachines, thisMachine } from '@renderer/lib/machineName'
 import { Input } from '@renderer/ui/Input'
 import {
   licenseSentence,
@@ -49,7 +50,7 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
   const [copied, setCopied] = useState(false)
   const [confirming, setConfirming] = useState<'release' | 'deactivate' | null>(null)
   // The reason code of a release that did not land — NOT a boolean, and NOT merged into `detail`:
-  // "offline" and "this Mac is not authorized" owe the user different sentences, and neither of
+  // "offline" and "this machine is not authorized" owe the user different sentences, and neither of
   // them is a statement about the license the panel is displaying. See `releaseFailureSentence`.
   const [releaseError, setReleaseError] = useState<string | null>(null)
   // `loadDetail` REJECTS on the Server Edition (`E_UNSUPPORTED` — there is no license layer in
@@ -151,7 +152,8 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
                 {sentence ? <p className="text-sm text-muted">{sentence}</p> : null}
                 {canUseKeyElsewhere(detail) ? (
                   <p className="text-sm text-muted">
-                    To use Pro on another Mac, open Settings → License there and paste this key.
+                    To use Pro on another {machineNoun()}, open Settings → License there and paste
+                    this key.
                   </p>
                 ) : null}
                 {canReleaseDevices(detail) ? (
@@ -226,7 +228,7 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
           house pattern (a single phone revoke gets a ConfirmDialog; these are larger). */}
       {confirming === 'release' ? (
         <ConfirmDialog
-          message="Release every other device on this license? Your other Macs and every paired phone lose Pro until they are activated again — this Mac keeps it. Devices can only be released once every 30 days."
+          message={`Release every other device on this license? Your ${otherMachines()} and every paired phone lose Pro until they are activated again — ${thisMachine()} keeps it. Devices can only be released once every 30 days.`}
           confirmLabel="Release others"
           onConfirm={runRelease}
           onCancel={() => setConfirming(null)}
@@ -239,8 +241,8 @@ export function LicenseSection({ isActive }: { isActive: boolean }): React.JSX.E
           // this sentence the buyer is back in the support queue this whole screen exists to end.
           message={
             keyOnFile
-              ? 'Deactivate Pro on this Mac? Copy your license key first — it is shown here only while Pro is active, and you need it to activate again.'
-              : 'Deactivate Pro on this Mac? Pro features stop here until this device is activated again.'
+              ? `Deactivate Pro on ${thisMachine()}? Copy your license key first — it is shown here only while Pro is active, and you need it to activate again.`
+              : `Deactivate Pro on ${thisMachine()}? Pro features stop here until this device is activated again.`
           }
           confirmLabel="Deactivate"
           onConfirm={() => {

--- a/src/renderer/components/settings/sections/PhoneSection.tsx
+++ b/src/renderer/components/settings/sections/PhoneSection.tsx
@@ -8,6 +8,7 @@ import { Switch } from '@renderer/ui/Switch'
 import { useSettings } from '@renderer/state/settings'
 import { usePhonePairing } from '../usePhonePairing'
 import { IOS_APP_STORE_URL } from '@renderer/lib/links'
+import { thisMachine } from '../../../lib/machineName'
 
 const ROWS = {
   remote: {
@@ -152,7 +153,8 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
             <div className="min-w-0">
               <h4 className="text-[13px] font-medium text-text">Remote access from your phone</h4>
               <p className="mt-1 text-sm text-muted">
-                Reach this Mac from anywhere — not just your local network — end-to-end encrypted
+                Reach {thisMachine()} from anywhere — not just your local network — end-to-end
+                encrypted
                 over the relay. Your paired phone connects through the relay; the connection is
                 verified with a code the first time.
               </p>
@@ -330,7 +332,7 @@ export function PhoneSection({ isActive }: { isActive: boolean }): React.JSX.Ele
           // Both legs, and the timing of the one that is not instant. "If" rather than a flat
           // claim: a free-tier desktop has no Pro of ours on that phone to take back, and this
           // dialog cannot tell — the server leg reports that only after the fact ('skipped').
-          message={`Revoke “${pendingRevoke.name}”? Its key is removed from this machine and it will no longer be able to connect. If its Pro comes from this Mac’s license, that is revoked too — the phone loses Pro within 7 days.`}
+          message={`Revoke “${pendingRevoke.name}”? Its key is removed from this machine and it will no longer be able to connect. If its Pro comes from ${thisMachine()}’s license, that is revoked too — the phone loses Pro within 7 days.`}
           confirmLabel="Revoke"
           onConfirm={() => void revokeDevice(pendingRevoke)}
           onCancel={() => setPendingRevoke(null)}

--- a/src/renderer/components/settings/sections/PresenceIdentitySection.tsx
+++ b/src/renderer/components/settings/sections/PresenceIdentitySection.tsx
@@ -7,6 +7,7 @@ import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
 import { Button } from '@renderer/ui/Button'
 import { Input } from '@renderer/ui/Input'
+import { thisMachine } from '../../../lib/machineName'
 
 const ROWS = {
   identity: {
@@ -44,7 +45,7 @@ export function PresenceIdentitySection({ isActive }: { isActive: boolean }): Re
     <SettingsSection
       id="presence"
       title="Your name"
-      description="The name and color other people see when they connect to this Mac — in the facepile, cursor labels, and board comments."
+      description={`The name and color other people see when they connect to ${thisMachine()} — in the facepile, cursor labels, and board comments.`}
       isActive={isActive}
       searchEntries={ENTRIES}
     >

--- a/src/renderer/components/settings/sections/RemoteSection.tsx
+++ b/src/renderer/components/settings/sections/RemoteSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useEntitlement } from '../../../state/entitlement'
 import { useProjects } from '../../../state/projects'
 import { hostShareOptions } from '../../../lib/relayHostShare'
+import { thisMachine } from '../../../lib/machineName'
 import { SettingsSection } from '../SettingsSection'
 import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
@@ -93,8 +94,8 @@ export function RemoteSection({
               <div className="space-y-2">
                 <p className="text-sm text-muted">
                   Sharing <strong className="text-text">{sharedName || 'this project'}</strong> —
-                  the joiner will see this project and can run commands on this Mac. Share this
-                  pairing code with the other device (single use):
+                  the joiner will see this project and can run commands on {thisMachine()}. Share
+                  this pairing code with the other device (single use):
                 </p>
                 <FieldRow
                   label="Pairing code"
@@ -134,7 +135,7 @@ export function RemoteSection({
                 ) : (
                   <p className="text-sm text-muted">
                     Sharing <strong className="text-text">{sharedName || 'this project'}</strong> —
-                    the joiner sees this project and can run commands on this Mac.
+                    the joiner sees this project and can run commands on {thisMachine()}.
                   </p>
                 )}
                 <Button disabled={hostBusy} onClick={() => void startHosting()}>

--- a/src/renderer/components/settings/sections/TeamAccessSection.tsx
+++ b/src/renderer/components/settings/sections/TeamAccessSection.tsx
@@ -7,6 +7,7 @@ import { SettingsSection } from '../SettingsSection'
 import { SearchableRow } from '../SearchableRow'
 import { FieldRow } from '../FieldRow'
 import { Button } from '@renderer/ui/Button'
+import { thisMachine } from '@renderer/lib/machineName'
 import { CopyButton } from '@renderer/ui/CopyButton'
 import { Input } from '@renderer/ui/Input'
 
@@ -81,7 +82,7 @@ export function TeamAccessSection({
     <SettingsSection
       id="team-access"
       title="Team seats"
-      description="Share this Mac with your team — Pro includes 3 seats, extra seats $5/seat/month."
+      description={`Share ${thisMachine()} with your team — Pro includes 3 seats, extra seats $5/seat/month.`}
       isActive={isActive}
       searchEntries={ENTRIES}
     >
@@ -116,8 +117,8 @@ export function TeamAccessSection({
             <div className="space-y-3">
               <h4 className="text-[13px] font-medium text-text">Invite a teammate</h4>
               <p className="text-sm text-muted">
-                A teammate on a seat can run commands on this Mac — the same as giving them SSH
-                access. Only invite people you trust.
+                A teammate on a seat can run commands on {thisMachine()} — the same as giving
+                them SSH access. Only invite people you trust.
               </p>
               <FieldRow
                 label="Teammate email"
@@ -185,14 +186,14 @@ export function TeamAccessSection({
               Upgrade to Pro — 3 collaborator seats included
             </h4>
             <p className="text-sm text-muted">
-              Pro comes with 3 seats to share this Mac with your team. Need more? Extra seats are
-              $5/seat/month. Each teammate connects from their own device over the end-to-end
-              encrypted relay.
+              Pro comes with 3 seats to share {thisMachine()} with your team. Need more? Extra
+              seats are $5/seat/month. Each teammate connects from their own device over the
+              end-to-end encrypted relay.
             </p>
             <p className="text-sm text-muted">
-              A seat grants shell access: a teammate on a seat can run commands on this Mac — the
-              same as giving them SSH access. Every connection is still verified with a one-time
-              pairing code you compare together.
+              A seat grants shell access: a teammate on a seat can run commands on{' '}
+              {thisMachine()} — the same as giving them SSH access. Every connection is still
+              verified with a one-time pairing code you compare together.
             </p>
             <Button variant="primary" onClick={() => void ent.upgrade()}>
               Upgrade to Pro — get 3 free seats

--- a/src/renderer/lib/accountPresentation.test.ts
+++ b/src/renderer/lib/accountPresentation.test.ts
@@ -6,7 +6,7 @@ describe('presentAccount', () => {
     expect(presentAccount({ label: 'Work', email: 'me@example.com' })).toEqual({
       identity: 'Work',
       provenance: 'Local',
-      tooltip: 'Work (me@example.com) · This Mac'
+      tooltip: 'Work (me@example.com) · This computer'
     })
   })
 
@@ -19,7 +19,7 @@ describe('presentAccount', () => {
     ).toEqual({
       identity: 'me@example.com',
       provenance: 'Local',
-      tooltip: 'me@example.com · This Mac'
+      tooltip: 'me@example.com · This computer'
     })
     // A row still carrying the generated placeholder collapses to "Default account".
     expect(presentAccount({ label: 'New Codex account' }).identity).toBe('Default account')

--- a/src/renderer/lib/accountPresentation.ts
+++ b/src/renderer/lib/accountPresentation.ts
@@ -4,6 +4,8 @@
 // This module is renderer-pure: it imports nothing from `src/core`, so presenting an account
 // never drags the impure core path machinery into the bundle.
 
+import { thisMachineCap } from './machineName'
+
 export interface AccountPresentation {
   /** Human identity: a chosen account name, otherwise the login email. */
   identity: string
@@ -46,7 +48,7 @@ export function presentAccount({
 }: {
   label?: string | null
   email?: string | null
-  /** Canonical SSH address (`user@host`). Omit for an account on this Mac. */
+  /** Canonical SSH address (`user@host`). Omit for an account on this machine. */
   host?: string | null
   /** Friendly saved SSH-machine name. */
   machineLabel?: string | null
@@ -55,7 +57,7 @@ export function presentAccount({
   const cleanEmail = email?.trim() || undefined
   const identity = displayLabel || cleanEmail || 'Default account'
   const provenance = host ? `SSH · ${machineLabel?.trim() || host}` : 'Local'
-  const originDetail = host ? `SSH ${host}` : 'This Mac'
+  const originDetail = host ? `SSH ${host}` : thisMachineCap()
   const identityDetail =
     cleanEmail && cleanEmail !== identity ? `${identity} (${cleanEmail})` : identity
   return {

--- a/src/renderer/lib/licenseCopy.test.ts
+++ b/src/renderer/lib/licenseCopy.test.ts
@@ -26,11 +26,11 @@ const keygen = (over: Partial<LicenseDetail> = {}): LicenseDetail => ({
 describe('licenseSentence — a keygen license that read cleanly', () => {
   it('reports usage against the cap and names phones as devices', () => {
     const s = licenseSentence(keygen({ used: 2, seats: 3 }))
-    expect(s).toBe('2 of 3 devices in use — this Mac and each paired phone counts as a device.')
+    expect(s).toBe('2 of 3 devices in use — this computer and each paired phone counts as a device.')
     // The numbers are the DATA's, not a template that happens to read well: a swapped pair or a
     // hardcoded cap would still match a looser assertion.
     expect(licenseSentence(keygen({ used: 1, seats: 5 }))).toBe(
-      '1 of 5 devices in use — this Mac and each paired phone counts as a device.'
+      '1 of 5 devices in use — this computer and each paired phone counts as a device.'
     )
   })
 
@@ -62,7 +62,7 @@ describe('licenseSentence — sources that have no key and no device count', () 
   it('says an App Store subscription bridged Pro here, and prints no counts', () => {
     const s = licenseSentence({ key: null, used: 0, seats: 0, source: 'apple', error: null })
     expect(s).toBe(
-      'Pro on this Mac comes from the App Store subscription on your paired phone, so there is no license key or device count to show here.'
+      'Pro on this computer comes from the App Store subscription on your paired phone, so there is no license key or device count to show here.'
     )
     // The zeros are "not applicable", not a measurement. Rendering them here is the exact
     // misdirection this branch exists to prevent.
@@ -106,7 +106,7 @@ describe('licenseSentence — a read that FAILED', () => {
   it('does not promise Pro is unaffected when the server said the license is inactive', () => {
     const s = licenseSentence({ key: null, used: 0, seats: 0, source: null, error: 'inactive' })
     expect(s).toBe(
-      'This license is not active, so there is no key or device count to show — and Pro on this Mac will stop when its current entitlement expires.'
+      'This license is not active, so there is no key or device count to show — and Pro on this computer will stop when its current entitlement expires.'
     )
     // A suspended/refunded license DOES drop Pro at the next refresh — the old shared sentence
     // told that user the opposite, in the one place they came to find out.
@@ -114,10 +114,10 @@ describe('licenseSentence — a read that FAILED', () => {
     expect(s).not.toContain('0 of 0')
   })
 
-  it('does not promise Pro is unaffected when this Mac was refused', () => {
+  it('does not promise Pro is unaffected when this machine was refused', () => {
     const s = licenseSentence({ key: null, used: 0, seats: 0, source: null, error: 'unauthorized' })
     expect(s).toBe(
-      'This Mac is not authorized on this license, so the key and device count are unavailable — and Pro here may stop when its current entitlement expires.'
+      'This computer is not authorized on this license, so the key and device count are unavailable — and Pro here may stop when its current entitlement expires.'
     )
     expect(s).not.toContain('unaffected')
     // "may", not "will": a later refresh can re-mint. Overstating is the other half of the lie.
@@ -234,7 +234,7 @@ describe('canUseKeyElsewhere', () => {
 
   it('is false AT the cap — the activation it invites would be refused', () => {
     // This line used to render under "All 3 devices are in use": we told the user to go and paste
-    // the key on another Mac, where the server answers seat_limit. Advice that cannot work.
+    // the key on another machine, where the server answers seat_limit. Advice that cannot work.
     expect(canUseKeyElsewhere(keygen({ used: 3, seats: 3 }))).toBe(false)
   })
 
@@ -286,7 +286,7 @@ describe('releaseFailureSentence', () => {
 
   it('states that nothing was released when the server ANSWERED and refused', () => {
     expect(releaseFailureSentence('unauthorized')).toBe(
-      'Could not release the other devices — this Mac is not authorized on this license. Nothing was released.'
+      'Could not release the other devices — this computer is not authorized on this license. Nothing was released.'
     )
     expect(releaseFailureSentence('inactive')).toBe(
       'Could not release the other devices — this license is not active. Nothing was released.'
@@ -328,7 +328,7 @@ describe('activationErrorSentence', () => {
     // (seat_limit).` — a word the buyer cannot look up, on the screen where they are stuck.
     const s = activationErrorSentence('seat_limit')
     expect(s).toBe(
-      'This license already has all its devices in use. On a Mac (or phone) where Pro is active, open Settings → License and choose “Release other devices”, then activate here again.'
+      'This license already has all its devices in use. On a computer (or phone) where Pro is active, open Settings → License and choose “Release other devices”, then activate here again.'
     )
     // The release action does not exist on THIS machine (it has no Pro yet), so the sentence must
     // send the user elsewhere — advice to "release below" would point at a button that isn't there.

--- a/src/renderer/lib/licenseCopy.ts
+++ b/src/renderer/lib/licenseCopy.ts
@@ -1,4 +1,5 @@
 import type { LicenseDetail } from '@shared/types'
+import { machineNoun, thisMachine, thisMachineCap } from './machineName'
 
 /**
  * Settings → License wording, derived from the data in ONE place so a sentence cannot promise
@@ -54,12 +55,12 @@ export function licenseSentence(detail: LicenseDetail | null): string {
     if (detail.error === 'inactive') {
       // A server ANSWER, not a failure to look. Pro is verified locally so it still works right
       // now, and saying "unaffected" would promise it keeps working — which it will not.
-      return 'This license is not active, so there is no key or device count to show — and Pro on this Mac will stop when its current entitlement expires.'
+      return `This license is not active, so there is no key or device count to show — and Pro on ${thisMachine()} will stop when its current entitlement expires.`
     }
     if (detail.error === 'unauthorized') {
-      // Also an answer: the server refused this Mac's entitlement. It may recover on the next
+      // Also an answer: the server refused this machine's entitlement. It may recover on the next
       // refresh, hence "may" — but it is not the "nothing changed" story the codes below tell.
-      return 'This Mac is not authorized on this license, so the key and device count are unavailable — and Pro here may stop when its current entitlement expires.'
+      return `${thisMachineCap()} is not authorized on this license, so the key and device count are unavailable — and Pro here may stop when its current entitlement expires.`
     }
     if (detail.error === 'offline' || detail.error === 'network' || detail.error === 'disabled') {
       // Deliberately not "could not reach the server": `disabled` is a build that never asked.
@@ -75,7 +76,7 @@ export function licenseSentence(detail: LicenseDetail | null): string {
   if (detail.source === 'apple') {
     // No keygen call was made for this license, so `used`/`seats` are zeros meaning "not
     // applicable". Printing them would read as a cap that is somehow both empty and full.
-    return 'Pro on this Mac comes from the App Store subscription on your paired phone, so there is no license key or device count to show here.'
+    return `Pro on ${thisMachine()} comes from the App Store subscription on your paired phone, so there is no license key or device count to show here.`
   }
   if (detail.source === 'free') {
     // A defensive value. Say only what is certain — where it came from is not.
@@ -94,7 +95,7 @@ export function licenseSentence(detail: LicenseDetail | null): string {
     if (detail.used === detail.seats) {
       return `All ${detail.seats} devices are in use. Release the others below to free them up.`
     }
-    return `${detail.used} of ${detail.seats} devices in use — this Mac and each paired phone counts as a device.`
+    return `${detail.used} of ${detail.seats} devices in use — ${thisMachine()} and each paired phone counts as a device.`
   }
 
   // A clean read that stated no source (only reachable by merging a release reply over an empty
@@ -128,7 +129,7 @@ export function canUseKeyElsewhere(detail: LicenseDetail | null): boolean {
 
 /**
  * Is this reason code a REFUSAL of the release (about the license), rather than a failure of the
- * call (about the network / this Mac's standing)?
+ * call (about the network / this machine's standing)?
  *
  * The store asks this to decide what may be merged onto `detail`, and the panel's release note is
  * the complement of it. One definition, because two copies of "which codes are refusals" is
@@ -154,7 +155,7 @@ export function isReleaseRefusal(code: string | null | undefined): boolean {
 export function releaseFailureSentence(code: string | null | undefined): string {
   if (!code || isReleaseRefusal(code)) return ''
   if (code === 'unauthorized') {
-    return 'Could not release the other devices — this Mac is not authorized on this license. Nothing was released.'
+    return `Could not release the other devices — ${thisMachine()} is not authorized on this license. Nothing was released.`
   }
   if (code === 'inactive') {
     return 'Could not release the other devices — this license is not active. Nothing was released.'
@@ -179,7 +180,7 @@ export function activationErrorSentence(code: string | null | undefined): string
   if (code === 'seat_limit') {
     // The one code this feature was built around. The remedy lives on a machine that HAS Pro —
     // this one does not, so "release devices here" would be advice the user cannot follow.
-    return 'This license already has all its devices in use. On a Mac (or phone) where Pro is active, open Settings → License and choose “Release other devices”, then activate here again.'
+    return `This license already has all its devices in use. On a ${machineNoun()} (or phone) where Pro is active, open Settings → License and choose “Release other devices”, then activate here again.`
   }
   if (code === 'suspended') {
     return 'This license has been suspended, so it cannot be activated. Get in touch and we will sort it out.'

--- a/src/renderer/lib/machineName.guard.test.ts
+++ b/src/renderer/lib/machineName.guard.test.ts
@@ -1,0 +1,82 @@
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { join, relative } from 'path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * No user-visible string may call the local machine a Mac.
+ *
+ * Issue #563 was not one slip: ~30 strings across 15 files said "this Mac", and a grep is the only
+ * thing that found them. The helper (`machineName.ts`) fixes the ones that existed; this test is
+ * what stops the next string from bringing the assumption back — the same posture as
+ * `fs-atomic.guard.test.ts`, and for the same reason: nothing else in the toolchain can see it,
+ * because on the platform most of this was written on the sentence is true.
+ *
+ * COMMENTS ARE NOT SCANNED. They are not shown to anyone, they carry real history ("a Mac→SSH
+ * node"), and rewriting them would bury the actual copy change in noise.
+ */
+const ROOTS = ['src/renderer', 'src/shared']
+
+/** Files where naming a Mac is the CORRECT answer, each with the reason it is exempt. */
+const ALLOWED = new Map<string, string>([
+  [
+    'src/renderer/lib/machineName.ts',
+    'the helper itself — its doc comment and examples name all three nouns'
+  ],
+  [
+    'src/renderer/components/PtyPressureBanner.tsx',
+    'genuinely macOS: kern.tty.ptmx_max and the macOS password prompt'
+  ],
+  [
+    'src/renderer/components/onboarding/OnboardingFlow.tsx',
+    'the notch step exists on macOS only (see the isMac step list in that file)'
+  ]
+])
+
+const BANNED = /\b(this|This|your|Your|a|another) Macs?\b|\bMacs\b/
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      sourceFiles(full, out)
+      continue
+    }
+    if (!/\.tsx?$/.test(entry) || /\.test\.tsx?$/.test(entry)) continue
+    out.push(full)
+  }
+  return out
+}
+
+/** Drop line comments and JSDoc/block-comment continuation lines — see the module doc. */
+function isComment(line: string): boolean {
+  const t = line.trimStart()
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')
+}
+
+describe('no user-visible copy calls this machine a Mac', () => {
+  it('finds none outside the documented exemptions', () => {
+    const offenders: string[] = []
+    for (const root of ROOTS) {
+      for (const file of sourceFiles(join(process.cwd(), root))) {
+        const rel = relative(process.cwd(), file)
+        if (ALLOWED.has(rel)) continue
+        readFileSync(file, 'utf8')
+          .split('\n')
+          .forEach((line, i) => {
+            if (isComment(line) || !BANNED.test(line)) return
+            offenders.push(`${rel}:${i + 1}: ${line.trim()}`)
+          })
+      }
+    }
+    expect(offenders, 'use thisMachine()/thisMachineCap()/machineNoun() from lib/machineName').toEqual(
+      []
+    )
+  })
+
+  it('keeps the exemption list honest — every entry still exists and still says Mac', () => {
+    for (const [rel, why] of ALLOWED) {
+      const src = readFileSync(join(process.cwd(), rel), 'utf8')
+      expect(BANNED.test(src), `${rel} no longer needs its exemption (${why})`).toBe(true)
+    }
+  })
+})

--- a/src/renderer/lib/machineName.test.ts
+++ b/src/renderer/lib/machineName.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const browser = vi.hoisted(() => ({ value: false }))
+vi.mock('../bridge/runtime', () => ({ isBrowserRuntime: () => browser.value }))
+
+import { machineNoun, otherMachines, thisMachine, thisMachineCap } from './machineName'
+
+const on = (platform: string, isBrowser = false): void => {
+  browser.value = isBrowser
+  vi.stubGlobal('navigator', { platform, userAgent: platform })
+}
+
+afterEach(() => {
+  browser.value = false
+  vi.unstubAllGlobals()
+})
+
+describe('machineNoun', () => {
+  it('names the machine the desktop app is actually running on', () => {
+    on('MacIntel')
+    expect(machineNoun()).toBe('Mac')
+    on('Win32')
+    expect(machineNoun()).toBe('PC')
+    on('Linux x86_64')
+    expect(machineNoun()).toBe('computer')
+  })
+
+  // Issue #563: the license, seats and sessions a Server Edition tab describes belong to the
+  // SERVER, whose OS the viewer's navigator says nothing about. A neutral word is the honest
+  // answer there; "This Mac" for a Mac browsing a Linux server is a confident wrong one.
+  it('stays neutral in a browser tab, whatever the VIEWER runs', () => {
+    on('MacIntel', true)
+    expect(machineNoun()).toBe('computer')
+    on('Win32', true)
+    expect(machineNoun()).toBe('computer')
+  })
+
+  it('stays neutral with no navigator at all', () => {
+    browser.value = false
+    vi.stubGlobal('navigator', undefined)
+    expect(machineNoun()).toBe('computer')
+  })
+})
+
+describe('the sentence forms', () => {
+  it('reads correctly mid-sentence, at a sentence start and in the plural', () => {
+    on('Win32')
+    expect(thisMachine()).toBe('this PC')
+    expect(thisMachineCap()).toBe('This PC')
+    expect(otherMachines()).toBe('other PCs')
+    on('MacIntel')
+    expect(thisMachine()).toBe('this Mac')
+    expect(thisMachineCap()).toBe('This Mac')
+    expect(otherMachines()).toBe('other Macs')
+    on('Linux x86_64')
+    expect(otherMachines()).toBe('other computers')
+  })
+})

--- a/src/renderer/lib/machineName.ts
+++ b/src/renderer/lib/machineName.ts
@@ -1,0 +1,48 @@
+/**
+ * What the UI calls the machine nodeterm is running on.
+ *
+ * There used to be no such helper: 30-odd user-visible strings said "this Mac", including the
+ * license and team-access copy. On Windows that is untidy in Accounts and actively harmful in
+ * billing — a user reading *"This Mac is not authorized on this license"* can no longer tell
+ * whether the sentence is even about their machine, and *"a teammate on a seat can run commands
+ * on this Mac"* is the sentence someone has to trust before handing out shell access (issue #563).
+ *
+ * One definition, so a new string cannot reintroduce the assumption, and so the noun agrees
+ * everywhere it appears in one dialog.
+ *
+ * **A brand name is only used where we KNOW the machine.** The desktop renderer runs on the host
+ * it describes, so the OS sniff is authoritative there. A Server Edition browser tab does not:
+ * the license, the seats and the sessions belong to the SERVER, whose OS the viewer's `navigator`
+ * says nothing about — so a browser tab always gets the neutral word rather than a confident
+ * wrong one. Same for any non-DOM context.
+ *
+ * Deliberately NOT applied to copy that really is macOS-specific: `PtyPressureBanner`
+ * (`kern.tty.ptmx_max`) and the onboarding notch step (which only exists on macOS).
+ */
+import { isMacPlatform, isWindowsPlatform } from '@shared/platform-utils'
+import { isBrowserRuntime } from '../bridge/runtime'
+
+export type MachineNoun = 'Mac' | 'PC' | 'computer'
+
+/** The bare noun: "Mac" / "PC" / "computer". */
+export function machineNoun(): MachineNoun {
+  if (typeof navigator === 'undefined' || isBrowserRuntime()) return 'computer'
+  if (isMacPlatform()) return 'Mac'
+  if (isWindowsPlatform()) return 'PC'
+  return 'computer'
+}
+
+/** "this Mac" / "this PC" / "this computer" — mid-sentence. */
+export function thisMachine(): string {
+  return `this ${machineNoun()}`
+}
+
+/** "This Mac" / "This PC" / "This computer" — sentence start, or a standalone label. */
+export function thisMachineCap(): string {
+  return `This ${machineNoun()}`
+}
+
+/** "other Macs" / "other PCs" / "other computers". */
+export function otherMachines(): string {
+  return `other ${machineNoun()}s`
+}

--- a/src/renderer/remote/ConsentNotice.tsx
+++ b/src/renderer/remote/ConsentNotice.tsx
@@ -2,11 +2,12 @@
 // is the pure describeGrant (src/shared/remote/consent.ts, unit-tested). 4c places this in the actual
 // invite/approve dialog. Kept tiny + prop-driven so it needs no store wiring.
 import { describeGrant } from '@shared/remote/consent'
+import { thisMachine } from '@renderer/lib/machineName'
 
 export function ConsentNotice({ peerLabel }: { peerLabel: string }): JSX.Element {
   return (
     <p className="remote-consent" role="note">
-      {describeGrant(peerLabel)}
+      {describeGrant(peerLabel, thisMachine())}
     </p>
   )
 }

--- a/src/renderer/session/localSession.ts
+++ b/src/renderer/session/localSession.ts
@@ -1,4 +1,5 @@
 import { createSession, setActiveSession, type WorkspaceSession } from './session'
+import { thisMachineCap } from '../lib/machineName'
 
 /** The single local session: its api is the preload object by identity. Built once at boot.
  *
@@ -8,5 +9,5 @@ import { createSession, setActiveSession, type WorkspaceSession } from './sessio
  *  the only importer of App (which imports this module). A static import of App from main.tsx
  *  would hoist this line ahead of the bridge install and silently capture `undefined` by identity
  *  in the browser. Keep the dynamic import. */
-export const localSession: WorkspaceSession = createSession('local', window.nodeTerminal, 'This Mac')
+export const localSession: WorkspaceSession = createSession('local', window.nodeTerminal, thisMachineCap())
 setActiveSession(localSession.id)

--- a/src/shared/remote/approval.test.ts
+++ b/src/shared/remote/approval.test.ts
@@ -7,7 +7,7 @@ describe('peerApprovalView', () => {
     const view = peerApprovalView({ id: 'peer-1', sas: '12-34-56', label: "Ayşe's Mac" })
     // The consent sentence the human must read is derived from this label via describeGrant.
     expect(view.peerLabel).toBe("Ayşe's Mac")
-    expect(describeGrant(view.peerLabel)).toContain('run commands on this Mac')
+    expect(describeGrant(view.peerLabel)).toContain('run commands on this computer')
     // The SAS both humans compare is in the dialog body verbatim.
     expect(view.message).toContain('12-34-56')
     // Confirm acts on THIS pending peer's id (relayHost.confirm(id)).

--- a/src/shared/remote/consent.test.ts
+++ b/src/shared/remote/consent.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { SHELL_ACCESS_CONSENT, describeGrant } from './consent'
+import { SHELL_ACCESS_CONSENT, describeGrant, shellAccessConsent } from './consent'
 
 describe('consent copy', () => {
   it('states shell access = SSH-equivalent, in plain words', () => {
     // The user must understand the grant BEFORE accepting — this is the whole point of the copy.
-    expect(SHELL_ACCESS_CONSENT).toContain('run commands on this Mac')
+    expect(SHELL_ACCESS_CONSENT).toContain('run commands on this computer')
     expect(SHELL_ACCESS_CONSENT).toContain('the same as giving them SSH access')
   })
 
   it('names the peer', () => {
     expect(describeGrant('Ayşe')).toBe(
-      'Ayşe will be able to run commands on this Mac — the same as giving them SSH access.'
+      'Ayşe will be able to run commands on this computer — the same as giving them SSH access.'
     )
   })
 
@@ -18,7 +18,18 @@ describe('consent copy', () => {
     expect(describeGrant('')).toBe(SHELL_ACCESS_CONSENT)
     expect(describeGrant('   ')).toBe(SHELL_ACCESS_CONSENT)
     expect(describeGrant('  Bora ')).toBe(
-      'Bora will be able to run commands on this Mac — the same as giving them SSH access.'
+      'Bora will be able to run commands on this computer — the same as giving them SSH access.'
     )
+  })
+
+  // Issue #563: this module is SHARED, so it cannot ask the renderer what this OS calls its
+  // machine — the caller names it, and the default is the neutral word rather than "this Mac"
+  // on a Windows box being asked to hand out shell access.
+  it('lets the caller name the machine, on both the named and the no-name sentence', () => {
+    expect(describeGrant('Ayşe', 'this PC')).toBe(
+      'Ayşe will be able to run commands on this PC — the same as giving them SSH access.'
+    )
+    expect(describeGrant('', 'this PC')).toBe(shellAccessConsent('this PC'))
+    expect(shellAccessConsent('this PC')).toContain('run commands on this PC')
   })
 })

--- a/src/shared/remote/consent.ts
+++ b/src/shared/remote/consent.ts
@@ -5,16 +5,29 @@
 // jail: the boundary is WHO you invite. So the copy is honest about the size of the grant. Lives in
 // src/shared (not src/main) because the renderer invite/approve UI shows it and cannot import main.
 //
-// Wording is the DESKTOP invite copy verbatim from docs/remote-sessions.md ("run commands on this
-// Mac — the same as giving them SSH access").
+// Wording is the DESKTOP invite copy from docs/remote-sessions.md ("run commands on this
+// <machine> — the same as giving them SSH access").
+//
+// The machine is NAMED BY THE CALLER (issue #563). This module is shared, so it cannot ask the
+// renderer what this OS calls its computer, and the default has to be the neutral word: a
+// hard-coded "Mac" is a false claim in the one sentence a user must read before handing out shell
+// access. The renderer passes `thisMachine()` (lib/machineName).
 
-const GRANT_TAIL = ' will be able to run commands on this Mac — the same as giving them SSH access.'
+const DEFAULT_MACHINE = 'this computer'
+
+const grantTail = (machine: string): string =>
+  ` will be able to run commands on ${machine} — the same as giving them SSH access.`
 
 /** No-name fallback sentence (also returned by describeGrant for a blank label). */
-export const SHELL_ACCESS_CONSENT = `This device${GRANT_TAIL}`
+export function shellAccessConsent(machine: string = DEFAULT_MACHINE): string {
+  return `This device${grantTail(machine)}`
+}
 
-/** The consent sentence naming the peer; blank labels fall back to SHELL_ACCESS_CONSENT. */
-export function describeGrant(peerLabel: string): string {
+/** No-name fallback with the neutral machine word — for callers that name no machine. */
+export const SHELL_ACCESS_CONSENT = shellAccessConsent()
+
+/** The consent sentence naming the peer; blank labels fall back to the no-name sentence. */
+export function describeGrant(peerLabel: string, machine: string = DEFAULT_MACHINE): string {
   const who = peerLabel.trim()
-  return who ? `${who}${GRANT_TAIL}` : SHELL_ACCESS_CONSENT
+  return who ? `${who}${grantTail(machine)}` : shellAccessConsent(machine)
 }


### PR DESCRIPTION
## What was wrong

Not one slip — the assumption ran through the product. In Accounts it is untidy; in the copy people
have to **trust** it is harmful:

> *"**This Mac** is not authorized on this license, so the key and device count are unavailable"*
> *"A teammate on a seat can run commands on **this Mac** — the same as giving them SSH access"*

A Windows user reading either can no longer tell whether the sentence is even about their machine —
and the second is what someone must understand before handing out shell access.

## The fix

**`src/renderer/lib/machineName.ts`** — one definition, four forms:

| | macOS desktop | Windows desktop | everything else, and any browser tab |
|---|---|---|---|
| `machineNoun()` | `Mac` | `PC` | `computer` |
| `thisMachine()` | this Mac | this PC | this computer |
| `thisMachineCap()` | This Mac | This PC | This computer |
| `otherMachines()` | other Macs | other PCs | other computers |

**A brand name only where we know the machine.** The desktop renderer runs on the host it
describes, so the OS sniff is authoritative there. A **Server Edition browser tab does not** — the
license, the seats and the sessions belong to the SERVER, whose OS the viewer's `navigator` says
nothing about — so it always gets the neutral word. "This Mac" for a Mac browsing a Linux server is
exactly the confident-wrong-noun this issue is about.

Applied to: Accounts (group label, both add-account buttons, the setting-up spinner),
`accountPresentation` tooltip, the local session's own name, `licenseCopy` (6 sentences),
LicenseSection (release + deactivate confirms, "another Mac"), TeamAccess (4), UpgradeDialog,
RemoteAccessDialog (2), RemoteSection (2), PhoneSection (2), PhonePairPopover (3),
PresenceIdentitySection.

`@shared/remote/consent.ts` cannot import a renderer helper, so `describeGrant(peer, machine)` now
takes the machine word as a **parameter defaulting to the neutral one** — `ConsentNotice` passes
`thisMachine()`. Hard-coding a brand into the shell-access consent sentence was the worst instance
of the bug, so the shared module now cannot contain one.

## Left alone, deliberately

- **`PtyPressureBanner`** — `kern.tty.ptmx_max` and the macOS password prompt really are macOS
  (the issue says so too).
- **The onboarding notch step** — that step only exists on macOS (`isMac ? ['notch'] : []`), so
  "your Mac" there is correct.
- **Code comments and JSDoc.** They are shown to nobody, they carry real history ("a Mac→SSH
  node"), and rewriting ~20 of them would bury the copy change in noise. The guard skips comments.

## Tests

- `machineName.test.ts` — the noun per platform, the neutral answer in a browser tab and with no
  `navigator`, and the three sentence forms.
- **`machineName.guard.test.ts`** — scans non-comment lines in `src/renderer` + `src/shared` and
  fails on any new "this/your/another Mac". Mutation-checked (adding one to an unrelated file reds
  it). The two exemptions are named **with their reason**, and a second test fails if an exempt
  file stops needing its exemption, so the list cannot rot.
- Existing copy assertions updated (licenseCopy, accountPresentation, consent, approval,
  LicenseSection).
- `npm run typecheck` green; `vitest run src/renderer src/shared` (358 files, 4876 tests) green.

Docs: a house rule in `CONTRIBUTING.md` (the guard will fail a contributor's PR, so they must know
before writing the string) and the invariant + reasoning in `CLAUDE.md`, per the two-docs rule.

## Device checklist — NOT verified on a device (this box is Linux)

1. **Windows**: Settings → Accounts — the Codex machine panel reads **"This PC"**; the add-account
   button reads "Add account — On this PC" and its spinner "Setting up on this PC…".
2. **Windows**: Settings → License with an active license — usage line, "To use Pro on another PC",
   and both confirm dialogs (release / deactivate) name a PC, not a Mac.
3. **Windows**: Team seats and the remote-access invite both read "run commands on this PC".
4. **Windows**: Settings → Phone and the quick-pair popover read "Reach this PC from anywhere"
   (including the toggle's accessible label).
5. **macOS**: every one of the above is unchanged, word for word — "this Mac".
6. **Server Edition in a browser** (Mac or Windows viewer, Linux server): the same surfaces read
   "this computer", never the viewer's OS.
7. **Linux desktop**: "this computer".
8. Nothing is truncated or re-wrapped badly by the longer word ("This computer" vs "This Mac") —
   the Accounts machine-panel label and the two Settings section descriptions are the tightest.

## Surfaces

Desktop + Server Edition (renderer copy only, no IPC change). Mobile: N/A — the iOS app has its own
strings; if it says "Mac" anywhere about the paired host, that is a separate change in
`nodeterm-ios` (@eneskirca).

## Note for merging

Touches `PhoneSection.tsx` / `PhonePairPopover.tsx`, which #572's PR also touches (different
hunks — that one owns the Remote-Login warning block, this one the "Reach … from anywhere" copy).
Whichever lands second may need a one-line import-block resolve.

Fixes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
