### PR TITLE
ci: cancel superseded PR runs with concurrency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   push:
     branches: [main]
 
+# Only PR runs may be cancelled: a cancelled merge_group run strands every PR queued
+# behind it, and a cancelled push-to-main run loses that commit's CI signal.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,12 @@ on:
     # Weekly re-scan so a newly-disclosed CVE in an unchanged dependency still surfaces.
     - cron: '17 4 * * 1'
 
+# Only PR runs may be cancelled: a cancelled merge_group run strands every PR queued
+# behind it, and a cancelled push-to-main run loses that commit's CodeQL baseline.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Least privilege: only CodeQL needs security-events:write to upload results.
 permissions:
   contents: read


### PR DESCRIPTION
@eneskirca some drive-by changes for the issues I noticed during my PR runs.

Neither workflow had a concurrency group, so force-pushing to a PR left the previous run burning runner minutes to completion instead of being replaced.

Both workflows also trigger on `merge_group` and on push to main, so `cancel-in-progress` is scoped to `pull_request` events only. Otherwise, cancelling a merge-queue run would strand every PR queued behind it waiting on a required check that will never report, and cancelling a `push-to-main` run would lose that commit's CI/CodeQL signal.