### PR TITLE
fix(github-issues): persist settings edits so Approve can see them

### DIFF
--- a/src/renderer/components/settings/sections/GitHubIssuesSection.test.tsx
+++ b/src/renderer/components/settings/sections/GitHubIssuesSection.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GitHubAuthStatus, GitHubControlView } from '@shared/github-issues'
 import { useProjects } from '../../../state/projects'
+import { registerWorkspaceDirty } from '../../../state/workspaceDirty'
 import { SettingsSearchContext } from '../context'
 import { GitHubIssuesSection } from './GitHubIssuesSection'
 
@@ -44,6 +45,8 @@ describe('GitHubIssuesSection', () => {
   let host: HTMLElement
   let saveToken: ReturnType<typeof vi.fn>
   let status: ReturnType<typeof vi.fn>
+  let dirty: ReturnType<typeof vi.fn<() => void>>
+  let unregisterDirty: () => void
 
   const mount = async (query = ''): Promise<void> => {
     root = createRoot(host)
@@ -68,6 +71,8 @@ describe('GitHubIssuesSection', () => {
   beforeEach(async () => {
     host = document.createElement('div')
     document.body.appendChild(host)
+    dirty = vi.fn<() => void>()
+    unregisterDirty = registerWorkspaceDirty(dirty)
     saveToken = vi.fn(async () => viewWith({}))
     ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
       githubControl: {
@@ -109,6 +114,7 @@ describe('GitHubIssuesSection', () => {
   afterEach(() => {
     act(() => root.unmount())
     host.remove()
+    unregisterDirty()
   })
 
   it('clears the write-only token field after Save and never renders the stored token', async () => {
@@ -137,6 +143,46 @@ describe('GitHubIssuesSection', () => {
     expect(useProjects.getState().getProject('p1')?.kanban?.github?.columnMappings)
       .toContainEqual({ columnId: 'todo', label: 'workflow:ready' })
   })
+
+
+  // A board edit made here reaches `.nodeterm/project.json` only through the debounced save Canvas
+  // owns: the host reads the project from DISK (`workspaceStore.githubProject`), so an unsaved
+  // config makes `resolveProject` throw `invalid-configuration` and Approve fail.
+  it('persists a label edit through the workspace-dirty seam', async () => {
+    await mount()
+    const input = host.querySelector<HTMLInputElement>('#github-label-todo')!
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(input, 'workflow:ready')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(dirty).toHaveBeenCalled()
+  })
+
+  it('persists enabling and disabling GitHub issues', async () => {
+    await mount()
+    const toggle = host.querySelector<HTMLElement>('[aria-label="Include GitHub issues"]')!
+    await act(async () => { toggle.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    expect(useProjects.getState().getProject('p1')?.kanban?.github).toBeUndefined()
+    expect(dirty).toHaveBeenCalled()
+  })
+
+
+
+  it('reports an Approve failure beside the Approve button, not three rows below it', async () => {
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.githubControl.approve =
+      vi.fn(async () => { throw Object.assign(new Error('invalid-configuration'), { code: 'invalid-configuration' }) })
+    await mount()
+    const approve = [...host.querySelectorAll('button')]
+      .find((button) => button.textContent === 'Approve this machine')!
+    await act(async () => { approve.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    const message = [...host.querySelectorAll('[role="status"]')]
+      .find((element) => element.textContent?.includes('have not finished saving'))!
+    expect(message).toBeDefined()
+    // Same container as the button: the user sees the answer where they clicked.
+    expect(message.closest('div')?.parentElement?.contains(approve)).toBe(true)
+  })
+
 
   it('moves the single token control into Advanced when the GitHub CLI signs the user in', async () => {
     stub(viewWith({ activeProvider: 'gh', ghAuthenticated: true, tokenPresent: false }, true))

--- a/src/renderer/components/settings/sections/GitHubIssuesSection.tsx
+++ b/src/renderer/components/settings/sections/GitHubIssuesSection.tsx
@@ -6,6 +6,7 @@ import type {
   ProjectKanbanGitHub
 } from '@shared/github-issues'
 import { useProjects } from '../../../state/projects'
+import { markWorkspaceDirty } from '../../../state/workspaceDirty'
 import { SettingsSection } from '../SettingsSection'
 import { SearchableRow } from '../SearchableRow'
 import { useSettingsSearch } from '../context'
@@ -42,6 +43,7 @@ const ROWS = {
 const ENTRIES = Object.values(ROWS)
 
 type Confirmation = 'labels' | 'cache' | 'revoke' | null
+type NoticeRow = 'repository' | 'authentication' | 'data'
 
 function defaultGitHub(columns: Array<{ id: string; title: string }>): ProjectKanbanGitHub {
   return {
@@ -61,6 +63,11 @@ function messageFor(error: unknown): string {
   if (code.includes('invalid-token')) return 'GitHub could not validate that token.'
   if (code.includes('not-authenticated')) return 'Sign in with GitHub CLI or save a valid token first.'
   if (code.includes('not-approved')) return 'Approve this repository on this machine first.'
+  // The settings edit is saved on a debounce, so a click within that window reaches a host that
+  // has not seen it yet. Name the wait rather than the generic failure.
+  if (code.includes('invalid-configuration') || code.includes('repository-not-found')) {
+    return 'These settings have not finished saving. Try again in a moment.'
+  }
   return 'The GitHub action could not be completed. Please try again.'
 }
 
@@ -77,6 +84,9 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
   const [repositoryDraft, setRepositoryDraft] = useState('')
   const [busy, setBusy] = useState('')
   const [notice, setNotice] = useState('')
+  // Which row the current notice belongs to. A result rendered away from the control that produced
+  // it reads as no result at all — an Approve failure shown three rows down looks like a dead button.
+  const [noticeRow, setNoticeRow] = useState<NoticeRow>('data')
   const [confirmation, setConfirmation] = useState<Confirmation>(null)
   const searchQuery = useSettingsSearch()
 
@@ -125,18 +135,30 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
     setRepositoryDraft(githubConfig?.repository ?? '')
   }, [projectId, githubConfig?.repository])
 
+  /** The host reads this project from DISK (`workspaceStore.githubProject`), so an edit that stays
+   *  in the renderer store is invisible to approve/refresh — `resolveProject` sees no `github`
+   *  block and throws `invalid-configuration`. `markWorkspaceDirty` is the seam every other
+   *  `setProjectKanban` caller pairs with (Canvas, GlobalKanbanView, NodeLabels): it rides Canvas's
+   *  debounced save, so the write keeps the canvas commit and the external-change conflict gate. */
   const updateConfig = (next: ProjectKanbanGitHub | undefined): void => {
     if (!board || !projectId) return
     const updated = { ...board }
     if (next) updated.github = next
     else delete updated.github
     setProjectKanban(projectId, updated)
+    markWorkspaceDirty()
     setNotice('')
   }
 
-  const run = async (name: string, action: () => Promise<void>, success: string): Promise<void> => {
+  const run = async (
+    name: string,
+    action: () => Promise<void>,
+    success: string,
+    row: NoticeRow = 'data'
+  ): Promise<void> => {
     setBusy(name)
     setNotice('')
+    setNoticeRow(row)
     try {
       await action()
       await refreshStatus()
@@ -226,7 +248,7 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
             onClick={() => void run('token', async () => {
               await window.nodeTerminal.githubControl.saveToken(token)
               setToken('')
-            }, 'Token saved securely.')}
+            }, 'Token saved securely.', 'authentication')}
           >
             Save token
           </Button>
@@ -236,7 +258,7 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
               onClick={() => void run('clear-token', async () => {
                 await window.nodeTerminal.githubControl.clearToken()
                 setToken('')
-              }, 'Saved token cleared.')}
+              }, 'Saved token cleared.', 'authentication')}
             >
               Clear
             </Button>
@@ -261,7 +283,7 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
               provider: event.target.value as GitHubAuthProvider,
               expectedRevision: current.control.revision
             })
-          }, 'Authentication preference updated.')}
+          }, 'Authentication preference updated.', 'authentication')}
         >
           <option value="auto">Auto</option>
           <option value="gh">GitHub CLI only</option>
@@ -351,12 +373,14 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
                         repository,
                         expectedRevision: status.control.revision
                       })
-                    }, 'Repository approved on this machine.')}
+                    }, 'Repository approved on this machine.', 'repository')}
                   >
                     Approve this machine
                   </Button>
                 )}
               </div>
