### PR TITLE
feat(canvas): one rope per relation, floating edge routing, eye hides connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1609,9 +1609,23 @@ else, and its context links must keep classifying across restarts).
   threw the command away in exactly the state the button exists to rescue). (6) Canvas subscribes
   to `armedDepSig`, NOT `useAgentStatus(s => s.byId)` —
   the same discipline as `loopSig`; the full map re-renders the canvas on every hook event.
-  Pure logic + refusal matrix in `renderer/lib/pendingLaunch.ts` (unit-tested); the dashed dep→node
-  edges are **derived, never persisted** (a pending dependency is a state that ends when the launch
-  fires — the durable relation is the context bridge `--after` also draws).
+  Pure logic + refusal matrix in `renderer/lib/pendingLaunch.ts` (unit-tested);
+  the dep→node edge is a **rope** (`ctrl-<dep>-<node>`, persisted in `project.ropes` like the
+  opener's) whose LOOK is derived: dashed + ⏳ while the node's `pendingLaunch.after` still lists the
+  dep, solid once it has launched (`lib/edgeModel.ts` `ropeVisual`, over the ONE `ropeInfoOf` lookup
+  the render and BOTH delete paths ask — two builders would be two answers, and the label the user
+  reads would stop describing what the delete does). The fan-in bridge `--after` also writes hides
+  under that rope (`hiddenLinkIds`), so ONE edge per pair holds on the canvas. Deleting a WAITING
+  rope drops that dep from `after` (`dropAfterDep`) and takes **nothing else** — the covered bridge
+  survives, because "stop waiting for it" is not "stop being able to read its work"; an emptied
+  list fires. Only the `open-*`/`verify` verbs write the rope, so `missingDepRopes` heals an armed
+  node that has none at **project load**: `pendingLaunch` is persisted and the rope is not, so a node
+  armed by any other path — or by a build older than this one — would otherwise hold a launch with
+  no arrow saying what for. All edges route through the single `floating` edge type
+  (`canvas/FloatingEdge.tsx`, a bezier between the nearest borders of the two node rectangles; an
+  unmeasured node draws nothing rather than a path to the origin) — no family sets a handle side;
+  and a node whose eye is closed (`hideFanout`) hides every edge touching it as well as its cards
+  (2026-09-02 edge model, spec in docs/superpowers/specs).
   **(7) Delivery waits for the node's PTY, and never fails silently** (issue #569 item 1, 2026-09).
   A satisfied dependency says nothing about whether there is a terminal to type into, and the
   original loop conflated the two: a flat 5 × 400 ms budget started when the CANVAS held the node
@@ -2422,6 +2436,14 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   be hidden, whatever settings.json says. The group-frame menu's colors strip answers to the same
   `colors` id; builders run through `tidySeparators` so a hidden row leaves no dangling rule.
 - **Add menu** = bottom dock (`Dock.tsx`) `+`, mirrored by the pane menu and command palette.
+- **Edges** are all one React Flow type, `floating` (`canvas/FloatingEdge.tsx` over the pure
+  `lib/floatingEdge.ts`): every family — ropes, context bridges, note links, subagent/loop card
+  edges, trigger edges — is drawn between the two nodes' nearest borders instead of fixed handle
+  sides, so an edge to a node placed left of or above its source takes the short way round rather
+  than looping across the canvas. A terminal node's **eye** (`hide-fanout`, "Hide cards &
+  connections") hides its subagent/loop cards AND every edge touching that node — display only:
+  the links still authorise reads and an `--after` still waits. See the `--after` bullet under
+  Canvas control for the rope model the eye hides.
 - **Undo/redo**: debounced snapshot of the nodes array on settle (drag/edit), `pastRef`/
   `futureRef` stacks, ⌘Z / ⌘⇧Z + dock buttons. History resets per project load; skipped
   while typing in inputs/terminals.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,6 +293,15 @@ has already produced a real hole: a traversal check that split on `/` alone saw 
 as a single harmless segment on *every* platform. Split on `[\\/]`, and prefer accepting both
 dialects while storing only one (see **Node icons** in CLAUDE.md for the worked example).
 
+**Canvas edges are all `type: 'floating'`, and one relation gets one edge.** Never set
+`sourceHandle`/`targetHandle` on an edge object — the rendered path is computed from the two nodes'
+rectangles (`renderer/lib/floatingEdge.ts`), and a fixed side is what sent an edge to a node placed
+left of its source looping across the whole canvas. And do not add a second edge family for a
+relation a rope already carries: `--after` is a **rope** whose dashed "⏳ waits for" look is DERIVED
+from the target's `pendingLaunch` (`renderer/lib/edgeModel.ts`), and the context bridge it also
+writes stays hidden underneath it. One `open-claude --after` used to land three edges on one node.
+`src/renderer/canvas/edge-model.source.test.ts` pins both halves.
+
 ## Testing
 
 `npm test` must pass, and `npm run typecheck` is the fastest gate.

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -640,6 +640,15 @@ describe('open-project + --project docs land with the dispatch (issue #338, spec
     }
   })
 
+  it('tells the agent that opened nodes AND --after stations are already linked — nothing to `link`', () => {
+    for (const [name, body] of bodies) {
+      expect(body, name).toMatch(/roped to each (listed )?station/)
+      expect(body, name).toMatch(/dashed while it waits/)
+      expect(body, name).toMatch(/already\s+linked/)
+      expect(body, name).toMatch(/nothing to `link`/)
+    }
+  })
+
   it('the orchestration recipe gains the multi-repo pattern', () => {
     for (const [name, body] of bodies) {
       expect(body, name).toContain('one project per repository')

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -646,6 +646,9 @@ describe('open-project + --project docs land with the dispatch (issue #338, spec
       expect(body, name).toMatch(/dashed while it waits/)
       expect(body, name).toMatch(/already\s+linked/)
       expect(body, name).toMatch(/nothing to `link`/)
+      // Only the skill body carries the orchestration recipe, so only it has the step-5 sentence
+      // that had to stop saying an unopened station is unlinked — an `--after` station is linked.
+      if (name === 'skill') expect(body, name).toMatch(/neither opened nor named in `--after`/)
     }
   })
 

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -313,11 +313,12 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     `- \`open-agent --agent ${agentChoices} [--count N] [--cwd P] [--prompt T | --prompt-file F] [--model M] [--group <id>] [--after <id,id>] [--project <id>]\` — open`,
     '  any agent CLI. `--group` parents the node(s) into a group frame; a worktree-bound group also',
     '  hands its worktree path down as the cwd. `--after <id,id>` opens the node ARMED: it does not',
-    '  start until every listed station has finished a turn SUCCESSFULLY, and is context-linked to',
-    '  them so it can read their work when it wakes — use it for "B needs what A produced" instead',
-    '  of polling. A station whose turn ended on an API error does NOT release its dependents even',
-    '  though it is idle (`list` marks it LAST TURN ERRORED); nudge or retry it, or run the armed',
-    '  node yourself. Only',
+    '  start until every listed station has finished a turn SUCCESSFULLY. It is',
+    '  roped to each listed station (one edge, dashed while it waits, solid once it runs) and can read',
+    '  their work with get-linked-context when it wakes — nothing to `link`. Use it for "B needs what',
+    '  A produced" instead of polling. A station whose turn ended on an API error does NOT release its',
+    '  dependents even though it is idle (`list` marks it LAST TURN ERRORED); nudge or retry it, or',
+    '  run the armed node yourself. Only',
     `  status-reporting agent nodes (${statusAgents}, or custom agents based on them) may be waited on; a plain terminal never`,
     '  reports finishing, so waiting on one is refused. `--project <id>` opens the node(s) in another',
     '  project instead of yours. It accepts exactly two things — any other id is refused: your OWN',
@@ -368,8 +369,8 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  arrange across frames in one call); arranging a frame\'s children also shrinks the frame to fit.',
     '- `link --to <id,id> [--from <id>]` — context-link nodes so each can READ the other\'s transcript',
     '  on demand (nodeterm linked-context CLI). `--from` defaults to you; nothing is pushed into the',
-    '  linked sessions. Agent sessions you open are linked to you automatically — use `link` for nodes',
-    '  you did not open, or to link two OTHER nodes together.',
+    '  linked sessions. Agent sessions you open, and the stations you name in `--after`, are already',
+    '  linked — nothing to `link`. Use `link` only for nodes you did not open, or to link two OTHER nodes.',
     '- `verify --node <id> [--lenses correctness,security,tests] [--focus "..."] [--synthesis off]` — open a',
     '  review panel over that node\'s work: one reviewer per lens, each armed behind the target and linked',
     '  to it, plus a judge armed behind the panel that merges the findings into one verdict. Reviewers are',
