### PR TITLE
fix(canvas): "go to node" lands on the node, centered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2704,13 +2704,15 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   when it has one (`getInternalNode` — `measured` reaches OUR node objects one render later via
   `onNodesChange`, and `internals.positionAbsolute` also accounts for `extent:'parent'` clamping),
   else `nodeFitRect` from the PERSISTED size, resolving the group-parent chain. Then
-  `viewportForRectClearOf`: **centred in the SCREEN**, and only nudged — by the smallest amount
-  that works — when the centred node would slide under the floating chrome (the chrome-free frame
-  comes from `solveFitFrame`, pane-local, the same solve `fitAll`'s padding is expressed through).
-  Centring in that FRAME instead was tried and is wrong: the free rect is whatever the dock and the
-  sidebar leave over, not where the eye looks, so a node landed too far right on an ultrawide and
-  half off-screen on a laptop. A node too large for the frame is left centred — a shift there only
-  swaps which edge is covered. Unknowable size or no pane ⇒ the camera **stands still**.
+  `viewportForRect`: **centred in the pane, and nothing else.** Framing a single focused node
+  against the chrome-free rectangle was tried twice and is wrong both ways — centred IN that rect
+  ("too far right on an ultrawide, half off-screen on a laptop") and centred in the pane then
+  nudged clear of it ("still not in the middle") — because `.sessions-sidebar` is a 300px absolute
+  OVERLAY and it is open exactly when this feature is used, so either rule pushes the node right by
+  most of its width. The couple of dozen pixels that end up behind the sidebar cost far less than
+  losing the centre. The free-rect solve (`solveFitFrame` / `solveFitPadding`) stays where it earns
+  its keep: `fitAll`, which fits EVERY node and would otherwise tuck them under the dock.
+  Unknowable size or no pane ⇒ the camera **stands still**.
   `settings.focusZoomToNode` (Behavior, default ON) is the escape hatch for the rescale: off, the
   camera keeps the zoom `getZoom()` reports and only pans, and that zoom is passed through
   **unclamped** — it is one the canvas is already displaying, and re-clamping it to the framing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2687,20 +2687,32 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   `main/index.ts` intercepts it in `before-input-event` and forwards `app:zoom-actual-size`, which
   re-asks the same refusals. Server Edition needs no intercept (no menu; Chrome/Firefox hand ⌘0 to
   the page) and stubs the subscription.
-- **"Go to node" (`goToNode`)** — the one camera-travel path (notification click, sessions
-  sidebar, ⌘K jump, presence travel, minimap double-click, double-click focus). It frames the node
-  with `fitView({nodes:[{id}]})` **only when React Flow has MEASURED it**: `getFitViewNodes` filters
-  the fit set by `measured` (no `width`/`height` fallback in there), so an unmeasured node leaves the
-  set EMPTY, its bounds collapse to `{0,0,0,0}` and the camera lands on the canvas **ORIGIN** at max
-  zoom — empty canvas, node off-screen. That is the state every node is in for the first tick after
-  its project loads, which is why **cross-project** focus (the load and the focus happen in the same
-  tick, and measuring can lose the race — heavier canvas = more likely) used to land on nothing and
-  only work on a second try. `renderer/lib/nodeFocus.ts` computes the identical framing from the
-  node's PERSISTED size for that window (`nodeFitRect` resolves the group-parent chain →
-  `viewportForRect` → `setViewport`), and the measured check reads React Flow's **store**
-  (`getInternalNode`), not our node object — `measured` reaches our state one render later (via
-  `onNodesChange`), so our copy lies about nodes the store has long sized. Unknowable size ⇒ the
-  camera **stands still**; never fall back to a bare `fitView` there, that IS the origin jump.
+- **"Go to node" (`goToNode` → `frameNode`)** — the one camera-travel path (notification click,
+  sessions sidebar, ⌘K jump, presence travel, minimap double-click, double-click focus).
+  **It computes the viewport itself and applies it with `setViewport`. It must never go through
+  `fitView`.** React Flow's `fitView` frames nothing when you call it: it sets `fitViewQueued` and
+  the fit is RESOLVED LATER — from a subsequent `setNodes` (and only once EVERY node is measured,
+  `nodesInitialized`) or from the next `updateNodeInternals` — against whatever `nodeLookup` holds
+  by then. Its fit set is also filtered by `measured` (no `width`/`height` fallback in
+  `getFitViewNodes`), so a set that comes out EMPTY collapses the bounds to `{0,0,0,0}` and
+  `getViewportForBounds` parks the canvas **ORIGIN** in the middle of the screen at max zoom. On a
+  canvas whose nodes sit thousands of px out that is the field report verbatim: right project,
+  empty stretch of canvas, *sometimes*. **Cross-project** focus lands in that window every time —
+  switch project → load its nodes → frame the target, all before the mount-time measuring has
+  settled — and the second click always works, which is what makes it read as intermittent.
+  The geometry is `renderer/lib/nodeFocus.ts`: the node's rect from React Flow's own measurement
+  when it has one (`getInternalNode` — `measured` reaches OUR node objects one render later via
+  `onNodesChange`, and `internals.positionAbsolute` also accounts for `extent:'parent'` clamping),
+  else `nodeFitRect` from the PERSISTED size, resolving the group-parent chain. Then the
+  chrome-free frame (`solveFitFrame`, pane-local — the same solve `fitAll`'s padding is expressed
+  through) → `viewportForRectInFrame`, which centres the node in the space it can actually be seen
+  in; no solvable frame ⇒ `viewportForRect` against the whole pane at the flat ratio. Unknowable
+  size or no pane ⇒ the camera **stands still**. Two rules a refactor must not undo: framing goes
+  through `frameNode` and nothing else (`canvas-wiring.test.tsx` pins that it contains no
+  `fitView(`), and a "stands still" branch must never be "helpfully" replaced by a bare `fitView` —
+  that IS the origin jump. `fitAll` still uses `fitView` deliberately: it is an explicit user
+  gesture on a settled canvas and its fit set is every node, but it carries the same deferral, so
+  do not reach for it from anything automatic.
 - **Breadcrumb trail** (`renderer/lib/breadcrumbs.ts` — all the pure logic lives there) — every
   deliberate `goToNode` landing records a `NavStop` ({nodeId, at, note}) for the ACTIVE project, and
   **Cmd+[ / Cmd+]** (`canvas.goBack` / `canvas.goForward`, bound in `shared/keybindings.ts`) plus the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2703,16 +2703,23 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   The geometry is `renderer/lib/nodeFocus.ts`: the node's rect from React Flow's own measurement
   when it has one (`getInternalNode` — `measured` reaches OUR node objects one render later via
   `onNodesChange`, and `internals.positionAbsolute` also accounts for `extent:'parent'` clamping),
-  else `nodeFitRect` from the PERSISTED size, resolving the group-parent chain. Then the
-  chrome-free frame (`solveFitFrame`, pane-local — the same solve `fitAll`'s padding is expressed
-  through) → `viewportForRectInFrame`, which centres the node in the space it can actually be seen
-  in; no solvable frame ⇒ `viewportForRect` against the whole pane at the flat ratio. Unknowable
-  size or no pane ⇒ the camera **stands still**. Two rules a refactor must not undo: framing goes
-  through `frameNode` and nothing else (`canvas-wiring.test.tsx` pins that it contains no
-  `fitView(`), and a "stands still" branch must never be "helpfully" replaced by a bare `fitView` —
-  that IS the origin jump. `fitAll` still uses `fitView` deliberately: it is an explicit user
-  gesture on a settled canvas and its fit set is every node, but it carries the same deferral, so
-  do not reach for it from anything automatic.
+  else `nodeFitRect` from the PERSISTED size, resolving the group-parent chain. Then
+  `viewportForRectClearOf`: **centred in the SCREEN**, and only nudged — by the smallest amount
+  that works — when the centred node would slide under the floating chrome (the chrome-free frame
+  comes from `solveFitFrame`, pane-local, the same solve `fitAll`'s padding is expressed through).
+  Centring in that FRAME instead was tried and is wrong: the free rect is whatever the dock and the
+  sidebar leave over, not where the eye looks, so a node landed too far right on an ultrawide and
+  half off-screen on a laptop. A node too large for the frame is left centred — a shift there only
+  swaps which edge is covered. Unknowable size or no pane ⇒ the camera **stands still**.
+  `settings.focusZoomToNode` (Behavior, default ON) is the escape hatch for the rescale: off, the
+  camera keeps the zoom `getZoom()` reports and only pans, and that zoom is passed through
+  **unclamped** — it is one the canvas is already displaying, and re-clamping it to the framing
+  range would rescale the view the option exists to leave alone. Two rules a refactor must not
+  undo: framing goes through `frameNode` and nothing else (`canvas-wiring.test.tsx` pins that it
+  contains no `fitView(`), and a "stands still" branch must never be "helpfully" replaced by a bare
+  `fitView` — that IS the origin jump. `fitAll` still uses `fitView` deliberately: it is an
+  explicit user gesture on a settled canvas and its fit set is every node, but it carries the same
+  deferral, so do not reach for it from anything automatic.
 - **Breadcrumb trail** (`renderer/lib/breadcrumbs.ts` — all the pure logic lives there) — every
   deliberate `goToNode` landing records a `NavStop` ({nodeId, at, note}) for the ACTIVE project, and
   **Cmd+[ / Cmd+]** (`canvas.goBack` / `canvas.goForward`, bound in `shared/keybindings.ts`) plus the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,6 +341,14 @@ from the target's `pendingLaunch` (`renderer/lib/edgeModel.ts`), and the context
 writes stays hidden underneath it. One `open-claude --after` used to land three edges on one node.
 `src/renderer/canvas/edge-model.source.test.ts` pins both halves.
 
+**React Flow's `fitView` is queued, not immediate — never use it to frame something automatically.**
+Calling it sets `fitViewQueued` and the fit runs from a later `setNodes` (only once every node is
+measured) or the next `updateNodeInternals`, against whatever the node lookup holds by then; a fit
+set that comes out empty parks the canvas origin in the middle of the screen. Compute the viewport
+yourself and apply it with `setViewport` (`renderer/lib/nodeFocus.ts`, `canvas/fit-view.ts`), which
+lands now and against the canvas you meant. `fitAll` is the one deliberate exception: an explicit
+user gesture on a settled canvas.
+
 ## Testing
 
 `npm test` must pass, and `npm run typecheck` is the fastest gate.

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -269,7 +269,7 @@ import {
   isMeasured,
   nodeFitRect,
   viewportForRect,
-  viewportForRectInFrame,
+  viewportForRectClearOf,
   type FocusableNode
 } from '../lib/nodeFocus'
 import { NODE_MAXIMIZE_MARGIN_PX, maximizeTargetRect } from '../lib/nodeMaximize'
@@ -6673,14 +6673,20 @@ export function Canvas() {
       // Size unknowable / no pane yet: leave the camera where it is. Standing still beats
       // teleporting the user to the origin, which is the failure this whole path exists for.
       if (!rect || !wrap) return
-      const frame = solveFitFrame(wrap, rect.width, rect.height)
       const box = wrap.getBoundingClientRect()
-      const viewport = frame
-        ? viewportForRectInFrame(rect, frame)
-        : viewportForRect(rect, box.width, box.height)
+      // `focusZoomToNode` off: keep the zoom the user settled on and only pan. The node is still
+      // centred and still kept clear of the chrome — only the rescale is dropped.
+      const keepZoom = useSettings.getState().settings.focusZoomToNode ? undefined : getZoom()
+      const viewport = viewportForRectClearOf(
+        rect,
+        box.width,
+        box.height,
+        solveFitFrame(wrap, rect.width, rect.height),
+        keepZoom
+      )
       if (viewport) void setViewport(viewport, { duration: 300 })
     },
-    [setViewport, getInternalNode]
+    [setViewport, getInternalNode, getZoom]
   )
 
   const goToNode = useCallback(

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -36,7 +36,7 @@ import {
   isSessionReady,
   subscribeSessionReady
 } from '../nodes/TerminalNode'
-import { solveFitFrame, solveFitPadding } from './fit-view'
+import { solveFitPadding } from './fit-view'
 import { FloatingEdge } from './FloatingEdge'
 import { MacWheelGestureRouter, trackpadRoutingEnabled } from './wheel-gesture'
 import { isBrowserRuntime } from '@renderer/bridge/runtime'
@@ -269,7 +269,6 @@ import {
   isMeasured,
   nodeFitRect,
   viewportForRect,
-  viewportForRectClearOf,
   type FocusableNode
 } from '../lib/nodeFocus'
 import { NODE_MAXIMIZE_MARGIN_PX, maximizeTargetRect } from '../lib/nodeMaximize'
@@ -6674,16 +6673,10 @@ export function Canvas() {
       // teleporting the user to the origin, which is the failure this whole path exists for.
       if (!rect || !wrap) return
       const box = wrap.getBoundingClientRect()
-      // `focusZoomToNode` off: keep the zoom the user settled on and only pan. The node is still
-      // centred and still kept clear of the chrome — only the rescale is dropped.
+      // `focusZoomToNode` off: keep the zoom the user settled on and only pan — the node still
+      // lands in the middle, only the rescale is dropped.
       const keepZoom = useSettings.getState().settings.focusZoomToNode ? undefined : getZoom()
-      const viewport = viewportForRectClearOf(
-        rect,
-        box.width,
-        box.height,
-        solveFitFrame(wrap, rect.width, rect.height),
-        keepZoom
-      )
+      const viewport = viewportForRect(rect, box.width, box.height, keepZoom)
       if (viewport) void setViewport(viewport, { duration: 300 })
     },
     [setViewport, getInternalNode, getZoom]

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -36,7 +36,7 @@ import {
   isSessionReady,
   subscribeSessionReady
 } from '../nodes/TerminalNode'
-import { solveFitPadding } from './fit-view'
+import { solveFitFrame, solveFitPadding } from './fit-view'
 import { FloatingEdge } from './FloatingEdge'
 import { MacWheelGestureRouter, trackpadRoutingEnabled } from './wheel-gesture'
 import { isBrowserRuntime } from '@renderer/bridge/runtime'
@@ -265,11 +265,11 @@ import {
   folderName
 } from '../lib/projectOpen'
 import {
-  FIT_NODE_OPTIONS,
   absolutePosition,
   isMeasured,
   nodeFitRect,
   viewportForRect,
+  viewportForRectInFrame,
   type FocusableNode
 } from '../lib/nodeFocus'
 import { NODE_MAXIMIZE_MARGIN_PX, maximizeTargetRect } from '../lib/nodeMaximize'
@@ -6634,54 +6634,53 @@ export function Canvas() {
    * The ONE framing implementation behind both deliberate focus (`goToNode`) and breadcrumb
    * back/forward (`stepAndFrame`) — extracted so CLAUDE.md's "Go to node" invariant has a single
    * copy to regress. Fit the node in view instead of centering at a fixed zoom — `zoom:
-   * max(current, 1)` overshot large terminals (their body never fit the viewport). fitView sizes
-   * the zoom to the node and resolves group-relative positions itself; the clamp keeps a small
-   * node from filling the whole screen and a huge one from being fit microscopic.
+   * max(current, 1)` overshot large terminals (their body never fit the viewport). The clamp keeps
+   * a small node from filling the whole screen and a huge one from being fit microscopic.
    *
-   * …but ONLY once React Flow has MEASURED the node. Its fit set is filtered by `measured`
-   * (no width/height fallback in there), so an unmeasured node leaves the set EMPTY, the
-   * bounds collapse to {0,0,0,0} and the camera flies to the canvas ORIGIN at max zoom —
-   * empty canvas, node off-screen. That is precisely the state a node is in for the first
-   * tick after its project loads, i.e. on every CROSS-PROJECT focus (OS-notification click,
-   * sessions sidebar, ⌘K jump, presence travel): the load and the focus happen in the same
-   * tick, so measuring can lose the race and only a second attempt would work. In that
-   * window we frame the node ourselves from its persisted size — see lib/nodeFocus.
+   * **It computes the camera itself and applies it with `setViewport`. It must never go through
+   * `fitView`.** React Flow's `fitView` does not frame anything when you call it: it sets
+   * `fitViewQueued` and runs LATER, from `setNodes` (and only once EVERY node is measured) or from
+   * the next `updateNodeInternals`. So the fit is resolved against whatever `nodeLookup` holds by
+   * then, not against the canvas the user clicked on — and its fit set is filtered by `measured`
+   * with no width/height fallback, so a set that comes out EMPTY collapses the bounds to
+   * {0,0,0,0} and the camera flies to the canvas ORIGIN at max zoom. On a canvas whose nodes sit
+   * thousands of px out that reads exactly as the field report: right project, empty stretch of
+   * canvas, "sometimes". A cross-project focus lands in that window every time (switch project →
+   * load its nodes → frame the target, all before the mount-time measuring has settled), and a
+   * second click works because by then everything is measured.
    *
-   * The measured check must read React Flow's OWN store (`getInternalNode`), not our node
-   * object: `measured` only reaches our state one render later, when `onNodesChange` applies
-   * the dimensions change, so our copy says "unmeasured" for nodes the store has long sized.
+   * So the geometry is ours: the node's rect from React Flow's measurement when it has one (its
+   * `positionAbsolute` also accounts for `extent: 'parent'` clamping) and from the PERSISTED size
+   * otherwise — which needs no layout — then the chrome-free frame, then `setViewport`, which
+   * applies immediately. See lib/nodeFocus and canvas/fit-view.
    *
-   * The framing itself is solved against the CURRENT chrome layout, exactly like `fitAll`:
-   * a flat 20% ratio has to reserve enough slack for the dock/minimap on EVERY side, which
-   * is what kept a big node (a group frame most of all) further away than it needed to be.
-   * The free-rect solver reclaims the space the chrome does not actually occupy, so the node
-   * is framed tighter without sliding underneath anything. Falls back to the flat ratio when
-   * there is nothing sensible to solve — the same ratio the unmeasured branch uses.
+   * The frame is solved against the CURRENT chrome layout, exactly like `fitAll`: a flat 20% ratio
+   * has to reserve enough slack for the dock/minimap on EVERY side, which is what kept a big node
+   * (a group frame most of all) further away than it needed to be. Falls back to the flat ratio
+   * against the whole pane when there is nothing sensible to solve.
    */
   const frameNode = useCallback(
     (node: Node) => {
       const internal = getInternalNode(node.id)
-      if (isMeasured(internal)) {
-        const wrap = flowWrapRef.current
-        const size = internal?.measured
-        const solved =
-          wrap && size?.width && size?.height ? solveFitPadding(wrap, size.width, size.height) : null
-        void fitView({
-          nodes: [{ id: node.id }],
-          duration: 300,
-          ...FIT_NODE_OPTIONS,
-          padding: solved ?? FIT_NODE_OPTIONS.padding
-        })
-        return
-      }
-      const rect = nodeFitRect(node as FocusableNode, nodesRef.current as FocusableNode[])
-      const wrap = flowWrapRef.current?.getBoundingClientRect()
-      const viewport = rect && wrap ? viewportForRect(rect, wrap.width, wrap.height) : null
+      const rect = isMeasured(internal)
+        ? {
+            ...internal!.internals.positionAbsolute,
+            width: internal!.measured.width as number,
+            height: internal!.measured.height as number
+          }
+        : nodeFitRect(node as FocusableNode, nodesRef.current as FocusableNode[])
+      const wrap = flowWrapRef.current
       // Size unknowable / no pane yet: leave the camera where it is. Standing still beats
-      // teleporting the user to the origin, which is the bug this branch exists for.
+      // teleporting the user to the origin, which is the failure this whole path exists for.
+      if (!rect || !wrap) return
+      const frame = solveFitFrame(wrap, rect.width, rect.height)
+      const box = wrap.getBoundingClientRect()
+      const viewport = frame
+        ? viewportForRectInFrame(rect, frame)
+        : viewportForRect(rect, box.width, box.height)
       if (viewport) void setViewport(viewport, { duration: 300 })
     },
-    [fitView, setViewport, getInternalNode]
+    [setViewport, getInternalNode]
   )
 
   const goToNode = useCallback(

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -155,6 +155,21 @@ describe('breadcrumb wiring the CLAUDE.md bullet calls load-bearing', () => {
     expect(CANVAS_SRC.match(/isMeasured\(internal\)/g) ?? []).toHaveLength(1)
   })
 
+  it('frameNode computes the camera itself and never routes through fitView', () => {
+    // React Flow's fitView is QUEUED, not immediate: it runs from a later setNodes (and only once
+    // EVERY node is measured) or the next updateNodeInternals, so it frames whatever nodeLookup
+    // holds by then. Resolved after the node set moved on, its fit set comes out empty, the bounds
+    // collapse to {0,0,0,0} and the camera flies to the canvas ORIGIN — the "right project, empty
+    // canvas, sometimes" report. A cross-project focus lands in that window every time.
+    const frame = CANVAS_SRC.slice(
+      CANVAS_SRC.indexOf('const frameNode = useCallback'),
+      CANVAS_SRC.indexOf('const goToNode = useCallback')
+    )
+    expect(frame.length).toBeGreaterThan(0)
+    expect(frame).not.toContain('fitView(')
+    expect(frame).toContain('setViewport(viewport, { duration: 300 })')
+  })
+
   it('the resume card slot is spent only on a card that can render, and only when opted in', () => {
     // Gated on settings.showResumeCard (default off) FIRST — a disabled card must not spend the
     // one-shot slot — then once per app run, only with a live stop, and never under the opaque

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -170,14 +170,16 @@ describe('breadcrumb wiring the CLAUDE.md bullet calls load-bearing', () => {
     expect(frame).toContain('setViewport(viewport, { duration: 300 })')
   })
 
-  it('frames the node in the SCREEN, honouring the keep-my-zoom setting', () => {
-    // Centring in the chrome-free rect instead read as "too far right" on a wide display and as
-    // half off-screen on a laptop; `viewportForRectClearOf` centres in the pane and only nudges.
+  it('centres the node in the pane and never solves chrome around it', () => {
+    // Framing a single focused node against the chrome-free rectangle was reported wrong twice
+    // ("too far right", "not in the middle"): the sessions sidebar is a 300px overlay and it is
+    // open exactly when this is used. The free-rect solve stays in fitAll, which fits every node.
     const frame = CANVAS_SRC.slice(
       CANVAS_SRC.indexOf('const frameNode = useCallback'),
       CANVAS_SRC.indexOf('const goToNode = useCallback')
     )
-    expect(frame).toContain('viewportForRectClearOf(')
+    expect(frame).toContain('viewportForRect(rect, box.width, box.height, keepZoom)')
+    expect(frame).not.toContain('solveFitFrame')
     expect(frame).toContain('settings.focusZoomToNode ? undefined : getZoom()')
   })
 

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -170,6 +170,17 @@ describe('breadcrumb wiring the CLAUDE.md bullet calls load-bearing', () => {
     expect(frame).toContain('setViewport(viewport, { duration: 300 })')
   })
 
+  it('frames the node in the SCREEN, honouring the keep-my-zoom setting', () => {
+    // Centring in the chrome-free rect instead read as "too far right" on a wide display and as
+    // half off-screen on a laptop; `viewportForRectClearOf` centres in the pane and only nudges.
+    const frame = CANVAS_SRC.slice(
+      CANVAS_SRC.indexOf('const frameNode = useCallback'),
+      CANVAS_SRC.indexOf('const goToNode = useCallback')
+    )
+    expect(frame).toContain('viewportForRectClearOf(')
+    expect(frame).toContain('settings.focusZoomToNode ? undefined : getZoom()')
+  })
+
   it('the resume card slot is spent only on a card that can render, and only when opted in', () => {
     // Gated on settings.showResumeCard (default off) FIRST — a disabled card must not spend the
     // one-shot slot — then once per app run, only with a live stop, and never under the opaque

--- a/src/renderer/canvas/fit-view.test.ts
+++ b/src/renderer/canvas/fit-view.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest'
-import { largestFreeRect, rectToPadding, rectsOverlap, type FitRect } from './fit-view'
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  FIT_VIEW_GAP,
+  largestFreeRect,
+  rectToPadding,
+  rectsOverlap,
+  solveFitFrame,
+  type FitRect
+} from './fit-view'
 
 /**
  * Geometry measured from a real 1264x722 canvas (see docs/superpowers/specs) — the chrome rects
@@ -120,5 +128,50 @@ describe('rectToPadding', () => {
       right: '0px',
       bottom: '0px'
     })
+  })
+})
+
+describe('solveFitFrame answers in the pane\u2019s own coordinates', () => {
+  // The camera transform lives in pane space, so a caller that computes the viewport itself
+  // (`viewportForRectInFrame`) needs the frame there — converting per call site is how the two
+  // would drift. `solveFitPadding` is expressed through this, so both stay one solve.
+  function pane(rect: { left: number; top: number; width: number; height: number }): HTMLElement {
+    const el = document.createElement('div')
+    el.getBoundingClientRect = () =>
+      ({
+        left: rect.left,
+        top: rect.top,
+        right: rect.left + rect.width,
+        bottom: rect.top + rect.height,
+        width: rect.width,
+        height: rect.height,
+        x: rect.left,
+        y: rect.top
+      }) as DOMRect
+    return el
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('offsets the frame by the pane origin, so an inset pane does not shift the camera', () => {
+    const flush = pane({ left: 0, top: 0, width: 1200, height: 800 })
+    const inset = pane({ left: 300, top: 120, width: 1200, height: 800 })
+    expect(solveFitFrame(inset, 600, 400)).toEqual(solveFitFrame(flush, 600, 400))
+  })
+
+  it('keeps the frame clear of visible chrome', () => {
+    document.body.innerHTML = '<div class="dock"></div>'
+    const dock = document.querySelector('.dock')!
+    dock.getBoundingClientRect = () =>
+      ({ left: 0, top: 700, right: 1200, bottom: 800, width: 1200, height: 100, x: 0, y: 700 }) as DOMRect
+    const frame = solveFitFrame(pane({ left: 0, top: 0, width: 1200, height: 800 }), 600, 400)!
+    expect(frame.bottom).toBeLessThanOrEqual(700 - FIT_VIEW_GAP)
+  })
+
+  it('gives up rather than returning a degenerate frame', () => {
+    expect(solveFitFrame(pane({ left: 0, top: 0, width: 8, height: 8 }), 600, 400)).toBeNull()
+    expect(solveFitFrame(pane({ left: 0, top: 0, width: 1200, height: 800 }), 0, 400)).toBeNull()
   })
 })

--- a/src/renderer/canvas/fit-view.ts
+++ b/src/renderer/canvas/fit-view.ts
@@ -140,14 +140,18 @@ export function rectToPadding(outer: FitRect, rect: FitRect): FitPadding {
 }
 
 /**
- * Solve the fit-view padding for the current chrome layout and content shape.
- * Returns null when there is nothing sensible to solve, so callers can fall back to plain fitView.
+ * The chrome-free rectangle for this content, in the pane's OWN coordinates (0,0 = the pane's
+ * top-left) rather than the window's. Null when there is nothing sensible to solve.
+ *
+ * Pane-local because that is the space a viewport transform lives in: a caller that computes the
+ * camera itself (`viewportForRectInFrame`) needs the frame in the same coordinates as the
+ * transform, and converting at each call site is how the two would drift.
  */
-export function solveFitPadding(
+export function solveFitFrame(
   wrap: HTMLElement,
   contentW: number,
   contentH: number
-): FitPadding | null {
+): FitRect | null {
   if (contentW <= 0 || contentH <= 0) return null
   const v = wrap.getBoundingClientRect()
   const outer: FitRect = { left: v.left, top: v.top, right: v.right, bottom: v.bottom }
@@ -159,5 +163,28 @@ export function solveFitPadding(
   }
   if (width(viewport) < 1 || height(viewport) < 1) return null
   const rect = largestFreeRect(viewport, chromeObstacles(viewport), contentW, contentH)
-  return rect ? rectToPadding(outer, rect) : null
+  return rect
+    ? {
+        left: rect.left - outer.left,
+        top: rect.top - outer.top,
+        right: rect.right - outer.left,
+        bottom: rect.bottom - outer.top
+      }
+    : null
+}
+
+/**
+ * Solve the fit-view padding for the current chrome layout and content shape.
+ * Returns null when there is nothing sensible to solve, so callers can fall back to plain fitView.
+ */
+export function solveFitPadding(
+  wrap: HTMLElement,
+  contentW: number,
+  contentH: number
+): FitPadding | null {
+  const frame = solveFitFrame(wrap, contentW, contentH)
+  if (!frame) return null
+  const v = wrap.getBoundingClientRect()
+  // `frame` is pane-local, so the pane's own box IS the outer rect at the origin.
+  return rectToPadding({ left: 0, top: 0, right: v.width, bottom: v.height }, frame)
 }

--- a/src/renderer/components/settings/sections/BehaviorSection.tsx
+++ b/src/renderer/components/settings/sections/BehaviorSection.tsx
@@ -36,6 +36,10 @@ const ROWS = {
   },
   panHover: { title: 'Pan-hover delay (ms)', keywords: ['pan', 'hover', 'delay', 'focus', 'guard'] },
   doubleClick: { title: 'Double-click to focus', keywords: ['double', 'click', 'focus'] },
+  focusZoom: {
+    title: 'Zoom when going to a node',
+    keywords: ['zoom', 'focus', 'go to', 'node', 'jump', 'camera', 'session', 'sidebar']
+  },
   mdPreview: {
     title: 'Open Markdown in preview',
     keywords: ['markdown', 'md', 'preview', 'render', 'editor', 'docs', 'readme', 'file']
@@ -212,6 +216,19 @@ export function BehaviorSection({ isActive }: { isActive: boolean }): React.JSX.
               checked={settings.doubleClickFocus}
               onChange={(v) => update({ doubleClickFocus: v })}
               ariaLabel="Double-click to focus"
+            />
+          }
+        />
+      </SearchableRow>
+      <SearchableRow {...ROWS.focusZoom}>
+        <FieldRow
+          label="Zoom when going to a node"
+          description="Off: going to a node keeps your current zoom and only pans to it."
+          control={
+            <Switch
+              checked={settings.focusZoomToNode}
+              onChange={(v) => update({ focusZoomToNode: v })}
+              ariaLabel="Zoom when going to a node"
             />
           }
         />

--- a/src/renderer/lib/nodeFocus.test.ts
+++ b/src/renderer/lib/nodeFocus.test.ts
@@ -6,7 +6,7 @@ import {
   isMeasured,
   nodeFitRect,
   viewportForRect,
-  viewportForRectInFrame
+  viewportForRectClearOf
 } from './nodeFocus'
 import type { FocusableNode } from './nodeFocus'
 
@@ -149,34 +149,64 @@ describe('viewportForRect', () => {
   })
 })
 
-describe('viewportForRectInFrame', () => {
-  // 1280×900 pane with a 340px sessions sidebar on the left: the chrome-free frame the solver
-  // hands over, in pane-local coordinates.
-  const frame = { left: 352, top: 12, right: 1268, bottom: 888 }
-
-  it('puts the node in the middle of the free frame, not of the whole pane', () => {
-    const rect = { x: 5000, y: 4000, width: 600, height: 400 }
-    const vp = viewportForRectInFrame(rect, frame)!
-    expect(vp.x + 5300 * vp.zoom).toBeCloseTo((frame.left + frame.right) / 2, 0)
-    expect(vp.y + 4200 * vp.zoom).toBeCloseTo((frame.top + frame.bottom) / 2, 0)
-    // And emphatically not at the canvas origin, which is where an empty fitView set lands the
-    // camera — the failure this whole path exists to make impossible.
-    expect(vp.x).not.toBeCloseTo((frame.left + frame.right) / 2, 0)
+describe('viewportForRectClearOf', () => {
+  const rect = { x: 5000, y: 4000, width: 600, height: 400 }
+  // A sessions sidebar on the left, as the free-rect solver reports it: pane-local coordinates.
+  const sidebar = (left: number, paneW: number, paneH: number) => ({
+    left,
+    top: 12,
+    right: paneW - 12,
+    bottom: paneH - 12
   })
 
-  it('applies the same zoom clamp as every other framing path', () => {
-    expect(viewportForRectInFrame({ x: 0, y: 0, width: 8, height: 8 }, frame)!.zoom).toBe(
-      FIT_NODE_OPTIONS.maxZoom
-    )
-    expect(viewportForRectInFrame({ x: 0, y: 0, width: 90000, height: 90000 }, frame)!.zoom).toBe(
-      FIT_NODE_OPTIONS.minZoom
-    )
+  it('centres the node in the SCREEN, not in the chrome-free rectangle', () => {
+    // The regression this pins: framing a node in the middle of the free rect reads as "too far
+    // right" on a wide display — the free rect is whatever the dock and the sidebar leave over,
+    // which is not where the eye looks. On an ultrawide the centred node clears the chrome by
+    // itself, so the answer must be the plain centred one.
+    const vp = viewportForRectClearOf(rect, 3440, 1400, sidebar(352, 3440, 1400))!
+    expect(vp).toEqual(viewportForRect(rect, 3440, 1400))
+    expect(vp.x + 5300 * vp.zoom).toBeCloseTo(1720, 0)
+    expect(vp.y + 4200 * vp.zoom).toBeCloseTo(700, 0)
   })
 
-  it('refuses a frame or a node it cannot size, so the camera stands still', () => {
-    const rect = { x: 0, y: 0, width: 600, height: 400 }
-    expect(viewportForRectInFrame(rect, { left: 10, top: 10, right: 10, bottom: 900 })).toBeNull()
-    expect(viewportForRectInFrame({ x: 0, y: 0, width: 0, height: 400 }, frame)).toBeNull()
+  it('nudges just enough to clear a panel the centred node would slide under', () => {
+    const frame = sidebar(500, 1440, 900)
+    const vp = viewportForRectClearOf(rect, 1440, 900, frame)!
+    const centred = viewportForRect(rect, 1440, 900)!
+    // Flush against the panel — moved, and no further than it had to be.
+    expect(vp.x + rect.x * vp.zoom).toBeCloseTo(frame.left, 0)
+    expect(vp.x).toBeGreaterThan(centred.x)
+    // The zoom and the other axis are untouched: this is a nudge, not a second framing.
+    expect(vp.zoom).toBe(centred.zoom)
+    expect(vp.y).toBe(centred.y)
+  })
+
+  it('leaves a node too large for the frame centred — a shift only swaps the covered edge', () => {
+    const vp = viewportForRectClearOf(rect, 1440, 900, { left: 600, top: 12, right: 900, bottom: 888 })
+    expect(vp).toEqual(viewportForRect(rect, 1440, 900))
+  })
+
+  it('keeps a given zoom and only pans (settings.focusZoomToNode off)', () => {
+    // The point of the option: a user who settled on a zoom level loses their sense of place when
+    // a jump also rescales the canvas. The node is still centred, and still nudged clear of chrome.
+    const vp = viewportForRectClearOf(rect, 1440, 900, sidebar(352, 1440, 900), 0.5)!
+    expect(vp.zoom).toBe(0.5)
+    expect(vp.x + 5300 * 0.5).toBeCloseTo(720, 0)
+    expect(vp.y + 4200 * 0.5).toBeCloseTo(450, 0)
+  })
+
+  it('passes an out-of-framing-range zoom through — it is one the canvas already shows', () => {
+    // Re-clamping to FIT_NODE_OPTIONS would rescale the very view this option exists to leave
+    // alone; the canvas's own limits already bound what getZoom() can return.
+    expect(viewportForRectClearOf(rect, 1440, 900, null, 1.9)!.zoom).toBe(1.9)
+    expect(viewportForRectClearOf(rect, 1440, 900, null, 0.1)!.zoom).toBe(0.1)
+    expect(viewportForRectClearOf(rect, 1440, 900, null, 0)).toBeNull()
+  })
+
+  it('is the plain centred answer when there is no frame to solve', () => {
+    expect(viewportForRectClearOf(rect, 1440, 900, null)).toEqual(viewportForRect(rect, 1440, 900))
+    expect(viewportForRectClearOf(rect, 0, 0, sidebar(352, 1440, 900))).toBeNull()
   })
 })
 

--- a/src/renderer/lib/nodeFocus.test.ts
+++ b/src/renderer/lib/nodeFocus.test.ts
@@ -5,8 +5,7 @@ import {
   absolutePosition,
   isMeasured,
   nodeFitRect,
-  viewportForRect,
-  viewportForRectClearOf
+  viewportForRect
 } from './nodeFocus'
 import type { FocusableNode } from './nodeFocus'
 
@@ -149,48 +148,26 @@ describe('viewportForRect', () => {
   })
 })
 
-describe('viewportForRectClearOf', () => {
+describe('viewportForRect — the framing "go to node" applies', () => {
   const rect = { x: 5000, y: 4000, width: 600, height: 400 }
-  // A sessions sidebar on the left, as the free-rect solver reports it: pane-local coordinates.
-  const sidebar = (left: number, paneW: number, paneH: number) => ({
-    left,
-    top: 12,
-    right: paneW - 12,
-    bottom: paneH - 12
-  })
 
-  it('centres the node in the SCREEN, not in the chrome-free rectangle', () => {
-    // The regression this pins: framing a node in the middle of the free rect reads as "too far
-    // right" on a wide display — the free rect is whatever the dock and the sidebar leave over,
-    // which is not where the eye looks. On an ultrawide the centred node clears the chrome by
-    // itself, so the answer must be the plain centred one.
-    const vp = viewportForRectClearOf(rect, 3440, 1400, sidebar(352, 3440, 1400))!
-    expect(vp).toEqual(viewportForRect(rect, 3440, 1400))
-    expect(vp.x + 5300 * vp.zoom).toBeCloseTo(1720, 0)
-    expect(vp.y + 4200 * vp.zoom).toBeCloseTo(700, 0)
-  })
-
-  it('nudges just enough to clear a panel the centred node would slide under', () => {
-    const frame = sidebar(500, 1440, 900)
-    const vp = viewportForRectClearOf(rect, 1440, 900, frame)!
-    const centred = viewportForRect(rect, 1440, 900)!
-    // Flush against the panel — moved, and no further than it had to be.
-    expect(vp.x + rect.x * vp.zoom).toBeCloseTo(frame.left, 0)
-    expect(vp.x).toBeGreaterThan(centred.x)
-    // The zoom and the other axis are untouched: this is a nudge, not a second framing.
-    expect(vp.zoom).toBe(centred.zoom)
-    expect(vp.y).toBe(centred.y)
-  })
-
-  it('leaves a node too large for the frame centred — a shift only swaps the covered edge', () => {
-    const vp = viewportForRectClearOf(rect, 1440, 900, { left: 600, top: 12, right: 900, bottom: 888 })
-    expect(vp).toEqual(viewportForRect(rect, 1440, 900))
+  it('centres the node in the pane, whatever chrome floats over it', () => {
+    // Twice-reported regression: framing against the chrome-free rectangle — centred in it, or
+    // centred in the pane and then nudged clear of it — pushes the node right by most of its width,
+    // because the sessions sidebar is a 300px OVERLAY and it is open exactly when this is used.
+    // "Go to node" puts the node where the eye is; the free-rect solve belongs to fitAll.
+    const wide = viewportForRect(rect, 3440, 1400)!
+    expect(wide.x + 5300 * wide.zoom).toBeCloseTo(1720, 0)
+    expect(wide.y + 4200 * wide.zoom).toBeCloseTo(700, 0)
+    const laptop = viewportForRect(rect, 1440, 900)!
+    expect(laptop.x + 5300 * laptop.zoom).toBeCloseTo(720, 0)
+    expect(laptop.y + 4200 * laptop.zoom).toBeCloseTo(450, 0)
   })
 
   it('keeps a given zoom and only pans (settings.focusZoomToNode off)', () => {
     // The point of the option: a user who settled on a zoom level loses their sense of place when
-    // a jump also rescales the canvas. The node is still centred, and still nudged clear of chrome.
-    const vp = viewportForRectClearOf(rect, 1440, 900, sidebar(352, 1440, 900), 0.5)!
+    // a jump also rescales the canvas. The node is still centred.
+    const vp = viewportForRect(rect, 1440, 900, 0.5)!
     expect(vp.zoom).toBe(0.5)
     expect(vp.x + 5300 * 0.5).toBeCloseTo(720, 0)
     expect(vp.y + 4200 * 0.5).toBeCloseTo(450, 0)
@@ -199,14 +176,9 @@ describe('viewportForRectClearOf', () => {
   it('passes an out-of-framing-range zoom through — it is one the canvas already shows', () => {
     // Re-clamping to FIT_NODE_OPTIONS would rescale the very view this option exists to leave
     // alone; the canvas's own limits already bound what getZoom() can return.
-    expect(viewportForRectClearOf(rect, 1440, 900, null, 1.9)!.zoom).toBe(1.9)
-    expect(viewportForRectClearOf(rect, 1440, 900, null, 0.1)!.zoom).toBe(0.1)
-    expect(viewportForRectClearOf(rect, 1440, 900, null, 0)).toBeNull()
-  })
-
-  it('is the plain centred answer when there is no frame to solve', () => {
-    expect(viewportForRectClearOf(rect, 1440, 900, null)).toEqual(viewportForRect(rect, 1440, 900))
-    expect(viewportForRectClearOf(rect, 0, 0, sidebar(352, 1440, 900))).toBeNull()
+    expect(viewportForRect(rect, 1440, 900, 1.9)!.zoom).toBe(1.9)
+    expect(viewportForRect(rect, 1440, 900, 0.1)!.zoom).toBe(0.1)
+    expect(viewportForRect(rect, 1440, 900, 0)).toBeNull()
   })
 })
 

--- a/src/renderer/lib/nodeFocus.test.ts
+++ b/src/renderer/lib/nodeFocus.test.ts
@@ -5,7 +5,8 @@ import {
   absolutePosition,
   isMeasured,
   nodeFitRect,
-  viewportForRect
+  viewportForRect,
+  viewportForRectInFrame
 } from './nodeFocus'
 import type { FocusableNode } from './nodeFocus'
 
@@ -145,6 +146,37 @@ describe('viewportForRect', () => {
 
   it('refuses to compute against a container it cannot size', () => {
     expect(viewportForRect({ x: 0, y: 0, width: 600, height: 400 }, 0, 0)).toBeNull()
+  })
+})
+
+describe('viewportForRectInFrame', () => {
+  // 1280×900 pane with a 340px sessions sidebar on the left: the chrome-free frame the solver
+  // hands over, in pane-local coordinates.
+  const frame = { left: 352, top: 12, right: 1268, bottom: 888 }
+
+  it('puts the node in the middle of the free frame, not of the whole pane', () => {
+    const rect = { x: 5000, y: 4000, width: 600, height: 400 }
+    const vp = viewportForRectInFrame(rect, frame)!
+    expect(vp.x + 5300 * vp.zoom).toBeCloseTo((frame.left + frame.right) / 2, 0)
+    expect(vp.y + 4200 * vp.zoom).toBeCloseTo((frame.top + frame.bottom) / 2, 0)
+    // And emphatically not at the canvas origin, which is where an empty fitView set lands the
+    // camera — the failure this whole path exists to make impossible.
+    expect(vp.x).not.toBeCloseTo((frame.left + frame.right) / 2, 0)
+  })
+
+  it('applies the same zoom clamp as every other framing path', () => {
+    expect(viewportForRectInFrame({ x: 0, y: 0, width: 8, height: 8 }, frame)!.zoom).toBe(
+      FIT_NODE_OPTIONS.maxZoom
+    )
+    expect(viewportForRectInFrame({ x: 0, y: 0, width: 90000, height: 90000 }, frame)!.zoom).toBe(
+      FIT_NODE_OPTIONS.minZoom
+    )
+  })
+
+  it('refuses a frame or a node it cannot size, so the camera stands still', () => {
+    const rect = { x: 0, y: 0, width: 600, height: 400 }
+    expect(viewportForRectInFrame(rect, { left: 10, top: 10, right: 10, bottom: 900 })).toBeNull()
+    expect(viewportForRectInFrame({ x: 0, y: 0, width: 0, height: 400 }, frame)).toBeNull()
   })
 })
 

--- a/src/renderer/lib/nodeFocus.ts
+++ b/src/renderer/lib/nodeFocus.ts
@@ -93,6 +93,14 @@ export function nodeFitRect(node: FocusableNode, all: readonly FocusableNode[]):
  * The viewport that frames `rect` in a `containerWidth × containerHeight` pane, with the same
  * padding/zoom clamp `fitView` would have applied. Null when the container has no size yet.
  *
+ * **Centred in the pane, and nothing else.** Framing a focused node against the chrome-free
+ * rectangle instead — centred in it, or centred in the pane and then nudged clear of it — was tried
+ * twice and is wrong both ways: the sessions sidebar is a 300px OVERLAY, so either rule pushes the
+ * node right by most of its width, and "go to node" stops putting the node where the eye is. The
+ * couple of dozen pixels of a node that end up behind the sidebar cost far less than that. The
+ * free-rect solve stays where it earns its keep, in `fitAll`, which fits EVERY node and would
+ * otherwise tuck them under the dock.
+ *
  * `zoom` keeps the camera at a scale the caller already has (`settings.focusZoomToNode` off): the
  * node is centred exactly as it would be, at that zoom, so "go to" stays a pan. It is passed
  * through UNCLAMPED — it is a zoom the canvas is already displaying, and re-clamping it to the
@@ -121,54 +129,6 @@ export function viewportForRect(
     FIT_NODE_OPTIONS.maxZoom,
     FIT_NODE_OPTIONS.padding
   )
-}
-
-/** A rectangle inside the flow pane, in the pane's OWN coordinates (0,0 = its top-left) — the
- *  chrome-free area a node should be framed into. Structurally the `FitRect` of `canvas/fit-view`,
- *  restated here so this module stays free of anything that touches the DOM. */
-export interface FitFrame {
-  left: number
-  top: number
-  right: number
-  bottom: number
-}
-
-/** The shift that brings a `size`-long span starting at `start` inside `[lo, hi]`, or 0 when it
- *  is already inside — or too long to fit, where any shift trades one clipped edge for the other. */
-function shiftInto(start: number, size: number, lo: number, hi: number): number {
-  if (size >= hi - lo) return 0
-  if (start < lo) return lo - start
-  if (start + size > hi) return hi - (start + size)
-  return 0
-}
-
-/**
- * `viewportForRect`, then the SMALLEST nudge that keeps the node clear of the floating chrome.
- *
- * "Go to node" means putting the node in front of the user, and the middle of the screen is where
- * that is: a node centred in the chrome-free rectangle instead reads as off to one side on a wide
- * display (the free rect is whatever the dock and the sidebar leave over, not the eye's centre) and
- * as half off-screen on a small one. So the centred answer stands, and the frame only pulls it back
- * when it would otherwise slide under a panel — usually the sessions sidebar the click came from.
- * A node too large to fit the frame is left centred: any shift there only swaps which edge is
- * covered. `frame` null (nothing sensible to solve) ⇒ the plain centred answer.
- */
-export function viewportForRectClearOf(
-  rect: Rect,
-  containerWidth: number,
-  containerHeight: number,
-  frame: FitFrame | null,
-  zoom?: number
-): Viewport | null {
-  const centred = viewportForRect(rect, containerWidth, containerHeight, zoom)
-  if (!centred || !frame) return centred
-  const width = rect.width * centred.zoom
-  const height = rect.height * centred.zoom
-  return {
-    zoom: centred.zoom,
-    x: centred.x + shiftInto(centred.x + rect.x * centred.zoom, width, frame.left, frame.right),
-    y: centred.y + shiftInto(centred.y + rect.y * centred.zoom, height, frame.top, frame.bottom)
-  }
 }
 
 /** Whether React Flow already knows this node's on-screen size — i.e. whether `fitView` will

--- a/src/renderer/lib/nodeFocus.ts
+++ b/src/renderer/lib/nodeFocus.ts
@@ -89,14 +89,30 @@ export function nodeFitRect(node: FocusableNode, all: readonly FocusableNode[]):
   return { ...absolutePosition(node, all), ...size }
 }
 
-/** The viewport that frames `rect` in a `containerWidth × containerHeight` pane, with the same
- *  padding/zoom clamp `fitView` would have applied. Null when the container has no size yet. */
+/**
+ * The viewport that frames `rect` in a `containerWidth × containerHeight` pane, with the same
+ * padding/zoom clamp `fitView` would have applied. Null when the container has no size yet.
+ *
+ * `zoom` keeps the camera at a scale the caller already has (`settings.focusZoomToNode` off): the
+ * node is centred exactly as it would be, at that zoom, so "go to" stays a pan. It is passed
+ * through UNCLAMPED — it is a zoom the canvas is already displaying, and re-clamping it to the
+ * framing range would rescale the view this option exists to leave alone.
+ */
 export function viewportForRect(
   rect: Rect,
   containerWidth: number,
-  containerHeight: number
+  containerHeight: number,
+  zoom?: number
 ): Viewport | null {
   if (!(containerWidth > 0) || !(containerHeight > 0)) return null
+  if (zoom !== undefined) {
+    if (!(zoom > 0)) return null
+    return {
+      x: containerWidth / 2 - (rect.x + rect.width / 2) * zoom,
+      y: containerHeight / 2 - (rect.y + rect.height / 2) * zoom,
+      zoom
+    }
+  }
   return getViewportForBounds(
     rect,
     containerWidth,
@@ -117,23 +133,41 @@ export interface FitFrame {
   bottom: number
 }
 
+/** The shift that brings a `size`-long span starting at `start` inside `[lo, hi]`, or 0 when it
+ *  is already inside — or too long to fit, where any shift trades one clipped edge for the other. */
+function shiftInto(start: number, size: number, lo: number, hi: number): number {
+  if (size >= hi - lo) return 0
+  if (start < lo) return lo - start
+  if (start + size > hi) return hi - (start + size)
+  return 0
+}
+
 /**
- * The viewport that puts `rect` in the middle of `frame`, at the zoom that fits it there.
+ * `viewportForRect`, then the SMALLEST nudge that keeps the node clear of the floating chrome.
  *
- * The counterpart to `viewportForRect` for callers that solved a chrome-free frame first: the node
- * is centred in the space it can actually be seen in, rather than in the whole pane and then
- * nudged out from under a panel. Null when either box has no usable size.
+ * "Go to node" means putting the node in front of the user, and the middle of the screen is where
+ * that is: a node centred in the chrome-free rectangle instead reads as off to one side on a wide
+ * display (the free rect is whatever the dock and the sidebar leave over, not the eye's centre) and
+ * as half off-screen on a small one. So the centred answer stands, and the frame only pulls it back
+ * when it would otherwise slide under a panel — usually the sessions sidebar the click came from.
+ * A node too large to fit the frame is left centred: any shift there only swaps which edge is
+ * covered. `frame` null (nothing sensible to solve) ⇒ the plain centred answer.
  */
-export function viewportForRectInFrame(rect: Rect, frame: FitFrame): Viewport | null {
-  const frameW = frame.right - frame.left
-  const frameH = frame.bottom - frame.top
-  if (!(frameW > 0) || !(frameH > 0) || !(rect.width > 0) || !(rect.height > 0)) return null
-  const fit = Math.min(frameW / rect.width, frameH / rect.height)
-  const zoom = Math.min(Math.max(fit, FIT_NODE_OPTIONS.minZoom), FIT_NODE_OPTIONS.maxZoom)
+export function viewportForRectClearOf(
+  rect: Rect,
+  containerWidth: number,
+  containerHeight: number,
+  frame: FitFrame | null,
+  zoom?: number
+): Viewport | null {
+  const centred = viewportForRect(rect, containerWidth, containerHeight, zoom)
+  if (!centred || !frame) return centred
+  const width = rect.width * centred.zoom
+  const height = rect.height * centred.zoom
   return {
-    x: (frame.left + frame.right) / 2 - (rect.x + rect.width / 2) * zoom,
-    y: (frame.top + frame.bottom) / 2 - (rect.y + rect.height / 2) * zoom,
-    zoom
+    zoom: centred.zoom,
+    x: centred.x + shiftInto(centred.x + rect.x * centred.zoom, width, frame.left, frame.right),
+    y: centred.y + shiftInto(centred.y + rect.y * centred.zoom, height, frame.top, frame.bottom)
   }
 }
 

--- a/src/renderer/lib/nodeFocus.ts
+++ b/src/renderer/lib/nodeFocus.ts
@@ -1,21 +1,26 @@
 import { getViewportForBounds, type Rect, type Viewport } from '@xyflow/system'
 
 /**
- * "Zoom to this node" geometry, computed WITHOUT React Flow's measurements.
+ * "Zoom to this node" geometry, computed without React Flow's `fitView`.
  *
  * Why this exists: `fitView({ nodes: [{ id }] })` is the natural way to frame one node, and it is
- * what `Canvas.goToNode` uses — but React Flow filters the fit set down to nodes it has already
- * MEASURED (`getFitViewNodes` keys off `measured.width && measured.height`; there is no
- * `width`/`height` fallback there). A node that was handed to React Flow a tick ago has no
- * measurement yet, so the fit set comes out EMPTY, its bounds collapse to `{0,0,0,0}` and the
- * camera flies to the canvas ORIGIN at max zoom — an empty stretch of canvas, nowhere near the
- * node. That is exactly the window a cross-project focus lands in: switch project → load its nodes
- * → focus the target, all before React Flow's mount-time measuring has run. (Clicking an OS
- * notification for a session in another project is the everyday path into it; the same node focuses
- * correctly on a second try, once it is measured.)
+ * what `Canvas.goToNode` used to do — but it frames nothing when you call it. It sets
+ * `fitViewQueued` and the fit is RESOLVED LATER: from a subsequent `setNodes` (and only once EVERY
+ * node is measured) or from the next `updateNodeInternals`. Whatever `nodeLookup` holds by then is
+ * what gets framed. And the fit set is filtered down to nodes React Flow has already MEASURED
+ * (`getFitViewNodes` keys off `measured.width && measured.height`; there is no `width`/`height`
+ * fallback there), so a set that comes out EMPTY collapses the bounds to `{0,0,0,0}` and the camera
+ * flies to the canvas ORIGIN at max zoom — an empty stretch of canvas, nowhere near the node.
  *
- * So for the unmeasured case we do the same maths ourselves from the size the node was persisted
- * with — which needs no layout — and drive the camera with `setViewport`.
+ * Both halves fire on the same everyday path. A cross-project focus (sessions sidebar, OS
+ * notification, ⌘K jump, presence travel) switches project → loads its nodes → frames the target,
+ * all before the mount-time measuring has settled: the queued fit then waits for a later node
+ * update, and by the time it runs the canvas may have moved on. The second click always works,
+ * because by then everything is measured — which is what makes it read as "sometimes".
+ *
+ * So the maths is ours, from React Flow's measurement when it has one and from the size the node
+ * was persisted with when it does not — neither needs layout — and the camera is driven with
+ * `setViewport`, which applies immediately.
  */
 
 /** The subset of a React Flow node this module needs. Loose on purpose: it must accept both a
@@ -30,9 +35,9 @@ export interface FocusableNode {
   style?: { width?: number | string | null; height?: number | string | null }
 }
 
-/** Zoom/padding for framing a single node. Kept beside the maths so the fallback path and
- *  `fitView` cannot drift apart: the clamp keeps a small node from filling the screen and a
- *  huge one from being fit microscopic. */
+/** Zoom/padding for framing a single node, shared by both framing paths here so the whole-pane
+ *  and chrome-free-frame answers cannot drift apart: the clamp keeps a small node from filling the
+ *  screen and a huge one from being fit microscopic. */
 export const FIT_NODE_OPTIONS = { padding: 0.2, minZoom: 0.25, maxZoom: 1.38 } as const
 
 /** A `parentId` chain longer than this is a data bug (or a cycle) — stop walking. */
@@ -100,6 +105,36 @@ export function viewportForRect(
     FIT_NODE_OPTIONS.maxZoom,
     FIT_NODE_OPTIONS.padding
   )
+}
+
+/** A rectangle inside the flow pane, in the pane's OWN coordinates (0,0 = its top-left) — the
+ *  chrome-free area a node should be framed into. Structurally the `FitRect` of `canvas/fit-view`,
+ *  restated here so this module stays free of anything that touches the DOM. */
+export interface FitFrame {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+/**
+ * The viewport that puts `rect` in the middle of `frame`, at the zoom that fits it there.
+ *
+ * The counterpart to `viewportForRect` for callers that solved a chrome-free frame first: the node
+ * is centred in the space it can actually be seen in, rather than in the whole pane and then
+ * nudged out from under a panel. Null when either box has no usable size.
+ */
+export function viewportForRectInFrame(rect: Rect, frame: FitFrame): Viewport | null {
+  const frameW = frame.right - frame.left
+  const frameH = frame.bottom - frame.top
+  if (!(frameW > 0) || !(frameH > 0) || !(rect.width > 0) || !(rect.height > 0)) return null
+  const fit = Math.min(frameW / rect.width, frameH / rect.height)
+  const zoom = Math.min(Math.max(fit, FIT_NODE_OPTIONS.minZoom), FIT_NODE_OPTIONS.maxZoom)
+  return {
+    x: (frame.left + frame.right) / 2 - (rect.x + rect.width / 2) * zoom,
+    y: (frame.top + frame.bottom) / 2 - (rect.y + rect.height / 2) * zoom,
+    zoom
+  }
 }
 
 /** Whether React Flow already knows this node's on-screen size — i.e. whether `fitView` will

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1359,6 +1359,12 @@ export interface Settings {
   /** ms to dwell over a terminal before it takes pointer focus (pan-across guard). */
   panHoverDelay: number
   doubleClickFocus: boolean
+  /** "Go to node" (sessions sidebar, notification click, ⌘K jump, breadcrumb steps, presence
+   *  travel) fits the node in view. Off: the camera keeps the CURRENT zoom and only pans, which is
+   *  what a user who has settled on a zoom level wants — a jump that also rescales the whole canvas
+   *  costs them the sense of where they were. Either way the node is centred and kept clear of the
+   *  floating chrome (renderer/lib/nodeFocus). */
+  focusZoomToNode: boolean
   /** Open Markdown files (.md, .markdown, …) in rendered preview instead of the code editor.
    *  Only picks the view an editor node OPENS in — the node's Preview/Edit toggle (and the
    *  markdown-toggle chord) still switches either way. Default ON since the release after
@@ -1669,6 +1675,7 @@ export const DEFAULT_SETTINGS: Settings = {
   worktreePathTemplate: DEFAULT_WORKTREE_PATH_TEMPLATE,
   panHoverDelay: 600,
   doubleClickFocus: true,
+  focusZoomToNode: true,
   openMarkdownPreview: true,
   openMarkdownPreviewMigrated: true,
   terminalMiddleClickPaste: false,


### PR DESCRIPTION
## What's wrong

Going to a node — the sessions sidebar, an OS notification click, the ⌘K jump, breadcrumb steps, presence travel — sometimes flew to an empty stretch of canvas: the right project, thousands of pixels from the session. A second click always worked, which is what made it read as intermittent.

Separately, when it did land, the node was not in the middle of the screen: well right of center on an ultrawide, only partly visible on a laptop.

## Why

**The jump to nowhere is `fitView`.** React Flow's `fitView` frames nothing when you call it. It sets `fitViewQueued`, and the fit is resolved *later* — from a subsequent `setNodes` (and only once *every* node is measured, `nodesInitialized`) or from the next `updateNodeInternals` — against whatever `nodeLookup` holds by then. Its fit set is also filtered by `measured`, with no `width`/`height` fallback, so a set that comes out empty collapses the bounds to `{0,0,0,0}` and `getViewportForBounds` parks the canvas **origin** in the middle of the screen at max zoom.

A cross-project focus lands in that window every time: switch project → load its nodes → frame the target, all before the mount-time measuring has settled. By the time the queued fit runs, the canvas has moved on.

**The off-center framing is the chrome-free rectangle.** `frameNode` solved the largest rectangle the floating chrome leaves over and framed the node against it. But `.sessions-sidebar` is a 300px absolute overlay, and it is open exactly when this feature is used — so any rule that keeps the node out of it pushes the node right by most of its own width. Both shapes were tried and both are wrong: centered *in* that rectangle, and centered in the pane then nudged clear of it.

## What changed

`frameNode` computes the viewport itself and applies it with `setViewport`, which lands immediately and against the canvas that was actually clicked:

- the node's rect from React Flow's own measurement when it has one (`internals.positionAbsolute` also accounts for `extent: 'parent'` clamping), else from the **persisted** size, which needs no layout;
- centered in the pane, and nothing else. The couple of dozen pixels that end up behind the sidebar cost far less than losing the center;
- unknowable size or no pane still leaves the camera where it is — standing still beats teleporting to the origin.

The free-rect solve keeps earning its keep in `fitAll`, which fits *every* node and would otherwise tuck them under the dock. `solveFitPadding` is now expressed through a new pane-local `solveFitFrame`, so there is one solve rather than two.

## New setting

**Settings → Behavior → "Zoom when going to a node"** (`settings.focusZoomToNode`, default on). Off, going to a node keeps the zoom you settled on and only pans — a jump that also rescales the whole canvas costs you your sense of where you were. The node still lands in the middle. That zoom is passed through **unclamped**: it is one the canvas is already displaying, so re-clamping it to the framing range would rescale the view the option exists to leave alone.

## Tests

- `renderer/lib/nodeFocus.test.ts` — centering on both a laptop and an ultrawide pane, the keep-my-zoom path, and the out-of-range zoom passthrough.
- `renderer/canvas/fit-view.test.ts` — `solveFitFrame` answers in pane coordinates, clears visible chrome, and refuses a degenerate frame.
- `renderer/canvas/canvas-wiring.test.tsx` — source-level pins that `frameNode` contains no `fitView(` and no `solveFitFrame`. Canvas has no render harness, and either one reintroduces a bug that passes every other test.

The reasoning and both rejected variants are written down in `nodeFocus.ts`, `CLAUDE.md` and `CONTRIBUTING.md`, so this does not come back a third time.

## Surfaces

Desktop and Server Edition are identical — pure renderer geometry plus one settings field, no new IPC or bridge member. Mobile: N/A (no canvas, no camera).
