### PR TITLE
Canvas reliability fixes and partial IME duplicate-input mitigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3371,6 +3371,49 @@ points at tmux's `server_accept()` calling `fatal()` under the suite's process/f
 memory-starved machine, and two identical runs finished clean. Sharing a server with the user's live
 sessions is a hazard whatever kills it; this removes the hazard, not a proven cause.
 
+## IME composition ownership
+
+Canvas and kanban terminals both install `installImeGuard` for xterm 5.5. While composition or
+its deferred finalizer owns the textarea, the fallback `insertText` path must not emit it
+again. Do not deduplicate strings: intentional repeated input is valid. Composition key events
+also bypass Nodeterm shortcuts. This adapter uses xterm private fields and needs native IME
+verification when xterm changes. Duplicate input still occurs intermittently in local use;
+this guard is only a partial mitigation, not a complete fix.
+
+## SSH deletion reconciliation
+
+Keep `IndexEntryV3.sshBaseline` machine-local and preserve it across saves and restarts. Only
+a newer, actually read, same-lineage remote snapshot proves that a previously shared node was
+deleted. Failed reads and optimistic write acknowledgments are not evidence of deletion.
+Renderer `CanvasDeletions` retains deletion memory across optimistic commits and releases it
+on explicit local undo. Older clients can still resurrect deletions if they concurrently write
+the same remote project.
+
+## Subagent lifecycle replay
+
+Both desktop and Server Edition record accepted subagent lifecycle events in bounded,
+in-memory `SubagentReplay`. Preload and WebSocket clients subscribe before requesting the
+snapshot and drain racing live events afterward. Never include state or permission alerts in
+the snapshot. Preserve original start timestamps and completed cards on duplicate starts; an
+end can reconstruct a missing start. This cannot recover hooks never received by the host, or
+survive a host-process restart.
+
+## Audio media nodes
+
+Audio files use the existing persisted `video` node kind and native audio controls, not the
+UTF-8 editor. File-opening decisions must use `isMediaFile` wherever audio and video share
+routing. On load, legacy audio editor nodes migrate while retaining their node IDs, paths, SSH
+provenance, and placement. A recognized file extension does not guarantee that the browser
+supports its codec.
+
+## Media range and cache lifetime
+
+Single-byte-range arithmetic lives in `core/media-range.ts`; suffix ranges count backward from
+EOF, and reversed/out-of-bounds ranges return 416. Remote files allowed for the current media
+session must remain cached for subsequent seeks. The cache limit is therefore soft until the
+app exits. Playback controls must not initiate canvas panning, and a changed source clears
+stale playback/error state.
+
 ## Conventions
 
 - **Two docs, two audiences — keep both.** This file holds the deep invariants with their

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,6 +363,49 @@ yourself and apply it with `setViewport` (`renderer/lib/nodeFocus.ts`, `canvas/f
 lands now and against the canvas you meant. `fitAll` is the one deliberate exception: an explicit
 user gesture on a settled canvas.
 
+## IME composition ownership
+
+Canvas and kanban terminals both install `installImeGuard` for xterm 5.5. While composition or
+its deferred finalizer owns the textarea, the fallback `insertText` path must not emit it
+again. Do not deduplicate strings: intentional repeated input is valid. Composition key events
+also bypass Nodeterm shortcuts. This adapter uses xterm private fields and needs native IME
+verification when xterm changes. Duplicate input still occurs intermittently in local use;
+this guard is only a partial mitigation, not a complete fix.
+
+## SSH deletion reconciliation
+
+Keep `IndexEntryV3.sshBaseline` machine-local and preserve it across saves and restarts. Only
+a newer, actually read, same-lineage remote snapshot proves that a previously shared node was
+deleted. Failed reads and optimistic write acknowledgments are not evidence of deletion.
+Renderer `CanvasDeletions` retains deletion memory across optimistic commits and releases it
+on explicit local undo. Older clients can still resurrect deletions if they concurrently write
+the same remote project.
+
+## Subagent lifecycle replay
+
+Both desktop and Server Edition record accepted subagent lifecycle events in bounded,
+in-memory `SubagentReplay`. Preload and WebSocket clients subscribe before requesting the
+snapshot and drain racing live events afterward. Never include state or permission alerts in
+the snapshot. Preserve original start timestamps and completed cards on duplicate starts; an
+end can reconstruct a missing start. This cannot recover hooks never received by the host, or
+survive a host-process restart.
+
+## Audio media nodes
+
+Audio files use the existing persisted `video` node kind and native audio controls, not the
+UTF-8 editor. File-opening decisions must use `isMediaFile` wherever audio and video share
+routing. On load, legacy audio editor nodes migrate while retaining their node IDs, paths, SSH
+provenance, and placement. A recognized file extension does not guarantee that the browser
+supports its codec.
+
+## Media range and cache lifetime
+
+Single-byte-range arithmetic lives in `core/media-range.ts`; suffix ranges count backward from
+EOF, and reversed/out-of-bounds ranges return 416. Remote files allowed for the current media
+session must remain cached for subsequent seeks. The cache limit is therefore soft until the
+app exits. Playback controls must not initiate canvas panning, and a changed source clears
+stale playback/error state.
+
 ## Testing
 
 `npm test` must pass, and `npm run typecheck` is the fastest gate.

--- a/src/core/media-range.test.ts
+++ b/src/core/media-range.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { mediaRange } from './media-range'
+
+describe('media byte ranges', () => {
+  it.each([
+    ['bytes=0-99', { start: 0, end: 99 }],
+    ['bytes=100-', { start: 100, end: 999 }],
+    ['bytes=-100', { start: 900, end: 999 }],
+    ['bytes=-2000', { start: 0, end: 999 }],
+    ['bytes=900-2000', { start: 900, end: 999 }],
+    ['bytes=1000-', 'unsatisfiable'], ['bytes=100-99', 'unsatisfiable'],
+    ['bytes=-0', 'unsatisfiable'], ['bytes=-', null],
+    ['bytes=1-2,4-5', null], ['junk bytes=1-2', null]
+  ])('%s', (header, expected) => expect(mediaRange(header, 1000)).toEqual(expected))
+  it('rejects ranges on empty files', () => expect(mediaRange('bytes=0-', 0)).toBe('unsatisfiable'))
+})

--- a/src/core/media-range.ts
+++ b/src/core/media-range.ts
@@ -1,0 +1,19 @@
+/** A single HTTP byte range. Malformed/multi-range requests are ignored (200);
+ * valid but unsatisfiable requests return 416. Suffix ranges count back from EOF. */
+export function mediaRange(header: string | null, size: number):
+  { start: number; end: number } | 'unsatisfiable' | null {
+  if (!header) return null
+  const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim())
+  if (!m || (!m[1] && !m[2])) return null
+  const first = m[1] ? Number(m[1]) : undefined
+  const last = m[2] ? Number(m[2]) : undefined
+  if ((first !== undefined && !Number.isSafeInteger(first)) ||
+      (last !== undefined && !Number.isSafeInteger(last))) return 'unsatisfiable'
+  if (size === 0) return 'unsatisfiable'
+  if (first === undefined) {
+    if (!last) return 'unsatisfiable'
+    return { start: Math.max(0, size - last), end: size - 1 }
+  }
+  if (first >= size || (last !== undefined && last < first)) return 'unsatisfiable'
+  return { start: first, end: Math.min(last ?? size - 1, size - 1) }
+}

--- a/src/core/remote-ssh/media-cache.test.ts
+++ b/src/core/remote-ssh/media-cache.test.ts
@@ -18,6 +18,11 @@ describe('remoteMediaCacheName', () => {
 })
 
 describe('mediaCachePruneList', () => {
+  it('keeps an oldest active player beyond the soft cap', () => {
+    const entries = Array.from({ length: 21 }, (_, i) => ({ name: `video-${i}`, mtimeMs: i }))
+    expect(mediaCachePruneList(entries, 'video-20')).toEqual(['video-0'])
+    expect(mediaCachePruneList(entries, 'video-20', 20, new Set(['video-0']))).toEqual([])
+  })
   const entry = (name: string, mtimeMs: number) => ({ name, mtimeMs })
 
   it('keeps everything under the cap', () => {

--- a/src/core/remote-ssh/media-cache.ts
+++ b/src/core/remote-ssh/media-cache.ts
@@ -25,11 +25,13 @@ export const MEDIA_CACHE_KEEP = 20
 export function mediaCachePruneList(
   entries: readonly { name: string; mtimeMs: number }[],
   except: string,
-  keep: number = MEDIA_CACHE_KEEP
+  keep: number = MEDIA_CACHE_KEEP,
+  protectedNames: ReadonlySet<string> = new Set()
 ): string[] {
   return entries
     .filter((e) => e.name !== except)
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
     .slice(Math.max(0, keep - 1))
+    .filter((e) => !protectedNames.has(e.name))
     .map((e) => e.name)
 }

--- a/src/core/subagent-replay.test.ts
+++ b/src/core/subagent-replay.test.ts
@@ -1,0 +1,37 @@
+import { expect, it } from 'vitest'
+import { SubagentReplay } from './subagent-replay'
+import type { NormalizedAgentEvent } from '../shared/agents/normalize'
+
+it('isolates identical tool ids by parent and bounds retained history', () => {
+  const replay = new SubagentReplay()
+  const event = { agentId: 'claude', kind: 'subagent-start', toolUseId: 'shared' } as const
+  replay.record({ ...event, nodeId: 'one' })
+  replay.record({ ...event, nodeId: 'two' })
+  replay.record({ agentId: 'claude', nodeId: 'one', kind: 'session', sessionPhase: 'end' })
+  expect(replay.snapshot().map(e => e.nodeId)).toEqual(['two'])
+  for (let i = 0; i < 600; i++) replay.record({ ...event, nodeId: 'parent-' + i })
+  expect(replay.snapshot()).toHaveLength(512)
+  const snapshot = replay.snapshot()
+  snapshot[0].nodeId = 'mutated'
+  expect(replay.snapshot()[0].nodeId).not.toBe('mutated')
+})
+
+it.each(['claude', 'codex'] as const)('rehydrates %s fan-out without replaying alerts', (agentId) => {
+  const replay = new SubagentReplay()
+  const start: NormalizedAgentEvent = { agentId, nodeId: 'parent', toolUseId: 'child', kind: 'subagent-start' }
+  replay.record(start)
+  const original = replay.snapshot()[0]
+  replay.record(start)
+  expect(replay.snapshot()).toEqual([original])
+  replay.record({ ...start, kind: 'state', state: 'blocked' })
+  expect(replay.snapshot()).toEqual([original])
+  replay.record({ ...start, kind: 'subagent-end', result: 'done' })
+  expect(replay.snapshot().map((e) => e.kind)).toEqual(['subagent-start', 'subagent-end'])
+  replay.record({ agentId, nodeId: 'parent', kind: 'state', newTurn: true })
+  expect(replay.snapshot()).toEqual([])
+  replay.record(start)
+  replay.record({ agentId, nodeId: 'parent', kind: 'state', newTurn: true })
+  expect(replay.snapshot()).toHaveLength(1)
+  replay.record({ agentId, nodeId: 'parent', kind: 'session', sessionPhase: 'end' })
+  expect(replay.snapshot()).toEqual([])
+})

--- a/src/core/subagent-replay.ts
+++ b/src/core/subagent-replay.ts
@@ -1,0 +1,30 @@
+import type { NormalizedAgentEvent } from '../shared/agents/normalize'
+
+/** In-memory, bounded fan-out snapshot shared by desktop and server. Replay ONLY
+ * subagent events: replaying state/permission events would repeat alerts/actions. */
+export class SubagentReplay {
+  private cards = new Map<string, { start?: NormalizedAgentEvent; end?: NormalizedAgentEvent }>()
+
+  record(e: NormalizedAgentEvent): void {
+    if (e.newTurn || e.sessionPhase) {
+      for (const [id, card] of this.cards) {
+        if ((card.start ?? card.end)?.nodeId === e.nodeId && (e.sessionPhase || card.end))
+          this.cards.delete(id)
+      }
+    }
+    if (!e.toolUseId || (e.kind !== 'subagent-start' && e.kind !== 'subagent-end')) return
+    const key = JSON.stringify([e.nodeId, e.toolUseId])
+    const card = this.cards.get(key) ?? {}
+    if (e.kind === 'subagent-start') {
+      if (!card.start && !card.end)
+        card.start = { ...e, subagentStartedAt: e.subagentStartedAt ?? Date.now() }
+    } else card.end = { ...e }
+    this.cards.set(key, card)
+    while (this.cards.size > 512) this.cards.delete(this.cards.keys().next().value!)
+  }
+
+  snapshot(): NormalizedAgentEvent[] {
+    return [...this.cards.values()].flatMap((c) =>
+      [c.start, c.end].filter((e): e is NormalizedAgentEvent => !!e).map((e) => ({ ...e })))
+  }
+}

--- a/src/core/workspace-files.ts
+++ b/src/core/workspace-files.ts
@@ -174,6 +174,10 @@ export interface ProjectFileV1 {
  * the data file into `<cwd>/.nodeterm/project.json` rather than a reshaping of the project.
  */
 export interface IndexEntryV3 {
+  /** Last actually READ SSH snapshot, machine-local. Distinguishes shared nodes
+   * deleted by another client from never-shared local additions. Not a write ack:
+   * remote writes may be optimistically acknowledged before transmission. */
+  sshBaseline?: { rev: number; ids: string[] }
   /**
    * THE project id — this machine's, and the only authority for it. It is minted here (a new
    * project, or `probeFolder`'s adoption of a folder) and never read back out of the shared

--- a/src/core/workspace-store.test.ts
+++ b/src/core/workspace-store.test.ts
@@ -809,6 +809,57 @@ describe('ssh mirror guarantee (unmirrored retry)', () => {
 // inflation (refresh seeded our counter from the remote lineage) made the empty canvas win every
 // later reconcile. These tests pin the lineage rules that prevent it.
 describe('ssh lineage safety', () => {
+  it('does not erase a local undo while reading back its own deletion write', async () => {
+    const { files, io } = cwdIO()
+    const store = new WorkspaceStore(io)
+    const a = project().nodes[0]
+    const b = { ...a, id: 'undo-node' }
+    const p = project({ id: 'ps', ssh: sshConn, nodes: [a, b] })
+    await store.save(ws([p]))
+    await store.refreshSshProject('ps')
+    await store.save(ws([{ ...p, nodes: [a] }]))
+    await store.save(ws([p])) // undo BEFORE a poll confirms the deletion write
+    expect(JSON.parse(files[sshConn.remoteCwd]).nodes.map((n: { id: string }) => n.id)).toEqual([a.id, b.id])
+  })
+  it('does not rescue a node another client deleted, including after a restart', async () => {
+    const { files, io } = cwdIO()
+    const store = new WorkspaceStore(io)
+    const a = project().nodes[0]
+    const b = { ...a, id: 'deleted-elsewhere' }
+    const p = project({ id: 'ps', ssh: sshConn, nodes: [a, b] })
+    await store.save(ws([p]))
+    await store.refreshSshProject('ps') // actually read/confirm the shared baseline
+    expect(files[sshConn.remoteCwd]).not.toContain('sshBaseline')
+    const remote = JSON.parse(files[sshConn.remoteCwd])
+    files[sshConn.remoteCwd] = JSON.stringify({ ...remote, rev: remote.rev + 1, nodes: [a] })
+    const restarted = new WorkspaceStore(io)
+    await restarted.load()
+    const adopted = await restarted.refreshSshProject('ps')
+    expect(adopted?.nodes.map((n) => n.id)).toEqual([a.id])
+    await restarted.refreshSshProject('ps')
+    expect(JSON.parse(files[sshConn.remoteCwd]).nodes.map((n: { id: string }) => n.id)).toEqual([a.id])
+  })
+  it('propagates remote deletion even when local revision is ahead, preserving a new local node', async () => {
+    const { files, io } = cwdIO()
+    const store = new WorkspaceStore(io)
+    const a = project().nodes[0]
+    const b = { ...a, id: 'deleted-elsewhere' }
+    const c = { ...a, id: 'local-new' }
+    const p = project({ id: 'ps', ssh: sshConn, nodes: [a, b] })
+    await store.save(ws([p]))
+    await store.refreshSshProject('ps')
+    const baseline = JSON.parse(files[sshConn.remoteCwd])
+    // Offline local edits advance cache without advancing the observed remote baseline.
+    io.write = async () => false
+    io.read = async () => ({ status: 'error' as never })
+    await store.save(ws([{ ...p, nodes: [a, b, c] }]))
+    await store.save(ws([{ ...p, name: 'edited', nodes: [a, b, c] }]))
+    files[sshConn.remoteCwd] = JSON.stringify({ ...baseline, rev: baseline.rev + 1, nodes: [a] })
+    io.read = async () => ({ status: 'ok', content: files[sshConn.remoteCwd] })
+    io.write = async (_id, _ssh, content) => { files[sshConn.remoteCwd] = content; return true }
+    const merged = await store.refreshSshProject('ps')
+    expect(merged?.nodes.map((n) => n.id)).toEqual([a.id, c.id])
+  })
   const sshConn = { server: { host: 'h', user: 'u' } as any, remoteCwd: '~/app' }
 
   /** A populated remote project file from ANOTHER lineage (different project id). */

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -929,6 +929,7 @@ export class WorkspaceStore {
     for (const entry of index.entries) {
       const previous = this.index?.entries.find((candidate) => candidate.id === entry.id)
       entry.localApprovalId = previous?.localApprovalId || randomUUID()
+      if (entry.ssh && previous?.sshBaseline) entry.sshBaseline = previous.sshBaseline
     }
 
     // The settings overlay / ssh settings cache ride every index write, like `localExec` and
@@ -1255,10 +1256,11 @@ export class WorkspaceStore {
     const e = this.index?.entries.find((x) => x.id === projectId && x.ssh)
     if (!e?.ssh || !this.remoteIO) return null
     const revBefore = e.cache?.rev
+    const baselineBefore = JSON.stringify(e.sshBaseline)
     const adopted = await this.reconcileSsh(e, opts?.pushIfStanding ?? true)
     // Persist the index only when the reconcile moved something — a quiet poll must not churn
     // workspace.json every tick.
-    if (adopted || e.cache?.rev !== revBefore) {
+    if (adopted || e.cache?.rev !== revBefore || JSON.stringify(e.sshBaseline) !== baselineBefore) {
       await writeAtomic(this.indexPath, JSON.stringify(this.index))
     }
     return adopted
@@ -1695,8 +1697,9 @@ export class WorkspaceStore {
       if (parsed?.version === 1 && Array.isArray(parsed.nodes)) remote = parsed
     } catch { /* corrupt server file — our cache is the only readable copy; it is written as-is */ }
     if (!remote || remote.id !== e.cache.id) return null
+    const removed = this.observeRemoteNodes(e, remote, !this.isOwnMirrorContent(e.id, res.content))
     const rescued = this.rescuableNodes(e.id, e.cache.nodes, remote.nodes)
-    if (!rescued.length) return null
+    if (!rescued.length && !removed) return null
     // The merged set must outrank both sides, or the next reconcile could rev-decide it away.
     e.cache = {
       ...e.cache,
@@ -1722,6 +1725,26 @@ export class WorkspaceStore {
     const cleared = this.clearedNodes.get(projectId)
     const missing = nodesMissingFrom(ours, theirs)
     return cleared ? missing.filter((n) => !cleared.has(n.id)) : missing
+  }
+
+  /** A newer observed snapshot's omissions are deletions, not local additions to
+   * rescue. Failed reads/old snapshots never advance this baseline. */
+  private observeRemoteNodes(e: IndexEntryV3, remote: ProjectFileV1, applyDeletions = true): boolean {
+    if (!e.cache || remote.id !== e.cache.id) return false
+    const old = e.sshBaseline
+    const valid = old && Number.isSafeInteger(old.rev) && Array.isArray(old.ids) &&
+      old.ids.every((id) => typeof id === 'string')
+    if (valid && remote.rev < old.rev) return false
+    const ids = new Set(remote.nodes.map((n) => n.id))
+    let removed = false
+    if (applyDeletions && valid && remote.rev > old.rev) {
+      const shared = new Set(old.ids)
+      const nodes = e.cache.nodes.filter((n) => !shared.has(n.id) || ids.has(n.id))
+      removed = nodes.length !== e.cache.nodes.length
+      if (removed) e.cache = { ...e.cache, nodes }
+    }
+    e.sshBaseline = { rev: remote.rev, ids: [...ids] }
+    return removed
   }
 
   /** Record the nodes a save removed from an ssh cache (see `clearedNodes`). */
@@ -1775,9 +1798,15 @@ export class WorkspaceStore {
       // said nothing new: the cache stands, and an owed mirror still pushes below. Matching by
       // exact bytes keeps the genuine-external-edit path untouched (any other writer's file —
       // a phone append, another machine's save — hashes differently).
-      if (remote && this.isOwnMirrorContent(e.id, res.content)) remote = null
+      if (remote && this.isOwnMirrorContent(e.id, res.content)) {
+        // Record confirmed delivery, but don't apply an older own write over local edits.
+        if (!e.sshBaseline || remote.rev >= e.sshBaseline.rev)
+          e.sshBaseline = { rev: remote.rev, ids: remote.nodes.map((n) => n.id) }
+        remote = null
+      }
     }
     this.reconciled.add(e.id)
+    const removedRemote = remote ? this.observeRemoteNodes(e, remote) : false
     const cacheRev = e.cache?.rev ?? 0
     const cacheNodes = e.cache?.nodes.length ?? 0
     const sameLineage = !e.cache || !remote || remote.id === e.cache.id
@@ -1802,7 +1831,7 @@ export class WorkspaceStore {
     // `clearedNodes` holds the ids this run removed, and `rescuableNodes` never brings those back,
     // so a real clear still travels. The remote half of the guard is untouched: an empty REMOTE with
     // a higher rev is the user clearing the canvas on another machine and still wins by rev.
-    const mergeable = sameLineage && !!e.cache && !!remote && remote.nodes.length > 0
+    const mergeable = sameLineage && !!e.cache && !!remote && (remote.nodes.length > 0 || removedRemote)
     if (remote && remoteWins) {
       let adopted = remote.id === e.id ? remote : { ...remote, id: e.id }
       let owed = false
@@ -1814,6 +1843,7 @@ export class WorkspaceStore {
         }
       }
       e.cache = adopted
+      e.sshBaseline = { rev: remote.rev, ids: remote.nodes.map((n) => n.id) }
       e.name = adopted.name
       e.color = adopted.color
       this.revs.set(e.id, adopted.rev)
@@ -1834,7 +1864,7 @@ export class WorkspaceStore {
     let merged: Project | null = null
     if (mergeable && e.cache && remote) {
       const rescued = this.rescuableNodes(e.id, e.cache.nodes, remote.nodes)
-      if (rescued.length) {
+      if (rescued.length || removedRemote) {
         e.cache = { ...e.cache, nodes: [...e.cache.nodes, ...rescued], rev: Math.max(cacheRev, remote.rev) + 1 }
         this.revs.set(e.id, e.cache.rev)
         this.unmirrored.add(e.id) // the merged set must land on the server

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -287,6 +287,7 @@ import {
   writeAgentHtml
 } from './media-protocol'
 import { initPlatform, platform } from '../core/platform'
+import { SubagentReplay } from '../core/subagent-replay'
 import { electronPlatform } from './platform-electron'
 import { wirePeerRegistry } from './peer-registry'
 import { WEBGL_CONTEXT_CAP_DESKTOP } from '../shared/webgl'
@@ -2160,6 +2161,8 @@ app.whenReady().then(async () => {
    * the next prompt. The result proves the ask settled; `working` is the honest next state (Claude
    * carries on with "User declined to answer questions"), and any real event corrects it anyway.
    */
+  const subagentReplay = new SubagentReplay()
+  corePlatform.handle(IPC.agentSubagentSnapshot, () => subagentReplay.snapshot())
   const onToolResult = (sessionId: string): void => {
     let nodeId: string | undefined
     for (const [nid, sid] of nodeContextSession) if (sid === sessionId) nodeId = nid
@@ -2188,6 +2191,7 @@ app.whenReady().then(async () => {
       toolUseId: n.toolUseId,
       result: n.result
     } satisfies NormalizedAgentEvent
+    subagentReplay.record(taskDoneEvent)
     sendToMain(IPC.agentStatus, taskDoneEvent)
     recordAgentEvent(taskDoneEvent)
     subagentTail.finish(n.toolUseId)
@@ -2462,6 +2466,7 @@ app.whenReady().then(async () => {
   // and the mobile-facing mirror. Named so the deterministic-approval answer handler below can reuse
   // it for the optimistic flip.
   const emitAgentStatus = (e: NormalizedAgentEvent): void => {
+    subagentReplay.record(e)
     // Record FIRST: recordAgentEvent computes the stash-priority classification and returns the
     // event ENRICHED for a needs-you edge (a question strips its pendingId), so the canvas keys off
     // the same single source of truth as the mirror/phone. Then broadcast the enriched event.

--- a/src/main/media-protocol.ts
+++ b/src/main/media-protocol.ts
@@ -4,6 +4,7 @@
 import { createReadStream, mkdirSync, writeFileSync, promises as fsp } from 'fs'
 import { join, normalize, sep } from 'path'
 import { app, protocol } from 'electron'
+import { mediaRange } from '../core/media-range'
 
 export const MEDIA_SCHEME = 'nt-media'
 
@@ -78,6 +79,11 @@ export function allowMediaPath(absPath: string): string {
   const norm = normalize(absPath)
   allowed.add(norm)
   return mediaUrlFor(norm)
+}
+
+/** Session-allowlisted media must retain its backing file for subsequent seeks. */
+export function isMediaPathAllowed(absPath: string): boolean {
+  return allowed.has(normalize(absPath))
 }
 
 /** The per-session directory holding agent-authored HTML (served under a restrictive CSP). */
@@ -163,19 +169,15 @@ export function initMediaProtocol(): void {
     }
     // Agent-authored HTML gets a restrictive CSP; video/image files get none (unchanged).
     const isAgentHtml = abs.startsWith(agentWebDir() + sep)
-    const range = req.headers.get('range')
-    const m = range && /bytes=(\d*)-(\d*)/.exec(range)
-    if (m) {
-      const start = m[1] ? parseInt(m[1], 10) : 0
-      let end = m[2] ? parseInt(m[2], 10) : size - 1
-      // Unsatisfiable range → 416 (NaN/negative start or start past EOF).
-      if (!Number.isFinite(start) || start < 0 || start >= size) {
-        return new Response('Range Not Satisfiable', {
-          status: 416,
-          headers: { 'Content-Range': `bytes */${size}` }
-        })
-      }
-      end = Math.min(end, size - 1)
+    const range = mediaRange(req.headers.get('range'), size)
+    if (range === 'unsatisfiable') {
+      return new Response('Range Not Satisfiable', {
+        status: 416,
+        headers: { 'Content-Range': `bytes */${size}` }
+      })
+    }
+    if (range) {
+      const { start, end } = range
       const stream = createReadStream(abs, { start, end })
       stream.on('error', () => stream.destroy())
       const headers: Record<string, string> = {

--- a/src/main/media-range-protocol.test.ts
+++ b/src/main/media-range-protocol.test.ts
@@ -1,0 +1,31 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  dataDir: '', handler: undefined as ((request: Request) => Promise<Response>) | undefined
+}))
+vi.mock('electron', () => ({
+  app: { getPath: () => state.dataDir },
+  protocol: { handle: (_scheme: string, handler: (request: Request) => Promise<Response>) => { state.handler = handler } }
+}))
+import { allowMediaPath, initMediaProtocol } from './media-protocol'
+
+afterEach(async () => { if (state.dataDir) await rm(state.dataDir, { recursive: true, force: true }); state.dataDir = '' })
+
+it('serves suffix bytes and rejects reversed ranges through the actual media handler', async () => {
+  state.dataDir = await mkdtemp(join(tmpdir(), 'nt-range-handler-'))
+  const file = join(state.dataDir, 'sample.bin')
+  await writeFile(file, '0123456789')
+  const url = allowMediaPath(file)
+  initMediaProtocol()
+  const suffix = await state.handler!(new Request(url, { headers: { Range: 'bytes=-3' } }))
+  expect(suffix.status).toBe(206)
+  expect(suffix.headers.get('Content-Range')).toBe('bytes 7-9/10')
+  expect(suffix.headers.get('Content-Length')).toBe('3')
+  expect(await suffix.text()).toBe('789')
+  const reversed = await state.handler!(new Request(url, { headers: { Range: 'bytes=8-2' } }))
+  expect(reversed.status).toBe(416)
+  expect(reversed.headers.get('Content-Range')).toBe('bytes */10')
+})

--- a/src/main/remote-ssh/ssh-project.ts
+++ b/src/main/remote-ssh/ssh-project.ts
@@ -20,7 +20,7 @@ import { removeAtomic, renameAtomic } from '../../core/fs-atomic'
 import { findExecutableSync, shellPathNow } from '../../core/exec-path'
 import { isSafeRemoteHome } from '../../core/remote-safety'
 import { mediaCachePruneList, remoteMediaCacheName } from '../../core/remote-ssh/media-cache'
-import { allowMediaPath } from '../media-protocol'
+import { allowMediaPath, isMediaPathAllowed } from '../media-protocol'
 import { remoteAccountConfigDir, isSupportedClaudeVersion } from '../../core/claude-accounts-core'
 import type { PushGrant } from '../../core/push-grants'
 import { REMOTE_GRANT_SCAN_CMD, parseRemoteGrants } from '../../core/remote-push-grants'
@@ -1126,6 +1126,7 @@ export class SshProjectManager {
         if (code !== 'ENOENT') throw error
       }
       if (Number.isFinite(remoteSize) && remoteSize >= 0 && cachedSize === remoteSize) {
+        allowMediaPath(dest)
         return { ok: true, localPath: dest }
       }
       await fs.mkdir(cacheDir, { recursive: true })
@@ -1144,6 +1145,7 @@ export class SshProjectManager {
       } finally {
         await removeScpPart(partPath)
       }
+      allowMediaPath(dest)
       void this.pruneMediaCache(cacheDir, path.basename(dest))
       return { ok: true, localPath: dest }
     } catch {
@@ -1151,16 +1153,17 @@ export class SshProjectManager {
     }
   }
 
-  /** Best-effort, bounded cache: keep the newest MEDIA_CACHE_KEEP entries. An evicted entry that
-   *  is still playing in an open node stops being seekable, acceptable for a 20-deep cache of a
-   *  convenience copy; the node re-fetches on next open. */
+  /** Soft bound: session-allowlisted files stay available for seeking. Older sessions'
+   * files are eligible for eviction; opening >20 files can exceed the cap until quit. */
   private async pruneMediaCache(cacheDir: string, except: string): Promise<void> {
     try {
       const names = (await fs.readdir(cacheDir)).filter((n) => !n.endsWith('.part'))
       const entries = await Promise.all(
         names.map(async (n) => ({ name: n, mtimeMs: (await fs.stat(path.join(cacheDir, n))).mtimeMs }))
       )
-      for (const n of mediaCachePruneList(entries, except)) {
+      const pinned = new Set(names.filter((n) => isMediaPathAllowed(path.join(cacheDir, n))))
+      for (const n of mediaCachePruneList(entries, except, undefined, pinned)) {
+        if (isMediaPathAllowed(path.join(cacheDir, n))) continue
         await fs.rm(path.join(cacheDir, n), { force: true }).catch(() => {})
       }
     } catch {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import { IPC } from '../shared/ipc'
+import { subscribeWithSnapshot } from '../shared/agents/subscribe-with-snapshot'
 import { resolveUiScale } from '../shared/ui-scale'
 import type {
   CanvasMutation,
@@ -757,11 +758,11 @@ const api: NodeTerminalApi = {
     ipcRenderer.on(IPC.agentUnreadClear, handler)
     return () => ipcRenderer.removeListener(IPC.agentUnreadClear, handler)
   },
-  onAgentStatus: (listener) => {
-    const handler = (_e: unknown, payload: Parameters<typeof listener>[0]) => listener(payload)
+  onAgentStatus: (listener) => subscribeWithSnapshot((deliver) => {
+    const handler = (_e: unknown, payload: Parameters<typeof listener>[0]) => deliver(payload)
     ipcRenderer.on(IPC.agentStatus, handler)
     return () => ipcRenderer.removeListener(IPC.agentStatus, handler)
-  },
+  }, () => ipcRenderer.invoke(IPC.agentSubagentSnapshot), listener),
   reportHibernated: (nodeId, on) => ipcRenderer.send(IPC.agentHibernated, { nodeId, on }),
   onAgentWake: (listener) => {
     const handler = (_e: unknown, nodeId: string) => listener(nodeId)

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -14,6 +14,8 @@ import {
   type RpcMessage
 } from '../../shared/rpc'
 import { IPC } from '../../shared/ipc'
+import { subscribeWithSnapshot } from '../../shared/agents/subscribe-with-snapshot'
+import type { NormalizedAgentEvent } from '../../shared/agents/normalize'
 import type { GitHubControlApi, GitHubIssuesApi } from '../../shared/github-issues'
 import {
   UNKNOWN_CLAUDE_CLI_CAPS,
@@ -643,7 +645,9 @@ export function buildAgentApi(
   | 'onAgentRenameNode'
 > {
   return {
-    onAgentStatus: (listener) => client.subscribe(IPC.agentStatus, listener as Listener),
+    onAgentStatus: (listener) => subscribeWithSnapshot<NormalizedAgentEvent>(
+      (deliver) => client.subscribe(IPC.agentStatus, deliver as Listener),
+      () => client.request(IPC.agentSubagentSnapshot) as Promise<NormalizedAgentEvent[]>, listener),
     // REAL forward: the Server Edition writes its own agent-status mirror, and the phone reads it
     // over its SSH browse path — a browser canvas hibernating a node must reach that file too.
     reportHibernated: (nodeId, on) => {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -70,6 +70,7 @@ import {
   type SshConnectFn
 } from '../lib/sshAttachments'
 import { terminalKey } from '../terminal/terminal-config'
+import { CanvasDeletions } from '../lib/canvasDeletions'
 import {
   setWebglGesture,
   setWebglZoom,
@@ -534,7 +535,7 @@ import {
   nodeSshFor,
   createVideoNode,
   createWebNode,
-  isVideoFile,
+  isMediaFile,
   duplicateNode,
   flowToNodeStates,
   addSelectionToGroup,
@@ -2533,13 +2534,17 @@ export function Canvas() {
   }, [])
 
   // ---- persistence helpers ----
+  const canvasDeletions = useRef(new CanvasDeletions())
   const commitActiveToStore = useCallback(() => {
     const id = useProjects.getState().activeProjectId
     // Epoch pairing: only commit while the nodes React Flow holds belong to the ACTIVE project.
     // The normal switch flow still commits — every caller commits BEFORE `setActive`, while the two
     // ids still agree — but an autosave timer armed under the previous project now skips instead of
     // writing its nodes under the new project's id (field bug 2026-08-10).
-    if (canCommitCanvas(nodesProjectIdRef.current, id))
+    if (canCommitCanvas(nodesProjectIdRef.current, id)) {
+      canvasDeletions.current.record(id,
+        useProjects.getState().getProject(id)?.nodes.map((n) => n.id) ?? [],
+        nodesRef.current.map((n) => n.id))
       useProjects
         .getState()
         .commitCanvas(
@@ -2549,6 +2554,7 @@ export function Canvas() {
           linkEdgesRef.current.map((e) => ({ id: e.id, source: e.source, target: e.target })),
           controlEdgesRef.current.map((e) => ({ id: e.id, source: e.source, target: e.target }))
         )
+    }
   }, [])
 
   const writeDisk = useCallback(async () => {
@@ -2677,6 +2683,8 @@ export function Canvas() {
   useEffect(() => {
     return api.workspace.onExternalChange((project) => {
       const { activeProjectId: current } = useProjects.getState()
+      project = canvasDeletions.current.filter(project,
+        project.id === current ? nodesRef.current.map((n) => n.id) : undefined)
       if (project.id !== current) {
         // Background project: adopt silently — it reloads into React Flow on next switch.
         useProjects.getState().replaceProject(project)
@@ -3192,6 +3200,12 @@ export function Canvas() {
       const snapped = snapSettings.snapToGrid
         ? snapResizeChanges(managed, nodesRef.current, snapSettings.gridSize || GRID)
         : managed
+      const removed = snapped.filter((c) => c.type === 'remove').map((c) => c.id)
+      if (removed.length && nodesProjectIdRef.current) {
+        const ids = new Set(removed)
+        canvasDeletions.current.record(nodesProjectIdRef.current,
+          removed, nodesRef.current.filter((n) => !ids.has(n.id)).map((n) => n.id))
+      }
       onNodesChange(snapped)
       if (snapped.some((c) => c.type !== 'select')) markDirty()
     },
@@ -3932,7 +3946,7 @@ export function Canvas() {
       setNodes((ns) => [
         ...ns.map((n) => (n.selected ? { ...n, selected: false } : n)),
         {
-          ...(isVideoFile(filePath)
+          ...(isMediaFile(filePath)
             ? createVideoNode(ns.length, filePath, center ?? viewCenter(), sshFs)
             : createEditorNode(ns.length, filePath, center ?? viewCenter(), sshFs)),
           selected: true
@@ -11891,7 +11905,8 @@ export function Canvas() {
             an.start(e.toolUseId, {
               parentNodeId: e.nodeId,
               type: e.subagentType,
-              label: e.taskLabel
+              label: e.taskLabel,
+              startedAt: e.subagentStartedAt
             })
           }
           break
@@ -11902,7 +11917,7 @@ export function Canvas() {
               tokens: e.tokens,
               toolUses: e.toolUses,
               result: e.result
-            })
+            }, e.nodeId)
           break
         case 'background-task':
           // A background shell task runs INSIDE the CLI process, so the `/exit` Eco hibernation

--- a/src/renderer/components/kanban/ModalTerminal.tsx
+++ b/src/renderer/components/kanban/ModalTerminal.tsx
@@ -38,6 +38,7 @@ import {
   SHIFT_ENTER_SEQ,
   CO_ATTACH_MOUSE_SEQ
 } from '../../terminal/terminal-config'
+import { installImeGuard } from '../../terminal/ime-guard'
 import { useXtermVisualSettings } from '../../terminal/useXtermVisualSettings'
 import {
   owningProjectId,
@@ -175,6 +176,7 @@ export function ModalTerminal({ nodeId, spawn, searchOpen, onCloseSearch }: Moda
     // view of one session, and a card that renders it in different colours reads as a different
     // terminal. (It used to hardcode its own background, which is exactly what happened.)
     const term = new Terminal(xtermOptionsFromSettings(s))
+    installImeGuard(term)
     // Without a handler xterm answers an OSC 8 click with a window.confirm — the one surface
     // where this session's links would prompt instead of opening like the canvas node's.
     term.options.linkHandler = createOsc8LinkHandler((uri) =>

--- a/src/renderer/lib/canvasDeletions.test.ts
+++ b/src/renderer/lib/canvasDeletions.test.ts
@@ -1,0 +1,13 @@
+import { expect, it } from 'vitest'
+import type { Project } from '@shared/types'
+import { CanvasDeletions } from './canvasDeletions'
+
+it('rejects stale resurrection after an optimistic commit, but permits undo and new ids', () => {
+  const memory = new CanvasDeletions()
+  const project = { id: 'p', nodes: [{ id: 'a' }, { id: 'b' }, { id: 'new' }] } as Project
+  memory.record('p', ['a', 'b'], ['a'])
+  expect(memory.filter(project).nodes.map((n) => n.id)).toEqual(['a', 'new'])
+  expect(memory.filter({ ...project, id: 'other' })).toBeDefined()
+  memory.record('p', ['a'], ['a', 'b'])
+  expect(memory.filter(project)).toBe(project)
+})

--- a/src/renderer/lib/canvasDeletions.ts
+++ b/src/renderer/lib/canvasDeletions.ts
@@ -1,0 +1,24 @@
+import type { Project } from '@shared/types'
+
+/** Session-local deletion memory, independent of the optimistic projects-store
+ * baseline. An old external snapshot must not turn a just-deleted id into an
+ * apparently new addition. Explicit local undo/recreation restores that id. */
+export class CanvasDeletions {
+  private byProject = new Map<string, Set<string>>()
+
+  record(projectId: string, before: Iterable<string>, after: Iterable<string>): void {
+    const live = new Set(after)
+    const deleted = this.byProject.get(projectId) ?? new Set<string>()
+    for (const id of before) if (!live.has(id)) deleted.add(id)
+    for (const id of live) deleted.delete(id)
+    this.byProject.set(projectId, deleted)
+  }
+
+  filter(project: Project, live?: Iterable<string>): Project {
+    const deleted = this.byProject.get(project.id)
+    if (!deleted?.size) return project
+    if (live) for (const id of live) deleted.delete(id)
+    const nodes = project.nodes.filter((n) => !deleted.has(n.id))
+    return nodes.length === project.nodes.length ? project : { ...project, nodes }
+  }
+}

--- a/src/renderer/lib/filesNode.ts
+++ b/src/renderer/lib/filesNode.ts
@@ -16,7 +16,7 @@
  * the filesystem-owning CORE, not the viewer, which is the rule `terminal/file-links.ts` already
  * implements and the one to copy.
  */
-import { isVideoFile } from '../state/workspace'
+import { isMediaFile } from '../state/workspace'
 import { opensInEditor } from './openTarget'
 import { folderTitle } from './explorerCreate'
 
@@ -188,6 +188,6 @@ export function filterEntries<T extends { name: string }>(entries: T[], query: s
  */
 export function fileOpenTarget(path: string, opts: { remote?: boolean } = {}): 'canvas' | 'os' {
   if (opts.remote) return 'canvas'
-  if (isVideoFile(path)) return 'canvas'
+  if (isMediaFile(path)) return 'canvas'
   return opensInEditor(path) ? 'canvas' : 'os'
 }

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -62,6 +62,7 @@ import {
   CO_ATTACH_MOUSE_SEQ,
   type SessionLife
 } from '../terminal/terminal-config'
+import { installImeGuard } from '../terminal/ime-guard'
 import { useXtermVisualSettings } from '../terminal/useXtermVisualSettings'
 import { ensureProjectLaunchInfo } from '../state/projectLaunchInfo'
 import { loseWebglContexts, registerWebglClient, type WebglClientHandle } from '../terminal/webgl-budget'
@@ -1960,6 +1961,7 @@ export function TerminalNode({
     // Appearance comes from ONE place, shared with the kanban card modal's viewer of this same
     // session (`ModalTerminal`) — see `xtermOptionsFromSettings`.
     const term = parked?.term ?? new Terminal(xtermOptionsFromSettings(s))
+    installImeGuard(term)
     // Only on a FRESH instance: a parked terminal already carries the table, and the buffer it kept
     // alive was measured with it — re-registering under a live buffer buys nothing.
     if (!parked) activateUnicode11(term)

--- a/src/renderer/nodes/VideoNode.tsx
+++ b/src/renderer/nodes/VideoNode.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Handle, NodeResizer, Position, useReactFlow, type NodeProps } from '@xyflow/react'
 import { NODE_MIN_SIZES } from '../lib/nodeSizing'
 import type { CanvasNode } from '../state/workspace'
+import { isAudioFile } from '../state/workspace'
 import { useProjects } from '../state/projects'
 
 /**
@@ -20,9 +21,12 @@ export default function VideoNode({ id, data, selected }: NodeProps<CanvasNode>)
   const filePath = (data.filePath as string) ?? ''
   const fileName = filePath.split('/').pop() || 'video'
   const remote = !!data.sshFs
+  const Player = isAudioFile(filePath) ? 'audio' : 'video'
 
   useEffect(() => {
     if (!filePath) return
+    setSrc('')
+    setError('')
     let alive = true
     if (remote) {
       // Remote fetch can take a while for a large file — say what the wait is.
@@ -95,9 +99,9 @@ export default function VideoNode({ id, data, selected }: NodeProps<CanvasNode>)
       </div>
 
       <div className="editor-node__body">
-        <div className="editor-node__image nodrag nowheel">
+        <div className="editor-node__image nodrag nowheel nopan">
           {src ? (
-            <video
+            <Player
               src={src}
               controls
               preload="metadata"

--- a/src/renderer/state/agentNodes.test.ts
+++ b/src/renderer/state/agentNodes.test.ts
@@ -2,6 +2,19 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { useAgentNodes } from './agentNodes'
 
 describe('loop node overrides vs per-turn fan-out', () => {
+  it('recovers an end without a start and ignores a replayed start after completion', () => {
+    const s = useAgentNodes.getState()
+    s.finish('lost-start', { result: 'done', durationMs: 500 }, 'parent')
+    expect(useAgentNodes.getState().byId['lost-start']).toMatchObject({ parentNodeId: 'parent', state: 'done', result: 'done' })
+    s.start('lost-start', { parentNodeId: 'parent' })
+    expect(useAgentNodes.getState().byId['lost-start'].state).toBe('done')
+  })
+  it('keeps the original replay timestamp and ignores repeated starts', () => {
+    const s = useAgentNodes.getState()
+    s.start('replay', { parentNodeId: 'parent', startedAt: 100 })
+    s.start('replay', { parentNodeId: 'parent' })
+    expect(useAgentNodes.getState().byId['replay'].startedAt).toBe(100)
+  })
   beforeEach(() => {
     useAgentNodes.setState({ byId: {}, activityById: {}, positions: {}, sizes: {}, expanded: {} })
   })

--- a/src/renderer/state/agentNodes.ts
+++ b/src/renderer/state/agentNodes.ts
@@ -64,8 +64,8 @@ interface AgentNodesState {
   toggleExpanded(id: string): void
   /** Drop a card's dragged position + resized size, returning it to its laid-out spot. */
   resetPlacement(id: string): void
-  start(toolUseId: string, viz: Omit<SubagentViz, 'state' | 'startedAt'>): void
-  finish(toolUseId: string, result: SubagentResult): void
+  start(toolUseId: string, viz: Omit<SubagentViz, 'state' | 'startedAt'> & { startedAt?: number }): void
+  finish(toolUseId: string, result: SubagentResult, parentNodeId?: string): void
   /** Append a chunk of the subagent's live transcript. */
   appendActivity(toolUseId: string, chunk: string): void
   /**
@@ -232,13 +232,15 @@ export const useAgentNodes = create<AgentNodesState>((set) => ({
     }),
 
   start: (toolUseId, viz) =>
-    set((s) => ({
-      byId: { ...s.byId, [toolUseId]: { ...viz, state: 'working', startedAt: Date.now() } }
+    set((s) => s.byId[toolUseId] ? s : ({
+      byId: { ...s.byId, [toolUseId]: { ...viz, state: 'working', startedAt: viz.startedAt ?? Date.now() } }
     })),
 
-  finish: (toolUseId, result) =>
+  finish: (toolUseId, result, parentNodeId) =>
     set((s) => {
-      const prev = s.byId[toolUseId]
+      const prev = s.byId[toolUseId] ?? (parentNodeId ? {
+        parentNodeId, state: 'working' as const, startedAt: Date.now() - (result.durationMs ?? 0)
+      } : undefined)
       if (!prev || prev.state === 'done') return s
       // Async subagents end via a <task-notification> that carries no timing stats — fall
       // back to the card's own elapsed time so the duration doesn't vanish on completion.

--- a/src/renderer/state/workspace.media.test.ts
+++ b/src/renderer/state/workspace.media.test.ts
@@ -3,11 +3,22 @@ import {
   createVideoNode,
   createWebNode,
   isVideoFile,
+  isAudioFile,
+  isMediaFile,
   nodeStatesToFlow,
   flowToNodeStates
 } from './workspace'
 
 describe('video/web nodes', () => {
+  it('routes audio as media, with the existing round-trippable video node kind', () => {
+    for (const path of ['/tmp/test.WAV', 'sound.mp3', 'voice.m4a', 'music.flac', 'a.opus', 'C:\\music\\voice.WAV']) {
+      expect(isAudioFile(path)).toBe(true)
+      expect(isMediaFile(path)).toBe(true)
+      const n = createVideoNode(0, path, undefined, true)
+      expect(nodeStatesToFlow(flowToNodeStates([n]))[0].data).toMatchObject({ filePath: path, sshFs: true })
+    }
+    expect(isMediaFile('notes.txt')).toBe(false)
+  })
   it('isVideoFile matches common video extensions, not images', () => {
     expect(isVideoFile('/a/b/clip.mp4')).toBe(true)
     expect(isVideoFile('/a/b/CLIP.WEBM')).toBe(true)
@@ -21,6 +32,14 @@ describe('video/web nodes', () => {
     expect(n.type).toBe('video')
     expect(n.data.filePath).toBe('/clips/demo.mp4')
     expect(n.data.title).toBe('demo.mp4')
+  })
+  it('repairs audio nodes persisted as editors by older builds', () => {
+    const state = flowToNodeStates([createVideoNode(0, '/tmp/old.wav', undefined, true)])[0]
+    state.kind = 'editor'
+    const repaired = nodeStatesToFlow([state])[0]
+    expect(repaired.type).toBe('video')
+    expect(repaired.id).toBe(state.id)
+    expect(repaired.data.sshFs).toBe(true)
   })
 
   it('createWebNode carries url or filePath', () => {

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -931,6 +931,16 @@ export function createEditorNode(
 }
 
 const VIDEO_EXTS = ['mp4', 'webm', 'mov', 'm4v', 'mkv', 'ogv', 'avi']
+const AUDIO_EXTS = ['mp3', 'wav', 'ogg', 'oga', 'opus', 'm4a', 'aac', 'flac', 'aif', 'aiff']
+
+export function isAudioFile(path: string): boolean {
+  return AUDIO_EXTS.includes(path.split('.').pop()?.toLowerCase() ?? '')
+}
+
+/** Audio reuses the persisted video/media node kind, never the UTF-8 editor. */
+export function isMediaFile(path: string): boolean {
+  return isVideoFile(path) || isAudioFile(path)
+}
 
 /** True when a path looks like a playable video file (by extension). */
 export function isVideoFile(path: string): boolean {
@@ -1897,7 +1907,9 @@ export function nodeStatesToFlow(states: CanvasNodeState[]): CanvasNode[] {
     return {
       id: n.id,
       // Default to 'terminal' for nodes saved before the kind field existed.
-      type: n.kind ?? 'terminal',
+      // Older builds opened audio as UTF-8 editors. Repair those persisted nodes
+      // on load, retaining their id/path/SSH provenance and canvas position.
+      type: n.kind === 'editor' && n.filePath && isAudioFile(n.filePath) ? 'video' : n.kind ?? 'terminal',
       ...((n.kind ?? 'terminal') === 'group' ? { dragHandle: '.group-node__label' } : {}),
       position: n.position,
       width: n.size.width,

--- a/src/renderer/terminal/ime-guard.test.ts
+++ b/src/renderer/terminal/ime-guard.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { installImeGuard } from './ime-guard'
+
+describe('xterm composition input ownership', () => {
+  it('blocks only the input fallback while composition owns the textarea', () => {
+    const input = vi.fn((_event: InputEvent) => true)
+    const helper = { isComposing: true, _isSendingComposition: false }
+    const core = { _compositionHelper: helper, _inputEvent: input }
+    const term = { _core: core }
+    installImeGuard(term as never)
+    installImeGuard(term as never) // parked terminal reattachment
+    const text = { inputType: 'insertText', data: '你好' } as InputEvent
+    expect(core._inputEvent(text)).toBe(false)
+    helper.isComposing = false
+    helper._isSendingComposition = true
+    expect(core._inputEvent(text)).toBe(false)
+    helper._isSendingComposition = false
+    core._inputEvent(text)
+    core._inputEvent(text) // intentional repeated text is never deduplicated
+    expect(input).toHaveBeenCalledTimes(2)
+    expect(input.mock.instances.every((self) => self === core)).toBe(true)
+  })
+})

--- a/src/renderer/terminal/ime-guard.ts
+++ b/src/renderer/terminal/ime-guard.ts
@@ -1,0 +1,25 @@
+import type { Terminal } from '@xterm/xterm'
+
+/** xterm 5.5's input fallback can emit the same text as its deferred composition
+ * finalizer when keyup precedes input. Let the composition helper be the sole
+ * writer while it owns the textarea. Do NOT deduplicate strings: repeated input
+ * is legitimate. Revalidate this private adapter against xterm when upgrading. */
+export function installImeGuard(term: Terminal): void {
+  type Core = {
+    _inputEvent: (event: InputEvent) => boolean
+    _compositionHelper?: { isComposing: boolean; _isSendingComposition: boolean }
+  }
+  const core = (term as unknown as { _core: Core })._core
+  if (guarded.has(core)) return
+  const input = core._inputEvent
+  if (typeof input !== 'function') throw new Error('Unsupported xterm input API')
+  core._inputEvent = function (event) {
+    const helper = this._compositionHelper
+    if (event.inputType === 'insertText' &&
+        (helper?.isComposing || helper?._isSendingComposition)) return false
+    return input.call(this, event)
+  }
+  guarded.add(core)
+}
+
+const guarded = new WeakSet<object>()

--- a/src/renderer/terminal/terminal-config.test.ts
+++ b/src/renderer/terminal/terminal-config.test.ts
@@ -55,6 +55,15 @@ const ev = (p: Partial<CopyShortcutEvent>): CopyShortcutEvent => ({
   ...p
 })
 
+describe('IME shortcut ownership', () => {
+  it('passes composition Enter through instead of submitting a newline shortcut', () => {
+    const enter = ev({ key: 'Enter', code: 'Enter', shiftKey: true })
+    expect(terminalKeyAction({ ...enter, isComposing: true }, false, false)).toBe('pass')
+    expect(terminalKeyAction({ ...enter, keyCode: 229 }, false, false)).toBe('pass')
+    expect(terminalKeyAction(enter, false, false)).not.toBe('pass')
+  })
+})
+
 describe('terminalKey (session-scope the node-keyed renderer-global maps)', () => {
   it('same session + node → the same key (stable across a park→remount)', () => {
     expect(terminalKey('local', 'abc')).toBe(terminalKey('local', 'abc'))

--- a/src/renderer/terminal/terminal-config.ts
+++ b/src/renderer/terminal/terminal-config.ts
@@ -708,6 +708,8 @@ export function createDataGate(write: (chunk: string) => void): DataGate {
 
 /** The subset of a KeyboardEvent the copy-shortcut decision looks at. */
 export interface CopyShortcutEvent {
+  isComposing?: boolean
+  keyCode?: number
   type: string
   key: string
   code: string
@@ -829,6 +831,7 @@ export function terminalKeyAction(
   registryOwns = false,
   isWindows: boolean = isWindowsPlatform()
 ): TerminalKeyAction {
+  if (e.isComposing || e.keyCode === 229) return 'pass'
   if (
     e.type === 'keydown' &&
     e.key === 'Enter' &&

--- a/src/server/agent-status.ts
+++ b/src/server/agent-status.ts
@@ -27,6 +27,7 @@ import { linkedClaudeConfigDirs } from '../core/claude-config-dir'
 import { isAsyncSubagentLaunch, grokRawFields, type NormalizedAgentEvent } from '../shared/agents/normalize'
 import { applyGrokHookSession } from '../core/grok-hook-session'
 import { IPC } from '../shared/ipc'
+import { SubagentReplay } from '../core/subagent-replay'
 import type { ServerPlatform } from './platform-server'
 
 /** The narrow surface of the hook server this module needs — injectable for tests. */
@@ -68,6 +69,8 @@ export function wireAgentStatus(
   opts: WireAgentStatusOptions = {}
 ): { contextTail: ContextTail; geminiContextTail: ContextTail } {
   const hooks = opts.hooks ?? hookServer
+  const subagentReplay = new SubagentReplay()
+  platform.handle(IPC.agentSubagentSnapshot, () => subagentReplay.snapshot())
   // nodeId → the agent session id of whichever hook-capable CLI runs in that node (claude's, and
   // since the grok branch below, grok's)
   const nodeContextSession = new Map<string, string>()
@@ -96,6 +99,7 @@ export function wireAgentStatus(
       toolUseId: n.toolUseId,
       result: n.result
     } satisfies NormalizedAgentEvent
+    subagentReplay.record(taskDoneEvent)
     platform.broadcast(IPC.agentStatus, taskDoneEvent)
     recordAgentEvent(taskDoneEvent)
     subagentTail.finish(n.toolUseId)
@@ -156,6 +160,7 @@ export function wireAgentStatus(
   })
 
   hooks.setListener((e) => {
+    subagentReplay.record(e)
     // Record FIRST: recordAgentEvent computes the stash-priority classification and returns the
     // event ENRICHED for a needs-you edge (a question strips its pendingId), so the browser canvas
     // keys off the same single source of truth as the mirror/phone. Then broadcast the enriched one.

--- a/src/shared/agents/normalize.ts
+++ b/src/shared/agents/normalize.ts
@@ -73,6 +73,8 @@ export interface NormalizedAgentEvent {
   // subagent
   toolUseId?: string
   subagentType?: string
+  /** Original start time when recovering an in-flight fan-out after renderer reload. */
+  subagentStartedAt?: number
   // grok StopCancelled only: normalized state-less so the mirror can make the session-aware badge
   // decision (a subagent cancellation must not end its parent session).
   cancelReason?:

--- a/src/shared/agents/subscribe-with-snapshot.test.ts
+++ b/src/shared/agents/subscribe-with-snapshot.test.ts
@@ -1,0 +1,42 @@
+import { expect, it, vi } from 'vitest'
+import { subscribeWithSnapshot } from './subscribe-with-snapshot'
+
+it('falls back to buffered live events when the snapshot is unsupported', async () => {
+  let live!: (e: string) => void
+  const delivered: string[] = []
+  const stop = subscribeWithSnapshot<string>(fn => { live = fn; return () => {} },
+    () => Promise.reject(new Error('unsupported')), event => delivered.push(event))
+  live('waiting')
+  await Promise.resolve()
+  live('done')
+  expect(delivered).toEqual(['waiting', 'done'])
+  stop()
+})
+
+it('discards a snapshot that settles after unsubscribe', async () => {
+  let finish!: (events: string[]) => void
+  const listener = vi.fn()
+  const stop = subscribeWithSnapshot<string>(() => () => {},
+    () => new Promise(resolve => { finish = resolve }), listener)
+  stop()
+  finish(['old-start'])
+  await Promise.resolve()
+  expect(listener).not.toHaveBeenCalled()
+})
+
+it('applies the snapshot before racing live events, and stops after unsubscribe', async () => {
+  let live!: (e: string) => void
+  let resolve!: (e: string[]) => void
+  const delivered: string[] = []
+  const off = vi.fn()
+  const unsubscribe = subscribeWithSnapshot<string>((fn) => { live = fn; return off },
+    () => new Promise((r) => { resolve = r }), (e) => delivered.push(e))
+  live('end')
+  resolve(['start'])
+  await Promise.resolve()
+  expect(delivered).toEqual(['start', 'end'])
+  unsubscribe()
+  live('ignored')
+  expect(delivered).toEqual(['start', 'end'])
+  expect(off).toHaveBeenCalledOnce()
+})

--- a/src/shared/agents/subscribe-with-snapshot.ts
+++ b/src/shared/agents/subscribe-with-snapshot.ts
@@ -1,0 +1,30 @@
+/** Subscribe before requesting a snapshot, then drain live events AFTER it. A
+ * late snapshot must never undo a newer finish/new-turn. Older servers without
+ * the snapshot channel simply fall back to the existing live stream. */
+export function subscribeWithSnapshot<T>(
+  subscribe: (listener: (event: T) => void) => () => void,
+  snapshot: () => Promise<T[]>,
+  listener: (event: T) => void
+): () => void {
+  let active = true
+  let pending = true
+  const queue: T[] = []
+  const off = subscribe((e) => {
+    if (!active) return
+    if (pending) queue.push(e)
+    else listener(e)
+  })
+  const finish = (events: T[]) => {
+    if (!active || !pending) return
+    pending = false
+    clearTimeout(timer)
+    for (const event of [...events, ...queue]) {
+      if (!active) break
+      listener(event)
+    }
+    queue.length = 0
+  }
+  const timer = setTimeout(() => finish([]), 5000)
+  void snapshot().then((events) => finish(Array.isArray(events) ? events : []), () => finish([]))
+  return () => { active = false; clearTimeout(timer); queue.length = 0; off() }
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -134,6 +134,7 @@ export const IPC = {
    *  Edition's browser tab has no raw input stream and keeps the heuristics. */
   canvasTrackpadGesture: 'canvas:trackpad-gesture',
   agentStatus: 'agent:status',
+  agentSubagentSnapshot: 'agent:subagent-snapshot',
   /** Renderer → main/server: answer a held Claude permission hook (deterministic approvals).
    *  Payload: `{ nodeId, pendingId, decision: 'allow'|'deny' }`; resolves boolean. See
    *  docs/hook-reply-approvals.md. */


### PR DESCRIPTION
## Context

Related to #680 (intentionally not auto-closing it).

Hi Enes! I'm a Python developer using nodeterm's SSH canvas. Thanks for maintaining the project. This is one consolidated draft PR with the local changes discussed in that issue.

The code and this description were produced with **gpt-6-astra, high reasoning effort**. Please bear with any mistakes in the AI-generated analysis. This is offered for review, with no expectation that you merge it; taking a different approach or declining it is completely fine.

## Important: duplicate input is not fully fixed

I still occasionally get duplicate text in a **local terminal, without SSH**. It seems less frequent after the attempted change, but it still happens. The IME guard below addresses one suspected overlapping-input path; it is a **partial mitigation, not a complete fix**. There is not yet a reliable minimal reproduction for the remaining duplication.

## Changes

- **IME input:** let xterm's composition helper own input while composition or its deferred finalizer is active, and pass composition key events through the shortcut layer. Apply the same guard to canvas and kanban terminals. Intentional repeated text is not deduplicated.
- **SSH canvas deletions:** persist a machine-local observed-node baseline so a newer remote deletion is not rescued from the local cache. Preserve local additions and undo; retain renderer deletion memory across optimistic commits.
- **Subagent cards:** add bounded host-side lifecycle replay and subscribe-before-snapshot ordering in both desktop and Server Edition bridges. Preserve original start times and recover an end event whose start was missed, without replaying permission/state alerts.
- **Audio routing:** open recognized audio as media with native audio controls, using the existing persisted node kind; repair legacy audio-as-editor nodes on load.
- **Media seeking:** handle suffix and invalid byte ranges, retain session-allowlisted remote media for later seeks, clear stale player state on source changes, and prevent playback gestures from panning the canvas.

## Validation

Tested on macOS with Node 22.23.2, based on upstream `f456e888` (0.3.4).

- Node and renderer TypeScript checks: passed.
- Production build, including the Codex relay: passed.
- Focused regression run: **12 files / 313 tests passed**.
- Full suite: **10,732 passed, 15 failed, 46 skipped**, plus **2 unhandled rejections**. This is not a clean full-suite result.
- The same 11 failures across six shell/tmux/account/session-client suites reproduced on unmodified upstream `f456e888`. The four additional failures and two unhandled rejections came from `pty-session-host.test.ts`; an isolated rerun on this branch passed all 34 tests, while a baseline rerun had two failures. These results indicate variability, not proof that the full suite is healthy.

## Limits and trade-offs

- The IME adapter depends on xterm 5.5 private fields and needs revalidation when xterm changes. Native IME event ordering and the remaining local duplication still need investigation.
- SSH reconciliation was checked with simulated remote IO, not a fresh two-host acceptance run. Other unpatched writers can still reintroduce deleted nodes.
- Subagent replay only covers events received by the current host process; it does not survive a host restart.
- Session-allowlisted media makes the cache limit a soft cap until app exit. Actual codec playback, seek gestures, and physical SSH transfers were not revalidated end to end.

Keeping this as a draft because of the unresolved input behavior and the non-green full-suite result.
