### PR TITLE
fix(canvas-control): an agent opening a node no longer moves the user's view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1861,6 +1861,47 @@ else, and its context links must keep classifying across restarts).
   so reporting it as "the error" would be a confident wrong fact. Reading the text, and the
   *failed-to-start* watchdog (a station that never emits ANY hook event — the opposite failure,
   which hangs dependents honestly rather than firing them wrongly), stay open.
+  **Opening a node never moves the human's view (`lib/offCanvasControl`, 2026-09).** Routing is by
+  SOURCE, and React Flow holds only the ACTIVE project's nodes, so a verb declared
+  `needsLiveCanvas` used to TRAVEL to the calling agent's project before it ran — which meant a
+  background agent rendering its output as a node (`show-web` for a report, `show-image` for a
+  screenshot, `open-claude` for a fan-out) yanked the user out of the project they were typing in,
+  at a moment they did not choose. Same G5 objection `send`/`reply`/`sticky`/`open-project` are
+  already exempt for; those verbs simply never needed a canvas, while these needed a PLACE TO PUT A
+  NODE — which the owning project's SERIALIZED nodes can be, exactly as the `--project` cold-open
+  branch already writes into another project's store. `OFF_CANVAS_VERBS` (`show-image`,
+  `show-video`, `show-web`, `open-browser`, `open-terminal`, `open-claude`, `open-agent`) are now
+  answered against a staged copy of that project's nodes, committed through
+  `applyNodeMutation` + the new `appendProjectEdges` (ropes and bridges — `commitCanvas` replaces
+  both arrays wholesale from the live canvas and cannot serve a project React Flow does not hold),
+  and the human gets a NOTICE naming the project with a "Go there" button. Rules a refactor must
+  not undo:
+  - **The handler's verb body reads and writes through the shims** (`readNodes` / `applyNodes` /
+    `addRopeEdges` / `addBridgeEdges` / `readLinkEdges` / `touchCanvas`), which are pass-throughs
+    on the on-screen path. A new verb reaching for `nodesRef.current` or `setNodes` compiles,
+    passes every other test, and quietly reads or writes the WRONG project;
+    `canvas-wiring.test.tsx` pins the absence at source level because nothing else can see it.
+  - **The acting project is the SOURCE's, not the active one.** `ctlProject` used to read
+    `activeProjectId`, which was correct only because the travel had just made the two the same
+    project — off canvas it decides another project's ssh flag, browser session key, managed
+    account, permission mode and launch override. `activePermissionMode` is replaced by
+    `projectPermissionMode(ctlProject, …)` on these paths; the verbs that still travel may keep
+    asking for the active project.
+  - **A node created off canvas is re-armed with `armForColdOpen`** — `initialCommand` is never
+    serialized, so a launch left there is silently dropped and the session never starts. The reply
+    therefore also CORRECTS `queued`/`queuedIds` to the whole batch and carries `offCanvas: true`
+    beside the sentence: an orchestrator must not report a session as started because its `--after`
+    deps happened to be satisfied. A REFUSAL commits nothing.
+  - **A worktree-bound `--group` is NOT answered off canvas** and still travels. `cwdForNewNodeIn`
+    subtracts the worktree store's `staleGroupIds`, which is scoped to the ACTIVE project; off
+    canvas that subtraction cannot be made, and failing open would hand the new node a checkout
+    deleted outside the app. Everything that reads or drives something LIVE also still travels —
+    `browser` needs a mounted `<webview>` guest, `write`/`close` a running pane, `focus`/`goto` a
+    camera that by definition belongs to the active project, and the layout verbs a human watching
+    the result. A verb joining `OFF_CANVAS_VERBS` owes the staging path the state it reads.
+  Surfaces: Desktop + Server Edition identical (pure renderer + the projects store — no new IPC or
+  bridge member); mobile N/A (no canvas, and the transport protocol carries no canvas nodes).
+
   **Review panel (`verify`, 2026-07):** `verify --node <id> [--lenses …] [--focus …] [--agent …]
   [--synthesis off]` opens one reviewer per LENS, each armed behind the target (`--after`) and
   bridged to it, wrapped in a `Verify: <title>` group, plus a judge armed behind the whole panel.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,6 +341,18 @@ from the target's `pendingLaunch` (`renderer/lib/edgeModel.ts`), and the context
 writes stays hidden underneath it. One `open-claude --after` used to land three edges on one node.
 `src/renderer/canvas/edge-model.source.test.ts` pins both halves.
 
+**An agent never moves the user's view.** The user works in one project at a time, and a canvas
+control call arrives from whichever project its agent runs in — usually not that one. Anything an
+agent can trigger must therefore act on the canvas it was ADDRESSED at, not on the one that happens
+to be on screen: a verb that only has to put a node somewhere writes into the owning project's
+serialized nodes (`renderer/lib/offCanvasControl.ts`) and the user gets a notice with a "Go there"
+button, rather than being teleported mid-keystroke. Inside the agent-control handler that means
+reading and writing through its shims (`readNodes` / `applyNodes` / `addRopeEdges` /
+`addBridgeEdges` / `touchCanvas`) and deriving every default from `ctlProject`, never from
+`activeProjectId` — both are pinned at source level in `canvas-wiring.test.tsx`, because a bare
+`nodesRef.current` compiles, passes every other test, and silently answers about another project.
+The same rule applies to any new surface that reacts to a background agent.
+
 ## Testing
 
 `npm test` must pass, and `npm run typecheck` is the fastest gate.

--- a/src/core/canvas-control-core.ts
+++ b/src/core/canvas-control-core.ts
@@ -344,7 +344,7 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  `send` to it and do not report it as started. It launches itself when its wait ends,',
     '  then reports through the ordinary status hooks — there is nothing to poll.',
     '  `queued: false` means the session is running.',
-    '  YOUR OWN project may also be off screen — the user works in one project at a time. The',
+    '  YOUR OWN project may also be off screen. The user works in one project at a time. The',
     '  node is still created, in your project, and the reply says `offCanvas: true`; it starts',
     '  when the user next views that project, exactly like a `--project` open. nodeterm does NOT',
     '  switch the user\'s view to show it, so never assume they are looking at what you opened.',
@@ -782,11 +782,11 @@ Verbs:
   ends and then reports through the ordinary status hooks, so there is nothing to poll.
   \`queued: false\` means the session is running.
   **Your own project may be off screen too.** The user works in one project at a time, and yours
-  is not necessarily the one they are looking at. The node is still created — in your project —
-  and the reply says \`offCanvas: true\`; it starts when the user next views that project, exactly
-  like a \`--project\` open. nodeterm deliberately does NOT switch their view to show it, so never
+  is not necessarily the one they are looking at. The node is still created, in your project, and
+  the reply says \`offCanvas: true\`; it starts when the user next views that project, exactly like
+  a \`--project\` open. nodeterm deliberately does NOT switch their view to show it, so never
   assume they are watching what you just opened. The same applies to \`show-web\`, \`show-image\`
-  and \`show-video\`: rendering something is an offer, not an interruption.
+  and \`show-video\`. Rendering something is an offer, not an interruption.
   \`--prompt\` arrives on ONE LINE. Every run of whitespace in it — newlines included — is
   collapsed to a single space before the session starts, because the prompt is passed as an
   argument on the agent CLI's launch command line and that line is typed into the pane. Two

--- a/src/core/canvas-control-core.ts
+++ b/src/core/canvas-control-core.ts
@@ -344,6 +344,10 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '  `send` to it and do not report it as started. It launches itself when its wait ends,',
     '  then reports through the ordinary status hooks — there is nothing to poll.',
     '  `queued: false` means the session is running.',
+    '  YOUR OWN project may also be off screen — the user works in one project at a time. The',
+    '  node is still created, in your project, and the reply says `offCanvas: true`; it starts',
+    '  when the user next views that project, exactly like a `--project` open. nodeterm does NOT',
+    '  switch the user\'s view to show it, so never assume they are looking at what you opened.',
     '  `--prompt` arrives on ONE LINE: every run of whitespace in it, newlines included, is',
     '  collapsed to a single space before the session starts (the prompt rides the launch command',
     '  line typed into the pane). For a structured or multi-line brief use `--prompt-file <abs',
