### PR TITLE
test(license): pin the machine noun so the copy suites pass on a Mac too

### DIFF
--- a/src/renderer/components/settings/sections/LicenseSection.test.tsx
+++ b/src/renderer/components/settings/sections/LicenseSection.test.tsx
@@ -5,6 +5,7 @@
 // which sentence lands beside which data, what a destructive button does before it does it, and
 // whether a failed ACTION is reported as a failed READ.
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { pinNeutralMachineNoun } from '@renderer/lib/testMachineNoun'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { LicenseDetail, LicenseStatus } from '@shared/types'
@@ -94,6 +95,10 @@ afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
+
+
+// See testMachineNoun.ts: the rendered copy names the machine, so the host OS is pinned.
+pinNeutralMachineNoun()
 
 describe('LicenseSection — a release that did not land', () => {
   it('reports the RELEASE, and keeps saying the truth about the license', async () => {

--- a/src/renderer/lib/accountPresentation.test.ts
+++ b/src/renderer/lib/accountPresentation.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import { pinNeutralMachineNoun } from './testMachineNoun'
 import { presentAccount } from './accountPresentation'
+
+
+// The copy under test names the machine, and `machineNoun()` sniffs the host — pin it so the
+// literals below hold on a Mac too (see testMachineNoun.ts).
+pinNeutralMachineNoun()
 
 describe('presentAccount', () => {
   it('uses a chosen name before the email and identifies a local login', () => {

--- a/src/renderer/lib/licenseCopy.test.ts
+++ b/src/renderer/lib/licenseCopy.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { pinNeutralMachineNoun } from './testMachineNoun'
 import type { LicenseDetail } from '@shared/types'
 import {
   licenseSentence,
@@ -22,6 +23,11 @@ const keygen = (over: Partial<LicenseDetail> = {}): LicenseDetail => ({
   error: null,
   ...over
 })
+
+
+// The copy under test names the machine, and `machineNoun()` sniffs the host — pin it so the
+// literals below hold on a Mac too (see testMachineNoun.ts).
+pinNeutralMachineNoun()
 
 describe('licenseSentence — a keygen license that read cleanly', () => {
   it('reports usage against the cap and names phones as devices', () => {

--- a/src/renderer/lib/testMachineNoun.ts
+++ b/src/renderer/lib/testMachineNoun.ts
@@ -1,0 +1,27 @@
+/**
+ * TEST-ONLY — pin the machine noun so copy assertions do not depend on the DEVELOPER'S OS.
+ *
+ * `machineNoun()` sniffs `navigator`, so a string built through it reads "this computer" on the
+ * Linux CI box and "this Mac" on a Mac. Three suites asserted the Linux answer as a literal and
+ * were therefore red on every macOS checkout — reported by a contributor whose branch touched
+ * none of those files (PR #592), which is the expensive way to find out: a test that fails only
+ * on the maintainer's own platform teaches contributors to ignore red.
+ *
+ * Pinning the platform is the fix rather than softening the assertions: the exact sentence is the
+ * thing under test (issue #563 is about billing copy naming the wrong machine), so it must stay a
+ * literal — what must not stay is the assumption about which machine is running the suite.
+ */
+import { afterAll, beforeAll } from 'vitest'
+
+/** Force `machineNoun()` to answer 'computer' for the whole file (jsdom `navigator.platform`). */
+export function pinNeutralMachineNoun(): void {
+  let original: PropertyDescriptor | undefined
+  beforeAll(() => {
+    original = Object.getOwnPropertyDescriptor(navigator, 'platform')
+    Object.defineProperty(navigator, 'platform', { value: 'Linux x86_64', configurable: true })
+  })
+  afterAll(() => {
+    if (original) Object.defineProperty(navigator, 'platform', original)
+    else delete (navigator as unknown as Record<string, unknown>).platform
+  })
+}


### PR DESCRIPTION
`machineNoun()` (from #563/#646) sniffs `navigator`, so any sentence built through it reads **"this computer"** on the Linux CI box and **"this Mac"** on a macOS checkout. Three suites assert the Linux answer as a literal:

- `renderer/lib/licenseCopy.test.ts`
- `renderer/lib/accountPresentation.test.ts`
- `renderer/components/settings/sections/LicenseSection.test.tsx`

They are therefore **red on every Mac checkout**, green on CI. Reported by @xaviguardia on #592, whose branch touches none of those files — which is the expensive way to find out. A suite that fails only on the maintainer's own platform teaches contributors to ignore red.

## The fix

`renderer/lib/testMachineNoun.ts` (test-only) pins `navigator.platform` for the file and restores it afterwards; the three suites call it. The assertions keep their exact literals on purpose — the precise sentence is the thing under test (#563 is about billing copy naming the wrong machine); what goes is the assumption about which machine runs the suite.

Verified: the three suites pass here (58 tests), and a throwaway probe confirmed the pin is load-bearing — with `navigator.platform = 'MacIntel'`, `machineNoun()` answers `Mac` unpinned and `computer` pinned.

Device checklist: run `npx vitest run src/renderer/lib/licenseCopy.test.ts src/renderer/lib/accountPresentation.test.ts src/renderer/components/settings/sections/LicenseSection.test.tsx` on a Mac — red before this change, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL