### PR TITLE
Add AGY, Pi, and Goose agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ then **Send** (nothing auto-submits). Your voice never leaves the machine.
 ### Node kinds
 
 🖥 **Terminal** (xterm + tmux, AI naming) · 🤖 **Agent** (Claude Code / Codex / Gemini /
-GitHub Copilot / opencode / Grok / custom) · 📝 **Sticky note** (link to an agent as context) · 🗂 **Group**
+GitHub Copilot / opencode / Grok / AGY / Pi / Goose / custom) · 📝 **Sticky note** (link to an agent as context) · 🗂 **Group**
 (bind to a **git worktree** for agent-per-branch) · ✏️ **Editor** (Monaco, ⌘S) ·
 🔀 **Diff** · 🌐 **Web / Video**
 

--- a/src/core/agent-launch.test.ts
+++ b/src/core/agent-launch.test.ts
@@ -177,6 +177,23 @@ describe("prepareAgentLaunch logical argv", () => {
     });
   });
 
+  it("builds AGY, Pi, and Goose interactive launches", async () => {
+    await expect(
+      prepareAgentLaunch(start("agy", { prompt: "fix it" }), "posix", builtinContext("agy")),
+    ).resolves.toEqual({ command: "'agy' '--prompt-interactive' 'fix it'" });
+    await expect(
+      prepareAgentLaunch(start("pi", { prompt: "fix it" }), "posix", builtinContext("pi")),
+    ).resolves.toEqual({ command: "'pi' 'fix it'" });
+    await expect(
+      prepareAgentLaunch(start("goose"), "posix", builtinContext("goose")),
+    ).resolves.toEqual({ command: "'goose' 'session'" });
+    await expect(
+      prepareAgentLaunch(start("goose", { prompt: "fix it" }), "posix", builtinContext("goose")),
+    ).resolves.toEqual({
+      command: "'goose' 'run' '--interactive' '--text' 'fix it'",
+    });
+  });
+
   it("builds every builtin resume grammar and derives shared identity from trusted context", async () => {
     await expect(
       prepareAgentLaunch(

--- a/src/core/agent-launch.test.ts
+++ b/src/core/agent-launch.test.ts
@@ -249,6 +249,27 @@ describe("prepareAgentLaunch logical argv", () => {
     ).resolves.toEqual({ command: "'agent' '--prompt' ''" });
   });
 
+  it("preserves a Goose base harness through the trusted session-host path", async () => {
+    const custom = {
+      id: "custom:goose-wrap",
+      launchCmd: "goose-wrap",
+      promptInjectionMode: "argv",
+      baseAgent: "goose",
+    } as const;
+    await expect(
+      prepareAgentLaunch(start(custom.id), "posix", customContext(custom)),
+    ).resolves.toEqual({ command: "'goose-wrap' 'session'" });
+    await expect(
+      prepareAgentLaunch(
+        start(custom.id, { prompt: "fix it" }),
+        "posix",
+        customContext(custom),
+      ),
+    ).resolves.toEqual({
+      command: "'goose-wrap' 'run' '--interactive' '--text' 'fix it'",
+    });
+  });
+
   it.each(["posix", "pwsh", "windows-powershell", "cmd"] as const)(
     "rejects custom stdin-after-start under %s without a trusted child-readiness handshake",
     async (dialect) => {

--- a/src/core/agent-launch.ts
+++ b/src/core/agent-launch.ts
@@ -93,7 +93,10 @@ interface LogicalAgentLaunch {
 interface ResolvedAgentConfig {
   id: AgentId;
   launchCmd: string;
+  launchArgs?: readonly string[];
+  promptLaunchArgs?: readonly string[];
   promptInjectionMode: PromptInjectionMode;
+  promptFlag?: string;
   argvPromptSeparator?: string;
   builtin: boolean;
 }
@@ -209,7 +212,10 @@ function isBuiltinAgentId(id: AgentId): id is BuiltinAgentId {
 
 function validPromptMode(value: unknown): value is PromptInjectionMode {
   return (
-    value === "argv" || value === "flag-prompt" || value === "stdin-after-start"
+    value === "argv" ||
+    value === "flag-prompt" ||
+    value === "flag-interactive" ||
+    value === "stdin-after-start"
   );
 }
 
@@ -222,7 +228,10 @@ function resolveTrustedAgentConfig(
     return {
       id: intent.agentId,
       launchCmd: config.launchCmd,
+      launchArgs: config.launchArgs,
+      promptLaunchArgs: config.promptLaunchArgs,
       promptInjectionMode: config.promptInjectionMode,
+      promptFlag: config.promptFlag,
       argvPromptSeparator: config.argvPromptSeparator,
       builtin: true,
     };
@@ -331,7 +340,11 @@ function logicalLaunch(
 ): LogicalAgentLaunch {
   const parsed = parseTrustedLaunchCommand(config.launchCmd);
   let executable = parsed[0];
-  const baseArgs = parsed.slice(1);
+  const harnessArgs =
+    intent.action === "start" && Object.hasOwn(intent, "prompt")
+      ? config.promptLaunchArgs ?? config.launchArgs ?? []
+      : config.launchArgs ?? [];
+  const baseArgs = [...parsed.slice(1), ...harnessArgs];
   if (config.builtin)
     executable = agentLaunchProgram(
       config.id,
@@ -379,12 +392,14 @@ function logicalLaunch(
     };
   }
 
-  if (promptInjectionMode === "flag-prompt") {
+  if (promptInjectionMode === "flag-prompt" || promptInjectionMode === "flag-interactive") {
+    const promptFlag = config.promptFlag ??
+      (promptInjectionMode === "flag-interactive" ? "--interactive" : "--prompt");
     return {
       executable,
       args: [
         ...baseArgs,
-        ...(hasPrompt ? ["--prompt", prompt as string] : []),
+        ...(hasPrompt ? [promptFlag, prompt as string] : []),
         ...modeFlags,
         ...sessionArgs,
       ],

--- a/src/core/agent-launch.ts
+++ b/src/core/agent-launch.ts
@@ -40,7 +40,7 @@ export type AgentLaunchExecutableKindResolver = (
 /** The one current custom-agent record selected from machine-local settings. */
 export type TrustedCustomAgentLaunchConfig = Pick<
   CustomAgent,
-  "id" | "launchCmd" | "promptInjectionMode"
+  "id" | "launchCmd" | "promptInjectionMode" | "baseAgent"
 >;
 
 /**
@@ -238,6 +238,8 @@ function resolveTrustedAgentConfig(
   }
 
   const custom = context.customAgent;
+  const base = custom?.baseAgent ? AGENT_CONFIG[custom.baseAgent] : undefined;
+  const promptInjectionMode = base?.promptInjectionMode ?? custom?.promptInjectionMode;
   if (
     !custom ||
     typeof custom.id !== "string" ||
@@ -245,14 +247,18 @@ function resolveTrustedAgentConfig(
     custom.id !== context.expectedAgentId ||
     !safeText(custom.launchCmd, MAX_LAUNCH_COMMAND_LENGTH) ||
     !custom.launchCmd.trim() ||
-    !validPromptMode(custom.promptInjectionMode)
+    !validPromptMode(promptInjectionMode)
   )
     fail("agent-unavailable");
 
   return {
     id: intent.agentId,
     launchCmd: custom.launchCmd,
-    promptInjectionMode: custom.promptInjectionMode,
+    launchArgs: base?.launchArgs,
+    promptLaunchArgs: base?.promptLaunchArgs,
+    promptInjectionMode,
+    promptFlag: base?.promptFlag,
+    argvPromptSeparator: base?.argvPromptSeparator,
     builtin: false,
   };
 }

--- a/src/core/context-link-core.ts
+++ b/src/core/context-link-core.ts
@@ -76,13 +76,13 @@ export function mergeInstructionsBlock(existing: string, block: string): string 
   return existing + sep + full + '\n'
 }
 
-/** The instructions body telling codex/gemini how to read linked-node context. */
+/** The instructions body telling agents without shared skill discovery how to read linked context. */
 export function buildLinkedContextInstructions(shimPath: string): string {
   return [
     '# Reading linked nodeterm nodes (get-linked-context)',
     '',
     'When you run inside a nodeterm canvas session, this node may be linked to other agent',
-    'nodes (Claude, Codex or Gemini) or sticky notes by a context-link edge. You can READ a',
+    'agent nodes or sticky notes by a context-link edge. You can READ a',
     "linked node's context on demand — nothing is pushed automatically:",
     '',
     '```sh',
@@ -325,13 +325,13 @@ export const CONTEXT_SHIM_SCRIPT = buildContextShimScript()
 export function buildContextLinkSkillBody(shimPath: string): string {
   return `---
 name: get-linked-context
-description: Read the conversation/transcript, a recent summary, or the terminal output of another agent node (Claude, Codex or Gemini) you are linked to on the nodeterm canvas. Use when you need to know what a connected node has been doing, hand off, or continue its work. Only meaningful inside a nodeterm session with a context-link edge. Also reads sticky notes linked to this node as context.
+description: Read the conversation transcript, a recent summary, or the terminal output of another agent node you are linked to on the nodeterm canvas. Use when you need to know what a connected node has been doing, hand off, or continue its work. Only meaningful inside a nodeterm session with a context-link edge. Also reads sticky notes linked to this node as context.
 ---
 
 # Get linked context
 
-On the nodeterm canvas, this Claude session may be connected to other agent nodes (Claude, Codex or Gemini) by a
-context-link edge. When you are linked, you can READ the other node's context on demand by
+On the nodeterm canvas, this agent session may be connected to other agent nodes by a context-link
+edge. When you are linked, you can READ the other node's context on demand by
 running the local CLI shim below. Nothing is pushed to you automatically — pull what you need.
 
 Run the shim (absolute path):

--- a/src/core/context-link.ts
+++ b/src/core/context-link.ts
@@ -55,14 +55,28 @@ export function contextLinkDir(): string {
 function cliShimPath(): string {
   return path.join(contextLinkDir(), 'context.sh')
 }
-function skillPaths(): string[] {
+function skillPaths(): Array<{ path: string; requiresParent?: string }> {
   const home = os.homedir()
   return [
-    path.join(home, '.claude', 'skills', 'get-linked-context', 'SKILL.md'),
-    // Shared Agent Skills path discovered by Pi and Goose.
-    path.join(home, '.agents', 'skills', 'get-linked-context', 'SKILL.md'),
+    { path: path.join(home, '.claude', 'skills', 'get-linked-context', 'SKILL.md') },
+    // Shared Agent Skills is intentionally visible to every tool that scans ~/.agents/skills.
+    // Do not create that third-party root: install only when a user/tool already owns it.
+    {
+      path: path.join(home, '.agents', 'skills', 'get-linked-context', 'SKILL.md'),
+      requiresParent: path.join(home, '.agents')
+    },
     // AGY CLI global skills path (distinct from Gemini CLI's ~/.gemini/skills).
-    path.join(home, '.gemini', 'antigravity-cli', 'skills', 'get-linked-context', 'SKILL.md')
+    {
+      path: path.join(
+        home,
+        '.gemini',
+        'antigravity-cli',
+        'skills',
+        'get-linked-context',
+        'SKILL.md'
+      ),
+      requiresParent: path.join(home, '.gemini', 'antigravity-cli')
+    }
   ]
 }
 
@@ -86,12 +100,13 @@ function writeCliFiles(): void {
 
 function installSkill(): void {
   const body = buildContextLinkSkillBody(cliShimPath())
-  for (const skillPath of skillPaths()) {
+  for (const target of skillPaths()) {
+    if (target.requiresParent && !fs.existsSync(target.requiresParent)) continue
     try {
-      fs.mkdirSync(path.dirname(skillPath), { recursive: true })
-      fs.writeFileSync(skillPath, body, 'utf8')
+      fs.mkdirSync(path.dirname(target.path), { recursive: true })
+      fs.writeFileSync(target.path, body, 'utf8')
     } catch (e) {
-      console.warn('[context-link] skill install failed', skillPath, e)
+      console.warn('[context-link] skill install failed', target.path, e)
     }
   }
 }

--- a/src/core/context-link.ts
+++ b/src/core/context-link.ts
@@ -4,10 +4,11 @@
 // renderer pushes the current link map to main (context-link:set-links); main builds one link
 // document per node (linked nodes' titles, transcript paths learned from hooks, cwds, tmux
 // session names) and answers reads over the hook server's /context-link/ route. A POSIX-sh shim
-// (context.sh) is the client; a globally-installed Claude skill (plus instruction blocks for the
-// agents that have no skill system) tells the agent how + when to call it. The local shim is built
-// with the shared-Codex thread resolver before its node-id gate; the SSH installer keeps the
-// machine-neutral body because this machine's ownership-record path is meaningless on the host.
+// (context.sh) is the client; globally-installed agent skills (plus instruction blocks for the
+// agents that do not scan the shared skill paths) tell the agent how + when to call it. The local
+// shim is built with the shared-Codex thread resolver before its node-id gate; the SSH installer
+// keeps the machine-neutral body because this machine's ownership-record path is meaningless on
+// the host.
 //
 // The reading and parsing happen HERE, on the desktop, not in the CLI. That is what lets an SSH
 // project's remote agent use the feature at all: its transcripts live on the host, reachable over
@@ -54,8 +55,15 @@ export function contextLinkDir(): string {
 function cliShimPath(): string {
   return path.join(contextLinkDir(), 'context.sh')
 }
-function skillPath(): string {
-  return path.join(os.homedir(), '.claude', 'skills', 'get-linked-context', 'SKILL.md')
+function skillPaths(): string[] {
+  const home = os.homedir()
+  return [
+    path.join(home, '.claude', 'skills', 'get-linked-context', 'SKILL.md'),
+    // Shared Agent Skills path discovered by Pi and Goose.
+    path.join(home, '.agents', 'skills', 'get-linked-context', 'SKILL.md'),
+    // AGY CLI global skills path (distinct from Gemini CLI's ~/.gemini/skills).
+    path.join(home, '.gemini', 'antigravity-cli', 'skills', 'get-linked-context', 'SKILL.md')
+  ]
 }
 
 function writeCliFiles(): void {
@@ -77,11 +85,14 @@ function writeCliFiles(): void {
 }
 
 function installSkill(): void {
-  try {
-    fs.mkdirSync(path.dirname(skillPath()), { recursive: true })
-    fs.writeFileSync(skillPath(), buildContextLinkSkillBody(cliShimPath()), 'utf8')
-  } catch (e) {
-    console.warn('[context-link] skill install failed', e)
+  const body = buildContextLinkSkillBody(cliShimPath())
+  for (const skillPath of skillPaths()) {
+    try {
+      fs.mkdirSync(path.dirname(skillPath), { recursive: true })
+      fs.writeFileSync(skillPath, body, 'utf8')
+    } catch (e) {
+      console.warn('[context-link] skill install failed', skillPath, e)
+    }
   }
 }
 

--- a/src/main/remote-ssh/remote-hooks.test.ts
+++ b/src/main/remote-ssh/remote-hooks.test.ts
@@ -625,7 +625,7 @@ describe('RemoteHooks.installCanvasControl', () => {
 describe('RemoteHooks.installContextLink', () => {
   const isWriteTo = (args: string[], p: string) => args.join(' ').includes('cat > ') && args.join(' ').includes(p)
 
-  it('writes an executable shim + the skill, and merges the instruction blocks', async () => {
+  it('writes an executable shim + every agent skill path, and merges the instruction blocks', async () => {
     const { rh, calls } = harness()
     await rh.installContextLink(conn, '/s.sock', '/home/u')
     const joined = calls.map((c) => c.args.join(' '))
@@ -640,6 +640,12 @@ describe('RemoteHooks.installContextLink', () => {
     const skill = calls.find((c) => isWriteTo(c.args, '/home/u/.claude/skills/get-linked-context/SKILL.md'))?.stdin ?? ''
     expect(skill).toContain('name: get-linked-context')
     expect(skill).toContain('sh "/home/u/.nodeterm/context.sh"')
+    expect(calls.some((c) => isWriteTo(c.args, '/home/u/.agents/skills/get-linked-context/SKILL.md'))).toBe(true)
+    expect(
+      calls.some((c) =>
+        isWriteTo(c.args, '/home/u/.gemini/antigravity-cli/skills/get-linked-context/SKILL.md')
+      )
+    ).toBe(true)
     expect(calls.some((c) => (c.stdin ?? '').includes('nodeterm:get-linked-context:start'))).toBe(true)
     expect(joined.some((j) => j.includes('~/'))).toBe(false)
   })

--- a/src/main/remote-ssh/remote-hooks.test.ts
+++ b/src/main/remote-ssh/remote-hooks.test.ts
@@ -626,7 +626,9 @@ describe('RemoteHooks.installContextLink', () => {
   const isWriteTo = (args: string[], p: string) => args.join(' ').includes('cat > ') && args.join(' ').includes(p)
 
   it('writes an executable shim + every agent skill path, and merges the instruction blocks', async () => {
-    const { rh, calls } = harness()
+    const { rh, calls } = harness({
+      responses: { "if [ -d '/home/u/.agents' ]": '0\n1\n' }
+    })
     await rh.installContextLink(conn, '/s.sock', '/home/u')
     const joined = calls.map((c) => c.args.join(' '))
     expect(joined.some((j) => j.includes("cat > '/home/u/.nodeterm/context.sh'") && j.includes('chmod 755'))).toBe(true)
@@ -648,6 +650,19 @@ describe('RemoteHooks.installContextLink', () => {
     ).toBe(true)
     expect(calls.some((c) => (c.stdin ?? '').includes('nodeterm:get-linked-context:start'))).toBe(true)
     expect(joined.some((j) => j.includes('~/'))).toBe(false)
+  })
+
+  it('does not create optional third-party skill roots that are absent', async () => {
+    const { rh, calls } = harness()
+    await rh.installContextLink(conn, '/s.sock', '/home/u')
+    expect(calls.some((c) => isWriteTo(c.args, '/home/u/.claude/skills/get-linked-context/SKILL.md'))).toBe(true)
+    expect(calls.some((c) => c.args.join(' ').includes("[ -d '/home/u/.agents' ]"))).toBe(true)
+    expect(calls.some((c) => isWriteTo(c.args, '/home/u/.agents/skills/get-linked-context/SKILL.md'))).toBe(false)
+    expect(
+      calls.some((c) =>
+        isWriteTo(c.args, '/home/u/.gemini/antigravity-cli/skills/get-linked-context/SKILL.md')
+      )
+    ).toBe(false)
   })
 
   it('leaves the canvas-control block in the same file alone', async () => {

--- a/src/main/remote-ssh/remote-hooks.ts
+++ b/src/main/remote-ssh/remote-hooks.ts
@@ -690,10 +690,20 @@ export class RemoteHooks {
       const shim = `${remoteHome}/.nodeterm/context.sh`
       await this.writeRemoteShim(conn, controlPath, shim, CONTEXT_SHIM_SCRIPT)
       const skillBody = buildContextLinkSkillBody(shim)
-      for (const configDir of [
-        `${remoteHome}/.claude`,
+      const optionalConfigDirs = [
+        // Shared Agent Skills is visible to every tool that scans ~/.agents/skills. Use it when
+        // the user or a tool already created the root, but do not claim that namespace ourselves.
         `${remoteHome}/.agents`,
         `${remoteHome}/.gemini/antigravity-cli`
+      ]
+      const presentConfigDirs = await this.existingRemoteDirectories(
+        conn,
+        controlPath,
+        optionalConfigDirs
+      )
+      for (const configDir of [
+        `${remoteHome}/.claude`,
+        ...optionalConfigDirs.filter((dir) => presentConfigDirs.has(dir))
       ]) {
         await this.writeRemoteSkill(conn, controlPath, configDir, 'get-linked-context', skillBody)
       }
@@ -760,6 +770,36 @@ export class RemoteHooks {
       childArgs(conn, controlPath, `mkdir -p ${posixQuote(dirnameOf(skill))} && cat > ${posixQuote(skill)}`),
       body
     )
+  }
+
+  /** Probe optional third-party config roots in one SSH round trip. A failed or malformed probe
+   *  returns none, so context-link setup keeps its own shim/Claude skill and creates no foreign
+   *  namespace by guess. */
+  private async existingRemoteDirectories(
+    conn: SshConnection,
+    controlPath: string,
+    directories: readonly string[]
+  ): Promise<Set<string>> {
+    if (!directories.length) return new Set()
+    try {
+      const command = directories
+        .map(
+          (directory, index) =>
+            `if [ -d ${posixQuote(directory)} ]; then printf '%s\\n' ${index}; fi`
+        )
+        .join('; ')
+      const { code, stdout } = await this.r.run(childArgs(conn, controlPath, command))
+      if (code !== 0) return new Set()
+      const indexes = new Set(
+        stdout
+          .split(/\r?\n/)
+          .filter((value) => /^\d+$/.test(value))
+          .map(Number)
+      )
+      return new Set(directories.filter((_, index) => indexes.has(index)))
+    } catch {
+      return new Set()
+    }
   }
 
   /** Read-merge-write one marker-delimited instructions block at a remote path EXPRESSION

--- a/src/main/remote-ssh/remote-hooks.ts
+++ b/src/main/remote-ssh/remote-hooks.ts
@@ -689,13 +689,14 @@ export class RemoteHooks {
     try {
       const shim = `${remoteHome}/.nodeterm/context.sh`
       await this.writeRemoteShim(conn, controlPath, shim, CONTEXT_SHIM_SCRIPT)
-      await this.writeRemoteSkill(
-        conn,
-        controlPath,
+      const skillBody = buildContextLinkSkillBody(shim)
+      for (const configDir of [
         `${remoteHome}/.claude`,
-        'get-linked-context',
-        buildContextLinkSkillBody(shim)
-      )
+        `${remoteHome}/.agents`,
+        `${remoteHome}/.gemini/antigravity-cli`
+      ]) {
+        await this.writeRemoteSkill(conn, controlPath, configDir, 'get-linked-context', skillBody)
+      }
       const block = buildLinkedContextInstructions(shim)
       // codex/gemini are plain quoted literals; opencode must stay shell-expandable and so
       // carries a prelude that binds the untrusted $HOME to a variable (see the helper).

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -453,7 +453,12 @@ import { uuid } from '../lib/uuid'
 import { planReopen, type ReopenPlan } from '../lib/reopenPlan'
 import { oneLine } from '@shared/one-line'
 import { invalidNodeColorMessage, isNodeColor } from '@shared/node-colors'
-import { parseLenses, verifyLensPrompt, verifySynthesisPrompt } from '../lib/verifyPanel'
+import {
+  parseLenses,
+  verifyAgentBlockReason,
+  verifyLensPrompt,
+  verifySynthesisPrompt
+} from '../lib/verifyPanel'
 import { useSettings } from '../state/settings'
 import { activePermissionMode, projectPermissionMode } from '../state/permissionMode'
 import { useContextWindow } from '../state/contextWindow'
@@ -3255,7 +3260,9 @@ export function Canvas() {
         (nodes.find((n) => n.id === id)?.data.title as string) || 'a linked node'
       if (kind === 'context') {
         // Discovery: tell each idle endpoint it is now linked (skip a node mid-turn so we
-        // don't interrupt it). Claude gets the skill pointer; codex/gemini get the CLI inline.
+        // don't interrupt it). Agents without hooks have no working state, so this user-triggered
+        // note may land mid-turn for them. Claude gets the skill pointer; other agents get the CLI
+        // inline.
         const note = async (selfId: string, otherId: string) => {
           if (status[selfId]?.state === 'working') return
           const { shimPath } = await window.nodeTerminal.contextLink.info()
@@ -10357,18 +10364,26 @@ export function Canvas() {
               return
             }
             const targetAgent = agentIdOf(targetId)
-            if (!targetAgent || !canContextLink(targetAgent)) {
+            const targetBlock = targetAgent ? verifyAgentBlockReason(targetAgent) : 'cannot-read'
+            if (targetBlock) {
               reply({
                 ok: false,
-                error: `verify: ${targetId} is not an agent session whose work can be read — the reviewers would have nothing to look at`
+                error:
+                  targetBlock === 'cannot-report-done'
+                    ? `verify: ${targetId} is not an agent session that reports when it is done`
+                    : `verify: ${targetId} is not an agent session whose work can be read — the reviewers would have nothing to look at`
               })
               return
             }
             const reviewAgent = ((args.agent as AgentId | undefined) || targetAgent) as AgentId
-            if (!canContextLink(reviewAgent)) {
+            const reviewerBlock = verifyAgentBlockReason(reviewAgent)
+            if (reviewerBlock) {
               reply({
                 ok: false,
-                error: `verify: --agent ${reviewAgent} cannot read linked context, so it cannot review anything`
+                error:
+                  reviewerBlock === 'cannot-report-done'
+                    ? `verify: --agent ${reviewAgent} does not report when it is done, so the panel cannot sequence its verdict`
+                    : `verify: --agent ${reviewAgent} cannot read linked context, so it cannot review anything`
               })
               return
             }

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -7343,6 +7343,9 @@ export function Canvas() {
       'node.newAgent.opencode': () => { addAgentNode('opencode'); return true },
       'node.newAgent.grok': () => { addAgentNode('grok'); return true },
       'node.newAgent.copilot': () => { addAgentNode('copilot'); return true },
+      'node.newAgent.agy': () => { addAgentNode('agy'); return true },
+      'node.newAgent.pi': () => { addAgentNode('pi'); return true },
+      'node.newAgent.goose': () => { addAgentNode('goose'); return true },
       'node.newSticky': () => { addSticky(); return true },
       'node.newBrowser': () => { addBrowser(); return true },
       // Opening the URL prompt IS claiming the chord — a cancelled prompt creates nothing, but the

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -430,7 +430,7 @@ import {
   reconnectRelayTab,
   type RelayTab,
 } from '../session/relay-tab'
-import { buildBackgroundLinkMaps, buildContextLinkNote, buildLinkMap, buildNotePushMessage, classifyLink, hiddenLinkIds, linkIdsCoveredByRopes, pairKey, planBridges, type LinkEndpoint } from '../lib/noteLink'
+import { buildBackgroundLinkMaps, buildContextLinkNote, buildLinkMap, buildNotePushMessage, classifyLink, contextLinkShimPath, hiddenLinkIds, linkIdsCoveredByRopes, pairKey, planBridges, type LinkEndpoint } from '../lib/noteLink'
 import {
   launchesToFire,
   launchRetryDelay,
@@ -3259,9 +3259,14 @@ export function Canvas() {
         const note = async (selfId: string, otherId: string) => {
           if (status[selfId]?.state === 'working') return
           const { shimPath } = await window.nodeTerminal.contextLink.info()
+          const self = nodesRef.current.find((n) => n.id === selfId)
+          const endpointShim = contextLinkShimPath(
+            shimPath,
+            isSshProject || isRemoteSessionNode(self?.data)
+          )
           void api.pty.sendText(
             selfId,
-            buildContextLinkNote(agentIdOf(selfId), titleOf(otherId), shimPath)
+            buildContextLinkNote(agentIdOf(selfId), titleOf(otherId), endpointShim)
           )
         }
         void note(source, target)
@@ -3281,7 +3286,7 @@ export function Canvas() {
       )
       if (msg) void api.pty.sendText(target, msg)
     },
-    [linkEndpointOf, agentIdOf, setLinkEdges, markDirty, nodes]
+    [linkEndpointOf, agentIdOf, setLinkEdges, markDirty, nodes, isSshProject]
   )
 
   // Of these ropes, the ones that are NOT live waits. A waiting rope's removal means "stop waiting

--- a/src/renderer/components/ShortcutsPanel.test.tsx
+++ b/src/renderer/components/ShortcutsPanel.test.tsx
@@ -54,7 +54,11 @@ function bindEverything(isMac: boolean): (id: CommandId) => readonly string[] {
   const pool = [
     ...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
     ...'0123456789'.split(''),
-    ...Array.from({ length: 12 }, (_, i) => `F${i + 1}`)
+    ...Array.from({ length: 12 }, (_, i) => `F${i + 1}`),
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight'
   ]
   expect(pool.length).toBeGreaterThanOrEqual(COMMAND_DEFINITIONS.length)
   const map = new Map<CommandId, string[]>()

--- a/src/renderer/components/settings/sections/CustomAgentsSection.tsx
+++ b/src/renderer/components/settings/sections/CustomAgentsSection.tsx
@@ -122,7 +122,7 @@ function AgentCard({
         label="Base harness"
         description={
           base
-            ? `Inherits ${base.label}'s hooks, resume, permission modes, and canvas control.`
+            ? `Inherits ${base.label}'s launch conventions and supported integrations.`
             : 'Optional: inherit a built-in harness’s integrations. Blank = a standalone CLI.'
         }
         control={

--- a/src/renderer/lib/noteLink.test.ts
+++ b/src/renderer/lib/noteLink.test.ts
@@ -5,6 +5,7 @@ import {
   buildLinkMap,
   buildNotePushMessage,
   classifyLink,
+  contextLinkShimPath,
   hiddenLinkIds,
   linkIdsCoveredByRopes,
   pairKey,
@@ -200,21 +201,31 @@ describe('buildLinkMap agent identity', () => {
 })
 
 describe('buildContextLinkNote', () => {
+  it('uses the host shim for a remote endpoint and the desktop shim locally', () => {
+    expect(contextLinkShimPath('/Applications/nodeterm/context.sh', false)).toBe(
+      '/Applications/nodeterm/context.sh'
+    )
+    expect(contextLinkShimPath('/Applications/nodeterm/context.sh', true)).toBe(
+      '$HOME/.nodeterm/context.sh'
+    )
+  })
   it('claude gets the skill wording', () => {
     const msg = buildContextLinkNote('claude', 'Builder', '/x/context.sh')
     expect(msg).toContain('[nodeterm] You are now linked to "Builder"')
     expect(msg).toContain('get-linked-context skill')
   })
-  it('codex/gemini get the inline CLI command, single line', () => {
-    const msg = buildContextLinkNote('codex', 'Builder', '/x/context.sh')
-    expect(msg).toContain('sh "/x/context.sh"')
-    expect(msg).toContain('Builder')
-    expect(msg).not.toContain('\n')
+  it('non-Claude agents get the inline CLI command, single line', () => {
+    for (const agent of ['codex', 'gemini', 'agy', 'pi', 'goose']) {
+      const msg = buildContextLinkNote(agent, 'Builder', '/x/context.sh')
+      expect(msg, agent).toContain('sh "/x/context.sh"')
+      expect(msg, agent).toContain('Builder')
+      expect(msg, agent).not.toContain('\n')
+    }
   })
   it('every variant says the note is informational — no action now', () => {
     // The message is injected + submitted as a prompt, so an agent that reads it as a task
     // launches an unsolicited investigation (observed with gemini). It must self-defuse.
-    for (const agent of [undefined, 'claude', 'codex', 'gemini']) {
+    for (const agent of [undefined, 'claude', 'codex', 'gemini', 'agy', 'pi', 'goose']) {
       const msg = buildContextLinkNote(agent, 'Builder', '/x/context.sh')
       expect(msg, `agent=${agent}`).toMatch(/[Nn]o action/)
       expect(msg, `agent=${agent}`).not.toContain('\n')

--- a/src/renderer/lib/noteLink.ts
+++ b/src/renderer/lib/noteLink.ts
@@ -20,6 +20,11 @@ export {
   type SkippedBridge
 } from '@shared/canvas-link'
 
+/** The inline context command runs inside the endpoint node, so SSH nodes need the host path. */
+export function contextLinkShimPath(localPath: string, remote: boolean): string {
+  return remote ? '$HOME/.nodeterm/context.sh' : localPath
+}
+
 /** Order-independent key for an edge's endpoints (a↔b and b↔a are the same connection). */
 export function pairKey(a: string, b: string): string {
   return a < b ? `${a}\0${b}` : `${b}\0${a}`
@@ -88,7 +93,7 @@ export function buildNotePushMessage(title: string, text: string, agentId?: stri
 
 /**
  * The one-shot message injected into each endpoint when a context link is drawn.
- * Claude discovers the capability via its installed skill; codex/gemini get the CLI
+ * Claude discovers the capability via its installed skill; other agents get the CLI
  * inline (their global-instructions block may not be loaded mid-session). Single-line:
  * pty.sendText appends Enter.
  *

--- a/src/renderer/lib/verifyPanel.test.ts
+++ b/src/renderer/lib/verifyPanel.test.ts
@@ -3,9 +3,20 @@ import {
   DEFAULT_LENSES,
   MAX_LENSES,
   parseLenses,
+  verifyAgentBlockReason,
   verifyLensPrompt,
   verifySynthesisPrompt
 } from './verifyPanel'
+
+describe('verifyAgentBlockReason', () => {
+  it('requires both readable context and completion hooks', () => {
+    expect(verifyAgentBlockReason('claude')).toBeNull()
+    expect(verifyAgentBlockReason('agy')).toBe('cannot-report-done')
+    expect(verifyAgentBlockReason('pi')).toBe('cannot-report-done')
+    expect(verifyAgentBlockReason('goose')).toBe('cannot-report-done')
+    expect(verifyAgentBlockReason('custom:unknown')).toBe('cannot-read')
+  })
+})
 
 describe('parseLenses', () => {
   it('falls back to the default panel when nothing is given', () => {

--- a/src/renderer/lib/verifyPanel.ts
+++ b/src/renderer/lib/verifyPanel.ts
@@ -5,6 +5,17 @@
 //
 // Kept free of React/store imports so the lens table and the prompt wording are unit-testable.
 
+import { canContextLink, hasHooks, type AgentId } from '@shared/agents/config'
+
+/** Why an agent cannot participate in an automatically sequenced verification panel. */
+export function verifyAgentBlockReason(
+  agentId: AgentId
+): 'cannot-read' | 'cannot-report-done' | null {
+  if (!canContextLink(agentId)) return 'cannot-read'
+  if (!hasHooks(agentId)) return 'cannot-report-done'
+  return null
+}
+
 /** Lens id → what that reviewer is told to hunt for. */
 const LENS_BRIEFS: Record<string, string> = {
   correctness:

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -1078,4 +1078,14 @@ describe('createAgentNode prompt injection', () => {
     expect(createAgentNode('codex', 0, undefined, undefined, 'do X').data.initialCommand).toBe("codex 'do X'")
     expect(createAgentNode('gemini', 0, undefined, undefined, 'do X').data.initialCommand).toBe("gemini 'do X'")
   })
+  it('launches AGY, Pi, and Goose with their interactive prompt forms', () => {
+    expect(createAgentNode('agy', 0, undefined, undefined, 'do X').data.initialCommand).toBe(
+      "agy --prompt-interactive 'do X'"
+    )
+    expect(createAgentNode('pi', 0, undefined, undefined, 'do X').data.initialCommand).toBe("pi 'do X'")
+    expect(createAgentNode('goose', 0).data.initialCommand).toBe('goose session')
+    expect(createAgentNode('goose', 0, undefined, undefined, 'do X').data.initialCommand).toBe(
+      "goose run --interactive --text 'do X'"
+    )
+  })
 })

--- a/src/server/context-link.test.ts
+++ b/src/server/context-link.test.ts
@@ -197,6 +197,8 @@ describe('initServerContextLink', () => {
   // writing into $HOME" would be indistinguishable from "we can no longer write into $HOME".
   // Safe to assert for real: `home` is a per-test scratch dir this suite points HOME at.
   it('installs the discovery surface into the agent config dirs when asked to', async () => {
+    await fsPromises.mkdir(join(home, '.agents'), { recursive: true })
+    await fsPromises.mkdir(join(home, '.gemini', 'antigravity-cli'), { recursive: true })
     const { link, registered } = start({
       ptyManager: fakePty(),
       canvases: () => [],
@@ -212,6 +214,17 @@ describe('initServerContextLink', () => {
       ['.gemini', 'antigravity-cli', 'skills', 'get-linked-context', 'SKILL.md']
     ]
     for (const parts of relativePaths) expect(existsSync(join(home, ...parts)), parts.join('/')).toBe(true)
+    await link.stop()
+  })
+
+  it('does not create optional third-party skill roots', async () => {
+    const { link } = start({
+      ptyManager: fakePty(),
+      canvases: () => [],
+      installAgentIntegrations: true
+    })
+    expect(existsSync(join(home, '.agents'))).toBe(false)
+    expect(existsSync(join(home, '.gemini', 'antigravity-cli'))).toBe(false)
     await link.stop()
   })
 

--- a/src/server/context-link.test.ts
+++ b/src/server/context-link.test.ts
@@ -207,6 +207,11 @@ describe('initServerContextLink', () => {
     expect(readFileSync(join(home, '.codex', 'AGENTS.md'), 'utf8')).toContain(
       'nodeterm:get-linked-context'
     )
+    const relativePaths = [
+      ['.agents', 'skills', 'get-linked-context', 'SKILL.md'],
+      ['.gemini', 'antigravity-cli', 'skills', 'get-linked-context', 'SKILL.md']
+    ]
+    for (const parts of relativePaths) expect(existsSync(join(home, ...parts)), parts.join('/')).toBe(true)
     await link.stop()
   })
 

--- a/src/shared/agents/config.capabilities.test.ts
+++ b/src/shared/agents/config.capabilities.test.ts
@@ -28,10 +28,10 @@ import {
 } from './config'
 
 describe('CONTEXT_LINK_CAPABLE', () => {
-  it('all three builtin agents can context-link', () => {
-    expect(canContextLink('claude')).toBe(true)
-    expect(canContextLink('codex')).toBe(true)
-    expect(canContextLink('gemini')).toBe(true)
+  it('all integrated builtin agents can context-link', () => {
+    for (const id of ['claude', 'codex', 'gemini', 'opencode', 'grok', 'agy', 'pi', 'goose'] as const) {
+      expect(canContextLink(id), id).toBe(true)
+    }
   })
   it('custom agents cannot', () => {
     expect(canContextLink('custom:abc')).toBe(false)
@@ -137,7 +137,6 @@ describe('launch-only builtin agents', () => {
       for (const can of [
         hasHooks,
         canResume,
-        canContextLink,
         canControlCanvas,
         canSwitchModel,
         hasUsage,
@@ -149,6 +148,7 @@ describe('launch-only builtin agents', () => {
       ]) {
         expect(can(id), `${id}: ${can.name}`).toBe(false)
       }
+      expect(canContextLink(id), id).toBe(true)
     }
   })
 })

--- a/src/shared/agents/config.capabilities.test.ts
+++ b/src/shared/agents/config.capabilities.test.ts
@@ -105,6 +105,54 @@ describe('opencode capabilities', () => {
   })
 })
 
+describe('launch-only builtin agents', () => {
+  it('declares the measured AGY, Pi, and Goose launch grammars', () => {
+    expect(AGENT_CONFIG.agy).toMatchObject({
+      label: 'AGY',
+      launchCmd: 'agy',
+      promptInjectionMode: 'flag-interactive',
+      promptFlag: '--prompt-interactive',
+      expectedProcess: 'agy'
+    })
+    expect(AGENT_CONFIG.pi).toMatchObject({
+      label: 'Pi',
+      launchCmd: 'pi',
+      promptInjectionMode: 'argv',
+      expectedProcess: 'pi'
+    })
+    expect(AGENT_CONFIG.goose).toMatchObject({
+      label: 'Goose',
+      launchCmd: 'goose',
+      launchArgs: ['session'],
+      promptLaunchArgs: ['run', '--interactive'],
+      promptInjectionMode: 'flag-prompt',
+      promptFlag: '--text',
+      expectedProcess: 'goose'
+    })
+  })
+
+  it('does not advertise provider-specific capabilities that are not wired', () => {
+    for (const id of ['agy', 'pi', 'goose'] as const) {
+      expect(BUILTIN_AGENT_IDS).toContain(id)
+      for (const can of [
+        hasHooks,
+        canResume,
+        canContextLink,
+        canControlCanvas,
+        canSwitchModel,
+        hasUsage,
+        canChat,
+        canTransferFrom,
+        canRename,
+        canReadTitle,
+        hasPermissionMode
+      ]) {
+        expect(can(id), `${id}: ${can.name}`).toBe(false)
+      }
+    }
+  })
+})
+
 describe('createdAgentId', () => {
   it('reads data.agentId, with the legacy tags fallback', () => {
     expect(createdAgentId({ agentId: 'codex' })).toBe('codex')

--- a/src/shared/agents/config.ts
+++ b/src/shared/agents/config.ts
@@ -192,7 +192,21 @@ export const BRANCH_CAPABLE = ['claude'] as const
 // `~/.grok/config.toml`, and `GROK_CLAUDE_SKILLS_ENABLED=false`. Then the skill is undiscoverable
 // however this list reads, and the same `inspect` cell is what says so (`enabled:false`, a
 // non-default `source`) rather than leaving support to guess.
-export const CONTEXT_LINK_CAPABLE = ['claude', 'codex', 'gemini', 'opencode', 'grok'] as const
+// AGY, Pi and Goose all discover the get-linked-context skill installed by initContextLink:
+//  - AGY: ~/.gemini/antigravity-cli/skills (its documented global CLI skill directory)
+//  - Pi + Goose: ~/.agents/skills (the shared Agent Skills directory both CLIs scan)
+// The link notification also carries the exact shim command so an already-running session can use
+// a newly drawn edge without restarting to refresh skill discovery.
+export const CONTEXT_LINK_CAPABLE = [
+  'claude',
+  'codex',
+  'gemini',
+  'opencode',
+  'grok',
+  'agy',
+  'pi',
+  'goose'
+] as const
 // Agents whose per-node context meter we can fill. Each needs BOTH numbers: a used count and a
 // TRUSTWORTHY window.
 //  - claude: used from its transcript's assistant usage, window INFERRED from the model family

--- a/src/shared/agents/config.ts
+++ b/src/shared/agents/config.ts
@@ -2,7 +2,16 @@
 // Design: an open AgentId string, a declarative config record, and
 // capabilities expressed as const membership lists (not a capability object).
 
-export type BuiltinAgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'grok' | 'copilot'
+export type BuiltinAgentId =
+  | 'claude'
+  | 'codex'
+  | 'gemini'
+  | 'opencode'
+  | 'grok'
+  | 'copilot'
+  | 'agy'
+  | 'pi'
+  | 'goose'
 // Open type — custom agents are any string ('custom:<uuid>'). Never restrict the set.
 export type AgentId = BuiltinAgentId | (string & {})
 
@@ -16,7 +25,13 @@ export interface AgentConfig {
   label: string // menu + node title, e.g. 'Claude Code'
   color: string // node color
   launchCmd: string // base launch command
+  /** Arguments required for an interactive launch with no initial prompt. */
+  launchArgs?: readonly string[]
+  /** Arguments used instead of launchArgs when an initial prompt is present. */
+  promptLaunchArgs?: readonly string[]
   promptInjectionMode: PromptInjectionMode
+  /** Override the flag implied by flag-prompt / flag-interactive. */
+  promptFlag?: string
   /**
    * Put this between the command and an `argv` prompt — in practice `'--'`, and only for a CLI
    * whose grammar has BOTH a positional prompt and subcommands.
@@ -40,7 +55,10 @@ export const BUILTIN_AGENT_IDS: readonly BuiltinAgentId[] = [
   'gemini',
   'opencode',
   'grok',
-  'copilot'
+  'copilot',
+  'agy',
+  'pi',
+  'goose'
 ]
 
 export const AGENT_CONFIG: Record<BuiltinAgentId, AgentConfig> = {
@@ -96,6 +114,31 @@ export const AGENT_CONFIG: Record<BuiltinAgentId, AgentConfig> = {
     // 1.0.80 CLI's `--interactive <prompt>` starts the ordinary TUI and submits the prompt there.
     promptInjectionMode: 'flag-interactive',
     expectedProcess: 'copilot'
+  },
+  agy: {
+    label: 'AGY',
+    color: '#4285f4',
+    launchCmd: 'agy',
+    promptInjectionMode: 'flag-interactive',
+    promptFlag: '--prompt-interactive',
+    expectedProcess: 'agy'
+  },
+  pi: {
+    label: 'Pi',
+    color: '#f59e0b',
+    launchCmd: 'pi',
+    promptInjectionMode: 'argv',
+    expectedProcess: 'pi'
+  },
+  goose: {
+    label: 'Goose',
+    color: '#f1be49',
+    launchCmd: 'goose',
+    launchArgs: ['session'],
+    promptLaunchArgs: ['run', '--interactive'],
+    promptInjectionMode: 'flag-prompt',
+    promptFlag: '--text',
+    expectedProcess: 'goose'
   }
 }
 

--- a/src/shared/agents/custom-agent.ts
+++ b/src/shared/agents/custom-agent.ts
@@ -27,7 +27,10 @@ export interface EffectiveAgentConfig {
   label: string
   color: string
   launchCmd: string
+  launchArgs?: readonly string[]
+  promptLaunchArgs?: readonly string[]
   promptInjectionMode: PromptInjectionMode
+  promptFlag?: string
   argvPromptSeparator?: string
   expectedProcess?: string
   /** `true` for a custom agent (`CustomAgent`), `false` for a builtin. */
@@ -74,7 +77,10 @@ export function resolveAgentConfig(
     label: customAgent?.label || id,
     color,
     launchCmd,
+    launchArgs: base?.launchArgs,
+    promptLaunchArgs: base?.promptLaunchArgs,
     promptInjectionMode,
+    promptFlag: base?.promptFlag,
     argvPromptSeparator: base?.argvPromptSeparator,
     expectedProcess: base?.expectedProcess,
     custom: true,

--- a/src/shared/agents/launch.test.ts
+++ b/src/shared/agents/launch.test.ts
@@ -100,6 +100,51 @@ describe('assembleLaunchCommand — builtins (byte-identical to the historical p
       ).command
     ).toBe("copilot --interactive 'fix it' --session-id=abc-123")
   })
+  it('uses each new builtin\'s interactive launch grammar', () => {
+    expect(assembleLaunchCommand({ agentId: 'agy' }, ENV).command).toBe('agy')
+    expect(
+      assembleLaunchCommand({ agentId: 'agy', initialPrompt: 'fix it' }, ENV).command
+    ).toBe("agy --prompt-interactive 'fix it'")
+    expect(
+      assembleLaunchCommand({ agentId: 'pi', initialPrompt: 'fix it' }, ENV).command
+    ).toBe("pi 'fix it'")
+    expect(assembleLaunchCommand({ agentId: 'goose' }, ENV).command).toBe('goose session')
+    expect(
+      assembleLaunchCommand({ agentId: 'goose', initialPrompt: 'fix it' }, ENV).command
+    ).toBe("goose run --interactive --text 'fix it'")
+  })
+  it('keeps Goose subcommands when its executable is overridden or inherited', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'goose', launchCmdOverride: 'goose-wrap', initialPrompt: 'fix it' },
+        ENV
+      ).command
+    ).toBe("goose-wrap run --interactive --text 'fix it'")
+
+    const gooseProxy: CustomAgent = {
+      id: 'custom:goose',
+      label: 'Goose proxy',
+      launchCmd: 'goose-wrap',
+      baseAgent: 'goose'
+    }
+    expect(
+      assembleLaunchCommand({ agentId: gooseProxy.id, customAgent: gooseProxy }, ENV).command
+    ).toBe('goose-wrap session')
+    expect(
+      assembleLaunchCommand(
+        { agentId: gooseProxy.id, customAgent: gooseProxy, initialPrompt: 'fix it' },
+        ENV
+      ).command
+    ).toBe("goose-wrap run --interactive --text 'fix it'")
+
+    const inheritedGoose = { ...gooseProxy, id: 'custom:goose-default', launchCmd: '' }
+    expect(
+      assembleLaunchCommand(
+        { agentId: inheritedGoose.id, customAgent: inheritedGoose, initialPrompt: 'fix it' },
+        ENV
+      ).command
+    ).toBe("goose run --interactive --text 'fix it'")
+  })
   it('adds a safely quoted model override after the ordinary Claude launch flags', () => {
     expect(
       assembleLaunchCommand(

--- a/src/shared/agents/launch.test.ts
+++ b/src/shared/agents/launch.test.ts
@@ -255,6 +255,18 @@ describe('assembleResumeCommand', () => {
   it('falls back to the bare launch command when there is no session id', () => {
     expect(assembleResumeCommand({ agentId: 'claude' }, ENV).command).toBe('claude')
   })
+  it('keeps Goose interactive launch args on restart and wrapper inheritance', () => {
+    expect(assembleResumeCommand({ agentId: 'goose' }, ENV).command).toBe('goose session')
+    const proxy: CustomAgent = {
+      id: 'custom:goose',
+      label: 'Goose proxy',
+      launchCmd: 'goose-wrap',
+      baseAgent: 'goose'
+    }
+    expect(assembleResumeCommand({ agentId: proxy.id, customAgent: proxy }, ENV).command).toBe(
+      'goose-wrap session'
+    )
+  })
   it('a claude-base proxy resumes with its own binary + claude grammar + args', () => {
     setCustomAgentBaseResolver((id) => (id === 'custom:proxy' ? 'claude' : undefined))
     expect(

--- a/src/shared/agents/launch.ts
+++ b/src/shared/agents/launch.ts
@@ -181,7 +181,11 @@ export function assembleLaunchCommand(
     ? launchCmd
     : agentLaunchProgram(inputs.agentId, launchCmd, inputs.sharedIdentity)
   const { fragment: argsFragment, missing: m2 } = expandedArgs(inputs.customAgent?.args ?? '', env)
-  const baseCmd = argsFragment ? `${program} ${argsFragment}` : program
+  const harnessArgs = inputs.initialPrompt || inputs.promptFile
+    ? eff.promptLaunchArgs ?? eff.launchArgs ?? []
+    : eff.launchArgs ?? []
+  const harnessFragment = harnessArgs.map(shellQuoteIfNeeded).join(' ')
+  const baseCmd = [program, harnessFragment, argsFragment].filter(Boolean).join(' ')
 
   // The prompt becomes an ARGUMENT on a command line that is then typed into the pane
   // (`writeWhenShellReady` → `deliverCommand`, which echo-verifies the line before submitting).
@@ -204,9 +208,9 @@ export function assembleLaunchCommand(
   const sep = eff.argvPromptSeparator
   const promptFlag =
     eff.promptInjectionMode === 'flag-prompt'
-      ? '--prompt'
+      ? eff.promptFlag ?? '--prompt'
       : eff.promptInjectionMode === 'flag-interactive'
-        ? '--interactive'
+        ? eff.promptFlag ?? '--interactive'
         : null
   const isFlagPrompt = !!promptFlag
   const usesSep = !!promptArg && !!sep && !isFlagPrompt

--- a/src/shared/agents/launch.ts
+++ b/src/shared/agents/launch.ts
@@ -263,7 +263,12 @@ export function assembleResumeCommand(
   const baseCmd = argsFragment ? `${program} ${argsFragment}` : program
 
   const resumeBase = inputs.sessionId ? resumeCommandWith(baseCmd, capId, inputs.sessionId) : null
-  const base = resumeBase ?? baseCmd
+  // Non-resumable harnesses still need their ordinary interactive subcommand on restart/wake.
+  // Goose is the concrete case: its configured fresh-session contract is `goose session`, so a
+  // restored node must use the same grammar. A real resume command remains unchanged.
+  const harnessFragment = (eff.launchArgs ?? []).map(shellQuoteIfNeeded).join(' ')
+  const freshBase = [program, harnessFragment, argsFragment].filter(Boolean).join(' ')
+  const base = resumeBase ?? freshBase
   const withMode = inputs.permissionMode
     ? withPermissionMode(base, capId, inputs.permissionMode)
     : base

--- a/src/shared/agents/pane-owner-predicate.ts
+++ b/src/shared/agents/pane-owner-predicate.ts
@@ -64,7 +64,10 @@ export const AGENT_BINARIES: Record<string, readonly string[]> = {
   copilot: ['copilot'],
   gemini: ['gemini'],
   opencode: ['opencode'],
-  grok: ['grok']
+  grok: ['grok'],
+  agy: ['agy'],
+  pi: ['pi'],
+  goose: ['goose']
 }
 
 /**

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -125,6 +125,12 @@ describe('registry invariants', () => {
         darwin: [], other: [] },
       { id: 'node.newAgent.copilot', title: 'New GitHub Copilot node', group: 'Nodes',
         scope: 'canvas', darwin: [], other: [] },
+      { id: 'node.newAgent.agy', title: 'New AGY node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newAgent.pi', title: 'New Pi node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
+      { id: 'node.newAgent.goose', title: 'New Goose node', group: 'Nodes', scope: 'canvas',
+        darwin: [], other: [] },
       { id: 'node.newSticky', title: 'New sticky note', group: 'Nodes', scope: 'canvas',
         darwin: [], other: [] },
       { id: 'node.newBrowser', title: 'New browser node', group: 'Nodes', scope: 'canvas',
@@ -205,7 +211,7 @@ describe('registry invariants', () => {
       'node.newDino',
       'node.newFile'
     ]
-    expect(added).toHaveLength(11)
+    expect(added).toHaveLength(14)
     for (const id of added) {
       const d = COMMANDS_BY_ID.get(id as CommandId)
       expect(d, id).toBeDefined()

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -59,7 +59,7 @@ export type CommandId =
   | 'canvas.groupSelection'
   | 'node.newTerminal'
   | 'node.newAgent'
-  // Per-builtin-agent creates. The six ids are spelled STATICALLY (never derived from
+  // Per-builtin-agent creates. The ids are spelled STATICALLY (never derived from
   // BUILTIN_AGENT_IDS) so this union stays literal — `isCommandId`, the overrides map and the
   // handler table all depend on that.
   | 'node.newAgent.claude'
@@ -68,6 +68,9 @@ export type CommandId =
   | 'node.newAgent.opencode'
   | 'node.newAgent.grok'
   | 'node.newAgent.copilot'
+  | 'node.newAgent.agy'
+  | 'node.newAgent.pi'
+  | 'node.newAgent.goose'
   | 'node.newSticky'
   | 'node.newBrowser'
   | 'node.newWebView'
@@ -172,6 +175,12 @@ export const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
   { id: 'node.newAgent.grok', title: `New ${AGENT_CONFIG.grok.label} node`, group: 'Nodes',
     scope: 'canvas', defaultBindings: both() },
   { id: 'node.newAgent.copilot', title: `New ${AGENT_CONFIG.copilot.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newAgent.agy', title: `New ${AGENT_CONFIG.agy.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newAgent.pi', title: `New ${AGENT_CONFIG.pi.label} node`, group: 'Nodes',
+    scope: 'canvas', defaultBindings: both() },
+  { id: 'node.newAgent.goose', title: `New ${AGENT_CONFIG.goose.label} node`, group: 'Nodes',
     scope: 'canvas', defaultBindings: both() },
   { id: 'node.newSticky', title: 'New sticky note', group: 'Nodes', scope: 'canvas',
     defaultBindings: both() },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1703,7 +1703,7 @@ export const DEFAULT_SETTINGS: Settings = {
   claudeAccounts: [],
   codexAccounts: [],
   systemAccountLabel: '',
-  // All three builtin agents (Claude/Codex/Gemini) show in the Add menus out of the box.
+  // All builtin agents show in the Add menus out of the box.
   // Existing users keep whatever they've saved (their persisted disabledAgents overrides this).
   disabledAgents: [],
   hiddenUsageProviders: [],


### PR DESCRIPTION
## Summary

- add built-in AGY, Pi, and Goose agents across creation menus, settings, keybindings, process recognition, and custom-agent launch handling
- use each CLI's interactive launch contract: `agy --prompt-interactive`, positional Pi prompts, and Goose `session` / `run --interactive --text`
- enable linked context sharing for all three agents in local and SSH sessions
- install the `get-linked-context` skill into Claude-compatible, Agent Skills, and Antigravity skill directories
- preserve Goose launch arguments when restarting linked sessions and select the remote context shim for SSH nodes

## Validation

- 234 focused tests pass
- `npm run typecheck` passes
- `npm run build` passes
- production Electron build launched real AGY 1.1.24, Pi 0.84.4, and Goose 1.45.0 TUIs
- Pi loaded `get-linked-context`; Goose discovered it through `goose skills list`
- authenticated context shim listed linked AGY and Goose nodes and read their live terminal output
- live run recorded zero console errors and zero failed requests

Full local suite: 10,172 passed, 25 failed, 37 skipped. All 11 failing test files are unchanged by this branch; failures are existing macOS/environment-sensitive real-shell, socket-path, localStorage, account-environment, and platform-copy expectations.

## Scope

Context sharing uses the terminal-output fallback for AGY, Pi, and Goose. Structured transcript parsing for these CLIs is not included.