@@ -712,8 +713,9 @@ Verbs:
   hands its worktree path down as the cwd.
   \`--after <id,id>\` opens the node **armed**: it does NOT start yet, and launches itself once
   every listed station has finished a turn successfully — that is how you express "B needs what A produces" without
-  sitting in a poll loop. The armed node is also context-linked to each station it waits on, so
-  it can read their work the moment it wakes. Only agent nodes that report status
+  sitting in a poll loop. The armed node is roped to each listed station (one edge,
+  dashed while it waits, solid once it runs) and can read their work with get-linked-context
+  the moment it wakes — nothing to \`link\`. Only agent nodes that report status
   (${statusAgents}, or custom agents based on them) can be waited on — waiting on a plain terminal is refused, because a
   plain terminal never reports finishing and the node would hang forever. Note the semantics:
   "idle" is the end of a station's TURN, not proof its whole job is done — right for a station
@@ -795,8 +797,9 @@ Verbs:
 - \`link --to <id,id> [--from <id>]\` — context-link nodes, so each can READ the other's
   transcript on demand with the get-linked-context skill. \`--from\` defaults to you. Nothing is
   pushed into the linked sessions — reading is on demand, so linking never interrupts anyone.
-  Agent sessions you open (\`open-claude\`/\`open-agent\`/\`spawn-team\`) are linked to you
-  automatically; use \`link\` for nodes you did not open, or to link two OTHER nodes together.
+  Agent sessions you open (\`open-claude\`/\`open-agent\`/\`spawn-team\`) and the stations you name in
+  \`--after\` are already linked — nothing to \`link\`. Use \`link\` only for nodes you did not open,
+  or to link two OTHER nodes together.
 - \`verify --node <id> [--lenses correctness,security,tests] [--focus "..."] [--agent <id>] [--synthesis off] [--label L]\` —
   open a review PANEL over that node's work: one reviewer per lens, each armed behind the target
   (they start when it goes idle) and linked to it so they can read what it actually did, plus a

--- a/src/main/canvas-control-core.ts
+++ b/src/main/canvas-control-core.ts
@@ -934,7 +934,8 @@ across Nodeterm sessions), be the orchestration chef — plan the kitchen, then 
    user to relay it. Then do the work only you can do: reconcile the streams against each
    other, name the conflicts and the leftovers, and report ONE synthesis. A station you never
    read is a station whose work you cannot vouch for — say so rather than assuming it went
-   fine. Stations you did not open are not linked; \`link --to <id>\` them first.
+   fine. Stations you neither opened nor named in \`--after\` are not linked; \`link --to <id>\`
+   them first.
 6. Verify before you report. When a station's work matters — anything touching money, auth, data
    migration or a public API — run \`verify --node <stationId>\` instead of re-reading it yourself.
    You cannot independently check work you were part of planning; a panel of reviewers who each

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -410,13 +410,13 @@ import {
 } from '../session/relay-tab'
 import { buildBackgroundLinkMaps, buildContextLinkNote, buildLinkMap, buildNotePushMessage, classifyLink, hiddenLinkIds, linkIdsCoveredByRopes, pairKey, planBridges, type LinkEndpoint } from '../lib/noteLink'
 import {
-  dependencyEdges,
   launchesToFire,
   launchRetryDelay,
   unmetDeps,
   LAUNCH_STALL_MS,
   type ArmedNode
 } from '../lib/pendingLaunch'
+import { WAIT_LABEL, dropAfterDep, edgeHidden, hiddenEdgeNodeIds, ropeVisual, type RopeNodeInfo } from '../lib/edgeModel'
 import { triggerEdges } from '../lib/triggerCard'
 import { freeSpot } from '../lib/placement'
 import { pushSessionRename, sessionNameUnchanged } from '../lib/sessionRename'
@@ -445,6 +445,7 @@ import type {
   CanvasNodeState,
   ClosedSessionEntry,
   NodeKind,
+  PendingLaunch,
   Project,
   ProjectKanban,
   SshPassphraseRequest,
@@ -735,17 +736,16 @@ async function waitForCanvasNode(
   }
 }
 
-// A "spawned by" rope: control-capable agent → node it opened (or browser popup → opener).
-// Display-only (never a context link) but persisted per project as `ropes`, so the lineage
-// survives restarts. Selectable; removed with ⌫ / double-click like a context link.
-const ropeEdge = (id: string, source: string, target: string, color: string): Edge => ({
+// A "spawned by" / "sequenced after" rope: control-capable agent → node it opened, browser popup →
+// opener, or `--after` dependency → the armed node. Display-only (never a context link) but
+// persisted per project as `ropes`, so the lineage survives restarts. Selectable; removed with ⌫ /
+// double-click like a context link. Colour and the waiting look are NOT stored here — displayEdges
+// derives both from the endpoints every render (lib/edgeModel.ts `ropeVisual`).
+const ropeEdge = (id: string, source: string, target: string): Edge => ({
   id,
   source,
-  sourceHandle: 'flow-out',
   target,
-  targetHandle: 'flow-in',
-  style: { stroke: color, strokeWidth: 1.5 },
-  markerEnd: { type: MarkerType.ArrowClosed, color, width: 14, height: 14 }
+  type: 'floating'
 })
 
 /** The one edge renderer — every family routes between nearest borders (see FloatingEdge). */
@@ -1813,7 +1813,7 @@ export function Canvas() {
       eEdges.push({
         id: `e-${lid}`,
         source: pid,
-        sourceHandle: 'flow-out',
+        type: 'floating',
         target: lid,
         animated: st.state === 'working',
         style: { stroke: accent, strokeWidth: 1.5 }
@@ -1871,7 +1871,7 @@ export function Canvas() {
         eEdges.push({
           id: `e-${cid}`,
           source: pid,
-          sourceHandle: 'flow-out',
+          type: 'floating',
           target: cid,
           animated: v.state === 'working',
           style: { stroke: accent, strokeWidth: 1.5 }
@@ -1910,46 +1910,20 @@ export function Canvas() {
         .join('|'),
     [nodes]
   )
-  // Dep edges (`--after`) are DERIVED from node data, so the obvious thing is to build them inside
-  // displayEdges off `nodes` — which is what this used to do, and it made `nodes` a dependency of
-  // the edge list. `nodes` gets a fresh identity on every drag FRAME, so dragging one node rebuilt
-  // every context link, rope and dep edge on the canvas ~60×/s (new object identities, so React
-  // Flow re-rendered all of them too). Same discipline as `stickySig`/`loopSig`: reduce the part
-  // that comes from `nodes` to a SIGNATURE, and hang the styled objects off that.
-  //
-  // The pairs themselves stay in `dependencyEdges` (the tested producer of both the id format and
-  // the liveness rule); the ref carries them from the cheap per-frame pass to the styled memo,
-  // which only re-runs when the signature — i.e. the actual set of pending dependencies — changes.
-  const depPairsRef = useRef<ReturnType<typeof dependencyEdges>>([])
-  const depEdgeSig = useMemo(() => {
-    // Fast path: no armed node → no Set allocation, no pairs, and the signature stays ''.
-    if (!nodes.some((n) => n.data.pendingLaunch)) {
-      depPairsRef.current = []
-      return ''
+  // The part of `nodes` the edge layer reads, reduced to a SIGNATURE so a drag frame does not
+  // rebuild every styled edge (same discipline as stickySig/loopSig): which nodes are armed on
+  // which deps (the waiting look), which agent each runs (the rope colour), and whose eye is
+  // closed (hidden edges). The styled objects rebuild only when this string changes.
+  const edgeSig = useMemo(() => {
+    let sig = ''
+    for (const n of nodes) {
+      const p = n.data.pendingLaunch as PendingLaunch | undefined
+      sig += `${n.id}=${(n.data.agentId as string) ?? ''}${n.data.hideFanout ? '!' : ''}:${p?.after.join(',') ?? ''}|`
     }
-    const pairs = dependencyEdges(nodes as unknown as ArmedNode[], new Set(nodes.map((n) => n.id)))
-    depPairsRef.current = pairs
-    return pairs.map((e) => e.id).join('|')
+    return sig
   }, [nodes])
-  const depEdges = useMemo(
-    () =>
-      depPairsRef.current.map((e) => ({
-        ...e,
-        type: 'default' as const,
-        animated: true,
-        label: '⏳ waits for',
-        labelStyle: { fill: '#8e8e93', fontSize: 11, fontWeight: 600 },
-        labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
-        labelBgPadding: [6, 3] as [number, number],
-        labelBgBorderRadius: 5,
-        style: { stroke: '#8e8e93', strokeWidth: 1.5, strokeDasharray: '6 4' },
-        markerEnd: { type: MarkerType.ArrowClosed, color: '#8e8e93', width: 14, height: 14 }
-      })),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- depEdgeSig IS the ref's signature
-    [depEdgeSig]
-  )
   // Trigger→target edges (issue #493) — derived, never persisted, same signature discipline as
-  // depEdges: the per-frame pass reduces `nodes` to a signature (which trigger points where), and
+  // edgeSig: the per-frame pass reduces `nodes` to a signature (which trigger points where), and
   // the styled objects only rebuild when that set actually changes, not on every drag frame.
   const trigPairsRef = useRef<ReturnType<typeof triggerEdges>>([])
   const trigEdgeSig = useMemo(() => {
@@ -1974,26 +1948,40 @@ export function Canvas() {
   const displayEdges = useMemo(() => {
     const stickyIds = new Set(stickySig ? stickySig.split('|') : [])
     const drivenTargets = drivingNodeIds(drivenLeaseEntries, Date.now())
+    // Endpoint facts the rope look derives from — read off the render-time ref, keyed by edgeSig.
+    const byId = new Map(nodesRef.current.map((n) => [n.id, n]))
+    const info = (id: string): RopeNodeInfo | undefined => {
+      const n = byId.get(id)
+      if (!n) return undefined
+      const agentId = n.data.agentId as AgentId | undefined
+      return {
+        agentColor: agentId ? agentConfig(agentId)?.color : undefined,
+        pendingAfter: (n.data.pendingLaunch as PendingLaunch | undefined)?.after
+      }
+    }
+    const hidden = hiddenEdgeNodeIds(nodesRef.current)
+    const labelBg = {
+      labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
+      labelBgPadding: [6, 3] as [number, number],
+      labelBgBorderRadius: 5
+    }
     // ONE edge per pair. A node an agent opens gets both a rope (lineage) and a context bridge
     // (readable context), which drew two near-identical arrows between the same two nodes. The
     // rope keeps the pixels; the bridge still exists in data (it is what authorizes reading) and
     // rides the rope's delete, so it can never become an invisible link with nothing to click.
-    const hidden = hiddenLinkIds(linkEdges, controlEdges)
-    const decorated = linkEdges.filter((e) => !hidden.has(e.id)).map((e) => {
+    // `--after` deps are ropes too, so their fan-in bridges hide the same way.
+    const hiddenLinks = hiddenLinkIds(linkEdges, controlEdges)
+    const decorated = linkEdges.filter((e) => !hiddenLinks.has(e.id)).map((e) => {
       const sel = !!e.selected
       const isNote = stickyIds.has(e.source)
       const stroke = sel ? '#ffffff' : accent
       const baseLabel = isNote ? '🗒 note' : '⇄ context'
       return {
         ...e,
-        type: 'default',
-        sourceHandle: 'link-out',
-        targetHandle: 'link-in',
+        type: 'floating',
         label: sel ? `${baseLabel} — ⌫ to remove` : baseLabel,
         labelStyle: { fill: stroke, fontSize: 11, fontWeight: 600 },
-        labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
-        labelBgPadding: [6, 3] as [number, number],
-        labelBgBorderRadius: 5,
+        ...labelBg,
         style: { stroke, strokeWidth: sel ? 3.5 : 2 },
         markerEnd: { type: MarkerType.ArrowClosed, color: stroke, width: 14, height: 14 },
         // Context links are bidirectional (arrowheads both ends); note links flow one way.
@@ -2002,48 +1990,58 @@ export function Canvas() {
           : { markerStart: { type: MarkerType.ArrowClosed, color: stroke, width: 14, height: 14 } })
       }
     })
-    // Control ropes: white + a removal hint while selected (mirrors the context-link look). A
-    // rope that is also standing in for a hidden context bridge says so, so the one visible edge
-    // never under-reports what removing it will take with it.
     const ropeCoversLink = new Set(
-      linkEdges.filter((e) => hidden.has(e.id)).map((e) => pairKey(e.source, e.target))
+      linkEdges.filter((e) => hiddenLinks.has(e.id)).map((e) => pairKey(e.source, e.target))
     )
+    // Ropes: colour from the source's agent, dashed + ⏳ while the target still waits on the
+    // source, white + a removal hint while selected, clay + flowing while the target is a driven
+    // browser. The look is derived every time — nothing about it is stored on the edge.
     const ropes = controlEdges.map((e) => {
-      if (e.selected)
-        return {
-          ...e,
-          label: ropeCoversLink.has(pairKey(e.source, e.target))
+      const v = ropeVisual(e, info)
+      const base = {
+        ...e,
+        type: 'floating',
+        animated: v.waiting,
+        style: { stroke: v.color, strokeWidth: 1.5, ...(v.waiting ? { strokeDasharray: '6 4' } : {}) },
+        markerEnd: { type: MarkerType.ArrowClosed, color: v.color, width: 14, height: 14 },
+        ...(v.waiting
+          ? { label: WAIT_LABEL, labelStyle: { fill: v.color, fontSize: 11, fontWeight: 600 }, ...labelBg }
+          : {})
+      }
+      if (e.selected) {
+        const label = v.waiting
+          ? `${WAIT_LABEL} · ⌫ to stop waiting`
+          : ropeCoversLink.has(pairKey(e.source, e.target))
             ? '⇄ context · ⌫ to remove'
-            : '⌫ to remove',
+            : '⌫ to remove'
+        return {
+          ...base,
+          label,
           labelStyle: { fill: '#ffffff', fontSize: 11, fontWeight: 600 },
-          labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
-          labelBgPadding: [6, 3] as [number, number],
-          labelBgBorderRadius: 5,
-          style: { ...e.style, stroke: '#ffffff', strokeWidth: 3 },
+          ...labelBg,
+          style: { ...base.style, stroke: '#ffffff', strokeWidth: 3 },
           markerEnd: { type: MarkerType.ArrowClosed, color: '#ffffff', width: 14, height: 14 }
         }
+      }
       // Driven: the same clay the RUNNING badge uses, thicker and flowing — legible on a zoomed-out
       // canvas where the header chip is unreadable. This is the whole point of highlighting the rope.
       if (drivenTargets.has(e.target))
         return {
-          ...e,
+          ...base,
           animated: true,
-          style: { ...e.style, stroke: '#d97757', strokeWidth: 2.5 },
+          style: { ...base.style, stroke: '#d97757', strokeWidth: 2.5 },
           markerEnd: { type: MarkerType.ArrowClosed, color: '#d97757', width: 14, height: 14 }
         }
-      return e
+      return base
     })
-    // Waiting edges for armed nodes (`--after`): dep → dependent, dashed and animated while the
-    // wait is on. Derived from node data rather than persisted — a pending dependency is a STATE
-    // that ends when the launch fires, unlike the context bridge `--after` also draws, which is a
-    // durable relation and stays. Built above (depEdges), keyed on the dependency signature so a
-    // drag frame does not rebuild it.
-    const extra =
-      ephemeralEdges.length || ropes.length || depEdges.length || trigEdges.length
-        ? [...ephemeralEdges, ...ropes, ...depEdges, ...trigEdges]
-        : []
-    return extra.length ? [...decorated, ...extra] : decorated
-  }, [linkEdges, ephemeralEdges, controlEdges, accent, stickySig, depEdges, trigEdges, drivenLeaseEntries])
+    const all =
+      ephemeralEdges.length || ropes.length || trigEdges.length
+        ? [...decorated, ...ephemeralEdges, ...ropes, ...trigEdges]
+        : decorated
+    // A closed eye hides every edge touching its node — data untouched, pixels gone.
+    return hidden.size ? all.filter((e) => !edgeHidden(e, hidden)) : all
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- edgeSig stands in for nodesRef
+  }, [linkEdges, ephemeralEdges, controlEdges, accent, stickySig, edgeSig, trigEdges, drivenLeaseEntries])
 
   // Header pin button (and ⌘⇧L): toggle the persisted pin preference. Clears the transient
   // dismiss so (re)pinning shows the docked panel; unpinning collapses it to hover-peek.
@@ -2321,14 +2319,7 @@ export function Canvas() {
       void useWorktrees.getState().refresh(project.cwd, boundGroups(flow))
     }
     setLinkEdges((project.bridges ?? []).map((b) => ({ id: b.id, source: b.source, target: b.target })))
-    // Restore control ropes with the source agent's color (falls back to the browser blue).
-    setControlEdges(
-      (project.ropes ?? []).map((r) => {
-        const srcState = project.nodes.find((n) => n.id === r.source)
-        const color = agentConfig((srcState?.agentId as AgentId) ?? '')?.color ?? '#0a84ff'
-        return ropeEdge(r.id, r.source, r.target, color)
-      })
-    )
+    setControlEdges((project.ropes ?? []).map((r) => ropeEdge(r.id, r.source, r.target)))
     // Reset history for the newly loaded project.
     committedRef.current = flow
     pastRef.current = []
@@ -3172,6 +3163,25 @@ export function Canvas() {
     [linkEndpointOf, agentIdOf, setLinkEdges, markDirty, nodes]
   )
 
+  // Removing a WAITING rope is "stop waiting on that one": the dep leaves the target's list, the
+  // rope goes, and (if it was the last wait) the held launch fires on the next effect run. A plain
+  // rope's removal changes no arming.
+  const disarmDepsFor = useCallback(
+    (ropeIds: readonly string[]) => {
+      const drops = controlEdgesRef.current.filter((r) => ropeIds.includes(r.id))
+      if (!drops.length) return
+      setNodes((ns) =>
+        ns.map((n) => {
+          const p = n.data.pendingLaunch as PendingLaunch | undefined
+          if (!p) return n
+          const next = drops.filter((r) => r.target === n.id).reduce((acc, r) => dropAfterDep(acc, r.source), p)
+          return next === p ? n : { ...n, data: { ...n.data, pendingLaunch: next } }
+        })
+      )
+    },
+    [setNodes]
+  )
+
   // Double-click a context link to remove it (ephemeral subagent/loop edges are left alone).
   const onEdgeDoubleClick = useCallback(
     (_e: React.MouseEvent, edge: Edge) => {
@@ -3183,6 +3193,7 @@ export function Canvas() {
         const covered = new Set(
           linkIdsCoveredByRopes([edge.id], controlEdgesRef.current, linkEdgesRef.current)
         )
+        disarmDepsFor([edge.id])
         setControlEdges((es) => es.filter((b) => b.id !== edge.id))
         if (covered.size) setLinkEdges((es) => es.filter((b) => !covered.has(b.id)))
         markDirty()
@@ -3192,7 +3203,7 @@ export function Canvas() {
       setLinkEdges((es) => es.filter((b) => b.id !== edge.id))
       markDirty()
     },
-    [setLinkEdges, markDirty]
+    [setLinkEdges, markDirty, disarmDepsFor]
   )
 
   // Route edge changes (selection) to the right store: `ctrl-` ids are control ropes (local
@@ -4954,6 +4965,7 @@ export function Canvas() {
       ])
       if (drop.size) setLinkEdges((es) => es.filter((b) => !drop.has(b.id)))
       if (ropeIds.length) {
+        disarmDepsFor(ropeIds)
         const dropRopes = new Set(ropeIds)
         setControlEdges((es) => es.filter((b) => !dropRopes.has(b.id)))
       }
@@ -4968,7 +4980,7 @@ export function Canvas() {
       }
     })
     return true
-  }, [deleteNodes, setLinkEdges, setControlEdges, markDirty, setConfirm])
+  }, [deleteNodes, setLinkEdges, setControlEdges, markDirty, setConfirm, disarmDepsFor])
 
   // When an account is removed in Settings, patch the ACTIVE project's live nodes (the projects
   // store only holds the other projects' serialized copies). The account's login node is
@@ -8568,7 +8580,7 @@ export function Canvas() {
       })
       const placed = src.parentId ? parentInto(node, src.parentId) : node
       setNodes((ns) => [...ns, placed])
-      setControlEdges((es) => [...es, ropeEdge(`ctrl-${sourceNodeId}-${placed.id}`, sourceNodeId, placed.id, '#0a84ff')])
+      setControlEdges((es) => [...es, ropeEdge(`ctrl-${sourceNodeId}-${placed.id}`, sourceNodeId, placed.id)])
       markDirty()
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -9100,10 +9112,21 @@ export function Canvas() {
         y: src.position.y + (srcGroup?.position.y ?? 0)
       }
       const belowY = srcAbs.y + srcH + 80
-      const edgeColor = agentConfig((src.data.agentId as string) ?? 'claude')?.color ?? '#d97757'
       const placeBelow = (i = 0) => ({ x: srcAbs.x + srcW / 2 + i * 460, y: belowY + 210 })
       const connect = (newId: string) =>
-        setControlEdges((es) => [...es, ropeEdge(`ctrl-${sourceNodeId}-${newId}`, sourceNodeId, newId, edgeColor)])
+        setControlEdges((es) => [...es, ropeEdge(`ctrl-${sourceNodeId}-${newId}`, sourceNodeId, newId)])
+      // `--after` is a rope too: dep → armed node, drawn dashed while the node waits and solid once
+      // it has launched (displayEdges derives that from pendingLaunch). The opener's own rope is
+      // skipped here — it already exists, and ropeVisual renders it waiting when the node waits on
+      // the opener itself. The fan-in bridge `--after` also writes hides under this rope exactly
+      // as the opener's bridge does.
+      const ropeDeps = (ids: string[], after: string[] | undefined): void => {
+        if (!after?.length) return
+        const ropes = ids.flatMap((nid) =>
+          after.filter((dep) => dep !== sourceNodeId).map((dep) => ropeEdge(`ctrl-${dep}-${nid}`, dep, nid))
+        )
+        if (ropes.length) setControlEdges((es) => [...es, ...ropes])
+      }
       // Draw real CONTEXT links (persisted `bridges`), not the display-only ropes `connect`
       // draws — a rope is lineage decoration, a bridge is what get-linked-context reads. This
       // is what lets an orchestrator fan IN: read back what the nodes it opened produced.
@@ -9370,6 +9393,7 @@ export function Canvas() {
             const ids = intoGroupId
               ? addGrouped(intoGroupId, count, make)
               : Array.from({ length: count }, (_, i) => addAndConnect(make(i)))
+            ropeDeps(ids, after)
             reply({
               ok: true,
               message:
@@ -9510,6 +9534,7 @@ export function Canvas() {
             const ids = intoGroupId
               ? addGrouped(intoGroupId, count, make)
               : Array.from({ length: count }, (_, i) => addAndConnect(make(i)))
+            ropeDeps(ids, after)
             // Context-link the new session(s) back to the opener (same rationale as spawn-team:
             // the fan-out needs a fan-in). The nodes were added via setNodes in this tick, so
             // resolve their endpoints from `agentId` rather than the not-yet-updated canvas.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -416,7 +416,7 @@ import {
   LAUNCH_STALL_MS,
   type ArmedNode
 } from '../lib/pendingLaunch'
-import { WAIT_LABEL, dropAfterDep, edgeHidden, hiddenEdgeNodeIds, ropeVisual, type RopeNodeInfo } from '../lib/edgeModel'
+import { WAIT_LABEL, dropAfterDep, edgeHidden, hiddenEdgeNodeIds, missingDepRopes, ropeInfoOf, ropeVisual } from '../lib/edgeModel'
 import { triggerEdges } from '../lib/triggerCard'
 import { freeSpot } from '../lib/placement'
 import { pushSessionRename, sessionNameUnchanged } from '../lib/sessionRename'
@@ -1918,7 +1918,7 @@ export function Canvas() {
     let sig = ''
     for (const n of nodes) {
       const p = n.data.pendingLaunch as PendingLaunch | undefined
-      sig += `${n.id}=${(n.data.agentId as string) ?? ''}${n.data.hideFanout ? '!' : ''}:${p?.after.join(',') ?? ''}|`
+      sig += `${n.id}=${(n.data.agentId as string) ?? ''}${n.data.hideFanout ? '!' : ''}:${p?.after?.join(',') ?? ''}|`
     }
     return sig
   }, [nodes])
@@ -1949,16 +1949,9 @@ export function Canvas() {
     const stickyIds = new Set(stickySig ? stickySig.split('|') : [])
     const drivenTargets = drivingNodeIds(drivenLeaseEntries, Date.now())
     // Endpoint facts the rope look derives from — read off the render-time ref, keyed by edgeSig.
-    const byId = new Map(nodesRef.current.map((n) => [n.id, n]))
-    const info = (id: string): RopeNodeInfo | undefined => {
-      const n = byId.get(id)
-      if (!n) return undefined
-      const agentId = n.data.agentId as AgentId | undefined
-      return {
-        agentColor: agentId ? agentConfig(agentId)?.color : undefined,
-        pendingAfter: (n.data.pendingLaunch as PendingLaunch | undefined)?.after
-      }
-    }
+    // The SAME builder the delete paths use (`nonWaitingRopeIds`), so what a rope's label promises
+    // is exactly what removing it does.
+    const info = ropeInfoOf(nodesRef.current, (a) => agentConfig(a as AgentId)?.color)
     const hidden = hiddenEdgeNodeIds(nodesRef.current)
     const labelBg = {
       labelBgStyle: { fill: '#1c1c1e', fillOpacity: 0.85 },
@@ -2319,7 +2312,14 @@ export function Canvas() {
       void useWorktrees.getState().refresh(project.cwd, boundGroups(flow))
     }
     setLinkEdges((project.bridges ?? []).map((b) => ({ id: b.id, source: b.source, target: b.target })))
-    setControlEdges((project.ropes ?? []).map((r) => ropeEdge(r.id, r.source, r.target)))
+    // A wait with no rope is a wait nothing on screen explains. Ropes for `--after` are written by
+    // the verbs that arm a node, so an arming that predates them (persisted `pendingLaunch`, no
+    // persisted rope) — or any future path that forgets one — is healed here on the next load.
+    const restoredRopes = (project.ropes ?? []).map((r) => ropeEdge(r.id, r.source, r.target))
+    setControlEdges([
+      ...restoredRopes,
+      ...missingDepRopes(flow, restoredRopes).map((r) => ropeEdge(r.id, r.source, r.target))
+    ])
     // Reset history for the newly loaded project.
     committedRef.current = flow
     pastRef.current = []
@@ -3126,7 +3126,7 @@ export function Canvas() {
       )
       if (exists) return
       setLinkEdges((es) =>
-        addEdge({ id: `bridge-${source}-${target}`, source, target, type: 'default' }, es)
+        addEdge({ id: `bridge-${source}-${target}`, source, target }, es)
       )
       markDirty()
       const status = useAgentStatus.getState().byId
@@ -3163,6 +3163,19 @@ export function Canvas() {
     [linkEndpointOf, agentIdOf, setLinkEdges, markDirty, nodes]
   )
 
+  // Of these ropes, the ones that are NOT live waits. A waiting rope's removal means "stop waiting
+  // on that one" and must not take the context bridge it covers with it: that bridge is durable
+  // (`--after` draws it so the dependent can READ its upstream) and simply becomes the visible
+  // `⇄ context` edge once the rope is gone. A plain lineage rope keeps the old rule — its hidden
+  // bridge goes with it, or the pair stays linked with nothing left on screen to unlink it. Asks
+  // the same lookup displayEdges renders from, so the label and the delete can never disagree.
+  const nonWaitingRopeIds = useCallback((ropeIds: readonly string[]): string[] => {
+    const info = ropeInfoOf(nodesRef.current, (a) => agentConfig(a as AgentId)?.color)
+    return controlEdgesRef.current
+      .filter((r) => ropeIds.includes(r.id) && !ropeVisual(r, info).waiting)
+      .map((r) => r.id)
+  }, [])
+
   // Removing a WAITING rope is "stop waiting on that one": the dep leaves the target's list, the
   // rope goes, and (if it was the last wait) the held launch fires on the next effect run. A plain
   // rope's removal changes no arming.
@@ -3189,9 +3202,14 @@ export function Canvas() {
       if (controlEdgesRef.current.some((b) => b.id === edge.id)) {
         // A rope may be the only DRAWN edge for a pair that also has a context bridge (see
         // displayEdges) — take that bridge with it, or the nodes stay linked with nothing left
-        // on screen to unlink them.
+        // on screen to unlink them. Unless it is a WAITING rope: that removal cancels only the
+        // wait, and the bridge it covered becomes the visible context edge.
         const covered = new Set(
-          linkIdsCoveredByRopes([edge.id], controlEdgesRef.current, linkEdgesRef.current)
+          linkIdsCoveredByRopes(
+            nonWaitingRopeIds([edge.id]),
+            controlEdgesRef.current,
+            linkEdgesRef.current
+          )
         )
         disarmDepsFor([edge.id])
         setControlEdges((es) => es.filter((b) => b.id !== edge.id))
@@ -3203,7 +3221,7 @@ export function Canvas() {
       setLinkEdges((es) => es.filter((b) => b.id !== edge.id))
       markDirty()
     },
-    [setLinkEdges, markDirty, disarmDepsFor]
+    [setLinkEdges, markDirty, disarmDepsFor, nonWaitingRopeIds]
   )
 
   // Route edge changes (selection) to the right store: `ctrl-` ids are control ropes (local
@@ -4958,10 +4976,15 @@ export function Canvas() {
       const ropeIds = controlEdgesRef.current.filter((b) => b.selected).map((b) => b.id)
       if (!edgeIds.length && !ropeIds.length) return false
       // A selected rope may be standing in for a hidden context bridge — drop both, or the
-      // pair stays linked with no edge left to click (see displayEdges).
+      // pair stays linked with no edge left to click (see displayEdges). A WAITING rope is the
+      // exception: removing it only cancels the wait, and its bridge surfaces as a context edge.
       const drop = new Set([
         ...edgeIds,
-        ...linkIdsCoveredByRopes(ropeIds, controlEdgesRef.current, linkEdgesRef.current)
+        ...linkIdsCoveredByRopes(
+          nonWaitingRopeIds(ropeIds),
+          controlEdgesRef.current,
+          linkEdgesRef.current
+        )
       ])
       if (drop.size) setLinkEdges((es) => es.filter((b) => !drop.has(b.id)))
       if (ropeIds.length) {
@@ -4980,7 +5003,7 @@ export function Canvas() {
       }
     })
     return true
-  }, [deleteNodes, setLinkEdges, setControlEdges, markDirty, setConfirm, disarmDepsFor])
+  }, [deleteNodes, setLinkEdges, setControlEdges, markDirty, setConfirm, disarmDepsFor, nonWaitingRopeIds])
 
   // When an account is removed in Settings, patch the ACTIVE project's live nodes (the projects
   // store only holds the other projects' serialized copies). The account's login node is
@@ -9150,7 +9173,7 @@ export function Canvas() {
         const plan = planBridges(fromId, targetIds, lookup, [...linkEdgesRef.current, ...drawn])
         if (plan.edges.length) {
           drawn.push(...plan.edges)
-          setLinkEdges((es) => [...es, ...plan.edges.map((e) => ({ ...e, type: 'default' }))])
+          setLinkEdges((es) => [...es, ...plan.edges])
           markDirty()
         }
         return plan
@@ -9205,7 +9228,9 @@ export function Canvas() {
       // instantly. Returns the ids, or null with the error already replied.
       const resolveAfter = (): string[] | null | undefined => {
         if (!args.after) return undefined
-        const ids = (args.after ?? '').split(',').map((s) => s.trim()).filter(Boolean)
+        // Deduped: `--after a,a` is one wait, and two dep ropes for one pair would collide on the
+        // single id `ctrl-a-<node>`.
+        const ids = [...new Set((args.after ?? '').split(',').map((s) => s.trim()).filter(Boolean))]
         if (ids.length === 0) return undefined
         for (const depId of ids) {
           const dep = nodesRef.current.find((nd) => nd.id === depId)
@@ -9547,7 +9572,9 @@ export function Canvas() {
             const bridged = bridgeTo(sourceNodeId, ids, openedEndpoint).linked
             // A dependency is also a READING relationship: the whole reason to wait for a
             // station is to consume what it produced. So `--after` additionally bridges each new
-            // node to each dep — that link is durable and outlives the dashed waiting edge.
+            // node to each dep. That bridge is DURABLE: while the wait is on it hides under the
+            // dep rope (one edge per pair), and cancelling the wait — deleting that rope — leaves
+            // it behind as an ordinary visible context edge.
             const depLinked = (after ?? []).length
               ? ids.flatMap((nid) => bridgeTo(nid, after ?? [], openedEndpoint).linked)
               : []
@@ -9929,6 +9956,11 @@ export function Canvas() {
             )
             setNodes(next)
             panelIds.forEach((pid) => connect(pid))
+            // `connect` only ropes the CALLER to each member — lineage. The panel's sequencing is
+            // its own relation, so each held wait gets its own rope and the group reads as the DAG
+            // it is: every reviewer waits on the target, the verdict waits on every reviewer.
+            for (const rid of reviewerIds) ropeDeps([rid], [targetId])
+            if (judge) ropeDeps([judge.id], reviewerIds)
             // Same-tick lookup: the panel is not on the canvas yet (setNodes is async).
             const panelEndpoint = (id: string): LinkEndpoint | null =>
               panelIds.includes(id)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -37,6 +37,7 @@ import {
   subscribeSessionReady
 } from '../nodes/TerminalNode'
 import { solveFitPadding } from './fit-view'
+import { FloatingEdge } from './FloatingEdge'
 import { MacWheelGestureRouter, trackpadRoutingEnabled } from './wheel-gesture'
 import { isBrowserRuntime } from '@renderer/bridge/runtime'
 import { WheelZoomBurstLimiter, clampWheelZoomSpeed, nextWheelZoom } from './wheel-zoom'
@@ -746,6 +747,9 @@ const ropeEdge = (id: string, source: string, target: string, color: string): Ed
   style: { stroke: color, strokeWidth: 1.5 },
   markerEnd: { type: MarkerType.ArrowClosed, color, width: 14, height: 14 }
 })
+
+/** The one edge renderer — every family routes between nearest borders (see FloatingEdge). */
+const edgeTypes = { floating: FloatingEdge }
 
 
 const minimapNodeColor = (n: Node): string =>
@@ -12492,6 +12496,7 @@ export function Canvas() {
           nodes={allNodes}
           edges={displayEdges}
           nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
           onNodesChange={handleNodesChange}
           onEdgesChange={handleEdgesChange}
           onConnect={onConnect}

--- a/src/renderer/canvas/FloatingEdge.tsx
+++ b/src/renderer/canvas/FloatingEdge.tsx
@@ -1,0 +1,63 @@
+// The canvas's ONE edge type. Reads both nodes' absolute rectangles from React Flow's internals
+// (so nodes inside group frames resolve correctly) and draws a bezier between their nearest
+// borders — see lib/floatingEdge.ts. An UNMEASURED node draws nothing this frame: React Flow's
+// internals report a 0×0 rectangle for the first tick after mount, and a path drawn from it would
+// point at the node's top-left corner, or at the origin.
+import { BaseEdge, getBezierPath, useInternalNode, type EdgeProps } from '@xyflow/react'
+import { floatingEdgeParams, type Rect } from '../lib/floatingEdge'
+
+function rectOf(n: ReturnType<typeof useInternalNode>): Rect | null {
+  if (!n) return null
+  const width = n.measured?.width ?? 0
+  const height = n.measured?.height ?? 0
+  if (!(width > 0) || !(height > 0)) return null
+  return { x: n.internals.positionAbsolute.x, y: n.internals.positionAbsolute.y, width, height }
+}
+
+export function FloatingEdge(props: EdgeProps) {
+  const {
+    id,
+    source,
+    target,
+    style,
+    markerEnd,
+    markerStart,
+    label,
+    labelStyle,
+    labelShowBg,
+    labelBgStyle,
+    labelBgPadding,
+    labelBgBorderRadius,
+    interactionWidth
+  } = props
+  const a = rectOf(useInternalNode(source))
+  const b = rectOf(useInternalNode(target))
+  if (!a || !b) return null
+  const p = floatingEdgeParams(a, b)
+  const [path, labelX, labelY] = getBezierPath({
+    sourceX: p.sx,
+    sourceY: p.sy,
+    sourcePosition: p.sourcePosition,
+    targetX: p.tx,
+    targetY: p.ty,
+    targetPosition: p.targetPosition
+  })
+  return (
+    <BaseEdge
+      id={id}
+      path={path}
+      style={style}
+      markerEnd={markerEnd}
+      markerStart={markerStart}
+      label={label}
+      labelX={labelX}
+      labelY={labelY}
+      labelStyle={labelStyle}
+      labelShowBg={labelShowBg}
+      labelBgStyle={labelBgStyle}
+      labelBgPadding={labelBgPadding}
+      labelBgBorderRadius={labelBgBorderRadius}
+      interactionWidth={interactionWidth}
+    />
+  )
+}

--- a/src/renderer/canvas/edge-model.source.test.ts
+++ b/src/renderer/canvas/edge-model.source.test.ts
@@ -41,4 +41,16 @@ describe('canvas edge model (source pins)', () => {
     expect((src.match(/disarmDepsFor\(\[?[a-zA-Z.]+\]?\)/g) ?? []).length).toBeGreaterThanOrEqual(2) // ⌫ path + double-click
     expect(src).toContain('dropAfterDep(')
   })
+
+  it('a WAITING rope\'s delete takes only the wait — the covered context bridge survives it', () => {
+    // Both delete paths ask the same lookup displayEdges renders from, so the label the user reads
+    // ("stop waiting") is what actually happens: only a NON-waiting rope drags its bridge along.
+    expect(src).toContain('const nonWaitingRopeIds = useCallback(')
+    expect((src.match(/linkIdsCoveredByRopes\(\s*nonWaitingRopeIds\(/g) ?? []).length).toBe(2)
+    expect(src).toContain('ropeInfoOf(')
+  })
+
+  it('an armed node with no dep rope heals at project load, not only where --after ran', () => {
+    expect(src).toContain('missingDepRopes(')
+  })
 })

--- a/src/renderer/canvas/edge-model.source.test.ts
+++ b/src/renderer/canvas/edge-model.source.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * Structural pins for the canvas edge model (spec: docs/superpowers/specs/2026-09-02-canvas-edge-
+ * model-design.md). The decisions are proven against real primitives in lib/edgeModel.test.ts and
+ * lib/floatingEdge.test.ts; what only the source can state is that Canvas consults them and that
+ * the families it replaced are gone.
+ */
+const src = readFileSync(new URL('./Canvas.tsx', import.meta.url), 'utf8')
+
+describe('canvas edge model (source pins)', () => {
+  it('every edge is a floating edge — no family picks a fixed handle side any more', () => {
+    expect(src).toContain('edgeTypes={edgeTypes}')
+    expect(src).not.toMatch(/sourceHandle:\s*'/)
+    expect(src).not.toMatch(/targetHandle:\s*'/)
+  })
+
+  it('the separate "waits for" family is gone; the waiting look is the rope\'s, from the model', () => {
+    expect(src).not.toContain('dependencyEdges')
+    expect(src).not.toContain('depEdges')
+    expect(src).not.toContain("'⏳ waits for'")
+    expect(src).toContain('ropeVisual(')
+    expect(src).toContain('WAIT_LABEL')
+  })
+
+  it('--after writes a rope from each dep to each opened node, beside the hidden bridge', () => {
+    // One helper, three verbs: the rope id shape is what hiddenLinkIds / delete key on.
+    expect(src).toMatch(/const ropeDeps = \(ids: string\[\], after: string\[\] \| undefined\)/)
+    expect(src).toContain('ropeEdge(`ctrl-${dep}-${nid}`, dep, nid)')
+    expect((src.match(/ropeDeps\(ids, after\)/g) ?? []).length).toBe(2)
+  })
+
+  it('the eye hides every edge touching the node, on every family', () => {
+    expect(src).toContain('hiddenEdgeNodeIds(')
+    expect(src).toMatch(/\.filter\(\(e\) => !edgeHidden\(e, hidden\)\)/)
+  })
+
+  it('deleting a waiting rope disarms that one dep (both the ⌫ path and double-click)', () => {
+    expect(src).toContain('const disarmDepsFor = useCallback(')
+    expect((src.match(/disarmDepsFor\(\[?[a-zA-Z.]+\]?\)/g) ?? []).length).toBeGreaterThanOrEqual(2) // ⌫ path + double-click
+    expect(src).toContain('dropAfterDep(')
+  })
+})

--- a/src/renderer/lib/edgeModel.test.ts
+++ b/src/renderer/lib/edgeModel.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ROPE_NEUTRAL,
+  dropAfterDep,
+  edgeHidden,
+  hiddenEdgeNodeIds,
+  ropeVisual,
+  type RopeNodeInfo
+} from './edgeModel'
+
+const infoOf =
+  (m: Record<string, RopeNodeInfo>) =>
+  (id: string): RopeNodeInfo | undefined =>
+    m[id]
+
+describe('ropeVisual — one rope, its look derived from the target\'s pendingLaunch', () => {
+  it('a rope whose target is still waiting on its source is WAITING', () => {
+    const v = ropeVisual({ source: 'y', target: 'n' }, infoOf({ y: { agentColor: '#d97757' }, n: { pendingAfter: ['y'] } }))
+    expect(v).toEqual({ waiting: true, color: '#d97757' })
+  })
+
+  it('the same rope is solid once the target no longer lists the source (launched, or disarmed)', () => {
+    expect(ropeVisual({ source: 'y', target: 'n' }, infoOf({ y: { agentColor: '#d97757' }, n: { pendingAfter: [] } })).waiting).toBe(false)
+    expect(ropeVisual({ source: 'y', target: 'n' }, infoOf({ y: { agentColor: '#d97757' }, n: {} })).waiting).toBe(false)
+  })
+
+  it('an opener rope is never "waiting" just because the target waits on SOMEONE ELSE', () => {
+    expect(ropeVisual({ source: 'x', target: 'n' }, infoOf({ x: { agentColor: '#10a37f' }, n: { pendingAfter: ['y'] } })).waiting).toBe(false)
+  })
+
+  it('takes the SOURCE\'s agent colour; a source with no agent (browser popup) is neutral grey', () => {
+    expect(ropeVisual({ source: 'x', target: 'n' }, infoOf({ x: { agentColor: '#10a37f' }, n: {} })).color).toBe('#10a37f')
+    expect(ropeVisual({ source: 'b', target: 'n' }, infoOf({ b: {}, n: {} })).color).toBe(ROPE_NEUTRAL)
+    expect(ropeVisual({ source: 'gone', target: 'n' }, infoOf({ n: {} })).color).toBe(ROPE_NEUTRAL)
+  })
+})
+
+describe('dropAfterDep — deleting a waiting rope means "stop waiting on that one"', () => {
+  it('removes exactly that dep and keeps the command', () => {
+    const p = { after: ['a', 'b'], command: 'claude "x"' }
+    expect(dropAfterDep(p, 'a')).toEqual({ after: ['b'], command: 'claude "x"' })
+  })
+
+  it('returns the SAME object when the dep is not listed (no spurious re-render)', () => {
+    const p = { after: ['a'], command: 'c' }
+    expect(dropAfterDep(p, 'zzz')).toBe(p)
+  })
+
+  it('leaves an empty list rather than disarming — launchesToFire fires a vacuous wait', () => {
+    expect(dropAfterDep({ after: ['a'], command: 'c' }, 'a')).toEqual({ after: [], command: 'c' })
+  })
+
+  it('keeps awaitSetupGroup', () => {
+    expect(dropAfterDep({ after: ['a'], command: 'c', awaitSetupGroup: 'g1' }, 'a')).toEqual({ after: [], command: 'c', awaitSetupGroup: 'g1' })
+  })
+})
+
+describe('hiddenEdgeNodeIds / edgeHidden — the eye hides every edge touching the node', () => {
+  const nodes = [
+    { id: 'a', data: { hideFanout: true } },
+    { id: 'b', data: {} },
+    { id: 'c', data: { hideFanout: false } }
+  ]
+  it('collects only nodes whose eye is closed', () => {
+    expect([...hiddenEdgeNodeIds(nodes)]).toEqual(['a'])
+  })
+  it('hides an edge on EITHER end, in either direction', () => {
+    const hidden = hiddenEdgeNodeIds(nodes)
+    expect(edgeHidden({ source: 'a', target: 'b' }, hidden)).toBe(true)
+    expect(edgeHidden({ source: 'b', target: 'a' }, hidden)).toBe(true)
+    expect(edgeHidden({ source: 'b', target: 'c' }, hidden)).toBe(false)
+  })
+  it('an empty set hides nothing', () => {
+    expect(edgeHidden({ source: 'a', target: 'b' }, new Set())).toBe(false)
+  })
+})

--- a/src/renderer/lib/edgeModel.test.ts
+++ b/src/renderer/lib/edgeModel.test.ts
@@ -4,6 +4,8 @@ import {
   dropAfterDep,
   edgeHidden,
   hiddenEdgeNodeIds,
+  missingDepRopes,
+  ropeInfoOf,
   ropeVisual,
   type RopeNodeInfo
 } from './edgeModel'
@@ -72,5 +74,72 @@ describe('hiddenEdgeNodeIds / edgeHidden — the eye hides every edge touching t
   })
   it('an empty set hides nothing', () => {
     expect(edgeHidden({ source: 'a', target: 'b' }, new Set())).toBe(false)
+  })
+})
+
+describe('ropeInfoOf — one endpoint lookup, shared by the render and the delete paths', () => {
+  const colorOf = (a: string) => ({ claude: '#d97757', codex: '#10a37f' })[a]
+
+  it('reports the node\'s agent colour through the injected registry', () => {
+    const info = ropeInfoOf([{ id: 'a', data: { agentId: 'claude' } }], colorOf)
+    expect(info('a')?.agentColor).toBe('#d97757')
+  })
+
+  it('a node with no agent has NO colour — ropeVisual is what falls back to the neutral', () => {
+    const info = ropeInfoOf([{ id: 'a', data: {} }], colorOf)
+    expect(info('a')).toEqual({ agentColor: undefined, pendingAfter: undefined })
+    expect(ropeVisual({ source: 'a', target: 'b' }, info).color).toBe(ROPE_NEUTRAL)
+  })
+
+  it('an agent the registry does not know also has no colour (never a thrown lookup)', () => {
+    const info = ropeInfoOf([{ id: 'a', data: { agentId: 'nobody' } }], colorOf)
+    expect(info('a')?.agentColor).toBeUndefined()
+  })
+
+  it('passes pendingLaunch.after straight through, so a rope reads as waiting', () => {
+    const info = ropeInfoOf(
+      [{ id: 'a', data: { agentId: 'claude' } }, { id: 'b', data: { pendingLaunch: { after: ['a'], command: 'x' } } }],
+      colorOf
+    )
+    expect(info('b')?.pendingAfter).toEqual(['a'])
+    expect(ropeVisual({ source: 'a', target: 'b' }, info)).toEqual({ waiting: true, color: '#d97757' })
+  })
+
+  it('an id that is not on the canvas answers undefined', () => {
+    expect(ropeInfoOf([{ id: 'a', data: {} }], colorOf)('ghost')).toBeUndefined()
+  })
+})
+
+describe('missingDepRopes — a wait with no rope is a wait nothing on screen explains', () => {
+  const armed = (id: string, after: string[]) => ({ id, data: { pendingLaunch: { after, command: 'go' } } })
+
+  it('synthesizes dep -> node for an armed node whose rope was never written', () => {
+    expect(missingDepRopes([{ id: 'a', data: {} }, armed('b', ['a'])], [])).toEqual([
+      { id: 'ctrl-a-b', source: 'a', target: 'b' }
+    ])
+  })
+
+  it('never duplicates a rope that already exists for that pair', () => {
+    expect(missingDepRopes([{ id: 'a', data: {} }, armed('b', ['a'])], [{ source: 'a', target: 'b' }])).toEqual([])
+  })
+
+  it('an OPPOSITE rope is not the same relation — the dep rope is still owed', () => {
+    expect(missingDepRopes([{ id: 'a', data: {} }, armed('b', ['a'])], [{ source: 'b', target: 'a' }])).toEqual([
+      { id: 'ctrl-a-b', source: 'a', target: 'b' }
+    ])
+  })
+
+  it('skips a dep that is not on the canvas (it can never report; the wait is already satisfied)', () => {
+    expect(missingDepRopes([armed('b', ['ghost'])], [])).toEqual([])
+  })
+
+  it('a node that is not armed is owed nothing', () => {
+    expect(missingDepRopes([{ id: 'a', data: {} }, { id: 'b', data: {} }], [])).toEqual([])
+  })
+
+  it('a repeated dep yields ONE rope — two edges with one id would be a React Flow collision', () => {
+    expect(missingDepRopes([{ id: 'a', data: {} }, armed('b', ['a', 'a'])], [])).toEqual([
+      { id: 'ctrl-a-b', source: 'a', target: 'b' }
+    ])
   })
 })

--- a/src/renderer/lib/edgeModel.ts
+++ b/src/renderer/lib/edgeModel.ts
@@ -1,0 +1,57 @@
+// Pure decisions behind the canvas edge model (spec: docs/superpowers/specs/2026-09-02-canvas-edge-
+// model-design.md). A ROPE is the one visible relation between two nodes — "opened by" and
+// "sequenced after (--after)" — and its LOOK is derived from the target's pendingLaunch, never
+// stored: dashed while the target still waits on the rope's source, solid otherwise. Kept free of
+// React/store imports so Canvas.tsx only wraps these in a memo.
+import type { PendingLaunch } from '@shared/types'
+
+/** Rope colour for a source with no agent (a browser popup, a plain terminal that opened nothing). */
+export const ROPE_NEUTRAL = '#8e8e93'
+/** The waiting rope's label. Canvas appends the removal hint when the rope is selected. */
+export const WAIT_LABEL = '⏳ waits for'
+
+export interface RopeNodeInfo {
+  /** The node's agent colour (AGENT_CONFIG), if it runs an agent. */
+  agentColor?: string
+  /** The node's `pendingLaunch.after`, if it is armed. */
+  pendingAfter?: readonly string[]
+}
+
+export interface RopeVisual {
+  /** The target is armed and still lists this rope's source among its deps. */
+  waiting: boolean
+  color: string
+}
+
+export function ropeVisual(
+  rope: { source: string; target: string },
+  info: (id: string) => RopeNodeInfo | undefined
+): RopeVisual {
+  const waiting = !!info(rope.target)?.pendingAfter?.includes(rope.source)
+  const color = info(rope.source)?.agentColor ?? ROPE_NEUTRAL
+  return { waiting, color }
+}
+
+/**
+ * Deleting a WAITING rope is the user saying "do not wait on that one": drop the dep from the
+ * target's list and keep everything else. Returns the same object when nothing changes so a caller
+ * can skip the state write. An emptied list is left in place — `launchesToFire` treats `[]` as
+ * satisfied and fires the held command, which is exactly what removing the last wait should do.
+ */
+export function dropAfterDep(p: PendingLaunch, depId: string): PendingLaunch {
+  if (!p.after.includes(depId)) return p
+  return { ...p, after: p.after.filter((d) => d !== depId) }
+}
+
+/** Nodes whose eye is closed (`hideFanout`): every edge touching them is hidden from the canvas. */
+export function hiddenEdgeNodeIds(
+  nodes: readonly { id: string; data: { hideFanout?: boolean } }[]
+): Set<string> {
+  const out = new Set<string>()
+  for (const n of nodes) if (n.data.hideFanout) out.add(n.id)
+  return out
+}
+
+export function edgeHidden(e: { source: string; target: string }, hidden: ReadonlySet<string>): boolean {
+  return hidden.size > 0 && (hidden.has(e.source) || hidden.has(e.target))
+}

--- a/src/renderer/lib/edgeModel.ts
+++ b/src/renderer/lib/edgeModel.ts
@@ -55,3 +55,53 @@ export function hiddenEdgeNodeIds(
 export function edgeHidden(e: { source: string; target: string }, hidden: ReadonlySet<string>): boolean {
   return hidden.size > 0 && (hidden.has(e.source) || hidden.has(e.target))
 }
+
+/**
+ * The endpoint lookup `ropeVisual` needs, built once from the canvas nodes. Extracted because the
+ * DELETE paths ask the same question the render does ("is this rope a wait?"), and two copies of
+ * the builder would be two answers: displayEdges would draw the waiting label while the delete
+ * path still took the covered context bridge with it. `colorOf` is injected so this file stays
+ * free of the agent registry.
+ */
+export function ropeInfoOf(
+  nodes: readonly { id: string; data: { agentId?: string; pendingLaunch?: PendingLaunch } }[],
+  colorOf: (agentId: string) => string | undefined
+): (id: string) => RopeNodeInfo | undefined {
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  return (id) => {
+    const n = byId.get(id)
+    if (!n) return undefined
+    const agentId = n.data.agentId
+    return {
+      agentColor: agentId ? colorOf(agentId) : undefined,
+      pendingAfter: n.data.pendingLaunch?.after
+    }
+  }
+}
+
+/**
+ * The dep ropes an armed node is owed but does not have. A rope is what makes a wait VISIBLE, and
+ * only the `open-*`/`verify` verbs write one — so a node armed by any other path, or armed by a
+ * build that predates the rope (its `pendingLaunch` is persisted, the rope is not), would show a
+ * launch it is holding with no arrow saying what for. Applied at project load, this heals both
+ * cases on the next open and costs nothing on a canvas with no armed node.
+ *
+ * A dep that is not on the canvas is skipped — it can never report, `launchesToFire` already treats
+ * it as satisfied, and an edge to a node that is not there would be dropped by React Flow anyway.
+ */
+export function missingDepRopes(
+  nodes: readonly { id: string; data: { pendingLaunch?: PendingLaunch } }[],
+  ropes: readonly { source: string; target: string }[]
+): { id: string; source: string; target: string }[] {
+  const live = new Set(nodes.map((n) => n.id))
+  const have = new Set(ropes.map((r) => `${r.source} ${r.target}`))
+  const out: { id: string; source: string; target: string }[] = []
+  for (const n of nodes) {
+    for (const dep of n.data.pendingLaunch?.after ?? []) {
+      if (!live.has(dep) || have.has(`${dep} ${n.id}`)) continue
+      have.add(`${dep} ${n.id}`)
+      out.push({ id: `ctrl-${dep}-${n.id}`, source: dep, target: n.id })
+    }
+  }
+  return out
+}

--- a/src/renderer/lib/floatingEdge.test.ts
+++ b/src/renderer/lib/floatingEdge.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { Position } from '@xyflow/react'
+import { borderExit, floatingEdgeParams, type Rect } from './floatingEdge'
+
+const box = (x: number, y: number, width = 100, height = 50): Rect => ({ x, y, width, height })
+
+describe('borderExit — where the centre-to-centre line leaves a rectangle', () => {
+  it('exits the RIGHT side toward a point to the right', () => {
+    expect(borderExit(box(0, 0), { x: 500, y: 25 })).toEqual({ x: 100, y: 25, position: Position.Right })
+  })
+  it('exits the LEFT side toward a point to the left', () => {
+    expect(borderExit(box(0, 0), { x: -500, y: 25 })).toEqual({ x: 0, y: 25, position: Position.Left })
+  })
+  it('exits the BOTTOM toward a point below', () => {
+    expect(borderExit(box(0, 0), { x: 50, y: 500 })).toEqual({ x: 50, y: 50, position: Position.Bottom })
+  })
+  it('exits the TOP toward a point above', () => {
+    expect(borderExit(box(0, 0), { x: 50, y: -500 })).toEqual({ x: 50, y: 0, position: Position.Top })
+  })
+  it('a diagonal target exits the side the line actually crosses (wide box → left/right)', () => {
+    // centre (50,25); toward (250,125): dx=200, dy=100 → |dx|/w=4 > |dy|/h=4? equal → right wins.
+    const e = borderExit(box(0, 0), { x: 250, y: 125 })
+    expect(e.position).toBe(Position.Right)
+    expect(e.x).toBe(100)
+    expect(e.y).toBeCloseTo(50)
+  })
+  it('a coincident centre (overlapping nodes) degrades to the right side, never NaN', () => {
+    const e = borderExit(box(0, 0), { x: 50, y: 25 })
+    expect(Number.isFinite(e.x) && Number.isFinite(e.y)).toBe(true)
+    expect(e.position).toBe(Position.Right)
+  })
+  it('a zero-size rectangle answers its own origin', () => {
+    expect(borderExit({ x: 10, y: 20, width: 0, height: 0 }, { x: 99, y: 99 })).toEqual({ x: 10, y: 20, position: Position.Right })
+  })
+})
+
+describe('floatingEdgeParams — both ends, facing each other', () => {
+  it('a node left of another: source exits right, target enters left', () => {
+    const p = floatingEdgeParams(box(0, 0), box(400, 0))
+    expect(p).toEqual({ sx: 100, sy: 25, sourcePosition: Position.Right, tx: 400, ty: 25, targetPosition: Position.Left })
+  })
+  it('a node ABOVE another (the case the fixed handles got wrong): bottom → top, no loop', () => {
+    const p = floatingEdgeParams(box(0, 0), box(0, 300))
+    expect(p.sourcePosition).toBe(Position.Bottom)
+    expect(p.targetPosition).toBe(Position.Top)
+  })
+  it('a target to the upper-left exits the source on its left/top side, not its right', () => {
+    const p = floatingEdgeParams(box(1000, 1000), box(0, 0))
+    expect([Position.Left, Position.Top]).toContain(p.sourcePosition)
+    expect([Position.Right, Position.Bottom]).toContain(p.targetPosition)
+  })
+})

--- a/src/renderer/lib/floatingEdge.test.ts
+++ b/src/renderer/lib/floatingEdge.test.ts
@@ -48,5 +48,8 @@ describe('floatingEdgeParams — both ends, facing each other', () => {
     const p = floatingEdgeParams(box(1000, 1000), box(0, 0))
     expect([Position.Left, Position.Top]).toContain(p.sourcePosition)
     expect([Position.Right, Position.Bottom]).toContain(p.targetPosition)
+    // The exact point, not just the side: the vertical branch interpolates x by HALF THE HEIGHT
+    // over |dy|, and a swapped half-extent still lands on the right side while missing the corner.
+    expect({ x: p.sx, y: p.sy }).toEqual({ x: 1025, y: 1000 })
   })
 })

--- a/src/renderer/lib/floatingEdge.ts
+++ b/src/renderer/lib/floatingEdge.ts
@@ -1,0 +1,57 @@
+// Pure geometry for the canvas's one edge type. An edge is drawn between the two points where the
+// centre-to-centre line leaves each node's rectangle, so it always takes the short way round — the
+// fixed-side handles it replaces sent an edge to a node placed left of (or above) its source on a
+// loop across the whole canvas, with its label drifting into empty space.
+import { Position } from '@xyflow/react'
+
+export interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface EdgeEnd {
+  x: number
+  y: number
+  position: Position
+}
+
+/**
+ * The point on `from`'s border where the line from its centre toward `toward` exits, and the side
+ * it exits on. A degenerate rectangle (unmeasured) or a coincident centre answers deterministically
+ * (its own point, `Right`) — never NaN, so a path is always drawable.
+ */
+export function borderExit(from: Rect, toward: { x: number; y: number }): EdgeEnd {
+  const hw = from.width / 2
+  const hh = from.height / 2
+  const cx = from.x + hw
+  const cy = from.y + hh
+  if (!(hw > 0) || !(hh > 0)) return { x: from.x, y: from.y, position: Position.Right }
+  const dx = toward.x - cx
+  const dy = toward.y - cy
+  if (dx === 0 && dy === 0) return { x: cx + hw, y: cy, position: Position.Right }
+  // Compare the slopes against the corner: |dx|/hw vs |dy|/hh decides which side the line crosses.
+  if (Math.abs(dx) * hh >= Math.abs(dy) * hw) {
+    const sx = dx >= 0 ? 1 : -1
+    return { x: cx + sx * hw, y: cy + dy * (hw / Math.abs(dx)), position: sx > 0 ? Position.Right : Position.Left }
+  }
+  const sy = dy >= 0 ? 1 : -1
+  return { x: cx + dx * (hh / Math.abs(dy)), y: cy + sy * hh, position: sy > 0 ? Position.Bottom : Position.Top }
+}
+
+export interface FloatingParams {
+  sx: number
+  sy: number
+  sourcePosition: Position
+  tx: number
+  ty: number
+  targetPosition: Position
+}
+
+export function floatingEdgeParams(a: Rect, b: Rect): FloatingParams {
+  const centre = (r: Rect) => ({ x: r.x + r.width / 2, y: r.y + r.height / 2 })
+  const s = borderExit(a, centre(b))
+  const t = borderExit(b, centre(a))
+  return { sx: s.x, sy: s.y, sourcePosition: s.position, tx: t.x, ty: t.y, targetPosition: t.position }
+}

--- a/src/renderer/lib/pendingLaunch.test.ts
+++ b/src/renderer/lib/pendingLaunch.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
 import {
-  dependencyEdges,
   launchesToFire,
   launchRetryDelay,
   launchTooltip,
@@ -153,23 +152,6 @@ describe('unmetDeps', () => {
 
   it('is empty for a node that is not armed', () => {
     expect(unmetDeps(plain('c'), {}, new Set(['c']))).toEqual([])
-  })
-})
-
-describe('dependencyEdges', () => {
-  it('draws one edge per live dep, pointing dep → dependent', () => {
-    expect(dependencyEdges([armed('c', ['a', 'b'])], new Set(['a', 'b', 'c']))).toEqual([
-      { id: 'dep-a-c', source: 'a', target: 'c' },
-      { id: 'dep-b-c', source: 'b', target: 'c' }
-    ])
-  })
-
-  it('draws nothing for a dep that is gone', () => {
-    expect(dependencyEdges([armed('c', ['ghost'])], new Set(['c']))).toEqual([])
-  })
-
-  it('draws nothing once the node is no longer armed', () => {
-    expect(dependencyEdges([plain('c')], new Set(['c']))).toEqual([])
   })
 })
 

--- a/src/renderer/lib/pendingLaunch.ts
+++ b/src/renderer/lib/pendingLaunch.ts
@@ -110,34 +110,6 @@ export function unmetDeps(
   return p.after.filter((d) => !depSatisfied(d, status, live))
 }
 
-export interface DependencyEdge {
-  id: string
-  source: string
-  target: string
-}
-
-/**
- * The dashed dep→node edges to draw for everything still waiting. Derived from node data on
- * every render rather than persisted as edges: a pending dependency is a STATE, not a durable
- * relation, and it disappears when the launch fires. (The durable relation `--after` also
- * creates is an ordinary context bridge, so the downstream node can still read its upstream
- * long after the arrow is gone.)
- */
-export function dependencyEdges(
-  nodes: readonly ArmedNode[],
-  live: ReadonlySet<string>
-): DependencyEdge[] {
-  const out: DependencyEdge[] = []
-  for (const n of nodes) {
-    for (const dep of n.data.pendingLaunch?.after ?? []) {
-      // A dep that is gone draws nothing — it is already satisfied, and an edge to a node that
-      // isn't there would be dropped by React Flow anyway.
-      if (live.has(dep)) out.push({ id: `dep-${dep}-${n.id}`, source: dep, target: n.id })
-    }
-  }
-  return out
-}
-
 /**
  * The backoff between delivery attempts, in milliseconds, indexed by the number of attempts
  * ALREADY made. `null` = the schedule is exhausted; the launch has failed for good.

--- a/src/renderer/lib/triggerCard.test.ts
+++ b/src/renderer/lib/triggerCard.test.ts
@@ -81,6 +81,9 @@ describe('triggerEdges', () => {
     const edges = triggerEdges(nodes as never, '#fff')
     expect(edges.map((e) => `${e.source}>${e.target}`)).toEqual(['trigger-a-1>term-tgt-1'])
     expect(edges[0].selectable).toBe(false)
+    // The canvas has ONE edge renderer: a trigger edge routes between nearest borders like
+    // every other family, so a card above its target does not loop out of the wrong side.
+    expect(edges[0].type).toBe('floating')
   })
 
   it('non-trigger nodes never draw', () => {

--- a/src/renderer/lib/triggerCard.ts
+++ b/src/renderer/lib/triggerCard.ts
@@ -113,7 +113,7 @@ export function triggerEdges(
       id: `trigger-edge-${n.id}`,
       source: n.id,
       target: spec.target,
-      type: 'smoothstep',
+      type: 'floating',
       style: { stroke: accent, strokeDasharray: '6 4', opacity: 0.55 },
       selectable: false,
       focusable: false

--- a/src/renderer/lib/ui-visibility.ts
+++ b/src/renderer/lib/ui-visibility.ts
@@ -37,7 +37,7 @@ export const HIDEABLE_HEADER_BUTTONS: readonly HideableRow[] = [
   { id: 'mic', label: 'Dictate' },
   { id: 'ai-name', label: 'Name with AI' },
   { id: 'comments', label: 'Comments' },
-  { id: 'hide-fanout', label: 'Hide subagent/loop cards' },
+  { id: 'hide-fanout', label: 'Hide cards & connections' },
   { id: 'tidy-fanout', label: 'Tidy subagent cards' }
 ]
 

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -5083,11 +5083,11 @@ export function TerminalNode({
             </button>
           </Tooltip>
         )}
-        {fanoutCapable && !isHidden('hide-fanout', hiddenHeaderButtons) && (
-          <Tooltip label={hideFanout ? 'Show subagent/loop cards' : 'Hide subagent/loop cards'}>
+        {!isHidden('hide-fanout', hiddenHeaderButtons) && (
+          <Tooltip label={hideFanout ? 'Show cards & connections' : 'Hide cards & connections'}>
             <button
               className="term-node__hide-fanout nodrag"
-              title={hideFanout ? 'Show subagent/loop cards' : 'Hide subagent/loop cards'}
+              title={hideFanout ? 'Show cards & connections' : 'Hide cards & connections'}
               aria-pressed={hideFanout}
               onClick={(e) => {
                 e.stopPropagation()

--- a/src/renderer/nodes/session-ready-signal.test.ts
+++ b/src/renderer/nodes/session-ready-signal.test.ts
@@ -107,3 +107,14 @@ describe('the QUEUED badge carries the delivery state (source pins)', () => {
     expect(src).toMatch(/else \{[\s\S]{0,200}?markFailed\(id, 1\)/)
   })
 })
+
+describe('the eye button hides cards AND connections (source pins)', () => {
+  it('is offered on every terminal node — a plain terminal has ropes too — and says what it hides', () => {
+    expect(src).toContain("'Hide cards & connections'")
+    expect(src).toContain("'Show cards & connections'")
+    expect(src).not.toContain("'Hide subagent/loop cards'")
+    // The button no longer requires a fan-out-capable agent; only the user's header-button
+    // visibility setting gates it.
+    expect(src).toMatch(/\{!isHidden\('hide-fanout', hiddenHeaderButtons\) && \(\s*<Tooltip label=\{hideFanout \? 'Show cards & connections'/)
+  })
+})


### PR DESCRIPTION
## Problem

One `open-claude --after Y` call from agent X landed **three** edges on the new node N: an orange
rope X→N (lineage, the opener's agent colour), a blue context bridge N↔Y (drawn for the `--after`
fan-in), and a dashed grey "⏳ waits for" edge Y→N (derived from `pendingLaunch`). Gemini's agent
colour (`#4285f4`) and the browser-popup rope (`#0a84ff`) are indistinguishable from the
accent-blue bridge, so the picture read as noise — and users could not tell whether they still had
to draw a blue link by hand to let an opener read what it opened.

