### PR TITLE
feat(agents): inspect masked session environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1198,6 +1198,14 @@ else, and its context links must keep classifying across restarts).
   the shared mapping. Desktop and Server Edition use the same core handler; relay tabs deliberately
   do not apply this machine's gateway to another core. Mobile needs a settings/model-picker surface
   before it can expose the feature.
+  **Spawn-environment visibility:** `pty.envInfo(persistKey)` (`pty:env-info`) supplies the context
+  meter on canvas nodes, kanban cards and card modals with the environment for that session. A
+  current local spawn returns the masked core capture (`source: 'spawn'`); an older local or SSH
+  session falls back to its tmux session environment (`source: 'tmux'`); a missing session or failed
+  read returns the explicit `unavailable` state. Credential-shaped names and values are irreversibly
+  masked in `core/pty-env-info.ts` before crossing IPC. The fallback parses `show-environment -s`
+  without evaluating its shell output, including multiline values and tmux's `unset NAME;` form
+  (the plain output spells the same removed-variable fact as `-NAME`).
 - **Grok** (`@xai-official/grok` 1.0.0, builtin since 2026-08) — in `AGENT_HOOK_TARGETS`,
   `RESUMABLE_AGENTS`, `RENAME_CAPABLE`, `PERMISSION_MODE_CAPABLE`, `CANVAS_CONTROL_CAPABLE`,
   `CONTEXT_LINK_CAPABLE`, `CHAT_CAPABLE`, `TRANSFER_SOURCE_CAPABLE`, `USAGE_CAPABLE` and

--- a/src/core/pty-env-info.test.ts
+++ b/src/core/pty-env-info.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSecretEnvKey,
+  isSecretEnvValue,
+  maskPtyEnv,
+  maskPtyEnvVar,
+  parseTmuxSessionEnv
+} from './pty-env-info'
+
+describe('isSecretEnvKey', () => {
+  it('marks the credential-shaped names the env layers actually write', () => {
+    expect(isSecretEnvKey('ANTHROPIC_AUTH_TOKEN')).toBe(true)
+    expect(isSecretEnvKey('ANTHROPIC_API_KEY')).toBe(true)
+    expect(isSecretEnvKey('OPENAI_API_KEY')).toBe(true)
+    expect(isSecretEnvKey('COPILOT_PROVIDER_API_KEY')).toBe(true)
+    expect(isSecretEnvKey('MY_CUSTOM_OAUTH_SECRET')).toBe(true)
+    expect(isSecretEnvKey('my_project_password')).toBe(true)
+  })
+
+  it('does NOT mark plain config names — including suffix look-alikes', () => {
+    // The gateway / autocompact / hook vars carry no credential.
+    expect(isSecretEnvKey('ANTHROPIC_BASE_URL')).toBe(false)
+    expect(isSecretEnvKey('CLAUDE_CODE_AUTO_COMPACT_WINDOW')).toBe(false)
+    expect(isSecretEnvKey('CLAUDE_AUTOCOMPACT_PCT_OVERRIDE')).toBe(false)
+    expect(isSecretEnvKey('CLAUDE_CODE_SUBAGENT_MODEL')).toBe(false)
+    expect(isSecretEnvKey('CLAUDE_CONFIG_DIR')).toBe(false)
+    expect(isSecretEnvKey('NODETERM_HOOK_ENDPOINT')).toBe(false)
+    // Socket/pid names end in SOCK/PID and must not mask.
+    expect(isSecretEnvKey('SSH_AUTH_SOCK')).toBe(false)
+    expect(isSecretEnvKey('SSH_AGENT_PID')).toBe(false)
+  })
+})
+
+describe('isSecretEnvValue', () => {
+  it('finds credentials hidden behind ordinary URL and connection-string names', () => {
+    expect(isSecretEnvValue('postgres://app:super-secret@db.internal/app')).toBe(true)
+    expect(isSecretEnvValue('jdbc:postgresql://app:super-secret@db.internal/app')).toBe(true)
+    expect(isSecretEnvValue('Server=db;User Id=app;Password=super-secret')).toBe(true)
+    expect(isSecretEnvValue('-----BEGIN PRIVATE KEY-----\nabc')).toBe(true)
+  })
+
+  it('keeps ordinary diagnostic endpoints visible', () => {
+    expect(isSecretEnvValue('https://bifrost.example/anthropic')).toBe(false)
+    expect(isSecretEnvValue('postgres://db.internal/app')).toBe(false)
+    expect(isSecretEnvValue('/usr/local/bin:/usr/bin:/bin')).toBe(false)
+  })
+})
+
+describe('maskPtyEnvVar', () => {
+  it('masks a secret value keeping only the ends', () => {
+    const v = maskPtyEnvVar('ANTHROPIC_AUTH_TOKEN', 'sk-ant-01234567890abcdefghijklmnop', true)
+    expect(v.secret).toBe(true)
+    expect(v.value.startsWith('sk-')).toBe(true)
+    expect(v.value.endsWith('mnop')).toBe(true)
+    expect(v.value).not.toContain('0123456789')
+  })
+
+  it('short secrets mask completely (no ends to preserve)', () => {
+    const v = maskPtyEnvVar('TOKEN', 'abc', true)
+    expect(v.secret).toBe(true)
+    expect(v.value).toBe('•••')
+  })
+
+  it('a non-secret value passes verbatim; an unset var reports "(not set)"', () => {
+    expect(maskPtyEnvVar('CLAUDE_CODE_AUTO_COMPACT_WINDOW', '400000', true)).toEqual({
+      key: 'CLAUDE_CODE_AUTO_COMPACT_WINDOW',
+      value: '400000'
+    })
+    expect(maskPtyEnvVar('SOMETHING_UNSET', undefined, false)).toEqual({
+      key: 'SOMETHING_UNSET',
+      value: '(not set)',
+      set: false
+    })
+  })
+
+  it('masks credential-bearing values even when the environment name looks harmless', () => {
+    const v = maskPtyEnvVar('DATABASE_URL', 'postgres://app:super-secret@db.internal/app', true)
+    expect(v.secret).toBe(true)
+    expect(v.value).not.toContain('super-secret')
+  })
+})
+
+describe('maskPtyEnv', () => {
+  it('renders the whole map sorted by key, masking only credentials', () => {
+    const vars = maskPtyEnv({
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: '400000',
+      ANTHROPIC_AUTH_TOKEN: 'sk-very-secret-value-here',
+      ANTHROPIC_BASE_URL: 'https://bifrost.example/anthropic'
+    })
+    expect(vars.map((v) => v.key)).toEqual([
+      'ANTHROPIC_AUTH_TOKEN',
+      'ANTHROPIC_BASE_URL',
+      'CLAUDE_CODE_AUTO_COMPACT_WINDOW'
+    ])
+    expect(vars[0].secret).toBe(true)
+    expect(vars[0].value).not.toContain('secret-value')
+    expect(vars[1].value).toBe('https://bifrost.example/anthropic')
+    expect(vars[2].value).toBe('400000')
+  })
+})
+
+describe('parseTmuxSessionEnv', () => {
+  it('parses shell-formatted records, masks credentials, and sorts', () => {
+    const vars = parseTmuxSessionEnv(
+      [
+        'CLAUDE_CODE_AUTO_COMPACT_WINDOW="400000"; export CLAUDE_CODE_AUTO_COMPACT_WINDOW;',
+        'ANTHROPIC_AUTH_TOKEN="sk-live-token-abcdef"; export ANTHROPIC_AUTH_TOKEN;',
+        'PATH="/usr/bin:/bin"; export PATH;'
+      ].join('\n') + '\n'
+    )
+    expect(vars.map((v) => v.key)).toEqual([
+      'ANTHROPIC_AUTH_TOKEN',
+      'CLAUDE_CODE_AUTO_COMPACT_WINDOW',
+      'PATH'
+    ])
+    expect(vars[0].secret).toBe(true)
+    expect(vars[0].value).not.toContain('abcdef')
+    expect(vars[1].value).toBe('400000')
+    expect(vars[2].value).toBe('/usr/bin:/bin')
+  })
+
+  it('renders an unset var as "(not set)", never as a blank cell', () => {
+    const vars = parseTmuxSessionEnv(
+      ['unset OPENAI_API_KEY;', 'TERM="tmux-256color"; export TERM;'].join('\n') + '\n'
+    )
+    const unset = vars.find((v) => v.key === 'OPENAI_API_KEY')
+    expect(unset).toEqual({ key: 'OPENAI_API_KEY', value: '(not set)', set: false })
+  })
+
+  it('keeps multiline secrets and embedded fake records inside one masked value', () => {
+    const vars = parseTmuxSessionEnv(
+      'DEMO_TOKEN="artificial-secret-line1\nINNOCENT=artificial-secret-line2"; export DEMO_TOKEN;\n' +
+        'KEY_MATERIAL="-----BEGIN PRIVATE KEY-----\nEVIL=\\"visible\\"; export EVIL;"; export KEY_MATERIAL;\n'
+    )
+    expect(vars.map((v) => v.key)).toEqual(['DEMO_TOKEN', 'KEY_MATERIAL'])
+    expect(vars.every((v) => v.secret)).toBe(true)
+    expect(vars.some((v) => v.key === 'INNOCENT' || v.key === 'EVIL')).toBe(false)
+  })
+
+  it('decodes only the quoting escapes emitted by tmux and preserves literal controls', () => {
+    const vars = parseTmuxSessionEnv(
+      'VALUE="space newline\ntab\t quote\\" slash\\\\ dollar\\$ tick\\`"; export VALUE;\n'
+    )
+    expect(vars).toEqual([
+      { key: 'VALUE', value: 'space newline\ntab\t quote" slash\\ dollar$ tick`' }
+    ])
+  })
+
+  it.each([
+    'BROKEN="unterminated',
+    'A="value"; export B;\n',
+    'A-B="value"; export A-B;\n',
+    'A="bad\\q"; export A;\n',
+    'A="one"; export A;\nA="two"; export A;\n',
+    'A="one"; export A;\r\n',
+    'stray text\n'
+  ])('fails closed on malformed shell output %#', (stdout) => {
+    expect(() => parseTmuxSessionEnv(stdout)).toThrow()
+  })
+})