@@ -777,6 +781,12 @@ Verbs:
   to it, do not \`send\` to it and do not report it as started. It launches itself when its wait
   ends and then reports through the ordinary status hooks, so there is nothing to poll.
   \`queued: false\` means the session is running.
+  **Your own project may be off screen too.** The user works in one project at a time, and yours
+  is not necessarily the one they are looking at. The node is still created — in your project —
+  and the reply says \`offCanvas: true\`; it starts when the user next views that project, exactly
+  like a \`--project\` open. nodeterm deliberately does NOT switch their view to show it, so never
+  assume they are watching what you just opened. The same applies to \`show-web\`, \`show-image\`
+  and \`show-video\`: rendering something is an offer, not an interruption.
   \`--prompt\` arrives on ONE LINE. Every run of whitespace in it — newlines included — is
   collapsed to a single space before the session starts, because the prompt is passed as an
   argument on the agent CLI's launch command line and that line is typed into the pane. Two

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -5810,6 +5810,9 @@ export function Canvas() {
   // Same reason as worktreeControlRef below: the agent-control handler needs the CURRENT
   // travelToProject (defined far below, after the project actions it composes).
   const travelToProjectRef = useRef<(projectId: string) => void>(() => {})
+  /** Latest `travelToNode`, for the agent-control handler: that effect mounts ONCE (empty deps),
+   *  so it cannot close over the callback. Same reason as travelToProjectRef. */
+  const travelToNodeRef = useRef<(nodeId: string) => void>(() => {})
 
   // Latest worktree callbacks for the agent-control handler. That effect mounts ONCE (empty
   // deps) and these callbacks' identities change with the active project (activeProjectId /
@@ -8916,10 +8919,14 @@ export function Canvas() {
         const store = useProjects.getState()
         const before = new Map(offCanvas.nodes.map((n) => [n.id, n]))
         let added = 0
+        let firstAdded = ''
         for (const node of stagedNodes) {
           if (before.get(node.id) === node) continue
           const fresh = !before.has(node.id)
-          if (fresh) added += 1
+          if (fresh) {
+            added += 1
+            if (!firstAdded) firstAdded = node.id
+          }
           store.applyNodeMutation(offCanvas.project.id, {
             op: 'upsert',
             node: flowToNodeStates([fresh ? armForColdOpen(node) : node])[0]
@@ -8931,12 +8938,17 @@ export function Canvas() {
         })
         void writeDisk()
         if (added > 0) {
-          const target = offCanvas.project.id
+          // To the NODE, not just to its project: the notice is about one thing that appeared, and
+          // landing on the project's saved camera would leave the user hunting for it. `travelToNode`
+          // reopens a closed project first and frames the node once its canvas has loaded (the
+          // pendingFocus path), and it resolves off the SERIALIZED nodes — which the upsert above
+          // has already written, so the node is findable even though no canvas holds it yet.
+          const target = firstAdded
           setNotice({
             kind: 'info',
             text: offCanvasNoticeText(offCanvas.project.name, added),
             sticky: true,
-            action: { label: 'Go there', run: () => travelToProjectRef.current(target) }
+            action: { label: 'Go there', run: () => travelToNodeRef.current(target) }
           })
         }
         return true
@@ -12408,6 +12420,12 @@ export function Canvas() {
     },
     [focusNodeById, reopenProject]
   )
+  // Published for the agent-control handler, which mounts ONCE and cannot close over it. Assigned
+  // BELOW the definition on purpose: an effect above it would read a const that is only
+  // initialized later in the body, which works today and breaks the day someone reorders.
+  useEffect(() => {
+    travelToNodeRef.current = travelToNode
+  })
 
   // OS-notification click → focus the originating node (see the note beside focusNodeById:
   // travelToNode, not focusNodeById, so a closed project's tab is reopened first).

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -10730,21 +10730,21 @@ export function Canvas() {
             const ids = [
               ...new Set((args.node ?? '').split(',').map((id) => id.trim()).filter(Boolean))
             ]
-            const live = nodesRef.current
+            const live = readNodes()
             const colored = ids.filter((id) => live.some((node) => node.id === id))
             if (!colored.length) {
               reply({ ok: false, error: 'color: none of the given node ids exist' })
               return
             }
             const selected = new Set(colored)
-            setNodes((nodes) =>
+            applyNodes((nodes) =>
               nodes.map((node) =>
                 selected.has(node.id)
                   ? { ...node, data: { ...node.data, color: args.color } }
                   : node
               )
             )
-            markDirty()
+            touchCanvas()
             const skipped = ids.length - colored.length
             const note = skipped ? ` (${skipped} unknown id(s) skipped)` : ''
             reply({

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -929,13 +929,18 @@ export function Canvas() {
   // top-banner column instead; an 'info' one fades itself out, an 'error' stays until dismissed.
   // `action` is the one affordance a notice may carry: work landed somewhere the human is not
   // looking, and the honest answer is to say so and offer the trip rather than take it for them.
+  // `sticky` keeps such a notice up until it is dismissed. An 'info' strip normally reports
+  // something the user just did and is watching, so a few seconds is enough; this one reports work
+  // that landed in ANOTHER project while they were busy elsewhere, and once it fades there is
+  // nothing left anywhere that says it happened.
   const [notice, setNotice] = useState<{
     kind: 'info' | 'error'
     text: string
+    sticky?: boolean
     action?: { label: string; run: () => void }
   } | null>(null)
   useEffect(() => {
-    if (notice?.kind !== 'info') return
+    if (notice?.kind !== 'info' || notice.sticky) return
     const t = setTimeout(() => setNotice(null), noticeDwellMs(notice.text))
     return () => clearTimeout(t)
   }, [notice])
@@ -8930,6 +8935,7 @@ export function Canvas() {
           setNotice({
             kind: 'info',
             text: offCanvasNoticeText(offCanvas.project.name, added),
+            sticky: true,
             action: { label: 'Go there', run: () => travelToProjectRef.current(target) }
           })
         }
@@ -8958,7 +8964,7 @@ export function Canvas() {
           requestId,
           ...r,
           message:
-            `${r.message ?? ''}\nPlaced in "${offCanvas.project.name}", which is not on screen — it starts when that project is next viewed.`.trim(),
+            `${r.message ?? ''}\nPlaced in "${offCanvas.project.name}", which is not on screen. It starts when that project is next viewed.`.trim(),
           result: {
             ...base,
             ...('queued' in base ? { queued: ids.length > 0, queuedIds: ids } : {}),

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -251,6 +251,7 @@ import {
   answerBrowserResolve,
   type BrowserResolveProject
 } from '../lib/controlRouting'
+import { answersOffCanvas, offCanvasNoticeText } from '../lib/offCanvasControl'
 import { applyStickyWrite, parseStickyArgs, resolveStickyRef } from '@shared/sticky-write'
 import {
   unavailableRecovery,
@@ -452,6 +453,7 @@ import { useEntitlement } from '../state/entitlement'
 import type { SshServer } from '@shared/ssh'
 import { sshHostKey } from '@shared/ssh'
 import type {
+  BridgeLink,
   CanvasNodeState,
   ClosedSessionEntry,
   NodeKind,
@@ -925,7 +927,13 @@ export function Canvas() {
   // Result of a worktree operation (merge / remove). These used to be `window.alert`s — a modal
   // that blocks the whole app to say "Merged feat into main." Shown as a strip in the existing
   // top-banner column instead; an 'info' one fades itself out, an 'error' stays until dismissed.
-  const [notice, setNotice] = useState<{ kind: 'info' | 'error'; text: string } | null>(null)
+  // `action` is the one affordance a notice may carry: work landed somewhere the human is not
+  // looking, and the honest answer is to say so and offer the trip rather than take it for them.
+  const [notice, setNotice] = useState<{
+    kind: 'info' | 'error'
+    text: string
+    action?: { label: string; run: () => void }
+  } | null>(null)
   useEffect(() => {
     if (notice?.kind !== 'info') return
     const t = setTimeout(() => setNotice(null), noticeDwellMs(notice.text))
@@ -3189,8 +3197,10 @@ export function Canvas() {
   // every local session carries the hook env (pty-manager defaults agentId to 'claude'), so
   // the managed hooks report who's actually running inside even when data.agentId was never
   // set at node creation.
-  const agentIdOf = useCallback((id: string): AgentId | undefined => {
-    const n = nodesRef.current.find((x) => x.id === id)
+  // `nodes` defaults to the live canvas. The off-canvas control path (lib/offCanvasControl) passes
+  // the owning project's staged nodes instead — same rule, a different canvas, one implementation.
+  const agentIdOf = useCallback((id: string, nodes?: CanvasNode[]): AgentId | undefined => {
+    const n = (nodes ?? nodesRef.current).find((x) => x.id === id)
     if (!n || n.type !== 'terminal') return undefined
     return (
       (n.data.agentId as AgentId | undefined) ??
@@ -3202,10 +3212,10 @@ export function Canvas() {
   // Endpoint descriptor for classifyLink: node kind + whether it's a context-link-capable
   // agent session (claude/codex/gemini). Null when the node doesn't exist.
   const linkEndpointOf = useCallback(
-    (id: string): LinkEndpoint | null => {
-      const n = nodesRef.current.find((x) => x.id === id)
+    (id: string, nodes?: CanvasNode[]): LinkEndpoint | null => {
+      const n = (nodes ?? nodesRef.current).find((x) => x.id === id)
       if (!n) return null
-      const a = agentIdOf(id)
+      const a = agentIdOf(id, nodes)
       return { kind: n.type ?? 'terminal', contextCapable: !!a && canContextLink(a) }
     },
     [agentIdOf]
@@ -3626,14 +3636,14 @@ export function Canvas() {
   // worktrees are unsupported in SSH projects in v1). This also keeps the two ↪ guards below honest,
   // since both decide by comparing against what this returns.
   const cwdForNewNodeIn = useCallback(
-    (parentId: string | undefined): string | undefined => {
+    (parentId: string | undefined, nodes?: CanvasNode[]): string | undefined => {
       // Frames nest, so the answer is the NEAREST ancestor that states one — a node dropped in a
       // sub-frame of a worktree frame still belongs to that worktree checkout.
       const seen = new Set<string>()
       let currentId = parentId
       while (currentId && !seen.has(currentId)) {
         seen.add(currentId)
-        const parent = nodesRef.current.find((n) => n.id === currentId)
+        const parent = (nodes ?? nodesRef.current).find((n) => n.id === currentId)
         if (!parent) return undefined
         const stale = useWorktrees.getState().staleGroupIds.includes(currentId)
         if (parent.data.worktree && !stale && !isSshProject) return parent.data.worktree.path
@@ -3664,22 +3674,23 @@ export function Canvas() {
 
   // Reparent a freshly-created node into a group (parentId + extent 'parent', position made
   // relative to the group frame). Mirrors how `groupSelectedNodes` parents its children.
-  const parentInto = useCallback((node: CanvasNode, groupId: string): CanvasNode => {
-    const group = nodesRef.current.find((n) => n.id === groupId)
-    if (!group) return node
-    // The frame's own position is relative to ITS parent once frames nest, so the incoming
-    // absolute point must be converted against the frame's ROOT-space origin.
-    const groupPosition = absolutePosition(
-      group as FocusableNode,
-      nodesRef.current as FocusableNode[]
-    )
-    return {
-      ...node,
-      parentId: groupId,
-      extent: 'parent' as const,
-      position: { x: node.position.x - groupPosition.x, y: node.position.y - groupPosition.y }
-    }
-  }, [])
+  const parentInto = useCallback(
+    (node: CanvasNode, groupId: string, nodes?: CanvasNode[]): CanvasNode => {
+      const all = nodes ?? nodesRef.current
+      const group = all.find((n) => n.id === groupId)
+      if (!group) return node
+      // The frame's own position is relative to ITS parent once frames nest, so the incoming
+      // absolute point must be converted against the frame's ROOT-space origin.
+      const groupPosition = absolutePosition(group as FocusableNode, all as FocusableNode[])
+      return {
+        ...node,
+        parentId: groupId,
+        extent: 'parent' as const,
+        position: { x: node.position.x - groupPosition.x, y: node.position.y - groupPosition.y }
+      }
+    },
+    []
+  )
 
   /** The group frame under an absolute canvas point, or undefined. Later entries win, so the
    *  frame drawn on top of another is the one that takes the node. */
@@ -8843,8 +8854,119 @@ export function Canvas() {
   // main never hangs to its 120s timeout.
   useEffect(() => {
     return api.onAgentControl(async ({ requestId, sourceNodeId, verb, args }) => {
-      const reply = (r: { ok: boolean; message?: string; result?: unknown; error?: string }) =>
-        api.sendAgentControlResult({ requestId, ...r })
+      // ── Where this command reads and writes (lib/offCanvasControl) ─────────────────────────
+      // Normally: the live React Flow canvas. When the CALLING agent's project is not the one on
+      // screen and the verb only has to put a node somewhere, the command runs against a staged
+      // copy of that project's serialized nodes instead of travelling to it — travelling is what
+      // let a background agent's `show-web` yank the human out of the project they were typing in.
+      // Every shim below is a pass-through while `offCanvas` is null, so the on-screen path is
+      // unchanged. They are declared HERE, above the store-answered early exits, so nothing in
+      // this handler has to know which mode it is in.
+      let offCanvas: { project: Project; nodes: CanvasNode[] } | null = null
+      let stagedNodes: CanvasNode[] | null = null
+      let stagedDirty = false
+      const stagedRopes: BridgeLink[] = []
+      const stagedBridges: BridgeLink[] = []
+      const readNodes = (): CanvasNode[] => stagedNodes ?? nodesRef.current
+      const applyNodes = (next: CanvasNode[] | ((ns: CanvasNode[]) => CanvasNode[])): void => {
+        if (stagedNodes) {
+          stagedNodes = typeof next === 'function' ? next(stagedNodes) : next
+          stagedDirty = true
+          return
+        }
+        setNodes(next)
+      }
+      const addRopeEdges = (edges: Edge[]): void => {
+        if (offCanvas) {
+          stagedRopes.push(...edges.map((e) => ({ id: e.id, source: e.source, target: e.target })))
+          return
+        }
+        setControlEdges((es) => [...es, ...edges])
+      }
+      const addBridgeEdges = (edges: BridgeLink[]): void => {
+        if (offCanvas) {
+          stagedBridges.push(...edges)
+          return
+        }
+        setLinkEdges((es) => [...es, ...edges])
+      }
+      const readLinkEdges = (): readonly { source: string; target: string }[] =>
+        offCanvas ? [...(offCanvas.project.bridges ?? []), ...stagedBridges] : linkEdgesRef.current
+      // `markDirty` marks the ACTIVE canvas; off canvas the staged commit below owns persistence.
+      const touchCanvas = (): void => {
+        if (offCanvas) {
+          stagedDirty = true
+          return
+        }
+        markDirty()
+      }
+      // Commit the staged canvas into the owning project's serialized nodes. Only nodes this
+      // command actually touched are written (identity diff against the snapshot it started
+      // from), so a peer edit landing in that project meanwhile is not clobbered. A node being
+      // ADDED is re-armed for a cold open: `initialCommand` is never serialized, so a launch left
+      // there would be silently dropped — the same rule the `--project` branch states.
+      const commitOffCanvas = (): boolean => {
+        if (!offCanvas || !stagedNodes) return false
+        if (!stagedDirty && stagedRopes.length === 0 && stagedBridges.length === 0) return false
+        const store = useProjects.getState()
+        const before = new Map(offCanvas.nodes.map((n) => [n.id, n]))
+        let added = 0
+        for (const node of stagedNodes) {
+          if (before.get(node.id) === node) continue
+          const fresh = !before.has(node.id)
+          if (fresh) added += 1
+          store.applyNodeMutation(offCanvas.project.id, {
+            op: 'upsert',
+            node: flowToNodeStates([fresh ? armForColdOpen(node) : node])[0]
+          })
+        }
+        store.appendProjectEdges(offCanvas.project.id, {
+          ropes: stagedRopes,
+          bridges: stagedBridges
+        })
+        void writeDisk()
+        if (added > 0) {
+          const target = offCanvas.project.id
+          setNotice({
+            kind: 'info',
+            text: offCanvasNoticeText(offCanvas.project.name, added),
+            action: { label: 'Go there', run: () => travelToProjectRef.current(target) }
+          })
+        }
+        return true
+      }
+      const reply = (r: { ok: boolean; message?: string; result?: unknown; error?: string }) => {
+        // Commit BEFORE answering: the agent is told what happened, so it must have happened. A
+        // REFUSAL commits nothing — a verb that staged something and then refused must leave the
+        // owning project exactly as it found it.
+        const staged = r.ok ? commitOffCanvas() : false
+        if (!staged || !offCanvas) {
+          api.sendAgentControlResult({ requestId, ...r })
+          return
+        }
+        // Said as a FIELD as well as a sentence, for the same reason `queued` is (#569 item 1): an
+        // orchestrator must not report a node as on screen when the human is looking elsewhere.
+        // And every SESSION opened this way is cold-open armed, whatever the verb computed from
+        // `--after` — so a result that speaks of queueing is corrected to the truth rather than
+        // left reporting a session as started because its dependencies happened to be satisfied.
+        const base = (typeof r.result === 'object' && r.result ? r.result : {}) as Record<
+          string,
+          unknown
+        >
+        const ids = Array.isArray(base.ids) ? (base.ids as string[]) : []
+        api.sendAgentControlResult({
+          requestId,
+          ...r,
+          message:
+            `${r.message ?? ''}\nPlaced in "${offCanvas.project.name}", which is not on screen — it starts when that project is next viewed.`.trim(),
+          result: {
+            ...base,
+            ...('queued' in base ? { queued: ids.length > 0, queuedIds: ids } : {}),
+            offCanvas: true,
+            projectId: offCanvas.project.id
+          }
+        })
+      }
       // `--dry-run` (issue #532): validate + report, mutate nothing. Only DRY_RUN_VERBS reach
       // this process with the flag set — main's setControlHandler refuses it for every other
       // verb before forwarding — so the per-case branches below are the whole renderer story:
@@ -9286,13 +9408,25 @@ export function Canvas() {
             })
             return
           }
-          travelToProjectRef.current(route.projectId)
+          // A verb whose whole effect is "put a node on that project's canvas" is answered against
+          // that project's SERIALIZED nodes — see lib/offCanvasControl for what qualifies and why
+          // a worktree-bound `--group` deliberately does not. Everything else still travels.
+          const owner = projects.find((p) => p.id === route.projectId)
+          const ownerNodes = owner ? nodeStatesToFlow(owner.nodes) : []
+          if (owner && answersOffCanvas(verb, args, ownerNodes)) {
+            offCanvas = { project: owner, nodes: ownerNodes }
+            stagedNodes = ownerNodes
+            src = ownerNodes.find((n) => n.id === sourceNodeId)
+          } else {
+            travelToProjectRef.current(route.projectId)
+          }
         }
         // Wait for the node to show up on the canvas: after a travel, because the active-project
         // effect hydrates React Flow a tick later; on `active`, because a control call can land
         // while the BOOT load of the owning project is still in flight — the very moment a
         // re-adopted agent starts talking again. `unknown`/`blocked` have no canvas to wait for.
-        if (route.kind !== 'unknown' && route.kind !== 'blocked') {
+        // An off-canvas answer has its source node already: there is no live canvas to wait for.
+        if (!offCanvas && route.kind !== 'unknown' && route.kind !== 'blocked') {
           src = await waitForCanvasNode(() => nodesRef.current.find((n) => n.id === sourceNodeId))
         }
       }
@@ -9318,10 +9452,16 @@ export function Canvas() {
       // got it right; every control verb passed `undefined` and got it wrong.) The factory reads
       // the node's cwd out of `remoteCwd`, so the effective cwd is threaded through there —
       // otherwise `--cwd` would be silently replaced by the project root.
-      const ctlProject = (() => {
-        const st = useProjects.getState()
-        return st.getProject(st.activeProjectId ?? '')
-      })()
+      // The project the SOURCE node belongs to — the canvas this command acts on. Every default
+      // derived from it (ssh, browser session key, managed account, permission mode, launch
+      // override) must follow the source, not whatever the human happens to be looking at. On the
+      // travelling path the two are the same project; off canvas they are not.
+      const ctlProject =
+        offCanvas?.project ??
+        (() => {
+          const st = useProjects.getState()
+          return st.getProject(st.activeProjectId ?? '')
+        })()
       const ctlSsh = ctlProject?.ssh
       const sshFor = (cwd?: string) => nodeSshFor(ctlSsh, cwd)
       // Place opened nodes BELOW the source and rope them to it (source flow-out → target
@@ -9332,7 +9472,7 @@ export function Canvas() {
       const srcH = src.measured?.height ?? (src.height as number) ?? 400
       // src.position is group-relative when the agent sits inside a group frame — resolve the
       // absolute position first so placements land below the agent regardless of grouping.
-      const srcGroup = src.parentId ? nodesRef.current.find((n) => n.id === src.parentId) : undefined
+      const srcGroup = src.parentId ? readNodes().find((n) => n.id === src.parentId) : undefined
       const srcAbs = {
         x: src.position.x + (srcGroup?.position.x ?? 0),
         y: src.position.y + (srcGroup?.position.y ?? 0)
@@ -9340,7 +9480,7 @@ export function Canvas() {
       const belowY = srcAbs.y + srcH + 80
       const placeBelow = (i = 0) => ({ x: srcAbs.x + srcW / 2 + i * 460, y: belowY + 210 })
       const connect = (newId: string) =>
-        setControlEdges((es) => [...es, ropeEdge(`ctrl-${sourceNodeId}-${newId}`, sourceNodeId, newId)])
+        addRopeEdges([ropeEdge(`ctrl-${sourceNodeId}-${newId}`, sourceNodeId, newId)])
       // `--after` is a rope too: dep → armed node, drawn dashed while the node waits and solid once
       // it has launched (displayEdges derives that from pendingLaunch). The opener's own rope is
       // skipped here — it already exists, and ropeVisual renders it waiting when the node waits on
@@ -9351,7 +9491,7 @@ export function Canvas() {
         const ropes = ids.flatMap((nid) =>
           after.filter((dep) => dep !== sourceNodeId).map((dep) => ropeEdge(`ctrl-${dep}-${nid}`, dep, nid))
         )
-        if (ropes.length) setControlEdges((es) => [...es, ...ropes])
+        if (ropes.length) addRopeEdges(ropes)
       }
       // Draw real CONTEXT links (persisted `bridges`), not the display-only ropes `connect`
       // draws — a rope is lineage decoration, a bridge is what get-linked-context reads. This
@@ -9371,13 +9511,13 @@ export function Canvas() {
       const bridgeTo = (
         fromId: string,
         targetIds: string[],
-        lookup: (id: string) => LinkEndpoint | null = linkEndpointOf
+        lookup: (id: string) => LinkEndpoint | null = (id) => linkEndpointOf(id, readNodes())
       ) => {
-        const plan = planBridges(fromId, targetIds, lookup, [...linkEdgesRef.current, ...drawn])
+        const plan = planBridges(fromId, targetIds, lookup, [...readLinkEdges(), ...drawn])
         if (plan.edges.length) {
           drawn.push(...plan.edges)
-          setLinkEdges((es) => [...es, ...plan.edges])
-          markDirty()
+          addBridgeEdges(plan.edges)
+          touchCanvas()
         }
         return plan
       }
@@ -9389,10 +9529,10 @@ export function Canvas() {
         // A node that arrives ALREADY parented (open-agent --group placed it into a frame with
         // relative coords) must pass through untouched — re-running parentInto would read its
         // relative position as absolute and land it off-frame.
-        const placed = node.parentId ? node : src.parentId ? parentInto(node, src.parentId) : node
-        setNodes((ns) => [...ns, placed])
+        const placed = node.parentId ? node : src.parentId ? parentInto(node, src.parentId, readNodes()) : node
+        applyNodes((ns) => [...ns, placed])
         connect(placed.id)
-        markDirty()
+        touchCanvas()
         return placed.id
       }
       // Grid slots INSIDE a group frame (open-agent --group): 2 columns of terminal-sized
@@ -9416,7 +9556,7 @@ export function Canvas() {
       // group frame. Returns its id, or null with the error already replied.
       const resolveIntoGroup = (): string | null | undefined => {
         if (!args.group) return undefined
-        const g = nodesRef.current.find((nd) => nd.id === args.group)
+        const g = readNodes().find((nd) => nd.id === args.group)
         if (!g || g.type !== 'group') {
           reply({ ok: false, error: `${verb}: --group must name an existing group frame` })
           return null
@@ -9436,7 +9576,7 @@ export function Canvas() {
         const ids = [...new Set((args.after ?? '').split(',').map((s) => s.trim()).filter(Boolean))]
         if (ids.length === 0) return undefined
         for (const depId of ids) {
-          const dep = nodesRef.current.find((nd) => nd.id === depId)
+          const dep = readNodes().find((nd) => nd.id === depId)
           if (!dep) {
             reply({ ok: false, error: `${verb}: --after names no existing node (${depId})` })
             return null
@@ -9484,7 +9624,7 @@ export function Canvas() {
         // (which waits for the shell prompt and echo-verifies). Arming would instead hand
         // delivery to the canvas effect, which would race the node's PTY into existence and
         // could fire into a session that does not exist yet.
-        const live = new Set([...nodesRef.current.map((nd) => nd.id), ...(extraLive ?? [])])
+        const live = new Set([...readNodes().map((nd) => nd.id), ...(extraLive ?? [])])
         const unmet = unmetDeps(
           { id: node.id, data: { pendingLaunch: { after, command } } },
           useAgentStatus.getState().byId,
@@ -9504,7 +9644,7 @@ export function Canvas() {
       // clamp children landing outside it), then drop each node into the next grid slot
       // after the existing children. Shared by the terminal and agent open verbs.
       const addGrouped = (groupId: string, count: number, make: (i: number) => CanvasNode): string[] => {
-        const existing = nodesRef.current.filter((nd) => nd.parentId === groupId).length
+        const existing = readNodes().filter((nd) => nd.parentId === groupId).length
         const ids: string[] = []
         for (let i = 0; i < count; i++) {
           const node = make(i)
@@ -9512,7 +9652,7 @@ export function Canvas() {
           const h = (node.height as number) ?? 400
           if (i === 0) {
             const need = groupSizeFor(existing + count, w, h)
-            setNodes((ns) =>
+            applyNodes((ns) =>
               ns.map((nd) =>
                 nd.id === groupId
                   ? {
@@ -9545,7 +9685,7 @@ export function Canvas() {
             // separately would be seven round trips to learn the one thing that changes what it
             // does next.
             const st = useAgentStatus.getState().byId
-            const list = nodesRef.current.map((n) => ({
+            const list = readNodes().map((n) => ({
               id: n.id,
               kind: n.type,
               title: n.data.title as string,
@@ -9569,7 +9709,7 @@ export function Canvas() {
             const intoGroupId = resolveIntoGroup()
             if (intoGroupId === null) return // bad --group, already replied
             const groupCwd = intoGroupId
-              ? worktreeControlRef.current.cwdForNewNodeIn(intoGroupId)
+              ? worktreeControlRef.current.cwdForNewNodeIn(intoGroupId, readNodes())
               : undefined
             const after = resolveAfter()
             if (after === null) return // bad --after, already replied
@@ -9605,7 +9745,7 @@ export function Canvas() {
             const make = (i: number): CanvasNode => {
               const node = armAfter(
                 createTerminalNode(
-                  nodesRef.current.length + i,
+                  readNodes().length + i,
                   termCwd,
                   placeBelow(i),
                   args.cmd,
@@ -9649,14 +9789,13 @@ export function Canvas() {
             const intoGroupId = resolveIntoGroup()
             if (intoGroupId === null) return // bad --group, already replied
             const groupCwd = intoGroupId
-              ? worktreeControlRef.current.cwdForNewNodeIn(intoGroupId)
+              ? worktreeControlRef.current.cwdForNewNodeIn(intoGroupId, readNodes())
               : undefined
             // Inherit the source node's managed account, else the project default, else system —
             // the same funnel as addAgentNode (the factory drops accounts on non-claude agents).
-            const projStore = useProjects.getState()
             const account = resolveNewNodeAccount(
               src.data.accountId as string | undefined,
-              projStore.getProject(projStore.activeProjectId ?? ''),
+              ctlProject,
               useSettings.getState().settings.claudeAccounts
             )
             const after = resolveAfter()
@@ -9736,16 +9875,18 @@ export function Canvas() {
               const node = armAfter(
                 createAgentNode(
                   agentId,
-                  nodesRef.current.length + i,
+                  readNodes().length + i,
                   agentCwd,
                   placeBelow(i),
                   args.prompt,
                   sshFor(agentCwd),
                   account,
-                  activePermissionMode(agentId),
-                  // Same project the account funnel above resolves from: the canvas the verb runs
-                  // on, whose `.nodeterm/settings.json` launch command applies to what it opens.
-                  projStore.activeProjectId,
+                  // The SOURCE's project, like the account funnel above — `activePermissionMode`
+                  // would answer for whatever is on screen, which off canvas is another project.
+                  projectPermissionMode(ctlProject, agentId),
+                  // Same project: the canvas the verb runs on, whose `.nodeterm/settings.json`
+                  // launch command applies to what it opens.
+                  ctlProject?.id,
                   // `--model` is a pass-through: `withAgentModel` re-validates the value at the
                   // interpolation site and emits nothing for an agent outside MODEL_SWITCH_CAPABLE,
                   // so an unsupported agent's command line stays byte-identical.
@@ -9768,10 +9909,10 @@ export function Canvas() {
             // resolve their endpoints from `agentId` rather than the not-yet-updated canvas.
             const openedEndpoint = (id: string): LinkEndpoint | null =>
               id === sourceNodeId
-                ? linkEndpointOf(id)
+                ? linkEndpointOf(id, readNodes())
                 : ids.includes(id)
                   ? { kind: 'terminal', contextCapable: canContextLink(agentId) }
-                  : linkEndpointOf(id)
+                  : linkEndpointOf(id, readNodes())
             const bridged = bridgeTo(sourceNodeId, ids, openedEndpoint).linked
             // A dependency is also a READING relationship: the whole reason to wait for a
             // station is to consume what it produced. So `--after` additionally bridges each new
@@ -9811,7 +9952,7 @@ export function Canvas() {
             // (`sshFs` routes fs.readBinary over the ControlMaster) — reading it locally would
             // either miss or, worse, open a same-named local file.
             const id = addAndConnect(
-              createEditorNode(nodesRef.current.length, args.path, placeBelow(), !!ctlSsh)
+              createEditorNode(readNodes().length, args.path, placeBelow(), !!ctlSsh)
             )
             reply({ ok: true, message: `showing image ${id}`, result: { id } })
             return
@@ -9827,7 +9968,7 @@ export function Canvas() {
             // same-named local file. Local projects allowlist the local path as before.
             if (!ctlSsh) await window.nodeTerminal.media.allow(args.path)
             const id = addAndConnect(
-              createVideoNode(nodesRef.current.length, args.path, placeBelow(), !!ctlSsh)
+              createVideoNode(readNodes().length, args.path, placeBelow(), !!ctlSsh)
             )
             reply({ ok: true, message: `showing video ${id}`, result: { id } })
             return
@@ -9854,7 +9995,7 @@ export function Canvas() {
             }
             // For an agent-provided --file (not html we just wrote), allowlist it first.
             if (webSrc.filePath && args.file) await window.nodeTerminal.media.allow(webSrc.filePath)
-            const id = addAndConnect(createWebNode(nodesRef.current.length, webSrc, placeBelow()))
+            const id = addAndConnect(createWebNode(readNodes().length, webSrc, placeBelow()))
             reply({ ok: true, message: `showing web ${id}`, result: { id } })
             return
           }
@@ -9878,7 +10019,7 @@ export function Canvas() {
               reply({ ok: false, error: "open-browser: this project's id cannot be used as a browser session key" })
               return
             }
-            const id = addAndConnect(createBrowserNode(nodesRef.current.length, browserUrl, placeBelow(), partition))
+            const id = addAndConnect(createBrowserNode(readNodes().length, browserUrl, placeBelow(), partition))
             // Return the project id + partition so main can record ownership in its in-memory
             // ledger (browser-control-ledger.ts). Main gates the claim on its OWN `verified` verdict
             // and keys it to the verified caller — these fields are descriptive (release-by-project,
@@ -9892,7 +10033,7 @@ export function Canvas() {
               return
             }
             const ids = (args.nodes ?? '').split(',').map((s) => s.trim()).filter(Boolean)
-            const live = nodesRef.current as CanvasNode[]
+            const live = readNodes() as CanvasNode[]
             const resolvable = ids.filter((id) => live.some((node) => node.id === id))
             if (resolvable.length === 0) {
               reply({ ok: false, error: 'group: none of the given node ids exist' })
@@ -9922,8 +10063,8 @@ export function Canvas() {
                   : nd
               )
             }
-            setNodes(grouped)
-            markDirty()
+            applyNodes(grouped)
+            touchCanvas()
             const skippedGrouped = ids.length - resolvable.length
             const groupNote = skippedGrouped > 0 ? ` (${skippedGrouped} unknown id(s) skipped)` : ''
             reply({
@@ -9935,15 +10076,15 @@ export function Canvas() {
           }
           case 'ungroup': {
             const gid = (args.group ?? '').trim()
-            const live = nodesRef.current as CanvasNode[]
+            const live = readNodes() as CanvasNode[]
             const frame = live.find((nd) => nd.id === gid && nd.type === 'group')
             if (!frame) {
               reply({ ok: false, error: `ungroup: --group names no group frame (${gid || 'missing'})` })
               return
             }
             const freed = live.filter((nd) => nd.parentId === gid).map((nd) => nd.id)
-            setNodes(ungroupNodes(live, gid))
-            markDirty()
+            applyNodes(ungroupNodes(live, gid))
+            touchCanvas()
             reply({ ok: true, message: `ungrouped ${gid}, freed ${freed.length} node(s)`, result: { freed } })
             return
           }
@@ -9953,7 +10094,7 @@ export function Canvas() {
             // deliberately won't do. `reparentNode` keeps each node's ROOT-space position fixed
             // and refuses a cycle (a frame into itself or its own descendant).
             const ids = (args.nodes ?? '').split(',').map((s) => s.trim()).filter(Boolean)
-            const live = nodesRef.current as CanvasNode[]
+            const live = readNodes() as CanvasNode[]
             const rawTarget = (args.group ?? '').trim().toLowerCase()
             const toTop = !rawTarget || rawTarget === 'top' || rawTarget === 'none' || rawTarget === 'ungrouped'
             const targetGroup = toTop ? null : args.group!.trim()
@@ -9985,8 +10126,8 @@ export function Canvas() {
             for (const g of affected) {
               if (next.some((n) => n.parentId === g)) next = fitGroupToChildren(next, g, snapGridNow())
             }
-            setNodes(next)
-            markDirty()
+            applyNodes(next)
+            touchCanvas()
             const where = targetGroup ? `into ${targetGroup}` : 'to the top level'
             reply({ ok: true, message: `moved ${moved.length} node(s) ${where}`, result: { moved, group: targetGroup } })
             return
@@ -9994,7 +10135,7 @@ export function Canvas() {
           case 'arrange':
           case 'align': {
             const ids = (args.nodes ?? '').split(',').map((s) => s.trim()).filter(Boolean)
-            const live = nodesRef.current as CanvasNode[]
+            const live = readNodes() as CanvasNode[]
             const edge = (['left', 'right', 'top', 'bottom', 'hcenter', 'vcenter'] as const).find((e2) => e2 === args.edge)
             if (verb === 'align' && !edge) {
               reply({ ok: false, error: 'align requires --edge left|right|top|bottom|hcenter|vcenter' })
@@ -10022,8 +10163,8 @@ export function Canvas() {
             // Tidying a frame's children usually leaves the frame oversized (it was sized to their
             // old scattered spots) — shrink it to hug the new layout. Top-level sets have no frame.
             if (container) next = fitGroupToChildren(next, container, snapGridNow())
-            setNodes(next)
-            markDirty()
+            applyNodes(next)
+            touchCanvas()
             const how = verb === 'arrange' ? `as ${layout}` : `to ${edge}`
             reply({ ok: true, message: `${verb === 'arrange' ? 'arranged' : 'aligned'} ${ids.length} node(s) ${how}`, result: { count: ids.length, container } })
             return
@@ -10037,7 +10178,7 @@ export function Canvas() {
               reply({ ok: false, error: 'link requires --to <id,id>' })
               return
             }
-            if (!linkEndpointOf(from)) {
+            if (!linkEndpointOf(from, readNodes())) {
               reply({ ok: false, error: `link: --from names no existing node (${from})` })
               return
             }
@@ -10066,7 +10207,7 @@ export function Canvas() {
             // is composed from the two primitives already built — `--after` and the context
             // bridge; `verify` is the shape, not new machinery.
             const targetId = (args.node ?? '').trim()
-            const target = nodesRef.current.find((nd) => nd.id === targetId)
+            const target = readNodes().find((nd) => nd.id === targetId)
             if (!target) {
               reply({ ok: false, error: `verify: --node names no existing node (${targetId})` })
               return
@@ -10092,7 +10233,7 @@ export function Canvas() {
             const { shimPath: vShim } = await window.nodeTerminal.contextLink.info()
             const targetTitle = (target.data.title as string) || targetId
             const targetCwd = target.data.cwd as string | undefined
-            const live = nodesRef.current as CanvasNode[]
+            const live = readNodes() as CanvasNode[]
             const vStore = useProjects.getState()
             // Reviewers inherit the TARGET's account, not the caller's: they read that node's
             // transcript, which is resolved inside its own account dir.
@@ -10170,7 +10311,7 @@ export function Canvas() {
                 ? { ...nd, data: { ...nd.data, title: args.label || `Verify: ${targetTitle}` } }
                 : nd
             )
-            setNodes(next)
+            applyNodes(next)
             panelIds.forEach((pid) => connect(pid))
             // `connect` only ropes the CALLER to each member — lineage. The panel's sequencing is
             // its own relation, so each held wait gets its own rope and the group reads as the DAG
@@ -10181,11 +10322,11 @@ export function Canvas() {
             const panelEndpoint = (id: string): LinkEndpoint | null =>
               panelIds.includes(id)
                 ? { kind: 'terminal', contextCapable: canContextLink(reviewAgent) }
-                : linkEndpointOf(id)
+                : linkEndpointOf(id, readNodes())
             for (const rid of reviewerIds) bridgeTo(rid, [targetId], panelEndpoint)
             bridgeTo(sourceNodeId, panelIds, panelEndpoint)
             if (judge) bridgeTo(judge.id, reviewerIds, panelEndpoint)
-            markDirty()
+            touchCanvas()
             reply({
               ok: true,
               message:
@@ -10252,7 +10393,7 @@ export function Canvas() {
               })
               return
             }
-            const live = nodesRef.current as CanvasNode[]
+            const live = readNodes() as CanvasNode[]
             // Same account funnel as open-claude/open-agent above; per-role the factory
             // drops the account for non-claude agents.
             const teamStore = useProjects.getState()
@@ -10301,21 +10442,21 @@ export function Canvas() {
             next = next.map((nd) =>
               nd.id === teamGroup.id ? { ...nd, data: { ...nd.data, title: args.label || 'Team' } } : nd
             )
-            setNodes(next)
+            applyNodes(next)
             memberIds.forEach((mid) => connect(mid))
             // …and CONTEXT-link each member back to the conductor, so the fan-out has a fan-in:
             // once a member is done, the conductor reads what it produced via get-linked-context
             // instead of asking the user to relay it. Members whose agent isn't context-capable
             // (a custom agent) just keep the display rope.
             const memberEndpoint = (id: string): LinkEndpoint | null => {
-              if (id === sourceNodeId) return linkEndpointOf(id)
+              if (id === sourceNodeId) return linkEndpointOf(id, readNodes())
               const m = members.find((x) => x.id === id)
               if (!m) return null
               const a = m.data.agentId as AgentId | undefined
               return { kind: m.type ?? 'terminal', contextCapable: !!a && canContextLink(a) }
             }
             const bridged = bridgeTo(sourceNodeId, memberIds, memberEndpoint).linked
-            markDirty()
+            touchCanvas()
             reply({
               ok: true,
               message:
@@ -10347,7 +10488,7 @@ export function Canvas() {
             }
             let bindGroupId: string | null = null
             if (args.group) {
-              const g = nodesRef.current.find((nd) => nd.id === args.group)
+              const g = readNodes().find((nd) => nd.id === args.group)
               if (!g || g.type !== 'group' || g.data.worktree) {
                 reply({ ok: false, error: 'open-worktree: --group must name an existing group without a worktree' })
                 return
@@ -10366,7 +10507,7 @@ export function Canvas() {
             const baseRes = resolveWorktreeBase(
               args.base,
               branch,
-              nodesRef.current.map((nd) => ({
+              readNodes().map((nd) => ({
                 id: nd.id,
                 parentId: nd.parentId,
                 worktree: nd.data.worktree as GroupWorktree | undefined
@@ -10441,7 +10582,7 @@ export function Canvas() {
             }
             // Fan successive frames out horizontally (frame width + gap) so several
             // open-worktree calls in one orchestration land side by side, not stacked.
-            const groupFan = nodesRef.current.filter(
+            const groupFan = readNodes().filter(
               (nd) => nd.type === 'group' && !nd.parentId
             ).length
             const frameAt = {
@@ -10467,7 +10608,7 @@ export function Canvas() {
           }
           case 'close-worktree': {
             const id = args.group ?? ''
-            const g = nodesRef.current.find((nd) => nd.id === id)
+            const g = readNodes().find((nd) => nd.id === id)
             if (!g || g.type !== 'group' || !g.data.worktree) {
               reply({ ok: false, error: `close-worktree: ${id} is not a worktree-bound group` })
               return
@@ -10503,7 +10644,7 @@ export function Canvas() {
           }
           case 'branch': {
             const id = args.node ?? ''
-            const target = nodesRef.current.find((nd) => nd.id === id)
+            const target = readNodes().find((nd) => nd.id === id)
             if (!target) {
               reply({ ok: false, error: `branch: no node with id ${id}` })
               return
@@ -10530,7 +10671,7 @@ export function Canvas() {
             // THIRD session, and read back by the phone, push alerts and the board log. Landing it
             // clean at the door is what keeps a control character out of all of them at once.
             const title = oneLine(args.title ?? '')
-            const target = nodesRef.current.find((nd) => nd.id === id)
+            const target = readNodes().find((nd) => nd.id === id)
             if (!target) {
               reply({ ok: false, error: `rename: no node with id ${id}` })
               return
@@ -10543,10 +10684,10 @@ export function Canvas() {
             const prevTitle = (target.data.title as string) ?? ''
             // Same semantics as renameSession: an explicit rename takes ownership of the
             // name (titleAuto off) and mirrors it into a rename-capable agent's session.
-            setNodes((ns) =>
+            applyNodes((ns) =>
               ns.map((nd) => (nd.id === id ? { ...nd, data: { ...nd.data, title, titleAuto: false } } : nd))
             )
-            markDirty()
+            touchCanvas()
             const agentId = target.data.agentId as AgentId | undefined
             if (agentId && canRename(agentId) && title) {
               // Gated twice: on the pane's owner (an agent that opens a node and renames it in the
@@ -10610,7 +10751,7 @@ export function Canvas() {
               return
             }
             const resolved = resolveStickyRef(
-              nodesRef.current.map((nd) => ({
+              readNodes().map((nd) => ({
                 id: nd.id,
                 sticky: nd.type === 'sticky',
                 title: (nd.data.title as string) ?? ''
@@ -10622,7 +10763,7 @@ export function Canvas() {
               return
             }
             if ('id' in resolved) {
-              const target = nodesRef.current.find((nd) => nd.id === resolved.id)
+              const target = readNodes().find((nd) => nd.id === resolved.id)
               if (!target) {
                 reply({ ok: false, error: `sticky: no node with id ${resolved.id}` })
                 return
@@ -10637,7 +10778,7 @@ export function Canvas() {
                 return
               }
               const stamp = { textUpdatedAt: Date.now(), textUpdatedBy: srcTitle }
-              setNodes((ns) =>
+              applyNodes((ns) =>
                 ns.map((nd) => {
                   if (nd.id !== resolved.id) return nd
                   const fresh = applyStickyWrite((nd.data.text as string) ?? '', parsed.write)
@@ -10647,7 +10788,7 @@ export function Canvas() {
                   return { ...nd, data: { ...nd.data, text: fresh.text, ...stamp } }
                 })
               )
-              markDirty()
+              touchCanvas()
               reply({
                 ok: true,
                 message: `note "${(target.data.title as string) || 'Note'}" (${resolved.id}): ${
@@ -10670,7 +10811,7 @@ export function Canvas() {
               reply({ ok: false, error: `sticky: ${next.error}` })
               return
             }
-            const node = createStickyNode(nodesRef.current.length, placeBelow())
+            const node = createStickyNode(readNodes().length, placeBelow())
             // `oneLine` at the door, exactly as `rename`: this title is composed into `list`
             // output, the board and the phone.
             node.data.title = oneLine(parsed.ref) || 'Note'
@@ -10785,7 +10926,7 @@ export function Canvas() {
             const store = useProjects.getState()
             const pid = store.activeProjectId
             const board = store.getProject(pid ?? '')?.kanban
-            const sessions = nodesRef.current
+            const sessions = readNodes()
               .map(toKanbanSession)
               .filter((s): s is KanbanSession => s !== null)
             const titleOf = new Map(sessions.map((s) => [s.id, s.title || 'Untitled']))
@@ -10831,7 +10972,7 @@ export function Canvas() {
             // board's own scope note called out as missing. Board metadata ONLY: assignNode writes
             // an assignment, it never touches the canvas node, its group, or the running session.
             const nodeId = (args.node ?? '').trim()
-            const target = nodesRef.current.find((n) => n.id === nodeId)
+            const target = readNodes().find((n) => n.id === nodeId)
             if (!target || toKanbanSession(target) === null) {
               reply({ ok: false, error: `assign: --node names no session card (${nodeId || 'missing'})` })
               return
@@ -10860,12 +11001,12 @@ export function Canvas() {
             const before = (args.before ?? '').trim() || null
             const next = assignNode(prev, nodeId, columnId, before)
             store.setProjectKanban(pid, next)
-            markDirty()
+            touchCanvas()
             // Board-log the move through the same diff funnel the UI uses (card-moved), so the
             // board feed reads identically whether a person or an agent moved the card. cardTitle
             // returns '' ONLY for a dead node; a live card with no title maps to 'Untitled'.
             const cardTitle = (id: string): string => {
-              const n = nodesRef.current.find((x) => x.id === id)
+              const n = readNodes().find((x) => x.id === id)
               const card = n ? toKanbanSession(n) : null
               return card ? card.title || 'Untitled' : ''
             }
@@ -12735,6 +12876,18 @@ export function Canvas() {
             <div className="announce-banner__content">
               <span className="announce-banner__body">{notice.text}</span>
             </div>
+            {notice.action && (
+              <button
+                className="announce-banner__btn"
+                onClick={() => {
+                  const run = notice.action?.run
+                  setNotice(null)
+                  run?.()
+                }}
+              >
+                {notice.action.label}
+              </button>
+            )}
             <button
               className="announce-banner__close"
               title="Dismiss"

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -12884,7 +12884,7 @@ export function Canvas() {
             </div>
             {notice.action && (
               <button
-                className="announce-banner__btn"
+                className="announce-banner__action"
                 onClick={() => {
                   const run = notice.action?.run
                   setNotice(null)

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -504,6 +504,17 @@ describe('the agent-control handler reads and writes through its own canvas shim
     expect(CANVAS_SRC).toContain('} else {\n            travelToProjectRef.current(route.projectId)')
   })
 
+  it('leaves the off-canvas notice up until it is dismissed', () => {
+    // An ordinary info strip reports something the user just did and is watching, so a few seconds
+    // is enough. This one reports work that landed in ANOTHER project while they were busy
+    // elsewhere: once it fades there is nothing left anywhere that says it happened, which is how
+    // it was missed in testing.
+    expect(CANVAS_SRC).toContain("if (notice?.kind !== 'info' || notice.sticky) return")
+    expect(CANVAS_SRC).toContain(
+      'text: offCanvasNoticeText(offCanvas.project.name, added),\n            sticky: true,'
+    )
+  })
+
   it('re-arms a node it creates off canvas for a cold open', () => {
     // `initialCommand` is never serialized, so a launch left there is silently dropped and the
     // session never starts — the rule the `--project` cold-open branch states.

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -504,6 +504,16 @@ describe('the agent-control handler reads and writes through its own canvas shim
     expect(CANVAS_SRC).toContain('} else {\n            travelToProjectRef.current(route.projectId)')
   })
 
+  it('sends the notice to the NODE, not just to its project', () => {
+    // The notice is about one thing that appeared. Landing on the project's saved camera would
+    // leave the user hunting for it; `travelToNode` reopens a closed project first and frames the
+    // node once its canvas loads, resolving off the serialized nodes the commit just wrote.
+    expect(CANVAS_SRC).toContain(
+      "action: { label: 'Go there', run: () => travelToNodeRef.current(target) }"
+    )
+    expect(CANVAS_SRC).toContain('if (!firstAdded) firstAdded = node.id')
+  })
+
   it('leaves the off-canvas notice up until it is dismissed', () => {
     // An ordinary info strip reports something the user just did and is watching, so a few seconds
     // is enough. This one reports work that landed in ANOTHER project while they were busy

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -12,7 +12,11 @@ import path from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { chromeObstacles, FIT_VIEW_GAP } from './fit-view'
 
-const CANVAS_SRC = fs.readFileSync(path.join(__dirname, 'Canvas.tsx'), 'utf8')
+// Normalized: the assertions below slice on '\n' literals, and a Windows checkout hands this
+// file back with CRLF whatever .gitattributes says about a tree cloned earlier (issue #578).
+const CANVAS_SRC = fs
+  .readFileSync(path.join(__dirname, 'Canvas.tsx'), 'utf8')
+  .replace(/\r\n/g, '\n')
 
 /** jsdom lays nothing out, so every rect is 0×0 and `chromeObstacles`'s size filter would drop the
  *  element. Give it the measurement a real bottom-left pill cluster has. */
@@ -454,5 +458,66 @@ describe('navigating from the sidebar dismisses the start screen', () => {
     expect(indexOfPresent(body, 'setWelcomeOpen(false)')).toBeLessThan(
       indexOfPresent(body, 'requestCard(')
     )
+  })
+})
+
+/**
+ * The agent-control handler must act on the canvas it was ADDRESSED at, not on the one the human
+ * happens to be looking at. Nothing else can see this: the handler is inside a `useEffect` with no
+ * render harness, the shims are pass-throughs on the on-screen path, and a new verb reaching for
+ * `nodesRef.current` or `setNodes` compiles, passes every other test, and quietly reads or writes
+ * the wrong project. See lib/offCanvasControl.
+ */
+describe('the agent-control handler reads and writes through its own canvas shims', () => {
+  /**
+   * The VERB BODY: from where the acting project is resolved (`ctlProject`) to the effect's own
+   * `}, [])`. Everything above that line deliberately reads the LIVE canvas — the source lookup,
+   * the `--project` branch's own active/serialized choice, and the post-travel wait all mean the
+   * canvas on screen. Below it, every verb acts on the canvas it was addressed at.
+   */
+  const HANDLER = (() => {
+    const anchor = CANVAS_SRC.indexOf('return api.onAgentControl(async (')
+    const start = CANVAS_SRC.indexOf('      const ctlProject =', anchor)
+    const end = CANVAS_SRC.indexOf('\n  }, [])', start)
+    expect(anchor).toBeGreaterThan(-1)
+    expect(start).toBeGreaterThan(anchor)
+    expect(end).toBeGreaterThan(start)
+    return CANVAS_SRC.slice(start, end)
+  })()
+
+  it('never reaches for the live canvas directly', () => {
+    // `readNodes()` is the live canvas while the project is on screen and the OWNING project's
+    // staged nodes otherwise. A bare `nodesRef.current` here answers about the wrong project.
+    expect(HANDLER).not.toContain('nodesRef.current')
+  })
+
+  it('never writes the live canvas directly', () => {
+    // Same, for writes — `applyNodes` stages off canvas and commits through the projects store.
+    expect(HANDLER).not.toContain('setNodes(')
+    expect(HANDLER).not.toContain('setLinkEdges(')
+  })
+
+  it('travels only when the verb cannot be answered off canvas', () => {
+    // The regression this pins: travelling unconditionally is what let a background agent's
+    // `show-web` yank the human out of the project they were typing in.
+    expect(CANVAS_SRC).toContain('answersOffCanvas(verb, args, ownerNodes)')
+    expect(CANVAS_SRC).toContain('} else {\n            travelToProjectRef.current(route.projectId)')
+  })
+
+  it('re-arms a node it creates off canvas for a cold open', () => {
+    // `initialCommand` is never serialized, so a launch left there is silently dropped and the
+    // session never starts — the rule the `--project` cold-open branch states.
+    expect(CANVAS_SRC).toContain('armForColdOpen(node) : node')
+  })
+
+  it('derives the acting project from the SOURCE node, not from what is on screen', () => {
+    // Reading the active project here was correct only because the travel had just made the two
+    // the same project. Off canvas it is another project's ssh, browser session key, managed
+    // account and permission mode. The verbs that still travel may keep asking for the active one.
+    expect(HANDLER).toContain('const ctlProject =\n        offCanvas?.project ??')
+    // Only the off-canvas-capable opens are pinned: `verify` and `spawn-team` still travel, so
+    // there the active project IS the acting one.
+    expect(HANDLER).toContain('projectPermissionMode(ctlProject, agentId)')
+    expect(HANDLER).toContain('agentBrowserPartition(ctlProject?.id')
   })
 })

--- a/src/renderer/lib/offCanvasControl.test.ts
+++ b/src/renderer/lib/offCanvasControl.test.ts
@@ -75,11 +75,13 @@ describe('groupChainHasWorktree', () => {
 
 describe('offCanvasNoticeText', () => {
   it('names the project and says it is not on screen, without travelling there', () => {
+    // Two sentences rather than a dash: this is UI copy, and the house rule for it is plain
+    // punctuation.
     expect(offCanvasNoticeText('api', 1)).toBe(
-      'A node opened by an agent in "api" — that project is not on screen.'
+      'A node opened by an agent in "api". That project is not on screen.'
     )
     expect(offCanvasNoticeText('api', 3)).toBe(
-      '3 nodes opened by an agent in "api" — that project is not on screen.'
+      '3 nodes opened by an agent in "api". That project is not on screen.'
     )
   })
 })

--- a/src/renderer/lib/offCanvasControl.test.ts
+++ b/src/renderer/lib/offCanvasControl.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  OFF_CANVAS_VERBS,
+  answersOffCanvas,
+  groupChainHasWorktree,
+  offCanvasNoticeText,
+  type OffCanvasNode
+} from './offCanvasControl'
+
+const nodes = (...ns: OffCanvasNode[]): OffCanvasNode[] => ns
+
+describe('answersOffCanvas', () => {
+  it('covers every verb whose whole effect is putting a node on the owning canvas', () => {
+    // The bug this closes: an agent in a project the human is NOT looking at renders its output as
+    // a node, and the app travelled there mid-keystroke. These verbs need a place to put a node,
+    // not a canvas on screen.
+    for (const verb of ['show-web', 'show-image', 'show-video', 'open-browser']) {
+      expect(answersOffCanvas(verb, {}, [])).toBe(true)
+    }
+    for (const verb of ['open-terminal', 'open-claude', 'open-agent']) {
+      expect(answersOffCanvas(verb, {}, [])).toBe(true)
+    }
+  })
+
+  it('refuses every verb that reads or drives something live', () => {
+    // `browser` needs a mounted <webview> guest, `write`/`close` a running pane, `focus`/`goto` a
+    // camera that belongs to the active project, and the layout verbs a human watching the result.
+    for (const verb of ['browser', 'write', 'close', 'focus', 'goto', 'group', 'move', 'arrange']) {
+      expect(answersOffCanvas(verb, {}, [])).toBe(false)
+    }
+  })
+
+  it('leaves the store-answered verbs alone — they never routed through a canvas at all', () => {
+    for (const verb of ['list', 'send', 'reply', 'sticky', 'open-project']) {
+      expect(OFF_CANVAS_VERBS.has(verb)).toBe(false)
+    }
+  })
+
+  it('refuses a --group bound to a git worktree, however deep the frame nests', () => {
+    // `cwdForNewNodeIn` subtracts the worktree store's staleGroupIds, which is scoped to the ACTIVE
+    // project. Off canvas that subtraction cannot be made, and failing open would hand the new node
+    // a checkout that was deleted outside the app. Travelling there knows the staleness; this does
+    // not, so it declines to answer.
+    const tree = nodes(
+      { id: 'outer', type: 'group', data: { worktree: { path: '/wt' } } },
+      { id: 'inner', type: 'group', parentId: 'outer', data: {} }
+    )
+    expect(answersOffCanvas('open-claude', { group: 'inner' }, tree)).toBe(false)
+    expect(answersOffCanvas('open-claude', { group: 'outer' }, tree)).toBe(false)
+  })
+
+  it('answers a --group that is an ordinary frame', () => {
+    const tree = nodes({ id: 'frame', type: 'group', data: { cwd: '/repo' } })
+    expect(answersOffCanvas('open-terminal', { group: 'frame' }, tree)).toBe(true)
+  })
+
+  it('treats a blank --group as no --group', () => {
+    expect(answersOffCanvas('open-terminal', { group: '  ' }, [])).toBe(true)
+  })
+})
+
+describe('groupChainHasWorktree', () => {
+  it('is false for an unknown frame — there is no binding to be wrong about', () => {
+    expect(groupChainHasWorktree([], 'ghost')).toBe(false)
+  })
+
+  it('survives a parent cycle instead of hanging', () => {
+    const tree = nodes(
+      { id: 'a', type: 'group', parentId: 'b', data: {} },
+      { id: 'b', type: 'group', parentId: 'a', data: {} }
+    )
+    expect(groupChainHasWorktree(tree, 'a')).toBe(false)
+  })
+})
+
+describe('offCanvasNoticeText', () => {
+  it('names the project and says it is not on screen, without travelling there', () => {
+    expect(offCanvasNoticeText('api', 1)).toBe(
+      'A node opened by an agent in "api" — that project is not on screen.'
+    )
+    expect(offCanvasNoticeText('api', 3)).toBe(
+      '3 nodes opened by an agent in "api" — that project is not on screen.'
+    )
+  })
+})

--- a/src/renderer/lib/offCanvasControl.test.ts
+++ b/src/renderer/lib/offCanvasControl.test.ts
@@ -78,10 +78,10 @@ describe('offCanvasNoticeText', () => {
     // Two sentences rather than a dash: this is UI copy, and the house rule for it is plain
     // punctuation.
     expect(offCanvasNoticeText('api', 1)).toBe(
-      'A node opened by an agent in "api". That project is not on screen.'
+      'An agent opened a node in "api". That project is not on screen.'
     )
     expect(offCanvasNoticeText('api', 3)).toBe(
-      '3 nodes opened by an agent in "api". That project is not on screen.'
+      'An agent opened 3 nodes in "api". That project is not on screen.'
     )
   })
 })

--- a/src/renderer/lib/offCanvasControl.ts
+++ b/src/renderer/lib/offCanvasControl.ts
@@ -85,9 +85,11 @@ export function answersOffCanvas(
   return !groupChainHasWorktree(nodes, args.group?.trim() || undefined)
 }
 
-/** The notice shown when a node was created in a project the human is not looking at. It says
- *  where the work went; travelling there stays the human's choice, which is the whole point. */
+/** The notice shown when a node was created in a project the human is not looking at. It says who
+ *  did what and where it went; travelling there stays the human's choice, which is the whole point.
+ *  Active voice and a full sentence: "A node opened by an agent in X." is a noun phrase, and the
+ *  passive repair ("was opened by") buries the actor the reader needs. */
 export function offCanvasNoticeText(projectName: string, count: number): string {
-  const what = count === 1 ? 'A node' : `${count} nodes`
-  return `${what} opened by an agent in "${projectName}". That project is not on screen.`
+  const what = count === 1 ? 'a node' : `${count} nodes`
+  return `An agent opened ${what} in "${projectName}". That project is not on screen.`
 }

--- a/src/renderer/lib/offCanvasControl.ts
+++ b/src/renderer/lib/offCanvasControl.ts
@@ -1,0 +1,93 @@
+// Which canvas-control verbs may be answered for a project that is NOT on screen.
+//
+// WHY IT EXISTS: routing is by SOURCE (`routeControlSource`), and React Flow holds only the ACTIVE
+// project's nodes — so a verb declared `needsLiveCanvas` used to TRAVEL to the calling agent's
+// project before it ran. For an agent that renders its output as a node (a report as `show-web`, a
+// screenshot as `show-image`, a fan-out as `open-claude`) that meant a background session yanked
+// the human's view out of the project they were typing in, at a moment they did not choose. That
+// is the same G5 objection `send`/`reply`/`sticky`/`open-project` are already exempt for; those
+// verbs simply never needed a canvas, while these ones needed a PLACE TO PUT A NODE — which the
+// owning project's serialized nodes can be, exactly as the `--project` cold-open branch already
+// writes into another project's store.
+//
+// WHAT THIS FILE DECIDES: only whether the off-canvas answer is available. Canvas.tsx does the
+// staging (it runs the verb against the owning project's serialized nodes and commits the result
+// through the projects store), and every verb outside this set keeps travelling as before.
+
+/** The little of a React Flow node this decision needs. */
+export interface OffCanvasNode {
+  id: string
+  type?: string
+  parentId?: string
+  data?: { worktree?: unknown; cwd?: unknown }
+}
+
+/**
+ * Verbs whose whole effect is "put a node on the owning project's canvas", and which therefore
+ * have a truthful answer without that canvas being on screen. The node is written into the
+ * project's serialized nodes and appears the moment that project is next shown.
+ *
+ * Deliberately NOT here: everything that reads or drives something LIVE — `browser` needs a
+ * mounted `<webview>` guest, `write`/`close` address a running pane, `focus`/`goto` move a camera
+ * that by definition belongs to the active project, and the layout verbs (`group`, `move`,
+ * `arrange`, `align`) are refinements a human is watching. Those still travel; a verb joining this
+ * set owes the staging path in Canvas.tsx the state it reads.
+ */
+export const OFF_CANVAS_VERBS: ReadonlySet<string> = new Set([
+  'show-image',
+  'show-video',
+  'show-web',
+  'open-browser',
+  'open-terminal',
+  'open-claude',
+  'open-agent'
+])
+
+/**
+ * Does the chain from `groupId` upward state a git worktree?
+ *
+ * `cwdForNewNodeIn` answers `--group`'s cwd from the nearest ancestor frame's `data.worktree`, and
+ * it subtracts the worktree store's `staleGroupIds` — which is scoped to the ACTIVE project. Off
+ * canvas that subtraction cannot be made, and the fail-open direction is the dangerous one: a
+ * worktree deleted outside the app would hand the new node a cwd that is not there. So a
+ * worktree-bound `--group` is not answered off canvas at all; it takes the old travelling path,
+ * where the staleness IS known.
+ */
+export function groupChainHasWorktree(
+  nodes: readonly OffCanvasNode[],
+  groupId: string | undefined
+): boolean {
+  const seen = new Set<string>()
+  let currentId = groupId
+  while (currentId && !seen.has(currentId)) {
+    seen.add(currentId)
+    const parent = nodes.find((n) => n.id === currentId)
+    if (!parent) {
+      return false
+    }
+    if (parent.data?.worktree) {
+      return true
+    }
+    currentId = parent.parentId
+  }
+  return false
+}
+
+/** May this call be answered against `nodes` (the owning project's serialized canvas)? */
+export function answersOffCanvas(
+  verb: string,
+  args: Record<string, string | undefined>,
+  nodes: readonly OffCanvasNode[]
+): boolean {
+  if (!OFF_CANVAS_VERBS.has(verb)) {
+    return false
+  }
+  return !groupChainHasWorktree(nodes, args.group?.trim() || undefined)
+}
+
+/** The notice shown when a node was created in a project the human is not looking at. It says
+ *  where the work went; travelling there stays the human's choice, which is the whole point. */
+export function offCanvasNoticeText(projectName: string, count: number): string {
+  const what = count === 1 ? 'A node' : `${count} nodes`
+  return `${what} opened by an agent in "${projectName}" — that project is not on screen.`
+}

--- a/src/renderer/lib/offCanvasControl.ts
+++ b/src/renderer/lib/offCanvasControl.ts
@@ -89,5 +89,5 @@ export function answersOffCanvas(
  *  where the work went; travelling there stays the human's choice, which is the whole point. */
 export function offCanvasNoticeText(projectName: string, count: number): string {
   const what = count === 1 ? 'A node' : `${count} nodes`
-  return `${what} opened by an agent in "${projectName}" — that project is not on screen.`
+  return `${what} opened by an agent in "${projectName}". That project is not on screen.`
 }

--- a/src/renderer/state/projects.mutation.test.ts
+++ b/src/renderer/state/projects.mutation.test.ts
@@ -75,3 +75,48 @@ describe('applyNodeMutation', () => {
     expect(useProjects.getState().projects).toHaveLength(0)
   })
 })
+
+/** The edge half of the same problem: a control call answered for a project that is NOT on screen
+ *  (lib/offCanvasControl) draws a rope to the node it opened and a context bridge back to the
+ *  opener. `commitCanvas` replaces both arrays wholesale from the live canvas, so it cannot serve
+ *  a project React Flow does not hold. */
+describe('appendProjectEdges', () => {
+  it('appends ropes and bridges to a background project', () => {
+    const p = useProjects.getState().addProject('p')
+    useProjects.getState().appendProjectEdges(p.id, {
+      ropes: [{ id: 'ctrl-a-b', source: 'a', target: 'b' }],
+      bridges: [{ id: 'bridge-a-b', source: 'a', target: 'b' }]
+    })
+
+    expect(useProjects.getState().getProject(p.id)?.ropes).toEqual([
+      { id: 'ctrl-a-b', source: 'a', target: 'b' }
+    ])
+    expect(useProjects.getState().getProject(p.id)?.bridges).toEqual([
+      { id: 'bridge-a-b', source: 'a', target: 'b' }
+    ])
+  })
+
+  it('keeps the edges already there and skips ids it has, so a retried call is idempotent', () => {
+    const p = useProjects.getState().addProject('p')
+    useProjects.getState().appendProjectEdges(p.id, {
+      ropes: [{ id: 'ctrl-a-b', source: 'a', target: 'b' }]
+    })
+    useProjects.getState().appendProjectEdges(p.id, {
+      ropes: [
+        { id: 'ctrl-a-b', source: 'a', target: 'b' },
+        { id: 'ctrl-a-c', source: 'a', target: 'c' }
+      ]
+    })
+
+    expect(useProjects.getState().getProject(p.id)?.ropes?.map((e) => e.id)).toEqual([
+      'ctrl-a-b',
+      'ctrl-a-c'
+    ])
+  })
+
+  it('writes nothing for an empty append', () => {
+    const p = useProjects.getState().addProject('p')
+    useProjects.getState().appendProjectEdges(p.id, {})
+    expect(useProjects.getState().getProject(p.id)?.ropes).toBeUndefined()
+  })
+})

--- a/src/renderer/state/projects.ts
+++ b/src/renderer/state/projects.ts
@@ -116,6 +116,16 @@ interface ProjectsState {
    * they deleted on the very next save — the data-loss shape canvas sync exists to fix.
    */
   applyNodeMutation(projectId: string, mutation: CanvasMutation): boolean
+  /**
+   * Appends control ropes / context bridges to a project that is NOT active — the edge half of
+   * the off-canvas control path (lib/offCanvasControl). `commitCanvas` replaces both arrays
+   * wholesale and is driven by the live canvas, so it cannot serve a project React Flow does not
+   * hold. Ids already present are skipped, which makes a retried control call idempotent.
+   */
+  appendProjectEdges(
+    projectId: string,
+    edges: { ropes?: BridgeLink[]; bridges?: BridgeLink[] }
+  ): void
   /** Renames a node within a project (source of truth for inactive projects). */
   renameNode(projectId: string, nodeId: string, title: string): void
   /** Recolors a node within a project. */
@@ -453,6 +463,25 @@ export const useProjects = create<ProjectsState>((set, get) => ({
       projects: s.projects.map((p) =>
         p.id === id
           ? { ...p, nodes, viewport, ...(bridges ? { bridges } : {}), ...(ropes ? { ropes } : {}) }
+          : p
+      )
+    }))
+  },
+
+  appendProjectEdges(projectId, edges) {
+    const { ropes = [], bridges = [] } = edges
+    if (ropes.length === 0 && bridges.length === 0) {
+      return
+    }
+    const merge = (existing: BridgeLink[] | undefined, added: BridgeLink[]): BridgeLink[] => {
+      const have = new Set((existing ?? []).map((e) => e.id))
+      const fresh = added.filter((e) => !have.has(e.id))
+      return fresh.length === 0 ? (existing ?? []) : [...(existing ?? []), ...fresh]
+    }
+    set((s) => ({
+      projects: s.projects.map((p) =>
+        p.id === projectId
+          ? { ...p, ropes: merge(p.ropes, ropes), bridges: merge(p.bridges, bridges) }
           : p
       )
     }))

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5221,7 +5221,11 @@ body,
   gap: 8px;
 }
 
-.confirm__btn {
+/* The app's default button. `.announce-banner__action` shares the recipe rather than restating it:
+   a banner offering an ordinary next step ("Go there") is not asking for the accent treatment
+   `.announce-banner__btn` gives an install or a reload, and two copies of a default button drift. */
+.confirm__btn,
+.announce-banner__action {
   background: var(--panel-header);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -5231,8 +5235,13 @@ body,
   cursor: pointer;
 }
 
-.confirm__btn:hover {
+.confirm__btn:hover,
+.announce-banner__action:hover {
   background: rgba(var(--tint-rgb), 0.1);
+}
+
+.announce-banner__action {
+  flex: none;
 }
 
 .confirm__btn.danger {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3683,7 +3683,7 @@ body,
   border-left: 3px solid var(--accent);
   border-radius: 10px;
   box-shadow: 0 8px 28px rgba(0, 0, 0, calc(0.45 * var(--shadow-k)));
-  font-size: 12.5px;
+  font-size: 13px;
   color: var(--text);
 }
 


### PR DESCRIPTION
## What's wrong

I work in several projects at once. My skills render their output as HTML in a webview, so a report, a PR review or a slide deck arrives as a node on the canvas. Every time one of those opened, nodeterm threw me into that project. I would be typing in a terminal in project 1, an agent in project 4 would finish, and suddenly I was in project 4.

## Why

Canvas control routes by source node, and React Flow only holds the active project's nodes. So when an agent in a background project calls a verb, its node is not on the live canvas: `routeControlSource` resolves the owning project and, for anything `needsLiveCanvas` says yes to, travels there first.

That travel exists to give the verb a canvas to act on. Only five verbs were exempt (`list`, `send`, `reply`, `sticky`, `open-project`), each for exactly this reason. The rule was never extended to the verbs that create a node, and those are the ones an agent reaches for when it has something to show you.

## What changed

A verb whose whole effect is putting a node on the owning project's canvas does not need that canvas on screen. It needs a place to put a node, and the project's serialized nodes are one. That is already how the `--project` cold-open branch writes into another project's store.

`OFF_CANVAS_VERBS` (`show-image`, `show-video`, `show-web`, `open-browser`, `open-terminal`, `open-claude`, `open-agent`) now run against a staged copy of the owning project's nodes and commit through `applyNodeMutation` plus a new `appendProjectEdges` for the ropes and context bridges. `commitCanvas` replaces both arrays wholesale from the live canvas, so it cannot serve a project React Flow does not hold.

You get a notice instead of a trip: `An agent opened a node in "api". That project is not on screen.` It stays up until you dismiss it, and its button takes you to the node.

## Rules worth reviewing

**The handler's verb body reads and writes through shims** (`readNodes` / `applyNodes` / `addRopeEdges` / `addBridgeEdges` / `readLinkEdges` / `touchCanvas`), which are pass-throughs on the on-screen path. A verb reaching for `nodesRef.current` or `setNodes` compiles, passes every other test, and quietly answers about the wrong project. `canvas-wiring.test.tsx` pins their absence at source level because nothing else can see it. That pin earned its keep during the rebase: the `color` verb landed upstream meanwhile, written the old way, and is now routed through the shims too.

**The acting project is the source's, not the active one.** `ctlProject` read `activeProjectId`, which was only correct because the travel had just made the two the same project. Off canvas it decides another project's ssh flag, browser session key, managed account, permission mode and launch override.

**A node created off canvas is re-armed with `armForColdOpen`.** `initialCommand` is never serialized, so a launch left there is silently dropped and the session never starts. The reply corrects `queued` and `queuedIds` to the whole batch and carries `offCanvas: true` beside the sentence, because an orchestrator must not report a session as started when its `--after` deps merely happened to be satisfied. A refusal commits nothing.

**A worktree-bound `--group` still travels.** `cwdForNewNodeIn` subtracts the worktree store's `staleGroupIds`, which is scoped to the active project. Off canvas that subtraction cannot be made, and failing open would hand the new node a checkout that was deleted outside the app.

Everything that reads or drives something live still travels: `browser` needs a mounted webview guest, `write` and `close` need a running pane, `focus` and `goto` move a camera that belongs to the active project by definition, and the layout verbs are refinements a human is watching.

## Smaller things in here

`.announce-banner` was `12.5px`. Half pixels are not a size this app uses, so it is `13px` now, which touches all five banners. The notice's button uses the app's default button rather than the accent treatment `.announce-banner__btn` gives an install or a reload; `.announce-banner__action` joins `.confirm__btn`'s selector instead of restating the recipe, so the two cannot drift.

## Tests

- `renderer/lib/offCanvasControl.test.ts` covers which verbs qualify, the worktree refusal including a nested frame and a parent cycle, and the notice copy.
- `renderer/state/projects.mutation.test.ts` covers `appendProjectEdges`, including that a retried call is idempotent.
- `renderer/canvas/canvas-wiring.test.tsx` pins the shims, the acting project, the cold-open re-arm, the sticky notice and the travel target.

## Surfaces

Desktop and Server Edition are identical. This is renderer code plus the projects store, with no new IPC or bridge member. Mobile is not applicable: it attaches to tmux sessions over the transport protocol and has no canvas.

## How to try it

Open two projects, A and B, with a terminal node in B. From B's terminal:

```sh
(sleep 15; sh "<userData>/canvas-control/nodeterm.sh" show-web --url https://example.com) &
```

Switch to A and keep working. You stay in A, the notice names B, and the node is waiting there when you go.
