### PR TITLE
fix(canvas-control): a display verb no longer moves the user's view either

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1783,7 +1783,7 @@ else, and its context links must keep classifying across restarts).
   originally did with the answer was TRAVEL there (`travelToProjectRef`), and that was a screen
   hijack: the user looks at project B, an agent in project A runs `open-claude`, the tab switches
   and A's saved viewport is applied, so the camera appears to jump and zoom on a background agent's
-  say-so. Two membership lists now decide, and their difference is the whole design:
+  say-so. THREE membership lists now decide, and their differences are the whole design:
   - `STORE_ANSWERED_VERBS` (`needsLiveCanvas` false) = **no canvas is needed at either end** —
     `list` reads names, `send`/`reply` deliver into a tmux PANE, `sticky` rewrites a note,
     `open-project` acts on the projects store.
@@ -1794,10 +1794,42 @@ else, and its context links must keep classifying across restarts).
     node is upserted through `applyNodeMutation`, edges go through `appendCanvasLinks` (the edge
     counterpart, so the opener's rope and the fan-in bridge are not lost), `writeDisk` persists, and
     the reply is the ONE shared `coldOpenMessage` sentence with `queued: true`.
+  - `OFF_CANVAS_VERBS` (`answersOffCanvas` — `show-image`/`show-video`/`show-web`/`open-browser`)
+    = **a canvas is needed, the serialized one will do, and there is nothing to defer.** The node
+    these make has no session behind it: a page, a video, an image, a browser node is inert
+    wherever it sits, so writing it into the owning project's serialized nodes IS the whole effect
+    and it is complete when `writeDisk` returns. That is why it is a third set and not four more
+    entries in the second one — a cold open reports `queued: true`, and a caller told its
+    screenshot is queued waits for something that already happened. It gets
+    `offCanvasReplyClause` and `offCanvas: true` instead. **This was the half the cold-open fix
+    left open, and it is the half an agent meets most often**: a skill that renders its report as
+    HTML reaches for `show-web` every time it finishes, and every one of those calls used to yank
+    the user out of the project they were typing in. The verb bodies are untouched; three things
+    they read from the canvas are staged — the colour index (`nodeCount`), the placement source
+    (the stored node, hydrated through `nodeStatesToFlow` so its shape cannot drift from a live
+    one's) and the append, where `applyNodeMutation` + `appendCanvasLinks` + `writeDisk` replace
+    `setNodes` + `connect` + `markDirty`. The opener's edge is a **rope** and only a rope: a
+    display node has nothing to read, so a bridge there would grant a context link the live path
+    never draws. **`ctlProject` resolves from the SOURCE's project**, not the active one — off
+    canvas it decides the ssh flag, the browser session key and the media allowlist route; on
+    every other path the travel has already made the two the same project. None of the four takes
+    `--group`, which is why this set owes no worktree question; a verb joining it that does would,
+    because `cwdForNewNodeIn` subtracts `staleGroupIds`, which is epoch-scoped to the ACTIVE
+    project.
   Everything else keeps travelling **on purpose**: `write`/`close`/`group`/`move`/`arrange`/
-  `align`/`verify`/`spawn-team`/`open-worktree`/`open-browser`/`show-*` read live canvas state the
-  serialized copy does not carry (measured node sizes, worktree staleness, the React Flow edge
-  arrays). Route `active` is byte-identical to before. Route **`reopen` (a CLOSED project) cold-writes
+  `align`/`verify`/`spawn-team`/`open-worktree` read live canvas state the serialized copy does not
+  carry (measured node sizes, worktree staleness, the React Flow edge arrays). **`browser` is the
+  pair worth stating beside `open-browser`**: it NAVIGATES a mounted `<webview>` guest, which
+  exists only while its project is on screen, so it travels; `open-browser` merely places the node
+  and its guest is created when that project is next shown, exactly as a cold-opened terminal's PTY
+  is. Route `active` is byte-identical to before.
+  **The human is told, once, in the other voice.** The reply goes to the agent; without a strip the
+  person sees nothing at all, and the whole point of not travelling is that the choice to go and
+  look stays theirs — a choice they can only make if they are told there is something to look at.
+  `offCanvasNoticeText` names the project and the button is `travelToNode` (which reopens a closed
+  project first and resolves off the SERIALIZED nodes the write has already made). It is **sticky**:
+  every other info strip reports something the user just did and is watching, this one reports work
+  that landed while they were busy elsewhere, and once it fades nothing anywhere says it happened. Route **`reopen` (a CLOSED project) cold-writes
   too and does NOT reopen the tab** — closing is the user's explicit "park this, keep it running", so
   restoring the tab *and* activating it is the loudest form of the hijack; the reply names the closure
   so a caller does not report a session as started. On the cold path `--group`/`--after` ARE resolved

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,15 +289,27 @@ retry anywhere, ask what the clock actually starts on and where its exhaustion b
 SOURCE, and React Flow holds only the ACTIVE project's nodes — so the dispatch used to travel to the
 caller's project before answering. For an OPEN that was a screen hijack: the user is looking at
 project B, an agent in project A runs `open-claude`, the tab switches and A's saved viewport is
-applied, so the camera appears to jump and zoom. The rule now has two tiers, both membership lists in
-`renderer/lib/controlRouting.ts`: `STORE_ANSWERED_VERBS` ("no canvas is needed at either end" —
-`list`, `send`, `reply`, `sticky`, `open-project`) and `canColdOpen` ("a canvas IS needed, but the
+applied, so the camera appears to jump and zoom. The rule now has three tiers, all membership lists
+in `renderer/lib/controlRouting.ts`: `STORE_ANSWERED_VERBS` ("no canvas is needed at either end" —
+`list`, `send`, `reply`, `sticky`, `open-project`), `canColdOpen` ("a canvas IS needed, but the
 serialized one will do" — `open-terminal`, `open-claude`, `open-agent`, which write into the owning
-project's stored nodes with their launch armed and report `queued: true`). Everything that acts on
-nodes which already exist still travels, because it reads live state the serialized copy does not
-carry. When you add a verb, decide which tier it is in — and if you change what a verb DOES, update
-`buildCanvasSkillBody` / `buildCanvasControlInstructions` in the same PR, with a test that goes red
-on the stale claim (`src/main/canvas-control-core.test.ts`).
+project's stored nodes with their launch armed and report `queued: true`) and `answersOffCanvas`
+("…and there is nothing to defer" — `show-image`, `show-video`, `show-web`, `open-browser`, whose
+node has no session behind it and is finished the moment it is written, so it reports `offCanvas:
+true` and never `queued`). Everything that acts on nodes which already exist still travels, because
+it reads live state the serialized copy does not carry — `browser` included, which navigates a
+mounted `<webview>` guest, unlike `open-browser`, which only places the node.
+
+Three things to carry over when you put a verb in one of the two off-screen tiers. **The acting
+project is the SOURCE's**: `ctlProject` decides the ssh flag, the browser session key and the media
+allowlist route, and reading `activeProjectId` there answers a background agent with whatever the
+human is looking at. **Nothing may reach the live canvas**: `setNodes` / `setControlEdges` /
+`markDirty` address the ACTIVE project, so the write goes through `applyNodeMutation` +
+`appendCanvasLinks` + `writeDisk`. And **tell the human** — the reply goes to the agent, so without
+a strip nothing anywhere reports that a node landed in another project; it is sticky, because it
+describes work the user was not watching. When you add a verb, decide which tier it is in — and if
+you change what a verb DOES, update `buildCanvasSkillBody` / `buildCanvasControlInstructions` in the
+same PR, with a test that goes red on the stale claim (`src/main/canvas-control-core.test.ts`).
 
 **Pointing a project at a folder is a WRITE — probe before you bind.** A project's canvas is
 written to `<cwd>/.nodeterm/project.json`, so the moment a project gains a `cwd` the next autosave

--- a/src/core/canvas-control-core.ts
+++ b/src/core/canvas-control-core.ts
@@ -379,6 +379,11 @@ export function buildCanvasControlInstructions(shimPath: string): string {
     '- `show-image <path>` / `show-video <path>` — open a media file as a node.',
     '- `show-web (--url U | --file P.html | --html "<...>")` — open a web viewer.',
     '- `open-browser --url U` — open a navigable browser node.',
+    '  These four NEVER switch the user\'s view either. If your project is not on screen the node is',
+    '  saved into it and waits there — the reply says which project, and adds `offCanvas: true`.',
+    '  Nothing is queued: unlike a session, a page or an image is finished the moment it is placed,',
+    '  so there is nothing to wait for and nothing to poll. Say where it went rather than assuming',
+    '  the user saw it.',
     '- `group --nodes <id,id> [--label L] [--color C]` — wrap sibling nodes or sibling groups in a new labeled frame.',
     '  Every id must share one container. `ungroup --group <id>` dissolves a frame and promotes its direct',
     '  children into the frame\'s parent. `move --nodes <id,id> [--group <id>]` reparents nodes or groups INTO an',
@@ -834,6 +839,12 @@ Verbs:
 - \`show-video <path>\` — open a video file as a player node.
 - \`show-web (--url U | --file P.html | --html "<...>")\` — open a web viewer (live URL or local HTML you wrote).
 - \`open-browser --url U\` — open a navigable browser (back/forward/address bar) at a URL.
+  **These four never switch the user's view either.** If the project you are running in is not the
+  one on screen, the node is saved into it and waits there; the reply names the project and carries
+  \`offCanvas: true\`, and if that project is **closed** it says so — the tab is not reopened for
+  you. Nothing here is ever \`queued\`: unlike a session, a page, a video or an image is finished
+  the moment it is placed, so there is nothing to wait for and nothing to poll. What this costs you
+  is the assumption that the user saw it — tell them where it went.
   In an SSH project, nodes you open run on the HOST (same machine as you). The media viewers
   render on the DESKTOP: \`show-image\` and \`show-video\` still work with a host path (the
   file is read/fetched back over the connection), but \`show-web --file/--html\` is refused —

--- a/src/main/canvas-control-core.test.ts
+++ b/src/main/canvas-control-core.test.ts
@@ -741,4 +741,23 @@ describe('the --project clause tells the truth about travel (review #363 I-1 + M
       expect(body, `${name}: tab not reopened`).toMatch(/not reopened/i)
     }
   })
+
+  it('both bodies say the DISPLAY verbs do not switch the view either — and are never queued', () => {
+    // The second half of the same promise, and the half an agent meets most often: a skill that
+    // renders its report as HTML reaches for `show-web` every time it finishes. Two facts it acts
+    // on, and the second is why these are not folded into the cold-open sentence: the node is
+    // COMPLETE when placed, so a caller told "queued" would wait for something that has already
+    // happened. The `offCanvas` field is what it reads instead.
+    for (const [name, body] of bodies) {
+      const start = body.indexOf('`show-image')
+      const end = body.indexOf('`group --nodes', start)
+      expect(start, `${name}: the display-verb entries`).toBeGreaterThan(-1)
+      expect(end, `${name}: the group entry after them`).toBeGreaterThan(start)
+      const clause = body.slice(start, end)
+      expect(clause, `${name}: never switches the view`).toMatch(/never switch(es)? the user'?s view/i)
+      expect(clause, `${name}: names the field`).toContain('offCanvas')
+      // THE STALE CLAIM the split exists to prevent: a display verb reported as queued.
+      expect(clause, `${name}: not queued`).toMatch(/nothing (here )?is (ever )?\`?queued/i)
+    }
+  })
 })

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -247,6 +247,7 @@ import {
   routeControlSource,
   needsLiveCanvas,
   canColdOpen,
+  answersOffCanvas,
   sourceIsControlCapable,
   storedNodeListing,
   answerBrowserResolve,
@@ -257,6 +258,8 @@ import {
   coldGroupChildCount,
   coldOpenMessage,
   coldPlaceBelow,
+  offCanvasNoticeText,
+  offCanvasReplyClause,
   coldResolveAfter,
   coldResolveGroup,
   groupSizeFor,
@@ -939,9 +942,19 @@ export function Canvas() {
   // Result of a worktree operation (merge / remove). These used to be `window.alert`s — a modal
   // that blocks the whole app to say "Merged feat into main." Shown as a strip in the existing
   // top-banner column instead; an 'info' one fades itself out, an 'error' stays until dismissed.
-  const [notice, setNotice] = useState<{ kind: 'info' | 'error'; text: string } | null>(null)
+  // `sticky` opts an info strip out of the fade. The dwell exists because a worktree result
+  // reports something the user just did and is watching; an off-canvas notice reports work that
+  // landed in ANOTHER project while they were busy elsewhere, and once it fades nothing anywhere
+  // says it happened. `action` is an ordinary next step, not an install or a reload, so it wears
+  // the app's default button rather than `.announce-banner__btn`'s accent treatment.
+  const [notice, setNotice] = useState<{
+    kind: 'info' | 'error'
+    text: string
+    sticky?: boolean
+    action?: { label: string; run: () => void }
+  } | null>(null)
   useEffect(() => {
-    if (notice?.kind !== 'info') return
+    if (notice?.kind !== 'info' || notice.sticky) return
     const t = setTimeout(() => setNotice(null), noticeDwellMs(notice.text))
     return () => clearTimeout(t)
   }, [notice])
@@ -5808,6 +5821,9 @@ export function Canvas() {
   // Same reason as worktreeControlRef below: the agent-control handler needs the CURRENT
   // travelToProject (defined far below, after the project actions it composes).
   const travelToProjectRef = useRef<(projectId: string) => void>(() => {})
+  /** Latest `travelToNode`, for the agent-control handler's off-canvas notice — same reason as
+   *  travelToProjectRef: that effect mounts ONCE, so it cannot close over the callback. */
+  const travelToNodeRef = useRef<(nodeId: string) => void>(() => {})
 
   // Latest worktree callbacks for the agent-control handler. That effect mounts ONCE (empty
   // deps) and these callbacks' identities change with the active project (activeProjectId /
@@ -8856,8 +8872,35 @@ export function Canvas() {
   // main never hangs to its 120s timeout.
   useEffect(() => {
     return api.onAgentControl(async ({ requestId, sourceNodeId, verb, args }) => {
-      const reply = (r: { ok: boolean; message?: string; result?: unknown; error?: string }) =>
+      // Set by the OFF-CANVAS branch below (`answersOffCanvas`): the verb runs against the owning
+      // project's SERIALIZED nodes because that project is not on screen. It stays undefined on
+      // every other path, which is what makes the on-screen behaviour byte-identical.
+      let offCanvas: { project: Project; closed: boolean; created: string[] } | undefined
+      const reply = (r: { ok: boolean; message?: string; result?: unknown; error?: string }) => {
+        // Say WHERE it went, once, in both voices. The verb bodies already say WHAT they made, so
+        // none of them has to know about routing: the clause is appended here and the human strip
+        // is raised here. A refusal decorates nothing — it created no node and moved no view.
+        if (offCanvas && r.ok && offCanvas.created.length) {
+          const { project, closed, created } = offCanvas
+          r = {
+            ...r,
+            message: (r.message ?? '') + offCanvasReplyClause(project.name, { closed }),
+            result: { ...(r.result as object), projectId: project.id, offCanvas: true }
+          }
+          const first = created[0]
+          setNotice({
+            kind: 'info',
+            sticky: true,
+            text: offCanvasNoticeText(project.name, created.length),
+            // The notice is about one thing that appeared, so the button goes to that thing —
+            // `travelToNode` reopens a closed project first and resolves off the SERIALIZED nodes,
+            // which the write above has already made. Landing on the project's saved camera
+            // instead would leave the user hunting for it.
+            action: { label: 'Go there', run: () => travelToNodeRef.current(first) }
+          })
+        }
         api.sendAgentControlResult({ requestId, ...r })
+      }
       // `--dry-run` (issue #532): validate + report, mutate nothing. Only DRY_RUN_VERBS reach
       // this process with the flag set — main's setControlHandler refuses it for every other
       // verb before forwarding — so the per-case branches below are the whole renderer story:
@@ -9574,13 +9617,45 @@ export function Canvas() {
             })
             return
           }
-          travelToProjectRef.current(route.projectId)
+          // ── OFF CANVAS ──────────────────────────────────────────────────────────────────
+          // A DISPLAY verb (`show-image` / `show-video` / `show-web` / `open-browser`) whose own
+          // project is not on screen. Same objection as the cold open above and the same answer,
+          // one set wider: an agent that renders its output as a node is the commonest reason a
+          // background session touches the canvas at all, and every one of those calls used to
+          // yank the human out of the project they were typing in.
+          //
+          // The difference from the cold open is that there is nothing to defer. These four make
+          // an INERT node — a page, a video, an image, a browser — which is complete the moment it
+          // is written, so the verb body runs unchanged and only the three things it touches on
+          // the canvas are staged: the node counter, the placement source, and the append.
+          // See `answersOffCanvas` in lib/controlRouting for why `browser` is not in the set.
+          if (answersOffCanvas(verb)) {
+            const ocStore = useProjects.getState()
+            const owner = ocStore.getProject(route.projectId)
+            const ocSrc = owner?.nodes.find((n) => n.id === sourceNodeId)
+            // Same authorization boundary and the same sentence as every other path — a stored
+            // node carries the agent id the live one would (`data.agentId` is serialized).
+            if (!owner || !ocSrc || !sourceIsControlCapable(ocSrc.agentId)) {
+              reply({ ok: false, error: 'source node is not a control-capable agent' })
+              return
+            }
+            offCanvas = { project: owner, closed: route.kind === 'reopen', created: [] }
+            // The body below reads the source for its title, cwd and placement geometry. Hydrate
+            // the ONE stored node rather than hand-rolling a partial: `nodeStatesToFlow` is what
+            // the project load itself uses, so the shape cannot drift from a live node's. It has
+            // no `measured` (nothing rendered it), which `placeBelow` already falls back for.
+            src = nodeStatesToFlow([ocSrc])[0] as CanvasNode
+          } else {
+            travelToProjectRef.current(route.projectId)
+          }
         }
         // Wait for the node to show up on the canvas: after a travel, because the active-project
         // effect hydrates React Flow a tick later; on `active`, because a control call can land
         // while the BOOT load of the owning project is still in flight — the very moment a
         // re-adopted agent starts talking again. `unknown`/`blocked` have no canvas to wait for.
-        if (route.kind !== 'unknown' && route.kind !== 'blocked') {
+        // An off-canvas answer has its source already and is deliberately NOT waiting for a
+        // canvas: waiting for one is what travelling was for.
+        if (!offCanvas && route.kind !== 'unknown' && route.kind !== 'blocked') {
           src = await waitForCanvasNode(() => nodesRef.current.find((n) => n.id === sourceNodeId))
         }
       }
@@ -9606,10 +9681,16 @@ export function Canvas() {
       // got it right; every control verb passed `undefined` and got it wrong.) The factory reads
       // the node's cwd out of `remoteCwd`, so the effective cwd is threaded through there —
       // otherwise `--cwd` would be silently replaced by the project root.
-      const ctlProject = (() => {
-        const st = useProjects.getState()
-        return st.getProject(st.activeProjectId ?? '')
-      })()
+      // Off canvas the two are different projects, and this one decides the ssh flag, the browser
+      // session key and the media allowlist route. Reading `activeProjectId` there would answer a
+      // background agent's call with whatever the human happens to be looking at; on every other
+      // path the travel has already made the two the same project, so nothing changes.
+      const ctlProject =
+        offCanvas?.project ??
+        (() => {
+          const st = useProjects.getState()
+          return st.getProject(st.activeProjectId ?? '')
+        })()
       const ctlSsh = ctlProject?.ssh
       const sshFor = (cwd?: string) => nodeSshFor(ctlSsh, cwd)
       // Place opened nodes BELOW the source and rope them to it (source flow-out → target
@@ -9678,11 +9759,33 @@ export function Canvas() {
         // relative coords) must pass through untouched — re-running parentInto would read its
         // relative position as absolute and land it off-frame.
         const placed = node.parentId ? node : src.parentId ? parentInto(node, src.parentId) : node
+        if (offCanvas) {
+          // The staged twin of the three lines below, and the whole of the off-canvas write. The
+          // live setters all address the ACTIVE canvas, which is some other project's here — they
+          // would put the node in front of the wrong person and dirty the wrong file.
+          // `applyNodeMutation` + `appendCanvasLinks` are the store paths a peer mutation and the
+          // cold open already take, and `writeDisk` is what persists them.
+          const ocStore = useProjects.getState()
+          ocStore.applyNodeMutation(offCanvas.project.id, {
+            op: 'upsert',
+            node: flowToNodeStates([placed])[0]
+          })
+          ocStore.appendCanvasLinks(offCanvas.project.id, {
+            ropes: [ropeEdge(`ctrl-${sourceNodeId}-${placed.id}`, sourceNodeId, placed.id)]
+          })
+          void writeDisk()
+          offCanvas.created.push(placed.id)
+          return placed.id
+        }
         setNodes((ns) => [...ns, placed])
         connect(placed.id)
         markDirty()
         return placed.id
       }
+      // The colour index every factory takes. Off canvas the live array holds another project's
+      // nodes, so counting it would colour by a number that has nothing to do with where the node
+      // lands. One name for the two sources, so no verb body has to ask which it is on.
+      const nodeCount = () => (offCanvas ? offCanvas.project.nodes.length : nodesRef.current.length)
       // Grid slots INSIDE a group frame (open-agent --group): 2 columns of terminal-sized
       // cells under the header. Pure geometry — the frame is grown to fit before children land.
       // `groupSlot`/`groupSizeFor` live in lib/coldOpen so the COLD path (an open answered out of a
@@ -10087,7 +10190,7 @@ export function Canvas() {
             // (`sshFs` routes fs.readBinary over the ControlMaster) — reading it locally would
             // either miss or, worse, open a same-named local file.
             const id = addAndConnect(
-              createEditorNode(nodesRef.current.length, args.path, placeBelow(), !!ctlSsh)
+              createEditorNode(nodeCount(), args.path, placeBelow(), !!ctlSsh)
             )
             reply({ ok: true, message: `showing image ${id}`, result: { id } })
             return
@@ -10103,7 +10206,7 @@ export function Canvas() {
             // same-named local file. Local projects allowlist the local path as before.
             if (!ctlSsh) await window.nodeTerminal.media.allow(args.path)
             const id = addAndConnect(
-              createVideoNode(nodesRef.current.length, args.path, placeBelow(), !!ctlSsh)
+              createVideoNode(nodeCount(), args.path, placeBelow(), !!ctlSsh)
             )
             reply({ ok: true, message: `showing video ${id}`, result: { id } })
             return
@@ -10130,7 +10233,7 @@ export function Canvas() {
             }
             // For an agent-provided --file (not html we just wrote), allowlist it first.
             if (webSrc.filePath && args.file) await window.nodeTerminal.media.allow(webSrc.filePath)
-            const id = addAndConnect(createWebNode(nodesRef.current.length, webSrc, placeBelow()))
+            const id = addAndConnect(createWebNode(nodeCount(), webSrc, placeBelow()))
             reply({ ok: true, message: `showing web ${id}`, result: { id } })
             return
           }
@@ -10154,7 +10257,7 @@ export function Canvas() {
               reply({ ok: false, error: "open-browser: this project's id cannot be used as a browser session key" })
               return
             }
-            const id = addAndConnect(createBrowserNode(nodesRef.current.length, browserUrl, placeBelow(), partition))
+            const id = addAndConnect(createBrowserNode(nodeCount(), browserUrl, placeBelow(), partition))
             // Return the project id + partition so main can record ownership in its in-memory
             // ledger (browser-control-ledger.ts). Main gates the claim on its OWN `verified` verdict
             // and keys it to the verified caller — these fields are descriptive (release-by-project,
@@ -12582,6 +12685,12 @@ export function Canvas() {
     [focusNodeById, reopenProject]
   )
 
+  // Published BELOW the callback it mirrors, not above it: an effect placed earlier would read a
+  // const that is only initialized later in the body. That works today and breaks on a reorder.
+  useEffect(() => {
+    travelToNodeRef.current = travelToNode
+  })
+
   // OS-notification click → focus the originating node (see the note beside focusNodeById:
   // travelToNode, not focusNodeById, so a closed project's tab is reopened first).
   useEffect(() => window.nodeTerminal.onFocusNode(travelToNode), [travelToNode])
@@ -13055,6 +13164,18 @@ export function Canvas() {
             <div className="announce-banner__content">
               <span className="announce-banner__body">{notice.text}</span>
             </div>
+            {notice.action && (
+              <button
+                className="announce-banner__action"
+                onClick={() => {
+                  const run = notice.action?.run
+                  setNotice(null)
+                  run?.()
+                }}
+              >
+                {notice.action.label}
+              </button>
+            )}
             <button
               className="announce-banner__close"
               title="Dismiss"

--- a/src/renderer/canvas/control-cold-open.source.test.ts
+++ b/src/renderer/canvas/control-cold-open.source.test.ts
@@ -18,13 +18,15 @@ import { readFileSync } from 'node:fs'
  */
 const src = readFileSync(new URL('./Canvas.tsx', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
 
-/** The cold-open block: from its `if (canColdOpen(verb))` guard to the travel call it stands in
- *  front of. */
+/** The cold-open block: from its `if (canColdOpen(verb))` guard to the off-canvas guard that
+ *  follows it. Bounded by that guard rather than by the travel call further down, so the pins
+ *  below judge THIS block and never inherit a passing verdict from the one after it — the two are
+ *  separate branches with separate contracts (`control-off-canvas.source.test.ts`). */
 function coldOpenBody(): string {
   const start = src.indexOf('if (canColdOpen(verb)) {')
   expect(start, 'the cold-open guard').toBeGreaterThan(-1)
-  const end = src.indexOf('travelToProjectRef.current(route.projectId)', start)
-  expect(end, 'the travel call after the block').toBeGreaterThan(start)
+  const end = src.indexOf('if (answersOffCanvas(verb)) {', start)
+  expect(end, 'the off-canvas guard after the block').toBeGreaterThan(start)
   return src.slice(start, end)
 }
 

--- a/src/renderer/canvas/control-off-canvas.source.test.ts
+++ b/src/renderer/canvas/control-off-canvas.source.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * STRUCTURAL pins for the OFF-CANVAS branch of the canvas-control dispatch — the sibling of
+ * `control-cold-open.source.test.ts`, and for the same reason: the branch lives inside a
+ * 12,000-line React component's IPC listener with no unit seam, and what it must be pinned on are
+ * properties of the SOURCE.
+ *
+ * Every behavioural half is proven separately against real primitives: the verb set and its
+ * disjointness from the other two in `lib/controlRouting.test.ts`, the reply clause and the notice
+ * copy in `lib/coldOpen.test.ts`, the edge append in `state/projects.links.test.ts`.
+ *
+ * THE BUG this closes, which the cold-open fix left open: the user is looking at project B; an
+ * agent in project A renders its output as a node — a report as `show-web`, a screenshot as
+ * `show-image` — and the app switched to A. Those are the commonest reason a background session
+ * touches the canvas at all, so the fix that covered `open-claude` covered the rarer half.
+ */
+const src = readFileSync(new URL('./Canvas.tsx', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
+
+/** The off-canvas block: from its `if (answersOffCanvas(verb))` guard to the travel call it stands
+ *  in front of. */
+function offCanvasBody(): string {
+  const start = src.indexOf('if (answersOffCanvas(verb)) {')
+  expect(start, 'the off-canvas guard').toBeGreaterThan(-1)
+  const end = src.indexOf('travelToProjectRef.current(route.projectId)', start)
+  expect(end, 'the travel call after the block').toBeGreaterThan(start)
+  return src.slice(start, end)
+}
+
+/** Line comments explain what a block must NOT do, so a negative pin has to judge the code. */
+function code(body: string): string {
+  return body
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n')
+}
+
+/** The `addAndConnect` helper, whose off-canvas half is the whole write. */
+function addAndConnectBody(): string {
+  const start = src.indexOf('const addAndConnect = (node: CanvasNode) => {')
+  expect(start, 'addAndConnect').toBeGreaterThan(-1)
+  const end = src.indexOf('const nodeCount = ()', start)
+  expect(end, 'nodeCount after it').toBeGreaterThan(start)
+  return src.slice(start, end)
+}
+
+describe('the off-canvas dispatch block (source pins)', () => {
+  it('stands IN FRONT of the travel call — a display verb never reaches it', () => {
+    // The travel call is what moved the user's screen. Scoped to the dispatch's source-routing
+    // block (Canvas has one other, unrelated travel for the browser-verb guest lookup), the
+    // off-canvas guard must precede the single travel in it, or the block is dead code sitting
+    // behind the very thing it replaces.
+    const from = src.indexOf('routeControlSource(projects, activeId, sourceNodeId)')
+    expect(from, 'the source-routing lookup').toBeGreaterThan(-1)
+    const to = src.indexOf('waitForCanvasNode(', from)
+    expect(to, 'the post-routing canvas wait').toBeGreaterThan(from)
+    const routing = src.slice(from, to)
+    expect(routing.match(/travelToProjectRef\.current\(route\.projectId\)/g)?.length).toBe(1)
+    const guard = routing.indexOf('if (answersOffCanvas(verb)) {')
+    const travel = routing.indexOf('travelToProjectRef.current(route.projectId)')
+    expect(guard, 'the off-canvas guard inside the routing block').toBeGreaterThan(-1)
+    expect(guard).toBeLessThan(travel)
+    // …and the travel is its ELSE, so the two are exclusive by construction rather than by a
+    // `return` someone can move.
+    expect(routing).toMatch(/\} else \{\s*travelToProjectRef\.current\(route\.projectId\)/)
+  })
+
+  it('the guard polarity is not inverted', () => {
+    expect(src).toContain('if (answersOffCanvas(verb)) {')
+    expect(src).not.toContain('if (!answersOffCanvas(verb))')
+  })
+
+  it('never travels, activates, reopens or moves the camera', () => {
+    // The whole point. A "Go there" button exists and is the user's to press; nothing here presses
+    // it for them.
+    const body = code(offCanvasBody())
+    expect(body).not.toContain('travelToProject')
+    expect(body).not.toContain('travelToNodeRef')
+    expect(body).not.toContain('setActive')
+    expect(body).not.toContain('reopenProject')
+    expect(body).not.toContain('goToNode')
+    expect(body).not.toContain('focusNodeById')
+  })
+
+  it('does NOT wait for a canvas — waiting for one is what travelling was for', () => {
+    // `waitForCanvasNode` polls the LIVE nodes for the source. Off canvas that node is never
+    // going to appear there, so an ungated wait would burn the whole timeout and then answer
+    // "source node is not on an open canvas" — a refusal for being off-screen, which is exactly
+    // what cecb4dfe removed.
+    expect(src).toContain('if (!offCanvas && route.kind !== \'unknown\' && route.kind !== \'blocked\') {')
+  })
+
+  it('keeps cecb4dfe’s fix: the only source refusal is the capability sentence', () => {
+    const body = code(offCanvasBody())
+    expect(body).toContain("error: 'source node is not a control-capable agent'")
+    expect(body).not.toContain('is not on an open canvas')
+    expect(body).not.toContain('not the active project')
+  })
+
+  it('resolves the source from the OWNING project’s serialized nodes', () => {
+    const body = offCanvasBody()
+    expect(body).toContain('ocStore.getProject(route.projectId)')
+    expect(body).toMatch(/owner\?\.nodes\.find\(\(n\) => n\.id === sourceNodeId\)/)
+    // Hydrated with the same transform the project load uses, so the shape cannot drift from a
+    // live node's — the verb bodies read `src.data.title`, `src.data.cwd` and its geometry.
+    expect(body).toContain('nodeStatesToFlow([ocSrc])[0]')
+  })
+
+  it('the acting project is the SOURCE’s, not whatever is on screen', () => {
+    // `ctlProject` decides the ssh flag, the browser session key and the media allowlist route.
+    // Reading `activeProjectId` off canvas answers a background agent with the human's project.
+    expect(src).toMatch(/const ctlProject =\s*\n\s*offCanvas\?\.project \?\?/)
+  })
+
+  it('writes through the store, never into the live canvas', () => {
+    // React Flow holds the ACTIVE project's nodes. `setNodes` / `setControlEdges` / `markDirty`
+    // would put the node in front of the wrong person and dirty the wrong file.
+    const body = addAndConnectBody()
+    const off = code(body.slice(body.indexOf('if (offCanvas) {'), body.indexOf('setNodes((ns) =>')))
+    expect(off.length).toBeGreaterThan(0)
+    expect(off).toContain('applyNodeMutation(offCanvas.project.id, {')
+    expect(off).toContain('appendCanvasLinks(offCanvas.project.id, {')
+    expect(off).toContain('writeDisk()')
+    expect(off).not.toContain('setNodes(')
+    expect(off).not.toContain('setControlEdges')
+    expect(off).not.toContain('markDirty()')
+  })
+
+  it('the opener’s rope is written too — a display node still hangs off its agent', () => {
+    // Same edge the live path's `connect` draws, under the same id, so the node reads as
+    // "produced by that conversation" when the project is next shown.
+    const body = addAndConnectBody()
+    expect(body).toContain('ropeEdge(`ctrl-${sourceNodeId}-${placed.id}`, sourceNodeId, placed.id)')
+  })
+
+  it('the colour index comes from the owning project, not the live array', () => {
+    expect(src).toContain(
+      'const nodeCount = () => (offCanvas ? offCanvas.project.nodes.length : nodesRef.current.length)'
+    )
+    // …and every display verb asks through it. A bare `nodesRef.current.length` in one of these
+    // four cases compiles, passes every other test, and colours by a count from another project.
+    // Scoped to the case bodies: these factories have unrelated callers (the user's own "open
+    // file"), which legitimately count the live array because they land on the live canvas.
+    for (const verb of ['show-image', 'show-video', 'show-web', 'open-browser']) {
+      const at = src.indexOf(`case '${verb}': {`)
+      expect(at, verb).toBeGreaterThan(-1)
+      const body = src.slice(at, src.indexOf("\n          case '", at + 1))
+      expect(body.length, verb).toBeGreaterThan(0)
+      expect(body, verb).toContain('nodeCount()')
+      expect(body, verb).not.toContain('nodesRef.current')
+    }
+  })
+
+  it('says WHERE it went in both voices, once, and only after a node was made', () => {
+    // The reply the agent reads and the strip the human reads are raised in the same place, so
+    // neither can be forgotten for a verb. `created.length` is the gate: a refusal and a
+    // `--dry-run` decorate nothing, because they made nothing.
+    const start = src.indexOf('const reply = (r: {')
+    expect(start).toBeGreaterThan(-1)
+    const decor = src.slice(start, src.indexOf('api.sendAgentControlResult({ requestId, ...r })', start))
+    expect(decor).toContain('if (offCanvas && r.ok && offCanvas.created.length) {')
+    expect(decor).toContain('offCanvasReplyClause(project.name, { closed })')
+    expect(decor).toContain('offCanvasNoticeText(project.name, created.length)')
+    expect(decor).toContain('sticky: true')
+    expect(decor).toContain("label: 'Go there'")
+  })
+
+  it('a CLOSED project is written into, and both voices say so', () => {
+    // The same choice route `reopen` gets on the cold path: restoring a tab AND activating it is
+    // the loudest version of the hijack this fixes.
+    expect(offCanvasBody()).toMatch(/closed: route\.kind === 'reopen'/)
+  })
+
+  it('the notice does not fade — it reports work the user was not watching', () => {
+    // An info strip that reports something the user just did may fade; this one reports a node
+    // that landed in another project while they were busy elsewhere, and once it fades nothing
+    // anywhere says it happened.
+    expect(src).toContain("if (notice?.kind !== 'info' || notice.sticky) return")
+  })
+})

--- a/src/renderer/canvas/control-off-canvas.source.test.ts
+++ b/src/renderer/canvas/control-off-canvas.source.test.ts
@@ -127,11 +127,23 @@ describe('the off-canvas dispatch block (source pins)', () => {
     expect(off).not.toContain('markDirty()')
   })
 
-  it('the opener’s rope is written too — a display node still hangs off its agent', () => {
+  it('the opener’s edge is a ROPE, and only a rope', () => {
     // Same edge the live path's `connect` draws, under the same id, so the node reads as
-    // "produced by that conversation" when the project is next shown.
-    const body = addAndConnectBody()
-    expect(body).toContain('ropeEdge(`ctrl-${sourceNodeId}-${placed.id}`, sourceNodeId, placed.id)')
+    // "produced by that conversation" when the project is next shown. `appendCanvasLinks` takes
+    // both arrays and the two mean different things: a rope is display-only lineage, a bridge is
+    // a context link that authorizes a READ. A display node has nothing to read, and the live
+    // path draws no bridge for one — writing it here would hand an agent a context edge on
+    // another project's canvas that nobody asked for, and the swap is a one-word edit.
+    const off = code(
+      addAndConnectBody().slice(
+        addAndConnectBody().indexOf('if (offCanvas) {'),
+        addAndConnectBody().indexOf('setNodes((ns) =>')
+      )
+    )
+    expect(off).toContain(
+      'ropes: [ropeEdge(`ctrl-${sourceNodeId}-${placed.id}`, sourceNodeId, placed.id)]'
+    )
+    expect(off).not.toContain('bridges:')
   })
 
   it('the colour index comes from the owning project, not the live array', () => {

--- a/src/renderer/lib/coldOpen.test.ts
+++ b/src/renderer/lib/coldOpen.test.ts
@@ -8,6 +8,8 @@ import {
   coldResolveGroup,
   groupSizeFor,
   groupSlot,
+  offCanvasNoticeText,
+  offCanvasReplyClause,
   storedAgentIdOf,
   type ColdNode
 } from './coldOpen'
@@ -216,5 +218,44 @@ describe('coldOpenMessage — ONE sentence for both cold-open sites', () => {
     const closed = coldOpenMessage(1, 'terminal', 'Docs', ['t1'], { closed: true })
     expect(closed.startsWith(open)).toBe(true)
     expect(closed).toContain('that project is closed')
+  })
+})
+
+describe('offCanvasReplyClause — the display verbs\' half of the same event', () => {
+  it('is a CLAUSE, so the verb keeps saying what it made', () => {
+    // Appended to `showing web nt-3f2a`, not instead of it: only the WHERE is new, which is what
+    // lets the four case bodies stay ignorant of routing.
+    expect(offCanvasReplyClause('api')).toBe(
+      ' — placed in "api"; that project is not on screen'
+    )
+  })
+
+  it('adds — and only adds — a clause when the project is CLOSED', () => {
+    const open = offCanvasReplyClause('api')
+    const closed = offCanvasReplyClause('api', { closed: true })
+    expect(closed.startsWith(open)).toBe(true)
+    expect(closed).toContain('reopen it from the welcome screen')
+  })
+
+  it('never claims the node is queued — it is complete when written', () => {
+    // The distinction this builder exists for. A cold-opened SESSION has not started; a page, a
+    // video or an image has. Telling a caller its screenshot is "queued" invites it to wait for
+    // something that already happened.
+    expect(offCanvasReplyClause('api')).not.toContain('queued')
+    expect(offCanvasReplyClause('api')).not.toContain('starts when')
+  })
+})
+
+describe('offCanvasNoticeText — the HUMAN half', () => {
+  it('is an active-voice sentence naming the actor and the project', () => {
+    expect(offCanvasNoticeText('api', 1)).toBe(
+      'An agent opened a node in "api". That project is not on screen.'
+    )
+  })
+
+  it('counts, rather than saying "a node" for five', () => {
+    expect(offCanvasNoticeText('api', 3)).toBe(
+      'An agent opened 3 nodes in "api". That project is not on screen.'
+    )
   })
 })

--- a/src/renderer/lib/coldOpen.ts
+++ b/src/renderer/lib/coldOpen.ts
@@ -218,3 +218,37 @@ export function coldOpenMessage(
     (opts.closed ? ' (that project is closed — reopen it from the welcome screen)' : '')
   )
 }
+
+/**
+ * The clause appended to a display verb's own reply when the node landed in a project the user is
+ * not looking at.
+ *
+ * A CLAUSE rather than a whole sentence, because the verb already said what it made ("showing web
+ * nt-3f2a") and only the WHERE is new — so the four case bodies need to know nothing about
+ * routing. Deliberately not `coldOpenMessage`: that one reports a session which has not started,
+ * while a web page, a video or an image is COMPLETE the moment it is written, and telling a caller
+ * its screenshot is "queued; starts when that project is next viewed" invites it to wait for
+ * something that already happened. The `closed` clause is additive for the same reason it is
+ * there: a caller told nothing would report the node as visible.
+ */
+export function offCanvasReplyClause(projectName: string, opts: { closed?: boolean } = {}): string {
+  return (
+    ` — placed in "${projectName}"; that project is not on screen` +
+    (opts.closed ? ' and is closed (reopen it from the welcome screen)' : '')
+  )
+}
+
+/**
+ * The HUMAN half of the same event: a strip naming the project a background agent just wrote to.
+ *
+ * The reply above goes to the agent. Without this the person sees nothing at all, and the whole
+ * point of not travelling is that the choice to go and look stays theirs — a choice they can only
+ * make if they are told there is something to look at.
+ *
+ * Active voice and a full sentence. "A node opened by an agent in X." is a noun phrase, and the
+ * passive repair ("was opened by") buries the actor the reader needs.
+ */
+export function offCanvasNoticeText(projectName: string, count: number): string {
+  const what = count === 1 ? 'a node' : `${count} nodes`
+  return `An agent opened ${what} in "${projectName}". That project is not on screen.`
+}

--- a/src/renderer/lib/controlRouting.test.ts
+++ b/src/renderer/lib/controlRouting.test.ts
@@ -3,6 +3,7 @@ import {
   routeControlSource,
   needsLiveCanvas,
   canColdOpen,
+  answersOffCanvas,
   controlVerbSetsForTests,
   sourceIsControlCapable,
   storedNodeListing,
@@ -141,6 +142,58 @@ describe('canColdOpen — an OPEN is answered out of the store, not by moving th
     }
   })
 
+  it('answers the four DISPLAY verbs off canvas, and nothing else', () => {
+    for (const verb of ['show-image', 'show-video', 'show-web', 'open-browser']) {
+      expect(answersOffCanvas(verb), verb).toBe(true)
+    }
+    for (const verb of [
+      'open-terminal',
+      'open-claude',
+      'open-agent',
+      'list',
+      'send',
+      'reply',
+      'sticky',
+      'open-project',
+      'write',
+      'close',
+      'group',
+      'ungroup',
+      'move',
+      'arrange',
+      'align',
+      'link',
+      'rename',
+      'color',
+      'verify',
+      'spawn-team',
+      'open-worktree',
+      'board',
+      'assign'
+    ]) {
+      expect(answersOffCanvas(verb), verb).toBe(false)
+    }
+  })
+
+  it('keeps `browser` on the travelling path — it NAVIGATES a mounted guest', () => {
+    // The one pair worth stating side by side. `open-browser` places a node, which a serialized
+    // canvas can hold; `browser` drives an Electron <webview> guest that exists only while its
+    // project is on screen. Adding it here would answer "navigated" about a guest that is not
+    // there.
+    expect(answersOffCanvas('open-browser')).toBe(true)
+    expect(answersOffCanvas('browser')).toBe(false)
+    expect(needsLiveCanvas('browser')).toBe(true)
+  })
+
+  it('the display verbs still NEED a canvas — off-canvas is the narrower claim again', () => {
+    // Same relationship the cold-open set has to store-answered: these do need somewhere to put a
+    // node, they just do not need the LIVE one. Collapsing them into STORE_ANSWERED_VERBS would
+    // send `show-web` down the `list` branch and answer it with a node listing.
+    for (const verb of ['show-image', 'show-video', 'show-web', 'open-browser']) {
+      expect(needsLiveCanvas(verb), verb).toBe(true)
+    }
+  })
+
   it('still NEEDS a canvas — cold-openable is a narrower claim than store-answered', () => {
     // The whole reason this is a second set: `needsLiveCanvas` stays TRUE for an open (it does
     // need somewhere to put the node), it just does not need the LIVE one. Collapsing the two
@@ -151,12 +204,15 @@ describe('canColdOpen — an OPEN is answered out of the store, not by moving th
     }
   })
 
-  it('the two sets are DISJOINT', () => {
-    const { storeAnswered, coldOpenable } = controlVerbSetsForTests()
+  it('the three sets are DISJOINT', () => {
+    const { storeAnswered, coldOpenable, offCanvas } = controlVerbSetsForTests()
     expect(storeAnswered.filter((v) => coldOpenable.includes(v))).toEqual([])
-    // …and neither is empty, so the assertion above cannot pass vacuously.
+    expect(storeAnswered.filter((v) => offCanvas.includes(v))).toEqual([])
+    expect(coldOpenable.filter((v) => offCanvas.includes(v))).toEqual([])
+    // …and none is empty, so the assertions above cannot pass vacuously.
     expect(storeAnswered.length).toBeGreaterThan(0)
     expect(coldOpenable.length).toBeGreaterThan(0)
+    expect(offCanvas.length).toBeGreaterThan(0)
   })
 
   it('does NOT change which project answers — routing is still by source (cecb4dfe stands)', () => {

--- a/src/renderer/lib/controlRouting.ts
+++ b/src/renderer/lib/controlRouting.ts
@@ -152,9 +152,10 @@ export function needsLiveCanvas(verb: string): boolean {
  * open needs somewhere to put the node, and a project's serialized nodes are somewhere.
  *
  * Deliberately NOT here: every verb that acts on nodes that already exist (`write`, `close`,
- * `group`, `move`, `arrange`, `align`, `verify`, `spawn-team`, `open-worktree`, `open-browser`,
- * `show-*`). They read live canvas state — measured node sizes, worktree staleness, the React Flow
- * edge arrays — that the serialized copy does not carry, so they keep travelling.
+ * `group`, `move`, `arrange`, `align`, `verify`, `spawn-team`, `open-worktree`). They read live
+ * canvas state — measured node sizes, worktree staleness, the React Flow edge arrays — that the
+ * serialized copy does not carry, so they keep travelling. The verbs that create a node with no
+ * session behind it are the third set below.
  */
 const COLD_OPENABLE_VERBS: ReadonlySet<string> = new Set([
   'open-terminal',
@@ -166,9 +167,52 @@ export function canColdOpen(verb: string): boolean {
   return COLD_OPENABLE_VERBS.has(verb)
 }
 
-/** Test-only view of the two sets, so their disjointness can be asserted rather than eyeballed. */
-export function controlVerbSetsForTests(): { storeAnswered: string[]; coldOpenable: string[] } {
-  return { storeAnswered: [...STORE_ANSWERED_VERBS], coldOpenable: [...COLD_OPENABLE_VERBS] }
+/**
+ * Verbs that create a DISPLAY node — one with no session behind it — and can therefore run against
+ * the owning project's serialized nodes without that canvas being on screen.
+ *
+ * The third set, and the reason it is not folded into `COLD_OPENABLE_VERBS`: a cold open has a
+ * launch to defer, so it moves the composed command into `pendingLaunch` and tells the caller the
+ * session is QUEUED. These four have nothing to defer. A web page, a video, an image and a browser
+ * node are inert wherever they sit; writing one into a project's serialized nodes is the whole
+ * effect, and it is complete the moment `writeDisk` returns. One set with two contracts inside it
+ * is how a caller ends up told a picture is queued.
+ *
+ * WHY they were still travelling after the cold-open fix: an agent that renders its output as a
+ * node — a report as `show-web`, a screenshot as `show-image` — is the commonest reason a
+ * background session touches the canvas at all, and every one of those calls yanked the human out
+ * of the project they were typing in. Same G5 objection, same answer as the two sets above.
+ *
+ * Deliberately NOT here: `browser`, which NAVIGATES an existing node and needs a mounted
+ * `<webview>` guest to do it. `open-browser` merely places the node; the guest is created when
+ * that project is next shown, exactly as a cold-opened terminal's PTY is.
+ *
+ * None of the four takes `--group`, which is why this set owes no worktree question. A verb
+ * joining it that does would: `cwdForNewNodeIn` subtracts the worktree store's `staleGroupIds`,
+ * which is epoch-scoped to the ACTIVE project, so off canvas that subtraction cannot be made.
+ */
+const OFF_CANVAS_VERBS: ReadonlySet<string> = new Set([
+  'show-image',
+  'show-video',
+  'show-web',
+  'open-browser'
+])
+
+export function answersOffCanvas(verb: string): boolean {
+  return OFF_CANVAS_VERBS.has(verb)
+}
+
+/** Test-only view of the three sets, so their disjointness can be asserted rather than eyeballed. */
+export function controlVerbSetsForTests(): {
+  storeAnswered: string[]
+  coldOpenable: string[]
+  offCanvas: string[]
+} {
+  return {
+    storeAnswered: [...STORE_ANSWERED_VERBS],
+    coldOpenable: [...COLD_OPENABLE_VERBS],
+    offCanvas: [...OFF_CANVAS_VERBS]
+  }
 }
 
 /**

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3703,7 +3703,7 @@ body,
   border-left: 3px solid var(--accent);
   border-radius: 10px;
   box-shadow: 0 8px 28px rgba(0, 0, 0, calc(0.45 * var(--shadow-k)));
-  font-size: 12.5px;
+  font-size: 13px;
   color: var(--text);
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5241,7 +5241,11 @@ body,
   gap: 8px;
 }
 
-.confirm__btn {
+/* The app's default button. `.announce-banner__action` shares the recipe rather than restating it:
+   a banner offering an ordinary next step ("Go there") is not asking for the accent treatment
+   `.announce-banner__btn` gives an install or a reload, and two copies of a default button drift. */
+.confirm__btn,
+.announce-banner__action {
   background: var(--panel-header);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -5251,8 +5255,13 @@ body,
   cursor: pointer;
 }
 
-.confirm__btn:hover {
+.confirm__btn:hover,
+.announce-banner__action:hover {
   background: rgba(var(--tint-rgb), 0.1);
+}
+
+.announce-banner__action {
+  flex: none;
 }
 
 .confirm__btn.danger {


### PR DESCRIPTION
Follow-up on #665, as invited when #664 was closed.

## What #665 left open

#665 stopped `open-terminal`, `open-claude` and `open-agent` from travelling to the calling agent's project. It left the four verbs that put something on screen still doing it: `show-image`, `show-video`, `show-web` and `open-browser`.

Those are the half an agent reaches for most. A skill that renders its report as HTML calls `show-web` every time it finishes, so in daily use the fix covered the rarer case. I work in several projects at once, and this is still the shape of it: I am typing in project 1, an agent in project 4 finishes and shows me its report, and I am now in project 4.

`controlRouting.ts:154-157` excludes them with the reason "they read live canvas state". True of `browser`, which navigates a mounted webview guest. Not true of the four that only place a node.

## The third set

Same objection, same answer, one set wider. `OFF_CANVAS_VERBS` is declared beside `STORE_ANSWERED_VERBS` and `COLD_OPENABLE_VERBS`, and the three are disjoint because they mean three different things: no canvas needed at either end, a canvas needed but the serialized one will do, and a node with no session behind it.

The third distinction is the reason this is not four more entries in `COLD_OPENABLE_VERBS`. A cold open has a launch to defer, so it arms `pendingLaunch` and reports `queued: true`. These four have nothing to defer. A page, a video, an image and a browser node are finished the moment `writeDisk` returns, and a caller told its screenshot is queued waits for something that already happened. They get `offCanvasReplyClause` and `offCanvas: true` instead.

`browser` stays on the travelling path. `open-browser` places the node; its guest is created when that project is next shown, exactly as a cold-opened terminal's PTY is.

## How it runs

The verb bodies are untouched. Three things they read from the canvas are staged.

`nodeCount()` replaces `nodesRef.current.length`, because off canvas the live array holds another project's nodes and the colour index would come from a count that has nothing to do with where the node lands.

The placement source is the stored node, hydrated through `nodeStatesToFlow` rather than hand-rolled, so its shape cannot drift from a live node's.

`addAndConnect` writes through `applyNodeMutation` + `appendCanvasLinks` + `writeDisk` instead of `setNodes` + `connect` + `markDirty`. The opener's edge is a rope and only a rope. A display node has nothing to read, so a bridge there would grant a context link the live path never draws, and the swap is a one-word edit, so it has its own pin.

`ctlProject` now resolves from the source's project. It was reading `activeProjectId`, which was correct only because the travel had just made the two the same project. Off canvas it decides the ssh flag, the browser session key and the media allowlist route.

## The notice

#665 answers the agent and says nothing to the person. A node lands in another project and nothing anywhere reports it.

A strip names the project, with a "Go there" button on the app's default button rather than the accent one `.announce-banner__btn` gives an install or a reload. `travelToNode` reopens a closed project first and resolves off the serialized nodes the write has already made, so the button lands on the node rather than on that project's saved camera.

It does not fade. Every other info strip reports something the user just did and is watching. This one reports work that landed while they were busy elsewhere, and once it fades nothing anywhere says it happened. The whole point of not travelling is that the choice to go and look stays theirs, and they can only make it if they are told there is something to look at.

One more line while I was in there. `.announce-banner__action` inherits `.confirm__btn`, which is `13px`, so the button sat a half pixel above the strip it lives in; `.announce-banner` goes to `13px` to match. Only that one. The stylesheet has 63 half-pixel font sizes across seven steps, 7.5 through 13.5, so they are a deliberate half-step scale rather than a slip, and lifting 12.5 on its own would drop it out of the run it belongs to.

## Routes

`active` is byte-identical: the branch sits inside the existing `if (!src)` guard. `switch` stages and does not travel. `reopen` (a closed project) stages too and does not reopen the tab, the same call #665 made and for the same reason, and both the reply clause and the notice say the project is closed. `blocked` and `unknown` are unchanged.

## Tests

- `lib/controlRouting.test.ts`: the four verbs in, 23 others out, three-way disjointness, `needsLiveCanvas` still true for the set, and `open-browser` vs `browser` stated side by side.
- `lib/coldOpen.test.ts`: the reply clause is additive over the closed case and never says "queued"; the notice copy singular and plural.
- `canvas/control-off-canvas.source.test.ts` (13): source pins on the dispatch block, the sibling of #665's own. It stands in front of the single travel in the routing block and the travel is its `else`; no travel, activate, reopen or camera move inside it; no `waitForCanvasNode`; the source comes from the owning project's serialized nodes; the write goes through the store and not `setNodes`/`setControlEdges`/`markDirty`; the edge is a rope and not a bridge; every display case asks `nodeCount()`; both voices are raised in one place and only after a node was made.
- `canvas/control-cold-open.source.test.ts`: `coldOpenBody()` now ends at the off-canvas guard instead of at the travel call, so #665's pins judge #665's block and cannot inherit a passing verdict from the one after it.
- `main/canvas-control-core.test.ts`: the agent-facing text, per the sync rule. Red on a display verb described as queued.

Mutation-verified, each reverted after:

| mutation | result |
|---|---|
| `answersOffCanvas` always true | 2 red |
| `answersOffCanvas` always false | 2 red |
| guard inverted | 17 red |
| `nodeCount` reads the live array | 1 red |
| `ctlProject` reads the active project | 1 red |
| the rope written as a bridge | 1 red |
| the notice allowed to fade | 1 red |
| "nothing is queued" flipped in the skill body | 1 red |

`npm run typecheck` clean. Full suite: 10726 passed, 13 pre-existing failures in this checkout (no tmux fixtures, no localStorage in the node environment) which fail identically on `origin/main`.

## Surfaces

Desktop and Server Edition are identical. This is renderer code plus `useProjects`, with no new IPC and no new bridge member. The kanban board has nothing to do: it shows cards for the active project, and this removes a project switch rather than adding one. Mobile is not applicable, it attaches to tmux sessions over the transport protocol and has no canvas to hijack.

## How to try it

Open two projects, A and B, with an agent node in B. From B's terminal:

```sh
(sleep 15; sh "<userData>/canvas-control/nodeterm.sh" show-web --url https://example.com) &
```

Switch to A and keep working. You stay in A, the strip names B, and the page is waiting there when you press "Go there".

## Not taken from #664

Two things from the closed PR I left out on purpose.

`appendProjectEdges` is gone. #665's `appendCanvasLinks` dedupes by endpoint pair in both directions, mine only by id, so this uses yours.

The worktree refusal is not here either. None of these four verbs takes `--group`, so the set owes no worktree question. The rule is written down for the next verb that does.
