### PR TITLE
fix(terminal): report command submission outcome

### DIFF
--- a/src/renderer/terminal/command-delivery.test.ts
+++ b/src/renderer/terminal/command-delivery.test.ts
@@ -1,3 +1,4 @@
+import type { DeliveryOutcome } from './command-delivery'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DELIVERY_ATTEMPTS,
@@ -226,11 +227,32 @@ describe('deliverCommand', () => {
 
   it('does not let a throwing Enter escape into the echo listener', () => {
     const f = throwingIo((d) => d === '\r')
-    let ends = 0
-    deliverCommand(f.io, CMD, () => (ends += 1))
+    const verdicts: DeliveryOutcome[] = []
+    deliverCommand(f.io, CMD, (outcome) => verdicts.push(outcome))
     expect(() => f.emit(CMD)).not.toThrow() // the throw would surface inside the PTY data callback
-    expect(ends).toBe(1) // the line was written and verified; only Enter was lost
+    expect(verdicts).toEqual(['cancelled']) // verified text is not a submission when Enter was lost
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('reports submitted only after the final Enter write succeeds', () => {
+    const f = fakeIo()
+    const verdicts: DeliveryOutcome[] = []
+    deliverCommand(f.io, CMD, (outcome) => verdicts.push(outcome))
+    expect(verdicts).toEqual([])
+    f.emit(CMD)
+    expect(verdicts).toEqual(['submitted'])
+    expect(f.writes.at(-1)).toBe('\r')
+  })
+
+  it('invokes a throwing settlement callback exactly once', () => {
+    const f = fakeIo()
+    const settled = vi.fn(() => {
+      throw new Error('consumer failed')
+    })
+    deliverCommand(f.io, CMD, settled)
+    expect(() => f.emit(CMD)).toThrow('consumer failed')
+    expect(settled).toHaveBeenCalledOnce()
+    expect(settled).toHaveBeenCalledWith('submitted')
   })
 
   it('ignores echo arriving after submit (no double Enter)', () => {

--- a/src/renderer/terminal/command-delivery.ts
+++ b/src/renderer/terminal/command-delivery.ts
@@ -85,9 +85,10 @@ export interface DeliveryIo {
 }
 
 /** Deliver `cmd` + Enter, echo-verified with bounded retries. Returns a cancel function
- *  (call on node teardown). `onSettled` fires exactly once when the delivery is over — submitted
- *  (verified or fail-open) or cancelled — for callers that must know when the LINE has left the
- *  pane, not merely when it was started: the retries run for up to
+ *  (call on node teardown). `onSettled` fires exactly once when the delivery is over and reports
+ *  whether the final Enter write succeeded, the line was too long, or delivery was cancelled.
+ *  Callers can use this to know when the LINE has left the pane, not merely when it was started:
+ *  the retries run for up to
  *  DELIVERY_ATTEMPTS × VERIFY_TIMEOUT_MS, and anything typed into the pane during that window
  *  lands inside the un-submitted line. The outcome argument is optional to read: every caller
  *  that only needs "the line has left the pane" keeps working unchanged. */
@@ -134,12 +135,25 @@ export function deliverCommand(
       return false
     }
   }
-  // Close the delivery BEFORE writing Enter: an io whose write echoes back synchronously (the
-  // in-place restart choreography feeds one) would otherwise re-enter the listener below while
-  // the tail still matches, and submit forever.
+  // Mark closed BEFORE writing Enter: an io whose write echoes back synchronously (the in-place
+  // restart choreography feeds one) would otherwise re-enter the listener below while the tail
+  // still matches, and submit forever. Announce success only AFTER that final write returns: the
+  // old ordering let a rejected Enter auto-dismiss a restart as successful.
   const submit = (): void => {
-    finish('submitted')
-    write('\r')
+    if (done) return
+    done = true
+    if (timer) clearTimeout(timer)
+    unsub?.()
+    let outcome: DeliveryOutcome = 'cancelled'
+    try {
+      io.write('\r')
+      outcome = 'submitted'
+    } catch {
+      // The transport rejected Enter. Report the failed submission below.
+    }
+    // Deliberately outside the transport try/catch: a caller callback that throws must still be
+    // invoked exactly once, and its own exception keeps propagating to that caller.
+    onSettled?.(outcome)
   }
   const tryOnce = (): void => {
     if (done) return
@@ -178,5 +192,5 @@ export function deliverCommand(
     }
   })
   tryOnce()
-  return finish
+  return () => finish()
 }


### PR DESCRIPTION
Command delivery now reports whether the final Enter write succeeded. Cancelled deliveries and failed writes report failure, allowing callers to distinguish submitted text from text still sitting in a terminal. The completion callback runs exactly once even when the callback itself throws.

Independent split from https://github.com/eneskirca/nodeterm/pull/715. The verified-restart draft consumes this result.

Validation: 18 focused delivery tests, TypeScript checks, and the production build passed; the patch applies cleanly to current main.