### PR TITLE
feat(session-memory): pause a session from the memory panel, beside the kill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2410,6 +2410,27 @@ about which machine they describe. Reading + parsing is `core/session-memory.ts`
   observed is killed on the host it observed it on (node ids are only per-launch unique, and nothing
   here rests on more). Ownership is re-resolved at click time, not taken from the row's stale
   `orphan` flag, so a node created since the sweep is not killed as an orphan.
+- **The panel's second action is PAUSE, and it is the one that should usually be clicked.** The `×`
+  was the only thing a row offered, which is the wrong tool for what the panel is mostly opened
+  for. Measured on the reporting host (2026-09-04, 149 `nt-` sessions, 46 GB of tree RSS): the
+  median session with a live `claude` holds **321 MB**, the median session whose CLI has already
+  gone holds **5.6 MB** — so exiting the CLI returns **98.3%** of it, and killing the tmux session
+  on top buys the remaining 1.7% at the price of the pane, its scrollback and the warm reattach.
+  Population-wide the same split is 95% `claude`+`node` against 1.8% shell. **This is the number to
+  quote when someone proposes making a memory lever destroy sessions**, and it is why issue #616's
+  "end the tmux session too" was not built. The control is NOT a third depth: it calls
+  `pauseAgentNode(id, false)` — the same "Pause session" the node menu offers, the same
+  `performExitPhase`, the same PAUSED chip and the same Resume — because a panel-only "hibernate"
+  would be a third concept for the user and a second exit path to keep in step with Eco's. Which
+  rows may offer it is the pure `renderer/lib/sessionPause.ts`, and its two directions are
+  deliberate: a row that could NEVER be paused (an orphan, a plain terminal, an agent we cannot
+  quit-and-resume) renders **nothing** — a dead control on most rows of a machine-wide list is
+  noise about something that was never possible — while a row that is merely refused right now
+  (busy, no session id, or its terminal is not mounted on this canvas, which is the common case in
+  a panel that spans every project) renders **disabled with the reason**. Canvas answers, because
+  it is the only place that can see the node's agent, its registered pause closure and its
+  `restartEligibility` at once; it asks on the same narrow `st?.sessionId` the node menu uses, so a
+  row cannot promise what the closure would refuse.
 - **The name and the host were never the hard part — the SOCKET was.** Two nodeterm tmux sockets
   live on one machine at once (`node-terminal` for a nodeterm running ON it, `nodeterm-rmt` for one
   SSH-ing INTO it) and the sweep lists **both**, while the kill targeted one — so every row off the

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -294,6 +294,7 @@ import {
   type BreadcrumbTarget
 } from '../lib/breadcrumbs'
 import { planSessionKill } from '../lib/sessionKill'
+import { sessionPauseOffer, type SessionPauseOffer } from '../lib/sessionPause'
 import { RemoteAccessDialog } from '../components/RemoteAccessDialog'
 import { SshProjectDialog } from '../components/SshProjectDialog'
 import { SshPassphrasePrompt } from '../components/SshPassphrasePrompt'
@@ -11271,6 +11272,50 @@ export function Canvas() {
     [closeSession, setConfirm]
   )
 
