### PR TITLE
fix(canvas): undo heals dep ropes; edges anchor on side midpoints, context links on the bridge handles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -928,8 +928,10 @@ session.
 - **trigger** (`TriggerNode.tsx`) — a canvas-owned schedule (cron / interval / once) that
   delivers a payload into a connected terminal/agent node when due (issue #493 — the inverse of
   the ephemeral loop/cron cards, which visualize AGENT-initiated recurrence). The card shows the
-  schedule + next-run countdown, the target (a derived, never-persisted edge — same rule as the
-  pending-launch dep edges), the payload, an honest ARMED/DISARMED/CHANGED/SET-UP chip with the
+  schedule + next-run countdown, the target (a derived, never-persisted edge — the
+  pending-launch dep edge is NO longer one: since the 2026-09-02 edge model it is a persisted rope,
+  `ctrl-<dep>-<node>`, whose dashed ⏳ LOOK is what is derived), the payload, an honest
+  ARMED/DISARMED/CHANGED/SET-UP chip with the
   "definitions travel with the repo, consent never does" narrative, Run-now, and the last runs
   (fired / delivered-late / queued / missed / failed / expired). Arming passes a ConfirmDialog
   showing the exact schedule+payload+target being consented to; all decisions are the pure,
@@ -2444,6 +2446,9 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   connections") hides its subagent/loop cards AND every edge touching that node — display only:
   the links still authorise reads and an `--after` still waits. See the `--after` bullet under
   Canvas control for the rope model the eye hides.
+  **Surfaces:** Desktop + Server Edition are identical (pure renderer + React Flow internals — no
+  new IPC or bridge member); the kanban board is N/A (it shows cards, never edges); mobile is N/A
+  (the transport protocol carries no edges).
 - **Undo/redo**: debounced snapshot of the nodes array on settle (drag/edit), `pastRef`/
   `futureRef` stacks, ⌘Z / ⌘⇧Z + dock buttons. History resets per project load; skipped
   while typing in inputs/terminals.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1624,8 +1624,10 @@ else, and its context links must keep classifying across restarts).
   node that has none at **project load**: `pendingLaunch` is persisted and the rope is not, so a node
   armed by any other path — or by a build older than this one — would otherwise hold a launch with
   no arrow saying what for. All edges route through the single `floating` edge type
-  (`canvas/FloatingEdge.tsx`, a bezier between the nearest borders of the two node rectangles; an
-  unmeasured node draws nothing rather than a path to the origin) — no family sets a handle side;
+  (`canvas/FloatingEdge.tsx`, a bezier between the MIDPOINTS of the two nodes' facing sides — one
+  anchor per side, so a hub's arrows converge instead of fanning along its border; context and note
+  links are restricted to the left/right sides, where the bridge handles sit; an unmeasured node
+  draws nothing rather than a path to the origin) — no family sets a handle side;
   and a node whose eye is closed (`hideFanout`) hides every edge touching it as well as its cards
   (2026-09-02 edge model, spec in docs/superpowers/specs).
   **(7) Delivery waits for the node's PTY, and never fails silently** (issue #569 item 1, 2026-09).
@@ -2440,9 +2442,12 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
 - **Add menu** = bottom dock (`Dock.tsx`) `+`, mirrored by the pane menu and command palette.
 - **Edges** are all one React Flow type, `floating` (`canvas/FloatingEdge.tsx` over the pure
   `lib/floatingEdge.ts`): every family — ropes, context bridges, note links, subagent/loop card
