### PR TITLE
Add a messaging default for new projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,8 +417,11 @@ project's nodes only.** The contract:
 
 ## Terminal session continuity (tmux)
 
-`src/core/pty-manager.ts` runs each terminal inside a persistent tmux session
-(`tmux new-session -A -D -s nt-<nodeId>`) on a dedicated socket (`-L node-terminal`) with
+`src/core/pty-manager.ts` runs each terminal inside a persistent tmux session on a dedicated socket
+(`-L node-terminal`). Ownership-sensitive local creates use a detached create-only command that
+returns the tmux generation, then attach a painter client; warm opens use attach-only. Each side
+recovers once if the session appears or disappears across the asynchronous probe. Other tmux paths
+still use attach-or-create where no ownership proof is minted. All paths use
 a generated config (`-f <userData>/tmux.conf`, so the user's `~/.tmux.conf` never
 interferes; status bar off, **mouse on**, 50k history, `set-clipboard on` + `terminal-features
 ",*:clipboard"`, and the copy-mode mouse bindings). Because the tmux *server* outlives the app,

--- a/src/core/agents/agent-message-decide.ts
+++ b/src/core/agents/agent-message-decide.ts
@@ -39,9 +39,9 @@ export type NotPermittedReason =
    *  the per-project grant cannot be attributed (PR #237 review I-1); its own word because the
    *  human's fix is de-duplicating ids, not moving nodes. See `agent-message-scope.ts`. */
   | 'ambiguous-target-node-id'
-  /** No RUNTIME proof of which project spawned the target pane: the ledger has no entry (never
-   *  spawned this run, or only re-attached after a restart), or its owner disagrees with the sole
-   *  store claimant (a project.json listing a pane it did not spawn). The store's node-set is
+  /** No proof of which project spawned the target pane: the ledger has neither a fresh-spawn fact
+   *  nor a valid generation-bound restart proof, or its owner disagrees with the sole store
+   *  claimant (a project.json listing a pane it did not spawn). The store's node-set is
    *  attacker-writable, so ownership is proven at spawn, not read from the file (PR #237 fix
    *  round 2 — the confused deputy driven end-to-end); unprovable ⇒ refuse. Not retryable: the
    *  pane must be freshly (re)spawned by its real owner before it can be messaged. */

--- a/src/core/agents/agent-messaging.ts
+++ b/src/core/agents/agent-messaging.ts
@@ -80,8 +80,9 @@ export interface AgentMessagingDeps {
    */
   messagingEnabled(projectId: string): boolean
   /**
-   * The project that PROVABLY spawned the target node's pane this run, or `undefined` when
-   * unproven (runtime ledger, `core/agents/pane-ownership.ts`). The delivery gate trusts THIS,
+   * The project that PROVABLY spawned the target node's pane, either this run or through a signed
+   * machine-local restart proof; `undefined` when unproven (`core/agents/pane-ownership.ts`). The
+   * delivery gate trusts THIS,
    * not the persisted store's node-set, to decide whose grant applies — the store is
    * attacker-writable (`project.json` lists any node id) and cannot tell a real owner from a
    * project that merely listed a live pane it never spawned (PR #237 fix round 2). Undefined ⇒
@@ -307,9 +308,10 @@ const NOT_PERMITTED_TEXT: Record<NotPermittedReason, string> = {
     'single project\'s messaging grant. De-duplicate the id (re-add the cloned folder to mint ' +
     'fresh ids) before messaging it.',
   'unproven-target-owner':
-    'the target pane\'s owning project cannot be proven at runtime (it was not freshly spawned in ' +
-    'this session, or its ownership is disputed), so a per-project messaging grant cannot be ' +
-    'applied to it. Re-open the target node so its owner is recorded, then try again.'
+    'the target pane\'s owning project cannot be proven (it may predate restart-safe ownership ' +
+    'proofs, use an unsupported persistence backend, or have disputed ownership), so a ' +
+    'per-project messaging grant cannot be applied to it. Restart the target terminal session ' +
+    'once — closing and reopening the card is not enough — then try again.'
 }
 
 /**
@@ -486,9 +488,9 @@ export async function runDelivery(
     // above resolved `projectId` from the persisted node-set, which is attacker-writable — a
     // hostile `project.json` can LIST a live pane's node id it never spawned, and when the real
     // owner is absent from the store that hostile project is the sole claimant. The ledger records
-    // who actually SPAWNED the pane this run; the grant is evaluated against THAT owner, and the
-    // store's `projectId` is only a cross-check. Unprovable — no ledger entry (restart / never
-    // spawned here), or the ledger owner disagrees with the sole store claimant — fails closed.
+    // who actually SPAWNED the pane or restores that fact from a signed machine-local proof; the
+    // grant is evaluated against THAT owner, and the store's `projectId` is only a cross-check.
+    // Missing proof, or disagreement with the sole store claimant, fails closed.
     const owner = projectId ? deps.paneOwnerProject(req.targetNodeId) : undefined
     if (!projectId || !owner || owner !== projectId) notPermitted = 'unproven-target-owner'
     else if (!deps.messagingEnabled(owner)) notPermitted = 'switch-off'

--- a/src/core/agents/pane-ownership-persistence.test.ts
+++ b/src/core/agents/pane-ownership-persistence.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { fakePlatform } from '../platform-fake'
+import { initPlatform, resetPlatformForTests } from '../platform'
+import {
+  forgetPersistedPaneOwner,
+  paneOwnerProject,
+  persistPaneOwner,
+  resetPaneOwnershipForTests,
+  restorePaneOwner
+} from './pane-ownership'
+
+const SECRET = Buffer.alloc(32, 7)
+const GENERATION = '101|$1|1700000000|%2|202'
+let dir = ''
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nodeterm-pane-owner-'))
+  resetPlatformForTests()
+  initPlatform(fakePlatform({ userDataDir: dir }))
+  resetPaneOwnershipForTests()
+})
+
+afterEach(() => {
+  resetPaneOwnershipForTests()
+  resetPlatformForTests()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('restart-stable pane ownership', () => {
+  it('restores a signed owner after the in-memory ledger is cleared', () => {
+    expect(persistPaneOwner('node-1', 'project-1', GENERATION, SECRET)).toBe(true)
+    resetPaneOwnershipForTests()
+    expect(restorePaneOwner('node-1', 'project-1', GENERATION, SECRET)).toBe(true)
+    expect(paneOwnerProject('node-1')).toBe('project-1')
+  })
+
+  it('refuses another project, another installation, and a tampered record', () => {
+    expect(persistPaneOwner('node-1', 'project-1', GENERATION, SECRET)).toBe(true)
+    resetPaneOwnershipForTests()
+    expect(restorePaneOwner('node-1', 'project-2', GENERATION, SECRET)).toBe(false)
+    expect(restorePaneOwner('node-1', 'project-1', GENERATION, Buffer.alloc(32, 8))).toBe(false)
+    expect(restorePaneOwner('node-1', 'project-1', '102|$1|1700000000|%2|202', SECRET)).toBe(
+      false
+    )
+
+    const [file] = fs.readdirSync(path.join(dir, 'pane-owners'))
+    const full = path.join(dir, 'pane-owners', file)
+    const stored = JSON.parse(fs.readFileSync(full, 'utf8')) as { projectId: string }
+    fs.writeFileSync(full, JSON.stringify({ ...stored, projectId: 'project-2' }))
+    expect(restorePaneOwner('node-1', 'project-2', GENERATION, SECRET)).toBe(false)
+    expect(paneOwnerProject('node-1')).toBeUndefined()
+  })
+
+  it('forgets the proof when the pane is deleted or recycled', () => {
+    expect(persistPaneOwner('node-1', 'project-1', GENERATION, SECRET)).toBe(true)
+    forgetPersistedPaneOwner('node-1')
+    expect(restorePaneOwner('node-1', 'project-1', GENERATION, SECRET)).toBe(false)
+  })
+
+  it('fails closed on unsafe ids or a missing secret', () => {
+    expect(persistPaneOwner('../node', 'project-1', GENERATION, SECRET)).toBe(false)
+    expect(persistPaneOwner('node-1', '../project', GENERATION, SECRET)).toBe(false)
+    expect(persistPaneOwner('node-1', 'project-1', undefined, SECRET)).toBe(false)
+    expect(persistPaneOwner('node-1', 'project-1', GENERATION, null)).toBe(false)
+    expect(restorePaneOwner('node-1', 'project-1', GENERATION, null)).toBe(false)
+  })
+})

--- a/src/core/agents/pane-ownership.test.ts
+++ b/src/core/agents/pane-ownership.test.ts
@@ -15,9 +15,8 @@ describe('pane-ownership ledger', () => {
     expect(paneOwnerProject('n1')).toBe('proj-a')
   })
 
-  it('an unrecorded node is UNPROVEN (undefined) — the fail-closed default after a restart', () => {
-    // The whole cold-state contract: nothing recorded ⇒ the delivery gate must refuse. This is the
-    // state every node is in immediately after an app restart (re-attach records nothing).
+  it('an unrecorded node is UNPROVEN (undefined) — the fail-closed default without a proof', () => {
+    // The whole cold-state contract: no fresh-spawn fact or valid restart proof ⇒ refuse.
     expect(paneOwnerProject('never-spawned')).toBeUndefined()
   })
 

--- a/src/core/agents/pane-ownership.ts
+++ b/src/core/agents/pane-ownership.ts
@@ -26,7 +26,9 @@
  * this installation's node-auth secret. The project file cannot forge that proof, a replacement
  * pane cannot inherit it, and a copied data file cannot verify on another installation. Missing,
  * stale or malformed proof stays UNPROVEN and fails closed. We never infer ownership from
- * project.json or from a tmux environment variable that a pane can rewrite.
+ * project.json or from a tmux environment variable that a pane can rewrite. The local caller gets
+ * the generation from a detached create-only command, then attaches its painter; a concurrent
+ * creator is treated as a warm attach and cannot mint ownership.
  *
  * ── SCOPE ───────────────────────────────────────────────────────────────────────────────────────
  * This is scoped to tmux-pane messaging ownership but is intentionally feature-neutral: S8 PR 4's

--- a/src/core/agents/pane-ownership.ts
+++ b/src/core/agents/pane-ownership.ts
@@ -19,16 +19,14 @@
  *    git-copied `id`. A cloned repo gets a fresh entry id, so it cannot inherit another copy's
  *    ownership either.
  *
- * ── COLD STATE / RESTART (stated honestly) ──────────────────────────────────────────────────────
- * This ledger is IN-MEMORY and starts empty every run. After an app restart the tmux SERVER
- * usually survives, so the renderer's re-open of a node ATTACHES (`fresh === false`) and records
- * nothing — the pane is then UNPROVEN and messaging to it is REFUSED (fail-closed) until the
- * session is truly respawned (or the machine reboots, killing the tmux server, after which the
- * next open is a real fresh spawn and records correctly). We do NOT repopulate on attach: there is
- * no cheap cross-restart signal a hostile agent could not also write (a tmux session-env var is
- * settable from any pane's shell), and guessing the owner on attach is exactly how the attacker
- * would re-acquire ownership by opening the victim's id first. Fail-closed is the safe direction
- * and is pinned by a test (`ownerOf` empty ⇒ the delivery gate refuses).
+ * ── COLD STATE / RESTART ────────────────────────────────────────────────────────────────────────
+ * The runtime map starts empty, but a genuine fresh spawn also writes a machine-local, HMAC-signed
+ * ownership record bound to the local tmux server/session/pane generation. A warm attach restores
+ * the map only when that live generation, node and project all match and the record verifies under
+ * this installation's node-auth secret. The project file cannot forge that proof, a replacement
+ * pane cannot inherit it, and a copied data file cannot verify on another installation. Missing,
+ * stale or malformed proof stays UNPROVEN and fails closed. We never infer ownership from
+ * project.json or from a tmux environment variable that a pane can rewrite.
  *
  * ── SCOPE ───────────────────────────────────────────────────────────────────────────────────────
  * This is scoped to tmux-pane messaging ownership but is intentionally feature-neutral: S8 PR 4's
@@ -38,8 +36,43 @@
  * now records and reads it through the same PtyManager and messaging service as desktop.
  */
 
-/** nodeId → owning projectId (machine-local entry id), for panes freshly spawned THIS run. */
+import { createHash, createHmac, timingSafeEqual } from 'crypto'
+import fs from 'fs'
+import path from 'path'
+import { platform } from '../platform'
+import { renameAtomicSync, tempNameFor } from '../fs-atomic'
+import { isSafeNodeId } from './node-auth-token'
+
+/** nodeId → owning projectId (machine-local entry id), proved this run or restored from proof. */
 const owners = new Map<string, string>()
+const OWNER_PROOF_PREFIX = 'nt-pane-owner-v1|'
+
+interface StoredPaneOwner {
+  version: 1
+  nodeId: string
+  projectId: string
+  generation: string
+  mac: string
+}
+
+function ownerProof(secret: Buffer, nodeId: string, projectId: string, generation: string): string {
+  return createHmac('sha256', secret)
+    .update(`${OWNER_PROOF_PREFIX}${nodeId}|${projectId}|${generation}`)
+    .digest('base64url')
+}
+
+function ownerFile(nodeId: string): string {
+  const key = createHash('sha256').update(nodeId).digest('hex')
+  return path.join(platform().userDataDir, 'pane-owners', `${key}.json`)
+}
+
+function proofMatches(secret: Buffer, stored: StoredPaneOwner): boolean {
+  const expected = Buffer.from(
+    ownerProof(secret, stored.nodeId, stored.projectId, stored.generation)
+  )
+  const actual = Buffer.from(stored.mac)
+  return expected.length === actual.length && timingSafeEqual(expected, actual)
+}
 
 /**
  * THE FRESH-GATE, pure and pinned: may this create() record pane ownership? True ONLY for a
@@ -69,9 +102,92 @@ export function recordFreshSpawnOwner(nodeId: string, ownerProjectId: string | u
   owners.set(nodeId, ownerProjectId)
 }
 
-/** The project that provably spawned this node's pane this run, or `undefined` when unproven
- *  (never spawned here, or only ever attached — e.g. after a restart). Undefined MUST fail closed
- *  at every gate: an unprovable owner is not an absent restriction. */
+/** Persist the ownership established by a genuine fresh spawn. Best-effort: a write failure keeps
+ *  this run working and leaves the next warm attach unproven. */
+export function persistPaneOwner(
+  nodeId: string,
+  ownerProjectId: string | undefined,
+  generation: string | undefined,
+  secret: Buffer | null
+): boolean {
+  if (
+    !secret ||
+    !isSafeNodeId(nodeId) ||
+    !ownerProjectId ||
+    !isSafeNodeId(ownerProjectId) ||
+    !generation
+  )
+    return false
+  const file = ownerFile(nodeId)
+  const tmp = tempNameFor(file)
+  const body: StoredPaneOwner = {
+    version: 1,
+    nodeId,
+    projectId: ownerProjectId,
+    generation,
+    mac: ownerProof(secret, nodeId, ownerProjectId, generation)
+  }
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+    fs.chmodSync(path.dirname(file), 0o700)
+    try {
+      fs.writeFileSync(tmp, `${JSON.stringify(body)}\n`, {
+        encoding: 'utf8',
+        mode: 0o600,
+        flag: 'wx'
+      })
+      renameAtomicSync(tmp, file)
+      fs.chmodSync(file, 0o600)
+    } finally {
+      try {
+        fs.rmSync(tmp, { force: true })
+      } catch {
+        /* already renamed */
+      }
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Restore a warm pane's owner only from this installation's signed record. The current tmux
+ *  generation and renderer-supplied owner must both match; neither is enough by itself. */
+export function restorePaneOwner(
+  nodeId: string,
+  ownerProjectId: string | undefined,
+  generation: string | undefined,
+  secret: Buffer | null
+): boolean {
+  if (
+    !secret ||
+    !isSafeNodeId(nodeId) ||
+    !ownerProjectId ||
+    !isSafeNodeId(ownerProjectId) ||
+    !generation
+  )
+    return false
+  try {
+    const stored = JSON.parse(fs.readFileSync(ownerFile(nodeId), 'utf8')) as StoredPaneOwner
+    if (
+      stored?.version !== 1 ||
+      stored.nodeId !== nodeId ||
+      stored.projectId !== ownerProjectId ||
+      stored.generation !== generation ||
+      typeof stored.mac !== 'string' ||
+      !proofMatches(secret, stored)
+    )
+      return false
+    owners.set(nodeId, ownerProjectId)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** The project that provably spawned this node's pane, or `undefined` when unproven (never spawned
+ *  here and no valid restart proof). Undefined MUST fail closed at every gate: an unprovable owner
+ *  is not an absent restriction. */
 export function paneOwnerProject(nodeId: string): string | undefined {
   return owners.get(nodeId)
 }
@@ -80,6 +196,16 @@ export function paneOwnerProject(nodeId: string): string | undefined {
  *  re-records; until then the id is unproven again, which fails closed. */
 export function forgetPaneOwner(nodeId: string): void {
   owners.delete(nodeId)
+}
+
+/** Remove the restart proof when the pane itself is deleted or recycled. */
+export function forgetPersistedPaneOwner(nodeId: string): void {
+  if (!isSafeNodeId(nodeId)) return
+  try {
+    fs.rmSync(ownerFile(nodeId), { force: true })
+  } catch {
+    /* missing/unwritable proof already fails closed */
+  }
 }
 
 /** Test seam only: wipe the ledger between cases. Never called in production. */

--- a/src/core/project-capability-consent.test.ts
+++ b/src/core/project-capability-consent.test.ts
@@ -4,6 +4,7 @@ import {
   needsCapabilityNotice,
   projectCapabilityGranted,
   projectCapabilityGrantedFor,
+  rearmDefaultCapabilityAcks,
   recordCapabilityAck
 } from './project-capability-consent'
 import * as shared from '../shared/project-capability-consent'
@@ -114,6 +115,10 @@ describe('the acknowledgment is MACHINE-LOCAL and carries the answer', () => {
     )
     expect(Object.keys(file)).not.toContain('capabilityAck')
     expect(JSON.stringify(file)).not.toContain('capabilityAck')
+    expect(JSON.stringify(projectToFile({
+      ...baseProject,
+      capabilityAckSource: { agentMessaging: 'local-default' }
+    }, 1, 't'))).not.toContain('capabilityAckSource')
   })
 
   it('a later answer overwrites an earlier one, without mutating the input', () => {
@@ -127,6 +132,28 @@ describe('the acknowledgment is MACHINE-LOCAL and carries the answer', () => {
     expect(after).not.toBe(before)
     expect(before.capabilityAck).toEqual({ agentBrowserControl: 'declined' })
     expect(after.capabilityAck).toEqual({ agentBrowserControl: 'kept' })
+  })
+
+  it('re-arms only a global-default answer when external project content arrives', () => {
+    const seeded: IndexEntryV3 = {
+      id: 'p1', name: 'p', color: '#fff',
+      capabilityAck: { agentMessaging: 'kept', agentBrowserControl: 'kept' },
+      capabilityAckSource: { agentMessaging: 'local-default' }
+    }
+    const rearmed = rearmDefaultCapabilityAcks(seeded)
+    expect(rearmed.capabilityAck).toEqual({ agentBrowserControl: 'kept' })
+    expect(rearmed.capabilityAckSource).toBeUndefined()
+    expect(seeded.capabilityAck?.agentMessaging).toBe('kept')
+  })
+
+  it('an explicit per-project answer replaces global-default provenance', () => {
+    const answered = recordCapabilityAck({
+      id: 'p1', name: 'p', color: '#fff',
+      capabilityAck: { agentMessaging: 'kept' },
+      capabilityAckSource: { agentMessaging: 'local-default' }
+    } as IndexEntryV3, 'agentMessaging', 'kept')
+    expect(answered.capabilityAck?.agentMessaging).toBe('kept')
+    expect(answered.capabilityAckSource).toBeUndefined()
   })
 
   it('a SECOND WORKTREE of the same repo notifies again', () => {

--- a/src/core/project-capability-consent.ts
+++ b/src/core/project-capability-consent.ts
@@ -10,8 +10,10 @@ export {
   needsCapabilityNotice,
   projectCapabilityGranted,
   projectCapabilityGrantedFor,
+  rearmDefaultCapabilityAcks,
   recordCapabilityAck,
   type CapabilityAckMap,
+  type CapabilityAckSourceMap,
   type CapabilityAnswer,
   type CapabilityConsentState
 } from '../shared/project-capability-consent'

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -681,6 +681,9 @@ interface Session {
   /** Generation returned by the atomic create-only local-tmux command, before this client
    *  attached. Present only for ownership-proved fresh creates. */
   createdTmuxGeneration?: string
+  /** The async absence probe lost a race to another creator, so create-only recovered by
+   *  attaching to the now-existing generation. It is warm and must never record a fresh owner. */
+  attachedAfterCreateRace?: boolean
 }
 
 /** Sinks for a detached session whose output is served somewhere other than the renderer
@@ -2190,19 +2193,34 @@ export class PtyManager {
         }
       }
     }
-    const sessionId = this.spawnSession(
+    const localTmuxMode = !options.sshRemote && tmuxBacked && options.ownerProjectId
+      ? fresh ? 'create' as const : 'attach' as const
+      : undefined
+    let sessionId = this.spawnSession(
       options,
       clientId,
       undefined,
       warmWindowsBackend,
       projectOverrides,
-      !options.sshRemote && tmuxBacked && options.ownerProjectId
-        ? fresh
-          ? 'create'
-          : 'attach'
-        : undefined
+      localTmuxMode
     )
-    const spawned = this.sessions.get(sessionId)
+    let spawned = this.sessions.get(sessionId)
+    if (spawned?.attachedAfterCreateRace) fresh = false
+    if (localTmuxMode === 'attach') {
+      // The warm session can disappear after has-session but before attach-session. Confirm after
+      // node-pty starts; if it vanished, discard that dead client and make one bounded cold-create
+      // attempt. That create has its own opposite-direction race recovery below.
+      const stillExists = await this.tmuxSessionExists(options.persistKey as string)
+      if (!stillExists || !spawned || this.sessions.get(sessionId) !== spawned) {
+        if (spawned && this.sessions.get(sessionId) === spawned)
+          this.discardFailedSpawn(sessionId, spawned)
+        sessionId = this.spawnSession(
+          options, clientId, undefined, warmWindowsBackend, projectOverrides, 'create'
+        )
+        spawned = this.sessions.get(sessionId)
+        fresh = !spawned?.attachedAfterCreateRace
+      }
+    }
     if (warmWindowsBackend === 'tmux') {
       // The first strict probe deliberately preceded profile resolution. Recheck after launching
       // attach-only: if the named session disappeared in that window, never return the transient
@@ -3140,6 +3158,7 @@ export class PtyManager {
     }
 
     let createdTmuxGeneration: string | undefined
+    let attachedAfterCreateRace = false
     if (useLocalTmux && localTmuxMode === 'create') {
       const command = args.indexOf('new-session')
       const createArgs = [
@@ -3155,7 +3174,14 @@ export class PtyManager {
         ...args.slice(command + 1)
       ]
       try {
-        const output = execFileSync(file, createArgs, { cwd, env, encoding: 'utf8' }).replace(
+        // Measured 2026-09-03 with tmux 3.6a: 20 detached /bin/sh creates, 7 ms median,
+        // 13 ms p95, 18 ms max. The timeout bounds shell/host anomalies, not ordinary latency.
+        const output = execFileSync(file, createArgs, {
+          cwd,
+          env,
+          encoding: 'utf8',
+          timeout: PROBE_TIMEOUT_MS
+        }).replace(
           /\r?\n$/,
           ''
         )
@@ -3163,11 +3189,27 @@ export class PtyManager {
           throw new Error('tmux returned no valid generation')
         createdTmuxGeneration = output
       } catch (error) {
-        throw new Error(
-          `Could not create the terminal session atomically: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        )
+        // Another window may have created this exact named session after our async absence probe.
+        // Recover only when tmux now reports a strict generation for that target; every other
+        // create error remains fatal. This sync confirmation shares the create timeout and runs
+        // only on the race/error path.
+        try {
+          const target = `=${sessionName(options.persistKey as string)}:`
+          const current = execFileSync(
+            file,
+            ['-L', TMUX_SOCKET, 'display-message', '-p', '-t', target,
+              '#{pid}|#{session_id}|#{session_created}|#{pane_id}|#{pane_pid}'],
+            { encoding: 'utf8', timeout: PROBE_TIMEOUT_MS }
+          ).replace(/\r?\n$/, '')
+          if (!/^\d+\|\$\d+\|\d+\|%\d+\|\d+$/.test(current)) throw error
+          attachedAfterCreateRace = true
+        } catch {
+          throw new Error(
+            `Could not create the terminal session atomically: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+        }
       }
       args = [
         '-L',
@@ -3308,7 +3350,8 @@ export class PtyManager {
       pausedBy: new Set<string>(),
       accountFallback,
       sessionHost: useSessionHost,
-      ...(createdTmuxGeneration ? { createdTmuxGeneration } : {})
+      ...(createdTmuxGeneration ? { createdTmuxGeneration } : {}),
+      ...(attachedAfterCreateRace ? { attachedAfterCreateRace: true } : {})
     }
     // Both shared timers are armed by the first session that needs them: the scrollback snapshots
     // and the idle reap are both about tmux-backed sessions and nothing else.
@@ -3493,10 +3536,16 @@ export class PtyManager {
     session.sizes.clear()
     session.shown.clear()
     session.pausedBy.clear()
-    // Do not use releasePty here: its defensive resume would issue a fresh host request from a
-    // shim whose attach just failed. SessionHostPty.destroy() is the exact detach/unsubscribe.
-    const hostPty = session.proc as unknown as SessionHostPty
-    hostPty.destroy()
+    if (session.sessionHost) {
+      // Do not use releasePty here: its defensive resume would issue a fresh host request from a
+      // shim whose attach just failed. SessionHostPty.destroy() is the exact detach/unsubscribe.
+      const hostPty = session.proc as unknown as SessionHostPty
+      hostPty.destroy()
+    } else {
+      // A local tmux attach that lost its session is also provisional. Close its client without
+      // recording released/shadow state; the bounded cold-create retry replaces it immediately.
+      releasePty(session.proc as ReleasablePty)
+    }
     this.forget(sessionId, session)
     const remaining = [...this.sessions.values()]
     if (!remaining.some((candidate) => candidate.persistKey) && this.snapshotTimer) {

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -42,6 +42,9 @@ import { classifyPaneCwd } from './pane-cwd'
 import {
   recordFreshSpawnOwner,
   forgetPaneOwner,
+  forgetPersistedPaneOwner,
+  persistPaneOwner,
+  restorePaneOwner,
   shouldRecordOwnership
 } from './agents/pane-ownership'
 import { PANE_OWNER_FMT, foregroundArgvArgs, paneOwnerFrom, parseCombinedPaneOwner, parsePaneOwner } from './agents/pane-owner'
@@ -675,6 +678,9 @@ interface Session {
    * already branches on `sshRemote`.
    */
   sessionHost?: boolean
+  /** Generation returned by the atomic create-only local-tmux command, before this client
+   *  attached. Present only for ownership-proved fresh creates. */
+  createdTmuxGeneration?: string
 }
 
 /** Sinks for a detached session whose output is served somewhere other than the renderer
@@ -2189,16 +2195,14 @@ export class PtyManager {
       clientId,
       undefined,
       warmWindowsBackend,
-      projectOverrides
+      projectOverrides,
+      !options.sshRemote && tmuxBacked && options.ownerProjectId
+        ? fresh
+          ? 'create'
+          : 'attach'
+        : undefined
     )
     const spawned = this.sessions.get(sessionId)
-    // PANE OWNERSHIP (agent messaging, PR #237 fix round 2): record the OWNING project of a pane
-    // this process just GENUINELY spawned. Gated on `fresh` — an attach/co-attach to a session
-    // someone else spawned (incl. an app-restart re-attach) leaves the pane UNPROVEN, so a second
-    // project that merely opens another's node id cannot claim it. The owner is the renderer's
-    // machine-local project id, never the git-shared file id. See `agents/pane-ownership.ts`.
-    if (shouldRecordOwnership(fresh, options.persistKey, options.ownerProjectId))
-      recordFreshSpawnOwner(options.persistKey as string, options.ownerProjectId)
     if (warmWindowsBackend === 'tmux') {
       // The first strict probe deliberately preceded profile resolution. Recheck after launching
       // attach-only: if the named session disappeared in that window, never return the transient
@@ -2246,6 +2250,42 @@ export class PtyManager {
         throw error
       }
     }
+    // PANE OWNERSHIP (agent messaging): wait until Session Host has returned authoritative
+    // freshness before recording anything. Every genuine fresh spawn gets a process-local owner.
+    // Only local tmux can recover that owner after an app restart: its proof is bound to tmux's
+    // current server/session/pane generation, so an out-of-band replacement cannot inherit stale
+    // authorization. Remote and Session Host warm attaches stay unproven and fail closed.
+    if (shouldRecordOwnership(fresh, options.persistKey, options.ownerProjectId)) {
+      if (tmuxBacked && !options.sshRemote && !spawned?.sessionHost) {
+        const generation = await this.localTmuxGeneration(options.persistKey as string)
+        if (generation && generation === spawned?.createdTmuxGeneration) {
+          recordFreshSpawnOwner(options.persistKey as string, options.ownerProjectId)
+          persistPaneOwner(
+            options.persistKey as string,
+            options.ownerProjectId,
+            generation,
+            hookServer.nodeAuthSecretOrNull()
+          )
+        }
+      } else {
+        recordFreshSpawnOwner(options.persistKey as string, options.ownerProjectId)
+      }
+    } else if (
+      !fresh &&
+      tmuxBacked &&
+      !options.sshRemote &&
+      !spawned?.sessionHost &&
+      options.persistKey &&
+      options.ownerProjectId
+    ) {
+      const generation = await this.localTmuxGeneration(options.persistKey)
+      restorePaneOwner(
+        options.persistKey,
+        options.ownerProjectId,
+        generation,
+        hookServer.nodeAuthSecretOrNull()
+      )
+    }
     // Surface a missing-account-dir fallback so the renderer can flag the node's account chip.
     const accountFallback = spawned?.accountFallback
     // The session's `persistKey` is set iff the spawn actually landed on a tmux, local or remote
@@ -2269,6 +2309,31 @@ export class PtyManager {
       ...(accountFallback ? { accountFallback } : {}),
       ...(staleCwd ? { staleCwd: true as const } : {}),
       ...(screen ? { screen } : {})
+    }
+  }
+
+  /** Stable identity for one live local-tmux generation. Exact targeting plus strict parsing is
+   *  load-bearing: tmux may exit 0 with empty format fields when a target vanished. */
+  private async localTmuxGeneration(persistKey: string): Promise<string | undefined> {
+    if (!this.tmuxPath) return undefined
+    try {
+      const { stdout } = await runAsync(
+        this.tmuxPath,
+        [
+          '-L',
+          TMUX_SOCKET,
+          'display-message',
+          '-p',
+          '-t',
+          `=${sessionName(persistKey)}:`,
+          '#{pid}|#{session_id}|#{session_created}|#{pane_id}|#{pane_pid}'
+        ],
+        { timeout: PROBE_TIMEOUT_MS }
+      )
+      const generation = stdout.replace(/\r?\n$/, '')
+      return /^\d+\|\$\d+\|\d+\|%\d+\|\d+$/.test(generation) ? generation : undefined
+    } catch {
+      return undefined
     }
   }
 
@@ -2537,7 +2602,9 @@ export class PtyManager {
     warmWindowsBackend?: 'session-host' | 'tmux',
     /** What the OWNING project contributes (see `projectSpawnOverrides`) — already resolved,
      *  because this function is synchronous. Null on every path with no proven project owner. */
-    overrides?: ProjectSpawnOverrides | null
+    overrides?: ProjectSpawnOverrides | null,
+    /** Security-sensitive local tmux path: create-only or attach-only, never `new-session -A`. */
+    localTmuxMode?: 'create' | 'attach'
   ): string {
     // PRE-FLIGHT — refuse before node-pty is touched, not after it fails.
     //
@@ -2977,7 +3044,7 @@ export class PtyManager {
       // on the client's inherited env would leak the first session's values into later ones).
       file = this.tmuxPath
       useLocalTmux = true
-      if (warmWindowsBackend === 'tmux') {
+      if (warmWindowsBackend === 'tmux' || localTmuxMode === 'attach') {
         // Attach-only is the critical distinction from `new-session -A`: if the proven warm
         // generation disappears in this window, tmux rejects instead of cold-spawning a shell
         // from options that deliberately skipped trusted profile resolution.
@@ -3028,7 +3095,7 @@ export class PtyManager {
         ...Object.keys(customEnvMerged),
         ...Object.keys(projectEnv ?? {})
       ])
-      const attachFlags = tmuxAttachFlags(!!sinks)
+      const attachFlags = localTmuxMode === 'create' ? [] : tmuxAttachFlags(!!sinks)
       args = [
         '-L',
         TMUX_SOCKET,
@@ -3070,6 +3137,48 @@ export class PtyManager {
       // explicitly instead of relying on it being empty there.
       file = localSessionShell
       args = localSessionArgs
+    }
+
+    let createdTmuxGeneration: string | undefined
+    if (useLocalTmux && localTmuxMode === 'create') {
+      const command = args.indexOf('new-session')
+      const createArgs = [
+        ...args.slice(0, command + 1),
+        '-d',
+        '-P',
+        '-F',
+        '#{pid}|#{session_id}|#{session_created}|#{pane_id}|#{pane_pid}',
+        '-x',
+        String(options.cols),
+        '-y',
+        String(options.rows),
+        ...args.slice(command + 1)
+      ]
+      try {
+        const output = execFileSync(file, createArgs, { cwd, env, encoding: 'utf8' }).replace(
+          /\r?\n$/,
+          ''
+        )
+        if (!/^\d+\|\$\d+\|\d+\|%\d+\|\d+$/.test(output))
+          throw new Error('tmux returned no valid generation')
+        createdTmuxGeneration = output
+      } catch (error) {
+        throw new Error(
+          `Could not create the terminal session atomically: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      }
+      args = [
+        '-L',
+        TMUX_SOCKET,
+        '-f',
+        this.confPath,
+        'attach-session',
+        ...(sinks ? [] : ['-d']),
+        '-t',
+        sessionName(options.persistKey as string)
+      ]
     }
 
     let proc: pty.IPty
@@ -3115,6 +3224,24 @@ export class PtyManager {
           env
         })
       } catch (err) {
+        // The ownership-sensitive create path starts the pane detached, then attaches its painter.
+        // If that attach fails, remove only the exact generation we created; a same-name
+        // replacement must survive rather than being killed on a stale assumption.
+        if (createdTmuxGeneration && options.persistKey) {
+          try {
+            const target = `=${sessionName(options.persistKey)}:`
+            const format = '#{pid}|#{session_id}|#{session_created}|#{pane_id}|#{pane_pid}'
+            const current = execFileSync(
+              file,
+              ['-L', TMUX_SOCKET, 'display-message', '-p', '-t', target, format],
+              { encoding: 'utf8' }
+            ).replace(/\r?\n$/, '')
+            if (current === createdTmuxGeneration)
+              execFileSync(file, localTmuxKillArgs(TMUX_SOCKET, sessionName(options.persistKey)))
+          } catch {
+            /* uncertain generation: preserve it rather than kill another process's pane */
+          }
+        }
         // node-pty surfaces the underlying failure as a bare "posix_spawnp failed." with no errno.
         // Two different field causes wear that same message, so BOTH are measured before anything is
         // said: a cross-arch `electron-builder --x64` run clobbering node-pty's spawn-helper (arm64
@@ -3180,7 +3307,8 @@ export class PtyManager {
       unwatchedSince: null,
       pausedBy: new Set<string>(),
       accountFallback,
-      sessionHost: useSessionHost
+      sessionHost: useSessionHost,
+      ...(createdTmuxGeneration ? { createdTmuxGeneration } : {})
     }
     // Both shared timers are armed by the first session that needs them: the scrollback snapshots
     // and the idle reap are both about tmux-backed sessions and nothing else.
@@ -4731,6 +4859,7 @@ export class PtyManager {
     // genuine respawn re-records it; until then the id is unproven, which fails closed for
     // messaging (agents/pane-ownership.ts). Safe on either intent: recycle's respawn overwrites.
     forgetPaneOwner(persistKey)
+    forgetPersistedPaneOwner(persistKey)
     // The tmux session is about to be killed, so everything attached to it goes now: a shadow would
     // otherwise linger until tmux dropped its client, and what we remembered about the released
     // session describes a pane that is about to stop existing.

--- a/src/core/pty-project-settings.test.ts
+++ b/src/core/pty-project-settings.test.ts
@@ -25,6 +25,11 @@ interface SpawnCall {
   env: Record<string, string>
 }
 const spawns = vi.hoisted(() => [] as SpawnCall[])
+const syncExecs = vi.hoisted(() => [] as Array<{
+  file: string
+  args: string[]
+  env?: Record<string, string>
+}>)
 
 // This suite mocks node-pty and asserts the plain-shell spawn path. Pin off the session-host
 // backend so a built `out/session-host/host.cjs` on disk cannot flip create() onto the host
@@ -67,10 +72,21 @@ vi.mock('child_process', () => {
   type Cb = (err: Error | null, res?: { stdout: string; stderr: string }) => void
   const execFile = (file: string, args: string[], a?: unknown, b?: unknown): unknown => {
     const cb = (typeof a === 'function' ? a : b) as Cb | undefined
-    cb?.(null, { stdout: '', stderr: '' })
+    if (args.includes('has-session')) cb?.(Object.assign(new Error('no session'), { code: 1 }))
+    else cb?.(null, { stdout: '', stderr: '' })
     return {}
   }
-  return { execFile, execFileSync: (): string => '' }
+  const execFileSync = (
+    file: string,
+    args: string[],
+    options?: { env?: Record<string, string> }
+  ): string => {
+    syncExecs.push({ file, args, env: options?.env ? { ...options.env } : undefined })
+    if (args.includes('-P')) return '101|$1|1700000000|%2|202\n'
+    if (args.includes('display-message')) return '101|$1|1700000000|%2|202\n'
+    return ''
+  }
+  return { execFile, execFileSync }
 })
 
 const NODE = 'node-1'
@@ -95,6 +111,7 @@ describe('project settings at the spawn — LOCAL leg', () => {
   let fake: FakePlatform
   beforeEach(() => {
     spawns.length = 0
+    syncExecs.length = 0
     staged.length = 0
     fake = fakePlatform()
     initPlatform(fake)
@@ -226,7 +243,9 @@ describe('project settings at the spawn — LOCAL leg', () => {
     await create({ persistKey: NODE, ownerProjectId: PROJECT })
     expect(seen[0]).toContain('PROJECT_TOKEN')
     // The VALUE never rides the tmux argv (that is the whole point of update-environment).
-    expect(spawns[0].args.join(' ')).not.toContain('abc')
+    const createCall = syncExecs.find((call) => call.args.includes('new-session'))
+    expect(createCall?.env?.PROJECT_TOKEN).toBe('abc')
+    expect(createCall?.args.join(' ')).not.toContain('abc')
   })
 })
 
@@ -303,6 +322,7 @@ describe('project settings at the spawn — SHELL precedence', () => {
   let fake: FakePlatform
   beforeEach(() => {
     spawns.length = 0
+    syncExecs.length = 0
     fake = fakePlatform()
     initPlatform(fake)
   })
@@ -337,10 +357,11 @@ describe('project settings at the spawn — SHELL precedence', () => {
       tmuxEnabled: true
     })
     await create({ persistKey: NODE, ownerProjectId: PROJECT })
-    expect(spawns[0].file).toBe('/usr/bin/tmux')
-    expect(spawns[0].args.at(-1)).toBe('/bin/fish')
-    expect(spawns[0].args).toContain(sessionName(NODE))
-    expect(spawns[0].args).toContain(TMUX_SOCKET)
+    const createCall = syncExecs.find((call) => call.args.includes('new-session'))
+    expect(createCall?.file).toBe('/usr/bin/tmux')
+    expect(createCall?.args.at(-1)).toBe('/bin/fish')
+    expect(createCall?.args).toContain(sessionName(NODE))
+    expect(createCall?.args).toContain(TMUX_SOCKET)
   })
 })
 
@@ -348,6 +369,7 @@ describe('project settings at the spawn — SSH leg', () => {
   let fake: FakePlatform
   beforeEach(() => {
     spawns.length = 0
+    syncExecs.length = 0
     staged.length = 0
     fake = fakePlatform()
     initPlatform(fake)

--- a/src/core/pty-session-host.test.ts
+++ b/src/core/pty-session-host.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IPC } from '../shared/ipc'
 import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform, type FakePlatform } from './platform-fake'
+import { hookServer } from './agents/hook-server'
+import { paneOwnerProject, resetPaneOwnershipForTests } from './agents/pane-ownership'
 
 const backend = vi.hoisted(() => ({
   supported: vi.fn(() => true),
@@ -84,6 +86,8 @@ describe('PtyManager session-host contracts', () => {
   let host: FakePlatform
 
   beforeEach(() => {
+    resetPaneOwnershipForTests()
+    hookServer.clearNodeAuthSecretForTests()
     host = fakePlatform()
     initPlatform(host)
     backend.supported.mockReturnValue(true)
@@ -99,6 +103,8 @@ describe('PtyManager session-host contracts', () => {
   afterEach(async () => {
     await manager?.killAll()
     manager = undefined
+    resetPaneOwnershipForTests()
+    hookServer.clearNodeAuthSecretForTests()
     resetPlatformForTests()
     vi.restoreAllMocks()
   })
@@ -227,6 +233,22 @@ describe('PtyManager session-host contracts', () => {
       persistent: true,
       screen: 'still alive'
     })
+  })
+
+  it('does not let a warm Session Host attach claim pane ownership from placeholder freshness', async () => {
+    backend.create.mockReturnValue(fakeSessionHostPty(Promise.resolve({ fresh: false })))
+    const m = await makeManager()
+    m.registerIpc()
+
+    await expect(
+      host.handlers[IPC.ptyCreate](7, {
+        cols: 80,
+        rows: 24,
+        persistKey: 'node-warm-owner',
+        ownerProjectId: 'project-clone'
+      })
+    ).resolves.toMatchObject({ fresh: false })
+    expect(paneOwnerProject('node-warm-owner')).toBeUndefined()
   })
 
   it('keeps a deletion tombstone when its owner recovery attach fails', async () => {

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -8,6 +8,16 @@ import { IPC } from '../shared/ipc'
 import { DEFAULT_SETTINGS } from '../shared/types'
 import { MODEL_GATEWAY_SECRET_REF } from '../shared/agents/model-gateway'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
+import { hookServer } from './agents/hook-server'
+import {
+  paneOwnerProject,
+  persistPaneOwner,
+  resetPaneOwnershipForTests,
+  restorePaneOwner
+} from './agents/pane-ownership'
+
+const NODE_AUTH_SECRET = Buffer.alloc(32, 11)
+const TMUX_GENERATION = '101|$1|1700000000|%2|202'
 
 /**
  * SINGLE-USER REGRESSION.
@@ -31,6 +41,7 @@ interface FakePty {
   killed: boolean
 }
 const spawned: FakePty[] = []
+let spawnError: Error | null = null
 const spawnArgs: Array<{
   file: string
   args: string[]
@@ -54,6 +65,7 @@ vi.mock('node-pty', () => ({
     args: string[],
     opts: { cols: number; rows: number; cwd: string; env: Record<string, string> }
   ) => {
+    if (spawnError) throw spawnError
     const p: FakePty = { resizes: [], paused: false, killed: false }
     spawned.push(p)
     spawnArgs.push({ file, args, cols: opts.cols, rows: opts.rows, cwd: opts.cwd, env: opts.env })
@@ -87,9 +99,11 @@ vi.mock('node-pty', () => ({
  * prove `kill` never issues `kill-session` while `destroy` does.
  */
 const execCalls: Array<{ file: string; args: string[] }> = []
+const execSyncCalls: Array<{ file: string; args: string[] }> = []
 const liveTmuxSessions = new Set<string>()
 let paneProcessReply = ''
 let processGroupReply = ''
+let tmuxGenerationReply = TMUX_GENERATION
 
 vi.mock('child_process', () => {
   type Cb = (err: Error | null, res?: { stdout: string; stderr: string }) => void
@@ -108,6 +122,8 @@ vi.mock('child_process', () => {
       ok('__NT_PATH_START__/usr/bin:/bin__NT_PATH_END__')
     } else if (args.includes('capture-pane')) {
       ok('PANE SNAPSHOT')
+    } else if (args.includes('#{pid}|#{session_id}|#{session_created}|#{pane_id}|#{pane_pid}')) {
+      ok(`${tmuxGenerationReply}\n`)
     } else if (args.includes('#{pane_pid}|#{pane_current_command}')) {
       ok(paneProcessReply)
     } else if (file === 'ps' && args.includes('tpgid=')) {
@@ -117,7 +133,13 @@ vi.mock('child_process', () => {
     }
     return {}
   }
-  return { execFile, execFileSync: (): string => '' }
+  const execFileSync = (file: string, args: string[]): string => {
+    execSyncCalls.push({ file, args })
+    if (args.includes('-P')) return `${TMUX_GENERATION}\n`
+    if (args.includes('display-message')) return `${tmuxGenerationReply}\n`
+    return ''
+  }
+  return { execFile, execFileSync }
 })
 
 const SOLO = 42
@@ -164,9 +186,14 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     spawned.length = 0
     spawnArgs.length = 0
     execCalls.length = 0
+    execSyncCalls.length = 0
     liveTmuxSessions.clear()
+    spawnError = null
     paneProcessReply = ''
     processGroupReply = ''
+    tmuxGenerationReply = TMUX_GENERATION
+    resetPaneOwnershipForTests()
+    hookServer.clearNodeAuthSecretForTests()
     userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-solo-'))
     fake = fakePlatform({ userDataDir })
     initPlatform(fake)
@@ -175,6 +202,8 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
+    resetPaneOwnershipForTests()
+    hookServer.clearNodeAuthSecretForTests()
     resetPlatformForTests()
     // BEST EFFORT, and it must stay that way. This races a write it cannot wait for: the scrollback
     // snapshot is fired and forgotten by design (`snapshotScrollback` is best-effort and nothing
@@ -399,6 +428,79 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     const r = await create(80, 24)
     expect(r.fresh).toBe(false)
     expect(tmuxCalls('has-session')).toHaveLength(1)
+  })
+
+  it('persists a fresh pane owner for restart recovery', async () => {
+    hookServer.setNodeAuthSecret(NODE_AUTH_SECRET)
+    await tmuxManager()
+    const r = await create(80, 24, 'owned-fresh', { ownerProjectId: 'project-1' })
+    expect(r.fresh).toBe(true)
+    expect(paneOwnerProject('owned-fresh')).toBe('project-1')
+    const createOnly = execSyncCalls.find((call) => call.args.includes('new-session'))
+    expect(createOnly?.args).toContain('-P')
+    expect(createOnly?.args).not.toContain('-A')
+    expect(spawnArgs[0].args).toContain('attach-session')
+    expect(spawnArgs[0].args).not.toContain('new-session')
+
+    resetPaneOwnershipForTests()
+    expect(
+      restorePaneOwner('owned-fresh', 'project-1', TMUX_GENERATION, NODE_AUTH_SECRET)
+    ).toBe(true)
+  })
+
+  it('uses create-only tmux even before the signing secret is available', async () => {
+    await tmuxManager()
+    const r = await create(80, 24, 'owned-no-secret', { ownerProjectId: 'project-1' })
+
+    expect(r.fresh).toBe(true)
+    expect(paneOwnerProject('owned-no-secret')).toBe('project-1')
+    const createOnly = execSyncCalls.find((call) => call.args.includes('new-session'))
+    expect(createOnly?.args).toContain('-P')
+    expect(createOnly?.args).not.toContain('-A')
+    expect(spawnArgs[0].args).toContain('attach-session')
+  })
+
+  it('does not record an owner when the created tmux generation was replaced', async () => {
+    hookServer.setNodeAuthSecret(NODE_AUTH_SECRET)
+    tmuxGenerationReply = '102|$2|1700000001|%3|203'
+    await tmuxManager()
+
+    await create(80, 24, 'owned-replaced', { ownerProjectId: 'project-1' })
+
+    expect(paneOwnerProject('owned-replaced')).toBeUndefined()
+    resetPaneOwnershipForTests()
+    expect(
+      restorePaneOwner('owned-replaced', 'project-1', TMUX_GENERATION, NODE_AUTH_SECRET)
+    ).toBe(false)
+  })
+
+  it('removes only its exact detached generation when painter attach fails', async () => {
+    await tmuxManager()
+    spawnError = new Error('attach failed')
+
+    await expect(
+      create(80, 24, 'owned-attach-failed', { ownerProjectId: 'project-1' })
+    ).rejects.toThrow('attach failed')
+
+    const kill = execSyncCalls.find((call) => call.args.includes('kill-session'))
+    expect(kill?.args).toContain(`=${sessionName('owned-attach-failed')}`)
+    expect(paneOwnerProject('owned-attach-failed')).toBeUndefined()
+  })
+
+  it('restores a signed pane owner through the warm-attach caller', async () => {
+    hookServer.setNodeAuthSecret(NODE_AUTH_SECRET)
+    expect(
+      persistPaneOwner('owned-warm', 'project-1', TMUX_GENERATION, NODE_AUTH_SECRET)
+    ).toBe(true)
+    resetPaneOwnershipForTests()
+    liveTmuxSessions.add(sessionName('owned-warm'))
+    await tmuxManager()
+
+    const r = await create(80, 24, 'owned-warm', { ownerProjectId: 'project-1' })
+    expect(r.fresh).toBe(false)
+    expect(paneOwnerProject('owned-warm')).toBe('project-1')
+    expect(execSyncCalls.some((call) => call.args.includes('new-session'))).toBe(false)
+    expect(spawnArgs[0].args).toContain('attach-session')
   })
 
   it('fresh:true after a reboot killed the tmux server (cold restore + agent resume)', async () => {

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -99,11 +99,13 @@ vi.mock('node-pty', () => ({
  * prove `kill` never issues `kill-session` while `destroy` does.
  */
 const execCalls: Array<{ file: string; args: string[] }> = []
-const execSyncCalls: Array<{ file: string; args: string[] }> = []
+const execSyncCalls: Array<{ file: string; args: string[]; options?: { timeout?: number } }> = []
 const liveTmuxSessions = new Set<string>()
 let paneProcessReply = ''
 let processGroupReply = ''
 let tmuxGenerationReply = TMUX_GENERATION
+let createSyncError: Error | null = null
+let dropAfterHasSession = false
 
 vi.mock('child_process', () => {
   type Cb = (err: Error | null, res?: { stdout: string; stderr: string }) => void
@@ -113,7 +115,10 @@ vi.mock('child_process', () => {
     const ok = (stdout: string): void => cb?.(null, { stdout, stderr: '' })
     if (args.includes('has-session')) {
       const target = args[args.indexOf('-t') + 1]
-      if (liveTmuxSessions.has(target)) ok('')
+      if (liveTmuxSessions.has(target)) {
+        ok('')
+        if (dropAfterHasSession) liveTmuxSessions.delete(target)
+      }
       // Real execFile carries tmux's exit status on err.code — 1 is what probeSaysAbsent
       // reads as genuine absence (vs a spawn failure, which has a string/no code).
       else cb?.(Object.assign(new Error('no such session'), { code: 1 }))
@@ -133,9 +138,12 @@ vi.mock('child_process', () => {
     }
     return {}
   }
-  const execFileSync = (file: string, args: string[]): string => {
-    execSyncCalls.push({ file, args })
-    if (args.includes('-P')) return `${TMUX_GENERATION}\n`
+  const execFileSync = (file: string, args: string[], options?: { timeout?: number }): string => {
+    execSyncCalls.push({ file, args, options })
+    if (args.includes('-P')) {
+      if (createSyncError) throw createSyncError
+      return `${TMUX_GENERATION}\n`
+    }
     if (args.includes('display-message')) return `${tmuxGenerationReply}\n`
     return ''
   }
@@ -192,6 +200,8 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     paneProcessReply = ''
     processGroupReply = ''
     tmuxGenerationReply = TMUX_GENERATION
+    createSyncError = null
+    dropAfterHasSession = false
     resetPaneOwnershipForTests()
     hookServer.clearNodeAuthSecretForTests()
     userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-solo-'))
@@ -439,6 +449,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     const createOnly = execSyncCalls.find((call) => call.args.includes('new-session'))
     expect(createOnly?.args).toContain('-P')
     expect(createOnly?.args).not.toContain('-A')
+    expect(createOnly?.options?.timeout).toBe(6_000)
     expect(spawnArgs[0].args).toContain('attach-session')
     expect(spawnArgs[0].args).not.toContain('new-session')
 
@@ -458,6 +469,30 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     expect(createOnly?.args).toContain('-P')
     expect(createOnly?.args).not.toContain('-A')
     expect(spawnArgs[0].args).toContain('attach-session')
+  })
+
+  it('recovers when another window creates the session after the absence probe', async () => {
+    await tmuxManager()
+    createSyncError = new Error('duplicate session')
+
+    const r = await create(80, 24, 'owned-create-race', { ownerProjectId: 'project-1' })
+
+    expect(r.fresh).toBe(false)
+    expect(spawnArgs[0].args).toContain('attach-session')
+    expect(paneOwnerProject('owned-create-race')).toBeUndefined()
+  })
+
+  it('recovers when a warm session disappears before attach', async () => {
+    await tmuxManager()
+    liveTmuxSessions.add(sessionName('owned-attach-race'))
+    dropAfterHasSession = true
+
+    const r = await create(80, 24, 'owned-attach-race', { ownerProjectId: 'project-1' })
+
+    expect(r.fresh).toBe(true)
+    expect(spawnArgs).toHaveLength(2)
+    expect(spawnArgs[1].args).toContain('attach-session')
+    expect(execSyncCalls.some((call) => call.args.includes('new-session'))).toBe(true)
   })
 
   it('does not record an owner when the created tmux generation was replaced', async () => {

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -200,6 +200,8 @@ export interface IndexEntryV3 {
    * entry, so a second worktree of the same repo (a second entry) notifies again, on purpose.
    */
   capabilityAck?: import('../shared/project-capability-consent').CapabilityAckMap
+  /** MACHINE-LOCAL provenance for a global-default answer. Never written to project.json. */
+  capabilityAckSource?: import('../shared/project-capability-consent').CapabilityAckSourceMap
   /** MACHINE-LOCAL camera navigation history for a ref'd project. Same rule as `viewport`: this
    *  user's "where was I" is not something a repo shares. See NavStop. */
   breadcrumbs?: NavStop[]
@@ -451,6 +453,8 @@ export function fileToProject(
     defaultAccountId?: string
     /** This machine's clone-notice acknowledgments for this entry (never from the file). */
     capabilityAck?: import('../shared/project-capability-consent').CapabilityAckMap
+    /** Machine-local provenance for a global-default answer; never accepted from the file. */
+    capabilityAckSource?: import('../shared/project-capability-consent').CapabilityAckSourceMap
     /** This machine's navigation history for this entry (never from the file). */
     breadcrumbs?: NavStop[]
     /** This machine's closed-session history for this entry (never from the file) — already
@@ -503,6 +507,7 @@ export function fileToProject(
     // Machine-local, from the index entry ONLY: a file field named `capabilityAck` is a forgery
     // attempt (the shared file cannot carry this machine's consent) and is simply never read.
     ...(base.capabilityAck ? { capabilityAck: base.capabilityAck } : {}),
+    ...(base.capabilityAckSource ? { capabilityAckSource: base.capabilityAckSource } : {}),
     // Machine-local, from the index entry ONLY: a file field named `breadcrumbs` is a forgery
     // attempt (the shared file cannot carry this machine's navigation history) and is never read.
     ...(base.breadcrumbs?.length ? { breadcrumbs: base.breadcrumbs } : {}),
@@ -614,6 +619,7 @@ export function splitWorkspace(
       // The clone-notice acknowledgment rides the machine-local entry, never the shared file
       // (projectToFile does not emit it — pinned by project-capability-consent.test.ts).
       ...(p.capabilityAck ? { capabilityAck: p.capabilityAck } : {}),
+      ...(p.capabilityAckSource ? { capabilityAckSource: p.capabilityAckSource } : {}),
       ...(p.breadcrumbs?.length ? { breadcrumbs: p.breadcrumbs } : {}),
       // Same rule: whose trash can holds what is machine-local, capped on the way OUT as well as
       // in (see CLOSED_SESSIONS_CAP) — an in-memory list inflated some other way must not be

--- a/src/core/workspace-store.test.ts
+++ b/src/core/workspace-store.test.ts
@@ -455,6 +455,29 @@ describe('readLocalRefByPath', () => {
     expect(await store.readLocalRefByPath(path.join(projRoot, 'nope/project.json'))).toBeNull()
   })
 
+  it('re-arms a global-default answer when a checkout replaces the machine-authored file', async () => {
+    const store = new WorkspaceStore()
+    await store.save(ws([project({
+      cwd: projRoot,
+      agentMessaging: true,
+      capabilityAck: { agentMessaging: 'kept' },
+      capabilityAckSource: { agentMessaging: 'local-default' }
+    })]))
+    const filePath = path.join(projRoot, '.nodeterm/project.json')
+    const checkedOut = JSON.parse(await fs.readFile(filePath, 'utf-8'))
+    checkedOut.name = 'from-checkout'
+    checkedOut.rev += 1
+    await fs.writeFile(filePath, JSON.stringify(checkedOut))
+
+    const changed = await store.readLocalRefByPath(filePath)
+    expect(changed?.agentMessaging).toBe(true)
+    expect(changed?.capabilityAck?.agentMessaging).toBeUndefined()
+    expect(changed?.capabilityAckSource).toBeUndefined()
+    const restarted = await new WorkspaceStore().load()
+    expect(restarted.projects[0].capabilityAck?.agentMessaging).toBeUndefined()
+    expect(restarted.projects[0].capabilityAckSource).toBeUndefined()
+  })
+
   it('leaves a git-conflict-marked file in place (mid-merge is hand-resolvable, never sidelined)', async () => {
     const store = new WorkspaceStore()
     await store.save(ws([project({ cwd: projRoot })]))
@@ -855,6 +878,25 @@ describe('ssh lineage safety', () => {
     const adopted = msg!.args[0] as Project
     await store.save(ws([{ ...adopted, name: 'renamed' }]))
     expect(JSON.parse(files['~/app'])).toMatchObject({ rev: 901, id: 'fresh1', name: 'renamed' })
+  })
+
+  it('an existing remote file re-arms consent seeded by the new-project default', async () => {
+    const { files, io } = cwdIO()
+    const remote = JSON.parse(foreignRemote(12))
+    remote.agentMessaging = true
+    files['~/app'] = JSON.stringify(remote)
+    const store = new WorkspaceStore(io)
+
+    await store.save(ws([project({
+      id: 'fresh1', ssh: sshConn, cwd: undefined, nodes: [], agentMessaging: true,
+      capabilityAck: { agentMessaging: 'kept' },
+      capabilityAckSource: { agentMessaging: 'local-default' }
+    })]))
+
+    const msg = fake.sent.find((m) => m.channel === 'workspace:external-change')
+    expect(msg?.args[0]).toMatchObject({ id: 'fresh1', agentMessaging: true })
+    expect((msg?.args[0] as Project).capabilityAck?.agentMessaging).toBeUndefined()
+    expect((msg?.args[0] as Project).capabilityAckSource).toBeUndefined()
   })
 
   it('an EMPTY foreign remote never beats a populated cache, even with a higher rev — and the push outbids it', async () => {

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -23,7 +23,7 @@ import {
   type ProjectSettingsSnapshot
 } from '../shared/project-settings'
 import { readProjectCapabilities, type ProjectCapability } from '../shared/project-capabilities'
-import type { CapabilityAckMap } from './project-capability-consent'
+import { rearmDefaultCapabilityAcks, type CapabilityAckMap } from './project-capability-consent'
 import { hoistLegacyNodeExec, type LocalNodeExecMap } from '../shared/node-exec'
 import { collisionSeed, derivedProjectId, freshProjectId } from '../shared/project-id'
 import { appendProjectNode, removeProjectNode, type RemoteNodeInput } from './project-node-append'
@@ -344,6 +344,7 @@ export class WorkspaceStore {
               breadcrumbs: e.breadcrumbs,
               closedSessions: e.closedSessions,
               capabilityAck: e.capabilityAck,
+              capabilityAckSource: e.capabilityAckSource,
               localExec: this.execOverlay(e, p)
             })
           })
@@ -366,6 +367,7 @@ export class WorkspaceStore {
               breadcrumbs: e.breadcrumbs,
               closedSessions: e.closedSessions,
               capabilityAck: e.capabilityAck,
+              capabilityAckSource: e.capabilityAckSource,
               localExec: this.execOverlay(e, e.cache)
             })
           })
@@ -851,6 +853,7 @@ export class WorkspaceStore {
       breadcrumbs: e.breadcrumbs,
       closedSessions: e.closedSessions,
       capabilityAck: e.capabilityAck,
+      capabilityAckSource: e.capabilityAckSource,
       localExec: this.execOverlay(e, read.file)
     })
     e.project = project
@@ -973,6 +976,7 @@ export class WorkspaceStore {
         // The clone-notice acknowledgment must also survive an unavailable window: forgetting it
         // would re-raise a notice the user already answered the moment the folder remounts.
         if (old?.capabilityAck) e.capabilityAck = old.capabilityAck
+        if (old?.capabilityAckSource) e.capabilityAckSource = old.capabilityAckSource
         // A data-ref placeholder (its file was unreadable at load) must stay a data-ref. Without
         // this the entry comes back as a PRE-FILE inline entry holding the placeholder's
         // `nodes: []` — the empty canvas becomes the stored truth and the file it named is
@@ -1200,7 +1204,13 @@ export class WorkspaceStore {
     return this.lastWritten.get(filePath) === content
   }
 
-  async readLocalRef(projectId: string): Promise<Project | null> {
+  readLocalRef(projectId: string): Promise<Project | null> {
+    const run = this.saveChain.then(() => this.readLocalRefNow(projectId))
+    this.saveChain = run.catch(() => {})
+    return run
+  }
+
+  private async readLocalRefNow(projectId: string): Promise<Project | null> {
     const e = this.index?.entries.find((x) => x.id === projectId && x.cwd)
     if (!e?.cwd) return null
     const read = await this.readProjectFile(e.cwd, false)
@@ -1210,6 +1220,15 @@ export class WorkspaceStore {
     // drops it. Same for the camera: a teammate's committed viewport must not yank this user's.
     this.revs.set(e.id, read.file.rev)
     this.lastWritten.set(projectFilePath(e.cwd), read.raw)
+    // This method is reached only for a watcher-confirmed external write. A global default was
+    // consent for the file this machine created, not for a checkout/pull that replaces it.
+    if (this.rearmSeededCapabilityAcks(e) && this.index) {
+      // Consent state must survive an immediate quit; leaving it only in the renderer would let
+      // the same external file regain the old seeded answer on restart. This read runs on
+      // saveChain, so the index write cannot race an ordinary workspace save.
+      this.applySettingsToIndex(this.index)
+      await writeAtomic(this.indexPath, JSON.stringify(this.index))
+    }
     return fileToProject(read.file, {
       id: e.id,
       cwd: e.cwd,
@@ -1220,6 +1239,7 @@ export class WorkspaceStore {
       breadcrumbs: e.breadcrumbs,
       closedSessions: e.closedSessions,
       capabilityAck: e.capabilityAck,
+      capabilityAckSource: e.capabilityAckSource,
       localExec: e.localExec
     })
   }
@@ -1439,25 +1459,32 @@ export class WorkspaceStore {
    */
   capabilityProjectFor(
     projectId: string
-  ): (Partial<Record<ProjectCapability, true>> & { capabilityAck?: CapabilityAckMap }) | undefined {
+  ): (Partial<Record<ProjectCapability, true>> & {
+    capabilityAck?: CapabilityAckMap
+    capabilityAckSource?: import('./project-capability-consent').CapabilityAckSourceMap
+  }) | undefined {
     for (const e of this.index?.entries ?? []) {
       if (e.project) {
         if (e.project.id !== projectId) continue
         return {
           ...readProjectCapabilities(e.project),
-          ...(e.project.capabilityAck ? { capabilityAck: e.project.capabilityAck } : {})
+          ...(e.project.capabilityAck ? { capabilityAck: e.project.capabilityAck } : {}),
+          ...(e.project.capabilityAckSource
+            ? { capabilityAckSource: e.project.capabilityAckSource }
+            : {})
         }
       }
       if (e.id !== projectId) continue
       const ack = e.capabilityAck ? { capabilityAck: e.capabilityAck } : {}
-      if (e.cache) return { ...readProjectCapabilities(e.cache), ...ack }
+      const source = e.capabilityAckSource ? { capabilityAckSource: e.capabilityAckSource } : {}
+      if (e.cache) return { ...readProjectCapabilities(e.cache), ...ack, ...source }
       if (e.cwd) {
         const raw = this.lastWritten.get(projectFilePath(e.cwd))
-        if (!raw) return { ...ack } // file never read this run: no flag known, so nothing grants
+        if (!raw) return { ...ack, ...source } // file never read this run: no flag known, so nothing grants
         try {
-          return { ...readProjectCapabilities(JSON.parse(raw)), ...ack }
+          return { ...readProjectCapabilities(JSON.parse(raw)), ...ack, ...source }
         } catch {
-          return { ...ack } // corrupt file: fail closed, like every other reader of this cache
+          return { ...ack, ...source } // corrupt file: fail closed, like every other reader of this cache
         }
       }
       return undefined
@@ -1511,6 +1538,16 @@ export class WorkspaceStore {
    *  (a phone append, another machine's save with its own savedAt) hashes differently. */
   private isOwnMirrorContent(projectId: string, content: string): boolean {
     return this.recentMirrorHashes.get(projectId)?.includes(contentHash(content)) ?? false
+  }
+
+  /** Re-arm only global-default answers when an external project document enters this lineage. */
+  private rearmSeededCapabilityAcks(e: IndexEntryV3): boolean {
+    const next = rearmDefaultCapabilityAcks(e)
+    if (next === e) return false
+    if (next.capabilityAck) e.capabilityAck = next.capabilityAck
+    else delete e.capabilityAck
+    delete e.capabilityAckSource
+    return true
   }
 
   /**
@@ -1583,6 +1620,7 @@ export class WorkspaceStore {
           breadcrumbs: e.breadcrumbs,
           closedSessions: e.closedSessions,
           capabilityAck: e.capabilityAck,
+          capabilityAckSource: e.capabilityAckSource,
           localExec: e.localExec
         })
       )
@@ -1641,6 +1679,7 @@ export class WorkspaceStore {
             breadcrumbs: e.breadcrumbs,
             closedSessions: e.closedSessions,
             capabilityAck: e.capabilityAck,
+            capabilityAckSource: e.capabilityAckSource,
             localExec: e.localExec
           })
         )
@@ -1708,7 +1747,8 @@ export class WorkspaceStore {
       id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
       viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
       closedSessions: e.closedSessions,
-      capabilityAck: e.capabilityAck, localExec: e.localExec
+      capabilityAck: e.capabilityAck, capabilityAckSource: e.capabilityAckSource,
+      localExec: e.localExec
     })
   }
 
@@ -1764,6 +1804,7 @@ export class WorkspaceStore {
       return null
     }
     let remote: ProjectFileV1 | null = null
+    let rearmedDefault = false
     if (res.status === 'ok') {
       try {
         const parsed = JSON.parse(res.content) as ProjectFileV1
@@ -1776,6 +1817,7 @@ export class WorkspaceStore {
       // exact bytes keeps the genuine-external-edit path untouched (any other writer's file —
       // a phone append, another machine's save — hashes differently).
       if (remote && this.isOwnMirrorContent(e.id, res.content)) remote = null
+      else if (remote) rearmedDefault = this.rearmSeededCapabilityAcks(e)
     }
     this.reconciled.add(e.id)
     const cacheRev = e.cache?.rev ?? 0
@@ -1826,7 +1868,8 @@ export class WorkspaceStore {
         id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
         viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
         closedSessions: e.closedSessions,
-        capabilityAck: e.capabilityAck, localExec: e.localExec
+        capabilityAck: e.capabilityAck, capabilityAckSource: e.capabilityAckSource,
+        localExec: e.localExec
       })
     }
     // Our cache stood. Before it clobbers the server, merge in any remote-only session nodes (the
@@ -1842,7 +1885,8 @@ export class WorkspaceStore {
           id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
           viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
           closedSessions: e.closedSessions,
-          capabilityAck: e.capabilityAck, localExec: e.localExec
+          capabilityAck: e.capabilityAck, capabilityAckSource: e.capabilityAckSource,
+          localExec: e.localExec
         })
       }
     }
@@ -1865,7 +1909,15 @@ export class WorkspaceStore {
     }
     // Surface a rescued merge to the renderer even on a read-only poll (pushIfStanding:false) — the
     // whole point is the phone's session reaching the live desktop canvas without a reconnect.
-    return merged
+    if (merged || !rearmedDefault || !e.cache) return merged
+    // Even when our cache wins on content, the remote file was not one this machine authored.
+    // Return the same canvas with its seeded answer removed so the renderer raises the notice.
+    return fileToProject(e.cache, {
+      id: e.id, ssh: e.ssh, closed: e.closed, closedAt: e.closedAt,
+      viewport: e.viewport, defaultAccountId: e.defaultAccountId, breadcrumbs: e.breadcrumbs,
+      closedSessions: e.closedSessions, capabilityAck: e.capabilityAck,
+      capabilityAckSource: e.capabilityAckSource, localExec: e.localExec
+    })
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1704,9 +1704,9 @@ app.whenReady().then(async () => {
     // clone notice (projectCapabilityGrantedFor — never the raw file bit). Read per call off
     // the store's index, so a decline or an off-toggle refuses the very next delivery.
     messagingEnabled: messagingEnabledVia((id) => workspaceStore.capabilityProjectFor(id)),
-    // Runtime pane ownership: which project actually SPAWNED the target's pane this run
-    // (core/agents/pane-ownership.ts). The gate trusts this over the attacker-writable store to
-    // decide whose grant applies; unproven ⇒ refused (PR #237 fix round 2).
+    // Proven pane ownership: which project actually spawned the target's pane, restored across an
+    // app restart only through a signed machine-local proof (core/agents/pane-ownership.ts). The
+    // gate trusts this over the attacker-writable store; unproven ⇒ refused (PR #237 fix round 2).
     paneOwnerProject: (id) => paneOwnerProject(id),
     customAgents: () => settingsStore.get().customAgents,
     appendBoardLog: (projectId, entry) => appendBoardLogVia(boardLogRouter, projectId, entry)

--- a/src/renderer/components/settings/agents-capabilities.test.tsx
+++ b/src/renderer/components/settings/agents-capabilities.test.tsx
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { Project } from '@shared/types'
+import { DEFAULT_SETTINGS } from '@shared/types'
 import {
   PROJECT_CAPABILITIES,
   PROJECT_CAPABILITY_COPY,
@@ -15,6 +16,7 @@ import {
 } from '@shared/project-capabilities'
 import { projectCapabilityGrantedFor } from '@shared/project-capability-consent'
 import { useProjects } from '../../state/projects'
+import { useSettings } from '../../state/settings'
 import { AgentsSection } from './sections/AgentsSection'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -50,6 +52,7 @@ beforeEach(() => {
     claude: { cliCaps: vi.fn(async () => null) }
   }
   useProjects.setState({ projects: [project()], activeProjectId: 'p1', reloadNonce: 0 })
+  useSettings.setState({ settings: DEFAULT_SETTINGS, hydrated: true })
 })
 
 afterEach(() => {
@@ -59,6 +62,17 @@ afterEach(() => {
 })
 
 describe('per-project capability rows, generated from PROJECT_CAPABILITIES', () => {
+  it('offers a machine-local messaging default for projects created later', () => {
+    mount()
+    const toggle = host.querySelector<HTMLElement>(
+      '[role="switch"][aria-label="Messaging in new projects"]'
+    )
+    expect(toggle).toBeTruthy()
+    expect(useSettings.getState().settings.agentMessagingDefault).toBe(false)
+    act(() => toggle!.click())
+    expect(useSettings.getState().settings.agentMessagingDefault).toBe(true)
+  })
+
   it('renders one row per capability, naming the active project, the grant and what travels', () => {
     mount()
     const text = host.textContent ?? ''

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -91,6 +91,10 @@ const ROWS = {
     title: 'One-click approvals',
     keywords: ['approve', 'deny', 'approval', 'permission', 'hook', 'phone', 'canvas', 'one click', 'claude']
   },
+  messagingDefault: {
+    title: 'Messaging in new projects',
+    keywords: ['agent', 'message', 'messaging', 'default', 'project', 'communication']
+  },
   nodeIdentity: {
     title: 'Verified node identity',
     keywords: [
@@ -396,6 +400,19 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
               checked={settings.hookReplyApprovals}
               ariaLabel="One-click hook-reply approvals"
               onChange={(on) => update({ hookReplyApprovals: on })}
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.messagingDefault}>
+        <FieldRow
+          label="Messaging in new projects"
+          description="Turn agent messaging on when this machine creates a project. Existing projects keep their current setting, and cloned project files still require confirmation."
+          control={
+            <Switch
+              checked={settings.agentMessagingDefault}
+              ariaLabel="Messaging in new projects"
+              onChange={(on) => update({ agentMessagingDefault: on })}
             />
           }
         />

--- a/src/renderer/state/projects.test.ts
+++ b/src/renderer/state/projects.test.ts
@@ -17,12 +17,14 @@ describe('messaging default for new projects', () => {
     const p = useProjects.getState().addProject('my-app', '/Users/me/dev/my-app')
     expect(p.agentMessaging).toBe(true)
     expect(p.capabilityAck?.agentMessaging).toBe('kept')
+    expect(p.capabilityAckSource?.agentMessaging).toBe('local-default')
   })
 
   it('leaves messaging absent when disabled', () => {
     const p = useProjects.getState().addProject('my-app', '/Users/me/dev/my-app')
     expect(p.agentMessaging).toBeUndefined()
     expect(p.capabilityAck?.agentMessaging).toBeUndefined()
+    expect(p.capabilityAckSource?.agentMessaging).toBeUndefined()
   })
 
   it('does not grant messaging to an adopted project', () => {

--- a/src/renderer/state/projects.test.ts
+++ b/src/renderer/state/projects.test.ts
@@ -1,8 +1,47 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { DEFAULT_SETTINGS } from '@shared/types'
 import { useProjects } from './projects'
+import { useSettings } from './settings'
 
 beforeEach(() => {
   useProjects.getState().hydrate({ version: 2, activeProjectId: '', projects: [] })
+  useSettings.setState({ settings: DEFAULT_SETTINGS, hydrated: true })
+})
+
+describe('messaging default for new projects', () => {
+  it('seeds the project switch and local consent when enabled', () => {
+    useSettings.setState({
+      settings: { ...DEFAULT_SETTINGS, agentMessagingDefault: true },
+      hydrated: true
+    })
+    const p = useProjects.getState().addProject('my-app', '/Users/me/dev/my-app')
+    expect(p.agentMessaging).toBe(true)
+    expect(p.capabilityAck?.agentMessaging).toBe('kept')
+  })
+
+  it('leaves messaging absent when disabled', () => {
+    const p = useProjects.getState().addProject('my-app', '/Users/me/dev/my-app')
+    expect(p.agentMessaging).toBeUndefined()
+    expect(p.capabilityAck?.agentMessaging).toBeUndefined()
+  })
+
+  it('does not grant messaging to an adopted project', () => {
+    useSettings.setState({
+      settings: { ...DEFAULT_SETTINGS, agentMessagingDefault: true },
+      hydrated: true
+    })
+    const p = useProjects.getState().adoptProject({
+      id: 'project-from-file',
+      name: 'clone',
+      color: '#7aa2f7',
+      cwd: '/Users/me/dev/clone',
+      agentMessaging: true,
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: []
+    })
+    expect(p.agentMessaging).toBe(true)
+    expect(p.capabilityAck?.agentMessaging).toBeUndefined()
+  })
 })
 
 describe('openFolderProject', () => {

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -1167,11 +1167,15 @@ export function createProject(
     color: NODE_COLORS[index % NODE_COLORS.length],
     cwd,
     ...(ssh ? { ssh } : {}),
-    // This machine's global preference is an explicit local choice, so it seeds both the
-    // git-shared switch and the machine-local consent answer. Adopted/cloned projects bypass this
-    // factory and retain the clone notice gate.
+    // This machine's global preference seeds the switch and a machine-local answer for a file
+    // created here. The provenance marker is re-armed if an external local/SSH file later replaces
+    // or contributes to that lineage; adopted/cloned projects bypass this factory entirely.
     ...(agentMessaging
-      ? { agentMessaging: true, capabilityAck: { agentMessaging: 'kept' as const } }
+      ? {
+          agentMessaging: true,
+          capabilityAck: { agentMessaging: 'kept' as const },
+          capabilityAckSource: { agentMessaging: 'local-default' as const }
+        }
       : {}),
     viewport: { x: 0, y: 0, zoom: 1 },
     nodes: []

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -1158,7 +1158,8 @@ export function createProject(
   index: number,
   name?: string,
   cwd?: string,
-  ssh?: Project['ssh']
+  ssh?: Project['ssh'],
+  agentMessaging = useSettings.getState().settings.agentMessagingDefault
 ): Project {
   return {
     id: nextId('project'),
@@ -1166,6 +1167,12 @@ export function createProject(
     color: NODE_COLORS[index % NODE_COLORS.length],
     cwd,
     ...(ssh ? { ssh } : {}),
+    // This machine's global preference is an explicit local choice, so it seeds both the
+    // git-shared switch and the machine-local consent answer. Adopted/cloned projects bypass this
+    // factory and retain the clone notice gate.
+    ...(agentMessaging
+      ? { agentMessaging: true, capabilityAck: { agentMessaging: 'kept' as const } }
+      : {}),
     viewport: { x: 0, y: 0, zoom: 1 },
     nodes: []
   }

--- a/src/shared/default-settings.test.ts
+++ b/src/shared/default-settings.test.ts
@@ -21,6 +21,10 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.claudePermissionMode).toBe('auto')
   })
 
+  it('keeps messaging in new projects opt-in', () => {
+    expect(DEFAULT_SETTINGS.agentMessagingDefault).toBe(false)
+  })
+
   it('uses the shared worktree path template default', () => {
     expect(DEFAULT_SETTINGS.worktreePathTemplate).toBe(DEFAULT_WORKTREE_PATH_TEMPLATE)
   })

--- a/src/shared/project-capability-consent.ts
+++ b/src/shared/project-capability-consent.ts
@@ -38,6 +38,11 @@ export type CapabilityAnswer = 'kept' | 'declined'
  *  test with an ack-carrying project as input). */
 export type CapabilityAckMap = Partial<Record<ProjectCapability, CapabilityAnswer>>
 
+/** A machine-local answer installed by a global creation default, before any shared file was
+ *  adopted. Unlike an explicit per-project answer, this provenance is re-armed when an external
+ *  project file replaces or contributes to the machine-authored lineage. */
+export type CapabilityAckSourceMap = Partial<Record<ProjectCapability, 'local-default'>>
+
 export interface CapabilityConsentState {
   capability: ProjectCapability
   /** The strict read of the shared file's switch (`projectCapabilityFlagInFile` — literal true
@@ -110,5 +115,29 @@ export function recordCapabilityAck<E extends { capabilityAck?: CapabilityAckMap
   cap: ProjectCapability,
   answer: CapabilityAnswer
 ): E {
-  return { ...entry, capabilityAck: { ...entry.capabilityAck, [cap]: answer } }
+  const next = { ...entry, capabilityAck: { ...entry.capabilityAck, [cap]: answer } } as E & {
+    capabilityAckSource?: CapabilityAckSourceMap
+  }
+  if (!next.capabilityAckSource?.[cap]) return next
+  const capabilityAckSource = { ...next.capabilityAckSource }
+  delete capabilityAckSource[cap]
+  if (Object.keys(capabilityAckSource).length) next.capabilityAckSource = capabilityAckSource
+  else delete next.capabilityAckSource
+  return next
+}
+
+/** Remove only answers seeded by the global creation default. Explicit per-project answers stand. */
+export function rearmDefaultCapabilityAcks<
+  E extends { capabilityAck?: CapabilityAckMap; capabilityAckSource?: CapabilityAckSourceMap }
+>(entry: E): E {
+  if (!entry.capabilityAckSource) return entry
+  const capabilityAck = { ...entry.capabilityAck }
+  for (const cap of Object.keys(entry.capabilityAckSource) as ProjectCapability[]) {
+    delete capabilityAck[cap]
+  }
+  const next = { ...entry } as E
+  if (Object.keys(capabilityAck).length) next.capabilityAck = capabilityAck
+  else delete next.capabilityAck
+  delete next.capabilityAckSource
+  return next
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -739,6 +739,9 @@ export interface Project {
    * (workspace-files.test.ts / capability-notice tests pin that the file bytes are unchanged).
    */
   capabilityAck?: import('./project-capability-consent').CapabilityAckMap
+  /** MACHINE-LOCAL provenance for an acknowledgment seeded by a global new-project default.
+   *  External project-file adoption clears the seeded answer and raises the normal notice. */
+  capabilityAckSource?: import('./project-capability-consent').CapabilityAckSourceMap
   /** Best dino-game score in this project — new dino nodes seed from it, so the record survives closing the node. */
   dinoHighScore?: number
   /** Kanban task board — shared via .nodeterm/project.json like nodes. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -92,10 +92,11 @@ export interface PtyCreateOptions {
   persistKey?: string
   /**
    * The machine-local id (`IndexEntryV3.id`) of the project this node belongs to, as the renderer
-   * knows it at the create call. Recorded in the runtime pane-ownership ledger on a GENUINE FRESH
-   * spawn (`agents/pane-ownership.ts`) so agent messaging can prove which project actually spawned
-   * a pane rather than trusting the git-shared, forgeable `project.json`. Optional: absent ⇒ the
-   * pane is left unproven and messaging to it fails closed (never derived from the file id).
+   * knows it at the create call. A GENUINE FRESH spawn records it in the pane-ownership ledger and
+   * writes a signed machine-local restart proof bound to that tmux generation
+   * (`agents/pane-ownership.ts`). A warm attach may restore only the same signed owner and live
+   * generation, so agent messaging never trusts the git-shared, forgeable `project.json`.
+   * Optional: absent ⇒ the pane is left unproven and messaging to it fails closed.
    */
   ownerProjectId?: string
   /**
@@ -1533,6 +1534,10 @@ export interface Settings {
    *  driver runs in `default`). Overridable per project via Project.defaultPermissionMode.
    *  `auto` is version-gated: CLIs below 2.1.71 reject the value, so it degrades to no flag. */
   claudePermissionMode: AgentPermissionMode
+  /** Turn agent messaging on when this machine creates a project. This is a machine-local
+   *  default, not a blanket grant: existing projects keep their own switch, and a project
+   *  adopted from `.nodeterm/project.json` still goes through the clone-consent gate. */
+  agentMessagingDefault: boolean
   /** "Eco": exit the agent CLI of a session that has been idle AND offscreen for
    *  `agentHibernationIdleMinutes`, reclaiming its RAM; the conversation is resumed automatically
    *  when the node is viewed again. Default OFF — opt-in, because it stops a real process.
@@ -1718,6 +1723,9 @@ export const DEFAULT_SETTINGS: Settings = {
   // Sessions start in auto mode out of the box. Existing users pick this up on hydrate
   // (settings hydrate merges over DEFAULT_SETTINGS) — a deliberate behavior change.
   claudePermissionMode: 'auto',
+  // Opt-in: new projects inherit this machine-local preference and record the user's consent.
+  // Existing and cloned projects are untouched.
+  agentMessagingDefault: false,
   // Opt-in: hibernation exits a live CLI, so nobody gets it without asking. The 30-minute floor
   // is deliberately long — shorter windows exit sessions the user is between turns on.
   agentHibernationEnabled: false,


### PR DESCRIPTION
## Summary

- add a machine-local setting that enables messaging for newly created projects
- keep existing projects unchanged and preserve clone confirmation
- restore local tmux pane ownership across app restarts with a signed, generation-bound proof
- keep unsupported or unverifiable warm sessions fail-closed

Existing local panes created before this upgrade need one terminal-session restart to establish a proof.

## Verification

- npm run typecheck
- 153 focused tests across settings, project creation, messaging ownership, and terminal persistence
- npm run build
- built Electron app exercised with Playwright: setting toggled successfully, no console or network errors
- independent correctness and security review: no remaining major findings