### PR TITLE
fix(agents): one chime per background fan-out, not one per subagent

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { playSfx, primeSfx } from '@renderer/lib/sfx'
+import { fanoutStillWorking } from '@renderer/lib/completionAlert'
 import {
   addEdge,
   applyEdgeChanges,
@@ -11968,10 +11969,19 @@ export function Canvas() {
       if (e.account) cs.setAccount(e.nodeId, { ...e.account, remote: observationIsRemote(originOf(e.nodeId)) })
       const agentLabel = agentConfig(e.agentId)?.label ?? 'Agent'
       // "<folder> — Claude finished" + last assistant message as the body.
-      const alert = (statusText: string, fallbackBody: string, sound: 'done' | 'needsYou') => {
+      const alert = (
+        statusText: string,
+        fallbackBody: string,
+        sound: 'done' | 'needsYou',
+        opts?: { quiet?: boolean }
+      ) => {
         // Unread unless the user is actively in this node's terminal (focused window +
         // this node is the active terminal). So a finish while you're in another terminal,
         // or with nothing focused, still flags unread.
+        //
+        // `opts.quiet` reaches this function BELOW this block on purpose (issue #708): it silences
+        // the two INTERRUPTS (chime, OS notification) and never the unread record or its ack. See
+        // `fanoutStillWorking` — a dot is a different fact from a chime.
         const watching = document.hasFocus() && cs.activeId === e.nodeId
         if (!watching) cs.markUnread(e.nodeId)
         // Watched it finish? Then it is already read. Nothing marks it unread in this branch, so
@@ -11979,6 +11989,9 @@ export function Canvas() {
         // green blob and the phone's Live Activity would keep glowing for a turn the user sat and
         // watched end. The mirror no-ops when there is no unresolved done event.
         else if (sound === 'done') void window.nodeTerminal.ackDone(e.nodeId)
+        // Everything from here down is an INTERRUPT, and this is where a quiet alert stops. The
+        // unread dot and its ack above are deliberately on the other side of this line.
+        if (opts?.quiet) return
         // Sound first: it is the one alert that also fires while you're in the app but looking at
         // another node — the case OS notifications deliberately skip.
         const snd = useSettings.getState().settings
@@ -12046,7 +12059,16 @@ export function Canvas() {
             // a renderer reload. Gating the badge but not the sound/notification would half-enforce
             // the flag and leave the expensive error — a false completion — fully reachable.
             cs.bumpLoop(e.nodeId, e.lastMessage) // count loop iterations + summary (no-op if not looping)
-            alert('finished', `${agentLabel} finished its turn.`, 'done')
+            // Issue #708: a turn that ended only because a BACKGROUND SUBAGENT reported back is
+            // not the fan-out finishing — the parent is about to be woken again by the next one.
+            // Read fresh (not the `an` snapshot taken at listener entry): `clearFinishedForParent`
+            // may have run just above. It only drops DONE cards, so the verdict is the same either
+            // way, and depending on that is exactly the kind of coupling that rots.
+            const fanoutBusy = fanoutStillWorking(
+              Object.values(useAgentNodes.getState().byId),
+              e.nodeId
+            )
+            alert('finished', `${agentLabel} finished its turn.`, 'done', { quiet: fanoutBusy })
           }
           if (e.state === 'blocked')
             alert('needs input', `${agentLabel} needs permission to continue.`, 'needsYou')

--- a/src/renderer/canvas/fanout-chime.test.ts
+++ b/src/renderer/canvas/fanout-chime.test.ts
@@ -1,0 +1,66 @@
+// The completion alert must go QUIET while the parent still holds working subagent cards, and the
+// unread record must stay on the other side of that gate (issue #708).
+//
+// Canvas.tsx is a ~12k-line monolith and this listener lives inside one of its `useEffect`s — there
+// is no harness that can dispatch an `agent:status` event at it (see the note at the top of
+// `agent-status-rescue.test.ts`, which pins its sibling invariant the same way). The DECISION is
+// pure and behaviourally tested in `renderer/lib/completionAlert.test.ts`; what only the source can
+// show is that Canvas asks it, asks it for the right event, and puts the quiet gate BELOW the
+// unread write rather than above it.
+
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const src = fs.readFileSync(path.resolve(__dirname, 'Canvas.tsx'), 'utf8').replace(/\r\n/g, '\n')
+
+/** The body of the `alert` closure in the agent-status listener. */
+function alertBody(): string {
+  const start = src.indexOf('const alert = (')
+  expect(start, 'Canvas must still build its alert closure').toBeGreaterThan(-1)
+  const end = src.indexOf('const an = useAgentNodes.getState()', start)
+  expect(end).toBeGreaterThan(start)
+  return src.slice(start, end)
+}
+
+describe('Canvas completion alert — background fan-out (issue #708)', () => {
+  it('asks the shared predicate rather than re-deriving "still working" inline', () => {
+    expect(src).toContain("import { fanoutStillWorking } from '@renderer/lib/completionAlert'")
+    // The verdict must be computed from the LIVE store, not from the `an` snapshot taken at
+    // listener entry, and it must be handed to the alert as `quiet`.
+    expect(src).toMatch(
+      /fanoutStillWorking\(\s*Object\.values\(useAgentNodes\.getState\(\)\.byId\),\s*e\.nodeId\s*\)/
+    )
+  })
+
+  it('gates only the completion alert, never "needs input"', () => {
+    // A blocked/waiting agent needs the user NOW, whatever its subagents are doing.
+    const done = src.match(/alert\('finished',[^\n]*\)/)
+    expect(done, "the 'finished' alert call must still exist").toBeTruthy()
+    expect(done![0]).toContain('quiet:')
+    for (const m of src.matchAll(/alert\('needs input',[^\n]*\)/g)) {
+      expect(m[0]).not.toContain('quiet')
+    }
+  })
+
+  it('silences the chime and the OS notification but NOT the unread record', () => {
+    const body = alertBody()
+    const unread = body.indexOf('cs.markUnread(e.nodeId)')
+    const ack = body.indexOf('ackDone(e.nodeId)')
+    const quiet = body.indexOf('opts?.quiet')
+    const sound = body.indexOf('playSfx(')
+    const notify = body.indexOf('nodeTerminal.notify(')
+    expect(unread).toBeGreaterThan(-1)
+    expect(ack).toBeGreaterThan(-1)
+    expect(quiet).toBeGreaterThan(-1)
+    expect(sound).toBeGreaterThan(-1)
+    expect(notify).toBeGreaterThan(-1)
+    // Unread + its ack are ABOVE the quiet return; both interrupts are below it.
+    expect(unread).toBeLessThan(quiet)
+    expect(ack).toBeLessThan(quiet)
+    expect(quiet).toBeLessThan(sound)
+    expect(quiet).toBeLessThan(notify)
+    // And the gate is a hard return, so nothing after it can leak through.
+    expect(body).toMatch(/if \(opts\?\.quiet\) return/)
+  })
+})

--- a/src/renderer/lib/completionAlert.test.ts
+++ b/src/renderer/lib/completionAlert.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { fanoutStillWorking } from './completionAlert'
+import { useAgentNodes } from '../state/agentNodes'
+import { WORKING_STALE_MS } from '@shared/agents/stale'
+
+const cards = (...cs: { parentNodeId: string; state?: string }[]): typeof cs => cs
+
+describe('fanoutStillWorking — the completion alert’s quiet gate (issue #708)', () => {
+  it('is loud with no cards at all — the ordinary agent node must never lose its chime', () => {
+    expect(fanoutStillWorking([], 'n1')).toBe(false)
+  })
+
+  it('is quiet while this parent still holds a working card', () => {
+    expect(fanoutStillWorking(cards({ parentNodeId: 'n1', state: 'working' }), 'n1')).toBe(true)
+  })
+
+  it('is loud once every card of this parent is done — the last one lands, the chime fires', () => {
+    expect(
+      fanoutStillWorking(
+        cards(
+          { parentNodeId: 'n1', state: 'done' },
+          { parentNodeId: 'n1', state: 'done' },
+          { parentNodeId: 'n1', state: 'done' }
+        ),
+        'n1'
+      )
+    ).toBe(false)
+  })
+
+  it('is quiet with nine done and one still working — the case in the report', () => {
+    const nine = Array.from({ length: 9 }, () => ({ parentNodeId: 'n1', state: 'done' }))
+    expect(fanoutStillWorking([...nine, { parentNodeId: 'n1', state: 'working' }], 'n1')).toBe(true)
+  })
+
+  it('is scoped per parent — another node’s live fan-out never silences this one', () => {
+    expect(fanoutStillWorking(cards({ parentNodeId: 'n2', state: 'working' }), 'n1')).toBe(false)
+  })
+
+  it('is LOUD for an unknown/absent state — the opposite direction from Eco’s liveSubagents', () => {
+    // Eco counts anything not provably `done` as live, because being wrong there kills running
+    // work. Being wrong HERE swallows a completion, so only a positive `working` may silence.
+    expect(fanoutStillWorking(cards({ parentNodeId: 'n1' }), 'n1')).toBe(false)
+    expect(fanoutStillWorking(cards({ parentNodeId: 'n1', state: 'queued' }), 'n1')).toBe(false)
+  })
+})
+
+describe('the real store feeds it the shape it expects', () => {
+  const P = 'parent-708'
+  const reset = (): void => useAgentNodes.getState().clearForParent(P)
+
+  it('goes quiet on start() and loud again on finish() — no adapter in between', () => {
+    reset()
+    const values = (): { parentNodeId: string; state?: string }[] =>
+      Object.values(useAgentNodes.getState().byId)
+
+    useAgentNodes.getState().start('t1', { parentNodeId: P })
+    useAgentNodes.getState().start('t2', { parentNodeId: P })
+    expect(fanoutStillWorking(values(), P)).toBe(true)
+
+    useAgentNodes.getState().finish('t1', {})
+    expect(fanoutStillWorking(values(), P)).toBe(true) // t2 still out there
+
+    useAgentNodes.getState().finish('t2', {})
+    expect(fanoutStillWorking(values(), P)).toBe(false)
+    reset()
+  })
+
+  it('the 20-minute stale decay is what bounds a lost subagent end', () => {
+    // A subagent whose end never arrives would otherwise silence this node's chimes forever.
+    reset()
+    useAgentNodes.getState().start('t3', { parentNodeId: P })
+    const startedAt = useAgentNodes.getState().byId['t3'].startedAt
+    const values = (): { parentNodeId: string; state?: string }[] =>
+      Object.values(useAgentNodes.getState().byId)
+
+    useAgentNodes.getState().sweepStaleWorking(startedAt + WORKING_STALE_MS - 1)
+    expect(fanoutStillWorking(values(), P)).toBe(true)
+
+    useAgentNodes.getState().sweepStaleWorking(startedAt + WORKING_STALE_MS + 1)
+    expect(fanoutStillWorking(values(), P)).toBe(false)
+    reset()
+  })
+})

--- a/src/renderer/lib/completionAlert.ts
+++ b/src/renderer/lib/completionAlert.ts
@@ -1,0 +1,77 @@
+/**
+ * Should a parent agent's turn-end alert be QUIET — no chime, no OS notification?
+ *
+ * Issue #708. Claude launches background subagents async: each one that finishes is announced back
+ * to the PARENT as a queued `<task-notification>` prompt, and the parent's handling of that
+ * notification is a full turn — `UserPromptSubmit` → … → `Stop`. `Stop` normalizes to
+ * `state: 'done'`, and `done` is what fires the completion alert. So a fan-out of ten background
+ * agents produces ten `done` events on ONE node, each of them a chime. The reporter's words: "a
+ * chime every few seconds :)))".
+ *
+ * None of those ten is a lie about the turn — the turn really did end. What they are wrong about is
+ * the thing the chime MEANS, which is "this node is finished and wants you". A parent still holding
+ * subagents in `working` has not finished; it is going to be woken again by the next one.
+ *
+ * ## What is suppressed, and what is deliberately not
+ *
+ * The chime and the OS notification only. **`unread` is NOT suppressed** — read the "Unread +
+ * notification" bullet in CLAUDE.md: unread is a durable per-node flag, cleared by looking at the
+ * node, and it is idempotent, so ten report-backs raise ONE dot rather than ten. It costs the user
+ * no interruption and it is the thing that still tells them "something happened here" if the final
+ * chime is ever lost. The chime and the banner are interrupts; the dot is a record. Suppressing the
+ * record to fix the interrupt would trade a noisy bug for a silent one.
+ *
+ * ## Why this fires exactly once at the end, with no deferred-alert bookkeeping
+ *
+ * The LAST subagent's completion writes its `<task-notification>` into the parent transcript, the
+ * context tail sniffs it within one poll (`POLL_MS` = 1 s in `core/context-tail.ts`) and emits the
+ * synthetic `subagent-end` that marks the card `done`. Only THEN does the parent wake and run the
+ * turn whose `Stop` arrives seconds later. By that point no card is `working`, so the alert fires
+ * normally. The "one chime when the whole fan-out is done" is therefore the ordinary alert, not a
+ * replayed one — there is no debt to remember and no second alert path that could double-chime.
+ *
+ * ## The direction of the guess is the OPPOSITE of Eco's
+ *
+ * `buildHibernationCandidates`' `liveSubagents` asks a related question and answers it
+ * conservatively the other way: anything that is not provably `done` counts as LIVE, because being
+ * wrong there means `/exit`ing a CLI with live background work in it (issue #402). Here being wrong
+ * means SWALLOWING a genuine completion, so the conservative direction is to stay loud: only a card
+ * this store positively holds in `working` may silence a chime. That is why this is its own
+ * predicate rather than a call into the hibernation adapter — same store, opposite failure cost.
+ *
+ * The store types `state` as `'working' | 'done'`, so on today's data the two spellings agree; the
+ * match is written as `=== 'working'` anyway so a future third state (or a card rehydrated from
+ * somewhere with a missing field) falls to the loud side by construction.
+ *
+ * ## The bounded worst case
+ *
+ * A subagent whose end never arrives (crashed CLI, killed pane, slept machine) pins its card in
+ * `working`, and this would then silence that node's completion chimes. It is bounded by the same
+ * decay everything else in this store leans on: Canvas's 60 s sweep runs `sweepStaleWorking`, which
+ * marks a card `done` after `WORKING_STALE_MS` (20 min). Past that the node chimes again on its
+ * next turn end. The alternative — remembering a suppressed alert and replaying it when the last
+ * card lands — was considered and rejected: the replay races the parent's own woken turn, so the
+ * normal path would chime twice whenever that turn takes longer than the node's 5 s sound cooldown,
+ * which is most of the time.
+ */
+
+/** One subagent card, narrowed to what this decision reads. */
+export interface FanoutCard {
+  parentNodeId: string
+  state?: string
+}
+
+/**
+ * Does this parent still hold at least one subagent card in `working`?
+ *
+ * Pure; `cards` is `Object.values(useAgentNodes.getState().byId)`.
+ */
+export function fanoutStillWorking(
+  cards: Iterable<FanoutCard>,
+  parentNodeId: string
+): boolean {
+  for (const c of cards) {
+    if (c.parentNodeId === parentNodeId && c.state === 'working') return true
+  }
+  return false
+}


### PR DESCRIPTION
Closes #708.

## What was happening

Claude launches background subagents async. Each one that finishes is announced back to the **parent** as a queued `<task-notification>` prompt, and the parent handling that notification is a full turn — so it ends with `Stop` → `state: 'done'` → the completion alert. Ten background agents produce ten `done` events on one node. The per-node 5 s sound cooldown only spaces them out, which is why the reporter got "a chime every few seconds :)))" rather than ten at once.

None of those events lies about the turn. They are wrong about what the chime *means* — "this node is finished and wants you". A parent still holding subagent cards in `working` has not finished; it is about to be woken again by the next one.

## What changed

The completion alert goes **quiet while the parent's fan-out is still running**, and fires normally once no card of that parent is `working`.

That needs no deferred-alert bookkeeping, and the ordering is why. The last subagent's `<task-notification>` is written into the parent transcript *first*; the context tail sniffs it within one poll (`POLL_MS` = 1 s, `core/context-tail.ts`) and emits the synthetic `subagent-end` that marks the card done; only then does the parent wake and run the turn whose `Stop` arrives seconds later. So "one chime when the whole fan-out is done" is the **ordinary** alert, not a replayed one — there is no debt to remember and no second alert path that could double-chime. (Replaying a suppressed alert on the last `subagent-end` was considered and rejected: it races the parent's own woken turn, so the normal path would chime twice whenever that turn outlasts the 5 s cooldown, which is most of the time.)

**Narrower than the issue's suggestion, deliberately.** Only the two *interrupts* are silenced — the chime and the OS notification. The unread dot and its `ackDone` stay on the other side of the gate:

- unread is a durable per-node record, cleared by looking at the node, and **idempotent** — ten report-backs raise one dot, not ten, so it was never part of the noise;
- it costs no interruption;
- it is the thing that still says "something happened here" if a final chime is ever lost.

CLAUDE.md already separates those two facts ("read state is independent from agent state"); suppressing the record to fix the interrupt would have traded a noisy bug for a silent one.

**The predicate is its own pure module, not a call into Eco's `liveSubagents`.** Same store, opposite failure cost: `buildHibernationCandidates` counts anything not provably `done` as live, because being wrong there `/exit`s a CLI with live background work in it (#402). Being wrong *here* swallows a genuine completion — so only a card the store positively holds in `working` may silence a chime, and an unknown or missing state falls to the loud side by construction.

## Worst case, and what bounds it

A subagent whose end never arrives (crashed CLI, killed pane, slept machine) pins its card in `working` and would silence that node's chimes. That is bounded by machinery already in place for the same reason: Canvas's 60 s sweep runs `useAgentNodes.sweepStaleWorking`, which marks a card done after `WORKING_STALE_MS` (20 min), after which the node chimes again on its next turn end. The unread dot is unaffected throughout.

## How it was checked

- `renderer/lib/completionAlert.test.ts` — behavioural, including against the real `useAgentNodes` store (start → quiet, last `finish()` → loud) and its stale decay at the `WORKING_STALE_MS` boundary.
- `renderer/canvas/fanout-chime.test.ts` — source pin, same idiom and for the same stated reason as the neighbouring `agent-status-rescue.test.ts`: Canvas.tsx's listener lives inside a `useEffect` in a ~12k-line file with no harness that can dispatch an `agent:status` event at it. It asserts Canvas asks the shared predicate against the **live** store, does not gate the `needs input` alerts, and keeps the quiet return **below** the unread write.
- Mutation-verified — five mutants, each reds at least one test: an always-false predicate, the Eco-direction (`!== 'done'`) predicate, a dropped parent scope, the quiet gate moved above the unread write, and the `quiet` argument dropped at the call site.
- `npm run typecheck` clean. `npx vitest run src/renderer/{lib,canvas,state,nodes}` — 2621 passed, 2 failed, both pre-existing worktree artefacts unrelated to this change (`keyContext.test.ts` and `directionalFocus.test.ts` read `node_modules/...` by a path relative to cwd, and this worktree has no `node_modules` of its own).

## Surfaces

- **Desktop / Server Edition**: identical — the whole change is renderer-side, in the shared `agent:status` listener both shells feed. No new IPC, no bridge member.
- **Kanban**: nothing to do. The chime and the OS notification are app-level, not card-level; the card's own unread dot reads the same `agentStatus` flag and is untouched.
- **Mobile**: N/A for this change, but worth a look — *nodeterm mobile* fires its own notification off the mirror's `done` edge, which has the same one-per-report-back shape. The mirror carries no subagent state today, so it cannot make this decision without a new field. @eneskirca

## Device checklist

Not run on a device — I have no machine with a live Claude session and background subagents to drive.

1. Launch 3+ background subagents from one Claude node, leave the window **unfocused**. Expect: **one** chime + **one** OS notification, when the last one lands — not one per report-back.
2. During the same run, confirm the node's unread dot appears on the first report-back and stays (header dot, minimap stroke, project-tab dot), and that clicking into the node clears it as before.
3. A Claude node with **no** subagents: chime + notification on every turn end, exactly as today.
4. A node whose subagent cards are all `done`: next turn end chimes normally.
5. `blocked` / `waiting` (a permission prompt) **while** subagents are running: the "needs input" chime must still fire — it is not gated.
6. Kill one subagent's CLI so its end never arrives, then finish a turn: no chime (expected). After ~20 min the stale sweep marks the card done; the next turn end chimes again.
7. Two agent nodes fanning out at once: node B's completion is not silenced by node A's live subagents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