-  edges, trigger edges — is drawn between the two nodes' nearest borders instead of fixed handle
-  sides, so an edge to a node placed left of or above its source takes the short way round rather
-  than looping across the canvas. A terminal node's **eye** (`hide-fanout`, "Hide cards &
+  edges, trigger edges — is drawn between the midpoints of the two nodes' facing sides instead of
+  fixed handle sides, so an edge to a node placed left of or above its source takes the short way
+  round rather than looping across the canvas, and every edge using a side meets the node at ONE
+  point (2026-09-03: enes's first try showed a hub with entries fanned along its whole top edge).
+  Context and note links are the exception in one respect: they anchor only on the left/right
+  sides (`data.anchor: 'horizontal'`), where the `link-out`/`link-in` drag handles are drawn. A terminal node's **eye** (`hide-fanout`, "Hide cards &
   connections") hides its subagent/loop cards AND every edge touching that node — display only:
   the links still authorise reads and an `--after` still waits. See the `--after` bullet under
   Canvas control for the rope model the eye hides.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -1972,6 +1972,9 @@ export function Canvas() {
       return {
         ...e,
         type: 'floating',
+        // Context and note links meet the node at its bridge handles (left/right dots) — the point
+        // the user dragged from — never at the top or bottom.
+        data: { anchor: 'horizontal' },
         label: sel ? `${baseLabel} — ⌫ to remove` : baseLabel,
         labelStyle: { fill: stroke, fontSize: 11, fontWeight: 600 },
         ...labelBg,
@@ -8592,7 +8595,7 @@ export function Canvas() {
 
   // A browser guest's new-window (target=_blank / window.open) request → open another browser node
   // (never a real popup; main denies the real one) roped below/right of the source. Reads the
-  // latest nodes via nodesRef so the deps stay []. Rope is display-only (controlEdges, not persisted).
+  // latest nodes via nodesRef so the deps stay []. Rope is display-only lineage (controlEdges, persisted as `ropes`).
   useEffect(() => {
     return window.nodeTerminal.browser.onBrowserNewWindow(({ url, sourceNodeId }) => {
       const src = nodesRef.current.find((n) => n.id === sourceNodeId)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -2989,9 +2989,18 @@ export function Canvas() {
     committedRef.current = prev
     nodesRef.current = prev
     setNodes(prev)
+    // Ropes are not in the history stack (they live in `controlEdges`), but the arming a rope
+    // explains IS — `disarmDepsFor` writes both, and only the node write is snapshotted. So a step
+    // that re-arms a node would leave it waiting with no arrow saying what for until the next
+    // project load. Same pair-keyed, idempotent healer the load site uses: a step that re-arms
+    // nothing adds nothing, and a rope the step did not remove is never duplicated.
+    setControlEdges((es) => {
+      const add = missingDepRopes(prev, es)
+      return add.length ? [...es, ...add.map((r) => ropeEdge(r.id, r.source, r.target))] : es
+    })
     bumpDirty() // an undo is an edit: it must count toward the in-flight-save generation too
     bumpHist((v) => v + 1)
-  }, [setNodes, bumpDirty])
+  }, [setNodes, setControlEdges, bumpDirty])
 
   const redo = useCallback(() => {
     if (!futureRef.current.length) return
@@ -3000,9 +3009,18 @@ export function Canvas() {
     committedRef.current = next
     nodesRef.current = next
     setNodes(next)
+    // Ropes are not in the history stack (they live in `controlEdges`), but the arming a rope
+    // explains IS — `disarmDepsFor` writes both, and only the node write is snapshotted. So a step
+    // that re-arms a node would leave it waiting with no arrow saying what for until the next
+    // project load. Same pair-keyed, idempotent healer the load site uses: a step that re-arms
+    // nothing adds nothing, and a rope the step did not remove is never duplicated.
+    setControlEdges((es) => {
+      const add = missingDepRopes(next, es)
+      return add.length ? [...es, ...add.map((r) => ropeEdge(r.id, r.source, r.target))] : es
+    })
     bumpDirty() // a redo is an edit: same reasoning as undo
     bumpHist((v) => v + 1)
-  }, [setNodes, bumpDirty])
+  }, [setNodes, setControlEdges, bumpDirty])
 
   // ---- canvas interactions ----
 

--- a/src/renderer/canvas/FloatingEdge.tsx
+++ b/src/renderer/canvas/FloatingEdge.tsx
@@ -1,10 +1,11 @@
 // The canvas's ONE edge type. Reads both nodes' absolute rectangles from React Flow's internals
-// (so nodes inside group frames resolve correctly) and draws a bezier between their nearest
-// borders — see lib/floatingEdge.ts. An UNMEASURED node draws nothing this frame: React Flow's
+// (so nodes inside group frames resolve correctly) and draws a bezier between the midpoints of
+// their facing sides — see lib/floatingEdge.ts. `data.anchor === 'horizontal'` (context and note
+// links) restricts both ends to the left/right sides, where the bridge handles are drawn. An UNMEASURED node draws nothing this frame: React Flow's
 // internals report a 0×0 rectangle for the first tick after mount, and a path drawn from it would
 // point at the node's top-left corner, or at the origin.
 import { BaseEdge, getBezierPath, useInternalNode, type EdgeProps } from '@xyflow/react'
-import { floatingEdgeParams, type Rect } from '../lib/floatingEdge'
+import { floatingEdgeParams, type AnchorSides, type Rect } from '../lib/floatingEdge'
 
 function rectOf(n: ReturnType<typeof useInternalNode>): Rect | null {
   if (!n) return null
@@ -33,7 +34,8 @@ export function FloatingEdge(props: EdgeProps) {
   const a = rectOf(useInternalNode(source))
   const b = rectOf(useInternalNode(target))
   if (!a || !b) return null
-  const p = floatingEdgeParams(a, b)
+  const anchor = (props.data as { anchor?: AnchorSides } | undefined)?.anchor
+  const p = floatingEdgeParams(a, b, anchor === 'horizontal' ? 'horizontal' : 'all')
   const [path, labelX, labelY] = getBezierPath({
     sourceX: p.sx,
     sourceY: p.sy,

--- a/src/renderer/canvas/edge-model.source.test.ts
+++ b/src/renderer/canvas/edge-model.source.test.ts
@@ -53,4 +53,31 @@ describe('canvas edge model (source pins)', () => {
   it('an armed node with no dep rope heals at project load, not only where --after ran', () => {
     expect(src).toContain('missingDepRopes(')
   })
+
+  it('undo and redo heal the dep ropes their own history step cannot restore', () => {
+    // Deleting a waiting rope writes BOTH the node (disarmDepsFor — snapshotted into the undo
+    // stack) and the control edges (not snapshotted). So a ⌘Z that re-arms a node would otherwise
+    // leave it waiting with no arrow saying what for until the next project load. Same pair-keyed,
+    // idempotent healer the load site uses: a history step that changes nothing adds nothing.
+    expect((src.match(/missingDepRopes\(/g) ?? []).length).toBe(3) // project load + undo + redo
+    const undoBody = src.slice(src.indexOf('const undo = useCallback'), src.indexOf('const redo = useCallback'))
+    const redoBody = src.slice(src.indexOf('const redo = useCallback'), src.indexOf('// ---- canvas interactions ----'))
+    expect(undoBody).toContain('missingDepRopes(prev, es)')
+    expect(redoBody).toContain('missingDepRopes(next, es)')
+  })
+
+  it('the composed edge labels are pinned — the sentence the user reads names what ⌫ does', () => {
+    expect(src).toContain('`${WAIT_LABEL} · ⌫ to stop waiting`')
+    expect(src).toContain("'⇄ context · ⌫ to remove'")
+    expect(src).toContain("'⌫ to remove'")
+  })
+
+  it("verify's panel arms through the same dep ropes, and --after dedupes its ids", () => {
+    // The two ruled deviations from `ropeDeps(ids, after)`: the reviewers wait on the target and
+    // the judge waits on the reviewers, both ids that exist only in that tick.
+    expect(src).toContain('ropeDeps([rid], [targetId])')
+    expect(src).toContain('ropeDeps([judge.id], reviewerIds)')
+    // `--after a,a` is one wait: two dep ropes for one pair would collide on one rope id.
+    expect(src).toContain("[...new Set((args.after ?? '').split(',').map((s) => s.trim()).filter(Boolean))]")
+  })
 })

--- a/src/renderer/canvas/edge-model.source.test.ts
+++ b/src/renderer/canvas/edge-model.source.test.ts
@@ -16,6 +16,12 @@ describe('canvas edge model (source pins)', () => {
     expect(src).not.toMatch(/targetHandle:\s*'/)
   })
 
+  it('context and note links anchor on the bridge handles (left/right), ropes on any side', () => {
+    expect(src).toContain("data: { anchor: 'horizontal' }")
+    // Exactly the one family: ropes and card edges keep the four-side choice.
+    expect((src.match(/anchor: 'horizontal'/g) ?? []).length).toBe(1)
+  })
+
   it('the separate "waits for" family is gone; the waiting look is the rope\'s, from the model', () => {
     expect(src).not.toContain('dependencyEdges')
     expect(src).not.toContain('depEdges')

--- a/src/renderer/lib/edgeModel.test.ts
+++ b/src/renderer/lib/edgeModel.test.ts
@@ -7,6 +7,7 @@ import {
   missingDepRopes,
   ropeInfoOf,
   ropeVisual,
+  WAIT_LABEL,
   type RopeNodeInfo
 } from './edgeModel'
 
@@ -14,6 +15,15 @@ const infoOf =
   (m: Record<string, RopeNodeInfo>) =>
   (id: string): RopeNodeInfo | undefined =>
     m[id]
+
+describe('WAIT_LABEL', () => {
+  it('is the one wording the waiting rope and its selected removal hint are both composed from', () => {
+    // Canvas renders it bare while the rope is idle and as `${WAIT_LABEL} · ⌫ to stop waiting`
+    // while it is selected, so the two sentences cannot drift apart (pinned in
+    // canvas/edge-model.source.test.ts).
+    expect(WAIT_LABEL).toBe('⏳ waits for')
+  })
+})
 
 describe('ropeVisual — one rope, its look derived from the target\'s pendingLaunch', () => {
   it('a rope whose target is still waiting on its source is WAITING', () => {

--- a/src/renderer/lib/floatingEdge.test.ts
+++ b/src/renderer/lib/floatingEdge.test.ts
@@ -17,12 +17,18 @@ describe('borderExit — where the centre-to-centre line leaves a rectangle', ()
   it('exits the TOP toward a point above', () => {
     expect(borderExit(box(0, 0), { x: 50, y: -500 })).toEqual({ x: 50, y: 0, position: Position.Top })
   })
-  it('a diagonal target exits the side the line actually crosses (wide box → left/right)', () => {
-    // centre (50,25); toward (250,125): dx=200, dy=100 → |dx|/w=4 > |dy|/h=4? equal → right wins.
+  it('a diagonal target picks the side the centre line crosses (|dx|/hw vs |dy|/hh; tie → left/right)', () => {
+    // centre (50,25); toward (250,125): dx=200, dy=100 → |dx|·hh = |dy|·hw → right wins.
     const e = borderExit(box(0, 0), { x: 250, y: 125 })
     expect(e.position).toBe(Position.Right)
-    expect(e.x).toBe(100)
-    expect(e.y).toBeCloseTo(50)
+    // The point is the side's MIDPOINT, not the crossing: every edge leaving a side leaves from
+    // one place, so arrows converge instead of fanning along the border.
+    expect({ x: e.x, y: e.y }).toEqual({ x: 100, y: 25 })
+  })
+  it('restricted to the horizontal sides (context links use the left/right bridge handles), a target above still exits left or right', () => {
+    expect(borderExit(box(0, 0), { x: 50, y: -500 }, 'horizontal')).toEqual({ x: 100, y: 25, position: Position.Right })
+    expect(borderExit(box(0, 0), { x: -300, y: -500 }, 'horizontal')).toEqual({ x: 0, y: 25, position: Position.Left })
+    expect(borderExit(box(0, 0), { x: 300, y: 500 }, 'horizontal')).toEqual({ x: 100, y: 25, position: Position.Right })
   })
   it('a coincident centre (overlapping nodes) degrades to the right side, never NaN', () => {
     const e = borderExit(box(0, 0), { x: 50, y: 25 })
@@ -48,8 +54,12 @@ describe('floatingEdgeParams — both ends, facing each other', () => {
     const p = floatingEdgeParams(box(1000, 1000), box(0, 0))
     expect([Position.Left, Position.Top]).toContain(p.sourcePosition)
     expect([Position.Right, Position.Bottom]).toContain(p.targetPosition)
-    // The exact point, not just the side: the vertical branch interpolates x by HALF THE HEIGHT
-    // over |dy|, and a swapped half-extent still lands on the right side while missing the corner.
-    expect({ x: p.sx, y: p.sy }).toEqual({ x: 1025, y: 1000 })
+    // The exact point is the TOP side's midpoint (the centre line crosses the top: |dy|·hw > |dx|·hh).
+    expect({ x: p.sx, y: p.sy }).toEqual({ x: 1050, y: 1000 })
+    expect({ x: p.tx, y: p.ty }).toEqual({ x: 50, y: 50 })
+  })
+  it('horizontal-only params: a node ABOVE another still connects right → left at the handle heights', () => {
+    const p = floatingEdgeParams(box(0, 0), box(0, 300), 'horizontal')
+    expect(p).toEqual({ sx: 100, sy: 25, sourcePosition: Position.Right, tx: 100, ty: 325, targetPosition: Position.Right })
   })
 })

--- a/src/renderer/lib/floatingEdge.ts
+++ b/src/renderer/lib/floatingEdge.ts
@@ -1,8 +1,14 @@
-// Pure geometry for the canvas's one edge type. An edge is drawn between the two points where the
-// centre-to-centre line leaves each node's rectangle, so it always takes the short way round — the
-// fixed-side handles it replaces sent an edge to a node placed left of (or above) its source on a
-// loop across the whole canvas, with its label drifting into empty space.
+// Pure geometry for the canvas's one edge type. An edge leaves each node from the MIDPOINT of the
+// side its centre-to-centre line crosses, so it always takes the short way round — the fixed-side
+// handles it replaces sent an edge to a node placed left of (or above) its source on a loop across
+// the whole canvas — and every edge using a side leaves from ONE point, so arrows converge instead
+// of fanning out along the border (measured on a hub node with a dozen ropes: entries were spread
+// across the whole top edge). Context links are restricted to the left/right sides: those are where
+// the drag handles (`link-out` / `link-in`) sit, and the edge should meet the dot the user dragged.
 import { Position } from '@xyflow/react'
+
+/** Which sides an edge may leave from: every side, or only left/right (the bridge handles). */
+export type AnchorSides = 'all' | 'horizontal'
 
 export interface Rect {
   x: number
@@ -18,11 +24,17 @@ export interface EdgeEnd {
 }
 
 /**
- * The point on `from`'s border where the line from its centre toward `toward` exits, and the side
- * it exits on. A degenerate rectangle (unmeasured) or a coincident centre answers deterministically
- * (its own point, `Right`) — never NaN, so a path is always drawable.
+ * The MIDPOINT of the side of `from` that the line from its centre toward `toward` crosses, and
+ * that side. `sides: 'horizontal'` restricts the choice to left/right (a target above or below
+ * still leaves from a side, picked by the sign of dx). A degenerate rectangle (unmeasured) or a
+ * coincident centre answers deterministically (its own point, `Right`) — never NaN, so a path is
+ * always drawable.
  */
-export function borderExit(from: Rect, toward: { x: number; y: number }): EdgeEnd {
+export function borderExit(
+  from: Rect,
+  toward: { x: number; y: number },
+  sides: AnchorSides = 'all'
+): EdgeEnd {
   const hw = from.width / 2
   const hh = from.height / 2
   const cx = from.x + hw
@@ -30,14 +42,12 @@ export function borderExit(from: Rect, toward: { x: number; y: number }): EdgeEn
   if (!(hw > 0) || !(hh > 0)) return { x: from.x, y: from.y, position: Position.Right }
   const dx = toward.x - cx
   const dy = toward.y - cy
-  if (dx === 0 && dy === 0) return { x: cx + hw, y: cy, position: Position.Right }
+  const right = { x: cx + hw, y: cy, position: Position.Right }
+  const left = { x: cx - hw, y: cy, position: Position.Left }
+  if (dx === 0 && dy === 0) return right
   // Compare the slopes against the corner: |dx|/hw vs |dy|/hh decides which side the line crosses.
-  if (Math.abs(dx) * hh >= Math.abs(dy) * hw) {
-    const sx = dx >= 0 ? 1 : -1
-    return { x: cx + sx * hw, y: cy + dy * (hw / Math.abs(dx)), position: sx > 0 ? Position.Right : Position.Left }
-  }
-  const sy = dy >= 0 ? 1 : -1
-  return { x: cx + dx * (hh / Math.abs(dy)), y: cy + sy * hh, position: sy > 0 ? Position.Bottom : Position.Top }
+  if (sides === 'horizontal' || Math.abs(dx) * hh >= Math.abs(dy) * hw) return dx >= 0 ? right : left
+  return dy >= 0 ? { x: cx, y: cy + hh, position: Position.Bottom } : { x: cx, y: cy - hh, position: Position.Top }
 }
 
 export interface FloatingParams {
@@ -49,9 +59,9 @@ export interface FloatingParams {
   targetPosition: Position
 }
 
-export function floatingEdgeParams(a: Rect, b: Rect): FloatingParams {
+export function floatingEdgeParams(a: Rect, b: Rect, sides: AnchorSides = 'all'): FloatingParams {
   const centre = (r: Rect) => ({ x: r.x + r.width / 2, y: r.y + r.height / 2 })
-  const s = borderExit(a, centre(b))
-  const t = borderExit(b, centre(a))
+  const s = borderExit(a, centre(b), sides)
+  const t = borderExit(b, centre(a), sides)
   return { sx: s.x, sy: s.y, sourcePosition: s.position, tx: t.x, ty: t.y, targetPosition: t.position }
 }


### PR DESCRIPTION
## Summary

Follow-up to #650 (merged before its final-review fix wave landed). Two commits:

1. **Undo/redo heal the dep ropes** (`9f63113a`) — deleting a waiting rope writes node data (the dep leaves `pendingLaunch.after`) but the rope removal is not in the undo stack, so ⌘Z re-armed the node with no rope on screen until the next project load. Both history handlers now run the restored node array through `missingDepRopes` (pair-keyed, idempotent). Plus the cheap items the whole-branch review asked for: source pins for the composed rope labels, verify's dep ropes and the `--after` dedupe; the stale trigger-bullet cross-reference in CLAUDE.md inverted; the Edges bullet now states the three surfaces.

2. **Edges anchor on side midpoints; context links on the bridge handles** (`087ebc2d`) — enes's first try after #650: a hub's incoming arrows fanned along its whole top edge and an orange bundle entered its bottom at a dozen x positions. Every edge using a side now leaves from that side's MIDPOINT (at most four anchors per node), so arrows converge. Context and note links are restricted to the left/right sides (`data.anchor: 'horizontal'`) — where the `link-out`/`link-in` drag handles are drawn, so the edge meets the dot the user dragged from. Ropes and card/trigger edges keep the four-side choice, so nothing loops.

## Tests

- `lib/floatingEdge.test.ts`: midpoint expectations + horizontal-only cases (4 red → green).
- `canvas/edge-model.source.test.ts`: heal in undo/redo (count pin), label literals, verify `ropeDeps`, dedupe, `anchor: 'horizontal'` exactly once.
- `npm run typecheck` clean; full vitest 749 files / 10227 tests green.

## Device checklist (Mac)

1. A hub with several ropes from below: all enter at the hub's bottom-centre, one point.
2. A context link between two nodes stacked vertically: leaves/enters at the left or right dots, never top/bottom.
3. Delete a dashed (waiting) rope, ⌘Z: the rope is back and dashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011im3HS5ZhCaJGNMd8gNMbP