+              {notice && noticeRow === 'repository' &&
+                <p role="status" className="text-[13px] text-muted">{notice}</p>}
             </div>
           </SearchableRow>
 
@@ -398,7 +422,8 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
                 <Button disabled={busy !== ''} onClick={() => void run(
                   'recheck',
                   async () => { /* the refresh inside run() is the whole action */ },
-                  'Authentication re-checked.'
+                  'Authentication re-checked.',
+                  'authentication'
                 )}>
                   Check again
                 </Button>
@@ -432,6 +457,9 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
                   {tokenIsAside && tokenFieldRow}
                 </div>
               </details>
+
+              {notice && noticeRow === 'authentication' &&
+                <p role="status" className="text-[13px] text-muted">{notice}</p>}
             </div>
           </SearchableRow>
 
@@ -520,7 +548,8 @@ export function GitHubIssuesSection({ isActive }: { isActive: boolean }): React.
                   Choose a mapped completion column before GitHub issue changes are enabled.
                 </p>
               )}
-              {notice && <p role="status" className="text-[13px] text-muted">{notice}</p>}
+              {notice && noticeRow === 'data' &&
+                <p role="status" className="text-[13px] text-muted">{notice}</p>}
             </div>
           </SearchableRow>
         </>


### PR DESCRIPTION
Enabling GitHub Issues seems to not work properly: "Approve this machine" fails on every click in my environment.

Digging into it, it looks like:

- `GitHubIssuesSection.updateConfig` wrote the board with `setProjectKanban`, but skipped `markWorkspaceDirty()`, which every other caller usually pairs, e.g. `Canvas.tsx`, `GlobalKanbanView.tsx`, `NodeLabels.tsx`, and `ProjectSettingsSection.tsx`. 

As a result, the edit stayed in the renderer store and never reached `.nodeterm/project.json`.

The host reads the project from disk (`workspaceStore.githubProject`), so `resolveProject` found no `github` block and threw `invalid-configuration`, which was not very apparent due to nothing in the dev console or requests.

I propose two changes:

1. `updateConfig` calls `markWorkspaceDirty()`, so the edit rides Canvas's debounced save - keeping the canvas commit and the external-change conflict gate, unlike a direct `workspace.save`.
2. Results are anchored to the row that produced them. Every notice used to render in "Sync and local data", three rows below the Approve button, so an Approve failure read as a dead button. The debounce window also gets its own message ("These settings have not finished saving. Try again in a moment.") instead of the generic failure.

<details>
<summary>Tests</summary>

Three added to `GitHubIssuesSection.test.tsx`, all verified red without the change:
- a label edit reaches the workspace-dirty seam
- toggling GitHub Issues off persists
- an Approve failure renders beside the Approve button

`GitHubIssuesSection.test.tsx` 13/13. Related suites: 1049 passed / 2 failed; both failures pre-existing on `origin/main` in this checkout (`cardModalSize` and `lucide-react` unresolved locally).
</details>

Surfaces: renderer-only, so both Desktop and Server Edition. Mobile N/A - no settings surface for this.