+  /**
+   * What the session-memory panel should render in a row's pause slot. Canvas answers because it
+   * is the only place that can see all four facts at once — the node's created-with agent, whether
+   * a live `pause` closure is registered for it (i.e. its terminal is mounted HERE), its persisted
+   * pause flags, and its restart eligibility. The rule itself is the pure `sessionPauseOffer`.
+   *
+   * Read from `nodesRef`/the store at CALL time rather than closed over: the panel calls this per
+   * row on every render, and a stale snapshot would light a control for a node that has since gone.
+   */
+  const sessionPauseOfferFor = useCallback(
+    (nodeId: string): SessionPauseOffer => {
+      const node = nodesRef.current.find((n) => n.id === nodeId)
+      const st = useAgentStatus.getState().byId[nodeId]
+      // `restartAgentIdOf`, not a bare `createdAgentId`: it is the ONE shared derivation the
+      // node's own restart/pause closures capture, and it already answers `undefined` for anything
+      // that is not a terminal — which `restartEligibility` reads as `not-resumable`.
+      const agentId = restartAgentIdOf(node)
+      return sessionPauseOffer({
+        // The panel's own `orphan` means "no node in ANY project"; this narrower "not on the active
+        // canvas" is what actually decides, because that is exactly when no pause closure can
+        // exist. Both end at the same refusal via `wired`, so this only has to say whether there is
+        // a node object to read an agent off.
+        orphan: !node,
+        agentId,
+        wired: !!agentPauseFns(nodeId),
+        paused: st?.paused,
+        hibernated: st?.hibernated,
+        // The same narrow fact the node menu's Pause row uses: `st?.sessionId` alone, never the
+        // minted `data.agentSessionId` fallback, because the pause closure gates on the live id and
+        // a row lit by the fallback would enable here and refuse there.
+        eligibility: restartEligibility(agentId, st?.state, st?.sessionId)
+      })
+    },
+    []
+  )
+
+  /** The panel's pause click — the SAME action as the node menu's "Pause session", so a session
+   *  paused from either surface is in one state with one Resume. `pauseAgentNode` raises its own
+   *  notices and re-asks eligibility inside the closure, so nothing is duplicated here. */
+  const pauseSessionById = useCallback(
+    (nodeId: string) => pauseAgentNode(nodeId, false),
+    [pauseAgentNode]
+  )
+
   const renameSession = useCallback(
     (projectId: string, id: string, title: string) => {
       // Both facts about the node are read BEFORE the rename lands: `renameNode` mutates the
@@ -13358,6 +13403,8 @@ export function Canvas() {
             overBoard={kanbanOpen}
             onGoToNode={travelToNode}
             onKillSession={killSessionById}
+            pauseOfferFor={sessionPauseOfferFor}
+            onPauseSession={pauseSessionById}
           />
         
           {/* Same write path as the TabBar caret menu (project.defaultAccountId + persist) — the

--- a/src/renderer/components/SessionMemoryPanel.test.tsx
+++ b/src/renderer/components/SessionMemoryPanel.test.tsx
@@ -7,6 +7,7 @@ import { useAgentStatus } from '../state/agentStatus'
 import { useProjects } from '../state/projects'
 import { useSessionMemory } from '../state/sessionMemory'
 import { SessionMemoryPanel } from './SessionMemoryPanel'
+import type { SessionPauseOffer } from '../lib/sessionPause'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -64,6 +65,11 @@ let onClose: Mock<() => void>
 let refreshFull: Mock<(scopeKey: string, projectId?: string) => Promise<void>>
 let startHostPoll: Mock<(scopeKey: string, projectId?: string) => void>
 let stopHostPoll: Mock<() => void>
+let onPauseSession: Mock<(nodeId: string) => Promise<void>>
+/** What `pauseOfferFor` answers for a row. Canvas owns the real decision (`sessionPauseOffer`);
+ *  the panel only draws it, so the harness supplies it directly. Default = the pre-feature panel:
+ *  no row offers a pause, so every existing assertion sees exactly the old DOM. */
+let pauseOffer: (nodeId: string) => SessionPauseOffer = () => ({ show: false })
 
 function mount(over: Partial<ReturnType<typeof useSessionMemory.getState>> = {}): void {
   useSessionMemory.setState({
@@ -80,7 +86,13 @@ function mount(over: Partial<ReturnType<typeof useSessionMemory.getState>> = {})
   root = createRoot(host)
   act(() =>
     root.render(
-      <SessionMemoryPanel onGoToNode={onGoToNode} onKillSession={onKillSession} onClose={onClose} />
+      <SessionMemoryPanel
+        onGoToNode={onGoToNode}
+        onKillSession={onKillSession}
+        pauseOfferFor={(id) => pauseOffer(id)}
+        onPauseSession={onPauseSession}
+        onClose={onClose}
+      />
     )
   )
 }
@@ -90,6 +102,8 @@ const mainOf = (i: number): HTMLButtonElement =>
   rowsOf()[i].querySelector<HTMLButtonElement>('.sessmem-row__main')!
 const killOf = (i: number): HTMLButtonElement =>
   rowsOf()[i].querySelector<HTMLButtonElement>('.sessmem-row__kill')!
+const pauseOf = (i: number): HTMLButtonElement | null =>
+  rowsOf()[i].querySelector<HTMLButtonElement>('.sessmem-row__pause')
 const text = (): string => host.textContent ?? ''
 
 beforeEach(() => {
@@ -99,6 +113,8 @@ beforeEach(() => {
   refreshFull = vi.fn<(scopeKey: string, projectId?: string) => Promise<void>>(async () => {})
   startHostPoll = vi.fn<(scopeKey: string, projectId?: string) => void>()
   stopHostPoll = vi.fn<() => void>()
+  onPauseSession = vi.fn<(nodeId: string) => Promise<void>>(async () => {})
+  pauseOffer = () => ({ show: false })
   useProjects.setState({ projects: PROJECTS, activeProjectId: 'p1' })
   useAgentStatus.setState({ byId: { t1: { state: 'working', unread: false } } })
 })
@@ -352,5 +368,56 @@ describe('SessionMemoryPanel', () => {
     expect(startHostPoll).not.toHaveBeenCalled()
     expect(stopHostPoll).not.toHaveBeenCalled()
     root = createRoot(document.createElement('div'))
+  })
+
+  describe('pause control', () => {
+    it('renders nothing in the slot for a row that cannot be paused', () => {
+      // The default offer in this harness is `{show:false}` for every row, which is also the
+      // pre-feature DOM — so every other test in this file asserts the unchanged panel.
+      mount()
+      expect(pauseOf(0)).toBeNull()
+      expect(pauseOf(1)).toBeNull()
+    })
+
+    it('pauses the row it was clicked on, then re-sweeps so the freed memory shows', () => {
+      pauseOffer = () => ({ show: true, disabled: false, hint: 'Pause session' })
+      mount()
+      refreshFull.mockClear()
+      const btn = pauseOf(0)!
+      act(() => btn.click())
+      expect(onPauseSession).toHaveBeenCalledWith(ROWS[0].nodeId)
+      // The sweep is what turns the action into a visible number; without it the row keeps
+      // reporting the memory of a process that has just exited.
+      return Promise.resolve().then(() => {
+        expect(refreshFull).toHaveBeenCalled()
+      })
+    })
+
+    it('does not fire for a disabled offer, even if the click gets through', () => {
+      // `disabled` is the DOM's answer; the handler carries the code's, so a synthetic click (or a
+      // browser that dispatches one anyway) cannot type `/exit` into a busy session.
+      pauseOffer = () => ({ show: true, disabled: true, hint: 'This session is busy' })
+      mount()
+      const btn = pauseOf(0)!
+      expect(btn.disabled).toBe(true)
+      act(() => btn.click())
+      expect(onPauseSession).not.toHaveBeenCalled()
+    })
+
+    it('carries the offer hint as the tooltip, so a refusal explains itself', () => {
+      pauseOffer = () => ({ show: true, disabled: true, hint: 'Open this session on its canvas' })
+      mount()
+      expect(pauseOf(0)!.title).toBe('Open this session on its canvas')
+    })
+
+    it('asks per row, so one row may offer a pause while another does not', () => {
+      pauseOffer = (id) =>
+        id === ROWS[0].nodeId
+          ? { show: true, disabled: false, hint: 'Pause session' }
+          : { show: false }
+      mount()
+      expect(pauseOf(0)).not.toBeNull()
+      expect(pauseOf(1)).toBeNull()
+    })
   })
 })

--- a/src/renderer/components/SessionMemoryPanel.tsx
+++ b/src/renderer/components/SessionMemoryPanel.tsx
@@ -9,7 +9,7 @@
 //      never enters the agent-status map at all.
 //   3. Every row is rendered. A cap would have to announce itself.
 
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { AgentState } from '@shared/agents/normalize'
 import { formatBytes } from '@shared/fsLimits'
 import { useAgentStatus } from '../state/agentStatus'
@@ -17,6 +17,7 @@ import { useProjects } from '../state/projects'
 import { useSessionMemory } from '../state/sessionMemory'
 import { resolveSessionRows, totalMb } from '../lib/sessionMemoryRows'
 import { usageScopeKey } from '../lib/usageScope'
+import type { SessionPauseOffer } from '../lib/sessionPause'
 
 export interface SessionMemoryPanelProps {
   /** Travel to the node behind a row. Canvas passes `travelToNode`, so a CLOSED project's tab is
@@ -25,6 +26,19 @@ export interface SessionMemoryPanelProps {
   /** Confirm + end the session. `orphan` says whether the panel believes there is a node behind it;
    *  Canvas re-resolves the owner at click time and only uses this for the wording. */
   onKillSession: (nodeId: string, orphan: boolean) => void
+  /**
+   * What this row's pause slot should render, decided by Canvas (which is the only place that can
+   * see the node's agent, its live pause closure and its restart eligibility). The pure rule is
+   * `lib/sessionPause.ts`; the panel only draws the answer.
+   */
+  pauseOfferFor: (nodeId: string) => SessionPauseOffer
+  /**
+   * Pause the session behind a row — the NON-destructive reclaim, beside the destructive `×`.
+   * Canvas routes it to the same `pauseAgentNode(id, false)` the node menu uses, raises its own
+   * notices, and re-resolves eligibility at click time; the panel awaits it only so it can
+   * re-sweep and show the memory that came back.
+   */
+  onPauseSession: (nodeId: string) => Promise<void>
   onClose: () => void
 }
 
@@ -53,8 +67,13 @@ function StatusDot({ state, hollow }: { state: AgentState | null; hollow: boolea
 export function SessionMemoryPanel({
   onGoToNode,
   onKillSession,
+  pauseOfferFor,
+  onPauseSession,
   onClose
 }: SessionMemoryPanelProps): JSX.Element {
+  /** Which row's pause is in flight, if any — an exit can take seconds (it polls the pane until a
+   *  shell owns it), and a control that looks idle through all of it invites a second click. */
+  const [pausing, setPausing] = useState<string | null>(null)
   const ok = useSessionMemory((s) => s.ok)
   const rows = useSessionMemory((s) => s.rows)
   const loading = useSessionMemory((s) => s.loading)
@@ -154,6 +173,35 @@ export function SessionMemoryPanel({
               <span className="sessmem-row__cmd">{v.row.command}</span>
               <span className="sessmem-row__mb">{formatMb(v.row.totalMb)}</span>
             </button>
+            {/* The NON-destructive reclaim, deliberately to the LEFT of the `×`: on the host this
+                was measured against, exiting the CLI returns 98.3% of a session's memory while the
+                `×` destroys the pane and its scrollback for the remaining 1.7%. A row that could
+                never be paused (an orphan, a plain terminal) renders nothing here rather than a
+                permanently dead control — see `sessionPauseOffer`. */}
+            {(() => {
+              const offer = pauseOfferFor(v.row.nodeId)
+              if (!offer.show) return null
+              return (
+                <button
+                  className="sessmem-row__pause"
+                  title={offer.hint}
+                  aria-label={`Pause ${v.title}`}
+                  disabled={offer.disabled || pausing === v.row.nodeId}
+                  onClick={() => {
+                    // `disabled` is the DOM's answer; this is the code's — and it also covers the
+                    // in-flight case, where a second click would queue a second `/exit` behind the
+                    // first (the restart guard refuses it, but silently).
+                    if (offer.disabled || pausing === v.row.nodeId) return
+                    setPausing(v.row.nodeId)
+                    void onPauseSession(v.row.nodeId)
+                      .then(() => sweep())
+                      .finally(() => setPausing(null))
+                  }}
+                >
+                  {pausing === v.row.nodeId ? '…' : '⏻'}
+                </button>
+              )
+            })()}
             <button
               className="sessmem-row__kill"
               title="End this session"

--- a/src/renderer/components/SystemResourcePill.test.tsx
+++ b/src/renderer/components/SystemResourcePill.test.tsx
@@ -49,7 +49,13 @@ function mount(mem: MemInfo | null, overBoard = false): void {
   root = createRoot(host)
   act(() =>
     root.render(
-      <SystemResourcePill overBoard={overBoard} onGoToNode={vi.fn()} onKillSession={vi.fn()} />
+      <SystemResourcePill
+        overBoard={overBoard}
+        onGoToNode={vi.fn()}
+        onKillSession={vi.fn()}
+        pauseOfferFor={() => ({ show: false })}
+        onPauseSession={async () => {}}
+      />
     )
   )
 }

--- a/src/renderer/components/SystemResourcePill.tsx
+++ b/src/renderer/components/SystemResourcePill.tsx
@@ -5,6 +5,7 @@ import { useSshConn } from '../state/sshConn'
 import { useSessionMemory } from '../state/sessionMemory'
 import { usageScopeKey } from '../lib/usageScope'
 import { SessionMemoryPanel } from './SessionMemoryPanel'
+import type { SessionPauseOffer } from '../lib/sessionPause'
 import { IconResource } from './icons'
 
 /** `formatBytes` speaks bytes; every number in this feature is MB. */
@@ -20,6 +21,10 @@ export interface SystemResourcePillProps {
    *  a panel whose rows silently do nothing. */
   onGoToNode: (nodeId: string) => void
   onKillSession: (nodeId: string, orphan: boolean) => void
+  /** Straight passthroughs to the panel — see SessionMemoryPanelProps. The pill is the panel's
+   *  only mount point, so every panel prop has to come through here. */
+  pauseOfferFor: (nodeId: string) => SessionPauseOffer
+  onPauseSession: (nodeId: string) => Promise<void>
 }
 
 /**
@@ -35,7 +40,9 @@ export interface SystemResourcePillProps {
 export function SystemResourcePill({
   overBoard = false,
   onGoToNode,
-  onKillSession
+  onKillSession,
+  pauseOfferFor,
+  onPauseSession
 }: SystemResourcePillProps): JSX.Element | null {
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
@@ -128,6 +135,8 @@ export function SystemResourcePill({
         <SessionMemoryPanel
           onGoToNode={onGoToNode}
           onKillSession={onKillSession}
+          pauseOfferFor={pauseOfferFor}
+          onPauseSession={onPauseSession}
           onClose={() => setOpen(false)}
         />
       )}

--- a/src/renderer/lib/sessionPause.test.ts
+++ b/src/renderer/lib/sessionPause.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { sessionPauseOffer, type SessionPauseInput } from './sessionPause'
+
+const ok = { ok: true } as const
+const base: SessionPauseInput = {
+  orphan: false,
+  agentId: 'claude',
+  wired: true,
+  eligibility: ok
+}
+
+describe('sessionPauseOffer', () => {
+  it('offers an enabled pause for a mounted, idle agent session', () => {
+    const o = sessionPauseOffer(base)
+    expect(o.show).toBe(true)
+    expect(o).toMatchObject({ disabled: false })
+    // The hint has to say what is KEPT, not just what is stopped — that is the whole difference
+    // between this control and the `×` beside it.
+    if (o.show) expect(o.hint).toMatch(/conversation, tmux session and scrollback/)
+  })
+
+  // A panel that spans every `nt-*` session on the machine is mostly NOT agents. A dead control on
+  // each of those rows is noise about something that was never possible.
+  it('shows nothing at all for a row that could never be paused', () => {
+    expect(sessionPauseOffer({ ...base, orphan: true })).toEqual({ show: false })
+    expect(sessionPauseOffer({ ...base, agentId: undefined })).toEqual({ show: false })
+    // A permanent property of the agent, not a passing state — so no button, not a dead one.
+    expect(
+      sessionPauseOffer({ ...base, eligibility: { ok: false, reason: 'not-resumable' } })
+    ).toEqual({ show: false })
+  })
+
+  // The opposite call: these rows DO owe the user a reason, so they render disabled rather than
+  // vanishing.
+  it('refuses a session whose terminal is not mounted here, and says so', () => {
+    const o = sessionPauseOffer({ ...base, wired: false })
+    expect(o).toMatchObject({ show: true, disabled: true })
+    if (o.show) expect(o.hint).toMatch(/Open this session on its canvas first/)
+  })
+
+  it('refuses a busy session with the same sentence the node menu uses', () => {
+    const o = sessionPauseOffer({ ...base, eligibility: { ok: false, reason: 'working' } })
+    expect(o).toMatchObject({ show: true, disabled: true })
+    if (o.show) expect(o.hint).toMatch(/busy/)
+  })
+
+  it('refuses a session that has not reported an id', () => {
+    const o = sessionPauseOffer({ ...base, eligibility: { ok: false, reason: 'no-session' } })
+    expect(o).toMatchObject({ show: true, disabled: true })
+    if (o.show) expect(o.hint).toMatch(/has not reported an id/)
+  })
+
+  it('refuses a session we already exited, rather than offering it twice', () => {
+    for (const flags of [{ paused: true }, { hibernated: true }]) {
+      const o = sessionPauseOffer({ ...base, ...flags })
+      expect(o).toMatchObject({ show: true, disabled: true })
+      if (o.show) expect(o.hint).toMatch(/already paused/)
+    }
+  })
+
+  // Ordering matters: an already-paused node is ALSO un-wired once its terminal unmounts, and a
+  // busy verdict on a paused node would be stale. The "already done" answer must win.
+  it('reports already-paused ahead of the wiring and busy refusals', () => {
+    const o = sessionPauseOffer({
+      ...base,
+      paused: true,
+      wired: false,
+      eligibility: { ok: false, reason: 'working' }
+    })
+    if (o.show) expect(o.hint).toMatch(/already paused/)
+  })
+
+  // …but "this agent can never be paused" outranks even that: it is the one fact that makes the
+  // control meaningless rather than merely unavailable.
+  it('keeps not-resumable hidden even when other refusals also apply', () => {
+    expect(
+      sessionPauseOffer({
+        ...base,
+        paused: true,
+        wired: false,
+        eligibility: { ok: false, reason: 'not-resumable' }
+      })
+    ).toEqual({ show: false })
+  })
+})

--- a/src/renderer/lib/sessionPause.ts
+++ b/src/renderer/lib/sessionPause.ts
@@ -1,0 +1,101 @@
+/**
+ * MAY THIS SESSION-MEMORY ROW OFFER "PAUSE"? — the pure decision behind the panel's ⏻ control.
+ *
+ * The panel's only action used to be the `×` that ENDS a session, which is the wrong tool for the
+ * thing it is most often opened for. Measured on the host that prompted this (2026-09-04): 149
+ * `nt-` sessions, 46 GB of tree RSS, and 98.3% of a median session's 321 MB is the agent CLI's own
+ * process — killing the tmux session on top reclaims the remaining 5.6 MB while destroying the
+ * pane, its scrollback and the ability to warm-reattach. So the panel needs the reclaim that is
+ * already built: exit the CLI, keep everything else, resume the conversation later.
+ *
+ * That mechanism exists and is NOT re-implemented here. This offers the SAME "Pause session" the
+ * node's context menu offers — `pauseAgentNode(id, false)` → the node's registered `pause` closure
+ * → `performExitPhase` — so a session paused from this panel is in exactly the state the PAUSED
+ * chip already describes and the existing Resume already ends. Inventing a third depth ("panel
+ * hibernate") would be a third concept for the user to hold, and a second exit path to keep in
+ * step with Eco's.
+ *
+ * WHY A ROW MAY BE OFFERED NOTHING AT ALL rather than a disabled button: this panel lists every
+ * `nt-*` session on the machine, and most of them are not agents — plain terminals, sticky-less
+ * shells, other people's orphans. A disabled control on every one of those rows is noise about a
+ * thing that was never possible, which is different from a control that is temporarily refused and
+ * owes the user a reason.
+ */
+
+/** What the panel should render in a row's pause slot. */
+export type SessionPauseOffer =
+  /** Nothing at all — this row could never be paused (see the header). */
+  | { show: false }
+  /** A control, possibly refused. `hint` is the tooltip in BOTH cases: enabled it says what will
+   *  happen, disabled it says why it will not. */
+  | { show: true; disabled: boolean; hint: string }
+
+export interface SessionPauseInput {
+  /** No node on any canvas backs this row (`SessionMemoryView.orphan`). */
+  orphan: boolean
+  /** The node's created-with agent (`data.agentId`); absent = a plain terminal. */
+  agentId?: string
+  /**
+   * Is this node MOUNTED here with a live pause closure (`agentPauseFns(id)`)? A session belonging
+   * to a non-active or closed project is listed by the panel but has no terminal in this renderer
+   * to type `/exit` into — the closure is registered by `TerminalNode`, so an unmounted node has
+   * none. Refusing with that reason beats a button that silently does nothing.
+   */
+  wired: boolean
+  /** Already exited by us — nothing left to reclaim. */
+  paused?: boolean
+  hibernated?: boolean
+  /**
+   * `restartEligibility(agentId, state, sessionId)`'s verdict, computed by the caller so this
+   * module stays free of the agent registry. `ok: false` carries the reason the caller renders.
+   */
+  eligibility: { ok: true } | { ok: false; reason: 'working' | 'no-session' | 'not-resumable' }
+}
+
+/**
+ * Refusals in the order a reader should meet them:
+ *
+ *  - **An orphan or a plain terminal shows nothing.** There is no agent CLI in that pane to quit,
+ *    and for an orphan there is no node in this renderer at all.
+ *  - **`not-resumable` shows nothing either.** Pause is exit + resume; an agent this app cannot
+ *    bring back has nothing pause could do for it, and that is a permanent property of the agent,
+ *    not a state that will change while the panel is open. A permanently-disabled button teaches
+ *    less than no button.
+ *  - **Already paused/hibernated is DISABLED, not hidden** — the row still exists and the user is
+ *    entitled to know why the action they expected is not there. (Its memory is already reclaimed,
+ *    so the row's number should be small; saying so beats silence.)
+ *  - **Not wired is DISABLED with the real reason.** This is the common case in a panel that spans
+ *    every project, and "open the project first" is actionable.
+ *  - **Busy is DISABLED**, with the same sentence the node menu uses: an exit line typed into a
+ *    permission prompt ANSWERS it rather than quitting.
+ */
+export function sessionPauseOffer(i: SessionPauseInput): SessionPauseOffer {
+  if (i.orphan || !i.agentId) return { show: false }
+  if (!i.eligibility.ok && i.eligibility.reason === 'not-resumable') return { show: false }
+  if (i.paused || i.hibernated)
+    return {
+      show: true,
+      disabled: true,
+      hint: 'This session is already paused — its agent process has been exited.'
+    }
+  if (!i.wired)
+    return {
+      show: true,
+      disabled: true,
+      hint: 'Open this session on its canvas first — pausing types into its pane, so the terminal has to be here.'
+    }
+  if (!i.eligibility.ok)
+    return {
+      show: true,
+      disabled: true,
+      hint:
+        i.eligibility.reason === 'working'
+          ? 'This session is busy — try again once its turn (or permission prompt) is done.'
+          : 'Nothing to resume yet — this session has not reported an id.'
+    }
+  return {
+    show: true,
+    disabled: false,
+    hint: 'Pause session: quits the agent CLI to free its memory and keeps the conversation, tmux session and scrollback. Resume brings it back.'
+  }
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6921,6 +6921,29 @@ button.group-node__setup:disabled {
   font-variant-numeric: tabular-nums;
   color: var(--text-strong);
 }
+/* Pause: the non-destructive reclaim, sharing the kill button's geometry so the two controls line
+   up, but never its danger colour on hover — this one keeps the session. A disabled offer stays
+   VISIBLE and dimmed rather than hidden, because it carries the reason in its tooltip. */
+.sessmem-row__pause {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(var(--tint-rgb), 0.45);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+.sessmem-row__pause:hover:not(:disabled) {
+  color: var(--accent);
+  background: rgba(var(--tint-rgb), 0.08);
+}
+.sessmem-row__pause:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
 .sessmem-row__kill {
   flex: 0 0 auto;
   width: 20px;


### PR DESCRIPTION
Refs #616.

## Why: 98.3% of a session's memory is the CLI, not the tmux session

The panel's only action was the `×` that **ends** a session — the wrong tool for the thing it is most often opened for. Measured on the reporting host, 2026-09-04 (149 `nt-` sessions, **46 GB** of tree RSS between them):

| population | n | total | median |
|---|---|---|---|
| pane running `claude` | 134 | 46,252 MB | **321.1 MB** |
| pane at a bare shell (CLI already gone) | 15 | 83 MB | **5.6 MB** |

**Exiting the CLI returns 98.3% of a session.** Killing its tmux session on top buys the remaining 1.7% — and costs the pane, its scrollback and the warm reattach. Population-wide the same split is 95.0% `claude`+`node` against 1.76% shell.

That number is the reason I did **not** build issue #616's "destroy the tmux session too": it is measurably not where the memory is. It is recorded in CLAUDE.md so the next person proposing a destructive memory lever has the figure to hand.

## What this adds

A pause control on each row, left of the `×`. It is **not a third depth**: it calls `pauseAgentNode(id, false)` — the same "Pause session" the node context menu offers, the same `performExitPhase`, the same PAUSED chip, the same Resume. A panel-only "hibernate" would be a third concept for the user to hold and a second exit path to keep in step with Eco's.

## Which rows offer it (`renderer/lib/sessionPause.ts`, pure + tested)

The two directions are deliberate, and they are the design:

- **Nothing at all** for a row that could *never* be paused — an orphan, a plain terminal, an agent this app cannot quit-and-resume. This panel lists every `nt-*` session on the machine and most of them are not agents; a dead control on each of those rows is noise about something that was never possible.
- **Disabled, with the reason** for a row that is merely refused *right now*: busy (the node menu's own sentence — an exit line typed into a permission prompt **answers** it), no reported session id, or **its terminal is not mounted on this canvas**. That last one is the common case in a panel that deliberately spans closed and inactive projects, and "open the project first" is actionable, so it earns a control rather than silence.

Canvas answers the question because it is the only place that can see all four facts at once: the node's created-with agent (via the existing shared `restartAgentIdOf`, not a second derivation), whether a live pause closure is registered, its persisted pause flags, and its `restartEligibility`. It asks on the same narrow `st?.sessionId` the node menu uses, so a row cannot promise what the closure would then refuse.

The panel re-sweeps after a pause resolves — otherwise the row keeps reporting the memory of a process that has just exited — and holds the control disabled while one is in flight (an exit polls the pane for up to 6 s).

## Surfaces

- **Desktop / Server Edition** — identical; the decision is pure renderer and the action reuses machinery already running in both.
- **SSH scope** — works, and this is the case that matters most: manual pause is **not** subject to Eco's remote exclusion, so a host reached over SSH can be reclaimed from this panel even though the automatic sweep will never touch it. (See my note on the third piece of #616 — that exclusion, not the idle clock, is why Eco is inert on a host like the reporter's.)
- **Relay tabs** — the whole panel is already `ok:false` there, so the control is unreachable.
- **Mobile** — N/A (no canvas, and the transport carries no per-session memory concept).

## Testing

`npm run typecheck` clean. New `sessionPause.test.ts` (8 tests, including the refusal-ordering cases) plus 5 new panel tests; `sessionPause` + `SessionMemoryPanel` + `SystemResourcePill` = 50 passing. The panel harness defaults every row to `{show:false}`, so every pre-existing assertion in that file sees exactly the old DOM.

Two failures in the wider renderer run (`keyContext`, `directionalFocus`) are **pre-existing worktree-environment issues** — both `readFileSync('node_modules/...')` on a relative path — and are untouched by this change.

## Device checklist (owed)

1. Idle agent node on the active canvas → pause control enabled; click it; the CLI exits, the PAUSED chip appears on the node, and the row's MB drops on the automatic re-sweep.
2. Resume from the node chip → the conversation comes back. Confirm it is the *same* state a menu-driven pause produces.
3. Busy node (mid-turn) → disabled, with the busy tooltip. Verify no `/exit` reaches the pane.
4. A node in a **non-active** project → disabled, "open this session on its canvas first".
5. Orphan row and plain-terminal row → **no** control at all (not a disabled one).
6. Already-paused node → disabled, "already paused".
7. **SSH project**: pause a remote agent node from the panel and confirm the memory actually drops on the host (`ps` on the box), since this is the scope Eco cannot serve.
8. Double-click the control fast → only one exit runs (in-flight guard).
9. The `×` still confirms and still ends the session — this must not have changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL