### PR TITLE
fix(canvas): an unreachable filesystem is not an empty folder (#294 follow-ups)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -963,9 +963,12 @@ session.
     (`main/ssh-fs.ts:164-176`) refuses, on the rule "a failed read is never evidence of absence". Now
     disambiguated by probing the PARENT's listing instead (`classifyEmptyListing`, pure,
     `lib/filesNode.ts` — the idiom `SshProjectDialog.tsx:112-125` and `file-links.ts`'s
-    `makeDirListingLookup` already use), which answers `missing` / `empty` / `unknown`: an unreadable
-    parent answers `unknown`, and we keep saying "empty" rather than claim a deletion we can't
-    prove. **`unknown` also covers every path whose parent CANNOT answer** — a non-`/`-absolute cwd
+    `makeDirListingLookup` already use), which answers `missing` / `empty` / `unreachable` /
+    `unknown`. The parent CONTAINS the directory we are standing in, so it cannot legitimately be
+    childless: an empty parent listing means we could not see it, which is `unreachable` and gets
+    its own sentence naming both possible causes. That case used to answer `unknown` and render as
+    "This folder is empty." over a dead ControlMaster, the commonest cause of an empty remote
+    listing and the most reassuring possible lie. **`unknown` is reserved for the paths whose parent CANNOT answer** — a non-`/`-absolute cwd
     (an SSH project's `remoteCwd` defaults to **`~`**, where `parentDir` is `/` and `/` has no entry
     named `~`, so an empty remote HOME reported a deletion), a `.git` cwd (both listing legs strip
     it on purpose), and `.`/`..` segments; a case-folded match counts as present, for the
@@ -1031,7 +1034,11 @@ session.
   - **The `/`-separator assumption is a KNOWN gap, shared with `explorerCreate`** (the Explorer
     drawer and canvas "New file…" already run on the same helpers) — `C:\x\y` reads as one segment.
     To be closed in ONE place for both, using the core-owns-the-dialect rule `terminal/file-links.ts`
-    already implements.
+    already implements. The TRAVERSAL half is closed: `newEntryPath` splits its `..` check on
+    `[\\/]` and refuses a Windows-absolute name, because a guard that reads `\` as ordinary text is
+    wrong about the machine that resolves the path. The construction half deliberately is not: on
+    POSIX a backslash is legal filename text, so the join stays `/` and `weird\name.txt` is still
+    one file. Guard on both dialects, construct in one.
   - **Mobile**: N/A — *nodeterm mobile* attaches to tmux sessions over the transport protocol and
     has no canvas or file-browsing concept; adding one means extending that protocol.
 - **dino** (`DinoNode.tsx`) — a small self-contained T-Rex-style runner on a canvas (no PTY);

--- a/src/renderer/lib/explorerCreate.test.ts
+++ b/src/renderer/lib/explorerCreate.test.ts
@@ -28,6 +28,31 @@ describe('newEntryPath', () => {
     expect(newEntryPath('/repo', 'a/../../evil')).toBeNull()
     expect(newEntryPath('/repo', 'a/')).toBeNull()
   })
+
+  // The hole eneskirca spotted on #294: `..` was only ever looked for between `/` separators, so
+  // a backslash-delimited traversal was one segment that is neither empty nor `..`. It passed on
+  // every platform and escaped `baseDir` as soon as Windows resolved it.
+  it('rejects a backslash traversal, which used to pass as a single segment', () => {
+    expect(newEntryPath('/repo', '..\\evil')).toBeNull()
+    expect(newEntryPath('/repo', 'a\\..\\..\\evil')).toBeNull()
+    expect(newEntryPath('/repo', 'a/..\\evil')).toBeNull()
+    expect(newEntryPath('/repo', 'a\\../evil')).toBeNull()
+  })
+
+  it('rejects a name that is absolute in the Windows dialect', () => {
+    expect(newEntryPath('/repo', '\\Windows\\system32')).toBeNull()
+    expect(newEntryPath('/repo', 'C:\\Windows')).toBeNull()
+    expect(newEntryPath('/repo', 'C:/Windows')).toBeNull()
+    expect(newEntryPath('/repo', 'a\\')).toBeNull()
+  })
+
+  // CONTRIBUTING is explicit that the two separators are NOT interchangeable: on POSIX a
+  // backslash is ordinary filename text. The guard reads both dialects, the construction stays
+  // `/`, and a legal POSIX name survives.
+  it('still accepts a backslash as ordinary filename text', () => {
+    expect(newEntryPath('/repo', 'weird\\name.txt')).toBe('/repo/weird\\name.txt')
+    expect(newEntryPath('/repo', 'a\\\\b')).toBe('/repo/a\\\\b')
+  })
 })
 
 describe('ancestorDirs', () => {

--- a/src/renderer/lib/explorerCreate.ts
+++ b/src/renderer/lib/explorerCreate.ts
@@ -14,13 +14,28 @@ export function parentDir(p: string): string {
 
 /**
  * Join a user-entered name onto a base dir. Multi-segment relative names (`a/b.ts`) are
- * allowed — intermediate dirs are the caller's job (see `ancestorDirs`). Returns null for
- * anything unsafe or senseless: empty, absolute, `..` traversal, trailing slash.
+ * allowed, and the intermediate dirs are the caller's job (see `ancestorDirs`). Returns null for
+ * anything unsafe or senseless: empty, absolute, `..` traversal, trailing separator.
+ *
+ * The `..` guard splits on BOTH separators, the rule CONTRIBUTING states for every path split:
+ * `..\x` used to be a single segment that was neither empty nor `..`, so it passed here on every
+ * platform and then escaped `baseDir` the moment Windows resolved it. That is the same hole the
+ * node-icon traversal check had, and the same fix.
+ *
+ * The path is still BUILT with `/`, and the empty-segment check still splits on `/` alone, on
+ * purpose: on POSIX a backslash is ordinary filename text, so `a\\b` is a legal name for one file
+ * and refusing it would be this guard being wrong about the filesystem it is writing to. Guard on
+ * both dialects, construct in one.
  */
 export function newEntryPath(baseDir: string, name: string): string | null {
   const n = name.trim()
-  if (!n || n.startsWith('/') || n.endsWith('/')) return null
-  if (n.split('/').some((seg) => !seg || seg === '..')) return null
+  if (!n) return null
+  // Absolute in either dialect escapes `baseDir`, which is the whole point of joining onto it:
+  // a leading `/`, a leading `\` (root of the current Windows drive), or a drive qualifier.
+  if (n.startsWith('/') || n.startsWith('\\') || /^[A-Za-z]:/.test(n)) return null
+  if (n.endsWith('/') || n.endsWith('\\')) return null
+  if (n.split(/[\\/]/).some((seg) => seg === '..')) return null
+  if (n.split('/').some((seg) => !seg)) return null
   return `${baseDir.replace(/\/+$/, '')}/${n}`
 }
 

--- a/src/renderer/lib/filesNode.test.ts
+++ b/src/renderer/lib/filesNode.test.ts
@@ -116,15 +116,25 @@ describe('classifyEmptyListing', () => {
     expect(classifyEmptyListing('/repo/docs/', parent)).toBe('empty')
   })
 
-  // "A failed read is never evidence of absence" (SshFs.readTextChecked). Under the same
-  // fail-open contract an empty PARENT means unreadable-or-gone, not childless — so we learned
-  // nothing and must not tell the user their folder was deleted.
-  it('says unknown when the parent itself came back empty', () => {
-    expect(classifyEmptyListing('/repo/docs', [])).toBe('unknown')
+  // The parent contains us, so it cannot legitimately be childless: an empty listing means we
+  // could not see it. That is real information, and reporting it as `unknown` let the node say
+  // "This folder is empty." over a dead ControlMaster, which is the commonest cause of an empty
+  // remote listing.
+  it('says unreachable when the parent itself came back empty', () => {
+    expect(classifyEmptyListing('/repo/docs', [])).toBe('unreachable')
   })
 
-  it('says unknown when the parent could not be asked at all', () => {
-    expect(classifyEmptyListing('/repo/docs', null)).toBe('unknown')
+  it('says unreachable when the parent could not be asked at all', () => {
+    expect(classifyEmptyListing('/repo/docs', null)).toBe('unreachable')
+  })
+
+  // The distinction that keeps `unreachable` honest: a path whose parent could never answer is
+  // still `unknown`, so a `~` root or a `.git` cwd does not start claiming the host is down.
+  it('keeps unknown for the paths no parent listing could ever answer', () => {
+    expect(classifyEmptyListing('~', null)).toBe('unknown')
+    expect(classifyEmptyListing('~', [])).toBe('unknown')
+    expect(classifyEmptyListing('/repo/.git', [])).toBe('unknown')
+    expect(classifyEmptyListing('relative/dir', [])).toBe('unknown')
   })
 
   // Root has no parent to interrogate and always exists.

--- a/src/renderer/lib/filesNode.ts
+++ b/src/renderer/lib/filesNode.ts
@@ -81,7 +81,7 @@ export function displacedFilesPatch(
     : { cwd: fallbackCwd }
 }
 
-export type EmptyListingVerdict = 'empty' | 'missing' | 'unknown'
+export type EmptyListingVerdict = 'empty' | 'missing' | 'unreachable' | 'unknown'
 
 /**
  * What an EMPTY listing actually means.
@@ -98,15 +98,18 @@ export type EmptyListingVerdict = 'empty' | 'missing' | 'unknown'
  * is never evidence of absence*. Instead we ask the PARENT's listing, the same way
  * `SshProjectDialog` and `file-links.ts`'s `makeDirListingLookup` already answer this question.
  *
- * Three answers, and the third is the point:
+ * Four answers, and the last two are the point:
  *  - `missing` — the parent listed real entries and ours is not among them. Only this earns the
  *    error state.
  *  - `empty`   — the parent lists us, so the directory is there and simply has nothing in it.
  *    Root takes this too: it has no parent to ask and always exists.
- *  - `unknown` — the parent itself came back empty, which under the same fail-open contract means
- *    the parent is unreadable or gone rather than childless. We learned nothing, so we claim
- *    nothing; the caller keeps saying "empty". Understating beats telling someone their folder
- *    was deleted because a network hiccup ate one `ls`.
+ *  - `unreachable` — the parent came back empty or could not be read at all. It cannot be
+ *    childless, since it contains us, so this says we could not see the filesystem. We still
+ *    cannot tell "the whole subtree is gone" from "the connection is down", so the verdict names
+ *    the doubt instead of guessing.
+ *  - `unknown` — the path SHAPE means no parent listing could ever answer (see below). Genuinely
+ *    no information, so the caller keeps saying "empty". Understating beats telling someone their
+ *    folder was deleted because a network hiccup ate one `ls`.
  *
  * Matching is by NAME, not by `dir`, deliberately: a symlinked directory can list as a non-dir
  * entry depending on the leg, and mistaking one for "missing" is the false alarm this exists to
@@ -134,7 +137,15 @@ export function classifyEmptyListing(
   //    node pointed at one can never find itself in its parent.
   if (!trimmed.startsWith('/') || name === '.' || name === '..' || name === '.git') return 'unknown'
 
-  if (!parentEntries || parentEntries.length === 0) return 'unknown'
+  // The parent could not be read. Note it cannot legitimately be EMPTY either: it contains the
+  // directory we are standing in, so an empty listing means we could not see it, exactly as the
+  // fail-open contract allows. That is real information and it used to be thrown away as
+  // `unknown`, leaving the node saying "This folder is empty." over a dead ControlMaster, which
+  // is the most common cause of an empty remote listing and the most reassuring possible lie.
+  //
+  // We still cannot say WHICH (the whole subtree deleted, or the filesystem out of reach), so the
+  // verdict names the doubt rather than picking one.
+  if (!parentEntries || parentEntries.length === 0) return 'unreachable'
   if (parentEntries.some((e) => e.name === name)) return 'empty'
   // A case-insensitive filesystem (APFS, NTFS) lists a directory fine under a cwd whose case
   // differs from the on-disk spelling, and `readdir` answers with the on-disk one. Treat that as

--- a/src/renderer/nodes/FilesNode.tsx
+++ b/src/renderer/nodes/FilesNode.tsx
@@ -48,6 +48,14 @@ import { ContextMenu, type MenuItem } from '../components/ContextMenu'
 import { isBrowserRuntime } from '../bridge/runtime'
 import { canUseLocalShell } from '../lib/download'
 
+/**
+ * Shown when the parent listing could not be read either. It deliberately names BOTH possible
+ * causes rather than picking one: the fail-open `FsApi` contract gives an empty array for a
+ * deleted directory and for a dead ControlMaster alike, so the honest thing is to say we could
+ * not see it and let the user tell the two apart.
+ */
+const UNREACHABLE_MESSAGE = 'Could not reach this folder. It may be gone, or its filesystem may be unavailable.'
+
 /** Surface a transient error the way every other node does (Canvas listens for this). */
 const toast = (message: string): void => {
   window.dispatchEvent(new CustomEvent('nodeterm:toast', { detail: { kind: 'error', message } }))
@@ -156,13 +164,17 @@ export function FilesNode({ id, data, selected }: NodeProps<CanvasNode>) {
       try {
         if (parent !== cwd) parentEntries = await fs.list(parent)
       } catch {
-        parentEntries = null // could not ask ⇒ claim nothing
+        parentEntries = null // could not ask, so claim nothing
       }
       if (!live) return
       setListing({ cwd, entries: list })
-      if (classifyEmptyListing(cwd, parentEntries) === 'missing') {
-        setError('Could not read this folder.')
-      }
+      // Only `empty` and `unknown` fall through to "This folder is empty.", and they are the two
+      // cases where that sentence is true or at least not a claim. The other two each get their
+      // own, because saying "empty" over a folder that is gone, or over a filesystem we simply
+      // could not see, is the reassuring kind of wrong.
+      const verdict = classifyEmptyListing(cwd, parentEntries)
+      if (verdict === 'missing') setError('Could not read this folder.')
+      else if (verdict === 'unreachable') setError(UNREACHABLE_MESSAGE)
     })()
     return () => {
       live = false


### PR DESCRIPTION
Hi all,

This picks up the two follow-ups from the #294 review: the file manager calling an unreachable filesystem "empty", which @eneskirca said he would take first, and `newEntryPath` still splitting on `/` only, which is the next site for the rule #293 added to CONTRIBUTING. They are independent, so it is one commit each.

## Why

The first one is the reassuring kind of wrong. `FsApi` is fail-open by contract, so an SSH project whose ControlMaster is down answers `[]` for the directory and `[]` for its parent as well, and the node then said "This folder is empty." about a host it could not reach at all. That is probably the commonest cause of an empty remote listing, and the sentence gives the user no reason to suspect their connection.

The parent listing is the evidence that was being thrown away. It contains the directory we are standing in, so it cannot legitimately be childless: an empty listing there means we could not see it, not that there is nothing to see. `unknown` was collapsing that together with the paths whose shape means no parent could ever answer, and those two deserve different sentences.

The second one is a traversal check that reads `\` as ordinary text. `..\x` was a single segment that is neither empty nor `..`, so it passed `newEntryPath` on every platform and escaped the base directory the moment Windows resolved it. It is the same hole the node-icon guard had in #293, which is where the CONTRIBUTING rule comes from, and this function is the next place it applies.

## What

* Added an `unreachable` verdict for a parent that came back empty or could not be read at all, with its own sentence naming both possible causes instead of picking one, since we genuinely cannot tell a deleted subtree from a dropped connection;
* Narrowed `unknown` to the paths whose SHAPE means no parent listing could ever answer (`~`, `.git`, dot segments, anything not `/`-absolute), so an empty remote home does not start claiming the host is down;
* Widened the `..` guard in `newEntryPath` to split on `[\\/]`, and refused a name that is absolute in the Windows dialect (a leading `\`, or a `C:` drive qualifier) the way the leading `/` already was.

## How

The construction half of the path is deliberately left alone. CONTRIBUTING is explicit that the two separators are not interchangeable, and that on POSIX a backslash is ordinary filename text, so the join stays `/` and `weird\name.txt` is still one legal file. Guard on both dialects, construct in one.

`unreachable` is kept narrow for the same reason `missing` is: it fires only where we actually asked the parent and got nothing back. A path that could never be answered stays `unknown` and keeps saying "empty", because understating beats inventing a cause, which is how the first version of this classifier went wrong on #294.

## Test

* `npm run typecheck`, the production build and the full suite all pass. Compared against a clean `main` worktree: 27 failures on the branch and 28 on main, and the one that differs is `tmux-paste.realtmux`, which passes 3/3 in isolation here, so it is real-tmux flakiness under the parallel run rather than anything this touches;
* Both guards are mutation tested. Narrowing the `..` split back to `/` turns a test red, and folding `unreachable` back into `unknown` turns two red;
* Not verified on a real SSH host or on Windows, same as #294. The `unreachable` path is proven against a simulated `FsApi`, and the backslash cases by unit test rather than on a Windows machine.
