### PR TITLE
feat(gateway): configure the model discovery path

### DIFF
--- a/src/core/agent-env-ipc.ts
+++ b/src/core/agent-env-ipc.ts
@@ -28,7 +28,7 @@ async function discoverModels(
   saved: ModelGatewaySettings | undefined,
   storedSecret: string | null
 ): Promise<ModelDiscoveryResult> {
-  const routes = modelGatewayRoutes(settings?.baseUrl ?? '')
+  const routes = modelGatewayRoutes(settings?.baseUrl ?? '', settings?.discoveryPath)
   const apiKeyField = settings?.apiKey ?? ''
   // SECURITY GATE — this handler is reachable by relay peers and Server Edition WS clients, and
   // `settings` (URL included) is caller-supplied. `${secret:…}` / `${env:…}` references resolve
@@ -37,6 +37,11 @@ async function discoverModels(
   // your own host. References therefore resolve ONLY when the requested baseUrl is byte-identical
   // to the persisted gateway URL; a literal key pasted into the form is the caller's own and may
   // be tested against any URL (the pre-save "does this key work?" flow in Settings).
+  //
+  // The discovery PATH needs no such byte-identity gate: `modelGatewayRoutes` reduces it to a
+  // validated path SUFFIX on the same baseUrl, so a forged one cannot aim the request — or the
+  // resolved key — at a different host; worst case is a 404 on the saved gateway, surfaced as an
+  // ordinary discovery error.
   const isReference = apiKeyField.includes('${')
   const trusted = !!settings?.baseUrl && settings.baseUrl === saved?.baseUrl
   if (isReference && !trusted) {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -1314,6 +1314,7 @@ export function Canvas() {
   }, [
     settings.modelGateway.baseUrl,
     settings.modelGateway.apiKey,
+    settings.modelGateway.discoveryPath,
     discoverModels,
     clearModels
   ])

--- a/src/renderer/components/settings/sections/ModelGatewaySection.test.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.test.tsx
@@ -77,6 +77,28 @@ describe('ModelGatewaySection credential modes', () => {
     expect(useSettings.getState().settings.modelGateway.apiKey).toBe('${env:GATEWAY_KEY}')
   })
 
+  it('persists the selected discovery path and previews its resolved endpoint', async () => {
+    await mount()
+    expect(host.textContent).toContain(
+      'Discovery: https://gateway.example.test/v1/models'
+    )
+
+    const openAiPath = [...host.querySelectorAll<HTMLInputElement>('input[type="radio"]')].find(
+      (input) => input.parentElement?.textContent?.includes('/openai/v1/models')
+    )!
+    await act(async () => {
+      openAiPath.click()
+    })
+
+    expect(useSettings.getState().settings.modelGateway.discoveryPath).toBe(
+      '/openai/v1/models'
+    )
+    expect(openAiPath.checked).toBe(true)
+    expect(host.textContent).toContain(
+      'Discovery: https://gateway.example.test/openai/v1/models'
+    )
+  })
+
   it('keeps a literal key write-only and stores only the secret sentinel in settings', async () => {
     await mount()
     const source = host.querySelector<HTMLSelectElement>('#model-gateway-credential-source')!

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -14,11 +14,6 @@ import { Select } from '@renderer/ui/Select'
 import { FieldRow } from '../FieldRow'
 import { SearchableRow } from '../SearchableRow'
 import { SettingsSection } from '../SettingsSection'
-import { SegmentedPill } from '@renderer/ui/SegmentedPill'
-
-/** The Model discovery endpoint picker. The first three write canonical gateway layouts; 'custom'
- *  reveals a free-text path (see the onChange comment in the row body). */
-type DiscoChoice = 'v1-models' | 'openai' | 'anthropic' | 'custom'
 
 const ROWS = {
   endpoint: {
@@ -78,12 +73,11 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
   const [credentialBusy, setCredentialBusy] = useState(false)
   const [credentialNotice, setCredentialNotice] = useState('')
 
-  // The "Model discovery endpoint" picker's transient editing state. The CURRENT value is read
-  // from `gateway.discoveryPath` every render (the source of truth), so a settings refresh keeps
-  // the pill in sync regardless of these locals — they only hold what the user is mid-typing.
+  // The "Model discovery endpoint" picker's transient editing state. The CURRENT selection is
+  // derived from `gateway.discoveryPath` every render (the source of truth); these locals only
+  // hold whether the custom text input is open and what the user is mid-typing into it.
   const [customMode, setCustomMode] = useState(false)
   const [customPath, setCustomPath] = useState('')
-  const [customChoice, setCustomChoice] = useState<DiscoChoice | null>(null)
   const routes = modelGatewayRoutes(gateway.baseUrl)
 
   const patchGateway = (patch: Partial<typeof gateway>): void => {
@@ -221,71 +215,107 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
       </SearchableRow>
 
       <SearchableRow {...ROWS.discoveryPath}>
-        <FieldRow
-          label="Model discovery endpoint"
-          description="Which gateway endpoint the model catalogue is read from. /v1/models is the OpenAI convention; /openai/v1/models and /anthropic/v1/models serve the same catalogue under a protocol prefix on some gateways. Only the discovery request changes — agent launches keep using the OpenAI and Anthropic launch routes below the Gateway URL."
-          htmlFor="model-gateway-discovery-path"
-          control={
-            <div className="w-80 space-y-2">
-              <SegmentedPill<DiscoChoice>
-                ariaLabel="Model discovery endpoint"
-                value={
-                  gateway.discoveryPath && gateway.discoveryPath !== '/v1/models'
-                    ? 'custom'
-                    : 'v1-models'
-                }
-                options={[
-                  { value: 'v1-models', label: '/v1/models' },
-                  { value: 'openai', label: '/openai/v1/models' },
-                  { value: 'anthropic', label: '/anthropic/v1/models' },
-                  { value: 'custom', label: 'Custom path…' }
-                  ]}
-                onChange={(choice) => {
-                  // The Custom option reveals a free-text path so an unknown-to-this-picker
-                  // layout is still expressible; v1/openai/anthropic write the canonical paths.
-                  // `undefined` (not '' or null) is the "use the conventional /v1/models" spelling
-                  // on ModelGatewaySettings.discoveryPath.
-                  if (choice === 'custom') {
-                    patchGateway({ discoveryPath: customPath || '/v1/models' })
-                    setCustomMode(true)
-                  } else {
-                    patchGateway({
-                      discoveryPath:
-                        choice === 'openai'
-                          ? '/openai/v1/models'
-                          : choice === 'anthropic'
-                            ? '/anthropic/v1/models'
-                            : undefined
-                    })
-                    setCustomMode(false)
-                    setCustomPath('')
-                  }
-                  setCustomChoice(choice)
-                }}
-              />
-              {(customMode || customChoice === 'custom') && (
-                <Input
-                  id="model-gateway-discovery-path"
-                  className="w-64 font-mono"
-                  type="text"
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder="/v1/models"
-                  value={customPath}
-                  onChange={(e) => {
-                    setCustomPath(e.target.value)
-                    patchGateway({ discoveryPath: e.target.value || undefined })
-                  }}
-                />
-              )}
+        <div className="space-y-2">
+          <div className="flex items-start justify-between gap-6">
+            <div>
+              <div className="text-sm font-medium text-text">Model discovery endpoint</div>
+              <p className="mt-1 max-w-xl text-[13px] text-muted">
+                Which gateway endpoint the model catalogue is read from. Only the discovery request
+                changes — agent launches keep using the OpenAI and Anthropic routes shown under the
+                Gateway URL.
+              </p>
             </div>
-          }
-        />
-        {gateway.discoveryPath && !routes ? (
-          <p className="text-right text-xs text-[color:var(--warn)]">
-            The path is ignored — fix the gateway URL above first.
-          </p>
-        ) : null}
+            {routes ? (
+              <div className="shrink-0 font-mono text-[11px] text-muted">
+                Discovery: {routes.discovery}
+              </div>
+            ) : null}
+          </div>
+          {/* Vertical radio group (the Speech-section pattern): one bordered row per endpoint.
+              `discoveryPath` absent = the conventional /v1/models row. Custom reveals a free-text
+              path so a layout this picker doesn't know is still expressible; the undefined spelling
+              means "use the conventional suffix" on ModelGatewaySettings. */}
+          {(() => {
+            const isCustomValue =
+              !!gateway.discoveryPath &&
+              gateway.discoveryPath !== '/v1/models' &&
+              gateway.discoveryPath !== '/openai/v1/models' &&
+              gateway.discoveryPath !== '/anthropic/v1/models'
+            return (
+              <div role="radiogroup" aria-label="Model discovery endpoint" className="space-y-2">
+                {(
+                  [
+                    {
+                      option: '/v1/models',
+                      label: '/v1/models',
+                      hint: 'OpenAI convention — the default.'
+                    },
+                    {
+                      option: '/openai/v1/models',
+                      label: '/openai/v1/models',
+                      hint: 'Same catalogue under the OpenAI launch-route prefix.'
+                    },
+                    {
+                      option: '/anthropic/v1/models',
+                      label: '/anthropic/v1/models',
+                      hint: 'Same catalogue under the Anthropic launch-route prefix.'
+                    },
+                    { option: 'custom', label: 'Custom path…', hint: 'Enter an exact path below.' }
+                  ] as const
+                ).map((opt) => (
+                  <div
+                    key={opt.option}
+                    className="flex items-center justify-between gap-3 rounded-md border border-border p-3"
+                  >
+                    <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3">
+                      <input
+                        type="radio"
+                        name="gateway-discovery-path"
+                        className="shrink-0"
+                        checked={
+                          opt.option === 'custom'
+                            ? isCustomValue
+                            : (gateway.discoveryPath ?? '/v1/models') === opt.option
+                        }
+                        onChange={() => {
+                          if (opt.option === 'custom') {
+                            setCustomMode(true)
+                            patchGateway({ discoveryPath: customPath || '/v1/models' })
+                          } else {
+                            setCustomMode(false)
+                            setCustomPath('')
+                            patchGateway({
+                              discoveryPath: opt.option === '/v1/models' ? undefined : opt.option
+                            })
+                          }
+                        }}
+                      />
+                      <div className="min-w-0">
+                        <span className="font-mono text-[13px] text-text">{opt.label}</span>
+                        <p className="text-[12px] text-muted">{opt.hint}</p>
+                      </div>
+                    </label>
+                  </div>
+                ))}
+              </div>
+            )
+          })()}
+          {customMode && (
+            <Input
+              id="model-gateway-discovery-path"
+              className="w-64 font-mono"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="/v1/models"
+              value={customPath}
+              onChange={(e) => {
+                setCustomPath(e.target.value)
+                patchGateway({ discoveryPath: e.target.value || undefined })
+              }}
+            />
+          )}
+        </div>
       </SearchableRow>
 
       <SearchableRow {...ROWS.key}>

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ChangeEvent } from 'react'
 import {
   MODEL_GATEWAY_SECRET_REF,
   modelGatewayCredentialKind,
@@ -14,6 +14,11 @@ import { Select } from '@renderer/ui/Select'
 import { FieldRow } from '../FieldRow'
 import { SearchableRow } from '../SearchableRow'
 import { SettingsSection } from '../SettingsSection'
+import { SegmentedPill } from '@renderer/ui/SegmentedPill'
+
+/** The Model discovery endpoint picker. The first three write canonical gateway layouts; 'custom'
+ *  reveals a free-text path (see the onChange comment in the row body). */
+type DiscoChoice = 'v1-models' | 'openai' | 'anthropic' | 'custom'
 
 const ROWS = {
   endpoint: {
@@ -72,6 +77,13 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
     useState<ModelGatewayCredentialStatus | null>(null)
   const [credentialBusy, setCredentialBusy] = useState(false)
   const [credentialNotice, setCredentialNotice] = useState('')
+
+  // The "Model discovery endpoint" picker's transient editing state. The CURRENT value is read
+  // from `gateway.discoveryPath` every render (the source of truth), so a settings refresh keeps
+  // the pill in sync regardless of these locals — they only hold what the user is mid-typing.
+  const [customMode, setCustomMode] = useState(false)
+  const [customPath, setCustomPath] = useState('')
+  const [customChoice, setCustomChoice] = useState<DiscoChoice | null>(null)
   const routes = modelGatewayRoutes(gateway.baseUrl)
 
   const patchGateway = (patch: Partial<typeof gateway>): void => {
@@ -210,24 +222,67 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
 
       <SearchableRow {...ROWS.discoveryPath}>
         <FieldRow
-          label="Discovery path"
-          description="Where the OpenAI-compatible model catalogue lives on the gateway — appended to the root URL. Leave as /v1/models unless your gateway serves it elsewhere (e.g. /openai/v1/models)."
+          label="Model discovery endpoint"
+          description="Which gateway endpoint the model catalogue is read from. /v1/models is the OpenAI convention; /openai/v1/models and /anthropic/v1/models serve the same catalogue under a protocol prefix on some gateways. Only the discovery request changes — agent launches keep using the OpenAI and Anthropic launch routes below the Gateway URL."
           htmlFor="model-gateway-discovery-path"
           control={
-            <Input
-              id="model-gateway-discovery-path"
-              className="w-64 font-mono"
-              type="text"
-              autoComplete="off"
-              spellCheck={false}
-              placeholder="/v1/models"
-              value={gateway.discoveryPath ?? ''}
-              onChange={(e) => patchGateway({ discoveryPath: e.target.value })}
-            />
+            <div className="w-80 space-y-2">
+              <SegmentedPill<DiscoChoice>
+                ariaLabel="Model discovery endpoint"
+                value={
+                  gateway.discoveryPath && gateway.discoveryPath !== '/v1/models'
+                    ? 'custom'
+                    : 'v1-models'
+                }
+                options={[
+                  { value: 'v1-models', label: '/v1/models' },
+                  { value: 'openai', label: '/openai/v1/models' },
+                  { value: 'anthropic', label: '/anthropic/v1/models' },
+                  { value: 'custom', label: 'Custom path…' }
+                  ]}
+                onChange={(choice) => {
+                  // The Custom option reveals a free-text path so an unknown-to-this-picker
+                  // layout is still expressible; v1/openai/anthropic write the canonical paths.
+                  // `undefined` (not '' or null) is the "use the conventional /v1/models" spelling
+                  // on ModelGatewaySettings.discoveryPath.
+                  if (choice === 'custom') {
+                    patchGateway({ discoveryPath: customPath || '/v1/models' })
+                    setCustomMode(true)
+                  } else {
+                    patchGateway({
+                      discoveryPath:
+                        choice === 'openai'
+                          ? '/openai/v1/models'
+                          : choice === 'anthropic'
+                            ? '/anthropic/v1/models'
+                            : undefined
+                    })
+                    setCustomMode(false)
+                    setCustomPath('')
+                  }
+                  setCustomChoice(choice)
+                }}
+              />
+              {(customMode || customChoice === 'custom') && (
+                <Input
+                  id="model-gateway-discovery-path"
+                  className="w-64 font-mono"
+                  type="text"
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="/v1/models"
+                  value={customPath}
+                  onChange={(e) => {
+                    setCustomPath(e.target.value)
+                    patchGateway({ discoveryPath: e.target.value || undefined })
+                  }}
+                />
+              )}
+            </div>
           }
         />
         {gateway.discoveryPath && !routes ? (
-          <p className="mt-2 text-right text-xs text-[color:var(--warn)]">
+          <p className="text-right text-xs text-[color:var(--warn)]">
             The path is ignored — fix the gateway URL above first.
           </p>
         ) : null}

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -21,6 +21,11 @@ const ROWS = {
     description: 'One gateway root URL for OpenAI-compatible discovery and agent routes.',
     keywords: ['openai compatible', 'bifrost', 'litellm', 'model', 'provider', 'base url', 'endpoint']
   },
+  discoveryPath: {
+    title: 'Discovery path',
+    description: 'Path the model catalogue is read from, appended to the gateway root.',
+    keywords: ['discover', 'models route', 'v1/models', 'openai/v1/models', 'catalogue path']
+  },
   key: {
     title: 'API key',
     description: 'A gateway bearer key from protected storage or an environment variable.',
@@ -200,6 +205,31 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
             <div>OpenAI: {routes.openai}</div>
             <div>Anthropic: {routes.anthropic}</div>
           </div>
+        ) : null}
+      </SearchableRow>
+
+      <SearchableRow {...ROWS.discoveryPath}>
+        <FieldRow
+          label="Discovery path"
+          description="Where the OpenAI-compatible model catalogue lives on the gateway — appended to the root URL. Leave as /v1/models unless your gateway serves it elsewhere (e.g. /openai/v1/models)."
+          htmlFor="model-gateway-discovery-path"
+          control={
+            <Input
+              id="model-gateway-discovery-path"
+              className="w-64 font-mono"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="/v1/models"
+              value={gateway.discoveryPath ?? ''}
+              onChange={(e) => patchGateway({ discoveryPath: e.target.value })}
+            />
+          }
+        />
+        {gateway.discoveryPath && !routes ? (
+          <p className="mt-2 text-right text-xs text-[color:var(--warn)]">
+            The path is ignored — fix the gateway URL above first.
+          </p>
         ) : null}
       </SearchableRow>
 

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ChangeEvent } from 'react'
+import { useEffect, useState } from 'react'
 import {
   MODEL_GATEWAY_SECRET_REF,
   modelGatewayCredentialKind,

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -262,41 +262,59 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
                     },
                     { option: 'custom', label: 'Custom path…', hint: 'Enter an exact path below.' }
                   ] as const
-                ).map((opt) => (
-                  <div
-                    key={opt.option}
-                    className="flex items-center justify-between gap-3 rounded-md border border-border p-3"
-                  >
-                    <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3">
-                      <input
-                        type="radio"
-                        name="gateway-discovery-path"
-                        className="shrink-0"
-                        checked={
-                          opt.option === 'custom'
-                            ? isCustomValue
-                            : (gateway.discoveryPath ?? '/v1/models') === opt.option
-                        }
-                        onChange={() => {
-                          if (opt.option === 'custom') {
-                            setCustomMode(true)
-                            patchGateway({ discoveryPath: customPath || '/v1/models' })
-                          } else {
-                            setCustomMode(false)
-                            setCustomPath('')
-                            patchGateway({
-                              discoveryPath: opt.option === '/v1/models' ? undefined : opt.option
-                            })
-                          }
-                        }}
-                      />
-                      <div className="min-w-0">
-                        <span className="font-mono text-[13px] text-text">{opt.label}</span>
-                        <p className="text-[12px] text-muted">{opt.hint}</p>
-                      </div>
-                    </label>
-                  </div>
-                ))}
+                ).map((opt) => {
+                  const checked =
+                    opt.option === 'custom'
+                      ? isCustomValue
+                      : (gateway.discoveryPath ?? '/v1/models') === opt.option
+                  return (
+                    <div
+                      key={opt.option}
+                      className={
+                        'flex items-center justify-between gap-3 rounded-md border p-3 transition-colors' +
+                        // The selected row is the one thing a scan must land on: accent border +
+                        // tinted fill, not just the (small, unstyled) native radio dot.
+                        (checked
+                          ? ' border-[color:var(--accent)] bg-[color:var(--accent)]/10'
+                          : ' border-border')
+                      }
+                    >
+                      <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3">
+                        <input
+                          type="radio"
+                          name="gateway-discovery-path"
+                          className="shrink-0"
+                          style={{ accentColor: 'var(--accent)' }}
+                          checked={checked}
+                          onChange={() => {
+                            if (opt.option === 'custom') {
+                              setCustomMode(true)
+                              patchGateway({ discoveryPath: customPath || '/v1/models' })
+                            } else {
+                              setCustomMode(false)
+                              setCustomPath('')
+                              patchGateway({
+                                discoveryPath: opt.option === '/v1/models' ? undefined : opt.option
+                              })
+                            }
+                          }}
+                        />
+                        <div className="min-w-0">
+                          <span
+                            className={
+                              checked
+                                ? 'font-mono text-[13px] font-medium text-text'
+                                : 'font-mono text-[13px] text-text'
+                            }
+                          >
+                            {opt.label}
+                          </span>
+                          <p className="text-[12px] text-muted">{opt.hint}</p>
+                        </div>
+                      </label>
+                    </div>
+                  )
+                })}
               </div>
             )
           })()}

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -263,10 +263,15 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
                     { option: 'custom', label: 'Custom path…', hint: 'Enter an exact path below.' }
                   ] as const
                 ).map((opt) => {
+                  // Custom is a MODE, not a stored alias value: `customMode` (this render
+                  // session's Custom selection) OR a persisted non-canonical path claims the
+                  // custom row. A custom seed of '/v1/models' before typing must NOT light the
+                  // first row — checked is single-owner: while customMode, the canonical rows
+                  // never light, whatever the field currently contains.
                   const checked =
                     opt.option === 'custom'
-                      ? isCustomValue
-                      : (gateway.discoveryPath ?? '/v1/models') === opt.option
+                      ? customMode || isCustomValue
+                      : !customMode && !isCustomValue && (gateway.discoveryPath ?? '/v1/models') === opt.option
                   return (
                     <div
                       key={opt.option}
@@ -288,8 +293,12 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
                           checked={checked}
                           onChange={() => {
                             if (opt.option === 'custom') {
+                              // Seed the input with the CURRENT stored path (or the conventional
+                              // default) so the box never shows empty over a live value. The
+                              // stored path is NOT rewritten here — Custom is only a mode until
+                              // the input itself is edited.
                               setCustomMode(true)
-                              patchGateway({ discoveryPath: customPath || '/v1/models' })
+                              setCustomPath(gateway.discoveryPath ?? '/v1/models')
                             } else {
                               setCustomMode(false)
                               setCustomPath('')

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -78,7 +78,7 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
   // hold whether the custom text input is open and what the user is mid-typing into it.
   const [customMode, setCustomMode] = useState(false)
   const [customPath, setCustomPath] = useState('')
-  const routes = modelGatewayRoutes(gateway.baseUrl)
+  const routes = modelGatewayRoutes(gateway.baseUrl, gateway.discoveryPath)
 
   const patchGateway = (patch: Partial<typeof gateway>): void => {
     const current = useSettings.getState().settings.modelGateway
@@ -143,7 +143,10 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
       const current = useSettings.getState().settings.modelGateway
       // Replacing a key leaves the settings sentinel unchanged, so Canvas's value-based effect has
       // no dependency change to observe. A first save does change it and gets the normal debounce.
-      if (replacingStoredKey && modelGatewayRoutes(current.baseUrl)) {
+      if (
+        replacingStoredKey &&
+        modelGatewayRoutes(current.baseUrl, current.discoveryPath)
+      ) {
         void discover({ ...current, apiKey: MODEL_GATEWAY_SECRET_REF })
       }
       setCredentialNotice('API key saved securely.')

--- a/src/shared/agents/model-gateway.test.ts
+++ b/src/shared/agents/model-gateway.test.ts
@@ -33,6 +33,38 @@ describe('modelGatewayRoutes', () => {
     expect(modelGatewayRoutes('https://example.test/#fragment')).toBeNull()
     expect(modelGatewayRoutes('not a URL')).toBeNull()
   })
+
+  it('appends a supplied discovery path instead of the conventional /v1/models', () => {
+    expect(modelGatewayRoutes('https://bifrost.example.test', '/openai/v1/models')).toEqual({
+      discovery: 'https://bifrost.example.test/openai/v1/models',
+      openai: 'https://bifrost.example.test/openai/v1',
+      anthropic: 'https://bifrost.example.test/anthropic'
+    })
+  })
+
+  it('falls back to /v1/models when the discovery path is absent, empty, or unsafe', () => {
+    // Absent/empty = the conventional suffix. Unsafe values (full URLs — a caller-chosen host
+    // would be a credential-exfiltration oracle — query, fragment, traversal) degrade to the
+    // derived default, never to a fetch somewhere unvetted.
+    expect(modelGatewayRoutes('https://bifrost.example.test', undefined)?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', '')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', 'https://evil.test/x')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', '/../etc')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', '/x?y=1')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', '/x#f')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+  })
 })
 
 describe('parseGatewayModels', () => {

--- a/src/shared/agents/model-gateway.ts
+++ b/src/shared/agents/model-gateway.ts
@@ -8,6 +8,28 @@ export interface ModelGatewaySettings {
   baseUrl: string
   /** Literal legacy key, `${env:VAR}` reference, or `MODEL_GATEWAY_SECRET_REF`. */
   apiKey: string
+  /** Path the discovery (Models API) request is sent to, appended to `baseUrl` — e.g.
+   *  `/openai/v1/models` for a gateway that serves its model catalogue under a protocol prefix.
+   *  Deliberately a PATH SUFFIX and never a full URL: discovery sends the resolved API key to the
+   *  target, and a caller-chosen host would turn the pre-save/relay flow into a credential-exfil-
+   *  tration oracle (the same reason `${env:VAR}` references resolve only for the saved baseUrl).
+   *  Empty/absent = the conventional derived `/v1/models` (see `modelGatewayRoutes`). */
+  discoveryPath?: string
+}
+
+/** Characters a discovery path may contain, minus URL structure that could change WHERE the
+ *  request goes: no query (`?`), fragment (`#`), dot-dot traversal, or second scheme. The value is
+ *  hand-editable settings.json AND caller-supplied over IPC, so it is re-validated at the point it
+ *  is appended to the root (the same rule as permission modes / model ids on a command line) — an
+ *  unrecognized value yields the derived default path, never a guessed one. */
+const GATEWAY_DISCOVERY_PATH = /^\/[A-Za-z0-9\-._~!$&'()*+,;=:@/]*$/
+
+/** A validated discovery path, or null when absent/unsafe (null ⇒ use the derived default). */
+export function sanitizedGatewayDiscoveryPath(path: string | undefined): string | null {
+  const value = path?.trim() ?? ''
+  if (!value) return null
+  if (value.length > 500 || value.includes('..') || !GATEWAY_DISCOVERY_PATH.test(value)) return null
+  return value.replace(/\/+$/, '') || null
 }
 
 /** Stored in settings.json when the literal credential lives in the shell's secret store. */
@@ -100,8 +122,18 @@ export function resolveModelGatewayApiKey(
  * the provider-specific paths are the Bifrost layout requested by the launch mapping. Only http(s)
  * URLs are accepted: this value is later handed to `fetch` and agent CLIs, and settings.json is
  * hand-editable. Invalid input degrades to null, never to a guessed endpoint.
+ *
+ * `discoveryPath` (optional, from the same `ModelGatewaySettings`) replaces the conventional
+ * `/v1/models` suffix when it is present and passes `sanitizedGatewayDiscoveryPath`. It changes
+ * only WHICH path on the saved root the catalogue is read from — never the host — so the
+ * credential trust gate upstream (references resolve only for the saved baseUrl) is unaffected.
+ * An unsafe value falls back to the derived default rather than sending a fetch somewhere the
+ * user did not vet.
  */
-export function modelGatewayRoutes(baseUrl: string): ModelGatewayRoutes | null {
+export function modelGatewayRoutes(
+  baseUrl: string,
+  discoveryPath?: string
+): ModelGatewayRoutes | null {
   const raw = baseUrl.trim().replace(/\/+$/, '')
   if (!raw) return null
   try {
@@ -111,8 +143,9 @@ export function modelGatewayRoutes(baseUrl: string): ModelGatewayRoutes | null {
     // The separate API-key field exists precisely so a secret never has to live there.
     if (parsed.username || parsed.password || parsed.search || parsed.hash) return null
     const root = parsed.toString().replace(/\/+$/, '')
+    const discoverySuffix = sanitizedGatewayDiscoveryPath(discoveryPath) ?? '/v1/models'
     return {
-      discovery: `${root}/v1/models`,
+      discovery: `${root}${discoverySuffix}`,
       openai: `${root}/openai/v1`,
       anthropic: `${root}/anthropic`
     }


### PR DESCRIPTION
Gateways can expose their model catalogue at /v1/models, /openai/v1/models, or a custom path under the saved gateway URL. Settings now provide that choice, preview the effective endpoint, and refresh discovery when the path changes. Path validation keeps credentials on the configured host and falls back for unsafe input.

Independent split from https://github.com/eneskirca/nodeterm/pull/715.

Validation: 21 focused route/settings tests, TypeScript checks, production and Codex relay builds, and diff checks passed using the lockfile dependencies. Regression coverage verifies that selecting a path persists it and updates the displayed endpoint.