### PR TITLE
fix(subagents): allow transcript text selection

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -6077,6 +6077,12 @@ button.group-node__setup:disabled {
   color: #d6d6d6;
   white-space: pre-wrap;
   word-break: break-word;
+  /* The transcript is TEXT, not a terminal emulator: drag-select + copy must work (the node
+     root's canvas-drag suppression must not swallow it — keep `nowheel` for scroll, but the
+     selection below is what makes the content usable). */
+  user-select: text;
+  -webkit-user-select: text;
+  cursor: text;
 }
 
 .subagent-node__head {


### PR DESCRIPTION
Enable drag selection and copying in subagent transcript text by overriding the canvas node's selection suppression. The text cursor follows the selectable content.

Independent CSS-only split from https://github.com/eneskirca/nodeterm/pull/715.

Validation: inspected the six-line selector change and passed git diff --check. No runtime code changes.