### PR TITLE
docs: say how a pull request should read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,11 @@ testing habits). This file is what you reach for when you need to know *why* a r
 is, or you are changing a subsystem it describes. A change that other developers must know about
 belongs in BOTH (see Conventions).
 
+**PR text (title, description, comments, review responses) follows the `pr-writing` skill**: what
+changed and why it matters, then how it was checked and what was not, then risks or follow-up when
+there are any. Structure proportional to the change. `CONTRIBUTING.md` § Pull requests is the
+human-facing half of the same rule.
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## What this is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -416,6 +416,10 @@ production socket on purpose; adding a third is a review conversation, not a che
 - Explain **why**, not just what. If a decision has a trade-off, name it and say what you rejected.
 - If you measured something, put the numbers in — they save the next person the same afternoon.
 - Say what you did **not** verify. That is more useful than a confident summary.
+- **Lead with what changed and why it matters.** A reviewer who reads only your first two
+  sentences should be able to decide whether to keep reading; implementation detail comes after.
+- **Match the length to the change.** A one line fix gets a paragraph, a change that moves a
+  boundary gets as much room as it needs, and neither is improved by headings it does not need.
 
 ## Documentation
 


### PR DESCRIPTION
`CONTRIBUTING.md`'s PR rules already ask for the why, the numbers, and what you did not verify. They do not say what the body should open with, or how much room a change deserves, which is where most PRs here actually go wrong: the point arrives in paragraph four, or a five line diff gets a document. Two bullets close that, in the same voice as the four already there.

`CLAUDE.md` gets the agent-side pointer near the top, where every Claude Code session in this repo loads it, naming the shared `pr-writing` skill. Contributors are not expected to have that skill, so `CONTRIBUTING.md` states the rules directly instead of pointing at internal tooling.

Checked: docs only, no code path touched, so CI's typecheck, tests and build are unaffected and I did not run them. I read the existing `## Pull requests` section first to avoid restating a rule it already has; "say what you did not verify" already covers not inflating verification, so I did not add a bullet for it. `CLAUDE.md`'s Conventions section requires that a rule other developers must know lands in both files, which is why this change edits both rather than only the agent-facing one.

Risk: none beyond the words. Revert the merge to undo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpHs2PzZ6LzdMT6FvzavAu