### PR TITLE
fix(ui): give the memory panel's pause the same icon as the node menu's

### DIFF
--- a/src/renderer/components/SessionMemoryPanel.test.tsx
+++ b/src/renderer/components/SessionMemoryPanel.test.tsx
@@ -410,6 +410,34 @@ describe('SessionMemoryPanel', () => {
       expect(pauseOf(0)!.title).toBe('Open this session on its canvas')
     })
 
+    it('draws the shared power icon, and the shared spinner while the pause is in flight', async () => {
+      // The panel's pause is the SAME action as the node menu's "Pause session", which draws
+      // `IconPower` — one action seen in two places must not speak in two voices.
+      let settle = (): void => {}
+      onPauseSession.mockImplementation(
+        () =>
+          new Promise<void>((res) => {
+            settle = () => res()
+          })
+      )
+      pauseOffer = () => ({ show: true, disabled: false, hint: 'Pause session' })
+      mount()
+      const btn = pauseOf(0)!
+      expect(btn.querySelector('svg')).not.toBeNull()
+      expect(btn.querySelector('.ui-spinner')).toBeNull()
+
+      act(() => btn.click())
+      expect(btn.querySelector('.ui-spinner')).not.toBeNull()
+      expect(btn.querySelector('svg')).toBeNull()
+
+      // Settle inside `act` so the icon is back before the test ends — a promise still pending at
+      // teardown resolves into an unmounted tree.
+      await act(async () => {
+        settle()
+      })
+      expect(pauseOf(0)!.querySelector('svg')).not.toBeNull()
+    })
+
     it('asks per row, so one row may offer a pause while another does not', () => {
       pauseOffer = (id) =>
         id === ROWS[0].nodeId

--- a/src/renderer/components/SessionMemoryPanel.tsx
+++ b/src/renderer/components/SessionMemoryPanel.tsx
@@ -10,6 +10,7 @@
 //   3. Every row is rendered. A cap would have to announce itself.
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { IconPower } from './icons'
 import type { AgentState } from '@shared/agents/normalize'
 import { formatBytes } from '@shared/fsLimits'
 import { useAgentStatus } from '../state/agentStatus'
@@ -198,7 +199,11 @@ export function SessionMemoryPanel({
                       .finally(() => setPausing(null))
                   }}
                 >
-                  {pausing === v.row.nodeId ? '…' : '⏻'}
+                  {pausing === v.row.nodeId ? (
+                    <span className="ui-spinner" aria-hidden />
+                  ) : (
+                    <IconPower />
+                  )}
                 </button>
               )
             })()}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6946,13 +6946,15 @@ button.group-node__setup:disabled {
    VISIBLE and dimmed rather than hidden, because it carries the reason in its tooltip. */
 .sessmem-row__pause {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 20px;
   height: 20px;
   border: none;
   border-radius: 10px;
   background: transparent;
   color: rgba(var(--tint-rgb), 0.45);
-  font-size: 11px;
   line-height: 1;
   cursor: pointer;
 }


### PR DESCRIPTION
The follow-up I mentioned on #554. It stands on its own and does not depend on that branch: `IconPower` and `.ui-spinner` are both already on main.

## What

The pause control the memory panel gained in #669 renders a bare `⏻` glyph, and a literal `…` while the pause is in flight. The "Pause session" row in the node context menu runs the exact same `pauseAgentNode` and renders `IconPower`. One action seen in two places was speaking in two voices, and for a 20px control the glyph is the half a user recognizes before they read the label.

So: `⏻` -> `<IconPower />`, `…` -> the shared `.ui-spinner`.

## Why `IconPower` specifically

Its own doc-block reserves it for acting on a **process** rather than a view, as opposed to `IconReload`'s circular arrow — and that is exactly what a pause is: it quits the agent CLI and leaves the tmux session, its scrollback and the conversation alone. It is also already what every pause/resume/restart entry in `Canvas.tsx` draws, so this makes the panel agree with the menu rather than inventing a third convention.

## The one CSS line

`.sessmem-row__pause` had no centering — it did not need any while its child was text. With an SVG child it does, so it gets the `inline-flex` + centering that `.sessmem-panel__refresh` two rules down already uses. The now-unused `font-size: 11px` goes with it.

## Not done here

The row's kill `×` is the other text glyph in that panel. It is swapped in #554 as part of the icon sweep, so touching it here would collide with that branch for no gain.

## Verification

`npm run typecheck` clean. Renderer suite green: 321 files, 4255 tests. (`state/cardModalSize.test.ts` fails 2 on my machine for a local Node/localStorage reason — it fails identically on a detached `origin/main`, so it is not this branch.)

New test pins the swap in both directions: the icon is there at rest, the spinner replaces it while the promise is pending, and the icon is back once it settles. It settles inside `act` on purpose — a promise still pending at teardown resolves into an unmounted tree and vitest reports it as an unhandled error.

Desktop and Server Edition are identical here (pure renderer, no IPC). Mobile has no memory panel.