--- a/src/core/pty-env-info.ts
+++ b/src/core/pty-env-info.ts
@@ -1,0 +1,159 @@
+// The spawned-env capture the context meter's popover renders (`pty.envInfo`).
+//
+// WHY CORE, not inline in pty-manager: masking is a security decision, the "is this key a
+// credential" rule is one list, and the tmux fallback reader (`show-environment`) is a second
+// query path the same rules must cover — a third copy of the rule is exactly the drift class
+// CLAUDE.md bans (one definition in core, consumed by every shell).
+//
+// SECURITY — the renderer never sees a raw credential. The whole map is masked HERE, before the
+// session record is written, so even the tmux-source path cannot leak a raw token. The popover has
+// no reveal path: once core marks a value secret, only its masked representation crosses IPC.
+
+import type { PtyEnvVar } from '../shared/types'
+
+/**
+ * Keys the popover must mask by default. Matched case-insensitively on anything that smells
+ * like a credential, plus the gateway/auth attributes by name. Deliberately NAME-based, not a
+ * hand list of every var: a future env layer (project env, custom-agent env) can introduce a
+ * key name with no ancestor in this file and it still masks.
+ */
+const SECRET_NAME_PARTS = [
+  'token',
+  'key',
+  'secret',
+  'auth',
+  'credential',
+  'password',
+  'passwd',
+  'bearer',
+  'apikey',
+  'cookie'
+] as const
+
+/** Exact non-secret names that end in the suspicious suffixes but are nothing of the sort. */
+const SECRET_NAME_EXEMPT = new Set([
+  'SSH_AGENT_PID',
+  'SSH_AUTH_SOCK',
+  'NODETERM_HOOK_SOCK',
+  'NODETERMPERM'
+])
+
+export function isSecretEnvKey(key: string): boolean {
+  if (SECRET_NAME_EXEMPT.has(key)) return false
+  const k = key.toLowerCase()
+  return SECRET_NAME_PARTS.some((p) => k.includes(p))
+}
+
+/**
+ * Credentials sometimes hide behind innocent names (`DATABASE_URL`, `REDIS_URL`, `SENTRY_DSN`).
+ * Inspect the value at the core boundary too: URI userinfo, connection-string password fields,
+ * and private-key material must never ride to the renderer merely because their key lacked a
+ * familiar suffix. Ordinary endpoint URLs remain visible for the popover's diagnostic purpose.
+ */
+export function isSecretEnvValue(value: string): boolean {
+  if (/-----BEGIN (?:[A-Z0-9]+ )?PRIVATE KEY-----/.test(value)) return true
+  if (/(?:^|[;\s])(?:password|passwd|pwd|token|secret|api[_-]?key)\s*=/i.test(value)) return true
+  try {
+    const parsed = new URL(value)
+    if (parsed.username || parsed.password) return true
+  } catch {
+    // Fall through to the nested/opaque URI check below.
+  }
+  // Covers JDBC-style nested schemes that WHATWG URL accepts but parses as an opaque path.
+  return /^[A-Za-z][A-Za-z0-9+.-]*:(?:[A-Za-z][A-Za-z0-9+.-]*:)?\/\/[^/\s:@]+(?::[^@\s]*)?@/.test(
+    value
+  )
+}
+
+/** Mask a secret value: first 3 + last 4 chars visible, middle elided. Same shape the terminal
+ *  industry uses for masking in logs/printouts. */
+function maskSecret(value: string): string {
+  if (value.length <= 8) return '•'.repeat(Math.max(value.length, 1))
+  return `${value.slice(0, 3)}${'•'.repeat(value.length - 8)}${value.slice(-4)}`
+}
+
+/**
+ * The mask applied to every var leaving core.
+ *
+ * Set: rendered verbatim unless secret-marked. Unset (the shell shows the var name but tmux has
+ * no value for it): rendered so the popover can say "not set" instead of a blank cell.
+ */
+export function maskPtyEnvVar(key: string, value: string | undefined, wasSet: boolean): PtyEnvVar {
+  if (!wasSet || value === undefined) return { key, value: '(not set)', set: false }
+  if (isSecretEnvKey(key) || isSecretEnvValue(value))
+    return { key, value: maskSecret(value), secret: true }
+  return { key, value }
+}
+
+/** Mask a whole composed env map (sorted by key for a stable popover). */
+export function maskPtyEnv(env: Record<string, string>): PtyEnvVar[] {
+  return Object.keys(env)
+    .sort()
+    .map((k) => maskPtyEnvVar(k, env[k], true))
+}
+
+/** Parse `tmux show-environment -s` without evaluating its shell-formatted output. Values may
+ * contain literal newlines, so this must scan the whole buffer rather than split it into lines. */
+export function parseTmuxSessionEnv(stdout: string): PtyEnvVar[] {
+  const out: PtyEnvVar[] = []
+  const seen = new Set<string>()
+  let at = 0
+  const nameAt = (): string => {
+    const match = /^[A-Za-z_][A-Za-z0-9_]*/.exec(stdout.slice(at))
+    if (!match) throw new Error('invalid tmux environment variable name')
+    at += match[0].length
+    return match[0]
+  }
+  const finishRecord = (): void => {
+    if (stdout[at] === '\n') at += 1
+    else if (at !== stdout.length) throw new Error('invalid tmux environment record separator')
+  }
+
+  while (at < stdout.length) {
+    if (stdout.startsWith('unset ', at)) {
+      at += 'unset '.length
+      const key = nameAt()
+      if (stdout.slice(at, at + 1) !== ';') throw new Error('invalid tmux unset record')
+      at += 1
+      finishRecord()
+      if (seen.has(key)) throw new Error('duplicate tmux environment variable')
+      seen.add(key)
+      out.push(maskPtyEnvVar(key, undefined, false))
+      continue
+    }
+
+    const key = nameAt()
+    if (stdout.slice(at, at + 2) !== '="') throw new Error('invalid tmux assignment record')
+    at += 2
+    let value = ''
+    let closed = false
+    while (at < stdout.length) {
+      const char = stdout[at++]
+      if (char === '"') {
+        closed = true
+        break
+      }
+      if (char !== '\\') {
+        value += char
+        continue
+      }
+      if (at >= stdout.length) throw new Error('dangling tmux environment escape')
+      const escaped = stdout[at++]
+      if (escaped !== '"' && escaped !== '\\' && escaped !== '$' && escaped !== '`') {
+        throw new Error('unsupported tmux environment escape')
+      }
+      value += escaped
+    }
+    if (!closed) throw new Error('unterminated tmux environment value')
+    const suffix = `; export ${key};`
+    if (stdout.slice(at, at + suffix.length) !== suffix) {
+      throw new Error('invalid tmux export record')
+    }
+    at += suffix.length
+    finishRecord()
+    if (seen.has(key)) throw new Error('duplicate tmux environment variable')
+    seen.add(key)
+    out.push(maskPtyEnvVar(key, value, true))
+  }
+  return out.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+}

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -670,6 +670,8 @@ interface Session {
   accountFallback?: boolean
   /** Masked snapshot of the fully composed environment for this session generation. */
   spawnEnv?: PtyEnvVar[]
+  /** Masked candidate withheld until the backend proves this generation was freshly created. */
+  pendingSpawnEnv?: PtyEnvVar[]
   /**
    * This session is backed by the session-host process (docs/windows-session-host.md), not a
    * local tmux — selected only when no local tmux was found (primarily Windows). `session.proc`
@@ -2198,6 +2200,13 @@ export class PtyManager {
       projectOverrides
     )
     const spawned = this.sessions.get(sessionId)
+    // A tmux attach runs a newly composed CLIENT env beside an older pane. Publish that env only
+    // when the pre-spawn probe proved this generation was created; warm sessions fall back to the
+    // tmux session environment instead. Session-host learns the same fact asynchronously below.
+    if (spawned && !spawned.sessionHost) {
+      spawned.spawnEnv = fresh ? spawned.pendingSpawnEnv : undefined
+      spawned.pendingSpawnEnv = undefined
+    }
     // PANE OWNERSHIP (agent messaging, PR #237 fix round 2): record the OWNING project of a pane
     // this process just GENUINELY spawned. Gated on `fresh` — an attach/co-attach to a session
     // someone else spawned (incl. an app-restart re-attach) leaves the pane UNPROVEN, so a second
@@ -2235,6 +2244,8 @@ export class PtyManager {
         }
         fresh = info.fresh
         screen = info.screen
+        spawned.spawnEnv = fresh ? spawned.pendingSpawnEnv : undefined
+        spawned.pendingSpawnEnv = undefined
         // Session-host registration is provisional until the exact ready barrier above succeeds.
         // Only now is an owner's resurrection real enough to remove a prior deletion tombstone.
         if (spawned.indexKey) this.tombstones.delete(spawned.indexKey)
@@ -2802,12 +2813,6 @@ export class PtyManager {
       customEnvMerged = merged.env
     }
 
-    // `env` is now fully composed. Remote sessions compose their environment on the host, so
-    // their fallback is the remote tmux session environment rather than this local SSH client env.
-    const spawnEnvCapture: PtyEnvVar[] | undefined = options.sshRemote
-      ? undefined
-      : maskPtyEnv(env)
-
     const settings = this.getSettings()
     let file: string
     let args: string[]
@@ -3192,7 +3197,9 @@ export class PtyManager {
       unwatchedSince: null,
       pausedBy: new Set<string>(),
       accountFallback,
-      spawnEnv: spawnEnvCapture,
+      // `env` is fully composed by this point. SSH would capture the local client environment,
+      // while detached paths provide no freshness proof, so neither publishes a candidate.
+      pendingSpawnEnv: !options.sshRemote && !sinks ? maskPtyEnv(env) : undefined,
       sessionHost: useSessionHost
     }
     // Both shared timers are armed by the first session that needs them: the scrollback snapshots
@@ -4063,6 +4070,7 @@ export class PtyManager {
       return { source: 'unavailable', vars: [] }
     }
     const live = this.liveSessionForPersistKey(persistKey)
+    if (!live) return { source: 'unavailable', vars: [] }
     if (live?.sessionHost) {
       return live.spawnEnv
         ? { source: 'spawn', vars: live.spawnEnv }

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -31,6 +31,7 @@ import {
   remotePasteDelivery,
   remoteCapturePaneArgs,
   remotePaneCommandArgs,
+  remoteShowEnvironmentArgs,
   remotePaneOwnerCombinedArgs,
   remotePaneProcessArgs,
   remoteTerminateForegroundArgs,
@@ -128,6 +129,8 @@ import {
 } from './session-host-backend'
 import type { SessionHostPty } from './session-host-pty'
 import type { ProjectSpawnOverrides, ProjectSpawnOverridesReader } from './project-spawn-overrides'
+import { maskPtyEnv, parseTmuxSessionEnv } from './pty-env-info'
+import type { PtyEnvInfo, PtyEnvVar } from '../shared/types'
 
 // How often we snapshot a live tmux session's scrollback to disk, so a machine reboot (which
 // kills the tmux server) can still replay recent output on cold restart. A final snapshot also
@@ -665,6 +668,8 @@ interface Session {
   /** True when this node had an `accountId` but its config dir was gone at spawn, so we fell back
    *  to the system account. `create()` surfaces it to the renderer (warning chip). */
   accountFallback?: boolean
+  /** Masked snapshot of the fully composed environment for this session generation. */
+  spawnEnv?: PtyEnvVar[]
   /**
    * This session is backed by the session-host process (docs/windows-session-host.md), not a
    * local tmux — selected only when no local tmux was found (primarily Windows). `session.proc`
@@ -1729,6 +1734,7 @@ export class PtyManager {
     )
     platform().handle(IPC.ptyTmuxStatus, () => this.tmuxStatus())
     platform().handle(IPC.ptyPaneCommand, (persistKey: string) => this.paneCommand(persistKey))
+    platform().handle(IPC.ptyEnvInfo, (persistKey: string) => this.envInfo(persistKey))
     platform().handle(IPC.ptyTerminateForeground, (persistKey: string, expectedAgentId?: string) =>
       this.terminateForeground(persistKey, expectedAgentId)
     )
@@ -2796,6 +2802,12 @@ export class PtyManager {
       customEnvMerged = merged.env
     }
 
+    // `env` is now fully composed. Remote sessions compose their environment on the host, so
+    // their fallback is the remote tmux session environment rather than this local SSH client env.
+    const spawnEnvCapture: PtyEnvVar[] | undefined = options.sshRemote
+      ? undefined
+      : maskPtyEnv(env)
+
     const settings = this.getSettings()
     let file: string
     let args: string[]
@@ -3180,6 +3192,7 @@ export class PtyManager {
       unwatchedSince: null,
       pausedBy: new Set<string>(),
       accountFallback,
+      spawnEnv: spawnEnvCapture,
       sessionHost: useSessionHost
     }
     // Both shared timers are armed by the first session that needs them: the scrollback snapshots
@@ -4040,6 +4053,54 @@ export class PtyManager {
       return stdout.trim() || null
     } catch {
       return null
+    }
+  }
+
+  /** Return the session's spawn environment with secrets already masked in core. A live session
+   * created before capture support falls back to tmux's shell-formatted environment output. */
+  async envInfo(persistKey: string): Promise<PtyEnvInfo> {
+    if (typeof persistKey !== 'string' || !persistKey) {
+      return { source: 'unavailable', vars: [] }
+    }
+    const live = this.liveSessionForPersistKey(persistKey)
+    if (live?.sessionHost) {
+      return live.spawnEnv
+        ? { source: 'spawn', vars: live.spawnEnv }
+        : { source: 'unavailable', vars: [] }
+    }
+    if (live?.spawnEnv) return { source: 'spawn', vars: live.spawnEnv }
+
+    const target = sessionName(persistKey)
+    const sshRemote = live?.sshRemote
+    if (sshRemote) {
+      const ssh = findSsh()
+      if (!ssh) return { source: 'unavailable', vars: [] }
+      try {
+        const { stdout } = await runAsync(
+          ssh,
+          remoteShowEnvironmentArgs(sshRemote.conn, sshRemote.controlPath, target)
+        )
+        return { source: 'tmux', vars: parseTmuxSessionEnv(stdout) }
+      } catch {
+        return { source: 'unavailable', vars: [] }
+      }
+    }
+
+    if (!this.tmuxPath) return { source: 'unavailable', vars: [] }
+    try {
+      const { stdout } = await runAsync(this.tmuxPath, [
+        '-L',
+        TMUX_SOCKET,
+        'show-environment',
+        '-s',
+        '-t',
+        target
+      ])
+      return { source: 'tmux', vars: parseTmuxSessionEnv(stdout) }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn(`[pty] env-info for ${persistKey}: tmux session env unavailable — ${message}`)
+      return { source: 'unavailable', vars: [] }
     }
   }
 

--- a/src/core/pty-session-host.test.ts
+++ b/src/core/pty-session-host.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IPC } from '../shared/ipc'
+import type { PtyEnvInfo } from '../shared/types'
 import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform, type FakePlatform } from './platform-fake'
 
@@ -219,6 +220,10 @@ describe('PtyManager session-host contracts', () => {
     await vi.waitFor(() => expect(backend.create).toHaveBeenCalledTimes(1))
     await Promise.resolve()
     expect(settled).toBe(false)
+    await expect(host.handlers[IPC.ptyEnvInfo]('node-pending')).resolves.toEqual({
+      source: 'unavailable',
+      vars: []
+    })
 
     resolveReady({ fresh: false, screen: 'still alive' })
     await expect(resultPromise).resolves.toMatchObject({
@@ -227,6 +232,30 @@ describe('PtyManager session-host contracts', () => {
       persistent: true,
       screen: 'still alive'
     })
+    await expect(host.handlers[IPC.ptyEnvInfo]('node-pending')).resolves.toEqual({
+      source: 'unavailable',
+      vars: []
+    })
+  })
+
+  it('publishes a session-host environment only after ready proves a fresh generation', async () => {
+    const inherited = process.env.ENV_CAPTURE_TEST
+    try {
+      process.env.ENV_CAPTURE_TEST = 'fresh-host-value'
+      const m = await makeManager()
+      m.registerIpc()
+      const create = host.handlers[IPC.ptyCreate]
+
+      await expect(
+        create(7, { cols: 80, rows: 24, persistKey: 'node-fresh-host' })
+      ).resolves.toMatchObject({ fresh: true })
+      const info = (await host.handlers[IPC.ptyEnvInfo]('node-fresh-host')) as PtyEnvInfo
+      expect(info).toMatchObject({ source: 'spawn' })
+      expect(info.vars).toContainEqual({ key: 'ENV_CAPTURE_TEST', value: 'fresh-host-value' })
+    } finally {
+      if (inherited === undefined) delete process.env.ENV_CAPTURE_TEST
+      else process.env.ENV_CAPTURE_TEST = inherited
+    }
   })
 
   it('keeps a deletion tombstone when its owner recovery attach fails', async () => {

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -6,6 +6,7 @@ import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform, type FakePlatform } from './platform-fake'
 import { IPC } from '../shared/ipc'
 import { DEFAULT_SETTINGS } from '../shared/types'
+import type { PtyEnvInfo } from '../shared/types'
 import { MODEL_GATEWAY_SECRET_REF } from '../shared/agents/model-gateway'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
 
@@ -90,6 +91,7 @@ const execCalls: Array<{ file: string; args: string[] }> = []
 const liveTmuxSessions = new Set<string>()
 let paneProcessReply = ''
 let processGroupReply = ''
+let tmuxEnvironmentReply = ''
 
 vi.mock('child_process', () => {
   type Cb = (err: Error | null, res?: { stdout: string; stderr: string }) => void
@@ -108,6 +110,8 @@ vi.mock('child_process', () => {
       ok('__NT_PATH_START__/usr/bin:/bin__NT_PATH_END__')
     } else if (args.includes('capture-pane')) {
       ok('PANE SNAPSHOT')
+    } else if (args.includes('show-environment')) {
+      ok(tmuxEnvironmentReply)
     } else if (args.includes('#{pane_pid}|#{pane_current_command}')) {
       ok(paneProcessReply)
     } else if (file === 'ps' && args.includes('tpgid=')) {
@@ -167,6 +171,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     liveTmuxSessions.clear()
     paneProcessReply = ''
     processGroupReply = ''
+    tmuxEnvironmentReply = ''
     userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nt-solo-'))
     fake = fakePlatform({ userDataDir })
     initPlatform(fake)
@@ -405,6 +410,56 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     await tmuxManager()
     const r = await create(80, 24) // no live tmux session → cold start
     expect(r.fresh).toBe(true)
+  })
+
+  it('publishes the original spawn environment across a same-generation co-attach', async () => {
+    const inherited = process.env.ENV_CAPTURE_TEST
+    try {
+      process.env.ENV_CAPTURE_TEST = 'original'
+      await tmuxManager()
+      await create(80, 24)
+      process.env.ENV_CAPTURE_TEST = 'changed-after-spawn'
+      await create(90, 30)
+
+      const info = (await fake.handlers[IPC.ptyEnvInfo]('solo-1')) as PtyEnvInfo
+      expect(info).toMatchObject({ source: 'spawn' })
+      expect(info.vars).toContainEqual({ key: 'ENV_CAPTURE_TEST', value: 'original' })
+    } finally {
+      if (inherited === undefined) delete process.env.ENV_CAPTURE_TEST
+      else process.env.ENV_CAPTURE_TEST = inherited
+    }
+  })
+
+  it('uses tmux environment for a warm attach instead of publishing the new client env', async () => {
+    const inherited = process.env.ENV_CAPTURE_TEST
+    try {
+      process.env.ENV_CAPTURE_TEST = 'new-client-value'
+      await tmuxManager()
+      liveTmuxSessions.add(sessionName('solo-1'))
+      tmuxEnvironmentReply = 'ENV_CAPTURE_TEST="old-session-value"; export ENV_CAPTURE_TEST;\n'
+      await expect(create(80, 24)).resolves.toMatchObject({ fresh: false })
+
+      const info = await fake.handlers[IPC.ptyEnvInfo]('solo-1')
+      expect(info).toEqual({
+        source: 'tmux',
+        vars: [{ key: 'ENV_CAPTURE_TEST', value: 'old-session-value' }]
+      })
+      expect(tmuxCalls('show-environment')[0]?.args).toContain('-s')
+    } finally {
+      if (inherited === undefined) delete process.env.ENV_CAPTURE_TEST
+      else process.env.ENV_CAPTURE_TEST = inherited
+    }
+  })
+
+  it('does not probe local tmux when no live Session identifies the backend', async () => {
+    await tmuxManager()
+    tmuxEnvironmentReply = 'WRONG_SESSION="visible"; export WRONG_SESSION;\n'
+
+    await expect(fake.handlers[IPC.ptyEnvInfo]('unknown-node')).resolves.toEqual({
+      source: 'unavailable',
+      vars: []
+    })
+    expect(tmuxCalls('show-environment')).toHaveLength(0)
   })
 
   // ── Output: one subscriber, one coalesced message, never a broadcast ──────────────────────

--- a/src/core/remote-ssh/control-master.test.ts
+++ b/src/core/remote-ssh/control-master.test.ts
@@ -10,6 +10,7 @@ import {
   probeSaysAbsent,
   remoteCapturePaneArgs,
   remotePaneCommandArgs,
+  remoteShowEnvironmentArgs,
   remotePaneProcessArgs,
   remoteTerminateForegroundArgs,
   remoteListSessionsArgs,
@@ -274,6 +275,15 @@ describe('remotePaneCommandArgs', () => {
     const args = remotePaneCommandArgs(conn, '/s.sock', 'nt-x')
     expect(args[args.length - 1]).toBe(
       `${TP}tmux -L ${RMT_TMUX_SOCKET} display-message -p -t nt-x '#{pane_current_command}'`
+    )
+  })
+})
+
+describe('remoteShowEnvironmentArgs', () => {
+  it('asks remote tmux for strict shell-formatted session environment records', () => {
+    const args = remoteShowEnvironmentArgs(conn, '/s.sock', 'nt-x')
+    expect(args[args.length - 1]).toBe(
+      `${TP}tmux -L ${RMT_TMUX_SOCKET} show-environment -s -t nt-x`
     )
   })
 })

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -505,6 +505,20 @@ export function remotePaneProcessArgs(
   )
 }
 
+/** Read shell-formatted session environment from remote tmux for `PtyManager.envInfo`.
+ * tmux emits `NAME="..."; export NAME;` for set vars and `unset NAME;` for removed vars. */
+export function remoteShowEnvironmentArgs(
+  conn: SshConnection,
+  controlPath: string,
+  sessionId: string
+): string[] {
+  return childArgs(
+    conn,
+    controlPath,
+    tmuxCmd(`tmux -L ${RMT_TMUX_SOCKET} show-environment -s -t ${sessionId}`)
+  )
+}
+
 /**
  * SIGTERM the remote pane's foreground process group, after core has already confirmed tmux is
  * reporting an agent rather than a shell. The shell re-reads tpgid here to close the process-race

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -41,6 +41,11 @@ describe('preload sshProject passphrase wiring', () => {
     expect(h.invoke).toHaveBeenCalledWith(IPC.ptyTerminateForeground, 'node-1', 'claude')
   })
 
+  it('routes environment inspection through request IPC', async () => {
+    await api.pty.envInfo('node-1')
+    expect(h.invoke).toHaveBeenCalledWith(IPC.ptyEnvInfo, 'node-1')
+  })
+
   it('exposes GitHub issue data and host-control namespaces on their exact channels', async () => {
     await api.githubIssues.query({ projectId: 'p1', columnId: null, pageSize: 50 })
     await api.githubControl.saveToken('write-only-secret')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -95,6 +95,7 @@ const api: NodeTerminalApi = {
       ipcRenderer.invoke(IPC.ptySendText, persistKey, text, opts?.enter),
     tmuxStatus: () => ipcRenderer.invoke(IPC.ptyTmuxStatus),
     paneCommand: (persistKey) => ipcRenderer.invoke(IPC.ptyPaneCommand, persistKey),
+    envInfo: (persistKey) => ipcRenderer.invoke(IPC.ptyEnvInfo, persistKey),
     terminateForeground: (persistKey, expectedAgentId) =>
       ipcRenderer.invoke(IPC.ptyTerminateForeground, persistKey, expectedAgentId),
     readSessionName: (sessionId, accountId, agentId) =>

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -40,6 +40,7 @@ import {
   type PresenceApi,
   type PtyApi,
   type PtyCreateOptions,
+  type PtyEnvInfo,
   type SettingsApi,
   type ClaudeUsage,
   type ProviderUsage,
@@ -253,6 +254,10 @@ export function buildRealApi(
     // shell yet" and gives up on its own deadline.
     paneCommand: (persistKey) =>
       client.request(IPC.ptyPaneCommand, persistKey).catch(() => null) as Promise<string | null>,
+    envInfo: (persistKey) =>
+      client
+        .request(IPC.ptyEnvInfo, persistKey)
+        .catch(() => ({ source: 'unavailable', vars: [] }) as PtyEnvInfo) as Promise<PtyEnvInfo>,
     terminateForeground: (persistKey, expectedAgentId) =>
       client.request(IPC.ptyTerminateForeground, persistKey, expectedAgentId).catch(() => false) as Promise<boolean>,
     // No server handler — the session-name poll degrades to no adopted name. A PRE-EXISTING gap,

--- a/src/renderer/components/ContextMeter.test.tsx
+++ b/src/renderer/components/ContextMeter.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PtyEnvInfo } from '@shared/types'
+
+const h = vi.hoisted(() => ({
+  requests: [] as Array<{
+    nodeId: string
+    resolve: (info: PtyEnvInfo) => void
+  }>
+}))
+
+vi.mock('../state/contextWindow', () => ({
+  useContextWindow: (selector: (state: unknown) => unknown) =>
+    selector({
+      bySessionId: {
+        session: {
+          sessionId: 'session',
+          usedTokens: 50_000,
+          windowTokens: 200_000,
+          usedPercent: 25,
+          model: 'test-model',
+          updatedAt: Date.now()
+        }
+      }
+    })
+}))
+
+vi.mock('../state/settings', () => ({
+  useSettings: (selector: (state: unknown) => unknown) =>
+    selector({ settings: { usagePercentMode: 'used' } })
+}))
+
+vi.mock('../session/session', () => ({
+  activeSessionApi: () => ({
+    pty: {
+      envInfo: (nodeId: string) =>
+        new Promise<PtyEnvInfo>((resolve) => h.requests.push({ nodeId, resolve }))
+    }
+  })
+}))
+
+import { ContextMeter } from './ContextMeter'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const info = (key: string): PtyEnvInfo => ({
+  source: 'spawn',
+  vars: [{ key, value: key.toLowerCase() }]
+})
+
+describe('ContextMeter spawn environment', () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    h.requests.length = 0
+    host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    document.body.innerHTML = ''
+  })
+
+  const clickMeter = (): void => {
+    ;(host.querySelector('.ctx-pill') as HTMLButtonElement).click()
+  }
+
+  it('clears an old result before refetching when reopened', async () => {
+    await act(async () => root.render(<ContextMeter sessionId="session" nodeId="node-a" />))
+    await act(async () => clickMeter())
+    expect(h.requests.map((request) => request.nodeId)).toEqual(['node-a'])
+    await act(async () => h.requests[0].resolve(info('A_ONLY')))
+    expect(host.textContent).toContain('A_ONLY')
+
+    await act(async () => clickMeter())
+    await act(async () => clickMeter())
+    expect(h.requests.map((request) => request.nodeId)).toEqual(['node-a', 'node-a'])
+    expect(host.textContent).not.toContain('A_ONLY')
+
+    await act(async () => h.requests[1].resolve(info('A_FRESH')))
+    expect(host.textContent).toContain('A_FRESH')
+  })
+
+  it('hides the prior node and ignores its late response after nodeId changes', async () => {
+    await act(async () => root.render(<ContextMeter sessionId="session" nodeId="node-a" />))
+    await act(async () => clickMeter())
+    await act(async () => h.requests[0].resolve(info('A_ONLY')))
+    expect(host.textContent).toContain('A_ONLY')
+
+    await act(async () => root.render(<ContextMeter sessionId="session" nodeId="node-b" />))
+    expect(h.requests.map((request) => request.nodeId)).toEqual(['node-a', 'node-b'])
+    expect(host.textContent).not.toContain('A_ONLY')
+
+    const superseded = h.requests[1]
+    await act(async () => root.render(<ContextMeter sessionId="session" nodeId="node-c" />))
+    await act(async () => h.requests[2].resolve(info('C_ONLY')))
+    expect(host.textContent).toContain('C_ONLY')
+    await act(async () => superseded.resolve(info('B_LATE')))
+    expect(host.textContent).toContain('C_ONLY')
+    expect(host.textContent).not.toContain('B_LATE')
+  })
+})

--- a/src/renderer/components/ContextMeter.tsx
+++ b/src/renderer/components/ContextMeter.tsx
@@ -1,17 +1,26 @@
 import { useEffect, useRef, useState } from 'react'
 import { useContextWindow } from '../state/contextWindow'
 import { useSettings } from '../state/settings'
+import { activeSessionApi } from '../session/session'
 import { barFillPercent, contextFillColor, contextPillText, formatModelLabel, formatTimeAgo, formatTokensShort, percentText } from '../lib/usageFormat'
+import type { PtyEnvInfo } from '@shared/types'
 
 /**
  * Per-Claude-node context-window meter. A small header pill (mini-bar + "NN%") that toggles
  * a popover with token figures and model. Renders nothing until the session has usage data.
  */
-export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.Element | null {
+export function ContextMeter({
+  sessionId,
+  nodeId
+}: {
+  sessionId: string | null
+  nodeId?: string
+}): JSX.Element | null {
   const usage = useContextWindow((s) => (sessionId ? s.bySessionId[sessionId] : undefined))
   const percentMode = useSettings((s) => s.settings.usagePercentMode)
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const [envResult, setEnvResult] = useState<{ nodeId: string; info: PtyEnvInfo } | null>(null)
 
   useEffect(() => {
     if (!open) return
@@ -22,7 +31,30 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
     return () => window.removeEventListener('mousedown', onDown)
   }, [open])
 
+  useEffect(() => {
+    if (!open || !nodeId) {
+      setEnvResult(null)
+      return
+    }
+    let cancelled = false
+    setEnvResult(null)
+    activeSessionApi()
+      .pty.envInfo(nodeId)
+      .then((info) => {
+        if (!cancelled) setEnvResult({ nodeId, info })
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setEnvResult({ nodeId, info: { source: 'unavailable', vars: [] } })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, nodeId])
+
   if (!usage) return null
+  const env = envResult && envResult.nodeId === nodeId ? envResult.info : null
   // The NUMBER honours the used/remaining/tokens display setting; the bar and its color stay
   // keyed to context FILL, so the severity colors keep meaning the same thing in every mode
   // (issue #78).
@@ -47,6 +79,39 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
                 gemini joined USAGE_CAPABLE — a codex popover would have claimed to be claude. */}
             {usage.model ? `${usage.model} · ` : ''}Updated {formatTimeAgo(usage.updatedAt)}
           </div>
+          {nodeId && (
+            <div className="ctx-env">
+              <div className="ctx-env__title">Spawn environment</div>
+              {env?.source === 'unavailable' && (
+                <div className="ctx-env__empty">Not available for this session.</div>
+              )}
+              {env && env.source !== 'unavailable' && (
+                <>
+                  <div className="ctx-env__sub">
+                    {env.source === 'spawn'
+                      ? 'captured when this session started'
+                      : 'read from the tmux session'}
+                  </div>
+                  <div className="ctx-env__vars">
+                    {env.vars.map((variable) => (
+                      <div
+                        className={`ctx-env__var${variable.secret ? ' ctx-env__var--secret' : ''}`}
+                        key={variable.key}
+                      >
+                        <code className="ctx-env__key">{variable.key}</code>
+                        <code
+                          className="ctx-env__value"
+                          title={variable.secret ? 'masked credential' : variable.value}
+                        >
+                          {variable.value}
+                        </code>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </div>
       )}
       <button
@@ -54,6 +119,7 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
         title={`Context window — ${percentText(usage.usedPercent, percentMode)}`}
         onClick={(e) => {
           e.stopPropagation()
+          setEnvResult(null)
           setOpen((v) => !v)
         }}
       >

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -317,7 +317,7 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
           {isTerminal && (
             <>
               {/* Same context-window pill + popover as the node header (null until usage data). */}
-              <ContextMeter sessionId={agentSessionId ?? null} />
+              <ContextMeter sessionId={agentSessionId ?? null} nodeId={session.id} />
               <button
                 className="kanban-modal__action"
                 title="Search this terminal"

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -191,7 +191,7 @@ export const SessionCard = memo(function SessionCard({
             <span className="kanban-card__stickytext">{stickyPreview}</span>
           ) : (
             <>
-              <ContextMeter sessionId={status?.sessionId ?? null} />
+              <ContextMeter sessionId={status?.sessionId ?? null} nodeId={session.id} />
               <AccountChip chip={accountChip} />
               {status?.session && (
                 <span className="kanban-card__session" title={status.session}>

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -4972,7 +4972,7 @@ export function TerminalNode({
             SSH {(data.ssh as SshConnection).user}@{(data.ssh as SshConnection).host}
           </span>
         ) : null}
-        {showUsage && <ContextMeter sessionId={status?.sessionId ?? null} />}
+        {showUsage && <ContextMeter sessionId={status?.sessionId ?? null} nodeId={id} />}
         {/* Who else is in this node. Subscribes to presence itself — see PresenceChips. */}
         <PresenceChips nodeId={id} />
         {status?.state === 'working' && (

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7082,6 +7082,45 @@ button.group-node__setup:disabled {
 .ctx-bar__fill { height: 100%; border-radius: 4px; }
 .ctx-popover__meta { margin-top: 8px; font-size: 12px; }
 .ctx-popover__sub { margin-top: 4px; font-size: 11px; color: rgba(var(--tint-rgb), 0.5); }
+.ctx-env { margin-top: 10px; }
+.ctx-env__title { font-size: 11px; font-weight: 600; margin-bottom: 2px; }
+.ctx-env__sub { font-size: 10px; color: rgba(var(--tint-rgb), 0.5); margin-bottom: 6px; }
+.ctx-env__empty { font-size: 11px; color: rgba(var(--tint-rgb), 0.5); line-height: 1.4; }
+.ctx-env__vars {
+  max-height: 170px;
+  overflow-y: auto;
+  border-top: 1px solid rgba(var(--tint-rgb), 0.08);
+}
+.ctx-env__var {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 3px 0;
+  border-bottom: 1px solid rgba(var(--tint-rgb), 0.06);
+  font-size: 10.5px;
+  min-width: 0;
+}
+.ctx-env__key {
+  flex: 0 0 45%;
+  max-width: 45%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(var(--tint-rgb), 0.75);
+  font-size: inherit;
+}
+.ctx-env__value {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-strong);
+  font-size: inherit;
+}
+.ctx-env__var--secret .ctx-env__value {
+  border-bottom: 1px dashed rgba(var(--tint-rgb), 0.35);
+}
 .usage-account__email { font-size: 13px; }
 
 .seg-pill {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -23,6 +23,8 @@ export const IPC = {
   /** The foreground command of a node's tmux pane (`#{pane_current_command}`) — how the in-place
    *  agent restart sees that the CLI has exited and a shell owns the pane again. */
   ptyPaneCommand: 'pty:pane-command',
+  /** Read a session's spawn environment with secrets masked in core. */
+  ptyEnvInfo: 'pty:env-info',
   /** Renderer → core: SIGTERM the non-shell foreground process group in this node's pane.
    *  Model switching uses this instead of typing an exit slash-command into an agent composer. */
   ptyTerminateForeground: 'pty:terminate-foreground',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -852,6 +852,20 @@ export type PtyLimitFixResult =
    *  renderer: nothing failed, so neither may raise an error toast. */
   | { ok: false; error: string; canceled?: boolean; busy?: boolean }
 
+/** A session environment entry after core has irreversibly masked credential-shaped values. */
+export interface PtyEnvVar {
+  key: string
+  value: string
+  secret?: boolean
+  /** False means tmux records this variable as removed from the session environment. */
+  set?: boolean
+}
+
+export interface PtyEnvInfo {
+  source: 'spawn' | 'tmux' | 'unavailable'
+  vars: PtyEnvVar[]
+}
+
 export interface PtyApi {
   /** Starts a new PTY session; returns its sessionId and whether the session was freshly
    *  created (cold start) vs reattached to a still-running tmux session (warm). */
@@ -905,6 +919,8 @@ export interface PtyApi {
    *  node persistKey. null when it is unknown — no session, no tmux, or the query failed — which
    *  callers must read as "not observed", never as evidence of a particular command. */
   paneCommand(persistKey: string): Promise<string | null>
+  /** Read this session's environment with secrets masked in core. */
+  envInfo(persistKey: string): Promise<PtyEnvInfo>
   /** Terminate the foreground process group in a node's pane. Returns false when the pane/process
    *  cannot be safely identified; it never kills the pane's login shell. When `expectedAgentId` is
    *  given, the kill happens only if that harness actually owns the foreground group (argv-verified)


### PR DESCRIPTION
Click a session context meter to inspect its environment. Fresh local sessions expose a masked capture; warm local and SSH sessions read their tmux environment. Pending or warm session-host attachments, and sessions with no live backend identity, report unavailable. Reopening the drawer or changing sessions clears previous results and ignores late responses.

Credential names and sensitive values are masked before leaving core. The tmux reader parses complete shell-format output without evaluating it, keeping multiline values together until masking and refusing malformed records. Captures become visible only after the backend confirms a fresh generation; a reattach cannot mislabel its new client environment as the older pane's spawn environment.

Validation: 159 focused tests passed on Node 22; TypeScript check and production/Codex relay builds passed. The local full-suite failures from the initial run were reproduced on unchanged `main` and traced to the local Node/native/macOS/tmux setup. Hosted checks run against this independent draft.

Split from https://github.com/eneskirca/nodeterm/pull/715. This branch targets `main` and has no gateway-launch or recovery prerequisites.
