### PR TITLE
feat(packaging): ship a .rpm for Fedora/RHEL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
 
   # Linux build: unsigned, so it runs on a plain GitHub runner (fast + free tier), in
   # parallel with the self-hosted mac job — it must never queue behind notarization.
-  # Publishes AppImage + deb + latest-linux.yml to the SAME tag's GitHub Release; the
+  # Publishes AppImage + deb + rpm + latest-linux.yml to the SAME tag's GitHub Release; the
   # nodeterm.dev update feed serves latest-linux.yml alongside the mac files.
   release-linux:
     runs-on: ubuntu-latest
@@ -155,6 +155,12 @@ jobs:
         with:
           node-version: 22
           cache: npm
+
+      # electron-builder ships its own fpm, but the rpm target shells out to the system
+      # rpmbuild ("Need executable 'rpmbuild' to convert dir to rpm"). Installed explicitly
+      # rather than relying on whatever the runner image happens to carry.
+      - name: Install rpmbuild
+        run: sudo apt-get update && sudo apt-get install -y rpm
 
       - name: Install dependencies
         run: npm ci
@@ -177,6 +183,7 @@ jobs:
           files: |
             dist/*.AppImage
             dist/*.deb
+            dist/*.rpm
             dist/latest-linux.yml
 
   # Windows build: UNSIGNED BETA (#454), on a plain GitHub runner. Publishes the NSIS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3225,6 +3225,43 @@ the same script hand-packs `build/icon.icns` (size-checked frames — issue #369
 zip, `--publish never`). Production release signing/notarization and the update-feed hosting are
 handled outside this repo.
 
+**Linux ships AppImage + deb + rpm**, all unsigned, all built by `release-linux` on a plain
+`ubuntu-latest` runner (`npm run dist:linux` locally). Three things about it are easy to get wrong:
+
+- **The packages are named `node-terminal`, the AppImage is named `nodeterm`.** electron-builder's
+  `linuxPackageName` is package.json's `name`, not `productName` (it only falls back to the product
+  name for an `@scope/…` name), so the artifacts are `node-terminal_<version>_amd64.deb`,
+  `node-terminal-<version>.x86_64.rpm` and `nodeterm-<version>.AppImage`, the launcher is
+  `/usr/bin/node-terminal`, and the install prefix is `/opt/nodeterm` (that one IS the productName).
+  Anything that matches on the package name (`scripts/uninstall.sh`'s `dpkg -s` / `rpm -q` probes,
+  the README's install lines) must say `node-terminal` or it silently never fires. Renaming the
+  package to match the app would strand existing `.deb` installs on a package apt no longer tracks,
+  which is why the mismatch is documented rather than fixed.
+- **The rpm target shells out to the system `rpmbuild`.** electron-builder bundles fpm, but not
+  rpmbuild, so `release-linux` installs it explicitly (`apt-get install -y rpm`); without it the
+  target dies with "Need executable 'rpmbuild' to convert dir to rpm". The default `Requires` set
+  electron-builder emits (gtk3, libnotify, nss, libXScrnSaver, `(libXtst or libXtst6)`, xdg-utils,
+  at-spi2-core, `(libuuid or libuuid1)`) resolves on Fedora 44 with nothing extra pulled in;
+  verified by installing the built rpm, which also proved rpm 6.0.2 accepts fpm's spec.
+- **Auto-update is already correct for rpm and needs no work**: `isManualUpdatePlatform`
+  (src/shared/update-platform.ts) keys off the absence of `APPIMAGE` in the environment, so a deb
+  and an rpm install both land on the manual-download card rather than downloading an AppImage
+  they cannot install.
+
+**Building on a GCC 14+ distro needs `CFLAGS=-D_GNU_SOURCE`** (Fedora, Arch, recent openSUSE; the
+CI runners are old enough not to care). smart-whisper's vendored `whisper.cpp/ggml/src/ggml.c`
+calls `CPU_ZERO`, `CPU_SET_S`, `pthread_getaffinity_np` and `getcpu` without ever defining
+`_GNU_SOURCE` (upstream ggml gets it from its CMake build, which node-gyp does not use), and GCC 14
+promoted implicit function declarations from a warning to an error, so a bare `npm install` fails
+in smart-whisper's own install script before our `postinstall` ever runs. Measured on Fedora 44 /
+GCC 16.2.1: `CFLAGS=-D_GNU_SOURCE npm install` builds both native modules clean. Two Fedora runtime
+packages are needed on top: **`libxcrypt-compat`** (fpm's bundled Ruby links `libcrypt.so.1`, which
+Fedora's glibc dropped, and without it BOTH the deb and the rpm target fail), and **`fuse-libs`**
+for anyone running the AppImage, whose default runtime is still the FUSE2 one. Switching
+`build.toolsets.appimage` to `"1.0.3"` would drop that FUSE2 requirement, but the static runtime is
+upstream-flagged beta and stops passing the `--no-sandbox` launcher argument the FUSE2 path adds,
+so it is a deliberate not-yet.
+
 **Windows ships as an UNSIGNED BETA** (extracted from external PR #276; the session-host phase
 #305 merged 2026-08-20, and the decision to release without signing is #454 — CI-green, but no
 real-device daily-use verification yet, and that is a stated risk, not an oversight). Deliberate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3247,6 +3247,13 @@ handled outside this repo.
   (src/shared/update-platform.ts) keys off the absence of `APPIMAGE` in the environment, so a deb
   and an rpm install both land on the manual-download card rather than downloading an AppImage
   they cannot install.
+- **The ORDER of `build.linux.target` is load-bearing: AppImage stays FIRST.** electron-builder
+  writes the update feed from the first target it can publish, so the entry at the head of that
+  array is what `latest-linux.yml` points at — and the AppImage is the only Linux artifact
+  electron-updater can actually install in place. `deb` has sat behind it for a long time without
+  disturbing the feed, and `rpm` is appended behind both for the same reason. package.json is JSON
+  and cannot carry the comment, so it is written here: **do not alphabetize or otherwise re-sort
+  that array.**
 
 **Building on a GCC 14+ distro needs `CFLAGS=-D_GNU_SOURCE`** (Fedora, Arch, recent openSUSE; the
 CI runners are old enough not to care). smart-whisper's vendored `whisper.cpp/ggml/src/ggml.c`

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ hidden tabs.
 [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/eneskirca/nodeterm?style=flat)](https://github.com/eneskirca/nodeterm/stargazers)
 [![Latest release](https://img.shields.io/github/v/release/eneskirca/nodeterm?include_prereleases&sort=semver)](https://github.com/eneskirca/nodeterm/releases)
-<!-- Installer downloads: .dmg + .AppImage + .deb + Setup .exe across every release, hand-written on purpose.
+<!-- Installer downloads: .dmg + .AppImage + .deb + .rpm + Setup .exe across every release, hand-written on purpose.
      shields' github/downloads/…/total reads ~12× higher because electron-updater's own traffic
      (latest-*.yml polls, mac .zip deltas, blockmaps) is counted as downloads there. Recount with:
      gh api --paginate repos/eneskirca/nodeterm/releases --jq \
-       '[.[].assets[] | select(.name|test("\\.(dmg|AppImage|deb|exe)$")) | .download_count] | add' -->
+       '[.[].assets[] | select(.name|test("\\.(dmg|AppImage|deb|rpm|exe)$")) | .download_count] | add' -->
 [![Downloads](https://img.shields.io/badge/downloads-1.2k-brightgreen)](https://github.com/eneskirca/nodeterm/releases)
 
 <a href="https://trendshift.io/repositories/103825?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-103825" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/103825" alt="eneskirca%2Fnodeterm | Trendshift" width="250" height="55"/></a>
@@ -208,8 +208,12 @@ detects your platform. Everything is also listed at
   `homebrew/cask` and reports the cask as not found; without the trust grant, Homebrew ≥6
   fails rather than prompting. The cask tracks each promoted release, and the app updates
   itself (electron-updater), so `brew upgrade` is rarely needed for it.
-- **Linux (x64)** — self-updating **AppImage**, or a `.deb` for Debian/Ubuntu
-  (`sudo apt install ./nodeterm-*.deb`; updates are manual for `.deb`).
+- **Linux (x64)** — self-updating **AppImage**, a `.deb` for Debian/Ubuntu
+  (`sudo apt install ./node-terminal_*.deb`), or an `.rpm` for Fedora/RHEL
+  (`sudo dnf install ./node-terminal-*.rpm`). Updates are manual for both packages: the app
+  tells you when a new version is out and links the download. The AppImage needs FUSE 2,
+  which Fedora does not install by default: `sudo dnf install fuse-libs` if it exits with
+  a `libfuse.so.2` error.
 - **Windows (x64) — beta** — `nodeterm-Setup-<version>.exe` (per-user installer) or a
   portable `-win.zip`. Early support, so know what you are getting: the installer is
   **unsigned** (SmartScreen will ask — *More info → Run anyway*), **updates are manual**
@@ -245,6 +249,18 @@ release job does this automatically), or just install tmux yourself. On **Window
 C++ build tools and Python 3 (needed to compile node-pty) and points you at the exact
 `winget` commands for anything missing, then runs `npm ci`.
 
+On **Fedora** (and any distro shipping GCC 14 or newer), export `CFLAGS=-D_GNU_SOURCE` for the
+install: smart-whisper's bundled whisper.cpp uses GNU-only CPU-affinity calls without asking for
+them, and GCC 14 turned that from a warning into an error, so a plain `npm install` fails while
+building it. Packaging additionally wants `rpm-build` (for the `.rpm` target) and
+`libxcrypt-compat` (electron-builder's bundled `fpm` runs a Ruby that still links
+`libcrypt.so.1`, without which both `.deb` and `.rpm` fail):
+
+```bash
+sudo dnf install -y rpm-build libxcrypt-compat
+CFLAGS=-D_GNU_SOURCE npm install
+```
+
 ```bash
 npm install        # deps + rebuilds node-pty against Electron's ABI (postinstall)
 npm run dev        # dev mode with renderer HMR
@@ -253,7 +269,7 @@ npm start          # preview the production build
 npm run typecheck  # fastest correctness gate
 npm test           # vitest unit + integration suite
 npm run dist       # local UNSIGNED .dmg into dist/ (smoke test)
-npm run dist:linux # AppImage + .deb into dist/ (on a Linux host)
+npm run dist:linux # AppImage + .deb + .rpm into dist/ (on a Linux host; .rpm needs rpmbuild)
 npm run dist:win   # unsigned NSIS installer + zip into dist/ (on a Windows host)
 npm run server:dev # build + run the browser Server Edition (needs Node 22 + tmux)
 ```

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
           "arch": [
             "x64"
           ]
+        },
+        {
+          "target": "rpm",
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "category": "Development",

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -527,8 +527,16 @@ note "    On each host: tmux -L nodeterm-rmt kill-server; rm -rf ~/.nodeterm  (t
 note "    script's agent-integration steps there if you used agents on that host)."
 note "  • The tmux/agent CLIs themselves (claude, codex, …) — nodeterm never owned them."
 if [ "$OS" != "Darwin" ]; then
-  if command -v dpkg >/dev/null 2>&1 && dpkg -s nodeterm >/dev/null 2>&1; then
-    note "  • The .deb package needs root to remove: sudo apt remove nodeterm"
+  # Both packages carry package.json's `name`, not the productName the app is installed
+  # under: electron-builder's linuxPackageName is `node-terminal`, /opt/nodeterm is not.
+  if command -v dpkg >/dev/null 2>&1 && dpkg -s node-terminal >/dev/null 2>&1; then
+    note "  • The .deb package needs root to remove: sudo apt remove node-terminal"
+  elif command -v rpm >/dev/null 2>&1 && rpm -q node-terminal >/dev/null 2>&1; then
+    if command -v dnf >/dev/null 2>&1; then
+      note "  • The .rpm package needs root to remove: sudo dnf remove node-terminal"
+    else
+      note "  • The .rpm package needs root to remove: sudo rpm -e node-terminal"
+    fi
   fi
   note "  • If you used the AppImage, delete the nodeterm-*.AppImage file you downloaded."
 fi


### PR DESCRIPTION
This PR adds a `.rpm` to the Linux release, so Fedora and RHEL get a package they can install
instead of a `.deb` they cannot and an AppImage that needs a library Fedora no longer ships by
default. It also corrects two places that named the Linux packages wrong, and writes down what a
Fedora checkout needs before it can build at all.

**Why the release job changes with the target.** electron-builder bundles fpm but shells out to the
system `rpmbuild`, so the rpm target dies on a bare runner with "Need executable 'rpmbuild' to
convert dir to rpm". The install step and the `dist/*.rpm` upload glob land in the same commit as
the target, so no release can be cut from a tree whose job builds a target it has no tool for.

**The package is called `node-terminal`, not `nodeterm`.** electron-builder derives the deb and rpm
package name from package.json's `name`, not `productName` (only an `@scope/...` name falls back to
the product name), so the artifacts are `node-terminal_0.3.4_amd64.deb` and
`node-terminal-0.3.4.x86_64.rpm`, while the AppImage and the `/opt/nodeterm` install prefix use the
product name. Two existing references assumed otherwise and therefore never matched anything: the
README's `sudo apt install ./nodeterm-*.deb` line, and `uninstall.sh`'s `dpkg -s nodeterm` probe,
which meant every `.deb` user reached the end of the uninstall script without being told the
package was still on their machine. Both now say `node-terminal`, and the probe covers rpm.

**Rejected: renaming the package to match the app.** `linux.packageName: "nodeterm"` would have made
the existing text correct instead, but apt and dnf would then treat it as a different package from
the one already shipped, turning an upgrade into a rename for current `.deb` users. Documenting the
real name is cheaper than that.

**Rejected for now: the static AppImage runtime.** The default runtime is still the FUSE2 one, so on
a stock Fedora install the AppImage exits with a `libfuse.so.2` error until `fuse-libs` is present.
`toolsets.appimage: "1.0.3"` drops that requirement, but it is upstream-flagged beta and the static
runtime stops passing the `--no-sandbox` launcher argument the FUSE2 path adds, which is a
behaviour change for every Linux user rather than a Fedora fix. The README names the one-line
workaround instead.

**Building on Fedora needs `CFLAGS=-D_GNU_SOURCE`.** smart-whisper's vendored
`whisper.cpp/ggml/src/ggml.c` calls `CPU_ZERO`, `CPU_SET_S`, `pthread_getaffinity_np` and `getcpu`
without ever defining `_GNU_SOURCE` (upstream ggml gets it from its CMake build, which node-gyp does
not use), and GCC 14 promoted implicit declarations from a warning to an error. A bare `npm install`
therefore fails inside smart-whisper's own install script, before this repo's `postinstall` runs, so
nothing here can patch around it. `libxcrypt-compat` is needed too: fpm's bundled Ruby links
`libcrypt.so.1`, which Fedora's glibc dropped, and without it both the deb and the rpm target fail.

**Measured on Fedora 44** (GCC 16.2.1, rpm 6.0.2, Node 24.18.1): `CFLAGS=-D_GNU_SOURCE npm install`
builds node-pty and smart-whisper clean against Electron 42's ABI; `npm run dist:linux` produces all
three artifacts (AppImage 176 MB, deb 135 MB, rpm 111 MB); `dnf install` of the rpm resolves with
nothing extra pulled in, so the default `Requires` set (gtk3, libnotify, nss, libXScrnSaver,
`(libXtst or libXtst6)`, xdg-utils, at-spi2-core, `(libuuid or libuuid1)`) is already satisfiable
there; the postinstall scriptlet correctly leaves `chrome-sandbox` at 0755 on a userns kernel; and
the installed app launches and renders.

**Not verified:** the rpm leg on the `ubuntu-latest` runner, which stays unexercised until a tag is
cut; any RHEL, openSUSE or Fedora-derivative host; the full `npm test` suite (typecheck is clean and
the packaging-adjacent suites pass); and the AppImage on a Fedora box with `fuse-libs` installed.
Auto-update needed no code change, since `isManualUpdatePlatform` already treats a Linux install
without `APPIMAGE` in the environment as manual-download, which is exactly what an rpm install is,
but that path was read rather than exercised.