Every family also left and entered nodes on **fixed sides** (bridges Right→Left, everything else
Bottom→Top) through React Flow's default bezier, so an edge to a node placed left of or above its
source looped across the whole canvas with its label drifting into empty space.

Measured 2026-09-02 on a live canvas: the opener↔opened context link is already automatic and
bidirectional (`buildLinkMap` maps context edges both ways; the opened node's own `context.sh
list/summary` returned the opener). The confusion was visual, not semantic.

## Decisions

1. An opener→opened rope already MEANS context; no second blue edge is drawn for it.
2. `--after` is **ONE** edge: dashed + ⏳ while N waits on Y, solid once N has launched; it carries
   context (N reads Y's work), so no separate bridge is shown.
3. Lineage ropes use the source's agent colour; hand-made context links stay accent blue and are
   also distinguished by SHAPE (two arrowheads + ⇄), so a colour clash stays readable.
4. Display-layer consolidation plus ropes for `--after` deps. No new persisted model.
5. The per-node eye also hides every edge touching that node (label now **"Hide cards &
   connections"**).

## Before / after — the three-edges-per-node case

| | before | after |
|---|---|---|
| `open-claude --after Y` from X | rope X→N (orange) + bridge N↔Y (blue) + dashed dep edge Y→N (grey) = **3 edges** | rope X→N + rope Y→N (dashed ⏳ while waiting) = **2 edges**, one per relation |
| the wait's look | its own `depEdges` family, its own colour and label | derived from the target's `pendingLaunch` on the SAME rope (`ropeVisual`) |
| the `--after` bridge | drawn as a second visible edge | still written, hidden under the rope (`hiddenLinkIds`), exactly as the opener's already was |
| deleting the wait | not expressible — the dashed edge was derived and not deletable | ⌫ on a waiting rope drops that dep from `after` (`dropAfterDep`); the covered bridge **survives** ("stop waiting" ≠ "stop reading its work"); an emptied list fires |
| an armed node whose rope is missing | n/a | healed at project load by `missingDepRopes` (`pendingLaunch` is persisted, the rope is not) |
| routing | fixed handle sides; an edge to a node left of its source looped across the canvas | one `floating` edge type for every family — nearest borders of the two node rectangles; an unmeasured node draws nothing rather than a path to the origin |
| a node's eye | hid its subagent/loop cards | hides its cards **and** every edge touching it (display only — links still authorise reads, an `--after` still waits) |

## What landed

- `src/renderer/lib/edgeModel.ts` — pure: `ropeVisual`, `ropeInfoOf` (the ONE endpoint lookup the
  render and both delete paths share — two builders would be two answers, and the label the user
  reads would stop describing what the delete does), `dropAfterDep`, `missingDepRopes`,
  `hiddenEdgeNodeIds` / `edgeHidden`.
- `src/renderer/lib/floatingEdge.ts` + `src/renderer/canvas/FloatingEdge.tsx` — `borderExit` /
  `floatingEdgeParams` and the one edge component; every edge is `type: 'floating'`.
- `Canvas.tsx` — `--after` writes `ctrl-<dep>-<node>` ropes in `open-terminal`/`open-claude`/
  `open-agent`/`verify`; the `depEdges` family and `dependencyEdges()` are gone; the eye filters
  `displayEdges`.
- Canvas-control skill body + instruction block updated in the same change (the #269 rule).
- `edge-model.source.test.ts` pins the structural claims (no `sourceHandle:`/`targetHandle:`, no
  `depEdges`, the rope-id shape, both delete paths, the load-time heal).

## Data and compatibility

`project.ropes` gains `ctrl-<dep>-<node>` entries for `--after`. **Backward compatible**: a
pre-change build renders them as ordinary solid ropes and keeps the bridge hidden under them —
harmless. `project.json` schema is unchanged, ropes already ride `workspace.save`, so the SSH
mirror and team sync need nothing new. Kanban has no edges. Server Edition is the same renderer and
the same code path. Mobile: N/A (the transport carries no canvas edges).

## Verification

- `npm run typecheck` — clean.
- `npx vitest run` — **749 files passed / 2 skipped, 10220 tests passed / 40 skipped**, whole suite
  green.
- `npm run build && npm run server:build` — both clean.
- Visual smoke on a scratch Server Edition (headless Chromium, private `NODETERM_DATA_DIR`), three
  claude nodes A / B armed after A / C armed after B, with **B placed LEFT of A** and only the A→B
  rope seeded:
  - exactly **2** edges in the DOM, both `react-flow__edge-floating`, both dashed `6, 4` with the
    `⏳ waits for` label in the claude clay colour `rgb(217, 119, 87)`;
  - the A→B path starts at **(550, 218)** = A's left border and ends at **(286, 218)** = B's right
    border (A x 550–808, B x 28–286, both centred at y 218) — one edge, the short way round, no loop;
  - `ctrl-B-C` was **not** in the seed and was created at project load by `missingDepRopes`;
  - after POSTing A's `UserPromptSubmit` + `Stop` hooks the A→B rope went **solid** (no dash, no
    label) while B→C stayed dashed, and B's pane printed `FIRED-B-0303`; C fired nothing;
  - clicking A's eye removed `ctrl-A-B` from the DOM and left `ctrl-B-C` alone; clicking again
    restored it.

## Device checklist (spec §6 — Mac desktop, owed)

1. `open-claude --after` shows one dashed rope from the dep, solid after it fires.
2. No blue bridge between opener and opened.
3. A hand-drawn drag still makes a blue ⇄ context edge.
4. Edges to nodes left of / above their source take the short path.
5. The eye hides cards + edges, and restores both.
6. Deleting a dashed rope disarms only that dep (and leaves the covered bridge).

Items 1, 4, 5 and part of 6 are covered by the headless smoke above; the rest need a real desktop
canvas with a live agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011im3HS5ZhCaJGNMd8gNMbP
