### PR TITLE
ci: skip electron-rebuild in the quality jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,19 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      # electron-rebuild (via postinstall) targets Electron's ABI, so vitest cannot load the
+      # binding it produces — the *.realtty / *.realtmux suites self-skip, and the Windows
+      # session-host tests only `import type`. Skip the compile; keep the two install effects
+      # that are actually load-bearing: patch-node-pty.mjs writes the markers
+      # src/main/node-pty-patch.test.ts asserts, and esbuild needs its platform binary linked.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Patch node-pty sources
+        run: node scripts/patch-node-pty.mjs
+
+      - name: Link esbuild platform binary
+        run: npm rebuild esbuild
 
       - name: Type check
         run: npm run typecheck
@@ -51,8 +62,19 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      # electron-rebuild (via postinstall) targets Electron's ABI, so vitest cannot load the
+      # binding it produces — the *.realtty / *.realtmux suites self-skip, and the Windows
+      # session-host tests only `import type`. Skip the compile; keep the two install effects
+      # that are actually load-bearing: patch-node-pty.mjs writes the markers
+      # src/main/node-pty-patch.test.ts asserts, and esbuild needs its platform binary linked.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Patch node-pty sources
+        run: node scripts/patch-node-pty.mjs
+
+      - name: Link esbuild platform binary
+        run: npm rebuild esbuild
 
       - name: Type check
         run: npm run typecheck


### PR DESCRIPTION
@eneskirca some drive-by changes for the issues I noticed during my PR runs.

`package.json's` postinstall runs `patch-node-pty.mjs` followed by `electron-rebuild -f -w node-pty,smart-whisper`, so every npm ci in CI does a full native compile of `node-pty` and `whisper.cpp`. 

E.g. on run `34057272144` that compile accounted for 220s of the 266s quality-windows job and 79s of the quality job.

That compiled output is never exercised by the test suite. electron-rebuild targets Electron's ABI, so a plain-node `vitest` run cannot load the resulting binding: the `*.realtty.test.ts` and `*.realtmux.test.ts` suites already self-skip for exactly this reason, the Windows job's session-host tests only `import type { IPty } from 'node-pty'` (erased at compile time), and `electron-vite` build keeps `node-pty` external anyway.

The only effect of the install step is `patch-node-pty.mjs`, which rewrites node-pty's C++ sources with the version-pinned markers `src/main/node-pty-patch.test.ts` asserts. 

Both quality jobs now run `npm ci --ignore-scripts`, then invoke the patch script directly, then `npm rebuild esbuild` (`esbuild`'s postinstall links its own platform binary and would otherwise be skipped). 
`release.yml` and `win-package-smoke.yml` are untouched, since those jobs ship or verify real native binaries.